### PR TITLE
fix: unify trusty-agents' $HOME test lock domain and make its guard fail loud

### DIFF
--- a/crates/trusty-agents/src/api/server/tests/models.rs
+++ b/crates/trusty-agents/src/api/server/tests/models.rs
@@ -131,21 +131,21 @@ async fn reachable_today_matches_documented_set() {
 /// resolves. Sets a fake `ANTHROPIC_API_KEY`; the resolver's env tier
 /// short-circuits before ever touching the (unsandboxed, possibly
 /// real-credential-bearing) secure store, so this deterministically makes
-/// anthropic resolve `true` without needing `$HOME` sandboxing — see
-/// `zero_credentials_configured_is_stable`'s doc comment for why sandboxing
-/// `$HOME` in this crate's test binary is NOT reliable (a handful of
-/// pre-existing tests elsewhere mutate `$HOME` without the shared lock).
+/// anthropic resolve `true` without needing `$HOME` sandboxing at all — so
+/// this test never has to join the crate's `$HOME` domain (`HOME_LOCK`); see
+/// `zero_credentials_configured_is_stable`'s doc comment for what an
+/// unsandboxed `$HOME` does and does not let either test assert.
 /// Asserts the raw response body never contains the fake value anywhere,
 /// while `credential_configured` still flips `true` for anthropic — proving
 /// the boolean is computed correctly, not just absent because nothing
 /// resolved.
 /// What: Holds `ENV_LOCK` (the only global mutation this test performs) for
 /// its full body; restores the env var on the way out. Also `#[serial]`:
-/// `llm::adapter::tests`, `llm::http::tests`, and other files mutate the same
-/// credential env vars from tests that can only join the crate-wide `#[serial]`
-/// group (not `ENV_LOCK`, e.g. `#[tokio::test]`s that can't hold a
-/// `std::sync::Mutex` guard across `.await`), so this test must carry
-/// `#[serial]` too to stay mutually exclusive with them.
+/// `llm::adapter::tests`, `llm::inference_client::tests`, and other files
+/// mutate the same credential env vars, some from tests that can only join
+/// the crate-wide `#[serial]` group (not `ENV_LOCK`, e.g. `#[tokio::test]`s
+/// that can't hold a `std::sync::Mutex` guard across `.await`), so this test
+/// must carry `#[serial]` too to stay mutually exclusive with them.
 #[tokio::test]
 #[serial]
 async fn credential_values_never_serialized() {
@@ -198,13 +198,11 @@ async fn credential_values_never_serialized() {
 /// Why: The GUI's picker must render sensibly on a fresh install with no
 /// *env-tier* credentials configured — this pins that the endpoint never
 /// errors with every credential env var cleared. It intentionally does NOT
-/// assert every provider is `false`: this crate's test binary has a handful
-/// of pre-existing tests (outside this module) that sandbox `$HOME` without
-/// holding `crate::test_env::HOME_LOCK`, so a `$HOME`-swap here can race
-/// against them and transiently see either the real secure store (on a dev
-/// machine that has one configured, as observed while writing this test) or
-/// a sandboxed empty one — asserting a fixed `false` would be flaky either
-/// way. Instead this test asserts *self-consistency*: whatever
+/// assert every provider is `false`: this test does not sandbox `$HOME`, so
+/// on a dev machine with a real secure store configured a provider can
+/// legitimately resolve `true` (as observed while writing this test), and
+/// asserting a fixed `false` would be flaky. Instead this test asserts
+/// *self-consistency*: whatever
 /// `resolve_key` (the exact function the handler calls) returns at the same
 /// moment, for each provider, is exactly what the response reports — which
 /// is the actually-load-bearing contract (the handler doesn't invert or

--- a/crates/trusty-agents/src/llm/helpers/tests.rs
+++ b/crates/trusty-agents/src/llm/helpers/tests.rs
@@ -244,13 +244,15 @@ fn tool_discipline_all_tool_calls_never_increments_counter() {
 //
 // SAFETY: each test below is `#[serial]` AND holds `crate::test_env::{ENV_LOCK,
 // HOME_LOCK}` for its full body (mirrors `llm::credentials::tests`'s documented
-// convention, #274). `#[serial]` is required because `llm::http::tests` and
-// `llm::inference_client::tests` mutate the same credential env vars from
-// `#[tokio::test]`s that cannot hold a `std::sync::Mutex` guard across
-// `.await` and rely on `#[serial]` alone for exclusion — so every sync test
-// touching these vars must also carry `#[serial]` to stay mutually exclusive
-// with them (a prior gap here caused a flaky cross-test env-var race under
-// `cargo test --workspace`).
+// convention, #274). `#[serial]` is required because
+// `llm::inference_client::tests` mutates the same credential env vars from a
+// `#[tokio::test]` that cannot hold a `std::sync::Mutex` guard across `.await`
+// and relies on `#[serial]` alone for exclusion — so every sync test touching
+// these vars must also carry `#[serial]` to stay mutually exclusive with it (a
+// prior gap here caused a flaky cross-test env-var race under
+// `cargo test --workspace`). #3952: `llm::http::tests` is no longer in that
+// category — its `$HOME`-sandboxing tests were converted to sync `#[test]`s
+// that hold `ENV_LOCK` + `lock_home()` like these do.
 
 #[test]
 #[serial]

--- a/crates/trusty-agents/src/llm/http/tests.rs
+++ b/crates/trusty-agents/src/llm/http/tests.rs
@@ -12,12 +12,44 @@
 //! Behaviour is unchanged from the inline versions; the only edit made
 //! during the move was carrying over #3464's `force_env_local_loaded()`
 //! preamble, which landed on `main` after this split was authored.
+//! #3952 later converted the five `$HOME`-sandboxing credential tests from
+//! `#[tokio::test]` to sync `#[test]` + [`block_on`] so they can join the
+//! crate's single `$HOME` lock domain — assertions unchanged.
 //! Test: This module IS the test.
 
 use super::*;
 use async_openai::types::{
     ChatCompletionRequestSystemMessageArgs, ChatCompletionRequestUserMessageArgs,
 };
+
+/// Drive `fut` to completion on a private CURRENT-THREAD tokio runtime.
+///
+/// Why (#3952): the five credential-resolution tests below sandbox `$HOME`,
+/// so they must hold `crate::test_env::lock_home()` — the crate's single
+/// `$HOME` synchronization domain — for their whole body, including the
+/// awaited `send_raw_completion` call. As `#[tokio::test]`s they could not:
+/// `HOME_LOCK` is a `std::sync::Mutex` and clippy's `await_holding_lock`
+/// correctly forbids holding its guard across `.await`, which is precisely
+/// why they were left on `#[serial]` alone and became the landmine #3952
+/// describes. Inverting the structure removes the conflict instead of
+/// suppressing it: a SYNC `#[test]` holds the guards and hands the future to
+/// an explicit runtime, so there is no `.await` in the guarded scope at all
+/// and the lint never applies. This is the same manoeuvre PR #3976 used to
+/// bring the embedder reference-accuracy test under its module's existing
+/// std lock (issue #3711).
+/// What: builds a fresh `Builder::new_current_thread().enable_all()` runtime
+/// — current-thread, never `Runtime::new()`/`new_multi_thread()`, both of
+/// which `crate::test_env::lock_home` now rejects outright (#3957) — and
+/// `block_on`s the future on the calling thread, which is the same thread
+/// that owns the `HomeLockGuard`.
+/// Test: used by every `send_raw_completion_*` test in this module.
+fn block_on<F: std::future::Future>(fut: F) -> F::Output {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("current-thread runtime")
+        .block_on(fut)
+}
 
 /// Why (fix regression test): `send_raw_completion` takes its auth value
 /// from `adapter.api_endpoint(false)`, which for `GenericAdapter` (no
@@ -31,21 +63,49 @@ use async_openai::types::{
 /// with a non-empty bearer token instead of bailing with "credential not
 /// found".
 /// Test: itself.
-// NOTE: none of the async tests below hold `crate::test_env::{ENV_LOCK,
-// HOME_LOCK}` (`std::sync::Mutex`) across their `.await` — clippy's
-// `await_holding_lock` correctly forbids that for a sync mutex. `#[serial]`
-// (unnamed group) provides the cross-test exclusion instead, matching the
-// established pattern in `inference_client::tests::with_store_honours_openrouter_base_url_override`.
+// #3952: every test below that sandboxes `$HOME` now holds
+// `crate::test_env::lock_home()` for its whole body — the crate's ONE `$HOME`
+// synchronization domain — instead of relying on `#[serial]` alone.
+//
+// The old arrangement was two mutually unaware exclusion mechanisms:
+// `#[serial]` (unnamed group) only excludes other `#[serial]`-tagged tests,
+// while dozens of `$HOME`-sandboxing tests elsewhere in this crate
+// (`listeners::poll`, `tools::mcp_tools`, `init::tests::*`, `api::server`,
+// `slack`, ...) exclude each other via `HOME_LOCK` and carry no `#[serial]`.
+// Neither mechanism serializes against the other, so this file's `$HOME`
+// swaps raced all of them — confirmed as the root cause of #3922's
+// `listeners::store::tests::dedup_seed_loads_recent_ids` CI flake. Two locks
+// do not serialize against each other; that is the same defect shape PR
+// #3976 fixed in the embedder module by collapsing two env-lock statics into
+// one, and the fix here is the same discipline, not a third mechanism.
+//
+// `#[serial]` is RETAINED (not replaced) because these tests also mutate
+// process-global credential env vars, whose domain is `ENV_LOCK` + the
+// crate-wide `#[serial]` convention documented in `llm::helpers::tests` —
+// unrelated to `$HOME`. Lock order matches every other multi-lock test in
+// this crate (`llm::{credentials,helpers,adapter}::tests`,
+// `system_status::credentials`): `#[serial]` → `ENV_LOCK` → `HOME_LOCK`.
+//
+// Holding sync guards is possible at all because these are now sync
+// `#[test]`s driving `block_on` (see this module's helper), so clippy's
+// `await_holding_lock` — the reason they were on `#[serial]` alone — no
+// longer applies to anything.
 
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn send_raw_completion_resolves_key_from_store_when_env_absent() {
+fn send_raw_completion_resolves_key_from_store_when_env_absent() {
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    // #3952: single `$HOME` domain — `lock_home()`, not the raw `HOME_LOCK`,
+    // so `listeners::store::events_dir`'s per-thread ownership guard also
+    // recognises this test as participating.
+    let _home_guard = crate::test_env::lock_home();
     // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
     crate::test_env::force_env_local_loaded();
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_home = std::env::var_os("HOME");
-    // SAFETY: `#[serial]` (unnamed group) serializes against every other
-    // unnamed `#[serial]` test in this binary.
+    // SAFETY: ENV_LOCK + HOME_LOCK held for the whole test body.
     unsafe {
         std::env::remove_var("OPENROUTER_API_KEY");
     }
@@ -69,15 +129,14 @@ async fn send_raw_completion_resolves_key_from_store_when_env_absent() {
     // Point it at an unroutable loopback port instead so the request
     // fails fast on connection refusal (not on auth), letting us assert
     // the fallback resolved a non-empty key without touching the network.
-    // SAFETY: still under `#[serial]` exclusion.
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
     unsafe {
         std::env::set_var("OPENROUTER_BASE_URL", "http://127.0.0.1:1");
     }
 
     let adapter = crate::llm::adapter::GenericAdapter;
     let body = serde_json::json!({"model": "gpt-4o", "messages": []});
-    let err = send_raw_completion(&body, &adapter)
-        .await
+    let err = block_on(send_raw_completion(&body, &adapter))
         .expect_err("connection to 127.0.0.1:1 must fail");
     let msg = format!("{err:#}");
     assert!(
@@ -85,7 +144,7 @@ async fn send_raw_completion_resolves_key_from_store_when_env_absent() {
         "must not report a missing credential when the store has one: {msg}"
     );
 
-    // SAFETY: still under `#[serial]` exclusion.
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
     unsafe {
         std::env::remove_var("OPENROUTER_BASE_URL");
         match prev_openrouter {
@@ -104,14 +163,19 @@ async fn send_raw_completion_resolves_key_from_store_when_env_absent() {
 /// instead of silently sending an empty bearer token and letting the
 /// provider's bare 401 stand in for the real problem.
 /// Test: itself.
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn send_raw_completion_missing_everywhere_errors_with_provider_name() {
+fn send_raw_completion_missing_everywhere_errors_with_provider_name() {
+    // #3952: ENV_LOCK then HOME_LOCK, held for the whole body.
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home_guard = crate::test_env::lock_home();
     // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
     crate::test_env::force_env_local_loaded();
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_home = std::env::var_os("HOME");
-    // SAFETY: `#[serial]` (unnamed group) provides exclusion.
+    // SAFETY: ENV_LOCK + HOME_LOCK held for the whole test body.
     unsafe {
         std::env::remove_var("OPENROUTER_API_KEY");
     }
@@ -123,8 +187,7 @@ async fn send_raw_completion_missing_everywhere_errors_with_provider_name() {
 
     let adapter = crate::llm::adapter::GenericAdapter;
     let body = serde_json::json!({"model": "gpt-4o", "messages": []});
-    let err = send_raw_completion(&body, &adapter)
-        .await
+    let err = block_on(send_raw_completion(&body, &adapter))
         .expect_err("no credential anywhere must error, not send an empty key");
     let msg = format!("{err:#}");
     assert!(
@@ -132,7 +195,7 @@ async fn send_raw_completion_missing_everywhere_errors_with_provider_name() {
         "error must name the provider and say credential not found: {msg}"
     );
 
-    // SAFETY: still under `#[serial]` exclusion.
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
     unsafe {
         match prev_openrouter {
             Some(v) => std::env::set_var("OPENROUTER_API_KEY", v),
@@ -182,14 +245,19 @@ impl ModelAdapter for NoCredentialAdapter {
 /// that supplies NO credential in its `ApiEndpoint`) must still resolve
 /// through the shared 3-tier resolver rather than a raw env read.
 /// Test: itself.
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn send_raw_completion_empty_endpoint_credential_falls_back_to_store() {
+fn send_raw_completion_empty_endpoint_credential_falls_back_to_store() {
+    // #3952: ENV_LOCK then HOME_LOCK, held for the whole body.
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home_guard = crate::test_env::lock_home();
     // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
     crate::test_env::force_env_local_loaded();
     let prev_openrouter = std::env::var_os("OPENROUTER_API_KEY");
     let prev_home = std::env::var_os("HOME");
-    // SAFETY: `#[serial]` (unnamed group) provides exclusion.
+    // SAFETY: ENV_LOCK + HOME_LOCK held for the whole test body.
     unsafe {
         std::env::remove_var("OPENROUTER_API_KEY");
     }
@@ -207,8 +275,7 @@ async fn send_raw_completion_empty_endpoint_credential_falls_back_to_store() {
 
     let adapter = NoCredentialAdapter;
     let body = serde_json::json!({"model": "gpt-4o", "messages": []});
-    let err = send_raw_completion(&body, &adapter)
-        .await
+    let err = block_on(send_raw_completion(&body, &adapter))
         .expect_err("connection to 127.0.0.1:1 must fail");
     let msg = format!("{err:#}");
     assert!(
@@ -216,7 +283,7 @@ async fn send_raw_completion_empty_endpoint_credential_falls_back_to_store() {
         "must not report a missing credential when the store has one: {msg}"
     );
 
-    // SAFETY: still under `#[serial]` exclusion.
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
     unsafe {
         match prev_openrouter {
             Some(v) => std::env::set_var("OPENROUTER_API_KEY", v),
@@ -234,14 +301,19 @@ async fn send_raw_completion_empty_endpoint_credential_falls_back_to_store() {
 /// credential not found" — the wrong provider name AND the wrong env
 /// var/config hint. This proves the error now names Fireworks.
 /// Test: itself.
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn send_raw_completion_fireworks_missing_key_errors_with_fireworks_name() {
+fn send_raw_completion_fireworks_missing_key_errors_with_fireworks_name() {
+    // #3952: ENV_LOCK then HOME_LOCK, held for the whole body.
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home_guard = crate::test_env::lock_home();
     // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
     crate::test_env::force_env_local_loaded();
     let prev_fireworks = std::env::var_os("FIREWORKS_API_KEY");
     let prev_home = std::env::var_os("HOME");
-    // SAFETY: `#[serial]` (unnamed group) provides exclusion.
+    // SAFETY: ENV_LOCK + HOME_LOCK held for the whole test body.
     unsafe {
         std::env::remove_var("FIREWORKS_API_KEY");
     }
@@ -255,8 +327,7 @@ async fn send_raw_completion_fireworks_missing_key_errors_with_fireworks_name() 
         model_id: "accounts/fireworks/models/llama-v3p1-8b-instruct".to_string(),
     };
     let body = serde_json::json!({"model": "accounts/fireworks/models/llama-v3p1-8b-instruct", "messages": []});
-    let err = send_raw_completion(&body, &adapter)
-        .await
+    let err = block_on(send_raw_completion(&body, &adapter))
         .expect_err("no fireworks credential anywhere must error, not send an empty key");
     let msg = format!("{err:#}");
     assert!(
@@ -268,7 +339,7 @@ async fn send_raw_completion_fireworks_missing_key_errors_with_fireworks_name() 
         "error must hint the correct env var: {msg}"
     );
 
-    // SAFETY: still under `#[serial]` exclusion.
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
     unsafe {
         match prev_fireworks {
             Some(v) => std::env::set_var("FIREWORKS_API_KEY", v),
@@ -286,15 +357,19 @@ async fn send_raw_completion_fireworks_missing_key_errors_with_fireworks_name() 
 /// `send_raw_completion_resolves_key_from_store_when_env_absent` but for
 /// the new `FireworksAdapter` instead of `GenericAdapter`/OpenRouter.
 /// Test: itself.
-#[tokio::test]
+#[test]
 #[serial_test::serial]
-async fn send_raw_completion_fireworks_resolves_key_from_store_when_env_absent() {
+fn send_raw_completion_fireworks_resolves_key_from_store_when_env_absent() {
+    // #3952: ENV_LOCK then HOME_LOCK, held for the whole body.
+    let _env_guard = crate::test_env::ENV_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let _home_guard = crate::test_env::lock_home();
     // #3464: see `crate::test_env::force_env_local_loaded`'s docs.
     crate::test_env::force_env_local_loaded();
     let prev_fireworks = std::env::var_os("FIREWORKS_API_KEY");
     let prev_home = std::env::var_os("HOME");
-    // SAFETY: `#[serial]` (unnamed group) serializes against every other
-    // unnamed `#[serial]` test in this binary.
+    // SAFETY: ENV_LOCK + HOME_LOCK held for the whole test body.
     unsafe {
         std::env::remove_var("FIREWORKS_API_KEY");
     }
@@ -315,7 +390,7 @@ async fn send_raw_completion_fireworks_resolves_key_from_store_when_env_absent()
     // Point the adapter at an unroutable loopback port so the request
     // fails fast on connection refusal (not on auth), proving the
     // fallback resolved a non-empty key without touching the network.
-    // SAFETY: still under `#[serial]` exclusion.
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
     unsafe {
         std::env::set_var("FIREWORKS_BASE_URL", "http://127.0.0.1:1/inference/v1");
     }
@@ -324,8 +399,7 @@ async fn send_raw_completion_fireworks_resolves_key_from_store_when_env_absent()
         model_id: "accounts/fireworks/models/llama-v3p1-8b-instruct".to_string(),
     };
     let body = serde_json::json!({"model": "accounts/fireworks/models/llama-v3p1-8b-instruct", "messages": []});
-    let err = send_raw_completion(&body, &adapter)
-        .await
+    let err = block_on(send_raw_completion(&body, &adapter))
         .expect_err("connection to 127.0.0.1:1 must fail");
     let msg = format!("{err:#}");
     assert!(
@@ -333,7 +407,7 @@ async fn send_raw_completion_fireworks_resolves_key_from_store_when_env_absent()
         "must not report a missing credential when the store has one: {msg}"
     );
 
-    // SAFETY: still under `#[serial]` exclusion.
+    // SAFETY: still holding ENV_LOCK + HOME_LOCK.
     unsafe {
         std::env::remove_var("FIREWORKS_BASE_URL");
         match prev_fireworks {

--- a/crates/trusty-agents/src/test_env.rs
+++ b/crates/trusty-agents/src/test_env.rs
@@ -55,6 +55,10 @@ thread_local! {
 /// marks this OS thread as the current holder, so
 /// [`home_lock_held_by_this_thread`] can answer "do *I* hold it?" instead of
 /// "is it contended by ANYONE?".
+///
+/// Deliberately `!Send` (it owns a `std::sync::MutexGuard`, which is `!Send`)
+/// — see [`assert_home_lock_guard_is_not_send`] for why that negative bound
+/// is load-bearing and compile-time asserted rather than merely inherited.
 pub struct HomeLockGuard {
     _inner: MutexGuard<'static, ()>,
 }
@@ -62,6 +66,84 @@ pub struct HomeLockGuard {
 impl Drop for HomeLockGuard {
     fn drop(&mut self) {
         HOME_LOCK_HELD_HERE.with(|c| c.set(false));
+    }
+}
+
+// #3957: layer 1 of 2 — COMPILE-TIME. `HomeLockGuard`'s thread-local
+// ownership flag is only meaningful while the guard cannot leave the thread
+// that created it: if the guard were moved to another thread, `Drop` would
+// clear the flag over THERE while the creating thread's flag stayed
+// permanently `true`, and any later, genuinely unguarded caller that happened
+// to run on that thread would read the stale `true` and sail past
+// `listeners::store::events_dir`'s recurrence guard — silently reintroducing
+// exactly the masking bug #3922/#3943 exist to close. Today the property is
+// inherited for free from `MutexGuard: !Send`, and that inheritance is
+// precisely what makes `tokio::spawn(async { let _g = lock_home(); .await })`
+// a COMPILE error (a spawned future must be `Send`). This assertion pins the
+// property so a future refactor of the guard's innards (e.g. swapping in a
+// `parking_lot` guard, or boxing state behind an `Arc`) cannot quietly make
+// it `Send` and reopen the hole; it fails at `cargo test` compile time, not
+// at review time.
+//
+// The mechanism is `static_assertions::assert_not_impl_any!`'s trick,
+// inlined because the workspace does not depend on that crate: two blanket
+// impls of a private helper trait — one for all types, one for `Send` types —
+// leave the `AmbiguousIfSend<_>` inference variable UNRESOLVABLE when (and
+// only when) the subject type is `Send`, so a `Send` guard fails to compile
+// with E0282/E0283.
+#[expect(
+    dead_code,
+    reason = "#3957: compile-time-only assertion; never executed"
+)]
+fn assert_home_lock_guard_is_not_send() {
+    trait AmbiguousIfSend<A> {
+        fn some_item() {}
+    }
+    impl<T: ?Sized> AmbiguousIfSend<()> for T {}
+    impl<T: ?Sized + Send> AmbiguousIfSend<u8> for T {}
+    let _ = <HomeLockGuard as AmbiguousIfSend<_>>::some_item;
+}
+
+/// Panic if the calling thread is running inside a MULTI-THREADED tokio
+/// runtime, where [`HOME_LOCK_HELD_HERE`]'s per-thread bookkeeping is not
+/// sound (#3957).
+///
+/// Why: the thread-local ownership model is correct only because a
+/// current-thread runtime pins a test's ENTIRE execution — every `.await`
+/// point included — to the one OS thread that `block_on`s it. On a
+/// multi-threaded runtime that pinning disappears: a task can resume on a
+/// different pool worker, the creating thread's `Cell` can stay `true`
+/// after the logical owner has moved on, and a later, genuinely unguarded
+/// task scheduled onto that reused thread reads the stale `true` and
+/// silently defeats `listeners::store::events_dir`'s guard. `tokio`'s
+/// `features = ["full"]` makes `rt-multi-thread` available to any future
+/// test in this crate, and prose in a doc comment does not stop anyone —
+/// so this refuses at the exact moment of danger with a message naming the
+/// alternatives. `Handle::try_current()` returning `Err` (no ambient
+/// runtime — a plain `#[test]`, or a `std::thread`) is fine: there is no
+/// scheduler that could migrate anything, so the thread is stable.
+/// What: reads `Handle::try_current()`'s `runtime_flavor()` and panics on
+/// `RuntimeFlavor::MultiThread`. Deliberately checked BEFORE `HOME_LOCK` is
+/// acquired, so a rejected caller never holds (nor poisons) the mutex.
+/// Note this also (intentionally) rejects `spawn_blocking` bodies on a
+/// multi-threaded runtime: those run on a reused pool thread, which is the
+/// same hazard.
+/// Test: `test_env::tests::lock_home_rejects_a_multi_thread_runtime`.
+fn assert_single_threaded_runtime_context() {
+    if let Ok(handle) = tokio::runtime::Handle::try_current()
+        && handle.runtime_flavor() == tokio::runtime::RuntimeFlavor::MultiThread
+    {
+        panic!(
+            "crate::test_env::lock_home(): called from a MULTI-THREADED tokio runtime \
+             (issue #3957). This guard tracks lock ownership in a thread-local, which is \
+             only sound while a task cannot migrate between OS threads — a multi-threaded \
+             runtime can leave the flag permanently set on a worker thread and let a later, \
+             genuinely unguarded caller read it as `true`, defeating \
+             `listeners::store::events_dir`'s recurrence guard (issue #3922). Use the \
+             default current-thread `#[tokio::test]` (no `flavor = \"multi_thread\"`), or \
+             — preferably — stop sandboxing $HOME entirely and inject a tempdir via an \
+             `*_at(dir, ..)` seam (see `listeners::store::EventStore`)."
+        );
     }
 }
 
@@ -86,19 +168,30 @@ impl Drop for HomeLockGuard {
 /// never poisons the lock for siblings), wrapped in a guard that also flips
 /// a thread-local flag on acquire and clears it on drop.
 /// `cargo test`'s default current-thread `#[tokio::test]` runtime (used by
-/// every test in this crate — grep confirms no test opts into
-/// `flavor = "multi_thread"`) pins an async test's ENTIRE execution,
+/// every test in this crate) pins an async test's ENTIRE execution,
 /// including every `.await` point, to the one OS thread that `block_on`s
 /// it, so a thread-local set for this guard's lifetime correctly tracks
 /// "this test currently holds the lock" without needing a heavier
 /// `tokio::task_local!` (which would additionally force every call site to
 /// restructure its body into a `.scope(...)` future — a much larger,
 /// crate-wide change this fix does not need).
+///
+/// #3957: that pinning precondition is no longer a grep-verified assumption
+/// that a future test could silently break. It is now enforced twice — at
+/// compile time by [`assert_home_lock_guard_is_not_send`] (the guard cannot
+/// be moved to, or `tokio::spawn`ed onto, another thread) and at run time by
+/// [`assert_single_threaded_runtime_context`] (acquiring inside a
+/// multi-threaded runtime panics on the spot). See both for the full
+/// argument.
+///
 /// Test: `listeners::store::tests::events_dir_panics_when_a_different_thread_holds_home_lock`
 /// (the exact masking scenario this seam exists to close) plus every
 /// migrated caller in `listeners::poll`, `api::server::tests::listener_events`,
-/// and `slack::tests::eventstream_tests`.
+/// and `slack::tests::eventstream_tests`; the #3957 guards themselves in
+/// `test_env::tests`.
 pub fn lock_home() -> HomeLockGuard {
+    // #3957: reject the unsound context BEFORE taking the mutex.
+    assert_single_threaded_runtime_context();
     let guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
     HOME_LOCK_HELD_HERE.with(|c| c.set(true));
     HomeLockGuard { _inner: guard }
@@ -112,6 +205,13 @@ pub fn lock_home() -> HomeLockGuard {
 /// What: `true` only while the CURRENT thread's own `lock_home()` guard is
 /// still alive; `false` in every other case, INCLUDING "some other thread
 /// holds `HOME_LOCK`" — that distinction is the entire point.
+///
+/// #3957: this reader needs no runtime-flavor check of its own. A stale
+/// `true` is the only unsafe answer it could give, and the flag can only be
+/// set by [`lock_home`], which refuses to run in the one context that could
+/// strand it. A `false` read from an unexpected thread is always safe: it
+/// makes `listeners::store::events_dir` panic loudly rather than pass
+/// silently.
 pub fn home_lock_held_by_this_thread() -> bool {
     HOME_LOCK_HELD_HERE.with(|c| c.get())
 }
@@ -271,4 +371,103 @@ pub async fn spawn_script(path: &std::path::Path) -> std::io::Result<tokio::proc
         }
     }
     Err(last_err.unwrap())
+}
+
+/// Tests for this module's own #3957 durability guards.
+///
+/// Why: `lock_home`'s thread-local ownership model is only sound under a
+/// single-threaded execution context, and #3957 asked for that precondition
+/// to be enforced rather than merely documented. An enforcement mechanism
+/// nobody exercises rots exactly like the prose it replaced, so both the
+/// rejection path and the accepted paths are pinned here.
+/// What: the multi-threaded-runtime rejection, plus the two contexts that
+/// must keep working (no ambient runtime, and the default current-thread
+/// `#[tokio::test]` runtime every other test in this crate uses).
+/// Test: this IS the test module.
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #3957: acquiring `lock_home()` inside a multi-threaded tokio runtime
+    /// must panic, not quietly hand back a guard whose thread-local flag
+    /// can be stranded on a pool worker. Also asserts the rejection is
+    /// clean — the flag is untouched and (because the check runs before the
+    /// acquisition) no `HOME_LOCK` guard was ever created.
+    #[test]
+    fn lock_home_rejects_a_multi_thread_runtime() {
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .expect("multi-thread runtime");
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            rt.block_on(async {
+                let _guard = lock_home();
+            });
+        }));
+
+        assert!(
+            result.is_err(),
+            "lock_home() must refuse a multi-threaded runtime — its thread-local \
+             ownership flag cannot survive task migration (#3957)"
+        );
+        let msg = result
+            .err()
+            .and_then(|e| {
+                e.downcast_ref::<String>()
+                    .cloned()
+                    .or_else(|| e.downcast_ref::<&str>().map(|s| (*s).to_string()))
+            })
+            .unwrap_or_default();
+        assert!(
+            msg.contains("#3957"),
+            "the panic must name the issue and the remedy, got: {msg}"
+        );
+        assert!(
+            !home_lock_held_by_this_thread(),
+            "a rejected acquisition must leave no ownership flag behind"
+        );
+    }
+
+    /// #3957: the rejection must not catch the contexts every real caller
+    /// uses — a plain `#[test]` with no ambient runtime at all, where no
+    /// scheduler exists to migrate anything.
+    #[test]
+    fn lock_home_accepts_a_thread_with_no_ambient_runtime() {
+        assert!(!home_lock_held_by_this_thread());
+        {
+            let _guard = lock_home();
+            assert!(
+                home_lock_held_by_this_thread(),
+                "the guard must mark this thread as the holder"
+            );
+        }
+        assert!(
+            !home_lock_held_by_this_thread(),
+            "dropping the guard must clear this thread's ownership flag"
+        );
+    }
+
+    /// #3957: likewise for the default current-thread `#[tokio::test]`
+    /// runtime — the flavor every `$HOME`-sandboxing test in this crate
+    /// runs on, which pins the whole test (every `.await` included) to one
+    /// OS thread and so keeps the thread-local honest.
+    // `await_holding_lock` is the whole point here: holding a sync guard
+    // across `.await` is exactly what this crate's HOME-sandboxing tests do,
+    // and this test asserts that doing so stays sound on this flavor.
+    #[allow(
+        clippy::await_holding_lock,
+        reason = "#3957: the held-across-await case IS the property under test"
+    )]
+    #[tokio::test]
+    async fn lock_home_accepts_the_default_current_thread_runtime() {
+        let _guard = lock_home();
+        assert!(home_lock_held_by_this_thread());
+        tokio::task::yield_now().await;
+        assert!(
+            home_lock_held_by_this_thread(),
+            "ownership must survive an .await on a current-thread runtime"
+        );
+    }
 }

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/checkpoint_resume.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/checkpoint_resume.rs
@@ -19,6 +19,23 @@
 //! the §3.5 failure-matrix fail-closed paths plus the two code-critic
 //! findings from PR #3244 (summary/content conflation, concurrent-resume
 //! mutual exclusion).
+//!
+//! #3989 — why every engine-driving test in THIS DIRECTORY is `#[serial]`,
+//! not just the ones in this file: `WorkflowEngine::run()` resolves its
+//! checkpoint destination from two PROCESS-GLOBAL env vars —
+//! `TAGENT_RUN_ID` (`executor/run.rs`) and `TAGENT_PROJECT_DIR` via
+//! `crate::usage::project_dir()` (`executor/phase_loop.rs`). The tests here
+//! own both for their bodies through `EnvVarGuard` + `#[serial]`, but
+//! `#[serial]` excludes only other `#[serial]` tests. A sibling test that
+//! drove the real engine WITHOUT the attribute therefore inherited this
+//! file's tempdir AND this file's run id, and wrote its own checkpoint over
+//! this file's journal — surfacing here as a checkpoint whose phases belong
+//! to a completely different workflow (`plan`, not `phase-a`). Guarding the
+//! writer is not enough when the guarded value is *read and acted on* by
+//! code outside the guard's domain; the readers have to join it too. Same
+//! defect shape as #3398, whose reader/writer halves this completes. The
+//! durable fix (inject `project_dir`/`run_id` into the engine, so no test
+//! needs the globals at all) is tracked in #3989.
 //! Test: This file IS the test suite.
 
 use std::collections::HashMap;

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/parallel_merge.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/parallel_merge.rs
@@ -76,6 +76,10 @@ fn parallel_workflow_json(label_a: &str, suffix_a: &str, label_b: &str, suffix_b
 /// directory) must fail the phase/workflow — not be swallowed into a
 /// `"merge failed: ..."` string appended to a successful `AgentOutput`.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn parallel_phase_merge_io_failure_fails_the_workflow() {
     let tmp = tempfile::tempdir().unwrap();
     let out_dir = tmp.path().join("out");
@@ -135,6 +139,10 @@ async fn parallel_phase_merge_io_failure_fails_the_workflow() {
 /// succeed exactly as before — both sub-agents' content shows up in the
 /// aggregated output and the merged files land on disk under `out_dir`.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn parallel_phase_clean_merge_still_succeeds() {
     let tmp = tempfile::tempdir().unwrap();
     let out_dir = tmp.path().join("out");

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/phase_order.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/phase_order.rs
@@ -72,6 +72,10 @@ fn discover_project_dir_falls_back_to_out_dir_when_no_project() {
 /// that snapshots the `out_dir` contents when QA is invoked, and assert
 /// both extracted files are visible from QA's perspective.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn files_are_extracted_before_next_phase_runs() {
     let tmp = tempfile::tempdir().expect("tempdir");
     let out_dir = tmp.path().to_path_buf();
@@ -137,6 +141,10 @@ async fn files_are_extracted_before_next_phase_runs() {
 /// if its output contains `## File:` sections. This guards the opt-in
 /// semantics — only the code phase should touch disk.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn phase_without_produces_files_does_not_extract() {
     let tmp = tempfile::tempdir().unwrap();
     let out_dir = tmp.path().to_path_buf();
@@ -184,6 +192,10 @@ async fn phase_without_produces_files_does_not_extract() {
 /// (`out/legacy-monolithic-test`), let `run_with_perf` create and
 /// canonicalize it, and assert the runner observed an absolute path.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn legacy_monolithic_path_passes_absolute_working_dir() {
     // Drive a relative out_dir path, mirroring how the CLI
     // (`--out-dir out/...`) actually wires this.

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/relocate.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/relocate.rs
@@ -206,6 +206,10 @@ async fn post_code_reconcile_is_noop_without_assignments() {
 /// engine prepends the path-search hint to the QA prompt, while leaving
 /// it absent for non-claude-code runners.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn qa_receives_correct_path_for_claude_code_runner() {
     // Arrange: a workflow with a code phase that uses an agent backed by
     // the claude-code runner, then a QA phase. We capture the rendered

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/retry.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/retry.rs
@@ -23,6 +23,10 @@ use crate::workflow::engine::retry::run_wave_file_with_retry;
 /// made.
 /// Test: this function.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn wave_loop_retries_on_transient_error() {
     use std::sync::atomic::{AtomicU32, Ordering};
 
@@ -119,6 +123,10 @@ async fn wave_loop_retries_on_transient_error() {
 /// exactly one call is made and the error propagates.
 /// Test: this function.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn wave_loop_does_not_retry_fatal_error() {
     use std::sync::atomic::{AtomicU32, Ordering};
 

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/skill_discovery.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/skill_discovery.rs
@@ -16,6 +16,10 @@ use super::*;
 /// We use a recording mock that captures the exact task text the runner
 /// receives and assert the prefix appears before the task body.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn init_context_is_prepended_to_phase_template() {
     struct RecordingRunner {
         tasks: Arc<Mutex<Vec<String>>>,
@@ -226,6 +230,10 @@ fn skill_discovery_returns_empty_when_registry_absent() {
 /// containing the "## Available Skills" header. Other phases must NOT
 /// receive that block.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn plan_agent_context_includes_skill_summaries() {
     let (_keep, reg) = temp_tag_registry_with_python_skills();
 

--- a/crates/trusty-agents/src/workflow/engine/executor/tests/wave_loop.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/tests/wave_loop.rs
@@ -21,6 +21,10 @@ use crate::workflow::engine::step_dispatch::{precreate_package_markers, should_p
 /// once per file in wave order, sets `TAGENT_ASSIGNED_FILE` for each
 /// call, and each file's prompt names the correct path.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn wave_loop_runs_one_agent_per_file() {
     let tmp = tempfile::tempdir().unwrap();
     let out_dir = tmp.path().to_path_buf();
@@ -131,6 +135,10 @@ async fn wave_loop_runs_one_agent_per_file() {
 /// recorded prompt contains the absolute path and the ABSOLUTE PATH
 /// warning language.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn wave_loop_task_uses_absolute_path_for_write() {
     let tmp = tempfile::tempdir().unwrap();
     let out_dir = tmp.path().to_path_buf();
@@ -218,6 +226,10 @@ async fn wave_loop_task_uses_absolute_path_for_write() {
 /// fall through to the legacy path. We assert the wave loop fires by
 /// counting per-file code-agent invocations.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn wave_loop_triggers_after_plan_phase_writes_assignments() {
     let tmp = tempfile::tempdir().unwrap();
     let out_dir = tmp.path().to_path_buf();
@@ -299,6 +311,10 @@ async fn wave_loop_triggers_after_plan_phase_writes_assignments() {
 /// #88: A workflow without assignments.json runs the code phase the old
 /// way — one invocation of the code-agent, not per-file.
 #[tokio::test]
+// #3989: joins the crate-wide `#[serial]` group — this test drives the real
+// `WorkflowEngine`, which resolves its checkpoint path from the PROCESS-GLOBAL
+// `TAGENT_PROJECT_DIR`/`TAGENT_RUN_ID`. See `checkpoint_resume.rs`'s module docs.
+#[serial_test::serial]
 async fn wave_loop_skipped_when_assignments_absent() {
     let tmp = tempfile::tempdir().unwrap();
     let out_dir = tmp.path().to_path_buf();


### PR DESCRIPTION
Closes #3952. Closes #3957.

Two exclusion mechanisms that are not mutually aware do not compose. These
two issues are the last two ways that fact could still bite `trusty-agents`.

## #3952 — the two `$HOME` domains, collapsed into one

`llm::http::tests`'s five credential tests sandboxed `$HOME` under
`#[serial]` **alone**, while dozens of tests elsewhere in the crate sandbox
it under `HOME_LOCK` and carry no `#[serial]`. `#[serial]` excludes only
other `#[serial]` tests; `HOME_LOCK` excludes only other lock-takers.
Neither says anything about the other, so those five raced every one of
them — the confirmed root cause of #3922's CI flake.

They could not simply add `HOME_LOCK`: as `#[tokio::test]`s they would hold
a `std::sync::Mutex` guard across `.await`, which `clippy::await_holding_lock`
correctly forbids — the exact reason they were left on `#[serial]` in the
first place. **Inverting the structure removes the conflict instead of
suppressing it**: a sync `#[test]` holds `ENV_LOCK` + `lock_home()` and
hands the future to an explicit current-thread runtime, so there is no
`.await` inside the guarded scope at all and the lint never applies. Same
manoeuvre PR #3976 used to bring the embedder reference-accuracy test under
its module's existing std lock, and the same discipline it established: one
domain, not a third mechanism. Assertions are unchanged.

`#[serial]` is **retained**, not replaced — these tests also mutate
credential env vars, whose domain is `ENV_LOCK` + the crate-wide `#[serial]`
convention, unrelated to `$HOME`. Lock order matches every other multi-lock
test in the crate: `#[serial]` → `ENV_LOCK` → `HOME_LOCK`.

### The race, reproduced and then closed

Pre-fix, under maximised parallelism (`--test-threads=32`, HOME-sandboxing
modules packed together) — **4/5 runs FAILED**, in both directions:

```
run 1: test result: FAILED. 288 passed; 1 failed; ...
run 2: test result: FAILED. 288 passed; 1 failed; ...
run 3: test result: FAILED. 288 passed; 1 failed; ...
run 4: test result: FAILED. 288 passed; 1 failed; ...
run 5: test result: ok.     289 passed; 0 failed; ...
```

A `HOME_LOCK`-holding test reading the http tests' tempdir `$HOME`:

```
---- ctrl::tests::config_tests::resolve_agent_config_falls_back_to_project_ctrl_toml stdout ----
panicked at crates/trusty-agents/src/ctrl/tests/config_tests.rs:253:5:
assertion failed: matches!(cfg.agent.role.as_str(), "controller" | "ctrl")
```

…and, in the same run, an http test reading a `HOME_LOCK` test's `$HOME`,
resolving a real secure-store credential and making a **live network call**
to `api.fireworks.ai` — from a test written to never touch the network:

```
---- llm::http::tests::send_raw_completion_fireworks_missing_key_errors_with_fireworks_name stdout ----
panicked at crates/trusty-agents/src/llm/http/tests.rs:262:5:
error must name fireworks, not openrouter: HTTP status client error (404 Not Found)
for url (https://api.fireworks.ai/inference/v1/chat/completions)
```

Post-fix, the same command, **10 consecutive runs**: see Verification below.

## #3957 — prose replaced by mechanism, in two layers

The thread-local ownership flag behind `lock_home()` /
`home_lock_held_by_this_thread()` is sound only while a task cannot migrate
between OS threads. That was a grep-verified assumption about the crate's
tokio flavors, with `tokio = ["full"]` leaving `rt-multi-thread` one
attribute away. It is now enforced:

**Compile time.** `HomeLockGuard` is asserted `!Send` via
`static_assertions::assert_not_impl_any!`'s trick, inlined (the workspace
has no such dependency). The property is inherited today from
`MutexGuard: !Send` — the assertion pins it so a future refactor of the
guard's innards cannot quietly make it `Send`. It is a real gate, not a
no-op; the same construct against a `Send` type fails to compile:

```
error[E0283]: type annotations needed
   | let _ = <SendThing as AmbiguousIfSend<_>>::some_item;
   | cannot infer type of the type parameter `A` declared on the trait `AmbiguousIfSend`
note: multiple `impl`s satisfying `SendThing: AmbiguousIfSend<_>` found
```

This is what already makes `tokio::spawn(async { let _g = lock_home(); … })`
a compile error — a spawned future must be `Send`.

**Run time.** `lock_home()` panics if `Handle::try_current()` reports
`RuntimeFlavor::MultiThread`, checked **before** the mutex is acquired so a
rejected caller never holds or poisons it, with a message naming the issue
and both remedies. `Err` (no ambient runtime) is fine — no scheduler exists
to migrate anything. Chose this over #3957's Option A (a `check_line_cap.sh`
-style grep gate): it fires at the exact moment of danger rather than on a
regex, and it cannot be satisfied by spelling the flavor differently.

Three tests pin it: the rejection (asserting the panic names #3957 and
leaves no ownership flag behind) and both accepted contexts — no ambient
runtime, and the default current-thread `#[tokio::test]` including across an
`.await`.

## #3989 — a latent race the fix surfaced, fixed here as an interim

Closing #3952 changes crate-wide test scheduling, which exposed a
**pre-existing** defect (10/10 green on `main`, ~2/6 failing here before this
part): 14 unguarded tests drive the real `WorkflowEngine`, whose checkpoint
destination comes from the process-global `TAGENT_RUN_ID` and
`TAGENT_PROJECT_DIR` that `checkpoint_resume`'s `#[serial]` tests own. An
unguarded run inherits *both* and writes its own journal over the serial
test's. Diagnostic capture — the record at the test's own run-id path
belongs to a different workflow entirely (`plan`, not `phase-a`):

```
DIAG project_dir="/var/folders/.../.tmpqrEeDw"
DIAG TAGENT_PROJECT_DIR=Some("/var/folders/.../.tmpqrEeDw")
DIAG state=PhaseRunning { phase_index: 1 } phase_outputs_keys=["plan"] summaries={"plan": "planned"}
```

Guarding a writer does nothing for readers outside the domain — precisely
#3952's shape, and the reader half of #3398. The 14 readers join the domain
here (8/8 clean full-suite runs); the durable injection fix is tracked in
**#3989**.

Also filed **#3990** and deliberately **not** fixed: `ctrl::tests::config_tests::
resolve_agent_config_falls_back_to_project_ctrl_toml` reads `$HOME` with no
lock and races its own siblings. It reproduces identically on pristine
`main` (~2/3 runs under the same filtered command) and is neither caused nor
worsened here.

## Verification

`cargo test -p trusty-agents` (all 10 binaries, rebased on `eb573dbd`):

```
running 2626 tests
test result: ok. 2627 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 32.78s
test result: ok. 6 passed; 0 failed; ...
test result: ok. 4 passed; 0 failed; 3 ignored; ...
test result: ok. 2 passed; 0 failed; ...
test result: ok. 3 passed; 0 failed; ...
test result: ok. 2 passed; 0 failed; ...
test result: ok. 7 passed; 0 failed; ...
test result: ok. 2 passed; 0 failed; ...
```

Thread-count variations, full lib:

```
### --test-threads=1   test result: ok. 2614 passed; 0 failed; ... finished in 68.62s
### --test-threads=4   test result: ok. 2614 passed; 0 failed; ... finished in 44.81s
### --test-threads=32  test result: ok. 2614 passed; 0 failed; ... finished in 28.20s
```

The #3952 stress command that failed 4/5 pre-fix, **10/10 post-fix**:

```
run  1: test result: ok. 289 passed; 0 failed; ...
run  2: test result: ok. 289 passed; 0 failed; ...
run  3: test result: ok. 289 passed; 0 failed; ...
run  4: test result: ok. 289 passed; 0 failed; ...
run  5: test result: ok. 289 passed; 0 failed; ...
run  6: test result: ok. 289 passed; 0 failed; ...
run  7: test result: ok. 289 passed; 0 failed; ...
run  8: test result: ok. 289 passed; 0 failed; ...
run  9: test result: ok. 289 passed; 0 failed; ...
run 10: test result: ok. 289 passed; 0 failed; ...
```

Repeated full-suite runs for the #3989 regression (8/8, vs ~2/6 failing
without that part):

```
run 1..8: test result: ok. 2614 passed; 0 failed; 12 ignored; ...
```

`cargo clippy -p trusty-agents --all-targets -- -D warnings` and
`cargo fmt --check`: clean. `check_line_cap.sh` (0 violations),
`check_sld.sh` (0 errors/warnings), `check_test_pointers.sh` (0 dangling).

## Cost

Crate lib test time goes 24s → 33s at default parallelism. The five http
tests spend ~21s in `with_llm_retry`'s exponential backoff against a
refused loopback connection; that time previously overlapped every
`$HOME`-sandboxing test and now correctly excludes them. Deliberate: the
overlap was the bug.

## Scope

**Test-only** — every touched file is `#[cfg(test)]` or a `tests.rs`
module; `test_env.rs` is `#![cfg(test)]` in its entirety. **No user-visible
behavior change, so no CHANGELOG entry.**

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
