### PR TITLE
fix(trusty-review): drop fabricated/withdrawn findings, close citation coverage gap

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -5,7 +5,52 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
-## [0.10.1] — 2026-07-23
+## [Unreleased]
+
+### Fixed
+
+- **Reliability cluster: fabricated findings, spec-as-implementation, and
+  unsound verdicts** (closes
+  [#4042](https://github.com/bobmatnyc/trusty-tools/issues/4042),
+  [#4043](https://github.com/bobmatnyc/trusty-tools/issues/4043),
+  [#4044](https://github.com/bobmatnyc/trusty-tools/issues/4044)):
+  three related emit-time integrity gaps that let trusty-review publish
+  claims it could not support.
+  - **#4042 — citation verification is now DROP, not downgrade, and covers
+    every finding.** The #2882 fix scoped verification to
+    `code_provable`/`code:`-cited findings and, critically, exempted the
+    mandated `[code: \`path:line\` — "excerpt"]` citation's own excerpt from
+    verification — exactly where #4042 showed the model puts its fabricated
+    "evidence." `citation_check::enforce_citation_integrity` now verifies
+    EVERY finding's `file` against the diff (Kept, SummaryOnly, AND
+    Stage-A-dropped files are all indexed so path existence is checkable
+    regardless of disposition), verifies `[code: …]` excerpts against their
+    own cited path, and adds a same-file/same-line mutual-contradiction
+    backstop for findings that assert incompatible content at one locator. A
+    finding that fails is DROPPED, never downgraded-in-place.
+  - **#4044 — self-withdrawn findings and chain-of-thought leaks.** New
+    `finding_hygiene::drop_self_negated_or_leaked_findings` removes any
+    finding whose own text already negates it ("Withdrawing…", "The code is
+    correct.") or leaks raw mid-reasoning deliberation ("Wait — actually
+    looking at the code more carefully…") before it can reach the rendered
+    review or the verdict floor. `finding_hygiene::relax_verdict_if_evidence_wiped`
+    additionally relaxes a model's own raw `verdict`/`grade` fields to
+    APPROVE when hygiene + citation-integrity wiped out every finding this
+    run — closing the loop so a BLOCK that rested entirely on
+    fabricated/withdrawn evidence cannot survive as the model's untouched
+    self-report.
+  - **#4043 — spec/doc reported as implementation.** New
+    `finding_hygiene::demote_diff_absent_speculation` demotes (never drops —
+    the documentation-drift signal is real) any High/Critical finding whose
+    own text admits it is reasoning about an implementation absent from the
+    diff ("no implementation of…", "if implementation follows the interface
+    literally…"), capping it below the BLOCK floor.
+  - Known residual scope (disclosed, not fully closed): (a) `[code: …]`
+    citation verification checks path+content, not the cited LINE number
+    specifically — no hunk-line-number arithmetic is performed; (b) #4043's
+    fix is marker-based on the finding's own admission and does not catch a
+    finding grounded in an in-code COMMENT's hypothetical (the code file
+    itself is real, so extension/path-based detection does not apply there).
 
 ### Fixed
 

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -221,6 +221,21 @@ pub enum FindingCategory {
 
 // ─── Finding ──────────────────────────────────────────────────────────────────
 
+/// Sentinel `Finding::file` value used when the LLM omits a file (a genuinely
+/// general, non-file-scoped observation).
+///
+/// Why: `citation_check::enforce_citation_integrity` (#4042) requires every
+/// finding's `file` to resolve against the diff — but a finding with no
+/// specific file at all is a legitimate shape, not a fabrication, and must not
+/// be dropped for "not resolving" a path it never claimed. Naming the sentinel
+/// once (rather than repeating the `"unknown"` literal in `parser.rs` and
+/// `citation_check.rs`) keeps the two call sites from drifting apart.
+/// What: the literal string `parser::convert_llm_finding` substitutes when the
+/// LLM's `file` field is empty.
+/// Test: `parse_finding_missing_file_defaults_to_unknown` (parser_tests.rs),
+/// `unknown_file_sentinel_is_exempt_from_path_check` (citation_check_tests.rs).
+pub const UNKNOWN_FILE_PLACEHOLDER: &str = "unknown";
+
 /// A single code-review finding / fix suggestion.
 ///
 /// Why: the pipeline extracts findings from the LLM review body and attaches

--- a/crates/trusty-review/src/pipeline/citation_check.rs
+++ b/crates/trusty-review/src/pipeline/citation_check.rs
@@ -1,30 +1,53 @@
-//! Deterministic citation verification for diff-provable findings (#2881).
+//! Deterministic citation verification for every emitted finding (#2881, #4042).
 //!
 //! Why: a `code_provable: true` finding (or a `code:`-cited finding) drives the
 //! deterministic BLOCK / REQUEST_CHANGES floor unconditionally
-//! (`grade::drives_block_floor` = `cited || code_provable`).  The reviewer LLM can
-//! confabulate such a finding — the #2881 repro emitted a high-severity
-//! `code_provable: true` finding claiming a new vitest test file's content had been
-//! "prepended" into a large regenerated bundle (`api/chat.js`), content that lives
-//! in a DIFFERENT changed file and never appears in the cited file at all.  The
-//! grade floor trusted the flag at face value and fail-CLOSED a clean PR to
-//! D+/REQUEST_CHANGES.  Diff-hunk attribution through the parse → split pipeline is
-//! correct (verified by the `mapreduce`/`diff_analyzer` tests); the missing layer
-//! is a check that a diff-provable CLAIM is actually grounded in the cited file.
+//! (`grade::drives_block_floor` = `cited || code_provable`).  The reviewer LLM
+//! can confabulate such a finding — the #2881 repro emitted a high-severity
+//! `code_provable: true` finding claiming a new vitest test file's content had
+//! been "prepended" into a large regenerated bundle (`api/chat.js`), content
+//! that lives in a DIFFERENT changed file and never appears in the cited file
+//! at all.  The original (#2882) fix downgraded (never dropped) any finding
+//! whose free-text quotes failed to ground in the cited file, but scoped the
+//! check to `code_provable`/`code:`-cited findings only, and — the load-bearing
+//! gap #4042 exploited — deliberately EXEMPTED the prompt-mandated
+//! `[code: `path:line` — "excerpt"]` citation's own excerpt from verification,
+//! on the theory that it was always a paraphrase.  #4042 showed the model often
+//! puts its verbatim "evidence" for a fabrication INSIDE that exact bracket
+//! (attributing four mutually exclusive contents to one file, `hotelPage.ts:207`
+//! citing a file/line that never existed in the diff at all), so the one
+//! citation form the check was built to verify was the one place it never
+//! looked.
 //!
-//! What: [`DiffContentIndex`] indexes the surviving diff by file (the exact content
-//! the reviewer saw, built from the post-filter [`FilteredDiff`]).
-//! [`downgrade_uncitable_findings`] scans findings and, for each finding that claims
-//! to be provable from the diff, verifies the cited file exists in the diff AND that
-//! the concrete code fragments the finding quotes actually appear in that file.  A
-//! finding that fails verification is DOWNGRADED (never silently dropped): its
-//! `code_provable` flag is cleared, a `code:` citation to the unverifiable location
-//! is removed, and its confidence is lowered to the refuted floor so it can no longer
-//! force any verdict floor — it survives as an advisory note.  The check is
-//! FAIL-OPEN: a finding that quotes nothing concrete, or whose quote is grounded in
-//! the cited file, is left untouched.
+//! What: rather than adding another downgrade layer on top of the confabulated
+//! finding, this module makes the emit path structurally incapable of carrying
+//! an unverifiable citation — every finding's citations are checked and, on
+//! failure, the finding is DROPPED (not downgraded, not neutered-but-kept):
 //!
-//! Test: `citation_check_tests.rs`.
+//!  - [`DiffContentIndex::from_filtered`] indexes every file the diff mentions
+//!    (Kept, SummaryOnly, AND Dropped/Stage-A-excluded) so path EXISTENCE can be
+//!    checked regardless of disposition, with content available only for
+//!    Kept/SummaryOnly files.
+//!  - [`enforce_citation_integrity`] runs on EVERY finding (not just
+//!    `code_provable`/cited ones — closing the #4042-named coverage gap) and
+//!    drops a finding whose `file` does not resolve in the diff at all, whose
+//!    free-text quotes contradict the cited file's real content, or whose
+//!    `[code: …]` bracket citation — INCLUDING its excerpt, no longer exempted
+//!    — is unresolvable or contradicted.
+//!  - A cheap, low-false-positive INTERNAL CONSISTENCY check
+//!    ([`detect_line_contradictions`]) drops any pair of findings that cite the
+//!    SAME file+line with two mutually exclusive quoted contents — at least one
+//!    must be invented, and the safest action is to drop both (#4042's own
+//!    suggested direction) — even when the file's content is not independently
+//!    indexable (SummaryOnly / Stage-A-dropped).
+//!
+//! FAIL-OPEN remains the default wherever there is genuinely nothing to verify:
+//! a finding with no quoted content at all is left alone (only path existence is
+//! checked); the `Finding::UNKNOWN_FILE_PLACEHOLDER` sentinel (a legitimately
+//! file-less, general observation) is exempt from path resolution entirely.
+//!
+//! Test: `citation_check_tests.rs`; end-to-end regressions in
+//! `tests/citation_2881_regression.rs` and `tests/citation_4042_regression.rs`.
 
 use std::collections::HashMap;
 use std::sync::LazyLock;
@@ -32,54 +55,74 @@ use std::sync::LazyLock;
 use regex::Regex;
 use tracing::warn;
 
-use crate::models::Finding;
+use crate::models::{Finding, UNKNOWN_FILE_PLACEHOLDER};
 use crate::pipeline::diff_analyzer::models::{FileDisposition, FilteredDiff};
 
 /// The four inline bracket-citation forms the system prompt mandates
 /// (`[code: … ]`, `[jira: … ]`, `[gh: … ]`, `[apex: … ]`).
 ///
-/// Why: the reviewer prompt REQUIRES a finding to cite grounding context with one
-/// of these bracket forms (see `assets/prompts/system_prompt_stock.md`), and the
-/// `[code: `path:line` — "brief excerpt"]` form carries a `path:line` token plus a
-/// deliberately-paraphrased excerpt — neither appears verbatim in diff content.
-/// Treating those as verifiable quotes would FALSE-downgrade a correctly-cited
-/// `code_provable` finding; stripping the whole bracket before quote extraction
-/// keeps only the finding's standalone code quotes (raw diff lines) for grounding.
-/// What: matches a bracket beginning with one of the four labels through its
-/// closing `]`, case-insensitively.
-/// Test: `extract_spans_skips_prompt_mandated_citation_grammar`,
-/// `keeps_finding_using_only_bracket_citation_grammar`.
+/// Why: used to strip ALL bracket citations before the generic backtick/quote
+/// scan, so a citation's `path:line` locator token is never mistaken for a
+/// free-text code quote. `jira:`/`gh:`/`apex:` citations ground in context
+/// (ticket/PR/spec-snippet text) this module has no index for and are left
+/// untouched (fail-open); `code:` citations are extracted and verified
+/// SEPARATELY, before this strip runs (see [`CODE_CITATION_RE`]).
+/// Test: `extract_spans_skips_prompt_mandated_citation_grammar`.
 static BRACKET_CITATION_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)\[(?:code|jira|gh|apex):[^\]]*\]")
         .expect("bracket-citation regex is a valid literal")
 });
 
-/// Confidence a downgraded finding is clamped to — mirrors the verifier-refuted
-/// floor so a citation-refuted finding is treated as the noise it is by every
-/// verdict floor (`grade::is_substantive`, `derive_verdict`'s low-confidence
-/// override, and the synthesis floor's confidence gate).
-const DOWNGRADED_CITATION_CONFIDENCE: f32 = 0.10;
-
-/// Minimum normalized length for a quoted fragment to count as verifiable evidence.
+/// The mandated `[code: `path:line` — "excerpt"]` citation form, captured
+/// structurally (#4042).
 ///
-/// Why: short quotes (a bare identifier, a single keyword) coincidentally appear in
-/// many files and would drive false-positive downgrades; a finding must quote a
-/// substantial fragment before we hold it to the "must appear in the cited file"
-/// bar.  Below this length we FAIL-OPEN (leave the finding untouched).
+/// Why: this is the ONE citation form the prompt requires the model to ground
+/// in a real diff/repo location, and the #2882 fix exempted its excerpt from
+/// verification entirely (assuming it was always a paraphrase). #4042 showed
+/// the model routinely puts its strongest — and sometimes fabricated —
+/// "evidence" here. Capturing the locator (group 1, backtick-delimited) and
+/// the remainder of the bracket (group 2, where the quoted excerpt lives)
+/// separately lets [`extract_citations`] verify the excerpt against the
+/// locator's OWN path, independent of `f.file` (a citation may legitimately
+/// point at a different file than the one the finding is primarily filed
+/// against).
+/// What: matches case-insensitively; group 1 is the backtick-delimited
+/// `path[:line]` locator, group 2 is everything else in the bracket up to `]`.
+/// Test: `code_citation_re_captures_path_line_and_excerpt`.
+static CODE_CITATION_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?is)\[code:\s*`([^`\]]+)`\s*[—-]+\s*([^\]]*)\]")
+        .expect("code-citation regex is a valid literal")
+});
+
+/// Minimum normalized length for a quoted fragment to count as verifiable
+/// evidence.
+///
+/// Why: short quotes (a bare identifier, a single keyword) coincidentally
+/// appear in many files and would drive false-positive drops; a finding must
+/// quote a substantial fragment before we hold it to the "must appear in the
+/// cited file" bar. Below this length we FAIL-OPEN.
 const MIN_SPAN_LEN: usize = 12;
 
 // ─── Diff content index ─────────────────────────────────────────────────────────
 
-/// Per-file index of the surviving diff content, for grounding finding citations.
+/// Per-file index of the diff, for grounding finding citations (#4042: now
+/// covers every disposition, not only Kept/SummaryOnly).
 ///
-/// Why: verifying a finding's quoted content requires the exact per-file text the
-/// reviewer saw.  Building it once from the [`FilteredDiff`] (the post-Stage-A/B
-/// content that actually reached the prompt) and reusing it across all findings
-/// keeps the check O(findings) rather than re-scanning the raw diff per finding.
-/// What: `by_file` maps a normalized file path to that file's normalized diff
-/// content (hunk line bodies, marker-stripped); `all` is every file's content
-/// concatenated, used to detect content that belongs to a DIFFERENT changed file.
-/// Test: `index_from_filtered_indexes_each_file`, `contains_is_whitespace_tolerant`.
+/// Why: verifying a finding's quoted content requires the exact per-file text
+/// the reviewer saw; verifying a finding's cited PATH requires knowing every
+/// file the diff actually touches, regardless of whether that file's content
+/// reached the prompt. Building both from the [`FilteredDiff`] once and
+/// reusing across all findings keeps the check O(findings).
+/// What: `by_file` maps a normalized file path to that file's normalized
+/// content — hunk line bodies for `Kept`, the summary line for `SummaryOnly`,
+/// and the EMPTY string for a Stage-A-excluded file (`dropped_files`): the path
+/// is real (part of the diff), but no content was ever shown to the model, so
+/// any finding that quotes SPECIFIC content for it is verifiably wrong. `all`
+/// is every file's content concatenated, used to distinguish "this quote
+/// belongs to a DIFFERENT changed file" from "this quote is absent everywhere".
+/// Test: `index_from_filtered_indexes_each_file`,
+/// `index_indexes_dropped_files_with_empty_content` (#4042),
+/// `contains_is_whitespace_tolerant`.
 pub struct DiffContentIndex {
     by_file: HashMap<String, String>,
     all: String,
@@ -88,15 +131,20 @@ pub struct DiffContentIndex {
 impl DiffContentIndex {
     /// Build an index from a post-filter [`FilteredDiff`].
     ///
-    /// Why: the `FilteredDiff` is the authoritative record of what the reviewer
-    /// saw — `Kept` files carry their surviving hunk lines and `SummaryOnly` files
-    /// their summary line; `Dropped` files never reached the prompt and are omitted
-    /// so a finding citing one is correctly treated as ungrounded.
-    /// What: for each surviving file, joins its hunk line bodies (or summary line)
-    /// into one normalized string keyed by the normalized path; also builds the
-    /// concatenated `all` blob.
+    /// Why: the `FilteredDiff` is the authoritative record of what the diff
+    /// contains — `Kept` files carry their surviving hunk lines and
+    /// `SummaryOnly` files their summary line; `dropped_files` (Stage A
+    /// exclusions — lockfiles, snapshots, generated code) never reached the
+    /// prompt but ARE real files in the diff, so their paths must still
+    /// resolve (#4042: a citation must be droppable for being fabricated, not
+    /// merely for citing a file the noise filter removed).
+    /// What: for each surviving file, joins its hunk line bodies (or summary
+    /// line) into one normalized string keyed by the normalized path; for each
+    /// Stage-A-dropped file, indexes an EMPTY string at its path. Also builds
+    /// the concatenated `all` blob (surviving files only — a dropped file's
+    /// absent content cannot possibly ground a cross-file misattribution).
     /// Test: `index_from_filtered_indexes_each_file`,
-    /// `index_omits_dropped_files`.
+    /// `index_indexes_dropped_files_with_empty_content`.
     pub fn from_filtered(filtered: &FilteredDiff) -> Self {
         let mut by_file: HashMap<String, String> = HashMap::new();
         let mut all = String::new();
@@ -117,12 +165,21 @@ impl DiffContentIndex {
                     buf
                 }
                 FileDisposition::SummaryOnly => file.summary_line.clone().unwrap_or_default(),
-                FileDisposition::Dropped => continue,
+                // Never populated in `filtered.files` (see `FilteredFile::disposition`'s
+                // doc) — handled defensively as "path real, content unseen".
+                FileDisposition::Dropped => String::new(),
             };
             let norm = normalize(&content);
             all.push_str(&norm);
             all.push(' ');
             by_file.insert(normalize_path(&file.filename), norm);
+        }
+
+        // Stage-A-excluded files: real paths in the diff, zero content shown to
+        // the model. Indexing them (empty) lets path resolution succeed while
+        // content verification still fails any finding that quotes them.
+        for dropped in &filtered.dropped_files {
+            by_file.entry(normalize_path(&dropped.path)).or_default();
         }
 
         Self { by_file, all }
@@ -157,156 +214,290 @@ impl DiffContentIndex {
 
 // ─── Public entry point ─────────────────────────────────────────────────────────
 
-/// Downgrade findings whose diff-provable citation is not grounded in the cited
-/// file, returning the number downgraded.
+/// Enforce citation integrity over every finding, DROPPING (never downgrading)
+/// any finding whose citation cannot be verified, returning the number dropped
+/// (#4042).
 ///
-/// Why: this is the deterministic backstop the #2881 repro needed — the reviewer
-/// LLM tagged a confabulated finding `code_provable: true`, and the grade floor
-/// trusted it.  Verifying the citation against the actual diff before the floor
-/// runs prevents a fabricated finding from ever forcing a verdict.
-/// What: for each finding that claims diff-provability (`code_provable` or a
-/// `code:` citation), verifies the cited file is in the diff and that at least one
-/// substantial code fragment the finding quotes appears in that file.  A finding
-/// that fails is downgraded via [`apply_downgrade`] (advisory, non-blocking) rather
-/// than dropped.  FAIL-OPEN: findings with no verifiable quote, or whose quote is
-/// grounded, are left exactly as-is.
-/// Test: `downgrades_cross_file_misattribution`, `keeps_grounded_code_provable`,
-/// `fail_open_when_cited_file_not_indexed`, `fail_open_when_no_quote`.
-pub fn downgrade_uncitable_findings(findings: &mut [Finding], index: &DiffContentIndex) -> usize {
-    let mut downgraded = 0usize;
-    for f in findings.iter_mut() {
-        if !is_diff_grounded(f) {
+/// Why: the property this pipeline must guarantee is "every emitted finding
+/// cites a path (and, where quoted, content) that verifiably exists in the
+/// diff." #2882 approximated this with a downgrade-only check scoped to
+/// `code_provable`/cited findings and exempting the mandated citation
+/// grammar's own excerpt; #4042 is the direct consequence of both narrowings.
+/// Dropping (rather than downgrading) the finding is the structurally simpler
+/// fix Bob's simplify mandate asks for: a dropped finding cannot leak into the
+/// rendered review OR the verdict floor by construction, with no second
+/// "is this still escalation-eligible after neutering" reasoning needed
+/// downstream.
+/// What: runs in two passes:
+///  1. [`detect_line_contradictions`] — a finding that cites the same
+///     file+line as another finding, with mutually exclusive quoted content, is
+///     dropped alongside its contradictor (internal-consistency backstop, no
+///     index required).
+///  2. Per-finding verification against `index` — a finding whose `file` does
+///     not resolve in the diff at all (except the
+///     [`UNKNOWN_FILE_PLACEHOLDER`] sentinel), whose free-text quotes
+///     contradict the cited file's real content, or whose `[code: …]` bracket
+///     citation is unresolvable or contradicted, is dropped.
+///
+/// FAIL-OPEN: a finding with no quoted content and a resolvable `file` is left
+/// completely untouched.
+///
+/// Test: `drops_cross_file_misattribution`, `keeps_grounded_code_provable`,
+/// `drops_citation_to_path_outside_diff` (#4042),
+/// `drops_findings_with_line_contradiction` (#4042),
+/// `fail_open_when_no_quote`.
+pub fn enforce_citation_integrity(findings: &mut Vec<Finding>, index: &DiffContentIndex) -> usize {
+    let contradictory = detect_line_contradictions(findings);
+
+    let mut reasons: Vec<Option<&'static str>> = Vec::with_capacity(findings.len());
+    for (i, f) in findings.iter().enumerate() {
+        reasons.push(if contradictory.contains(&i) {
+            Some(
+                "mutual-contradiction: another finding cites the same file+line with \
+                  incompatible content",
+            )
+        } else {
+            unresolvable_reason(f, index)
+        });
+    }
+
+    let mut dropped = 0usize;
+    let mut kept = Vec::with_capacity(findings.len());
+    for (f, reason) in std::mem::take(findings).into_iter().zip(reasons) {
+        match reason {
+            Some(reason) => {
+                warn!(
+                    file = %f.file,
+                    line = ?f.line,
+                    kind = %f.kind,
+                    reason,
+                    "citation-check: dropping unverifiable finding (#4042)"
+                );
+                dropped += 1;
+            }
+            None => kept.push(f),
+        }
+    }
+    *findings = kept;
+
+    if dropped > 0 {
+        warn!(count = dropped, "citation-check: findings dropped");
+    }
+    dropped
+}
+
+/// Decide whether a single finding's citations are unresolvable, and why.
+///
+/// Why: isolates the decision from the mutation so it is unit-testable.
+/// What: returns `Some(reason)` when:
+///  - `f.file` is not the [`UNKNOWN_FILE_PLACEHOLDER`] sentinel AND does not
+///    resolve in `index` at all (outside the diff entirely — the
+///    `hotelPage.ts:207` #4042 shape); or
+///  - `f.file` resolves AND the finding quotes ≥1 substantial free-text
+///    fragment (backtick/quote spans OUTSIDE any bracket citation) of which
+///    NONE appears in that file's content; or
+///  - any `[code: …]` bracket citation's own path does not resolve in `index`,
+///    or its excerpt does not appear in that path's content.
+///
+/// Every other case FAILS OPEN and returns `None` — most notably a finding
+/// with a resolvable `file` and no verifiable quote at all.
+///
+/// Test: covered by the `drops_*` / `keeps_*` / `fail_open_*` tests.
+fn unresolvable_reason(f: &Finding, index: &DiffContentIndex) -> Option<&'static str> {
+    let extracted = extract_citations(f);
+
+    if f.file != UNKNOWN_FILE_PLACEHOLDER {
+        match index.lookup(&f.file) {
+            None => return Some("cited file is not part of the diff at all"),
+            Some(content) => {
+                if !extracted.generic.is_empty()
+                    && !extracted
+                        .generic
+                        .iter()
+                        .any(|s| content.contains(s.as_str()))
+                {
+                    let elsewhere = extracted
+                        .generic
+                        .iter()
+                        .any(|s| index.all.contains(s.as_str()));
+                    return Some(if elsewhere {
+                        "quoted content belongs to a different changed file"
+                    } else {
+                        "quoted content is absent from the diff entirely"
+                    });
+                }
+            }
+        }
+    }
+
+    for citation in &extracted.code_citations {
+        match index.lookup(&citation.path) {
+            None => return Some("[code: …] citation's path is not part of the diff at all"),
+            Some(content) => {
+                if !content.contains(citation.excerpt.as_str()) {
+                    return Some("[code: …] citation's excerpt does not appear at the cited path");
+                }
+            }
+        }
+    }
+
+    None
+}
+
+/// Detect pairs of findings that cite the SAME file+line with mutually
+/// exclusive quoted content (#4042's "internal consistency" backstop).
+///
+/// Why: at most one of two findings that assert incompatible contents for the
+/// SAME location can be right — this is provable without knowing the file's
+/// real content, so it catches fabrications even when the cited file's content
+/// was never indexed (`SummaryOnly` / Stage-A-dropped). Scoped to the SAME
+/// line (not merely the same file) deliberately: two real, distinct findings
+/// about DIFFERENT lines of one file are normal and must never be flagged as
+/// contradictory — only the same locator with incompatible content is proof.
+/// What: groups every qualifying quoted span (free-text spans keyed by
+/// `(f.file, f.line)`; `[code: …]` excerpts keyed by their OWN
+/// `(citation.path, citation.line)`) by locator. Within a group, any two
+/// DISTINCT findings whose spans are neither a substring nor a superstring of
+/// one another are marked contradictory (both findings, not just one — #4042:
+/// "at least one had to be invented", and there is no deterministic way to
+/// tell which).
+/// Test: `drops_findings_with_line_contradiction`,
+/// `distinct_lines_are_never_contradictory`.
+fn detect_line_contradictions(findings: &[Finding]) -> std::collections::HashSet<usize> {
+    let mut groups: HashMap<(String, u32), Vec<(usize, String)>> = HashMap::new();
+
+    for (i, f) in findings.iter().enumerate() {
+        let extracted = extract_citations(f);
+        if let Some(line) = f.line {
+            for span in &extracted.generic {
+                groups
+                    .entry((normalize_path(&f.file), line))
+                    .or_default()
+                    .push((i, span.clone()));
+            }
+        }
+        for citation in &extracted.code_citations {
+            if let Some(line) = citation.line {
+                groups
+                    .entry((normalize_path(&citation.path), line))
+                    .or_default()
+                    .push((i, citation.excerpt.clone()));
+            }
+        }
+    }
+
+    let mut contradictory = std::collections::HashSet::new();
+    for entries in groups.into_values() {
+        if entries.len() < 2 {
             continue;
         }
-        let Some(reason) = uncitable_reason(f, index) else {
-            continue;
-        };
-        warn!(
-            file = %f.file,
-            line = ?f.line,
-            kind = %f.kind,
-            reason,
-            "citation-check: downgrading unverifiable diff-provable finding (#2881)"
-        );
-        apply_downgrade(f);
-        downgraded += 1;
+        for a in 0..entries.len() {
+            for b in (a + 1)..entries.len() {
+                let (idx_a, span_a) = &entries[a];
+                let (idx_b, span_b) = &entries[b];
+                if idx_a == idx_b {
+                    continue; // same finding citing itself twice — not a conflict
+                }
+                if !span_a.contains(span_b.as_str()) && !span_b.contains(span_a.as_str()) {
+                    contradictory.insert(*idx_a);
+                    contradictory.insert(*idx_b);
+                }
+            }
+        }
     }
-    if downgraded > 0 {
-        warn!(count = downgraded, "citation-check: findings downgraded");
-    }
-    downgraded
-}
-
-/// Decide whether a diff-grounded finding's citation is unverifiable, and why.
-///
-/// Why: isolates the decision from the mutation so it is unit-testable and the
-/// FAIL-OPEN boundaries are explicit.
-/// What: returns `Some(reason)` ONLY when the cited file IS present in the diff
-/// AND the finding quotes ≥1 substantial fragment of which NONE appears in that
-/// file (distinguishing content that belongs to another changed file from content
-/// absent everywhere, for logging only).  Every other case FAILS OPEN and returns
-/// `None`:
-///  - the cited file is not indexed (outside the diff, or a header the parser
-///    could not attribute) — we have no content to check against, so we never
-///    penalise a finding merely for citing a file we did not index; and
-///  - the finding quotes nothing concrete, or a quote is found in the cited file.
-///
-/// This keeps the check high-precision: a legitimate diff-provable finding is
-/// never downgraded, and only a demonstrable content mismatch (the #2881 shape)
-/// is caught.
-///
-/// Test: covered by the `downgrade_*` / `keeps_*` / `fail_open_*` tests.
-fn uncitable_reason(f: &Finding, index: &DiffContentIndex) -> Option<&'static str> {
-    // FAIL OPEN when the cited file is not indexed: without the file's actual
-    // content there is nothing to verify against, and citing a file outside the
-    // reviewed diff is not, by itself, proof of fabrication.
-    let content = index.lookup(&f.file)?;
-
-    let spans = extract_quoted_spans(f);
-    if spans.is_empty() {
-        return None; // nothing concrete to verify — fail open
-    }
-    if spans.iter().any(|s| content.contains(s.as_str())) {
-        return None; // a quote is grounded in the cited file — keep
-    }
-    // None of the finding's substantial quotes appear in the cited file.
-    let elsewhere = spans.iter().any(|s| index.all.contains(s.as_str()));
-    Some(if elsewhere {
-        "content-belongs-to-another-file"
-    } else {
-        "cited-content-absent-from-diff"
-    })
-}
-
-/// Return `true` when a finding claims to be provable from the diff itself.
-///
-/// Why: only diff-provable claims are verifiable against the diff — a finding
-/// grounded in an external spec/ticket (`jira:`/`gh:`/`apex:` citation) is out of
-/// scope for this check and must be left untouched.
-/// What: true iff `code_provable` is set OR the `source_citation` is a `code:`
-/// location.
-/// Test: `is_diff_grounded_detects_code_provable_and_code_citation`.
-fn is_diff_grounded(f: &Finding) -> bool {
-    f.code_provable || has_code_citation(f)
-}
-
-/// Return `true` when the finding carries a `code:`-prefixed source citation.
-fn has_code_citation(f: &Finding) -> bool {
-    f.source_citation
-        .as_deref()
-        .map(|c| c.trim_start().to_ascii_lowercase().starts_with("code:"))
-        .unwrap_or(false)
-}
-
-/// Neutralize a finding whose diff citation could not be verified.
-///
-/// Why: an unverifiable diff-provable claim must never force a verdict floor, but
-/// dropping it outright would hide a possible (unproven) concern from the author —
-/// so we downgrade to advisory instead (honest partial signal, mirroring the
-/// verifier-refuted treatment).
-/// What: clears `code_provable`; removes ANY `source_citation` (not just a `code:`
-/// one); and lowers confidence to the refuted floor so every verdict floor treats
-/// it as non-evidence.  Stripping the whole citation is deliberate: a finding whose
-/// diff-provable factual basis was just disproven cannot be trusted to have
-/// correctly grounded a co-attached spec/ticket citation either, and leaving a
-/// non-`code:` citation in place would keep `grade::is_escalation_eligible` true
-/// (the citation-grammar shape check) — so `drives_block_floor` would still fire
-/// and the downgrade would be a no-op (code-critic WARN, #2881).
-/// Test: `apply_downgrade_clears_provability_and_all_citations`,
-/// `downgrade_neutralizes_surviving_non_code_citation`.
-fn apply_downgrade(f: &mut Finding) {
-    f.code_provable = false;
-    f.source_citation = None;
-    f.confidence = f.confidence.min(DOWNGRADED_CITATION_CONFIDENCE);
+    contradictory
 }
 
 // ─── Quote extraction + normalization ───────────────────────────────────────────
 
-/// Extract substantial code fragments the finding explicitly quotes.
+/// A single `[code: `path:line` — "excerpt"]` citation, extracted structurally.
+struct CodeCitation {
+    path: String,
+    line: Option<u32>,
+    excerpt: String,
+}
+
+/// The citations extracted from one finding's text.
+struct ExtractedCitations {
+    /// `[code: …]` citations, each carrying its OWN path/line (may differ from
+    /// `f.file`/`f.line`).
+    code_citations: Vec<CodeCitation>,
+    /// Free-text backtick/quote spans OUTSIDE any bracket citation, checked
+    /// against `f.file`'s content.
+    generic: Vec<String>,
+}
+
+/// Extract every citation a finding carries — structured `[code: …]` brackets
+/// (with their own path/line/excerpt) AND free-text quoted spans — from its
+/// `description` and `consequence` (#4042).
 ///
-/// Why: a fabricated diff-provable finding "proves" its claim by quoting content it
-/// asserts is present at the cited location; verifying those quotes against the
-/// cited file is what catches the confabulation.  Only the model's OWN explicit
-/// quotes are used (never paraphrase) to keep the check high-precision.
-/// What: pulls backtick-, double-quote-, and single-quote-delimited spans from the
-/// finding's `description` and `consequence` AFTER stripping the prompt-mandated
-/// bracket citations (via [`BRACKET_CITATION_RE`]) so a `path:line` token or a
-/// paraphrased excerpt inside a `[code: … ]` citation is never mistaken for a
-/// verifiable diff quote.  Each span is normalized and kept only if at least
-/// [`MIN_SPAN_LEN`] chars.  `suggested_replacement` is deliberately excluded — it
-/// is the PROPOSED fix, which by design need not appear in the diff.
-/// Test: `extract_spans_pulls_backtick_and_quotes`, `extract_spans_skips_short`,
-/// `extract_spans_skips_prompt_mandated_citation_grammar`.
-fn extract_quoted_spans(f: &Finding) -> Vec<String> {
-    let mut out = Vec::new();
+/// Why: #2882 stripped `[code: …]` brackets wholesale before scanning for
+/// quotes, on the theory the excerpt inside was always a paraphrase — #4042
+/// showed that is where the model's fabricated "evidence" most often lives.
+/// Extracting the bracket's locator (path/line) and excerpt SEPARATELY from
+/// the general free-text scan lets each be verified against its OWN cited
+/// path, while still preventing the locator token itself (`path.ts:42`, never
+/// literally present in that file's content) from being misread as a
+/// content quote.
+/// What: for each `[code: `path:line` — "excerpt"]` match, splits the locator
+/// into path + optional line and pulls the excerpt from the remainder via
+/// quote-delimited scanning; then strips ALL FOUR bracket forms (`code`,
+/// `jira`, `gh`, `apex`) and scans the remainder for backtick/double/single
+/// quoted spans ≥ [`MIN_SPAN_LEN`] chars. `suggested_replacement` and
+/// `suggestion` are deliberately excluded (as before #4042) — they are the
+/// PROPOSED fix, which by design need not appear in the diff.
+/// Test: `code_citation_re_captures_path_line_and_excerpt`,
+/// `extract_spans_pulls_backtick_and_quotes`, `extract_spans_skips_short`.
+fn extract_citations(f: &Finding) -> ExtractedCitations {
+    let mut code_citations = Vec::new();
+    let mut generic = Vec::new();
+
     for text in [f.description.as_str(), f.consequence.as_str()] {
+        for caps in CODE_CITATION_RE.captures_iter(text) {
+            let locator = caps.get(1).map(|m| m.as_str().trim()).unwrap_or_default();
+            let rest = caps.get(2).map(|m| m.as_str()).unwrap_or_default();
+            let (path, line) = split_locator(locator);
+            let mut excerpts = Vec::new();
+            collect_delimited(rest, '"', &mut excerpts);
+            collect_delimited(rest, '\'', &mut excerpts);
+            for excerpt in excerpts {
+                if excerpt.len() >= MIN_SPAN_LEN {
+                    code_citations.push(CodeCitation {
+                        path: path.clone(),
+                        line,
+                        excerpt,
+                    });
+                }
+            }
+        }
+
         let stripped = BRACKET_CITATION_RE.replace_all(text, " ");
-        collect_delimited(&stripped, '`', &mut out);
-        collect_delimited(&stripped, '"', &mut out);
-        collect_delimited(&stripped, '\'', &mut out);
+        collect_delimited(&stripped, '`', &mut generic);
+        collect_delimited(&stripped, '"', &mut generic);
+        collect_delimited(&stripped, '\'', &mut generic);
     }
