### PR TITLE
fix(trusty-mpm): correct two wrong instructions in bundled assets (index_id, ticket routing)

### DIFF
--- a/crates/trusty-code/src/assets/agents/ticketing.md
+++ b/crates/trusty-code/src/assets/agents/ticketing.md
@@ -13,9 +13,23 @@ Intelligent ticket management with MCP-first architecture and CLI fallbacks. Enf
 
 ## Integration Priority
 
-**Primary**: Use `mcp__mcp-ticketer__*` MCP tools when available.
+Pick the backend by what the project actually uses — check in this order and
+use the first that applies. All three are yours; you are granted the full tool
+set, so `gh` is available regardless of which MCP servers are configured.
 
-**Fallback**: Use `aitrackdown` CLI when MCP is not available:
+**1. Ticketing MCP**: Use `mcp__mcp-ticketer__*` tools when configured.
+
+**2. GitHub Issues**: When the project's tracker is GitHub (no ticketing MCP,
+a `gh`-authenticated repo — this is the common case), use `gh` directly:
+```bash
+gh issue create --title "Title" --body "Details" --assignee @me --label trusty-mpm
+gh issue edit 4069 --add-label bug --milestone "v1.1"
+gh issue list --search "search terms" --state all   # dedupe BEFORE creating
+gh issue comment 4069 --body "Progress: …"
+gh issue close 4069 --comment "Fixed by #4194"
+```
+
+**3. `aitrackdown` CLI**: When neither of the above is available:
 ```bash
 aitrackdown create issue "Title" --description "Details"
 aitrackdown create task "Title" --issue ISS-0001
@@ -25,9 +39,23 @@ aitrackdown status tasks
 
 ## Ticket Types
 
+On **GitHub**, the ticket is the issue number (`#4069`) and the type is carried
+by labels (`bug`, `enhancement`, `epic`); parent/child is expressed by task
+lists and `Closes #N` references rather than a distinct id namespace.
+
+On **mcp-ticketer / aitrackdown**:
+
 - **EP-XXXX**: Epics — major initiatives
 - **ISS-XXXX**: Issues — bugs, features, user requests
 - **TSK-XXXX**: Tasks — individual work items
+
+## Scope Boundary — Ticketing vs. Version Control
+
+You own issue/ticket **bookkeeping**: create, update, close, label, triage,
+comment, dedupe. You do NOT do git or PR mechanics — branch, push, rebase,
+conflict resolution, merge, release, tag — those belong to `version-control`.
+Opening or editing a PR *body* is bookkeeping and is yours; pushing or merging
+that PR is not.
 
 ## Scope Validation Protocol
 
@@ -60,7 +88,14 @@ Never enable auto-detection of labels when PM has provided tags.
 
 ## Workflow States
 
-Valid transitions: `open → in-progress → ready → tested → done`
+On **GitHub**, an issue is only ever `open` or `closed` — there is no
+intermediate state to transition through. Express progress with labels
+(`in-progress`, `blocked`) and comments, and close with a reason
+(`--comment "Fixed by #4194"`, or `gh issue close N --reason "not planned"`).
+Never leave an issue open as a status marker once its work has landed.
+
+On **mcp-ticketer / aitrackdown**, valid transitions are:
+`open → in-progress → ready → tested → done`
 
 Match states semantically to context:
 - Work started → `in-progress`

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -117,6 +117,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Bundled instructions no longer tell every agent to pass an `index_id` that
+  does not exist**: `BASE_PM.md` instructed "Always pass `index_id` = the
+  project directory name (e.g. `index_id: "trusty-mpm"`)", and the
+  `tm-tool-usage-guide` / `tm-circuit-breaker` skills repeated it in their
+  worked examples. No index is registered under a project *name*, so the call
+  returned `404 unknown index` every time — agents concluded code search was
+  broken and silently degraded to `grep`. It also defeated the fix it sat on
+  top of: the launcher already pins each session to its own index via
+  `trusty-search serve --index <id>` in `.mcp.json` precisely so a bare call
+  cannot reach the wrong project (issue #1373), and the tool schema documents
+  `index_id` as defaulting to that pinned index when omitted. All four sites
+  now instruct OMITTING `index_id`, and the misleading worked examples are
+  gone. Deliberately no id *format* is documented, so the guidance stays
+  correct however ids are derived. Because `BASE_PM.md` is the last,
+  non-overridable instruction layer, no project could correct this locally —
+  it affected every session on every project.
+
 - **The worktree reclaim path no longer force-deletes uncommitted work**
   ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091)): the
   orphaned-worktree sweep had no dirty-tree check anywhere — its entire safety

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -117,8 +117,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- **Bundled instructions no longer tell every agent to pass an `index_id` that
-  does not exist**: `BASE_PM.md` instructed "Always pass `index_id` = the
+- **Two wrong instructions corrected in the bundled assets composed into every
+  session's prompt.** Both were static text that no project could override, and
+  both had demonstrably misrouted live sessions.
+
+  *Code search.* Agents were told to pass an `index_id` that
+  does not exist: `BASE_PM.md` instructed "Always pass `index_id` = the
   project directory name (e.g. `index_id: "trusty-mpm"`)", and the
   `tm-tool-usage-guide` / `tm-circuit-breaker` skills repeated it in their
   worked examples. No index is registered under a project *name*, so the call
@@ -133,6 +137,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   correct however ids are derived. Because `BASE_PM.md` is the last,
   non-overridable instruction layer, no project could correct this locally —
   it affected every session on every project.
+
+  *Ticket routing.* Issue bookkeeping was routed to the `version-control`
+  agent instead of `ticketing`. `PM_INSTRUCTIONS.md` sent
+  `gh issue list/view/create/close` (prohibition P6) and all "ticket
+  references" to Version Control; `tm-bug-reporting` sent manual issue filing
+  there too; and `tm-ticketing` actively argued for the split, on the premise
+  that the `ticketing` agent only spoke `mcp-ticketer`/`aitrackdown` and so
+  could not touch GitHub. That premise is false — `ticketing` is granted the
+  full tool set and uses `gh` directly — so the rationale was stale, not a
+  competing design. One line is now drawn consistently across all four assets:
+  issue/ticket **bookkeeping** (create, update, close, label, triage, comment)
+  is `ticketing`; **git and PR mechanics** (branch, push, rebase, conflict
+  resolution, merge, release, tag) stay `version-control`; opening or editing
+  a PR *body* is bookkeeping, pushing or merging it is not. `P6` is split into
+  `P6` (issues → Ticketing) and `P7` (PRs/git → Version Control), and the
+  bundled `ticketing` agent now documents GitHub as a first-class backend
+  alongside the other two, with GitHub-native ids (`#4069`) and states
+  (open/closed). `AGENT_DELEGATION.md` carries the same defect and is
+  deliberately untouched here — its content diff is owned by the delegation
+  roster work, which replaces that section wholesale rather than hand-editing
+  it.
 
 - **The worktree reclaim path no longer force-deletes uncommitted work**
   ([#4091](https://github.com/bobmatnyc/trusty-tools/issues/4091)): the

--- a/crates/trusty-mpm/src/assets/agents/ticketing.md
+++ b/crates/trusty-mpm/src/assets/agents/ticketing.md
@@ -13,9 +13,23 @@ Intelligent ticket management with MCP-first architecture and CLI fallbacks. Enf
 
 ## Integration Priority
 
-**Primary**: Use `mcp__mcp-ticketer__*` MCP tools when available.
+Pick the backend by what the project actually uses — check in this order and
+use the first that applies. All three are yours; you are granted the full tool
+set, so `gh` is available regardless of which MCP servers are configured.
 
-**Fallback**: Use `aitrackdown` CLI when MCP is not available:
+**1. Ticketing MCP**: Use `mcp__mcp-ticketer__*` tools when configured.
+
+**2. GitHub Issues**: When the project's tracker is GitHub (no ticketing MCP,
+a `gh`-authenticated repo — this is the common case), use `gh` directly:
+```bash
+gh issue create --title "Title" --body "Details" --assignee @me --label trusty-mpm
+gh issue edit 4069 --add-label bug --milestone "v1.1"
+gh issue list --search "search terms" --state all   # dedupe BEFORE creating
+gh issue comment 4069 --body "Progress: …"
+gh issue close 4069 --comment "Fixed by #4194"
+```
+
+**3. `aitrackdown` CLI**: When neither of the above is available:
 ```bash
 aitrackdown create issue "Title" --description "Details"
 aitrackdown create task "Title" --issue ISS-0001
@@ -25,9 +39,23 @@ aitrackdown status tasks
 
 ## Ticket Types
 
+On **GitHub**, the ticket is the issue number (`#4069`) and the type is carried
+by labels (`bug`, `enhancement`, `epic`); parent/child is expressed by task
+lists and `Closes #N` references rather than a distinct id namespace.
+
+On **mcp-ticketer / aitrackdown**:
+
 - **EP-XXXX**: Epics — major initiatives
 - **ISS-XXXX**: Issues — bugs, features, user requests
 - **TSK-XXXX**: Tasks — individual work items
+
+## Scope Boundary — Ticketing vs. Version Control
+
+You own issue/ticket **bookkeeping**: create, update, close, label, triage,
+comment, dedupe. You do NOT do git or PR mechanics — branch, push, rebase,
+conflict resolution, merge, release, tag — those belong to `version-control`.
+Opening or editing a PR *body* is bookkeeping and is yours; pushing or merging
+that PR is not.
 
 ## Scope Validation Protocol
 
@@ -60,7 +88,14 @@ Never enable auto-detection of labels when PM has provided tags.
 
 ## Workflow States
 
-Valid transitions: `open → in-progress → ready → tested → done`
+On **GitHub**, an issue is only ever `open` or `closed` — there is no
+intermediate state to transition through. Express progress with labels
+(`in-progress`, `blocked`) and comments, and close with a reason
+(`--comment "Fixed by #4194"`, or `gh issue close N --reason "not planned"`).
+Never leave an issue open as a status marker once its work has landed.
+
+On **mcp-ticketer / aitrackdown**, valid transitions are:
+`open → in-progress → ready → tested → done`
 
 Match states semantically to context:
 - Work started → `in-progress`

--- a/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
+++ b/crates/trusty-mpm/src/assets/instructions/BASE_PM.md
@@ -78,7 +78,7 @@ You have native MCP access to trusty-search and trusty-memory. Always use these 
 - `mcp__trusty-memory__memory_note` — append a lightweight note to the palace
 
 ### Code/Architecture Search — use BEFORE grep/find
-- `mcp__trusty-search__search` — unified hybrid BM25+vector+KG search (replaces the legacy `search_code`); pass `index_id` matching the project name
+- `mcp__trusty-search__search` — unified hybrid BM25+vector+KG search (replaces the legacy `search_code`); omit `index_id` so it resolves to this session's pinned project index
 - `mcp__trusty-search__search_all` — cross-project search when scope is unclear
 - `mcp__trusty-search__search_similar` — find semantically similar code
 - `mcp__trusty-search__search_health` — verify daemon is live (NOT curl/lsof)
@@ -89,7 +89,7 @@ You have native MCP access to trusty-search and trusty-memory. Always use these 
 - If key is `mcp-vector-search` (legacy) → `mcp__mcp-vector-search__*`
 - Check `.mcp.json` first if uncertain.
 
-**Always pass `index_id`** = the project directory name (e.g. `index_id: "trusty-mpm"`, `index_id: "aipowerranking"`).
+**Omit `index_id`** — your `.mcp.json` pins this session to its own project index, so a bare call already resolves to the right one (issue #1373). A guessed id fails with `404 unknown index`. Pass `index_id` only to target a *different* index, using an id from `list_indexes`.
 
 ### Service health checks — MCP only, never bash
 - trusty-search alive: `mcp__trusty-search__search_health`

--- a/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
+++ b/crates/trusty-mpm/src/assets/instructions/PM_INSTRUCTIONS.md
@@ -19,7 +19,8 @@ All other sections reference this table. Violation = Circuit Breaker triggered.
 | P3 | `curl`,`wget`,`lsof`,`netstat`,`ps`,`pm2`,`docker ps` | Local Ops / QA | 7 |
 | P4 | `make` (any target), `pytest`, `npm test`, `uv run pytest` | Local Ops / QA / Engineer | 7 |
 | P5 | `sed`,`awk`,`patch`,`git apply`, pipe to file | Engineer | 14 |
-| P6 | `gh issue list/view/create/close`, `gh pr view/list/diff/review` | Version Control | 6 |
+| P6 | `gh issue list/view/create/close/edit`, issue labels/comments/triage | Ticketing | 6 |
+| P7 | `gh pr view/list/diff/review`, branch/push/rebase/merge/tag | Version Control | 6 |
 | P8 | `mcp__chrome-devtools__*`, `mcp__claude-in-chrome__*`, `mcp__playwright__*` | Web QA | 6 |
 | P9 | `rm`,`rmdir` on project files | Local Ops | 7 |
 | P10 | Any non-git Bash command | Appropriate agent | 1/7 |
@@ -31,7 +32,7 @@ allows up to 3 combined P1+P5 file changes per turn before hard-blocking, not a
 single-call absolute prohibition. This is enforced by the hook itself, not a
 license to plan around it — still delegate by default; the budget exists so a
 trivial one-line fix doesn't force a full Task/Agent round-trip, not as routine
-headroom. All OTHER prohibitions (P2–P4, P6, P8–P11) remain absolute, no budget.
+headroom. All OTHER prohibitions (P2–P4, P6–P11) remain absolute, no budget.
 
 ## PM Allowlist (strict -- nothing else)
 
@@ -367,7 +368,11 @@ the required wording.
 
 ## Ticketing Integration
 
-Ticket references → delegate to Version Control agent. No direct ticket tool access.
+Ticket/issue **bookkeeping** — create, update, close, label, triage, comment —
+→ delegate to the **Ticketing** agent. **Git and PR mechanics** — branch, push,
+rebase, resolve conflicts, merge, release, tag — → delegate to **Version
+Control**. Opening or editing a PR *body* is bookkeeping; pushing or merging
+that PR is version control. No direct ticket tool access either way.
 
 ## Documentation Routing
 

--- a/crates/trusty-mpm/src/assets/skills/tm-bug-reporting.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-bug-reporting.md
@@ -57,7 +57,7 @@ user's behalf.
 Some bugs (a skill's documented command no longer exists, a stale path in an
 instruction file, a UX gap the user reports directly) have no corresponding
 daemon-captured error event — `list_recent_errors` will not surface them.
-For these, delegate to the **Version Control** agent to file a `gh issue
+For these, delegate to the **Ticketing** agent to file a `gh issue
 create` against `bobmatnyc/trusty-tools` directly, using the same
 information standard below (title, labels, structured body). Apply the shipped
 issue defaults — `--assignee @me --label trusty-mpm --label ws/<session-name>`

--- a/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
@@ -90,7 +90,7 @@ PM: Grep("<symbol>", path="src/")                      # investigation
 
 **Correct:**
 ```
-PM: mcp__trusty-search__search(query="<what to find>", index_id="<project>")
+PM: mcp__trusty-search__search(query="<what to find>")
 PM: *delegates to Research if results are insufficient*
 Research: reads/greps as needed, returns findings
 PM: uses findings to write a grounded Engineer delegation

--- a/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-ticketing.md
@@ -21,17 +21,25 @@ has this real priority order — verified against the agent source, not
 assumed:
 
 1. **Primary**: `mcp__mcp-ticketer__*` MCP tools, when configured.
-2. **Fallback**: `aitrackdown` CLI (`aitrackdown create issue/task`,
-   `aitrackdown transition`, `aitrackdown status tasks`) when no ticketing
-   MCP server is available.
+2. **GitHub Issues**: `gh issue create/edit/view/list/close` (or
+   `mcp__github__*`) when the project's tracker is GitHub — as it is for this
+   repo (see root `CLAUDE.md`): spec → issue → worktree branch → PR →
+   trusty-review gate → squash-merge.
+3. **Fallback**: `aitrackdown` CLI (`aitrackdown create issue/task`,
+   `aitrackdown transition`, `aitrackdown status tasks`) when neither of the
+   above is available.
 
-Separately, this repo's own convention (see root `CLAUDE.md`) defaults to
-**GitHub Issues** for the actual delivery chain: spec → issue → worktree
-branch → PR → trusty-review gate → squash-merge. When no dedicated ticketing
-MCP is configured, route GitHub issue operations to the **Version Control**
-agent (`gh issue create/view/list`, or `mcp__github__*` tools), not the
-`ticketing` agent's `mcp-ticketer`/`aitrackdown` path — they serve different
-scopes (external ticket-tracker vs. this repo's own GitHub issues).
+All three are the `ticketing` agent's paths — it is granted the full tool set,
+so `gh` is available to it whichever backend a project uses. Route **GitHub
+issue operations to `ticketing`**, not to Version Control. (Earlier revisions
+of this skill said the opposite, on the theory that `ticketing` only spoke
+`mcp-ticketer`/`aitrackdown` and so could not touch GitHub. That is no longer
+true and the split it created is retired.)
+
+**Version Control keeps git and PR mechanics** — branch, push, rebase,
+conflict resolution, merge, release, tag. The dividing line is bookkeeping
+vs. mechanics, not GitHub vs. external tracker: opening or editing a PR
+*body* is bookkeeping; pushing or merging that PR is version control.
 
 For lightweight, session-local task tracking that isn't a formal ticket at
 all, use `mcp__trusty-memory__task_add` / `task_list` / `task_complete`
@@ -57,7 +65,7 @@ PM: [presents results]
 ## Ask Before Creating
 
 If the user references a ticket/issue but no matching one is found:
-ticketing (or Version Control, for GitHub issues) MUST NOT auto-create.
+ticketing MUST NOT auto-create.
 Ask: "I didn't find an existing issue for [topic]. Create one, or did you
 mean a different one?" Auto-create only on explicit "create a
 ticket/issue for X."

--- a/crates/trusty-mpm/src/assets/skills/tm-tool-usage-guide.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-tool-usage-guide.md
@@ -46,8 +46,8 @@ Before delegating to Research or reading any file:
 1. `mcp__trusty-memory__memory_recall` (or `memory_recall_deep` for a
    cross-palace sweep) — check what is already known.
 2. `mcp__trusty-search__search` (hybrid BM25+vector) or `search_semantic` /
-   `search_lexical` — pass `index_id` matching the project name (e.g.
-   `trusty-mpm`, `trusty-tools`). Use `search_all` when the scope spans
+   `search_lexical` — omit `index_id`; it defaults to this session's pinned
+   project index. Use `search_all` when the scope spans
    multiple indexed projects, `search_similar` to find analogous code, and
    `list_indexes` to discover what is indexed.
 3. Only if both are insufficient — delegate to Research.
@@ -70,7 +70,7 @@ is CB#2 / CB#10 in `tm-circuit-breaker`.
 
 **Example:**
 ```
-mcp__trusty-search__search(query="skill deploy no-op", index_id="trusty-mpm", limit=5)
+mcp__trusty-search__search(query="skill deploy no-op", limit=5)
 ```
 
 **Index Pinning (Automatic):** In managed sessions, your `.mcp.json` pinpoints


### PR DESCRIPTION
Two independent defects in the bundled instruction assets composed into every session's prompt. Both are static text no project could override, and both had demonstrably misrouted live sessions. Assets only — no behaviour change, no `Cargo.lock` churn.

---

# Fix 1 — code search: an `index_id` that always 404s

Three assets told agents to pass `index_id` as the project/directory name:

- `assets/instructions/BASE_PM.md:81, :92` — *"Always pass `index_id` = the project directory name (e.g. `index_id: "trusty-mpm"`, `index_id: "aipowerranking"`)"*
- `assets/skills/tm-tool-usage-guide.md:49, :73`
- `assets/skills/tm-circuit-breaker.md:93`

**That call always fails.** Reproduced live from a managed session:

```
mcp__trusty-search__search(query=..., index_id="trusty-tools")
-> 404 {"error":"unknown index: trusty-tools"}
```

`list_indexes` confirms no index is registered under a project *name* for this repo, and no named alias exists alongside the real id.

### Why it is worse than a broken example

`core/session_launch/search_index.rs:40-54` already pins each session to its own index by writing `["serve", "--index", <id>]` into `.mcp.json`. Its own doc comment (lines 26-34) says that pinning exists *because* the contextless stub "left index selection to the LLM, which routinely queried the WRONG index" — issue #1373. The tool schema agrees:

> `index_id` — *"Target index id. Defaults to this session's pinned project index when omitted."*

So the instruction told every agent to override a correct default with a guess. Observed failure mode: 404 → agent concludes code search is broken → silently degrades to `grep`, which is CB#2 / CB#10 in `tm-circuit-breaker` — a circuit breaker the same skill file was mis-teaching.

`tm-tool-usage-guide.md` was already self-contradictory: line 49 said pass `index_id`, while its own "Index Pinning (Automatic)" section 27 lines later says bare `search` calls resolve correctly.

### The fix

All five sites now instruct **omitting** `index_id`; the misleading worked examples are gone. **No id format is documented**, deliberately — pending work would derive ids from git org/repo rather than the current basename scheme, and "omit it, let the session pin resolve" is correct under both.

---

# Fix 2 — ticket routing: issue bookkeeping sent to `version-control`

Four assets routed GitHub issue work to the `version-control` agent instead of `ticketing`:

- `assets/instructions/PM_INSTRUCTIONS.md:22` — prohibition **P6** listed `gh issue list/view/create/close` together with `gh pr ...` under Version Control
- `assets/instructions/PM_INSTRUCTIONS.md:370` — *"Ticket references → delegate to Version Control agent"*
- `assets/skills/tm-bug-reporting.md:60` — manual issue filing → Version Control
- `assets/skills/tm-ticketing.md:28-34` — actively **argued for** the split

`tm-ticketing`'s rationale was that the `ticketing` agent only spoke `mcp-ticketer`/`aitrackdown` and so "could not touch GitHub — they serve different scopes."

**That premise is false.** The `ticketing` agent is granted the full tool set, so `gh` is available to it regardless of which MCP servers are configured. It filed every issue in this repo tonight — #4176, #4179, #4181, #4195, and epic #4183 with all ten children (#4184–#4193) — via `gh issue create/edit/list/close`, including label/assignee ops and a duplicate-close. So the rationale is stale documentation, not a competing design, and is retired rather than honored.

### The line, drawn consistently

- **Bookkeeping → `ticketing`**: create, update, close, label, triage, comment, dedupe.
- **Git and PR mechanics → `version-control`**: branch, push, rebase, resolve conflicts, merge, release, tag.
- Opening or editing a PR *body* is bookkeeping; pushing or merging that PR is not.

`P6` is split into `P6` (issues → Ticketing) and `P7` (PRs/git → Version Control), taking the previously-unused P7 slot; the `P2–P4, P6, P8–P11` enumeration at line 34 is updated to `P2–P4, P6–P11` to match. The bundled `ticketing` agent now documents GitHub as a first-class backend alongside the other two, with GitHub-native ids (`#4069`) and states (open/closed) — the `mcp-ticketer`/`aitrackdown` paths are kept, since they are the configured path in other projects.

### `AGENT_DELEGATION.md` is deliberately untouched

It carries the same defect (`:59` routes "ticket", "issue", "PR" → Version Control and never names `ticketing`; `:18` has no ticketing row). It is **not** fixed here: that content diff is owned by the delegation-roster work, whose acceptance criteria already require `ticketing` to appear in the delivered prompt and which regenerates the section from the project manifest rather than hand-editing the static asset. Two changes must not write competing versions of that section.

---

## Verification

No test asserts on any changed string, so no test update was required. (`BASE_PM.md` and `PM_INSTRUCTIONS.md` are `include_str!`-compiled via `core/bundle.rs` / `core/instruction_pipeline.rs:69`, but nothing asserts the changed text.)

```
scripts/check_line_cap.sh   line-cap: 7 allowlisted, 0 violations — OK.   (exit 0)
cargo fmt --all -- --check                              FMT_EXIT=0
cargo check -p trusty-mpm     Finished `dev` profile in 12.31s            (exit 0)
cargo clippy --all-targets -- -D warnings
                              Finished `dev` profile in 31.01s            (exit 0)
cargo test -p trusty-mpm                                TEST_EXIT=0
    test result: ok. 3722 passed; 0 failed; 6 ignored
    test result: ok. 1256 passed; 0 failed; 1 ignored
    test result: ok. 1256 passed; 0 failed; 1 ignored
    (+ 27 further test binaries, every one ok, 0 failed)
```

`Cargo.lock` untouched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
