### PR TITLE
feat(trusty-mpm): observe native subagent dispatches and give delegations a real lifecycle (#2864 S1+S2)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -17,7 +17,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `Running` → `Completed`/`Failed` instead of sitting in `Queued` forever, and a
   `Delegation` now carries `source`, `tool_use_id`, `agent_id`,
   `transcript_path`, `cwd`, `started_at`, and `ended_at`. A dispatch that both
-  declares (`agent_delegate`) and executes produces one record, not two.
+  declares (`agent_delegate`) and executes the *same* task produces one record,
+  not two.
 - **`tm hook` forwards Claude Code's subagent correlation keys** (#2864):
   `tool_use_id` and `transcript_path` on tool events, and `agent_id` /
   `agent_type` / `agent_transcript_path` on `SubagentStop`. A `tool_response` is
@@ -27,12 +28,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **The idle nudge is no longer suppressed forever by a single delegation**
+- **The idle nudge is no longer suppressed indefinitely by a single delegation**
   (#2864): `has_live_children` treats `Queued`/`Running` as live, but nothing
   ever advanced a delegation out of `Queued`, so any session that had delegated
   once looked permanently busy. Delegations now terminalize on `SubagentStop`,
   correlated exactly by `agent_id`, so concurrent subagents close independently
-  and finishing one never closes another.
+  and finishing one never closes another. `SubagentStop` is not guaranteed to
+  arrive, so a background sweep additionally bounds liveness (below) — together
+  these cover both the hook-observed and the never-observed cases.
+- **A delegation whose `SubagentStop` never arrives can no longer pin a session
+  "busy" for the daemon's lifetime** (#2864 review): a dropped hook POST, an
+  interrupted subagent, or a dispatch that never learned an `agent_id` left a
+  `Running` record with no route out. The 60-second reap loop now sweeps
+  delegations: a live record past its budget (6 hours for `Running`, 15 minutes
+  for a `Queued` `agent_delegate` declaration that was never dispatched) is
+  marked with the new `stale` status, and non-live records are evicted an hour
+  after they stop being live. `stale` deliberately means "tracking lost this",
+  **not** "the agent finished" — it stops counting as live but is not terminal,
+  so a late `SubagentStop` still resolves it to the truth.
+- **A `PostToolUse` whose `tool_response` is absent or unrecognized no longer
+  marks a running subagent `Completed`** (#2864 review): the launch handler
+  inferred "not async, therefore finished" from no evidence at all, so a Claude
+  Code response-shape change would have silently reported "no agents in flight"
+  ~1 ms after every dispatch. It now terminalizes only on a response it
+  recognizes, and the recognized key set is defined once and shared by the
+  `tm hook` projection and the daemon so the two cannot drift.
+- **Two same-agent dispatches inside the dedup window are no longer merged into
+  one record** (#2864 review): dedup matched on the agent name alone, so a
+  declaration plus an unrelated later dispatch of the same agent collapsed
+  together — undercounting work in flight and displaying the declaration's task
+  text for the dispatch that was actually running. The task description is now a
+  required discriminator (whitespace/case-insensitive prefix match either way),
+  and the window is 120 seconds rather than 300.
 
 - **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
   `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -8,7 +8,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-
 - **Agent delegations are now tracked automatically, with a real lifecycle**
   ([#2864](https://github.com/bobmatnyc/trusty-tools/issues/2864), slices
   S1+S2): the daemon observes every native subagent dispatch from the
@@ -25,42 +24,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   relayed only for a subagent-dispatch tool and only as a fixed five-key
   projection, so an ordinary tool's output is never forwarded. All fields are
   additive.
-
-### Fixed
-
-- **The idle nudge is no longer suppressed indefinitely by a single delegation**
-  (#2864): `has_live_children` treats `Queued`/`Running` as live, but nothing
-  ever advanced a delegation out of `Queued`, so any session that had delegated
-  once looked permanently busy. Delegations now terminalize on `SubagentStop`,
-  correlated exactly by `agent_id`, so concurrent subagents close independently
-  and finishing one never closes another. `SubagentStop` is not guaranteed to
-  arrive, so a background sweep additionally bounds liveness (below) — together
-  these cover both the hook-observed and the never-observed cases.
-- **A delegation whose `SubagentStop` never arrives can no longer pin a session
-  "busy" for the daemon's lifetime** (#2864 review): a dropped hook POST, an
-  interrupted subagent, or a dispatch that never learned an `agent_id` left a
-  `Running` record with no route out. The 60-second reap loop now sweeps
-  delegations: a live record past its budget (6 hours for `Running`, 15 minutes
-  for a `Queued` `agent_delegate` declaration that was never dispatched) is
-  marked with the new `stale` status, and non-live records are evicted an hour
-  after they stop being live. `stale` deliberately means "tracking lost this",
-  **not** "the agent finished" — it stops counting as live but is not terminal,
-  so a late `SubagentStop` still resolves it to the truth.
-- **A `PostToolUse` whose `tool_response` is absent or unrecognized no longer
-  marks a running subagent `Completed`** (#2864 review): the launch handler
-  inferred "not async, therefore finished" from no evidence at all, so a Claude
-  Code response-shape change would have silently reported "no agents in flight"
-  ~1 ms after every dispatch. It now terminalizes only on a response it
-  recognizes, and the recognized key set is defined once and shared by the
-  `tm hook` projection and the daemon so the two cannot drift.
-- **Two same-agent dispatches inside the dedup window are no longer merged into
-  one record** (#2864 review): dedup matched on the agent name alone, so a
-  declaration plus an unrelated later dispatch of the same agent collapsed
-  together — undercounting work in flight and displaying the declaration's task
-  text for the dispatch that was actually running. The task description is now a
-  required discriminator (whitespace/case-insensitive prefix match either way),
-  and the window is 120 seconds rather than 300.
-
 - **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
   `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**
   (worktree-hygiene follow-up to
@@ -99,6 +62,55 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981).
 
 ### Fixed
+
+- **The idle nudge is no longer suppressed indefinitely by a single delegation**
+  (#2864): `has_live_children` treats `Queued`/`Running` as live, but nothing
+  ever advanced a delegation out of `Queued`, so any session that had delegated
+  once looked permanently busy. Delegations now terminalize on `SubagentStop`,
+  correlated exactly by `agent_id`, so concurrent subagents close independently
+  and finishing one never closes another. `SubagentStop` is not guaranteed to
+  arrive, so a background sweep additionally bounds liveness (below) — together
+  these cover both the hook-observed and the never-observed cases.
+- **A delegation whose `SubagentStop` never arrives can no longer pin a session
+  "busy" for the daemon's lifetime** (#2864 review): a dropped hook POST, an
+  interrupted subagent, or a dispatch that never learned an `agent_id` left a
+  `Running` record with no route out. The 60-second reap loop now sweeps
+  delegations: a live record past its budget (6 hours for `Running`, 15 minutes
+  for a `Queued` `agent_delegate` declaration that was never dispatched) is
+  marked with the new `stale` status. `stale` deliberately means "tracking lost
+  this", **not** "the agent finished" — it stops counting as live but is not
+  terminal, so a late `SubagentStop` still resolves it to the truth.
+- **The delegation map is bounded, without expiring the `stale` recovery
+  window** (#2864 review): a terminal delegation is evicted an hour after
+  `ended_at`; nothing can resolve a terminal record, so that costs nothing. A
+  `stale` one is held for 24 hours from its own start — an **18-hour** window in
+  which a late `SubagentStop` still resolves it — and a live one is never
+  evicted at any age. The sweep does not stamp `ended_at` on `stale`, so that
+  field keeps meaning exactly "reached a terminal status". Past 24 hours a
+  `stale` record is dropped and a later stop finds nothing: the recovery window
+  is long, not infinite, because the map must stay bounded.
+- **A `PostToolUse` no longer marks a running subagent `Completed` on an absent,
+  unparseable, or `agentId`-bearing response** (#2864 review): the launch
+  handler inferred "not async, therefore finished" from an absent response, so a
+  Claude Code response-shape change would have silently reported "no agents in
+  flight" ~1 ms after every dispatch. The response is now classified three ways
+  — *launched* / *returned* / *unknown* — and only *returned* completes. A
+  response carrying an `agentId` counts as *launched*, since that key exists
+  precisely so a future `SubagentStop` can quote it; marking such a dispatch
+  complete while storing the id to expect a stop for was self-contradictory. The
+  recognized key set is defined once and shared by the `tm hook` projection and
+  the daemon so the two cannot drift. *Known limitation:* a recognized response
+  that carries no `agentId` and is silent about liveness is still read as a
+  synchronous return — such a response has no other route to termination, so
+  tightening it is blocked on giving `SubagentStop` a recovery path first.
+- **Two same-agent dispatches inside the dedup window are no longer merged into
+  one record** (#2864 review): dedup matched on the agent name alone, so a
+  declaration plus an unrelated later dispatch of the same agent collapsed
+  together — undercounting work in flight and displaying the declaration's task
+  text for the dispatch that was actually running. The task description is now a
+  required discriminator (whitespace/case-insensitive prefix match either way; a
+  dispatch with no description declines to merge at all), and the window is 120
+  seconds rather than 300.
 
 - **Bare `tm` no longer misreports a managed pane as "not a git project"**
   (closes [#4061](https://github.com/bobmatnyc/trusty-tools/issues/4061)):

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Agent delegations are now tracked automatically, with a real lifecycle**
+  ([#2864](https://github.com/bobmatnyc/trusty-tools/issues/2864), slices
+  S1+S2): the daemon observes every native subagent dispatch from the
+  `PreToolUse` hook it already receives on every managed session, so tracking no
+  longer depends on the PM voluntarily calling `agent_delegate`. Delegations move
+  `Running` → `Completed`/`Failed` instead of sitting in `Queued` forever, and a
+  `Delegation` now carries `source`, `tool_use_id`, `agent_id`,
+  `transcript_path`, `cwd`, `started_at`, and `ended_at`. A dispatch that both
+  declares (`agent_delegate`) and executes produces one record, not two.
+- **`tm hook` forwards Claude Code's subagent correlation keys** (#2864):
+  `tool_use_id` and `transcript_path` on tool events, and `agent_id` /
+  `agent_type` / `agent_transcript_path` on `SubagentStop`. A `tool_response` is
+  relayed only for a subagent-dispatch tool and only as a fixed five-key
+  projection, so an ordinary tool's output is never forwarded. All fields are
+  additive.
+
+### Fixed
+
+- **The idle nudge is no longer suppressed forever by a single delegation**
+  (#2864): `has_live_children` treats `Queued`/`Running` as live, but nothing
+  ever advanced a delegation out of `Queued`, so any session that had delegated
+  once looked permanently busy. Delegations now terminalize on `SubagentStop`,
+  correlated exactly by `agent_id`, so concurrent subagents close independently
+  and finishing one never closes another.
+
 - **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
   `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**
   (worktree-hygiene follow-up to

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
@@ -1,0 +1,300 @@
+//! `tm hook` → daemon payload construction (#2864 S1).
+//!
+//! Why: the hook handler forwarded only `cwd`, `tool`, `input`, and the
+//! idle-parking flags to `POST /hooks`. That is enough to audit a tool call but
+//! not enough to *correlate* one: a `PreToolUse` dispatching a subagent and the
+//! `SubagentStop` that ends it were indistinguishable from any other pair of
+//! events, so the daemon could never tell which of several concurrent subagents
+//! had finished. The correlation keys Claude Code already ships in the hook
+//! payload — `tool_use_id` on the tool events and `agent_id` on `SubagentStop` —
+//! were simply being dropped on the floor. This module forwards them.
+//!
+//! Extracting the builder out of `commands::misc` is deliberate: `misc.rs` sits
+//! ~10 SLOC under the 500-line production cap, and a pure function is unit
+//! testable without spawning the binary or standing up an HTTP server.
+//!
+//! What: [`build_hook_payload`] returns the JSON object sent as `payload`. Every
+//! field it adds beyond the pre-#2864 set is additive and emitted only when the
+//! source field is present, so existing daemon consumers are unaffected.
+//! [`compact_tool_response`] bounds what a `PostToolUse` may carry — see its own
+//! note on why the raw `tool_response` must never be forwarded wholesale.
+//!
+//! Field names are those Claude Code actually emits, confirmed empirically
+//! against Claude Code 2.1.220 by capturing live hook stdin (see the #2864
+//! Step-0 probe): `PreToolUse`/`PostToolUse` carry `tool_use_id` and
+//! `transcript_path`; `SubagentStop` carries `agent_id`, `agent_type`, and
+//! `agent_transcript_path` (the *subagent's* transcript — distinct from
+//! `transcript_path`, which on that event is the *parent's*).
+//!
+//! Test: the `#[cfg(test)]` suite below, plus the end-to-end
+//! `tm_hook_delegation_payload` integration test which asserts these fields
+//! survive the real binary's stdin → HTTP POST path.
+
+use serde_json::Value;
+
+/// Fields copied verbatim from the stdin hook payload when present.
+///
+/// Why: all five are short, bounded scalars that the daemon's delegation
+/// tracker needs and that no existing consumer reads, so copying them is cheap
+/// and cannot regress anything. `tool_response` is deliberately NOT in this list
+/// — see [`compact_tool_response`].
+/// What: `transcript_path` and `tool_use_id` (tool events), `agent_id`,
+/// `agent_type`, `agent_transcript_path` (`SubagentStop`).
+/// Test: `forwards_pre_tool_use_correlation_keys`,
+/// `forwards_subagent_stop_correlation_keys`.
+const PASSTHROUGH_FIELDS: &[&str] = &[
+    "transcript_path",
+    "tool_use_id",
+    "agent_id",
+    "agent_type",
+    "agent_transcript_path",
+];
+
+/// Keys retained from a subagent-dispatch `tool_response`.
+///
+/// Why: `agentId` is the join between `tool_use_id` and `SubagentStop.agent_id`;
+/// `status`/`isAsync` tell the daemon whether the dispatch returned
+/// synchronously (subagent already done) or was merely launched
+/// (`"async_launched"` — subagent still running, so terminalizing here would be
+/// wrong); `resolvedModel` refines the delegation's model tier; `is_error`
+/// distinguishes a failed dispatch from a successful one.
+/// Test: `compacts_tool_response_to_correlation_keys`.
+const TOOL_RESPONSE_KEYS: &[&str] = &["agentId", "status", "isAsync", "resolvedModel", "is_error"];
+
+/// Reduce a subagent-dispatch `tool_response` to its correlation fields.
+///
+/// Why: a raw `tool_response` carries the subagent's entire result payload —
+/// unbounded text that would be POSTed to the daemon on every dispatch and then
+/// held in the ring buffer. The daemon needs five small scalars from it and
+/// nothing else, so forwarding the whole object would buy nothing and cost an
+/// arbitrary amount of memory and bandwidth. Projecting to a fixed key set makes
+/// the forwarded size constant regardless of how much the subagent wrote.
+/// What: returns an object holding whichever of [`TOOL_RESPONSE_KEYS`] are
+/// present, or `None` when `response` is not an object or holds none of them.
+/// Test: `compacts_tool_response_to_correlation_keys`,
+/// `compact_tool_response_drops_bulk_output`.
+fn compact_tool_response(response: &Value) -> Option<Value> {
+    let obj = response.as_object()?;
+    let mut out = serde_json::Map::new();
+    for key in TOOL_RESPONSE_KEYS {
+        if let Some(v) = obj.get(*key) {
+            out.insert((*key).to_string(), v.clone());
+        }
+    }
+    (!out.is_empty()).then_some(Value::Object(out))
+}
+
+/// Build the `payload` object for one `POST /hooks` relay.
+///
+/// Why: one place that decides what the daemon is told about a hook event, so
+/// the forwarded shape is auditable and testable rather than smeared across the
+/// handler. See the module note for why the correlation keys matter.
+/// What: always emits `cwd` (issue #1744 — the daemon correlates a
+/// `SessionStart` to a managed session by workspace path). Adds
+/// `idle_parking`/`idle_parking_phrase` when `idle_parking_phrase` is `Some`
+/// (#2610); `tool`/`input` from `tool_name`/`tool_input` (#1956); each present
+/// member of [`PASSTHROUGH_FIELDS`]; and, only for a
+/// [`is_subagent_dispatch_tool`](trusty_mpm::core::agent::is_subagent_dispatch_tool)
+/// tool, a [`compact_tool_response`] under `tool_response` (#2864).
+///
+/// This function performs no I/O and writes nothing to stdout — it is called on
+/// the `PreToolUse` path, which has a hard stdout-purity contract (the hook's
+/// stdout must contain only the rewrite JSON object, if any).
+/// Test: the `#[cfg(test)]` suite below.
+pub(crate) fn build_hook_payload(
+    cwd: &str,
+    stdin_payload: Option<&Value>,
+    idle_parking_phrase: Option<&str>,
+) -> Value {
+    let mut payload = serde_json::json!({ "cwd": cwd });
+
+    // #2610: forward the idle-parking signal so the daemon can surface it and
+    // auto-nudge.
+    if let Some(phrase) = idle_parking_phrase {
+        payload["idle_parking"] = Value::Bool(true);
+        payload["idle_parking_phrase"] = Value::String(phrase.to_string());
+    }
+
+    let Some(stdin) = stdin_payload else {
+        return payload;
+    };
+
+    // #1956: the daemon's hook_service reads `payload["tool"]`/`["input"]`.
+    let tool_name = stdin.get("tool_name").and_then(Value::as_str);
+    if let Some(name) = tool_name {
+        payload["tool"] = Value::String(name.to_string());
+    }
+    if let Some(input) = stdin.get("tool_input") {
+        payload["input"] = input.clone();
+    }
+
+    // #2864: correlation keys. Copied only when present — a hook event that
+    // does not carry a field simply omits it.
+    for field in PASSTHROUGH_FIELDS {
+        if let Some(v) = stdin.get(*field)
+            && !v.is_null()
+        {
+            payload[*field] = v.clone();
+        }
+    }
+
+    // #2864: the dispatch response, compacted, and only for a subagent-dispatch
+    // tool — this is where `agentId` comes from.
+    if tool_name.is_some_and(trusty_mpm::core::agent::is_subagent_dispatch_tool)
+        && let Some(response) = stdin.get("tool_response")
+        && let Some(compact) = compact_tool_response(response)
+    {
+        payload["tool_response"] = compact;
+    }
+
+    payload
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A `PreToolUse` payload as Claude Code 2.1.220 actually emits it for a
+    /// subagent dispatch (verbatim shape from the #2864 Step-0 capture).
+    fn pre_tool_use_agent() -> Value {
+        serde_json::json!({
+            "session_id": "d6066d66-8c7f-41f1-8914-8d0710d563aa",
+            "transcript_path": "/tmp/proj/d6066d66.jsonl",
+            "cwd": "/tmp/proj",
+            "prompt_id": "31fd3d1b-d586-412f-9772-2baf48d56acf",
+            "permission_mode": "bypassPermissions",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Agent",
+            "tool_input": {
+                "description": "probe alpha",
+                "prompt": "Reply with ALPHA.",
+                "subagent_type": "general-purpose"
+            },
+            "tool_use_id": "toolu_01DAvdgnCx8jYZQmn8NYpUge"
+        })
+    }
+
+    #[test]
+    fn forwards_pre_tool_use_correlation_keys() {
+        let p = build_hook_payload("/tmp/proj", Some(&pre_tool_use_agent()), None);
+        assert_eq!(p["cwd"], "/tmp/proj");
+        assert_eq!(p["tool"], "Agent");
+        assert_eq!(p["input"]["subagent_type"], "general-purpose");
+        assert_eq!(p["input"]["description"], "probe alpha");
+        // The #2864 additions.
+        assert_eq!(p["tool_use_id"], "toolu_01DAvdgnCx8jYZQmn8NYpUge");
+        assert_eq!(p["transcript_path"], "/tmp/proj/d6066d66.jsonl");
+    }
+
+    #[test]
+    fn forwards_subagent_stop_correlation_keys() {
+        // SubagentStop carries `agent_id` (the correlation key) plus BOTH the
+        // parent transcript (`transcript_path`) and the subagent's own
+        // (`agent_transcript_path`) — they are different files.
+        let stdin = serde_json::json!({
+            "hook_event_name": "SubagentStop",
+            "session_id": "d6066d66-8c7f-41f1-8914-8d0710d563aa",
+            "transcript_path": "/tmp/proj/d6066d66.jsonl",
+            "agent_id": "a403cdbc078b5c474",
+            "agent_type": "general-purpose",
+            "agent_transcript_path": "/tmp/proj/d6066d66/subagents/agent-a403cdbc078b5c474.jsonl",
+            "last_assistant_message": "ALPHA"
+        });
+        let p = build_hook_payload("/tmp/proj", Some(&stdin), None);
+        assert_eq!(p["agent_id"], "a403cdbc078b5c474");
+        assert_eq!(p["agent_type"], "general-purpose");
+        assert_eq!(
+            p["agent_transcript_path"],
+            "/tmp/proj/d6066d66/subagents/agent-a403cdbc078b5c474.jsonl"
+        );
+        assert_eq!(p["transcript_path"], "/tmp/proj/d6066d66.jsonl");
+        // No tool on a stop event.
+        assert!(p.get("tool").is_none());
+    }
+
+    #[test]
+    fn compacts_tool_response_to_correlation_keys() {
+        let stdin = serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Agent",
+            "tool_use_id": "toolu_01DAvdgnCx8jYZQmn8NYpUge",
+            "tool_response": {
+                "isAsync": true,
+                "status": "async_launched",
+                "agentId": "a403cdbc078b5c474",
+                "resolvedModel": "claude-haiku-4-5-20251001",
+                "description": "probe alpha",
+                "prompt": "Reply with ALPHA.",
+                "outputFile": "/tmp/out.txt",
+                "canReadOutputFile": true
+            }
+        });
+        let p = build_hook_payload("/tmp/proj", Some(&stdin), None);
+        assert_eq!(p["tool_response"]["agentId"], "a403cdbc078b5c474");
+        assert_eq!(p["tool_response"]["status"], "async_launched");
+        assert_eq!(p["tool_response"]["isAsync"], true);
+        assert_eq!(
+            p["tool_response"]["resolvedModel"],
+            "claude-haiku-4-5-20251001"
+        );
+        // Bulk / irrelevant fields are dropped.
+        assert!(p["tool_response"].get("prompt").is_none());
+        assert!(p["tool_response"].get("outputFile").is_none());
+    }
+
+    #[test]
+    fn compact_tool_response_drops_bulk_output() {
+        // A non-dispatch tool's response must never be forwarded at all, no
+        // matter how large — this is the bandwidth guard.
+        let huge = "x".repeat(200_000);
+        let stdin = serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_use_id": "toolu_bash",
+            "tool_response": { "stdout": huge, "is_error": false }
+        });
+        let p = build_hook_payload("/tmp/proj", Some(&stdin), None);
+        assert!(
+            p.get("tool_response").is_none(),
+            "non-dispatch tool_response must not be forwarded"
+        );
+        assert!(p.to_string().len() < 1000, "payload must stay bounded");
+    }
+
+    #[test]
+    fn preserves_idle_parking_fields() {
+        // #2610 behaviour must be unchanged by the #2864 additions.
+        let stdin = serde_json::json!({
+            "hook_event_name": "SubagentStop",
+            "agent_id": "a403cdbc078b5c474"
+        });
+        let p = build_hook_payload("/w", Some(&stdin), Some("waiting for the monitor"));
+        assert_eq!(p["idle_parking"], true);
+        assert_eq!(p["idle_parking_phrase"], "waiting for the monitor");
+        assert_eq!(p["agent_id"], "a403cdbc078b5c474");
+    }
+
+    #[test]
+    fn no_stdin_payload_yields_cwd_only() {
+        let p = build_hook_payload("/w", None, None);
+        assert_eq!(p["cwd"], "/w");
+        assert_eq!(p.as_object().expect("object").len(), 1);
+    }
+
+    #[test]
+    fn absent_fields_are_omitted_not_nulled() {
+        // A minimal Bash PreToolUse has no correlation keys; the builder must
+        // omit them rather than emit explicit nulls (which would make the
+        // daemon's `get(..).and_then(as_str)` reads ambiguous).
+        let stdin = serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": { "command": "ls" },
+            "agent_id": Value::Null
+        });
+        let p = build_hook_payload("/w", Some(&stdin), None);
+        assert!(p.get("agent_id").is_none());
+        assert!(p.get("tool_use_id").is_none());
+        assert!(p.get("transcript_path").is_none());
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/hook_payload.rs
@@ -31,6 +31,7 @@
 //! survive the real binary's stdin → HTTP POST path.
 
 use serde_json::Value;
+use trusty_mpm::core::agent::TOOL_RESPONSE_KEYS;
 
 /// Fields copied verbatim from the stdin hook payload when present.
 ///
@@ -49,17 +50,6 @@ const PASSTHROUGH_FIELDS: &[&str] = &[
     "agent_type",
     "agent_transcript_path",
 ];
-
-/// Keys retained from a subagent-dispatch `tool_response`.
-///
-/// Why: `agentId` is the join between `tool_use_id` and `SubagentStop.agent_id`;
-/// `status`/`isAsync` tell the daemon whether the dispatch returned
-/// synchronously (subagent already done) or was merely launched
-/// (`"async_launched"` — subagent still running, so terminalizing here would be
-/// wrong); `resolvedModel` refines the delegation's model tier; `is_error`
-/// distinguishes a failed dispatch from a successful one.
-/// Test: `compacts_tool_response_to_correlation_keys`.
-const TOOL_RESPONSE_KEYS: &[&str] = &["agentId", "status", "isAsync", "resolvedModel", "is_error"];
 
 /// Reduce a subagent-dispatch `tool_response` to its correlation fields.
 ///

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -664,23 +664,13 @@ pub(crate) async fn hook(client: &reqwest::Client, url: &str) -> anyhow::Result<
         .ok()
         .and_then(|p| p.to_str().map(str::to_owned))
         .unwrap_or_default();
-    let mut payload = serde_json::json!({ "cwd": cwd });
-    // #2610: forward the idle-parking signal in the structured hook payload so
-    // the daemon can surface it (dashboard / errors feed) and a future pass can
-    // auto-nudge. Additive fields — harmless to existing hook_service consumers.
-    if let Some(phrase) = idle_parking {
-        payload["idle_parking"] = serde_json::Value::Bool(true);
-        payload["idle_parking_phrase"] = serde_json::Value::String(phrase.to_string());
-    }
-    // #1956: enrich the observability payload with tool/input when present —
-    // the daemon's hook_service already reads `payload["tool"]`/`["input"]`
-    // (see `daemon::services::hook_service::OverseerContext` construction).
-    if let Some(name) = tool_name {
-        payload["tool"] = serde_json::Value::String(name.to_string());
-    }
-    if let Some(input) = tool_input {
-        payload["input"] = input.clone();
-    }
+    // #2610 (idle-parking flags), #1956 (tool/input), #2864 (subagent
+    // correlation keys: tool_use_id / agent_id / transcript paths). Built by
+    // `commands::hook_payload` — a pure, unit-tested function that performs no
+    // I/O and never writes to stdout, so the PreToolUse stdout-purity contract
+    // documented above is preserved.
+    let payload =
+        super::hook_payload::build_hook_payload(&cwd, stdin_payload.as_ref(), idle_parking);
     let body = serde_json::json!({
         "session_id": session_id,
         "event": event,

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod guided_inplace;
 pub(crate) mod guided_launch;
 pub(crate) mod guided_resolver;
 pub(crate) mod guided_resume;
+pub(crate) mod hook_payload;
 pub(crate) mod hook_rewrite;
 pub(crate) mod hooks;
 pub(crate) mod install;

--- a/crates/trusty-mpm/src/core/agent.rs
+++ b/crates/trusty-mpm/src/core/agent.rs
@@ -81,6 +81,29 @@ pub fn is_subagent_dispatch_tool(tool_name: &str) -> bool {
     SUBAGENT_DISPATCH_TOOLS.contains(&tool_name)
 }
 
+/// Keys retained from (and recognised in) a subagent-dispatch `tool_response`.
+///
+/// Why: this list is the contract between the two halves of #2864, and both
+/// halves must agree on it or the daemon silently misreads the world. `tm hook`
+/// (S1) projects an incoming `tool_response` down to exactly these keys, so a
+/// subagent's unbounded output is never forwarded; the daemon (S2) treats a
+/// response carrying at least one of them as *understood*, and only an
+/// understood response is evidence about whether the dispatch left a subagent
+/// running. If the two lists drifted, the daemon would either see a response it
+/// could not interpret (fail-closed, merely no tracking) or — worse — treat an
+/// uninterpretable object as a synchronous return. One definition removes the
+/// possibility.
+///
+/// `agentId` is the join between `tool_use_id` and `SubagentStop.agent_id`;
+/// `status`/`isAsync` say whether the dispatch returned synchronously or was
+/// merely launched (`"async_launched"` — subagent still running);
+/// `resolvedModel` refines the model tier; `is_error` distinguishes a failed
+/// dispatch from a successful one.
+/// Test: `compacts_tool_response_to_correlation_keys` (S1),
+/// `post_tool_use_with_unrecognized_response_stays_running` (S2).
+pub const TOOL_RESPONSE_KEYS: &[&str] =
+    &["agentId", "status", "isAsync", "resolvedModel", "is_error"];
+
 /// Stable identifier for one agent delegation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DelegationId(pub Uuid);
@@ -112,6 +135,50 @@ pub enum DelegationStatus {
     Failed,
     /// Delegation was cancelled before completion.
     Cancelled,
+    /// Tracking lost this delegation: it sat in a live status past the liveness
+    /// budget and no terminal signal ever arrived (#2864 review, HIGH 2).
+    ///
+    /// Why this is a distinct status and not `Completed`/`Cancelled`: "we know
+    /// it finished" and "we lost track of it" are different facts, and
+    /// collapsing them is exactly the false report this feature exists to
+    /// prevent. `Stale` asserts only that the record may no longer be trusted as
+    /// evidence of work in flight. It is deliberately **neither live nor
+    /// terminal** — see [`DelegationStatus::is_live`] and
+    /// [`DelegationStatus::is_terminal`] — so it stops suppressing the idle
+    /// nudge, yet a late `SubagentStop` can still resolve it to the truth.
+    /// Test: `stale_running_delegation_stops_suppressing_the_nudge`,
+    /// `late_subagent_stop_still_resolves_a_stale_delegation`.
+    Stale,
+}
+
+impl DelegationStatus {
+    /// Does a delegation in this status still count as work in flight?
+    ///
+    /// Why: the single definition of "live" shared by
+    /// [`crate::daemon::idle_nudge::has_live_children`] (which must not nudge a
+    /// session whose children are still running) and the staleness sweep (which
+    /// must only ever act on live records). Two copies of this predicate would
+    /// eventually disagree, and a disagreement here is a false idle report.
+    /// What: `true` for `Queued` and `Running` only.
+    /// Test: `has_live_children_true_for_running`,
+    /// `has_live_children_false_when_terminal`.
+    pub fn is_live(self) -> bool {
+        matches!(self, Self::Queued | Self::Running)
+    }
+
+    /// Is this a settled outcome the tracker will never move away from?
+    ///
+    /// Why: `SubagentStop` must not re-terminalize an already-closed delegation
+    /// (idempotence), but it *must* still be able to close a `Stale` one — that
+    /// recovery path is what keeps the staleness sweep from being a one-way
+    /// false negative for a genuinely long-running agent.
+    /// What: `true` for `Completed`/`Failed`/`Cancelled`. `Stale` is **not**
+    /// terminal.
+    /// Test: `subagent_stop_is_idempotent`,
+    /// `late_subagent_stop_still_resolves_a_stale_delegation`.
+    pub fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
+    }
 }
 
 /// How a delegation record came to exist.
@@ -194,7 +261,15 @@ pub struct Delegation {
     /// When the subagent actually started running (UTC), when known.
     #[serde(default)]
     pub started_at: Option<chrono::DateTime<chrono::Utc>>,
-    /// When the delegation reached a terminal status (UTC), when known.
+    /// When the delegation stopped being live (UTC), when known.
+    ///
+    /// Note this is "when tracking stopped counting it as in flight", not
+    /// necessarily "when the subagent finished": for
+    /// [`DelegationStatus::Stale`] it is the moment the staleness sweep gave up
+    /// on the record, and the subagent may well still be running. The `status`
+    /// field is what disambiguates. It is also the retention clock — a record
+    /// with `ended_at` set is evicted once it ages past
+    /// `daemon::state::sessions::DELEGATION_RETENTION_SECS`.
     #[serde(default)]
     pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/crates/trusty-mpm/src/core/agent.rs
+++ b/crates/trusty-mpm/src/core/agent.rs
@@ -261,15 +261,15 @@ pub struct Delegation {
     /// When the subagent actually started running (UTC), when known.
     #[serde(default)]
     pub started_at: Option<chrono::DateTime<chrono::Utc>>,
-    /// When the delegation stopped being live (UTC), when known.
+    /// When the delegation reached a **terminal** status (UTC), when known.
     ///
-    /// Note this is "when tracking stopped counting it as in flight", not
-    /// necessarily "when the subagent finished": for
-    /// [`DelegationStatus::Stale`] it is the moment the staleness sweep gave up
-    /// on the record, and the subagent may well still be running. The `status`
-    /// field is what disambiguates. It is also the retention clock — a record
-    /// with `ended_at` set is evicted once it ages past
-    /// `daemon::state::sessions::DELEGATION_RETENTION_SECS`.
+    /// This means exactly that and nothing broader — every writer sets it
+    /// alongside `Completed`/`Failed`/`Cancelled`. In particular the staleness
+    /// sweep does NOT stamp it: a [`DelegationStatus::Stale`] record has no
+    /// `ended_at`, because it did not end — tracking merely stopped trusting it,
+    /// and the subagent may still be running. Keeping the field single-meaning
+    /// is what lets it serve as the terminal-retention clock without putting a
+    /// possibly-live record on that clock (#2864 re-review).
     #[serde(default)]
     pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
 }

--- a/crates/trusty-mpm/src/core/agent.rs
+++ b/crates/trusty-mpm/src/core/agent.rs
@@ -53,6 +53,34 @@ impl ModelTier {
     }
 }
 
+/// Tool names Claude Code uses to dispatch a native subagent.
+///
+/// Why (#2864): delegation tracking hangs off the `PreToolUse`/`PostToolUse`
+/// hook, which names the tool being invoked. The subagent-dispatch tool was
+/// called `Task` in earlier Claude Code releases and is called `Agent` in
+/// current ones (empirically confirmed against Claude Code 2.1.220, whose
+/// `PreToolUse` payload carries `"tool_name": "Agent"`). Matching only one of
+/// the two names silently disables tracking on half the installed base, so both
+/// are recognised and neither may be removed without re-probing the live hook
+/// payload.
+/// What: the exact `tool_name` values that mean "a subagent is being spawned".
+/// Test: `subagent_dispatch_tool_matches_both_names`.
+pub const SUBAGENT_DISPATCH_TOOLS: &[&str] = &["Task", "Agent"];
+
+/// Is `tool_name` the native subagent-dispatch tool?
+///
+/// Why: the single predicate both the `tm hook` payload builder and the daemon's
+/// delegation tracker consult, so the two can never disagree about what counts
+/// as a delegation. It is also the hot-path early-out — every non-dispatch tool
+/// call in every managed session hits this and nothing else.
+/// What: case-sensitive membership test against [`SUBAGENT_DISPATCH_TOOLS`]
+/// (Claude Code emits the tool name verbatim, so an exact match is correct and
+/// avoids matching an unrelated user tool named `agent`).
+/// Test: `subagent_dispatch_tool_matches_both_names`.
+pub fn is_subagent_dispatch_tool(tool_name: &str) -> bool {
+    SUBAGENT_DISPATCH_TOOLS.contains(&tool_name)
+}
+
 /// Stable identifier for one agent delegation.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct DelegationId(pub Uuid);
@@ -86,6 +114,30 @@ pub enum DelegationStatus {
     Cancelled,
 }
 
+/// How a delegation record came to exist.
+///
+/// Why (#2864): tracking used to be opt-in — a delegation existed only if the PM
+/// voluntarily called the `agent_delegate` MCP tool, so a PM that dispatched
+/// work with the native subagent tool alone left no trace at all. The daemon now
+/// also *observes* dispatches from the `PreToolUse` hook, which is non-opt-in.
+/// Recording which of the two produced a record lets the dedup pass merge the
+/// declaration and the observation of the *same* delegation into one node
+/// instead of double-counting it, and lets consumers tell a PM-asserted
+/// intention from an observed fact.
+/// What: `McpDeclared` — created by the `agent_delegate` MCP tool (the PM said
+/// it would delegate). `HookObserved` — created from a `PreToolUse` hook naming
+/// a [`SUBAGENT_DISPATCH_TOOLS`] tool (the runtime actually dispatched).
+/// Test: `delegation_defaults_to_mcp_declared_source`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DelegationSource {
+    /// Declared through the `agent_delegate` MCP tool.
+    #[default]
+    McpDeclared,
+    /// Observed from a `PreToolUse` subagent-dispatch hook.
+    HookObserved,
+}
+
 /// A node in a session's agent-delegation tree.
 ///
 /// Why: the dashboard renders delegations as a tree (PM → research → ...).
@@ -115,6 +167,36 @@ pub struct Delegation {
     pub task: String,
     /// When the delegation was created (UTC).
     pub created_at: chrono::DateTime<chrono::Utc>,
+    /// How this record was created (#2864).
+    #[serde(default)]
+    pub source: DelegationSource,
+    /// Claude Code's `tool_use_id` for the dispatching tool call, when known.
+    ///
+    /// Why: this is the key that joins `PreToolUse` to its matching
+    /// `PostToolUse` — both carry the identical `toolu_…` id. It is what makes
+    /// correlation exact under concurrency instead of a "most recent" guess.
+    #[serde(default)]
+    pub tool_use_id: Option<String>,
+    /// Claude Code's subagent `agent_id`, learned from the `PostToolUse`
+    /// response and matched against `SubagentStop.agent_id` (#2864).
+    ///
+    /// Why: `SubagentStop` does not carry `tool_use_id`; it carries `agent_id`.
+    /// `PostToolUse.tool_response.agentId` is the only place the two identifier
+    /// spaces meet, so it must be persisted here for the stop hook to resolve.
+    #[serde(default)]
+    pub agent_id: Option<String>,
+    /// Transcript the dispatching turn was writing to, when known.
+    #[serde(default)]
+    pub transcript_path: Option<std::path::PathBuf>,
+    /// Working directory the dispatch was issued from, when known.
+    #[serde(default)]
+    pub cwd: Option<std::path::PathBuf>,
+    /// When the subagent actually started running (UTC), when known.
+    #[serde(default)]
+    pub started_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// When the delegation reached a terminal status (UTC), when known.
+    #[serde(default)]
+    pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 impl Delegation {
@@ -136,6 +218,51 @@ impl Delegation {
             circuit: CircuitState::Closed,
             task: task.into(),
             created_at: chrono::Utc::now(),
+            source: DelegationSource::McpDeclared,
+            tool_use_id: None,
+            agent_id: None,
+            transcript_path: None,
+            cwd: None,
+            started_at: None,
+            ended_at: None,
+        }
+    }
+
+    /// Build a `Running` delegation observed from a subagent-dispatch hook.
+    ///
+    /// Why (#2864): a `PreToolUse` naming a [`SUBAGENT_DISPATCH_TOOLS`] tool is
+    /// proof the runtime is spawning a subagent *now* — not queueing it — so
+    /// unlike [`Self::new`] this starts in [`DelegationStatus::Running`] with
+    /// `started_at` stamped. Carrying `tool_use_id` from birth is what lets the
+    /// matching `PostToolUse` find exactly this record among concurrent
+    /// siblings.
+    /// What: same shape as [`Self::new`] but `source = HookObserved`, status
+    /// `Running`, and `started_at = created_at`.
+    /// Test: `observed_delegation_starts_running`.
+    pub fn observed(
+        session: SessionId,
+        agent: impl Into<String>,
+        task: impl Into<String>,
+        tool_use_id: Option<String>,
+    ) -> Self {
+        let now = chrono::Utc::now();
+        Self {
+            id: DelegationId::new(),
+            session,
+            parent: None,
+            agent: agent.into(),
+            tier: ModelTier::Sonnet,
+            status: DelegationStatus::Running,
+            circuit: CircuitState::Closed,
+            task: task.into(),
+            created_at: now,
+            source: DelegationSource::HookObserved,
+            tool_use_id,
+            agent_id: None,
+            transcript_path: None,
+            cwd: None,
+            started_at: Some(now),
+            ended_at: None,
         }
     }
 }
@@ -174,6 +301,69 @@ mod tests {
         assert_eq!(back.status, DelegationStatus::Queued);
         assert_eq!(back.tier, ModelTier::Sonnet);
         assert!(back.parent.is_none());
+    }
+
+    #[test]
+    fn subagent_dispatch_tool_matches_both_names() {
+        // Both the legacy (`Task`) and current (`Agent`, Claude Code 2.1.220)
+        // names must match — recognising only one silently disables tracking.
+        assert!(is_subagent_dispatch_tool("Task"));
+        assert!(is_subagent_dispatch_tool("Agent"));
+        // Exact match only: ordinary tools and lookalikes must not match.
+        assert!(!is_subagent_dispatch_tool("Bash"));
+        assert!(!is_subagent_dispatch_tool("agent"));
+        assert!(!is_subagent_dispatch_tool("TaskRunner"));
+        assert!(!is_subagent_dispatch_tool(""));
+    }
+
+    #[test]
+    fn delegation_defaults_to_mcp_declared_source() {
+        // `Delegation::new` is the `agent_delegate` path and must keep its
+        // pre-#2864 semantics: Queued, MCP-declared, no hook correlation keys.
+        let d = Delegation::new(SessionId::new(), None, "qa", ModelTier::Sonnet, "test");
+        assert_eq!(d.source, DelegationSource::McpDeclared);
+        assert_eq!(d.status, DelegationStatus::Queued);
+        assert!(d.tool_use_id.is_none());
+        assert!(d.started_at.is_none());
+        assert!(d.ended_at.is_none());
+    }
+
+    #[test]
+    fn observed_delegation_starts_running() {
+        let d = Delegation::observed(
+            SessionId::new(),
+            "engineer",
+            "implement",
+            Some("toolu_01ABC".into()),
+        );
+        assert_eq!(d.source, DelegationSource::HookObserved);
+        assert_eq!(d.status, DelegationStatus::Running);
+        assert_eq!(d.tool_use_id.as_deref(), Some("toolu_01ABC"));
+        assert_eq!(d.started_at, Some(d.created_at));
+        assert!(d.ended_at.is_none());
+    }
+
+    #[test]
+    fn legacy_delegation_json_without_new_fields_round_trips() {
+        // Records persisted before #2864 carry none of the new fields; they must
+        // still deserialize (every new field is `#[serde(default)]`) and default
+        // to the MCP-declared source they in fact came from.
+        let legacy = serde_json::json!({
+            "id": Uuid::new_v4(),
+            "session": SessionId::new(),
+            "agent": "research",
+            "tier": "sonnet",
+            "status": "queued",
+            "circuit": CircuitState::Closed,
+            "task": "investigate",
+            "created_at": chrono::Utc::now(),
+        });
+        let back: Delegation =
+            serde_json::from_value(legacy).expect("legacy delegation JSON must deserialize");
+        assert_eq!(back.source, DelegationSource::McpDeclared);
+        assert!(back.tool_use_id.is_none());
+        assert!(back.agent_id.is_none());
+        assert!(back.cwd.is_none());
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/idle_nudge.rs
+++ b/crates/trusty-mpm/src/daemon/idle_nudge.rs
@@ -25,7 +25,7 @@ use std::sync::Arc;
 use chrono::{DateTime, Utc};
 use tracing::{info, warn};
 
-use crate::core::agent::{Delegation, DelegationStatus};
+use crate::core::agent::Delegation;
 use crate::core::config::MpmConfig;
 use crate::core::hook::HookEvent;
 use crate::core::idle_nudge::{IdleNudgeConfig, NudgeDecision, NudgeLedger, decide_nudge};
@@ -42,19 +42,18 @@ use crate::session_manager::{ManagedSessionState, SessionManager};
 /// A leaf engineer agent (the common dogfooding park) has no live children, so
 /// this returns `false` and the nudge proceeds; a PM with a running delegation
 /// returns `true` and is left alone.
-/// What: `true` iff any delegation is [`DelegationStatus::Queued`] or
-/// [`DelegationStatus::Running`]. `Completed`/`Failed`/`Cancelled` delegations
-/// are terminal and do not count. An empty list (no tracked delegations at all)
-/// is `false` — the conservative default that lets a leaf agent be nudged.
+/// What: `true` iff any delegation's status
+/// [`is_live`](DelegationStatus::is_live) — i.e. `Queued` or `Running`.
+/// `Completed`/`Failed`/`Cancelled` are terminal and do not count, and neither
+/// does `Stale`: a delegation the staleness sweep gave up on is no longer
+/// trustworthy evidence of work in flight, and treating it as live is what let a
+/// single lost `SubagentStop` suppress this session's nudge forever (#2864
+/// review). An empty list (no tracked delegations at all) is `false` — the
+/// conservative default that lets a leaf agent be nudged.
 /// Test: `has_live_children_true_for_running`, `has_live_children_false_when_terminal`,
-/// `has_live_children_false_when_empty`.
+/// `has_live_children_false_when_empty`, `stale_running_delegation_stops_suppressing_the_nudge`.
 pub fn has_live_children(delegations: &[Delegation]) -> bool {
-    delegations.iter().any(|d| {
-        matches!(
-            d.status,
-            DelegationStatus::Queued | DelegationStatus::Running
-        )
-    })
+    delegations.iter().any(|d| d.status.is_live())
 }
 
 /// The result of one nudge attempt, for structured logging and tests.
@@ -287,7 +286,7 @@ pub async fn maybe_nudge_parked_session(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::agent::{Delegation, ModelTier};
+    use crate::core::agent::{Delegation, DelegationStatus, ModelTier};
     use crate::core::idle_nudge::SkipReason;
     use crate::core::session::SessionId;
     use crate::session_manager::{FakeNoopTmuxDriver, ManagedSessionId};

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -386,7 +386,11 @@ const REAP_INTERVAL_SECS: u64 = 60;
 /// forever; a slow background sweep keeps the registry honest.
 /// What: every [`REAP_INTERVAL_SECS`] seconds, discovers tmux and calls
 /// [`DaemonState::reap_dead_sessions`]; exits cleanly when `cancel` fires
-/// rather than being dropped mid-sweep on SIGTERM.
+/// rather than being dropped mid-sweep on SIGTERM. Also runs
+/// [`DaemonState::sweep_delegations`] (#2864) — unconditionally, since bounding
+/// delegation liveness and map growth has nothing to do with tmux being
+/// discoverable, and it is here rather than on the `PreToolUse` hot path
+/// precisely because it is an O(N) pass.
 /// Test: the reaping rule is unit-tested via `DaemonState::reap_against`;
 /// `cancel_token_stops_reap_loop_cleanly` asserts the loop exits on cancel.
 async fn reap_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::CancellationToken) {
@@ -398,6 +402,13 @@ async fn reap_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cancellati
                 break;
             }
             _ = tick.tick() => {
+                let sweep = state.sweep_delegations();
+                if sweep.staled > 0 || sweep.evicted > 0 {
+                    info!(
+                        "delegations: {} marked stale (no terminal signal), {} evicted (#2864)",
+                        sweep.staled, sweep.evicted
+                    );
+                }
                 if let Ok(driver) = tmux::TmuxDriver::discover() {
                     let result = state.reap_dead_sessions(&driver);
                     if result.reaped > 0 {

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -1,0 +1,346 @@
+//! Non-opt-in delegation tracking from Claude Code hooks (#2864 S2).
+//!
+//! Why: delegation tracking had two defects that together made it useless as a
+//! basis for "which agents are in flight?". (1) It was opt-in — a record existed
+//! only if the PM chose to call the `agent_delegate` MCP tool, so a PM that
+//! dispatched work with the native subagent tool alone left no trace. (2) Status
+//! never moved: the only production construction is
+//! [`Delegation::new`](crate::core::agent::Delegation::new), which yields
+//! `Queued`, and nothing ever wrote `Running`/`Completed`/`Failed`. So
+//! [`has_live_children`](crate::daemon::idle_nudge::has_live_children) — which
+//! treats `Queued` and `Running` as live — reported *every* delegation as live
+//! forever, permanently suppressing the idle nudge for any session that had ever
+//! delegated once.
+//!
+//! This module fixes both by observing hooks the daemon already receives: a
+//! `PreToolUse` with `matcher: "*"` is installed on every managed session, so
+//! every native subagent dispatch already arrives here. No new hook, no opt-in.
+//!
+//! # Correlation model (empirically established, #2864 Step 0)
+//!
+//! Captured from live Claude Code 2.1.220 stdin with two *concurrent*
+//! subagents — the case that breaks any "most recent delegation" guess:
+//!
+//! ```text
+//! PreToolUse   tool_name=Agent  tool_use_id=toolu_01DA…   (no agent id yet)
+//! PostToolUse  tool_name=Agent  tool_use_id=toolu_01DA…
+//!              tool_response={ isAsync: true,
+//!                              status: "async_launched",
+//!                              agentId: "a403cdbc078b5c474" }
+//! SubagentStop                  agent_id="a403cdbc078b5c474"
+//! ```
+//!
+//! Two consequences drive the whole design, and **neither may be "simplified"
+//! away without re-running the probe**:
+//!
+//! 1. **`PostToolUse` does NOT mean the subagent finished.** For an async
+//!    dispatch it fires ~1 ms after launch (`duration_ms: 1`) with
+//!    `status: "async_launched"`, while the subagent runs on for minutes.
+//!    Terminalizing there would mark every delegation `Completed` almost
+//!    immediately and report "no agents in flight" while they are all still
+//!    running — strictly worse than not tracking at all. `PostToolUse` is
+//!    therefore a *join* step (it teaches us `agentId`), and terminalizes only
+//!    when the dispatch genuinely returned synchronously.
+//! 2. **`SubagentStop` DOES carry an exact correlation key** — `agent_id`,
+//!    identical to `tool_response.agentId`. It is the authoritative terminal
+//!    signal, not an advisory one. Because the key is exact, closing one of two
+//!    concurrent delegations cannot close the other.
+//!
+//! Absent an `agent_id` (an older Claude Code, or a dispatch whose `PostToolUse`
+//! was missed) a `SubagentStop` terminalizes **nothing**. Guessing "the most
+//! recent Running delegation" would close the wrong one under concurrency and
+//! manufacture a false idle, which is the specific failure this design exists to
+//! prevent.
+//!
+//! # Cost
+//!
+//! [`observe`] runs inside the synchronous `PreToolUse` hook, which has a 5 s
+//! timeout and sits in front of *every* tool call in *every* managed session.
+//! The non-delegation path — which is essentially all traffic — is one
+//! `payload.get("tool")` plus an exact string compare against two constants, and
+//! then returns. The delegation path is in-memory `DashMap` work only: no disk,
+//! no network, no async, no blocking lock.
+//!
+//! # Known limitation
+//!
+//! Records are keyed by the session id the event arrives under: the Claude
+//! session UUID for hook-observed records (matching
+//! [`crate::daemon::idle_nudge::maybe_nudge_parked_session`]), but whatever id
+//! the PM passed for `agent_delegate` records. When those differ, [`dedup`]
+//! cannot match and a declaration plus its observation remain two records. That
+//! id ambiguity predates #2864 and is not addressed here.
+//!
+//! Test: the `#[cfg(test)]` suite below.
+
+use chrono::Utc;
+use serde_json::Value;
+
+use crate::core::agent::{
+    Delegation, DelegationId, DelegationSource, DelegationStatus, ModelTier,
+    is_subagent_dispatch_tool,
+};
+use crate::core::hook::HookEvent;
+use crate::core::session::SessionId;
+use crate::daemon::state::DaemonState;
+
+/// How long after an `agent_delegate` call an observed dispatch may be treated
+/// as the *same* delegation.
+///
+/// Why: a PM that both declares (`agent_delegate`) and dispatches (native tool)
+/// must produce one record, not two. The declaration immediately precedes the
+/// dispatch in practice, so a generous-but-finite window merges the pair while
+/// preventing a long-stale `Queued` record from swallowing an unrelated later
+/// dispatch to the same agent.
+/// Test: `dedups_declaration_and_observation`, `dedup_window_expires`.
+const DEDUP_WINDOW_SECS: i64 = 300;
+
+/// Observe one hook event and update delegation tracking.
+///
+/// Why: the single entry point [`crate::daemon::services::hook_service::HookService::process`]
+/// calls, so the hook pipeline gains delegation tracking by way of one line and
+/// all the correlation rules stay here.
+/// What: routes a subagent-dispatch `PreToolUse` to [`on_dispatch`], its
+/// `PostToolUse`/`PostToolUseFailure` to [`on_launched`], and
+/// `SubagentStop`/`SubagentStopFailure` to [`on_subagent_stop`]. Every other
+/// event returns immediately. Never panics and never blocks; a payload missing
+/// the fields it needs is skipped silently (fail-open — tracking is
+/// observational and must never affect the hook verdict).
+/// Test: `ignores_unrelated_tools`, `pre_tool_use_creates_running_delegation`,
+/// and the rest of the suite below.
+pub fn observe(state: &DaemonState, session: SessionId, event: HookEvent, payload: &Value) {
+    match event {
+        // Hot path: the overwhelming majority of PreToolUse events are ordinary
+        // tools. Bail on the tool-name compare before touching any state.
+        HookEvent::PreToolUse => {
+            if dispatch_tool(payload).is_some() {
+                on_dispatch(state, session, payload);
+            }
+        }
+        HookEvent::PostToolUse | HookEvent::PostToolUseFailure => {
+            if dispatch_tool(payload).is_some() {
+                on_launched(state, session, payload, event);
+            }
+        }
+        HookEvent::SubagentStop | HookEvent::SubagentStopFailure => {
+            on_subagent_stop(state, session, payload, event);
+        }
+        _ => {}
+    }
+}
+
+/// The tool name, when this payload names a subagent-dispatch tool.
+///
+/// Why: the hot-path early-out — one map lookup and one exact string compare.
+/// Test: `ignores_unrelated_tools`.
+fn dispatch_tool(payload: &Value) -> Option<&str> {
+    payload
+        .get("tool")
+        .and_then(Value::as_str)
+        .filter(|t| is_subagent_dispatch_tool(t))
+}
+
+/// Read a `&str` field from a payload, treating empty as absent.
+fn field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
+    payload
+        .get(key)
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
+/// `PreToolUse` on a dispatch tool: a subagent is starting now.
+///
+/// Why: this is the moment tracking must record a *live* child, so a PM with
+/// work in flight is never mistaken for idle.
+/// What: reads `input.subagent_type` (agent) and `input.description` (task).
+/// Idempotent on `tool_use_id` — a redelivered hook updates nothing twice. Tries
+/// [`dedup`] first so a matching `agent_delegate` record is promoted in place to
+/// `Running`; otherwise inserts a fresh
+/// [`Delegation::observed`](crate::core::agent::Delegation::observed). Records
+/// `cwd` and `transcript_path` when present.
+/// Test: `pre_tool_use_creates_running_delegation`,
+/// `dedups_declaration_and_observation`, `duplicate_pre_tool_use_is_idempotent`.
+fn on_dispatch(state: &DaemonState, session: SessionId, payload: &Value) {
+    let input = payload.get("input");
+    let agent = input
+        .and_then(|i| i.get("subagent_type"))
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let task = input
+        .and_then(|i| i.get("description"))
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    let tool_use_id = field(payload, "tool_use_id").map(str::to_string);
+
+    // Idempotence: an already-tracked tool_use_id means this hook was redelivered.
+    if let Some(id) = tool_use_id.as_deref()
+        && state
+            .find_delegation(session, |d| d.tool_use_id.as_deref() == Some(id))
+            .is_some()
+    {
+        return;
+    }
+
+    let cwd = field(payload, "cwd").map(std::path::PathBuf::from);
+    let transcript = field(payload, "transcript_path").map(std::path::PathBuf::from);
+
+    // Merge with a matching `agent_delegate` declaration when one is pending.
+    if let Some(existing) = dedup(state, session, agent) {
+        state.mutate_delegation(existing, |d| {
+            d.status = DelegationStatus::Running;
+            d.started_at = Some(Utc::now());
+            d.tool_use_id = tool_use_id.clone();
+            d.cwd = cwd.clone();
+            d.transcript_path = transcript.clone();
+            if d.task.is_empty() && !task.is_empty() {
+                d.task = task.to_string();
+            }
+        });
+        return;
+    }
+
+    let mut delegation = Delegation::observed(session, agent, task, tool_use_id);
+    delegation.cwd = cwd;
+    delegation.transcript_path = transcript;
+    state.upsert_delegation(delegation);
+}
+
+/// Find a pending `agent_delegate` declaration this dispatch should merge into.
+///
+/// Why: a PM instructed to call `agent_delegate` *and* actually dispatch would
+/// otherwise produce two records for one subagent, inflating the live-children
+/// count and leaving an immortal `Queued` orphan (nothing would ever terminalize
+/// the declaration, since only the observed record carries the correlation
+/// keys).
+/// What: the most recent same-session, same-agent delegation that is still
+/// `Queued`, was `McpDeclared`, has not already been bound to a `tool_use_id`,
+/// and was created within [`DEDUP_WINDOW_SECS`].
+/// Test: `dedups_declaration_and_observation`, `dedup_window_expires`,
+/// `dedup_ignores_different_agent`.
+fn dedup(state: &DaemonState, session: SessionId, agent: &str) -> Option<DelegationId> {
+    let cutoff = Utc::now() - chrono::Duration::seconds(DEDUP_WINDOW_SECS);
+    state
+        .delegations_for(session)
+        .into_iter()
+        .filter(|d| {
+            d.source == DelegationSource::McpDeclared
+                && d.status == DelegationStatus::Queued
+                && d.tool_use_id.is_none()
+                && d.agent == agent
+                && d.created_at >= cutoff
+        })
+        .max_by_key(|d| d.created_at)
+        .map(|d| d.id)
+}
+
+/// `PostToolUse` on a dispatch tool: learn `agentId`, terminalize only if the
+/// dispatch really returned.
+///
+/// Why: see the module note — an async dispatch returns in ~1 ms while the
+/// subagent runs on, so this is primarily the *join* that binds `tool_use_id` to
+/// the `agent_id` that `SubagentStop` will quote.
+/// What: locates the delegation by `tool_use_id`, stores
+/// `tool_response.agentId`, and refines the tier from `resolvedModel`. Leaves
+/// the status `Running` when the response says `isAsync`/`async_launched`;
+/// otherwise terminalizes — `Failed` on a `PostToolUseFailure` event or an
+/// `is_error` response, else `Completed`.
+/// Test: `async_launch_keeps_delegation_running`,
+/// `synchronous_post_tool_use_completes_delegation`,
+/// `post_tool_use_failure_marks_failed`.
+fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: HookEvent) {
+    let Some(tool_use_id) = field(payload, "tool_use_id") else {
+        return;
+    };
+    let Some(id) =
+        state.find_delegation(session, |d| d.tool_use_id.as_deref() == Some(tool_use_id))
+    else {
+        return;
+    };
+
+    let response = payload.get("tool_response");
+    let agent_id = response
+        .and_then(|r| r.get("agentId"))
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let tier = response
+        .and_then(|r| r.get("resolvedModel"))
+        .and_then(Value::as_str)
+        .map(ModelTier::from_model_id);
+
+    // Still running? An async dispatch reports launch, not completion.
+    let still_running = response.is_some_and(|r| {
+        r.get("isAsync").and_then(Value::as_bool).unwrap_or(false)
+            || r.get("status").and_then(Value::as_str) == Some("async_launched")
+    });
+    let errored = event == HookEvent::PostToolUseFailure
+        || response
+            .and_then(|r| r.get("is_error"))
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+
+    state.mutate_delegation(id, |d| {
+        if agent_id.is_some() {
+            d.agent_id = agent_id.clone();
+        }
+        if let Some(t) = tier {
+            d.tier = t;
+        }
+        if !still_running {
+            d.status = if errored {
+                DelegationStatus::Failed
+            } else {
+                DelegationStatus::Completed
+            };
+            d.ended_at = Some(Utc::now());
+        }
+    });
+}
+
+/// `SubagentStop`: terminalize exactly the delegation that ended.
+///
+/// Why: this is the authoritative completion signal, and the only one that
+/// arrives when the subagent actually finishes.
+/// What: resolves `payload.agent_id` against the stored `agent_id` and
+/// terminalizes that record alone (`Failed` for `SubagentStopFailure`, else
+/// `Completed`). When `agent_id` is absent, or matches nothing, **nothing is
+/// terminalized** — see the module note on why a "most recent" fallback is
+/// forbidden.
+/// Test: `subagent_stop_completes_matching_delegation`,
+/// `subagent_stop_without_agent_id_terminalizes_nothing`,
+/// `concurrent_delegations_terminalize_independently`.
+fn on_subagent_stop(state: &DaemonState, session: SessionId, payload: &Value, event: HookEvent) {
+    let Some(agent_id) = field(payload, "agent_id") else {
+        tracing::trace!(
+            "SubagentStop without agent_id — no delegation terminalized (#2864); a \
+             'most recent' guess would close the wrong one under concurrency"
+        );
+        return;
+    };
+    let Some(id) = state.find_delegation(session, |d| {
+        d.agent_id.as_deref() == Some(agent_id) && !is_terminal(d.status)
+    }) else {
+        return;
+    };
+    let status = if event == HookEvent::SubagentStopFailure {
+        DelegationStatus::Failed
+    } else {
+        DelegationStatus::Completed
+    };
+    state.terminate_delegation(id, status);
+}
+
+/// Is this status terminal (i.e. the delegation is no longer live)?
+///
+/// Why: keeps the "live" definition aligned with
+/// [`crate::daemon::idle_nudge::has_live_children`], which counts
+/// `Queued`/`Running` as live.
+/// Test: exercised via `subagent_stop_is_idempotent`.
+fn is_terminal(status: DelegationStatus) -> bool {
+    matches!(
+        status,
+        DelegationStatus::Completed | DelegationStatus::Failed | DelegationStatus::Cancelled
+    )
+}
+
+#[cfg(test)]
+#[path = "delegation_tracker_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -52,6 +52,27 @@
 //! manufacture a false idle, which is the specific failure this design exists to
 //! prevent.
 //!
+//! # Fail direction
+//!
+//! Every branch here fails **closed**: uncertainty leaves a delegation `Running`
+//! and never terminalizes it. A false "still running" delays an idle nudge; a
+//! false "completed" tells a human that no agents are in flight when several
+//! are, which is the one report this feature must never produce. So
+//! [`on_subagent_stop`] acts only on an exact `agent_id`, and [`on_launched`]
+//! acts only on a `tool_response` it [`recognized_response`]-ised — an absent or
+//! unrecognized response is "we do not know", not "it finished".
+//!
+//! The cost of failing closed is that a delegation can enter `Running` with no
+//! route out: `SubagentStop` is not guaranteed to arrive (`tm hook` POSTs fail
+//! open on a 2 s budget, an interrupted subagent emits no stop, a dispatch that
+//! never learned an `agent_id` can never be resolved by one). That is bounded
+//! outside the hot path by
+//! [`DaemonState::sweep_delegations`](crate::daemon::state::DaemonState::sweep_delegations),
+//! which the 60 s reap loop drives: a long-overdue live delegation becomes
+//! `Stale` — explicitly *not* `Completed`, and still recoverable by a late stop —
+//! so it stops suppressing the idle nudge without anyone ever being told it
+//! finished.
+//!
 //! # Cost
 //!
 //! [`observe`] runs inside the synchronous `PreToolUse` hook, which has a 5 s
@@ -76,7 +97,7 @@ use chrono::Utc;
 use serde_json::Value;
 
 use crate::core::agent::{
-    Delegation, DelegationId, DelegationSource, DelegationStatus, ModelTier,
+    Delegation, DelegationId, DelegationSource, DelegationStatus, ModelTier, TOOL_RESPONSE_KEYS,
     is_subagent_dispatch_tool,
 };
 use crate::core::hook::HookEvent;
@@ -88,11 +109,15 @@ use crate::daemon::state::DaemonState;
 ///
 /// Why: a PM that both declares (`agent_delegate`) and dispatches (native tool)
 /// must produce one record, not two. The declaration immediately precedes the
-/// dispatch in practice, so a generous-but-finite window merges the pair while
-/// preventing a long-stale `Queued` record from swallowing an unrelated later
-/// dispatch to the same agent.
+/// dispatch *in the same turn*, so the true gap is seconds; the window only has
+/// to absorb a slow turn, not a whole work item. It was 300 s, which is long
+/// enough for a PM that dispatches the same agent repeatedly — this repo
+/// routinely runs several `rust-engineer`s — to have an unrelated later dispatch
+/// absorbed into an earlier declaration (#2864 review, MEDIUM 2). Two minutes
+/// keeps the legitimate merge and cuts the collision surface; [`tasks_match`] is
+/// the second, independent discriminator.
 /// Test: `dedups_declaration_and_observation`, `dedup_window_expires`.
-const DEDUP_WINDOW_SECS: i64 = 300;
+const DEDUP_WINDOW_SECS: i64 = 120;
 
 /// Observe one hook event and update delegation tracking.
 ///
@@ -184,7 +209,7 @@ fn on_dispatch(state: &DaemonState, session: SessionId, payload: &Value) {
     let transcript = field(payload, "transcript_path").map(std::path::PathBuf::from);
 
     // Merge with a matching `agent_delegate` declaration when one is pending.
-    if let Some(existing) = dedup(state, session, agent) {
+    if let Some(existing) = dedup(state, session, agent, task) {
         state.mutate_delegation(existing, |d| {
             d.status = DelegationStatus::Running;
             d.started_at = Some(Utc::now());
@@ -213,23 +238,57 @@ fn on_dispatch(state: &DaemonState, session: SessionId, payload: &Value) {
 /// keys).
 /// What: the most recent same-session, same-agent delegation that is still
 /// `Queued`, was `McpDeclared`, has not already been bound to a `tool_use_id`,
-/// and was created within [`DEDUP_WINDOW_SECS`].
+/// was created within [`DEDUP_WINDOW_SECS`], and whose task [`tasks_match`]es
+/// this dispatch's description.
+///
+/// The agent name alone is NOT a sufficient key (#2864 review, MEDIUM 2): this
+/// repo dispatches several `rust-engineer`s concurrently, so "same agent,
+/// recently" false-merges two distinct dispatches — halving the live-child count
+/// and leaving the merged record showing the *declaration's* task text, which is
+/// precisely the string `/tm-session-pause` puts in front of a human. When in
+/// doubt this now declines to merge: two records for one subagent overcounts and
+/// is corrected by the staleness sweep, whereas a false merge undercounts work
+/// in flight and mislabels it, with no recovery.
 /// Test: `dedups_declaration_and_observation`, `dedup_window_expires`,
-/// `dedup_ignores_different_agent`.
-fn dedup(state: &DaemonState, session: SessionId, agent: &str) -> Option<DelegationId> {
+/// `dedup_ignores_different_agent`, `dedup_does_not_merge_a_different_task`.
+fn dedup(state: &DaemonState, session: SessionId, agent: &str, task: &str) -> Option<DelegationId> {
     let cutoff = Utc::now() - chrono::Duration::seconds(DEDUP_WINDOW_SECS);
-    state
-        .delegations_for(session)
-        .into_iter()
-        .filter(|d| {
-            d.source == DelegationSource::McpDeclared
-                && d.status == DelegationStatus::Queued
-                && d.tool_use_id.is_none()
-                && d.agent == agent
-                && d.created_at >= cutoff
-        })
-        .max_by_key(|d| d.created_at)
-        .map(|d| d.id)
+    state.latest_delegation_matching(session, |d| {
+        d.source == DelegationSource::McpDeclared
+            && d.status == DelegationStatus::Queued
+            && d.tool_use_id.is_none()
+            && d.agent == agent
+            && d.created_at >= cutoff
+            && tasks_match(&d.task, task)
+    })
+}
+
+/// Do a declared task and a dispatched description describe the same work?
+///
+/// Why: the task text is the only discriminator available between two dispatches
+/// to the same agent inside the dedup window, and it must tolerate the PM
+/// wording the `agent_delegate` task and the dispatch `description` slightly
+/// differently while still rejecting two plainly different work items.
+/// What: case- and whitespace-insensitive prefix match in either direction
+/// (which subsumes equality), so a short dispatch description matches the longer
+/// declaration it summarises. An empty string on either side means no
+/// discriminator was supplied — the agent name and the window are then all we
+/// have, and merging remains the better guess for a declaration immediately
+/// followed by a description-less dispatch.
+/// Test: `dedups_declaration_and_observation`,
+/// `dedup_does_not_merge_a_different_task`.
+fn tasks_match(declared: &str, dispatched: &str) -> bool {
+    if declared.is_empty() || dispatched.is_empty() {
+        return true;
+    }
+    let normalize = |s: &str| {
+        s.split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+            .to_lowercase()
+    };
+    let (a, b) = (normalize(declared), normalize(dispatched));
+    a.starts_with(&b) || b.starts_with(&a)
 }
 
 /// `PostToolUse` on a dispatch tool: learn `agentId`, terminalize only if the
@@ -239,13 +298,15 @@ fn dedup(state: &DaemonState, session: SessionId, agent: &str) -> Option<Delegat
 /// subagent runs on, so this is primarily the *join* that binds `tool_use_id` to
 /// the `agent_id` that `SubagentStop` will quote.
 /// What: locates the delegation by `tool_use_id`, stores
-/// `tool_response.agentId`, and refines the tier from `resolvedModel`. Leaves
-/// the status `Running` when the response says `isAsync`/`async_launched`;
-/// otherwise terminalizes — `Failed` on a `PostToolUseFailure` event or an
-/// `is_error` response, else `Completed`.
+/// `tool_response.agentId`, and refines the tier from `resolvedModel`. It
+/// terminalizes **only on positive evidence** that the dispatch left nothing
+/// running — see [`recognized_response`] for why an absent or unrecognized
+/// response must not be read as completion.
 /// Test: `async_launch_keeps_delegation_running`,
 /// `synchronous_post_tool_use_completes_delegation`,
-/// `post_tool_use_failure_marks_failed`.
+/// `post_tool_use_failure_marks_failed`,
+/// `post_tool_use_without_tool_response_stays_running`,
+/// `post_tool_use_with_unrecognized_response_stays_running`.
 fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: HookEvent) {
     let Some(tool_use_id) = field(payload, "tool_use_id") else {
         return;
@@ -256,7 +317,10 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
         return;
     };
 
-    let response = payload.get("tool_response");
+    // Only a response we actually recognized carries evidence either way.
+    let response = payload
+        .get("tool_response")
+        .filter(|r| recognized_response(r));
     let agent_id = response
         .and_then(|r| r.get("agentId"))
         .and_then(Value::as_str)
@@ -266,16 +330,21 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
         .and_then(Value::as_str)
         .map(ModelTier::from_model_id);
 
-    // Still running? An async dispatch reports launch, not completion.
-    let still_running = response.is_some_and(|r| {
+    // An async dispatch reports *launch*, not completion — the subagent runs on
+    // for minutes. This is positive evidence that something IS still running,
+    // and it overrides every other signal on this event.
+    let async_launched = response.is_some_and(|r| {
         r.get("isAsync").and_then(Value::as_bool).unwrap_or(false)
             || r.get("status").and_then(Value::as_str) == Some("async_launched")
     });
+    // The dispatch call itself failed: no subagent was left running.
     let errored = event == HookEvent::PostToolUseFailure
         || response
             .and_then(|r| r.get("is_error"))
             .and_then(Value::as_bool)
             .unwrap_or(false);
+    // A response we understood, with no async marker: the dispatch returned.
+    let sync_return = response.is_some();
 
     state.mutate_delegation(id, |d| {
         if agent_id.is_some() {
@@ -284,7 +353,10 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
         if let Some(t) = tier {
             d.tier = t;
         }
-        if !still_running {
+        // Fail CLOSED: terminalize only on positive evidence. With no evidence
+        // the delegation stays `Running` for `SubagentStop` (or, ultimately, the
+        // staleness sweep) to close.
+        if !async_launched && (sync_return || errored) {
             d.status = if errored {
                 DelegationStatus::Failed
             } else {
@@ -293,6 +365,32 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
             d.ended_at = Some(Utc::now());
         }
     });
+}
+
+/// Is this `tool_response` one we can draw a conclusion from?
+///
+/// Why (#2864 review, HIGH 1): the previous guard asked "does the response say
+/// async?", so an absent response answered *no* and the delegation was
+/// terminalized `Completed` ~1 ms after launch while the subagent ran on — the
+/// exact false "no agents in flight" this module's header calls strictly worse
+/// than not tracking at all. And absence is not hypothetical: `tm hook`'s S1
+/// projection ([`TOOL_RESPONSE_KEYS`]) emits no `tool_response` at all when the
+/// response is not an object or holds none of those keys, so a Claude Code key
+/// rename or a content-block-array response would trigger it with no code change
+/// and no failing test on our side.
+///
+/// Inverting it costs nothing on the happy path and makes the two hook branches
+/// share one posture: `on_subagent_stop` already refuses to act without an exact
+/// `agent_id`, and now `on_launched` refuses to act without a response it
+/// understood.
+/// What: `true` iff `response` is an object carrying at least one
+/// [`TOOL_RESPONSE_KEYS`] member.
+/// Test: `post_tool_use_without_tool_response_stays_running`,
+/// `post_tool_use_with_unrecognized_response_stays_running`.
+fn recognized_response(response: &Value) -> bool {
+    response
+        .as_object()
+        .is_some_and(|o| TOOL_RESPONSE_KEYS.iter().any(|k| o.contains_key(*k)))
 }
 
 /// `SubagentStop`: terminalize exactly the delegation that ended.
@@ -315,8 +413,10 @@ fn on_subagent_stop(state: &DaemonState, session: SessionId, payload: &Value, ev
         );
         return;
     };
+    // `Stale` is deliberately not terminal, so a stop that arrives after the
+    // staleness sweep gave up still replaces "we lost track" with the truth.
     let Some(id) = state.find_delegation(session, |d| {
-        d.agent_id.as_deref() == Some(agent_id) && !is_terminal(d.status)
+        d.agent_id.as_deref() == Some(agent_id) && !d.status.is_terminal()
     }) else {
         return;
     };
@@ -326,19 +426,6 @@ fn on_subagent_stop(state: &DaemonState, session: SessionId, payload: &Value, ev
         DelegationStatus::Completed
     };
     state.terminate_delegation(id, status);
-}
-
-/// Is this status terminal (i.e. the delegation is no longer live)?
-///
-/// Why: keeps the "live" definition aligned with
-/// [`crate::daemon::idle_nudge::has_live_children`], which counts
-/// `Queued`/`Running` as live.
-/// Test: exercised via `subagent_stop_is_idempotent`.
-fn is_terminal(status: DelegationStatus) -> bool {
-    matches!(
-        status,
-        DelegationStatus::Completed | DelegationStatus::Failed | DelegationStatus::Cancelled
-    )
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -271,14 +271,23 @@ fn dedup(state: &DaemonState, session: SessionId, agent: &str, task: &str) -> Op
 /// differently while still rejecting two plainly different work items.
 /// What: case- and whitespace-insensitive prefix match in either direction
 /// (which subsumes equality), so a short dispatch description matches the longer
-/// declaration it summarises. An empty string on either side means no
-/// discriminator was supplied — the agent name and the window are then all we
-/// have, and merging remains the better guess for a declaration immediately
-/// followed by a description-less dispatch.
+/// declaration it summarises.
+///
+/// The two empty cases are NOT symmetric (#2864 re-review, LOW 1). A dispatch
+/// with no description offers nothing to discriminate on, and merging it would
+/// keep the *declaration's* text as the label for a dispatch we cannot identify
+/// — precisely the mislabel this discriminator exists to prevent — so it
+/// declines. An unlabelled *declaration* is different: merging adopts the
+/// dispatch's own text (`on_dispatch` fills an empty task), so no wrong label
+/// can survive, and it merges.
 /// Test: `dedups_declaration_and_observation`,
-/// `dedup_does_not_merge_a_different_task`.
+/// `dedup_does_not_merge_a_different_task`,
+/// `dedup_declines_a_description_less_dispatch`.
 fn tasks_match(declared: &str, dispatched: &str) -> bool {
-    if declared.is_empty() || dispatched.is_empty() {
+    if dispatched.is_empty() {
+        return false;
+    }
+    if declared.is_empty() {
         return true;
     }
     let normalize = |s: &str| {
@@ -298,15 +307,16 @@ fn tasks_match(declared: &str, dispatched: &str) -> bool {
 /// subagent runs on, so this is primarily the *join* that binds `tool_use_id` to
 /// the `agent_id` that `SubagentStop` will quote.
 /// What: locates the delegation by `tool_use_id`, stores
-/// `tool_response.agentId`, and refines the tier from `resolvedModel`. It
-/// terminalizes **only on positive evidence** that the dispatch left nothing
-/// running — see [`recognized_response`] for why an absent or unrecognized
-/// response must not be read as completion.
+/// `tool_response.agentId`, and refines the tier from `resolvedModel`. Whether
+/// to terminalize is decided entirely by [`classify_dispatch`], which is a
+/// three-way answer — `Launched` / `Returned` / `Unknown` — not a boolean.
 /// Test: `async_launch_keeps_delegation_running`,
 /// `synchronous_post_tool_use_completes_delegation`,
 /// `post_tool_use_failure_marks_failed`,
 /// `post_tool_use_without_tool_response_stays_running`,
-/// `post_tool_use_with_unrecognized_response_stays_running`.
+/// `post_tool_use_with_unrecognized_response_stays_running`,
+/// `post_tool_use_with_only_an_agent_id_stays_running`,
+/// `changed_async_status_value_with_an_agent_id_stays_running`.
 fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: HookEvent) {
     let Some(tool_use_id) = field(payload, "tool_use_id") else {
         return;
@@ -330,21 +340,13 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
         .and_then(Value::as_str)
         .map(ModelTier::from_model_id);
 
-    // An async dispatch reports *launch*, not completion — the subagent runs on
-    // for minutes. This is positive evidence that something IS still running,
-    // and it overrides every other signal on this event.
-    let async_launched = response.is_some_and(|r| {
-        r.get("isAsync").and_then(Value::as_bool).unwrap_or(false)
-            || r.get("status").and_then(Value::as_str) == Some("async_launched")
-    });
     // The dispatch call itself failed: no subagent was left running.
     let errored = event == HookEvent::PostToolUseFailure
         || response
             .and_then(|r| r.get("is_error"))
             .and_then(Value::as_bool)
             .unwrap_or(false);
-    // A response we understood, with no async marker: the dispatch returned.
-    let sync_return = response.is_some();
+    let outcome = classify_dispatch(response);
 
     state.mutate_delegation(id, |d| {
         if agent_id.is_some() {
@@ -353,40 +355,128 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
         if let Some(t) = tier {
             d.tier = t;
         }
-        // Fail CLOSED: terminalize only on positive evidence. With no evidence
-        // the delegation stays `Running` for `SubagentStop` (or, ultimately, the
-        // staleness sweep) to close.
-        if !async_launched && (sync_return || errored) {
-            d.status = if errored {
+        // Fail CLOSED. `Launched` never terminalizes, whatever else the event
+        // says — a running subagent outranks an errored dispatch call, and
+        // `SubagentStop` will close it. `Unknown` terminalizes only on an
+        // explicit dispatch failure, which is itself positive evidence that
+        // nothing was left running.
+        let terminal = match outcome {
+            DispatchOutcome::Launched => None,
+            DispatchOutcome::Returned => Some(if errored {
                 DelegationStatus::Failed
             } else {
                 DelegationStatus::Completed
-            };
+            }),
+            DispatchOutcome::Unknown if errored => Some(DelegationStatus::Failed),
+            DispatchOutcome::Unknown => None,
+        };
+        if let Some(status) = terminal {
+            d.status = status;
             d.ended_at = Some(Utc::now());
         }
     });
 }
 
+/// What a dispatch `PostToolUse` response says about whether a subagent is
+/// still running.
+///
+/// Why this is three-valued and not a boolean: "I could parse this response"
+/// and "this response says nothing was left running" are different
+/// propositions, and the first round of #2864 review was about exactly that
+/// conflation one layer up. `Unknown` is a first-class answer here for the same
+/// reason [`DelegationStatus::Stale`] is a first-class status: not knowing is
+/// not the same as knowing it finished.
+/// Test: the `post_tool_use_*` suite.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DispatchOutcome {
+    /// A subagent is running now — an explicit async marker, or an `agentId`
+    /// handle for a future `SubagentStop` to quote.
+    Launched,
+    /// The call returned rather than launching; nothing is left running.
+    Returned,
+    /// The response is absent or unrecognized — no conclusion is available.
+    Unknown,
+}
+
+/// Classify a dispatch response (#2864 review HIGH 1, re-review MEDIUM 1).
+///
+/// Why: an absent response used to read as "not async, therefore finished",
+/// terminalizing a still-running subagent ~1 ms after launch — and absence is
+/// not hypothetical, since `tm hook`'s S1 projection ([`TOOL_RESPONSE_KEYS`])
+/// omits `tool_response` entirely when the payload is not an object or carries
+/// none of those keys. That is [`DispatchOutcome::Unknown`].
+///
+/// The re-review then found a narrower conflation: a response holding only
+/// `agentId` produced `Completed` *and* stored the `agent_id` in the same
+/// breath — recording "expect a `SubagentStop` for this agent" and "this
+/// already finished" simultaneously. Hence the launch test comes first and
+/// includes `agentId`.
+///
+/// What, in order:
+///
+/// - `Launched` — `isAsync == true`, `status == "async_launched"`, or an
+///   `agentId` is present. An `agentId` is by design the *async* correlation
+///   key; handing one back is evidence of a launch, never of a return. Testing
+///   it first is also what makes a `status` whose **value** drifted (rather than
+///   its key) safe, since such a response still carries its `agentId`.
+/// - `Returned` — any other recognized response.
+/// - `Unknown` — absent, not an object, or carrying no [`TOOL_RESPONSE_KEYS`]
+///   member.
+///
+/// # KNOWN LIMITATION — an `agentId`-less response is read as a return
+///
+/// `Returned` is deliberately still *residual* rather than affirmative
+/// (`isAsync == false` or a non-launch `status`), so a recognized response that
+/// is silent about liveness — `resolvedModel` alone, `is_error` alone — is
+/// treated as a synchronous return. That is a real fail-open band and it is
+/// **knowingly left open** here, because closing it would make things worse
+/// today, not better:
+///
+/// [`on_subagent_stop`] resolves a delegation *only* by `agent_id`, and
+/// `agent_id` is taught *only* by this function. A response with no `agentId`
+/// therefore has **no** route to termination other than this branch — nothing
+/// can ever quote it back to us. Compounding that, `PostToolUse` is installed
+/// `async: true` while `SubagentStop` is synchronous
+/// (`core::standalone::hooks`), so the two are independent `tm hook` processes
+/// whose arrival order at the daemon is not guaranteed; an out-of-order stop
+/// matches nothing and nothing re-checks. Making this branch affirmative without
+/// first giving `on_subagent_stop` a recovery path would convert a rare
+/// fail-open into a guaranteed six-hour phantom "agent in flight" for every such
+/// dispatch.
+///
+/// The band is unobserved: Claude Code 2.1.220 returns
+/// `{isAsync, status, agentId, resolvedModel}` for a dispatch, which takes the
+/// `Launched` branch. Tightening is blocked on the stop-side recovery work and
+/// is tracked with it, not attempted here.
+/// Test: `post_tool_use_without_tool_response_stays_running`,
+/// `post_tool_use_with_unrecognized_response_stays_running`,
+/// `post_tool_use_with_only_an_agent_id_stays_running`,
+/// `changed_async_status_value_with_an_agent_id_stays_running`,
+/// `synchronous_post_tool_use_completes_delegation`,
+/// `liveness_silent_response_is_read_as_a_return_known_gap`.
+fn classify_dispatch(response: Option<&Value>) -> DispatchOutcome {
+    let Some(r) = response else {
+        return DispatchOutcome::Unknown;
+    };
+    if r.get("isAsync").and_then(Value::as_bool) == Some(true)
+        || r.get("status").and_then(Value::as_str) == Some("async_launched")
+        || r.get("agentId").is_some()
+    {
+        return DispatchOutcome::Launched;
+    }
+    DispatchOutcome::Returned
+}
+
 /// Is this `tool_response` one we can draw a conclusion from?
 ///
-/// Why (#2864 review, HIGH 1): the previous guard asked "does the response say
-/// async?", so an absent response answered *no* and the delegation was
-/// terminalized `Completed` ~1 ms after launch while the subagent ran on — the
-/// exact false "no agents in flight" this module's header calls strictly worse
-/// than not tracking at all. And absence is not hypothetical: `tm hook`'s S1
-/// projection ([`TOOL_RESPONSE_KEYS`]) emits no `tool_response` at all when the
-/// response is not an object or holds none of those keys, so a Claude Code key
-/// rename or a content-block-array response would trigger it with no code change
-/// and no failing test on our side.
-///
-/// Inverting it costs nothing on the happy path and makes the two hook branches
-/// share one posture: `on_subagent_stop` already refuses to act without an exact
-/// `agent_id`, and now `on_launched` refuses to act without a response it
-/// understood.
+/// Why: `tm hook`'s S1 projection already restricts the forwarded object to
+/// [`TOOL_RESPONSE_KEYS`], but the daemon must not depend on a filter living in
+/// a different crate target for its fail-direction. Re-asserting it here means a
+/// more permissive S1 (a raw string, a content-block array) cannot silently turn
+/// "unrecognized" back into "understood".
 /// What: `true` iff `response` is an object carrying at least one
 /// [`TOOL_RESPONSE_KEYS`] member.
-/// Test: `post_tool_use_without_tool_response_stays_running`,
-/// `post_tool_use_with_unrecognized_response_stays_running`.
+/// Test: `post_tool_use_with_unrecognized_response_stays_running`.
 fn recognized_response(response: &Value) -> bool {
     response
         .as_object()

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
@@ -16,6 +16,7 @@ use crate::core::session::{ControlModel, Session, SessionStatus};
 use crate::daemon::idle_nudge::has_live_children;
 use crate::daemon::state::sessions::{
     DECLARED_STALE_AFTER_SECS, DELEGATION_RETENTION_SECS, RUNNING_STALE_AFTER_SECS,
+    STALE_RETENTION_SECS,
 };
 use std::sync::Arc;
 
@@ -144,7 +145,8 @@ fn async_launch_keeps_delegation_running() {
 
 #[test]
 fn synchronous_post_tool_use_completes_delegation() {
-    // A dispatch that returns synchronously (no isAsync marker) IS complete.
+    // A dispatch that returns with no launch marker and no `agentId` handle IS
+    // complete — there is nothing left for a `SubagentStop` to quote back.
     let (state, sid) = state_with_session();
     observe(
         &state,
@@ -155,12 +157,46 @@ fn synchronous_post_tool_use_completes_delegation() {
     let payload = serde_json::json!({
         "tool": "Task",
         "tool_use_id": "toolu_s",
-        "tool_response": { "is_error": false }
+        "tool_response": { "isAsync": false, "is_error": false }
     });
     observe(&state, sid, HookEvent::PostToolUse, &payload);
     let d = only(&state, sid);
     assert_eq!(d.status, DelegationStatus::Completed);
     assert!(d.ended_at.is_some());
+}
+
+#[test]
+fn liveness_silent_response_is_read_as_a_return_known_gap() {
+    // KNOWN LIMITATION, asserted so it is visible rather than lurking: a
+    // recognized response that says nothing about liveness (`resolvedModel`
+    // alone) is treated as a synchronous return. Closing this band requires
+    // `on_subagent_stop` to gain a recovery path first — it resolves only by
+    // `agent_id`, which only `on_launched` teaches, so a response with no
+    // `agentId` has no other route to termination and tightening here would
+    // turn a rare fail-open into a guaranteed 6 h phantom "agent in flight".
+    // See `classify_dispatch`'s KNOWN LIMITATION note. Unobserved against
+    // Claude Code 2.1.220, whose dispatch response takes the `Launched` branch.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "tool_response": { "resolvedModel": "claude-haiku-4-5-20251001" }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+    let d = only(&state, sid);
+    assert_eq!(
+        d.status,
+        DelegationStatus::Completed,
+        "documented residual — change this assertion only together with the \
+         stop-side recovery path"
+    );
+    assert_eq!(d.tier, ModelTier::Haiku, "tier is still refined");
 }
 
 #[test]
@@ -515,6 +551,58 @@ fn post_tool_use_with_unrecognized_response_stays_running() {
 }
 
 #[test]
+fn post_tool_use_with_only_an_agent_id_stays_running() {
+    // The self-contradiction case: storing `agent_id` (whose ONLY purpose is to
+    // let a future SubagentStop resolve this record) while marking it Completed
+    // in the same closure. `agentId` is by design the ASYNC correlation key, so
+    // handing one back is evidence of a launch, never of a return.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "tool_response": { "agentId": "aid_p1" }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+
+    let d = only(&state, sid);
+    assert_eq!(d.status, DelegationStatus::Running);
+    assert_eq!(
+        d.agent_id.as_deref(),
+        Some("aid_p1"),
+        "the join key is still learned — it is just not read as completion"
+    );
+    // …and the stop it implies still resolves the record.
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid_p1"));
+    assert_eq!(only(&state, sid).status, DelegationStatus::Completed);
+}
+
+#[test]
+fn changed_async_status_value_with_an_agent_id_stays_running() {
+    // Value drift, not key drift: `status` keeps its name but stops saying
+    // "async_launched". The `agentId` handle is what keeps this safe.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "tool_response": { "status": "launched", "agentId": "aid_p3" }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+    assert_eq!(only(&state, sid).status, DelegationStatus::Running);
+}
+
+#[test]
 fn renamed_async_marker_does_not_terminalize() {
     // The specific drift scenario: `isAsync`/`status` renamed but `agentId`
     // kept. We still recognise the response, so we would infer a synchronous
@@ -660,8 +748,9 @@ fn terminal_delegations_are_evicted_after_retention() {
 
 #[test]
 fn live_delegations_are_never_evicted() {
-    // The retention clock is `ended_at`, which a live record never has — so no
-    // amount of elapsed time can drop work that is still in flight.
+    // The live branch of the sweep unconditionally retains, at ANY age. At
+    // +30 days the record has of course gone Stale (that is the liveness
+    // bound), but nothing evicted it in that pass, and it is still there.
     let (state, sid) = state_with_session();
     observe(
         &state,
@@ -670,14 +759,15 @@ fn live_delegations_are_never_evicted() {
         &pre("Agent", "engineer", "t", "toolu_1"),
     );
     let sweep = state.sweep_delegations_at(Utc::now() + chrono::Duration::days(30));
-    assert_eq!(sweep.evicted, 0);
+    assert_eq!(sweep.evicted, 0, "a live record is never evicted");
     assert_eq!(state.delegations_for(sid).len(), 1);
 }
 
 #[test]
-fn a_stale_delegation_is_retained_then_evicted() {
-    // Stale records survive one retention window so a human paused mid-flight
-    // still sees "tracking lost" rather than nothing at all.
+fn a_stale_delegation_has_no_ended_at() {
+    // `ended_at` means "reached a terminal status" and nothing broader. If the
+    // sweep stamped it, `Stale` would ride the terminal retention clock and the
+    // recovery window would silently collapse from 18 h to 1 h.
     let (state, sid) = state_with_session();
     observe(
         &state,
@@ -685,20 +775,91 @@ fn a_stale_delegation_is_retained_then_evicted() {
         HookEvent::PreToolUse,
         &pre("Agent", "engineer", "t", "toolu_1"),
     );
-    let staled_at = Utc::now() + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + 1);
-    state.sweep_delegations_at(staled_at);
+    state
+        .sweep_delegations_at(Utc::now() + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + 1));
+    let d = only(&state, sid);
+    assert_eq!(d.status, DelegationStatus::Stale);
+    assert!(
+        d.ended_at.is_none(),
+        "the sweep must not claim the delegation ended — it did not end, we \
+         stopped trusting the record"
+    );
+}
+
+#[test]
+fn stale_delegation_stays_resolvable_far_past_the_terminal_window() {
+    // The guarantee `Stale` is justified by, asserted rather than assumed: it
+    // used to be dropped one terminal-retention window (1 h) after staling —
+    // ~7 h total — after which a late SubagentStop resolved nothing because
+    // there was no record left. It must survive far past that.
+    let (state, sid) = state_with_session();
+    let t0 = Utc::now();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    state.sweep_delegations_at(t0 + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + 1));
     assert_eq!(only(&state, sid).status, DelegationStatus::Stale);
 
-    state
-        .sweep_delegations_at(staled_at + chrono::Duration::seconds(DELEGATION_RETENTION_SECS - 1));
+    // The old 7 h horizon, and then a full day short of eviction.
+    state.sweep_delegations_at(
+        t0 + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + DELEGATION_RETENTION_SECS + 60),
+    );
     assert_eq!(
         state.delegations_for(sid).len(),
         1,
-        "still inside retention"
+        "the record that used to vanish at ~7 h must still be here"
     );
+    let sweep =
+        state.sweep_delegations_at(t0 + chrono::Duration::seconds(STALE_RETENTION_SECS - 60));
+    assert_eq!(sweep.evicted, 0);
 
-    state
-        .sweep_delegations_at(staled_at + chrono::Duration::seconds(DELEGATION_RETENTION_SECS + 1));
+    // …and it is still resolvable, which is the whole point.
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(
+        only(&state, sid).status,
+        DelegationStatus::Completed,
+        "a stop arriving ~24 h later still replaces 'we lost track' with the truth"
+    );
+}
+
+#[test]
+fn a_stale_delegation_is_eventually_evicted() {
+    // The recovery window is long, not infinite — the map must stay bounded.
+    // This asserts the bound rather than leaving it incidental, and documents
+    // exactly what is lost past it.
+    let (state, sid) = state_with_session();
+    let t0 = Utc::now();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    state.sweep_delegations_at(t0 + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + 1));
+
+    let sweep =
+        state.sweep_delegations_at(t0 + chrono::Duration::seconds(STALE_RETENTION_SECS + 60));
+    assert_eq!(sweep.evicted, 1);
+    assert!(state.delegations_for(sid).is_empty());
+
+    // Past the bound there is nothing left to resolve — a documented limit,
+    // not a surprise.
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
     assert!(state.delegations_for(sid).is_empty());
 }
 
@@ -740,6 +901,48 @@ fn dedup_does_not_merge_a_different_task() {
         observed.task, "rebase the release branch",
         "the dispatched task text must survive"
     );
+}
+
+#[test]
+fn dedup_declines_a_description_less_dispatch() {
+    // No description on the dispatch means no discriminator at all, and merging
+    // would keep the declaration's text as the label for a dispatch we cannot
+    // identify — the mislabel this discriminator exists to prevent.
+    let (state, sid) = state_with_session();
+    state.upsert_delegation(Delegation::new(
+        sid,
+        None,
+        "engineer",
+        ModelTier::Sonnet,
+        "fix the delegation tracker",
+    ));
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "input": { "subagent_type": "engineer" }
+    });
+    observe(&state, sid, HookEvent::PreToolUse, &payload);
+    assert_eq!(state.delegations_for(sid).len(), 2);
+}
+
+#[test]
+fn dedup_merges_an_unlabelled_declaration() {
+    // The other empty case is NOT symmetric: an unlabelled declaration supplies
+    // no discriminator of its own, but merging adopts the dispatch's text, so
+    // no wrong label can survive.
+    let (state, sid) = state_with_session();
+    let declared = Delegation::new(sid, None, "engineer", ModelTier::Opus, "");
+    let declared_id = declared.id;
+    state.upsert_delegation(declared);
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "rebase the release branch", "toolu_1"),
+    );
+    let d = only(&state, sid);
+    assert_eq!(d.id, declared_id);
+    assert_eq!(d.task, "rebase the release branch");
 }
 
 #[test]

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
@@ -14,6 +14,9 @@
 use super::*;
 use crate::core::session::{ControlModel, Session, SessionStatus};
 use crate::daemon::idle_nudge::has_live_children;
+use crate::daemon::state::sessions::{
+    DECLARED_STALE_AFTER_SECS, DELEGATION_RETENTION_SECS, RUNNING_STALE_AFTER_SECS,
+};
 use std::sync::Arc;
 
 fn state_with_session() -> (Arc<DaemonState>, SessionId) {
@@ -390,9 +393,11 @@ fn dedup_ignores_different_agent() {
 
 #[test]
 fn dedup_window_expires() {
-    // A stale Queued declaration must not swallow a much later dispatch.
+    // A stale Queued declaration must not swallow a much later dispatch — even
+    // one whose task text is identical, so this isolates the window from the
+    // task discriminator.
     let (state, sid) = state_with_session();
-    let mut old = Delegation::new(sid, None, "engineer", ModelTier::Sonnet, "old");
+    let mut old = Delegation::new(sid, None, "engineer", ModelTier::Sonnet, "same task");
     old.created_at = Utc::now() - chrono::Duration::seconds(DEDUP_WINDOW_SECS + 60);
     state.upsert_delegation(old);
 
@@ -400,7 +405,7 @@ fn dedup_window_expires() {
         &state,
         sid,
         HookEvent::PreToolUse,
-        &pre("Agent", "engineer", "new", "toolu_1"),
+        &pre("Agent", "engineer", "same task", "toolu_1"),
     );
     assert_eq!(state.delegations_for(sid).len(), 2);
 }
@@ -455,6 +460,316 @@ fn delegations_are_scoped_per_session() {
         DelegationStatus::Running,
         "a stop in session A must not touch session B"
     );
+}
+
+// ---- HIGH 1: an unusable `tool_response` must fail CLOSED -----------------
+
+#[test]
+fn post_tool_use_without_tool_response_stays_running() {
+    // The regression: `is_some_and` on an absent response yielded `false`, so
+    // "not async" was inferred from no evidence at all and the delegation was
+    // marked Completed ~1ms after launch while the subagent ran on. `tm hook`
+    // omits `tool_response` entirely whenever its five-key projection finds
+    // nothing it recognises, so this arrives with no bug on our side.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({ "tool": "Agent", "tool_use_id": "toolu_1" });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+
+    let d = only(&state, sid);
+    assert_eq!(
+        d.status,
+        DelegationStatus::Running,
+        "no response is 'unknown', not 'finished' — terminalizing here reports \
+         'no agents in flight' while the subagent is still running"
+    );
+    assert!(d.ended_at.is_none());
+    assert!(has_live_children(&state.delegations_for(sid)));
+}
+
+#[test]
+fn post_tool_use_with_unrecognized_response_stays_running() {
+    // A Claude Code key rename or a content-block-array response: an object we
+    // cannot interpret. It must be treated exactly like an absent response.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "tool_response": { "content": [{ "type": "text", "text": "…" }] }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+
+    assert_eq!(only(&state, sid).status, DelegationStatus::Running);
+    assert!(has_live_children(&state.delegations_for(sid)));
+}
+
+#[test]
+fn renamed_async_marker_does_not_terminalize() {
+    // The specific drift scenario: `isAsync`/`status` renamed but `agentId`
+    // kept. We still recognise the response, so we would infer a synchronous
+    // return — except the delegation is then closed only if nothing else says
+    // otherwise. Assert the safe half explicitly: an *entirely* renamed
+    // response is unrecognised and leaves the record alone.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "tool_response": { "agent_id": "a403", "is_async": true, "state": "async_launched" }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+
+    let d = only(&state, sid);
+    assert_eq!(d.status, DelegationStatus::Running);
+    assert!(
+        d.agent_id.is_none(),
+        "no key we recognise, so nothing learned"
+    );
+}
+
+// ---- HIGH 2: bounded liveness --------------------------------------------
+
+#[test]
+fn stale_running_delegation_stops_suppressing_the_nudge() {
+    // A Running delegation whose SubagentStop never arrives (dropped hook POST,
+    // interrupted subagent) used to be immortal and suppress this session's
+    // idle nudge for the daemon's lifetime.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    assert!(has_live_children(&state.delegations_for(sid)));
+
+    // Well inside the budget: a genuinely long-running agent is untouched.
+    let sweep = state.sweep_delegations_at(Utc::now() + chrono::Duration::hours(3));
+    assert_eq!(sweep.staled, 0, "a 3h-old agent is still plausibly running");
+    assert!(has_live_children(&state.delegations_for(sid)));
+
+    let past = Utc::now() + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + 60);
+    let sweep = state.sweep_delegations_at(past);
+    assert_eq!(sweep.staled, 1);
+
+    let d = only(&state, sid);
+    assert_eq!(
+        d.status,
+        DelegationStatus::Stale,
+        "tracking gave up — but it must NOT claim the agent completed"
+    );
+    assert_ne!(d.status, DelegationStatus::Completed);
+    assert!(!has_live_children(&state.delegations_for(sid)));
+}
+
+#[test]
+fn late_subagent_stop_still_resolves_a_stale_delegation() {
+    // Staleness must be recoverable, or a too-short budget would be a one-way
+    // false negative for a genuinely long-running agent.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    state
+        .sweep_delegations_at(Utc::now() + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + 1));
+    assert_eq!(only(&state, sid).status, DelegationStatus::Stale);
+
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(
+        only(&state, sid).status,
+        DelegationStatus::Completed,
+        "a late stop replaces 'we lost track' with the truth"
+    );
+}
+
+#[test]
+fn declared_but_never_dispatched_goes_stale_quickly() {
+    // `agent_delegate` declares intent and explicitly does not execute (#1942),
+    // so an undispatched Queued record is not evidence of a running agent and
+    // gets a far shorter budget than a Running one.
+    let (state, sid) = state_with_session();
+    state.upsert_delegation(Delegation::new(
+        sid,
+        None,
+        "engineer",
+        ModelTier::Sonnet,
+        "declared",
+    ));
+    let sweep = state.sweep_delegations_at(
+        Utc::now() + chrono::Duration::seconds(DECLARED_STALE_AFTER_SECS + 1),
+    );
+    assert_eq!(sweep.staled, 1);
+    assert_eq!(only(&state, sid).status, DelegationStatus::Stale);
+    assert!(!has_live_children(&state.delegations_for(sid)));
+}
+
+// ---- MEDIUM 1: bounded growth --------------------------------------------
+
+#[test]
+fn terminal_delegations_are_evicted_after_retention() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(state.delegations_for(sid).len(), 1);
+
+    let sweep = state.sweep_delegations_at(
+        Utc::now() + chrono::Duration::seconds(DELEGATION_RETENTION_SECS + 1),
+    );
+    assert_eq!(sweep.evicted, 1);
+    assert!(
+        state.delegations_for(sid).is_empty(),
+        "the map must not grow monotonically for the daemon's lifetime"
+    );
+}
+
+#[test]
+fn live_delegations_are_never_evicted() {
+    // The retention clock is `ended_at`, which a live record never has — so no
+    // amount of elapsed time can drop work that is still in flight.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let sweep = state.sweep_delegations_at(Utc::now() + chrono::Duration::days(30));
+    assert_eq!(sweep.evicted, 0);
+    assert_eq!(state.delegations_for(sid).len(), 1);
+}
+
+#[test]
+fn a_stale_delegation_is_retained_then_evicted() {
+    // Stale records survive one retention window so a human paused mid-flight
+    // still sees "tracking lost" rather than nothing at all.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let staled_at = Utc::now() + chrono::Duration::seconds(RUNNING_STALE_AFTER_SECS + 1);
+    state.sweep_delegations_at(staled_at);
+    assert_eq!(only(&state, sid).status, DelegationStatus::Stale);
+
+    state
+        .sweep_delegations_at(staled_at + chrono::Duration::seconds(DELEGATION_RETENTION_SECS - 1));
+    assert_eq!(
+        state.delegations_for(sid).len(),
+        1,
+        "still inside retention"
+    );
+
+    state
+        .sweep_delegations_at(staled_at + chrono::Duration::seconds(DELEGATION_RETENTION_SECS + 1));
+    assert!(state.delegations_for(sid).is_empty());
+}
+
+// ---- MEDIUM 2: dedup must not false-merge --------------------------------
+
+#[test]
+fn dedup_does_not_merge_a_different_task() {
+    // This repo routinely declares one agent and then dispatches that same
+    // agent for different work inside the window. Merging halves the live-child
+    // count AND leaves the record showing the declaration's task text — the
+    // exact string `/tm-session-pause` shows a human.
+    let (state, sid) = state_with_session();
+    state.upsert_delegation(Delegation::new(
+        sid,
+        None,
+        "rust-engineer",
+        ModelTier::Sonnet,
+        "fix the delegation tracker",
+    ));
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre(
+            "Agent",
+            "rust-engineer",
+            "rebase the release branch",
+            "toolu_2",
+        ),
+    );
+
+    let all = state.delegations_for(sid);
+    assert_eq!(all.len(), 2, "different work is a different delegation");
+    let observed = all
+        .iter()
+        .find(|d| d.source == DelegationSource::HookObserved)
+        .expect("observed record");
+    assert_eq!(
+        observed.task, "rebase the release branch",
+        "the dispatched task text must survive"
+    );
+}
+
+#[test]
+fn dedup_merges_a_summarised_task_description() {
+    // The dispatch `description` is typically a short summary of the longer
+    // `agent_delegate` task, so a prefix match in either direction still merges.
+    let (state, sid) = state_with_session();
+    let declared = Delegation::new(
+        sid,
+        None,
+        "engineer",
+        ModelTier::Opus,
+        "Fix the delegation tracker fail-open bug",
+    );
+    let declared_id = declared.id;
+    state.upsert_delegation(declared);
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre(
+            "Agent",
+            "engineer",
+            "fix   the delegation TRACKER",
+            "toolu_1",
+        ),
+    );
+    let d = only(&state, sid);
+    assert_eq!(d.id, declared_id);
+    assert_eq!(d.status, DelegationStatus::Running);
 }
 
 #[test]

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
@@ -1,0 +1,470 @@
+//! Tests for the #2864 hook-driven delegation tracker.
+//!
+//! Why: `delegation_tracker.rs` sits under the 500-SLOC production cap, and its
+//! suite is large because the correlation rules it protects are the difference
+//! between accurate in-flight tracking and a false "no agents running" report —
+//! coverage worth keeping in full. Splitting the tests into this file (scored
+//! against the test cap by `scripts/check_line_cap.sh`) keeps both the module
+//! and its coverage intact.
+//! What: unit coverage of dispatch -> launch -> stop correlation, the
+//! async-launch guard, per-session scoping, concurrency independence, and dedup.
+//! Test: this file IS the test module
+//! (`#[path = "delegation_tracker_tests.rs"] mod tests;`).
+
+use super::*;
+use crate::core::session::{ControlModel, Session, SessionStatus};
+use crate::daemon::idle_nudge::has_live_children;
+use std::sync::Arc;
+
+fn state_with_session() -> (Arc<DaemonState>, SessionId) {
+    let state = Arc::new(DaemonState::new());
+    let id = SessionId::new();
+    let mut s = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
+    s.status = SessionStatus::Active;
+    state.register_session(s);
+    (state, id)
+}
+
+/// A `PreToolUse` dispatch payload as `tm hook` forwards it.
+fn pre(tool: &str, agent: &str, desc: &str, tool_use_id: &str) -> Value {
+    serde_json::json!({
+        "tool": tool,
+        "cwd": "/tmp/p",
+        "transcript_path": "/tmp/p/parent.jsonl",
+        "tool_use_id": tool_use_id,
+        "input": { "subagent_type": agent, "description": desc, "prompt": "do it" }
+    })
+}
+
+/// A `PostToolUse` async-launch payload (the real Claude Code shape).
+fn post_async(tool: &str, tool_use_id: &str, agent_id: &str) -> Value {
+    serde_json::json!({
+        "tool": tool,
+        "tool_use_id": tool_use_id,
+        "tool_response": {
+            "isAsync": true,
+            "status": "async_launched",
+            "agentId": agent_id,
+            "resolvedModel": "claude-haiku-4-5-20251001"
+        }
+    })
+}
+
+fn stop(agent_id: &str) -> Value {
+    serde_json::json!({ "agent_id": agent_id, "agent_type": "general-purpose" })
+}
+
+fn only(state: &DaemonState, session: SessionId) -> Delegation {
+    let all = state.delegations_for(session);
+    assert_eq!(all.len(), 1, "expected exactly one delegation, got {all:?}");
+    all.into_iter().next().expect("one")
+}
+
+#[test]
+fn ignores_unrelated_tools() {
+    let (state, sid) = state_with_session();
+    let payload = serde_json::json!({ "tool": "Bash", "input": { "command": "ls" } });
+    observe(&state, sid, HookEvent::PreToolUse, &payload);
+    assert!(state.delegations_for(sid).is_empty());
+}
+
+#[test]
+fn pre_tool_use_creates_running_delegation() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "build the thing", "toolu_1"),
+    );
+    let d = only(&state, sid);
+    assert_eq!(d.status, DelegationStatus::Running);
+    assert_eq!(d.source, DelegationSource::HookObserved);
+    assert_eq!(d.agent, "engineer");
+    assert_eq!(d.task, "build the thing");
+    assert_eq!(d.tool_use_id.as_deref(), Some("toolu_1"));
+    assert_eq!(d.cwd, Some(std::path::PathBuf::from("/tmp/p")));
+    assert!(d.started_at.is_some());
+}
+
+#[test]
+fn legacy_task_tool_name_is_tracked() {
+    // Older Claude Code names the dispatch tool `Task`, not `Agent`.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Task", "qa", "verify", "toolu_t"),
+    );
+    assert_eq!(only(&state, sid).status, DelegationStatus::Running);
+}
+
+#[test]
+fn duplicate_pre_tool_use_is_idempotent() {
+    let (state, sid) = state_with_session();
+    let p = pre("Agent", "engineer", "task", "toolu_1");
+    observe(&state, sid, HookEvent::PreToolUse, &p);
+    observe(&state, sid, HookEvent::PreToolUse, &p);
+    assert_eq!(state.delegations_for(sid).len(), 1);
+}
+
+#[test]
+fn async_launch_keeps_delegation_running() {
+    // THE critical regression: PostToolUse fires ~1ms after launch with
+    // status=async_launched while the subagent is still running. It must
+    // record agentId and must NOT terminalize.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "a403cdbc"),
+    );
+    let d = only(&state, sid);
+    assert_eq!(
+        d.status,
+        DelegationStatus::Running,
+        "an async_launched dispatch must stay Running — terminalizing here \
+         reports 'no agents in flight' while they are all still running"
+    );
+    assert_eq!(d.agent_id.as_deref(), Some("a403cdbc"));
+    assert_eq!(d.tier, ModelTier::Haiku, "tier refined from resolvedModel");
+    assert!(has_live_children(&state.delegations_for(sid)));
+}
+
+#[test]
+fn synchronous_post_tool_use_completes_delegation() {
+    // A dispatch that returns synchronously (no isAsync marker) IS complete.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Task", "qa", "t", "toolu_s"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Task",
+        "tool_use_id": "toolu_s",
+        "tool_response": { "is_error": false }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+    let d = only(&state, sid);
+    assert_eq!(d.status, DelegationStatus::Completed);
+    assert!(d.ended_at.is_some());
+}
+
+#[test]
+fn post_tool_use_failure_marks_failed() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "qa", "t", "toolu_f"),
+    );
+    let payload = serde_json::json!({ "tool": "Agent", "tool_use_id": "toolu_f" });
+    observe(&state, sid, HookEvent::PostToolUseFailure, &payload);
+    assert_eq!(only(&state, sid).status, DelegationStatus::Failed);
+}
+
+#[test]
+fn subagent_stop_completes_matching_delegation() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "a403cdbc"),
+    );
+    observe(&state, sid, HookEvent::SubagentStop, &stop("a403cdbc"));
+    let d = only(&state, sid);
+    assert_eq!(d.status, DelegationStatus::Completed);
+    assert!(d.ended_at.is_some());
+    assert!(!has_live_children(&state.delegations_for(sid)));
+}
+
+#[test]
+fn subagent_stop_failure_marks_failed() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "e", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    observe(&state, sid, HookEvent::SubagentStopFailure, &stop("aid1"));
+    assert_eq!(only(&state, sid).status, DelegationStatus::Failed);
+}
+
+#[test]
+fn subagent_stop_without_agent_id_terminalizes_nothing() {
+    // No correlation key => no guess. Closing "the most recent" would close
+    // the wrong delegation under concurrency and manufacture a false idle.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "a403cdbc"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::SubagentStop,
+        &serde_json::json!({ "transcript_path": "/tmp/p/parent.jsonl" }),
+    );
+    assert_eq!(only(&state, sid).status, DelegationStatus::Running);
+    assert!(has_live_children(&state.delegations_for(sid)));
+}
+
+#[test]
+fn subagent_stop_with_unknown_agent_id_is_a_noop() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "e", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "known"),
+    );
+    observe(&state, sid, HookEvent::SubagentStop, &stop("stranger"));
+    assert_eq!(only(&state, sid).status, DelegationStatus::Running);
+}
+
+#[test]
+fn subagent_stop_is_idempotent() {
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "e", "t", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    let first = only(&state, sid).ended_at;
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(only(&state, sid).ended_at, first, "must not re-terminalize");
+}
+
+#[test]
+fn concurrent_delegations_terminalize_independently() {
+    // Two subagents in flight; stopping one must not close the other.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "alpha", "a", "toolu_a"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "beta", "b", "toolu_b"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_a", "aid_alpha"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_b", "aid_beta"),
+    );
+    assert_eq!(state.delegations_for(sid).len(), 2);
+
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid_alpha"));
+
+    let all = state.delegations_for(sid);
+    let alpha = all.iter().find(|d| d.agent == "alpha").expect("alpha");
+    let beta = all.iter().find(|d| d.agent == "beta").expect("beta");
+    assert_eq!(alpha.status, DelegationStatus::Completed);
+    assert_eq!(
+        beta.status,
+        DelegationStatus::Running,
+        "terminalizing alpha must NOT close the concurrently-running beta"
+    );
+    assert!(
+        has_live_children(&all),
+        "beta is still live, so the session must not look idle"
+    );
+
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid_beta"));
+    assert!(!has_live_children(&state.delegations_for(sid)));
+}
+
+#[test]
+fn dedups_declaration_and_observation() {
+    // A PM that calls agent_delegate AND dispatches natively must yield ONE
+    // record, promoted in place to Running — not two.
+    let (state, sid) = state_with_session();
+    let declared = Delegation::new(sid, None, "engineer", ModelTier::Opus, "declared task");
+    let declared_id = declared.id;
+    state.upsert_delegation(declared);
+
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "declared task", "toolu_1"),
+    );
+
+    let d = only(&state, sid);
+    assert_eq!(d.id, declared_id, "must reuse the declared record");
+    assert_eq!(d.status, DelegationStatus::Running);
+    assert_eq!(d.tool_use_id.as_deref(), Some("toolu_1"));
+    assert_eq!(d.source, DelegationSource::McpDeclared);
+
+    // And it still terminalizes correctly through the full chain.
+    observe(
+        &state,
+        sid,
+        HookEvent::PostToolUse,
+        &post_async("Agent", "toolu_1", "aid1"),
+    );
+    observe(&state, sid, HookEvent::SubagentStop, &stop("aid1"));
+    assert_eq!(only(&state, sid).status, DelegationStatus::Completed);
+}
+
+#[test]
+fn dedup_ignores_different_agent() {
+    let (state, sid) = state_with_session();
+    state.upsert_delegation(Delegation::new(
+        sid,
+        None,
+        "research",
+        ModelTier::Sonnet,
+        "investigate",
+    ));
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "build", "toolu_1"),
+    );
+    assert_eq!(
+        state.delegations_for(sid).len(),
+        2,
+        "a different agent is a different delegation"
+    );
+}
+
+#[test]
+fn dedup_window_expires() {
+    // A stale Queued declaration must not swallow a much later dispatch.
+    let (state, sid) = state_with_session();
+    let mut old = Delegation::new(sid, None, "engineer", ModelTier::Sonnet, "old");
+    old.created_at = Utc::now() - chrono::Duration::seconds(DEDUP_WINDOW_SECS + 60);
+    state.upsert_delegation(old);
+
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "new", "toolu_1"),
+    );
+    assert_eq!(state.delegations_for(sid).len(), 2);
+}
+
+#[test]
+fn dedup_does_not_steal_an_already_bound_record() {
+    // Two dispatches to the same agent must stay two records.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "first", "toolu_1"),
+    );
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "second", "toolu_2"),
+    );
+    assert_eq!(state.delegations_for(sid).len(), 2);
+}
+
+#[test]
+fn delegations_are_scoped_per_session() {
+    // A stop in one session must never terminalize another session's child.
+    let (state, sid_a) = state_with_session();
+    let sid_b = SessionId::new();
+    let mut s = Session::new(sid_b, "/tmp/q", ControlModel::Tmux, None);
+    s.status = SessionStatus::Active;
+    state.register_session(s);
+
+    for sid in [sid_a, sid_b] {
+        observe(
+            &state,
+            sid,
+            HookEvent::PreToolUse,
+            &pre("Agent", "engineer", "t", "toolu_shared"),
+        );
+        observe(
+            &state,
+            sid,
+            HookEvent::PostToolUse,
+            &post_async("Agent", "toolu_shared", "aid_shared"),
+        );
+    }
+    observe(&state, sid_a, HookEvent::SubagentStop, &stop("aid_shared"));
+
+    assert_eq!(only(&state, sid_a).status, DelegationStatus::Completed);
+    assert_eq!(
+        only(&state, sid_b).status,
+        DelegationStatus::Running,
+        "a stop in session A must not touch session B"
+    );
+}
+
+#[test]
+fn missing_subagent_type_still_tracks_as_live() {
+    // Fail-safe: an unparseable dispatch must still count as a live child
+    // rather than vanish (vanishing would under-report work in flight).
+    let (state, sid) = state_with_session();
+    let payload = serde_json::json!({ "tool": "Agent", "tool_use_id": "toolu_x" });
+    observe(&state, sid, HookEvent::PreToolUse, &payload);
+    let d = only(&state, sid);
+    assert_eq!(d.agent, "unknown");
+    assert_eq!(d.status, DelegationStatus::Running);
+}

--- a/crates/trusty-mpm/src/daemon/services/hook_service.rs
+++ b/crates/trusty-mpm/src/daemon/services/hook_service.rs
@@ -248,6 +248,16 @@ impl HookService {
             &payload,
         );
 
+        // 1c (#2864): track native subagent dispatches. Claude Code already
+        // routes every `Task`/`Agent` tool call through this pipeline via the
+        // `matcher: "*"` PreToolUse hook, so tracking needs no opt-in — it just
+        // needs to read the correlation keys. Synchronous and in-memory only
+        // (one DashMap write): this runs inside the 5 s PreToolUse budget on
+        // the hot path of every tool call, and `observe` early-outs on the tool
+        // name before touching state. Purely observational — it cannot change
+        // the verdict below.
+        crate::daemon::services::delegation_tracker::observe(&self.state, session, event, &payload);
+
         // 2. PostToolUse: compress tool output before it enters the ring buffer.
         if event == HookEvent::PostToolUse {
             let tool_name = payload
@@ -375,6 +385,91 @@ mod tests {
         );
         assert_eq!(decision, HookDecision::Allow);
         assert_eq!(state.recent_hook_events().len(), 1);
+    }
+
+    #[test]
+    fn process_tracks_delegation_lifecycle_and_unblocks_idle_nudge() {
+        // #2864 regression: before this, the only production construction of a
+        // Delegation was `Queued` and nothing ever advanced it, so
+        // `has_live_children` reported a delegation as live FOREVER and
+        // permanently suppressed the idle nudge for any session that had ever
+        // delegated. This drives the real pipeline (`process`, not the tracker
+        // directly) through dispatch → async launch → stop and asserts the live
+        // flag both raises and — critically — clears again.
+        use crate::core::agent::DelegationStatus;
+        use crate::daemon::idle_nudge::has_live_children;
+
+        let state = Arc::new(DaemonState::new());
+        let id = SessionId::new();
+        let mut s = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
+        s.status = SessionStatus::Active;
+        state.register_session(s);
+        let svc = HookService::new(Arc::clone(&state));
+
+        // No delegations yet: a leaf agent must remain nudgeable.
+        assert!(!has_live_children(&state.delegations_for(id)));
+
+        // Dispatch.
+        svc.process(
+            id,
+            HookEvent::PreToolUse,
+            serde_json::json!({
+                "tool": "Agent",
+                "tool_use_id": "toolu_1",
+                "input": { "subagent_type": "engineer", "description": "implement" }
+            }),
+        );
+        assert!(
+            has_live_children(&state.delegations_for(id)),
+            "a dispatched subagent must count as a live child"
+        );
+
+        // Async launch: still running, now bound to an agent id.
+        svc.process(
+            id,
+            HookEvent::PostToolUse,
+            serde_json::json!({
+                "tool": "Agent",
+                "tool_use_id": "toolu_1",
+                "tool_response": { "isAsync": true, "status": "async_launched", "agentId": "aid1" }
+            }),
+        );
+        assert!(
+            has_live_children(&state.delegations_for(id)),
+            "async_launched is a launch, not a completion"
+        );
+
+        // Stop: the delegation terminalizes and the session is nudgeable again.
+        svc.process(
+            id,
+            HookEvent::SubagentStop,
+            serde_json::json!({ "agent_id": "aid1" }),
+        );
+        let delegations = state.delegations_for(id);
+        assert_eq!(delegations.len(), 1);
+        assert_eq!(delegations[0].status, DelegationStatus::Completed);
+        assert!(
+            !has_live_children(&delegations),
+            "a finished delegation must not suppress the idle nudge forever"
+        );
+    }
+
+    #[test]
+    fn process_leaves_ordinary_tool_calls_untracked() {
+        // The hot path: an ordinary tool call must create no delegation state.
+        let state = Arc::new(DaemonState::new());
+        let id = SessionId::new();
+        let mut s = Session::new(id, "/tmp/p", ControlModel::Tmux, None);
+        s.status = SessionStatus::Active;
+        state.register_session(s);
+
+        let svc = HookService::new(Arc::clone(&state));
+        svc.process(
+            id,
+            HookEvent::PreToolUse,
+            serde_json::json!({ "tool": "Bash", "input": { "command": "ls" } }),
+        );
+        assert!(state.delegations_for(id).is_empty());
     }
 
     // ---- is_coding_file unit tests ---------------------------------------

--- a/crates/trusty-mpm/src/daemon/services/mod.rs
+++ b/crates/trusty-mpm/src/daemon/services/mod.rs
@@ -11,6 +11,7 @@
 //! Test: each submodule carries its own `#[cfg(test)]` suite; run them with
 //! `cargo test -p trusty-mpm-daemon services`.
 
+pub mod delegation_tracker;
 pub mod hook_service;
 pub mod pairing_service;
 pub mod session_service;

--- a/crates/trusty-mpm/src/daemon/state/mod.rs
+++ b/crates/trusty-mpm/src/daemon/state/mod.rs
@@ -15,7 +15,7 @@
 mod core;
 mod overseer;
 mod resources;
-mod sessions;
+pub(crate) mod sessions;
 mod sm;
 
 #[cfg(test)]
@@ -24,3 +24,4 @@ mod tests;
 pub use core::{
     DaemonState, EVENT_CHANNEL_CAPACITY, HOOK_HISTORY_LIMIT, PAIR_CODE_TTL, ReapResult,
 };
+pub use sessions::DelegationSweep;

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -9,7 +9,7 @@
 
 use std::path::PathBuf;
 
-use crate::core::agent::Delegation;
+use crate::core::agent::{Delegation, DelegationId, DelegationStatus};
 use crate::core::project::ProjectInfo;
 use crate::core::session::{Session, SessionId};
 
@@ -422,6 +422,65 @@ impl DaemonState {
             .filter(|e| e.value().session == session)
             .map(|e| e.value().clone())
             .collect()
+    }
+
+    /// Find one session's delegation matching `pred`, returning its id (#2864).
+    ///
+    /// Why: the hook delegation tracker resolves a record by correlation key
+    /// (`tool_use_id` or `agent_id`) and then mutates it. Returning the id
+    /// rather than the record keeps the scan's read guards from overlapping the
+    /// subsequent write, which would deadlock a `DashMap` shard.
+    /// What: scans this session's delegations and returns the first match's
+    /// [`DelegationId`], or `None`. The session filter is what stops one
+    /// session's `SubagentStop` from resolving another's child.
+    /// Test: `daemon::services::delegation_tracker` suite, in particular
+    /// `delegations_are_scoped_per_session`.
+    pub fn find_delegation(
+        &self,
+        session: SessionId,
+        pred: impl Fn(&Delegation) -> bool,
+    ) -> Option<DelegationId> {
+        self.delegations
+            .iter()
+            .find(|e| e.value().session == session && pred(e.value()))
+            .map(|e| e.value().id)
+    }
+
+    /// Apply `f` to one delegation in place (#2864).
+    ///
+    /// Why: hook correlation updates a few fields of an existing record
+    /// (status, `agent_id`, tier, timestamps); a read-clone-reinsert cycle would
+    /// race a concurrent update from another hook event.
+    /// What: takes the entry's write guard and runs `f`. Returns `false` when no
+    /// such delegation exists. `f` must not touch the delegation store — it runs
+    /// under a shard lock.
+    /// Test: `daemon::services::delegation_tracker` suite.
+    pub fn mutate_delegation(&self, id: DelegationId, f: impl FnOnce(&mut Delegation)) -> bool {
+        match self.delegations.get_mut(&id.0) {
+            Some(mut entry) => {
+                f(entry.value_mut());
+                true
+            }
+            None => false,
+        }
+    }
+
+    /// Move one delegation to a terminal status, stamping `ended_at` (#2864).
+    ///
+    /// Why: before #2864 nothing ever left `Queued`, so
+    /// [`has_live_children`](crate::daemon::idle_nudge::has_live_children)
+    /// reported every delegation as live forever and permanently suppressed the
+    /// idle nudge. This is the mutator that closes a delegation out.
+    /// What: sets `status` and stamps `ended_at` with the current time. Returns
+    /// `false` when no such delegation exists. Callers are responsible for only
+    /// passing a terminal [`DelegationStatus`].
+    /// Test: `subagent_stop_completes_matching_delegation`,
+    /// `concurrent_delegations_terminalize_independently`.
+    pub fn terminate_delegation(&self, id: DelegationId, status: DelegationStatus) -> bool {
+        self.mutate_delegation(id, |d| {
+            d.status = status;
+            d.ended_at = Some(chrono::Utc::now());
+        })
     }
 
     /// Reap managed sessions whose tmux session has disappeared.

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -9,13 +9,75 @@
 
 use std::path::PathBuf;
 
-use crate::core::agent::{Delegation, DelegationId, DelegationStatus};
+use crate::core::agent::{Delegation, DelegationId, DelegationSource, DelegationStatus};
 use crate::core::project::ProjectInfo;
 use crate::core::session::{Session, SessionId};
 
 use super::core::PAIR_CODE_TTL;
 use super::core::{DaemonState, ReapResult};
 use crate::daemon::tmux::TmuxDriver;
+
+/// How long a live delegation may go without a terminal signal before tracking
+/// gives up on it and marks it [`DelegationStatus::Stale`] (#2864 review).
+///
+/// Why this exists at all: `SubagentStop` is the only signal that closes a
+/// `Running` delegation, and it is not guaranteed to arrive — `tm hook` POSTs
+/// fail open on a 2 s budget, an interrupted subagent emits no stop at all, and
+/// a dispatch that never learned an `agent_id` can never be resolved by one.
+/// Without a bound, one such delegation suppresses its session's idle nudge for
+/// the daemon's entire lifetime, which is the very bug #2864 set out to fix.
+///
+/// Why six hours and not minutes: agents in this workspace legitimately run for
+/// hours (a foreground `gh pr checks --watch` on a slow CI leg, a multi-crate
+/// release chain). A short TTL would manufacture the false negative it is meant
+/// to prevent. Six hours is well past the longest observed real run (~2 h) while
+/// still bounding the damage to one working day rather than forever.
+///
+/// Why being wrong is survivable: the sweep writes `Stale`, never `Completed`.
+/// A delegation that outlives the budget is reported as "tracking lost", not as
+/// finished, and a late `SubagentStop` still resolves it to the truth because
+/// `Stale` is not terminal.
+/// Test: `stale_running_delegation_stops_suppressing_the_nudge`.
+pub(crate) const RUNNING_STALE_AFTER_SECS: i64 = 6 * 60 * 60;
+
+/// How long a `Queued` `McpDeclared` delegation may sit undispatched before it
+/// is marked [`DelegationStatus::Stale`] (#2864 review).
+///
+/// Why so much shorter than [`RUNNING_STALE_AFTER_SECS`]: a `Queued`
+/// `McpDeclared` record is a *declaration of intent* — `agent_delegate`
+/// explicitly does not execute anything (#1942) — so it is not evidence of a
+/// running agent at all. Nothing but a matching hook observation ever advances
+/// it, and the dedup that would consume it gives up after
+/// `delegation_tracker::DEDUP_WINDOW_SECS`. Past that window an undispatched
+/// declaration is stale by definition; keeping it "live" only suppresses the
+/// idle nudge for a subagent that was never spawned.
+/// Test: `declared_but_never_dispatched_goes_stale_quickly`.
+pub(crate) const DECLARED_STALE_AFTER_SECS: i64 = 15 * 60;
+
+/// How long a non-live delegation is retained before eviction (#2864 review).
+///
+/// Why: without eviction the delegation map grows monotonically for the
+/// daemon's lifetime, and every dispatch pays two O(N) scans over it. An hour
+/// is far longer than any consumer needs — `session_status` and
+/// `/tm-session-pause` both ask "what is in flight *now*" — and it bounds N to
+/// roughly one hour of fleet dispatch volume instead of one uptime's worth.
+/// Test: `terminal_delegations_are_evicted_after_retention`,
+/// `live_delegations_are_never_evicted`.
+pub(crate) const DELEGATION_RETENTION_SECS: i64 = 60 * 60;
+
+/// What one [`DaemonState::sweep_delegations`] pass did.
+///
+/// Why: the sweep runs on a timer with no caller to inspect its effects, so it
+/// returns a count for the log line and gives tests a precise assertion target
+/// instead of forcing them to re-derive the outcome from the map.
+/// Test: every `*_goes_stale_*` / `*_evicted_*` test asserts on this.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct DelegationSweep {
+    /// Live delegations marked [`DelegationStatus::Stale`] this pass.
+    pub staled: usize,
+    /// Non-live delegations removed from the map this pass.
+    pub evicted: usize,
+}
 
 impl DaemonState {
     // ---- bot pairing ----------------------------------------------------
@@ -444,6 +506,101 @@ impl DaemonState {
             .iter()
             .find(|e| e.value().session == session && pred(e.value()))
             .map(|e| e.value().id)
+    }
+
+    /// The most recently created delegation of one session matching `pred`.
+    ///
+    /// Why: [`Self::delegations_for`] clones every matching record — including
+    /// its `String`s and `PathBuf`s — which is pure waste when the caller only
+    /// wants an id to mutate. The delegation-tracker dedup runs this on the
+    /// dispatch path, so the allocations were per-dispatch and proportional to
+    /// the whole map. Returning a `Copy` id also keeps the scan's read guards
+    /// from overlapping the subsequent write, exactly as [`Self::find_delegation`]
+    /// does.
+    /// What: scans this session's delegations, keeps those satisfying `pred`,
+    /// and returns the id of the one with the greatest `created_at`.
+    /// Test: `dedups_declaration_and_observation`, `dedup_window_expires`.
+    pub fn latest_delegation_matching(
+        &self,
+        session: SessionId,
+        pred: impl Fn(&Delegation) -> bool,
+    ) -> Option<DelegationId> {
+        self.delegations
+            .iter()
+            .filter(|e| e.value().session == session && pred(e.value()))
+            .max_by_key(|e| e.value().created_at)
+            .map(|e| e.value().id)
+    }
+
+    /// Bound delegation liveness and delegation-map growth (#2864 review).
+    ///
+    /// Why: `SubagentStop` is the only signal that closes a `Running`
+    /// delegation and it is not guaranteed to arrive (dropped hook POST,
+    /// interrupted subagent, a dispatch that never learned an `agent_id`).
+    /// Before this sweep such a record was immortal: it counted as live in
+    /// [`crate::daemon::idle_nudge::has_live_children`] forever, suppressing
+    /// that session's idle nudge for the daemon's lifetime, and it was never
+    /// removed from the map, which therefore grew without bound while every
+    /// dispatch paid an O(N) scan over it. Both are the same root cause — a
+    /// delegation with no route out — so one sweep closes both.
+    ///
+    /// What: one pass over the map, off the `PreToolUse` hot path (it is driven
+    /// by the 60 s reap loop, never by a hook). For each record:
+    /// - live and older than its budget ([`DECLARED_STALE_AFTER_SECS`] for an
+    ///   undispatched `McpDeclared` declaration, else
+    ///   [`RUNNING_STALE_AFTER_SECS`]) → [`DelegationStatus::Stale`] with
+    ///   `ended_at` stamped. **Never `Completed`** — the sweep records that
+    ///   tracking gave up, not that the agent finished, and `Stale` is
+    ///   non-terminal so a late `SubagentStop` still resolves it correctly.
+    /// - not live and `ended_at` older than [`DELEGATION_RETENTION_SECS`] →
+    ///   removed. A live record has no `ended_at` and is never evicted, so work
+    ///   in flight can never be dropped by the retention rule.
+    ///
+    /// The age clock is `started_at` when known, else `created_at`.
+    /// Test: `stale_running_delegation_stops_suppressing_the_nudge`,
+    /// `declared_but_never_dispatched_goes_stale_quickly`,
+    /// `terminal_delegations_are_evicted_after_retention`,
+    /// `live_delegations_are_never_evicted`.
+    pub fn sweep_delegations(&self) -> DelegationSweep {
+        self.sweep_delegations_at(chrono::Utc::now())
+    }
+
+    /// [`Self::sweep_delegations`] with an injected clock.
+    ///
+    /// Why: the budgets are hours long, so the tests must be able to name "now"
+    /// rather than sleep or backdate every field of every fixture.
+    /// Test: as [`Self::sweep_delegations`].
+    pub(crate) fn sweep_delegations_at(
+        &self,
+        now: chrono::DateTime<chrono::Utc>,
+    ) -> DelegationSweep {
+        let mut sweep = DelegationSweep::default();
+        self.delegations.retain(|_, d| {
+            if d.status.is_live() {
+                let budget = if d.status == DelegationStatus::Queued
+                    && d.source == DelegationSource::McpDeclared
+                {
+                    DECLARED_STALE_AFTER_SECS
+                } else {
+                    RUNNING_STALE_AFTER_SECS
+                };
+                let since = d.started_at.unwrap_or(d.created_at);
+                if now - since > chrono::Duration::seconds(budget) {
+                    d.status = DelegationStatus::Stale;
+                    d.ended_at = Some(now);
+                    sweep.staled += 1;
+                }
+                return true;
+            }
+            let keep = d
+                .ended_at
+                .is_none_or(|t| now - t <= chrono::Duration::seconds(DELEGATION_RETENTION_SECS));
+            if !keep {
+                sweep.evicted += 1;
+            }
+            keep
+        });
+        sweep
     }
 
     /// Apply `f` to one delegation in place (#2864).

--- a/crates/trusty-mpm/src/daemon/state/sessions.rs
+++ b/crates/trusty-mpm/src/daemon/state/sessions.rs
@@ -54,16 +54,42 @@ pub(crate) const RUNNING_STALE_AFTER_SECS: i64 = 6 * 60 * 60;
 /// Test: `declared_but_never_dispatched_goes_stale_quickly`.
 pub(crate) const DECLARED_STALE_AFTER_SECS: i64 = 15 * 60;
 
-/// How long a non-live delegation is retained before eviction (#2864 review).
+/// How long a **terminal** delegation is retained after `ended_at` (#2864
+/// review).
 ///
 /// Why: without eviction the delegation map grows monotonically for the
 /// daemon's lifetime, and every dispatch pays two O(N) scans over it. An hour
 /// is far longer than any consumer needs — `session_status` and
 /// `/tm-session-pause` both ask "what is in flight *now*" — and it bounds N to
 /// roughly one hour of fleet dispatch volume instead of one uptime's worth.
+/// Nothing can ever resolve a terminal record, so evicting it loses nothing.
+/// [`DelegationStatus::Stale`] is emphatically NOT terminal and does not use
+/// this window — see [`STALE_RETENTION_SECS`].
 /// Test: `terminal_delegations_are_evicted_after_retention`,
 /// `live_delegations_are_never_evicted`.
 pub(crate) const DELEGATION_RETENTION_SECS: i64 = 60 * 60;
+
+/// How long a [`DelegationStatus::Stale`] delegation is retained, measured from
+/// its own start (#2864 re-review).
+///
+/// Why this is separate from — and 24x — [`DELEGATION_RETENTION_SECS`]: the
+/// entire justification for `Stale` being a distinct, *non-terminal* status is
+/// that a late `SubagentStop` can still resolve it to the truth. Reusing the
+/// terminal retention window silently cancelled that guarantee: a record whose
+/// agent may still be alive was dropped one hour after tracking gave up on it
+/// (about 7 h total), after which a stop resolved nothing because there was no
+/// record left to find. A guarantee that expires unannounced is worse than no
+/// guarantee.
+///
+/// Measuring from `started_at`/`created_at` rather than from a separate
+/// "when we gave up" stamp keeps [`Delegation::ended_at`] meaning exactly one
+/// thing — *reached a terminal status* — which matters because S3 will persist
+/// it. With the current constants a `Running` delegation goes `Stale` at 6 h and
+/// remains resolvable until 24 h: an **18-hour** recovery window, and a hard
+/// bound so the map still cannot grow without limit.
+/// Test: `stale_delegation_stays_resolvable_far_past_the_terminal_window`,
+/// `a_stale_delegation_is_eventually_evicted`.
+pub(crate) const STALE_RETENTION_SECS: i64 = 24 * 60 * 60;
 
 /// What one [`DaemonState::sweep_delegations`] pass did.
 ///
@@ -545,22 +571,37 @@ impl DaemonState {
     /// delegation with no route out — so one sweep closes both.
     ///
     /// What: one pass over the map, off the `PreToolUse` hot path (it is driven
-    /// by the 60 s reap loop, never by a hook). For each record:
-    /// - live and older than its budget ([`DECLARED_STALE_AFTER_SECS`] for an
-    ///   undispatched `McpDeclared` declaration, else
-    ///   [`RUNNING_STALE_AFTER_SECS`]) → [`DelegationStatus::Stale`] with
-    ///   `ended_at` stamped. **Never `Completed`** — the sweep records that
-    ///   tracking gave up, not that the agent finished, and `Stale` is
-    ///   non-terminal so a late `SubagentStop` still resolves it correctly.
-    /// - not live and `ended_at` older than [`DELEGATION_RETENTION_SECS`] →
-    ///   removed. A live record has no `ended_at` and is never evicted, so work
-    ///   in flight can never be dropped by the retention rule.
+    /// by the 60 s reap loop, never by a hook). A record is *aged* from
+    /// `started_at` when known, else `created_at`. Exactly three dispositions,
+    /// and eviction is stated as a guarantee the code actually keeps:
     ///
-    /// The age clock is `started_at` when known, else `created_at`.
+    /// | status | staling | eviction |
+    /// |---|---|---|
+    /// | `Queued`/`Running` (live) | past [`DECLARED_STALE_AFTER_SECS`] for an undispatched `McpDeclared` declaration, else [`RUNNING_STALE_AFTER_SECS`] → [`DelegationStatus::Stale`] | **never, at any age** |
+    /// | `Stale` | — | aged past [`STALE_RETENTION_SECS`] |
+    /// | terminal | — | [`DELEGATION_RETENTION_SECS`] after `ended_at` |
+    ///
+    /// The sweep writes `Stale` and **never** `Completed`: it records that
+    /// tracking gave up, not that the agent finished. It deliberately does NOT
+    /// stamp `ended_at`, which keeps that field meaning exactly *"reached a
+    /// terminal status"* and keeps `Stale` off the terminal retention clock.
+    ///
+    /// So the precise safety property — the one a reader will rely on — is:
+    /// **a record is evicted only once nothing can still resolve it.** A live
+    /// record is never evicted at any age. A `Stale` record stays present, and
+    /// stays resolvable by a late `SubagentStop` (which matches on
+    /// `!is_terminal()`), for `STALE_RETENTION_SECS` minus its staling budget —
+    /// **18 hours** with the current constants — after tracking gave up. A
+    /// terminal record can be resolved by nothing, so its shorter window costs
+    /// nothing. Past 24 h a `Stale` record IS dropped and a later stop finds
+    /// nothing: the recovery window is long, not infinite, because the map must
+    /// stay bounded. That bound is asserted, not incidental.
     /// Test: `stale_running_delegation_stops_suppressing_the_nudge`,
     /// `declared_but_never_dispatched_goes_stale_quickly`,
     /// `terminal_delegations_are_evicted_after_retention`,
-    /// `live_delegations_are_never_evicted`.
+    /// `live_delegations_are_never_evicted`,
+    /// `stale_delegation_stays_resolvable_far_past_the_terminal_window`,
+    /// `a_stale_delegation_is_eventually_evicted`.
     pub fn sweep_delegations(&self) -> DelegationSweep {
         self.sweep_delegations_at(chrono::Utc::now())
     }
@@ -576,6 +617,7 @@ impl DaemonState {
     ) -> DelegationSweep {
         let mut sweep = DelegationSweep::default();
         self.delegations.retain(|_, d| {
+            let age_from = d.started_at.unwrap_or(d.created_at);
             if d.status.is_live() {
                 let budget = if d.status == DelegationStatus::Queued
                     && d.source == DelegationSource::McpDeclared
@@ -584,17 +626,26 @@ impl DaemonState {
                 } else {
                     RUNNING_STALE_AFTER_SECS
                 };
-                let since = d.started_at.unwrap_or(d.created_at);
-                if now - since > chrono::Duration::seconds(budget) {
+                if now - age_from > chrono::Duration::seconds(budget) {
+                    // Status only. Stamping `ended_at` here would both overload
+                    // that field's meaning and put a still-possibly-live record
+                    // on the terminal retention clock, silently expiring the
+                    // recovery guarantee `Stale` exists to provide.
                     d.status = DelegationStatus::Stale;
-                    d.ended_at = Some(now);
                     sweep.staled += 1;
                 }
+                // A live record is never evicted, at any age.
                 return true;
             }
-            let keep = d
-                .ended_at
-                .is_none_or(|t| now - t <= chrono::Duration::seconds(DELEGATION_RETENTION_SECS));
+            let keep = if d.status == DelegationStatus::Stale {
+                // May still be resolvable by a late `SubagentStop`: held far
+                // longer, on its own age clock.
+                now - age_from <= chrono::Duration::seconds(STALE_RETENTION_SECS)
+            } else {
+                // Terminal: nothing can resolve it, so nothing is lost.
+                now - d.ended_at.unwrap_or(d.created_at)
+                    <= chrono::Duration::seconds(DELEGATION_RETENTION_SECS)
+            };
             if !keep {
                 sweep.evicted += 1;
             }

--- a/crates/trusty-mpm/tests/tm_hook_delegation_payload.rs
+++ b/crates/trusty-mpm/tests/tm_hook_delegation_payload.rs
@@ -1,0 +1,228 @@
+//! Integration test: `tm hook` forwards subagent correlation keys (#2864 S1).
+//!
+//! Why: the daemon can only correlate a `SubagentStop` back to the dispatch that
+//! started it if the hook shim actually forwards the keys Claude Code provides.
+//! The pure builder is unit-tested in `commands::hook_payload`, but nothing
+//! proved those fields survive the real path — stdin JSON → `tm hook` → HTTP
+//! POST body. A regression there would be invisible to the unit tests and would
+//! silently disable delegation tracking in production, so it is asserted here
+//! against the actual built binary.
+//! What: stands up a one-shot loopback HTTP server, runs the built `tm` binary
+//! as `tm --url <server> hook` with a real captured hook payload on stdin, and
+//! asserts on the JSON body the daemon would have received. The payloads mirror
+//! live Claude Code 2.1.220 captures (the #2864 Step-0 probe).
+//! Test: `cargo test -p trusty-mpm --test tm_hook_delegation_payload`.
+
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::process::{Command, Stdio};
+
+/// Read one HTTP request off `stream` and return its body.
+///
+/// Why: the hook POSTs a single small JSON body; a full HTTP stack would be
+/// overkill. Reading headers to find `Content-Length` and then exactly that many
+/// bytes is deterministic and avoids relying on the peer closing the socket.
+fn read_http_body(stream: &mut TcpStream) -> String {
+    let mut buf = Vec::new();
+    let mut chunk = [0u8; 1024];
+
+    // Read until the end of the header block.
+    let header_end = loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break buf.windows(4).position(|w| w == b"\r\n\r\n"),
+            Ok(n) => {
+                buf.extend_from_slice(&chunk[..n]);
+                if let Some(p) = buf.windows(4).position(|w| w == b"\r\n\r\n") {
+                    break Some(p);
+                }
+            }
+            Err(e) => panic!("read failed: {e}"),
+        }
+    }
+    .expect("request must contain a header terminator");
+
+    let headers = String::from_utf8_lossy(&buf[..header_end]).to_lowercase();
+    let len: usize = headers
+        .lines()
+        .find_map(|l| l.strip_prefix("content-length:"))
+        .and_then(|v| v.trim().parse().ok())
+        .expect("hook POST must carry a content-length");
+
+    let body_start = header_end + 4;
+    while buf.len() < body_start + len {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => buf.extend_from_slice(&chunk[..n]),
+            Err(e) => panic!("read failed: {e}"),
+        }
+    }
+    String::from_utf8_lossy(&buf[body_start..body_start + len]).into_owned()
+}
+
+/// Run `tm hook` with `stdin_json` against a one-shot capture server and return
+/// the POSTed body, the process's success flag, and its stdout.
+fn capture_hook_post(stdin_json: &str) -> (serde_json::Value, bool, String) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let port = listener.local_addr().expect("addr").port();
+
+    let server = std::thread::spawn(move || {
+        let (mut stream, _) = listener.accept().expect("accept");
+        let body = read_http_body(&mut stream);
+        let _ = stream.write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}");
+        let _ = stream.flush();
+        body
+    });
+
+    let bin = env!("CARGO_BIN_EXE_tm");
+    let mut child = Command::new(bin)
+        .args(["--url", &format!("http://127.0.0.1:{port}"), "hook"])
+        .env_remove("TRUSTY_MPM_DISABLE_HOOKS")
+        .env_remove("CLAUDE_MPM_SUB_AGENT")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn `tm hook`");
+    child
+        .stdin
+        .take()
+        .expect("child stdin")
+        .write_all(stdin_json.as_bytes())
+        .expect("write stdin");
+    let output = child.wait_with_output().expect("wait for tm hook");
+
+    let body = server.join().expect("capture server panicked");
+    let json: serde_json::Value =
+        serde_json::from_str(&body).unwrap_or_else(|e| panic!("body was not JSON ({e}): {body}"));
+    (
+        json,
+        output.status.success(),
+        String::from_utf8_lossy(&output.stdout).into_owned(),
+    )
+}
+
+#[test]
+fn pre_tool_use_dispatch_forwards_tool_use_id_and_cwd() {
+    // Verbatim shape of a live Claude Code 2.1.220 subagent dispatch.
+    let stdin = serde_json::json!({
+        "session_id": "d6066d66-8c7f-41f1-8914-8d0710d563aa",
+        "transcript_path": "/tmp/proj/d6066d66.jsonl",
+        "cwd": "/tmp/proj",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Agent",
+        "tool_input": {
+            "description": "probe alpha",
+            "prompt": "Reply with ALPHA.",
+            "subagent_type": "general-purpose"
+        },
+        "tool_use_id": "toolu_01DAvdgnCx8jYZQmn8NYpUge"
+    })
+    .to_string();
+
+    let (body, ok, stdout) = capture_hook_post(&stdin);
+    assert!(ok, "hook must exit 0 (fail-open)");
+    // PreToolUse stdout-purity contract: no rewrite applies to a dispatch tool,
+    // so the hook must print nothing at all.
+    assert!(
+        stdout.is_empty(),
+        "PreToolUse must not write to stdout here, got: {stdout:?}"
+    );
+
+    assert_eq!(body["event"], "PreToolUse");
+    assert_eq!(body["session_id"], "d6066d66-8c7f-41f1-8914-8d0710d563aa");
+
+    let p = &body["payload"];
+    // Pre-#2864 fields still present.
+    assert_eq!(p["tool"], "Agent");
+    assert_eq!(p["input"]["subagent_type"], "general-purpose");
+    assert!(
+        p["cwd"].as_str().is_some_and(|s| !s.is_empty()),
+        "cwd must be forwarded (#1744)"
+    );
+    // The #2864 additions that make correlation possible.
+    assert_eq!(p["tool_use_id"], "toolu_01DAvdgnCx8jYZQmn8NYpUge");
+    assert_eq!(p["transcript_path"], "/tmp/proj/d6066d66.jsonl");
+}
+
+#[test]
+fn post_tool_use_forwards_compacted_agent_id() {
+    let stdin = serde_json::json!({
+        "session_id": "d6066d66-8c7f-41f1-8914-8d0710d563aa",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Agent",
+        "tool_use_id": "toolu_01DAvdgnCx8jYZQmn8NYpUge",
+        "tool_response": {
+            "isAsync": true,
+            "status": "async_launched",
+            "agentId": "a403cdbc078b5c474",
+            "resolvedModel": "claude-haiku-4-5-20251001",
+            "prompt": "Reply with ALPHA.",
+            "outputFile": "/tmp/out.txt"
+        }
+    })
+    .to_string();
+
+    let (body, ok, _) = capture_hook_post(&stdin);
+    assert!(ok);
+    let p = &body["payload"];
+    assert_eq!(p["tool_use_id"], "toolu_01DAvdgnCx8jYZQmn8NYpUge");
+    assert_eq!(p["tool_response"]["agentId"], "a403cdbc078b5c474");
+    assert_eq!(p["tool_response"]["status"], "async_launched");
+    assert_eq!(p["tool_response"]["isAsync"], true);
+    // Bulk fields are not relayed.
+    assert!(p["tool_response"].get("prompt").is_none());
+    assert!(p["tool_response"].get("outputFile").is_none());
+}
+
+#[test]
+fn subagent_stop_forwards_agent_id_and_both_transcripts() {
+    // `agent_id` is THE correlation key; `agent_transcript_path` is the
+    // subagent's own transcript, distinct from the parent's `transcript_path`.
+    let stdin = serde_json::json!({
+        "session_id": "d6066d66-8c7f-41f1-8914-8d0710d563aa",
+        "transcript_path": "/tmp/proj/d6066d66.jsonl",
+        "hook_event_name": "SubagentStop",
+        "agent_id": "a403cdbc078b5c474",
+        "agent_type": "general-purpose",
+        "agent_transcript_path": "/tmp/proj/d6066d66/subagents/agent-a403cdbc078b5c474.jsonl",
+        "last_assistant_message": "ALPHA"
+    })
+    .to_string();
+
+    let (body, ok, _) = capture_hook_post(&stdin);
+    assert!(ok);
+    let p = &body["payload"];
+    assert_eq!(body["event"], "SubagentStop");
+    assert_eq!(p["agent_id"], "a403cdbc078b5c474");
+    assert_eq!(p["agent_type"], "general-purpose");
+    assert_eq!(
+        p["agent_transcript_path"],
+        "/tmp/proj/d6066d66/subagents/agent-a403cdbc078b5c474.jsonl"
+    );
+    assert_eq!(p["transcript_path"], "/tmp/proj/d6066d66.jsonl");
+}
+
+#[test]
+fn ordinary_tool_use_does_not_gain_a_tool_response() {
+    // The bandwidth guard, end to end: a Bash PostToolUse must not relay its
+    // (potentially enormous) tool_response.
+    let stdin = serde_json::json!({
+        "session_id": "d6066d66-8c7f-41f1-8914-8d0710d563aa",
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_use_id": "toolu_bash",
+        "tool_response": { "stdout": "x".repeat(100_000) }
+    })
+    .to_string();
+
+    let (body, ok, _) = capture_hook_post(&stdin);
+    assert!(ok);
+    let p = &body["payload"];
+    assert_eq!(p["tool"], "Bash");
+    assert_eq!(p["tool_use_id"], "toolu_bash");
+    assert!(
+        p.get("tool_response").is_none(),
+        "a non-dispatch tool_response must never be relayed"
+    );
+    assert!(body.to_string().len() < 2000, "relay must stay bounded");
+}


### PR DESCRIPTION
## Summary

Slices **S1 + S2** of #2864 — the foundation for `/tm-session-pause` recording in-flight agents. Later slices (S3 persistence, S4 pause snapshot, S5 resume, S6 quiesce) build on this and are **not** in scope here.

Delegation tracking had two defects that together made it useless as a basis for *"which agents are in flight?"*:

1. **It was opt-in.** A record existed only if the PM chose to call the `agent_delegate` MCP tool, so a PM that dispatched work with the native subagent tool alone left no trace at all.
2. **Status never moved.** The only production construction yields `Queued` (`core/agent.rs`) and nothing ever wrote `Running`/`Completed`/`Failed`. Since `has_live_children` counts `Queued`/`Running` as live, **every delegation was live forever**, permanently suppressing the idle nudge for any session that had ever delegated once.

Both are fixed by observing hooks the daemon **already receives**: `PreToolUse` with `matcher: "*"` is installed on every managed session, so every native subagent dispatch already arrives at `HookService::process`. No new hook, no opt-in — the correlation keys were simply being dropped on the floor.

## Step 0: the correlation model was measured, not assumed

Captured from **live Claude Code 2.1.220** hook stdin, with two *concurrent* subagents — the case that breaks any "most recent" guess:

```
PreToolUse   tool_name=Agent  tool_use_id=toolu_01DA…   (no agent id yet)
PostToolUse  tool_name=Agent  tool_use_id=toolu_01DA…
             tool_response={ isAsync: true, status: "async_launched",
                             agentId: "a403cdbc078b5c474", duration_ms: 1 }
SubagentStop                  agent_id="a403cdbc078b5c474"
```

Three findings, two of which **inverted** the planned design:

| Question | Answer |
|---|---|
| Does `SubagentStop` carry a correlation key? | **Yes — `agent_id`**, byte-identical to `PostToolUse.tool_response.agentId`. Authoritative, not advisory. |
| Does `SubagentStop.transcript_path` point at the subagent? | **No — the parent's.** The subagent's is a separate `agent_transcript_path` field. |
| Does `PreToolUse`/`PostToolUse` carry `tool_use_id`? | **Yes**, and it is identical across the pair. |

- **The tool is named `Agent`, not `Task`,** in current Claude Code. Both names are matched — recognising only one silently disables tracking on half the installed base.
- **`PostToolUse` does NOT mean the subagent finished.** For an async dispatch it fires ~1 ms after launch (`status: "async_launched"`, `duration_ms: 1`) while the subagent runs on for minutes. Terminalizing there — the fallback the plan called for if no correlation key existed — would mark every delegation `Completed` almost immediately and report *"no agents in flight"* while they were all still running. It is instead a **join** step that learns `agentId`, and terminalizes only on a genuinely synchronous return.
- Absent an `agent_id`, **nothing is terminalized.** A "most recent Running" guess would close the wrong delegation under concurrency and manufacture a false idle — the specific failure this design exists to prevent.

## Changes

**S1 — widen the forwarded payload** (additive only)

- `tm hook` now forwards `tool_use_id` + `transcript_path` on tool events, and `agent_id` / `agent_type` / `agent_transcript_path` on `SubagentStop`. `cwd` was already forwarded and is confirmed by test.
- `tool_response` is relayed **only** for a subagent-dispatch tool, and only as a fixed five-key projection — an ordinary tool's unbounded output is never forwarded (bandwidth guard, asserted with a 100 KB payload).
- Extracted to `commands::hook_payload` as a pure function. `misc.rs` was 10 SLOC under the production cap; this leaves it **9 SLOC smaller** and makes the forwarded shape unit-testable. It performs no I/O and writes nothing to stdout, so the `PreToolUse` **stdout-purity contract is preserved** (asserted in an integration test).

**S2 — make tracking real**

- New `daemon::services::delegation_tracker`: upserts a `Running` delegation on dispatch, joins `agentId` on launch, terminalizes on stop.
- `Delegation` gains `source` (`McpDeclared` | `HookObserved`), `tool_use_id`, `agent_id`, `transcript_path`, `cwd`, `started_at`, `ended_at`. Every new field is `#[serde(default)]`, so pre-existing records still deserialize (covered by a legacy-JSON test).
- New state mutators: `find_delegation`, `mutate_delegation`, `terminate_delegation`.
- Dedup: a PM that calls **both** `agent_delegate` and the native tool yields **one** record, promoted in place to `Running`, within a 300 s window.

## Performance

`PreToolUse` is synchronous with a 5 s timeout in front of every tool call in every managed session. Measured (release, 200k iterations):

| Path | Cost |
|---|---|
| **Ordinary tool (Bash) — ~all traffic** | **11.4 ns/call** |
| No-tool payload | 6.6 ns/call |
| Dispatch path, 50 existing delegations | 830 ns/call |

11.4 ns against a 5 s budget is ~2×10⁻⁷ % — one map lookup and an exact string compare before returning. The dispatch path is in-memory DashMap work only: no disk, no network, no async, no blocking lock.

## Blast radius

**No change to `agent_delegate`** (`daemon/mcp_backend.rs`) and **no change to the tool description** (`mcp/tools/core.rs`). `git diff origin/main` is empty for both, and for `mcp/tools/mod.rs`. The #1942 CI guard test `agent_delegate_description_clarifies_it_does_not_execute` passes **untouched**. Nothing forced me toward touching them.

## Tests

23 new tests, all required cases covered:

- `PreToolUse{Agent}` → a `Running` delegation appears
- `PostToolUse` → `Completed` (synchronous) / stays `Running` (async launch)
- `has_live_children` flips both ways — explicit regression that `idle_nudge` no longer suppresses nudges forever, driven through the real `HookService::process`
- Dedup: `agent_delegate` + native dispatch → exactly one record
- **Concurrency: two simultaneous `Running` delegations; terminalizing one does not close the other**
- Per-session scoping, idempotent redelivery, unknown/missing `agent_id` no-ops, legacy `Task` tool name, legacy JSON round-trip
- 4 end-to-end tests driving the real `tm` binary against a capture server, proving the fields survive stdin → HTTP POST

## Quality gate

| Gate | Result |
|---|---|
| `cargo check --all-targets` | clean |
| `cargo test -p trusty-mpm` (full surface) | **6389 passed, 0 failed** |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | exit 0 |
| `scripts/check_line_cap.sh` | 7 allowlisted, 0 violations |

No test was `#[ignore]`d, cfg-gated, excluded, or deleted. The known-flaky `prepare_session_excludes_spoofed_trusty_search_when_injector_disabled` passed here (the trusty-memory daemon was running).

Refs #2864

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
