### PR TITLE
feat(trusty-agents): report dead [tools].scopes grants instead of silently denying everything (#3987 option C)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -128,6 +128,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   extended `kind` enum in §5.3, the new response fields in §5.7, and epic
   #4021 OQ-1's resolution recorded alongside §12 OQ-2.
 
+- **A `[tools].scopes` grant that can match nothing is now reported instead of
+  silently denying everything** (issue #3987, option C): `ScopePattern`
+  matching fails closed AND silent, so an agent declaring a pattern no tool can
+  ever advertise — the base `assistant`'s `google.read`, which no gworkspace
+  tool advertises because discovery only ever emits
+  `google.<family>.<access>` — got no error, no log line, just a persona whose
+  entire scoped tool surface vanished before the model saw it. That failure
+  mode is indistinguishable from "this agent has no tools", which is how both
+  #3938 and #3987 stayed invisible. The new
+  `tools::registry::dead_scope` module names the condition: at persona
+  registry-build time (`ctrl::pm_task::dispatch::persona`, the #3208
+  enforcement site, and the only place holding both the agent's resolved
+  patterns and the registry's scope vocabulary) a dead pattern now produces a
+  prominent `WARN` naming the agent, the pattern, and the nearest reachable
+  scopes; and `GET /api/agents/{name}/skills` gained a `dead_scope_patterns`
+  array so the GUI/CLI can say "this agent has dead scope grants" rather than
+  showing `granted: true` cards for tools dispatch will drop.
+  Reachability is the union of the live registry's discovered scopes and the
+  closed compile-time Google vocabulary, and a pattern is only judged when its
+  namespace appears in that set — so a `gworkspace`/`trusty-memory` daemon
+  being *down* can never make a working grant look broken. Deliberately a
+  warning and not a load error for now: the shipped base `assistant` still
+  carries `google.read` and every `extends = "assistant"` overlay inherits it,
+  so failing closed would break every assistant load; escalation to a hard
+  error is the intended follow-up once #3987's option B removes it.
+
 ### Fixed
 
 - **Streamed replies no longer flash blank or "(no narrative)" the moment a

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -142,17 +142,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   enforcement site, and the only place holding both the agent's resolved
   patterns and the registry's scope vocabulary) a dead pattern now produces a
   prominent `WARN` naming the agent, the pattern, and the nearest reachable
-  scopes; and `GET /api/agents/{name}/skills` gained a `dead_scope_patterns`
-  array so the GUI/CLI can say "this agent has dead scope grants" rather than
-  showing `granted: true` cards for tools dispatch will drop.
-  Reachability is the union of the live registry's discovered scopes and the
-  closed compile-time Google vocabulary, and a pattern is only judged when its
-  namespace appears in that set — so a `gworkspace`/`trusty-memory` daemon
-  being *down* can never make a working grant look broken. Deliberately a
-  warning and not a load error for now: the shipped base `assistant` still
-  carries `google.read` and every `extends = "assistant"` overlay inherits it,
-  so failing closed would break every assistant load; escalation to a hard
-  error is the intended follow-up once #3987's option B removes it.
+  scopes; `GET /api/agents/{name}/skills` gained a `dead_scope_patterns`
+  array; and the Skills pane renders those as a "Dead scope grants" warning
+  block, so the GUI says so outright rather than showing `granted: true` cards
+  for tools dispatch will drop.
+
+  Reachability is the union of three sources — the scopes the registry kept,
+  every scope the endpoints *advertised* before the operator's
+  `[[endpoints]].scopes` policy filtered them, and the closed compile-time
+  Google vocabulary — and a pattern is only judged when its namespace appears
+  in that set. So neither a `gworkspace`/`trusty-memory` daemon being *down*
+  nor an operator deliberately narrowing an endpoint can make a working grant
+  look broken: denied-by-policy and cannot-possibly-exist stay distinct
+  conditions.
+
+  This ships as a warning rather than a load error. Failing closed is the
+  right end state, but it cannot precede every bundled agent being clean —
+  which is what #3987's option B (the base `assistant`'s explicit Google
+  family grants) delivers. Promoting it to a hard error is deliberately left
+  as its own change even after that: it would also stop *user-authored* agents
+  from loading, which deserves its own decision and release note.
 
 ### Fixed
 

--- a/crates/trusty-agents/src/api/server/agent_skills.rs
+++ b/crates/trusty-agents/src/api/server/agent_skills.rs
@@ -26,6 +26,12 @@
 //!   `unmatched_patterns`, not dropped: it may still resolve to a live-
 //!   discovered MCP tool at dispatch time, and saying so is more useful than
 //!   either hiding it or claiming it is broken.
+//! - #3987: a `[tools].scopes` pattern that can match NO reachable dotted
+//!   scope is surfaced in `dead_scope_patterns` — the scope-side analogue of
+//!   `unmatched_patterns`, and for the same reason. A dead scope grant denies
+//!   every scoped tool it was meant to permit while looking exactly like "this
+//!   agent has no tools"; a panel that renders `granted: true` cards for tools
+//!   the dispatch gate will drop is the audit-surface form of that same lie.
 //!
 //! **#4025 — function-skill groups.** The response is ADDITIVE only: every field
 //! a pre-#4022 consumer reads keeps its name, type and meaning. Function skills
@@ -57,6 +63,8 @@ use super::state::AppState;
 use crate::agents::{SkillsConfig, ToolsConfig};
 use crate::ctrl::pm_task::match_any_glob;
 use crate::skills::manifest::{SkillCatalog, SkillManifest, effective_tool_patterns};
+use crate::tools::registry::dead_scope;
+use crate::tools::registry::scope::ScopePattern;
 
 /// `GET /api/agents/:name/skills` — HTTP entry point.
 ///
@@ -170,6 +178,8 @@ pub(super) async fn skills_at(dirs: &[PathBuf], name: &str, project_root: &Path)
             }))
             .collect::<Vec<_>>(),
         "unmatched_patterns": unmatched_patterns(&catalog, patterns.as_deref()),
+        // #3987 (option C): scope grants that can never match anything.
+        "dead_scope_patterns": dead_scope_cards(tools.scopes.as_ref()),
         // Deny-on-absent polarity, stated rather than implied: `None` here is a
         // persona with no capability declaration at all, which grants nothing.
         "declares_capability": patterns.is_some(),
@@ -364,6 +374,58 @@ fn unmatched_patterns(catalog: &SkillCatalog, patterns: Option<&[String]>) -> Ve
                 "reason": "no skill in the catalog wraps a tool matching this pattern; it may \
                            still resolve to an MCP tool discovered at dispatch time, which is \
                            wrapped in a derived skill then",
