### PR TITLE
chore(release): coordinated version bump — trusty-common 0.27.0 + 6 crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11674,7 +11674,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11269,7 +11269,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11410,7 +11410,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.26.2"
+version = "0.27.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11634,7 +11634,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.21.2"
+version = "0.21.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11674,7 +11674,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.0.2"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11767,7 +11767,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-review"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11808,7 +11808,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.39.1"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ trusty-code = { path = "crates/trusty-code" }
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
 trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.3.0" }
-trusty-common = { path = "crates/trusty-common", version = "0.26.0" }
+trusty-common = { path = "crates/trusty-common", version = "0.27" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.
 trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }
@@ -114,7 +114,7 @@ trusty-mpm = { path = "crates/trusty-mpm", version = "1.0.0" }
 # trusty-review: LLM-backed PR-review service. Referenced by trusty-analyze
 # (behind the optional `review` feature) so the analyze MCP server can expose
 # the trusty-review pipeline as `tr_review_*` tools (#630).
-trusty-review = { path = "crates/trusty-review", version = "0.10.0" }
+trusty-review = { path = "crates/trusty-review", version = "0.11" }
 # trusty-console: web dashboard for trusty services. As of #1318 the standalone
 # `trusty-console` crate is the SOLE producer of the `trusty-console` binary
 # (de-bundled from the host crates for single-owner-per-binary). It is still a

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -66,7 +66,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
 trusty-memory = { path = "../trusty-memory", version = "0.21.1", default-features = false }
-trusty-search = { path = "../trusty-search", version = "0.39.1" }
+trusty-search = { path = "../trusty-search", version = "0.40" }
 # Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
 # trusty-gworkspace's connector layer (`api::client::BaseClient` +
 # `api::services::gmail::*`) DIRECTLY as library functions — the same code

--- a/crates/trusty-agents/src/llm/stream.rs
+++ b/crates/trusty-agents/src/llm/stream.rs
@@ -220,6 +220,9 @@ where
                 break;
             }
             ChatEvent::Done => break,
+            // `ChatEvent` is `#[non_exhaustive]` (trusty-common 0.27.0): a wildcard
+            // keeps a future variant from breaking this crate's build.
+            _ => {}
         }
     }
 

--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -7,6 +7,32 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
+## [Unreleased]
+
+---
+
+## [0.7.5] — 2026-07-27
+
+### Changed
+
+- `trusty-common` requirement raised to `^0.27` (was `^0.26`, inherited from
+  `[workspace.dependencies]`): 0.27.0 makes `ChatEvent` `#[non_exhaustive]`,
+  which a `^0.26` requirement cannot express.
+
+### Fixed
+
+- **Post-publish source drift — `explain` did not compile against the
+  `ChatEvent::Usage` variant.** `src/core/explain.rs` gained its
+  `ChatEvent::Usage(_)` arm in #4112, *after* 0.7.4 was published, so the
+  published 0.7.4 artifact cannot build against any `trusty-common` carrying
+  that variant. This is the same failure shape as #4079 below — a downstream
+  exhaustive `match` broken by an upstream variant addition — and this release
+  ships the arm before it can bite a `cargo install`. The match also gained a
+  wildcard arm now that `ChatEvent` is `#[non_exhaustive]`, so the next variant
+  addition is no longer breaking here.
+
+---
+
 ## [0.7.4] — 2026-07-27
 
 ### Fixed

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.7.4"
+version     = "0.7.5"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-analyze/src/core/explain.rs
+++ b/crates/trusty-analyze/src/core/explain.rs
@@ -147,6 +147,9 @@ pub async fn explain_report(
                     stream_error = Some(msg);
                     break;
                 }
+                // `ChatEvent` is `#[non_exhaustive]` (trusty-common 0.27.0): a wildcard
+                // keeps a future variant from breaking this crate's build.
+                _ => {}
             }
         }
         if let Some(msg) = stream_error {

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.27.0] — 2026-07-27
+
+MINOR, not patch — deliberately. `ChatEvent::Usage` (added below) is a new
+variant on an enum that was neither `#[non_exhaustive]` nor private, so every
+downstream exhaustive `match` over it stops compiling with E0004; five
+in-workspace consumers had to gain an arm. Shipping that as 0.26.3 would have
+let `^0.26` re-resolve the ALREADY-PUBLISHED, arm-less consumer sources onto
+the new variant and hard-fail `cargo install` — the exact failure that forced
+`trusty-analyze` 0.7.3 to be yanked on 2026-07-27. `^0.26` excludes 0.27.0, so
+published consumers keep resolving to 0.26.2 and stay installable.
+
+### Changed
+
+- **`chat::ChatEvent` is now `#[non_exhaustive]`.** Downstream `match`es must
+  carry a wildcard arm. This is itself the breaking change that the MINOR bump
+  covers, and it is an ADDITION to that bump rather than a substitute for it:
+  it does nothing for consumers published before it landed, it only stops the
+  *next* variant addition from repeating the break.
+
 ### Added
 
 - **`chat::BedrockProvider` now streams via `ConverseStream` instead of

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.26.2"
+version = "0.27.0"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/src/chat/mod.rs
+++ b/crates/trusty-common/src/chat/mod.rs
@@ -222,7 +222,24 @@ pub struct ChatUsage {
 /// provider also returns `Err` from `chat_stream`, but `Error` lets the
 /// caller display partial-stream failures inline).
 /// Test: `ollama_provider_streams_sse_deltas`.
+///
+/// # Stability
+///
+/// `#[non_exhaustive]`: adding a variant here is otherwise a SemVer-breaking
+/// change for every downstream crate, because an exhaustive `match` over the
+/// old variant set stops compiling with E0004. That is not hypothetical — the
+/// `Usage` variant forced arm additions in five consumers at once
+/// (`trusty-agents`, `trusty-analyze`, `trusty-memory`, `trusty-mpm`,
+/// `trusty-search`) and is the direct cause of the 0.27.0 MINOR bump: a patch
+/// release would have re-resolved the already-published, arm-less consumer
+/// sources against the new variant and hard-failed `cargo install` (the same
+/// failure that forced `trusty-analyze` 0.7.3 to be yanked).
+///
+/// Downstream matches must therefore carry a wildcard arm. This attribute does
+/// NOT retroactively fix consumers published before it landed — it only stops
+/// the next variant addition from repeating the break.
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub enum ChatEvent {
     Delta(String),
     ToolCall(ToolCall),

--- a/crates/trusty-gworkspace/Cargo.toml
+++ b/crates/trusty-gworkspace/Cargo.toml
@@ -15,7 +15,7 @@ name = "trusty-gworkspace-mcp"
 path = "src/bin/trusty-gworkspace-mcp.rs"
 
 [dependencies]
-trusty-common = { path = "../trusty-common", version = "0.26.0", features = ["mcp"] }
+trusty-common = { path = "../trusty-common", version = "0.27", features = ["mcp"] }
 anyhow = { workspace = true }
 thiserror = { workspace = true }
 serde = { workspace = true }

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -6,6 +6,45 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+---
+
+## [0.21.3] — 2026-07-27
+
+### Changed
+
+- `trusty-common` requirement raised to `^0.27` (was `^0.26.2`): 0.27.0 makes
+  `ChatEvent` `#[non_exhaustive]`, which a `^0.26` requirement cannot express.
+
+### Fixed
+
+- **Post-publish source drift — the SSE chat handler did not compile against
+  the `ChatEvent::Usage` variant.** `src/chat/handler.rs` gained its
+  `ChatEvent::Usage(_)` arm in #4112, *after* 0.21.2 was published, so the
+  published 0.21.2 artifact cannot build against any `trusty-common` carrying
+  that variant. This release ships the arm. The match also gained a wildcard
+  arm now that `ChatEvent` is `#[non_exhaustive]`, so the next variant
+  addition is no longer breaking here.
+
+---
+
+## [0.21.2] — 2026-07-26
+
+### Fixed
+
+- slim build (`--no-default-features`) now compiles: `tools::dream_ops` reached
+  the user-config loader through the `axum-server`-gated `crate::web::` re-export,
+  breaking any dependent that opts out of `axum-server` (e.g. `trusty-agents`,
+  which uses `default-features = false`). Now routes through the axum-free
+  `crate::service::load_user_config` like `chat_provider()` already does
+  (closes #2049).
+- decouple recall/remember from embedder warm-up (closes #1970) ([#1972](https://github.com/bobmatnyc/trusty-tools/pull/1972)) ([`bb322d4`](https://github.com/bobmatnyc/trusty-tools/commit/bb322d4678f8e167691688e77190b44d9c08627a))
+- palace-level alias resolution for claude-mpm parity (owner-repo -> bare palace) ([#1945](https://github.com/bobmatnyc/trusty-tools/pull/1945)) ([`af7f904`](https://github.com/bobmatnyc/trusty-tools/commit/af7f90499402971ac65aed5b104cde251e182599))
+- stop console_metrics force-opening every palace on poll (closes #1924) ([#1926](https://github.com/bobmatnyc/trusty-tools/pull/1926)) ([`74e9e54`](https://github.com/bobmatnyc/trusty-tools/commit/74e9e54243efc6de3778d7c43d938add2ab7b676))
+
+---
+
 ## [0.21.1] — 2026-07-24
 
 ### Fixed
@@ -97,23 +136,6 @@ attribution work.
 
 ---
 
-## [Unreleased]
-
----
-
-## [0.21.2] — 2026-07-26
-
-### Fixed
-
-- slim build (`--no-default-features`) now compiles: `tools::dream_ops` reached
-  the user-config loader through the `axum-server`-gated `crate::web::` re-export,
-  breaking any dependent that opts out of `axum-server` (e.g. `trusty-agents`,
-  which uses `default-features = false`). Now routes through the axum-free
-  `crate::service::load_user_config` like `chat_provider()` already does
-  (closes #2049).
-- decouple recall/remember from embedder warm-up (closes #1970) ([#1972](https://github.com/bobmatnyc/trusty-tools/pull/1972)) ([`bb322d4`](https://github.com/bobmatnyc/trusty-tools/commit/bb322d4678f8e167691688e77190b44d9c08627a))
-- palace-level alias resolution for claude-mpm parity (owner-repo -> bare palace) ([#1945](https://github.com/bobmatnyc/trusty-tools/pull/1945)) ([`af7f904`](https://github.com/bobmatnyc/trusty-tools/commit/af7f90499402971ac65aed5b104cde251e182599))
-- stop console_metrics force-opening every palace on poll (closes #1924) ([#1926](https://github.com/bobmatnyc/trusty-tools/pull/1926)) ([`74e9e54`](https://github.com/bobmatnyc/trusty-tools/commit/74e9e54243efc6de3778d7c43d938add2ab7b676))
 ## [0.17.0] — 2026-06-25
 
 ### Added

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.21.2"
+version = "0.21.3"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true
@@ -83,7 +83,7 @@ path = "src/bin/mcp_bridge.rs"
 #      build for the binary path keeps `axum-server` on (see [features]
 #      below), so existing `cargo install` / `cargo build` flows are
 #      unaffected.
-trusty-common = { path = "../trusty-common", version = "0.26.2", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
+trusty-common = { path = "../trusty-common", version = "0.27", default-features = false, features = ["mcp", "memory-core", "monitor-tui", "bm25-client", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }
 # `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478)
 # Why: declaring trusty-bm25-daemon as a Cargo dependency causes `cargo install
 #      trusty-memory` to also build and install the daemon binary alongside
@@ -166,7 +166,7 @@ serial_test = { workspace = true }
 # which is gated behind `embedder-test-support`. Re-declaring trusty-common here
 # with the feature activates it for all integration tests without enabling it in
 # the production library (mirrors the trusty-mpm and trusty-search pattern).
-trusty-common = { path = "../trusty-common", version = "0.26.0", default-features = false, features = ["memory-core", "embedder-test-support"] }
+trusty-common = { path = "../trusty-common", version = "0.27", default-features = false, features = ["memory-core", "embedder-test-support"] }
 chrono = { workspace = true }
 
 [features]

--- a/crates/trusty-memory/src/chat/handler.rs
+++ b/crates/trusty-memory/src/chat/handler.rs
@@ -330,6 +330,9 @@ pub(crate) async fn chat_handler(
                         stream_err = Some(e);
                         break;
                     }
+                    // `ChatEvent` is `#[non_exhaustive]` (trusty-common 0.27.0): a wildcard
+                    // keeps a future variant from breaking this crate's build.
+                    _ => {}
                 }
             }
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [1.1.0] — 2026-07-27
+
+MINOR: substantial new public library surface (`core::push_guard`,
+`core::claude_json_guard`, `control::delegation_tracker`,
+`core::worktree_safety`) plus the MCP-trust hardening chain. Two internal
+plumbing functions (`core::mcp_config::managed_mcp_server_names`,
+`core::standalone::trust_seed::preseed_managed_trust`) did gain parameters,
+which is technically MAJOR-shaped for a 1.x crate; no published crate depends
+on `trusty-mpm` as a library (verified against the published `trusty-code`
+0.2.0 and `trusty-agents-common` 0.3.0 manifests, neither of which declares
+it), and no in-workspace caller outside this crate references either symbol,
+so a 2.0.0 would signal a break that cannot reach anyone.
+
 ### Added
 
 - **Cross-branch `git push` guard for every worktree of a managed base clone**
@@ -110,6 +124,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   [#3981](https://github.com/bobmatnyc/trusty-tools/issues/3981).
 
 ### Changed
+
+- `trusty-common` requirement raised to `^0.27` (was `^0.26`): 0.27.0 makes
+  `ChatEvent` `#[non_exhaustive]`, which a `^0.26` requirement cannot express.
+  `activity::monitor`'s `ChatEvent` match gained a wildcard arm accordingly.
 
 - **Orphan-sweep candidates are processed in sorted order** rather than
   filesystem order, so a `--dry-run` preview predicts the real run and any

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -8,7 +8,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ---
-## [1.1.0] — 2026-07-27
+## [1.2.0] — 2026-07-27
 
 MINOR: substantial new public library surface (`core::push_guard`,
 `core::claude_json_guard`, `control::delegation_tracker`,

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.1.0"
+version = "1.2.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.0.2"
+version = "1.1.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-mpm/src/activity/monitor.rs
+++ b/crates/trusty-mpm/src/activity/monitor.rs
@@ -498,6 +498,9 @@ impl LlmClassifier for OpenRouterClassifier {
                     ChatEvent::Error(e) => stream_error = Some(e),
                     // #3767: no usage-accounting consumer wired up here yet.
                     ChatEvent::ToolCall(_) | ChatEvent::Done | ChatEvent::Usage(_) => {}
+                    // `ChatEvent` is `#[non_exhaustive]` (trusty-common 0.27.0): a wildcard
+                    // keeps a future variant from breaking this crate's build.
+                    _ => {}
                 }
             }
         });

--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.11.0] — 2026-07-27
+
+MINOR, not patch: `HealthResponse::is_serving` and
+`pipeline::citation_check::downgrade_uncitable_findings` were removed from the
+public API (replaced by `serving_state()` and
+`enforce_citation_integrity` respectively), and `pipeline::finding_hygiene` is
+a new public module.
+
+### Changed
+
+- `trusty-common` requirement raised to `^0.27` (was `^0.26`, inherited from
+  `[workspace.dependencies]`): 0.27.0 makes `ChatEvent` `#[non_exhaustive]`,
+  which a `^0.26` requirement cannot express.
+
 ### Fixed
 
 - **A live trusty-search was reported as `"unreachable"`, and a degraded verdict
@@ -81,6 +96,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     fix is marker-based on the finding's own admission and does not catch a
     finding grounded in an in-code COMMENT's hypothetical (the code file
     itself is real, so extension/path-based detection does not apply there).
+
+---
+## [0.10.1] — 2026-07-23
 
 ### Fixed
 

--- a/crates/trusty-review/Cargo.toml
+++ b/crates/trusty-review/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-review"
-version     = "0.10.1"
+version     = "0.11.0"
 edition     = "2024"
 rust-version.workspace = true
 license.workspace      = true

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [0.40.0] — 2026-07-27
+
+MINOR, not patch: `service::lazy_loader::store`'s public
+`register_cold_entries` changed its return type from `()` to
+`Vec<Arc<()>>` (it now hands back the per-entry residency tokens that
+`mark_loaded_if` needs to detect a reindex that raced a cold restore). In
+0.x, MINOR is the breaking axis.
+
+### Changed
+
+- `trusty-common` requirement raised to `^0.27` (was `^0.26`): 0.27.0 makes
+  `ChatEvent` `#[non_exhaustive]`, which a `^0.26` requirement cannot express.
+  `service::ui`'s `ChatEvent` match gained a wildcard arm accordingly.
+
+
 ### Fixed
 
 - **Two more index-registration paths had no `root_path` collision guard —

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.39.1"
+version = "0.40.0"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -54,7 +54,7 @@ path = "src/bin/trusty-embedderd.rs"
 
 [dependencies]
 # ── Shared trusty-common crates ────────────────────────────────────────────
-trusty-common = { version = "0.26.0", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
+trusty-common = { version = "0.27", default-features = false, features = ["axum-server", "mcp", "embedder", "embedder-test-support", "symgraph", "monitor-tui", "embedder-client", "bm25", "migrations", "cli-help", "update-check", "bug-capture", "console-metrics", "config-cli"] }  # `config-cli` (#2405): implies `credentials`, giving both the shared `.env.local` loader `load_env_local_once` (retiring trusty-search's ad hoc dotenvy call) AND the embeddable `ConfigKeysCommand` nested under `trusty-search config keys …`  # `symgraph` enables only the contracts surface — no tree-sitter, no `links` conflict; `monitor-tui` powers `trusty-search monitor tui`; `embedder-client` provides EmbedderClient/RemoteEmbedderClient/UdsEmbedderClient (issue #164); `bm25` is the canonical lexical index (issue #156); `migrations` provides the shared schema-migration kernel (issue #179); `cli-help` provides the shared declarative CLI help + "did you mean?" suggester (issue #216); `update-check` provides throttled crates.io update notification; `bug-capture` enables Phase 1 ERROR event capture to JSONL + in-memory ring (bug-reporting #478); `console-metrics` provides ConsoleMetricsReport for the trusty-console dashboard (issue #1104)
 
 # ── Bundled sidecars ─────────────────────────────────────────────────────────
 # Why: the trusty-embedderd binary is a required runtime dependency (issue

--- a/crates/trusty-search/src/service/ui.rs
+++ b/crates/trusty-search/src/service/ui.rs
@@ -315,6 +315,9 @@ pub async fn chat_handler(
             ChatEvent::Usage(_) => {}
             ChatEvent::Done => {}
             ChatEvent::Error(e) => stream_error = Some(e),
+            // `ChatEvent` is `#[non_exhaustive]` (trusty-common 0.27.0): a wildcard
+            // keeps a future variant from breaking this crate's build.
+            _ => {}
         }
     }
     match stream_task.await {


### PR DESCRIPTION
Version bumps and changelogs **only**. Nothing is published to crates.io by this PR — publishing stays a separate, human-authorized step.

## The load-bearing decision: `trusty-common` goes 0.27.0, not 0.26.3

`crates/trusty-common/src/chat/mod.rs` declares `pub enum ChatEvent` with no `#[non_exhaustive]`. PR #4112 added a `Usage(ChatUsage)` variant. That is SemVer-breaking: every downstream exhaustive `match` fails with E0004. The in-tree proof is that #4112 had to add a `ChatEvent::Usage(_)` arm to five consumers at once.

Those consumers are already published pinned at `^0.26.x`. Shipping this as **0.26.3** would let `^0.26` re-resolve the already-published, arm-less consumer sources onto the new variant and hard-fail `cargo install` — bit-for-bit the bug that forced `trusty-analyze` 0.7.3 to be yanked and 0.7.4 published earlier today.

### Proved empirically, not asserted

The workspace itself cannot demonstrate this — path deps mean caller and definition never diverge in-tree. So the proof is a minimal reproduction outside the workspace, driven by a real cargo `directory` source holding multiple versions, with the consumer's requirement copied verbatim from the **published** `trusty-memory` 0.21.2 manifest (`[dependencies.trusty-common] version = "0.26.2"`) and its `match` copied shape-for-shape from that same published crate's `src/chat/handler.rs:301` (four arms, no `Usage`, no wildcard — the source that is on crates.io today and cannot be changed retroactively).

**Scenario A — we publish 0.26.3 (PATCH).** Registry offers `{0.26.2, 0.26.3}`:

```
   Compiling evproof-common v0.26.3
   Compiling evproof-consumer v0.21.2
error[E0004]: non-exhaustive patterns: `ChatEvent::Usage(_)` not covered
  --> src/lib.rs:9:15
   |
 9 |         match event {
   |               ^^^^^ pattern `ChatEvent::Usage(_)` not covered
...
 5 |     Usage(u32),   // <- the variant PR #4112 added
   |     ----- not covered
error: could not compile `evproof-consumer` (lib) due to 1 previous error
--- resolved to: ---
name = "evproof-common"
version = "0.26.3"
```

**Scenario B — we publish 0.27.0 (MINOR).** Registry offers `{0.26.2, 0.27.0}`:

```
     Locking 1 package to latest compatible version
      Adding evproof-common v0.26.2 (available: v0.27.0)
   Compiling evproof-common v0.26.2
   Compiling evproof-consumer v0.21.2
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.27s
--- resolved to: ---
name = "evproof-common"
version = "0.26.2"
```

The `(available: v0.27.0)` line is the control: cargo **saw** 0.27.0 and deliberately declined it, because `^0.26.2` excludes it. Published consumers keep resolving to 0.26.2 and stay installable.

### `#[non_exhaustive]` added — in addition to, not instead of, the minor bump

`ChatEvent` is now `#[non_exhaustive]`. This does **nothing** for consumers published before it lands; it only stops the *next* variant addition from repeating the break. It is itself the breaking change the MINOR bump covers. Wildcard arms added in the five in-workspace consumers this newly requires (`trusty-agents`, `trusty-analyze`, `trusty-memory`, `trusty-mpm`, `trusty-search`).

Every `trusty-common` requirement re-pinned to `^0.27`, including the `[workspace.dependencies]` entry.

## Per-crate version decisions

| Crate | Version | Why this level |
|---|---|---|
| **trusty-common** | 0.26.2 → **0.27.0** | Mandated MINOR (above). `#[non_exhaustive]` on `ChatEvent` is independently breaking; in 0.x, MINOR is the breaking axis. |
| **trusty-mpm** | 1.0.2 → **1.2.0** | Set by the owner. New public modules (`push_guard`, `claude_json_guard`, `delegation_tracker`, `worktree_safety`) + the MCP-trust chain. See the note below. |
| **trusty-review** | 0.10.1 → **0.11.0** | Breaking: `HealthResponse::is_serving` and `citation_check::downgrade_uncitable_findings` were removed; new public `pipeline::finding_hygiene` module. |
| **trusty-search** | 0.39.1 → **0.40.0** | Breaking: public `register_cold_entries` changed its return type from `()` to `Vec<Arc<()>>`. |
| **trusty-memory** | 0.21.2 → **0.21.3** | PATCH — the only source drift is the `ChatEvent` arm in `src/chat/handler.rs`. No public API change. |
| **trusty-analyze** | 0.7.4 → **0.7.5** | PATCH — same, `src/core/explain.rs` only. 0.7.4 IS live; this is post-publish drift. |
| **trusty-console** | **0.5.0, unchanged** | Verified, not assumed: `git log 831103dd..HEAD -- crates/trusty-console` returns **zero commits**, so nothing has landed since 0.5.0 was set. 0.5.0 is already a correct MINOR over published 0.4.0 (it removed public `origin_is_loopback` and `guard_write_origin`). No further bump warranted. |

### Note on `trusty-mpm`'s level

**1.2.0 is the owner's decision**, applied as given.

Recording the analysis that preceded it, since it is the kind of thing a future
reader will want: two internal-plumbing functions gained parameters —
`core::mcp_config::managed_mcp_server_names` and
`core::standalone::trust_seed::preseed_managed_trust` — which is MAJOR-shaped
for a 1.x crate. The reason that does not force a 2.0.0 is that **no published
crate depends on `trusty-mpm` as a library**: the published `trusty-code` 0.2.0
and `trusty-agents-common` 0.3.0 tarballs declare no `trusty-mpm` dependency at
all (their only `trusty_mpm::` occurrences are inside doc comments), and no
in-workspace caller outside this crate references either symbol.

Verified that this bump is not working around a collision: neither 1.1.0 nor
1.2.0 is published on crates.io (max is 1.0.2), and no `trusty-mpm-v1.1.0` or
`trusty-mpm-v1.2.0` tag exists locally or on `origin`.

## Cargo.lock: not refreshed

`Cargo.lock` changed **exactly 6 lines** — the six bumped crates' own `version =` entries. Zero third-party churn, so no MSRV movement (the failure mode from the installer 0.4.10 release).

```
 Cargo.lock | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)
```

## Changelogs

Each populated `[Unreleased]` moved under its new version heading dated 2026-07-27. The three named hygiene problems are fixed:

- **trusty-review** had no `[0.10.1]` heading despite 0.10.1 being published. Restored — and the cause is instructive: `[Unreleased]` contained **two `### Fixed` headers**, exactly the duplicate-header merge artifact that git never flags. The second block was 0.10.1's content (the #3693 `context_gate` fix), confirmed by diffing against the `trusty-review-v0.10.1` tag, which still carries the heading.
- **trusty-memory** had an empty `[Unreleased]` sitting below `[0.21.1]` and above `[0.21.2]`. `[Unreleased]` is back at the top and 0.21.2 is above 0.21.1. The older 0.19.2/0.20.0 ordering scramble further down is pre-existing and deliberately left alone.
- **trusty-analyze** and **trusty-memory** had no `[Unreleased]` content despite carrying real post-publish drift; both now have entries describing that drift.

### Verified, not eyeballed

Multiset-diff of non-blank lines, old vs new, run post-rebase against `origin/main`:

```
trusty-common:  LOST=0  ADDED=16
trusty-mpm:     LOST=0  ADDED=15
trusty-review:  LOST=0  ADDED=13
trusty-search:  LOST=0  ADDED=11
trusty-memory:  LOST=0  ADDED=14
trusty-analyze: LOST=0  ADDED=18
trusty-console: LOST=0  ADDED=0
```

`###` header count per authored `## [version]` block — no duplicates:

```
trusty-common    ## [0.27.0]  {'### Changed': 1, '### Added': 1}
trusty-mpm       ## [1.2.0]   {'### Added': 1, '### Changed': 1, '### Fixed': 1}
trusty-review    ## [0.11.0]  {'### Changed': 1, '### Fixed': 1}
trusty-review    ## [0.10.1]  {'### Fixed': 1}
trusty-search    ## [0.40.0]  {'### Changed': 1, '### Fixed': 1}
trusty-memory    ## [0.21.3]  {'### Changed': 1, '### Fixed': 1}
trusty-analyze   ## [0.7.5]   {'### Changed': 1, '### Fixed': 1}
```

(Two duplicates I introduced on the first pass were caught by this check and merged before commit.)

## Gate

Run with the workspace exclusions CI itself uses (`ci.yml` excludes `trusty-mpm-gui`, `trusty-code-gui`, `trusty-agents-ui` — Tauri crates that need a prebuilt frontend; without it `cargo check --workspace` fails on a fresh clone regardless of this PR). No new `#[ignore]`, no cfg-gating, no exclusion added to buy green.

```
cargo check --workspace          -> CHECK_EXIT=0
cargo fmt --all -- --check       -> FMT_EXIT=0   (no diff output)
cargo clippy --all-targets -D warnings -> CLIPPY_EXIT=0
cargo test --workspace           -> 19062 passed; 1 failed; 90 ignored
scripts/check_line_cap.sh        -> 7 allowlisted, 0 violations — OK.
scripts/check_test_pointers.sh   -> 0 dangling pointers — OK.
```

The single failure is `trusty-search service::server::tests_components::patch_component_toggle_persists_to_toml` (a 500 from a registry TOML write). It is a local-sandbox flake, not a regression: it passes in isolation (`11 passed; 0 failed`), and this PR's entire `trusty-search` diff is 3 files — CHANGELOG, Cargo.toml, and one wildcard `match` arm in `service/ui.rs` — none of which touch the PATCH handler or persistence.

Two other tests flaked across earlier full-suite runs and are **proven pre-existing**: `trusty-agents tools::python_skill::execute_dispatches_to_python_and_parses_json` fails identically (`uv` temp-dir ENOENT) on an unmodified `origin/main` checkout, and `trusty-agents --test api_e2e` intermittently misses its hard 5s health budget when four `tagent` processes spawn under full-suite load. All three pass in isolation. CI on a dedicated runner is the authoritative check.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
