### PR TITLE
fix(trusty-agents): declare cto-assistant's Gmail/Tasks scopes on the directory package (#3938)

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -98,6 +98,30 @@ allow = [
     # are already granted by the base's Gmail surface).
     "create_draft",
 ]
+# #3938: OpenRPC scopes (#3208) for the Gmail/Tasks surface above. These are
+# NOT a delta the base can supply and they are NOT redundant with `allow`:
+# `allow` gates by tool NAME, `scopes` gates by the capability the tool's
+# credential actually holds, and BOTH must pass in
+# `ctrl::pm_task::dispatch::persona::filter_persona_tool_names` (#3208).
+#
+# The base `assistant` deliberately declares read-only `google.read`
+# (`../assistant/agent.toml`, §5.5) — but no gworkspace tool ever advertises
+# that scope: `registry::google_scope` maps every `x-google-scopes` OAuth URL
+# to `google.<family>.<access>` (e.g. `google.gmail.write`,
+# `google.tasks.write`), and `ScopePattern::matches` compares on segment
+# boundaries, so `google.read` matches nothing. Inheriting it by union was
+# therefore inheriting NO Google capability at all, and every Gmail/Tasks tool
+# allowlisted above was silently dropped before the model ever saw it.
+#
+# This overlay is a single named user's private assistant (Masa/Duetto) whose
+# whole point is Gmail triage (#473) and Granola->Google Tasks sync (#472/#485),
+# so it opts in EXPLICITLY and NARROWLY to exactly those two families —
+# deliberately not izzie's blanket `google.*`, which would also hand this
+# persona Calendar/Drive/Docs write. This restores, verbatim, the scope line
+# the flat `../cto-assistant.toml` has always carried (its own comment there
+# predicted this exact failure); converting that file into this directory
+# package dropped it, and the package WINS the loader's resolution order.
+scopes = ["google.gmail.*", "google.tasks.*"]
 
 [system_prompt]
 # CTO-specific skill DELTAS only — `gworkspace-calendar` is already granted

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -41,6 +41,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   anything else with `422`, mirroring the existing closed-set RBAC tier check
   on the inbound half.
 
+- **`cto-assistant`'s Gmail and Google Tasks tools are no longer scope-denied at
+  dispatch** (issue #3938): the bundled `cto-assistant` DIRECTORY PACKAGE
+  (`.trusty-agents/agents/cto-assistant/agent.toml`), which wins the loader's
+  resolution order over the flat `cto-assistant.toml`, declared no
+  `[tools].scopes` — so it inherited only the base assistant's `google.read` by
+  union. No gworkspace tool ever advertises that scope: discovery maps every
+  `x-google-scopes` OAuth URL to `google.<family>.<access>` (`google.gmail.write`,
+  `google.tasks.write`), and `ScopePattern::matches` compares on segment
+  boundaries, so `google.read` matched nothing and the per-agent scope gate in
+  `filter_persona_tool_names` (#3208) dropped the persona's entire Gmail/Tasks
+  surface before the model saw it. The package now declares
+  `scopes = ["google.gmail.*", "google.tasks.*"]` explicitly — narrowly, the two
+  families its allowlisted tools actually need, not a blanket `google.*` —
+  restoring the line the flat file has always carried and that the package
+  conversion dropped. A new test resolves the SHIPPED package through the real
+  loader, derives each tool's dotted scope from the real `trusty-gworkspace`
+  `rpc.discover` document, and runs the real dispatch-time filter, so
+  re-dropping the declaration fails in CI instead of at a user's dispatch.
+
 - **Streamed chat turns now send the same sampling parameters as the blocking
   path** (issue #3758): `llm::stream::stream_reply` built its
   `OpenRouterProvider` with no temperature, token ceiling, or stop sequences, so

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -465,3 +465,100 @@ fn persona_max_turns_with_tools_honors_config_override() {
     let llm = llm_params_with_persona_max_turns(Some(12));
     assert_eq!(persona_max_turns(true, &llm), 12);
 }
+
+/// #3938 regression pin: the bundled `cto-assistant` DIRECTORY PACKAGE must
+/// carry enough Google scope to survive the dispatch-time scope
+/// intersection for its Gmail/Tasks surface.
+///
+/// Why: the package (`.trusty-agents/agents/cto-assistant/agent.toml`) WINS
+/// over the flat `cto-assistant.toml` in `by_name_unresolved_src_in`, and
+/// when it was converted from the flat form its `scopes = [...]` line was
+/// dropped. With none declared it inherited only the base assistant's
+/// `google.read` by union (`extends::merge_extends`) — a pattern that
+/// matches NO scope any gworkspace tool advertises (every dotted scope is
+/// `google.<family>.<access>`; see `registry::google_scope`), so
+/// `agent_can_use` denied the whole Gmail/Tasks surface even though every
+/// tool was allowlisted by name. Asserting on the checked-in package rather
+/// than a synthetic fixture is the point: this pins the SHIPPED config, so
+/// re-dropping the line (or converting another agent the same way) fails
+/// here instead of at a user's dispatch.
+/// What: resolves the real package through the real loader (`by_name_in`,
+/// including its `extends = "assistant"` union), derives each tool's dotted
+/// scope from the real `trusty-gworkspace` `rpc.discover` document through
+/// the real `parse_manifest` -> `x-google-scopes` mapping, and runs the real
+/// `filter_persona_tool_names` gate. No daemon, no network, no LLM.
+#[test]
+fn cto_assistant_package_gmail_and_tasks_tools_survive_scope_intersection() {
+    // The scoped gworkspace tools this persona is built around: Gmail triage
+    // (#473, inherited from the base's Gmail surface) and Google Tasks
+    // (#472/#485, this package's own delta). `create_draft` / `create_task`
+    // are deliberately absent — they are legacy names gworkspace no longer
+    // exposes, so they carry no scope and are filtered by registration, not
+    // by scope (see `skills::manifest::builtin::gworkspace`).
+    const GMAIL_AND_TASKS: &[&str] = &[
+        "search_gmail_messages",
+        "get_gmail_message_content",
+        "modify_gmail_messages",
+        "list_tasks",
+        "complete_task",
+    ];
+
+    let agents_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".trusty-agents")
+        .join("agents");
+    let cfg = AgentConfig::by_name_in(&[agents_dir], "cto-assistant")
+        .expect("bundled cto-assistant directory package resolves");
+
+    let manifest = crate::tools::registry::discovery::parse_manifest(
+        "gworkspace",
+        &trusty_gworkspace::openrpc::discover_response(),
+    )
+    .expect("gworkspace rpc.discover document parses");
+    let tool_scopes: std::collections::HashMap<String, String> = manifest
+        .tools
+        .iter()
+        .map(|t| (t.name.clone(), t.scope.clone()))
+        .collect();
+
+    // Guard against a vacuous pass: every name below must still BE a scoped
+    // gworkspace tool, otherwise the scope gate would wave it through on the
+    // `None` branch and prove nothing.
+    for name in GMAIL_AND_TASKS {
+        assert!(
+            tool_scopes.contains_key(*name),
+            "{name} no longer advertises a gworkspace scope — refresh this list"
+        );
+    }
+
+    let allow = cfg
+        .tools
+        .allow
+        .clone()
+        .expect("cto-assistant declares [tools].allow");
+    let scope_patterns: Vec<ScopePattern> = cfg
+        .tools
+        .scopes
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .map(ScopePattern::new)
+        .collect();
+
+    let all_names: Vec<String> = GMAIL_AND_TASKS.iter().map(|s| (*s).to_string()).collect();
+    let allowed_by_tier: std::collections::HashSet<String> = all_names.iter().cloned().collect();
+
+    let survivors = filter_persona_tool_names(
+        all_names.clone(),
+        &allow,
+        &allowed_by_tier,
+        &tool_scopes,
+        &scope_patterns,
+    );
+
+    assert_eq!(
+        survivors, all_names,
+        "cto-assistant's Gmail/Tasks tools were scope-denied at dispatch; \
+         resolved [tools].scopes = {:?}",
+        cfg.tools.scopes
+    );
+}


### PR DESCRIPTION
## Summary

Fixes **#3938**. The bundled `cto-assistant` persona granted Gmail/Tasks tools by name but had no Google scope that could carry them, so the dispatch-time scope gate on the persona-chat path (GUI + REPL) silently dropped **every one of them** before the model saw the registry.

## Root cause (confirmed, not inferred)

1. `agents/cto-assistant/agent.toml` — the **directory package** — declared no `[tools].scopes`. The package WINS the loader's resolution order over the flat `agents/cto-assistant.toml` (`agents/loader.rs::by_name_unresolved_src_in`); the flat file is reachable only via `extends_shadow_fallback_in`. The conversion from flat file to package dropped the scopes line.
2. With none declared, the package inherits the base assistant's set by union (`extends::merge_extends` → `union_opt_vec`): `["memory.read", "memory.write", "search.read", "google.read"]`.
3. **`google.read` is a dead pattern.** It is not merely "too narrow" — no gworkspace tool ever advertises it. `registry::google_scope::dotted_scope_for_google_scopes` maps every `x-google-scopes` OAuth URL to `google.<family>.<access>`, so the real scopes are `google.gmail.write` / `google.tasks.write`. `ScopePattern::matches` compares on segment boundaries and rejects middle wildcards, so `google.read` matches neither.
4. `agent_can_use` therefore denies them in `filter_persona_tool_names` (`ctrl/pm_task/dispatch/persona.rs`, the #3208 enforcement site).

Reproduced before the fix, through the real code path:

```
assertion `left == right` failed: cto-assistant's Gmail/Tasks tools were scope-denied at dispatch;
  resolved [tools].scopes = Some(["memory.read", "memory.write", "search.read", "google.read"])
  left: []
 right: ["search_gmail_messages", "get_gmail_message_content", "modify_gmail_messages", "list_tasks", "complete_task"]
```

`left: []` — the whole surface, not a subset.

## Fix

`agents/cto-assistant/agent.toml` declares the two families its allowlisted tools actually need:

```toml
scopes = ["google.gmail.*", "google.tasks.*"]
```

This is the **package's** declaration, union-merged onto the base's — not a widening of the shared base and not a blanket `google.*`. Justification lives in the doc comment at the change site: this overlay is one named user's private assistant whose stated purpose is Gmail triage (#473) and Granola→Google Tasks sync (#472/#485), and this restores verbatim the scope line the flat `cto-assistant.toml` has always carried — whose own comment predicted this exact failure ("would be silently denied at dispatch the moment scope enforcement is active"). Deliberately **not** izzie's blanket `google.*`, which would also hand this persona Calendar/Drive/Docs write it never asked for.

The inheritance logic itself was audited and is **correct** — `union_opt_vec` merges scopes base-first with dedup exactly as specified. No code change was warranted there.

## Test

`cto_assistant_package_gmail_and_tasks_tools_survive_scope_intersection` (`persona_tests.rs`) pins the regression end-to-end with no daemon, no network, no LLM:

- resolves the **shipped** package via the real loader `AgentConfig::by_name_in` (including its `extends = "assistant"` union) — asserting on the checked-in config, so re-dropping the line, or converting another agent the same way, fails in CI instead of at a user's dispatch;
- derives each tool's dotted scope from the real `trusty_gworkspace::openrpc::discover_response()` through the real `registry::discovery::parse_manifest` → `x-google-scopes` mapping;
- runs the real `filter_persona_tool_names` gate;
- guards against a vacuous pass: each fixture name must still BE a scoped gworkspace tool, otherwise the `None` branch would wave it through and prove nothing.

## Adjacent finding — NOT fixed here (deliberate)

The same investigation shows the base `assistant` template's `google.read` matches **nothing**, so the ~45 gworkspace tools it allowlists (Calendar, Drive, Docs, Sheets, Slides, and its own Gmail surface) are scope-denied for the base persona and for every overlay that does not opt in explicitly. That is a real defect, but the base's read-only posture is an owner/product decision (`assistant/agent.toml` §5.5), and a genuinely read-only Google posture is currently **inexpressible**: every gworkspace OAuth scope is the full-access variant, so `google_scope` classifies them all as `.write`, and `google.*.read` is a middle wildcard the matcher rejects by design. Widening the shared base unilaterally would be exactly the scope-widening hack this change avoids. Flagging for a separate issue rather than smuggling it in here.

## Gates (raw)

```
$ cargo test -p trusty-agents
test result: ok. 2612 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 25.19s
(+ all 9 integration test binaries green)
TEST_EXIT=0

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 43s
CLIPPY_EXIT=0

$ cargo fmt --check
FMT_EXIT=0

$ bash scripts/check_agent_assets.sh
agent-assets: 29 byte-parity file(s) match, 4 pinned deviation(s) match upstream — OK.

$ bash scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.
```

Closes #3938

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
