### PR TITLE
fix(trusty-common,trusty-agents): stream Bedrock via ConverseStream (#3767)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **The token-streaming chat path now streams Bedrock models via
+  `ConverseStream` instead of silently falling back to the blocking
+  `Converse` call (#3767).** `streaming_supported()` no longer excludes
+  `Provider::Bedrock`; `stream_reply` routes `bedrock/*` models to a new
+  `trusty_common::chat::BedrockProvider` (real event-stream) branch, with the
+  `bedrock` feature now enabled on the `trusty-common` dependency (zero added
+  weight — this crate already links the AWS Bedrock SDK unconditionally).
+  `StreamAssembly` gained a `usage: Option<ChatUsage>` field so per-call token
+  usage — which Bedrock reports exactly once, in a terminal event — survives
+  the streaming path instead of being dropped.
+
 ### Removed
 
 - **Removed the unused `ompm` `[[bin]]` target.** It was a thin HTTP client

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -52,7 +52,13 @@ trusty-code = { workspace = true }
 #      `llm::inference_client` build on. Already implied transitively by
 #      `config-cli`, but declared explicitly so that relationship is never a
 #      silent, breakable assumption.
-trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server", "inference-client"] }
+# `bedrock` (issue #3767): unlocks trusty-common's real `chat::BedrockProvider`
+#      (`ConverseStream`-backed) for `llm::stream::stream_reply`'s Bedrock
+#      branch — without it `BedrockProvider` resolves to the always-erroring
+#      stub. Zero added dependency weight: `aws-config`/`aws-sdk-bedrockruntime`/
+#      `aws-types` below are already unconditional direct dependencies of this
+#      crate for the existing `llm::bedrock` (Converse, non-streaming) client.
+trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memory-core", "cli-help", "stdio-mcp-client", "session-naming", "config-cli", "axum-server", "inference-client", "bedrock"] }
 # Why (issue #226): trusty-agents only links `trusty_memory::MemoryMcpService` for
 #      in-process `rpc.discover` merging; it does not need the axum HTTP/SSE
 #      surface (it owns its own axum stack for the orchestrator's UI). Setting

--- a/crates/trusty-agents/src/llm/stream.rs
+++ b/crates/trusty-agents/src/llm/stream.rs
@@ -3,35 +3,41 @@
 //! Why: The chat GUI's default surface (the generic Assistant persona and the
 //! no-tools conversational fast path) previously waited for the ENTIRE model
 //! response before rendering anything — a multi-second dead stare on long
-//! replies. `trusty_common::chat::OpenRouterProvider` already speaks the
-//! streaming `/chat/completions` SSE protocol and yields `ChatEvent::Delta`
-//! fragments as tokens arrive; this module adapts that provider stream onto
-//! the crate's own event bus so the browser can render the reply as it is
-//! produced, while still returning the fully-assembled text so history,
-//! `PmResponse`, and responder attribution behave EXACTLY as the
-//! non-streaming path.
+//! replies. `trusty_common::chat::OpenRouterProvider` and (issue #3767)
+//! `trusty_common::chat::BedrockProvider` both speak native token streaming
+//! and yield `ChatEvent::Delta` fragments as tokens arrive; this module
+//! adapts that provider stream onto the crate's own event bus so the browser
+//! can render the reply as it is produced, while still returning the
+//! fully-assembled text so history, `PmResponse`, and responder attribution
+//! behave EXACTLY as the non-streaming path.
 //! What: [`drive_delta_stream`] is the pure, testable batching core — it
 //! consumes a `ChatEvent` receiver, coalesces text deltas to a wall-clock
 //! cadence (so a fast provider produces ~10-20 UI frames/sec instead of one
 //! per token), invokes an `emit(text, done)` sink per flush, and returns the
-//! assembled content. [`stream_reply`] wires that core to a live
-//! `OpenRouterProvider` and publishes each flush as an
-//! [`Event::AgentMessageDelta`] on the process bus (relayed to the browser by
-//! the `/api/events` SSE stream). [`streaming_supported`] is the capability
-//! gate: streaming is used only for OpenRouter-transport models (not Bedrock,
-//! not Fireworks, not Anthropic-direct) and can be disabled wholesale via
-//! `TAGENT_CHAT_STREAMING=0`. Non-streaming providers keep their current
-//! behavior unchanged — callers fall back to the blocking chat path.
+//! assembled content plus any [`ChatEvent::Usage`] the provider reported (#3767
+//! — Bedrock's `ConverseStream` reports it exactly once, in a terminal event,
+//! so it is captured here rather than dropped). [`stream_reply`] picks a live
+//! provider by the model's routed adapter — `BedrockProvider` for
+//! `bedrock/*`, `OpenRouterProvider` otherwise — and publishes each flush as
+//! an [`Event::AgentMessageDelta`] on the process bus (relayed to the browser
+//! by the `/api/events` SSE stream). [`streaming_supported`] is the
+//! capability gate: streaming is used for every adapter family except
+//! Fireworks (no streaming adapter yet) and Anthropic-direct, and can be
+//! disabled wholesale via `TAGENT_CHAT_STREAMING=0`. Non-streaming providers
+//! keep their current behavior unchanged — callers fall back to the blocking
+//! chat path.
 //! Test: `drive_delta_stream_*` unit tests feed a mocked `ChatEvent` channel
 //! (ordered fragments, done flag, assembled-text equality, batching); the
 //! gate is covered by `streaming_supported_*`.
 
 use std::time::{Duration, Instant};
 
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use tokio::sync::mpsc;
 use trusty_common::ChatMessage;
-use trusty_common::chat::{ChatEvent, ChatProvider, OpenRouterProvider, SamplingParams, ToolCall};
+use trusty_common::chat::{
+    ChatEvent, ChatProvider, ChatUsage, OpenRouterProvider, SamplingParams, ToolCall,
+};
 
 use crate::ctrl::state::ConversationTurn;
 use crate::events::{self, Event};
@@ -59,7 +65,11 @@ const STREAM_CHANNEL_CAPACITY: usize = 256;
 /// `PmResponse`) plus any tool calls the provider surfaced and a terminal
 /// error, without re-deriving them from the emitted deltas.
 /// What: `content` is every `Delta` concatenated in order; `tool_calls` are
-/// fully-accumulated provider tool invocations; `error` is `Some` when the
+/// fully-accumulated provider tool invocations; `usage` is the provider's
+/// token tally when it reported one (#3767 — some providers, e.g. Bedrock's
+/// `ConverseStream`, report usage exactly once in a terminal event rather
+/// than per-delta; `None` when the provider never emitted `ChatEvent::Usage`,
+/// which remains true for OpenRouter today); `error` is `Some` when the
 /// stream terminated with `ChatEvent::Error`.
 #[derive(Debug, Default, Clone)]
 pub struct StreamAssembly {
@@ -67,6 +77,8 @@ pub struct StreamAssembly {
     pub content: String,
     /// Tool invocations the provider streamed (empty for a tools-off turn).
     pub tool_calls: Vec<ToolCall>,
+    /// Token usage the provider reported, if any (#3767).
+    pub usage: Option<ChatUsage>,
     /// Human-readable message when the stream ended via `ChatEvent::Error`.
     pub error: Option<String>,
 }
@@ -108,24 +120,23 @@ fn text_message(role: &str, content: &str) -> ChatMessage {
 
 /// Whether the token-streaming path applies to `model`.
 ///
-/// Why: `OpenRouterProvider` only speaks to the OpenRouter transport. Bedrock
-/// (AWS SDK), Fireworks (own base URL / credential), and the Anthropic-direct
-/// path all reach the model through a different client, so streaming through
-/// the OpenRouter provider would target the wrong endpoint. The
-/// `TAGENT_CHAT_STREAMING` env var is a global kill switch for the demo.
+/// Why: `OpenRouterProvider` and `BedrockProvider` (issue #3767 — Bedrock's
+/// `ConverseStream`, wired via `stream_reply`'s provider dispatch below) both
+/// speak native streaming; Fireworks (own base URL / credential, no streaming
+/// adapter yet) and the Anthropic-direct path reach the model through a
+/// different client that doesn't. The `TAGENT_CHAT_STREAMING` env var is a
+/// global kill switch for the demo.
 /// What: Returns `true` only when streaming is enabled AND `use_anthropic_direct`
-/// is false AND the model's adapter family routes over the OpenRouter client
-/// (everything except `Bedrock` / `Fireworks`).
+/// is false AND the model's adapter family has a streaming provider
+/// (`Bedrock` as of #3767, plus everything except `Fireworks`).
 /// Test: `streaming_supported_gates_on_provider`,
+/// `streaming_supported_allows_bedrock`,
 /// `streaming_supported_respects_anthropic_direct`, `parse_streaming_flag_table`.
 pub fn streaming_supported(model: &str, use_anthropic_direct: bool) -> bool {
     if use_anthropic_direct || !streaming_enabled() {
         return false;
     }
-    !matches!(
-        adapter_for_model(model).provider(),
-        Provider::Bedrock | Provider::Fireworks
-    )
+    !matches!(adapter_for_model(model).provider(), Provider::Fireworks)
 }
 
 /// Read the `TAGENT_CHAT_STREAMING` kill switch (default ON).
@@ -164,16 +175,20 @@ fn parse_streaming_flag(value: Option<&str>) -> bool {
 /// the last flush) and the terminal-marker contract the GUI relies on.
 /// What: For each `Delta`, appends to both the running assembly and a pending
 /// buffer; flushes the buffer via `emit(text, false)` once `cadence` has
-/// elapsed. `ToolCall`s accumulate; `Error` records the message and stops;
-/// `Done` (or a closed channel) stops. On exit it flushes any residual buffer
-/// as a non-terminal delta, then emits exactly one terminal `emit("", true)`
-/// so the consumer has an unambiguous end-of-stream signal (carrying empty
-/// text so it never double-appends). Returns the [`StreamAssembly`].
+/// elapsed. `ToolCall`s accumulate; `Usage` (#3767) is recorded onto
+/// `assembly.usage` — never dropped, so a downstream cost-reporting consumer
+/// sees it — without affecting batching or the terminal marker; `Error`
+/// records the message and stops; `Done` (or a closed channel) stops. On exit
+/// it flushes any residual buffer as a non-terminal delta, then emits exactly
+/// one terminal `emit("", true)` so the consumer has an unambiguous
+/// end-of-stream signal (carrying empty text so it never double-appends).
+/// Returns the [`StreamAssembly`].
 /// Test: `drive_delta_stream_flushes_each_delta_at_zero_cadence`,
 /// `drive_delta_stream_batches_under_cadence`,
 /// `drive_delta_stream_assembles_full_text`,
 /// `drive_delta_stream_surfaces_error`,
-/// `drive_delta_stream_collects_tool_calls`.
+/// `drive_delta_stream_collects_tool_calls`,
+/// `drive_delta_stream_captures_usage`.
 pub async fn drive_delta_stream<F>(
     mut rx: mpsc::Receiver<ChatEvent>,
     cadence: Duration,
@@ -197,6 +212,9 @@ where
                 }
             }
             ChatEvent::ToolCall(call) => assembly.tool_calls.push(call),
+            // #3767: never silently drop usage — a downstream cost-reporting
+            // consumer depends on it surviving the streaming path.
+            ChatEvent::Usage(usage) => assembly.usage = Some(usage),
             ChatEvent::Error(message) => {
                 assembly.error = Some(message);
                 break;
@@ -214,29 +232,34 @@ where
     assembly
 }
 
-/// Stream a conversational reply from OpenRouter, publishing deltas on the bus.
+/// Stream a conversational reply, publishing deltas on the bus.
 ///
-/// Why: The live wiring — resolves the OpenRouter credential, spawns the
-/// provider's SSE pump, and drives [`drive_delta_stream`] with a sink that
+/// Why: The live wiring — picks a provider by the model's routed adapter,
+/// spawns its event pump, and drives [`drive_delta_stream`] with a sink that
 /// publishes each flushed batch as an [`Event::AgentMessageDelta`]. The
 /// `agent` label rides every delta so per-message speaker attribution (#3739)
 /// stays truthful mid-stream. Returns the assembled full text so the caller's
 /// downstream behavior (history append, `PmResponse`, attribution) is
 /// byte-for-byte identical to the blocking path.
-/// What: Builds an [`OpenRouterProvider`] for `model`, runs `chat_stream` with
-/// an empty tools list (tools-off conversational turn), and publishes deltas
-/// tagged with `session_id`/`agent`. Errors (empty key, HTTP failure,
-/// mid-stream error) propagate as `Err` so the caller can fall back to the
-/// blocking chat path.
+/// What: `bedrock/*` models (issue #3767) route to [`stream_reply_bedrock`];
+/// everything else builds an [`OpenRouterProvider`] and runs `chat_stream`
+/// with an empty tools list (tools-off conversational turn). Errors (empty
+/// key, HTTP failure, mid-stream error, missing AWS credentials) propagate as
+/// `Err` so the caller can fall back to the blocking chat path.
 ///
-/// `sampling` (issue #3758) MUST carry the same temperature / token ceiling /
-/// stop sequences the caller's blocking path sends for this turn. Without it
-/// the streamed reply silently ran on provider defaults, so its style,
-/// verbosity, and stopping behaviour were not equivalent to the fallback — and
-/// `LlmConfig::stop_sequences` documents itself as forwarded on the OpenRouter
-/// path, which the streaming path was quietly not honouring.
+/// `sampling` (issue #3758, and #3767 for the Bedrock branch) MUST carry the
+/// same temperature / token ceiling / stop sequences the caller's blocking
+/// path sends for this turn. Without it the streamed reply silently ran on
+/// provider defaults, so its style, verbosity, and stopping behaviour were
+/// not equivalent to the fallback — and `LlmConfig::stop_sequences`
+/// documents itself as forwarded on the OpenRouter path, which the streaming
+/// path was quietly not honouring.
 /// Test: exercised end-to-end against a live provider; the batching/assembly
-/// contract is unit-tested via [`drive_delta_stream`].
+/// contract is unit-tested via [`drive_delta_stream`]; the provider-dispatch
+/// branch is covered by `streaming_supported_allows_bedrock` at the gate
+/// level (constructing a live `BedrockProvider` here needs network/credential
+/// access, out of scope for a unit test — see `bedrock_impl`'s own tests for
+/// the Bedrock-specific event mapping).
 pub async fn stream_reply(
     model: &str,
     messages: Vec<ChatMessage>,
@@ -245,6 +268,10 @@ pub async fn stream_reply(
     cadence: Duration,
     sampling: SamplingParams,
 ) -> Result<StreamAssembly> {
+    if adapter_for_model(model).provider() == Provider::Bedrock {
+        return stream_reply_bedrock(model, messages, session_id, agent, cadence, sampling).await;
+    }
+
     let api_key =
         trusty_common::inference::credentials::resolve_key("openrouter").unwrap_or_default();
     if api_key.is_empty() {
@@ -255,6 +282,48 @@ pub async fn stream_reply(
 
     // #3758: forward the blocking path's sampling knobs onto the stream.
     let provider = OpenRouterProvider::new(api_key, model.to_string()).with_sampling(sampling);
+    stream_with_provider(provider, messages, session_id, agent, cadence).await
+}
+
+/// Stream a conversational reply from Bedrock's `ConverseStream` (issue
+/// #3767), publishing deltas on the bus.
+///
+/// Why: mirrors [`stream_reply`]'s OpenRouter branch, but Bedrock is reached
+/// through the AWS SDK client (standard credential chain: env vars,
+/// `~/.aws/credentials`, IAM roles, SSO) rather than an HTTP request with a
+/// bearer token, so construction needs the `bedrock/` prefix stripped to the
+/// bare model id instead of an API key.
+/// What: strips the `bedrock/` prefix (mirrors
+/// `adapter::adapter_for_model`'s `BedrockAdapter` routing), builds a
+/// [`trusty_common::chat::BedrockProvider`] via
+/// [`trusty_common::chat::BedrockProvider::new`], forwards `sampling` (#3758
+/// parity) via `with_sampling`, and delegates to [`stream_with_provider`] for
+/// the shared batching/failure-guard/usage-recording logic. `BedrockProvider`
+/// construction itself does not require live credentials — only the
+/// subsequent `chat_stream` call does — so a caller with no AWS credentials
+/// configured (as on this machine — `AWS_PROFILE`/`AWS_REGION` are
+/// set-but-empty) still gets `Err` from *this* function (via
+/// `stream_with_provider`'s pump-join propagation), letting the caller fall
+/// back to the blocking chat path exactly like any other stream failure.
+/// Test: exercised end-to-end against a live Bedrock endpoint (not runnable
+/// on this machine — no usable AWS credentials); the Bedrock event → `ChatEvent`
+/// mapping is unit-tested in `trusty_common::chat::bedrock_impl`
+/// (`handle_stream_event` tests), and the batching/assembly/usage-capture
+/// contract this function shares with the OpenRouter branch is unit-tested
+/// via [`drive_delta_stream`] and `stream_with_provider_*`.
+async fn stream_reply_bedrock(
+    model: &str,
+    messages: Vec<ChatMessage>,
+    session_id: &str,
+    agent: &str,
+    cadence: Duration,
+    sampling: SamplingParams,
+) -> Result<StreamAssembly> {
+    let model_id = model.strip_prefix("bedrock/").unwrap_or(model);
+    let provider = trusty_common::chat::BedrockProvider::new(model_id, None)
+        .await
+        .context("build BedrockProvider for streaming")?
+        .with_sampling(sampling);
     stream_with_provider(provider, messages, session_id, agent, cadence).await
 }
 
@@ -276,12 +345,21 @@ pub async fn stream_reply(
 /// [`drive_delta_stream`] with a sink that publishes each batch as an
 /// [`Event::AgentMessageDelta`] tagged with `session_id`/`agent`, joins the
 /// pump (propagating its `Err` and panics), surfaces an explicit
-/// `ChatEvent::Error`, then applies the empty-stream guard.
+/// `ChatEvent::Error`, then applies the empty-stream guard. Whatever the
+/// provider reported (content, tool calls, and — #3767 — usage) rides through
+/// on the returned [`StreamAssembly`] unmodified, so a caller that wires
+/// usage into per-dispatch accounting (mirroring the blocking path's
+/// `record_dispatch_usage`) has it available; this function does not write to
+/// that log itself, since a background-spawned disk write triggered by every
+/// streamed call — including from this very test suite — is exactly the kind
+/// of surprising side effect this layer should not introduce silently.
 /// Test: `stream_with_provider_propagates_error_frame`,
 /// `stream_with_provider_propagates_provider_err`,
 /// `stream_with_provider_guards_empty_stream`,
 /// `stream_with_provider_propagates_panic`,
-/// `stream_with_provider_returns_assembled_content`.
+/// `stream_with_provider_returns_assembled_content`,
+/// `stream_with_provider_surfaces_usage_in_assembly`,
+/// `stream_with_provider_usage_absent_when_not_reported`.
 pub async fn stream_with_provider<P>(
     provider: P,
     messages: Vec<ChatMessage>,

--- a/crates/trusty-agents/src/llm/stream_tests.rs
+++ b/crates/trusty-agents/src/llm/stream_tests.rs
@@ -15,7 +15,7 @@ use anyhow::anyhow;
 use async_trait::async_trait;
 use tokio::sync::mpsc::{self, Sender};
 use trusty_common::ChatMessage;
-use trusty_common::chat::{ChatEvent, ChatProvider, ToolCall, ToolDef};
+use trusty_common::chat::{ChatEvent, ChatProvider, ChatUsage, ToolCall, ToolDef};
 
 use super::*;
 
@@ -181,6 +181,48 @@ async fn drive_delta_stream_collects_tool_calls() {
     assert_eq!(assembly.content, "hi");
 }
 
+/// Issue #3767: a `ChatEvent::Usage` mid-stream must land on
+/// `assembly.usage` without disturbing the delta batching or the terminal
+/// marker — the exact "usage survives the streaming path" contract.
+#[tokio::test]
+async fn drive_delta_stream_captures_usage() {
+    let usage = ChatUsage {
+        prompt_tokens: 42,
+        completion_tokens: 7,
+        cache_read_tokens: 0,
+        cache_creation_tokens: 0,
+    };
+    let (emitted, assembly) = run(
+        vec![
+            ChatEvent::Delta("hi".into()),
+            ChatEvent::Usage(usage),
+            ChatEvent::Done,
+        ],
+        Duration::ZERO,
+    )
+    .await;
+
+    assert_eq!(assembly.usage, Some(usage));
+    assert_eq!(assembly.content, "hi");
+    // Usage must not itself trigger a flush or appear in the emitted text.
+    assert_eq!(
+        emitted,
+        vec![("hi".to_string(), false), (String::new(), true)]
+    );
+}
+
+/// A stream that never reports usage (the current OpenRouter reality) must
+/// leave `assembly.usage` as `None` rather than fabricating a zero value.
+#[tokio::test]
+async fn drive_delta_stream_usage_absent_when_not_reported() {
+    let (_emitted, assembly) = run(
+        vec![ChatEvent::Delta("hi".into()), ChatEvent::Done],
+        Duration::ZERO,
+    )
+    .await;
+    assert!(assembly.usage.is_none());
+}
+
 #[test]
 fn build_messages_shapes_roles() {
     let history = vec![ConversationTurn {
@@ -197,14 +239,20 @@ fn build_messages_shapes_roles() {
 
 #[test]
 fn streaming_supported_gates_on_provider() {
-    // Bedrock routes through the AWS SDK, never the OpenRouter provider —
-    // false regardless of the (default-on) kill switch.
-    assert!(!streaming_supported(
+    // Fireworks has its own base URL / credential and no streaming adapter.
+    assert!(!streaming_supported("fireworks/llama-v3", false));
+}
+
+/// Issue #3767: Bedrock now has a real `ConverseStream` provider
+/// (`trusty_common::chat::BedrockProvider`) wired through `stream_reply`'s
+/// provider dispatch, so the capability gate must allow it — the opposite of
+/// the pre-#3767 assertion this replaces.
+#[test]
+fn streaming_supported_allows_bedrock() {
+    assert!(streaming_supported(
         "bedrock/anthropic.claude-3-sonnet",
         false
     ));
-    // Fireworks has its own base URL / credential.
-    assert!(!streaming_supported("fireworks/llama-v3", false));
 }
 
 #[test]
@@ -278,6 +326,41 @@ async fn stream_with_provider_returns_assembled_content() {
         .expect("stream should succeed");
     assert_eq!(out.content, "Hello, world");
     assert!(out.error.is_none());
+}
+
+/// Issue #3767: when the provider reports usage, `stream_with_provider` must
+/// surface it on the returned `StreamAssembly` — the caller-facing half of
+/// "usage is not silently dropped on the streaming path".
+#[tokio::test]
+async fn stream_with_provider_surfaces_usage_in_assembly() {
+    let usage = ChatUsage {
+        prompt_tokens: 100,
+        completion_tokens: 20,
+        cache_read_tokens: 5,
+        cache_creation_tokens: 0,
+    };
+    let provider = FakeProvider::ok(vec![
+        ChatEvent::Delta("Hello".into()),
+        ChatEvent::Usage(usage),
+        ChatEvent::Done,
+    ]);
+    let out = stream_with_provider(provider, vec![], "s1", "agent", FAST)
+        .await
+        .expect("stream should succeed");
+    assert_eq!(out.usage, Some(usage));
+    assert_eq!(out.content, "Hello");
+}
+
+/// A provider that never reports usage (OpenRouter today) must leave
+/// `assembly.usage` as `None` — no fabricated zero, and the usage-recording
+/// branch inside `stream_with_provider` must be skipped without erroring.
+#[tokio::test]
+async fn stream_with_provider_usage_absent_when_not_reported() {
+    let provider = FakeProvider::ok(vec![ChatEvent::Delta("Hello".into()), ChatEvent::Done]);
+    let out = stream_with_provider(provider, vec![], "s1", "agent", FAST)
+        .await
+        .expect("stream should succeed");
+    assert!(out.usage.is_none());
 }
 
 #[test]

--- a/crates/trusty-analyze/src/core/explain.rs
+++ b/crates/trusty-analyze/src/core/explain.rs
@@ -139,6 +139,9 @@ pub async fn explain_report(
                 ChatEvent::ToolCall(_) => {
                     // Tools aren't used for explain; ignore spurious calls.
                 }
+                // #3767: no usage-accounting consumer wired up here yet;
+                // ignore rather than let the match go non-exhaustive.
+                ChatEvent::Usage(_) => {}
                 ChatEvent::Done => break,
                 ChatEvent::Error(msg) => {
                     stream_error = Some(msg);

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`chat::BedrockProvider` now streams via `ConverseStream` instead of
+  buffering a full `Converse` reply into a single delta (issue #3767).**
+  `chat_stream` drives Bedrock's binary event-stream framing: `ContentBlockDelta`
+  text fragments become incremental `ChatEvent::Delta`s, mid-stream failures
+  (throttling, validation, transport errors) emit `ChatEvent::Error` and
+  return `Err` — mirroring the OpenAI-compatible SSE pump's #3757 dual-channel
+  failure contract — and the terminal `Metadata` event's token tally becomes
+  a new `ChatEvent::Usage` (Bedrock reports usage exactly once, never
+  per-delta, so it needed its own event to avoid being silently dropped).
+  `BedrockProvider` also gained `with_sampling` (parity with
+  `OpenRouterProvider::with_sampling`, #3758) so a Bedrock-routed streamed
+  turn honours the same temperature/token-ceiling/stop-sequences as the
+  blocking path.
+- **`chat::ChatEvent::Usage(ChatUsage)`** — a new event variant carrying
+  prompt/completion/cache token counts for providers that report usage
+  out-of-band from text deltas. `ChatUsage` is re-exported from the crate
+  root alongside `ChatEvent`.
+
 ---
 ## [0.26.2] — 2026-07-26
 

--- a/crates/trusty-common/src/chat/bedrock_impl.rs
+++ b/crates/trusty-common/src/chat/bedrock_impl.rs
@@ -1,30 +1,41 @@
-//! AWS Bedrock `Converse` API provider for the `ChatProvider` trait.
+//! AWS Bedrock `ConverseStream` API provider for the `ChatProvider` trait.
 //!
 //! Why: organizations on AWS often prefer Bedrock (private VPC, IAM-based
 //! auth, no per-request data egress to a third-party SaaS) over OpenRouter
-//! for LLM access. This module wires the AWS SDK's `Converse` endpoint into
-//! the `trusty-common` `ChatProvider` contract so trusty-analyze's deep pass
-//! can use Bedrock models by setting
-//! `TRUSTY_LLM_MODEL=bedrock/<bedrock-model-id>`.
+//! for LLM access. This module wires the AWS SDK's `ConverseStream` endpoint
+//! into the `trusty-common` `ChatProvider` contract so trusty-analyze's deep
+//! pass and trusty-agents' token-streaming chat path (issue #3767) can both
+//! use Bedrock models by setting `TRUSTY_LLM_MODEL=bedrock/<bedrock-model-id>`
+//! / `model=bedrock/<id>` respectively.
 //!
-//! What: [`BedrockProvider`] wraps an `aws-sdk-bedrockruntime` client. It
-//! calls `Converse` (non-streaming) and emits a single `ChatEvent::Delta`
-//! followed by `ChatEvent::Done` — sufficient for the deep-analysis pass,
-//! which only needs the full narrative string. Auth via the standard AWS
-//! credential chain (env vars, `~/.aws/credentials`, IAM roles, SSO).
+//! What: [`BedrockProvider`] wraps an `aws-sdk-bedrockruntime` client.
+//! `chat_stream` calls `ConverseStream` and drives its event-stream framing —
+//! `ContentBlockDelta` text fragments become [`ChatEvent::Delta`], the
+//! terminal `Metadata` event's token tally becomes a single
+//! [`ChatEvent::Usage`] (Bedrock reports usage exactly once, at the end of
+//! the stream — never per-delta, unlike token text), a mid-stream
+//! `SdkError` becomes [`ChatEvent::Error`] followed by `Err` (mirroring the
+//! OpenAI-compatible pump's #3757 failure contract), and a clean stream end
+//! becomes [`ChatEvent::Done`]. Tool use is not supported on this path (the
+//! `tools` argument is silently ignored, matching the pre-#3767 behaviour).
+//! Auth via the standard AWS credential chain (env vars,
+//! `~/.aws/credentials`, IAM roles, SSO).
 //!
 //! Test: `bedrock_provider_reports_metadata` (unit, no network);
 //! `bedrock_provider_new_uses_region` (unit, no network);
-//! `bedrock_live_converse_smoke_test` (`#[ignore]`, requires real AWS creds).
+//! `bedrock_live_converse_stream_smoke_test` (`#[ignore]`, requires real AWS
+//! creds).
 
-use super::{ChatEvent, ChatProvider, ToolDef};
+use super::{ChatEvent, ChatProvider, ChatUsage, SamplingParams, ToolDef};
 use crate::ChatMessage;
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_sdk_bedrockruntime::Client as BedrockClient;
+use aws_sdk_bedrockruntime::types::ConverseStreamOutput as StreamEvent;
 use aws_sdk_bedrockruntime::types::{
-    ContentBlock, ConversationRole, InferenceConfiguration, Message, SystemContentBlock,
+    ContentBlock, ContentBlockDelta, ConversationRole, InferenceConfiguration, Message,
+    SystemContentBlock,
 };
 use tokio::sync::mpsc::Sender;
 
@@ -73,21 +84,30 @@ pub fn resolve_bedrock_region(explicit: Option<&str>) -> String {
     DEFAULT_BEDROCK_REGION.to_string()
 }
 
-/// AWS Bedrock `Converse` API provider implementing [`ChatProvider`].
+/// AWS Bedrock `ConverseStream` API provider implementing [`ChatProvider`].
 ///
-/// Why: provides a Bedrock alternative to the OpenRouter path for trusty-analyze's
-/// deep-analysis pass, supporting AWS-native auth (IAM roles, SSO, env keys)
-/// without requiring an OpenRouter API key.
-/// What: holds a pre-built `BedrockClient` and model id. `chat_stream` calls
-/// `Converse` (non-streaming), then sends a single `ChatEvent::Delta` with the
-/// full response followed by `ChatEvent::Done`. Tool use is not supported for
-/// this text-only deep-analysis path (tools vec is silently ignored).
+/// Why: provides a Bedrock alternative to the OpenRouter path for
+/// trusty-analyze's deep-analysis pass and trusty-agents' token-streaming
+/// chat path (issue #3767), supporting AWS-native auth (IAM roles, SSO, env
+/// keys) without requiring an OpenRouter API key.
+/// What: holds a pre-built `BedrockClient`, model id, and optional
+/// `SamplingParams`. `chat_stream` calls `ConverseStream` and forwards its
+/// event-stream framing as incremental `ChatEvent::Delta`s, a single terminal
+/// `ChatEvent::Usage`, and `ChatEvent::Done`. Tool use is not supported on
+/// this path (the `tools` argument is silently ignored).
 /// Test: `bedrock_provider_reports_metadata` (no network);
-/// `bedrock_live_converse_smoke_test` (`#[ignore]`, requires real AWS creds).
+/// `bedrock_live_converse_stream_smoke_test` (`#[ignore]`, requires real AWS
+/// creds).
 pub struct BedrockProvider {
     client: BedrockClient,
     model: String,
     region: String,
+    /// #3767: sampling knobs forwarded onto the `ConverseStream` request so a
+    /// Bedrock-routed streamed turn matches the blocking path's temperature /
+    /// token ceiling / stop sequences — the same parity #3758 established for
+    /// the OpenRouter streaming path. Default (all-absent) reproduces this
+    /// provider's pre-existing hardcoded `max_tokens(4096)` behaviour.
+    sampling: SamplingParams,
 }
 
 impl BedrockProvider {
@@ -118,6 +138,7 @@ impl BedrockProvider {
             client,
             model: model.into(),
             region: region_str,
+            sampling: SamplingParams::default(),
         })
     }
 
@@ -137,7 +158,20 @@ impl BedrockProvider {
             client,
             model: model.into(),
             region: region.into(),
+            sampling: SamplingParams::default(),
         }
+    }
+
+    /// Attach sampling parameters to every request this provider sends.
+    ///
+    /// Why (#3767): parallel to `OpenRouterProvider::with_sampling` (#3758) —
+    /// callers with a blocking Bedrock path need the streamed turn to honour
+    /// the same temperature / token ceiling / stop sequences.
+    /// What: consuming builder; returns `self` with `sampling` replaced.
+    /// Test: `bedrock_stream_forwards_sampling_params`.
+    pub fn with_sampling(mut self, sampling: SamplingParams) -> Self {
+        self.sampling = sampling;
+        self
     }
 
     /// The configured AWS region.
@@ -156,19 +190,40 @@ impl ChatProvider for BedrockProvider {
         &self.model
     }
 
-    /// Call Bedrock `Converse` (non-streaming) and emit the full text as one
-    /// `ChatEvent::Delta` followed by `ChatEvent::Done`.
+    /// Call Bedrock `ConverseStream` and drive its event-stream framing onto
+    /// `tx` as [`ChatEvent`]s.
     ///
-    /// Why: the deep-analysis pass accumulates the full narrative string, so
-    /// true streaming offers no benefit here. Non-streaming `Converse` is
-    /// simpler to implement correctly and avoids the reconnect complexity of
-    /// `ConverseStream`.
-    /// What: builds a single-turn `Converse` request with a system prompt
-    /// inferred from the first `system`-role message in `messages`, then
-    /// joins all remaining messages as the conversation history. On success,
-    /// emits `Delta(full_text)` + `Done`. Tool definitions are ignored — the
-    /// deep-analysis call never uses tools.
-    /// Test: `bedrock_live_converse_smoke_test` (`#[ignore]`).
+    /// Why (issue #3767): the token-streaming chat path needs real
+    /// incremental deltas — the previous non-streaming `Converse` call
+    /// buffered the entire reply before emitting a single `Delta`, which is
+    /// indistinguishable from the blocking path and defeats the point of
+    /// streaming. `ConverseStream`'s wire format differs structurally from
+    /// the OpenAI-compatible SSE the other providers speak: it is a binary
+    /// AWS event-stream (framed and demultiplexed by the SDK's
+    /// `EventReceiver`, not raw `data:` lines), and usage/token accounting
+    /// arrives exactly once, in a terminal `Metadata` event — never
+    /// per-delta. Both are handled below so usage is never silently dropped.
+    /// What: builds a single-turn `ConverseStream` request (system prompt
+    /// from the first `system`-role message, the rest as conversation
+    /// history, `self.sampling` forwarded as `InferenceConfiguration`),
+    /// then loops `EventReceiver::recv()`: `ContentBlockDelta::Text` becomes
+    /// `ChatEvent::Delta`; the `Metadata` event's `usage` becomes exactly one
+    /// `ChatEvent::Usage`; every other event variant (`MessageStart`,
+    /// `ContentBlockStart/Stop`, `MessageStop`, and any future `Unknown`
+    /// variant) is a structural marker with nothing to forward and is
+    /// ignored. A clean `Ok(None)` end-of-stream emits `ChatEvent::Done`. A
+    /// mid-stream `Err(SdkError)` (a modeled exception — throttling,
+    /// validation, an internal/service error — or a transport failure)
+    /// emits `ChatEvent::Error` AND returns `Err`, mirroring the
+    /// OpenAI-compatible pump's #3757 dual-channel failure contract so
+    /// neither a channel-only consumer nor a task-joining caller can mistake
+    /// a failed stream for a complete one. Tool definitions are ignored —
+    /// this path has never supported tool use (matches pre-#3767 behaviour).
+    /// Test: `bedrock_stream_forwards_text_deltas_in_order`,
+    /// `bedrock_stream_reports_usage_from_metadata_event`,
+    /// `bedrock_stream_surfaces_mid_stream_error`,
+    /// `bedrock_stream_forwards_sampling_params`,
+    /// `bedrock_live_converse_stream_smoke_test` (`#[ignore]`).
     async fn chat_stream(
         &self,
         messages: Vec<ChatMessage>,
@@ -204,11 +259,19 @@ impl ChatProvider for BedrockProvider {
             ));
         }
 
-        let inference = InferenceConfiguration::builder().max_tokens(4096).build();
+        // #3767/#3758 parity: forward the caller's sampling knobs instead of
+        // the previous hardcoded `max_tokens(4096)` — `unwrap_or(4096)` keeps
+        // that exact default when the caller supplies nothing.
+        let stop_sequences = (!self.sampling.stop.is_empty()).then(|| self.sampling.stop.clone());
+        let inference = InferenceConfiguration::builder()
+            .max_tokens(self.sampling.max_tokens.unwrap_or(4096) as i32)
+            .set_temperature(self.sampling.temperature)
+            .set_stop_sequences(stop_sequences)
+            .build();
 
         let mut req = self
             .client
-            .converse()
+            .converse_stream()
             .model_id(&self.model)
             .inference_config(inference)
             .set_messages(Some(converse_messages));
@@ -217,48 +280,117 @@ impl ChatProvider for BedrockProvider {
             req = req.set_system(Some(system_blocks));
         }
 
-        let resp = req.send().await.with_context(|| {
+        let output = req.send().await.with_context(|| {
             format!(
-                "AWS Bedrock Converse request failed (model={}, region={}). \
-                     Ensure AWS credentials are configured for Bedrock deep analysis \
+                "AWS Bedrock ConverseStream request failed (model={}, region={}). \
+                     Ensure AWS credentials are configured for Bedrock \
                      (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY / AWS_PROFILE / IAM role).",
                 self.model, self.region
             )
         })?;
 
-        // Extract text blocks from the Converse response output.
-        let text = extract_converse_text(&resp);
-        let text = text.unwrap_or_default();
-
-        if tx.send(ChatEvent::Delta(text)).await.is_err() {
-            return Ok(());
+        let mut stream = output.stream;
+        loop {
+            let recv_result = stream
+                .recv()
+                .await
+                .map_err(|sdk_err| format!("Bedrock ConverseStream error: {sdk_err}"));
+            match handle_stream_event(recv_result, &tx).await {
+                Flow::Continue => {}
+                Flow::Stop => return Ok(()),
+                // The Error event is already sent; the Err is the second
+                // half of the #3757-style dual-channel failure contract.
+                Flow::Failed(message) => return Err(anyhow!("{message}")),
+            }
         }
-        let _ = tx.send(ChatEvent::Done).await;
-        Ok(())
     }
 }
 
-/// Extract joined text from a `ConverseOutput` response.
+/// What the event loop should do after one decoded (or failed) `recv()`.
 ///
-/// Why: the Converse API wraps all content in typed `ContentBlock` variants;
-/// we only need the `Text` blocks for the deep-analysis pass.
-/// What: iterates the output message's content blocks and joins `Text` blocks
-/// with newlines.
-/// Test: covered indirectly via `bedrock_live_converse_smoke_test`.
-fn extract_converse_text(
-    resp: &aws_sdk_bedrockruntime::operation::converse::ConverseOutput,
-) -> Option<String> {
-    let msg = resp.output()?.as_message().ok()?;
-    let mut out = String::new();
-    for block in msg.content() {
-        if let ContentBlock::Text(t) = block {
-            if !out.is_empty() {
-                out.push('\n');
+/// Why: mirrors `openai_compat::sse_pump::Flow` so the two streaming
+/// providers in this crate share one failure-signalling shape — `Continue`
+/// keeps reading, `Stop` means a normal terminal was already sent, `Failed`
+/// means [`ChatEvent::Error`] was already sent and the caller MUST return
+/// `Err`.
+/// What: three variants, identical contract to the SSE pump's `Flow`.
+/// Test: exercised indirectly via `handle_stream_event`'s own tests.
+#[derive(Debug, PartialEq, Eq)]
+enum Flow {
+    Continue,
+    Stop,
+    Failed(String),
+}
+
+/// Map one `ConverseStream` `recv()` result onto `tx` as zero or one
+/// [`ChatEvent`]s, returning what the caller's loop should do next.
+///
+/// Why (issue #3767): this is the actual event → `ChatEvent` translation —
+/// the part of the fix with real branching logic — split out from
+/// `chat_stream`'s AWS-SDK plumbing so it is unit-testable with a scripted
+/// sequence of events instead of a live Bedrock connection or hand-encoded
+/// event-stream wire bytes (the SDK's `EventReceiver` has no public
+/// constructor outside a real HTTP response, but every event TYPE it yields
+/// has a public builder, so tests construct those directly).
+/// What: `Ok(Some(ContentBlockDelta(text)))` sends `ChatEvent::Delta` and
+/// returns `Continue`; `Ok(Some(Metadata(meta)))` sends `ChatEvent::Usage`
+/// when `meta.usage()` is present (Bedrock reports usage exactly once, here,
+/// never per-delta — dropping it would silently zero out every Bedrock
+/// streamed call for any usage/cost consumer) and returns `Continue`; every
+/// other event variant (`MessageStart`/`ContentBlockStart`/`ContentBlockStop`/
+/// `MessageStop`, and any SDK `Unknown` future variant) is a structural
+/// marker with nothing to forward and returns `Continue`; `Ok(None)` sends
+/// `ChatEvent::Done` and returns `Stop`; `Err(message)` sends
+/// `ChatEvent::Error(message)` and returns `Failed(message)`. A receiver
+/// that has hung up (`tx.send` failing) short-circuits to `Stop` — mirrors
+/// the SSE pump's "consumer walked away" handling.
+/// Test: `bedrock_stream_forwards_text_deltas_in_order`,
+/// `bedrock_stream_ignores_structural_events`,
+/// `bedrock_stream_reports_usage_from_metadata_event`,
+/// `bedrock_stream_metadata_without_usage_emits_nothing`,
+/// `bedrock_stream_surfaces_mid_stream_error`,
+/// `bedrock_stream_done_emits_terminal_marker`.
+async fn handle_stream_event(
+    result: std::result::Result<Option<StreamEvent>, String>,
+    tx: &Sender<ChatEvent>,
+) -> Flow {
+    match result {
+        Ok(Some(StreamEvent::ContentBlockDelta(ev))) => {
+            if let Some(ContentBlockDelta::Text(text)) = ev.delta()
+                && tx.send(ChatEvent::Delta(text.clone())).await.is_err()
+            {
+                return Flow::Stop;
             }
-            out.push_str(t);
+            Flow::Continue
+        }
+        Ok(Some(StreamEvent::Metadata(meta))) => {
+            if let Some(usage) = meta.usage() {
+                let chat_usage = ChatUsage {
+                    prompt_tokens: usage.input_tokens().max(0) as u32,
+                    completion_tokens: usage.output_tokens().max(0) as u32,
+                    cache_read_tokens: usage.cache_read_input_tokens().unwrap_or(0).max(0) as u32,
+                    cache_creation_tokens: usage.cache_write_input_tokens().unwrap_or(0).max(0)
+                        as u32,
+                };
+                if tx.send(ChatEvent::Usage(chat_usage)).await.is_err() {
+                    return Flow::Stop;
+                }
+            }
+            Flow::Continue
+        }
+        // MessageStart/ContentBlockStart/ContentBlockStop/MessageStop are
+        // structural markers (and any SDK-`Unknown` future variant) — nothing
+        // to forward.
+        Ok(Some(_)) => Flow::Continue,
+        Ok(None) => {
+            let _ = tx.send(ChatEvent::Done).await;
+            Flow::Stop
+        }
+        Err(message) => {
+            let _ = tx.send(ChatEvent::Error(message.clone())).await;
+            Flow::Failed(message)
         }
     }
-    if out.is_empty() { None } else { Some(out) }
 }
 
 #[cfg(test)]
@@ -358,20 +490,28 @@ mod tests {
     }
 
     /// Live smoke test: verifies `BedrockProvider` can round-trip a real
-    /// `Converse` call to Bedrock. Requires real AWS credentials with
+    /// `ConverseStream` call to Bedrock. Requires real AWS credentials with
     /// `bedrock:InvokeModel` permission on the target model.
     ///
     /// Run with:
-    ///   cargo test -p trusty-common --features bedrock -- bedrock_live_converse_smoke_test --ignored
+    ///   cargo test -p trusty-common --features bedrock -- bedrock_live_converse_stream_smoke_test --ignored
     ///
-    /// Why: validates the full end-to-end path including credential resolution,
-    /// wire serialization, and response parsing.
+    /// Why (issue #3767): validates the full end-to-end streaming path
+    /// including credential resolution, event-stream wire decoding, and
+    /// usage extraction — none of which the scripted `handle_stream_event`
+    /// unit tests below can exercise, since they inject already-decoded
+    /// events rather than driving a live AWS connection. This machine has no
+    /// usable AWS credentials configured (`AWS_PROFILE`/`AWS_REGION` are
+    /// set-but-empty), so this test could not be run live as part of this
+    /// change — it remains `#[ignore]`d for an operator with real Bedrock
+    /// access to run manually.
     /// What: sends a one-sentence user message and asserts the response is
-    /// non-empty.
+    /// non-empty, `Done` was observed, and — the #3767-specific assertion —
+    /// usage was reported at least once with non-zero tokens.
     /// Test: `#[ignore]` — requires live AWS credentials.
     #[tokio::test]
     #[ignore = "requires real AWS credentials with bedrock:InvokeModel permission"]
-    async fn bedrock_live_converse_smoke_test() {
+    async fn bedrock_live_converse_stream_smoke_test() {
         let provider = BedrockProvider::new(DEFAULT_BEDROCK_MODEL, None)
             .await
             .expect("BedrockProvider::new failed");
@@ -402,12 +542,14 @@ mod tests {
 
         let mut text = String::new();
         let mut saw_done = false;
+        let mut usage: Option<ChatUsage> = None;
         while let Some(ev) = rx.recv().await {
             match ev {
                 ChatEvent::Delta(s) => text.push_str(&s),
                 ChatEvent::Done => saw_done = true,
                 ChatEvent::Error(e) => panic!("stream error: {e}"),
                 ChatEvent::ToolCall(_) => {}
+                ChatEvent::Usage(u) => usage = Some(u),
             }
         }
         handle
@@ -416,6 +558,241 @@ mod tests {
             .expect("chat_stream failed");
         assert!(!text.is_empty(), "expected non-empty response");
         assert!(saw_done, "expected ChatEvent::Done");
-        eprintln!("bedrock_live_converse_smoke_test response: {text:?}");
+        let usage = usage.expect("expected a ChatEvent::Usage before Done (#3767)");
+        assert!(
+            usage.prompt_tokens > 0 || usage.completion_tokens > 0,
+            "expected non-zero usage: {usage:?}"
+        );
+        eprintln!("bedrock_live_converse_stream_smoke_test response: {text:?} usage={usage:?}");
+    }
+
+    // ── #3767: `handle_stream_event` mapping tests ─────────────────────────
+    //
+    // Why: `EventReceiver` (the AWS SDK's decoded-event source) has no public
+    // constructor outside a real HTTP response — its home module is private
+    // (`aws_sdk_bedrockruntime::event_receiver`) — so these tests drive
+    // `handle_stream_event` directly with hand-built `StreamEvent`s (every
+    // event TYPE's builder IS public) instead of a live connection or
+    // hand-encoded event-stream wire bytes.
+
+    /// A normal streamed completion: two text deltas followed by a clean
+    /// end-of-stream must assemble into `Delta("He")`, `Delta("llo")`, `Done`
+    /// — in order, nothing dropped or reordered.
+    #[tokio::test]
+    async fn bedrock_stream_forwards_text_deltas_in_order() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChatEvent>(8);
+
+        let flow1 = handle_stream_event(Ok(Some(content_delta("He"))), &tx).await;
+        assert_eq!(flow1, Flow::Continue);
+        let flow2 = handle_stream_event(Ok(Some(content_delta("llo"))), &tx).await;
+        assert_eq!(flow2, Flow::Continue);
+        let flow3 = handle_stream_event(Ok(None), &tx).await;
+        assert_eq!(flow3, Flow::Stop);
+        drop(tx);
+
+        let mut collected = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            collected.push(ev);
+        }
+        assert!(matches!(&collected[0], ChatEvent::Delta(d) if d == "He"));
+        assert!(matches!(&collected[1], ChatEvent::Delta(d) if d == "llo"));
+        assert!(matches!(collected[2], ChatEvent::Done));
+        assert_eq!(collected.len(), 3, "no extra events: {collected:?}");
+    }
+
+    /// Structural events with no text payload (`MessageStart`,
+    /// `ContentBlockStart`, `ContentBlockStop`, `MessageStop`) must not
+    /// forward anything — only `ContentBlockDelta`/`Metadata`/terminal events
+    /// produce a `ChatEvent`.
+    #[tokio::test]
+    async fn bedrock_stream_ignores_structural_events() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChatEvent>(8);
+
+        let flow = handle_stream_event(
+            Ok(Some(StreamEvent::MessageStart(
+                aws_sdk_bedrockruntime::types::MessageStartEvent::builder()
+                    .role(ConversationRole::Assistant)
+                    .build()
+                    .unwrap(),
+            ))),
+            &tx,
+        )
+        .await;
+        assert_eq!(flow, Flow::Continue);
+
+        let flow = handle_stream_event(
+            Ok(Some(StreamEvent::MessageStop(
+                aws_sdk_bedrockruntime::types::MessageStopEvent::builder()
+                    .stop_reason(aws_sdk_bedrockruntime::types::StopReason::EndTurn)
+                    .build()
+                    .unwrap(),
+            ))),
+            &tx,
+        )
+        .await;
+        assert_eq!(flow, Flow::Continue);
+
+        drop(tx);
+        assert!(
+            rx.recv().await.is_none(),
+            "structural events must not emit any ChatEvent"
+        );
+    }
+
+    /// The terminal `Metadata` event's `usage` must survive as exactly one
+    /// `ChatEvent::Usage` carrying the token counts — the core #3767
+    /// assertion (Bedrock reports usage only here, never per-delta).
+    #[tokio::test]
+    async fn bedrock_stream_reports_usage_from_metadata_event() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChatEvent>(8);
+
+        let flow = handle_stream_event(Ok(Some(metadata_with_usage(120, 45, 30, 10))), &tx).await;
+        assert_eq!(flow, Flow::Continue);
+        drop(tx);
+
+        let events: Vec<_> = {
+            let mut out = Vec::new();
+            while let Some(ev) = rx.recv().await {
+                out.push(ev);
+            }
+            out
+        };
+        assert_eq!(events.len(), 1, "expected exactly one event: {events:?}");
+        match &events[0] {
+            ChatEvent::Usage(u) => {
+                assert_eq!(u.prompt_tokens, 120);
+                assert_eq!(u.completion_tokens, 45);
+                assert_eq!(u.cache_read_tokens, 30);
+                assert_eq!(u.cache_creation_tokens, 10);
+            }
+            other => panic!("expected ChatEvent::Usage, got {other:?}"),
+        }
+    }
+
+    /// A `Metadata` event with no `usage` field (Bedrock omits it on some
+    /// error/guardrail paths) must not fabricate a zeroed `ChatEvent::Usage`
+    /// — nothing should be sent at all.
+    #[tokio::test]
+    async fn bedrock_stream_metadata_without_usage_emits_nothing() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChatEvent>(8);
+        let meta = aws_sdk_bedrockruntime::types::ConverseStreamMetadataEvent::builder().build();
+        let flow = handle_stream_event(Ok(Some(StreamEvent::Metadata(meta))), &tx).await;
+        assert_eq!(flow, Flow::Continue);
+        drop(tx);
+        assert!(rx.recv().await.is_none(), "no usage means no ChatEvent");
+    }
+
+    /// A mid-stream failure (a modeled exception surfaced as `Err`, e.g.
+    /// throttling or a transport error) must emit `ChatEvent::Error` AND
+    /// return `Flow::Failed` so the caller returns `Err` — never silently
+    /// truncate to what text arrived so far.
+    #[tokio::test]
+    async fn bedrock_stream_surfaces_mid_stream_error() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChatEvent>(8);
+
+        let flow1 = handle_stream_event(Ok(Some(content_delta("partial "))), &tx).await;
+        assert_eq!(flow1, Flow::Continue);
+        let flow2 = handle_stream_event(
+            Err("Bedrock ConverseStream error: throttled".to_string()),
+            &tx,
+        )
+        .await;
+        assert_eq!(
+            flow2,
+            Flow::Failed("Bedrock ConverseStream error: throttled".to_string())
+        );
+        drop(tx);
+
+        let mut collected = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            collected.push(ev);
+        }
+        assert!(matches!(&collected[0], ChatEvent::Delta(d) if d == "partial "));
+        match &collected[1] {
+            ChatEvent::Error(msg) => assert!(msg.contains("throttled")),
+            other => panic!("expected ChatEvent::Error, got {other:?}"),
+        }
+        assert_eq!(
+            collected.len(),
+            2,
+            "a mid-stream error must not also emit Done: {collected:?}"
+        );
+    }
+
+    /// A clean `Ok(None)` end-of-stream (no error, no more events) must emit
+    /// exactly one terminal `ChatEvent::Done` and `Flow::Stop`.
+    #[tokio::test]
+    async fn bedrock_stream_done_emits_terminal_marker() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<ChatEvent>(8);
+        let flow = handle_stream_event(Ok(None), &tx).await;
+        assert_eq!(flow, Flow::Stop);
+        drop(tx);
+        let mut collected = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            collected.push(ev);
+        }
+        assert_eq!(collected.len(), 1);
+        assert!(matches!(collected[0], ChatEvent::Done));
+    }
+
+    /// `with_sampling` must forward temperature/max_tokens/stop onto the
+    /// `InferenceConfiguration` the request builds — parity with #3758's
+    /// OpenRouter fix. This is a construction-only check (no network): it
+    /// verifies the provider stores what it's given rather than silently
+    /// discarding it, mirroring `sampling_params_serialize_into_request_body`
+    /// in the `openai_compat` module.
+    #[test]
+    fn bedrock_stream_forwards_sampling_params() {
+        let sampling = SamplingParams {
+            temperature: Some(0.2),
+            max_tokens: Some(512),
+            stop: vec!["STOP".to_string()],
+        };
+        // `BedrockProvider` has no live-network-free way to introspect the
+        // built request, so this pins the builder contract directly: the
+        // same `InferenceConfiguration` construction `chat_stream` performs
+        // must not panic and must carry the caller's values through
+        // (exercised end-to-end by the live smoke test above).
+        let inference = InferenceConfiguration::builder()
+            .max_tokens(sampling.max_tokens.unwrap_or(4096) as i32)
+            .set_temperature(sampling.temperature)
+            .set_stop_sequences((!sampling.stop.is_empty()).then(|| sampling.stop.clone()))
+            .build();
+        assert_eq!(inference.max_tokens(), Some(512));
+        assert_eq!(inference.temperature(), Some(0.2));
+        assert_eq!(inference.stop_sequences(), &["STOP".to_string()][..]);
+    }
+
+    /// Helper: a `ContentBlockDelta::Text` event carrying `text`.
+    fn content_delta(text: &str) -> StreamEvent {
+        StreamEvent::ContentBlockDelta(
+            aws_sdk_bedrockruntime::types::ContentBlockDeltaEvent::builder()
+                .delta(ContentBlockDelta::Text(text.to_string()))
+                .content_block_index(0)
+                .build()
+                .expect("build ContentBlockDeltaEvent"),
+        )
+    }
+
+    /// Helper: a `Metadata` event carrying a fully-populated `TokenUsage`.
+    fn metadata_with_usage(
+        input_tokens: i32,
+        output_tokens: i32,
+        cache_read: i32,
+        cache_write: i32,
+    ) -> StreamEvent {
+        let usage = aws_sdk_bedrockruntime::types::TokenUsage::builder()
+            .input_tokens(input_tokens)
+            .output_tokens(output_tokens)
+            .total_tokens(input_tokens + output_tokens)
+            .cache_read_input_tokens(cache_read)
+            .cache_write_input_tokens(cache_write)
+            .build()
+            .expect("build TokenUsage");
+        StreamEvent::Metadata(
+            aws_sdk_bedrockruntime::types::ConverseStreamMetadataEvent::builder()
+                .usage(usage)
+                .build(),
+        )
     }
 }

--- a/crates/trusty-common/src/chat/bedrock_impl.rs
+++ b/crates/trusty-common/src/chat/bedrock_impl.rs
@@ -260,14 +260,8 @@ impl ChatProvider for BedrockProvider {
         }
 
         // #3767/#3758 parity: forward the caller's sampling knobs instead of
-        // the previous hardcoded `max_tokens(4096)` — `unwrap_or(4096)` keeps
-        // that exact default when the caller supplies nothing.
-        let stop_sequences = (!self.sampling.stop.is_empty()).then(|| self.sampling.stop.clone());
-        let inference = InferenceConfiguration::builder()
-            .max_tokens(self.sampling.max_tokens.unwrap_or(4096) as i32)
-            .set_temperature(self.sampling.temperature)
-            .set_stop_sequences(stop_sequences)
-            .build();
+        // the previous hardcoded `max_tokens(4096)`.
+        let inference = build_inference_config(&self.sampling);
 
         let mut req = self
             .client
@@ -304,6 +298,34 @@ impl ChatProvider for BedrockProvider {
             }
         }
     }
+}
+
+/// Build the `ConverseStream` request's `InferenceConfiguration` from the
+/// caller's sampling knobs.
+///
+/// Why (#3767/#3758 parity, code-critic MEDIUM on PR #4112): pulled out of
+/// `chat_stream` so the sampling-forwarding contract has a unit test that
+/// calls the SAME code the live request builds, rather than a test asserting
+/// against its own copy-pasted expression — the latter would keep passing
+/// even if `chat_stream` regressed (e.g. reverted to the pre-#3767 hardcoded
+/// `max_tokens(4096)`, or dropped `.set_temperature()`), since nothing would
+/// call the changed line. This is also the only CI-run coverage of #3758
+/// parity on this path — the live smoke test is `#[ignore]`d.
+/// What: `max_tokens` defaults to `4096` when the caller supplies nothing
+/// (preserves the exact pre-#3767 hardcoded behaviour); `temperature` and
+/// `stop` are forwarded via `set_*` so an absent value omits the field
+/// (matches `SamplingParams::stop_slice`'s empty-means-omitted convention —
+/// an empty `stop` array is never sent, since some servers reject `"stop":
+/// []`).
+/// Test: `bedrock_stream_forwards_sampling_params`,
+/// `bedrock_stream_sampling_defaults_when_unset`.
+fn build_inference_config(sampling: &SamplingParams) -> InferenceConfiguration {
+    let stop_sequences = (!sampling.stop.is_empty()).then(|| sampling.stop.clone());
+    InferenceConfiguration::builder()
+        .max_tokens(sampling.max_tokens.unwrap_or(4096) as i32)
+        .set_temperature(sampling.temperature)
+        .set_stop_sequences(stop_sequences)
+        .build()
 }
 
 /// What the event loop should do after one decoded (or failed) `recv()`.
@@ -735,12 +757,20 @@ mod tests {
         assert!(matches!(collected[0], ChatEvent::Done));
     }
 
-    /// `with_sampling` must forward temperature/max_tokens/stop onto the
-    /// `InferenceConfiguration` the request builds — parity with #3758's
-    /// OpenRouter fix. This is a construction-only check (no network): it
-    /// verifies the provider stores what it's given rather than silently
-    /// discarding it, mirroring `sampling_params_serialize_into_request_body`
-    /// in the `openai_compat` module.
+    /// `build_inference_config` — the exact function `chat_stream` calls —
+    /// must forward temperature/max_tokens/stop onto the
+    /// `InferenceConfiguration` it builds, parity with #3758's OpenRouter
+    /// fix.
+    ///
+    /// Why (code-critic MEDIUM on PR #4112): the prior version of this test
+    /// duplicated the `InferenceConfiguration::builder()...` expression
+    /// instead of calling production code, so it would keep passing even if
+    /// `chat_stream` regressed (e.g. reverted to the hardcoded
+    /// `max_tokens(4096)`, or dropped `.set_temperature()`) — this is the
+    /// only CI-run coverage of #3758 parity on this path, since the live
+    /// smoke test is `#[ignore]`d. Calling `build_inference_config` directly
+    /// closes that gap: a regression in the real function now fails this
+    /// test.
     #[test]
     fn bedrock_stream_forwards_sampling_params() {
         let sampling = SamplingParams {
@@ -748,19 +778,22 @@ mod tests {
             max_tokens: Some(512),
             stop: vec!["STOP".to_string()],
         };
-        // `BedrockProvider` has no live-network-free way to introspect the
-        // built request, so this pins the builder contract directly: the
-        // same `InferenceConfiguration` construction `chat_stream` performs
-        // must not panic and must carry the caller's values through
-        // (exercised end-to-end by the live smoke test above).
-        let inference = InferenceConfiguration::builder()
-            .max_tokens(sampling.max_tokens.unwrap_or(4096) as i32)
-            .set_temperature(sampling.temperature)
-            .set_stop_sequences((!sampling.stop.is_empty()).then(|| sampling.stop.clone()))
-            .build();
+        let inference = build_inference_config(&sampling);
         assert_eq!(inference.max_tokens(), Some(512));
         assert_eq!(inference.temperature(), Some(0.2));
         assert_eq!(inference.stop_sequences(), &["STOP".to_string()][..]);
+    }
+
+    /// With no sampling knobs supplied, `build_inference_config` must
+    /// reproduce the exact pre-#3767 hardcoded behaviour: `max_tokens(4096)`,
+    /// no temperature, no stop sequences (an empty `stop` array is never
+    /// sent — some servers reject `"stop": []`).
+    #[test]
+    fn bedrock_stream_sampling_defaults_when_unset() {
+        let inference = build_inference_config(&SamplingParams::default());
+        assert_eq!(inference.max_tokens(), Some(4096));
+        assert_eq!(inference.temperature(), None);
+        assert!(inference.stop_sequences().is_empty());
     }
 
     /// Helper: a `ContentBlockDelta::Text` event carrying `text`.

--- a/crates/trusty-common/src/chat/mod.rs
+++ b/crates/trusty-common/src/chat/mod.rs
@@ -182,16 +182,28 @@ impl SamplingParams {
 /// `types` module — never depends on a feature-gated type.
 /// What: four token buckets mirroring the shape every provider in this
 /// workspace already reports (prompt/completion split, plus the two
-/// prompt-cache buckets); a provider that has none of the cache fields
-/// simply leaves them zero.
+/// prompt-cache buckets). The four fields are SEPARATE and ADDITIVE — not
+/// nested — matching both the Bedrock `TokenUsage` wire shape
+/// (`input_tokens`/`output_tokens`/`cache_read_input_tokens`/
+/// `cache_write_input_tokens` are independent fields, verified against
+/// `aws-sdk-bedrockruntime` 1.132.0) and this workspace's existing
+/// convention (`crate::perf::TokenUsage`,
+/// `trusty-agents/src/llm/anthropic_native/mod.rs`'s usage parsing, and
+/// `chat::bedrock_impl::parse_usage`'s non-streaming counterpart). A
+/// provider that has none of the cache fields simply leaves them zero.
 /// Test: `bedrock_stream_reports_usage_from_metadata_event` (bedrock_impl).
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub struct ChatUsage {
-    /// Prompt (input) tokens billed, including any cached-read tokens.
+    /// Prompt (input) tokens. Separate from `cache_read_tokens` — a
+    /// cost-accounting consumer that assumes this already includes cache
+    /// reads will double-count; one that assumes it excludes the full
+    /// prompt will undercount. Sum with `cache_read_tokens` for the total
+    /// prompt-side token count when that is what's needed.
     pub prompt_tokens: u32,
     /// Completion (output) tokens produced.
     pub completion_tokens: u32,
-    /// Prompt tokens served from the provider's prompt cache.
+    /// Prompt tokens served from the provider's prompt cache — additive
+    /// with `prompt_tokens`, not a subset of it.
     pub cache_read_tokens: u32,
     /// Prompt tokens newly written into the prompt cache this turn.
     pub cache_creation_tokens: u32,

--- a/crates/trusty-common/src/chat/mod.rs
+++ b/crates/trusty-common/src/chat/mod.rs
@@ -169,13 +169,43 @@ impl SamplingParams {
     }
 }
 
+/// Token-usage tally surfaced at the end of a streamed response.
+///
+/// Why (issue #3767): Bedrock's `ConverseStream` reports usage only once, in
+/// a terminal `metadata` event — unlike the per-token deltas, it has no
+/// natural home in [`ChatEvent::Delta`]. Without a dedicated variant a
+/// streaming provider has no way to hand token counts back to the caller, so
+/// a downstream cost-reporting consumer would silently see zero usage for
+/// every streamed call. Kept as a small standalone struct (rather than
+/// reusing `trusty_common::inference::types::Usage`) so the `chat` module —
+/// which compiles unconditionally, unlike the `inference-client`-gated
+/// `types` module — never depends on a feature-gated type.
+/// What: four token buckets mirroring the shape every provider in this
+/// workspace already reports (prompt/completion split, plus the two
+/// prompt-cache buckets); a provider that has none of the cache fields
+/// simply leaves them zero.
+/// Test: `bedrock_stream_reports_usage_from_metadata_event` (bedrock_impl).
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct ChatUsage {
+    /// Prompt (input) tokens billed, including any cached-read tokens.
+    pub prompt_tokens: u32,
+    /// Completion (output) tokens produced.
+    pub completion_tokens: u32,
+    /// Prompt tokens served from the provider's prompt cache.
+    pub cache_read_tokens: u32,
+    /// Prompt tokens newly written into the prompt cache this turn.
+    pub cache_creation_tokens: u32,
+}
+
 /// Streaming chat event.
 ///
 /// Why: replaces the previous "string-only" channel so callers can
 /// distinguish text deltas from tool invocations and from terminal
 /// success/error without parsing magic markers out of the text stream.
 /// What: `Delta` is a content chunk; `ToolCall` is a fully-accumulated tool
-/// invocation; `Done` signals the upstream stream terminated normally;
+/// invocation; `Usage` carries the call's token tally (emitted zero or one
+/// times, whenever the provider's wire format reports it — see
+/// [`ChatUsage`]); `Done` signals the upstream stream terminated normally;
 /// `Error` carries a human-readable message for stream-mid failures (the
 /// provider also returns `Err` from `chat_stream`, but `Error` lets the
 /// caller display partial-stream failures inline).
@@ -184,6 +214,7 @@ impl SamplingParams {
 pub enum ChatEvent {
     Delta(String),
     ToolCall(ToolCall),
+    Usage(ChatUsage),
     Done,
     Error(String),
 }

--- a/crates/trusty-common/src/chat/openai_compat/mod.rs
+++ b/crates/trusty-common/src/chat/openai_compat/mod.rs
@@ -181,6 +181,7 @@ mod tests {
                 ChatEvent::Delta(s) => deltas.push(s),
                 ChatEvent::Done => saw_done = true,
                 ChatEvent::ToolCall(_) => panic!("unexpected tool call"),
+                ChatEvent::Usage(_) => {}
                 ChatEvent::Error(e) => panic!("stream error: {e}"),
             }
         }
@@ -246,6 +247,7 @@ mod tests {
                 crate::chat::ChatEvent::ToolCall(tc) => tool_calls.push(tc),
                 ChatEvent::Done => saw_done = true,
                 ChatEvent::Delta(_) => {}
+                ChatEvent::Usage(_) => {}
                 ChatEvent::Error(e) => panic!("stream error: {e}"),
             }
         }

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -654,7 +654,7 @@ pub mod tmux;
 // ─── Re-exports preserving the pre-split public API ───────────────────────
 
 pub use chat::{
-    BedrockProvider, ChatEvent, ChatProvider, DEFAULT_BEDROCK_MODEL, LocalModelConfig,
+    BedrockProvider, ChatEvent, ChatProvider, ChatUsage, DEFAULT_BEDROCK_MODEL, LocalModelConfig,
     OllamaProvider, OpenRouterProvider, SamplingParams, ToolCall, ToolDef,
     auto_detect_local_provider,
 };

--- a/crates/trusty-memory/src/chat/handler.rs
+++ b/crates/trusty-memory/src/chat/handler.rs
@@ -323,6 +323,9 @@ pub(crate) async fn chat_handler(
                         tool_calls_this_round.push(tc);
                     }
                     ChatEvent::Done => break,
+                    // #3767: no usage-accounting consumer wired up here yet;
+                    // ignore rather than let the match go non-exhaustive.
+                    ChatEvent::Usage(_) => {}
                     ChatEvent::Error(e) => {
                         stream_err = Some(e);
                         break;

--- a/crates/trusty-mpm/src/activity/monitor.rs
+++ b/crates/trusty-mpm/src/activity/monitor.rs
@@ -496,7 +496,8 @@ impl LlmClassifier for OpenRouterClassifier {
                 match event {
                     ChatEvent::Delta(d) => full_text.push_str(&d),
                     ChatEvent::Error(e) => stream_error = Some(e),
-                    ChatEvent::ToolCall(_) | ChatEvent::Done => {}
+                    // #3767: no usage-accounting consumer wired up here yet.
+                    ChatEvent::ToolCall(_) | ChatEvent::Done | ChatEvent::Usage(_) => {}
                 }
             }
         });

--- a/crates/trusty-search/src/service/ui.rs
+++ b/crates/trusty-search/src/service/ui.rs
@@ -310,6 +310,9 @@ pub async fn chat_handler(
             // No tools wired up for trusty-search yet — model shouldn't call
             // any since `tools` is empty, but if it does we ignore the call.
             ChatEvent::ToolCall(_) => {}
+            // #3767: no usage-accounting consumer wired up here yet; ignore
+            // rather than let the match go non-exhaustive.
+            ChatEvent::Usage(_) => {}
             ChatEvent::Done => {}
             ChatEvent::Error(e) => stream_error = Some(e),
         }


### PR DESCRIPTION
## Summary

- Issue #3767 is real, not stale, as of current `main` (`45447e42`): `streaming_supported()` in `crates/trusty-agents/src/llm/stream.rs` explicitly excluded `Provider::Bedrock`, and `trusty_common::chat::BedrockProvider::chat_stream` called the non-streaming `Converse` API, buffering the entire reply into one `ChatEvent::Delta`. Bedrock requests never went through real token streaming.
- `chat::BedrockProvider::chat_stream` now drives AWS's `ConverseStream` event-stream framing directly: `ContentBlockDelta` text becomes incremental `ChatEvent::Delta`s, the terminal `Metadata` event's token tally becomes a new `ChatEvent::Usage` (Bedrock reports usage exactly once, never per-delta — this event exists so it's never silently dropped), a mid-stream `SdkError` emits `ChatEvent::Error` **and** returns `Err` (mirrors the OpenAI-compatible SSE pump's #3757 dual-channel failure contract), and a clean end emits `ChatEvent::Done`.
- `BedrockProvider` gained `with_sampling` (temperature/max_tokens/stop), matching `OpenRouterProvider::with_sampling` (#3758 parity). The `InferenceConfiguration` construction is factored into `build_inference_config(&SamplingParams)` so the sampling-forwarding contract is unit-tested against the exact function `chat_stream` calls, not a copy of it.
- `trusty-agents`: `streaming_supported()` no longer excludes Bedrock; `stream_reply` now dispatches `bedrock/*` models to a new `stream_reply_bedrock` branch. `StreamAssembly` gained `usage: Option<ChatUsage>` so usage survives to the caller instead of being dropped.
- `trusty-agents`'s `Cargo.toml` now enables the `bedrock` feature on its `trusty-common` dependency — without it, `BedrockProvider` resolves to the always-erroring stub. Zero added dependency weight: `aws-sdk-bedrockruntime`/`aws-config`/`aws-types` are already unconditional direct dependencies of this crate (used by the existing non-streaming `llm::bedrock` client).
- Updated every `ChatEvent` consumer across the workspace (trusty-memory, trusty-search, trusty-analyze, trusty-mpm, trusty-common's own tests) to handle the new `Usage` variant so the exhaustive matches still compile — all are no-op ignores since none of those call sites do usage accounting today.
- Deliberately did **not** wire a usage-accounting file write (`record_dispatch_usage`) into the shared `stream_with_provider` — that would trigger a background-spawned disk write (`.trusty-agents/state/usage.jsonl`) from every streamed call, including from this test suite, which is a surprising side effect this layer shouldn't introduce silently. Usage is fully surfaced on `StreamAssembly.usage` for a caller (or the sibling cost-reporting feature) to consume. **Neither `stream_reply` call site (`history.rs`, `persona.rs`) reads `assembly.usage` yet — that consumption is deliberately out of scope for this PR** and is being tracked separately.

## Code-critic follow-up (addressed in-PR)

code-critic reviewed and returned **APPROVE**, with two fixes landed before merge:
- **MEDIUM**: `bedrock_stream_forwards_sampling_params` tested a copy-pasted `InferenceConfiguration` expression instead of production code, so a regression in `chat_stream`'s sampling forwarding wouldn't have failed it. Fixed by extracting `build_inference_config` and pointing the test at it; added `bedrock_stream_sampling_defaults_when_unset` for the no-sampling-supplied default.
- **LOW**: `ChatUsage::prompt_tokens`'s doc comment incorrectly claimed it already includes cached-read tokens. Corrected — in `aws-sdk-bedrockruntime` 1.132.0 the four `TokenUsage` fields are separate and additive, matching this workspace's existing convention (`perf::TokenUsage`, `anthropic_native/mod.rs`'s usage parsing).

## What I could not verify live

This machine has no usable AWS credentials (`AWS_PROFILE`/`AWS_REGION` are set-but-empty). The live end-to-end path (`bedrock_live_converse_stream_smoke_test`) is `#[ignore]`d and needs an operator with real Bedrock access to run manually:
```
cargo test -p trusty-common --features bedrock -- bedrock_live_converse_stream_smoke_test --ignored
```
Everything else is verified with real unit/integration tests against hand-built AWS SDK event types (the SDK's `EventReceiver` has no public constructor outside a live HTTP response, so the event→`ChatEvent` mapping logic is exercised directly via `handle_stream_event`, which is the actual novel logic this issue adds).

## Test plan

- [x] `cargo test -p trusty-common --features bedrock -- bedrock` — 11 passed, 1 ignored (live smoke test)
- [x] `cargo test -p trusty-agents --lib -- llm::stream` — 19 passed
- [x] `SKIP_UI_BUILD=1 cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` (CI's exact invocation) — full workspace green, 192 test-result blocks, zero failures
- [x] `SKIP_UI_BUILD=1 cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — exit 0
- [x] `cargo fmt --check` — clean

Note: the plain `make check` target's `cargo test --workspace` (no exclusions) fails on `trusty-code-gui` due to a pre-existing, unrelated `frontendDist` build-order issue (the Tauri frontend `ui/dist` isn't built in this environment) — CI's actual `ci.yml` excludes the three Tauri GUI crates and sets `SKIP_UI_BUILD=1`, which is the command used above and is unaffected by this PR's changes.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools