### PR TITLE
feat(trusty-kb,trusty-agents): OKG ingestion feeds the bound search index (#3892 option a)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,46 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **OKG ingestion feeds the bound search index (#3892, remediation (a)):** an
+  `okg_ingest_*` call used to write markdown into the KB tree and stop there,
+  while `vector_search` queried an index built over an unrelated root — so an
+  ingest could report "N entities ingested" truthfully and the assistant would
+  still find nothing, with no error on either side. Every ingest tool now ends
+  by draining that source's index backlog into the agent's `[[stores]]`-bound
+  trusty-search index (`stores::index_feed`, over the daemon's
+  `POST /indexes/{id}/index-file` / `remove-file` routes). The contract: the
+  tree write is the durable record and is never gated on a reachable daemon;
+  the journal line is appended only AFTER the daemon acknowledges the push, so
+  a crash costs one redundant re-push rather than a lost entity; every run
+  reconciles the whole backlog, so a failed push is self-healing; a changed
+  entity is withdrawn before it is re-pushed and a tombstoned one is withdrawn
+  outright. Fail-open, never silent — each result reports `index.indexed` /
+  `removed` / `pending` plus a `reason` when nothing could be fed. The
+  operator's configured index roots are untouched (remediation (b) was not
+  taken). One constraint the live check surfaced and the feed now enforces:
+  trusty-search post-filters any search result whose path escapes the index
+  root (issues #64 / #541), so pushing a tree into a foreign-rooted index would
+  store the chunks and hide them from every query. The feed reads the index's
+  root first and REFUSES with an actionable reason when it does not contain the
+  tree, rather than reporting `indexed: N, pending: 0` over a corpus nothing can
+  return.
+- **`okg://<agent>` finally resolves (`stores::binding`, #3892):** the URI was an
+  opaque label nothing ever mapped to a path, so a binding's tree tail matching
+  its KB directory was a naming coincidence rather than an invariant. It now
+  resolves to `<knowledge_dir>/<slug(agent)>`, and a push is REFUSED when the
+  binding names a different tree than the one that was written — trading a
+  silent-empty failure for a loud one instead of a silent-wrong one.
+
+### Changed
+
+- **Store status surfaces the unsearchable backlog (#3892):** `okg_sources`
+  reports per-source `index.synced` / `index.pending` and names the bound index;
+  `GET /api/agents/:name/stores` adds the resolved `tree_path` plus
+  `pending_index` / `synced_index`, so a store can no longer read as CONNECTED
+  while holding none of the content its tree holds.
+
 ### Changed
 
 - **Agent configuration is five sections: Personality / Knowledge / Skills /

--- a/crates/trusty-agents/src/stores/binding.rs
+++ b/crates/trusty-agents/src/stores/binding.rs
@@ -1,0 +1,394 @@
+//! Resolving `okg://<agent>` to a filesystem tree, and a tree back to its
+//! bound search index (#3892).
+//!
+//! Why: #3892's third finding was that `okg://<agent>` is an OPAQUE LABEL —
+//! nothing in the repo ever stripped the scheme or joined it onto a directory,
+//! so the fact that a binding's tree tail and the `Roots`-derived KB directory
+//! name coincided was a naming coincidence, not an enforced invariant. Feeding
+//! ingestion into the bound index (remediation (a)) is only sound if that
+//! coincidence becomes a CHECKED correspondence: pushing a tree's entities into
+//! an index bound to some OTHER tree would trade a silent-empty failure for a
+//! silent-wrong one. This module is the resolution the binding always implied.
+//!
+//! What: [`okg_tree_path`] is the one canonical `okg://X` →
+//! `<knowledge_dir>/<slug(X)>` mapping, matching `trusty_kb::roots::Roots`'
+//! agent mapping exactly. [`bound_index_for_tree`] answers "which index does
+//! this KB tree feed?" — from a named agent when the caller has one, or by
+//! searching the agent roster for the single agent whose binding claims that
+//! tree. Every failure returns a human-readable reason instead of an error
+//! type, because the caller's job is to REPORT the reason, never to fail the
+//! ingest over it.
+//!
+//! Test: the `mod tests` at the bottom of this file.
+
+use std::path::{Path, PathBuf};
+
+use trusty_kb::entity::slugify;
+
+use super::config::{OKG_SCHEME, StoresConfig};
+
+/// The agent + index a KB tree feeds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BoundIndex {
+    /// The agent whose `agent.toml` carries the binding.
+    pub agent: String,
+    /// The store binding's name.
+    pub store: String,
+    /// The trusty-search index id to push into.
+    pub index: String,
+}
+
+/// Resolve an `okg://<agent>` tree URI to its directory under `knowledge_dir`.
+///
+/// Why: see the module doc — this is the mapping the URI always implied and
+/// nothing ever performed. Slugging matches `Roots::resolve`'s agent mapping so
+/// a tree addressed by an OKG tool and a tree named by a `[[stores]]` binding
+/// resolve to the SAME directory or the mismatch is visible.
+/// What: `Some(path)` for a well-formed `okg://` URI with a non-blank tail;
+/// `None` for anything else (a `https://` tree, a blank tail) — those are
+/// already reported by [`super::config::AgentStoreBinding::validate`].
+/// Test: `okg_uri_resolves_under_the_knowledge_dir`,
+/// `non_okg_uri_does_not_resolve`.
+pub fn okg_tree_path(knowledge_dir: &Path, tree_uri: &str) -> Option<PathBuf> {
+    let tail = tree_uri.strip_prefix(OKG_SCHEME)?.trim();
+    if tail.is_empty() {
+        return None;
+    }
+    let slug = slugify(tail);
+    if slug.is_empty() {
+        return None;
+    }
+    Some(knowledge_dir.join(slug))
+}
+
+/// Two paths name the same directory, tolerating one or both not existing yet.
+///
+/// Why: a first ingest creates the tree, so the comparison must work BEFORE the
+/// directory exists — canonicalising unconditionally would report "different"
+/// for every first run. What: canonicalises when possible (so a symlinked or
+/// `/tmp` vs `/private/tmp` spelling still matches) and falls back to a literal
+/// comparison otherwise.
+fn same_dir(a: &Path, b: &Path) -> bool {
+    match (a.canonicalize(), b.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+/// Which search index, if any, the KB tree at `root` feeds.
+///
+/// Why: the index push must target the index bound to THIS tree. Passing the
+/// agent name explicitly is the common case (every OKG tool takes one); when it
+/// is absent the roster is searched instead, and an ambiguous answer is refused
+/// rather than guessed — pushing a tree's contents into the wrong agent's index
+/// is worse than not pushing at all.
+/// What: `Ok(BoundIndex)` when exactly one agent binds this tree and its
+/// binding validates; `Err(reason)` otherwise, phrased for a tool result.
+/// `agent_hint`'s binding must actually claim `root`, or the mismatch is the
+/// reason — that check is the whole point of this module.
+/// Test: `resolves_index_from_the_named_agent`,
+/// `reports_a_binding_that_names_a_different_tree`,
+/// `finds_the_only_agent_binding_a_tree`, `refuses_an_ambiguous_tree`,
+/// `reports_an_agent_with_no_binding`.
+pub fn bound_index_for_tree(
+    agent_dirs: &[PathBuf],
+    knowledge_dir: &Path,
+    root: &Path,
+    agent_hint: Option<&str>,
+) -> Result<BoundIndex, String> {
+    if let Some(agent) = agent_hint {
+        let Some(stores) = load_stores(agent_dirs, agent) else {
+            return Err(format!(
+                "agent `{agent}` was not found in {}",
+                describe_dirs(agent_dirs)
+            ));
+        };
+        return binding_for(knowledge_dir, root, agent, &stores);
+    }
+
+    let mut matches: Vec<BoundIndex> = Vec::new();
+    for agent in roster(agent_dirs) {
+        let Some(stores) = load_stores(agent_dirs, &agent) else {
+            continue;
+        };
+        if let Ok(found) = binding_for(knowledge_dir, root, &agent, &stores) {
+            matches.push(found);
+        }
+    }
+    match matches.len() {
+        0 => Err(format!(
+            "no agent binds the tree at {} — add a `[[stores]]` entry naming \
+             `{OKG_SCHEME}<agent>` and its search index, or pass `agent`",
+            root.display()
+        )),
+        1 => Ok(matches.remove(0)),
+        _ => Err(format!(
+            "{} agents bind the tree at {} ({}); pass `agent` to disambiguate",
+            matches.len(),
+            root.display(),
+            matches
+                .iter()
+                .map(|m| m.agent.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        )),
+    }
+}
+
+/// The primary binding of `agent`, verified to claim the tree at `root`.
+fn binding_for(
+    knowledge_dir: &Path,
+    root: &Path,
+    agent: &str,
+    stores: &StoresConfig,
+) -> Result<BoundIndex, String> {
+    let Some(binding) = stores.primary() else {
+        return Err(format!(
+            "agent `{agent}` binds no OKG store, so there is no index to feed"
+        ));
+    };
+    if let Some(issue) = binding.validate() {
+        return Err(issue);
+    }
+    let tree_uri = binding.resolved_tree(agent);
+    let Some(tree_path) = okg_tree_path(knowledge_dir, &tree_uri) else {
+        return Err(format!(
+            "store `{}` declares tree `{tree_uri}`, which does not resolve to a \
+             knowledge-tree directory",
+            binding.name
+        ));
+    };
+    if !same_dir(&tree_path, root) {
+        return Err(format!(
+            "agent `{agent}` binds tree `{tree_uri}` ({}), but this ingest wrote to {} \
+             — refusing to feed an index that describes a different tree",
+            tree_path.display(),
+            root.display()
+        ));
+    }
+    Ok(BoundIndex {
+        agent: agent.to_string(),
+        store: binding.name.clone(),
+        index: binding.resolved_index().to_string(),
+    })
+}
+
+/// Parse just the `[[stores]]` table out of an agent's config.
+///
+/// Why: reading the whole file through `AgentConfig` would require `[llm]` /
+/// `[system_prompt]` to be present and valid, which a directory-package
+/// `agent.toml` deliberately omits — the same partial-read precedent as
+/// `api::server::agent_stores::parse_stores`. A malformed file degrades to "no
+/// bindings", which the caller reports as a reason.
+fn load_stores(dirs: &[PathBuf], agent: &str) -> Option<StoresConfig> {
+    if agent.is_empty() || agent.contains(['/', '\\']) || agent == "." || agent == ".." {
+        return None;
+    }
+    let path = dirs.iter().find_map(|dir| {
+        let package = dir.join(agent).join("agent.toml");
+        if package.is_file() {
+            return Some(package);
+        }
+        let flat = dir.join(format!("{agent}.toml"));
+        flat.is_file().then_some(flat)
+    })?;
+    let raw = std::fs::read_to_string(path).ok()?;
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        #[serde(default)]
+        stores: StoresConfig,
+    }
+    Some(
+        toml::from_str::<Partial>(&raw)
+            .map(|p| p.stores)
+            .unwrap_or_default(),
+    )
+}
+
+/// Every agent name discoverable in `dirs`, package or flat form.
+fn roster(dirs: &[PathBuf]) -> Vec<String> {
+    let mut names: Vec<String> = Vec::new();
+    for dir in dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let name = if path.is_dir() && path.join("agent.toml").is_file() {
+                path.file_name().map(|n| n.to_string_lossy().to_string())
+            } else if path.extension().is_some_and(|e| e == "toml") {
+                path.file_stem().map(|n| n.to_string_lossy().to_string())
+            } else {
+                None
+            };
+            if let Some(name) = name
+                && !names.contains(&name)
+            {
+                names.push(name);
+            }
+        }
+    }
+    names.sort();
+    names
+}
+
+/// Render the searched directories for an error message.
+fn describe_dirs(dirs: &[PathBuf]) -> String {
+    if dirs.is_empty() {
+        return "(no agent directories configured)".to_string();
+    }
+    dirs.iter()
+        .map(|d| d.display().to_string())
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An agents dir holding one package agent with the given `[[stores]]`.
+    fn agent_dir(tmp: &Path, name: &str, stores_toml: &str) {
+        let dir = tmp.join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("agent.toml"),
+            format!("[agent]\nname = \"{name}\"\n{stores_toml}"),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn okg_uri_resolves_under_the_knowledge_dir() {
+        let kdir = Path::new("/kb/knowledge");
+        assert_eq!(
+            okg_tree_path(kdir, "okg://cto-assistant"),
+            Some(PathBuf::from("/kb/knowledge/cto-assistant"))
+        );
+        // Slugged exactly like `Roots::resolve`'s agent mapping, so a name with
+        // a space cannot inject a path separator.
+        assert_eq!(
+            okg_tree_path(kdir, "okg://CTO Bot"),
+            Some(PathBuf::from("/kb/knowledge/cto-bot"))
+        );
+    }
+
+    #[test]
+    fn non_okg_uri_does_not_resolve() {
+        let kdir = Path::new("/kb/knowledge");
+        assert_eq!(okg_tree_path(kdir, "https://example.com/kb"), None);
+        assert_eq!(okg_tree_path(kdir, "okg://"), None);
+        assert_eq!(okg_tree_path(kdir, "okg://   "), None);
+    }
+
+    #[test]
+    fn resolves_index_from_the_named_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let kdir = tmp.path().join("knowledge");
+        agent_dir(
+            &agents,
+            "cto-assistant",
+            "[[stores]]\nname = \"cto-assistant-kb\"\ntree = \"okg://cto-assistant\"\nindex = \"cto-assistant\"\n",
+        );
+        let found = bound_index_for_tree(
+            &[agents],
+            &kdir,
+            &kdir.join("cto-assistant"),
+            Some("cto-assistant"),
+        )
+        .unwrap();
+        assert_eq!(found.index, "cto-assistant");
+        assert_eq!(found.store, "cto-assistant-kb");
+    }
+
+    /// Why: this is #3892's third finding turned into a guard — the tree tail
+    /// and the KB directory coinciding was a coincidence, so a binding that
+    /// names a DIFFERENT tree must be refused rather than fed.
+    #[test]
+    fn reports_a_binding_that_names_a_different_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let kdir = tmp.path().join("knowledge");
+        agent_dir(
+            &agents,
+            "izzie",
+            "[[stores]]\nname = \"bob-kb\"\ntree = \"okg://izzie\"\nindex = \"bob-kb\"\n",
+        );
+        let err = bound_index_for_tree(&[agents], &kdir, &kdir.join("someone-else"), Some("izzie"))
+            .unwrap_err();
+        assert!(err.contains("different tree"), "reason was: {err}");
+    }
+
+    #[test]
+    fn finds_the_only_agent_binding_a_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let kdir = tmp.path().join("knowledge");
+        agent_dir(&agents, "izzie", "[[stores]]\nname = \"bob-kb\"\n");
+        agent_dir(
+            &agents,
+            "cto-assistant",
+            "[[stores]]\nname = \"cto-assistant-kb\"\nindex = \"cto-assistant\"\n",
+        );
+        let found =
+            bound_index_for_tree(&[agents], &kdir, &kdir.join("cto-assistant"), None).unwrap();
+        assert_eq!(found.agent, "cto-assistant");
+        assert_eq!(found.index, "cto-assistant");
+    }
+
+    #[test]
+    fn refuses_an_ambiguous_tree() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let kdir = tmp.path().join("knowledge");
+        // Two agents both explicitly claiming the same tree.
+        agent_dir(
+            &agents,
+            "one",
+            "[[stores]]\nname = \"a\"\ntree = \"okg://shared\"\nindex = \"a\"\n",
+        );
+        agent_dir(
+            &agents,
+            "two",
+            "[[stores]]\nname = \"b\"\ntree = \"okg://shared\"\nindex = \"b\"\n",
+        );
+        let err = bound_index_for_tree(&[agents], &kdir, &kdir.join("shared"), None).unwrap_err();
+        assert!(err.contains("disambiguate"), "reason was: {err}");
+    }
+
+    #[test]
+    fn reports_an_agent_with_no_binding() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let kdir = tmp.path().join("knowledge");
+        agent_dir(&agents, "plain", "");
+        let err =
+            bound_index_for_tree(&[agents], &kdir, &kdir.join("plain"), Some("plain")).unwrap_err();
+        assert!(err.contains("binds no OKG store"), "reason was: {err}");
+    }
+
+    #[test]
+    fn reports_an_unknown_agent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        std::fs::create_dir_all(&agents).unwrap();
+        let kdir = tmp.path().join("knowledge");
+        let err =
+            bound_index_for_tree(&[agents], &kdir, &kdir.join("ghost"), Some("ghost")).unwrap_err();
+        assert!(err.contains("was not found"), "reason was: {err}");
+    }
+
+    /// Why: an unbound tree is a normal state (a hand-built KB with no agent),
+    /// and it must produce a REASON, never a match against some unrelated
+    /// agent's index.
+    #[test]
+    fn reports_a_tree_no_agent_binds() {
+        let tmp = tempfile::tempdir().unwrap();
+        let agents = tmp.path().join("agents");
+        let kdir = tmp.path().join("knowledge");
+        agent_dir(&agents, "izzie", "[[stores]]\nname = \"bob-kb\"\n");
+        let err = bound_index_for_tree(&[agents], &kdir, &kdir.join("orphan"), None).unwrap_err();
+        assert!(err.contains("no agent binds"), "reason was: {err}");
+    }
+}

