### PR TITLE
fix(trusty-agents): wire trusty-memory/trusty-search as live MCP-stdio services

### DIFF
--- a/crates/trusty-agents/assets/config/default-config.toml
+++ b/crates/trusty-agents/assets/config/default-config.toml
@@ -126,6 +126,52 @@ description = "Retrieve a specific Granola meeting note"
 name = "granola_list_recent"
 description = "List recent Granola meetings"
 
+# trusty-memory — native memory/recall/knowledge-graph service (crate
+# `trusty-memory`, bin `trusty-memory`). `serve --stdio` is the same
+# self-contained stdio MCP entry point the repo-root `.mcp.json` already uses
+# for Claude Code itself (`.mcp.json`), so this block gives trusty-agents
+# personas the identical MCP surface.
+#
+# Previously declared as a `[[tool_registry.endpoints]]` OpenRPC entry
+# (`driver = "direct"`, `command = "trusty-memory", args = ["--rpc"]`) that
+# was permanently `enabled = false` because the binary has never implemented
+# an OpenRPC `--rpc` stdio mode — that entry was dead on arrival and the GUI
+# correctly reported it DISABLED. `trusty-memory serve --stdio` is a real,
+# already-working MCP-stdio server, so this replaces the dead OpenRPC stanza
+# with a live `[[mcp.services]]` entry using `StdioMcpClient`'s generic
+# MCP-stdio path (the same path `trusty-mpm` and `granola-notes` already use
+# below) instead of waiting on a driver that will never ship. `discover =
+# true` live-discovers the real tool surface (`memory_recall`,
+# `memory_remember`, `kg_query`, ...) rather than hand-maintaining a static
+# list that can drift, per the `gworkspace` retirement note above.
+[[mcp.services]]
+name = "trusty-memory"
+description = "Trusty memory service — recall/remember/forget over a native MCP-stdio server"
+command = "trusty-memory"
+args = ["serve", "--stdio"]
+transport = "stdio"
+enabled = true
+discover = true
+
+# trusty-search — native semantic + keyword code/knowledge search service
+# (crate `trusty-search`, bin `trusty-search`). `serve` is the same
+# self-contained stdio MCP entry point the repo-root `.mcp.json` already uses
+# for Claude Code itself (`.mcp.json`).
+#
+# Previously declared as a `[[tool_registry.endpoints]]` OpenRPC entry
+# (`driver = "direct"`, `command = "trusty-search", args = ["--rpc"]`) that
+# was permanently `enabled = false` for the same reason as trusty-memory
+# above: no `--rpc` OpenRPC mode has ever existed on this binary. Replaced
+# with a live `[[mcp.services]]` entry, same rationale as trusty-memory.
+[[mcp.services]]
+name = "trusty-search"
+description = "Trusty search service — semantic + keyword code/knowledge search over a native MCP-stdio server"
+command = "trusty-search"
+args = ["serve"]
+transport = "stdio"
+enabled = true
+discover = true
+
 # Duetto org memory service — Duetto-internal HTTP MCP (#256).
 # Disabled by default since it's only reachable on Duetto infrastructure.
 # Enable with `mcp_enable duetto-memory` when on a Duetto-connected machine.
@@ -180,46 +226,22 @@ max_tokens = 2048
 # Declares external JSON-RPC 2.0 endpoints (driver = "direct") that advertise
 # tools via `rpc.discover`. The `direct` driver spawns a subprocess and
 # speaks JSON-RPC 2.0 over its stdin/stdout (NDJSON; one JSON object per
-# line, JSON array for batch). Endpoints below are DISABLED by default —
-# flip `enabled = true` once the corresponding binary supports an OpenRPC
-# stdio mode (e.g. via a `--rpc` flag). See
+# line, JSON array for batch). See
 # docs/trusty-agents/research/openrpc-trusty-contract.md for the wire format.
 [tool_registry]
 scope_enforcement = "deny"
 
