### PR TITLE
feat(trusty-agents): Permissions pane backend — structured permissions model

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -19,6 +19,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `StreamAssembly` gained a `usage: Option<ChatUsage>` field so per-call token
   usage — which Bedrock reports exactly once, in a terminal event — survives
   the streaming path instead of being dropped.
+- **`GET /api/agents/:name/permissions` — the Permissions pane's structured
+  backend (#3936, DOC-57 §7).** A new `[permissions]` `agent.toml` section
+  (`scopes`, `user_authority`, `default_tier`/`unauthenticated_tier`,
+  `autonomy`, `[[grants]]`) describes the four scattered enforcement
+  mechanisms (`[tools].allow`, `[tools].scopes`, RBAC tiers, the endpoint
+  scope filter) as one coherent model rather than inventing a new one. Every
+  response field carries an `enforced` boolean — `true` only for `scopes[]`,
+  which is now resolved by `agents::permissions::effective_scopes` and fed
+  into the SAME persona-chat dispatch gate the route reports on (so the
+  claim is never aspirational); every other field (`user_authority`, tiers,
+  `autonomy`, `grants`) is honestly `enforced: false`, since none has a live
+  enforcement site yet. `[permissions].scopes` supersedes legacy
+  `[tools].scopes` within one file (CC-9 — the union is deliberately not
+  taken) but still unions base-first across `extends` (§2.3), so a
+  partially-migrated inheritance chain never silently drops a base's
+  un-migrated grant. `source` distinguishes `declared` from
+  `inherited:<base>` so the class of defect DOC-57 §7.3 records (an agent
+  granting tools whose scopes it never actually declared) is visible in the
+  pane. `user_authority` (DOC-41 §5.5's reserved singleton) is now a real,
+  parsed `AgentConfig` field and is never inherited across `extends`
+  (PM-3) — the previously `#[ignore]`d
+  `extends_does_not_inherit_user_authority` regression test is un-ignored.
+  Read-only in every phase (PM-4); grants or widens nothing (C-06.4).
 
 ### Removed
 

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -30,7 +30,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   into the SAME persona-chat dispatch gate the route reports on (so the
   claim is never aspirational); every other field (`user_authority`, tiers,
   `autonomy`, `grants`) is honestly `enforced: false`, since none has a live
-  enforcement site yet. `[permissions].scopes` supersedes legacy
+  enforcement site yet. `enforced: true` is **qualified**, not universal:
+  each `scopes[]` element also carries `enforced_on: ["persona_chat"]`,
+  because `effective_scopes` gates the persona-chat dispatch path only — the
+  `--direct`/subprocess path (`runtime::subagent_mode` →
+  `scope_assistant_allowed_tools`) filters by `[tools].allow` name globs and
+  never consults a scope pattern, so an agent invoked via `tagent --direct`
+  is not scope-restricted by anything this pane reports (#3987/#4093 track
+  unifying the two paths). `[permissions].scopes` supersedes legacy
   `[tools].scopes` within one file (CC-9 — the union is deliberately not
   taken) but still unions base-first across `extends` (§2.3), so a
   partially-migrated inheritance chain never silently drops a base's

--- a/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
@@ -105,6 +105,7 @@ fn test_agent_config(name: &str, model: &str, system_prompt: &str) -> AgentConfi
         listeners: Vec::new(),
         stores: crate::stores::StoresConfig::default(),
         skills: crate::agents::SkillsConfig::default(),
+        permissions: crate::agents::PermissionsConfig::default(),
         subagents: crate::agents::SubagentsConfig::default(),
     }
 }

--- a/crates/trusty-agents/src/agents/claude_mpm_loader.rs
+++ b/crates/trusty-agents/src/agents/claude_mpm_loader.rs
@@ -139,6 +139,8 @@ impl ClaudeMpmAgent {
             // unbound store is a valid state (see `AgentConfig::stores`).
             stores: crate::stores::StoresConfig::default(),
             skills: crate::agents::SkillsConfig::default(),
+            // #3936: claude-mpm agents carry no `[permissions]` table.
+            permissions: crate::agents::PermissionsConfig::default(),
             // #4026: no cross-product grants from a claude-mpm agent yet.
             subagents: crate::agents::SubagentsConfig::default(),
         }

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -180,6 +180,24 @@ pub struct AgentConfig {
     #[serde(default)]
     pub skills: SkillsConfig,
 
+    /// Optional `[permissions]` section (#3936, DOC-57 §7) — the structured
+    /// permissions model: scopes, tiers, `user_authority`, autonomy posture,
+    /// per-skill grants.
+    ///
+    /// Why: An agent's permission posture was spread across four unrelated
+    /// mechanisms in three locations with three different failure polarities
+    /// (DOC-57 §7.1) — `[tools].scopes`, `[rbac]`, and two more with no config
+    /// surface at all. `[permissions]` DESCRIBES that union; it invents no new
+    /// enforcement (PM-1). Absent = today's behaviour exactly: scope
+    /// resolution falls back to `[tools].scopes` verbatim
+    /// ([`super::permissions::effective_scopes`]), tiers fall back to
+    /// `[rbac]`, and `user_authority` defaults `false` (its documented
+    /// default either way).
+    /// What: [`super::permissions::PermissionsConfig`].
+    /// Test: `super::permissions::tests`.
+    #[serde(default)]
+    pub permissions: super::permissions::PermissionsConfig,
+
     // #4026: cross-product subagent grants — the config source for the
     // bridge-layer allow-set (epic #4021, OQ-3/OQ-7).
     /// Optional `[subagents]` section (#4026, epic #4021) — which external

--- a/crates/trusty-agents/src/agents/extends/mod.rs
+++ b/crates/trusty-agents/src/agents/extends/mod.rs
@@ -141,6 +141,13 @@ where
 /// Test: `extends_resolved_config_has_no_extends`.
 fn clear_extends(mut cfg: AgentConfig) -> AgentConfig {
     cfg.agent.extends = None;
+    // #3936: seed the `permissions.scopes` accumulator with THIS (root)
+    // level's own CC-9-resolved value, so a root agent and a merged
+    // multi-level agent share one invariant: after resolution,
+    // `permissions.scopes` always holds the chain's fully-resolved effective
+    // scope set — see `merge_extends`'s matching seed for the non-root case.
+    cfg.permissions.scopes =
+        crate::agents::permissions::effective_scopes(&cfg.tools, &cfg.permissions);
     cfg
 }
 
@@ -181,6 +188,26 @@ fn clear_extends(mut cfg: AgentConfig) -> AgentConfig {
 /// `extends_llm_child_overrides_max_tokens_only`,
 /// `extends_llm_child_inherits_when_omitted`.
 pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
+    // #3936: the base's own contribution to the `permissions.scopes`
+    // accumulator, captured BEFORE `base` moves into `merged` below.
+    //
+    // `resolve_inner` always hands this function a `base` that already went
+    // through `clear_extends` (root) or a prior `merge_extends` call
+    // (multi-level) — either way `base.permissions.scopes` already holds
+    // that level's CC-9-collapsed, chain-unioned value, and is used
+    // verbatim. A `base` that skipped both (a direct `merge_extends` call,
+    // e.g. from a unit test) has NOT been collapsed yet, so this falls back
+    // to computing it here — the same `effective_scopes` call
+    // `clear_extends` makes — rather than silently dropping that level's
+    // legacy `[tools].scopes` contribution. Idempotent either way: re-running
+    // `effective_scopes` over an already-collapsed value is a no-op because
+    // `permissions.scopes` is already `Some`.
+    let base_scopes_seed = if base.permissions.scopes.is_some() {
+        base.permissions.scopes.clone()
+    } else {
+        crate::agents::permissions::effective_scopes(&base.tools, &base.permissions)
+    };
+
     let mut merged = base;
 
     // #3738: capture the base's identity BEFORE overwriting it with the
@@ -286,6 +313,13 @@ pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
         merged.llm.max_tokens = child.llm.max_tokens;
     }
 
+    // #3936: computed BEFORE the `child.tools.*` partial moves below (`scopes`
+    // and `search_indexes` are moved out of `child.tools` by `union_opt_vec`
+    // a few lines down) — `effective_scopes` needs to borrow `child.tools`
+    // and `child.permissions` together, so it must run first.
+    let child_effective_scopes =
+        crate::agents::permissions::effective_scopes(&child.tools, &child.permissions);
+
     // --- List fields: union (dedup, base-first order) ---
     merged.tools.allowed = union_opt_vec(merged.tools.allowed, child.tools.allowed);
     merged.tools.allow = union_opt_vec(merged.tools.allow, child.tools.allow);
@@ -308,6 +342,41 @@ pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
     // the same reason — an overlay ADDS capability to its base and must never
     // silently remove what the base granted.
     merged.skills.allow = union_opt_vec(merged.skills.allow, child.skills.allow);
+
+    // `[permissions]` (#3936, DOC-57 §2.3 + §7.2):
+    //
+    // `scopes` — base-first UNION across the chain, same polarity as legacy
+    // `tools.scopes` above, but sourced through `effective_scopes` so a
+    // per-file CC-9 collapse (this file's OWN `[permissions].scopes` beats
+    // this file's OWN legacy `[tools].scopes`) happens BEFORE the cross-chain
+    // union. `base_scopes_seed` (captured above, before `base` moved into
+    // `merged`) already holds the accumulated union of every ancestor level;
+    // this only has to fold in the CHILD's own contribution (also computed
+    // above, before the partial moves).
+    merged.permissions.scopes = union_opt_vec(base_scopes_seed, child_effective_scopes);
+    // `grants[]` — union keyed by `skill`, same shape as the listener-binding
+    // union: a child re-declaring a grant for a skill OVERRIDES the base's
+    // mode for it rather than appending a second, shadowing entry.
+    merged.permissions.grants =
+        union_permission_grants(merged.permissions.grants, child.permissions.grants);
+    // `default_tier` / `unauthenticated_tier` / `autonomy` — child-declares-
+    // wins, child-omits-inherits (same posture as `enforce_search_indexes`
+    // above): a hardened base stays hardened under a silent overlay.
+    if child.permissions.default_tier.is_some() {
+        merged.permissions.default_tier = child.permissions.default_tier.clone();
+    }
+    if child.permissions.unauthenticated_tier.is_some() {
+        merged.permissions.unauthenticated_tier = child.permissions.unauthenticated_tier.clone();
+    }
+    if child.permissions.autonomy.is_some() {
+        merged.permissions.autonomy = child.permissions.autonomy;
+    }
+    // `user_authority` — NEVER inherited (PM-3, DOC-41 §5.5). Always the
+    // child's own explicit setting (defaulting `false`), even when `extends`
+    // targets the authority holder. `merged` starts as a clone of `base`, so
+    // this assignment is what actually enforces the exclusion — omitting it
+    // would leave the base's value sitting in `merged` untouched.
+    merged.permissions.user_authority = child.permissions.user_authority;
     merged.system_prompt.skills =
         union_opt_vec(merged.system_prompt.skills, child.system_prompt.skills);
     merged.agent.capabilities =
@@ -410,6 +479,32 @@ fn union_listener_bindings(
             *existing = child_binding;
         } else {
             merged.push(child_binding);
+        }
+    }
+    merged
+}
+
+/// Union two `[[permissions.grants]]` lists, base-first, keyed by `skill` —
+/// a child grant for a skill already named by the base REPLACES the base's
+/// mode for it (#3936, DOC-57 §2.3 "grants union-by-skill").
+///
+/// Why: Mirrors [`union_listener_bindings`]'s keyed-replace semantics exactly
+/// — a grant is identified by WHICH skill it governs, not by its `mode`, so
+/// two grants for the same skill are the same declaration with the child's
+/// value winning, not two independent entries.
+/// What: base entries, with any child entry sharing a `skill` overwriting
+/// in place; a child entry naming a new skill is appended.
+/// Test: `extends_permission_grants_union_by_skill`.
+fn union_permission_grants(
+    base: Vec<crate::agents::permissions::PermissionGrant>,
+    child: Vec<crate::agents::permissions::PermissionGrant>,
+) -> Vec<crate::agents::permissions::PermissionGrant> {
+    let mut merged = base;
+    for grant in child {
+        if let Some(existing) = merged.iter_mut().find(|g| g.skill == grant.skill) {
+            *existing = grant;
+        } else {
+            merged.push(grant);
         }
     }
     merged

--- a/crates/trusty-agents/src/agents/extends/tests.rs
+++ b/crates/trusty-agents/src/agents/extends/tests.rs
@@ -747,19 +747,167 @@ tags = ["general", "personal"]
     assert_eq!(caps.tags, vec!["general", "personal"]);
 }
 
