### PR TITLE
fix(trusty-search): stop denying create_index/relocate_index tests via sensitive-path denylist

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -9,6 +9,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Test-side remediation for `create_index`/`relocate_index` tests spuriously
+  denied by the sensitive-path denylist (issue #3955).** `SENSITIVE_PATH_PREFIXES`
+  denies `/tmp/`, `/private/tmp`, and `/var/folders` — which on macOS is where
+  `std::env::temp_dir()` resolves by default, and on Linux CI it's `/tmp`
+  outright. A dozen-plus `create_index_*`/`relocate_index_*` tests allocated
+  their index roots via `tempfile::tempdir()`, so they intermittently got
+  HTTP 400 from the very denylist they weren't testing. The denylist itself is
+  correct and unchanged; the fix is a new shared test helper,
+  `service::server::test_support::allowlisted_index_root`, that roots test
+  index directories under `$HOME/.trusty-search-test-roots` — safe regardless
+  of `$TMPDIR` or where the checkout itself lives (unlike the ad hoc
+  `target/`-relative workaround some of these tests already had, which still
+  fails if the checkout is placed under a denylisted prefix). RAII `TempDir`
+  cleanup plus a best-effort 24h staleness sweep keep `$HOME` tidy.
 - **Staged-write-then-swap for the periodic HNSW incremental persister closes
   a crash-safety hole independent of shutdown (issue #3970).**
   `spawn_incremental_persist` used to checkpoint the in-memory HNSW graph

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -36,6 +36,8 @@ mod typeahead;
 #[cfg(test)]
 mod list_repo_identity_tests;
 #[cfg(test)]
+mod test_support;
+#[cfg(test)]
 mod tests_1073;
 #[cfg(test)]
 mod tests_2336;

--- a/crates/trusty-search/src/service/server/test_support.rs
+++ b/crates/trusty-search/src/service/server/test_support.rs
@@ -1,0 +1,94 @@
+//! Shared helper for allocating index-root directories in tests without
+//! tripping the sensitive-path denylist (issue #3955).
+//!
+//! Why: `tempfile::tempdir()` roots under `std::env::temp_dir()`, which
+//! resolves to `/var/folders/…` by default on macOS and `/tmp` on Linux —
+//! both hard-denylisted by `crate::allowlist::SENSITIVE_PATH_PREFIXES`. A
+//! `create_index`/`relocate_index` test that hands such a path straight to
+//! the handler gets refused with `400` for a reason unrelated to what the
+//! test is actually checking.
+//!
+//! Several tests independently worked around this by rooting a
+//! `tempfile::Builder` dir at `<checkout>/target/…` instead. That helps when
+//! `$TMPDIR` is the problem, but not when the *checkout itself* lives under
+//! a denylisted prefix: `is_denied` matches the full, checkout-independent
+//! path string, so a worktree placed under `/private/tmp` (as could happen
+//! before the harness-level guard added in #3978) denies `target/…` too —
+//! every path under such a checkout starts with `/private/tmp`. A directory
+//! anchored at `$HOME` under a name that appears in none of
+//! `SENSITIVE_HOME_TOP_DIRS` / `SENSITIVE_COMPONENT_NAMES` is the one
+//! location that is safe regardless of both the checkout's location and
+//! `$TMPDIR` — see `crate::allowlist::is_denied_inner`'s four checks.
+//!
+//! What: [`allowlisted_index_root`] creates a fresh RAII-cleaned `TempDir`
+//! under `$HOME/.trusty-search-test-roots/<prefix>…` and returns it
+//! alongside its canonicalized path, ready to hand to
+//! `CreateIndexRequest.root_path` / `RelocateIndexRequest.root_path`. Stale
+//! entries older than a day are opportunistically swept on each call
+//! (best-effort — a run that panics past unwind or is SIGKILLed leaks a
+//! directory since `Drop` never runs; the sweep bounds that litter instead
+//! of relying on cleanup happening every time).
+//!
+//! Test: every `create_index_*` / `relocate_index_*` test that needs a real,
+//! allowlist-passing root uses this helper (`tests_1073`, `tests_2336`,
+//! `tests_2984`, `tests_index`, `tests_state`). `tests_denylist` deliberately
+//! keeps using raw `tempfile::tempdir()` for its two "still rejects" /
+//! "opts in" tests — those exist to prove the denylist itself works, so
+//! they must not use an allowlisted root.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+use tempfile::TempDir;
+
+/// How long a leftover test-root directory survives before the next call
+/// opportunistically sweeps it. Generous enough to never race a slow CI
+/// test run, short enough to keep `$HOME` tidy across many local runs.
+const STALE_AFTER: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Base directory for allowlist-safe test index roots: `$HOME/.trusty-search-test-roots`.
+fn test_roots_base() -> PathBuf {
+    let home = dirs::home_dir().expect("HOME must be set to run trusty-search tests");
+    let base = home.join(".trusty-search-test-roots");
+    std::fs::create_dir_all(&base).expect("create ~/.trusty-search-test-roots");
+    sweep_stale_entries(&base);
+    base
+}
+
+/// Best-effort removal of entries older than [`STALE_AFTER`]. Failures
+/// (permission issues, concurrent removal by another test process racing
+/// this one) are swallowed — this is tidiness, not correctness, and must
+/// never fail a test.
+fn sweep_stale_entries(base: &Path) {
+    let Ok(entries) = std::fs::read_dir(base) else {
+        return;
+    };
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let is_stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|modified| now.duration_since(modified).ok())
+            .is_some_and(|age| age > STALE_AFTER);
+        if is_stale {
+            let _ = std::fs::remove_dir_all(entry.path());
+        }
+    }
+}
+
+/// Create a fresh, RAII-cleaned directory under the allowlist-safe base for
+/// use as an index `root_path` in tests.
+///
+/// Returns the `TempDir` guard (drop it to clean up immediately — keep it
+/// alive for the lifetime of the test) alongside its canonicalized path,
+/// since handlers under test canonicalize `root_path` before storing it and
+/// tests assert against that canonical form.
+pub(super) fn allowlisted_index_root(prefix: &str) -> (TempDir, PathBuf) {
+    let base = test_roots_base();
+    let dir = tempfile::Builder::new()
+        .prefix(prefix)
+        .tempdir_in(&base)
+        .unwrap_or_else(|e| panic!("create tempdir under {}: {e}", base.display()));
+    let canonical = std::fs::canonicalize(dir.path()).expect("canonicalize tempdir");
+    (dir, canonical)
+}

--- a/crates/trusty-search/src/service/server/tests_1073.rs
+++ b/crates/trusty-search/src/service/server/tests_1073.rs
@@ -75,22 +75,11 @@ async fn relocate_index_updates_root_path() {
     state.install_embedder(embedder).await;
     let state_arc = Arc::new(state);
 
-    // Build the initial and target directories under target/ (never in the
-    // denylist), using RAII TempDir for cleanup.
-    let cwd = std::env::current_dir().expect("cwd");
-    let base = cwd.join("target");
-    std::fs::create_dir_all(&base).expect("create target/");
-    let old_dir = tempfile::Builder::new()
-        .prefix("ts-relocate-old-")
-        .tempdir_in(&base)
-        .expect("create old_dir");
-    let new_dir = tempfile::Builder::new()
-        .prefix("ts-relocate-new-")
-        .tempdir_in(&base)
-        .expect("create new_dir");
-
-    let old_root = old_dir.path().canonicalize().expect("canonicalize old_dir");
-    let new_root = new_dir.path().canonicalize().expect("canonicalize new_dir");
+    // Build the initial and target directories under an allowlist-safe base
+    // (see `test_support::allowlisted_index_root`), using RAII TempDir for
+    // cleanup.
+    let (_old_dir, old_root) = super::test_support::allowlisted_index_root("ts-relocate-old-");
+    let (_new_dir, new_root) = super::test_support::allowlisted_index_root("ts-relocate-new-");
 
     // Step 1: register the index at old_root.
     let create_resp = super::indexes::create_index_handler(

--- a/crates/trusty-search/src/service/server/tests_2336.rs
+++ b/crates/trusty-search/src/service/server/tests_2336.rs
@@ -49,19 +49,9 @@ fn create_req(id: &str, root_path: std::path::PathBuf) -> super::router::CreateI
     }
 }
 
-/// Create a temp directory under `target/` (never in the hard denylist) with
-/// RAII cleanup, returning its canonical path.
-fn temp_root(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf) {
-    let cwd = std::env::current_dir().expect("cwd");
-    let base = cwd.join("target");
-    std::fs::create_dir_all(&base).expect("create target/");
-    let dir = tempfile::Builder::new()
-        .prefix(prefix)
-        .tempdir_in(&base)
-        .expect("create tempdir");
-    let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
-    (dir, canonical)
-}
+// Allowlist-safe temp roots come from `super::test_support::allowlisted_index_root`
+// — see that module for why a checkout-relative `target/` dir is not enough
+// (issue #3955).
 
 /// Build a fresh, empty registry with a mock embedder installed — enough for
 /// `create_index_handler` / `relocate_index_handler` to run without a live
@@ -81,7 +71,7 @@ async fn mock_state_async() -> Arc<SearchAppState> {
 #[tokio::test]
 async fn create_index_rejects_duplicate_root_path() {
     let state = mock_state_async().await;
-    let (_dir, root) = temp_root("ts-2336-dup-root-");
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-2336-dup-root-");
 
     let first = super::indexes::create_index_handler(
         State(Arc::clone(&state)),
@@ -124,7 +114,7 @@ async fn create_index_rejects_duplicate_root_path() {
 #[tokio::test]
 async fn create_index_same_id_same_root_is_idempotent_not_a_collision() {
     let state = mock_state_async().await;
-    let (_dir, root) = temp_root("ts-2336-idempotent-");
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-2336-idempotent-");
 
     let first = super::indexes::create_index_handler(
         State(Arc::clone(&state)),
@@ -153,8 +143,8 @@ async fn create_index_same_id_same_root_is_idempotent_not_a_collision() {
 #[tokio::test]
 async fn create_index_distinct_roots_both_succeed() {
     let state = mock_state_async().await;
-    let (_dir_a, root_a) = temp_root("ts-2336-distinct-a-");
-    let (_dir_b, root_b) = temp_root("ts-2336-distinct-b-");
+    let (_dir_a, root_a) = super::test_support::allowlisted_index_root("ts-2336-distinct-a-");
+    let (_dir_b, root_b) = super::test_support::allowlisted_index_root("ts-2336-distinct-b-");
 
     let a = super::indexes::create_index_handler(
         State(Arc::clone(&state)),
@@ -185,8 +175,8 @@ async fn relocate_index_rejects_root_path_owned_by_another_index() {
     use super::indexes_relocate::{relocate_index_handler, RelocateIndexRequest};
 
     let state = mock_state_async().await;
-    let (_dir_a, root_a) = temp_root("ts-2336-relocate-a-");
-    let (_dir_b, root_b) = temp_root("ts-2336-relocate-b-");
+    let (_dir_a, root_a) = super::test_support::allowlisted_index_root("ts-2336-relocate-a-");
+    let (_dir_b, root_b) = super::test_support::allowlisted_index_root("ts-2336-relocate-b-");
 
     let create_a = super::indexes::create_index_handler(
         State(Arc::clone(&state)),
@@ -242,7 +232,7 @@ async fn relocate_index_onto_own_current_root_is_not_a_collision() {
     use super::indexes_relocate::{relocate_index_handler, RelocateIndexRequest};
 
     let state = mock_state_async().await;
-    let (_dir, root) = temp_root("ts-2336-relocate-self-");
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-2336-relocate-self-");
 
     let create = super::indexes::create_index_handler(
         State(Arc::clone(&state)),
@@ -280,7 +270,7 @@ async fn relocate_index_onto_own_current_root_is_not_a_collision() {
 #[tokio::test]
 async fn create_index_concurrent_same_root_only_one_wins() {
     let state = mock_state_async().await;
-    let (_dir, root) = temp_root("ts-2336-race-");
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-2336-race-");
 
     let state_a = Arc::clone(&state);
     let root_a = root.clone();
@@ -328,7 +318,7 @@ async fn create_index_concurrent_same_root_only_one_wins() {
 #[tokio::test]
 async fn create_index_rejects_case_variant_of_registered_root() {
     let state = mock_state_async().await;
-    let (_dir, root) = temp_root("TS-2336-CaseVariant-");
+    let (_dir, root) = super::test_support::allowlisted_index_root("TS-2336-CaseVariant-");
 
     let first = super::indexes::create_index_handler(
         State(Arc::clone(&state)),

--- a/crates/trusty-search/src/service/server/tests_2984.rs
+++ b/crates/trusty-search/src/service/server/tests_2984.rs
@@ -66,23 +66,9 @@ fn create_req_with_skip_kg(
     }
 }
 
-/// Create a temp directory under `target/` (never in the hard denylist) with
-/// RAII cleanup, returning its canonical path.
-///
-/// Why: identical helper to `tests_2336::temp_root` — duplicated rather than
-/// shared because `tests_2336` is itself a `#[cfg(test)]`-only sibling
-/// module with no public surface to import from.
-fn temp_root(prefix: &str) -> (tempfile::TempDir, std::path::PathBuf) {
-    let cwd = std::env::current_dir().expect("cwd");
-    let base = cwd.join("target");
-    std::fs::create_dir_all(&base).expect("create target/");
-    let dir = tempfile::Builder::new()
-        .prefix(prefix)
-        .tempdir_in(&base)
-        .expect("create tempdir");
-    let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
-    (dir, canonical)
-}
+// Allowlist-safe temp roots come from `super::test_support::allowlisted_index_root`
+// — see that module for why a checkout-relative `target/` dir is not enough
+// (issue #3955).
 
 /// Build a fresh, empty registry with a mock embedder installed — enough for
 /// `create_index_handler` to run without a live daemon or network.
@@ -99,7 +85,7 @@ async fn mock_state_async() -> Arc<SearchAppState> {
 #[tokio::test]
 async fn create_index_handler_honors_skip_kg_on_reregister() {
     let state = mock_state_async().await;
-    let (_dir, root) = temp_root("ts-2984-skip-kg-");
+    let (_dir, root) = super::test_support::allowlisted_index_root("ts-2984-skip-kg-");
     let id = IndexId::new("skip-kg-reregister");
 
     // Phase 1: create the index with skip_kg=false and index real content

--- a/crates/trusty-search/src/service/server/tests_index.rs
+++ b/crates/trusty-search/src/service/server/tests_index.rs
@@ -261,11 +261,12 @@ async fn create_index_rejects_nonexistent_root_path() {
 /// `file_is_within_root` won't match.
 ///
 /// Note: `tempfile::tempdir()` creates dirs under `/tmp/` which is now in
-/// the sensitive-root denylist. This test uses `tempfile::Builder` with a
-/// `prefix_dir` under `target/` (which is never in the denylist) so that
+/// the sensitive-root denylist. This test uses
+/// `super::test_support::allowlisted_index_root` (see that module's doc
+/// comment for why a `target/`-relative dir alone is not enough) so that
 /// `validate_root_path` accepts the directory while still exercising the
 /// symlink-canonicalization logic. `TempDir` provides RAII cleanup even on
-/// panic, ensuring no leaked directories in `target/`.
+/// panic, ensuring no leaked directories.
 #[cfg(unix)]
 #[tokio::test]
 async fn create_index_canonicalizes_symlinked_root_path() {
@@ -278,18 +279,16 @@ async fn create_index_canonicalizes_symlinked_root_path() {
     state.install_embedder(embedder).await;
     let state_arc = Arc::new(state);
 
-    // Create the real directory under target/ (not /tmp) so the denylist allows
-    // it. TempDir provides RAII cleanup even on panic.
-    let cwd = std::env::current_dir().expect("cwd");
-    let base = cwd.join("target");
-    std::fs::create_dir_all(&base).expect("create target/");
-    let real_dir = tempfile::Builder::new()
-        .prefix("ts-symlink-real-")
-        .tempdir_in(&base)
-        .expect("create real_root under target/");
-    let real_root = std::fs::canonicalize(real_dir.path()).expect("canonicalize real root");
+    // Create the real directory under an allowlist-safe base. TempDir
+    // provides RAII cleanup even on panic.
+    let (real_dir, real_root) = super::test_support::allowlisted_index_root("ts-symlink-real-");
 
-    // The symlink lives alongside the real dir (also under target/).
+    // The symlink lives alongside the real dir (same allowlist-safe base).
+    let base = real_dir
+        .path()
+        .parent()
+        .expect("allowlisted root has a parent")
+        .to_path_buf();
     let link_path = base.join(format!("ts-symlink-link-{}", std::process::id()));
     let _ = std::fs::remove_file(&link_path);
     symlink(&real_root, &link_path).expect("create symlink");
@@ -339,10 +338,10 @@ async fn create_index_canonicalizes_symlinked_root_path() {
 
 /// Issue #63: an absolute, existing directory must be accepted.
 ///
-/// Note: uses `tempfile::Builder` rooted under `target/` (never in the
-/// denylist) instead of `tempfile::tempdir()` (which creates dirs under
-/// `/tmp/`, now in the sensitive-root denylist). `TempDir` provides RAII
-/// cleanup even on panic — no leaked directories.
+/// Note: uses `super::test_support::allowlisted_index_root` instead of
+/// `tempfile::tempdir()` (which creates dirs under `/tmp/`, now in the
+/// sensitive-root denylist). `TempDir` provides RAII cleanup even on panic
+/// — no leaked directories.
 #[tokio::test]
 async fn create_index_accepts_valid_absolute_root_path() {
     use crate::core::registry::IndexRegistry;
@@ -352,20 +351,14 @@ async fn create_index_accepts_valid_absolute_root_path() {
     state.install_embedder(embedder).await;
     let state_arc = Arc::new(state);
 
-    // TempDir under target/ — RAII cleanup on drop, never under /tmp/.
-    let cwd = std::env::current_dir().expect("cwd");
-    let base = cwd.join("target");
-    std::fs::create_dir_all(&base).expect("create target/");
-    let test_dir = tempfile::Builder::new()
-        .prefix("ts-valid-abs-")
-        .tempdir_in(&base)
-        .expect("create test_dir under target/");
+    // TempDir under an allowlist-safe base — RAII cleanup on drop.
+    let (_test_dir, test_root) = super::test_support::allowlisted_index_root("ts-valid-abs-");
 
     let resp = create_index_handler(
         State(Arc::clone(&state_arc)),
         Json(CreateIndexRequest {
             id: "valid-abs".into(),
-            root_path: test_dir.path().to_path_buf(),
+            root_path: test_root,
             include_paths: None,
             exclude_globs: None,
             extensions: None,
@@ -384,7 +377,7 @@ async fn create_index_accepts_valid_absolute_root_path() {
         }),
     )
     .await;
-    // test_dir is dropped here → RAII cleanup
+    // _test_dir is dropped here → RAII cleanup
     assert_eq!(resp.status(), StatusCode::OK);
 }
 // Denylist tests live in `tests_denylist.rs` (split to keep this file ≤ 500 lines).

--- a/crates/trusty-search/src/service/server/tests_state.rs
+++ b/crates/trusty-search/src/service/server/tests_state.rs
@@ -39,19 +39,15 @@ async fn create_index_returns_503_with_error_when_embedder_failed() {
     // Use a real non-denied directory so the `validate_root_path` guard
     // (issue #63 + index-denylist) accepts the path and the handler
     // proceeds to the embedder-error branch we're asserting on.
-    // Note: `tempfile::tempdir()` creates dirs under /tmp which is now
-    // in the sensitive-root denylist — use target/ under the workspace root.
-    let base = std::env::current_dir().expect("cwd").join("target");
-    std::fs::create_dir_all(&base).ok();
-    let test_dir = tempfile::Builder::new()
-        .prefix("ts-embedder-fail-")
-        .tempdir_in(&base)
-        .expect("create test_dir under target/");
+    // Note: `tempfile::tempdir()` creates dirs under /tmp which is now in
+    // the sensitive-root denylist — use `test_support::allowlisted_index_root`
+    // instead (issue #3955).
+    let (_test_dir, test_root) = super::test_support::allowlisted_index_root("ts-embedder-fail-");
     let resp = create_index_handler(
         State(state_arc),
         Json(CreateIndexRequest {
             id: "demo".to_string(),
-            root_path: test_dir.path().to_path_buf(),
+            root_path: test_root,
             include_paths: None,
             exclude_globs: None,
             extensions: None,


### PR DESCRIPTION
## Summary

Test-side remediation for issue #3955. `SENSITIVE_PATH_PREFIXES`
(`crates/trusty-search/src/allowlist/mod.rs:102-111`) correctly denies
`/tmp/`, `/private/tmp`, and `/var/folders` — but `std::env::temp_dir()`
resolves under `/var/folders/…` by default on macOS, and under `/tmp`
outright on Linux CI. A dozen-plus `create_index_*`/`relocate_index_*` tests
allocated their index roots via `tempfile::tempdir()`, so they intermittently
got HTTP 400 from the very denylist they weren't testing — proven by a
same-commit A/B: 12 lib-test failures from a `/private/tmp` checkout, 0 from
a clean one.

**The denylist is correct and is unchanged by this PR.** It is a security
control refusing to index sensitive paths, working as designed. The bug was
always in the tests: they allocated roots where the product rightly refuses
to index.

Several affected tests had already worked around this ad hoc with a
`target/`-relative `tempfile::Builder` dir, duplicated per-file. That only
solves the `$TMPDIR`-resolves-to-`/var/folders` case — it does **not** solve
the checkout itself living under a denylisted prefix, because `is_denied`
matches the full path string: if the whole worktree sits under
`/private/tmp`, every path under it (including `target/…`) still starts with
`/private/tmp` and is still denied. Verified this is a real, reproducible gap
(see Test plan).

**Fix:** one shared helper,
`service::server::test_support::allowlisted_index_root`, roots test index
directories under `$HOME/.trusty-search-test-roots` — safe regardless of
`$TMPDIR` or where the checkout lives, since none of the denylist's four
checks (`SENSITIVE_PATH_PREFIXES`, `SENSITIVE_COMPONENT_NAMES`,
`SENSITIVE_FILE_NAMES`, `SENSITIVE_HOME_TOP_DIRS`) match a hidden dot-dir
directly under `$HOME`. RAII `TempDir` cleanup plus a best-effort 24h
staleness sweep keep `$HOME` tidy across interrupted runs. Every affected
test (`tests_1073`, `tests_2336`, `tests_2984`, `tests_index`,
`tests_state`) now uses this one helper instead of five duplicated ad hoc
copies. `tests_denylist.rs` intentionally keeps raw `tempfile::tempdir()`
for its two tests that prove the denylist itself rejects/allows a sensitive
path — those must not use an allowlisted root, or they'd stop testing
anything.

Note: the harness half of #3955 (worktrees ending up under `/tmp` in the
first place) is resolved by convention — the three existing in-project
worktree roots, now enforced by #3977 / `bac23b80` (`git worktree add`
hard-blocked under `/tmp`, `/private/tmp`, `/var/folders`, or the
scratchpad). This PR closes the test-side half.

## Test plan

- [x] `cargo test -p trusty-search` (full, no `--lib`) — clean location:
      **1346 passed; 0 failed; 1 ignored** (lib), all integration suites
      green. Ran 3x, no flakiness.
- [x] Reproduced the bug live: copied the fixed-branch tree to
      `/private/tmp/…` (plain directory copy, not `git worktree add` —
      that's now hard-blocked), swapped in the pre-fix (origin/main)
      versions of the 5 affected test files, and confirmed **12 failures**,
      matching the issue's reported 12-13. Restored the fix in place and
      re-ran from the same `/private/tmp` location: **1346 passed; 0
      failed**.
- [x] `cargo clippy -p trusty-search --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p trusty-search --check` — clean.
- [x] No litter: `$HOME/.trusty-search-test-roots` empty after every run
      (RAII cleanup verified).
- [x] Denylist coverage intact:
      `tests_denylist::create_index_still_rejects_sensitive_path_by_default`
      and the rest of `tests_denylist.rs` still pass unmodified.
- [x] Known-bad `core::memguard::tests::test_trim_heap_never_increases_rss_after_bulk_free`
      (#3954, Linux-gated) does not appear in this macOS run — not chased,
      not touched.

Closes #3955

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools