### PR TITLE
chore: bump trusty-common to v0.26.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6549,7 +6549,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11409,7 +11409,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.26.1"
+version = "0.26.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.26.2] — 2026-07-26
+
 ### Added
 
 - **`chat::SamplingParams` — sampling parity for streamed turns** (issue

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.26.1"
+version = "0.26.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true


### PR DESCRIPTION
Bump trusty-common version to 0.26.2 with the write-hang fix from PR #3996 (issue #3992).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools