### PR TITLE
feat: cross-product non-coding subagent delegation via the dispatch_task bridge (#4026, #4027, #4028)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,64 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`dispatch_task` can now hand a task to a NAMED non-coding specialist in
+  trusty-code's roster, behind a fail-closed bridge-layer allow-set (#4026,
+  #4028; epic #4021 bridge track).** The bridge previously hardcoded a single
+  opaque target (`pm`), so a trusty-agents agent could never reach the
+  `research`/`ticketing` specialists the owner's directive names. The tool
+  gained an optional `specialist` argument and an optional
+  HandoffContext-shaped `handoff` payload:
+  - **Fail-closed allow-set (#4026, epic #4021 OQ-3/OQ-7).** A named
+    specialist is resolved by `tools::cross_product::SubagentAllowSet` — the
+    INTERSECTION of the bridge's own `NON_CODING_TARGETS` floor (`research`,
+    `ticketing`) with the calling agent's new `[subagents].allowed` config
+    list. Caller configuration can only ever NARROW that floor: a config that
+    lists `rust-engineer` is still denied AT THE BRIDGE, per the owner's OQ-7
+    ruling that enforcement is never caller-trusted alone. The default is
+    EMPTY — an agent with no `[subagents]` section grants no cross-product
+    reach at all, so this ships as no silent capability grant. A denial
+    returns before the backend is invoked; nothing is dispatched. #4030's
+    runtime-built domain authority will later feed the same `SubagentAllowSet`
+    seam without touching the bridge.
+  - **Propose-not-authorize envelope (#4028, epic #4021 OQ-6).** A named
+    specialist's result is wrapped in `tools::cross_product::ProposalEnvelope`
+    — origin agent, target agent, the CALLER's authority tier, and a
+    `Disposition` marker that `for_cross_product` can only ever set to
+    `Proposal`. This is DOC-41 §5.5's "propose-not-authorize, absolute for M1
+    — no exceptions" made structural rather than conventional, mirroring
+    #3078/AUTH-5's rule on `delegate_to_agent`: a caller holding
+    `user_authority` has that tier RECORDED on the envelope but the
+    specialist's output is still never an authorization — the holder acts on
+    the proposal in its own turn, under its own identity. No new authority
+    tier was invented; `CallerAuthority` names exactly the two states §5.5
+    already describes, and reports the fail-closed `Standard` until
+    #3074/AUTH-1 adds the `user_authority` field to `AgentConfig`.
+  - **Minimal HandoffContext (#4028, OQ-6).** `tools::cross_product::HandoffContext`
+    is a LOCAL copy of epic #2809's shape (`summary`/`relevant_state`/
+    `constraints`, 4 KiB serialized cap) with NO dependency on #2809 landing —
+    an over-cap payload is a recoverable error and the target is never
+    invoked.
+  - **Unchanged for every existing caller.** Omitting `specialist` is
+    byte-identical to pre-#4026 behaviour: same `route_task` derivation, same
+    default target (`pm`), same bare scrubbed transcript back with no
+    envelope. `scrub_branding` and the RBAC tier gate are untouched, and the
+    widened schema still names no backend and enumerates no roster.
+
+### Changed
+
+- **`PmBridgeBackend::run` gained a `target: Option<&str>` parameter (#4026).**
+  `None` preserves today's exact command line. Only the tcode leg honours a
+  target; the tm leg has no per-agent selector and deliberately ignores one
+  rather than mis-routing (the tool forces the tcode leg whenever a specialist
+  is named, so this is unreachable in practice).
+- **`AgentConfig` gained an optional `[subagents]` section (#4026).**
+  `SubagentsConfig { allowed: Option<Vec<String>> }` — a struct rather than a
+  bare list so #4029's Sub-agents configuration section can add fields without
+  a breaking config change, exactly as `SkillsConfig` was shaped. Absent =
+  EMPTY, never "all". Exact names only, no glob dialect.
+
 ### Fixed
 
 - **Streamed replies no longer flash blank or "(no narrative)" the moment a

--- a/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
@@ -105,6 +105,7 @@ fn test_agent_config(name: &str, model: &str, system_prompt: &str) -> AgentConfi
         listeners: Vec::new(),
         stores: crate::stores::StoresConfig::default(),
         skills: crate::agents::SkillsConfig::default(),
+        subagents: crate::agents::SubagentsConfig::default(),
     }
 }
 

--- a/crates/trusty-agents/src/agents/claude_mpm_loader.rs
+++ b/crates/trusty-agents/src/agents/claude_mpm_loader.rs
@@ -139,6 +139,8 @@ impl ClaudeMpmAgent {
             // unbound store is a valid state (see `AgentConfig::stores`).
             stores: crate::stores::StoresConfig::default(),
             skills: crate::agents::SkillsConfig::default(),
+            // #4026: no cross-product grants from a claude-mpm agent yet.
+            subagents: crate::agents::SubagentsConfig::default(),
         }
     }
 }

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -179,10 +179,49 @@ pub struct AgentConfig {
     /// Test: `skills::manifest::tests`.
     #[serde(default)]
     pub skills: SkillsConfig,
+
+    // #4026: cross-product subagent grants — the config source for the
+    // bridge-layer allow-set (epic #4021, OQ-3/OQ-7).
+    /// Optional `[subagents]` section (#4026, epic #4021) — which external
+    /// non-coding specialists this agent may target through `dispatch_task`.
+    ///
+    /// Why: OQ-7's owner ruling puts enforcement at the BRIDGE, fail-closed,
+    /// but OQ-3's ruling makes the caller's config the source of the set until
+    /// #4030's runtime-built domain authority exists to feed it. This section
+    /// is that source. Absent = EMPTY, never "all" — an agent with no
+    /// `[subagents]` section cannot reach any cross-product specialist, the
+    /// same deny-by-default posture `[skills].allow` takes.
+    /// What: [`SubagentsConfig`], whose `allowed` list is intersected with
+    /// `tools::cross_product::NON_CODING_TARGETS` by
+    /// `tools::cross_product::SubagentAllowSet` — config can only ever narrow
+    /// that floor, never widen it.
+    /// Test: `subagents_config_defaults_empty`, `subagents_config_parses_allowed`.
+    #[serde(default)]
+    pub subagents: SubagentsConfig,
 }
 
 fn default_adapter() -> Arc<dyn ModelAdapter> {
     Arc::new(crate::llm::adapter::GenericAdapter)
+}
+
+// #4026: minimal, forward-compatible shape — a struct (not a bare `Vec`) so
+// #4029's Sub-agents configuration section can add `deny`/`domain` keys
+// without a breaking config change, exactly as `SkillsConfig` was shaped.
+/// Optional `[subagents]` section in agent TOML (#4026, epic #4021).
+///
+/// Why: kept as its own struct rather than a bare list so #4029's Sub-agents
+/// configuration section — and #4030's domain-authority feed — can add fields
+/// later without a breaking change, mirroring [`SkillsConfig`]'s rationale.
+/// What: `allowed` is a list of external specialist names. `None` (missing
+/// section) and `Some(vec![])` both resolve to an EMPTY allow-set; the
+/// distinction is deliberately NOT load-bearing here because neither may grant
+/// anything (unlike `[skills]`, where absence leaves `[tools].allow` as the
+/// sole source). No glob dialect — exact names only.
+/// Test: `subagents_config_defaults_empty`, `subagents_config_parses_allowed`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct SubagentsConfig {
+    #[serde(default)]
+    pub allowed: Option<Vec<String>>,
 }
 
 /// Optional `[skills]` section in agent TOML (#3933).

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -31,9 +31,10 @@ pub(crate) mod tests;
 
 // Re-export the config data shapes so `crate::agents::<Type>` keeps resolving
 // for every external consumer after the #358 file split.
+// #4026 adds `SubagentsConfig` (the `[subagents]` cross-product grants).
 pub use config::{
     AgentCapabilities, AgentConfig, AgentInfo, NativeToolsConfig, RunnerKind, SkillsConfig,
-    SystemPrompt, TicketingTomlConfig, ToolsConfig,
+    SubagentsConfig, SystemPrompt, TicketingTomlConfig, ToolsConfig,
 };
 pub use params::{
     AgentCompressConfig, AgentPluginsConfig, LlmParams, RbacConfig, RunnerConfig,

--- a/crates/trusty-agents/src/agents/registry/md_agent.rs
+++ b/crates/trusty-agents/src/agents/registry/md_agent.rs
@@ -225,5 +225,7 @@ pub(crate) fn parse_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
         // store is a valid state (see `AgentConfig::stores`).
         stores: crate::stores::StoresConfig::default(),
         skills: crate::agents::SkillsConfig::default(),
+        // #4026: no cross-product grants from an .md-sourced agent yet.
+        subagents: crate::agents::SubagentsConfig::default(),
     })
 }

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -602,3 +602,71 @@ max_auto = 2
     let cfg: AgentConfig = toml::from_str(toml_str).expect("tolerates legacy [skills]");
     assert_eq!(cfg.agent.name, "x");
 }
+
+#[test]
+fn subagents_config_defaults_empty() {
+    // #4026 EMPTY-DEFAULT PIN: an agent TOML with no `[subagents]` section
+    // grants NO cross-product reach. An absent section must never be read as
+    // "all" — that would be a silent capability grant across a product
+    // boundary, the exact failure mode the owner's OQ-7 fail-closed ruling
+    // exists to prevent.
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert!(cfg.subagents.allowed.is_none());
+    assert!(
+        crate::tools::cross_product::SubagentAllowSet::from_allowed(
+            cfg.subagents.allowed.as_deref()
+        )
+        .is_empty(),
+        "absent [subagents] must resolve to the EMPTY allow-set"
+    );
+}
+
+#[test]
+fn subagents_config_parses_allowed() {
+    // #4026: `[subagents] allowed = [...]` parses alongside `[tools]`/`[skills]`
+    // without disturbing either — the same independence `skills_config_parses_allow`
+    // pins for the skills section.
+    let toml_str = r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+
+[tools]
+allow = ["git_log"]
+
+[subagents]
+allowed = ["research", "ticketing"]
+"#;
+    let cfg: AgentConfig = toml::from_str(toml_str).expect("parses");
+    assert_eq!(
+        cfg.subagents.allowed.as_deref(),
+        Some(&["research".to_string(), "ticketing".to_string()][..])
+    );
+    assert_eq!(
+        cfg.tools.allow.as_deref(),
+        Some(&["git_log".to_string()][..])
+    );
+}

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -20,6 +20,7 @@ use crate::intent::{IntentClass, classify_intent};
 use crate::llm;
 use crate::rbac::ServiceTier;
 use crate::subprocess::SubprocessAgentRunner;
+use crate::tools::cross_product::{CallerAuthority, SubagentAllowSet};
 use crate::tools::pm_bridge::PmBridgeTool;
 use crate::tools::pm_bridge_backend::ProcessPmBridge;
 use crate::tools::{AgentRunner, ToolRegistry, delegate::DelegateToAgentTool};
@@ -393,11 +394,23 @@ pub async fn run_pm_task_with_history(
     ));
     // #3052 PR B (lane 3): the opaque tm<->tcode bridge, distinct from lane 2
     // (`delegate_to_agent` above). RBAC-locked to deny ReadOnly + Analytics.
+    // #4026/#4028: the caller's `[subagents].allowed` list is resolved into the
+    // bridge's fail-closed allow-set here, at registration, so `execute` never
+    // consults anything the LLM can influence mid-turn. Absent section = EMPTY
+    // = named cross-product targeting stays off. #4030's domain authority will
+    // feed the same `SubagentAllowSet` seam.
     registry.register(Arc::new(
         PmBridgeTool::new(Arc::new(ProcessPmBridge::from_project(
             project_path.to_path_buf(),
         )))
-        .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics]),
+        .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics])
+        .with_allow_set(SubagentAllowSet::from_allowed(
+            pm_cfg.subagents.allowed.as_deref(),
+        ))
+        // `user_authority` has no `AgentConfig` field yet (#3074/AUTH-1), so
+        // the fail-closed `Standard` tier is reported until it lands — never
+        // an invented tier.
+        .with_origin(pm_cfg.agent.name.clone(), CallerAuthority::Standard),
     ));
     let stop_pending: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let active_project_slot: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
@@ -24,6 +24,7 @@ impl PmBridgeBackend for NoopBackend {
     async fn run(
         &self,
         _route: crate::intent::route::BridgeRoute,
+        _target: Option<&str>,
         _task: &str,
     ) -> anyhow::Result<String> {
         Ok("ok".to_string())

--- a/crates/trusty-agents/src/runtime/mcp_serve.rs
+++ b/crates/trusty-agents/src/runtime/mcp_serve.rs
@@ -379,7 +379,12 @@ mod mcp_serve_tests {
         }
         #[async_trait::async_trait]
         impl PmBridgeBackend for RecordingBackend {
-            async fn run(&self, _route: BridgeRoute, task: &str) -> anyhow::Result<String> {
+            async fn run(
+                &self,
+                _route: BridgeRoute,
+                _target: Option<&str>,
+                task: &str,
+            ) -> anyhow::Result<String> {
                 self.seen.lock().unwrap().push(task.to_string());
                 Ok("backend transcript".into())
             }

--- a/crates/trusty-agents/src/runtime/pm_mode.rs
+++ b/crates/trusty-agents/src/runtime/pm_mode.rs
@@ -65,6 +65,7 @@ use tools::{ToolRegistry, delegate::DelegateToAgentTool};
 
 use crate::rbac::ServiceTier;
 use crate::subprocess;
+use crate::tools::cross_product::{CallerAuthority, SubagentAllowSet};
 use crate::tools::pm_bridge::PmBridgeTool;
 use crate::tools::pm_bridge_backend::ProcessPmBridge;
 
@@ -98,9 +99,16 @@ pub(super) async fn run_pm() -> Result<()> {
     // (`delegate_to_agent` above). RBAC-locked to deny ReadOnly + Analytics.
     {
         let cwd = std::env::current_dir().unwrap_or_else(|_| std::path::PathBuf::from("."));
+        // #4026/#4028: same registration-time wiring as the history dispatch
+        // path — `[subagents].allowed` resolved into the bridge's fail-closed
+        // allow-set (absent = EMPTY), plus envelope provenance.
         registry.register(Arc::new(
             PmBridgeTool::new(Arc::new(ProcessPmBridge::from_project(cwd)))
-                .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics]),
+                .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics])
+                .with_allow_set(SubagentAllowSet::from_allowed(
+                    pm_cfg.subagents.allowed.as_deref(),
+                ))
+                .with_origin(pm_cfg.agent.name.clone(), CallerAuthority::Standard),
         ));
     }
     // #304: Coordinator-facing shell executor — see `tools::run_bash`.

--- a/crates/trusty-agents/src/tools/cross_product.rs
+++ b/crates/trusty-agents/src/tools/cross_product.rs
@@ -1,0 +1,424 @@
+//! Cross-product subagent primitives for the `dispatch_task` bridge (epic
+//! #4021, issues #4026/#4028): the bridge-layer allow-set that decides WHICH
+//! external non-coding specialist may be targeted, and the propose-only
+//! envelope every such specialist's result is wrapped in.
+//!
+//! Why: `dispatch_task` (`crate::tools::pm_bridge`) historically hardcoded a
+//! single opaque target. Widening it so a caller can name a specialist
+//! (#4026) opens two questions that must be answered HERE, at the bridge,
+//! rather than at the caller: (1) which names are reachable at all — the
+//! owner's OQ-7 ruling is bridge-layer, fail-closed enforcement, never
+//! caller-trusted alone; and (2) what authority the result carries — DOC-41
+//! §5.5's "propose-not-authorize, absolute for M1 — no exceptions"
+//! (`docs/specs/trusty-agents-eve-style-agents-spec.md:1398`) plus #3078's
+//! AUTH-5 regression pattern on `delegate_to_agent`. An external specialist
+//! runs in a DIFFERENT PRODUCT that has no `user_authority` concept at all,
+//! so by construction its output can only ever be a proposal.
+//! What: [`NON_CODING_TARGETS`] is the hard, bridge-owned floor of reachable
+//! specialist names; [`SubagentAllowSet`] intersects it with the calling
+//! agent's own `[subagents].allowed` config list
+//! (`crate::agents::config::SubagentsConfig`) and resolves a requested name
+//! or returns a [`TargetDenied`] reason. [`HandoffContext`] is the minimal
+//! #2809-SHAPED outbound payload (`summary`/`relevant_state`/`constraints`,
+//! 4 KiB serialized cap) — a local copy of that shape per the owner's OQ-6
+//! ruling, with NO dependency on epic #2809 landing. [`ProposalEnvelope`] is
+//! the inbound wrapper: origin agent, target agent, the CALLER's authority
+//! tier, and a [`Disposition`] marker that this bridge always sets to
+//! `Proposal`.
+//! Test: `cross_product_tests` — empty-default pin, allow-set fail-closed
+//! rejection, non-coding floor beating a permissive config, envelope shape
+//! and always-`Proposal` disposition, and the 4 KiB handoff cap.
+
+use serde::{Deserialize, Serialize};
+
+/// Maximum serialized size of a [`HandoffContext`], in bytes (#2809 §5.2's
+/// 4 KiB cap, mirrored locally per OQ-6).
+///
+/// Why: an unbounded caller-supplied handoff would let the calling LLM smuggle
+/// its whole conversation across a process boundary, defeating the
+/// clean-context guarantee #2809 specifies and inflating every dispatch. The
+/// cap is checked BEFORE the target is invoked so an oversized payload is a
+/// recoverable caller error, never a half-executed dispatch.
+/// What: 4096 bytes, measured over `serde_json::to_vec`.
+/// Test: `handoff_over_cap_is_rejected`, `handoff_at_cap_is_accepted`.
+pub const HANDOFF_MAX_BYTES: usize = 4096;
+
+/// The bridge-owned floor of externally reachable NON-CODING specialist names
+/// (#4026, epic #4021 OQ-7).
+///
+/// Why: the owner's OQ-7 ruling is that the bridge itself hard-denies anything
+/// outside the non-coding set "regardless of caller configuration" — a
+/// misconfigured or LLM-influenced `[subagents].allowed` must never be able to
+/// reach a coding agent (which would hand a sandboxed assistant an
+/// unrestricted write/shell surface in another product, the same escalation
+/// class `delegate_to_agent`'s `allowed_target_roles` gate closed for the
+/// in-product path). Two layers, not one: this floor AND the caller's config.
+/// What: the two specialists epic #4021's owner directive names explicitly —
+/// `research` (already in trusty-code's roster) and `ticketing` (ported by
+/// #4027). Deliberately a closed literal list, not a heuristic: #4030's
+/// runtime-built domain authority is what will eventually FEED this set, and
+/// until it exists an exact list is the only honest source.
+/// Test: `non_coding_floor_rejects_a_coding_target_even_when_config_allows_it`,
+/// `allow_set_accepts_a_named_non_coding_target`.
+pub const NON_CODING_TARGETS: &[&str] = &["research", "ticketing"];
+
+/// Why a requested cross-product target was refused.
+///
+/// Why: the bridge must fail CLOSED with a clear, caller-actionable reason and
+/// without dispatching anything — but it must not enumerate the roster back to
+/// a black-boxed persona (the #3052 PR A CRITICAL-2 rule `delegate_to_agent`
+/// already follows). A small reason enum keeps the caller-facing string in one
+/// place instead of scattered format strings.
+/// What: three variants covering the three ways resolution fails.
+/// Test: `blank_target_is_rejected`, `empty_default_allow_set_denies_everything`,
+/// `non_coding_floor_rejects_a_coding_target_even_when_config_allows_it`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetDenied {
+    /// The requested name was blank/whitespace-only.
+    Blank,
+    /// The name is not in [`NON_CODING_TARGETS`] — the bridge's hard floor.
+    NotNonCoding(String),
+    /// The name passed the floor but the caller's `[subagents].allowed` list
+    /// does not grant it (this includes the EMPTY default — see
+    /// [`SubagentAllowSet::empty`]).
+    NotGranted(String),
+}
+
+impl std::fmt::Display for TargetDenied {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TargetDenied::Blank => write!(f, "specialist name must not be empty"),
+            // Both denials render the SAME generic text on purpose: the
+            // difference between "not a permitted kind of specialist" and "not
+            // granted to you" would let a caller probe the floor list.
+            TargetDenied::NotNonCoding(name) | TargetDenied::NotGranted(name) => {
+                write!(f, "specialist '{name}' is not available to this agent")
+            }
+        }
+    }
+}
+
+/// The fail-closed set of cross-product specialist names one calling agent may
+/// target through the bridge (#4026).
+///
+/// Why: see the module docs. Constructed once at tool-registration time from
+/// the calling agent's config so `execute()` never consults anything the LLM
+/// can influence mid-turn.
+/// What: `granted` holds the caller's configured names, already trimmed and
+/// lowercased. [`SubagentAllowSet::resolve`] requires membership in BOTH
+/// `granted` and [`NON_CODING_TARGETS`]. The default ([`Self::empty`]) grants
+/// nothing — an absent `[subagents]` section is NOT a silent capability grant.
+/// Test: `empty_default_allow_set_denies_everything`,
+/// `allow_set_accepts_a_named_non_coding_target`.
+#[derive(Debug, Clone, Default)]
+pub struct SubagentAllowSet {
+    granted: Vec<String>,
+}
+
+impl SubagentAllowSet {
+    /// The empty allow-set — the DEFAULT, granting nothing.
+    ///
+    /// Why: an absent `[subagents]` section must not widen capability. This is
+    /// the pinned posture for the whole feature: named cross-product targeting
+    /// is off until an agent's config explicitly turns it on, mirroring
+    /// `[tools].allow`/`[skills].allow`'s deny-by-default stance.
+    /// What: an allow-set with no granted names; every `resolve` returns
+    /// [`TargetDenied::NotGranted`].
+    /// Test: `empty_default_allow_set_denies_everything`,
+    /// `default_impl_is_the_empty_allow_set`.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Build from a caller's configured `[subagents].allowed` list.
+    ///
+    /// Why: OQ-3's ruling makes the config list the source of truth for now,
+    /// with #4030's runtime-built domain authority feeding the same set later
+    /// — so this constructor is the single seam that will gain that second
+    /// source without touching the bridge or the tool.
+    /// What: `None` (absent section) yields [`Self::empty`]. Names are
+    /// trimmed, lowercased, and de-duplicated; blank entries are dropped. No
+    /// glob dialect — exact names only, matching `[skills].allow`'s
+    /// literal-ids-only invariant.
+    /// Test: `from_allowed_none_is_empty`, `from_allowed_normalizes_entries`.
+    pub fn from_allowed(allowed: Option<&[String]>) -> Self {
+        let Some(list) = allowed else {
+            return Self::empty();
+        };
+        let mut granted: Vec<String> = Vec::new();
+        for raw in list {
+            let name = raw.trim().to_ascii_lowercase();
+            if name.is_empty() || granted.contains(&name) {
+                continue;
+            }
+            granted.push(name);
+        }
+        Self { granted }
+    }
+
+    /// Whether this allow-set grants nothing (the default posture).
+    ///
+    /// Why: the tool layer uses this to decide whether to advertise the
+    /// specialist parameter at all — an agent with no grants should not be
+    /// invited to guess names.
+    /// What: true iff no name is granted.
+    /// Test: `empty_default_allow_set_denies_everything`.
+    pub fn is_empty(&self) -> bool {
+        self.granted.is_empty()
+    }
+
+    /// Resolve a caller-requested specialist name, fail-closed.
+    ///
+    /// Why: THE enforcement point (OQ-7). Nothing is dispatched unless this
+    /// returns `Ok`; both the non-coding floor and the caller's own grant list
+    /// must admit the name.
+    /// What: trims/lowercases `requested`, then requires membership in
+    /// [`NON_CODING_TARGETS`] first (the bridge's own floor, checked BEFORE
+    /// config so a permissive config can never widen it) and in `granted`
+    /// second. Returns the normalized name on success.
+    /// Test: `allow_set_accepts_a_named_non_coding_target`,
+    /// `non_coding_floor_rejects_a_coding_target_even_when_config_allows_it`,
+    /// `blank_target_is_rejected`.
+    pub fn resolve(&self, requested: &str) -> Result<String, TargetDenied> {
+        let name = requested.trim().to_ascii_lowercase();
+        if name.is_empty() {
+            return Err(TargetDenied::Blank);
+        }
+        if !NON_CODING_TARGETS.contains(&name.as_str()) {
+            return Err(TargetDenied::NotNonCoding(name));
+        }
+        if !self.granted.contains(&name) {
+            return Err(TargetDenied::NotGranted(name));
+        }
+        Ok(name)
+    }
+}
+
+/// Minimal, #2809-SHAPED outbound handoff payload (#4028, OQ-6).
+///
+/// Why: the owner's OQ-6 ruling is "minimal HandoffContext-shaped envelope
+/// now, no dependency on #2809". This is that local copy: the SAME three
+/// fields and the SAME 4 KiB cap epic #2809 specifies, so when #2809's struct
+/// lands the two reconcile by renaming rather than by re-designing the wire
+/// shape. It is deliberately NOT re-exported as #2809's type — this module
+/// owns the cross-product copy and nothing else depends on it.
+/// What: `summary` (what the caller already knows), `relevant_state`
+/// (caller-selected facts), `constraints` (limits the specialist must honour).
+/// All optional; an omitted handoff is byte-identical to pre-#4026 behaviour.
+/// [`HandoffContext::validate`] enforces [`HANDOFF_MAX_BYTES`].
+/// Test: `handoff_over_cap_is_rejected`, `handoff_at_cap_is_accepted`,
+/// `handoff_renders_into_the_task_preamble`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct HandoffContext {
+    /// Short statement of the situation the specialist is being handed.
+    #[serde(default)]
+    pub summary: Option<String>,
+    /// Caller-selected facts the specialist needs; free-form key/value text.
+    #[serde(default)]
+    pub relevant_state: Option<String>,
+    /// Limits the specialist must honour (scope, tone, forbidden actions).
+    #[serde(default)]
+    pub constraints: Vec<String>,
+}
+
+impl HandoffContext {
+    /// Enforce the 4 KiB serialized cap BEFORE any dispatch happens.
+    ///
+    /// Why: #4028's acceptance is explicit — an oversized payload "returns a
+    /// recoverable error without invoking the target". Validating here, ahead
+    /// of the backend call, is what makes "without invoking" true.
+    /// What: `Err(actual_size)` when `serde_json::to_vec` exceeds
+    /// [`HANDOFF_MAX_BYTES`]; `Ok(())` otherwise. A serialization failure is
+    /// treated as over-cap (fail-closed) rather than silently passing.
+    /// Test: `handoff_over_cap_is_rejected`, `handoff_at_cap_is_accepted`.
+    pub fn validate(&self) -> Result<(), usize> {
+        match serde_json::to_vec(self) {
+            Ok(bytes) if bytes.len() <= HANDOFF_MAX_BYTES => Ok(()),
+            Ok(bytes) => Err(bytes.len()),
+            Err(_) => Err(usize::MAX),
+        }
+    }
+
+    /// Whether every field is unset — i.e. the caller supplied no handoff.
+    ///
+    /// Why: an all-empty handoff must render NOTHING into the task text so the
+    /// no-handoff path stays byte-identical to pre-#4026 dispatch.
+    /// What: true iff both optional fields are `None`/blank and `constraints`
+    /// is empty.
+    /// Test: `empty_handoff_renders_nothing`.
+    pub fn is_empty(&self) -> bool {
+        self.summary.as_deref().unwrap_or("").trim().is_empty()
+            && self
+                .relevant_state
+                .as_deref()
+                .unwrap_or("")
+                .trim()
+                .is_empty()
+            && self.constraints.is_empty()
+    }
+
+    /// Render the handoff as a plain-text preamble prepended to the task.
+    ///
+    /// Why: the external CLI leg accepts one task string and nothing else, so
+    /// a structured handoff must be flattened to cross the process boundary.
+    /// Plain text (not JSON) because the receiving side is an LLM persona, not
+    /// a parser.
+    /// What: returns `None` when [`Self::is_empty`]; otherwise a labelled
+    /// block naming only the fields that are actually set.
+    /// Test: `handoff_renders_into_the_task_preamble`,
+    /// `empty_handoff_renders_nothing`.
+    pub fn render_preamble(&self) -> Option<String> {
+        if self.is_empty() {
+            return None;
+        }
+        let mut out = String::from("Context handed to you:\n");
+        if let Some(s) = self
+            .summary
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            out.push_str(&format!("- Summary: {s}\n"));
+        }
+        if let Some(s) = self
+            .relevant_state
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            out.push_str(&format!("- Relevant state: {s}\n"));
+        }
+        for c in self
+            .constraints
+            .iter()
+            .map(|c| c.trim())
+            .filter(|c| !c.is_empty())
+        {
+            out.push_str(&format!("- Constraint: {c}\n"));
+        }
+        Some(out)
+    }
+}
+
+/// The authority tier of the agent that CALLED the bridge (#4028).
+///
+/// Why: DOC-41 §5.5's `user_authority` is a manifest-level singleton that has
+/// no field on `AgentConfig` yet (reserved for #3074/AUTH-1, see
+/// `docs/specs/agent-config-five-sections.md:649`). Recording the caller's
+/// tier in the envelope — rather than inventing a new tier — lets the
+/// authority-holder recognise that IT, in its own turn under its own identity,
+/// is the party that may act on a returned proposal. No new tier is defined
+/// here: this enum names exactly the two states §5.5 already describes.
+/// What: `Standard` (the default, fail-closed) and `UserAuthority`.
+/// Test: `envelope_records_caller_authority_without_upgrading_disposition`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CallerAuthority {
+    /// No `user_authority` — every agent except the singleton holder.
+    #[default]
+    Standard,
+    /// The DOC-41 §5.5 singleton authority-holder.
+    UserAuthority,
+}
+
+/// Whether an envelope's payload is a PROPOSAL or an executed ACTION (#4028).
+///
+/// Why: DOC-41 §5.5 line 1398 — "propose-not-authorize, absolute for M1 — no
+/// exceptions". A cross-product specialist runs in a different product with no
+/// `user_authority` concept at all, so its output is a proposal
+/// UNCONDITIONALLY — including when the caller itself holds `user_authority`
+/// (that caller may then act, in its own turn, on its own identity; the
+/// specialist's output still never IS the action). `Action` exists so the
+/// marker is a genuine two-state discriminator rather than a constant, and is
+/// documented as never produced by this bridge.
+/// What: `Proposal` is the only value [`ProposalEnvelope::for_cross_product`]
+/// can emit.
+/// Test: `cross_product_result_is_always_a_proposal`,
+/// `envelope_records_caller_authority_without_upgrading_disposition`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Disposition {
+    /// Drafted content for the caller to review — never self-authorizing.
+    Proposal,
+    /// An action already taken under the actor's own authority. NEVER emitted
+    /// by the cross-product bridge; present so `Proposal` is a real choice.
+    Action,
+}
+
+/// The propose-only wrapper around a cross-product specialist's result
+/// (#4028).
+///
+/// Why: see [`Disposition`]. Without an explicit marker on the wire, a
+/// specialist's transcript reaching the caller's context is indistinguishable
+/// from the caller's own authorized output — exactly the confusion #3078's
+/// AUTH-5 tests exist to prevent on the in-product path.
+/// What: the minimal HandoffContext-SHAPED envelope epic #4021 OQ-6 settled
+/// on: `origin_agent`, `target_agent`, `authority` (the CALLER's tier),
+/// `disposition` (always `Proposal`), and the specialist's already-scrubbed
+/// `result` text.
+/// Test: `cross_product_result_is_always_a_proposal`, `envelope_json_shape`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProposalEnvelope {
+    /// The trusty-agents agent that initiated the dispatch.
+    pub origin_agent: String,
+    /// The external non-coding specialist that produced `result`.
+    pub target_agent: String,
+    /// The ORIGIN agent's authority tier — never the target's (the target has
+    /// none; it is a different product).
+    pub authority: CallerAuthority,
+    /// Always [`Disposition::Proposal`] for a cross-product result.
+    pub disposition: Disposition,
+    /// The specialist's output, already branding-scrubbed by the tool layer.
+    pub result: String,
+}
+
+impl ProposalEnvelope {
+    /// Wrap a cross-product result, unconditionally as a proposal.
+    ///
+    /// Why: making this the ONLY constructor is what makes DOC-41 §5.5's
+    /// absolute rule structural rather than a convention a future edit could
+    /// forget — there is no code path through this type that yields
+    /// [`Disposition::Action`], regardless of `authority`.
+    /// What: builds the envelope with `disposition: Proposal` always.
+    /// Test: `cross_product_result_is_always_a_proposal`,
+    /// `envelope_records_caller_authority_without_upgrading_disposition`.
+    pub fn for_cross_product(
+        origin_agent: impl Into<String>,
+        target_agent: impl Into<String>,
+        authority: CallerAuthority,
+        result: impl Into<String>,
+    ) -> Self {
+        Self {
+            origin_agent: origin_agent.into(),
+            target_agent: target_agent.into(),
+            authority,
+            // Never `Action` — see the type docs and DOC-41 §5.5 line 1398.
+            disposition: Disposition::Proposal,
+            result: result.into(),
+        }
+    }
+
+    /// Render as the tool-result string handed back to the calling LLM.
+    ///
+    /// Why: the caller is a model, not a parser; a pretty JSON document with a
+    /// leading plain-language line states the propose-only status in a form
+    /// the model reliably honours while keeping the fields machine-readable.
+    /// What: one advisory line plus the pretty-printed envelope. Falls back to
+    /// the bare result text if serialization somehow fails, so a returned
+    /// transcript is never lost.
+    /// Test: `envelope_json_shape`.
+    pub fn render(&self) -> String {
+        match serde_json::to_string_pretty(self) {
+            Ok(json) => format!(
+                "The specialist's output below is a PROPOSAL for you to review \
+                 and act on yourself; it does not authorize anything on its own.\n\
+                 {json}"
+            ),
+            Err(_) => self.result.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "cross_product_tests.rs"]
+mod cross_product_tests;

--- a/crates/trusty-agents/src/tools/cross_product_tests.rs
+++ b/crates/trusty-agents/src/tools/cross_product_tests.rs
@@ -1,0 +1,230 @@
+//! Tests for `tools::cross_product` — the bridge-layer allow-set (#4026) and
+//! the propose-only envelope (#4028), epic #4021's bridge track.
+//!
+//! Why: every assertion here pins an owner ruling or a spec rule that a future
+//! edit could silently relax: OQ-7's fail-closed bridge enforcement, the
+//! EMPTY-by-default allow-set (no silent capability grant), DOC-41 §5.5's
+//! absolute propose-not-authorize rule, and #2809's 4 KiB handoff cap.
+//! What: unit tests over `SubagentAllowSet`, `HandoffContext`, and
+//! `ProposalEnvelope`. No I/O, no subprocesses — the dispatch-side
+//! fail-closed behaviour (nothing dispatched on denial) is pinned in
+//! `pm_bridge_tests.rs` where a recording backend can observe it.
+
+use super::*;
+
+// =====================================================================
+// Allow-set — fail-closed resolution (#4026, OQ-7)
+// =====================================================================
+
+/// The DEFAULT allow-set grants nothing: an agent with no `[subagents]`
+/// section cannot reach ANY cross-product specialist, not even a non-coding
+/// one. Pins "no silent capability grant".
+#[test]
+fn empty_default_allow_set_denies_everything() {
+    let set = SubagentAllowSet::empty();
+    assert!(set.is_empty());
+    for name in NON_CODING_TARGETS {
+        assert_eq!(
+            set.resolve(name),
+            Err(TargetDenied::NotGranted((*name).to_string())),
+            "empty allow-set must deny the non-coding target '{name}'"
+        );
+    }
+}
+
+/// `Default` and `empty()` are the same posture — a `SubagentAllowSet` that
+/// materializes through `#[derive(Default)]` must not be permissive.
+#[test]
+fn default_impl_is_the_empty_allow_set() {
+    assert!(SubagentAllowSet::default().is_empty());
+}
+
+/// An absent `[subagents].allowed` list (serde `None`) is the empty set.
+#[test]
+fn from_allowed_none_is_empty() {
+    assert!(SubagentAllowSet::from_allowed(None).is_empty());
+}
+
+/// Entries are trimmed, lowercased and de-duplicated; blanks are dropped.
+#[test]
+fn from_allowed_normalizes_entries() {
+    let raw = vec![
+        "  Research ".to_string(),
+        "research".to_string(),
+        "   ".to_string(),
+        "TICKETING".to_string(),
+    ];
+    let set = SubagentAllowSet::from_allowed(Some(&raw));
+    assert_eq!(set.resolve("research").unwrap(), "research");
+    assert_eq!(set.resolve("  TiCkEtInG  ").unwrap(), "ticketing");
+}
+
+/// A named, granted, non-coding target resolves.
+#[test]
+fn allow_set_accepts_a_named_non_coding_target() {
+    let set = SubagentAllowSet::from_allowed(Some(&["research".to_string()]));
+    assert_eq!(set.resolve("research").unwrap(), "research");
+    // ...but a non-coding target the caller did NOT grant is still denied.
+    assert_eq!(
+        set.resolve("ticketing"),
+        Err(TargetDenied::NotGranted("ticketing".to_string()))
+    );
+}
+
+/// #4027: the ported ticketing agent is reachable once granted.
+#[test]
+fn allow_set_accepts_ticketing_once_granted() {
+    let set = SubagentAllowSet::from_allowed(Some(&["ticketing".to_string()]));
+    assert_eq!(set.resolve("ticketing").unwrap(), "ticketing");
+    assert!(NON_CODING_TARGETS.contains(&"ticketing"));
+}
+
+/// OQ-7's core ruling: the BRIDGE hard-denies a coding target even when the
+/// calling agent's own config explicitly lists it. Caller configuration can
+/// only ever NARROW the non-coding floor, never widen it.
+#[test]
+fn non_coding_floor_rejects_a_coding_target_even_when_config_allows_it() {
+    let permissive = vec![
+        "rust-engineer".to_string(),
+        "engineer".to_string(),
+        "pm".to_string(),
+        "research".to_string(),
+    ];
+    let set = SubagentAllowSet::from_allowed(Some(&permissive));
+    for coding in ["rust-engineer", "engineer", "pm"] {
+        assert_eq!(
+            set.resolve(coding),
+            Err(TargetDenied::NotNonCoding(coding.to_string())),
+            "bridge floor must deny coding target '{coding}' despite config"
+        );
+    }
+    // The one legitimate entry in the same list still resolves.
+    assert_eq!(set.resolve("research").unwrap(), "research");
+}
+
+/// A blank/whitespace name is rejected before any lookup.
+#[test]
+fn blank_target_is_rejected() {
+    let set = SubagentAllowSet::from_allowed(Some(&["research".to_string()]));
+    assert_eq!(set.resolve("   "), Err(TargetDenied::Blank));
+    assert_eq!(set.resolve(""), Err(TargetDenied::Blank));
+}
+
+/// Both denial reasons render the SAME generic message so a caller cannot
+/// probe the floor list by diffing error text.
+#[test]
+fn denial_messages_do_not_distinguish_floor_from_grant() {
+    let floor = TargetDenied::NotNonCoding("engineer".to_string()).to_string();
+    let grant = TargetDenied::NotGranted("engineer".to_string()).to_string();
+    assert_eq!(floor, grant);
+    assert!(floor.contains("not available"), "unexpected text: {floor}");
+}
+
+// =====================================================================
+// HandoffContext — #2809-shaped, 4 KiB cap (#4028, OQ-6)
+// =====================================================================
+
+/// A handoff within the cap validates.
+#[test]
+fn handoff_at_cap_is_accepted() {
+    let handoff = HandoffContext {
+        summary: Some("x".repeat(64)),
+        relevant_state: None,
+        constraints: vec!["stay read-only".to_string()],
+    };
+    assert!(handoff.validate().is_ok());
+    assert!(serde_json::to_vec(&handoff).unwrap().len() <= HANDOFF_MAX_BYTES);
+}
+
+/// An oversized handoff is a recoverable error carrying the actual size.
+#[test]
+fn handoff_over_cap_is_rejected() {
+    let handoff = HandoffContext {
+        summary: Some("x".repeat(HANDOFF_MAX_BYTES + 1)),
+        relevant_state: None,
+        constraints: Vec::new(),
+    };
+    let err = handoff.validate().expect_err("over-cap handoff must fail");
+    assert!(err > HANDOFF_MAX_BYTES, "reported size {err} not over cap");
+}
+
+/// An all-empty handoff renders nothing, so the no-handoff path is unchanged.
+#[test]
+fn empty_handoff_renders_nothing() {
+    assert!(HandoffContext::default().is_empty());
+    assert!(HandoffContext::default().render_preamble().is_none());
+}
+
+/// A populated handoff renders a labelled preamble naming only set fields.
+#[test]
+fn handoff_renders_into_the_task_preamble() {
+    let handoff = HandoffContext {
+        summary: Some("backlog triage".to_string()),
+        relevant_state: None,
+        constraints: vec!["do not close anything".to_string()],
+    };
+    let rendered = handoff
+        .render_preamble()
+        .expect("non-empty handoff renders");
+    assert!(rendered.contains("backlog triage"));
+    assert!(rendered.contains("do not close anything"));
+    assert!(
+        !rendered.contains("Relevant state"),
+        "unset field must not be rendered: {rendered}"
+    );
+}
+
+// =====================================================================
+// ProposalEnvelope — propose-not-authorize (#4028, DOC-41 §5.5)
+// =====================================================================
+
+/// DOC-41 §5.5 line 1398, absolute: a cross-product result is a PROPOSAL,
+/// never an action — for BOTH caller authority tiers.
+#[test]
+fn cross_product_result_is_always_a_proposal() {
+    for authority in [CallerAuthority::Standard, CallerAuthority::UserAuthority] {
+        let env = ProposalEnvelope::for_cross_product("assistant", "ticketing", authority, "ok");
+        assert_eq!(env.disposition, Disposition::Proposal);
+        assert_ne!(env.disposition, Disposition::Action);
+    }
+}
+
+/// #3078/AUTH-5 mirrored to the bridge: holding `user_authority` is RECORDED
+/// on the envelope but never upgrades the target's output out of proposal
+/// status — the caller must act in its own turn, under its own identity.
+#[test]
+fn envelope_records_caller_authority_without_upgrading_disposition() {
+    let env = ProposalEnvelope::for_cross_product(
+        "assistant",
+        "research",
+        CallerAuthority::UserAuthority,
+        "findings",
+    );
+    assert_eq!(env.authority, CallerAuthority::UserAuthority);
+    assert_eq!(env.disposition, Disposition::Proposal);
+}
+
+/// The envelope's serialized shape carries every field #4028 requires:
+/// origin agent, target agent, authority tier, proposal-vs-action marker.
+#[test]
+fn envelope_json_shape() {
+    let env = ProposalEnvelope::for_cross_product(
+        "assistant",
+        "ticketing",
+        CallerAuthority::Standard,
+        "drafted ISS-1",
+    );
+    let value: serde_json::Value =
+        serde_json::from_str(&serde_json::to_string(&env).expect("envelope serializes"))
+            .expect("envelope is valid json");
+
+    assert_eq!(value["origin_agent"], "assistant");
+    assert_eq!(value["target_agent"], "ticketing");
+    assert_eq!(value["authority"], "standard");
+    assert_eq!(value["disposition"], "proposal");
+    assert_eq!(value["result"], "drafted ISS-1");
+
+    let rendered = env.render();
+    assert!(rendered.contains("PROPOSAL"), "rendered: {rendered}");
+    assert!(rendered.contains("\"disposition\": \"proposal\""));
+}

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -14,6 +14,8 @@ pub mod agent_plugin;
 pub mod always_on;
 pub mod analysis;
 pub mod ast_tools;
+// #4026/#4028: cross-product subagent allow-set + propose-only envelope.
+pub mod cross_product;
 pub mod delegate;
 pub mod file_filter;
 pub mod finish_task;

--- a/crates/trusty-agents/src/tools/pm_bridge.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge.rs
@@ -26,6 +26,29 @@
 //! right side, `scrub_branding` strips every forbidden token from a sample
 //! backend transcript, `name()`/`schema()` stay clean, and an RBAC test
 //! proves both denied tiers never see the tool via `filter_tools_for_user`.
+//!
+//! ## Cross-product specialists (epic #4021, #4026/#4028)
+//!
+//! The tool now also accepts an OPTIONAL `specialist` name, routing the task
+//! to that named external non-coding agent instead of the default opaque
+//! target. Two rules govern it, both enforced here rather than at the caller:
+//!
+//! - **#4026, fail-closed allow-set.** A named specialist is resolved through
+//!   `cross_product::SubagentAllowSet` — the intersection of the bridge's own
+//!   `NON_CODING_TARGETS` floor with the calling agent's `[subagents].allowed`
+//!   config. The default is EMPTY: omitting `with_allow_set` disables named
+//!   targeting entirely. A denial returns before `backend.run`, so nothing is
+//!   dispatched. Per the owner's OQ-7 ruling this is never caller-trusted;
+//!   #4030's domain authority will later feed the same seam.
+//! - **#4028, propose-not-authorize.** A named specialist's result is wrapped
+//!   in `cross_product::ProposalEnvelope` (origin agent, target agent, the
+//!   CALLER's authority tier, and a `Disposition` marker that is always
+//!   `Proposal`) per DOC-41 §5.5 line 1398 and #3078's AUTH-5 pattern. Holding
+//!   `user_authority` is recorded, never an upgrade: the caller acts on the
+//!   proposal in its own turn, under its own identity.
+//!
+//! Omitting `specialist` is byte-identical to pre-#4026 behaviour: same route
+//! derivation, same default target, same bare scrubbed transcript back.
 
 use std::sync::{Arc, OnceLock};
 
@@ -33,16 +56,34 @@ use async_trait::async_trait;
 use regex::Regex;
 use serde_json::{Value, json};
 
-use crate::intent::route::route_task;
+use crate::intent::route::{BridgeRoute, route_task};
 use crate::rbac::ServiceTier;
+use crate::tools::cross_product::{
+    CallerAuthority, HandoffContext, ProposalEnvelope, SubagentAllowSet,
+};
 use crate::tools::pm_bridge_backend::PmBridgeBackend;
 use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Envelope `origin_agent` used when a registration site names none.
+///
+/// Why: `ProposalEnvelope` must always identify an origin, but the older
+/// registration sites have no agent identity to hand in. A generic, non-
+/// branded placeholder keeps the envelope honest without leaking anything.
+/// What: the literal used unless `with_origin` supplies a real name.
+/// Test: `envelope_carries_origin_target_and_authority`.
+const DEFAULT_ORIGIN_AGENT: &str = "assistant";
 
 /// `dispatch_task` — hands a task to whichever backend `route_task` decides,
 /// via an injected `PmBridgeBackend`.
 pub struct PmBridgeTool {
     backend: Arc<dyn PmBridgeBackend>,
     restricted: Vec<ServiceTier>,
+    // #4026: the fail-closed, bridge-owned allow-set for named cross-product
+    // specialists. EMPTY by default — see `with_allow_set`.
+    allow_set: SubagentAllowSet,
+    // #4028: envelope provenance/authority for cross-product results.
+    origin_agent: String,
+    caller_authority: CallerAuthority,
 }
 
 impl PmBridgeTool {
@@ -59,7 +100,54 @@ impl PmBridgeTool {
         Self {
             backend,
             restricted: Vec::new(),
+            // #4026: EMPTY allow-set by default — constructing the tool grants
+            // no cross-product reach whatsoever.
+            allow_set: SubagentAllowSet::empty(),
+            origin_agent: DEFAULT_ORIGIN_AGENT.to_string(),
+            caller_authority: CallerAuthority::Standard,
         }
+    }
+
+    /// Attach the calling agent's cross-product allow-set (#4026).
+    ///
+    /// Why: OQ-7 puts enforcement at the bridge, fail-closed. Injecting the
+    /// resolved set at REGISTRATION time (from the caller's
+    /// `[subagents].allowed`, see `agents::config::SubagentsConfig`) means
+    /// `execute` never consults anything the LLM can influence mid-turn, and
+    /// #4030's domain authority can later feed the same seam without touching
+    /// this tool.
+    /// What: replaces the default EMPTY set. Omitting this call leaves named
+    /// specialist targeting fully disabled — the no-silent-grant default.
+    /// Test: `named_specialist_is_denied_when_no_allow_set_is_configured`,
+    /// `named_specialist_reaches_the_backend_when_allowed`.
+    pub fn with_allow_set(mut self, allow_set: SubagentAllowSet) -> Self {
+        self.allow_set = allow_set;
+        self
+    }
+
+    /// Attach the envelope's origin identity and the CALLER's authority tier
+    /// (#4028).
+    ///
+    /// Why: `ProposalEnvelope` records who dispatched and at what tier so an
+    /// authority-holder can recognise that IT, in its own turn, is the party
+    /// that may act on a returned proposal (DOC-41 §5.5). The tier is supplied
+    /// by the registration site rather than read here because `user_authority`
+    /// has no `AgentConfig` field yet (reserved for #3074/AUTH-1) — this is
+    /// the seam that will read it when it lands, with no new tier invented.
+    /// What: sets `origin_agent` (blank falls back to the generic default) and
+    /// `caller_authority`.
+    /// Test: `envelope_carries_origin_target_and_authority`.
+    pub fn with_origin(
+        mut self,
+        origin_agent: impl Into<String>,
+        caller_authority: CallerAuthority,
+    ) -> Self {
+        let origin = origin_agent.into();
+        if !origin.trim().is_empty() {
+            self.origin_agent = origin;
+        }
+        self.caller_authority = caller_authority;
+        self
     }
 
     /// Attach the RBAC-denied tiers.
@@ -94,6 +182,25 @@ impl ToolExecutor for PmBridgeTool {
                         "task": {
                             "type": "string",
                             "description": "A concrete, self-contained description of the work to hand off."
+                        },
+                        // #4026: optional named specialist. Described without
+                        // naming any backend or enumerating the roster (the
+                        // #3052 PR A CRITICAL-2 rule) — the caller's own
+                        // instructions are the source of legitimate names.
+                        "specialist": {
+                            "type": "string",
+                            "description": "Optional name of a non-coding specialist to hand this to, when your own instructions name one. Omit to let the system choose how to execute the task."
+                        },
+                        // #4028: optional HandoffContext-shaped payload.
+                        "handoff": {
+                            "type": "object",
+                            "description": "Optional context to hand along with the task. Keep it small; it is capped.",
+                            "properties": {
+                                "summary": { "type": "string" },
+                                "relevant_state": { "type": "string" },
+                                "constraints": { "type": "array", "items": { "type": "string" } }
+                            },
+                            "additionalProperties": false
                         }
                     },
                     "required": ["task"],
@@ -111,9 +218,71 @@ impl ToolExecutor for PmBridgeTool {
             return ToolResult::err("dispatch_task: 'task' must not be empty");
         }
 
-        let route = route_task(task);
-        match self.backend.run(route, task).await {
-            Ok(out) => ToolResult::ok(scrub_branding(&out)),
+        // #4028: validate the handoff BEFORE anything is dispatched, so an
+        // over-cap payload is a recoverable caller error and the target is
+        // never invoked.
+        let handoff = match args.get("handoff") {
+            None | Some(Value::Null) => HandoffContext::default(),
+            Some(raw) => match serde_json::from_value::<HandoffContext>(raw.clone()) {
+                Ok(h) => h,
+                Err(e) => return ToolResult::err(format!("dispatch_task: invalid 'handoff': {e}")),
+            },
+        };
+        if let Err(size) = handoff.validate() {
+            return ToolResult::err(format!(
+                "dispatch_task: 'handoff' is too large ({size} bytes; limit {}) — nothing was dispatched",
+                crate::tools::cross_product::HANDOFF_MAX_BYTES
+            ));
+        }
+
+        // #4026: resolve the named specialist against the fail-closed
+        // bridge-layer allow-set. A denial returns BEFORE `backend.run`, so
+        // nothing is dispatched.
+        let requested = args
+            .get("specialist")
+            .and_then(Value::as_str)
+            .filter(|s| !s.trim().is_empty());
+        let target = match requested {
+            Some(name) => match self.allow_set.resolve(name) {
+                Ok(resolved) => Some(resolved),
+                Err(denied) => return ToolResult::err(format!("dispatch_task: {denied}")),
+            },
+            None => None,
+        };
+
+        let body = match handoff.render_preamble() {
+            Some(preamble) => format!("{preamble}\n{task}"),
+            None => task.to_string(),
+        };
+        // #4026: a named specialist always takes the external-roster leg —
+        // that roster is where the non-coding specialists live (#4027), and
+        // re-deriving the route would let an unrelated phrase in `task` send
+        // a named target somewhere it does not exist.
+        let route = match target {
+            Some(_) => BridgeRoute::Tcode,
+            None => route_task(task),
+        };
+
+        match self.backend.run(route, target.as_deref(), &body).await {
+            Ok(out) => {
+                let scrubbed = scrub_branding(&out);
+                match target {
+                    // #4028: a cross-product specialist's result is wrapped in
+                    // the propose-only envelope — DOC-41 §5.5 line 1398.
+                    Some(name) => ToolResult::ok(
+                        ProposalEnvelope::for_cross_product(
+                            self.origin_agent.clone(),
+                            name,
+                            self.caller_authority,
+                            scrubbed,
+                        )
+                        .render(),
+                    ),
+                    // Unnamed dispatch is the pre-#4026 opaque path, returned
+                    // byte-identically to before this change.
+                    None => ToolResult::ok(scrubbed),
+                }
+            }
             // Scrubbed too: a raw backend error can name the process it
             // tried to spawn (see `ProcessPmBridge::run_tcode`/`run_tm`),
             // which would defeat the whole point of a black-boxed tool.

--- a/crates/trusty-agents/src/tools/pm_bridge_backend.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_backend.rs
@@ -61,10 +61,27 @@ const ACTIVITY_LINES: u64 = 200;
 /// processes named `tcode`/`tm`.
 /// Test: `RecordingBackend` in `pm_bridge_tests.rs`; `ProcessPmBridge` in
 /// `pm_bridge_backend_tests.rs`.
+///
+/// #4026: `run` gained a `target` parameter naming a specific external
+/// specialist. `None` preserves the pre-#4026 behaviour exactly (the `Tcode`
+/// leg's hardcoded default agent, the `Tm` leg unchanged). The name is
+/// ALREADY validated against the bridge-layer allow-set
+/// (`crate::tools::cross_product::SubagentAllowSet`) by the time it reaches
+/// here — this trait never re-decides admissibility, it only executes.
 #[async_trait]
 pub trait PmBridgeBackend: Send + Sync {
-    async fn run(&self, route: BridgeRoute, task: &str) -> Result<String>;
+    async fn run(&self, route: BridgeRoute, target: Option<&str>, task: &str) -> Result<String>;
 }
+
+/// The external agent the `Tcode` leg targets when no specialist is named.
+///
+/// Why: #4026 requires that omitting a specialist stay byte-identical to
+/// pre-change `dispatch_task` calls — which always ran this one agent. Naming
+/// the constant keeps that guarantee greppable instead of a bare string
+/// literal inside the command builder.
+/// What: the opaque orchestrator agent the bridge has always used.
+/// Test: `default_tcode_agent_is_unchanged_by_the_4026_widening`.
+const DEFAULT_TCODE_AGENT: &str = "pm";
 
 /// Production `PmBridgeBackend`: subprocess `tcode` for `Tcode`, MCP-over-
 /// stdio `tm` for `Tm`.
@@ -106,14 +123,22 @@ impl ProcessPmBridge {
     /// not on PATH, mirroring `TrustySearchPlugin::try_spawn`'s
     /// graceful-degradation contract.
     /// Test: `process_pm_bridge_tcode_route_fails_closed_without_binary`;
-    /// `tcode_route_smoke` (binary-gated).
-    async fn run_tcode(&self, task: &str) -> Result<String> {
+    /// `tcode_route_smoke` (binary-gated);
+    /// `default_tcode_agent_is_unchanged_by_the_4026_widening`.
+    ///
+    /// #4026: `target` names the external specialist to run. `None` uses
+    /// [`DEFAULT_TCODE_AGENT`], preserving the exact pre-#4026 command line.
+    /// The remote CLI already accepts any agent name (`run-task <AGENT>
+    /// <TASK>`, `crates/trusty-code/src/cli/run_task.rs`) — the bottleneck was
+    /// only ever this hardcoded argument.
+    async fn run_tcode(&self, target: Option<&str>, task: &str) -> Result<String> {
         if !binary_on_path("tcode") {
             bail!("tcode backend unavailable: binary not found on PATH");
         }
+        let agent = target.unwrap_or(DEFAULT_TCODE_AGENT);
         let output = Command::new("tcode")
             .arg("run-task")
-            .arg("pm")
+            .arg(agent)
             .arg(task)
             .arg("--project")
             .arg(&self.project_dir)
@@ -246,9 +271,12 @@ impl ProcessPmBridge {
 
 #[async_trait]
 impl PmBridgeBackend for ProcessPmBridge {
-    async fn run(&self, route: BridgeRoute, task: &str) -> Result<String> {
+    async fn run(&self, route: BridgeRoute, target: Option<&str>, task: &str) -> Result<String> {
         match route {
-            BridgeRoute::Tcode => self.run_tcode(task).await,
+            // #4026: only the Tcode leg can name a specialist; the Tm leg's
+            // managed-session lifecycle has no per-agent selector, so a target
+            // is deliberately ignored there rather than silently mis-routed.
+            BridgeRoute::Tcode => self.run_tcode(target, task).await,
             BridgeRoute::Tm => self.run_tm(task).await,
         }
     }

--- a/crates/trusty-agents/src/tools/pm_bridge_backend_tests.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_backend_tests.rs
@@ -121,7 +121,7 @@ async fn process_pm_bridge_tcode_route_fails_closed_without_binary() {
 
     let tmp = tempfile::tempdir().unwrap();
     let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
-    let err = with_empty_path(|| bridge.run(BridgeRoute::Tcode, "fix the parser"))
+    let err = with_empty_path(|| bridge.run(BridgeRoute::Tcode, None, "fix the parser"))
         .await
         .expect_err("must fail closed when tcode is not on PATH");
     assert!(
@@ -138,7 +138,7 @@ async fn process_pm_bridge_tm_route_fails_closed_without_binary() {
 
     let tmp = tempfile::tempdir().unwrap();
     let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
-    let err = with_empty_path(|| bridge.run(BridgeRoute::Tm, "spawn a new session"))
+    let err = with_empty_path(|| bridge.run(BridgeRoute::Tm, None, "spawn a new session"))
         .await
         .expect_err("must fail closed when tm is not on PATH");
     assert!(
@@ -198,7 +198,11 @@ async fn tcode_route_smoke() {
     std::fs::create_dir_all(tmp.path().join(".claude/agents")).unwrap();
     let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
     let result = bridge
-        .run(BridgeRoute::Tcode, "reply with a one-line status only")
+        .run(
+            BridgeRoute::Tcode,
+            None,
+            "reply with a one-line status only",
+        )
         .await;
     match result {
         Ok(out) => assert_no_branded_word(&crate::tools::pm_bridge::scrub_branding(&out)),
@@ -225,11 +229,28 @@ async fn tm_route_smoke() {
     }
     let tmp = tempfile::tempdir().unwrap();
     let bridge = ProcessPmBridge::from_project(tmp.path().to_path_buf());
-    let result = bridge.run(BridgeRoute::Tm, "report session status").await;
+    let result = bridge
+        .run(BridgeRoute::Tm, None, "report session status")
+        .await;
     match result {
         Ok(out) => assert_no_branded_word(&crate::tools::pm_bridge::scrub_branding(&out)),
         Err(e) => {
             eprintln!("tm_route_smoke: run failed (acceptable in an unconfigured env): {e:#}");
         }
     }
+}
+
+/// #4026 regression pin: widening `run_tcode` to accept a named target must
+/// not change what an UNNAMED dispatch runs. The default agent argument is the
+/// same literal the bridge has always passed, so a caller omitting a
+/// specialist produces a byte-identical command line.
+///
+/// Why: #4026's acceptance requires "omitting `agent_name` preserves today's
+/// exact behavior". A one-line constant is easy to edit by accident; this pins
+/// it without needing the real binary on PATH.
+/// What: asserts `DEFAULT_TCODE_AGENT` is still `"pm"`.
+/// Test: this test.
+#[test]
+fn default_tcode_agent_is_unchanged_by_the_4026_widening() {
+    assert_eq!(super::DEFAULT_TCODE_AGENT, "pm");
 }

--- a/crates/trusty-agents/src/tools/pm_bridge_tests.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_tests.rs
@@ -16,7 +16,7 @@ use crate::tools::ToolRegistry;
 /// fixed, caller-supplied transcript — mirrors `delegate.rs`'s
 /// `RecordingRunner`.
 struct RecordingBackend {
-    invoked_with: Mutex<Vec<(BridgeRoute, String)>>,
+    invoked_with: Mutex<Vec<(BridgeRoute, Option<String>, String)>>,
     response: String,
 }
 
@@ -31,11 +31,12 @@ impl RecordingBackend {
 
 #[async_trait]
 impl PmBridgeBackend for RecordingBackend {
-    async fn run(&self, route: BridgeRoute, task: &str) -> Result<String> {
-        self.invoked_with
-            .lock()
-            .unwrap()
-            .push((route, task.to_string()));
+    async fn run(&self, route: BridgeRoute, target: Option<&str>, task: &str) -> Result<String> {
+        self.invoked_with.lock().unwrap().push((
+            route,
+            target.map(str::to_string),
+            task.to_string(),
+        ));
         Ok(self.response.clone())
     }
 }
@@ -47,7 +48,7 @@ struct FailingBackend {
 
 #[async_trait]
 impl PmBridgeBackend for FailingBackend {
-    async fn run(&self, _route: BridgeRoute, _task: &str) -> Result<String> {
+    async fn run(&self, _route: BridgeRoute, _target: Option<&str>, _task: &str) -> Result<String> {
         Err(anyhow::anyhow!(self.message.clone()))
     }
 }
@@ -309,4 +310,206 @@ fn dispatch_task_denies_read_only_and_analytics_tiers() {
             .any(|t| t.name() == "dispatch_task"),
         "All tier must still see dispatch_task"
     );
+}
+
+// =====================================================================
+// Cross-product specialists (#4026 allow-set, #4028 envelope)
+// =====================================================================
+
+use crate::tools::cross_product::{CallerAuthority, HANDOFF_MAX_BYTES, SubagentAllowSet};
+
+/// EMPTY-DEFAULT PIN (#4026): a tool constructed without `with_allow_set`
+/// grants no cross-product reach — a named specialist is denied and, crucially,
+/// the backend is never invoked.
+#[tokio::test]
+async fn named_specialist_is_denied_when_no_allow_set_is_configured() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({ "task": "triage the backlog", "specialist": "ticketing" }))
+        .await;
+
+    assert!(result.is_error(), "expected denial: {}", result.content());
+    assert!(
+        backend.invoked_with.lock().unwrap().is_empty(),
+        "FAIL-CLOSED: nothing may be dispatched on denial"
+    );
+}
+
+/// FAIL-CLOSED PIN (#4026, OQ-7): a coding target is denied AT THE BRIDGE even
+/// when the calling agent's own config lists it, and nothing is dispatched.
+#[tokio::test]
+async fn coding_specialist_is_denied_at_the_bridge_despite_caller_config() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool =
+        PmBridgeTool::new(backend.clone()).with_allow_set(SubagentAllowSet::from_allowed(Some(&[
+            "rust-engineer".to_string(),
+            "research".to_string(),
+        ])));
+
+    let result = tool
+        .execute(json!({ "task": "rewrite the parser", "specialist": "rust-engineer" }))
+        .await;
+
+    assert!(result.is_error(), "expected denial: {}", result.content());
+    assert!(
+        backend.invoked_with.lock().unwrap().is_empty(),
+        "FAIL-CLOSED: nothing may be dispatched on denial"
+    );
+}
+
+/// An allowed named specialist reaches the backend as an explicit target on
+/// the external-roster leg (#4026).
+#[tokio::test]
+async fn named_specialist_reaches_the_backend_when_allowed() {
+    let backend = Arc::new(RecordingBackend::new("findings"));
+    let tool =
+        PmBridgeTool::new(backend.clone()).with_allow_set(SubagentAllowSet::from_allowed(Some(&[
+            "research".to_string(),
+        ])));
+
+    let result = tool
+        .execute(json!({ "task": "map the auth flow", "specialist": "research" }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert_eq!(invoked.len(), 1);
+    assert_eq!(invoked[0].0, BridgeRoute::Tcode);
+    assert_eq!(invoked[0].1.as_deref(), Some("research"));
+}
+
+/// #4027: the ported ticketing specialist is reachable through the same leg.
+#[tokio::test]
+async fn ticketing_specialist_is_reachable_through_the_bridge() {
+    let backend = Arc::new(RecordingBackend::new("drafted ISS-1"));
+    let tool =
+        PmBridgeTool::new(backend.clone()).with_allow_set(SubagentAllowSet::from_allowed(Some(&[
+            "ticketing".to_string(),
+        ])));
+
+    let result = tool
+        .execute(json!({ "task": "file an issue for the flaky test", "specialist": "ticketing" }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert_eq!(invoked[0].1.as_deref(), Some("ticketing"));
+}
+
+/// #4028: the result of a named specialist is wrapped in the propose-only
+/// envelope carrying origin, target, authority tier and the proposal marker —
+/// and holding `user_authority` does NOT upgrade it (DOC-41 §5.5, #3078
+/// AUTH-5).
+#[tokio::test]
+async fn envelope_carries_origin_target_and_authority() {
+    let backend = Arc::new(RecordingBackend::new("drafted the reply"));
+    let tool = PmBridgeTool::new(backend)
+        .with_allow_set(SubagentAllowSet::from_allowed(Some(&[
+            "ticketing".to_string()
+        ])))
+        .with_origin("izzie", CallerAuthority::UserAuthority);
+
+    let result = tool
+        .execute(json!({ "task": "close the stale tickets", "specialist": "ticketing" }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    let body = result.content();
+    assert!(body.contains("\"origin_agent\": \"izzie\""), "{body}");
+    assert!(body.contains("\"target_agent\": \"ticketing\""), "{body}");
+    assert!(body.contains("\"authority\": \"user_authority\""), "{body}");
+    assert!(
+        body.contains("\"disposition\": \"proposal\""),
+        "a user_authority caller must NOT upgrade a cross-product result: {body}"
+    );
+    assert!(!body.contains("\"disposition\": \"action\""), "{body}");
+}
+
+/// Regression guard (#4026): omitting `specialist` preserves the pre-change
+/// contract exactly — route derived from the task, no explicit target, and the
+/// bare scrubbed transcript back with no envelope.
+#[tokio::test]
+async fn omitting_specialist_preserves_pre_change_behaviour() {
+    let backend = Arc::new(RecordingBackend::new("all done"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({ "task": "fix the failing unit test in parser.rs" }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    assert_eq!(result.content(), "all done");
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert_eq!(invoked[0].0, BridgeRoute::Tcode);
+    assert_eq!(invoked[0].1, None, "no target when no specialist is named");
+    assert_eq!(invoked[0].2, "fix the failing unit test in parser.rs");
+}
+
+/// #4028: an over-cap handoff is a recoverable error and the target is NEVER
+/// invoked.
+#[tokio::test]
+async fn oversized_handoff_is_rejected_without_invoking_the_target() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool =
+        PmBridgeTool::new(backend.clone()).with_allow_set(SubagentAllowSet::from_allowed(Some(&[
+            "research".to_string(),
+        ])));
+
+    let result = tool
+        .execute(json!({
+            "task": "map the auth flow",
+            "specialist": "research",
+            "handoff": { "summary": "y".repeat(HANDOFF_MAX_BYTES + 1) }
+        }))
+        .await;
+
+    assert!(
+        result.is_error(),
+        "expected rejection: {}",
+        result.content()
+    );
+    assert!(
+        backend.invoked_with.lock().unwrap().is_empty(),
+        "target must not be invoked when the handoff is over cap"
+    );
+}
+
+/// A within-cap handoff is rendered into the dispatched task text (#4028).
+#[tokio::test]
+async fn handoff_is_prepended_to_the_dispatched_task() {
+    let backend = Arc::new(RecordingBackend::new("done"));
+    let tool =
+        PmBridgeTool::new(backend.clone()).with_allow_set(SubagentAllowSet::from_allowed(Some(&[
+            "research".to_string(),
+        ])));
+
+    let result = tool
+        .execute(json!({
+            "task": "map the auth flow",
+            "specialist": "research",
+            "handoff": { "summary": "prior pass covered login only" }
+        }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert!(invoked[0].2.contains("prior pass covered login only"));
+    assert!(invoked[0].2.contains("map the auth flow"));
+}
+
+/// The widened schema stays black-boxed: no backend identity, and no roster
+/// enumeration in the `specialist` description.
+#[test]
+fn widened_schema_names_no_backend_or_roster() {
+    let tool = PmBridgeTool::new(Arc::new(RecordingBackend::new("x")));
+    let schema = tool.schema().to_string().to_lowercase();
+    for forbidden in ["tcode", "trusty-code", "trusty-mpm", "run-task", "research"] {
+        assert!(
+            !schema.contains(forbidden),
+            "schema leaks '{forbidden}': {schema}"
+        );
+    }
+    assert!(schema.contains("specialist"));
 }

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -10,6 +10,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`ticketing` is now a bundled, dispatchable roster agent (#4027; epic
+  #4021 bridge track).** `crates/trusty-code/src/assets/agents/ticketing.md`
+  is a byte-for-byte port of `crates/trusty-mpm/src/assets/agents/ticketing.md`
+  — the same treatment `research.md` already gets — so trusty-agents' widened
+  cross-product `dispatch_task` bridge (#4026) reaches ONE roster instead of
+  growing a second dispatch leg into trusty-mpm (the owner's OQ-4 ruling).
+  `tcode run-task ticketing "<task>"` resolves through the existing
+  `resolve_agent` embedded tier with no CLI change; the roster is now 33
+  dispatchable agents and `EMBEDDED_TM_AGENT_SOURCES` 34 entries. It is a
+  PARITY copy, not a pinned deviation: it carries no tcode-only `tools:`
+  restriction, so `scripts/check_agent_assets.sh` keeps it in lockstep with
+  upstream automatically. Its non-coding property is enforced where the owner
+  put enforcement — the bridge's fail-closed `NON_CODING_TARGETS` floor in
+  `crates/trusty-agents/src/tools/cross_product.rs` — not by an asset-level
+  allowlist a direct `tcode run-task` invocation would bypass anyway.
+
+### Added
+
 - **`session.get_context_budget` now surfaces the real working-context
   floor, not just a point-in-time snapshot (#3912).** The load-realistic
   compression soak (epic #3866, PR #3909) proved the RPC's cached

--- a/crates/trusty-code/src/agents/mod.rs
+++ b/crates/trusty-code/src/agents/mod.rs
@@ -425,18 +425,19 @@ pub fn available_agent_names(dir: &Path) -> Vec<String> {
 mod tests {
     use super::*;
 
-    /// The 32-name default embedded roster, in `crate::assets::DEFAULT_AGENTS`'s
-    /// declared order (Slice E3, #2958; `pm` added for #3437) — shared by
+    /// The 33-name default embedded roster, in `crate::assets::DEFAULT_AGENTS`'s
+    /// declared order (Slice E3, #2958; `pm` added for #3437, `ticketing` for
+    /// #4027) — shared by
     /// every fallback test in this module so the expected list is written
     /// once, not duplicated per-test with the risk of one copy drifting from
     /// another.
     ///
     /// Why: three separate fallback scenarios (empty dir, all-invalid dir,
-    /// only-orphaned-toml dir) all assert the identical 32-name outcome; a
+    /// only-orphaned-toml dir) all assert the identical 33-name outcome; a
     /// single source avoids a silent typo in one copy passing review
     /// unnoticed.
     /// What: tcode's original 4 (`engineer`, `qa-agent`, `code-reviewer`,
-    /// `pm`) followed by the 28 roster names, alphabetical, matching
+    /// `pm`) followed by the 29 roster names, alphabetical, matching
     /// `DEFAULT_AGENTS`'s literal declaration order.
     /// Test: every `load_all_agents_falls_back_*` test below.
     fn expected_default_agent_names() -> Vec<&'static str> {
@@ -470,6 +471,8 @@ mod tests {
             "security",
             "svelte-engineer",
             "tauri-engineer",
+            // #4027: non-coding ticketing specialist for the cross-product bridge.
+            "ticketing",
             "typescript-engineer",
             "web-qa",
             "web-ui-engineer",

--- a/crates/trusty-code/src/assets/agents/ticketing.md
+++ b/crates/trusty-code/src/assets/agents/ticketing.md
@@ -1,0 +1,97 @@
+---
+name: ticketing
+role: ticketing
+description: Ticket management specialist. Creates, updates, and tracks issues with scope validation, scope-aware linking, and workflow state intelligence.
+model: haiku
+extends: base-agent
+skills: [brainstorming, git-workflow, requesting-code-review, writing-plans, json-data-handling, root-cause-tracing, systematic-debugging, verification-before-completion, internal-comms, test-driven-development]
+---
+
+# Ticketing Agent
+
+Intelligent ticket management with MCP-first architecture and CLI fallbacks. Enforce scope boundaries and maintain bidirectional traceability.
+
+## Integration Priority
+
+**Primary**: Use `mcp__mcp-ticketer__*` MCP tools when available.
+
+**Fallback**: Use `aitrackdown` CLI when MCP is not available:
+```bash
+aitrackdown create issue "Title" --description "Details"
+aitrackdown create task "Title" --issue ISS-0001
+aitrackdown transition ISS-0001 in-progress
+aitrackdown status tasks
+```
+
+## Ticket Types
+
+- **EP-XXXX**: Epics — major initiatives
+- **ISS-XXXX**: Issues — bugs, features, user requests
+- **TSK-XXXX**: Tasks — individual work items
+
+## Scope Validation Protocol
+
+Before creating any ticket, classify the work item relative to a parent ticket:
+
+**IN-SCOPE** (create as subtask under parent):
+- Required to satisfy parent acceptance criteria
+- Blocks parent ticket from closing
+- Same domain/feature area as parent
+
+**SCOPE-ADJACENT** (ask PM for guidance):
+- Related to parent but not required for completion
+- Enhancement discovered during work
+- Parent can close without this work
+
+**OUT-OF-SCOPE** (escalate to PM; create as separate ticket):
+- Different feature area or domain
+- Pre-existing bug discovered during work
+- Would significantly expand parent scope
+
+## Tag Preservation
+
+When PM provides tags in the delegation context, ALWAYS preserve them:
+```
+pm_tags = delegation.get('tags', [])
+final_tags = pm_tags + scope_tags   # merge, never replace
+```
+
+Never enable auto-detection of labels when PM has provided tags.
+
+## Workflow States
+
+Valid transitions: `open → in-progress → ready → tested → done`
+
+Match states semantically to context:
+- Work started → `in-progress`
+- Questions posted, waiting for user → `clarify` or `waiting`
+- Implementation complete, needs user validation → `in-review` or `UAT`
+- Dependency missing → `blocked`
+
+## Bidirectional Linking
+
+For follow-up tickets (discovered during parent work):
+1. Create the new ticket with a description referencing the parent
+2. Add a comment to the parent ticket linking to the new ticket
+3. Report the bidirectional traceability to the PM
+
+For subtasks (in-scope work):
+- Use `parent_id` or `issue_id` parameter — the system establishes the link automatically
+
+## TODO-to-Ticket Conversion
+
+When PM delegates a TODO list for conversion:
+1. Parse title, description, priority, and type from each item
+2. Validate the parent ticket exists
+3. Create tickets sequentially (subtasks for in-scope, separate tickets for out-of-scope)
+4. Report all created ticket IDs with links
+
+## Reporting Format
+
+Always report scope classification in your response:
+```
+IN-SCOPE (2 items — created as subtasks)
+SCOPE-ADJACENT (1 item — awaiting PM decision)
+OUT-OF-SCOPE (1 item — created as separate ticket)
+Scope Boundary Status: Maintained
+```

--- a/crates/trusty-code/src/assets/mod.rs
+++ b/crates/trusty-code/src/assets/mod.rs
@@ -9,11 +9,12 @@
 //! disk-based `.claude/agents/` and `.claude/skills/` always take precedence
 //! when present (see `agents::load_all_agents` and
 //! `skills::discover_skill_metadata`'s embedded-fallback branches).
-//! What: [`EmbeddedAgent`]/[`DEFAULT_AGENTS`] — the 32-agent dispatchable
-//! roster (Slice E3, #2958, plus `pm` added for #3437): tcode's own 4
-//! defaults (`engineer`, `qa-agent`, `code-reviewer`, `pm`, no `extends:`
-//! chain — projected via `agents::md_loader::project_embedded_md`) plus the
-//! 28 coding-relevant tm agents Bob selected in #2958 (`extends:`-chained
+//! What: [`EmbeddedAgent`]/[`DEFAULT_AGENTS`] — the 33-agent dispatchable
+//! roster (Slice E3, #2958, plus `pm` added for #3437 and `ticketing` for
+//! #4027): tcode's own 4 defaults (`engineer`, `qa-agent`, `code-reviewer`,
+//! `pm`, no `extends:` chain — projected via
+//! `agents::md_loader::project_embedded_md`) plus the 29 tm agents (the 28
+//! coding-relevant ones Bob selected in #2958, plus `ticketing`) (`extends:`-chained
 //! through the 5 `BASE-*` templates — projected via
 //! `agents::md_loader::project_embedded_md_with_extends`, which resolves
 //! against [`EMBEDDED_TM_AGENT_SOURCES`]). Authored as Markdown+frontmatter
@@ -68,6 +69,20 @@
 //! trusty-mpm byte-parity beyond the `tools:` line alone; the deferred E4
 //! staleness guard must whitelist the reworded prose sections in these three
 //! files too, not just the `tools:` line.
+//!
+//! ## Non-coding cross-product roster addition (#4027, epic #4021)
+//!
+//! `ticketing` was ported here from `crates/trusty-mpm/src/assets/agents/`
+//! byte-for-byte (same treatment `research` got) so trusty-agents' widened
+//! `dispatch_task` bridge (#4026) can reach ONE roster instead of growing a
+//! second dispatch leg into trusty-mpm — the owner's OQ-4 ruling. It carries
+//! no tcode-specific `tools:` restriction: it is a byte-parity copy, NOT a
+//! pinned deviation, so `check_agent_assets.sh` keeps it in lockstep with
+//! upstream automatically. Its non-coding property is enforced where the
+//! owner's OQ-7 ruling put enforcement — the BRIDGE's fail-closed
+//! `NON_CODING_TARGETS` floor in
+//! `crates/trusty-agents/src/tools/cross_product.rs` — not by an asset-level
+//! allowlist that a direct `tcode run-task` invocation would bypass anyway.
 //!
 //! ## E4 staleness guard (issue #2958, `scripts/check_agent_assets.sh`)
 //!
@@ -163,15 +178,15 @@ const QA_AGENT_MD: &str = include_str!("agents/qa-agent.md");
 const CODE_REVIEWER_MD: &str = include_str!("agents/code-reviewer.md");
 const PM_MD: &str = include_str!("agents/pm.md");
 
-/// The 32-agent dispatchable default roster, embedded at compile time
-/// (Slice E3, #2958, plus `pm` added for #3437): tcode's original 3
-/// defaults plus `pm` plus the 28 coding-relevant tm roster agents. The 5
+/// The 33-agent dispatchable default roster, embedded at compile time
+/// (Slice E3, #2958, plus `pm` added for #3437 and `ticketing` for #4027):
+/// tcode's original 3 defaults plus `pm` plus the 29 tm roster agents. The 5
 /// `BASE-*` extends templates in [`EMBEDDED_TM_AGENT_SOURCES`] are
 /// deliberately NOT entries here — they are extends-sources only, never
 /// dispatchable — and trusty-mpm's own `engineer` agent is excluded from the
 /// roster upstream (#2958's roster decision) precisely because it would
 /// collide with tcode's `engineer` below;
-/// `assets::tests::no_name_collisions_across_the_32_agent_roster` pins that
+/// `assets::tests::no_name_collisions_across_the_33_agent_roster` pins that
 /// no collision exists in the final table.
 ///
 /// Why: gives `agents::load_all_agents`'s embedded-fallback branch a fixed,
@@ -188,14 +203,15 @@ const PM_MD: &str = include_str!("agents/pm.md");
 /// (adversarial, read-only review, no `bash`), `pm` (orchestrator/default —
 /// delegates when `delegate_to_agent` is available, executes directly
 /// otherwise; see `assets/agents/pm.md`) — all four [`EmbeddedAgent::Direct`].
-/// Then the 28 [`EmbeddedAgent::Composed`] roster agents, alphabetical,
+/// Then the 29 [`EmbeddedAgent::Composed`] roster agents, alphabetical,
 /// matching [`EMBEDDED_TM_AGENT_SOURCES`]'s roster ordering. Four of them
 /// (`qa`, `code-critic`, `code-analyzer`, `web-qa`) carry a tcode-only
 /// restrictive `tools:` override in their `.md` source — see this module's
 /// "Tools-restriction deviation" doc section above.
 /// Test: `assets::tests::default_agents_parse_and_names_match`,
 /// `assets::tests::base_templates_are_never_dispatchable`,
-/// `assets::tests::no_name_collisions_across_the_32_agent_roster`,
+/// `assets::tests::no_name_collisions_across_the_33_agent_roster`,
+/// `assets::tests::ticketing_is_dispatchable_for_cross_product_delegation`,
 /// `assets::tests::restricted_reviewer_agents_carry_read_only_tools`,
 /// `assets::tests::documentation_and_research_remain_unrestricted`,
 /// `assets::tests::default_task_run_agent_resolves_against_default_agents`,
@@ -280,6 +296,10 @@ pub const DEFAULT_AGENTS: &[EmbeddedAgent] = &[
     EmbeddedAgent::Composed {
         name: "tauri-engineer",
     },
+    // #4027: non-coding ticketing specialist, reachable from trusty-agents'
+    // widened cross-product bridge (#4026). See this module's "Non-coding
+    // cross-product roster addition" doc section.
+    EmbeddedAgent::Composed { name: "ticketing" },
     EmbeddedAgent::Composed {
         name: "typescript-engineer",
     },
@@ -352,13 +372,15 @@ const RUST_ENGINEER_MD: &str = include_str!("agents/rust-engineer.md");
 const SECURITY_MD: &str = include_str!("agents/security.md");
 const SVELTE_ENGINEER_MD: &str = include_str!("agents/svelte-engineer.md");
 const TAURI_ENGINEER_MD: &str = include_str!("agents/tauri-engineer.md");
+// #4027: byte-parity copy of trusty-mpm's ticketing agent.
+const TICKETING_MD: &str = include_str!("agents/ticketing.md");
 const TYPESCRIPT_ENGINEER_MD: &str = include_str!("agents/typescript-engineer.md");
 const WEB_QA_MD: &str = include_str!("agents/web-qa.md");
 const WEB_UI_ENGINEER_MD: &str = include_str!("agents/web-ui-engineer.md");
 
 /// The embedded tm agent catalog's raw sources (Slice E2, #2958): the 5
-/// `BASE-*` extends templates plus the 28 coding-relevant roster agents Bob
-/// selected in #2958 (mpm/memory/cloud-vendor agents excluded -- see the
+/// `BASE-*` extends templates plus the 29 roster agents (the 28
+/// coding-relevant ones Bob selected in #2958, plus `ticketing` from #4027) (mpm/memory/cloud-vendor agents excluded -- see the
 /// issue's roster decision). Keyed by each asset's ORIGINAL embedded
 /// filename (`"BASE-QA.md"`, `"rust-engineer.md"`, ...) rather than a
 /// pre-lowercased bare name, because
@@ -368,18 +390,18 @@ const WEB_UI_ENGINEER_MD: &str = include_str!("agents/web-ui-engineer.md");
 /// `extends: base-qa` reference with no extra normalisation needed here.
 ///
 /// Why: `agents::md_loader::project_embedded_md_with_extends` needs a single
-/// batch source for `build_in_memory_source_map` instead of 33 individual
+/// batch source for `build_in_memory_source_map` instead of 34 individual
 /// `insert` calls; this table is that source. Kept separate from
 /// [`DEFAULT_AGENTS`] (rather than folded into it) because this table's key
 /// space includes the 5 `BASE-*` templates, which must remain resolvable as
 /// `extends:` targets while staying permanently non-dispatchable -- merging
 /// the two tables would require a third state ("resolvable but not listed")
 /// that the current `Direct`/`Composed` enum has no need to express.
-/// What: 33 `(original_filename, raw_md_content)` pairs: 5 `BASE-*` templates
-/// (never dispatchable) plus the 28 roster agents (dispatchable as of Slice
+/// What: 34 `(original_filename, raw_md_content)` pairs: 5 `BASE-*` templates
+/// (never dispatchable) plus the 29 roster agents (dispatchable as of Slice
 /// E3 via [`DEFAULT_AGENTS`]'s `EmbeddedAgent::Composed` entries, which
 /// resolve against this table at load time).
-/// Test: `assets::tests::embedded_tm_agent_sources_has_33_entries_and_unique_keys`,
+/// Test: `assets::tests::embedded_tm_agent_sources_has_34_entries_and_unique_keys`,
 /// `assets::tests::base_templates_are_never_dispatchable`,
 /// `md_loader::tests::project_embedded_md_with_extends_resolves_rust_engineer_from_base_engineer`.
 pub const EMBEDDED_TM_AGENT_SOURCES: &[(&str, &str)] = &[
@@ -413,6 +435,7 @@ pub const EMBEDDED_TM_AGENT_SOURCES: &[(&str, &str)] = &[
     ("security.md", SECURITY_MD),
     ("svelte-engineer.md", SVELTE_ENGINEER_MD),
     ("tauri-engineer.md", TAURI_ENGINEER_MD),
+    ("ticketing.md", TICKETING_MD),
     ("typescript-engineer.md", TYPESCRIPT_ENGINEER_MD),
     ("web-qa.md", WEB_QA_MD),
     ("web-ui-engineer.md", WEB_UI_ENGINEER_MD),

--- a/crates/trusty-code/src/assets/tests.rs
+++ b/crates/trusty-code/src/assets/tests.rs
@@ -20,7 +20,7 @@ use crate::agents::md_loader::{project_embedded_md, project_embedded_md_with_ext
 /// Why: A typo in either the `.md` frontmatter or the table entry would
 /// silently break `agents::load_all_agents`'s embedded-fallback at runtime
 /// instead of failing fast in CI. This is also the acceptance test for Slice
-/// E3 (#2958): every one of the 32 entries must actually compose (a `Composed`
+/// E3 (#2958): every one of the 33 entries must actually compose (a `Composed`
 /// variant that panics here rather than resolving would otherwise only be
 /// caught at runtime by `load_embedded_default_agents`'s log-and-skip path).
 /// Test: this test.
@@ -28,8 +28,9 @@ use crate::agents::md_loader::{project_embedded_md, project_embedded_md_with_ext
 fn default_agents_parse_and_names_match() {
     assert_eq!(
         DEFAULT_AGENTS.len(),
-        32,
-        "4 originals (engineer, qa-agent, code-reviewer, pm) + 28 roster agents"
+        33,
+        "4 originals (engineer, qa-agent, code-reviewer, pm) + 28 roster agents \
+         + ticketing (#4027)"
     );
     for agent in DEFAULT_AGENTS {
         let cfg = match agent {
@@ -142,7 +143,7 @@ fn default_agents_field_identical_to_retired_toml() {
 }
 
 /// The embedded fallback still fires when the disk `.claude/agents` dir is
-/// empty, and yields the full 32-agent roster with the original 4 defaults
+/// empty, and yields the full 33-agent roster with the original 4 defaults
 /// intact as the first four entries — proving Slice E3's roster expansion
 /// (and #3437's `pm` addition) did not disturb the original fallback wiring
 /// `.md` (#2897 Slice C) established.
@@ -150,20 +151,24 @@ fn default_agents_field_identical_to_retired_toml() {
 /// Why: #2897 Slice C's non-breaking claim rests on this: a fresh project
 /// with no `.claude/agents/` must still boot with `engineer`/`qa-agent`/
 /// `code-reviewer`/`pm` available, exactly as it did when the defaults were
-/// TOML — Slice E3 only ADDS the 28 roster agents after them, never replaces
-/// or reorders the originals.
+/// TOML — Slice E3 only ADDS the roster agents after them (28, plus
+/// `ticketing` from #4027), never replaces or reorders the originals.
 /// What: calls `crate::agents::load_all_agents` on a nonexistent directory;
 /// asserts the returned names' first four entries are exactly
-/// `["engineer", "qa-agent", "code-reviewer", "pm"]` and the full 32-name
+/// `["engineer", "qa-agent", "code-reviewer", "pm"]` and the full 33-name
 /// list matches `crate::assets::DEFAULT_AGENTS`'s declared order with no
 /// duplicates.
 /// Test: this test.
 #[test]
-fn embedded_fallback_still_fires_and_yields_32_agents_with_original_4_intact() {
+fn embedded_fallback_still_fires_and_yields_33_agents_with_original_4_intact() {
     let agents = crate::agents::load_all_agents(std::path::Path::new("/nonexistent/agents/dir"));
     let names: Vec<&str> = agents.iter().map(|a| a.agent.name.as_str()).collect();
 
-    assert_eq!(names.len(), 32, "32-agent roster: 4 originals + 28 roster");
+    assert_eq!(
+        names.len(),
+        33,
+        "33-agent roster: 4 originals + 28 roster + ticketing (#4027)"
+    );
     assert_eq!(
         &names[..4],
         &["engineer", "qa-agent", "code-reviewer", "pm"],
@@ -190,7 +195,7 @@ fn embedded_fallback_still_fires_and_yields_32_agents_with_original_4_intact() {
 /// `BASE-*` entry leaking into the dispatchable roster would let a caller
 /// invoke a template fragment (no concrete role, designed to be composed
 /// into a leaf agent, not run standalone) as if it were a real agent.
-/// What: asserts none of the 32 `DEFAULT_AGENTS` names matches any of the 5
+/// What: asserts none of the 33 `DEFAULT_AGENTS` names matches any of the 5
 /// base template names (case-insensitive, since the source table keys them
 /// `BASE-QA.md` while `extends:` references use `base-qa`).
 /// Test: this test.
@@ -206,7 +211,7 @@ fn base_templates_are_never_dispatchable() {
     }
 }
 
-/// No two entries in the 32-agent `DEFAULT_AGENTS` roster share a dispatch
+/// No two entries in the 33-agent `DEFAULT_AGENTS` roster share a dispatch
 /// name — in particular, trusty-mpm's own `engineer` agent (excluded from
 /// the roster upstream specifically because it collides with tcode's
 /// `engineer` default) does not sneak back in under any composed entry.
@@ -216,13 +221,13 @@ fn base_templates_are_never_dispatchable() {
 /// default)" — this test is the regression pin for that exclusion, and a
 /// general guard against any future roster addition silently shadowing an
 /// existing dispatch name.
-/// What: collects all 32 names, dedupes, asserts the length is unchanged;
+/// What: collects all 33 names, dedupes, asserts the length is unchanged;
 /// separately asserts `"engineer"` appears exactly once.
 /// Test: this test.
 #[test]
-fn no_name_collisions_across_the_32_agent_roster() {
+fn no_name_collisions_across_the_33_agent_roster() {
     let names: Vec<&str> = DEFAULT_AGENTS.iter().map(|a| a.name()).collect();
-    assert_eq!(names.len(), 32);
+    assert_eq!(names.len(), 33);
 
     let mut deduped = names.clone();
     deduped.sort_unstable();
@@ -230,7 +235,7 @@ fn no_name_collisions_across_the_32_agent_roster() {
     assert_eq!(
         deduped.len(),
         names.len(),
-        "no name collisions across the 32-agent roster: {names:?}"
+        "no name collisions across the 33-agent roster: {names:?}"
     );
 
     assert_eq!(
@@ -468,7 +473,7 @@ fn default_skills_names_are_unique() {
     }
 }
 
-/// `EMBEDDED_TM_AGENT_SOURCES` (Slice E2, #2958) has exactly 33 entries (5
+/// `EMBEDDED_TM_AGENT_SOURCES` (Slice E2, #2958) has exactly 34 entries (5
 /// `BASE-*` templates + 28 roster agents), every key is unique, and every
 /// entry's raw content opens with a frontmatter fence.
 ///
@@ -482,8 +487,8 @@ fn default_skills_names_are_unique() {
 /// content string opens with `---`.
 /// Test: this test.
 #[test]
-fn embedded_tm_agent_sources_has_33_entries_and_unique_keys() {
-    assert_eq!(EMBEDDED_TM_AGENT_SOURCES.len(), 33);
+fn embedded_tm_agent_sources_has_34_entries_and_unique_keys() {
+    assert_eq!(EMBEDDED_TM_AGENT_SOURCES.len(), 34);
     let mut keys: Vec<String> = EMBEDDED_TM_AGENT_SOURCES
         .iter()
         .map(|(name, _)| name.to_lowercase())
@@ -498,4 +503,56 @@ fn embedded_tm_agent_sources_has_33_entries_and_unique_keys() {
             "embedded tm agent source '{name}' must open with a frontmatter fence"
         );
     }
+}
+
+/// #4027 (epic #4021): the ported `ticketing` agent is a real, dispatchable
+/// roster entry that resolves through the SAME resolver `tcode run-task
+/// <AGENT>` uses — the reachability guarantee trusty-agents' widened
+/// cross-product bridge (#4026) depends on.
+///
+/// Why: the bridge dispatches `run-task ticketing <task>`; if the name did not
+/// resolve here, that call would fail at the far end with an unresolved-agent
+/// error the bridge cannot distinguish from a real task failure. Asserting
+/// resolution through `resolve_agent` (not just table membership) is what makes
+/// this an end-to-end reachability pin rather than a table-shape assertion.
+/// What: resolves `ticketing` against an EMPTY disk dir so the embedded tier is
+/// exercised, and asserts the composed config carries the ticketing persona's
+/// own identity (not a fallback to `pm` and not a `NotFound`).
+/// Test: this test.
+#[test]
+fn ticketing_is_dispatchable_for_cross_product_delegation() {
+    assert!(
+        DEFAULT_AGENTS.iter().any(|a| a.name() == "ticketing"),
+        "ticketing must be a dispatchable roster entry"
+    );
+
+    let cfg =
+        crate::agents::resolve_agent(std::path::Path::new("/nonexistent/agents/dir"), "ticketing")
+            .expect("ticketing must resolve via the embedded roster");
+    assert_eq!(cfg.agent.name, "ticketing");
+    assert_ne!(cfg.agent.name, "pm", "must not silently fall back to pm");
+}
+
+/// #4027: the ported copy stays byte-identical to its trusty-mpm source, the
+/// same treatment `research` gets — it is a PARITY copy, never a pinned
+/// deviation.
+///
+/// Why: `scripts/check_agent_assets.sh` enforces this in CI, but a unit test
+/// makes the intent visible at the point of use: the ticketing persona has no
+/// tcode-specific restriction, because its non-coding property is enforced at
+/// the trusty-agents bridge (#4026's `NON_CODING_TARGETS` floor), not here.
+/// What: asserts the embedded source carries no `tools:` frontmatter override
+/// (which is what the four deliberately-deviated files add).
+/// Test: this test; `scripts/check_agent_assets.sh` is the byte-parity gate.
+#[test]
+fn ticketing_copy_carries_no_tcode_only_tools_restriction() {
+    let (_, md) = EMBEDDED_TM_AGENT_SOURCES
+        .iter()
+        .find(|(k, _)| *k == "ticketing.md")
+        .expect("ticketing.md must be in the embedded source table");
+    let frontmatter = md.split("---").nth(1).expect("frontmatter fence");
+    assert!(
+        !frontmatter.contains("tools:"),
+        "ticketing is a byte-parity copy, not a pinned deviation"
+    );
 }

--- a/scripts/check_agent_assets.sh
+++ b/scripts/check_agent_assets.sh
@@ -265,6 +265,11 @@ done
 
 # --- 2. Parity files: every tracked tcode .md not in TCODE_ONLY or
 #        DEVIATED_FILES must byte-match its trusty-mpm source. ---
+# #4027: PARITY_COUNT is tallied rather than hardcoded in the summary line —
+# the roster grows (ticketing was added for epic #4021's cross-product bridge)
+# and a stale literal in a PASSING message is the kind of quiet lie this gate
+# exists to prevent.
+PARITY_COUNT=0
 while IFS= read -r f; do
   [ -n "$f" ] || continue
   base="${f##*/}"
@@ -287,6 +292,7 @@ while IFS= read -r f; do
     continue
   fi
 
+  PARITY_COUNT=$((PARITY_COUNT + 1))
   if ! cmp -s "$f" "$mpm_path"; then
     echo "FAIL: COPY DRIFTED — $f no longer byte-matches $mpm_path." >&2
     echo "      Either restore byte-parity (unintentional edit), or if this is a" >&2
@@ -303,5 +309,5 @@ if [ "$FAIL" -ne 0 ]; then
   exit 1
 fi
 
-echo "agent-assets: 29 byte-parity file(s) match, ${#DEVIATED_ARR[@]} pinned deviation(s) match upstream — OK."
+echo "agent-assets: ${PARITY_COUNT} byte-parity file(s) match, ${#DEVIATED_ARR[@]} pinned deviation(s) match upstream — OK."
 exit 0


### PR DESCRIPTION
Part of epic #4021 — the **bridge track** (#4026 + #4027 + #4028), landed as
ONE PR. Rationale for one PR rather than two: the tcode-side port (#4027) is
not independently meaningful — the bridge's `NON_CODING_TARGETS` floor names
`ticketing`, and the bridge test that proves it is reachable would be a lie
until the roster entry exists. `scripts/check_agent_assets.sh` also has to
pass with both halves present. Splitting would mean landing a bridge that
advertises an unreachable target, or a roster entry nothing can reach.

Closes #4026
Closes #4027
Closes #4028

## Owner rulings this implements

Every OQ below was resolved by the owner on epic #4021 (comment
[5085939988](https://github.com/bobmatnyc/trusty-tools/issues/4021#issuecomment-5085939988)):

| OQ | Ruling | How it lands here |
|---|---|---|
| **OQ-2** | External cross-product delegation is **IN** | **This supersedes #3816's "trusty-agents drops the subagent concept entirely."** Per the owner, #3816's drop applied to the INTERNAL agent-creation machinery; external cross-product delegation returns. The `[subagents]` config key and the `SubagentAllowSet` type are named accordingly, deliberately, and not hedged into alternate vocabulary. |
| **OQ-3** | Allow-set derives from config + (eventually) the domain authority | `[subagents].allowed` is the source today. `SubagentAllowSet::from_allowed` is the single seam #4030's domain authority feeds later — nothing else needs to change to add that second source. |
| **OQ-4** | Ticketing **PORTS** into tcode's roster | Byte-for-byte port, one bridge, no second dispatch leg into trusty-mpm. |
| **OQ-6** | Minimal HandoffContext-SHAPED envelope, no #2809 dependency | Local `HandoffContext` copy: same three fields, same 4 KiB cap, zero dependency on epic #2809. #2809 is NOT implemented here. |
| **OQ-7** | Enforcement at the **BRIDGE**, fail-closed | `SubagentAllowSet::resolve` checks the bridge's own floor BEFORE the caller's config, and a denial returns before `backend.run` — nothing dispatched. |

## Design

### The two-layer allow-set (#4026)

```
requested name
   ↓ trim + lowercase; blank → Blank
   ↓ NON_CODING_TARGETS (bridge-owned floor: research, ticketing)   ← checked FIRST
   ↓ [subagents].allowed  (caller's config, EMPTY by default)
   ↓
resolved target → tcode run-task <target> …
```

Config can only ever **narrow** the floor. An agent whose config lists
`rust-engineer` is still denied at the bridge — pinned by
`non_coding_floor_rejects_a_coding_target_even_when_config_allows_it` and by
`coding_specialist_is_denied_at_the_bridge_despite_caller_config` (which also
asserts the recording backend saw **zero** invocations).

The **empty default** is the load-bearing posture: an agent with no
`[subagents]` section has no cross-product reach whatsoever. Pinned in three
places — `subagents_config_defaults_empty` (config layer),
`empty_default_allow_set_denies_everything` (type layer),
`named_specialist_is_denied_when_no_allow_set_is_configured` (tool layer,
asserting nothing dispatched).

Both denial reasons (`NotNonCoding` / `NotGranted`) render the **same** generic
message so a caller cannot probe the floor list by diffing error text — the
#3052 PR A CRITICAL-2 no-roster-enumeration rule.

### The envelope shape (#4028)

Two structs, deliberately split by direction:

**Outbound** — `HandoffContext`, the minimal #2809-SHAPED payload, validated
BEFORE dispatch so an over-cap payload never invokes the target:

```rust
pub struct HandoffContext {
    pub summary: Option<String>,
    pub relevant_state: Option<String>,
    pub constraints: Vec<String>,
}
pub const HANDOFF_MAX_BYTES: usize = 4096;   // serde_json::to_vec
```

**Inbound** — `ProposalEnvelope`, wrapping the (already branding-scrubbed)
result:

```rust
pub struct ProposalEnvelope {
    pub origin_agent: String,       // who dispatched
    pub target_agent: String,       // which specialist produced `result`
    pub authority: CallerAuthority, // Standard | UserAuthority — the CALLER's
    pub disposition: Disposition,   // ALWAYS Proposal
    pub result: String,
}
```

On the wire:

```json
{
  "origin_agent": "izzie",
  "target_agent": "ticketing",
  "authority": "user_authority",
  "disposition": "proposal",
  "result": "…"
}
```

`for_cross_product` is the **only** constructor and it can only ever set
`Disposition::Proposal` — DOC-41 §5.5 line 1398's "propose-not-authorize,
absolute for M1 — no exceptions" made structural rather than conventional.
`Disposition::Action` exists so the marker is a genuine two-state
discriminator, documented as never produced by this bridge.

**On "PROPOSAL unless the caller holds user_authority":** #4028's own
acceptance is explicit that the result "cannot resolve any `user.*`
authority-gated action **even when the calling agent itself holds
`user_authority: true`**". Both are satisfied by: disposition is always
`Proposal`, and the caller's tier is **recorded** on the envelope so an
authority-holder recognises that IT — in its own turn, under its own identity
— is the party that may act on the proposal. That is exactly DOC-41 §5.5's
model ("the authority-holder reviews … before invoking the tool itself, in its
own turn, under its own identity"). Pinned by
`cross_product_result_is_always_a_proposal` and
`envelope_records_caller_authority_without_upgrading_disposition`.

**No new authority tier was invented.** `CallerAuthority` names exactly the two
states §5.5 already describes. `user_authority` has no `AgentConfig` field yet
(reserved for #3074/AUTH-1), so both registration sites report the fail-closed
`Standard` — `with_origin` is the seam that reads the real field when it lands.

### Config surface (#4026, forward-compatible with #4029)

```toml
[subagents]
allowed = ["research", "ticketing"]
```

`SubagentsConfig { allowed: Option<Vec<String>> }` — a struct, not a bare list,
so #4029's Sub-agents configuration section can add `deny`/`domain` keys
without a breaking change (exactly how `SkillsConfig` was shaped for the same
reason). Exact names only, no glob dialect — matching `[skills].allow`'s
literal-ids-only invariant. Absent = EMPTY, never "all".

### Ticketing port (#4027)

`crates/trusty-code/src/assets/agents/ticketing.md` is a **byte-parity** copy,
not a pinned deviation — the same treatment `research.md` already gets. It
therefore stays in lockstep with upstream automatically via
`check_agent_assets.sh`, with no new pin row and no `--force-add`.

It carries **no** tcode-only `tools:` restriction. That is deliberate: a direct
`tcode run-task ticketing …` invocation would bypass an asset-level allowlist
anyway, so the non-coding property is enforced where the owner's OQ-7 ruling
put enforcement — the bridge's fail-closed `NON_CODING_TARGETS` floor. A
tcode-specific gh-first / read-only adaptation would require declaring a new
pinned deviation and is deliberately left for a follow-up if wanted.

Roster: 32 → **33** dispatchable agents; `EMBEDDED_TM_AGENT_SOURCES` 33 → **34**.

### Backward compatibility

Omitting `specialist` is byte-identical to pre-#4026 behaviour — same
`route_task` derivation, same default target (`DEFAULT_TCODE_AGENT = "pm"`),
same bare scrubbed transcript, **no** envelope. Pinned by
`omitting_specialist_preserves_pre_change_behaviour` (asserts route, `target ==
None`, unmodified task text, and exact result string) and
`default_tcode_agent_is_unchanged_by_the_4026_widening`. `scrub_branding` and
the RBAC tier gate are untouched, and `widened_schema_names_no_backend_or_roster`
pins that the new parameters leak neither backend identity nor roster names.

A named specialist forces the tcode leg rather than re-deriving the route — an
unrelated phrase in `task` must not send a named target to a leg where it does
not exist.

## Live verification of #4027 (raw output)

```
$ TCODE_MOCK_LLM=echo tcode run-task ticketing \
    "List the open issues; do not modify any source files." \
    --project /tmp/tmp.NUICY9RHXk --json
{
  "agent": "ticketing",
  "binding": { "root": "/private/var/.../tmp.NUICY9RHXk", "state": "git_repo" },
  "created_at": "2026-07-26T23:58:19.778741Z",
  "id": "e60e6870-6808-4130-8815-54a074911255",
  "mode": "daily-driver",
  "project": "/private/var/.../tmp.NUICY9RHXk",
  "status": "finished",
  "task": "List the open issues; do not modify any source files.",
  "workstream_id": null
}
EXIT=0
```

`"agent": "ticketing"`, `"status": "finished"` — end-to-end resolution through
the exact `run-task <AGENT>` leg the widened bridge dispatches on.

## Gates (raw)

```
$ cargo test -p trusty-agents
running 2667 tests
test result: ok. 2655 passed; 0 failed; 12 ignored; 0 measured; 0 filtered out
(+ 9 further test binaries, all ok)
AGENTS_TEST_EXIT=0

$ cargo test -p trusty-code
test result: ok. 1602 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out
(+ 16 further test binaries, all ok)
CODE_TEST_EXIT=0

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
trusty-agents clippy EXIT=0

$ cargo clippy -p trusty-code --all-targets -- -D warnings
trusty-code clippy EXIT=0

$ cargo fmt --all --check
EXIT=0

$ bash scripts/check_sld.sh
sld-lint: scanned 47 spec doc(s) + 2888 code file(s); 0 error(s), 0 warning(s)
SLD_EXIT=0

$ bash scripts/check_line_cap.sh
line-cap: 8 allowlisted, 0 violations — OK.
LINECAP_EXIT=0

$ bash scripts/check_agent_assets.sh
agent-assets: 30 byte-parity file(s) match, 4 pinned deviation(s) match upstream — OK.
ASSETS_EXIT=0
```

(That gate's success line previously printed a hardcoded `29`; it now tallies
the real count, since a stale literal in a PASSING message is exactly the quiet
lie the gate exists to prevent.)

## Not in scope

- Epic #2809 (`HandoffContext` delegation protocol) is **not** implemented —
  only its SHAPE is mirrored locally, per OQ-6.
- #4029 (Sub-agents configuration section UI/API) and #4030 (domain-authority
  builder) are separate tickets; the config struct and `SubagentAllowSet` are
  shaped so neither needs to reopen this code.
- No changes to `scrub_branding`, the RBAC tier gate, or `delegate_to_agent`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