--- a/crates/trusty-agents/src/stores/index_feed.rs
+++ b/crates/trusty-agents/src/stores/index_feed.rs
@@ -1,0 +1,338 @@
+//! Pushing OKG ingest output into the store's bound search index (#3892,
+//! remediation (a)).
+//!
+//! Why: an OKG store's `[[stores]]` binding reads as "one store, with a tree
+//! facet and an index facet", but nothing kept the two describing the same
+//! content — `okg_ingest_*` wrote markdown into the KB tree while
+//! `vector_search` queried an index built over an unrelated root, so an ingest
+//! could report "N entities ingested" truthfully and still leave the assistant
+//! finding nothing, with no error on either side. This module is the half that
+//! was missing: after an entity is durably written to the tree, its content is
+//! pushed into the bound index, making the binding's semantics true.
+//!
+//! It lives in `trusty-agents`, not `trusty-kb`, for the same reason the
+//! Gmail/Drive fetchers do: the push is a NETWORK call, and `trusty-kb` stays
+//! deterministic and network-free. The reconcile that decides WHAT to push is
+//! pure and therefore stays in the KB crate
+//! ([`KbStore::okg_index_backlog`](trusty_kb::store::KbStore::okg_index_backlog));
+//! this module owns only the seam ([`IndexFeed`]) and the drive loop, so every
+//! ordering property is testable against a fake with no daemon running.
+//!
+//! ## The contract
+//!
+//! 1. **The tree write is the durable record.** The item ledger is never gated
+//!    on a push. A search daemon that is down, slow, or 500ing cannot lose
+//!    ingestion work or make it non-convergent (DOC-55 SPEC-OKGIMPORT-06
+//!    §7.2.4).
+//! 2. **But success is never claimed falsely.** Every run reports `indexed`,
+//!    `removed`, and `pending` — the count of entities that are in the tree and
+//!    NOT yet searchable — plus one error line per failed push.
+//! 3. **Ordering: push, then record.** A journal line is appended only after
+//!    the daemon acknowledged the write, so a crash in between costs one
+//!    redundant re-push (the push is an upsert keyed by file path), never a
+//!    permanently-unindexed entity. This mirrors the ingest engine's
+//!    entity-before-ledger ordering.
+//! 4. **Every run reconciles the whole backlog**, not just what it ingested.
+//!    An entity the ingest engine skipped as unchanged, but which never reached
+//!    the index, is pushed by the next run. That is what makes a failed push
+//!    self-healing rather than permanent.
+//! 5. **A changed entity is withdrawn before it is re-pushed.** trusty-search
+//!    chunks by content, so a shorter revision would otherwise leave the old
+//!    chunks searchable alongside the new ones.
+//! 6. **A bound index that cannot serve the tree is refused, not fed.**
+//!    trusty-search post-filters every result whose path escapes the index
+//!    root (issues #64 / #541 — verified live: the push succeeds, the chunks
+//!    exist, `search` returns nothing). So the feed asks the daemon for the
+//!    index's root FIRST and, when it does not contain the tree, reports that
+//!    with the remediation instead of manufacturing a fresh silent failure.
+//!    This is why remediation (a) does not require re-pointing anyone's
+//!    existing index root: a binding whose index cannot serve its tree is a
+//!    configuration error, and it is now a LOUD one.
+//!
+//! Test: `super::index_feed::tests` — a fake feed covers push/remove ordering,
+//! idempotency, failure retention and recovery; a mock HTTP server pins the
+//! real daemon route shape.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde::Serialize;
+use trusty_kb::okg::index_journal::{IndexJournal, IndexOp, IndexTask};
+use trusty_kb::okg::registry::SourceSpec;
+use trusty_kb::store::KbStore;
+
+/// Per-push timeout.
+///
+/// Why: generous compared to [`super::status::PROBE_TIMEOUT`] because a push is
+/// real work — trusty-search chunks, embeds, and commits the file inline — but
+/// still bounded, so one wedged request cannot hang an ingest indefinitely. A
+/// timeout is reported as a failed push and retried on the next run, which is
+/// exactly the pending-item path.
+pub const PUSH_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// The seam between "decide what to index" and "talk to trusty-search".
+///
+/// Why: the drive loop's ordering guarantees (record only after success, retry
+/// on the next run, withdraw before replace) are the part that can silently
+/// regress, so they must be testable without a daemon — the same reason the
+/// ingest engine splits at `SourceItem`.
+/// What: two operations, both keyed by the entity file's absolute path, which
+/// is the identity trusty-search stores and the one `remove_file` withdraws by.
+#[async_trait]
+pub trait IndexFeed: Send + Sync {
+    /// Upsert one file's content into `index`.
+    async fn index_file(&self, index: &str, path: &str, content: &str) -> anyhow::Result<()>;
+    /// Withdraw one file from `index`.
+    async fn remove_file(&self, index: &str, path: &str) -> anyhow::Result<()>;
+    /// The index's configured root directory, when the daemon reports one.
+    ///
+    /// Why: this is a PREFLIGHT, not a nicety — see [`covers`]. trusty-search
+    /// post-filters every search result whose file path falls outside the
+    /// index root, so pushing an entity into a foreign-rooted index stores it
+    /// and then hides it from every query. Without this check the feed would
+    /// report `indexed: 2, pending: 0` while `vector_search` still returned
+    /// nothing: a NEW silent failure, in the shape of the one #3892 is about.
+    /// What: `Ok(None)` means the daemon reported no root and the check is
+    /// skipped (fail-open on an unknown); `Err` means the index could not be
+    /// interrogated at all.
+    async fn index_root(&self, index: &str) -> anyhow::Result<Option<std::path::PathBuf>>;
+}
+
+/// Whether entities under `tree` would survive `index`'s out-of-root filter.
+///
+/// Why: trusty-search's `file_is_within_root` post-filter (issues #64 / #541)
+/// drops any result whose path escapes the index root — a defence against
+/// stale, mis-registered indexes leaking cross-project results. It applies to
+/// pushed content exactly as it does to walked content, so an OKG store's index
+/// is only usable when its root CONTAINS the tree it is bound to.
+/// What: prefix check, canonicalising both sides when they exist so a
+/// `/tmp` vs `/private/tmp` or symlinked spelling still matches.
+/// Test: `refuses_an_index_rooted_away_from_the_tree`.
+fn covers(root: &std::path::Path, tree: &std::path::Path) -> bool {
+    let canon = |p: &std::path::Path| p.canonicalize().unwrap_or_else(|_| p.to_path_buf());
+    canon(tree).starts_with(canon(root))
+}
+
+/// The live feed: the trusty-search daemon's per-file HTTP surface.
+///
+/// Why/What: `POST /indexes/{id}/index-file` takes `{path, content}` and
+/// `POST /indexes/{id}/remove-file` takes `{path}` — the HTTP equivalents of
+/// the `index_file` / `remove_file` MCP tools. Content is supplied in the body,
+/// so an entity does NOT need to live under the index's own root: this is what
+/// lets remediation (a) leave the operator's configured index root untouched.
+/// Test: `http_feed_calls_the_daemon_routes`.
+pub struct HttpIndexFeed {
+    base: String,
+    client: reqwest::Client,
+}
+
+impl HttpIndexFeed {
+    /// Build a feed against a trusty-search base URL (`http://127.0.0.1:7878`).
+    pub fn new(base: impl Into<String>) -> anyhow::Result<Self> {
+        Ok(Self {
+            base: base.into().trim_end_matches('/').to_string(),
+            client: reqwest::Client::builder().timeout(PUSH_TIMEOUT).build()?,
+        })
+    }
+
+    /// POST one JSON body, mapping every non-2xx answer to an error.
+    async fn post(&self, url: String, body: serde_json::Value) -> anyhow::Result<()> {
+        let resp = self.client.post(&url).json(&body).send().await?;
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(());
+        }
+        // The daemon's error bodies are short; including one turns "500" into a
+        // diagnosable line in the tool result.
+        let detail = resp.text().await.unwrap_or_default();
+        let detail = detail.chars().take(200).collect::<String>();
+        anyhow::bail!("trusty-search returned HTTP {status} for {url}: {detail}")
+    }
+}
+
+#[async_trait]
+impl IndexFeed for HttpIndexFeed {
+    async fn index_file(&self, index: &str, path: &str, content: &str) -> anyhow::Result<()> {
+        self.post(
+            format!("{}/indexes/{index}/index-file", self.base),
+            serde_json::json!({ "path": path, "content": content }),
+        )
+        .await
+    }
+
+    async fn remove_file(&self, index: &str, path: &str) -> anyhow::Result<()> {
+        self.post(
+            format!("{}/indexes/{index}/remove-file", self.base),
+            serde_json::json!({ "path": path }),
+        )
+        .await
+    }
+
+    async fn index_root(&self, index: &str) -> anyhow::Result<Option<std::path::PathBuf>> {
+        let url = format!("{}/indexes/{index}/status", self.base);
+        let resp = self.client.get(&url).send().await?;
+        if resp.status() == reqwest::StatusCode::NOT_FOUND {
+            anyhow::bail!("search index `{index}` is not registered on the trusty-search daemon");
+        }
+        if !resp.status().is_success() {
+            anyhow::bail!(
+                "trusty-search returned HTTP {} for index `{index}`",
+                resp.status()
+            );
+        }
+        let body: serde_json::Value = resp.json().await?;
+        Ok(body
+            .get("root_path")
+            .and_then(serde_json::Value::as_str)
+            .map(std::path::PathBuf::from))
+    }
+}
+
+/// What one feed pass did — the caller-facing summary.
+///
+/// Why: this is the honesty half of the contract. `pending` is the number the
+/// #3892 report was missing entirely: entities that ARE in the tree and are NOT
+/// searchable. It is non-zero whenever the daemon is unreachable, a push failed,
+/// or no index is bound at all, and it must be surfaced next to the ingest
+/// counts rather than folded into them.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct IndexFeedReport {
+    /// The index that was fed, when one resolved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<String>,
+    /// Entities pushed into the index this pass.
+    pub indexed: usize,
+    /// Entities withdrawn from the index this pass.
+    pub removed: usize,
+    /// Entities still owed to the index after this pass — INGESTED BUT NOT YET
+    /// SEARCHABLE. A later run drains them.
+    pub pending: usize,
+    /// Entities the index already held at this exact content.
+    pub synced: usize,
+    /// Why nothing was fed, when `index` is `None` (no binding, daemon
+    /// undiscoverable, tree/index mismatch). Never an ingest failure.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Per-entity failures. A failed push leaves its entity pending.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<String>,
+}
+
+impl IndexFeedReport {
+    /// A pass that could not run, with the pending backlog it leaves behind.
+    ///
+    /// Why: "no index bound" and "daemon down" must still report HOW MUCH is
+    /// unsearchable, or the caller learns nothing it did not already know.
+    pub fn not_fed(reason: String, pending: usize, synced: usize) -> Self {
+        Self {
+            index: None,
+            pending,
+            synced,
+            reason: Some(reason),
+            ..Self::default()
+        }
+    }
+}
+
+/// Drain one source's index backlog into `index`.
+///
+/// Why/What/Test: see the module doc — this is the drive loop the contract
+/// describes. Per item: withdraw-if-replacing, push, then record. A failure is
+/// recorded as an error and the item stays pending; it never aborts the pass,
+/// because one poisoned entity must not block the other 4,999.
+pub async fn feed_source(
+    store: &KbStore,
+    spec: &SourceSpec,
+    index: &str,
+    feed: &dyn IndexFeed,
+    now: &str,
+) -> anyhow::Result<IndexFeedReport> {
+    let backlog = store.okg_index_backlog(spec)?;
+    let pending = backlog.tasks.len() + backlog.notes.len();
+
+    // Preflight: an index whose root does not contain this tree would STORE
+    // every push and then hide it from every query (see `covers`). Refusing
+    // loudly is the only honest outcome — pushing anyway would manufacture a
+    // fresh silent failure.
+    match feed.index_root(index).await {
+        Ok(Some(root)) if !covers(&root, &store.root) => {
+            return Ok(IndexFeedReport::not_fed(
+                format!(
+                    "index `{index}` is rooted at {}, which does not contain this tree ({}). \
+                     trusty-search drops any search result whose path falls outside the index \
+                     root, so entities pushed there would be stored and never returned. Bind a \
+                     search index registered over the tree itself.",
+                    root.display(),
+                    store.root.display()
+                ),
+                pending,
+                backlog.synced,
+            ));
+        }
+        Ok(_) => {}
+        Err(e) => {
+            return Ok(IndexFeedReport::not_fed(
+                format!("index `{index}` could not be interrogated: {e}"),
+                pending,
+                backlog.synced,
+            ));
+        }
+    }
+
+    let mut journal = IndexJournal::load(&store.root, &spec.id)?;
+    let mut report = IndexFeedReport {
+        index: Some(index.to_string()),
+        synced: backlog.synced,
+        // An unresolvable row is unsearchable too, so it counts against
+        // `pending` as well as being reported — the same honesty rule.
+        pending: backlog.notes.len(),
+        errors: backlog.notes,
+        ..IndexFeedReport::default()
+    };
+
+    for task in &backlog.tasks {
+        let path = task.path.to_string_lossy().to_string();
+        match run_task(store, feed, index, task, &path, &mut journal, now).await {
+            Ok(IndexOp::Remove) => report.removed += 1,
+            Ok(IndexOp::Index { .. }) => report.indexed += 1,
+            Err(e) => {
+                // Left unrecorded on purpose: the entity stays in the backlog
+                // and the next run retries it. This is the fail-open half of
+                // the contract — loud, counted, never lost.
+                report.pending += 1;
+                report.errors.push(format!("{}: {e}", task.entity));
+            }
+        }
+    }
+    Ok(report)
+}
+
+/// Perform one task and record it. Any error leaves the journal untouched.
+async fn run_task(
+    store: &KbStore,
+    feed: &dyn IndexFeed,
+    index: &str,
+    task: &IndexTask,
+    path: &str,
+    journal: &mut IndexJournal,
+    now: &str,
+) -> anyhow::Result<IndexOp> {
+    match task.op {
+        IndexOp::Remove => feed.remove_file(index, path).await?,
+        IndexOp::Index { replace } => {
+            // Withdraw the stale revision first — trusty-search keys chunks by
+            // content, so a shorter revision would leave orphans searchable.
+            if replace {
+                feed.remove_file(index, path).await?;
+            }
+            let content = std::fs::read_to_string(&task.path)?;
+            feed.index_file(index, path, &content).await?;
+        }
+    }
+    store.okg_record_index(journal, task, now)?;
+    Ok(task.op)
+}
+
+#[cfg(test)]
+#[path = "index_feed_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/stores/index_feed_tests.rs
+++ b/crates/trusty-agents/src/stores/index_feed_tests.rs
@@ -1,0 +1,463 @@
+//! Ordering and convergence tests for the index feed (#3892).
+//!
+//! Why: every guarantee in the module doc's contract is invisible in normal
+//! operation and catastrophic when it regresses — a lost push is silent on both
+//! sides, which is the exact bug #3892 reports. The seam exists so all of it can
+//! be proved against a FAKE feed with no daemon: push-then-record ordering, a
+//! failed push staying pending and healing on a later run, replace-before-push
+//! on an edit, and withdrawal on a tombstone.
+//! What: a recording fake with an arm-able failure, driven over a real temp KB
+//! tree and a real doc-store ingest; plus one mock-HTTP test pinning the live
+//! daemon's route and body shape.
+//! Test: `cargo test -p trusty-agents stores::index_feed`.
+
+use std::sync::Mutex;
+
+use super::*;
+use trusty_kb::okg::policy::DocStorePolicy;
+use trusty_kb::okg::registry::Locator;
+use trusty_kb::schema::Profile;
+
+/// One recorded call against the fake feed.
+#[derive(Debug, Clone, PartialEq)]
+enum Call {
+    Index { path: String, content: String },
+    Remove { path: String },
+}
+
+/// A feed that records every call and can be armed to fail.
+#[derive(Default)]
+struct FakeFeed {
+    calls: Mutex<Vec<Call>>,
+    /// When true, every operation fails — the "daemon is broken" case.
+    failing: Mutex<bool>,
+    /// The root this fake index claims. `None` = daemon reported none, which
+    /// skips the coverage preflight.
+    root: Mutex<Option<std::path::PathBuf>>,
+}
+
+impl FakeFeed {
+    fn arm_failure(&self, failing: bool) {
+        *self.failing.lock().unwrap() = failing;
+    }
+    fn set_root(&self, root: Option<std::path::PathBuf>) {
+        *self.root.lock().unwrap() = root;
+    }
+    fn calls(&self) -> Vec<Call> {
+        self.calls.lock().unwrap().clone()
+    }
+    fn check(&self) -> anyhow::Result<()> {
+        if *self.failing.lock().unwrap() {
+            anyhow::bail!("search daemon unavailable");
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl IndexFeed for FakeFeed {
+    async fn index_file(&self, _index: &str, path: &str, content: &str) -> anyhow::Result<()> {
+        self.check()?;
+        self.calls.lock().unwrap().push(Call::Index {
+            path: path.to_string(),
+            content: content.to_string(),
+        });
+        Ok(())
+    }
+    async fn remove_file(&self, _index: &str, path: &str) -> anyhow::Result<()> {
+        self.check()?;
+        self.calls.lock().unwrap().push(Call::Remove {
+            path: path.to_string(),
+        });
+        Ok(())
+    }
+    async fn index_root(&self, _index: &str) -> anyhow::Result<Option<std::path::PathBuf>> {
+        // The preflight is a status read, so it is NOT gated by `failing` —
+        // arming a failure must exercise the push path, not short-circuit it.
+        Ok(self.root.lock().unwrap().clone())
+    }
+}
+
+/// A KB store plus a doc-store corpus under one tempdir.
+struct Fixture {
+    _tmp: tempfile::TempDir,
+    store: KbStore,
+    corpus: std::path::PathBuf,
+    policy: DocStorePolicy,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let tmp = tempfile::tempdir().unwrap();
+        let store = KbStore::new(tmp.path().join("kb"), Profile::default_profile());
+        let corpus = tmp.path().join("corpus");
+        std::fs::create_dir_all(&corpus).unwrap();
+        let policy = DocStorePolicy::new(vec![tmp.path().canonicalize().unwrap()]);
+        Self {
+            _tmp: tmp,
+            store,
+            corpus,
+            policy,
+        }
+    }
+
+    fn register(&self) -> SourceSpec {
+        let mut spec = SourceSpec::new(
+            "corpus",
+            Some("notes"),
+            Locator::DocStore {
+                path: self.corpus.to_string_lossy().to_string(),
+                extensions: vec![],
+                recursive: true,
+            },
+            "t0",
+        );
+        spec.tombstone_deleted = true;
+        self.store.okg_register_source(spec).unwrap();
+        self.store.okg_source("corpus").unwrap()
+    }
+
+    fn ingest(&self, now: &str) {
+        self.store
+            .okg_ingest_docstore("corpus", &self.policy, now)
+            .unwrap();
+    }
+}
+
+/// Why: the base case the whole issue is about — after an ingest, the entities
+/// must actually reach the index, and a second pass must push nothing.
+/// What: ingests two files, feeds, asserts both were pushed with their real
+/// content, then asserts the immediate re-feed is inert (upsert, not duplicate).
+/// Test: self-contained.
+#[tokio::test]
+async fn feeds_the_backlog_then_settles() {
+    let fx = Fixture::new();
+    std::fs::write(fx.corpus.join("one.md"), "alpha note").unwrap();
+    std::fs::write(fx.corpus.join("two.md"), "beta note").unwrap();
+    let spec = fx.register();
+    fx.ingest("t0");
+
+    let feed = FakeFeed::default();
+    let report = feed_source(&fx.store, &spec, "scratch-index", &feed, "t0")
+        .await
+        .unwrap();
+    assert_eq!(
+        (report.indexed, report.removed, report.pending),
+        (2, 0, 0),
+        "errors: {:?}",
+        report.errors
+    );
+    assert_eq!(report.index.as_deref(), Some("scratch-index"));
+    let calls = feed.calls();
+    assert_eq!(calls.len(), 2, "one push per entity: {calls:?}");
+    assert!(
+        calls
+            .iter()
+            .any(|c| matches!(c, Call::Index { content, .. } if content.contains("alpha note"))),
+        "the pushed content must be the entity file's real body: {calls:?}"
+    );
+
+    let second = feed_source(&fx.store, &spec, "scratch-index", &feed, "t1")
+        .await
+        .unwrap();
+    assert_eq!((second.indexed, second.removed, second.pending), (0, 0, 0));
+    assert_eq!(second.synced, 2);
+    assert_eq!(feed.calls().len(), 2, "a settled feed makes no calls");
+}
+
+/// Why: THE convergence property. A push that fails (daemon down, 500, timeout)
+/// must not lose the entity and must not be silently forgotten — the ingest
+/// engine will skip the unchanged item on every later run, so only the index
+/// backlog can bring it back.
+/// What: fails every push, asserts the work is reported as pending with an error
+/// line and nothing recorded, then re-runs the whole ingest + feed with the
+/// daemon "back" and asserts the item is indexed after all.
+/// Test: self-contained.
+#[tokio::test]
+async fn failed_push_stays_pending_and_heals_on_a_later_run() {
+    let fx = Fixture::new();
+    std::fs::write(fx.corpus.join("one.md"), "alpha note").unwrap();
+    let spec = fx.register();
+    fx.ingest("t0");
+
+    let feed = FakeFeed::default();
+    feed.arm_failure(true);
+    let failed = feed_source(&fx.store, &spec, "scratch-index", &feed, "t0")
+        .await
+        .unwrap();
+    assert_eq!((failed.indexed, failed.pending), (0, 1));
+    assert_eq!(
+        failed.errors.len(),
+        1,
+        "the failure is reported, not hidden"
+    );
+    assert!(
+        failed.errors[0].contains("unavailable"),
+        "{:?}",
+        failed.errors
+    );
+
+    // A second ingest skips the unchanged file entirely — only the index
+    // backlog can rescue it.
+    fx.ingest("t1");
+    feed.arm_failure(false);
+    let healed = feed_source(&fx.store, &spec, "scratch-index", &feed, "t1")
+        .await
+        .unwrap();
+    assert_eq!(
+        (healed.indexed, healed.pending),
+        (1, 0),
+        "an unindexed entity must never be permanently skipped"
+    );
+    assert!(
+        feed_source(&fx.store, &spec, "scratch-index", &feed, "t2")
+            .await
+            .unwrap()
+            .indexed
+            == 0,
+        "and it settles afterwards"
+    );
+}
+
+/// Why: an edited entity must REPLACE its index content. trusty-search chunks by
+/// content, so pushing the new revision without withdrawing the old one leaves
+/// stale text searchable — a subtler version of the same lie.
+/// What: feeds, edits the source file, re-ingests and re-feeds, then asserts the
+/// pass issued a withdrawal BEFORE the new push and that the pushed body is the
+/// revised one.
+/// Test: self-contained.
+#[tokio::test]
+async fn edited_entity_is_withdrawn_before_it_is_repushed() {
+    let fx = Fixture::new();
+    std::fs::write(fx.corpus.join("one.md"), "alpha note").unwrap();
+    let spec = fx.register();
+    fx.ingest("t0");
+    let feed = FakeFeed::default();
+    feed_source(&fx.store, &spec, "idx", &feed, "t0")
+        .await
+        .unwrap();
+
+    std::fs::write(fx.corpus.join("one.md"), "alpha note, revised").unwrap();
+    fx.ingest("t1");
+    let report = feed_source(&fx.store, &spec, "idx", &feed, "t1")
+        .await
+        .unwrap();
+    assert_eq!((report.indexed, report.pending), (1, 0));
+
+    let calls = feed.calls();
+    assert_eq!(calls.len(), 3, "index, remove, index: {calls:?}");
+    assert!(
+        matches!(&calls[1], Call::Remove { .. }),
+        "the stale revision must be withdrawn first: {calls:?}"
+    );
+    assert!(
+        matches!(&calls[2], Call::Index { content, .. } if content.contains("revised")),
+        "{calls:?}"
+    );
+}
+
+/// Why: a deleted source item must stop being findable, or search keeps serving
+/// content the tree has already flagged as gone.
+/// What: feeds, deletes the file, re-ingests (tombstoning) and re-feeds, then
+/// asserts exactly one withdrawal and a settled backlog.
+/// Test: self-contained.
+#[tokio::test]
+async fn tombstoned_entity_is_withdrawn_from_the_index() {
+    let fx = Fixture::new();
+    std::fs::write(fx.corpus.join("one.md"), "alpha note").unwrap();
+    let spec = fx.register();
+    fx.ingest("t0");
+    let feed = FakeFeed::default();
+    feed_source(&fx.store, &spec, "idx", &feed, "t0")
+        .await
+        .unwrap();
+
+    std::fs::remove_file(fx.corpus.join("one.md")).unwrap();
+    fx.ingest("t1");
+    let report = feed_source(&fx.store, &spec, "idx", &feed, "t1")
+        .await
+        .unwrap();
+    assert_eq!((report.indexed, report.removed, report.pending), (0, 1, 0));
+    assert!(matches!(feed.calls().last(), Some(Call::Remove { .. })));
+
+    let settled = feed_source(&fx.store, &spec, "idx", &feed, "t2")
+        .await
+        .unwrap();
+    assert_eq!((settled.removed, settled.pending), (0, 0));
+}
+
+/// Why: one poisoned entity must not block the rest of a 5,000-item backlog, and
+/// the partial progress it does make has to be durable.
+/// What: makes one of three entity files unreadable (removed from the tree after
+/// ingest), feeds, and asserts the other two still land while the bad one is
+/// reported.
+/// Test: self-contained.
+#[tokio::test]
+async fn a_bad_entity_does_not_abort_the_pass() {
+    let fx = Fixture::new();
+    for name in ["one", "two", "three"] {
+        std::fs::write(fx.corpus.join(format!("{name}.md")), format!("{name} note")).unwrap();
+    }
+    let spec = fx.register();
+    fx.ingest("t0");
+    // Delete one entity from the TREE (not the corpus) behind the ledger's back.
+    std::fs::remove_file(fx.store.entity_path("notes", "two").unwrap()).unwrap();
+
+    let feed = FakeFeed::default();
+    let report = feed_source(&fx.store, &spec, "idx", &feed, "t0")
+        .await
+        .unwrap();
+    assert_eq!(report.indexed, 2, "the healthy entities still land");
+    assert_eq!(
+        report.pending, 1,
+        "an unresolvable entity is unsearchable and must be counted"
+    );
+    assert_eq!(report.errors.len(), 1, "errors: {:?}", report.errors);
+    assert!(
+        report.errors[0].contains("not readable"),
+        "{:?}",
+        report.errors
+    );
+}
+
+/// Why: THE live-verification finding. trusty-search post-filters every search
+/// result whose path escapes the index root (issues #64 / #541), so pushing a
+/// tree's entities into an index rooted elsewhere stores them and hides them
+/// from every query — `indexed: 2, pending: 0` and `vector_search` still empty.
+/// That is a NEW silent failure in the shape of the one #3892 reports, so the
+/// feed must refuse and say why rather than push.
+/// What: claims a root that does not contain the tree, asserts NOTHING was
+/// pushed, the reason names both paths, and the backlog is still reported.
+/// A root that DOES contain the tree feeds normally.
+/// Test: self-contained.
+#[tokio::test]
+async fn refuses_an_index_rooted_away_from_the_tree() {
+    let fx = Fixture::new();
+    std::fs::write(fx.corpus.join("one.md"), "alpha note").unwrap();
+    let spec = fx.register();
+    fx.ingest("t0");
+
+    let feed = FakeFeed::default();
+    let elsewhere = tempfile::tempdir().unwrap();
+    feed.set_root(Some(elsewhere.path().to_path_buf()));
+    let refused = feed_source(&fx.store, &spec, "wrong-root", &feed, "t0")
+        .await
+        .unwrap();
+    assert_eq!(
+        (refused.indexed, refused.pending),
+        (0, 1),
+        "nothing may be pushed into an index that cannot serve it"
+    );
+    assert!(feed.calls().is_empty(), "calls: {:?}", feed.calls());
+    let reason = refused.reason.as_deref().unwrap_or_default();
+    assert!(
+        reason.contains("does not contain this tree") && reason.contains("never returned"),
+        "the reason must be actionable: {reason}"
+    );
+
+    // The same feed, now rooted ABOVE the tree, works.
+    feed.set_root(Some(fx.store.root.clone()));
+    let fed = feed_source(&fx.store, &spec, "right-root", &feed, "t1")
+        .await
+        .unwrap();
+    assert_eq!((fed.indexed, fed.pending), (1, 0), "{:?}", fed.errors);
+}
+
+/// Why: the live route shape is the one thing a fake cannot prove, and a wrong
+/// path or body key would fail only against the real daemon.
+/// What: stands up a mock exposing trusty-search's actual `index-file` /
+/// `remove-file` routes, drives [`HttpIndexFeed`], and asserts the URL, the JSON
+/// keys, and that a non-2xx answer surfaces as an error.
+/// Test: self-contained.
+#[tokio::test]
+async fn http_feed_calls_the_daemon_routes() {
+    use axum::{Json, Router, extract::Path, http::StatusCode, routing::post};
+    use std::sync::Arc;
+    use tokio::net::TcpListener;
+
+    let seen: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let index_seen = seen.clone();
+    let remove_seen = seen.clone();
+    let app = Router::new()
+        .route(
+            "/indexes/{id}/index-file",
+            post(
+                move |Path(id): Path<String>, Json(body): Json<serde_json::Value>| {
+                    let seen = index_seen.clone();
+                    async move {
+                        seen.lock().unwrap().push(format!(
+                            "index {id} {} {}",
+                            body["path"].as_str().unwrap_or_default(),
+                            body["content"].as_str().unwrap_or_default()
+                        ));
+                        (StatusCode::OK, Json(serde_json::json!({"indexed": true})))
+                    }
+                },
+            ),
+        )
+        .route(
+            "/indexes/{id}/remove-file",
+            post(
+                move |Path(id): Path<String>, Json(body): Json<serde_json::Value>| {
+                    let seen = remove_seen.clone();
+                    async move {
+                        // Mirror the daemon: an unregistered index is a 404.
+                        if id == "ghost" {
+                            return (
+                                StatusCode::NOT_FOUND,
+                                Json(serde_json::json!({"error": "no such index"})),
+                            );
+                        }
+                        seen.lock().unwrap().push(format!(
+                            "remove {id} {}",
+                            body["path"].as_str().unwrap_or_default()
+                        ));
+                        (
+                            StatusCode::OK,
+                            Json(serde_json::json!({"removed_chunks": 3})),
+                        )
+                    }
+                },
+            ),
+        )
+        .route(
+            "/indexes/{id}/status",
+            axum::routing::get(|Path(id): Path<String>| async move {
+                if id == "ghost" {
+                    return (
+                        StatusCode::NOT_FOUND,
+                        Json(serde_json::json!({"error": "no such index"})),
+                    );
+                }
+                (
+                    StatusCode::OK,
+                    Json(serde_json::json!({"index_id": id, "root_path": "/Users/masa/kb"})),
+                )
+            }),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let feed = HttpIndexFeed::new(format!("http://{addr}/")).unwrap();
+    assert_eq!(
+        feed.index_root("kb").await.unwrap(),
+        Some(std::path::PathBuf::from("/Users/masa/kb")),
+        "the preflight must read root_path off the status route"
+    );
+    feed.index_file("kb", "/tmp/a.md", "hello").await.unwrap();
+    feed.remove_file("kb", "/tmp/a.md").await.unwrap();
+    assert_eq!(
+        *seen.lock().unwrap(),
+        vec!["index kb /tmp/a.md hello", "remove kb /tmp/a.md"]
+    );
+
+    // A 404 (unregistered index) must surface as an error, not a silent success.
+    let err = feed
+        .remove_file("ghost", "/tmp/a.md")
+        .await
+        .expect_err("an unknown index must fail loudly");
+    assert!(err.to_string().contains("404"), "error was: {err}");
+}

--- a/crates/trusty-agents/src/stores/mod.rs
+++ b/crates/trusty-agents/src/stores/mod.rs
@@ -15,6 +15,12 @@
 //!   array-of-tables, or the spec's `[stores] allow = [...]` shorthand).
 //!   Pure serde data, per the standing "agents are declarative-only" rule
 //!   (#2791).
+//! - `binding` — resolving `okg://<agent>` to a real directory, and a KB tree
+//!   back to the index it feeds (#3892). Until this landed the `okg://` URI was
+//!   an opaque label nothing ever resolved.
+//! - `index_feed` — pushing OKG ingest output into the bound trusty-search
+//!   index, so the binding's "one store, two facets" semantics are true rather
+//!   than aspirational (#3892 remediation (a)).
 //! - `status` — live resolution of a binding against the running
 //!   trusty-search / trusty-memory daemons, producing a per-store
 //!   connected/not-connected report. Every failure mode degrades to
@@ -22,8 +28,12 @@
 //!   cannot be resolved NEVER blocks agent boot.
 //! Test: See each submodule's own unit tests.
 
+pub mod binding;
 pub mod config;
+pub mod index_feed;
 pub mod status;
 
+pub use binding::{BoundIndex, bound_index_for_tree, okg_tree_path};
 pub use config::{AgentStoreBinding, StoresConfig};
+pub use index_feed::{HttpIndexFeed, IndexFeed, IndexFeedReport, feed_source};
 pub use status::{StoreStatus, resolve_store_statuses};

--- a/crates/trusty-agents/src/stores/status.rs
+++ b/crates/trusty-agents/src/stores/status.rs
@@ -75,6 +75,23 @@ pub struct StoreStatus {
     pub palace_connected: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub palace_reason: Option<String>,
+    /// The `okg://` tree resolved to a real directory (#3892). `None` when the
+    /// URI does not resolve — the state that made the two facets independent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tree_path: Option<String>,
+    /// Entities this store has INGESTED but not yet made SEARCHABLE (#3892).
+    ///
+    /// Why: `connected` says the index exists; it says nothing about whether the
+    /// tree's content is in it. A store can be connected, non-empty, and still
+    /// be missing everything the last ingest wrote — the failure this field
+    /// exists to make visible. `None` when the tree has no OKG source registry
+    /// (a hand-built tree), which is not the same as zero.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pending_index: Option<usize>,
+    /// Entities recorded as current in the index. Same nullability as
+    /// `pending_index`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub synced_index: Option<usize>,
 }
 
 impl StoreStatus {
@@ -96,7 +113,53 @@ impl StoreStatus {
             index_status: None,
             palace_connected: None,
             palace_reason: None,
+            tree_path: None,
+            pending_index: None,
+            synced_index: None,
         }
+    }
+}
+
+/// The knowledge directory holding one KB tree per assistant.
+///
+/// Mirrors `trusty-kb`'s own default (and `tools::okg::knowledge_dir`) so every
+/// surface addresses the same trees: `$KB_KNOWLEDGE_DIR`, else
+/// `<home>/.trusty-agents/knowledge`.
+fn knowledge_dir() -> std::path::PathBuf {
+    if let Some(dir) = std::env::var_os("KB_KNOWLEDGE_DIR") {
+        return std::path::PathBuf::from(dir);
+    }
+    std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|| std::path::PathBuf::from("."))
+        .join(".trusty-agents")
+        .join("knowledge")
+}
+
+/// Fill in the tree-side half of a store's status (#3892).
+///
+/// Why: the probe above answers "does the index exist?"; this answers "and does
+/// it hold what the tree holds?". Both halves are needed before a card can
+/// honestly say a store is working.
+/// What: resolves the `okg://` tree to a directory and, when that directory has
+/// an OKG source registry, folds its index coverage. Local filesystem work only
+/// — one `stat` per settled entity — and every failure leaves the fields `None`
+/// rather than degrading the connection verdict.
+/// Test: `reports_the_unsearchable_backlog_for_a_bound_tree`.
+fn attach_tree_coverage(status: &mut StoreStatus) {
+    let Some(tree_path) = super::binding::okg_tree_path(&knowledge_dir(), &status.tree) else {
+        return;
+    };
+    status.tree_path = Some(tree_path.display().to_string());
+    if !tree_path.is_dir() {
+        return;
+    }
+    let store =
+        trusty_kb::store::KbStore::new(tree_path, trusty_kb::schema::Profile::default_profile());
+    if let Ok(coverage) = store.okg_index_coverage() {
+        status.pending_index = Some(coverage.pending);
+        status.synced_index = Some(coverage.synced);
     }
 }
 
@@ -223,6 +286,9 @@ async fn resolve_one(
                     .map(str::to_string),
                 palace_connected: None,
                 palace_reason: None,
+                tree_path: None,
+                pending_index: None,
+                synced_index: None,
             },
         },
     };