-    out.retain(|s| s.len() >= MIN_SPAN_LEN);
-    out
+    generic.retain(|s| s.len() >= MIN_SPAN_LEN);
+
+    ExtractedCitations {
+        code_citations,
+        generic,
+    }
+}
+
+/// Split a `[code: …]` locator into its path and optional trailing line
+/// number.
+///
+/// What: if `locator` ends in `:<digits>`, returns `(path-without-suffix,
+/// Some(n))`; otherwise returns `(locator, None)` unchanged (e.g. a spec file
+/// cited without a line, `docs/specs/foo.md`).
+/// Test: `split_locator_extracts_line`, `split_locator_no_line`.
+fn split_locator(locator: &str) -> (String, Option<u32>) {
+    if let Some((path, line)) = locator.rsplit_once(':')
+        && let Ok(n) = line.trim().parse::<u32>()
+    {
+        return (path.trim().to_string(), Some(n));
+    }
+    (locator.to_string(), None)
 }
 
 /// Collect normalized spans delimited by `delim` from `text` into `out`.

--- a/crates/trusty-review/src/pipeline/citation_check_tests.rs
+++ b/crates/trusty-review/src/pipeline/citation_check_tests.rs
@@ -1,9 +1,9 @@
-//! Unit tests for the #2881 citation-verification layer.
+//! Unit tests for the citation-verification layer (#2881, extended #4042).
 
 use super::*;
 use crate::models::{Effort, Finding};
 use crate::pipeline::diff_analyzer::models::{
-    FileDisposition, FilteredDiff, FilteredFile, FilteredHunk,
+    DroppedFile, FileDisposition, FilteredDiff, FilteredFile, FilteredHunk,
 };
 use std::collections::HashMap;
 
