### PR TITLE
feat(trusty-mpm): hard-block git worktree add targeting /tmp, /private/tmp, /var/folders, or the scratchpad

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
+  `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**
+  (worktree-hygiene follow-up to
+  [#3955](https://github.com/bobmatnyc/trusty-tools/issues/3955)): worktrees
+  provisioned there silently fail unrelated tests (trusty-search's
+  `SENSITIVE_PATH_PREFIXES` denylist) and can be reaped mid-task by the OS or
+  harness. The check is called directly from `pm_guard()` BEFORE Guard 4's
+  native-subagent-dispatch exemption, and is unconditional — including for
+  Task/Agent-dispatched subagents, which is who actually provisions these
+  worktrees in practice. `pm_guard_bash::evaluate_worktree_add_command`
+  resolves the target (relative paths, `cd`/`git -C` tracking, `~`/`$TMPDIR`/
+  `$TMP` expansion, lexical `.`/`..` normalization) without touching the
+  filesystem; only the exact `worktree add` subcommand is affected —
+  `list`/`remove`/`prune`/`lock`/… and ordinary temp usage (`mktemp`, temp
+  files, cargo build artifacts) are untouched.
+
 ### Fixed
 
 - **`prune-worktrees` never scanned `.claude/worktrees`, so Claude Code's

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -34,10 +34,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Guard 1 short-circuited to ALLOW before the stdin payload was even read, so
   a `CLAUDE_MPM_SUB_AGENT=1`-tagged `git worktree add /tmp/...` call was
   silently allowed. Guards 2/3 (`TRUSTY_MPM_DISABLE_HOOKS` /
-  `TRUSTY_MPM_PM_UNRESTRICTED`) are deliberately left UN-pierced — both are
-  genuine operator-set escape hatches never set programmatically anywhere in
-  this codebase, so an operator who disables the hook or invokes the
-  unrestricted bypass still gets exactly that, including for this guard.
+  `TRUSTY_MPM_PM_UNRESTRICTED`) are deliberately left UN-pierced — neither is
+  ever set programmatically anywhere in this codebase's Rust source, so
+  whoever sets them still gets exactly that, including for this guard.
+  **Round 3 correction:** that is narrower than "operator-only" — Claude
+  Code's `settings.json` `env` object can set either var for every hook
+  invocation (live-reloaded mid-session), and a write to
+  `.claude/settings.json` is not itself blocked by `pm_guard` today, so the
+  PM or an exempt subagent can self-exempt from this entire guard via that
+  pre-existing, unrelated gap. Not introduced or widened by this change; not
+  fixed here; tracked as
+  [#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981).
 
 ### Fixed
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -25,6 +25,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `list`/`remove`/`prune`/`lock`/… and ordinary temp usage (`mktemp`, temp
   files, cargo build artifacts) are untouched.
 
+  **Round 2 (code-critic BLOCK, PR #3978):** the guard also pierces Guard 1
+  (`CLAUDE_MPM_SUB_AGENT`) — the automatic marker trusty-agents' own
+  subprocess/runner spawn helpers stamp on every nested subagent process
+  (`crates/trusty-agents/src/subprocess/spawn.rs:189-192`,
+  `crates/trusty-agents/src/agents/claude_code_runner/run.rs:211-215`), which
+  is who actually provisions most of these worktrees. Before this round,
+  Guard 1 short-circuited to ALLOW before the stdin payload was even read, so
+  a `CLAUDE_MPM_SUB_AGENT=1`-tagged `git worktree add /tmp/...` call was
+  silently allowed. Guards 2/3 (`TRUSTY_MPM_DISABLE_HOOKS` /
+  `TRUSTY_MPM_PM_UNRESTRICTED`) are deliberately left UN-pierced — both are
+  genuine operator-set escape hatches never set programmatically anywhere in
+  this codebase, so an operator who disables the hook or invokes the
+  unrestricted bypass still gets exactly that, including for this guard.
+
 ### Fixed
 
 - **`prune-worktrees` never scanned `.claude/worktrees`, so Claude Code's

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -61,13 +61,23 @@
 //! round 2 code-critic review (PR #3978) established that Guards 1/4 are
 //! automatic markers a spawn helper stamps on every nested/dispatched
 //! subagent process (no human decides per-invocation whether they're set),
-//! while Guards 2/3 are operator-set escape hatches nothing in this codebase
-//! ever sets programmatically — see [`pm_guard`]'s body for the exact
-//! reordering this required (Guard 1's check moved after the stdin payload
-//! read, specifically so this worktree check — which needs the payload — can
-//! run first). This is the one place in the file that pierces an
-//! automatic-marker exemption; see that call site's comment for why it must
-//! never be routed through [`evaluate_tool`] instead.
+//! while nothing in this codebase's Rust source ever sets
+//! `TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED` programmatically via
+//! `std::env::var` — see [`pm_guard`]'s body for the exact reordering this
+//! required (Guard 1's check moved after the stdin payload read, specifically
+//! so this worktree check — which needs the payload — can run first). **This
+//! is NOT the same as "operator-only"**: Claude Code's `settings.json`
+//! supports a top-level `env` object applied to every session/subprocess it
+//! spawns (hooks included, live-reloaded mid-session), and a `Write`/`Edit`
+//! to `.claude/settings.json` is not itself blocked by this guard (`.json` is
+//! not in [`SOURCE_CODE_EXTENSIONS`], so [`evaluate_edit_tool`] falls through
+//! to an unconditional ALLOW) — so the PM, or any Guard-4-exempt subagent,
+//! can set either var there and self-exempt from this entire guard. That gap
+//! predates this PR by many issues and is NOT introduced or widened by it;
+//! tracked separately as issue #3981, not fixed here. This is the one place
+//! in the file that pierces an automatic-marker exemption; see that call
+//! site's comment for why it must never be routed through [`evaluate_tool`]
+//! instead.
 //! Test: `evaluate_tool_*`, `payload_is_subagent_dispatch_*`, and
 //! `build_pretooluse_deny_response_*` below cover the tool policy, sub-agent
 //! exemption, and JSON shape; the Bash-command classifier (composition and
@@ -181,18 +191,24 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
     // Guard 2: universal opt-out for CI / build shells that can't edit
     // settings.json without a restart. Checked FIRST (ahead of Guard 1, a
     // reordering from this function's original shape — see the code-critic
-    // round 2 finding on PR #3978): this and Guard 3 below are genuine
-    // operator-set escape hatches — nothing in this codebase ever sets
-    // `TRUSTY_MPM_DISABLE_HOOKS` or `TRUSTY_MPM_PM_UNRESTRICTED`
-    // programmatically (verified: no occurrence outside doc comments and
-    // this module) — so they must keep working exactly as before, including
-    // against the ABSOLUTE worktree-tmp guard below: an operator who
-    // deliberately disables the hook, or says "you do it this time", gets
-    // exactly that, no exceptions. Guard 1 (`SUB_AGENT_ENV`), by contrast, is
-    // an AUTOMATIC marker a spawn helper stamps on every nested MPM subagent
-    // process with no per-invocation human decision involved — see Guard 1's
-    // own comment below for why it is checked LATER, after the worktree
-    // guard, instead of here.
+    // round 2 finding on PR #3978): this and Guard 3 below are never SET
+    // programmatically anywhere in this codebase's Rust source (verified: no
+    // `std::env::var`/`set_var` occurrence outside doc comments and this
+    // module) — so they must keep working exactly as before, including
+    // against the ABSOLUTE worktree-tmp guard below: whoever sets
+    // `TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED` gets exactly
+    // that, no exceptions. That is a narrower claim than "operator-only",
+    // though: Claude Code's `settings.json` `env` object can set either var
+    // for every hook invocation, and a write to `.claude/settings.json` is
+    // not itself blocked by this guard (see the module doc above, "This is
+    // NOT the same as 'operator-only'") — so the PM or an exempt subagent CAN
+    // self-exempt via that path. That gap predates this PR by many issues and
+    // is out of scope here; tracked as issue #3981. Guard 1 (`SUB_AGENT_ENV`),
+    // by contrast, is an
+    // AUTOMATIC marker a spawn helper stamps on every nested MPM subagent
+    // process with no per-invocation env-write decision involved — see
+    // Guard 1's own comment below for why it is checked LATER, after the
+    // worktree guard, instead of here.
     if std::env::var_os(DISABLE_HOOKS_ENV).is_some() {
         return Ok(());
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -55,10 +55,19 @@
 //! [`crate::commands::pm_guard_bash::evaluate_worktree_add_command`] DIRECTLY,
 //! before Guard 4's early return, denying any `git worktree add` whose target
 //! resolves under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR`, or the
-//! harness scratchpad — unconditionally, including native-subagent-dispatched
-//! calls. This is the one place in the file that pierces the Guard 4
-//! exemption; see that call site's comment for why it must never be routed
-//! through [`evaluate_tool`] instead.
+//! harness scratchpad. It also pierces Guard 1 (`CLAUDE_MPM_SUB_AGENT`) —
+//! Guard 2 (`TRUSTY_MPM_DISABLE_HOOKS`) and Guard 3
+//! (`TRUSTY_MPM_PM_UNRESTRICTED`) run first and are UNAFFECTED, since a
+//! round 2 code-critic review (PR #3978) established that Guards 1/4 are
+//! automatic markers a spawn helper stamps on every nested/dispatched
+//! subagent process (no human decides per-invocation whether they're set),
+//! while Guards 2/3 are operator-set escape hatches nothing in this codebase
+//! ever sets programmatically — see [`pm_guard`]'s body for the exact
+//! reordering this required (Guard 1's check moved after the stdin payload
+//! read, specifically so this worktree check — which needs the payload — can
+//! run first). This is the one place in the file that pierces an
+//! automatic-marker exemption; see that call site's comment for why it must
+//! never be routed through [`evaluate_tool`] instead.
 //! Test: `evaluate_tool_*`, `payload_is_subagent_dispatch_*`, and
 //! `build_pretooluse_deny_response_*` below cover the tool policy, sub-agent
 //! exemption, and JSON shape; the Bash-command classifier (composition and
