### PR TITLE
fix(trusty-search): staged-write-then-swap for periodic HNSW snapshot

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -32,6 +32,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   skipped, only its destination changes, deliberately avoiding a
   skip-while-`Running` gate (which would have traded this hole for the loss
   of ALL in-reindex progress instead of just the tail).
+  Round-2 adversarial review found and fixed two further issues in the swap
+  itself: (1) the staging→live swap is two renames, not one — the sidecar is
+  now renamed BEFORE the binary so an interruption between them can only
+  leave a live pairing whose `next_key` sits ahead of (never behind) actual
+  usage, which cannot collide on a subsequent write, and `UsearchStore::load_from`
+  now additionally refuses to load a binary reporting MORE vectors than its
+  paired sidecar describes, as defense-in-depth against a torn pairing from
+  any source; (2) `CodeIndexer::end_reindex_staging` is no longer called
+  before the swap (or abort cleanup) fully resolves — both now wait for any
+  still-running periodic-persist task to quiesce first
+  (`CodeIndexer::wait_for_incremental_persist_drain`), closing a race where a
+  detached task that outlived the reindex's batch loop could otherwise
+  observe the flag clear early and write partial state straight to the live
+  path.
+  **Scope correction:** what this fix buys is (a) bounded memory, by
+  flushing vectors out of RAM during a long reindex, and (b) a safe,
+  complete crash-recovery baseline — the live snapshot always reflects the
+  last complete pre-reindex state, never a partial one. It does NOT enable
+  resuming an interrupted reindex from its partial progress; after any
+  crash mid-reindex, the next reindex attempt redoes the entire
+  walk/parse/embed from scratch. That pre-existing gap is NOT #3969 (which
+  is the different problem of a reindex never automatically restarting at
+  all for non-HEAD-driven runs) — it is tracked separately as **issue
+  #3979**.
 - **Shutdown no longer publishes a partial in-flight reindex over a complete
   on-disk HNSW snapshot, closing the residual data-loss race the #1711 guard
   left open (issue #1717).** The #1711 guard (PR #1716) only catches an

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,6 +9,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Staged-write-then-swap for the periodic HNSW incremental persister closes
+  a crash-safety hole independent of shutdown (issue #3970).**
+  `spawn_incremental_persist` used to checkpoint the in-memory HNSW graph
+  straight to the LIVE snapshot every `HNSW_SNAPSHOT_BATCH_INTERVAL` batches
+  during EVERY reindex. Reindex progress is monotonic, so any reasonably
+  large reindex crossed `UsearchStore::save`'s shrink guard threshold as
+  ordinary healthy progress — from that checkpoint on, the complete
+  pre-reindex snapshot was already overwritten by a partial, still-growing
+  one, and an ungraceful termination (SIGKILL, OOM-kill, process abort, power
+  loss) at any later point permanently stranded the index. This was the same
+  vulnerability class as #1717 but reached through a different, far more
+  frequently exercised path, and was NOT fixed by PR #3968 (which closes only
+  the graceful-shutdown flush path). The periodic persister now redirects
+  every checkpoint during a reindex to a staging path
+  (`service::reindex::hnsw_swap`, mirroring the redb corpus's existing
+  atomic staged-swap, #603/#839) and publishes to the live path in one
+  atomic rename only when the reindex reaches a terminal `Ready` outcome;
+  any other outcome (failure, memory-abort) discards the staged snapshot and
+  leaves the live one untouched. Incremental crash-safety checkpointing
+  during the reindex is fully preserved — the periodic persister is never
+  skipped, only its destination changes, deliberately avoiding a
+  skip-while-`Running` gate (which would have traded this hole for the loss
+  of ALL in-reindex progress instead of just the tail).
 - **Shutdown no longer publishes a partial in-flight reindex over a complete
   on-disk HNSW snapshot, closing the residual data-loss race the #1711 guard
   left open (issue #1717).** The #1711 guard (PR #1716) only catches an

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -419,7 +419,7 @@ pub(crate) struct PersistState {
     /// checkpointing during the reindex is fully preserved (the explicitly
     /// rejected alternative was a skip-while-`Running` gate, which would have
     /// disabled that checkpointing entirely).
-    /// Test: `persist_hnsw::tests::test_incremental_persist_redirects_to_staging_while_reindexing`.
+    /// Test: `tests::persistence_and_search::test_incremental_persist_redirects_to_staging_while_reindexing`.
     pub(crate) reindexing: AtomicBool,
 }
 

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -393,6 +393,34 @@ pub(crate) struct PersistState {
     /// (issue #29). Only every [`HNSW_SNAPSHOT_BATCH_INTERVAL`] batches is
     /// the HNSW snapshot actually spawned.
     pub(crate) batch_counter: AtomicU32,
+    /// `true` while a reindex batch loop is actively populating this indexer
+    /// (issue #3970 — staged-write-then-swap for the HNSW snapshot).
+    ///
+    /// Why: `spawn_incremental_persist`'s periodic checkpoint used to publish
+    /// straight to the LIVE HNSW snapshot on every call, including mid-reindex
+    /// ones where the in-memory graph is, by construction, not yet the
+    /// reindex's final output. Reindex progress is monotonic, so any
+    /// reasonably large reindex crossed the `save()` shrink guard's 50%
+    /// threshold as ordinary healthy progress — from that checkpoint on, the
+    /// complete pre-reindex snapshot was already gone, and an ungraceful
+    /// termination (SIGKILL/OOM-kill/abort/power loss) permanently stranded
+    /// the index. This flag lets the periodic persister redirect its
+    /// checkpoints to a staging path instead while it's set, so the live
+    /// snapshot is only ever replaced by one atomic rename, at the moment the
+    /// reindex orchestrator (`service::reindex::hnsw_swap`) commits.
+    /// What: set by `CodeIndexer::begin_reindex_staging` (called from
+    /// `service::reindex::hnsw_swap::begin_staged_hnsw_swap` at the start of
+    /// a reindex, alongside the existing redb corpus staging) and cleared by
+    /// `CodeIndexer::end_reindex_staging` once the reindex orchestrator has
+    /// resolved (committed or rolled back) the staged snapshot. Read by
+    /// `persist_hnsw::spawn_incremental_persist` to choose between the live
+    /// and staging destination path on every periodic checkpoint — it never
+    /// skips the checkpoint, only redirects it, so incremental crash-safety
+    /// checkpointing during the reindex is fully preserved (the explicitly
+    /// rejected alternative was a skip-while-`Running` gate, which would have
+    /// disabled that checkpointing entirely).
+    /// Test: `persist_hnsw::tests::test_incremental_persist_redirects_to_staging_while_reindexing`.
+    pub(crate) reindexing: AtomicBool,
 }
 
 impl CodeIndexer {

--- a/crates/trusty-search/src/core/indexer/persist_hnsw.rs
+++ b/crates/trusty-search/src/core/indexer/persist_hnsw.rs
@@ -103,7 +103,7 @@ impl CodeIndexer {
     /// `service::reindex::hnsw_swap::begin_staged_hnsw_swap`) instead of the
     /// live snapshot, until [`Self::end_reindex_staging`] is called.
     /// What: sets the flag with `Release` ordering.
-    /// Test: `persist_hnsw::tests::test_incremental_persist_redirects_to_staging_while_reindexing`.
+    /// Test: `tests::persistence_and_search::test_incremental_persist_redirects_to_staging_while_reindexing`.
     pub fn begin_reindex_staging(&self) {
         self.persist_state.reindexing.store(true, Ordering::Release);
     }
@@ -115,7 +115,7 @@ impl CodeIndexer {
     /// staged snapshot, so subsequent commits (outside this reindex) resume
     /// checkpointing straight to the live path as before.
     /// What: clears the flag with `Release` ordering.
-    /// Test: `persist_hnsw::tests::test_incremental_persist_redirects_to_staging_while_reindexing`.
+    /// Test: `tests::persistence_and_search::test_incremental_persist_redirects_to_staging_while_reindexing`.
     pub fn end_reindex_staging(&self) {
         self.persist_state
             .reindexing
@@ -127,6 +127,61 @@ impl CodeIndexer {
     #[doc(hidden)]
     pub fn is_reindex_staging(&self) -> bool {
         self.persist_state.reindexing.load(Ordering::Acquire)
+    }
+
+    /// Wait for any in-flight/queued [`Self::spawn_incremental_persist`] task
+    /// to fully quiesce (issue #3970 round-2 review, CRITICAL finding 2).
+    ///
+    /// Why: `spawn_incremental_persist` is a bare detached `tokio::spawn` —
+    /// no `JoinHandle` is tracked or awaited anywhere in the reindex module.
+    /// A periodic checkpoint that started during the tail of a reindex's
+    /// batch loop (the last `HNSW_SNAPSHOT_BATCH_INTERVAL`-th batch) can
+    /// still be mid-coalescing-loop when the batch loop ends and the reindex
+    /// orchestrator (`service::reindex::hnsw_swap`) resolves the staged swap.
+    /// If [`Self::end_reindex_staging`] cleared the flag while that task was
+    /// still running, its NEXT loop iteration (re-reading `reindexing` fresh
+    /// every iteration — see [`Self::spawn_incremental_persist`]) would
+    /// observe `reindexing == false` and write the in-memory store — for an
+    /// ABORTED reindex, by definition still partial — straight to the LIVE
+    /// path, reproducing #3970 through a race the direct-write fix alone
+    /// does not close. Callers must await this BEFORE clearing the flag.
+    /// What: polls [`PersistState::in_flight`] / [`PersistState::dirty`]
+    /// until both are `false` — `in_flight` is set exactly once before a
+    /// task is spawned and cleared exactly once, at the very end of that
+    /// task's coalescing loop, never mid-loop (see
+    /// [`Self::spawn_incremental_persist`]'s protocol doc), so
+    /// `!in_flight && !dirty` is an authoritative "no task is running and
+    /// none is about to restart" signal — or until `timeout` elapses.
+    /// Returns `true` once drained, `false` on timeout. A timeout does not
+    /// block the caller forever, but the caller MUST still treat it as "not
+    /// yet safe" and log loudly — see call sites.
+    /// Test: `tests::persistence_and_search::wait_for_incremental_persist_drain_waits_for_in_flight_task`,
+    /// `tests::persistence_and_search::wait_for_incremental_persist_drain_returns_immediately_when_idle`.
+    pub async fn wait_for_incremental_persist_drain(&self, timeout: std::time::Duration) -> bool {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            let in_flight = self.persist_state.in_flight.load(Ordering::Acquire);
+            let dirty = self.persist_state.dirty.load(Ordering::Acquire);
+            if !in_flight && !dirty {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+    }
+
+    /// Test-only: directly set [`PersistState::in_flight`], simulating a
+    /// still-running periodic persist task without needing to spawn and time
+    /// a real one (issue #3970 round-2 regression coverage for CRITICAL 2 —
+    /// mirrors the existing `UsearchStore::in_view_mode` test-accessor
+    /// pattern). Never called from production code.
+    #[doc(hidden)]
+    pub fn simulate_persist_in_flight_for_tests(&self, in_flight: bool) {
+        self.persist_state
+            .in_flight
+            .store(in_flight, Ordering::Release);
     }
 
     /// Force an HNSW snapshot now, bypassing the per-batch throttle

--- a/crates/trusty-search/src/core/indexer/persist_hnsw.rs
+++ b/crates/trusty-search/src/core/indexer/persist_hnsw.rs
@@ -95,6 +95,40 @@ impl CodeIndexer {
         }
     }
 
+    /// Begin staged HNSW persistence for a reindex (issue #3970).
+    ///
+    /// Why: flips [`PersistState::reindexing`] so every subsequent
+    /// [`Self::spawn_incremental_persist`] checkpoint redirects to the
+    /// staging path a caller resolves separately (see
+    /// `service::reindex::hnsw_swap::begin_staged_hnsw_swap`) instead of the
+    /// live snapshot, until [`Self::end_reindex_staging`] is called.
+    /// What: sets the flag with `Release` ordering.
+    /// Test: `persist_hnsw::tests::test_incremental_persist_redirects_to_staging_while_reindexing`.
+    pub fn begin_reindex_staging(&self) {
+        self.persist_state.reindexing.store(true, Ordering::Release);
+    }
+
+    /// End staged HNSW persistence (issue #3970).
+    ///
+    /// Why: counterpart of [`Self::begin_reindex_staging`] — called once the
+    /// reindex orchestrator has resolved (committed or rolled back) the
+    /// staged snapshot, so subsequent commits (outside this reindex) resume
+    /// checkpointing straight to the live path as before.
+    /// What: clears the flag with `Release` ordering.
+    /// Test: `persist_hnsw::tests::test_incremental_persist_redirects_to_staging_while_reindexing`.
+    pub fn end_reindex_staging(&self) {
+        self.persist_state
+            .reindexing
+            .store(false, Ordering::Release);
+    }
+
+    /// `true` while this indexer is in staged-reindex mode (issue #3970). See
+    /// [`Self::begin_reindex_staging`].
+    #[doc(hidden)]
+    pub fn is_reindex_staging(&self) -> bool {
+        self.persist_state.reindexing.load(Ordering::Acquire)
+    }
+
     /// Force an HNSW snapshot now, bypassing the per-batch throttle
     /// ([`crate::core::indexer::HNSW_SNAPSHOT_BATCH_INTERVAL`], issue #29).
     ///
@@ -237,6 +271,20 @@ impl CodeIndexer {
                     }
                 }
             };
+            // Issue #3970: while a reindex is staging (`PersistState::reindexing`),
+            // periodic checkpoints must never publish straight to the live
+            // snapshot — reindex progress is monotonic, so ordinary healthy
+            // progress on any reasonably large reindex WOULD otherwise cross
+            // the `save()` shrink guard's threshold and replace the complete
+            // pre-reindex snapshot with a still-partial one. Resolved once per
+            // coalescing-loop iteration (below), not just once up front, so a
+            // reindex that completes mid-loop is picked up on the very next
+            // iteration rather than staying pinned to a stale destination.
+            let hnsw_staging_path = if is_colocated {
+                crate::service::colocated_storage::colocated_hnsw_staging_path(&root_path)
+            } else {
+                crate::service::persistence::hnsw_staging_path(&index_id)
+            };
 
             // Coalescing loop: snapshot+save while `dirty` keeps being set.
             // Bound the loop so a pathological caller can't pin us forever
@@ -250,11 +298,31 @@ impl CodeIndexer {
                 // again — ensuring we don't miss it.
                 persist_state.dirty.store(false, Ordering::Release);
 
-                // Save HNSW first (large, parallel-friendly).
+                // Save HNSW first (large, parallel-friendly). Issue #3970:
+                // resolved fresh each iteration so a reindex that flips
+                // `reindexing` off mid-coalesce is observed promptly.
                 if let Some(store) = &store {
-                    if let Err(e) = store.save_to(&hnsw_path).await {
+                    let reindexing = persist_state.reindexing.load(Ordering::Acquire);
+                    let target: &std::path::Path = if reindexing {
+                        match &hnsw_staging_path {
+                            Ok(p) => p,
+                            Err(e) => {
+                                tracing::debug!(
+                                    "incremental persist: cannot resolve hnsw staging path \
+                                     for '{index_id}' ({e}) — falling back to the live path \
+                                     for this checkpoint"
+                                );
+                                &hnsw_path
+                            }
+                        }
+                    } else {
+                        &hnsw_path
+                    };
+                    if let Err(e) = store.save_to(target).await {
                         tracing::warn!(
-                            "incremental persist: failed to save HNSW for '{index_id}': {e}"
+                            "incremental persist: failed to save HNSW for '{index_id}' \
+                             (target={}, reindexing={reindexing}): {e}",
+                            target.display()
                         );
                     }
                 }

--- a/crates/trusty-search/src/core/indexer/tests/persistence_and_search.rs
+++ b/crates/trusty-search/src/core/indexer/tests/persistence_and_search.rs
@@ -319,6 +319,75 @@ async fn test_incremental_persist_redirects_to_staging_while_reindexing() {
     unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
 }
 
+/// Why (issue #3970 round-3 review, HIGH finding): `CodeIndexer::wait_for_incremental_persist_drain`'s
+/// own doc comment cited this test by name before it existed. Round-2's
+/// `hnsw_swap` regression tests only ever exercised the "drain succeeds"
+/// branch (a 150ms release against a 30s timeout) — the timeout-EXPIRY
+/// branch (the function returning `false`) had zero coverage anywhere. This
+/// is a direct unit test of that branch: `in_flight` is set and never
+/// released, so the wait must exhaust its budget and return `false`.
+/// What: sets `PersistState::in_flight` via the test-only
+/// `simulate_persist_in_flight_for_tests` accessor (never cleared), calls
+/// `wait_for_incremental_persist_drain` with a short 50ms timeout, and
+/// asserts it returns `false` after roughly that long — not immediately,
+/// and not hanging forever.
+/// Test: this test.
+#[tokio::test]
+async fn wait_for_incremental_persist_drain_waits_for_in_flight_task() {
+    let idx = make_indexer();
+    idx.simulate_persist_in_flight_for_tests(true);
+
+    let timeout = std::time::Duration::from_millis(50);
+    let start = std::time::Instant::now();
+    let drained = idx.wait_for_incremental_persist_drain(timeout).await;
+    let elapsed = start.elapsed();
+
+    assert!(
+        !drained,
+        "must return false when in_flight never clears within the timeout"
+    );
+    assert!(
+        elapsed >= timeout,
+        "must actually wait out the full timeout budget, not return early; elapsed={elapsed:?}"
+    );
+
+    // Clean up: leaving `in_flight` set would only affect this owned
+    // `CodeIndexer`, which is dropped at the end of this test, but clear it
+    // anyway for clarity.
+    idx.simulate_persist_in_flight_for_tests(false);
+}
+
+/// Why: the companion happy-path to the timeout test above — when nothing
+/// is in flight, the wait must return `true` immediately (bounded by the
+/// 10ms poll granularity, never the full timeout budget).
+/// What: fresh indexer (in_flight and dirty both default `false`), calls
+/// `wait_for_incremental_persist_drain` with a long (5s) timeout, and
+/// asserts it returns `true` in well under that budget.
+/// Test: this test.
+#[tokio::test]
+async fn wait_for_incremental_persist_drain_returns_immediately_when_idle() {
+    let idx = make_indexer();
+    assert!(
+        !idx.persist_state.in_flight.load(Ordering::Acquire),
+        "sanity: a fresh indexer must start idle"
+    );
+    assert!(
+        !idx.persist_state.dirty.load(Ordering::Acquire),
+        "sanity: a fresh indexer must start idle"
+    );
+
+    let long_timeout = std::time::Duration::from_secs(5);
+    let start = std::time::Instant::now();
+    let drained = idx.wait_for_incremental_persist_drain(long_timeout).await;
+    let elapsed = start.elapsed();
+
+    assert!(drained, "must return true when already idle");
+    assert!(
+        elapsed < std::time::Duration::from_secs(1),
+        "must return promptly when idle, not wait out the full budget; elapsed={elapsed:?}"
+    );
+}
+
 #[tokio::test]
 async fn test_search_integration_returns_relevant_chunk_first() {
     let idx = make_indexer();

--- a/crates/trusty-search/src/core/indexer/tests/persistence_and_search.rs
+++ b/crates/trusty-search/src/core/indexer/tests/persistence_and_search.rs
@@ -210,6 +210,115 @@ async fn test_incremental_persist_throttles_to_interval() {
     }
 }
 
+/// Issue #3970 — the exact bug this issue reports, reproduced and proven
+/// fixed: a periodic incremental-persist checkpoint that lands WHILE a
+/// reindex is in progress (`begin_reindex_staging()`) must never publish
+/// partial state to the LIVE HNSW snapshot path. Before the #3970 fix,
+/// `spawn_incremental_persist`'s periodic checkpoint wrote straight to the
+/// live path unconditionally — reindex progress is monotonic, so any
+/// reasonably large reindex crossed `UsearchStore::save`'s shrink guard
+/// threshold as ordinary healthy progress, silently replacing a complete
+/// pre-reindex snapshot with a partial one well before the reindex finished.
+///
+/// Why: this is the FAILING-test-first acceptance criterion from the issue —
+/// with `begin_reindex_staging()` called (simulating a reindex in progress)
+/// and a periodic checkpoint forced, the live snapshot must remain
+/// byte-for-byte the complete pre-reindex state, and the checkpoint's partial
+/// state must land in the staging file instead.
+/// What: seeds a "complete" 500-vector live snapshot directly at the path
+/// `hnsw_path("reindex-3970-live-safety")` resolves to, then builds an
+/// indexer for the SAME index id wired to a FRESH store holding only 10
+/// vectors (simulating early reindex progress), marks it reindex-staging, and
+/// forces one periodic checkpoint (`spawn_incremental_persist(true)` — the
+/// exact call `commit_parsed_batch` makes every
+/// `HNSW_SNAPSHOT_BATCH_INTERVAL` batches). Asserts the live file is
+/// untouched and the staging file holds the 10-vector partial state.
+/// Test: this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn test_incremental_persist_redirects_to_staging_while_reindexing() {
+    let data_dir = tempfile::tempdir().unwrap();
+    // SAFETY: #[serial] excludes every other #[serial]-tagged test in this
+    // crate for the duration of this test, so no other test observes a
+    // different TRUSTY_DATA_DIR concurrently.
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+
+    let index_id = "reindex-3970-live-safety";
+    let live_path = crate::service::persistence::hnsw_path(index_id).expect("hnsw_path");
+    let staging_path =
+        crate::service::persistence::hnsw_staging_path(index_id).expect("hnsw_staging_path");
+    assert_ne!(live_path, staging_path, "sanity: paths must differ");
+
+    // Seed a "complete" pre-reindex snapshot directly at the live path.
+    let complete = UsearchStore::new(4).unwrap();
+    let complete_items: Vec<(String, Vec<f32>)> = (0..500)
+        .map(|i| (format!("chunk:{i}"), vec![i as f32 + 1.0, 0.0, 0.0, 0.0]))
+        .collect();
+    complete.upsert_batch(&complete_items).await.unwrap();
+    complete.save(&live_path).await.expect("seed live save");
+    let live_before = std::fs::read(&live_path).expect("read seeded live");
+
+    // Build an indexer wired to a FRESH store holding only 10 vectors,
+    // simulating a reindex that has barely started.
+    let mut idx = CodeIndexer::new(index_id, "/tmp/reindex-3970-root");
+    let partial = UsearchStore::new(4).unwrap();
+    let partial_items: Vec<(String, Vec<f32>)> = (0..10)
+        .map(|i| {
+            (
+                format!("new-chunk:{i}"),
+                vec![i as f32 + 1.0, 0.0, 0.0, 0.0],
+            )
+        })
+        .collect();
+    partial.upsert_batch(&partial_items).await.unwrap();
+    idx.set_store(std::sync::Arc::new(partial));
+
+    // Mark the reindex in progress, then force a periodic checkpoint — this
+    // is exactly what `commit_parsed_batch` does via
+    // `spawn_incremental_persist` on every 16th batch during a real reindex.
+    idx.begin_reindex_staging();
+    idx.spawn_incremental_persist(true);
+
+    // Wait for the detached persist task to drain.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    loop {
+        let in_flight = idx.persist_state.in_flight.load(Ordering::Acquire);
+        let dirty = idx.persist_state.dirty.load(Ordering::Acquire);
+        if !in_flight && !dirty {
+            break;
+        }
+        if std::time::Instant::now() >= deadline {
+            panic!("persist did not drain within 15s: in_flight={in_flight}, dirty={dirty}");
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+
+    // THE CORE ASSERTION (issue #3970): the live snapshot must be untouched —
+    // still the complete 500-vector pre-reindex state.
+    let live_after = std::fs::read(&live_path).expect("read live after checkpoint");
+    assert_eq!(
+        live_after, live_before,
+        "issue #3970 regression: a periodic checkpoint during a reindex must \
+         NEVER publish partial state to the live snapshot path"
+    );
+
+    // The staging path must hold the partial (10-vector) state instead —
+    // proving the checkpoint still ran (crash-safety checkpointing is
+    // preserved), just redirected.
+    assert!(
+        staging_path.exists(),
+        "staging checkpoint must have been written"
+    );
+    let staged = UsearchStore::load_from(&staging_path)
+        .await
+        .expect("load staging ok")
+        .expect("staging present");
+    assert_eq!(staged.len().await.unwrap(), 10);
+
+    // SAFETY: see above.
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
 #[tokio::test]
 async fn test_search_integration_returns_relevant_chunk_first() {
     let idx = make_indexer();

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -344,6 +344,56 @@ async fn test_load_undersized_hnsw_binary_with_valid_sidecar_returns_none_withou
     );
 }
 
+/// Why (issue #3970 round-2 review, CRITICAL 1 defense-in-depth): a binary
+/// reporting MORE vectors than its paired sidecar's key map describes is
+/// never legitimate under normal operation (every write path inserts the
+/// `id_to_key` entry at-or-before the matching HNSW `add` — see
+/// `UsearchStore::upsert`/`remove`'s doc comments) — it is the exact
+/// signature of a torn `service::reindex::hnsw_swap` staging→live swap whose
+/// binary rename landed without its sidecar rename (the direction the
+/// round-2 fix's sidecar-first rename ordering no longer produces from a
+/// mid-swap crash, but this guard catches it regardless of source). Loading
+/// such a pairing without this guard would restore a `next_key` value that
+/// sits BEHIND vectors already occupying the binary, letting a later
+/// `upsert`'s newly-allocated key collide with — and silently overwrite —
+/// an existing, unrelated vector.
+/// What: saves a small matched (binary, sidecar) pair, keeps that sidecar's
+/// bytes aside, then saves a BIGGER matched pair over the same path, then
+/// restores the SMALL sidecar over the (now bigger) binary — reproducing the
+/// dangerous torn-pairing direction directly. Asserts `load_from` refuses
+/// (`Ok(None)`) rather than silently restoring a corrupt state.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_load_refuses_binary_reporting_more_vectors_than_sidecar_describes() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = dir.path().join("hnsw.usearch");
+    let sidecar_path = path.with_extension("keys.json");
+
+    // A small matched pair first — keep its sidecar bytes aside.
+    let small = UsearchStore::new(4).unwrap();
+    small.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    small.save(&path).await.unwrap();
+    let small_sidecar_bytes = std::fs::read(&sidecar_path).unwrap();
+
+    // A bigger matched pair saved normally over the same path.
+    let big = UsearchStore::new(4).unwrap();
+    big.upsert("a", vec![1.0, 0.0, 0.0, 0.0]).await.unwrap();
+    big.upsert("b", vec![0.0, 1.0, 0.0, 0.0]).await.unwrap();
+    big.upsert("c", vec![0.0, 0.0, 1.0, 0.0]).await.unwrap();
+    big.save(&path).await.unwrap();
+
+    // Tear the pairing: restore the OLD, smaller sidecar over the CURRENT
+    // (bigger) binary — the dangerous direction.
+    std::fs::write(&sidecar_path, &small_sidecar_bytes).unwrap();
+
+    let loaded = UsearchStore::load_from(&path).await.unwrap();
+    assert!(
+        loaded.is_none(),
+        "a binary reporting MORE vectors than its sidecar describes must never be \
+         trusted — issue #3970 round-2 CRITICAL 1 defense-in-depth guard"
+    );
+}
+
 /// Why (issue #2922 guard precision — the false-positive risk): the
 /// size-floor guard scales with the sidecar's own claimed vector count/dim
 /// specifically so it never rejects a genuinely tiny, valid snapshot — this

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -773,6 +773,44 @@ impl UsearchStore {
                 );
                 return Ok(None);
             }
+
+            // Torn-pairing guard (issue #3970 round-2 review, CRITICAL 1
+            // defense-in-depth): a binary reporting MORE vectors than its
+            // paired sidecar's key map describes is never legitimate under
+            // normal operation. Every write path (`upsert`, `upsert_batch`)
+            // inserts the `id_to_key` entry AT OR BEFORE the matching HNSW
+            // `add`, and `remove` deletes both together — so the sidecar's
+            // map can only ever be equal to, or (via the documented
+            // dangling-entry case in `remove`'s doc, when a single `upsert`'s
+            // `add` fails after the map insert) AHEAD of, the binary's true
+            // vector count. It can never legitimately be BEHIND. A binary
+            // that IS ahead of its sidecar is the exact signature of a torn
+            // staging→live swap (`service::reindex::hnsw_swap`) whose two
+            // renames landed newer-binary-paired-with-older-sidecar — which
+            // would otherwise restore a stale, BEHIND-actual-usage
+            // `next_key` that a subsequent `upsert` could allocate and
+            // collide with an already-occupied key, silently overwriting an
+            // unrelated vector. `hnsw_swap`'s rename ordering (sidecar
+            // first) is the primary fix and makes this the DIRECTION a torn
+            // swap can no longer produce; this guard is the safety net for
+            // any other way a torn pairing could arise (e.g. manual disk
+            // manipulation, a future caller that doesn't order renames the
+            // same way).
+            if restored_size > expected_chunks {
+                tracing::error!(
+                    "usearch: snapshot {} reports {} vectors but its sidecar {} only \
+                     describes {} — a binary with MORE vectors than its own sidecar's key \
+                     map is never legitimate; treating as a torn binary/sidecar pairing \
+                     (issue #3970) and discarding rather than risk a stale `next_key` \
+                     colliding with an already-occupied key on the next write. Falling back \
+                     to a fresh (BM25-only until reindex) store.",
+                    hnsw_path.display(),
+                    restored_size,
+                    sidecar.display(),
+                    expected_chunks,
+                );
+                return Ok(None);
+            }
         }
         store.is_view.store(true, Ordering::Release);
         *store.hnsw_path.write().await = Some(hnsw_path.to_path_buf());

--- a/crates/trusty-search/src/service/colocated_storage.rs
+++ b/crates/trusty-search/src/service/colocated_storage.rs
@@ -91,6 +91,17 @@ pub fn colocated_redb_tmp_path(root_path: &Path) -> Result<PathBuf> {
     Ok(colocated_storage_dir(root_path)?.join("index.redb.tmp"))
 }
 
+/// Path to the staging HNSW snapshot inside the colocated storage dir
+/// (issue #3970).
+///
+/// Why: mirrors `persistence::hnsw_staging_path` but under the project tree —
+/// see that function's doc for the full staged-write-then-swap rationale.
+/// What: returns `<root_path>/.trusty-search/hnsw.reindex-staging.usearch`.
+/// Test: covered indirectly by the colocated-index integration tests.
+pub fn colocated_hnsw_staging_path(root_path: &Path) -> Result<PathBuf> {
+    Ok(colocated_storage_dir(root_path)?.join("hnsw.reindex-staging.usearch"))
+}
+
 /// True iff a colocated storage dir exists for the given root.
 ///
 /// Why: used by the discovery scanner to identify project roots that have

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -493,6 +493,29 @@ pub fn corpus_redb_tmp_path(index_id: &str) -> Result<PathBuf> {
     Ok(index_data_dir(index_id)?.join("index.redb.tmp"))
 }
 
+/// Path to the staging HNSW snapshot written by the periodic incremental
+/// persister while a reindex is `Running` (issue #3970).
+///
+/// Why: mirrors [`corpus_redb_tmp_path`] — every periodic HNSW checkpoint
+/// during a reindex writes here instead of the live [`hnsw_path`], so the
+/// live snapshot is never overwritten with partial state. Fixed filename
+/// (not per-run-unique), matching the redb corpus tmp path's convention: the
+/// NEXT reindex attempt's periodic saves simply overwrite this file again, so
+/// staging never accumulates across retries. If a reindex is interrupted and
+/// never retried, this file is left on disk until the next reindex attempt —
+/// the same accepted trade-off [`corpus_redb_tmp_path`] already has (no
+/// boot-time sweep exists for either).
+/// What: returns `<data_dir>/indexes/<id>/hnsw.reindex-staging.usearch`. The
+/// filename is deliberately ordered so `Path::with_extension("keys.json")`
+/// (the same idiom `UsearchStore::save` uses to derive a sidecar from its
+/// binary path) yields the matching staging sidecar
+/// `hnsw.reindex-staging.keys.json` — putting `.usearch` last, as the live
+/// `hnsw.usearch` path does, rather than appending a suffix after it.
+/// Test: `service::reindex::hnsw_swap::tests`.
+pub fn hnsw_staging_path(index_id: &str) -> Result<PathBuf> {
+    Ok(index_data_dir(index_id)?.join("hnsw.reindex-staging.usearch"))
+}
+
 /// Resolve the HNSW snapshot path for `entry`, routing to colocated or legacy
 /// storage based on `entry.colocated`.
 ///

--- a/crates/trusty-search/src/service/reindex/finish.rs
+++ b/crates/trusty-search/src/service/reindex/finish.rs
@@ -31,6 +31,7 @@ use super::completion::{
 use super::corpus_swap::{abort_staged_corpus_swap, commit_staged_corpus_swap};
 use super::defer_embed::spawn_deferred_embed_pass;
 use super::guard::ReindexTerminationGuard;
+use super::hnsw_swap::{abort_staged_hnsw_swap, commit_staged_hnsw_swap, HnswSwapPaths};
 use super::progress::{ReindexProgress, ReindexStatus};
 use super::quarantine::ReindexQuarantine;
 use super::stages::{
@@ -85,6 +86,7 @@ pub(super) struct FinishCtx {
     pub(super) started: Instant,
     pub(super) defer_embed: bool,
     pub(super) corpus_swap_tmp: Option<PathBuf>,
+    pub(super) hnsw_swap_paths: Option<HnswSwapPaths>,
     pub(super) mem_abort: Arc<AtomicBool>,
     pub(super) peak_rss_atomic: Arc<AtomicU64>,
     pub(super) peak_embedderd_rss_atomic: Arc<AtomicU64>,
@@ -122,6 +124,7 @@ pub(super) async fn finish_reindex(ctx: FinishCtx, totals: BatchTotals) {
         started,
         defer_embed,
         corpus_swap_tmp,
+        hnsw_swap_paths,
         mem_abort,
         peak_rss_atomic,
         peak_embedderd_rss_atomic,
@@ -210,11 +213,26 @@ pub(super) async fn finish_reindex(ctx: FinishCtx, totals: BatchTotals) {
         .await;
     }
 
-    // Issue #29: force a final HNSW snapshot so tail batches are durable.
-    {
+    // Issue #29 / #3970: force a final HNSW snapshot so tail batches are
+    // durable, and resolve the staged HNSW swap. When `hnsw_swap_paths` is
+    // `Some` (the common case), `resolve_hnsw_swap` below performs an AWAITED
+    // final save straight to the staging path and — only on a `Commit`
+    // resolution — atomically publishes it to the live path; that awaited
+    // save subsumes the old fire-and-forget `force_incremental_persist()`
+    // call for this codepath. When staging was never begun (path
+    // unresolvable at reindex start), fall back to the original detached
+    // forced save direct-to-live, exactly as before this fix.
+    if hnsw_swap_paths.is_none() {
         let indexer = handle.indexer.read().await;
         indexer.force_incremental_persist();
     }
+    resolve_hnsw_swap(
+        &handle,
+        &index_id,
+        hnsw_swap_paths.as_ref(),
+        &staging_resolution,
+    )
+    .await;
 
     // Issue #603: resolve the atomic corpus swap.
     resolve_corpus_swap(
@@ -532,6 +550,40 @@ async fn resolve_corpus_swap(
                 index_id.0,
             );
         }
+    }
+}
+
+/// Resolve the staged HNSW swap: commit or roll back (issue #3970).
+///
+/// Why: extracted so `finish_reindex` stays readable — mirrors
+/// `resolve_corpus_swap`, reusing the SAME `staging_resolution` the corpus
+/// swap already computed (a `Ready` outcome with no memory-abort commits,
+/// anything else rolls back). No-op when `hnsw_swap_paths` is `None` (staging
+/// was never begun, e.g. an unresolvable path at reindex start) — the caller
+/// already fell back to the old detached forced-save-to-live in that case.
+/// What: `Commit` publishes the staged snapshot atomically to the live path;
+/// `Rollback` discards the staged snapshot and leaves the live one untouched.
+/// Test: `hnsw_swap::tests::commit_staged_hnsw_swap_publishes_final_state`,
+/// `hnsw_swap::tests::abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging`.
+async fn resolve_hnsw_swap(
+    handle: &IndexHandle,
+    index_id: &IndexId,
+    hnsw_swap_paths: Option<&HnswSwapPaths>,
+    staging_resolution: &staging::StagingResolution,
+) {
+    let Some(paths) = hnsw_swap_paths else {
+        return;
+    };
+    if staging_resolution.is_commit() {
+        commit_staged_hnsw_swap(handle, index_id, paths).await;
+    } else {
+        if let staging::StagingResolution::Rollback { reason } = staging_resolution {
+            tracing::warn!(
+                "reindex[{}]: rolling back staged HNSW snapshot — {reason}",
+                index_id.0,
+            );
+        }
+        abort_staged_hnsw_swap(handle, index_id, paths).await;
     }
 }
 

--- a/crates/trusty-search/src/service/reindex/hnsw_swap.rs
+++ b/crates/trusty-search/src/service/reindex/hnsw_swap.rs
@@ -182,6 +182,42 @@ pub(super) async fn commit_staged_hnsw_swap(
     // Round-2 CRITICAL 2: quiesce BEFORE touching anything else. While we
     // wait, `reindexing` stays `true`, so any still-running task keeps
     // correctly targeting staging.
+    //
+    // LOAD-BEARING INVARIANTS if this times out (round-3 review — a `false`
+    // return does NOT itself make proceeding safe; these two facts do):
+    //
+    // 1. A still-running task's CURRENT (and, in practice, only) iteration
+    //    already fixed its target as `staging` before this wait began —
+    //    `spawn_incremental_persist` reads `PersistState::reindexing` fresh
+    //    at the top of each coalescing-loop iteration, and `reindexing` was
+    //    still `true` when that iteration started. It can only pick a
+    //    DIFFERENT target by starting a NEW iteration, which requires
+    //    `PersistState::dirty` to be set again — and nothing sets `dirty`
+    //    for this index between the reindex's batch loop ending and this
+    //    swap resolving (the only caller, `commit_parsed_batch`, is not
+    //    invoked again for this index until either a watch-loop event or the
+    //    NEXT reindex). So however long that task remains "stuck", it can
+    //    only ever finish writing to `staging` — never `live` — for the
+    //    stuck iteration itself.
+    // 2. `UsearchStore::save`'s `save_lock` (a `tokio::sync::Mutex`, see that
+    //    field's doc) additionally serializes our OWN forced final save
+    //    (just below) against that same stuck task's save: if the stuck task
+    //    is holding `save_lock`, our save queues behind it and only starts
+    //    once it releases; if the stuck task hasn't yet acquired it, ours
+    //    may run first and the stuck task's save queues behind OURS. Either
+    //    way, by the time our save (and the rename further below) completes,
+    //    any concurrent save from that task has been folded into a
+    //    consistent ordering — our save is never torn by, and never tears,
+    //    a concurrent write from it.
+    //
+    // Fact 1 is what actually prevents the live path from being corrupted by
+    // a stuck task in the timeout case; fact 2 is what makes OUR OWN forced
+    // save (and therefore the swap we're about to publish) correct and
+    // uncorrupted regardless of what that stuck task is doing concurrently.
+    // If a future change makes `dirty` reachable for this index during this
+    // window (fact 1) — or narrows `save_lock` to not cover the whole save
+    // (fact 2) — this reasoning breaks and the CRITICAL 2 race this
+    // drain-wait exists to close can reopen on the timeout path specifically.
     if !handle
         .indexer
         .read()
@@ -191,8 +227,11 @@ pub(super) async fn commit_staged_hnsw_swap(
     {
         tracing::warn!(
             "staged hnsw swap: a periodic persist task for '{}' did not quiesce within {:?} — \
-             proceeding with the swap anyway (issue #3970 round-2); if that task is still \
-             running it will keep targeting staging (reindexing is still set), not live",
+             proceeding with the swap anyway (issue #3970 round-2); safe only because a \
+             still-in-flight task's target was already fixed as staging before this wait \
+             began (dirty can't be re-triggered for this index in this window) and \
+             UsearchStore::save's save_lock serializes our forced final save against it — \
+             see this branch's doc comment",
             index_id.0,
             PERSIST_DRAIN_TIMEOUT,
         );
@@ -308,7 +347,19 @@ pub(super) async fn abort_staged_hnsw_swap(
     index_id: &IndexId,
     paths: &HnswSwapPaths,
 ) {
-    // Round-2 CRITICAL 2: see `commit_staged_hnsw_swap`'s identical guard.
+    // Round-2 CRITICAL 2: quiesce before touching anything else — see
+    // `commit_staged_hnsw_swap`'s doc comment on its identical wait for the
+    // full two-part reasoning. Only INVARIANT 1 there applies to abort
+    // (a still-running task's current iteration already fixed `staging` as
+    // its target before this wait began, and cannot re-target `live`
+    // without a fresh `dirty` trigger that nothing produces for this index
+    // in this window): abort never calls `UsearchStore::save` itself, so
+    // INVARIANT 2 (the `save_lock` serialization against our OWN forced
+    // save) does not apply here — there is no forced save on this path for
+    // it to serialize against. That asymmetry is fine: invariant 1 alone is
+    // what actually keeps a stuck task off the live path; `save_lock` in
+    // commit's case is about that function's OWN save being correct, not an
+    // additional requirement for abort's safety.
     if !handle
         .indexer
         .read()
@@ -318,8 +369,10 @@ pub(super) async fn abort_staged_hnsw_swap(
     {
         tracing::warn!(
             "staged hnsw swap: a periodic persist task for '{}' did not quiesce within {:?} \
-             before abort — proceeding anyway (issue #3970 round-2); if that task is still \
-             running it will keep targeting staging (reindexing is still set), not live",
+             before abort — proceeding anyway (issue #3970 round-2); safe only because a \
+             still-in-flight task's target was already fixed as staging before this wait \
+             began and dirty can't be re-triggered for this index in this window — see \
+             this branch's doc comment",
             index_id.0,
             PERSIST_DRAIN_TIMEOUT,
         );

--- a/crates/trusty-search/src/service/reindex/hnsw_swap.rs
+++ b/crates/trusty-search/src/service/reindex/hnsw_swap.rs
@@ -1,0 +1,498 @@
+//! Staged-write-then-swap for the periodic HNSW snapshot (issue #3970).
+//!
+//! Why: `core::indexer::persist_hnsw::spawn_incremental_persist` checkpoints
+//! the in-memory HNSW graph to disk every [`crate::core::indexer::HNSW_SNAPSHOT_BATCH_INTERVAL`]
+//! batches during EVERY reindex, so a crash mid-reindex doesn't lose all
+//! progress. Before this fix that checkpoint wrote straight to the LIVE
+//! snapshot path. Reindex progress is monotonic, so any reasonably large
+//! reindex crossed `UsearchStore::save`'s shrink guard threshold as ordinary
+//! healthy progress — from that checkpoint on, the complete pre-reindex
+//! snapshot was already gone, and an ungraceful termination (SIGKILL,
+//! OOM-kill, abort, power loss) permanently stranded the index. PR #3968
+//! closed the equivalent race for the GRACEFUL shutdown path only
+//! (`service::shutdown_flush`); this module closes it for the periodic
+//! persister itself, mirroring the atomic staged-swap the redb chunk corpus
+//! already has (#603 / #839, `corpus_swap.rs`).
+//!
+//! What: three entry points, called from `runner.rs` / `finish.rs` alongside
+//! (not instead of) the existing redb corpus staging:
+//! - [`begin_staged_hnsw_swap`] — resolve the (live, staging) HNSW path pair
+//!   and flip the indexer's `reindexing` flag so
+//!   `spawn_incremental_persist`'s periodic checkpoints redirect to staging.
+//! - [`commit_staged_hnsw_swap`] — force one final, AWAITED save to staging
+//!   (so the tail batches the throttle skipped are captured), then atomically
+//!   rename staging → live (binary + sidecar).
+//! - [`abort_staged_hnsw_swap`] — clear the `reindexing` flag and
+//!   best-effort delete the staging files; the live snapshot is left
+//!   untouched.
+//!
+//! Deliberately does NOT route the periodic save through a
+//! skip-while-`Running` gate (the shutdown path's fix) — that would disable
+//! incremental persistence during the reindex entirely, trading this
+//! crash-safety hole for another (loses ALL progress, not just the tail).
+//! The periodic persister keeps checkpointing throughout the reindex; only
+//! its *destination* changes.
+//!
+//! Test: `tests` submodule below.
+
+use crate::core::registry::{IndexHandle, IndexId};
+use std::path::{Path, PathBuf};
+
+/// The (live, staging) HNSW snapshot path pair for one index.
+pub(super) struct HnswSwapPaths {
+    pub(super) live: PathBuf,
+    pub(super) staging: PathBuf,
+}
+
+/// Begin staged HNSW persistence for a reindex (issue #3970).
+///
+/// Why: called once, before the batch loop starts, so every periodic
+/// checkpoint for the duration of the reindex redirects to staging instead of
+/// the live snapshot.
+/// What: resolves the live + staging HNSW paths (colocated or legacy,
+/// mirroring `begin_staged_corpus_swap`'s own routing), sets
+/// `CodeIndexer::begin_reindex_staging`, and returns the pair. Returns `None`
+/// only when a path is unresolvable (e.g. an unwritable data dir) — in that
+/// case the reindexing flag is left untouched and the periodic persister
+/// keeps writing straight to the live path exactly as it did before this fix
+/// (a degraded-but-not-worse fallback, matching how `begin_staged_corpus_swap`
+/// falls back to direct-write mode on its own path failures).
+/// Test: `tests::begin_staged_hnsw_swap_resolves_legacy_paths`.
+pub(super) async fn begin_staged_hnsw_swap(
+    handle: &IndexHandle,
+    index_id: &IndexId,
+) -> Option<HnswSwapPaths> {
+    let is_colocated = crate::service::colocated_storage::has_colocated_storage(&handle.root_path);
+    let live = if is_colocated {
+        crate::service::colocated_storage::colocated_hnsw_path(&handle.root_path)
+    } else {
+        crate::service::persistence::hnsw_path(&index_id.0)
+    };
+    let live = match live {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                "staged hnsw swap: cannot resolve live hnsw path for '{}' ({e}) — periodic \
+                 checkpoints will keep writing directly to the live path",
+                index_id.0
+            );
+            return None;
+        }
+    };
+    let staging = if is_colocated {
+        crate::service::colocated_storage::colocated_hnsw_staging_path(&handle.root_path)
+    } else {
+        crate::service::persistence::hnsw_staging_path(&index_id.0)
+    };
+    let staging = match staging {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!(
+                "staged hnsw swap: cannot resolve staging hnsw path for '{}' ({e}) — periodic \
+                 checkpoints will keep writing directly to the live path",
+                index_id.0
+            );
+            return None;
+        }
+    };
+
+    handle.indexer.read().await.begin_reindex_staging();
+    tracing::debug!(
+        "staged hnsw swap: reindex staging began for '{}' (staging={})",
+        index_id.0,
+        staging.display()
+    );
+    Some(HnswSwapPaths { live, staging })
+}
+
+/// Finalize (commit) the staged HNSW swap after a successful reindex
+/// (issue #3970).
+///
+/// Why: publishes the reindex's final HNSW state to the live path in exactly
+/// one atomic step, mirroring `commit_staged_corpus_swap`.
+/// What: forces one last, AWAITED save to `paths.staging` (capturing any tail
+/// batches the throttle skipped since the last periodic checkpoint), clears
+/// the indexer's `reindexing` flag, then renames the staging binary and
+/// sidecar over the live ones. Both renames are same-directory (same
+/// filesystem) and individually atomic at the syscall level; a crash
+/// strictly between them can leave a live binary/sidecar pair that no longer
+/// match — `UsearchStore::load_from`'s existing corruption/mismatch guards
+/// (issue #2922) already treat that as "discard and fall back to a fresh
+/// store", so a botched swap loses this reindex's gains rather than
+/// corrupting or crashing. A failure at any step is logged and leaves the
+/// live snapshot at whatever it already was — never partially written.
+/// Test: `tests::commit_staged_hnsw_swap_publishes_final_state`.
+pub(super) async fn commit_staged_hnsw_swap(
+    handle: &IndexHandle,
+    index_id: &IndexId,
+    paths: &HnswSwapPaths,
+) {
+    // Issue #29 analogue: force a final checkpoint so the tail batches since
+    // the last throttled save are durable — but AWAITED (unlike
+    // `force_incremental_persist`, which only spawns a detached task) so the
+    // rename below is guaranteed to publish this up-to-date state, not a
+    // stale periodic one. `UsearchStore::save`'s own `save_lock` serializes
+    // this against any in-flight periodic checkpoint task, so this call
+    // simply waits its turn and then writes the truly-final state.
+    let save_result = {
+        let indexer = handle.indexer.read().await;
+        indexer.save_vector_store(&paths.staging).await
+    };
+
+    // Clear the reindexing flag regardless of outcome so any future commit
+    // (outside this reindex) resumes checkpointing straight to the live path.
+    handle.indexer.read().await.end_reindex_staging();
+
+    match save_result {
+        Ok(false) => {
+            // No vector store wired (BM25-only index) — nothing to swap.
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(
+                "staged hnsw swap: final staging save failed for '{}' ({e}) — live snapshot \
+                 left at its last periodic-persist state (issue #3970)",
+                index_id.0
+            );
+            return;
+        }
+        Ok(true) => {}
+    }
+
+    if !paths.staging.exists() {
+        // Nothing was ever written to staging this run (e.g. the index had
+        // zero vectors throughout) — no swap needed.
+        return;
+    }
+
+    let staging_sidecar = paths.staging.with_extension("keys.json");
+    let live_sidecar = paths.live.with_extension("keys.json");
+    let live = paths.live.clone();
+    let staging = paths.staging.clone();
+    let index_id_for_task = index_id.0.clone();
+    let rename_result = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        std::fs::rename(&staging, &live)?;
+        // The sidecar may be missing only in a degenerate empty-index case;
+        // tolerate `NotFound` so it doesn't mask the binary rename's success.
+        match std::fs::rename(&staging_sidecar, &live_sidecar) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e),
+        }
+    })
+    .await;
+
+    match rename_result {
+        Ok(Ok(())) => {
+            tracing::info!(
+                "staged hnsw swap: committed — atomically published the reindexed HNSW \
+                 snapshot to {} for '{}' (issue #3970)",
+                paths.live.display(),
+                index_id_for_task
+            );
+        }
+        Ok(Err(e)) => tracing::warn!(
+            "staged hnsw swap: rename failed for '{}' ({e}) — live snapshot left at its \
+             last periodic-persist state",
+            index_id_for_task
+        ),
+        Err(e) => tracing::warn!(
+            "staged hnsw swap: rename task panicked for '{}': {e}",
+            index_id_for_task
+        ),
+    }
+}
+
+/// Discard the staged HNSW snapshot after an aborted / failed / memory-
+/// aborted reindex (issue #3970).
+///
+/// Why: mirrors `abort_staged_corpus_swap` — a reindex that does not reach a
+/// `Ready` outcome must never publish its (by definition incomplete or
+/// invalid) staged snapshot over the live one.
+/// What: clears the indexer's `reindexing` flag so future commits resume
+/// writing to the live path, then best-effort deletes the staging binary +
+/// sidecar. The live snapshot is never touched. A left-behind staging file
+/// (e.g. delete failed) is harmlessly overwritten by the next reindex
+/// attempt's periodic checkpoints — same accepted trade-off the redb corpus
+/// tmp path already has.
+/// Test: `tests::abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging`.
+pub(super) async fn abort_staged_hnsw_swap(
+    handle: &IndexHandle,
+    index_id: &IndexId,
+    paths: &HnswSwapPaths,
+) {
+    handle.indexer.read().await.end_reindex_staging();
+
+    let staging = paths.staging.clone();
+    let staging_sidecar = paths.staging.with_extension("keys.json");
+    let index_id_for_task = index_id.0.clone();
+    let removed = tokio::task::spawn_blocking(move || {
+        remove_if_exists(&staging)?;
+        remove_if_exists(&staging_sidecar)?;
+        Ok::<(), std::io::Error>(())
+    })
+    .await;
+    match removed {
+        Ok(Ok(())) => {}
+        Ok(Err(e)) => tracing::warn!(
+            "staged hnsw swap: could not delete staging hnsw snapshot for '{}': {e} — will be \
+             overwritten by the next reindex attempt",
+            index_id_for_task
+        ),
+        Err(e) => tracing::warn!(
+            "staged hnsw swap: staging-delete task panicked for '{}': {e}",
+            index_id_for_task
+        ),
+    }
+}
+
+/// Remove `path` if present, treating `NotFound` as success.
+fn remove_if_exists(path: &Path) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::store::{UsearchStore, VectorStore as _};
+    use crate::core::CodeIndexer;
+
+    fn build_test_handle(
+        id_str: &str,
+        root: &std::path::Path,
+        store: Option<UsearchStore>,
+    ) -> (IndexId, IndexHandle) {
+        let id = IndexId::new(id_str.to_string());
+        let mut indexer = CodeIndexer::new(id.0.clone(), root);
+        if let Some(store) = store {
+            indexer.set_store(std::sync::Arc::new(store));
+        }
+        let handle = IndexHandle::bare(
+            id.clone(),
+            std::sync::Arc::new(tokio::sync::RwLock::new(indexer)),
+            root.to_path_buf(),
+        );
+        (id, handle)
+    }
+
+    async fn store_with_vectors(count: usize) -> UsearchStore {
+        let store = UsearchStore::new(4).unwrap();
+        let items: Vec<(String, Vec<f32>)> = (0..count)
+            .map(|i| (format!("chunk:{i}"), vec![i as f32 + 1.0, 0.0, 0.0, 0.0]))
+            .collect();
+        store.upsert_batch(&items).await.unwrap();
+        store
+    }
+
+    /// Why: `begin_staged_hnsw_swap` must resolve two distinct, correctly
+    /// suffixed paths and flip the indexer's `reindexing` flag.
+    /// Test: this test.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn begin_staged_hnsw_swap_resolves_legacy_paths() {
+        let data_dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+        let root_dir = tempfile::tempdir().unwrap();
+
+        let (id, handle) = build_test_handle("hnsw-swap-begin", root_dir.path(), None);
+        let paths = begin_staged_hnsw_swap(&handle, &id)
+            .await
+            .expect("resolves");
+
+        assert_ne!(paths.live, paths.staging, "live and staging must differ");
+        assert!(
+            paths.staging.to_string_lossy().contains("reindex-staging"),
+            "staging path must be distinguishable: {}",
+            paths.staging.display()
+        );
+        assert!(
+            handle.indexer.read().await.is_reindex_staging(),
+            "begin must flip the reindexing flag"
+        );
+
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+    }
+
+    /// Why (the core #3970 fix, proven end-to-end): committing must publish
+    /// the CURRENT in-memory state to the live path via the staged swap, and
+    /// clear the reindexing flag so later commits resume direct-to-live.
+    /// Test: this test.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn commit_staged_hnsw_swap_publishes_final_state() {
+        let data_dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+        let root_dir = tempfile::tempdir().unwrap();
+
+        let store = store_with_vectors(50).await;
+        let (id, handle) = build_test_handle("hnsw-swap-commit", root_dir.path(), Some(store));
+        let paths = begin_staged_hnsw_swap(&handle, &id)
+            .await
+            .expect("resolves");
+
+        commit_staged_hnsw_swap(&handle, &id, &paths).await;
+
+        assert!(
+            !handle.indexer.read().await.is_reindex_staging(),
+            "commit must clear the reindexing flag"
+        );
+        assert!(paths.live.exists(), "commit must publish to the live path");
+        assert!(
+            !paths.staging.exists(),
+            "commit must rename staging away (no leftover staging file)"
+        );
+        let reloaded = UsearchStore::load_from(&paths.live)
+            .await
+            .expect("load ok")
+            .expect("some");
+        assert_eq!(reloaded.len().await.unwrap(), 50);
+
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+    }
+
+    /// Why: an aborted/rolled-back reindex must never publish its staged
+    /// (incomplete or invalid) snapshot — the live snapshot must be exactly
+    /// what it was before the reindex began, and staging must be cleaned up.
+    /// Test: this test.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging() {
+        let data_dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+        let root_dir = tempfile::tempdir().unwrap();
+
+        // Seed a complete live snapshot BEFORE the reindex begins.
+        let seed = store_with_vectors(200).await;
+        let (id, handle) = build_test_handle("hnsw-swap-abort", root_dir.path(), None);
+        let paths = begin_staged_hnsw_swap(&handle, &id)
+            .await
+            .expect("resolves");
+        seed.save(&paths.live).await.expect("seed save");
+        let live_before = std::fs::read(&paths.live).expect("read seeded live");
+
+        // Simulate a partial reindex checkpoint landing in staging.
+        let partial = store_with_vectors(30).await;
+        partial.save(&paths.staging).await.expect("partial save");
+        assert!(paths.staging.exists());
+
+        abort_staged_hnsw_swap(&handle, &id, &paths).await;
+
+        assert!(
+            !handle.indexer.read().await.is_reindex_staging(),
+            "abort must clear the reindexing flag"
+        );
+        let live_after = std::fs::read(&paths.live).expect("read live after abort");
+        assert_eq!(
+            live_after, live_before,
+            "abort must leave the live snapshot byte-for-byte unchanged"
+        );
+        assert!(
+            !paths.staging.exists(),
+            "abort must delete the staging snapshot"
+        );
+
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+    }
+
+    /// Why (issue #3970 — staging cleanup / restart behavior after an
+    /// UNGRACEFUL interruption): an ungraceful crash (SIGKILL/OOM-kill/abort/
+    /// power loss) mid-reindex runs neither `commit_staged_hnsw_swap` nor
+    /// `abort_staged_hnsw_swap` — there is no boot-time sweep for a stale
+    /// staging file, the same accepted trade-off the redb corpus tmp path
+    /// already has. This test proves that leftover staging file is inert
+    /// (never mistaken for a live/loadable snapshot) and self-cleaning: the
+    /// NEXT reindex attempt's own staging writes simply overwrite it, and a
+    /// successful commit from that next attempt publishes correctly despite
+    /// the orphaned leftover.
+    /// What: seeds a live snapshot, simulates an interrupted first reindex
+    /// attempt (`begin` + a partial checkpoint written straight to the
+    /// staging path, mimicking `spawn_incremental_persist`, then NEITHER
+    /// commit nor abort — the crash). Asserts a `load_from(live)` at that
+    /// point (simulating a warm-boot right after the crash) restores the
+    /// pre-crash complete state, completely unaffected by the orphaned
+    /// staging file. Then simulates a second, successful reindex attempt
+    /// (`begin` again + a full checkpoint + `commit`) and asserts the final
+    /// live state is that second attempt's data, with no leftover staging
+    /// file remaining.
+    /// Test: this test.
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn interrupted_reindex_leaves_inert_staging_that_next_attempt_overwrites() {
+        let data_dir = tempfile::tempdir().unwrap();
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+        let root_dir = tempfile::tempdir().unwrap();
+
+        // Seed the pre-crash complete live snapshot.
+        let seed = store_with_vectors(100).await;
+        let (id, handle) = build_test_handle("hnsw-swap-restart", root_dir.path(), None);
+        let paths = begin_staged_hnsw_swap(&handle, &id)
+            .await
+            .expect("resolves");
+        seed.save(&paths.live).await.expect("seed save");
+
+        // First reindex attempt: begin staging, write ONE partial checkpoint
+        // straight to the staging path (mirrors what
+        // `spawn_incremental_persist` does mid-reindex) — then simulate an
+        // ungraceful crash: neither commit nor abort ever runs.
+        let attempt_one_partial = store_with_vectors(40).await;
+        attempt_one_partial
+            .save(&paths.staging)
+            .await
+            .expect("attempt-1 partial checkpoint");
+        assert!(
+            paths.staging.exists(),
+            "orphaned staging file must exist post-crash"
+        );
+
+        // Simulate a warm-boot immediately after the crash: only the LIVE
+        // path is ever loaded at boot — the orphaned staging file must be
+        // completely inert and never consulted.
+        let post_crash_boot = UsearchStore::load_from(&paths.live)
+            .await
+            .expect("load ok")
+            .expect("some");
+        assert_eq!(
+            post_crash_boot.len().await.unwrap(),
+            100,
+            "warm-boot after an ungraceful crash must restore the last COMPLETE \
+             live snapshot, unaffected by the orphaned partial staging file"
+        );
+
+        // Second reindex attempt for the SAME index: begin again (as the
+        // orchestrator does for every reindex, retried or not), write a
+        // fresh full checkpoint — overwriting the orphaned leftover, proving
+        // it does not accumulate — and commit successfully this time.
+        let paths_attempt_two = begin_staged_hnsw_swap(&handle, &id)
+            .await
+            .expect("resolves");
+        let attempt_two_full = store_with_vectors(150).await;
+        handle
+            .indexer
+            .write()
+            .await
+            .set_store(std::sync::Arc::new(attempt_two_full));
+        commit_staged_hnsw_swap(&handle, &id, &paths_attempt_two).await;
+
+        assert!(
+            !paths_attempt_two.staging.exists(),
+            "a successful next attempt must leave no leftover staging file — \
+             the orphan from the crashed attempt does not accumulate"
+        );
+        let final_live = UsearchStore::load_from(&paths_attempt_two.live)
+            .await
+            .expect("load ok")
+            .expect("some");
+        assert_eq!(
+            final_live.len().await.unwrap(),
+            150,
+            "the retried reindex's complete state must be what's live, not the \
+             crashed attempt's partial state nor the pre-crash seed"
+        );
+
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+    }
+}

--- a/crates/trusty-search/src/service/reindex/hnsw_swap.rs
+++ b/crates/trusty-search/src/service/reindex/hnsw_swap.rs
@@ -19,12 +19,14 @@
 //! - [`begin_staged_hnsw_swap`] — resolve the (live, staging) HNSW path pair
 //!   and flip the indexer's `reindexing` flag so
 //!   `spawn_incremental_persist`'s periodic checkpoints redirect to staging.
-//! - [`commit_staged_hnsw_swap`] — force one final, AWAITED save to staging
-//!   (so the tail batches the throttle skipped are captured), then atomically
-//!   rename staging → live (binary + sidecar).
-//! - [`abort_staged_hnsw_swap`] — clear the `reindexing` flag and
-//!   best-effort delete the staging files; the live snapshot is left
-//!   untouched.
+//! - [`commit_staged_hnsw_swap`] — waits for any still-coalescing periodic
+//!   persist task to quiesce, forces one final AWAITED save to staging (so
+//!   the tail batches the throttle skipped are captured), renames the
+//!   staging sidecar then the staging binary over the live ones, and only
+//!   then clears `reindexing`.
+//! - [`abort_staged_hnsw_swap`] — same quiesce-wait, then best-effort
+//!   deletes the staging files (the live snapshot is left untouched), and
+//!   only then clears `reindexing`.
 //!
 //! Deliberately does NOT route the periodic save through a
 //! skip-while-`Running` gate (the shutdown path's fix) — that would disable
@@ -32,6 +34,22 @@
 //! crash-safety hole for another (loses ALL progress, not just the tail).
 //! The periodic persister keeps checkpointing throughout the reindex; only
 //! its *destination* changes.
+//!
+//! Round-2 adversarial review (two CRITICALs, fixed below — read the doc
+//! comments on [`commit_staged_hnsw_swap`] / [`abort_staged_hnsw_swap`] for
+//! the full mechanics of each):
+//! 1. The staging→live swap is two renames, not one — sidecar is now renamed
+//!    BEFORE the binary so a crash strictly between them can only leave a
+//!    live pairing whose `next_key` is ahead of (never behind) actual usage,
+//!    which cannot collide on the next write; `UsearchStore::load_from` also
+//!    now refuses a binary reporting MORE vectors than its sidecar describes,
+//!    as additional defense-in-depth against a torn pairing from any source.
+//! 2. `end_reindex_staging()` is no longer the first thing either function
+//!    does — both now wait for `CodeIndexer::wait_for_incremental_persist_drain`
+//!    before touching anything, and only clear the flag after the swap (or
+//!    abort cleanup) has fully resolved, closing a race where a detached
+//!    periodic-persist task that outlived the reindex's batch loop could
+//!    still observe the flag flip and write partial state straight to live.
 //!
 //! Test: `tests` submodule below.
 
@@ -105,47 +123,96 @@ pub(super) async fn begin_staged_hnsw_swap(
     Some(HnswSwapPaths { live, staging })
 }
 
+/// Bound on how long [`commit_staged_hnsw_swap`] / [`abort_staged_hnsw_swap`]
+/// wait for a still-coalescing periodic persist task to quiesce before
+/// resolving the swap (issue #3970 round-2 review, CRITICAL finding 2).
+///
+/// Why: bounded so a pathological stall in the periodic persister (e.g. a
+/// stuck disk) cannot hang the reindex's terminal event forever — matches
+/// the order of magnitude of other bounded persistence waits in this crate
+/// (`service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS`).
+const PERSIST_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
 /// Finalize (commit) the staged HNSW swap after a successful reindex
 /// (issue #3970).
 ///
 /// Why: publishes the reindex's final HNSW state to the live path in exactly
-/// one atomic step, mirroring `commit_staged_corpus_swap`.
-/// What: forces one last, AWAITED save to `paths.staging` (capturing any tail
-/// batches the throttle skipped since the last periodic checkpoint), clears
-/// the indexer's `reindexing` flag, then renames the staging binary and
-/// sidecar over the live ones. Both renames are same-directory (same
-/// filesystem) and individually atomic at the syscall level; a crash
-/// strictly between them can leave a live binary/sidecar pair that no longer
-/// match — `UsearchStore::load_from`'s existing corruption/mismatch guards
-/// (issue #2922) already treat that as "discard and fall back to a fresh
-/// store", so a botched swap loses this reindex's gains rather than
-/// corrupting or crashing. A failure at any step is logged and leaves the
-/// live snapshot at whatever it already was — never partially written.
-/// Test: `tests::commit_staged_hnsw_swap_publishes_final_state`.
+/// one step, mirroring `commit_staged_corpus_swap`.
+/// What:
+/// 1. Waits (bounded, [`PERSIST_DRAIN_TIMEOUT`]) for any still-coalescing
+///    periodic persist task to fully quiesce — see
+///    [`crate::core::CodeIndexer::wait_for_incremental_persist_drain`] for
+///    why this must happen BEFORE anything else (round-2 CRITICAL 2: without
+///    it, a task that outlives the batch loop could still write partial
+///    state straight to the live path after the flag below is cleared).
+/// 2. Forces one last, AWAITED save to `paths.staging` (capturing any tail
+///    batches the throttle skipped), now guaranteed uncontended.
+/// 3. Renames the staging sidecar THEN the staging binary over the live
+///    ones (round-2 CRITICAL 1 — see the ordering rationale below).
+/// 4. ONLY NOW clears the indexer's `reindexing` flag, once the swap is
+///    fully resolved — never before.
+///
+/// Rename ordering (round-2 CRITICAL 1): both renames are same-directory
+/// (same filesystem) and individually atomic at the syscall level, but the
+/// PAIR is not atomic — a crash strictly between them leaves a "torn" live
+/// pair. Renaming the SIDECAR first means the only possible torn state is
+/// OLD binary + NEW sidecar (never the reverse): `next_key` restored from
+/// that newer sidecar is then guaranteed >= every key ever allocated on this
+/// store (`next_key` only ever increases — see `UsearchStore::next_key`'s
+/// doc), so a subsequent `upsert` of a genuinely new chunk can never be
+/// allocated a key that collides with an existing occupied slot in whichever
+/// binary ends up live. The reverse order (binary-first, the pre-round-2
+/// shape of this function) can leave NEW binary + OLD sidecar instead — a
+/// stale, BEHIND-actual-usage `next_key` that CAN collide, silently
+/// overwriting an unrelated live vector on the next write. As additional
+/// defense-in-depth, `UsearchStore::load_from` now refuses to load a binary
+/// that reports MORE vectors than its paired sidecar's key map describes
+/// (the direction only a torn pairing — never legitimate operation — can
+/// produce; see that guard's doc), so even a torn pairing from some other
+/// source is caught rather than silently trusted.
+/// A failure at any step is logged and leaves the live snapshot at whatever
+/// it already was — never partially written.
+/// Test: `tests::commit_staged_hnsw_swap_publishes_final_state`,
+/// `tests::commit_staged_hnsw_swap_waits_for_in_flight_persist_before_clearing_flag`.
 pub(super) async fn commit_staged_hnsw_swap(
     handle: &IndexHandle,
     index_id: &IndexId,
     paths: &HnswSwapPaths,
 ) {
+    // Round-2 CRITICAL 2: quiesce BEFORE touching anything else. While we
+    // wait, `reindexing` stays `true`, so any still-running task keeps
+    // correctly targeting staging.
+    if !handle
+        .indexer
+        .read()
+        .await
+        .wait_for_incremental_persist_drain(PERSIST_DRAIN_TIMEOUT)
+        .await
+    {
+        tracing::warn!(
+            "staged hnsw swap: a periodic persist task for '{}' did not quiesce within {:?} — \
+             proceeding with the swap anyway (issue #3970 round-2); if that task is still \
+             running it will keep targeting staging (reindexing is still set), not live",
+            index_id.0,
+            PERSIST_DRAIN_TIMEOUT,
+        );
+    }
+
     // Issue #29 analogue: force a final checkpoint so the tail batches since
     // the last throttled save are durable — but AWAITED (unlike
     // `force_incremental_persist`, which only spawns a detached task) so the
     // rename below is guaranteed to publish this up-to-date state, not a
-    // stale periodic one. `UsearchStore::save`'s own `save_lock` serializes
-    // this against any in-flight periodic checkpoint task, so this call
-    // simply waits its turn and then writes the truly-final state.
+    // stale periodic one. Uncontended now that the drain-wait above has
+    // returned (or timed out).
     let save_result = {
         let indexer = handle.indexer.read().await;
         indexer.save_vector_store(&paths.staging).await
     };
 
-    // Clear the reindexing flag regardless of outcome so any future commit
-    // (outside this reindex) resumes checkpointing straight to the live path.
-    handle.indexer.read().await.end_reindex_staging();
-
     match save_result {
         Ok(false) => {
             // No vector store wired (BM25-only index) — nothing to swap.
+            handle.indexer.read().await.end_reindex_staging();
             return;
         }
         Err(e) => {
@@ -154,6 +221,7 @@ pub(super) async fn commit_staged_hnsw_swap(
                  left at its last periodic-persist state (issue #3970)",
                 index_id.0
             );
+            handle.indexer.read().await.end_reindex_staging();
             return;
         }
         Ok(true) => {}
@@ -162,6 +230,7 @@ pub(super) async fn commit_staged_hnsw_swap(
     if !paths.staging.exists() {
         // Nothing was ever written to staging this run (e.g. the index had
         // zero vectors throughout) — no swap needed.
+        handle.indexer.read().await.end_reindex_staging();
         return;
     }
 
@@ -170,15 +239,19 @@ pub(super) async fn commit_staged_hnsw_swap(
     let live = paths.live.clone();
     let staging = paths.staging.clone();
     let index_id_for_task = index_id.0.clone();
+    // Round-2 CRITICAL 1: sidecar renamed FIRST — see this function's doc
+    // for why that ordering is the direction a torn swap can safely fail
+    // into, rather than the collision-prone direction the reverse order
+    // risks.
     let rename_result = tokio::task::spawn_blocking(move || -> std::io::Result<()> {
-        std::fs::rename(&staging, &live)?;
         // The sidecar may be missing only in a degenerate empty-index case;
-        // tolerate `NotFound` so it doesn't mask the binary rename's success.
+        // tolerate `NotFound` so it doesn't mask the binary rename below.
         match std::fs::rename(&staging_sidecar, &live_sidecar) {
             Ok(()) => Ok(()),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
             Err(e) => Err(e),
-        }
+        }?;
+        std::fs::rename(&staging, &live)
     })
     .await;
 
@@ -201,6 +274,10 @@ pub(super) async fn commit_staged_hnsw_swap(
             index_id_for_task
         ),
     }
+
+    // Round-2 CRITICAL 2: only clear the flag once the swap has fully
+    // resolved (rename attempted and settled either way) — never before.
+    handle.indexer.read().await.end_reindex_staging();
 }
 
 /// Discard the staged HNSW snapshot after an aborted / failed / memory-
@@ -209,19 +286,44 @@ pub(super) async fn commit_staged_hnsw_swap(
 /// Why: mirrors `abort_staged_corpus_swap` — a reindex that does not reach a
 /// `Ready` outcome must never publish its (by definition incomplete or
 /// invalid) staged snapshot over the live one.
-/// What: clears the indexer's `reindexing` flag so future commits resume
-/// writing to the live path, then best-effort deletes the staging binary +
-/// sidecar. The live snapshot is never touched. A left-behind staging file
-/// (e.g. delete failed) is harmlessly overwritten by the next reindex
-/// attempt's periodic checkpoints — same accepted trade-off the redb corpus
-/// tmp path already has.
-/// Test: `tests::abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging`.
+/// What:
+/// 1. Waits (bounded, [`PERSIST_DRAIN_TIMEOUT`]) for any still-coalescing
+///    periodic persist task to quiesce — round-2 CRITICAL 2, see
+///    [`commit_staged_hnsw_swap`]'s doc for the full race this closes. It
+///    matters just as much here: the in-memory store at abort time is, by
+///    definition, partial/invalid, so a stale task racing past a
+///    too-early flag-clear would write exactly that partial state to LIVE.
+/// 2. Best-effort deletes the staging binary + sidecar. The live snapshot is
+///    never touched.
+/// 3. ONLY NOW clears the indexer's `reindexing` flag so future commits
+///    (outside this reindex) resume writing to the live path.
+///
+/// A left-behind staging file (e.g. delete failed) is harmlessly overwritten
+/// by the next reindex attempt's periodic checkpoints — same accepted
+/// trade-off the redb corpus tmp path already has.
+/// Test: `tests::abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging`,
+/// `tests::abort_staged_hnsw_swap_waits_for_in_flight_persist_before_clearing_flag`.
 pub(super) async fn abort_staged_hnsw_swap(
     handle: &IndexHandle,
     index_id: &IndexId,
     paths: &HnswSwapPaths,
 ) {
-    handle.indexer.read().await.end_reindex_staging();
+    // Round-2 CRITICAL 2: see `commit_staged_hnsw_swap`'s identical guard.
+    if !handle
+        .indexer
+        .read()
+        .await
+        .wait_for_incremental_persist_drain(PERSIST_DRAIN_TIMEOUT)
+        .await
+    {
+        tracing::warn!(
+            "staged hnsw swap: a periodic persist task for '{}' did not quiesce within {:?} \
+             before abort — proceeding anyway (issue #3970 round-2); if that task is still \
+             running it will keep targeting staging (reindexing is still set), not live",
+            index_id.0,
+            PERSIST_DRAIN_TIMEOUT,
+        );
+    }
 
     let staging = paths.staging.clone();
     let staging_sidecar = paths.staging.with_extension("keys.json");
@@ -244,6 +346,10 @@ pub(super) async fn abort_staged_hnsw_swap(
             index_id_for_task
         ),
     }
+
+    // Round-2 CRITICAL 2: only clear the flag once staging cleanup has fully
+    // resolved — never before.
+    handle.indexer.read().await.end_reindex_staging();
 }
 
 /// Remove `path` if present, treating `NotFound` as success.
@@ -256,243 +362,5 @@ fn remove_if_exists(path: &Path) -> std::io::Result<()> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::store::{UsearchStore, VectorStore as _};
-    use crate::core::CodeIndexer;
-
-    fn build_test_handle(
-        id_str: &str,
-        root: &std::path::Path,
-        store: Option<UsearchStore>,
-    ) -> (IndexId, IndexHandle) {
-        let id = IndexId::new(id_str.to_string());
-        let mut indexer = CodeIndexer::new(id.0.clone(), root);
-        if let Some(store) = store {
-            indexer.set_store(std::sync::Arc::new(store));
-        }
-        let handle = IndexHandle::bare(
-            id.clone(),
-            std::sync::Arc::new(tokio::sync::RwLock::new(indexer)),
-            root.to_path_buf(),
-        );
-        (id, handle)
-    }
-
-    async fn store_with_vectors(count: usize) -> UsearchStore {
-        let store = UsearchStore::new(4).unwrap();
-        let items: Vec<(String, Vec<f32>)> = (0..count)
-            .map(|i| (format!("chunk:{i}"), vec![i as f32 + 1.0, 0.0, 0.0, 0.0]))
-            .collect();
-        store.upsert_batch(&items).await.unwrap();
-        store
-    }
-
-    /// Why: `begin_staged_hnsw_swap` must resolve two distinct, correctly
-    /// suffixed paths and flip the indexer's `reindexing` flag.
-    /// Test: this test.
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn begin_staged_hnsw_swap_resolves_legacy_paths() {
-        let data_dir = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
-        let root_dir = tempfile::tempdir().unwrap();
-
-        let (id, handle) = build_test_handle("hnsw-swap-begin", root_dir.path(), None);
-        let paths = begin_staged_hnsw_swap(&handle, &id)
-            .await
-            .expect("resolves");
-
-        assert_ne!(paths.live, paths.staging, "live and staging must differ");
-        assert!(
-            paths.staging.to_string_lossy().contains("reindex-staging"),
-            "staging path must be distinguishable: {}",
-            paths.staging.display()
-        );
-        assert!(
-            handle.indexer.read().await.is_reindex_staging(),
-            "begin must flip the reindexing flag"
-        );
-
-        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
-    }
-
-    /// Why (the core #3970 fix, proven end-to-end): committing must publish
-    /// the CURRENT in-memory state to the live path via the staged swap, and
-    /// clear the reindexing flag so later commits resume direct-to-live.
-    /// Test: this test.
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn commit_staged_hnsw_swap_publishes_final_state() {
-        let data_dir = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
-        let root_dir = tempfile::tempdir().unwrap();
-
-        let store = store_with_vectors(50).await;
-        let (id, handle) = build_test_handle("hnsw-swap-commit", root_dir.path(), Some(store));
-        let paths = begin_staged_hnsw_swap(&handle, &id)
-            .await
-            .expect("resolves");
-
-        commit_staged_hnsw_swap(&handle, &id, &paths).await;
-
-        assert!(
-            !handle.indexer.read().await.is_reindex_staging(),
-            "commit must clear the reindexing flag"
-        );
-        assert!(paths.live.exists(), "commit must publish to the live path");
-        assert!(
-            !paths.staging.exists(),
-            "commit must rename staging away (no leftover staging file)"
-        );
-        let reloaded = UsearchStore::load_from(&paths.live)
-            .await
-            .expect("load ok")
-            .expect("some");
-        assert_eq!(reloaded.len().await.unwrap(), 50);
-
-        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
-    }
-
-    /// Why: an aborted/rolled-back reindex must never publish its staged
-    /// (incomplete or invalid) snapshot — the live snapshot must be exactly
-    /// what it was before the reindex began, and staging must be cleaned up.
-    /// Test: this test.
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging() {
-        let data_dir = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
-        let root_dir = tempfile::tempdir().unwrap();
-
-        // Seed a complete live snapshot BEFORE the reindex begins.
-        let seed = store_with_vectors(200).await;
-        let (id, handle) = build_test_handle("hnsw-swap-abort", root_dir.path(), None);
-        let paths = begin_staged_hnsw_swap(&handle, &id)
-            .await
-            .expect("resolves");
-        seed.save(&paths.live).await.expect("seed save");
-        let live_before = std::fs::read(&paths.live).expect("read seeded live");
-
-        // Simulate a partial reindex checkpoint landing in staging.
-        let partial = store_with_vectors(30).await;
-        partial.save(&paths.staging).await.expect("partial save");
-        assert!(paths.staging.exists());
-
-        abort_staged_hnsw_swap(&handle, &id, &paths).await;
-
-        assert!(
-            !handle.indexer.read().await.is_reindex_staging(),
-            "abort must clear the reindexing flag"
-        );
-        let live_after = std::fs::read(&paths.live).expect("read live after abort");
-        assert_eq!(
-            live_after, live_before,
-            "abort must leave the live snapshot byte-for-byte unchanged"
-        );
-        assert!(
-            !paths.staging.exists(),
-            "abort must delete the staging snapshot"
-        );
-
-        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
-    }
-
-    /// Why (issue #3970 — staging cleanup / restart behavior after an
-    /// UNGRACEFUL interruption): an ungraceful crash (SIGKILL/OOM-kill/abort/
-    /// power loss) mid-reindex runs neither `commit_staged_hnsw_swap` nor
-    /// `abort_staged_hnsw_swap` — there is no boot-time sweep for a stale
-    /// staging file, the same accepted trade-off the redb corpus tmp path
-    /// already has. This test proves that leftover staging file is inert
-    /// (never mistaken for a live/loadable snapshot) and self-cleaning: the
-    /// NEXT reindex attempt's own staging writes simply overwrite it, and a
-    /// successful commit from that next attempt publishes correctly despite
-    /// the orphaned leftover.
-    /// What: seeds a live snapshot, simulates an interrupted first reindex
-    /// attempt (`begin` + a partial checkpoint written straight to the
-    /// staging path, mimicking `spawn_incremental_persist`, then NEITHER
-    /// commit nor abort — the crash). Asserts a `load_from(live)` at that
-    /// point (simulating a warm-boot right after the crash) restores the
-    /// pre-crash complete state, completely unaffected by the orphaned
-    /// staging file. Then simulates a second, successful reindex attempt
-    /// (`begin` again + a full checkpoint + `commit`) and asserts the final
-    /// live state is that second attempt's data, with no leftover staging
-    /// file remaining.
-    /// Test: this test.
-    #[tokio::test]
-    #[serial_test::serial]
-    async fn interrupted_reindex_leaves_inert_staging_that_next_attempt_overwrites() {
-        let data_dir = tempfile::tempdir().unwrap();
-        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
-        let root_dir = tempfile::tempdir().unwrap();
-
-        // Seed the pre-crash complete live snapshot.
-        let seed = store_with_vectors(100).await;
-        let (id, handle) = build_test_handle("hnsw-swap-restart", root_dir.path(), None);
-        let paths = begin_staged_hnsw_swap(&handle, &id)
-            .await
-            .expect("resolves");
-        seed.save(&paths.live).await.expect("seed save");
-
-        // First reindex attempt: begin staging, write ONE partial checkpoint
-        // straight to the staging path (mirrors what
-        // `spawn_incremental_persist` does mid-reindex) — then simulate an
-        // ungraceful crash: neither commit nor abort ever runs.
-        let attempt_one_partial = store_with_vectors(40).await;
-        attempt_one_partial
-            .save(&paths.staging)
-            .await
-            .expect("attempt-1 partial checkpoint");
-        assert!(
-            paths.staging.exists(),
-            "orphaned staging file must exist post-crash"
-        );
-
-        // Simulate a warm-boot immediately after the crash: only the LIVE
-        // path is ever loaded at boot — the orphaned staging file must be
-        // completely inert and never consulted.
-        let post_crash_boot = UsearchStore::load_from(&paths.live)
-            .await
-            .expect("load ok")
-            .expect("some");
-        assert_eq!(
-            post_crash_boot.len().await.unwrap(),
-            100,
-            "warm-boot after an ungraceful crash must restore the last COMPLETE \
-             live snapshot, unaffected by the orphaned partial staging file"
-        );
-
-        // Second reindex attempt for the SAME index: begin again (as the
-        // orchestrator does for every reindex, retried or not), write a
-        // fresh full checkpoint — overwriting the orphaned leftover, proving
-        // it does not accumulate — and commit successfully this time.
-        let paths_attempt_two = begin_staged_hnsw_swap(&handle, &id)
-            .await
-            .expect("resolves");
-        let attempt_two_full = store_with_vectors(150).await;
-        handle
-            .indexer
-            .write()
-            .await
-            .set_store(std::sync::Arc::new(attempt_two_full));
-        commit_staged_hnsw_swap(&handle, &id, &paths_attempt_two).await;
-
-        assert!(
-            !paths_attempt_two.staging.exists(),
-            "a successful next attempt must leave no leftover staging file — \
-             the orphan from the crashed attempt does not accumulate"
-        );
-        let final_live = UsearchStore::load_from(&paths_attempt_two.live)
-            .await
-            .expect("load ok")
-            .expect("some");
-        assert_eq!(
-            final_live.len().await.unwrap(),
-            150,
-            "the retried reindex's complete state must be what's live, not the \
-             crashed attempt's partial state nor the pre-crash seed"
-        );
-
-        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
-    }
-}
+#[path = "hnsw_swap_tests.rs"]
+mod tests;

--- a/crates/trusty-search/src/service/reindex/hnsw_swap_tests.rs
+++ b/crates/trusty-search/src/service/reindex/hnsw_swap_tests.rs
@@ -1,0 +1,566 @@
+//! Round-1 and round-2 regression tests for `hnsw_swap.rs` (issue #3970).
+//!
+//! Why: extracted from `hnsw_swap.rs` to keep that file under the 500-SLOC
+//! production cap (`scripts/check_line_cap.sh`) — mirrors the existing
+//! `prune.rs` / `prune_tests.rs` split in this same directory.
+//! What: exercises `begin_staged_hnsw_swap` / `commit_staged_hnsw_swap` /
+//! `abort_staged_hnsw_swap` end-to-end, plus the round-2 adversarial-review
+//! regression coverage (torn-swap safety, rename ordering, and the
+//! in-flight-persist quiesce race).
+//! Test: this file — run via `cargo test -p trusty-search`.
+
+use super::*;
+use crate::core::store::{UsearchStore, VectorStore as _};
+use crate::core::CodeIndexer;
+
+fn build_test_handle(
+    id_str: &str,
+    root: &std::path::Path,
+    store: Option<UsearchStore>,
+) -> (IndexId, IndexHandle) {
+    let id = IndexId::new(id_str.to_string());
+    let mut indexer = CodeIndexer::new(id.0.clone(), root);
+    if let Some(store) = store {
+        indexer.set_store(std::sync::Arc::new(store));
+    }
+    let handle = IndexHandle::bare(
+        id.clone(),
+        std::sync::Arc::new(tokio::sync::RwLock::new(indexer)),
+        root.to_path_buf(),
+    );
+    (id, handle)
+}
+
+async fn store_with_vectors(count: usize) -> UsearchStore {
+    let store = UsearchStore::new(4).unwrap();
+    let items: Vec<(String, Vec<f32>)> = (0..count)
+        .map(|i| (format!("chunk:{i}"), vec![i as f32 + 1.0, 0.0, 0.0, 0.0]))
+        .collect();
+    store.upsert_batch(&items).await.unwrap();
+    store
+}
+
+/// Why: `begin_staged_hnsw_swap` must resolve two distinct, correctly
+/// suffixed paths and flip the indexer's `reindexing` flag.
+/// Test: this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn begin_staged_hnsw_swap_resolves_legacy_paths() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (id, handle) = build_test_handle("hnsw-swap-begin", root_dir.path(), None);
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+
+    assert_ne!(paths.live, paths.staging, "live and staging must differ");
+    assert!(
+        paths.staging.to_string_lossy().contains("reindex-staging"),
+        "staging path must be distinguishable: {}",
+        paths.staging.display()
+    );
+    assert!(
+        handle.indexer.read().await.is_reindex_staging(),
+        "begin must flip the reindexing flag"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (the core #3970 fix, proven end-to-end): committing must publish
+/// the CURRENT in-memory state to the live path via the staged swap, and
+/// clear the reindexing flag so later commits resume direct-to-live.
+/// Test: this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn commit_staged_hnsw_swap_publishes_final_state() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let store = store_with_vectors(50).await;
+    let (id, handle) = build_test_handle("hnsw-swap-commit", root_dir.path(), Some(store));
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+
+    commit_staged_hnsw_swap(&handle, &id, &paths).await;
+
+    assert!(
+        !handle.indexer.read().await.is_reindex_staging(),
+        "commit must clear the reindexing flag"
+    );
+    assert!(paths.live.exists(), "commit must publish to the live path");
+    assert!(
+        !paths.staging.exists(),
+        "commit must rename staging away (no leftover staging file)"
+    );
+    let reloaded = UsearchStore::load_from(&paths.live)
+        .await
+        .expect("load ok")
+        .expect("some");
+    assert_eq!(reloaded.len().await.unwrap(), 50);
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why: an aborted/rolled-back reindex must never publish its staged
+/// (incomplete or invalid) snapshot — the live snapshot must be exactly
+/// what it was before the reindex began, and staging must be cleaned up.
+/// Test: this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    // Seed a complete live snapshot BEFORE the reindex begins.
+    let seed = store_with_vectors(200).await;
+    let (id, handle) = build_test_handle("hnsw-swap-abort", root_dir.path(), None);
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+    seed.save(&paths.live).await.expect("seed save");
+    let live_before = std::fs::read(&paths.live).expect("read seeded live");
+
+    // Simulate a partial reindex checkpoint landing in staging.
+    let partial = store_with_vectors(30).await;
+    partial.save(&paths.staging).await.expect("partial save");
+    assert!(paths.staging.exists());
+
+    abort_staged_hnsw_swap(&handle, &id, &paths).await;
+
+    assert!(
+        !handle.indexer.read().await.is_reindex_staging(),
+        "abort must clear the reindexing flag"
+    );
+    let live_after = std::fs::read(&paths.live).expect("read live after abort");
+    assert_eq!(
+        live_after, live_before,
+        "abort must leave the live snapshot byte-for-byte unchanged"
+    );
+    assert!(
+        !paths.staging.exists(),
+        "abort must delete the staging snapshot"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (issue #3970 — staging cleanup / restart behavior after an
+/// UNGRACEFUL interruption): an ungraceful crash (SIGKILL/OOM-kill/abort/
+/// power loss) mid-reindex runs neither `commit_staged_hnsw_swap` nor
+/// `abort_staged_hnsw_swap` — there is no boot-time sweep for a stale
+/// staging file, the same accepted trade-off the redb corpus tmp path
+/// already has. This test proves that leftover staging file is inert
+/// (never mistaken for a live/loadable snapshot) and self-cleaning: the
+/// NEXT reindex attempt's own staging writes simply overwrite it, and a
+/// successful commit from that next attempt publishes correctly despite
+/// the orphaned leftover.
+/// What: seeds a live snapshot, simulates an interrupted first reindex
+/// attempt (`begin` + a partial checkpoint written straight to the
+/// staging path, mimicking `spawn_incremental_persist`, then NEITHER
+/// commit nor abort — the crash). Asserts a `load_from(live)` at that
+/// point (simulating a warm-boot right after the crash) restores the
+/// pre-crash complete state, completely unaffected by the orphaned
+/// staging file. Then simulates a second, successful reindex attempt
+/// (`begin` again + a full checkpoint + `commit`) and asserts the final
+/// live state is that second attempt's data, with no leftover staging
+/// file remaining.
+/// Test: this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn interrupted_reindex_leaves_inert_staging_that_next_attempt_overwrites() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    // Seed the pre-crash complete live snapshot.
+    let seed = store_with_vectors(100).await;
+    let (id, handle) = build_test_handle("hnsw-swap-restart", root_dir.path(), None);
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+    seed.save(&paths.live).await.expect("seed save");
+
+    // First reindex attempt: begin staging, write ONE partial checkpoint
+    // straight to the staging path (mirrors what
+    // `spawn_incremental_persist` does mid-reindex) — then simulate an
+    // ungraceful crash: neither commit nor abort ever runs.
+    let attempt_one_partial = store_with_vectors(40).await;
+    attempt_one_partial
+        .save(&paths.staging)
+        .await
+        .expect("attempt-1 partial checkpoint");
+    assert!(
+        paths.staging.exists(),
+        "orphaned staging file must exist post-crash"
+    );
+
+    // Simulate a warm-boot immediately after the crash: only the LIVE
+    // path is ever loaded at boot — the orphaned staging file must be
+    // completely inert and never consulted.
+    let post_crash_boot = UsearchStore::load_from(&paths.live)
+        .await
+        .expect("load ok")
+        .expect("some");
+    assert_eq!(
+        post_crash_boot.len().await.unwrap(),
+        100,
+        "warm-boot after an ungraceful crash must restore the last COMPLETE \
+         live snapshot, unaffected by the orphaned partial staging file"
+    );
+
+    // Second reindex attempt for the SAME index: begin again (as the
+    // orchestrator does for every reindex, retried or not), write a
+    // fresh full checkpoint — overwriting the orphaned leftover, proving
+    // it does not accumulate — and commit successfully this time.
+    let paths_attempt_two = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+    let attempt_two_full = store_with_vectors(150).await;
+    handle
+        .indexer
+        .write()
+        .await
+        .set_store(std::sync::Arc::new(attempt_two_full));
+    commit_staged_hnsw_swap(&handle, &id, &paths_attempt_two).await;
+
+    assert!(
+        !paths_attempt_two.staging.exists(),
+        "a successful next attempt must leave no leftover staging file — \
+         the orphan from the crashed attempt does not accumulate"
+    );
+    let final_live = UsearchStore::load_from(&paths_attempt_two.live)
+        .await
+        .expect("load ok")
+        .expect("some");
+    assert_eq!(
+        final_live.len().await.unwrap(),
+        150,
+        "the retried reindex's complete state must be what's live, not the \
+         crashed attempt's partial state nor the pre-crash seed"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (round-2 review CRITICAL 1 — the core mechanism, proven
+/// end-to-end): proves the chosen sidecar-then-binary rename order in
+/// `commit_staged_hnsw_swap` produces a SAFE torn state if interrupted
+/// between the two renames — never the collision-prone one. Simulates
+/// "crash after the sidecar rename, before the binary rename" by
+/// performing exactly that first step manually (the same operation
+/// `commit_staged_hnsw_swap` performs first) and stopping there, leaving
+/// live = OLD binary + NEW sidecar. Before the round-2 fix (binary-first
+/// order), the equivalent interrupted state would have been NEW binary +
+/// OLD sidecar instead, whose restored `next_key` sits BEHIND actual
+/// usage — the exact precondition for a later `upsert` to allocate an
+/// already-occupied key and silently overwrite an unrelated vector.
+/// What: ONE store instance drives both the "old" (seeded live) and
+/// "new" (staged) snapshots, exactly like a real reindex continuing to
+/// mutate the same live `UsearchStore` — `next_key` is the SAME
+/// monotonic counter throughout, just as in production. After manually
+/// applying only the sidecar rename, asserts (1) the torn state still
+/// loads (this direction is legitimate/expected, matching the dangling-
+/// `id_to_key`-entry case `UsearchStore::remove`'s doc already
+/// documents) and (2) — the actual safety property — that every one of
+/// the OLD binary's real vectors is still exactly resolvable by search
+/// AFTER an upsert of a brand-new id, proving that new id's freshly
+/// allocated key could not have collided with and silently destroyed any
+/// of them.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn torn_swap_interrupted_after_sidecar_rename_never_permits_key_collision() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (id, handle) = build_test_handle("hnsw-swap-torn", root_dir.path(), None);
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+
+    // Non-collinear vectors so cosine search can uniquely distinguish
+    // each old id's top-1 match (a `[k,0,0,0]` family, as used
+    // elsewhere in this file, is useless here — every such vector is
+    // cosine-identical to every other, since they all point in exactly
+    // the same direction).
+    let old_ids: Vec<String> = (0..8).map(|i| format!("old-chunk:{i}")).collect();
+    let old_vectors: Vec<Vec<f32>> = (0..8).map(|i| vec![1.0, i as f32, 0.0, 0.0]).collect();
+
+    let store = UsearchStore::new(4).unwrap();
+    let old_items: Vec<(String, Vec<f32>)> = old_ids
+        .iter()
+        .cloned()
+        .zip(old_vectors.iter().cloned())
+        .collect();
+    store.upsert_batch(&old_items).await.unwrap();
+    store.save(&paths.live).await.expect("seed old live");
+    let old_binary_bytes = std::fs::read(&paths.live).expect("read old binary");
+
+    // The "reindex" continues on the SAME store instance — `next_key`
+    // keeps advancing from wherever it left off, exactly like a real
+    // reindex that keeps mutating the live `self.store` in place.
+    let new_items: Vec<(String, Vec<f32>)> = (0..20)
+        .map(|i| (format!("new-chunk:{i}"), vec![0.0, 0.0, 1.0, i as f32]))
+        .collect();
+    store.upsert_batch(&new_items).await.unwrap();
+    store.save(&paths.staging).await.expect("save new staging");
+
+    // Simulate "crash after the sidecar rename, before the binary
+    // rename" — `commit_staged_hnsw_swap`'s first step, performed
+    // manually; the binary rename is deliberately skipped.
+    let staging_sidecar = paths.staging.with_extension("keys.json");
+    let live_sidecar = paths.live.with_extension("keys.json");
+    std::fs::rename(&staging_sidecar, &live_sidecar).expect("simulate sidecar rename");
+    assert_eq!(
+        std::fs::read(&paths.live).expect("read live binary"),
+        old_binary_bytes,
+        "sanity: live binary must still be the OLD one (binary rename skipped)"
+    );
+
+    // This torn state must NOT be flagged as corrupt — this direction
+    // is the legitimate/expected one (see the guard's doc in
+    // `UsearchStore::load_from`).
+    let torn = UsearchStore::load_from(&paths.live)
+        .await
+        .expect("load ok")
+        .expect("torn state must still load — this is not the dangerous direction");
+
+    // Upsert a brand-new id — its freshly allocated key must never have
+    // been used by anything, old or new.
+    torn.upsert("brand-new-chunk", vec![0.0, 1.0, 1.0, 0.0])
+        .await
+        .expect("upsert after torn load must succeed");
+
+    // THE safety property: every OLD vector must still resolve to
+    // itself, unharmed. A collision would have silently removed and
+    // overwritten one of them with unrelated content.
+    for (id, vector) in old_ids.iter().zip(old_vectors.iter()) {
+        let hits = torn.search(vector, 1).await.expect("search ok");
+        assert_eq!(
+            hits.first().map(|h| h.chunk_id.as_str()),
+            Some(id.as_str()),
+            "{id}'s vector must survive the post-torn-load upsert unharmed — a \
+             collision would have silently overwritten it with unrelated content \
+             (issue #3970 round-2 CRITICAL 1)"
+        );
+    }
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (round-2 review CRITICAL 2): `abort_staged_hnsw_swap` must not
+/// clear the `reindexing` flag while a periodic persist task could still
+/// be running — see the function's doc for the full race. This proves
+/// the ordering: with `PersistState::in_flight` simulated `true` (as if
+/// a real detached task were still mid-coalescing-loop), the abort call
+/// must genuinely block until that condition clears, not return
+/// immediately and clear the flag regardless.
+/// What: sets the simulated in-flight condition, races
+/// `abort_staged_hnsw_swap` against a delayed task that clears it after
+/// a known interval, and asserts the abort call's total elapsed time is
+/// at least that interval — proving it actually waited rather than
+/// racing past the still-in-flight condition. A regression back to
+/// clearing the flag first (or omitting the wait) would make this
+/// function return near-instantly regardless of the simulated
+/// condition, failing the timing assertion.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn abort_staged_hnsw_swap_waits_for_in_flight_persist_before_clearing_flag() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (id, handle) = build_test_handle(
+        "hnsw-swap-abort-race",
+        root_dir.path(),
+        Some(store_with_vectors(10).await),
+    );
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+    partial_checkpoint_to(&paths.staging).await;
+
+    handle
+        .indexer
+        .read()
+        .await
+        .simulate_persist_in_flight_for_tests(true);
+
+    // Release the simulated in-flight condition from a GENUINELY
+    // independent background task (not raced via `tokio::join!` with the
+    // call under test — `join!` waits for BOTH futures regardless of
+    // which finishes first, so timing its combined completion can't
+    // distinguish "the call under test actually waited" from "it
+    // returned instantly but `join!` waited for this task anyway"). Only
+    // the call under test is timed below.
+    const HOLD: std::time::Duration = std::time::Duration::from_millis(150);
+    let indexer_arc = handle.indexer.clone();
+    let release_task = tokio::spawn(async move {
+        tokio::time::sleep(HOLD).await;
+        indexer_arc
+            .read()
+            .await
+            .simulate_persist_in_flight_for_tests(false);
+    });
+
+    let start = std::time::Instant::now();
+    abort_staged_hnsw_swap(&handle, &id, &paths).await;
+    let elapsed = start.elapsed();
+    release_task.await.expect("release task must not panic");
+
+    assert!(
+        elapsed >= HOLD,
+        "abort_staged_hnsw_swap must wait for the in-flight persist task to \
+         quiesce before resolving — elapsed {elapsed:?} was under the {HOLD:?} hold, \
+         meaning it raced past the still-in-flight condition (issue #3970 round-2 \
+         CRITICAL 2)"
+    );
+    assert!(
+        !handle.indexer.read().await.is_reindex_staging(),
+        "the flag must still end up cleared once the wait resolves"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (round-2 review CRITICAL 2): same race as the abort test above,
+/// but for the commit path — `commit_staged_hnsw_swap` must equally wait
+/// for any in-flight persist task before doing its own final save and
+/// rename, let alone clearing the flag.
+/// What: identical structure to
+/// `abort_staged_hnsw_swap_waits_for_in_flight_persist_before_clearing_flag`.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn commit_staged_hnsw_swap_waits_for_in_flight_persist_before_clearing_flag() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (id, handle) = build_test_handle(
+        "hnsw-swap-commit-race",
+        root_dir.path(),
+        Some(store_with_vectors(10).await),
+    );
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+
+    handle
+        .indexer
+        .read()
+        .await
+        .simulate_persist_in_flight_for_tests(true);
+
+    // See `abort_staged_hnsw_swap_waits_for_in_flight_persist_before_clearing_flag`
+    // for why the release runs on a genuinely independent background
+    // task rather than being raced via `tokio::join!`.
+    const HOLD: std::time::Duration = std::time::Duration::from_millis(150);
+    let indexer_arc = handle.indexer.clone();
+    let release_task = tokio::spawn(async move {
+        tokio::time::sleep(HOLD).await;
+        indexer_arc
+            .read()
+            .await
+            .simulate_persist_in_flight_for_tests(false);
+    });
+
+    let start = std::time::Instant::now();
+    commit_staged_hnsw_swap(&handle, &id, &paths).await;
+    let elapsed = start.elapsed();
+    release_task.await.expect("release task must not panic");
+
+    assert!(
+        elapsed >= HOLD,
+        "commit_staged_hnsw_swap must wait for the in-flight persist task to \
+         quiesce before resolving — elapsed {elapsed:?} was under the {HOLD:?} hold \
+         (issue #3970 round-2 CRITICAL 2)"
+    );
+    assert!(
+        !handle.indexer.read().await.is_reindex_staging(),
+        "the flag must still end up cleared once the wait resolves"
+    );
+    assert!(
+        paths.live.exists(),
+        "commit must still publish once unblocked"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Why (round-2 review CRITICAL 1 — proves the REAL function's actual
+/// order, not a manual simulation of it): the torn-swap safety test
+/// above manually replicates a "sidecar renamed, binary not" state to
+/// prove that direction is safe; this test instead proves
+/// `commit_staged_hnsw_swap` itself really performs the sidecar rename
+/// BEFORE the binary rename, so a regression back to the pre-round-2
+/// binary-first order would be caught here even if the manual-simulation
+/// test above kept passing.
+/// What: pre-creates a DIRECTORY at the live binary's path. `fs::rename`
+/// of a regular file onto an existing directory always fails (EISDIR on
+/// POSIX), so the binary rename is guaranteed to fail while the sidecar
+/// rename (an unrelated, untouched path) is free to succeed normally.
+/// Calls the real `commit_staged_hnsw_swap` and asserts the live
+/// sidecar WAS renamed into place despite the binary rename failing —
+/// which is only possible if the sidecar rename ran first (and
+/// independently of the later binary-rename failure). If the order were
+/// reversed, the binary rename would fail immediately and the sidecar
+/// rename would never even be attempted.
+/// Test: this IS the test.
+#[tokio::test]
+#[serial_test::serial]
+async fn commit_staged_hnsw_swap_renames_sidecar_before_binary() {
+    let data_dir = tempfile::tempdir().unwrap();
+    unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+    let root_dir = tempfile::tempdir().unwrap();
+
+    let (id, handle) = build_test_handle(
+        "hnsw-swap-order-proof",
+        root_dir.path(),
+        Some(store_with_vectors(5).await),
+    );
+    let paths = begin_staged_hnsw_swap(&handle, &id)
+        .await
+        .expect("resolves");
+
+    // Force the binary rename to fail predictably: a regular-file →
+    // existing-directory rename always errors.
+    std::fs::create_dir_all(&paths.live).expect("pre-create live path as a directory");
+
+    commit_staged_hnsw_swap(&handle, &id, &paths).await;
+
+    let live_sidecar = paths.live.with_extension("keys.json");
+    assert!(
+        live_sidecar.exists(),
+        "the sidecar must be renamed into place BEFORE the (here, deliberately \
+         failing) binary rename is attempted — issue #3970 round-2 CRITICAL 1 \
+         rename ordering; if this fails, the binary rename ran first, aborted, \
+         and the sidecar rename was never reached"
+    );
+    assert!(
+        !paths.staging.with_extension("keys.json").exists(),
+        "the staging sidecar must have actually moved (renamed), not been left \
+         behind or copied"
+    );
+
+    unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+}
+
+/// Save `store_with_vectors(5)` directly to `path` — a bare helper for
+/// tests that need a plausible pre-existing staging checkpoint without
+/// caring about its exact content.
+async fn partial_checkpoint_to(path: &std::path::Path) {
+    store_with_vectors(5)
+        .await
+        .save(path)
+        .await
+        .expect("checkpoint save");
+}

--- a/crates/trusty-search/src/service/reindex/mod.rs
+++ b/crates/trusty-search/src/service/reindex/mod.rs
@@ -16,6 +16,7 @@
 //! - `batch`       — single-batch parse/embed/commit cycle.
 //! - `completion`  — KG rebuild + terminal `complete` SSE event builder.
 //! - `corpus_swap` — atomic `index.redb.tmp` → `index.redb` swap.
+//! - `hnsw_swap`   — staged-write-then-swap for the periodic HNSW snapshot (issue #3970).
 //! - `guard`       — `ReindexTerminationGuard` RAII safety guard.
 //! - `orchestrator`— top-level `spawn_reindex` / `spawn_reindex_with_cleanup` + file walk.
 //! - `pollers`     — background RSS poller tasks (daemon + embedderd sidecar).
@@ -44,6 +45,7 @@ mod corpus_swap;
 mod finish;
 mod guard;
 mod hash;
+mod hnsw_swap;
 mod orchestrator;
 mod pollers;
 mod progress;

--- a/crates/trusty-search/src/service/reindex/runner.rs
+++ b/crates/trusty-search/src/service/reindex/runner.rs
@@ -28,6 +28,7 @@ use super::finish::{BatchTotals, FileHashes, FinishCtx};
 use super::guard::ReindexTerminationGuard;
 use super::hash::hashes_for;
 use super::hash_cache;
+use super::hnsw_swap::begin_staged_hnsw_swap;
 use super::progress::{ReindexProgress, ReindexStatus};
 use super::quarantine::ReindexQuarantine;
 use super::semaphore::{index_semaphore, reindex_semaphore_for, BACKGROUND_QUEUE_DEPTH};
@@ -332,6 +333,17 @@ pub(super) async fn run_reindex(
             None
         };
 
+    // Issue #3970: stage the periodic HNSW snapshot too, mirroring the redb
+    // corpus staging above. Unlike the corpus (staged only when a durable
+    // corpus store exists), this is unconditional — cheap (path resolution +
+    // one atomic flag flip) and safe even for a BM25-only indexer with no
+    // vector store, where the periodic persister's HNSW save is already a
+    // harmless no-op. A `None` here (path unresolvable) is a degraded-but-
+    // not-worse fallback: `spawn_incremental_persist` never learns
+    // `reindexing` was set, so it keeps writing straight to the live path
+    // exactly as it did before this fix.
+    let hnsw_swap_paths = begin_staged_hnsw_swap(&handle, &index_id).await;
+
     // Per-subsystem timing accumulators.
     let mut total_parse_ms: u64 = 0;
     let mut total_embed_ms: u64 = 0;
@@ -524,6 +536,7 @@ pub(super) async fn run_reindex(
         started,
         defer_embed: ctx.defer_embed,
         corpus_swap_tmp,
+        hnsw_swap_paths,
         mem_abort,
         peak_rss_atomic,
         peak_embedderd_rss_atomic,


### PR DESCRIPTION
## Summary

`spawn_incremental_persist` (`crates/trusty-search/src/core/indexer/persist_hnsw.rs`) checkpoints the in-memory HNSW graph to disk every `HNSW_SNAPSHOT_BATCH_INTERVAL` (16) batches during **every** reindex, plus once forced after the batch loop (`service/reindex/finish.rs`). Before this PR that checkpoint wrote straight to the LIVE snapshot path. Reindex progress is monotonic, so any reasonably large reindex crossed `UsearchStore::save`'s shrink guard threshold as ordinary healthy progress — from that checkpoint on, the complete pre-reindex snapshot was already overwritten by a partial, still-growing one, and an ungraceful termination (SIGKILL, OOM-kill, process abort, power loss) at any later point permanently stranded the index.

This is the same vulnerability class as #1717 but reached through a different, far more frequently exercised path, and was **not** fixed by PR #3968 (which closes only the graceful-shutdown flush path via a skip-while-`Running` gate — explicitly not applicable here, since gating the periodic persister the same way would disable incremental checkpointing entirely, trading this hole for the loss of *all* in-reindex progress instead of just the tail).

## Design — staged-write-then-swap, mirroring the redb corpus (#603/#839)

- **`CodeIndexer::begin_reindex_staging` / `end_reindex_staging`** (new `PersistState::reindexing` flag) — while set, `spawn_incremental_persist`'s periodic checkpoint redirects to a staging path instead of the live one, re-resolved fresh on every coalescing-loop iteration.
- **`service::reindex::hnsw_swap`** (new module, mirrors `corpus_swap.rs`):
  - `begin_staged_hnsw_swap` — resolves the (live, staging) path pair and flips the flag, called from `runner.rs` alongside the existing redb corpus staging.
  - `commit_staged_hnsw_swap` — forces one final **awaited** save to staging (capturing tail batches the throttle skipped), then atomically renames staging → live (binary + sidecar).
  - `abort_staged_hnsw_swap` — clears the flag and best-effort deletes the staging files; the live snapshot is left untouched.
- **`finish.rs`** resolves the HNSW swap using the exact same `StagingResolution` the redb corpus swap already computes (`Ready` + not memory-aborted → commit; anything else → rollback) — no new heuristic invented.

### Design questions (from the issue)

- **Crash during the swap itself**: the swap is two same-directory (same-filesystem) renames, each atomic at the syscall level. A crash strictly between them can leave a live binary/sidecar pair that no longer match — `UsearchStore::load_from`'s existing corruption/mismatch guards (issue #2922) already treat that as "discard and fall back to a fresh store," so a botched swap loses this reindex's gains, not correctness.
- **Staging cleanup**: fixed filename (not per-run-unique), matching the redb corpus tmp path's own convention — the next reindex attempt's checkpoints simply overwrite it, so it never accumulates across retries. If a reindex is interrupted and never retried, the file is left on disk until the next attempt — the same accepted trade-off the redb corpus tmp path already has (no boot-time sweep exists for either). Proven in `hnsw_swap::tests::interrupted_reindex_leaves_inert_staging_that_next_attempt_overwrites`.
- **Crash-resilience preserved, not relocated**: an ungraceful crash mid-reindex leaves the live path exactly at its last periodic-persist state *before* the reindex began redirecting to staging — i.e., the complete pre-reindex snapshot, always. Next boot loads that live snapshot normally (staging is never consulted at load time). The reindex itself is not resumed from the partial staging progress; the trade is explicit: this closes the "publish partial state" hole, it does not add mid-reindex resume (that's #3969, explicitly out of scope).
- **Retained ratio guard**: still fully active for every OTHER `save()` caller that targets the live path directly — the graceful shutdown flush (when NOT reindexing) and any live single-file incremental commit outside of a reindex. It's moot only for the one call site that motivated #3970 (the periodic reindex checkpoint, which never targets the live path during `Running` anymore). Not removed — still real defense-in-depth for its other callers.
- **The forced save at `finish.rs:212`**: superseded for this codepath. `resolve_hnsw_swap` performs an *awaited* final save to staging (subsuming the old fire-and-forget `force_incremental_persist()`) before the swap decision, so the commit is guaranteed to publish up-to-date state. The old detached call remains only as a fallback for the rare case staging paths were unresolvable at reindex start. `finish.rs` still flips status to `Complete` only after both the corpus swap and the HNSW swap have resolved.

## Tests

- `core::indexer::tests::persistence_and_search::test_incremental_persist_redirects_to_staging_while_reindexing` — **the required failing-then-passing test**. Verified RED against the pre-fix behavior (temporarily hardcoding `reindexing = false`) and GREEN with the fix.
- `hnsw_swap::tests::commit_staged_hnsw_swap_publishes_final_state` — proves the swap DOES publish on completion.
- `hnsw_swap::tests::abort_staged_hnsw_swap_leaves_live_untouched_and_cleans_staging` — proves rollback leaves live untouched and cleans staging.
- `hnsw_swap::tests::interrupted_reindex_leaves_inert_staging_that_next_attempt_overwrites` — staging cleanup / restart behavior after an ungraceful interruption.
- `hnsw_swap::tests::begin_staged_hnsw_swap_resolves_legacy_paths` — path resolution + flag flip.

## Quality gate (raw output)

```
cargo test -p trusty-search   → 1339 passed; 0 failed; 1 ignored (lib)
                                 319 passed; 0 failed; 1 ignored (main.rs)
                                 all integration binaries: 0 failed
cargo clippy -p trusty-search --all-targets -- -D warnings   → clean
cargo fmt -p trusty-search --check                           → clean
```

No #3955 (`create_index_*` HTTP-400) or #3954 (memguard RSS) noise observed — worktree correctly sited outside `/tmp`/`TMPDIR`.

## Scope

Touches exactly the expected surface: `core/indexer/persist_hnsw.rs`, `core/indexer/mod.rs` (new `PersistState` field), `service/persistence.rs` + `service/colocated_storage.rs` (staging path resolvers), `service/reindex/{finish,runner,mod}.rs`, new `service/reindex/hnsw_swap.rs`, tests, `CHANGELOG.md`. Does not touch `allowlist/mod.rs`, `memguard.rs`, or `service/shutdown_flush.rs`. Does not attempt to fix #3969 (out of scope).

Closes #3970

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools