### PR TITLE
fix(trusty-agents): stop session_done from racing the real narrative onto the web bus

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Streamed replies no longer flash blank or "(no narrative)" the moment a
+  task finishes** (issue #3759): in browser mode the GUI's SSE→web-bus bridge
+  emitted a `task-complete` with a hardcoded empty narrative on every
+  `session_done`, racing the poll loop's `task-complete` that carries the real
+  text. Last writer won, and with token streaming (#3753) `session_done`
+  normally landed first — up to a poll interval ahead — wiping freshly streamed
+  prose mid-read. `session_done` now stays off the web bus entirely (its status
+  bookkeeping already flowed through the workflow store and the Events log), so
+  a task's narrative has exactly one emitter per transport. As a side effect, a
+  foreign session finishing mid-turn — the `/api/events` stream is a
+  process-wide broadcast — no longer clears this tab's spinner.
+
 - **Streamed chat turns now send the same sampling parameters as the blocking
   path** (issue #3758): `llm::stream::stream_reply` built its
   `OpenRouterProvider` with no temperature, token ceiling, or stop sequences, so

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -17,9 +17,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   normally landed first — up to a poll interval ahead — wiping freshly streamed
   prose mid-read. `session_done` now stays off the web bus entirely (its status
   bookkeeping already flowed through the workflow store and the Events log), so
-  a task's narrative has exactly one emitter per transport. As a side effect, a
-  foreign session finishing mid-turn — the `/api/events` stream is a
-  process-wide broadcast — no longer clears this tab's spinner.
+  a task's narrative has exactly one emitter per transport. Two consequences,
+  both deliberate: a foreign session finishing mid-turn — the `/api/events`
+  stream is a process-wide broadcast — no longer clears this tab's spinner; and
+  the spinner now stops on the poll-driven completion rather than on the SSE
+  event, so it runs up to one poll interval longer (250ms for the first ~5s of
+  a turn, 500ms after). That bound is the price of a single narrative emitter
+  and errs the safe way — a spinner that over-runs reads as "still working",
+  where stopping early reads as "done" over text that has not arrived.
 
 - **Streamed chat turns now send the same sampling parameters as the blocking
   path** (issue #3758): `llm::stream::stream_reply` built its

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -20,28 +20,26 @@
   // #3752: live Slack conversation mirror — the SSE bridge feeds these two
   // event kinds into the store the SlackMirror pane renders.
   import { pushSlackEvent } from './lib/slack-mirror';
-  // #3819: the Events tab's rolling log — fed from the same bridge as
-  // `pushSlackEvent`, additive, never a replacement for the existing
-  // task-progress/webBus routing below.
-  import { pushEvent } from './lib/events';
-  import { invoke, isDesktop, connectEventSource, listenEvent, emitWebEvent, type AppEvent } from './lib/transport';
-  import { bridgeDelta } from './lib/chatStream';
+  // #3759: the SSE→web-bus routing table (Events-tab log, workflow store,
+  // Slack mirror and recap fan-out included) now lives in `lib/eventBridge.ts`
+  // so it is unit-testable; it used to be an inline `bridgeEventToWebBus`
+  // here, with no automated coverage at all.
+  import { bridgeEventToWebBus } from './lib/eventBridge';
+  import { invoke, isDesktop, connectEventSource, listenEvent, type AppEvent } from './lib/transport';
   import { shouldRefetchCatalogs } from './lib/catalogRefetch';
   import {
     apiAuthRequired,
     getCurrentApiToken,
     setApiToken,
-    addMessage,
     fetchAgentCatalog,
     fetchModelCatalog,
     refreshOverlayAgents,
   } from './stores/app';
-  import { setRecap, type Recap } from './stores/recap';
   import { requestExitConfigPane } from './stores/configPane';
   // Why (#3217): parallel structured-data sink — see stores/workflow.ts doc
   // comment for the full rationale. Additive to the flattened webBus path
-  // below, never a replacement.
-  import { handleWorkflowEvent, applyTaskResult, resetWorkflow, workflowState } from './stores/workflow';
+  // in `lib/eventBridge.ts`, never a replacement.
+  import { applyTaskResult, resetWorkflow, workflowState } from './stores/workflow';
   // Why: Importing the theme store has the side-effect of running applyTheme()
   // for the persisted theme, ensuring the `dark` class on <html> tracks the
   // user's preference for the lifetime of the app (the inline <head> script
@@ -204,20 +202,6 @@
   }
 
   /**
-   * Why: When a typed server event arrives, route it onto the legacy webBus
-   * names so ChatView / TaskHistory / Sidebar pick it up without rewriting
-   * each component's listener wiring. Phase B keeps the migration mechanical
-   * — Phase C will surface the new event vocabulary directly to components
-   * that can render richer state (per-phase timeline, per-agent output).
-   * What: Maps a small set of high-signal server events to the existing
-   * `task-progress` / `task-complete` / `task-error` web-bus events. Unknown
-   * event types are forwarded as `task-progress` with a friendly summary so
-   * they show up in the UI rather than being silently dropped.
-   * Test: Trigger a workflow run with the API server up; observe Sidebar
-   * "Recent tasks" updates without a page refresh and ChatView shows live
-   * progress text.
-   */
-  /**
    * Why (#3257 code-critic HIGH): `workflowState.resetWorkflow()` previously
    * only fired on the SSE `session_started` event — but Tauri desktop mode
    * never opens the SSE stream (`startEventStream()` below no-ops when
@@ -247,151 +231,6 @@
     if (current.taskId !== taskId) {
       resetWorkflow();
       workflowState.update((s) => ({ ...s, taskId, status: 'running' }));
-    }
-  }
-
-  function bridgeEventToWebBus(ev: AppEvent) {
-    // #3819: feed the Events tab's rolling log for EVERY event, including
-    // ping/lag — additive, never short-circuits anything below.
-    pushEvent(ev);
-    // #3217: feed the structured workflow store first — additive, never
-    // short-circuits the flattened-text switch below.
-    handleWorkflowEvent(ev);
-    switch (ev.type) {
-      case 'session_started':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: 'Task started…',
-        });
-        break;
-      case 'session_done':
-        emitWebEvent('task-complete', {
-          id: ev.session_id ?? '',
-          status: ev.status ?? 'completed',
-          narrative: '',
-        });
-        break;
-      case 'session_cancelled':
-        emitWebEvent('task-error', {
-          task_id: ev.session_id ?? '',
-          error: 'cancelled',
-        });
-        break;
-      case 'pm_thinking':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: ev.text ?? '(thinking)',
-        });
-        break;
-      case 'pm_delegating':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `Delegating to ${ev.agent}: ${ev.task_preview ?? ''}`,
-        });
-        break;
-      case 'agent_spawned':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `Agent ${ev.agent} starting…`,
-        });
-        break;
-      case 'agent_message':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `[${ev.agent}] ${ev.text ?? ''}`,
-        });
-        break;
-      case 'agent_message_delta': {
-        // Token-level streaming: forward each coalesced fragment on the
-        // dedicated `task-delta` bus so ChatView can grow the in-flight reply
-        // bubble incrementally (see `lib/chatStream.ts`). The final
-        // `task-complete` still replaces the accumulation with the
-        // authoritative narrative.
-        const delta = bridgeDelta(ev);
-        if (delta) emitWebEvent('task-delta', delta);
-        break;
-      }
-      case 'agent_done':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `Agent ${ev.agent} done (${ev.status ?? 'ok'})`,
-        });
-        break;
-      case 'agent_failed':
-        emitWebEvent('task-error', {
-          task_id: ev.session_id ?? '',
-          error: `Agent ${ev.agent} failed: ${ev.error ?? ''}`,
-        });
-        break;
-      case 'tool_called':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `Tool ${ev.tool}: ${ev.preview ?? ''}`,
-        });
-        break;
-      case 'phase_started':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `Phase: ${ev.phase}`,
-        });
-        break;
-      case 'phase_done':
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `Phase ${ev.phase} ${ev.status ?? 'done'}`,
-        });
-        break;
-      case 'recap_generated': {
-        // Why: #371 — surface session recaps in two places: the persistent
-        // RecapPanel between chat and input (latest recap per session) and as
-        // a banner-style chat message so the recap is preserved in the
-        // scrollback. Both consumers read from the recap store; the chat
-        // banner is appended via addMessage with role='recap'.
-        const sessionId = (ev.session_id ?? '') as string;
-        const summary = ((ev as Record<string, unknown>).summary ?? '') as string;
-        const rawRows = (ev as Record<string, unknown>).table_rows as unknown;
-        const rows: [string, string][] = Array.isArray(rawRows)
-          ? (rawRows as unknown[])
-              .filter((r): r is [unknown, unknown] => Array.isArray(r) && r.length === 2)
-              .map(([s, r]) => [String(s), String(r)])
-          : [];
-        const recap: Recap = {
-          session_id: sessionId,
-          summary,
-          table_rows: rows,
-          received_at: Date.now(),
-        };
-        setRecap(recap);
-        if (sessionId) {
-          addMessage(sessionId, {
-            id: `recap-${sessionId}-${recap.received_at}`,
-            role: 'recap',
-            content: summary,
-            timestamp: recap.received_at,
-            recapRows: rows,
-          });
-        }
-        break;
-      }
-      case 'slack_message_received':
-      case 'slack_reply_sent':
-        // #3752: live Slack conversation mirror. These are conversation-scoped
-        // (no session_id), so they don't belong on the task web-bus — fold them
-        // straight into the SlackMirror store and stop (no default fall-through
-        // to a `task-progress` emit).
-        pushSlackEvent(ev);
-        break;
-      case 'ping':
-      case 'lag':
-        // Diagnostic — no UI action; consumers that care can listen for the
-        // typed AppEvent directly via `connectEventSource`.
-        break;
-      default:
-        // Forward unknown events as progress so they're not invisible.
-        emitWebEvent('task-progress', {
-          task_id: ev.session_id ?? '',
-          message: `[${ev.type}]`,
-        });
     }
   }
 

--- a/crates/trusty-agents/ui/src/components/ChatView.test.ts
+++ b/crates/trusty-agents/ui/src/components/ChatView.test.ts
@@ -1,0 +1,159 @@
+// #3759 — the browser-mode task-complete flash race, pinned against the real
+// `ChatView`.
+//
+// Why: `session_done` (SSE lifecycle) and the poll loop's `task-complete`
+// (`transport.ts::send_message`) both landed on the same web bus for the same
+// task id, and `ChatView`'s handler is last-writer-wins. Because `session_done`
+// carried a fabricated `narrative: ''`, whichever arrived last decided whether
+// the user saw the real reply or "(no narrative)" — and with token streaming
+// (#3753) `session_done` normally arrives FIRST, one poll interval (250–500ms)
+// ahead of the real text, so freshly streamed prose visibly blanked mid-read.
+// A bus-level assertion alone (`lib/eventBridge.test.ts`) can't express that:
+// the defect is what the reader SEES, so these mount the component and read
+// the rendered bubble. Both interleavings are asserted because the fix must be
+// order-independent, not merely tuned for the ordering that happens to be
+// common today.
+// What: Mounts `ChatView` (browser transport — no Tauri globals under jsdom,
+// so `listenEvent` binds to the in-process web bus), seeds one assistant
+// bubble tagged with a task id, then replays each ordering, following
+// `ChatPane.test.ts`'s mounting pattern.
+// Test: this file.
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import ChatView from './ChatView.svelte';
+import { bridgeEventToWebBus } from '../lib/eventBridge';
+import { emitWebEvent, type AppEvent } from '../lib/transport';
+import { streamAccumulator } from '../lib/chatStream';
+import { resetWorkflow } from '../stores/workflow';
+import { activeProjectId, addMessage, isRunning, messages } from '../stores/app';
+
+const PROJECT = 'ctrl';
+const TASK = 'task-1';
+const STREAMED = 'The streamed answer so far';
+const REAL = 'The authoritative final narrative.';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+async function waitFor(predicate: () => boolean, timeoutMs = 2000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error('timed out waiting for condition');
+}
+
+/** The rendered text of the assistant bubble under test. */
+function bubbleText(): string {
+  const paras = Array.from(target.querySelectorAll('p.whitespace-pre-wrap'));
+  return paras.map((p) => p.textContent ?? '').join('\n');
+}
+
+/** Settle Svelte's render queue so `bubbleText()` reflects the last emit. */
+async function rendered(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+/** The SSE lifecycle event that used to fabricate an empty narrative. */
+function sessionDone(): void {
+  bridgeEventToWebBus({ type: 'session_done', session_id: TASK, status: 'success' } as AppEvent);
+}
+
+/** The poll loop's real completion, mirroring `transport.ts::send_message`. */
+function pollComplete(): void {
+  emitWebEvent('task-complete', { id: TASK, narrative: REAL, status: 'success' });
+}
+
+beforeEach(async () => {
+  messages.set(new Map());
+  activeProjectId.set(PROJECT);
+  isRunning.set(true);
+  streamAccumulator.finalize(TASK);
+  resetWorkflow();
+
+  target = document.createElement('div');
+  document.body.appendChild(target);
+  instance = mount(ChatView, { target }) as Record<string, unknown>;
+
+  addMessage(PROJECT, {
+    id: 'asst-1',
+    role: 'assistant',
+    content: '',
+    timestamp: 0,
+    taskId: TASK,
+    speaker: 'Assistant',
+  });
+
+  // The component wires its bus listeners from an async `onMount`; emitting
+  // before they are attached would silently drop the events under test.
+  await waitFor(() => {
+    emitWebEvent('task-delta', { task_id: TASK, text: STREAMED, agent: '', done: false });
+    return bubbleText().includes(STREAMED);
+  });
+});
+
+afterEach(() => {
+  if (instance) unmount(instance);
+  instance = null;
+  target.remove();
+});
+
+describe('task-complete race (#3759)', () => {
+  it('session_done first: never blanks the streamed text, then shows the real narrative', async () => {
+    // The common ordering. Before the fix this rendered "(no narrative)" for
+    // one poll interval, wiping text the user was mid-way through reading.
+    sessionDone();
+    await rendered();
+
+    expect(bubbleText()).toContain(STREAMED);
+    expect(bubbleText()).not.toContain('(no narrative)');
+
+    pollComplete();
+    await rendered();
+
+    expect(bubbleText()).toContain(REAL);
+  });
+
+  it('real narrative first: a following session_done does not overwrite it', async () => {
+    // The reverse interleaving (a slow SSE hop, or a fast first poll). Before
+    // the fix this ended on "(no narrative)" permanently — no later event ever
+    // arrives to repair it.
+    pollComplete();
+    await rendered();
+
+    expect(bubbleText()).toContain(REAL);
+
+    sessionDone();
+    await rendered();
+
+    expect(bubbleText()).toContain(REAL);
+    expect(bubbleText()).not.toContain('(no narrative)');
+  });
+
+  it('a foreign session finishing mid-turn leaves this tab alone', async () => {
+    // `/api/events` is a process-wide broadcast, so a task started elsewhere
+    // (Telegram, another tab) delivers its `session_done` here too. It must
+    // touch neither the bubble nor the spinner.
+    bridgeEventToWebBus({
+      type: 'session_done',
+      session_id: 'someone-elses-task',
+      status: 'success',
+    } as AppEvent);
+    await rendered();
+
+    expect(bubbleText()).toContain(STREAMED);
+    expect(target.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it('an empty narrative from the authoritative emitter is still reported', async () => {
+    // The guard is "session_done carries no narrative", NOT "empty narratives
+    // are ignored" — a genuinely empty result from the poll loop must still
+    // read as such rather than freezing on stale streamed text.
+    emitWebEvent('task-complete', { id: TASK, narrative: '', status: 'success' });
+    await rendered();
+
+    expect(bubbleText()).toContain('(no narrative)');
+  });
+});

--- a/crates/trusty-agents/ui/src/components/ChatView.test.ts
+++ b/crates/trusty-agents/ui/src/components/ChatView.test.ts
@@ -51,6 +51,11 @@ function bubbleText(): string {
   return paras.map((p) => p.textContent ?? '').join('\n');
 }
 
+/** Whether the "Assistant is responding" spinner is on screen (`$isRunning`). */
+function spinnerVisible(): boolean {
+  return target.querySelector('[role="status"]') !== null;
+}
+
 /** Settle Svelte's render queue so `bubbleText()` reflects the last emit. */
 async function rendered(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -110,10 +115,25 @@ describe('task-complete race (#3759)', () => {
     expect(bubbleText()).toContain(STREAMED);
     expect(bubbleText()).not.toContain('(no narrative)');
 
+    // ACCEPTED, BOUNDED TIMING TRADE-OFF (#3759 code-critic MEDIUM-1) — pinned
+    // deliberately, not incidental. The spinner used to stop on `session_done`;
+    // it now stops only when the poll-driven `task-complete` fires, so it keeps
+    // spinning across this gap: at most one poll interval (250ms for the first
+    // 20 polls, then 500ms — `transport.ts::pollIntervalMs`). That is the price
+    // of a single narrative emitter, and it errs the safe way (a spinner that
+    // over-runs by 250ms reads as "still working", where stopping early reads
+    // as "done" over text that has not arrived). This assertion exists so a
+    // future change cannot silently WIDEN the gap — if the spinner starts
+    // outliving the poll result, the next assertion fails.
+    expect(spinnerVisible()).toBe(true);
+
     pollComplete();
     await rendered();
 
     expect(bubbleText()).toContain(REAL);
+    // The gap closes here, and nowhere later: completion still stops the
+    // spinner in exactly one place.
+    expect(spinnerVisible()).toBe(false);
   });
 
   it('real narrative first: a following session_done does not overwrite it', async () => {
@@ -144,7 +164,7 @@ describe('task-complete race (#3759)', () => {
     await rendered();
 
     expect(bubbleText()).toContain(STREAMED);
-    expect(target.querySelector('[role="status"]')).not.toBeNull();
+    expect(spinnerVisible()).toBe(true);
   });
 
   it('an empty narrative from the authoritative emitter is still reported', async () => {

--- a/crates/trusty-agents/ui/src/lib/eventBridge.test.ts
+++ b/crates/trusty-agents/ui/src/lib/eventBridge.test.ts
@@ -1,0 +1,130 @@
+// Regression coverage for the browser-mode SSE→web-bus bridge, and
+// specifically for #3759: `session_done` must NOT put a narrative-bearing
+// `task-complete` on the bus.
+//
+// The bug: the bridge emitted `task-complete` with a hardcoded
+// `narrative: ''` on every `session_done`. That raced the poll loop in
+// `transport.ts::send_message`, the emitter that carries the REAL narrative,
+// and whichever landed last won in `ChatView` — blanking the reply to
+// "(no narrative)". `ChatView.test.ts` pins the user-visible half (both
+// orderings, against the real component); this file pins the bus-level
+// contract that makes those orderings impossible to get wrong in the first
+// place, plus the surrounding routing arms so the #3759 change can't quietly
+// take a neighbour with it.
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { get } from 'svelte/store';
+import { bridgeEventToWebBus } from './eventBridge';
+import { listenEvent, type AppEvent } from './transport';
+import { clearEventLog, eventLog } from './events';
+import { workflowState, resetWorkflow } from '../stores/workflow';
+
+/** Records every web-bus message the bridge emits, in order. */
+function busRecorder() {
+  const seen: Array<{ event: string; payload: unknown }> = [];
+  const unlisten: Array<() => void> = [];
+  const ready = Promise.all(
+    ['task-progress', 'task-complete', 'task-error', 'task-delta'].map((name) =>
+      listenEvent(name, (payload: unknown) => seen.push({ event: name, payload })).then((fn) =>
+        unlisten.push(fn),
+      ),
+    ),
+  );
+  return {
+    ready,
+    seen,
+    stop: () => unlisten.forEach((fn) => fn()),
+  };
+}
+
+let bus: ReturnType<typeof busRecorder>;
+
+beforeEach(async () => {
+  bus?.stop();
+  clearEventLog();
+  resetWorkflow();
+  bus = busRecorder();
+  await bus.ready;
+});
+
+describe('bridge_session_done_emits_no_task_complete (#3759)', () => {
+  it('puts nothing at all on the web bus for session_done', () => {
+    bridgeEventToWebBus({ type: 'session_done', session_id: 't1', status: 'success' } as AppEvent);
+
+    expect(bus.seen).toEqual([]);
+  });
+
+  it('never emits a task-complete carrying an empty narrative', () => {
+    // The precise defect: an empty-narrative `task-complete` is the payload
+    // ChatView renders as "(no narrative)". No bridge arm may produce one.
+    bridgeEventToWebBus({ type: 'session_done', session_id: 't1', status: 'success' } as AppEvent);
+    bridgeEventToWebBus({ type: 'session_done', session_id: 't1', status: 'failed' } as AppEvent);
+    bridgeEventToWebBus({ type: 'session_done' } as AppEvent);
+
+    expect(bus.seen.filter((m) => m.event === 'task-complete')).toEqual([]);
+  });
+
+  it('does not fall through to the unknown-event task-progress arm', () => {
+    // The explicit `break` is load-bearing: dropping the arm entirely would
+    // route `session_done` into `default:` and emit `[session_done]` progress.
+    bridgeEventToWebBus({ type: 'session_done', session_id: 't1', status: 'success' } as AppEvent);
+
+    expect(bus.seen.filter((m) => m.event === 'task-progress')).toEqual([]);
+  });
+
+  it('still does its status bookkeeping — workflow status and the Events log', () => {
+    // Staying off the web bus must not make `session_done` invisible: the two
+    // sinks that legitimately consume it run above the switch, unconditionally.
+    bridgeEventToWebBus({ type: 'session_started', session_id: 't1' } as AppEvent);
+    bridgeEventToWebBus({ type: 'session_done', session_id: 't1', status: 'success' } as AppEvent);
+
+    expect(get(workflowState).status).toBe('done');
+    expect(get(eventLog).map((r) => r.type)).toEqual(['session_started', 'session_done']);
+  });
+
+  it('maps a failed session to the failed workflow status', () => {
+    bridgeEventToWebBus({ type: 'session_started', session_id: 't1' } as AppEvent);
+    bridgeEventToWebBus({ type: 'session_done', session_id: 't1', status: 'failed' } as AppEvent);
+
+    expect(get(workflowState).status).toBe('failed');
+  });
+});
+
+describe('bridge_routes_known_events', () => {
+  it('session_started announces progress', () => {
+    bridgeEventToWebBus({ type: 'session_started', session_id: 't1' } as AppEvent);
+
+    expect(bus.seen).toEqual([
+      { event: 'task-progress', payload: { task_id: 't1', message: 'Task started…' } },
+    ]);
+  });
+
+  it('session_cancelled still reaches the error bus', () => {
+    bridgeEventToWebBus({ type: 'session_cancelled', session_id: 't1' } as AppEvent);
+
+    expect(bus.seen).toEqual([
+      { event: 'task-error', payload: { task_id: 't1', error: 'cancelled' } },
+    ]);
+  });
+
+  it('agent_message_delta still reaches the streaming bus', () => {
+    bridgeEventToWebBus({
+      type: 'agent_message_delta',
+      session_id: 't1',
+      text: 'Hel',
+      agent: 'izzie',
+    } as AppEvent);
+
+    expect(bus.seen).toEqual([
+      { event: 'task-delta', payload: { task_id: 't1', text: 'Hel', agent: 'izzie', done: false } },
+    ]);
+  });
+
+  it('unknown events still surface as progress', () => {
+    bridgeEventToWebBus({ type: 'brand_new_event', session_id: 't1' } as unknown as AppEvent);
+
+    expect(bus.seen).toEqual([
+      { event: 'task-progress', payload: { task_id: 't1', message: '[brand_new_event]' } },
+    ]);
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/eventBridge.test.ts
+++ b/crates/trusty-agents/ui/src/lib/eventBridge.test.ts
@@ -17,7 +17,10 @@ import { get } from 'svelte/store';
 import { bridgeEventToWebBus } from './eventBridge';
 import { listenEvent, type AppEvent } from './transport';
 import { clearEventLog, eventLog } from './events';
+import { clearSlackMirror, slackMirror } from './slack-mirror';
 import { workflowState, resetWorkflow } from '../stores/workflow';
+import { messages } from '../stores/app';
+import { recaps } from '../stores/recap';
 
 /** Records every web-bus message the bridge emits, in order. */
 function busRecorder() {
@@ -42,7 +45,10 @@ let bus: ReturnType<typeof busRecorder>;
 beforeEach(async () => {
   bus?.stop();
   clearEventLog();
+  clearSlackMirror();
   resetWorkflow();
+  messages.set(new Map());
+  recaps.set(new Map());
   bus = busRecorder();
   await bus.ready;
 });
@@ -90,41 +96,176 @@ describe('bridge_session_done_emits_no_task_complete (#3759)', () => {
   });
 });
 
-describe('bridge_routes_known_events', () => {
-  it('session_started announces progress', () => {
-    bridgeEventToWebBus({ type: 'session_started', session_id: 't1' } as AppEvent);
-
-    expect(bus.seen).toEqual([
-      { event: 'task-progress', payload: { task_id: 't1', message: 'Task started…' } },
-    ]);
-  });
-
-  it('session_cancelled still reaches the error bus', () => {
-    bridgeEventToWebBus({ type: 'session_cancelled', session_id: 't1' } as AppEvent);
-
-    expect(bus.seen).toEqual([
-      { event: 'task-error', payload: { task_id: 't1', error: 'cancelled' } },
-    ]);
-  });
-
-  it('agent_message_delta still reaches the streaming bus', () => {
-    bridgeEventToWebBus({
-      type: 'agent_message_delta',
-      session_id: 't1',
-      text: 'Hel',
-      agent: 'izzie',
-    } as AppEvent);
-
-    expect(bus.seen).toEqual([
+// Every arm of the bridge's switch, pinned (#3759 code-critic MEDIUM-2). The
+// #3759 move was byte-identical, so these are PINS on behavior that already
+// shipped, not assertions about new logic — the point of extracting the bridge
+// was that its routing table stops being untestable, and a table that covers
+// only the arms one bugfix happened to touch does not deliver that.
+const ROUTED: Array<{ arm: string; ev: Record<string, unknown>; emits: Array<{ event: string; payload: unknown }> }> = [
+  {
+    arm: 'session_started',
+    ev: { type: 'session_started', session_id: 't1' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'Task started…' } }],
+  },
+  {
+    arm: 'session_cancelled',
+    ev: { type: 'session_cancelled', session_id: 't1' },
+    emits: [{ event: 'task-error', payload: { task_id: 't1', error: 'cancelled' } }],
+  },
+  {
+    arm: 'pm_thinking',
+    ev: { type: 'pm_thinking', session_id: 't1', text: 'weighing options' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'weighing options' } }],
+  },
+  {
+    arm: 'pm_thinking (no text ⇒ placeholder)',
+    ev: { type: 'pm_thinking', session_id: 't1' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: '(thinking)' } }],
+  },
+  {
+    arm: 'pm_delegating',
+    ev: { type: 'pm_delegating', session_id: 't1', agent: 'izzie', task_preview: 'fix the bug' },
+    emits: [
+      { event: 'task-progress', payload: { task_id: 't1', message: 'Delegating to izzie: fix the bug' } },
+    ],
+  },
+  {
+    arm: 'pm_delegating (no preview)',
+    ev: { type: 'pm_delegating', session_id: 't1', agent: 'izzie' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'Delegating to izzie: ' } }],
+  },
+  {
+    arm: 'agent_spawned',
+    ev: { type: 'agent_spawned', session_id: 't1', agent: 'izzie' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'Agent izzie starting…' } }],
+  },
+  {
+    arm: 'agent_message',
+    ev: { type: 'agent_message', session_id: 't1', agent: 'izzie', text: 'on it' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: '[izzie] on it' } }],
+  },
+  {
+    arm: 'agent_message (no text)',
+    ev: { type: 'agent_message', session_id: 't1', agent: 'izzie' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: '[izzie] ' } }],
+  },
+  {
+    arm: 'agent_message_delta',
+    ev: { type: 'agent_message_delta', session_id: 't1', text: 'Hel', agent: 'izzie' },
+    emits: [
       { event: 'task-delta', payload: { task_id: 't1', text: 'Hel', agent: 'izzie', done: false } },
+    ],
+  },
+  {
+    arm: 'agent_done',
+    ev: { type: 'agent_done', session_id: 't1', agent: 'izzie', status: 'success' },
+    emits: [
+      { event: 'task-progress', payload: { task_id: 't1', message: 'Agent izzie done (success)' } },
+    ],
+  },
+  {
+    arm: 'agent_done (no status ⇒ ok)',
+    ev: { type: 'agent_done', session_id: 't1', agent: 'izzie' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'Agent izzie done (ok)' } }],
+  },
+  {
+    arm: 'agent_failed',
+    ev: { type: 'agent_failed', session_id: 't1', agent: 'izzie', error: 'boom' },
+    emits: [{ event: 'task-error', payload: { task_id: 't1', error: 'Agent izzie failed: boom' } }],
+  },
+  {
+    arm: 'tool_called',
+    ev: { type: 'tool_called', session_id: 't1', tool: 'grep', preview: 'foo' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'Tool grep: foo' } }],
+  },
+  {
+    arm: 'phase_started',
+    ev: { type: 'phase_started', session_id: 't1', phase: 'IMPLEMENT' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'Phase: IMPLEMENT' } }],
+  },
+  {
+    arm: 'phase_done',
+    ev: { type: 'phase_done', session_id: 't1', phase: 'IMPLEMENT', status: 'failed' },
+    emits: [
+      { event: 'task-progress', payload: { task_id: 't1', message: 'Phase IMPLEMENT failed' } },
+    ],
+  },
+  {
+    arm: 'phase_done (no status ⇒ done)',
+    ev: { type: 'phase_done', session_id: 't1', phase: 'VERIFY' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: 'Phase VERIFY done' } }],
+  },
+  {
+    arm: 'unknown event',
+    ev: { type: 'brand_new_event', session_id: 't1' },
+    emits: [{ event: 'task-progress', payload: { task_id: 't1', message: '[brand_new_event]' } }],
+  },
+  // The four arms that deliberately stay OFF the task web bus. `session_done`
+  // is #3759's own arm and is asserted in depth above; these three were always
+  // silent and must stay that way — a `default:` fall-through would spam every
+  // one of them onto `task-progress`.
+  { arm: 'recap_generated', ev: { type: 'recap_generated', session_id: 't1', summary: 's' }, emits: [] },
+  { arm: 'slack_message_received', ev: { type: 'slack_message_received', channel: 'C1', text: 'hi' }, emits: [] },
+  { arm: 'slack_reply_sent', ev: { type: 'slack_reply_sent', channel: 'C1', text: 'yo' }, emits: [] },
+  { arm: 'ping', ev: { type: 'ping' }, emits: [] },
+  { arm: 'lag', ev: { type: 'lag' }, emits: [] },
+];
+
+describe('bridge_routes_known_events', () => {
+  it.each(ROUTED)('$arm', ({ ev, emits }) => {
+    bridgeEventToWebBus(ev as unknown as AppEvent);
+
+    expect(bus.seen).toEqual(emits);
+  });
+});
+
+describe('bridge_fans_out_to_non_bus_sinks', () => {
+  it('recap_generated fills the recap store and the chat scrollback', () => {
+    bridgeEventToWebBus({
+      type: 'recap_generated',
+      session_id: 't1',
+      summary: 'Shipped the fix',
+      table_rows: [
+        ['build', 'ok'],
+        ['malformed row'],
+      ],
+    } as unknown as AppEvent);
+
+    const recap = get(recaps).get('t1');
+    expect(recap?.summary).toBe('Shipped the fix');
+    // Rows that aren't 2-tuples are dropped rather than rendered half-empty.
+    expect(recap?.table_rows).toEqual([['build', 'ok']]);
+
+    const banner = get(messages).get('t1')?.[0];
+    expect(banner?.role).toBe('recap');
+    expect(banner?.content).toBe('Shipped the fix');
+  });
+
+  it('slack events fold into the mirror instead of the task bus', () => {
+    bridgeEventToWebBus({
+      type: 'slack_message_received',
+      channel: 'C1',
+      text: 'deploy?',
+      tier: 'all',
+      user_display: 'Bob',
+    } as unknown as AppEvent);
+    bridgeEventToWebBus({
+      type: 'slack_reply_sent',
+      channel: 'C1',
+      text: 'on it',
+    } as unknown as AppEvent);
+
+    expect(get(slackMirror).map((b) => [b.kind, b.text])).toEqual([
+      ['inbound', 'deploy?'],
+      ['reply', 'on it'],
     ]);
   });
 
-  it('unknown events still surface as progress', () => {
-    bridgeEventToWebBus({ type: 'brand_new_event', session_id: 't1' } as unknown as AppEvent);
+  it('every event reaches the Events tab log, ping and lag included', () => {
+    bridgeEventToWebBus({ type: 'ping' } as AppEvent);
+    bridgeEventToWebBus({ type: 'lag' } as AppEvent);
+    bridgeEventToWebBus({ type: 'slack_reply_sent', channel: 'C1', text: 'yo' } as unknown as AppEvent);
 
-    expect(bus.seen).toEqual([
-      { event: 'task-progress', payload: { task_id: 't1', message: '[brand_new_event]' } },
-    ]);
+    expect(get(eventLog).map((r) => r.type)).toEqual(['ping', 'lag', 'slack_reply_sent']);
   });
 });

--- a/crates/trusty-agents/ui/src/lib/eventBridge.ts
+++ b/crates/trusty-agents/ui/src/lib/eventBridge.ts
@@ -1,0 +1,210 @@
+// The browser-mode SSE→web-bus bridge (#192 Phase B), extracted verbatim from
+// `App.svelte` so it can be unit-tested (#3759).
+//
+// Why: Every typed server `AppEvent` arriving on `/api/events` has to be
+// routed onto the legacy web-bus names (`task-progress` / `task-complete` /
+// `task-error` / `task-delta`) that `ChatView` / `TaskHistory` / `InputArea`
+// already listen on, plus fanned out to the structured sinks (`workflowState`,
+// the Events-tab log, the Slack mirror, the recap store). While this lived
+// inline in `App.svelte` it had ZERO automated coverage — every doc comment
+// around it said "Test: Manual" — which is how #3759 (the `session_done`
+// empty-narrative race) shipped and survived. Living in `src/lib` next to the
+// other pure-ish reducers (`events.ts`, `slack-mirror.ts`, `chatStream.ts`)
+// means the whole routing table is now vitest-reachable without mounting the
+// app shell. Behavior is unchanged by the move itself.
+// What: `bridgeEventToWebBus(ev)` — the single entry point `App.svelte`'s
+// `connectEventSource` callback calls for each incoming event. It is
+// side-effecting by design (it writes to the same stores the app renders
+// from); tests drive it and observe those stores plus the web bus.
+// This bridge runs in BROWSER MODE ONLY — `App.svelte`'s `startEventStream()`
+// early-returns under Tauri, where the desktop shell has its own `listen()`
+// bridge.
+// Test: `eventBridge.test.ts`.
+
+import { pushSlackEvent } from './slack-mirror';
+import { pushEvent } from './events';
+import { emitWebEvent, type AppEvent } from './transport';
+import { bridgeDelta } from './chatStream';
+import { addMessage } from '../stores/app';
+import { setRecap, type Recap } from '../stores/recap';
+import { handleWorkflowEvent } from '../stores/workflow';
+
+/**
+ * Why: When a typed server event arrives, route it onto the legacy webBus
+ * names so ChatView / TaskHistory / Sidebar pick it up without rewriting
+ * each component's listener wiring. Phase B keeps the migration mechanical
+ * — Phase C will surface the new event vocabulary directly to components
+ * that can render richer state (per-phase timeline, per-agent output).
+ * What: Maps a small set of high-signal server events to the existing
+ * `task-progress` / `task-complete` / `task-error` web-bus events. Unknown
+ * event types are forwarded as `task-progress` with a friendly summary so
+ * they show up in the UI rather than being silently dropped.
+ * Test: `bridge_session_done_emits_no_task_complete`,
+ * `bridge_routes_known_events`.
+ */
+export function bridgeEventToWebBus(ev: AppEvent) {
+  // #3819: feed the Events tab's rolling log for EVERY event, including
+  // ping/lag — additive, never short-circuits anything below.
+  pushEvent(ev);
+  // #3217: feed the structured workflow store first — additive, never
+  // short-circuits the flattened-text switch below.
+  handleWorkflowEvent(ev);
+  switch (ev.type) {
+    case 'session_started':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: 'Task started…',
+      });
+      break;
+    case 'session_done':
+      // #3759: deliberately emits NOTHING on the web bus.
+      //
+      // This arm used to emit `task-complete` with a hardcoded
+      // `narrative: ''`. `task-complete` is the narrative-BEARING result
+      // event, and `session_done` structurally cannot carry a narrative — the
+      // SSE lifecycle event has no result text on the wire. So the fabricated
+      // empty string raced the poll-driven `task-complete` in
+      // `transport.ts::send_message` (the emitter that carries the REAL text):
+      // whichever landed last won in `ChatView`, and with token streaming
+      // (#3753) `session_done` normally lands FIRST — up to one poll interval
+      // (250–500ms) ahead of the real narrative — blanking freshly streamed
+      // text to "(no narrative)".
+      //
+      // Nothing is lost by staying silent here. The status bookkeeping this
+      // arm appeared to do already happens ABOVE, unconditionally and with
+      // better fidelity: `handleWorkflowEvent` maps `session_done` to
+      // `workflowState.status` (and filters foreign sessions while doing so),
+      // and `pushEvent` logs it to the Events tab. The narrative, the
+      // `isRunning` flip, and the `TaskHistory` refresh all still arrive with
+      // the poll-driven `task-complete` for this tab's own task — which, being
+      // per-task rather than a process-wide broadcast, also stops a FOREIGN
+      // session's completion (a Telegram task finishing mid-turn) from
+      // clearing this tab's spinner.
+      //
+      // The `break` is load-bearing: without an explicit arm, `session_done`
+      // would fall through to `default:` and emit a `[session_done]`
+      // `task-progress` instead.
+      break;
+    case 'session_cancelled':
+      emitWebEvent('task-error', {
+        task_id: ev.session_id ?? '',
+        error: 'cancelled',
+      });
+      break;
+    case 'pm_thinking':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: ev.text ?? '(thinking)',
+      });
+      break;
+    case 'pm_delegating':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `Delegating to ${ev.agent}: ${ev.task_preview ?? ''}`,
+      });
+      break;
+    case 'agent_spawned':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `Agent ${ev.agent} starting…`,
+      });
+      break;
+    case 'agent_message':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `[${ev.agent}] ${ev.text ?? ''}`,
+      });
+      break;
+    case 'agent_message_delta': {
+      // Token-level streaming: forward each coalesced fragment on the
+      // dedicated `task-delta` bus so ChatView can grow the in-flight reply
+      // bubble incrementally (see `lib/chatStream.ts`). The final
+      // `task-complete` still replaces the accumulation with the
+      // authoritative narrative.
+      const delta = bridgeDelta(ev);
+      if (delta) emitWebEvent('task-delta', delta);
+      break;
+    }
+    case 'agent_done':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `Agent ${ev.agent} done (${ev.status ?? 'ok'})`,
+      });
+      break;
+    case 'agent_failed':
+      emitWebEvent('task-error', {
+        task_id: ev.session_id ?? '',
+        error: `Agent ${ev.agent} failed: ${ev.error ?? ''}`,
+      });
+      break;
+    case 'tool_called':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `Tool ${ev.tool}: ${ev.preview ?? ''}`,
+      });
+      break;
+    case 'phase_started':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `Phase: ${ev.phase}`,
+      });
+      break;
+    case 'phase_done':
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `Phase ${ev.phase} ${ev.status ?? 'done'}`,
+      });
+      break;
+    case 'recap_generated': {
+      // Why: #371 — surface session recaps in two places: the persistent
+      // RecapPanel between chat and input (latest recap per session) and as
+      // a banner-style chat message so the recap is preserved in the
+      // scrollback. Both consumers read from the recap store; the chat
+      // banner is appended via addMessage with role='recap'.
+      const sessionId = (ev.session_id ?? '') as string;
+      const summary = ((ev as Record<string, unknown>).summary ?? '') as string;
+      const rawRows = (ev as Record<string, unknown>).table_rows as unknown;
+      const rows: [string, string][] = Array.isArray(rawRows)
+        ? (rawRows as unknown[])
+            .filter((r): r is [unknown, unknown] => Array.isArray(r) && r.length === 2)
+            .map(([s, r]) => [String(s), String(r)])
+        : [];
+      const recap: Recap = {
+        session_id: sessionId,
+        summary,
+        table_rows: rows,
+        received_at: Date.now(),
+      };
+      setRecap(recap);
+      if (sessionId) {
+        addMessage(sessionId, {
+          id: `recap-${sessionId}-${recap.received_at}`,
+          role: 'recap',
+          content: summary,
+          timestamp: recap.received_at,
+          recapRows: rows,
+        });
+      }
+      break;
+    }
+    case 'slack_message_received':
+    case 'slack_reply_sent':
+      // #3752: live Slack conversation mirror. These are conversation-scoped
+      // (no session_id), so they don't belong on the task web-bus — fold them
+      // straight into the SlackMirror store and stop (no default fall-through
+      // to a `task-progress` emit).
+      pushSlackEvent(ev);
+      break;
+    case 'ping':
+    case 'lag':
+      // Diagnostic — no UI action; consumers that care can listen for the
+      // typed AppEvent directly via `connectEventSource`.
+      break;
+    default:
+      // Forward unknown events as progress so they're not invisible.
+      emitWebEvent('task-progress', {
+        task_id: ev.session_id ?? '',
+        message: `[${ev.type}]`,
+      });
+  }
+}


### PR DESCRIPTION
Closes #3759.

## The bug

In browser mode, two independent emitters put `task-complete` on the same
in-process web bus for the same task id:

- `App.svelte`'s SSE bridge, on `session_done`, with a hardcoded
  `narrative: ''`;
- the poll loop in `lib/transport.ts::send_message` (`/api/task/{id}`), with
  the REAL narrative at terminal status.

`ChatView`'s handler is last-writer-wins with no ordering guard, and it renders
an empty narrative as `(no narrative)`. With token streaming (#3753)
`session_done` normally arrives FIRST — up to one poll interval (250-500ms)
ahead of the poll result — so freshly streamed prose visibly blanked mid-read
and then reappeared. In the reverse interleaving the bubble was left reading
`(no narrative)` permanently: no later event ever arrives to repair it.

## Approach chosen: remove the emit (the research pass's recommended direction)

`session_done` no longer puts anything on the web bus. Validated before
committing to it — the alternative (guard `ChatView` so an empty narrative can't
overwrite a non-empty one) was rejected for two reasons:

1. **It doesn't actually fix the common ordering.** The text being wiped is
   *streamed* text, not a previously-applied narrative, so a
   "don't overwrite a non-empty narrative" guard would still let the
   session_done-first case blank the bubble. Making it work would mean the guard
   also had to read current bubble content — stateful, ordering-sensitive, and
   easy to get wrong again.
2. **It leaves the lie on the bus.** `task-complete` is the narrative-bearing
   result event; `session_done` structurally cannot carry a narrative (the SSE
   lifecycle event has no result text on the wire). Fabricating `''` and then
   teaching every consumer to distrust it is the wrong layer.

Removing the emit is order-independent by construction: a task's narrative now
has exactly one emitter per transport (the browser poll loop; the Tauri
`send_message` command on desktop, which this bridge never runs for anyway —
`startEventStream()` early-returns under Tauri).

The status bookkeeping the arm appeared to do already ran unconditionally
*above* the switch: `handleWorkflowEvent` maps `session_done` to
`workflowState.status` (filtering foreign sessions while it does), and
`pushEvent` logs it to the Events tab. The narrative, the `isRunning` flip and
the `TaskHistory` refresh all still arrive with the poll-driven
`task-complete`. The explicit `break` is load-bearing — dropping the arm
entirely would route `session_done` into `default:` and emit a `[session_done]`
progress tick.

## Behavior changes (three, all deliberate)

1. **Bonus fix — cross-session contamination.** `/api/events` is a process-wide
   broadcast (`events::bus()`), so a FOREIGN session finishing mid-turn — a
   Telegram task, another tab — used to clear *this* tab's spinner via
   `isRunning.set(false)`. It no longer does. Covered by a test.

2. **Accepted timing trade-off — the spinner runs slightly longer**
   (code-critic MEDIUM-1; this section was missing from the first revision,
   whose "nothing is lost" framing read as parity). The spinner previously
   could stop near-instantly on the SSE `session_done`; it now stops only when
   the poll-driven `task-complete` fires, i.e. up to one poll interval later —
   250ms for the first 20 polls (~5s, covering most turns), 500ms after
   (`transport.ts::pollIntervalMs`). Bounded, and it errs the safe way: a
   spinner that over-runs by 250ms reads as "still working", where stopping
   early reads as "done" over text that has not arrived. The session_done-first
   test now asserts the spinner state on BOTH sides of that gap so a future
   change cannot silently widen it — verified by temporarily removing
   `isRunning.set(false)` from ChatView's completion handler, which fails the
   new assertion.

3. **Accepted loss — foreign-task history refresh.** `TaskHistory` refreshes on
   `task-complete`, so it no longer auto-refreshes when a task *this tab did not
   submit* completes. It still refreshes on mount and on this tab's own
   completions. That live refresh only ever worked as a side effect of the same
   cross-session contamination fixed in (1); happy to file a follow-up for a
   properly-scoped history refresh signal if you want it back.

## Making it testable

`bridgeEventToWebBus` moved verbatim from `App.svelte` (169 lines) to
`lib/eventBridge.ts`. It had ZERO automated coverage — every doc comment around
it said "Test: Manual" — which is how this shipped and survived. It now sits
next to the other reducers (`events.ts`, `slack-mirror.ts`, `chatStream.ts`) and
is vitest-reachable without mounting the app shell. No logic changed in the move
itself; `App.svelte` shrank 582 → 421 lines.

## Tests

Both orderings, plus the bus-level contract. Red-green verified: all five
race assertions fail when the pre-fix `session_done` arm is restored.

- `src/components/ChatView.test.ts` — mounts the real component and reads the
  rendered bubble, because the defect is what the reader SEES:
  - session_done-then-real: streamed text survives, real narrative lands after,
    and the spinner is pinned across the completion gap (see behavior note 2);
  - real-then-session_done: the real narrative is not overwritten;
  - a foreign session's completion touches neither bubble nor spinner;
  - a genuinely empty narrative *from the authoritative emitter* still reads as
    `(no narrative)` — the guard is "session_done carries no narrative", not
    "empty narratives are ignored".
- `src/lib/eventBridge.test.ts` — `session_done` emits nothing at all, never an
  empty-narrative `task-complete`, never a `default:` fall-through; still does
  its workflow-status and Events-log bookkeeping. Plus (code-critic MEDIUM-2)
  a table-driven pass over EVERY switch arm rather than the four the bugfix
  happened to touch — including the `??` defaults (`pm_thinking` with no text,
  `agent_done`/`phase_done` with no status) and the four arms that deliberately
  stay OFF the task bus (`recap_generated`, both Slack kinds, `ping`/`lag`),
  where a `default:` fall-through would spam all of them onto `task-progress` —
  and three tests for the non-bus sinks: the recap store and its chat banner
  (including the malformed-row drop), the Slack mirror, and the Events log.
  The move was byte-identical, so these are pins on shipped behavior.

## Verification

All run in `crates/trusty-agents/ui`. CI's `ui-checks (trusty-agents)` job runs
`pnpm run test:unit && pnpm run check`, so these are enforced.

```
$ pnpm test:unit
 Test Files  23 passed (23)
      Tests  233 passed (233)

$ pnpm check          # svelte-check
COMPLETED 1734 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
                      # both warnings pre-existing, in untouched ProjectsView.svelte

$ pnpm build
✓ 1699 modules transformed.
✓ built in 1.43s

$ pnpm check:tokens
All enforced crates match the canonical token source.
```

Red-green proof (pre-fix `session_done` arm temporarily restored):

```
 × puts nothing at all on the web bus for session_done
 × never emits a task-complete carrying an empty narrative
 × session_done first: never blanks the streamed text, then shows the real narrative
   AssertionError: expected '(no narrative)' to contain 'The streamed answer so far'
 × real narrative first: a following session_done does not overwrite it
   AssertionError: expected '(no narrative)' to contain 'The authoritative final narrative.'
 × a foreign session finishing mid-turn leaves this tab alone
 Tests  5 failed | 8 passed (13)
```

Spinner-pin proof (`isRunning.set(false)` temporarily removed from ChatView's
completion handler, i.e. the gap widened to unbounded):

```
 × session_done first: never blanks the streamed text, then shows the real narrative
   AssertionError: expected true to be false
 Tests  1 failed | 3 passed (4)
```

No Rust source touched (UI TypeScript/Svelte + `CHANGELOG.md` only).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