@@ -146,13 +155,19 @@ const SOURCE_CODE_EXTENSIONS: &[&str] = &[
 ///
 /// Why: this is the load-bearing integration point wired into every managed
 /// session's `PreToolUse` hook (see `session_launch::settings::write_project_hooks`).
-/// It must be fast and fail-open: guard env vars short-circuit to ALLOW so
-/// nested sub-agents (`CLAUDE_MPM_SUB_AGENT`) and CI / build shells
-/// (`TRUSTY_MPM_DISABLE_HOOKS`) are never blocked, and the explicit
-/// `TRUSTY_MPM_PM_UNRESTRICTED=1` bypass lets the operator lift enforcement on
-/// demand. Any missing/malformed input degrades to ALLOW rather than wedging
-/// the PM. The decision is computed purely from the static tool classification
-/// — never a daemon call — so a down daemon can never hard-block a tool call.
+/// It must be fast and fail-open: CI/build shells (`TRUSTY_MPM_DISABLE_HOOKS`)
+/// and the explicit `TRUSTY_MPM_PM_UNRESTRICTED=1` operator bypass short-circuit
+/// to ALLOW before the stdin payload is even read — both are genuine
+/// human-operated escape hatches (nothing in this codebase sets either
+/// programmatically), so they lift EVERY check below, including the absolute
+/// worktree-tmp guard. Nested MPM sub-agents (`CLAUDE_MPM_SUB_AGENT`) are
+/// different: that marker is stamped automatically by a spawn helper, not
+/// operator-decided per call, so it is checked LATER — after the worktree-tmp
+/// guard has already had a chance to fire (issue #3977; PR #3978 round 2) —
+/// and exempts everything else, matching the pre-#3977 behavior. Any missing/
+/// malformed input degrades to ALLOW rather than wedging the PM. The decision
+/// is computed purely from the static tool classification — never a daemon
+/// call — so a down daemon can never hard-block a tool call.
 /// What: returns `Ok(())` (ALLOW, no stdout) for every short-circuit, a payload
 /// with no `tool_name`, or an [`evaluate_tool`] verdict of ALLOW. On DENY it
 /// fires a best-effort audit POST to `<url>/hooks` (tight timeout, result
@@ -163,13 +178,21 @@ const SOURCE_CODE_EXTENSIONS: &[&str] = &[
 /// `tests/tm_hook_pm_guard.rs`; the pure policy is covered by this module's
 /// unit tests.
 pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
-    // Guard 1: never block a nested MPM sub-agent — it is doing the delegated
-    // work the PM is being steered toward.
-    if std::env::var_os(SUB_AGENT_ENV).is_some() {
-        return Ok(());
-    }
     // Guard 2: universal opt-out for CI / build shells that can't edit
-    // settings.json without a restart.
+    // settings.json without a restart. Checked FIRST (ahead of Guard 1, a
+    // reordering from this function's original shape — see the code-critic
+    // round 2 finding on PR #3978): this and Guard 3 below are genuine
+    // operator-set escape hatches — nothing in this codebase ever sets
+    // `TRUSTY_MPM_DISABLE_HOOKS` or `TRUSTY_MPM_PM_UNRESTRICTED`
+    // programmatically (verified: no occurrence outside doc comments and
+    // this module) — so they must keep working exactly as before, including
+    // against the ABSOLUTE worktree-tmp guard below: an operator who
+    // deliberately disables the hook, or says "you do it this time", gets
+    // exactly that, no exceptions. Guard 1 (`SUB_AGENT_ENV`), by contrast, is
+    // an AUTOMATIC marker a spawn helper stamps on every nested MPM subagent
+    // process with no per-invocation human decision involved — see Guard 1's
+    // own comment below for why it is checked LATER, after the worktree
+    // guard, instead of here.
     if std::env::var_os(DISABLE_HOOKS_ENV).is_some() {
         return Ok(());
     }
@@ -192,19 +215,28 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
         .and_then(|v| v.as_str())
         .unwrap_or_default();
 
-    // ABSOLUTE guard (issue #3977, worktree-hygiene follow-up to #3955) — deliberately
-    // placed BEFORE Guard 4's subagent-exemption early return, and called
-    // DIRECTLY rather than routed through `evaluate_tool`. A prior
-    // investigation established that `evaluate_tool` (and therefore
+    // ABSOLUTE guard (issue #3977, worktree-hygiene follow-up to #3955) —
+    // deliberately placed BEFORE Guard 1's and Guard 4's subagent-exemption
+    // early returns, and called DIRECTLY rather than routed through
+    // `evaluate_tool`. Two prior investigations (PR #3978 rounds 1 and 2)
+    // established that BOTH exemptions must be pierced, for the same
+    // underlying reason: `evaluate_tool` (and therefore
     // `pm_guard_bash::evaluate_bash_command`, its only Bash-classifying
     // callee) is NEVER reached for a payload carrying a non-empty `agent_id`
-    // — Guard 4 below returns before `evaluate_tool` runs — so a
-    // `git worktree add` rule placed inside the ordinary Bash classifier
-    // would be a silent no-op for exactly the calling pattern (a native
-    // Task/Agent-dispatched subagent) that actually provisions these
-    // worktrees. DO NOT move this block after Guard 4, and do NOT fold it
-    // into `evaluate_tool`/`evaluate_bash_command` — doing so re-introduces
-    // the no-op this comment exists to prevent.
+    // (Guard 4 returns first) NOR for a process with `CLAUDE_MPM_SUB_AGENT`
+    // set (Guard 1, formerly the very first check in this function, returned
+    // before the stdin payload was even read) — so a `git worktree add` rule
+    // placed inside the ordinary Bash classifier, or checked only after
+    // either exemption, would be a silent no-op for the calling patterns
+    // (native Task/Agent dispatch AND trusty-agents' own subprocess-spawned
+    // subagents — `crates/trusty-agents/src/subprocess/spawn.rs:189-192`,
+    // `crates/trusty-agents/src/agents/claude_code_runner/run.rs:211-215`)
+    // that actually provision these worktrees in practice. Guards 2/3 above
+    // are DELIBERATELY still checked earlier (before this) — they are human
+    // escape hatches, not automatic markers; see their comments. DO NOT move
+    // this block after Guard 1 or Guard 4, and do NOT fold it into
+    // `evaluate_tool`/`evaluate_bash_command` — doing so re-introduces the
+    // no-op this comment exists to prevent.
     if tool_name == "Bash" {
         let command = tool_input
             .and_then(|v| v.get("command"))
@@ -221,6 +253,18 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
             println!("{}", build_pretooluse_deny_response(reason));
             return Ok(());
         }
+    }
+
+    // Guard 1: never block a nested MPM sub-agent for anything else — it is
+    // doing the delegated work the PM is being steered toward. Moved here
+    // (originally the first line of this function, short-circuiting before
+    // any stdin read) specifically so the ABSOLUTE worktree guard above —
+    // which needs the payload — runs first and cannot be silently bypassed
+    // by this automatic marker. See that guard's comment for the full
+    // rationale; see Guards 2/3 above for why THOSE stayed in their original
+    // position instead.
+    if std::env::var_os(SUB_AGENT_ENV).is_some() {
+        return Ok(());
     }
 
     // Guard 4: native Claude Code sub-agent dispatch (issue #2014). A

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -51,6 +51,14 @@
 //! the specialist matching the target file's content type instead of a
 //! hardcoded `rust-engineer`.
 //! Build/test and network denials are NOT budget-eligible and stay absolute.
+//! **Worktree-tmp guard (issue #3977, follow-up to #3955):** [`pm_guard`] calls
+//! [`crate::commands::pm_guard_bash::evaluate_worktree_add_command`] DIRECTLY,
+//! before Guard 4's early return, denying any `git worktree add` whose target
+//! resolves under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR`, or the
+//! harness scratchpad — unconditionally, including native-subagent-dispatched
+//! calls. This is the one place in the file that pierces the Guard 4
+//! exemption; see that call site's comment for why it must never be routed
+//! through [`evaluate_tool`] instead.
 //! Test: `evaluate_tool_*`, `payload_is_subagent_dispatch_*`, and
 //! `build_pretooluse_deny_response_*` below cover the tool policy, sub-agent
 //! exemption, and JSON shape; the Bash-command classifier (composition and
@@ -60,9 +68,12 @@
 //! exercises the stdin→decision→stdout path (and the env bypasses / sub-agent
 //! exemption / fail-open) end to end through the real binary.
 
+use std::path::PathBuf;
+
 use crate::commands::misc::{DISABLE_HOOKS_ENV, SUB_AGENT_ENV, read_stdin_hook_payload};
 use crate::commands::pm_guard_bash::{
-    SHELL_EDIT_REASON, evaluate_bash_command, extract_shell_edit_target,
+    SHELL_EDIT_REASON, evaluate_bash_command, evaluate_worktree_add_command,
+    extract_shell_edit_target,
 };
 use crate::commands::pm_guard_budget::{self, BudgetDecision, DEFAULT_FILE_CHANGE_BUDGET};
 use crate::commands::pm_guard_deny_by_default::{self, PERSONA_DENY_REASON};
@@ -180,6 +191,37 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
         .get("session_id")
         .and_then(|v| v.as_str())
         .unwrap_or_default();
+
+    // ABSOLUTE guard (issue #3977, worktree-hygiene follow-up to #3955) — deliberately
+    // placed BEFORE Guard 4's subagent-exemption early return, and called
+    // DIRECTLY rather than routed through `evaluate_tool`. A prior
+    // investigation established that `evaluate_tool` (and therefore
+    // `pm_guard_bash::evaluate_bash_command`, its only Bash-classifying
+    // callee) is NEVER reached for a payload carrying a non-empty `agent_id`
+    // — Guard 4 below returns before `evaluate_tool` runs — so a
+    // `git worktree add` rule placed inside the ordinary Bash classifier
+    // would be a silent no-op for exactly the calling pattern (a native
+    // Task/Agent-dispatched subagent) that actually provisions these
+    // worktrees. DO NOT move this block after Guard 4, and do NOT fold it
+    // into `evaluate_tool`/`evaluate_bash_command` — doing so re-introduces
+    // the no-op this comment exists to prevent.
+    if tool_name == "Bash" {
+        let command = tool_input
+            .and_then(|v| v.get("command"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let hook_cwd = payload
+            .get("cwd")
+            .and_then(|v| v.as_str())
+            .map(PathBuf::from)
+            .or_else(|| std::env::current_dir().ok())
+            .unwrap_or_default();
+        if let Some(reason) = evaluate_worktree_add_command(command, &hook_cwd) {
+            audit_denied_tool(url, session_id, tool_name, reason).await;
+            println!("{}", build_pretooluse_deny_response(reason));
+            return Ok(());
+        }
+    }
 
     // Guard 4: native Claude Code sub-agent dispatch (issue #2014). A
     // Task/Agent-dispatched sub-agent is doing exactly the delegated work the

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -567,6 +567,24 @@ const WORKTREE_ADD_FLAGS_WITH_ARG: &[&str] = &["-b", "-B", "--reason"];
 /// - A `cd`/`-C` argument built from command substitution
 ///   (`cd "$(mktemp -d)"`) is not resolved — this module classifies text
 ///   structurally, it does not execute the shell.
+/// - **Largest of this list, tracked separately as
+///   [issue #3981](https://github.com/bobmatnyc/trusty-tools/issues/3981):**
+///   `pm_guard`'s Guard 2/3 escape hatches
+///   (`TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED`) bypass this
+///   entire guard when set, and while neither is ever set programmatically
+///   in this codebase's Rust source, Claude Code's `settings.json` supports a
+///   top-level `env` object applied to every hook invocation (live-reloaded
+///   mid-session) — and a `Write`/`Edit` to `.claude/settings.json` is not
+///   itself blocked by `pm_guard` today (`.json` is not a source-code
+///   extension, so `evaluate_edit_tool` falls through to an unconditional
+///   ALLOW). So the PM, or any subagent Guard 4 already exempts, can set
+///   either var there and self-exempt from every rule in this module,
+///   including this one, in one ordinary already-permitted config write. This
+///   is a pre-existing gap (Guard 3 predates this worktree guard by many
+///   issues) that this change neither introduces nor widens; it guards
+///   against an agent going off-script, not a determined adversary, and is
+///   deliberately NOT fixed here — the remedy belongs in the edit-tool
+///   classifier, not this Bash classifier, and is the project owner's call.
 ///
 /// Test: `evaluate_worktree_add_command_*` below;
 /// `pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload` and siblings

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -26,6 +26,8 @@
 mod sed_awk;
 mod shell_lex;
 
+use std::path::{Path, PathBuf};
+
 use crate::commands::hook_rewrite::{effective_tool_name, first_command_token};
 use shell_lex::QuoteScan;
 
@@ -475,6 +477,269 @@ pub(crate) fn has_file_write_redirection(command: &str) -> bool {
         i += 1;
     }
     false
+}
+
+/// Deny reason for `git worktree add` targeting a denylisted temp root.
+///
+/// Why (issue #3977, filed as the worktree-hygiene follow-up to #3955): a
+/// worktree provisioned under `/tmp`/`/private/tmp`/`/var/folders` silently
+/// fails unrelated tests (trusty-search's `SENSITIVE_PATH_PREFIXES` denylist,
+/// #3955) and has repeatedly caused agents to lose in-flight work when the
+/// harness or OS reaps that scratch space out from under a live worktree.
+/// The message must be actionable, not a bare refusal, so it names the
+/// project-local convention directly.
+pub(crate) const WORKTREE_TMP_REASON: &str = "`git worktree add` must not target /tmp, \
+     /private/tmp, /var/folders, $TMPDIR, or the harness scratchpad — worktrees provisioned \
+     there silently fail unrelated tests and can be reaped mid-task (issue #3955). Use \
+     `<repo-root>/.claude/worktrees/<name>` (the tm-pr-workflow convention) instead.";
+
+/// Filesystem roots `git worktree add` must never target (issue #3977).
+///
+/// Why: `/tmp` and `/private/tmp` are the same location on macOS (`/tmp` is a
+/// symlink) but both are listed literally because [`resolves_under_denylisted_tmp`]
+/// does a lexical prefix match, not a filesystem-resolving one (see that
+/// function's doc for why). `/var/folders` is the root `$TMPDIR` resolves
+/// under on macOS (e.g. `/var/folders/x1/…/T/`), and the harness scratchpad
+/// (`/private/tmp/claude-502/…`) is already covered by the `/private/tmp`
+/// entry — it is called out separately in the deny message (not here) because
+/// agents are told to prefer it "instead of /tmp", making it the subtle case
+/// that looks compliant while still landing in a denylisted zone.
+const WORKTREE_TMP_DENYLIST_ROOTS: &[&str] = &["/tmp", "/private/tmp", "/var/folders"];
+
+/// `git worktree add`'s own flags that consume a following argv token.
+///
+/// Why: needed so [`worktree_add_target_token`] can skip past `-b <branch>` /
+/// `-B <branch>` / `--reason <text>` (used with `--lock`) without mistaking
+/// the flag's value for the target path.
+const WORKTREE_ADD_FLAGS_WITH_ARG: &[&str] = &["-b", "-B", "--reason"];
+
+/// Detect a `git worktree add` call whose target resolves under a denylisted
+/// temp root, regardless of who dispatches the `Bash` call.
+///
+/// Why: this is the ONE piece of policy that must be called directly from
+/// `pm_guard()` **before** its Guard 4 subagent-exemption early return, NOT
+/// routed through [`evaluate_tool`]/[`evaluate_bash_command`] like every other
+/// Bash rule in this module. `evaluate_bash_command` is the sole callee of
+/// `evaluate_tool`, which Guard 4 never reaches for a payload carrying a
+/// non-empty `agent_id` — i.e. every native Task/Agent-dispatched subagent,
+/// which is exactly who provisions these worktrees in practice. A rule placed
+/// inside `evaluate_bash_command`/`classify_bash_segment` would therefore be a
+/// silent no-op for that calling pattern. See `pm_guard::pm_guard`'s call site
+/// for the enforcement of "before Guard 4", and its comment for why that must
+/// never be "simplified" back inside `evaluate_tool`.
+/// What: splits `command` into composition segments (reusing
+/// [`split_shell_segments`] for consistency with the rest of the module),
+/// tracks a running effective working directory across the command line by
+/// following `cd <dir>` segments and a leading `git -C <dir>` override (a
+/// deliberate, PARTIAL closing of the `cd /tmp && git worktree add wt-foo`
+/// bypass — see the "Residual bypasses" note below), resolves each `worktree
+/// add` segment's target (skipping `-b`/`-B`/`--reason` flag values) against
+/// that directory, lexically normalizes it (collapsing `.`/`..` WITHOUT
+/// touching the filesystem — the target usually does not exist yet), expands
+/// a leading `~` and any `$TMPDIR`/`${TMPDIR}`/`$TMP`/`${TMP}` occurrence
+/// using the guard process's own environment (which a Bash tool call inherits
+/// unchanged), and denies when the result lexically starts with one of
+/// [`WORKTREE_TMP_DENYLIST_ROOTS`]. Only the exact `worktree add` two-token
+/// form denies — `list`/`remove`/`prune`/`lock`/… are left alone, matching
+/// git's own subcommand structure (`git worktree <subcmd>`, not
+/// `git worktree add <subcmd>`), and no other `git`/shell verb is touched.
+///
+/// Residual bypasses accepted (documented per the task's explicit instruction
+/// to state, not hide, what remains open — a missed instance here fails open
+/// to ALLOW, same as every other classifier in this module):
+/// - Indirection through an intermediate shell variable
+///   (`X=/tmp; git worktree add "$X/foo"`) is not resolved — this module does
+///   not implement a shell variable table.
+/// - A `cd`/`-C` target that is itself a symlink into a denylisted root
+///   (e.g. a project-tree symlink pointing at `/tmp`) is not caught: path
+///   resolution here is purely lexical, never touches the filesystem
+///   (`fs::canonicalize`), because the worktree target usually does not exist
+///   yet and a guard must stay fast and side-effect-free.
+///   `resolves_under_denylisted_tmp` therefore cannot see through a symlink
+///   the way the OS eventually would.
+///   `/tmp` itself being a symlink to `/private/tmp` is NOT in this bucket —
+///   both spellings are literal entries in [`WORKTREE_TMP_DENYLIST_ROOTS`],
+///   so a literal `/tmp/...` argument is caught without needing to resolve
+///   the symlink.
+/// - Multiple/cumulative `git -C` flags are collapsed to "the last one
+///   present"; real git applies them successively relative to each other.
+///   Realistic invocations use at most one `-C`.
+/// - A `cd`/`-C` argument built from command substitution
+///   (`cd "$(mktemp -d)"`) is not resolved — this module classifies text
+///   structurally, it does not execute the shell.
+///
+/// Test: `evaluate_worktree_add_command_*` below;
+/// `pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload` and siblings
+/// in `tests/tm_hook_pm_guard.rs` exercise the end-to-end binary path,
+/// including the `agent_id`-present case this function exists for.
+pub(crate) fn evaluate_worktree_add_command(command: &str, cwd: &Path) -> Option<&'static str> {
+    let mut effective_cwd = cwd.to_path_buf();
+    for segment in split_shell_segments(command) {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if first_command_token(trimmed) == Some("cd") {
+            if let Some(argv) = shlex::split(trimmed)
+                && let Some(dest) = argv.get(1)
+            {
+                effective_cwd = resolve_target_path(dest, &effective_cwd);
+            }
+            continue;
+        }
+        if shell_lex::git_subcommand(trimmed).as_deref() != Some("worktree") {
+            continue;
+        }
+        let Some(argv) = shlex::split(trimmed) else {
+            continue;
+        };
+        let Some(worktree_idx) = argv
+            .windows(2)
+            .position(|w| w[0] == "worktree" && w[1] == "add")
+        else {
+            // Not the `add` subcommand (list/remove/prune/lock/…) — never
+            // blocked.
+            continue;
+        };
+        let base = match git_dash_c_override(&argv, worktree_idx) {
+            Some(dash_c) => resolve_target_path(dash_c, &effective_cwd),
+            None => effective_cwd.clone(),
+        };
+        let Some(target) = worktree_add_target_token(&argv[worktree_idx + 2..]) else {
+            continue;
+        };
+        let resolved = resolve_target_path(&target, &base);
+        if resolves_under_denylisted_tmp(&resolved) {
+            return Some(WORKTREE_TMP_REASON);
+        }
+    }
+    None
+}
+
+/// The `-C <path>` value preceding a resolved `worktree` subcommand token, if
+/// any — git's own global working-directory override.
+///
+/// Why: `git -C /tmp worktree add wt-foo` changes git's effective working
+/// directory for the whole invocation exactly as a preceding `cd /tmp &&`
+/// would, so it must feed the same resolution base as
+/// [`evaluate_worktree_add_command`]'s `cd`-tracking. Scoped to `argv[..worktree_idx]`
+/// so a `-C` appearing after `worktree` (not valid git syntax, but shlex would
+/// still tokenize it) is never mistaken for the global option.
+/// What: the last `-C <value>` pair found before `worktree_idx` (real git
+/// applies multiple `-C` flags cumulatively/relative to each other — this
+/// collapses to "last wins", a documented simplification; see the residual
+/// bypass list on [`evaluate_worktree_add_command`]).
+fn git_dash_c_override(argv: &[String], worktree_idx: usize) -> Option<&str> {
+    let mut i = 0;
+    let mut last = None;
+    while i < worktree_idx {
+        if argv[i] == "-C" && i + 1 < worktree_idx {
+            last = Some(argv[i + 1].as_str());
+            i += 2;
+            continue;
+        }
+        i += 1;
+    }
+    last
+}
+
+/// The target-path token of a `git worktree add …` argv tail (everything
+/// after the `add` token), skipping flags and their values.
+///
+/// Why: `git worktree add [-f] [--detach] [--checkout] [--lock [--reason
+/// <text>]] [--orphan] [(-b | -B) <branch>] <path> [<commit-ish>]` — the path
+/// is the first non-flag positional, but `-b`/`-B`/`--reason` each consume a
+/// following token that must not be mistaken for it.
+/// What: walks `tail`, skipping [`WORKTREE_ADD_FLAGS_WITH_ARG`] pairs and any
+/// other `-`-prefixed flag, returning the first remaining token.
+fn worktree_add_target_token(tail: &[String]) -> Option<String> {
+    let mut i = 0;
+    while i < tail.len() {
+        let tok = &tail[i];
+        if WORKTREE_ADD_FLAGS_WITH_ARG.contains(&tok.as_str()) {
+            i += 2;
+            continue;
+        }
+        if tok.starts_with('-') {
+            i += 1;
+            continue;
+        }
+        return Some(tok.clone());
+    }
+    None
+}
+
+/// Expand a leading `~`, `$TMPDIR`/`${TMPDIR}`, and `$TMP`/`${TMP}` in a path
+/// token using the current process environment, then resolve it against
+/// `base` if relative, then lexically normalize (collapse `.`/`..` components
+/// WITHOUT touching the filesystem).
+///
+/// Why: `shlex::split` does not perform shell variable expansion, so a target
+/// argument like `$TMPDIR/wt-foo` or `~/scratch/wt-foo` reaches this function
+/// as literal text; the guard must expand it itself to see where it really
+/// points. Filesystem-touching resolution (`fs::canonicalize`) is deliberately
+/// avoided — the worktree target usually does not exist yet, and a
+/// `PreToolUse` hook must stay fast and side-effect-free.
+/// What: string-replaces the env-var forms (guard process env — a `Bash` tool
+/// call inherits it unchanged), expands a `~`/`~/…` prefix via `$HOME`, joins
+/// onto `base` if the result is still relative, then normalizes.
+fn resolve_target_path(token: &str, base: &Path) -> PathBuf {
+    let mut expanded = token.to_string();
+    if let Ok(tmpdir) = std::env::var("TMPDIR") {
+        expanded = expanded
+            .replace("${TMPDIR}", &tmpdir)
+            .replace("$TMPDIR", &tmpdir);
+    }
+    if let Ok(tmp) = std::env::var("TMP") {
+        expanded = expanded.replace("${TMP}", &tmp).replace("$TMP", &tmp);
+    }
+    if expanded == "~" {
+        if let Ok(home) = std::env::var("HOME") {
+            expanded = home;
+        }
+    } else if let Some(rest) = expanded.strip_prefix("~/")
+        && let Ok(home) = std::env::var("HOME")
+    {
+        expanded = format!("{home}/{rest}");
+    }
+    let path = Path::new(&expanded);
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        base.join(path)
+    };
+    normalize_lexically(&joined)
+}
+
+/// Collapse `.`/`..` path components without touching the filesystem.
+///
+/// Why: [`resolve_target_path`] must not call `fs::canonicalize` (the target
+/// usually doesn't exist yet), but a purely textual join like
+/// `/repo/../tmp/wt` must still be recognized as resolving under `/tmp`.
+/// What: walks `path`'s components, popping the accumulator on `..` and
+/// dropping `.`, otherwise appending. Does not consult the filesystem, so it
+/// cannot see through symlinks (see the residual-bypass note on
+/// [`evaluate_worktree_add_command`]).
+fn normalize_lexically(path: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Whether `path` lexically starts with one of [`WORKTREE_TMP_DENYLIST_ROOTS`].
+fn resolves_under_denylisted_tmp(path: &Path) -> bool {
+    WORKTREE_TMP_DENYLIST_ROOTS
+        .iter()
+        .any(|root| path.starts_with(root))
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -657,3 +657,155 @@ fn evaluate_bash_command_allows_quoted_substitution_prose() {
         "double-quoted substitution is still live"
     );
 }
+
+#[test]
+fn evaluate_worktree_add_command_denies_direct_tmp_targets() {
+    let cwd = Path::new("/Users/x/proj");
+    for cmd in [
+        "git worktree add /tmp/wt-x",
+        "git worktree add /private/tmp/wt-x",
+        "git worktree add /var/folders/x1/abc/T/wt-x",
+        "git worktree add -b feat-x /tmp/wt-x",
+        "git worktree add --lock --reason busy /tmp/wt-x",
+    ] {
+        assert_eq!(
+            evaluate_worktree_add_command(cmd, cwd),
+            Some(WORKTREE_TMP_REASON),
+            "expected deny for: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_worktree_add_command_allows_project_targets() {
+    let cwd = Path::new("/Users/x/proj");
+    for cmd in [
+        "git worktree add .claude/worktrees/wt-x",
+        "git worktree add /Users/x/proj/.claude/worktrees/wt-x",
+        "git worktree add ../sibling-wt",
+        "git worktree add -b feat-x .claude/worktrees/wt-x",
+    ] {
+        assert_eq!(
+            evaluate_worktree_add_command(cmd, cwd),
+            None,
+            "expected allow for: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_worktree_add_command_only_matches_add_subcommand() {
+    let cwd = Path::new("/Users/x/proj");
+    for cmd in [
+        "git worktree list",
+        "git worktree remove /tmp/wt-x",
+        "git worktree prune",
+        "git worktree lock /tmp/wt-x",
+    ] {
+        assert_eq!(
+            evaluate_worktree_add_command(cmd, cwd),
+            None,
+            "non-add worktree subcommand must never be blocked: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_worktree_add_command_ignores_ordinary_temp_usage() {
+    let cwd = Path::new("/Users/x/proj");
+    for cmd in [
+        "mktemp -d",
+        "echo x > /tmp/scratch.txt",
+        "cargo build --target-dir /tmp/build",
+        "git status",
+        "git commit -m 'add worktree support'",
+    ] {
+        assert_eq!(
+            evaluate_worktree_add_command(cmd, cwd),
+            None,
+            "ordinary temp usage must not be blocked: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn evaluate_worktree_add_command_resolves_relative_target_against_cwd() {
+    // A relative target under a cwd that is ITSELF under /tmp must resolve
+    // (and deny) even though the argument text never spells "/tmp".
+    let cwd = Path::new("/tmp/some-repo");
+    assert_eq!(
+        evaluate_worktree_add_command("git worktree add wt-x", cwd),
+        Some(WORKTREE_TMP_REASON)
+    );
+    // The same relative target from a project cwd is fine.
+    let ok_cwd = Path::new("/Users/x/proj");
+    assert_eq!(
+        evaluate_worktree_add_command("git worktree add wt-x", ok_cwd),
+        None
+    );
+}
+
+#[test]
+fn evaluate_worktree_add_command_follows_cd_prefix() {
+    // `cd /tmp && git worktree add wt-foo` — the cwd change must be tracked
+    // across composition segments (documented partial mitigation).
+    let cwd = Path::new("/Users/x/proj");
+    assert_eq!(
+        evaluate_worktree_add_command("cd /tmp && git worktree add wt-foo", cwd),
+        Some(WORKTREE_TMP_REASON)
+    );
+    assert_eq!(
+        evaluate_worktree_add_command("cd .claude/worktrees && git worktree add wt-foo", cwd),
+        None
+    );
+}
+
+#[test]
+fn evaluate_worktree_add_command_follows_git_dash_c_override() {
+    let cwd = Path::new("/Users/x/proj");
+    assert_eq!(
+        evaluate_worktree_add_command("git -C /tmp worktree add wt-foo", cwd),
+        Some(WORKTREE_TMP_REASON)
+    );
+    assert_eq!(
+        evaluate_worktree_add_command("git -C /tmp worktree add /Users/x/proj/wt-foo", cwd),
+        None,
+        "an absolute in-project target overrides the -C base"
+    );
+}
+
+#[test]
+fn evaluate_worktree_add_command_expands_tmpdir_and_home() {
+    let cwd = Path::new("/Users/x/proj");
+    // SAFETY: test-only env mutation, no concurrent access to these vars in
+    // this process's test execution of this specific test.
+    unsafe {
+        std::env::set_var("TMPDIR", "/private/tmp/claude-502/scratch");
+        std::env::set_var("HOME", "/Users/x");
+    }
+    assert_eq!(
+        evaluate_worktree_add_command("git worktree add $TMPDIR/wt-foo", cwd),
+        Some(WORKTREE_TMP_REASON),
+        "$TMPDIR indirection must resolve to the harness scratchpad, still denylisted"
+    );
+    assert_eq!(
+        evaluate_worktree_add_command("git worktree add ~/proj/.claude/worktrees/wt-foo", cwd),
+        None,
+        "~ expansion to an in-project target must be allowed"
+    );
+    unsafe {
+        std::env::remove_var("TMPDIR");
+    }
+}
+
+#[test]
+fn evaluate_worktree_add_command_normalizes_dot_dot_traversal() {
+    // A purely textual `..` escape must be recognized without touching the fs.
+    // cwd has exactly 2 name components (Users, proj), so 2 `..` pops back to
+    // root before descending into `tmp`.
+    let cwd = Path::new("/Users/proj");
+    assert_eq!(
+        evaluate_worktree_add_command("git worktree add ../../tmp/wt-x", cwd),
+        Some(WORKTREE_TMP_REASON)
+    );
+}

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -529,6 +529,79 @@ fn pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload() {
 }
 
 #[test]
+fn pm_guard_blocks_worktree_add_under_tmp_via_claude_mpm_sub_agent_env() {
+    // Round 2 (code-critic BLOCK on PR #3978): `CLAUDE_MPM_SUB_AGENT=1` — the
+    // automatic marker trusty-agents' own subprocess/runner spawn helpers
+    // stamp on every nested subagent process (spawn.rs:189-192,
+    // claude_code_runner/run.rs:211-215) — must NOT exempt a `git worktree
+    // add /tmp/...` call, exactly like the `agent_id` case above. Before this
+    // fix, Guard 1 short-circuited to ALLOW before the stdin payload was even
+    // read, so this call was silently allowed. This is THE regression test
+    // for that finding.
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git worktree add /tmp/wt-x"}}"#;
+    let stdout = run_pm_guard(payload, &[("CLAUDE_MPM_SUB_AGENT", "1")]);
+    assert_denied(&stdout);
+    assert!(
+        stdout.contains("3955"),
+        "deny message must cite issue #3955: {stdout}"
+    );
+}
+
+#[test]
+fn pm_guard_claude_mpm_sub_agent_env_still_allows_everything_else() {
+    // Companion to the above: Guard 1's original "exempt everything else for
+    // a nested MPM subagent" behavior must be unchanged for calls that are
+    // NOT `git worktree add` under a denylisted root — including source-code
+    // Edit, which `pm_guard_sub_agent_env_allows_all` already covers, and a
+    // worktree add targeting an in-project path.
+    let ok_worktree = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git worktree add .claude/worktrees/wt-x"}}"#,
+        &[("CLAUDE_MPM_SUB_AGENT", "1")],
+    );
+    assert_eq!(
+        ok_worktree.trim(),
+        "",
+        "an in-project worktree target under CLAUDE_MPM_SUB_AGENT must stay allowed"
+    );
+}
+
+#[test]
+fn pm_guard_disable_hooks_env_still_allows_worktree_add_under_tmp() {
+    // `TRUSTY_MPM_DISABLE_HOOKS` is a genuine operator-set escape hatch (never
+    // set programmatically anywhere in this codebase) — unlike
+    // `CLAUDE_MPM_SUB_AGENT` above, it is deliberately NOT pierced: an
+    // operator who disables the hook entirely gets exactly that, including
+    // for the worktree-tmp guard.
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git worktree add /tmp/wt-x"}}"#,
+        &[("TRUSTY_MPM_DISABLE_HOOKS", "1")],
+    );
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "the disable-hooks operator escape hatch must still allow everything, \
+         including the worktree-tmp guard"
+    );
+}
+
+#[test]
+fn pm_guard_unrestricted_env_still_allows_worktree_add_under_tmp() {
+    // `TRUSTY_MPM_PM_UNRESTRICTED=1` — the explicit "the operator said you do
+    // it this time" override — is likewise a genuine human escape hatch and
+    // must still lift the worktree-tmp guard along with everything else.
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git worktree add /tmp/wt-x"}}"#,
+        &[("TRUSTY_MPM_PM_UNRESTRICTED", "1")],
+    );
+    assert_eq!(
+        stdout.trim(),
+        "",
+        "the unrestricted operator bypass must still allow everything, \
+         including the worktree-tmp guard"
+    );
+}
+
+#[test]
 fn pm_guard_allows_worktree_add_under_project_dir_via_subagent_payload() {
     // The companion positive case: the SAME subagent payload shape, but
     // targeting the documented in-project convention, must be allowed.

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -477,6 +477,106 @@ fn pm_guard_denies_composition_hidden_verb() {
 }
 
 #[test]
+fn pm_guard_blocks_worktree_add_under_tmp_for_pm_own_call() {
+    // The PM's own (non-subagent) `git worktree add /tmp/...` must be denied
+    // — this is the baseline the subagent case (below) is compared against.
+    for target in [
+        "/tmp/wt-x",
+        "/private/tmp/wt-x",
+        "/var/folders/x1/abc/T/wt-x",
+    ] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{{"command":"git worktree add {target}"}}}}"#
+        );
+        let stdout = run_pm_guard(&payload, &[]);
+        assert_denied(&stdout);
+        assert!(
+            stdout.contains("3955"),
+            "deny message must cite issue #3955: {stdout}"
+        );
+        assert!(
+            stdout.contains(".claude/worktrees"),
+            "deny message must name the correct location: {stdout}"
+        );
+    }
+}
+
+#[test]
+fn pm_guard_blocks_worktree_add_under_scratchpad_for_pm_own_call() {
+    // The harness scratchpad is the subtle case: agents are told to prefer it
+    // "instead of /tmp", so it looks compliant while still landing under the
+    // denylisted /private/tmp root.
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git worktree add /private/tmp/claude-502/some-session/scratchpad/wt-x"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload() {
+    // THE case the whole task turns on: a native Task/Agent-dispatched
+    // subagent (agent_id present) attempting `git worktree add` under /tmp
+    // must ALSO be denied. Guard 4's subagent exemption would normally allow
+    // an arbitrary Bash call from this payload shape (see
+    // `pm_guard_native_subagent_dispatch_allows_bash` above) — proving this
+    // case denies proves the worktree-tmp check fires BEFORE that exemption,
+    // not through the ordinary `evaluate_tool`/`evaluate_bash_command` path.
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","agent_type":"rust-engineer","tool_name":"Bash","tool_input":{"command":"git worktree add /tmp/wt-x"}}"#;
+    let stdout = run_pm_guard(payload, &[]);
+    assert_denied(&stdout);
+    assert!(
+        stdout.contains("3955"),
+        "deny message must cite issue #3955: {stdout}"
+    );
+}
+
+#[test]
+fn pm_guard_allows_worktree_add_under_project_dir_via_subagent_payload() {
+    // The companion positive case: the SAME subagent payload shape, but
+    // targeting the documented in-project convention, must be allowed.
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","tool_name":"Bash","tool_input":{"command":"git worktree add .claude/worktrees/wt-x"}}"#;
+    assert_eq!(
+        run_pm_guard(payload, &[]).trim(),
+        "",
+        "an in-project worktree target must be allowed even unbudgeted \
+         (worktree add is not a budget-eligible file-change deny)"
+    );
+}
+
+#[test]
+fn pm_guard_worktree_add_denial_is_not_budget_eligible() {
+    // Unlike source-code Edit/Write or shell file edits, a worktree-tmp deny
+    // must be an ABSOLUTE prohibition, not consumed against/gated by the
+    // per-turn file-change budget — repeating the call must deny every time.
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git worktree add /tmp/wt-x"}}"#;
+    for _ in 1..=4 {
+        assert_denied(&run_pm_guard(payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
+fn pm_guard_allows_non_add_worktree_subcommands_and_ordinary_temp_usage() {
+    // list/remove/prune must never be blocked, and ordinary temp usage
+    // (mktemp, temp-file writes, cargo build artifacts) must keep working.
+    for command in [
+        "git worktree list",
+        "git worktree remove /tmp/wt-x",
+        "git worktree prune",
+        "mktemp -d",
+        "cargo build --target-dir /tmp/build-cache",
+    ] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{{"command":"{command}"}}}}"#
+        );
+        assert_eq!(
+            run_pm_guard(&payload, &[]).trim(),
+            "",
+            "expected allow for: {command}"
+        );
+    }
+}
+
+#[test]
 fn pm_guard_allows_benign_pipes_and_dev_null() {
     // Composition with no forbidden segment must still allow.
     let piped = run_pm_guard(

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -310,6 +310,40 @@ fn pm_guard_sub_agent_env_allows_all() {
 }
 
 #[test]
+fn pm_guard_claude_mpm_sub_agent_env_still_allows_forbidden_bash_verb() {
+    // Round 3 (code-critic MEDIUM on PR #3978): the round-2 reorder moved
+    // Guard 1 (`CLAUDE_MPM_SUB_AGENT`) to AFTER the worktree-tmp guard, but
+    // no test previously covered a plain forbidden-Bash-verb case under that
+    // env var post-reorder —
+    // `pm_guard_claude_mpm_sub_agent_env_still_allows_everything_else` only
+    // used an in-project `git worktree add`, which `evaluate_bash_command`
+    // would allow even with NO exemption at all, making it a weak proxy.
+    // Mirrors `pm_guard_native_subagent_dispatch_allows_bash`: `sed -i` is
+    // denied unconditionally for the PM's own shell, so it must still be
+    // exempt here to prove Guard 1's original "exempt everything else"
+    // behavior survived the reorder intact.
+    let sed = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"sed -i s/a/b/ f"}}"#,
+        &[("CLAUDE_MPM_SUB_AGENT", "1")],
+    );
+    assert_eq!(
+        sed.trim(),
+        "",
+        "a nested MPM sub-agent's sed -i call must still be allowed post-reorder"
+    );
+
+    let make = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"make build"}}"#,
+        &[("CLAUDE_MPM_SUB_AGENT", "1")],
+    );
+    assert_eq!(
+        make.trim(),
+        "",
+        "a nested MPM sub-agent's make build call must still be allowed post-reorder"
+    );
+}
+
+#[test]
 fn pm_guard_native_subagent_dispatch_allows_edit() {
     // Native Task/Agent-tool dispatch (issue #2014): Claude Code stamps
     // `agent_id` on the PreToolUse payload when the hook fires inside a


### PR DESCRIPTION
## Summary

- Closes #3977 (worktree-hygiene follow-up to #3955): `tm hook --pm-guard` now hard-blocks `git worktree add` whose target resolves under `/tmp`, `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad.
- The check (`pm_guard_bash::evaluate_worktree_add_command`) is called DIRECTLY from `pm_guard()` **before** both automatic subagent-exemption early returns:
  - Guard 4 (native Task/Agent dispatch, `agent_id` present) — round 1.
  - Guard 1 (`CLAUDE_MPM_SUB_AGENT`, the marker `crates/trusty-agents/src/subprocess/spawn.rs:189-192` and `crates/trusty-agents/src/agents/claude_code_runner/run.rs:211-215` stamp automatically on every nested trusty-agents-spawned subagent) — round 2, added after a code-critic BLOCK caught that this was a total, silent bypass of the entire guard for what is the dominant real worktree-creation pathway.
- Guards 2/3 (`TRUSTY_MPM_DISABLE_HOOKS`, `TRUSTY_MPM_PM_UNRESTRICTED`) are **deliberately left un-pierced**: neither is ever set programmatically anywhere in this codebase's Rust source (`std::env::var`/`set_var`), so whoever sets them still gets exactly that, including for this guard.
  - **Round 3 correction:** that is narrower than "operator-only" — Claude Code's `settings.json` `env` object can set either var for every hook invocation (live-reloaded mid-session), and a `Write`/`Edit` to `.claude/settings.json` is not itself blocked by `pm_guard` today (`.json` is not a source-code extension, so `evaluate_edit_tool` falls through to an unconditional ALLOW). So the PM, or any Guard-4-exempt subagent, can self-exempt from this entire guard — and every other `pm_guard` rule — via that pre-existing, unrelated gap in one ordinary already-permitted config write. This is **not introduced or widened by this PR** (Guard 3 predates it by many issues); it guards against an agent going off-script, not a determined adversary; and it is deliberately **not fixed here** — the remedy belongs in the edit-tool classifier, not this Bash/worktree classifier, and is the project owner's call. Tracked as #3981.
- Path resolution (no filesystem access, since the target usually doesn't exist yet): relative paths, `cd <dir>`/`git -C <dir>` tracking across composition segments, `~`/`$TMPDIR`/`${TMPDIR}`/`$TMP`/`${TMP}` expansion, lexical `.`/`..` normalization.
- Only the exact `git worktree add` subcommand is affected — `list`/`remove`/`prune`/`lock`/… and ordinary temp usage (`mktemp`, temp file writes, cargo build artifacts, `test_support::hermetic_temp_dir`) are untouched.
- Documented residual bypasses (not silently accepted) on `evaluate_worktree_add_command`'s doc comment: shell-variable indirection, a symlinked `cd`/`-C` target, multiple cumulative `-C` flags collapsed to "last wins", a `cd`/`-C` argument built from command substitution, and (largest, round 3) the settings.json self-exemption path above (#3981).

## Evidence this fires for the cases it exists for

Verified failing-then-passing in both directions, twice:

1. **Round 1 (Guard 4 / `agent_id`):** temporarily moved the check to the naive placement (after Guard 4) — `pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload` went RED. Restored — green.
2. **Round 2 (Guard 1 / `CLAUDE_MPM_SUB_AGENT`):** temporarily reverted `pm_guard()` to its original guard ordering — `pm_guard_blocks_worktree_add_under_tmp_via_claude_mpm_sub_agent_env` went RED, all 31 other tests stayed green. Restored — green.

Round 3 (this update) is a coverage/documentation correction, not a behavior change — verified via the real binary that `CLAUDE_MPM_SUB_AGENT=1` + `sed -i`/`make build` still ALLOW post-round-2-reorder (new test `pm_guard_claude_mpm_sub_agent_env_still_allows_forbidden_bash_verb`).

## Test plan

- [x] `cargo test -p trusty-mpm --bin tm evaluate_worktree_add_command` — 9/9 unit tests pass.
- [x] `cargo test -p trusty-mpm --test tm_hook_pm_guard` — 33/33 pass, including:
  - `pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload` (native `agent_id` dispatch, round 1)
  - `pm_guard_blocks_worktree_add_under_tmp_via_claude_mpm_sub_agent_env` (trusty-agents-spawned subagent marker, round 2)
  - `pm_guard_claude_mpm_sub_agent_env_still_allows_forbidden_bash_verb` (round 3 — closes the coverage gap the critic flagged)
  - `pm_guard_claude_mpm_sub_agent_env_still_allows_everything_else`, `pm_guard_disable_hooks_env_still_allows_worktree_add_under_tmp`, `pm_guard_unrestricted_env_still_allows_worktree_add_under_tmp`
- [x] `cargo test -p trusty-mpm` (full suite, no `--lib`) — 3604 passed, 0 failed, 6 ignored.
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p trusty-mpm --check` — clean.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