@@ -232,6 +298,7 @@ async fn resolve_one(
         status.palace_connected = Some(ok);
         status.palace_reason = reason;
     }
+    attach_tree_coverage(&mut status);
 
     status
 }
@@ -425,6 +492,107 @@ palace = "owner-profile"
         let out = resolve_store_statuses("izzie", &stores, Some("http://127.0.0.1:1"), None).await;
         assert!(!out[0].connected);
         assert!(out[0].reason.as_deref().unwrap().contains("okg://"));
+    }
+
+    /// Why (#3892): "connected" only ever meant "the index exists". A store can
+    /// be connected, hold 200,090 chunks, and contain NOTHING the agent
+    /// ingested — the exact state the issue documents. The card must therefore
+    /// carry the tree side too: where `okg://` actually resolves, and how much
+    /// of that tree is not yet searchable.
+    /// What: sandboxes `KB_KNOWLEDGE_DIR`, builds a real ingested-but-unfed KB
+    /// tree at the bound `okg://` path, and asserts the resolved status reports
+    /// the tree path and the pending backlog alongside `connected`.
+    /// Test: self-contained.
+    /// Sandbox `KB_KNOWLEDGE_DIR` for one test, restoring it on drop.
+    ///
+    /// Why: the guard has to survive `.await` points (the probes are async), and
+    /// a bare `MutexGuard` held across an await is both a clippy error and a
+    /// genuine deadlock hazard. Owning the guard inside a struct — the same
+    /// shape as `tools::okg::tests::KnowledgeDirGuard` — keeps the critical
+    /// section scoped to the test body without hand-written restore paths.
+    struct KnowledgeDirGuard {
+        _lock: std::sync::MutexGuard<'static, ()>,
+        prior: Option<std::ffi::OsString>,
+        dir: tempfile::TempDir,
+    }
+
+    impl KnowledgeDirGuard {
+        fn new() -> Self {
+            let lock = crate::test_env::HOME_LOCK
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+            let dir = tempfile::tempdir().unwrap();
+            let prior = std::env::var_os("KB_KNOWLEDGE_DIR");
+            // SAFETY: guarded by HOME_LOCK; restored in Drop.
+            unsafe { std::env::set_var("KB_KNOWLEDGE_DIR", dir.path()) };
+            Self {
+                _lock: lock,
+                prior,
+                dir,
+            }
+        }
+    }
+
+    impl Drop for KnowledgeDirGuard {
+        fn drop(&mut self) {
+            // SAFETY: still holding HOME_LOCK for this guard's lifetime.
+            unsafe {
+                match &self.prior {
+                    Some(v) => std::env::set_var("KB_KNOWLEDGE_DIR", v),
+                    None => std::env::remove_var("KB_KNOWLEDGE_DIR"),
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn reports_the_unsearchable_backlog_for_a_bound_tree() {
+        let guard = KnowledgeDirGuard::new();
+        let tmp = guard.dir.path();
+
+        // A tree at okg://izzie with one ingested, never-indexed entity.
+        let corpus = tmp.join("corpus");
+        std::fs::create_dir_all(&corpus).unwrap();
+        std::fs::write(corpus.join("one.md"), "a note").unwrap();
+        let store = trusty_kb::store::KbStore::new(
+            tmp.join("izzie"),
+            trusty_kb::schema::Profile::default_profile(),
+        );
+        store
+            .okg_register_source(trusty_kb::okg::registry::SourceSpec::new(
+                "corpus",
+                Some("notes"),
+                trusty_kb::okg::registry::Locator::DocStore {
+                    path: corpus.to_string_lossy().to_string(),
+                    extensions: vec![],
+                    recursive: true,
+                },
+                "t0",
+            ))
+            .unwrap();
+        store
+            .okg_ingest_docstore(
+                "corpus",
+                &trusty_kb::okg::policy::DocStorePolicy::new(vec![tmp.canonicalize().unwrap()]),
+                "t0",
+            )
+            .unwrap();
+
+        let base = mock_daemon().await;
+        let stores = stores_toml("[[stores]]\nname = \"bob-kb\"\ntree = \"okg://izzie\"\n");
+        let out = resolve_store_statuses("izzie", &stores, Some(&base), None).await;
+
+        assert!(out[0].connected, "reason: {:?}", out[0].reason);
+        assert_eq!(
+            out[0].tree_path.as_deref(),
+            Some(tmp.join("izzie").display().to_string().as_str()),
+            "the okg:// URI must resolve to a real directory"
+        );
+        assert_eq!(
+            (out[0].pending_index, out[0].synced_index),
+            (Some(1), Some(0)),
+            "connected, and still holding nothing the tree holds"
+        );
     }
 
     #[tokio::test]

--- a/crates/trusty-agents/src/tools/okg/docstore.rs
+++ b/crates/trusty-agents/src/tools/okg/docstore.rs
@@ -63,7 +63,7 @@ impl ToolExecutor for OkgIngestDocstoreTool {
     }
 
     async fn execute(&self, args: Value) -> ToolResult {
-        match run(&args) {
+        match run(&args).await {
             Ok(result) => result,
             Err(e) => ToolResult::err(format!("okg_ingest_docstore failed: {e}")),
         }
@@ -71,7 +71,7 @@ impl ToolExecutor for OkgIngestDocstoreTool {
 }
 
 /// The fallible body — any `Err` becomes an error result.
-fn run(args: &Value) -> anyhow::Result<ToolResult> {
+async fn run(args: &Value) -> anyhow::Result<ToolResult> {
     let store = resolve_store(args)?;
     let source_id = require_str(args, "source_id")?;
     let now = now_iso();
@@ -141,9 +141,20 @@ fn run(args: &Value) -> anyhow::Result<ToolResult> {
     spec.tombstone_deleted = tombstone;
     let registered = store.okg_register_source(spec)?;
     let report = store.okg_ingest_docstore(&registered.id, &policy, &now)?;
+    // Then make it findable. The tree write above is the durable record; this
+    // step is fail-open but never silent — see `tools::okg::index_feed`.
+    let spec = store.okg_source(&registered.id)?;
+    let index = crate::tools::okg::index_feed::feed_bound_index(
+        &store,
+        &spec,
+        arg_str(args, "agent"),
+        &now,
+    )
+    .await;
 
     Ok(ok_json(&json!({
         "source": registered,
         "ingest": report,
+        "index": index,
     })))
 }

--- a/crates/trusty-agents/src/tools/okg/drive.rs
+++ b/crates/trusty-agents/src/tools/okg/drive.rs
@@ -227,8 +227,18 @@ async fn run(args: &Value) -> anyhow::Result<ToolResult> {
     report.skipped += skipped_unchanged;
     report.scanned = files.len();
 
+    // Make the downloaded files findable — fail-open, never silent (#3892).
+    let index = crate::tools::okg::index_feed::feed_bound_index(
+        &store,
+        &spec,
+        arg_str(args, "agent"),
+        &now,
+    )
+    .await;
+
     Ok(ok_json(&json!({
         "source": registered,
+        "index": index,
         "folder_id": folder_id,
         "listed": files.len(),
         "downloaded": needs_fetch.len(),

--- a/crates/trusty-agents/src/tools/okg/gmail.rs
+++ b/crates/trusty-agents/src/tools/okg/gmail.rs
@@ -213,8 +213,18 @@ async fn run(args: &Value) -> anyhow::Result<ToolResult> {
     report.skipped += ids.len() - unseen.len();
     report.scanned = ids.len();
 
+    // Make the pulled messages findable — fail-open, never silent (#3892).
+    let index = crate::tools::okg::index_feed::feed_bound_index(
+        &store,
+        &spec,
+        arg_str(args, "agent"),
+        &now,
+    )
+    .await;
+
     Ok(ok_json(&json!({
         "source": registered,
+        "index": index,
         "query": effective_query,
         "listed": ids.len(),
         "fetched": fetched,

--- a/crates/trusty-agents/src/tools/okg/index_feed.rs
+++ b/crates/trusty-agents/src/tools/okg/index_feed.rs
@@ -1,0 +1,89 @@
+//! The ingest→index step shared by every `okg_ingest_*` tool (#3892).
+//!
+//! Why: an ingest that writes the tree and stops there is the bug — the entities
+//! are real, the report is truthful, and `vector_search` still returns nothing.
+//! Every ingest tool therefore ends with the same three questions: which index
+//! does this tree feed, is the search daemon reachable, and how much is still
+//! not searchable? Answering them in one place means a future connector inherits
+//! the behaviour with no per-connector work (DOC-55 SPEC-OKGIMPORT-06 §7.2.3).
+//!
+//! What: [`feed_bound_index`] resolves the agent's `[[stores]]` binding for the
+//! tree that was just written, drains that source's index backlog through the
+//! live trusty-search feed, and returns the JSON block the tool embeds as
+//! `"index"`. It NEVER fails the ingest: a missing binding, an undiscoverable
+//! daemon, and a failed push all degrade to a report carrying `pending` plus a
+//! `reason`, because the tree write is the durable record and a later run
+//! reconciles the backlog.
+//!
+//! Test: `super::tests::docstore_tool_reports_the_index_backlog`,
+//! `docstore_tool_feeds_the_bound_index`.
+
+use serde_json::{Value, json};
+use trusty_kb::okg::registry::SourceSpec;
+use trusty_kb::store::KbStore;
+
+use crate::stores::index_feed::{HttpIndexFeed, IndexFeed, IndexFeedReport, feed_source};
+
+/// Feed everything this source owes the agent's bound search index.
+///
+/// Why/What/Test: see the module doc. `agent` is the tool's own `agent`
+/// argument — the hint that avoids searching the roster; when it is absent the
+/// binding is resolved by finding the single agent that claims this tree.
+pub(super) async fn feed_bound_index(
+    store: &KbStore,
+    spec: &SourceSpec,
+    agent: Option<&str>,
+    now: &str,
+) -> Value {
+    let report = match resolve_feed(store, agent) {
+        Ok((index, feed)) => match feed_source(store, spec, &index, feed.as_ref(), now).await {
+            Ok(report) => report,
+            // A reconcile that cannot even read its own journal is worth
+            // reporting, but it is still not an ingest failure.
+            Err(e) => IndexFeedReport::not_fed(format!("index reconcile failed: {e}"), 0, 0),
+        },
+        Err(reason) => {
+            let (pending, synced) = backlog_counts(store, spec);
+            IndexFeedReport::not_fed(reason, pending, synced)
+        }
+    };
+    serde_json::to_value(&report).unwrap_or_else(|e| json!({ "error": e.to_string() }))
+}
+
+/// Resolve the bound index id and a live feed for it.
+///
+/// Every failure is a REASON string, never an error the caller propagates —
+/// "this tree has no bound index" and "the search daemon is down" are normal,
+/// reportable states.
+fn resolve_feed(
+    store: &KbStore,
+    agent: Option<&str>,
+) -> Result<(String, Box<dyn IndexFeed>), String> {
+    let bound = crate::stores::bound_index_for_tree(
+        &crate::agents::agents_dir_candidates(),
+        &super::knowledge_dir(),
+        &store.root,
+        agent,
+    )?;
+    let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
+        return Err(format!(
+            "trusty-search daemon not discoverable (no address file; is it running?) — \
+             `{}` is bound but nothing was pushed",
+            bound.index
+        ));
+    };
+    let feed = HttpIndexFeed::new(base).map_err(|e| format!("HTTP client unavailable: {e}"))?;
+    Ok((bound.index, Box::new(feed)))
+}
+
+/// `(pending, synced)` for a source whose feed could not run.
+///
+/// Why: reporting "not fed" without the size of the backlog tells the caller
+/// nothing actionable. A reconcile failure here degrades to zeroes rather than
+/// masking the real reason with a second one.
+fn backlog_counts(store: &KbStore, spec: &SourceSpec) -> (usize, usize) {
+    match store.okg_index_backlog(spec) {
+        Ok(b) => (b.tasks.len() + b.notes.len(), b.synced),
+        Err(_) => (0, 0),
+    }
+}

--- a/crates/trusty-agents/src/tools/okg/index_feed.rs
+++ b/crates/trusty-agents/src/tools/okg/index_feed.rs
@@ -15,8 +15,9 @@
 //! `reason`, because the tree write is the durable record and a later run
 //! reconciles the backlog.
 //!
-//! Test: `super::tests::docstore_tool_reports_the_index_backlog`,
-//! `docstore_tool_feeds_the_bound_index`.
+//! Test: `super::tests::docstore_tool_reports_the_unsearchable_backlog`,
+//! `super::tests::bound_store_reports_pending_when_the_daemon_is_down`,
+//! `super::tests::sources_tool_reports_the_unsearchable_backlog`.
 
 use serde_json::{Value, json};
 use trusty_kb::okg::registry::SourceSpec;

--- a/crates/trusty-agents/src/tools/okg/mod.rs
+++ b/crates/trusty-agents/src/tools/okg/mod.rs
@@ -10,8 +10,11 @@
 //! ingested items into people/organizations/events entities.
 //!
 //! What: `okg_ingest_docstore`, `okg_ingest_gmail`, `okg_ingest_drive` each
-//! register-or-update their source and then ingest it; `okg_sources` reports
-//! every source with its live coverage. Registration is folded into ingestion
+//! register-or-update their source, ingest it, and then feed what they wrote
+//! into the agent's bound trusty-search index ([`index_feed`], #3892) so the
+//! `[[stores]]` binding's "one store, tree and index" semantics are true rather
+//! than aspirational; `okg_sources` reports every source with its live coverage,
+//! tree AND index. Registration is folded into ingestion
 //! on purpose — "point at this directory" and "reach further back in time" are
 //! the same call, so widening a window can never desync from the ledger.
 //! Gmail/Drive fetching goes through `trusty-gworkspace`'s authenticated client
@@ -25,6 +28,7 @@ pub mod docstore;
 pub mod drive;
 pub mod gapi;
 pub mod gmail;
+mod index_feed;
 pub mod sources;
 
 use std::path::PathBuf;

--- a/crates/trusty-agents/src/tools/okg/sources.rs
+++ b/crates/trusty-agents/src/tools/okg/sources.rs
@@ -3,11 +3,17 @@
 //! Why: before widening a window or adding a store, the operator (and the
 //! assistant) needs to see what is already covered. Coverage is DERIVED from
 //! each source's ledger rather than stored as a separate counter, so it can
-//! never claim more than was actually ingested.
+//! never claim more than was actually ingested. It reports TWO coverages, not
+//! one (#3892): what is in the tree, and what of that is actually searchable —
+//! conflating them is exactly how an ingest could report "N entities ingested"
+//! while `vector_search` found nothing.
 //! What: lists every registered source with its kind, locator, destination
-//! collection, and watermark (item count, tombstones, oldest/newest item
-//! timestamp, last run). Read-only — it never registers or mutates anything.
-//! Test: `super::tests::sources_tool_reports_registered_sources`.
+//! collection, watermark (item count, tombstones, oldest/newest item timestamp,
+//! last run) and index coverage (synced / pending), plus the tree's bound search
+//! index. Read-only, and offline-safe: the index coverage is derived from local
+//! journals, never from a daemon call. It never registers or mutates anything.
+//! Test: `super::tests::sources_tool_reports_registered_sources`,
+//! `super::tests::sources_tool_reports_the_unsearchable_backlog`.
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
@@ -42,7 +48,7 @@ impl ToolExecutor for OkgSourcesTool {
             "type": "function",
             "function": {
                 "name": "okg_sources",
-                "description": "List the sources feeding the assistant's knowledge graph, with per-source status: kind, locator, destination collection, how many items are ingested, how many are tombstoned, the oldest and newest item covered, and when it last ran. Read-only.",
+                "description": "List the sources feeding the assistant's knowledge graph, with per-source status: kind, locator, destination collection, how many items are ingested, how many are tombstoned, the oldest and newest item covered, when it last ran, and how many of its entities have actually reached the bound search index (index.synced) versus are ingested but NOT yet searchable (index.pending). Also reports which search index this tree feeds. Read-only.",
                 "parameters": {
                     "type": "object",
                     "properties": with_root(json!({})),
@@ -64,9 +70,25 @@ impl ToolExecutor for OkgSourcesTool {
 fn run(args: &Value) -> anyhow::Result<ToolResult> {
     let store = resolve_store(args)?;
     let sources = store.okg_sources()?;
+    let pending: usize = sources.iter().map(|s| s.index.pending).sum();
+    // Resolution is pure config + path work (no daemon call), so naming the
+    // bound index — or saying why there is none — costs this read nothing.
+    let bound = crate::stores::bound_index_for_tree(
+        &crate::agents::agents_dir_candidates(),
+        &crate::tools::okg::knowledge_dir(),
+        &store.root,
+        crate::tools::okg::arg_str(args, "agent"),
+    );
+    let index = match &bound {
+        Ok(b) => {
+            json!({ "index": b.index, "store": b.store, "agent": b.agent, "pending": pending })
+        }
+        Err(reason) => json!({ "index": Value::Null, "reason": reason, "pending": pending }),
+    };
     Ok(ok_json(&json!({
         "root": store.root.to_string_lossy(),
         "count": sources.len(),
+        "bound_index": index,
         "sources": sources,
     })))
 }

--- a/crates/trusty-agents/src/tools/okg/tests.rs
+++ b/crates/trusty-agents/src/tools/okg/tests.rs
@@ -15,18 +15,23 @@ use serde_json::{Value, json};
 use super::*;
 use crate::test_env::HOME_LOCK;
 
-/// Sandbox both the KB knowledge dir and `$HOME` into one tempdir.
+/// Sandbox the KB knowledge dir, `$HOME`, and daemon discovery into one
+/// tempdir.
 ///
 /// `$HOME` matters as much as `KB_KNOWLEDGE_DIR` here: it is what the
 /// doc-store read policy defaults to, so without sandboxing it a test corpus in
 /// a tempdir would be (correctly) refused, and a misconfigured test could reach
-/// the developer's real home. Both are process-global mutations, so every test
-/// holds `HOME_LOCK` (the crate's existing serializing mutex) and restores the
-/// prior values on drop.
+/// the developer's real home. `TRUSTY_DATA_DIR_OVERRIDE` sandboxes the third
+/// thing an ingest now touches (#3892): the trusty-search address file. Without
+/// it a test run on a developer machine would DISCOVER the live daemon and push
+/// test fixtures into a real index. Every one of these is a process-global
+/// mutation, so every test holds `HOME_LOCK` (the crate's existing serializing
+/// mutex) and restores the prior values on drop.
 struct KnowledgeDirGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     prior_knowledge: Option<std::ffi::OsString>,
     prior_home: Option<std::ffi::OsString>,
+    prior_data_dir: Option<std::ffi::OsString>,
     dir: tempfile::TempDir,
 }
 
@@ -36,18 +41,36 @@ impl KnowledgeDirGuard {
         let dir = tempfile::tempdir().expect("tempdir");
         let prior_knowledge = std::env::var_os("KB_KNOWLEDGE_DIR");
         let prior_home = std::env::var_os("HOME");
+        let prior_data_dir = std::env::var_os("TRUSTY_DATA_DIR_OVERRIDE");
         // SAFETY: guarded by HOME_LOCK — no other test mutates the env
         // concurrently, and the prior values are restored in Drop.
         unsafe {
             std::env::set_var("KB_KNOWLEDGE_DIR", dir.path());
             std::env::set_var("HOME", dir.path());
+            std::env::set_var("TRUSTY_DATA_DIR_OVERRIDE", dir.path());
         }
         Self {
             _lock: lock,
             prior_knowledge,
             prior_home,
+            prior_data_dir,
             dir,
         }
+    }
+
+    /// Write an agent that binds `index` to this tree, in the sandboxed
+    /// `$HOME/.trusty-agents/agents` tier `agents_dir_candidates()` searches.
+    fn bind_agent(&self, agent: &str, index: &str) {
+        let pkg = self.dir.path().join(".trusty-agents/agents").join(agent);
+        std::fs::create_dir_all(&pkg).unwrap();
+        std::fs::write(
+            pkg.join("agent.toml"),
+            format!(
+                "[agent]\nname = \"{agent}\"\n\n[[stores]]\nname = \"{agent}-kb\"\n\
+                 tree = \"okg://{agent}\"\nindex = \"{index}\"\n"
+            ),
+        )
+        .unwrap();
     }
 
     /// The tree root under the temp knowledge dir.
@@ -67,6 +90,10 @@ impl Drop for KnowledgeDirGuard {
             match &self.prior_home {
                 Some(v) => std::env::set_var("HOME", v),
                 None => std::env::remove_var("HOME"),
+            }
+            match &self.prior_data_dir {
+                Some(v) => std::env::set_var("TRUSTY_DATA_DIR_OVERRIDE", v),
+                None => std::env::remove_var("TRUSTY_DATA_DIR_OVERRIDE"),
             }
         }
     }
@@ -282,6 +309,119 @@ async fn sources_tool_reports_registered_sources() {
     );
     assert!(source["watermark"]["oldest"].is_null());
     assert!(source["watermark"]["last_ingest_at"].is_null());
+}
+
+// ─────────────────────── ingest → search index (#3892) ───────────────────────
+
+/// Why (#3892): the whole bug was an ingest reporting success while nothing
+/// became searchable. When no index can be resolved the tool must still say so
+/// — with a REASON and the size of the unsearchable backlog — instead of
+/// returning a report that reads like everything worked.
+/// What: ingests into a tree no agent binds and asserts the `index` block names
+/// the pending count and the reason, while the ingest itself still succeeded.
+/// Test: self-contained (no daemon; discovery is sandboxed by the guard).
+#[tokio::test]
+async fn docstore_tool_reports_the_unsearchable_backlog() {
+    let guard = KnowledgeDirGuard::new();
+    let corpus = guard.dir.path().join("corpus-unbound");
+    std::fs::create_dir_all(&corpus).unwrap();
+    std::fs::write(corpus.join("note.md"), "an unbound note").unwrap();
+
+    let out = payload(
+        &OkgIngestDocstoreTool::new()
+            .execute(json!({
+                "root": guard.root().to_string_lossy(),
+                "source_id": "unbound",
+                "path": corpus.to_string_lossy(),
+                "collection": "notes",
+            }))
+            .await,
+    );
+    assert_eq!(out["ingest"]["ingested"], 1, "the tree write still happens");
+    assert_eq!(
+        out["index"]["pending"], 1,
+        "and the entity is reported as NOT searchable: {out}"
+    );
+    assert_eq!(out["index"]["indexed"], 0);
+    assert!(out["index"]["index"].is_null());
+    let reason = out["index"]["reason"].as_str().unwrap_or_default();
+    assert!(
+        reason.contains("no agent binds"),
+        "the reason must be actionable: {reason}"
+    );
+}
+
+/// Why: the second half of the honesty contract — a store that IS bound but
+/// whose daemon is unreachable must not lose the work and must not claim it
+/// landed. The tree write is durable; the backlog is what a later run drains.
+/// What: binds an agent to the tree, ingests with no discoverable daemon, and
+/// asserts the reason names the daemon while `pending` counts the entities.
+/// Test: self-contained.
+#[tokio::test]
+async fn bound_store_reports_pending_when_the_daemon_is_down() {
+    let guard = KnowledgeDirGuard::new();
+    guard.bind_agent("okg-feed-test", "okg-feed-test-index");
+    let corpus = guard.dir.path().join("corpus-bound");
+    std::fs::create_dir_all(&corpus).unwrap();
+    std::fs::write(corpus.join("one.md"), "a bound note").unwrap();
+    std::fs::write(corpus.join("two.md"), "another bound note").unwrap();
+
+    let out = payload(
+        &OkgIngestDocstoreTool::new()
+            .execute(json!({
+                "agent": "okg-feed-test",
+                "source_id": "bound",
+                "path": corpus.to_string_lossy(),
+                "collection": "notes",
+            }))
+            .await,
+    );
+    assert_eq!(out["ingest"]["ingested"], 2);
+    assert_eq!(out["index"]["pending"], 2, "{out}");
+    let reason = out["index"]["reason"].as_str().unwrap_or_default();
+    assert!(
+        reason.contains("not discoverable") && reason.contains("okg-feed-test-index"),
+        "the reason must name the daemon AND the bound index: {reason}"
+    );
+}
+
+/// Why: `okg_sources` is where an operator looks BEFORE re-running an ingest, so
+/// "ingested but not searchable" has to be visible there rather than only in the
+/// ingest that happened to produce it.
+/// What: ingests into a bound tree with no daemon, then asserts the status view
+/// reports the per-source index coverage and names the bound index.
+/// Test: self-contained.
+#[tokio::test]
+async fn sources_tool_reports_the_unsearchable_backlog() {
+    let guard = KnowledgeDirGuard::new();
+    guard.bind_agent("okg-status-test", "okg-status-index");
+    let corpus = guard.dir.path().join("corpus-status");
+    std::fs::create_dir_all(&corpus).unwrap();
+    std::fs::write(corpus.join("one.md"), "a note").unwrap();
+
+    OkgIngestDocstoreTool::new()
+        .execute(json!({
+            "agent": "okg-status-test",
+            "source_id": "status",
+            "path": corpus.to_string_lossy(),
+            "collection": "notes",
+        }))
+        .await;
+
+    let listed = payload(
+        &OkgSourcesTool::new()
+            .execute(json!({ "agent": "okg-status-test" }))
+            .await,
+    );
+    assert_eq!(
+        listed["bound_index"]["index"], "okg-status-index",
+        "{listed}"
+    );
+    assert_eq!(listed["bound_index"]["pending"], 1);
+    let source = &listed["sources"][0];
+    assert_eq!(source["watermark"]["items"], 1, "in the tree");
+    assert_eq!(source["index"]["synced"], 0, "but not in the index");
+    assert_eq!(source["index"]["pending"], 1);
 }
 
 // ───────────────────── doc-store read confinement ─────────────────────

--- a/crates/trusty-kb/CHANGELOG.md
+++ b/crates/trusty-kb/CHANGELOG.md
@@ -8,6 +8,26 @@ independent semantic versioning per the workspace convention.
 
 ### Added
 
+- **OKG index journal + reconcile (`okg::index_journal`, #3892):** a second
+  append-only journal per source, `_sources/<id>.index.jsonl`, recording which
+  entities reached the store's bound trusty-search index and at what content
+  hash, plus `KbStore::okg_index_backlog` — the pure diff of that journal
+  against the item ledger. This is what makes "ingested" and "searchable" two
+  separately reportable facts instead of one silently-conflated claim. The item
+  ledger is deliberately NOT overloaded with index state: an index push failure
+  must not make ingestion non-convergent when the search daemon is merely down,
+  and an entity the ledger skips as unchanged must still be re-pushed if it
+  never landed. Staleness is decided by the entity file's content hash (a
+  `volatile` item's fingerprint carries no information), short-circuited by a
+  `(size, mtime)` check so a settled tree costs one `stat` per entity. The push
+  itself lives in `trusty-agents` — this crate stays deterministic and
+  network-free.
+- **`okg_sources` reports search coverage:** each row carries `index.synced` /
+  `index.pending` alongside its watermark, and `KbStore::okg_index_coverage`
+  folds the same numbers tree-wide. "Ingested but not yet searchable" is now a
+  visible state rather than an invisible one.
+
+
 - **OKG builder engine (`okg` module):** the machinery that GROWS a KB tree from
   real sources, idempotently and additively. Three durable guarantees, all
   unit-proved:

--- a/crates/trusty-kb/CHANGELOG.md
+++ b/crates/trusty-kb/CHANGELOG.md
@@ -26,8 +26,6 @@ independent semantic versioning per the workspace convention.
   `index.pending` alongside its watermark, and `KbStore::okg_index_coverage`
   folds the same numbers tree-wide. "Ingested but not yet searchable" is now a
   visible state rather than an invisible one.
-
-
 - **OKG builder engine (`okg` module):** the machinery that GROWS a KB tree from
   real sources, idempotently and additively. Three durable guarantees, all
   unit-proved:

--- a/crates/trusty-kb/src/okg/index_journal.rs
+++ b/crates/trusty-kb/src/okg/index_journal.rs
@@ -1,0 +1,356 @@
+//! Per-source index journal — what the BOUND SEARCH INDEX actually holds.
+//!
+//! Why (#3892): an OKG store is one thing with two facets — a markdown tree and
+//! a trusty-search index over it — but until now only the tree was ever
+//! written. An ingest reported "N entities ingested" truthfully while
+//! `vector_search` found nothing, because nothing ever pushed those entities
+//! into the bound index. Feeding the index needs a durable answer to "which
+//! entities, at which content, are already in the index?", and that answer must
+//! NOT be folded into the item [`Ledger`]: the ledger is the record of KB-TREE
+//! truth, and making a ledger line conditional on a network push would make
+//! ingestion non-convergent whenever the search daemon is merely down
+//! (DOC-55 SPEC-OKGIMPORT-06 §7.2.4). So index state lives in its own
+//! append-only journal beside the ledger, and the two never gate each other.
+//!
+//! What: `_sources/<slug(id)>.index.jsonl`, one [`IndexRecord`] per push, last
+//! record per entity wins. Each record pins the entity file's content hash plus
+//! a cheap `(size, mtime)` stamp, which is what makes reconciliation both
+//! correct and affordable: an unchanged entity is dismissed by a `stat`, a
+//! changed one is caught by the hash even when its ledger fingerprint cannot
+//! change (a `volatile` source item). [`KbStore::okg_index_backlog`] diffs the
+//! ledger against this journal to produce the work list — everything ingested
+//! but not yet searchable, plus everything tombstoned but not yet withdrawn.
+//!
+//! The push itself is NOT here. This crate is deterministic and network-free;
+//! the HTTP call into trusty-search lives in `trusty-agents`
+//! (`crate::stores::index_feed`), exactly like the Gmail/Drive fetchers. This
+//! module is the part that must be unit-testable without a daemon.
+//!
+//! Test: `backlog_lists_freshly_ingested_entities`,
+//! `recorded_entity_leaves_the_backlog`, `changed_entity_reenters_the_backlog`,
+//! `tombstoned_entity_becomes_a_remove_task`,
+//! `never_indexed_tombstone_needs_no_removal`,
+//! `torn_index_journal_line_is_skipped_not_fatal`.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+use crate::entity::slugify;
+use crate::okg::jsonl::{Appender, read_journal};
+use crate::okg::ledger::{ItemStatus, Ledger};
+use crate::okg::registry::{SOURCES_DIR, SourceSpec};
+use crate::roots::{assert_within, confine};
+use crate::store::KbStore;
+
+/// What a journal line asserts about an entity's presence in the index.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexState {
+    /// The entity's content was pushed into the bound index.
+    Indexed,
+    /// The entity was withdrawn from the bound index (its source item was
+    /// tombstoned). The markdown file itself is preserved — a tombstone is a
+    /// flag, never a deletion.
+    Removed,
+}
+
+/// One journal line: the durable record of a single index push.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexRecord {
+    /// `<collection>/<slug>` — the same identity the ledger records.
+    pub entity: String,
+    /// SHA-256 of the entity file's bytes AS PUSHED. This, not the source
+    /// item's fingerprint, is what decides staleness: a `volatile` item's
+    /// fingerprint is constant by definition, so trusting it would freeze stale
+    /// content in the index forever.
+    pub content_hash: String,
+    /// Entity file size at push time — the cheap half of the staleness check.
+    #[serde(default)]
+    pub size: u64,
+    /// Entity file mtime (nanos since epoch) at push time, when the filesystem
+    /// reported one. A mismatch only triggers a re-hash, never a blind re-push,
+    /// so a lying mtime costs work and never correctness.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mtime_ns: Option<u128>,
+    /// Indexed or removed.
+    pub state: IndexState,
+    /// When this record was written (ISO-8601).
+    pub at: String,
+}
+
+/// Whether an entity needs pushing, withdrawing, or nothing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexOp {
+    /// Push the file's current content into the index. `replace` is true when
+    /// the index already holds an older version of this entity, which the
+    /// caller must withdraw first — trusty-search chunks by content, so a
+    /// shorter revision would otherwise leave the old chunks orphaned and
+    /// searchable.
+    Index { replace: bool },
+    /// Withdraw the entity from the index.
+    Remove,
+}
+
+/// One unit of index work, resolved to a concrete file.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct IndexTask {
+    /// The source item that produced this entity.
+    pub item_id: String,
+    /// `<collection>/<slug>`.
+    pub entity: String,
+    /// Absolute path of the entity file — the identity the search index keys
+    /// on, so `remove_file` can later withdraw exactly what was pushed.
+    pub path: PathBuf,
+    /// Content hash to record once the push succeeds.
+    pub content_hash: String,
+    /// File size to record once the push succeeds.
+    pub size: u64,
+    /// File mtime to record once the push succeeds.
+    pub mtime_ns: Option<u128>,
+    /// What to do.
+    pub op: IndexOp,
+}
+
+/// The diff between the tree (per the ledger) and the index (per the journal).
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct IndexBacklog {
+    /// Work still owed to the index, in ledger order.
+    pub tasks: Vec<IndexTask>,
+    /// Entities the journal says are already current in the index.
+    pub synced: usize,
+    /// Ledger rows that could not be resolved to a readable file (e.g. an
+    /// entity deleted out from under the tree). Surfaced, never silently
+    /// dropped.
+    pub notes: Vec<String>,
+}
+
+/// An open, append-only index journal for one source.
+pub struct IndexJournal {
+    /// Last record per entity — the effective state.
+    latest: BTreeMap<String, IndexRecord>,
+    /// Count of unparseable lines encountered on load.
+    malformed: usize,
+    /// Durable append handle (heals a crash-torn final line).
+    appender: Appender,
+}
+
+impl IndexJournal {
+    /// The confined journal path for a source id under a KB root.
+    ///
+    /// Why: the id comes from a tool argument; slugging plus [`confine`] means a
+    /// hostile id can never name a file outside `_sources/`.
+    /// What: `<root>/_sources/<slug(id)>.index.jsonl` — a distinct suffix from
+    /// the item ledger so the two can never collide.
+    pub fn path_for(root: &Path, source_id: &str) -> anyhow::Result<PathBuf> {
+        let file = format!("{}.index.jsonl", slugify(source_id));
+        let path = confine(root, &[SOURCES_DIR, &file])?;
+        assert_within(root, &path)?;
+        Ok(path)
+    }
+
+    /// Read a source's index journal into a last-record-wins view.
+    ///
+    /// Why/What/Test: identical damage tolerance to [`Ledger::load`] — see
+    /// [`crate::okg::jsonl::read_journal`].
+    pub fn load(root: &Path, source_id: &str) -> anyhow::Result<Self> {
+        let path = Self::path_for(root, source_id)?;
+        let load = read_journal::<IndexRecord>(&path)?;
+        let mut journal = Self {
+            latest: BTreeMap::new(),
+            malformed: load.malformed,
+            appender: Appender::new(path, load.needs_newline),
+        };
+        for record in load.records {
+            journal.latest.insert(record.entity.clone(), record);
+        }
+        Ok(journal)
+    }
+
+    /// The effective record for an entity, if it was ever pushed.
+    pub fn get(&self, entity: &str) -> Option<&IndexRecord> {
+        self.latest.get(entity)
+    }
+
+    /// Lines that failed to parse on load.
+    pub fn malformed_lines(&self) -> usize {
+        self.malformed
+    }
+
+    /// Durably append one record, updating the in-memory view.
+    ///
+    /// Why: this is called only AFTER the corresponding push succeeded, so the
+    /// journal can never claim more than the index actually holds. A crash
+    /// between a successful push and this append costs one redundant re-push on
+    /// the next run (the push is an upsert), never a lost entity — the exact
+    /// mirror of the ledger's entity-before-record ordering.
+    pub fn append(&mut self, record: IndexRecord) -> anyhow::Result<()> {
+        self.appender.append(&record)?;
+        self.latest.insert(record.entity.clone(), record);
+        Ok(())
+    }
+}
+
+/// A file's staleness stamp: content hash plus the cheap `(size, mtime)` pair.
+struct FileStamp {
+    hash: String,
+    size: u64,
+    mtime_ns: Option<u128>,
+}
+
+/// Stamp an entity file, re-hashing only when the cheap check says it may have
+/// moved.
+///
+/// Why: reconciliation runs on every ingest AND on every status read, so the
+/// steady state — nothing changed — must not cost a full re-hash of the tree.
+/// `size`/`mtime` can only produce a FALSE "changed" (a touched-but-identical
+/// file), which the hash comparison then absorbs; they can never produce a
+/// false "unchanged" that would leave stale content searchable, because any
+/// write moves at least one of the two.
+/// What: returns `None` when the file is unreadable, `Some(stamp)` otherwise.
+/// `prior` short-circuits the hash when both cheap fields match.
+fn stamp_file(path: &Path, prior: Option<&IndexRecord>) -> Option<FileStamp> {
+    let meta = std::fs::metadata(path).ok()?;
+    let size = meta.len();
+    let mtime_ns = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_nanos());
+    if let Some(prior) = prior
+        && prior.size == size
+        && prior.mtime_ns.is_some()
+        && prior.mtime_ns == mtime_ns
+    {
+        return Some(FileStamp {
+            hash: prior.content_hash.clone(),
+            size,
+            mtime_ns,
+        });
+    }
+    let bytes = std::fs::read(path).ok()?;
+    Some(FileStamp {
+        hash: format!("sha256:{:x}", Sha256::digest(&bytes)),
+        size,
+        mtime_ns,
+    })
+}
+
+impl KbStore {
+    /// What this source still owes the bound search index.
+    ///
+    /// Why (#3892): this is the reconcile that makes a failed or skipped push
+    /// self-healing. The ledger decides what is IN THE TREE; this diff decides
+    /// what is IN THE INDEX. Because the two are independent journals, a run
+    /// with the search daemon down loses nothing: the entities land, the
+    /// backlog grows, and the next run drains it — including items whose source
+    /// fingerprint is unchanged and which the ingest engine therefore skipped
+    /// entirely.
+    /// What: for every live ledger item, a push task unless the journal already
+    /// records this exact file content; for every tombstoned item that WAS
+    /// pushed, a withdrawal task. Pure filesystem work — no network.
+    /// Test: `backlog_lists_freshly_ingested_entities`,
+    /// `recorded_entity_leaves_the_backlog`,
+    /// `changed_entity_reenters_the_backlog`,
+    /// `tombstoned_entity_becomes_a_remove_task`,
+    /// `never_indexed_tombstone_needs_no_removal`.
+    pub fn okg_index_backlog(&self, spec: &SourceSpec) -> anyhow::Result<IndexBacklog> {
+        let ledger = Ledger::load(&self.root, &spec.id)?;
+        let journal = IndexJournal::load(&self.root, &spec.id)?;
+        let mut backlog = IndexBacklog::default();
+
+        for record in ledger.records() {
+            let prior = journal.get(&record.entity);
+            let path = self.entity_file_path(spec, &record.entity)?;
+            match record.status {
+                ItemStatus::Ingested => {
+                    let Some(stamp) = stamp_file(&path, prior) else {
+                        backlog.notes.push(format!(
+                            "{}: entity {} is not readable at {}",
+                            record.item_id,
+                            record.entity,
+                            path.display()
+                        ));
+                        continue;
+                    };
+                    let current = prior.is_some_and(|p| {
+                        p.state == IndexState::Indexed && p.content_hash == stamp.hash
+                    });
+                    if current {
+                        backlog.synced += 1;
+                        continue;
+                    }
+                    backlog.tasks.push(IndexTask {
+                        item_id: record.item_id.clone(),
+                        entity: record.entity.clone(),
+                        path,
+                        content_hash: stamp.hash,
+                        size: stamp.size,
+                        mtime_ns: stamp.mtime_ns,
+                        // A prior Indexed record means the index holds an older
+                        // revision that must be withdrawn before the new one
+                        // lands, or both would be searchable at once.
+                        op: IndexOp::Index {
+                            replace: prior.is_some_and(|p| p.state == IndexState::Indexed),
+                        },
+                    });
+                }
+                ItemStatus::Tombstoned => match prior {
+                    // Never pushed, or already withdrawn — nothing owed.
+                    None => {}
+                    Some(p) if p.state == IndexState::Removed => backlog.synced += 1,
+                    Some(p) => backlog.tasks.push(IndexTask {
+                        item_id: record.item_id.clone(),
+                        entity: record.entity.clone(),
+                        path,
+                        content_hash: p.content_hash.clone(),
+                        size: p.size,
+                        mtime_ns: p.mtime_ns,
+                        op: IndexOp::Remove,
+                    }),
+                },
+            }
+        }
+        Ok(backlog)
+    }
+
+    /// Record that one task's push into the index succeeded.
+    ///
+    /// Why: called by the feed layer AFTER the daemon acknowledged the write,
+    /// never before — see [`IndexJournal::append`].
+    pub fn okg_record_index(
+        &self,
+        journal: &mut IndexJournal,
+        task: &IndexTask,
+        now: &str,
+    ) -> anyhow::Result<()> {
+        journal.append(IndexRecord {
+            entity: task.entity.clone(),
+            content_hash: task.content_hash.clone(),
+            size: task.size,
+            mtime_ns: task.mtime_ns,
+            state: match task.op {
+                IndexOp::Index { .. } => IndexState::Indexed,
+                IndexOp::Remove => IndexState::Removed,
+            },
+            at: now.to_string(),
+        })
+    }
+
+    /// Absolute path of an entity named `<collection>/<slug>` by a journal.
+    ///
+    /// Mirrors `ingest::tombstone_item`'s derivation: the slug is the last
+    /// segment, and the collection comes from the SPEC rather than the string,
+    /// so a hand-edited entity value can never redirect the write.
+    fn entity_file_path(&self, spec: &SourceSpec, entity: &str) -> anyhow::Result<PathBuf> {
+        let slug = entity.rsplit('/').next().unwrap_or(entity);
+        self.entity_path(&spec.collection, slug)
+    }
+}
+
+#[cfg(test)]
+#[path = "index_journal_tests.rs"]
+mod tests;

--- a/crates/trusty-kb/src/okg/index_journal_tests.rs
+++ b/crates/trusty-kb/src/okg/index_journal_tests.rs
@@ -1,0 +1,326 @@
+//! Reconcile-layer tests for the OKG index journal (#3892).
+//!
+//! Why: the whole point of the journal is that the tree and the bound search
+//! index converge WITHOUT the ledger ever depending on a reachable daemon.
+//! Every property that claim rests on is proved here, with no network and no
+//! daemon: a fresh ingest is owed to the index, a recorded push leaves the
+//! backlog, an edit re-enters it, a tombstone becomes a withdrawal, and a
+//! crash-torn journal line costs one record rather than the file.
+//! What: drives `KbStore::okg_index_backlog` against a real temp tree.
+//! Test: `cargo test -p trusty-kb okg::index_journal`.
+
+use super::*;
+use crate::okg::policy::DocStorePolicy;
+use crate::okg::registry::Locator;
+use crate::schema::Profile;
+
+/// A store plus a doc-store corpus directory under one tempdir.
+fn fixture() -> (tempfile::TempDir, KbStore, std::path::PathBuf) {
+    let tmp = tempfile::tempdir().unwrap();
+    let store = KbStore::new(tmp.path().join("kb"), Profile::default_profile());
+    let corpus = tmp.path().join("corpus");
+    std::fs::create_dir_all(&corpus).unwrap();
+    (tmp, store, corpus)
+}
+
+fn policy(tmp: &tempfile::TempDir) -> DocStorePolicy {
+    DocStorePolicy::new(vec![tmp.path().canonicalize().unwrap()])
+}
+
+/// Register a doc-store source over `corpus`, with tombstoning on.
+fn register(store: &KbStore, corpus: &std::path::Path) -> SourceSpec {
+    let mut spec = SourceSpec::new(
+        "corpus",
+        Some("notes"),
+        Locator::DocStore {
+            path: corpus.to_string_lossy().to_string(),
+            extensions: vec![],
+            recursive: true,
+        },
+        "t0",
+    );
+    spec.tombstone_deleted = true;
+    store.okg_register_source(spec).unwrap();
+    store.okg_source("corpus").unwrap()
+}
+
+/// Simulate a successful push of every task in the backlog.
+fn drain(store: &KbStore, spec: &SourceSpec, now: &str) -> usize {
+    let backlog = store.okg_index_backlog(spec).unwrap();
+    let mut journal = IndexJournal::load(&store.root, &spec.id).unwrap();
+    for task in &backlog.tasks {
+        store.okg_record_index(&mut journal, task, now).unwrap();
+    }
+    backlog.tasks.len()
+}
+
+/// Why: this is the #3892 failure in miniature — an ingest that reports N
+/// entities must leave exactly N items owed to the index, not zero.
+/// What: ingests two files and asserts both appear as first-time push tasks
+/// resolved to real, readable entity files.
+/// Test: self-contained.
+#[test]
+fn backlog_lists_freshly_ingested_entities() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "first note").unwrap();
+    std::fs::write(corpus.join("two.md"), "second note").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+
+    let backlog = store.okg_index_backlog(&spec).unwrap();
+    assert_eq!(
+        backlog.tasks.len(),
+        2,
+        "both entities are owed to the index"
+    );
+    assert_eq!(backlog.synced, 0);
+    assert!(backlog.notes.is_empty(), "notes: {:?}", backlog.notes);
+    for task in &backlog.tasks {
+        assert_eq!(task.op, IndexOp::Index { replace: false });
+        assert!(task.path.is_file(), "{} must exist", task.path.display());
+        assert!(task.content_hash.starts_with("sha256:"));
+        let bytes = std::fs::read(&task.path).unwrap();
+        assert_eq!(
+            task.content_hash,
+            format!("sha256:{:x}", sha2::Sha256::digest(&bytes)),
+            "the task must pin the CURRENT file content"
+        );
+    }
+}
+
+/// Why: idempotency — re-running an unchanged source must push nothing, or
+/// every run would re-embed the whole corpus and duplicate index work.
+/// What: drains the backlog, then asserts a second reconcile (and one after a
+/// full re-ingest that skips everything) is empty.
+/// Test: self-contained.
+#[test]
+fn recorded_entity_leaves_the_backlog() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "first note").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+    assert_eq!(drain(&store, &spec, "t0"), 1);
+
+    let after = store.okg_index_backlog(&spec).unwrap();
+    assert!(after.tasks.is_empty(), "tasks: {:?}", after.tasks);
+    assert_eq!(after.synced, 1);
+
+    // A full re-ingest skips the item entirely; the index must stay settled.
+    let report = store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t1")
+        .unwrap();
+    assert_eq!(report.skipped, 1);
+    assert!(store.okg_index_backlog(&spec).unwrap().tasks.is_empty());
+}
+
+/// Why: a push that never happened (daemon down, HTTP error, crash between the
+/// entity write and the push) must be RETRIED, not silently skipped — the
+/// convergence guarantee this design exists for.
+/// What: ingests, deliberately records nothing, re-runs the ingest (which skips
+/// the unchanged item), and asserts the item is still owed to the index.
+/// Test: self-contained.
+#[test]
+fn unrecorded_push_stays_pending_across_runs() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "first note").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+
+    // Simulate a run whose push failed: the ledger has the item, the journal
+    // does not.
+    assert_eq!(store.okg_index_backlog(&spec).unwrap().tasks.len(), 1);
+    let second = store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t1")
+        .unwrap();
+    assert_eq!(second.skipped, 1, "the ingest engine skips it — by design");
+
+    let backlog = store.okg_index_backlog(&spec).unwrap();
+    assert_eq!(
+        backlog.tasks.len(),
+        1,
+        "an unindexed item must never fall out of the backlog"
+    );
+    assert_eq!(drain(&store, &spec, "t1"), 1, "and a later run drains it");
+    assert!(store.okg_index_backlog(&spec).unwrap().tasks.is_empty());
+}
+
+/// Why: a changed entity must REPLACE its index content. The old chunks have to
+/// be withdrawn first (trusty-search chunks by content, so a shorter revision
+/// would leave orphans searchable), which is what `replace: true` signals.
+/// What: edits the source file, re-ingests, and asserts the task reappears as a
+/// replacement carrying the NEW hash.
+/// Test: self-contained.
+#[test]
+fn changed_entity_reenters_the_backlog() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "first note").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+    drain(&store, &spec, "t0");
+    let before = store.okg_index_backlog(&spec).unwrap();
+    assert!(before.tasks.is_empty());
+
+    std::fs::write(corpus.join("one.md"), "first note, revised").unwrap();
+    let report = store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t1")
+        .unwrap();
+    assert_eq!(report.updated, 1);
+
+    let backlog = store.okg_index_backlog(&spec).unwrap();
+    assert_eq!(backlog.tasks.len(), 1);
+    assert_eq!(
+        backlog.tasks[0].op,
+        IndexOp::Index { replace: true },
+        "the stale revision must be withdrawn before the new one lands"
+    );
+    let content = std::fs::read_to_string(&backlog.tasks[0].path).unwrap();
+    assert!(content.contains("revised"));
+}
+
+/// Why: a vanished source item must not stay searchable — that is the same
+/// silent-lie failure as #3892, only inverted.
+/// What: deletes the file, re-ingests (tombstoning), and asserts a withdrawal
+/// task appears and settles once recorded.
+/// Test: self-contained.
+#[test]
+fn tombstoned_entity_becomes_a_remove_task() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "first note").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+    drain(&store, &spec, "t0");
+
+    std::fs::remove_file(corpus.join("one.md")).unwrap();
+    let report = store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t1")
+        .unwrap();
+    assert_eq!(report.tombstoned, 1);
+
+    let backlog = store.okg_index_backlog(&spec).unwrap();
+    assert_eq!(backlog.tasks.len(), 1);
+    assert_eq!(backlog.tasks[0].op, IndexOp::Remove);
+
+    assert_eq!(drain(&store, &spec, "t1"), 1);
+    let settled = store.okg_index_backlog(&spec).unwrap();
+    assert!(settled.tasks.is_empty(), "withdrawal settles");
+    assert_eq!(settled.synced, 1);
+}
+
+/// Why: withdrawing something that was never pushed would make every offline
+/// ingest emit spurious `remove_file` calls against the daemon.
+/// What: ingests and tombstones WITHOUT ever recording a push, then asserts the
+/// backlog is empty rather than holding a phantom removal.
+/// Test: self-contained.
+#[test]
+fn never_indexed_tombstone_needs_no_removal() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "first note").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+    std::fs::remove_file(corpus.join("one.md")).unwrap();
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t1")
+        .unwrap();
+
+    let backlog = store.okg_index_backlog(&spec).unwrap();
+    assert!(
+        backlog.tasks.is_empty(),
+        "nothing was ever pushed, so nothing is owed: {:?}",
+        backlog.tasks
+    );
+}
+
+/// Why: the index journal inherits the ledger's crash tolerance — a `kill -9`
+/// mid-append must cost one record, not the file. Without this the source would
+/// re-push its whole corpus on every subsequent run.
+/// What: tears the final line, then asserts the intact record still counts as
+/// synced, the damage is counted, and a later append is not swallowed.
+/// Test: self-contained.
+#[test]
+fn torn_index_journal_line_is_skipped_not_fatal() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "first note").unwrap();
+    std::fs::write(corpus.join("two.md"), "second note").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+    drain(&store, &spec, "t0");
+
+    let path = IndexJournal::path_for(&store.root, "corpus").unwrap();
+    let mut torn = std::fs::read_to_string(&path).unwrap();
+    torn.push_str("{\"entity\":\"notes/thr");
+    std::fs::write(&path, torn).unwrap();
+
+    let journal = IndexJournal::load(&store.root, "corpus").unwrap();
+    assert_eq!(journal.malformed_lines(), 1);
+    let backlog = store.okg_index_backlog(&spec).unwrap();
+    assert!(
+        backlog.tasks.is_empty(),
+        "the two intact records survive the tear: {:?}",
+        backlog.tasks
+    );
+
+    // And the journal keeps working: a new entity records cleanly.
+    std::fs::write(corpus.join("three.md"), "third note").unwrap();
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t1")
+        .unwrap();
+    assert_eq!(drain(&store, &spec, "t1"), 1);
+    assert!(store.okg_index_backlog(&spec).unwrap().tasks.is_empty());
+}
+
+/// Why: a status view that re-hashed every entity on every read would make the
+/// GUI's store card quadratically expensive on a large tree. The cheap
+/// `(size, mtime)` short-circuit is what keeps a settled reconcile to one
+/// `stat` per entity — but it must never mask a real edit.
+/// What: proves an edit that PRESERVES the byte length is still detected (mtime
+/// moves), and that a byte-identical rewrite settles back to "synced" rather
+/// than looping (the hash absorbs the false positive).
+/// Test: self-contained.
+#[test]
+fn same_length_edit_is_still_detected() {
+    let (tmp, store, corpus) = fixture();
+    std::fs::write(corpus.join("one.md"), "aaaa").unwrap();
+    let spec = register(&store, &corpus);
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+        .unwrap();
+    drain(&store, &spec, "t0");
+
+    std::fs::write(corpus.join("one.md"), "bbbb").unwrap();
+    store
+        .okg_ingest_docstore("corpus", &policy(&tmp), "t1")
+        .unwrap();
+    let backlog = store.okg_index_backlog(&spec).unwrap();
+    assert_eq!(
+        backlog.tasks.len(),
+        1,
+        "a same-length edit must still re-index"
+    );
+    drain(&store, &spec, "t1");
+
+    // Touch the entity file without changing a byte: the cheap check fires,
+    // the hash absorbs it, and nothing is re-pushed.
+    let entity = store.entity_path("notes", "one").unwrap();
+    let bytes = std::fs::read(&entity).unwrap();
+    std::fs::write(&entity, &bytes).unwrap();
+    let settled = store.okg_index_backlog(&spec).unwrap();
+    assert!(
+        settled.tasks.is_empty(),
+        "an identical rewrite must not re-push: {:?}",
+        settled.tasks
+    );
+}

--- a/crates/trusty-kb/src/okg/jsonl.rs
+++ b/crates/trusty-kb/src/okg/jsonl.rs
@@ -1,0 +1,143 @@
+//! Append-only JSONL journal mechanics, shared by every OKG journal.
+//!
+//! Why: the OKG now keeps TWO append-only journals per source — the item
+//! [`ledger`](crate::okg::ledger) (what was pulled into the tree) and the
+//! [`index journal`](crate::okg::index_journal) (what was pushed into the bound
+//! search index). Both need the same two hard-won behaviours, and duplicating
+//! them would let the copies drift: a crash-torn final line must cost exactly
+//! one record rather than bricking the file, and the first append after such a
+//! tear must emit a healing newline or it silently concatenates into the torn
+//! fragment and loses the NEW record too (the bug fixed by
+//! `append_after_torn_line_does_not_corrupt_the_new_record`).
+//!
+//! What: [`read_journal`] parses a whole file BYTE-wise — decoding per line, so
+//! a tear mid-UTF-8-codepoint damages only its own line — and reports how many
+//! lines were unusable plus whether the file ends without a newline.
+//! [`Appender`] owns the lazily-opened handle and performs the healing write.
+//!
+//! Test: the behaviours are pinned by the callers' own suites
+//! (`torn_line_is_skipped_not_fatal`,
+//! `torn_mid_utf8_codepoint_is_skipped_not_fatal`,
+//! `append_after_torn_line_does_not_corrupt_the_new_record`, and
+//! `index_journal::tests::torn_index_journal_line_is_skipped_not_fatal`).
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// The outcome of reading one journal file.
+pub(crate) struct JournalLoad<T> {
+    /// Every record that parsed, in file order.
+    pub records: Vec<T>,
+    /// Lines that could not be used (bad JSON or invalid UTF-8).
+    pub malformed: usize,
+    /// The file's last line lacks a terminating newline — the signature of a
+    /// write interrupted mid-line. The next append must heal it.
+    pub needs_newline: bool,
+}
+
+impl<T> Default for JournalLoad<T> {
+    fn default() -> Self {
+        Self {
+            records: Vec::new(),
+            malformed: 0,
+            needs_newline: false,
+        }
+    }
+}
+
+/// Read and parse an append-only JSONL journal, tolerating damage.
+///
+/// Why: an absent journal is a first run, not an error, and a damaged line must
+/// be SKIPPED rather than abort the load — one torn write from a crash would
+/// otherwise permanently brick the source.
+///
+/// The parse is deliberately BYTE-oriented. Reading the file as a `String`
+/// first fails the WHOLE load on invalid UTF-8, and a crash mid-write lands
+/// mid-codepoint whenever the record carries non-ASCII text — which for this
+/// crate is the common case (a Gmail subject with an em-dash, a Drive filename
+/// in kana), not the exotic one.
+/// What: splits on `b'\n'`, tolerates CRLF and blank lines, and parses each
+/// line independently.
+/// Test: see the module doc.
+pub(crate) fn read_journal<T: DeserializeOwned>(path: &Path) -> anyhow::Result<JournalLoad<T>> {
+    if !path.exists() {
+        return Ok(JournalLoad::default());
+    }
+    let bytes = std::fs::read(path)?;
+    let mut out = JournalLoad {
+        needs_newline: !bytes.is_empty() && bytes.last() != Some(&b'\n'),
+        ..JournalLoad::default()
+    };
+    for line in bytes.split(|b| *b == b'\n') {
+        let line = line.strip_suffix(b"\r").unwrap_or(line);
+        if line.iter().all(u8::is_ascii_whitespace) {
+            continue;
+        }
+        // `from_slice` handles the UTF-8 check itself, so an invalid-UTF-8 line
+        // lands in the same `malformed` bucket as bad JSON.
+        match serde_json::from_slice::<T>(line) {
+            Ok(record) => out.records.push(record),
+            Err(_) => out.malformed += 1,
+        }
+    }
+    Ok(out)
+}
+
+/// A lazily-opened, per-item-durable appender for one journal file.
+pub(crate) struct Appender {
+    path: PathBuf,
+    handle: Option<File>,
+    needs_newline: bool,
+}
+
+impl Appender {
+    /// Build an appender for `path`, healing a torn final line on first write.
+    pub(crate) fn new(path: PathBuf, needs_newline: bool) -> Self {
+        Self {
+            path,
+            handle: None,
+            needs_newline,
+        }
+    }
+
+    /// Durably append one record as a JSON line.
+    ///
+    /// Why: per-item durability is what makes a crashed run converge — the line
+    /// is flushed AND `sync_data`'d before returning, so a process killed
+    /// immediately after has lost nothing it already reported.
+    /// What: opens (once) in append mode, heals a torn final line, writes one
+    /// line, syncs best-effort.
+    /// Test: see the module doc.
+    pub(crate) fn append<T: Serialize>(&mut self, record: &T) -> anyhow::Result<()> {
+        if self.handle.is_none() {
+            if let Some(parent) = self.path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            self.handle = Some(
+                OpenOptions::new()
+                    .create(true)
+                    .append(true)
+                    .open(&self.path)?,
+            );
+        }
+        let line = serde_json::to_string(record)?;
+        let file = self
+            .handle
+            .as_mut()
+            .expect("handle just opened above; None is unreachable");
+        if self.needs_newline {
+            writeln!(file)?;
+            self.needs_newline = false;
+        }
+        writeln!(file, "{line}")?;
+        file.flush()?;
+        // Best-effort durability: a filesystem that cannot fsync must not fail
+        // the run — the line is already flushed to the OS at this point.
+        let _ = file.sync_data();
+        Ok(())
+    }
+}

--- a/crates/trusty-kb/src/okg/ledger.rs
+++ b/crates/trusty-kb/src/okg/ledger.rs
@@ -24,13 +24,12 @@
 //! `watermark_spans_oldest_and_newest`.
 
 use std::collections::BTreeMap;
-use std::fs::{File, OpenOptions};
-use std::io::Write;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
 
 use crate::entity::slugify;
+use crate::okg::jsonl::{Appender, read_journal};
 use crate::okg::registry::SOURCES_DIR;
 use crate::roots::{assert_within, confine};
 
@@ -86,23 +85,15 @@ pub struct Watermark {
 
 /// An open, append-only ledger for one source.
 pub struct Ledger {
-    /// Journal file path.
-    path: PathBuf,
     /// Last record seen per item id — the effective state.
     latest: BTreeMap<String, LedgerRecord>,
     /// `ingested_at` of the last line read or written.
     last_ingest_at: Option<String>,
     /// Count of unparseable lines encountered on load.
     malformed: usize,
-    /// The file's final line lacks a terminating newline — the signature of a
-    /// write interrupted mid-line. The first [`Ledger::append`] must emit a
-    /// newline before its own record, or the two would concatenate into one
-    /// unparseable line and the NEW record would be lost too. Without this the
-    /// journal never converges: every subsequent run re-ingests that item and
-    /// re-corrupts it the same way.
-    needs_newline: bool,
-    /// Lazily opened append handle, kept across a run.
-    handle: Option<File>,
+    /// Durable append handle, which also heals a crash-torn final line — see
+    /// [`crate::okg::jsonl`].
+    appender: Appender,
 }
 
 impl Ledger {
@@ -123,54 +114,24 @@ impl Ledger {
     ///
     /// Why: an absent journal is a first run, not an error; and a damaged line
     /// must be SKIPPED rather than abort the load, or one torn write from a
-    /// crash would permanently brick the source.
-    ///
-    /// The parse is deliberately BYTE-oriented. Reading the file as a `String`
-    /// first (`read_to_string`) fails the WHOLE load on invalid UTF-8, and a
-    /// crash mid-write lands mid-codepoint whenever the record contains
-    /// non-ASCII text — which for this crate is the common case, not the exotic
-    /// one: a Gmail subject with a dash or an accent, a Drive filename in any
-    /// non-Latin script. That turned a one-item loss into a permanently
-    /// unloadable source, the exact failure this doc promises cannot happen.
-    /// Splitting on `b'\n'` and decoding per line contains the damage to the
-    /// torn line, whether it is invalid UTF-8 or merely invalid JSON.
-    ///
-    /// What: splits the raw bytes on newlines, decodes and parses each line
-    /// independently, keeps the last record per item id, and counts every line
-    /// it could not use.
+    /// crash would permanently brick the source. Both properties live in
+    /// [`crate::okg::jsonl::read_journal`], shared with the index journal.
+    /// What: reads every parseable line, keeps the last record per item id, and
+    /// counts every line it could not use.
     /// Test: `torn_line_is_skipped_not_fatal`,
     /// `torn_mid_utf8_codepoint_is_skipped_not_fatal`.
     pub fn load(root: &Path, source_id: &str) -> anyhow::Result<Self> {
         let path = Self::path_for(root, source_id)?;
+        let load = read_journal::<LedgerRecord>(&path)?;
         let mut ledger = Self {
-            path,
             latest: BTreeMap::new(),
             last_ingest_at: None,
-            malformed: 0,
-            needs_newline: false,
-            handle: None,
+            malformed: load.malformed,
+            appender: Appender::new(path, load.needs_newline),
         };
-        if !ledger.path.exists() {
-            return Ok(ledger);
-        }
-        let bytes = std::fs::read(&ledger.path)?;
-        ledger.needs_newline = !bytes.is_empty() && bytes.last() != Some(&b'\n');
-        for line in bytes.split(|b| *b == b'\n') {
-            // Tolerate CRLF journals and blank separator lines.
-            let line = line.strip_suffix(b"\r").unwrap_or(line);
-            if line.iter().all(u8::is_ascii_whitespace) {
-                continue;
-            }
-            // `from_slice` handles the UTF-8 check itself, so an invalid-UTF-8
-            // line lands in exactly the same `malformed` bucket as bad JSON —
-            // no separate decode step, no way for one to abort the other.
-            match serde_json::from_slice::<LedgerRecord>(line) {
-                Ok(record) => {
-                    ledger.last_ingest_at = Some(record.ingested_at.clone());
-                    ledger.latest.insert(record.item_id.clone(), record);
-                }
-                Err(_) => ledger.malformed += 1,
-            }
+        for record in load.records {
+            ledger.last_ingest_at = Some(record.ingested_at.clone());
+            ledger.latest.insert(record.item_id.clone(), record);
         }
         Ok(ledger)
     }
@@ -205,6 +166,15 @@ impl Ledger {
         self.latest.contains_key(item_id)
     }
 
+    /// Every item's effective record, item-id sorted.
+    ///
+    /// Why: the index reconcile (`KbStore::okg_index_backlog`) must see
+    /// TOMBSTONED rows too — they are what tells it to withdraw an entity from
+    /// the search index — so [`Self::live_item_ids`] is deliberately not enough.
+    pub fn records(&self) -> impl Iterator<Item = &LedgerRecord> {
+        self.latest.values()
+    }
+
     /// Item ids currently in the ingested (non-tombstoned) state, sorted.
     pub fn live_item_ids(&self) -> Vec<String> {
         self.latest
@@ -222,33 +192,7 @@ impl Ledger {
     /// What: opens (once per run) in append mode, writes one JSON line, syncs.
     /// Test: `append_then_reload_is_current`.
     pub fn append(&mut self, record: LedgerRecord) -> anyhow::Result<()> {
-        if self.handle.is_none() {
-            if let Some(parent) = self.path.parent() {
-                std::fs::create_dir_all(parent)?;
-            }
-            self.handle = Some(
-                OpenOptions::new()
-                    .create(true)
-                    .append(true)
-                    .open(&self.path)?,
-            );
-        }
-        let line = serde_json::to_string(&record)?;
-        let file = self
-            .handle
-            .as_mut()
-            .expect("handle just opened above; None is unreachable");
-        // Heal a torn final line before appending — see `needs_newline`.
-        if self.needs_newline {
-            writeln!(file)?;
-            self.needs_newline = false;
-        }
-        writeln!(file, "{line}")?;
-        file.flush()?;
-        // Best-effort durability: a filesystem that cannot fsync must not fail
-        // the ingest — the line is already flushed to the OS at this point.
-        let _ = file.sync_data();
-
+        self.appender.append(&record)?;
         self.last_ingest_at = Some(record.ingested_at.clone());
         self.latest.insert(record.item_id.clone(), record);
         Ok(())

--- a/crates/trusty-kb/src/okg/mod.rs
+++ b/crates/trusty-kb/src/okg/mod.rs
@@ -15,10 +15,15 @@
 //!   - [`ingest`]   — the fetcher-agnostic engine ([`ingest::SourceItem`] in,
 //!     entities + ledger lines out).
 //!   - [`docstore`] — the in-crate filesystem fetcher.
+//!   - [`index_journal`] — `_sources/<id>.index.jsonl`, the record of what
+//!     reached the bound SEARCH index, and the reconcile that diffs it against
+//!     the ledger (#3892).
 //!
 //! Gmail and Drive fetchers deliberately live in `trusty-agents`, where the
 //! authenticated `trusty-gworkspace` client already is — this crate stays pure,
-//! deterministic, and network-free.
+//! deterministic, and network-free. For the same reason the index PUSH lives
+//! there too (`trusty_agents::stores::index_feed`); this crate only decides
+//! what is owed.
 //!
 //! This file adds the store-level entry points that compose those pieces:
 //! [`KbStore::okg_register_source`], [`KbStore::okg_sources`], and
@@ -28,7 +33,9 @@
 //! `docstore_ingest_is_idempotent_end_to_end`.
 
 pub mod docstore;
+pub mod index_journal;
 pub mod ingest;
+mod jsonl;
 pub mod ledger;
 pub mod policy;
 pub mod registry;
@@ -60,6 +67,34 @@ pub struct SourceStatus {
     pub locator: Json,
     /// Derived coverage: item counts, time span, last run.
     pub watermark: Watermark,
+    /// How much of this source has reached the bound SEARCH INDEX (#3892).
+    pub index: IndexCoverage,
+}
+
+/// Per-source search-index coverage — the "is it actually findable?" half.
+///
+/// Why (#3892): `watermark` answers "what is in the tree", and for a long time
+/// that was silently read as "what the assistant can find". It is not: an
+/// entity is only searchable once it has been pushed into the store's bound
+/// trusty-search index, and that push can lag (daemon down, push failed, no
+/// binding at all). This field makes the lag VISIBLE — an "ingested but not yet
+/// searchable" backlog is the exact failure mode #3892 reports, and it must
+/// never again be invisible on both sides.
+/// What: `synced` entities the index journal says are current, and `pending`
+/// still owed — pushes, withdrawals, AND rows that could not be resolved to a
+/// readable entity file (unsearchable too, and additionally listed in `notes`).
+/// Derived, like the watermark, so it cannot claim more than was recorded.
+/// Test: `sources_report_index_coverage`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct IndexCoverage {
+    /// Entities recorded as current in the bound index.
+    pub synced: usize,
+    /// Entities still owed to the index (not yet searchable, or not yet
+    /// withdrawn after a tombstone).
+    pub pending: usize,
+    /// Rows the reconcile could not resolve to a readable entity file.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub notes: Vec<String>,
 }
 
 impl KbStore {
@@ -97,14 +132,28 @@ impl KbStore {
     ///
     /// Why: "what does this store cover, and how far back?" is the question an
     /// operator asks before widening a window or adding a store. Coverage is
-    /// derived from the ledgers, so it cannot drift from what was ingested.
-    /// Test: `register_is_additive_across_sources`.
+    /// derived from the ledgers, so it cannot drift from what was ingested. It
+    /// additionally reports SEARCH coverage (#3892) — see [`IndexCoverage`] —
+    /// because "ingested" and "findable" are two different claims and conflating
+    /// them is what made the ingest→search gap silent.
+    /// What: one row per registered source. The index reconcile is local
+    /// filesystem work (one `stat` per settled entity, a re-hash only when the
+    /// cheap check moves), never a daemon call, so this stays a read-only,
+    /// offline-safe status view.
+    /// Test: `register_is_additive_across_sources`,
+    /// `sources_report_index_coverage`.
     pub fn okg_sources(&self) -> anyhow::Result<Vec<SourceStatus>> {
         let reg = SourceRegistry::load(&self.root)?;
         let mut out = Vec::with_capacity(reg.sources.len());
         for spec in &reg.sources {
             let watermark = Ledger::load(&self.root, &spec.id)?.watermark();
+            let backlog = self.okg_index_backlog(spec)?;
             out.push(SourceStatus {
+                index: IndexCoverage {
+                    synced: backlog.synced,
+                    pending: backlog.tasks.len() + backlog.notes.len(),
+                    notes: backlog.notes,
+                },
                 id: spec.id.clone(),
                 kind: spec.kind().to_string(),
                 collection: spec.collection.clone(),
@@ -116,6 +165,26 @@ impl KbStore {
             });
         }
         Ok(out)
+    }
+
+    /// Tree-wide search coverage, folded across every registered source.
+    ///
+    /// Why (#3892): the store card and the `[[stores]]` status endpoint answer
+    /// "is this store connected?" per INDEX; this answers the other half — how
+    /// much of the tree has actually reached that index. A store can be
+    /// perfectly connected and still hold nothing the assistant ingested.
+    /// What: sums [`IndexCoverage`] over the registry. Returns zeroes for a tree
+    /// with no registry at all, which is the normal state for a hand-built tree.
+    /// Test: `sources_report_index_coverage`.
+    pub fn okg_index_coverage(&self) -> anyhow::Result<IndexCoverage> {
+        let mut total = IndexCoverage::default();
+        for spec in &SourceRegistry::load(&self.root)?.sources {
+            let backlog = self.okg_index_backlog(spec)?;
+            total.synced += backlog.synced;
+            total.pending += backlog.tasks.len() + backlog.notes.len();
+            total.notes.extend(backlog.notes);
+        }
+        Ok(total)
     }
 
     /// Scan a registered doc store and ingest whatever changed.
@@ -391,5 +460,58 @@ mod tests {
         let status = store.okg_sources().unwrap();
         assert_eq!(status[0].watermark.items, 1);
         assert_eq!(status[0].watermark.tombstoned, 1);
+    }
+
+    /// Why (#3892): "N entities ingested" was truthful and still meant "findable
+    /// by nobody". The status view must therefore separate tree coverage from
+    /// SEARCH coverage, so an operator can see a backlog instead of guessing.
+    /// What: ingests two files with no index feed at all and asserts both the
+    /// per-source row and the tree-wide fold report them as pending, then
+    /// asserts recording the pushes moves them to synced.
+    /// Test: self-contained.
+    #[test]
+    fn sources_report_index_coverage() {
+        let (tmp, store) = store();
+        let docs = tmp.path().join("corpus");
+        std::fs::create_dir_all(&docs).unwrap();
+        std::fs::write(docs.join("one.md"), "first note").unwrap();
+        std::fs::write(docs.join("two.md"), "second note").unwrap();
+        store
+            .okg_register_source(SourceSpec::new(
+                "corpus",
+                Some("notes"),
+                Locator::DocStore {
+                    path: docs.to_string_lossy().to_string(),
+                    extensions: vec![],
+                    recursive: true,
+                },
+                "t0",
+            ))
+            .unwrap();
+        store
+            .okg_ingest_docstore("corpus", &policy(&tmp), "t0")
+            .unwrap();
+
+        let status = store.okg_sources().unwrap();
+        assert_eq!(status[0].watermark.items, 2, "both are in the TREE");
+        assert_eq!(
+            (status[0].index.synced, status[0].index.pending),
+            (0, 2),
+            "and neither is searchable yet — the #3892 state, now visible"
+        );
+        assert_eq!(store.okg_index_coverage().unwrap().pending, 2);
+
+        // Record the pushes the feed layer would have made.
+        let spec = store.okg_source("corpus").unwrap();
+        let backlog = store.okg_index_backlog(&spec).unwrap();
+        let mut journal =
+            crate::okg::index_journal::IndexJournal::load(&store.root, "corpus").unwrap();
+        for task in &backlog.tasks {
+            store.okg_record_index(&mut journal, task, "t0").unwrap();
+        }
+
+        let settled = store.okg_sources().unwrap();
+        assert_eq!((settled[0].index.synced, settled[0].index.pending), (2, 0));
+        assert_eq!(store.okg_index_coverage().unwrap().synced, 2);
     }
 }

--- a/docs/specs/okg-universal-importer.md
+++ b/docs/specs/okg-universal-importer.md
@@ -6,7 +6,7 @@
 **Last-updated:** 2026-07-25  
 **Spec ID:** `SPEC-OKGIMPORT-01~draft` … `SPEC-OKGIMPORT-07~draft` (DOC-55)  
 **Builds on:** DOC-54 [Trusty Agents Product Specification](./trusty-agents-product-spec.md) §5.1 (the `[[stores]]` config leg); the shipped OKG ingestion engine (#3881 / PR #3883); the OKG store binding (#3878)  
-**Related issues:** epic #3052 (Assistant M1), #3881 (ingestion layer, closed), #3892 (ingest→search gap, OPEN — see §7), #3816 (declarative templates), #3837 (git-backed per-agent content store)
+**Related issues:** epic #3052 (Assistant M1), #3881 (ingestion layer, closed), #3892 (ingest→search gap, RESOLVED via remediation (a) — see §7), #3816 (declarative templates), #3837 (git-backed per-agent content store)
 
 ---
 
@@ -40,11 +40,11 @@ that makes both of them useful:
   connect to, we should be able to crawl and import that data into an OKG store
   for an assistant, driven by the assistant."*
 
-**What this spec deliberately does not do:** it does not decide #3892 (whether an
-ingested entity reaches the bound search index, and how). §7 states the
-importer's position relative to that open decision explicitly rather than
-silently assuming one, because every additional format and connector multiplies
-the blast radius of getting it wrong.
+**On #3892 (ingest→search):** the first draft of this spec deliberately took no
+position on whether an ingested entity reaches the bound search index. That
+decision has since been made — remediation **(a)**, ingestion feeds the bound
+index — and §7 now records the shipped contract every extractor and connector
+inherits, rather than an open question.
 
 ---
 
@@ -141,7 +141,8 @@ would destroy that property and is out of scope (§3.3).
   credential resolver (#2643), never a bespoke token store.
 - **No parallel KB format.** Entity writes continue through
   `KbStore::put_entity`.
-- **No resolution of #3892.** See §7.
+- **No re-litigation of #3892.** Settled as remediation (a); §7 records the
+  contract this spec's connectors inherit.
 - **No SQL / structured-database ingestion** (`cto.db`, `analytics.duckdb`) —
   explicitly out of scope in #3881 and still out of scope here. A spreadsheet
   read as a document (§4.4) is not the same thing as a database connector.
@@ -510,46 +511,84 @@ the assumption that the first real backfill will immediately want it.
 
 ## 7. SPEC-OKGIMPORT-06 — Position Relative to the Ingest→Search Gap (#3892) {#SPEC-OKGIMPORT-06~draft}
 
-### 7.1 The open decision
+### 7.1 The decision, now settled
 
-#3892 (OPEN) documents, with live evidence, that an OKG store's two facets do not
+#3892 documented, with live evidence, that an OKG store's two facets did not
 meet: `okg_ingest_*` writes into
 `${KB_KNOWLEDGE_DIR:-$HOME/.trusty-agents/knowledge}/<agent>`, while the
 `[[stores]]` binding's `index` is a trusty-search index built over an unrelated
-root; `okg://<agent>` is never resolved to a filesystem path at all. A user can
+root; `okg://<agent>` was never resolved to a filesystem path at all. A user could
 run an ingest, get a truthful "N entities ingested", and still get nothing from
-`vector_search`. Two coherent remediations are on the table — **(a)** ingest also
+`vector_search`. Two coherent remediations were on the table — **(a)** ingest also
 feeds the bound index, or **(b)** the store's index is (re)built over the KB tree
-— and (b) collides with a deliberate operator choice (the 200,090-chunk
-`bob-duetto/cto` index), which is why the issue is flagged for owner sign-off.
+— and (b) collided with a deliberate operator choice (the 200,090-chunk
+`bob-duetto/cto` index).
 
-### 7.2 This spec's position (normative)
+**The owner chose (a)** (2026-07-25). Ingestion now feeds the bound index, and the
+operator's index-root configuration is left untouched. Shipped shape:
 
-1. **DOC-55 does not decide #3892, and must not be read as having decided it.**
-   Nothing in §§4–6 presumes either remediation.
-2. **DOC-55 makes #3892 strictly more urgent.** Every extractor and every
-   connector multiplies the volume of content that lands in a tree the assistant
-   cannot search. Shipping the importer without resolving #3892 produces a larger,
-   more convincing, still-invisible corpus — the worst outcome, because the
-   failure is silent by construction on both sides.
-3. **The importer is designed to be neutral to the outcome.** The extraction
-   layer is upstream of `SourceItem` and cannot care. The connector framework
-   ends at the ingest engine and cannot care. If (a) is chosen, the index push
-   attaches at exactly one place — after `write_item` succeeds, per item or
-   batched at end of run — and every connector inherits it with no per-connector
-   work. If (b) is chosen, nothing in this spec changes at all.
-4. **If (a) is chosen, the ledger's role must be settled deliberately.** #3892
-   already names the partial-failure mode (entity written, index push failed).
-   The importer's position: the ledger is the record of *KB-tree* truth and
-   should not be overloaded with index state; an index push failure belongs in
-   `IngestReport::errors` and is repaired by an index-level reconcile, not by
-   rolling back a ledger line. Recording index state in the ledger would make
-   ingestion non-convergent when the search daemon is merely down.
-5. **Sequencing recommendation:** #3892 should be decided before the connector
-   roster (§5.4) expands beyond the Google surface — i.e. before phase 3 in §9.
-   The extraction layer (phase 1) can land ahead of it safely, because it changes
-   only the *quality* of what already lands in the tree, not the volume of
-   sources.
+- `trusty_kb::okg::index_journal` — a second append-only journal per source,
+  `_sources/<id>.index.jsonl`, recording what reached the index and at what
+  content hash, plus `KbStore::okg_index_backlog`, the pure reconcile that diffs
+  the item ledger against it. The ledger is untouched: it remains the record of
+  KB-tree truth.
+- `trusty_agents::stores::index_feed` — the network half (`IndexFeed` seam,
+  `HttpIndexFeed` over `POST /indexes/{id}/index-file` and `/remove-file`) and
+  the drive loop. It lives in `trusty-agents` for the same reason the
+  Gmail/Drive fetchers do: `trusty-kb` stays deterministic and network-free.
+- `trusty_agents::stores::binding` — `okg://<agent>` finally RESOLVES, to
+  `<knowledge_dir>/<slug(agent)>`, and a push is refused when the binding's tree
+  is not the tree that was written. The naming coincidence #3892 named is now a
+  checked correspondence.
+
+### 7.2 The resulting contract (normative)
+
+Every connector and every extractor inherits this; none of them may weaken it.
+
+1. **The tree write is the durable record; the index push is not.** A ledger
+   line is never gated on a reachable daemon. A search daemon that is down,
+   slow, or 500ing cannot lose ingestion work or make it non-convergent. This is
+   the position §7.2.4 of the draft took and it is what shipped: the ledger is
+   KB-tree truth and is NOT overloaded with index state.
+2. **Success is never claimed falsely.** Every ingest reports `index.indexed`,
+   `index.removed`, and `index.pending` — the count of entities that are in the
+   tree and NOT searchable — plus a `reason` when nothing could be fed at all
+   (no binding, daemon undiscoverable, tree/index mismatch). "N entities
+   ingested" alone is no longer a complete answer, and no surface is allowed to
+   imply it is.
+3. **Push, then record.** A journal line is appended only after the daemon
+   acknowledges the write. A crash in between costs one redundant re-push (the
+   push is an upsert keyed by the entity file path), never a permanently
+   unindexed entity — the mirror of the engine's entity-before-ledger ordering.
+4. **Every run reconciles the whole backlog, not just what it ingested.** An
+   entity the engine skipped as unchanged but which never reached the index is
+   pushed by the next run. This is what makes a failed push self-healing rather
+   than permanent, and it is why index state cannot live in the ledger: the
+   ledger's own skip decision would hide it forever.
+5. **A changed entity is withdrawn before it is re-pushed**, and a tombstoned one
+   is withdrawn outright. trusty-search chunks by content, so re-pushing without
+   withdrawing would leave the old revision searchable alongside the new one.
+6. **An index that cannot serve the tree is refused, not fed.** trusty-search
+   post-filters every search result whose file path escapes the index root
+   (issues #64 / #541) — verified live: the push succeeds, the chunks are in the
+   corpus, and `search` returns nothing. So an OKG store's bound index is usable
+   only when its root CONTAINS the tree. The feed asks the daemon for the index
+   root first and, when it does not, reports that with the remediation rather
+   than manufacturing a fresh silent failure. This is also why (a) never has to
+   re-point an existing index root: a binding whose index cannot serve its tree
+   is a configuration error, and it is now a loud one. (For `cto-assistant`
+   specifically: the `bob-duetto/cto` index remains a separate raw-search layer;
+   making its OKG tree searchable means binding an index registered over that
+   tree.)
+7. **The backlog is visible where an operator looks.** `okg_sources` reports
+   per-source `index.synced` / `index.pending` and names the bound index;
+   `GET /api/agents/:name/stores` reports the resolved `tree_path` plus
+   `pending_index` / `synced_index`. "Ingested but not yet searchable" is a
+   reportable state, never an invisible one.
+8. **The importer remains neutral in shape.** The extraction layer is upstream of
+   `SourceItem`; the connector framework ends at the ingest engine. The index
+   push attaches at exactly one place — the ingest tool's tail, over the source's
+   backlog — so a new connector inherits it with no per-connector work.
 
 ---
 
@@ -594,8 +633,9 @@ no longer means editing the engine, and a crawl is scriptable.**
 **Phase 3 — Google surface completion.**
 `drive_content` routes base64 through extraction (§4.6); export-format selection
 for native Docs/Sheets/Slides; `gmail-attachments` connector. Net effect: **the
-data the user already has in Google lands in full fidelity.** *Gated on the #3892
-decision per §7.2.5.*
+data the user already has in Google lands in full fidelity.** *The #3892 gate is
+cleared — remediation (a) shipped, and every connector inherits the §7.2
+contract for free.*
 
 **Phase 4 — Assistant-driven crawl.**
 `okg_plan_import`; `okg_register` split; plan-level progress derived from
@@ -612,7 +652,7 @@ ticket.
 | # | Question | Recommendation |
 |---|---|---|
 | Q1 | Is `tagent okg` (§6.4) in the first wave or a follow-up? | Phase 2 — the first real backfill will want it immediately |
-| Q2 | #3892 remediation (a) or (b)? | Not decided here; §7.2.5 asks for it before phase 3 |
+| Q2 | ~~#3892 remediation (a) or (b)?~~ | **Answered 2026-07-25: (a).** Shipped; §7 records the contract |
 | Q3 | Do extracted-format entities need a distinguishing marker in frontmatter (`extracted_by: docx@2`)? | Yes — it is free, and it makes an extractor-version re-ingest auditable |
 | Q4 | PDF parser dependency choice (pure-Rust vs. bindings) | Pure-Rust, per §8.3; the specific crate is an implementation ticket |
 | Q5 | Should `xlsx` become a *structured* source (rows as entities) rather than a document? | No — that is the SQL/database gap (#3881 out-of-scope), tracked separately |
@@ -638,3 +678,4 @@ ticket.
 | Date | Change |
 |---|---|
 | 2026-07-25 | Initial draft — extraction layer, connector framework, assistant-driven crawl, #3892 position |
+| 2026-07-25 | §7 rewritten: #3892 settled as remediation (a); the open position becomes the shipped ingest→index contract |


### PR DESCRIPTION
## The gap

`okg_ingest_*` (#3883) wrote entities into the KB tree
(`~/.trusty-agents/knowledge/<agent>/`); the agent's `[[stores]]`-bound
trusty-search index (#3878) was built over a **different** root; and
`okg://<agent>` was an opaque label nothing ever resolved to a path. Net effect:
a truthful "N entities ingested" followed by `vector_search` finding nothing,
with no error on either side.

**Remediation (a), owner-approved: ingestion also feeds the bound index.** The
operator's index-root choice stands — nothing is re-pointed (that was option
(b), not taken).

## Design

| Layer | Where | Why there |
|---|---|---|
| *What is owed to the index* | `trusty_kb::okg::index_journal` | pure, deterministic, unit-testable with no daemon |
| *Pushing it* | `trusty_agents::stores::index_feed` | it is a NETWORK call — same split as the Gmail/Drive fetchers, so `trusty-kb` stays network-free |
| *Which index* | `trusty_agents::stores::binding` | `okg://<agent>` → `<knowledge_dir>/<slug(agent)>`, checked against the tree that was written |

A **second append-only journal** per source (`_sources/<id>.index.jsonl`)
records what reached the index and at what content hash. The item ledger is
deliberately **not** overloaded with index state (DOC-55 §7.2.4): gating a
ledger line on a reachable daemon would make ingestion non-convergent, and the
ledger's own skip decision would hide an unindexed entity forever. Staleness is
decided by the entity file's content hash — a `volatile` item's fingerprint
carries no information — short-circuited by a `(size, mtime)` check so a settled
tree costs one `stat` per entity.

## The contract (settled here, recorded in DOC-55 §7)

1. **The tree write is the durable record.** A search daemon that is down, slow,
   or 500ing cannot lose ingestion work.
2. **Success is never claimed falsely.** Every run reports `indexed` / `removed`
   / `pending` (in the tree, NOT searchable) plus a `reason` when nothing could
   be fed.
3. **Push, then record.** The journal line is appended only after the daemon
   acknowledges. A crash in between costs one redundant re-push (upsert by path),
   never a permanently-unindexed entity — the mirror of the engine's
   entity-before-ledger ordering.
4. **Every run reconciles the whole backlog**, not just what it ingested, so a
   failed push is self-healing.
5. **Changed → withdraw, then re-push. Tombstoned → withdraw.** trusty-search
   chunks by content, so re-pushing alone would leave the old revision searchable.
6. **An index that cannot serve the tree is refused, not fed** (see below).

## The live-verification finding

trusty-search **post-filters every search result whose path escapes the index
root** (issues #64 / #541). Verified live: pushing the tree into an index rooted
elsewhere stored the chunks (`chunk_count: 4`) and `search` returned `[]` with
`stale_index_root: true`. Shipping the naive push would have manufactured a NEW
silent failure — `indexed: 2, pending: 0` over a corpus nothing can return.

So the feed reads the index's root first and refuses with the remediation:

```
"reason": "index `okg-scratch-3892` is rooted at /Users/masa/okg-scratch-3892-index-root,
 which does not contain this tree (/Users/masa/.trusty-agents/knowledge/okg-scratch-3892).
 trusty-search drops any search result whose path falls outside the index root, so entities
 pushed there would be stored and never returned. Bind a search index registered over the
 tree itself."
```

This is also why (a) never needs to re-point an existing root: a binding whose
index cannot serve its tree is a *configuration error*, and it is now a loud one.
(For `cto-assistant`: the 200,090-chunk `bob-duetto/cto` index stays a separate
raw-search layer; making its OKG tree searchable means binding an index
registered over that tree.)

## Live evidence (scratch agent + real daemons, cleaned up afterwards)

Correctly-rooted index, re-running the SAME ingest — the engine skips everything,
and only the index backlog drains (the reconcile, live):

```
ingest : {'scanned': 2, 'ingested': 0, 'skipped': 2, 'tombstoned': 0}
index  : {'index': 'okg-scratch-3892', 'indexed': 2, 'pending': 0, 'removed': 0}
```

The round trip — a paraphrase query with almost no shared literal terms:

```
POST /indexes/okg-scratch-3892/search
{"text":"where does the Perth team plan its scheduled measurement runs","top_k":3,"stage":"semantic"}

meta: {"stale_index_root": false, ...}
file : /Users/masa/.trusty-agents/knowledge/okg-scratch-3892/notes/quokka-briefing.md  score: 0.0016
text : # Quokka Briefing / The zephyrine quokka protocol governs how the Perth field office
       schedules its Tuesday telemetry sweeps. Codeword: MARSUPIAL-LANTERN-77
results: 3
```

Tombstone leg — delete the source file, re-run:

```
ingest : {'scanned': 1, 'ingested': 0, 'skipped': 1, 'tombstoned': 1}
index  : {'indexed': 0, 'removed': 1, 'pending': 0, 'synced': 1}

POST .../search {"text":"Fremantle ledger reconciliation"}  ->  results: 0
```

Status surface (`okg_sources`, live):

```json
"bound_index": { "agent": "okg-scratch-3892", "index": "okg-scratch-3892",
                 "store": "okg-scratch-3892-kb", "pending": 0 },
"sources": [ { "index": { "synced": 2, "pending": 0 },
               "watermark": { "items": 1, "tombstoned": 1 } } ]
```

Scratch agent, tree, corpus and index removed afterwards; the daemon is back to
its original 65 indexes.

## Status surfaces (the failure #3892 is about, made visible)

- `okg_sources` — per-source `index.synced` / `index.pending`, plus the resolved
  `bound_index` (or the reason there is none). Offline-safe: no daemon call.
- `GET /api/agents/:name/stores` — adds `tree_path`, `pending_index`,
  `synced_index`, so a store can no longer read CONNECTED while holding none of
  its tree's content.

## Not touched

`DocStorePolicy` confinement, the #3942 untrusted-data envelope, and index-root
configuration.

## Gates

```
cargo test -p trusty-kb      -> 92 + 8 + 3 passed; 0 failed
cargo test -p trusty-agents  -> 2539 passed; 0 failed; 12 ignored (+ 9 suites green)
cargo clippy -p trusty-kb -p trusty-agents --all-targets -- -D warnings  -> clean
cargo fmt --check            -> clean
scripts/check_line_cap.sh    -> 8 allowlisted, 0 violations
scripts/check_sld.sh         -> 0 errors, 0 warnings
```

New tests: crash-convergence (failed push stays pending, heals on a later run),
upsert-not-duplicate on re-run, replace-on-change (withdraw first),
remove-on-tombstone, per-entity failure isolation, wrong-root refusal, the HTTP
route/body shape against a mock daemon, `okg://` resolution + binding mismatch,
and the pending-index reporting on both status surfaces. The daemon call sits
behind the `IndexFeed` seam, so all of it runs with no network.

Closes #3892
Refs #3883, #3878, epic #3904

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
