### PR TITLE
fix(trusty-code): bound the initial session-events connect so it cannot hang (#3494)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -102,6 +102,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **The TUI's initial session-events connect could hang forever, bypassing the
+  reconnect budget (#3494).** `build_http_client()` sets `connect_timeout(5s)`,
+  which bounds only the TCP handshake — a daemon that accepts the connection but
+  never sends response headers (wedged, deadlocked, or slow-lorising) left
+  `pump_session_events`'s `GET /sessions/{id}/events` `.send().await` pending
+  indefinitely. `SESSION_STREAM_MAX_RECONNECTS` never applied, because that
+  budget only starts counting once `.send().await` resolves. A per-request
+  `.timeout(CONNECT_TIMEOUT)` (10s) now bounds connect-through-headers only; the
+  body read stays governed by `SSE_IDLE_TIMEOUT`. A timed-out connect surfaces as
+  an ordinary transport error, so it counts against the reconnect budget like
+  every other failure rather than being a silent-hang path of its own.
+
 - **`TurnCapExceeded` permanently un-resumed a session (#3888).** A
   session whose `task.run` call exhausted its per-call
   `AgentLoopConfig::max_turns` budget fell through

--- a/crates/trusty-code/src/tui_client/engine.rs
+++ b/crates/trusty-code/src/tui_client/engine.rs
@@ -52,6 +52,31 @@ use super::workstream_subscription::run_workstream_subscription;
 /// and `workstream_subscription.rs`.
 pub(super) const SSE_IDLE_TIMEOUT: Duration = Duration::from_secs(45);
 
+/// Bound on the initial `GET /sessions/{id}/events` request — from
+/// connecting through receiving response headers — before
+/// `EngineState::pump_session_events` treats it as a failed attempt (issue
+/// #3494).
+///
+/// Why: `build_http_client()` sets a `connect_timeout(5s)` at the
+/// `reqwest::Client` level, which only bounds the TCP handshake. A daemon
+/// that accepts the connection but then never sends response headers (e.g.
+/// wedged, deadlocked, or slow-lorising) leaves `.send().await` pending
+/// forever — hanging `pump_session_events` indefinitely and completely
+/// bypassing `SESSION_STREAM_MAX_RECONNECTS`, since that reconnect budget
+/// only starts counting once `.send().await` actually resolves. A
+/// request-level `.timeout(CONNECT_TIMEOUT)` (applied only to THIS request,
+/// not the whole client) closes that gap: reqwest's per-request timeout
+/// bounds the connect-through-headers future `.send()` awaits (the same
+/// future `Response` resolves from) — it does NOT extend to the
+/// already-established `resp.bytes_stream()` body read afterward, which
+/// stays governed by [`SSE_IDLE_TIMEOUT`] via the existing
+/// `tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data())` below. A
+/// timed-out connect surfaces as a `reqwest::Error` from `.send()`, so it
+/// falls into the SAME retryable `Err(source)` branch as any other
+/// transport failure — counted against `SESSION_STREAM_MAX_RECONNECTS`
+/// like every other failure mode, not a new silent-hang path.
+pub(super) const CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Fixed backoff between SSE reconnect attempts. Not exponential — MVP
 /// scope (DOC-50 §5 Slice 3); a persistently-down daemon retries at a
 /// steady, human-visible cadence rather than hot-looping. Shared with

--- a/crates/trusty-code/src/tui_client/engine_state.rs
+++ b/crates/trusty-code/src/tui_client/engine_state.rs
@@ -32,7 +32,9 @@ use trusty_tui::{CommandDescriptor, PickerItem, ReplEvent, StatuslineSegment, Wo
 
 use crate::events::SessionEventEnvelope;
 
-use super::engine::{RECONNECT_BACKOFF, SESSION_STREAM_MAX_RECONNECTS, SSE_IDLE_TIMEOUT};
+use super::engine::{
+    CONNECT_TIMEOUT, RECONNECT_BACKOFF, SESSION_STREAM_MAX_RECONNECTS, SSE_IDLE_TIMEOUT,
+};
 use super::error::EngineError;
 use super::rpc::RpcHttpClient;
 use super::session_events::{
@@ -318,7 +320,18 @@ impl EngineState {
         let url = format!("{}/sessions/{session_id}/events", self.rpc.base_url());
         let mut attempts = 0u32;
         'reconnect: loop {
-            let resp = match self.rpc.http().get(&url).send().await {
+            // `.timeout(CONNECT_TIMEOUT)` bounds connect-through-headers only
+            // (issue #3494) — see that const's doc comment for why this
+            // can't silently extend to the `resp.bytes_stream()` body read
+            // governed by `SSE_IDLE_TIMEOUT` below.
+            let resp = match self
+                .rpc
+                .http()
+                .get(&url)
+                .timeout(CONNECT_TIMEOUT)
+                .send()
+                .await
+            {
                 Ok(r) if r.status().is_success() => r,
                 Ok(r) => {
                     let status = r.status();

--- a/crates/trusty-code/src/tui_client/engine_tests.rs
+++ b/crates/trusty-code/src/tui_client/engine_tests.rs
@@ -291,3 +291,71 @@ fn statusline_segments_reflect_active_workstream_and_clear_on_none() {
         "deactivation must clear the segment, not leave a stale one"
     );
 }
+
+/// Regression test for issue #3494: a daemon that accepts the TCP
+/// connection but never sends response headers must not hang
+/// `pump_session_events`'s initial `GET /sessions/{id}/events` forever —
+/// before this fix, `.send().await` had no per-request bound and would wait
+/// indefinitely, completely bypassing `SESSION_STREAM_MAX_RECONNECTS`.
+///
+/// Uses a raw `TcpListener` that accepts every connection and then holds it
+/// open without ever writing a byte — the exact "TCP accepted, headers
+/// never sent" trigger the issue describes (a `wiremock` mock always
+/// completes the HTTP handshake, so it can't reproduce this). If
+/// `CONNECT_TIMEOUT` were removed, `.send().await` would still be pending
+/// when the outer bound below elapses, and no `ConnectionLost` would ever
+/// arrive — this test would fail deterministically on a timeout rather than
+/// hang the test binary, same rationale as
+/// `tests/tui_client_engine.rs`'s exhausted-reconnects test.
+///
+/// Deliberately does NOT wait for `pump_session_events` to exhaust all
+/// `SESSION_STREAM_MAX_RECONNECTS` (every attempt would hang the same way,
+/// ~1 minute total) — observing the FIRST `ConnectionLost` is sufficient
+/// proof the connect attempt is bounded by `CONNECT_TIMEOUT`, not infinite.
+#[tokio::test]
+async fn events_connect_hang_is_bounded_by_connect_timeout_not_infinite() {
+    let std_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    std_listener.set_nonblocking(true).expect("set_nonblocking");
+    let listener = tokio::net::TcpListener::from_std(std_listener).expect("tokio listener");
+    let addr = listener.local_addr().expect("local_addr");
+
+    // Accept connections forever, never writing/closing — `mem::forget`
+    // keeps each accepted socket's fd open (dropping it would close the
+    // connection, which reqwest would see as a fast, distinct failure mode,
+    // not the hang this test targets).
+    let accept_task = tokio::spawn(async move {
+        while let Ok((stream, _)) = listener.accept().await {
+            std::mem::forget(stream);
+        }
+    });
+
+    let state = EngineState::new(
+        RpcHttpClient::new(reqwest::Client::new(), format!("http://{addr}")),
+        None,
+    );
+    let (tx, mut rx) = unbounded_channel();
+
+    let pump_task = tokio::spawn(async move { state.pump_session_events("s-1", &tx).await });
+
+    // CONNECT_TIMEOUT (10s) plus slack — comfortably short of the ~1 minute
+    // a full 5-reconnect exhaustion would take, but generous enough that
+    // this never flakes on a loaded CI box.
+    match tokio::time::timeout(CONNECT_TIMEOUT + Duration::from_secs(10), rx.recv()).await {
+        Ok(Some(ReplEvent::ConnectionLost { reason })) => {
+            assert!(
+                reason.contains("connection failed"),
+                "expected a transport-error ConnectionLost from the timed-out connect, got: \
+                 {reason}"
+            );
+        }
+        Ok(Some(other)) => panic!("expected ConnectionLost, got {other:?}"),
+        Ok(None) => panic!("channel closed with no event — pump_session_events exited silently"),
+        Err(_) => panic!(
+            "no ConnectionLost observed within CONNECT_TIMEOUT + slack — the initial connect \
+             attempt hung past CONNECT_TIMEOUT (issue #3494 regression)"
+        ),
+    }
+
+    pump_task.abort();
+    accept_task.abort();
+}


### PR DESCRIPTION
Closes #3494.

## The bug

`build_http_client()` sets `connect_timeout(5s)`, which bounds **only the TCP
handshake**. `EngineState::pump_session_events` then opens the session-events
stream with a bare:

```rust
let resp = match self.rpc.http().get(&url).send().await {
```

A daemon that **accepts the connection but never sends response headers** — wedged,
deadlocked, or deliberately slow-lorising — satisfies `connect_timeout` and then
leaves `.send().await` pending **forever**.

The damaging part is what that bypasses: `SESSION_STREAM_MAX_RECONNECTS` and the
reconnect-exhaustion / visible-error path only begin to apply *once
`.send().await` resolves*. While it hangs, the entire reconnect budget is inert.
So this is not "a slow connect" — it is a silent-hang mode that defeats the
supervision mechanism designed to catch exactly this.

## The fix

A **per-request** `.timeout(CONNECT_TIMEOUT)` (10s) on this one call — not a
client-level timeout.

That distinction is the crux of the change, and the reason it is safe: reqwest's
per-request timeout bounds the connect-through-headers future that `.send()`
awaits (the same future `Response` resolves from). It does **not** extend to the
already-established `resp.bytes_stream()` body read afterward, which continues to
be governed by `SSE_IDLE_TIMEOUT` via the existing
`tokio::time::timeout(SSE_IDLE_TIMEOUT, lines.next_data())`. A client-level
timeout *would* have capped the body read and broken long-lived SSE streams.

A timed-out connect surfaces as an ordinary `reqwest::Error` from `.send()`, so it
lands in the **same retryable `Err(source)` branch** as any other transport
failure — counted against `SESSION_STREAM_MAX_RECONNECTS` like every other failure
mode, rather than introducing a new special case.

## Provenance — why this is a separate PR

This fix was found bundled into the rescued #3696 Slice 2 branch (`dcc4f33b`),
mixed in with unrelated TUI streaming work. It has been **split out** so each PR is
single-purpose; the streaming half is #4145.

The split is lossless and verified by arithmetic: the original branch was
`+262/−3`; this PR is `+108/−2` and the streaming half is `+154/−1`.

Issue #3494 was confirmed **still open** before opening this PR, and `main` was
confirmed to still carry the unbounded `.send().await`. This is not redundant work.

## Regression test

`events_connect_hang_is_bounded_by_connect_timeout_not_infinite` uses a raw
`TcpListener` that accepts every connection and then holds it open without writing
a byte — reproducing the exact "TCP accepted, headers never sent" trigger.
`wiremock` **cannot** reproduce this, because it always completes the HTTP
handshake.

The test is a genuine regression guard, not a tautology: with `CONNECT_TIMEOUT`
removed, `.send().await` would still be pending when the outer bound elapses, no
`ConnectionLost` would ever arrive, and the test fails deterministically on its own
timeout rather than hanging the test binary.

Evidence it actually exercised the timeout path rather than passing trivially: the
unit-test suite runtime rises from **2.44s** to **11.39s** on this branch,
consistent with the 10s `CONNECT_TIMEOUT` elapsing for real.

It deliberately observes only the *first* `ConnectionLost` rather than waiting out
all 5 reconnects (~1 minute), since one bounded attempt is sufficient proof.

## Verification

```
$ cargo fmt --check
exit 0

$ cargo clippy --all-targets -p trusty-code -- -D warnings
exit 0

$ cargo test -p trusty-code          # FULL surface, not --lib
test tui_client::engine::engine_tests::events_connect_hang_is_bounded_by_connect_timeout_not_infinite ... ok
test result: ok. 1603 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 11.39s
test result: ok. 7 passed; 0 failed; 0 ignored     (tcode bin)
tests/agent_fallback_e2e.rs           ok. 3 passed; 0 failed
tests/agent_id_e2e.rs                 ok. 1 passed; 0 failed
tests/agents_e2e.rs                   ok. 2 passed; 0 failed
tests/cli_e2e.rs                      ok. 14 passed; 0 failed
tests/config_mount.rs                 ok. 2 passed; 0 failed
tests/connector_e2e.rs                ok. 7 passed; 0 failed
tests/inference_shared_adapter_e2e.rs ok. 4 passed; 0 failed
tests/m1_cutline_e2e.rs               ok. 4 passed; 0 failed
tests/readiness_e2e.rs                ok. 2 passed; 0 failed
tests/recall_content_e2e.rs           ok. 1 passed; 0 failed
tests/search_hits_e2e.rs              ok. 1 passed; 0 failed
tests/session_e2e.rs                  ok. 2 passed; 0 failed
tests/task_e2e.rs                     ok. 6 passed; 0 failed
tests/tui_client_engine.rs            ok. 7 passed; 0 failed

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.
```

`1603 = 1602` on `main` `+ 1` new test here. No test was `#[ignore]`d, cfg-gated,
excluded, or deleted to reach green; the 4 ignored tests are pre-existing on `main`.

## Follow-up not taken here

The original issue suggests checking `run_workstream_subscription`'s analogous
initial `GET /workstreams/{id}/events` connect for the same gap. That call site is
**not** touched by this PR — it was not part of the rescued diff, and widening
scope during a rescue-and-split is how the bundling problem started. Worth a
separate look.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
