### PR TITLE
fix(trusty-search): unresolvable colocated storage path must fail loudly, not report a silent 0-chunk success

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,6 +9,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **A legacy/colocated index whose storage path could not be resolved at
+  warm-boot no longer silently restores as a healthy 0-chunk store (issue
+  #2847).** `build_indexer_from_entry` / `build_store_for_entry` previously
+  only logged a WARN when `corpus_redb_path_for_entry` / `hnsw_path_for_entry`
+  failed (e.g. a colocated `.trusty-search` shadow path that could not be
+  created — missing/broken symlink, permission denied) and otherwise
+  proceeded as if the index had simply never been populated —
+  `corpus_open_failed` stayed `false` and `hnsw_load_failed` stayed `false`,
+  so the daemon reported the index as healthy while it served zero results.
+  Both resolution failures now flag `corpus_open_failed` / `hnsw_load_failed`
+  so the existing warm-boot stage classifier reports the index as degraded
+  instead — a genuinely empty, never-indexed index is unaffected and still
+  reports as pending, not failed.
 - **Warm-boot's colocated-root discovery scan now honors `--no-auto-discover`
   / `TRUSTY_NO_AUTO_DISCOVER` (issue #3929).** Previously the flag only gated
   the unrelated `auto_discover_and_index()` git-repo scan; `restore_indexes`

--- a/crates/trusty-search/src/service/persistence_loader/mod.rs
+++ b/crates/trusty-search/src/service/persistence_loader/mod.rs
@@ -113,7 +113,9 @@ pub async fn build_indexer_with_persisted_state(
 /// Test: `colocated_create_path_wires_corpus_store_for_schema_version` and
 /// `colocated_create_handler_path_survives_simulated_reload` cover the
 /// colocated path; `legacy_non_colocated_path_does_not_panic` covers the
-/// legacy path.
+/// legacy path; `build_indexer_from_entry_flags_corpus_open_failed_when_storage_path_unresolvable`
+/// and `build_indexer_from_entry_does_not_flag_legitimately_empty_index_as_failed`
+/// cover the #2847 silent-empty-store regression.
 pub async fn build_indexer_from_entry(
     entry: &PersistedIndex,
     embedder: &Arc<dyn Embedder>,
@@ -161,7 +163,25 @@ pub async fn build_indexer_from_entry(
                 }
             }
         }
-        Err(e) => tracing::warn!("cannot resolve redb corpus path for '{index_id}': {e}"),
+        Err(e) => {
+            // Issue #2847: an unresolvable storage path (e.g. a colocated
+            // shadow dir that cannot be created — missing/broken symlink,
+            // permission denied) is indistinguishable in effect from a
+            // failed open: no corpus store gets wired, `restore_corpus_for_entry`
+            // below will report 0 chunks, and — before this fix — nothing
+            // told the caller. Treat it the same as the open-failure branch
+            // above so the stage-classifier fails ALL stages instead of
+            // reporting `corpus_open_failed=false` while the index silently
+            // serves 0 chunks (the exact production outage in #2847).
+            tracing::error!(
+                "warm-boot: cannot resolve redb corpus path for '{index_id}': {e}. The \
+                 durable corpus store location could not be determined — the index will \
+                 restore with 0 chunks even though a real corpus may exist on disk. \
+                 Marking corpus_open_failed so /health reports this as degraded instead \
+                 of silently 'ok'. (refs #2847, #1158)"
+            );
+            indexer.corpus_open_failed = true;
+        }
     }
 
     restore_corpus_for_entry(&mut indexer, entry).await;
@@ -292,11 +312,15 @@ fn stamp_if_unversioned_for_entry(entry: &PersistedIndex) {
 /// Why: uses `hnsw_path_for_entry` so colocated indexes read from the project's
 /// `.trusty-search/hnsw.usearch`; propagates OOM as `Err` (closes #954).
 /// What: resolves path, checks for snapshot, loads (or falls back), returns
-/// `(store, load_failed)`. `load_failed` is `true` only when a snapshot file
-/// existed but could not be restored (issue #2922) — never for the ordinary
-/// "no snapshot yet" first-boot case — so callers can distinguish "never
-/// indexed" from "corrupt/truncated on-disk state" when deriving
-/// `hnsw_snapshot_ready` for `/health`.
+/// `(store, load_failed)`. `load_failed` is `true` when a snapshot file
+/// existed but could not be restored (issue #2922), OR when the storage path
+/// itself could not be resolved at all (issue #2847 — e.g. a colocated
+/// shadow dir that cannot be created) — never for the ordinary "no snapshot
+/// yet" first-boot case, where the path resolves cleanly and simply has
+/// nothing at it. This lets callers distinguish "never indexed" (legitimately
+/// empty) from "corrupt/truncated on-disk state" or "storage location
+/// unresolvable" (both real failures) when deriving `hnsw_snapshot_ready`
+/// for `/health`.
 /// Test: warm-boot integration tests (legacy) + colocated integration tests;
 /// `tests::build_store_for_entry_flags_load_failure_on_corrupt_snapshot`.
 async fn build_store_for_entry(
@@ -307,8 +331,21 @@ async fn build_store_for_entry(
     let path = match persistence::hnsw_path_for_entry(entry) {
         Ok(p) => p,
         Err(e) => {
-            tracing::warn!("cannot resolve hnsw path for '{index_id}': {e}");
-            return Ok((fresh_store(dim)?, false));
+            // Issue #2847: a path-resolution failure (e.g. a colocated
+            // shadow dir that cannot be created) is NOT the ordinary
+            // "never indexed" first-boot case — we can't even determine
+            // whether a snapshot exists. Flag it as `load_failed=true` (not
+            // `false`) so `hnsw_snapshot_ready` — and therefore the
+            // warm-boot stage classifier / `/health` — never reports
+            // semantic search as ready off the back of an unresolvable
+            // store, mirroring the corrupt-snapshot handling below.
+            tracing::warn!(
+                "warm-boot: cannot resolve hnsw path for '{index_id}': {e} — starting fresh \
+                 (semantic search will report not-ready for '{index_id}' until reindexed; \
+                 treated as a load failure, not first-boot, since the storage location \
+                 itself could not be determined, refs #2847, #2922)"
+            );
+            return Ok((fresh_store(dim)?, true));
         }
     };
 

--- a/crates/trusty-search/src/service/persistence_loader/tests.rs
+++ b/crates/trusty-search/src/service/persistence_loader/tests.rs
@@ -436,6 +436,179 @@ async fn warm_boot_shared_root_double_open_is_prevented_by_dedup() {
     );
 }
 
+// ── Issue #2847 regression: unresolvable colocated shadow path must not ───
+// ── silently report success with a 0-chunk store ───────────────────────────
+
+/// Block colocated storage-path resolution for `root` by placing a regular
+/// FILE at the exact `<root>/.trusty-search` location.
+///
+/// Why: `colocated_storage_dir` calls `std::fs::create_dir_all` on that path
+/// every time it resolves a colocated path (`hnsw_path_for_entry`,
+/// `corpus_redb_path_for_entry`, `schema_version_path_for_entry`). When a
+/// non-directory entry already occupies that path, `create_dir_all` fails
+/// (`AlreadyExists`/`NotADirectory` depending on platform) and every one of
+/// those resolvers returns `Err` — the same observable failure mode as the
+/// production report's dangling `<repos>/.trusty-search` symlink pointing at
+/// a missing target (a broken symlink also occupies the dirent without being
+/// a usable directory). This is a portable, deterministic stand-in that does
+/// not depend on symlink semantics.
+/// What: writes an ordinary file at `<root>/.trusty-search`.
+/// Test: used by the #2847 regression tests below.
+fn block_colocated_storage_path(root: &Path) {
+    std::fs::write(root.join(".trusty-search"), b"not a directory").unwrap();
+}
+
+/// THE failing-test-first regression for issue #2847: reproduces the
+/// production outage where a legacy/colocated index's shadow storage path
+/// could not be resolved at warm-boot, and the loader silently restored a
+/// 0-chunk store while reporting `corpus_open_failed=false` — `/health`
+/// then reported `status: ok` while the index served nothing.
+///
+/// Why: before the fix, `build_indexer_from_entry`'s `Err` arm for
+/// `corpus_redb_path_for_entry` only logged a WARN and left
+/// `corpus_open_failed` at its default `false` — the exact silent-failure
+/// mechanism from the bug report. This test asserts the CORRECT behavior
+/// (`corpus_open_failed == true`, 0 chunks); against pre-fix code it fails
+/// with `corpus_open_failed == false`, proving the bug.
+/// What: builds a colocated entry whose `.trusty-search` path is blocked by
+/// [`block_colocated_storage_path`], calls `build_indexer_from_entry`, and
+/// asserts both that the corpus reports 0 chunks AND that the failure is
+/// surfaced via `corpus_open_failed` rather than silently swallowed.
+/// Test: this IS the test.
+#[tokio::test]
+async fn build_indexer_from_entry_flags_corpus_open_failed_when_storage_path_unresolvable() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+    block_colocated_storage_path(&root);
+    let embedder = mock_embedder();
+
+    let entry = PersistedIndex {
+        id: "test-idx-2847-corpus-unresolvable".to_string(),
+        root_path: root.clone(),
+        colocated: true,
+        ..Default::default()
+    };
+
+    let indexer = build_indexer_from_entry(&entry, &embedder).await.unwrap();
+
+    // The silent-empty symptom: no corpus store got wired, so the chunk
+    // count is 0 — this alone is legitimate for a fresh index, which is
+    // exactly why the flag below is the load-bearing assertion.
+    assert!(
+        !indexer.has_corpus_store(),
+        "#2847: an unresolvable storage path must not silently produce a \
+         wired-but-empty corpus store"
+    );
+    let chunk_count = indexer
+        .corpus_store()
+        .map(|c| c.chunk_count().unwrap_or(0))
+        .unwrap_or(0);
+    assert_eq!(chunk_count, 0, "#2847: silent-empty symptom — 0 chunks");
+
+    // The actual bug: this failure must be OBSERVABLE, not silent.
+    assert!(
+        indexer.corpus_open_failed,
+        "#2847: a colocated storage path that cannot be resolved must set \
+         corpus_open_failed=true so the warm-boot stage classifier (and, via \
+         the existing corpus_open_failed -> Failed aggregation, /health) \
+         reports this index as degraded instead of falsely healthy"
+    );
+}
+
+/// Companion #2847 regression for the HNSW half of the same defect: the
+/// vector-store loader must likewise flag `hnsw_load_failed=true` (not
+/// `false`) when the storage path itself cannot be resolved, so semantic
+/// search readiness is never derived from an unresolvable store.
+///
+/// Why: mirrors `build_store_for_entry_flags_load_failure_on_corrupt_snapshot`
+/// (issue #2922) but for path-resolution failure rather than on-disk
+/// corruption — before the fix, `build_store_for_entry`'s path-resolution
+/// `Err` arm returned `load_failed=false`, indistinguishable from ordinary
+/// first-boot.
+/// What: builds a colocated entry with a blocked `.trusty-search` path,
+/// calls `build_store_for_entry` directly, and asserts `load_failed`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn build_store_for_entry_flags_load_failure_when_storage_path_unresolvable() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+    block_colocated_storage_path(&root);
+    let embedder = mock_embedder();
+    let dim = embedder.dimension();
+
+    let entry = PersistedIndex {
+        id: "test-idx-2847-hnsw-unresolvable".to_string(),
+        root_path: root.clone(),
+        colocated: true,
+        ..Default::default()
+    };
+
+    let (store, load_failed): (Arc<dyn VectorStore>, bool) =
+        build_store_for_entry(&entry, dim).await.unwrap();
+    assert_eq!(
+        store.len().await.unwrap(),
+        0,
+        "#2847: an unresolvable hnsw path must fall back to an empty store"
+    );
+    assert!(
+        load_failed,
+        "#2847: an unresolvable hnsw storage path must set load_failed=true, \
+         not be treated as ordinary first-boot"
+    );
+}
+
+/// The required counterpart: a genuinely first-boot / never-populated
+/// colocated index (storage path resolves fine, nothing has been indexed
+/// yet) must NOT be reported as failed by either signal. This is the
+/// "legitimately empty" case the #2847 fix must not over-report.
+///
+/// Why: the fix must distinguish "empty because the store could not be
+/// resolved" (#2847 — now `corpus_open_failed`/`hnsw_load_failed = true`)
+/// from "empty because nothing was indexed yet" (ordinary first boot,
+/// resolvable path, no content). Both produce `chunk_count == 0`, so the
+/// distinguishing signal has to be these flags, not the chunk count itself.
+/// What: builds a colocated entry at a normal (unblocked) fresh tmp dir and
+/// asserts both flags stay `false` despite 0 chunks / no snapshot.
+/// Test: this IS the test.
+#[tokio::test]
+async fn build_indexer_from_entry_does_not_flag_legitimately_empty_index_as_failed() {
+    let tmp = tempdir().unwrap();
+    let root = tmp.path().to_path_buf();
+    let embedder = mock_embedder();
+
+    let entry = PersistedIndex {
+        id: "test-idx-2847-legit-empty".to_string(),
+        root_path: root.clone(),
+        colocated: true,
+        ..Default::default()
+    };
+
+    let indexer = build_indexer_from_entry(&entry, &embedder).await.unwrap();
+
+    assert!(
+        indexer.has_corpus_store(),
+        "#2847: a resolvable colocated path must still wire a (empty) corpus store"
+    );
+    let chunk_count = indexer
+        .corpus_store()
+        .expect("corpus store must be set")
+        .chunk_count()
+        .expect("chunk_count must succeed");
+    assert_eq!(chunk_count, 0, "sanity: nothing has been indexed yet");
+
+    assert!(
+        !indexer.corpus_open_failed,
+        "#2847: a legitimately empty (never-indexed) colocated index must \
+         NOT be flagged corpus_open_failed — that would over-report failure \
+         for the ordinary first-boot case"
+    );
+    assert!(
+        !indexer.hnsw_load_failed,
+        "#2847: a legitimately empty (never-indexed) colocated index must \
+         NOT be flagged hnsw_load_failed either"
+    );
+}
+
 /// Why: the fix must not merge indexes that live in different redb files.
 /// Two colocated indexes at distinct roots must open independent corpora
 /// simultaneously with zero `DatabaseAlreadyOpen`, and dedup must keep both.

--- a/crates/trusty-search/src/service/persistence_loader/tests.rs
+++ b/crates/trusty-search/src/service/persistence_loader/tests.rs
@@ -557,6 +557,127 @@ async fn build_store_for_entry_flags_load_failure_when_storage_path_unresolvable
     );
 }
 
+// ── Issue #2847 round-2 critic finding: the LEGACY (non-colocated) path ────
+// ── named by the issue/PR title/CHANGELOG had no failure-forcing test ─────
+
+/// THE failing-test-first legacy-path counterpart to
+/// `build_indexer_from_entry_flags_corpus_open_failed_when_storage_path_unresolvable`.
+///
+/// Why: the code fix is symmetric across both `hnsw_path_for_entry` /
+/// `corpus_redb_path_for_entry` dispatch targets — colocated
+/// (`colocated_storage_dir`) and legacy/non-colocated (`index_data_dir` ->
+/// `data_dir()`, `service/persistence.rs:373-411`) — but only the colocated
+/// `Err` arm had a regression test proving it. The legacy path is the one
+/// issue #2847, this PR's title, and its CHANGELOG entry name explicitly, so
+/// it needs its own failure-forcing coverage, not just the symmetric-code
+/// argument.
+/// What: points `TRUSTY_DATA_DIR` at a path whose PARENT is a regular file,
+/// so `data_dir()`'s own `create_dir_all` (persistence.rs:381) fails —
+/// exactly the technique already proven in
+/// `server::tests_index_config::patch_persist_failure_returns_500` — which
+/// makes every legacy path resolver built on `data_dir()` (`index_data_dir`,
+/// `hnsw_path`, `corpus_redb_path`) return `Err`. Builds a `colocated: false`
+/// entry under that override, calls `build_indexer_from_entry`, and asserts
+/// `corpus_open_failed == true`. Against pre-fix code this fails with
+/// `corpus_open_failed == false` — reproducing the issue's headline path.
+/// `#[serial_test::serial]` (this crate's default unnamed group, shared by
+/// every other `TRUSTY_DATA_DIR`-mutating test in this binary — see
+/// `server::tests_components`'s module doc) plus removing the env var
+/// immediately after `await`ing the call (before any assertion can panic)
+/// avoids leaking the override into concurrently-running tests.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn build_indexer_from_entry_flags_corpus_open_failed_when_legacy_storage_path_unresolvable() {
+    let tmp = tempdir().unwrap();
+    let blocker = tmp.path().join("not-a-dir");
+    std::fs::write(&blocker, b"x").unwrap();
+    let bad_data_dir = blocker.join("data"); // parent is a file -> mkdir fails
+                                             // SAFETY: test-only; #[serial_test::serial] (default group) excludes
+                                             // every other TRUSTY_DATA_DIR-mutating test in this binary from running
+                                             // concurrently with this one.
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", &bad_data_dir) };
+
+    let embedder = mock_embedder();
+    let entry = PersistedIndex {
+        id: "test-idx-2847-legacy-corpus-unresolvable".to_string(),
+        root_path: tmp.path().to_path_buf(),
+        colocated: false,
+        ..Default::default()
+    };
+    let result = build_indexer_from_entry(&entry, &embedder).await;
+
+    // Remove the override immediately after the call completes and before
+    // any assertion below can panic — matches this crate's established
+    // TRUSTY_DATA_DIR-test convention (e.g. `daemon_tests::
+    // daemon_dir_respects_trusty_data_dir_env_var`) so a failing assertion
+    // never leaves the process env var pointed at a blocked path for later
+    // tests.
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+
+    let indexer = result.expect("build_indexer_from_entry must not hard-fail on Err path");
+    assert!(
+        !indexer.has_corpus_store(),
+        "#2847 (legacy): an unresolvable data dir must not silently produce a \
+         wired-but-empty corpus store"
+    );
+    assert!(
+        indexer.corpus_open_failed,
+        "#2847 (legacy): a legacy storage path that cannot be resolved \
+         (TRUSTY_DATA_DIR itself unresolvable) must set corpus_open_failed=true \
+         — this is the headline path named by the issue, the PR title, and the \
+         CHANGELOG entry"
+    );
+}
+
+/// Legacy-path counterpart to
+/// `build_store_for_entry_flags_load_failure_when_storage_path_unresolvable`
+/// for the HNSW half of the same #2847 defect (round-2 critic finding).
+///
+/// Why / What: see
+/// `build_indexer_from_entry_flags_corpus_open_failed_when_legacy_storage_path_unresolvable`
+/// for the blocking technique and serialization rationale — identical setup,
+/// exercised against `build_store_for_entry` directly (mirroring how the
+/// colocated HNSW counterpart calls it) and asserting `load_failed == true`.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn build_store_for_entry_flags_load_failure_when_legacy_storage_path_unresolvable() {
+    let tmp = tempdir().unwrap();
+    let blocker = tmp.path().join("not-a-dir");
+    std::fs::write(&blocker, b"x").unwrap();
+    let bad_data_dir = blocker.join("data");
+    // SAFETY: test-only; see the corpus counterpart above.
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", &bad_data_dir) };
+
+    let embedder = mock_embedder();
+    let dim = embedder.dimension();
+    let entry = PersistedIndex {
+        id: "test-idx-2847-legacy-hnsw-unresolvable".to_string(),
+        root_path: tmp.path().to_path_buf(),
+        colocated: false,
+        ..Default::default()
+    };
+    let result = build_store_for_entry(&entry, dim).await;
+
+    // Remove immediately after the call, before any assertion can panic —
+    // see the corpus counterpart above for the rationale.
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+
+    let (store, load_failed): (Arc<dyn VectorStore>, bool) =
+        result.expect("build_store_for_entry must not hard-fail on Err path");
+    assert_eq!(
+        store.len().await.unwrap(),
+        0,
+        "#2847 (legacy): an unresolvable hnsw path must fall back to an empty store"
+    );
+    assert!(
+        load_failed,
+        "#2847 (legacy): an unresolvable legacy hnsw storage path must set \
+         load_failed=true, not be treated as ordinary first-boot"
+    );
+}
+
 /// The required counterpart: a genuinely first-boot / never-populated
 /// colocated index (storage path resolves fine, nothing has been indexed
 /// yet) must NOT be reported as failed by either signal. This is the


### PR DESCRIPTION
## Summary

- A legacy/colocated index whose `.trusty-search` shadow storage path could not be resolved at warm-boot (e.g. a missing/broken symlink, permission denied) previously fell through to a bare `WARN` log while `corpus_open_failed` and `hnsw_load_failed` stayed at their default `false`. The daemon then restored the index with 0 chunks while reporting it as successfully restored, so `/health` said `status: ok` while the index served zero results for every query — a full silent outage (issue #2847, production incident 2026-07-16).
- `build_indexer_from_entry`'s `corpus_redb_path_for_entry` `Err` arm and `build_store_for_entry`'s `hnsw_path_for_entry` `Err` arm now set `corpus_open_failed` / `hnsw_load_failed = true` instead of silently leaving them `false`.
- A genuinely empty, never-indexed colocated index (path resolves fine, nothing has been written yet) is unaffected — it still reports as pending, not failed. The two cases are distinguished by whether path resolution itself succeeded (`Ok`/`Err`), not by chunk count, since both produce `chunk_count == 0`.

## Root cause (file:line)

`crates/trusty-search/src/service/persistence_loader/mod.rs`:
- `build_indexer_from_entry`, the `Err` arm of the `corpus_redb_path_for_entry` match (was line 164, a bare `tracing::warn!` with no flag set) — this is the primary generator of the exact "chunks=0 / `corpus_open_failed=false`" signal quoted in the issue, since `restore_corpus_for_entry` finds no wired corpus store and reports 0 chunks.
- `build_store_for_entry` (originally cited in the task, lines ~302-330), the `Err` arm of the `hnsw_path_for_entry` match — same defect pattern for the HNSW vector store: previously returned `load_failed=false`, identical to the ordinary "never indexed" first-boot case.

Both call `persistence::colocated_storage_dir`, which runs `std::fs::create_dir_all` on `<root_path>/.trusty-search` on every resolution; a dangling symlink or permission failure at that path makes `create_dir_all` return `Err`, which the pre-fix code treated as equivalent to "nothing to load" instead of "storage could not be resolved."

## Design choice: which signal, and does it reach `/health`?

`corpus_open_failed` and `hnsw_load_failed` are the two flags this repo *already* uses for exactly this class of problem — a persisted-but-unwireable store, distinct from "never indexed." They're already piped into the existing warm-boot stage classifier (`core/indexer/mod.rs`, `service/warm_boot/stages.rs`):
- `corpus_open_failed == true` fails **all three** stages (lexical, semantic, graph) — the strongest existing signal, previously only set on an open failure with a resolved path. Reusing it for a resolution failure is a one-line, in-family fix and it already flows through the stage classifier into `/health`'s `overall_status` (via the `warm_boot_degraded` aggregation from #3706 / `b9ce823e`) without touching `health.rs`.
- `hnsw_load_failed == true` folds into `hnsw_snapshot_ready = false`, so semantic search is never reported `Ready` off an unresolvable store.

I did not introduce a new, distinct "missing-shadow" signal — the existing flags already mean "we don't have a trustworthy loaded store," which is precisely true here, and reusing them means the fix is entirely additive to the existing aggregation instead of requiring new wiring into `/health` (out of scope per the task).

## Distinguishing "legitimately empty" from "unresolvable"

Representable and tested: whether `hnsw_path_for_entry` / `corpus_redb_path_for_entry` return `Ok` (path resolves; if nothing has been written yet, that's ordinary first-boot, flags stay `false`) or `Err` (storage location itself could not be determined, flags become `true`). Chunk count alone cannot distinguish the two cases (both are 0), so the flags — not chunk count — carry the distinction.

## Tests

Added to `crates/trusty-search/src/service/persistence_loader/tests.rs`:
- `build_indexer_from_entry_flags_corpus_open_failed_when_storage_path_unresolvable` — reproduces the silent-empty case (blocks `.trusty-search` path resolution with a non-directory file), asserts `corpus_open_failed == true` + 0 chunks. **Fails against pre-fix code** (`corpus_open_failed == false`), passes post-fix.
- `build_store_for_entry_flags_load_failure_when_storage_path_unresolvable` — same reproduction for the HNSW path, asserts `load_failed == true`. Fails pre-fix, passes post-fix.
- `build_indexer_from_entry_does_not_flag_legitimately_empty_index_as_failed` — a normal fresh colocated index (unblocked path, nothing indexed) asserts both flags stay `false`. Passes both before and after (guards against over-reporting).

## Scope

Touches only `persistence_loader/mod.rs`, `persistence_loader/tests.rs`, and `CHANGELOG.md`. Does not touch `health.rs`, `commands/start/*`, `warm_boot/*`, `memguard.rs`, or `allowlist/mod.rs`.

## Quality gate (raw output, run from `~/trusty-mpm-projects/bobmatnyc/trusty-tools-worktrees/wt-2847-legacy-store-silent-empty`, outside `/tmp`/`/private/tmp`/`$TMPDIR` to avoid the known #3955 allowlist artifact)

- `cargo test -p trusty-search` (no `--lib`, full integration surface): **0 failed** across every binary — lib (1328 passed, 1 ignored), cli (319 passed), and every integration test file. No `#3955` or `#3954` artifacts observed (this worktree is outside the sensitive-path prefixes that trigger #3955; #3954 did not reproduce either).
- `cargo clippy -p trusty-search --all-targets -- -D warnings`: clean, exit 0.
- `cargo fmt -p trusty-search --check`: clean, exit 0.

Closes #2847

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools