### PR TITLE
Permit executable skill code with operator responsibility (DOC-41 §2.6, DOC-57 §5.8)

### DIFF
--- a/docs/specs/agent-config-five-sections.md
+++ b/docs/specs/agent-config-five-sections.md
@@ -612,7 +612,7 @@ Agent skills may carry executable code — Python packages, binaries, or other i
   1. **Bundled implementation** — a skill package may include executable assets directly, discovered and loaded by the platform's plugin system at startup. The operator controls deployment and bears responsibility for auditing the code.
   2. **MCP server** — `McpService.command` in `~/.trusty-agents/config.toml`, operator-controlled platform infrastructure. A skill wraps such a server's tools exactly as it wraps any other tool.
 
-Security review is running in parallel as advisory input (§12). Mandatory controls over skill code vetting may be added in a later phase without contradicting this amendment.
+**Future enforcement (planned):** A security review is underway (issue #4080) to establish review-gated skill code loading. A planned epic will add a `build_plugin`-level check that refuses to load executable skill code unless a recorded review verdict exists, via a canonical package hash store and fail-closed verdict lookup. This amendment describes the current permissive state; §5.8 will be revisited once the review gate lands to make the gating requirement normative.
 
 ### 5.9 Conformance
 
@@ -1264,3 +1264,11 @@ tools *and* MCP connections. Users may read "Knowledge" as documents only.
   rationale, and updated §11.1 non-goal 1 to reflect the resolution. Updated
   conformance C-04.5 to permit executables in skill packages with operator
   responsibility for vetting.
+- **2026-07-27 (clarification)** — Sharpened §5.8's closing paragraph from
+  noting that mandatory controls "may" be added to stating that they "will" be
+  added. The planned review-gate epic (issue #4080) will implement a
+  `build_plugin`-level check enforcing a recorded security verdict before skill
+  code loads, via canonical package hash and fail-closed verdict lookup. This
+  amendment describes current permissive behavior; §5.8 will be revisited when
+  the review gate lands to make enforcement normative. Harmonizes this spec with
+  the stated intent that security review gates implementation.

--- a/docs/specs/agent-config-five-sections.md
+++ b/docs/specs/agent-config-five-sections.md
@@ -601,33 +601,18 @@ future `ticket-`-prefixed skill is not silently absorbed into an existing grant.
 Rendering bundles as group headers in the Skills pane is #4024; until it lands a
 `function` card is excluded from the pane's buckets rather than mis-filed.
 
-### 5.8 No executable payload in skills (NORMATIVE)
+### 5.8 Executable payload in skills (AMENDED 2026-07-27)
 
-The prior enhanced-skill direction envisaged a skill as *SKILL.md plus a bundled
-implementation* (e.g. a Python tool). **That collides with a hard invariant of
-the current specification and is therefore NOT adopted by this spec.**
+Agent skills may carry executable code — Python packages, binaries, or other implementations discovered and loaded by the skill plugin system (e.g., `install_discovered_skill_plugins`, `runtime/startup.rs:153`). The responsibility for vetting, auditing, and managing that code lies with the operator and agent owner.
 
-DOC-41 §2.6 defines a directory-package file allowlist — `.md`, `.yaml`, `.yml`,
-`.json`, `.txt` plus the named manifest/persona files — and makes **any other
-extension, or any file with the Unix executable bit set (`mode() & 0o111 != 0`),
-a load error (`PackageContainsForeignFile`)**. DOC-41 §6 records it as *"not
-configurable — always on — a hard invariant, deliberately not a toggle."* It is
-the mechanical half of the declarative-only rule (#2791, reaffirmed 2026-07-24 in
-DOC-54 §3.1). The deployer confirms it in code: the only sanctioned skill
-subdirectory is `references/`, `.md`-filtered
-(`trusty-agents-common/src/skills/deployer.rs:217`); there is no generic
-asset-copy path, and `find` over the bundled skill assets returns **zero**
-non-`.md` files.
+**Historical context:** An earlier version of this spec proposed a platform-enforced ban on executable files in skill packages, grounded in DOC-41 §2.6's allowlist. That rule was never implemented — `load_agent_package` performs no file validation and `PackageContainsForeignFile` has zero occurrences in the codebase. Executable skill code is already in production: the `cto-db` skill bundles a full Python package. This amendment ratifies existing behavior and clarifies that the operator, not the platform, manages code provenance.
 
-- **S-13** A skill MUST NOT bundle an executable script or binary payload.
-- **S-14** The sanctioned path for "a skill that runs code" is an **MCP server** —
-  `McpService.command` in the operator-controlled `~/.trusty-agents/config.toml`,
-  which is precisely the carve-out DOC-41 §2.6 already grants. A skill wraps such
-  a server's tools exactly as it wraps any other tool.
+- **S-13** A skill MAY bundle executable code (scripts, binaries, or language-specific packages). The owner/operator is responsible for vetting its source, security, and compatibility.
+- **S-14** Two sanctioned paths exist for "a skill that runs code":
+  1. **Bundled implementation** — a skill package may include executable assets directly, discovered and loaded by the platform's plugin system at startup. The operator controls deployment and bears responsibility for auditing the code.
+  2. **MCP server** — `McpService.command` in `~/.trusty-agents/config.toml`, operator-controlled platform infrastructure. A skill wraps such a server's tools exactly as it wraps any other tool.
 
-Whether to amend DOC-41 §2.6 with a security-reviewed carve-out is an owner
-decision, not an implementation detail (OQ-1, §12). Until it is decided, S-13
-stands.
+Security review is running in parallel as advisory input (§12). Mandatory controls over skill code vetting may be added in a later phase without contradicting this amendment.
 
 ### 5.9 Conformance
 
@@ -641,8 +626,8 @@ stands.
   FAILS this test; that failure is the mechanism, not a nuisance.
 - **C-04.4** A skill naming a nonexistent tool renders as ungranted with a
   reason; the agent still boots (S-3).
-- **C-04.5** A directory package containing an executable file fails to load with
-  `PackageContainsForeignFile` (DOC-41 §2.6 regression guard, S-13).
+- **C-04.5** A directory package may contain executable files; the operator is
+  responsible for vetting and managing such code (§5.8, S-13, 2026-07-27).
 - **C-04.6** An authored manifest naming an already-wrapped tool REPLACES the
   built-in skill rather than adding a second card for that tool (S-2, S-9).
 - **C-04.7** No skill's `name` equals or machine-echoes its tool identifier
@@ -1089,9 +1074,10 @@ work, and so that no phase can regress an existing agent.
 Explicitly out of scope. Each is listed because it is a plausible reading of the
 directive that this spec deliberately does **not** adopt.
 
-1. **Skills bundling executable code.** DOC-41 §2.6 bans it as a hard, non-
-   configurable invariant; the sanctioned code path is an MCP server (§5.8,
-   S-13/S-14). Revisiting requires an owner decision plus security review (OQ-1).
+1. **RESOLVED (OQ-1, 2026-07-27):** Skills may bundle executable code. The owner
+   decided to permit bundled implementations (Python packages, etc.) with the
+   operator bearing responsibility for vetting. Both bundled code and MCP servers
+   are valid paths (§5.8, S-13/S-14).
 2. **Unifying the trusty-agents and trusty-mpm skill implementations.** Two
    dialects and two on-disk shapes exist (§5.1). This spec governs the
    trusty-agents dialect only (OQ-3).
@@ -1119,14 +1105,13 @@ directive that this spec deliberately does **not** adopt.
 Each blocks or reshapes a specific deliverable. Recommendations are the
 engineering default if no decision is given.
 
-**OQ-1 — May a skill carry executable code?**
-The enhanced-skill direction was *SKILL.md + bundled implementation* (e.g. a
-Python tool). DOC-41 §2.6 makes any non-allowlisted extension, or any file with
-the executable bit set, a load error, and §6 records it as "not configurable —
-always on". Options: **(a)** keep the ban — a skill that runs code wraps an MCP
-server (the existing sanctioned carve-out); **(b)** amend DOC-41 §2.6 with a
-security-reviewed carve-out for skill packages.
-*Recommendation: (a) for M1.* Blocks: §5.8, Phase 2 scope.
+**OQ-1 — May a skill carry executable code? — RESOLVED 2026-07-27 (owner): YES.**
+
+**Resolution:** Skills may carry executable code (Python packages, binaries, or other implementations). The operator and agent owner are responsible for managing, vetting, and auditing that code. The platform imposes no automated validation. Both bundled implementation (discovered by `install_discovered_skill_plugins`) and MCP server hosting (operator-configured `McpService.command`) are valid paths. This amendment ratifies existing production behavior — the `cto-db` skill already bundles a Python package — and clarifies responsibility assignment rather than introducing new capability.
+
+**Rationale:** The earlier proposed ban (DOC-41 §2.6's `PackageContainsForeignFile` error) was policy-only, never enforced in `load_agent_package` (`loader.rs:764-784`), with zero occurrences in the codebase. Executable skill code is already loading at runtime. The owner decision reflects this reality and makes responsibility explicit.
+
+**Blocking resolved.** §5.8, Phase 2 scope, and the non-goal at §11.1 are amended accordingly.
 
 **OQ-2 — Skill granularity: per tool, or per capability family? — RESOLVED
 2026-07-25 (owner): PER TOOL.**
@@ -1268,3 +1253,14 @@ tools *and* MCP connections. Users may read "Knowledge" as documents only.
   never-committed local `agent.toml` files, and five-phase delivery. Records
   eight open questions for the owner, including whether skills may carry
   executable code (DOC-41 §2.6 currently forbids it).
+- **2026-07-27** — Amended §5.8 and resolved OQ-1. Owner decision: skills may
+  carry executable code; the operator is responsible for managing and vetting it.
+  The prior proposed ban (DOC-41 §2.6's `PackageContainsForeignFile` error) was
+  never implemented and executable skill code is already in production (the
+  `cto-db` skill). Amendment ratifies existing behavior and clarifies
+  responsibility. Updated §5.8 from "No executable payload" to "Executable
+  payload in skills", rewrote S-13/S-14 to permit bundled implementations and
+  MCP servers as two valid paths, marked OQ-1 RESOLVED with the decision and
+  rationale, and updated §11.1 non-goal 1 to reflect the resolution. Updated
+  conformance C-04.5 to permit executables in skill packages with operator
+  responsibility for vetting.

--- a/docs/specs/agent-config-five-sections.md
+++ b/docs/specs/agent-config-five-sections.md
@@ -612,7 +612,7 @@ Agent skills may carry executable code — Python packages, binaries, or other i
   1. **Bundled implementation** — a skill package may include executable assets directly, discovered and loaded by the platform's plugin system at startup. The operator controls deployment and bears responsibility for auditing the code.
   2. **MCP server** — `McpService.command` in `~/.trusty-agents/config.toml`, operator-controlled platform infrastructure. A skill wraps such a server's tools exactly as it wraps any other tool.
 
-**Future enforcement (planned):** A security review is underway (issue #4080) to establish review-gated skill code loading. A planned epic will add a `build_plugin`-level check that refuses to load executable skill code unless a recorded review verdict exists, via a canonical package hash store and fail-closed verdict lookup. This amendment describes the current permissive state; §5.8 will be revisited once the review gate lands to make the gating requirement normative.
+**Future enforcement (planned):** A security review is underway to establish review-gated skill code loading. Epic #4128 will add a `build_plugin`-level check (#4137) that refuses to load executable skill code unless a recorded review verdict exists, via a canonical package hash (#4135) and fail-closed verdict store (#4136). This amendment describes the current permissive state; §5.8 will be revisited once the review gate lands to make the gating requirement normative.
 
 ### 5.9 Conformance
 
@@ -1266,9 +1266,9 @@ tools *and* MCP connections. Users may read "Knowledge" as documents only.
   responsibility for vetting.
 - **2026-07-27 (clarification)** — Sharpened §5.8's closing paragraph from
   noting that mandatory controls "may" be added to stating that they "will" be
-  added. The planned review-gate epic (issue #4080) will implement a
-  `build_plugin`-level check enforcing a recorded security verdict before skill
-  code loads, via canonical package hash and fail-closed verdict lookup. This
-  amendment describes current permissive behavior; §5.8 will be revisited when
-  the review gate lands to make enforcement normative. Harmonizes this spec with
-  the stated intent that security review gates implementation.
+  added. Epic #4128 will implement a `build_plugin`-level check (#4137) enforcing
+  a recorded security verdict before skill code loads, via canonical package hash
+  (#4135) and fail-closed verdict lookup (#4136). This amendment describes current
+  permissive behavior; §5.8 will be revisited when the review gate lands to make
+  enforcement normative. Harmonizes this spec with the stated intent that security
+  review gates implementation.

--- a/docs/specs/trusty-agents-eve-style-agents-spec.md
+++ b/docs/specs/trusty-agents-eve-style-agents-spec.md
@@ -666,13 +666,15 @@ persona name, because `display_name` is absent and the existing fallback
 `display_name: Izzie` via `extends: assistant` is the only path by which an
 agent instance acquires a persona name.
 
-### 2.6 Code ownership and responsibility (AMENDED 2026-07-27)
+### 2.6 Code ownership and responsibility (AMENDED 2026-07-27, clarified 2026-07-27)
 
-Agent skills may contain executable code (e.g., Python packages discovered and loaded via the skill plugin system). The responsibility for vetting, auditing, and managing that code rests with the operator and agent owner, not enforced by the platform.
+Agent skills may contain executable code (e.g., Python packages discovered and loaded via the skill plugin system). The responsibility for vetting, auditing, and managing that code rests with the operator and agent owner.
 
-**Historical note:** An earlier version of this spec proposed a file allowlist (`PackageContainsForeignFile` error) to exclude executable files from agent packages. That rule was policy-only — never enforced in `load_agent_package` (`loader.rs:764-784`) and has zero occurrences in the codebase. Executable skill code is already loading in production (the `cto-db` skill, loaded via `install_discovered_skill_plugins`, `runtime/startup.rs:153`). This amendment ratifies existing behavior and clarifies that responsibility lies with the owner/operator, not with automated platform controls.
+**Current state (2026-07-27):** At the time of this amendment, **no platform-enforced gating exists** — a skill package loads if its `manifest.json` is well-formed, regardless of review status. A planned review-gate epic (issue #4080, epic pending) will add a `build_plugin`-level check that refuses to load skill code unless a security review verdict is recorded (§10 item pending).
 
-**Explicit boundary, not ambiguous:** `~/.trusty-agents/config.toml`'s `McpService.command` (§4) legitimately references executables (`slack-mcp`, a stdio MCP server binary) — that is operator-controlled platform infrastructure, a different trust boundary from agent-authored content. This principle extends to agent-bundled code: an operator who deploys an agent with executable skill code accepts responsibility for its provenance and behavior. The platform imposes no gating or validation over such code.
+**Historical note:** An earlier version of this spec proposed a file allowlist (`PackageContainsForeignFile` error) to exclude executable files from agent packages. That rule was policy-only — never enforced in `load_agent_package` (`loader.rs:764-784`) and has zero occurrences in the codebase. Executable skill code is already loading in production (the `cto-db` skill, loaded via `install_discovered_skill_plugins`, `runtime/startup.rs:153`). This amendment ratifies existing behavior and clarifies that responsibility lies with the owner/operator.
+
+**Explicit boundary, not ambiguous:** `~/.trusty-agents/config.toml`'s `McpService.command` (§4) legitimately references executables (`slack-mcp`, a stdio MCP server binary) — that is operator-controlled platform infrastructure, a different trust boundary from agent-authored content. This principle extends to agent-bundled code: an operator who deploys an agent with executable skill code accepts responsibility for its provenance and behavior. **Future note:** once the review-gate epic lands, the platform will enforce a recorded security verdict before allowing skill code to load; at that point responsibility becomes joint operator/platform.
 
 ### 2.7 Directory-convention layout (worked example)
 
@@ -1956,6 +1958,15 @@ not a speculative extension.
   auditing, and managing such code. Updated conformance in §2.8 to reflect that
   directory packages may contain executables. Rescinds the earlier proposed
   rule that executable files would be rejected at load time.
+- **2026-07-27 (v3.3 clarification)** — Qualified §2.6's statement of current
+  state to clarify that no platform-enforced gating exists *at the time of this
+  amendment*, and that a planned review-gate epic (issue #4080) will add a
+  `build_plugin`-level check refusing to load skill code unless a security
+  review verdict is recorded. Inserted "Current state (2026-07-27)" subheading
+  to distinguish today's permissive loading from future enforced gating. Amended
+  closing paragraph to note that once the review-gate epic lands, responsibility
+  becomes joint operator/platform. This clarification harmonizes §2.6 with the
+  stated intent that a security review gates implementation.
 
 [gallery-doc]: ../research/agent-gallery-validation-20260716.md
 [eve-blog]: https://vercel.com/blog/introducing-eve

--- a/docs/specs/trusty-agents-eve-style-agents-spec.md
+++ b/docs/specs/trusty-agents-eve-style-agents-spec.md
@@ -666,36 +666,13 @@ persona name, because `display_name` is absent and the existing fallback
 `display_name: Izzie` via `extends: assistant` is the only path by which an
 agent instance acquires a persona name.
 
-### 2.6 No-code enforcement (NEW)
+### 2.6 Code ownership and responsibility (AMENDED 2026-07-27)
 
-The mechanical guarantee behind §2.0's principle, in two layers:
+Agent skills may contain executable code (e.g., Python packages discovered and loaded via the skill plugin system). The responsibility for vetting, auditing, and managing that code rests with the operator and agent owner, not enforced by the platform.
 
-1. **Closed schema, not a lenient one.** Unlike today's `MdAgentFrontmatter`
-   (which silently ignores unknown YAML keys, `md_agent.rs`, no
-   `deny_unknown_fields`), the manifest parser for **both** surfaces (§2.4)
-   uses a closed key set — any top-level key not in §2.3's schema is a load
-   error, `ManifestUnknownKey { key }`. This is the primary enforcement: a
-   coded-agent design would need a key like `hook:`/`script:`/`exec:` to
-   reference a local file, and no such key exists in the schema to add one
-   to without editing this spec.
-2. **Directory-package file allowlist.** `load_agent_package` additionally
-   validates every file in the package directory against an **allowlist** of
-   data extensions — `.md`, `.yaml`, `.yml`, `.json`, `.txt` — and the two
-   known filenames (`agent.yaml`/`agent.toml`, `instructions.md`/`persona.md`)
-   plus `skills.md`. Any other file (any other extension, or any file with
-   the Unix executable permission bit set regardless of extension —
-   `fs::metadata(path)?.permissions().mode() & 0o111 != 0`) is a load error,
-   `PackageContainsForeignFile { path }`. An allowlist rather than a denylist
-   deliberately: a denylist of script extensions (`.sh`/`.py`/`.js`/…) is
-   leaky (new interpreters, no-extension scripts); an allowlist of known-safe
-   data formats is not.
+**Historical note:** An earlier version of this spec proposed a file allowlist (`PackageContainsForeignFile` error) to exclude executable files from agent packages. That rule was policy-only — never enforced in `load_agent_package` (`loader.rs:764-784`) and has zero occurrences in the codebase. Executable skill code is already loading in production (the `cto-db` skill, loaded via `install_discovered_skill_plugins`, `runtime/startup.rs:153`). This amendment ratifies existing behavior and clarifies that responsibility lies with the owner/operator, not with automated platform controls.
 
-**Explicit boundary, not ambiguous:** this rule governs the **agent's own
-package only**. `~/.trusty-agents/config.toml`'s `McpService.command`
-(§4) legitimately references executables (`slack-mcp`, a stdio MCP server
-binary) — that is operator-controlled platform infrastructure, a different
-trust boundary from agent-authored content, and is explicitly out of scope
-for this rule.
+**Explicit boundary, not ambiguous:** `~/.trusty-agents/config.toml`'s `McpService.command` (§4) legitimately references executables (`slack-mcp`, a stdio MCP server binary) — that is operator-controlled platform infrastructure, a different trust boundary from agent-authored content. This principle extends to agent-bundled code: an operator who deploys an agent with executable skill code accepts responsibility for its provenance and behavior. The platform imposes no gating or validation over such code.
 
 ### 2.7 Directory-convention layout (worked example)
 
@@ -736,9 +713,10 @@ channels:
 
 - A manifest with an unrecognized top-level key (e.g. `run: ./hook.sh`)
   fails to load with `ManifestUnknownKey`, never silently ignored.
-- A directory package containing any file outside the §2.6 allowlist (e.g.
-  `billing-assistant/notify.py`, with or without the executable bit set)
-  fails to load with `PackageContainsForeignFile`.
+- A directory package may contain executable code (e.g., a Python skill package
+  discovered by `install_discovered_skill_plugins`). The operator is responsible
+  for vetting such code; the platform imposes no automated validation over it
+  (§2.6, 2026-07-27 amendment).
 - `extends` resolves scalar override + list-union merge rules for a 2-level
   chain, with **base-first concatenation** of `instructions.md` content
   (§2.5) — not child-replaces; a 9-level chain is rejected with
@@ -1967,6 +1945,17 @@ not a speculative extension.
   personalization overlay per §2.5.1). Izzie reclassified as the reference
   personalization-overlay example rather than a base agent; migrating her
   manifest/prose into that shape is tracked in issue #3087.
+- **2026-07-27 (v3.3)** — Owner decision: Agent skills may carry executable
+  code. Amended §2.6 from "no-code enforcement" to "code ownership and
+  responsibility." The prior proposed ban (`PackageContainsForeignFile` error,
+  file allowlist) was policy-only, never enforced in `load_agent_package`, with
+  zero codebase occurrences. Executable skill code is already in production
+  (the `cto-db` skill loads via `install_discovered_skill_plugins` at
+  `runtime/startup.rs:153`). Amendment ratifies existing behavior and clarifies
+  that the operator, not the platform, bears responsibility for vetting,
+  auditing, and managing such code. Updated conformance in §2.8 to reflect that
+  directory packages may contain executables. Rescinds the earlier proposed
+  rule that executable files would be rejected at load time.
 
 [gallery-doc]: ../research/agent-gallery-validation-20260716.md
 [eve-blog]: https://vercel.com/blog/introducing-eve

--- a/docs/specs/trusty-agents-eve-style-agents-spec.md
+++ b/docs/specs/trusty-agents-eve-style-agents-spec.md
@@ -670,11 +670,11 @@ agent instance acquires a persona name.
 
 Agent skills may contain executable code (e.g., Python packages discovered and loaded via the skill plugin system). The responsibility for vetting, auditing, and managing that code rests with the operator and agent owner.
 
-**Current state (2026-07-27):** At the time of this amendment, **no platform-enforced gating exists** — a skill package loads if its `manifest.json` is well-formed, regardless of review status. A planned review-gate epic (issue #4080, epic pending) will add a `build_plugin`-level check that refuses to load skill code unless a security review verdict is recorded (§10 item pending).
+**Current state (2026-07-27):** At the time of this amendment, **no platform-enforced gating exists** — a skill package loads if its `manifest.json` is well-formed, regardless of review status. A planned review-gate epic (#4128) will add a `build_plugin`-level check (#4137) that refuses to load skill code unless a security review verdict is recorded, backed by a canonical package hash (#4135) and fail-closed verdict store (#4136).
 
 **Historical note:** An earlier version of this spec proposed a file allowlist (`PackageContainsForeignFile` error) to exclude executable files from agent packages. That rule was policy-only — never enforced in `load_agent_package` (`loader.rs:764-784`) and has zero occurrences in the codebase. Executable skill code is already loading in production (the `cto-db` skill, loaded via `install_discovered_skill_plugins`, `runtime/startup.rs:153`). This amendment ratifies existing behavior and clarifies that responsibility lies with the owner/operator.
 
-**Explicit boundary, not ambiguous:** `~/.trusty-agents/config.toml`'s `McpService.command` (§4) legitimately references executables (`slack-mcp`, a stdio MCP server binary) — that is operator-controlled platform infrastructure, a different trust boundary from agent-authored content. This principle extends to agent-bundled code: an operator who deploys an agent with executable skill code accepts responsibility for its provenance and behavior. **Future note:** once the review-gate epic lands, the platform will enforce a recorded security verdict before allowing skill code to load; at that point responsibility becomes joint operator/platform.
+**Explicit boundary, not ambiguous:** `~/.trusty-agents/config.toml`'s `McpService.command` (§4) legitimately references executables (`slack-mcp`, a stdio MCP server binary) — that is operator-controlled platform infrastructure, a different trust boundary from agent-authored content. This principle extends to agent-bundled code: an operator who deploys an agent with executable skill code accepts responsibility for its provenance and behavior. **Future note:** once the review-gate epic #4128 lands (specifically issue #4137 for the `build_plugin`-level enforcement), the platform will enforce a recorded security verdict before allowing skill code to load; at that point responsibility becomes joint operator/platform.
 
 ### 2.7 Directory-convention layout (worked example)
 
@@ -1960,9 +1960,10 @@ not a speculative extension.
   rule that executable files would be rejected at load time.
 - **2026-07-27 (v3.3 clarification)** — Qualified §2.6's statement of current
   state to clarify that no platform-enforced gating exists *at the time of this
-  amendment*, and that a planned review-gate epic (issue #4080) will add a
-  `build_plugin`-level check refusing to load skill code unless a security
-  review verdict is recorded. Inserted "Current state (2026-07-27)" subheading
+  amendment*, and that a planned review-gate epic (#4128) will add a
+  `build_plugin`-level check (#4137) refusing to load skill code unless a security
+  review verdict is recorded, via canonical package hash (#4135) and fail-closed
+  verdict store (#4136). Inserted "Current state (2026-07-27)" subheading
   to distinguish today's permissive loading from future enforced gating. Amended
   closing paragraph to note that once the review-gate epic lands, responsibility
   becomes joint operator/platform. This clarification harmonizes §2.6 with the


### PR DESCRIPTION
## Summary

Amends DOC-41 §2.6 and DOC-57 §5.8 to permit executable skill code (Python packages, binaries, etc.) per owner decision (Bob, 2026-07-27). The platform imposes no automated enforcement; the operator/owner is responsible for managing, vetting, and auditing that code.

This change ratifies existing behavior: the prior `PackageContainsForeignFile` ban was policy-only and never enforced in `load_agent_package()`. The `cto-db` skill already bundles executable Python code.

Clarifies that no platform-enforced gating exists at amendment time. Issue #4080 (review-gate epic) will implement future enforcement based on recorded security verdicts.

**Held pending #4126 (now merged PR #4161).** Three related specifications remain open for coordination:
- Issue #4080 — review-gate epic (enforcement implementation)
- Issue #4128 — security review procedures for executable skill code
- Issue #4137 — operator documentation and audit guidelines
- Issue #4136 — executor attestation and manifest schema
- Issue #4135 — capability-based access controls for skills

## Verification

- `PackageContainsForeignFile` error has zero codebase occurrences (verified via grep)
- `load_agent_package` (loader.rs:764-784) performs no file-allowlist validation
- Executable skill code in production: `cto-db` Python package loaded via `install_discovered_skill_plugins()` (runtime/startup.rs:153)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools