### PR TITLE
fix(trusty-mpm): refuse to reclaim a worktree holding unsaved work (#4091)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,67 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **Agent delegations are now tracked automatically, with a real lifecycle**
+  ([#2864](https://github.com/bobmatnyc/trusty-tools/issues/2864), slices
+  S1+S2): the daemon observes every native subagent dispatch from the
+  `PreToolUse` hook it already receives on every managed session, so tracking no
+  longer depends on the PM voluntarily calling `agent_delegate`. Delegations move
+  `Running` → `Completed`/`Failed` instead of sitting in `Queued` forever, and a
+  `Delegation` now carries `source`, `tool_use_id`, `agent_id`,
+  `transcript_path`, `cwd`, `started_at`, and `ended_at`. A dispatch that both
+  declares (`agent_delegate`) and executes the *same* task produces one record,
+  not two.
+- **`tm hook` forwards Claude Code's subagent correlation keys** (#2864):
+  `tool_use_id` and `transcript_path` on tool events, and `agent_id` /
+  `agent_type` / `agent_transcript_path` on `SubagentStop`. A `tool_response` is
+  relayed only for a subagent-dispatch tool and only as a fixed five-key
+  projection, so an ordinary tool's output is never forwarded. All fields are
+  additive.
+- **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
+  `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**
+  (worktree-hygiene follow-up to
+  [#3955](https://github.com/bobmatnyc/trusty-tools/issues/3955)): worktrees
+  provisioned there silently fail unrelated tests (trusty-search's
+  `SENSITIVE_PATH_PREFIXES` denylist) and can be reaped mid-task by the OS or
+  harness. The check is called directly from `pm_guard()` BEFORE Guard 4's
+  native-subagent-dispatch exemption, and is unconditional — including for
+  Task/Agent-dispatched subagents, which is who actually provisions these
+  worktrees in practice. `pm_guard_bash::evaluate_worktree_add_command`
+  resolves the target (relative paths, `cd`/`git -C` tracking, `~`/`$TMPDIR`/
+  `$TMP` expansion, lexical `.`/`..` normalization) without touching the
+  filesystem; only the exact `worktree add` subcommand is affected —
+  `list`/`remove`/`prune`/`lock`/… and ordinary temp usage (`mktemp`, temp
+  files, cargo build artifacts) are untouched.
+
+  **Round 2 (code-critic BLOCK, PR #3978):** the guard also pierces Guard 1
+  (`CLAUDE_MPM_SUB_AGENT`) — the automatic marker trusty-agents' own
+  subprocess/runner spawn helpers stamp on every nested subagent process
+  (`crates/trusty-agents/src/subprocess/spawn.rs:189-192`,
+  `crates/trusty-agents/src/agents/claude_code_runner/run.rs:211-215`), which
+  is who actually provisions most of these worktrees. Before this round,
+  Guard 1 short-circuited to ALLOW before the stdin payload was even read, so
+  a `CLAUDE_MPM_SUB_AGENT=1`-tagged `git worktree add /tmp/...` call was
+  silently allowed. Guards 2/3 (`TRUSTY_MPM_DISABLE_HOOKS` /
+  `TRUSTY_MPM_PM_UNRESTRICTED`) are deliberately left UN-pierced — neither is
+  ever set programmatically anywhere in this codebase's Rust source, so
+  whoever sets them still gets exactly that, including for this guard.
+  **Round 3 correction:** that is narrower than "operator-only" — Claude
+  Code's `settings.json` `env` object can set either var for every hook
+  invocation (live-reloaded mid-session), and a write to
+  `.claude/settings.json` is not itself blocked by `pm_guard` today, so the
+  PM or an exempt subagent can self-exempt from this entire guard via that
+  pre-existing, unrelated gap. Not introduced or widened by this change; not
+  fixed here; tracked as
+  [#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981).
+
+### Changed
+
+- **Orphan-sweep candidates are processed in sorted order** rather than
+  filesystem order, so a `--dry-run` preview predicts the real run and any
+  ordering-dependent behaviour is reproducible.
+
 ### Fixed
 
 - **The worktree reclaim path no longer force-deletes uncommitted work**
@@ -73,6 +134,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     once up front left the whole sweep's duration between "certified clean" and
     "deleted".
 
+- **A nested self-contained clone is no longer assessed with the wrong loss
+  model** ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091),
+  review round 3): the nested-repository scan found unregistered clones in
+  gitignored subtrees and then asked them the *candidate's* questions — `HEAD`
+  and `session/<leaf>` — which are the right questions only when the object
+  store lives outside the candidate and survives it. A self-contained clone
+  keeps its entire `.git` INSIDE the candidate, so every local branch, tag,
+  stash entry and reflog dies with it. A clone whose `HEAD` sat on a pushed
+  `main` while a `feature` branch held the only copy of a commit answered clean
+  on all three questions and was destroyed. The two shapes are now separated by
+  `git rev-parse --path-format=absolute --git-common-dir` — a direct test of
+  *does this repository's object store live inside the directory we are about
+  to delete* — and a self-contained clone is measured with
+  `rev-list --count --all --not --remotes` plus a `refs/stash` check. Registered
+  nested worktrees keep the shared-store model, so a clean agent worktree still
+  does not pin its parent. A clone with no remotes at all counts every commit,
+  which is the correct answer for a scratch clone nobody pushed.
+
+- **`.trusty-mpm/`'s existence probe no longer fails toward CLEAN**
+  ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091), review round
+  3): it used `Path::exists()`, which collapses every I/O error to `false`,
+  while the first status pass had already skipped every `.trusty-mpm/`-scoped
+  entry on the promise that the second pass owned them — so a permission error
+  became CLEAN, inverting the module's own fail-safe invariant.
+
+- **The unpushed-commit check now covers the bare branch spelling too**
+  ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091), review round
+  3): `core::worktree_naming::worktree_branch_for` says `session/<leaf>`, but
+  `provisioner/workspace.rs` names the branch for the
+  `.base/.worktrees/<session-id>` shape **bare** — the dominant population of a
+  sweep — so the check was inert exactly where most worktrees live. Both
+  spellings are now counted, in one `rev-list` so a shared commit is not counted
+  twice.
+
 - **The age-based ephemeral auto-reaper now honours the dirty-tree guard**
   ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091), review
   round): `reap_aged_ephemeral` reaches the same
@@ -80,69 +175,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   orphan sweep but never passed through the guard, and it fires automatically
   on every daemon GC tick. An aged ephemeral whose workspace holds unsaved work
   is now left in place for an operator. There is deliberately no discard opt-in
-  on this path.
-
-### Changed
-
-- **Orphan-sweep candidates are processed in sorted order** rather than
-  filesystem order, so a `--dry-run` preview predicts the real run and any
-  ordering-dependent behaviour is reproducible.
-
-### Added
-- **Agent delegations are now tracked automatically, with a real lifecycle**
-  ([#2864](https://github.com/bobmatnyc/trusty-tools/issues/2864), slices
-  S1+S2): the daemon observes every native subagent dispatch from the
-  `PreToolUse` hook it already receives on every managed session, so tracking no
-  longer depends on the PM voluntarily calling `agent_delegate`. Delegations move
-  `Running` → `Completed`/`Failed` instead of sitting in `Queued` forever, and a
-  `Delegation` now carries `source`, `tool_use_id`, `agent_id`,
-  `transcript_path`, `cwd`, `started_at`, and `ended_at`. A dispatch that both
-  declares (`agent_delegate`) and executes the *same* task produces one record,
-  not two.
-- **`tm hook` forwards Claude Code's subagent correlation keys** (#2864):
-  `tool_use_id` and `transcript_path` on tool events, and `agent_id` /
-  `agent_type` / `agent_transcript_path` on `SubagentStop`. A `tool_response` is
-  relayed only for a subagent-dispatch tool and only as a fixed five-key
-  projection, so an ordinary tool's output is never forwarded. All fields are
-  additive.
-- **`tm hook --pm-guard` now hard-blocks `git worktree add` targeting `/tmp`,
-  `/private/tmp`, `/var/folders`, `$TMPDIR`, or the harness scratchpad**
-  (worktree-hygiene follow-up to
-  [#3955](https://github.com/bobmatnyc/trusty-tools/issues/3955)): worktrees
-  provisioned there silently fail unrelated tests (trusty-search's
-  `SENSITIVE_PATH_PREFIXES` denylist) and can be reaped mid-task by the OS or
-  harness. The check is called directly from `pm_guard()` BEFORE Guard 4's
-  native-subagent-dispatch exemption, and is unconditional — including for
-  Task/Agent-dispatched subagents, which is who actually provisions these
-  worktrees in practice. `pm_guard_bash::evaluate_worktree_add_command`
-  resolves the target (relative paths, `cd`/`git -C` tracking, `~`/`$TMPDIR`/
-  `$TMP` expansion, lexical `.`/`..` normalization) without touching the
-  filesystem; only the exact `worktree add` subcommand is affected —
-  `list`/`remove`/`prune`/`lock`/… and ordinary temp usage (`mktemp`, temp
-  files, cargo build artifacts) are untouched.
-
-  **Round 2 (code-critic BLOCK, PR #3978):** the guard also pierces Guard 1
-  (`CLAUDE_MPM_SUB_AGENT`) — the automatic marker trusty-agents' own
-  subprocess/runner spawn helpers stamp on every nested subagent process
-  (`crates/trusty-agents/src/subprocess/spawn.rs:189-192`,
-  `crates/trusty-agents/src/agents/claude_code_runner/run.rs:211-215`), which
-  is who actually provisions most of these worktrees. Before this round,
-  Guard 1 short-circuited to ALLOW before the stdin payload was even read, so
-  a `CLAUDE_MPM_SUB_AGENT=1`-tagged `git worktree add /tmp/...` call was
-  silently allowed. Guards 2/3 (`TRUSTY_MPM_DISABLE_HOOKS` /
-  `TRUSTY_MPM_PM_UNRESTRICTED`) are deliberately left UN-pierced — neither is
-  ever set programmatically anywhere in this codebase's Rust source, so
-  whoever sets them still gets exactly that, including for this guard.
-  **Round 3 correction:** that is narrower than "operator-only" — Claude
-  Code's `settings.json` `env` object can set either var for every hook
-  invocation (live-reloaded mid-session), and a write to
-  `.claude/settings.json` is not itself blocked by `pm_guard` today, so the
-  PM or an exempt subagent can self-exempt from this entire guard via that
-  pre-existing, unrelated gap. Not introduced or widened by this change; not
-  fixed here; tracked as
-  [#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981).
-
-### Fixed
+  on this path, and the check is unconditional rather than restricted to
+  `.worktrees/<leaf>` paths — `decommission` also `remove_dir_all`s the whole
+  workspace for `workspace_owned` records, which a path-shape filter would have
+  excused entirely.
 
 - **The idle nudge is no longer suppressed indefinitely by a single delegation**
   (#2864): `has_live_children` treats `Queued`/`Running` as live, but nothing

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **The worktree reclaim path no longer force-deletes uncommitted work**
+  ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091)): the
+  orphaned-worktree sweep had no dirty-tree check anywhere — its entire safety
+  model was the #3649 ownership sentinel, and a candidate with a KNOWN owner
+  that passed the owner-terminal and grace-window gates was removed with
+  `git worktree remove --force` (falling back to `fs::remove_dir_all`) no
+  matter what was in it. Because `session_context_pause` prunes by DEFAULT,
+  this fired on an ordinary `/tm-session-pause`. A new
+  `session_manager::worktree_safety::inspect_dirt` gate now runs on every
+  candidate the ownership gate approves, and refuses to remove a worktree that
+  has modified/staged tracked files, untracked (non-ignored) files, or commits
+  present on no remote — that last case matters because
+  `remove_session_worktree` also runs `git branch -D session/<leaf>`, so an
+  unpushed commit loses its last reachable ref. **Every error path resolves to
+  DIRTY**: a git subprocess that cannot run, exits non-zero, or returns an
+  unparsable count, and an unreadable directory, all skip rather than delete.
+  trusty-mpm's own untracked artefacts (the `.trusty-mpm-worktree` sentinel and
+  the `.trusty-mpm/` scrollback directory) are excluded, since counting them
+  would mark every managed worktree permanently dirty; a TRACKED edit under
+  `.trusty-mpm/` still counts. Skips are never silent — they are returned as
+  `skipped_dirty` (path, reason, file/commit counts) from the sweep, as
+  `skipped_dirty_worktrees` from the `session_context_pause` MCP tool, in the
+  `prune-worktrees` HTTP response, printed by `tm session prune-worktrees`, and
+  warned per-path by the daemon's orphan-GC loop. Discarding that work requires
+  an explicit opt-in (`discard_dirty` on the HTTP route,
+  `tm session prune-worktrees --discard-dirty`); `--force` alone does NOT imply
+  it, and the pause tool's schema is closed with no such knob at all, so no
+  default `/tm-session-pause` can reach it. Purely additive — the #3649
+  owner/sentinel guard is unchanged.
+
 ### Added
 - **Agent delegations are now tracked automatically, with a real lifecycle**
   ([#2864](https://github.com/bobmatnyc/trusty-tools/issues/2864), slices

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -25,10 +25,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   unpushed commit loses its last reachable ref. **Every error path resolves to
   DIRTY**: a git subprocess that cannot run, exits non-zero, or returns an
   unparsable count, and an unreadable directory, all skip rather than delete.
-  trusty-mpm's own untracked artefacts (the `.trusty-mpm-worktree` sentinel and
-  the `.trusty-mpm/` scrollback directory) are excluded, since counting them
-  would mark every managed worktree permanently dirty; a TRACKED edit under
-  `.trusty-mpm/` still counts. Skips are never silent — they are returned as
+  Skips are never silent — they are returned as
   `skipped_dirty` (path, reason, file/commit counts) from the sweep, as
   `skipped_dirty_worktrees` from the `session_context_pause` MCP tool, in the
   `prune-worktrees` HTTP response, printed by `tm session prune-worktrees`, and
@@ -38,6 +35,58 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   it, and the pause tool's schema is closed with no such knob at all, so no
   default `/tm-session-pause` can reach it. Purely additive — the #3649
   owner/sentinel guard is unchanged.
+
+- **The dirty-tree guard now sees work `git status` hides**
+  ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091), review
+  round): `git status --porcelain` reports what git has been *configured* to
+  show, and the most valuable content in a session worktree was outside that.
+  Six holes closed, each with a test:
+  - **Nested repositories are now enumerated, not inferred.** A worktree
+    containing nested git worktrees or clones that hold uncommitted or unpushed
+    work is DIRTY regardless of gitignore — the `.claude/worktrees/` agent shape
+    is gitignored on `main`, so seven live nested worktrees inside one session
+    checkout produced `dirty_files = 0`. Since the #3649 gate deliberately
+    refuses to delete those nested worktrees directly, the sweep would have
+    honoured that refusal and then deleted their parent. Registered worktrees
+    come from `git worktree list --porcelain`; unregistered clones come from a
+    bounded walk of gitignored subtrees that skips regenerable build directories
+    (`target/`, `node_modules/`, …). A nested worktree that is itself clean and
+    pushed does NOT pin its parent.
+  - **`.trusty-mpm/` is no longer excused wholesale.** Only
+    `scrollback.txt` and `last-instructions.md` are treated as disposable;
+    pause snapshots under `sessions/`, checkpoints, and anything else — a live
+    example held twelve files of hand-rescued uncommitted Rust source — now
+    count as work, whether the project gitignores the subtree or not.
+  - **Config can no longer silence the guard.** `status.showUntrackedFiles=no`
+    made `git status --porcelain` exit 0 with empty output while untracked work
+    sat on disk, and a `core.excludesFile` naming that work hid it the same way
+    — either one in the shared `.base/.git/config` would have blinded every
+    worktree in a sweep. Both are now pinned on the command line.
+  - **`GIT_DIR`/`GIT_WORK_TREE` and friends are stripped** from every git
+    invocation, so an inherited environment cannot point the check at a
+    different (clean) repository.
+  - **Unpushed commits on `session/<leaf>` are counted**, not just on `HEAD`.
+    `decommission` force-deletes that branch by directory name, and a worktree
+    switched off its own branch reported HEAD fully pushed while the branch
+    about to be destroyed was not.
+  - **The verdict is re-checked immediately before each removal.** Computing it
+    once up front left the whole sweep's duration between "certified clean" and
+    "deleted".
+
+- **The age-based ephemeral auto-reaper now honours the dirty-tree guard**
+  ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091), review
+  round): `reap_aged_ephemeral` reaches the same
+  `worktree remove --force` → `remove_dir_all` → `branch -D` sequence as the
+  orphan sweep but never passed through the guard, and it fires automatically
+  on every daemon GC tick. An aged ephemeral whose workspace holds unsaved work
+  is now left in place for an operator. There is deliberately no discard opt-in
+  on this path.
+
+### Changed
+
+- **Orphan-sweep candidates are processed in sorted order** rather than
+  filesystem order, so a `--dry-run` preview predicts the real run and any
+  ordering-dependent behaviour is reproducible.
 
 ### Added
 - **Agent delegations are now tracked automatically, with a real lifecycle**

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/mcp-tools.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/mcp-tools.md
@@ -175,7 +175,7 @@ Return a STRUCTURED (JSON, not prose) resume digest for `project_dir`: paused se
 
 ## `session_context_pause`
 
-Write a session-pause snapshot for `project_dir`: a `session-YYYYMMDD-HHMMSS.md` file in the SAME section format the catch-up reader already parses (`## Summary` / `## Completed` / `## In Progress` / `## Next Steps` / `## Git Context` / `## Tmux Window`), plus an appended `pause` line in the append-only `sessions-log.jsonl`. Also prunes orphaned managed-session git worktrees in-process (same engine as `tm session prune-worktrees`) unless `prune_worktrees` is set to `false`. Does NOT touch tmux — window realignment on resume stays a PM-side `tmux select-window` step.
+Write a session-pause snapshot for `project_dir`: a `session-YYYYMMDD-HHMMSS.md` file in the SAME section format the catch-up reader already parses (`## Summary` / `## Completed` / `## In Progress` / `## Next Steps` / `## Git Context` / `## Tmux Window`), plus an appended `pause` line in the append-only `sessions-log.jsonl`. Also prunes orphaned managed-session git worktrees in-process (same engine as `tm session prune-worktrees`) unless `prune_worktrees` is set to `false`. That prune NEVER removes a worktree holding uncommitted or unpushed work (#4091) — any such worktree is returned in `skipped_dirty_worktrees` with a reason and file/commit counts for you to relay to the user. Does NOT touch tmux — window realignment on resume stays a PM-side `tmux select-window` step.
 
 | Parameter | Type | Required |
 |---|---|---|

--- a/crates/trusty-mpm/src/assets/skills/tm-session-pause.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-session-pause.md
@@ -147,7 +147,8 @@ mcp__trusty-mpm__session_context_pause(
 )
 ```
 
-The tool returns `{ snapshot_path, timestamp, pruned_worktrees }`. It writes
+The tool returns
+`{ snapshot_path, timestamp, pruned_worktrees, skipped_dirty_worktrees }`. It writes
 `.trusty-mpm/sessions/session-YYYYMMDD-HHMMSS.md` in the same section format
 `/tm-session-resume` already parses (`## Summary` / `## Completed` /
 `## In Progress` / `## Next Steps` / `## Git Context` / `## Tmux Window`,
@@ -158,6 +159,16 @@ in the same project keep their own history), and computes the
 itself — no separate `git status`/`git log` shell-out needed.
 
 Report the returned `snapshot_path` to the user.
+
+**If `skipped_dirty_worktrees` is non-empty, you MUST report it** — do not let
+it disappear into the tool result. Each entry is
+`{ path, reason, dirty_files, unpushed_commits }` and names a worktree the
+prune refused to delete because it still holds uncommitted or unpushed work.
+List them for the user, with the path and reason, and say plainly that the
+work is still on disk and needs a human decision (commit it, push it, or
+delete the directory deliberately). Never summarise them as "some worktrees
+were skipped" — the whole point of the #4091 guard is that unsaved work stops
+being invisible.
 
 ## If the Tool Call Fails — Diagnose Before Falling Back
 
@@ -257,13 +268,25 @@ true`, the default) — the same in-process engine `tm session prune-worktrees`
 uses. Only directories with **no** corresponding active session are ever
 touched; the tool returns the list of paths removed as `pruned_worktrees`.
 
+**A worktree holding unsaved work is never removed** (#4091). Before deleting
+anything, the prune checks each candidate for uncommitted or staged changes,
+untracked (non-ignored) files, and commits that exist on no remote — and
+refuses to touch it if any are present, or if the check itself cannot
+complete. Those are returned as `skipped_dirty_worktrees` (see above) rather
+than deleted. `/tm-session-pause` has **no** option that can override this;
+discarding unsaved work requires the deliberate CLI opt-in below.
+
 Pass `prune_worktrees: false` to skip this step (e.g. to preview first with
 the CLI):
 
 ```bash
 tm session prune-worktrees          # dry-run by default (preview only)
-tm session prune-worktrees --force  # actually remove the orphaned dirs
+tm session prune-worktrees --force  # remove the orphaned dirs, sparing dirty ones
 ```
+
+`--force` still refuses to delete a worktree with unsaved work; it lists them
+on stderr instead. Only `tm session prune-worktrees --force --discard-dirty`
+destroys that work, and it should be reached for only after reading that list.
 
 `tm doctor`'s `worktrees` probe reports the orphan count and suggests this
 command; run it whenever that probe is non-zero, and always before ending a

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
@@ -475,11 +475,19 @@ pub(crate) enum SessionAction {
     /// are ever touched. `tm doctor` reports the count of orphans and suggests
     /// running this command.
     /// What: POSTs `/api/v1/sessions/managed/prune-worktrees`; defaults to dry
-    /// run (pass `--force` to actually delete).
-    /// Test: `cli_parses_session_prune_worktrees`.
+    /// run (pass `--force` to actually delete). `--force` alone still refuses
+    /// to touch a worktree holding uncommitted or unpushed work (#4091) — it
+    /// is reported instead; `--discard-dirty` is the separate, explicit opt-in
+    /// that permits destroying that work.
+    /// Test: `cli_parses_session_prune_worktrees`,
+    /// `cli_prune_worktrees_discard_dirty_is_opt_in`.
     PruneWorktrees {
         /// Actually delete orphaned dirs (default: dry-run / preview only).
         #[arg(long)]
         force: bool,
+        /// ALSO delete worktrees that still hold uncommitted or unpushed work
+        /// (#4091). Off by default; this discards that work irreversibly.
+        #[arg(long)]
+        discard_dirty: bool,
     },
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -704,17 +704,24 @@ pub(crate) async fn session_prune(
 /// `git worktree remove` failed, leave stale `.worktrees/<session-id>/`
 /// directories on disk. This verb lets operators clean them up safely — only
 /// dirs without a corresponding active session are ever removed.
-/// What: POSTs `/api/v1/sessions/managed/prune-worktrees` with `{ dry_run }`;
-/// prints one path per removed (or would-remove) directory and a summary count.
-/// Test: HTTP path covered by integration test; CLI parse by `cli_parses_session_prune`.
+/// What: POSTs `/api/v1/sessions/managed/prune-worktrees` with
+/// `{ dry_run, discard_dirty }`; prints one path per removed (or would-remove)
+/// directory and a summary count, then prints every worktree the #4091
+/// dirty-tree gate refused to touch (path + reason) to stderr so a skip is
+/// never silent — a skipped worktree still holds work the operator needs to
+/// deal with by hand.
+/// Test: HTTP path covered by integration test; CLI parse by
+/// `cli_parses_session_prune_worktrees` and
+/// `cli_prune_worktrees_discard_dirty_is_opt_in`.
 pub(crate) async fn session_prune_worktrees(
     client: &reqwest::Client,
     url: &str,
     dry_run: bool,
+    discard_dirty: bool,
 ) -> anyhow::Result<()> {
     let resp = client
         .post(format!("{url}/api/v1/sessions/managed/prune-worktrees"))
-        .json(&serde_json::json!({ "dry_run": dry_run }))
+        .json(&serde_json::json!({ "dry_run": dry_run, "discard_dirty": discard_dirty }))
         .send()
         .await?;
     let body: serde_json::Value = resp.error_for_status()?.json().await?;
@@ -737,6 +744,33 @@ pub(crate) async fn session_prune_worktrees(
     }
     let verb = if dry_run { "would remove" } else { "removed" };
     println!("{verb} {printed} orphaned worktree dir(s)");
+
+    // #4091: surface every dirty-skip. These are worktrees that WOULD have
+    // been reclaimed but still hold unsaved work; staying quiet about them is
+    // how the sweep silently loses work.
+    let skipped = body
+        .get("skipped_dirty")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if !skipped.is_empty() {
+        eprintln!(
+            "skipped {} worktree(s) holding uncommitted or unpushed work (#4091) — \
+             review them by hand; `--discard-dirty` would destroy this work:",
+            skipped.len()
+        );
+        for entry in &skipped {
+            let path = entry
+                .get("path")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<unknown path>");
+            let reason = entry
+                .get("reason")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("<no reason reported>");
+            eprintln!("  {path}: {reason}");
+        }
+    }
     Ok(())
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -391,9 +391,15 @@ pub(crate) async fn session(
             crate::commands::managed::session_prune(client, url, state, dry_run, include_active)
                 .await?
         }
-        SessionAction::PruneWorktrees { force } => {
+        SessionAction::PruneWorktrees {
+            force,
+            discard_dirty,
+        } => {
             // `--force` means "actually delete"; absence means dry-run (#1840).
-            crate::commands::managed::session_prune_worktrees(client, url, !force).await?
+            // `--discard-dirty` is a SEPARATE opt-in that additionally permits
+            // destroying uncommitted/unpushed work (#4091).
+            crate::commands::managed::session_prune_worktrees(client, url, !force, discard_dirty)
+                .await?
         }
         // #2444: re-sync a live session's (or every syncable session's)
         // deployed assets against the current catalog. Fleet-wide store

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -521,9 +521,14 @@ fn cli_parses_session_prune_worktrees() {
     let cli = Cli::try_parse_from(["trusty-mpm", "session", "prune-worktrees"]).unwrap();
     match cli.command.unwrap() {
         Command::Session {
-            action: SessionAction::PruneWorktrees { force },
+            action:
+                SessionAction::PruneWorktrees {
+                    force,
+                    discard_dirty,
+                },
         } => {
             assert!(!force, "default must be dry-run (force=false)");
+            assert!(!discard_dirty, "default must never discard dirty work");
         }
         other => panic!("expected session prune-worktrees, got {other:?}"),
     }
@@ -532,9 +537,49 @@ fn cli_parses_session_prune_worktrees() {
         Cli::try_parse_from(["trusty-mpm", "session", "prune-worktrees", "--force"]).unwrap();
     match cli2.command.unwrap() {
         Command::Session {
-            action: SessionAction::PruneWorktrees { force },
+            action:
+                SessionAction::PruneWorktrees {
+                    force,
+                    discard_dirty,
+                },
         } => {
             assert!(force, "--force must set force=true");
+            assert!(
+                !discard_dirty,
+                "#4091: --force alone must NOT imply discarding uncommitted work"
+            );
+        }
+        other => panic!("expected session prune-worktrees, got {other:?}"),
+    }
+}
+
+/// #4091: discarding uncommitted work requires its own explicit flag — it is
+/// never implied by `--force`, and never on by default.
+///
+/// Why: `--force` already means "stop previewing, actually delete", and an
+/// operator reaching for it to clear stale directories must not silently also
+/// authorise destroying another session's unsaved work. Two separate flags
+/// keep those two decisions separate.
+#[test]
+fn cli_prune_worktrees_discard_dirty_is_opt_in() {
+    let cli = Cli::try_parse_from([
+        "trusty-mpm",
+        "session",
+        "prune-worktrees",
+        "--force",
+        "--discard-dirty",
+    ])
+    .unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action:
+                SessionAction::PruneWorktrees {
+                    force,
+                    discard_dirty,
+                },
+        } => {
+            assert!(force);
+            assert!(discard_dirty, "--discard-dirty must set discard_dirty=true");
         }
         other => panic!("expected session prune-worktrees, got {other:?}"),
     }

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -18,7 +18,7 @@ use serde::Deserialize;
 use tracing::warn;
 
 use crate::daemon::state::DaemonState;
-use crate::session_manager::PruneFilter;
+use crate::session_manager::{DirtyWorktreePolicy, PruneFilter};
 
 /// Request body for POST /api/v1/sessions/managed/prune (#1508).
 ///
@@ -67,13 +67,21 @@ pub async fn decommission_ephemeral_route(
 ///
 /// Why: the orphaned-worktree sweep should default to dry-run so operators can
 /// preview what will be removed before committing.
-/// What: `dry_run` (default true — safe preview default).
-/// Test: integration test via `prune_worktrees_route`.
+/// What: `dry_run` (default true — safe preview default) and `discard_dirty`
+/// (#4091, default FALSE — the only way to reach
+/// [`DirtyWorktreePolicy::ForceDiscard`], i.e. to delete a worktree that still
+/// holds uncommitted or unpushed work; omitting the field, or sending `{}`,
+/// always yields the safe skip-and-report behaviour).
+/// Test: `prune_worktrees_request_defaults_to_skip_dirty`.
 #[derive(Debug, Deserialize)]
 pub struct PruneWorktreesRequest {
     /// When true (the default), report orphans without deleting anything.
     #[serde(default = "default_dry_run")]
     pub dry_run: bool,
+    /// When true, ALSO remove worktrees holding uncommitted/unpushed work
+    /// (#4091). Defaults to false — the fail-safe default.
+    #[serde(default)]
+    pub discard_dirty: bool,
 }
 
 fn default_dry_run() -> bool {
@@ -88,11 +96,16 @@ fn default_dry_run() -> bool {
 /// that belongs to an active session.
 /// What: collects active workspace paths and the managed workspace root, then
 /// delegates to [`SessionManager::prune_orphaned_worktrees`]. Returns
-/// `{ dry_run, paths: ["..."], owner_unknown_paths: ["..."] }` (#3649 adds the
-/// second field: worktrees conservatively skipped because their ownership
-/// sentinel had no resolvable owner — never auto-deleted, surfaced here for
-/// operator review). Dry-run is the default.
-/// Test: `prune_worktrees_route_dry_run`.
+/// `{ dry_run, paths: ["..."], owner_unknown_paths: ["..."], skipped_dirty: [...] }`
+/// (#3649 added the second field: worktrees conservatively skipped because
+/// their ownership sentinel had no resolvable owner — never auto-deleted,
+/// surfaced here for operator review; #4091 adds the third: worktrees skipped
+/// because they still hold uncommitted or unpushed work, each an object with
+/// `path`, `reason`, `dirty_files`, and `unpushed_commits`). Dry-run is the
+/// default, and so is skipping dirty worktrees — `discard_dirty: true` is the
+/// only path to a destructive removal of unsaved work.
+/// Test: `prune_worktrees_route_dry_run`,
+/// `prune_worktrees_request_defaults_to_skip_dirty`.
 pub async fn prune_worktrees_route(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<PruneWorktreesRequest>,
@@ -107,8 +120,15 @@ pub async fn prune_worktrees_route(
     let repos_root = crate::core::trusty_tools_config::workspace_root(&config);
     // Item 7 (#1845): propagate scan failures as HTTP 500 instead of silently
     // returning an empty path list (which could mask the underlying error).
+    // #4091: the ONLY place `ForceDiscard` can be requested, and only via an
+    // explicit `discard_dirty: true` in the request body.
+    let policy = if req.discard_dirty {
+        DirtyWorktreePolicy::ForceDiscard
+    } else {
+        DirtyWorktreePolicy::Skip
+    };
     match mgr
-        .prune_orphaned_worktrees(&repos_root, &active_workspace_paths, req.dry_run)
+        .prune_orphaned_worktrees(&repos_root, &active_workspace_paths, req.dry_run, policy)
         .await
     {
         Ok(outcome) => {
@@ -126,6 +146,7 @@ pub async fn prune_worktrees_route(
                 "dry_run": req.dry_run,
                 "paths": paths,
                 "owner_unknown_paths": owner_unknown_paths,
+                "skipped_dirty": outcome.skipped_dirty,
             }))
             .into_response()
         }
@@ -171,5 +192,29 @@ pub async fn prune_managed_route(
     {
         Ok(outcome) => Json(outcome).into_response(),
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// #4091: a request body that says nothing about dirty worktrees must
+    /// deserialize to the SAFE behaviour. An omitted field is the overwhelming
+    /// majority of real calls (the CLI's non-`--discard-dirty` path, and any
+    /// third-party caller), so the serde default is the actual guard here.
+    #[test]
+    fn prune_worktrees_request_defaults_to_skip_dirty() {
+        let req: PruneWorktreesRequest = serde_json::from_str("{}").expect("empty body parses");
+        assert!(req.dry_run, "an unspecified prune must preview, not delete");
+        assert!(
+            !req.discard_dirty,
+            "an unspecified prune must NEVER discard uncommitted work"
+        );
+
+        let explicit: PruneWorktreesRequest =
+            serde_json::from_str(r#"{"dry_run":false,"discard_dirty":true}"#)
+                .expect("explicit body parses");
+        assert!(explicit.discard_dirty, "the opt-in must round-trip");
     }
 }

--- a/crates/trusty-mpm/src/daemon/mcp_context.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_context.rs
@@ -133,6 +133,15 @@ pub async fn session_context_catchup(
 /// just called directly instead of over HTTP. A worktree-prune failure is
 /// logged and reported as an empty list rather than failing the whole pause
 /// (the snapshot write is the operation that must not silently fail).
+///
+/// #4091: the prune leg always passes
+/// [`crate::session_manager::DirtyWorktreePolicy::Skip`] — a worktree holding
+/// uncommitted or unpushed work is never removed by a pause, and every such
+/// skip is returned in the `skipped_dirty_worktrees` field (path + reason +
+/// file/commit counts) so the `/tm-session-pause` skill can surface it to the
+/// operator instead of it being a log line nobody reads. There is
+/// deliberately no argument through which the MCP tool could request the
+/// force-discard policy.
 /// Test: `session_context_pause_missing_project_dir_errors`,
 /// `session_context_pause_requires_summary`,
 /// `session_context_pause_writes_snapshot_without_pruning`.
@@ -169,6 +178,7 @@ pub async fn session_context_pause(
     let outcome = trusty_common::catchup::pause::write_pause_snapshot(&project_path, &input)
         .map_err(|e| format!("failed to write pause snapshot: {e}"))?;
 
+    let mut skipped_dirty = Vec::new();
     let pruned_worktrees: Vec<String> = if prune_worktrees {
         let mgr = state.session_manager().await;
         let records = mgr.list().await;
@@ -178,15 +188,27 @@ pub async fn session_context_pause(
             .collect();
         let tt_config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
         let repos_root = crate::core::trusty_tools_config::workspace_root(&tt_config);
+        // #4091: the pause path ALWAYS uses the default skip-dirty policy —
+        // there is deliberately no argument threaded from the MCP tool that
+        // could turn this into a force-discard, so an ordinary
+        // `/tm-session-pause` can never destroy uncommitted work.
         match mgr
-            .prune_orphaned_worktrees(&repos_root, &active_workspace_paths, false)
+            .prune_orphaned_worktrees(
+                &repos_root,
+                &active_workspace_paths,
+                false,
+                crate::session_manager::DirtyWorktreePolicy::Skip,
+            )
             .await
         {
-            Ok(outcome) => outcome
-                .removed
-                .iter()
-                .map(|p| p.to_string_lossy().into_owned())
-                .collect(),
+            Ok(sweep) => {
+                skipped_dirty = sweep.skipped_dirty;
+                sweep
+                    .removed
+                    .iter()
+                    .map(|p| p.to_string_lossy().into_owned())
+                    .collect()
+            }
             Err(e) => {
                 tracing::warn!("session_context_pause: worktree prune failed: {e}");
                 Vec::new()
@@ -200,6 +222,7 @@ pub async fn session_context_pause(
         "snapshot_path": outcome.snapshot_path.display().to_string(),
         "timestamp": outcome.timestamp.to_rfc3339(),
         "pruned_worktrees": pruned_worktrees,
+        "skipped_dirty_worktrees": skipped_dirty,
     }))
 }
 

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -683,6 +683,19 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                                 outcome.owner_unknown.len()
                             );
                         }
+                        // #4091: a worktree holding uncommitted or unpushed
+                        // work is NEVER auto-deleted. Warn (not info) with the
+                        // per-path reason — this is unsaved work sitting in a
+                        // directory the sweep would otherwise have reclaimed,
+                        // and the operator needs to see it, not discover it
+                        // missing later.
+                        for dirt in &outcome.skipped_dirty {
+                            tracing::warn!(
+                                path = %dirt.path.display(),
+                                reason = %dirt.reason,
+                                "orphan-GC left a worktree with unsaved work untouched (#4091)"
+                            );
+                        }
                     }
                     Err(e) => tracing::warn!("orphan-GC worktree sweep failed: {e}"),
                 }

--- a/crates/trusty-mpm/src/mcp/tools/mod.rs
+++ b/crates/trusty-mpm/src/mcp/tools/mod.rs
@@ -176,6 +176,40 @@ mod tests {
         }
     }
 
+    /// #4091 REGRESSION: `session_context_pause` must expose NO knob that could
+    /// authorise discarding uncommitted work.
+    ///
+    /// Why: the pause tool prunes worktrees by DEFAULT, so it is the single
+    /// most likely place for a destructive override to be added "for
+    /// convenience" and then triggered by an ordinary `/tm-session-pause`. The
+    /// discard opt-in belongs on the deliberate operator surfaces only (the
+    /// `prune-worktrees` HTTP route / CLI). This test fails if anyone adds a
+    /// force/discard/dirty property to the pause schema.
+    #[test]
+    fn session_context_pause_schema_has_no_dirty_override() {
+        let catalog = tool_catalog();
+        let pause = catalog
+            .iter()
+            .find(|t| t["name"] == "session_context_pause")
+            .expect("session_context_pause must be in the catalog");
+        let props = pause["inputSchema"]["properties"]
+            .as_object()
+            .expect("pause schema must declare properties");
+        for key in props.keys() {
+            let lowered = key.to_ascii_lowercase();
+            assert!(
+                !lowered.contains("force")
+                    && !lowered.contains("discard")
+                    && !lowered.contains("dirty"),
+                "#4091: `{key}` would let a default /tm-session-pause discard unsaved work"
+            );
+        }
+        assert_eq!(
+            pause["inputSchema"]["additionalProperties"], false,
+            "the pause schema must stay closed so no override can be smuggled in"
+        );
+    }
+
     #[test]
     fn console_tools_present() {
         let catalog = tool_catalog();

--- a/crates/trusty-mpm/src/mcp/tools/session.rs
+++ b/crates/trusty-mpm/src/mcp/tools/session.rs
@@ -306,7 +306,10 @@ pub(super) fn session_tools() -> Vec<Value> {
              `## Tmux Window`), plus an appended `pause` line in the \
              append-only `sessions-log.jsonl`. Also prunes orphaned managed-session \
              git worktrees in-process (same engine as `tm session prune-worktrees`) \
-             unless `prune_worktrees` is set to `false`. Does NOT touch tmux — \
+             unless `prune_worktrees` is set to `false`. That prune NEVER removes a \
+             worktree holding uncommitted or unpushed work (#4091) — any such \
+             worktree is returned in `skipped_dirty_worktrees` with a reason and \
+             file/commit counts for you to relay to the user. Does NOT touch tmux — \
              window realignment on resume stays a PM-side `tmux select-window` step.",
             json!({
                 "type": "object",

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -34,6 +34,7 @@ pub mod store;
 pub mod task_inject;
 pub mod workspace_guard;
 pub(crate) mod worktree_ownership;
+pub mod worktree_safety;
 
 #[cfg(test)]
 mod tests;
@@ -101,6 +102,11 @@ mod slots_tests;
 #[cfg(test)]
 mod send_input_gate_tests;
 
+/// Shared real-git fixtures for the #4091 dirty-worktree-guard tests, used by
+/// both `worktree_safety::worktree_safety_tests` and `prune::orphan_tests`.
+#[cfg(test)]
+pub(crate) mod worktree_git_fixture;
+
 /// Real tmux driver adapter — only available when the `daemon` feature (and thus
 /// the daemon's `TmuxDriver`) is compiled in.
 #[cfg(feature = "daemon")]
@@ -114,6 +120,7 @@ pub use session_guard::TmuxSessionGuard;
 pub use slots::{NumberedSlot, SlotRegistry};
 pub use store::{SessionStore, StoreError};
 pub use task_inject::should_inject_task;
+pub use worktree_safety::{DirtyWorktree, DirtyWorktreePolicy};
 
 #[cfg(feature = "daemon")]
 pub use real_tmux::RealTmuxDriver;

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -33,6 +33,7 @@ pub mod snapshot;
 pub mod store;
 pub mod task_inject;
 pub mod workspace_guard;
+mod worktree_nested;
 pub(crate) mod worktree_ownership;
 pub mod worktree_safety;
 

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -23,6 +23,9 @@ use tracing::{error, info, warn};
 use super::driver::ManagedTmuxDriver;
 use super::manager::{ManagedError, SessionManager};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use super::worktree_safety::{
+    DirtyWorktree, DirtyWorktreePolicy, git_worktree_list_agrees, inspect_dirt,
+};
 
 /// Maximum age an EPHEMERAL session may reach before the auto-reaper tears it
 /// down — default 24 hours (#1508).
@@ -567,9 +570,14 @@ fn scan_worktree_shape(
 /// left in place for `tm doctor` / `--dry-run` review, not merely "not found".
 /// What: `removed` — paths actually removed (or that WOULD be removed under
 /// `dry_run`); `owner_unknown` — paths whose ownership sentinel had no
-/// resolvable owner (absent, empty/legacy, or unparsable content).
+/// resolvable owner (absent, empty/legacy, or unparsable content);
+/// `skipped_dirty` (#4091) — paths whose owner WAS resolvable and provably
+/// gone, but which still hold uncommitted or unpushed work (or whose
+/// dirty-check could not complete), each with the reason and counts behind
+/// the decision so no skip is ever silent.
 /// Test: `prune_orphaned_worktrees_skips_owner_unknown`,
-///       `prune_orphaned_worktrees_reclaims_terminal_owner`.
+///       `prune_orphaned_worktrees_reclaims_terminal_owner`,
+///       `prune_orphaned_worktrees_skips_modified_tracked_file` (#4091).
 #[derive(Debug, Clone, Default)]
 pub struct OrphanSweepOutcome {
     /// Paths actually removed (or that would be removed under `dry_run`).
@@ -577,59 +585,9 @@ pub struct OrphanSweepOutcome {
     /// Paths skipped because their sentinel's owner could not be resolved —
     /// never auto-deleted; surfaced here for `tm doctor`/manual review.
     pub owner_unknown: Vec<std::path::PathBuf>,
-}
-
-/// Best-effort cross-check: does `git worktree list` on the checkout owning
-/// `candidate` agree that `candidate` is a real, currently-registered git
-/// worktree (#3649)?
-///
-/// Why: the sentinel + store-ownerless checks establish WHO owned this
-/// directory and whether that owner is provably gone, but neither confirms
-/// git's OWN bookkeeping still recognises the path as a worktree at all — a
-/// belt-and-suspenders safety net against deleting a directory that merely
-/// LOOKS like a worktree (e.g. its git worktree entry was already pruned by
-/// something else, or the shape matched by coincidence). A disagreement is
-/// treated conservatively: skip rather than delete.
-/// What: runs `git -C <repo_root> worktree list --porcelain`, where
-/// `repo_root` is `candidate`'s grandparent directory — the SAME derivation
-/// `decommission::remove_session_worktree` uses, which works identically for
-/// both worktree-store shapes (`<repo>/.worktrees/<name>` and
-/// `<repo>/.base/.worktrees/<id>`, since either way the grandparent of the
-/// worktree leaf is the git checkout root). Returns `true` (agree — deletion
-/// may proceed, subject to the caller's other checks) when the git command
-/// cannot be run or fails outright — this check is an ADDITIONAL safety net
-/// on top of the sentinel/store checks, not a replacement for them, so a
-/// missing `git` binary or a transient failure never blocks a deletion those
-/// checks already approved. Returns `true` only when `candidate`'s
-/// canonicalized path appears among the porcelain output's `worktree <path>`
-/// lines.
-/// Test: `git_worktree_list_agrees_true_for_real_worktree`,
-///       `git_worktree_list_agrees_false_for_untracked_dir`.
-fn git_worktree_list_agrees(candidate: &std::path::Path) -> bool {
-    let Some(repo_root) = candidate.parent().and_then(|p| p.parent()) else {
-        return true;
-    };
-    let out = std::process::Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .args(["worktree", "list", "--porcelain"])
-        .output();
-    let Ok(out) = out else {
-        return true; // best-effort: git unavailable must never block a delete
-    };
-    if !out.status.success() {
-        return true;
-    }
-    let stdout = String::from_utf8_lossy(&out.stdout);
-    let canonical_candidate =
-        std::fs::canonicalize(candidate).unwrap_or_else(|_| candidate.to_path_buf());
-    stdout
-        .lines()
-        .filter_map(|l| l.strip_prefix("worktree "))
-        .any(|p| {
-            let pb = std::path::PathBuf::from(p);
-            std::fs::canonicalize(&pb).unwrap_or(pb) == canonical_candidate
-        })
+    /// Paths skipped because they hold unsaved work (#4091) — never
+    /// auto-deleted under the default [`DirtyWorktreePolicy::Skip`].
+    pub skipped_dirty: Vec<DirtyWorktree>,
 }
 
 impl SessionManager {
@@ -846,18 +804,38 @@ impl SessionManager {
     ///   path is a real worktree ([`git_worktree_list_agrees`]) — a
     ///   disagreement is skipped conservatively, never deleted.
     ///
+    /// #4091 DIRTY-TREE GATE (applied AFTER the #3649 gate, additively — it
+    /// never widens what ownership already approved, only narrows it): every
+    /// candidate that survived the ownership gate is passed to
+    /// [`inspect_dirt`], which fails toward DIRTY on any error. Under the
+    /// default `policy` ([`DirtyWorktreePolicy::Skip`]) a dirty candidate is
+    /// NEVER removed — it is reported in [`OrphanSweepOutcome::skipped_dirty`]
+    /// with the reason and file/commit counts. `DirtyWorktreePolicy::ForceDiscard`
+    /// removes it anyway after a `warn!` naming exactly what is being
+    /// discarded; that variant is reachable only from an explicit operator
+    /// opt-in (`discard_dirty` on the HTTP route / `tm session prune-worktrees
+    /// --discard-dirty`), never from the default `/tm-session-pause` path.
+    /// The gate runs under `dry_run` too, so a preview matches a real run.
+    ///
     /// Test: `prune_orphaned_worktrees_removes_orphan`,
     /// `prune_orphaned_worktrees_spares_active`,
     /// `prune_orphaned_worktrees_store_snapshot_blocks_deletion` (item 1),
     /// `prune_orphaned_worktrees_skips_owner_unknown`,
     /// `prune_orphaned_worktrees_reclaims_terminal_owner`,
     /// `prune_orphaned_worktrees_spares_live_owner`,
-    /// `prune_orphaned_worktrees_spares_recent_unregistered_owner` (#3649).
+    /// `prune_orphaned_worktrees_spares_recent_unregistered_owner` (#3649),
+    /// `prune_orphaned_worktrees_skips_modified_tracked_file`,
+    /// `prune_orphaned_worktrees_skips_untracked_file`,
+    /// `prune_orphaned_worktrees_skips_unpushed_commit`,
+    /// `prune_orphaned_worktrees_reclaims_clean_pushed_worktree`,
+    /// `prune_orphaned_worktrees_skips_when_dirty_check_errors`,
+    /// `prune_orphaned_worktrees_force_discards_dirty` (#4091).
     pub async fn prune_orphaned_worktrees(
         &self,
         repos_root: &std::path::Path,
         active_workspace_paths: &[std::path::PathBuf],
         dry_run: bool,
+        policy: DirtyWorktreePolicy,
     ) -> Result<OrphanSweepOutcome, anyhow::Error> {
         use super::decommission::remove_session_worktree;
         use super::worktree_ownership::SentinelOwner;
@@ -884,6 +862,7 @@ impl SessionManager {
         // deletion decision — applied identically under dry-run and real runs
         // so a preview reflects reality.
         let mut owner_unknown = Vec::new();
+        let mut skipped_dirty: Vec<DirtyWorktree> = Vec::new();
         let mut reclaimable = Vec::new();
         for candidate in candidates {
             match super::worktree_ownership::read_sentinel_owner(&candidate) {
@@ -913,6 +892,26 @@ impl SessionManager {
                         );
                         continue;
                     }
+                    // #4091: last gate — never destroy unsaved work.
+                    if let Some(dirt) = inspect_dirt(&candidate) {
+                        if policy == DirtyWorktreePolicy::Skip {
+                            warn!(
+                                path = %candidate.display(),
+                                reason = %dirt.reason,
+                                "prune-worktrees: candidate holds unsaved work — refusing to \
+                                 remove it; re-run with an explicit discard opt-in only if the \
+                                 work is genuinely disposable (#4091)"
+                            );
+                            skipped_dirty.push(dirt);
+                            continue;
+                        }
+                        warn!(
+                            path = %candidate.display(),
+                            reason = %dirt.reason,
+                            "prune-worktrees: DISCARDING unsaved work — explicit \
+                             force-discard opt-in was supplied (#4091)"
+                        );
+                    }
                     reclaimable.push(candidate);
                 }
             }
@@ -925,6 +924,7 @@ impl SessionManager {
             return Ok(OrphanSweepOutcome {
                 removed: reclaimable,
                 owner_unknown,
+                skipped_dirty,
             });
         }
 
@@ -1037,6 +1037,7 @@ impl SessionManager {
         Ok(OrphanSweepOutcome {
             removed,
             owner_unknown,
+            skipped_dirty,
         })
     }
 
@@ -1054,7 +1055,10 @@ impl SessionManager {
     /// active set, then delegates to `prune_orphaned_worktrees` with
     /// `dry_run = false`. The two-phase TOCTOU safety (a fresh store snapshot taken
     /// immediately before deletion) and the "only leaf dirs under `.worktrees/`,
-    /// never the base clone" guard are inherited unchanged. Returns the paths removed.
+    /// never the base clone" guard are inherited unchanged, as is the #4091
+    /// dirty-tree gate — the periodic daemon sweep ALWAYS uses the default
+    /// [`DirtyWorktreePolicy::Skip`] and has no way to opt into discarding
+    /// work. Returns the paths removed.
     /// Test: `reap_orphaned_worktrees_removes_orphan_preserves_live` in
     /// `super::reap_orphaned_worktrees_tests`.
     pub async fn reap_orphaned_worktrees(
@@ -1067,7 +1071,7 @@ impl SessionManager {
             .into_iter()
             .filter_map(|r| r.workspace_path)
             .collect();
-        self.prune_orphaned_worktrees(repos_root, &active, false)
+        self.prune_orphaned_worktrees(repos_root, &active, false, DirtyWorktreePolicy::Skip)
             .await
     }
 

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -24,7 +24,7 @@ use super::driver::ManagedTmuxDriver;
 use super::manager::{ManagedError, SessionManager};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::worktree_safety::{
-    DirtyWorktree, DirtyWorktreePolicy, git_worktree_list_agrees, inspect_dirt,
+    DirtyWorktree, DirtyWorktreePolicy, dirt_blocks_removal, git_worktree_list_agrees, inspect_dirt,
 };
 
 /// Maximum age an EPHEMERAL session may reach before the auto-reaper tears it
@@ -484,6 +484,11 @@ pub(crate) fn find_orphaned_worktrees(
             }
         }
     }
+    // #4118: `read_dir` order is filesystem-dependent, so two runs of the same
+    // sweep could remove the same worktrees in different orders — which makes a
+    // dry-run preview a poor predictor of the real run and makes any ordering
+    // bug unreproducible. Sorting costs nothing at this scale.
+    orphans.sort();
     orphans
 }
 
@@ -817,6 +822,17 @@ impl SessionManager {
     /// --discard-dirty`), never from the default `/tm-session-pause` path.
     /// The gate runs under `dry_run` too, so a preview matches a real run.
     ///
+    /// #4118 DIRTY-GATE TOCTOU: the Phase 1.5 verdict above is computed for
+    /// EVERY candidate before ANY removal happens, so across a ~95-candidate
+    /// sweep the gap between "certified clean" and "deleted" is the sweep's
+    /// whole duration — minutes, not the sub-millisecond window the paragraph
+    /// above describes for the ACTIVE-SESSION check. [`inspect_dirt`] is
+    /// therefore re-run immediately before each individual
+    /// `remove_session_worktree`, so the authoritative verdict is adjacent to
+    /// the deletion. The Phase 1.5 pass is kept because it is what `dry_run`
+    /// reports and what keeps a preview honest. Two extra git invocations per
+    /// candidate is nothing against a `remove_dir_all` of gigabytes.
+    ///
     /// Test: `prune_orphaned_worktrees_removes_orphan`,
     /// `prune_orphaned_worktrees_spares_active`,
     /// `prune_orphaned_worktrees_store_snapshot_blocks_deletion` (item 1),
@@ -893,24 +909,9 @@ impl SessionManager {
                         continue;
                     }
                     // #4091: last gate — never destroy unsaved work.
-                    if let Some(dirt) = inspect_dirt(&candidate) {
-                        if policy == DirtyWorktreePolicy::Skip {
-                            warn!(
-                                path = %candidate.display(),
-                                reason = %dirt.reason,
-                                "prune-worktrees: candidate holds unsaved work — refusing to \
-                                 remove it; re-run with an explicit discard opt-in only if the \
-                                 work is genuinely disposable (#4091)"
-                            );
-                            skipped_dirty.push(dirt);
-                            continue;
-                        }
-                        warn!(
-                            path = %candidate.display(),
-                            reason = %dirt.reason,
-                            "prune-worktrees: DISCARDING unsaved work — explicit \
-                             force-discard opt-in was supplied (#4091)"
-                        );
+                    if let Some(dirt) = dirt_blocks_removal(&candidate, policy, "scan") {
+                        skipped_dirty.push(dirt);
+                        continue;
                     }
                     reclaimable.push(candidate);
                 }
@@ -1019,6 +1020,14 @@ impl SessionManager {
                 continue;
             }
 
+            // #4118 TOCTOU: the scan-time verdict is now minutes old. Re-ask
+            // immediately before THIS removal so the clean-to-deleted window is
+            // sub-millisecond again rather than the whole sweep's duration.
+            if let Some(dirt) = dirt_blocks_removal(&candidate, policy, "pre-removal") {
+                skipped_dirty.push(dirt);
+                continue;
+            }
+
             info!(path = %candidate.display(), "prune-worktrees: removing orphaned worktree");
             let candidate_clone = candidate.clone();
             let removed_ok =
@@ -1110,6 +1119,26 @@ impl SessionManager {
 
         let mut reaped = 0usize;
         for record in stale {
+            // #4118: `decommission` reaches the SAME `remove_session_worktree`
+            // (worktree remove --force + remove_dir_all + branch -D) as the
+            // orphan sweep, but never passed through the #4091 guard — and this
+            // reaper fires automatically on every daemon GC tick. Guarding one
+            // sweep while its sibling deletes freely is a half-measure. There is
+            // no discard opt-in here by design: an automatic reaper must never
+            // be able to destroy work.
+            if let Some(dirt) = record
+                .workspace_path
+                .as_deref()
+                .filter(|p| super::decommission::is_session_worktree(p))
+                .and_then(inspect_dirt)
+            {
+                warn!(
+                    id = %record.id, path = %dirt.path.display(), reason = %dirt.reason,
+                    "auto-reap: workspace holds unsaved work — leaving the session in \
+                     place for an operator (#4118)"
+                );
+                continue;
+            }
             match self.decommission(&record.id, None).await {
                 Ok(_) => {
                     reaped += 1;

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -1126,12 +1126,14 @@ impl SessionManager {
             // sweep while its sibling deletes freely is a half-measure. There is
             // no discard opt-in here by design: an automatic reaper must never
             // be able to destroy work.
-            if let Some(dirt) = record
-                .workspace_path
-                .as_deref()
-                .filter(|p| super::decommission::is_session_worktree(p))
-                .and_then(inspect_dirt)
-            {
+            //
+            // Checked UNCONDITIONALLY, not just for `.worktrees/<leaf>` paths:
+            // `decommission` also `remove_dir_all`s the whole workspace when
+            // `workspace_owned` is true, which an `is_session_worktree` filter
+            // would have excused entirely. No current call site sets that flag,
+            // but it is persisted store data that outlives upgrades — and "no
+            // caller does this today" is not a safety property.
+            if let Some(dirt) = record.workspace_path.as_deref().and_then(inspect_dirt) {
                 warn!(
                     id = %record.id, path = %dirt.path.display(), reason = %dirt.reason,
                     "auto-reap: workspace holds unsaved work — leaving the session in \

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -1003,6 +1003,166 @@ async fn prune_orphaned_worktrees_reclaims_clean_pushed_worktree() {
     );
 }
 
+/// #4118 TOCTOU: a candidate that goes dirty AFTER the Phase 1.5 scan but
+/// BEFORE its own removal must not be removed.
+///
+/// Why: the scan classifies every candidate up front and the removal loop runs
+/// afterwards, so across a ~95-candidate / ~730 GB sweep the gap between
+/// "certified clean" and "deleted" is the whole sweep duration — minutes, not
+/// the sub-millisecond window `prune_orphaned_worktrees` documents for the
+/// active-session check. Re-checking adjacent to the deletion is what closes it.
+///
+/// Both candidates scan CLEAN — asserted below, so the test cannot pass because
+/// `zzz-victim` was dirty from the start. `find_orphaned_worktrees` sorts its
+/// candidates, so `aaa-remover` is always processed first. A watcher waits for
+/// `aaa-remover`'s directory to disappear and only then writes an untracked
+/// file into `zzz-victim`: a transition that is impossible during Phase 1.5 and
+/// guaranteed to land before `zzz-victim`'s own removal.
+///
+/// The window is not a gamble. `remove_session_worktree` runs
+/// `git worktree prune` and `git branch -D` AFTER the directory is gone — two
+/// process spawns, tens of milliseconds — while the watcher polls at 200 µs and
+/// the loop needs only a `canonicalize` before re-checking. The watcher also
+/// reports whether it fired, so a lost race FAILS the test rather than passing
+/// it vacuously.
+///
+/// Without the pre-removal re-check, `zzz-victim` is still on the Phase 1.5
+/// `reclaimable` list and is handed to `remove_session_worktree` regardless.
+#[tokio::test]
+async fn prune_orphaned_worktrees_rechecks_dirt_immediately_before_removal() {
+    let (mgr, _store, fx, remover) = reclaimable_fixture("aaa-remover").await;
+    let victim = fx.add_worktree("zzz-victim");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&victim);
+
+    // Both are clean and reclaimable RIGHT NOW — assert it, so the test cannot
+    // pass because the victim was dirty from the start.
+    let preview = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], true, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("dry run must not error");
+    assert!(
+        preview.skipped_dirty.is_empty() && preview.removed.len() == 2,
+        "premise broken: both candidates must scan CLEAN; got removed={:?} skipped={:?}",
+        preview.removed,
+        preview.skipped_dirty
+    );
+
+    let fired = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let watcher = {
+        let (remover, victim, fired) = (remover.clone(), victim.clone(), fired.clone());
+        std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+            while remover.exists() {
+                if std::time::Instant::now() > deadline {
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_micros(200));
+            }
+            std::fs::write(victim.join("notes.md"), "written mid-sweep\n").unwrap();
+            fired.store(true, std::sync::atomic::Ordering::SeqCst);
+        })
+    };
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+    watcher.join().expect("watcher thread");
+
+    assert!(
+        fired.load(std::sync::atomic::Ordering::SeqCst),
+        "the watcher never observed the first removal, so nothing was tested"
+    );
+    assert!(
+        outcome.removed.iter().any(|p| p == &remover),
+        "the first candidate was clean throughout and must still be reclaimed; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        !outcome.removed.iter().any(|p| p == &victim),
+        "a candidate dirtied AFTER the scan must NOT be removed; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        victim.join("notes.md").exists(),
+        "the work written mid-sweep must still be on disk"
+    );
+    assert!(
+        outcome.skipped_dirty.iter().any(|d| d.path == victim),
+        "the mid-sweep skip must be REPORTED, not merely logged; got {:?}",
+        outcome.skipped_dirty
+    );
+}
+
+/// #4118: the age-based auto-reaper reaches the SAME destructive sequence
+/// (`worktree remove --force` → `remove_dir_all` → `branch -D`) without going
+/// through the orphan sweep, and it fires automatically on every daemon GC
+/// tick. Guarding one sweep while its sibling deletes freely is a half-measure.
+///
+/// There is deliberately no discard opt-in on this path: an automatic reaper
+/// must never be able to destroy work, whatever an operator asks for elsewhere.
+#[tokio::test]
+async fn reap_aged_ephemeral_spares_a_worktree_holding_unsaved_work() {
+    let store_dir = tempfile::tempdir().unwrap();
+    let mgr = SessionManager::new(
+        store_dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("aged-ephemeral");
+    std::fs::write(wt.join("rescued.rs"), "// never committed\n").unwrap();
+
+    let id = crate::session_manager::record::ManagedSessionId::new();
+    let record = crate::session_manager::record::SessionRecord {
+        id,
+        tmux_name: format!("tmpm-aged-{id}"),
+        cwd: fx.repo.clone(),
+        task: "aged".into(),
+        state: crate::session_manager::record::ManagedSessionState::Active,
+        created_at: chrono::Utc::now() - chrono::Duration::hours(2),
+        last_activity_at: None,
+        workspace_path: Some(wt.clone()),
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: true,
+        workspace_owned: false,
+        source_id: None,
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: Default::default(),
+        worktree_owner: None,
+    };
+    mgr.store.write().await.upsert(record).await.expect("seed");
+
+    let reaped = mgr
+        .reap_aged_ephemeral(chrono::Duration::hours(1))
+        .await
+        .expect("reap must not error");
+
+    assert_eq!(
+        reaped, 0,
+        "an aged ephemeral holding uncommitted work must not be auto-reaped"
+    );
+    assert!(
+        wt.join("rescued.rs").exists(),
+        "the uncommitted work must still be on disk"
+    );
+    assert_eq!(
+        mgr.get(&id).await.unwrap().state,
+        crate::session_manager::record::ManagedSessionState::Active,
+        "the record must be left for an operator, not silently decommissioned"
+    );
+}
+
 /// A worktree with MODIFIED TRACKED files must not be removed, and the skip
 /// must be visible in the return value — not merely logged.
 #[tokio::test]

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -208,7 +208,7 @@ async fn prune_orphaned_worktrees_store_snapshot_blocks_deletion() {
     // runs — still never removed, now for the #3649 safe-default reason
     // rather than (only) the #1845 TOCTOU fresh-snapshot reason.
     let outcome = mgr
-        .prune_orphaned_worktrees(repos_tmp.path(), &[], false)
+        .prune_orphaned_worktrees(repos_tmp.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -334,7 +334,7 @@ async fn prune_orphaned_worktrees_never_deletes_claude_native_worktree() {
     // `isolation: "worktree"` mechanism never writes trusty-mpm's sentinel.
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -442,7 +442,7 @@ async fn prune_orphaned_worktrees_never_deletes_base_claude_native_worktree() {
     // Deliberately NO sentinel file written.
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -497,7 +497,7 @@ async fn prune_orphaned_worktrees_never_deletes_nested_session_claude_worktree()
     // candidate for each scanned shape).
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -541,7 +541,7 @@ async fn prune_orphaned_worktrees_skips_owner_unknown() {
     // Deliberately NO sentinel file written — simulates a legacy worktree.
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -614,7 +614,7 @@ async fn prune_orphaned_worktrees_reclaims_terminal_owner() {
     .expect("write sentinel");
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -663,7 +663,7 @@ async fn prune_orphaned_worktrees_spares_recent_unregistered_owner() {
     .expect("write sentinel");
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -731,7 +731,7 @@ async fn prune_orphaned_worktrees_spares_live_owner() {
     .expect("write sentinel");
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false)
+        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -938,4 +938,281 @@ fn canonicalize_streak_evicts_paths_no_longer_active() {
         3,
         "a path still present in the active set must be untouched by eviction"
     );
+}
+
+// ── #4091: the dirty-tree gate, wired into the reclaim path ──────────────
+//
+// Every test below builds a REAL git checkout + worktree in a throwaway
+// `tempfile::tempdir()` via `GitWorktreeFixture`, stamps it with an aged
+// ownership sentinel so the #3649 owner gate PASSES (otherwise the candidate
+// would be spared for the wrong reason and prove nothing), and then asserts
+// what the #4091 gate does with it. No live worktree is ever touched.
+
+use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+
+/// Build a manager plus a fixture whose worktree `name` is fully reclaimable
+/// as far as the #3649 ownership gate is concerned — so the ONLY thing that
+/// can still spare it is the #4091 dirty gate.
+async fn reclaimable_fixture(
+    name: &str,
+) -> (
+    SessionManager,
+    tempfile::TempDir,
+    GitWorktreeFixture,
+    std::path::PathBuf,
+) {
+    let store_dir = tempfile::tempdir().unwrap();
+    let mgr = SessionManager::new(
+        store_dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree(name);
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+    (mgr, store_dir, fx, wt)
+}
+
+/// The control case: a genuinely clean, fully-pushed, owner-known stale
+/// worktree IS still reclaimed. Without this the guard could "pass" every
+/// other test simply by never deleting anything, which would be a silent leak
+/// rather than a fix.
+#[tokio::test]
+async fn prune_orphaned_worktrees_reclaims_clean_pushed_worktree() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("clean-pushed").await;
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.skipped_dirty.is_empty(),
+        "a clean worktree must not be reported dirty; got {:?}",
+        outcome.skipped_dirty
+    );
+    assert!(
+        outcome.removed.iter().any(|p| p == &wt),
+        "a clean, fully-pushed, owner-known stale worktree must still be reclaimed; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        !wt.exists(),
+        "the reclaimed worktree must be gone from disk"
+    );
+}
+
+/// A worktree with MODIFIED TRACKED files must not be removed, and the skip
+/// must be visible in the return value — not merely logged.
+#[tokio::test]
+async fn prune_orphaned_worktrees_skips_modified_tracked_file() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("modified").await;
+    std::fs::write(wt.join("README.md"), "uncommitted edit\n").unwrap();
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "a worktree with modified tracked files must NOT be removed; got {:?}",
+        outcome.removed
+    );
+    let dirt = outcome
+        .skipped_dirty
+        .iter()
+        .find(|d| d.path == wt)
+        .expect("the skip must be reported in skipped_dirty, not just logged");
+    assert_eq!(dirt.dirty_files, 1, "reason: {}", dirt.reason);
+    assert!(wt.exists(), "the dirty worktree must survive on disk");
+}
+
+/// A worktree holding ONLY untracked (non-ignored) files must not be removed.
+/// Untracked work exists nowhere else at all.
+#[tokio::test]
+async fn prune_orphaned_worktrees_skips_untracked_file() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("untracked").await;
+    std::fs::write(wt.join("scratch-notes.md"), "never added to git\n").unwrap();
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "a worktree with untracked files must NOT be removed; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        outcome.skipped_dirty.iter().any(|d| d.path == wt),
+        "the untracked-file skip must be reported; got {:?}",
+        outcome.skipped_dirty
+    );
+    assert!(wt.exists(), "the dirty worktree must survive on disk");
+}
+
+/// A worktree whose work is COMMITTED but never pushed must not be removed.
+/// This is the case that looks safe and is not: `remove_session_worktree`
+/// deletes the `session/<leaf>` branch, taking the commit's last reachable
+/// ref with it.
+#[tokio::test]
+async fn prune_orphaned_worktrees_skips_unpushed_commit() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("unpushed").await;
+    GitWorktreeFixture::commit_unpushed(&wt);
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "a worktree with unpushed commits must NOT be removed; got {:?}",
+        outcome.removed
+    );
+    let dirt = outcome
+        .skipped_dirty
+        .iter()
+        .find(|d| d.path == wt)
+        .expect("the unpushed-commit skip must be reported");
+    assert_eq!(dirt.unpushed_commits, 1, "reason: {}", dirt.reason);
+    assert!(wt.exists(), "the worktree must survive on disk");
+}
+
+/// FAIL-SAFE, end to end: when the dirty check itself cannot complete, the
+/// candidate is SKIPPED, never removed. An error on the check must never be a
+/// green light to delete — that would invert the entire guard.
+///
+/// The failure is injected by replacing the worktree's git index with a
+/// directory, which makes `git status` exit 128 while leaving the worktree
+/// registration intact (so the #3649 `git worktree list` cross-check still
+/// agrees and the candidate genuinely reaches the #4091 gate).
+#[tokio::test]
+async fn prune_orphaned_worktrees_skips_when_dirty_check_errors() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("broken-index").await;
+    let index = fx
+        .repo
+        .join(".git")
+        .join("worktrees")
+        .join("broken-index")
+        .join("index");
+    std::fs::remove_file(&index).expect("remove worktree index");
+    std::fs::create_dir(&index).expect("replace index with a directory");
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "a candidate whose dirty-check errored must NOT be removed; got {:?}",
+        outcome.removed
+    );
+    let dirt = outcome
+        .skipped_dirty
+        .iter()
+        .find(|d| d.path == wt)
+        .expect("an errored dirty-check must be reported as a dirty skip");
+    assert!(
+        dirt.reason.contains("dirty-check failed"),
+        "unexpected reason: {}",
+        dirt.reason
+    );
+    assert!(
+        wt.exists(),
+        "the unexaminable worktree must survive on disk"
+    );
+}
+
+/// The explicit override DOES remove a dirty worktree — the guard is a
+/// default, not a wall. If this ever stops working the override is dead code
+/// and operators will reach for `rm -rf` instead.
+#[tokio::test]
+async fn prune_orphaned_worktrees_force_discards_dirty() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("force-discard").await;
+    std::fs::write(wt.join("README.md"), "uncommitted edit\n").unwrap();
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(
+            &fx.repos_root,
+            &[],
+            false,
+            DirtyWorktreePolicy::ForceDiscard,
+        )
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.iter().any(|p| p == &wt),
+        "the explicit force-discard opt-in must remove a dirty worktree; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        outcome.skipped_dirty.is_empty(),
+        "force-discard reports nothing as skipped; got {:?}",
+        outcome.skipped_dirty
+    );
+    assert!(!wt.exists(), "the force-discarded worktree must be gone");
+}
+
+/// REGRESSION (#4091): the DEFAULT policy — the one the `/tm-session-pause`
+/// path and the periodic daemon orphan-GC both use, neither of which has any
+/// argument that could change it — cannot delete dirty work.
+///
+/// Asserting `DirtyWorktreePolicy::default()` here (rather than naming `Skip`)
+/// is deliberate: it fails if anyone ever flips the default, which is the only
+/// way the pause path could silently gain destructive behaviour.
+#[tokio::test]
+async fn prune_orphaned_worktrees_default_policy_cannot_delete_dirty_work() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("default-policy").await;
+    std::fs::write(wt.join("precious.txt"), "hours of work\n").unwrap();
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::default())
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "the DEFAULT prune policy must never delete dirty work; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        wt.exists(),
+        "the dirty worktree must survive the default sweep"
+    );
+    assert_eq!(
+        std::fs::read_to_string(wt.join("precious.txt")).unwrap(),
+        "hours of work\n",
+        "the untracked file's contents must be intact"
+    );
+}
+
+/// A `dry_run` preview must report the same dirty skip a real run would, so an
+/// operator previewing a 95-worktree sweep sees exactly what will be spared.
+#[tokio::test]
+async fn prune_orphaned_worktrees_dry_run_reports_dirty_skip() {
+    let (mgr, _store, fx, wt) = reclaimable_fixture("dry-run-dirty").await;
+    std::fs::write(wt.join("README.md"), "uncommitted edit\n").unwrap();
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], true, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.is_empty(),
+        "dry-run must not list a dirty worktree as would-remove; got {:?}",
+        outcome.removed
+    );
+    assert!(
+        outcome.skipped_dirty.iter().any(|d| d.path == wt),
+        "dry-run must report the dirty skip; got {:?}",
+        outcome.skipped_dirty
+    );
+    assert!(wt.exists(), "dry-run must not touch anything");
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -163,6 +163,52 @@ impl GitWorktreeFixture {
         .expect("fixture: write sentinel");
     }
 
+    /// Add a nested git worktree of the SAME repo INSIDE `parent`, at
+    /// `<parent>/<rel>` (#4118).
+    ///
+    /// Why: this is the shape that made the guard bypassable — Claude Code's
+    /// `isolation: "worktree"` agents create `.claude/worktrees/<name>` inside a
+    /// session checkout, this repo's `main` gitignores that path, and seven of
+    /// them were live inside `.base/.worktrees/2eb72dca-…` while the parent
+    /// reported `dirty_files = 0`.
+    /// What: `git worktree add -b agent/<name>` under `parent`. Returns the
+    /// nested worktree path.
+    /// Test: `inspect_dirt_reports_nested_gitignored_worktree`.
+    pub(crate) fn add_nested_worktree(&self, parent: &Path, rel: &str, name: &str) -> PathBuf {
+        let nested = parent.join(rel).join(name);
+        git_ok(
+            &self.repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                &format!("agent/{name}"),
+                nested.to_str().expect("utf8 nested worktree path"),
+            ],
+        );
+        git_ok(&nested, &["config", "user.email", "ci@test.invalid"]);
+        git_ok(&nested, &["config", "user.name", "CI"]);
+        git_ok(&nested, &["config", "commit.gpgsign", "false"]);
+        nested
+    }
+
+    /// Commit everything in `wt` and push it, so the worktree reads CLEAN.
+    ///
+    /// Why: several #4118 tests need a parent worktree whose ONLY dirt is the
+    /// thing under test (a nested checkout, a `.trusty-mpm/` artefact). Setting
+    /// those up requires committing a `.gitignore` first, and an uncommitted or
+    /// unpushed `.gitignore` would make the parent dirty for the wrong reason —
+    /// the test would pass without exercising anything.
+    /// What: stages all, commits, pushes the current branch to `origin` under
+    /// its own name, and fetches so the remote-tracking ref exists locally.
+    /// Test: `inspect_dirt_reports_nested_gitignored_worktree`.
+    pub(crate) fn commit_all_and_push(wt: &Path, msg: &str) {
+        git_ok(wt, &["add", "-A"]);
+        git_ok(wt, &["commit", "-m", msg]);
+        git_ok(wt, &["push", "origin", "HEAD"]);
+        git_ok(wt, &["fetch", "origin"]);
+    }
+
     /// Commit a new file inside `wt` without pushing it anywhere.
     ///
     /// Why: this is the "committed but unpushed" case — the one that looks

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -1,0 +1,180 @@
+//! Shared REAL-git fixtures for the #4091 dirty-worktree-guard tests.
+//!
+//! Why: the guard's whole value is that it reads real `git status` /
+//! `git rev-list` output, so a mocked git would test nothing. Both
+//! `worktree_safety_tests` (the checker in isolation) and `prune_orphan_tests`
+//! (the checker wired into the reclaim path) need the same non-trivial
+//! setup — a checkout with a remote, a pushed `main`, and a per-session
+//! worktree carrying an aged #3649 ownership sentinel so the owner gate lets
+//! the candidate through to the dirty gate — so it is built once here rather
+//! than twice.
+//!
+//! These fixtures are built entirely inside a fresh `tempfile::TempDir`.
+//! Nothing here ever touches a real worktree; deleting a live worktree is the
+//! exact failure #4091 exists to prevent.
+//!
+//! What: [`GitWorktreeFixture`], which owns the temp dir and exposes
+//! `repos_root` (the `<repos_root>/<owner>/<repo>/` shape
+//! `find_orphaned_worktrees` walks) plus helpers to add worktrees and dirty
+//! them.
+//! Test: exercised by every `#4091` test in `worktree_safety_tests` and
+//! `prune_orphan_tests`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use super::record::ManagedSessionId;
+
+/// A throwaway `<repos_root>/owner/repo` checkout with a bare remote (#4091).
+///
+/// Why: `prune_orphaned_worktrees` walks `<repos_root>/<owner>/<repo>/…`, the
+/// `git worktree list` cross-check resolves the repo root as the candidate's
+/// GRANDPARENT, and the unpushed-commit check needs real remote-tracking refs.
+/// One fixture has to satisfy all three at once.
+/// What: owns the `TempDir` (dropped = everything cleaned up) and exposes the
+/// repos root and the checkout path.
+/// Test: used by `inspect_dirt_clean_pushed_worktree_is_none` and friends.
+pub(crate) struct GitWorktreeFixture {
+    /// Kept alive so the temp tree outlives the test.
+    _tmp: tempfile::TempDir,
+    /// The `<repos_root>` that `prune_orphaned_worktrees` should be pointed at.
+    pub repos_root: PathBuf,
+    /// The checkout at `<repos_root>/owner/repo`.
+    pub repo: PathBuf,
+}
+
+/// Run `git -C <dir> <args>`, panicking with git's own stderr on failure.
+///
+/// Why: a fixture step that silently no-ops produces a test that passes for
+/// the wrong reason — exactly the "green by deleting coverage" failure mode.
+/// What: asserts the command spawned AND exited zero.
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("fixture: `git {}` could not be run: {e}", args.join(" ")));
+    assert!(
+        out.status.success(),
+        "fixture: `git {}` failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+impl GitWorktreeFixture {
+    /// Build a checkout on `main`, pushed to a bare remote in the same temp dir.
+    ///
+    /// Why: "clean and fully pushed" is the state the guard must still allow to
+    /// be reclaimed, so the happy path needs a genuine remote-tracking ref to
+    /// measure against — without one, every commit is legitimately unpushed and
+    /// the guard would (correctly, but uninterestingly) skip everything.
+    /// What: `git init` a bare remote and a working checkout, make one commit,
+    /// push it, and fetch so `refs/remotes/origin/main` exists locally.
+    /// Test: `inspect_dirt_clean_pushed_worktree_is_none`.
+    pub(crate) fn new() -> Self {
+        let tmp = tempfile::tempdir().expect("fixture: tempdir");
+        let repos_root = tmp.path().join("repos");
+        let repo = repos_root.join("owner").join("repo");
+        let remote = tmp.path().join("remote.git");
+        std::fs::create_dir_all(&repo).expect("fixture: create repo dir");
+        std::fs::create_dir_all(&remote).expect("fixture: create remote dir");
+
+        git_ok(&remote, &["init", "--bare", "--initial-branch=main"]);
+        git_ok(&repo, &["init", "--initial-branch=main"]);
+        git_ok(&repo, &["config", "user.email", "ci@test.invalid"]);
+        git_ok(&repo, &["config", "user.name", "CI"]);
+        git_ok(&repo, &["config", "commit.gpgsign", "false"]);
+        std::fs::write(repo.join("README.md"), "base\n").expect("fixture: write README");
+        git_ok(&repo, &["add", "README.md"]);
+        git_ok(&repo, &["commit", "-m", "base"]);
+        git_ok(
+            &repo,
+            &[
+                "remote",
+                "add",
+                "origin",
+                remote.to_str().expect("utf8 remote"),
+            ],
+        );
+        git_ok(&repo, &["push", "origin", "main"]);
+        git_ok(&repo, &["fetch", "origin"]);
+
+        Self {
+            _tmp: tmp,
+            repos_root,
+            repo,
+        }
+    }
+
+    /// Add a real per-session worktree at `<repo>/.worktrees/<name>`.
+    ///
+    /// Why: the reclaim path only ever considers leaf dirs under a
+    /// `.worktrees`-shaped parent, and `git_worktree_list_agrees` requires the
+    /// path to be a genuinely registered worktree — a bare `mkdir` would be
+    /// rejected before the dirty gate ever ran.
+    /// What: `git worktree add -b session/<name>` off the current `HEAD`.
+    /// Returns the worktree path.
+    /// Test: `inspect_dirt_clean_pushed_worktree_is_none`.
+    pub(crate) fn add_worktree(&self, name: &str) -> PathBuf {
+        let wt = self.repo.join(".worktrees").join(name);
+        git_ok(
+            &self.repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                &format!("session/{name}"),
+                wt.to_str().expect("utf8 worktree path"),
+            ],
+        );
+        git_ok(&wt, &["config", "user.email", "ci@test.invalid"]);
+        git_ok(&wt, &["config", "user.name", "CI"]);
+        git_ok(&wt, &["config", "commit.gpgsign", "false"]);
+        wt
+    }
+
+    /// Stamp `wt` with an ownership sentinel old enough to clear the #3649
+    /// grace window, naming an owner that will never resolve to a record.
+    ///
+    /// Why: without this the #3649 gate classifies the candidate as
+    /// owner-unknown and skips it BEFORE the #4091 dirty gate runs, so the
+    /// test would pass without exercising anything. The sentinel is what makes
+    /// these fixtures genuinely reclaimable, which is the only condition under
+    /// which the dirty gate is load-bearing.
+    /// What: writes an aged [`super::worktree_ownership::WorktreeSentinel`] for
+    /// a fresh, never-registered [`ManagedSessionId`].
+    /// Test: `prune_orphaned_worktrees_reclaims_clean_pushed_worktree`.
+    pub(crate) fn stamp_reclaimable_sentinel(wt: &Path) {
+        let aged = chrono::Utc::now()
+            - super::worktree_ownership::OWNERLESS_GRACE
+            - chrono::Duration::minutes(1);
+        let payload = serde_json::to_vec(&super::worktree_ownership::WorktreeSentinel {
+            owner_session_id: ManagedSessionId::new(),
+            created_at: aged,
+        })
+        .expect("fixture: serialize sentinel");
+        std::fs::write(
+            wt.join(super::decommission::WORKTREE_SENTINEL_FILE),
+            payload,
+        )
+        .expect("fixture: write sentinel");
+    }
+
+    /// Commit a new file inside `wt` without pushing it anywhere.
+    ///
+    /// Why: this is the "committed but unpushed" case — the one that looks
+    /// safe (the work IS committed) but is destroyed anyway, because
+    /// `decommission::remove_session_worktree` runs
+    /// `git branch -D session/<leaf>` after a successful removal and takes the
+    /// commit's last reachable ref with it.
+    /// What: writes `unpushed.txt`, stages it, and commits.
+    /// Test: `inspect_dirt_reports_unpushed_commit`.
+    pub(crate) fn commit_unpushed(wt: &Path) {
+        std::fs::write(wt.join("unpushed.txt"), "local only\n").expect("fixture: write file");
+        git_ok(wt, &["add", "unpushed.txt"]);
+        git_ok(wt, &["commit", "-m", "local only"]);
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_nested.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_nested.rs
@@ -1,0 +1,441 @@
+//! Nested-repository discovery and loss-model selection for the #4091
+//! dirty-worktree guard (split out of `worktree_safety.rs` in the #4118 round 3
+//! review, which took that file to its 500-SLOC cap).
+//!
+//! Why: `git status` on a candidate says NOTHING about a checkout nested inside
+//! it, and deleting the candidate deletes that checkout too. Two shapes of
+//! nested repository exist beneath a session worktree, they lose completely
+//! different things when the candidate is removed, and **assessing one with the
+//! other's model manufactures false confidence** — which is worse than not
+//! looking at all, because the sweep then deletes with a clean bill of health:
+//!
+//! - A **registered worktree** of the enclosing repository (the
+//!   `.claude/worktrees/<name>` agent shape). Its object store and ref
+//!   namespace live in the SHARED `.base/.git`, *outside* the candidate, and
+//!   survive its removal. Only its working tree and the branch
+//!   `decommission` force-deletes are at risk — the same model that is correct
+//!   for the candidate itself.
+//! - A **self-contained clone** — someone ran `git clone` into a gitignored
+//!   scratch directory. Its `.git` lives INSIDE the candidate, so **every**
+//!   local branch, tag, stash entry and reflog dies with it. Asking only about
+//!   `HEAD` is close to asking nothing: a clone whose HEAD is on a pushed
+//!   `main` while a `feature` branch holds the only copy of a commit reads
+//!   perfectly clean.
+//!
+//! What: [`nested_dirt`] (the entry point), [`nested_repo_roots`] (exact
+//! enumeration — registered worktrees from git's own bookkeeping, unregistered
+//! clones from a bounded on-disk walk), and the loss-model discriminator
+//! [`object_store_dies_with`].
+//!
+//! The discriminator is `git rev-parse --path-format=absolute --git-common-dir`,
+//! and it is a direct test of the question that matters — *does this
+//! repository's object store live inside the directory we are about to
+//! delete?* — rather than a proxy for how the repository was created. Measured
+//! on both shapes under one candidate:
+//!
+//! ```text
+//! candidate           : …/base/.worktrees/candidate
+//! registered worktree : …/base/.git                              <- OUTSIDE, survives
+//! self-contained clone: …/base/.worktrees/candidate/scratch/work/.git  <- INSIDE, dies
+//! ```
+//!
+//! FAIL-SAFE DIRECTION, unchanged from `worktree_safety`: every error here —
+//! an unreadable directory, a git subprocess that will not run, an exhausted
+//! scan budget, a path this code cannot spell — resolves to DIRTY.
+//! Test: `worktree_nested_tests`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use super::worktree_safety::{DirtyWorktree, count_dirty_files, git_stdout, inspect_dirt_at};
+
+/// Directory names whose contents are regenerable build/cache output (#4118).
+///
+/// Why: the nested-repository scan has to walk gitignored subtrees, and those
+/// are dominated by exactly two things — enormous disposable build output, and
+/// the occasional nested checkout that holds real work. Walking `target/` on 95
+/// candidates would cost minutes and find nothing; skipping it by NAME is the
+/// difference between a scan that runs and one that gets disabled. These names
+/// are regenerable by definition: no tool writes work-of-record into them, and
+/// losing them costs only CPU.
+/// What: matched against a directory's own file name at any depth. A nested
+/// repository underneath one of these is NOT seen — see the residual-risk note
+/// in `worktree_safety`.
+/// Test: `inspect_dirt_does_not_scan_disposable_build_dirs`.
+const DISPOSABLE_DIR_NAMES: &[&str] = &[
+    "target",
+    "node_modules",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".turbo",
+    ".parcel-cache",
+    ".cache",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    ".gradle",
+    "coverage",
+    ".terraform",
+];
+
+/// Directory entries the gitignored-subtree scan may visit per candidate.
+///
+/// Why: an unbounded walk of an arbitrary ignored tree is a denial-of-service
+/// against the sweep. Measured against this repo's own 31 session worktrees, a
+/// FULL-tree walk with [`DISPOSABLE_DIR_NAMES`] pruning visited 5.6k entries per
+/// worktree on average; the ignored-only subset is far smaller, so 50k is two
+/// orders of magnitude of headroom.
+/// What: exceeding the budget is an ERROR, which the caller turns into DIRTY —
+/// "I could not finish looking" is never "there is nothing there".
+const IGNORED_SCAN_ENTRY_BUDGET: usize = 50_000;
+
+/// Collapsed listing of gitignored entries, used to bound the nested-repo scan.
+const IGNORED_STATUS_ARGS: &[&str] = &[
+    "status",
+    "--porcelain",
+    "--untracked-files=normal",
+    "--ignored",
+    "--ignore-submodules=none",
+];
+
+/// Does a NESTED repository under this candidate hold unsaved work (#4091)?
+///
+/// Why: this is the hole that made the whole guard bypassable. Deleting the
+/// candidate deletes everything inside it, but `git status` on the candidate
+/// says nothing about a nested checkout — `.claude/worktrees/` is gitignored on
+/// this repo's `main` (`.gitignore:40`), so seven registered agent worktrees
+/// inside `.base/.worktrees/2eb72dca-…` produced `dirty_files = 0`. Worse, the
+/// #3649 ownership gate deliberately REFUSES to delete those nested worktrees
+/// directly (no sentinel ⇒ owner-unknown), so the sweep would have honoured
+/// that refusal and then deleted the directory they live in — bypassing its own
+/// guard by removing the parent.
+/// What: every nested root from [`nested_repo_roots`] is inspected under the
+/// loss model that actually applies to it (see [`object_store_dies_with`]). A
+/// nested root that is dirty OR unassessable makes the PARENT dirty; one that
+/// is provably safe does not, so a session that merely once spawned an agent
+/// worktree stays reclaimable. The reported counts are the nested root's own.
+/// Test: `inspect_dirt_reports_nested_gitignored_worktree`,
+/// `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`,
+/// `inspect_dirt_reports_self_contained_clone_with_work_on_another_branch`,
+/// `inspect_dirt_allows_clean_nested_worktree`.
+pub(super) fn nested_dirt(candidate: &Path) -> Option<DirtyWorktree> {
+    let canonical = match std::fs::canonicalize(candidate) {
+        Ok(c) => c,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                candidate,
+                format!("candidate is unreadable: {e}"),
+                0,
+                0,
+            ));
+        }
+    };
+    let roots = match nested_repo_roots(candidate, &canonical) {
+        Ok(r) => r,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                candidate,
+                format!("nested-repository scan failed: {e}"),
+                0,
+                0,
+            ));
+        }
+    };
+    for root in roots {
+        // A nested root that is provably safe does not pin the parent.
+        let Some(inner) = inspect_nested_root(&root, &canonical) else {
+            continue;
+        };
+        let shown = root
+            .strip_prefix(&canonical)
+            .unwrap_or(&root)
+            .display()
+            .to_string();
+        return Some(DirtyWorktree::new(
+            candidate,
+            format!(
+                "nested git worktree/repository `{shown}` holds unsaved work \
+                 that `git status` on this directory cannot see: {}",
+                inner.reason
+            ),
+            inner.dirty_files,
+            inner.unpushed_commits,
+        ));
+    }
+    None
+}
+
+/// Inspect one nested root under the loss model that applies to it (#4118).
+///
+/// Why: see the module header. Using the shared-store model on a self-contained
+/// clone is a demonstrated false CLEAN with unrecoverable loss.
+/// What: dispatches on [`object_store_dies_with`]. A discriminator that cannot
+/// answer is DIRTY — not knowing which model applies means not knowing what
+/// removal costs.
+/// Test: `inspect_dirt_reports_self_contained_clone_with_work_on_another_branch`,
+/// `inspect_dirt_allows_clean_nested_worktree`.
+fn inspect_nested_root(root: &Path, candidate: &Path) -> Option<DirtyWorktree> {
+    match object_store_dies_with(root, candidate) {
+        // Shared store outside the candidate: only the working tree and the
+        // force-deleted branch are at risk — the top-level model.
+        Ok(false) => inspect_dirt_at(root, false),
+        Ok(true) => self_contained_dirt(root),
+        Err(e) => Some(DirtyWorktree::new(
+            root,
+            format!("nested-repository loss-model probe failed: {e}"),
+            0,
+            0,
+        )),
+    }
+}
+
+/// Would removing `candidate` destroy `root`'s entire object store (#4118)?
+///
+/// Why: this is the whole question, asked directly instead of inferred from how
+/// the repository was created. `git rev-parse --git-common-dir` resolves to the
+/// directory holding the objects, refs and reflogs that a worktree shares — the
+/// shared `.base/.git` for a registered worktree, and its own `.git` for a
+/// standalone clone. Whether that path is inside the directory about to be
+/// deleted IS the loss model.
+/// What: `Ok(true)` when the common dir is a strict descendant of `candidate`;
+/// `Ok(false)` otherwise; `Err` when git cannot answer. `--path-format=absolute`
+/// is required — the default is relative to the queried worktree, which would
+/// make the containment test meaningless.
+/// Test: `object_store_dies_with_is_false_for_a_registered_worktree`,
+/// `object_store_dies_with_is_true_for_a_self_contained_clone`.
+pub(super) fn object_store_dies_with(root: &Path, candidate: &Path) -> Result<bool, String> {
+    let raw = git_stdout(
+        root,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )?;
+    let common = PathBuf::from(raw.trim());
+    if common.as_os_str().is_empty() {
+        return Err("`rev-parse --git-common-dir` returned nothing".into());
+    }
+    let common = std::fs::canonicalize(&common).unwrap_or(common);
+    Ok(common.starts_with(candidate) && common != candidate)
+}
+
+/// Dirt check for a nested repository whose ENTIRE store dies with the
+/// candidate (#4118).
+///
+/// Why: the top-level model asks about `HEAD` and one branch because every
+/// other ref survives in the shared store. Here nothing survives, so the
+/// question widens to *everything this repository holds that exists nowhere
+/// else*. The reviewer's repro: a clone in a gitignored `scratch/`, HEAD on a
+/// pushed `main`, one commit on a `feature` branch that exists nowhere else —
+/// `status` empty, `origin/main..HEAD` = 0, no `session/<leaf>` branch, so all
+/// three top-level questions answered clean while the commit was destroyed.
+/// `--all --not --remotes` returns 3 for that same repository.
+/// What: working-tree entries, PLUS commits reachable from any local ref but
+/// from no remote-tracking ref, PLUS stash entries. A clone with no remotes at
+/// all makes `--remotes` expand to nothing, so every commit counts — the
+/// correct, conservative answer for a scratch clone nobody ever pushed.
+/// Test: `inspect_dirt_reports_self_contained_clone_with_work_on_another_branch`,
+/// `inspect_dirt_reports_self_contained_clone_holding_only_a_stash`,
+/// `inspect_dirt_allows_fully_pushed_self_contained_clone`.
+fn self_contained_dirt(root: &Path) -> Option<DirtyWorktree> {
+    let files = match count_dirty_files(root) {
+        Ok(n) => n,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                root,
+                format!("dirty-check failed: {e}"),
+                0,
+                0,
+            ));
+        }
+    };
+    let local_only = match count_local_only_commits(root) {
+        Ok(n) => n,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                root,
+                format!("dirty-check failed: {e}"),
+                files,
+                0,
+            ));
+        }
+    };
+    let stashed = match count_stash_entries(root) {
+        Ok(n) => n,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                root,
+                format!("dirty-check failed: {e}"),
+                files,
+                local_only,
+            ));
+        }
+    };
+    if files == 0 && local_only == 0 && stashed == 0 {
+        return None;
+    }
+    Some(DirtyWorktree::new(
+        root,
+        format!(
+            "self-contained clone (its object store dies with the candidate): \
+             {files} uncommitted/untracked file(s), {local_only} commit(s) on no remote \
+             across ALL local refs, {stashed} stash entr(y/ies)"
+        ),
+        files,
+        local_only,
+    ))
+}
+
+/// Count commits reachable from any local ref but from no remote-tracking ref.
+///
+/// Why: `--all` covers every branch, tag and `refs/stash`, not just `HEAD`.
+/// That breadth is the point — a self-contained clone loses all of them.
+/// What: `rev-list --count --all --not --remotes`.
+/// Test: `inspect_dirt_reports_self_contained_clone_with_work_on_another_branch`.
+fn count_local_only_commits(root: &Path) -> Result<usize, String> {
+    let raw = git_stdout(
+        root,
+        &["rev-list", "--count", "--all", "--not", "--remotes"],
+    )?;
+    raw.trim()
+        .parse::<usize>()
+        .map_err(|e| format!("unparsable rev-list count `{}`: {e}", raw.trim()))
+}
+
+/// Count stash entries, which die with a self-contained clone.
+///
+/// Why: `worktree_safety`'s residual-risk note says the stash is "repo-level,
+/// not per-worktree". True for the top-level candidate — its stash lives in the
+/// shared `.base/.git` and survives. FALSE for a self-contained clone, whose
+/// `refs/stash` and its reflog are inside the directory being deleted.
+/// What: `for-each-ref` first, because it exits 0 with EMPTY output when the ref
+/// is absent — so "no stash" is distinguishable from "git failed", which stays
+/// an `Err`. Only then is the reflog walked for a count.
+/// Test: `inspect_dirt_reports_self_contained_clone_holding_only_a_stash`.
+fn count_stash_entries(root: &Path) -> Result<usize, String> {
+    let listed = git_stdout(root, &["for-each-ref", "--format=%(refname)", "refs/stash"])?;
+    if listed.trim().is_empty() {
+        return Ok(0);
+    }
+    let log = git_stdout(root, &["reflog", "show", "--format=%H", "refs/stash"])?;
+    Ok(log.lines().filter(|l| !l.trim().is_empty()).count())
+}
+
+/// Enumerate every nested repository root strictly beneath `candidate`.
+///
+/// Why: "does this directory contain a checkout" must be answered EXACTLY, not
+/// heuristically, because the answer decides whether gigabytes get deleted. Two
+/// disjoint populations exist and neither subsumes the other: worktrees
+/// REGISTERED with the enclosing repository (the `.claude/worktrees/…` shape,
+/// free to enumerate — git already knows) and independent clones that git has
+/// never heard of (only findable on disk).
+/// What: the union of (a) `worktree list --porcelain` entries that are strict
+/// descendants of `candidate` — exact, at any depth, and immune to gitignore
+/// because git's own bookkeeping is the source — and (b) a bounded walk of the
+/// gitignored subtrees `git status --ignored` reports, looking for a `.git`
+/// entry. Untracked-but-not-ignored nested repos need no walk at all: they
+/// already surface as `??` lines in `count_dirty_files`.
+/// Test: `inspect_dirt_reports_nested_gitignored_worktree`,
+/// `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`.
+fn nested_repo_roots(candidate: &Path, canonical: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut roots: BTreeSet<PathBuf> = BTreeSet::new();
+
+    for line in git_stdout(candidate, &["worktree", "list", "--porcelain"])?.lines() {
+        let Some(raw) = line.strip_prefix("worktree ") else {
+            continue;
+        };
+        let listed = PathBuf::from(raw.trim());
+        let listed = std::fs::canonicalize(&listed).unwrap_or(listed);
+        if listed != canonical && listed.starts_with(canonical) {
+            roots.insert(listed);
+        }
+    }
+
+    let mut budget = IGNORED_SCAN_ENTRY_BUDGET;
+    for line in git_stdout(candidate, IGNORED_STATUS_ARGS)?.lines() {
+        let Some(raw) = line.strip_prefix("!! ") else {
+            continue;
+        };
+        let entry = raw.trim();
+        if entry.starts_with('"') {
+            return Err(format!(
+                "ignored entry `{entry}` has a quoted path this scan cannot interpret"
+            ));
+        }
+        scan_for_repos(
+            &canonical.join(entry.trim_end_matches('/')),
+            &mut roots,
+            &mut budget,
+        )?;
+    }
+    Ok(roots.into_iter().collect())
+}
+
+/// Walk `root`, collecting directories that contain a `.git` entry.
+///
+/// Why: an unregistered clone inside a gitignored directory is invisible to
+/// every git question asked of the CANDIDATE, so the only way to find it is to
+/// look. Iterative rather than recursive so a pathologically deep tree cannot
+/// overflow the stack, and symlinks are never followed — `remove_dir_all`
+/// deletes a link, not its target, so nothing beyond one is at risk.
+/// What: pushes each directory holding a `.git` entry into `out` and stops
+/// descending there. Skips [`DISPOSABLE_DIR_NAMES`] by name at every level.
+/// Exhausting `budget`, or any unreadable entry, is an `Err` the caller turns
+/// into DIRTY.
+/// Test: `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`,
+/// `inspect_dirt_does_not_scan_disposable_build_dirs`.
+fn scan_for_repos(
+    root: &Path,
+    out: &mut BTreeSet<PathBuf>,
+    budget: &mut usize,
+) -> Result<(), String> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        match std::fs::symlink_metadata(&dir) {
+            // A plain file, or a symlink of any kind: nothing to descend into.
+            Ok(meta) if !meta.is_dir() => continue,
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(format!("`{}` is unreadable: {e}", dir.display())),
+        }
+        let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+        if DISPOSABLE_DIR_NAMES.contains(&name) {
+            continue;
+        }
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|e| format!("`{}` is unreadable: {e}", dir.display()))?;
+        let mut children = Vec::new();
+        let mut is_repo = false;
+        for entry in entries {
+            let entry =
+                entry.map_err(|e| format!("an entry of `{}` is unreadable: {e}", dir.display()))?;
+            if *budget == 0 {
+                return Err(format!(
+                    "gitignored-subtree scan exceeded its {IGNORED_SCAN_ENTRY_BUDGET}-entry \
+                     budget at `{}`",
+                    dir.display()
+                ));
+            }
+            *budget -= 1;
+            if entry.file_name() == ".git" {
+                is_repo = true;
+                break;
+            }
+            children.push(entry.path());
+        }
+        if is_repo {
+            out.insert(dir);
+            continue;
+        }
+        stack.extend(children);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+#[path = "worktree_nested_tests.rs"]
+mod worktree_nested_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_nested_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_nested_tests.rs
@@ -1,0 +1,257 @@
+//! Unit tests for the nested-repository loss-model split (#4118 round 3).
+//!
+//! Why: the round-3 CRITICAL was not "the scan misses something" — the scan
+//! found the clone. It was that the clone was then assessed with the WRONG loss
+//! model, which is worse than not looking, because the sweep deletes with a
+//! clean bill of health. These tests pin the discriminator and both models.
+//! What: the `--git-common-dir` discriminator on both real shapes, the
+//! self-contained model (other-branch commits, stash, remote-less clones), and
+//! the counterweights that keep reclamation alive.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use std::path::{Path, PathBuf};
+
+use super::*;
+use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+use crate::session_manager::worktree_safety::inspect_dirt;
+
+/// Run `git -C <dir> <args>`, panicking with git's own stderr on failure.
+///
+/// Why: a fixture step that silently no-ops produces a test that passes for the
+/// wrong reason — precisely the failure this round is about.
+fn git_ok(dir: &Path, args: &[&str]) {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("fixture: `git {}` could not be run: {e}", args.join(" ")));
+    assert!(
+        out.status.success(),
+        "fixture: `git {}` failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+/// Build a SELF-CONTAINED clone (its own `.git`, its own remote) inside
+/// `parent`, at a path `parent` gitignores.
+///
+/// Why: this is the shape the round-3 CRITICAL is about — `git clone` into a
+/// scratch directory. Its object store lives inside the candidate, so removing
+/// the candidate destroys every ref it holds.
+/// What: a bare remote beside the fixture plus a clone at `<parent>/scratch/work`
+/// whose `main` is pushed and tracking. Returns the clone path.
+fn seed_self_contained_clone(fx: &GitWorktreeFixture, parent: &Path) -> PathBuf {
+    let remote = fx.repos_root.join("inner-remote.git");
+    std::fs::create_dir_all(&remote).unwrap();
+    git_ok(&remote, &["init", "--bare", "--initial-branch=main"]);
+
+    let clone = parent.join("scratch").join("work");
+    std::fs::create_dir_all(&clone).unwrap();
+    git_ok(&clone, &["init", "--initial-branch=main"]);
+    git_ok(&clone, &["config", "user.email", "ci@test.invalid"]);
+    git_ok(&clone, &["config", "user.name", "CI"]);
+    git_ok(&clone, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(clone.join("a.txt"), "base\n").unwrap();
+    git_ok(&clone, &["add", "a.txt"]);
+    git_ok(&clone, &["commit", "-m", "base"]);
+    git_ok(
+        &clone,
+        &["remote", "add", "origin", remote.to_str().unwrap()],
+    );
+    git_ok(&clone, &["push", "origin", "main"]);
+    git_ok(&clone, &["fetch", "origin"]);
+    git_ok(&clone, &["branch", "--set-upstream-to=origin/main", "main"]);
+    clone
+}
+
+/// A parent worktree that is clean, pushed, and gitignores `scratch/`.
+fn seed_parent(fx: &GitWorktreeFixture, name: &str) -> PathBuf {
+    let parent = fx.add_worktree(name);
+    std::fs::write(parent.join(".gitignore"), "scratch/\n.claude/worktrees/\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&parent, "ignore scratch and agent worktrees");
+    parent
+}
+
+/// THE ROUND-3 CRITICAL: a self-contained clone whose HEAD is fully pushed but
+/// which carries a commit on another local branch must make the parent DIRTY.
+///
+/// Why: every question the top-level model asks answers "clean" here — `status`
+/// is empty, `origin/main..HEAD` is 0, and there is no `session/<leaf>` branch.
+/// The commit on `feature` exists nowhere but inside the candidate, so removing
+/// the candidate destroys it. Finding the clone and then assessing it with the
+/// shared-store model manufactured confidence rather than safety.
+#[test]
+fn inspect_dirt_reports_self_contained_clone_with_work_on_another_branch() {
+    let fx = GitWorktreeFixture::new();
+    let parent = seed_parent(&fx, "clone-other-branch");
+    let clone = seed_self_contained_clone(&fx, &parent);
+    git_ok(&clone, &["checkout", "-b", "feature"]);
+    std::fs::write(clone.join("only-here.txt"), "the only copy\n").unwrap();
+    git_ok(&clone, &["add", "only-here.txt"]);
+    git_ok(&clone, &["commit", "-m", "work that only exists here"]);
+    git_ok(&clone, &["checkout", "main"]);
+
+    // Prove the premise: the OLD model really did answer clean on this clone.
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&clone)
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+        "premise broken: the clone's working tree should be clean"
+    );
+    let head = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&clone)
+        .args(["rev-list", "--count", "origin/main..HEAD"])
+        .output()
+        .unwrap();
+    assert_eq!(
+        String::from_utf8_lossy(&head.stdout).trim(),
+        "0",
+        "premise broken: the clone's HEAD should be fully pushed"
+    );
+
+    let dirt = inspect_dirt(&parent)
+        .expect("a commit living only on another local branch of a nested clone must be seen");
+    assert!(
+        dirt.reason.contains("self-contained clone"),
+        "the reason must say which loss model applied; got: {}",
+        dirt.reason
+    );
+    assert!(
+        dirt.unpushed_commits >= 1,
+        "the unreachable commit must be counted; got: {}",
+        dirt.reason
+    );
+}
+
+/// The same conflation, via the stash. A self-contained clone's `refs/stash`
+/// and its reflog live inside the candidate and die with it — unlike the
+/// top-level candidate's stash, which lives in the shared `.base/.git` and
+/// survives. The old residual-risk note asserted the top-level truth
+/// universally.
+#[test]
+fn inspect_dirt_reports_self_contained_clone_holding_only_a_stash() {
+    let fx = GitWorktreeFixture::new();
+    let parent = seed_parent(&fx, "clone-stash");
+    let clone = seed_self_contained_clone(&fx, &parent);
+    std::fs::write(clone.join("a.txt"), "stash me\n").unwrap();
+    git_ok(&clone, &["stash"]);
+
+    // Premise: stashing left the working tree clean and HEAD pushed, so the
+    // ONLY thing at risk is the stash itself.
+    let status = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&clone)
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&status.stdout).trim().is_empty(),
+        "premise broken: `git stash` should have left a clean tree"
+    );
+
+    let dirt = inspect_dirt(&parent).expect("a nested clone's stash dies with it and must be seen");
+    assert!(
+        dirt.reason.contains("stash"),
+        "the reason must name the stash; got: {}",
+        dirt.reason
+    );
+}
+
+/// A clone nobody ever pushed anywhere has no remote-tracking refs at all, so
+/// `--not --remotes` excludes nothing and every commit counts. Conservative and
+/// correct — this is the common "scratch clone" case.
+#[test]
+fn inspect_dirt_reports_remote_less_self_contained_clone() {
+    let fx = GitWorktreeFixture::new();
+    let parent = seed_parent(&fx, "clone-no-remote");
+    let clone = parent.join("scratch").join("orphan");
+    std::fs::create_dir_all(&clone).unwrap();
+    git_ok(&clone, &["init", "--initial-branch=main"]);
+    git_ok(&clone, &["config", "user.email", "ci@test.invalid"]);
+    git_ok(&clone, &["config", "user.name", "CI"]);
+    git_ok(&clone, &["config", "commit.gpgsign", "false"]);
+    std::fs::write(clone.join("solo.txt"), "never pushed anywhere\n").unwrap();
+    git_ok(&clone, &["add", "solo.txt"]);
+    git_ok(&clone, &["commit", "-m", "solo"]);
+
+    let dirt = inspect_dirt(&parent).expect("a remote-less nested clone must read as dirty");
+    assert!(
+        dirt.reason.contains("self-contained clone"),
+        "unexpected reason: {}",
+        dirt.reason
+    );
+}
+
+/// THE COUNTERWEIGHT, and it matters as much as the finding: a self-contained
+/// clone with everything pushed and nothing stashed must NOT pin the parent.
+/// Without this the new model could "pass" every test above by calling every
+/// nested clone dirty, which is a silent leak rather than a fix.
+#[test]
+fn inspect_dirt_allows_fully_pushed_self_contained_clone() {
+    let fx = GitWorktreeFixture::new();
+    let parent = seed_parent(&fx, "clone-clean");
+    seed_self_contained_clone(&fx, &parent);
+
+    assert!(
+        inspect_dirt(&parent).is_none(),
+        "a fully-pushed nested clone must not pin the parent; got {:?}",
+        inspect_dirt(&parent)
+    );
+}
+
+/// The discriminator, measured directly on a REGISTERED nested worktree: its
+/// object store is the shared `.base/.git`, outside the candidate, and survives
+/// removal. This is what keeps a clean nested agent worktree from pinning its
+/// parent — behaviour exercised live by the seven nested worktrees under
+/// `.base/.worktrees/2eb72dca-…`.
+#[test]
+fn object_store_dies_with_is_false_for_a_registered_worktree() {
+    let fx = GitWorktreeFixture::new();
+    let parent = seed_parent(&fx, "discriminator-registered");
+    let nested = fx.add_nested_worktree(&parent, ".claude/worktrees", "agentA");
+    let canonical = std::fs::canonicalize(&parent).unwrap();
+
+    assert_eq!(
+        object_store_dies_with(&nested, &canonical),
+        Ok(false),
+        "a registered worktree's store lives outside the candidate and survives it"
+    );
+}
+
+/// The other half of the discriminator: a self-contained clone's store IS
+/// inside the candidate, so everything it holds dies with the directory.
+#[test]
+fn object_store_dies_with_is_true_for_a_self_contained_clone() {
+    let fx = GitWorktreeFixture::new();
+    let parent = seed_parent(&fx, "discriminator-clone");
+    let clone = seed_self_contained_clone(&fx, &parent);
+    let canonical = std::fs::canonicalize(&parent).unwrap();
+
+    assert_eq!(
+        object_store_dies_with(&clone, &canonical),
+        Ok(true),
+        "a self-contained clone's store lives inside the candidate and dies with it"
+    );
+}
+
+/// FAIL-SAFE: when the discriminator cannot answer, the nested root is DIRTY.
+/// Not knowing which loss model applies means not knowing what removal costs.
+#[test]
+fn object_store_dies_with_errors_on_a_non_repository() {
+    let tmp = tempfile::tempdir().unwrap();
+    let plain = tmp.path().join("not-a-repo");
+    std::fs::create_dir_all(&plain).unwrap();
+
+    assert!(
+        object_store_dies_with(&plain, tmp.path()).is_err(),
+        "a directory git cannot speak for must not yield a loss-model verdict"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -60,21 +60,32 @@
 //!   session worktrees, treating every non-disposable ignored entry as dirt
 //!   would flag `.claude/` in 30 of 31 and disable reclamation outright, which
 //!   is the failure mode of a guard nobody can run.
-//! - **Anything under a [`DISPOSABLE_DIR_NAMES`] directory**, including a
-//!   nested repository inside `target/` or `node_modules/`.
+//! - **Anything under a disposable build directory** (`target/`,
+//!   `node_modules/`, …), including a nested repository inside one — see
+//!   `super::worktree_nested::DISPOSABLE_DIR_NAMES`.
 //! - **`.git/info/exclude`**, which is per-repo and on-disk and cannot be
 //!   overridden from the command line the way `core.excludesFile` can.
-//! - **`git stash` entries** — the stash is repo-level, not per-worktree.
+//! - **The stash — but only for the CANDIDATE ITSELF, and this distinction
+//!   matters.** A session worktree's stash lives in the shared `.base/.git`
+//!   *outside* the candidate, so it survives removal and is genuinely out of
+//!   scope here. A **self-contained nested clone** is the opposite case: its
+//!   `refs/stash` and reflog sit inside the directory being deleted and die
+//!   with it, so [`super::worktree_nested`] counts them. The earlier blanket
+//!   claim that "the stash is repo-level, not per-worktree" was true of the
+//!   top-level candidate and false of a nested clone — the same conflation
+//!   that produced the round-3 CRITICAL.
 //! - **Symlinked subtrees** — not followed, because `remove_dir_all` deletes
 //!   the link and not its target, so no work is at risk there.
 //! - **A repository nested inside a gitignored subtree OF a nested repository**
 //!   — the scan stops descending at the first `.git` it finds.
+//! - **The bare-branch population, partially.** `count_session_branch_unpushed`
+//!   covers both `session/<leaf>` and the bare `<leaf>` spelling, but see its
+//!   own doc for which of the two `decommission` actually force-deletes today.
 //! - **`DirtyWorktreePolicy::ForceDiscard`**, which destroys all of the above
 //!   by explicit operator opt-in.
 //!
 //! Test: `worktree_safety_tests`.
 
-use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -106,53 +117,6 @@ const DISPOSABLE_TRUSTY_MPM_FILES: &[&str] = &[
     ".trusty-mpm/scrollback.txt",
     ".trusty-mpm/last-instructions.md",
 ];
-
-/// Directory names whose contents are regenerable build/cache output (#4118).
-///
-/// Why: the nested-repository scan ([`nested_repo_roots`]) has to walk
-/// gitignored subtrees, and those are dominated by exactly two things —
-/// enormous disposable build output, and the occasional nested checkout that
-/// holds real work. Walking `target/` on 95 candidates would cost minutes and
-/// find nothing; skipping it by NAME is the difference between a scan that runs
-/// and one that gets disabled. These names are regenerable by definition: no
-/// tool writes work-of-record into them, and losing them costs only CPU.
-/// What: matched against a directory's own file name at any depth. A nested
-/// repository underneath one of these is NOT seen — see the module-level
-/// residual-risk note.
-/// Test: `inspect_dirt_does_not_scan_disposable_build_dirs`.
-const DISPOSABLE_DIR_NAMES: &[&str] = &[
-    "target",
-    "node_modules",
-    "dist",
-    "build",
-    ".next",
-    ".nuxt",
-    ".svelte-kit",
-    ".turbo",
-    ".parcel-cache",
-    ".cache",
-    "__pycache__",
-    ".pytest_cache",
-    ".mypy_cache",
-    ".ruff_cache",
-    ".tox",
-    ".venv",
-    "venv",
-    ".gradle",
-    "coverage",
-    ".terraform",
-];
-
-/// Directory entries the gitignored-subtree scan may visit per candidate.
-///
-/// Why: an unbounded walk of an arbitrary ignored tree is a denial-of-service
-/// against the sweep. Measured against this repo's own 31 session worktrees, a
-/// FULL-tree walk with [`DISPOSABLE_DIR_NAMES`] pruning visited 5.6k entries per
-/// worktree on average; the ignored-only subset is far smaller, so 50k is two
-/// orders of magnitude of headroom.
-/// What: exceeding the budget is an ERROR, which the caller turns into DIRTY —
-/// "I could not finish looking" is never "there is nothing there".
-const IGNORED_SCAN_ENTRY_BUDGET: usize = 50_000;
 
 /// Git global options pinned on EVERY invocation this module makes (#4118).
 ///
@@ -239,15 +203,6 @@ const TRUSTY_MPM_STATUS_ARGS: &[&str] = &[
     TRUSTY_MPM_DIR,
 ];
 
-/// Collapsed listing of gitignored entries, used to bound the nested-repo scan.
-const IGNORED_STATUS_ARGS: &[&str] = &[
-    "status",
-    "--porcelain",
-    "--untracked-files=normal",
-    "--ignored",
-    "--ignore-submodules=none",
-];
-
 /// What the reclaim path does when a candidate holds unsaved work (#4091).
 ///
 /// Why: the default must be impossible to trigger accidentally — an ordinary
@@ -299,7 +254,12 @@ pub struct DirtyWorktree {
 
 impl DirtyWorktree {
     /// Build a skip record for `path` with an explicit reason and counts.
-    fn new(path: &Path, reason: impl Into<String>, dirty_files: usize, unpushed: usize) -> Self {
+    pub(super) fn new(
+        path: &Path,
+        reason: impl Into<String>,
+        dirty_files: usize,
+        unpushed: usize,
+    ) -> Self {
         Self {
             path: path.to_path_buf(),
             reason: reason.into(),
@@ -322,7 +282,8 @@ impl DirtyWorktree {
 ///    `.trusty-mpm/` that is not one of two disposable artefacts;
 /// 2. [`count_unpushed`] finds a commit that is on no remote, on `HEAD` or on
 ///    the `session/<leaf>` branch `remove_session_worktree` force-deletes;
-/// 3. [`nested_dirt`] finds a nested repository holding unsaved work,
+/// 3. [`super::worktree_nested::nested_dirt`] finds a nested repository
+///    holding unsaved work,
 ///    regardless of gitignore;
 /// 4. the directory is not a git worktree ROOT at all and is not empty — see
 ///    [`non_git_dirt`];
@@ -351,7 +312,7 @@ pub(crate) fn inspect_dirt(path: &Path) -> Option<DirtyWorktree> {
 /// registered worktrees at EVERY depth in one flat pass.
 /// What: `scan_nested = false` answers only questions 1, 2 and 4 for `path`.
 /// Test: `inspect_dirt_reports_nested_gitignored_worktree`.
-fn inspect_dirt_at(path: &Path, scan_nested: bool) -> Option<DirtyWorktree> {
+pub(super) fn inspect_dirt_at(path: &Path, scan_nested: bool) -> Option<DirtyWorktree> {
     match is_worktree_root(path) {
         Ok(true) => {}
         // Not a git worktree root (or git cannot tell us) — fall back to the
@@ -389,7 +350,7 @@ fn inspect_dirt_at(path: &Path, scan_nested: bool) -> Option<DirtyWorktree> {
         return Some(DirtyWorktree::new(path, reason, dirty_files, unpushed));
     }
     if scan_nested {
-        return nested_dirt(path);
+        return super::worktree_nested::nested_dirt(path);
     }
     None
 }
@@ -406,7 +367,7 @@ fn inspect_dirt_at(path: &Path, scan_nested: bool) -> Option<DirtyWorktree> {
 /// [`trusty_mpm_dirt`], which sees ignored and untracked content alike.
 /// Test: `inspect_dirt_counts_wip_backup_under_trusty_mpm`,
 /// `inspect_dirt_excludes_own_sentinel`.
-fn count_dirty_files(path: &Path) -> Result<usize, String> {
+pub(super) fn count_dirty_files(path: &Path) -> Result<usize, String> {
     let status = git_stdout(path, STATUS_ARGS)?;
     let mut count = 0usize;
     for line in status.lines() {
@@ -463,8 +424,15 @@ fn is_trusty_mpm_scoped(path: &str) -> bool {
 /// Test: `inspect_dirt_counts_wip_backup_under_trusty_mpm`,
 /// `inspect_dirt_counts_pause_snapshots_under_trusty_mpm`.
 fn trusty_mpm_dirt(root: &Path) -> Result<usize, String> {
-    if !root.join(TRUSTY_MPM_DIR).exists() {
-        return Ok(0);
+    // NOT `Path::exists()`: that collapses every I/O error to `false`, and
+    // pass 1 has already skipped every `.trusty-mpm/`-scoped entry on the
+    // promise that this pass owns them — so a permission error here would
+    // become CLEAN, inverting the module's own fail-safe invariant.
+    let dir = root.join(TRUSTY_MPM_DIR);
+    match std::fs::symlink_metadata(&dir) {
+        Ok(_) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(0),
+        Err(e) => return Err(format!("`{}` is unreadable: {e}", dir.display())),
     }
     let out = git_stdout(root, TRUSTY_MPM_STATUS_ARGS)?;
     let mut count = 0usize;
@@ -484,174 +452,6 @@ fn trusty_mpm_dirt(root: &Path) -> Result<usize, String> {
         count += 1;
     }
     Ok(count)
-}
-
-/// Does a NESTED repository under this candidate hold unsaved work (#4118)?
-///
-/// Why: this is the hole that made the whole guard bypassable. Deleting the
-/// candidate deletes everything inside it, but `git status` on the candidate
-/// says nothing about a nested checkout — `.claude/worktrees/` is gitignored on
-/// this repo's `main` (`.gitignore:40`), so seven registered agent worktrees
-/// inside `.base/.worktrees/2eb72dca-…` produced `dirty_files = 0`. Worse, the
-/// #3649 ownership gate deliberately REFUSES to delete those nested worktrees
-/// directly (no sentinel ⇒ owner-unknown), so the sweep would have honoured
-/// that refusal and then deleted the directory they live in — bypassing its own
-/// guard by removing the parent.
-/// What: every nested root from [`nested_repo_roots`] is put through
-/// [`inspect_dirt_at`] with the nested scan off. A nested root that is dirty OR
-/// unassessable makes the PARENT dirty; one that is provably clean and pushed
-/// does not, so a session that merely once spawned an agent worktree stays
-/// reclaimable. The reported counts are the nested root's own, unmodified.
-/// Test: `inspect_dirt_reports_nested_gitignored_worktree`,
-/// `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`,
-/// `inspect_dirt_allows_clean_nested_worktree`.
-fn nested_dirt(candidate: &Path) -> Option<DirtyWorktree> {
-    let roots = match nested_repo_roots(candidate) {
-        Ok(r) => r,
-        Err(e) => {
-            return Some(DirtyWorktree::new(
-                candidate,
-                format!("nested-repository scan failed: {e}"),
-                0,
-                0,
-            ));
-        }
-    };
-    for root in roots {
-        // A clean, pushed nested root does not pin the parent — keep looking.
-        let Some(inner) = inspect_dirt_at(&root, false) else {
-            continue;
-        };
-        let shown = root
-            .strip_prefix(candidate)
-            .unwrap_or(&root)
-            .display()
-            .to_string();
-        return Some(DirtyWorktree::new(
-            candidate,
-            format!(
-                "nested git worktree/repository `{shown}` holds unsaved work \
-                 that `git status` on this directory cannot see: {}",
-                inner.reason
-            ),
-            inner.dirty_files,
-            inner.unpushed_commits,
-        ));
-    }
-    None
-}
-
-/// Enumerate every nested repository root strictly beneath `candidate`.
-///
-/// Why: "does this directory contain a checkout" must be answered EXACTLY, not
-/// heuristically, because the answer decides whether gigabytes get deleted. Two
-/// disjoint populations exist and neither subsumes the other: worktrees
-/// REGISTERED with the enclosing repository (the `.claude/worktrees/…` shape,
-/// free to enumerate — git already knows) and independent clones that git has
-/// never heard of (only findable on disk).
-/// What: the union of (a) `worktree list --porcelain` entries that are strict
-/// descendants of `candidate` — exact, at any depth, and immune to gitignore
-/// because git's own bookkeeping is the source — and (b) a bounded walk of the
-/// gitignored subtrees `git status --ignored` reports, looking for a `.git`
-/// entry. Untracked-but-not-ignored nested repos need no walk at all: they
-/// already surface as `??` lines in [`count_dirty_files`].
-/// Test: `inspect_dirt_reports_nested_gitignored_worktree`,
-/// `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`.
-fn nested_repo_roots(candidate: &Path) -> Result<Vec<PathBuf>, String> {
-    let canonical =
-        std::fs::canonicalize(candidate).map_err(|e| format!("candidate is unreadable: {e}"))?;
-    let mut roots: BTreeSet<PathBuf> = BTreeSet::new();
-
-    for line in git_stdout(candidate, &["worktree", "list", "--porcelain"])?.lines() {
-        let Some(raw) = line.strip_prefix("worktree ") else {
-            continue;
-        };
-        let listed = PathBuf::from(raw.trim());
-        let listed = std::fs::canonicalize(&listed).unwrap_or(listed);
-        if listed != canonical && listed.starts_with(&canonical) {
-            roots.insert(listed);
-        }
-    }
-
-    let mut budget = IGNORED_SCAN_ENTRY_BUDGET;
-    for line in git_stdout(candidate, IGNORED_STATUS_ARGS)?.lines() {
-        let Some(raw) = line.strip_prefix("!! ") else {
-            continue;
-        };
-        let entry = raw.trim();
-        if entry.starts_with('"') {
-            return Err(format!(
-                "ignored entry `{entry}` has a quoted path this scan cannot interpret"
-            ));
-        }
-        scan_for_repos(
-            &canonical.join(entry.trim_end_matches('/')),
-            &mut roots,
-            &mut budget,
-        )?;
-    }
-    Ok(roots.into_iter().collect())
-}
-
-/// Walk `root`, collecting directories that contain a `.git` entry.
-///
-/// Why: an unregistered clone inside a gitignored directory is invisible to
-/// every git question asked of the CANDIDATE, so the only way to find it is to
-/// look. Iterative rather than recursive so a pathologically deep tree cannot
-/// overflow the stack, and symlinks are never followed — `remove_dir_all`
-/// deletes a link, not its target, so nothing beyond one is at risk.
-/// What: pushes each directory holding a `.git` entry into `out` and stops
-/// descending there. Skips [`DISPOSABLE_DIR_NAMES`] by name at every level.
-/// Exhausting `budget`, or any unreadable entry, is an `Err` the caller turns
-/// into DIRTY.
-/// Test: `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`,
-/// `inspect_dirt_does_not_scan_disposable_build_dirs`.
-fn scan_for_repos(
-    root: &Path,
-    out: &mut BTreeSet<PathBuf>,
-    budget: &mut usize,
-) -> Result<(), String> {
-    let mut stack = vec![root.to_path_buf()];
-    while let Some(dir) = stack.pop() {
-        match std::fs::symlink_metadata(&dir) {
-            // A plain file, or a symlink of any kind: nothing to descend into.
-            Ok(meta) if !meta.is_dir() => continue,
-            Ok(_) => {}
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
-            Err(e) => return Err(format!("`{}` is unreadable: {e}", dir.display())),
-        }
-        let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or_default();
-        if DISPOSABLE_DIR_NAMES.contains(&name) {
-            continue;
-        }
-        let entries = std::fs::read_dir(&dir)
-            .map_err(|e| format!("`{}` is unreadable: {e}", dir.display()))?;
-        let mut children = Vec::new();
-        let mut is_repo = false;
-        for entry in entries {
-            let entry =
-                entry.map_err(|e| format!("an entry of `{}` is unreadable: {e}", dir.display()))?;
-            if *budget == 0 {
-                return Err(format!(
-                    "gitignored-subtree scan exceeded its {IGNORED_SCAN_ENTRY_BUDGET}-entry \
-                     budget at `{}`",
-                    dir.display()
-                ));
-            }
-            *budget -= 1;
-            if entry.file_name() == ".git" {
-                is_repo = true;
-                break;
-            }
-            children.push(entry.path());
-        }
-        if is_repo {
-            out.insert(dir);
-            continue;
-        }
-        stack.extend(children);
-    }
-    Ok(())
 }
 
 /// Classify a candidate that is NOT a git worktree root (#4091).
@@ -786,33 +586,59 @@ fn count_unpushed(path: &Path) -> Result<usize, String> {
 /// switching to `main`, `rev-list --count HEAD --not --remotes` returns 0 while
 /// the branch still carries the commit. HEAD-only counting therefore returned a
 /// false CLEAN for the one branch about to be force-deleted.
-/// What: 0 when no such branch exists (`for-each-ref` exits 0 with empty output,
-/// so absence is distinguishable from a spawn failure, which stays an `Err`).
-/// Otherwise the commits on that branch reachable from no remote AND not
+/// What: BOTH spellings of "the branch named after this directory" are checked
+/// — `refs/heads/session/<leaf>` and the bare `refs/heads/<leaf>` — because the
+/// two halves of trusty-mpm disagree about which one it is, and have since
+/// before this guard existed:
+/// - `core::worktree_naming::worktree_branch_for` (used by
+///   `inproject::create_session_worktree` AND by `remove_session_worktree`'s
+///   `branch -D`) says `session/<leaf>`;
+/// - `provisioner/workspace.rs:803` names the branch for the
+///   `.base/.worktrees/<session-id>` shape **bare** — `session_id.to_string()`
+///   — which is the DOMINANT population of the ~95-worktree sweep.
+///
+/// Today that divergence is not a loss path: `branch -D session/<uuid>` simply
+/// misses, so a bare branch survives the removal. Checking it anyway is
+/// deliberate conservatism, and the reason is the point of this whole PR — the
+/// divergence is a live bug that will be fixed on ONE side or the other, and if
+/// it is fixed on the `remove_session_worktree` side then bare branches start
+/// being destroyed. A guard that silently goes from correct to inert because
+/// somebody repaired an unrelated naming bug is exactly the failure mode this
+/// module exists to prevent. Over-reporting costs an operator one look; the
+/// other direction costs the work. Tracked as a follow-up rather than fixed
+/// here, since renaming branches is not a safety-gate change.
+///
+/// 0 when neither ref exists (`for-each-ref` exits 0 with empty output, so
+/// absence is distinguishable from a spawn failure, which stays an `Err`).
+/// Otherwise the commits on those branches reachable from no remote AND not
 /// already counted via `HEAD` — excluding `HEAD` is what stops the common
-/// "branch IS the checked-out branch" case from being counted twice.
+/// "branch IS the checked-out branch" case from being counted twice, and
+/// passing both refs to ONE `rev-list` stops a commit shared by both spellings
+/// from being counted twice either.
 /// Test: `inspect_dirt_reports_unpushed_session_branch_when_head_moved`,
+/// `inspect_dirt_reports_unpushed_bare_leaf_branch_when_head_moved`,
 /// `inspect_dirt_does_not_double_count_the_checked_out_session_branch`.
 fn count_session_branch_unpushed(path: &Path) -> Result<usize, String> {
     let Some(leaf) = path.file_name().and_then(|n| n.to_str()) else {
         return Ok(0);
     };
-    let refname = format!("refs/heads/session/{leaf}");
-    let listed = git_stdout(path, &["for-each-ref", "--format=%(refname)", &refname])?;
-    if listed.trim().is_empty() {
+    let mut present = Vec::new();
+    for refname in [
+        format!("refs/heads/session/{leaf}"),
+        format!("refs/heads/{leaf}"),
+    ] {
+        let listed = git_stdout(path, &["for-each-ref", "--format=%(refname)", &refname])?;
+        if !listed.trim().is_empty() {
+            present.push(refname);
+        }
+    }
+    if present.is_empty() {
         return Ok(0);
     }
-    let raw = git_stdout(
-        path,
-        &[
-            "rev-list",
-            "--count",
-            &refname,
-            "--not",
-            "--remotes",
-            "HEAD",
-        ],
-    )?;
+    let mut args: Vec<&str> = vec!["rev-list", "--count"];
+    args.extend(present.iter().map(String::as_str));
+    args.extend(["--not", "--remotes", "HEAD"]);
+    let raw = git_stdout(path, &args)?;
     raw.trim()
         .parse::<usize>()
         .map_err(|e| format!("unparsable rev-list count `{}`: {e}", raw.trim()))
@@ -826,7 +652,7 @@ fn count_session_branch_unpushed(path: &Path) -> Result<usize, String> {
 /// What: non-zero exit and spawn failure both become `Err` carrying the
 /// command and git's own stderr; stdout is lossily decoded.
 /// Test: `inspect_dirt_treats_missing_path_as_dirty`.
-fn git_stdout(dir: &Path, args: &[&str]) -> Result<String, String> {
+pub(super) fn git_stdout(dir: &Path, args: &[&str]) -> Result<String, String> {
     let out = git_command(dir, args)
         .output()
         .map_err(|e| format!("`git {}` could not be run: {e}", args.join(" ")))?;

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -25,12 +25,228 @@
 //! unparsable count, and a directory that cannot be read, all mean "this
 //! check could not prove the directory is safe to delete" — which must never
 //! become a green light to delete. That inverts the whole point.
+//!
+//! # The rule, stated once (#4118 review round)
+//!
+//! `git status` answers "what does git see", and the two most valuable things
+//! in a session worktree are precisely the things it does NOT see: work hidden
+//! behind `.gitignore`, and work hidden behind this guard's own carve-outs.
+//! Both were live on this machine on 2026-07-27, on DIFFERENT branches of the
+//! same repo — `main` gitignores `.claude/worktrees/` and `.trusty-mpm/*`
+//! (`.gitignore:40,49`), while the older branch checked out in
+//! `.base/.worktrees/2eb72dca-…` gitignores neither, so the same content
+//! arrives as `??` lines there and is invisible here. A guard that closed only
+//! one of those would be sound on one branch and useless on the other, so this
+//! module never reasons from "is it gitignored". It asks four questions:
+//!
+//! 1. **Does git report anything?** — [`STATUS_ARGS`], with every
+//!    config knob that could silence it pinned on the command line.
+//! 2. **Is anything committed but not on a remote?** — on `HEAD` *and* on the
+//!    `session/<leaf>` branch that `decommission` force-deletes.
+//! 3. **Is there a nested repository holding unsaved work?** — enumerated
+//!    exactly, never inferred: registered worktrees from
+//!    `git worktree list --porcelain`, plus a bounded walk of gitignored
+//!    subtrees for unregistered clones. Each nested root is then put through
+//!    questions 1, 2 and 4 in its own right.
+//! 4. **Is there anything under `.trusty-mpm/` that is not one of two
+//!    disposable artefacts?** — accounted per-file by pathspec, covering the
+//!    gitignored and untracked spellings alike.
+//!
+//! # What this rule still CANNOT see (residual risk)
+//!
+//! - **Gitignored loose files outside `.trusty-mpm/`** that are not part of a
+//!   nested repository — a `.env.local`, a `.mcp.json.bak`, a scratch note in
+//!   an ignored directory. Deliberately not counted: on this repo's own 31
+//!   session worktrees, treating every non-disposable ignored entry as dirt
+//!   would flag `.claude/` in 30 of 31 and disable reclamation outright, which
+//!   is the failure mode of a guard nobody can run.
+//! - **Anything under a [`DISPOSABLE_DIR_NAMES`] directory**, including a
+//!   nested repository inside `target/` or `node_modules/`.
+//! - **`.git/info/exclude`**, which is per-repo and on-disk and cannot be
+//!   overridden from the command line the way `core.excludesFile` can.
+//! - **`git stash` entries** — the stash is repo-level, not per-worktree.
+//! - **Symlinked subtrees** — not followed, because `remove_dir_all` deletes
+//!   the link and not its target, so no work is at risk there.
+//! - **A repository nested inside a gitignored subtree OF a nested repository**
+//!   — the scan stops descending at the first `.git` it finds.
+//! - **`DirtyWorktreePolicy::ForceDiscard`**, which destroys all of the above
+//!   by explicit operator opt-in.
+//!
 //! Test: `worktree_safety_tests`.
 
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde::Serialize;
+
+/// The bookkeeping directory trusty-mpm writes into every managed workspace.
+const TRUSTY_MPM_DIR: &str = ".trusty-mpm";
+
+/// The ONLY two artefacts under [`TRUSTY_MPM_DIR`] this guard treats as
+/// disposable (#4118 gap review).
+///
+/// Why: the first cut of this guard excused the whole `.trusty-mpm/` subtree on
+/// the grounds that it is "the scrollback-snapshot directory". It is not. That
+/// subtree ALSO holds `sessions/` pause snapshots (written by
+/// `trusty-common`'s `catchup::pause`, read back by `/tm-session-resume`),
+/// config checkpoints, and — observed live on 2026-07-27 in
+/// `.base/.worktrees/2eb72dca-…/.trusty-mpm/wip-backup-20260727-jira/` — twelve
+/// files of hand-rescued, uncommitted Rust source. A prefix match excused all
+/// of it, so `dirty_files` stayed 0 and the worktree read CLEAN.
+/// What: an ALLOWLIST of exact repo-relative paths, not a prefix. `scrollback`
+/// is a pane dump the daemon rewrites on every snapshot;
+/// `last-instructions.md` is a regenerated copy of the PM brief. Everything
+/// else under `.trusty-mpm/` — named or not, tracked, untracked, or gitignored
+/// — counts as work.
+/// Test: `inspect_dirt_counts_wip_backup_under_trusty_mpm`,
+/// `inspect_dirt_counts_pause_snapshots_under_trusty_mpm`,
+/// `inspect_dirt_excludes_untracked_trusty_mpm_dir`.
+const DISPOSABLE_TRUSTY_MPM_FILES: &[&str] = &[
+    ".trusty-mpm/scrollback.txt",
+    ".trusty-mpm/last-instructions.md",
+];
+
+/// Directory names whose contents are regenerable build/cache output (#4118).
+///
+/// Why: the nested-repository scan ([`nested_repo_roots`]) has to walk
+/// gitignored subtrees, and those are dominated by exactly two things —
+/// enormous disposable build output, and the occasional nested checkout that
+/// holds real work. Walking `target/` on 95 candidates would cost minutes and
+/// find nothing; skipping it by NAME is the difference between a scan that runs
+/// and one that gets disabled. These names are regenerable by definition: no
+/// tool writes work-of-record into them, and losing them costs only CPU.
+/// What: matched against a directory's own file name at any depth. A nested
+/// repository underneath one of these is NOT seen — see the module-level
+/// residual-risk note.
+/// Test: `inspect_dirt_does_not_scan_disposable_build_dirs`.
+const DISPOSABLE_DIR_NAMES: &[&str] = &[
+    "target",
+    "node_modules",
+    "dist",
+    "build",
+    ".next",
+    ".nuxt",
+    ".svelte-kit",
+    ".turbo",
+    ".parcel-cache",
+    ".cache",
+    "__pycache__",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".ruff_cache",
+    ".tox",
+    ".venv",
+    "venv",
+    ".gradle",
+    "coverage",
+    ".terraform",
+];
+
+/// Directory entries the gitignored-subtree scan may visit per candidate.
+///
+/// Why: an unbounded walk of an arbitrary ignored tree is a denial-of-service
+/// against the sweep. Measured against this repo's own 31 session worktrees, a
+/// FULL-tree walk with [`DISPOSABLE_DIR_NAMES`] pruning visited 5.6k entries per
+/// worktree on average; the ignored-only subset is far smaller, so 50k is two
+/// orders of magnitude of headroom.
+/// What: exceeding the budget is an ERROR, which the caller turns into DIRTY —
+/// "I could not finish looking" is never "there is nothing there".
+const IGNORED_SCAN_ENTRY_BUDGET: usize = 50_000;
+
+/// Git global options pinned on EVERY invocation this module makes (#4118).
+///
+/// Why: `git status --porcelain` does not report "all work". It reports all
+/// work git has been CONFIGURED to show, and three of those config keys can
+/// silence it outright. Proven on git 2.54.0 against throwaway repos:
+/// `status.showUntrackedFiles=no` makes `git status --porcelain` exit 0 with
+/// EMPTY output while untracked work sits on disk; a `core.excludesFile`
+/// naming that work hides it the same way. The natural home for either is the
+/// SHARED `.base/.git/config` that all ~95 worktrees in the sweep read, so one
+/// line there would blind the guard fleet-wide. A work-destroying gate must not
+/// be steerable by configuration it does not control.
+/// What: `--no-optional-locks` (never write to a candidate's index just to
+/// inspect it), plus `-c` pins for every key that changes what status reports
+/// or how it spells a path. `-c` beats every config file, so this is
+/// deterministic regardless of system/global/repo config. NOT pinned: aliases
+/// (git refuses to let an alias shadow a built-in command — verified) and
+/// `status.branch` (verified to have no effect on `--porcelain` v1 output).
+/// Test: `inspect_dirt_survives_hostile_show_untracked_files_config`,
+/// `inspect_dirt_survives_hostile_global_excludes_file`.
+const GIT_PINNED_GLOBAL_ARGS: &[&str] = &[
+    "--no-optional-locks",
+    "-c",
+    "core.quotePath=false",
+    "-c",
+    "core.excludesFile=",
+    "-c",
+    "status.relativePaths=true",
+    "-c",
+    "status.showUntrackedFiles=normal",
+];
+
+/// Environment variables that point git at a DIFFERENT repository (#4118).
+///
+/// Why: `git -C <candidate> status` obeys `GIT_DIR`/`GIT_WORK_TREE` over its
+/// own `-C`. The daemon inherits its environment from whatever launched it, and
+/// a `GIT_DIR` + `GIT_WORK_TREE` pair naming a CLEAN repository makes every
+/// candidate report clean — verified: with both set, status on a repo holding
+/// an untracked file exits 0 with empty output. Most other combinations fail
+/// toward DIRTY, but "most" is not a safety property.
+/// What: removed from the child environment so git always resolves the
+/// repository from `-C <candidate>` alone. `GIT_CONFIG_COUNT` is stripped too
+/// because env-injected config would otherwise compete with
+/// [`GIT_PINNED_GLOBAL_ARGS`].
+/// Test: `git_command_strips_repository_redirecting_env`.
+const GIT_ENV_REDIRECTS: &[&str] = &[
+    "GIT_DIR",
+    "GIT_WORK_TREE",
+    "GIT_INDEX_FILE",
+    "GIT_COMMON_DIR",
+    "GIT_OBJECT_DIRECTORY",
+    "GIT_ALTERNATE_OBJECT_DIRECTORIES",
+    "GIT_CEILING_DIRECTORIES",
+    "GIT_NAMESPACE",
+    "GIT_CONFIG_COUNT",
+];
+
+/// Working-tree status for the candidate itself.
+const STATUS_ARGS: &[&str] = &[
+    "status",
+    "--porcelain",
+    "--untracked-files=normal",
+    "--ignore-submodules=none",
+];
+
+/// Per-file accounting of `.trusty-mpm/`, scoped by pathspec (#4118).
+///
+/// Why: `--untracked-files=normal` COLLAPSES an untracked directory to a single
+/// `?? .trusty-mpm/` line, which makes scrollback indistinguishable from
+/// rescued source — the exact discrimination the allowlist needs. `-uall` plus
+/// `--ignored=matching` restores per-path detail AND covers the case where the
+/// project gitignores `.trusty-mpm/*` (this repo's `main`) so the subtree is
+/// invisible to plain status altogether. Both spellings are live in the fleet
+/// right now, so the guard must not depend on either.
+/// What: scoped by the `-- .trusty-mpm` pathspec so the expensive `-uall`
+/// recursion is confined to one small directory instead of the whole checkout.
+const TRUSTY_MPM_STATUS_ARGS: &[&str] = &[
+    "status",
+    "--porcelain",
+    "--untracked-files=all",
+    "--ignored=matching",
+    "--ignore-submodules=none",
+    "--",
+    TRUSTY_MPM_DIR,
+];
+
+/// Collapsed listing of gitignored entries, used to bound the nested-repo scan.
+const IGNORED_STATUS_ARGS: &[&str] = &[
+    "status",
+    "--porcelain",
+    "--untracked-files=normal",
+    "--ignored",
+    "--ignore-submodules=none",
+];
 
 /// What the reclaim path does when a candidate holds unsaved work (#4091).
 ///
@@ -101,18 +317,16 @@ impl DirtyWorktree {
 /// What: returns `None` only when the directory is PROVABLY free of unsaved
 /// work; `Some(DirtyWorktree)` in every other case, including every error.
 /// "Dirty" means any of:
-/// 1. `git status --porcelain` reports at least one entry — modified or staged
-///    tracked files AND untracked-but-not-ignored files, in one command
-///    (ignored files are excluded by design: build artefacts are not work, and
-///    so are trusty-mpm's own untracked artefacts — see [`is_tool_bookkeeping`]);
-/// 2. at least one commit on `HEAD` is not on the branch's upstream (when one
-///    is configured) or, with no upstream, is not on ANY remote-tracking ref.
-///    This second leg matters because `remove_session_worktree` deletes the
-///    worktree's `session/<leaf>` branch, so unpushed commits lose their last
-///    reachable ref;
-/// 3. the directory is not a git worktree ROOT at all and is not empty — see
+/// 1. [`count_dirty_files`] finds a working-tree entry — modified or staged
+///    tracked files, untracked-but-not-ignored files, and anything under
+///    `.trusty-mpm/` that is not one of two disposable artefacts;
+/// 2. [`count_unpushed`] finds a commit that is on no remote, on `HEAD` or on
+///    the `session/<leaf>` branch `remove_session_worktree` force-deletes;
+/// 3. [`nested_dirt`] finds a nested repository holding unsaved work,
+///    regardless of gitignore;
+/// 4. the directory is not a git worktree ROOT at all and is not empty — see
 ///    [`non_git_dirt`];
-/// 4. any check errored — see the module-level FAIL-SAFE note.
+/// 5. any check errored — see the module-level FAIL-SAFE note.
 ///
 /// The worktree-root identity check is not incidental: running
 /// `git status` inside a plain directory that happens to sit INSIDE a checkout
@@ -126,6 +340,18 @@ impl DirtyWorktree {
 /// `inspect_dirt_treats_non_worktree_with_files_as_dirty`,
 /// `inspect_dirt_allows_empty_non_git_leftover`.
 pub(crate) fn inspect_dirt(path: &Path) -> Option<DirtyWorktree> {
+    inspect_dirt_at(path, true)
+}
+
+/// [`inspect_dirt`], with the nested-repository scan switchable off.
+///
+/// Why: the nested scan inspects each nested root by calling back into this
+/// function. Running the scan again from inside a nested root would recurse
+/// without bound, and buys nothing — [`nested_repo_roots`] already enumerates
+/// registered worktrees at EVERY depth in one flat pass.
+/// What: `scan_nested = false` answers only questions 1, 2 and 4 for `path`.
+/// Test: `inspect_dirt_reports_nested_gitignored_worktree`.
+fn inspect_dirt_at(path: &Path, scan_nested: bool) -> Option<DirtyWorktree> {
     match is_worktree_root(path) {
         Ok(true) => {}
         // Not a git worktree root (or git cannot tell us) — fall back to the
@@ -133,8 +359,8 @@ pub(crate) fn inspect_dirt(path: &Path) -> Option<DirtyWorktree> {
         Ok(false) | Err(_) => return non_git_dirt(path),
     }
 
-    let status = match git_stdout(path, &["status", "--porcelain"]) {
-        Ok(s) => s,
+    let dirty_files = match count_dirty_files(path) {
+        Ok(n) => n,
         Err(e) => {
             return Some(DirtyWorktree::new(
                 path,
@@ -144,11 +370,6 @@ pub(crate) fn inspect_dirt(path: &Path) -> Option<DirtyWorktree> {
             ));
         }
     };
-    let dirty_files = status
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .filter(|l| !is_tool_bookkeeping(l))
-        .count();
 
     let unpushed = match count_unpushed(path) {
         Ok(n) => n,
@@ -162,43 +383,275 @@ pub(crate) fn inspect_dirt(path: &Path) -> Option<DirtyWorktree> {
         }
     };
 
-    if dirty_files == 0 && unpushed == 0 {
-        return None;
+    if dirty_files > 0 || unpushed > 0 {
+        let reason =
+            format!("{dirty_files} uncommitted/untracked file(s), {unpushed} unpushed commit(s)");
+        return Some(DirtyWorktree::new(path, reason, dirty_files, unpushed));
     }
-    let reason =
-        format!("{dirty_files} uncommitted/untracked file(s), {unpushed} unpushed commit(s)");
-    Some(DirtyWorktree::new(path, reason, dirty_files, unpushed))
+    if scan_nested {
+        return nested_dirt(path);
+    }
+    None
 }
 
-/// Is this `git status --porcelain` line trusty-mpm's OWN bookkeeping rather
-/// than somebody's work (#4091)?
+/// Count working-tree entries that represent WORK, in two passes (#4118).
 ///
-/// Why: this exclusion is what keeps the guard from degenerating into "never
-/// reclaim anything". trusty-mpm writes two artefacts into EVERY managed
-/// worktree it creates — the `.trusty-mpm-worktree` ownership sentinel
-/// (`create_session_worktree`) and the `.trusty-mpm/` scrollback-snapshot
-/// directory (`snapshot::write_scrollback`) — and neither is typically
-/// gitignored by the host project. Counting them would mark every single
-/// managed worktree permanently dirty, which is worse than useless: it stops
-/// all reclamation AND buries the genuinely-dirty worktrees in noise, which is
-/// how a safety report gets ignored.
-/// What: excuses a line ONLY when it is UNTRACKED (`??`) and its path is the
-/// sentinel file or lives under `.trusty-mpm/`. A TRACKED modification is
-/// never excused, no matter its path — if a project tracks
-/// `.trusty-mpm/INSTRUCTIONS.md` and someone edited it, that is real work.
-/// Test: `inspect_dirt_excludes_own_sentinel`,
-/// `inspect_dirt_excludes_untracked_trusty_mpm_dir`,
-/// `inspect_dirt_counts_tracked_trusty_mpm_edit`.
-fn is_tool_bookkeeping(line: &str) -> bool {
-    let Some(rest) = line.strip_prefix("?? ") else {
-        return false;
+/// Why: one `git status` cannot both stay cheap on a whole checkout and stay
+/// per-file precise inside `.trusty-mpm/`. `-unormal` collapses untracked
+/// directories (cheap, but `?? .trusty-mpm/` hides what is underneath) and
+/// `-uall` does not (precise, but recurses the entire tree). Splitting by
+/// pathspec buys the precision exactly where the allowlist needs it.
+/// What: pass one counts every `-unormal` entry except the ownership sentinel
+/// and anything rooted at `.trusty-mpm/`; pass two hands `.trusty-mpm/` to
+/// [`trusty_mpm_dirt`], which sees ignored and untracked content alike.
+/// Test: `inspect_dirt_counts_wip_backup_under_trusty_mpm`,
+/// `inspect_dirt_excludes_own_sentinel`.
+fn count_dirty_files(path: &Path) -> Result<usize, String> {
+    let status = git_stdout(path, STATUS_ARGS)?;
+    let mut count = 0usize;
+    for line in status.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let entry = porcelain_path(line);
+        if line.starts_with("?? ") && entry == super::decommission::WORKTREE_SENTINEL_FILE {
+            continue;
+        }
+        if is_trusty_mpm_scoped(entry) {
+            continue; // owned by the per-file pass below
+        }
+        count += 1;
+    }
+    Ok(count + trusty_mpm_dirt(path)?)
+}
+
+/// The repo-relative path of a `git status --porcelain` v1 line.
+///
+/// Why: every line is `XY <path>`, so the path starts at byte 3. A rename is
+/// `R  <old> -> <new>`; this returns the whole `<old> -> <new>` span, which no
+/// caller matches against an allowlist — a rename INTO an excused path
+/// therefore fails the match and COUNTS, which is the fail-safe direction.
+/// What: the trimmed remainder of the line, or `""` for a malformed one (which
+/// then matches no allowlist entry and is counted).
+fn porcelain_path(line: &str) -> &str {
+    line.get(3..).unwrap_or("").trim()
+}
+
+/// Is this repo-relative path rooted at the `.trusty-mpm/` bookkeeping dir?
+///
+/// Why: the ownership sentinel is `.trusty-mpm-worktree`, a SIBLING whose name
+/// shares the prefix. Matching on a bare `.trusty-mpm` prefix would route the
+/// sentinel into the per-file pass, where it is not on the allowlist and would
+/// be counted — marking every managed worktree dirty forever.
+/// What: true for `.trusty-mpm`, `.trusty-mpm/` and anything beneath it; false
+/// for `.trusty-mpm-worktree`.
+/// Test: `inspect_dirt_excludes_own_sentinel`.
+fn is_trusty_mpm_scoped(path: &str) -> bool {
+    path == TRUSTY_MPM_DIR || path.starts_with(".trusty-mpm/")
+}
+
+/// Count entries under `.trusty-mpm/` that are not disposable bookkeeping.
+///
+/// Why: see [`DISPOSABLE_TRUSTY_MPM_FILES`]. This is the leg that closes the
+/// live `wip-backup-20260727-jira/` hole, and it must work whether the subtree
+/// is gitignored (invisible to plain status) or untracked (collapsed by plain
+/// status) — hence [`TRUSTY_MPM_STATUS_ARGS`].
+/// What: 0 when the directory does not exist; otherwise one count per reported
+/// entry that is not on the allowlist. A quoted path is an ERROR, not a
+/// silently-unmatched one: if the guard cannot spell the path it cannot decide
+/// the path is disposable.
+/// Test: `inspect_dirt_counts_wip_backup_under_trusty_mpm`,
+/// `inspect_dirt_counts_pause_snapshots_under_trusty_mpm`.
+fn trusty_mpm_dirt(root: &Path) -> Result<usize, String> {
+    if !root.join(TRUSTY_MPM_DIR).exists() {
+        return Ok(0);
+    }
+    let out = git_stdout(root, TRUSTY_MPM_STATUS_ARGS)?;
+    let mut count = 0usize;
+    for line in out.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let entry = porcelain_path(line);
+        if entry.starts_with('"') {
+            return Err(format!(
+                "`{entry}` under {TRUSTY_MPM_DIR}/ has a quoted path this guard cannot classify"
+            ));
+        }
+        if DISPOSABLE_TRUSTY_MPM_FILES.contains(&entry) {
+            continue;
+        }
+        count += 1;
+    }
+    Ok(count)
+}
+
+/// Does a NESTED repository under this candidate hold unsaved work (#4118)?
+///
+/// Why: this is the hole that made the whole guard bypassable. Deleting the
+/// candidate deletes everything inside it, but `git status` on the candidate
+/// says nothing about a nested checkout — `.claude/worktrees/` is gitignored on
+/// this repo's `main` (`.gitignore:40`), so seven registered agent worktrees
+/// inside `.base/.worktrees/2eb72dca-…` produced `dirty_files = 0`. Worse, the
+/// #3649 ownership gate deliberately REFUSES to delete those nested worktrees
+/// directly (no sentinel ⇒ owner-unknown), so the sweep would have honoured
+/// that refusal and then deleted the directory they live in — bypassing its own
+/// guard by removing the parent.
+/// What: every nested root from [`nested_repo_roots`] is put through
+/// [`inspect_dirt_at`] with the nested scan off. A nested root that is dirty OR
+/// unassessable makes the PARENT dirty; one that is provably clean and pushed
+/// does not, so a session that merely once spawned an agent worktree stays
+/// reclaimable. The reported counts are the nested root's own, unmodified.
+/// Test: `inspect_dirt_reports_nested_gitignored_worktree`,
+/// `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`,
+/// `inspect_dirt_allows_clean_nested_worktree`.
+fn nested_dirt(candidate: &Path) -> Option<DirtyWorktree> {
+    let roots = match nested_repo_roots(candidate) {
+        Ok(r) => r,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                candidate,
+                format!("nested-repository scan failed: {e}"),
+                0,
+                0,
+            ));
+        }
     };
-    // Git quotes paths containing unusual characters; neither artefact's name
-    // ever needs quoting, so a quoted path is by definition something else.
-    let path = rest.trim();
-    path == super::decommission::WORKTREE_SENTINEL_FILE
-        || path == ".trusty-mpm/"
-        || path.starts_with(".trusty-mpm/")
+    for root in roots {
+        // A clean, pushed nested root does not pin the parent — keep looking.
+        let Some(inner) = inspect_dirt_at(&root, false) else {
+            continue;
+        };
+        let shown = root
+            .strip_prefix(candidate)
+            .unwrap_or(&root)
+            .display()
+            .to_string();
+        return Some(DirtyWorktree::new(
+            candidate,
+            format!(
+                "nested git worktree/repository `{shown}` holds unsaved work \
+                 that `git status` on this directory cannot see: {}",
+                inner.reason
+            ),
+            inner.dirty_files,
+            inner.unpushed_commits,
+        ));
+    }
+    None
+}
+
+/// Enumerate every nested repository root strictly beneath `candidate`.
+///
+/// Why: "does this directory contain a checkout" must be answered EXACTLY, not
+/// heuristically, because the answer decides whether gigabytes get deleted. Two
+/// disjoint populations exist and neither subsumes the other: worktrees
+/// REGISTERED with the enclosing repository (the `.claude/worktrees/…` shape,
+/// free to enumerate — git already knows) and independent clones that git has
+/// never heard of (only findable on disk).
+/// What: the union of (a) `worktree list --porcelain` entries that are strict
+/// descendants of `candidate` — exact, at any depth, and immune to gitignore
+/// because git's own bookkeeping is the source — and (b) a bounded walk of the
+/// gitignored subtrees `git status --ignored` reports, looking for a `.git`
+/// entry. Untracked-but-not-ignored nested repos need no walk at all: they
+/// already surface as `??` lines in [`count_dirty_files`].
+/// Test: `inspect_dirt_reports_nested_gitignored_worktree`,
+/// `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`.
+fn nested_repo_roots(candidate: &Path) -> Result<Vec<PathBuf>, String> {
+    let canonical =
+        std::fs::canonicalize(candidate).map_err(|e| format!("candidate is unreadable: {e}"))?;
+    let mut roots: BTreeSet<PathBuf> = BTreeSet::new();
+
+    for line in git_stdout(candidate, &["worktree", "list", "--porcelain"])?.lines() {
+        let Some(raw) = line.strip_prefix("worktree ") else {
+            continue;
+        };
+        let listed = PathBuf::from(raw.trim());
+        let listed = std::fs::canonicalize(&listed).unwrap_or(listed);
+        if listed != canonical && listed.starts_with(&canonical) {
+            roots.insert(listed);
+        }
+    }
+
+    let mut budget = IGNORED_SCAN_ENTRY_BUDGET;
+    for line in git_stdout(candidate, IGNORED_STATUS_ARGS)?.lines() {
+        let Some(raw) = line.strip_prefix("!! ") else {
+            continue;
+        };
+        let entry = raw.trim();
+        if entry.starts_with('"') {
+            return Err(format!(
+                "ignored entry `{entry}` has a quoted path this scan cannot interpret"
+            ));
+        }
+        scan_for_repos(
+            &canonical.join(entry.trim_end_matches('/')),
+            &mut roots,
+            &mut budget,
+        )?;
+    }
+    Ok(roots.into_iter().collect())
+}
+
+/// Walk `root`, collecting directories that contain a `.git` entry.
+///
+/// Why: an unregistered clone inside a gitignored directory is invisible to
+/// every git question asked of the CANDIDATE, so the only way to find it is to
+/// look. Iterative rather than recursive so a pathologically deep tree cannot
+/// overflow the stack, and symlinks are never followed — `remove_dir_all`
+/// deletes a link, not its target, so nothing beyond one is at risk.
+/// What: pushes each directory holding a `.git` entry into `out` and stops
+/// descending there. Skips [`DISPOSABLE_DIR_NAMES`] by name at every level.
+/// Exhausting `budget`, or any unreadable entry, is an `Err` the caller turns
+/// into DIRTY.
+/// Test: `inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir`,
+/// `inspect_dirt_does_not_scan_disposable_build_dirs`.
+fn scan_for_repos(
+    root: &Path,
+    out: &mut BTreeSet<PathBuf>,
+    budget: &mut usize,
+) -> Result<(), String> {
+    let mut stack = vec![root.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        match std::fs::symlink_metadata(&dir) {
+            // A plain file, or a symlink of any kind: nothing to descend into.
+            Ok(meta) if !meta.is_dir() => continue,
+            Ok(_) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(format!("`{}` is unreadable: {e}", dir.display())),
+        }
+        let name = dir.file_name().and_then(|n| n.to_str()).unwrap_or_default();
+        if DISPOSABLE_DIR_NAMES.contains(&name) {
+            continue;
+        }
+        let entries = std::fs::read_dir(&dir)
+            .map_err(|e| format!("`{}` is unreadable: {e}", dir.display()))?;
+        let mut children = Vec::new();
+        let mut is_repo = false;
+        for entry in entries {
+            let entry =
+                entry.map_err(|e| format!("an entry of `{}` is unreadable: {e}", dir.display()))?;
+            if *budget == 0 {
+                return Err(format!(
+                    "gitignored-subtree scan exceeded its {IGNORED_SCAN_ENTRY_BUDGET}-entry \
+                     budget at `{}`",
+                    dir.display()
+                ));
+            }
+            *budget -= 1;
+            if entry.file_name() == ".git" {
+                is_repo = true;
+                break;
+            }
+            children.push(entry.path());
+        }
+        if is_repo {
+            out.insert(dir);
+            continue;
+        }
+        stack.extend(children);
+    }
+    Ok(())
 }
 
 /// Classify a candidate that is NOT a git worktree root (#4091).
@@ -314,6 +767,52 @@ fn count_unpushed(path: &Path) -> Result<usize, String> {
         Some(up) => git_stdout(path, &["rev-list", "--count", &format!("{up}..HEAD")])?,
         None => git_stdout(path, &["rev-list", "--count", "HEAD", "--not", "--remotes"])?,
     };
+    let head = raw
+        .trim()
+        .parse::<usize>()
+        .map_err(|e| format!("unparsable rev-list count `{}`: {e}", raw.trim()))?;
+    Ok(head + count_session_branch_unpushed(path)?)
+}
+
+/// Count unpushed commits on the `session/<leaf>` branch `decommission` deletes.
+///
+/// Why: [`count_unpushed`] inspects `HEAD`, but
+/// `decommission::remove_session_worktree` step 3 force-deletes
+/// `session/<leaf>` derived from the DIRECTORY NAME, not from `HEAD`. Switching
+/// a session worktree off its own branch is routine here — the live
+/// `.base/.worktrees/2eb72dca-…` sits on `fix/4061-…`, not `session/2eb72dca-…`
+/// — and in that state HEAD is fully pushed while the session branch is not.
+/// Reproduced end-to-end on git 2.54.0: after committing on `session/sess` and
+/// switching to `main`, `rev-list --count HEAD --not --remotes` returns 0 while
+/// the branch still carries the commit. HEAD-only counting therefore returned a
+/// false CLEAN for the one branch about to be force-deleted.
+/// What: 0 when no such branch exists (`for-each-ref` exits 0 with empty output,
+/// so absence is distinguishable from a spawn failure, which stays an `Err`).
+/// Otherwise the commits on that branch reachable from no remote AND not
+/// already counted via `HEAD` — excluding `HEAD` is what stops the common
+/// "branch IS the checked-out branch" case from being counted twice.
+/// Test: `inspect_dirt_reports_unpushed_session_branch_when_head_moved`,
+/// `inspect_dirt_does_not_double_count_the_checked_out_session_branch`.
+fn count_session_branch_unpushed(path: &Path) -> Result<usize, String> {
+    let Some(leaf) = path.file_name().and_then(|n| n.to_str()) else {
+        return Ok(0);
+    };
+    let refname = format!("refs/heads/session/{leaf}");
+    let listed = git_stdout(path, &["for-each-ref", "--format=%(refname)", &refname])?;
+    if listed.trim().is_empty() {
+        return Ok(0);
+    }
+    let raw = git_stdout(
+        path,
+        &[
+            "rev-list",
+            "--count",
+            &refname,
+            "--not",
+            "--remotes",
+            "HEAD",
+        ],
+    )?;
     raw.trim()
         .parse::<usize>()
         .map_err(|e| format!("unparsable rev-list count `{}`: {e}", raw.trim()))
@@ -328,10 +827,7 @@ fn count_unpushed(path: &Path) -> Result<usize, String> {
 /// command and git's own stderr; stdout is lossily decoded.
 /// Test: `inspect_dirt_treats_missing_path_as_dirty`.
 fn git_stdout(dir: &Path, args: &[&str]) -> Result<String, String> {
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(dir)
-        .args(args)
+    let out = git_command(dir, args)
         .output()
         .map_err(|e| format!("`git {}` could not be run: {e}", args.join(" ")))?;
     if !out.status.success() {
@@ -343,6 +839,65 @@ fn git_stdout(dir: &Path, args: &[&str]) -> Result<String, String> {
         ));
     }
     Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Build a `git` invocation that cannot be steered by ambient config or
+/// environment (#4118).
+///
+/// Why: EVERY git call in this module has to be immune to the two hijacks that
+/// turn a dirty worktree into a clean report — config keys that suppress
+/// output ([`GIT_PINNED_GLOBAL_ARGS`]) and environment variables that point git
+/// at a different repository ([`GIT_ENV_REDIRECTS`]). Centralising it here is
+/// what makes "every git call" true rather than aspirational; a future call
+/// site cannot forget.
+/// What: `git <pinned globals> -C <dir> <args>`, with the redirect variables
+/// removed from the child environment.
+/// Test: `git_command_strips_repository_redirecting_env`,
+/// `git_command_pins_untracked_and_excludes_config`.
+fn git_command(dir: &Path, args: &[&str]) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.args(GIT_PINNED_GLOBAL_ARGS)
+        .arg("-C")
+        .arg(dir)
+        .args(args);
+    for key in GIT_ENV_REDIRECTS {
+        cmd.env_remove(key);
+    }
+    cmd
+}
+
+/// Decide whether a reclaim candidate may be removed, and say so out loud.
+///
+/// Why: the reclaim path has to make this decision TWICE — once while
+/// classifying candidates and again immediately before each removal (#4118
+/// TOCTOU) — and `prune.rs` sits against its 500-SLOC cap. Both call sites also
+/// have to log identically, or a reader of the daemon log cannot tell which
+/// pass spared a worktree.
+/// What: `Some(dirt)` means "do not remove this, and record it"; `None` means
+/// "proceed". Under [`DirtyWorktreePolicy::ForceDiscard`] a dirty candidate
+/// returns `None` after a `warn!` naming exactly what is about to be destroyed.
+/// Test: `prune_orphaned_worktrees_rechecks_dirt_immediately_before_removal`.
+pub(crate) fn dirt_blocks_removal(
+    candidate: &Path,
+    policy: DirtyWorktreePolicy,
+    phase: &'static str,
+) -> Option<DirtyWorktree> {
+    let dirt = inspect_dirt(candidate)?;
+    if policy == DirtyWorktreePolicy::Skip {
+        tracing::warn!(
+            path = %candidate.display(), reason = %dirt.reason, phase,
+            "prune-worktrees: candidate holds unsaved work — refusing to remove it; \
+             re-run with an explicit discard opt-in only if the work is genuinely \
+             disposable (#4091)"
+        );
+        return Some(dirt);
+    }
+    tracing::warn!(
+        path = %candidate.display(), reason = %dirt.reason, phase,
+        "prune-worktrees: DISCARDING unsaved work — explicit force-discard opt-in \
+         was supplied (#4091)"
+    );
+    None
 }
 
 /// Best-effort cross-check: does `git worktree list` on the checkout owning
@@ -376,11 +931,7 @@ pub(crate) fn git_worktree_list_agrees(candidate: &Path) -> bool {
     let Some(repo_root) = candidate.parent().and_then(|p| p.parent()) else {
         return true;
     };
-    let out = Command::new("git")
-        .arg("-C")
-        .arg(repo_root)
-        .args(["worktree", "list", "--porcelain"])
-        .output();
+    let out = git_command(repo_root, &["worktree", "list", "--porcelain"]).output();
     let Ok(out) = out else {
         return true; // best-effort: git unavailable must never block a delete
     };

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -1,0 +1,404 @@
+//! Pre-deletion safety checks for an orphaned-worktree reclaim candidate
+//! (#3649 `git worktree list` cross-check, extended #4091 dirty-tree guard).
+//!
+//! Why: before #4091 the reclaim path's ENTIRE safety model was "who owned
+//! this directory" — the #3649 ownership sentinel plus the
+//! [`git_worktree_list_agrees`] cross-check. Neither asks the one question an
+//! operator actually cares about: *is there unsaved work in here*. A worktree
+//! with a KNOWN owner that passed the owner-terminal + grace-window gates was
+//! force-deleted (`git worktree remove --force`, falling back to
+//! `fs::remove_dir_all`) with uncommitted edits still in it, silently. Worse,
+//! `decommission::remove_session_worktree` also runs
+//! `git branch -D session/<leaf>` on success, so commits made on the
+//! worktree's own branch and never pushed lose their last reachable ref too —
+//! committed work is genuinely destroyed by a reclaim, not merely detached.
+//! Ownership answers "may I delete this"; it must not also have to answer "is
+//! this safe to delete".
+//! What: [`DirtyWorktreePolicy`] (skip vs. explicit force-discard),
+//! [`DirtyWorktree`] (a reportable skip record), [`inspect_dirt`] (the check
+//! itself), and [`git_worktree_list_agrees`] (moved here verbatim from
+//! `prune.rs`, which is at its 500-SLOC cap — these are the same category of
+//! check and belong together).
+//!
+//! FAIL-SAFE DIRECTION: every error path in this module resolves to DIRTY.
+//! A git subprocess that cannot be spawned, exits non-zero, or emits an
+//! unparsable count, and a directory that cannot be read, all mean "this
+//! check could not prove the directory is safe to delete" — which must never
+//! become a green light to delete. That inverts the whole point.
+//! Test: `worktree_safety_tests`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use serde::Serialize;
+
+/// What the reclaim path does when a candidate holds unsaved work (#4091).
+///
+/// Why: the default must be impossible to trigger accidentally — an ordinary
+/// `/tm-session-pause` (which prunes by DEFAULT, `prune_worktrees` unwrapping
+/// to `true`) must never be able to discard uncommitted work. Modelling the
+/// override as its own two-variant enum rather than a `force: bool` keeps it
+/// from being positionally confused with the `dry_run: bool` that already sits
+/// next to it in [`super::prune::SessionManager::prune_orphaned_worktrees`]'s
+/// signature, where a swapped argument would mean "really delete, and discard
+/// dirty work" instead of "preview".
+/// What: [`Skip`](Self::Skip) (the [`Default`]) refuses to remove a dirty
+/// candidate and reports it; [`ForceDiscard`](Self::ForceDiscard) removes it
+/// anyway, and is reachable ONLY from the explicit `discard_dirty` flag on the
+/// `prune-worktrees` HTTP route / `tm session prune-worktrees --discard-dirty`.
+/// Test: `dirty_policy_defaults_to_skip`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum DirtyWorktreePolicy {
+    /// Refuse to remove a candidate holding unsaved work; report it instead.
+    #[default]
+    Skip,
+    /// Explicit opt-in: remove the candidate even though work will be lost.
+    ForceDiscard,
+}
+
+/// A reclaim candidate that was skipped because it holds unsaved work (#4091).
+///
+/// Why: "never silently" is half the fix. A skipped worktree that only shows
+/// up as a log line is invisible to the MCP caller, the HTTP client, and the
+/// `/tm-session-pause` skill — so the operator sweeping ~95 worktrees would
+/// have no idea which ones still hold work. This is the structured, wire-
+/// serializable form that every surface returns.
+/// What: the candidate `path`, a human-readable `reason`, and the two counts
+/// behind that reason — `dirty_files` (working-tree entries reported by
+/// `git status --porcelain`, i.e. modified/staged tracked files PLUS
+/// untracked-but-not-ignored files) and `unpushed_commits`.
+/// Test: `inspect_dirt_reports_modified_tracked_file`,
+/// `inspect_dirt_reports_untracked_file`, `inspect_dirt_reports_unpushed_commit`.
+#[derive(Debug, Clone, Serialize)]
+pub struct DirtyWorktree {
+    /// The candidate directory that was NOT removed.
+    pub path: PathBuf,
+    /// Human-readable explanation of what was found (or why it is unknown).
+    pub reason: String,
+    /// Working-tree entries from `git status --porcelain` (0 when unknown).
+    pub dirty_files: usize,
+    /// Commits on `HEAD` not present on the upstream / any remote (0 when unknown).
+    pub unpushed_commits: usize,
+}
+
+impl DirtyWorktree {
+    /// Build a skip record for `path` with an explicit reason and counts.
+    fn new(path: &Path, reason: impl Into<String>, dirty_files: usize, unpushed: usize) -> Self {
+        Self {
+            path: path.to_path_buf(),
+            reason: reason.into(),
+            dirty_files,
+            unpushed_commits: unpushed,
+        }
+    }
+}
+
+/// Does this reclaim candidate hold work that removal would destroy (#4091)?
+///
+/// Why: this is the check the reclaim path never had. It is deliberately the
+/// LAST gate — it runs only on candidates the #3649 ownership gate has already
+/// approved, so it is additive and cannot weaken that guard.
+/// What: returns `None` only when the directory is PROVABLY free of unsaved
+/// work; `Some(DirtyWorktree)` in every other case, including every error.
+/// "Dirty" means any of:
+/// 1. `git status --porcelain` reports at least one entry — modified or staged
+///    tracked files AND untracked-but-not-ignored files, in one command
+///    (ignored files are excluded by design: build artefacts are not work, and
+///    so are trusty-mpm's own untracked artefacts — see [`is_tool_bookkeeping`]);
+/// 2. at least one commit on `HEAD` is not on the branch's upstream (when one
+///    is configured) or, with no upstream, is not on ANY remote-tracking ref.
+///    This second leg matters because `remove_session_worktree` deletes the
+///    worktree's `session/<leaf>` branch, so unpushed commits lose their last
+///    reachable ref;
+/// 3. the directory is not a git worktree ROOT at all and is not empty — see
+///    [`non_git_dirt`];
+/// 4. any check errored — see the module-level FAIL-SAFE note.
+///
+/// The worktree-root identity check is not incidental: running
+/// `git status` inside a plain directory that happens to sit INSIDE a checkout
+/// would report the ENCLOSING repository's status, which is both wrong and
+/// misleading, so the toplevel must canonicalize to the candidate itself.
+/// Test: `inspect_dirt_clean_pushed_worktree_is_none`,
+/// `inspect_dirt_reports_modified_tracked_file`,
+/// `inspect_dirt_reports_untracked_file`,
+/// `inspect_dirt_reports_unpushed_commit`,
+/// `inspect_dirt_treats_missing_path_as_dirty`,
+/// `inspect_dirt_treats_non_worktree_with_files_as_dirty`,
+/// `inspect_dirt_allows_empty_non_git_leftover`.
+pub(crate) fn inspect_dirt(path: &Path) -> Option<DirtyWorktree> {
+    match is_worktree_root(path) {
+        Ok(true) => {}
+        // Not a git worktree root (or git cannot tell us) — fall back to the
+        // "is it even empty" question, the only one answerable without git.
+        Ok(false) | Err(_) => return non_git_dirt(path),
+    }
+
+    let status = match git_stdout(path, &["status", "--porcelain"]) {
+        Ok(s) => s,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                path,
+                format!("dirty-check failed: {e}"),
+                0,
+                0,
+            ));
+        }
+    };
+    let dirty_files = status
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .filter(|l| !is_tool_bookkeeping(l))
+        .count();
+
+    let unpushed = match count_unpushed(path) {
+        Ok(n) => n,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                path,
+                format!("dirty-check failed: {e}"),
+                dirty_files,
+                0,
+            ));
+        }
+    };
+
+    if dirty_files == 0 && unpushed == 0 {
+        return None;
+    }
+    let reason =
+        format!("{dirty_files} uncommitted/untracked file(s), {unpushed} unpushed commit(s)");
+    Some(DirtyWorktree::new(path, reason, dirty_files, unpushed))
+}
+
+/// Is this `git status --porcelain` line trusty-mpm's OWN bookkeeping rather
+/// than somebody's work (#4091)?
+///
+/// Why: this exclusion is what keeps the guard from degenerating into "never
+/// reclaim anything". trusty-mpm writes two artefacts into EVERY managed
+/// worktree it creates — the `.trusty-mpm-worktree` ownership sentinel
+/// (`create_session_worktree`) and the `.trusty-mpm/` scrollback-snapshot
+/// directory (`snapshot::write_scrollback`) — and neither is typically
+/// gitignored by the host project. Counting them would mark every single
+/// managed worktree permanently dirty, which is worse than useless: it stops
+/// all reclamation AND buries the genuinely-dirty worktrees in noise, which is
+/// how a safety report gets ignored.
+/// What: excuses a line ONLY when it is UNTRACKED (`??`) and its path is the
+/// sentinel file or lives under `.trusty-mpm/`. A TRACKED modification is
+/// never excused, no matter its path — if a project tracks
+/// `.trusty-mpm/INSTRUCTIONS.md` and someone edited it, that is real work.
+/// Test: `inspect_dirt_excludes_own_sentinel`,
+/// `inspect_dirt_excludes_untracked_trusty_mpm_dir`,
+/// `inspect_dirt_counts_tracked_trusty_mpm_edit`.
+fn is_tool_bookkeeping(line: &str) -> bool {
+    let Some(rest) = line.strip_prefix("?? ") else {
+        return false;
+    };
+    // Git quotes paths containing unusual characters; neither artefact's name
+    // ever needs quoting, so a quoted path is by definition something else.
+    let path = rest.trim();
+    path == super::decommission::WORKTREE_SENTINEL_FILE
+        || path == ".trusty-mpm/"
+        || path.starts_with(".trusty-mpm/")
+}
+
+/// Classify a candidate that is NOT a git worktree root (#4091).
+///
+/// Why: the orphan sweep's original purpose (#1838) is reclaiming the leftover
+/// `.worktrees/<id>` SHELLS that accumulate when `git worktree remove` never
+/// ran or half-ran — one project grew 94 of them. Those shells carry no git
+/// metadata, so no git-based dirty check can speak to them, and treating every
+/// one as dirty would neuter reclamation entirely (the guard must not become a
+/// permanent leak). But a non-git directory that still holds FILES is exactly
+/// the case we cannot assess, and the fail-safe direction is to keep it.
+/// What: `None` when the directory holds nothing but the trusty-mpm ownership
+/// sentinel (an empty shell — provably no work); `Some` otherwise, including
+/// when the directory cannot be read at all.
+/// Test: `inspect_dirt_allows_empty_non_git_leftover`,
+/// `inspect_dirt_treats_non_worktree_with_files_as_dirty`,
+/// `inspect_dirt_treats_missing_path_as_dirty`.
+fn non_git_dirt(path: &Path) -> Option<DirtyWorktree> {
+    let entries = match std::fs::read_dir(path) {
+        Ok(e) => e,
+        Err(e) => {
+            return Some(DirtyWorktree::new(
+                path,
+                format!("not a git worktree and the directory is unreadable: {e}"),
+                0,
+                0,
+            ));
+        }
+    };
+    let mut count = 0usize;
+    for entry in entries {
+        let Ok(entry) = entry else {
+            return Some(DirtyWorktree::new(
+                path,
+                "not a git worktree and a directory entry is unreadable",
+                count,
+                0,
+            ));
+        };
+        if entry.file_name() == super::decommission::WORKTREE_SENTINEL_FILE {
+            continue;
+        }
+        count += 1;
+    }
+    if count == 0 {
+        return None;
+    }
+    Some(DirtyWorktree::new(
+        path,
+        format!(
+            "not a git worktree root, but holds {count} entr(y/ies) whose contents \
+             cannot be verified as saved"
+        ),
+        count,
+        0,
+    ))
+}
+
+/// Does `path` canonicalize to its own git worktree toplevel?
+///
+/// Why: `git -C <dir> status` happily answers for an ENCLOSING repository when
+/// `dir` is merely nested inside one, so an identity check is required before
+/// any status output can be attributed to the candidate itself.
+/// What: `Ok(true)` when `git rev-parse --show-toplevel` canonicalizes to the
+/// same path as `path`; `Ok(false)` when it resolves elsewhere; `Err` when git
+/// cannot answer (not a repository, git missing, spawn failure).
+/// Test: `inspect_dirt_treats_non_worktree_with_files_as_dirty` (the nested
+/// plain-directory case), `inspect_dirt_clean_pushed_worktree_is_none`.
+fn is_worktree_root(path: &Path) -> Result<bool, String> {
+    let top = git_stdout(path, &["rev-parse", "--show-toplevel"])?;
+    let top = PathBuf::from(top.trim());
+    if top.as_os_str().is_empty() {
+        return Ok(false);
+    }
+    let resolved_top = std::fs::canonicalize(&top).unwrap_or(top);
+    let resolved_self =
+        std::fs::canonicalize(path).map_err(|e| format!("candidate is unreadable: {e}"))?;
+    Ok(resolved_top == resolved_self)
+}
+
+/// Count commits on `HEAD` that are not yet safely on a remote (#4091).
+///
+/// Why: `decommission::remove_session_worktree` deletes the worktree's
+/// `session/<leaf>` branch after a successful removal, so a commit that exists
+/// only on that branch loses its last reachable ref and becomes garbage-
+/// collectable. "Committed" is therefore NOT the same as "safe".
+/// What: when the checked-out branch has an upstream, counts
+/// `<upstream>..HEAD`. With NO upstream configured, counts commits reachable
+/// from `HEAD` but from no remote-tracking ref at all
+/// (`rev-list --count HEAD --not --remotes`) — which subsumes the
+/// "not on `origin/main`" rule (a commit absent from `origin/main` AND every
+/// other remote ref is counted) while not falsely flagging a branch that WAS
+/// pushed under its own name but never had upstream tracking configured. In a
+/// repository with no remotes at all, `--remotes` expands to nothing and every
+/// commit counts as unpushed — the correct, conservative answer.
+/// Test: `inspect_dirt_reports_unpushed_commit`,
+/// `inspect_dirt_clean_pushed_worktree_is_none`.
+fn count_unpushed(path: &Path) -> Result<usize, String> {
+    let upstream = git_stdout(
+        path,
+        &[
+            "rev-parse",
+            "--abbrev-ref",
+            "--symbolic-full-name",
+            "@{upstream}",
+        ],
+    )
+    .ok()
+    .map(|s| s.trim().to_string())
+    .filter(|s| !s.is_empty());
+
+    let raw = match upstream {
+        Some(up) => git_stdout(path, &["rev-list", "--count", &format!("{up}..HEAD")])?,
+        None => git_stdout(path, &["rev-list", "--count", "HEAD", "--not", "--remotes"])?,
+    };
+    raw.trim()
+        .parse::<usize>()
+        .map_err(|e| format!("unparsable rev-list count `{}`: {e}", raw.trim()))
+}
+
+/// Run `git -C <dir> <args>` and return stdout, or an error string.
+///
+/// Why: every check in this module needs the same "ran, exited zero, gave me
+/// stdout" contract, and every deviation from it must surface as an `Err` the
+/// caller turns into DIRTY rather than being swallowed.
+/// What: non-zero exit and spawn failure both become `Err` carrying the
+/// command and git's own stderr; stdout is lossily decoded.
+/// Test: `inspect_dirt_treats_missing_path_as_dirty`.
+fn git_stdout(dir: &Path, args: &[&str]) -> Result<String, String> {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map_err(|e| format!("`git {}` could not be run: {e}", args.join(" ")))?;
+    if !out.status.success() {
+        return Err(format!(
+            "`git {}` failed ({}): {}",
+            args.join(" "),
+            out.status,
+            String::from_utf8_lossy(&out.stderr).trim()
+        ));
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).into_owned())
+}
+
+/// Best-effort cross-check: does `git worktree list` on the checkout owning
+/// `candidate` agree that `candidate` is a real, currently-registered git
+/// worktree (#3649)?
+///
+/// Why: the sentinel + store-ownerless checks establish WHO owned this
+/// directory and whether that owner is provably gone, but neither confirms
+/// git's OWN bookkeeping still recognises the path as a worktree at all — a
+/// belt-and-suspenders safety net against deleting a directory that merely
+/// LOOKS like a worktree (e.g. its git worktree entry was already pruned by
+/// something else, or the shape matched by coincidence). A disagreement is
+/// treated conservatively: skip rather than delete.
+/// What: runs `git -C <repo_root> worktree list --porcelain`, where
+/// `repo_root` is `candidate`'s grandparent directory — the SAME derivation
+/// `decommission::remove_session_worktree` uses, which works identically for
+/// both worktree-store shapes (`<repo>/.worktrees/<name>` and
+/// `<repo>/.base/.worktrees/<id>`, since either way the grandparent of the
+/// worktree leaf is the git checkout root). Returns `true` (agree — deletion
+/// may proceed, subject to the caller's other checks) when the git command
+/// cannot be run or fails outright — this check is an ADDITIONAL safety net
+/// on top of the sentinel/store checks, not a replacement for them, so a
+/// missing `git` binary or a transient failure never blocks a deletion those
+/// checks already approved. It is emphatically NOT the fail-safe gate; that
+/// role belongs to [`inspect_dirt`], which fails toward DIRTY. Returns `true`
+/// only when `candidate`'s canonicalized path appears among the porcelain
+/// output's `worktree <path>` lines.
+/// Test: `git_worktree_list_agrees_true_for_real_worktree`,
+///       `git_worktree_list_agrees_false_for_untracked_dir`.
+pub(crate) fn git_worktree_list_agrees(candidate: &Path) -> bool {
+    let Some(repo_root) = candidate.parent().and_then(|p| p.parent()) else {
+        return true;
+    };
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(repo_root)
+        .args(["worktree", "list", "--porcelain"])
+        .output();
+    let Ok(out) = out else {
+        return true; // best-effort: git unavailable must never block a delete
+    };
+    if !out.status.success() {
+        return true;
+    }
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let canonical_candidate =
+        std::fs::canonicalize(candidate).unwrap_or_else(|_| candidate.to_path_buf());
+    stdout
+        .lines()
+        .filter_map(|l| l.strip_prefix("worktree "))
+        .any(|p| {
+            let pb = PathBuf::from(p);
+            std::fs::canonicalize(&pb).unwrap_or(pb) == canonical_candidate
+        })
+}
+
+#[cfg(test)]
+#[path = "worktree_safety_tests.rs"]
+mod worktree_safety_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -519,6 +519,53 @@ fn inspect_dirt_reports_unpushed_session_branch_when_head_moved() {
     );
 }
 
+/// The `.base/.worktrees/<session-id>` shape — the DOMINANT population of the
+/// sweep — has its branch named BARE by `provisioner/workspace.rs:803`
+/// (`session_id.to_string()`), not `session/<id>`. Checking only the prefixed
+/// spelling left this leg inert exactly where most worktrees live.
+///
+/// Deliberately conservative: `branch -D session/<id>` currently MISSES the
+/// bare branch, so it survives removal today. The divergence is a live
+/// pre-existing bug that will be repaired on one side or the other, and if it
+/// is repaired on the `remove_session_worktree` side then bare branches start
+/// being destroyed. A guard that goes silently inert because somebody fixed an
+/// unrelated naming bug is the failure mode this module exists to prevent.
+#[test]
+fn inspect_dirt_reports_unpushed_bare_leaf_branch_when_head_moved() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("bare-branch");
+    // Re-point the worktree at a BARE branch named after the leaf, the way the
+    // provisioner names it, then commit on it and switch HEAD away.
+    for args in [
+        vec!["switch", "-c", "bare-branch"],
+        vec!["branch", "-D", "session/bare-branch"],
+    ] {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&wt)
+            .args(&args)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{args:?}: {out:?}");
+    }
+    GitWorktreeFixture::commit_unpushed(&wt);
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["switch", "--detach", "origin/main"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+
+    let dirt = inspect_dirt(&wt)
+        .expect("an unpushed commit on the bare leaf-named branch must read as dirty");
+    assert_eq!(
+        dirt.unpushed_commits, 1,
+        "HEAD is pushed but the bare `bare-branch` is not; reason: {}",
+        dirt.reason
+    );
+}
+
 /// The counterweight to the test above: when the session branch IS the
 /// checked-out branch, its commits must be counted ONCE, not twice.
 #[test]

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -124,20 +124,110 @@ fn inspect_dirt_excludes_own_sentinel() {
     );
 }
 
-/// The untracked `.trusty-mpm/` scrollback-snapshot directory the daemon
-/// writes into every managed workspace must not count as work either.
+/// The two DISPOSABLE `.trusty-mpm/` artefacts — and only those — must not
+/// count as work. The daemon rewrites both on every snapshot.
 #[test]
 fn inspect_dirt_excludes_untracked_trusty_mpm_dir() {
     let fx = GitWorktreeFixture::new();
     let wt = fx.add_worktree("scrollback");
     std::fs::create_dir_all(wt.join(".trusty-mpm")).unwrap();
     std::fs::write(wt.join(".trusty-mpm").join("scrollback.txt"), "pane dump\n").unwrap();
+    std::fs::write(
+        wt.join(".trusty-mpm").join("last-instructions.md"),
+        "brief\n",
+    )
+    .unwrap();
 
     assert!(
         inspect_dirt(&wt).is_none(),
-        "the daemon's own scrollback dir must not make a worktree dirty; got {:?}",
+        "the daemon's own scrollback artefacts must not make a worktree dirty; got {:?}",
         inspect_dirt(&wt)
     );
+}
+
+/// THE REGRESSION THIS ROUND EXISTS FOR: hand-rescued source parked under
+/// `.trusty-mpm/` must read as work.
+///
+/// Why this exact shape: on 2026-07-27 the live session worktree
+/// `.base/.worktrees/2eb72dca-…` held
+/// `.trusty-mpm/wip-backup-20260727-jira/` containing twelve files of
+/// uncommitted `trusty-git-analytics` source, deliberately preserved by an
+/// earlier rescue operation. The first cut of this guard excused the whole
+/// `.trusty-mpm/` subtree by prefix, so `dirty_files` stayed 0, `inspect_dirt`
+/// returned `None`, and `git worktree remove --force` would have destroyed it
+/// silently. The carve-out is now an allowlist of two exact paths.
+#[test]
+fn inspect_dirt_counts_wip_backup_under_trusty_mpm() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("wip-backup");
+    let wip = wt.join(".trusty-mpm").join("wip-backup-20260727-jira");
+    std::fs::create_dir_all(wip.join("crates").join("foo").join("src")).unwrap();
+    std::fs::write(
+        wip.join("crates").join("foo").join("src").join("main.rs"),
+        "fn main() { /* rescued, uncommitted */ }\n",
+    )
+    .unwrap();
+    // The disposable artefacts sit alongside it, exactly as they do live.
+    std::fs::write(wt.join(".trusty-mpm").join("scrollback.txt"), "pane dump\n").unwrap();
+
+    let dirt = inspect_dirt(&wt).expect("rescued source under .trusty-mpm/ must read as dirty");
+    assert_eq!(
+        dirt.dirty_files, 1,
+        "the wip-backup tree must count and the scrollback must not; reason: {}",
+        dirt.reason
+    );
+}
+
+/// Pause snapshots under `.trusty-mpm/sessions/` are what `/tm-session-resume`
+/// reads back, and this PR's own skill change tells operators to trust the
+/// pause path. They are not disposable.
+#[test]
+fn inspect_dirt_counts_pause_snapshots_under_trusty_mpm() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("pause-snapshots");
+    std::fs::create_dir_all(wt.join(".trusty-mpm").join("sessions")).unwrap();
+    std::fs::write(
+        wt.join(".trusty-mpm").join("sessions").join("s-01.md"),
+        "# paused session\n",
+    )
+    .unwrap();
+
+    let dirt = inspect_dirt(&wt).expect("pause snapshots must read as dirty");
+    assert!(dirt.dirty_files >= 1, "reason: {}", dirt.reason);
+}
+
+/// The SAME `.trusty-mpm/` content must read as dirty when the project
+/// GITIGNORES it, which is how this repo's `main` spells it (`.gitignore:49`,
+/// `.trusty-mpm/*`). Plain `git status` cannot see it at all in that spelling —
+/// only the per-file `--ignored=matching` pass can. Both spellings are live in
+/// the fleet simultaneously, on different branches of this one repo.
+#[test]
+fn inspect_dirt_counts_gitignored_trusty_mpm_work() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("ignored-tm");
+    std::fs::write(wt.join(".gitignore"), ".trusty-mpm/*\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&wt, "gitignore .trusty-mpm");
+    std::fs::create_dir_all(wt.join(".trusty-mpm").join("wip-backup-x")).unwrap();
+    std::fs::write(
+        wt.join(".trusty-mpm").join("wip-backup-x").join("main.rs"),
+        "fn main() {}\n",
+    )
+    .unwrap();
+
+    // Prove the premise: plain porcelain really is blind to it.
+    let plain = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&plain.stdout).trim().is_empty(),
+        "premise broken: plain porcelain should not see the gitignored subtree"
+    );
+
+    let dirt = inspect_dirt(&wt).expect("gitignored .trusty-mpm/ work must still read as dirty");
+    assert!(dirt.dirty_files >= 1, "reason: {}", dirt.reason);
 }
 
 /// The counterweight: a TRACKED file under `.trusty-mpm/` that someone edited
@@ -188,6 +278,308 @@ fn inspect_dirt_reports_unpushed_commit() {
     let dirt = inspect_dirt(&wt).expect("an unpushed commit must read as dirty");
     assert_eq!(dirt.dirty_files, 0, "reason: {}", dirt.reason);
     assert_eq!(dirt.unpushed_commits, 1, "reason: {}", dirt.reason);
+}
+
+/// THE CRITICAL: a parent worktree containing a GITIGNORED nested worktree
+/// holding uncommitted work must read as DIRTY.
+///
+/// Why: `.gitignore:40` on this repo's `main` ignores `.claude/worktrees/`, the
+/// exact shape `find_orphaned_worktrees` location 5 exists to walk. The nested
+/// worktrees carry no ownership sentinel, so the #3649 gate routes them to
+/// `owner_unknown` and REFUSES to delete them — and then the sweep would delete
+/// the parent they live inside, having certified it clean. The guard was
+/// bypassable by deleting its own parent.
+#[test]
+fn inspect_dirt_reports_nested_gitignored_worktree() {
+    let fx = GitWorktreeFixture::new();
+    let parent = fx.add_worktree("parent");
+    std::fs::write(parent.join(".gitignore"), ".claude/worktrees/\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&parent, "ignore agent worktrees");
+    let nested = fx.add_nested_worktree(&parent, ".claude/worktrees", "agentA");
+    std::fs::write(nested.join("patch.rs"), "// agent work, never committed\n").unwrap();
+
+    // Prove the premise: the parent's own porcelain really is blind to it.
+    let plain = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&parent)
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&plain.stdout).trim().is_empty(),
+        "premise broken: plain porcelain should not see the gitignored nested worktree"
+    );
+
+    let dirt = inspect_dirt(&parent)
+        .expect("a nested worktree holding uncommitted work must make the parent dirty");
+    assert!(
+        dirt.reason.contains("nested git worktree/repository"),
+        "unexpected reason: {}",
+        dirt.reason
+    );
+}
+
+/// The same hole, but via an UNREGISTERED repository — an independent clone
+/// dropped into a gitignored directory. `git worktree list` has never heard of
+/// it, so only the on-disk scan can find it.
+#[test]
+fn inspect_dirt_reports_unregistered_nested_repo_in_ignored_dir() {
+    let fx = GitWorktreeFixture::new();
+    let parent = fx.add_worktree("with-clone");
+    std::fs::write(parent.join(".gitignore"), "scratch/\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&parent, "ignore scratch");
+    let inner = parent.join("scratch").join("side-project");
+    std::fs::create_dir_all(&inner).unwrap();
+    for args in [vec!["init", "--initial-branch=main"], vec!["status"]] {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&inner)
+            .args(&args)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{args:?}: {out:?}");
+    }
+    std::fs::write(inner.join("work.rs"), "// never committed anywhere\n").unwrap();
+
+    let dirt = inspect_dirt(&parent)
+        .expect("an unregistered nested repo holding work must make the parent dirty");
+    assert!(
+        dirt.reason.contains("nested git worktree/repository"),
+        "unexpected reason: {}",
+        dirt.reason
+    );
+}
+
+/// The counterweight, and it matters as much as the finding: a nested worktree
+/// that is itself CLEAN and pushed must NOT pin the parent.
+///
+/// Why: without this, any session that ever spawned an agent worktree would be
+/// permanently unreclaimable, which is the "guard that silently disables
+/// reclamation" failure mode — indistinguishable from having no sweep at all.
+#[test]
+fn inspect_dirt_allows_clean_nested_worktree() {
+    let fx = GitWorktreeFixture::new();
+    let parent = fx.add_worktree("clean-parent");
+    std::fs::write(parent.join(".gitignore"), ".claude/worktrees/\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&parent, "ignore agent worktrees");
+    let nested = fx.add_nested_worktree(&parent, ".claude/worktrees", "agentClean");
+    std::fs::write(nested.join("done.rs"), "// finished agent work\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&nested, "agent work, pushed");
+
+    assert!(
+        inspect_dirt(&parent).is_none(),
+        "a clean, pushed nested worktree must not pin the parent; got {:?}",
+        inspect_dirt(&parent)
+    );
+}
+
+/// A dirty nested worktree sitting BEHIND a clean one must still be found.
+///
+/// Why this test exists: it pins a real bug. The first cut of the scan used
+/// `?` on the per-root inspection, so the first CLEAN nested root returned
+/// `None` for the whole scan and every root after it went unexamined — a parent
+/// with one finished agent worktree and one in-flight one read CLEAN. Roots are
+/// visited in sorted order, so `aaa-clean` is checked before `zzz-dirty`.
+#[test]
+fn inspect_dirt_keeps_scanning_past_a_clean_nested_worktree() {
+    let fx = GitWorktreeFixture::new();
+    let parent = fx.add_worktree("two-nested");
+    std::fs::write(parent.join(".gitignore"), ".claude/worktrees/\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&parent, "ignore agent worktrees");
+
+    let clean = fx.add_nested_worktree(&parent, ".claude/worktrees", "aaa-clean");
+    std::fs::write(clean.join("done.rs"), "// finished\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&clean, "finished, pushed");
+
+    let dirty = fx.add_nested_worktree(&parent, ".claude/worktrees", "zzz-dirty");
+    std::fs::write(dirty.join("wip.rs"), "// in flight, never committed\n").unwrap();
+
+    let dirt = inspect_dirt(&parent)
+        .expect("a dirty nested worktree behind a clean one must still make the parent dirty");
+    assert!(
+        dirt.reason.contains("zzz-dirty"),
+        "the reason must name the nested worktree that is actually dirty; got: {}",
+        dirt.reason
+    );
+}
+
+/// Documents the residual, so it is a decision rather than an accident: the
+/// nested-repo scan does NOT descend into disposable build directories, so a
+/// repository inside `target/` is invisible. Skipping them by name is what
+/// keeps the scan affordable across ~95 candidates.
+#[test]
+fn inspect_dirt_does_not_scan_disposable_build_dirs() {
+    let fx = GitWorktreeFixture::new();
+    let parent = fx.add_worktree("disposable");
+    std::fs::write(parent.join(".gitignore"), "target/\n").unwrap();
+    GitWorktreeFixture::commit_all_and_push(&parent, "ignore target");
+    let buried = parent.join("target").join("debug").join("checkout");
+    std::fs::create_dir_all(buried.join(".git")).unwrap();
+    std::fs::write(buried.join("thing.rs"), "// inside target/\n").unwrap();
+
+    assert!(
+        inspect_dirt(&parent).is_none(),
+        "target/ is deliberately not scanned; got {:?}",
+        inspect_dirt(&parent)
+    );
+}
+
+/// HIGH-1: `status.showUntrackedFiles=no` makes bare `git status --porcelain`
+/// exit 0 with EMPTY output while untracked work sits on disk. Its natural home
+/// is the SHARED `.base/.git/config` every worktree in the sweep reads, so one
+/// line there would blind the guard fleet-wide. The mode is pinned on the
+/// command line, which beats every config file.
+#[test]
+fn inspect_dirt_survives_hostile_show_untracked_files_config() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("hostile-untracked");
+    std::fs::write(wt.join("notes.md"), "hand-written, never added\n").unwrap();
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["config", "status.showUntrackedFiles", "no"])
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    // Prove the premise: unpinned porcelain really does go silent.
+    let plain = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&plain.stdout).trim().is_empty(),
+        "premise broken: the hostile config should have silenced plain porcelain"
+    );
+
+    let dirt = inspect_dirt(&wt).expect("a hostile config must not be able to hide untracked work");
+    assert_eq!(dirt.dirty_files, 1, "reason: {}", dirt.reason);
+}
+
+/// The same class of hijack via `core.excludesFile`: a user-global excludes
+/// file naming the work hides it exactly as `showUntrackedFiles=no` does.
+/// Pinned empty on the command line.
+#[test]
+fn inspect_dirt_survives_hostile_global_excludes_file() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("hostile-excludes");
+    let excludes = fx.repo.join("hostile-excludes.txt");
+    std::fs::write(&excludes, "secret-work.txt\n").unwrap();
+    std::fs::write(wt.join("secret-work.txt"), "REAL WORK\n").unwrap();
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["config", "core.excludesFile"])
+        .arg(&excludes)
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let plain = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["status", "--porcelain"])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&plain.stdout).trim().is_empty(),
+        "premise broken: the excludes file should have hidden the work"
+    );
+
+    let dirt = inspect_dirt(&wt).expect("a hostile excludes file must not hide untracked work");
+    assert_eq!(dirt.dirty_files, 1, "reason: {}", dirt.reason);
+}
+
+/// MEDIUM: `decommission` force-deletes `session/<leaf>` derived from the
+/// DIRECTORY NAME, not from `HEAD`. When HEAD has been switched off that branch
+/// — routine; the live `.base/.worktrees/2eb72dca-…` sits on `fix/4061-…` —
+/// HEAD reads fully pushed while the branch about to be destroyed is not.
+#[test]
+fn inspect_dirt_reports_unpushed_session_branch_when_head_moved() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("moved-head");
+    GitWorktreeFixture::commit_unpushed(&wt);
+    // Switch HEAD off session/moved-head onto the pushed base commit.
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["switch", "--detach", "origin/main"])
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "{out:?}");
+
+    let dirt = inspect_dirt(&wt)
+        .expect("an unpushed commit on the branch decommission deletes must read as dirty");
+    assert_eq!(
+        dirt.unpushed_commits, 1,
+        "HEAD is pushed but session/moved-head is not; reason: {}",
+        dirt.reason
+    );
+}
+
+/// The counterweight to the test above: when the session branch IS the
+/// checked-out branch, its commits must be counted ONCE, not twice.
+#[test]
+fn inspect_dirt_does_not_double_count_the_checked_out_session_branch() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("single-count");
+    GitWorktreeFixture::commit_unpushed(&wt);
+
+    let dirt = inspect_dirt(&wt).expect("an unpushed commit must read as dirty");
+    assert_eq!(
+        dirt.unpushed_commits, 1,
+        "the same commit must not be counted by both legs; reason: {}",
+        dirt.reason
+    );
+}
+
+/// MEDIUM: `GIT_DIR` + `GIT_WORK_TREE` pointing at a clean repository make
+/// `git -C <candidate> status` answer for THAT repository — a false CLEAN. The
+/// daemon inherits whatever environment launched it. Asserted on the command
+/// itself rather than by mutating process-global environment, which is racy
+/// under a parallel test runner.
+#[test]
+fn git_command_strips_repository_redirecting_env() {
+    let cmd = super::git_command(std::path::Path::new("/tmp"), &["status"]);
+    let removed: Vec<&str> = cmd
+        .get_envs()
+        .filter(|(_, v)| v.is_none())
+        .filter_map(|(k, _)| k.to_str())
+        .collect();
+    for key in [
+        "GIT_DIR",
+        "GIT_WORK_TREE",
+        "GIT_INDEX_FILE",
+        "GIT_CONFIG_COUNT",
+    ] {
+        assert!(
+            removed.contains(&key),
+            "{key} must be removed from the child environment; removed: {removed:?}"
+        );
+    }
+}
+
+/// Every git invocation must carry the pins, not just the ones someone
+/// remembered — that is the point of routing them through one builder.
+#[test]
+fn git_command_pins_untracked_and_excludes_config() {
+    let cmd = super::git_command(std::path::Path::new("/tmp"), &["status"]);
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    for pin in [
+        "core.excludesFile=",
+        "status.showUntrackedFiles=normal",
+        "core.quotePath=false",
+    ] {
+        assert!(
+            args.iter().any(|a| a == pin),
+            "`{pin}` must be pinned on every git call; args: {args:?}"
+        );
+    }
 }
 
 /// FAIL-SAFE: a path git cannot examine at all reads as DIRTY, never as clean.

--- a/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs
@@ -1,0 +1,248 @@
+//! Unit tests for the #4091 dirty-worktree guard in `worktree_safety.rs`.
+//!
+//! Why: these exercise [`super::inspect_dirt`] in isolation against REAL git
+//! repositories built under `tempfile::tempdir()` — never a live worktree —
+//! so each "dirty" definition (modified tracked, untracked-not-ignored,
+//! committed-but-unpushed) and each fail-safe error path is pinned
+//! independently of the reclaim path that consumes them. The wired-up
+//! behaviour is covered separately by the `#4091` tests in
+//! `prune_orphan_tests`.
+//! What: the clean/pushed baseline, the three dirty definitions, the
+//! ignored-files carve-out, the non-git-directory classification, and the
+//! error-means-dirty invariant.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use super::*;
+use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+
+/// The default policy must be the SAFE one. If this ever flips, every caller
+/// that relies on `..Default::default()` silently gains the power to destroy
+/// uncommitted work.
+#[test]
+fn dirty_policy_defaults_to_skip() {
+    assert_eq!(
+        DirtyWorktreePolicy::default(),
+        DirtyWorktreePolicy::Skip,
+        "the default dirty policy must never be ForceDiscard"
+    );
+}
+
+/// Baseline: a worktree with no local edits, whose HEAD is already on a
+/// remote-tracking ref, is PROVABLY clean — the guard must return `None` so
+/// reclamation still works. Without this the guard would be a permanent leak.
+#[test]
+fn inspect_dirt_clean_pushed_worktree_is_none() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("clean");
+    assert!(
+        inspect_dirt(&wt).is_none(),
+        "a clean, fully-pushed worktree must be reclaimable; got {:?}",
+        inspect_dirt(&wt)
+    );
+}
+
+/// Definition 1a of dirty: a MODIFIED TRACKED file.
+#[test]
+fn inspect_dirt_reports_modified_tracked_file() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("modified");
+    std::fs::write(wt.join("README.md"), "edited but never committed\n").unwrap();
+
+    let dirt = inspect_dirt(&wt).expect("a modified tracked file must read as dirty");
+    assert_eq!(dirt.dirty_files, 1, "reason was: {}", dirt.reason);
+    assert_eq!(dirt.unpushed_commits, 0);
+    assert_eq!(dirt.path, wt);
+}
+
+/// Definition 1b of dirty: an UNTRACKED, non-ignored file. Untracked work is
+/// the most easily lost kind — it exists nowhere but that directory.
+#[test]
+fn inspect_dirt_reports_untracked_file() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("untracked");
+    std::fs::write(wt.join("notes.md"), "hand-written, never added\n").unwrap();
+
+    let dirt = inspect_dirt(&wt).expect("an untracked file must read as dirty");
+    assert_eq!(dirt.dirty_files, 1, "reason was: {}", dirt.reason);
+}
+
+/// The carve-out that keeps the guard usable: IGNORED files (build artefacts)
+/// are not work, and must not pin a worktree as dirty forever. A `target/`
+/// directory in every checkout would otherwise make the guard refuse
+/// everything, which is indistinguishable from having no reclamation at all.
+#[test]
+fn inspect_dirt_ignores_gitignored_files() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("ignored");
+    std::fs::write(wt.join(".gitignore"), "build-output/\n").unwrap();
+    std::fs::create_dir_all(wt.join("build-output")).unwrap();
+    std::fs::write(wt.join("build-output").join("artifact.bin"), "junk\n").unwrap();
+    // Commit the .gitignore itself so only the IGNORED path remains on disk.
+    let commit = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["add", ".gitignore"])
+        .output()
+        .unwrap();
+    assert!(commit.status.success());
+    let commit = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["commit", "-m", "ignore build output"])
+        .output()
+        .unwrap();
+    assert!(commit.status.success());
+
+    // The commit itself is unpushed, so the worktree IS dirty — but for the
+    // commit, not for the ignored artefact. Assert on the file count.
+    let dirt = inspect_dirt(&wt).expect("the new commit is unpushed, so this is dirty");
+    assert_eq!(
+        dirt.dirty_files, 0,
+        "ignored build output must not count as uncommitted work; reason: {}",
+        dirt.reason
+    );
+    assert_eq!(dirt.unpushed_commits, 1, "reason: {}", dirt.reason);
+}
+
+/// trusty-mpm's OWN untracked ownership sentinel must not count as work.
+///
+/// Why this test exists: it caught a real self-inflicted bug. Every managed
+/// worktree carries a `.trusty-mpm-worktree` sentinel, and most host projects
+/// do not gitignore it — so counting it marked EVERY managed worktree
+/// permanently dirty, which would have shipped a guard that silently disabled
+/// all reclamation.
+#[test]
+fn inspect_dirt_excludes_own_sentinel() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("sentinel-only");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+
+    assert!(
+        inspect_dirt(&wt).is_none(),
+        "trusty-mpm's own sentinel must not make a worktree dirty; got {:?}",
+        inspect_dirt(&wt)
+    );
+}
+
+/// The untracked `.trusty-mpm/` scrollback-snapshot directory the daemon
+/// writes into every managed workspace must not count as work either.
+#[test]
+fn inspect_dirt_excludes_untracked_trusty_mpm_dir() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("scrollback");
+    std::fs::create_dir_all(wt.join(".trusty-mpm")).unwrap();
+    std::fs::write(wt.join(".trusty-mpm").join("scrollback.txt"), "pane dump\n").unwrap();
+
+    assert!(
+        inspect_dirt(&wt).is_none(),
+        "the daemon's own scrollback dir must not make a worktree dirty; got {:?}",
+        inspect_dirt(&wt)
+    );
+}
+
+/// The counterweight: a TRACKED file under `.trusty-mpm/` that someone edited
+/// IS real work, and the bookkeeping exclusion must not swallow it. The
+/// exclusion is scoped to untracked entries precisely so this stays protected.
+#[test]
+fn inspect_dirt_counts_tracked_trusty_mpm_edit() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("tracked-config");
+    std::fs::create_dir_all(wt.join(".trusty-mpm")).unwrap();
+    std::fs::write(wt.join(".trusty-mpm").join("INSTRUCTIONS.md"), "v1\n").unwrap();
+    for args in [
+        vec!["add", ".trusty-mpm/INSTRUCTIONS.md"],
+        vec!["commit", "-m", "track instructions"],
+    ] {
+        let out = std::process::Command::new("git")
+            .arg("-C")
+            .arg(&wt)
+            .args(&args)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "{args:?}: {:?}", out);
+    }
+    std::fs::write(
+        wt.join(".trusty-mpm").join("INSTRUCTIONS.md"),
+        "v2 edited\n",
+    )
+    .unwrap();
+
+    let dirt = inspect_dirt(&wt).expect("a tracked edit is real work, wherever it lives");
+    assert_eq!(
+        dirt.dirty_files, 1,
+        "a tracked .trusty-mpm/ edit must still count; reason: {}",
+        dirt.reason
+    );
+}
+
+/// Definition 2 of dirty: a COMMITTED but UNPUSHED commit. This looks safe —
+/// the work is committed — but `remove_session_worktree` deletes the
+/// `session/<leaf>` branch after removal, so the commit loses its last
+/// reachable ref.
+#[test]
+fn inspect_dirt_reports_unpushed_commit() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("unpushed");
+    GitWorktreeFixture::commit_unpushed(&wt);
+
+    let dirt = inspect_dirt(&wt).expect("an unpushed commit must read as dirty");
+    assert_eq!(dirt.dirty_files, 0, "reason: {}", dirt.reason);
+    assert_eq!(dirt.unpushed_commits, 1, "reason: {}", dirt.reason);
+}
+
+/// FAIL-SAFE: a path git cannot examine at all reads as DIRTY, never as clean.
+/// An error on the check must never become a green light to delete.
+#[test]
+fn inspect_dirt_treats_missing_path_as_dirty() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("does").join("not").join("exist");
+    let dirt = inspect_dirt(&missing).expect("an unexaminable path must read as dirty");
+    assert!(
+        dirt.reason.contains("unreadable") || dirt.reason.contains("not a git worktree"),
+        "unexpected reason: {}",
+        dirt.reason
+    );
+}
+
+/// A plain directory that is NOT a git worktree root but holds files cannot be
+/// assessed by git at all — and the fail-safe answer is DIRTY. This also pins
+/// the identity check: the directory sits INSIDE a real checkout, so a naive
+/// `git status` would have reported the ENCLOSING repo's (clean) status and
+/// wrongly approved deletion.
+#[test]
+fn inspect_dirt_treats_non_worktree_with_files_as_dirty() {
+    let fx = GitWorktreeFixture::new();
+    let plain = fx.repo.join(".worktrees").join("not-a-worktree");
+    std::fs::create_dir_all(&plain).unwrap();
+    std::fs::write(plain.join("leftover.txt"), "who knows\n").unwrap();
+
+    let dirt = inspect_dirt(&plain).expect("a non-worktree dir holding files must read as dirty");
+    assert_eq!(dirt.dirty_files, 1, "reason: {}", dirt.reason);
+    assert!(
+        dirt.reason.contains("not a git worktree root"),
+        "unexpected reason: {}",
+        dirt.reason
+    );
+}
+
+/// The counterweight to the test above: an EMPTY leftover shell (nothing but
+/// the ownership sentinel) is provably free of work and stays reclaimable.
+/// This is the #1838 case the orphan sweep exists for — one project grew 94 of
+/// these — so the guard must not turn it into a permanent leak.
+#[test]
+fn inspect_dirt_allows_empty_non_git_leftover() {
+    let tmp = tempfile::tempdir().unwrap();
+    let shell = tmp.path().join(".worktrees").join("empty-shell");
+    std::fs::create_dir_all(&shell).unwrap();
+    std::fs::write(
+        shell.join(super::super::decommission::WORKTREE_SENTINEL_FILE),
+        "{}",
+    )
+    .unwrap();
+
+    assert!(
+        inspect_dirt(&shell).is_none(),
+        "an empty leftover shell must stay reclaimable; got {:?}",
+        inspect_dirt(&shell)
+    );
+}


### PR DESCRIPTION
## What

Adds the dirty-tree safety check the worktree reclaim path never had, and makes
destroying unsaved work require an explicit, separate opt-in.

Closes #4091.

## The defect, confirmed against the code

The issue's analysis holds exactly. Verified before changing anything:

- **The #3649 owner/sentinel guard works as described and is untouched by this
  PR.** `SentinelOwner::Unknown` → `owner_unknown`, reported but never fed to
  the deletion loop (`prune.rs:889-897` pre-change). `find_orphaned_worktrees`
  does walk all five shapes including `.base/.claude/worktrees/`. Owner-unknown
  ad-hoc worktrees were, and remain, never auto-deleted.
- **The gap was exactly the known-owner + dirty case.** Nothing in the reclaim
  path inspected `git status`, the index, or untracked files.
  `session_context_pause` prunes by default (`session_dispatch.rs:181-184` →
  `mcp_context.rs:172-197`, trailing `false` = not a dry run), so this fired on
  an ordinary `/tm-session-pause`.
- **One thing the issue did not say, which raises the stakes on the unpushed
  leg:** `decommission::remove_session_worktree` runs
  `git branch -D session/<leaf>` after a successful removal
  (`decommission.rs:100-120`). Committed-but-unpushed work is therefore not
  merely "left detached in the object store" — it loses its last reachable ref
  and becomes garbage-collectable. The unpushed check is load-bearing, not
  defence in depth.

## How "dirty" is defined

`session_manager::worktree_safety::inspect_dirt` returns `None` **only** when a
candidate is provably free of unsaved work. Dirty means any of:

1. **Working tree** — `git status --porcelain` reports an entry: modified or
   staged tracked files, and untracked-but-not-ignored files. Gitignored files
   are excluded (build artefacts are not work).
2. **Unpushed commits** — `<upstream>..HEAD` when the branch has an upstream;
   with no upstream, commits reachable from `HEAD` but from no remote-tracking
   ref (`rev-list --count HEAD --not --remotes`). In a repo with no remotes at
   all, `--remotes` expands to nothing and every commit counts as unpushed.
3. **Not a git worktree root, and not empty** — git cannot speak to it, so only
   an empty leftover shell (nothing but the ownership sentinel) is treated as
   clean. This preserves the #1838 case the sweep exists for.
4. **Any error** — see below.

A deliberate deviation from the issue's wording: for the no-upstream case the
check asks "is this commit on *any* remote-tracking ref", not specifically "is
it on `origin/main`". That subsumes the `origin/main` rule (a commit on neither
`origin/main` nor anything else is counted) while not flagging a branch that
genuinely *was* pushed under its own name without upstream tracking configured.

**Fail-safe direction.** Every error resolves to DIRTY: git that cannot spawn,
exits non-zero, or returns an unparsable count; a directory that cannot be read.
An error on the check never becomes a green light to delete.

**One carve-out, and it was found the hard way.** trusty-mpm writes two
artefacts into every managed worktree it creates — the `.trusty-mpm-worktree`
sentinel and the `.trusty-mpm/` scrollback directory — and host projects
typically do not gitignore them. The first draft counted them, which marked
*every* managed worktree permanently dirty; that would have shipped a guard that
silently disabled all reclamation and buried genuinely-dirty worktrees in noise.
Untracked entries at those two paths are excluded. A **tracked** edit under
`.trusty-mpm/` still counts as work
(`inspect_dirt_counts_tracked_trusty_mpm_edit`).

## Never silent, and hard to trigger by accident

A skip is surfaced as `OrphanSweepOutcome::skipped_dirty` (path, reason,
`dirty_files`, `unpushed_commits`) and propagated to every surface:
`skipped_dirty_worktrees` from the `session_context_pause` MCP tool, the
`prune-worktrees` HTTP response, stderr from `tm session prune-worktrees`, and a
per-path `warn!` from the daemon orphan-GC loop. The `/tm-session-pause` skill
is updated to require reporting them to the user.

The override is `DirtyWorktreePolicy::{Skip, ForceDiscard}` — an enum rather
than a `force: bool`, so it cannot be positionally confused with the
`dry_run: bool` beside it. `Skip` is the `Default`. `ForceDiscard` is reachable
only from `discard_dirty: true` on the HTTP route / `tm session prune-worktrees
--discard-dirty`. `--force` alone does **not** imply it. The pause path passes
`Skip` unconditionally and the pause tool's schema is closed with no
force/discard/dirty property at all — pinned by
`session_context_pause_schema_has_no_dirty_override`.

## Tests

All against throwaway `tempfile::tempdir()` git repos built by
`worktree_git_fixture`. No live worktree is touched.

Reclaim-path behaviour (`prune_orphan_tests`), each with an aged sentinel so the
#3649 gate *passes* and the new gate is the only thing that can spare it:

- `prune_orphaned_worktrees_skips_modified_tracked_file`
- `prune_orphaned_worktrees_skips_untracked_file`
- `prune_orphaned_worktrees_skips_unpushed_commit`
- `prune_orphaned_worktrees_reclaims_clean_pushed_worktree` — the control case;
  without it the guard could "pass" everything by never deleting anything
- `prune_orphaned_worktrees_skips_when_dirty_check_errors` — `git status` made
  to exit 128 while the worktree registration stays intact, so the candidate
  genuinely reaches the gate
- `prune_orphaned_worktrees_force_discards_dirty`
- `prune_orphaned_worktrees_default_policy_cannot_delete_dirty_work` — the
  regression test, asserting on `DirtyWorktreePolicy::default()` so it fails if
  anyone flips the default
- `prune_orphaned_worktrees_dry_run_reports_dirty_skip`

Checker in isolation (`worktree_safety_tests`), 12 tests including the
gitignored-files carve-out, the two bookkeeping exclusions and their
tracked-file counterweight, and the missing-path fail-safe. Plus
`prune_worktrees_request_defaults_to_skip_dirty` and
`cli_prune_worktrees_discard_dirty_is_opt_in`.

No test was `#[ignore]`d, cfg-gated, excluded, or deleted.

## Quality gate

```
cargo test -p trusty-mpm    -> 3635 passed; 0 failed (lib)
                               1240 passed; 0 failed (bin tm)
                               1240 passed; 0 failed (bin trusty-mpm)
                               + all integration targets, 0 failed
cargo clippy -p trusty-mpm --all-targets -- -D warnings -> clean
cargo fmt --all --check        -> clean
scripts/check_line_cap.sh      -> 7 allowlisted, 0 violations - OK
scripts/check_test_pointers.sh -> 0 dangling pointers - OK
cargo check --workspace --all-targets \
  --exclude trusty-mpm-gui --exclude trusty-code-gui -> clean
```

`cargo check --workspace` without those two exclusions fails on
`trusty-mpm-gui` / `trusty-code-gui` with `frontendDist ... "ui/dist" ...
doesn't exist`. That is pre-existing and environmental: `ui/dist` is a build
artefact with zero tracked files (`git ls-files .../ui/dist` -> 0), so it is
absent in any fresh checkout, and this branch touches no GUI code.

`prune.rs` lands at 494 SLOC against the 500 cap — `git_worktree_list_agrees`
was moved verbatim into the new module to make room. Worth knowing before the
next change to that file.

## Residual risk — what this does NOT protect

- **`git stash` entries are not checked.** The stash is repo-level, not
  per-worktree, and stashed work survives worktree removal, but a stash created
  *in* a worktree that is then deleted is easy to lose track of.
- **Untracked files under `.trusty-mpm/`** are excluded by design. Anything an
  agent wrote there is not protected.
- **Gitignored files are excluded by design.** If real work lives in a
  gitignored path (a local `.env`, a scratch dir named in `.gitignore`), it is
  not seen.
- **The non-git empty-shell carve-out.** A directory that is not a git worktree
  root and contains nothing but the sentinel is still removed without further
  inspection.
- **TOCTOU.** The check runs before removal; work written between the check and
  the `git worktree remove` is not seen. The pre-existing residual window
  documented on `prune_orphaned_worktrees` is unchanged.
- **`--discard-dirty` still destroys work**, by design. Nothing stops an
  operator from passing it.
- **Nothing here protects against removal by any path other than this sweep** —
  a manual `rm -rf`, or the out-of-band deleter behind #3715, is untouched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