@@ -78,6 +78,11 @@ fn code_provable_finding(file: &str, description: &str) -> Finding {
     f
 }
 
+/// Helper: wrap a single finding into a `Vec` (kept local to avoid churn).
+fn findings_of(f: Finding) -> Vec<Finding> {
+    vec![f]
+}
+
 // ─── Index tests ─────────────────────────────────────────────────────────────
 
 #[test]
@@ -89,11 +94,21 @@ fn index_from_filtered_indexes_each_file() {
 }
 
 #[test]
-fn index_omits_dropped_files() {
-    let mut dropped = kept_file("build/gen.js", vec![hunk("@@ -1 +1 @@", &["+x"])]);
-    dropped.disposition = FileDisposition::Dropped;
-    let idx = DiffContentIndex::from_filtered(&filtered(vec![dropped]));
-    assert!(idx.lookup("build/gen.js").is_none());
+fn index_indexes_dropped_files_with_empty_content() {
+    // #4042: a Stage-A-excluded file (lockfile, snapshot, generated code) is a
+    // REAL file in the diff — its path must resolve — but no content was ever
+    // shown to the model, so it is indexed with an EMPTY body.
+    let mut diff = filtered(vec![]);
+    diff.dropped_files.push(DroppedFile {
+        path: "build/gen.js".to_string(),
+        reason: "generated".to_string(),
+    });
+    let idx = DiffContentIndex::from_filtered(&diff);
+    assert_eq!(
+        idx.lookup("build/gen.js"),
+        Some(""),
+        "path resolves; content is empty"
+    );
 }
 
 #[test]
@@ -120,10 +135,10 @@ fn contains_is_whitespace_tolerant() {
     assert_eq!(normalize("a   b\n\tc"), "a b c");
 }
 
-// ─── Downgrade behaviour ─────────────────────────────────────────────────────
+// ─── enforce_citation_integrity: drop behaviour ───────────────────────────────
 
 #[test]
-fn downgrades_cross_file_misattribution() {
+fn drops_cross_file_misattribution() {
     // THE #2881 REPRO: a code_provable finding cites the bundle but quotes the
     // vitest test content, which lives in a different changed file.
     let idx = repro_index();
@@ -134,15 +149,9 @@ fn downgrades_cross_file_misattribution() {
     )];
     findings[0].line = Some(35271);
 
-    let n = downgrade_uncitable_findings(&mut findings, &idx);
-    assert_eq!(n, 1, "the misattributed finding must be downgraded");
-    assert!(!findings[0].code_provable, "code_provable must be cleared");
-    assert!(
-        findings[0].confidence <= DOWNGRADED_CITATION_CONFIDENCE,
-        "confidence must be lowered to the advisory floor"
-    );
-    // And it must no longer be able to drive the BLOCK floor.
-    assert!(!crate::pipeline::grade::drives_block_floor(&findings[0]));
+    let n = enforce_citation_integrity(&mut findings, &idx);
+    assert_eq!(n, 1, "the misattributed finding must be dropped");
+    assert!(findings.is_empty());
 }
 
 #[test]
@@ -154,194 +163,259 @@ fn keeps_grounded_code_provable() {
         "api/chat.js",
         "Suspicious call `const bundleVar = compiledThing(42);` may overflow.",
     )];
-    let n = downgrade_uncitable_findings(&mut findings, &idx);
+    let n = enforce_citation_integrity(&mut findings, &idx);
     assert_eq!(n, 0, "a grounded finding must survive");
+    assert_eq!(findings.len(), 1);
     assert!(findings[0].code_provable);
     assert!((findings[0].confidence - 0.75).abs() < f32::EPSILON);
 }
 
 #[test]
-fn fail_open_when_cited_file_not_indexed() {
-    // FAIL OPEN: a finding citing a file we did not index (outside the diff, or a
-    // header the parser could not attribute) is never downgraded — without the
-    // file's content there is nothing to verify against, and citing an
-    // out-of-diff file is not, by itself, proof of fabrication.
+fn drops_citation_to_path_outside_diff() {
+    // #4042: a finding citing a file that was NEVER part of the diff at all
+    // (not Kept, not SummaryOnly, not even Stage-A-dropped) must be DROPPED,
+    // not fail-open — this is the standalone `hotelPage.ts:207` incident shape.
     let idx = repro_index();
     let mut findings = vec![code_provable_finding(
         "src/never/changed.rs",
         "Off-by-one in the loop bound `for i in 0..=len { arr[i] }`.",
     )];
-    let n = downgrade_uncitable_findings(&mut findings, &idx);
+    let n = enforce_citation_integrity(&mut findings, &idx);
     assert_eq!(
-        n, 0,
-        "an un-indexed cited file must not trigger a downgrade"
+        n, 1,
+        "a citation to a path outside the diff must be dropped"
     );
-    assert!(findings[0].code_provable);
+    assert!(findings.is_empty());
 }
 
 #[test]
 fn fail_open_when_no_quote() {
-    // A code_provable finding that quotes nothing concrete cannot be verified —
-    // leave it alone (fail open) rather than risk a false-positive downgrade.
+    // A finding whose cited file resolves but quotes nothing concrete cannot be
+    // verified further — leave it alone (fail open) rather than risk a
+    // false-positive drop.
     let idx = repro_index();
     let mut findings = vec![code_provable_finding(
         "api/chat.js",
         "There may be a subtle logic issue in this function.",
     )];
-    let n = downgrade_uncitable_findings(&mut findings, &idx);
+    let n = enforce_citation_integrity(&mut findings, &idx);
     assert_eq!(n, 0, "no verifiable quote → fail open");
-    assert!(findings[0].code_provable);
+    assert_eq!(findings.len(), 1);
 }
 
 #[test]
-fn ignores_non_diff_grounded_findings() {
-    // A finding that is neither code_provable nor code:-cited is out of scope,
-    // even if it cites content absent from its file.
+fn every_finding_is_checked_not_just_code_provable() {
+    // #4042's NAMED coverage gap: a finding that is neither `code_provable` nor
+    // `code:`-cited must STILL have its `file` path verified against the diff —
+    // the #2882 fix scoped verification to the code_provable subset, which is
+    // exactly the gap #4042 exploited.
     let idx = repro_index();
     let mut f = Finding::new(
-        "api/chat.js",
+        "src/never/changed.rs",
         "style",
-        "Consider `import { describe } from 'vitest';` elsewhere.",
+        "Minor formatting nit.",
         "n/a",
         0.9,
         Effort::Low,
     );
     f.source_citation = Some("jira:PROJ-1".to_string());
     let mut findings = vec![f];
-    let n = downgrade_uncitable_findings(&mut findings, &idx);
-    assert_eq!(n, 0, "non-diff-grounded findings are untouched");
-    assert_eq!(findings[0].source_citation.as_deref(), Some("jira:PROJ-1"));
+    let n = enforce_citation_integrity(&mut findings, &idx);
+    assert_eq!(
+        n, 1,
+        "path resolution now applies to every finding, not only code_provable ones"
+    );
 }
 
 #[test]
-fn downgrades_code_citation_to_unverifiable_content() {
-    // A `code:`-cited finding whose quote is not in the cited file is downgraded,
-    // and its citation is stripped (see
-    // `apply_downgrade_clears_provability_and_all_citations`).
+fn unknown_file_sentinel_is_exempt_from_path_check() {
+    // A genuinely general, file-less finding (the LLM omitted `file`, parsed as
+    // the `UNKNOWN_FILE_PLACEHOLDER` sentinel) must never be dropped for "not
+    // resolving" a path it never claimed.
     let idx = repro_index();
-    let mut f = Finding::new(
+    let mut findings = vec![Finding::new(
+        crate::models::UNKNOWN_FILE_PLACEHOLDER,
+        "style",
+        "Overall the PR could use a changelog entry.",
+        "n/a",
+        0.6,
+        Effort::Low,
+    )];
+    let n = enforce_citation_integrity(&mut findings, &idx);
+    assert_eq!(
+        n, 0,
+        "the unknown-file sentinel is exempt from path checking"
+    );
+    assert_eq!(findings.len(), 1);
+}
+
+#[test]
+fn code_citation_bracket_content_is_now_verified() {
+    // #4042's OTHER named gap: the mandated `[code: …]` citation's own excerpt
+    // was previously EXEMPTED from verification entirely. A finding whose ONLY
+    // "evidence" lives inside that bracket, and which is fabricated, must now
+    // be dropped.
+    let idx = repro_index();
+    let mut f = code_provable_finding(
         "api/chat.js",
-        "logic-error",
-        "Bundle embeds `it('contains aria prompt', () => expect(INSTRUCTIONS)` verbatim.",
-        "fix",
-        0.8,
-        Effort::High,
+        "The bundle embeds the test suite \
+         [code: `api/chat.js:1` — \"import { describe, it, expect } from 'vitest';\"].",
     );
-    f.code_provable = false;
-    f.source_citation = Some("code:api/chat.js:35271".to_string());
-    let mut findings = vec![f];
-    let n = downgrade_uncitable_findings(&mut findings, &idx);
-    assert_eq!(n, 1);
-    assert!(
-        findings[0].source_citation.is_none(),
-        "code citation must be stripped"
+    f.line = Some(1);
+    let n = enforce_citation_integrity(&mut findings_of_mut(&mut f), &idx);
+    assert_eq!(
+        n, 1,
+        "a fabricated bracket-citation excerpt must now be caught"
     );
+}
+
+/// Helper: wrap a `&mut Finding` clone into an owned `Vec` for the drop-based API.
+fn findings_of_mut(f: &mut Finding) -> Vec<Finding> {
+    vec![f.clone()]
+}
+
+#[test]
+fn code_citation_bracket_grounded_content_survives() {
+    // A correctly-grounded `[code: …]` excerpt (matches the real cited content)
+    // must NOT be dropped — the new bracket-verification must not over-fire.
+    let idx = repro_index();
+    let mut f = code_provable_finding(
+        "api/chat.js",
+        "Suspicious overflow risk \
+         [code: `api/chat.js:35271` — \"const bundleVar = compiledThing(42);\"].",
+    );
+    f.line = Some(35271);
+    let mut findings = findings_of(f);
+    let n = enforce_citation_integrity(&mut findings, &idx);
+    assert_eq!(n, 0, "a grounded bracket citation must survive");
+    assert_eq!(findings.len(), 1);
+}
+
+#[test]
+fn code_citation_bracket_path_outside_diff_is_dropped() {
+    // A `[code: …]` citation whose OWN path is not part of the diff at all
+    // (independent of `f.file`) must be dropped — the `hotelPage.ts:207` shape
+    // expressed via the bracket grammar instead of `f.file`.
+    let idx = repro_index();
+    let mut f = code_provable_finding(
+        "api/chat.js",
+        "Race condition in the loser branch \
+         [code: `hotelPage.ts:207` — \"await Promise.race([a, b])\"].",
+    );
+    let n = enforce_citation_integrity(&mut findings_of_mut(&mut f), &idx);
+    assert_eq!(
+        n, 1,
+        "an unresolvable bracket citation path must be dropped"
+    );
+}
+
+// ─── Mutual contradiction ──────────────────────────────────────────────────────
+
+#[test]
+fn drops_findings_with_line_contradiction() {
+    // #4042 centerpiece shape: two findings cite the SAME file+line via the
+    // `[code: …]` bracket grammar but quote mutually exclusive content — at
+    // least one must be invented, so both are dropped.
+    let idx = repro_index();
+    let mut findings = vec![
+        code_provable_finding(
+            "api/chat.js",
+            "This is a Drizzle JSON snapshot \
+             [code: `api/chat.js:1` — \"id: 893644d4-fabricated-snapshot-content\"].",
+        ),
+        code_provable_finding(
+            "api/chat.js",
+            "This is a Vitest suite for draft-form \
+             [code: `api/chat.js:1` — \"import { describe, expect, it } from 'vitest'\"].",
+        ),
+    ];
+    let n = enforce_citation_integrity(&mut findings, &idx);
+    assert_eq!(n, 2, "both contradictory findings must be dropped");
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn distinct_lines_are_never_contradictory() {
+    // Two REAL, distinct findings about DIFFERENT lines of the same file are
+    // normal — must never be flagged as contradictory.
+    let idx = repro_index();
+    let mut findings = vec![
+        code_provable_finding(
+            "api/chat.js",
+            "Overflow risk \
+             [code: `api/chat.js:35271` — \"const bundleVar = compiledThing(42);\"].",
+        ),
+        code_provable_finding(
+            "api/chat.js",
+            "Missing null check \
+             [code: `api/chat.js:35272` — \"return bundleVar;\"].",
+        ),
+    ];
+    let n = enforce_citation_integrity(&mut findings, &idx);
+    assert_eq!(
+        n, 0,
+        "distinct real lines in the same file must not be treated as contradictory"
+    );
+    assert_eq!(findings.len(), 2);
 }
 
 // ─── Helper unit tests ───────────────────────────────────────────────────────
 
 #[test]
-fn is_diff_grounded_detects_code_provable_and_code_citation() {
-    let mut f = Finding::new("f", "k", "d", "s", 0.5, Effort::Low);
-    assert!(!is_diff_grounded(&f));
-    f.code_provable = true;
-    assert!(is_diff_grounded(&f));
-    f.code_provable = false;
-    f.source_citation = Some("code:f:1".to_string());
-    assert!(is_diff_grounded(&f));
-    f.source_citation = Some("gh:owner/repo#1".to_string());
-    assert!(!is_diff_grounded(&f));
-}
-
-#[test]
-fn apply_downgrade_clears_provability_and_all_citations() {
-    let mut f = code_provable_finding("f", "d");
-    f.source_citation = Some("code:f:1".to_string());
-    f.confidence = 0.9;
-    apply_downgrade(&mut f);
-    assert!(!f.code_provable);
-    assert!(f.source_citation.is_none());
-    assert!(f.confidence <= DOWNGRADED_CITATION_CONFIDENCE);
-
-    // A non-code citation is ALSO cleared: the finding's factual basis was
-    // disproven, and leaving it would keep the finding escalation-eligible.
-    let mut g = code_provable_finding("f", "d");
-    g.source_citation = Some("jira:X-1".to_string());
-    apply_downgrade(&mut g);
-    assert!(g.source_citation.is_none());
-}
-
-#[test]
-fn downgrade_neutralizes_surviving_non_code_citation() {
-    // A fabricated code_provable finding that ALSO carries a spec/ticket citation
-    // must fully lose block-floor eligibility after downgrade — otherwise the
-    // surviving citation keeps `drives_block_floor` true (code-critic WARN).
-    let idx = repro_index();
-    let mut f = code_provable_finding(
-        "api/chat.js",
-        "Bundle embeds `import { describe, it, expect } from 'vitest';` from the test file.",
-    );
-    f.source_citation = Some("jira:PROJ-123".to_string());
-    assert!(
-        crate::pipeline::grade::drives_block_floor(&f),
-        "precondition: forces floor"
-    );
-
-    let mut findings = vec![f];
-    let n = downgrade_uncitable_findings(&mut findings, &idx);
-    assert_eq!(n, 1);
-    assert!(
-        findings[0].source_citation.is_none(),
-        "surviving citation must be cleared"
-    );
-    assert!(
-        !crate::pipeline::grade::drives_block_floor(&findings[0]),
-        "downgraded finding must no longer drive the BLOCK floor"
-    );
-}
-
-#[test]
-fn keeps_finding_using_only_bracket_citation_grammar() {
-    // A correctly-grounded code_provable finding that cites via the prompt-mandated
-    // `[code: `path:line` — "excerpt"]` grammar (whose path:line + paraphrased
-    // excerpt never appear verbatim in diff content) must NOT be false-downgraded.
-    let idx = repro_index();
-    let mut f = code_provable_finding(
-        "api/chat.js",
-        "The bundle symbol is unsafe [code: `api/chat.js:35271` — \"a paraphrased summary \
-         of the concern that is not a literal diff line\"].",
-    );
-    f.line = Some(35271);
-    let n = downgrade_uncitable_findings(&mut findings_of(f), &idx);
+fn split_locator_extracts_line() {
     assert_eq!(
-        n, 0,
-        "a bracket-cited finding with no standalone diff quote must survive"
+        split_locator("src/lib/foo.ts:42"),
+        ("src/lib/foo.ts".to_string(), Some(42))
     );
 }
 
-/// Helper: wrap a single finding into a `Vec` (kept local to avoid churn).
-fn findings_of(f: Finding) -> Vec<Finding> {
-    vec![f]
+#[test]
+fn split_locator_no_line() {
+    assert_eq!(
+        split_locator("docs/specs/foo.md"),
+        ("docs/specs/foo.md".to_string(), None)
+    );
 }
 
 #[test]
-fn extract_spans_skips_prompt_mandated_citation_grammar() {
-    // The four bracket-citation forms are stripped before quote extraction, so
-    // their inner path:line token and excerpt are never treated as verifiable.
+fn code_citation_re_captures_path_line_and_excerpt() {
     let f = Finding::new(
         "f",
         "k",
-        "See [code: `src/big/File.ts:4242` — \"brief excerpt from the file here\"] and \
-         [jira: PROJ-9 — \"ticket paraphrase text goes here\"].",
+        "See [code: `src/big/File.ts:4242` — \"a verbatim excerpt right here\"].",
         "s",
         0.5,
         Effort::Low,
     );
-    let spans = extract_quoted_spans(&f);
-    assert!(
-        spans.is_empty(),
-        "bracket-citation contents must not be treated as quotes: {spans:?}"
+    let extracted = extract_citations(&f);
+    assert_eq!(extracted.code_citations.len(), 1);
+    assert_eq!(extracted.code_citations[0].path, "src/big/File.ts");
+    assert_eq!(extracted.code_citations[0].line, Some(4242));
+    assert_eq!(
+        extracted.code_citations[0].excerpt,
+        "a verbatim excerpt right here"
     );
+}
+
+#[test]
+fn extract_spans_skips_prompt_mandated_citation_grammar() {
+    // The non-`code:` bracket forms are stripped before generic quote
+    // extraction — `jira`/`gh`/`apex` citations are out of this module's scope.
+    let f = Finding::new(
+        "f",
+        "k",
+        "See [jira: PROJ-9 — \"ticket paraphrase text goes here\"].",
+        "s",
+        0.5,
+        Effort::Low,
+    );
+    let extracted = extract_citations(&f);
+    assert!(
+        extracted.generic.is_empty(),
+        "non-code bracket contents must not be treated as generic quotes: {:?}",
+        extracted.generic
+    );
+    assert!(extracted.code_citations.is_empty());
 }
 
 #[test]
@@ -355,17 +429,32 @@ fn extract_spans_pulls_backtick_and_quotes() {
         Effort::Low,
     );
     f.consequence = "single 'yet_another_fragment(z)' here".to_string();
-    let spans = extract_quoted_spans(&f);
-    assert!(spans.iter().any(|s| s.contains("let x = compute(y);")));
-    assert!(spans.iter().any(|s| s.contains("another_long_snippet()")));
-    assert!(spans.iter().any(|s| s.contains("yet_another_fragment(z)")));
+    let extracted = extract_citations(&f);
+    assert!(
+        extracted
+            .generic
+            .iter()
+            .any(|s| s.contains("let x = compute(y);"))
+    );
+    assert!(
+        extracted
+            .generic
+            .iter()
+            .any(|s| s.contains("another_long_snippet()"))
+    );
+    assert!(
+        extracted
+            .generic
+            .iter()
+            .any(|s| s.contains("yet_another_fragment(z)"))
+    );
 }
 
 #[test]
 fn extract_spans_skips_short() {
     let f = Finding::new("f", "k", "tiny `x` and `ab`", "s", 0.5, Effort::Low);
     assert!(
-        extract_quoted_spans(&f).is_empty(),
+        extract_citations(&f).generic.is_empty(),
         "short quotes are not evidence"
     );
 }

--- a/crates/trusty-review/src/pipeline/finding_hygiene.rs
+++ b/crates/trusty-review/src/pipeline/finding_hygiene.rs
@@ -1,0 +1,279 @@
+//! Output-hygiene filters applied to LLM-authored findings before grading and
+//! rendering (#4043, #4044).
+//!
+//! Why: both defects share the shape this module closes — the reviewer's OWN
+//! text already disqualifies the finding (it withdrew the claim, it leaked raw
+//! mid-reasoning deliberation, or it admits it is speculating beyond what the
+//! diff actually shows), yet nothing acted on that self-admission before the
+//! finding reached the verdict floor or the rendered review:
+//!
+//!  - **#4044, defect 1 — unsound verdict.** A review graded F/BLOCK with 7 of
+//!    34 findings self-withdrawn in their own published text ("Withdrawing this
+//!    finding — confidence too low.", "This is correctly implemented."). The
+//!    aggregator counted cardinality/severity of EMITTED findings, never
+//!    checking whether the finding's own prose had already negated itself.
+//!  - **#4044, defect 2 — chain-of-thought leak.** One finding's published body
+//!    included raw deliberation verbatim ("Wait — actually looking at the code
+//!    more carefully, ..."). There is no separate "thinking" channel in this
+//!    pipeline (see `llm::bedrock` — no extended-thinking mode is requested);
+//!    the model narrates reasoning directly inside the same `body`/`description`
+//!    field the JSON schema exposes, so a leak is an output-text problem, not a
+//!    transport one.
+//!  - **#4043 — spec reported as implementation.** A finding derived from a
+//!    SPEC/doc artifact was emitted as if it described shipped code, refuted by
+//!    the actual implementation. The clearest instances are findings that
+//!    ADMIT the gap in their own text ("the diff contains only the spec
+//!    document ... no implementation ... is present", "if implementation
+//!    follows the interface literally") and reason past it anyway.
+//!
+//! What: [`sanitize_findings`] runs two independent, marker-based passes, both
+//! reusing the SAME shape — the finding's own text is the signal, no LLM
+//! double-check required:
+//!
+//!  1. [`drop_self_negated_or_leaked_findings`] — DROPS any finding whose text
+//!     contains a self-negation marker ("withdrawing", "this is correct", …) or
+//!     a raw-deliberation transition marker ("wait — actually", "on
+//!     re-inspection", …). Dropping (not stripping-in-place) is deliberate:
+//!     Bob's simplify mandate prefers a finding that cannot leak at all over a
+//!     surgical text edit that risks leaving a mangled remainder; a finding
+//!     that talked itself out of its own claim is not lost signal.
+//!  2. [`demote_diff_absent_speculation`] — DEMOTES (does not drop — the
+//!     documentation-drift signal is real and worth keeping, per #4043's own
+//!     suggested direction) any High/Critical finding whose text admits it is
+//!     reasoning about an implementation that is not present in the diff. This
+//!     structurally prevents it from ever driving BLOCK
+//!     (`grade::drives_block_floor` requires `Effort::High`), while leaving it
+//!     as an advisory note.
+//!
+//! Both passes run BEFORE `citation_check::enforce_citation_integrity` (see
+//! `runner.rs` / `mapreduce/mod.rs`) so a self-negated finding never
+//! participates in the mutual-contradiction check either.
+//!
+//! Test: `finding_hygiene_tests.rs`.
+
+use tracing::warn;
+
+use crate::models::{Effort, Finding, Verdict};
+
+/// Case-insensitive substrings that mean the finding's OWN text has already
+/// negated it, or leaked raw mid-reasoning deliberation (#4044).
+///
+/// Why: chosen from the VERBATIM closing lines and transition phrases #4044
+/// quotes (`"Withdrawing this finding — confidence too low."`, `"This is
+/// correctly implemented."`, `"Wait — actually looking at the code more
+/// carefully"`, `"On re-inspection this is actually correct"`) — each is a
+/// phrase a model uses specifically when narrating that IT no longer believes
+/// its own claim, or when the raw deliberation trace itself leaked into the
+/// field. Deliberately NOT single generic words ("correct", "issue") that
+/// would false-drop a legitimate finding describing correct behavior elsewhere
+/// in the same file.
+/// What: matched via `str::contains` after lowercasing both the marker and the
+/// finding's text (cheap, dependency-free, no regex needed for fixed
+/// substrings).
+/// Test: `drops_finding_containing_each_self_negation_marker`,
+/// `does_not_drop_legitimate_finding_using_the_word_correct`.
+const SELF_NEGATION_MARKERS: &[&str] = &[
+    "withdrawing",
+    "withdraw this finding",
+    "not a finding",
+    "no finding here",
+    "no actual bug",
+    "this is a non-issue",
+    "is correctly implemented",
+    "the code is correct",
+    "appears correct",
+    "actually correct",
+    "wait — actually",
+    "wait, actually",
+    "wait -- actually",
+    "actually looking at the code more carefully",
+    "on re-inspection",
+    "on second look, this is",
+    "let me re-check",
+    "let me reconsider",
+];
+
+/// Case-insensitive substrings meaning the finding's own text admits it is
+/// speculating about an implementation that is NOT present in the diff under
+/// review (#4043).
+///
+/// Why: chosen from the VERBATIM admissions #4043 quotes ("the diff contains
+/// only the spec document ... no implementation ... is present", "If
+/// implementation follows the interface literally", "An implementer following
+/// §5 literally would introduce", "this is a spec document (not yet
+/// implemented code)"). Each phrase is the model narrating the SAME
+/// stop-condition #4043 asks be enforced: when the implementation is not in
+/// the diff, reasoning about what it "would" do is speculation, not a code
+/// finding.
+/// What: matched via `str::contains` after lowercasing.
+/// Test: `demotes_finding_admitting_diff_absent_speculation`.
+const DIFF_ABSENT_SPECULATION_MARKERS: &[&str] = &[
+    "no implementation of",
+    "if implementation follows",
+    "if an implementer follows",
+    "an implementer following",
+    "not yet implemented",
+    "is a spec document",
+    "is not yet implemented code",
+];
+
+/// Run every output-hygiene pass over `findings`, in place.
+///
+/// Why: a single call site for both #4043 and #4044's fixes keeps `runner.rs`
+/// and `mapreduce/mod.rs` from having to know the internal pass ordering.
+/// What: drops self-negated/leaked findings FIRST (so they never participate
+/// in downstream checks — e.g. `citation_check`'s mutual-contradiction pass),
+/// then demotes any surviving diff-absent-speculation High finding. Returns
+/// `(dropped, demoted)`.
+/// Test: `sanitize_findings_runs_both_passes`.
+pub fn sanitize_findings(findings: &mut Vec<Finding>) -> (usize, usize) {
+    let dropped = drop_self_negated_or_leaked_findings(findings);
+    let demoted = demote_diff_absent_speculation(findings);
+    (dropped, demoted)
+}
+
+/// Drop any finding whose `kind`/`description`/`consequence` contains a
+/// self-negation or raw-deliberation marker (#4044).
+///
+/// Why: a finding that withdrew itself, or that leaked its own mid-reasoning
+/// trace, must never reach the rendered review or the verdict floor. Dropping
+/// the WHOLE finding (rather than truncating the text at the marker) is the
+/// structurally simple choice: it cannot leave a half-scrubbed remainder, and
+/// a finding contaminated enough to narrate its own uncertainty this openly is
+/// not reliable signal worth salvaging.
+/// What: case-insensitive substring match against [`SELF_NEGATION_MARKERS`]
+/// over `kind`, `description`, and `consequence`; a hit removes the finding
+/// from the `Vec` and logs the reason at `warn` (never surfaced to the
+/// rendered review — this IS the mechanism that keeps it from being surfaced).
+/// Test: `drops_finding_containing_each_self_negation_marker`,
+/// `does_not_drop_legitimate_finding_using_the_word_correct`.
+pub fn drop_self_negated_or_leaked_findings(findings: &mut Vec<Finding>) -> usize {
+    let mut dropped = 0usize;
+    let mut kept = Vec::with_capacity(findings.len());
+    for f in std::mem::take(findings) {
+        match matching_marker(&f, SELF_NEGATION_MARKERS) {
+            Some(marker) => {
+                warn!(
+                    file = %f.file,
+                    line = ?f.line,
+                    kind = %f.kind,
+                    marker,
+                    "finding-hygiene: dropping self-negated/CoT-leaking finding (#4044)"
+                );
+                dropped += 1;
+            }
+            None => kept.push(f),
+        }
+    }
+    *findings = kept;
+    dropped
+}
+
+/// Demote (never drop) any High/Critical finding admitting it reasons about an
+/// implementation absent from the diff (#4043).
+///
+/// Why: #4043's own suggested direction — "reclassify spec/code disagreement
+/// as documentation drift ... severity-floored and excluded from a BLOCK
+/// verdict" — asks for demotion, not deletion: the observation that a spec and
+/// the (absent) implementation disagree is real and useful, it is simply not a
+/// CODE finding. Capping `effort` at `Medium` structurally excludes it from
+/// `grade::drives_block_floor` (which requires `Effort::High`) without a
+/// second escalation-eligibility check.
+/// What: for each finding whose `description`/`consequence` matches
+/// [`DIFF_ABSENT_SPECULATION_MARKERS`] AND whose `effort` is `High`, sets
+/// `effort = Medium` and `code_provable = false` (a claim about an absent
+/// implementation cannot be "provable from the diff itself"). Findings already
+/// below `High` are left untouched — they cannot drive BLOCK regardless.
+/// Test: `demotes_finding_admitting_diff_absent_speculation`,
+/// `does_not_touch_medium_diff_absent_finding`.
+pub fn demote_diff_absent_speculation(findings: &mut [Finding]) -> usize {
+    let mut demoted = 0usize;
+    for f in findings.iter_mut() {
+        if f.effort != Effort::High {
+            continue;
+        }
+        if let Some(marker) = matching_marker(f, DIFF_ABSENT_SPECULATION_MARKERS) {
+            warn!(
+                file = %f.file,
+                line = ?f.line,
+                kind = %f.kind,
+                marker,
+                "finding-hygiene: demoting diff-absent speculation to advisory (#4043)"
+            );
+            f.effort = Effort::Medium;
+            f.code_provable = false;
+            demoted += 1;
+        }
+    }
+    demoted
+}
+
+/// Relax a self-reported `verdict`/`grade` to APPROVE when THIS run's hygiene +
+/// citation-integrity passes wiped out every finding that used to be present
+/// (#4042, #4044).
+///
+/// Why: `grade::derive_verdict` takes `stricter_of(model_proposed, floor)` —
+/// by design it can only RAISE a verdict via the floor, never lower the
+/// model's own raw self-reported `verdict`/`grade` JSON fields (that
+/// asymmetry is deliberate elsewhere — see `verify::rederive_verdict`'s
+/// path (c), which preserves a self-reported verdict across a verifier
+/// INFRASTRUCTURE failure, #726). Dropping fabricated/self-negated findings
+/// therefore closes the FLOOR half of "fabricated findings block clean PRs",
+/// but not the other half: the SAME hallucinating LLM call that invented the
+/// findings also wrote the top-level `verdict: "BLOCK"` / `grade: "F"`
+/// fields, and those are not automatically corrected by pruning the finding
+/// list underneath them.
+///
+/// This closes that gap WITHOUT touching `derive_verdict`'s shared,
+/// heavily-calibrated floor semantics (which every other caller —
+/// `verify::rederive_verdict`, `mapreduce::reduce`, the synthesis floor —
+/// continues to rely on unchanged): it is gated on a LOCALLY OBSERVED fact
+/// this run (findings went from non-empty to empty because OUR OWN passes
+/// just removed them), not on "findings happens to be empty" in general,
+/// so it can never fire on `verify::rederive_verdict`'s infra-failure path
+/// (a completely different call site, operating on already-hygiene-passed
+/// findings).
+/// What: when `findings_before > 0`, `findings.is_empty()`, and `verdict` is
+/// neither already `Approve` nor the terminal `Unknown`, resets `verdict` to
+/// `Approve` and `grade` to `None` (letting the caller's existing
+/// `default_grade_for_verdict` fallback recompute a grade consistent with
+/// APPROVE) and logs why. No-op otherwise.
+/// Test: `relaxes_verdict_when_all_findings_wiped_this_run`,
+/// `does_not_relax_when_findings_were_already_empty`,
+/// `does_not_relax_when_findings_survive`.
+pub fn relax_verdict_if_evidence_wiped(
+    verdict: &mut Verdict,
+    grade: &mut Option<String>,
+    findings_before: usize,
+    findings: &[Finding],
+) {
+    if findings_before == 0 || !findings.is_empty() {
+        return;
+    }
+    if *verdict == Verdict::Approve || *verdict == Verdict::Unknown {
+        return;
+    }
+    warn!(
+        prior_findings = findings_before,
+        verdict = %verdict,
+        "finding-hygiene: every finding was dropped this run — the model's own \
+         top-level verdict/grade rested on the same evidence and cannot be \
+         trusted either; relaxing to APPROVE (#4042, #4044)"
+    );
+    *verdict = Verdict::Approve;
+    *grade = None;
+}
+
+/// Return the first marker from `markers` found (case-insensitively) in
+/// `f.kind`, `f.description`, or `f.consequence`, if any.
+fn matching_marker(f: &Finding, markers: &[&'static str]) -> Option<&'static str> {
+    let haystack = format!("{} {} {}", f.kind, f.description, f.consequence).to_lowercase();
+    markers
+        .iter()
+        .find(|marker| haystack.contains(*marker))
+        .copied()
+}
+
+#[cfg(test)]
+#[path = "finding_hygiene_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/finding_hygiene_tests.rs
+++ b/crates/trusty-review/src/pipeline/finding_hygiene_tests.rs
@@ -1,0 +1,312 @@
+//! Unit tests for `finding_hygiene` (#4043, #4044), using verbatim (or
+//! near-verbatim, where the issue only quoted a fragment) text from the two
+//! issues so the fixtures are traceable back to the reported evidence.
+
+use super::*;
+use crate::models::Finding;
+
+fn finding(effort: Effort, description: &str) -> Finding {
+    Finding::new(
+        "src/app.ts",
+        "logic-error",
+        description,
+        "fix it",
+        0.8,
+        effort,
+    )
+}
+
+// ─── #4044 defect 1: self-withdrawn findings ──────────────────────────────────
+
+#[test]
+fn drops_finding_containing_each_self_negation_marker() {
+    // Verbatim closing lines from #4044's table (findings 22, 29, 30, 31, 32,
+    // 33, 34) plus review 2's finding 27.
+    let verbatim_closers = [
+        "This is correctly implemented.",
+        "This appears correct — noting it for completeness.",
+        "The code is correct.",
+        "No actual bug here — flagging as low confidence.",
+        "Withdrawing this finding — confidence too low.",
+        "This is a praise-worthy design decision, not a finding. Withdrawing.",
+        "This flow is actually correct. No finding here — the setAssembled(null) \
+         in toggleAffirmation handles it properly. Withdrawing this finding.",
+        "On re-inspection this is actually correct — both are cleared at the start. \
+         This is a non-issue.",
+    ];
+    for closer in verbatim_closers {
+        let mut findings = vec![finding(Effort::Medium, closer)];
+        let dropped = drop_self_negated_or_leaked_findings(&mut findings);
+        assert_eq!(dropped, 1, "must drop self-negated finding: {closer:?}");
+        assert!(findings.is_empty());
+    }
+}
+
+#[test]
+fn does_not_drop_legitimate_finding_using_the_word_correct() {
+    // A real finding may legitimately use "correct" in a non-self-negating way
+    // (e.g. contrasting correct vs. broken behavior) — must survive.
+    let mut findings = vec![finding(
+        Effort::High,
+        "The OLD validation path was correct, but this diff removes the null \
+         check that made it so, introducing a panic on empty input.",
+    )];
+    let dropped = drop_self_negated_or_leaked_findings(&mut findings);
+    assert_eq!(dropped, 0, "a legitimate finding must not be false-dropped");
+    assert_eq!(findings.len(), 1);
+}
+
+// ─── #4044 defect 2: chain-of-thought leak ────────────────────────────────────
+
+#[test]
+fn drops_finding_with_leaked_chain_of_thought() {
+    // Verbatim (abbreviated) from #4044's finding 32 — the full published body
+    // that begins with a fabricated ordering, then narrates a live correction.
+    let leaked = "In POST /api/admin/rounds/:roundId/voters, the JSON parse and Zod \
+        validation happen AFTER the MUTABLE_COHORT_STATUSES check. Wait — actually \
+        looking at the code more carefully, the order is different. So a request \
+        with a malformed body against a closed round returns 400. Withdrawing this \
+        finding — confidence too low.";
+    let mut findings = vec![finding(Effort::Medium, leaked)];
+    let dropped = drop_self_negated_or_leaked_findings(&mut findings);
+    assert_eq!(
+        dropped, 1,
+        "a finding leaking raw deliberation must be dropped"
+    );
+    assert!(findings.is_empty());
+}
+
+#[test]
+fn drops_finding_with_deliberation_marker_even_without_withdrawal() {
+    // The deliberation-leak markers alone (no explicit "withdrawing") must
+    // still trip the filter — CoT must never reach output regardless of
+    // whether the finding ultimately re-affirms itself.
+    let mut findings = vec![finding(
+        Effort::High,
+        "Wait — actually looking at the code more carefully, this does look like \
+         a real null-deref on line 42.",
+    )];
+    let dropped = drop_self_negated_or_leaked_findings(&mut findings);
+    assert_eq!(
+        dropped, 1,
+        "raw deliberation text must never reach user-visible output"
+    );
+}
+
+// ─── #4044: verdict excludes withdrawn findings (integration of the two fixes) ─
+
+#[test]
+fn sanitize_findings_removes_withdrawn_before_verdict_would_see_them() {
+    use crate::models::Verdict;
+    use crate::pipeline::grade::derive_verdict;
+
+    // 34-finding-shaped batch: 1 real BLOCK-driving finding + 3 self-withdrawn.
+    let mut findings = vec![
+        finding(
+            Effort::High,
+            "SQL injection: raw user input concatenated into query.",
+        ),
+        finding(
+            Effort::Medium,
+            "Withdrawing this finding — confidence too low.",
+        ),
+        finding(Effort::Medium, "The code is correct."),
+        finding(Effort::Low, "This is a non-issue."),
+    ];
+    // Give the real finding a citation so it clears the escalation gate.
+    findings[0].code_provable = true;
+
+    sanitize_findings(&mut findings);
+    assert_eq!(
+        findings.len(),
+        1,
+        "only the real finding must survive to reach the verdict floor"
+    );
+    let verdict = derive_verdict(Verdict::Block, &findings);
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "the real finding still drives BLOCK on its own merits"
+    );
+}
+
+#[test]
+fn sanitize_findings_floor_no_longer_counts_withdrawn_findings() {
+    use crate::models::Verdict;
+    use crate::pipeline::grade::derive_verdict;
+
+    // The literal #4044 crux: "findings that the reviewer itself has withdrawn
+    // ... are entering the aggregation at all." A self-withdrawn High finding
+    // must no longer be able to drive the deterministic BLOCK floor once
+    // `sanitize_findings` runs, even though the model's own top-line verdict
+    // (represented here by the `derive_verdict` seed) did not itself change.
+    let mut findings = vec![
+        finding(
+            Effort::High,
+            "Withdrawing this finding — confidence too low.",
+        ),
+        finding(Effort::Low, "Minor style nit."),
+    ];
+    findings[0].code_provable = true; // escalation-eligible — would drive BLOCK
+
+    let before = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        before,
+        Verdict::Block,
+        "precondition: the withdrawn-but-not-yet-sanitized High finding still \
+         forces the BLOCK floor"
+    );
+
+    sanitize_findings(&mut findings);
+    assert_eq!(findings.len(), 1, "only the real Low finding survives");
+
+    let after = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        after,
+        Verdict::Approve,
+        "a withdrawn finding must never drive the verdict floor"
+    );
+}
+
+// ─── #4043: spec reported as implementation ───────────────────────────────────
+
+#[test]
+fn demotes_finding_admitting_diff_absent_speculation() {
+    // Near-verbatim from #4043 review 2, finding 6.
+    let mut findings = vec![finding(
+        Effort::High,
+        "However, the diff contains only the spec document \
+         (docs/specs/admin-judging-api.md) and migrations — no implementation of \
+         src/lib/judging/aggregate.ts, src/lib/judging/z-score.ts, or any other \
+         scoring engine file is present. If implementation follows the interface \
+         literally, the COI filter for stack-rank picks will be absent.",
+    )];
+    findings[0].code_provable = true;
+
+    let demoted = demote_diff_absent_speculation(&mut findings);
+    assert_eq!(demoted, 1);
+    assert_eq!(findings[0].effort, Effort::Medium);
+    assert!(
+        !findings[0].code_provable,
+        "a claim about an absent implementation cannot be diff-provable"
+    );
+    assert!(
+        !crate::pipeline::grade::drives_block_floor(&findings[0]),
+        "demoted finding must never drive the BLOCK floor"
+    );
+}
+
+#[test]
+fn demotes_finding_admitting_spec_document_not_implemented() {
+    // Near-verbatim from #4043 review 1, finding 7.
+    let mut findings = vec![finding(
+        Effort::High,
+        "Since this is a spec document (not yet implemented code), the consequence \
+         is that an implementer following §5 literally would introduce the \
+         denial-of-service bug the spec's §2 section explicitly analyzed and \
+         rejected.",
+    )];
+    let demoted = demote_diff_absent_speculation(&mut findings);
+    assert_eq!(demoted, 1);
+    assert_eq!(findings[0].effort, Effort::Medium);
+}
+
+#[test]
+fn does_not_touch_medium_diff_absent_finding() {
+    // Already below High — cannot drive BLOCK regardless; must be left alone
+    // (no spurious mutation of a finding the floor already treats safely).
+    let mut findings = vec![finding(
+        Effort::Medium,
+        "If implementation follows the interface literally, a field would be missing.",
+    )];
+    let demoted = demote_diff_absent_speculation(&mut findings);
+    assert_eq!(demoted, 0);
+    assert_eq!(findings[0].effort, Effort::Medium);
+}
+
+#[test]
+fn does_not_demote_legitimate_implementation_grounded_finding() {
+    // A real, diff-grounded High finding with no diff-absent admission must
+    // survive completely untouched.
+    let mut findings = vec![finding(
+        Effort::High,
+        "The diff removes the null check before dereferencing `user.profile`, \
+         a real null-deref provable from the code under review.",
+    )];
+    findings[0].code_provable = true;
+    let demoted = demote_diff_absent_speculation(&mut findings);
+    assert_eq!(demoted, 0);
+    assert_eq!(findings[0].effort, Effort::High);
+    assert!(findings[0].code_provable);
+}
+
+// ─── Orchestration ─────────────────────────────────────────────────────────────
+
+#[test]
+fn sanitize_findings_runs_both_passes() {
+    let mut findings = vec![
+        finding(
+            Effort::Medium,
+            "Withdrawing this finding — confidence too low.",
+        ),
+        finding(
+            Effort::High,
+            "If implementation follows the interface literally, this breaks.",
+        ),
+        finding(Effort::High, "Real SQL injection provable from the diff."),
+    ];
+    let (dropped, demoted) = sanitize_findings(&mut findings);
+    assert_eq!(dropped, 1);
+    assert_eq!(demoted, 1);
+    assert_eq!(findings.len(), 2);
+    assert_eq!(findings[0].effort, Effort::Medium, "demoted, not dropped");
+    assert_eq!(findings[1].effort, Effort::High, "untouched real finding");
+}
+
+// ─── relax_verdict_if_evidence_wiped (#4042, #4044) ───────────────────────────
+
+#[test]
+fn relaxes_verdict_when_all_findings_wiped_this_run() {
+    // The full end-to-end guarantee: a model that self-reported BLOCK on the
+    // strength of findings we then wiped out entirely (fabricated + withdrawn)
+    // must have its OWN raw verdict/grade relaxed too — not just the floor.
+    let mut verdict = Verdict::Block;
+    let mut grade = Some("F".to_string());
+    relax_verdict_if_evidence_wiped(&mut verdict, &mut grade, 3, &[]);
+    assert_eq!(verdict, Verdict::Approve);
+    assert_eq!(grade, None);
+}
+
+#[test]
+fn does_not_relax_when_findings_were_already_empty() {
+    // `findings_before == 0` means there was never any evidence to begin with
+    // (a clean APPROVE with no findings, or a genuinely finding-free BLOCK from
+    // some other signal) — this is NOT the "we just wiped the evidence" case
+    // and must be left alone.
+    let mut verdict = Verdict::Block;
+    let mut grade = Some("F".to_string());
+    relax_verdict_if_evidence_wiped(&mut verdict, &mut grade, 0, &[]);
+    assert_eq!(verdict, Verdict::Block, "not our call to relax this one");
+}
+
+#[test]
+fn does_not_relax_when_findings_survive() {
+    let survivor = finding(Effort::High, "Real SQL injection provable from the diff.");
+    let mut verdict = Verdict::Block;
+    let mut grade = Some("F".to_string());
+    relax_verdict_if_evidence_wiped(&mut verdict, &mut grade, 2, std::slice::from_ref(&survivor));
+    assert_eq!(
+        verdict,
+        Verdict::Block,
+        "real surviving evidence still backs BLOCK"
+    );
+}
+
+#[test]
+fn does_not_touch_an_already_approve_verdict() {
+    let mut verdict = Verdict::Approve;
+    let mut grade = Some("A-".to_string());
+    relax_verdict_if_evidence_wiped(&mut verdict, &mut grade, 2, &[]);
+    assert_eq!(verdict, Verdict::Approve);
+    assert_eq!(grade.as_deref(), Some("A-"), "no-op — nothing to relax");
+}

--- a/crates/trusty-review/src/pipeline/mapreduce/mod.rs
+++ b/crates/trusty-review/src/pipeline/mapreduce/mod.rs
@@ -77,16 +77,33 @@ pub async fn run_map_reduce(
     );
     let mut outcomes = run_map_stage(&units, llm, ctx, config.concurrency).await;
 
-    // Verify diff-provable citations BEFORE reduce derives the aggregate verdict
-    // (#2881): a per-unit reviewer can confabulate a `code_provable: true` finding
-    // whose cited content is not in the file it reviewed (the repro attributed a
-    // new test file's content to a large regenerated bundle).  Downgrade any such
-    // finding against the whole filtered diff so it can never force the deterministic
-    // BLOCK / REQUEST_CHANGES floor in `reduce`/`synthesize`.
+    // Sanitize + verify citation integrity BEFORE reduce derives the aggregate
+    // verdict (#2881, #4042, #4044): a per-unit reviewer can self-negate a
+    // finding in its own text, leak raw deliberation, or confabulate a
+    // `code_provable: true` finding whose cited content is not in the file it
+    // reviewed. Drop any such finding against the whole filtered diff so it can
+    // never force the deterministic BLOCK / REQUEST_CHANGES floor in
+    // `reduce`/`synthesize`, nor reach the rendered review.
     let cite_index = crate::pipeline::citation_check::DiffContentIndex::from_filtered(filtered);
     for outcome in &mut outcomes {
-        if let MapOutcome::Reviewed { findings, .. } = outcome {
-            crate::pipeline::citation_check::downgrade_uncitable_findings(findings, &cite_index);
+        if let MapOutcome::Reviewed {
+            findings, verdict, ..
+        } = outcome
+        {
+            let findings_before = findings.len();
+            crate::pipeline::finding_hygiene::sanitize_findings(findings);
+            crate::pipeline::citation_check::enforce_citation_integrity(findings, &cite_index);
+            // This chunk's own `verdict` field rested on the SAME findings we
+            // may have just wiped out — relax it too so a wiped-out chunk
+            // cannot poison `reduce`'s stricter-of-all-chunks seed (#4042,
+            // #4044).
+            let mut grade_unused = None;
+            crate::pipeline::finding_hygiene::relax_verdict_if_evidence_wiped(
+                verdict,
+                &mut grade_unused,
+                findings_before,
+                findings,
+            );
         }
     }
 

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -28,6 +28,11 @@ pub mod citation_check;
 pub mod context_gate;
 pub mod diff;
 pub mod diff_analyzer;
+// Why: output-hygiene filters (self-negation / chain-of-thought-leak drop,
+// diff-absent-speculation demotion) closing #4043/#4044 — kept separate from
+// `citation_check` (path/content verification, #4042) since the two concerns
+// have independent marker sets and independent test surfaces.
+pub mod finding_hygiene;
 pub mod grade;
 // Why: reconciles the grade embedded in the raw `review_body` JSON with the
 // authoritative top-level grade so the two can never disagree (issue #1886).

--- a/crates/trusty-review/src/pipeline/parser.rs
+++ b/crates/trusty-review/src/pipeline/parser.rs
@@ -343,7 +343,7 @@ fn convert_llm_finding(f: LlmFinding) -> Finding {
         _ => Effort::Low,
     };
     let file = if f.file.is_empty() {
-        "unknown".to_string()
+        crate::models::UNKNOWN_FILE_PLACEHOLDER.to_string()
     } else {
         f.file
     };

--- a/crates/trusty-review/src/pipeline/runner.rs
+++ b/crates/trusty-review/src/pipeline/runner.rs
@@ -540,15 +540,31 @@ pub async fn run_review(
         );
     }
 
-    // ── Step 7-cite: verify diff-provable citations BEFORE grading (#2881) ─
-    // A confabulated `code_provable: true` finding drives the deterministic BLOCK
-    // floor at face value; verify each such finding's cited content against the
-    // actual (filtered) diff and downgrade any that is not grounded in the cited
-    // file, so a fabricated finding can never fail-close a clean PR.
+    // ── Step 7-hyg: drop self-negated / CoT-leaking findings (#4044) ───────
+    // A finding that withdraws itself in its own text, or leaks raw mid-
+    // reasoning deliberation, must never reach the rendered review or the
+    // verdict floor — see `finding_hygiene` module doc.
+    let findings_before_hygiene = parsed.findings.len();
+    crate::pipeline::finding_hygiene::sanitize_findings(&mut parsed.findings);
+
+    // ── Step 7-cite: enforce citation integrity BEFORE grading (#2881, #4042) ─
+    // Every finding's cited path (and, where quoted, content) must verifiably
+    // exist in the diff; a finding that fails is DROPPED (never downgraded-but-
+    // kept) so a fabrication can never fail-close a clean PR nor survive into
+    // the rendered review.
     let cite_index = crate::pipeline::citation_check::DiffContentIndex::from_filtered(&filtered);
-    crate::pipeline::citation_check::downgrade_uncitable_findings(
-        &mut parsed.findings,
-        &cite_index,
+    crate::pipeline::citation_check::enforce_citation_integrity(&mut parsed.findings, &cite_index);
+
+    // ── Step 7-relax: the model's own raw verdict/grade rested on the SAME
+    // findings we may have just wiped out entirely — relax it too (#4042,
+    // #4044). See `finding_hygiene::relax_verdict_if_evidence_wiped` doc for
+    // why this is safe and does not touch `derive_verdict`'s shared floor
+    // semantics.
+    crate::pipeline::finding_hygiene::relax_verdict_if_evidence_wiped(
+        &mut parsed.verdict,
+        &mut parsed.grade,
+        findings_before_hygiene,
+        &parsed.findings,
     );
 
     // ── Step 7b–7e: grade derivation, coverage floor, verification, reconcile ─

--- a/crates/trusty-review/src/pipeline/runner_tests.rs
+++ b/crates/trusty-review/src/pipeline/runner_tests.rs
@@ -300,6 +300,28 @@ fn local_diff_source(diff: &str) -> (DiffSource, tempfile::NamedTempFile) {
     (DiffSource::LocalFile { path }, tmp)
 }
 
+/// Build a local-diff source as a PROPER unified diff (with a `+++ b/<file>`
+/// header) whose path matches a `FakeLlm` fixture's finding `file` (#4042).
+///
+/// Why: `citation_check::enforce_citation_integrity` now requires every
+/// finding's `file` to resolve against the diff actually under review — a
+/// bare `"+<line>\n"` fragment with no `diff --git`/`+++ b/` header (what
+/// `local_diff_source` alone produces) contains no file path at all, so a
+/// fixture finding citing e.g. `"file":"src/a.rs"` would be (correctly)
+/// dropped as unresolvable. Tests that exist to exercise VERIFICATION-ROUND /
+/// grade-envelope plumbing — not citation checking — need a diff whose file
+/// path actually matches the fixture finding so that unrelated machinery
+/// keeps working.
+fn local_diff_source_for_file(
+    file: &str,
+    added_line: &str,
+) -> (DiffSource, tempfile::NamedTempFile) {
+    let diff = format!(
+        "diff --git a/{file} b/{file}\nindex 0000000..1111111 100644\n--- a/{file}\n+++ b/{file}\n@@ -1 +1 @@\n{added_line}\n"
+    );
+    local_diff_source(&diff)
+}
+
 // ── Helper to build a two-commit git repo for GitRange tests (#2993) ───
 
 /// Build a tiny git repo in a tempdir with two commits, returning the dir and
@@ -386,8 +408,9 @@ async fn run_review_with_fake_provider_approves() {
 
 #[tokio::test]
 async fn run_review_request_changes_parsed_correctly() {
-    let (source, _tmp) = local_diff_source(
-        "+fn bad_query(id: &str) { db.exec(format!(\"SELECT * FROM users WHERE id={id}\")) }\n",
+    let (source, _tmp) = local_diff_source_for_file(
+        "src/a.rs",
+        "+fn bad_query(id: &str) { db.exec(format!(\"SELECT * FROM users WHERE id={id}\")) }",
     );
     let config = default_config();
     let input = ReviewInput {
@@ -1474,7 +1497,7 @@ async fn run_review_writes_dry_run_log_on_log_only_path() {
 /// verdict (Phase 2, #583 deliverable 2/3).
 #[tokio::test]
 async fn run_review_verification_refutes_and_relaxes_verdict() {
-    let (source, _tmp) = local_diff_source("+fn bad() {}\n");
+    let (source, _tmp) = local_diff_source_for_file("src/a.rs", "+fn bad() {}");
     let config = default_config();
     let input = ReviewInput {
         diff_source: source,
@@ -1521,7 +1544,7 @@ async fn run_review_verification_refutes_and_relaxes_verdict() {
 /// (a confirmed, well-evidenced finding must not be silently softened).
 #[tokio::test]
 async fn run_review_verification_confirms_and_preserves_verdict() {
-    let (source, _tmp) = local_diff_source("+fn bad() {}\n");
+    let (source, _tmp) = local_diff_source_for_file("src/a.rs", "+fn bad() {}");
     let config = default_config();
     let input = ReviewInput {
         diff_source: source,
@@ -1557,7 +1580,7 @@ async fn run_review_verification_confirms_and_preserves_verdict() {
 /// the verdict is the un-verified grade.
 #[tokio::test]
 async fn run_review_verification_disabled_skips_round() {
-    let (source, _tmp) = local_diff_source("+fn bad() {}\n");
+    let (source, _tmp) = local_diff_source_for_file("src/a.rs", "+fn bad() {}");
     let mut config = default_config();
     config.verification.enabled = false; // disable the round
     let input = ReviewInput {
@@ -1629,7 +1652,10 @@ async fn envelope_grade_tracks_verdict_after_verification_relaxation_1486() {
 ```json
 {"verdict":"APPROVE","grade":"B-","summary":"Looks solid","findings":[{"title":"Potential XSS","body":"line 5 unescaped","severity":"high","confidence":0.95,"file":"src/render.rs","line":5}]}
 ```"#;
-    let (source, _tmp) = local_diff_source("+fn render(s: &str) { println!(\"{s}\"); }\n");
+    let (source, _tmp) = local_diff_source_for_file(
+        "src/render.rs",
+        "+fn render(s: &str) { println!(\"{s}\"); }",
+    );
     let config = default_config();
     let input = ReviewInput {
         diff_source: source,
@@ -1698,7 +1724,7 @@ async fn envelope_grade_stays_block_when_high_effort_confirmed_1486() {
 ```json
 {"verdict":"APPROVE","grade":"B-","summary":"Mostly OK","findings":[{"title":"Auth bypass","body":"line 10","severity":"high","confidence":0.95,"file":"src/auth.rs","line":10,"code_provable":true}]}
 ```"#;
-    let (source, _tmp) = local_diff_source("+fn auth(t: &str) {}\n");
+    let (source, _tmp) = local_diff_source_for_file("src/auth.rs", "+fn auth(t: &str) {}");
     let config = default_config();
     let input = ReviewInput {
         diff_source: source,

--- a/crates/trusty-review/tests/citation_2881_regression.rs
+++ b/crates/trusty-review/tests/citation_2881_regression.rs
@@ -7,13 +7,14 @@
 //!      correct file through the full parse → filter → split pipeline; no file's
 //!      content leaks into another file's map unit.
 //!  (b) CITATION VERIFICATION — a confabulated `code_provable` finding that cites
-//!      one file but quotes content from another is downgraded before the verdict
+//!      one file but quotes content from another is DROPPED before the verdict
 //!      floor runs, so it can no longer fail-close a clean PR (the exact #2881
-//!      D+/REQUEST_CHANGES symptom).
+//!      D+/REQUEST_CHANGES symptom) — as of #4042 this is a drop, not a
+//!      downgrade-in-place: the fabricated finding does not survive at all.
 
 use trusty_review::config::mapreduce::MapReduceConfig;
 use trusty_review::models::{Effort, Finding, Verdict};
-use trusty_review::pipeline::citation_check::{DiffContentIndex, downgrade_uncitable_findings};
+use trusty_review::pipeline::citation_check::{DiffContentIndex, enforce_citation_integrity};
 use trusty_review::pipeline::derive_verdict;
 use trusty_review::pipeline::diff_analyzer::DiffAnalyzer;
 use trusty_review::pipeline::mapreduce::MapOutcome;
@@ -123,7 +124,7 @@ fn fabricated_finding() -> Finding {
 }
 
 /// (b) BEFORE the fix the fabricated finding drives BLOCK; AFTER citation
-/// verification it is downgraded and the verdict recovers to APPROVE.
+/// verification it is DROPPED and the verdict recovers to APPROVE.
 #[tokio::test]
 async fn repro_fabricated_finding_no_longer_forces_block() {
     let diff = repro_diff();
@@ -141,17 +142,25 @@ async fn repro_fabricated_finding_no_longer_forces_block() {
 
     // AFTER: verify citations, then re-derive.
     let mut findings = vec![fabricated_finding()];
-    let n = downgrade_uncitable_findings(&mut findings, &index);
-    assert_eq!(n, 1, "the misattributed finding must be downgraded");
-    assert!(!findings[0].code_provable, "code_provable must be cleared");
-    // The finding is still surfaced (advisory) — downgraded, not dropped.
-    assert_eq!(findings.len(), 1);
+    let n = enforce_citation_integrity(&mut findings, &index);
+    assert_eq!(n, 1, "the misattributed finding must be dropped");
+    // #4042: dropped, not downgraded-in-place — it does not survive at all.
+    assert!(findings.is_empty());
 
-    let after = derive_verdict(Verdict::RequestChanges, &findings);
+    // The FLOOR component (what a fabricated finding could hijack) no longer
+    // escalates — seeded with APPROVE here to isolate exactly that guarantee.
+    // (The model's own raw self-reported REQUEST_CHANGES/BLOCK, produced by
+    // the SAME hallucinating call, is a separate signal `derive_verdict`
+    // deliberately treats as a floor it can only raise, never lower — see
+    // `grade::derive_verdict_with`'s doc; the full pipeline additionally
+    // relaxes THAT via `finding_hygiene::relax_verdict_if_evidence_wiped`,
+    // covered by `citation_4042_regression.rs` /
+    // `finding_hygiene_tests.rs::relaxes_verdict_when_all_findings_wiped_this_run`.)
+    let after = derive_verdict(Verdict::Approve, &findings);
     assert_eq!(
         after,
         Verdict::Approve,
-        "downgraded finding must not force any floor"
+        "a dropped finding must not force any floor"
     );
 }
 
@@ -165,15 +174,33 @@ async fn repro_reduce_recovers_after_downgrade() {
     let index = DiffContentIndex::from_filtered(&filtered);
     let cfg = MapReduceConfig::default();
 
+    let findings_before = 1;
     let mut findings = vec![fabricated_finding()];
-    downgrade_uncitable_findings(&mut findings, &index);
+    enforce_citation_integrity(&mut findings, &index);
 
-    // The bundle chunk's model verdict was REQUEST_CHANGES (driven by the finding);
-    // the two source chunks were clean APPROVE.
+    // The bundle chunk's model verdict was REQUEST_CHANGES (driven by the
+    // finding) — mirror production's `run_map_reduce` wiring, which relaxes a
+    // per-chunk verdict that rested entirely on findings this run just wiped
+    // out (`finding_hygiene::relax_verdict_if_evidence_wiped`, #4042, #4044).
+    let mut chunk_verdict = Verdict::RequestChanges;
+    let mut chunk_grade = None;
+    trusty_review::pipeline::finding_hygiene::relax_verdict_if_evidence_wiped(
+        &mut chunk_verdict,
+        &mut chunk_grade,
+        findings_before,
+        &findings,
+    );
+    assert_eq!(
+        chunk_verdict,
+        Verdict::Approve,
+        "the chunk's own verdict must relax once its only finding is dropped"
+    );
+
+    // The two source chunks were clean APPROVE.
     let outcomes = vec![
         MapOutcome::Reviewed {
             file: "api/chat.js".to_string(),
-            verdict: Verdict::RequestChanges,
+            verdict: chunk_verdict,
             findings,
             tokens: TokenUsage::default(),
         },
@@ -195,12 +222,10 @@ async fn repro_reduce_recovers_after_downgrade() {
     assert_eq!(
         reduced.verdict,
         Verdict::Approve,
-        "a clean PR must not be fail-closed by a downgraded confabulation"
+        "a clean PR must not be fail-closed by a dropped confabulation"
     );
-    assert_eq!(
-        reduced.findings.len(),
-        1,
-        "the finding is retained as advisory"
+    assert!(
+        reduced.findings.is_empty(),
+        "#4042: the fabricated finding is dropped, not retained as advisory"
     );
-    assert!(!reduced.findings[0].code_provable);
 }

--- a/crates/trusty-review/tests/citation_4042_regression.rs
+++ b/crates/trusty-review/tests/citation_4042_regression.rs
@@ -1,0 +1,252 @@
+//! Regression tests for #4042: fabricated findings from diff-path
+//! misattribution returned on trusty-review 0.10.1 (regression of #2881 /
+//! #2882).
+//!
+//! The fixture reproduces the issue's "centerpiece" shape as closely as
+//! possible without access to the reporter's private repo (`duettoresearch/
+//! code-intelligence`, not reachable from this environment): a real TS module
+//! (`src/lib/team-registration-early-access.ts`) diffed ALONGSIDE a Drizzle
+//! JSON snapshot and a Vitest test file — the exact "adjacent `.json` /
+//! `.test.ts`" shape #4042 itself suggests as the reproducing case — plus the
+//! VERBATIM finding text quoted in the issue (findings 1, 2, 3, and 33).
+//!
+//! Two things are locked in:
+//!  (a) each of the fabricated findings (verbatim from #4042) is dropped —
+//!      never downgraded-but-kept, never emitted;
+//!  (b) a LEGITIMATE finding that correctly quotes the real file survives
+//!      unchanged, proving the fix does not suppress real findings alongside
+//!      invented ones.
+
+use trusty_review::models::{Effort, Finding, Verdict};
+use trusty_review::pipeline::citation_check::{DiffContentIndex, enforce_citation_integrity};
+use trusty_review::pipeline::derive_verdict;
+use trusty_review::pipeline::diff_analyzer::DiffAnalyzer;
+
+/// The real content of `src/lib/team-registration-early-access.ts` (ground
+/// truth per #4042: "an ordinary TypeScript module that exports exactly the
+/// function finding #4 says is missing: `isTeamRegistrationOpenFor`").
+const REAL_MODULE: &str =
+    "export function isTeamRegistrationOpenFor(round) {\n  return round.status === 'open';\n}\n";
+
+/// Build a multi-file diff: the real module, adjacent to a Drizzle JSON
+/// snapshot and a Vitest test file — the shape #4042 itself suggests as the
+/// reproducing case for diff-hunk-to-path misattribution.
+fn repro_diff() -> String {
+    let mut d = String::new();
+
+    d.push_str("diff --git a/src/lib/team-registration-early-access.ts b/src/lib/team-registration-early-access.ts\n");
+    d.push_str("new file mode 100644\nindex 0000000..1111111\n");
+    d.push_str("--- /dev/null\n+++ b/src/lib/team-registration-early-access.ts\n");
+    d.push_str("@@ -0,0 +1,3 @@\n");
+    for line in REAL_MODULE.lines() {
+        d.push('+');
+        d.push_str(line);
+        d.push('\n');
+    }
+
+    d.push_str("diff --git a/drizzle/meta/0007_snapshot.json b/drizzle/meta/0007_snapshot.json\n");
+    d.push_str("new file mode 100644\nindex 0000000..2222222\n");
+    d.push_str("--- /dev/null\n+++ b/drizzle/meta/0007_snapshot.json\n");
+    d.push_str("@@ -0,0 +1,1 @@\n");
+    d.push_str("+{ \"id\": \"893644d4-aaaa-bbbb-cccc-000000000000\", \"tables\": {} }\n");
+
+    d.push_str("diff --git a/src/lib/draft-form.test.ts b/src/lib/draft-form.test.ts\n");
+    d.push_str("new file mode 100644\nindex 0000000..3333333\n");
+    d.push_str("--- /dev/null\n+++ b/src/lib/draft-form.test.ts\n");
+    d.push_str("@@ -0,0 +1,2 @@\n");
+    d.push_str("+import { describe, expect, it } from 'vitest';\n");
+    d.push_str("+describe('draft-form', () => {});\n");
+
+    d
+}
+
+/// Finding 1 (verbatim from #4042): claims the real module is a Drizzle JSON
+/// snapshot, quoting `drizzle/meta/0007_snapshot.json`'s content as if it were
+/// `team-registration-early-access.ts`'s own content.
+fn fabricated_finding_1() -> Finding {
+    let mut f = Finding::new(
+        "src/lib/team-registration-early-access.ts",
+        "logic-error",
+        "The first file in the diff is team-registration-early-access.ts but \
+         its entire content is a Drizzle ORM JSON snapshot (a drizzle/meta/ artifact). \
+         [code: `src/lib/team-registration-early-access.ts:1` — \"id: 893644d4 fabricated snapshot content\"].",
+        "The module never provides isTeamRegistrationOpenFor, breaking every caller.",
+        0.8,
+        Effort::High,
+    );
+    f.line = Some(1);
+    f.code_provable = true;
+    f
+}
+
+/// Finding 2 (verbatim from #4042): claims the real module is a Vitest suite
+/// for `draft-form.ts`, quoting the ADJACENT test file's import line.
+fn fabricated_finding_2() -> Finding {
+    let mut f = Finding::new(
+        "src/lib/team-registration-early-access.ts",
+        "logic-error",
+        "The file team-registration-early-access.ts is named and pathed as if \
+         it were a library module, but its content is entirely a Vitest test suite \
+         (describe/it/expect) for draft-form.ts. \
+         [code: `src/lib/team-registration-early-access.ts:1` — \"import { describe, expect, it } from 'vitest'\"].",
+        "No isTeamRegistrationOpenFor export exists; the build fails.",
+        0.8,
+        Effort::High,
+    );
+    f.line = Some(1);
+    f.code_provable = true;
+    f
+}
+
+/// Finding 33 (verbatim shape from #4042): a SHORT, sub-`MIN_SPAN_LEN` quote
+/// ("publishedAt", 11 chars) that individual content-verification alone
+/// fails-open on — this is the finding the mutual-contradiction backstop is
+/// for, since it shares `src/lib/team-registration-early-access.ts:1` with
+/// findings 1 and 2 above.
+fn fabricated_finding_33() -> Finding {
+    let mut f = Finding::new(
+        "src/lib/team-registration-early-access.ts",
+        "logic-error",
+        "In `team-registration-early-access.ts` (the override route), the new row \
+         inherits `publishedAt` from the superseded row. \
+         [code: `src/lib/team-registration-early-access.ts:1` — \"override route handler entrypoint\"].",
+        "Stale publishedAt values leak into new rows.",
+        0.7,
+        Effort::Medium,
+    );
+    f.line = Some(1);
+    f
+}
+
+/// A LEGITIMATE finding, correctly grounded in the real module's own content —
+/// must survive the fix unchanged.
+fn legitimate_finding() -> Finding {
+    let mut f = Finding::new(
+        "src/lib/team-registration-early-access.ts",
+        "logic-error",
+        "isTeamRegistrationOpenFor compares `round.status === 'open'` with no null guard \
+         [code: `src/lib/team-registration-early-access.ts:2` — \"round.status === 'open'\"].",
+        "Throws if round is null.",
+        0.85,
+        Effort::High,
+    );
+    f.line = Some(2);
+    f.code_provable = true;
+    f
+}
+
+/// (a)+(b): after citation-integrity enforcement, all three fabricated
+/// findings are dropped and the legitimate finding survives untouched.
+#[tokio::test]
+async fn fabricated_centerpiece_findings_are_dropped_legit_finding_survives() {
+    let diff = repro_diff();
+    let filtered = DiffAnalyzer::default().analyze(&diff).await;
+    let index = DiffContentIndex::from_filtered(&filtered);
+
+    let mut findings = vec![
+        fabricated_finding_1(),
+        fabricated_finding_2(),
+        fabricated_finding_33(),
+        legitimate_finding(),
+    ];
+    let before_verdict = derive_verdict(Verdict::Block, &findings);
+    assert_eq!(
+        before_verdict,
+        Verdict::Block,
+        "precondition: the fabricated Highs force BLOCK before enforcement"
+    );
+
+    let dropped = enforce_citation_integrity(&mut findings, &index);
+    assert_eq!(
+        dropped, 3,
+        "all three fabricated findings must be dropped: {findings:#?}"
+    );
+    assert_eq!(findings.len(), 1, "only the legitimate finding survives");
+    assert_eq!(
+        findings[0].description,
+        legitimate_finding().description,
+        "the surviving finding must be the legitimate one, verbatim"
+    );
+
+    // The verdict now reflects only the legitimate (still-High, still-grounded)
+    // finding — BLOCK survives because it is a REAL grounded citation, not
+    // because fabrications forced it.
+    let after_verdict = derive_verdict(Verdict::Approve, &findings);
+    assert_eq!(
+        after_verdict,
+        Verdict::Block,
+        "the legitimate high-severity finding must still drive its own floor"
+    );
+}
+
+/// End-to-end: when EVERY finding in a review is fabricated (no legitimate
+/// finding at all — the worst case), the model's own self-reported BLOCK must
+/// ALSO relax, not just the deterministic floor (#4042, #4044). This is the
+/// literal "fabricated findings block clean PRs" symptom #4042 reports.
+#[tokio::test]
+async fn fully_fabricated_review_relaxes_the_top_level_verdict_too() {
+    use trusty_review::pipeline::finding_hygiene::relax_verdict_if_evidence_wiped;
+
+    let diff = repro_diff();
+    let filtered = DiffAnalyzer::default().analyze(&diff).await;
+    let index = DiffContentIndex::from_filtered(&filtered);
+
+    let mut findings = vec![
+        fabricated_finding_1(),
+        fabricated_finding_2(),
+        fabricated_finding_33(),
+    ];
+    let findings_before = findings.len();
+
+    // The model itself (having believed its own fabrications) self-reported
+    // BLOCK/F — this is the raw top-level field, not derived from the floor.
+    let mut model_verdict = Verdict::Block;
+    let mut model_grade = Some("F".to_string());
+
+    let dropped = enforce_citation_integrity(&mut findings, &index);
+    assert_eq!(dropped, 3, "every fabricated finding must be dropped");
+    assert!(findings.is_empty());
+
+    relax_verdict_if_evidence_wiped(
+        &mut model_verdict,
+        &mut model_grade,
+        findings_before,
+        &findings,
+    );
+    assert_eq!(
+        model_verdict,
+        Verdict::Approve,
+        "the model's own raw BLOCK must relax once every supporting finding is gone"
+    );
+    assert_eq!(model_grade, None);
+
+    // And the floor agrees.
+    let final_verdict = derive_verdict(model_verdict, &findings);
+    assert_eq!(final_verdict, Verdict::Approve);
+}
+
+/// The independent #4042 incident: a finding citing a path/line that was
+/// NEVER part of the diff at all (`hotelPage.ts:207`, no relationship to this
+/// diff) must be dropped as unresolvable, not fail-open.
+#[tokio::test]
+async fn citation_to_a_path_outside_the_diff_is_dropped() {
+    let diff = repro_diff();
+    let filtered = DiffAnalyzer::default().analyze(&diff).await;
+    let index = DiffContentIndex::from_filtered(&filtered);
+
+    let mut f = Finding::new(
+        "hotelPage.ts",
+        "logic-error",
+        "Promise.race never resolves because the loser promise is never cancelled.",
+        "hangs forever",
+        0.7,
+        Effort::High,
+    );
+    f.line = Some(207);
+    f.code_provable = true;
+    let mut findings = vec![f];
+
+    let dropped = enforce_citation_integrity(&mut findings, &index);
+    assert_eq!(dropped, 1, "an out-of-diff citation must be dropped");
+    assert!(findings.is_empty());
+}


### PR DESCRIPTION
## Summary

Fixes the trusty-review reliability cluster: three P1/P2 bugs in the review
GATE itself emitting claims it cannot support.

Closes #4042, #4043, #4044.

## Root cause: related but NOT one shared code defect

All three are failures of the same underlying *property* — every emitted
finding must cite a path (and, where quoted, content) that verifiably exists
— but the mechanisms are genuinely different:

- **#4042 (citation fabrication):** the #2882 fix scoped verification to
  `code_provable`/`code:`-cited findings, and — the load-bearing gap —
  **exempted the mandated `[code: \`path:line\` — "excerpt"]` citation's own
  excerpt** from verification (assumed to always be a paraphrase). #4042's
  evidence shows the model routinely puts verbatim, fabricated "evidence"
  exactly there.
- **#4044 (unsound verdict + CoT leak):** an aggregation/output-hygiene gap —
  self-withdrawn findings ("Withdrawing this finding…") and raw deliberation
  text ("Wait — actually looking at the code more carefully…") were never
  filtered before counting toward the grade or reaching rendered output.
- **#4043 (spec-as-implementation):** a provenance gap — findings grounded in
  a spec/doc artifact were emitted as claims about shipped code, with no
  distinction carried downstream.

Each needed a different mechanism; fixing #4042's citation-check alone would
not have caught #4043 or #4044, and vice versa.

## Fix shape — drop, not downgrade (Bob's simplify mandate)

Per the explicit instruction to prefer removing the code path that lets an
unverifiable finding get emitted over adding another verification layer on
top:

- **`citation_check::enforce_citation_integrity`** (was
  `downgrade_uncitable_findings`) now **drops** (never downgrades-in-place):
  - every finding's `file` must resolve in the diff (Kept, SummaryOnly, AND
    Stage-A-dropped files are now all indexed — dropped files with empty
    content, so citing them is legal but quoting fabricated content for them
    is not);
  - the mandated `[code: …]` citation's own excerpt is now verified against
    its own cited path (previously the one thing exempted);
  - a same-file/same-line mutual-contradiction backstop: if two findings
    assert incompatible content at the exact same locator, both are dropped
    (scoped to same-line specifically — two real findings about *different*
    lines of one file are normal and must never be flagged).
- **New `finding_hygiene` module** (#4043, #4044):
  - `drop_self_negated_or_leaked_findings` — marker-based drop of any finding
    whose own text already withdraws it or leaks raw deliberation.
  - `demote_diff_absent_speculation` — demotes (does not drop — the
    documentation-drift signal is real) any High/Critical finding admitting
    it reasons about an implementation absent from the diff.
  - `relax_verdict_if_evidence_wiped` — when hygiene + citation-integrity wipe
    out every finding this run, the model's own raw `verdict`/`grade` fields
    (produced by the same hallucinating call) are relaxed to APPROVE too —
    otherwise dropping the findings closes the deterministic-floor half of
    "fabricated findings block clean PRs" but not the self-report half. This
    is scoped tightly to a LOCALLY OBSERVED "we just wiped it this run" fact
    so it never touches `derive_verdict`'s shared floor semantics other
    callers (`verify::rederive_verdict`'s #726 infra-failure preservation)
    rely on unchanged.

Wired into both the unified (`runner.rs`) and map-reduce (`mapreduce/mod.rs`,
per-chunk) paths.

## Proof by execution

`tests/citation_4042_regression.rs` reproduces #4042's centerpiece shape (a
real TS module diffed alongside a Drizzle JSON snapshot and a Vitest test
file, matching #4042's own suggested reproducing shape — no access to the
reporter's private repo `duettoresearch/code-intelligence` was available):

- **Before fix** (ran against unmodified code first): 0 of 3 fabricated
  findings caught — confirmed the regression exactly as reported.
- **After fix**: all 3 fabricated findings dropped, the legitimate finding on
  the SAME file survives verbatim, and the fully-fabricated case additionally
  proves the model's own raw self-reported BLOCK relaxes to APPROVE (not just
  the floor).

`finding_hygiene_tests.rs` uses verbatim/near-verbatim text from #4043 and
#4044's own issue bodies as fixtures.

## Before/after (regression-suite proxy, since the real reported PRs are in a
private repo we cannot access)

| | citation_4042_regression.rs | citation_2881_regression.rs |
|---|---|---|
| Before (unmodified code) | 0/3 fabricated findings dropped | fabricated finding survives, downgraded-in-place |
| After | 3/3 dropped, legit finding survives, top-level BLOCK relaxes | fabricated finding dropped, verdict recovers |

6 pre-existing `runner_tests.rs` fixtures used header-less synthetic diffs
whose fake-LLM findings cited a file never present in the diff — legal under
the old narrow check (gated on `code_provable`/citation + a matching quote),
now correctly caught by the broadened path-resolution check. Fixed via a new
`local_diff_source_for_file` helper producing a proper unified diff instead
of loosening the new invariant.

## Residual scope (disclosed, not fully closed — mirroring #2882's own disclosed gap)

- `[code: …]` verification checks path + content, not the cited LINE number
  specifically via hunk-line arithmetic — a wrong line number attached to
  otherwise-correct content is not caught.
- #4043's fix is marker-based on the finding's own admission; it does not
  catch a finding grounded in an in-code COMMENT's hypothetical (review 2
  finding 25 in #4043) — the cited file there is genuinely code, so
  extension/path-based classification doesn't apply. Flagged as a known
  follow-up, same shape as #2882's disclosed quote-less-paraphrase gap.

## Publish note

trusty-review 0.10.1 is the currently published, live version and IS affected
by #4042/#4043/#4044 in production. A patch release (0.10.2) is warranted
once this merges — **not published from this PR** per instructions.

## Gates (raw output)

```
cargo test -p trusty-review
  lib:          1539 passed; 0 failed; 5 ignored
  bin (main.rs):   68 passed; 0 failed
  citation_2881_regression.rs: 3 passed; 0 failed
  citation_4042_regression.rs: 3 passed; 0 failed
  config_mount.rs:              2 passed; 0 failed
  report_analyze_e2e.rs:        2 passed; 0 failed
  report_e2e.rs:                3 passed; 0 failed
  report_investigate.rs:        3 passed; 0 failed

cargo clippy -p trusty-review --all-targets -- -D warnings   → clean
cargo fmt --check -p trusty-review                            → clean
scripts/check_line_cap.sh                                     → 8 allowlisted, 0 violations — OK
scripts/check_sld.sh                                           → 47 spec docs + 2884 code files; 0 errors, 0 warnings
scripts/check_test_pointers.sh                                 → exit 0
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools