### PR TITLE
fix(trusty-common): bound the palace open-queue wait under sustained writer contention

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -24,6 +24,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`PalaceRegistry::open_palace` no longer queues callers indefinitely
+  behind sustained redb writer-lock contention** (issue #3992): the
+  per-palace `open_lock` that serialises concurrent opens of the same
+  palace id was acquired with an unbounded `Mutex::lock()`. Each individual
+  `try_open_or_snapshot` retry under `OpenIntent::Writer` was already
+  bounded (~1.55s), but a failed Writer open is never cached, so every
+  caller queued behind the lock repeated that bounded dance from scratch —
+  the Nth queued caller waited for N-1 earlier callers' own attempts to
+  finish first, with no ceiling on the total. Reproduced live: 5 concurrent
+  openers against a genuinely held lock made the 5th caller wait 9.86s, and
+  this exact linear-with-queue-depth pattern is how a single
+  `memory_remember` call was observed to hang for 1800s under sustained
+  multi-process contention. `open_palace` now acquires the lock via
+  `try_lock_for` with a new, independently-tunable
+  `memory_core::timeouts::open_queue_timeout()` (default 60s,
+  `TRUSTY_OPEN_QUEUE_TIMEOUT_SECS`), returning a clear error instead of
+  hanging once the deadline elapses.
+
 - **`default_model_matches_sentence_transformers_reference` no longer
   misreports a wrong-model load as an fp32 accuracy failure** (issue #3711):
   the merge-gate flake that failed at `mean_cosine=0.990649` vs `>= 0.999` was

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -123,12 +123,49 @@ pub struct PalaceRegistry {
     /// just-evicted palace would double-open and the loser would error. A tiny
     /// per-id sync mutex makes the second racer wait, re-check the cache, and
     /// share the winner's handle instead.
+    ///
+    /// Why bounded (issue #3992): a FAILED `Writer` open is never cached (a
+    /// nonexistent handle must not be), so under *sustained* cross-process
+    /// contention every caller queued behind this mutex repeats the full
+    /// bounded (~1.55 s) `try_open_or_snapshot` dance from scratch once it is
+    /// finally its turn. Each individual redb-open attempt is bounded, but
+    /// the mutex acquisition itself previously was not: the Nth queued
+    /// caller waited for N-1 earlier callers' own ~1.55 s attempts to finish
+    /// first, so a caller's *total* wait scaled with queue depth with no
+    /// ceiling -- reproduced live (issue #3992: 5 concurrent openers against
+    /// a held lock made the 5th caller wait 10 s; sustained contention across
+    /// many requests over a long window is exactly how a single
+    /// `memory_remember` call was observed to hang for 1800 s). The reader
+    /// path has no analogous queue-depth problem to mirror: a `ReadOnlyClient`
+    /// open always resolves quickly via the snapshot fallback (issue #59) and
+    /// therefore never queues for long. So `open_palace` bounds this wait
+    /// with a dedicated
+    /// [`crate::memory_core::timeouts::open_queue_timeout`] (issue #3992,
+    /// default 60 s, `TRUSTY_OPEN_QUEUE_TIMEOUT_SECS`) -- a sibling of the
+    /// established `write_lock_timeout` (issue #906) that governs the
+    /// per-palace write mutex once a palace is already open, kept as its own
+    /// knob since the two protect different pipelines and operators may need
+    /// to tune them independently. A caller stuck behind persistent
+    /// contention gets a clear, actionable ERROR within one bounded window
+    /// instead of hanging indefinitely.
     /// What: `DashMap<PalaceId, Arc<parking_lot::Mutex<()>>>`. Held only across
     /// the (rare) open pipeline — never across an `.await` — so a
     /// `parking_lot::Mutex` is safe. Entries are lightweight and left in place
-    /// (bounded by palace count) rather than reference-counted out.
-    /// Test: `registry_tests::evict_idle_then_reopen_preserves_recall`.
+    /// (bounded by palace count) rather than reference-counted out. Acquired
+    /// via `try_lock_for(open_queue_timeout())` in `open_palace`.
+    /// Test: `registry_tests::evict_idle_then_reopen_preserves_recall`,
+    /// `registry_tests::writer_open_queue_wait_is_bounded_under_sustained_contention`
+    /// (issue #3992 — proves the bound against real multi-writer contention).
     open_locks: Arc<DashMap<PalaceId, Arc<Mutex<()>>>>,
+    /// Bound applied to `open_lock.try_lock_for` in `open_palace` (issue
+    /// #3992). Defaults to
+    /// [`crate::memory_core::timeouts::open_queue_timeout`] (process-wide env
+    /// override) but is stored per-instance — rather than re-read from the
+    /// environment on every call — so [`PalaceRegistry::with_open_queue_timeout`]
+    /// can inject a short deadline in tests without mutating global process
+    /// state (which would race other tests running in parallel).
+    /// Test: `registry_tests::writer_open_queue_wait_is_bounded_under_sustained_contention`.
+    open_queue_timeout: Duration,
 }
 
 impl Default for PalaceRegistry {
@@ -166,7 +203,24 @@ impl PalaceRegistry {
             // daemon overrides this via `with_writer_intent` (issue #1487).
             open_intent: OpenIntent::ReadOnlyClient,
             open_locks: Arc::new(DashMap::new()),
+            open_queue_timeout: crate::memory_core::timeouts::open_queue_timeout(),
         }
+    }
+
+    /// Override the per-palace open-queue timeout (issue #3992).
+    ///
+    /// Why: production callers get a sane env-configurable default (see the
+    /// `open_locks` field doc); tests that need to prove the bound against
+    /// real multi-writer contention within a fast, deterministic wall-clock
+    /// budget inject a short deadline here instead of mutating the
+    /// process-wide `TRUSTY_OPEN_QUEUE_TIMEOUT_SECS` env var (which would
+    /// race any other test running in parallel).
+    /// What: Consuming builder that overwrites `open_queue_timeout`.
+    /// Test: `registry_tests::writer_open_queue_wait_is_bounded_under_sustained_contention`.
+    #[must_use]
+    pub fn with_open_queue_timeout(mut self, timeout: Duration) -> Self {
+        self.open_queue_timeout = timeout;
+        self
     }
 
     /// Create a registry whose open-handle cap comes from the environment.
@@ -363,10 +417,16 @@ impl PalaceRegistry {
     /// is silently evicted (its fds close); the data is safe on disk.
     /// What: Returns the cached `Arc<PalaceHandle>` if present (promotes to MRU);
     /// otherwise loads metadata via `PalaceStore::load_palace`, calls
-    /// `PalaceHandle::open`, and inserts the handle (may evict LRU).
+    /// `PalaceHandle::open`, and inserts the handle (may evict LRU). The
+    /// per-palace open-lock acquisition is bounded (issue #3992) — see the
+    /// `open_locks` field doc for why an unbounded wait there let sustained
+    /// writer contention hang a caller indefinitely even though every
+    /// individual redb-open attempt underneath is itself bounded.
     /// Test: `registry_create_and_open` round-trips create -> drop -> reopen;
     /// `lru_evicted_handle_reopens` verifies evicted handles are transparently
-    /// reopened; `open_palace_follows_alias` covers the alias redirect.
+    /// reopened; `open_palace_follows_alias` covers the alias redirect;
+    /// `writer_open_queue_wait_is_bounded_under_sustained_contention` proves the bound
+    /// against real multi-writer contention.
     pub fn open_palace(&self, data_root: &Path, palace_id: &PalaceId) -> Result<Arc<PalaceHandle>> {
         // Fast path: an already-open handle under the requested id.
         if let Some(h) = self.get(palace_id) {
@@ -388,12 +448,28 @@ impl PalaceRegistry {
         // double-open the redb files — under `Writer` intent the loser would
         // otherwise fail loud after the flock handoff-retry window. The winner
         // opens + registers; the loser re-checks the cache below and shares it.
+        //
+        // Bounded (issue #3992): a failed `Writer` open is never cached, so
+        // under sustained cross-process contention every queued caller repeats
+        // the full bounded (~1.55 s) open dance in turn — the Nth caller waits
+        // for N-1 earlier callers' own attempts first, with no ceiling on the
+        // total. `try_lock_for` caps that total wait so a caller stuck behind
+        // persistent contention gets a clear ERROR instead of hanging (proved
+        // live by `writer_open_queue_wait_is_bounded_under_sustained_contention`).
         let open_lock = self
             .open_locks
             .entry(effective_id.clone())
             .or_insert_with(|| Arc::new(Mutex::new(())))
             .clone();
-        let _open_guard = open_lock.lock();
+        let open_queue_timeout = self.open_queue_timeout;
+        let _open_guard = open_lock.try_lock_for(open_queue_timeout).ok_or_else(|| {
+            anyhow::anyhow!(
+                "palace '{effective_id}' open queue timed out after {open_queue_timeout:?} \
+                 waiting behind other callers retrying a redb write-lock conflict (issue #3992); \
+                 another process may be holding the lock persistently — stop it, or raise \
+                 TRUSTY_OPEN_QUEUE_TIMEOUT_SECS if this is expected under heavy contention"
+            )
+        })?;
         // Re-check under the open lock: another racer may have opened it while
         // we waited for the lock.
         if let Some(h) = self.get(&effective_id) {

--- a/crates/trusty-common/src/memory_core/registry_tests.rs
+++ b/crates/trusty-common/src/memory_core/registry_tests.rs
@@ -690,3 +690,135 @@ async fn evict_idle_then_reopen_preserves_recall() {
         "recall after idle-evict + rehydrate must match pre-eviction results"
     );
 }
+
+/// Why (issue #3992): reproduces the reported hang under REAL multi-writer
+/// contention, not a mocked one. `PalaceRegistry::open_palace` serialises
+/// concurrent opens of the SAME palace id behind a per-palace
+/// `open_lock: parking_lot::Mutex<()>` (see the `open_locks` field doc).
+/// Each individual `Database::create` retry inside `try_open_or_snapshot`
+/// IS already bounded (`WRITER_RETRY_ATTEMPTS` x `WRITER_RETRY_SLEEP_MS`,
+/// ~1.55s) — but a failed Writer open is never cached, so the NEXT caller
+/// repeats the same ~1.55s bounded dance from scratch. Under sustained
+/// contention (the redb file never becomes available), every caller queued
+/// behind `open_lock` pays its OWN ~1.55s bounded attempt AFTER waiting for
+/// every earlier queued caller's ~1.55s attempt to finish first — so the
+/// LAST caller's total wait scales with queue depth, not with any single
+/// constant. That is "unbounded" from any individual caller's point of
+/// view even though no single redb-open call exceeds ~1.55s. Live evidence
+/// before this fix: 5 concurrent openers against a genuinely held lock made
+/// the 5th caller wait 9.86s (and the pattern extrapolates linearly — this
+/// is exactly how a single `memory_remember` was observed to hang 1800s
+/// under sustained contention).
+/// What: holds a genuine flock conflict on the real backing file
+/// (`kg.redb` — `KnowledgeGraph::open_with_intent` translates the legacy
+/// `kg.db` path callers pass in), exactly like `concurrent_open::tests::
+/// writer_intent_fails_on_locked_file`, for the whole test. Uses
+/// `with_open_queue_timeout` to inject a short (2s) deadline instead of
+/// mutating the process-wide `TRUSTY_OPEN_QUEUE_TIMEOUT_SECS` env var (which
+/// would race any other test running in parallel with this one). Fires
+/// `WRITER_COUNT` concurrent `open_palace` calls at a `with_writer_intent`
+/// registry for the SAME palace id and records each caller's wall-clock
+/// wait; asserts every caller returns within one bounded window
+/// (queue-timeout + one ~1.55-2.1s redb attempt) regardless of queue depth.
+/// Test: this test.
+#[test]
+fn writer_open_queue_wait_is_bounded_under_sustained_contention() {
+    use crate::memory_core::palace::Palace;
+    use chrono::Utc;
+    use redb::Database;
+
+    const WRITER_COUNT: usize = 5;
+    // Short enough that the test runs fast and deterministically; injected
+    // per-registry (not via env var) so it cannot race other parallel tests.
+    const OPEN_QUEUE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(2);
+
+    let dir = tempdir().unwrap();
+    let data_root = dir.path();
+    let palace_id = PalaceId::new("contended");
+    let palace_dir = data_root.join(palace_id.as_str());
+    std::fs::create_dir_all(&palace_dir).unwrap();
+
+    // Persist palace.json so `open_palace` can load metadata.
+    let palace = Palace {
+        id: palace_id.clone(),
+        name: "Contended".to_string(),
+        description: None,
+        created_at: Utc::now(),
+        data_dir: palace_dir.clone(),
+    };
+    crate::memory_core::store::palace_store::PalaceStore::save_palace(&palace)
+        .expect("save palace metadata");
+
+    // Hold a REAL, permanent flock conflict on the actual redb file for the
+    // whole test — mirrors `writer_intent_fails_on_locked_file` exactly,
+    // just held longer. This process never releases it, so every Writer
+    // open attempt genuinely exhausts its bounded retry window and fails.
+    let kg_path = palace_dir.join("kg.redb");
+    let _lock_holder = Database::create(&kg_path).expect("hold kg.redb lock for the test");
+
+    let reg = std::sync::Arc::new(
+        PalaceRegistry::new()
+            .with_writer_intent()
+            .with_open_queue_timeout(OPEN_QUEUE_TIMEOUT),
+    );
+    eprintln!("registry open_intent = {:?}", reg.open_intent());
+    let start = std::time::Instant::now();
+    let handles: Vec<_> = (0..WRITER_COUNT)
+        .map(|i| {
+            let reg = reg.clone();
+            let data_root = data_root.to_path_buf();
+            let palace_id = palace_id.clone();
+            std::thread::spawn(move || {
+                let t0 = std::time::Instant::now();
+                let result = reg.open_palace(&data_root, &palace_id);
+                let elapsed = t0.elapsed();
+                match &result {
+                    Ok(h) => eprintln!(
+                        "writer {i}: elapsed={elapsed:?} ok=true is_read_only={} (since test start: {:?})",
+                        h.is_read_only(),
+                        start.elapsed()
+                    ),
+                    Err(e) => eprintln!(
+                        "writer {i}: elapsed={elapsed:?} ok=false err={e:#} (since test start: {:?})",
+                        start.elapsed()
+                    ),
+                }
+                (result.is_ok(), elapsed)
+            })
+        })
+        .collect();
+
+    let results: Vec<(bool, std::time::Duration)> =
+        handles.into_iter().map(|h| h.join().unwrap()).collect();
+    let total = start.elapsed();
+    let max_wait = results.iter().map(|(_, d)| *d).max().unwrap();
+    eprintln!(
+        "writer_open_queue_depth: {WRITER_COUNT} concurrent writers, total={total:?}, \
+         max_single_caller_wait={max_wait:?}"
+    );
+
+    // Every attempt must fail (the lock is held for the whole test) — never
+    // a silent snapshot degrade for Writer intent.
+    assert!(
+        results.iter().all(|(ok, _)| !ok),
+        "every writer-intent open must fail while the lock is held, never succeed silently"
+    );
+
+    // The bounded-fix assertion: no single caller may wait longer than the
+    // injected open-queue timeout plus one bounded writer-open attempt
+    // (~1.55-2.1s in practice), REGARDLESS of how many other callers are
+    // queued ahead of it for the same palace. Pre-fix, `open_lock.lock()`
+    // was unbounded and callers queued behind every earlier caller's own
+    // attempt in turn, so `max_wait` scaled with `WRITER_COUNT` (measured
+    // live: 9.86s for 5 callers against a genuinely held lock — see the
+    // test doc comment). Post-fix it stays pinned near
+    // `OPEN_QUEUE_TIMEOUT` regardless of `WRITER_COUNT`.
+    let slack = std::time::Duration::from_millis(2_500);
+    assert!(
+        max_wait < OPEN_QUEUE_TIMEOUT + slack,
+        "a queued caller must not wait longer than the open-queue timeout plus \
+         one bounded writer-open attempt, regardless of queue depth; got \
+         {max_wait:?} (bound {OPEN_QUEUE_TIMEOUT:?} + {slack:?} slack) for \
+         {WRITER_COUNT} concurrent callers (issue #3992)"
+    );
+}

--- a/crates/trusty-common/src/memory_core/timeouts.rs
+++ b/crates/trusty-common/src/memory_core/timeouts.rs
@@ -42,6 +42,23 @@ const DEFAULT_EMBED_BATCH_SECS: u64 = 30;
 /// above 1 s; 60 s is conservative without risking an indefinite cascade.
 const DEFAULT_WRITE_LOCK_SECS: u64 = 60;
 
+/// Default ceiling for the per-palace *open-queue* mutex in
+/// `PalaceRegistry::open_palace` (issue #3992).
+///
+/// Why: distinct from [`DEFAULT_WRITE_LOCK_SECS`] on purpose — that one
+/// bounds waiting for an *already-open* palace's write mutex (held for a
+/// sub-second embed+upsert+persist pipeline), while this one bounds waiting
+/// to become the next caller allowed to attempt *opening* a palace's redb
+/// files under sustained `OpenIntent::Writer` lock contention. Each queued
+/// opener's own attempt is separately bounded to ~1.55 s
+/// (`concurrent_open::WRITER_RETRY_ATTEMPTS` x `WRITER_RETRY_SLEEP_MS`), but
+/// a failed Writer open is never cached, so under persistent contention every
+/// new caller repeats that ~1.55 s dance — 60 s (the same order of magnitude
+/// as the write-mutex bound, chosen for the same reason: generous for a
+/// legitimate burst, still finite) caps roughly 30+ such attempts before
+/// giving up with a clear error rather than hanging indefinitely.
+const DEFAULT_OPEN_QUEUE_SECS: u64 = 60;
+
 /// Return the `FastEmbedder::new()` init timeout.
 ///
 /// Why: Overridable via `TRUSTY_EMBEDDER_INIT_TIMEOUT_SECS` so operators on
@@ -74,6 +91,20 @@ pub fn embed_batch_timeout() -> Duration {
 /// Test: `write_lock_timeout_default`.
 pub fn write_lock_timeout() -> Duration {
     parse_secs_env("TRUSTY_WRITE_LOCK_TIMEOUT_SECS", DEFAULT_WRITE_LOCK_SECS)
+}
+
+/// Return the per-palace open-queue acquisition timeout (issue #3992).
+///
+/// Why: Overridable via `TRUSTY_OPEN_QUEUE_TIMEOUT_SECS`, independently of
+/// [`write_lock_timeout`] — see [`DEFAULT_OPEN_QUEUE_SECS`] for why the two
+/// are deliberately separate knobs. Operators whose palace files sit on slow
+/// or contended storage (network mounts, many concurrent sessions hammering
+/// one freshly-evicted palace) can raise this without also loosening the
+/// unrelated write-mutex bound.
+/// What: Reads the env var; falls back to `DEFAULT_OPEN_QUEUE_SECS` (60).
+/// Test: `open_queue_timeout_default`.
+pub fn open_queue_timeout() -> Duration {
+    parse_secs_env("TRUSTY_OPEN_QUEUE_TIMEOUT_SECS", DEFAULT_OPEN_QUEUE_SECS)
 }
 
 /// Acquire a `tokio::sync::Mutex` with a bounded timeout, returning an error
@@ -253,5 +284,18 @@ mod tests {
         unsafe { std::env::remove_var("TRUSTY_WRITE_LOCK_TIMEOUT_SECS") };
         let t = write_lock_timeout();
         assert_eq!(t, Duration::from_secs(DEFAULT_WRITE_LOCK_SECS));
+    }
+
+    /// Why (issue #3992): Guard that the default is 60 s when the env var is
+    /// absent, and that it is a distinct knob from `write_lock_timeout`.
+    /// What: Hold the env mutex, unset the var, call `open_queue_timeout()`,
+    /// assert 60 s.
+    /// Test: itself.
+    #[test]
+    fn open_queue_timeout_default() {
+        let _guard = env_lock();
+        unsafe { std::env::remove_var("TRUSTY_OPEN_QUEUE_TIMEOUT_SECS") };
+        let t = open_queue_timeout();
+        assert_eq!(t, Duration::from_secs(DEFAULT_OPEN_QUEUE_SECS));
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #3992: `memory_remember` (and any Writer-intent palace open) could
  hang far longer than any documented bound under sustained multi-process
  redb lock contention.
- Root cause, confirmed against the running code (not assumed): each
  individual `try_open_or_snapshot` retry under `OpenIntent::Writer` is
  already bounded to ~1.55s (issue #1487 / PR #1488). The asymmetry the
  issue describes as "reader bounded / writer unbounded" is real, but it
  is **not** inside that retry loop — it is `PalaceRegistry::open_palace`'s
  per-palace `open_lock`, previously acquired with a plain, unbounded
  `parking_lot::Mutex::lock()`. A failed Writer open is never cached (a
  nonexistent handle must not be), so under sustained contention every
  caller queued behind the lock repeats the full ~1.55s bounded dance from
  scratch once it's finally its turn — the Nth caller waits for N-1 earlier
  callers' own attempts first, with **no ceiling on the total**.
- `open_palace` now acquires that lock via `try_lock_for`, bounded by a new,
  independently-tunable `memory_core::timeouts::open_queue_timeout()`
  (default 60s, `TRUSTY_OPEN_QUEUE_TIMEOUT_SECS`) — a sibling of the
  existing `write_lock_timeout` (issue #906) kept as its own knob since the
  two guard different pipelines. A caller stuck behind persistent
  contention now gets a clear, actionable ERROR instead of hanging.

## Before / after evidence (real multi-writer contention, not mocked)

New test `writer_open_queue_wait_is_bounded_under_sustained_contention`
holds a genuine flock conflict on the real backing redb file (`kg.redb` —
`KnowledgeGraph::open_with_intent` translates the legacy `kg.db` path
callers pass in) via a second `Database::create`, exactly like the existing
`writer_intent_fails_on_locked_file` test, then fires 5 concurrent
`open_palace` calls at a `with_writer_intent` registry for the same palace.

**Before the fix** (`open_lock.lock()`, unbounded):
```
writer 0: elapsed=2.126474042s ... still locked ... attempts=5
writer 1: elapsed=3.979972958s ... still locked ... attempts=5
writer 2: elapsed=5.894132833s ... still locked ... attempts=5
writer 3: elapsed=8.048605667s ... still locked ... attempts=5
writer 4: elapsed=10.031702125s ... still locked ... attempts=5
writer_open_queue_depth: 5 concurrent writers, total=10.032225333s,
  max_single_caller_wait=10.031702125s
```
The 5th caller waited **10 seconds** for a palace that never became
available — each caller serialized behind every earlier caller's own
bounded attempt, with the wait growing linearly with queue depth. This is
exactly how a single `memory_remember` call was observed to hang for
1800s under sustained contention from 9 concurrent sessions.

**After the fix** (`open_lock.try_lock_for(open_queue_timeout)`, bounded;
test injects a 2s deadline via the new `with_open_queue_timeout` builder to
stay fast/deterministic without mutating global env state):
```
writer 4: elapsed=2.149208625s ... open queue timed out after 2s ...
writer 1: elapsed=2.14923225s  ... open queue timed out after 2s ...
writer 3: elapsed=2.149233416s ... open queue timed out after 2s ...
writer 0: elapsed=2.149233875s ... open queue timed out after 2s ...
writer 2: elapsed=2.188552709s ... still locked ... attempts=5
writer_open_queue_depth: 5 concurrent writers, total=2.188760708s,
  max_single_caller_wait=2.188552709s
```
All 5 callers now return within ~2.2s total instead of 10s, with the
queue-timeout error naming the actual cause.

## `tm doctor` gap (not fixed here, reported separately per the brief)

`tm doctor` / `trusty-memory doctor` reported HEALTHY while six threads
were genuinely stuck retrying a redb lock. This fix makes any *individual*
caller's wait bounded and produce a clear error, but does **not** make
doctor detect live in-process lock-contention — that is a fully independent
gap (doctor checks liveness/lock-marker cleanliness, not live retry-loop
occupancy) and should be filed/handled as its own issue.

## Test plan

- [x] `cargo test -p trusty-common --lib --features memory-core` — 605
      passed, 0 failed
- [x] `cargo test -p trusty-common --features memory-core` (integration
      suites included) — all green
- [x] `cargo test -p trusty-memory` (unit + full integration suite,
      including `serve_stdio_*_e2e`) — 452 lib + all integration tests
      passed, 0 failed
- [x] `cargo clippy -p trusty-common --lib --features memory-core
      --all-targets -- -D warnings` — clean
- [x] `cargo clippy -p trusty-memory --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo check -p trusty-agents -p trusty-mpm` (downstream
      `PalaceRegistry` consumers) — clean, no breaking API changes

Closes #3992.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools