### PR TITLE
fix: constant-time secret compares, relay identity gate, and channel-scopable Slack SSE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11183,6 +11183,7 @@ dependencies = [
  "similar",
  "stop-words",
  "strip-ansi-escapes",
+ "subtle",
  "teloxide",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -26,6 +26,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   and errs the safe way — a spinner that over-runs reads as "still working",
   where stopping early reads as "done" over text that has not arrived.
 
+- **Relay token compared in constant time; reply identity validated
+  server-side** (issue #3761): `POST /api/internal/relay-event` compared its
+  shared secret with `==`, which short-circuits on the first differing byte and
+  leaks the matching-prefix length to a caller able to time its own requests —
+  now a constant-time byte comparison via `subtle::ConstantTimeEq` (length is
+  still checked first; a token's length is not secret). The same treatment is
+  applied to the API bearer token in `auth_middleware`, which is the
+  higher-value of the two secrets since it gates every `/api/*` route. The
+  `SlackReplySent` arm also published `identity` completely unchecked, so any
+  holder of the relay token could stamp a reply with a fabricated speaker such
+  as "CTO Bot (as Bob)" and the mirror pane would render it as truth. The
+  server knows the one honest value (`slack::BOT_IDENTITY`) and now rejects
+  anything else with `422`, mirroring the existing closed-set RBAC tier check
+  on the inbound half.
+
 - **Streamed chat turns now send the same sampling parameters as the blocking
   path** (issue #3758): `llm::stream::stream_reply` built its
   `OpenRouterProvider` with no temperature, token ceiling, or stop sequences, so
@@ -46,6 +61,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   falls back to the blocking chat path.
 
 ### Added
+
+- **`GET /api/events` can scope the Slack mirror to one channel** (refs #3760):
+  `SlackMessageReceived` / `SlackReplySent` carry no `session_id`, and
+  `/api/events` treats a missing session as "always include", so every
+  connected client receives every Slack channel's inbound message text and bot
+  reply — harmless for the single-operator demo, a cross-viewer leak the moment
+  a second client attaches. The stream now accepts an optional `channel` query
+  parameter that scopes the mirror to one Slack channel id (the same key the
+  gateway already keys its session state by, exposed as
+  `Event::slack_channel()`). **This is the server-side capability only.** No
+  client passes `channel=` yet and the mirror pane has no viewer→channel
+  binding, so the leak #3760 describes persists in the product until the client
+  side lands — tracked separately. **Compatibility: the parameter is optional
+  and absent means no filtering**, so an existing client — including the
+  shipped GUI, which opens the stream with no query params — receives exactly
+  what it received before. Events with no channel (keepalives, task telemetry,
+  and `ListenerEventReceived`, which is provider-generic and carries a
+  `listener_id` rather than a channel) always pass a channel filter rather than
+  being suppressed. `EventsQuery` is `deny_unknown_fields`, so a typo'd
+  `?channel_id=` is rejected instead of silently returning an unfiltered
+  stream — these filters fail open when absent, so a misspelling must be loud.
 
 - **Skill-wrapping runtime — one named skill per tool (#3933, DOC-57 §5, epic
   #3931):** a skill had no binding to the tool it described. `web-search.md`

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -122,6 +122,12 @@ shlex = { workspace = true }
 stop-words = "0.8"
 dirs = "5"
 sha2 = "0.10"
+# subtle (#3761): constant-time byte equality for the internal relay's shared
+# secret (`api::server::relay::relay_authorized`). Plain `==` short-circuits on
+# the first differing byte, leaking the matching-prefix length to a caller that
+# can time its own requests. Already present in the lockfile as a transitive
+# dependency of the TLS stack, so declaring it directly adds no new compilation.
+subtle = "2"
 comrak = { workspace = true }
 serde_yaml = { workspace = true }
 toml_edit = "0.22"

--- a/crates/trusty-agents/src/api/server/auth.rs
+++ b/crates/trusty-agents/src/api/server/auth.rs
@@ -16,6 +16,7 @@ use axum::{
     response::{IntoResponse, Response},
 };
 use serde::Serialize;
+use subtle::ConstantTimeEq;
 
 /// Server configuration. (#181, #3329)
 ///
@@ -65,6 +66,28 @@ pub(super) struct AuthState {
     pub(super) token: String,
 }
 
+/// Whether a presented bearer token matches the configured one. (#3761)
+///
+/// Why: Plain `==` short-circuits on the first differing byte, so an attacker
+/// who can time their own requests learns the length of the matching prefix and
+/// can recover the token byte-by-byte instead of brute-forcing it whole. This
+/// is the HIGHER-value of the two secrets the server holds — it gates every
+/// `/api/*` route, not just the internal relay — so it gets the same
+/// constant-time treatment `relay::relay_authorized` does.
+/// What: Rejects on differing length (a token's length is not secret; it is
+/// already observable from the request frame, and `ct_eq` needs equal-length
+/// slices), then compares the bytes in constant time. An empty configured token
+/// is not special-cased here — `auth_middleware` only runs when the operator
+/// configured one (see `routes::build_router_with_config`).
+/// Test: `bearer_token_matches_is_exact`, `auth_middleware_accepts_valid_token`,
+/// `auth_middleware_rejects_wrong_token`.
+pub(super) fn bearer_token_matches(expected: &str, provided: &str) -> bool {
+    if expected.len() != provided.len() {
+        return false;
+    }
+    expected.as_bytes().ct_eq(provided.as_bytes()).into()
+}
+
 /// Bearer-token authentication middleware. (#181)
 ///
 /// Why: The server binds `0.0.0.0`, so any process on the LAN can reach the
@@ -75,9 +98,12 @@ pub(super) struct AuthState {
 /// the token via `/api/config` before issuing authenticated requests.
 /// What: For requests under `/api/*` (other than `/api/health`), checks
 /// `Authorization: Bearer <token>` and returns 401 JSON
-/// `{"error":"unauthorized"}` on mismatch.
+/// `{"error":"unauthorized"}` on mismatch. #3761: the comparison is
+/// constant-time (`bearer_token_matches`) — this is the higher-value secret of
+/// the two the server holds, so it gets the same treatment as the relay token.
 /// Test: `auth_middleware_rejects_missing_token`,
-/// `auth_middleware_accepts_valid_token`, `auth_middleware_allows_health`.
+/// `auth_middleware_accepts_valid_token`, `auth_middleware_allows_health`,
+/// `bearer_token_matches_is_exact`.
 pub(super) async fn auth_middleware(
     State(auth): State<AuthState>,
     req: Request<axum::body::Body>,
@@ -110,7 +136,8 @@ pub(super) async fn auth_middleware(
         .map(str::trim);
 
     match header_val {
-        Some(t) if t == auth.token => next.run(req).await,
+        // #3761: constant-time compare — see `bearer_token_matches`.
+        Some(t) if bearer_token_matches(&auth.token, t) => next.run(req).await,
         _ => (
             StatusCode::UNAUTHORIZED,
             Json(serde_json::json!({ "error": "unauthorized" })),

--- a/crates/trusty-agents/src/api/server/events_sse.rs
+++ b/crates/trusty-agents/src/api/server/events_sse.rs
@@ -5,10 +5,11 @@
 //! events the instant the back-end emits them, cutting perceived latency from
 //! "up to 2 s" to "≤ network RTT" while reducing request load.
 //! What: Subscribes to the process-global `events::bus`, optionally filters to
-//! a single `session_id`, and yields each event as an SSE frame with periodic
-//! keepalive pings.
+//! a single `session_id` and/or a single Slack `channel`, and yields each event
+//! as an SSE frame with periodic keepalive pings.
 //! Test: After `cargo run -- --api --port 7654 &`, `curl -N
-//! http://localhost:7654/api/events` streams events as tasks execute.
+//! http://localhost:7654/api/events` streams events as tasks execute; the pure
+//! filter predicate is covered by `super::tests::events_sse`.
 
 use std::convert::Infallible;
 use std::time::Duration;
@@ -20,29 +21,87 @@ use axum::{
 use serde::Deserialize;
 use tokio_stream::Stream;
 
-use crate::events;
+use crate::events::{self, Event};
 
-/// Query string for `GET /api/events`. (#192 Phase B)
+/// Query string for `GET /api/events`. (#192 Phase B, #3760)
 ///
 /// Why: Lets a single-task UI subscribe only to events for its session
 /// without filtering N other concurrent tasks client-side. When omitted,
 /// the stream emits every event the server's bus produces.
-/// What: Optional `session_id` filter.
-/// Test: Driven via the live `/api/events` stream (integration).
+/// What: Optional `session_id` filter and optional Slack `channel` filter
+/// (#3760). Both are independent and both default to "no filter", so an
+/// existing client that passes neither keeps receiving every event.
+///
+/// `deny_unknown_fields` (#3760): every field here is a SECURITY filter whose
+/// absent form fails OPEN (unfiltered stream). Without it a client that typo'd
+/// `?channel_id=C123` would silently get the full firehose it was trying to
+/// narrow — the exact leak this parameter exists to close, reintroduced by a
+/// spelling mistake and invisible at both ends. Rejecting the request instead
+/// makes the mistake loud. Safe to add: no shipped client sends any other
+/// parameter (`ui/src/lib/transport.ts` sends `session_id` or nothing;
+/// `ui/src-tauri/src/sse_bridge.rs` sends nothing).
+/// Test: `event_passes_*` in `super::tests::events_sse`;
+/// `events_query_rejects_unknown_parameter`,
+/// `events_query_accepts_known_parameters`; end-to-end via the live
+/// `/api/events` stream (integration).
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(super) struct EventsQuery {
     session_id: Option<String>,
+    /// #3760: Slack channel id to scope the Slack conversation mirror to.
+    channel: Option<String>,
 }
 
-/// `GET /api/events?session_id=<optional>` — Server-Sent Events stream of
-/// real-time PM/agent/workflow telemetry. (#192 Phase B)
+/// #3760: Whether one bus event should be delivered to a subscriber holding
+/// the given filters.
+///
+/// Why: The Slack-mirror events carry no `session_id`, so the pre-existing
+/// session filter read them as "always include" and every connected
+/// `/api/events` client received every channel's message text — a leak the
+/// moment more than one viewer is attached. Splitting the predicate out of the
+/// stream body makes both filter dimensions directly testable instead of only
+/// reachable through a live SSE connection.
+/// What: Each filter is applied only to events that expose the corresponding
+/// key. An event whose key is `None` (a `Ping`, or any non-Slack event under a
+/// `channel` filter) always passes — keepalives and task telemetry must not be
+/// suppressed by a Slack-scoping request. Both filters absent ⇒ everything
+/// passes, which is the pre-#3760 behaviour and what the single-operator GUI
+/// relies on.
+/// Test: `event_passes_without_filters`, `event_passes_scopes_slack_by_channel`,
+/// `event_passes_leaves_non_slack_events_alone`,
+/// `event_passes_still_scopes_by_session`.
+pub(super) fn event_passes(
+    event: &Event,
+    session_filter: Option<&str>,
+    channel_filter: Option<&str>,
+) -> bool {
+    if let Some(sid) = session_filter
+        && let Some(ev_sid) = event.session_id()
+        && ev_sid != sid
+    {
+        return false;
+    }
+    if let Some(chan) = channel_filter
+        && let Some(ev_chan) = event.slack_channel()
+        && ev_chan != chan
+    {
+        return false;
+    }
+    true
+}
+
+/// `GET /api/events?session_id=<optional>&channel=<optional>` — Server-Sent
+/// Events stream of real-time PM/agent/workflow telemetry. (#192 Phase B,
+/// #3760)
 ///
 /// Why: Replaces the 2-second `setInterval` poll the UI used to hit
 /// `/api/tasks` with. SSE keeps a single long-lived HTTP connection open and
 /// pushes events the instant the back-end emits them, cutting perceived
 /// latency from "up to 2 s" to "≤ network RTT" while reducing request load.
 /// What: Subscribes to the process-global `events::bus`, optionally filters
-/// to a single `session_id`, and yields each event as `event: event\ndata:
+/// to a single `session_id` and/or a single Slack `channel` (#3760 — absent
+/// means "no filter", so existing single-operator clients are unchanged), and
+/// yields each surviving event as `event: event\ndata:
 /// <json>\n\n`. Emits `event: ping\ndata: {}` every 15 s as a keepalive so
 /// reverse proxies and mobile networks don't reap idle connections. On
 /// `RecvError::Lagged(n)` (slow subscriber), yields one `event: lag\ndata:
@@ -55,7 +114,9 @@ pub(super) async fn events_handler(
     Query(params): Query<EventsQuery>,
 ) -> Sse<impl Stream<Item = Result<SseEvent, Infallible>>> {
     let mut rx = events::subscribe();
-    let filter = params.session_id;
+    let session_filter = params.session_id;
+    // #3760: optional Slack-channel scope for the conversation mirror.
+    let channel_filter = params.channel;
 
     // `async_stream::stream!` lets us write linear-looking code that yields
     // SSE events; the macro lowers it to a poll-based `Stream`.
@@ -71,13 +132,16 @@ pub(super) async fn events_handler(
                 result = rx.recv() => {
                     match result {
                         Ok(event) => {
-                            // Filter by session_id when the client requested one.
-                            // `Ping` (session_id == None) always passes — keepalives
-                            // must reach every subscriber.
-                            if let Some(ref sid) = filter
-                                && let Some(ev_sid) = event.session_id()
-                                && ev_sid != sid.as_str()
-                            {
+                            // Filter by session_id and/or Slack channel when the
+                            // client requested them. `Ping` (no session, no channel)
+                            // always passes — keepalives must reach every subscriber.
+                            // #3760: the channel dimension is what keeps a Slack
+                            // mirror from fanning out to every connected viewer.
+                            if !event_passes(
+                                &event,
+                                session_filter.as_deref(),
+                                channel_filter.as_deref(),
+                            ) {
                                 continue;
                             }
                             let data = serde_json::to_string(&event)

--- a/crates/trusty-agents/src/api/server/relay.rs
+++ b/crates/trusty-agents/src/api/server/relay.rs
@@ -9,9 +9,11 @@
 //! re-publishes it locally — a minimal relay.
 //! What: `POST /api/internal/relay-event` accepts one JSON `Event` ONLY when the
 //! caller presents the shared relay secret (`x-relay-token` header matching the
-//! `TAGENT_RELAY_TOKEN` env on this process); it then rejects any kind that is
-//! not a `Slack*` mirror event (whitelist) and any `SlackMessageReceived` whose
-//! `tier` is not a known `ServiceTier`, and publishes what survives. The route
+//! `TAGENT_RELAY_TOKEN` env on this process, compared in constant time —
+//! #3761); it then rejects any kind that is not a `Slack*` mirror event
+//! (whitelist), any `SlackMessageReceived` whose `tier` is not a known
+//! `ServiceTier`, and any `SlackReplySent` whose `identity` is not the one
+//! honest bot label (#3761), and publishes what survives. The route
 //! also inherits the router-wide same-origin write guard + optional bearer auth
 //! from `routes::build_router_with_origins`, but the mandatory shared secret is
 //! the load-bearing control: the origin guard fails OPEN for absent-`Origin`
@@ -23,6 +25,7 @@
 //! `relay_rejects_wrong_token`, `relay_rejects_when_token_unset_server_side`,
 //! `relay_rejects_non_slack_kind`, `relay_rejects_unknown_tier`,
 //! `relay_rejects_malformed_body`, `relay_authorized_fails_closed_when_unset`,
+//! `relay_rejects_unknown_identity`, `relay_accepts_honest_identity`,
 //! `tier_is_known_accepts_the_closed_set` in `super::tests::relay`.
 
 use axum::{
@@ -30,6 +33,7 @@ use axum::{
     http::{HeaderMap, StatusCode},
     response::{IntoResponse, Response},
 };
+use subtle::ConstantTimeEq;
 
 use crate::events::{self, Event};
 
@@ -48,14 +52,47 @@ pub(super) const RELAY_TOKEN_ENV: &str = "TAGENT_RELAY_TOKEN";
 /// of a configured secret must therefore DENY, never allow.
 /// What: Returns `true` only when `expected` is present and non-empty AND
 /// `provided` equals it exactly. Any `None`/empty `expected` (secret not
-/// configured server-side) → `false`.
+/// configured server-side) → `false`. #3761: the byte comparison is
+/// constant-time (`subtle::ConstantTimeEq`) rather than `==`, whose
+/// short-circuit on the first differing byte leaks the length of the matching
+/// prefix to a caller that can time its own requests. The length check that
+/// precedes it is deliberately NOT constant-time: a token's length is already
+/// observable from the request frame, so only its BYTES are secret.
 /// Test: `relay_authorized_fails_closed_when_unset`,
 /// `relay_authorized_requires_exact_match`.
 pub(super) fn relay_authorized(expected: Option<&str>, provided: Option<&str>) -> bool {
-    match expected {
-        Some(exp) if !exp.is_empty() => provided == Some(exp),
-        _ => false,
+    // #3761: fail closed on an unset/empty server-side secret before any
+    // comparison happens.
+    let Some(exp) = expected.filter(|e| !e.is_empty()) else {
+        return false;
+    };
+    let Some(got) = provided else {
+        return false;
+    };
+    // #3761: length is not secret; differing lengths can never be equal, and
+    // `ct_eq` requires equal-length slices anyway.
+    if exp.len() != got.len() {
+        return false;
     }
+    exp.as_bytes().ct_eq(got.as_bytes()).into()
+}
+
+/// Whether `identity` is the ONE honest reply-speaker label. (#3761)
+///
+/// Why: `identity` is rendered verbatim by the mirror pane as "who said this",
+/// and the relay published it unchecked — any holder of the shared token (or a
+/// buggy gateway build) could stamp a reply with a fabricated speaker such as
+/// "Masa" or "CTO Bot (as Bob)", which is exactly the impersonation the pane's
+/// honesty contract forbids. The server knows the only truthful value, so it
+/// validates rather than trusts, mirroring the closed-set `tier` check on the
+/// inbound half.
+/// What: `true` iff `identity` is exactly `slack::BOT_IDENTITY` — the bot
+/// always replies AS ITSELF; there is no impersonation mode in code, so there
+/// is no second legitimate value to admit.
+/// Test: `identity_is_honest_accepts_only_the_bot_label`,
+/// `relay_rejects_unknown_identity`, `relay_accepts_honest_identity`.
+pub(super) fn identity_is_honest(identity: &str) -> bool {
+    identity == crate::slack::BOT_IDENTITY
 }
 
 /// Whether `tier` names a known `ServiceTier` (the closed RBAC set).
@@ -76,14 +113,17 @@ pub(super) fn tier_is_known(tier: &str) -> bool {
 ///
 /// Why: See the module doc — the whitelist bounds WHICH events can be injected;
 /// the shared secret bounds WHO can inject them (fail closed); the tier check
-/// bounds what a badge can claim.
+/// bounds what an inbound badge can claim; the identity check (#3761) bounds
+/// what a reply can claim to be spoken by.
 /// What: `401` when the secret is unset server-side or the `x-relay-token`
 /// header is missing/wrong; `400` for a well-formed non-`Slack*` event; `422`
-/// for an unknown tier (or a body that does not deserialize to `Event`, via the
-/// `Json` extractor); `202 Accepted` + publish otherwise.
+/// for an unknown tier, a dishonest reply identity, or a body that does not
+/// deserialize to `Event` (via the `Json` extractor); `202 Accepted` + publish
+/// otherwise.
 /// Test: `relay_accepts_with_matching_token`, `relay_rejects_missing_token`,
 /// `relay_rejects_wrong_token`, `relay_rejects_when_token_unset_server_side`,
-/// `relay_rejects_non_slack_kind`, `relay_rejects_unknown_tier`.
+/// `relay_rejects_non_slack_kind`, `relay_rejects_unknown_tier`,
+/// `relay_rejects_unknown_identity`, `relay_accepts_honest_identity`.
 pub(super) async fn relay_event_handler(headers: HeaderMap, Json(event): Json<Event>) -> Response {
     // Mandatory shared-secret gate (fail closed).
     let expected = std::env::var(RELAY_TOKEN_ENV).ok();
@@ -114,7 +154,18 @@ pub(super) async fn relay_event_handler(headers: HeaderMap, Json(event): Json<Ev
             events::publish(event);
             StatusCode::ACCEPTED.into_response()
         }
-        Event::SlackReplySent { .. } => {
+        Event::SlackReplySent { identity, .. } => {
+            // #3761: the reply's speaker label was published unchecked; the
+            // server knows the single honest value, so reject anything else
+            // rather than let the pane render a forged identity. Mirrors the
+            // unknown-tier rejection above.
+            if !identity_is_honest(identity) {
+                return (
+                    StatusCode::UNPROCESSABLE_ENTITY,
+                    Json(serde_json::json!({ "error": "unknown reply identity" })),
+                )
+                    .into_response();
+            }
             events::publish(event);
             StatusCode::ACCEPTED.into_response()
         }

--- a/crates/trusty-agents/src/api/server/tests/events_sse.rs
+++ b/crates/trusty-agents/src/api/server/tests/events_sse.rs
@@ -1,0 +1,193 @@
+//! Tests for the `/api/events` SSE delivery filter (#192 Phase B, #3760).
+//!
+//! Why: The Slack conversation mirror leaked across clients — `SlackMessageReceived`
+//! / `SlackReplySent` carry no `session_id`, so the pre-#3760 filter read them as
+//! "always include" and every connected `/api/events` subscriber received every
+//! channel's message text. These cases lock the new `channel` scope AND, just as
+//! importantly, lock the compatibility case: a client that sends no filters must
+//! still receive everything, because that is exactly what the shipped
+//! single-operator GUI does.
+//! What: Exercises `events_sse::event_passes`, the pure predicate the stream body
+//! calls per bus event, rather than driving a live SSE connection — the filtering
+//! decision is the whole contract and it is directly observable here.
+//! Test: this module IS the test.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::api::server::events_sse::event_passes;
+use crate::api::server::routes::build_router;
+use crate::api::server::state::AppState;
+use crate::events::Event;
+
+fn inbound(channel: &str) -> Event {
+    Event::SlackMessageReceived {
+        channel: channel.into(),
+        user_display: "Masa".into(),
+        text: "deploy status?".into(),
+        tier: "all".into(),
+    }
+}
+
+fn reply(channel: &str) -> Event {
+    Event::SlackReplySent {
+        channel: channel.into(),
+        text: "green".into(),
+        identity: crate::slack::BOT_IDENTITY.into(),
+    }
+}
+
+fn listener_event() -> Event {
+    Event::ListenerEventReceived {
+        listener_id: "slack".into(),
+        provider: "slack".into(),
+        event_type: "message".into(),
+        summary: "Masa: deploy status?".into(),
+        included: true,
+    }
+}
+
+fn task_event(session_id: &str) -> Event {
+    Event::PmThinking {
+        session_id: session_id.into(),
+        text: "planning".into(),
+    }
+}
+
+// -- compatibility: no filters means no filtering -----------------------------
+
+#[test]
+fn event_passes_without_filters() {
+    // The shipped GUI opens `/api/events` with no query params at all. Every
+    // event kind must still reach it — #3760 must not narrow the default.
+    for ev in [
+        inbound("C0123ABC"),
+        reply("C0123ABC"),
+        listener_event(),
+        task_event("sess-1"),
+        Event::Ping,
+    ] {
+        assert!(
+            event_passes(&ev, None, None),
+            "unfiltered subscriber must receive {ev:?}"
+        );
+    }
+}
+
+// -- #3760: channel scoping ---------------------------------------------------
+
+#[test]
+fn event_passes_scopes_slack_by_channel() {
+    // A client scoped to one channel sees that channel's BOTH halves...
+    assert!(event_passes(&inbound("C0123ABC"), None, Some("C0123ABC")));
+    assert!(event_passes(&reply("C0123ABC"), None, Some("C0123ABC")));
+    // ...and none of another channel's — this is the leak #3760 reported.
+    assert!(!event_passes(&inbound("C_OTHER"), None, Some("C0123ABC")));
+    assert!(!event_passes(&reply("C_OTHER"), None, Some("C0123ABC")));
+}
+
+#[test]
+fn event_passes_leaves_non_slack_events_alone() {
+    // Events that carry no channel always pass a channel filter. Suppressing
+    // keepalives would kill the connection; suppressing task telemetry or the
+    // provider-generic listener stream would silently blank unrelated panes.
+    // `ListenerEventReceived` is deliberately NOT channel-scoped (see the doc
+    // comment on `Event::slack_channel`): it has no channel to scope by.
+    assert!(event_passes(&Event::Ping, None, Some("C0123ABC")));
+    assert!(event_passes(&task_event("sess-1"), None, Some("C0123ABC")));
+    assert!(event_passes(&listener_event(), None, Some("C0123ABC")));
+}
+
+// -- pre-existing session scoping still holds ---------------------------------
+
+#[test]
+fn event_passes_still_scopes_by_session() {
+    assert!(event_passes(&task_event("sess-1"), Some("sess-1"), None));
+    assert!(!event_passes(&task_event("sess-2"), Some("sess-1"), None));
+    // A session filter must never suppress keepalives.
+    assert!(event_passes(&Event::Ping, Some("sess-1"), None));
+    // ...nor the Slack mirror, which has no session to match against: the two
+    // filter dimensions are independent, so a session-scoped client that wants
+    // no Slack traffic scopes the channel too.
+    assert!(event_passes(&inbound("C0123ABC"), Some("sess-1"), None));
+}
+
+// -- #3760: a mistyped filter must fail LOUD, never fail open ----------------
+
+/// Open `/api/events` with the given query string and return the status.
+///
+/// The SSE handler streams forever once it is entered, so we only ever assert
+/// on the response STATUS here — reaching a 200 means the `Query<EventsQuery>`
+/// extractor accepted the parameters, which is the whole contract under test.
+async fn get_events(query: &str) -> StatusCode {
+    let app = build_router(AppState::default());
+    let req = Request::builder()
+        .uri(format!("/api/events{query}"))
+        .body(Body::empty())
+        .unwrap();
+    app.oneshot(req).await.unwrap().status()
+}
+
+#[tokio::test]
+async fn events_query_rejects_unknown_parameter() {
+    // Every field on `EventsQuery` is a security filter whose ABSENT form fails
+    // open (unfiltered stream). Without `deny_unknown_fields` a typo'd
+    // `?channel_id=` would silently hand back the full firehose the caller was
+    // trying to narrow — the #3760 leak, reintroduced by a spelling mistake and
+    // invisible at both ends.
+    assert!(
+        get_events("?channel_id=C0123ABC").await.is_client_error(),
+        "a typo'd filter parameter must be rejected, not silently ignored"
+    );
+    assert!(get_events("?sessionId=sess-1").await.is_client_error());
+    assert!(
+        get_events("?channel=C0123ABC&bogus=1")
+            .await
+            .is_client_error()
+    );
+}
+
+#[tokio::test]
+async fn events_query_accepts_known_parameters() {
+    // The compatibility surface: no params, each param alone, and both
+    // together must all be accepted. No shipped client sends anything else
+    // (transport.ts sends `session_id` or nothing; sse_bridge.rs sends nothing).
+    for q in [
+        "",
+        "?session_id=sess-1",
+        "?channel=C0123ABC",
+        "?session_id=sess-1&channel=C0123ABC",
+    ] {
+        assert_eq!(
+            get_events(q).await,
+            StatusCode::OK,
+            "query {q:?} must be accepted"
+        );
+    }
+}
+
+#[test]
+fn event_passes_applies_both_filters_independently() {
+    // Both set: each event is judged only by the key it actually carries.
+    assert!(event_passes(
+        &task_event("sess-1"),
+        Some("sess-1"),
+        Some("C0123ABC")
+    ));
+    assert!(!event_passes(
+        &task_event("sess-2"),
+        Some("sess-1"),
+        Some("C0123ABC")
+    ));
+    assert!(event_passes(
+        &reply("C0123ABC"),
+        Some("sess-1"),
+        Some("C0123ABC")
+    ));
+    assert!(!event_passes(
+        &reply("C_OTHER"),
+        Some("sess-1"),
+        Some("C0123ABC")
+    ));
+}

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -11,6 +11,7 @@ mod agent_skills;
 mod agent_stores;
 mod cancel;
 mod ctrl_sessions;
+mod events_sse;
 mod guard;
 mod listener_events;
 mod listing;
@@ -217,6 +218,38 @@ async fn auth_middleware_rejects_wrong_token() {
         .unwrap();
     let resp = app.oneshot(req).await.unwrap();
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn auth_middleware_rejects_same_length_wrong_token() {
+    // #3761: the compare is now length-check-then-`ct_eq`. The pre-existing
+    // wrong-token case ("wrong" vs "secret") differs in LENGTH, so it only
+    // exercises the shortcut; this one is equal-length and must still 401.
+    let app = auth_router("secret");
+    let req = Request::builder()
+        .uri("/api/tasks")
+        .header(header::AUTHORIZATION, "Bearer secreT")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[test]
+fn bearer_token_matches_is_exact() {
+    use super::auth::bearer_token_matches;
+    // #3761: constant-time, but behaviourally identical to the `==` it
+    // replaced. Pin the cases a length-first / byte-loop compare could break.
+    assert!(bearer_token_matches("secret", "secret"));
+    assert!(!bearer_token_matches("secret", "secreT")); // last byte
+    assert!(!bearer_token_matches("secret", "Secret")); // first byte
+    assert!(!bearer_token_matches("secret", "secre")); // shorter
+    assert!(!bearer_token_matches("secret", "secrets")); // longer
+    assert!(!bearer_token_matches("secret", "")); // empty
+    // Multi-byte UTF-8 of equal byte length: compared as bytes, no panic on a
+    // char boundary.
+    assert!(bearer_token_matches("tökén-π", "tökén-π"));
+    assert!(!bearer_token_matches("tökén-π", "tökén-ω"));
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/api/server/tests/relay.rs
+++ b/crates/trusty-agents/src/api/server/tests/relay.rs
@@ -5,7 +5,8 @@
 //! security-relevant: it is the load-bearing honesty control for the mirror
 //! pane, so it must FAIL CLOSED without the shared secret, reject a wrong/
 //! missing token, accept only with a matching token, then accept only the two
-//! `Slack*` kinds with a known RBAC tier. These cases lock that contract.
+//! `Slack*` kinds with a known RBAC tier and (#3761) an honest reply identity.
+//! These cases lock that contract.
 //! What: oneshots the endpoint on a default (loopback-only) router — the origin
 //! guard fails open on the absent `Origin` header (the real server-to-server
 //! posture), so the shared-secret gate is what actually protects the route.
@@ -20,7 +21,7 @@ use axum::body::Body;
 use axum::http::{Method, Request, StatusCode, header};
 use tower::ServiceExt;
 
-use crate::api::server::relay::{relay_authorized, tier_is_known};
+use crate::api::server::relay::{identity_is_honest, relay_authorized, tier_is_known};
 use crate::api::server::routes::build_router;
 use crate::api::server::state::AppState;
 use crate::events;
@@ -67,6 +68,47 @@ fn inbound_body(tier: &str) -> String {
         tier: tier.into(),
     })
     .unwrap()
+}
+
+/// #3761: a reply-half body carrying an arbitrary speaker label.
+fn reply_body(channel: &str, identity: &str) -> String {
+    serde_json::to_string(&events::Event::SlackReplySent {
+        channel: channel.into(),
+        text: "all green".into(),
+        identity: identity.into(),
+    })
+    .unwrap()
+}
+
+/// Drain everything currently queued for `rx` on the process-global bus,
+/// reporting how many events the channel dropped underneath us.
+///
+/// Why: `while let Ok(ev) = rx.try_recv()` — the idiom these tests used — stops
+/// at the FIRST `Err`, and `TryRecvError::Lagged(n)` IS an `Err`. On a busy bus
+/// (every other test in this binary publishes to the same global channel) that
+/// silently truncates the drain. In a positive test that is a flake; in a
+/// negative test asserting "nothing reached the bus" it is worse — the
+/// assertion passes VACUOUSLY in exactly the case where events were dropped
+/// unseen. Continuing past `Lagged` and surfacing the count lets a caller
+/// refuse to conclude anything from a truncated view.
+/// What: Returns `(events, skipped)`; `skipped` totals the events the broadcast
+/// channel reported as dropped for this receiver. Stops on `Empty`/`Closed`.
+/// Test: used by `relay_accepts_with_matching_token`,
+/// `relay_accepts_honest_identity`, `relay_rejects_unknown_identity`.
+fn drain_bus(
+    rx: &mut tokio::sync::broadcast::Receiver<events::Event>,
+) -> (Vec<events::Event>, u64) {
+    use tokio::sync::broadcast::error::TryRecvError;
+    let mut drained = Vec::new();
+    let mut skipped = 0u64;
+    loop {
+        match rx.try_recv() {
+            Ok(ev) => drained.push(ev),
+            Err(TryRecvError::Lagged(n)) => skipped += n,
+            Err(TryRecvError::Empty | TryRecvError::Closed) => break,
+        }
+    }
+    (drained, skipped)
 }
 
 // -- shared-secret gate (fail closed) ---------------------------------------
@@ -121,19 +163,20 @@ async fn relay_accepts_with_matching_token() {
         StatusCode::ACCEPTED
     );
 
-    // The bus is process-global, so drain and find our unique event.
-    let mut found = false;
-    while let Ok(ev) = rx.try_recv() {
-        if let events::Event::SlackMessageReceived { channel, tier, .. } = ev
-            && channel == unique_channel
-        {
-            assert_eq!(tier, "all");
-            found = true;
-        }
-    }
+    // The bus is process-global, so drain and find our unique event. `drain_bus`
+    // survives a `Lagged` notice instead of stopping at it.
+    let (drained, skipped) = drain_bus(&mut rx);
+    let found = drained.iter().any(|ev| {
+        matches!(
+            ev,
+            events::Event::SlackMessageReceived { channel, tier, .. }
+                if channel == unique_channel && tier == "all"
+        )
+    });
     assert!(
         found,
-        "relay did not publish the injected event onto the bus"
+        "relay did not publish the injected event onto the bus \
+         ({skipped} event(s) were dropped by broadcast lag)"
     );
     set_relay_env(None);
 }
@@ -159,6 +202,80 @@ async fn relay_rejects_unknown_tier() {
     // A tier outside the closed ServiceTier set must not become a badge.
     let status = post_relay(&inbound_body("root"), Some("s3cret")).await;
     assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
+    set_relay_env(None);
+}
+
+// -- #3761: reply identity must be the one honest label --------------------
+
+#[tokio::test]
+async fn relay_rejects_unknown_identity() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
+
+    // Subscribe first so we can prove NOTHING was published, not merely that
+    // the status was 422.
+    let mut rx = events::subscribe();
+    let unique_channel = "C_RELAY_FORGED_IDENTITY";
+
+    // A valid-token holder must still not be able to stamp a reply with a
+    // fabricated speaker — that is the impersonation the pane forbids.
+    for forged in ["CTO Bot (as Bob)", "Masa", "", "cto bot (as itself)"] {
+        assert_eq!(
+            post_relay(&reply_body(unique_channel, forged), Some("s3cret")).await,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "identity {forged:?} must be rejected"
+        );
+    }
+
+    let (drained, skipped) = drain_bus(&mut rx);
+    // A truncated view cannot prove absence. If the bus lagged, FAIL rather
+    // than let "nothing reached the bus" pass vacuously.
+    assert_eq!(
+        skipped, 0,
+        "the bus dropped {skipped} event(s); this test cannot prove the forged \
+         reply was absent from a truncated view"
+    );
+    for ev in &drained {
+        if let events::Event::SlackReplySent {
+            channel, identity, ..
+        } = ev
+        {
+            assert_ne!(
+                channel, unique_channel,
+                "a forged-identity reply reached the bus (identity {identity:?})"
+            );
+        }
+    }
+    set_relay_env(None);
+}
+
+#[tokio::test]
+async fn relay_accepts_honest_identity() {
+    let _g = RELAY_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set_relay_env(Some("s3cret"));
+
+    let mut rx = events::subscribe();
+    let unique_channel = "C_RELAY_HONEST_IDENTITY";
+    let body = reply_body(unique_channel, crate::slack::BOT_IDENTITY);
+
+    assert_eq!(
+        post_relay(&body, Some("s3cret")).await,
+        StatusCode::ACCEPTED
+    );
+
+    let (drained, skipped) = drain_bus(&mut rx);
+    let found = drained.iter().any(|ev| {
+        matches!(
+            ev,
+            events::Event::SlackReplySent { channel, identity, .. }
+                if channel == unique_channel && identity == crate::slack::BOT_IDENTITY
+        )
+    });
+    assert!(
+        found,
+        "the honest reply was not published onto the bus \
+         ({skipped} event(s) were dropped by broadcast lag)"
+    );
     set_relay_env(None);
 }
 
@@ -189,6 +306,44 @@ fn relay_authorized_requires_exact_match() {
     assert!(relay_authorized(Some("abc"), Some("abc")));
     assert!(!relay_authorized(Some("abc"), Some("abcd")));
     assert!(!relay_authorized(Some("abc"), None));
+
+    // #3761: the compare is now constant-time (`subtle::ConstantTimeEq`).
+    // Correctness must be identical to the `==` it replaced, so pin the cases
+    // a length-first / byte-loop implementation is most likely to get wrong.
+    // Shorter, longer, and equal-length-but-different provided values:
+    assert!(!relay_authorized(Some("abc"), Some("ab")));
+    assert!(!relay_authorized(Some("abc"), Some("abd")));
+    assert!(!relay_authorized(Some("abc"), Some("")));
+    // Differs only in the LAST byte (the case `==`'s short-circuit made
+    // slowest to reject) and only in the FIRST (the fastest):
+    assert!(!relay_authorized(
+        Some("s3cret-token"),
+        Some("s3cret-tokeN")
+    ));
+    assert!(!relay_authorized(
+        Some("s3cret-token"),
+        Some("S3cret-token")
+    ));
+    // Long exact match still succeeds, and multi-byte UTF-8 is compared by
+    // bytes without panicking on a char boundary.
+    assert!(relay_authorized(
+        Some("a-fairly-long-shared-secret-0123456789"),
+        Some("a-fairly-long-shared-secret-0123456789")
+    ));
+    assert!(relay_authorized(Some("tökén-π"), Some("tökén-π")));
+    assert!(!relay_authorized(Some("tökén-π"), Some("tökén-ω")));
+}
+
+#[test]
+fn identity_is_honest_accepts_only_the_bot_label() {
+    // #3761: exactly one honest value — the bot always speaks as itself.
+    assert!(identity_is_honest(crate::slack::BOT_IDENTITY));
+    assert!(!identity_is_honest("CTO Bot (as Bob)"));
+    assert!(!identity_is_honest("Masa"));
+    assert!(!identity_is_honest(""));
+    // No case- or whitespace-insensitive near-misses.
+    assert!(!identity_is_honest("cto bot (as itself)"));
+    assert!(!identity_is_honest(" CTO Bot (as itself) "));
 }
 
 #[test]

--- a/crates/trusty-agents/src/events.rs
+++ b/crates/trusty-agents/src/events.rs
@@ -371,9 +371,79 @@ impl Event {
             // Slack-mirror and listener events are conversation/harness-scoped,
             // not task-scoped: like `Ping` they carry no `session_id`, so they
             // always pass the SSE session filter and reach the GUI's
-            // app-lifetime EventSource.
+            // app-lifetime EventSource. #3760: the Slack pair is instead
+            // scoped by `slack_channel()` below.
             Event::SlackMessageReceived { .. }
             | Event::SlackReplySent { .. }
+            | Event::ListenerEventReceived { .. }
+            | Event::Ping => None,
+        }
+    }
+
+    /// #3760: Return the Slack channel id this event belongs to, if any. Used
+    /// by the SSE handler to scope the Slack conversation mirror to one
+    /// channel instead of broadcasting it to every connected client.
+    ///
+    /// Why: `session_id()` returns `None` for the Slack-mirror pair, which the
+    /// SSE filter reads as "always include" — so with several viewers attached
+    /// to `/api/events`, every one of them received every channel's inbound
+    /// message and reply text. The mirror events already carry the only key
+    /// that can separate them (`channel`, the Slack channel id the gateway
+    /// itself keys its session state by), so exposing it here gives the SSE
+    /// filter a scoping dimension without inventing a new correlation id or
+    /// changing the wire format.
+    /// What: `Some(&str)` for `SlackMessageReceived` / `SlackReplySent`;
+    /// `None` for everything else, which the SSE filter treats as "always
+    /// include" — exactly as it treats `session_id() == None`.
+    ///
+    /// `ListenerEventReceived` deliberately returns `None`, and the reason is
+    /// narrower than "it has no channel". It has no channel FIELD: the variant
+    /// is provider-generic (Gmail, Calendar, and the Slack gateway all emit it
+    /// keyed only by `listener_id`, and the gateway's rows use the fixed id
+    /// `"slack"` for the whole workspace). A Slack-emitted row does embed the
+    /// channel — but only as free text inside the human-facing `summary`
+    /// display string (`slack::handlers` formats it as `"{channel}: {snippet}"`).
+    /// Parsing a display string to recover a security-scoping key is not an
+    /// acceptable filter input: the format exists to be read by a human and can
+    /// be changed by anyone editing that line, and a channel id is not
+    /// distinguishable from a snippet that merely contains a colon. The real
+    /// scoping axis for the Events pane is `listener_id`, which is a structured
+    /// field; that axis is tracked as a follow-up rather than overloaded onto
+    /// the `channel` parameter here.
+    ///
+    /// Deliberately NOT a `_ => None` wildcard: this is the one function whose
+    /// entire job is deciding the scoping key, so a future `SlackReactionAdded`
+    /// / `SlackThreadReply` must fail to compile until someone decides whether
+    /// it is channel-scoped, rather than defaulting to the broadcast-to-all
+    /// behaviour that caused #3760 in the first place.
+    pub fn slack_channel(&self) -> Option<&str> {
+        match self {
+            Event::SlackMessageReceived { channel, .. } | Event::SlackReplySent { channel, .. } => {
+                Some(channel)
+            }
+            Event::SessionStarted { .. }
+            | Event::SessionDone { .. }
+            | Event::SessionCancelled { .. }
+            | Event::PmThinking { .. }
+            | Event::PmDelegating { .. }
+            | Event::AgentSpawned { .. }
+            | Event::AgentMessage { .. }
+            | Event::AgentMessageDelta { .. }
+            | Event::AgentDone { .. }
+            | Event::AgentFailed { .. }
+            | Event::ToolCalled { .. }
+            | Event::ToolResult { .. }
+            | Event::AstOperation { .. }
+            | Event::PhaseStarted { .. }
+            | Event::PhaseDone { .. }
+            | Event::PhaseSkipped { .. }
+            | Event::PersonaDetected { .. }
+            | Event::RunResumed { .. }
+            | Event::LlmRequested { .. }
+            | Event::LlmResponded { .. }
+            | Event::AgentStarted { .. }
+            | Event::ReportGenerated { .. }
+            | Event::RecapGenerated { .. }
             | Event::ListenerEventReceived { .. }
             | Event::Ping => None,
         }

--- a/crates/trusty-agents/src/slack/mod.rs
+++ b/crates/trusty-agents/src/slack/mod.rs
@@ -56,6 +56,12 @@ pub use pairing::{
     PendingPairs, SENTINEL_PAIRING_CHANNEL_ID, issue_repl_pairing_code, new_pending_pairs,
 };
 pub use rbac::{SlackRbacConfig, SlackUserConfig};
+// #3761: the API process's relay endpoint validates an incoming
+// `SlackReplySent.identity` against the ONE honest speaker label, so the
+// constant must be reachable outside this module. Re-exported (rather than
+// duplicated) so the gateway that stamps it and the server that checks it can
+// never drift apart.
+pub(crate) use relay::BOT_IDENTITY;
 
 /// Max processed envelopes tracked for dedup (LRU-style).
 ///

--- a/crates/trusty-agents/src/slack/relay.rs
+++ b/crates/trusty-agents/src/slack/relay.rs
@@ -44,7 +44,11 @@ const RELAY_TOKEN_HEADER: &str = "x-relay-token";
 
 /// Honest reply-speaker label. The bot always replies AS ITSELF — there is no
 /// "as-Bob" impersonation mode in code, so the mirror must never claim one.
-pub(super) const BOT_IDENTITY: &str = "CTO Bot (as itself)";
+///
+/// #3761: `pub(crate)` (re-exported as `crate::slack::BOT_IDENTITY`) because
+/// the `--api` process's relay endpoint validates every inbound
+/// `SlackReplySent.identity` against this exact value.
+pub(crate) const BOT_IDENTITY: &str = "CTO Bot (as itself)";
 
 /// Render an RBAC `ServiceTier` as its snake_case badge label.
 ///


### PR DESCRIPTION
Two defects in the Slack conversation-mirror path in `crates/trusty-agents` — same subsystem (relay/SSE), landed together.

> **Scope honesty up front.** This PR **closes #3761**. It **does not close #3760** — it delivers the *server-side capability* for channel scoping, but no client passes the new parameter yet, so the leak #3760 describes is still live in the product after this merge. Details in the #3760 section below; client-side work is tracked in **#3988**.

## #3761 — relay + auth hardening (CLOSED by this PR)

**(a) Constant-time token compares.** `relay_authorized` (`api/server/relay.rs`) used `provided == Some(exp)`, whose short-circuit on the first differing byte leaks the length of the matching prefix to a caller able to time its own requests. Now `subtle::ConstantTimeEq` over the token bytes. The length check still runs first and is deliberately *not* constant-time: a token's length is already observable from the request frame, so only its bytes are secret.

The **API bearer token** in `auth::auth_middleware` had the identical flaw and is the higher-value of the two secrets — it gates every `/api/*` route, not just the internal relay — so it gets the same treatment via a new `bearer_token_matches`. `subtle` was already in `Cargo.lock` as a transitive dependency of the TLS stack, so the direct declaration adds no new compilation.

**(b) `SlackReplySent.identity` validated server-side.** The reply arm published `identity` with no check at all, unlike the inbound arm whose `tier` goes through `tier_is_known`. Any holder of the relay token (or a buggy gateway build) could stamp a reply with a fabricated speaker such as `"CTO Bot (as Bob)"` and the mirror pane would render it as truth — exactly the impersonation the pane's honesty contract forbids. The server knows the only honest value, `slack::BOT_IDENTITY` (`"CTO Bot (as itself)"` — the bot always replies as itself; there is no impersonation mode in code), so the new `identity_is_honest` check rejects anything else with **422**, mirroring the existing tier rejection. `BOT_IDENTITY` was widened to `pub(crate)` and re-exported from `slack` so the gateway that stamps it and the server that checks it can never drift apart.

## #3760 — channel-scopable SSE (REFS, not Closes — server side only)

`SlackMessageReceived` / `SlackReplySent` carry no `session_id`, and `Event::session_id()` returned `None` for them (`events.rs`). The `/api/events` SSE filter reads a missing session as **"always include"**, so every connected client receives every Slack channel's inbound message text and bot reply.

**What this PR adds** (both mirror events already carry `channel: String`, and the gateway already keys its session state by `ChannelId`, so the scoping key exists — no wire-format change or new correlation id needed):

- `Event::slack_channel() -> Option<&str>` — `Some` for the two Slack-mirror variants, `None` otherwise.
- `channel` as an optional query parameter on `GET /api/events`.
- `events_sse::event_passes(event, session_filter, channel_filter)` — the filter predicate extracted out of the stream body so both dimensions are directly testable instead of only reachable through a live SSE connection.

### Why this does not close #3760

Nothing consumes the new capability, so an operator sees no behavioural change:

- `ui/src/lib/transport.ts:366-369` builds the URL as `?session_id=…` or bare `/api/events` — never `channel=`.
- `ui/src-tauri/src/sse_bridge.rs:59` opens `/api/events` with no query parameters at all.
- `ui/src/lib/slack-mirror.ts` renders every mirror event into one pane; there is no viewer→channel binding for a client to pass even if the transport supported it.

**The cross-viewer leak therefore persists until the client side lands.** Filed as **#3988**, which carries three facets: (1) mirror-pane channel binding + passing `channel=` through both transports; (2) the `listener_id` scoping axis for `ListenerEventReceived`; (3) `GET /api/listener-events`, which serves every stored Slack snippet cross-viewer from the shared `EventStore` — same leak family, different endpoint, predates this PR, and would silently defeat a scoped stream if left unscoped.

### Compatibility — explicitly unbroken

**The `channel` parameter is optional and absent means no filtering.** A client that sends no query params receives exactly what it received before this PR — which is what the shipped GUI does. `event_passes_without_filters` and `events_query_accepts_known_parameters` lock this as regression tests rather than leaving it to inspection.

Events that carry no channel always pass a channel filter rather than being suppressed — keepalives (`Ping`) and task telemetry must never be silenced by a Slack-scoping request.

`EventsQuery` is now `#[serde(deny_unknown_fields)]`: every field on it is a security filter whose *absent* form fails **open** (unfiltered stream), so a typo'd `?channel_id=C123` would otherwise silently hand back the full firehose the caller was trying to narrow — the same leak, reintroduced by a spelling mistake and invisible at both ends. Safe to add: no shipped client sends any other parameter.

### `ListenerEventReceived` — deliberately NOT channel-scoped

#3820's `ea49e0d1` extended the same unscoped bucket to `ListenerEventReceived`, so the question is in scope. It returns `None` from `slack_channel()` and always passes the channel filter.

The reason is narrower than "it has no channel". It has no channel **field**: the variant is provider-generic (Gmail, Calendar, and the Slack gateway all emit it keyed only by `listener_id`, and the gateway uses the fixed id `"slack"` for the whole workspace). A Slack-emitted row *does* embed the channel — but only as free text inside the human-facing `summary` display string (`slack/handlers.rs:493` formats it `"{channel}: {snippet}"`). Parsing a display string to recover a security-scoping key is not acceptable: the format exists to be read by a human and can be changed by anyone editing that line, and a channel id is not reliably distinguishable from a snippet containing a colon. The real axis is `listener_id`, a structured field — tracked as facet 2 of #3988. Reasoning recorded in the doc comment on `Event::slack_channel`; behaviour pinned by `event_passes_leaves_non_slack_events_alone`.

`Event::slack_channel` matches **every** variant explicitly rather than using a `_ => None` wildcard — this is the one function whose entire job is deciding the scoping key, so a future `SlackReactionAdded` / `SlackThreadReply` must fail to compile until someone decides whether it is channel-scoped, instead of defaulting to the broadcast-to-all behaviour that caused #3760.

## Tests

New `crates/trusty-agents/src/api/server/tests/events_sse.rs` (7 cases):
- `event_passes_without_filters` — **the compatibility case**: every kind reaches an unfiltered subscriber.
- `event_passes_scopes_slack_by_channel` — both halves of the requested channel pass; another channel's do not (the reported leak).
- `event_passes_leaves_non_slack_events_alone` — `Ping`, task telemetry, and `ListenerEventReceived` all pass a channel filter.
- `event_passes_still_scopes_by_session`, `event_passes_applies_both_filters_independently`.
- `events_query_rejects_unknown_parameter` / `events_query_accepts_known_parameters` — the `deny_unknown_fields` surface, including that no-params and each param alone are still accepted.

In `tests/relay.rs` and `tests/mod.rs`:
- `relay_authorized_requires_exact_match` **extended**, and new `bearer_token_matches_is_exact`, with the cases a length-first / byte-loop implementation is most likely to get wrong: differs only in the first byte, only in the last byte, shorter, longer, empty, long exact match, and multi-byte UTF-8 (equal byte length, so it exercises `ct_eq` rather than the length shortcut).
- `auth_middleware_rejects_same_length_wrong_token` (new) — the pre-existing middleware case used `"wrong"` vs `"secret"`, which differ in length and so only exercised the shortcut.
- `relay_rejects_unknown_identity` (new) — four forged labels including a case-variant near-miss; asserts **nothing reached the bus**, not merely that the status was 422.
- `relay_accepts_honest_identity`, `identity_is_honest_accepts_only_the_bot_label` (new).
- All three bus-drain loops now go through a `drain_bus` helper. `while let Ok(ev) = rx.try_recv()` stops at the first `Err`, and `TryRecvError::Lagged(n)` **is** an `Err` — on a busy global bus that silently truncated the drain, which in the negative test meant "nothing reached the bus" could pass **vacuously** in exactly the case where events were dropped unseen. `drain_bus` continues past `Lagged`, reports the dropped count, and the negative test now **fails** if any lag was observed.

## Gates (crate-scoped, raw — re-run after the fix round)

```
$ cargo test -p trusty-agents
test result: ok. 2623 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 27.63s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 4 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   Doc-tests trusty_agents: ok. 0 passed; 0 failed

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 32.38s
(no warnings, no errors)

$ cargo fmt --check
(exit 0, no diff)
```

Closes #3761
Refs #3760

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