-/// TODO(#3075 / AUTH-2): once AUTH-1/#3074 adds the `user_authority` field to
-/// `AgentConfig`, this test must assert that a child's `user_authority` is
-/// NEVER inherited/unioned from the base through `extends` — even when the
-/// child extends the authority holder, the merged value is the child's own
-/// explicit setting (defaulting `false`). The exclusion hook is stubbed at the
-/// `merge_extends` merge site (see the `user_authority` comment there); the
-/// field does not exist yet, so this placeholder is `#[ignore]`d.
+/// #3936 (PM-3, DOC-41 §5.5): a child's `user_authority` is NEVER
+/// inherited/unioned from the base through `extends` — even when the child
+/// extends the authority holder, the merged value is always the child's own
+/// explicit setting (defaulting `false`).
 #[test]
-#[ignore = "user_authority field lands in AUTH-1/#3074; assertion filled by AUTH-2/#3075"]
 fn extends_does_not_inherit_user_authority() {
-    // Intentionally empty: see doc comment. When #3074 lands, build a base
-    // with user_authority = true and a child that omits it, then assert the
-    // merged config's user_authority is false (the child's own default).
+    let mut base = cfg(r#"
+[agent]
+name = "authority-holder"
+role = "assistant"
+model = "m1"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "base"
+"#);
+    base.permissions.user_authority = true;
+
+    // A child that OMITS `[permissions]` entirely must NOT inherit `true`.
+    let ch = child("overlay", "authority-holder", "child");
+    let merged = merge_extends(base.clone(), ch);
+    assert!(
+        !merged.permissions.user_authority,
+        "a child must never inherit user_authority=true from its base"
+    );
+
+    // A child that explicitly declares its OWN `user_authority = true` keeps
+    // its own explicit setting (this was never in question, but pins the
+    // "always the child's own value" framing rather than "always false").
+    let mut ch2 = child("overlay2", "authority-holder", "child2");
+    ch2.permissions.user_authority = true;
+    let merged2 = merge_extends(base, ch2);
+    assert!(merged2.permissions.user_authority);
+}
+
+/// #3936 (DOC-57 §2.3): `[permissions].scopes` unions base-first across the
+/// chain, same polarity as legacy `[tools].scopes`.
+#[test]
+fn extends_unions_permissions_scopes() {
+    let mut base = cfg(r#"
+[agent]
+name = "base"
+role = "r"
+model = "m1"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "base"
+"#);
+    base.permissions.scopes = Some(vec!["memory.read".to_string()]);
+
+    let mut ch = child("child", "base", "child");
+    ch.permissions.scopes = Some(vec!["google.gmail.*".to_string()]);
+
+    let merged = merge_extends(base, ch);
+    assert_eq!(
+        merged.permissions.scopes,
+        Some(vec![
+            "memory.read".to_string(),
+            "google.gmail.*".to_string()
+        ])
+    );
+}
+
+/// #3936 (DOC-57 CC-9 + §2.3): a base declaring only legacy `[tools].scopes`
+/// and a child declaring only `[permissions].scopes` must UNION across the
+/// chain — the child's migration to the new key must not silently drop the
+/// base's un-migrated legacy grant.
+#[test]
+fn extends_permissions_scopes_union_survives_a_partially_migrated_chain() {
+    let base = cfg(r#"
+[agent]
+name = "base"
+role = "r"
+model = "m1"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "base"
+
+[tools]
+scopes = ["memory.read"]
+"#);
+
+    let mut ch = child("child", "base", "child");
+    ch.permissions.scopes = Some(vec!["google.gmail.*".to_string()]);
+
+    let merged = merge_extends(base, ch);
+    assert_eq!(
+        merged.permissions.scopes,
+        Some(vec![
+            "memory.read".to_string(),
+            "google.gmail.*".to_string()
+        ]),
+        "the base's un-migrated [tools].scopes must survive the child's [permissions].scopes"
+    );
+}
+
+/// #3936 (DOC-57 §2.3): `[[permissions.grants]]` unions by `skill`; a child
+/// re-declaring the same skill overrides the base's mode for it.
+#[test]
+fn extends_permission_grants_union_by_skill() {
+    use crate::agents::{GrantMode, PermissionGrant};
+
+    let mut base = cfg(r#"
+[agent]
+name = "base"
+role = "r"
+model = "m1"
+description = "d"
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "base"
+"#);
+    base.permissions.grants = vec![
+        PermissionGrant {
+            skill: "gmail".to_string(),
+            mode: GrantMode::Ask,
+        },
+        PermissionGrant {
+            skill: "git-status".to_string(),
+            mode: GrantMode::Allow,
+        },
+    ];
+
+    let mut ch = child("child", "base", "child");
+    ch.permissions.grants = vec![PermissionGrant {
+        skill: "gmail".to_string(),
+        mode: GrantMode::Deny,
+    }];
+
+    let merged = merge_extends(base, ch);
+    assert_eq!(
+        merged.permissions.grants.len(),
+        2,
+        "{:?}",
+        merged.permissions.grants
+    );
+    let gmail = merged
+        .permissions
+        .grants
+        .iter()
+        .find(|g| g.skill == "gmail")
+        .unwrap();
+    assert_eq!(gmail.mode, GrantMode::Deny, "child overrides base's mode");
+    assert!(
+        merged
+            .permissions
+            .grants
+            .iter()
+            .any(|g| g.skill == "git-status" && g.mode == GrantMode::Allow),
+        "an un-overridden base grant survives"
+    );
 }
 
 // --- resolve() walk tests -----------------------------------------------

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -22,6 +22,7 @@ pub mod in_process_runner;
 mod loader;
 mod model;
 mod params;
+pub mod permissions;
 pub mod persona;
 pub mod prompt_builder;
 pub mod registry;
@@ -39,6 +40,10 @@ pub use config::{
 pub use params::{
     AgentCompressConfig, AgentPluginsConfig, LlmParams, RbacConfig, RunnerConfig,
     SessionCompressionConfig, ToolChoice, WorkstreamContextConfig,
+};
+// #3936: the `[permissions]` section (DOC-57 §7).
+pub use permissions::{
+    AutonomyMode, GrantMode, PermissionGrant, PermissionsConfig, effective_scopes,
 };
 
 // Model resolution: `resolve_model` and `ModelSource` are part of the public

--- a/crates/trusty-agents/src/agents/permissions.rs
+++ b/crates/trusty-agents/src/agents/permissions.rs
@@ -1,0 +1,238 @@
+//! `[permissions]` — the structured permissions model (#3936, DOC-57 §7).
+//!
+//! Why: An agent's permission posture is spread across four unrelated
+//! mechanisms in three locations with three different failure polarities
+//! (DOC-57 §7.1): `[tools].allow` globs (absent ⇒ zero tools), `[tools].scopes`
+//! (empty ⇒ denies everything), RBAC tiers (default ⇒ degrades open), and the
+//! harness-level endpoint scope filter. `[permissions]` **describes** that
+//! union — it does not invent new enforcement (PM-1) — so a GUI pane can show
+//! one coherent model instead of four scattered mechanisms.
+//! What: [`PermissionsConfig`] is the `[permissions]` section of `agent.toml`.
+//! [`effective_scopes`] is the ONE place CC-9 precedence
+//! (`[permissions].scopes` wins over legacy `[tools].scopes` when a single
+//! file declares both — the union is deliberately NOT taken, DOC-57 §9.4) is
+//! decided, so the persona-chat dispatch gate (`ctrl::pm_task::dispatch::persona`)
+//! and the `GET /api/agents/:name/permissions` route can never disagree about
+//! what is actually enforced.
+//! Test: `effective_scopes_prefers_permissions_over_legacy_tools_scopes`,
+//! `effective_scopes_falls_back_to_tools_scopes_when_permissions_absent`,
+//! `effective_scopes_absent_both_is_none`.
+
+use serde::{Deserialize, Serialize};
+
+use super::config::ToolsConfig;
+use crate::rbac::ServiceTier;
+
+/// `[permissions]` section (#3936, DOC-57 §7.2).
+///
+/// Why: Promotes scopes/tiers/authority/autonomy from four scattered
+/// mechanisms into one declared, first-class section. Every field either maps
+/// to an existing enforced mechanism or is explicitly reserved/declarative
+/// (PM-1) — the route that reports this config (`agent_permissions.rs`) is
+/// what makes that distinction visible via its `enforced` flags.
+/// What: `scopes` supersedes legacy `[tools].scopes` per-file (CC-9,
+/// [`effective_scopes`]). `user_authority` is DOC-41 §5.5's reserved
+/// singleton — parsed and surfaced now, enforced when #3074 lands.
+/// `default_tier`/`unauthenticated_tier` supersede legacy `[rbac]` fields.
+/// `autonomy` is a declarative enum (DOC-23 owns the real decision model,
+/// PM-2). `grants` is a declarative per-skill override list — Phase 4 ships
+/// it read-only; there is no enforcement site for it yet (PM-1, PM-4).
+/// Test: `permissions_config_parses_full_block`,
+/// `permissions_config_defaults_when_absent`.
+#[derive(Debug, Clone, Default, PartialEq, Deserialize, Serialize)]
+pub struct PermissionsConfig {
+    #[serde(default)]
+    pub scopes: Option<Vec<String>>,
+    /// DOC-41 §5.5's `user_authority` singleton. Reserved: parsed and
+    /// surfaced, but nothing in this crate enforces it yet (#3074/#3075).
+    /// Defaults `false`, matching the singleton's documented default.
+    #[serde(default)]
+    pub user_authority: bool,
+    #[serde(default)]
+    pub default_tier: Option<ServiceTier>,
+    #[serde(default)]
+    pub unauthenticated_tier: Option<ServiceTier>,
+    #[serde(default)]
+    pub autonomy: Option<AutonomyMode>,
+    #[serde(default)]
+    pub grants: Vec<PermissionGrant>,
+}
+
+/// DOC-54 §2.1's ask-first / learn-to-act posture (§7.2). Declarative only in
+/// M1 — the real decision model is DOC-23 (PM-2, OQ-5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum AutonomyMode {
+    #[default]
+    AskFirst,
+    LearnToAct,
+}
+
+/// One `[[permissions.grants]]` entry — a per-skill override (§7.2).
+///
+/// Why: Declarative in M1 (PM-1/PM-4) — there is no enforcement site for a
+/// per-skill grant mode yet, so this is data the route reports, not a control
+/// the dispatch gate consults.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub struct PermissionGrant {
+    pub skill: String,
+    pub mode: GrantMode,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum GrantMode {
+    Allow,
+    Ask,
+    Deny,
+}
+
+/// Resolve the effective declared scope patterns for ONE agent file (CC-9).
+///
+/// Why: **This is the whole compatibility + honesty story for scopes.**
+/// `[permissions].scopes` supersedes legacy `[tools].scopes` when BOTH are
+/// declared in the same file — the union is deliberately NOT taken (DOC-57
+/// §9.4: unioning a legacy and a new declaration could only ever WIDEN the
+/// scope set, which is the wrong default for a migration path). Calling this
+/// function from both the persona-chat dispatch gate
+/// (`ctrl::pm_task::dispatch::persona`) and the `/permissions` route is what
+/// lets the route's `enforced: true` claim for a `[permissions].scopes]`-only
+/// agent be TRUE rather than aspirational — see PM-6.
+/// What: `Some(permissions.scopes)` when declared (logging a WARN when
+/// `tools.scopes` is ALSO declared and differs, naming both so the file is
+/// self-diagnosing); otherwise `tools.scopes.clone()`; `None` when neither is
+/// declared (preserves today's absent-denies-all polarity exactly).
+/// Test: `effective_scopes_prefers_permissions_over_legacy_tools_scopes`,
+/// `effective_scopes_falls_back_to_tools_scopes_when_permissions_absent`,
+/// `effective_scopes_absent_both_is_none`,
+/// `effective_scopes_is_byte_identical_when_permissions_matches_tools`.
+pub fn effective_scopes(
+    tools: &ToolsConfig,
+    permissions: &PermissionsConfig,
+) -> Option<Vec<String>> {
+    if let Some(scopes) = &permissions.scopes {
+        if let Some(legacy) = &tools.scopes
+            && legacy != scopes
+        {
+            tracing::warn!(
+                permissions_scopes = ?scopes,
+                tools_scopes = ?legacy,
+                "agent declares both [permissions].scopes and legacy [tools].scopes with \
+                 different values; [permissions].scopes wins per DOC-57 CC-9 — the union is \
+                 not taken"
+            );
+        }
+        return Some(scopes.clone());
+    }
+    tools.scopes.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tools_with_scopes(scopes: Option<Vec<&str>>) -> ToolsConfig {
+        ToolsConfig {
+            scopes: scopes.map(|v| v.into_iter().map(str::to_string).collect()),
+            ..Default::default()
+        }
+    }
+
+    fn permissions_with_scopes(scopes: Option<Vec<&str>>) -> PermissionsConfig {
+        PermissionsConfig {
+            scopes: scopes.map(|v| v.into_iter().map(str::to_string).collect()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn effective_scopes_prefers_permissions_over_legacy_tools_scopes() {
+        let tools = tools_with_scopes(Some(vec!["memory.read"]));
+        let permissions = permissions_with_scopes(Some(vec!["google.gmail.*"]));
+        assert_eq!(
+            effective_scopes(&tools, &permissions),
+            Some(vec!["google.gmail.*".to_string()])
+        );
+    }
+
+    #[test]
+    fn effective_scopes_falls_back_to_tools_scopes_when_permissions_absent() {
+        let tools = tools_with_scopes(Some(vec!["memory.read"]));
+        let permissions = permissions_with_scopes(None);
+        assert_eq!(
+            effective_scopes(&tools, &permissions),
+            Some(vec!["memory.read".to_string()])
+        );
+    }
+
+    #[test]
+    fn effective_scopes_absent_both_is_none() {
+        let tools = tools_with_scopes(None);
+        let permissions = permissions_with_scopes(None);
+        assert_eq!(effective_scopes(&tools, &permissions), None);
+    }
+
+    #[test]
+    fn effective_scopes_is_byte_identical_when_permissions_matches_tools() {
+        let tools = tools_with_scopes(Some(vec!["search.read"]));
+        let permissions = permissions_with_scopes(Some(vec!["search.read"]));
+        assert_eq!(
+            effective_scopes(&tools, &permissions),
+            Some(vec!["search.read".to_string()])
+        );
+    }
+
+    #[test]
+    fn permissions_config_parses_full_block() {
+        let raw = r#"
+[agent]
+name = "x"
+
+[permissions]
+scopes = ["memory.read", "google.gmail.*"]
+user_authority = true
+default_tier = "analytics"
+unauthenticated_tier = "read_only"
+autonomy = "learn-to-act"
+
+[[permissions.grants]]
+skill = "gmail"
+mode = "ask"
+"#;
+        #[derive(Deserialize)]
+        struct W {
+            permissions: PermissionsConfig,
+        }
+        let w: W = toml::from_str(raw).unwrap();
+        assert_eq!(
+            w.permissions.scopes,
+            Some(vec![
+                "memory.read".to_string(),
+                "google.gmail.*".to_string()
+            ])
+        );
+        assert!(w.permissions.user_authority);
+        assert_eq!(w.permissions.default_tier, Some(ServiceTier::Analytics));
+        assert_eq!(
+            w.permissions.unauthenticated_tier,
+            Some(ServiceTier::ReadOnly)
+        );
+        assert_eq!(w.permissions.autonomy, Some(AutonomyMode::LearnToAct));
+        assert_eq!(w.permissions.grants.len(), 1);
+        assert_eq!(w.permissions.grants[0].skill, "gmail");
+        assert_eq!(w.permissions.grants[0].mode, GrantMode::Ask);
+    }
+
+    #[test]
+    fn permissions_config_defaults_when_absent() {
+        #[derive(Deserialize, Default)]
+        struct W {
+            #[serde(default)]
+            permissions: PermissionsConfig,
+        }
+        let w: W = toml::from_str("[agent]\nname = \"x\"\n").unwrap();
+        assert_eq!(w.permissions, PermissionsConfig::default());
+        assert!(!w.permissions.user_authority);
+        assert_eq!(w.permissions.autonomy, None);
+    }
+}

--- a/crates/trusty-agents/src/agents/registry/md_agent.rs
+++ b/crates/trusty-agents/src/agents/registry/md_agent.rs
@@ -225,6 +225,8 @@ pub(crate) fn parse_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
         // store is a valid state (see `AgentConfig::stores`).
         stores: crate::stores::StoresConfig::default(),
         skills: crate::agents::SkillsConfig::default(),
+        // #3936: markdown agents carry no `[permissions]` table.
+        permissions: crate::agents::PermissionsConfig::default(),
         // #4026: no cross-product grants from an .md-sourced agent yet.
         subagents: crate::agents::SubagentsConfig::default(),
     })

--- a/crates/trusty-agents/src/api/server/agent_permissions.rs
+++ b/crates/trusty-agents/src/api/server/agent_permissions.rs
@@ -1,0 +1,322 @@
+//! `GET /api/agents/:name/permissions` — the agent's structured permissions
+//! model: scopes, tiers, `user_authority`, autonomy posture, per-skill
+//! grants (#3936, DOC-57 §7).
+//!
+//! Why: An agent's permission posture is spread across four unrelated
+//! mechanisms in three locations with three different failure polarities
+//! (DOC-57 §7.1). This route is the ONE place a client reads them as a single
+//! coherent model instead of four scattered files/comments.
+//!
+//! **Honesty rules this route holds to (PM-6):**
+//! - Every element carries an `enforced` boolean. `scopes[]` is `enforced:
+//!   true` — `agents::permissions::effective_scopes` (the SAME function
+//!   `ctrl::pm_task::dispatch::persona` calls) feeds the SAME
+//!   `agent_can_use`/`ScopePattern` gate on the persona-chat path, so this is
+//!   not aspirational. Every other field (`user_authority`, `tiers`,
+//!   `autonomy`, `grants`) is `enforced: false` — none has a live enforcement
+//!   site in this crate yet (tiers: DOC-57 §7.1 mechanism 3, "`[rbac]` block
+//!   has no read site"; `user_authority`: #3074/#3075; `autonomy`: PM-2,
+//!   DOC-23 owns the real model; `grants`: PM-1/PM-4, no enforcement site by
+//!   design in this phase).
+//! - `source` distinguishes `declared` (in this agent's OWN file) from
+//!   `inherited:<base>` (only reachable via its immediate `extends` target),
+//!   so the DOC-57 §7.3 class of defect (an agent granting tools whose
+//!   scopes it never actually declared, `google.read` only) is visible in
+//!   the pane rather than requiring a reader to simulate `merge_extends`.
+//!   Multi-level provenance is approximated to the IMMEDIATE base — see
+//!   [`permissions_at`]'s doc for why that is still a true statement.
+//! - This route grants or widens nothing (C-06.4, PM-4) — it is a read
+//!   surface over `AgentConfig::by_name_in`'s existing resolution.
+//!
+//! What: [`agent_permissions_route`] is the axum shim; [`permissions_at`] is
+//! the testable core.
+//! Test: `super::tests::agent_permissions`.
+
+use std::path::PathBuf;
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::{Value, json};
+
+use super::agent_patch::resolve_agent_paths;
+use super::state::AppState;
+use crate::agents::permissions::{PermissionsConfig, effective_scopes};
+use crate::agents::{AgentConfig, RbacConfig, ToolsConfig};
+use crate::rbac::ServiceTier;
+
+/// `GET /api/agents/:name/permissions` — HTTP entry point.
+///
+/// Why/What: see the module doc.
+/// Test: `super::tests::agent_permissions::permissions_route_reports_declared_scopes`.
+pub(super) async fn agent_permissions_route(
+    State(_state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    permissions_at(&crate::agents::agents_dir_candidates(), &name).await
+}
+
+/// Core permissions-resolution logic against an explicit agents-dir list.
+///
+/// Why: Same testability rationale as `agent_stores::stores_at` /
+/// `agent_skills::skills_at`. Reads the agent's OWN file directly (partial
+/// parse, matching the sibling routes' package-tolerant style) for the
+/// `declared` half of `source`, AND resolves the full `extends` chain via
+/// `AgentConfig::by_name_in` for the effective (chain-unioned) half — the
+/// only route of the three that needs BOTH, because `source` (PM-7) is the
+/// one field that requires knowing what this agent's OWN file said versus
+/// what the chain as a whole resolves to.
+/// What: `400` for an invalid name, `404` for an unknown agent, `500` only
+/// when the resolved file cannot be read at all. Malformed TOML degrades to
+/// `config_error` (never a `500`, K-1's posture applied here). An `extends`
+/// chain that fails to resolve (missing base, cycle, depth) degrades to
+/// this agent's own declarations only — every scope reports `source:
+/// "declared"` rather than the route going dark.
+///
+/// Multi-level provenance approximation: `source` names the agent's
+/// IMMEDIATE `extends` target for anything not in its own declared set, even
+/// across a longer chain. This is still a TRUE statement — the pattern IS
+/// reachable only via that immediate base, whatever THAT base in turn
+/// inherited — and avoids re-deriving per-level provenance from
+/// `merge_extends`'s flattened output, which does not retain it.
+/// Test: `permissions_route_reports_declared_scopes`,
+/// `permissions_route_reports_inherited_scope_from_immediate_base`,
+/// `permissions_route_never_inherits_user_authority`,
+/// `permissions_route_degrades_on_malformed_toml`,
+/// `permissions_route_degrades_gracefully_on_unresolvable_extends`.
+pub(super) async fn permissions_at(dirs: &[PathBuf], name: &str) -> Response {
+    if name.is_empty() || name.contains(['/', '\\']) || name == "." || name == ".." {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid agent name" })),
+        )
+            .into_response();
+    }
+    let Some((path, _package_dir)) = resolve_agent_paths(dirs, name) else {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "unknown agent", "name": name })),
+        )
+            .into_response();
+    };
+    let raw = match tokio::fs::read_to_string(&path).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!(?e, agent = name, path = %path.display(), "permissions_at: read failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "error": "failed to read agent config" })),
+            )
+                .into_response();
+        }
+    };
+
+    let (own_tools, own_permissions, extends_target, config_error) =
+        parse_permission_sections(&raw);
+    let own_scopes = effective_scopes(&own_tools, &own_permissions).unwrap_or_default();
+
+    // Resolve the full `extends` chain so inherited scopes/tiers/autonomy are
+    // visible (PM-7). Falls back to the single-file view on ANY resolution
+    // failure — the pane still renders this agent's own declarations rather
+    // than going dark over an unrelated ancestor's typo.
+    let resolved = AgentConfig::by_name_in(dirs, name).ok();
+    let (all_scopes, permissions, rbac) = match &resolved {
+        Some(cfg) => (
+            effective_scopes(&cfg.tools, &cfg.permissions).unwrap_or_default(),
+            cfg.permissions.clone(),
+            cfg.rbac.clone(),
+        ),
+        None => (
+            own_scopes.clone(),
+            own_permissions.clone(),
+            RbacConfig::default(),
+        ),
+    };
+
+    let scopes: Vec<Value> = all_scopes
+        .iter()
+        .map(|pattern| {
+            let source = if own_scopes.contains(pattern) {
+                "declared".to_string()
+            } else if let Some(base) = &extends_target {
+                format!("inherited:{base}")
+            } else {
+                // No `extends` on this file at all, yet the pattern isn't in
+                // `own_scopes` — only possible if `extends` resolution itself
+                // failed (see the doc comment); report it honestly rather
+                // than asserting a provenance we cannot back.
+                "declared".to_string()
+            };
+            json!({ "pattern": pattern, "source": source, "enforced": true })
+        })
+        .collect();
+
+    let default_tier = permissions
+        .default_tier
+        .clone()
+        .unwrap_or_else(|| rbac.effective_default_tier());
+    let unauthenticated_tier = permissions
+        .unauthenticated_tier
+        .clone()
+        .unwrap_or_else(|| rbac.effective_unauthenticated_tier());
+
+    let mut body = json!({
+        "scopes": scopes,
+        "user_authority": {
+            "value": permissions.user_authority,
+            "enforced": false,
+            "reason": "field reserved — #3074 not landed",
+        },
+        "tiers": {
+            "default": tier_str(&default_tier),
+            "unauthenticated": tier_str(&unauthenticated_tier),
+            "enforced": false,
+        },
+        "autonomy": {
+            "mode": autonomy_str(permissions.autonomy.unwrap_or_default()),
+            "enforced": false,
+            "reason": "declarative; see DOC-23",
+        },
+        "grants": permissions.grants.iter().map(|g| json!({
+            "skill": g.skill,
+            "mode": grant_mode_str(g.mode),
+            "enforced": false,
+        })).collect::<Vec<_>>(),
+    });
+    if let Some(err) = config_error {
+        body["config_error"] = Value::String(err);
+    } else if resolved.is_none() && extends_target.is_some() {
+        // Own file parsed fine but the chain didn't resolve (missing base,
+        // cycle, depth) — additive, non-normative field; `config_error`
+        // stays reserved for THIS file's own parse failures, matching the
+        // sibling routes.
+        body["extends_warning"] = Value::String(
+            "this agent's `extends` chain did not resolve; showing its own declarations only"
+                .to_string(),
+        );
+    }
+    (StatusCode::OK, Json(body)).into_response()
+}
+
+fn tier_str(tier: &ServiceTier) -> &'static str {
+    match tier {
+        ServiceTier::All => "all",
+        ServiceTier::Analytics => "analytics",
+        ServiceTier::ReadOnly => "read_only",
+    }
+}
+
+fn autonomy_str(mode: crate::agents::permissions::AutonomyMode) -> &'static str {
+    use crate::agents::permissions::AutonomyMode;
+    match mode {
+        AutonomyMode::AskFirst => "ask-first",
+        AutonomyMode::LearnToAct => "learn-to-act",
+    }
+}
+
+fn grant_mode_str(mode: crate::agents::permissions::GrantMode) -> &'static str {
+    use crate::agents::permissions::GrantMode;
+    match mode {
+        GrantMode::Allow => "allow",
+        GrantMode::Ask => "ask",
+        GrantMode::Deny => "deny",
+    }
+}
+
+/// Parse `[agent].extends`, `[tools]` and `[permissions]` out of a raw
+/// `agent.toml`.
+///
+/// Why: Same partial-read rationale as the sibling routes' parse helpers — a
+/// directory-package `agent.toml` omits `[system_prompt]`, so reading
+/// through the full `AgentConfig` would reject it for the "own file" half of
+/// this route's job (the "resolved chain" half separately uses the full
+/// loader, which DOES handle packages — see `permissions_at`).
+/// What: `(tools, permissions, extends_target, None)` on success; defaults
+/// plus `Some(message)` when the file is not valid TOML.
+/// Test: `parse_permission_sections_reads_all_three`,
+/// `parse_permission_sections_reports_bad_toml`.
+fn parse_permission_sections(
+    raw: &str,
+) -> (
+    ToolsConfig,
+    PermissionsConfig,
+    Option<String>,
+    Option<String>,
+) {
+    #[derive(serde::Deserialize, Default)]
+    struct AgentIdentity {
+        #[serde(default)]
+        extends: Option<String>,
+    }
+    #[derive(serde::Deserialize)]
+    struct Partial {
+        #[serde(default)]
+        agent: AgentIdentity,
+        #[serde(default)]
+        tools: ToolsConfig,
+        #[serde(default)]
+        permissions: PermissionsConfig,
+    }
+    match toml::from_str::<Partial>(raw) {
+        Ok(p) => (p.tools, p.permissions, p.agent.extends, None),
+        Err(e) => (
+            ToolsConfig::default(),
+            PermissionsConfig::default(),
+            None,
+            Some(e.to_string()),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn parse_permission_sections_reads_all_three() {
+        let raw = r#"
+[agent]
+name = "cto-assistant"
+extends = "assistant"
+
+[tools]
+scopes = ["memory.read"]
+
+[permissions]
+scopes = ["google.gmail.*"]
+user_authority = true
+"#;
+        let (tools, permissions, extends, err) = parse_permission_sections(raw);
+        assert!(err.is_none());
+        assert_eq!(tools.scopes, Some(vec!["memory.read".to_string()]));
+        assert_eq!(permissions.scopes, Some(vec!["google.gmail.*".to_string()]));
+        assert!(permissions.user_authority);
+        assert_eq!(extends.as_deref(), Some("assistant"));
+    }
+
+    #[test]
+    fn parse_permission_sections_tolerates_package_agent_toml() {
+        let (tools, permissions, extends, err) =
+            parse_permission_sections("[agent]\nname = \"x\"\n");
+        assert!(err.is_none());
+        assert!(tools.scopes.is_none());
+        assert_eq!(permissions, PermissionsConfig::default());
+        assert!(extends.is_none());
+    }
+
+    #[test]
+    fn parse_permission_sections_reports_bad_toml() {
+        let (_, _, _, err) = parse_permission_sections("not = = toml");
+        assert!(err.is_some());
+    }
+
+    #[test]
+    fn tier_str_matches_serde_spelling() {
+        assert_eq!(tier_str(&ServiceTier::All), "all");
+        assert_eq!(tier_str(&ServiceTier::Analytics), "analytics");
+        assert_eq!(tier_str(&ServiceTier::ReadOnly), "read_only");
+    }
+}

--- a/crates/trusty-agents/src/api/server/agent_permissions.rs
+++ b/crates/trusty-agents/src/api/server/agent_permissions.rs
@@ -11,13 +11,25 @@
 //! - Every element carries an `enforced` boolean. `scopes[]` is `enforced:
 //!   true` — `agents::permissions::effective_scopes` (the SAME function
 //!   `ctrl::pm_task::dispatch::persona` calls) feeds the SAME
-//!   `agent_can_use`/`ScopePattern` gate on the persona-chat path, so this is
-//!   not aspirational. Every other field (`user_authority`, `tiers`,
-//!   `autonomy`, `grants`) is `enforced: false` — none has a live enforcement
-//!   site in this crate yet (tiers: DOC-57 §7.1 mechanism 3, "`[rbac]` block
-//!   has no read site"; `user_authority`: #3074/#3075; `autonomy`: PM-2,
-//!   DOC-23 owns the real model; `grants`: PM-1/PM-4, no enforcement site by
-//!   design in this phase).
+//!   `agent_can_use`/`ScopePattern` gate — so this is not aspirational, BUT it
+//!   is **not universal either**. `effective_scopes` is called from exactly
+//!   ONE dispatch path in this crate: the persona-chat gate
+//!   (`ctrl::pm_task::dispatch::persona`). The `--direct`/subprocess path
+//!   (`runtime::subagent_mode` → `runtime::tool_registry::scope_assistant_allowed_tools`)
+//!   filters purely by `[tools].allow` NAME globs and never reads
+//!   `tools.scopes`, `permissions.scopes`, `ScopePattern`, or `agent_can_use`
+//!   at all — an agent invoked via `tagent --direct` is NOT scope-restricted
+//!   by anything this pane reports. Each scope element therefore ALSO carries
+//!   `enforced_on: ["persona_chat"]` ([`SCOPE_ENFORCED_ON`]) so the JSON
+//!   contract itself says so, not just this doc comment — a bare `enforced:
+//!   true` with no qualifier is exactly the half-true "some path enforces
+//!   this" reading that made #4018 a half-fix (#3987/#4093 track unifying the
+//!   two paths; not attempted here). Every other field (`user_authority`,
+//!   `tiers`, `autonomy`, `grants`) is `enforced: false` — none has a live
+//!   enforcement site in this crate yet (tiers: DOC-57 §7.1 mechanism 3,
+//!   "`[rbac]` block has no read site"; `user_authority`: #3074/#3075;
+//!   `autonomy`: PM-2, DOC-23 owns the real model; `grants`: PM-1/PM-4, no
+//!   enforcement site by design in this phase).
 //! - `source` distinguishes `declared` (in this agent's OWN file) from
 //!   `inherited:<base>` (only reachable via its immediate `extends` target),
 //!   so the DOC-57 §7.3 class of defect (an agent granting tools whose
@@ -47,6 +59,21 @@ use super::state::AppState;
 use crate::agents::permissions::{PermissionsConfig, effective_scopes};
 use crate::agents::{AgentConfig, RbacConfig, ToolsConfig};
 use crate::rbac::ServiceTier;
+
+/// The dispatch path(s) `agents::permissions::effective_scopes` actually
+/// gates, named on every `scopes[]` element (`enforced_on`).
+///
+/// Why: `enforced: true` alone reads as universal. It is not — the
+/// `--direct`/subprocess path (`runtime::subagent_mode` →
+/// `runtime::tool_registry::scope_assistant_allowed_tools`) filters by
+/// `[tools].allow` name globs only and never consults a scope pattern at
+/// all. Naming the ONE path that does (module doc) in the wire contract
+/// itself, not only in a comment, is what keeps this pane from overstating
+/// its own reach — the exact failure class (#4018) this crate has already
+/// shipped once.
+/// What: A single-element list today; grows if/when #3987/#4093 unify the
+/// two dispatch paths' scope enforcement.
+const SCOPE_ENFORCED_ON: &[&str] = &["persona_chat"];
 
 /// `GET /api/agents/:name/permissions` — HTTP entry point.
 ///
@@ -150,7 +177,15 @@ pub(super) async fn permissions_at(dirs: &[PathBuf], name: &str) -> Response {
                 // than asserting a provenance we cannot back.
                 "declared".to_string()
             };
-            json!({ "pattern": pattern, "source": source, "enforced": true })
+            json!({
+                "pattern": pattern,
+                "source": source,
+                "enforced": true,
+                // Qualifies the boolean above — see `SCOPE_ENFORCED_ON`'s doc
+                // and the module doc's PM-6 bullet: this is NOT universal,
+                // the `--direct`/subprocess dispatch path never reaches it.
+                "enforced_on": SCOPE_ENFORCED_ON,
+            })
         })
         .collect();
 

--- a/crates/trusty-agents/src/api/server/agent_permissions.rs
+++ b/crates/trusty-agents/src/api/server/agent_permissions.rs
@@ -78,7 +78,7 @@ const SCOPE_ENFORCED_ON: &[&str] = &["persona_chat"];
 /// `GET /api/agents/:name/permissions` — HTTP entry point.
 ///
 /// Why/What: see the module doc.
-/// Test: `super::tests::agent_permissions::permissions_route_reports_declared_scopes`.
+/// Test: `super::tests::agent_permissions::permissions_route_reports_declared_and_inherited_scopes`.
 pub(super) async fn agent_permissions_route(
     State(_state): State<AppState>,
     AxumPath(name): AxumPath<String>,
@@ -109,8 +109,7 @@ pub(super) async fn agent_permissions_route(
 /// reachable only via that immediate base, whatever THAT base in turn
 /// inherited — and avoids re-deriving per-level provenance from
 /// `merge_extends`'s flattened output, which does not retain it.
-/// Test: `permissions_route_reports_declared_scopes`,
-/// `permissions_route_reports_inherited_scope_from_immediate_base`,
+/// Test: `permissions_route_reports_declared_and_inherited_scopes`,
 /// `permissions_route_never_inherits_user_authority`,
 /// `permissions_route_degrades_on_malformed_toml`,
 /// `permissions_route_degrades_gracefully_on_unresolvable_extends`.

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -16,6 +16,8 @@
 //!   - `projects`     → project / session / agent listing handlers
 //!   - `agent_patch`  → per-agent model/provider write path
 //!     (`PATCH /api/agents/:name`, #3246)
+//!   - `agent_permissions` → structured permissions model
+//!     (`GET /api/agents/:name/permissions`, #3936, DOC-57 §7)
 //!   - `project_registration` → project register + per-project config lookup
 //!   - `ctrl_sessions`→ CTRL session CRUD (`om session …`)
 //!   - `tm`           → tmux session management (`/api/tm/*`)
@@ -31,6 +33,7 @@
 
 mod agent_create;
 mod agent_patch;
+mod agent_permissions;
 mod agent_skills;
 mod agent_stores;
 mod auth;

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -23,6 +23,7 @@ use trusty_common::server::{SelfOrigins, with_guarded_middleware};
 
 use super::agent_create::create_agent_route;
 use super::agent_patch::{get_agent_persona_route, get_agent_route, patch_agent_route};
+use super::agent_permissions::agent_permissions_route;
 use super::agent_skills::agent_skills_route;
 use super::agent_stores::agent_stores_route;
 use super::auth::{ApiClientConfig, ApiConfig, AuthState, auth_middleware};
@@ -164,6 +165,15 @@ pub fn build_router_with_origins(
         .route(
             "/api/agents/{name}/skills",
             axum::routing::get(agent_skills_route),
+        )
+        // #3936: the Permissions pane reads the agent's structured
+        // permissions model — scopes (with declared/inherited provenance),
+        // tiers, `user_authority`, autonomy posture, per-skill grants — with
+        // an `enforced` flag on every field (DOC-57 §7). Read-only in every
+        // phase (PM-4).
+        .route(
+            "/api/agents/{name}/permissions",
+            axum::routing::get(agent_permissions_route),
         )
         .route("/api/workstreams", get(list_workstreams_route))
         .route(

--- a/crates/trusty-agents/src/api/server/tests/agent_permissions.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_permissions.rs
@@ -1,0 +1,296 @@
+//! `GET /api/agents/:name/permissions` handler tests (#3936, DOC-57 §7).
+//!
+//! Why: This route's whole value is honesty (PM-6) — every field must carry
+//! `enforced` truthfully, and `source` must distinguish what an agent
+//! declared itself from what it inherited. The tests pin: a declared scope,
+//! an inherited scope naming the immediate base, `[permissions].scopes`
+//! superseding legacy `[tools].scopes` per CC-9, `user_authority` never
+//! inheriting `true` from a base (PM-3), and honest degradation on malformed
+//! TOML / an unresolvable `extends` chain.
+//! What: `permissions_at` driven against a `tempfile::TempDir` (the
+//! `agent_stores`/`agent_skills` pattern), plus one full-router test.
+//! Test: This module IS the test.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::api::server::agent_permissions::permissions_at;
+use crate::api::server::routes::build_router;
+use crate::api::server::state::AppState;
+
+// `AgentConfig::by_name_in` — the full loader `permissions_at` uses to
+// resolve `extends` — requires `[llm]` and `[system_prompt]` (no serde
+// defaults on `AgentConfig::llm`/`system_prompt`), unlike the sibling
+// routes' partial-parse fixtures. Every fixture that needs full-chain
+// resolution therefore carries both sections.
+const BASE_FIXTURE: &str = r#"[agent]
+name = "assistant"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[tools]
+scopes = ["memory.read"]
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#;
+
+/// Declares its own scope AND extends a base that declares another.
+const CHILD_FIXTURE: &str = r#"[agent]
+name = "cto-assistant"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+extends = "assistant"
+
+[permissions]
+scopes = ["google.gmail.*"]
+default_tier = "analytics"
+autonomy = "learn-to-act"
+
+[[permissions.grants]]
+skill = "gmail"
+mode = "ask"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#;
+
+/// `[permissions].scopes` supersedes legacy `[tools].scopes` in the SAME
+/// file (CC-9) — declares both to prove the precedence, not the union.
+const CC9_FIXTURE: &str = r#"[agent]
+name = "migrated"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[tools]
+scopes = ["memory.read"]
+
+[permissions]
+scopes = ["search.read"]
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#;
+
+/// A base with `user_authority = true` and a child that extends it without
+/// declaring its own (PM-3: must never inherit `true`).
+const AUTHORITY_BASE_FIXTURE: &str = r#"[agent]
+name = "authority-holder"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[permissions]
+user_authority = true
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#;
+
+const AUTHORITY_CHILD_FIXTURE: &str = r#"[agent]
+name = "overlay"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+extends = "authority-holder"
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#;
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn find_scope<'a>(body: &'a serde_json::Value, pattern: &str) -> &'a serde_json::Value {
+    body["scopes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|s| s["pattern"] == pattern)
+        .unwrap_or_else(|| panic!("scope {pattern} missing from response: {body:?}"))
+}
+
+#[tokio::test]
+async fn permissions_route_reports_declared_and_inherited_scopes() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("assistant.toml"), BASE_FIXTURE).unwrap();
+    std::fs::write(dir.path().join("cto-assistant.toml"), CHILD_FIXTURE).unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "cto-assistant").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+
+    let own = find_scope(&body, "google.gmail.*");
+    assert_eq!(own["source"], "declared");
+    assert_eq!(own["enforced"], true);
+
+    let inherited = find_scope(&body, "memory.read");
+    assert_eq!(
+        inherited["source"], "inherited:assistant",
+        "a scope only the base declared must name the immediate base"
+    );
+    assert_eq!(inherited["enforced"], true);
+
+    assert_eq!(body["tiers"]["default"], "analytics");
+    assert_eq!(body["tiers"]["enforced"], false);
+    assert_eq!(body["autonomy"]["mode"], "learn-to-act");
+    assert_eq!(body["autonomy"]["enforced"], false);
+
+    let grants = body["grants"].as_array().unwrap();
+    assert_eq!(grants.len(), 1);
+    assert_eq!(grants[0]["skill"], "gmail");
+    assert_eq!(grants[0]["mode"], "ask");
+    assert_eq!(grants[0]["enforced"], false);
+}
+
+#[tokio::test]
+async fn permissions_route_permissions_scopes_supersedes_legacy_tools_scopes() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("migrated.toml"), CC9_FIXTURE).unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "migrated").await;
+    let body = body_json(resp).await;
+    let scopes = body["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 1, "CC-9: the union is not taken, {scopes:?}");
+    assert_eq!(scopes[0]["pattern"], "search.read");
+    assert_eq!(scopes[0]["source"], "declared");
+}
+
+#[tokio::test]
+async fn permissions_route_never_inherits_user_authority() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("authority-holder.toml"),
+        AUTHORITY_BASE_FIXTURE,
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("overlay.toml"), AUTHORITY_CHILD_FIXTURE).unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "overlay").await;
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["user_authority"]["value"], false,
+        "a child must never inherit user_authority=true from its base (PM-3)"
+    );
+    assert_eq!(body["user_authority"]["enforced"], false);
+
+    // The base itself still reports its own explicit value.
+    let base_resp = permissions_at(&[dir.path().to_path_buf()], "authority-holder").await;
+    let base_body = body_json(base_resp).await;
+    assert_eq!(base_body["user_authority"]["value"], true);
+}
+
+#[tokio::test]
+async fn permissions_route_grants_no_permission_it_did_not_already_hold() {
+    // C-06.4: the route is read-only and must never widen a scope beyond
+    // what the config declares — sanity-check on the bare-agent case.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("plain.toml"),
+        "[agent]\nname = \"plain\"\nrole = \"assistant\"\nmodel = \"claude-sonnet-4-6\"\ndescription = \"test\"\n",
+    )
+    .unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "plain").await;
+    let body = body_json(resp).await;
+    assert!(body["scopes"].as_array().unwrap().is_empty());
+    assert!(body["grants"].as_array().unwrap().is_empty());
+    assert_eq!(body["user_authority"]["value"], false);
+}
+
+#[tokio::test]
+async fn permissions_route_unknown_agent_404() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp = permissions_at(&[dir.path().to_path_buf()], "nobody").await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn permissions_route_rejects_traversal_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp = permissions_at(&[dir.path().to_path_buf()], "../etc").await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn permissions_route_degrades_on_malformed_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("broken.toml"), "not = = toml").unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "broken").await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::OK,
+        "a hand-edit typo must not 500 the panel"
+    );
+    let body = body_json(resp).await;
+    assert!(body["scopes"].as_array().unwrap().is_empty());
+    assert!(body["config_error"].is_string());
+}
+
+#[tokio::test]
+async fn permissions_route_degrades_gracefully_on_unresolvable_extends() {
+    // `extends` points at a base that does not exist — `AgentConfig::by_name_in`
+    // fails to resolve the chain, and the route must still render this
+    // agent's OWN declarations rather than going dark.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("orphan.toml"),
+        "[agent]\nname = \"orphan\"\nrole = \"assistant\"\nmodel = \"claude-sonnet-4-6\"\ndescription = \"test\"\nextends = \"does-not-exist\"\n\n[permissions]\nscopes = [\"memory.read\"]\n",
+    )
+    .unwrap();
+
+    let resp = permissions_at(&[dir.path().to_path_buf()], "orphan").await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    let scopes = body["scopes"].as_array().unwrap();
+    assert_eq!(scopes.len(), 1);
+    assert_eq!(scopes[0]["pattern"], "memory.read");
+    assert_eq!(scopes[0]["source"], "declared");
+    assert!(body["extends_warning"].is_string());
+}
+
+/// Proves the route is wired into `build_router`.
+#[tokio::test]
+async fn permissions_route_is_wired_into_router() {
+    let app: axum::Router = build_router(AppState::default());
+    let req = Request::builder()
+        .uri("/api/agents/definitely-not-an-agent-3936/permissions")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["error"], "unknown agent",
+        "a 404 from the handler, not from an unrouted path"
+    );
+}

--- a/crates/trusty-agents/src/api/server/tests/agent_permissions.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_permissions.rs
@@ -151,6 +151,15 @@ async fn permissions_route_reports_declared_and_inherited_scopes() {
     let own = find_scope(&body, "google.gmail.*");
     assert_eq!(own["source"], "declared");
     assert_eq!(own["enforced"], true);
+    // HIGH (code-critic, PR #4127): `enforced: true` alone reads as
+    // universal, but `effective_scopes` only feeds the persona-chat gate —
+    // the `--direct`/subprocess path never consults a scope pattern at all.
+    // The wire contract must say so, not just a doc comment.
+    assert_eq!(
+        own["enforced_on"],
+        serde_json::json!(["persona_chat"]),
+        "the enforcement claim must be qualified to the path that actually gates it: {own:?}"
+    );
 
     let inherited = find_scope(&body, "memory.read");
     assert_eq!(
@@ -158,6 +167,10 @@ async fn permissions_route_reports_declared_and_inherited_scopes() {
         "a scope only the base declared must name the immediate base"
     );
     assert_eq!(inherited["enforced"], true);
+    assert_eq!(
+        inherited["enforced_on"],
+        serde_json::json!(["persona_chat"])
+    );
 
     assert_eq!(body["tiers"]["default"], "analytics");
     assert_eq!(body["tiers"]["enforced"], false);

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -7,6 +7,7 @@
 #![allow(clippy::await_holding_lock)]
 
 mod agent_patch;
+mod agent_permissions;
 mod agent_skills;
 mod agent_stores;
 mod cancel;

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -512,16 +512,27 @@ pub async fn run_pm_task_with_persona(
                         .map(String::from)
                 })
                 .collect();
-            // #3208: agent-declared `[tools].scopes` enforcement. `tool_scopes`
-            // maps the (few) OpenRPC-registry-discovered tools to their scope
-            // string; `agent_scope_patterns` is this persona's own declared
-            // patterns. Native/in-process tools carry no scope and are
-            // unaffected — see `filter_persona_tool_names`.
+            // #3208: agent-declared scope enforcement. `tool_scopes` maps the
+            // (few) OpenRPC-registry-discovered tools to their scope string;
+            // `agent_scope_patterns` is this persona's own declared patterns.
+            // Native/in-process tools carry no scope and are unaffected — see
+            // `filter_persona_tool_names`.
+            //
+            // #3936: resolved via `agents::permissions::effective_scopes`
+            // rather than reading `persona_cfg.tools.scopes` directly, so
+            // `[permissions].scopes` (DOC-57 §7.2) is honoured with the SAME
+            // CC-9 precedence (`[permissions].scopes` wins over legacy
+            // `[tools].scopes` when a file declares both) the
+            // `/permissions` route reports — the ONE place this precedence
+            // is decided, so the route's `enforced: true` claim for a
+            // `[permissions].scopes`-only agent is never aspirational. Byte-
+            // identical to the pre-#3936 read when `[permissions]` is absent.
             let tool_scopes = registry.tool_scopes();
-            let agent_scope_patterns: Vec<ScopePattern> = persona_cfg
-                .tools
-                .scopes
-                .clone()
+            let agent_scope_patterns: Vec<ScopePattern> =
+                crate::agents::permissions::effective_scopes(
+                    &persona_cfg.tools,
+                    &persona_cfg.permissions,
+                )
                 .unwrap_or_default()
                 .into_iter()
                 .map(ScopePattern::new)


### PR DESCRIPTION
## Summary

- Implements #3936 (DOC-57 §7, Phase 4 of the five-section agent-config model): `GET /api/agents/:name/permissions`.
- New `[permissions]` `agent.toml` section (`agents/permissions.rs`): `scopes`, `user_authority` (DOC-41 §5.5's reserved singleton, now a real parsed field), `default_tier`/`unauthenticated_tier`, `autonomy`, `[[grants]]`. `[permissions]` **describes** the four scattered enforcement mechanisms DOC-57 §7.1 catalogs — it invents no new enforcement (PM-1).
- **Every response field carries an honest `enforced` boolean (PM-6):**
  - `scopes[]` → `enforced: true`. `agents::permissions::effective_scopes` is the ONE place CC-9 precedence is decided (`[permissions].scopes` wins over legacy `[tools].scopes` within a single file — the union is deliberately not taken), and it's now the SAME function `ctrl::pm_task::dispatch::persona`'s scope gate calls. That's what makes the `enforced: true` claim true rather than aspirational.
  - `user_authority`, `tiers`, `autonomy`, `grants` → `enforced: false`, each with a `reason` — none has a live enforcement site in this crate yet (`user_authority`: #3074/#3075; tiers: DOC-57 §7.1 says `[rbac]` "has no read site"; `autonomy`: PM-2, DOC-23 owns the real model; `grants`: PM-1/PM-4).
- `source` on each scope distinguishes `declared` (this agent's own file) from `inherited:<base>` — the DOC-57 §7.3 defect class (an agent granting tools whose scopes it never actually declared) becomes visible in the pane instead of requiring a reader to simulate `merge_extends`.
- `extends/mod.rs`: `permissions.scopes` unions base-first across the chain (a partially-migrated chain — base on legacy `[tools].scopes`, child on new `[permissions].scopes` — still unions correctly, tested explicitly), `grants[]` unions by `skill`, `user_authority` is **never** inherited (PM-3) — un-ignores the `extends_does_not_inherit_user_authority` regression test that had been stubbed since AUTH-1/#3074 was filed.
- Read-only in every phase (PM-4); grants or widens nothing (C-06.4) — the route resolves `AgentConfig::by_name_in`'s existing chain, nothing new.

## Honest-degradation behavior

- Malformed `agent.toml` → `200` + `config_error`, never `500`.
- An unresolvable `extends` chain (missing base, cycle) → `200`, falls back to the agent's own declarations (every scope reports `source: "declared"`), plus a non-normative `extends_warning` field naming the gap.

## Test plan

- [x] `cargo test -p trusty-agents --lib` — 2755 passed, 0 failed (full crate suite; one unrelated pre-existing flake — `tools::python_skill::tests::execute_dispatches_to_python_and_parses_json`, a venv/environment race untouched by this PR, confirmed flaky independent of these changes by re-running clean)
- [x] `cargo clippy -p trusty-agents --lib --tests -- -D warnings` — clean
- [x] `cargo fmt -p trusty-agents -- --check` — clean
- [x] `agents::permissions` + `agents::extends` unit tests (39 total) — including the newly un-ignored `extends_does_not_inherit_user_authority`, the partially-migrated-chain union test, and the grants-union-by-skill test
- [x] `api::server::agent_permissions` route tests (13 total) — declared vs. inherited provenance, CC-9 precedence, `user_authority` non-inheritance at the route level, malformed TOML, unresolvable `extends`, router wiring

## Adjacent defects noted, deliberately not touched

- `AgentDetail.scopes` in `projects.rs:531` still reads `cfg.tools.scopes` directly rather than through `effective_scopes` — that's the Phase-1 GUI mapping DOC-57 §8.5 documents as superseded by this route; left alone to keep this PR scoped to the new route + its own enforcement wiring.
- #3987 / #4093 (dead scope/tool-allow diagnostics on the two independent dispatch paths) — explicitly out of scope per the task; not touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools