### PR TITLE
chore: allow crates.io publishing for trusty-agents, trusty-channels, trusty-gworkspace

### DIFF
--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "trusty-agents"
 version = "0.38.6"
-publish = false
 edition = "2024"
 description = "Trusty Agents: Rust-native agentic harness with multi-model routing, tool execution, and subprocess delegation."
 license.workspace = true

--- a/crates/trusty-channels/Cargo.toml
+++ b/crates/trusty-channels/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "trusty-channels"
 version = "0.1.0"
-publish = false
 edition = "2021"
 description = "Native chat-channel MCP servers (Slack, …) for the Trusty suite — chat-as-tools"
 license.workspace = true

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.2.2"
 edition = "2024" # edition 2024 required: let-chains used in api/client.rs, api/services/gmail/, api/services/docs/ (issue #258)
 description = "Google Workspace MCP server for the Trusty suite"
 license.workspace = true
+repository.workspace = true
+homepage = "https://github.com/bobmatnyc/trusty-tools"
 
 [lib]
 crate-type = ["rlib"]

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "trusty-gworkspace"
 version = "0.2.2"
-publish = false
 edition = "2024" # edition 2024 required: let-chains used in api/client.rs, api/services/gmail/, api/services/docs/ (issue #258)
 description = "Google Workspace MCP server for the Trusty suite"
 license.workspace = true


### PR DESCRIPTION
## Summary

Reverses the `publish = false` guard on three crates -- `trusty-agents`,
`trusty-channels`, `trusty-gworkspace` -- so they can be published to
crates.io like the workspace's other main tools (`trusty-search`,
`trusty-common`, `trusty-memory`, ...). **This is a deliberate, explicit
policy reversal authorized verbally by Bob (repo owner).**

- `crates/trusty-agents/Cargo.toml`: drop `publish = false` (set 2026-06-06, reaffirmed 2026-07-24)
- `crates/trusty-channels/Cargo.toml`: drop `publish = false` (set at the crate's founding commit, 2026-07-15)
- `crates/trusty-gworkspace/Cargo.toml`: drop `publish = false` (set 2026-05-20)

This matches the convention already used by most publishable crates in this
workspace: they simply omit the `publish` key (default `true`) rather than
writing `publish = true` explicitly. Some crates (trusty-embedderd,
trusty-embedderd-py, trusty-bm25-daemon, trusty-git-analytics) use explicit
`publish = true`, but both patterns are valid and supported; this PR follows
the "omit the key" convention used by already-published tools like
`trusty-search`, `trusty-common`, and `trusty-memory`.

## Why now

- All three crates were restricted in **d3a9cadc** ("chore: restrict crates.io
  publishing to 4 main tools + required lib deps," 2026-05-20), which set
  `publish = false` on 12 crates so that only a small core tool set shipped
  to crates.io.
- Since then, **ADR-0014** (native MCP support, accepted 2026-07-14)
  established that each of these three crates ships a native per-crate MCP
  binary -- `trusty-agents` -> `ompm`/`tagent`, `trusty-channels` ->
  `slack-mcp`/`telegram-mcp`, `trusty-gworkspace` -> `trusty-gworkspace-mcp`
  -- following the same tool-registration convention already used by the
  currently-published `trusty-memory` and `trusty-search`. Architecturally
  they're already first-class tools of the same shape as what's already
  published; this PR just aligns the publish policy with that reality.
- A separate, unimplemented idea (#3828, "trusty-mcp unified CLI
  multiplexer") does **not** block this -- it's an open, zero-progress
  aspiration with no code, not a reason to keep these off crates.io.

## Known precedent -- please don't reflexively flag this

`trusty-gworkspace` was published once before: **0.1.0, published
2026-05-20 (the same day the restriction commit landed), yanked
2026-05-26.** That yank is already understood context, not new information
-- it's exactly why this PR is manifest-only (see below) rather than
publishing immediately.

## What this PR deliberately does NOT do

- Does **not** run `cargo publish` or tag anything. This is purely the
  policy/manifest change. The actual publish is a separate follow-up once
  this merges, via the `cargo-publish` skill workflow.
- Does **not** merge itself. This reverses the repo owner's own prior
  explicit policy commit, so even though Bob authorized the change
  verbally, it should get his eyes (plus CI/code-critic) before merging.

## Verification

- License check: all three crates already use `license.workspace = true`,
  which resolves to the workspace's `license = "MIT"` -- a valid SPDX
  identifier, so no `license-file` fix is needed (unlike, say, an
  `Elastic-2.0` crate would need).
- Checked each crate's remaining path dependencies for other
  `publish = false` crates that would block a standalone `cargo publish`
  resolution -- none found (`trusty-memory`, `trusty-search`, `trusty-kb`,
  `trusty-agents-common`, `trusty-common` are all already publishable).
- `crates/trusty-publish-guard` (the version-parity drift detector) and
  `.github/workflows/release.yml`'s publishability gate both determine
  "is this crate publishable" dynamically by grepping/parsing the
  manifest's `publish` field -- no hardcoded allowlist anywhere needed
  updating for this flip.
- Metadata fix: added `repository.workspace = true` and `homepage`
  fields to `trusty-gworkspace/Cargo.toml` to match metadata patterns used
  by other published crates like `trusty-search` and `trusty-common`.
- Ran `cargo check -p trusty-gworkspace`: passes after metadata addition.

## Test plan

- [x] `cargo check --workspace` passes (modulo the two pre-existing,
      unrelated Tauri GUI frontend-dist failures reproduced on main)
- [ ] CI green
- [ ] code-critic review
- [ ] Bob's sign-off before merge (holding per his own instruction not to
      self-merge a reversal of his prior explicit policy)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
