### PR TITLE
fix: emit ChatEvent::Error on failed SSE streams and restore streaming sampling parity

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **Streamed chat turns now send the same sampling parameters as the blocking
+  path** (issue #3758): `llm::stream::stream_reply` built its
+  `OpenRouterProvider` with no temperature, token ceiling, or stop sequences, so
+  a streamed conversational/persona reply ran on provider defaults while the
+  blocking fallback for the SAME turn sent `llm.temperature`, `llm.max_tokens`,
+  and `llm.stop_sequences` — the streamed and fallback answers could differ in
+  style, verbosity, and where they stopped. Both call sites (the persona turn
+  and the conversational fast path) now forward their turn's exact values,
+  including the conversational path's `effective_max_tokens`, which the
+  local-route branch may override.
+
+- **A truncated stream no longer renders as a complete answer** (issue #3757):
+  `stream_with_provider`'s empty-stream guard only caught a stream that produced
+  NOTHING, so a partial-then-truncated stream returned its cut-off text as a
+  success and the blocking fallback never engaged. The upstream pump now emits
+  `ChatEvent::Error` for a mid-stream error frame, a truncated EOF, and an
+  unusable non-SSE 200, so those surface through `assembly.error` and the caller
+  falls back to the blocking chat path.
+
 ### Added
 
 - **Skill-wrapping runtime — one named skill per tool (#3933, DOC-57 §5, epic

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -277,6 +277,15 @@ pub async fn run_pm_task_with_history(
                 &sid,
                 &pm_cfg.agent.name,
                 llm::stream::DEFAULT_STREAM_CADENCE,
+                // #3758: the SAME sampling knobs the blocking
+                // `chat_with_tools_gated` call below sends — including
+                // `effective_max_tokens`, which the local-route branch above
+                // may have overridden.
+                trusty_common::chat::SamplingParams {
+                    temperature: Some(pm_cfg.llm.temperature),
+                    max_tokens: Some(effective_max_tokens),
+                    stop: pm_cfg.llm.stop_sequences.clone(),
+                },
             )
             .await
             {

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -602,6 +602,13 @@ pub async fn run_pm_task_with_persona(
             &sid,
             &persona_cfg.agent.name,
             llm::stream::DEFAULT_STREAM_CADENCE,
+            // #3758: the SAME sampling knobs the blocking tool-loop call below
+            // sends, so a streamed reply's style/verbosity/stopping matches.
+            trusty_common::chat::SamplingParams {
+                temperature: Some(persona_cfg.llm.temperature),
+                max_tokens: Some(persona_cfg.llm.max_tokens),
+                stop: persona_cfg.llm.stop_sequences.clone(),
+            },
         )
         .await
         {

--- a/crates/trusty-agents/src/llm/stream.rs
+++ b/crates/trusty-agents/src/llm/stream.rs
@@ -31,7 +31,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Result, anyhow};
 use tokio::sync::mpsc;
 use trusty_common::ChatMessage;
-use trusty_common::chat::{ChatEvent, ChatProvider, OpenRouterProvider, ToolCall};
+use trusty_common::chat::{ChatEvent, ChatProvider, OpenRouterProvider, SamplingParams, ToolCall};
 
 use crate::ctrl::state::ConversationTurn;
 use crate::events::{self, Event};
@@ -228,6 +228,13 @@ where
 /// tagged with `session_id`/`agent`. Errors (empty key, HTTP failure,
 /// mid-stream error) propagate as `Err` so the caller can fall back to the
 /// blocking chat path.
+///
+/// `sampling` (issue #3758) MUST carry the same temperature / token ceiling /
+/// stop sequences the caller's blocking path sends for this turn. Without it
+/// the streamed reply silently ran on provider defaults, so its style,
+/// verbosity, and stopping behaviour were not equivalent to the fallback — and
+/// `LlmConfig::stop_sequences` documents itself as forwarded on the OpenRouter
+/// path, which the streaming path was quietly not honouring.
 /// Test: exercised end-to-end against a live provider; the batching/assembly
 /// contract is unit-tested via [`drive_delta_stream`].
 pub async fn stream_reply(
@@ -236,6 +243,7 @@ pub async fn stream_reply(
     session_id: &str,
     agent: &str,
     cadence: Duration,
+    sampling: SamplingParams,
 ) -> Result<StreamAssembly> {
     let api_key =
         trusty_common::inference::credentials::resolve_key("openrouter").unwrap_or_default();
@@ -245,7 +253,8 @@ pub async fn stream_reply(
         ));
     }
 
-    let provider = OpenRouterProvider::new(api_key, model.to_string());
+    // #3758: forward the blocking path's sampling knobs onto the stream.
+    let provider = OpenRouterProvider::new(api_key, model.to_string()).with_sampling(sampling);
     stream_with_provider(provider, messages, session_id, agent, cadence).await
 }
 
@@ -255,16 +264,14 @@ pub async fn stream_reply(
 /// Why: Split out of [`stream_reply`] so the error branches can be unit-tested
 /// with a controllable fake provider (no live API key) — and so the
 /// failed-stream detection lives in exactly one place. The upstream SSE pump
-/// (`trusty_common::chat`) never emits `ChatEvent::Error`: a mid-stream error
-/// frame, a truncated EOF, or a non-SSE `200` all currently arrive as a clean
-/// `Done`. Without a guard those would return an empty (or partial-but-treated-
-/// as-complete) success and the caller's blocking fallback would never engage,
-/// leaving the user staring at an empty bubble. This function turns the
-/// unambiguous failure signal — a stream that yielded NO content and NO tool
-/// calls — into an `Err` so the caller falls back to the blocking chat path.
-/// (A partial-then-error stream that already produced some text is NOT caught
-/// here; robustly detecting that needs the pump to emit `ChatEvent::Error`,
-/// which is deferred to avoid destabilizing the shared tcode/memory consumers.)
+/// (`trusty_common::chat`) now emits `ChatEvent::Error` for a mid-stream error
+/// frame, a truncated EOF, and an unusable non-SSE `200` (issue #3757 — those
+/// three previously arrived as a clean `Done`), so the partial-then-truncated
+/// case IS caught here: the error surfaces through `assembly.error` and the
+/// caller falls back to the blocking chat path instead of rendering a cut-off
+/// answer as complete. The empty-stream guard below remains as the backstop for
+/// any remaining way a stream can yield NO content and NO tool calls without
+/// saying so.
 /// What: Spawns `provider.chat_stream` into a bounded channel, drives
 /// [`drive_delta_stream`] with a sink that publishes each batch as an
 /// [`Event::AgentMessageDelta`] tagged with `session_id`/`agent`, joins the

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -78,7 +78,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   since not every provider sends the sentinel); and a `Content-Type` guard.
   Failures are reported BOTH as `ChatEvent::Error` and as an `Err` return,
   because consumers are split between watching the channel (trusty-memory,
-  trusty-analyze) and joining the pump task (trusty-agents, trusty-search).
+  trusty-analyze) and joining the pump task (trusty-agents, trusty-search,
+  trusty-mpm's activity monitor).
+
+  Three refinements from review: the frame decoder distinguishes a FAILED stop
+  from a normal one, so an error frame returns `Err` instead of the `Ok(())` an
+  earlier revision returned (which silently broke the both-channels contract
+  for consumers that only join the task); a present-but-null `"error": null`
+  key — a real wire shape for providers that always include the field — is not
+  treated as a failure; and the truncation detector now decodes the residual
+  tail first, so a final frame missing only its trailing newline (including a
+  bare `data: [DONE]`) still completes cleanly rather than flipping a working
+  stream to an error and costing the caller a second blocking LLM call.
 
 - **A non-SSE streaming response degrades instead of vanishing** (issue #3757):
   a gateway that strips streaming and returns a buffered 200 previously decoded

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`chat::SamplingParams` — sampling parity for streamed turns** (issue
+  #3758): the OpenAI-compatible streaming request wire sent only
+  `model`/`messages`/`tools`, so a streamed reply silently ran on provider
+  defaults while the blocking path for the same turn sent the caller's
+  configured temperature, token ceiling, and stop sequences — a documented
+  contract (`LlmConfig::stop_sequences` claims to be forwarded on the
+  OpenRouter path) that the streaming path was not honouring.
+  `OpenRouterProvider::with_sampling` / `OllamaProvider::with_sampling` attach
+  `temperature`, `max_tokens`, and `stop` to every request. All three fields
+  are omitted when absent (an empty `stop` array is never sent — some servers
+  reject `"stop": []`, the same trap an empty `tools` array has), so a caller
+  that does not opt in produces a byte-identical request body to before.
+
 ### Fixed
 
 - **`default_model_matches_sentence_transformers_reference` no longer
@@ -49,6 +64,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   shared `embedder::test_env` module holding the single lock and RAII guard;
   the four tests in `provider_tests.rs` became synchronous so they can take it,
   building an explicit current-thread runtime where they need one.
+
+- **Chat SSE pump surfaces stream failures instead of ending them as `Done`**
+  (issue #3757): `chat::openai_compat`'s shared pump never emitted
+  `ChatEvent::Error`, so a mid-stream `{"error": {...}}` frame, a stream cut off
+  mid-frame, and a 200 answered with a non-SSE body ALL arrived at the consumer
+  as a clean `ChatEvent::Done` — a partial answer rendered as a complete one,
+  and `trusty-agents`' blocking fallback never engaged. The pump now mirrors the
+  three guards `inference::streaming` shipped in #3751: an in-band error probe
+  that reads a numeric (`429`) or string (`"insufficient_quota"`) `code`;
+  incomplete-frame detection at EOF (bytes still buffered mid-frame is a
+  truncation, while a clean boundary without `[DONE]` remains a normal finish,
+  since not every provider sends the sentinel); and a `Content-Type` guard.
+  Failures are reported BOTH as `ChatEvent::Error` and as an `Err` return,
+  because consumers are split between watching the channel (trusty-memory,
+  trusty-analyze) and joining the pump task (trusty-agents, trusty-search).
+
+- **A non-SSE streaming response degrades instead of vanishing** (issue #3757):
+  a gateway that strips streaming and returns a buffered 200 previously decoded
+  to zero deltas plus `Done`, dropping the whole answer. Such a body is now
+  replayed as its `message.content` + `message.tool_calls`; a body that still
+  carries `data:` frames under the wrong `Content-Type` is decoded as SSE
+  anyway, so a mislabelled-but-valid stream keeps working; and only a body with
+  nothing renderable becomes an error.
+
+- **A chunk boundary splitting a multi-byte UTF-8 character no longer discards
+  the chunk** (issue #3757): the pump decoded each raw chunk with
+  `str::from_utf8` and skipped the entire chunk on failure, silently losing
+  text whenever a character straddled a socket read. It now buffers bytes and
+  decodes per complete line.
 
 - **`catchup::session_finder::extract_section` no longer absorbs trailing
   header text** (issue #3901): a substring match on `## <header>` treated a

--- a/crates/trusty-common/src/chat/mod.rs
+++ b/crates/trusty-common/src/chat/mod.rs
@@ -124,6 +124,51 @@ pub struct ToolCall {
     pub arguments: String,
 }
 
+/// Sampling knobs forwarded to an OpenAI-compatible provider.
+///
+/// Why (issue #3758): the streaming request wire previously sent only
+/// `model`/`messages`/`tools`, so a streamed reply's style, verbosity, and
+/// stopping behaviour were NOT equivalent to the blocking path's for the same
+/// turn — the caller silently got provider defaults instead of its configured
+/// temperature, token ceiling, and stop sequences. Carrying them in one struct
+/// (rather than three provider constructor arguments) keeps `new()` stable for
+/// existing callers and lets the set grow without churning call sites.
+/// What: every field is optional — `None`/empty means "omit from the request
+/// body and let the provider default apply", which is exactly the pre-#3758
+/// behaviour, so a caller that does not opt in is unaffected. `stop` maps to
+/// the OpenAI `stop` array (the direct-Anthropic dialect calls the same thing
+/// `stop_sequences`).
+/// Test: `sampling_params_serialize_into_request_body`,
+/// `default_sampling_omits_fields`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SamplingParams {
+    /// Sampling temperature; `None` omits the field.
+    pub temperature: Option<f32>,
+    /// Maximum tokens to generate; `None` omits the field.
+    pub max_tokens: Option<u32>,
+    /// Stop sequences; empty omits the field.
+    pub stop: Vec<String>,
+}
+
+impl SamplingParams {
+    /// The stop sequences as a request-body-ready `Option<&[String]>`.
+    ///
+    /// Why: an EMPTY `stop` array is not the same as an absent one — some
+    /// OpenAI-compatible servers reject `"stop": []` outright, which is the
+    /// same trap [`ChatProvider`] already documents for an empty `tools`
+    /// array. Collapsing empty to `None` at the boundary keeps that decision
+    /// in one place instead of at each provider.
+    /// What: `None` when empty, `Some(slice)` otherwise.
+    /// Test: `default_sampling_omits_fields`.
+    pub fn stop_slice(&self) -> Option<&[String]> {
+        if self.stop.is_empty() {
+            None
+        } else {
+            Some(&self.stop)
+        }
+    }
+}
+
 /// Streaming chat event.
 ///
 /// Why: replaces the previous "string-only" channel so callers can

--- a/crates/trusty-common/src/chat/openai_compat/providers.rs
+++ b/crates/trusty-common/src/chat/openai_compat/providers.rs
@@ -16,7 +16,7 @@
 use super::sse_pump::pump_openai_sse;
 use super::wire::tools_wire;
 use crate::ChatMessage;
-use crate::chat::{ChatEvent, ChatProvider, ToolDef};
+use crate::chat::{ChatEvent, ChatProvider, SamplingParams, ToolDef};
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use tokio::sync::mpsc::Sender;
@@ -41,6 +41,10 @@ const X_TITLE: &str = "trusty-common";
 pub struct OpenRouterProvider {
     pub api_key: String,
     pub model: String,
+    /// #3758: sampling knobs forwarded on the streaming request so a streamed
+    /// turn matches the blocking path's style/verbosity/stopping. Default
+    /// (all-absent) reproduces the pre-#3758 body exactly.
+    pub sampling: SamplingParams,
 }
 
 impl OpenRouterProvider {
@@ -54,7 +58,21 @@ impl OpenRouterProvider {
         Self {
             api_key: api_key.into(),
             model: model.into(),
+            sampling: SamplingParams::default(),
         }
+    }
+
+    /// Attach sampling parameters to every request this provider sends.
+    ///
+    /// Why (#3758): callers that also have a blocking path must be able to send
+    /// the SAME temperature / token ceiling / stop sequences on the streaming
+    /// path, without `new()` growing three arguments that every existing call
+    /// site would have to spell out.
+    /// What: consuming builder; returns `self` with `sampling` replaced.
+    /// Test: `sampling_params_serialize_into_request_body`.
+    pub fn with_sampling(mut self, sampling: SamplingParams) -> Self {
+        self.sampling = sampling;
+        self
     }
 }
 
@@ -93,6 +111,10 @@ impl ChatProvider for OpenRouterProvider {
             messages: &messages,
             stream: true,
             tools: tw,
+            // #3758: forward the same sampling knobs the blocking path sends.
+            temperature: self.sampling.temperature,
+            max_tokens: self.sampling.max_tokens,
+            stop: self.sampling.stop_slice(),
         };
         let resp = client
             .post(OPENROUTER_URL)
@@ -129,6 +151,9 @@ impl ChatProvider for OpenRouterProvider {
 pub struct OllamaProvider {
     pub base_url: String,
     pub model: String,
+    /// #3758: see [`OpenRouterProvider::sampling`] — kept in lock-step so both
+    /// OpenAI-compatible providers send the same request shape.
+    pub sampling: SamplingParams,
 }
 
 impl OllamaProvider {
@@ -143,7 +168,19 @@ impl OllamaProvider {
         Self {
             base_url: base_url.into(),
             model: model.into(),
+            sampling: SamplingParams::default(),
         }
+    }
+
+    /// Attach sampling parameters to every request this provider sends.
+    ///
+    /// Why: parallel to [`OpenRouterProvider::with_sampling`] (#3758) so both
+    /// providers stay in lock-step.
+    /// What: consuming builder; returns `self` with `sampling` replaced.
+    /// Test: `sampling_params_serialize_into_request_body`.
+    pub fn with_sampling(mut self, sampling: SamplingParams) -> Self {
+        self.sampling = sampling;
+        self
     }
 }
 
@@ -179,6 +216,10 @@ impl ChatProvider for OllamaProvider {
             messages: &messages,
             stream: true,
             tools: tw,
+            // #3758: forward the same sampling knobs the blocking path sends.
+            temperature: self.sampling.temperature,
+            max_tokens: self.sampling.max_tokens,
+            stop: self.sampling.stop_slice(),
         };
         let resp = client
             .post(&url)

--- a/crates/trusty-common/src/chat/openai_compat/sse_pump.rs
+++ b/crates/trusty-common/src/chat/openai_compat/sse_pump.rs
@@ -104,14 +104,22 @@ impl ToolCallAccumulator {
 /// Why: [`handle_line`] is shared by the live byte-stream loop and the
 /// buffered-body fallback, so it must report "a terminal event was already
 /// dispatched" without either caller re-deriving that from the event itself.
-/// What: `Continue` keeps reading; `Stop` means a terminal
-/// (`Done`/`Error`) was sent, or the receiver hung up, and the caller must
-/// return immediately without sending anything else.
-/// Test: `sse_pump_tests.rs`.
+/// Crucially it must distinguish a SUCCESSFUL stop from a FAILED one: an
+/// earlier revision collapsed both into `Stop`, so a mid-stream error frame
+/// emitted `ChatEvent::Error` but still returned `Ok(())` — contradicting this
+/// module's own contract that a failure surfaces on both channels, and leaving
+/// consumers that only join the pump task (trusty-agents, trusty-search)
+/// believing the stream succeeded.
+/// What: `Continue` keeps reading; `Stop` means a normal terminal (`Done`) was
+/// sent or the receiver hung up — either way the caller returns `Ok`;
+/// `Failed(message)` means [`ChatEvent::Error`] was already sent and the caller
+/// MUST return `Err` carrying `message`.
+/// Test: `error_frame_emits_error_event`, `error_frame_returns_err`.
 #[derive(Debug, PartialEq, Eq)]
 enum Flow {
     Continue,
     Stop,
+    Failed(String),
 }
 
 /// Render a provider's in-band `error` payload as a human-readable message.
@@ -204,11 +212,12 @@ async fn handle_line(line: &str, acc: &mut ToolCallAccumulator, tx: &Sender<Chat
     };
     // #3757: an in-band error frame is a FAILURE, not a delta — surface it
     // instead of letting the stream end as an apparently complete answer.
-    if let Some(err) = v.get("error") {
-        let _ = tx
-            .send(ChatEvent::Error(error_message_from_frame(err)))
-            .await;
-        return Flow::Stop;
+    // `"error": null` is a real wire shape (providers that always include the
+    // key), so a PRESENT-but-null value must not be read as a failure.
+    if let Some(err) = v.get("error").filter(|e| !e.is_null()) {
+        let message = error_message_from_frame(err);
+        let _ = tx.send(ChatEvent::Error(message.clone())).await;
+        return Flow::Failed(message);
     }
     let Some(delta) = v
         .get("choices")
@@ -290,19 +299,39 @@ pub(super) async fn pump_openai_sse(resp: reqwest::Response, tx: Sender<ChatEven
 
         while let Some(idx) = buf.iter().position(|b| *b == b'\n') {
             let line: Vec<u8> = buf.drain(..=idx).collect();
-            if handle_line(&String::from_utf8_lossy(&line), &mut acc, &tx).await == Flow::Stop {
-                return Ok(());
+            match handle_line(&String::from_utf8_lossy(&line), &mut acc, &tx).await {
+                Flow::Continue => {}
+                Flow::Stop => return Ok(()),
+                // The Error event is already sent; the Err is the second half
+                // of the contract.
+                Flow::Failed(message) => return Err(anyhow!("{message}")),
             }
         }
     }
 
     // #3757: EOF. A clean socket close on a frame boundary is a normal finish,
-    // but bytes left mid-frame mean the stream was CUT OFF — reporting that as
+    // but bytes left MID-frame mean the stream was CUT OFF — reporting that as
     // Done would render a truncated answer as a complete one.
-    if buf.iter().any(|b| !b.is_ascii_whitespace()) {
-        let message = "chat stream ended with an incomplete SSE frame (truncated response)";
-        let _ = tx.send(ChatEvent::Error(message.to_string())).await;
-        return Err(anyhow!("{message}"));
+    //
+    // "Bytes remain" alone is too blunt a signal: a body whose final frame
+    // simply lacks its trailing newline (including a bare `data: [DONE]`) is
+    // COMPLETE, and failing it would flip a previously-successful stream to an
+    // error — in trusty-agents, a second full blocking LLM call per turn. So
+    // decode the residual first and only call it a truncation when it is not a
+    // whole frame.
+    let residual = String::from_utf8_lossy(&buf);
+    let residual = residual.trim();
+    if !residual.is_empty() {
+        if !is_complete_frame(residual) {
+            let message = "chat stream ended with an incomplete SSE frame (truncated response)";
+            let _ = tx.send(ChatEvent::Error(message.to_string())).await;
+            return Err(anyhow!("{message}"));
+        }
+        match handle_line(residual, &mut acc, &tx).await {
+            Flow::Continue => {}
+            Flow::Stop => return Ok(()),
+            Flow::Failed(message) => return Err(anyhow!("{message}")),
+        }
     }
     flush_terminal(acc, &tx).await;
     Ok(())
@@ -334,8 +363,10 @@ async fn pump_non_sse_body(resp: reqwest::Response, tx: Sender<ChatEvent>) -> Re
     if text.lines().any(|l| l.trim_start().starts_with("data:")) {
         let mut acc = ToolCallAccumulator::default();
         for line in text.split_inclusive('\n') {
-            if handle_line(line, &mut acc, &tx).await == Flow::Stop {
-                return Ok(());
+            match handle_line(line, &mut acc, &tx).await {
+                Flow::Continue => {}
+                Flow::Stop => return Ok(()),
+                Flow::Failed(message) => return Err(anyhow!("{message}")),
             }
         }
         flush_terminal(acc, &tx).await;
@@ -353,7 +384,8 @@ async fn pump_non_sse_body(resp: reqwest::Response, tx: Sender<ChatEvent>) -> Re
         )
         .await;
     };
-    if let Some(err) = v.get("error") {
+    // A present-but-null `error` key is not a failure (see `handle_line`).
+    if let Some(err) = v.get("error").filter(|e| !e.is_null()) {
         return fail(&tx, error_message_from_frame(err)).await;
     }
 
@@ -398,6 +430,34 @@ async fn pump_non_sse_body(resp: reqwest::Response, tx: Sender<ChatEvent>) -> Re
     }
     let _ = tx.send(ChatEvent::Done).await;
     Ok(())
+}
+
+/// Whether a newline-less trailing line is a COMPLETE SSE frame rather than a
+/// truncated one.
+///
+/// Why: at EOF the only thing distinguishing "the provider did not terminate
+/// its last frame with a newline" from "the socket was cut mid-frame" is
+/// whether the residual payload is self-consistent. Treating every residual as
+/// a truncation makes a previously-successful stream fail — an expensive false
+/// positive, since trusty-agents answers it with a second full blocking LLM
+/// call.
+/// What: `true` for an SSE comment/keep-alive (no payload to truncate), for
+/// `[DONE]`, and for a `data:` payload that parses as complete JSON. `false`
+/// for an unparseable payload (a cut-off JSON object) or a line that is not a
+/// recognisable field at all (a severed `dat…` prefix).
+/// Test: `unterminated_done_sentinel_completes_cleanly`,
+/// `truncated_stream_errors_instead_of_done`.
+fn is_complete_frame(line: &str) -> bool {
+    let line = line.trim();
+    if line.is_empty() || line.starts_with(':') {
+        return true;
+    }
+    let Some(payload) = line.strip_prefix("data:").map(str::trim) else {
+        return false;
+    };
+    payload.is_empty()
+        || payload == "[DONE]"
+        || serde_json::from_str::<serde_json::Value>(payload).is_ok()
 }
 
 /// Report an unrecoverable stream failure on BOTH channels.

--- a/crates/trusty-common/src/chat/openai_compat/sse_pump.rs
+++ b/crates/trusty-common/src/chat/openai_compat/sse_pump.rs
@@ -9,12 +9,24 @@
 //! `delta.content` as `ChatEvent::Delta`, accumulates `delta.tool_calls`,
 //! and on `[DONE]` (or upstream EOF) emits one `ChatEvent::ToolCall` per
 //! accumulated call followed by `ChatEvent::Done`.
+//! Failure detection (issue #3757): the pump never used to emit
+//! [`ChatEvent::Error`] — a mid-stream `{"error": {...}}` frame, a stream cut
+//! off mid-frame, and a 200 answered with a non-SSE body ALL arrived as a clean
+//! [`ChatEvent::Done`], so a partial answer rendered as a complete one. This
+//! file now mirrors the three guards `inference::streaming` shipped in PR
+//! #3751: a string-or-numeric in-band error probe, incomplete-frame detection
+//! at EOF, and a `Content-Type` guard that degrades a buffered body instead of
+//! silently dropping it.
 //! Test: `ollama_provider_streams_sse_deltas`,
-//! `accumulates_streamed_tool_call_fragments`.
+//! `accumulates_streamed_tool_call_fragments`, and `sse_pump_tests.rs`.
 
 use crate::chat::{ChatEvent, ToolCall};
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow};
 use tokio::sync::mpsc::Sender;
+
+#[cfg(test)]
+#[path = "sse_pump_tests.rs"]
+mod tests;
 
 /// Accumulator for streamed tool-call fragments.
 ///
@@ -87,86 +99,333 @@ impl ToolCallAccumulator {
     }
 }
 
+/// What the frame loop should do after one decoded SSE line.
+///
+/// Why: [`handle_line`] is shared by the live byte-stream loop and the
+/// buffered-body fallback, so it must report "a terminal event was already
+/// dispatched" without either caller re-deriving that from the event itself.
+/// What: `Continue` keeps reading; `Stop` means a terminal
+/// (`Done`/`Error`) was sent, or the receiver hung up, and the caller must
+/// return immediately without sending anything else.
+/// Test: `sse_pump_tests.rs`.
+#[derive(Debug, PartialEq, Eq)]
+enum Flow {
+    Continue,
+    Stop,
+}
+
+/// Render a provider's in-band `error` payload as a human-readable message.
+///
+/// Why (issue #3757): OpenRouter and other gateways report a mid-stream failure
+/// as a JSON `{"error": {...}}` frame rather than a non-2xx status — the
+/// connection already succeeded — and the `code` is provider-dependent: a
+/// NUMBER (`429`) on some, a STRING (`"insufficient_quota"`) on others. Probing
+/// both shapes (and a bare string payload) keeps a real quota/rate-limit
+/// failure from being silently dropped, exactly as
+/// `inference::streaming::error_from_chunk` does for the other stack.
+/// What: a bare string payload is used verbatim; otherwise `message` (with a
+/// generic fallback) prefixed by `code` when present in either shape.
+/// Test: `error_message_reads_numeric_code`, `error_message_reads_string_code`,
+/// `error_message_falls_back_without_code`.
+fn error_message_from_frame(err: &serde_json::Value) -> String {
+    if let Some(s) = err.as_str().filter(|s| !s.is_empty()) {
+        return s.to_string();
+    }
+    let message = err
+        .get("message")
+        .and_then(|m| m.as_str())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("provider streaming error");
+    let code = err.get("code");
+    let code_str = code
+        .and_then(|c| c.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+        .or_else(|| code.and_then(|c| c.as_u64()).map(|n| n.to_string()));
+    match code_str {
+        Some(c) => format!("{c}: {message}"),
+        None => message.to_string(),
+    }
+}
+
+/// Whether a response body is an SSE stream according to its `Content-Type`.
+///
+/// Why (issue #3757): a conformant provider answers a `stream:true` request
+/// with `text/event-stream`. Some gateways/load balancers strip streaming and
+/// return a buffered JSON body at 200 — feeding THAT to the frame loop yields
+/// zero deltas and a clean `Done`, silently dropping the entire answer.
+/// What: case-insensitive substring match; a missing header is treated as
+/// non-SSE, which is safe because [`pump_non_sse_body`] still decodes a body
+/// that turns out to contain `data:` frames.
+/// Test: `content_type_guard_matches_sse`.
+fn is_event_stream(headers: &reqwest::header::HeaderMap) -> bool {
+    headers
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|v| v.to_ascii_lowercase().contains("text/event-stream"))
+        .unwrap_or(false)
+}
+
+/// Flush accumulated tool calls followed by the terminal [`ChatEvent::Done`].
+async fn flush_terminal(acc: ToolCallAccumulator, tx: &Sender<ChatEvent>) -> Flow {
+    for call in acc.finalize() {
+        if tx.send(ChatEvent::ToolCall(call)).await.is_err() {
+            return Flow::Stop;
+        }
+    }
+    let _ = tx.send(ChatEvent::Done).await;
+    Flow::Stop
+}
+
+/// Decode one `data:` line into events on `tx`.
+///
+/// Why: the single frame decoder, shared by the live stream and the
+/// buffered-body fallback so both paths treat `[DONE]`, error frames, content
+/// deltas, and tool-call fragments identically.
+/// What: non-`data:` lines, blank payloads, and unparseable NON-error frames
+/// are skipped (best effort, matching the pre-#3757 behaviour). `[DONE]` flushes
+/// the terminal events. An `error` field emits [`ChatEvent::Error`] and stops —
+/// checked on the raw `Value` BEFORE anything else so a malformed-but-error
+/// payload is never skipped as "just a bad frame".
+/// Test: `sse_pump_tests.rs`.
+async fn handle_line(line: &str, acc: &mut ToolCallAccumulator, tx: &Sender<ChatEvent>) -> Flow {
+    let line = line.trim();
+    let Some(payload) = line.strip_prefix("data:").map(str::trim) else {
+        return Flow::Continue;
+    };
+    if payload.is_empty() {
+        return Flow::Continue;
+    }
+    if payload == "[DONE]" {
+        return flush_terminal(std::mem::take(acc), tx).await;
+    }
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(payload) else {
+        return Flow::Continue;
+    };
+    // #3757: an in-band error frame is a FAILURE, not a delta — surface it
+    // instead of letting the stream end as an apparently complete answer.
+    if let Some(err) = v.get("error") {
+        let _ = tx
+            .send(ChatEvent::Error(error_message_from_frame(err)))
+            .await;
+        return Flow::Stop;
+    }
+    let Some(delta) = v
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("delta"))
+    else {
+        return Flow::Continue;
+    };
+    let content = delta
+        .get("content")
+        .and_then(|c| c.as_str())
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string());
+    if let Some(content) = content
+        && tx.send(ChatEvent::Delta(content)).await.is_err()
+    {
+        return Flow::Stop;
+    }
+    if let Some(tc) = delta.get("tool_calls") {
+        acc.apply_delta(tc);
+    }
+    Flow::Continue
+}
+
 /// Drive one OpenAI-compatible SSE stream into the caller's [`ChatEvent`]
 /// channel.
 ///
 /// Why: OpenRouter and Ollama both speak the same wire format; sharing the
 /// loop keeps the two providers in lock-step.
-/// What: reads `resp.bytes_stream()`, splits on newlines, parses `data:`
-/// frames, forwards `delta.content` as [`ChatEvent::Delta`], accumulates
-/// `delta.tool_calls`, and on `[DONE]` (or upstream EOF) emits one
-/// [`ChatEvent::ToolCall`] per accumulated call followed by
-/// [`ChatEvent::Done`].
-/// Test: covered by `ollama_provider_streams_sse_deltas` and
-/// `accumulates_streamed_tool_call_fragments`.
+/// What: on an SSE body, reads `resp.bytes_stream()`, splits on newlines, and
+/// feeds each line to [`handle_line`] — forwarding `delta.content` as
+/// [`ChatEvent::Delta`], accumulating `delta.tool_calls`, and on `[DONE]`
+/// emitting one [`ChatEvent::ToolCall`] per accumulated call followed by
+/// [`ChatEvent::Done`]. A non-SSE body is handed to [`pump_non_sse_body`].
+///
+/// Failure paths (issue #3757), each emitting [`ChatEvent::Error`] AND
+/// returning `Err` so both channel-only consumers and those that join the pump
+/// task observe the failure:
+///   - a mid-stream `{"error": {...}}` frame ([`handle_line`]);
+///   - a transport error part-way through the stream;
+///   - EOF with bytes still buffered mid-frame — a TRUNCATED stream, which must
+///     not be reported as a complete short answer. EOF on a clean frame
+///     boundary WITHOUT `[DONE]` remains a normal finish: not every provider
+///     emits the sentinel.
+///
+/// Test: `ollama_provider_streams_sse_deltas`,
+/// `accumulates_streamed_tool_call_fragments`, and `sse_pump_tests.rs`.
 pub(super) async fn pump_openai_sse(resp: reqwest::Response, tx: Sender<ChatEvent>) -> Result<()> {
     use futures_util::StreamExt;
 
+    // #3757: a 200 that is not an SSE body would decode to zero deltas and a
+    // clean Done, silently dropping the answer.
+    if !is_event_stream(resp.headers()) {
+        return pump_non_sse_body(resp, tx).await;
+    }
+
     let mut acc = ToolCallAccumulator::default();
-    let mut buf = String::new();
+    // Bytes, not a String: a chunk boundary can split a multi-byte UTF-8
+    // character, and the previous `from_utf8(..).is_err() => continue` dropped
+    // that whole chunk — another silent-truncation path (#3757).
+    let mut buf: Vec<u8> = Vec::new();
     let mut stream = resp.bytes_stream();
 
     while let Some(chunk) = stream.next().await {
-        let bytes = chunk.context("read chat stream chunk")?;
-        let text = match std::str::from_utf8(&bytes) {
-            Ok(s) => s,
-            Err(_) => continue,
+        let bytes = match chunk {
+            Ok(b) => b,
+            Err(e) => {
+                // #3757: consumers that only watch the channel never see the
+                // returned Err, so report the failure both ways.
+                let _ = tx
+                    .send(ChatEvent::Error(format!(
+                        "chat stream transport error: {e}"
+                    )))
+                    .await;
+                return Err(e).context("read chat stream chunk");
+            }
         };
-        buf.push_str(text);
+        buf.extend_from_slice(&bytes);
 
-        while let Some(idx) = buf.find('\n') {
-            let line: String = buf.drain(..=idx).collect();
-            let line = line.trim();
-            let Some(payload) = line.strip_prefix("data:").map(str::trim) else {
-                continue;
-            };
-            if payload.is_empty() {
-                continue;
-            }
-            if payload == "[DONE]" {
-                for call in std::mem::take(&mut acc).finalize() {
-                    if tx.send(ChatEvent::ToolCall(call)).await.is_err() {
-                        return Ok(());
-                    }
-                }
-                let _ = tx.send(ChatEvent::Done).await;
+        while let Some(idx) = buf.iter().position(|b| *b == b'\n') {
+            let line: Vec<u8> = buf.drain(..=idx).collect();
+            if handle_line(&String::from_utf8_lossy(&line), &mut acc, &tx).await == Flow::Stop {
                 return Ok(());
-            }
-            let v: serde_json::Value = match serde_json::from_str(payload) {
-                Ok(v) => v,
-                Err(_) => continue,
-            };
-            let delta = v
-                .get("choices")
-                .and_then(|c| c.get(0))
-                .and_then(|c| c.get("delta"));
-            if let Some(delta) = delta {
-                // Forward any non-empty text content as a Delta event.
-                let content_opt = delta
-                    .get("content")
-                    .and_then(|c| c.as_str())
-                    .filter(|s| !s.is_empty())
-                    .map(|s| s.to_string());
-                let send_err = match content_opt {
-                    Some(content) => tx.send(ChatEvent::Delta(content)).await.is_err(),
-                    None => false,
-                };
-                if send_err {
-                    return Ok(());
-                }
-                if let Some(tc) = delta.get("tool_calls") {
-                    acc.apply_delta(tc);
-                }
             }
         }
     }
 
-    // Upstream EOF without a [DONE] sentinel — still flush and finish.
-    for call in acc.finalize() {
+    // #3757: EOF. A clean socket close on a frame boundary is a normal finish,
+    // but bytes left mid-frame mean the stream was CUT OFF — reporting that as
+    // Done would render a truncated answer as a complete one.
+    if buf.iter().any(|b| !b.is_ascii_whitespace()) {
+        let message = "chat stream ended with an incomplete SSE frame (truncated response)";
+        let _ = tx.send(ChatEvent::Error(message.to_string())).await;
+        return Err(anyhow!("{message}"));
+    }
+    flush_terminal(acc, &tx).await;
+    Ok(())
+}
+
+/// Handle a 2xx response whose body is not an SSE stream.
+///
+/// Why (issue #3757): a gateway/LB that strips streaming answers `stream:true`
+/// with a buffered body. Running the frame loop over it produces zero deltas
+/// and a clean `Done`, so the whole answer disappears with no error anywhere.
+/// What: degrades instead of dropping —
+///   1. a body that still carries `data:` frames (right wire, wrong
+///      `Content-Type`) is decoded as SSE, so a mislabelled-but-valid stream
+///      keeps working;
+///   2. a buffered chat completion is replayed as the first choice's
+///      `message.content` plus its `message.tool_calls`, then `Done`;
+///   3. an `error` object, an unparseable body, or a completion carrying
+///      neither content nor tool calls emits [`ChatEvent::Error`] and returns
+///      `Err` — those are the cases with nothing to render.
+///
+/// Test: `non_sse_json_body_is_replayed`, `non_sse_body_without_content_errors`,
+/// `mislabelled_sse_body_is_decoded`.
+async fn pump_non_sse_body(resp: reqwest::Response, tx: Sender<ChatEvent>) -> Result<()> {
+    let text = resp
+        .text()
+        .await
+        .context("read non-SSE chat completion body")?;
+
+    if text.lines().any(|l| l.trim_start().starts_with("data:")) {
+        let mut acc = ToolCallAccumulator::default();
+        for line in text.split_inclusive('\n') {
+            if handle_line(line, &mut acc, &tx).await == Flow::Stop {
+                return Ok(());
+            }
+        }
+        flush_terminal(acc, &tx).await;
+        return Ok(());
+    }
+
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(&text) else {
+        return fail(
+            &tx,
+            format!(
+                "chat stream: provider returned a non-SSE, non-JSON body ({} bytes): {}",
+                text.len(),
+                excerpt(&text)
+            ),
+        )
+        .await;
+    };
+    if let Some(err) = v.get("error") {
+        return fail(&tx, error_message_from_frame(err)).await;
+    }
+
+    let message = v
+        .get("choices")
+        .and_then(|c| c.get(0))
+        .and_then(|c| c.get("message"));
+    let content = message
+        .and_then(|m| m.get("content"))
+        .and_then(|c| c.as_str())
+        .filter(|s| !s.is_empty());
+    let mut acc = ToolCallAccumulator::default();
+    if let Some(tc) = message.and_then(|m| m.get("tool_calls")) {
+        acc.apply_delta(tc);
+    }
+    let calls = acc.finalize();
+    if content.is_none() && calls.is_empty() {
+        return fail(
+            &tx,
+            format!(
+                "chat stream: provider returned a non-SSE body with no content and no tool \
+                 calls ({} bytes): {}",
+                text.len(),
+                excerpt(&text)
+            ),
+        )
+        .await;
+    }
+
+    if let Some(content) = content
+        && tx
+            .send(ChatEvent::Delta(content.to_string()))
+            .await
+            .is_err()
+    {
+        return Ok(());
+    }
+    for call in calls {
         if tx.send(ChatEvent::ToolCall(call)).await.is_err() {
             return Ok(());
         }
     }
     let _ = tx.send(ChatEvent::Done).await;
     Ok(())
+}
+
+/// Report an unrecoverable stream failure on BOTH channels.
+///
+/// Why (issue #3757): consumers are split — `trusty-agents`' streaming driver
+/// and `trusty-search`'s UI join the pump task and inspect its `Result`, while
+/// `trusty-memory` and `trusty-analyze` only watch the event channel. Sending
+/// [`ChatEvent::Error`] *and* returning `Err` means neither group can mistake a
+/// failed stream for a complete answer.
+/// What: sends the message as an `Error` event (ignoring a hung-up receiver),
+/// then returns it as an `Err`.
+/// Test: `non_sse_body_without_content_errors`.
+async fn fail(tx: &Sender<ChatEvent>, message: String) -> Result<()> {
+    let _ = tx.send(ChatEvent::Error(message.clone())).await;
+    Err(anyhow!("{message}"))
+}
+
+/// First 200 characters of a body, for error messages.
+///
+/// Why: an unusable body must be identifiable in a log without pasting a
+/// multi-megabyte HTML error page into the error message.
+/// What: truncates on a character boundary and appends an ellipsis marker.
+/// Test: `non_sse_body_without_content_errors`.
+fn excerpt(text: &str) -> String {
+    const LIMIT: usize = 200;
+    if text.chars().count() <= LIMIT {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(LIMIT).collect();
+    format!("{head}…")
 }

--- a/crates/trusty-common/src/chat/openai_compat/sse_pump_tests.rs
+++ b/crates/trusty-common/src/chat/openai_compat/sse_pump_tests.rs
@@ -80,7 +80,12 @@ async fn error_frame_emits_error_event() {
     )
     .await;
 
-    assert_eq!(flow, Flow::Stop);
+    assert_eq!(
+        flow,
+        Flow::Failed("429: rate limited".to_string()),
+        "an error frame must report FAILED, not a plain stop — the caller has \
+         to know to return Err"
+    );
     drop(tx);
     let mut events = Vec::new();
     while let Some(ev) = rx.recv().await {
@@ -263,6 +268,127 @@ async fn mislabelled_sse_body_is_decoded() {
     );
     assert!(matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "still works"));
     assert!(matches!(events.last(), Some(ChatEvent::Done)));
+}
+
+/// The contract this module documents is that a failure surfaces on BOTH
+/// channels. An earlier revision emitted the `Error` event but still returned
+/// `Ok(())`, so a consumer that only joins the pump task saw success.
+#[tokio::test]
+async fn error_frame_returns_err() {
+    let body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"partial\"}}]}\n\n",
+        "data: {\"error\":{\"message\":\"rate limited\",\"code\":429}}\n\n",
+    );
+    let (events, result) = pump_response("Content-Type: text/event-stream", body).await;
+
+    let err = result.expect_err("a mid-stream error frame must return Err");
+    assert!(
+        err.to_string().contains("429: rate limited"),
+        "the Err must carry the provider's message: {err}"
+    );
+    assert!(
+        matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "partial"),
+        "content before the error is still delivered: {events:?}"
+    );
+    match events.last() {
+        Some(ChatEvent::Error(msg)) => assert_eq!(msg, "429: rate limited"),
+        other => panic!("expected a terminal Error event, got {other:?}"),
+    }
+    assert!(
+        !events.iter().any(|e| matches!(e, ChatEvent::Done)),
+        "an errored stream must not also emit Done: {events:?}"
+    );
+}
+
+/// A final frame missing only its trailing newline is COMPLETE, not truncated.
+/// Failing it would flip a working stream to an error and cost the caller a
+/// second full blocking LLM call.
+#[tokio::test]
+async fn unterminated_done_sentinel_completes_cleanly() {
+    let body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"complete\"}}]}\n\n",
+        "data: [DONE]",
+    );
+    let (events, result) = pump_response("Content-Type: text/event-stream", body).await;
+
+    assert!(
+        result.is_ok(),
+        "an unterminated [DONE] is a clean finish: {result:?}"
+    );
+    assert!(matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "complete"));
+    assert!(matches!(events.last(), Some(ChatEvent::Done)));
+}
+
+/// Same for a complete JSON frame whose trailing newline never arrived.
+#[tokio::test]
+async fn unterminated_complete_frame_is_not_a_truncation() {
+    let body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"first \"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"second\"}}]}",
+    );
+    let (events, result) = pump_response("Content-Type: text/event-stream", body).await;
+
+    assert!(
+        result.is_ok(),
+        "a whole final frame is not a truncation: {result:?}"
+    );
+    let deltas: Vec<&str> = events
+        .iter()
+        .filter_map(|e| match e {
+            ChatEvent::Delta(d) => Some(d.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(deltas, vec!["first ", "second"], "both frames must arrive");
+    assert!(matches!(events.last(), Some(ChatEvent::Done)));
+}
+
+/// `is_complete_frame` is the truncation discriminator; pin its edges.
+#[test]
+fn complete_frame_detection_edges() {
+    assert!(is_complete_frame("data: [DONE]"));
+    assert!(is_complete_frame("data: {\"choices\":[]}"));
+    assert!(
+        is_complete_frame(": keep-alive"),
+        "a comment has no payload"
+    );
+    assert!(is_complete_frame(""));
+    assert!(
+        !is_complete_frame("data: {\"choices\":[{\"delta\":{\"content\":\"cut"),
+        "a severed JSON payload is a truncation"
+    );
+    assert!(
+        !is_complete_frame("dat"),
+        "a severed field name is a truncation"
+    );
+}
+
+/// A provider that always includes an `error` key sends `"error": null` on
+/// healthy frames — that must not be read as a failure.
+#[tokio::test]
+async fn null_error_key_is_not_a_failure() {
+    let body = concat!(
+        "data: {\"error\":null,\"choices\":[{\"delta\":{\"content\":\"healthy\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    let (events, result) = pump_response("Content-Type: text/event-stream", body).await;
+
+    assert!(
+        result.is_ok(),
+        "a null error key must not fail the stream: {result:?}"
+    );
+    assert!(matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "healthy"));
+    assert!(matches!(events.last(), Some(ChatEvent::Done)));
+}
+
+/// The same null guard on the buffered (non-SSE) body path.
+#[tokio::test]
+async fn null_error_key_in_buffered_body_is_not_a_failure() {
+    let body = r#"{"error":null,"choices":[{"message":{"content":"buffered"}}]}"#;
+    let (events, result) = pump_response("Content-Type: application/json", body).await;
+
+    assert!(result.is_ok(), "null error in a buffered body: {result:?}");
+    assert!(matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "buffered"));
 }
 
 // ── #3758: request-body parity ────────────────────────────────────────────────

--- a/crates/trusty-common/src/chat/openai_compat/sse_pump_tests.rs
+++ b/crates/trusty-common/src/chat/openai_compat/sse_pump_tests.rs
@@ -1,0 +1,328 @@
+//! Failure-path tests for the shared OpenAI-compatible SSE pump (issue #3757).
+//!
+//! Why: before #3757 every one of these cases arrived at the consumer as a
+//! clean `ChatEvent::Done`, so a partial or empty answer rendered as a complete
+//! one. Each test below pins one of those cases to an explicit
+//! `ChatEvent::Error`.
+//! What: the pure decoders (`error_message_from_frame`, `is_event_stream`,
+//! `handle_line`) are exercised directly; the transport-level guards
+//! (truncated EOF, non-SSE body) go through a raw-TCP mock server, matching the
+//! pattern the module's existing round-trip tests use.
+//! Test: this file.
+
+use super::super::providers::OllamaProvider;
+use super::super::wire::ChatRequestWire;
+use super::*;
+use crate::chat::{ChatEvent, ChatProvider, SamplingParams};
+use tokio::sync::mpsc;
+
+// ── Pure decoders ─────────────────────────────────────────────────────────────
+
+#[test]
+fn error_message_reads_numeric_code() {
+    let v = serde_json::json!({"message": "rate limited", "code": 429});
+    assert_eq!(error_message_from_frame(&v), "429: rate limited");
+}
+
+#[test]
+fn error_message_reads_string_code() {
+    let v = serde_json::json!({"message": "no credits", "code": "insufficient_quota"});
+    assert_eq!(
+        error_message_from_frame(&v),
+        "insufficient_quota: no credits"
+    );
+}
+
+#[test]
+fn error_message_falls_back_without_code() {
+    assert_eq!(
+        error_message_from_frame(&serde_json::json!({"message": "boom"})),
+        "boom"
+    );
+    assert_eq!(
+        error_message_from_frame(&serde_json::json!({})),
+        "provider streaming error"
+    );
+    assert_eq!(
+        error_message_from_frame(&serde_json::json!("upstream exploded")),
+        "upstream exploded"
+    );
+}
+
+#[test]
+fn content_type_guard_matches_sse() {
+    use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
+
+    let mut sse = HeaderMap::new();
+    sse.insert(
+        CONTENT_TYPE,
+        HeaderValue::from_static("text/event-stream; charset=utf-8"),
+    );
+    assert!(is_event_stream(&sse));
+
+    let mut json = HeaderMap::new();
+    json.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+    assert!(!is_event_stream(&json));
+
+    assert!(!is_event_stream(&HeaderMap::new()));
+}
+
+/// An in-band error frame must terminate the stream with `Error`, not `Done`.
+#[tokio::test]
+async fn error_frame_emits_error_event() {
+    let (tx, mut rx) = mpsc::channel::<ChatEvent>(8);
+    let mut acc = ToolCallAccumulator::default();
+
+    let flow = handle_line(
+        "data: {\"error\":{\"message\":\"rate limited\",\"code\":429}}\n",
+        &mut acc,
+        &tx,
+    )
+    .await;
+
+    assert_eq!(flow, Flow::Stop);
+    drop(tx);
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+    assert_eq!(events.len(), 1, "expected exactly one event: {events:?}");
+    match &events[0] {
+        ChatEvent::Error(msg) => assert_eq!(msg, "429: rate limited"),
+        other => panic!("expected Error, got {other:?}"),
+    }
+}
+
+/// A malformed frame that is NOT an error stays best-effort-skipped, so one bad
+/// keep-alive cannot kill an otherwise healthy stream.
+#[tokio::test]
+async fn malformed_non_error_frame_is_skipped() {
+    let (tx, mut rx) = mpsc::channel::<ChatEvent>(8);
+    let mut acc = ToolCallAccumulator::default();
+
+    assert_eq!(
+        handle_line("data: {not json\n", &mut acc, &tx).await,
+        Flow::Continue
+    );
+    assert_eq!(
+        handle_line(": keep-alive\n", &mut acc, &tx).await,
+        Flow::Continue
+    );
+    assert_eq!(handle_line("\n", &mut acc, &tx).await, Flow::Continue);
+
+    drop(tx);
+    assert!(rx.recv().await.is_none(), "no events expected");
+}
+
+// ── Transport-level guards ────────────────────────────────────────────────────
+
+/// Serve one HTTP response over a throwaway TCP listener and stream it through
+/// an `OllamaProvider`, returning every event the pump produced plus the pump's
+/// own `Result`.
+async fn pump_response(headers: &str, body: &str) -> (Vec<ChatEvent>, anyhow::Result<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let base = format!("http://{addr}");
+    let response = format!("HTTP/1.1 200 OK\r\n{headers}\r\nConnection: close\r\n\r\n{body}");
+
+    tokio::spawn(async move {
+        if let Ok((mut sock, _)) = listener.accept().await {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            let mut buf = [0u8; 4096];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock.write_all(response.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+
+    let provider = OllamaProvider::new(base, "test-model");
+    let (tx, mut rx) = mpsc::channel::<ChatEvent>(16);
+    let handle = tokio::spawn(async move {
+        provider
+            .chat_stream(
+                vec![crate::ChatMessage {
+                    role: "user".into(),
+                    content: "hi".into(),
+                    tool_call_id: None,
+                    tool_calls: None,
+                }],
+                vec![],
+                tx,
+            )
+            .await
+    });
+
+    let mut events = Vec::new();
+    while let Some(ev) = rx.recv().await {
+        events.push(ev);
+    }
+    (events, handle.await.expect("pump task panicked"))
+}
+
+/// The headline #3757 case: content arrives, then the socket dies mid-frame.
+/// The partial text must NOT be capped with a `Done` that makes it look whole.
+#[tokio::test]
+async fn truncated_stream_errors_instead_of_done() {
+    let body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"partial answ\"}}]}\n\n",
+        "data: {\"choices\":[{\"delta\":{\"content\":\"er that never fin",
+    );
+    let (events, result) = pump_response("Content-Type: text/event-stream", body).await;
+
+    assert!(
+        result.is_err(),
+        "a truncated stream must return Err, got {result:?}"
+    );
+    assert!(
+        matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "partial answ"),
+        "the complete frame must still be delivered: {events:?}"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(e, ChatEvent::Done)),
+        "a truncated stream must not emit Done: {events:?}"
+    );
+    match events.last() {
+        Some(ChatEvent::Error(msg)) => assert!(
+            msg.contains("incomplete SSE frame"),
+            "unexpected error text: {msg}"
+        ),
+        other => panic!("expected a terminal Error, got {other:?}"),
+    }
+}
+
+/// EOF on a frame boundary without `[DONE]` is a NORMAL finish — not every
+/// provider sends the sentinel, so this must stay a clean `Done`.
+#[tokio::test]
+async fn clean_eof_without_done_sentinel_still_completes() {
+    let body = "data: {\"choices\":[{\"delta\":{\"content\":\"all of it\"}}]}\n\n";
+    let (events, result) = pump_response("Content-Type: text/event-stream", body).await;
+
+    assert!(result.is_ok(), "clean EOF must not error: {result:?}");
+    assert!(matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "all of it"));
+    assert!(matches!(events.last(), Some(ChatEvent::Done)));
+}
+
+/// A gateway that strips streaming returns a buffered completion at 200. The
+/// answer must be replayed, not silently dropped as zero deltas + `Done`.
+#[tokio::test]
+async fn non_sse_json_body_is_replayed() {
+    let body = r#"{"choices":[{"message":{"content":"buffered answer"}}]}"#;
+    let (events, result) = pump_response("Content-Type: application/json", body).await;
+
+    assert!(result.is_ok(), "degrade path must succeed: {result:?}");
+    assert!(
+        matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "buffered answer"),
+        "expected the buffered content replayed: {events:?}"
+    );
+    assert!(matches!(events.last(), Some(ChatEvent::Done)));
+}
+
+/// A non-SSE body with nothing renderable is the silent-empty-answer case.
+#[tokio::test]
+async fn non_sse_body_without_content_errors() {
+    let (events, result) =
+        pump_response("Content-Type: text/html", "<html>bad gateway</html>").await;
+
+    assert!(result.is_err(), "unusable body must return Err: {result:?}");
+    match events.last() {
+        Some(ChatEvent::Error(msg)) => assert!(
+            msg.contains("non-SSE"),
+            "error should name the non-SSE body: {msg}"
+        ),
+        other => panic!("expected a terminal Error, got {other:?}"),
+    }
+    assert!(!events.iter().any(|e| matches!(e, ChatEvent::Done)));
+}
+
+/// An in-band error object in a buffered body must surface too.
+#[tokio::test]
+async fn non_sse_error_object_surfaces() {
+    let body = r#"{"error":{"message":"no credits","code":"insufficient_quota"}}"#;
+    let (events, result) = pump_response("Content-Type: application/json", body).await;
+
+    assert!(result.is_err(), "error body must return Err: {result:?}");
+    match events.last() {
+        Some(ChatEvent::Error(msg)) => assert_eq!(msg, "insufficient_quota: no credits"),
+        other => panic!("expected a terminal Error, got {other:?}"),
+    }
+}
+
+/// Right frames, wrong `Content-Type`: the guard must not destroy a valid
+/// stream from a server that mislabels its SSE body.
+#[tokio::test]
+async fn mislabelled_sse_body_is_decoded() {
+    let body = concat!(
+        "data: {\"choices\":[{\"delta\":{\"content\":\"still works\"}}]}\n\n",
+        "data: [DONE]\n\n",
+    );
+    let (events, result) = pump_response("Content-Type: application/json", body).await;
+
+    assert!(
+        result.is_ok(),
+        "mislabelled SSE must still decode: {result:?}"
+    );
+    assert!(matches!(events.first(), Some(ChatEvent::Delta(d)) if d == "still works"));
+    assert!(matches!(events.last(), Some(ChatEvent::Done)));
+}
+
+// ── #3758: request-body parity ────────────────────────────────────────────────
+
+/// The streaming request must carry the same sampling knobs the blocking path
+/// sends, and must omit them entirely when the caller supplies none.
+#[test]
+fn sampling_params_serialize_into_request_body() {
+    let messages: Vec<crate::ChatMessage> = Vec::new();
+    let sampling = SamplingParams {
+        temperature: Some(0.2),
+        max_tokens: Some(4096),
+        stop: vec!["```\n\n".to_string()],
+    };
+    let body = ChatRequestWire {
+        model: "m",
+        messages: &messages,
+        stream: true,
+        tools: None,
+        temperature: sampling.temperature,
+        max_tokens: sampling.max_tokens,
+        stop: sampling.stop_slice(),
+    };
+    let v = serde_json::to_value(&body).unwrap();
+    // `temperature` is f32 — the same width the blocking (async-openai) builder
+    // uses — so it widens to the identical JSON literal on both paths. Compare
+    // with a tolerance rather than pinning the f32→f64 expansion.
+    let temperature = v["temperature"].as_f64().expect("temperature must be sent");
+    assert!(
+        (temperature - 0.2).abs() < 1e-6,
+        "temperature must round-trip: {temperature}"
+    );
+    assert_eq!(v["max_tokens"], 4096);
+    assert_eq!(v["stop"][0], "```\n\n");
+    assert_eq!(v["stream"], true);
+}
+
+#[test]
+fn default_sampling_omits_fields() {
+    let sampling = SamplingParams::default();
+    assert!(
+        sampling.stop_slice().is_none(),
+        "empty stop must be omitted"
+    );
+
+    let messages: Vec<crate::ChatMessage> = Vec::new();
+    let body = ChatRequestWire {
+        model: "m",
+        messages: &messages,
+        stream: true,
+        tools: None,
+        temperature: sampling.temperature,
+        max_tokens: sampling.max_tokens,
+        stop: sampling.stop_slice(),
+    };
+    let v = serde_json::to_value(&body).unwrap();
+    let obj = v.as_object().unwrap();
+    // Byte-identical to the pre-#3758 body: no sampling keys at all.
+    assert!(!obj.contains_key("temperature"), "got {v}");
+    assert!(!obj.contains_key("max_tokens"), "got {v}");
+    assert!(!obj.contains_key("stop"), "got {v}");
+    assert!(!obj.contains_key("tools"), "got {v}");
+}

--- a/crates/trusty-common/src/chat/openai_compat/wire.rs
+++ b/crates/trusty-common/src/chat/openai_compat/wire.rs
@@ -31,6 +31,17 @@ pub(super) struct OpenAiFunctionWire<'a> {
 }
 
 /// OpenAI-compatible streaming chat request body.
+///
+/// Why: #3758 — the sampling fields below were missing, so a streamed turn
+/// silently ran on provider defaults while the blocking path for the SAME turn
+/// sent the caller's configured temperature, token ceiling, and stop
+/// sequences. Every one of them is `skip_serializing_if`-gated, so a caller
+/// that supplies nothing produces byte-identical JSON to the pre-#3758 body.
+/// What: `stream` is always sent; `tools`, `temperature`, `max_tokens`, and
+/// `stop` are omitted when absent (an empty array is NOT sent — some servers
+/// reject `"stop": []`, mirroring the empty-`tools` trap).
+/// Test: `sampling_params_serialize_into_request_body`,
+/// `default_sampling_omits_fields`.
 #[derive(Debug, Serialize)]
 pub(super) struct ChatRequestWire<'a> {
     pub(super) model: &'a str,
@@ -38,6 +49,16 @@ pub(super) struct ChatRequestWire<'a> {
     pub(super) stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(super) tools: Option<Vec<OpenAiToolWire<'a>>>,
+    // #3758: sampling parity with the blocking path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) temperature: Option<f32>,
+    // #3758: sampling parity with the blocking path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) max_tokens: Option<u32>,
+    // #3758: OpenAI spells this `stop`; the direct-Anthropic dialect calls the
+    // same parameter `stop_sequences`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) stop: Option<&'a [String]>,
 }
 
 /// Map a `ToolDef` slice to the OpenAI `tools` array, or `None` when empty.

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -655,7 +655,8 @@ pub mod tmux;
 
 pub use chat::{
     BedrockProvider, ChatEvent, ChatProvider, DEFAULT_BEDROCK_MODEL, LocalModelConfig,
-    OllamaProvider, OpenRouterProvider, ToolCall, ToolDef, auto_detect_local_provider,
+    OllamaProvider, OpenRouterProvider, SamplingParams, ToolCall, ToolDef,
+    auto_detect_local_provider,
 };
 
 // Port

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -48,6 +48,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Activity monitor no longer misreports a provider stream failure as a
+  serialization error** (issue #3757): `LlmActivityClassifier::classify`
+  matched only `ChatEvent::Delta` and discarded `ChatEvent::Error`, so once the
+  shared SSE pump began reporting mid-stream error frames, truncated EOFs, and
+  unusable non-SSE bodies, the truncated text still reached `serde_json` and
+  surfaced as `ActivityError::Serialization` — blaming our own parser for
+  someone else's outage. The error arm now maps to `ActivityError::Llm`.
+
 - **`prune-worktrees` never scanned `.claude/worktrees`, so Claude Code's
   native agent worktrees were never reclaimed** (closes
   [#3971](https://github.com/bobmatnyc/trusty-tools/issues/3971)):

--- a/crates/trusty-mpm/src/activity/monitor.rs
+++ b/crates/trusty-mpm/src/activity/monitor.rs
@@ -484,16 +484,27 @@ impl LlmClassifier for OpenRouterClassifier {
 
         let send_fut = provider.chat_stream(messages, vec![], tx);
         let mut full_text = String::new();
+        // #3757: the pump now reports a mid-stream error frame, a truncated
+        // EOF, and an unusable non-SSE body as `ChatEvent::Error`. Dropping it
+        // here would feed truncated text to the JSON parse below and misreport
+        // a provider failure as `Serialization` — a misleading diagnosis of
+        // someone else's outage.
+        let mut stream_error: Option<String> = None;
 
         let (send_result, ()) = tokio::join!(send_fut, async {
             while let Some(event) = rx.recv().await {
-                if let ChatEvent::Delta(d) = event {
-                    full_text.push_str(&d);
+                match event {
+                    ChatEvent::Delta(d) => full_text.push_str(&d),
+                    ChatEvent::Error(e) => stream_error = Some(e),
+                    ChatEvent::ToolCall(_) | ChatEvent::Done => {}
                 }
             }
         });
 
         send_result.map_err(|e| ActivityError::Llm(e.to_string()))?;
+        if let Some(e) = stream_error {
+            return Err(ActivityError::Llm(e));
+        }
 
         // Parse the JSON verdict from the accumulated text.
         let json_str = extract_json(&full_text).unwrap_or(&full_text);


### PR DESCRIPTION
Closes #3757. Closes #3758.

Both were deferred from PR #3753's re-review; both live in the OpenAI-compatible chat path, so they ship together.

## #3757 — a failed stream ended as `Done`

`chat::openai_compat`'s shared SSE pump never emitted `ChatEvent::Error`. A mid-stream `{"error": {...}}` frame, a stream cut off mid-frame, and a 200 answered with a non-SSE body **all** arrived as a clean `ChatEvent::Done` — a partial answer rendered as a complete one, and `trusty-agents`' blocking fallback never engaged (its empty-stream guard only caught streams that produced *nothing*).

Ported the three guards `inference::streaming` shipped in #3751:

| guard | behavior |
|---|---|
| in-band error probe | reads a numeric (`429`) or string (`"insufficient_quota"`) `code`, checked on the raw `Value` **before** anything else so a malformed-but-error payload is never skipped as "just a bad frame" |
| incomplete frame at EOF | bytes still buffered mid-frame = TRUNCATION → `Error`. A clean frame boundary without `[DONE]` stays a normal finish — not every provider sends the sentinel |
| `Content-Type` guard | **degrades, never drops**: a buffered completion is replayed as `message.content` + `message.tool_calls`; a body still carrying `data:` frames under the wrong `Content-Type` is decoded as SSE anyway; only a body with nothing renderable errors |

Failures are reported **both** as `ChatEvent::Error` and as an `Err` return, because the shared consumers are split — `trusty-memory` / `trusty-analyze` watch only the channel, while `trusty-agents` / `trusty-search` join the pump task. All four already have `ChatEvent::Error` arms that record and surface the failure, so this is the signal they were waiting for rather than a destabilization.

Also fixes a silent-truncation path in the same loop: the pump decoded each raw chunk with `str::from_utf8` and skipped the **whole chunk** on failure, losing text whenever a multi-byte character straddled a socket read. It now buffers bytes and decodes per complete line.

## #3758 — streamed turns ignored the caller's sampling knobs

`ChatRequestWire` sent only `model`/`messages`/`tools`, so a streamed reply ran on provider defaults while the blocking path for the **same turn** sent `llm.temperature`, `llm.max_tokens`, and `llm.stop_sequences`. `LlmConfig::stop_sequences` documents itself as "forwarded as the request's `stop`/`stop_sequences` parameter on the OpenRouter path" — streaming was quietly not honouring that.

New `chat::SamplingParams`, attached via `OpenRouterProvider::with_sampling` / `OllamaProvider::with_sampling`. Every field is `skip_serializing_if`-gated (an empty `stop` array is never sent — some servers reject `"stop": []`, the same trap an empty `tools` array has), so **a caller that does not opt in produces a byte-identical request body to before**; `new()` is unchanged, so the tcode/memory/analyze/review call sites need no edits. Both `trusty-agents` call sites forward their turn's exact values, including the conversational path's `effective_max_tokens` that the local-route branch may override.

## Tests

12 new — the pure decoders directly, the transport guards through the raw-TCP mock server the module's existing round-trip tests already use. Two of them pin the *non*-regressions: a clean EOF without `[DONE]` still completes, and a mislabelled SSE body still decodes.

```
test chat::openai_compat::sse_pump::tests::truncated_stream_errors_instead_of_done ... ok
test chat::openai_compat::sse_pump::tests::clean_eof_without_done_sentinel_still_completes ... ok
test chat::openai_compat::sse_pump::tests::error_frame_emits_error_event ... ok
test chat::openai_compat::sse_pump::tests::non_sse_json_body_is_replayed ... ok
test chat::openai_compat::sse_pump::tests::non_sse_body_without_content_errors ... ok
test chat::openai_compat::sse_pump::tests::non_sse_error_object_surfaces ... ok
test chat::openai_compat::sse_pump::tests::mislabelled_sse_body_is_decoded ... ok
test chat::openai_compat::sse_pump::tests::malformed_non_error_frame_is_skipped ... ok
test chat::openai_compat::sse_pump::tests::sampling_params_serialize_into_request_body ... ok
test chat::openai_compat::sse_pump::tests::default_sampling_omits_fields ... ok
test chat::openai_compat::tests::ollama_provider_streams_sse_deltas ... ok
test chat::openai_compat::tests::ollama_provider_emits_tool_call ... ok
```

```
cargo test -p trusty-common → test result: ok. 191 passed; 0 failed; 6 ignored
cargo test -p trusty-agents → test result: ok. 2541 passed; 0 failed; 12 ignored
```

`cargo fmt --check` exit 0 · `cargo clippy -p trusty-common --all-targets -- -D warnings` clean · `cargo clippy -p trusty-agents --all-targets -- -D warnings` exit 0 · `scripts/check_line_cap.sh` 0 violations.

## Review round (critic: WARN — 1 HIGH, 3 MEDIUM)

All four gating findings fixed on this branch; rebased onto latest main.

- **HIGH** — a mid-stream error frame emitted `ChatEvent::Error` but returned `Ok(())`, breaking this module's own both-channels contract for consumers that only join the pump task. `Flow::Stop` had conflated "receiver hung up" with "I just sent Error"; `Flow` now carries a distinct `Failed(message)` and both call sites return `Err`. New end-to-end test asserts **both** the `Error` event and `result.is_err()`.
- **MEDIUM** — `trusty-mpm`'s activity monitor (`activity/monitor.rs`) was a **fifth** `chat_stream` consumer I missed in the original impact analysis. It matched only `ChatEvent::Delta`, so truncated text reached `serde_json` and misreported a provider outage as `ActivityError::Serialization`. Now mapped to `ActivityError::Llm`.
- **MEDIUM** — `v.get("error")` matched a present-but-null key, so a provider that always includes `"error": null` would have every healthy frame turned into a terminal failure. Filtered at both the frame and buffered-body sites.
- **MEDIUM** — the truncation detector fired on *any* residual bytes, including a complete final frame merely missing its trailing newline (a bare `data: [DONE]` among them) — flipping a working stream to an error, which in trusty-agents costs a second full blocking LLM call per turn. The residual is now decoded first via `is_complete_frame()`; only a severed payload or field name counts as truncation.

Tests: 32 in `chat::` (was 26). `cargo test -p trusty-common` 197 passed / 0 failed · `cargo test -p trusty-mpm` 3611 + 1222 + 1222 passed / 0 failed · clippy `-D warnings` exit 0 on trusty-common, trusty-mpm, trusty-agents · `cargo fmt --check` exit 0.

### Known sibling defect, deliberately NOT fixed here

`crates/trusty-common/src/inference/streaming.rs:372` — the stack this pattern was ported from (#3751) has the **same** present-but-null `error` hole. Left untouched to keep this PR scoped to the chat path; the repo's own `sm_e2e_smoke.rs:544` shows that wire shape is real, so it needs the same one-line filter.

### Non-gating follow-ups

The critic's five non-gating findings (buffered non-SSE body loses incremental streaming; provider→wire sampling wiring untested; `OllamaProvider::with_sampling` has no call site; `excerpt()` O(n) char count; `tests/inference_adapters.rs` silently absent from every green gate) are filed as **#3982** rather than expanded here.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
