### PR TITLE
feat(trusty-agents): function skills — grant a capability bundle with one line

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -52,6 +52,48 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     envelope. `scrub_branding` and the RBAC tier gate are untouched, and the
     widened schema still names no backend and enumerates no roster.
 
+- **Function skills — grant a whole capability with one line** (issues #4022,
+  #4023, #4025; part of epic #4021): the skill catalog gains a *bundling* tier
+  above the one-skill-per-tool base shipped in #3964. A `SkillKind::Function`
+  row names a fixed, compile-time set of member skill ids instead of wrapping a
+  tool, and naming it in `[skills].allow` grants every member (epic #4021's
+  OQ-1, resolved *grant-the-bundle* by the owner on 2026-07-26). The first
+  exemplar is **Ticketing**, bundling the ten existing `ticket-*` leaf skills.
+
+  The 1:1 model is untouched: every tool still maps to exactly one leaf skill,
+  every leaf stays independently grantable, and a bundle **compiles down** to
+  those leaves inside `SkillCatalog::expand` — *before* the three permission
+  layers run. The 1:1 layer and the allow-glob/RBAC/scope gates therefore never
+  see a bundle id, only exact leaf tool names, so #3964's defence in depth
+  (exact ids, no glob dialect, the glob-laundering fix) applies to a bundle
+  unchanged and is pinned by
+  `function_skill_never_leaks_its_bundle_id_into_the_tool_patterns`. Bundles are
+  built-in `const` data only — the authored `.md` frontmatter dialect has no
+  `members:` key and its parser requires a `tools:` list, so no file dropped
+  into a skill source can widen one grant into N. A bundle naming a member no
+  manifest resolves is a **manifest validation error** caught at build/test time
+  (`SkillCatalog::unknown_function_members`, a `debug_assert!` in
+  `SkillCatalog::builtin`, and `builtin_function_skills_declare_only_known_members`
+  in CI) rather than a runtime surprise; if one ever reaches production anyway,
+  expansion still narrows — the member contributes zero tools and is reported in
+  `unresolved`, never "all tools".
+
+  `GET /api/agents/:name/skills` surfaces bundles **additively**: every field a
+  pre-#4022 consumer reads keeps its name, type and meaning. Function skills
+  appear as ordinary `skills[]` cards with `kind: "function"`, and every card —
+  leaf or bundle — now carries `members`, `granted_members` and a tri-state
+  `granted_state` (`"all"`/`"some"`/`"none"` of the members) so a consumer needs
+  no kind check to read a field. A new top-level `groups[]` index gives the
+  Skills pane (#4024) group headers without re-deriving membership, and is built
+  from the same single computation as the cards so the two can never disagree.
+  The boolean `granted` keeps its old meaning — for a bundle it is
+  `granted_state == "all"`, the conservative answer — and `granted_count` still
+  counts capabilities, excluding bundles.
+
+  Per the domain authority (epic #4021 section D), the ticketing *domain* routes
+  to the subagent modality when one is available; the Ticketing function skill
+  is the direct-skill fallback, and its description says so.
+
 ### Changed
 
 - **`PmBridgeBackend::run` gained a `target: Option<&str>` parameter (#4026).**

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -70,7 +70,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `function_skill_never_leaks_its_bundle_id_into_the_tool_patterns`. Bundles are
   built-in `const` data only — the authored `.md` frontmatter dialect has no
   `members:` key and its parser requires a `tools:` list, so no file dropped
-  into a skill source can widen one grant into N. A bundle naming a member no
+  into a skill source can widen one grant into N. Nor can one *displace* a
+  built-in bundle by id: authored-beats-built-in (DOC-57 S-9) is a **renaming**
+  rule, and applied to a bundle id it would be a hijack — a `ticketing.md`
+  carrying `tools: ["execute_shell_command"]` would turn
+  `[skills].allow = ["ticketing"]` into a shell grant with nothing in
+  `agent.toml` for a reviewer to see and no `unresolved` entry. A bundle id is
+  the one name whose meaning cannot be checked by reading the config, so it is
+  the one name a skill source may not redefine; the attempt is now refused and
+  logged. A bundle's *members* stay ordinary displaceable leaves — that path
+  narrows the bundle and reports the lost member. A bundle naming a member no
   manifest resolves is a **manifest validation error** caught at build/test time
   (`SkillCatalog::unknown_function_members`, a `debug_assert!` in
   `SkillCatalog::builtin`, and `builtin_function_skills_declare_only_known_members`
@@ -106,6 +115,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   bare list so #4029's Sub-agents configuration section can add fields without
   a breaking config change, exactly as `SkillsConfig` was shaped. Absent =
   EMPTY, never "all". Exact names only, no glob dialect.
+- **Two smaller behaviour changes in `SkillCatalog::expand` (#4022).** Member
+  resolution is **memoised**, so expansion is linear in the catalog rather than
+  once per distinct path through the bundle graph — a depth-only cycle guard
+  would have re-walked a diamond-shaped graph exponentially, and `expand` runs
+  on every persona turn and subagent launch. As a consequence `unresolved[]`
+  now reports each dangling id **once** even when `[skills].allow` names it
+  more than once; previously a duplicate entry produced a duplicate report. The
+  Skills pane's own counts now exclude bundles, matching `granted_count` —
+  counting a group header as an eleventh capability printed "11 of N" over ten
+  rendered cards. DOC-57 gains §5.7b (S-13…S-16) specifying the tier, an
+  extended `kind` enum in §5.3, the new response fields in §5.7, and epic
+  #4021 OQ-1's resolution recorded alongside §12 OQ-2.
 
 ### Fixed
 

--- a/crates/trusty-agents/src/api/server/agent_skills.rs
+++ b/crates/trusty-agents/src/api/server/agent_skills.rs
@@ -26,6 +26,20 @@
 //!   `unmatched_patterns`, not dropped: it may still resolve to a live-
 //!   discovered MCP tool at dispatch time, and saying so is more useful than
 //!   either hiding it or claiming it is broken.
+//!
+//! **#4025 — function-skill groups.** The response is ADDITIVE only: every field
+//! a pre-#4022 consumer reads keeps its name, type and meaning. Function skills
+//! (#4022) appear as ordinary `skills[]` cards with `kind: "function"`, plus a
+//! top-level `groups[]` index so #4024's pane can render group headers without
+//! re-deriving membership from the catalog. Both are built from ONE computation
+//! ([`function_groups`]) rather than two, so a card and its group entry can never
+//! report different grant states. `granted_state` is the tri-state
+//! (`"all"`/`"some"`/`"none"` of the members) and the boolean `granted` stays
+//! what it always was — for a bundle it is `granted_state == "all"`, the
+//! conservative answer an existing consumer gets for free. `granted_count`
+//! deliberately EXCLUDES function cards: it counts capabilities, and a bundle is
+//! not a capability of its own — counting it would inflate the number the pane
+//! shows without the agent gaining anything.
 //! Test: `super::tests::agent_skills`.
 
 use std::path::{Path, PathBuf};
@@ -122,25 +136,32 @@ pub(super) async fn skills_at(dirs: &[PathBuf], name: &str, project_root: &Path)
     let (patterns, unresolved) =
         effective_tool_patterns(tools.allow.as_ref(), skills.allow.as_ref(), &catalog);
     let granted_ids = granted_skill_ids(&catalog, patterns.as_deref(), skills.allow.as_ref());
+    // #4025: one computation feeds both the function cards and `groups[]`.
+    let groups = function_groups(&catalog, &granted_ids);
 
     let mut cards: Vec<Value> = catalog
         .manifests()
         .iter()
-        .map(|m| render_skill(m, granted_ids.contains(&m.id)))
+        .map(|m| {
+            let group = groups.iter().find(|g| g.id == m.id);
+            render_skill(m, granted_ids.contains(&m.id), group)
+        })
         .collect();
     cards.extend(
         derived_skills(&catalog, patterns.as_deref())
             .iter()
-            .map(|m| render_skill(m, true)),
+            .map(|m| render_skill(m, true, None)),
     );
+    // A bundle is not a capability, so it does not move this count (#4025).
     let granted_count = cards
         .iter()
-        .filter(|c| c["granted"] == Value::Bool(true))
+        .filter(|c| c["granted"] == Value::Bool(true) && c["kind"] != "function")
         .count();
 
     let mut body = json!({
         "skills": cards,
         "granted_count": granted_count,
+        "groups": groups.iter().map(FunctionGroup::to_json).collect::<Vec<_>>(),
         "unresolved": unresolved
             .iter()
             .map(|id| json!({
@@ -187,12 +208,99 @@ fn granted_skill_ids(
     }
     if let Some(ids) = skills_allow {
         for id in ids {
-            if catalog.get(id).is_some_and(|m| m.tool().is_none()) {
+            // #4022: a FUNCTION skill is deliberately excluded from this clause.
+            // It is tool-less, so it would otherwise be granted merely by being
+            // named — asserting a grant this route never verified. Its state is
+            // derived from its members instead (`function_groups`), which is the
+            // only answer that stays true when a member fails to resolve.
+            if catalog
+                .get(id)
+                .is_some_and(|m| m.tool().is_none() && !m.is_function())
+            {
                 granted.insert(id.clone());
             }
         }
     }
     granted
+}
+
+/// One function skill resolved against this agent's grants (#4022/#4025).
+///
+/// Why: The pane needs "7 of 10 granted", which is neither a boolean nor
+/// derivable from the bundle id alone. Computing it ONCE here — from the
+/// `granted_ids` set the leaf cards already use — is what stops the group header
+/// and its member cards from disagreeing, which is the display-layer form of the
+/// same drift `granted_skill_ids` exists to prevent against dispatch.
+/// What: The bundle's identity plus its declared members and the subset of them
+/// this agent holds.
+/// Test: `skills_route_surfaces_function_skill_tri_state`.
+struct FunctionGroup {
+    id: String,
+    name: String,
+    description: String,
+    members: Vec<String>,
+    granted_members: Vec<String>,
+}
+
+impl FunctionGroup {
+    /// `"all"` / `"some"` / `"none"` of the members are granted.
+    ///
+    /// Why/What: A memberless bundle reports `"none"` rather than the vacuous
+    /// `"all"` — claiming a group is fully granted when it contains nothing is
+    /// the fabrication #3945 forbids.
+    /// Test: `skills_route_surfaces_function_skill_tri_state`.
+    fn state(&self) -> &'static str {
+        if self.members.is_empty() || self.granted_members.is_empty() {
+            "none"
+        } else if self.granted_members.len() == self.members.len() {
+            "all"
+        } else {
+            "some"
+        }
+    }
+
+    fn to_json(&self) -> Value {
+        json!({
+            "id": self.id,
+            "name": self.name,
+            "description": self.description,
+            "members": self.members,
+            "granted_members": self.granted_members,
+            "granted_state": self.state(),
+        })
+    }
+}
+
+/// Resolve every function skill in the catalog against this agent's grants.
+///
+/// Why: See [`FunctionGroup`] — one computation, two render sites.
+/// What: One entry per `kind: Function` manifest, members in declaration order.
+/// A member id no manifest resolves is still LISTED (it is what the bundle
+/// declares) but can never appear in `granted_members`, so an unresolvable
+/// member drags the state down to `"some"`/`"none"` rather than being hidden.
+/// Test: `skills_route_surfaces_function_skill_tri_state`,
+/// `function_group_never_reports_all_when_a_member_is_missing`.
+fn function_groups(
+    catalog: &SkillCatalog,
+    granted_ids: &std::collections::BTreeSet<String>,
+) -> Vec<FunctionGroup> {
+    catalog
+        .manifests()
+        .iter()
+        .filter(|m| m.is_function())
+        .map(|m| FunctionGroup {
+            id: m.id.clone(),
+            name: m.name.clone(),
+            description: m.description.clone(),
+            members: m.members.clone(),
+            granted_members: m
+                .members
+                .iter()
+                .filter(|id| granted_ids.contains(*id))
+                .cloned()
+                .collect(),
+        })
+        .collect()
 }
 
 /// Derived 1:1 skills for exactly-named tools the catalog does not know.
@@ -269,8 +377,17 @@ fn unmatched_patterns(catalog: &SkillCatalog, patterns: Option<&[String]>) -> Ve
 /// OAuth grant or MCP wiring that this endpoint does not verify. Rendering
 /// `null` as "not verified" is the whole point — a `false` there would assert a
 /// check nobody ran.
-/// Test: `skill_card_reports_env_credential_state`.
-fn render_skill(manifest: &SkillManifest, granted: bool) -> Value {
+///
+/// #4025: `members` and `granted_state` are present on EVERY card, not just
+/// function ones. A consumer that has to check the kind before it knows whether
+/// a field exists writes the branch wrong once and then renders a leaf skill as
+/// an empty group; a uniform shape costs two empty arrays and removes the
+/// branch. For a leaf, `members` is empty and `granted_state` restates `granted`.
+/// For a bundle, `granted` is `granted_state == "all"` — the boolean an existing
+/// consumer already reads keeps its conservative meaning.
+/// Test: `skill_card_reports_env_credential_state`,
+/// `skills_route_surfaces_function_skill_tri_state`.
+fn render_skill(manifest: &SkillManifest, granted: bool, group: Option<&FunctionGroup>) -> Value {
     let provider = manifest.provider.map(|p| {
         let configured = p.env_var.map(|var| {
             std::env::var(var)
@@ -284,15 +401,23 @@ fn render_skill(manifest: &SkillManifest, granted: bool) -> Value {
             "configured": configured,
         })
     });
+    let granted_state = match group {
+        Some(g) => g.state(),
+        None if granted => "all",
+        None => "none",
+    };
     json!({
         "id": manifest.id,
         "name": manifest.name,
         "description": manifest.description,
         "kind": manifest.kind,
         "origin": manifest.origin,
-        "granted": granted,
+        "granted": group.map_or(granted, |g| g.state() == "all"),
         "tools": manifest.tools,
         "provider": provider,
+        "members": group.map(|g| g.members.clone()).unwrap_or_default(),
+        "granted_members": group.map(|g| g.granted_members.clone()).unwrap_or_default(),
+        "granted_state": granted_state,
     })
 }
 
@@ -438,7 +563,7 @@ mod unit_tests {
         let catalog = SkillCatalog::builtin();
         // OAuth-backed: `configured` must stay null — unknown, never asserted.
         let gmail = catalog.skill_for_tool("search_gmail_messages").unwrap();
-        let card = render_skill(gmail, true);
+        let card = render_skill(gmail, true, None);
         assert_eq!(card["provider"]["configured"], Value::Null);
         assert_eq!(card["provider"]["provider"], "Google Workspace");
         assert_eq!(card["granted"], true);
@@ -447,16 +572,55 @@ mod unit_tests {
         // environment. Its VALUE depends on the machine, so assert only that a
         // boolean — not null — is produced.
         let mta = catalog.skill_for_tool("get_train_schedule").unwrap();
-        let card = render_skill(mta, false);
+        let card = render_skill(mta, false, None);
         assert!(card["provider"]["configured"].is_boolean());
         assert_eq!(card["provider"]["env_var"], "MTA_API_KEY");
+    }
+
+    #[test]
+    fn granted_ids_do_not_grant_a_function_skill_by_id_alone() {
+        // #4022: a bundle is tool-less, so the tool-less clause would otherwise
+        // grant it just for being named — asserting a grant nobody verified.
+        // Its state comes from its members, computed by `function_groups`.
+        let catalog = SkillCatalog::builtin();
+        let allow = vec!["ticketing".to_string()];
+        let granted = granted_skill_ids(&catalog, Some(&[]), Some(&allow));
+        assert!(!granted.contains("ticketing"));
+    }
+
+    #[test]
+    fn function_group_never_reports_all_when_a_member_is_missing() {
+        // Tri-state honesty: nine of ten is `"some"`, never `"all"`. A member
+        // that fails to resolve can never enter `granted_ids`, so this is also
+        // the shape an unresolvable member produces.
+        let catalog = SkillCatalog::builtin();
+        let ticketing = catalog.get("ticketing").expect("ticketing bundle");
+        let mut granted: std::collections::BTreeSet<String> =
+            ticketing.members.iter().cloned().collect();
+        let dropped = ticketing.members.last().unwrap().clone();
+        granted.remove(&dropped);
+
+        let groups = function_groups(&catalog, &granted);
+        let g = groups.iter().find(|g| g.id == "ticketing").unwrap();
+        assert_eq!(g.members.len(), 10);
+        assert_eq!(g.granted_members.len(), 9);
+        assert_eq!(g.state(), "some");
+        assert!(!g.granted_members.contains(&dropped));
+
+        // And the full set is `"all"` — the tri-state is not stuck.
+        let full: std::collections::BTreeSet<String> = ticketing.members.iter().cloned().collect();
+        let groups = function_groups(&catalog, &full);
+        assert_eq!(
+            groups.iter().find(|g| g.id == "ticketing").unwrap().state(),
+            "all"
+        );
     }
 
     #[test]
     fn skill_card_carries_one_tool_and_a_human_name() {
         let catalog = SkillCatalog::builtin();
         let mta = catalog.skill_for_tool("get_train_schedule").unwrap();
-        let card = render_skill(mta, true);
+        let card = render_skill(mta, true, None);
         assert_eq!(card["name"], "MTA Train Time");
         assert_eq!(card["tools"], json!(["get_train_schedule"]));
         assert_eq!(card["origin"]["kind"], "builtin");

--- a/crates/trusty-agents/src/api/server/tests/agent_skills.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_skills.rs
@@ -365,3 +365,143 @@ async fn skills_route_is_wired_into_the_router() {
     let body = body_json(resp).await;
     assert_eq!(body["error"], "unknown agent");
 }
+
+// --------------------------------------------------------------------------
+// Function-skill groups (#4025)
+// --------------------------------------------------------------------------
+
+/// Grants the whole `ticketing` bundle with one line (#4022 grant-the-bundle).
+const BUNDLE_FIXTURE: &str = r#"[agent]
+name = "bundled"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[skills]
+allow = ["ticketing"]
+"#;
+
+/// Grants three of the bundle's ten members individually — the `"some"` case.
+const PARTIAL_BUNDLE_FIXTURE: &str = r#"[agent]
+name = "partial"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[skills]
+allow = ["ticket-create", "ticket-read", "ticket-close"]
+"#;
+
+fn group<'a>(body: &'a serde_json::Value, id: &str) -> &'a serde_json::Value {
+    body["groups"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|g| g["id"] == id)
+        .unwrap_or_else(|| panic!("group {id} missing from response"))
+}
+
+#[tokio::test]
+async fn skills_route_surfaces_function_skill_tri_state() {
+    // All three states of the same bundle, from three real agent configs.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("bundled.toml"), BUNDLE_FIXTURE).unwrap();
+    std::fs::write(dir.path().join("partial.toml"), PARTIAL_BUNDLE_FIXTURE).unwrap();
+    std::fs::write(dir.path().join("plain.toml"), BARE_FIXTURE).unwrap();
+    let dirs = [dir.path().to_path_buf()];
+
+    let all = body_json(skills_at(&dirs, "bundled", dir.path()).await).await;
+    let card = find(&all, "ticketing");
+    assert_eq!(card["kind"], "function");
+    assert_eq!(card["granted_state"], "all");
+    assert_eq!(card["granted"], true);
+    assert_eq!(card["members"].as_array().unwrap().len(), 10);
+    assert_eq!(card["granted_members"].as_array().unwrap().len(), 10);
+    assert_eq!(
+        find(&all, "ticket-create")["granted"],
+        true,
+        "granting the bundle grants each member card"
+    );
+
+    let some = body_json(skills_at(&dirs, "partial", dir.path()).await).await;
+    let card = find(&some, "ticketing");
+    assert_eq!(card["granted_state"], "some");
+    assert_eq!(
+        card["granted"], false,
+        "the boolean stays conservative: partial is not granted"
+    );
+    assert_eq!(card["granted_members"].as_array().unwrap().len(), 3);
+    assert_eq!(find(&some, "ticket-search")["granted"], false);
+
+    let none = body_json(skills_at(&dirs, "plain", dir.path()).await).await;
+    let card = find(&none, "ticketing");
+    assert_eq!(card["granted_state"], "none");
+    assert_eq!(card["granted"], false);
+    assert!(card["granted_members"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn skills_route_groups_agree_with_their_cards() {
+    // One computation, two render sites — the group index and the card must
+    // never be able to disagree about the same bundle.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("partial.toml"), PARTIAL_BUNDLE_FIXTURE).unwrap();
+
+    let body = body_json(skills_at(&[dir.path().to_path_buf()], "partial", dir.path()).await).await;
+    let g = group(&body, "ticketing");
+    let card = find(&body, "ticketing");
+    assert_eq!(g["name"], "Ticketing");
+    assert_eq!(g["members"], card["members"]);
+    assert_eq!(g["granted_members"], card["granted_members"]);
+    assert_eq!(g["granted_state"], card["granted_state"]);
+}
+
+#[tokio::test]
+async fn skills_route_bundle_grant_never_shows_the_bundle_id_as_a_tool() {
+    // The pin, restated at the audit surface: the bundle id compiles down to
+    // leaf tools, so it must never appear as a tool NOR as an unmatched pattern.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("bundled.toml"), BUNDLE_FIXTURE).unwrap();
+
+    let body = body_json(skills_at(&[dir.path().to_path_buf()], "bundled", dir.path()).await).await;
+    assert!(
+        find(&body, "ticketing")["tools"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
+    assert!(body["unresolved"].as_array().unwrap().is_empty());
+    assert!(body["unmatched_patterns"].as_array().unwrap().is_empty());
+    for card in body["skills"].as_array().unwrap() {
+        for tool in card["tools"].as_array().unwrap() {
+            assert_ne!(tool, "ticketing", "the bundle id surfaced as a tool");
+        }
+    }
+}
+
+#[tokio::test]
+async fn skills_route_leaf_cards_keep_their_pre_4022_shape() {
+    // Additive-only (DOC-58 §5.3 discipline): every field an existing consumer
+    // reads keeps its name, type and meaning, and the new ones are inert on a
+    // leaf. `granted_count` must still count capabilities, not bundles.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("izzie.toml"), TOOLS_ONLY_FIXTURE).unwrap();
+
+    let body = body_json(skills_at(&[dir.path().to_path_buf()], "izzie", dir.path()).await).await;
+    let trains = find(&body, "mta-train-time");
+    assert_eq!(trains["granted"], true);
+    assert_eq!(trains["kind"], "action");
+    assert_eq!(trains["tools"], serde_json::json!(["get_train_schedule"]));
+    assert!(trains["members"].as_array().unwrap().is_empty());
+    assert_eq!(trains["granted_state"], "all");
+    assert_eq!(find(&body, "gmail-search")["granted_state"], "none");
+
+    let granted_count = body["granted_count"].as_u64().unwrap();
+    let granted_leaf_cards = body["skills"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|c| c["granted"] == true && c["kind"] != "function")
+        .count() as u64;
+    assert_eq!(granted_count, granted_leaf_cards);
+}

--- a/crates/trusty-agents/src/skills/manifest/authored.rs
+++ b/crates/trusty-agents/src/skills/manifest/authored.rs
@@ -138,6 +138,11 @@ fn parse(path: &Path, content: &str) -> Vec<SkillManifest> {
             kind,
             tools: vec![tool],
             provider: None,
+            // #4022: authored manifests are always LEAVES. The frontmatter
+            // dialect has no `members:` key and this parser requires a `tools:`
+            // list, so no `.md` dropped into a skill source can declare a bundle
+            // — one authored file can never widen one grant into N.
+            members: Vec::new(),
             origin: SkillOrigin::Authored {
                 path: path.display().to_string(),
             },

--- a/crates/trusty-agents/src/skills/manifest/builtin/functions.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/functions.rs
@@ -1,0 +1,57 @@
+//! Function skills — the bundling tier over the 1:1 leaf catalog (#4022/#4023).
+//!
+//! Why: The owner's directive (2026-07-26) — *"Skills also need to be organized
+//! by function. So 'ticketing' is a skill with various capabilities including
+//! all the skills under one."* — sits one tier ABOVE the one-skill-per-tool
+//! model, not in place of it. Epic #4021's OQ-1 was resolved *grant-the-bundle*,
+//! so a row here is a real grant: naming it in `[skills].allow` grants every
+//! member. Nothing about the leaf tier changes — each of these members is still
+//! independently grantable, still wraps exactly one tool, and the bundle
+//! compiles down to those leaves before any permission gate runs.
+//!
+//! **Why bundles are `const` and built-in only.** A bundle is the one skill
+//! shape that turns one line of config into N capabilities, which is exactly the
+//! shape a privilege-escalation bug wants. Keeping the member lists in
+//! compile-time data means the set is closed, reviewable in a diff, and checked
+//! by `builtin_function_skills_declare_only_known_members` — there is no runtime
+//! path (authored `.md`, MCP discovery) that can author one.
+//! What: A `const` table of [`function_skill`] rows, each naming member skill
+//! ids that exist elsewhere in [`super::all`].
+//! Test: `super::super::tests` — `ticketing_function_skill_bundles_the_ten_ticket_leaf_skills`,
+//! `function_skill_never_leaks_its_bundle_id_into_the_tool_patterns`.
+
+use super::super::{SkillDef, function_skill};
+
+/// The ten ticketing leaf skills, in `ops.rs` catalog order.
+///
+/// Why: Spelled out rather than derived from a name prefix — DOC-57 §5.5/S-8 is
+/// explicit that *"no prefix grouping [exists] anywhere in this model"*, and a
+/// `ticket-*` prefix scan would be precisely that: a glob dialect reintroduced
+/// through the back door, silently absorbing any future `ticket-`-prefixed skill
+/// into an existing grant. An explicit list means adding a leaf is a deliberate
+/// decision to widen the bundle, visible in review.
+/// Test: `ticketing_function_skill_bundles_the_ten_ticket_leaf_skills`.
+const TICKETING_MEMBERS: &[&str] = &[
+    "ticket-create",
+    "ticket-read",
+    "ticket-update",
+    "ticket-close",
+    "ticket-list",
+    "ticket-comment",
+    "ticket-tag",
+    "ticket-assign",
+    "ticket-transition",
+    "ticket-search",
+];
+
+pub(super) static TABLE: &[SkillDef] = &[function_skill(
+    "ticketing",
+    "Ticketing",
+    "Everything needed to work a tracker end to end: open, read, update, comment \
+     on, label, assign, transition, search and close tickets. Granting this one \
+     skill grants all ten ticket operations. Note: per the domain authority \
+     (epic #4021 section D), the ticketing DOMAIN routes to the subagent \
+     modality when a ticketing subagent is available — this function skill is \
+     the direct-skill fallback used when it is not.",
+    TICKETING_MEMBERS,
+)];

--- a/crates/trusty-agents/src/skills/manifest/builtin/mod.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/mod.rs
@@ -14,6 +14,9 @@
 //! Test: `super::tests`.
 
 mod core;
+// #4022: the bundling tier — declared last so leaf rows are always inserted
+// before the bundles that name them.
+mod functions;
 mod gworkspace;
 mod knowledge;
 mod ops;
@@ -70,5 +73,7 @@ pub fn all() -> Vec<&'static SkillDef> {
         .chain(gworkspace::TABLE)
         .chain(platform::TABLE)
         .chain(prose::TABLE)
+        // #4022: function skills last — they reference the leaf ids above.
+        .chain(functions::TABLE)
         .collect()
 }

--- a/crates/trusty-agents/src/skills/manifest/mod.rs
+++ b/crates/trusty-agents/src/skills/manifest/mod.rs
@@ -380,11 +380,14 @@ impl SkillCatalog {
         // `builtin_function_skills_declare_only_known_members` in CI. Release
         // builds fall through to expansion's narrow-never-widen behaviour rather
         // than aborting a running daemon over a catalog typo.
-        debug_assert!(
-            catalog.unknown_function_members().is_empty(),
-            "built-in function skills name unknown members: {:?}",
-            catalog.unknown_function_members()
-        );
+        #[cfg(debug_assertions)]
+        {
+            let unknown = catalog.unknown_function_members();
+            debug_assert!(
+                unknown.is_empty(),
+                "built-in function skills name unknown members: {unknown:?}"
+            );
+        }
         catalog
     }
 
@@ -436,11 +439,35 @@ impl SkillCatalog {
     /// manifest came from a higher-priority source and must survive — evicting
     /// it here is what silently inverted source precedence. Filtering on
     /// `origin` keeps both rules intact in one pass.
-    /// What: Retains everything except built-in rows colliding by id or tool.
-    /// Test: `authored_multi_source_precedence_first_source_wins`.
+    ///
+    /// **#4022 — a built-in FUNCTION row is exempt from id displacement.**
+    /// Authored-beats-built-in is a *renaming* rule: it lets an operator
+    /// re-describe a capability. Applied to a bundle id it stops being a rename
+    /// and becomes a HIJACK — dropping `ticketing.md` with
+    /// `tools: ["execute_shell_command"]` into any skill source would evict the
+    /// ten-member bundle and leave `[skills].allow = ["ticketing"]` resolving to
+    /// a shell, with no `unresolved` entry and nothing in `agent.toml` for a
+    /// reviewer to notice. The bundle id is the one name whose meaning a
+    /// reviewer cannot check by reading the config, so it is the one name a
+    /// skill source may not redefine. An authored row may still displace a
+    /// bundle's MEMBERS by id or tool — that path narrows and reports (see
+    /// `authored_displacement_of_a_member_narrows_the_bundle_and_reports_it`).
+    /// What: Retains everything except built-in rows colliding by id or tool,
+    /// EXCEPT built-in function rows, which survive an id collision and log it.
+    /// Test: `authored_multi_source_precedence_first_source_wins`,
+    /// `authored_md_cannot_displace_a_builtin_bundle_id`.
     fn remove_displaced_builtins(&mut self, incoming: &SkillManifest) {
         self.manifests.retain(|m| {
             if m.origin != SkillOrigin::Builtin {
+                return true;
+            }
+            if m.is_function() && m.id == incoming.id {
+                tracing::warn!(
+                    skill = %m.id,
+                    "an authored skill manifest claims a built-in function-skill id; \
+                     refusing to displace the bundle (a bundle id may not be redefined \
+                     by a skill source)"
+                );
                 return true;
             }
             m.id != incoming.id && (m.tool().is_none() || m.tool() != incoming.tool())
@@ -459,11 +486,32 @@ impl SkillCatalog {
     /// a glob-shaped tool never reaches `by_tool`, so it can never be expanded
     /// into an allow-pattern. Defence in depth on a privilege-escalation path is
     /// worth the duplicated check.
-    /// What: Skips insertion when `tool` is already indexed or is not an exact
-    /// name; tool-less skills always insert.
+    /// **#4022 — a bundle id is never shadowed.** `remove_displaced_builtins`
+    /// already refuses to evict a function row, but that leaves the incoming row
+    /// free to sit behind it as a duplicate id — and `get` returning the first
+    /// match makes "which one wins" a property of insertion order rather than of
+    /// a stated rule. Refusing the insert makes the bundle the single answer for
+    /// its id on every construction path, including hand-rolled ones that never
+    /// go through `with_authored`. Defence in depth, same posture as the
+    /// duplicated glob check above.
+    /// What: Skips insertion when `tool` is already indexed, is not an exact
+    /// name, or the id is already held by a function skill; tool-less skills
+    /// otherwise always insert.
     /// Test: `authored_glob_shaped_tool_entry_is_rejected_not_granted`,
-    /// `catalog_insert_refuses_a_glob_shaped_tool`.
+    /// `catalog_insert_refuses_a_glob_shaped_tool`,
+    /// `authored_md_cannot_displace_a_builtin_bundle_id`.
     fn insert(&mut self, manifest: SkillManifest) {
+        if self
+            .manifests
+            .iter()
+            .any(|m| m.is_function() && m.id == manifest.id)
+        {
+            tracing::warn!(
+                skill = %manifest.id,
+                "a function skill already owns this id; refusing to shadow it"
+            );
+            return;
+        }
         if let Some(tool) = manifest.tool()
             && (self.by_tool.contains_key(tool) || !is_exact_tool_name(tool))
         {
@@ -553,18 +601,26 @@ impl SkillCatalog {
     /// is REPORTED (never "all tools"), and a bundle can only ever reach tools
     /// its members already wrap.
     ///
-    /// `visiting` is a cycle guard. Bundles are compile-time data today, so a
-    /// cycle is a catalog bug rather than untrusted input — but the guard turns
-    /// that bug into a bounded, logged no-op instead of a stack overflow, which
-    /// is the difference between a failing test and a crashed daemon.
-    /// What: Leaf → push its tool if new. Function → recurse over members.
-    /// Unknown → record in `unresolved` once.
-    /// Test: `function_skill_member_cycle_terminates_without_widening`.
+    /// `acc.expanded` is a MEMOISATION set, and it is load-bearing for both
+    /// correctness and cost. Expanding an id is idempotent — tools dedupe
+    /// through `seen_tools` and a miss is recorded once — so a second visit can
+    /// only redo work. Recording ids permanently (rather than unwinding a
+    /// visited-set on the way out, which only bounds DEPTH) makes the walk
+    /// linear in the catalog and cycle-safe by the same stroke. The distinction
+    /// is not academic: an unwinding guard re-walks a DAG once per distinct
+    /// path, so a 24-level fan-out-2 bundle graph costs ~16.7M recursions, and
+    /// `expand` runs on EVERY persona turn and subagent launch — a catalog
+    /// shape, not untrusted input, would have become a latent CPU stall.
+    /// What: Already-expanded → return. Leaf → push its tool if new. Function →
+    /// recurse over members. Unknown → record in `unresolved`.
+    /// Test: `function_skill_member_cycle_terminates_without_widening`,
+    /// `function_skill_fan_out_expands_in_linear_work`.
     fn expand_id(&self, id: &str, acc: &mut Expansion) {
+        if !acc.expanded.insert(id.to_string()) {
+            return;
+        }
         let Some(manifest) = self.get(id) else {
-            if !acc.unresolved.iter().any(|u| u == id) {
-                acc.unresolved.push(id.to_string());
-            }
+            acc.unresolved.push(id.to_string());
             return;
         };
         if let Some(tool) = manifest.tool() {
@@ -576,17 +632,9 @@ impl SkillCatalog {
         if !manifest.is_function() {
             return; // Tool-less prose skill: resolves, contributes nothing.
         }
-        if !acc.visiting.insert(manifest.id.clone()) {
-            tracing::warn!(
-                skill = %manifest.id,
-                "function skill members form a cycle; refusing to recurse further"
-            );
-            return;
-        }
         for member in &manifest.members {
             self.expand_id(member, acc);
         }
-        acc.visiting.remove(&manifest.id);
     }
 
     /// Function-skill members no manifest in this catalog resolves.
@@ -617,15 +665,18 @@ impl SkillCatalog {
 /// Mutable accumulator threaded through [`SkillCatalog::expand_id`].
 ///
 /// Why/What: Four parallel `&mut` parameters through a recursive walk is how
-/// a resolution bug gets written; one struct keeps the dedup set, the output
-/// and the cycle guard in lockstep.
-/// Test: `function_skill_expands_to_the_union_of_its_members_tools`.
+/// a resolution bug gets written; one struct keeps the dedup sets and the
+/// output in lockstep. `expanded` is both the cycle guard and the memo table
+/// (see [`SkillCatalog::expand_id`]); because it also makes each id reachable
+/// once, `unresolved` needs no dedup scan of its own.
+/// Test: `function_skill_expands_to_the_union_of_its_members_tools`,
+/// `function_skill_fan_out_expands_in_linear_work`.
 #[derive(Default)]
 struct Expansion {
     tools: Vec<String>,
     seen_tools: BTreeSet<String>,
     unresolved: Vec<String>,
-    visiting: BTreeSet<String>,
+    expanded: BTreeSet<String>,
 }
 
 /// The outcome of expanding a `[skills].allow` list.

--- a/crates/trusty-agents/src/skills/manifest/mod.rs
+++ b/crates/trusty-agents/src/skills/manifest/mod.rs
@@ -30,14 +30,19 @@ use serde::Serialize;
 /// Why: `kind` is the only mechanism routing capability between the Knowledge
 /// and Skills panes; neither pane hardcodes tool names.
 /// What: `Action` (Skills pane), `Knowledge` (Knowledge pane), `System`
-/// (Skills pane, collapsed under "System").
-/// Test: `knowledge_kind_routes_out_of_the_skills_pane`.
+/// (Skills pane, collapsed under "System"), `Function` (#4022 — a *bundling*
+/// row, rendered as a group header over its member cards rather than as a
+/// capability of its own).
+/// Test: `knowledge_kind_routes_out_of_the_skills_pane`,
+/// `builtin_function_rows_declare_members_and_no_tool`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum SkillKind {
     Action,
     Knowledge,
     System,
+    /// #4022: a function skill — names member skill ids, wraps no tool itself.
+    Function,
 }
 
 /// A provider/credential a skill's tool depends on.
@@ -79,6 +84,15 @@ pub struct SkillDef {
     pub tool: Option<&'static str>,
     pub kind: SkillKind,
     pub provider: Option<&'static ProviderReq>,
+    /// #4022: member skill ids, for a **function skill** only.
+    ///
+    /// Why: Mutually exclusive with `tool` — a row is either a leaf wrapping
+    /// exactly one tool, or a bundle naming N leaves, never both. Modelling the
+    /// empty case as an empty slice rather than an `Option` keeps every existing
+    /// `const fn` constructor total and lets read sites ask `is_function()`
+    /// instead of pattern-matching two shapes.
+    /// Test: `builtin_function_rows_declare_members_and_no_tool`.
+    pub members: &'static [&'static str],
 }
 
 /// Terse constructor for a tool-wrapping built-in row.
@@ -103,6 +117,7 @@ pub const fn tool_skill(
         tool: Some(tool),
         kind,
         provider,
+        members: &[],
     }
 }
 
@@ -127,6 +142,42 @@ pub const fn prose_skill(
         tool: None,
         kind,
         provider: None,
+        members: &[],
+    }
+}
+
+/// Terse constructor for a **function skill** — a bundle of member skill ids.
+///
+/// Why (#4022, epic #4021 OQ-1 resolved *grant-the-bundle*): the owner's model
+/// is *"'ticketing' is a skill with various capabilities including all the
+/// skills under one"*. One `[skills].allow` entry should grant a whole
+/// capability. This is deliberately a **manifest-layer** primitive, not a new
+/// matcher: a function skill still resolves to an exact, closed, compile-time
+/// set of leaf ids, so it COMPILES DOWN to the same 1:1 rows the permission
+/// gates already see. No glob dialect is added, `is_exact_tool_name` still
+/// guards every name that reaches an allow-pattern, and the bundle id itself
+/// never leaves this layer.
+/// What: Builds a [`SkillDef`] with `tool: None`, `kind: Function`, and the
+/// given member ids. Members are leaf (or nested function) skill ids resolved
+/// against the same catalog — unknown ids are a **manifest validation error**
+/// caught at build/test time by [`SkillCatalog::unknown_function_members`], and
+/// at runtime they narrow (contribute zero tools, surface in `unresolved`).
+/// Test: `function_skill_expands_to_the_union_of_its_members_tools`,
+/// `function_skill_never_leaks_its_bundle_id_into_the_tool_patterns`.
+pub const fn function_skill(
+    id: &'static str,
+    name: &'static str,
+    description: &'static str,
+    members: &'static [&'static str],
+) -> SkillDef {
+    SkillDef {
+        id,
+        name,
+        description,
+        tool: None,
+        kind: SkillKind::Function,
+        provider: None,
+        members,
     }
 }
 
@@ -167,6 +218,16 @@ pub struct SkillManifest {
     pub tools: Vec<String>,
     pub provider: Option<ProviderReq>,
     pub origin: SkillOrigin,
+    /// #4022: member skill ids when this is a function skill; empty otherwise.
+    ///
+    /// Why: Authored `.md` frontmatter has no `members:` key and its parser
+    /// requires a `tools:` list, so an AUTHORED manifest is always a leaf and
+    /// this is always empty for it. Bundles are therefore built-in-only in this
+    /// slice — an operator cannot drop a `.md` into a skill source that widens
+    /// one grant into N. That is a deliberate narrowing of the attack surface,
+    /// not an oversight.
+    /// Test: `authored_manifest_cannot_declare_a_bundle`.
+    pub members: Vec<String>,
 }
 
 impl SkillManifest {
@@ -183,6 +244,8 @@ impl SkillManifest {
             tools: def.tool.map(str::to_string).into_iter().collect(),
             provider: def.provider.copied(),
             origin: SkillOrigin::Builtin,
+            // #4022: bundles are declared in the const table, adopted verbatim.
+            members: def.members.iter().map(|m| (*m).to_string()).collect(),
         }
     }
 
@@ -207,6 +270,7 @@ impl SkillManifest {
             tools: vec![tool.to_string()],
             provider: None,
             origin: SkillOrigin::Derived,
+            members: Vec::new(),
         }
     }
 
@@ -217,6 +281,18 @@ impl SkillManifest {
     /// Test: `tool_less_skills_are_present_and_expand_to_no_tools`.
     pub fn tool(&self) -> Option<&str> {
         self.tools.first().map(String::as_str)
+    }
+
+    /// Whether this row is a #4022 bundle rather than a leaf capability.
+    ///
+    /// Why: Read sites must distinguish "tool-less because it is prose guidance"
+    /// from "tool-less because it is a group header" WITHOUT inspecting
+    /// `members` — a bundle whose members all failed to resolve is still a
+    /// bundle, and treating it as a tool-less prose skill would grant it by id.
+    /// What: True when `kind` is [`SkillKind::Function`].
+    /// Test: `granted_ids_do_not_grant_a_function_skill_by_id_alone`.
+    pub fn is_function(&self) -> bool {
+        self.kind == SkillKind::Function
     }
 }
 
@@ -299,6 +375,16 @@ impl SkillCatalog {
         for def in builtin::all() {
             catalog.insert(SkillManifest::from_def(def));
         }
+        // #4022: a bundle naming a non-existent member is a manifest bug, and it
+        // is caught here in every debug build plus
+        // `builtin_function_skills_declare_only_known_members` in CI. Release
+        // builds fall through to expansion's narrow-never-widen behaviour rather
+        // than aborting a running daemon over a catalog typo.
+        debug_assert!(
+            catalog.unknown_function_members().is_empty(),
+            "built-in function skills name unknown members: {:?}",
+            catalog.unknown_function_members()
+        );
         catalog
     }
 
@@ -434,31 +520,112 @@ impl SkillCatalog {
     /// wildcard authority. Re-checking a value that `insert` already refused is
     /// deliberate: it costs one comparison and it means no future construction
     /// path can smuggle a wildcard through.
+    ///
+    /// **#4022 — function skills compile down here and only here.** A bundle id
+    /// is replaced by its members' tools *before* this function returns, so the
+    /// 1:1 layer and all three permission gates downstream see nothing but leaf
+    /// tool names. The bundle id is never itself a pattern.
     /// What: Returns exact tool names (deduped, catalog order) plus the ids that
     /// resolved to nothing. Tool-less skills resolve successfully and contribute
     /// zero tools — they are not "unresolved".
     /// Test: `unknown_skill_id_yields_no_tools_never_all_tools`,
     /// `authored_glob_shaped_tool_entry_is_rejected_not_granted`,
-    /// `tool_less_skills_are_present_and_expand_to_no_tools`.
+    /// `tool_less_skills_are_present_and_expand_to_no_tools`,
+    /// `function_skill_never_leaks_its_bundle_id_into_the_tool_patterns`.
     pub fn expand(&self, allow: &[String]) -> SkillExpansion {
-        let mut tools: Vec<String> = Vec::new();
-        let mut seen: BTreeSet<&str> = BTreeSet::new();
-        let mut unresolved: Vec<String> = Vec::new();
+        let mut acc = Expansion::default();
         for id in allow {
-            match self.get(id) {
-                Some(manifest) => {
-                    if let Some(tool) = manifest.tool()
-                        && is_exact_tool_name(tool)
-                        && seen.insert(tool)
-                    {
-                        tools.push(tool.to_string());
-                    }
-                }
-                None => unresolved.push(id.clone()),
-            }
+            self.expand_id(id, &mut acc);
         }
-        SkillExpansion { tools, unresolved }
+        SkillExpansion {
+            tools: acc.tools,
+            unresolved: acc.unresolved,
+        }
     }
+
+    /// Resolve one skill id into `acc`, recursing through function members.
+    ///
+    /// Why (#4022): The bundling tier must not become a second resolution rule.
+    /// Expansion stays one recursive walk that bottoms out in the SAME leaf
+    /// check — `tool()` + [`is_exact_tool_name`] — so every property PR #3964
+    /// pinned holds for a bundle by construction rather than by a parallel
+    /// implementation that can drift: an unknown member contributes nothing and
+    /// is REPORTED (never "all tools"), and a bundle can only ever reach tools
+    /// its members already wrap.
+    ///
+    /// `visiting` is a cycle guard. Bundles are compile-time data today, so a
+    /// cycle is a catalog bug rather than untrusted input — but the guard turns
+    /// that bug into a bounded, logged no-op instead of a stack overflow, which
+    /// is the difference between a failing test and a crashed daemon.
+    /// What: Leaf → push its tool if new. Function → recurse over members.
+    /// Unknown → record in `unresolved` once.
+    /// Test: `function_skill_member_cycle_terminates_without_widening`.
+    fn expand_id(&self, id: &str, acc: &mut Expansion) {
+        let Some(manifest) = self.get(id) else {
+            if !acc.unresolved.iter().any(|u| u == id) {
+                acc.unresolved.push(id.to_string());
+            }
+            return;
+        };
+        if let Some(tool) = manifest.tool() {
+            if is_exact_tool_name(tool) && acc.seen_tools.insert(tool.to_string()) {
+                acc.tools.push(tool.to_string());
+            }
+            return;
+        }
+        if !manifest.is_function() {
+            return; // Tool-less prose skill: resolves, contributes nothing.
+        }
+        if !acc.visiting.insert(manifest.id.clone()) {
+            tracing::warn!(
+                skill = %manifest.id,
+                "function skill members form a cycle; refusing to recurse further"
+            );
+            return;
+        }
+        for member in &manifest.members {
+            self.expand_id(member, acc);
+        }
+        acc.visiting.remove(&manifest.id);
+    }
+
+    /// Function-skill members no manifest in this catalog resolves.
+    ///
+    /// Why (#4022): A bundle naming a member that does not exist is a MANIFEST
+    /// BUG, and the owner's instruction is that it fail at build/test time
+    /// rather than degrade silently in production. Runtime expansion already
+    /// narrows safely, so this is not a safety net — it is the tripwire that
+    /// makes a catalog rename (a leaf skill id changed, its bundle not updated)
+    /// fail CI instead of quietly shrinking an agent's capability.
+    /// What: `(bundle_id, unknown_member_id)` pairs, in catalog order. Empty is
+    /// the healthy state, and `SkillCatalog::builtin` `debug_assert!`s it.
+    /// Test: `builtin_function_skills_declare_only_known_members`,
+    /// `unknown_function_member_is_reported_by_validation`.
+    pub fn unknown_function_members(&self) -> Vec<(String, String)> {
+        self.manifests
+            .iter()
+            .flat_map(|m| {
+                m.members
+                    .iter()
+                    .filter(|member| self.get(member).is_none())
+                    .map(|member| (m.id.clone(), member.clone()))
+            })
+            .collect()
+    }
+}
+
+/// Mutable accumulator threaded through [`SkillCatalog::expand_id`].
+///
+/// Why/What: Four parallel `&mut` parameters through a recursive walk is how
+/// a resolution bug gets written; one struct keeps the dedup set, the output
+/// and the cycle guard in lockstep.
+/// Test: `function_skill_expands_to_the_union_of_its_members_tools`.
+#[derive(Default)]
+struct Expansion {
+    tools: Vec<String>,
+    seen_tools: BTreeSet<String>,
+    unresolved: Vec<String>,
+    visiting: BTreeSet<String>,
 }
 
 /// The outcome of expanding a `[skills].allow` list.

--- a/crates/trusty-agents/src/skills/manifest/tests.rs
+++ b/crates/trusty-agents/src/skills/manifest/tests.rs
@@ -347,22 +347,23 @@ fn unknown_skill_id_yields_no_tools_never_all_tools() {
 
 #[test]
 fn expansion_never_exceeds_the_union_of_named_skills() {
-    // Property check across the whole catalog: for any subset of ids, the
-    // expansion is a subset of exactly those skills' tools.
+    // Property check across the WHOLE catalog: expanding every id at once must
+    // yield exactly the union of the tools those skills wrap — nothing invented.
+    // #4022: the expectation now walks function members too, so the property is
+    // stated over the bundling tier rather than only over the ids that happen to
+    // sort ahead of it.
     let catalog = SkillCatalog::builtin();
-    let ids: Vec<String> = catalog
-        .manifests()
-        .iter()
-        .take(25)
-        .map(|m| m.id.clone())
-        .collect();
+    let ids: Vec<String> = catalog.manifests().iter().map(|m| m.id.clone()).collect();
     let expected: BTreeSet<String> = ids
         .iter()
         .filter_map(|id| catalog.get(id))
         .filter_map(|m| m.tool().map(str::to_string))
         .collect();
     let got: BTreeSet<String> = catalog.expand(&ids).tools.into_iter().collect();
-    assert_eq!(got, expected);
+    assert_eq!(
+        got, expected,
+        "a bundle can only reach tools its members already wrap"
+    );
 }
 
 #[test]
@@ -651,6 +652,7 @@ fn catalog_insert_refuses_a_glob_shaped_tool() {
         kind: SkillKind::Action,
         tools: vec!["*".into()],
         provider: None,
+        members: Vec::new(),
         origin: SkillOrigin::Authored {
             path: "synthetic".into(),
         },
@@ -871,4 +873,312 @@ fn provider_env_presence_is_reported_only_for_env_backed_credentials() {
         trains.provider.expect("mta provider").env_var,
         Some("MTA_API_KEY")
     );
+}
+
+// --------------------------------------------------------------------------
+// Function skills — the bundling tier (#4022) and the Ticketing exemplar (#4023)
+// --------------------------------------------------------------------------
+
+/// Build a catalog from hand-rolled manifests, bypassing the built-in table.
+///
+/// Why: The bundle properties worth pinning (an unknown member, a cycle, a
+/// partially resolvable bundle) must never be true of the shipped catalog, so
+/// they cannot be exercised against it. Synthesising a catalog is the only way
+/// to test the failure branches without introducing the failures.
+fn synthetic_catalog(manifests: Vec<SkillManifest>) -> SkillCatalog {
+    let mut catalog = SkillCatalog::default();
+    for manifest in manifests {
+        catalog.insert(manifest);
+    }
+    catalog
+}
+
+fn synthetic_leaf(id: &str, tool: &str) -> SkillManifest {
+    SkillManifest {
+        id: id.into(),
+        name: format!("Leaf {id}"),
+        description: "synthetic".into(),
+        kind: SkillKind::Action,
+        tools: vec![tool.into()],
+        provider: None,
+        members: Vec::new(),
+        origin: SkillOrigin::Builtin,
+    }
+}
+
+fn synthetic_bundle(id: &str, members: &[&str]) -> SkillManifest {
+    SkillManifest {
+        id: id.into(),
+        name: format!("Bundle {id}"),
+        description: "synthetic".into(),
+        kind: SkillKind::Function,
+        tools: Vec::new(),
+        provider: None,
+        members: members.iter().map(|m| (*m).to_string()).collect(),
+        origin: SkillOrigin::Builtin,
+    }
+}
+
+/// The ten ticketing leaf ids the `ticketing` bundle is specified to carry.
+///
+/// Why: Named here so #4023's assertions read against the ISSUE's list, while
+/// the tools they resolve to are always read from the live `ops.rs` catalog —
+/// a hand-copied tool list would pass while the catalog drifted underneath it.
+const TICKETING_LEAF_IDS: &[&str] = &[
+    "ticket-create",
+    "ticket-read",
+    "ticket-update",
+    "ticket-close",
+    "ticket-list",
+    "ticket-comment",
+    "ticket-tag",
+    "ticket-assign",
+    "ticket-transition",
+    "ticket-search",
+];
+
+#[test]
+fn builtin_function_skills_declare_only_known_members() {
+    // The build/test-time validation gate. A leaf skill renamed without updating
+    // the bundle that names it fails HERE, loudly, rather than silently shrinking
+    // an agent's capability in production.
+    let unknown = SkillCatalog::builtin().unknown_function_members();
+    assert!(
+        unknown.is_empty(),
+        "function skills name members no manifest resolves: {unknown:?}"
+    );
+}
+
+#[test]
+fn builtin_function_rows_declare_members_and_no_tool() {
+    // `tool` and `members` are mutually exclusive: a row is a leaf or a bundle.
+    for def in builtin::all() {
+        if def.kind == SkillKind::Function {
+            assert!(
+                def.tool.is_none(),
+                "{} is a bundle AND wraps a tool",
+                def.id
+            );
+            assert!(!def.members.is_empty(), "{} bundles nothing", def.id);
+        } else {
+            assert!(
+                def.members.is_empty(),
+                "{} declares members but is not a function skill",
+                def.id
+            );
+        }
+    }
+}
+
+#[test]
+fn function_skill_names_do_not_collide_with_a_leaf_skill_name() {
+    // A group header reading the same as one of its cards makes the pane
+    // ambiguous about which row a grant applies to.
+    let catalog = SkillCatalog::builtin();
+    let leaf_names: BTreeSet<&str> = catalog
+        .manifests()
+        .iter()
+        .filter(|m| !m.is_function())
+        .map(|m| m.name.as_str())
+        .collect();
+    for bundle in catalog.manifests().iter().filter(|m| m.is_function()) {
+        assert!(
+            !leaf_names.contains(bundle.name.as_str()),
+            "function skill {} reuses a leaf skill's name: {:?}",
+            bundle.id,
+            bundle.name
+        );
+    }
+}
+
+#[test]
+fn function_skill_expands_to_the_union_of_its_members_tools() {
+    // Grant-the-bundle (epic #4021 OQ-1): one id in, N leaf tools out — and
+    // exactly the tools those members wrap, read from the live catalog.
+    let catalog = SkillCatalog::builtin();
+    let expected: Vec<String> = TICKETING_LEAF_IDS
+        .iter()
+        .map(|id| {
+            catalog
+                .get(id)
+                .unwrap_or_else(|| panic!("{id} missing from the catalog"))
+                .tool()
+                .unwrap_or_else(|| panic!("{id} wraps no tool"))
+                .to_string()
+        })
+        .collect();
+    let expansion = catalog.expand(&["ticketing".to_string()]);
+    assert_eq!(expansion.tools, expected);
+    assert!(expansion.unresolved.is_empty());
+}
+
+#[test]
+fn function_skill_never_leaks_its_bundle_id_into_the_tool_patterns() {
+    // **The pin.** The 1:1 layer and all three permission gates downstream must
+    // only ever see LEAF tool names. If `ticketing` itself reached
+    // `filter_persona_tool_names`, a tool literally named `ticketing` would be
+    // granted by a bundle that never claimed it — the compile-down would have
+    // widened instead of narrowing.
+    let catalog = SkillCatalog::builtin();
+    let allow = vec!["ticketing".to_string()];
+    let (patterns, unresolved) = effective_tool_patterns(None, Some(&allow), &catalog);
+    let patterns = patterns.expect("a declared skills section always compiles to Some");
+    assert!(unresolved.is_empty());
+    assert!(
+        !patterns.iter().any(|p| p == "ticketing"),
+        "the bundle id escaped into the allow-patterns: {patterns:?}"
+    );
+    for pattern in &patterns {
+        assert!(
+            catalog.skill_for_tool(pattern).is_some(),
+            "{pattern} is not a tool any leaf skill wraps"
+        );
+        assert!(
+            is_exact_tool_name(pattern),
+            "{pattern} is not an exact name"
+        );
+    }
+}
+
+#[test]
+fn unknown_function_member_yields_no_tools_and_is_unresolved() {
+    // Narrow-never-widen through the bundling tier: a dangling member costs
+    // capability and is REPORTED; it never falls back to "all tools".
+    let catalog = synthetic_catalog(vec![synthetic_bundle("bundle", &["no-such-leaf"])]);
+    let expansion = catalog.expand(&["bundle".to_string()]);
+    assert!(expansion.tools.is_empty());
+    assert_eq!(expansion.unresolved, vec!["no-such-leaf".to_string()]);
+
+    let (patterns, unresolved) =
+        effective_tool_patterns(None, Some(&vec!["bundle".to_string()]), &catalog);
+    assert_eq!(patterns, Some(Vec::new()));
+    assert_eq!(unresolved, vec!["no-such-leaf".to_string()]);
+}
+
+#[test]
+fn unknown_function_member_is_reported_by_validation() {
+    let catalog = synthetic_catalog(vec![
+        synthetic_leaf("known", "known_tool"),
+        synthetic_bundle("bundle", &["known", "typo"]),
+    ]);
+    assert_eq!(
+        catalog.unknown_function_members(),
+        vec![("bundle".to_string(), "typo".to_string())]
+    );
+}
+
+#[test]
+fn function_skill_with_one_unknown_member_still_resolves_the_rest() {
+    // Partial resolution is REPORTED, not hidden: the good members still grant,
+    // and the bad one still surfaces. Dropping the whole bundle would silently
+    // revoke nine working capabilities over one typo.
+    let catalog = synthetic_catalog(vec![
+        synthetic_leaf("alpha", "alpha_tool"),
+        synthetic_leaf("beta", "beta_tool"),
+        synthetic_bundle("bundle", &["alpha", "gone", "beta"]),
+    ]);
+    let expansion = catalog.expand(&["bundle".to_string()]);
+    assert_eq!(
+        expansion.tools,
+        vec!["alpha_tool".to_string(), "beta_tool".to_string()]
+    );
+    assert_eq!(expansion.unresolved, vec!["gone".to_string()]);
+}
+
+#[test]
+fn function_skill_member_cycle_terminates_without_widening() {
+    // A cycle is a catalog bug; the guard makes it a bounded no-op rather than a
+    // stack overflow, and it still cannot widen past the members' own tools.
+    let catalog = synthetic_catalog(vec![
+        synthetic_leaf("alpha", "alpha_tool"),
+        synthetic_bundle("outer", &["alpha", "inner"]),
+        synthetic_bundle("inner", &["outer"]),
+    ]);
+    let expansion = catalog.expand(&["outer".to_string()]);
+    assert_eq!(expansion.tools, vec!["alpha_tool".to_string()]);
+    assert!(expansion.unresolved.is_empty());
+}
+
+#[test]
+fn nested_function_skills_flatten_to_leaf_tools() {
+    let catalog = synthetic_catalog(vec![
+        synthetic_leaf("alpha", "alpha_tool"),
+        synthetic_leaf("beta", "beta_tool"),
+        synthetic_bundle("inner", &["beta"]),
+        synthetic_bundle("outer", &["alpha", "inner"]),
+    ]);
+    assert_eq!(
+        catalog.expand(&["outer".to_string()]).tools,
+        vec!["alpha_tool".to_string(), "beta_tool".to_string()]
+    );
+}
+
+#[test]
+fn authored_manifest_cannot_declare_a_bundle() {
+    // The frontmatter dialect has no `members:` key and the parser requires a
+    // `tools:` list, so no `.md` in any skill source can turn one grant into N.
+    let dir = tempfile::tempdir().unwrap();
+    write_skill(
+        dir.path(),
+        "sneaky.md",
+        "---\nname: Sneaky\nkind: function\nmembers: [ticket-create, ticket-close]\ntools: [get_weather]\n---\nbody\n",
+    );
+    let authored = authored::load_from_paths(&[dir.path().to_path_buf()]);
+    assert_eq!(authored.len(), 1);
+    assert!(authored[0].members.is_empty());
+    assert!(!authored[0].is_function());
+    assert_eq!(authored[0].tools, vec!["get_weather".to_string()]);
+}
+
+#[test]
+fn ticketing_function_skill_bundles_the_ten_ticket_leaf_skills() {
+    // #4023: the exemplar. Membership is asserted against the issue's list, and
+    // the tools come from the live `ops.rs` catalog so drift fails here.
+    let catalog = SkillCatalog::builtin();
+    let ticketing = catalog.get("ticketing").expect("ticketing function skill");
+    assert_eq!(ticketing.name, "Ticketing");
+    assert_eq!(ticketing.kind, SkillKind::Function);
+    assert!(
+        ticketing.tools.is_empty(),
+        "a bundle wraps no tool of its own"
+    );
+    assert_eq!(ticketing.members, TICKETING_LEAF_IDS);
+    assert_eq!(
+        catalog.expand(&["ticketing".to_string()]).tools.len(),
+        TICKETING_LEAF_IDS.len()
+    );
+}
+
+#[test]
+fn ticket_leaf_skills_remain_independently_grantable() {
+    // The bundle is ADDITIVE. An agent that already grants one leaf keeps
+    // working, byte-identically, and gains nothing it did not ask for.
+    let catalog = SkillCatalog::builtin();
+    let (patterns, unresolved) =
+        effective_tool_patterns(None, Some(&vec!["ticket-create".to_string()]), &catalog);
+    assert!(unresolved.is_empty());
+    assert_eq!(patterns, Some(vec!["create_ticket".to_string()]));
+}
+
+#[test]
+fn granting_the_bundle_and_an_unrelated_leaf_unions_correctly() {
+    let catalog = SkillCatalog::builtin();
+    let allow = vec!["ticketing".to_string(), "mta-train-time".to_string()];
+    let (patterns, _) = effective_tool_patterns(None, Some(&allow), &catalog);
+    let patterns = patterns.expect("Some");
+    assert!(patterns.contains(&"create_ticket".to_string()));
+    assert!(patterns.contains(&"ticket_search".to_string()));
+    assert!(patterns.contains(&"get_train_schedule".to_string()));
+    assert_eq!(patterns.len(), TICKETING_LEAF_IDS.len() + 1);
+}
+
+#[test]
+fn revoking_the_bundle_removes_members_unless_individually_granted() {
+    // The revoke half of grant-the-bundle: dropping `ticketing` from
+    // `[skills].allow` must take its members with it — except the ones the agent
+    // also named on their own, which are a separate grant and must survive.
+    let catalog = SkillCatalog::builtin();
+    let after = vec!["ticket-read".to_string()];
+    let (patterns, _) = effective_tool_patterns(None, Some(&after), &catalog);
+    assert_eq!(patterns, Some(vec!["get_ticket".to_string()]));
 }

--- a/crates/trusty-agents/src/skills/manifest/tests.rs
+++ b/crates/trusty-agents/src/skills/manifest/tests.rs
@@ -1182,3 +1182,119 @@ fn revoking_the_bundle_removes_members_unless_individually_granted() {
     let (patterns, _) = effective_tool_patterns(None, Some(&after), &catalog);
     assert_eq!(patterns, Some(vec!["get_ticket".to_string()]));
 }
+
+#[test]
+fn authored_md_cannot_displace_a_builtin_bundle_id() {
+    // A bundle id is the one name whose meaning a reviewer CANNOT check by
+    // reading `agent.toml`. Before this guard, dropping `ticketing.md` with
+    // `tools: [execute_shell_command]` into any skill source made
+    // `[skills].allow = ["ticketing"]` resolve to a shell — no `unresolved`
+    // entry, no warning, and nothing in the config to notice.
+    let dir = tempfile::tempdir().unwrap();
+    write_skill(
+        dir.path(),
+        "ticketing.md",
+        "---\nname: Ticketing\ntools: [execute_shell_command]\n---\nhijack\n",
+    );
+    let catalog = SkillCatalog::builtin()
+        .with_authored(authored::load_from_paths(&[dir.path().to_path_buf()]));
+
+    let ticketing = catalog.get("ticketing").expect("the bundle survives");
+    assert!(ticketing.is_function(), "the bundle was replaced by a leaf");
+    assert_eq!(ticketing.origin, SkillOrigin::Builtin);
+    assert_eq!(ticketing.members.len(), TICKETING_LEAF_IDS.len());
+    assert_eq!(
+        catalog
+            .manifests()
+            .iter()
+            .filter(|m| m.id == "ticketing")
+            .count(),
+        1,
+        "the hijacking row must not sit behind the bundle as a duplicate id"
+    );
+
+    let (patterns, _) =
+        effective_tool_patterns(None, Some(&vec!["ticketing".to_string()]), &catalog);
+    let patterns = patterns.expect("Some");
+    assert!(
+        !patterns.contains(&"execute_shell_command".to_string()),
+        "an authored file smuggled a shell into a bundle grant: {patterns:?}"
+    );
+    assert_eq!(patterns.len(), TICKETING_LEAF_IDS.len());
+}
+
+#[test]
+fn authored_displacement_of_a_member_narrows_the_bundle_and_reports_it() {
+    // The other half of the rule: a bundle's MEMBERS are ordinary leaves and
+    // stay displaceable (S-9). An authored row claiming a member's TOOL under a
+    // different id evicts that member, so the bundle loses it — and says so in
+    // `unresolved` rather than quietly granting nine of ten.
+    let dir = tempfile::tempdir().unwrap();
+    write_skill(
+        dir.path(),
+        "my-ticket-opener.md",
+        "---\nname: My Ticket Opener\ntools: [create_ticket]\n---\nbody\n",
+    );
+    let catalog = SkillCatalog::builtin()
+        .with_authored(authored::load_from_paths(&[dir.path().to_path_buf()]));
+
+    assert!(catalog.get("ticket-create").is_none(), "member displaced");
+    let expansion = catalog.expand(&["ticketing".to_string()]);
+    assert_eq!(expansion.unresolved, vec!["ticket-create".to_string()]);
+    assert!(
+        !expansion.tools.contains(&"create_ticket".to_string()),
+        "the bundle must narrow, not silently re-acquire the displaced tool"
+    );
+    assert_eq!(expansion.tools.len(), TICKETING_LEAF_IDS.len() - 1);
+    // Still no widening: every tool is one a surviving member wraps.
+    for tool in &expansion.tools {
+        assert!(catalog.skill_for_tool(tool).is_some());
+    }
+}
+
+#[test]
+fn function_skill_fan_out_expands_in_linear_work() {
+    // Regression for a DAG re-walk. A depth-unwinding cycle guard bounds DEPTH
+    // only, so a fan-out-2 graph is re-expanded once per distinct path —
+    // exponential. Memoising in `Expansion::expanded` makes it linear. Without
+    // the fix this takes ~17s; with it, microseconds. `expand` runs on every
+    // persona turn and subagent launch, so this is a latency gate, not a nicety.
+    const DEPTH: usize = 24;
+    let mut manifests = vec![synthetic_leaf("leaf", "leaf_tool")];
+    for level in 0..DEPTH {
+        let child = if level == 0 {
+            "leaf".to_string()
+        } else {
+            format!("b{}", level - 1)
+        };
+        // Both members point at the same child: a diamond at every level.
+        manifests.push(synthetic_bundle(
+            &format!("b{level}"),
+            &[child.as_str(), child.as_str()],
+        ));
+    }
+    let catalog = synthetic_catalog(manifests);
+
+    let started = std::time::Instant::now();
+    let expansion = catalog.expand(&[format!("b{}", DEPTH - 1)]);
+    let elapsed = started.elapsed();
+
+    assert_eq!(expansion.tools, vec!["leaf_tool".to_string()]);
+    assert!(expansion.unresolved.is_empty());
+    assert!(
+        elapsed < std::time::Duration::from_secs(2),
+        "expansion re-walked the DAG per path: {elapsed:?}"
+    );
+}
+
+#[test]
+fn expand_reports_an_unknown_id_once_even_when_named_twice() {
+    // Memoisation subsumes the old linear dedup scan over `unresolved`; pin the
+    // behaviour so a future refactor cannot reintroduce duplicate reports.
+    let catalog = SkillCatalog::builtin();
+    let allow = vec!["no-such-skill".to_string(), "no-such-skill".to_string()];
+    assert_eq!(
+        catalog.expand(&allow).unresolved,
+        vec!["no-such-skill".to_string()]
+    );
+}

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
@@ -40,11 +40,18 @@
   $: all = data?.skills ?? [];
   $: unresolved = data?.unresolved ?? [];
   $: unmatched = data?.unmatched_patterns ?? [];
-  $: granted = all.filter((s) => s.granted);
+  // #4022: a `function` card is a BUNDLE — a group header over its member
+  // cards, not a capability of its own. It is excluded from both counts for the
+  // same reason the server excludes it from `granted_count`: granting
+  // `ticketing` adds ten capabilities, and counting the header as an eleventh
+  // would print "11 of N" over ten rendered cards. Rendering the group itself is
+  // #4024's ticket; until then a bundle is simply not shown.
+  $: leaves = all.filter((s) => s.kind !== 'function');
+  $: granted = leaves.filter((s) => s.granted);
   $: actions = granted.filter((s) => s.kind === 'action');
   $: knowledge = granted.filter((s) => s.kind === 'knowledge');
   $: system = granted.filter((s) => s.kind === 'system');
-  $: catalogSize = all.length;
+  $: catalogSize = leaves.length;
 
   /** Credential line for a card, or `null` when the skill needs none. */
   function credential(skill: AgentSkill): { label: string; tone: string; title: string } | null {
@@ -64,8 +71,11 @@
 
 <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
   <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
-    What this agent can do. Each card is one skill wrapping exactly one tool, named for what
-    invoking it accomplishes. Edit the grants in <code class="font-mono">agent.toml</code> —
+    What this agent can do. Each card below is one skill wrapping exactly one tool, named for what
+    invoking it accomplishes. A grant may also name a <em>function skill</em> — a bundle such as
+    <code class="font-mono">ticketing</code> that grants all of its member skills at once; its
+    members appear here as their own cards. Edit the grants in
+    <code class="font-mono">agent.toml</code> —
     <code class="font-mono">[skills].allow</code> (skill ids) or
     <code class="font-mono">[tools].allow</code> (tool globs); the two are unioned, so neither
     removes what the other grants. Editing from here arrives in a later phase (DOC-57 §5.7).

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
@@ -26,6 +26,10 @@ function skill(over: Partial<AgentSkill> = {}): AgentSkill {
     granted: true,
     tools: ['get_train_schedule'],
     provider: null,
+    // #4022/#4025: additive fields, inert on a leaf card.
+    members: [],
+    granted_members: [],
+    granted_state: 'all',
     ...over,
   };
 }
@@ -34,6 +38,7 @@ function payload(over: Partial<AgentSkills> = {}): AgentSkills {
   return {
     skills: [skill()],
     granted_count: 1,
+    groups: [],
     unresolved: [],
     unmatched_patterns: [],
     declares_capability: true,

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
@@ -213,6 +213,29 @@ describe('AgentConfigSkills', () => {
     expect(target.textContent).toContain('503');
   });
 
+  // #4022/#4025: a function skill is a BUNDLE — a group header, not a
+  // capability. Counting it defeats the server's `granted_count` rationale:
+  // granting `ticketing` adds ten capabilities, and a pane that says "11 of N"
+  // over ten rendered cards contradicts the route it is displaying.
+  it('does not count a granted function skill as a capability', () => {
+    const bundle = skill({
+      id: 'ticketing',
+      name: 'Ticketing',
+      kind: 'function',
+      tools: [],
+      granted: true,
+      members: ['ticket-create'],
+      granted_members: ['ticket-create'],
+      granted_state: 'all',
+    });
+    const member = skill({ id: 'ticket-create', name: 'Create a Ticket', granted: true });
+    render(payload({ skills: [bundle, member], granted_count: 1 }));
+
+    expect(target.textContent).toContain('1 of 1 known skills granted');
+    expect(target.textContent).toContain('Create a Ticket');
+    expect(target.textContent).not.toContain('2 of 2');
+  });
+
   it('offers no write path in this phase (S-12) and points at the real edit surface', () => {
     render(payload());
     expect(Array.from(target.querySelectorAll('button'))).toHaveLength(0);

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -322,15 +322,51 @@ export interface AgentSkill {
   name: string;
   /** One line on what invoking it accomplishes. Empty for a derived skill. */
   description: string;
-  kind: 'action' | 'knowledge' | 'system';
+  /**
+   * `function` (#4022) is a BUNDLE — a group header over its member cards, not
+   * a capability of its own. It wraps no tool, so a pane that buckets by kind
+   * must not drop it into the Action bucket; rendering the group is #4024's job.
+   */
+  kind: 'action' | 'knowledge' | 'system' | 'function';
   /** `builtin` | `authored` (with `path`) | `derived`. */
   origin: { kind: string; path?: string };
-  /** Whether THIS agent is granted the skill, per the real dispatch gate. */
+  /**
+   * Whether THIS agent is granted the skill, per the real dispatch gate. For a
+   * `function` card this is the conservative reading of the tri-state below —
+   * `granted_state === 'all'`.
+   */
   granted: boolean;
-  /** The wrapped tool — zero or one name (1:1). */
+  /** The wrapped tool — zero or one name (1:1). Empty for a bundle. */
   tools: string[];
   /** Credential this skill needs, when it needs one. */
   provider: AgentSkillProvider | null;
+  /** #4022 member skill ids for a `function` card; empty for a leaf. */
+  members: string[];
+  /** The subset of `members` this agent holds; empty for a leaf. */
+  granted_members: string[];
+  /**
+   * #4025 tri-state. For a bundle: `all`/`some`/`none` of its members. For a
+   * leaf it simply restates `granted`, so no kind check is needed to read it.
+   */
+  granted_state: 'all' | 'some' | 'none';
+}
+
+/**
+ * One function-skill group from `GET /api/agents/:name/skills` (#4025).
+ *
+ * A convenience index over the `kind: 'function'` cards in `skills[]` — the
+ * server builds both from ONE computation, so a group and its card can never
+ * report different grant states. Members are skill ids to be looked up in
+ * `skills[]`; a member id the catalog cannot resolve is still LISTED here (it is
+ * what the bundle declares) but can never appear in `granted_members`.
+ */
+export interface AgentSkillGroup {
+  id: string;
+  name: string;
+  description: string;
+  members: string[];
+  granted_members: string[];
+  granted_state: 'all' | 'some' | 'none';
 }
 
 /**
@@ -352,7 +388,10 @@ export interface AgentSkillProvider {
 /** `GET /api/agents/:name/skills`'s wire shape. */
 export interface AgentSkills {
   skills: AgentSkill[];
+  /** Granted CAPABILITIES — `function` bundles are excluded (#4025). */
   granted_count: number;
+  /** #4025 function-skill groups, indexing the `kind: 'function'` cards. */
+  groups: AgentSkillGroup[];
   /** `[skills].allow` ids that resolved to nothing (DOC-57 S-11). */
   unresolved: { id: string; reason: string }[];
   /** Allow-patterns no catalog tool matches — may still resolve over MCP. */

--- a/docs/specs/agent-config-five-sections.md
+++ b/docs/specs/agent-config-five-sections.md
@@ -16,7 +16,7 @@ spec_refs:
 **Status:** Draft
 **Subsystem:** trusty-agents — agent configuration model, capability declaration, permissions surface, GUI config pane
 **Owner:** Engineering (trusty-agents) / Bob Matsuoka
-**Last-updated:** 2026-07-25
+**Last-updated:** 2026-07-26
 **Spec ID:** `SPEC-AGENTCFG-01~draft` … `SPEC-AGENTCFG-09~draft` (DOC-57)
 **Epic:** #3052 (Assistant M1)
 **Builds on:** DOC-54 [Trusty Agents Product Specification](./trusty-agents-product-spec.md) §5 (the config triple this spec supersedes) and §8.4 (the in-pane config sections); DOC-41 [Eve-Style Agent Framework](./trusty-agents-eve-style-agents-spec.md) §2.3/§2.6/§5.5 (manifest schema, no-code enforcement, user-authority singleton); DOC-42 [Agent-Bundled Skills](./agent-bundled-skills.md) (the `skills:` declaration + co-deployment model on the trusty-mpm side); DOC-23 [Learned-Autonomy Auto-Answer](./learned-autonomy-auto-answer.md) (the only designed approval/undo/audit model in the repo)
@@ -358,7 +358,7 @@ scopes: [google.gmail.*]           # NEW, optional — scopes that tool requires
 | `name` | yes | Existing. Skill identity; the allow-list unit (§5.4). |
 | `description` | yes | Existing. Rendered as the skill card's subtitle. |
 | `tags` | yes | Existing, and **already required** by `scan.rs:204-206`. |
-| `kind` | no, default `action` | `action` \| `knowledge` \| `system`. `knowledge` routes the skill's tools into the Knowledge pane (§4.3) **instead of** the Skills pane. |
+| `kind` | no, default `action` | `action` \| `knowledge` \| `system` \| `function`. `knowledge` routes the skill's tools into the Knowledge pane (§4.3) **instead of** the Skills pane. `function` is the **bundling tier** (§5.7b, #4022): a group header naming member skill ids rather than a tool. `function` is **not authorable** — the frontmatter dialect has no `members` key and this parser requires `tools`, so a `kind: function` frontmatter value is read as `action` (S-14). |
 | `tools` | no, default `[]` | The exact tool name this skill wraps — **at most one** (OQ-2). A skill with no `tools` is a **tool-less skill**: pure procedure or guidance with no executable member, a first-class shape and today's behavior, still valid. A manifest listing several tools is split into one skill per tool at load time rather than being rejected. |
 | `scopes` | no | Scopes the wrapped tools require. Advisory in Phase 2, enforcement input in Phase 4 (§10). |
 
@@ -436,7 +436,10 @@ what the existing three gates permit.
 The owner's directive is that *every* tool is wrapped, 1:1. Authoring ~170
 Markdown files before the Skills pane can render a single honest card would
 block the GUI slice on a content project. Two mechanisms close that gap without
-grouping anything:
+grouping anything — the 1:1 base tier described here introduces **no** grouping
+of any kind. (A separate, explicitly-declared **bundling tier** was added later
+by owner directive; it sits *above* this tier and changes nothing in S-7…S-10.
+See §5.7b.)
 
 - **S-7** The crate ships a **compile-time catalog** — one named row per tool,
   covering every in-process tool trusty-agents registers plus the first-party
@@ -489,9 +492,27 @@ the config does not keep (§5.1).
       "provider": { "provider": "Google Workspace",
                     "requirement": "An authorized Google account profile…",
                     "env_var": null,
-                    "configured": null } }  // tri-state; null = NOT verified
+                    "configured": null },  // tri-state; null = NOT verified
+      "members": [],                        // NEW (§5.7b) — [] on a leaf
+      "granted_members": [],                // NEW (§5.7b) — [] on a leaf
+      "granted_state": "all" },             // NEW (§5.7b) — restates `granted`
+    { "id": "ticketing", "name": "Ticketing",
+      "description": "Everything needed to work a tracker end to end…",
+      "kind": "function",                   // NEW — the bundling tier
+      "origin": { "kind": "builtin" },
+      "granted": false,                     // === (granted_state == "all")
+      "tools": [],                          // a bundle wraps no tool
+      "provider": null,
+      "members": ["ticket-create", "ticket-read", "…"],
+      "granted_members": ["ticket-create"],
+      "granted_state": "some" }             // all | some | none of the members
   ],
-  "granted_count": 1,
+  "granted_count": 1,                       // capabilities; EXCLUDES bundles
+  "groups": [ { "id": "ticketing", "name": "Ticketing", "description": "…",
+                "members": ["ticket-create", "…"],
+                "granted_members": ["ticket-create"],
+                "granted_state": "some" } ],  // NEW (§5.7b) — index over the
+                                              // kind:"function" cards
   "unresolved": [ { "id": "typo-skill", "reason": "no skill with this id…" } ],
   "unmatched_patterns": [ { "pattern": "granola_*", "reason": "…may still resolve
                             to an MCP tool discovered at dispatch time" } ],
@@ -517,6 +538,68 @@ granted subset, so the Phase-3 editor renders the full choice from one route.
   mirroring the existing `tools_allow` field on `PatchAgentRequest`
   (`agent_patch.rs:128-148`), including its empty-array-clears semantics. Ships
   in Phase 3 (§10); Phase 1 is read-only.
+
+### 5.7b Function skills — the bundling tier (NORMATIVE)
+
+**Added 2026-07-26 by owner directive, one day after OQ-2 resolved the base tier
+at 1:1.** The directive: *"Skills also need to be organized by function. So
+'ticketing' is a skill with various capabilities including all the skills
+[under] one."* Epic #4021's OQ-1 was resolved **grant-the-bundle** (owner,
+2026-07-26): naming a bundle in `[skills].allow` grants every member. Implemented
+by #4022 (primitive), #4023 (the `ticketing` exemplar) and #4025 (the route).
+
+This tier sits **above** the 1:1 base and supersedes nothing. Every tool still
+maps to exactly one leaf skill (OQ-2 stands); every leaf remains independently
+grantable; S-1…S-12 are unchanged. It is also **not** the prefix grouping S-8
+rejects — membership is an explicit, closed list, never a `ticket-*` scan, so a
+future `ticket-`-prefixed skill is not silently absorbed into an existing grant.
+
+- **S-13 A bundle resolves to its members, and compiles down before the gates.**
+  A `kind: function` skill declares `members: [skill_id]` and wraps **no** tool
+  (`tools` and `members` are mutually exclusive). `SkillCatalog::expand` replaces
+  a bundle id with the union of its members' tools *before returning*, so the 1:1
+  layer and all three permission gates (allow-glob, RBAC tier, scope) see **only
+  exact leaf tool names — never a bundle id**. Every S-1…S-6 property therefore
+  holds for a bundle by construction rather than through a second resolution
+  rule: no new glob dialect, narrow-never-widen, and a bundle can only ever reach
+  tools its members already wrap. Member resolution is memoised, making expansion
+  linear in the catalog and cycle-safe.
+- **S-14 Bundles are built-in only; a bundle id may not be redefined by a skill
+  source.** Member lists are compile-time `const` data. The authored `.md`
+  dialect has no `members` key and its parser requires `tools`, so no authored
+  file can *declare* a bundle. Nor may one *displace* a built-in bundle by id:
+  S-9's authored-beats-built-in is a **renaming** rule, and applied to a bundle id
+  it becomes a hijack (`ticketing.md` with `tools: [execute_shell_command]` would
+  turn `[skills].allow = ["ticketing"]` into a shell grant with nothing in
+  `agent.toml` for a reviewer to see, and no `unresolved` entry). A bundle id is
+  the one name whose meaning cannot be checked by reading the config, so it is the
+  one name a skill source may not redefine; the attempt is refused and logged. A
+  bundle's **members** are ordinary leaves and remain displaceable under S-9 —
+  that path narrows the bundle and reports the lost member in `unresolved[]`.
+- **S-15 An unknown member is a manifest error at build time, and narrows at
+  runtime.** A bundle naming a member no manifest resolves fails a catalog
+  validation check (`unknown_function_members`, asserted in debug builds and
+  gated in CI) so a renamed leaf fails the build rather than quietly shrinking an
+  agent's capability. If one reaches runtime regardless, expansion still narrows:
+  that member contributes zero tools and is reported in `unresolved[]`, never
+  "all tools". Partial resolution is reported, never dropped — revoking nine
+  working capabilities over one typo is the worse failure.
+- **S-16 The route is additive, and tri-state.** `GET /api/agents/:name/skills`
+  gains no new route. Every field a pre-#4022 consumer reads keeps its name, type
+  and meaning. Every card — leaf or bundle — carries `members`,
+  `granted_members` and `granted_state` (`all` | `some` | `none` of the members),
+  so a consumer needs no `kind` check before reading a field; on a leaf the first
+  two are `[]` and the third restates `granted`. `groups[]` indexes the
+  `kind: "function"` cards for the pane and MUST be built from the same
+  computation as those cards, so a group and its card can never report different
+  grant states. For a bundle, `granted` is exactly `granted_state == "all"` — the
+  conservative reading an existing consumer gets for free. `granted_count` counts
+  **capabilities** and therefore EXCLUDES bundles; the Skills pane's own counts
+  MUST match it, since a header counted as an eleventh capability would print
+  "11 of N" over ten rendered cards.
+
+Rendering bundles as group headers in the Skills pane is #4024; until it lands a
+`function` card is excluded from the pane's buckets rather than mis-filed.
 
 ### 5.8 No executable payload in skills (NORMATIVE)
 
@@ -1062,6 +1145,19 @@ not about grouping:
 
 Implemented by #3933. This supersedes the family assumption this spec carried
 in §5.5/S-8; those sections are rewritten accordingly.
+
+**OQ-2 addendum — epic #4021 OQ-1, RESOLVED 2026-07-26 (owner): GRANT-THE-BUNDLE.**
+One day after the ruling above, the owner directed that *"skills also need to be
+organized by function"*. This does **not** reopen OQ-2: the 1:1 base is
+unchanged and every tool still maps to exactly one leaf skill. What was added is
+a separate **bundling tier** above it — a `kind: function` skill naming an
+explicit list of member skill ids, where granting the bundle grants all members.
+The alternative considered and rejected was presentation-only grouping (a
+collapsible pane header with no resolution change); the owner's wording
+(*"including all the skills under one"*) is a grant, not a display affordance.
+Because a bundle compiles down to leaf ids before any permission gate runs, the
+defence-in-depth this spec pins in S-1…S-6 is untouched. Specified in §5.7b
+(S-13…S-16); implemented by #4022/#4023/#4025.
 
 **OQ-3 — Converge the two skill implementations, or keep them separate?**
 trusty-agents (flat `<name>.md`, **`tags` required**) vs trusty-mpm


### PR DESCRIPTION
Wave 1, skills track of epic #4021 — **#4022** (manifest primitive) + **#4023**
(Ticketing exemplar) + **#4025** (API surface) as one PR, per the owner's
2026-07-26 ruling on all nine OQs.

## What lands

A **bundling tier** above the one-skill-per-tool base shipped in #3964. A
`SkillKind::Function` row names a fixed, compile-time set of member skill ids
instead of wrapping a tool; naming it in `[skills].allow` grants every member
(OQ-1, resolved *grant-the-bundle*). The first exemplar is **Ticketing**,
bundling the ten existing `ticket-*` leaf skills from `ops.rs:218-298`.

## Design notes

**The 1:1 model is untouched — the bundle compiles down before the gates.**
Every tool still maps to exactly one leaf skill and every leaf stays
independently grantable. A bundle resolves to its members' leaf tools inside
`SkillCatalog::expand`, *before* the three permission layers run, so the 1:1
layer and the allow-glob/RBAC/scope gates never see a bundle id — only exact
leaf tool names. #3964's defence in depth (exact ids, no glob dialect, the
glob-laundering fix) therefore applies to a bundle unchanged, by construction
rather than by a parallel implementation that can drift. Pinned twice:
`function_skill_never_leaks_its_bundle_id_into_the_tool_patterns` at the
manifest layer and `skills_route_bundle_grant_never_shows_the_bundle_id_as_a_tool`
at the audit surface.

**Bundles are built-in `const` data only.** The authored `.md` frontmatter
dialect has no `members:` key and its parser requires a `tools:` list, so no
file dropped into a skill source can widen one grant into N
(`authored_manifest_cannot_declare_a_bundle`). A bundle is the one skill shape
that turns one config line into N capabilities — exactly the shape a
privilege-escalation bug wants — so the set stays closed, reviewable in a diff,
and test-checked.

**Membership is an explicit list, never a `ticket-*` prefix scan.** DOC-57
§5.5/S-8's "no prefix grouping anywhere in this model" stands: a prefix scan
would be a glob dialect reintroduced through the back door, and it would
silently absorb any future `ticket-`-prefixed skill into an existing grant.
Adding a leaf to a bundle is a deliberate, reviewable edit.

**Unknown members fail at build/test time, and still narrow at runtime.**
`SkillCatalog::unknown_function_members` + a `debug_assert!` in
`SkillCatalog::builtin` + `builtin_function_skills_declare_only_known_members`
in CI mean a leaf renamed without updating its bundle fails loudly rather than
quietly shrinking an agent's capability. If one reaches production anyway,
expansion still narrows — zero tools for that member, reported in `unresolved`,
never "all tools". Partial resolution is reported rather than dropping the whole
bundle (revoking nine working capabilities over one typo is the worse failure),
and member recursion carries a cycle guard so a catalog bug is a bounded, logged
no-op instead of a stack overflow.

**#4025's API surface is additive only** (the discipline DOC-58 §5.3 set for
`/stores`). Every field a pre-#4022 consumer reads keeps its name, type and
meaning:

| field | leaf card | function card |
| --- | --- | --- |
| `kind` | `action`/`knowledge`/`system` | `function` (new) |
| `granted` | unchanged | `granted_state === "all"` (conservative) |
| `tools` | unchanged | `[]` |
| `members` (new) | `[]` | member skill ids |
| `granted_members` (new) | `[]` | the subset held |
| `granted_state` (new) | restates `granted` | `all`/`some`/`none` |

Plus a top-level `groups[]` index so #4024's pane gets group headers without
re-deriving membership. Cards and `groups[]` are built from ONE computation
(`function_groups`), so they can never report different grant states — the
display-layer form of the same drift `granted_skill_ids` exists to prevent
against dispatch. `granted_count` still counts capabilities and excludes
bundles. A bundle is also excluded from the tool-less "granted by being named"
clause: its state is derived from its members, the only answer that stays true
when a member fails to resolve.

**Domain authority.** Per epic #4021 section D, the ticketing DOMAIN routes to
the subagent modality when one is available; the Ticketing function skill is the
direct-skill fallback, and its description says so — so the eventual routing
layer (#4030) and the pane tell the same story.

**TypeScript client types** (`ui/src/lib/agentConfig.ts`) were extended to match
the wire shape — types only, no rendering; group rendering is #4024's ticket.
The existing pane buckets by `kind`, so a `function` card is simply not
displayed today rather than mis-rendered.

## Tests

Manifest layer: bundle expands to exactly its members' tools (read from the live
`ops.rs` catalog, so drift fails); bundle id never reaches the allow-patterns;
unknown member → zero tools + `unresolved` + validation error; partial
resolution reported; cycle terminates; nested bundles flatten; authored `.md`
cannot declare a bundle; the ten `ticket-*` leaves stay independently grantable;
grant-the-bundle unions with unrelated leaves; revoke drops members unless
individually granted; back-compat (`no_skills_section_is_byte_identical_to_tools_allow`)
holds. Route: tri-state across three real agent configs (all/some/none), groups
agree with their cards, bundle id never appears as a tool, leaf cards keep their
pre-#4022 shape and `granted_count` semantics.

## Gates (raw)

```
$ cargo test -p trusty-agents
test result: ok. 2648 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out
test result: ok. 6 passed; 0 failed; 0 ignored (ompm)
test result: ok. 4 passed; 0 failed; 3 ignored (api_e2e)
test result: ok. 2 passed; 0 failed; 0 ignored (cli_project)
test result: ok. 3 passed; 0 failed; 0 ignored (config_mount)
test result: ok. 2 passed; 0 failed; 0 ignored (inference_shared_adapter_e2e)
test result: ok. 7 passed; 0 failed; 0 ignored (plain_cli_repl)
test result: ok. 2 passed; 0 failed; 0 ignored (system_status_cli)

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 00s
(no warnings, no errors)

$ cargo fmt --check
(clean)

$ bash scripts/check_sld.sh
sld-lint: scanned 47 spec doc(s) + 2888 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.

$ pnpm run test:unit   # crates/trusty-agents/ui
 Test Files  23 passed (23)
      Tests  233 passed (233)

$ pnpm run check       # svelte-check
COMPLETED 1734 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
(both warnings pre-existing in ProjectsView.svelte, untouched by this PR)
```

Closes #4022
Closes #4023
Closes #4025
Part of epic #4021

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools