### PR TITLE
fix(trusty-mpm): stop bare tm from misreporting a managed pane as 'not a git project' (#4061)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -48,6 +48,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Bare `tm` no longer misreports a managed pane as "not a git project"**
+  (closes [#4061](https://github.com/bobmatnyc/trusty-tools/issues/4061)):
+  when a managed pane was still settling, the in-place relaunch could observe
+  the session as not-yet-resolvable and fall through to the generic
+  non-git-project hint — telling the operator their repo wasn't a git project
+  when it plainly was. Bare `tm` now retries the in-place relaunch when an
+  env-resolved managed session id exists, and if the session still hasn't
+  settled it prints an honest "still settling" message instead of the
+  misleading non-git hint.
+
 - **Concurrent workspace-trust seeds no longer clobber each other's
   `~/.claude.json` entries** (closes
   [#4072](https://github.com/bobmatnyc/trusty-tools/issues/4072)):

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -1006,6 +1006,75 @@ pub(crate) fn untracked_ancestor_message(git_root: &std::path::Path) -> String {
     )
 }
 
+/// Decision for the non-git-project branch of [`fallback_protected`]: does an
+/// env-resolved managed-session id mean the "not in a git project" verdict is
+/// premature (#4061)?
+///
+/// Why: `derive_project`/`classify_cwd_project` finding no usable git root is
+/// exactly right for a genuinely unmanaged directory — but it says nothing
+/// about whether THIS pane is a managed session's own pane whose daemon
+/// record simply has not settled the Active -> Stopped race yet (the same
+/// race [`super::guided_inplace::fetch_managed_session_until_stopped`] bounds
+/// for `try_inplace_relaunch`'s own gate at the top of `run_guided_default`).
+/// Separating this decision from the I/O (the env lookup, and the retry
+/// itself) keeps it exhaustively unit-testable.
+/// What: `Some(id)` — [`super::guided_inplace::resolve_env_managed_session_id`]
+/// found a managed-session id in either the process or tmux SESSION
+/// environment — means retry [`super::guided_inplace::try_inplace_relaunch`]
+/// once more (real wall-clock time has elapsed since its first attempt at the
+/// top of `run_guided_default`, doing the nested-session-guard round trip and
+/// project detection in between) before ever printing a message that blames
+/// "not a git project". `None` — no signal at all — is the ordinary,
+/// unaffected fast path: print [`super::misc::NON_GIT_FALLBACK_HINT`]
+/// immediately, no extra daemon round trip, no added latency.
+/// Test: `plan_non_git_fallback_retries_when_env_id_present`,
+/// `plan_non_git_fallback_ordinary_when_no_env_id`.
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) enum NonGitFallbackPlan {
+    /// No managed-session signal anywhere — the ordinary "not in a git
+    /// project" hint is correct; print it immediately.
+    OrdinaryNotGit,
+    /// A managed-session id WAS found in the environment — give
+    /// `try_inplace_relaunch` one more bounded attempt before ever printing a
+    /// git-project-shaped message for a pane we have evidence is managed.
+    RetryInPlace(String),
+}
+
+/// Pure decision behind [`NonGitFallbackPlan`] — see its doc for the full
+/// rationale.
+///
+/// Test: `plan_non_git_fallback_retries_when_env_id_present`,
+/// `plan_non_git_fallback_ordinary_when_no_env_id`.
+pub(crate) fn plan_non_git_fallback(env_managed_session_id: Option<&str>) -> NonGitFallbackPlan {
+    match env_managed_session_id {
+        Some(id) => NonGitFallbackPlan::RetryInPlace(id.to_string()),
+        None => NonGitFallbackPlan::OrdinaryNotGit,
+    }
+}
+
+/// Build the operator-facing notice printed when a managed-session id WAS
+/// found in the environment (#4061) but the retried
+/// [`super::guided_inplace::try_inplace_relaunch`] still could not confirm
+/// the in-place relaunch — e.g. the daemon's Active -> Stopped settle race is
+/// taking longer than both bounded attempts combined, or the daemon is
+/// genuinely unreachable.
+///
+/// Why: printing [`super::misc::NON_GIT_FALLBACK_HINT`] here would actively
+/// mislead the operator — this cwd may well not be a git project, but that is
+/// NOT why nothing happened; the pane is a known managed one whose record
+/// just has not settled yet. An honest, actionable message names the session
+/// id and tells the operator the one thing that reliably works: try again.
+/// What: a single-line notice naming `id`. Pure — the caller prints it via
+/// `eprintln!` and returns `Ok(())`, exactly like every other fallback notice
+/// in this module.
+/// Test: `managed_pane_settle_pending_message_names_id`.
+pub(crate) fn managed_pane_settle_pending_message(id: &str) -> String {
+    format!(
+        "tm: this pane belongs to managed session {id}, but its daemon record has not \
+         finished settling yet — run `tm` again in a moment."
+    )
+}
+
 /// Daemon-unreachable fallback that protects ALL live git checkouts (#1724).
 ///
 /// Why: the guided default MUST NOT deploy framework files into ANY git
@@ -1025,9 +1094,11 @@ pub(crate) fn untracked_ancestor_message(git_root: &std::path::Path) -> String {
 /// Test: `guided_fallback_never_pollutes_github_git_checkout`,
 /// `guided_fallback_blocks_non_github_git_checkout`,
 /// `guided_fallback_blocks_github_git_from_subdirectory`,
-/// `guided_fallback_untracked_ancestor_does_not_redirect`, and
-/// `guided_fallback_redirect_success_worktree_not_live_checkout` in
-/// `tests_behavior_b_tests.rs`.
+/// `guided_fallback_untracked_ancestor_does_not_redirect`,
+/// `guided_fallback_redirect_success_worktree_not_live_checkout`,
+/// `guided_fallback_non_git_dir_reaches_launch_path` (fast path unaffected),
+/// and `guided_fallback_non_git_dir_with_managed_env_retries_instead_of_hint`
+/// (#4061 race) in `tests_behavior_b_tests.rs`.
 pub(crate) async fn fallback_protected(
     client: &reqwest::Client,
     url: &str,
@@ -1045,9 +1116,34 @@ pub(crate) async fn fallback_protected(
             return Ok(());
         }
         CwdProject::NotGit => {
-            // Not inside a git working tree: print a helpful note and exit cleanly (#1839).
-            eprintln!("{}", super::misc::NON_GIT_FALLBACK_HINT);
-            return Ok(());
+            // #4061: before blaming "not in a git project", ask whether ANY
+            // signal says this pane belongs (or very recently belonged) to a
+            // managed session — see `plan_non_git_fallback`'s doc for the
+            // full race this closes. A pane with no such signal takes the
+            // ordinary, unaffected fast path below (no extra daemon round
+            // trip). A pane WITH the signal gets one more bounded
+            // `try_inplace_relaunch` attempt — real wall-clock time has
+            // passed since its first attempt at the top of
+            // `run_guided_default` — before this ever prints a
+            // git-project-shaped message for a pane we have evidence is
+            // managed.
+            match plan_non_git_fallback(
+                super::guided_inplace::resolve_env_managed_session_id().as_deref(),
+            ) {
+                NonGitFallbackPlan::RetryInPlace(id) => {
+                    if let Some(result) =
+                        super::guided_inplace::try_inplace_relaunch(client, url).await
+                    {
+                        return result;
+                    }
+                    eprintln!("{}", managed_pane_settle_pending_message(&id));
+                    return Ok(());
+                }
+                NonGitFallbackPlan::OrdinaryNotGit => {
+                    eprintln!("{}", super::misc::NON_GIT_FALLBACK_HINT);
+                    return Ok(());
+                }
+            }
         }
     };
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -1097,7 +1097,9 @@ pub(crate) fn managed_pane_settle_pending_message(id: &str) -> String {
 /// `guided_fallback_untracked_ancestor_does_not_redirect`,
 /// `guided_fallback_redirect_success_worktree_not_live_checkout`,
 /// `guided_fallback_non_git_dir_reaches_launch_path` (fast path unaffected),
-/// and `guided_fallback_non_git_dir_with_managed_env_retries_instead_of_hint`
+/// `guided_fallback_non_git_dir_no_managed_env_is_fast`,
+/// `guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_promptly`,
+/// and `guided_fallback_non_git_dir_with_managed_env_unreachable_daemon_does_not_hang`
 /// (#4061 race) in `tests_behavior_b_tests.rs`.
 pub(crate) async fn fallback_protected(
     client: &reqwest::Client,

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -177,6 +177,36 @@ fn read_tmux_env_managed_session_id() -> Option<String> {
     parse_show_environment_value(&String::from_utf8_lossy(&output.stdout))
 }
 
+/// Resolve [`MANAGED_SESSION_ID_ENV`] from EITHER the process environment or
+/// the tmux SESSION environment — the exact two-source lookup
+/// [`try_inplace_relaunch`] itself performs (issue #4061).
+///
+/// Why (#4061): the guided-default's non-git fallback (`guided::
+/// fallback_protected`'s `CwdProject::NotGit` arm) previously printed the
+/// "not in a git project" hint unconditionally whenever `derive_project`
+/// found no usable git root — including for a managed pane whose bare `tm`
+/// happened to run from a non-git cwd while the daemon's Active -> Stopped
+/// settle race (the same one [`fetch_managed_session_until_stopped`] guards
+/// against) had not yet resolved by the time [`try_inplace_relaunch`]'s own
+/// bounded retry gave up. That produced the reported two-invocation UX: a
+/// scary "not in a git project" error on the first bare `tm`, then success on
+/// an immediate retry once the daemon's record had settled. Exposing the
+/// SAME env-var resolution `try_inplace_relaunch` uses lets that fallback ask
+/// "does ANY signal say this pane belongs (or very recently belonged) to a
+/// managed session?" before ever blaming "not a git project" — without
+/// duplicating the process-env-then-tmux-env chain a second time.
+/// What: [`read_env_managed_session_id`] first (the exact shell that ran the
+/// `export` prefix), falling back to [`read_tmux_env_managed_session_id`] (a
+/// sibling pane/window in the same tmux session, or a pane spawned before the
+/// durable `tmux set-environment` publish existed). `None` when neither
+/// source has it — meaning there is no evidence at all that this pane is a
+/// managed one, so the ordinary "not in a git project" hint is exactly right.
+/// Test: `resolve_env_managed_session_id_prefers_process_env`,
+/// `resolve_env_managed_session_id_none_when_unset` in `guided_inplace/tests.rs`.
+pub(crate) fn resolve_env_managed_session_id() -> Option<String> {
+    read_env_managed_session_id().or_else(read_tmux_env_managed_session_id)
+}
+
 /// Parse the id out of `tmux show-environment <name>`'s stdout.
 ///
 /// Why: separating the parse from the process spawn makes the format-handling

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -278,6 +278,88 @@ fn parse_show_environment_value_none_when_empty() {
     );
 }
 
+// ── resolve_env_managed_session_id (#4061) ───────────────────────────────────
+//
+// Mutates the real process environment (`TM_MANAGED_SESSION_ID`, `TMUX`), so
+// these are `#[serial_test::serial]` — mirroring the convention already used
+// by env-mutating tests elsewhere in this binary (e.g.
+// `tests_behavior_b_tests.rs`'s `REPOS_ROOT_ENV` tests) — and each restores
+// whatever was there before via an RAII-style guard so no other test in the
+// suite ever observes a leaked value.
+
+/// Restores a named env var to its prior value (or removes it if it was
+/// unset) when dropped — keeps env-mutating tests exception-safe and
+/// leak-free regardless of assertion panics.
+struct EnvVarGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    fn set(key: &'static str, value: &str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: serialised by `#[serial_test::serial]` at every call site.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        // SAFETY: serialised by `#[serial_test::serial]` at every call site.
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+#[test]
+#[serial_test::serial]
+fn resolve_env_managed_session_id_prefers_process_env() {
+    let _g1 = EnvVarGuard::set(MANAGED_SESSION_ID_ENV, TEST_ID);
+    // Ensure the tmux fallback path is not what's answering — unset $TMUX so
+    // a bug that skipped straight to the tmux branch could not accidentally
+    // pass by returning None from a real `tmux` shell-out on this host.
+    let _g2 = EnvVarGuard {
+        key: "TMUX",
+        prev: std::env::var("TMUX").ok(),
+    };
+    // SAFETY: serialised by `#[serial_test::serial]`.
+    unsafe { std::env::remove_var("TMUX") };
+
+    assert_eq!(
+        resolve_env_managed_session_id(),
+        Some(TEST_ID.to_string()),
+        "the process env value must be returned even with no tmux session"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn resolve_env_managed_session_id_none_when_unset() {
+    let _g1 = EnvVarGuard {
+        key: MANAGED_SESSION_ID_ENV,
+        prev: std::env::var(MANAGED_SESSION_ID_ENV).ok(),
+    };
+    // SAFETY: serialised by `#[serial_test::serial]`.
+    unsafe { std::env::remove_var(MANAGED_SESSION_ID_ENV) };
+    let _g2 = EnvVarGuard {
+        key: "TMUX",
+        prev: std::env::var("TMUX").ok(),
+    };
+    // SAFETY: serialised by `#[serial_test::serial]`.
+    unsafe { std::env::remove_var("TMUX") };
+
+    assert_eq!(
+        resolve_env_managed_session_id(),
+        None,
+        "neither source has a value — must resolve to None, never a stale leak"
+    );
+}
+
 #[test]
 fn plan_inplace_selected_when_env_set_and_stopped() {
     assert_eq!(

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -1193,6 +1193,228 @@ async fn guided_fallback_non_git_dir_reaches_launch_path() {
     );
 }
 
+// ── #4061: managed-pane settle race vs. the non-git fallback ─────────────────
+//
+// Root cause: `try_inplace_relaunch` (the FIRST thing bare `tm` tries, at the
+// top of `run_guided_default`) is gated on the daemon's session record
+// actually reading "stopped" within a small bounded retry budget
+// (`FETCH_RETRY_BUDGET`, ~400ms) — the async `SessionEnd` healing step that
+// flips a just-exited managed pane's record from "active" to "stopped" can
+// still be in flight at that exact moment. When that gate misses, control
+// used to fall straight through project detection to `fallback_protected`'s
+// `CwdProject::NotGit` arm, which printed the "not in a git project" hint —
+// actively misleading for a pane that plainly IS (or very recently was) a
+// managed session's own pane. These tests exercise `fallback_protected`
+// directly (the layer the fix lives in) with `TM_MANAGED_SESSION_ID` present,
+// mirroring the exact "operator's shell already has the env var exported"
+// scenario from #2023 component B.
+
+#[tokio::test]
+#[serial_test::serial]
+async fn guided_fallback_non_git_dir_no_managed_env_is_fast() {
+    // Why: the common case — no managed-session signal in the environment at
+    // all — must take the ordinary, unaffected fast path: no extra daemon
+    // round trip, no added latency (#4061 must not slow down bare `tm` for a
+    // genuinely non-managed pane).
+    let managed_key = "TM_MANAGED_SESSION_ID";
+    let prev = std::env::var(managed_key).ok();
+    // SAFETY: serialised by `#[serial_test::serial]`.
+    unsafe { std::env::remove_var(managed_key) };
+    let prev_tmux = std::env::var("TMUX").ok();
+    // SAFETY: serialised by `#[serial_test::serial]`.
+    unsafe { std::env::remove_var("TMUX") };
+
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path();
+    assert!(!project.join(".git").exists(), "test precondition");
+
+    let client = reqwest::Client::new();
+    let start = std::time::Instant::now();
+    let result =
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", project).await;
+    let elapsed = start.elapsed();
+
+    // Restore before any assertion can panic.
+    unsafe {
+        match prev {
+            Some(ref v) => std::env::set_var(managed_key, v),
+            None => std::env::remove_var(managed_key),
+        }
+        match prev_tmux {
+            Some(ref v) => std::env::set_var("TMUX", v),
+            None => std::env::remove_var("TMUX"),
+        }
+    }
+
+    assert!(
+        result.is_ok(),
+        "non-git dir must exit cleanly; got {result:?}"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_millis(150),
+        "no managed-session signal must never pay the #4061 retry budget; took {elapsed:?}"
+    );
+}
+
+/// Local HTTP mock replying `{"id","name","state"}`, walking through `states`
+/// one entry per connection (clamping to the last once exhausted) — mirrors
+/// `commands::guided_inplace::tests::spawn_state_mock`'s convention (that
+/// helper lives in a sibling test module and is not reachable from this file,
+/// hence the small local copy).
+async fn spawn_4061_state_mock(
+    id: &'static str,
+    states: Vec<&'static str>,
+) -> (String, std::sync::Arc<std::sync::atomic::AtomicUsize>) {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let hits = Arc::new(AtomicUsize::new(0));
+    let hits_task = hits.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                break;
+            };
+            let n = hits_task.fetch_add(1, Ordering::SeqCst);
+            // Drain the request before replying (avoids connection-reset
+            // flakiness on a naive single read).
+            let mut buf = [0u8; 4096];
+            loop {
+                match tokio::time::timeout(
+                    std::time::Duration::from_millis(200),
+                    sock.read(&mut buf),
+                )
+                .await
+                {
+                    Ok(Ok(n)) if n > 0 => {
+                        if buf[..n].windows(4).any(|w| w == b"\r\n\r\n") {
+                            break;
+                        }
+                    }
+                    _ => break,
+                }
+            }
+            let idx = n.min(states.len().saturating_sub(1));
+            let state = states.get(idx).copied().unwrap_or("active");
+            let body = format!(r#"{{"id":"{id}","name":"tm-test-4061","state":"{state}"}}"#);
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+    (format!("http://{addr}"), hits)
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_promptly() {
+    // #4061 race, reproduced: a managed-session id IS present in the
+    // environment, and the daemon record settles to "stopped" on the very
+    // next poll (simulating the `SessionEnd` healing step catching up a
+    // beat after the first bare-`tm` attempt already gave up). The retried
+    // `try_inplace_relaunch` this fix adds must observe that promptly —
+    // never exhausting the full retry budget once the state resolves — and
+    // must exit cleanly rather than ever printing the misleading "not in a
+    // git project" hint for this pane.
+    const TEST_ID: &str = "11111111-2222-3333-4444-555555555555";
+    let (url, hits) = spawn_4061_state_mock(TEST_ID, vec!["active", "stopped"]).await;
+
+    let managed_key = "TM_MANAGED_SESSION_ID";
+    let prev = std::env::var(managed_key).ok();
+    // SAFETY: serialised by `#[serial_test::serial]`.
+    unsafe { std::env::set_var(managed_key, TEST_ID) };
+
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path();
+
+    let client = reqwest::Client::new();
+    let start = std::time::Instant::now();
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        crate::commands::guided::fallback_protected(&client, &url, project),
+    )
+    .await;
+    let elapsed = start.elapsed();
+
+    // Restore before any assertion can panic.
+    unsafe {
+        match prev {
+            Some(ref v) => std::env::set_var(managed_key, v),
+            None => std::env::remove_var(managed_key),
+        }
+    }
+
+    let result = result.expect("#4061: fallback_protected must never hang");
+    assert!(
+        result.is_ok(),
+        "a managed pane whose record settles must still exit cleanly; got {result:?}"
+    );
+    assert!(
+        !project.join("CLAUDE.md").exists(),
+        "CLAUDE.md must not be written for this non-git cwd"
+    );
+    assert!(
+        hits.load(std::sync::atomic::Ordering::SeqCst) >= 1,
+        "the retried in-place check must actually query the daemon"
+    );
+    assert!(
+        elapsed < std::time::Duration::from_millis(300),
+        "a record that settles on the second poll must not pay the full \
+         retry budget; took {elapsed:?}"
+    );
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn guided_fallback_non_git_dir_with_managed_env_unreachable_daemon_does_not_hang() {
+    // #4061: even in the worst case — a managed-session id present but the
+    // daemon unreachable (or the record never settling) — the fallback must
+    // still resolve promptly (bounded by the SAME small retry budget
+    // `try_inplace_relaunch` already uses) rather than hang, and must still
+    // exit cleanly.
+    const TEST_ID: &str = "11111111-2222-3333-4444-555555555555";
+    let managed_key = "TM_MANAGED_SESSION_ID";
+    let prev = std::env::var(managed_key).ok();
+    // SAFETY: serialised by `#[serial_test::serial]`.
+    unsafe { std::env::set_var(managed_key, TEST_ID) };
+
+    let dir = tempfile::tempdir().unwrap();
+    let project = dir.path();
+
+    let client = reqwest::Client::new();
+    let result = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        crate::commands::guided::fallback_protected(&client, "http://127.0.0.1:1", project),
+    )
+    .await;
+
+    // Restore before any assertion can panic.
+    unsafe {
+        match prev {
+            Some(ref v) => std::env::set_var(managed_key, v),
+            None => std::env::remove_var(managed_key),
+        }
+    }
+
+    let result = result.expect("#4061: fallback_protected must never hang, even unreachable");
+    assert!(
+        result.is_ok(),
+        "an unreachable daemon must still exit cleanly; got {result:?}"
+    );
+    assert!(
+        !project.join("CLAUDE.md").exists(),
+        "CLAUDE.md must not be written for this non-git cwd"
+    );
+}
+
 /// Why (#1724 HIGH gap): `fallback_protected` previously used `cwd.join(".git").exists()`
 /// which only fires when `cwd` IS the repo root. Running `tm` from a subdirectory
 /// (e.g. `~/project/src/`) silently bypassed the guard and called `launch(None)`,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -26,11 +26,12 @@ use crate::commands::first_run::needs_first_run_clone;
 /// racing `needs_first_run_clone_returns_some_when_no_clone`.
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
-    CwdProject, NestedFallbackAction, classify_cwd_project, cwd_owns_git_entry, derive_project,
-    fallback_protected, format_project_context_row, github_host, inplace_self_relaunch_hint,
-    is_github_remote, ls_tree_reports_tracked_dir, nested_fallback_action, nested_guard_notice,
-    non_github_refusal_message, print_non_tty_hint, print_project_context, tty_gate,
-    untracked_ancestor_message,
+    CwdProject, NestedFallbackAction, NonGitFallbackPlan, classify_cwd_project, cwd_owns_git_entry,
+    derive_project, fallback_protected, format_project_context_row, github_host,
+    inplace_self_relaunch_hint, is_github_remote, ls_tree_reports_tracked_dir,
+    managed_pane_settle_pending_message, nested_fallback_action, nested_guard_notice,
+    non_github_refusal_message, plan_non_git_fallback, print_non_tty_hint, print_project_context,
+    tty_gate, untracked_ancestor_message,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{
@@ -1859,6 +1860,49 @@ fn guided_non_github_refusal_message_reassures_live_checkout_untouched() {
     assert!(
         msg.contains("not touched"),
         "refusal must use the phrase 'not touched': {msg}"
+    );
+}
+
+// ── #4061: bare-`tm` "not in a git project" vs. managed-pane settle race ─────
+
+#[test]
+fn plan_non_git_fallback_retries_when_env_id_present() {
+    // Why: a managed-session id resolved from the environment (process or
+    // tmux SESSION table) is evidence THIS pane belongs to a managed session
+    // — the fallback must retry `try_inplace_relaunch` rather than
+    // immediately declaring "not in a git project" (#4061).
+    assert_eq!(
+        plan_non_git_fallback(Some("11111111-2222-3333-4444-555555555555")),
+        NonGitFallbackPlan::RetryInPlace("11111111-2222-3333-4444-555555555555".to_string())
+    );
+}
+
+#[test]
+fn plan_non_git_fallback_ordinary_when_no_env_id() {
+    // Why: the common case — a genuinely unmanaged pane/directory — must take
+    // the ordinary fast path with no extra daemon round trip (no added
+    // latency, no behavior change from pre-#4061).
+    assert_eq!(
+        plan_non_git_fallback(None),
+        NonGitFallbackPlan::OrdinaryNotGit
+    );
+}
+
+#[test]
+fn managed_pane_settle_pending_message_names_id() {
+    // Why: the operator must see the specific session id this pane is bound
+    // to, and the message must NOT read like the misleading "not in a git
+    // project" hint it replaces for this case.
+    let id = "11111111-2222-3333-4444-555555555555";
+    let msg = managed_pane_settle_pending_message(id);
+    assert!(msg.contains(id), "message must name the session id: {msg}");
+    assert!(
+        !msg.to_ascii_lowercase().contains("not in a git project"),
+        "must not reuse the misleading non-git wording: {msg}"
+    );
+    assert!(
+        msg.contains("run `tm` again"),
+        "message must give the operator an actionable retry hint: {msg}"
     );
 }
 


### PR DESCRIPTION
## Summary

- `try_inplace_relaunch` (the first thing bare `tm` tries) is gated on the daemon's session record reading `"stopped"` within a bounded ~400ms retry budget (`FETCH_RETRY_BUDGET`). The async `SessionEnd` healing step that flips a just-exited managed pane's record from `active` to `stopped` can still be in flight at that exact moment, so the very first bare `tm` in that pane can miss the gate and fall through to the guided-default's non-git fallback, which printed a misleading `"tm: not in a git project"` error — only succeeding on a confusing second invocation once the daemon had settled.
- `fallback_protected`'s `CwdProject::NotGit` branch now asks whether `TM_MANAGED_SESSION_ID` resolves from either the process environment or the tmux SESSION environment (`guided_inplace::resolve_env_managed_session_id`, the same two-source lookup `try_inplace_relaunch` itself uses) before ever blaming "not a git project" (`guided::plan_non_git_fallback`). When present, it retries `try_inplace_relaunch` once more — bounded, same budget, real wall-clock time has passed since the first attempt — before ever printing a git-project-shaped message; if that retry still can't confirm, it prints an honest `"...daemon record has not finished settling yet — run tm again in a moment"` message instead (`guided::managed_pane_settle_pending_message`).
- A pane with no such signal at all (the common, non-managed case) takes the unchanged fast path — no extra daemon round trip, no added latency.

## Test plan

- [x] `plan_non_git_fallback_retries_when_env_id_present` / `plan_non_git_fallback_ordinary_when_no_env_id` — pure decision logic
- [x] `managed_pane_settle_pending_message_names_id` — honest message replaces the misleading git-project hint
- [x] `resolve_env_managed_session_id_prefers_process_env` / `resolve_env_managed_session_id_none_when_unset` — env resolution
- [x] `guided_fallback_non_git_dir_no_managed_env_is_fast` — fast path unaffected (asserts no added latency)
- [x] `guided_fallback_non_git_dir_with_managed_env_settles_quickly_returns_promptly` — reproduces the race with a local mock whose record starts `"active"` then flips to `"stopped"` on the next poll
- [x] `guided_fallback_non_git_dir_with_managed_env_unreachable_daemon_does_not_hang` — worst case still resolves promptly, never hangs
- [x] `cargo test -p trusty-mpm` — full suite green (3555 + 1226 + 1226 unit tests, all integration test binaries), 0 failed
- [x] `cargo clippy -p trusty-mpm --all-targets` — clean
- [x] `cargo fmt --check -p trusty-mpm` — clean

Closes #4061

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools