### PR TITLE
fix: stop reporting a live trusty-search as unreachable, and label degraded verdicts

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -9,6 +9,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **A live trusty-search was reported as `"unreachable"`, and a degraded verdict
+  was indistinguishable from a complete one** (closes
+  [#4086](https://github.com/bobmatnyc/trusty-tools/issues/4086)).
+  - **`reachable` now means the transport worked, nothing more.** `probe_deps`
+    published one boolean as both `reachable` and `state`, so a trusty-search
+    that was up, embedder-ready, and answering queries was reported as
+    `reachable: false, state: "unreachable"` whenever its warm boot had left any
+    index behind. Since trusty-search #3706 folded the whole
+    `warm_boot_degraded` aggregate into the top-level `status`, one unrelated
+    repo's index failing to load on the host was enough to trigger it — and
+    "unreachable" sends an operator hunting a process that is running.
+    `HealthResponse::serving_state()` now returns
+    `Serving`/`Degraded(reason)`/`NotServing(reason)` by reading the individual
+    warm-boot counters instead of the aggregate flag, a new `DepState::Degraded`
+    carries that middle case, and `reachable` covers `Ok | Degraded`. A new
+    `detail` field on each dep names the gap and its query-time consequence.
+    Top-level `status` still reports `"degraded"` (it gates on `state == Ok`),
+    so the fix corrects the misreport without hiding the gap, and the #3693
+    benign network-mount watcher-disable path is unchanged.
+  - **A degraded review is now detectable from the MCP envelope alone.** A
+    `Degraded` result — a real verdict produced WITHOUT full code context —
+    returned `isError: false` and no envelope marker, so any consumer reading
+    the envelope saw it as identical to a fully-contexted verdict; the caveat
+    lived only inside the serialised text blob and a Markdown banner.
+    `wrap_result` now emits `mcp_status: "degraded_context"` plus
+    `degraded_reason`. `isError` deliberately stays `false` — the review ran and
+    its findings are real. A serving-but-degraded search routes to
+    `GateOutcome::Degraded` (labelled review) rather than a blanket skip, while
+    a search that cannot serve at all still hard-Skips.
+
 - **Reliability cluster: fabricated findings, spec-as-implementation, and
   unsound verdicts** (closes
   [#4042](https://github.com/bobmatnyc/trusty-tools/issues/4042),

--- a/crates/trusty-review/src/integrations/health.rs
+++ b/crates/trusty-review/src/integrations/health.rs
@@ -114,71 +114,80 @@ pub struct HealthResponse {
     /// JSON bool (`true`/`false`) and JSON string (`"ready"`, `"loading"`, …).
     #[serde(default)]
     pub embedder: EmbedderState,
-    /// Warm-boot health summary (issue #3693).
+    /// Warm-boot health summary (issues #3693, #3706, #4079).
     ///
-    /// Why: trusty-search downgrades its top-level `status` to `"degraded"`
-    /// for two very different reasons when it does downgrade: (1) a benign,
-    /// intentional capability gap — the file watcher was auto-disabled on a
-    /// network-mounted (EFS/NFS) root, indexes stay fully
-    /// queryable/reindexable via the explicit `index-file`/`remove-file`
-    /// API — or (2) `indexes_corpus_failed > 0` — a corpus that failed to
-    /// open. `warmboot_summary.warm_boot_degraded` is `true` for reason (2)
-    /// (and also for TCC/FDA denial, a scan timeout, or a large fraction of
-    /// indexes missing after warm-boot — see trusty-search's own
-    /// `WarmBootSummary::warm_boot_degraded` doc), but as of trusty-search
-    /// 0.38.1 those latter three conditions do NOT flip the top-level
-    /// `status` to `"degraded"` on their own — trusty-search issue #3706
-    /// tracks folding them in. Until that ships, a warm-boot broken only by
-    /// TCC-denial / scan-timeout / mass-index-loss (no corpus-open failure)
-    /// reports `status: "ok"` and `is_serving` never gets to inspect this
-    /// field for it — a pre-existing gap, not introduced or worsened by
-    /// #3693 (the prior `is_healthy` had the identical blind spot, since it
-    /// too only ever looked at the top-level `status` string). Absent on
-    /// older trusty-search versions or transport errors, in which case
-    /// callers must treat degraded as "unknown, assume not serving" (see
-    /// `is_serving`'s doc comment).
+    /// Why: since trusty-search #3706 the top-level `status` is `"degraded"`
+    /// whenever ANY warm-boot condition tripped — a benign auto-disabled file
+    /// watcher on a network-mounted root, a corpus that failed to open, a
+    /// warm-boot scan timeout, a TCC/FDA denial, or mass index loss. The status
+    /// string alone therefore cannot distinguish "fine, one unrelated repo's
+    /// index did not load" from "queries against index X silently return
+    /// nothing". [`HealthResponse::serving_state`] reads the individual counters
+    /// in this summary to build an actionable reason instead of guessing from
+    /// the status string. Absent on older trusty-search versions or a partial
+    /// response, which is reported as degraded-with-unknown-cause rather than as
+    /// an outage — the daemon did answer the probe.
     /// Test: `health_response_degraded_watcher_only_is_serving`,
-    /// `health_response_degraded_warmboot_degraded_is_not_serving`,
-    /// `health_response_degraded_missing_summary_is_not_serving`.
+    /// `health_response_live_warmboot_degraded_payload_is_reachable`,
+    /// `health_response_degraded_missing_summary_is_degraded_not_fatal`.
     #[serde(default)]
     pub warmboot_summary: Option<WarmBootSummary>,
 }
 
-/// Minimal mirror of trusty-search's warm-boot health summary (issue #3693).
+/// Mirror of trusty-search's warm-boot health summary (issues #3693, #4079).
 ///
-/// Why: trusty-review only needs the single aggregate `warm_boot_degraded`
-/// flag to distinguish a benign "degraded" (network-mount watcher disable)
-/// from a genuine fault (TCC denial, scan timeout, corpus-open failure, or a
-/// large fraction of indexes missing) — see trusty-search's
-/// `WarmBootSummary::warm_boot_degraded` doc for the full list of what folds
-/// into it. Deliberately does not mirror the other counters: this consumer
-/// only ever branches on the one boolean, and unknown fields are discarded
-/// by serde (no `deny_unknown_fields`) so future additions on the
-/// trusty-search side never break parsing here.
-/// What: `warm_boot_degraded == true` means trusty-search itself considers
-/// its warm-boot state broken, regardless of the top-level `status` string.
+/// Why: the aggregate `warm_boot_degraded` flag alone is not actionable. It is
+/// an OR over four structurally different conditions (TCC/FDA denial, warm-boot
+/// scan timeout, corpus-open failure, and mass index loss), and since
+/// trusty-search #3706 folded that whole aggregate into the top-level `status`
+/// field, ANY one of them makes trusty-search report `status: "degraded"`.
+/// Branching on the aggregate alone therefore cannot tell a daemon that is
+/// silently answering queries wrong (corpus-open failure) from one that merely
+/// left some unrelated repo's index unloaded (scan timeout) — and reading it as
+/// "not serving" reported a live, query-answering daemon as unreachable
+/// (#4079). Mirroring the individual counters lets `serving_state` explain
+/// WHICH gap exists, in a message an operator can act on.
+/// What: the individual warm-boot counters plus the aggregate flag. Every field
+/// is `#[serde(default)]` and unknown fields are discarded (no
+/// `deny_unknown_fields`) so a trusty-search-side addition never breaks parsing
+/// here.
 /// Test: see `HealthResponse` test list above; `warm_boot_summary_wire_shape_is_pinned`
-/// below pins the exact field name this type deserialises against.
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// below pins the exact field names this type deserialises against.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct WarmBootSummary {
-    /// `true` when trusty-search's own warm-boot health check considers
-    /// itself degraded for a real reason (not merely a network-mount
-    /// watcher disable).
+    /// Indexes successfully restored into the registry at warm boot.
+    #[serde(default)]
+    pub indexes_loaded: u32,
+    /// Indexes skipped at warm boot because macOS TCC/FDA denied access to
+    /// their root. They are absent from the registry until the next boot.
+    #[serde(default)]
+    pub indexes_skipped_tcc: u32,
+    /// Indexes skipped at warm boot because their restore exceeded the
+    /// per-index deadline. Like the TCC case they are absent from the registry
+    /// entirely (not parked for lazy load), so a query naming one of them 404s
+    /// loudly and `search_all` simply does not fan out to it.
+    #[serde(default)]
+    pub indexes_skipped_timeout: u32,
+    /// Registered indexes whose restore was recorded as failed.
+    #[serde(default)]
+    pub indexes_failed: u32,
+    /// Registered indexes whose durable corpus failed to open. This is the one
+    /// genuinely SILENT failure mode: trusty-search keeps serving them and
+    /// returns `200 OK` with an EMPTY result set rather than an error, so a
+    /// review against such an index would get no context and no signal that
+    /// anything was wrong.
+    #[serde(default)]
+    pub indexes_corpus_failed: u32,
+    /// trusty-search's own aggregate "my warm boot was broken" flag — the OR of
+    /// the counters above plus mass index loss.
     ///
-    /// Danger (fail-open direction): `#[serde(default)]` means a future
-    /// trusty-search rename/removal of this JSON key (e.g. a typo fix or a
-    /// schema refactor upstream) silently deserialises this field as `false`
-    /// rather than erroring — `is_serving()` would then read a *genuinely*
-    /// degraded response as `warm_boot_degraded: false` and report it as
-    /// serving. This is the deliberate trade-off for forward-compatibility
-    /// (an unrelated trusty-search field addition must never break parsing
-    /// here), but it means a rename on the wire is invisible at the type
-    /// level — only `warm_boot_summary_wire_shape_is_pinned` (which
-    /// hardcodes today's exact key name) would catch it, by failing to
-    /// compile/assert against a wire fixture that no longer contains the
-    /// field it expects. Treat a failure in that test as a signal to check
-    /// whether trusty-search actually renamed the field vs. the fixture
-    /// merely going stale.
+    /// Kept on the wire mirror because it is part of the pinned payload shape
+    /// and is re-serialised by consumers of this type, but deliberately NOT
+    /// branched on: reading the aggregate is exactly what made a live daemon
+    /// report as unreachable (#4079). `serving_state` reads the individual
+    /// counters instead, so a future trusty-search rename of this key degrades
+    /// to a `false` default without changing any decision — the counters, and
+    /// `warm_boot_summary_wire_shape_is_pinned`, are the real guards.
     #[serde(default)]
     pub warm_boot_degraded: bool,
 }
@@ -195,55 +204,166 @@ impl HealthResponse {
         self.status == "ok" && self.embedder.is_ready()
     }
 
-    /// Returns `true` when trusty-search is actually serving requests and can
-    /// supply real code context — the signal `context_gate` should use
-    /// instead of string-matching `status == "ok"` (issue #3693).
+    /// Classify what trusty-search can actually do for a review right now
+    /// (issues #3693, #4079).
     ///
-    /// Why: trusty-search 0.38.1 intentionally reports `status: "degraded"`
-    /// on EFS/NFS-mounted repos purely because it auto-disabled its file
-    /// watcher (an OS-level limitation, not a fault) — search itself stays
-    /// 100% functional. Treating every non-`"ok"` status as "unreachable"
-    /// (the pre-fix behaviour) fail-closed the gate and skipped every review
-    /// on such deployments. This method inspects the structured
-    /// `warmboot_summary.warm_boot_degraded` flag — trusty-search's own "am I
-    /// actually broken" signal — rather than guessing from the status
-    /// string, so a genuinely broken search that trusty-search itself
-    /// reports as `status: "degraded"` (embedder dead — caught separately by
-    /// the embedder-readiness check below — or an unloadable/corpus-open-failed
-    /// index) still reports `false`. Caveat (trusty-search issue #3706): TCC
-    /// denial, a scan timeout, and mass index loss also set
-    /// `warm_boot_degraded: true`, but as of trusty-search 0.38.1 they do NOT
-    /// by themselves flip the top-level `status` away from `"ok"` — this
-    /// method inherits that upstream blind spot unchanged from the prior
-    /// `is_healthy` (both only ever look at `status`); it is not made worse
-    /// by this fix, and closing it is out of scope here (see #3706).
-    /// What: `false` if the embedder is not ready. Otherwise: `status ==
-    /// "ok"` → `true`; `status == "degraded"` → `true` only when
-    /// `warmboot_summary` is present AND `warm_boot_degraded == false`
-    /// (missing summary — an older trusty-search or a transport-level
-    /// partial response — is treated conservatively as NOT serving, since
-    /// there is no way to confirm the degradation is benign); any other
-    /// status (`"starting"`, `"error"`, …) → `false`.
+    /// Why: reachability and full health are different questions, and folding
+    /// them into one boolean produced a flatly false report. trusty-search
+    /// #3706 folded the whole `warm_boot_degraded` aggregate into the top-level
+    /// `status`, so a daemon that merely skipped some OTHER repo's index on a
+    /// warm-boot scan timeout now answers `status: "degraded"`. The previous
+    /// `is_serving` read that as "not serving", which `probe_deps` in turn
+    /// reported as `reachable: false, state: "unreachable"` — for a daemon that
+    /// was up, embedder-ready, and answering queries. Operators reasonably read
+    /// "unreachable" as "the daemon is down" and went looking for a dead
+    /// process that did not exist (#4079). The three outcomes here keep the
+    /// genuinely-fatal cases fatal while making a partial capability gap
+    /// visible and explainable instead of masquerading as an outage.
+    /// What: [`ServingState::NotServing`] when the embedder is not ready (no
+    /// semantic search is possible at all) or the status is neither `"ok"` nor
+    /// `"degraded"` (`"starting"`, `"error"`, …). [`ServingState::Serving`]
+    /// when `status == "ok"`. Otherwise [`ServingState::Degraded`] carrying a
+    /// human-readable reason built from the individual warm-boot counters — a
+    /// `"degraded"` daemon is still answering queries, so the caller proceeds
+    /// but must stamp the reason onto its output rather than swallow it.
+    ///
+    /// Deliberate policy change vs. the pre-#4079 behaviour: a warm-boot gap is
+    /// no longer a blanket refusal. `indexes_corpus_failed` (the one silent
+    /// failure mode — trusty-search answers `200 OK` with an empty result set
+    /// for such an index) and `indexes_skipped_*` (indexes absent from the
+    /// registry, where a direct query 404s loudly) are BOTH per-index
+    /// conditions, and `/health` does not say which indexes they apply to. One
+    /// unrelated repo's bad corpus must not silently cancel every review on the
+    /// host; it must instead be reported on the review that ran. Closing the
+    /// remaining gap properly needs a per-index status probe against the index
+    /// the review actually uses — see the follow-up noted in #4079.
     /// Test: `health_response_degraded_watcher_only_is_serving`,
-    /// `health_response_degraded_warmboot_degraded_is_not_serving`,
-    /// `health_response_degraded_missing_summary_is_not_serving`,
+    /// `health_response_live_warmboot_degraded_payload_is_reachable`,
+    /// `health_response_degraded_reason_names_corpus_failures`,
+    /// `health_response_degraded_missing_summary_is_degraded_not_fatal`,
     /// `health_response_ok_is_serving`,
     /// `health_response_ok_embedder_not_ready_is_not_serving`,
     /// `health_response_other_status_is_not_serving`.
-    pub fn is_serving(&self) -> bool {
+    pub fn serving_state(&self) -> ServingState {
         if !self.embedder.is_ready() {
-            return false;
+            return ServingState::NotServing(
+                "trusty-search embedder is not ready — semantic code context is unavailable"
+                    .to_string(),
+            );
         }
         match self.status.as_str() {
-            "ok" => true,
-            "degraded" => self
-                .warmboot_summary
-                .as_ref()
-                .map(|w| !w.warm_boot_degraded)
-                .unwrap_or(false),
-            _ => false,
+            "ok" => ServingState::Serving,
+            // A `"degraded"` status with every warm-boot counter clean is the
+            // benign network-mount watcher disable of #3408/#3693: indexes stay
+            // fully queryable, so this is `Serving`, exactly as #3693 intended.
+            "degraded" => match self.degraded_reason() {
+                Some(reason) => ServingState::Degraded(reason),
+                None => ServingState::Serving,
+            },
+            other => ServingState::NotServing(format!(
+                "trusty-search reports status {other:?} — not serving queries"
+            )),
         }
     }
+
+    /// Build the operator-facing explanation for a `status: "degraded"` daemon,
+    /// or `None` when the degradation does not affect query results.
+    ///
+    /// Why: "degraded" on its own tells an operator nothing about whether their
+    /// review lost context. Naming the specific counters — and what each one
+    /// means for query results — is the difference between an actionable notice
+    /// and noise, and it is what gets stamped into a degraded review body.
+    /// What: `None` when every warm-boot counter is clean (the benign
+    /// network-mount watcher disable of #3408/#3693 — indexes remain fully
+    /// queryable, so there is nothing to report). Otherwise a `; `-joined clause
+    /// list built from the non-zero counters, each annotated with its query-time
+    /// consequence. A missing summary yields a generic message rather than
+    /// `None`: the cause is unknown, which is itself worth saying.
+    /// Test: `health_response_degraded_reason_names_corpus_failures`,
+    /// `health_response_degraded_missing_summary_is_degraded_not_fatal`,
+    /// `health_response_degraded_watcher_only_is_serving`.
+    fn degraded_reason(&self) -> Option<String> {
+        let Some(w) = self.warmboot_summary.as_ref() else {
+            return Some(
+                "trusty-search reports status \"degraded\" but sent no warm-boot summary \
+                 (older trusty-search or partial response) — code context may be incomplete"
+                    .to_string(),
+            );
+        };
+        let mut clauses: Vec<String> = Vec::new();
+        if w.indexes_corpus_failed > 0 {
+            clauses.push(format!(
+                "{} index(es) failed to open their corpus — trusty-search answers queries \
+                 against those indexes with an EMPTY result set and no error",
+                w.indexes_corpus_failed
+            ));
+        }
+        if w.indexes_failed > 0 {
+            clauses.push(format!("{} index(es) failed to restore", w.indexes_failed));
+        }
+        if w.indexes_skipped_timeout > 0 {
+            clauses.push(format!(
+                "{} index(es) were skipped on a warm-boot scan timeout and are absent from the \
+                 registry",
+                w.indexes_skipped_timeout
+            ));
+        }
+        if w.indexes_skipped_tcc > 0 {
+            clauses.push(format!(
+                "{} index(es) were skipped because macOS Full Disk Access was denied",
+                w.indexes_skipped_tcc
+            ));
+        }
+        if clauses.is_empty() {
+            // `status: "degraded"` with every warm-boot counter clean is the
+            // benign network-mount watcher disable of #3408/#3693 — indexes stay
+            // fully queryable, so there is nothing to warn a reviewer about.
+            return None;
+        }
+        Some(format!(
+            "serving but degraded ({} of {} index(es) loaded): {}",
+            w.indexes_loaded,
+            w.indexes_loaded + w.indexes_skipped_timeout + w.indexes_skipped_tcc,
+            clauses.join("; ")
+        ))
+    }
+
+    /// Returns `true` when trusty-search can serve queries at all.
+    ///
+    /// Why: several call sites only need the yes/no gate and do not care about
+    /// the reason; keeping the boolean means they do not each re-match on
+    /// [`ServingState`].
+    /// What: `!matches!(self.serving_state(), ServingState::NotServing(_))` —
+    /// note that a `Degraded` daemon counts as serving, because it is answering
+    /// queries. Callers that must report or stamp the degradation use
+    /// [`HealthResponse::serving_state`] instead.
+    /// Test: `health_response_live_warmboot_degraded_payload_is_reachable`,
+    /// `health_response_ok_embedder_not_ready_is_not_serving`.
+    pub fn is_serving(&self) -> bool {
+        !matches!(self.serving_state(), ServingState::NotServing(_))
+    }
+}
+
+/// What trusty-search can do for a review right now (issue #4079).
+///
+/// Why: the pre-#4079 code had one boolean for two questions — "is the daemon
+/// answering?" and "is it fully healthy?" — and reported the answer to the
+/// second under the name of the first. Three explicit states make the middle
+/// case (up and answering, with a named capability gap) representable, so it can
+/// be reported honestly instead of being rounded down to "unreachable".
+/// What: `Serving` (fully nominal), `Degraded(reason)` (answering queries, with
+/// an operator-facing explanation that MUST be surfaced, never swallowed), and
+/// `NotServing(reason)` (cannot produce code context at all).
+/// Test: the `health_response_*` tests below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ServingState {
+    /// Fully nominal — `status: "ok"` and the embedder is ready.
+    Serving,
+    /// Answering queries, but with a named capability gap that the caller must
+    /// surface on any output derived from this daemon.
+    Degraded(String),
+    /// Cannot supply code context at all.
+    NotServing(String),
 }
 
 // ─── Unit tests ───────────────────────────────────────────────────────────────
@@ -423,40 +543,105 @@ mod tests {
             "warmboot_summary": {"warm_boot_degraded": false}
         }"#;
         let resp: HealthResponse = serde_json::from_str(json).unwrap();
-        assert!(
-            resp.is_serving(),
-            "degraded solely due to watcher-network-degraded must still serve (#3693)"
+        assert_eq!(
+            resp.serving_state(),
+            ServingState::Serving,
+            "degraded solely due to watcher-network-degraded must serve CLEANLY (#3693) — a clean \
+             warm boot leaves nothing for a reviewer to act on, so it must not raise a caveat"
         );
     }
 
-    /// A genuinely broken warm-boot (TCC denial / scan timeout / corpus-open
-    /// failure / mass index loss) must still fail-closed.
+    /// REGRESSION (#4079): the VERBATIM `/health` payload captured from the
+    /// live daemon that trusty-review reported as `state: "unreachable"`.
+    ///
+    /// Why: this exact daemon was up, embedder-ready, and answering queries
+    /// (`uptime_secs: 3220`, 20 indexes loaded, `indexes_failed: 0`) while
+    /// `review_health` reported `trusty_search: {reachable: false, state:
+    /// "unreachable"}`. That word sent an operator hunting for a dead process
+    /// that did not exist. A daemon that returns a parseable health body is
+    /// reachable, full stop; a warm-boot gap is reported as degraded WITH a
+    /// reason, never as an outage.
+    /// Test: this test.
     #[test]
-    fn health_response_degraded_warmboot_degraded_is_not_serving() {
+    fn health_response_live_warmboot_degraded_payload_is_reachable() {
+        // Captured verbatim from the live trusty-search 0.39.1 daemon.
         let json = r#"{
             "status": "degraded",
+            "version": "0.39.1",
+            "uptime_secs": 3220,
             "embedder": "ready",
-            "warmboot_summary": {"warm_boot_degraded": true}
+            "embedder_last_ok_secs_ago": 0,
+            "embedder_recent_timeout_count": 0,
+            "indexes": 20,
+            "warmboot_summary": {
+                "indexes_corpus_failed": 3,
+                "indexes_failed": 0,
+                "indexes_lazy": 0,
+                "indexes_loaded": 20,
+                "indexes_skipped_timeout": 11,
+                "indexes_skipped_tcc": 0,
+                "warm_boot_degraded": true
+            }
         }"#;
         let resp: HealthResponse = serde_json::from_str(json).unwrap();
         assert!(
-            !resp.is_serving(),
-            "warm_boot_degraded=true must not serve regardless of embedder state"
+            resp.is_serving(),
+            "a live, embedder-ready, query-answering daemon must never be classified as \
+             not-serving just because warm boot left some indexes behind (#4079)"
+        );
+        assert!(
+            matches!(resp.serving_state(), ServingState::Degraded(_)),
+            "the warm-boot gap must still be reported — as Degraded, not swallowed"
         );
     }
 
-    /// `status: "degraded"` with no `warmboot_summary` at all (older
-    /// trusty-search, or a partial/transport-shaped response) is treated
-    /// conservatively as NOT serving — there is no structured signal to
-    /// confirm the degradation is benign, so guessing "serving" would risk
-    /// silently reviewing against a genuinely broken daemon.
+    /// The degraded reason must NAME the silent failure mode, not just say
+    /// "degraded": an index whose corpus failed to open answers `200 OK` with
+    /// an empty result set, so a review against it loses context invisibly.
     #[test]
-    fn health_response_degraded_missing_summary_is_not_serving() {
+    fn health_response_degraded_reason_names_corpus_failures() {
+        let json = r#"{
+            "status": "degraded",
+            "embedder": "ready",
+            "warmboot_summary": {
+                "indexes_loaded": 20,
+                "indexes_skipped_timeout": 11,
+                "indexes_corpus_failed": 3,
+                "warm_boot_degraded": true
+            }
+        }"#;
+        let resp: HealthResponse = serde_json::from_str(json).unwrap();
+        let ServingState::Degraded(reason) = resp.serving_state() else {
+            panic!("expected Degraded, got {:?}", resp.serving_state());
+        };
+        assert!(
+            reason.contains("3 index(es) failed to open their corpus"),
+            "reason must name the corpus failures; got: {reason}"
+        );
+        assert!(
+            reason.contains("EMPTY result set"),
+            "reason must state the query-time consequence; got: {reason}"
+        );
+        assert!(
+            reason.contains("11 index(es) were skipped on a warm-boot scan timeout"),
+            "reason must name the skipped indexes; got: {reason}"
+        );
+    }
+
+    /// `status: "degraded"` with no `warmboot_summary` (older trusty-search, or
+    /// a partial response) is degraded-with-unknown-cause — NOT an outage. The
+    /// daemon answered the probe, so calling it unreachable is false; the
+    /// missing detail is itself reported in the reason.
+    #[test]
+    fn health_response_degraded_missing_summary_is_degraded_not_fatal() {
         let json = r#"{"status":"degraded","embedder":"ready"}"#;
         let resp: HealthResponse = serde_json::from_str(json).unwrap();
+        let ServingState::Degraded(reason) = resp.serving_state() else {
+            panic!("expected Degraded, got {:?}", resp.serving_state());
+        };
         assert!(
-            !resp.is_serving(),
-            "degraded status without a warmboot_summary must not serve (conservative default)"
+            reason.contains("no warm-boot summary"),
+            "reason must say the cause is unknown; got: {reason}"
         );
     }
 
@@ -471,25 +656,21 @@ mod tests {
 
     /// Pins the exact wire shape `WarmBootSummary` deserialises against.
     ///
-    /// Why: `#[serde(default)]` on `warm_boot_degraded` is a deliberately
-    /// fail-open direction (see the field's doc comment) — a future
-    /// trusty-search rename/removal of the `warm_boot_degraded` JSON key
-    /// would silently parse as `false` (not serving-relevant/degraded)
-    /// rather than erroring, which `is_serving()` would then misread as "not
-    /// actually broken." There is no type-level way to catch a silent rename
-    /// against an unknown-fields-tolerant struct; this test is the guard
-    /// instead — it hardcodes today's exact key name inside a full
-    /// `warmboot_summary` object shaped like a real trusty-search
-    /// response, and asserts the parsed value is `true`. If trusty-search
-    /// ever renames the key, THIS SPECIFIC ASSERTION starts failing (the
-    /// value would silently come back `false` due to `#[serde(default)]`)
-    /// even though `serde_json::from_str` itself still reports success —
-    /// that combination (parse ok, assertion fails) is the signal to go
-    /// check trusty-search's actual `/health` payload for a rename before
-    /// assuming this test fixture merely went stale.
-    /// What: deserialises a `warmboot_summary: {"warm_boot_degraded": true, ...}`
-    /// object (with sibling counters present, mirroring the real payload) and
-    /// asserts `warm_boot_degraded == true` round-trips.
+    /// Why: every field here is `#[serde(default)]`, a deliberately fail-open
+    /// direction — a future trusty-search rename/removal of any of these JSON
+    /// keys parses as `0`/`false` rather than erroring, which would silently
+    /// erase a real warm-boot gap from the degraded reason. There is no
+    /// type-level way to catch a silent rename against an unknown-fields-
+    /// tolerant struct; this test is the guard instead — it hardcodes today's
+    /// exact key names inside a full `warmboot_summary` object shaped like a
+    /// real trusty-search response and asserts each value round-trips. If
+    /// trusty-search ever renames a key, THIS SPECIFIC ASSERTION starts failing
+    /// even though `serde_json::from_str` itself still reports success — that
+    /// combination (parse ok, assertion fails) is the signal to go check
+    /// trusty-search's actual `/health` payload for a rename before assuming
+    /// this fixture merely went stale.
+    /// What: deserialises a real-shaped `warmboot_summary` object and asserts
+    /// every mirrored counter and the aggregate flag round-trip.
     /// Test: this test itself.
     #[test]
     fn warm_boot_summary_wire_shape_is_pinned() {
@@ -499,23 +680,31 @@ mod tests {
             "warmboot_summary": {
                 "indexes_loaded": 40,
                 "indexes_skipped_tcc": 2,
-                "indexes_skipped_timeout": 0,
+                "indexes_skipped_timeout": 3,
                 "warm_boot_degraded": true,
                 "indexes_lazy": 0,
-                "indexes_corpus_failed": 0
+                "indexes_failed": 1,
+                "indexes_corpus_failed": 4
             }
         }"#;
         let resp: HealthResponse =
             serde_json::from_str(json).expect("must parse a real-shaped warmboot_summary object");
+        let w = resp
+            .warmboot_summary
+            .as_ref()
+            .expect("warmboot_summary must deserialise, not default to None");
         assert_eq!(
-            resp.warmboot_summary.as_ref().map(|w| w.warm_boot_degraded),
-            Some(true),
-            "warm_boot_degraded=true in the wire payload must deserialise as Some(true), not \
-             silently default to Some(false)/None on a key-name mismatch"
-        );
-        assert!(
-            !resp.is_serving(),
-            "a warm_boot_degraded=true response must not serve, end to end through is_serving()"
+            (
+                w.indexes_loaded,
+                w.indexes_skipped_tcc,
+                w.indexes_skipped_timeout,
+                w.indexes_failed,
+                w.indexes_corpus_failed,
+                w.warm_boot_degraded,
+            ),
+            (40, 2, 3, 1, 4, true),
+            "every mirrored warmboot_summary key must round-trip; a zero/false here means \
+             trusty-search renamed a key and `#[serde(default)]` swallowed it"
         );
     }
 }

--- a/crates/trusty-review/src/mcp/console_metrics.rs
+++ b/crates/trusty-review/src/mcp/console_metrics.rs
@@ -274,6 +274,7 @@ mod tests {
                 embedder: EmbedderState::Bool(true),
                 warmboot_summary: Some(crate::integrations::health::WarmBootSummary {
                     warm_boot_degraded: false,
+                    ..Default::default()
                 }),
             })
         }

