### PR TITLE
fix(trusty-agents): grant the base assistant the Google families its allowlist names (#3987 option B)

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
@@ -94,8 +94,13 @@ allow = [
   #     ~/.gnupg are refused without being enumerated). Widen it deliberately —
   #     anything reachable becomes searchable and quotable in chat, and
   #     ingested content is itself untrusted input.
-  # The Google-backed tools reuse the existing read-only `google.read`
-  # credentials and never prompt for auth.
+  # #3987: the Google-backed ingest tools reuse the credentials the
+  # gworkspace surface below already holds — which are WRITE-CAPABLE Google
+  # OAuth grants, not read-only ones (the "read-only `google.read`" this
+  # comment used to claim never existed; see the `[tools].scopes` note
+  # below). These three are in-process tools that return `None` from
+  # `ToolExecutor::scope()`, so they are not scope-gated at all; they read
+  # Gmail/Drive through the same credential the scoped tools use.
   "okg_ingest_docstore",
   "okg_ingest_gmail",
   "okg_ingest_drive",
@@ -175,12 +180,86 @@ allow = [
 ]
 # OpenRPC (https://spec.open-rpc.org/) over stdio scopes (#455, #454). The base
 # assistant remembers facts across sessions (memory.write), recalls them
-# (memory.read), and reads notes/snippets via search (search.read). Google
-# access defaults to READ-ONLY (`google.read`) on the base template per §5.5 —
-# a generic, un-personalized assistant should not mutate a user's mailbox /
-# calendar / drive by default. A personalization overlay opts into write
-# (`google.*`) explicitly (see `../izzie/agent.toml`).
-scopes = ["memory.read", "memory.write", "search.read", "google.read"]
+# (memory.read), and reads notes/snippets via search (search.read).
+#
+# #3987 (option B, Bob's explicit decision — see the issue's PM-recommendation
+# comment): the Google grants below REPLACE the former `google.read`.
+#
+# WHAT `google.read` ACTUALLY DID: nothing. It was a dead pattern. Discovery
+# maps every `x-google-scopes` OAuth URL to `google.<family>.<access>`
+# (`tools::registry::google_scope::FAMILY_TABLE`), so the vocabulary contains
+# `google.gmail.write`, `google.calendar.write`, … and never a bare
+# `google.read`; `ScopePattern::matches` takes the no-wildcard branch for it
+# and requires string equality. Every one of the ~60 gworkspace tools
+# allowlisted above was therefore scope-denied at dispatch on the persona-chat
+# path, and had been since the scopes line was written. There was no
+# read-only enforcement to preserve here — the posture was fictional, which is
+# why replacing it is a correction of the config to match reality and not a
+# widening of a boundary that was holding.
+#
+# HONEST POSTURE STATEMENT (replacing the old §5.5 read-only claim): a base
+# assistant granted the tools above holds WRITE-CAPABLE Google credentials.
+# Every OAuth scope `trusty-gworkspace` requests is the full-access variant of
+# its API, never a `.readonly` one (`trusty-gworkspace/src/openrpc.rs::scopes`),
+# so the same `gmail.modify` token a "search" tool uses can also delete mail.
+# A genuinely read-only tier is #3987's option A and is DEFERRED: it needs
+# `.readonly` OAuth variants, user re-consent, and either middle-wildcard
+# support in `ScopePattern` or a scope-naming redesign. If option A is built,
+# these grants shrink naturally.
+#
+# THE ALLOW-LIST REMAINS THE BINDING CONSTRAINT. `filter_persona_tool_names`
+# intersects `[tools].allow` (by NAME) AND `[tools].scopes` (by CAPABILITY) —
+# verified in #3985 — so these family grants do not expose a single tool the
+# curated allowlist above does not already name. Widening the reachable
+# surface means editing `allow`, not this line.
+#
+# ONE FAMILY PER SURFACE THE ALLOW-LIST ACTUALLY NAMES — audited tool-by-tool
+# against the real `rpc.discover` document, and pinned by
+# `base_assistant_scope_grants_cover_every_allowlisted_gworkspace_tool` (which
+# also fails if a family here has NO allowlisted tool, so this list cannot
+# quietly over-grant):
+#   google.gmail.*    — 9 tools: compose_email, download_gmail_attachment,
+#                       get_gmail_message_content, list_message_attachments,
+#                       manage_gmail_filters, manage_gmail_labels,
+#                       manage_gmail_settings, modify_gmail_messages,
+#                       search_gmail_messages
+#   google.calendar.* — 3 tools: manage_calendars, manage_events,
+#                       query_free_busy
+#   google.drive.*    — 6 tools: get_drive_file_content, list_drive_contents,
+#                       list_shared_drives, manage_drive_file,
+#                       manage_file_permissions, search_drive_files
+#   google.docs.*     — 25 tools: the whole `*_document` / `*_in_document` /
+#                       `*_table_*` cluster (Docs tools request `documents`
+#                       AND `drive`; the resource-specific scope wins, see
+#                       `google_scope`'s priority note)
+#   google.sheets.*   — 5 tools: create_chart, format_sheet, get_spreadsheet,
+#                       manage_spreadsheet, modify_sheet_values
+#   google.slides.*   — 3 tools: add_slide_content, get_slides, manage_slides
+#   google.tasks.*    — 2 tools: manage_task_lists, manage_tasks
+#   google.accounts.* — 1 tool: list_accounts (Google's one genuinely
+#                       read-only scope, `userinfo.profile`)
+# No family is granted speculatively: every one above has at least one
+# allowlisted tool, and no allowlisted scoped gworkspace tool lacks a family.
+#
+# Personalization overlays are UNIONED with this list (`extends::merge_extends`
+# -> `union_opt_vec`, deduped), so `../cto-assistant/`'s narrow
+# `google.gmail.*` / `google.tasks.*` (#3985) now collapse into these as exact
+# duplicates, and `../izzie/`'s blanket `google.*` remains a superset. Both are
+# deliberately left declared: an overlay whose whole purpose is Gmail should
+# say so itself rather than depend on the base keeping a grant forever.
+scopes = [
+  "memory.read",
+  "memory.write",
+  "search.read",
+  "google.gmail.*",
+  "google.calendar.*",
+  "google.drive.*",
+  "google.docs.*",
+  "google.sheets.*",
+  "google.slides.*",
+  "google.tasks.*",
+  "google.accounts.*",
+]
 
 [system_prompt]
 # Generic productivity skills only — resolved by name from the skill registry.

--- a/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
@@ -207,39 +207,35 @@ allow = [
 # support in `ScopePattern` or a scope-naming redesign. If option A is built,
 # these grants shrink naturally.
 #
+# INJECTION SURFACE — the risk this posture creates, named rather than left
+# implicit: this same persona ingests attacker-controllable text in the SAME
+# turn that holds send/share credentials (`okg_ingest_gmail`,
+# `okg_ingest_drive`, `get_gmail_message_content`, `web_search` above all pull
+# in an inbound mail body, a shared Drive doc, or a web page). The
+# exfiltration-capable subset of the allowlist is `compose_email`,
+# `manage_file_permissions`, `manage_gmail_settings`, `manage_gmail_filters`
+# and `modify_gmail_messages` — the allow-list bounds WHICH tools exist, not
+# what an injected model chooses to do with them. A confirmation gate for
+# exactly those five is tracked in #4054 (it needs either #3074/#3075's
+# `user_authority` field or an interim read site for
+# `[[permissions.grants]] mode = "ask"`, neither of which exists yet).
+#
 # THE ALLOW-LIST REMAINS THE BINDING CONSTRAINT. `filter_persona_tool_names`
 # intersects `[tools].allow` (by NAME) AND `[tools].scopes` (by CAPABILITY) —
 # verified in #3985 — so these family grants do not expose a single tool the
 # curated allowlist above does not already name. Widening the reachable
 # surface means editing `allow`, not this line.
 #
-# ONE FAMILY PER SURFACE THE ALLOW-LIST ACTUALLY NAMES — audited tool-by-tool
-# against the real `rpc.discover` document, and pinned by
-# `base_assistant_scope_grants_cover_every_allowlisted_gworkspace_tool` (which
-# also fails if a family here has NO allowlisted tool, so this list cannot
-# quietly over-grant):
-#   google.gmail.*    — 9 tools: compose_email, download_gmail_attachment,
-#                       get_gmail_message_content, list_message_attachments,
-#                       manage_gmail_filters, manage_gmail_labels,
-#                       manage_gmail_settings, modify_gmail_messages,
-#                       search_gmail_messages
-#   google.calendar.* — 3 tools: manage_calendars, manage_events,
-#                       query_free_busy
-#   google.drive.*    — 6 tools: get_drive_file_content, list_drive_contents,
-#                       list_shared_drives, manage_drive_file,
-#                       manage_file_permissions, search_drive_files
-#   google.docs.*     — 25 tools: the whole `*_document` / `*_in_document` /
-#                       `*_table_*` cluster (Docs tools request `documents`
-#                       AND `drive`; the resource-specific scope wins, see
-#                       `google_scope`'s priority note)
-#   google.sheets.*   — 5 tools: create_chart, format_sheet, get_spreadsheet,
-#                       manage_spreadsheet, modify_sheet_values
-#   google.slides.*   — 3 tools: add_slide_content, get_slides, manage_slides
-#   google.tasks.*    — 2 tools: manage_task_lists, manage_tasks
-#   google.accounts.* — 1 tool: list_accounts (Google's one genuinely
-#                       read-only scope, `userinfo.profile`)
-# No family is granted speculatively: every one above has at least one
-# allowlisted tool, and no allowlisted scoped gworkspace tool lacks a family.
+# ONE FAMILY PER SURFACE THE ALLOW-LIST ACTUALLY NAMES. No family is granted
+# speculatively: every one below has at least one allowlisted tool, and no
+# allowlisted scoped gworkspace tool lacks a family. That correspondence is
+# ENFORCED, in both directions, by
+# `base_assistant_scope_grants_cover_every_allowlisted_gworkspace_tool`
+# (`src/ctrl/pm_task/dispatch/persona_tests.rs`), which derives every tool's
+# dotted scope from the real `rpc.discover` document. Read the test, not a
+# comment, for the per-family tool counts — an enumeration here would drift
+# out of date the first time the allowlist changed, and a stale audit is
+# worse than none.
 #
 # Personalization overlays are UNIONED with this list (`extends::merge_extends`
 # -> `union_opt_vec`, deduped), so `../cto-assistant/`'s narrow

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -104,14 +104,22 @@ allow = [
 # credential actually holds, and BOTH must pass in
 # `ctrl::pm_task::dispatch::persona::filter_persona_tool_names` (#3208).
 #
-# The base `assistant` deliberately declares read-only `google.read`
-# (`../assistant/agent.toml`, §5.5) — but no gworkspace tool ever advertises
-# that scope: `registry::google_scope` maps every `x-google-scopes` OAuth URL
-# to `google.<family>.<access>` (e.g. `google.gmail.write`,
-# `google.tasks.write`), and `ScopePattern::matches` compares on segment
-# boundaries, so `google.read` matches nothing. Inheriting it by union was
-# therefore inheriting NO Google capability at all, and every Gmail/Tasks tool
-# allowlisted above was silently dropped before the model ever saw it.
+# HISTORY (#3938): the base `assistant` used to declare a read-only
+# `google.read` — but no gworkspace tool ever advertises that scope:
+# `registry::google_scope` maps every `x-google-scopes` OAuth URL to
+# `google.<family>.<access>` (e.g. `google.gmail.write`, `google.tasks.write`),
+# and `ScopePattern::matches` compares on segment boundaries, so `google.read`
+# matched nothing. Inheriting it by union was therefore inheriting NO Google
+# capability at all, and every Gmail/Tasks tool allowlisted above was silently
+# dropped before the model ever saw it.
+#
+# #3987 (option B) has since replaced that dead pattern on the base with
+# explicit family grants, which now INCLUDE `google.gmail.*` and
+# `google.tasks.*` — so the line below is currently redundant and the extends
+# union dedups it away (`union_opt_vec`). It is kept declared on purpose: an
+# overlay whose entire purpose is Gmail triage and Tasks sync should state the
+# capability it depends on rather than rely on the shared base never narrowing
+# it. If the base is ever trimmed, this package keeps working.
 #
 # This overlay is a single named user's private assistant (Masa/Duetto) whose
 # whole point is Gmail triage (#473) and Granola->Google Tasks sync (#472/#485),

--- a/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
@@ -171,9 +171,21 @@ allow = [
   "create_chart",
   "list_accounts",
 ]
-# Izzie opts INTO Google write (`google.*`) — a personalization decision on top
-# of the base template's read-only `google.read` default (§5.5). The rest of the
-# scope list matches the base and is redundant until #3055 (see header note).
+# Izzie opts into BLANKET Google access (`google.*`) — one pattern covering
+# every family, present and future.
+#
+# #3987: this used to be described as opting "into write on top of the base
+# template's read-only `google.read` default (§5.5)". That framing was wrong in
+# both halves: `google.read` matched nothing (no gworkspace tool advertises it —
+# discovery only emits `google.<family>.<access>`), so there was no read-only
+# default to sit on top of; and every Google OAuth scope `trusty-gworkspace`
+# requests is the full-access variant of its API, so "write" was never a
+# separate tier. The base now grants the eight families its allowlist names
+# (`../assistant/agent.toml`); `google.*` is a strict superset of those and is
+# kept deliberately — izzie is a single named user's private assistant and is
+# meant to reach new Google families as they appear without a config edit.
+# The rest of the scope list matches the base and is redundant until #3055
+# (see header note).
 scopes = ["memory.read", "memory.write", "search.read", "google.*"]
 
 [system_prompt]

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -195,6 +195,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `google.tasks.*` (#3985) collapse into the base's by the extends union's
   dedup, and `izzie`'s blanket `google.*` remains a superset.
 
+  **Known gap, tracked in #4054**: the base persona ingests
+  attacker-controllable text (`okg_ingest_gmail`, `okg_ingest_drive`,
+  `get_gmail_message_content`, `web_search`) in the same turn that now holds
+  send/share credentials, and five allowlisted tools are exfiltration-capable
+  (`compose_email`, `manage_file_permissions`, `manage_gmail_settings`,
+  `manage_gmail_filters`, `modify_gmail_messages`). The allow-list bounds
+  which tools exist, not what an injected model does with them. A
+  confirmation gate for those five needs either #3074/#3075's
+  `user_authority` field or an interim read site for
+  `[[permissions.grants]] mode = "ask"` — neither exists yet, so it is filed
+  rather than shipped here.
+
   Consequently the base assistant, and every `extends = "assistant"` overlay,
   is now clean under the #3987 option-C dead-grant diagnostic, which
   discharges the sequencing constraint that forced that check to ship as a

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -163,6 +163,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   as its own change even after that: it would also stop *user-authored* agents
   from loading, which deserves its own decision and release note.
 
+### Changed
+
+- **The base `assistant` template now declares explicit Google family scope
+  grants instead of the dead `google.read`** (issue #3987, option B — owner
+  decision, see the issue's PM-recommendation comment). All ~60 Google
+  Workspace tools the base allowlists were scope-denied at dispatch on the
+  persona-chat path, and had been since the line was written: no gworkspace
+  tool ever advertises `google.read` (discovery only emits
+  `google.<family>.<access>`) and `google.read` is a no-wildcard pattern
+  requiring string equality. The base now grants
+  `google.gmail.*`, `google.calendar.*`, `google.drive.*`, `google.docs.*`,
+  `google.sheets.*`, `google.slides.*`, `google.tasks.*` and
+  `google.accounts.*` — audited tool-by-tool against the real `rpc.discover`
+  document, one family per surface the allowlist actually names, with no
+  family granted that has no allowlisted tool behind it (a new test fails in
+  both directions).
+
+  **Posture note, stated plainly**: a base assistant granted these tools holds
+  WRITE-CAPABLE Google credentials. There was no read-only enforcement to
+  preserve — `google.read` granted nothing, so the read-only posture was
+  fictional — but the honest description of what the base can now do is
+  "read and mutate the user's Gmail, Calendar, Drive, Docs, Sheets, Slides and
+  Tasks", because every OAuth scope `trusty-gworkspace` requests is the
+  full-access variant of its API. A genuinely read-only tier (#3987 option A)
+  is deferred pending a product requirement; it needs `.readonly` OAuth
+  variants and user re-consent. The `[tools].allow` list remains the binding
+  constraint — scope and allow-list intersect at dispatch (verified in
+  #3985) — so this exposes no tool the curated allowlist does not already
+  name. Overlays are unaffected: `cto-assistant`'s narrow `google.gmail.*` /
+  `google.tasks.*` (#3985) collapse into the base's by the extends union's
+  dedup, and `izzie`'s blanket `google.*` remains a superset.
+
+  Consequently the base assistant, and every `extends = "assistant"` overlay,
+  is now clean under the #3987 option-C dead-grant diagnostic, which
+  discharges the sequencing constraint that forced that check to ship as a
+  warning rather than a load error.
+
 ### Fixed
 
 - **Streamed replies no longer flash blank or "(no narrative)" the moment a

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -560,15 +560,37 @@ fn base_assistant_package_is_generic_default_and_curated() {
     );
     let scopes = cfg.tools.scopes.expect("base assistant declares scopes");
     assert!(scopes.iter().any(|s| s == "memory.write"));
-    // §5.5: the generic base template defaults to READ-ONLY Google access.
-    // Write (`google.*`) is opted into by a personalization overlay, not the base.
+    // #3987 (option B, owner decision): this assertion used to require
+    // `google.read` per §5.5's read-only intent. That pattern granted
+    // NOTHING — no gworkspace tool advertises it, so all ~60 allowlisted
+    // Google tools were scope-denied at dispatch — and it has been replaced
+    // by explicit per-family grants. What is still worth pinning here is the
+    // NARROWNESS: the base enumerates the families its allowlist names and
+    // must NOT reach for izzie's blanket `google.*`, so a family added to the
+    // base later is a deliberate edit rather than something a wildcard
+    // absorbs silently.
     assert!(
-        scopes.iter().any(|s| s == "google.read"),
-        "base assistant must default to read-only Google (google.read)"
+        !scopes.iter().any(|s| s == "google.read"),
+        "the dead `google.read` pattern must not return to the base (#3987)"
     );
+    for family in [
+        "google.gmail.*",
+        "google.calendar.*",
+        "google.drive.*",
+        "google.docs.*",
+        "google.sheets.*",
+        "google.slides.*",
+        "google.tasks.*",
+        "google.accounts.*",
+    ] {
+        assert!(
+            scopes.iter().any(|s| s == family),
+            "base assistant must grant {family} for the tools it allowlists: {scopes:?}"
+        );
+    }
     assert!(
         !scopes.iter().any(|s| s == "google.*"),
-        "base assistant must NOT grant Google write by default"
+        "base assistant must enumerate families, not take a blanket google.* grant"
     );
     // Generic productivity skills only — NO user-specific skills on the base.
     let skills = cfg.system_prompt.skills.expect("base declares skills");

--- a/crates/trusty-agents/src/api/server/agent_skills.rs
+++ b/crates/trusty-agents/src/api/server/agent_skills.rs
@@ -642,11 +642,12 @@ mod unit_tests {
     /// #3987: the base assistant's `google.read` must reach the panel as a
     /// dead grant, with actionable alternatives.
     ///
-    /// NOTE: #3987's option B removes `google.read` from the shipped base;
-    /// this test asserts on a LITERAL pattern, not on the shipped config, so
-    /// it stays valid after that lands. The shipped-config assertion lives in
-    /// `ctrl::pm_task::dispatch::persona_tests` and is the one option B
-    /// updates.
+    /// NOTE: #3987's option B has removed `google.read` from the shipped
+    /// base; this test asserts on a LITERAL pattern, not on the shipped
+    /// config, so it survived that change — a USER can still hand-write
+    /// `google.read` in their own agent, and the panel must still say so.
+    /// The shipped-config assertion lives in
+    /// `ctrl::pm_task::dispatch::persona_tests`.
     #[test]
     fn dead_scope_cards_flags_the_google_read_pattern() {
         let scopes = vec![

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -532,12 +532,12 @@ pub async fn run_pm_task_with_persona(
             // actually built — so it is where a pattern that can match
             // nothing becomes detectable. Emitted here, immediately before
             // the gate that would otherwise drop the surface in silence.
-            // Deliberately a WARN and not a hard failure for now: the bundled
-            // base `assistant` still ships the dead `google.read` pattern that
-            // every `extends = "assistant"` overlay inherits, so failing
-            // closed here would break every assistant load. Escalate to a hard
-            // error once #3987's option B has removed it — see
-            // `tools::registry::dead_scope`'s module doc.
+            // Still a WARN and not a hard failure. #3987's option B has
+            // removed the dead `google.read` from the shipped base, so the
+            // sequencing constraint that forced a warning is discharged and
+            // escalation is unblocked — but promoting this to a fatal would
+            // stop USER-authored agents from loading, which is its own
+            // decision. See `tools::registry::dead_scope`'s module doc.
             dead_scope::warn_dead_scope_patterns(
                 persona_name,
                 &dead_scope::dead_scope_patterns(

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -563,22 +563,24 @@ fn cto_assistant_package_gmail_and_tasks_tools_survive_scope_intersection() {
     );
 }
 
-/// #3987 (option C) pinned against the SHIPPED base template: the bundled
-/// `assistant`'s declared `google.read` is a dead scope pattern.
+/// #3987 (option B) pinned against the SHIPPED base template: the bundled
+/// `assistant` declares NO dead scope pattern.
 ///
 /// Why assert on the checked-in config rather than a literal: the diagnostic's
-/// value is that it fires on the real defect, and the real defect is in the
+/// value is that it fires on the real defect, and the real defect was in the
 /// file we ship. Resolving through the real loader also proves the check sees
 /// the POST-`extends` scope set, which is the set the dispatch gate uses.
 ///
-/// **This test is updated by #3987's option B**, which replaces the base's
-/// `google.read` with explicit family grants. After that lands the assertion
-/// inverts to "the base assistant has NO dead scope patterns" — that inversion
-/// is the acceptance criterion for option B, not a regression here. The
-/// warning-not-error posture in `persona.rs` exists precisely because this
-/// test currently passes: a hard load error today would break every assistant.
+/// **This assertion was INVERTED by option B**, and the inversion is the
+/// point. Option C (the preceding PR) landed this test asserting the base's
+/// `google.read` WAS dead — that is why option C shipped as a `warn!` rather
+/// than a hard load error, since failing closed would have broken every
+/// `extends = "assistant"` load. Option B removed the dead pattern, so the
+/// base is now clean and the sequencing constraint is discharged: escalating
+/// `persona.rs`'s warning to a hard error is unblocked, and this test is what
+/// will keep it unblocked.
 #[test]
-fn base_assistant_google_read_is_a_dead_scope_pattern() {
+fn base_assistant_declares_no_dead_scope_patterns() {
     use crate::tools::registry::dead_scope;
 
     let agents_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -586,49 +588,145 @@ fn base_assistant_google_read_is_a_dead_scope_pattern() {
         .join("agents");
     let cfg = AgentConfig::by_name_in(&[agents_dir], "assistant")
         .expect("bundled assistant template resolves");
-    let patterns: Vec<ScopePattern> = cfg
+    let scopes = cfg
         .tools
         .scopes
         .clone()
-        .expect("the base assistant declares [tools].scopes")
-        .into_iter()
-        .map(ScopePattern::new)
-        .collect();
+        .expect("the base assistant declares [tools].scopes");
+    let patterns: Vec<ScopePattern> = scopes.iter().cloned().map(ScopePattern::new).collect();
 
-    // No live registry: the static Google vocabulary alone is enough to prove
-    // this pattern is dead under ANY registry state.
+    // No live registry: the static Google vocabulary alone settles this under
+    // ANY registry state.
     let dead = dead_scope::dead_scope_patterns(
         &patterns,
         &dead_scope::reachable_scopes(std::iter::empty::<String>()),
     );
-    assert_eq!(
-        dead.iter().map(|d| d.pattern.as_str()).collect::<Vec<_>>(),
-        vec!["google.read"],
-        "resolved [tools].scopes = {:?}",
-        cfg.tools.scopes
+    assert!(
+        dead.is_empty(),
+        "the base assistant carries dead scope grants: {dead:?} (declared: {scopes:?})"
+    );
+    // Guard against a vacuous pass in the other direction: the dead pattern
+    // this issue is about must be GONE, not merely un-flagged because the
+    // whole scopes line was deleted.
+    assert!(
+        !scopes.iter().any(|s| s == "google.read"),
+        "the dead `google.read` pattern is still declared: {scopes:?}"
     );
     assert!(
-        dead[0].nearest.iter().any(|s| s == "google.gmail.write"),
-        "the diagnostic must name a reachable alternative: {:?}",
-        dead[0].nearest
-    );
-
-    // The base's OTHER scopes must NOT be flagged: `memory.*`/`search.*` come
-    // from endpoints whose vocabulary this crate does not know statically, and
-    // reporting them dead when their daemon merely isn't running would be the
-    // false-positive that makes the whole diagnostic ignorable.
-    assert!(
-        !dead
-            .iter()
-            .any(|d| d.pattern.starts_with("memory.") || d.pattern.starts_with("search.")),
-        "namespace guard failed: {dead:?}"
+        scopes.iter().any(|s| s == "google.gmail.*"),
+        "the base must still grant the Gmail surface its allowlist names: {scopes:?}"
     );
 }
 
-/// #3987 the negative half: a live family/wildcard pattern is never flagged.
-/// `izzie` ships blanket `google.*` and `cto-assistant` ships the narrow
-/// `google.gmail.*` / `google.tasks.*` pair (#3985) — both are working grants
-/// and a diagnostic that cried wolf on them would be worse than none.
+/// #3987 (option B): every scoped gworkspace tool the base assistant
+/// allowlists must survive the dispatch-time scope intersection — and every
+/// Google family the base grants must be earned by at least one allowlisted
+/// tool.
+///
+/// Why both directions: the first half is the defect (#3987 — all ~60
+/// allowlisted gworkspace tools were denied). The second half is the guard on
+/// the FIX: option B is a posture change on the shared base, so a family
+/// added here without an allowlisted tool behind it would be exactly the
+/// speculative widening the issue warned against. Asserting it in code is
+/// what keeps the audit table in `assistant/agent.toml` honest as the
+/// allowlist evolves.
+/// What: resolves the SHIPPED base through the real loader, derives each
+/// tool's dotted scope from the real `trusty-gworkspace` `rpc.discover`
+/// document through the real `parse_manifest`, and runs the real
+/// `filter_persona_tool_names` gate. No daemon, no network, no LLM — same
+/// harness shape as `cto_assistant_package_gmail_and_tasks_tools_survive_scope_intersection`
+/// (#3985).
+#[test]
+fn base_assistant_scope_grants_cover_every_allowlisted_gworkspace_tool() {
+    let agents_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join(".trusty-agents")
+        .join("agents");
+    let cfg = AgentConfig::by_name_in(&[agents_dir], "assistant")
+        .expect("bundled assistant template resolves");
+
+    let manifest = crate::tools::registry::discovery::parse_manifest(
+        "gworkspace",
+        &trusty_gworkspace::openrpc::discover_response(),
+    )
+    .expect("gworkspace rpc.discover document parses");
+    // A tool whose scope could not be derived gets `""` from discovery and is
+    // dropped by the ENDPOINT scope filter long before an agent sees it
+    // (`format_email_content`, a pure local transform, is the only such tool
+    // the base allowlists). Excluding those here keeps the assertion about
+    // agent scope grants rather than about discovery.
+    let tool_scopes: std::collections::HashMap<String, String> = manifest
+        .tools
+        .iter()
+        .filter(|t| !t.scope.is_empty())
+        .map(|t| (t.name.clone(), t.scope.clone()))
+        .collect();
+
+    let allow = cfg
+        .tools
+        .allow
+        .clone()
+        .expect("the base assistant declares [tools].allow");
+    let scopes = cfg
+        .tools
+        .scopes
+        .clone()
+        .expect("the base assistant declares [tools].scopes");
+    let patterns: Vec<ScopePattern> = scopes.iter().cloned().map(ScopePattern::new).collect();
+
+    // Exact allowlist entries that ARE scoped gworkspace tools. Glob entries
+    // (`granola_*`) and names gworkspace no longer exposes (`sync_drive`,
+    // `convert_document`, `publish_markdown_to_doc`, `render_mermaid_to_doc`,
+    // `format_slide`) are filtered by REGISTRATION, not by scope, so they are
+    // not this test's subject.
+    let scoped: Vec<String> = allow
+        .iter()
+        .filter(|n| !n.contains('*'))
+        .filter(|n| tool_scopes.contains_key(*n))
+        .cloned()
+        .collect();
+    assert!(
+        scoped.len() >= 50,
+        "expected the base's large gworkspace surface, got {} — has the \
+         allowlist or the manifest changed? {scoped:?}",
+        scoped.len()
+    );
+
+    let allowed_by_tier: std::collections::HashSet<String> = scoped.iter().cloned().collect();
+    let survivors = filter_persona_tool_names(
+        scoped.clone(),
+        &allow,
+        &allowed_by_tier,
+        &tool_scopes,
+        &patterns,
+    );
+    assert_eq!(
+        survivors, scoped,
+        "base assistant gworkspace tools were scope-denied at dispatch; \
+         resolved [tools].scopes = {scopes:?}"
+    );
+
+    // No speculative grants: every declared `google.*` family must be needed.
+    for pattern in patterns
+        .iter()
+        .filter(|p| p.as_str().starts_with("google."))
+    {
+        assert!(
+            scoped
+                .iter()
+                .any(|name| { pattern.matches(&Scope::new(tool_scopes[name].clone())) }),
+            "`{}` is granted but no allowlisted tool needs it — grant only \
+             families the allow-list actually names (#3987)",
+            pattern.as_str()
+        );
+    }
+}
+
+/// #3987 the negative half: a live family/wildcard pattern is never flagged,
+/// and option B introduces no double-grant weirdness in the overlays.
+/// `izzie` ships blanket `google.*`; `cto-assistant` ships the narrow
+/// `google.gmail.*` / `google.tasks.*` pair (#3985), which the base now also
+/// grants — `extends::union_opt_vec` dedups exact string matches, so the
+/// duplicates collapse rather than accumulating.
 #[test]
 fn shipped_agents_with_live_google_patterns_are_not_flagged() {
     use crate::tools::registry::dead_scope;
@@ -640,22 +738,23 @@ fn shipped_agents_with_live_google_patterns_are_not_flagged() {
     for name in ["izzie", "cto-assistant"] {
         let cfg = AgentConfig::by_name_in(std::slice::from_ref(&agents_dir), name)
             .unwrap_or_else(|e| panic!("bundled {name} resolves: {e}"));
-        let patterns: Vec<ScopePattern> = cfg
-            .tools
-            .scopes
-            .clone()
-            .unwrap_or_default()
-            .into_iter()
-            .map(ScopePattern::new)
-            .collect();
+        let scopes = cfg.tools.scopes.clone().unwrap_or_default();
+        let patterns: Vec<ScopePattern> = scopes.iter().cloned().map(ScopePattern::new).collect();
         let dead = dead_scope::dead_scope_patterns(&patterns, &reachable);
-        // Both agents UNION the base's scopes via `extends`, so they inherit
-        // `google.read` too — that inherited pattern is expected here and is
-        // removed by option B. What must NOT appear is any of their OWN
-        // family patterns.
+        // Post-option-B these overlays inherit only live patterns, so the
+        // resolved set must be completely clean — no `google.read` left to
+        // tolerate.
         assert!(
-            dead.iter().all(|d| d.pattern == "google.read"),
-            "{name}: a live family pattern was flagged dead: {dead:?}"
+            dead.is_empty(),
+            "{name}: dead scope grants after option B: {dead:?} (declared: {scopes:?})"
+        );
+        let mut deduped = scopes.clone();
+        deduped.sort();
+        deduped.dedup();
+        assert_eq!(
+            deduped.len(),
+            scopes.len(),
+            "{name}: the extends union produced duplicate scope patterns: {scopes:?}"
         );
     }
 }

--- a/crates/trusty-agents/src/tools/registry/dead_scope.rs
+++ b/crates/trusty-agents/src/tools/registry/dead_scope.rs
@@ -59,16 +59,22 @@
 //!
 //! ## Warning today, hard error later (deliberate sequencing)
 //!
-//! This is intentionally NOT a load-time error yet. At the time of writing,
-//! the bundled base `assistant` template itself declares the dead
-//! `google.read` pattern (`.trusty-agents/agents/assistant/agent.toml`), and
-//! every `extends = "assistant"` overlay inherits it by union — so failing
-//! closed here would break EVERY assistant load, including the default
-//! persona, on the very commit that added the check. #3987's option B
-//! removes that pattern from the shipped base; once it has landed and no
-//! bundled agent trips this diagnostic, escalating
-//! [`dead_scope_patterns`]'s callers from `warn!` to a hard load error is
-//! the intended follow-up. Do not escalate before then.
+//! This is still a `warn!` and not a load-time error. When option C landed it
+//! HAD to be: the bundled base `assistant` itself declared the dead
+//! `google.read` pattern, and every `extends = "assistant"` overlay inherited
+//! it by union, so failing closed would have broken every assistant load.
+//!
+//! #3987's option B has since removed that pattern
+//! (`.trusty-agents/agents/assistant/agent.toml` now grants explicit
+//! families), and
+//! `persona_tests::base_assistant_declares_no_dead_scope_patterns` +
+//! `shipped_agents_with_live_google_patterns_are_not_flagged` pin every
+//! bundled agent clean. **The sequencing constraint is therefore discharged
+//! and escalation to a hard error is unblocked** — it is deliberately left as
+//! a separate change because promoting a diagnostic to a fatal is a behaviour
+//! change for USER-authored agents (a hand-written `google.read` would stop
+//! loading rather than degrading), which deserves its own decision and its
+//! own release note rather than riding along with a config fix.
 //!
 //! **A second precondition for that escalation**: every caller must be
 //! feeding in the UNFILTERED endpoint vocabulary (source 2 above). Escalating
@@ -78,8 +84,8 @@
 //! bundled configs, before flipping this to an error.
 //!
 //! Test: the `tests` module below, plus
-//! `ctrl::pm_task::dispatch::persona_tests::base_assistant_google_read_is_a_dead_scope_pattern`
-//! which pins the diagnostic against the SHIPPED base template.
+//! `ctrl::pm_task::dispatch::persona_tests::base_assistant_declares_no_dead_scope_patterns`
+//! which pins the SHIPPED base template clean.
 
 use std::collections::BTreeSet;
 

--- a/docs/specs/agent-config-five-sections.md
+++ b/docs/specs/agent-config-five-sections.md
@@ -804,6 +804,14 @@ active on the persona-chat path.
 
 - **PM-5** This is filed separately rather than fixed inside a docs PR (OQ-6,
   §12). It is cited here as motivating evidence, not as spec content.
+- **RESOLVED (historical record above).** The overlay half was filed as #3938
+  and fixed in PR #3985 (the package now declares `google.gmail.*` /
+  `google.tasks.*`). The base half — `google.read` matching nothing at all —
+  was filed as #3987 and fixed in two parts: a dead-scope-pattern diagnostic
+  (`tools::registry::dead_scope`, warning at registry build and surfaced in
+  `GET /api/agents/:name/skills` as `dead_scope_patterns`), and explicit
+  per-family grants on the base `assistant`. §7.3's quoted scope line is the
+  pre-fix state, retained because it is what motivated this section.
 
 ### 7.4 Backend contract (NEW)
 


### PR DESCRIPTION
## Base branch

**This branch is stacked in git on `feat-3987-dead-scope-pattern-diagnostic` (#4018) — its parent commit is #4018's HEAD, not `main`.**

The PR's GitHub base is nonetheless set to `main`, deliberately: the CI workflows trigger only on `pull_request: branches: [main]`, so a PR targeting the stacked branch gets **zero checks reported** — I opened it against the stacked branch first and confirmed exactly that. Targeting `main` is what makes CI run at all.

Consequence: **the diff below currently shows #4018's commit as well as this one.** Review this PR as the second commit only (`fix(trusty-agents): grant the base assistant the Google families…`); #4018 is reviewed on its own PR. Once #4018 merges I will rebase this onto `main` so the diff reduces to this commit alone. **Merge #4018 first.**

## What

Issue #3987, **option B** — the second half of Bob's C-then-B decision (see the issue's PM-recommendation comment). The base `assistant` template's dead `google.read` is replaced with explicit family grants covering exactly the Google surfaces its allow-list already names.

`google.read` granted **nothing**. `ScopePattern::matches` takes the no-wildcard branch for it and requires string equality; discovery only ever emits `google.<family>.<access>` (`registry::google_scope::FAMILY_TABLE`). So all ~60 allowlisted Google Workspace tools on the base — and on every `extends = "assistant"` overlay that did not declare its own — were scope-denied at dispatch on the persona-chat path, and had been since the line was written.

## Authorization

This is a posture change on the shared base and is **explicitly authorized**, not landed as a "fix" on someone's own judgement:

> For the posture question, choose option B now: declare explicit family grants on the base assistant for the surfaces its allow-list already names. The read-only posture is already fictional — `google.read` grants nothing, so there is no read-only enforcement to preserve — and PR #3985 verified the allow-list remains the binding constraint (scope AND allow-list intersect at dispatch).
>
> — Bob, [PM-recommendation comment on #3987](https://github.com/bobmatnyc/trusty-tools/issues/3987), adopted as the decision; sequencing (C first, then B, as two PRs) directed separately.

## Family-grant audit

Derived tool-by-tool from the real `trusty_gworkspace::openrpc::discover_response()` document through the real `parse_manifest` → `x-google-scopes` mapping — not from reading the allow-list's section comments.

| Family granted | Dotted scope it covers | Allowlisted tools | Tools |
|---|---|---:|---|
| `google.gmail.*` | `google.gmail.write` | 9 | `compose_email`, `download_gmail_attachment`, `get_gmail_message_content`, `list_message_attachments`, `manage_gmail_filters`, `manage_gmail_labels`, `manage_gmail_settings`, `modify_gmail_messages`, `search_gmail_messages` |
| `google.calendar.*` | `google.calendar.write` | 3 | `manage_calendars`, `manage_events`, `query_free_busy` |
| `google.drive.*` | `google.drive.write` | 6 | `get_drive_file_content`, `list_drive_contents`, `list_shared_drives`, `manage_drive_file`, `manage_file_permissions`, `search_drive_files` |
| `google.docs.*` | `google.docs.write` | 25 | `append_to_document`, `apply_table_style`, `create_document`, `create_document_from_template`, `create_document_tab`, `create_list_in_document`, `delete_range_in_document`, `find_tables_in_document`, `format_document_range`, `format_paragraph_in_document`, `get_document`, `get_document_named_styles`, `get_document_structure`, `insert_image_in_document`, `insert_table_in_document`, `insert_text_in_document`, `manage_document_comments`, `manage_document_header_footer`, `manage_document_tabs`, `manage_table_structure`, `move_paragraph_in_document`, `replace_text_in_document`, `set_document_style`, `set_table_column_widths`, `update_document_named_styles` |
| `google.sheets.*` | `google.sheets.write` | 5 | `create_chart`, `format_sheet`, `get_spreadsheet`, `manage_spreadsheet`, `modify_sheet_values` |
| `google.slides.*` | `google.slides.write` | 3 | `add_slide_content`, `get_slides`, `manage_slides` |
| `google.tasks.*` | `google.tasks.write` | 2 | `manage_task_lists`, `manage_tasks` |
| `google.accounts.*` | `google.accounts.read` | 1 | `list_accounts` |

**Every family has at least one allowlisted tool, and every allowlisted scoped gworkspace tool has a family** — the audit came out with no family to drop and none to add. `google.*` (blanket) is deliberately NOT used: enumerating families means a new Google surface reaching the base is a deliberate edit rather than something a wildcard absorbs silently.

Allowlist entries deliberately **outside** this table, for completeness:

- `format_email_content` — a pure local transform; gworkspace advertises no scope for it, so discovery gives it `""` and the **endpoint** scope filter drops it long before an agent's grants matter. Not a scope question.
- `sync_drive`, `convert_document`, `publish_markdown_to_doc`, `render_mermaid_to_doc`, `format_slide` — allowlisted names gworkspace's manifest does not expose. Filtered by **registration**, not by scope (same category as `create_draft` / `create_task` in #3985's test).
- `okg_ingest_gmail` / `okg_ingest_drive` — in-process tools returning `None` from `ToolExecutor::scope()`; not scope-gated at all. Their section comment claimed they "reuse the existing read-only `google.read` credentials", which was false in both halves and is corrected.
- `granola_*`, `git_*`, `web_search`, `delegate_to_agent` — not Google.

## Posture, stated plainly

A base assistant granted these tools holds **write-capable Google credentials**. Every OAuth scope `trusty-gworkspace` requests is the full-access variant of its API, never a `.readonly` one (`trusty-gworkspace/src/openrpc.rs::scopes`) — the same `gmail.modify` token a "search" tool uses can also delete mail. The old §5.5 read-only claim is replaced in `assistant/agent.toml` with that statement rather than quietly dropped.

Two things bound the change:

- **The allow-list remains the binding constraint.** `filter_persona_tool_names` intersects `[tools].allow` (by name) AND `[tools].scopes` (by capability) — verified in #3985 — so these grants expose **no tool the curated allowlist does not already name**. Widening the reachable surface means editing `allow`, not this line.
- **Nothing was actually enforcing read-only before.** `google.read` matched nothing, so the practical delta is "the 60 tools the base advertises now work" rather than "the base gained a capability it was being denied".

Option A (a genuine read tier: `.readonly` OAuth variants, user re-consent, and either middle-wildcard support or a scope-naming redesign) remains deferred per Bob's decision. #3987 tracks it, so this PR does not resolve the issue.

## Overlays checked — no double-grant weirdness

`extends::merge_extends` unions scope lists through `union_opt_vec`, which dedups on exact string match:

- **`cto-assistant`** declares `google.gmail.*` / `google.tasks.*` (#3985). Both are now also on the base, so the union collapses them — the resolved list contains each exactly once. The declaration is **kept** on purpose: an overlay whose entire purpose is Gmail triage and Tasks sync should state the capability it depends on rather than rely on the shared base never narrowing it.
- **`izzie`** declares blanket `google.*`, a strict superset of the eight families. It appends (different string) and remains correct; matching is `any`, so the superset simply dominates.

`shipped_agents_with_live_google_patterns_are_not_flagged` now asserts both overlays resolve to a completely dead-grant-free set **and** that the union produced no duplicate patterns.

## Tests

- **`base_assistant_declares_no_dead_scope_patterns`** — the option-C shipped-config test, **inverted**. #4018 landed it asserting the base's `google.read` *was* dead (which is exactly why option C shipped as a `warn!` and not a load error); it now asserts the base is clean. It also guards against a vacuous pass in the other direction: `google.read` must be *gone*, and `google.gmail.*` must be *present* — deleting the whole scopes line would not satisfy it.
- **`base_assistant_scope_grants_cover_every_allowlisted_gworkspace_tool`** (new) — resolves the shipped base through the real loader, derives every tool's dotted scope from the real `rpc.discover` document, runs the real `filter_persona_tool_names` gate, and asserts (a) all 54 scoped allowlisted tools survive, and (b) **no granted `google.*` family lacks an allowlisted tool**. Direction (b) is the guard on the fix itself — it is what stops this list from quietly over-granting later. No daemon, no network, no LLM; same harness shape as #3985's test.
- **`base_assistant_package_is_generic_default_and_curated`** — the pre-existing #3738 loader test asserted `google.read` was present per §5.5. Updated to assert the eight families are present, `google.read` is absent, and blanket `google.*` is still refused on the base.
- **`shipped_agents_with_live_google_patterns_are_not_flagged`** — tightened from "only `google.read` may be flagged" to "nothing may be flagged", plus the union-dedup assertion.

## Docs corrected

- `assistant/agent.toml` — the `[tools].scopes` comment now explains what `google.read` actually did (nothing), states the write-capable posture, records the per-family audit inline, and notes the allow-list is the binding constraint. The `okg_ingest_*` section comment's false "read-only `google.read` credentials" claim is fixed.
- `izzie/agent.toml` and `cto-assistant/agent.toml` — stale comments describing the base's "read-only `google.read` default" corrected; `cto-assistant`'s #3938 note is re-framed as history plus the reason its now-redundant declaration is kept.
- `dead_scope.rs` module doc and the `persona.rs` call site — the "Warning today, hard error later" note now records that the sequencing constraint is **discharged** and escalation is unblocked, and why it is nonetheless left as its own change (promoting the diagnostic to fatal would stop *user-authored* agents from loading — a separate decision with its own release note).
- `docs/specs/agent-config-five-sections.md` §7.3 — the live-defect record gains a resolution note so it does not read as current state.

## Gates (raw)

```
$ cargo fmt --check
exit=0

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
   Compiling trusty-agents v0.38.6 (/private/tmp/wt-3987-b/crates/trusty-agents)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.10s

$ cargo test -p trusty-agents
test result: ok. 2648 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out; finished in 32.84s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 4 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ bash scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_agent_assets.sh
agent-assets: 29 byte-parity file(s) match, 4 pinned deviation(s) match upstream — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 46 spec doc(s) + 2888 code file(s); 0 error(s), 0 warning(s)
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