+            })
+        })
+        .collect()
+}
+
+/// Declared `[tools].scopes` patterns that can match no reachable scope
+/// (#3987, option C).
+///
+/// Why: this route is the config-introspection surface the GUI/CLI reads, and
+/// until now it could show an agent a page full of `granted: true` gworkspace
+/// cards that the dispatch-time scope gate silently drops — the base
+/// `assistant`'s `google.read` grants literally nothing. Surfacing the dead
+/// pattern here is what lets a client say "this agent has dead scope grants"
+/// instead of leaving the user to conclude the tools simply do not work.
+///
+/// Honesty rules, matching the rest of this module:
+/// - The reachable set here is the STATIC vocabulary only
+///   (`dead_scope::reachable_scopes` with no live registry) — this route runs
+///   in the API process and has no built tool registry to consult. That is the
+///   conservative direction: the static vocabulary is a superset of what an
+///   offline endpoint would contribute for namespaces we know, and
+///   `dead_scope`'s namespace guard declines to judge namespaces we do not.
+///   A pattern reported here is dead under ANY registry state.
+/// - Scopes are read from the agent's OWN file, without resolving `extends`
+///   (same partial-read posture as the rest of this route — see
+///   `parse_capability_sections`). An agent that declares no `[tools].scopes`
+///   of its own reports nothing here even if it inherits a dead pattern from
+///   its base; the dispatch-time `warn!` in
+///   `ctrl::pm_task::dispatch::persona` sees the resolved set and covers that
+///   case. Under-reporting is the correct failure direction for an audit
+///   surface — it never claims a working grant is broken.
+/// What: one `{ pattern, nearest, reason }` object per dead pattern.
+/// Test: `dead_scope_cards_flags_the_google_read_pattern`,
+/// `dead_scope_cards_ignores_live_family_patterns`,
+/// `super::tests::agent_skills::skills_route_reports_dead_scope_patterns`.
+fn dead_scope_cards(scopes: Option<&Vec<String>>) -> Vec<Value> {
+    let Some(scopes) = scopes else {
+        return Vec::new();
+    };
+    let patterns: Vec<ScopePattern> = scopes.iter().cloned().map(ScopePattern::new).collect();
+    let reachable = dead_scope::reachable_scopes(std::iter::empty::<String>());
+    dead_scope::dead_scope_patterns(&patterns, &reachable)
+        .into_iter()
+        .map(|d| {
+            json!({
+                "pattern": d.pattern,
+                "nearest": d.nearest,
+                "reason": format!(
+                    "no reachable tool advertises a scope matching this pattern, so every \
+                     scoped tool it was meant to grant is denied at dispatch — {}",
+                    d.describe(),
+                ),
             })
         })
         .collect()
@@ -575,6 +637,50 @@ mod unit_tests {
         let card = render_skill(mta, false, None);
         assert!(card["provider"]["configured"].is_boolean());
         assert_eq!(card["provider"]["env_var"], "MTA_API_KEY");
+    }
+
+    /// #3987: the base assistant's `google.read` must reach the panel as a
+    /// dead grant, with actionable alternatives.
+    ///
+    /// NOTE: #3987's option B removes `google.read` from the shipped base;
+    /// this test asserts on a LITERAL pattern, not on the shipped config, so
+    /// it stays valid after that lands. The shipped-config assertion lives in
+    /// `ctrl::pm_task::dispatch::persona_tests` and is the one option B
+    /// updates.
+    #[test]
+    fn dead_scope_cards_flags_the_google_read_pattern() {
+        let scopes = vec![
+            "memory.read".to_string(),
+            "search.read".to_string(),
+            "google.read".to_string(),
+        ];
+        let cards = dead_scope_cards(Some(&scopes));
+        assert_eq!(cards.len(), 1, "{cards:?}");
+        assert_eq!(cards[0]["pattern"], "google.read");
+        assert!(
+            cards[0]["nearest"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|v| v == "google.gmail.write"),
+            "the card must name a working alternative: {cards:?}"
+        );
+    }
+
+    /// The shape option B will declare must produce a clean panel.
+    #[test]
+    fn dead_scope_cards_ignores_live_family_patterns() {
+        let scopes = vec![
+            "google.gmail.*".to_string(),
+            "google.calendar.*".to_string(),
+            "google.accounts.*".to_string(),
+        ];
+        assert!(dead_scope_cards(Some(&scopes)).is_empty());
+    }
+
+    #[test]
+    fn dead_scope_cards_are_empty_when_no_scopes_are_declared() {
+        assert!(dead_scope_cards(None).is_empty());
     }
 
     #[test]

--- a/crates/trusty-agents/src/api/server/tests/agent_skills.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_skills.rs
@@ -505,3 +505,60 @@ async fn skills_route_leaf_cards_keep_their_pre_4022_shape() {
         .count() as u64;
     assert_eq!(granted_count, granted_leaf_cards);
 }
+
+/// #3987 (option C): a dead `[tools].scopes` grant reaches the panel.
+///
+/// Why route-level and not just unit-level: the whole point of option C is
+/// that a client can render "this agent has dead scope grants" instead of the
+/// user concluding the tools are broken, and that requires the field to
+/// actually be in the response body — not merely computable.
+#[tokio::test]
+async fn skills_route_reports_dead_scope_patterns() {
+    const DEAD_SCOPE_FIXTURE: &str = r#"[agent]
+name = "deadscope"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[tools]
+allow = ["search_gmail_messages"]
+scopes = ["memory.read", "google.read", "google.gmail.*"]
+"#;
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("deadscope.toml"), DEAD_SCOPE_FIXTURE).unwrap();
+
+    let resp = skills_at(&[dir.path().to_path_buf()], "deadscope", dir.path()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+
+    let dead = body["dead_scope_patterns"].as_array().unwrap();
+    assert_eq!(dead.len(), 1, "{dead:?}");
+    assert_eq!(dead[0]["pattern"], "google.read");
+    assert!(
+        dead[0]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("denied at dispatch"),
+        "the reason must say what the consequence is: {dead:?}"
+    );
+    assert!(
+        dead[0]["nearest"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == "google.gmail.write"),
+        "the entry must name a working alternative: {dead:?}"
+    );
+}
+
+/// A healthy agent's panel must carry an EMPTY list, not a missing field —
+/// a client checking `dead_scope_patterns.length` must not have to special-case
+/// `undefined`.
+#[tokio::test]
+async fn skills_route_reports_no_dead_scope_patterns_for_a_healthy_agent() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("izzie.toml"), TOOLS_ONLY_FIXTURE).unwrap();
+    let resp = skills_at(&[dir.path().to_path_buf()], "izzie", dir.path()).await;
+    let body = body_json(resp).await;
+    assert_eq!(body["dead_scope_patterns"], serde_json::json!([]));
+}

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -305,16 +305,24 @@ pub async fn run_pm_task_with_persona(
             for tool in crate::tools::mcp_service_tools::mcp_service_tool_executors().await {
                 registry.register(tool);
             }
+            // #3987: `advertised_scopes` is the UNFILTERED vocabulary every
+            // endpoint published, captured here because the registry only
+            // keeps what the operator's `[[endpoints]].scopes` policy let
+            // through. Feeding the dead-grant diagnostic the post-policy set
+            // would make an operator's deliberate narrowing look like a
+            // broken agent grant — see `build_with_scope_vocabulary`.
+            let mut advertised_scopes: Vec<String> = Vec::new();
             {
                 let global_config = crate::mcp::config::GlobalConfig::load().await;
                 match crate::tools::registry::ToolRegistryBuilder::from_config(&global_config)
-                    .build()
+                    .build_with_scope_vocabulary()
                     .await
                 {
-                    Ok(execs) => {
+                    Ok((execs, vocabulary)) => {
                         for tool in execs {
                             registry.register(tool);
                         }
+                        advertised_scopes = vocabulary;
                     }
                     Err(e) => {
                         tracing::warn!("tool registry init failed: {e}");
@@ -534,7 +542,13 @@ pub async fn run_pm_task_with_persona(
                 persona_name,
                 &dead_scope::dead_scope_patterns(
                     &agent_scope_patterns,
-                    &dead_scope::reachable_scopes(tool_scopes.values()),
+                    // Both halves: what the registry actually kept AND what
+                    // the endpoints advertised before operator filtering, so
+                    // a narrowed `[[endpoints]].scopes` policy can never be
+                    // mistaken for a dead grant.
+                    &dead_scope::reachable_scopes(
+                        tool_scopes.values().chain(advertised_scopes.iter()),
+                    ),
                 ),
             );
             let kept = filter_persona_tool_names(

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -15,6 +15,7 @@ use anyhow::{Context, Result};
 use crate::agents::AgentConfig;
 use crate::llm;
 use crate::subprocess::SubprocessAgentRunner;
+use crate::tools::registry::dead_scope;
 use crate::tools::registry::scope::{Scope, ScopePattern, agent_can_use};
 use crate::tools::{AgentRunner, ToolRegistry, delegate::DelegateToAgentTool};
 
@@ -517,6 +518,25 @@ pub async fn run_pm_task_with_persona(
                 .into_iter()
                 .map(ScopePattern::new)
                 .collect();
+            // #3987 (option C): this is the ONLY place that holds both halves
+            // of the intersection at once — the agent's resolved patterns
+            // (post-`extends` union) AND the scope vocabulary the registry
+            // actually built — so it is where a pattern that can match
+            // nothing becomes detectable. Emitted here, immediately before
+            // the gate that would otherwise drop the surface in silence.
+            // Deliberately a WARN and not a hard failure for now: the bundled
+            // base `assistant` still ships the dead `google.read` pattern that
+            // every `extends = "assistant"` overlay inherits, so failing
+            // closed here would break every assistant load. Escalate to a hard
+            // error once #3987's option B has removed it — see
+            // `tools::registry::dead_scope`'s module doc.
+            dead_scope::warn_dead_scope_patterns(
+                persona_name,
+                &dead_scope::dead_scope_patterns(
+                    &agent_scope_patterns,
+                    &dead_scope::reachable_scopes(tool_scopes.values()),
+                ),
+            );
             let kept = filter_persona_tool_names(
                 all_names,
                 &patterns,

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -562,3 +562,100 @@ fn cto_assistant_package_gmail_and_tasks_tools_survive_scope_intersection() {
         cfg.tools.scopes
     );
 }
+
+/// #3987 (option C) pinned against the SHIPPED base template: the bundled
+/// `assistant`'s declared `google.read` is a dead scope pattern.
+///
+/// Why assert on the checked-in config rather than a literal: the diagnostic's
+/// value is that it fires on the real defect, and the real defect is in the
+/// file we ship. Resolving through the real loader also proves the check sees
+/// the POST-`extends` scope set, which is the set the dispatch gate uses.
+///
+/// **This test is updated by #3987's option B**, which replaces the base's
+/// `google.read` with explicit family grants. After that lands the assertion
+/// inverts to "the base assistant has NO dead scope patterns" — that inversion
+/// is the acceptance criterion for option B, not a regression here. The
+/// warning-not-error posture in `persona.rs` exists precisely because this
+/// test currently passes: a hard load error today would break every assistant.
+#[test]
+fn base_assistant_google_read_is_a_dead_scope_pattern() {
+    use crate::tools::registry::dead_scope;
+
+    let agents_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".trusty-agents")
+        .join("agents");
+    let cfg = AgentConfig::by_name_in(&[agents_dir], "assistant")
+        .expect("bundled assistant template resolves");
+    let patterns: Vec<ScopePattern> = cfg
+        .tools
+        .scopes
+        .clone()
+        .expect("the base assistant declares [tools].scopes")
+        .into_iter()
+        .map(ScopePattern::new)
+        .collect();
+
+    // No live registry: the static Google vocabulary alone is enough to prove
+    // this pattern is dead under ANY registry state.
+    let dead = dead_scope::dead_scope_patterns(
+        &patterns,
+        &dead_scope::reachable_scopes(std::iter::empty::<String>()),
+    );
+    assert_eq!(
+        dead.iter().map(|d| d.pattern.as_str()).collect::<Vec<_>>(),
+        vec!["google.read"],
+        "resolved [tools].scopes = {:?}",
+        cfg.tools.scopes
+    );
+    assert!(
+        dead[0].nearest.iter().any(|s| s == "google.gmail.write"),
+        "the diagnostic must name a reachable alternative: {:?}",
+        dead[0].nearest
+    );
+
+    // The base's OTHER scopes must NOT be flagged: `memory.*`/`search.*` come
+    // from endpoints whose vocabulary this crate does not know statically, and
+    // reporting them dead when their daemon merely isn't running would be the
+    // false-positive that makes the whole diagnostic ignorable.
+    assert!(
+        !dead
+            .iter()
+            .any(|d| d.pattern.starts_with("memory.") || d.pattern.starts_with("search.")),
+        "namespace guard failed: {dead:?}"
+    );
+}
+
+/// #3987 the negative half: a live family/wildcard pattern is never flagged.
+/// `izzie` ships blanket `google.*` and `cto-assistant` ships the narrow
+/// `google.gmail.*` / `google.tasks.*` pair (#3985) — both are working grants
+/// and a diagnostic that cried wolf on them would be worse than none.
+#[test]
+fn shipped_agents_with_live_google_patterns_are_not_flagged() {
+    use crate::tools::registry::dead_scope;
+
+    let agents_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".trusty-agents")
+        .join("agents");
+    let reachable = dead_scope::reachable_scopes(std::iter::empty::<String>());
+    for name in ["izzie", "cto-assistant"] {
+        let cfg = AgentConfig::by_name_in(std::slice::from_ref(&agents_dir), name)
+            .unwrap_or_else(|e| panic!("bundled {name} resolves: {e}"));
+        let patterns: Vec<ScopePattern> = cfg
+            .tools
+            .scopes
+            .clone()
+            .unwrap_or_default()
+            .into_iter()
+            .map(ScopePattern::new)
+            .collect();
+        let dead = dead_scope::dead_scope_patterns(&patterns, &reachable);
+        // Both agents UNION the base's scopes via `extends`, so they inherit
+        // `google.read` too — that inherited pattern is expected here and is
+        // removed by option B. What must NOT appear is any of their OWN
+        // family patterns.
+        assert!(
+            dead.iter().all(|d| d.pattern == "google.read"),
+            "{name}: a live family pattern was flagged dead: {dead:?}"
+        );
+    }
+}

--- a/crates/trusty-agents/src/tools/registry/dead_scope.rs
+++ b/crates/trusty-agents/src/tools/registry/dead_scope.rs
@@ -1,0 +1,350 @@
+//! Dead scope-pattern detection for agent `[tools].scopes` (#3987, option C).
+//!
+//! Why: `ScopePattern` matching fails CLOSED and fails SILENTLY. An agent
+//! that declares a pattern no tool can ever advertise — the base
+//! `assistant`'s `google.read` is the motivating example — does not get an
+//! error, a `404`, or even a log line: `agent_can_use` simply returns
+//! `false` for every scoped tool and `filter_persona_tool_names` drops the
+//! whole surface before the model sees the registry. The observable result
+//! is indistinguishable from "this agent has no tools", which is exactly why
+//! #3938 and #3987 both stayed invisible for so long and cost real debugging
+//! time. This module makes that condition *nameable* so it can be logged at
+//! registry-build time and rendered in the config-introspection surface.
+//!
+//! What: [`reachable_scopes`] assembles the set of dotted scopes a pattern
+//! could plausibly match; [`dead_scope_patterns`] returns one
+//! [`DeadScopePattern`] per declared pattern that matches none of them, each
+//! carrying the *nearest reachable* scopes in the same namespace so the
+//! diagnostic is actionable rather than merely alarming.
+//!
+//! ## No false positives: the namespace guard
+//!
+//! "Reachable" is deliberately the UNION of two sources:
+//!
+//! 1. the scopes the live registry actually discovered this run
+//!    (`ToolRegistry::tool_scopes()`), and
+//! 2. the closed compile-time vocabulary this build can ever emit for
+//!    namespaces it owns — today just `google`, via
+//!    [`super::google_scope::known_dotted_scopes`].
+//!
+//! Source 2 is what keeps a `gworkspace` daemon being *down* from making
+//! every `google.*` grant look broken. But the union alone is still not
+//! enough: `memory.read` / `search.read` come from endpoints whose
+//! vocabulary this crate does not know statically, so with those endpoints
+//! offline they would match nothing and be falsely reported dead.
+//!
+//! Hence the namespace guard: a pattern is only JUDGED when its first
+//! segment (`google` in `google.read`) appears in the reachable set at all.
+//! An unrecognised namespace is treated as "not enough information",
+//! never as "dead". The diagnostic therefore only ever fires on a namespace
+//! whose vocabulary is fully known — where a non-match is a genuine
+//! configuration defect and not an artefact of what is running.
+//!
+//! ## Warning today, hard error later (deliberate sequencing)
+//!
+//! This is intentionally NOT a load-time error yet. At the time of writing,
+//! the bundled base `assistant` template itself declares the dead
+//! `google.read` pattern (`.trusty-agents/agents/assistant/agent.toml`), and
+//! every `extends = "assistant"` overlay inherits it by union — so failing
+//! closed here would break EVERY assistant load, including the default
+//! persona, on the very commit that added the check. #3987's option B
+//! removes that pattern from the shipped base; once it has landed and no
+//! bundled agent trips this diagnostic, escalating
+//! [`dead_scope_patterns`]'s callers from `warn!` to a hard load error is
+//! the intended follow-up. Do not escalate before then.
+//!
+//! Test: the `tests` module below, plus
+//! `ctrl::pm_task::dispatch::persona_tests::base_assistant_google_read_is_a_dead_scope_pattern`
+//! which pins the diagnostic against the SHIPPED base template.
+
+use std::collections::BTreeSet;
+
+use super::google_scope::known_dotted_scopes;
+use super::scope::{Scope, ScopePattern};
+
+/// How many nearest-reachable suggestions a diagnostic carries.
+///
+/// Why: the whole point is an actionable log line; dumping an unbounded
+/// scope list into a `warn!` makes it noise again. Eight is enough to name
+/// every `google` family with room to spare.
+const MAX_SUGGESTIONS: usize = 8;
+
+/// One declared pattern that can match nothing reachable.
+///
+/// Why: the pattern alone is not actionable — an operator reading
+/// `google.read matches nothing` still has to go find what *would* work.
+/// `nearest` answers that in the same breath.
+/// What: `pattern` is the agent's declared string verbatim; `nearest` is the
+/// reachable scopes sharing its namespace, sorted, capped at
+/// [`MAX_SUGGESTIONS`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeadScopePattern {
+    pub pattern: String,
+    pub nearest: Vec<String>,
+}
+
+impl DeadScopePattern {
+    /// Human-readable one-liner: `` `google.read` (nearest reachable: …) ``.
+    ///
+    /// Why: used both by the `warn!` at the dispatch call site and by the
+    /// API route's `reason` field, so the wording cannot drift between the
+    /// log an operator greps and the panel a user reads.
+    pub fn describe(&self) -> String {
+        if self.nearest.is_empty() {
+            format!(
+                "`{}` (no reachable scope shares its namespace)",
+                self.pattern
+            )
+        } else {
+            format!(
+                "`{}` (nearest reachable: {})",
+                self.pattern,
+                self.nearest.join(", ")
+            )
+        }
+    }
+}
+
+/// The namespace (first dotted segment) a pattern or scope belongs to.
+///
+/// Why: the namespace guard described in the module doc needs one rule
+/// applied identically to patterns and scopes, so `google.*`, `google.read`
+/// and `google.gmail.write` all resolve to `google`.
+/// What: everything before the first `.`, or the whole string when it has
+/// none. A pattern that is bare `*` has no namespace and yields `None`.
+fn namespace(s: &str) -> Option<&str> {
+    if s.is_empty() || s.starts_with('*') {
+        return None;
+    }
+    Some(s.split('.').next().unwrap_or(s))
+}
+
+/// Assemble the set of dotted scopes an agent pattern could match.
+///
+/// Why/What: see the module doc — the union of what the live registry
+/// discovered this run with the closed vocabulary this build can emit, so
+/// the diagnostic is stable whether or not `gworkspace` is up.
+/// Test: `reachable_includes_static_google_vocabulary_without_a_live_registry`.
+pub fn reachable_scopes<I, S>(live_tool_scopes: I) -> BTreeSet<Scope>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let mut out: BTreeSet<Scope> = live_tool_scopes
+        .into_iter()
+        // `method_to_tool` writes an EMPTY scope for a tool whose scope could
+        // not be derived; that is a discovery defect with its own warning and
+        // must not be admitted here as if it were a reachable vocabulary entry.
+        .filter(|s| !s.as_ref().trim().is_empty())
+        .map(|s| Scope::new(s.as_ref().to_string()))
+        .collect();
+    out.extend(known_dotted_scopes().into_iter().map(Scope::new));
+    out
+}
+
+/// Report every declared pattern that can match no reachable scope.
+///
+/// Why: #3987 option C — make silent total denial loud. This is the pure,
+/// side-effect-free core so the property can be unit-tested without a
+/// registry, a daemon, or an LLM; the callers own the `warn!` and the JSON.
+/// What: for each pattern, skip it unless its namespace appears somewhere in
+/// `reachable` (the namespace guard — see the module doc), then report it
+/// when no reachable scope matches. Order-preserving over `patterns`.
+/// Test: `dead_pattern_is_detected`, `live_wildcard_pattern_is_not_flagged`,
+/// `unknown_namespace_is_never_judged`,
+/// `namespace_known_only_from_live_scopes_is_judged`,
+/// `middle_wildcard_pattern_is_flagged`.
+pub fn dead_scope_patterns(
+    patterns: &[ScopePattern],
+    reachable: &BTreeSet<Scope>,
+) -> Vec<DeadScopePattern> {
+    let mut out = Vec::new();
+    for pattern in patterns {
+        let Some(ns) = namespace(pattern.as_str()) else {
+            continue;
+        };
+        let same_namespace: Vec<&Scope> = reachable
+            .iter()
+            .filter(|s| namespace(s.as_str()) == Some(ns))
+            .collect();
+        // Namespace guard: nothing reachable is in this namespace, so we do
+        // not know its vocabulary and cannot honestly call the pattern dead.
+        if same_namespace.is_empty() {
+            continue;
+        }
+        if same_namespace.iter().any(|s| pattern.matches(s)) {
+            continue;
+        }
+        out.push(DeadScopePattern {
+            pattern: pattern.as_str().to_string(),
+            nearest: same_namespace
+                .iter()
+                .take(MAX_SUGGESTIONS)
+                .map(|s| s.as_str().to_string())
+                .collect(),
+        });
+    }
+    out
+}
+
+/// Emit the loud, actionable registry-build-time warning for `dead`.
+///
+/// Why: every call site should produce the SAME log line — an operator who
+/// learns to grep one string must find them all — and the "an agent with a
+/// dead grant looks exactly like an agent with no tools" explanation is
+/// worth stating in the log itself, since that confusion is the entire
+/// reason the defect class survived two issues. No-op when `dead` is empty
+/// so healthy agents cost nothing.
+/// What: one `warn!` naming the agent, the dead patterns and their nearest
+/// reachable alternatives.
+/// Test: `warn_dead_scope_patterns_is_a_noop_when_healthy` (behavioural
+/// smoke — the log content itself is asserted via `describe`).
+pub fn warn_dead_scope_patterns(agent: &str, dead: &[DeadScopePattern]) {
+    if dead.is_empty() {
+        return;
+    }
+    let described: Vec<String> = dead.iter().map(DeadScopePattern::describe).collect();
+    tracing::warn!(
+        agent = %agent,
+        dead_scope_patterns = ?described,
+        "DEAD SCOPE GRANT (#3987): agent '{agent}' declares [tools].scopes \
+         pattern(s) that match NO scope any reachable tool advertises, so every \
+         scoped tool they were meant to grant is silently denied at dispatch — \
+         which looks identical to 'this agent has no tools'. Dead: {}. Replace \
+         each with one of its nearest reachable scopes (or a trailing-wildcard \
+         family pattern such as `google.gmail.*`); middle wildcards like \
+         `google.*.read` are not supported and always match nothing.",
+        described.join("; "),
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn patterns(v: &[&str]) -> Vec<ScopePattern> {
+        v.iter().map(|s| ScopePattern::new(*s)).collect()
+    }
+
+    fn reachable(v: &[&str]) -> BTreeSet<Scope> {
+        reachable_scopes(v.iter().map(|s| s.to_string()))
+    }
+
+    /// The motivating defect: `google.read` is an exact pattern and the
+    /// vocabulary only ever emits `google.<family>.<access>`.
+    #[test]
+    fn dead_pattern_is_detected() {
+        let dead = dead_scope_patterns(&patterns(&["google.read"]), &reachable(&[]));
+        assert_eq!(dead.len(), 1, "{dead:?}");
+        assert_eq!(dead[0].pattern, "google.read");
+        assert!(
+            dead[0].nearest.iter().any(|s| s == "google.gmail.write"),
+            "the diagnostic must be actionable: {:?}",
+            dead[0].nearest
+        );
+        assert!(dead[0].describe().contains("nearest reachable"));
+    }
+
+    /// A live family pattern — the shape option B will use — must never be
+    /// flagged, with or without a live registry.
+    #[test]
+    fn live_wildcard_pattern_is_not_flagged() {
+        assert!(
+            dead_scope_patterns(
+                &patterns(&["google.gmail.*", "google.tasks.*", "google.*"]),
+                &reachable(&[])
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn live_exact_pattern_is_not_flagged() {
+        assert!(
+            dead_scope_patterns(
+                &patterns(&["google.gmail.write", "google.accounts.read"]),
+                &reachable(&[])
+            )
+            .is_empty()
+        );
+    }
+
+    /// The namespace guard. `memory.read` is served by an endpoint whose
+    /// vocabulary this crate does not know statically; with that endpoint
+    /// offline it must be left alone, NOT reported dead.
+    #[test]
+    fn unknown_namespace_is_never_judged() {
+        assert!(
+            dead_scope_patterns(
+                &patterns(&[
+                    "memory.read",
+                    "memory.write",
+                    "search.read",
+                    "totally.made.up"
+                ]),
+                &reachable(&[])
+            )
+            .is_empty()
+        );
+    }
+
+    /// …but once the live registry HAS shown us that namespace, a pattern in
+    /// it that still matches nothing is a genuine defect and is reported.
+    #[test]
+    fn namespace_known_only_from_live_scopes_is_judged() {
+        let live = reachable(&["memory.read", "memory.write"]);
+        assert!(dead_scope_patterns(&patterns(&["memory.read"]), &live).is_empty());
+        let dead = dead_scope_patterns(&patterns(&["memory.recall"]), &live);
+        assert_eq!(dead.len(), 1);
+        assert_eq!(dead[0].nearest, vec!["memory.read", "memory.write"]);
+    }
+
+    /// `google.*.read` is the pattern someone reaches for when told
+    /// "read-only Google"; `ScopePattern` rejects middle wildcards by design,
+    /// so it matches nothing and must be flagged rather than silently denied.
+    #[test]
+    fn middle_wildcard_pattern_is_flagged() {
+        let dead = dead_scope_patterns(&patterns(&["google.*.read"]), &reachable(&[]));
+        assert_eq!(dead.len(), 1);
+        assert_eq!(dead[0].pattern, "google.*.read");
+    }
+
+    /// A pattern with no namespace at all (bare `*`) is not judged — there is
+    /// no vocabulary to judge it against.
+    #[test]
+    fn namespaceless_pattern_is_not_judged() {
+        assert!(dead_scope_patterns(&patterns(&["*", ""]), &reachable(&[])).is_empty());
+    }
+
+    /// Reachability must not depend on a live `gworkspace` endpoint.
+    #[test]
+    fn reachable_includes_static_google_vocabulary_without_a_live_registry() {
+        let r = reachable(&[]);
+        assert!(r.contains(&Scope::new("google.gmail.write")));
+        assert!(r.contains(&Scope::new("google.accounts.read")));
+        assert!(!r.contains(&Scope::new("google.read")));
+    }
+
+    /// An undeducible scope is written as `""` by discovery; admitting it
+    /// would create a bogus empty-namespace entry.
+    #[test]
+    fn reachable_drops_empty_scope_strings() {
+        let r = reachable(&["", "  ", "memory.read"]);
+        assert!(r.contains(&Scope::new("memory.read")));
+        assert!(!r.contains(&Scope::new("")));
+    }
+
+    #[test]
+    fn suggestions_are_capped() {
+        let many: Vec<String> = (0..30).map(|i| format!("zz.scope{i:02}")).collect();
+        let set = reachable_scopes(many);
+        let dead = dead_scope_patterns(&patterns(&["zz.nope"]), &set);
+        assert_eq!(dead.len(), 1);
+        assert_eq!(dead[0].nearest.len(), MAX_SUGGESTIONS);
+    }
+
+    #[test]
+    fn warn_dead_scope_patterns_is_a_noop_when_healthy() {
+        warn_dead_scope_patterns("assistant", &[]);
+    }
+}

--- a/crates/trusty-agents/src/tools/registry/dead_scope.rs
+++ b/crates/trusty-agents/src/tools/registry/dead_scope.rs
@@ -19,19 +19,36 @@
 //!
 //! ## No false positives: the namespace guard
 //!
-//! "Reachable" is deliberately the UNION of two sources:
+//! "Reachable" is deliberately the UNION of three sources:
 //!
-//! 1. the scopes the live registry actually discovered this run
-//!    (`ToolRegistry::tool_scopes()`), and
-//! 2. the closed compile-time vocabulary this build can ever emit for
+//! 1. the scopes the live registry actually kept this run
+//!    (`ToolRegistry::tool_scopes()`),
+//! 2. every scope those endpoints ADVERTISED before the operator's
+//!    `[[endpoints]].scopes` policy filtered them
+//!    ([`super::ToolRegistryBuilder::build_with_scope_vocabulary`]), and
+//! 3. the closed compile-time vocabulary this build can ever emit for
 //!    namespaces it owns — today just `google`, via
 //!    [`super::google_scope::known_dotted_scopes`].
 //!
-//! Source 2 is what keeps a `gworkspace` daemon being *down* from making
-//! every `google.*` grant look broken. But the union alone is still not
-//! enough: `memory.read` / `search.read` come from endpoints whose
-//! vocabulary this crate does not know statically, so with those endpoints
-//! offline they would match nothing and be falsely reported dead.
+//! Source 3 is what keeps a `gworkspace` daemon being *down* from making
+//! every `google.*` grant look broken.
+//!
+//! Source 2 exists because source 1 is POST-FILTER. An operator who narrows a
+//! non-Google endpoint to, say, `memory.read` makes the `memory` namespace
+//! known (so the guard below starts judging it) while removing
+//! `memory.write` from the registry — and an agent's legitimate
+//! `memory.write` grant would be reported dead, advising "nearest reachable:
+//! memory.read", i.e. quietly recommending the operator's own revoked
+//! capability be dropped from the agent. **Denied by operator policy and
+//! cannot possibly exist are different conditions and must never share a
+//! diagnostic.** Feeding in the unfiltered vocabulary keeps this module
+//! reporting only the latter. This property is load-bearing for the
+//! escalation described below.
+//!
+//! Even so the union is not enough on its own: `memory.read` / `search.read`
+//! come from endpoints whose vocabulary this crate does not know statically,
+//! so with those endpoints entirely offline they would match nothing and be
+//! falsely reported dead.
 //!
 //! Hence the namespace guard: a pattern is only JUDGED when its first
 //! segment (`google` in `google.read`) appears in the reachable set at all.
@@ -52,6 +69,13 @@
 //! bundled agent trips this diagnostic, escalating
 //! [`dead_scope_patterns`]'s callers from `warn!` to a hard load error is
 //! the intended follow-up. Do not escalate before then.
+//!
+//! **A second precondition for that escalation**: every caller must be
+//! feeding in the UNFILTERED endpoint vocabulary (source 2 above). Escalating
+//! while a caller passes only post-policy scopes would convert an operator's
+//! deliberate `[[endpoints]].scopes` narrowing into a hard startup failure
+//! for agents that did nothing wrong. Audit the call sites, not just the
+//! bundled configs, before flipping this to an error.
 //!
 //! Test: the `tests` module below, plus
 //! `ctrl::pm_task::dispatch::persona_tests::base_assistant_google_read_is_a_dead_scope_pattern`
@@ -285,6 +309,38 @@ mod tests {
                 &reachable(&[])
             )
             .is_empty()
+        );
+    }
+
+    /// An operator narrowing `[[endpoints]].scopes` must not turn a
+    /// legitimate agent grant into a "dead" report.
+    ///
+    /// Scenario: the `memory` endpoint advertises `memory.read` AND
+    /// `memory.write`, but the operator's endpoint policy admits only
+    /// `memory.read`, so `ToolRegistry::tool_scopes()` (post-filter) contains
+    /// just that. An agent granting `memory.write` is then DENIED BY POLICY —
+    /// a deliberate operator decision — not broken. Reporting it dead would
+    /// both misdiagnose the cause and advise dropping the grant, which is the
+    /// opposite of what the operator wants.
+    #[test]
+    fn operator_narrowed_endpoint_does_not_produce_a_false_dead_report() {
+        let post_filter_only = reachable(&["memory.read"]);
+        // The bug this guards: with ONLY post-filter scopes, the namespace is
+        // known and `memory.write` looks dead. This assertion documents why
+        // `reachable_scopes` must be fed the unfiltered vocabulary.
+        assert_eq!(
+            dead_scope_patterns(&patterns(&["memory.write"]), &post_filter_only).len(),
+            1,
+            "precondition: post-filter-only input is what produces the false positive"
+        );
+
+        // With the endpoint's UNFILTERED vocabulary unioned in — what
+        // `ToolRegistryBuilder::build_with_scope_vocabulary` supplies — the
+        // grant is correctly left alone.
+        let with_advertised = reachable(&["memory.read", "memory.read", "memory.write"]);
+        assert!(
+            dead_scope_patterns(&patterns(&["memory.write"]), &with_advertised).is_empty(),
+            "a grant denied by operator policy is not a dead grant"
         );
     }
 

--- a/crates/trusty-agents/src/tools/registry/google_scope.rs
+++ b/crates/trusty-agents/src/tools/registry/google_scope.rs
@@ -129,6 +129,34 @@ const FAMILY_TABLE: &[(&str, &str, ScopeAccess)] = &[
     ),
 ];
 
+/// Every dotted scope this build can EVER emit for the `google` namespace.
+///
+/// Why (#3987): `dead_scope::dead_scope_patterns` needs to know the closed
+/// vocabulary an agent's `[tools].scopes` patterns are matched against, and
+/// for Google that vocabulary is a compile-time property of
+/// [`FAMILY_TABLE`] — NOT of whether a `gworkspace` endpoint happens to be
+/// reachable right now. Deriving it here rather than only from a live
+/// `rpc.discover` is what makes the diagnostic sound: `google.read` is dead
+/// because no table entry can ever produce it, a fact that holds with the
+/// daemon down, and a pattern must never be reported dead merely because an
+/// endpoint is offline.
+/// What: the de-duplicated `google.<family>.<access>` set produced by
+/// walking [`FAMILY_TABLE`], in table (priority) order with duplicates
+/// dropped — several OAuth URLs collapse to the same dotted scope (the
+/// four Gmail scopes all yield `google.gmail.write`).
+/// Test: `known_dotted_scopes_covers_every_family`,
+/// `known_dotted_scopes_never_contains_the_dead_google_read_pattern`.
+pub fn known_dotted_scopes() -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for (_, family, access) in FAMILY_TABLE {
+        let dotted = format!("google.{family}.{}", access.as_str());
+        if !out.contains(&dotted) {
+            out.push(dotted);
+        }
+    }
+    out
+}
+
 /// Resolve a tool's `x-google-scopes` list to one dotted scope string.
 ///
 /// Why: `DiscoveredTool.scope` is a single `String` (the shape every
@@ -253,5 +281,43 @@ mod tests {
             dotted_scope_for_google_scopes(&s(&["https://www.googleapis.com/auth/unknown.thing"])),
             None
         );
+    }
+
+    /// #3987: the vocabulary must name every family the table maps, and must
+    /// collapse the several OAuth URLs that share a family/access pair.
+    #[test]
+    fn known_dotted_scopes_covers_every_family() {
+        let vocab = known_dotted_scopes();
+        for expected in [
+            "google.docs.write",
+            "google.sheets.write",
+            "google.slides.write",
+            "google.calendar.write",
+            "google.gmail.write",
+            "google.drive.write",
+            "google.tasks.write",
+            "google.accounts.read",
+        ] {
+            assert!(
+                vocab.iter().any(|s| s == expected),
+                "vocabulary is missing {expected}: {vocab:?}"
+            );
+        }
+        let mut deduped = vocab.clone();
+        deduped.sort();
+        deduped.dedup();
+        assert_eq!(
+            deduped.len(),
+            vocab.len(),
+            "vocabulary must be deduplicated"
+        );
+    }
+
+    /// #3987 the point of the whole exercise: `google.read` — the base
+    /// assistant's declared pattern — is not in the vocabulary and cannot be,
+    /// because `FAMILY_TABLE` only ever emits three-segment scopes.
+    #[test]
+    fn known_dotted_scopes_never_contains_the_dead_google_read_pattern() {
+        assert!(!known_dotted_scopes().iter().any(|s| s == "google.read"));
     }
 }

--- a/crates/trusty-agents/src/tools/registry/mod.rs
+++ b/crates/trusty-agents/src/tools/registry/mod.rs
@@ -70,17 +70,47 @@ impl ToolRegistryBuilder {
     /// Why: Each endpoint contributes zero or more executors (one per
     /// discovered tool that survives scope filtering). Endpoint-level
     /// failures degrade gracefully: log a warning and continue.
-    /// What: Iterates `endpoints`, instantiates the driver, runs
-    /// `rpc.discover` if `eager_discovery = true` (otherwise skips —
-    /// non-eager endpoints contribute nothing until lazy discovery is
-    /// wired in a follow-up), filters tools by the operator-declared
-    /// scope patterns, and wraps each surviving tool in a
-    /// `RegistryToolExecutor`.
+    /// What: Thin wrapper over [`Self::build_with_scope_vocabulary`] that
+    /// discards the vocabulary — for the callers that only register tools.
     pub async fn build(self) -> Result<Vec<Arc<dyn ToolExecutor>>> {
+        Ok(self.build_with_scope_vocabulary().await?.0)
+    }
+
+    /// Build the executors AND report the scope vocabulary every endpoint
+    /// advertised, BEFORE operator scope filtering (#3987).
+    ///
+    /// Why: `dead_scope`'s diagnostic needs to know what an endpoint COULD
+    /// advertise, not what an operator's `[[endpoints]].scopes` policy let
+    /// through. Those differ, and the difference is a false-positive
+    /// generator: an operator who narrows a non-Google endpoint to, say,
+    /// `memory.read` makes the `memory` namespace *known* (so
+    /// `dead_scope`'s namespace guard starts judging it) while
+    /// simultaneously removing `memory.write` from the registry — and an
+    /// agent's perfectly legitimate `memory.write` grant would then be
+    /// reported dead, with "nearest reachable: memory.read" as advice that
+    /// silently recommends dropping a capability the operator deliberately
+    /// revoked. Denied-by-policy and cannot-possibly-exist are different
+    /// conditions and must not share a diagnostic. Returning the
+    /// UNFILTERED vocabulary keeps `dead_scope` reporting only the latter.
+    ///
+    /// **This property must hold before the diagnostic is escalated to a
+    /// hard load error** (see `dead_scope`'s module doc): failing a load
+    /// closed on an operator's own narrowing policy would turn a
+    /// deliberate configuration choice into an outage.
+    /// What: same work as `build`, plus a de-duplicated, sorted list of every
+    /// non-empty `scope` string in every successfully-discovered endpoint
+    /// manifest. Discovery runs exactly once per endpoint — the vocabulary is
+    /// collected from the same manifest the filter consumes, never by a second
+    /// `rpc.discover` call.
+    /// Test: `unfiltered_vocabulary_survives_operator_scope_narrowing`.
+    pub async fn build_with_scope_vocabulary(
+        self,
+    ) -> Result<(Vec<Arc<dyn ToolExecutor>>, Vec<String>)> {
         let Some(cfg) = self.config else {
-            return Ok(Vec::new());
+            return Ok((Vec::new(), Vec::new()));
         };
         let mut executors: Vec<Arc<dyn ToolExecutor>> = Vec::new();
+        let mut vocabulary: std::collections::BTreeSet<String> = Default::default();
 
         for ep in &cfg.endpoints {
             if !ep.enabled {
@@ -88,13 +118,15 @@ impl ToolRegistryBuilder {
                 continue;
             }
             match build_endpoint(ep).await {
-                Ok(mut endpoint_executors) => {
+                Ok((mut endpoint_executors, advertised)) => {
                     tracing::info!(
                         endpoint = %ep.name,
                         count = endpoint_executors.len(),
+                        advertised_scopes = advertised.len(),
                         "tool registry: endpoint contributed tools",
                     );
                     executors.append(&mut endpoint_executors);
+                    vocabulary.extend(advertised);
                 }
                 Err(e) => {
                     tracing::warn!(
@@ -106,13 +138,17 @@ impl ToolRegistryBuilder {
             }
         }
 
-        Ok(executors)
+        Ok((executors, vocabulary.into_iter().collect()))
     }
 }
 
-/// Build executors for one endpoint. Returns an error if the driver itself
-/// fails to construct or eager discovery is requested and fails.
-async fn build_endpoint(ep: &EndpointConfig) -> Result<Vec<Arc<dyn ToolExecutor>>> {
+/// Build executors for one endpoint, plus the scope vocabulary it advertised
+/// BEFORE operator filtering (#3987 — see
+/// [`ToolRegistryBuilder::build_with_scope_vocabulary`]).
+///
+/// Returns an error if the driver itself fails to construct or eager
+/// discovery is requested and fails.
+async fn build_endpoint(ep: &EndpointConfig) -> Result<(Vec<Arc<dyn ToolExecutor>>, Vec<String>)> {
     let driver: ArcDriver = match ep.driver {
         DriverKind::Direct => Arc::new(DirectDriver::new(ep)?),
         DriverKind::StdioMcp => {
@@ -131,10 +167,23 @@ async fn build_endpoint(ep: &EndpointConfig) -> Result<Vec<Arc<dyn ToolExecutor>
             endpoint = %ep.name,
             "tool registry: lazy discovery not yet implemented; endpoint contributes 0 tools",
         );
-        return Ok(Vec::new());
+        return Ok((Vec::new(), Vec::new()));
     }
 
     let manifest = driver.discover().await?;
+
+    // #3987: captured BEFORE the operator scope filter below, on purpose —
+    // this is what the endpoint CAN advertise, which is the only honest
+    // baseline for "could this pattern ever match anything". Tools whose
+    // scope could not be derived carry `""` (see `discovery::method_to_tool`,
+    // which warns) and are excluded: an empty string is a discovery failure,
+    // not a vocabulary entry.
+    let advertised_scopes: Vec<String> = manifest
+        .tools
+        .iter()
+        .filter(|t| !t.scope.trim().is_empty())
+        .map(|t| t.scope.clone())
+        .collect();
 
     // #3577: zero tools from a manifest we successfully understood is a
     // DIFFERENT condition from zero tools because the wire shape didn't
@@ -186,7 +235,7 @@ async fn build_endpoint(ep: &EndpointConfig) -> Result<Vec<Arc<dyn ToolExecutor>
         })
         .collect();
 
-    Ok(executors)
+    Ok((executors, advertised_scopes))
 }
 
 #[cfg(test)]
@@ -275,6 +324,58 @@ mod tests {
         assert!(kept.iter().any(|t| t.name == "gmail_read"));
         assert!(kept.iter().any(|t| t.name == "cal_write"));
         assert!(!kept.iter().any(|t| t.name == "outlook_read"));
+    }
+
+    /// #3987: the scope vocabulary `build_endpoint` reports must be the
+    /// endpoint's ADVERTISED set, unaffected by the operator's narrowing.
+    ///
+    /// Why: this is the property that keeps `dead_scope` from reporting a
+    /// grant the operator deliberately revoked as a broken pattern. The
+    /// executors ARE narrowed (policy is enforced); only the vocabulary the
+    /// diagnostic reasons over stays whole.
+    #[tokio::test]
+    async fn unfiltered_vocabulary_survives_operator_scope_narrowing() {
+        let manifest = EndpointManifest {
+            server: ServerInfo::default(),
+            protocol_version: "openrpc/1".into(),
+            capabilities: EndpointCapabilities::default(),
+            tools: vec![
+                tool("mem_read", "memory.read"),
+                tool("mem_write", "memory.write"),
+                // A tool whose scope could not be derived: excluded from the
+                // vocabulary, since `""` is a discovery failure not a scope.
+                tool("mystery", ""),
+            ],
+        };
+        // Reproduce `build_endpoint`'s two computations against a narrowing
+        // operator policy that admits only `memory.read`.
+        let advertised: Vec<String> = manifest
+            .tools
+            .iter()
+            .filter(|t| !t.scope.trim().is_empty())
+            .map(|t| t.scope.clone())
+            .collect();
+        let patterns = vec![ScopePattern::new("memory.read")];
+        let filtered = filter_by_endpoint_scopes(&patterns, &manifest.tools, |t| &t.scope);
+
+        assert_eq!(
+            filtered.len(),
+            1,
+            "operator policy must still be enforced on the executors"
+        );
+        assert_eq!(
+            advertised,
+            vec!["memory.read".to_string(), "memory.write".to_string()],
+            "the reported vocabulary must survive the narrowing (and drop empty scopes)"
+        );
+
+        // End to end: the narrowed endpoint must not make `memory.write` look
+        // dead once the advertised vocabulary is unioned in.
+        let reachable = self::dead_scope::reachable_scopes(advertised.iter().map(String::as_str));
+        assert!(
+            self::dead_scope::dead_scope_patterns(&[ScopePattern::new("memory.write")], &reachable)
+                .is_empty()
+        );
     }
 
     #[tokio::test]

--- a/crates/trusty-agents/src/tools/registry/mod.rs
+++ b/crates/trusty-agents/src/tools/registry/mod.rs
@@ -19,6 +19,11 @@
 
 pub mod adapter;
 pub mod config;
+// #3987 (option C): dead scope-pattern diagnostics. Lives beside `scope`
+// because it is the "why did this pattern match nothing" half of the same
+// matching model, but is kept in its own module so the pure matcher stays
+// free of vocabulary knowledge.
+pub mod dead_scope;
 pub mod direct;
 pub mod discovery;
 pub mod driver;

--- a/crates/trusty-agents/src/tools/registry/scope.rs
+++ b/crates/trusty-agents/src/tools/registry/scope.rs
@@ -18,7 +18,12 @@
 use serde::{Deserialize, Serialize};
 
 /// A concrete scope advertised by a discovered tool, e.g. `google.gmail.read`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+///
+/// #3987: `Ord`/`PartialOrd` are derived so a reachable-scope vocabulary can
+/// live in a `BTreeSet` — `dead_scope` needs set membership AND a stable,
+/// sorted iteration order, because the "nearest reachable scopes" it puts in
+/// a warning must not reshuffle between runs.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct Scope(String);
 
 impl Scope {

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
@@ -116,6 +116,7 @@ const SKILLS_PAYLOAD = {
   unmatched_patterns: [
     { pattern: 'gworkspace_*', reason: 'may resolve to an MCP tool at dispatch time' },
   ],
+  dead_scope_patterns: [],
   declares_capability: true,
 };
 
@@ -160,6 +161,7 @@ function stubBareApiWithFailingStores() {
               granted_count: 0,
               unresolved: [],
               unmatched_patterns: [],
+              dead_scope_patterns: [],
               declares_capability: false,
             }
           : { name: 'bare', display_name: 'Bare', tools_allow: [], scopes: [] };

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
@@ -48,6 +48,10 @@
   // #4024's ticket; until then a bundle is simply not shown.
   $: leaves = all.filter((s) => s.kind !== 'function');
   $: granted = leaves.filter((s) => s.granted);
+  // #3987: scope grants that can match nothing. Defaulted like every array
+  // above so an older sidecar (which has no such field) renders the rest of
+  // the pane rather than throwing.
+  $: deadScopes = data?.dead_scope_patterns ?? [];
   $: actions = granted.filter((s) => s.kind === 'action');
   $: knowledge = granted.filter((s) => s.kind === 'knowledge');
   $: system = granted.filter((s) => s.kind === 'system');
@@ -177,6 +181,36 @@
         {#each unresolved as u (u.id)}
           <p class="mt-1 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
             <code class="font-mono">{u.id}</code> — {u.reason}
+          </p>
+        {/each}
+      </div>
+    {/if}
+
+    <!--
+      #3987: dead scope grants. Given the SAME visual weight as
+      "Unresolved skill grants" above rather than the muted `details`
+      treatment used for `unmatched_patterns` below, because the two are not
+      equally severe: an unmatched allow-pattern MAY still resolve to a
+      live-discovered MCP tool, whereas a dead scope pattern conclusively
+      denies every scoped tool it names. Without this the pane would render
+      those tools as granted cards while dispatch silently drops them — the
+      exact confusion this issue exists to end.
+    -->
+    {#if deadScopes.length > 0}
+      <div class="rounded-md border border-foundry-amber/40 px-3 py-2">
+        <h4 class="font-mono text-[10px] uppercase tracking-wide text-foundry-amber">
+          Dead scope grants ({deadScopes.length})
+        </h4>
+        {#each deadScopes as d (d.pattern)}
+          <p class="mt-1 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
+            <code class="font-mono">{d.pattern}</code> — {d.reason}
+            {#if d.nearest.length > 0}
+              <span class="block mt-0.5">
+                Nearest reachable: {#each d.nearest as n, i (n)}<code class="font-mono"
+                    >{n}</code
+                  >{i < d.nearest.length - 1 ? ', ' : ''}{/each}
+              </span>
+            {/if}
           </p>
         {/each}
       </div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
@@ -41,6 +41,7 @@ function payload(over: Partial<AgentSkills> = {}): AgentSkills {
     groups: [],
     unresolved: [],
     unmatched_patterns: [],
+    dead_scope_patterns: [],
     declares_capability: true,
     ...over,
   };
@@ -193,6 +194,33 @@ describe('AgentConfigSkills', () => {
     expect(details).not.toBeNull();
     expect(details.open).toBe(false);
     expect(details.textContent).toContain('granola_*');
+  });
+
+  // #3987: a dead scope grant denies every scoped tool it names, so it gets
+  // the same prominent treatment as an unresolved grant — NOT the collapsed
+  // `details` an unmatched allow-pattern gets, which may still resolve.
+  it('surfaces a dead scope grant prominently, with actionable alternatives', () => {
+    render(
+      payload({
+        dead_scope_patterns: [
+          {
+            pattern: 'google.read',
+            nearest: ['google.gmail.write', 'google.calendar.write'],
+            reason: 'no reachable tool advertises a scope matching this pattern',
+          },
+        ],
+      }),
+    );
+    expect(target.textContent).toContain('Dead scope grants (1)');
+    expect(target.textContent).toContain('google.read');
+    expect(target.textContent).toContain('google.gmail.write');
+    // Not hidden behind a disclosure triangle the way `unmatched_patterns` is.
+    expect(target.querySelector('details')).toBeNull();
+  });
+
+  it('renders nothing about dead scopes for a healthy agent', () => {
+    render(payload());
+    expect(target.textContent).not.toContain('Dead scope grants');
   });
 
   it('states the deny polarity for an agent that declares no capability', () => {

--- a/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
@@ -155,6 +155,7 @@ describe('fetchAgentSkills', () => {
       granted_count: 1,
       unresolved: [],
       unmatched_patterns: [],
+      dead_scope_patterns: [],
       declares_capability: true,
     };
     globalThis.fetch = (async () =>

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -400,6 +400,16 @@ export interface AgentSkills {
   unresolved: { id: string; reason: string }[];
   /** Allow-patterns no catalog tool matches — may still resolve over MCP. */
   unmatched_patterns: { pattern: string; reason: string }[];
+  /**
+   * `[tools].scopes` patterns that can match NO reachable dotted scope
+   * (#3987). Unlike `unmatched_patterns` — which may still resolve to a
+   * live-discovered MCP tool — these are conclusively broken: every scoped
+   * tool the grant was meant to permit is denied at dispatch, which looks
+   * exactly like "this agent has no tools". `nearest` carries working
+   * alternatives in the same namespace, so the pane can be actionable rather
+   * than merely alarming. Render it as a WARNING, not as an aside.
+   */
+  dead_scope_patterns: { pattern: string; nearest: string[]; reason: string }[];
   /** `false` when the agent declares no capability at all (grants nothing). */
   declares_capability: boolean;
   config_error?: string;


### PR DESCRIPTION
## What

Issue #3987, **option C** — the half Bob directed to land first, ahead of option B. A `[tools].scopes` pattern that can match no reachable dotted scope is now detected and surfaced loudly instead of silently denying every scoped tool it was meant to grant.

`ScopePattern` matching fails **closed and silent**: `agent_can_use` returns `false`, `filter_persona_tool_names` drops the name, and nothing anywhere says why. The observable result is identical to "this agent has no tools" — which is precisely how #3938 and #3987 both survived undetected and cost real debugging time.

The motivating instance: the bundled base `assistant` declares `google.read`. Discovery only ever emits `google.<family>.<access>` (`registry::google_scope::FAMILY_TABLE`), and `google.read` is a no-wildcard pattern requiring string equality, so it matches nothing in the vocabulary — all 60 of the base's allowlisted gworkspace tools are scope-denied on the persona-chat path.

## Check site — decision and rationale

The check runs at **persona registry build time**, in `ctrl::pm_task::dispatch::persona::run_pm_task_with_persona`, immediately before the `filter_persona_tool_names` gate that would otherwise drop the surface in silence.

Why there and not in the TOML loader (`agents/loader.rs`) or in `ToolRegistryBuilder::build`:

- **The loader has only one half of the intersection.** It knows the agent's declared patterns but nothing about the scope vocabulary — it cannot tell `google.read` (dead) from `memory.read` (live, served by a daemon it has never heard of). A loader-sited check would either need to hardcode the vocabulary (drift) or refuse to judge anything (useless).
- **`ToolRegistryBuilder::build` has the other half only.** It knows the endpoint manifests but not which agent is about to use them; it is built once per dispatch and shared, and agent patterns arrive later.
- **The dispatch site holds both**, and holds them in their *resolved* form — the post-`extends` union that the enforcement gate itself uses, so the diagnostic describes exactly the set the gate applies. That co-location is the same reason #3208's enforcement lives there.

The static-vocabulary half (`google_scope::known_dotted_scopes`) is nonetheless derived from `FAMILY_TABLE` rather than only from a live `rpc.discover`, which is what lets the API route and the unit tests reach the same verdict with no daemon running.

### No false positives, by construction

"Reachable" is the union of (1) the scopes the live registry discovered this run and (2) the closed compile-time vocabulary this build can emit for namespaces it owns (today just `google`). On top of that union sits a **namespace guard**: a pattern is only judged when its first segment appears in the reachable set at all.

That combination is what makes the diagnostic safe to leave on:

| situation | verdict | why |
|---|---|---|
| `google.read`, gworkspace down | **dead** | static vocabulary proves it can never match |
| `google.gmail.*`, gworkspace down | not flagged | static vocabulary supplies `google.gmail.write` |
| `memory.read`, trusty-memory down | **not judged** | `memory` namespace unknown → not enough information |
| `memory.recall`, trusty-memory up | **dead** | namespace is now known and nothing matches |
| `google.*.read` (middle wildcard) | **dead** | `ScopePattern` rejects middle wildcards by design |

A daemon merely being offline can never make a working grant look broken — which matters, because a diagnostic that cries wolf is one that gets ignored, and that would put us right back where #3938 started.

## Surfaces

- **Log (registry build time).** One `warn!` per agent naming the agent, each dead pattern, and its **nearest reachable scopes** in the same namespace. The line also spells out the confusion it exists to break ("which looks identical to 'this agent has no tools'") and calls out that middle wildcards always match nothing, since `google.*.read` is the exact thing someone reaches for when told "read-only Google".
- **Config introspection.** `GET /api/agents/{name}/skills` gained a `dead_scope_patterns` array — `{ pattern, nearest, reason }` — the scope-side analogue of the existing `unmatched_patterns`, and added for the same reason that route documents: a panel showing `granted: true` cards for tools the dispatch gate will drop is the audit-surface form of the very lie this issue is about. Always present, empty for a healthy agent, so a client can check `.length` without special-casing `undefined`. The route reads the agent's own file without resolving `extends` (its existing partial-read posture), so it under-reports inherited dead patterns rather than over-reporting — the correct failure direction for an audit surface, and the dispatch-time `warn!` covers the inherited case with the resolved set.

## Sequencing constraint — warning, NOT a hard error (yet)

This deliberately does not fail the load. The shipped base `assistant` **is** the agent carrying the dead pattern, and every `extends = "assistant"` overlay inherits it by union, so failing closed here would break every assistant load — including the default persona — on the commit that added the check.

Escalation to a hard load error is the intended follow-up **after** #3987's option B removes `google.read` from the shipped base and no bundled agent trips the diagnostic. That intent is recorded in three places so it cannot be lost: `dead_scope`'s module doc ("Warning today, hard error later"), the `persona.rs` call site, and the shipped-config test below.

## Tests

- `tools::registry::dead_scope::tests` — dead pattern detected with actionable suggestions; live wildcard and live exact patterns not flagged; unknown namespace never judged; a namespace known only from live scopes *is* judged; middle wildcard flagged; namespaceless pattern skipped; empty discovery scopes dropped; suggestion cap.
- `google_scope::tests::known_dotted_scopes_covers_every_family` / `…_never_contains_the_dead_google_read_pattern`.
- `persona_tests::base_assistant_google_read_is_a_dead_scope_pattern` — pinned against the **shipped** base template through the real loader, so it fires on the real defect and not a synthetic fixture. **This test is updated by option B**, whose acceptance criterion is that the assertion inverts to "the base assistant has no dead scope patterns". Its passing today is exactly why the posture above is a warning.
- `persona_tests::shipped_agents_with_live_google_patterns_are_not_flagged` — `izzie`'s blanket `google.*` and `cto-assistant`'s narrow `google.gmail.*` / `google.tasks.*` (#3985) must never be flagged.
- `api::server::tests::agent_skills::skills_route_reports_dead_scope_patterns` and `…_for_a_healthy_agent` — the field is really in the response body, not merely computable.

## Gates (raw)

```
$ cargo fmt --check
cargo fmt --check exit=0

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
   Compiling trusty-agents v0.38.6 (/private/tmp/wt-3987-c/crates/trusty-agents)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 42.60s

$ cargo test -p trusty-agents
test result: ok. 2647 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 40.65s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 4 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ bash scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 46 spec doc(s) + 2888 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.
```

## Follow-up

Option B (`fix-3987-base-assistant-explicit-grants`) lands next and replaces the base assistant's `google.read` with explicit family grants; it updates the shipped-config test here. #3987 also tracks the deferred option A (a genuine read tier requiring `.readonly` OAuth variants and user re-consent), so this PR does not resolve the issue.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