--- a/crates/trusty-review/src/mcp/tools.rs
+++ b/crates/trusty-review/src/mcp/tools.rs
@@ -27,7 +27,7 @@ use crate::{
     config::{InvocationSurface, ReviewConfig},
     integrations::github::{AuthStrategy, GithubClient, RunMode},
     mcp::console_metrics,
-    models::ReviewResult,
+    models::{ReviewResult, ReviewStatus},
     pipeline::{DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
     service::{
         AppState,
@@ -339,11 +339,13 @@ async fn call_review_health(state: &AppState) -> Value {
                 "required": deps.trusty_search.required,
                 "reachable": deps.trusty_search.reachable,
                 "state": deps.trusty_search.state,
+                "detail": deps.trusty_search.detail,
             },
             "trusty_analyze": {
                 "required": deps.trusty_analyze.required,
                 "reachable": deps.trusty_analyze.reachable,
                 "state": deps.trusty_analyze.state,
+                "detail": deps.trusty_analyze.detail,
             },
         },
     });
@@ -475,6 +477,25 @@ fn require_str<'a>(args: &'a Value, key: &str) -> Result<&'a str, ToolError> {
 /// Test: `wrap_result_infra_unavailable_sets_error_and_sentinel` (tools_tests.rs).
 const MCP_STATUS_INFRA_UNAVAILABLE: &str = "infrastructure_unavailable";
 
+/// Machine-readable envelope sentinel signalling that a tool result IS a real
+/// verdict but was produced without complete context (issue #4079).
+///
+/// Why: a degraded review used to be distinguishable from a complete one only
+/// by parsing `content[0].text` and reading `status`/`error`, or by noticing a
+/// Markdown banner inside `review_body`. Every programmatic consumer that
+/// checked the envelope — the only stable, non-prose part of the response — saw
+/// a degraded verdict and a fully-contexted verdict as byte-identical. That is
+/// the silent downgrade: a reviewer cannot act on a caveat it cannot see.
+/// `isError` deliberately stays `false`, because the review DID run and its
+/// findings are real; flipping it would make harnesses discard a useful verdict
+/// and would collapse "incomplete" back into "failed" — the same conflation
+/// #4079 removes on the health side.
+/// What: the literal value written to the envelope's `mcp_status` field,
+/// alongside a `degraded_reason` string naming what was missing.
+/// Test: `wrap_result_degraded_sets_sentinel_and_reason`,
+/// `wrap_result_degraded_stays_isError_false` (tools_tests.rs).
+const MCP_STATUS_DEGRADED_CONTEXT: &str = "degraded_context";
+
 /// Wrap a `ReviewResult` in the MCP content envelope, optionally surfacing a
 /// reviewer-model override-fallback reason (closes #1357 item 2).
 ///
@@ -528,6 +549,22 @@ fn wrap_result(result: &ReviewResult, fallback: Option<&str>) -> Value {
             "mcp_status".to_string(),
             Value::String(MCP_STATUS_INFRA_UNAVAILABLE.to_string()),
         );
+    } else if result.status == ReviewStatus::Degraded
+        && let Some(obj) = envelope.as_object_mut()
+    {
+        // #4079: a real verdict, but produced with incomplete context. Both the
+        // sentinel and the reason live on the envelope so a caller never has to
+        // parse prose to learn the verdict is qualified.
+        obj.insert(
+            "mcp_status".to_string(),
+            Value::String(MCP_STATUS_DEGRADED_CONTEXT.to_string()),
+        );
+        if let Some(reason) = result.error.as_deref() {
+            obj.insert(
+                "degraded_reason".to_string(),
+                Value::String(reason.to_string()),
+            );
+        }
     }
     if let (Some(reason), Some(obj)) = (fallback, envelope.as_object_mut()) {
         obj.insert(

--- a/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_dispatch_tests.rs
@@ -255,8 +255,9 @@ async fn call_tool_review_diff_returns_non_empty_verdict() {
 /// instead of wasting the developer's time with a hard-Skip.
 /// What: builds `offline_state_search_down_unconfigured()` (search down,
 /// `require_search` unconfigured); calls `call_tool("review_diff", ...)`;
-/// asserts `isError: false`, no infra sentinel, `status == "degraded"` (NOT
-/// `"skipped"`), and a real non-Unknown verdict — proving the LLM actually ran.
+/// asserts `isError: false`, the DEGRADED (not infra) sentinel, `status ==
+/// "degraded"` (NOT `"skipped"`), and a real non-Unknown verdict — proving the
+/// LLM actually ran.
 /// Test: this test itself; no network, no credentials needed.
 #[tokio::test]
 async fn call_tool_review_diff_search_down_interactive_default_degrades() {
@@ -274,9 +275,11 @@ async fn call_tool_review_diff_search_down_interactive_default_degrades() {
         json!(false),
         "a Degraded (not Skipped) outcome must NOT set isError:true"
     );
-    assert!(
-        result.get("mcp_status").is_none(),
-        "a Degraded outcome must not carry the infra-unavailable sentinel"
+    assert_eq!(
+        result["mcp_status"],
+        json!("degraded_context"),
+        "a Degraded outcome must carry the degraded sentinel (#4079), never the \
+         infra-unavailable one — the review ran, it was just incomplete"
     );
 
     let text = result["content"][0]["text"]

--- a/crates/trusty-review/src/mcp/tools_tests.rs
+++ b/crates/trusty-review/src/mcp/tools_tests.rs
@@ -149,6 +149,7 @@ impl SearchClient for DegradedButServingSearchTool {
             embedder: EmbedderState::Bool(true),
             warmboot_summary: Some(crate::integrations::health::WarmBootSummary {
                 warm_boot_degraded: false,
+                ..Default::default()
             }),
         })
     }
@@ -499,7 +500,8 @@ fn wrap_result_policy_skip_without_infra_flag_stays_is_error_false() {
 /// Why: distinguishes the "opted-in / interactive-surface-defaulted degrade"
 /// path from the "infra Skip" path — both are non-authoritative, but only the
 /// Skip is a non-result.
-/// What: constructs a `Degraded` result; asserts the envelope stays clean.
+/// What: constructs a `Degraded` result; asserts `isError` stays false and the
+/// envelope carries the degraded sentinel rather than the infra one.
 /// Test: this test itself.
 #[test]
 fn wrap_result_degraded_stays_is_error_false() {
@@ -513,9 +515,60 @@ fn wrap_result_degraded_stays_is_error_false() {
         envelope["isError"], false,
         "a degraded-but-real verdict must not be flagged as an MCP error"
     );
+    assert_eq!(
+        envelope["mcp_status"], "degraded_context",
+        "a degraded result must carry the degraded sentinel, never the infra one"
+    );
+}
+
+/// REGRESSION (#4079): a degraded verdict must be distinguishable from a
+/// complete one WITHOUT parsing `content[0].text`.
+///
+/// Why: before this fix, the only difference between an APPROVE produced with
+/// full code context and an APPROVE produced with none was buried inside a
+/// serialised JSON blob and a Markdown banner. Every programmatic consumer that
+/// looked at the envelope — the stable, non-prose part of the response — saw
+/// two byte-identical results. A caveat nobody can see is not a caveat.
+/// What: builds a `Degraded` APPROVE with a reason, and asserts the envelope
+/// alone carries both the sentinel and the human-readable reason.
+/// Test: this test itself.
+#[test]
+fn wrap_result_degraded_sets_sentinel_and_reason() {
+    let mut result = ReviewResult::new("acme", "backend", 11, "Add Q", "https://example/pr/11");
+    result.status = ReviewStatus::Degraded;
+    result.verdict = Verdict::Approve;
+    result.error = Some(
+        "degraded (non-authoritative): trusty-search at http://localhost:7878: \
+         3 index(es) failed to open their corpus"
+            .to_string(),
+    );
+
+    let envelope = wrap_result(&result, None);
+
+    assert_eq!(
+        envelope["mcp_status"], "degraded_context",
+        "a degraded verdict must be machine-detectable from the envelope alone"
+    );
     assert!(
-        envelope.get("mcp_status").is_none(),
-        "a degraded (non-infra) result must not carry the infra sentinel"
+        envelope["degraded_reason"]
+            .as_str()
+            .is_some_and(|r| r.contains("failed to open their corpus")),
+        "the envelope must name what was missing; got: {:?}",
+        envelope.get("degraded_reason")
+    );
+
+    // The control: an otherwise-identical COMPLETE review must be clean, so the
+    // sentinel is a real signal and not noise attached to every response.
+    let mut complete = ReviewResult::new("acme", "backend", 11, "Add Q", "https://example/pr/11");
+    complete.verdict = Verdict::Approve;
+    let complete_envelope = wrap_result(&complete, None);
+    assert!(
+        complete_envelope.get("mcp_status").is_none(),
+        "a complete review must carry no status sentinel"
+    );
+    assert!(
+        complete_envelope.get("degraded_reason").is_none(),
+        "a complete review must carry no degraded reason"
     );
 }
 

--- a/crates/trusty-review/src/pipeline/context_gate.rs
+++ b/crates/trusty-review/src/pipeline/context_gate.rs
@@ -23,6 +23,7 @@ use tracing::{info, warn};
 
 use crate::{
     config::{InvocationSurface, ReviewConfig},
+    integrations::health::ServingState,
     pipeline::runner::ReviewDeps,
 };
 
@@ -129,22 +130,38 @@ pub async fn preflight_context(
     // guessing from the status string, so this scenario now proceeds (with a
     // WARN noting the reason) while a genuinely broken search (embedder
     // dead, indexes unloadable, TCC-denied, scan-timed-out) still gates shut.
+    //
+    // Issue #4079: a `Degraded` daemon is SERVING — it answers queries — so the
+    // review proceeds and gets real context. But the gap it reported is never
+    // swallowed: it becomes a `GateOutcome::Degraded` reason, which the runner
+    // stamps into the review body as a banner and into `result.error`. That is
+    // the deliberate choice between the two failure modes available here.
+    // Refusing every review because ONE of ~20 unrelated indexes on the host
+    // failed to open its corpus is a false-positive machine that trains callers
+    // to ignore the gate; returning a clean-looking verdict is the silent
+    // downgrade this fix exists to eliminate. Proceed-and-stamp is the only
+    // option that is neither.
     let mut search_error_detail: Option<String> = None;
+    let mut search_degraded_reason: Option<String> = None;
     let search_ok = match &search_health {
-        Ok(h) if h.is_serving() => {
-            if h.status != "ok" {
+        Ok(h) => match h.serving_state() {
+            ServingState::Serving => true,
+            ServingState::Degraded(reason) => {
                 warn!(
                     status = %h.status,
-                    "trusty-search reports a non-'ok' status but is confirmed serving \
-                     (warm_boot_degraded=false) — proceeding (#3693)"
+                    reason = %reason,
+                    "trusty-search is serving with a capability gap — proceeding, review will be \
+                     labelled DEGRADED (#4079)"
                 );
+                search_degraded_reason = Some(reason);
+                true
             }
-            true
-        }
-        Ok(h) => {
-            warn!(status = %h.status, "trusty-search health is not serving");
-            false
-        }
+            ServingState::NotServing(reason) => {
+                warn!(status = %h.status, reason = %reason, "trusty-search health is not serving");
+                search_error_detail = Some(reason);
+                false
+            }
+        },
         Err(e) => {
             warn!("trusty-search health probe failed: {e}");
             search_error_detail = Some(e.to_string());
@@ -194,6 +211,14 @@ pub async fn preflight_context(
             "trusty-analyze unavailable at {analyzer_url}; review produced WITHOUT \
              static-analysis context"
         ));
+    }
+
+    // ── trusty-search serving-but-degraded (#4079) ─────────────────────────
+    // Checked last so a hard analyze outage still wins the reason slot. Search
+    // answered and supplied context, so this is not a skip — but the gap must
+    // reach the reader of the review, not just the daemon's own log.
+    if let Some(reason) = search_degraded_reason {
+        return GateOutcome::Degraded(format!("trusty-search at {search_url}: {reason}"));
     }
 
     GateOutcome::Proceed

--- a/crates/trusty-review/src/pipeline/context_gate_tests.rs
+++ b/crates/trusty-review/src/pipeline/context_gate_tests.rs
@@ -276,12 +276,11 @@ async fn explicit_require_skips_even_interactive_surface() {
 
 // ── Degraded-but-serving (#3693) ───────────────────────────────────────────────
 
-/// Search stub whose `/health` reports a fixed `status` + `warmboot_summary`
-/// pair, independent of the `Some(bool)`/`None` shape `StubSearch` uses —
-/// needed to exercise the `"degraded"` status with an explicit
-/// `warm_boot_degraded` value (#3693).
+/// Search stub whose `/health` reports `status: "degraded"` with a caller-chosen
+/// warm-boot summary, independent of the `Some(bool)`/`None` shape `StubSearch`
+/// uses (#3693, #4079).
 struct DegradedSearch {
-    warm_boot_degraded: bool,
+    summary: crate::integrations::health::WarmBootSummary,
 }
 
 #[async_trait]
@@ -290,9 +289,7 @@ impl SearchClient for DegradedSearch {
         Ok(HealthResponse {
             status: "degraded".to_string(),
             embedder: EmbedderState::Bool(true),
-            warmboot_summary: Some(crate::integrations::health::WarmBootSummary {
-                warm_boot_degraded: self.warm_boot_degraded,
-            }),
+            warmboot_summary: Some(self.summary.clone()),
         })
     }
     async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
@@ -329,35 +326,99 @@ async fn degraded_but_serving_proceeds() {
     let cfg = config(); // defaults: require_search=true
     let d = deps_with_search(
         Arc::new(DegradedSearch {
-            warm_boot_degraded: false,
+            summary: Default::default(),
         }),
         true,
     );
     assert_eq!(
         preflight_context(&cfg, &d, InvocationSurface::Hosted).await,
         GateOutcome::Proceed,
-        "degraded-but-serving (benign watcher disable) must proceed, not skip (#3693)"
+        "degraded-but-serving (benign watcher disable) must proceed cleanly — a clean warm boot \
+         behind a 'degraded' status affects nothing a reviewer can act on (#3693)"
     );
 }
 
-/// A genuinely broken trusty-search (`warm_boot_degraded == true` — TCC
-/// denial, scan timeout, corpus-open failure, or mass index loss) reporting
-/// `status: "degraded"` must still fail-closed under the default
-/// `require_search=true`.
+/// REGRESSION (#4079): a trusty-search with a real warm-boot gap must produce a
+/// LABELLED review, not a blanket skip and not a clean-looking verdict.
+///
+/// Why: this is the live payload that broke — 11 indexes skipped on a scan
+/// timeout and 3 with a failed corpus, on a daemon that was up and answering.
+/// The pre-fix gate hard-skipped every review on the host over it; the failure
+/// mode being avoided in the other direction is a verdict that looks complete.
+/// Proceed-and-label is the only outcome that is neither, and the reason must
+/// name the silent failure mode by hand so a reader can act on it.
+/// Test: this test itself.
 #[tokio::test]
-async fn degraded_not_serving_skips() {
-    let cfg = config();
+async fn degraded_warm_boot_gap_labels_review_instead_of_skipping() {
+    let cfg = config(); // defaults: require_search=true
     let d = deps_with_search(
         Arc::new(DegradedSearch {
-            warm_boot_degraded: true,
+            summary: crate::integrations::health::WarmBootSummary {
+                indexes_loaded: 20,
+                indexes_skipped_timeout: 11,
+                indexes_corpus_failed: 3,
+                warm_boot_degraded: true,
+                ..Default::default()
+            },
         }),
         true,
     );
     match preflight_context(&cfg, &d, InvocationSurface::Hosted).await {
-        GateOutcome::Skip(msg) => assert!(msg.contains("trusty-search"), "msg: {msg}"),
-        other => {
-            panic!("genuinely broken (warm_boot_degraded=true) search must Skip, got {other:?}")
+        GateOutcome::Degraded(reason) => {
+            assert!(
+                reason.contains("failed to open their corpus"),
+                "the degraded reason must name the SILENT failure mode; got: {reason}"
+            );
+            assert!(
+                reason.contains("trusty-search at"),
+                "the reason must say which daemon it is about; got: {reason}"
+            );
         }
+        other => panic!(
+            "a serving-but-degraded search must produce a labelled review, not {other:?} (#4079)"
+        ),
+    }
+}
+
+/// A trusty-search that cannot serve at all (embedder not ready) must STILL
+/// fail-closed under the default `require_search=true`.
+///
+/// Why: #4079 relaxes the warm-boot gap, and the risk of that change is
+/// relaxing the genuine outage too. Without an embedder there is no semantic
+/// code context to be had, so there is nothing to label — the review must not
+/// run. This test is the guard on that boundary.
+/// Test: this test itself.
+#[tokio::test]
+async fn not_serving_search_still_skips() {
+    struct EmbedderDownSearch;
+
+    #[async_trait]
+    impl SearchClient for EmbedderDownSearch {
+        async fn health(&self) -> Result<HealthResponse, SearchClientError> {
+            Ok(HealthResponse {
+                status: "ok".to_string(),
+                embedder: EmbedderState::Str("loading".to_string()),
+                warmboot_summary: None,
+            })
+        }
+        async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+            Ok(vec![])
+        }
+        async fn search(
+            &self,
+            _: &str,
+            _: &str,
+            _: Option<u32>,
+        ) -> Result<Vec<SearchResult>, SearchClientError> {
+            Ok(vec![])
+        }
+    }
+
+    let cfg = config();
+    let d = deps_with_search(Arc::new(EmbedderDownSearch), true);
+    match preflight_context(&cfg, &d, InvocationSurface::Hosted).await {
+        GateOutcome::Skip(msg) => assert!(msg.contains("trusty-search"), "msg: {msg}"),
+        other => panic!("a search that cannot serve at all must Skip, got {other:?}"),
     }
 }
 

--- a/crates/trusty-review/src/service/handlers.rs
+++ b/crates/trusty-review/src/service/handlers.rs
@@ -23,7 +23,10 @@ use tracing::{debug, info};
 
 use crate::{
     config::{InvocationSurface, ReviewConfig},
-    integrations::{analyze_client::AnalyzeClient, github::RunMode, search_client::SearchClient},
+    integrations::{
+        analyze_client::AnalyzeClient, github::RunMode, health::ServingState,
+        search_client::SearchClient,
+    },
     llm::LlmProvider,
     pipeline::{DiffSource, ReviewDeps, ReviewInput, TriggerDecision, run_review},
     service::inference_probe::{InferenceProbe, InferenceStatus},
@@ -214,24 +217,46 @@ pub struct DepInfo {
     /// Whether this dep is required for the service to function.
     pub required: bool,
     /// Whether the dep responded to a liveness probe at last check.
-    /// `true` iff `state == DepState::Ok`.  Kept for back-compat: existing
-    /// consumers gate on this single boolean field (#3658 is additive).
+    ///
+    /// Means exactly what it says: the dependency answered. `true` for
+    /// `DepState::Ok` AND `DepState::Degraded` — a daemon that returns a
+    /// parseable health body is reachable even when that body reports a
+    /// capability gap. Before #4079 this was `state == Ok`, so a live,
+    /// query-answering trusty-search with a warm-boot gap was published as
+    /// `reachable: false, state: "unreachable"`, which operators correctly read
+    /// as "the daemon is down" and acted on — chasing a process that was
+    /// running the whole time. Capability lives in `state`/`detail`; this field
+    /// is about the transport only.
     pub reachable: bool,
-    /// Tri-state probe result: `ok`, `unreachable`, or `timeout` (#3658).
+    /// Probe result: `ok`, `degraded`, `unreachable`, or `timeout`
+    /// (#3658, #4079).
     pub state: DepState,
+    /// Operator-facing explanation for a non-`ok` `state` — which capability is
+    /// missing and what it means for results.
+    ///
+    /// Why: `state: "degraded"` without a reason is not actionable, and the
+    /// whole point of #4079 is that a partial capability gap must be
+    /// explainable rather than collapsed into one misleading word.
+    /// Omitted from the JSON when absent so the payload shape is unchanged for
+    /// a healthy dependency.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
 }
 
-/// Tri-state outcome of a single bounded dependency probe (#3658).
+/// Outcome of a single bounded dependency probe (#3658, #4079).
 ///
 /// Why: post-#722 the dep probe correctly reported reachability, but a slow
 /// (not down) dependency and a hard-down dependency both collapsed into
-/// `reachable: false`, with no bound on how long the probe could take. This
-/// type distinguishes "probe returned an error / unhealthy response"
-/// (`Unreachable`) from "probe did not complete within the internal deadline"
-/// (`Timeout`), so operators can tell "trusty-search is down" apart from
-/// "trusty-search is just slow right now".
-/// What: serialises as a lowercase string (`"ok"`, `"unreachable"`,
-/// `"timeout"`) via `#[serde(rename_all = "snake_case")]`.
+/// `reachable: false`, with no bound on how long the probe could take (#3658
+/// split those). #4079 found the remaining conflation: a dependency that
+/// answered the probe but reported a partial capability gap was ALSO collapsed
+/// into `Unreachable`, publishing "unreachable" for a daemon that was up and
+/// serving. `Degraded` is that missing middle state, so each word means one
+/// thing: `Unreachable` = the probe failed, `Degraded` = the probe succeeded
+/// and the dependency said it is running with a gap, `Timeout` = no answer in
+/// time.
+/// What: serialises as a lowercase string (`"ok"`, `"degraded"`,
+/// `"unreachable"`, `"timeout"`) via `#[serde(rename_all = "snake_case")]`.
 /// Test: `dep_state_serialises_lowercase`, `bounded_probe_*` in
 /// `handlers_tests.rs`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
@@ -239,12 +264,30 @@ pub struct DepInfo {
 pub enum DepState {
     /// Probe completed within the deadline and reported a healthy dependency.
     Ok,
-    /// Probe completed within the deadline but reported an error or an
-    /// unhealthy response (e.g. embedder not ready).
+    /// Probe completed within the deadline; the dependency answered and is
+    /// serving, but reported a capability gap that callers must surface.
+    Degraded,
+    /// Probe completed within the deadline but the dependency errored or
+    /// reported that it cannot serve at all (e.g. embedder not ready).
     Unreachable,
     /// Probe did not complete within `dep_probe_timeout()` — the dependency
     /// is slow, not necessarily down.
     Timeout,
+}
+
+impl DepState {
+    /// Whether the dependency answered the probe.
+    ///
+    /// Why: single source of truth for `DepInfo::reachable`, so the
+    /// "reachable means the transport worked" rule cannot drift back into
+    /// "reachable means fully healthy" (#4079).
+    /// What: `true` for `Ok` and `Degraded`; `false` for `Unreachable` and
+    /// `Timeout`.
+    /// Test: `dep_state_degraded_is_reachable`,
+    /// `probe_deps_degraded_search_is_reachable` in `handlers_tests.rs`.
+    pub fn is_reachable(self) -> bool {
+        matches!(self, DepState::Ok | DepState::Degraded)
+    }
 }
 
 /// Response body for GET /status.
@@ -327,7 +370,12 @@ pub struct ReviewRequest {
 /// `health_status_ok_optional_dep_down`,
 /// `health_status_ok_inference_unknown` in `handlers_status_tests.rs`.
 pub fn compute_status(inference: InferenceStatus, deps: &DepStatus) -> &'static str {
-    let required_deps_ok = deps.trusty_search.reachable || !deps.trusty_search.required;
+    // #4079: gate on `state == Ok`, NOT on `reachable`. `reachable` now
+    // (correctly) includes `Degraded`, and a required dependency running with a
+    // capability gap must still surface as a degraded service — silently
+    // reporting "ok" because the daemon merely answered would be the exact
+    // silent-downgrade this fix exists to remove.
+    let required_deps_ok = deps.trusty_search.state == DepState::Ok || !deps.trusty_search.required;
     // `Unknown` (probe timed out) is treated the same as `Ok` for the purpose of
     // computing the top-level status: we do not degrade because we couldn't confirm
     // reachability within the probe window (#739).
@@ -382,35 +430,34 @@ pub(crate) fn dep_probe_timeout() -> Duration {
 /// `DepState::Unreachable`; a completed `Err(_)` is `DepState::Unreachable`;
 /// an elapsed deadline is `DepState::Timeout` — deliberately distinct from
 /// `Unreachable` so a slow-but-up dependency is never reported as hard-down.
+/// `classify` maps a successful response to its `(DepState, detail)` pair, so a
+/// dependency that answers with a capability gap can report `Degraded` plus the
+/// reason instead of being flattened into `Unreachable` (#4079).
 /// Test: `bounded_probe_ok_on_healthy_response`,
 /// `bounded_probe_unreachable_on_error`,
 /// `bounded_probe_unreachable_on_unhealthy_response`,
+/// `bounded_probe_degraded_carries_detail`,
 /// `bounded_probe_timeout_on_stalled_future`,
 /// `health_unhealthy_search_response_reports_state_unreachable` (the
-/// `Ok(Ok(v))` + `is_healthy(v) == false` branch exercised end-to-end through
-/// a real `SearchClient`, e.g. a degraded embedder),
-/// `health_degraded_but_serving_stays_ok` (issue #3693: `probe_deps` passes
-/// `HealthResponse::is_serving` — not `is_healthy` — as the `is_healthy`
-/// closure param here, so a `status: "degraded"` response caused only by a
-/// benign watcher-disable reports `reachable: true`) in `handlers_tests.rs`.
+/// `Ok(Ok(v))` + not-serving branch exercised end-to-end through a real
+/// `SearchClient`, e.g. a degraded embedder),
+/// `health_degraded_but_serving_stays_ok` (issue #3693) in `handlers_tests.rs`.
 async fn bounded_probe<Fut, T, E>(
     fut: Fut,
     timeout: Duration,
-    is_healthy: impl FnOnce(T) -> bool,
-) -> DepState
+    classify: impl FnOnce(T) -> (DepState, Option<String>),
+) -> (DepState, Option<String>)
 where
     Fut: std::future::Future<Output = Result<T, E>>,
+    E: std::fmt::Display,
 {
     match tokio::time::timeout(timeout, fut).await {
-        Ok(Ok(v)) => {
-            if is_healthy(v) {
-                DepState::Ok
-            } else {
-                DepState::Unreachable
-            }
-        }
-        Ok(Err(_)) => DepState::Unreachable,
-        Err(_elapsed) => DepState::Timeout,
+        Ok(Ok(v)) => classify(v),
+        Ok(Err(e)) => (DepState::Unreachable, Some(e.to_string())),
+        Err(_elapsed) => (
+            DepState::Timeout,
+            Some(format!("no response within {timeout:?}")),
+        ),
     }
 }
 
@@ -437,31 +484,40 @@ where
 pub async fn probe_deps(state: &AppState) -> DepStatus {
     let timeout = dep_probe_timeout();
 
-    // Issue #3693: `is_serving()` (not `is_healthy()`) — a trusty-search
-    // `status: "degraded"` caused solely by an intentional, benign
-    // watcher-disable on a network-mounted (EFS/NFS) root must still report
-    // `reachable: true` here; a genuinely broken search (embedder dead,
-    // indexes unloadable) still reports `false`. See
-    // `HealthResponse::is_serving` for the full rationale.
-    let search_probe = bounded_probe(state.search.health(), timeout, |r| r.is_serving());
+    // Issue #4079: map trusty-search's own three-way self-assessment straight
+    // through instead of collapsing it to a boolean. A daemon that answered is
+    // reachable; whether it is fully capable is `state` + `detail`.
+    let search_probe = bounded_probe(state.search.health(), timeout, |r| {
+        match r.serving_state() {
+            ServingState::Serving => (DepState::Ok, None),
+            ServingState::Degraded(reason) => (DepState::Degraded, Some(reason)),
+            ServingState::NotServing(reason) => (DepState::Unreachable, Some(reason)),
+        }
+    });
     let analyze_probe = async {
         match &state.analyze {
-            Some(a) => bounded_probe(a.health(), timeout, |_| true).await,
-            None => DepState::Unreachable,
+            Some(a) => bounded_probe(a.health(), timeout, |_| (DepState::Ok, None)).await,
+            None => (
+                DepState::Unreachable,
+                Some("no trusty-analyze client configured".to_string()),
+            ),
         }
     };
-    let (search_state, analyze_state) = tokio::join!(search_probe, analyze_probe);
+    let ((search_state, search_detail), (analyze_state, analyze_detail)) =
+        tokio::join!(search_probe, analyze_probe);
 
     DepStatus {
         trusty_search: DepInfo {
             required: true,
-            reachable: search_state == DepState::Ok,
+            reachable: search_state.is_reachable(),
             state: search_state,
+            detail: search_detail,
         },
         trusty_analyze: DepInfo {
             required: false,
-            reachable: analyze_state == DepState::Ok,
+            reachable: analyze_state.is_reachable(),
             state: analyze_state,
+            detail: analyze_detail,
         },
     }
 }

--- a/crates/trusty-review/src/service/handlers_status_tests.rs
+++ b/crates/trusty-review/src/service/handlers_status_tests.rs
@@ -33,11 +33,13 @@ fn health_status_ok_all_good() {
             required: true,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
     };
     assert_eq!(
@@ -61,11 +63,13 @@ fn health_status_degraded_required_dep_down() {
             required: true,
             reachable: false, // required dep is down
             state: DepState::Unreachable,
+            detail: None,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
     };
     assert_eq!(
@@ -88,11 +92,13 @@ fn health_status_degraded_inference_auth_error() {
             required: true,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
     };
     assert_eq!(
@@ -119,11 +125,13 @@ fn health_status_ok_inference_unknown() {
             required: true,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
     };
     assert_eq!(
@@ -146,11 +154,13 @@ fn health_status_ok_optional_dep_down() {
             required: true,
             reachable: true,
             state: DepState::Ok,
+            detail: None,
         },
         trusty_analyze: DepInfo {
             required: false,
             reachable: false, // optional dep down — must not degrade
             state: DepState::Unreachable,
+            detail: None,
         },
     };
     assert_eq!(

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -175,6 +175,84 @@ impl SearchClient for DegradedButServingSearch {
     }
 }
 
+/// A search stub reproducing the LIVE payload from #4079: up, embedder ready,
+/// answering queries, but with a real warm-boot gap (11 indexes skipped on a
+/// scan timeout, 3 with a failed corpus).
+pub(super) struct WarmBootGapSearch;
+
+#[async_trait]
+impl SearchClient for WarmBootGapSearch {
+    async fn health(&self) -> Result<SearchHealth, SearchClientError> {
+        Ok(SearchHealth {
+            status: "degraded".to_string(),
+            embedder: EmbedderState::Str("ready".to_string()),
+            warmboot_summary: Some(crate::integrations::health::WarmBootSummary {
+                indexes_loaded: 20,
+                indexes_skipped_timeout: 11,
+                indexes_corpus_failed: 3,
+                warm_boot_degraded: true,
+                ..Default::default()
+            }),
+        })
+    }
+
+    async fn list_indexes(&self) -> Result<Vec<IndexInfo>, SearchClientError> {
+        Ok(vec![])
+    }
+
+    async fn search(
+        &self,
+        _index_id: &str,
+        _query: &str,
+        _top_k: Option<u32>,
+    ) -> Result<Vec<SearchResult>, SearchClientError> {
+        Ok(vec![])
+    }
+}
+
+/// REGRESSION (#4079): `probe_deps` must publish a serving-but-degraded
+/// trusty-search as REACHABLE, with the gap in `state`/`detail`.
+///
+/// Why: the type-level guard (`dep_state_degraded_is_reachable`) proves the
+/// mapping; this proves the whole probe path actually produces it from a real
+/// `SearchClient` response, which is where the false "unreachable" was minted.
+/// What: probes `WarmBootGapSearch`; asserts `reachable`, `state == Degraded`,
+/// a detail naming the corpus failures, and that `compute_status` still reports
+/// `"degraded"` overall so the gap is not swallowed.
+/// Test: this test itself.
+#[tokio::test]
+async fn probe_deps_degraded_search_is_reachable() {
+    use super::{DepState, compute_status, probe_deps};
+    use crate::service::inference_probe::InferenceStatus;
+
+    let state = AppState::new(
+        crate::config::ReviewConfig::load(None),
+        Arc::new(FakeLlm),
+        Arc::new(WarmBootGapSearch),
+        None,
+    );
+    let deps = probe_deps(&state).await;
+
+    assert!(
+        deps.trusty_search.reachable,
+        "a daemon that answered the probe must be reachable, whatever its warm boot did (#4079)"
+    );
+    assert_eq!(deps.trusty_search.state, DepState::Degraded);
+    assert!(
+        deps.trusty_search
+            .detail
+            .as_deref()
+            .is_some_and(|d| d.contains("failed to open their corpus")),
+        "the gap must be explained, not just named; got: {:?}",
+        deps.trusty_search.detail
+    );
+    assert_eq!(
+        compute_status(InferenceStatus::Ok, &deps),
+        "degraded",
+        "correcting the reachability lie must not hide the gap — overall status stays degraded"
+    );
+}
+
 // ── Fake LLM that returns auth error ─────────────────────────────────────────
 
 pub(super) struct AuthErrorLlm;

--- a/crates/trusty-review/src/service/handlers_tests.rs
+++ b/crates/trusty-review/src/service/handlers_tests.rs
@@ -156,6 +156,7 @@ impl SearchClient for DegradedButServingSearch {
             embedder: EmbedderState::Bool(true),
             warmboot_summary: Some(crate::integrations::health::WarmBootSummary {
                 warm_boot_degraded: false,
+                ..Default::default()
             }),
         })
     }
@@ -572,14 +573,34 @@ async fn health_stalled_dep_returns_timeout_state_within_bound() {
     );
 }
 
-// ── DepState serialisation + bounded_probe unit tests (#3658) ─────────────────
+// ── DepState serialisation + bounded_probe unit tests (#3658, #4079) ──────────
+
+/// Minimal `classify` closure for the `bounded_probe` unit tests: `true` maps to
+/// a healthy dep, `false` to one that cannot serve.
+///
+/// Why: `bounded_probe` now takes a `(DepState, Option<String>)` classifier
+/// rather than a bool predicate (#4079); sharing one helper keeps the four probe
+/// tests focused on the branch each exercises.
+/// What: `true` → `(DepState::Ok, None)`; `false` → `(DepState::Unreachable, …)`.
+/// Test: used by the `bounded_probe_*` tests below.
+fn classify_bool(v: bool) -> (super::DepState, Option<String>) {
+    if v {
+        (super::DepState::Ok, None)
+    } else {
+        (
+            super::DepState::Unreachable,
+            Some("dep reported itself unable to serve".to_string()),
+        )
+    }
+}
 
 /// `DepState` serialises as the documented lowercase strings.
 ///
 /// Why: `handlers.rs`'s doc comment on `DepState` promises `"ok"` /
-/// `"unreachable"` / `"timeout"` via `#[serde(rename_all = "snake_case")]`;
-/// this test locks that contract in so a future derive-attribute change is
-/// caught immediately rather than surfacing as a silent wire-format break.
+/// `"degraded"` / `"unreachable"` / `"timeout"` via
+/// `#[serde(rename_all = "snake_case")]`; this test locks that contract in so a
+/// future derive-attribute change is caught immediately rather than surfacing as
+/// a silent wire-format break.
 /// What: serialises each variant via `serde_json::to_value` and compares
 /// against the exact lowercase string.
 /// Test: this test itself.
@@ -592,12 +613,76 @@ fn dep_state_serialises_lowercase() {
         serde_json::json!("ok")
     );
     assert_eq!(
+        serde_json::to_value(DepState::Degraded).unwrap(),
+        serde_json::json!("degraded")
+    );
+    assert_eq!(
         serde_json::to_value(DepState::Unreachable).unwrap(),
         serde_json::json!("unreachable")
     );
     assert_eq!(
         serde_json::to_value(DepState::Timeout).unwrap(),
         serde_json::json!("timeout")
+    );
+}
+
+/// REGRESSION (#4079): `reachable` must describe the transport, never the
+/// dependency's capability.
+///
+/// Why: reporting a live, answering daemon as `reachable: false` sent an
+/// operator hunting a process that was running the whole time. `Degraded` is the
+/// state that regression produced, so it is the one that must read as reachable.
+/// What: asserts `is_reachable()` for every variant.
+/// Test: this test itself.
+#[test]
+fn dep_state_degraded_is_reachable() {
+    use super::DepState;
+
+    assert!(
+        DepState::Degraded.is_reachable(),
+        "a dependency that answered the probe is reachable, whatever it reported (#4079)"
+    );
+    assert!(DepState::Ok.is_reachable());
+    assert!(
+        !DepState::Unreachable.is_reachable(),
+        "only a failed probe is unreachable"
+    );
+    assert!(
+        !DepState::Timeout.is_reachable(),
+        "a probe that never answered is not reachable"
+    );
+}
+
+/// `bounded_probe` carries a `Degraded` classification and its reason through
+/// unchanged (#4079).
+///
+/// Why: the whole point of the middle state is the reason attached to it. A
+/// `Degraded` state whose detail was dropped on the floor would be as
+/// unactionable as the single word it replaced.
+/// What: classifies an `Ok` response as `Degraded` with a reason; asserts both
+/// the state and the exact reason survive.
+/// Test: this test itself.
+#[tokio::test]
+async fn bounded_probe_degraded_carries_detail() {
+    use super::{DepState, bounded_probe};
+
+    let (state, detail) = bounded_probe(
+        async { Ok::<bool, &str>(true) },
+        std::time::Duration::from_millis(50),
+        |_| {
+            (
+                DepState::Degraded,
+                Some("3 index(es) failed to open their corpus".to_string()),
+            )
+        },
+    )
+    .await;
+
+    assert_eq!(state, DepState::Degraded);
+    assert_eq!(
+        detail.as_deref(),
+        Some("3 index(es) failed to open their corpus"),
+        "the degradation reason must survive the probe, not be reduced to a state word"
     );
 }
 
@@ -613,13 +698,14 @@ fn dep_state_serialises_lowercase() {
 async fn bounded_probe_ok_on_healthy_response() {
     use super::{DepState, bounded_probe};
 
-    let result = bounded_probe(
-        async { Ok::<bool, ()>(true) },
+    let (result, detail) = bounded_probe(
+        async { Ok::<bool, &str>(true) },
         std::time::Duration::from_millis(50),
-        |v| v,
+        classify_bool,
     )
     .await;
 
+    assert_eq!(detail, None, "a healthy dep needs no detail");
     assert_eq!(
         result,
         DepState::Ok,
@@ -640,10 +726,10 @@ async fn bounded_probe_ok_on_healthy_response() {
 async fn bounded_probe_unreachable_on_error() {
     use super::{DepState, bounded_probe};
 
-    let result = bounded_probe(
-        async { Err::<bool, ()>(()) },
+    let (result, detail) = bounded_probe(
+        async { Err::<bool, &str>("connection refused") },
         std::time::Duration::from_millis(50),
-        |v| v,
+        classify_bool,
     )
     .await;
 
@@ -651,6 +737,11 @@ async fn bounded_probe_unreachable_on_error() {
         result,
         DepState::Unreachable,
         "Ok(Err(_)) must be DepState::Unreachable"
+    );
+    assert_eq!(
+        detail.as_deref(),
+        Some("connection refused"),
+        "the transport error text must reach the caller, not be dropped"
     );
 }
 
@@ -671,10 +762,10 @@ async fn bounded_probe_unreachable_on_error() {
 async fn bounded_probe_unreachable_on_unhealthy_response() {
     use super::{DepState, bounded_probe};
 
-    let result = bounded_probe(
-        async { Ok::<bool, ()>(false) },
+    let (result, _detail) = bounded_probe(
+        async { Ok::<bool, &str>(false) },
         std::time::Duration::from_millis(50),
-        |v| v,
+        classify_bool,
     )
     .await;
 
@@ -699,10 +790,10 @@ async fn bounded_probe_unreachable_on_unhealthy_response() {
 async fn bounded_probe_timeout_on_stalled_future() {
     use super::{DepState, bounded_probe};
 
-    let result = bounded_probe(
-        std::future::pending::<Result<bool, ()>>(),
+    let (result, _detail) = bounded_probe(
+        std::future::pending::<Result<bool, &str>>(),
         std::time::Duration::from_millis(20),
-        |v| v,
+        classify_bool,
     )
     .await;
 


### PR DESCRIPTION
Closes #4086

## The report vs. what was actually happening

The symptom was read as "the first review ran degraded because trusty-search was down." trusty-search was never down. At the moment `review_health` said `trusty_search: {reachable: false, state: "unreachable"}`, the daemon had been up 3220 s, its embedder was ready, 20 indexes were loaded, `indexes_failed: 0`, and it was answering queries.

The word "unreachable" was the whole problem: it is what sent someone looking for a dead process that was running the entire time.

## Root cause — one boolean answering two questions

`probe_deps` classified trusty-search with `HealthResponse::is_serving()` and published that single boolean as **both** `reachable` **and** `state`. `is_serving()` returned `false` whenever `status == "degraded" && warm_boot_degraded == true`.

`warm_boot_degraded` is an OR over four structurally different conditions (TCC/FDA denial, warm-boot scan timeout, corpus-open failure, mass index loss). trusty-search **#3706** folded that whole aggregate into the top-level `status`, so **any one** of them now makes the daemon answer `"degraded"`. In the observed payload it was 11 indexes skipped on a warm-boot scan timeout plus 3 with a failed corpus — none of which stop the daemon serving the other 17.

So: one unrelated repo's index failing to load on this host published "trusty-search is unreachable" for every review on the machine.

**Not a discovery or addressing bug**, ruled out with evidence:
- `search_url` resolves to `http://localhost:7878` (`config/mod.rs:421`); the live daemon listened on exactly `127.0.0.1:7878` and `curl /health` returned `200` in 22 ms.
- `state` was `"unreachable"`, not `"timeout"` — the probe completed and parsed a body.
- `trusty_analyze` reported `reachable: true` over the same loopback in the same probe pass.
- **trusty-review performs no discovery for trusty-search at all.** Its only `read_daemon_addr` use is publishing/reading *its own* address for `trusty-review port`. The search address comes solely from `TRUSTY_SEARCH_URL` or the compiled-in default.

A shared-discovery-helper hypothesis (prompted by `127.0.0.1:1` appearing in CI on #4067) was considered and **discarded on two independent grounds**: that CI failure was root-caused separately and fixed by #4072 (concurrent `~/.claude.json` trust-seed clobbering; the real panic was `enabledMcpjsonServers is an array`, and the trusty-memory lines were incidental log noise), and the code does not support it either — `127.0.0.1:1` is `UNREACHABLE_PLACEHOLDER` in `trusty-common/src/mcp/memory_rpc.rs:61`, reachable only via `resolve_memory_base_url_or_unreachable`, which has 8 callers in trusty-code/trusty-mpm and **none** in trusty-review. These are unrelated bugs. The sentinel-port fail-open is a real smell on its own merits and is filed separately as **#4092**.

## Raw proof

The verbatim live payload, fed through the **pre-fix** predicate:

```
test integrations::health::tests::health_response_live_warmboot_degraded_payload_is_reachable ... FAILED
panicked at crates/trusty-review/src/integrations/health.rs:599:9:
a live, embedder-ready, query-answering daemon must never be classified as
not-serving just because warm boot left some indexes behind (#4079)
```

Same test, same payload, after the fix:

```
test integrations::health::tests::health_response_live_warmboot_degraded_payload_is_reachable ... ok
```

## What changed

**Defect 1 — separate the two questions.**
- `HealthResponse::serving_state() -> ServingState { Serving | Degraded(reason) | NotServing(reason) }`, reading the **individual** warm-boot counters instead of the aggregate flag, and building a reason that names each gap's query-time consequence.
- New `DepState::Degraded`. `reachable` becomes `state.is_reachable()` (`Ok | Degraded`) — it now describes the transport and nothing else. A new `detail` field carries the reason to the caller.
- `compute_status` gates on `state == Ok`, **not** `reachable`, so top-level `status: "degraded"` is unchanged. The fix corrects the lie without hiding the gap.
- #3693 is preserved exactly: a `"degraded"` status with a clean warm boot (the benign network-mount watcher disable) stays `Serving` / `reachable: true` / `status: "ok"`. `degraded_reason()` returns `None` for that case rather than manufacturing a caveat nobody can act on.

**Defect 2 — stamp the output, don't fail loud.**
- `context_gate` routes a serving-but-degraded search to `GateOutcome::Degraded(reason)`, which the runner already stamps as a `DEGRADED — NOT AUTHORITATIVE` banner plus `result.error`.
- `wrap_result` emits `mcp_status: "degraded_context"` + `degraded_reason` on the envelope, with `isError` deliberately left `false`.

### Why (b) and not (a), from the call sites

`wrap_result`'s envelope is the only stable, non-prose part of an MCP response, and it was the one place a degraded verdict was invisible: `isError: false`, no `mcp_status`, the caveat buried in a serialised JSON blob and a Markdown banner. A context-free APPROVE and a fully-contexted APPROVE were byte-identical there.

Hard-failing was rejected in both directions. `isError: true` would make harnesses discard a verdict that genuinely ran and whose findings are real — re-collapsing "incomplete" into "failed", the same conflation Defect 1 is about. And refusing every review because one of ~20 unrelated indexes on the host has a bad corpus is a false-positive machine that trains callers to ignore the gate; the pre-fix code did exactly that on the `Hosted` surface. Proceed-and-label is the only outcome that is neither silent nor a blanket refusal.

A genuine outage still hard-Skips: embedder not ready, or any status outside `ok`/`degraded`. `not_serving_search_still_skips` guards that boundary, since relaxing the real outage is the risk this change carries.

## Known remaining gap (out of scope, noted in #4086)

`/health` reports warm-boot counters **host-wide** with no index identity. If the review's own index happens to be one of the corpus-failed ones it gets an empty result set and only a banner. Closing that needs a per-index probe (`GET /indexes/:id/status`) against the index the review actually uses, i.e. a new `SearchClient` trait method — deliberately not done here.

## Tests

Added:
- `health_response_live_warmboot_degraded_payload_is_reachable` — the verbatim live payload; **fails on the pre-fix predicate** (output above).
- `health_response_degraded_reason_names_corpus_failures` — the reason must name the silent failure mode and its consequence, not just say "degraded".
- `health_response_degraded_missing_summary_is_degraded_not_fatal`.
- `dep_state_degraded_is_reachable`, `bounded_probe_degraded_carries_detail` — a probe failure must not silently produce a bogus classification, and a reason must not be dropped.
- `probe_deps_degraded_search_is_reachable` — the same guarantee end-to-end through a real `SearchClient` returning the live payload, which is where the false "unreachable" was actually minted; also asserts the overall status stays `"degraded"` so correcting the lie does not hide the gap.
- `degraded_warm_boot_gap_labels_review_instead_of_skipping` + `not_serving_search_still_skips` — both sides of the relaxed gate.
- `wrap_result_degraded_sets_sentinel_and_reason` — includes a complete-review control asserting the sentinel is absent, so it is a real signal and not noise on every response.

Updated to the corrected semantics (no test disabled, ignored, or cfg-gated): `health_response_degraded_watcher_only_is_serving`, `warm_boot_summary_wire_shape_is_pinned` (now pins every mirrored counter, not just the aggregate), `dep_state_serialises_lowercase`, `wrap_result_degraded_stays_is_error_false`, `call_tool_review_diff_search_down_interactive_default_degrades`.

## Verification

```
cargo test -p trusty-review
test result: ok. 1545 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out
test result: ok. 68 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo clippy -p trusty-review --all-targets -- -D warnings   → clean
cargo fmt --check                                            → clean
bash scripts/check_line_cap.sh                               → 7 allowlisted, 0 violations — OK
cargo check --workspace --all-targets                        → clean
```

Workspace check excludes `trusty-code-gui` / `trusty-mpm-gui`, which fail in this worktree on a pre-existing missing `ui/dist` tauri asset. Neither depends on trusty-review, and this branch touches only `crates/trusty-review/`.

The five ignored tests are pre-existing (live-daemon / network-gated); none were added or newly ignored here.

## Related

Defect 3 from the same investigation — trusty-search corpus-failed indexes returning silently-empty `200`s, and timeout-skipped indexes being dropped rather than parked cold — is reported separately in #4087 and deliberately **not** touched by this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
