### PR TITLE
chore: bump trusty-installer to v0.4.10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11587,7 +11587,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.4.9"
+version = "0.4.10"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -6,7 +6,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [Unreleased]
+## [0.4.10] — 2026-07-26
 
 ### Fixed
 

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.4.9"
+version = "0.4.10"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump trusty-installer version from 0.4.9 to 0.4.10
- Move [Unreleased] CHANGELOG entries to [0.4.10] dated 2026-07-26
- Five fixes from live demo debugging: post-install verify hangs (#3875), verify table false-negatives on incomplete PATH (#3876), non-login shell PATH setup (#3874), clean macOS Homebrew edge case (#3821), and tmux prereq auto-install progress feedback (#3830)

## Test plan
- [x] cargo test -p trusty-installer: 483 passed, 0 failed
- [x] cargo check -p trusty-installer: passed
- [x] CHANGELOG entries verified under new version heading

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools