### PR TITLE
chore: bump trusty-memory to v0.21.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11633,7 +11633,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.21.1"
+version = "0.21.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -94,7 +94,14 @@ attribution work.
 ### Changed
 
 - release trusty-common 0.22.2 + trusty-mpm 0.19.1 ([#2241](https://github.com/bobmatnyc/trusty-tools/pull/2241)) ([`f7ab5f4`](https://github.com/bobmatnyc/trusty-tools/commit/f7ab5f43c8a5cc41ed4d821e2a53800974e74207))
+
+---
+
 ## [Unreleased]
+
+---
+
+## [0.21.2] — 2026-07-26
 
 ### Fixed
 

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.21.1"
+version = "0.21.2"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.26.0", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
+trusty-common = { path = "../trusty-common", version = "0.26.2", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside


### PR DESCRIPTION
Bump trusty-memory to v0.21.2 with the trusty-common fix dependency (0.26.2, issue #3992).

Includes:
- Slim build fix (#2049)
- Recall/remember decoupled from embedder warm-up (#1970)
- Palace-level alias resolution

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools