### PR TITLE
fix(trusty-agents): taint delegate_to_agent spawns to close injection-to-RCE path

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,48 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **Closed a prompt-injection-to-arbitrary-code-execution path through
+  `delegate_to_agent` (#4126).** An assistant-tier persona (`assistant`,
+  `cto-assistant`, `izzie`) holding live external-content tools
+  (`get_gmail_message_content`, `web_search`, …) plus `delegate_to_agent`
+  could be driven by attacker-controlled fetched content to delegate an
+  attacker-authored task to `engineer` — a worker role with no
+  `[tools].allow` at all — and the spawned `claude-code` subprocess got its
+  full unrestricted tool surface (shell, file write) with no narrowing,
+  because the existing `scope_assistant_allowed_tools` gate only narrowed a
+  spawn when the SPAWNED agent's own role was `"assistant"`. Every
+  assistant-tier `delegate_to_agent` call now tags its spawn with the
+  delegator's own `[tools].allow` posture (`SubprocessAgentRunner::
+  with_delegation_taint`); the spawned worker's registry is narrowed to that
+  posture regardless of its own declared role, on both dispatch paths (the
+  `--direct`/`--agent` subprocess path and the in-process `/agent`
+  persona-chat path). A malformed/corrupted taint value fails CLOSED
+  (deny-all), never silently untainted. Narrowing is logged on both the
+  parent (pre-spawn) and child (post-scoping) sides, and a disallowed tool
+  call already returned (and continues to return) a legible
+  "not permitted for this agent" error rather than a silently-missing tool.
+
+- **Follow-up hardening for the `delegate_to_agent` taint fix above (#4126):
+  closed a multi-hop composition gap, added a fail-closed default, and
+  covered a third, previously-unpatched dispatch path.** (1) At hop 2+
+  (`assistant -> izzie -> engineer`), both dispatch paths forwarded the
+  INTERMEDIATE agent's own native `[tools].allow` as the outbound taint
+  instead of intersecting it with the INBOUND taint it had itself received —
+  a taint could widen back out instead of only ever narrowing. A new
+  `compose_delegation_taint` helper is now the single place both paths
+  compute the outbound taint, always as an intersection. (2) An
+  assistant-tier agent reached with no taint AND no resolvable
+  `[tools].allow` previously fell through to fully unrestricted; it is now
+  denied every tool by default. (3) `run_pm_task_with_history` — the path
+  backing the REPL, Slack, Telegram, and the API server, and `ctrl.toml`
+  (the standalone default) declares `role = "assistant"` per #3812 — built
+  its `DelegateToAgentTool` with no taint and no target-role gate at all,
+  reproducing #4126's exact exploit shape on the default path; it now
+  applies the same taint and `ASSISTANT_ALLOWED_DELEGATE_ROLES` gate as the
+  other two dispatch paths (`pm`/orchestrator-role callers are unaffected).
+
 ### Added
 
 - **The token-streaming chat path now streams Bedrock models via

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -380,18 +380,41 @@ pub async fn run_pm_task_with_history(
         return Ok(content);
     }
 
-    let runner: Arc<dyn AgentRunner> =
-        Arc::new(SubprocessAgentRunner::new().with_config_dir(Some(config_dir.clone())));
+    // Security fix (delegate_to_agent injection-to-RCE path, item 3, #4126):
+    // this THIRD dispatch path (backing the REPL, Slack, Telegram, and the
+    // API server, and `ctrl.toml` is the standalone-mode default) built its
+    // `DelegateToAgentTool` with NO taint and NO `allowed_target_roles` at
+    // all — `pm_cfg` resolves to `ctrl.toml`, which declares
+    // `role = "assistant"` (deliberately, per #3812, for role-filtered
+    // picker grouping), the SAME role value the OTHER two dispatch paths
+    // (`runtime::subagent_mode`, `persona.rs`) treat as "holds live
+    // external-content tools (web_search here), must never produce an
+    // unrestricted delegate_to_agent spawn." See `ctrl_delegate_posture`.
+    let inbound_taint = crate::runtime::tool_registry::parse_delegation_taint_env(
+        std::env::var("TAGENT_DELEGATION_TAINT_ALLOW").ok(),
+    );
+    let (delegation_taint, allowed_target_roles) = ctrl_delegate_posture(
+        &pm_cfg.agent.role,
+        pm_cfg.tools.allow.as_deref(),
+        inbound_taint.as_deref(),
+    );
+    let runner: Arc<dyn AgentRunner> = Arc::new(
+        SubprocessAgentRunner::new()
+            .with_config_dir(Some(config_dir.clone()))
+            .with_delegation_taint(delegation_taint),
+    );
 
     let mut registry = ToolRegistry::new();
-    registry.register(Arc::new(
-        // #3737: thread the task's session id so a successful delegation emits
-        // `AgentSpawned` and the API server can attribute the answer to the
-        // specialist that produced it (chat-bubble responder attribution).
-        DelegateToAgentTool::new(runner)
-            .with_config_dir(config_dir.clone())
-            .with_session_id(sid.clone()),
-    ));
+    // #3737: thread the task's session id so a successful delegation emits
+    // `AgentSpawned` and the API server can attribute the answer to the
+    // specialist that produced it (chat-bubble responder attribution).
+    let mut delegate_tool = DelegateToAgentTool::new(runner)
+        .with_config_dir(config_dir.clone())
+        .with_session_id(sid.clone());
+    if let Some(roles) = allowed_target_roles {
+        delegate_tool = delegate_tool.with_allowed_target_roles(roles);
+    }
+    registry.register(Arc::new(delegate_tool));
     // #3052 PR B (lane 3): the opaque tm<->tcode bridge, distinct from lane 2
     // (`delegate_to_agent` above). RBAC-locked to deny ReadOnly + Analytics.
     // #4026/#4028: the caller's `[subagents].allowed` list is resolved into the
@@ -513,6 +536,54 @@ pub async fn run_pm_task_with_history(
         text: events::preview(&content, 240),
     });
     Ok(content)
+}
+
+/// Compute the delegation-taint and role-allowlist posture
+/// `run_pm_task_with_history` applies to the `DelegateToAgentTool` it builds
+/// (security fix — item 3, #4126).
+///
+/// Why: Pulled out of the ~500-line dispatch body specifically so this
+/// fail-closed / role-gate behavior is unit-testable without a live LLM call
+/// — mirrors why `runtime::tool_registry::scope_for_delegation` and
+/// `compose_delegation_taint` are pure functions rather than inlined at
+/// their call sites. This was the THIRD `delegate_to_agent` construction
+/// site (besides `runtime::subagent_mode`/`runtime::tool_registry` and
+/// `ctrl::pm_task::dispatch::persona`) and, until this fix, the only one
+/// with no taint and no `allowed_target_roles` at all — even though
+/// `resolve_agent_config` can resolve `ctrl.toml`, which declares
+/// `role = "assistant"` (#3812).
+/// What: `role != "assistant"` (e.g. a resolved `pm.toml`, `role =
+/// "orchestrator"`) returns `(None, None)` — completely unaffected; `pm` is
+/// the trusted orchestrator, not a sandboxed persona, and this dispatch path
+/// must keep working exactly as before for it. `role == "assistant"`
+/// returns `(Some(taint), Some(roles))`: `taint` is
+/// `compose_delegation_taint(native_allow, inbound_taint).unwrap_or_default()`
+/// — ALWAYS `Some`, even when empty, matching
+/// `build_assistant_tier_registry`'s fail-closed convention (an absent
+/// `[tools].allow` on `ctrl.toml` narrows to deny-all, never skips tainting);
+/// `roles` is always `ASSISTANT_ALLOWED_DELEGATE_ROLES` — the same
+/// worker + peer-assistant allowlist `build_assistant_tier_registry` uses,
+/// deliberately excluding `orchestrator`/`controller`/`observer`/`analysis`.
+/// Test: `ctrl_delegate_posture_orchestrator_role_is_unrestricted`,
+/// `ctrl_delegate_posture_assistant_role_fails_closed_without_allow`,
+/// `ctrl_delegate_posture_assistant_role_forwards_native_allow`,
+/// `ctrl_delegate_posture_assistant_role_always_gates_target_roles`.
+fn ctrl_delegate_posture(
+    role: &str,
+    native_allow: Option<&[String]>,
+    inbound_taint: Option<&[String]>,
+) -> (Option<Vec<String>>, Option<Vec<String>>) {
+    if role != "assistant" {
+        return (None, None);
+    }
+    let taint =
+        crate::runtime::tool_registry::compose_delegation_taint(native_allow, inbound_taint)
+            .unwrap_or_default();
+    let roles = crate::runtime::tool_registry::ASSISTANT_ALLOWED_DELEGATE_ROLES
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+    (Some(taint), Some(roles))
 }
 
 /// Compute `chat_with_tools_gated`'s `allowed_tools` argument from an

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
@@ -9,7 +9,7 @@
 
 use serde_json::json;
 
-use super::allowed_tool_names_for;
+use super::{allowed_tool_names_for, ctrl_delegate_posture};
 use crate::rbac::{ServiceTier, UserIdentity};
 use crate::tools::ToolRegistry;
 use crate::tools::pm_bridge::PmBridgeTool;
@@ -177,5 +177,88 @@ async fn dispatch_task_invocable_when_no_user_through_dispatch_gated() {
         !result.is_error(),
         "no UserIdentity (local REPL/CLI) must preserve full access: {}",
         result.content()
+    );
+}
+
+// --- `ctrl_delegate_posture` (security fix, item 3, #4126) ---
+//
+// The THIRD `delegate_to_agent` construction site: `run_pm_task_with_history`
+// backs the REPL, Slack, Telegram, and the API server, and `ctrl.toml` (the
+// standalone-mode default) declares `role = "assistant"` (#3812) — the same
+// role value the OTHER two dispatch paths treat as "holds live
+// external-content tools, must never produce an unrestricted
+// `delegate_to_agent` spawn." Before this fix, this path applied NEITHER a
+// taint NOR a role-gate at all.
+
+#[test]
+fn ctrl_delegate_posture_orchestrator_role_is_unrestricted() {
+    // `resolve_agent_config` can load a project's `pm.toml` (`role =
+    // "orchestrator"`) instead of `ctrl.toml`. That case must be completely
+    // unaffected — `pm` is the trusted orchestrator, not a sandboxed
+    // persona — so this dispatch path keeps working exactly as before for it.
+    let (taint, roles) = ctrl_delegate_posture("orchestrator", None, None);
+    assert_eq!(taint, None, "pm/orchestrator must not be tainted");
+    assert_eq!(roles, None, "pm/orchestrator must not be role-gated");
+}
+
+#[test]
+fn ctrl_delegate_posture_assistant_role_fails_closed_without_allow() {
+    // `ctrl.toml` declares no `[tools]` section at all — `native_allow` is
+    // `None` — and there is no inbound taint (ctrl is always a top-level
+    // dispatch, never itself a delegation target). The fix must still
+    // produce an EXPLICIT empty (deny-all) taint, not skip tainting.
+    let (taint, roles) = ctrl_delegate_posture("assistant", None, None);
+    assert_eq!(
+        taint,
+        Some(Vec::new()),
+        "an assistant-tier ctrl with no declared [tools].allow must taint its \
+         delegate_to_agent spawns with an explicit deny-all set, never None \
+         (which would mean untainted/unrestricted)"
+    );
+    assert!(
+        roles.is_some(),
+        "assistant-tier ctrl must always be role-gated"
+    );
+}
+
+#[test]
+fn ctrl_delegate_posture_assistant_role_forwards_native_allow() {
+    // When `ctrl.toml` (or an operator override) DOES declare
+    // `[tools].allow`, that posture is what gets forwarded as the taint —
+    // not silently dropped to empty.
+    let native = vec!["web_search".to_string(), "delegate_to_agent".to_string()];
+    let (taint, _roles) = ctrl_delegate_posture("assistant", Some(&native), None);
+    assert_eq!(taint, Some(native));
+}
+
+#[test]
+fn ctrl_delegate_posture_assistant_role_always_gates_target_roles() {
+    // The role-gate must exclude orchestrator/controller/observer/analysis —
+    // the same privilege-escalation targets #3555 closed for the other two
+    // dispatch paths — and must include the worker roster ctrl legitimately
+    // delegates to.
+    let (_taint, roles) = ctrl_delegate_posture("assistant", None, None);
+    let roles = roles.expect("assistant-tier ctrl must be role-gated");
+    for expected in [
+        "engineer",
+        "qa",
+        "researcher",
+        "documentation",
+        "ops",
+        "planner",
+    ] {
+        assert!(
+            roles.iter().any(|r| r == expected),
+            "{expected} must be an allowed delegation target for ctrl, got: {roles:?}"
+        );
+    }
+    assert!(
+        !roles.iter().any(|r| r == "orchestrator"),
+        "orchestrator (pm) must NOT be a directly delegatable role for the \
+         assistant-tier gate, got: {roles:?}"
+    );
+    assert!(
+        !roles.iter().any(|r| r == "controller"),
+        "controller must NOT be a directly delegatable role, got: {roles:?}"
     );
 }

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -346,8 +346,32 @@ pub async fn run_pm_task_with_persona(
             // against `patterns` (the persona's `[tools].allow` globs), so
             // registering them here does not by itself grant access.
             let config_dir = project_path.join(".trusty-agents").join("agents");
-            let runner: Arc<dyn AgentRunner> =
-                Arc::new(SubprocessAgentRunner::new().with_config_dir(Some(config_dir.clone())));
+            // Security fix (delegate_to_agent injection-to-RCE path): this
+            // in-process persona-chat dispatch is the SECOND place (besides
+            // the `--direct`/`--agent` subprocess path handled in
+            // `runtime::subagent_mode`/`runtime::tool_registry`) that builds
+            // a `DelegateToAgentTool` for an assistant-tier persona holding
+            // live external-content tools (Gmail/Drive/web) plus
+            // `delegate_to_agent`. Tag the runner with THIS persona's own
+            // `[tools].allow` posture (`patterns`, already resolved above)
+            // whenever the persona's role is the assistant tier
+            // (`runtime::tool_registry::ASSISTANT_TIER_ROLE` — literal here
+            // because that constant is private to `runtime`, mirroring the
+            // existing `cfg.agent.role == "assistant"` comparison in
+            // `repl::agent_commands`) so whatever this persona spawns is
+            // narrowed to its own posture regardless of the spawned agent's
+            // declared role. Non-assistant-tier callers of this same chat
+            // path (if any) are unaffected — `None` is a byte-identical no-op.
+            let delegation_taint = if persona_cfg.agent.role == "assistant" {
+                Some(patterns.clone())
+            } else {
+                None
+            };
+            let runner: Arc<dyn AgentRunner> = Arc::new(
+                SubprocessAgentRunner::new()
+                    .with_config_dir(Some(config_dir.clone()))
+                    .with_delegation_taint(delegation_taint),
+            );
             registry.register(Arc::new(
                 // #3737: thread the session id so a persona that delegates
                 // onward attributes the answer to the specialist that produced

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -362,8 +362,28 @@ pub async fn run_pm_task_with_persona(
             // narrowed to its own posture regardless of the spawned agent's
             // declared role. Non-assistant-tier callers of this same chat
             // path (if any) are unaffected — `None` is a byte-identical no-op.
+            // Security fix (multi-hop taint composition, item 1, #4126): this
+            // in-process persona-chat dispatch is always a fresh top-level
+            // turn today (the ONLY way an already-tainted delegation reaches
+            // this process is via a subprocess spawn, and every subprocess
+            // spawn -- `--agent <name>` -- runs through
+            // `runtime::subagent_mode::run_subagent` instead, never this
+            // function). Reading `TAGENT_DELEGATION_TAINT_ALLOW` here anyway
+            // and composing it via `compose_delegation_taint` (rather than
+            // forwarding `patterns` verbatim) means this call site can never
+            // silently widen past an inbound taint if that assumption ever
+            // stops holding, at zero behavioral cost today: no env var is set
+            // on this process, so `inbound_taint` is `None` and the result is
+            // byte-identical to the prior `Some(patterns.clone())`/`None`
+            // split.
+            let inbound_taint = crate::runtime::tool_registry::parse_delegation_taint_env(
+                std::env::var("TAGENT_DELEGATION_TAINT_ALLOW").ok(),
+            );
             let delegation_taint = if persona_cfg.agent.role == "assistant" {
-                Some(patterns.clone())
+                crate::runtime::tool_registry::compose_delegation_taint(
+                    Some(&patterns),
+                    inbound_taint.as_deref(),
+                )
             } else {
                 None
             };

--- a/crates/trusty-agents/src/runtime/mod.rs
+++ b/crates/trusty-agents/src/runtime/mod.rs
@@ -94,7 +94,14 @@ mod subagent_exec;
 mod subagent_mode;
 mod subcommands;
 mod system_cmd;
-mod tool_registry;
+// Security fix (delegate_to_agent injection-to-RCE path, #4126): `pub(crate)`
+// (not private) so `ctrl::pm_task::dispatch::{persona, history}` — the two
+// OTHER `delegate_to_agent` call sites outside this module — can reuse
+// `ASSISTANT_ALLOWED_DELEGATE_ROLES`, `parse_delegation_taint_env`, and
+// `compose_delegation_taint` as the single source of truth for the
+// assistant-tier delegation-taint invariant, rather than re-deriving
+// (and risking drift in) their own copies.
+pub(crate) mod tool_registry;
 mod workflow_mode;
 
 use cli_def::{Cli, HELP, argv_as_task_text};

--- a/crates/trusty-agents/src/runtime/subagent_mode.rs
+++ b/crates/trusty-agents/src/runtime/subagent_mode.rs
@@ -132,6 +132,35 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
     // agents (role != "assistant") are completely unaffected.
     let is_assistant_tier = cfg.agent.role == super::tool_registry::ASSISTANT_TIER_ROLE;
 
+    // Security fix (delegate_to_agent injection-to-RCE path): a spawn tagged
+    // by `SubprocessAgentRunner::with_delegation_taint` (assistant-tier
+    // `delegate_to_agent` only — see that doc comment) carries the
+    // delegator's own `[tools].allow` posture as JSON here. `is_assistant_tier`
+    // above is keyed on THIS agent's OWN role, so `engineer` (no `[tools].allow`
+    // at all) previously sailed straight past every scoping check below and
+    // kept its full unrestricted registry regardless of who spawned it.
+    // `delegation_taint_allow`, when present, forces the SAME narrowing
+    // `scope_assistant_allowed_tools` already applies to assistant-tier
+    // agents onto THIS agent too, using the DELEGATOR's patterns instead of
+    // this agent's own — closing that gap without touching the (correct,
+    // unrelated) behavior for every non-delegated spawn. A malformed env var
+    // is treated as an empty (deny-all) taint rather than ignored, so a
+    // corrupted/truncated value can only narrow further, never widen.
+    let delegation_taint_allow: Option<Vec<String>> =
+        super::tool_registry::parse_delegation_taint_env(
+            std::env::var("TAGENT_DELEGATION_TAINT_ALLOW").ok(),
+        );
+    let is_tainted_delegation = delegation_taint_allow.is_some();
+    if is_tainted_delegation {
+        tracing::info!(
+            agent = %name,
+            role = %cfg.agent.role,
+            taint_patterns = ?delegation_taint_allow,
+            "sub-agent spawned via a tainted assistant-tier delegation; \
+             tool registry will be narrowed to the delegator's own posture"
+        );
+    }
+
     // #88: Per-call `max_turns` override via `TAGENT_MAX_TURNS`. The wave
     // loop sets this to tighten the turn budget per file (e.g. 20) so a
     // single invocation can't absorb an entire wave's work. Applied after
@@ -344,6 +373,7 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         code_dir.as_deref(),
         skill_registry.clone(),
         tag_skill_registry.clone(),
+        cfg.tools.allow.as_deref(),
     );
 
     // #57: If the agent opts into `use_finish_task`, auto-register the
@@ -408,17 +438,25 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
             "[skills].allow names skills that resolved to nothing; they grant no tools"
         );
     }
-    cfg.tools.allowed = super::tool_registry::scope_assistant_allowed_tools(
+    // Security fix (delegate_to_agent injection-to-RCE path): `scope_for_delegation`
+    // is `scope_assistant_allowed_tools` plus taint handling — see its doc
+    // comment in `tool_registry.rs` for the full rationale and the fixed
+    // vulnerability. Byte-identical to the pre-fix `scope_assistant_allowed_tools`
+    // call when `is_tainted_delegation` is false.
+    cfg.tools.allowed = super::tool_registry::scope_for_delegation(
         is_assistant_tier,
+        is_tainted_delegation,
         cfg.tools.allowed.clone(),
         skill_scoped_allow.as_deref(),
+        delegation_taint_allow.as_deref(),
         registry.as_ref(),
     );
-    if is_assistant_tier {
+    if is_assistant_tier || is_tainted_delegation {
         tracing::info!(
             agent = %name,
+            tainted = is_tainted_delegation,
             tools = ?cfg.tools.allowed,
-            "assistant-tier tool registry scoped to [tools].allow"
+            "assistant-tier/tainted-delegation tool registry scoped"
         );
     }
 

--- a/crates/trusty-agents/src/runtime/subagent_mode.rs
+++ b/crates/trusty-agents/src/runtime/subagent_mode.rs
@@ -364,6 +364,19 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         &default_bundled_config_dir(),
     ));
 
+    // Security fix (multi-hop taint composition, item 1, #4126): the taint
+    // THIS agent stamps on whatever IT spawns next must be the INTERSECTION
+    // of any INBOUND taint it received (`delegation_taint_allow`, parsed
+    // above) with its own NATIVE `[tools].allow` — never the native list
+    // alone. Without this, hop 2 of `assistant -> izzie -> engineer` forwards
+    // izzie's own (potentially wider) posture instead of the narrower of the
+    // two, discarding hop 1's narrowing. See `compose_delegation_taint`.
+    let outbound_delegate_allow: Option<Vec<String>> =
+        super::tool_registry::compose_delegation_taint(
+            cfg.tools.allow.as_deref(),
+            delegation_taint_allow.as_deref(),
+        );
+
     // Build the per-agent tool registry based on agent name (and role, for
     // the assistant-tier gate — see `ASSISTANT_TIER_ROLE`).
     let mut registry = super::tool_registry::build_registry_for_agent(
@@ -373,7 +386,7 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         code_dir.as_deref(),
         skill_registry.clone(),
         tag_skill_registry.clone(),
-        cfg.tools.allow.as_deref(),
+        outbound_delegate_allow.as_deref(),
     );
 
     // #57: If the agent opts into `use_finish_task`, auto-register the

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -143,6 +143,13 @@ pub(super) const ASSISTANT_ALLOWED_DELEGATE_ROLES: &[&str] = &[
 /// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
 /// `assistant_tier_registry_includes_curated_tools`; called during
 /// `run_subagent`.
+///
+/// `delegator_allow` (security fix, delegation-taint issue): the CURRENT
+/// assistant-tier agent's own resolved `[tools].allow` glob patterns —
+/// passed straight through to `build_assistant_tier_registry` so the
+/// `delegate_to_agent` tool THIS agent registers narrows whatever it spawns
+/// to this agent's own tool posture. Ignored (and safe to pass `None`) for
+/// every non-assistant-tier role.
 pub(super) fn build_registry_for_agent(
     name: &str,
     role: &str,
@@ -150,9 +157,10 @@ pub(super) fn build_registry_for_agent(
     code_dir: Option<&std::path::Path>,
     skill_registry: Arc<skills::SkillRegistry>,
     tag_skill_registry: Arc<skills::registry::SkillRegistry>,
+    delegator_allow: Option<&[String]>,
 ) -> Option<ToolRegistry> {
     if role == ASSISTANT_TIER_ROLE {
-        return Some(build_assistant_tier_registry());
+        return Some(build_assistant_tier_registry(delegator_allow));
     }
     // #222: When `code_dir` is set and distinct from `out_dir`, the code-agent
     // and any future tool that writes *generated source files* should root at
@@ -427,7 +435,24 @@ pub(super) fn build_registry_for_agent(
 /// `assistant_tier_registry_includes_curated_tools`,
 /// `assistant_tier_registry_includes_izzie_tools`,
 /// `izzie_allow_list_surfaces_persona_tools_through_scoping`.
-pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
+///
+/// `delegator_allow` (security fix — delegate_to_agent injection-to-RCE
+/// path, see `ASSISTANT_ALLOWED_DELEGATE_ROLES`'s doc comment and
+/// `scope_assistant_allowed_tools`): this agent's own resolved
+/// `[tools].allow` glob patterns. Threaded into the `DelegateToAgentTool`
+/// this function registers via `SubprocessAgentRunner::with_delegation_taint`
+/// so EVERY spawn this assistant-tier agent makes is tagged with its own
+/// tool posture — regardless of the spawned agent's declared role. Without
+/// this, `delegate_to_agent(agent_name="engineer", ...)` handed a fully
+/// unrestricted `claude-code` subprocess to whatever text reached this
+/// agent's turn (including live Gmail/Drive/web content the untrusted-data
+/// envelope in `persona_memory.rs` never covers, because it only wraps
+/// persisted memory-drawer recall — not live tool return values). `None`
+/// (no `[tools].allow` resolved) still tags the spawn with an EMPTY pattern
+/// list rather than skipping tainting — fail-closed, not fail-open: a
+/// mis-configured or absent allow-list denies the child every tool rather
+/// than granting it every tool.
+pub(super) fn build_assistant_tier_registry(delegator_allow: Option<&[String]>) -> ToolRegistry {
     let mut reg = ToolRegistry::new();
     let cwd = std::env::current_dir().unwrap_or_default();
 
@@ -453,8 +478,20 @@ pub(super) fn build_assistant_tier_registry() -> ToolRegistry {
     // and can never diverge.
     let config_dirs = crate::agents::agents_dir_candidates();
     let primary_config_dir = config_dirs.first().cloned();
+    // Security fix (delegate_to_agent injection-to-RCE path): tag every
+    // spawn from this DelegateToAgentTool with this agent's own
+    // `[tools].allow` posture. `run_subagent` (the child process) reads this
+    // back via `TAGENT_DELEGATION_TAINT_ALLOW` and applies it through
+    // `scope_assistant_allowed_tools` REGARDLESS of the spawned agent's own
+    // role/`[tools].allow` — closing the gap where `scope_assistant_allowed_tools`
+    // previously no-op'd for any target whose OWN role wasn't `"assistant"`
+    // (e.g. `engineer`, which declares no `[tools].allow` at all and would
+    // otherwise get its full unrestricted `claude-code` tool surface).
+    let taint_allow: Vec<String> = delegator_allow.map(<[String]>::to_vec).unwrap_or_default();
     let runner: Arc<dyn AgentRunner> = Arc::new(
-        crate::subprocess::SubprocessAgentRunner::new().with_config_dir(primary_config_dir),
+        crate::subprocess::SubprocessAgentRunner::new()
+            .with_config_dir(primary_config_dir)
+            .with_delegation_taint(Some(taint_allow)),
     );
     // #3555 CRITICAL follow-up: role-gate the assistant tier's delegation
     // target to workers + peer assistants ONLY — see
@@ -550,6 +587,107 @@ pub(super) fn scope_assistant_allowed_tools(
         .filter(|n| crate::ctrl::pm_task::match_any_glob(n, patterns))
         .collect();
     Some(kept)
+}
+
+/// Resolve the effective `[tools].allowed` override for a spawned sub-agent,
+/// accounting for a TAINTED delegation (security fix — delegate_to_agent
+/// injection-to-RCE path).
+///
+/// Why: `scope_assistant_allowed_tools` only narrows a spawned agent when
+/// ITS OWN role is the assistant tier — by design, since a coding sub-agent
+/// (`engineer`, `qa-agent`, …) legitimately needs its full tool surface when
+/// spawned normally (by `pm`/`ctrl`, which are trusted). But
+/// `ASSISTANT_ALLOWED_DELEGATE_ROLES` lets an assistant-TIER persona holding
+/// live external-content tools (Gmail/Drive/web) delegate to those SAME
+/// coding sub-agents. Attacker-controlled text reaching that persona's turn
+/// (a fetched email, a scraped page — none of it covered by the
+/// `persona_memory.rs` untrusted-data envelope, which wraps only persisted
+/// memory-drawer recall) could drive `delegate_to_agent(agent_name="engineer",
+/// task="<attacker text>")`, and `engineer` — no `[tools].allow` declared —
+/// got its full unrestricted `claude-code` subprocess with no narrowing at
+/// all. This function is the fix: when `is_tainted` (the spawn was tagged by
+/// `SubprocessAgentRunner::with_delegation_taint`), it forces the same
+/// `scope_assistant_allowed_tools` narrowing using the DELEGATOR's own
+/// `taint_allow` patterns instead of this agent's own posture — "regardless
+/// of the spawned agent's own role", per the fix design (unconditional
+/// tainting of every assistant-tier delegation, not only turns that happened
+/// to touch a live-fetch tool: simpler, and fail-safe against content
+/// fetched in an earlier turn that is still present in history).
+/// What: When `is_tainted` is false, delegates unchanged to
+/// `scope_assistant_allowed_tools(is_assistant_tier, original_allowed,
+/// skill_scoped_allow, registry)` — byte-identical to the pre-fix behavior.
+/// When `is_tainted` is true, ALWAYS applies `taint_allow` against
+/// `registry` (bypassing `scope_assistant_allowed_tools`'s
+/// `existing_allowed.is_some()` early-return — a taint must never be
+/// skippable just because the agent's own TOML also set an exact
+/// `[tools].allowed`), then intersects the result with `original_allowed`
+/// when the agent's own TOML declared one, so a taint only ever narrows,
+/// never widens past an explicit author-set restriction either.
+/// Test: `tainted_delegation_cannot_reach_tool_delegator_lacked`,
+/// `untainted_delegation_is_unaffected`,
+/// `tainted_delegation_intersects_with_existing_allowed`,
+/// `assistant_delegate_to_engineer_path_is_scoped`.
+pub(super) fn scope_for_delegation(
+    is_assistant_tier: bool,
+    is_tainted: bool,
+    original_allowed: Option<Vec<String>>,
+    skill_scoped_allow: Option<&[String]>,
+    taint_allow: Option<&[String]>,
+    registry: Option<&ToolRegistry>,
+) -> Option<Vec<String>> {
+    if !is_tainted {
+        return scope_assistant_allowed_tools(
+            is_assistant_tier,
+            original_allowed,
+            skill_scoped_allow,
+            registry,
+        );
+    }
+    let mut scoped = scope_assistant_allowed_tools(true, None, taint_allow, registry);
+    if let (Some(orig), Some(sc)) = (&original_allowed, &scoped) {
+        let orig_set: std::collections::HashSet<&String> = orig.iter().collect();
+        scoped = Some(
+            sc.iter()
+                .filter(|n| orig_set.contains(n))
+                .cloned()
+                .collect(),
+        );
+    }
+    scoped
+}
+
+/// Parse the `TAGENT_DELEGATION_TAINT_ALLOW` child-process env var (security
+/// fix — delegate_to_agent injection-to-RCE path).
+///
+/// Why: Pulled out of `run_subagent` so the "a malformed/corrupted value
+/// fails CLOSED, not open" invariant is unit-testable without spawning a
+/// real subprocess or mutating process-global env vars from a test — the
+/// same rationale `scope_assistant_allowed_tools` documents for its own
+/// extraction.
+/// What: `None` (env var unset — the overwhelming majority of spawns, which
+/// were never delegated by an assistant-tier persona) returns `None`
+/// (untainted, byte-identical to pre-fix behavior). `Some(raw)` that parses
+/// as a JSON `Vec<String>` returns `Some(patterns)`. `Some(raw)` that fails
+/// to parse returns `Some(vec![])` — an empty, deny-all taint — rather than
+/// falling back to `None` (untainted): a truncated/corrupted env var must
+/// only ever narrow further, never silently disable the taint.
+/// Test: `parse_delegation_taint_env_absent_is_untainted`,
+/// `parse_delegation_taint_env_valid_json_is_tainted`,
+/// `parse_delegation_taint_env_malformed_fails_closed`.
+pub(super) fn parse_delegation_taint_env(raw: Option<String>) -> Option<Vec<String>> {
+    let raw = raw?;
+    match serde_json::from_str::<Vec<String>>(&raw) {
+        Ok(patterns) => Some(patterns),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                raw = %raw,
+                "TAGENT_DELEGATION_TAINT_ALLOW present but unparseable; \
+                 treating as an empty (deny-all) taint"
+            );
+            Some(Vec::new())
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -117,7 +117,16 @@ pub(super) const ASSISTANT_TIER_ROLE: &str = "assistant";
 /// `delegate_assistant_role_gate_allows_worker_role`,
 /// `delegate_assistant_role_gate_allows_peer_assistant_role`
 /// (`src/tools/delegate.rs`).
-pub(super) const ASSISTANT_ALLOWED_DELEGATE_ROLES: &[&str] = &[
+///
+/// `pub(crate)` (security fix, third dispatch path, #4126): `ctrl::pm_task::
+/// dispatch::history::run_pm_task_with_history` builds its OWN
+/// `DelegateToAgentTool` (it does not go through `build_assistant_tier_registry`
+/// below) and needed the SAME role allowlist for the SAME reason — the
+/// caller's config (`ctrl.toml`, `role = "assistant"` per #3812) makes it
+/// eligible for the assistant-tier treatment even though it lives in a
+/// different module tree. Reusing this constant (rather than a second
+/// hand-copied list) is the single-source-of-truth choice.
+pub(crate) const ASSISTANT_ALLOWED_DELEGATE_ROLES: &[&str] = &[
     "engineer",          // engineer.toml, code-agent.toml, python-engineer.toml, …
     "qa",                // qa-agent.toml
     "researcher",        // research-agent.toml
@@ -562,7 +571,21 @@ pub(super) fn build_assistant_tier_registry(delegator_allow: Option<&[String]>) 
 /// is untouched.
 /// Test: `scope_assistant_allowed_tools_filters_by_glob`,
 /// `scope_assistant_allowed_tools_noop_for_non_assistant`,
-/// `scope_assistant_allowed_tools_noop_when_allowed_already_set`.
+/// `scope_assistant_allowed_tools_noop_when_allowed_already_set`,
+/// `scope_assistant_allowed_tools_fails_closed_when_allow_absent`,
+/// `scope_assistant_allowed_tools_fails_closed_when_registry_absent`.
+///
+/// Security fix (item 2, fail-closed on absent taint/allow, #4126): when
+/// `is_assistant_tier` is true and no explicit `[tools].allowed` was already
+/// set, reaching this point with NO resolvable `allow` glob patterns (or no
+/// `registry` to resolve them against) used to fall through to
+/// `existing_allowed` — which is `None` here (the `existing_allowed.is_some()`
+/// case already returned above) — i.e. "every registered tool is callable."
+/// That is the WRONG default for a tier whose entire security model is a
+/// curated, narrowed surface: a misconfigured persona TOML (missing
+/// `[tools].allow`) or a registry that failed to build must never silently
+/// grant full access. `scope_for_delegation`'s `!is_tainted` branch is the
+/// caller that exercises this in practice — see its own doc comment.
 pub(super) fn scope_assistant_allowed_tools(
     is_assistant_tier: bool,
     existing_allowed: Option<Vec<String>>,
@@ -573,7 +596,11 @@ pub(super) fn scope_assistant_allowed_tools(
         return existing_allowed;
     }
     let (Some(patterns), Some(reg)) = (allow, registry) else {
-        return existing_allowed;
+        // Fail closed: an assistant-tier agent with nothing to scope against
+        // gets NO tools, never every tool. A persona that legitimately wants
+        // tools declares `[tools].allow` and takes the `Some(patterns)`
+        // branch below.
+        return Some(Vec::new());
     };
     let kept: Vec<String> = reg
         .schemas()
@@ -626,7 +653,10 @@ pub(super) fn scope_assistant_allowed_tools(
 /// Test: `tainted_delegation_cannot_reach_tool_delegator_lacked`,
 /// `untainted_delegation_is_unaffected`,
 /// `tainted_delegation_intersects_with_existing_allowed`,
-/// `assistant_delegate_to_engineer_path_is_scoped`.
+/// `assistant_delegate_to_engineer_path_is_scoped`,
+/// `scope_for_delegation_untainted_assistant_tier_fails_closed_without_allow`
+/// (item 2 fail-closed regression), `multi_hop_delegation_narrows_at_every_hop`
+/// (item 1 multi-hop regression).
 pub(super) fn scope_for_delegation(
     is_assistant_tier: bool,
     is_tainted: bool,
@@ -674,7 +704,12 @@ pub(super) fn scope_for_delegation(
 /// Test: `parse_delegation_taint_env_absent_is_untainted`,
 /// `parse_delegation_taint_env_valid_json_is_tainted`,
 /// `parse_delegation_taint_env_malformed_fails_closed`.
-pub(super) fn parse_delegation_taint_env(raw: Option<String>) -> Option<Vec<String>> {
+///
+/// `pub(crate)` (security fix, #4126): `ctrl::pm_task::dispatch::persona` and
+/// `ctrl::pm_task::dispatch::history` both defensively read this same env var
+/// (see `compose_delegation_taint`'s doc comment for why) — a single parser
+/// with one fail-closed behavior, not a second hand-copied one.
+pub(crate) fn parse_delegation_taint_env(raw: Option<String>) -> Option<Vec<String>> {
     let raw = raw?;
     match serde_json::from_str::<Vec<String>>(&raw) {
         Ok(patterns) => Some(patterns),
@@ -686,6 +721,60 @@ pub(super) fn parse_delegation_taint_env(raw: Option<String>) -> Option<Vec<Stri
                  treating as an empty (deny-all) taint"
             );
             Some(Vec::new())
+        }
+    }
+}
+
+/// Compose the OUTBOUND delegation taint an assistant-tier agent tags its
+/// OWN `delegate_to_agent` spawns with, given any INBOUND taint this agent
+/// itself received (security fix — item 1, multi-hop taint composition,
+/// #4126).
+///
+/// Why: The delegation-taint fix's stated invariant is "a taint only ever
+/// narrows, never widens." That broke at hop 2: `run_subagent` passed
+/// `cfg.tools.allow.as_deref()` (THIS agent's own native `[tools].allow`)
+/// straight into `build_registry_for_agent`'s `delegator_allow` parameter —
+/// which becomes the taint `build_assistant_tier_registry` stamps on
+/// whatever THIS agent spawns next — completely ignoring any INBOUND taint
+/// it was itself spawned under. Concretely: `assistant` (native allow `A`)
+/// delegates to `izzie` (native allow `B`, tainted with `A` via
+/// `TAGENT_DELEGATION_TAINT_ALLOW`); when izzie then delegates to `engineer`,
+/// the pre-fix code tagged that spawn with `B` alone — potentially WIDER
+/// than `A` — silently discarding hop 1's narrowing. `run_pm_task_with_persona`
+/// had the identical shape (`patterns.clone()`, ignoring any inbound taint).
+/// What: `inbound_taint = None` (this agent was not itself spawned via a
+/// tainted delegation — every hop-0/top-level dispatch, and still the
+/// overwhelming common case even at hop 2+) returns `native` unchanged:
+/// byte-identical to pre-fix behavior. `inbound_taint = Some(patterns)`
+/// returns the INTERSECTION of `inbound_taint` and `native`, by pattern
+/// string. `native == None` (this agent declares no explicit `[tools].allow`
+/// of its own) is treated as "impose no FURTHER narrowing beyond what was
+/// already received" — the result is `inbound_taint` unchanged — never wider
+/// than what this agent itself was handed, and never wider than its own
+/// declared posture either.
+/// Test: `compose_delegation_taint_untainted_forwards_native_unchanged`,
+/// `compose_delegation_taint_intersects_native_with_inbound`,
+/// `compose_delegation_taint_no_native_forwards_inbound_unchanged`,
+/// `multi_hop_delegation_narrows_at_every_hop`.
+pub(crate) fn compose_delegation_taint(
+    native: Option<&[String]>,
+    inbound_taint: Option<&[String]>,
+) -> Option<Vec<String>> {
+    let Some(inbound) = inbound_taint else {
+        return native.map(<[String]>::to_vec);
+    };
+    match native {
+        None => Some(inbound.to_vec()),
+        Some(native_patterns) => {
+            let native_set: std::collections::HashSet<&str> =
+                native_patterns.iter().map(String::as_str).collect();
+            Some(
+                inbound
+                    .iter()
+                    .filter(|p| native_set.contains(p.as_str()))
+                    .cloned()
+                    .collect(),
+            )
         }
     }
 }

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -71,6 +71,7 @@ fn research_agent_registry_has_web_tools() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("research-agent builds a registry");
     assert!(
@@ -93,6 +94,7 @@ fn research_agent_registry_has_memory_tools() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("memory_recall"), "memory_recall missing");
@@ -110,6 +112,7 @@ fn research_agent_registry_has_readonly_fs_tools() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("read_file"), "read_file missing");
@@ -128,6 +131,7 @@ fn plan_agent_registry_has_memory_tools() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("plan-agent builds a registry");
     assert!(reg.contains("memory_recall"), "memory_recall missing");
@@ -156,6 +160,7 @@ fn all_known_agents_get_skill_tools() {
             None,
             empty_skill_registry(),
             empty_tag_registry(),
+            None,
         )
         .unwrap_or_else(|| panic!("{agent} should get a registry"));
         assert!(reg.contains("load_skill"), "{agent}: load_skill missing");
@@ -174,6 +179,7 @@ fn plan_agent_registry_has_write_file_tool() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("plan-agent builds a registry");
     assert!(
@@ -193,6 +199,7 @@ fn docs_agent_registry_has_write_and_read_tools() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("docs-agent builds a registry");
     assert!(reg.contains("write_file"), "write_file missing");
@@ -231,6 +238,7 @@ async fn list_skills_uses_tag_registry_when_wired() {
         None,
         empty_skill_registry(),
         tag_reg,
+        None,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("list_skills"));
@@ -265,6 +273,7 @@ async fn list_skills_falls_back_to_legacy_when_tag_registry_empty() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("list_skills"));
@@ -337,6 +346,7 @@ fn assistant_tier_registry_excludes_skill_catalog_tools() {
         None,
         empty_skill_registry(),
         tag_reg,
+        None,
     )
     .expect("assistant-tier agent builds a registry");
 
@@ -363,6 +373,7 @@ fn assistant_tier_registry_includes_curated_tools() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("assistant-tier agent builds a registry");
     assert!(
@@ -392,6 +403,7 @@ fn assistant_tier_registry_includes_izzie_tools() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("assistant-tier agent builds a registry");
     for expected in ["get_weather", "get_train_schedule", "get_train_alerts"] {
@@ -411,7 +423,7 @@ fn izzie_allow_list_surfaces_persona_tools_through_scoping() {
     // it — proving the fix at the exact seam that dropped it (the allow list
     // was correct; the tool simply was not in the registry to survive the
     // intersection).
-    let reg = build_assistant_tier_registry();
+    let reg = build_assistant_tier_registry(None);
     let allow = vec![
         "delegate_to_agent".to_string(),
         "web_search".to_string(),
@@ -436,7 +448,7 @@ fn non_opted_in_persona_does_not_get_izzie_tools() {
     // allowed_tools` still gates by the persona's own `[tools].allow`. A
     // persona allowing only `web_search` gets only `web_search`, never
     // `get_weather`.
-    let reg = build_assistant_tier_registry();
+    let reg = build_assistant_tier_registry(None);
     let allow = vec!["web_search".to_string()];
     let kept =
         scope_assistant_allowed_tools(true, None, Some(&allow), Some(&reg)).unwrap_or_default();
@@ -460,6 +472,7 @@ fn role_takes_precedence_over_name_for_assistant_tier() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("builds a registry");
     assert!(
@@ -481,6 +494,7 @@ fn scope_assistant_allowed_tools_filters_by_glob() {
         None,
         empty_skill_registry(),
         empty_tag_registry(),
+        None,
     )
     .expect("assistant-tier agent builds a registry");
 
@@ -516,6 +530,187 @@ fn scope_assistant_allowed_tools_noop_when_allowed_already_set() {
     assert_eq!(kept, existing);
 }
 
+// --- `scope_for_delegation` (security fix: delegate_to_agent injection-to-RCE path) ---
+//
+// Chain: an assistant-tier persona holding live external-content tools
+// (get_gmail_message_content, web_search, …) plus `delegate_to_agent` could
+// hand attacker-controlled text to `delegate_to_agent(agent_name="engineer",
+// task=…)`. `engineer` declares no `[tools].allow`, so its spawned
+// `claude-code` subprocess got the FULL unrestricted registry — the
+// `scope_assistant_allowed_tools` narrowing only ever fired when the SPAWNED
+// agent's own role was "assistant". `scope_for_delegation` is the fix.
+
+#[test]
+fn tainted_delegation_cannot_reach_tool_delegator_lacked() {
+    // `local-ops-agent`'s registry carries a genuinely permissive `shell_exec`
+    // tool (`tools::shell::ShellExecTool` — the real, unrestricted local-ops
+    // command runner, distinct from qa-agent's narrowly-scoped `pytest_exec`)
+    // plus read-only file tools. None of these match a curated assistant
+    // persona's typical `[tools].allow` surface.
+    let reg = build_registry_for_agent(
+        "local-ops-agent",
+        "engineer",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+    )
+    .expect("local-ops-agent builds a registry");
+    assert!(
+        reg.contains("shell_exec"),
+        "fixture assumption: local-ops-agent must register the real shell_exec tool"
+    );
+
+    // The delegator's (assistant persona's) own posture — none of these
+    // patterns match shell_exec/read_file/list_dir/grep_files.
+    let taint_allow = vec!["delegate_to_agent".to_string(), "web_search".to_string()];
+
+    let kept = scope_for_delegation(
+        /* is_assistant_tier */ false, // engineer's OWN role, unaffected by taint
+        /* is_tainted */ true,
+        /* original_allowed */ None,
+        /* skill_scoped_allow */ None,
+        /* taint_allow */ Some(&taint_allow),
+        Some(&reg),
+    )
+    .expect("a tainted spawn must always be scoped, never left unrestricted");
+
+    assert!(
+        !kept.iter().any(|n| n == "shell_exec"),
+        "tainted engineer must not reach shell_exec — the delegator never had it; kept={kept:?}"
+    );
+    assert!(
+        !kept
+            .iter()
+            .any(|n| n == "read_file" || n == "list_dir" || n == "grep_files"),
+        "tainted engineer must not reach filesystem tools the delegator lacked; kept={kept:?}"
+    );
+}
+
+#[test]
+fn untainted_delegation_is_unaffected() {
+    // A normal (non-delegated, or delegated by a trusted pm/ctrl caller that
+    // never taints) engineer spawn must be BYTE-IDENTICAL to pre-fix
+    // behavior: fully unrestricted (`None` = "every registered tool is
+    // callable" per `ToolsConfig::allowed`'s doc comment).
+    let reg = build_registry_for_agent(
+        "local-ops-agent",
+        "engineer",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+    )
+    .expect("local-ops-agent builds a registry");
+
+    let kept = scope_for_delegation(false, false, None, None, None, Some(&reg));
+    assert_eq!(
+        kept, None,
+        "untainted, non-assistant-tier spawns must remain unrestricted"
+    );
+}
+
+#[test]
+fn tainted_delegation_intersects_with_existing_allowed() {
+    // A taint must only ever narrow, never widen past an explicit
+    // `[tools].allowed` (exact list) the spawned agent's own TOML already
+    // declared.
+    let reg = build_registry_for_agent(
+        "docs-agent",
+        "documentation",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+    )
+    .expect("docs-agent builds a registry");
+    assert!(reg.contains("write_file"));
+    assert!(reg.contains("read_file"));
+
+    let original_allowed = Some(vec!["write_file".to_string(), "read_file".to_string()]);
+    let taint_allow = vec!["write_file".to_string()];
+
+    let kept = scope_for_delegation(
+        false,
+        true,
+        original_allowed,
+        None,
+        Some(&taint_allow),
+        Some(&reg),
+    )
+    .expect("tainted spawn must be scoped");
+
+    assert_eq!(
+        kept,
+        vec!["write_file".to_string()],
+        "result must be the INTERSECTION of the taint and the agent's own allowlist, \
+         not either side alone"
+    );
+}
+
+#[test]
+fn assistant_delegate_to_engineer_path_is_scoped() {
+    // The SPECIFIC vulnerable path: `assistant` (role "assistant", holding
+    // live Gmail/Drive/web tools + `delegate_to_agent`) delegates to a
+    // worker whose role is NOT "assistant" and which declares no
+    // `[tools].allow` at all — exactly `engineer.toml`'s shape. Before this
+    // fix, `is_assistant_tier` (keyed on the SPAWNED agent's role) was
+    // `false` here, so `scope_assistant_allowed_tools` no-op'd and the spawn
+    // kept its full registry — proved below via the `is_tainted=false`
+    // baseline, which is the exact pre-fix call shape `run_subagent` used to
+    // make unconditionally.
+    let reg = build_registry_for_agent(
+        "local-ops-agent",
+        "engineer",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+    )
+    .expect("engineer-shaped registry builds");
+    assert!(reg.contains("shell_exec"));
+
+    // Pre-fix behavior (still reachable today for a genuinely untainted
+    // spawn, e.g. pm/ctrl delegating directly — NOT a regression, just the
+    // baseline this test contrasts against): unrestricted.
+    let pre_fix_equivalent = scope_for_delegation(false, false, None, None, None, Some(&reg));
+    assert_eq!(
+        pre_fix_equivalent, None,
+        "sanity: an untainted spawn is unrestricted, matching pre-fix behavior for \
+         legitimate (non-assistant-originated) delegation"
+    );
+
+    // A representative slice of `assistant/agent.toml`'s actual `[tools].allow`
+    // surface (delegate_to_agent, git_*, web_search, gmail — no shell, no
+    // filesystem writes).
+    let assistant_allow = vec![
+        "delegate_to_agent".to_string(),
+        "git_log".to_string(),
+        "git_status".to_string(),
+        "web_search".to_string(),
+        "get_gmail_message_content".to_string(),
+    ];
+    let post_fix =
+        scope_for_delegation(false, true, None, None, Some(&assistant_allow), Some(&reg))
+            .expect("tainted delegation from an assistant-tier persona must always be scoped");
+
+    assert!(
+        !post_fix.iter().any(|n| n == "shell_exec"),
+        "the delegate_to_agent(engineer) injection-to-RCE path must be closed: \
+         shell_exec must not survive a tainted assistant-tier delegation; kept={post_fix:?}"
+    );
+    assert!(
+        post_fix.is_empty(),
+        "local-ops-agent's tool surface (shell_exec, read_file, list_dir, grep_files, \
+         load_skill, list_skills) has no overlap with the assistant's own allow-list, so \
+         the tainted spawn should be left with NO callable tools; kept={post_fix:?}"
+    );
+}
+
 /// #3555 CRITICAL follow-up (code-critic) — live wiring check, `#[ignore]`d
 /// by default.
 ///
@@ -523,7 +718,7 @@ fn scope_assistant_allowed_tools_noop_when_allowed_already_set() {
 /// `src/tools/delegate.rs` (`delegate_assistant_role_gate_rejects_*`), using
 /// a hand-built `DelegateToAgentTool` + tempdir so they're fast and
 /// environment-independent. This test instead exercises the REAL production
-/// wiring — `build_assistant_tier_registry()` unmodified, resolving against
+/// wiring — `build_assistant_tier_registry(None)` unmodified, resolving against
 /// whatever roster is ACTUALLY deployed at `$HOME/.trusty-agents/agents/` on
 /// the machine running it (via `agents::bundled::ensure_bundled_agents_deployed`,
 /// which every `tagent` invocation runs at startup) — as an end-to-end proof
@@ -542,7 +737,7 @@ fn scope_assistant_allowed_tools_noop_when_allowed_already_set() {
 #[tokio::test]
 #[ignore]
 async fn live_assistant_registry_rejects_pm_role() {
-    let reg = build_assistant_tier_registry();
+    let reg = build_assistant_tier_registry(None);
     assert!(
         reg.contains("delegate_to_agent"),
         "sanity: delegate_to_agent must be registered"
@@ -643,7 +838,7 @@ fn deployed_assistant_config_survives_scoping_with_delegate_to_agent() {
         cfg.tools.allow
     );
 
-    let reg = build_assistant_tier_registry();
+    let reg = build_assistant_tier_registry(None);
     let kept = scope_assistant_allowed_tools(
         true,
         cfg.tools.allowed.clone(),
@@ -656,5 +851,52 @@ fn deployed_assistant_config_survives_scoping_with_delegate_to_agent() {
         kept.iter().any(|n| n == "delegate_to_agent"),
         "delegate_to_agent must survive the refresh -> deployed-config -> \
          registry-scoping chain, got: {kept:?}"
+    );
+}
+
+// --- `parse_delegation_taint_env` (security fix: delegate_to_agent
+// injection-to-RCE path) ---
+
+#[test]
+fn parse_delegation_taint_env_absent_is_untainted() {
+    // The overwhelming majority of spawns: no env var at all, e.g. every
+    // pm/ctrl-initiated coding sub-agent. Must be byte-identical to pre-fix
+    // behavior — `None` in, `None` out.
+    assert_eq!(parse_delegation_taint_env(None), None);
+}
+
+#[test]
+fn parse_delegation_taint_env_valid_json_is_tainted() {
+    let raw = r#"["delegate_to_agent","web_search"]"#.to_string();
+    let parsed = parse_delegation_taint_env(Some(raw));
+    assert_eq!(
+        parsed,
+        Some(vec![
+            "delegate_to_agent".to_string(),
+            "web_search".to_string()
+        ])
+    );
+}
+
+#[test]
+fn parse_delegation_taint_env_empty_array_is_tainted_deny_all() {
+    // An explicit empty allow-list (e.g. an assistant persona with no
+    // `[tools].allow` resolved at all — should not happen in practice, but
+    // must fail closed if it does) taints with a deny-all set, not `None`.
+    let parsed = parse_delegation_taint_env(Some("[]".to_string()));
+    assert_eq!(parsed, Some(Vec::new()));
+}
+
+#[test]
+fn parse_delegation_taint_env_malformed_fails_closed() {
+    // A corrupted/truncated env var (process env tampering, a future
+    // encoding bug, …) must NEVER silently disable the taint — that would
+    // reopen the exact hole this fix closes. It must fail CLOSED: an empty
+    // (deny-all), not `None` (untainted/unrestricted).
+    let parsed = parse_delegation_taint_env(Some("not valid json".to_string()));
+    assert_eq!(
+        parsed,
+        Some(Vec::new()),
+        "a malformed taint env var must fail closed (deny-all), never silently untainted"
     );
 }

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -530,6 +530,208 @@ fn scope_assistant_allowed_tools_noop_when_allowed_already_set() {
     assert_eq!(kept, existing);
 }
 
+// --- item 2 regression: fail-closed on absent taint/allow signal (#4126) ---
+
+#[test]
+fn scope_assistant_allowed_tools_fails_closed_when_allow_absent() {
+    // The bug: an assistant-tier agent with no `[tools].allow` resolved at
+    // all (misconfigured persona TOML) and no pre-existing `[tools].allowed`
+    // used to fall through to `None` here — "every registered tool is
+    // callable" — the exact opposite of what the assistant tier's security
+    // model requires. Must be `Some(vec![])` (deny-all), never `None`.
+    let reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+    )
+    .expect("assistant-tier agent builds a registry");
+
+    let kept = scope_assistant_allowed_tools(true, None, None, Some(&reg));
+    assert_eq!(
+        kept,
+        Some(Vec::new()),
+        "an assistant-tier agent with no resolvable allow patterns must be denied \
+         every tool, never left unrestricted"
+    );
+}
+
+#[test]
+fn scope_assistant_allowed_tools_fails_closed_when_registry_absent() {
+    // Same fail-closed requirement when `registry` itself is unavailable
+    // (e.g. the registry failed to build) — still must not fall through to
+    // unrestricted `None`.
+    let allow = vec!["web_search".to_string()];
+    let kept = scope_assistant_allowed_tools(true, None, Some(&allow), None);
+    assert_eq!(kept, Some(Vec::new()));
+}
+
+#[test]
+fn scope_for_delegation_untainted_assistant_tier_fails_closed_without_allow() {
+    // End-to-end of item 2 through the actual caller, `scope_for_delegation`,
+    // in its `!is_tainted` branch: an assistant-tier agent invoked directly
+    // (not via a tainted delegation) with no resolvable `[tools].allow` must
+    // still be denied every tool, not handed an unrestricted registry.
+    let reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+    )
+    .expect("assistant-tier agent builds a registry");
+
+    let kept = scope_for_delegation(
+        /* is_assistant_tier */ true,
+        /* is_tainted */ false,
+        /* original_allowed */ None,
+        /* skill_scoped_allow */ None,
+        /* taint_allow */ None,
+        Some(&reg),
+    );
+    assert_eq!(
+        kept,
+        Some(Vec::new()),
+        "an untainted assistant-tier agent with no declared posture must never end up \
+         unrestricted"
+    );
+}
+
+// --- item 1 regression: multi-hop taint composition (#4126) ---
+//
+// `compose_delegation_taint` is what `run_subagent` (`subagent_mode.rs`) and
+// `run_pm_task_with_persona` (`persona.rs`) now call instead of forwarding
+// their own native `[tools].allow` verbatim as the outbound taint for
+// whatever they spawn next.
+
+#[test]
+fn compose_delegation_taint_untainted_forwards_native_unchanged() {
+    // Hop 0 (no inbound taint): this agent forwards its OWN posture,
+    // byte-identical to the pre-fix `cfg.tools.allow.as_deref()` call.
+    let native = vec!["web_search".to_string(), "delegate_to_agent".to_string()];
+    let composed = compose_delegation_taint(Some(&native), None);
+    assert_eq!(composed, Some(native));
+}
+
+#[test]
+fn compose_delegation_taint_intersects_native_with_inbound() {
+    // Hop 2: an inbound taint narrower than (or disjoint from) this agent's
+    // own native posture must NEVER widen back out to the native list.
+    let native = vec![
+        "delegate_to_agent".to_string(),
+        "web_search".to_string(),
+        "get_weather".to_string(),
+    ];
+    let inbound = vec!["delegate_to_agent".to_string(), "web_search".to_string()];
+    let composed = compose_delegation_taint(Some(&native), Some(&inbound));
+    assert_eq!(
+        composed,
+        Some(vec![
+            "delegate_to_agent".to_string(),
+            "web_search".to_string()
+        ]),
+        "get_weather is native-only (not in the inbound taint) and must be dropped"
+    );
+}
+
+#[test]
+fn compose_delegation_taint_no_native_forwards_inbound_unchanged() {
+    // This agent declares no `[tools].allow` of its own — it cannot impose
+    // any FURTHER narrowing, so the inbound taint passes through unchanged
+    // (never widened, since there is nothing native to widen it with).
+    let inbound = vec!["delegate_to_agent".to_string()];
+    let composed = compose_delegation_taint(None, Some(&inbound));
+    assert_eq!(composed, Some(inbound));
+}
+
+#[test]
+fn multi_hop_delegation_narrows_at_every_hop() {
+    // The concrete scenario named in the fix: `assistant -> izzie ->
+    // engineer`. `assistant`'s own posture (A) is broader than `izzie`'s own
+    // posture (B) in one dimension (A grants get_gmail_message_content,
+    // which izzie does not have) and narrower in another (izzie grants
+    // get_weather, which assistant does not have) — proving the hop-2 taint
+    // is the TRUE intersection, not either side alone.
+    let assistant_allow = vec![
+        "delegate_to_agent".to_string(),
+        "web_search".to_string(),
+        "get_gmail_message_content".to_string(),
+    ];
+
+    // Hop 1: assistant -> izzie. No inbound taint at hop 0, so izzie is
+    // tainted with assistant's own posture verbatim.
+    let hop1_taint =
+        compose_delegation_taint(Some(&assistant_allow), None).expect("hop 1 must produce a taint");
+    assert_eq!(hop1_taint, assistant_allow);
+
+    // Hop 2: izzie -> engineer. Izzie's OWN native posture (B) includes
+    // get_weather (not in A) and omits get_gmail_message_content (which IS
+    // in A) — the bug this closes forwarded B verbatim, ignoring hop 1's
+    // taint (A) entirely.
+    let izzie_allow = vec![
+        "delegate_to_agent".to_string(),
+        "web_search".to_string(),
+        "get_weather".to_string(),
+    ];
+    let hop2_taint = compose_delegation_taint(Some(&izzie_allow), Some(&hop1_taint))
+        .expect("hop 2 must produce a taint");
+
+    assert!(
+        hop2_taint.iter().any(|p| p == "delegate_to_agent"),
+        "delegate_to_agent is in both A and B and must survive: {hop2_taint:?}"
+    );
+    assert!(
+        hop2_taint.iter().any(|p| p == "web_search"),
+        "web_search is in both A and B and must survive: {hop2_taint:?}"
+    );
+    assert!(
+        !hop2_taint.iter().any(|p| p == "get_weather"),
+        "get_weather is izzie-only (not in assistant's forwarded taint) and must be \
+         dropped, not forwarded to engineer: {hop2_taint:?}"
+    );
+    assert!(
+        !hop2_taint.iter().any(|p| p == "get_gmail_message_content"),
+        "get_gmail_message_content is assistant-only (izzie's own posture never \
+         granted it) and must be dropped: {hop2_taint:?}"
+    );
+
+    // Finally, prove the composed hop-2 taint actually narrows `engineer`'s
+    // real registry the same way `scope_for_delegation` would when
+    // `run_subagent` applies it: engineer's shell_exec/read_file surface has
+    // no overlap with either persona's tool posture, so it must end up with
+    // zero callable tools.
+    let engineer_reg = build_registry_for_agent(
+        "local-ops-agent",
+        "engineer",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+    )
+    .expect("engineer-shaped registry builds");
+    assert!(engineer_reg.contains("shell_exec"));
+
+    let engineer_scoped = scope_for_delegation(
+        false,
+        true,
+        None,
+        None,
+        Some(&hop2_taint),
+        Some(&engineer_reg),
+    )
+    .expect("a tainted engineer spawn must always be scoped");
+    assert!(
+        !engineer_scoped.iter().any(|n| n == "shell_exec"),
+        "engineer must not reach shell_exec via the narrowed hop-2 taint: {engineer_scoped:?}"
+    );
+}
+
 // --- `scope_for_delegation` (security fix: delegate_to_agent injection-to-RCE path) ---
 //
 // Chain: an assistant-tier persona holding live external-content tools

--- a/crates/trusty-agents/src/subprocess/mod.rs
+++ b/crates/trusty-agents/src/subprocess/mod.rs
@@ -63,6 +63,16 @@ pub struct SubprocessAgentRunner {
     /// search, edit) operate against the project source files rather than the
     /// artifacts directory.
     project_dir: Option<PathBuf>,
+    /// Security fix (delegate_to_agent injection-to-RCE path): glob patterns
+    /// forwarded to the child as `TAGENT_DELEGATION_TAINT_ALLOW` (JSON array).
+    /// `Some(patterns)` — including `Some(vec![])` — marks every spawn this
+    /// runner performs as a TAINTED delegation: the child's `run_subagent`
+    /// applies `patterns` via `scope_assistant_allowed_tools` regardless of
+    /// the child's own declared role or `[tools].allow`, narrowing it to
+    /// (at most) the delegator's own tool posture. `None` (every caller
+    /// except `build_assistant_tier_registry`) is byte-identical to before
+    /// this field existed. See `with_delegation_taint`.
+    delegation_taint_allow: Option<Vec<String>>,
 }
 
 impl SubprocessAgentRunner {
@@ -73,6 +83,7 @@ impl SubprocessAgentRunner {
             memory: None,
             config_dir: None,
             project_dir: None,
+            delegation_taint_allow: None,
         }
     }
 
@@ -129,6 +140,39 @@ impl SubprocessAgentRunner {
         self
     }
 
+    /// Mark every spawn this runner performs as a TAINTED delegation
+    /// (security fix — delegate_to_agent injection-to-RCE path).
+    ///
+    /// Why: `scope_assistant_allowed_tools` only ever narrowed a spawned
+    /// child's tool registry when the CHILD's own role was `"assistant"`
+    /// (see `runtime::tool_registry::scope_assistant_allowed_tools`). An
+    /// assistant-tier persona holding live external-content tools
+    /// (`get_gmail_message_content`, `web_search`, …) plus `delegate_to_agent`
+    /// could hand attacker-controlled task text to `delegate_to_agent(
+    /// agent_name="engineer", ...)` — `engineer` declares no `[tools].allow`
+    /// at all, so the spawned `claude-code` subprocess got its full
+    /// unrestricted tool surface (shell, file write) with no narrowing
+    /// whatsoever. Calling this on the runner backing an assistant-tier
+    /// `DelegateToAgentTool` closes that: every spawn is tagged with the
+    /// delegator's own allow patterns regardless of the target's role.
+    /// What: Stores `patterns`; forwarded to the child as
+    /// `TAGENT_DELEGATION_TAINT_ALLOW` (JSON array) by `spawn_and_run_inner`.
+    /// `run_subagent` reads it back and applies it via
+    /// `scope_assistant_allowed_tools(true, ..., patterns, ...)`
+    /// unconditionally — i.e. EVERY assistant-tier delegation is tainted,
+    /// not only ones whose turn happened to touch a live-fetch tool (the
+    /// simpler, fail-safe posture: per-turn tracking would still miss
+    /// content fetched in an earlier turn and still present in history).
+    /// `None` (every caller except `build_assistant_tier_registry`) leaves
+    /// behavior byte-identical to before this field existed.
+    /// Test: `delegation_taint_allow_env_set_when_configured`,
+    /// `delegation_taint_allow_env_absent_by_default` (`subprocess::tests`);
+    /// `scope_assistant_allowed_tools_*` (`tool_registry_tests`).
+    pub fn with_delegation_taint(mut self, patterns: Option<Vec<String>>) -> Self {
+        self.delegation_taint_allow = patterns;
+        self
+    }
+
     /// Builder-style constructor that attaches a memory graph for auto-capture.
     ///
     /// Why: Wiring memory at construction keeps the runner API otherwise
@@ -178,6 +222,7 @@ impl AgentRunner for SubprocessAgentRunner {
                 &[],
                 config_dir,
                 Some(ctx),
+                self.delegation_taint_allow.as_deref(),
             )
             .await?
         } else {
@@ -193,6 +238,7 @@ impl AgentRunner for SubprocessAgentRunner {
                 ctx: Some(ctx),
                 config_dir: None,
                 project_dir: self.project_dir.as_deref(),
+                delegation_taint_allow: self.delegation_taint_allow.as_deref(),
             })
             .await?
         };
@@ -219,6 +265,7 @@ impl AgentRunner for SubprocessAgentRunner {
                 history,
                 config_dir,
                 Some(ctx),
+                self.delegation_taint_allow.as_deref(),
             )
             .await?
         } else {
@@ -231,6 +278,7 @@ impl AgentRunner for SubprocessAgentRunner {
                 ctx: Some(ctx),
                 config_dir: None,
                 project_dir: self.project_dir.as_deref(),
+                delegation_taint_allow: self.delegation_taint_allow.as_deref(),
             })
             .await?
         };

--- a/crates/trusty-agents/src/subprocess/mod.rs
+++ b/crates/trusty-agents/src/subprocess/mod.rs
@@ -166,8 +166,11 @@ impl SubprocessAgentRunner {
     /// `None` (every caller except `build_assistant_tier_registry`) leaves
     /// behavior byte-identical to before this field existed.
     /// Test: `delegation_taint_allow_env_set_when_configured`,
-    /// `delegation_taint_allow_env_absent_by_default` (`subprocess::tests`);
-    /// `scope_assistant_allowed_tools_*` (`tool_registry_tests`).
+    /// `delegation_taint_allow_env_absent_by_default`,
+    /// `delegation_taint_allow_env_empty_vec_still_sets_deny_all`
+    /// (`subprocess::tests`, exercising `spawn::apply_delegation_taint_env`
+    /// directly against a real `Command`); `scope_assistant_allowed_tools_*`
+    /// (`tool_registry_tests`).
     pub fn with_delegation_taint(mut self, patterns: Option<Vec<String>>) -> Self {
         self.delegation_taint_allow = patterns;
         self

--- a/crates/trusty-agents/src/subprocess/spawn.rs
+++ b/crates/trusty-agents/src/subprocess/spawn.rs
@@ -98,6 +98,7 @@ pub async fn spawn_subagent_and_run_with_full_env_ctx(
         ctx: Some(ctx),
         config_dir: None,
         project_dir: None,
+        delegation_taint_allow: None,
     })
     .await
 }
@@ -129,6 +130,13 @@ pub(super) struct SpawnConfig<'a> {
     /// Also used as the child's `current_dir` when `ctx.working_dir` is None
     /// so agents see the source tree rather than the artifacts directory.
     pub(super) project_dir: Option<&'a std::path::Path>,
+    /// Security fix (delegate_to_agent injection-to-RCE path): when
+    /// `Some(patterns)`, forwarded to the child as JSON in
+    /// `TAGENT_DELEGATION_TAINT_ALLOW` — see
+    /// `SubprocessAgentRunner::with_delegation_taint` for the full rationale.
+    /// `None` (every non-assistant-tier caller) sets no env var; the child
+    /// behaves exactly as before this field existed.
+    pub(super) delegation_taint_allow: Option<&'a [String]>,
 }
 
 /// Unified subprocess spawn + IPC round-trip.
@@ -153,6 +161,7 @@ pub(super) async fn spawn_and_run_inner(cfg: SpawnConfig<'_>) -> Result<IpcMessa
         ctx,
         config_dir,
         project_dir,
+        delegation_taint_allow,
     } = cfg;
 
     let exe_path: PathBuf = std::env::current_exe().context("failed to resolve current_exe")?;
@@ -175,6 +184,43 @@ pub(super) async fn spawn_and_run_inner(cfg: SpawnConfig<'_>) -> Result<IpcMessa
         });
     if let Some(cd) = config_dir {
         cmd.env("TAGENT_CONFIG_DIR", cd);
+    }
+
+    // Security fix (delegate_to_agent injection-to-RCE path): forward the
+    // delegator's tainted allow-posture to the child as JSON. `run_subagent`
+    // reads this back and narrows the child's tool registry via
+    // `scope_assistant_allowed_tools` regardless of the child's own declared
+    // role — see `SubprocessAgentRunner::with_delegation_taint` for the full
+    // rationale. Logged at `info` (not merely `debug`) precisely because a
+    // narrowing that only shows up in a log nobody reads is not observable
+    // (#4111 found the app-launched daemon emits no logs at all — this is
+    // the PARENT-side half of that observability; `run_subagent` logs the
+    // CHILD-side half when it actually applies the narrowing).
+    if let Some(patterns) = delegation_taint_allow {
+        match serde_json::to_string(patterns) {
+            Ok(encoded) => {
+                cmd.env("TAGENT_DELEGATION_TAINT_ALLOW", encoded);
+                tracing::info!(
+                    agent = %agent_name,
+                    taint_patterns = ?patterns,
+                    "delegate_to_agent: tainting spawned worker to delegator's own tool posture"
+                );
+            }
+            Err(e) => {
+                // Fail closed: if we can't encode the allow-list, forward an
+                // empty (deny-all) taint rather than silently spawning
+                // untainted. This should be unreachable (`Vec<String>` is
+                // always representable as JSON) but a defensive default here
+                // costs nothing.
+                cmd.env("TAGENT_DELEGATION_TAINT_ALLOW", "[]");
+                tracing::warn!(
+                    agent = %agent_name,
+                    error = %e,
+                    "delegate_to_agent: failed to encode taint patterns; \
+                     falling back to deny-all taint for the spawned worker"
+                );
+            }
+        }
     }
 
     // Stamp the MPM sub-agent marker so any Claude Code instance running
@@ -439,6 +485,7 @@ pub(super) async fn spawn_subagent_with_config_dir(
     history: &[HistoryMessage],
     config_dir: &std::path::Path,
     ctx: Option<&RunContext>,
+    delegation_taint_allow: Option<&[String]>,
 ) -> Result<IpcMessage> {
     spawn_and_run_inner(SpawnConfig {
         agent_name,
@@ -449,6 +496,7 @@ pub(super) async fn spawn_subagent_with_config_dir(
         ctx,
         config_dir: Some(config_dir),
         project_dir,
+        delegation_taint_allow,
     })
     .await
 }

--- a/crates/trusty-agents/src/subprocess/spawn.rs
+++ b/crates/trusty-agents/src/subprocess/spawn.rs
@@ -139,6 +139,69 @@ pub(super) struct SpawnConfig<'a> {
     pub(super) delegation_taint_allow: Option<&'a [String]>,
 }
 
+/// Apply the delegation-taint env var to a child `Command` (security fix —
+/// delegate_to_agent injection-to-RCE path, item 4, #4126).
+///
+/// Why: Pulled out of `spawn_and_run_inner` so the `cmd.env(
+/// "TAGENT_DELEGATION_TAINT_ALLOW", ...)` write — previously asserted only
+/// indirectly, if at all — is directly unit-testable against a real
+/// `tokio::process::Command` via `Command::as_std().get_envs()`, without
+/// needing a full subprocess round-trip. Forwards the delegator's tainted
+/// allow-posture to the child as JSON; `run_subagent` reads this back and
+/// narrows the child's tool registry via `scope_assistant_allowed_tools`
+/// regardless of the child's own declared role — see
+/// `SubprocessAgentRunner::with_delegation_taint` for the full rationale.
+/// Logged at `info` (not merely `debug`) precisely because a narrowing that
+/// only shows up in a log nobody reads is not observable (#4111 found the
+/// app-launched daemon emits no logs at all — this is the PARENT-side half
+/// of that observability; `run_subagent` logs the CHILD-side half when it
+/// actually applies the narrowing).
+/// What: `None` sets no env var at all — the child's `run_subagent` sees an
+/// absent `TAGENT_DELEGATION_TAINT_ALLOW`, byte-identical to every caller
+/// before this feature existed. `Some(patterns)` sets the var to the JSON
+/// encoding of `patterns` (including `Some(vec![])`, which still sets the
+/// var — to `"[]"` — marking the spawn tainted with a deny-all set, NOT the
+/// same as not tainting at all). A JSON-encode failure (should be
+/// unreachable for `Vec<String>`) falls back to writing the literal `"[]"`
+/// rather than skipping the env var — fail closed, never silently untainted.
+/// Test: `delegation_taint_allow_env_set_when_configured`,
+/// `delegation_taint_allow_env_absent_by_default`,
+/// `delegation_taint_allow_env_empty_vec_still_sets_deny_all`
+/// (`subprocess::tests`).
+pub(super) fn apply_delegation_taint_env(
+    cmd: &mut Command,
+    delegation_taint_allow: Option<&[String]>,
+    agent_name: &str,
+) {
+    let Some(patterns) = delegation_taint_allow else {
+        return;
+    };
+    match serde_json::to_string(patterns) {
+        Ok(encoded) => {
+            cmd.env("TAGENT_DELEGATION_TAINT_ALLOW", encoded);
+            tracing::info!(
+                agent = %agent_name,
+                taint_patterns = ?patterns,
+                "delegate_to_agent: tainting spawned worker to delegator's own tool posture"
+            );
+        }
+        Err(e) => {
+            // Fail closed: if we can't encode the allow-list, forward an
+            // empty (deny-all) taint rather than silently spawning
+            // untainted. This should be unreachable (`Vec<String>` is
+            // always representable as JSON) but a defensive default here
+            // costs nothing.
+            cmd.env("TAGENT_DELEGATION_TAINT_ALLOW", "[]");
+            tracing::warn!(
+                agent = %agent_name,
+                error = %e,
+                "delegate_to_agent: failed to encode taint patterns; \
+                 falling back to deny-all taint for the spawned worker"
+            );
+        }
+    }
+}
+
 /// Unified subprocess spawn + IPC round-trip.
 ///
 /// Why: The two public spawn functions previously shared ~80% identical code:
@@ -187,41 +250,12 @@ pub(super) async fn spawn_and_run_inner(cfg: SpawnConfig<'_>) -> Result<IpcMessa
     }
 
     // Security fix (delegate_to_agent injection-to-RCE path): forward the
-    // delegator's tainted allow-posture to the child as JSON. `run_subagent`
-    // reads this back and narrows the child's tool registry via
-    // `scope_assistant_allowed_tools` regardless of the child's own declared
-    // role — see `SubprocessAgentRunner::with_delegation_taint` for the full
-    // rationale. Logged at `info` (not merely `debug`) precisely because a
-    // narrowing that only shows up in a log nobody reads is not observable
-    // (#4111 found the app-launched daemon emits no logs at all — this is
-    // the PARENT-side half of that observability; `run_subagent` logs the
-    // CHILD-side half when it actually applies the narrowing).
-    if let Some(patterns) = delegation_taint_allow {
-        match serde_json::to_string(patterns) {
-            Ok(encoded) => {
-                cmd.env("TAGENT_DELEGATION_TAINT_ALLOW", encoded);
-                tracing::info!(
-                    agent = %agent_name,
-                    taint_patterns = ?patterns,
-                    "delegate_to_agent: tainting spawned worker to delegator's own tool posture"
-                );
-            }
-            Err(e) => {
-                // Fail closed: if we can't encode the allow-list, forward an
-                // empty (deny-all) taint rather than silently spawning
-                // untainted. This should be unreachable (`Vec<String>` is
-                // always representable as JSON) but a defensive default here
-                // costs nothing.
-                cmd.env("TAGENT_DELEGATION_TAINT_ALLOW", "[]");
-                tracing::warn!(
-                    agent = %agent_name,
-                    error = %e,
-                    "delegate_to_agent: failed to encode taint patterns; \
-                     falling back to deny-all taint for the spawned worker"
-                );
-            }
-        }
-    }
+    // delegator's tainted allow-posture to the child as JSON. See
+    // `apply_delegation_taint_env` for the full rationale — extracted to its
+    // own function so the `cmd.env(...)` write is unit-testable in isolation
+    // (item 4, #4126: this exact write previously had no test coverage at
+    // all, end-to-end or otherwise).
+    apply_delegation_taint_env(&mut cmd, delegation_taint_allow, agent_name);
 
     // Stamp the MPM sub-agent marker so any Claude Code instance running
     // inside this child knows it is nested. The `trusty-mpm hook` consumer

--- a/crates/trusty-agents/src/subprocess/tests.rs
+++ b/crates/trusty-agents/src/subprocess/tests.rs
@@ -7,10 +7,89 @@
 //! Test: This module is itself the test coverage.
 
 use tokio::io::AsyncBufReadExt;
+use tokio::process::Command;
 
 use crate::ipc::{IpcMessage, parse_message};
+use crate::subprocess::spawn::apply_delegation_taint_env;
 #[cfg(unix)]
 use crate::test_env::{spawn_script, write_executable_script};
+
+/// Read back the value `apply_delegation_taint_env` (or any other
+/// `cmd.env(...)` call) set for `key` on a `tokio::process::Command`,
+/// without spawning it.
+///
+/// Why: `Command` does not expose a `get_env`-by-key lookup directly;
+/// `as_std().get_envs()` returns an iterator of every EXPLICITLY set
+/// var (inherited process env is not included), which is exactly the
+/// "what did we just tell the child to see" question these tests ask.
+fn get_env_on_command<'a>(cmd: &'a Command, key: &str) -> Option<&'a std::ffi::OsStr> {
+    cmd.as_std()
+        .get_envs()
+        .find(|(k, _)| *k == std::ffi::OsStr::new(key))
+        .and_then(|(_, v)| v)
+}
+
+/// Security fix (delegate_to_agent injection-to-RCE path, item 4, #4126):
+/// the `cmd.env("TAGENT_DELEGATION_TAINT_ALLOW", ...)` write in
+/// `apply_delegation_taint_env` had no direct test coverage at all before
+/// this — the doc comment on `SubprocessAgentRunner::with_delegation_taint`
+/// cited two tests (`delegation_taint_allow_env_set_when_configured`,
+/// `delegation_taint_allow_env_absent_by_default`) that did not exist
+/// anywhere in the repo (a "doc-comment pointer lint" CI failure). This is
+/// the REAL round trip: build an actual `Command`, apply the function, read
+/// the env var back off the `Command` object (never spawned).
+#[test]
+fn delegation_taint_allow_env_set_when_configured() {
+    let mut cmd = Command::new("true");
+    let patterns = vec!["web_search".to_string(), "delegate_to_agent".to_string()];
+
+    apply_delegation_taint_env(&mut cmd, Some(&patterns), "engineer");
+
+    let value = get_env_on_command(&cmd, "TAGENT_DELEGATION_TAINT_ALLOW")
+        .expect(
+            "TAGENT_DELEGATION_TAINT_ALLOW must be set on the Command when a taint is configured",
+        )
+        .to_str()
+        .expect("value must be valid UTF-8");
+    let decoded: Vec<String> = serde_json::from_str(value).expect("value must round-trip as JSON");
+    assert_eq!(decoded, patterns);
+}
+
+/// Companion to the test above: when the caller passes `None` (every
+/// non-assistant-tier / non-delegated spawn — still the overwhelming
+/// majority), NO env var is written at all, byte-identical to every spawn
+/// before this feature existed.
+#[test]
+fn delegation_taint_allow_env_absent_by_default() {
+    let mut cmd = Command::new("true");
+
+    apply_delegation_taint_env(&mut cmd, None, "engineer");
+
+    assert!(
+        get_env_on_command(&cmd, "TAGENT_DELEGATION_TAINT_ALLOW").is_none(),
+        "no taint configured must mean no TAGENT_DELEGATION_TAINT_ALLOW env var on the child Command at all"
+    );
+}
+
+/// `Some(vec![])` (an assistant-tier delegator with no resolvable
+/// `[tools].allow` of its own — the fail-closed case item 2/3 rely on) must
+/// still WRITE the env var — to the literal `"[]"` — rather than being
+/// treated the same as `None`. If this collapsed to "no var set", the child
+/// would see an absent env var and run completely untainted, silently
+/// reopening the exact hole the fail-closed default exists to close.
+#[test]
+fn delegation_taint_allow_env_empty_vec_still_sets_deny_all() {
+    let mut cmd = Command::new("true");
+    let empty: Vec<String> = Vec::new();
+
+    apply_delegation_taint_env(&mut cmd, Some(&empty), "engineer");
+
+    let value = get_env_on_command(&cmd, "TAGENT_DELEGATION_TAINT_ALLOW")
+        .expect("an empty (deny-all) taint must still set the env var")
+        .to_str()
+        .expect("value must be valid UTF-8");
+    assert_eq!(value, "[]");
+}
 
 /// #147: A subprocess that writes a valid IpcMessage::Result to stdout and
 /// then exits with code 1 must be treated as success by the rescue logic in


### PR DESCRIPTION
## Summary

Closes #4126 — a live, exploitable prompt-injection-to-code-execution path through `delegate_to_agent`.

**The vulnerability (independently confirmed against `origin/main` @ `4e36002d`):**

1. Assistant-tier personas (`assistant`, `cto-assistant`, `izzie`) are granted live external-content tools (`get_gmail_message_content`, `web_search`, etc.) — `crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml:73-106`.
2. The untrusted-data neutralization envelope (`crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_memory.rs:420-515`) wraps only persisted memory-drawer recall — not live tool return values.
3. The same personas are granted `delegate_to_agent`.
4. Delegation is role-gated by `ASSISTANT_ALLOWED_DELEGATE_ROLES` (`tool_registry.rs:120-127`), which checks only the *target's role name*, never the content of the `task` string.
5. `engineer.toml` declares `role = "engineer"`, `runner = "claude-code"`, and no `[tools].allow`.
6. `scope_assistant_allowed_tools` (`tool_registry.rs:529-553`) — the gate that would narrow a spawned worker — only fired when the **spawned** agent's own role was `"assistant"`. For `engineer` this was a no-op.
7. With no allowlist, `dispatch_gated`'s `None` semantics make every registered tool callable — under `runner = "claude-code"` that's a real `claude` subprocess with full shell and file-write access.

Net: attacker text fetched during a persona turn (an inbound email, a scraped page) could drive `delegate_to_agent(agent_name="engineer", task="<attacker text>")` and the spawned engineer would execute it with unrestricted access.

## The fix

`scope_assistant_allowed_tools`'s narrowing now travels *with the delegation* rather than gating on the spawned agent's own role. Every assistant-tier `delegate_to_agent` call tags its `SubprocessAgentRunner` with the delegator's own `[tools].allow` posture (`with_delegation_taint`), forwarded to the child process as `TAGENT_DELEGATION_TAINT_ALLOW` (JSON). `run_subagent` reads this back and applies the same narrowing using the *delegator's* patterns, regardless of the spawned agent's declared role — closing the gap on both dispatch paths:

- the `--direct`/`--agent` subprocess path (`runtime/tool_registry.rs` + `runtime/subagent_mode.rs`)
- the in-process `/agent` persona-chat path (`ctrl/pm_task/dispatch/persona.rs`)

**Taint scope decision: unconditional**, applied to every assistant-tier delegation rather than only turns that happened to call a live-fetch tool. Chosen because (a) it's simpler and fails safe, (b) per-turn tracking would still miss content fetched in an *earlier* turn that's still present in conversation history, and (c) assistant personas' core value proposition is live content access, so a conditional gate would rarely differ from unconditional in practice while adding real implementation risk.

**Observability**: narrowing is logged at `info` on both the parent (pre-spawn, in `spawn_and_run_inner`) and child (post-scoping, in `run_subagent`) sides. A disallowed tool call already returns (and continues to return) a legible `"Tool 'X' is not permitted for this agent. Allowed: ..."` error via `dispatch_gated` — not a silently-missing tool. A malformed/corrupted taint env var fails **closed** (empty/deny-all), never silently untainted.

A taint also never widens past an agent's own explicit `[tools].allowed` when one is set — the two are intersected.

## Diff

- `crates/trusty-agents/src/subprocess/mod.rs` / `spawn.rs` — new `SubprocessAgentRunner::with_delegation_taint`, forwarded as `TAGENT_DELEGATION_TAINT_ALLOW` env var, logged at spawn time.
- `crates/trusty-agents/src/runtime/tool_registry.rs` — `build_assistant_tier_registry` now tags its own `delegate_to_agent` tool with the current agent's `[tools].allow`; new pure, unit-tested `scope_for_delegation` and `parse_delegation_taint_env` helpers.
- `crates/trusty-agents/src/runtime/subagent_mode.rs` — reads the taint env var, applies `scope_for_delegation` instead of the old unconditional `scope_assistant_allowed_tools` call.
- `crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs` — same taint wiring for the in-process persona-chat dispatch path.
- `crates/trusty-agents/src/runtime/tool_registry_tests.rs` — 8 new tests (see below).
- `crates/trusty-agents/CHANGELOG.md` — Security entry.

## Tests

New, all passing:
- `tainted_delegation_cannot_reach_tool_delegator_lacked` — a tainted `local-ops-agent`-shaped registry (real `shell_exec`) cannot reach `shell_exec`/`read_file`/`list_dir`/`grep_files` when the taint patterns don't cover them.
- `untainted_delegation_is_unaffected` — an untainted spawn stays fully unrestricted (byte-identical to pre-fix).
- `tainted_delegation_intersects_with_existing_allowed` — taint narrows, never widens past an agent's own `[tools].allowed`.
- `assistant_delegate_to_engineer_path_is_scoped` — the exact `assistant → delegate_to_agent(engineer) → unrestricted tools` path, closed.
- `parse_delegation_taint_env_{absent_is_untainted,valid_json_is_tainted,empty_array_is_tainted_deny_all,malformed_fails_closed}` — env-var parsing, including the fail-closed guarantee.

## Quality gate (raw output)

```
$ cargo fmt --check
(clean, exit 0)

$ cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
(exit 0; only pre-existing unrelated `tga` crate warnings, not gated by -D warnings)

$ SKIP_UI_BUILD=1 cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --no-fail-fast
TOTAL passed=19320 failed=5
```

The 5 failures are two pre-existing environmental flakes, independently reproduced identically on a clean `origin/main` checkout with zero changes:
- `tools::python_skill::tests::execute_dispatches_to_python_and_parses_json` (1 failure) — a `uv` cache-lock race under parallel test execution; passes standalone with or without this diff.
- `tests/api_e2e.rs` (4 failures) — spawned API server doesn't become healthy within the test's 5s timeout in this sandboxed environment; reproduces identically on unmodified `main`.

Neither touches any file in this diff.

## Coordination

Stayed scoped to the tool-registry/delegation area per instructions; did not touch `~/.trusty-agents/`, `.bundled-stamp`, or run a reprovision.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools