### PR TITLE
fix(trusty-mpm): deny writes to pm_guard's own trust anchor

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -39,6 +39,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   absolute check (it still denies, via the pre-existing substitution scan,
   but as the budget-eligible `SHELL_EDIT_REASON`).
 
+- **`pm_guard_bash::bash_targets_trust_anchor` now also catches `cp`/`mv`/
+  `install` writes to the trust anchor**
+  ([#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981) follow-up):
+  these verbs take their target as a plain positional argument rather than a
+  `>` redirect or a `sed`/`patch`-style trailing token, so `cp evil.json
+  .claude/settings.json`, `mv evil.json .claude/settings.json`, and
+  `install -m 644 evil.json .claude/settings.json` previously sailed straight
+  through as an unclassified allow. New `non_flag_tokens` helper checks EVERY
+  non-flag positional token of the segment (source and destination alike,
+  deliberately not attempting to pin down "the" destination token position —
+  over-inclusion only ever widens the deny, never narrows it), wired into the
+  same `bash_targets_trust_anchor` function already called unconditionally
+  from `pm_guard()`'s body, so it denies absolutely (not the budget-eligible
+  `SHELL_EDIT_REASON`) for both the PM's own call and a dispatched subagent's.
+
 - **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
   `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**
   (worktree-hygiene follow-up to

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`tm hook --pm-guard` now denies any write to its own trust anchor**
+  ([#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981)): a direct
+  `Write`/`Edit`/`MultiEdit`/`NotebookEdit` targeting `.claude/settings.json`,
+  `.claude/settings.local.json`, or the `$CLAUDE_CONFIG_DIR` global
+  equivalent was previously an unconditional, unbudgeted ALLOW (`.json` is
+  not a source-code extension) — letting the PM, or any Guard-4-exempt
+  subagent, set `TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED` in
+  that file's `env` block and silently disable every pm_guard rule in one
+  ordinary permitted write. New `pm_guard_trust_anchor` module resolves the
+  target path (relative, `~`, `..` traversal, and symlinked ancestors — all
+  without requiring the target file to exist) and matches it structurally
+  (any `.claude/settings*.json`, plus the exact `$CLAUDE_CONFIG_DIR`
+  equivalent, which has NO `.claude/` nesting). Checked from THREE places:
+  `pm_guard()`'s body directly, before Guards 1/4's subagent-exemption early
+  returns (matching the worktree-tmp guard's placement, for the same
+  reason — a dispatched subagent's write is exactly as dangerous as the PM's
+  own); `evaluate_edit_tool`, as defense in depth; and
+  `pm_guard_bash::evaluate_bash_command`/`bash_targets_trust_anchor`, closing
+  the equivalent shell route (`echo … > .claude/settings.json`, `tee`,
+  `sed -i`, `awk`, `patch`, `git apply`) as an absolute,
+  non-budget-eligible deny rather than the ordinary budget-eligible
+  `SHELL_EDIT_REASON`. The deny message does not suggest delegating via the
+  Task/Agent tool (a dispatched subagent is denied identically) — the only
+  remedies are a human operator editing the file directly outside the
+  guarded session, or setting `TRUSTY_MPM_PM_UNRESTRICTED=1` in their own
+  shell. Known residual gap: a trust-anchor write hidden inside a `$(…)`/
+  backtick Bash command substitution is not specially detected by the new
+  absolute check (it still denies, via the pre-existing substitution scan,
+  but as the budget-eligible `SHELL_EDIT_REASON`).
+
 - **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
   `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**
   (worktree-hygiene follow-up to

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,8 +9,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **`tm hook --pm-guard` now denies any write to its own trust anchor**
-  ([#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981)): a direct
+- **`tm hook --pm-guard` now denies the EASY, naive writes to its own trust
+  anchor** ([#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981),
+  hardened per the [#3994](https://github.com/bobmatnyc/trusty-tools/pull/3994)
+  adversarial review — see the honesty note below): a direct
   `Write`/`Edit`/`MultiEdit`/`NotebookEdit` targeting `.claude/settings.json`,
   `.claude/settings.local.json`, or the `$CLAUDE_CONFIG_DIR` global
   equivalent was previously an unconditional, unbudgeted ALLOW (`.json` is
@@ -28,16 +30,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   own); `evaluate_edit_tool`, as defense in depth; and
   `pm_guard_bash::evaluate_bash_command`/`bash_targets_trust_anchor`, closing
   the equivalent shell route (`echo … > .claude/settings.json`, `tee`,
-  `sed -i`, `awk`, `patch`, `git apply`) as an absolute,
-  non-budget-eligible deny rather than the ordinary budget-eligible
-  `SHELL_EDIT_REASON`. The deny message does not suggest delegating via the
-  Task/Agent tool (a dispatched subagent is denied identically) — the only
-  remedies are a human operator editing the file directly outside the
-  guarded session, or setting `TRUSTY_MPM_PM_UNRESTRICTED=1` in their own
-  shell. Known residual gap: a trust-anchor write hidden inside a `$(…)`/
-  backtick Bash command substitution is not specially detected by the new
-  absolute check (it still denies, via the pre-existing substitution scan,
-  but as the budget-eligible `SHELL_EDIT_REASON`).
+  `sed -i`, `awk`, `patch`, `git apply`, `cp`/`mv`/`install`, `ln`/`ln -s`,
+  `git mv`, and an `xargs`-indirected verb whose target is spelled out
+  literally on the command line) as an absolute, non-budget-eligible deny
+  rather than the ordinary budget-eligible `SHELL_EDIT_REASON`. The deny
+  message does not suggest delegating via the Task/Agent tool (a dispatched
+  subagent is denied identically) — the only remedies are a human operator
+  editing the file directly outside the guarded session, or setting
+  `TRUSTY_MPM_PM_UNRESTRICTED=1` in their own shell.
+
+  **Honesty note (this is not a hardened security boundary):** this closes
+  the easy/naive self-exemption paths — the ordinary shell verbs a PM would
+  reach for without specifically probing for a gap — and raises the bar
+  against accidental or unsophisticated self-exemption. It is **not** a
+  security boundary against a party with unrestricted Bash access.
+  Documented, tracked-open residual gaps: (1) a trust-anchor write hidden
+  inside a `$(…)`/backtick command substitution still denies, but only as the
+  budget-eligible `SHELL_EDIT_REASON`, not this absolute deny; (2) a write
+  performed by an interpreter's inline program text (`python3 -c "…"`,
+  `perl -e`, `node -e`, `dd of=…`, `rsync … dest`, a re-invoked
+  `bash -c "…"`) or a runtime-assembled path (concatenation, base64, an env
+  var) is not detected at all — no static token scan can enumerate these;
+  (3) `xargs` whose target arrives purely via stdin, rather than appearing
+  literally on the command line, is likewise invisible to the new `xargs`
+  handling. A determined actor with Bash access can defeat this guard; it is
+  a guardrail against going off-script, not a hardened boundary. Also
+  documented as a deliberate, accepted trade-off (not an oversight): because
+  the `cp`/`mv`/`install`/`ln` scan checks source AND destination positions,
+  `cp .claude/settings.json /tmp/backup.json` — a harmless read/backup — is
+  denied absolutely too; narrowing to destination-only risks miscounting
+  `cp`'s N-arg-plus-directory form in the dangerous direction, so the
+  over-inclusion is kept on purpose.
 
 - **`pm_guard_bash::bash_targets_trust_anchor` now also catches `cp`/`mv`/
   `install` writes to the trust anchor**

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,9 +9,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **`tm hook --pm-guard` now denies the EASY, naive writes to its own trust
+- **`tm hook --pm-guard` now denies EVERY LITERAL write to its own trust
   anchor** ([#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981),
-  hardened per the [#3994](https://github.com/bobmatnyc/trusty-tools/pull/3994)
+  through three rounds of the [#3994](https://github.com/bobmatnyc/trusty-tools/pull/3994)
   adversarial review — see the honesty note below): a direct
   `Write`/`Edit`/`MultiEdit`/`NotebookEdit` targeting `.claude/settings.json`,
   `.claude/settings.local.json`, or the `$CLAUDE_CONFIG_DIR` global
@@ -29,53 +29,83 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   reason — a dispatched subagent's write is exactly as dangerous as the PM's
   own); `evaluate_edit_tool`, as defense in depth; and
   `pm_guard_bash::evaluate_bash_command`/`bash_targets_trust_anchor`, closing
-  the equivalent shell route (`echo … > .claude/settings.json`, `tee`,
-  `sed -i`, `awk`, `patch`, `git apply`, `cp`/`mv`/`install`, `ln`/`ln -s`,
-  `git mv`, and an `xargs`-indirected verb whose target is spelled out
-  literally on the command line) as an absolute, non-budget-eligible deny
-  rather than the ordinary budget-eligible `SHELL_EDIT_REASON`. The deny
-  message does not suggest delegating via the Task/Agent tool (a dispatched
-  subagent is denied identically) — the only remedies are a human operator
-  editing the file directly outside the guarded session, or setting
+  the equivalent shell route as an absolute, non-budget-eligible deny rather
+  than the ordinary budget-eligible `SHELL_EDIT_REASON`. The deny message
+  does not suggest delegating via the Task/Agent tool (a dispatched subagent
+  is denied identically) — the only remedies are a human operator editing
+  the file directly outside the guarded session, or setting
   `TRUSTY_MPM_PM_UNRESTRICTED=1` in their own shell.
 
-  **Honesty note (this is not a hardened security boundary):** this closes
-  the easy/naive self-exemption paths — the ordinary shell verbs a PM would
-  reach for without specifically probing for a gap — and raises the bar
-  against accidental or unsophisticated self-exemption. It is **not** a
-  security boundary against a party with unrestricted Bash access.
-  Documented, tracked-open residual gaps: (1) a trust-anchor write hidden
-  inside a `$(…)`/backtick command substitution still denies, but only as the
-  budget-eligible `SHELL_EDIT_REASON`, not this absolute deny; (2) a write
-  performed by an interpreter's inline program text (`python3 -c "…"`,
-  `perl -e`, `node -e`, `dd of=…`, `rsync … dest`, a re-invoked
-  `bash -c "…"`) or a runtime-assembled path (concatenation, base64, an env
-  var) is not detected at all — no static token scan can enumerate these;
-  (3) `xargs` whose target arrives purely via stdin, rather than appearing
-  literally on the command line, is likewise invisible to the new `xargs`
-  handling. A determined actor with Bash access can defeat this guard; it is
-  a guardrail against going off-script, not a hardened boundary. Also
-  documented as a deliberate, accepted trade-off (not an oversight): because
-  the `cp`/`mv`/`install`/`ln` scan checks source AND destination positions,
-  `cp .claude/settings.json /tmp/backup.json` — a harmless read/backup — is
-  denied absolutely too; narrowing to destination-only risks miscounting
-  `cp`'s N-arg-plus-directory form in the dangerous direction, so the
-  over-inclusion is kept on purpose.
+  **Round 1** closed the direct Edit/Write route plus the obvious Bash
+  routes: `echo … > .claude/settings.json`, `tee`, `sed -i`/`awk`/`patch`/
+  `git apply`. **Round 2** closed `cp`/`mv`/`install` (a `non_flag_tokens`
+  helper scanning every positional argument of those verbs). **Round 3**
+  (code-critic BLOCK) closed `ln`/`ln -s` and `git mv` — the review's
+  CRITICAL finding was that `ln -sf /tmp/evil.json .claude/settings.json`
+  was a complete, zero-friction bypass: write attacker content anywhere,
+  symlink it over the trust anchor, and Claude Code reads through it on its
+  next config load.
 
-- **`pm_guard_bash::bash_targets_trust_anchor` now also catches `cp`/`mv`/
-  `install` writes to the trust anchor**
-  ([#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981) follow-up):
-  these verbs take their target as a plain positional argument rather than a
-  `>` redirect or a `sed`/`patch`-style trailing token, so `cp evil.json
-  .claude/settings.json`, `mv evil.json .claude/settings.json`, and
-  `install -m 644 evil.json .claude/settings.json` previously sailed straight
-  through as an unclassified allow. New `non_flag_tokens` helper checks EVERY
-  non-flag positional token of the segment (source and destination alike,
-  deliberately not attempting to pin down "the" destination token position —
-  over-inclusion only ever widens the deny, never narrows it), wired into the
-  same `bash_targets_trust_anchor` function already called unconditionally
-  from `pm_guard()`'s body, so it denies absolutely (not the budget-eligible
-  `SHELL_EDIT_REASON`) for both the PM's own call and a dispatched subagent's.
+  **Round 4 — the whack-a-mole pattern itself was the bug, not any one
+  verb (second #3994 BLOCK):** the re-review of round 3 found `rsync` and
+  `scp` completely unclassified — a full, unbudgeted ALLOW, identical in
+  shape to the just-closed `ln` gap — and caught the module doc actively
+  MIS-FILING `rsync SRC DST` as belonging to the "genuinely hard,
+  runtime-assembled" bucket alongside `python3 -c`/`dd`/`bash -c`, when its
+  destination is a plain literal argv token exactly like `cp`'s. Three
+  rounds of "enumerate the verb, add it to the match arm" each shipped with
+  the next unenumerated verb still open — an inherently losing, open-ended
+  list that fails OPEN on anything unlisted. `bash_targets_trust_anchor` is
+  now INVERTED: rather than matching a known-verb allowlist and scanning
+  only that verb's conventional argument positions, it splits the whole raw
+  command on a generous set of shell/quoting/punctuation delimiters
+  (whitespace, quotes, parens/braces/brackets, `,`/`;`, the redirect/pipe
+  operators, `=`, `$`) and denies if ANY resulting fragment resolves to the
+  trust anchor — regardless of which program that fragment is an argument
+  to. This closes `rsync`/`scp` in the same move as every verb closed in
+  rounds 1–3, PLUS `dd of=PATH` (the `=` delimiter isolates the value), a
+  literal path inside `bash -c "…"`/`sh -c "…"`, a literal path inside an
+  interpreter one-liner (`python3 -c`, `perl -e`, `node -e`, `ruby -e`), and
+  a literal path inside a `$(…)`/backtick command substitution — none of
+  which required naming a verb, and none of which required naming the NEXT
+  verb nobody has thought of yet either, since the scan no longer depends on
+  verb recognition at all. The prior verb-specific helpers
+  (`non_flag_tokens`, `tee_target_tokens`, and the `git mv`-specific tail
+  scan) are removed as dead code, superseded by the single generic scan.
+
+  **The accepted cost of the inversion, stated plainly (product decision,
+  not an oversight):** because the scan no longer knows or cares what a
+  token's role is, it now also denies a pure READ (`cat
+  .claude/settings.json`, `grep`, `diff`, `less`) and a MERE TEXTUAL MENTION
+  of the path in an argument that isn't a write target at all (e.g. a commit
+  message: `git commit -m "fixes .claude/settings.json handling"`). This is
+  the same trade-off the round-2 `cp .claude/settings.json /tmp/backup.json`
+  case already established and documented — over-denying a harmless read is
+  a workflow annoyance with a working remedy (a human operator, or
+  `TRUSTY_MPM_PM_UNRESTRICTED=1`); a missed write is a silent, total guard
+  bypass. Narrowing the scan to "only when this token is really being
+  written to" would reintroduce exactly the position-by-position,
+  verb-by-verb reasoning that just failed three rounds in a row.
+
+  **Honesty note (this is not a hardened security boundary):** this closes
+  every LITERAL, spelled-out-on-the-command-line occurrence of the trust
+  anchor path, and raises the bar against accidental or unsophisticated
+  self-exemption. It is **not** a security boundary against a party with
+  unrestricted Bash access. What remains open is now narrowed to ONLY what a
+  static token scan structurally cannot see, because the path never appears
+  as literal text on the command line: (1) a path assembled at RUNTIME —
+  string concatenation, base64/hex decoding, or indirection through an
+  intermediate shell variable (`X=.claude/settings.json; cp evil "$X"`);
+  (2) an environment-variable-relative path where only the variable's NAME
+  appears literally, not its resolved value
+  (`cp evil "$CLAUDE_CONFIG_DIR/settings.json"`); (3) `xargs`/any command
+  whose target arrives purely via STDIN rather than appearing literally on
+  the command line (`echo .claude/settings.json | xargs rm`). None of these
+  three are specific to the trust anchor, nor introduced by this function —
+  they are pre-existing properties of any static command-line classifier. A
+  determined actor with Bash access can still defeat this guard via one of
+  those three; it is a guardrail against going off-script, not a hardened
+  boundary.
 
 - **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
   `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -44,6 +44,7 @@ pub(crate) mod pm_guard_bash;
 pub(crate) mod pm_guard_budget;
 pub(crate) mod pm_guard_deny_by_default;
 pub(crate) mod pm_guard_routing;
+pub(crate) mod pm_guard_trust_anchor;
 pub(crate) mod project;
 pub(crate) mod projects;
 pub(crate) mod prune;

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -68,16 +68,35 @@
 //! so this worktree check — which needs the payload — can run first). **This
 //! is NOT the same as "operator-only"**: Claude Code's `settings.json`
 //! supports a top-level `env` object applied to every session/subprocess it
-//! spawns (hooks included, live-reloaded mid-session), and a `Write`/`Edit`
-//! to `.claude/settings.json` is not itself blocked by this guard (`.json` is
-//! not in [`SOURCE_CODE_EXTENSIONS`], so [`evaluate_edit_tool`] falls through
-//! to an unconditional ALLOW) — so the PM, or any Guard-4-exempt subagent,
-//! can set either var there and self-exempt from this entire guard. That gap
-//! predates this PR by many issues and is NOT introduced or widened by it;
-//! tracked separately as issue #3981, not fixed here. This is the one place
-//! in the file that pierces an automatic-marker exemption; see that call
-//! site's comment for why it must never be routed through [`evaluate_tool`]
-//! instead.
+//! spawns (hooks included, live-reloaded mid-session), so a `Write`/`Edit` to
+//! `.claude/settings.json` could otherwise set either var and self-exempt
+//! from this entire guard (`.json` is not in [`SOURCE_CODE_EXTENSIONS`], so
+//! without an explicit check [`evaluate_edit_tool`] would fall through to an
+//! unconditional ALLOW). **Trust-anchor denylist (issue #3981):** a
+//! dispatched sub-agent's write to `.claude/settings.json` is EXACTLY as
+//! dangerous as the PM's own (it can self-exempt from every rule in this
+//! file just the same), so — like the worktree-tmp guard immediately above,
+//! and for the identical reason — [`pm_guard`] calls
+//! [`crate::commands::pm_guard_trust_anchor::is_trust_anchor_path`] DIRECTLY
+//! from its body, right after the worktree check, BEFORE Guard 1 and Guard
+//! 4's exemption early-returns. [`evaluate_edit_tool`] ALSO checks it (before
+//! even the PM-orchestration allow-list) as a second, pure-function layer of
+//! defense in depth for any other caller of [`evaluate_tool`] (e.g. the
+//! opt-in deny-by-default persona gate below, which calls `evaluate_tool` to
+//! ask "would this call be guarded at all"); for the PM's own direct calls
+//! that second layer is reachable, but for a dispatched sub-agent the direct
+//! check in [`pm_guard`]'s body always fires first, exactly like the
+//! worktree guard. [`crate::commands::pm_guard_bash::evaluate_bash_command`]
+//! applies the SAME check unconditionally too, ahead of its ordinary verb/
+//! redirection classification, so a shell redirect/`tee`/`sed -i`/`patch`
+//! targeting the same file is an absolute (non-budget-eligible) deny — see
+//! that module's doc comment for why the Bash-side check has to be a
+//! separate, unconditional pass rather than an upgrade of an
+//! already-computed [`SHELL_EDIT_REASON`]. Because delegation does NOT help
+//! here (a dispatched sub-agent is denied identically), the deny message
+//! does not suggest it — see
+//! [`crate::commands::pm_guard_trust_anchor::TRUST_ANCHOR_DENY_REASON`]'s own
+//! doc comment for the actual (human-only) remedies.
 //! Test: `evaluate_tool_*`, `payload_is_subagent_dispatch_*`, and
 //! `build_pretooluse_deny_response_*` below cover the tool policy, sub-agent
 //! exemption, and JSON shape; the Bash-command classifier (composition and
@@ -97,6 +116,7 @@ use crate::commands::pm_guard_bash::{
 use crate::commands::pm_guard_budget::{self, BudgetDecision, DEFAULT_FILE_CHANGE_BUDGET};
 use crate::commands::pm_guard_deny_by_default::{self, PERSONA_DENY_REASON};
 use crate::commands::pm_guard_routing::{GENERIC_ENGINEER_HINT, delegation_hint_for_path};
+use crate::commands::pm_guard_trust_anchor::{TRUST_ANCHOR_DENY_REASON, is_trust_anchor_path};
 
 /// Escape-hatch env var: `TRUSTY_MPM_PM_UNRESTRICTED=1` disables all PM
 /// enforcement for the invocation.
@@ -195,20 +215,22 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
     // programmatically anywhere in this codebase's Rust source (verified: no
     // `std::env::var`/`set_var` occurrence outside doc comments and this
     // module) — so they must keep working exactly as before, including
-    // against the ABSOLUTE worktree-tmp guard below: whoever sets
-    // `TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED` gets exactly
-    // that, no exceptions. That is a narrower claim than "operator-only",
-    // though: Claude Code's `settings.json` `env` object can set either var
-    // for every hook invocation, and a write to `.claude/settings.json` is
-    // not itself blocked by this guard (see the module doc above, "This is
-    // NOT the same as 'operator-only'") — so the PM or an exempt subagent CAN
-    // self-exempt via that path. That gap predates this PR by many issues and
-    // is out of scope here; tracked as issue #3981. Guard 1 (`SUB_AGENT_ENV`),
-    // by contrast, is an
-    // AUTOMATIC marker a spawn helper stamps on every nested MPM subagent
-    // process with no per-invocation env-write decision involved — see
-    // Guard 1's own comment below for why it is checked LATER, after the
-    // worktree guard, instead of here.
+    // against the ABSOLUTE worktree-tmp AND trust-anchor guards below:
+    // whoever sets `TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED`
+    // directly in their OWN shell environment gets exactly that, no
+    // exceptions — that is the documented, intended operator escape hatch.
+    // The gap issue #3981 identified was narrower: Claude Code's
+    // `settings.json` `env` object can ALSO set either var for every hook
+    // invocation, and — before the trust-anchor guard below existed — a
+    // Write/Edit to `.claude/settings.json` was not itself blocked by this
+    // guard at all, so the PM or an exempt subagent could self-exempt via
+    // that file-write path with no human involved. The trust-anchor guard
+    // below closes that specific gap; it does not and must not touch these
+    // two genuine human-operated bypasses. Guard 1 (`SUB_AGENT_ENV`), by
+    // contrast, is an AUTOMATIC marker a spawn helper stamps on every nested
+    // MPM subagent process with no per-invocation env-write decision
+    // involved — see Guard 1's own comment below for why it is checked
+    // LATER, after the worktree and trust-anchor guards, instead of here.
     if std::env::var_os(DISABLE_HOOKS_ENV).is_some() {
         return Ok(());
     }
@@ -269,6 +291,44 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
             println!("{}", build_pretooluse_deny_response(reason));
             return Ok(());
         }
+    }
+
+    // ABSOLUTE guard (issue #3981) — pm_guard's own trust anchor. Placed
+    // here for the EXACT same reason as the worktree-tmp guard immediately
+    // above (see its comment): a native Task/Agent-dispatched subagent
+    // (`agent_id` present, Guard 4) or a trusty-agents-spawned nested
+    // subagent (`CLAUDE_MPM_SUB_AGENT` set, Guard 1) writing
+    // `.claude/settings.json` is EXACTLY as dangerous as the PM doing it
+    // directly — it can set `TRUSTY_MPM_DISABLE_HOOKS`/
+    // `TRUSTY_MPM_PM_UNRESTRICTED` in that file's `env` block and disable
+    // every rule in this file for every future invocation, subagent or not.
+    // A check routed through `evaluate_tool` (as `evaluate_edit_tool` and
+    // `evaluate_bash_command` also independently apply, for defense in depth
+    // on the direct-PM-call path) would never fire for either exemption, so
+    // this direct, unconditional call is required. Covers both write routes
+    // in one place: the Edit/Write/MultiEdit/NotebookEdit tools via
+    // [`edit_tool_target_path`], and `Bash` (redirects/`tee`/`sed`-`awk`/
+    // `patch`/`git apply`) via
+    // [`crate::commands::pm_guard_bash::bash_targets_trust_anchor`]. DO NOT
+    // move this after Guard 1 or Guard 4.
+    let trust_anchor_target = if EDIT_TOOLS.contains(&tool_name) {
+        edit_tool_target_path(tool_input).is_some_and(is_trust_anchor_path)
+    } else if tool_name == "Bash" {
+        let command = tool_input
+            .and_then(|v| v.get("command"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        crate::commands::pm_guard_bash::bash_targets_trust_anchor(command)
+    } else {
+        false
+    };
+    if trust_anchor_target {
+        audit_denied_tool(url, session_id, tool_name, TRUST_ANCHOR_DENY_REASON).await;
+        println!(
+            "{}",
+            build_pretooluse_deny_response(TRUST_ANCHOR_DENY_REASON)
+        );
+        return Ok(());
     }
 
     // Guard 1: never block a nested MPM sub-agent for anything else — it is
@@ -448,7 +508,10 @@ pub(crate) fn evaluate_tool(
 /// directive (live dogfooding): "the PM can write single files." The pre-#2604
 /// guard blocked *all* Edit/Write, which denied the PM its own session-pause
 /// snapshot write to `.trusty-mpm/sessions/session-*.md`.
-/// What: reads the target path; ALLOW (`None`) when it is PM-owned orchestration
+/// What: reads the target path; DENY ([`TRUST_ANCHOR_DENY_REASON`], issue
+/// #3981) FIRST — before any allow-list, including PM-orchestration state —
+/// when the resolved path is pm_guard's own trust anchor
+/// ([`is_trust_anchor_path`]); ALLOW (`None`) when it is PM-owned orchestration
 /// state ([`is_pm_orchestration_path`], the HARD always-allow set — this wins
 /// over the source-code rule); DENY ([`SOURCE_EDIT_REASON`]) when it is a
 /// source-code file ([`is_source_code_path`]); otherwise ALLOW (a single-file
@@ -457,9 +520,15 @@ pub(crate) fn evaluate_tool(
 /// Test: `evaluate_tool_denies_source_code_edits`,
 /// `evaluate_tool_allows_pm_orchestration_state`,
 /// `evaluate_tool_allows_non_source_single_file_writes`,
-/// `evaluate_edit_tool_fails_open_without_path`.
+/// `evaluate_edit_tool_fails_open_without_path`,
+/// `evaluate_tool_denies_trust_anchor_write` (see also
+/// `pm_guard_trust_anchor`'s own unit tests and
+/// `tests/tm_hook_pm_guard.rs::pm_guard_denies_settings_json_write_*`).
 fn evaluate_edit_tool(tool_input: Option<&serde_json::Value>) -> Option<&'static str> {
     let path = edit_tool_target_path(tool_input)?;
+    if is_trust_anchor_path(path) {
+        return Some(TRUST_ANCHOR_DENY_REASON);
+    }
     if is_pm_orchestration_path(path) {
         return None;
     }
@@ -623,6 +692,35 @@ mod tests {
                 Some(&serde_json::json!({"notebook_path": "/x/nb.ipynb"}))
             ),
             Some(SOURCE_EDIT_REASON)
+        );
+    }
+
+    #[test]
+    fn evaluate_tool_denies_trust_anchor_write() {
+        // Issue #3981: a direct write to `.claude/settings.json` (or
+        // `.local.json`) must be denied BEFORE the non-source-file fallback
+        // would otherwise allow it — this is the pure-function layer of the
+        // fix; `pm_guard`'s own absolute pre-Guard-1/4 check (see the body of
+        // `pm_guard()`) is what actually covers the subagent-bypass cases,
+        // exercised end to end in `tests/tm_hook_pm_guard.rs`.
+        for path in [
+            "/repo/.claude/settings.json",
+            "/repo/.claude/settings.local.json",
+        ] {
+            assert_eq!(
+                evaluate_tool("Write", Some(&serde_json::json!({"file_path": path}))),
+                Some(TRUST_ANCHOR_DENY_REASON),
+                "expected {path} to be denied as the trust anchor"
+            );
+        }
+        // A sibling `.claude/` file (not the trust anchor itself) is
+        // unaffected — still allowed as an ordinary non-source write.
+        assert_eq!(
+            evaluate_tool(
+                "Write",
+                Some(&serde_json::json!({"file_path": "/repo/.claude/config.toml"}))
+            ),
+            None
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -86,31 +86,72 @@ pub(crate) fn evaluate_bash_command(command: &str) -> Option<&'static str> {
 }
 
 /// Whether `command` writes, via any Bash mechanism this module recognizes,
-/// to pm_guard's own trust-anchor settings file (issue #3981).
+/// to pm_guard's own trust-anchor settings file (issue #3981/#3994).
+///
+/// **Honesty note (added in response to the #3994 adversarial review): this
+/// function closes the EASY, naive self-exemption paths — the ordinary,
+/// always-visible shell verbs a PM would reach for without specifically
+/// probing for a gap. It is NOT a hardened security boundary.** A determined
+/// actor with unrestricted Bash access still has multiple ways through (see
+/// the residual-gap list below), some closeable in principle (more verbs to
+/// enumerate) and some not (runtime-assembled paths, an interpreter's inline
+/// program text). Treat this as raising the bar against accidental/naive
+/// self-exemption, not as "the PM can no longer disable pm_guard."
 ///
 /// Why: a shell redirect (`echo … > .claude/settings.json`, `cat >>`), `tee`
 /// (which takes its output file as an ARGUMENT, not a `>` redirect — invisible
 /// to [`has_file_write_redirection`]/[`redirection_target`]), `sed -i`/`awk`/
 /// `patch`/`git apply` (whose target is conventionally their trailing
-/// non-flag argument, per [`trailing_file_token`]), or `cp`/`mv`/`install`
+/// non-flag argument, per [`trailing_file_token`]), `cp`/`mv`/`install`/`ln`
 /// (whose source AND destination are both plain positional arguments, per
-/// [`non_flag_tokens`]) can all write the trust anchor exactly as surely as
-/// the `Write`/`Edit` tool. Without this check those would classify as the
-/// ordinary [`SHELL_EDIT_REASON`] (or, for `cp`/`mv`/`install`, would not be
-/// classified as a file-edit AT ALL — see the residual-gap note below) —
+/// [`non_flag_tokens`] — `ln`'s destination/linkname argument is exactly
+/// where the danger is: `ln -sf /tmp/evil.json .claude/settings.json` makes
+/// Claude Code read the attacker-controlled file on its next config load, a
+/// full bypass if left unclassified, per the #3994 review), `git mv` (a
+/// two-token verb whose subcommand shifts the positional layout — scanned via
+/// [`shell_lex::git_subcommand_with_args`]'s tail rather than
+/// [`non_flag_tokens`], since the latter only skips ONE leading token and
+/// `git` is not the argument-bearing verb), or `xargs` invoking any of the
+/// above with the trust-anchor path spelled out LITERALLY on the command line
+/// (`… | xargs -I{} cp {} .claude/settings.json`) can all write the trust
+/// anchor exactly as surely as the `Write`/`Edit` tool. Without this check
+/// those would classify as the ordinary [`SHELL_EDIT_REASON`] (or, for the
+/// verbs above, would not be classified as a file-edit AT ALL) —
 /// `pm_guard`'s per-turn budget (issue #2918) allows a `SHELL_EDIT_REASON`
 /// deny up to 3 times BEFORE hard-blocking, silently reopening the exact hole
 /// the Edit/Write-side trust-anchor denylist closes.
 /// What: scans every composition segment ([`split_shell_segments`]) for a
 /// real file-write redirect target ([`redirection_target`]), a `tee`
-/// argument ([`tee_target_tokens`]), a `cp`/`mv`/`install` argument
+/// argument ([`tee_target_tokens`]), a `cp`/`mv`/`install`/`ln` argument
 /// ([`non_flag_tokens`] — checks EVERY positional token, source included, not
 /// just the destination: `cp .claude/settings.json /tmp/x` reads the trust
 /// anchor into an attacker-controlled sibling path, and being conservative
 /// about ambiguous positional order costs nothing since this check only ever
-/// widens a deny, never an allow), or — for the sed/awk-family/`patch`/
-/// `git apply` verbs — the trailing file token ([`trailing_file_token`]), and
-/// returns `true` on the first one [`is_trust_anchor_path`] confirms.
+/// widens a deny, never an allow), a `git mv` argument
+/// ([`shell_lex::git_subcommand_with_args`]'s tail, same every-positional-token
+/// scan as `non_flag_tokens`), an `xargs` argument (also [`non_flag_tokens`] —
+/// deliberately generic rather than verb-aware: it scans every non-flag token
+/// following `xargs` for the trust-anchor path regardless of which command
+/// `xargs` invokes, since the point is only "does the trust anchor's path
+/// appear literally on this line", not "is xargs's target verb one we
+/// recognize"), or — for the sed/awk-family/`patch`/`git apply` verbs — the
+/// trailing file token ([`trailing_file_token`]), and returns `true` on the
+/// first one [`is_trust_anchor_path`] confirms.
+///
+/// **Documented false-positive trade-off (named explicitly per the #3994
+/// review, not left implicit):** because [`non_flag_tokens`] scans source AND
+/// destination alike, `cp .claude/settings.json /tmp/backup.json` — a
+/// harmless read/backup of the trust anchor to an unrelated destination — is
+/// denied absolutely, with no self-service remedy (only a human operator
+/// setting `TRUSTY_MPM_PM_UNRESTRICTED=1` unblocks it). This is a deliberate,
+/// accepted trade-off, not an oversight: narrowing to destination-only risks
+/// getting `cp`'s N-arg-plus-directory form (`cp SRC1 SRC2 DIR/`,
+/// `cp -t DIR SRC1 SRC2`) subtly wrong in the dangerous direction (excluding
+/// a real destination token by miscounting), and the failure mode of
+/// over-denying a backup is a rare workflow annoyance while the failure mode
+/// of a missed real write is silent total guard bypass. Safety over
+/// convenience; kept over-inclusive on purpose.
+///
 /// Known residual gaps, deliberately NOT attempted here because a textual
 /// classifier cannot close them without becoming trivially evadable (a false
 /// sense of security is worse than an honest gap — see the PR description):
@@ -125,11 +166,19 @@ pub(crate) fn evaluate_bash_command(command: &str) -> Option<&'static str> {
 /// (`bash -c "…"`, `sh -c "…"`) whose quoted body this function does not
 /// recursively parse — is not detected at all; the path can be assembled at
 /// runtime (concatenation, base64, an env var) in ways no static prefix/token
-/// scan can enumerate. Both gaps are pre-existing properties of
-/// [`evaluate_bash_command`]'s whole classification strategy (neither is
-/// specific to the trust anchor, nor introduced by this function), tracked
-/// for a possible follow-up allowlist-based Bash gate rather than papered
-/// over with a brittle heuristic here.
+/// scan can enumerate; (3) `xargs` whose target path arrives via STDIN rather
+/// than appearing literally on the command line
+/// (`echo .claude/settings.json | xargs rm`) is invisible to the `xargs`
+/// handling added here — that handling only sees literal argv tokens on the
+/// line itself, the same fundamental limit as (2). None of these three gaps
+/// are specific to the trust anchor, nor introduced by this function — they
+/// are pre-existing properties of [`evaluate_bash_command`]'s whole
+/// classification strategy — tracked for a possible follow-up
+/// allowlist-based Bash gate rather than papered over with a brittle
+/// heuristic here. See also the strategic caveat at the top of this doc
+/// comment: this list is illustrative, not exhaustive — any renaming/copying/
+/// linking verb this module does not yet enumerate is presumptively open
+/// until proven otherwise.
 /// Test: `bash_targets_trust_anchor_*` below.
 pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
     for segment in split_shell_segments(command) {
@@ -153,7 +202,7 @@ pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
             }
             continue;
         }
-        if matches!(program, "cp" | "mv" | "install") {
+        if matches!(program, "cp" | "mv" | "install" | "ln" | "xargs") {
             for target in non_flag_tokens(trimmed) {
                 if is_trust_anchor_path(target) {
                     return true;
@@ -161,11 +210,31 @@ pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
             }
             continue;
         }
+        if program == "git" {
+            if let Some((sub, rest)) = shell_lex::git_subcommand_with_args(trimmed) {
+                match sub.as_str() {
+                    "apply" => {
+                        if let Some(target) = trailing_file_token(trimmed)
+                            && is_trust_anchor_path(&target)
+                        {
+                            return true;
+                        }
+                    }
+                    "mv" => {
+                        for tok in &rest {
+                            if !tok.starts_with('-') && is_trust_anchor_path(tok) {
+                                return true;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            continue;
+        }
         let is_sed_awk_family =
             matches!(program, "patch" | "sed" | "awk" | "gawk" | "nawk" | "mawk");
-        let is_git_apply =
-            program == "git" && shell_lex::git_subcommand(trimmed).as_deref() == Some("apply");
-        if (is_sed_awk_family || is_git_apply)
+        if is_sed_awk_family
             && let Some(target) = trailing_file_token(trimmed)
             && is_trust_anchor_path(&target)
         {
@@ -175,16 +244,25 @@ pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
     false
 }
 
-/// Every non-flag positional argument of a `cp`/`mv`/`install`-headed
-/// segment, source AND destination alike (issue #3981).
+/// Every non-flag positional argument of a `cp`/`mv`/`install`/`ln`/`xargs`-
+/// headed segment, source AND destination alike (issue #3981/#3994).
 ///
 /// Why: unlike `tee` (output-only arguments) or `sed`/`patch` (a single
-/// trailing target), `cp`/`mv`/`install` take BOTH a source and a destination
-/// as plain positional arguments in either the 2-arg (`cp SRC DST`) or
-/// N-arg-plus-directory (`cp SRC1 SRC2 DIR/`, `cp -t DIR SRC1 SRC2`) forms —
-/// there is no single reliable "the target is always token N" rule cheap
-/// enough to be worth getting subtly wrong. Checking every positional token
-/// is simpler and can only widen the deny, never narrow it.
+/// trailing target), `cp`/`mv`/`install`/`ln` take BOTH a source and a
+/// destination as plain positional arguments in either the 2-arg
+/// (`cp SRC DST`, `ln TARGET LINKNAME`) or N-arg-plus-directory
+/// (`cp SRC1 SRC2 DIR/`, `cp -t DIR SRC1 SRC2`) forms — there is no single
+/// reliable "the target is always token N" rule cheap enough to be worth
+/// getting subtly wrong. `xargs` reuses the same scan for a different reason:
+/// it is not itself a file-write verb, so this deliberately does NOT try to
+/// parse `xargs`'s own flags (`-I{}`, `-n`, `-P`) to find where ITS embedded
+/// command begins — it just asks "does the trust-anchor path appear literally
+/// anywhere on this line", which is enough to catch the realistic bypass
+/// (`… | xargs -I{} cp {} .claude/settings.json`, where the destination is
+/// written out in full) while honestly NOT catching a target fed purely
+/// through stdin (see the residual-gap list on [`bash_targets_trust_anchor`]).
+/// Checking every positional token is simpler and can only widen the deny,
+/// never narrow it.
 /// What: the program token (index 0) is skipped; every remaining
 /// whitespace-separated token that does not start with `-` is returned. This
 /// deliberately does NOT track which flags consume a following value token
@@ -731,24 +809,27 @@ const WORKTREE_ADD_FLAGS_WITH_ARG: &[&str] = &["-b", "-B", "--reason"];
 /// - A `cd`/`-C` argument built from command substitution
 ///   (`cd "$(mktemp -d)"`) is not resolved — this module classifies text
 ///   structurally, it does not execute the shell.
-/// - **Largest of this list, tracked separately as
-///   [issue #3981](https://github.com/bobmatnyc/trusty-tools/issues/3981):**
+/// - **Formerly the largest gap in this list — now narrowed, not eliminated,
+///   by [issue #3981](https://github.com/bobmatnyc/trusty-tools/issues/3981)/
+///   [#3994](https://github.com/bobmatnyc/trusty-tools/pull/3994):**
 ///   `pm_guard`'s Guard 2/3 escape hatches
 ///   (`TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED`) bypass this
-///   entire guard when set, and while neither is ever set programmatically
-///   in this codebase's Rust source, Claude Code's `settings.json` supports a
+///   entire guard when set, and Claude Code's `settings.json` supports a
 ///   top-level `env` object applied to every hook invocation (live-reloaded
-///   mid-session) — and a `Write`/`Edit` to `.claude/settings.json` is not
-///   itself blocked by `pm_guard` today (`.json` is not a source-code
-///   extension, so `evaluate_edit_tool` falls through to an unconditional
-///   ALLOW). So the PM, or any subagent Guard 4 already exempts, can set
-///   either var there and self-exempt from every rule in this module,
-///   including this one, in one ordinary already-permitted config write. This
-///   is a pre-existing gap (Guard 3 predates this worktree guard by many
-///   issues) that this change neither introduces nor widens; it guards
-///   against an agent going off-script, not a determined adversary, and is
-///   deliberately NOT fixed here — the remedy belongs in the edit-tool
-///   classifier, not this Bash classifier, and is the project owner's call.
+///   mid-session). A direct `Write`/`Edit`/`Bash` write to
+///   `.claude/settings.json` targeting THOSE vars is now denied by
+///   [`bash_targets_trust_anchor`]/`pm_guard_trust_anchor::is_trust_anchor_path`
+///   (checked from `pm_guard()` ahead of this very function, and ahead of
+///   Guards 1/4) — but that check closes only the easy, naive verbs
+///   enumerated there (redirects, `tee`, `sed`/`awk`/`patch`/`git apply`,
+///   `cp`/`mv`/`install`/`ln`, `git mv`, literal-target `xargs`
+///   indirection), not every conceivable write route (see that function's
+///   own "Known residual gaps" doc — command substitution, interpreter
+///   inline program text, runtime-assembled paths, stdin-fed `xargs`
+///   targets). So a sufficiently determined PM or Guard-4-exempt subagent
+///   can still self-exempt from every rule in this module via one of those
+///   remaining routes; it guards against an agent going off-script, not a
+///   determined adversary.
 ///
 /// Test: `evaluate_worktree_add_command_*` below;
 /// `pm_guard_blocks_worktree_add_under_tmp_via_subagent_payload` and siblings

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -85,231 +85,124 @@ pub(crate) fn evaluate_bash_command(command: &str) -> Option<&'static str> {
     evaluate_bash_command_inner(command, 0)
 }
 
-/// Whether `command` writes, via any Bash mechanism this module recognizes,
-/// to pm_guard's own trust-anchor settings file (issue #3981/#3994).
+/// Punctuation/whitespace characters that separate a literal path from
+/// surrounding shell or interpreter syntax, for [`bash_targets_trust_anchor`]'s
+/// verb-agnostic token scan (issue #3981/#3994 — the round-3 inversion).
 ///
-/// **Honesty note (added in response to the #3994 adversarial review): this
-/// function closes the EASY, naive self-exemption paths — the ordinary,
-/// always-visible shell verbs a PM would reach for without specifically
-/// probing for a gap. It is NOT a hardened security boundary.** A determined
-/// actor with unrestricted Bash access still has multiple ways through (see
-/// the residual-gap list below), some closeable in principle (more verbs to
-/// enumerate) and some not (runtime-assembled paths, an interpreter's inline
-/// program text). Treat this as raising the bar against accidental/naive
-/// self-exemption, not as "the PM can no longer disable pm_guard."
+/// Why: whitespace alone is not enough — a literal path can be glued to
+/// adjacent syntax with no space at all (`cat>.claude/settings.json`,
+/// `dd of=.claude/settings.json`, `'.claude/settings.json'` inside a quoted
+/// interpreter one-liner). Each character here is something a path is
+/// commonly wrapped in or separated from: quotes (`'`, `"`, `` ` ``),
+/// grouping/expansion punctuation (`(`, `)`, `{`, `}`, `[`, `]`), argument
+/// separators (`,`, `;`), the shell redirection/pipe/background operators
+/// (`<`, `>`, `|`, `&`), `=` (isolates `dd of=PATH`, `--file=PATH`, and
+/// `KEY=PATH` env-assignment values as their own fragment), and `$` (so a
+/// `$(...)`/`${...}` boundary never glues onto an adjacent literal path).
+/// Splitting on a superset of "real" delimiters is safe by construction: an
+/// extra split point can only ever produce MORE, smaller candidate fragments
+/// to check — never fewer — so it can only widen the deny, never narrow it.
+const TRUST_ANCHOR_FRAGMENT_DELIMITERS: &[char] = &[
+    ' ', '\t', '\n', '\r', '\'', '"', '`', '(', ')', '{', '}', '[', ']', ',', ';', '|', '&', '<',
+    '>', '=', '$',
+];
+
+/// Whether `command` contains ANY token that resolves to pm_guard's own
+/// trust-anchor settings file, regardless of which program that token is an
+/// argument to (issue #3981/#3994).
 ///
-/// Why: a shell redirect (`echo … > .claude/settings.json`, `cat >>`), `tee`
-/// (which takes its output file as an ARGUMENT, not a `>` redirect — invisible
-/// to [`has_file_write_redirection`]/[`redirection_target`]), `sed -i`/`awk`/
-/// `patch`/`git apply` (whose target is conventionally their trailing
-/// non-flag argument, per [`trailing_file_token`]), `cp`/`mv`/`install`/`ln`
-/// (whose source AND destination are both plain positional arguments, per
-/// [`non_flag_tokens`] — `ln`'s destination/linkname argument is exactly
-/// where the danger is: `ln -sf /tmp/evil.json .claude/settings.json` makes
-/// Claude Code read the attacker-controlled file on its next config load, a
-/// full bypass if left unclassified, per the #3994 review), `git mv` (a
-/// two-token verb whose subcommand shifts the positional layout — scanned via
-/// [`shell_lex::git_subcommand_with_args`]'s tail rather than
-/// [`non_flag_tokens`], since the latter only skips ONE leading token and
-/// `git` is not the argument-bearing verb), or `xargs` invoking any of the
-/// above with the trust-anchor path spelled out LITERALLY on the command line
-/// (`… | xargs -I{} cp {} .claude/settings.json`) can all write the trust
-/// anchor exactly as surely as the `Write`/`Edit` tool. Without this check
-/// those would classify as the ordinary [`SHELL_EDIT_REASON`] (or, for the
-/// verbs above, would not be classified as a file-edit AT ALL) —
-/// `pm_guard`'s per-turn budget (issue #2918) allows a `SHELL_EDIT_REASON`
-/// deny up to 3 times BEFORE hard-blocking, silently reopening the exact hole
-/// the Edit/Write-side trust-anchor denylist closes.
-/// What: scans every composition segment ([`split_shell_segments`]) for a
-/// real file-write redirect target ([`redirection_target`]), a `tee`
-/// argument ([`tee_target_tokens`]), a `cp`/`mv`/`install`/`ln` argument
-/// ([`non_flag_tokens`] — checks EVERY positional token, source included, not
-/// just the destination: `cp .claude/settings.json /tmp/x` reads the trust
-/// anchor into an attacker-controlled sibling path, and being conservative
-/// about ambiguous positional order costs nothing since this check only ever
-/// widens a deny, never an allow), a `git mv` argument
-/// ([`shell_lex::git_subcommand_with_args`]'s tail, same every-positional-token
-/// scan as `non_flag_tokens`), an `xargs` argument (also [`non_flag_tokens`] —
-/// deliberately generic rather than verb-aware: it scans every non-flag token
-/// following `xargs` for the trust-anchor path regardless of which command
-/// `xargs` invokes, since the point is only "does the trust anchor's path
-/// appear literally on this line", not "is xargs's target verb one we
-/// recognize"), or — for the sed/awk-family/`patch`/`git apply` verbs — the
-/// trailing file token ([`trailing_file_token`]), and returns `true` on the
-/// first one [`is_trust_anchor_path`] confirms.
+/// **Why this is a verb-agnostic scan, not a verb allowlist (round 3 of the
+/// #3994 review):** the prior design matched a known-verb allowlist
+/// (`cp`/`mv`/`install`/`ln`/`tee`/`sed`/`awk`/`patch`/`git apply`/`git mv`/
+/// `xargs`) and scanned only THAT verb's conventional argument positions.
+/// Each review round found the next verb nobody had enumerated yet
+/// completely unclassified — `cp`/`mv`/`install` closed round 1, `ln`/
+/// `git mv` closed round 2, and round 2's own re-review then found `rsync`
+/// and `scp` wide open with a full, unbudgeted ALLOW, because they were
+/// never added to the match arm. Enumerating verbs is an open-ended list
+/// that fails OPEN on anything unlisted — a structurally losing game. This
+/// function inverts the question: instead of "is this a known write verb,
+/// and if so where is its destination argument", it asks "does ANY token on
+/// this command line — split without regard to which program it belongs to
+/// — resolve to the trust anchor". That closes every verb above in one
+/// move, plus `rsync`, `scp`, `dd of=`, a literal path inside `bash -c "…"`/
+/// `sh -c "…"`, and a literal path inside an interpreter one-liner
+/// (`python3 -c`, `perl -e`, `node -e`, `ruby -e`) or a `$(…)`/backtick
+/// command substitution — none of which require recognizing a verb at all,
+/// and none of which this function needs to name to close. It also closes
+/// every verb nobody has thought of yet: a program this module has never
+/// heard of, invoked with the trust-anchor path as a literal argument, is
+/// caught exactly the same way.
 ///
-/// **Documented false-positive trade-off (named explicitly per the #3994
-/// review, not left implicit):** because [`non_flag_tokens`] scans source AND
-/// destination alike, `cp .claude/settings.json /tmp/backup.json` — a
-/// harmless read/backup of the trust anchor to an unrelated destination — is
-/// denied absolutely, with no self-service remedy (only a human operator
-/// setting `TRUSTY_MPM_PM_UNRESTRICTED=1` unblocks it). This is a deliberate,
-/// accepted trade-off, not an oversight: narrowing to destination-only risks
-/// getting `cp`'s N-arg-plus-directory form (`cp SRC1 SRC2 DIR/`,
-/// `cp -t DIR SRC1 SRC2`) subtly wrong in the dangerous direction (excluding
-/// a real destination token by miscounting), and the failure mode of
-/// over-denying a backup is a rare workflow annoyance while the failure mode
-/// of a missed real write is silent total guard bypass. Safety over
-/// convenience; kept over-inclusive on purpose.
+/// **Honesty note (unchanged in spirit from the prior rounds): this closes
+/// every LITERAL, spelled-out-on-the-command-line occurrence of the trust
+/// anchor path. It is NOT a hardened security boundary.** A determined actor
+/// with unrestricted Bash access still has ways through — see the residual-gap
+/// list below — but all of them now require the path to be assembled or
+/// supplied at RUNTIME rather than appearing as plain text anywhere on the
+/// command line; there is no longer a "just pick an unlisted verb" bypass.
 ///
-/// Known residual gaps, deliberately NOT attempted here because a textual
-/// classifier cannot close them without becoming trivially evadable (a false
-/// sense of security is worse than an honest gap — see the PR description):
-/// (1) a trust-anchor write hidden inside a `$(…)`/backtick command
-/// substitution is not specially detected by this function (it scans
-/// top-level segments only) — such a call still denies, but as the ordinary
-/// budget-eligible `SHELL_EDIT_REASON` via [`classify_command_substitutions`]'s
-/// existing recursive scan, not this absolute deny; (2) a write performed by
-/// an interpreter's *inline program text* rather than the shell itself —
-/// `python3 -c "open('.claude/settings.json','w')…"`, `perl -e …`, `node -e
-/// …`, `ruby -e …`, `dd of=…`, `rsync … dest`, or a re-invoked shell
-/// (`bash -c "…"`, `sh -c "…"`) whose quoted body this function does not
-/// recursively parse — is not detected at all; the path can be assembled at
-/// runtime (concatenation, base64, an env var) in ways no static prefix/token
-/// scan can enumerate; (3) `xargs` whose target path arrives via STDIN rather
-/// than appearing literally on the command line
-/// (`echo .claude/settings.json | xargs rm`) is invisible to the `xargs`
-/// handling added here — that handling only sees literal argv tokens on the
-/// line itself, the same fundamental limit as (2). None of these three gaps
-/// are specific to the trust anchor, nor introduced by this function — they
-/// are pre-existing properties of [`evaluate_bash_command`]'s whole
-/// classification strategy — tracked for a possible follow-up
-/// allowlist-based Bash gate rather than papered over with a brittle
-/// heuristic here. See also the strategic caveat at the top of this doc
-/// comment: this list is illustrative, not exhaustive — any renaming/copying/
-/// linking verb this module does not yet enumerate is presumptively open
-/// until proven otherwise.
+/// **The accepted cost, stated plainly (per explicit product direction, not
+/// an oversight): this over-blocks.** Because the scan does not know or care
+/// what a token's role is, THREE new categories of harmless command are now
+/// denied absolutely, on top of the pre-existing `cp <anchor> <dest>`
+/// backup/read trade-off documented below:
+/// - A pure READ: `cat .claude/settings.json`, `grep foo
+///   .claude/settings.json`, `diff a.json .claude/settings.json`,
+///   `less .claude/settings.json`.
+/// - A MERE TEXTUAL MENTION of the path in an argument that isn't a target at
+///   all — e.g. a commit message (`git commit -m "fixes .claude/settings.json
+///   handling"`) or an `echo` string — because the scan checks every token
+///   regardless of quoting or position, not just "the" destination argument.
+/// - Command-substitution bodies that merely READ the file
+///   (`` X=$(cat .claude/settings.json) ``) rather than write it.
+///
+/// This is a deliberate continuation of the trade-off the `cp <anchor>
+/// <dest>` case already established one round ago: narrowing the scan to
+/// "only when this token is really being written to" would require
+/// re-introducing exactly the verb-by-verb, position-by-position reasoning
+/// that just failed three times in a row (most recently for `rsync`/`scp`).
+/// A textual classifier that tries to be clever about "read vs. write intent"
+/// is a textual classifier an attacker can find the un-enumerated gap in.
+/// Over-denying a `cat`/`grep`/commit-message is a workflow annoyance with a
+/// working remedy (a human operator, or `TRUSTY_MPM_PM_UNRESTRICTED=1`); a
+/// missed write is a silent, total guard bypass. Safety over convenience,
+/// applied consistently rather than re-litigated per verb.
+///
+/// What: splits `command` on [`TRUST_ANCHOR_FRAGMENT_DELIMITERS`] (a superset
+/// of whitespace) into candidate fragments, and returns `true` the first time
+/// [`is_trust_anchor_path`] confirms one resolves to the trust anchor. No
+/// verb recognition, no argument-position reasoning, no per-segment
+/// composition splitting ([`split_shell_segments`]) — none of that machinery
+/// is needed because the scan runs directly over the whole raw command text.
+///
+/// Known residual gaps — now narrowed to ONLY what a static token scan
+/// structurally cannot see, because it requires the path to not appear as
+/// literal text anywhere on the command line:
+/// (1) a path assembled at RUNTIME — string concatenation
+/// (`"$A$B"`/`printf -v`), base64/hex decoding, or indirection through an
+/// intermediate shell variable (`X=.claude/settings.json; cp evil "$X"`) —
+/// has no literal occurrence of the trust-anchor path for this function to
+/// find; this module classifies text structurally, it does not execute or
+/// simulate the shell; (2) an environment-variable-relative path where the
+/// variable's NAME appears literally but its resolved VALUE does not
+/// (`cp evil "$CLAUDE_CONFIG_DIR/settings.json"` — the fragment
+/// `CLAUDE_CONFIG_DIR/settings.json` does not textually equal a resolvable
+/// trust-anchor path, and this function does not read env vars to resolve
+/// it); (3) `xargs`/any command whose target path arrives purely via STDIN
+/// rather than appearing literally on the command line
+/// (`echo .claude/settings.json | xargs rm`) is invisible by construction —
+/// there is no argv token to find. None of these three are specific to the
+/// trust anchor, nor introduced by this function — they are pre-existing
+/// properties of any static command-line classifier, tracked for a possible
+/// follow-up allowlist-based Bash gate rather than papered over with a
+/// brittle heuristic here.
 /// Test: `bash_targets_trust_anchor_*` below.
 pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
-    for segment in split_shell_segments(command) {
-        let trimmed = segment.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if let Some(target) = redirection_target(trimmed)
-            && is_trust_anchor_path(&target)
-        {
-            return true;
-        }
-        let Some(program) = first_command_token(trimmed) else {
-            continue;
-        };
-        if program == "tee" {
-            for target in tee_target_tokens(trimmed) {
-                if is_trust_anchor_path(target) {
-                    return true;
-                }
-            }
-            continue;
-        }
-        if matches!(program, "cp" | "mv" | "install" | "ln" | "xargs") {
-            for target in non_flag_tokens(trimmed) {
-                if is_trust_anchor_path(target) {
-                    return true;
-                }
-            }
-            continue;
-        }
-        if program == "git" {
-            if let Some((sub, rest)) = shell_lex::git_subcommand_with_args(trimmed) {
-                match sub.as_str() {
-                    "apply" => {
-                        if let Some(target) = trailing_file_token(trimmed)
-                            && is_trust_anchor_path(&target)
-                        {
-                            return true;
-                        }
-                    }
-                    "mv" => {
-                        for tok in &rest {
-                            if !tok.starts_with('-') && is_trust_anchor_path(tok) {
-                                return true;
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            continue;
-        }
-        let is_sed_awk_family =
-            matches!(program, "patch" | "sed" | "awk" | "gawk" | "nawk" | "mawk");
-        if is_sed_awk_family
-            && let Some(target) = trailing_file_token(trimmed)
-            && is_trust_anchor_path(&target)
-        {
-            return true;
-        }
-    }
-    false
-}
-
-/// Every non-flag positional argument of a `cp`/`mv`/`install`/`ln`/`xargs`-
-/// headed segment, source AND destination alike (issue #3981/#3994).
-///
-/// Why: unlike `tee` (output-only arguments) or `sed`/`patch` (a single
-/// trailing target), `cp`/`mv`/`install`/`ln` take BOTH a source and a
-/// destination as plain positional arguments in either the 2-arg
-/// (`cp SRC DST`, `ln TARGET LINKNAME`) or N-arg-plus-directory
-/// (`cp SRC1 SRC2 DIR/`, `cp -t DIR SRC1 SRC2`) forms — there is no single
-/// reliable "the target is always token N" rule cheap enough to be worth
-/// getting subtly wrong. `xargs` reuses the same scan for a different reason:
-/// it is not itself a file-write verb, so this deliberately does NOT try to
-/// parse `xargs`'s own flags (`-I{}`, `-n`, `-P`) to find where ITS embedded
-/// command begins — it just asks "does the trust-anchor path appear literally
-/// anywhere on this line", which is enough to catch the realistic bypass
-/// (`… | xargs -I{} cp {} .claude/settings.json`, where the destination is
-/// written out in full) while honestly NOT catching a target fed purely
-/// through stdin (see the residual-gap list on [`bash_targets_trust_anchor`]).
-/// Checking every positional token is simpler and can only widen the deny,
-/// never narrow it.
-/// What: the program token (index 0) is skipped; every remaining
-/// whitespace-separated token that does not start with `-` is returned. This
-/// deliberately does NOT track which flags consume a following value token
-/// (`install -m 644 …`, `cp -t DIR …`) — the value token (`644`, `DIR`) is
-/// returned right alongside the real source/destination tokens, exactly as
-/// if it were itself positional. That is harmless, not merely tolerated: the
-/// caller only ever asks "does ANY of these tokens match the trust-anchor
-/// path", so an extra, unrelated candidate token (a numeric mode, a
-/// directory name) can only ever be checked and rejected — it can never
-/// suppress a real match. Trying to enumerate every verb's flag arity so
-/// only the "true" positionals remain would add real complexity for zero
-/// added safety, and would risk getting it subtly wrong in the dangerous
-/// direction (excluding a real destination token by miscounting).
-/// Test: `non_flag_tokens_*`.
-fn non_flag_tokens(command: &str) -> Vec<&str> {
     command
-        .split_whitespace()
-        .skip(1)
-        .filter(|t| !t.starts_with('-'))
-        .collect()
-}
-
-/// The non-flag argument tokens of a `tee`-headed segment.
-///
-/// Why: `tee` writes its output to file ARGUMENTS, not a `>` redirect, so it
-/// is invisible to [`has_file_write_redirection`]/[`redirection_target`]; a
-/// dedicated scan is the only way [`bash_targets_trust_anchor`] can see
-/// `tee .claude/settings.json` or `sudo tee -a .claude/settings.json`.
-/// What: finds the first whitespace token equal to `tee` (or ending in
-/// `/tee`, covering an absolute-path invocation), then returns every
-/// remaining whitespace-separated token that does not start with `-` (an
-/// option flag) — `tee` accepts multiple output files, so ALL of them are
-/// returned, not just the first/last.
-/// Test: `tee_target_tokens_*`.
-fn tee_target_tokens(command: &str) -> Vec<&str> {
-    let all: Vec<&str> = command.split_whitespace().collect();
-    let Some(pos) = all
-        .iter()
-        .position(|t| *t == "tee" || t.rsplit('/').next() == Some("tee"))
-    else {
-        return Vec::new();
-    };
-    all[pos + 1..]
-        .iter()
-        .filter(|t| !t.starts_with('-'))
-        .copied()
-        .collect()
+        .split(TRUST_ANCHOR_FRAGMENT_DELIMITERS)
+        .filter(|fragment| !fragment.is_empty())
+        .any(is_trust_anchor_path)
 }
 
 /// Depth-aware core of [`evaluate_bash_command`].

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -90,25 +90,46 @@ pub(crate) fn evaluate_bash_command(command: &str) -> Option<&'static str> {
 ///
 /// Why: a shell redirect (`echo … > .claude/settings.json`, `cat >>`), `tee`
 /// (which takes its output file as an ARGUMENT, not a `>` redirect — invisible
-/// to [`has_file_write_redirection`]/[`redirection_target`]), or `sed -i`/
-/// `awk`/`patch`/`git apply` (whose target is conventionally their trailing
-/// non-flag argument, per [`trailing_file_token`]) can all write the trust
-/// anchor exactly as surely as the `Write`/`Edit` tool. Without this check
-/// those would classify as the ordinary [`SHELL_EDIT_REASON`] — which
-/// `pm_guard`'s per-turn budget (issue #2918) allows up to 3 times BEFORE
-/// hard-blocking — silently reopening the exact hole the Edit/Write-side
-/// trust-anchor denylist closes.
+/// to [`has_file_write_redirection`]/[`redirection_target`]), `sed -i`/`awk`/
+/// `patch`/`git apply` (whose target is conventionally their trailing
+/// non-flag argument, per [`trailing_file_token`]), or `cp`/`mv`/`install`
+/// (whose source AND destination are both plain positional arguments, per
+/// [`non_flag_tokens`]) can all write the trust anchor exactly as surely as
+/// the `Write`/`Edit` tool. Without this check those would classify as the
+/// ordinary [`SHELL_EDIT_REASON`] (or, for `cp`/`mv`/`install`, would not be
+/// classified as a file-edit AT ALL — see the residual-gap note below) —
+/// `pm_guard`'s per-turn budget (issue #2918) allows a `SHELL_EDIT_REASON`
+/// deny up to 3 times BEFORE hard-blocking, silently reopening the exact hole
+/// the Edit/Write-side trust-anchor denylist closes.
 /// What: scans every composition segment ([`split_shell_segments`]) for a
 /// real file-write redirect target ([`redirection_target`]), a `tee`
-/// argument ([`tee_target_tokens`]), or — for the sed/awk-family/`patch`/
-/// `git apply` verbs — the trailing file token ([`trailing_file_token`]),
-/// and returns `true` on the first one [`is_trust_anchor_path`] confirms.
-/// Known residual gap: a trust-anchor write hidden inside a `$(…)`/backtick
-/// command substitution is NOT specially detected by this function (it scans
+/// argument ([`tee_target_tokens`]), a `cp`/`mv`/`install` argument
+/// ([`non_flag_tokens`] — checks EVERY positional token, source included, not
+/// just the destination: `cp .claude/settings.json /tmp/x` reads the trust
+/// anchor into an attacker-controlled sibling path, and being conservative
+/// about ambiguous positional order costs nothing since this check only ever
+/// widens a deny, never an allow), or — for the sed/awk-family/`patch`/
+/// `git apply` verbs — the trailing file token ([`trailing_file_token`]), and
+/// returns `true` on the first one [`is_trust_anchor_path`] confirms.
+/// Known residual gaps, deliberately NOT attempted here because a textual
+/// classifier cannot close them without becoming trivially evadable (a false
+/// sense of security is worse than an honest gap — see the PR description):
+/// (1) a trust-anchor write hidden inside a `$(…)`/backtick command
+/// substitution is not specially detected by this function (it scans
 /// top-level segments only) — such a call still denies, but as the ordinary
 /// budget-eligible `SHELL_EDIT_REASON` via [`classify_command_substitutions`]'s
-/// existing recursive scan, not this absolute deny. Documented, not silently
-/// swept under the rug — see the PR description for the same note.
+/// existing recursive scan, not this absolute deny; (2) a write performed by
+/// an interpreter's *inline program text* rather than the shell itself —
+/// `python3 -c "open('.claude/settings.json','w')…"`, `perl -e …`, `node -e
+/// …`, `ruby -e …`, `dd of=…`, `rsync … dest`, or a re-invoked shell
+/// (`bash -c "…"`, `sh -c "…"`) whose quoted body this function does not
+/// recursively parse — is not detected at all; the path can be assembled at
+/// runtime (concatenation, base64, an env var) in ways no static prefix/token
+/// scan can enumerate. Both gaps are pre-existing properties of
+/// [`evaluate_bash_command`]'s whole classification strategy (neither is
+/// specific to the trust anchor, nor introduced by this function), tracked
+/// for a possible follow-up allowlist-based Bash gate rather than papered
+/// over with a brittle heuristic here.
 /// Test: `bash_targets_trust_anchor_*` below.
 pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
     for segment in split_shell_segments(command) {
@@ -132,6 +153,14 @@ pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
             }
             continue;
         }
+        if matches!(program, "cp" | "mv" | "install") {
+            for target in non_flag_tokens(trimmed) {
+                if is_trust_anchor_path(target) {
+                    return true;
+                }
+            }
+            continue;
+        }
         let is_sed_awk_family =
             matches!(program, "patch" | "sed" | "awk" | "gawk" | "nawk" | "mawk");
         let is_git_apply =
@@ -144,6 +173,38 @@ pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
         }
     }
     false
+}
+
+/// Every non-flag positional argument of a `cp`/`mv`/`install`-headed
+/// segment, source AND destination alike (issue #3981).
+///
+/// Why: unlike `tee` (output-only arguments) or `sed`/`patch` (a single
+/// trailing target), `cp`/`mv`/`install` take BOTH a source and a destination
+/// as plain positional arguments in either the 2-arg (`cp SRC DST`) or
+/// N-arg-plus-directory (`cp SRC1 SRC2 DIR/`, `cp -t DIR SRC1 SRC2`) forms —
+/// there is no single reliable "the target is always token N" rule cheap
+/// enough to be worth getting subtly wrong. Checking every positional token
+/// is simpler and can only widen the deny, never narrow it.
+/// What: the program token (index 0) is skipped; every remaining
+/// whitespace-separated token that does not start with `-` is returned. This
+/// deliberately does NOT track which flags consume a following value token
+/// (`install -m 644 …`, `cp -t DIR …`) — the value token (`644`, `DIR`) is
+/// returned right alongside the real source/destination tokens, exactly as
+/// if it were itself positional. That is harmless, not merely tolerated: the
+/// caller only ever asks "does ANY of these tokens match the trust-anchor
+/// path", so an extra, unrelated candidate token (a numeric mode, a
+/// directory name) can only ever be checked and rejected — it can never
+/// suppress a real match. Trying to enumerate every verb's flag arity so
+/// only the "true" positionals remain would add real complexity for zero
+/// added safety, and would risk getting it subtly wrong in the dangerous
+/// direction (excluding a real destination token by miscounting).
+/// Test: `non_flag_tokens_*`.
+fn non_flag_tokens(command: &str) -> Vec<&str> {
+    command
+        .split_whitespace()
+        .skip(1)
+        .filter(|t| !t.starts_with('-'))
+        .collect()
 }
 
 /// The non-flag argument tokens of a `tee`-headed segment.

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/mod.rs
@@ -29,6 +29,7 @@ mod shell_lex;
 use std::path::{Path, PathBuf};
 
 use crate::commands::hook_rewrite::{effective_tool_name, first_command_token};
+use crate::commands::pm_guard_trust_anchor::is_trust_anchor_path;
 use shell_lex::QuoteScan;
 
 /// Deny reason for editing files through a shell tool (sed/awk/patch/git apply/redirection).
@@ -67,7 +68,109 @@ const MAX_SUBSTITUTION_DEPTH: usize = 32;
 /// Test: `evaluate_bash_command_denies_*`, `evaluate_bash_command_allows_*`,
 /// `evaluate_bash_command_denies_composition_*`.
 pub(crate) fn evaluate_bash_command(command: &str) -> Option<&'static str> {
+    // Trust-anchor check (issue #3981) — deliberately runs FIRST and
+    // unconditionally, ahead of the ordinary verb/redirection classification
+    // below. `pm_guard::pm_guard` already calls [`bash_targets_trust_anchor`]
+    // directly, ahead of the Guard 1/Guard 4 subagent exemptions that never
+    // reach this function at all — so for THAT caller this check is
+    // redundant by construction. It is kept here too as defense in depth for
+    // any OTHER caller of this pure classifier (e.g. `evaluate_tool`, used by
+    // the opt-in deny-by-default persona gate to ask "would this call be
+    // guarded at all") and so a trust-anchor write is never misreported as
+    // the ordinary, budget-eligible [`SHELL_EDIT_REASON`] regardless of call
+    // site.
+    if bash_targets_trust_anchor(command) {
+        return Some(crate::commands::pm_guard_trust_anchor::TRUST_ANCHOR_DENY_REASON);
+    }
     evaluate_bash_command_inner(command, 0)
+}
+
+/// Whether `command` writes, via any Bash mechanism this module recognizes,
+/// to pm_guard's own trust-anchor settings file (issue #3981).
+///
+/// Why: a shell redirect (`echo … > .claude/settings.json`, `cat >>`), `tee`
+/// (which takes its output file as an ARGUMENT, not a `>` redirect — invisible
+/// to [`has_file_write_redirection`]/[`redirection_target`]), or `sed -i`/
+/// `awk`/`patch`/`git apply` (whose target is conventionally their trailing
+/// non-flag argument, per [`trailing_file_token`]) can all write the trust
+/// anchor exactly as surely as the `Write`/`Edit` tool. Without this check
+/// those would classify as the ordinary [`SHELL_EDIT_REASON`] — which
+/// `pm_guard`'s per-turn budget (issue #2918) allows up to 3 times BEFORE
+/// hard-blocking — silently reopening the exact hole the Edit/Write-side
+/// trust-anchor denylist closes.
+/// What: scans every composition segment ([`split_shell_segments`]) for a
+/// real file-write redirect target ([`redirection_target`]), a `tee`
+/// argument ([`tee_target_tokens`]), or — for the sed/awk-family/`patch`/
+/// `git apply` verbs — the trailing file token ([`trailing_file_token`]),
+/// and returns `true` on the first one [`is_trust_anchor_path`] confirms.
+/// Known residual gap: a trust-anchor write hidden inside a `$(…)`/backtick
+/// command substitution is NOT specially detected by this function (it scans
+/// top-level segments only) — such a call still denies, but as the ordinary
+/// budget-eligible `SHELL_EDIT_REASON` via [`classify_command_substitutions`]'s
+/// existing recursive scan, not this absolute deny. Documented, not silently
+/// swept under the rug — see the PR description for the same note.
+/// Test: `bash_targets_trust_anchor_*` below.
+pub(crate) fn bash_targets_trust_anchor(command: &str) -> bool {
+    for segment in split_shell_segments(command) {
+        let trimmed = segment.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if let Some(target) = redirection_target(trimmed)
+            && is_trust_anchor_path(&target)
+        {
+            return true;
+        }
+        let Some(program) = first_command_token(trimmed) else {
+            continue;
+        };
+        if program == "tee" {
+            for target in tee_target_tokens(trimmed) {
+                if is_trust_anchor_path(target) {
+                    return true;
+                }
+            }
+            continue;
+        }
+        let is_sed_awk_family =
+            matches!(program, "patch" | "sed" | "awk" | "gawk" | "nawk" | "mawk");
+        let is_git_apply =
+            program == "git" && shell_lex::git_subcommand(trimmed).as_deref() == Some("apply");
+        if (is_sed_awk_family || is_git_apply)
+            && let Some(target) = trailing_file_token(trimmed)
+            && is_trust_anchor_path(&target)
+        {
+            return true;
+        }
+    }
+    false
+}
+
+/// The non-flag argument tokens of a `tee`-headed segment.
+///
+/// Why: `tee` writes its output to file ARGUMENTS, not a `>` redirect, so it
+/// is invisible to [`has_file_write_redirection`]/[`redirection_target`]; a
+/// dedicated scan is the only way [`bash_targets_trust_anchor`] can see
+/// `tee .claude/settings.json` or `sudo tee -a .claude/settings.json`.
+/// What: finds the first whitespace token equal to `tee` (or ending in
+/// `/tee`, covering an absolute-path invocation), then returns every
+/// remaining whitespace-separated token that does not start with `-` (an
+/// option flag) — `tee` accepts multiple output files, so ALL of them are
+/// returned, not just the first/last.
+/// Test: `tee_target_tokens_*`.
+fn tee_target_tokens(command: &str) -> Vec<&str> {
+    let all: Vec<&str> = command.split_whitespace().collect();
+    let Some(pos) = all
+        .iter()
+        .position(|t| *t == "tee" || t.rsplit('/').next() == Some("tee"))
+    else {
+        return Vec::new();
+    };
+    all[pos + 1..]
+        .iter()
+        .filter(|t| !t.starts_with('-'))
+        .copied()
+        .collect()
 }
 
 /// Depth-aware core of [`evaluate_bash_command`].
@@ -734,11 +837,16 @@ fn resolve_target_path(token: &str, base: &Path) -> PathBuf {
 /// Why: [`resolve_target_path`] must not call `fs::canonicalize` (the target
 /// usually doesn't exist yet), but a purely textual join like
 /// `/repo/../tmp/wt` must still be recognized as resolving under `/tmp`.
+/// `pub(crate)` (rather than private) so
+/// [`crate::commands::pm_guard_trust_anchor`] reuses the SAME lexical-collapse
+/// rule (issue #3981) instead of a second, potentially-drifting
+/// implementation — that module layers its own filesystem-touching symlink
+/// resolution on top, which this function deliberately does not attempt.
 /// What: walks `path`'s components, popping the accumulator on `..` and
 /// dropping `.`, otherwise appending. Does not consult the filesystem, so it
-/// cannot see through symlinks (see the residual-bypass note on
+/// cannot see through symlinks on its own (see the residual-bypass note on
 /// [`evaluate_worktree_add_command`]).
-fn normalize_lexically(path: &Path) -> PathBuf {
+pub(crate) fn normalize_lexically(path: &Path) -> PathBuf {
     use std::path::Component;
     let mut out = PathBuf::new();
     for component in path.components() {

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -169,21 +169,36 @@ const GIT_GLOBAL_OPTS_WITH_ARG: &[&str] = &[
 /// Resolve the real `git` subcommand of a single pipeline segment.
 ///
 /// Why (issue #2734): the guard must recognise an allowlisted git subcommand
-/// (`commit`, `status`, …) — and the one forbidden one (`apply`) — through any
-/// leading git global flags, which the earlier two-token `effective_tool_name`
-/// matcher could not see past. Parsing the argv properly closes both the
-/// `git -C <path> commit` false positive and the `git -C <path> apply`
-/// false negative.
-/// What: shlex-splits `segment` (quote-aware; `None` on unbalanced quotes →
-/// caller falls back), skips leading `KEY=value`/`sudo`/`env` prefixes, requires
-/// the program basename to be `git`, then walks past global options — those in
-/// [`GIT_GLOBAL_OPTS_WITH_ARG`] consume an extra token, `=`-joined long options
-/// consume none, other dash-prefixed tokens are valueless global flags — and
-/// returns the first non-option token (the subcommand). `None` when the segment
-/// is not `git`, is unparseable, or has no subcommand after the options.
+/// (`commit`, `status`, …) — and the forbidden ones (`apply`, `mv` — issue
+/// #3981/#3994) — through any leading git global flags, which the earlier
+/// two-token `effective_tool_name` matcher could not see past. Parsing the
+/// argv properly closes both the `git -C <path> commit` false positive and
+/// the `git -C <path> apply` false negative.
+/// What: thin wrapper over [`git_subcommand_with_args`] that discards the
+/// remaining argv and keeps just the subcommand name, for the (still common)
+/// callers that only need to know WHICH subcommand ran.
 /// Test: `git_subcommand_skips_global_flags`, `git_subcommand_plain`,
 /// `git_subcommand_none_for_non_git`, `git_subcommand_none_when_unbalanced`.
 pub(super) fn git_subcommand(segment: &str) -> Option<String> {
+    git_subcommand_with_args(segment).map(|(sub, _)| sub)
+}
+
+/// Resolve the real `git` subcommand of a single pipeline segment AND its
+/// remaining argv tail (everything after the subcommand token, flags
+/// included) — issue #3981/#3994.
+///
+/// Why: `git apply`'s target is conventionally its trailing token
+/// ([`trailing_file_token`] in the parent module handles that), but `git mv
+/// SRC DST` takes two POSITIONAL arguments after the subcommand, the same
+/// shape `cp`/`mv`/`install`/`ln` do — a caller needs the subcommand's own
+/// argv slice (not the whole segment's whitespace tokens, which would still
+/// include any leading `git -C <path>` global-flag noise) to scan those
+/// positions the same way [`super::non_flag_tokens`] scans `cp`/`mv`.
+/// What: identical parse to [`git_subcommand`] but returns
+/// `(subcommand, argv[after_subcommand..])` instead of discarding the tail.
+/// Test: `git_subcommand_with_args_returns_tail`,
+/// `git_subcommand_with_args_skips_global_flags`.
+pub(super) fn git_subcommand_with_args(segment: &str) -> Option<(String, Vec<String>)> {
     let argv = shlex::split(segment)?;
     let mut i = 0;
     // Skip env-assignment / sudo / env prefixes (mirrors first_command_token).
@@ -239,7 +254,7 @@ pub(super) fn git_subcommand(segment: &str) -> Option<String> {
             i += 1;
             continue;
         }
-        return Some(tok.clone());
+        return Some((tok.clone(), argv[i + 1..].to_vec()));
     }
     None
 }
@@ -365,5 +380,24 @@ mod tests {
             git_subcommand("/usr/bin/git -C /p commit").as_deref(),
             Some("commit")
         );
+    }
+
+    #[test]
+    fn git_subcommand_with_args_returns_tail() {
+        let (sub, rest) = git_subcommand_with_args("git mv a.json b.json").unwrap();
+        assert_eq!(sub, "mv");
+        assert_eq!(rest, vec!["a.json".to_string(), "b.json".to_string()]);
+    }
+
+    #[test]
+    fn git_subcommand_with_args_skips_global_flags() {
+        let (sub, rest) = git_subcommand_with_args("git -C /repo mv a.json b.json").unwrap();
+        assert_eq!(sub, "mv");
+        assert_eq!(rest, vec!["a.json".to_string(), "b.json".to_string()]);
+    }
+
+    #[test]
+    fn git_subcommand_with_args_none_for_non_git() {
+        assert!(git_subcommand_with_args("mv a b").is_none());
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/shell_lex.rs
@@ -187,13 +187,24 @@ pub(super) fn git_subcommand(segment: &str) -> Option<String> {
 /// remaining argv tail (everything after the subcommand token, flags
 /// included) — issue #3981/#3994.
 ///
-/// Why: `git apply`'s target is conventionally its trailing token
-/// ([`trailing_file_token`] in the parent module handles that), but `git mv
-/// SRC DST` takes two POSITIONAL arguments after the subcommand, the same
-/// shape `cp`/`mv`/`install`/`ln` do — a caller needs the subcommand's own
-/// argv slice (not the whole segment's whitespace tokens, which would still
-/// include any leading `git -C <path>` global-flag noise) to scan those
-/// positions the same way [`super::non_flag_tokens`] scans `cp`/`mv`.
+/// Why: originally added so a caller could scan `git mv SRC DST`'s two
+/// POSITIONAL arguments (the subcommand's own argv slice, not the whole
+/// segment's whitespace tokens, which would still include any leading
+/// `git -C <path>` global-flag noise) the same way the parent module's
+/// former verb-allowlist scanned `cp`/`mv`. **Status note (round 3 of the
+/// #3994 review):** `bash_targets_trust_anchor` was inverted to a
+/// verb-agnostic literal-token scan over the whole raw command (see its doc
+/// in the parent module) that no longer calls this function at all — a plain
+/// `git mv SRC .claude/settings.json` is now caught by the generic scan
+/// finding `.claude/settings.json` as its own whitespace token, without
+/// needing to know it followed a `git mv`. This function is NOT dead code —
+/// [`git_subcommand`] still wraps it and is still called from
+/// `classify_bash_segment` (the `git apply` shell-edit check),
+/// `evaluate_worktree_add_command`, and `extract_shell_edit_target` — but its
+/// distinguishing feature, the argv tail, is currently exercised only by this
+/// module's own unit tests, not by any production caller. Left unchanged
+/// rather than collapsed back into a bare subcommand-only lookup, since it is
+/// still correct, still tested, and a future caller may yet want the tail.
 /// What: identical parse to [`git_subcommand`] but returns
 /// `(subcommand, argv[after_subcommand..])` instead of discarding the tail.
 /// Test: `git_subcommand_with_args_returns_tail`,

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -809,3 +809,144 @@ fn evaluate_worktree_add_command_normalizes_dot_dot_traversal() {
         Some(WORKTREE_TMP_REASON)
     );
 }
+
+// ─── trust-anchor Bash-route coverage (issue #3981) ────────────────────────
+
+#[test]
+fn bash_targets_trust_anchor_detects_redirection() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    for cmd in [
+        format!("echo '{{\"env\":{{\"TRUSTY_MPM_PM_UNRESTRICTED\":\"1\"}}}}' > {target_s}"),
+        format!("cat >> {target_s}"),
+        format!("printf 'x' >{target_s}"),
+    ] {
+        assert!(
+            bash_targets_trust_anchor(&cmd),
+            "expected trust-anchor detection for: {cmd}"
+        );
+    }
+
+    // A benign redirect elsewhere must not trip it.
+    assert!(!bash_targets_trust_anchor("echo hi > /tmp/out.txt"));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_tee() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    for cmd in [
+        format!("echo x | tee {target_s}"),
+        format!("tee {target_s}"),
+        format!("sudo tee -a {target_s}"),
+        format!("tee /tmp/other.json {target_s}"),
+    ] {
+        assert!(
+            bash_targets_trust_anchor(&cmd),
+            "expected tee to be caught for: {cmd}"
+        );
+    }
+
+    assert!(!bash_targets_trust_anchor("echo x | tee /tmp/notes.txt"));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_sed_awk_patch_git_apply() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    for cmd in [
+        format!("sed -i s/a/b/ {target_s}"),
+        format!("patch -p1 {target_s}"),
+        format!("git apply {target_s}"),
+    ] {
+        assert!(
+            bash_targets_trust_anchor(&cmd),
+            "expected trailing-token detection for: {cmd}"
+        );
+    }
+
+    assert!(!bash_targets_trust_anchor("sed -i s/a/b/ src/lib.rs"));
+}
+
+#[test]
+#[serial_test::serial(claude_config_dir_env)]
+fn bash_targets_trust_anchor_detects_claude_config_dir_target() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config_dir = tmp.path().join("claude-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let target = config_dir.join("settings.json");
+    let target_s = target.to_string_lossy().to_string();
+
+    // Serialized (see the attribute above) under the SAME key
+    // `pm_guard_trust_anchor`'s own `CLAUDE_CONFIG_DIR`-mutating test uses, so
+    // the two never interleave and race the process-wide env var. Scoped
+    // set/remove around the single assertion, mirroring this file's other
+    // env-mutating tests
+    // (`evaluate_worktree_add_command_resolves_env_and_tilde_expansion`
+    // above, which predates this pattern and is intentionally left as-is).
+    let prior = std::env::var_os("CLAUDE_CONFIG_DIR");
+    unsafe {
+        std::env::set_var("CLAUDE_CONFIG_DIR", &config_dir);
+    }
+    let result = bash_targets_trust_anchor(&format!("echo x > {target_s}"));
+    unsafe {
+        match prior {
+            Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+            None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+        }
+    }
+    assert!(result);
+}
+
+#[test]
+fn bash_targets_trust_anchor_allows_benign_commands() {
+    for cmd in [
+        "git status",
+        "cargo test",
+        "echo hi",
+        "sed -i s/a/b/ src/lib.rs",
+        "cat .claude/agents/foo.md",
+    ] {
+        assert!(
+            !bash_targets_trust_anchor(cmd),
+            "expected no trust-anchor detection for: {cmd}"
+        );
+    }
+}
+
+#[test]
+fn tee_target_tokens_extracts_all_non_flag_args() {
+    assert_eq!(tee_target_tokens("tee f1 f2"), vec!["f1", "f2"]);
+    assert_eq!(tee_target_tokens("tee -a f1"), vec!["f1"]);
+    assert_eq!(tee_target_tokens("sudo tee -a f1"), vec!["f1"]);
+    assert_eq!(tee_target_tokens("/usr/bin/tee f1"), vec!["f1"]);
+    assert_eq!(tee_target_tokens("echo x | tee f1"), vec!["f1"]);
+    assert!(tee_target_tokens("git status").is_empty());
+}
+
+#[test]
+fn evaluate_bash_command_returns_trust_anchor_reason_not_shell_edit_reason() {
+    // The whole point of issue #3981's Bash-side fix: a trust-anchor write
+    // must classify as the absolute TRUST_ANCHOR_DENY_REASON, NOT the
+    // budget-eligible SHELL_EDIT_REASON a plain redirect would otherwise get.
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let cmd = format!("echo x > {}", target.to_string_lossy());
+
+    let reason = evaluate_bash_command(&cmd);
+    assert_eq!(
+        reason,
+        Some(crate::commands::pm_guard_trust_anchor::TRUST_ANCHOR_DENY_REASON)
+    );
+    assert_ne!(reason, Some(SHELL_EDIT_REASON));
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -906,6 +906,88 @@ fn bash_targets_trust_anchor_detects_cp_mv_install() {
 }
 
 #[test]
+fn bash_targets_trust_anchor_detects_ln() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    for cmd in [
+        // Symlink form — the LINKNAME (destination) is the dangerous
+        // position: Claude Code reads through the symlink on its next
+        // config load and applies the attacker/PM-controlled source's `env`
+        // block (issue #3994 critical finding).
+        format!("ln -sf /tmp/evil.json {target_s}"),
+        format!("ln -s /tmp/evil.json {target_s}"),
+        // Hardlink form.
+        format!("ln /tmp/evil.json {target_s}"),
+        // Reading the trust anchor as the symlink SOURCE is also caught
+        // (same deliberate over-inclusion as cp/mv/install).
+        format!("ln -sf {target_s} /tmp/exfil.json"),
+    ] {
+        assert!(
+            bash_targets_trust_anchor(&cmd),
+            "expected ln detection for: {cmd}"
+        );
+    }
+
+    assert!(!bash_targets_trust_anchor("ln -sf /tmp/a.txt /tmp/b.txt"));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_git_mv() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    for cmd in [
+        format!("git mv evil.json {target_s}"),
+        // Global `-C <path>` flag before the subcommand must not hide it.
+        format!("git -C /some/repo mv evil.json {target_s}"),
+        // Reading the trust anchor as the rename SOURCE is also caught.
+        format!("git mv {target_s} /tmp/exfil.json"),
+    ] {
+        assert!(
+            bash_targets_trust_anchor(&cmd),
+            "expected git mv detection for: {cmd}"
+        );
+    }
+
+    assert!(!bash_targets_trust_anchor("git mv src/a.rs src/b.rs"));
+    // `git apply`/other subcommands must not be mistaken for `mv`.
+    assert!(!bash_targets_trust_anchor("git status"));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_xargs_indirection() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    for cmd in [
+        format!("echo /tmp/evil.json | xargs -I{{}} cp {{}} {target_s}"),
+        format!("find /tmp -name evil.json | xargs -I{{}} cp {{}} {target_s}"),
+    ] {
+        assert!(
+            bash_targets_trust_anchor(&cmd),
+            "expected xargs indirection detection for: {cmd}"
+        );
+    }
+
+    // A benign xargs invocation with no trust-anchor token anywhere on the
+    // line must not be denied.
+    assert!(!bash_targets_trust_anchor(
+        "echo /tmp/a.txt | xargs -I{} cp {} /tmp/b.txt"
+    ));
+    // The known, documented residual gap: the path arriving purely via
+    // stdin (not spelled out literally on the command line) is NOT caught —
+    // this asserts the honest boundary rather than silently relying on it.
+    assert!(!bash_targets_trust_anchor("cat paths.txt | xargs rm"));
+}
+
+#[test]
 fn non_flag_tokens_skips_program_and_flags() {
     assert_eq!(non_flag_tokens("cp a b"), vec!["a", "b"]);
     assert_eq!(non_flag_tokens("cp -r a b"), vec!["a", "b"]);

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -878,6 +878,48 @@ fn bash_targets_trust_anchor_detects_sed_awk_patch_git_apply() {
 }
 
 #[test]
+fn bash_targets_trust_anchor_detects_cp_mv_install() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    for cmd in [
+        format!("cp backup.json {target_s}"),
+        format!("mv backup.json {target_s}"),
+        format!("install -m 644 backup.json {target_s}"),
+        // Destination-flag form: the flag's VALUE is a plain path and must
+        // still be caught even though it isn't the trailing token.
+        format!("cp -t {target_s} backup.json"),
+        // Reading the trust anchor as a SOURCE (not the last token) is also
+        // caught — deliberately conservative, see `non_flag_tokens`'s doc.
+        format!("cp {target_s} /tmp/exfil.json"),
+    ] {
+        assert!(
+            bash_targets_trust_anchor(&cmd),
+            "expected cp/mv/install detection for: {cmd}"
+        );
+    }
+
+    assert!(!bash_targets_trust_anchor("cp src/lib.rs src/lib.rs.bak"));
+    assert!(!bash_targets_trust_anchor("mv /tmp/a.txt /tmp/b.txt"));
+}
+
+#[test]
+fn non_flag_tokens_skips_program_and_flags() {
+    assert_eq!(non_flag_tokens("cp a b"), vec!["a", "b"]);
+    assert_eq!(non_flag_tokens("cp -r a b"), vec!["a", "b"]);
+    // A value-taking flag's value token (`644`) is NOT specially filtered
+    // out — it is returned right alongside the real positional tokens. See
+    // the function's doc for why that over-inclusion is safe rather than a
+    // bug: the caller only ever checks membership against the trust-anchor
+    // path, so an extra candidate token can only ever be checked and
+    // rejected, never suppress a real match.
+    assert_eq!(non_flag_tokens("install -m 644 a b"), vec!["644", "a", "b"]);
+    assert!(non_flag_tokens("cp -r").is_empty());
+}
+
+#[test]
 #[serial_test::serial(claude_config_dir_env)]
 fn bash_targets_trust_anchor_detects_claude_config_dir_target() {
     let tmp = tempfile::TempDir::new().unwrap();

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -892,7 +892,8 @@ fn bash_targets_trust_anchor_detects_cp_mv_install() {
         // still be caught even though it isn't the trailing token.
         format!("cp -t {target_s} backup.json"),
         // Reading the trust anchor as a SOURCE (not the last token) is also
-        // caught — deliberately conservative, see `non_flag_tokens`'s doc.
+        // caught — deliberately conservative, see `bash_targets_trust_anchor`'s
+        // doc (the "accepted cost" section).
         format!("cp {target_s} /tmp/exfil.json"),
     ] {
         assert!(
@@ -987,18 +988,120 @@ fn bash_targets_trust_anchor_detects_xargs_indirection() {
     assert!(!bash_targets_trust_anchor("cat paths.txt | xargs rm"));
 }
 
+// ─── round-3 inversion coverage (issue #3981/#3994, second BLOCK) ─────────
+// `rsync`/`scp` were found completely unclassified (full, unbudgeted ALLOW)
+// under the prior verb-allowlist design. These tests exercise the
+// verb-agnostic scan directly against the verbs the review named, PLUS the
+// "any future verb" claim itself via a made-up program name.
+
 #[test]
-fn non_flag_tokens_skips_program_and_flags() {
-    assert_eq!(non_flag_tokens("cp a b"), vec!["a", "b"]);
-    assert_eq!(non_flag_tokens("cp -r a b"), vec!["a", "b"]);
-    // A value-taking flag's value token (`644`) is NOT specially filtered
-    // out — it is returned right alongside the real positional tokens. See
-    // the function's doc for why that over-inclusion is safe rather than a
-    // bug: the caller only ever checks membership against the trust-anchor
-    // path, so an extra candidate token can only ever be checked and
-    // rejected, never suppress a real match.
-    assert_eq!(non_flag_tokens("install -m 644 a b"), vec!["644", "a", "b"]);
-    assert!(non_flag_tokens("cp -r").is_empty());
+fn bash_targets_trust_anchor_detects_rsync() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    assert!(bash_targets_trust_anchor(&format!(
+        "rsync /tmp/evil.json {target_s}"
+    )));
+    assert!(!bash_targets_trust_anchor("rsync /tmp/a.txt /tmp/b.txt"));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_scp() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    assert!(bash_targets_trust_anchor(&format!(
+        "scp /tmp/evil.json {target_s}"
+    )));
+    assert!(!bash_targets_trust_anchor("scp /tmp/a.txt /tmp/b.txt"));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_dd_of_equals() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    // `dd of=PATH` carries the target glued to the flag with `=`, no space —
+    // the `=` delimiter isolates it as its own fragment.
+    assert!(bash_targets_trust_anchor(&format!(
+        "dd if=/tmp/evil.json of={target_s}"
+    )));
+    assert!(!bash_targets_trust_anchor("dd if=/tmp/a.txt of=/tmp/b.txt"));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_bash_c_literal_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    // A re-invoked shell with the target spelled out literally inside its
+    // quoted `-c` body — previously bucketed as "genuinely hard" alongside
+    // interpreter inline program text; now closed because the scan runs over
+    // the raw command text, quotes included.
+    assert!(bash_targets_trust_anchor(&format!(
+        "bash -c \"cp /tmp/evil.json {target_s}\""
+    )));
+    assert!(!bash_targets_trust_anchor(
+        "bash -c \"cp /tmp/a.txt /tmp/b.txt\""
+    ));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_python_c_literal_path() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    assert!(bash_targets_trust_anchor(&format!(
+        "python3 -c \"import shutil; shutil.copy('/tmp/evil.json', '{target_s}')\""
+    )));
+    assert!(!bash_targets_trust_anchor(
+        "python3 -c \"import shutil; shutil.copy('/tmp/a.txt', '/tmp/b.txt')\""
+    ));
+}
+
+#[test]
+fn bash_targets_trust_anchor_detects_unenumerated_program() {
+    // The core claim of the inversion: a program this module has NEVER heard
+    // of (no verb-match arm names it, now or ever) is still caught, because
+    // the scan does not depend on recognizing the verb at all.
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    assert!(bash_targets_trust_anchor(&format!(
+        "some-future-sync-tool --mirror /tmp/evil.json {target_s}"
+    )));
+}
+
+#[test]
+fn bash_targets_trust_anchor_accepted_cost_blocks_reads_and_prose_mentions() {
+    // Documents the accepted over-blocking cost explicitly (per product
+    // direction): a pure read, and a mere textual mention of the path in an
+    // argument that isn't a write target at all, both now deny. This is
+    // asserted as EXPECTED behavior, not a bug to fix.
+    let tmp = tempfile::TempDir::new().unwrap();
+    std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+    let target = tmp.path().join(".claude/settings.json");
+    let target_s = target.to_string_lossy();
+
+    // A pure read.
+    assert!(bash_targets_trust_anchor(&format!("cat {target_s}")));
+    // A mere textual mention inside a commit message — not a write to the
+    // file at all, but the fragment still appears literally on the line.
+    assert!(bash_targets_trust_anchor(&format!(
+        "git commit -m \"fixes {target_s} handling\""
+    )));
 }
 
 #[test]
@@ -1045,16 +1148,6 @@ fn bash_targets_trust_anchor_allows_benign_commands() {
             "expected no trust-anchor detection for: {cmd}"
         );
     }
-}
-
-#[test]
-fn tee_target_tokens_extracts_all_non_flag_args() {
-    assert_eq!(tee_target_tokens("tee f1 f2"), vec!["f1", "f2"]);
-    assert_eq!(tee_target_tokens("tee -a f1"), vec!["f1"]);
-    assert_eq!(tee_target_tokens("sudo tee -a f1"), vec!["f1"]);
-    assert_eq!(tee_target_tokens("/usr/bin/tee f1"), vec!["f1"]);
-    assert_eq!(tee_target_tokens("echo x | tee f1"), vec!["f1"]);
-    assert!(tee_target_tokens("git status").is_empty());
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_trust_anchor.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_trust_anchor.rs
@@ -1,0 +1,456 @@
+//! Trust-anchor denylist for `tm hook --pm-guard` (issue #3981).
+//!
+//! Why: `pm_guard`'s own enforcement pivots on two env vars —
+//! `TRUSTY_MPM_DISABLE_HOOKS` and `TRUSTY_MPM_PM_UNRESTRICTED` (see
+//! `pm_guard.rs` Guards 2/3) — that Claude Code's `settings.json` can set via
+//! its top-level `env` object, applied to every session and subprocess it
+//! spawns (hooks included), live-reloaded mid-session. `.claude/settings.json`
+//! has extension `json`, which is not in `pm_guard::SOURCE_CODE_EXTENSIONS`
+//! and is not PM-orchestration state, so a direct `Write`/`Edit` to it used to
+//! fall through `evaluate_edit_tool`'s "not source code -> allow" fallback
+//! unconditionally and unbudgeted — letting the PM (or any Guard-1/Guard-4
+//! exempt caller) self-exempt from ALL pm_guard enforcement in one ordinary
+//! permitted write. This module is the fix: a structural denylist checked
+//! BEFORE that fallback (from `pm_guard::evaluate_edit_tool`) and again,
+//! unconditionally, ahead of the ordinary Bash classifier (from
+//! `pm_guard_bash::evaluate_bash_command`) so a shell redirect/`tee`/`sed -i`
+//! targeting the same file cannot slip through as a budget-eligible
+//! [`crate::commands::pm_guard_bash::SHELL_EDIT_REASON`] instead of an
+//! absolute deny.
+//!
+//! What: [`is_trust_anchor_path`] resolves a (possibly relative, `~`-prefixed,
+//! or `..`-traversing) path against the session's cwd and the real
+//! filesystem — lexically normalizing `.`/`..` components first, then
+//! resolving symlinks in whatever prefix of the path already exists — and
+//! matches it against two anchors: (1) any `.claude/settings.json` or
+//! `.claude/settings.local.json`, matched *structurally* by "immediate parent
+//! directory literally named `.claude`" so it fires for the project-local
+//! file under ANY project root and for the real per-user `~/.claude/...`
+//! alike, without needing to know which project directory is "the" one; and
+//! (2) the managed-session global equivalent directly under
+//! `$CLAUDE_CONFIG_DIR` when that env var is set — confirmed against
+//! `core::standalone::settings_defaults::ensure_settings_defaults` that
+//! `settings.json` sits directly at `<CLAUDE_CONFIG_DIR>/settings.json`, with
+//! NO nested `.claude/` component, so anchor (1)'s structural match cannot
+//! see it and it needs its own exact-path check.
+//!
+//! No existing helper in this codebase reads the *live* `CLAUDE_CONFIG_DIR`
+//! env var with a real-home fallback — every other reference either SETS it
+//! for a spawned `claude` subprocess (`runtime::claude_code`,
+//! `core::standalone::run`) or resolves tm's own fixed managed default
+//! (`core::trusty_tools_config::managed_claude_config_dir`, which is anchored
+//! at `~/.trusty-tools/trusty-mpm/claude-config` regardless of what THIS
+//! process's environment actually carries). `pm_guard` runs AS the hook
+//! subprocess of the exact session it is protecting, so its own inherited
+//! `CLAUDE_CONFIG_DIR` (or its absence) is the correct, and only correct,
+//! signal for where that session's global settings file lives — reading it
+//! directly here is not a reimplementation of either existing resolver, both
+//! of which answer a different question.
+//!
+//! Test: `is_trust_anchor_path_*` below cover project-local, real-home, and
+//! `CLAUDE_CONFIG_DIR` matches, `..`-traversal and symlink resolution, and the
+//! non-match cases (source files, `settings.json` NOT under a `.claude` dir,
+//! other `.claude/` siblings). Wired end to end via
+//! `tests/tm_hook_pm_guard.rs::pm_guard_denies_settings_json_write_*`.
+
+use std::path::{Path, PathBuf};
+
+use crate::commands::pm_guard_bash::normalize_lexically as lexically_normalize;
+
+/// Deny reason for a write to pm_guard's own trust anchor (issue #3981).
+///
+/// Why: kept as a `pub(crate)` constant (rather than inlined at each call
+/// site) so `pm_guard::evaluate_edit_tool` and
+/// `pm_guard_bash::evaluate_bash_command` return the IDENTICAL string —
+/// `pm_guard`'s budget gate compares a returned reason by value to decide
+/// eligibility, and this reason must never match [`crate::commands::pm_guard_bash::SHELL_EDIT_REASON`]
+/// / the source-edit reason so it always falls through to the unconditional,
+/// non-budget-eligible deny branch (a trust-anchor write must be an absolute
+/// prohibition, never something a PM can exhaust its per-turn budget to get
+/// away with once).
+/// What: names what was blocked, why it matters (it can disable ALL pm_guard
+/// enforcement), cites issue #3981, and tells the reader what to do instead.
+/// Deliberately does NOT suggest "delegate via Task/Agent tool" — unlike
+/// every other deny reason in this file, this one is intentionally pierced
+/// through to a dispatched sub-agent too (see `pm_guard::pm_guard`'s
+/// absolute pre-Guard-4 check), so delegating would just move the same
+/// denial to the sub-agent's own call, not bypass it. The only real remedies
+/// are the genuine HUMAN escape hatches: an operator editing the file
+/// directly outside this guarded session, or setting
+/// `TRUSTY_MPM_PM_UNRESTRICTED=1`/`TRUSTY_MPM_DISABLE_HOOKS=1` in their OWN
+/// shell (Guards 2/3 run before this check and still bypass it — see
+/// `pm_guard.rs`'s module doc).
+pub(crate) const TRUST_ANCHOR_DENY_REASON: &str = "PM must not write pm_guard's own trust \
+     anchor — `.claude/settings.json`, `.claude/settings.local.json`, or the global \
+     CLAUDE_CONFIG_DIR equivalent (issue #3981). These files carry the `env` block Claude \
+     Code applies to every session and subprocess, including hooks — a write here can set \
+     TRUSTY_MPM_DISABLE_HOOKS or TRUSTY_MPM_PM_UNRESTRICTED and silently disable every \
+     pm_guard rule. This is NOT delegable — a dispatched sub-agent is denied the same way. \
+     Ask a human operator to edit the file directly outside this session, or have them set \
+     TRUSTY_MPM_PM_UNRESTRICTED=1 in their own shell for this session.";
+
+/// The two trust-anchor file basenames.
+///
+/// Why: Claude Code reads both `settings.json` (shared/checked-in) and
+/// `settings.local.json` (personal/gitignored) as one merged config — either
+/// carries the `env` block described above, so both are covered.
+/// What: matched via [`is_trust_anchor_path`]'s [`Path::file_name`] check.
+const TRUST_ANCHOR_FILENAMES: &[&str] = &["settings.json", "settings.local.json"];
+
+/// Whether `path` resolves to pm_guard's own trust anchor.
+///
+/// Why: see the module doc — this is the single check shared by both write
+/// routes (the Edit/Write tool path via `pm_guard::evaluate_edit_tool`, and
+/// the Bash redirect/`tee`/`sed`-`awk`/`patch`/`git apply` path via
+/// `pm_guard_bash`).
+/// What: resolves `path` to an absolute, lexically-normalized, best-effort
+/// symlink-resolved [`PathBuf`] via [`resolve_for_trust_anchor_check`], then
+/// returns `true` when its file name is one of [`TRUST_ANCHOR_FILENAMES`] AND
+/// either its immediate parent directory is literally named `.claude`
+/// (project-local or real-home), or its parent equals the resolved
+/// `$CLAUDE_CONFIG_DIR` (or, when unset, `~/.claude` — the same fallback
+/// [`global_claude_config_dir`] uses, making this branch a harmless
+/// duplicate of the first in the unset case rather than a gap). An empty or
+/// unresolvable path returns `false` (fail-open, consistent with the rest of
+/// this module).
+/// Test: `is_trust_anchor_path_matches_project_local`,
+/// `is_trust_anchor_path_matches_real_home`,
+/// `is_trust_anchor_path_matches_claude_config_dir_env`,
+/// `is_trust_anchor_path_resists_parent_traversal`,
+/// `is_trust_anchor_path_resists_symlink_indirection`,
+/// `is_trust_anchor_path_allows_unrelated_files`.
+pub(crate) fn is_trust_anchor_path(path: &str) -> bool {
+    if path.trim().is_empty() {
+        return false;
+    }
+    let resolved = resolve_for_trust_anchor_check(path);
+    let Some(file_name) = resolved.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    if !TRUST_ANCHOR_FILENAMES.contains(&file_name) {
+        return false;
+    }
+    let Some(parent) = resolved.parent() else {
+        return false;
+    };
+
+    if parent.file_name().and_then(|n| n.to_str()) == Some(".claude") {
+        return true;
+    }
+
+    if let Some(config_dir) = global_claude_config_dir() {
+        let resolved_config_dir = resolve_symlinks_best_effort(&lexically_normalize(&config_dir));
+        if parent == resolved_config_dir {
+            return true;
+        }
+    }
+
+    false
+}
+
+/// The directory holding the global (non-project) `settings.json` for THIS
+/// session.
+///
+/// Why: see the module doc's explanation of why this reads the live env var
+/// directly rather than routing through either existing (differently-scoped)
+/// resolver.
+/// What: `$CLAUDE_CONFIG_DIR` when set to a non-empty value (managed sessions
+/// relocate the entire Claude Code config home there — `settings.json` sits
+/// directly inside it, no nested `.claude/`), otherwise `~/.claude` (Claude
+/// Code's own documented default, matching every other `dirs::home_dir()`
+/// fallback in this crate). `None` only when neither the env var nor the home
+/// directory can be resolved.
+/// Test: covered indirectly via `is_trust_anchor_path_matches_claude_config_dir_env`
+/// (sets the env var) and the real-home cases (leaves it unset).
+fn global_claude_config_dir() -> Option<PathBuf> {
+    if let Some(dir) = std::env::var_os("CLAUDE_CONFIG_DIR") {
+        let dir = PathBuf::from(dir);
+        if !dir.as_os_str().is_empty() {
+            return Some(dir);
+        }
+    }
+    dirs::home_dir().map(|h| h.join(".claude"))
+}
+
+/// Resolve a raw tool-input path to an absolute, traversal- and
+/// symlink-resistant [`PathBuf`] for trust-anchor matching.
+///
+/// Why: the requirement is "match on the resolved path, not a raw string" —
+/// a relative path, a `~`-prefixed path, or a path containing `..` components
+/// must all resolve to the SAME [`PathBuf`] a literal absolute path to the
+/// same file would, so `.claude/../.claude/settings.json` cannot slip past
+/// [`is_trust_anchor_path`]'s structural check.
+/// What: expands a leading `~` ([`expand_home`]), joins a relative path onto
+/// [`std::env::current_dir`] (falling back to the expanded path itself if the
+/// cwd cannot be read), lexically normalizes `.`/`..` components
+/// ([`lexically_normalize`] — pure, no filesystem access, so it works even
+/// when the target file does not exist yet), then resolves symlinks in
+/// whatever prefix of the normalized path already exists on disk
+/// ([`resolve_symlinks_best_effort`]).
+/// Test: `is_trust_anchor_path_resists_parent_traversal`,
+/// `is_trust_anchor_path_resists_symlink_indirection`.
+fn resolve_for_trust_anchor_check(raw: &str) -> PathBuf {
+    let expanded = expand_home(raw);
+    let absolute = if expanded.is_absolute() {
+        expanded
+    } else {
+        std::env::current_dir()
+            .map(|cwd| cwd.join(&expanded))
+            .unwrap_or(expanded)
+    };
+    resolve_symlinks_best_effort(&lexically_normalize(&absolute))
+}
+
+/// Expand a leading `~` (home-relative shell shorthand) to an absolute path.
+///
+/// Why: Bash commands and, less commonly, tool-input paths use `~/...` for
+/// the user's home; leaving it unexpanded would make `~/.claude/settings.json`
+/// resolve to a nonsense relative path under the cwd instead of the real
+/// trust anchor.
+/// What: `~` alone or `~/rest` is replaced with [`dirs::home_dir`] joined to
+/// `rest`; any other leading path (including `~other-user`, which this module
+/// does not attempt to resolve) passes through unchanged. When the home
+/// directory cannot be resolved, the raw string is kept as-is rather than
+/// silently dropping the `~` (fail-open, not fail-wrong).
+/// Test: covered via `is_trust_anchor_path_matches_real_home`.
+fn expand_home(raw: &str) -> PathBuf {
+    if raw == "~" {
+        return dirs::home_dir().unwrap_or_else(|| PathBuf::from(raw));
+    }
+    if let Some(rest) = raw.strip_prefix("~/")
+        && let Some(home) = dirs::home_dir()
+    {
+        return home.join(rest);
+    }
+    PathBuf::from(raw)
+}
+
+/// Resolve symlinks in whatever prefix of `path` already exists, without
+/// requiring the full path to exist.
+///
+/// Why: a symlinked ancestor directory (e.g. a `.claude` that is actually a
+/// symlink to some other tree) must not let a write dodge the structural
+/// `.claude`-parent check, but the FILE itself — `settings.json` — is
+/// typically being created by the very call under evaluation, so plain
+/// [`Path::canonicalize`] (which requires full existence) cannot be used
+/// directly on the whole path.
+/// What: tries [`Path::canonicalize`] on the whole path first (the common
+/// case: the file already exists). On failure, walks up parents collecting
+/// the non-existent tail components, canonicalizes the deepest EXISTING
+/// ancestor (falling back to that ancestor unresolved if even it cannot be
+/// canonicalized — e.g. a permissions error), then rejoins the tail
+/// components in original order. Because the input has already been through
+/// [`lexically_normalize`], every remaining component is a plain path
+/// segment (no `.`/`..` left to confuse the walk).
+/// Test: `is_trust_anchor_path_resists_symlink_indirection`.
+fn resolve_symlinks_best_effort(path: &Path) -> PathBuf {
+    if let Ok(canon) = path.canonicalize() {
+        return canon;
+    }
+    let mut existing = path;
+    let mut tail: Vec<&std::ffi::OsStr> = Vec::new();
+    while !existing.exists() {
+        let Some(name) = existing.file_name() else {
+            break;
+        };
+        tail.push(name);
+        let Some(parent) = existing.parent() else {
+            break;
+        };
+        existing = parent;
+    }
+    let mut base = existing
+        .canonicalize()
+        .unwrap_or_else(|_| existing.to_path_buf());
+    for comp in tail.into_iter().rev() {
+        base.push(comp);
+    }
+    base
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_trust_anchor_path_matches_project_local() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("proj/.claude")).unwrap();
+        let target = tmp
+            .path()
+            .join("proj/.claude/settings.json")
+            .to_string_lossy()
+            .to_string();
+        assert!(is_trust_anchor_path(&target));
+
+        let local = tmp
+            .path()
+            .join("proj/.claude/settings.local.json")
+            .to_string_lossy()
+            .to_string();
+        assert!(is_trust_anchor_path(&local));
+    }
+
+    #[test]
+    fn is_trust_anchor_path_matches_relative_path_against_cwd() {
+        // Deliberately does NOT mutate the process cwd (`set_current_dir` is
+        // global, process-wide state that would race every other test in
+        // this binary) — instead builds the expected absolute path directly
+        // and hands the RELATIVE form to `is_trust_anchor_path`, confirming
+        // it resolves against whatever the real cwd already is.
+        let real_cwd = std::env::current_dir().unwrap();
+        let unique = format!(
+            "trust-anchor-relpath-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        );
+        let claude_dir = real_cwd.join(&unique).join(".claude");
+        std::fs::create_dir_all(&claude_dir).unwrap();
+
+        let relative = format!("{unique}/.claude/settings.json");
+        let result = is_trust_anchor_path(&relative);
+        std::fs::remove_dir_all(real_cwd.join(&unique)).ok();
+        assert!(result, "a relative path must resolve against the real cwd");
+    }
+
+    #[test]
+    fn is_trust_anchor_path_resists_parent_traversal() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path().join("proj/.claude")).unwrap();
+        // `.claude/../.claude/settings.json` must lexically collapse to the
+        // same trust-anchor path.
+        let target = tmp
+            .path()
+            .join("proj/.claude/../.claude/settings.json")
+            .to_string_lossy()
+            .to_string();
+        assert!(is_trust_anchor_path(&target));
+
+        // A traversal that lands somewhere else must NOT be caught.
+        let elsewhere = tmp
+            .path()
+            .join("proj/.claude/../not-claude/settings.json")
+            .to_string_lossy()
+            .to_string();
+        assert!(!is_trust_anchor_path(&elsewhere));
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn is_trust_anchor_path_resists_symlink_indirection() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let real_claude = tmp.path().join("real/.claude");
+        std::fs::create_dir_all(&real_claude).unwrap();
+        let link = tmp.path().join("link_dir");
+        std::os::unix::fs::symlink(&real_claude, &link).unwrap();
+
+        // The target file does not exist yet (this is a Write call), but the
+        // symlinked ancestor does — resolution must still land on `.claude`.
+        let target = link.join("settings.json").to_string_lossy().to_string();
+        assert!(
+            is_trust_anchor_path(&target),
+            "a symlink to a .claude dir must not bypass the check"
+        );
+    }
+
+    #[test]
+    #[serial_test::serial(claude_config_dir_env)]
+    fn is_trust_anchor_path_matches_claude_config_dir_env() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let config_dir = tmp.path().join("managed-claude-config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+
+        // Serialized (see the attribute above) against every other test in
+        // this binary that might observe `CLAUDE_CONFIG_DIR` mid-mutation —
+        // `std::env::set_var`/`remove_var` are documented as unsound to race
+        // across threads, matching the established convention elsewhere in
+        // this crate (e.g. `core::paths`'s `HOME`-mutating tests).
+        temp_env_var("CLAUDE_CONFIG_DIR", Some(&config_dir), || {
+            let target = config_dir
+                .join("settings.json")
+                .to_string_lossy()
+                .to_string();
+            assert!(is_trust_anchor_path(&target));
+            let local = config_dir
+                .join("settings.local.json")
+                .to_string_lossy()
+                .to_string();
+            assert!(is_trust_anchor_path(&local));
+        });
+    }
+
+    #[test]
+    fn is_trust_anchor_path_allows_unrelated_files() {
+        for p in [
+            "/x/a.rs",
+            "/x/.claude/agents/foo.md",
+            "/x/.claude/config.toml",
+            "notes.md",
+            "settings.json",
+            "/x/settings.json",
+        ] {
+            assert!(
+                !is_trust_anchor_path(p),
+                "{p} must NOT be classified as the trust anchor"
+            );
+        }
+    }
+
+    #[test]
+    fn is_trust_anchor_path_allows_empty() {
+        assert!(!is_trust_anchor_path(""));
+        assert!(!is_trust_anchor_path("   "));
+    }
+
+    #[test]
+    fn lexically_normalize_collapses_parent_dirs() {
+        // Regression coverage for THIS module's dependency on
+        // `pm_guard_bash::normalize_lexically` (imported as
+        // `lexically_normalize` above) — `pm_guard_bash` has its own tests
+        // for the worktree-guard use case; this pins the contract
+        // `resolve_for_trust_anchor_check` relies on.
+        assert_eq!(
+            lexically_normalize(Path::new("/a/b/../c")),
+            PathBuf::from("/a/c")
+        );
+        assert_eq!(
+            lexically_normalize(Path::new("/a/./b/./c")),
+            PathBuf::from("/a/b/c")
+        );
+        // Cannot traverse above root.
+        assert_eq!(lexically_normalize(Path::new("/../a")), PathBuf::from("/a"));
+    }
+
+    #[test]
+    fn expand_home_replaces_leading_tilde() {
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(expand_home("~"), home);
+            assert_eq!(
+                expand_home("~/.claude/settings.json"),
+                home.join(".claude/settings.json")
+            );
+        }
+        assert_eq!(expand_home("/abs/path"), PathBuf::from("/abs/path"));
+        assert_eq!(expand_home("relative/path"), PathBuf::from("relative/path"));
+    }
+
+    /// Run `f` with `key` set to `value`'s path for the duration, restoring
+    /// (or removing) the prior value afterward — a minimal scoped env-var
+    /// helper so `is_trust_anchor_path_matches_claude_config_dir_env` cannot
+    /// leak `CLAUDE_CONFIG_DIR` into other tests in this binary.
+    fn temp_env_var(key: &str, value: Option<&Path>, f: impl FnOnce()) {
+        let prior = std::env::var_os(key);
+        match value {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+        f();
+        match prior {
+            Some(v) => unsafe { std::env::set_var(key, v) },
+            None => unsafe { std::env::remove_var(key) },
+        }
+    }
+}

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -683,6 +683,205 @@ fn pm_guard_allows_non_add_worktree_subcommands_and_ordinary_temp_usage() {
     }
 }
 
+// ─── trust-anchor denylist (issue #3981) ───────────────────────────────────
+
+#[test]
+fn pm_guard_denies_settings_json_write_for_pm_direct_call() {
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/some/repo/.claude/settings.json","content":"{}"}}"#,
+        &[],
+    );
+    assert_denied(&stdout);
+    assert!(
+        stdout.contains("3981"),
+        "deny message must cite issue #3981: {stdout}"
+    );
+}
+
+#[test]
+fn pm_guard_denies_settings_local_json_write() {
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Edit","tool_input":{"file_path":"/some/repo/.claude/settings.local.json","old_string":"a","new_string":"b"}}"#,
+        &[],
+    );
+    assert_denied(&stdout);
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_subagent_payload() {
+    // THE case the whole task turns on: a native Task/Agent-dispatched
+    // subagent (agent_id present) writing pm_guard's own trust anchor must
+    // ALSO be denied — Guard 4's exemption must not reach this call.
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","agent_type":"rust-engineer","tool_name":"Write","tool_input":{"file_path":"/some/repo/.claude/settings.json","content":"{\"env\":{\"TRUSTY_MPM_PM_UNRESTRICTED\":\"1\"}}"}}"#,
+        &[],
+    );
+    assert_denied(&stdout);
+    assert!(
+        stdout.contains("3981"),
+        "deny message must cite issue #3981: {stdout}"
+    );
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_claude_mpm_sub_agent_env() {
+    // Same requirement under the OTHER subagent-exemption marker
+    // (CLAUDE_MPM_SUB_AGENT=1, Guard 1) — Guard 1 must not reach this call
+    // either.
+    let stdout = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/some/repo/.claude/settings.json","content":"{}"}}"#,
+        &[("CLAUDE_MPM_SUB_AGENT", "1")],
+    );
+    assert_denied(&stdout);
+    assert!(
+        stdout.contains("3981"),
+        "deny message must cite issue #3981: {stdout}"
+    );
+}
+
+#[test]
+fn pm_guard_settings_json_denial_is_not_budget_eligible() {
+    // Unlike a source-code Edit/Write, a trust-anchor write must be an
+    // ABSOLUTE prohibition — repeating the call must deny every time, never
+    // sliding through on the per-turn file-change budget (issue #2918).
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/some/repo/.claude/settings.json","content":"{}"}}"#;
+    for _ in 1..=4 {
+        assert_denied(&run_pm_guard(payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_redirect() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo '{\"env\":{\"TRUSTY_MPM_PM_UNRESTRICTED\":\"1\"}}' > /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_tee() {
+    // `tee` writes to a file ARGUMENT, not a `>` redirect — a distinct code
+    // path from the redirection test above.
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo x | tee /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_sed_in_place() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"sed -i s/false/true/ /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_under_subagent_payload() {
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","tool_name":"Bash","tool_input":{"command":"echo x > /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_under_claude_mpm_sub_agent_env() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo x > /some/repo/.claude/settings.json"}}"#;
+    let stdout = run_pm_guard(payload, &[("CLAUDE_MPM_SUB_AGENT", "1")]);
+    assert_denied(&stdout);
+}
+
+#[test]
+fn pm_guard_bash_settings_json_denial_is_not_budget_eligible() {
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"echo x > /some/repo/.claude/settings.json"}}"#;
+    for _ in 1..=4 {
+        assert_denied(&run_pm_guard(payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_parent_traversal() {
+    // `.claude/../.claude/settings.json` must lexically collapse to the same
+    // resolved trust-anchor path — the raw string differs, the resolved path
+    // does not.
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/some/repo/.claude/../.claude/settings.json","content":"{}"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+#[cfg(unix)]
+fn pm_guard_denies_settings_json_write_via_symlinked_claude_dir() {
+    // A `.claude`-named ancestor reached only through a symlink must not
+    // bypass the structural check — the target file does not exist yet
+    // (this is a `Write` call), only the symlinked directory does.
+    let tmp = tempfile::tempdir().unwrap();
+    let real_claude = tmp.path().join("real/.claude");
+    std::fs::create_dir_all(&real_claude).unwrap();
+    let link = tmp.path().join("link_dir");
+    std::os::unix::fs::symlink(&real_claude, &link).unwrap();
+    let target = link.join("settings.json");
+    let payload = format!(
+        r#"{{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{{"file_path":"{}","content":"{{}}"}}}}"#,
+        target.to_string_lossy()
+    );
+    assert_denied(&run_pm_guard(&payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_global_claude_config_dir_settings_write() {
+    // The managed-session global equivalent: `settings.json` sits directly
+    // under `$CLAUDE_CONFIG_DIR`, with NO nested `.claude/` component.
+    let tmp = tempfile::tempdir().unwrap();
+    let config_dir = tmp.path().join("claude-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let target = config_dir.join("settings.json");
+    let payload = format!(
+        r#"{{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{{"file_path":"{}","content":"{{}}"}}}}"#,
+        target.to_string_lossy()
+    );
+    let config_dir_s = config_dir.to_string_lossy().to_string();
+    let stdout = run_pm_guard(&payload, &[("CLAUDE_CONFIG_DIR", &config_dir_s)]);
+    assert_denied(&stdout);
+}
+
+#[test]
+fn pm_guard_allows_ordinary_non_source_writes_unaffected_by_trust_anchor_guard() {
+    // The trust-anchor denylist must be narrow: ordinary non-source writes
+    // (a README, a data JSON file elsewhere, a sibling `.claude/` file that
+    // is NOT the trust anchor itself) must all remain allowed.
+    let readme = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"README.md","content":"x"}}"#,
+        &[],
+    );
+    assert_eq!(readme.trim(), "", "README.md must remain allowed");
+
+    let data_json = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"data/config.json","content":"{}"}}"#,
+        &[],
+    );
+    assert_eq!(
+        data_json.trim(),
+        "",
+        "a data JSON file elsewhere must remain allowed"
+    );
+
+    let agent_md = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/repo/.claude/agents/foo.md","content":"x"}}"#,
+        &[],
+    );
+    assert_eq!(
+        agent_md.trim(),
+        "",
+        "a sibling .claude/ file that is not the trust anchor must remain allowed"
+    );
+
+    let config_toml = run_pm_guard(
+        r#"{"hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"/repo/.claude/config.toml","content":"x"}}"#,
+        &[],
+    );
+    assert_eq!(
+        config_toml.trim(),
+        "",
+        "a non-settings file directly in .claude/ must remain allowed"
+    );
+}
+
 #[test]
 fn pm_guard_allows_benign_pipes_and_dev_null() {
     // Composition with no forbidden segment must still allow.

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -773,6 +773,55 @@ fn pm_guard_denies_settings_json_write_via_sed_in_place() {
 }
 
 #[test]
+fn pm_guard_denies_settings_json_write_via_bash_cp() {
+    // `cp` writes its destination as a plain positional ARGUMENT — neither a
+    // `>` redirect (pm_guard_denies_settings_json_write_via_bash_redirect)
+    // nor a `tee`-style output argument (…_via_bash_tee); a distinct code
+    // path (issue #3981 follow-up: cp/mv/install were the residual gap).
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cp evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_mv() {
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"mv evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_install() {
+    // `install` additionally takes flags with values (`-m 644`) preceding the
+    // destination — confirms the flag-value token doesn't shift or hide the
+    // real destination token.
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"install -m 644 evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_cp_under_subagent_payload() {
+    // THE case the guard exists for: a native Task/Agent-dispatched subagent
+    // (agent_id present) copying over the trust anchor via `cp` must ALSO be
+    // denied — Guard 4's exemption must not reach this call, mirroring
+    // pm_guard_denies_settings_json_write_via_bash_under_subagent_payload for
+    // the redirect route.
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","agent_type":"rust-engineer","tool_name":"Bash","tool_input":{"command":"cp evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_cp_settings_json_denial_is_not_budget_eligible() {
+    // Same absolute-prohibition requirement as the redirect/tee/sed routes —
+    // a cp-based trust-anchor write must deny every time, never sliding
+    // through on the per-turn file-change budget (issue #2918).
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"cp evil.json /some/repo/.claude/settings.json"}}"#;
+    for _ in 1..=4 {
+        assert_denied(&run_pm_guard(payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
 fn pm_guard_denies_settings_json_write_via_bash_under_subagent_payload() {
     let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","tool_name":"Bash","tool_input":{"command":"echo x > /some/repo/.claude/settings.json"}}"#;
     assert_denied(&run_pm_guard(payload, &[]));

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -822,6 +822,58 @@ fn pm_guard_cp_settings_json_denial_is_not_budget_eligible() {
 }
 
 #[test]
+fn pm_guard_denies_settings_json_write_via_bash_ln() {
+    // `ln -sf TARGET LINKNAME` writes its destination as a plain positional
+    // ARGUMENT (the LINKNAME, second token) — the #3994 review's critical
+    // finding: an unclassified `ln` was a complete, zero-friction bypass of
+    // the whole feature (write attacker content anywhere, then symlink it
+    // over the trust anchor so Claude Code reads through it next load).
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ln -sf /tmp/evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_bash_ln_under_subagent_payload() {
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","agent_type":"rust-engineer","tool_name":"Bash","tool_input":{"command":"ln -sf /tmp/evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_ln_settings_json_denial_is_not_budget_eligible() {
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ln -sf /tmp/evil.json /some/repo/.claude/settings.json"}}"#;
+    for _ in 1..=4 {
+        assert_denied(&run_pm_guard(payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_git_mv() {
+    // `git mv SRC DST` — a two-token verb whose subcommand shifts the
+    // positional layout (issue #3994 HIGH finding, undisclosed in the
+    // original PR).
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git mv evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_denies_settings_json_write_via_git_mv_under_subagent_payload() {
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","agent_type":"rust-engineer","tool_name":"Bash","tool_input":{"command":"git mv evil.json /some/repo/.claude/settings.json"}}"#;
+    assert_denied(&run_pm_guard(payload, &[]));
+}
+
+#[test]
+fn pm_guard_git_mv_settings_json_denial_is_not_budget_eligible() {
+    let home = isolated_home();
+    let home_s = home.path().to_string_lossy().to_string();
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"git mv evil.json /some/repo/.claude/settings.json"}}"#;
+    for _ in 1..=4 {
+        assert_denied(&run_pm_guard(payload, &[("HOME", &home_s)]));
+    }
+}
+
+#[test]
 fn pm_guard_denies_settings_json_write_via_bash_under_subagent_payload() {
     let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-xyz789","tool_name":"Bash","tool_input":{"command":"echo x > /some/repo/.claude/settings.json"}}"#;
     assert_denied(&run_pm_guard(payload, &[]));


### PR DESCRIPTION
## Summary

`.claude/settings.json` / `.claude/settings.local.json` (and the `$CLAUDE_CONFIG_DIR` global equivalent) were an unconditional, unbudgeted ALLOW in `tm hook --pm-guard` — `.json` is not a source-code extension, so `evaluate_edit_tool` fell through to allow. Claude Code applies that file's top-level `env` object to every session/subprocess it spawns (hooks included, live-reloaded mid-session), so a `Write`/`Edit` there could set `TRUSTY_MPM_DISABLE_HOOKS`/`TRUSTY_MPM_PM_UNRESTRICTED` and silently disable every pm_guard rule — the PM's own trust anchor was writable by the thing the guard constrains.

**Honesty note, added after the adversarial review below: this PR closes the EASY, naive self-exemption paths — the ordinary shell verbs a PM would reach for without specifically probing for a gap. It is NOT a hardened security boundary against a party with unrestricted Bash access.** See "Update: response to review" for the two gaps the critic found, now closed, and the ones that remain open by design (documented, not hidden).

- New `pm_guard_trust_anchor` module resolves the target path (relative, `~`, `..` traversal, symlinked ancestors — all without requiring the target to exist yet) and matches it structurally: any path whose parent directory is literally `.claude` and whose filename is `settings.json`/`settings.local.json`, OR the exact `$CLAUDE_CONFIG_DIR/settings*.json` equivalent (confirmed that dir has NO nested `.claude/`, unlike the project/home case).
- Checked from **three** places: `pm_guard()`'s body directly, before Guards 1/4's subagent-exemption early returns (mirrors the worktree-tmp guard's placement — a dispatched subagent's write is exactly as dangerous as the PM's own, so it must NOT be exempt); `evaluate_edit_tool`, as a second pure-function layer of defense in depth; and `pm_guard_bash::bash_targets_trust_anchor`, closing the equivalent shell route as an **absolute, non-budget-eligible** deny (previously a Bash write to the file would have been the ordinary budget-eligible `SHELL_EDIT_REASON`, allowed up to 3 times before blocking).
- The deny message deliberately does **not** suggest delegating via the Task/Agent tool — a dispatched sub-agent is denied identically, so that would be misleading. The only real remedies are human-only: an operator editing the file directly outside the guarded session, or setting `TRUSTY_MPM_PM_UNRESTRICTED=1`/`TRUSTY_MPM_DISABLE_HOOKS=1` in their own shell (Guards 2/3 still run first and are unaffected).

## Update: response to the adversarial review (commit `1b88d3f8`)

The [full review](https://github.com/bobmatnyc/trusty-tools/pull/3994#issuecomment-5085102241) BLOCKed on two verified-by-execution gaps and flagged one undisclosed find and one undisclosed false positive. All four are addressed:

1. **`ln`/`ln -sf` (CRITICAL, closed).** Was completely unclassified — a zero-friction, full bypass of this entire feature: write attacker/PM-controlled content to any ordinary path, then `ln -sf` it over `.claude/settings.json`; Claude Code reads through the symlink on its next config load. Closed by adding `ln` to the same `non_flag_tokens` verb scan `cp`/`mv`/`install` already use (both the symlink target/linkname and the hardlink form). Verified failing-first (removed `"ln"` from the match arm → new test failed → restored → passed) and against the real binary, including the exact critic repro (a real `.claude/settings.json` on disk, `ln -sf /tmp/evil.json <path>`, both the PM's own call and an `agent_id`-carrying subagent payload) — all deny, 4-for-4 on repeat (not budget-eligible).
2. **`git mv` (HIGH, closed).** A two-token verb whose subcommand shifts the positional layout, so neither the `cp`/`mv`/`install` arm nor the existing `git apply`-only check caught it. Closed via a new `shell_lex::git_subcommand_with_args` (refactor of the existing `git_subcommand` — same parse, now also returns the argv tail after the resolved subcommand, correctly skipping leading `git -C <path>` global flags) so `mv`'s two positional args are scanned the same way. Verified failing-first and against the real binary the same way as `ln` above (direct call, subagent payload, 4x-repeat absoluteness).
3. **`xargs -I{} cp ... {}` indirection (undisclosed in the original PR, now closed for the realistic case).** Judgment call: rather than parsing `xargs`'s own flag grammar to find where its embedded command begins, `xargs` reuses the same `non_flag_tokens` scan generically — it asks "does the trust-anchor path appear literally on this line" regardless of which verb `xargs` invokes. This catches the critic's exact repro (`… | xargs -I{} cp {} .claude/settings.json`, destination spelled out in full) without the complexity/error risk of a bespoke `xargs` argv parser. Honestly does **not** catch a target fed purely through stdin (`echo .claude/settings.json | xargs rm`) — that's the same fundamental "cannot statically enumerate a runtime-assembled value" limit as the interpreter-inline-program-text gaps already documented below, and it's now named explicitly rather than left implicit.
4. **`cp <anchor> <harmless-dest>` false positive (MEDIUM, documented not narrowed).** Judgment call, per the critic's own warning that narrowing risks reintroducing a miss: kept the over-inclusive scan (source AND destination checked) rather than narrowing to destination-only, because `cp`'s N-arg-plus-directory form (`cp SRC1 SRC2 DIR/`, `cp -t DIR SRC1 SRC2`) has no single reliable "the target is always token N" rule cheap enough to get right, and the failure mode of over-denying a harmless backup is far less costly than the failure mode of a missed real write. Now named explicitly in the module doc and CHANGELOG (was previously only implied by the "can only widen a deny" design note) so it isn't a surprise bug report later.

Framing softened throughout (this PR body, the module doc, and the CHANGELOG) per the review's core complaint: the original framing buried the easiest bypass (`ln`) inside a list dominated by genuinely-hard-to-close gaps (interpreter `-c`, `dd`, `rsync`, `bash -c` re-invocation, runtime-assembled paths), making the residual surface sound harder to reach than it was. This is corrected — see the "Known residual gaps" section below, restated honestly.

## Other-write-route finding (Bash)

A Bash redirect/`tee`/`sed -i`/`awk`/`patch`/`git apply`/`cp`/`mv`/`install`/`ln`/`git mv`/literal-target-`xargs` targeting the trust anchor is closed via `pm_guard_bash::bash_targets_trust_anchor`, called both directly and unconditionally from `pm_guard()` (bypassing Guards 1/4) and defensively inside `evaluate_bash_command`.

**Known residual gaps — tracked, not a closed boundary:**
- A trust-anchor write hidden inside a `$(…)`/backtick Bash command substitution (e.g. `eval "$(echo 'sed -i ... .claude/settings.json')"`) still denies, via the pre-existing recursive substitution scanner, but as the ordinary budget-eligible `SHELL_EDIT_REASON`, not the absolute trust-anchor reason.
- A write performed by an interpreter's inline program text (`python3 -c "…"`, `perl -e`, `node -e`, `dd of=…`, `rsync … dest`, a re-invoked `bash -c "…"`) or a runtime-assembled path (concatenation, base64, an env var) is not detected at all — no static token scan can enumerate these.
- `xargs` whose target arrives purely via stdin rather than appearing literally on the command line is likewise invisible to the handling added here.

None of these are specific to the trust anchor — they're pre-existing properties of the whole Bash classification strategy — and a determined actor with unrestricted Bash access defeats this guard in one command via any of them, every time. This PR raises the bar against accidental/naive self-exemption; it is not, and should not be read as, "the PM can no longer disable pm_guard."

No MCP filesystem tool was found available in this session/repo that could write `.claude/settings.json` outside the Bash/Edit/Write tool surface already covered.

## Over-blocking check

Confirmed via research: `tm`'s own Rust bootstrapping (`write_project_hooks`, `write_output_style`, `write_status_line`, `ensure_settings_defaults`) writes these files directly via `std::fs`/`write_json_atomic`, never through the Claude Code tool layer that `PreToolUse` intercepts — unaffected. No bundled trusty-mpm skill/agent instructs the PM to self-edit `settings.json` directly (`tm-init.md` explicitly routes config deployment through `tm install`, not PM edits). The one real-world flow this narrows: a global `update-config`-style skill asking the PM to edit `settings.json` directly (e.g. "add a permission") inside a `tm`-managed session now requires a human operator's `TRUSTY_MPM_PM_UNRESTRICTED=1`/direct edit — intentional, matches the issue's chosen remedy. The `cp <anchor> <harmless-dest>` false positive (see item 4 above) is the one additional, now-documented over-block this PR introduces.

## Test plan

- [x] `cargo test -p trusty-mpm` (no `--lib`) — 0 failed across every test binary, run from a non-`/tmp` worktree (raw output captured in session)
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p trusty-mpm --check` — clean
- [x] Failing-first verified per-verb: `ln`, `git mv`, and `xargs` each temporarily neutralized in isolation → the corresponding new unit test failed → restored → passed (in addition to the original `is_trust_anchor_path` failing-first pass covering the base feature)
- [x] New unit tests: `bash_targets_trust_anchor_detects_ln`, `bash_targets_trust_anchor_detects_git_mv`, `bash_targets_trust_anchor_detects_xargs_indirection`, `shell_lex::git_subcommand_with_args_*`
- [x] New integration tests in `tests/tm_hook_pm_guard.rs`: `ln` and `git mv`, each with direct-PM-call, native-subagent-payload (`agent_id`), and not-budget-eligible (4x-repeat) variants
- [x] Live binary verification against a real `.claude/settings.json` on disk, including the exact critic repro (`ln -sf /tmp/evil.json <real-path>/.claude/settings.json`) and the `agent_id`-subagent/`CLAUDE_MPM_SUB_AGENT=1` cases — all deny with the absolute trust-anchor reason

Still: Do NOT merge — adversarial code-critic gate follows.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
