### PR TITLE
feat(trusty-agents): attach arbitrary search indexes + enumerate/enforce them in vector_search

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -81,6 +81,49 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Agents can attach arbitrary trusty-search indexes, and `vector_search` now
+  advertises them** (issues #3232, #4009; part of epic #4007): an agent's
+  `[[stores]]` binding is the *curated* knowledge tier — one OKG store per
+  agent, and that stays. Everything else an agent should be able to search (a
+  third-party repo, a shared doc corpus) now has a second, uncurated tier:
+  `[tools] search_indexes = ["apex", "cto-projects"]`, a plain list of
+  trusty-search index ids with no tree, palace, or ingestion behind them. The
+  list unions base-first through `extends` exactly like `[tools].allow` and
+  `scopes`, so a CTO Assistant extending a base Assistant adds `cto-projects`
+  without re-declaring — or being able to silently drop — what the base
+  attached, and it is reported by `GET /api/agents/:name/stores` (alongside the
+  curated stores, not mixed into them) and in the agent catalog. Those two
+  `/stores` fields — `search_indexes` and `enforce_search_indexes` — are an
+  **interim raw surface** licensed by DOC-58 §5: the resolved declared list and
+  the knob state, with no daemon probe behind either. The forthcoming
+  `/knowledge.attached_indexes[]` route is the probed, authoritative surface
+  for the GUI. Both must report the same id set, so declaring one id in *both*
+  tiers — legal, and accepted by the tool from either — is deduped server-side
+  and presented once under its bound role.
+
+  `vector_search` reads that list twice over. Its `index_id` schema description
+  now **enumerates** the agent's bound store plus every attached index, closing
+  the discoverability half of #4009: querying another corpus was always
+  mechanically possible, but the model had to *guess* an id that happened to
+  exist because the tool advertised no list. Second, `[tools]
+  enforce_search_indexes = true` turns that same list into a fail-closed
+  allowlist — an explicit `index_id` outside `{bound store} ∪ search_indexes`
+  is refused with an error naming the permitted set, and is deliberately **not**
+  degraded to the local index, since answering a refused request from a
+  different corpus is worse than refusing.
+
+  **Enforcement is opt-in and defaults to off** (owner decision on epic #4007's
+  OQ-2 — declarative-only at M1). `vector_search` has never gated `index_id` in
+  production, so failing closed by default would break every persona that
+  cross-queries today. An agent that is unenforced *and* declares no attached
+  indexes is byte-identical to before: the same resolution path, and a schema
+  whose bytes are pinned unchanged by test, since a tool definition is prompt
+  input and drift there would alter every existing agent's context. An
+  **enforced** agent's schema always states the restriction, including the
+  bound-store-only lockdown case (`[[stores]]` + `enforce = true` + no
+  `search_indexes`) — the schema describes what the tool accepts, so silence
+  there would advertise an open corpus over closed behaviour.
+
 - **`GET /api/events` can scope the Slack mirror to one channel** (refs #3760):
   `SlackMessageReceived` / `SlackReplySent` carry no `session_id`, and
   `/api/events` treats a missing session as "always include", so every

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -261,9 +261,85 @@ pub struct ToolsConfig {
     /// `tools_config_parses_*` cases when the field is present.
     #[serde(default)]
     pub scopes: Option<Vec<String>>,
+
+    /// Arbitrary trusty-search indexes attached to this agent (#3232, epic
+    /// #4007's tier-2 mechanism).
+    ///
+    /// Why: `[[stores]]` is the CURATED tier — exactly one OKG store per
+    /// agent by the 2026-07-24 owner decision, and that ceiling stays. The
+    /// multiplicity an agent needs ("also let me search the APEX repo")
+    /// belongs to a second, uncurated tier: a plain list of trusty-search
+    /// `index_id`s over any corpus, with no OKG tree, palace, or ingestion
+    /// requirement behind them. Declaring them in config (rather than
+    /// leaving the model to guess an id that happens to exist) is what makes
+    /// them discoverable — `vector_search`'s schema enumerates this list
+    /// (#4009) so the model sees real, queryable options.
+    /// What: Optional list of index ids (`["apex", "cto-projects"]`).
+    /// `None` (missing section/field) means "no attached indexes" and is the
+    /// pre-#3232 state exactly. Unioned base-first through `extends` — like
+    /// `allow`/`scopes`, an overlay ADDS reach and never silently removes
+    /// what its base attached. Use [`Self::resolved_search_indexes`] rather
+    /// than reading the field directly, so blank ids and duplicates from a
+    /// hand-edited file are normalized once.
+    /// Test: `tools_config_parses_search_indexes`,
+    /// `extends_unions_search_indexes`,
+    /// `resolved_search_indexes_normalizes_blanks_and_dupes`.
+    #[serde(default)]
+    pub search_indexes: Option<Vec<String>>,
+
+    /// Opt-in allowlist enforcement for `vector_search`'s `index_id` (#4009).
+    ///
+    /// Why: Owner decision on epic #4007's OQ-2 — enforcement is OPT-IN with
+    /// declarative-only as the default at M1. Today `vector_search` forwards
+    /// ANY `index_id` string to the daemon unchecked; flipping that to
+    /// fail-closed by default would silently break every persona that
+    /// currently cross-queries an index it never declared. So the default is
+    /// `false` = today's behaviour, byte-identical; an operator who wants a
+    /// hard boundary sets `[tools] enforce_search_indexes = true` and gets a
+    /// fail-closed allowlist of `{bound OKG index} ∪ search_indexes`.
+    /// Schema enrichment (#4009's other half) ships regardless of this flag.
+    /// What: `Option<bool>`, read through [`Self::search_indexes_enforced`].
+    /// `None`/`Some(false)` = declarative-only. Through `extends`, a child
+    /// that declares the key wins; a child that omits it inherits the base's
+    /// posture (so a hardened base stays hardened under an overlay).
+    /// Test: `tools_config_parses_enforce_search_indexes`,
+    /// `extends_child_overrides_enforce_search_indexes`,
+    /// `vector_search_default_is_unenforced`.
+    #[serde(default)]
+    pub enforce_search_indexes: Option<bool>,
 }
 
 impl ToolsConfig {
+    /// The agent's attached search indexes, normalized (#3232).
+    ///
+    /// Why: The field is hand-editable TOML and is produced by a union
+    /// merge, so it can carry blanks (`""`, `"  "`) and — across a deep
+    /// `extends` chain re-declaring the same id — duplicates. Normalizing at
+    /// the single read point means neither the tool schema nor the API
+    /// response has to re-derive the rule.
+    /// What: Trimmed, blank-dropped, first-occurrence-wins dedup, declaration
+    /// order preserved. Empty vec when the field is absent.
+    /// Test: `resolved_search_indexes_normalizes_blanks_and_dupes`.
+    pub fn resolved_search_indexes(&self) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for id in self.search_indexes.iter().flatten() {
+            let id = id.trim();
+            if id.is_empty() || out.iter().any(|e| e == id) {
+                continue;
+            }
+            out.push(id.to_string());
+        }
+        out
+    }
+
+    /// Whether `vector_search` should fail closed on an undeclared index id
+    /// (#4009). Absent = `false` = today's behaviour.
+    ///
+    /// Test: `tools_config_parses_enforce_search_indexes`.
+    pub fn search_indexes_enforced(&self) -> bool {
+        self.enforce_search_indexes.unwrap_or(false)
+    }
+
     /// Whether the AST-native tool bundle should be registered for this agent.
     ///
     /// Why: There are two equally-valid TOML spellings (`[tools] ast_native = true`

--- a/crates/trusty-agents/src/agents/extends/mod.rs
+++ b/crates/trusty-agents/src/agents/extends/mod.rs
@@ -290,6 +290,20 @@ pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
     merged.tools.allowed = union_opt_vec(merged.tools.allowed, child.tools.allowed);
     merged.tools.allow = union_opt_vec(merged.tools.allow, child.tools.allow);
     merged.tools.scopes = union_opt_vec(merged.tools.scopes, child.tools.scopes);
+    // #3232: `[tools].search_indexes` — attached trusty-search indexes, the
+    // tier-2 knowledge mechanism (epic #4007). Same base-first union as
+    // `allow`/`scopes` for the same reason, and it is the overlay case the
+    // ticket names: a base Assistant attaches its project index, a CTO
+    // Assistant extending it unions in `cto-projects` WITHOUT re-declaring
+    // (or being able to silently drop) the base's.
+    merged.tools.search_indexes =
+        union_opt_vec(merged.tools.search_indexes, child.tools.search_indexes);
+    // #4009: `enforce_search_indexes` is a posture, not a list — child
+    // child-declares-wins (an overlay may harden or relax), child-omits
+    // inherits, so a hardened base stays hardened under a silent overlay.
+    if child.tools.enforce_search_indexes.is_some() {
+        merged.tools.enforce_search_indexes = child.tools.enforce_search_indexes;
+    }
     // `[skills].allow` (#3933): same base-first union as `[tools].allow`, for
     // the same reason — an overlay ADDS capability to its base and must never
     // silently remove what the base granted.

--- a/crates/trusty-agents/src/agents/extends/tests.rs
+++ b/crates/trusty-agents/src/agents/extends/tests.rs
@@ -436,6 +436,145 @@ scopes = ["memory.read", "search.read"]
     );
 }
 
+/// #3232: the ticket's own worked example — a base Assistant attaches its
+/// project index; a CTO Assistant extending it unions in `cto-projects`
+/// WITHOUT re-declaring the base's and without being able to silently drop
+/// it. Same base-first-union-with-dedup contract as `allow`/`scopes`.
+#[test]
+fn extends_unions_search_indexes() {
+    let base = cfg(r#"
+[agent]
+name = "assistant"
+role = "r"
+model = "m"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "b"
+[tools]
+search_indexes = ["trusty-tools", "shared-docs"]
+"#);
+    let ch = cfg(r#"
+[agent]
+name = "cto-assistant"
+role = "agent"
+model = ""
+description = ""
+extends = "assistant"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "c"
+[tools]
+search_indexes = ["shared-docs", "cto-projects", "apex"]
+"#);
+    let merged = merge_extends(base, ch);
+    assert_eq!(
+        merged.tools.resolved_search_indexes(),
+        vec!["trusty-tools", "shared-docs", "cto-projects", "apex"],
+        "base-first union, dedup — the overlay may only ADD reach"
+    );
+}
+
+/// #3232: a child that declares nothing keeps its base's attached indexes;
+/// a base that declares nothing does not erase the child's. Mirrors
+/// `extends_union_none_cases` for the pre-existing list fields.
+#[test]
+fn extends_search_indexes_none_cases() {
+    let mk = |name: &str, extends: &str, line: &str| {
+        cfg(&format!(
+            r#"
+[agent]
+name = "{name}"
+role = "agent"
+model = "m"
+description = "d"
+{extends}
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "x"
+[tools]
+{line}
+"#
+        ))
+    };
+    // Child silent → inherits the base's list.
+    let merged = merge_extends(
+        mk("base", "", "search_indexes = [\"apex\"]"),
+        mk("child", "extends = \"base\"", ""),
+    );
+    assert_eq!(merged.tools.resolved_search_indexes(), vec!["apex"]);
+    // Base silent → the child's own list survives.
+    let merged = merge_extends(
+        mk("base", "", ""),
+        mk("child", "extends = \"base\"", "search_indexes = [\"apex\"]"),
+    );
+    assert_eq!(merged.tools.resolved_search_indexes(), vec!["apex"]);
+    // Neither declares → still absent (the pre-#3232 state).
+    let merged = merge_extends(mk("base", "", ""), mk("child", "extends = \"base\"", ""));
+    assert!(merged.tools.search_indexes.is_none());
+    assert!(!merged.tools.search_indexes_enforced());
+}
+
+/// #4009: `enforce_search_indexes` is a POSTURE, not a list — so it does not
+/// union. A child that declares it wins (may harden or relax); a child that
+/// omits it inherits, so a hardened base cannot be silently un-hardened by
+/// an overlay that simply never mentions the key.
+#[test]
+fn extends_child_overrides_enforce_search_indexes() {
+    let mk = |name: &str, extends: &str, line: &str| {
+        cfg(&format!(
+            r#"
+[agent]
+name = "{name}"
+role = "agent"
+model = "m"
+description = "d"
+{extends}
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "x"
+[tools]
+search_indexes = ["apex"]
+{line}
+"#
+        ))
+    };
+    // Hardened base + silent child → stays hardened.
+    let merged = merge_extends(
+        mk("base", "", "enforce_search_indexes = true"),
+        mk("child", "extends = \"base\"", ""),
+    );
+    assert!(merged.tools.search_indexes_enforced());
+    // Hardened base + child explicitly relaxing → child wins.
+    let merged = merge_extends(
+        mk("base", "", "enforce_search_indexes = true"),
+        mk(
+            "child",
+            "extends = \"base\"",
+            "enforce_search_indexes = false",
+        ),
+    );
+    assert!(!merged.tools.search_indexes_enforced());
+    // Unenforced base + child hardening → child wins.
+    let merged = merge_extends(
+        mk("base", "", ""),
+        mk(
+            "child",
+            "extends = \"base\"",
+            "enforce_search_indexes = true",
+        ),
+    );
+    assert!(merged.tools.search_indexes_enforced());
+}
+
 #[test]
 fn extends_unions_listener_bindings_by_name() {
     let base = cfg(r#"

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -10,7 +10,7 @@
 pub(crate) mod loading;
 mod params;
 
-use crate::agents::AgentConfig;
+use crate::agents::{AgentConfig, ToolsConfig};
 
 #[test]
 fn llm_params_parses_model_override() {
@@ -389,6 +389,127 @@ allow = ["mcp_*", "git_log", "git_status"]
     );
     // `allowed` (legacy exact-match) is independent of `allow` (globs).
     assert!(cfg.tools.allowed.is_none());
+}
+
+/// #3232: `[tools] search_indexes = [...]` — the tier-2 attached-index list
+/// (epic #4007). Pinned alongside `allow`/`scopes` because all three are
+/// independent capability axes: declaring one must never imply another.
+#[test]
+fn tools_config_parses_search_indexes() {
+    let toml_str = r#"
+[agent]
+name = "cto-assistant"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+
+[tools]
+allow = ["vector_search"]
+search_indexes = ["apex", "cto-projects"]
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert_eq!(
+        cfg.tools.resolved_search_indexes(),
+        vec!["apex".to_string(), "cto-projects".to_string()]
+    );
+    // Independent axes: attaching indexes neither widens `allow` nor claims
+    // an OpenRPC scope.
+    assert_eq!(
+        cfg.tools.allow.as_deref(),
+        Some(&["vector_search".to_string()][..])
+    );
+    assert!(cfg.tools.scopes.is_none());
+}
+
+/// #3232/#4009 DEFAULT-STATE PIN: an agent that declares neither key must
+/// come out of parsing in exactly the pre-#3232 state — no attached indexes,
+/// enforcement OFF. This is the config-layer half of the "default off =
+/// today's behaviour" guarantee (its runtime half is
+/// `vector_search_default_is_unenforced`).
+#[test]
+fn tools_config_without_search_indexes_is_unattached_and_unenforced() {
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+
+[tools]
+allow = ["vector_search"]
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert!(cfg.tools.search_indexes.is_none());
+    assert!(cfg.tools.resolved_search_indexes().is_empty());
+    assert_eq!(cfg.tools.enforce_search_indexes, None);
+    assert!(!cfg.tools.search_indexes_enforced());
+    // An agent with NO `[tools]` table at all must land in the same state.
+    assert!(!ToolsConfig::default().search_indexes_enforced());
+    assert!(ToolsConfig::default().resolved_search_indexes().is_empty());
+}
+
+/// #4009: the opt-in enforcement knob parses and is readable through its
+/// accessor. Owner decision (epic #4007 OQ-2): opt-in, default false.
+#[test]
+fn tools_config_parses_enforce_search_indexes() {
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+
+[tools]
+search_indexes = ["apex"]
+enforce_search_indexes = true
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert_eq!(cfg.tools.enforce_search_indexes, Some(true));
+    assert!(cfg.tools.search_indexes_enforced());
+}
+
+/// #3232: `resolved_search_indexes` is the single normalization point — a
+/// hand-edited file (or a deep `extends` chain re-declaring an id) must never
+/// produce a blank index id, which would build a `/indexes//search` URL, nor
+/// a duplicate the schema would list twice.
+#[test]
+fn resolved_search_indexes_normalizes_blanks_and_dupes() {
+    let tools = ToolsConfig {
+        search_indexes: Some(vec![
+            "  apex  ".to_string(),
+            "".to_string(),
+            "   ".to_string(),
+            "apex".to_string(),
+            "cto-projects".to_string(),
+        ]),
+        ..Default::default()
+    };
+    assert_eq!(
+        tools.resolved_search_indexes(),
+        vec!["apex".to_string(), "cto-projects".to_string()],
+        "trimmed, blank-dropped, first-occurrence-wins dedup, order preserved"
+    );
 }
 
 #[test]

--- a/crates/trusty-agents/src/api/server/agent_stores.rs
+++ b/crates/trusty-agents/src/api/server/agent_stores.rs
@@ -12,8 +12,18 @@
 //! testable core taking the agents-dir list and both daemon base URLs
 //! explicitly (same injected-dependency convention as `agent_patch::*_at` and
 //! `workstreams::list_workstreams_at`). Response shape:
-//! `{"stores": [StoreStatus, …]}` — an empty array for an agent that binds
-//! nothing, which is a valid state, not an error. A daemon being down is
+//! `{"stores": [StoreStatus, …], "issues": […], "search_indexes": […],
+//! "enforce_search_indexes": bool}` — empty arrays for an agent that binds
+//! nothing, which is a valid state, not an error. `search_indexes` /
+//! `enforce_search_indexes` (#3232/#4009, epic #4007) are the second,
+//! UNCURATED knowledge tier: arbitrary trusty-search indexes attached to the
+//! agent, reported next to the curated OKG stores rather than mixed into
+//! them. Those two fields are an INTERIM RAW surface licensed by DOC-58 §5 —
+//! the resolved declared list and the knob state, with NO daemon probe behind
+//! either. The future `/knowledge.attached_indexes[]` route is the probed,
+//! authoritative surface for the GUI; both must report the same id set, which
+//! is why the overlap rule ([`attached_indexes_deduped`]) is applied
+//! server-side here. A daemon being down is
 //! likewise reported per-store, never as a route failure: this endpoint
 //! returns `200` whenever the agent resolves at all.
 //! Test: `super::tests::agent_stores`.
@@ -29,6 +39,7 @@ use axum::{
 
 use super::agent_patch::resolve_agent_paths;
 use super::state::AppState;
+use crate::agents::ToolsConfig;
 use crate::stores::{StoresConfig, resolve_store_statuses};
 
 /// `GET /api/agents/:name/stores` — HTTP entry point.
@@ -94,16 +105,60 @@ pub(super) async fn stores_at(
         }
     };
 
-    let (stores, config_error) = parse_stores(&raw);
+    let (stores, tools, config_error) = parse_stores(&raw);
     let statuses = resolve_store_statuses(name, &stores, search_base, memory_base).await;
     let mut body = serde_json::json!({
         "stores": statuses,
         "issues": stores.validate(),
+        // #3232/#4009 (epic #4007): the agent's TIER-2 knowledge — arbitrary
+        // trusty-search indexes attached via `[tools].search_indexes`,
+        // deliberately reported alongside (not inside) `stores`, because they
+        // carry none of a store's structure: no OKG tree, no palace, no
+        // curation. `enforce_search_indexes` reports whether that list gates
+        // `vector_search` or is declarative-only (the default), so a client
+        // never has to infer the posture from the list's presence.
+        //
+        // DOC-58 §5 (interim raw surface): both fields are RAW and
+        // non-authoritative — the declared list verbatim, with NO daemon
+        // probe. The future `/knowledge.attached_indexes[]` route is the
+        // probed, authoritative surface for the GUI; the two id sets must
+        // stay consistent, which is why the dedupe rule lives here rather
+        // than in each client.
+        "search_indexes": attached_indexes_deduped(&stores, &tools),
+        "enforce_search_indexes": tools.search_indexes_enforced(),
     });
     if let Some(err) = config_error {
         body["config_error"] = serde_json::Value::String(err);
     }
     (StatusCode::OK, Json(body)).into_response()
+}
+
+/// The attached tier-2 indexes MINUS any id already bound as an OKG store
+/// (#3232/#4009, DOC-58 §5's dedupe-by-id rule).
+///
+/// Why: Declaring the same index id in BOTH `[[stores]]` and
+/// `[tools].search_indexes` is legal — an operator may reasonably restate the
+/// bound index in the attach list, and enforcement (#4009) accepts it from
+/// either tier. But this response must present each id exactly ONCE, under
+/// its BOUND role: an id that is a curated store is a store, and echoing it
+/// again as an uncurated attachment would make the GUI render the same corpus
+/// twice with two different provenances. `VectorSearchTool::allowed_index_ids`
+/// resolves the identical overlap the identical way (bound first, deduped), so
+/// what this route reports and what the tool accepts cannot disagree.
+/// What: `ToolsConfig::resolved_search_indexes` (already trimmed/deduped)
+/// filtered against every binding's `resolved_index`.
+/// Test: `attached_indexes_deduped_presents_overlap_under_its_bound_role`.
+fn attached_indexes_deduped(stores: &StoresConfig, tools: &ToolsConfig) -> Vec<String> {
+    tools
+        .resolved_search_indexes()
+        .into_iter()
+        .filter(|id| {
+            !stores
+                .bindings
+                .iter()
+                .any(|b| b.resolved_index() == id.as_str())
+        })
+        .collect()
 }
 
 /// Parse just the `[[stores]]` table out of a raw `agent.toml`.
@@ -114,18 +169,28 @@ pub(super) async fn stores_at(
 /// `system_prompt.content` (it lives in `persona.md`). Deserializing only the
 /// field this endpoint needs keeps the route working for both file layouts,
 /// matching `parse_agent_toml`'s partial-read precedent.
-/// What: `(bindings, None)` on success; `(empty, Some(message))` when the
-/// file isn't valid TOML or its `stores` value has an unusable shape.
-/// Test: `parse_stores_reads_array_form`, `parse_stores_reports_bad_toml`.
-fn parse_stores(raw: &str) -> (StoresConfig, Option<String>) {
+/// What: `(bindings, tools, None)` on success; `(empty, empty, Some(message))`
+/// when the file isn't valid TOML or its `stores` value has an unusable shape.
+/// #3232: `[tools]` rides along in the same partial read because the tier-2
+/// attached indexes live there, and this endpoint reports BOTH tiers — one
+/// parse, one place for the two to disagree about the same file.
+/// Test: `parse_stores_reads_array_form`, `parse_stores_reports_bad_toml`,
+/// `parse_stores_reads_attached_search_indexes`.
+fn parse_stores(raw: &str) -> (StoresConfig, ToolsConfig, Option<String>) {
     #[derive(serde::Deserialize)]
     struct Partial {
         #[serde(default)]
         stores: StoresConfig,
+        #[serde(default)]
+        tools: ToolsConfig,
     }
     match toml::from_str::<Partial>(raw) {
-        Ok(p) => (p.stores, None),
-        Err(e) => (StoresConfig::default(), Some(e.to_string())),
+        Ok(p) => (p.stores, p.tools, None),
+        Err(e) => (
+            StoresConfig::default(),
+            ToolsConfig::default(),
+            Some(e.to_string()),
+        ),
     }
 }
 
@@ -144,7 +209,7 @@ name = "bob-kb"
 index = "bob-kb"
 palace = "owner-profile"
 "#;
-        let (stores, err) = parse_stores(raw);
+        let (stores, _tools, err) = parse_stores(raw);
         assert!(err.is_none());
         assert_eq!(stores.default_search_index(), Some("bob-kb"));
     }
@@ -154,14 +219,104 @@ palace = "owner-profile"
         // A package `agent.toml` has no `[system_prompt]` — parsing must not
         // require one (see this fn's doc comment).
         let raw = "[agent]\nname = \"x\"\n[tools]\nallow = [\"a\"]\n";
-        let (stores, err) = parse_stores(raw);
+        let (stores, _tools, err) = parse_stores(raw);
         assert!(err.is_none());
         assert!(stores.bindings.is_empty());
     }
 
+    /// #3232/#4009: the Knowledge endpoint reports BOTH tiers off one parse —
+    /// the curated `[[stores]]` binding and the arbitrary attached indexes —
+    /// and an agent may declare either without the other.
+    #[test]
+    fn parse_stores_reads_attached_search_indexes() {
+        let raw = r#"
+[agent]
+name = "cto-assistant"
+
+[[stores]]
+name = "cto-assistant"
+
+[tools]
+search_indexes = ["apex", "  ", "apex"]
+enforce_search_indexes = true
+"#;
+        let (stores, tools, err) = parse_stores(raw);
+        assert!(err.is_none());
+        assert_eq!(stores.default_search_index(), Some("cto-assistant"));
+        assert_eq!(tools.resolved_search_indexes(), vec!["apex".to_string()]);
+        assert!(tools.search_indexes_enforced());
+
+        // Tier-2 without tier-1, and the unattached default.
+        let (stores, tools, err) =
+            parse_stores("[agent]\nname = \"x\"\n[tools]\nsearch_indexes = [\"apex\"]\n");
+        assert!(err.is_none());
+        assert!(stores.bindings.is_empty());
+        assert_eq!(tools.resolved_search_indexes(), vec!["apex".to_string()]);
+        assert!(!tools.search_indexes_enforced());
+    }
+
+    /// DOC-58 §5 dedupe-by-id: an id declared in BOTH tiers is legal and is
+    /// presented ONCE, under its bound role — it stays in `stores` and is
+    /// filtered out of `search_indexes`, so the GUI never renders the same
+    /// corpus twice with two provenances.
+    #[test]
+    fn attached_indexes_deduped_presents_overlap_under_its_bound_role() {
+        let raw = r#"
+[agent]
+name = "cto-assistant"
+
+[[stores]]
+name = "cto-assistant"
+
+[tools]
+search_indexes = ["cto-assistant", "apex"]
+"#;
+        let (stores, tools, err) = parse_stores(raw);
+        assert!(
+            err.is_none(),
+            "restating the bound index is legal, not an error"
+        );
+        assert_eq!(stores.default_search_index(), Some("cto-assistant"));
+        assert_eq!(
+            attached_indexes_deduped(&stores, &tools),
+            vec!["apex".to_string()],
+            "the bound id is presented under its store role, not echoed as an attachment"
+        );
+        // The overlap is still queryable — the tool's allowlist accepts it
+        // from the bound tier, so the two surfaces agree on the id SET.
+        let allowed = crate::tools::memory::VectorSearchTool::new()
+            .with_default_index(stores.default_search_index().map(str::to_string))
+            .with_attached_indexes(tools.resolved_search_indexes())
+            .allowed_index_ids();
+        assert_eq!(
+            allowed,
+            vec!["cto-assistant".to_string(), "apex".to_string()]
+        );
+
+        // A binding whose explicit `index` differs from its `name` dedupes on
+        // the RESOLVED index, which is the id `vector_search` actually sends.
+        let raw = r#"
+[agent]
+name = "x"
+
+[[stores]]
+name = "store-label"
+index = "real-index"
+
+[tools]
+search_indexes = ["real-index", "store-label"]
+"#;
+        let (stores, tools, _) = parse_stores(raw);
+        assert_eq!(
+            attached_indexes_deduped(&stores, &tools),
+            vec!["store-label".to_string()],
+            "dedupe keys on resolved_index, not the store's display name"
+        );
+    }
+
     #[test]
     fn parse_stores_reports_bad_toml() {
-        let (stores, err) = parse_stores("this is not = = toml");
+        let (stores, _tools, err) = parse_stores("this is not = = toml");
         assert!(stores.bindings.is_empty());
         assert!(err.is_some());
     }

--- a/crates/trusty-agents/src/api/server/projects.rs
+++ b/crates/trusty-agents/src/api/server/projects.rs
@@ -416,6 +416,21 @@ pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_j
                 .collect()
         })
         .unwrap_or_default();
+    // #3232: `[tools].search_indexes` — the agent's attached tier-2
+    // trusty-search indexes (epic #4007). Surfaced here for the same reason
+    // `tools_allow`/`scopes` are: it is part of the agent's declared
+    // capability surface, and a client rendering "what can this agent reach"
+    // must not have to re-read the TOML itself. Same empty-array-not-absent
+    // convention as its neighbours.
+    let search_indexes: Vec<String> = tools
+        .and_then(|t| t.get("search_indexes"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(str::to_string))
+                .collect()
+        })
+        .unwrap_or_default();
     // #3819: `hidden` — listing-surface-only visibility flag (see
     // `AgentInfo::hidden`'s doc comment for why this is a dedicated field
     // rather than repurposing `role`). Defaults to `false` when absent.
@@ -437,6 +452,7 @@ pub(super) fn parse_agent_toml(raw: &str, fallback_name: &str) -> Option<serde_j
         "display_name": display_name,
         "tools_allow": tools_allow,
         "scopes": scopes,
+        "search_indexes": search_indexes,
         "hidden": hidden,
         "kind": kind,
     }))
@@ -513,6 +529,9 @@ fn md_agent_to_catalog_json(
         "display_name": display_name,
         "tools_allow": cfg.tools.allow.clone().unwrap_or_default(),
         "scopes": cfg.tools.scopes.clone().unwrap_or_default(),
+        // #3232: normalized (blank-dropped, deduped) rather than the raw
+        // field, so the catalog never advertises an empty-string index id.
+        "search_indexes": cfg.tools.resolved_search_indexes(),
         "hidden": a.hidden,
         "kind": a.kind.clone(),
     })

--- a/crates/trusty-agents/src/api/server/tests/agent_patch.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_patch.rs
@@ -705,6 +705,31 @@ scopes = ["memory.read", "google.*"]
     );
 }
 
+/// #3232: `[tools].search_indexes` is part of the agent's declared capability
+/// surface, so the catalog reports it next to `tools_allow`/`scopes` — same
+/// `[tools]`-table source and same empty-array-not-absent convention, so a
+/// client rendering "what can this agent reach" never re-reads the TOML.
+#[test]
+fn parse_agent_toml_reads_search_indexes_from_tools_table() {
+    let toml = r#"
+[agent]
+name = "cto-assistant"
+role = "assistant"
+
+[tools]
+allow = ["vector_search"]
+search_indexes = ["apex", "cto-projects"]
+"#;
+    let parsed = parse_agent_toml(toml, "cto-assistant").expect("valid TOML");
+    assert_eq!(
+        parsed["search_indexes"],
+        serde_json::json!(["apex", "cto-projects"])
+    );
+    // Absent → empty array, never a missing key.
+    let bare = parse_agent_toml("[agent]\nname = \"a\"\n", "a").expect("valid TOML");
+    assert_eq!(bare["search_indexes"], serde_json::json!([]));
+}
+
 #[test]
 fn parse_agent_toml_hidden_defaults_false_and_parses_true() {
     let visible = "[agent]\nname = \"a\"\n";

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -389,13 +389,25 @@ pub async fn run_pm_task_with_persona(
             // behaviour. As with every tool above, registration alone grants
             // nothing — `filter_persona_tool_names` against `patterns` still
             // decides reachability.
+            //
+            // #3232/#4009: the SAME tool also carries this persona's tier-2
+            // attached indexes (`[tools].search_indexes`, already
+            // extends-unioned by the time `persona_cfg` is loaded) and its
+            // enforcement posture. Attached ids are enumerated in the tool
+            // schema so the model can see them; they only GATE anything when
+            // the persona opts in with `enforce_search_indexes = true`. A
+            // persona declaring neither gets `(vec![], false)` — identical to
+            // the pre-#3232 registration above.
             registry.register(Arc::new(
-                crate::tools::memory::VectorSearchTool::new().with_default_index(
-                    persona_cfg
-                        .stores
-                        .default_search_index()
-                        .map(str::to_string),
-                ),
+                crate::tools::memory::VectorSearchTool::new()
+                    .with_default_index(
+                        persona_cfg
+                            .stores
+                            .default_search_index()
+                            .map(str::to_string),
+                    )
+                    .with_attached_indexes(persona_cfg.tools.resolved_search_indexes())
+                    .with_index_enforcement(persona_cfg.tools.search_indexes_enforced()),
             ));
 
             // system_status epic (#3052): lets a persona report on-demand

--- a/crates/trusty-agents/src/tools/memory/tests.rs
+++ b/crates/trusty-agents/src/tools/memory/tests.rs
@@ -717,6 +717,271 @@ async fn vector_search_routes_to_daemon_index() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #3232 / #4009 — tier-2 attached indexes (epic #4007)
+// ---------------------------------------------------------------------------
+
+/// #4009 schema enrichment: BOTH tiers are enumerated — the curated bound OKG
+/// store first, then the arbitrary attached indexes — so the model picks from
+/// real ids instead of guessing one that happens to exist.
+#[test]
+fn vector_search_schema_lists_attached_indexes() {
+    let s = VectorSearchTool::new()
+        .with_default_index(Some("cto-assistant".to_string()))
+        .with_attached_indexes(vec!["apex".to_string(), "cto-projects".to_string()])
+        .schema();
+    let desc = s["function"]["parameters"]["properties"]["index_id"]["description"]
+        .as_str()
+        .unwrap();
+    for id in ["cto-assistant", "apex", "cto-projects"] {
+        assert!(desc.contains(id), "`{id}` missing from description: {desc}");
+    }
+    // Declarative-only by default: the schema must not claim a restriction
+    // the tool does not actually apply (the #3864 defect class, inverted).
+    assert!(
+        !desc.contains("rejected"),
+        "unenforced schema must not claim enforcement: {desc}"
+    );
+}
+
+/// #4009: an agent with attached indexes but NO bound store still gets them
+/// enumerated (the OKG tier is optional; the tier-2 list stands alone).
+#[test]
+fn vector_search_schema_lists_attached_indexes_without_bound_store() {
+    let s = VectorSearchTool::new()
+        .with_attached_indexes(vec!["apex".to_string()])
+        .schema();
+    let desc = s["function"]["parameters"]["properties"]["index_id"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(desc.contains("apex"), "description was: {desc}");
+}
+
+/// #4009: when enforcement IS on, the schema says so — the model should learn
+/// the boundary from the tool definition rather than from a rejected call.
+#[test]
+fn vector_search_enforced_schema_states_the_restriction() {
+    let s = VectorSearchTool::new()
+        .with_default_index(Some("cto-assistant".to_string()))
+        .with_attached_indexes(vec!["apex".to_string()])
+        .with_index_enforcement(true)
+        .schema();
+    let desc = s["function"]["parameters"]["properties"]["index_id"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(
+        desc.contains("Only these indexes"),
+        "description was: {desc}"
+    );
+}
+
+/// #3232/#4009 NO-BEHAVIOUR-CHANGE PIN: an UNENFORCED agent that declares no
+/// attached indexes must produce a schema BYTE-IDENTICAL to the pre-#4009 one
+/// — the tool definition is prompt input, so drift here changes every existing
+/// agent's context.
+///
+/// Deliberately scoped to `enforce == false`. An earlier revision of this test
+/// also looped `enforce == true`, which pinned a defect rather than a
+/// guarantee: a bound-only enforced agent DOES reject other indexes, so a
+/// schema that stayed silent about it was advertise/accept drift. See
+/// `vector_search_bound_only_enforcement_is_stated_in_schema`.
+#[test]
+fn vector_search_schema_unchanged_when_unenforced_without_attached_indexes() {
+    for bound in [None, Some("cto-assistant".to_string())] {
+        let baseline = VectorSearchTool::new()
+            .with_default_index(bound.clone())
+            .schema();
+        let after = VectorSearchTool::new()
+            .with_default_index(bound.clone())
+            .with_attached_indexes(vec![])
+            .with_index_enforcement(false)
+            .schema();
+        assert_eq!(
+            baseline, after,
+            "schema drifted for an unenforced agent with no attached indexes (bound={bound:?})"
+        );
+    }
+}
+
+/// #4009 (code-critic HIGH): `[[stores]]` bound + NO `search_indexes` +
+/// `enforce = true` is a legal config — an operator locking an agent to only
+/// its own corpus. `authorized_index_id` genuinely refuses every other id
+/// there, so the schema must SAY so; staying silent would leave the
+/// description promising "search a different corpus" over closed behaviour,
+/// which is the #3864 defect class in the schema-says-open direction.
+#[test]
+fn vector_search_bound_only_enforcement_is_stated_in_schema() {
+    let t = VectorSearchTool::new()
+        .with_default_index(Some("cto-assistant".to_string()))
+        .with_index_enforcement(true);
+    // Precondition: the behaviour really is closed.
+    assert_eq!(t.allowed_index_ids(), vec!["cto-assistant".to_string()]);
+    assert!(
+        t.authorized_index_id(&json!({"query": "q", "index_id": "apex"}))
+            .is_err(),
+        "bound-only enforcement must actually reject other ids"
+    );
+    let s = t.schema();
+    let desc = s["function"]["parameters"]["properties"]["index_id"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(
+        desc.contains("Only these indexes"),
+        "enforced bound-only schema must state the restriction: {desc}"
+    );
+    assert!(
+        desc.contains("`cto-assistant`"),
+        "and must name the one permitted index: {desc}"
+    );
+}
+
+/// #4009: enforcement with NOTHING queryable (no bound store, no attachments)
+/// — reachable once the schema note is gated on enforcement — must read as an
+/// explanation, not a dangling empty list.
+#[test]
+fn vector_search_enforced_empty_allowlist_schema_says_nothing_queryable() {
+    let s = VectorSearchTool::new()
+        .with_index_enforcement(true)
+        .schema();
+    let desc = s["function"]["parameters"]["properties"]["index_id"]["description"]
+        .as_str()
+        .unwrap();
+    assert!(desc.contains("no queryable"), "description was: {desc}");
+    assert!(
+        !desc.contains("Indexes available to this agent: ."),
+        "must not emit an empty list: {desc}"
+    );
+}
+
+/// #4009: the allowlist is `{bound OKG index} ∪ search_indexes`, bound first,
+/// deduped — the single derivation feeding both the schema and the gate.
+#[test]
+fn vector_search_allowed_ids_put_bound_index_first() {
+    let t = VectorSearchTool::new()
+        .with_default_index(Some("cto-assistant".to_string()))
+        // `cto-assistant` re-declared as an attachment must not appear twice.
+        .with_attached_indexes(vec![
+            "apex".to_string(),
+            "cto-assistant".to_string(),
+            "  ".to_string(),
+        ]);
+    assert_eq!(t.allowed_index_ids(), vec!["cto-assistant", "apex"]);
+    // Neither tier declared → empty allowlist.
+    assert!(VectorSearchTool::new().allowed_index_ids().is_empty());
+}
+
+/// #4009 DEFAULT-OFF PIN (the runtime half): with enforcement off — today's
+/// default — `authorized_index_id` is exactly `effective_index_id`, for every
+/// combination of declared/undeclared id. No allowlist is consulted, so an
+/// agent that never opts in behaves byte-identically to pre-#4009.
+#[test]
+fn vector_search_default_is_unenforced() {
+    let t = VectorSearchTool::new()
+        .with_default_index(Some("bob-kb".to_string()))
+        .with_attached_indexes(vec!["apex".to_string()]);
+    for args in [
+        json!({"query": "q"}),
+        json!({"query": "q", "index_id": "apex"}),
+        json!({"query": "q", "index_id": "bob-kb"}),
+        // The whole point: an UNDECLARED id still passes through untouched.
+        json!({"query": "q", "index_id": "somebody-elses-index"}),
+        json!({"query": "q", "index_id": "  "}),
+    ] {
+        assert_eq!(
+            t.authorized_index_id(&args),
+            Ok(t.effective_index_id(&args)),
+            "unenforced resolution must match the pre-#4009 result for {args}"
+        );
+    }
+}
+
+/// #4009: with enforcement ON, both tiers are accepted and an omitted
+/// `index_id` still resolves to the agent's own bound store.
+#[test]
+fn vector_search_enforcement_allows_bound_and_attached() {
+    let t = VectorSearchTool::new()
+        .with_default_index(Some("cto-assistant".to_string()))
+        .with_attached_indexes(vec!["apex".to_string()])
+        .with_index_enforcement(true);
+    assert_eq!(
+        t.authorized_index_id(&json!({"query": "q"})),
+        Ok(Some("cto-assistant".to_string()))
+    );
+    assert_eq!(
+        t.authorized_index_id(&json!({"query": "q", "index_id": "cto-assistant"})),
+        Ok(Some("cto-assistant".to_string()))
+    );
+    assert_eq!(
+        t.authorized_index_id(&json!({"query": "q", "index_id": "apex"})),
+        Ok(Some("apex".to_string()))
+    );
+    // An agent with neither tier and nothing requested is not an error — it
+    // simply has no index, exactly as before.
+    let bare = VectorSearchTool::new().with_index_enforcement(true);
+    assert_eq!(bare.authorized_index_id(&json!({"query": "q"})), Ok(None));
+}
+
+/// #4009: with enforcement ON, an explicit id outside the allowlist is
+/// rejected with a message that NAMES the permitted set — a model that
+/// guessed wrong must be able to correct itself from the error alone.
+#[test]
+fn vector_search_enforcement_rejects_undeclared_index() {
+    let t = VectorSearchTool::new()
+        .with_default_index(Some("cto-assistant".to_string()))
+        .with_attached_indexes(vec!["apex".to_string()])
+        .with_index_enforcement(true);
+    let err = t
+        .authorized_index_id(&json!({"query": "q", "index_id": "bob-kb"}))
+        .expect_err("undeclared index must be rejected when enforced");
+    assert!(err.contains("bob-kb"), "must name the rejected id: {err}");
+    assert!(
+        err.contains("`cto-assistant`"),
+        "must name the bound index: {err}"
+    );
+    assert!(
+        err.contains("`apex`"),
+        "must name the attached index: {err}"
+    );
+    assert!(
+        err.contains("search_indexes"),
+        "must name the remedy: {err}"
+    );
+
+    // An agent with an EMPTY allowlist rejects everything, with a message
+    // that reads as an explanation rather than an empty list.
+    let bare = VectorSearchTool::new().with_index_enforcement(true);
+    let err = bare
+        .authorized_index_id(&json!({"query": "q", "index_id": "apex"}))
+        .expect_err("empty allowlist rejects any explicit id");
+    assert!(err.contains("none"), "message was: {err}");
+}
+
+/// #4009 end-to-end: a rejected id is a tool ERROR and must NOT fall through
+/// to the local/grep path — silently answering from a different corpus than
+/// the one that was refused would be worse than refusing at all.
+#[tokio::test]
+async fn vector_search_execute_rejects_undeclared_index_when_enforced() {
+    let tmp = tempdir().unwrap();
+    let tool = VectorSearchTool::new()
+        .with_code_dir(tmp.path().join("no-index"))
+        .with_default_index(Some("cto-assistant".to_string()))
+        .with_attached_indexes(vec!["apex".to_string()])
+        .with_index_enforcement(true)
+        // Deliberately unreachable: enforcement must reject before any I/O.
+        .with_search_base_url(Some("http://127.0.0.1:1".to_string()));
+
+    let out = tool
+        .execute(json!({"query": "q", "index_id": "bob-kb"}))
+        .await;
+    assert!(out.is_error(), "must be a tool error: {}", out.content());
+    assert!(out.content().contains("bob-kb"));
+    assert!(
+        !out.content().contains("grep_fallback"),
+        "a refused index must not silently answer from another corpus: {}",
+        out.content()
+    );
+}
+
 /// A missing index on the daemon degrades to the local/grep path rather than
 /// erroring the agent turn.
 #[tokio::test]

--- a/crates/trusty-agents/src/tools/memory/vector_search.rs
+++ b/crates/trusty-agents/src/tools/memory/vector_search.rs
@@ -19,6 +19,19 @@
 //! `grep`/`search` tools use). Every failure — daemon undiscoverable, index
 //! missing, transport error — degrades to the embedded index and then to the
 //! regex fallback, so the tool never hard-fails an agent turn.
+//! #3232/#4009 (epic #4007's two-tier knowledge model) add a SECOND tier of
+//! corpora alongside the one curated OKG store: `[tools].search_indexes`, a
+//! plain list of trusty-search index ids attached to the agent. The tool
+//! enumerates bound + attached ids in its `index_id` schema description so
+//! the model no longer has to guess an id that happens to exist, and — only
+//! when `[tools] enforce_search_indexes = true` — rejects an explicit id
+//! outside that set. Enforcement is opt-in by owner decision (epic #4007
+//! OQ-2); an agent that is unenforced AND declares no attached indexes takes
+//! every path here byte-identically to pre-#4009, schema bytes included.
+//! Note the conjunction: an ENFORCED agent's schema always states the
+//! restriction, even with no attached indexes (bound-store-only lockdown is a
+//! legal config), because the schema must describe what the tool accepts.
+//!
 //! Test: See `super::tests` — `vector_search_returns_graceful_error_without_index`,
 //! `vector_search_schema_advertises_index_id`,
 //! `vector_search_prefers_explicit_index_over_default`,
@@ -60,6 +73,16 @@ pub struct VectorSearchTool {
     /// explicit `index_id` (#3864). `None` for agents with no `[[stores]]`
     /// binding — those keep the pre-#3864 local-index behaviour exactly.
     default_index_id: Option<String>,
+    /// Arbitrary trusty-search indexes attached to this agent via
+    /// `[tools].search_indexes` (#3232) — epic #4007's tier-2 knowledge
+    /// mechanism, distinct from the single curated OKG store above. Empty for
+    /// agents that declare none, which is the pre-#3232 state exactly.
+    attached_index_ids: Vec<String>,
+    /// Whether an explicit `index_id` outside the allowlist is REJECTED
+    /// (#4009). `false` (the default, per epic #4007 OQ-2) = declarative-only:
+    /// the allowlist informs the schema but gates nothing, byte-identically
+    /// to pre-#4009 behaviour.
+    enforce_index_allowlist: bool,
     /// trusty-search daemon base URL override. `None` = discover at call time
     /// via `trusty_common::resolve_daemon_base_url` (tests inject a mock).
     search_base_url: Option<String>,
@@ -79,6 +102,8 @@ impl VectorSearchTool {
             code_dir: PathBuf::from(".trusty-agents").join("state").join("code"),
             fallback: Arc::new(GrepFilesTool::new()),
             default_index_id: None,
+            attached_index_ids: Vec::new(),
+            enforce_index_allowlist: false,
             search_base_url: None,
         }
     }
@@ -96,6 +121,71 @@ impl VectorSearchTool {
     pub fn with_default_index(mut self, index_id: Option<String>) -> Self {
         self.default_index_id = index_id.filter(|s| !s.trim().is_empty());
         self
+    }
+
+    /// Attach the agent's arbitrary tier-2 search indexes (#3232/#4009).
+    ///
+    /// Why: `[tools].search_indexes` is where an agent declares corpora it
+    /// may query BESIDES its one curated OKG store. Passing the resolved list
+    /// in at registry-build time (where `AgentConfig` is in scope) keeps the
+    /// tool free of config loading, exactly as `with_default_index` does.
+    /// What: Sets `attached_index_ids`, dropping blanks and any id already
+    /// present (the caller normally passes
+    /// `ToolsConfig::resolved_search_indexes`, which has done this already —
+    /// this is belt-and-braces for direct callers and tests).
+    /// Test: `vector_search_schema_lists_attached_indexes`.
+    pub fn with_attached_indexes(mut self, ids: Vec<String>) -> Self {
+        let mut out: Vec<String> = Vec::new();
+        for id in ids {
+            let id = id.trim();
+            if id.is_empty() || out.iter().any(|e| e == id) {
+                continue;
+            }
+            out.push(id.to_string());
+        }
+        self.attached_index_ids = out;
+        self
+    }
+
+    /// Turn the allowlist from declarative into fail-closed (#4009).
+    ///
+    /// Why: Owner decision on epic #4007 OQ-2 — opt-in, default off. See
+    /// `ToolsConfig::enforce_search_indexes`.
+    /// What: Sets `enforce_index_allowlist`; `false` leaves every code path
+    /// byte-identical to pre-#4009.
+    /// Test: `vector_search_enforcement_rejects_undeclared_index`,
+    /// `vector_search_default_is_unenforced`.
+    pub fn with_index_enforcement(mut self, enforce: bool) -> Self {
+        self.enforce_index_allowlist = enforce;
+        self
+    }
+
+    /// The full set of indexes this agent may query: its bound OKG store
+    /// first, then its attached tier-2 indexes (#3232/#4009).
+    ///
+    /// Why: ONE derivation feeds both halves of #4009 — the schema
+    /// enumeration the model reads and the enforcement check — so what the
+    /// tool advertises and what it accepts can never drift apart. That
+    /// drift is precisely the #3864 class of defect this ticket must not
+    /// reintroduce in the other direction.
+    /// What: Bound index (when set) followed by the attached ids, deduped,
+    /// declaration order preserved. Empty for an agent with neither.
+    /// Test: `vector_search_allowed_ids_put_bound_index_first`.
+    pub fn allowed_index_ids(&self) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for id in self
+            .default_index_id
+            .iter()
+            .map(String::as_str)
+            .chain(self.attached_index_ids.iter().map(String::as_str))
+        {
+            let id = id.trim();
+            if id.is_empty() || out.iter().any(|e| e == id) {
+                continue;
+            }
+            out.push(id.to_string());
+        }
+        out
     }
 
     /// Override the on-disk index location (used by tests).
@@ -136,6 +226,54 @@ impl VectorSearchTool {
             .map(str::to_string)
             .or_else(|| self.default_index_id.clone())
     }
+
+    /// [`Self::effective_index_id`] plus the #4009 allowlist gate — the entry
+    /// point `execute` uses.
+    ///
+    /// Why: Resolution (which index does this call mean?) and authorization
+    /// (may this agent query it?) are separate concerns, and only the second
+    /// is opt-in. Keeping them as two functions lets the resolution contract
+    /// stay pinned by its pre-existing tests while enforcement is layered on
+    /// top; keeping the gate on the path `execute` actually calls means an
+    /// enforced agent cannot reach `daemon_query` with an undeclared id.
+    /// What: With enforcement OFF (the default) this is exactly
+    /// `Ok(effective_index_id(args))` — no allowlist is consulted, so the
+    /// default path is byte-identical to pre-#4009. With enforcement ON, an
+    /// EXPLICIT `index_id` outside [`Self::allowed_index_ids`] returns `Err`
+    /// with a message naming the permitted set; the agent's own bound default
+    /// is never rejected (it is always a member), and an omitted `index_id`
+    /// therefore always resolves.
+    /// Test: `vector_search_enforcement_rejects_undeclared_index`,
+    /// `vector_search_enforcement_allows_bound_and_attached`,
+    /// `vector_search_default_is_unenforced`,
+    /// `vector_search_execute_rejects_undeclared_index_when_enforced`.
+    pub fn authorized_index_id(&self, args: &Value) -> Result<Option<String>, String> {
+        let resolved = self.effective_index_id(args);
+        if !self.enforce_index_allowlist {
+            return Ok(resolved);
+        }
+        let Some(id) = resolved else {
+            return Ok(None);
+        };
+        let allowed = self.allowed_index_ids();
+        if allowed.iter().any(|a| a == &id) {
+            return Ok(Some(id));
+        }
+        let allowed_list = if allowed.is_empty() {
+            "(none — this agent declares no bound store and no [tools].search_indexes)".to_string()
+        } else {
+            allowed
+                .iter()
+                .map(|a| format!("`{a}`"))
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        Err(format!(
+            "vector_search: index_id `{id}` is not attached to this agent. Allowed indexes: \
+             {allowed_list}. Attach it via [tools].search_indexes in the agent config, or omit \
+             index_id to search the agent's own store."
+        ))
+    }
 }
 
 impl Default for VectorSearchTool {
@@ -154,7 +292,7 @@ impl ToolExecutor for VectorSearchTool {
         // #3864: `index_id`'s description names the agent's bound default
         // explicitly when there is one, so the model can see which corpus an
         // unqualified call will actually search rather than guessing.
-        let index_desc = match &self.default_index_id {
+        let mut index_desc = match &self.default_index_id {
             Some(id) => format!(
                 "trusty-search index to search. Defaults to this agent's bound OKG store index \
                  (`{id}`) when omitted. Pass an explicit id to search a different corpus."
@@ -163,6 +301,46 @@ impl ToolExecutor for VectorSearchTool {
                      project code index."
                 .to_string(),
         };
+        // #4009: enumerate the agent's attached tier-2 indexes
+        // (`[tools].search_indexes`, #3232) alongside the bound OKG store, so
+        // the model picks from real queryable ids instead of guessing one that
+        // happens to exist.
+        //
+        // The `|| enforce` half of this gate is load-bearing, not defensive.
+        // A bound store with NO `search_indexes` and `enforce = true` is a
+        // legal config — an operator locking an agent to only its own corpus —
+        // and there `allowed_index_ids()` is `[bound]` while
+        // `authorized_index_id()` genuinely refuses everything else. Gating on
+        // the attached list alone would leave that agent's schema saying
+        // "Pass an explicit id to search a different corpus" over closed
+        // behaviour: the #3864 advertise/accept drift, in the
+        // schema-says-open direction. The schema must describe what the tool
+        // ACCEPTS, so the note appears whenever enforcement is active.
+        //
+        // Unenforced agents with no attached indexes still take neither branch
+        // and keep the exact pre-#4009 description, prompt bytes unchanged —
+        // that, and not "enforce is invisible", is the compatibility promise.
+        if !self.attached_index_ids.is_empty() || self.enforce_index_allowlist {
+            let allowed = self.allowed_index_ids();
+            if allowed.is_empty() {
+                // Only reachable under enforcement (an unenforced agent with
+                // no ids took neither branch): nothing is queryable at all, so
+                // say that rather than emit a dangling empty list.
+                index_desc
+                    .push_str(" This agent has no queryable trusty-search index; omit index_id.");
+            } else {
+                let listed = allowed
+                    .iter()
+                    .map(|id| format!("`{id}`"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                index_desc.push_str(&format!(" Indexes available to this agent: {listed}."));
+                if self.enforce_index_allowlist {
+                    index_desc
+                        .push_str(" Only these indexes may be queried; any other id is rejected.");
+                }
+            }
+        }
         json!({
             "type": "function",
             "function": {
@@ -206,7 +384,17 @@ impl ToolExecutor for VectorSearchTool {
         // #3864 fast path: a named trusty-search index (explicit arg, or the
         // agent's bound OKG store). Any failure falls through to the
         // pre-existing local paths rather than erroring the turn.
-        if let Some(index_id) = self.effective_index_id(&args) {
+        // #4009: authorize before routing. With enforcement off (the default)
+        // this is the pre-existing `effective_index_id` result unchanged; with
+        // it on, an undeclared explicit id is a hard tool error rather than a
+        // silent daemon call — and deliberately NOT a fall-through to the
+        // local index, which would leak an answer from the wrong corpus in
+        // response to a rejected request.
+        let index_id = match self.authorized_index_id(&args) {
+            Ok(id) => id,
+            Err(msg) => return ToolResult::err(msg),
+        };
+        if let Some(index_id) = index_id {
             match self.daemon_query(&index_id, query, limit).await {
                 Ok(payload) => return ToolResult::ok(payload),
                 Err(e) => tracing::warn!(


### PR DESCRIPTION
Foundation of the two-tier knowledge architecture — issues #3232 and #4009 as one PR (they are one change: #4009 reads the field #3232 adds, and shipping the field without the tool that surfaces it would be a declared capability with nothing behind it, which is the #3864 defect class this epic is explicitly trying not to repeat).

## The shape

`[[stores]]` remains the **curated** tier: exactly one OKG store per agent — tree, index, palace, built via `okg_ingest_*`. `[tools].search_indexes` is the **second, uncurated** tier: a plain list of trusty-search index ids over any corpus, N per agent, zero curation requirement.

### #3232 — the attach-list primitive

- `ToolsConfig.search_indexes: Option<Vec<String>>`, unioned base-first through `extends` via the existing `union_opt_vec` — the same contract as `allow` / `scopes`: an overlay may only ADD reach, never silently remove what its base attached. The ticket's own worked example is pinned as a test (base Assistant attaches its project index; a CTO Assistant extending it unions in `cto-projects` and `apex` without re-declaring the base's).
- `resolved_search_indexes()` is the single normalization point — trim, drop blanks, first-occurrence-wins dedup. One place for the rule means no consumer re-derives it, and a hand-edited blank id can never build a `/indexes//search` URL.
- The resolved list surfaces wherever the agent's effective config is introspectable: the agent catalog (`parse_agent_toml`, `md_agent_to_catalog_json`) and `GET /api/agents/:name/stores`, where it is reported **alongside** the curated stores rather than mixed into them — a store has structure an attached index simply doesn't have. The stores route also reports `enforce_search_indexes`, so a client never has to infer the posture from the list's presence.

### #4009 — enumerate, then (optionally) enforce

- **Schema enrichment, unconditional.** `vector_search`'s `index_id` description now **enumerates** the agent's bound store plus every attached index. Cross-index querying has always been mechanically possible — `effective_index_id` forwards any string to `POST /indexes/{id}/search` — the model just had to *guess* an id that happened to exist. This is the discoverability half.
- **Allowlist enforcement, opt-in.** `[tools] enforce_search_indexes = true` turns that same list into a fail-closed allowlist. `authorized_index_id()` refuses an explicit `index_id` outside `{bound store} ∪ search_indexes` with an error naming the permitted set and the remedy, and deliberately does **not** degrade to the local index — answering a refused request from a different corpus is worse than refusing.
- One derivation, `allowed_index_ids()`, feeds both the schema and the gate, so what the tool advertises and what it accepts cannot drift apart. That drift, in the other direction, is exactly what #3864 filed.

## Owner-decided defaults (Bob, 2026-07-26)

Cited here because they resolve two of epic #4007's open questions:

- **OQ-1:** OKG `[[stores]]` stays single-binding. Attached indexes are the multiplicity mechanism — this PR does not lift the one-store-per-agent ceiling, it routes around the need to.
- **OQ-2:** Enforcement is **opt-in, declarative-only at M1**. `vector_search` has never gated `index_id` in production, so failing closed by default would break every persona that cross-queries an index it never declared. `enforce_search_indexes` defaults to `false`.

## Backward compatibility — pinned, not asserted

An agent that is unenforced *and* declares no attached indexes takes the identical resolution path and gets a schema whose **bytes are asserted unchanged**, across bound and unbound. A tool definition is prompt input; drift there would alter every existing agent's context, so it is pinned rather than eyeballed. `effective_index_id`'s pre-existing contract and tests are untouched — enforcement is layered in `authorized_index_id`, the path `execute` actually calls.

The pin is deliberately scoped to `enforce == false`. An earlier revision also looped `enforce == true`, which pinned a *defect* rather than a guarantee (caught by code-critic, HIGH): `[[stores]]` bound + no `search_indexes` + `enforce = true` is a legal config — an operator locking an agent to only its own corpus — where `authorized_index_id` genuinely refuses every other id, yet the schema still read "Pass an explicit id to search a different corpus." That is this PR's own stated failure mode in the schema-says-open direction. The schema note is now gated on `!attached.is_empty() || enforce`, so it appears whenever enforcement is actually active; `vector_search_bound_only_enforcement_is_stated_in_schema` asserts the rejection and the schema text together. Widening the gate made one more case reachable — enforcement with nothing queryable at all — which now reads as an explanation instead of a dangling empty list (`vector_search_enforced_empty_allowlist_schema_says_nothing_queryable`).

## API surface note (DOC-58 §5.3)

This PR adds two fields to `GET /api/agents/:name/stores`, which was outside #4009's written ticket scope. Per the PM decision on the DOC-58 spec review (PR #4017), they are **blessed as an interim raw surface** — now licensed by [DOC-58 §5.3](docs/specs/DOC-58-knowledge-kd-attached-indexes.md) (KD-17…KD-20), merged as #4008. Semantics:

| Field | Semantics |
|---|---|
| `search_indexes` | The **resolved declared list** — trimmed, deduped, from `[tools].search_indexes`, minus ids already bound as a store (see below). **No daemon probe.** |
| `enforce_search_indexes` | The **knob state** (`[tools].enforce_search_indexes`), so a client never infers the posture from the list's presence. |

Both are **raw and non-authoritative**. The future `/knowledge.attached_indexes[]` route is the probed, authoritative surface for the GUI; this one exists so the two-tier config is readable before that route lands. The id sets reported by the two must stay consistent.

**The `search_indexes` source deviation is resolved in this implementation's favour.** §5.3's original source table specified `resolved_search_indexes()` verbatim, which this handler does not do. The critic ruled the table — not the handler — out of sync with DOC-58's own KD-18/KD-21/C-KD.8, and the spec has since been amended (`ddeaab53`, now on main): §5.3 sources the field from `attached_indexes_deduped()`, explains why it is not the raw resolver, and closes with "Do not 'fix' this back to `resolved_search_indexes()`." Its cited line refs (`agent_stores.rs:127-128` and `:151`) are exact against this branch's head.

**Dedupe-by-id is enforced server-side.** Declaring the same id in both `[[stores]]` and `[tools].search_indexes` is legal — an operator may reasonably restate the bound index, and `vector_search`'s allowlist accepts it from either tier — but the response presents it exactly once, **under its bound role**: it stays in `stores` and is filtered out of `search_indexes`, so the GUI never renders one corpus twice with two provenances. Deduping keys on the binding's *resolved* index (the id `vector_search` actually sends), not the store's display name. `VectorSearchTool::allowed_index_ids()` resolves the same overlap the same way, so the route and the tool cannot disagree about the id set — covered by `attached_indexes_deduped_presents_overlap_under_its_bound_role`.

## Adjacent, deliberately not foreclosed

#3231 (wiring the orphaned `TrustySearchPlugin` / stale `search_code` name) is a different tool path and is untouched here. Nothing in this change assumes `vector_search` is the only index-aware tool: `resolved_search_indexes()` / `search_indexes_enforced()` are plain `ToolsConfig` accessors that `SearchCodeTool` can read the same way when #3231 lands.

## Tests (21 new)

Union-extends resolution incl. base-silent / child-silent / neither cases; the posture-not-list merge semantics for the enforcement flag (hardened base stays hardened under a silent overlay); normalization of blanks and dupes; schema enumeration of both tiers, with and without a bound store; the enforced-schema wording incl. the bound-only lockdown and empty-allowlist cases; allowlist ordering and dedup; enforcement accept/reject incl. the empty-allowlist message and the end-to-end no-fall-through guarantee; the `/stores` overlap dedupe; and the two default-off no-behaviour-change pins (config layer + runtime).

## Gates

```
cargo test -p trusty-agents      → ok. 2648 passed; 0 failed; 12 ignored (lib)
                                   + 6 / 4 / 2 / 3 / 2 / 7 / 2 passed across integration bins, 0 failed
cargo clippy -p trusty-agents --all-targets -- -D warnings → clean
cargo fmt --check -p trusty-agents → exit 0
```

Refs #4007 — part of epic #4007 (two-tier knowledge architecture).

Closes #3232
Closes #4009

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