-# trusty-memory — recall/remember/forget over JSON-RPC 2.0 stdio.
-# Disabled until the trusty-memory binary supports `--rpc` mode (where it
-# reads OpenRPC requests from stdin and writes responses to stdout).
-[[tool_registry.endpoints]]
-name = "trusty-memory"
-driver = "direct"
-description = "Trusty memory service — recall/remember/forget"
-command = "trusty-memory"
-args = ["--rpc"]
-enabled = false
-scopes = ["memory.read", "memory.write"]
-discovery_ttl_secs = 0
-eager_discovery = true
-
-[tool_registry.endpoints.transport]
-timeout_ms = 5000
-
-# trusty-search — semantic/keyword code search over JSON-RPC 2.0 stdio.
-# Disabled until the trusty-search binary supports `--rpc` mode.
-[[tool_registry.endpoints]]
-name = "trusty-search"
-driver = "direct"
-description = "Trusty search service — semantic + keyword code search"
-command = "trusty-search"
-args = ["--rpc"]
-enabled = false
-scopes = ["search.read"]
-discovery_ttl_secs = 0
-eager_discovery = true
-
-[tool_registry.endpoints.transport]
-timeout_ms = 5000
-
+# trusty-memory / trusty-search — REMOVED as `[[tool_registry.endpoints]]`
+# entries (see the fix note above `[[mcp.services]]` name = "trusty-memory").
+# Both used to sit here, permanently `enabled = false`, because they declared
+# `driver = "direct"` (OpenRPC-over-stdio via a `--rpc` flag) but neither
+# binary has ever implemented that mode — genuinely dead config, not merely
+# disabled-by-default. Both binaries DO already implement the generic
+# MCP-stdio protocol (`trusty-memory serve --stdio`, `trusty-search serve`),
+# so they now live as live `[[mcp.services]]` entries above instead of
+# waiting on a driver that will never ship. Do not re-add them here; extend
+# their `[[mcp.services]]` entries instead.
+#
 # gworkspace — Google Workspace (Gmail, Calendar, Drive, Docs, Sheets, Tasks)
 # via JSON-RPC 2.0 stdio. The `trusty-gworkspace-mcp` binary (renamed from
 # `gworkspace-mcp` in #2644 to resolve a $PATH collision with the legacy pipx

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -72,7 +72,10 @@ async fn load_or_create_writes_default_when_absent() {
         .iter()
         .find(|s| s.name == "trusty-search")
         .expect("trusty-search present as a live mcp.services entry");
-    assert!(search.enabled, "trusty-search must ship enabled, not DISABLED");
+    assert!(
+        search.enabled,
+        "trusty-search must ship enabled, not DISABLED"
+    );
     assert!(
         !cfg.mcp
             .services
@@ -200,7 +203,10 @@ async fn load_returns_documented_defaults_when_absent() {
         .iter()
         .find(|s| s.name == "trusty-search")
         .expect("trusty-search present in defaults");
-    assert!(search.enabled, "trusty-search must ship enabled, not DISABLED");
+    assert!(
+        search.enabled,
+        "trusty-search must ship enabled, not DISABLED"
+    );
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/mcp/config/tests/mod.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/mod.rs
@@ -45,12 +45,13 @@ async fn load_or_create_writes_default_when_absent() {
     );
 
     // Defaults after ADR-0014 (#256, native-MCP retire) + #3203/#3204:
-    // trusty-mpm (enabled, native), granola-notes (enabled), duetto-memory
-    // (disabled). slack-user-proxy was retired as a dead external stub;
-    // gworkspace-mcp was removed (#3204) — its static tool list had drifted
-    // from the real binary and is superseded by the OpenRPC "gworkspace"
-    // tool_registry.endpoints entry.
-    assert_eq!(cfg.mcp.services.len(), 3);
+    // trusty-mpm (enabled, native), granola-notes (enabled), trusty-memory
+    // (enabled, native — moved off the dead OpenRPC tool_registry.endpoints
+    // stub), trusty-search (same), duetto-memory (disabled). slack-user-proxy
+    // was retired as a dead external stub; gworkspace-mcp was removed
+    // (#3204) — its static tool list had drifted from the real binary and is
+    // superseded by the OpenRPC "gworkspace" tool_registry.endpoints entry.
+    assert_eq!(cfg.mcp.services.len(), 5);
     let tm = cfg
         .mcp
         .services
@@ -58,6 +59,20 @@ async fn load_or_create_writes_default_when_absent() {
         .find(|s| s.name == "trusty-mpm")
         .expect("trusty-mpm present in defaults (#3203)");
     assert!(tm.enabled);
+    let mem = cfg
+        .mcp
+        .services
+        .iter()
+        .find(|s| s.name == "trusty-memory")
+        .expect("trusty-memory present as a live mcp.services entry");
+    assert!(mem.enabled, "trusty-memory must ship enabled, not DISABLED");
+    let search = cfg
+        .mcp
+        .services
+        .iter()
+        .find(|s| s.name == "trusty-search")
+        .expect("trusty-search present as a live mcp.services entry");
+    assert!(search.enabled, "trusty-search must ship enabled, not DISABLED");
     assert!(
         !cfg.mcp
             .services
@@ -157,9 +172,11 @@ async fn load_returns_documented_defaults_when_absent() {
     let path = home.join(".trusty-agents").join("config.toml");
     assert!(!path.exists(), "load() must not create the config file");
     // #245/#256 + ADR-0014 + #3203/#3204: defaults mirror DEFAULT_CONFIG_TOML —
-    // 3 services (trusty-mpm, granola-notes, duetto-memory) after
-    // slack-user-proxy retire and gworkspace-mcp removal.
-    assert_eq!(cfg.mcp.services.len(), 3);
+    // 5 services (trusty-mpm, granola-notes, trusty-memory, trusty-search,
+    // duetto-memory) after slack-user-proxy retire and gworkspace-mcp
+    // removal. trusty-memory/trusty-search moved here from the dead
+    // tool_registry.endpoints OpenRPC stubs (see default-config.toml).
+    assert_eq!(cfg.mcp.services.len(), 5);
     assert!(cfg.mcp.services.iter().any(|s| s.name == "trusty-mpm"));
     assert!(!cfg.mcp.services.iter().any(|s| s.name == "gworkspace-mcp"));
     assert!(
@@ -170,6 +187,20 @@ async fn load_returns_documented_defaults_when_absent() {
     );
     assert!(cfg.mcp.services.iter().any(|s| s.name == "granola-notes"));
     assert!(cfg.mcp.services.iter().any(|s| s.name == "duetto-memory"));
+    let mem = cfg
+        .mcp
+        .services
+        .iter()
+        .find(|s| s.name == "trusty-memory")
+        .expect("trusty-memory present in defaults");
+    assert!(mem.enabled, "trusty-memory must ship enabled, not DISABLED");
+    let search = cfg
+        .mcp
+        .services
+        .iter()
+        .find(|s| s.name == "trusty-search")
+        .expect("trusty-search present in defaults");
+    assert!(search.enabled, "trusty-search must ship enabled, not DISABLED");
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
@@ -234,10 +234,12 @@ fn default_config_includes_local_inference_section() {
 #[test]
 fn default_config_is_valid_toml() {
     let cfg = GlobalConfig::from_toml_str(DEFAULT_CONFIG_TOML).expect("default parses");
-    // ADR-0014 + #3203/#3204: 3 services after slack-user-proxy retire and
+    // ADR-0014 + #3203/#3204: 5 services after slack-user-proxy retire and
     // the gworkspace-mcp → trusty-mpm swap (gworkspace-mcp's static tool list
-    // had drifted from the real binary; trusty-mpm's is fresh, see #3203).
-    assert_eq!(cfg.mcp.services.len(), 3);
+    // had drifted from the real binary; trusty-mpm's is fresh, see #3203),
+    // plus trusty-memory/trusty-search moved here from the dead
+    // tool_registry.endpoints OpenRPC stubs (see default-config.toml).
+    assert_eq!(cfg.mcp.services.len(), 5);
     let tm = cfg
         .mcp
         .services
@@ -249,6 +251,26 @@ fn default_config_is_valid_toml() {
     assert_eq!(tm.args, vec!["serve".to_string(), "--stdio".to_string()]);
     assert!(tm.tools.iter().any(|t| t.name == "session_list"));
     assert!(tm.tools.iter().any(|t| t.name == "agent_delegate"));
+    let mem = cfg
+        .mcp
+        .services
+        .iter()
+        .find(|s| s.name == "trusty-memory")
+        .expect("trusty-memory present");
+    assert!(mem.enabled, "trusty-memory must ship enabled, not DISABLED");
+    assert_eq!(mem.command, "trusty-memory");
+    assert_eq!(mem.args, vec!["serve".to_string(), "--stdio".to_string()]);
+    assert!(mem.discover, "trusty-memory should live-discover its tools");
+    let search = cfg
+        .mcp
+        .services
+        .iter()
+        .find(|s| s.name == "trusty-search")
+        .expect("trusty-search present");
+    assert!(search.enabled, "trusty-search must ship enabled, not DISABLED");
+    assert_eq!(search.command, "trusty-search");
+    assert_eq!(search.args, vec!["serve".to_string()]);
+    assert!(search.discover, "trusty-search should live-discover its tools");
     assert!(
         !cfg.mcp
             .services

--- a/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
+++ b/crates/trusty-agents/src/mcp/config/tests/render_tests.rs
@@ -267,10 +267,16 @@ fn default_config_is_valid_toml() {
         .iter()
         .find(|s| s.name == "trusty-search")
         .expect("trusty-search present");
-    assert!(search.enabled, "trusty-search must ship enabled, not DISABLED");
+    assert!(
+        search.enabled,
+        "trusty-search must ship enabled, not DISABLED"
+    );
     assert_eq!(search.command, "trusty-search");
     assert_eq!(search.args, vec!["serve".to_string()]);
-    assert!(search.discover, "trusty-search should live-discover its tools");
+    assert!(
+        search.discover,
+        "trusty-search should live-discover its tools"
+    );
     assert!(
         !cfg.mcp
             .services

--- a/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigKnowledge.test.ts
@@ -119,12 +119,17 @@ describe('AgentConfigKnowledge — knowledge tools (K-b)', () => {
 });
 
 describe('AgentConfigKnowledge — MCP connections (K-c)', () => {
-  it('lists a configured-but-disabled endpoint with its reason, never hidden (C-03.2)', () => {
+  it('lists every declared endpoint, never hidden, with a reason iff disabled (C-03.2)', () => {
     render();
     expect(target.textContent).toContain('trusty-memory');
     expect(target.textContent).toContain('trusty-search');
     expect(target.textContent).toContain('gworkspace');
-    expect(target.textContent).toContain('awaits `--rpc` mode');
+    // trusty-memory/trusty-search moved from dead `[[tool_registry.endpoints]]`
+    // OpenRPC stubs to live `[[mcp.services]]` MCP-stdio entries, so they no
+    // longer carry a disabled-reason — asserting the OLD `--rpc` reason text
+    // would now be asserting a fabricated status (the exact defect C-03.2
+    // guards against), so it must be ABSENT.
+    expect(target.textContent).not.toContain('awaits `--rpc` mode');
     // The list is the shipped declaration, not a probe — saying so is the
     // difference between honest scaffolding and an invented status.
     expect(target.textContent).toContain('not probed');

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
@@ -24,6 +24,36 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { mount, tick, unmount } from 'svelte';
 import AgentConfigPanel from './AgentConfigPanel.svelte';
 
+/**
+ * The C-07.2 "degraded backends" test below asserts that a disabled MCP
+ * knowledge connection renders honestly as DISABLED rather than being hidden.
+ * That guarantee must hold regardless of which endpoints the shipped
+ * `config.toml` defaults currently happen to enable — trusty-memory and
+ * trusty-search moved from disabled OpenRPC stubs to enabled live MCP-stdio
+ * services (#4064), which correctly left zero disabled entries in the real
+ * `KNOWLEDGE_MCP_ENDPOINTS` list. Rather than re-coupling this regression test
+ * to whatever is enabled-by-default today (which would just break again next
+ * time that list changes), append one synthetic always-disabled endpoint so
+ * the "disabled renders as disabled" invariant is tested independently of the
+ * shipped defaults.
+ */
+vi.mock('../lib/agentConfig', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/agentConfig')>();
+  return {
+    ...actual,
+    KNOWLEDGE_MCP_ENDPOINTS: [
+      ...actual.KNOWLEDGE_MCP_ENDPOINTS,
+      {
+        name: 'stub-disabled-endpoint',
+        description: 'Synthetic endpoint fixture — always disabled (regression coverage only).',
+        enabled: false,
+        scopes: ['stub.read'],
+        reason: 'disabled in this test fixture, independent of shipped config.toml defaults',
+      },
+    ],
+  };
+});
+
 let target: HTMLDivElement;
 let instance: Record<string, unknown> | null = null;
 
@@ -335,7 +365,10 @@ describe('AgentConfigPanel — degraded backends (#3932, C-07.2)', () => {
     tabButton('Knowledge').click();
     await waitFor(() => target.textContent?.includes('Could not read store bindings') ?? false);
     // The knowledge-classification gap is named rather than guessed at, and a
-    // disabled endpoint is shown as disabled rather than hidden (C-03.2).
+    // disabled endpoint is shown as disabled rather than hidden (C-03.2). The
+    // synthetic `stub-disabled-endpoint` fixture (see the `agentConfig` mock
+    // above) supplies the disabled entry independently of whatever the
+    // shipped config.toml defaults currently enable.
     expect(target.textContent).toContain('kind = "knowledge"');
     expect(target.textContent).toContain('disabled');
 

--- a/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
@@ -175,11 +175,15 @@ describe('fetchAgentSkills', () => {
 });
 
 describe('KNOWLEDGE_MCP_ENDPOINTS', () => {
-  it('reports the shipped disabled defaults with a reason, never as connected (C-03.2)', () => {
+  it('reports the shipped defaults, with a reason iff disabled, never fabricated (C-03.2)', () => {
     const byName = Object.fromEntries(KNOWLEDGE_MCP_ENDPOINTS.map((e) => [e.name, e]));
-    expect(byName['trusty-memory'].enabled).toBe(false);
-    expect(byName['trusty-memory'].reason).toBeTruthy();
-    expect(byName['trusty-search'].enabled).toBe(false);
+    // trusty-memory/trusty-search moved from dead `[[tool_registry.endpoints]]`
+    // OpenRPC stubs to live `[[mcp.services]]` MCP-stdio entries — both now
+    // ship enabled by default, same as gworkspace.
+    expect(byName['trusty-memory'].enabled).toBe(true);
+    expect(byName['trusty-memory'].reason).toBeFalsy();
+    expect(byName['trusty-search'].enabled).toBe(true);
+    expect(byName['trusty-search'].reason).toBeFalsy();
     expect(byName['gworkspace'].enabled).toBe(true);
     // A disabled endpoint carries a reason; an enabled one has nothing to
     // explain. The invariant, not the individual flags, is what must hold.

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -268,35 +268,39 @@ export interface KnowledgeEndpoint {
 /**
  * Why (DOC-57 §8.5): Phase 1 maps the Knowledge pane's K-c sub-surface onto "a
  * read-only, statically-declared MCP knowledge-endpoint list", because no
- * route exposes `[[tool_registry.endpoints]]` yet. §4.4 is emphatic about WHAT
- * such a list must say: the two endpoints most obviously "MCP connections to
- * knowledge stores" ship `enabled = false` (awaiting `--rpc` on their
- * binaries), so the agent's memory and search capability today flows through
- * in-process tools, not through these endpoints. Rendering a
- * configured-but-disabled endpoint as connected — or omitting it — is the same
- * class of defect as the fabricated listener pane (C-03.2).
+ * route exposes live MCP connection state yet. §4.4 is emphatic about WHAT
+ * such a list must say: `trusty-memory` and `trusty-search` used to ship as
+ * `[[tool_registry.endpoints]]` OpenRPC entries with `enabled = false`
+ * (awaiting a `--rpc` stdio mode neither binary ever implemented — genuinely
+ * dead config, not merely disabled-by-default). Both binaries already
+ * implement the generic MCP-stdio protocol trusty-agents uses for
+ * `trusty-mpm`/`granola-notes`, so the fix moved them to live
+ * `[[mcp.services]]` entries (`enabled = true`, `discover = true`) instead of
+ * waiting on a driver that will never ship. Rendering a
+ * configured-but-disabled endpoint as connected — or a configured-and-enabled
+ * one as disabled — is the same class of defect as the fabricated listener
+ * pane (C-03.2).
  * What: The three knowledge endpoints declared in this crate's shipped
- * `assets/config/default-config.toml:193-243`, verbatim including their
- * `enabled` flags and scopes. This is the DEFAULT declaration; an operator who
+ * `assets/config/default-config.toml` `[[mcp.services]]` section, mirroring
+ * their `enabled` flags. This is the DEFAULT declaration; an operator who
  * has edited `~/.trusty-agents/config.toml` may have flipped a flag, which is
  * why the pane labels the list as declared-not-probed and Phase 3's
  * `GET /api/agents/:name/knowledge` (§4.5) replaces it with resolved state.
- * Test: `knowledgeEndpoints_report_the_shipped_disabled_defaults`.
+ * Test: `knowledgeEndpoints_report_the_shipped_defaults`.
  */
 export const KNOWLEDGE_MCP_ENDPOINTS: KnowledgeEndpoint[] = [
   {
     name: 'trusty-memory',
-    description: 'Trusty memory service — recall/remember/forget',
-    enabled: false,
+    description: 'Trusty memory service — recall/remember/forget over a native MCP-stdio server',
+    enabled: true,
     scopes: ['memory.read', 'memory.write'],
-    reason: 'disabled in the shipped config — awaits `--rpc` mode on the binary',
   },
   {
     name: 'trusty-search',
-    description: 'Trusty search service — semantic + keyword code search',
-    enabled: false,
+    description:
+      'Trusty search service — semantic + keyword code/knowledge search over a native MCP-stdio server',
+    enabled: true,
     scopes: ['search.read'],
-    reason: 'disabled in the shipped config — awaits `--rpc` mode on the binary',
   },
   {
     name: 'gworkspace',


### PR DESCRIPTION
## Summary

- The GUI's Knowledge pane showed **trusty-memory** and **trusty-search** as `DISABLED` — root cause: `crates/trusty-agents/assets/config/default-config.toml` declared both under `[[tool_registry.endpoints]]` with `driver = "direct"` (OpenRPC-over-stdio via a `--rpc` flag). Neither binary has ever implemented an OpenRPC `--rpc` mode, so those entries were permanently `enabled = false` — dead config, not merely disabled-by-default.
- Both binaries already implement the generic MCP-stdio protocol trusty-agents already uses successfully for `trusty-mpm` and `granola-notes` (`[[mcp.services]]`), and the repo-root `.mcp.json` already proves the exact working invocation (`trusty-search serve`, `trusty-memory serve --stdio`). This PR replaces the dead OpenRPC stanzas with live `[[mcp.services]]` entries (`enabled = true`, `discover = true` so the real tool surface is live-discovered instead of hand-maintained and prone to drift).
- Updated the UI's static `KNOWLEDGE_MCP_ENDPOINTS` mirror (`crates/trusty-agents/ui/src/lib/agentConfig.ts`) to match, plus its Vitest coverage (`agentConfig.test.ts`, `AgentConfigKnowledge.test.ts`).
- Fixed 3 Rust tests whose hardcoded `mcp.services.len()` assertion (`3`) didn't account for the 2 new entries (now `5`), and added explicit enabled/command/args/discover assertions for the new entries.
- Separately, per the parent task: registered a `cto-assistant` trusty-search index (the `cto-assistant-kb` store's `okg://cto-assistant` binding in `.trusty-agents/agents/cto-assistant/agent.toml` had no backing index, so it showed `NOT CONNECTED`). Resolved path via `okg_tree_path` (`crates/trusty-agents/src/stores/binding.rs`) = `$HOME/.trusty-agents/knowledge/cto-assistant`; created the directory (didn't exist) and registered the index via `trusty-search`'s `create_index`. It is currently **empty** (0 chunks) — a valid state, awaiting the OKG ingest feed (`crates/trusty-agents/src/stores/index_feed.rs`) to populate it. This is a data/registration fix, not a code change, so it isn't part of this diff, but I verified it live against the already-running local `tagent --api` daemon: `GET /api/agents/cto-assistant/stores` now reports `"connected": true` for both the index and the palace.

Config-only + test-only fix; **no new driver code**.

## Test plan

- [x] `cargo build -p trusty-agents` — succeeds cleanly (only pre-existing, unrelated warnings)
- [x] `cargo test -p trusty-agents mcp::config` — 20/20 pass (was 17/20 before the test-count fix commit)
- [x] `cargo test -p trusty-agents stores` — 57/57 pass (includes `api::server::tests::agent_stores::*` and `stores::binding::*`)
- [x] `npx vitest run src/lib/agentConfig.test.ts src/components/AgentConfigKnowledge.test.ts` (crates/trusty-agents/ui) — 22/22 pass
- [x] Live-verified against the already-running local daemon (`tagent --api --port 8765`) that the `cto-assistant-kb` store now resolves `connected: true` for both index and palace via `GET /api/agents/cto-assistant/stores`
- [ ] The `trusty-memory`/`trusty-search` GUI connector cards themselves are Phase-1 **static, declared-not-probed** (per DOC-57 §8.5 — no live route exists yet), so there is no live endpoint to re-query for those two; the fix is verified via the config parse + the UI unit tests above

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools