### PR TITLE
fix: document trusty-analyze 0.7.4 as the E0063 install-breakage release

### DIFF
--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -7,9 +7,29 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
-## [0.7.4] — 2026-07-21
+## [0.7.4] — 2026-07-27
 
 ### Fixed
+
+- **`cargo install trusty-analyze` failed to compile with `error[E0063]: missing
+  field `no_spawn_hint` in initializer of `DaemonBridgeConfig``**
+  ([#4079](https://github.com/bobmatnyc/trusty-tools/issues/4079)): a fresh
+  install of the previously-published `0.7.3` could not be built at all. `0.7.3`
+  was published 2026-07-07 and declared `trusty-common = "0.22.0"` — a caret
+  range `[0.22.0, 0.23.0)`. Five days later, `trusty-common` 0.22.5 added the
+  public field `no_spawn_hint` to `DaemonBridgeConfig` (a SemVer-breaking
+  public-field addition shipped in a *patch* bump; the struct carries neither
+  `#[non_exhaustive]` nor a `Default` impl, so a struct literal missing a field
+  is a hard compile error). `cargo install` re-resolves without a lockfile, so it
+  picked the newest in-range `0.22.x` and paired 0.7.3's pre-field source with a
+  post-field dependency. This release carries the corrected call site
+  (`crates/trusty-analyze/src/commands/daemon_guard.rs` now sets
+  `no_spawn_hint: None`) and declares `trusty-common ^0.26.0`, verified against
+  the live registry with `cargo publish --dry-run`. Workspace CI never caught
+  this because every member consumes `trusty-common` through a path dependency
+  plus a root `[patch.crates-io]` override, so caller and definition are
+  permanently in lockstep and no version resolution ever happens locally.
+  Users on 0.7.3 could work around it with `cargo install trusty-analyze --locked`.
 
 - **Smell-count false positives made the codebase-wide quality metric untrustworthy**
   ([#3522](https://github.com/bobmatnyc/trusty-tools/issues/3522)): the


### PR DESCRIPTION
## Summary

Closes #4079 — `cargo install trusty-analyze` fails on the published `0.7.3` with
`error[E0063]: missing field `no_spawn_hint` in initializer of `DaemonBridgeConfig``.

**Bob's read was correct: the fix is the release.** In-tree `main` is already
correct and already bumped to `0.7.4`; no source change was needed. This PR adds
the missing CHANGELOG entry (0.7.4's notes said nothing about the install
breakage, which is the headline reason to cut the release) and records the
verification.

## Root cause — a SemVer break by the *defining* crate

1. `trusty-common` 0.22.5 added `pub no_spawn_hint: Option<String>` to
   `DaemonBridgeConfig` (`crates/trusty-common/src/mcp/daemon_bridge.rs:117`,
   commit `e993c18a`, 2026-07-12) in a **patch** bump. The struct has neither
   `#[non_exhaustive]` nor a `Default` impl, so a cross-crate struct literal
   missing a field is a hard compile error.
2. `trusty-analyze 0.7.3` was published 2026-07-07 — five days *before* the field
   landed — declaring `trusty-common = "0.22.0"`, i.e. caret `[0.22.0, 0.23.0)`.
3. `cargo install` re-resolves without a lockfile, picks the newest in-range
   `0.22.x`, and pairs pre-field source with a post-field dependency → E0063.

Workspace CI is structurally blind to this: every member consumes `trusty-common`
via a path dependency plus a root `[patch.crates-io]` override, so caller and
definition are permanently in lockstep and no version resolution ever happens
locally.

## Verification — registry-resolved, not path-patched

`cargo publish -p trusty-analyze --dry-run` is the only check that exercises
end-user resolution, and it passed:

```
    Updating crates.io index
   Packaging trusty-analyze v0.7.4
    Packaged 134 files, 1.5MiB (381.9KiB compressed)
   Verifying trusty-analyze v0.7.4
   ...
   Compiling trusty-common v0.26.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 54.36s
   Uploading trusty-analyze v0.7.4
warning: aborting upload due to dry run
```

Note `Compiling trusty-common v0.26.2` with **no path in parentheses** — it came
from crates.io. `cargo check` on the same tree prints
`trusty-common v0.26.2 (/…/crates/trusty-common)`. That difference is the proof
the dry-run is not blind to this bug class.

## Quality gates

```
cargo check -p trusty-analyze --all-targets   → exit 0
cargo test  -p trusty-analyze                 → 442 + 25 + 2 + 2 passed; 0 failed
cargo clippy -p trusty-analyze --all-targets -- -D warnings → exit 0
cargo fmt --check                             → exit 0
scripts/check_line_cap.sh                     → 7 allowlisted, 0 violations — OK
```

Test surface is full (no `--lib`): integration tests `tests/config_mount.rs` and
`tests/stdio_harness.rs` both ran.

## Release-ordering: no prerequisite publish

`trusty-analyze 0.7.4` declares `trusty-common ^0.26.0` → resolves to the
already-live `0.26.2`, and `trusty-review ^0.10.0` → live `0.10.1`. **No other
crate needs publishing first.** `Cargo.lock` is byte-identical to `main` (no
`cargo update` was run).

`ui/dist` is tracked in git, not excluded by the manifest's `exclude` list, and
is included in the package (3 files). It is current: `ui/src` and `ui/dist` were
last touched by the same commit `26250315`. No `release-prep` bundle rebuild is
needed for this crate.

## Deliberately out of scope

Hardening `DaemonBridgeConfig` with `#[non_exhaustive]` + a builder. That breaks
all four cross-crate literal constructors (trusty-analyze, trusty-search,
trusty-memory, trusty-mpm), requires a `trusty-common` minor bump, and would gate
this urgent user-facing publish behind a second crates.io publish — for zero
benefit to the reported breakage. Tracked in the follow-up checklist on #4079,
along with the registry-only install smoke test and `cargo-semver-checks`.

## Post-merge (not done here)

1. Publish `trusty-analyze 0.7.4` from merged `main` / a release tag on `main`.
2. Optionally yank `0.7.3` so new installs fall back to the unaffected `0.7.2`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
