### PR TITLE
fix(trusty-mpm): scan .claude/worktrees for orphans + stop .gitignore fallthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@
 .mcp.json
 .trusty-search
 
+# trusty-mpm shared-base-checkout clone + per-session worktrees (machine-local
+# session-manager state, never a deliverable — issue #3972)
+.base/
+
 # Ignore all of .claude/ and .claude-mpm/ by default, then re-include what we want
 .claude/
 .claude-mpm/*
@@ -26,6 +30,24 @@
 # Exclude agent runtime-state dot-files (not source-controlled)
 .claude/agents/.dependency_cache
 .claude/agents/.mpm_deployment_state
+
+# Claude Code's native `isolation: "worktree"` agent worktrees are
+# machine-local, not a deliverable (issue #3972). `.claude/` is broadly
+# re-included just above for the paths we DO want tracked (settings.json,
+# agents/) — worktrees/ must be explicitly re-excluded here or it falls
+# through as untracked noise, since `!.claude/` un-ignores the whole
+# directory and only the listed subpaths are re-added.
+.claude/worktrees/
+
+# trusty-mpm session/worktree runtime state is machine-local (issue #3972),
+# except the one intentionally-tracked file. Uses `.trusty-mpm/*` (ignore
+# immediate children only), NOT `.trusty-mpm/` + `!.trusty-mpm/` — the latter
+# un-ignores the directory itself and reproduces the exact `.claude/` bug
+# this issue is about (only the explicitly re-included children survive;
+# every other child falls through as untracked). Mirrors the existing
+# `.claude-mpm/*` + re-include pattern above.
+.trusty-mpm/*
+!.trusty-mpm/INSTRUCTIONS.md
 
 # Re-include tracked files from .claude-mpm/
 !.claude-mpm/INSTRUCTIONS.md

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -22,7 +22,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Claude-Code-created worktree (which never carries trusty-mpm's
   `.trusty-mpm-worktree` sentinel) as owner-unknown, so newly-discovered
   candidates are surfaced for `tm doctor`/`--dry-run` review, never
-  auto-deleted.
+  auto-deleted. Follow-up review found the initial fix anchored only at
+  `<repo>/.claude/worktrees`, missing two sibling locations confirmed live
+  with real entries: `<repo>/.base/.claude/worktrees` (agent worktrees
+  created directly inside the bare `.base` clone checkout) and
+  `<repo>/.base/.worktrees/<session-id>/.claude/worktrees` (agent worktrees
+  nested inside a per-session checkout) — both are now scanned too.
 
 - **A toggle being on was treated as proof of a successful MCP-server pin,
   even when the force-overwrite write itself failed** (closes

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`prune-worktrees` never scanned `.claude/worktrees`, so Claude Code's
+  native agent worktrees were never reclaimed** (closes
+  [#3971](https://github.com/bobmatnyc/trusty-tools/issues/3971)):
+  `find_orphaned_worktrees` walked only the two trusty-mpm-owned shapes
+  (`.worktrees/<name>`, `.base/.worktrees/<session-id>`) and never
+  `.claude/worktrees/<name>` — the path Claude Code's native
+  `isolation: "worktree"` mechanism uses — so those worktrees accumulated
+  silently, invisible to `tm session prune-worktrees` and `tm doctor`. Now
+  scanned as a third shape via the same `scan_worktree_shape` walk; the
+  existing #3649 ownership-sentinel gate already treats a
+  Claude-Code-created worktree (which never carries trusty-mpm's
+  `.trusty-mpm-worktree` sentinel) as owner-unknown, so newly-discovered
+  candidates are surfaced for `tm doctor`/`--dry-run` review, never
+  auto-deleted.
+
 - **A toggle being on was treated as proof of a successful MCP-server pin,
   even when the force-overwrite write itself failed** (closes
   [#3950](https://github.com/bobmatnyc/trusty-tools/issues/3950), fifth

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -371,19 +371,28 @@ fn matches_filter(record: &SessionRecord, filter: PruneFilter) -> bool {
 /// walk logic can be tested independently of the full session-manager setup,
 /// and reused by the `doctor.rs` worktree health probe without duplicating the
 /// filesystem walk.
-/// What: walks BOTH known worktree-store shapes (#3649) under each
-/// `<repos_root>/<owner>/<repo>/`: the in-project shape
-/// (`.worktrees/<name>`, added #1840) AND the clone-based shared-base-checkout
-/// shape (`.base/.worktrees/<session-id>`, added #3649 — this walk previously
-/// covered ONLY the in-project shape, so every `.base/.worktrees` dir was
-/// invisible to both this scan and the doctor/dry-run surfaces built on it).
-/// Any leaf directory whose canonicalized path is NOT in `active_set` is
-/// collected as an orphan. Using a `HashSet` with canonicalized paths avoids
-/// O(n×m) linear scan and correctly handles symlinked workspace paths. A
+/// What: walks all THREE known worktree-store shapes under each
+/// `<repos_root>/<owner>/<repo>/`: the in-project shape (`.worktrees/<name>`,
+/// added #1840), the clone-based shared-base-checkout shape
+/// (`.base/.worktrees/<session-id>`, added #3649), and Claude Code's native
+/// `isolation: "worktree"` agent shape (`.claude/worktrees/<name>`, added
+/// #3971 — this walk previously covered only the first two, so every
+/// `.claude/worktrees` dir was invisible to both this scan and the
+/// doctor/dry-run surfaces built on it). Any leaf directory whose
+/// canonicalized path is NOT in `active_set` is collected as an orphan
+/// CANDIDATE — the caller (`prune_orphaned_worktrees`) still applies the
+/// #3649 ownership-sentinel gate before ever deleting anything, so a
+/// candidate discovered here is never auto-deleted unless it also carries a
+/// trusty-mpm ownership sentinel naming a provably-ownerless owner (see that
+/// function's doc). Using a `HashSet` with canonicalized paths avoids O(n×m)
+/// linear scan and correctly handles symlinked workspace paths. A
 /// non-existent or unreadable `repos_root` returns an empty vec.
 /// Test: `prune_orphaned_worktrees_spares_active`,
 ///       `prune_orphaned_worktrees_removes_orphan`,
-///       `find_orphaned_worktrees_covers_base_worktrees_shape` (#3649).
+///       `find_orphaned_worktrees_covers_base_worktrees_shape` (#3649),
+///       `find_orphaned_worktrees_covers_claude_worktrees_shape`,
+///       `find_orphaned_worktrees_spares_live_claude_worktree`,
+///       `prune_orphaned_worktrees_never_deletes_claude_native_worktree` (#3971).
 pub(crate) fn find_orphaned_worktrees(
     repos_root: &std::path::Path,
     active_set: &std::collections::HashSet<std::path::PathBuf>,
@@ -409,6 +418,17 @@ pub(crate) fn find_orphaned_worktrees(
             // `provisioner::workspace::WorkspaceProvisioner::provision_in`).
             scan_worktree_shape(
                 &repo_path.join(".base").join(".worktrees"),
+                active_set,
+                &mut orphans,
+            );
+            // Shape 3 (#3971): Claude Code's native `isolation: "worktree"`
+            // agent worktrees at `<repo>/.claude/worktrees/<name>` — never
+            // created by trusty-mpm, so these candidates never carry the
+            // `.trusty-mpm-worktree` sentinel and are gated to owner-unknown
+            // (report-only) by `prune_orphaned_worktrees`'s existing #3649
+            // ownership check, not auto-deleted.
+            scan_worktree_shape(
+                &repo_path.join(".claude").join("worktrees"),
                 active_set,
                 &mut orphans,
             );

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -371,28 +371,57 @@ fn matches_filter(record: &SessionRecord, filter: PruneFilter) -> bool {
 /// walk logic can be tested independently of the full session-manager setup,
 /// and reused by the `doctor.rs` worktree health probe without duplicating the
 /// filesystem walk.
-/// What: walks all THREE known worktree-store shapes under each
-/// `<repos_root>/<owner>/<repo>/`: the in-project shape (`.worktrees/<name>`,
-/// added #1840), the clone-based shared-base-checkout shape
-/// (`.base/.worktrees/<session-id>`, added #3649), and Claude Code's native
-/// `isolation: "worktree"` agent shape (`.claude/worktrees/<name>`, added
-/// #3971 — this walk previously covered only the first two, so every
-/// `.claude/worktrees` dir was invisible to both this scan and the
-/// doctor/dry-run surfaces built on it). Any leaf directory whose
-/// canonicalized path is NOT in `active_set` is collected as an orphan
-/// CANDIDATE — the caller (`prune_orphaned_worktrees`) still applies the
-/// #3649 ownership-sentinel gate before ever deleting anything, so a
-/// candidate discovered here is never auto-deleted unless it also carries a
-/// trusty-mpm ownership sentinel naming a provably-ownerless owner (see that
-/// function's doc). Using a `HashSet` with canonicalized paths avoids O(n×m)
-/// linear scan and correctly handles symlinked workspace paths. A
-/// non-existent or unreadable `repos_root` returns an empty vec.
+/// What: walks all FIVE known worktree-store locations under each
+/// `<repos_root>/<owner>/<repo>/`:
+/// 1. the in-project shape (`.worktrees/<name>`, added #1840);
+/// 2. the clone-based shared-base-checkout shape
+///    (`.base/.worktrees/<session-id>`, added #3649);
+/// 3. Claude Code's native `isolation: "worktree"` agent shape at the repo
+///    root (`.claude/worktrees/<name>`, added #3971);
+/// 4. the SAME Claude Code agent shape, but created while working directly
+///    inside the bare `.base` clone checkout itself
+///    (`.base/.claude/worktrees/<name>`, added #3971 follow-up — the #3971
+///    fix covered only location 3, so this sibling location, and location 5
+///    below, were still invisible even after that fix landed; confirmed live
+///    on this machine with 29 real entries);
+/// 5. the SAME Claude Code agent shape again, but nested inside a per-session
+///    checkout (`.base/.worktrees/<session-id>/.claude/worktrees/<name>`,
+///    added #3971 follow-up — this is the exact shape this repo's own
+///    trusty-mpm sessions produce when a Claude Code agent spawns a nested
+///    worktree from within its own session checkout). Enumerated by listing
+///    each `.base/.worktrees` session leaf (via [`list_immediate_dirs`]) and
+///    probing it for a nested `.claude/worktrees`, since the session-id
+///    directory name is not known in advance.
+///
+/// Any leaf directory whose canonicalized path is NOT in `active_set` is
+/// collected as an orphan CANDIDATE — the caller (`prune_orphaned_worktrees`)
+/// still applies the #3649 ownership-sentinel gate before ever deleting
+/// anything, so a candidate discovered here is never auto-deleted unless it
+/// also carries a trusty-mpm ownership sentinel naming a provably-ownerless
+/// owner (see that function's doc); locations 3-5 are all Claude-Code-created
+/// and so never carry that sentinel, landing in `owner_unknown` (report-only)
+/// rather than being deleted. Using a `HashSet` with canonicalized paths
+/// avoids O(n×m) linear scan and correctly handles symlinked workspace
+/// paths. A non-existent or unreadable `repos_root` returns an empty vec.
+///
+/// Deliberately explicit rather than a generic recursive walk: each location
+/// is a specific, named join reusing the shared [`scan_worktree_shape`]
+/// leaf-collection logic, matching the style already established by
+/// locations 1-2 and keeping every location individually testable. A blind
+/// recursive walk of a whole checkout's source tree (crates/, node_modules/,
+/// target/, …) would be pathological on a repo this size; this walk only
+/// ever touches the fixed, known worktree-bookkeeping directory names
+/// (`.worktrees`, `.base`, `.claude`), never a checkout's actual source
+/// files.
 /// Test: `prune_orphaned_worktrees_spares_active`,
 ///       `prune_orphaned_worktrees_removes_orphan`,
 ///       `find_orphaned_worktrees_covers_base_worktrees_shape` (#3649),
 ///       `find_orphaned_worktrees_covers_claude_worktrees_shape`,
 ///       `find_orphaned_worktrees_spares_live_claude_worktree`,
-///       `prune_orphaned_worktrees_never_deletes_claude_native_worktree` (#3971).
+///       `prune_orphaned_worktrees_never_deletes_claude_native_worktree` (#3971),
+///       `find_orphaned_worktrees_covers_base_claude_worktrees_shape`,
+///       `find_orphaned_worktrees_covers_nested_session_claude_worktrees_shape`
+///       (#3971 follow-up).
 pub(crate) fn find_orphaned_worktrees(
     repos_root: &std::path::Path,
     active_set: &std::collections::HashSet<std::path::PathBuf>,
@@ -411,17 +440,14 @@ pub(crate) fn find_orphaned_worktrees(
         };
         for repo_entry in repo_entries.flatten() {
             let repo_path = repo_entry.path();
-            // Shape 1 (#1840): in-project worktrees at `<repo>/.worktrees/<name>`.
+            // Location 1 (#1840): in-project worktrees at `<repo>/.worktrees/<name>`.
             scan_worktree_shape(&repo_path.join(".worktrees"), active_set, &mut orphans);
-            // Shape 2 (#3649): clone-based shared-base-checkout worktrees at
+            // Location 2 (#3649): clone-based shared-base-checkout worktrees at
             // `<repo>/.base/.worktrees/<session-id>` (see
             // `provisioner::workspace::WorkspaceProvisioner::provision_in`).
-            scan_worktree_shape(
-                &repo_path.join(".base").join(".worktrees"),
-                active_set,
-                &mut orphans,
-            );
-            // Shape 3 (#3971): Claude Code's native `isolation: "worktree"`
+            let base_worktrees = repo_path.join(".base").join(".worktrees");
+            scan_worktree_shape(&base_worktrees, active_set, &mut orphans);
+            // Location 3 (#3971): Claude Code's native `isolation: "worktree"`
             // agent worktrees at `<repo>/.claude/worktrees/<name>` — never
             // created by trusty-mpm, so these candidates never carry the
             // `.trusty-mpm-worktree` sentinel and are gated to owner-unknown
@@ -432,9 +458,57 @@ pub(crate) fn find_orphaned_worktrees(
                 active_set,
                 &mut orphans,
             );
+            // Location 4 (#3971 follow-up): the same Claude Code agent shape,
+            // created while working directly inside the bare `.base` clone
+            // checkout, at `<repo>/.base/.claude/worktrees/<name>`.
+            scan_worktree_shape(
+                &repo_path.join(".base").join(".claude").join("worktrees"),
+                active_set,
+                &mut orphans,
+            );
+            // Location 5 (#3971 follow-up): the same Claude Code agent shape
+            // again, nested inside a per-session checkout, at
+            // `<repo>/.base/.worktrees/<session-id>/.claude/worktrees/<name>`.
+            // The session-id leaf name is not known in advance, so list each
+            // leaf under `.base/.worktrees` (location 2's own directory) and
+            // probe it for a nested `.claude/worktrees`.
+            for session_leaf in list_immediate_dirs(&base_worktrees) {
+                scan_worktree_shape(
+                    &session_leaf.join(".claude").join("worktrees"),
+                    active_set,
+                    &mut orphans,
+                );
+            }
         }
     }
     orphans
+}
+
+/// List the immediate child directories of `dir`, ignoring unreadable
+/// entries (#3971 follow-up).
+///
+/// Why: [`find_orphaned_worktrees`]'s location 5 needs to enumerate each
+/// `.base/.worktrees/<session-id>` leaf so it can probe each one for a
+/// nested `.claude/worktrees`, but the session-id names are not known in
+/// advance. Unlike [`scan_worktree_shape`], this does NOT filter against an
+/// `active_set` or collect orphans itself — it exists purely to enumerate
+/// CONTAINER directories for the caller to recurse into, keeping the
+/// active-set/orphan-candidate logic owned by exactly one function
+/// ([`scan_worktree_shape`]).
+/// What: returns every directory entry directly under `dir`; a non-existent
+/// or unreadable `dir` (including the common case of a repo with no
+/// `.base/.worktrees` at all) returns an empty vec, mirroring
+/// [`scan_worktree_shape`]'s own tolerant-missing-directory behavior.
+/// Test: `find_orphaned_worktrees_covers_nested_session_claude_worktrees_shape`.
+fn list_immediate_dirs(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return Vec::new();
+    };
+    entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect()
 }
 
 /// Scan one `.worktrees`-shaped directory for leaf dirs not in `active_set`,

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -351,6 +351,172 @@ async fn prune_orphaned_worktrees_never_deletes_claude_native_worktree() {
     assert!(claude_wt.exists(), "worktree dir must survive the prune");
 }
 
+// ── #3971 follow-up: the two Claude-worktree locations the first #3971 fix
+// missed — `.base/.claude/worktrees` and the nested per-session-checkout
+// shape (BLOCK finding: the fix only anchored at `<repo>/.claude/worktrees`,
+// covering roughly a third of the real on-disk surface) ────────────────────
+
+/// `find_orphaned_worktrees` must discover Claude Code agent worktrees
+/// created directly inside the bare `.base` clone checkout itself, at
+/// `<repo>/.base/.claude/worktrees/<name>` — a sibling of the repo-root
+/// `.claude/worktrees` shape the first #3971 fix covered, but a distinct
+/// filesystem location the walk did not anchor at (confirmed live on the
+/// dogfood machine with 29 real entries).
+#[test]
+fn find_orphaned_worktrees_covers_base_claude_worktrees_shape() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let base_claude_wt = root
+        .join("owner")
+        .join("repo")
+        .join(".base")
+        .join(".claude")
+        .join("worktrees")
+        .join("agent-1111111111111111111111111111111111111111");
+    std::fs::create_dir_all(&base_claude_wt).unwrap();
+    let empty_active: std::collections::HashSet<std::path::PathBuf> =
+        std::collections::HashSet::new();
+    let orphans = find_orphaned_worktrees(root, &empty_active);
+    assert!(
+        orphans.contains(&base_claude_wt),
+        "the .base/.claude/worktrees shape must be discovered as a candidate; got {orphans:?}"
+    );
+}
+
+/// `find_orphaned_worktrees` must discover Claude Code agent worktrees
+/// nested INSIDE a per-session checkout, at
+/// `<repo>/.base/.worktrees/<session-id>/.claude/worktrees/<name>` — the
+/// exact shape a Claude Code agent spawned from within its own trusty-mpm
+/// session checkout produces (this is literally the shape this leg's own
+/// `fix-worktree-hygiene` worktree lives under). The session-id leaf name is
+/// dynamic, so this exercises the `list_immediate_dirs` enumeration path,
+/// not a fixed join.
+#[test]
+fn find_orphaned_worktrees_covers_nested_session_claude_worktrees_shape() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let nested_claude_wt = root
+        .join("owner")
+        .join("repo")
+        .join(".base")
+        .join(".worktrees")
+        .join("2eb72dca-de08-481b-8dfa-22ab7f81b1f9")
+        .join(".claude")
+        .join("worktrees")
+        .join("fix-worktree-hygiene");
+    std::fs::create_dir_all(&nested_claude_wt).unwrap();
+    let empty_active: std::collections::HashSet<std::path::PathBuf> =
+        std::collections::HashSet::new();
+    let orphans = find_orphaned_worktrees(root, &empty_active);
+    assert!(
+        orphans.contains(&nested_claude_wt),
+        "the nested .base/.worktrees/<session-id>/.claude/worktrees shape must be \
+         discovered as a candidate; got {orphans:?}"
+    );
+}
+
+/// End-to-end through the real ownership gate (mirrors
+/// `prune_orphaned_worktrees_never_deletes_claude_native_worktree`): a
+/// sentinel-less `.base/.claude/worktrees/<name>` candidate is discovered but
+/// never auto-deleted, only reported as owner-unknown (#3971 follow-up).
+#[tokio::test]
+async fn prune_orphaned_worktrees_never_deletes_base_claude_native_worktree() {
+    let store_dir = tempfile::tempdir().unwrap();
+    let repos = tempfile::tempdir().unwrap();
+    let mgr = SessionManager::new(
+        store_dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let base_claude_wt = repos
+        .path()
+        .join("owner")
+        .join("repo")
+        .join(".base")
+        .join(".claude")
+        .join("worktrees")
+        .join("agent-2222222222222222222222222222222222222222");
+    std::fs::create_dir_all(&base_claude_wt).unwrap();
+    // Deliberately NO sentinel file written.
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "a Claude-Code-native worktree under .base/.claude must never be auto-deleted; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        outcome.owner_unknown.iter().any(|p| p == &base_claude_wt),
+        "expected {base_claude_wt:?} to be reported as owner-unknown; got {:?}",
+        outcome.owner_unknown
+    );
+    assert!(
+        base_claude_wt.exists(),
+        "worktree dir must survive the prune"
+    );
+}
+
+/// End-to-end through the real ownership gate for the NESTED
+/// per-session-checkout shape: a sentinel-less
+/// `.base/.worktrees/<session-id>/.claude/worktrees/<name>` candidate is
+/// discovered but never auto-deleted, only reported as owner-unknown (#3971
+/// follow-up).
+#[tokio::test]
+async fn prune_orphaned_worktrees_never_deletes_nested_session_claude_worktree() {
+    let store_dir = tempfile::tempdir().unwrap();
+    let repos = tempfile::tempdir().unwrap();
+    let mgr = SessionManager::new(
+        store_dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let nested_claude_wt = repos
+        .path()
+        .join("owner")
+        .join("repo")
+        .join(".base")
+        .join(".worktrees")
+        .join("some-session-id")
+        .join(".claude")
+        .join("worktrees")
+        .join("nested-agent");
+    std::fs::create_dir_all(&nested_claude_wt).unwrap();
+    // Deliberately NO sentinel file written on the nested Claude worktree.
+    // The session-id leaf itself also has no sentinel — it must not be
+    // misclassified as a location-2 (`.base/.worktrees`) orphan candidate
+    // either, since it still contains a live-looking nested checkout; that
+    // is exercised implicitly here (only the leaf-most directory is ever a
+    // candidate for each scanned shape).
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "a nested Claude-Code-native worktree must never be auto-deleted; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        outcome.owner_unknown.iter().any(|p| p == &nested_claude_wt),
+        "expected {nested_claude_wt:?} to be reported as owner-unknown; got {:?}",
+        outcome.owner_unknown
+    );
+    assert!(
+        nested_claude_wt.exists(),
+        "worktree dir must survive the prune"
+    );
+}
+
 /// A candidate whose ownership sentinel is absent (no `.trusty-mpm-worktree`
 /// file at all — the pre-#3649/legacy shape) is NEVER auto-deleted, and is
 /// counted in [`OrphanSweepOutcome::owner_unknown`] (#3649 item 4b).

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -247,6 +247,110 @@ fn find_orphaned_worktrees_covers_base_worktrees_shape() {
     );
 }
 
+// ── #3971: extended `.claude/worktrees` walk (Claude Code native agent
+// worktrees) ──────────────────────────────────────────────────────────────
+
+/// `find_orphaned_worktrees` must ALSO discover Claude Code's native
+/// `.claude/worktrees/agent-<hash>` shape, not just the two trusty-mpm-owned
+/// shapes (#3971 — this walk previously covered ONLY `.worktrees/<name>` and
+/// `.base/.worktrees/<id>`, so every Claude-Code-created agent worktree was
+/// invisible to the orphan-GC, `tm doctor`, and `--dry-run`, letting them
+/// accumulate silently).
+#[test]
+fn find_orphaned_worktrees_covers_claude_worktrees_shape() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let claude_wt = root
+        .join("owner")
+        .join("repo")
+        .join(".claude")
+        .join("worktrees")
+        .join("agent-0123456789abcdef0123456789abcdef01234567");
+    std::fs::create_dir_all(&claude_wt).unwrap();
+    let empty_active: std::collections::HashSet<std::path::PathBuf> =
+        std::collections::HashSet::new();
+    let orphans = find_orphaned_worktrees(root, &empty_active);
+    assert!(
+        orphans.contains(&claude_wt),
+        "the .claude/worktrees shape must be discovered as a candidate; got {orphans:?}"
+    );
+}
+
+/// A LIVE (non-orphaned) `.claude/worktrees/agent-<hash>` directory — one
+/// whose canonicalized path IS present in the caller-supplied active set —
+/// must never be returned as an orphan candidate (#3971). Mirrors the
+/// existing `prune_orphaned_worktrees_spares_active` guarantee for the other
+/// two shapes.
+#[test]
+fn find_orphaned_worktrees_spares_live_claude_worktree() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path();
+    let claude_wt = root
+        .join("owner")
+        .join("repo")
+        .join(".claude")
+        .join("worktrees")
+        .join("agent-fedcba9876543210fedcba9876543210fedcba98");
+    std::fs::create_dir_all(&claude_wt).unwrap();
+    let active: std::collections::HashSet<_> =
+        vec![std::fs::canonicalize(&claude_wt).unwrap_or_else(|_| claude_wt.clone())]
+            .into_iter()
+            .collect();
+    let orphans = find_orphaned_worktrees(root, &active);
+    assert!(
+        orphans.is_empty(),
+        "a live .claude/worktrees entry must not be listed as orphan; got {orphans:?}"
+    );
+}
+
+/// Even when discovered as an orphan CANDIDATE by the walk, a
+/// `.claude/worktrees/agent-<hash>` directory is never created by
+/// trusty-mpm's own provisioning code, so it never carries the
+/// `.trusty-mpm-worktree` ownership sentinel. The existing #3649 ownership
+/// gate therefore classifies it as `SentinelOwner::Unknown` and the full
+/// `prune_orphaned_worktrees` sweep must NEVER auto-delete it — only report
+/// it via `OrphanSweepOutcome::owner_unknown`, exactly like any other
+/// legacy/owner-unknown worktree (#3971).
+#[tokio::test]
+async fn prune_orphaned_worktrees_never_deletes_claude_native_worktree() {
+    let store_dir = tempfile::tempdir().unwrap();
+    let repos = tempfile::tempdir().unwrap();
+    let mgr = SessionManager::new(
+        store_dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let claude_wt = repos
+        .path()
+        .join("owner")
+        .join("repo")
+        .join(".claude")
+        .join("worktrees")
+        .join("agent-00112233445566778899aabbccddeeff00112233");
+    std::fs::create_dir_all(&claude_wt).unwrap();
+    // Deliberately NO sentinel file written — Claude Code's native
+    // `isolation: "worktree"` mechanism never writes trusty-mpm's sentinel.
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "a Claude-Code-native worktree must never be auto-deleted; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        outcome.owner_unknown.iter().any(|p| p == &claude_wt),
+        "expected {claude_wt:?} to be reported as owner-unknown; got {:?}",
+        outcome.owner_unknown
+    );
+    assert!(claude_wt.exists(), "worktree dir must survive the prune");
+}
+
 /// A candidate whose ownership sentinel is absent (no `.trusty-mpm-worktree`
 /// file at all — the pre-#3649/legacy shape) is NEVER auto-deleted, and is
 /// counted in [`OrphanSweepOutcome::owner_unknown`] (#3649 item 4b).


### PR DESCRIPTION
## Summary

Two related worktree-hygiene defects, fixed together:

- **Fix A (#3971):** `find_orphaned_worktrees` (`crates/trusty-mpm/src/session_manager/prune.rs`) only walked `.worktrees/<name>` and `.base/.worktrees/<session-id>`. Claude Code's native `isolation: "worktree"` agent worktrees under `.claude/worktrees/<name>` were never scanned, so they were invisible to `tm session prune-worktrees` and `tm doctor` and accumulated silently. Added as a third `scan_worktree_shape` target, mirroring the #3649 pattern that added `.base/.worktrees`.

- **Fix B (#3972):** `.gitignore` re-includes `.claude/` for `settings.json`/`agents/`, which un-ignores the *whole* directory and lets `worktrees/` fall through as untracked noise (`?? .claude/worktrees/`). `.trusty-mpm/` had the identical problem for `sessions/`, `last-instructions.md`, `scrollback.txt`. `.base/` was missing from `.gitignore` entirely (`?? .base/`). Fixed by mirroring the existing `.claude-mpm/*` + explicit re-include pattern already used in this same file, rather than the "un-ignore the dir, hope nothing else appears" pattern that caused the bug.

## Safety — how liveness is established for the new `.claude/worktrees` shape

`find_orphaned_worktrees` only ever returns orphan **candidates**. The real deletion gate is `prune_orphaned_worktrees`'s existing #3649 ownership-sentinel check (`worktree_ownership::read_sentinel_owner`): a candidate is deleted only if it carries a `.trusty-mpm-worktree` sentinel naming a provably-ownerless owner, cross-checked against `git worktree list`.

Claude Code's native worktree-creation path never writes trusty-mpm's sentinel, so every `.claude/worktrees/agent-<hash>` candidate is unconditionally classified `SentinelOwner::Unknown` and is **never auto-deleted** — it is only counted in `OrphanSweepOutcome::owner_unknown`, surfaced for `tm doctor` / `--dry-run` review, exactly like any other legacy/owner-unknown worktree. No new deletion logic was written and no liveness heuristic had to be guessed at — the existing conservative gate already produces the correct "reporting-only" behavior for this shape, for free.

`--force` is still required for any real deletion (`tm session prune-worktrees` defaults to dry-run) — unchanged by this PR.

## Test plan

- [x] Failing-first: `find_orphaned_worktrees_covers_claude_worktrees_shape` fails before the fix (`got []`), passes after.
- [x] `find_orphaned_worktrees_spares_live_claude_worktree` — a live (active-set) `.claude/worktrees` entry is never returned as an orphan candidate.
- [x] `prune_orphaned_worktrees_never_deletes_claude_native_worktree` — end-to-end through the real ownership gate: a sentinel-less `.claude/worktrees` candidate is never in `outcome.removed`, and IS reported in `outcome.owner_unknown`.
- [x] `cargo test -p trusty-mpm` (full workspace test surface, not `--lib`) — all green.
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p trusty-mpm --check` — clean.
- [x] `git status --porcelain` before/after proving `.base/`, `.claude/worktrees/`, `.trusty-mpm/{sessions/,last-instructions.md,scrollback.txt}` all disappear from status, while `.claude/settings.json`, `.claude/agents/`, and `.trusty-mpm/INSTRUCTIONS.md` remain correctly un-ignored/tracked.
- [x] Root `CLAUDE.md` guard script (`scripts/check_claude_md_not_tracked.sh`) still passes — unaffected by this change.

Closes #3971
Closes #3972

Not merging — mandatory adversarial code-critic gate follows.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools