### PR TITLE
feat(trusty-agents): L0/L1 persona tier + one-directional delegation gate

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -9,6 +9,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- **Defined the L0/L1 persona privilege tier and made the L1->L0 delegation
+  path structurally forbidden (#4168, #4169, epic #4167).** Added an
+  explicit `AgentTier` (`AgentInfo::tier`, TOML `[agent].tier` / `.md`
+  frontmatter `tier`), decoupled from `role`, that fails closed to
+  `L1Standard` on an absent, blank, or unrecognized value — never `L0`.
+  `delegate_to_agent` now refuses any call where the resolved TARGET's tier
+  is `L0Orchestration` unless the DELEGATOR's own tier is also
+  `L0Orchestration`, checked at every dispatch path that can construct a
+  `DelegateToAgentTool` (the `--direct`/`--agent` subprocess path, the
+  persona-chat REPL path, and the ctrl history/session path), including
+  through a peer-assistant delegation hop — no chain of L1 hops can reach
+  L0. This PR defines the tier and the boundary only; it grants L0 no new
+  capabilities and creates no L0 persona instance (those are #4170-#4173).
+
 - **Closed a prompt-injection-to-arbitrary-code-execution path through
   `delegate_to_agent` (#4126).** An assistant-tier persona (`assistant`,
   `cto-assistant`, `izzie`) holding live external-content tools

--- a/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
+++ b/crates/trusty-agents/src/agents/claude_code_runner/tests.rs
@@ -70,6 +70,7 @@ fn test_agent_config(name: &str, model: &str, system_prompt: &str) -> AgentConfi
             kind: "assistant".to_string(),
             prompt_label: None,
             extends: None,
+            tier: None,
         },
         llm: LlmParams {
             temperature: 0.0,

--- a/crates/trusty-agents/src/agents/claude_mpm_loader.rs
+++ b/crates/trusty-agents/src/agents/claude_mpm_loader.rs
@@ -98,6 +98,7 @@ impl ClaudeMpmAgent {
                 kind: "assistant".to_string(),
                 prompt_label: None,
                 extends: None,
+                tier: None,
             },
             llm: LlmParams {
                 temperature: 0.3,

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -639,9 +639,105 @@ pub struct AgentInfo {
     /// Test: `agents::extends::tests` — see `extends_*` unit tests.
     #[serde(default)]
     pub extends: Option<String>,
+
+    /// Privilege tier declaration (#4168, epic #4167 — L0/L1 orchestration
+    /// model), raw as parsed from TOML. Use [`AgentInfo::tier`] rather than
+    /// reading this field directly.
+    ///
+    /// Why: The owner's tiered persona model (#4167) needs a privilege
+    /// boundary distinct from `role`. `role` is already triple-overloaded —
+    /// it selects the per-agent tool-registry branch
+    /// (`runtime::tool_registry::build_registry_for_agent`), gates
+    /// `delegate_to_agent`'s target allowlist
+    /// (`ASSISTANT_ALLOWED_DELEGATE_ROLES`), and drives capability matching
+    /// — and `hidden`'s own doc comment above already names the hazard of
+    /// adding a FOURTH meaning to it: "repurposing role would silently
+    /// change tool permissions too — not a safe mechanism." A dedicated
+    /// field keeps this SPECIFIC boundary (L0 orchestration-tier PM-grants
+    /// vs. L1 standard black-box posture) explicit, grep-able, and
+    /// independent of any future `role` value — an operator adding a new
+    /// specialist `role` can never accidentally grant it orchestration-tier
+    /// delegation reach as a side effect.
+    /// What: Raw TOML string (`"l0"` / `"orchestration"` for L0,
+    /// `"l1"` / `"standard"` for L1, case-insensitive). Resolved by
+    /// [`AgentInfo::tier`], which FAILS CLOSED: `None` (field absent —
+    /// every persona shipped before #4168, and the overwhelming majority
+    /// going forward), an unrecognized string, or a blank/whitespace-only
+    /// string all resolve to [`AgentTier::L1Standard`] — the most
+    /// restricted tier — NEVER [`AgentTier::L0Orchestration`]. This is a
+    /// privilege boundary, not a convenience default: every call site that
+    /// needs to know an agent's tier MUST call `AgentInfo::tier()`, never
+    /// match on this raw field.
+    /// Test: `agent_tier_defaults_to_l1_when_absent`,
+    /// `agent_tier_parses_l0_orchestration_aliases`,
+    /// `agent_tier_parses_l1_standard_aliases`,
+    /// `agent_tier_unknown_value_fails_closed_to_l1`,
+    /// `agent_tier_blank_value_fails_closed_to_l1`.
+    #[serde(default)]
+    pub tier: Option<String>,
+}
+
+/// Persona privilege tier (#4168, epic #4167 — L0/L1 orchestration model).
+///
+/// Why: The owner decision (2026-07-27) splits personas into two tiers: L0
+/// ("orchestration assistant") carries PM-tier grants (GitHub/PR/CI,
+/// session-state read, cross-project git, shell/build/test execution,
+/// delegation) under a YOLO risk posture the owner explicitly accepts —
+/// deliberately NOT sandboxed, but it must never ingest untrusted content
+/// (no Gmail/Drive/Calendar surface). L1 ("standard assistant") is today's
+/// `assistant`/`cto-assistant`/`izzie`: the documented black-box posture,
+/// which DOES ingest untrusted content and therefore must never be able to
+/// acquire L0's grants — including via delegation (#4169, epic #4167).
+/// This PR defines the tier and its one-directional delegation boundary
+/// ONLY; it grants L0 no actual capabilities (those are #4170-#4173) and
+/// creates no L0 persona instance.
+/// What: Two variants. `L1Standard` is `#[default]` — every accessor that
+/// falls back to `Default::default()` (or an explicit fail-closed match
+/// arm) lands on the restricted tier, never the elevated one.
+/// Test: See `AgentInfo::tier`'s Test pointer for parsing; delegation-gate
+/// behavior is covered by `crate::tools::delegate` tests (search
+/// `l1_to_l0` / `l0_to_l1` / `tier`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum AgentTier {
+    /// L1 — standard assistant tier. Black-box posture; may ingest
+    /// untrusted content (Gmail/Drive/web); MUST NOT reach L0 via
+    /// delegation. The fail-closed default.
+    #[default]
+    L1Standard,
+    /// L0 — orchestration tier. PM-tier grants; YOLO risk posture
+    /// explicitly accepted by the owner; deliberately not sandboxed but
+    /// must never ingest untrusted content. Only reachable by an EXPLICIT
+    /// `tier = "l0"` / `tier = "orchestration"` declaration — never a
+    /// default, never inferred from `role`.
+    L0Orchestration,
 }
 
 impl AgentInfo {
+    /// Resolve this agent's privilege tier, fail-closed (#4168).
+    ///
+    /// Why: The single normalization point for the raw [`Self::tier`]
+    /// string — see that field's doc comment for the full fail-closed
+    /// rationale. Every consumer (the delegation gate, and any future
+    /// L0-gated capability) MUST call this rather than matching on the raw
+    /// field, so "what counts as L0" can never drift between call sites.
+    /// What: Case-insensitive, trimmed match against `"l0"`/`"orchestration"`
+    /// (-> [`AgentTier::L0Orchestration`]) and `"l1"`/`"standard"` (->
+    /// [`AgentTier::L1Standard`]); anything else — absent, blank, or an
+    /// unrecognized string — resolves to [`AgentTier::L1Standard`].
+    /// Test: `agent_tier_defaults_to_l1_when_absent`,
+    /// `agent_tier_parses_l0_orchestration_aliases`,
+    /// `agent_tier_parses_l1_standard_aliases`,
+    /// `agent_tier_unknown_value_fails_closed_to_l1`,
+    /// `agent_tier_blank_value_fails_closed_to_l1`.
+    pub fn tier(&self) -> AgentTier {
+        match self.tier.as_deref().map(str::trim) {
+            Some(s) if s.eq_ignore_ascii_case("l0") || s.eq_ignore_ascii_case("orchestration") => {
+                AgentTier::L0Orchestration
+            }
+            _ => AgentTier::L1Standard,
+        }
+    }
+
     /// The human-facing speaker label for this persona (#3738).
     ///
     /// Why: The chat surface (GUI per-message speaker attribution, the REPL

--- a/crates/trusty-agents/src/agents/extends/mod.rs
+++ b/crates/trusty-agents/src/agents/extends/mod.rs
@@ -186,7 +186,10 @@ fn clear_extends(mut cfg: AgentConfig) -> AgentConfig {
 /// `extends_nameless_child_does_not_inherit_named_base_display`,
 /// `extends_scalar_child_override`, `extends_llm_child_overrides_temperature_only`,
 /// `extends_llm_child_overrides_max_tokens_only`,
-/// `extends_llm_child_inherits_when_omitted`.
+/// `extends_llm_child_inherits_when_omitted`,
+/// `extends_tier_child_inherits_l0_from_base_when_omitted`,
+/// `extends_tier_child_can_downgrade_l0_base_to_l1`,
+/// `extends_tier_omitted_everywhere_resolves_l1`.
 pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
     // #3936: the base's own contribution to the `permissions.scopes`
     // accumulator, captured BEFORE `base` moves into `merged` below.
@@ -274,6 +277,22 @@ pub fn merge_extends(base: AgentConfig, child: AgentConfig) -> AgentConfig {
     // (`false` is the neutral default and inherits the base).
     if child.agent.persistent_session {
         merged.agent.persistent_session = true;
+    }
+    // `tier` (#4168, epic #4167 — L0/L1 orchestration model): child-declares-
+    // wins, child-omits-inherits — the SAME posture as `enforce_search_indexes`/
+    // `default_tier` below: a hardened (L1) base stays hardened under a
+    // silent overlay, and this is a privilege boundary, not a convenience
+    // default, so the rule cuts both ways deliberately. An L0 base's
+    // elevated tier travels to a child overlay that doesn't explicitly
+    // declare its own `tier` — exactly like every other un-redeclared field
+    // in an `extends` overlay — while a child that DOES declare `tier`
+    // (including downgrading an L0 base to `l1`) always wins. This is
+    // distinct from the "absent/malformed -> L1" fail-closed resolution
+    // `AgentInfo::tier()` performs: that guards a chain where NO level ever
+    // declares a recognized value, not a child that inherits an ancestor's
+    // explicit declaration.
+    if child.agent.tier.is_some() {
+        merged.agent.tier = child.agent.tier.clone();
     }
 
     // --- user_authority: NEVER inherited/unioned through `extends` ---

--- a/crates/trusty-agents/src/agents/extends/tests.rs
+++ b/crates/trusty-agents/src/agents/extends/tests.rs
@@ -575,6 +575,83 @@ search_indexes = ["apex"]
     assert!(merged.tools.search_indexes_enforced());
 }
 
+// --- `tier` merge (#4168, epic #4167 — L0/L1 orchestration model) ---------
+//
+// Same posture as `enforce_search_indexes` above: child-declares-wins,
+// child-omits-inherits. This is a PRIVILEGE boundary though, so each
+// direction (an L0 base's tier traveling to a silent child overlay, AND a
+// child explicitly downgrading it) is pinned separately.
+
+fn agent_with_tier(name: &str, extends: &str, tier_line: &str) -> AgentConfig {
+    cfg(&format!(
+        r#"
+[agent]
+name = "{name}"
+role = "agent"
+model = "m"
+description = "d"
+{extends}
+{tier_line}
+[llm]
+temperature = 0.0
+max_tokens = 1024
+[system_prompt]
+content = "x"
+"#
+    ))
+}
+
+#[test]
+fn extends_tier_child_inherits_l0_from_base_when_omitted() {
+    // An L0 base's tier travels to a child overlay that never redeclares
+    // `tier` — the same "hardened base stays hardened under a silent
+    // overlay" rule `enforce_search_indexes` follows, applied to a
+    // privilege boundary instead of a search-index posture.
+    let base = agent_with_tier("base", "", r#"tier = "orchestration""#);
+    let child = agent_with_tier("child", "extends = \"base\"", "");
+    let merged = merge_extends(base, child);
+    assert_eq!(
+        merged.agent.tier(),
+        crate::agents::AgentTier::L0Orchestration,
+        "a child overlay that never declares its own tier must inherit the \
+         base's L0 tier, exactly like every other un-redeclared field"
+    );
+}
+
+#[test]
+fn extends_tier_child_can_downgrade_l0_base_to_l1() {
+    // A child that explicitly declares its own tier always wins — including
+    // downgrading an L0 base to L1.
+    let base = agent_with_tier("base", "", r#"tier = "orchestration""#);
+    let child = agent_with_tier("child", "extends = \"base\"", r#"tier = "l1""#);
+    let merged = merge_extends(base, child);
+    assert_eq!(merged.agent.tier(), crate::agents::AgentTier::L1Standard);
+}
+
+#[test]
+fn extends_tier_omitted_everywhere_resolves_l1() {
+    // Neither base nor child ever declares `tier` — the chain must resolve
+    // to the fail-closed default, never accidentally L0.
+    let base = agent_with_tier("base", "", "");
+    let child = agent_with_tier("child", "extends = \"base\"", "");
+    let merged = merge_extends(base, child);
+    assert_eq!(merged.agent.tier(), crate::agents::AgentTier::L1Standard);
+}
+
+#[test]
+fn extends_tier_child_can_declare_l0_over_l1_base() {
+    // The reverse direction: an L1 (or tier-less) base, and a child that
+    // explicitly opts INTO L0 — a deliberate, explicit declaration, which
+    // is the only way `tier()` ever resolves to L0.
+    let base = agent_with_tier("base", "", r#"tier = "l1""#);
+    let child = agent_with_tier("child", "extends = \"base\"", r#"tier = "orchestration""#);
+    let merged = merge_extends(base, child);
+    assert_eq!(
+        merged.agent.tier(),
+        crate::agents::AgentTier::L0Orchestration
+    );
+}
+
 #[test]
 fn extends_unions_listener_bindings_by_name() {
     let base = cfg(r#"

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -34,8 +34,8 @@ pub(crate) mod tests;
 // for every external consumer after the #358 file split.
 // #4026 adds `SubagentsConfig` (the `[subagents]` cross-product grants).
 pub use config::{
-    AgentCapabilities, AgentConfig, AgentInfo, NativeToolsConfig, RunnerKind, SkillsConfig,
-    SubagentsConfig, SystemPrompt, TicketingTomlConfig, ToolsConfig,
+    AgentCapabilities, AgentConfig, AgentInfo, AgentTier, NativeToolsConfig, RunnerKind,
+    SkillsConfig, SubagentsConfig, SystemPrompt, TicketingTomlConfig, ToolsConfig,
 };
 pub use params::{
     AgentCompressConfig, AgentPluginsConfig, LlmParams, RbacConfig, RunnerConfig,

--- a/crates/trusty-agents/src/agents/registry/md_agent.rs
+++ b/crates/trusty-agents/src/agents/registry/md_agent.rs
@@ -73,6 +73,15 @@ struct MdAgentFrontmatter {
     /// Test: `agents::extends::tests`.
     #[serde(default)]
     extends: Option<String>,
+    /// Privilege tier declaration (#4168, epic #4167 — L0/L1 orchestration
+    /// model). Mirrors `AgentInfo::tier`'s raw string exactly — see that
+    /// field's doc comment for the fail-closed resolution
+    /// (`AgentInfo::tier()`) every consumer must call. Absent (the
+    /// overwhelming majority of `.md` overlays) resolves to L1, same as a
+    /// TOML agent that omits `[agent].tier`.
+    /// Test: `md_frontmatter_tier_parses_and_defaults_absent`.
+    #[serde(default)]
+    tier: Option<String>,
 }
 
 /// Parse an `.md` agent file into an `AgentConfig`.
@@ -184,6 +193,7 @@ pub(crate) fn parse_md_agent(path: &Path) -> anyhow::Result<AgentConfig> {
             kind: "assistant".to_string(),
             prompt_label: None,
             extends: fm.extends,
+            tier: fm.tier,
         },
         llm: LlmParams {
             temperature: llm_temperature,

--- a/crates/trusty-agents/src/agents/registry/tests.rs
+++ b/crates/trusty-agents/src/agents/registry/tests.rs
@@ -289,6 +289,43 @@ SYSTEM PROMPT BODY HERE
     assert_eq!(caps.tags, vec!["rest-api"]);
 }
 
+/// #4168 (epic #4167): `.md` frontmatter's `tier` key parses and mirrors
+/// the TOML `[agent].tier` fail-closed contract — absent resolves to L1,
+/// an explicit `tier: orchestration` resolves to L0.
+#[test]
+fn md_frontmatter_tier_parses_and_defaults_absent() {
+    let dir = TempDir::new().unwrap();
+
+    let no_tier = r#"---
+name: md-agent-no-tier
+role: assistant
+model: anthropic/claude-sonnet-4-6
+description: no tier declared
+---
+body
+"#;
+    let path = dir.path().join("md-agent-no-tier.md");
+    fs::write(&path, no_tier).unwrap();
+    let cfg = parse_md_agent(&path).expect("md parses");
+    assert_eq!(cfg.agent.tier, None);
+    assert_eq!(cfg.agent.tier(), crate::agents::AgentTier::L1Standard);
+
+    let with_tier = r#"---
+name: md-agent-l0
+role: assistant
+model: anthropic/claude-sonnet-4-6
+description: declares orchestration tier
+tier: orchestration
+---
+body
+"#;
+    let path = dir.path().join("md-agent-l0.md");
+    fs::write(&path, with_tier).unwrap();
+    let cfg = parse_md_agent(&path).expect("md parses");
+    assert_eq!(cfg.agent.tier.as_deref(), Some("orchestration"));
+    assert_eq!(cfg.agent.tier(), crate::agents::AgentTier::L0Orchestration);
+}
+
 #[test]
 fn registry_picks_up_md_files_alongside_toml() {
     let dir = TempDir::new().unwrap();

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -670,3 +670,97 @@ allowed = ["research", "ticketing"]
         Some(&["git_log".to_string()][..])
     );
 }
+
+// --- `AgentInfo::tier` (#4168, epic #4167 — L0/L1 orchestration model) ---
+//
+// Fail-closed contract: absent, blank, or unrecognized `[agent].tier` must
+// NEVER resolve to `AgentTier::L0Orchestration` — only an explicit,
+// recognized declaration does.
+
+fn agent_toml_with_tier(tier_line: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "x"
+role = "x"
+model = "x"
+description = "x"
+{tier_line}
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#
+    )
+}
+
+#[test]
+fn agent_tier_defaults_to_l1_when_absent() {
+    // No `tier` key at all — the state of every persona TOML shipped before
+    // #4168, and the overwhelming majority going forward.
+    let cfg: AgentConfig = toml::from_str(&agent_toml_with_tier("")).expect("parses");
+    assert_eq!(cfg.agent.tier, None);
+    assert_eq!(cfg.agent.tier(), crate::agents::AgentTier::L1Standard);
+}
+
+#[test]
+fn agent_tier_parses_l0_orchestration_aliases() {
+    for alias in ["l0", "L0", "orchestration", "Orchestration", "  l0  "] {
+        let cfg: AgentConfig =
+            toml::from_str(&agent_toml_with_tier(&format!(r#"tier = "{alias}""#))).expect("parses");
+        assert_eq!(
+            cfg.agent.tier(),
+            crate::agents::AgentTier::L0Orchestration,
+            "alias {alias:?} must resolve to L0Orchestration"
+        );
+    }
+}
+
+#[test]
+fn agent_tier_parses_l1_standard_aliases() {
+    for alias in ["l1", "L1", "standard", "Standard"] {
+        let cfg: AgentConfig =
+            toml::from_str(&agent_toml_with_tier(&format!(r#"tier = "{alias}""#))).expect("parses");
+        assert_eq!(
+            cfg.agent.tier(),
+            crate::agents::AgentTier::L1Standard,
+            "alias {alias:?} must resolve to L1Standard"
+        );
+    }
+}
+
+#[test]
+fn agent_tier_unknown_value_fails_closed_to_l1() {
+    // The core fail-closed requirement: a malformed/unrecognized value must
+    // NEVER silently become the elevated tier.
+    for bogus in ["orchestrator", "l2", "yolo", "L0RCHESTRATION", "true"] {
+        let cfg: AgentConfig =
+            toml::from_str(&agent_toml_with_tier(&format!(r#"tier = "{bogus}""#))).expect("parses");
+        assert_eq!(
+            cfg.agent.tier(),
+            crate::agents::AgentTier::L1Standard,
+            "unrecognized tier value {bogus:?} must fail closed to L1Standard, never L0"
+        );
+    }
+}
+
+#[test]
+fn agent_tier_blank_value_fails_closed_to_l1() {
+    let cfg: AgentConfig =
+        toml::from_str(&agent_toml_with_tier(r#"tier = "   ""#)).expect("parses");
+    assert_eq!(cfg.agent.tier(), crate::agents::AgentTier::L1Standard);
+}
+
+#[test]
+fn agent_tier_default_trait_is_l1_standard() {
+    // `AgentTier::default()` (used as the fail-closed default in
+    // `DelegateToAgentTool::new`) must be `L1Standard`, not derived
+    // accidentally onto the wrong variant by a future field reorder.
+    assert_eq!(
+        crate::agents::AgentTier::default(),
+        crate::agents::AgentTier::L1Standard
+    );
+}

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -393,10 +393,11 @@ pub async fn run_pm_task_with_history(
     let inbound_taint = crate::runtime::tool_registry::parse_delegation_taint_env(
         std::env::var("TAGENT_DELEGATION_TAINT_ALLOW").ok(),
     );
-    let (delegation_taint, allowed_target_roles) = ctrl_delegate_posture(
+    let (delegation_taint, allowed_target_roles, delegator_tier) = ctrl_delegate_posture(
         &pm_cfg.agent.role,
         pm_cfg.tools.allow.as_deref(),
         inbound_taint.as_deref(),
+        pm_cfg.agent.tier(),
     );
     let runner: Arc<dyn AgentRunner> = Arc::new(
         SubprocessAgentRunner::new()
@@ -410,7 +411,8 @@ pub async fn run_pm_task_with_history(
     // specialist that produced it (chat-bubble responder attribution).
     let mut delegate_tool = DelegateToAgentTool::new(runner)
         .with_config_dir(config_dir.clone())
-        .with_session_id(sid.clone());
+        .with_session_id(sid.clone())
+        .with_delegator_tier(delegator_tier);
     if let Some(roles) = allowed_target_roles {
         delegate_tool = delegate_tool.with_allowed_target_roles(roles);
     }
@@ -553,28 +555,45 @@ pub async fn run_pm_task_with_history(
 /// `resolve_agent_config` can resolve `ctrl.toml`, which declares
 /// `role = "assistant"` (#3812).
 /// What: `role != "assistant"` (e.g. a resolved `pm.toml`, `role =
-/// "orchestrator"`) returns `(None, None)` — completely unaffected; `pm` is
-/// the trusted orchestrator, not a sandboxed persona, and this dispatch path
-/// must keep working exactly as before for it. `role == "assistant"`
-/// returns `(Some(taint), Some(roles))`: `taint` is
+/// "orchestrator"`) returns `(None, None, AgentTier::L0Orchestration)` —
+/// completely unaffected on the taint/role front; `pm` is the trusted
+/// orchestrator, not a sandboxed persona, and this dispatch path must keep
+/// working exactly as before for it. The THIRD element is deliberately
+/// `AgentTier::L0Orchestration` here too (#4169, epic #4167) — not because
+/// `pm`/`ctrl`-as-orchestrator IS an L0 persona, but because it sits
+/// OUTSIDE the L0/L1 persona tier model entirely (already fully trusted,
+/// already unrestricted) and must not be newly blocked from reaching a
+/// future L0 persona by a gate that was never meant to restrict it; see
+/// `DelegateToAgentTool::delegator_tier`'s doc comment for the same pattern.
+/// `role == "assistant"` returns `(Some(taint), Some(roles),
+/// declared_tier)`: `taint` is
 /// `compose_delegation_taint(native_allow, inbound_taint).unwrap_or_default()`
 /// — ALWAYS `Some`, even when empty, matching
 /// `build_assistant_tier_registry`'s fail-closed convention (an absent
 /// `[tools].allow` on `ctrl.toml` narrows to deny-all, never skips tainting);
 /// `roles` is always `ASSISTANT_ALLOWED_DELEGATE_ROLES` — the same
 /// worker + peer-assistant allowlist `build_assistant_tier_registry` uses,
-/// deliberately excluding `orchestrator`/`controller`/`observer`/`analysis`.
+/// deliberately excluding `orchestrator`/`controller`/`observer`/`analysis`;
+/// `declared_tier` is `pm_cfg.agent.tier()` verbatim (fail-closed to
+/// `L1Standard` for every persona shipped before #4168).
 /// Test: `ctrl_delegate_posture_orchestrator_role_is_unrestricted`,
 /// `ctrl_delegate_posture_assistant_role_fails_closed_without_allow`,
 /// `ctrl_delegate_posture_assistant_role_forwards_native_allow`,
-/// `ctrl_delegate_posture_assistant_role_always_gates_target_roles`.
+/// `ctrl_delegate_posture_assistant_role_always_gates_target_roles`,
+/// `ctrl_delegate_posture_orchestrator_role_reports_l0_tier`,
+/// `ctrl_delegate_posture_assistant_role_reports_its_declared_tier`.
 fn ctrl_delegate_posture(
     role: &str,
     native_allow: Option<&[String]>,
     inbound_taint: Option<&[String]>,
-) -> (Option<Vec<String>>, Option<Vec<String>>) {
+    declared_tier: crate::agents::AgentTier,
+) -> (
+    Option<Vec<String>>,
+    Option<Vec<String>>,
+    crate::agents::AgentTier,
+) {
     if role != "assistant" {
-        return (None, None);
+        return (None, None, crate::agents::AgentTier::L0Orchestration);
     }
     let taint =
         crate::runtime::tool_registry::compose_delegation_taint(native_allow, inbound_taint)
@@ -583,7 +602,7 @@ fn ctrl_delegate_posture(
         .iter()
         .map(|s| s.to_string())
         .collect();
-    (Some(taint), Some(roles))
+    (Some(taint), Some(roles), declared_tier)
 }
 
 /// Compute `chat_with_tools_gated`'s `allowed_tools` argument from an

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history_tests.rs
@@ -196,9 +196,34 @@ fn ctrl_delegate_posture_orchestrator_role_is_unrestricted() {
     // "orchestrator"`) instead of `ctrl.toml`. That case must be completely
     // unaffected — `pm` is the trusted orchestrator, not a sandboxed
     // persona — so this dispatch path keeps working exactly as before for it.
-    let (taint, roles) = ctrl_delegate_posture("orchestrator", None, None);
+    let (taint, roles, _tier) = ctrl_delegate_posture(
+        "orchestrator",
+        None,
+        None,
+        crate::agents::AgentTier::L1Standard,
+    );
     assert_eq!(taint, None, "pm/orchestrator must not be tainted");
     assert_eq!(roles, None, "pm/orchestrator must not be role-gated");
+}
+
+/// #4169 (epic #4167): the orchestrator branch reports `L0Orchestration`
+/// for the THIRD tuple element regardless of what `declared_tier` was
+/// passed in — `pm`/`ctrl`-as-orchestrator sits outside the L0/L1 persona
+/// model entirely and must never be newly blocked from reaching a future
+/// L0 persona.
+#[test]
+fn ctrl_delegate_posture_orchestrator_role_reports_l0_tier() {
+    let (_taint, _roles, tier) = ctrl_delegate_posture(
+        "orchestrator",
+        None,
+        None,
+        crate::agents::AgentTier::L1Standard,
+    );
+    assert_eq!(
+        tier,
+        crate::agents::AgentTier::L0Orchestration,
+        "pm/orchestrator must be treated as unrestricted by the tier gate too"
+    );
 }
 
 #[test]
@@ -207,7 +232,12 @@ fn ctrl_delegate_posture_assistant_role_fails_closed_without_allow() {
     // `None` — and there is no inbound taint (ctrl is always a top-level
     // dispatch, never itself a delegation target). The fix must still
     // produce an EXPLICIT empty (deny-all) taint, not skip tainting.
-    let (taint, roles) = ctrl_delegate_posture("assistant", None, None);
+    let (taint, roles, _tier) = ctrl_delegate_posture(
+        "assistant",
+        None,
+        None,
+        crate::agents::AgentTier::L1Standard,
+    );
     assert_eq!(
         taint,
         Some(Vec::new()),
@@ -227,8 +257,32 @@ fn ctrl_delegate_posture_assistant_role_forwards_native_allow() {
     // `[tools].allow`, that posture is what gets forwarded as the taint —
     // not silently dropped to empty.
     let native = vec!["web_search".to_string(), "delegate_to_agent".to_string()];
-    let (taint, _roles) = ctrl_delegate_posture("assistant", Some(&native), None);
+    let (taint, _roles, _tier) = ctrl_delegate_posture(
+        "assistant",
+        Some(&native),
+        None,
+        crate::agents::AgentTier::L1Standard,
+    );
     assert_eq!(taint, Some(native));
+}
+
+/// #4169: the assistant branch forwards `declared_tier` verbatim (unlike
+/// the orchestrator branch, which always reports `L0Orchestration`
+/// regardless of input) — `ctrl.toml`'s own declared tier genuinely governs
+/// what it may delegate to.
+#[test]
+fn ctrl_delegate_posture_assistant_role_reports_its_declared_tier() {
+    let (_taint, _roles, tier) = ctrl_delegate_posture(
+        "assistant",
+        None,
+        None,
+        crate::agents::AgentTier::L0Orchestration,
+    );
+    assert_eq!(
+        tier,
+        crate::agents::AgentTier::L0Orchestration,
+        "an assistant-role caller's OWN declared tier must be forwarded verbatim"
+    );
 }
 
 #[test]
@@ -237,7 +291,12 @@ fn ctrl_delegate_posture_assistant_role_always_gates_target_roles() {
     // the same privilege-escalation targets #3555 closed for the other two
     // dispatch paths — and must include the worker roster ctrl legitimately
     // delegates to.
-    let (_taint, roles) = ctrl_delegate_posture("assistant", None, None);
+    let (_taint, roles, _tier) = ctrl_delegate_posture(
+        "assistant",
+        None,
+        None,
+        crate::agents::AgentTier::L1Standard,
+    );
     let roles = roles.expect("assistant-tier ctrl must be role-gated");
     for expected in [
         "engineer",

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -387,6 +387,22 @@ pub async fn run_pm_task_with_persona(
             } else {
                 None
             };
+            // #4169 (epic #4167): the one-directional L0/L1 delegation gate.
+            // This persona-chat dispatch path (backing the REPL `/agent`
+            // command) is the SECOND site — besides `runtime::subagent_mode`
+            // — that builds a `DelegateToAgentTool` for a persona that may
+            // hold live external-content tools. `role == "assistant"` is the
+            // SAME population `delegation_taint` above already gates; a
+            // non-assistant-tier role here is treated the same way the
+            // taint above treats it — outside the persona tier model
+            // entirely (mirrors `ctrl_delegate_posture`'s `role !=
+            // "assistant"` branch in `history.rs`) — so it is never gated by
+            // the L1->L0 boundary, exactly as it is never tainted.
+            let delegator_tier = if persona_cfg.agent.role == "assistant" {
+                persona_cfg.agent.tier()
+            } else {
+                crate::agents::AgentTier::L0Orchestration
+            };
             let runner: Arc<dyn AgentRunner> = Arc::new(
                 SubprocessAgentRunner::new()
                     .with_config_dir(Some(config_dir.clone()))
@@ -398,7 +414,8 @@ pub async fn run_pm_task_with_persona(
                 // it (chat-bubble responder attribution).
                 DelegateToAgentTool::new(runner)
                     .with_config_dir(config_dir.clone())
-                    .with_session_id(sid.clone()),
+                    .with_session_id(sid.clone())
+                    .with_delegator_tier(delegator_tier),
             ));
             registry.register(Arc::new(AddProjectTool));
             registry.register(Arc::new(ListProjectsTool));

--- a/crates/trusty-agents/src/runtime/pm_mode.rs
+++ b/crates/trusty-agents/src/runtime/pm_mode.rs
@@ -92,6 +92,22 @@ pub(super) async fn run_pm() -> Result<()> {
 
     // Registry with a single tool (delegate_to_agent) wired to the
     // production subprocess runner.
+    //
+    // #4169 (epic #4167) coverage note: this `DelegateToAgentTool` is built
+    // with NO `config_dirs` (`with_config_dir`/`with_config_dirs` are never
+    // called here) — pre-flight validation, including the new one-directional
+    // L0/L1 tier gate, is entirely skipped for it (see
+    // `DelegateToAgentTool::execute`'s `config_dirs.is_empty()` guard), so
+    // `run_pm` needs no `with_delegator_tier` call to be correct. This is
+    // deliberate, not an oversight: `pm` (role `orchestrator`) is the
+    // trusted top-level orchestrator, already unreachable as a delegation
+    // TARGET from any L1 persona (`orchestrator` was never in
+    // `ASSISTANT_ALLOWED_DELEGATE_ROLES`, proven by
+    // `delegate_assistant_role_gate_rejects_orchestrator_role` in
+    // `tools::delegate`'s tests) — so no L1 persona can ever reach THIS
+    // unrestricted registry transitively, and gating it further would only
+    // block `pm` itself from reaching a future L0 persona, which is not
+    // what #4169 asks for.
     let runner: Arc<dyn tools::AgentRunner> = Arc::new(SubprocessAgentRunner::new());
     let mut registry = ToolRegistry::new();
     registry.register(Arc::new(DelegateToAgentTool::new(runner)));

--- a/crates/trusty-agents/src/runtime/subagent_mode.rs
+++ b/crates/trusty-agents/src/runtime/subagent_mode.rs
@@ -387,6 +387,7 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         skill_registry.clone(),
         tag_skill_registry.clone(),
         outbound_delegate_allow.as_deref(),
+        cfg.agent.tier(),
     );
 
     // #57: If the agent opts into `use_finish_task`, auto-register the

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -159,6 +159,14 @@ pub(crate) const ASSISTANT_ALLOWED_DELEGATE_ROLES: &[&str] = &[
 /// `delegate_to_agent` tool THIS agent registers narrows whatever it spawns
 /// to this agent's own tool posture. Ignored (and safe to pass `None`) for
 /// every non-assistant-tier role.
+///
+/// `delegator_tier` (#4169, epic #4167 — one-directional L0/L1 delegation
+/// gate): THIS agent's own resolved `AgentInfo::tier()`. Passed straight
+/// through to `build_assistant_tier_registry` so the `delegate_to_agent`
+/// tool this agent registers refuses to target an L0-orchestration
+/// specialist unless this agent is itself L0. Ignored for every
+/// non-assistant-tier role (those never register `delegate_to_agent` at
+/// all — see `build_assistant_tier_registry`'s doc comment).
 pub(super) fn build_registry_for_agent(
     name: &str,
     role: &str,
@@ -167,9 +175,13 @@ pub(super) fn build_registry_for_agent(
     skill_registry: Arc<skills::SkillRegistry>,
     tag_skill_registry: Arc<skills::registry::SkillRegistry>,
     delegator_allow: Option<&[String]>,
+    delegator_tier: crate::agents::AgentTier,
 ) -> Option<ToolRegistry> {
     if role == ASSISTANT_TIER_ROLE {
-        return Some(build_assistant_tier_registry(delegator_allow));
+        return Some(build_assistant_tier_registry(
+            delegator_allow,
+            delegator_tier,
+        ));
     }
     // #222: When `code_dir` is set and distinct from `out_dir`, the code-agent
     // and any future tool that writes *generated source files* should root at
@@ -461,7 +473,22 @@ pub(super) fn build_registry_for_agent(
 /// list rather than skipping tainting — fail-closed, not fail-open: a
 /// mis-configured or absent allow-list denies the child every tool rather
 /// than granting it every tool.
-pub(super) fn build_assistant_tier_registry(delegator_allow: Option<&[String]>) -> ToolRegistry {
+///
+/// `delegator_tier` (#4169, epic #4167 — one-directional L0/L1 delegation
+/// gate): this agent's own resolved `AgentInfo::tier()`, threaded into the
+/// `DelegateToAgentTool` via `with_delegator_tier` (always called here,
+/// alongside `with_allowed_target_roles`) so its pre-flight check refuses
+/// any target that resolves to `AgentTier::L0Orchestration` unless THIS
+/// agent is itself L0. If a call to this function ever omitted the
+/// `with_delegator_tier` wiring, `DelegateToAgentTool` would STILL enforce
+/// the tier gate fail-closed to `AgentTier::L1Standard` (because
+/// `with_allowed_target_roles` is always called here too — see
+/// `DelegateToAgentTool::delegator_tier`'s doc comment for the
+/// belt-and-suspenders rule), never silently skip it.
+pub(super) fn build_assistant_tier_registry(
+    delegator_allow: Option<&[String]>,
+    delegator_tier: crate::agents::AgentTier,
+) -> ToolRegistry {
     let mut reg = ToolRegistry::new();
     let cwd = std::env::current_dir().unwrap_or_default();
 
@@ -515,7 +542,8 @@ pub(super) fn build_assistant_tier_registry(delegator_allow: Option<&[String]>) 
                     .iter()
                     .map(|s| s.to_string())
                     .collect(),
-            ),
+            )
+            .with_delegator_tier(delegator_tier),
     ));
 
     // #3745 item C: register the izzie platform-hosted tools

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -72,6 +72,7 @@ fn research_agent_registry_has_web_tools() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("research-agent builds a registry");
     assert!(
@@ -95,6 +96,7 @@ fn research_agent_registry_has_memory_tools() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("memory_recall"), "memory_recall missing");
@@ -113,6 +115,7 @@ fn research_agent_registry_has_readonly_fs_tools() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("read_file"), "read_file missing");
@@ -132,6 +135,7 @@ fn plan_agent_registry_has_memory_tools() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("plan-agent builds a registry");
     assert!(reg.contains("memory_recall"), "memory_recall missing");
@@ -161,6 +165,7 @@ fn all_known_agents_get_skill_tools() {
             empty_skill_registry(),
             empty_tag_registry(),
             None,
+            crate::agents::AgentTier::L1Standard,
         )
         .unwrap_or_else(|| panic!("{agent} should get a registry"));
         assert!(reg.contains("load_skill"), "{agent}: load_skill missing");
@@ -180,6 +185,7 @@ fn plan_agent_registry_has_write_file_tool() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("plan-agent builds a registry");
     assert!(
@@ -200,6 +206,7 @@ fn docs_agent_registry_has_write_and_read_tools() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("docs-agent builds a registry");
     assert!(reg.contains("write_file"), "write_file missing");
@@ -239,6 +246,7 @@ async fn list_skills_uses_tag_registry_when_wired() {
         empty_skill_registry(),
         tag_reg,
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("list_skills"));
@@ -274,6 +282,7 @@ async fn list_skills_falls_back_to_legacy_when_tag_registry_empty() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("research-agent builds a registry");
     assert!(reg.contains("list_skills"));
@@ -347,6 +356,7 @@ fn assistant_tier_registry_excludes_skill_catalog_tools() {
         empty_skill_registry(),
         tag_reg,
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("assistant-tier agent builds a registry");
 
@@ -374,6 +384,7 @@ fn assistant_tier_registry_includes_curated_tools() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("assistant-tier agent builds a registry");
     assert!(
@@ -404,6 +415,7 @@ fn assistant_tier_registry_includes_izzie_tools() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("assistant-tier agent builds a registry");
     for expected in ["get_weather", "get_train_schedule", "get_train_alerts"] {
@@ -423,7 +435,7 @@ fn izzie_allow_list_surfaces_persona_tools_through_scoping() {
     // it — proving the fix at the exact seam that dropped it (the allow list
     // was correct; the tool simply was not in the registry to survive the
     // intersection).
-    let reg = build_assistant_tier_registry(None);
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L1Standard);
     let allow = vec![
         "delegate_to_agent".to_string(),
         "web_search".to_string(),
@@ -448,7 +460,7 @@ fn non_opted_in_persona_does_not_get_izzie_tools() {
     // allowed_tools` still gates by the persona's own `[tools].allow`. A
     // persona allowing only `web_search` gets only `web_search`, never
     // `get_weather`.
-    let reg = build_assistant_tier_registry(None);
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L1Standard);
     let allow = vec!["web_search".to_string()];
     let kept =
         scope_assistant_allowed_tools(true, None, Some(&allow), Some(&reg)).unwrap_or_default();
@@ -473,6 +485,7 @@ fn role_takes_precedence_over_name_for_assistant_tier() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("builds a registry");
     assert!(
@@ -495,6 +508,7 @@ fn scope_assistant_allowed_tools_filters_by_glob() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("assistant-tier agent builds a registry");
 
@@ -547,6 +561,7 @@ fn scope_assistant_allowed_tools_fails_closed_when_allow_absent() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("assistant-tier agent builds a registry");
 
@@ -583,6 +598,7 @@ fn scope_for_delegation_untainted_assistant_tier_fails_closed_without_allow() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("assistant-tier agent builds a registry");
 
@@ -713,6 +729,7 @@ fn multi_hop_delegation_narrows_at_every_hop() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("engineer-shaped registry builds");
     assert!(engineer_reg.contains("shell_exec"));
@@ -757,6 +774,7 @@ fn tainted_delegation_cannot_reach_tool_delegator_lacked() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("local-ops-agent builds a registry");
     assert!(
@@ -804,6 +822,7 @@ fn untainted_delegation_is_unaffected() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("local-ops-agent builds a registry");
 
@@ -827,6 +846,7 @@ fn tainted_delegation_intersects_with_existing_allowed() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("docs-agent builds a registry");
     assert!(reg.contains("write_file"));
@@ -872,6 +892,7 @@ fn assistant_delegate_to_engineer_path_is_scoped() {
         empty_skill_registry(),
         empty_tag_registry(),
         None,
+        crate::agents::AgentTier::L1Standard,
     )
     .expect("engineer-shaped registry builds");
     assert!(reg.contains("shell_exec"));
@@ -920,7 +941,7 @@ fn assistant_delegate_to_engineer_path_is_scoped() {
 /// `src/tools/delegate.rs` (`delegate_assistant_role_gate_rejects_*`), using
 /// a hand-built `DelegateToAgentTool` + tempdir so they're fast and
 /// environment-independent. This test instead exercises the REAL production
-/// wiring — `build_assistant_tier_registry(None)` unmodified, resolving against
+/// wiring — `build_assistant_tier_registry(None, AgentTier::L1Standard)` unmodified, resolving against
 /// whatever roster is ACTUALLY deployed at `$HOME/.trusty-agents/agents/` on
 /// the machine running it (via `agents::bundled::ensure_bundled_agents_deployed`,
 /// which every `tagent` invocation runs at startup) — as an end-to-end proof
@@ -939,7 +960,7 @@ fn assistant_delegate_to_engineer_path_is_scoped() {
 #[tokio::test]
 #[ignore]
 async fn live_assistant_registry_rejects_pm_role() {
-    let reg = build_assistant_tier_registry(None);
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L1Standard);
     assert!(
         reg.contains("delegate_to_agent"),
         "sanity: delegate_to_agent must be registered"
@@ -1040,7 +1061,7 @@ fn deployed_assistant_config_survives_scoping_with_delegate_to_agent() {
         cfg.tools.allow
     );
 
-    let reg = build_assistant_tier_registry(None);
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L1Standard);
     let kept = scope_assistant_allowed_tools(
         true,
         cfg.tools.allowed.clone(),
@@ -1100,5 +1121,109 @@ fn parse_delegation_taint_env_malformed_fails_closed() {
         parsed,
         Some(Vec::new()),
         "a malformed taint env var must fail closed (deny-all), never silently untainted"
+    );
+}
+
+// --- `build_assistant_tier_registry`'s `delegator_tier` wiring (#4169,
+// epic #4167 — one-directional L0/L1 delegation gate) ---
+//
+// Mirrors `deployed_assistant_config_survives_scoping_with_delegate_to_agent`'s
+// approach: drive the REAL production wiring end-to-end (the actual
+// `agents_dir_candidates()` resolution via `TAGENT_CONFIG_DIR`, the REAL
+// `build_assistant_tier_registry`, dispatched through `reg.dispatch`) rather
+// than constructing a `DelegateToAgentTool` by hand — proving `delegator_tier`
+// genuinely reaches the tool this function registers, not just the
+// `DelegateToAgentTool` unit tests in `tools::delegate`.
+#[tokio::test]
+async fn assistant_tier_registry_delegator_tier_blocks_l0_target_end_to_end() {
+    use crate::agents::tests::loading::ENV_LOCK;
+
+    let _guard = ENV_LOCK.lock().await;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("orchestration-assistant.toml"),
+        "[agent]\nname = \"orchestration-assistant\"\nrole = \"assistant\"\ntier = \"orchestration\"\nmodel = \"m\"\ndescription = \"d\"\n\n[llm]\ntemperature = 0.2\nmax_tokens = 1024\n\n[system_prompt]\ncontent = \"x\"\n",
+    )
+    .unwrap();
+
+    // SAFETY: guarded by ENV_LOCK, same convention as every other
+    // TAGENT_CONFIG_DIR mutator in this crate.
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", tmp.path());
+    }
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L1Standard);
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+    }
+
+    let result = reg
+        .dispatch(
+            "delegate_to_agent",
+            serde_json::json!({
+                "agent_name": "orchestration-assistant",
+                "task": "escalate"
+            }),
+        )
+        .await;
+
+    assert!(
+        result.is_error(),
+        "an L1-tier assistant registry must refuse to delegate to an L0 target \
+         resolved via the REAL agents_dir_candidates() wiring, got: {}",
+        result.content()
+    );
+}
+
+/// Counter-test: an L0-declared `delegator_tier` reaching the SAME L0
+/// target must NOT be rejected by the tier gate through the identical real
+/// wiring.
+///
+/// Why this doesn't assert overall success: `build_assistant_tier_registry`
+/// wires a REAL `SubprocessAgentRunner` (unlike the mock-runner unit tests
+/// in `tools::delegate`), so a call that clears pre-flight validation goes
+/// on to actually spawn a subprocess — which fails in this test environment
+/// for unrelated reasons (no real `orchestration-assistant` binary/roster to
+/// spawn), exactly as the pre-existing `live_assistant_registry_rejects_pm_role`
+/// test's doc comment notes for the same wiring. What THIS test pins is
+/// narrower and fully verifiable without a live spawn: the error, if any,
+/// must NOT be the tier-gate's specific refusal text — proving the gate
+/// itself let the call through.
+#[tokio::test]
+async fn assistant_tier_registry_l0_delegator_tier_reaches_l0_target_end_to_end() {
+    use crate::agents::tests::loading::ENV_LOCK;
+
+    let _guard = ENV_LOCK.lock().await;
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(
+        tmp.path().join("orchestration-assistant.toml"),
+        "[agent]\nname = \"orchestration-assistant\"\nrole = \"assistant\"\ntier = \"orchestration\"\nmodel = \"m\"\ndescription = \"d\"\n\n[llm]\ntemperature = 0.2\nmax_tokens = 1024\n\n[system_prompt]\ncontent = \"x\"\n",
+    )
+    .unwrap();
+
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", tmp.path());
+    }
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L0Orchestration);
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+    }
+
+    let result = reg
+        .dispatch(
+            "delegate_to_agent",
+            serde_json::json!({
+                "agent_name": "orchestration-assistant",
+                "task": "escalate"
+            }),
+        )
+        .await;
+
+    assert!(
+        !result
+            .content()
+            .contains("orchestration-tier (L0) specialist"),
+        "an L0-tier delegator must NOT be refused by the tier gate when reaching \
+         an L0 target, got: {}",
+        result.content()
     );
 }

--- a/crates/trusty-agents/src/tools/delegate.rs
+++ b/crates/trusty-agents/src/tools/delegate.rs
@@ -81,6 +81,47 @@ pub struct DelegateToAgentTool {
     /// `delegate_assistant_role_gate_allows_worker_role`,
     /// `delegate_assistant_role_gate_allows_peer_assistant_role`.
     allowed_target_roles: Option<Vec<String>>,
+    /// This instance's OWN privilege tier — the DELEGATOR's tier, not the
+    /// target's (#4169, epic #4167 — one-directional L0/L1 delegation gate).
+    ///
+    /// Why: L0 (orchestration) personas carry PM-tier grants under a YOLO
+    /// posture the owner explicitly accepts; L1 (standard) personas are the
+    /// documented black-box tier and may ingest untrusted content (Gmail/
+    /// Drive/web). If an L1 persona could delegate INTO an L0 target,
+    /// untrusted content would acquire the owner's L0 grant just by asking
+    /// the L1 persona to hand the work down — issue #4126's class,
+    /// reachable through a new path. Privilege must never be acquirable via
+    /// delegation, so this check is layered ON TOP of (never a replacement
+    /// for) the existing taint-composition machinery (#4161's
+    /// `compose_delegation_taint`) and the `allowed_target_roles` gate
+    /// above — an independent dimension, checked whenever EITHER
+    /// `allowed_target_roles` is set OR this field is explicitly set (see
+    /// `execute`'s `needs_full_resolution`).
+    /// What: `None` (the default — every caller that constructs a
+    /// `DelegateToAgentTool` and never calls `with_delegator_tier`, which
+    /// includes `pm`/`ctrl`-as-orchestrator's own unrestricted delegation
+    /// and pre-#4169 tests exercising unrelated resolution behavior with
+    /// bare/incomplete fixture TOMLs) means "this instance was never asked
+    /// to enforce the tier gate" — byte-identical to pre-#4169 behavior,
+    /// including the cheap existence-only pre-flight check when
+    /// `allowed_target_roles` is ALSO unset. `Some(tier)` (every real
+    /// assistant-tier / persona-chat construction site in this crate) means
+    /// "enforce the gate using `tier` as this delegator's own tier" and
+    /// forces full `AgentConfig` resolution so the target's tier can be
+    /// read. When `allowed_target_roles` IS set but this field was left
+    /// `None` (a caller that opted into role-gating but forgot tier), the
+    /// check still runs with a FAIL-CLOSED `AgentTier::L1Standard` default
+    /// (via `unwrap_or_default()`) — belt-and-suspenders: the population
+    /// that cares about role-gating can never silently skip tier-gating
+    /// too. Set explicitly via `with_delegator_tier`.
+    /// Test: `delegate_l1_to_l0_is_refused`, `delegate_l0_to_l1_succeeds`,
+    /// `delegate_l1_to_l1_is_unaffected_by_tier_gate`,
+    /// `delegate_multi_hop_l1_peer_to_l0_is_refused`,
+    /// `delegate_tier_gate_applies_even_without_role_allowlist`,
+    /// `delegate_role_gate_without_declared_tier_fails_closed_to_l1`,
+    /// `no_tier_and_no_role_gate_preserves_cheap_existence_check`,
+    /// `delegator_tier_defaults_to_none_on_construction`.
+    delegator_tier: Option<crate::agents::AgentTier>,
     /// #3737 (per-message chat attribution, epic #3052): the id of the task
     /// whose turn this tool is delegating within, used as the `session_id` on
     /// the `AgentSpawned` event emitted on a successful delegation so the API
@@ -115,6 +156,7 @@ impl DelegateToAgentTool {
             runner,
             config_dirs: Vec::new(),
             allowed_target_roles: None,
+            delegator_tier: None,
             session_id: None,
         }
     }
@@ -207,6 +249,26 @@ impl DelegateToAgentTool {
         self.allowed_target_roles = Some(roles);
         self
     }
+
+    /// Declare THIS instance's own delegator tier (#4169, epic #4167).
+    ///
+    /// Why: See the `delegator_tier` field doc for the full rationale.
+    /// Every production call site that constructs a `DelegateToAgentTool`
+    /// for an assistant-tier (persona) caller must call this with that
+    /// caller's own resolved `AgentInfo::tier()` so the one-directional
+    /// L1->L0 gate has something to check against. Callers representing a
+    /// caller OUTSIDE the persona tier model entirely — `pm`/`ctrl`-as-
+    /// orchestrator, already fully trusted and already unaffected by
+    /// `allowed_target_roles` — pass [`crate::agents::AgentTier::L0Orchestration`]
+    /// explicitly to mean "this caller is not gated by the L0/L1 boundary",
+    /// not because it IS an L0 persona.
+    /// What: Stores `Some(tier)`, which — combined with `config_dirs` being
+    /// non-empty — forces full target resolution so the tier gate can run.
+    /// Test: `delegate_l1_to_l0_is_refused`, `delegate_l0_to_l1_succeeds`.
+    pub fn with_delegator_tier(mut self, tier: crate::agents::AgentTier) -> Self {
+        self.delegator_tier = Some(tier);
+        self
+    }
 }
 
 #[async_trait]
@@ -282,27 +344,68 @@ impl ToolExecutor for DelegateToAgentTool {
         // "unknown name" and "role not allowed" cases return the identical
         // generic message below so neither leaks which one occurred.
         if !self.config_dirs.is_empty() {
-            let rejected = if let Some(allowed_roles) = &self.allowed_target_roles {
+            // #4169 (epic #4167): the one-directional L0/L1 delegation gate.
+            // `needs_full_resolution` decides whether the cheap
+            // existence-only check (pre-#4169 behavior, byte-identical for
+            // every caller that opts into NEITHER gate — `pm`/`ctrl`-as-
+            // orchestrator's own unrestricted delegation, and any test
+            // exercising unrelated resolution behavior with bare fixture
+            // TOMLs) is enough, or whether the target must be fully parsed
+            // so its role AND tier can be inspected. Triggered by EITHER
+            // gate being requested — `allowed_target_roles.is_some()`
+            // (unchanged from pre-#4169) OR `delegator_tier.is_some()` (new):
+            // a caller that opts into tier-gating must get it even if it
+            // never set a role allowlist (this is exactly the persona-chat
+            // dispatch path's historical shape — see
+            // `ctrl::pm_task::dispatch::persona`).
+            let needs_full_resolution =
+                self.allowed_target_roles.is_some() || self.delegator_tier.is_some();
+            let (rejected, tier_blocked) = if needs_full_resolution {
+                // Fail-closed default (#4169 constraint 1): a caller that DID
+                // opt into role-gating but never declared its own tier is
+                // still checked as if it were L1Standard — the population
+                // that cares enough to role-gate can never silently skip
+                // tier-gating too.
+                let delegator_tier = self.delegator_tier.unwrap_or_default();
                 match crate::agents::AgentConfig::by_name_in(&self.config_dirs, agent_name) {
                     Ok(cfg) => {
-                        let allowed = allowed_roles.iter().any(|r| r == &cfg.agent.role);
-                        if !allowed {
-                            tracing::debug!(
+                        let target_tier = cfg.agent.tier();
+                        let tier_blocked = target_tier == crate::agents::AgentTier::L0Orchestration
+                            && delegator_tier != crate::agents::AgentTier::L0Orchestration;
+                        if tier_blocked {
+                            tracing::warn!(
                                 agent_name,
-                                target_role = %cfg.agent.role,
-                                allowed_roles = ?allowed_roles,
-                                "delegate_to_agent: target role not in the assistant-tier allowlist"
+                                delegator_tier = ?delegator_tier,
+                                target_tier = ?target_tier,
+                                "delegate_to_agent: refusing an L1-tier delegation into an \
+                                 L0-orchestration target — privilege cannot be acquired via \
+                                 delegation"
                             );
                         }
-                        !allowed
+                        let role_ok = match &self.allowed_target_roles {
+                            Some(allowed_roles) => {
+                                let allowed = allowed_roles.iter().any(|r| r == &cfg.agent.role);
+                                if !allowed {
+                                    tracing::debug!(
+                                        agent_name,
+                                        target_role = %cfg.agent.role,
+                                        allowed_roles = ?allowed_roles,
+                                        "delegate_to_agent: target role not in the assistant-tier allowlist"
+                                    );
+                                }
+                                allowed
+                            }
+                            None => true,
+                        };
+                        (tier_blocked || !role_ok, tier_blocked)
                     }
                     Err(e) => {
                         tracing::debug!(
                             agent_name,
                             error = %format!("{e:#}"),
-                            "delegate_to_agent: role-gated target failed to resolve"
+                            "delegate_to_agent: gated target failed to resolve"
                         );
-                        true
+                        (true, false)
                     }
                 }
             } else if !crate::agents::agent_name_resolves(&self.config_dirs, agent_name) {
@@ -311,10 +414,28 @@ impl ToolExecutor for DelegateToAgentTool {
                     config_dirs = ?self.config_dirs,
                     "delegate_to_agent: agent not found in any candidate directory"
                 );
-                true
+                (true, false)
             } else {
-                false
+                (false, false)
             };
+            if tier_blocked {
+                // #4169 AC: "error message educates the user on the
+                // constraint" — deliberately DISTINCT from the generic
+                // roster-hiding message below. Unlike the anti-roster-leak
+                // rationale for an unknown-name/disallowed-role rejection
+                // (which must never confirm internal role taxonomy exists),
+                // the L0/L1 tier split is a product-level concept the owner
+                // named directly; explaining it here does not enumerate any
+                // OTHER roster entry, only the one name the caller already
+                // supplied.
+                return ToolResult::err(format!(
+                    "'{agent_name}' cannot be delegated to: it is an orchestration-tier \
+                     (L0) specialist, and this persona is standard-tier (L1). L1 personas \
+                     may not delegate to L0 orchestration targets — this boundary is \
+                     structural and is never bypassable, including through an \
+                     intermediate delegation hop."
+                ));
+            }
             if rejected {
                 return ToolResult::err(format!(
                     "'{agent_name}' is not a recognized specialist. Check your own \

--- a/crates/trusty-agents/src/tools/delegate_tests.rs
+++ b/crates/trusty-agents/src/tools/delegate_tests.rs
@@ -260,6 +260,18 @@ async fn delegate_rejects_agent_absent_from_all_config_dirs() {
 /// requires, unlike the bare `[agent]\nname = "..."` fixtures the
 /// existence-only tests above use (those never parse the file).
 fn write_agent_toml_with_role(dir: &std::path::Path, name: &str, role: &str) {
+    write_agent_toml_with_role_and_tier(dir, name, role, None);
+}
+
+/// Sibling to `write_agent_toml_with_role` that also declares `[agent].tier`
+/// when `tier` is `Some` (#4169, epic #4167).
+fn write_agent_toml_with_role_and_tier(
+    dir: &std::path::Path,
+    name: &str,
+    role: &str,
+    tier: Option<&str>,
+) {
+    let tier_line = tier.map(|t| format!(r#"tier = "{t}""#)).unwrap_or_default();
     std::fs::write(
         dir.join(format!("{name}.toml")),
         format!(
@@ -269,6 +281,7 @@ name = "{name}"
 role = "{role}"
 model = "anthropic/claude-sonnet-4-6"
 description = "test fixture"
+{tier_line}
 
 [llm]
 temperature = 0.2
@@ -517,4 +530,353 @@ fn session_id_gate_normalizes_blank_to_none() {
             .as_deref(),
         Some("task-42")
     );
+}
+
+// ============================================================================
+// #4169 (epic #4167) — the one-directional L0/L1 delegation gate.
+//
+// L0 (orchestration tier) carries PM-tier grants under a YOLO posture the
+// owner explicitly accepts. L1 (standard tier) is today's black-box
+// assistant/cto-assistant/izzie and may ingest untrusted content. If an L1
+// persona could delegate INTO an L0 target, untrusted content would acquire
+// the owner's L0 grant just by asking the L1 persona to hand the work down
+// — issue #4126's class, reachable through a new path. These tests exercise
+// the REAL `DelegateToAgentTool::execute()` call path (the same one
+// `build_assistant_tier_registry` / `ctrl_delegate_posture` /
+// `run_pm_task_with_persona` wire in production), not a hand-rolled
+// reimplementation of the gate.
+// ============================================================================
+
+/// THE single most important test in this PR: an L1-tier delegator must be
+/// refused when the resolved target's own declared tier is L0
+/// (orchestration). The runner must never be invoked.
+#[tokio::test]
+async fn delegate_l1_to_l0_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role_and_tier(
+        dir.path(),
+        "orchestration-assistant",
+        "assistant",
+        Some("orchestration"),
+    );
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "orchestration-assistant",
+            "task": "run cargo check and push a fix"
+        }))
+        .await;
+
+    assert!(
+        result.is_error(),
+        "an L1 delegator must be refused when targeting an L0 specialist"
+    );
+    assert!(
+        result.content().contains("L0") && result.content().contains("L1"),
+        "error should educate the user on the tier boundary, got: {}",
+        result.content()
+    );
+    assert!(
+        runner.invoked.lock().unwrap().is_empty(),
+        "runner must NEVER be invoked when the tier gate refuses"
+    );
+}
+
+/// The counter-test: an L0-tier delegator reaching an L1 (standard) target
+/// must succeed — this PR must not break legitimate downward delegation.
+#[tokio::test]
+async fn delegate_l0_to_l1_succeeds() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "izzie", "assistant");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_delegator_tier(crate::agents::AgentTier::L0Orchestration);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "izzie",
+            "task": "consult on train schedules"
+        }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "L0 -> L1 delegation must succeed: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// L1 -> L1 (a target with no `tier` declared, or explicitly `l1`) must be
+/// completely unaffected by the new gate — it existed before #4169 and must
+/// keep working.
+#[tokio::test]
+async fn delegate_l1_to_l1_is_unaffected_by_tier_gate() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "cto-assistant", "assistant");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "cto-assistant",
+            "task": "consult on architecture"
+        }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "L1 -> L1 must be unaffected: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// `delegator_tier` defaults to `None` on construction ("this instance was
+/// never asked to enforce the tier gate") — the field-level contract
+/// `with_delegator_tier` overrides. Mirrors
+/// `session_id_gate_normalizes_blank_to_none`'s same-module field check.
+/// The BEHAVIORAL consequence of `None` splits in two, covered separately:
+/// `no_tier_and_no_role_gate_preserves_cheap_existence_check` (neither gate
+/// opted in — untouched) and
+/// `delegate_role_gate_without_declared_tier_fails_closed_to_l1` (role gate
+/// opted in, tier forgotten — still fails closed to L1Standard).
+#[test]
+fn delegator_tier_defaults_to_none_on_construction() {
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    assert_eq!(
+        DelegateToAgentTool::new(runner.clone()).delegator_tier,
+        None
+    );
+    assert_eq!(
+        DelegateToAgentTool::new(runner)
+            .with_delegator_tier(crate::agents::AgentTier::L0Orchestration)
+            .delegator_tier,
+        Some(crate::agents::AgentTier::L0Orchestration)
+    );
+}
+
+/// A target whose `tier` is malformed/unrecognized must resolve to L1 (per
+/// `AgentInfo::tier()`'s fail-closed contract) and therefore NOT be blocked
+/// by the tier gate — proving the gate composes correctly with the
+/// fail-closed resolution rather than double-failing or crashing.
+#[tokio::test]
+async fn delegate_malformed_target_tier_resolves_l1_and_is_not_tier_blocked() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role_and_tier(dir.path(), "engineer", "engineer", Some("bogus-value"));
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_delegator_tier(crate::agents::AgentTier::L1Standard)
+        .with_allowed_target_roles(vec!["engineer".to_string()]);
+
+    let result = tool
+        .execute(json!({ "agent_name": "engineer", "task": "run cargo check" }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "a malformed target tier must resolve to L1 (not block), got: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// The tier gate is checked EVEN WHEN no `allowed_target_roles` allowlist is
+/// set — proving it is not merely piggybacking on the role gate's existing
+/// resolution, but an independent, unconditional check. This is the
+/// specific regression #4169 exists to prevent: a dispatch path (like
+/// `ctrl::pm_task::dispatch::persona`, historically) that builds a
+/// `DelegateToAgentTool` with a `config_dir` but no role allowlist must
+/// still be tier-gated.
+#[tokio::test]
+async fn delegate_tier_gate_applies_even_without_role_allowlist() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role_and_tier(
+        dir.path(),
+        "orchestration-assistant",
+        "assistant",
+        Some("orchestration"),
+    );
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    // No `.with_allowed_target_roles(...)` call at all.
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "orchestration-assistant",
+            "task": "do orchestration-tier things"
+        }))
+        .await;
+
+    assert!(
+        result.is_error(),
+        "the tier gate must apply even without a role allowlist configured"
+    );
+    assert!(runner.invoked.lock().unwrap().is_empty());
+}
+
+/// TRANSITIVE / multi-hop escalation: `assistant (L1) -> izzie (L1 peer) ->
+/// orchestration-assistant (L0)` must be impossible. This builds TWO real
+/// `DelegateToAgentTool` instances — one per hop — using the SAME
+/// construction shape production code uses (role-allowlisted,
+/// tier-declared), and drives them in sequence: hop 1 succeeds (peer-assistant
+/// delegation is legitimate), but when the spawned peer (izzie, itself L1)
+/// attempts hop 2 into the L0 target, ITS OWN `DelegateToAgentTool` (built
+/// with izzie's own L1 tier, exactly as `build_assistant_tier_registry`
+/// would build it for the real izzie subprocess) refuses. No chain of L1
+/// hops can ever reach L0.
+#[tokio::test]
+async fn delegate_multi_hop_l1_peer_to_l0_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "izzie", "assistant");
+    write_agent_toml_with_role_and_tier(
+        dir.path(),
+        "orchestration-assistant",
+        "assistant",
+        Some("orchestration"),
+    );
+
+    // Hop 1: assistant (L1) -> izzie (L1 peer). Legitimate; must succeed.
+    let hop1_runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let hop1_tool = DelegateToAgentTool::new(hop1_runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["assistant".to_string()])
+        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+    let hop1_result = hop1_tool
+        .execute(json!({ "agent_name": "izzie", "task": "hand off to izzie" }))
+        .await;
+    assert!(
+        !hop1_result.is_error(),
+        "hop 1 (L1 -> L1 peer) must succeed: {}",
+        hop1_result.content()
+    );
+
+    // Hop 2: izzie (itself L1 — no tier declared, so `tier()` resolves
+    // L1Standard) attempts to reach the L0 target. Built exactly as
+    // `build_assistant_tier_registry` builds izzie's OWN delegate tool when
+    // izzie is spawned: role-allowlisted to `ASSISTANT_ALLOWED_DELEGATE_ROLES`-
+    // equivalent, tier-declared from izzie's OWN resolved config.
+    let hop2_runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let hop2_tool = DelegateToAgentTool::new(hop2_runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["assistant".to_string()])
+        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+    let hop2_result = hop2_tool
+        .execute(json!({
+            "agent_name": "orchestration-assistant",
+            "task": "escalate to orchestration tier"
+        }))
+        .await;
+
+    assert!(
+        hop2_result.is_error(),
+        "hop 2 (L1 peer -> L0) must be refused — no chain of L1 hops may reach L0"
+    );
+    assert!(
+        hop2_runner.invoked.lock().unwrap().is_empty(),
+        "the L0 target's runner must never be invoked via the transitive path"
+    );
+}
+
+/// A caller that opts into role-gating (`with_allowed_target_roles`) but
+/// never declares its own tier must still be tier-gated, fail-closed to
+/// `L1Standard` — belt-and-suspenders: the population that cares enough to
+/// role-gate can never silently skip tier-gating too.
+#[tokio::test]
+async fn delegate_role_gate_without_declared_tier_fails_closed_to_l1() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role_and_tier(
+        dir.path(),
+        "orchestration-assistant",
+        "assistant",
+        Some("orchestration"),
+    );
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    // Role-gated, but no `.with_delegator_tier(...)` call at all.
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["assistant".to_string()]);
+
+    let result = tool
+        .execute(json!({
+            "agent_name": "orchestration-assistant",
+            "task": "escalate"
+        }))
+        .await;
+
+    assert!(
+        result.is_error(),
+        "role-gated caller with no declared tier must still fail closed against an L0 target"
+    );
+    assert!(runner.invoked.lock().unwrap().is_empty());
+}
+
+/// A caller that opts into NEITHER gate (no role allowlist, no declared
+/// tier) must keep the pre-#4169 cheap existence-only pre-flight check —
+/// proven by resolving a BARE, otherwise-unparseable fixture (missing
+/// `model`/`description`/`[llm]`/`[system_prompt]`) that only
+/// `agent_name_resolves` (not a full `AgentConfig::by_name_in` parse) can
+/// succeed against. This is the exact regression guard for the mistake
+/// this PR's first draft made: threading the tier gate in naively broke
+/// `known_agent_reaches_runner`/`delegate_resolves_agent_from_secondary_config_dir`
+/// by forcing full resolution unconditionally.
+#[tokio::test]
+async fn no_tier_and_no_role_gate_preserves_cheap_existence_check() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(
+        dir.path().join("bare-agent.toml"),
+        "[agent]\nname = \"bare-agent\"\n",
+    )
+    .unwrap();
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool =
+        DelegateToAgentTool::new(runner.clone()).with_config_dirs(vec![dir.path().to_path_buf()]);
+
+    let result = tool
+        .execute(json!({ "agent_name": "bare-agent", "task": "do the thing" }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "a caller opted into neither gate must keep the cheap existence-only check: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
 }


### PR DESCRIPTION
## Summary

Foundation of epic #4167 (Level-0 orchestration assistant tier). Implements the owner's tiered persona model decision (2026-07-27): a new L0 "orchestration assistant" tier that will eventually carry PM-tier grants under an explicit YOLO risk posture, and today's `assistant`/`cto-assistant`/`izzie` become L1 "standard" — retaining the documented black-box posture.

- **#4168 — tier in the agent-config model.** Adds `AgentInfo.tier: Option<String>` (TOML `[agent].tier`, `.md` frontmatter `tier`) plus `AgentTier` (`L1Standard` / `L0Orchestration`) and `AgentInfo::tier()`, the single fail-closed resolver every consumer must call.
- **#4169 — the one-directional delegation gate.** `delegate_to_agent` refuses any call where the resolved target's tier is `L0Orchestration` unless the delegator's own tier is also `L0Orchestration`.

Closes #4168, Closes #4169

## Design decisions

**Dedicated `tier` field vs. deriving from `role`.** Chose a dedicated field. `role` already has three overloaded meanings in this codebase (dispatch-branch selection in `build_registry_for_agent`, delegate-target allowlisting via `ASSISTANT_ALLOWED_DELEGATE_ROLES`, and capability matching) — `AgentInfo.hidden`'s own doc comment already names the hazard of layering a fourth meaning onto `role`: *"repurposing role would silently change tool permissions too — not a safe mechanism."* A dedicated field keeps this privilege boundary explicit, grep-able, and immune to an unrelated `role` edit silently changing it.

**Fail-closed resolution (`AgentInfo::tier()`).** Mirrors the existing `ToolsConfig::search_indexes_enforced()` pattern: a raw `Option<String>` field plus a normalizing accessor. Absent, blank, or any unrecognized string resolves to `AgentTier::L1Standard` — never `L0Orchestration`. Recognized aliases: `l0`/`orchestration` → L0; `l1`/`standard` → L1 (case-insensitive, trimmed).

**`extends` composition.** Child-declares-wins, child-omits-inherits — the same posture `enforce_search_indexes`/`default_tier` already use ("a hardened base stays hardened under a silent overlay"). An L0 base's tier travels to a child overlay that never redeclares `tier`; a child can still explicitly downgrade (or upgrade) it.

**The delegation gate builds on #4161's taint machinery, not a replacement.** `compose_delegation_taint` / `scope_for_delegation` still own tool-surface narrowing across hops. The tier gate is an independent, additional pre-flight check inside `DelegateToAgentTool::execute()`, alongside the existing `allowed_target_roles` role gate.

**Every dispatch/registry-construction site, enumerated:**
| Site | Coverage |
|---|---|
| `runtime/subagent_mode.rs` → `tool_registry::build_assistant_tier_registry` | Gated — `cfg.agent.tier()` threaded through `with_delegator_tier` |
| `ctrl/pm_task/dispatch/persona.rs` (`run_pm_task_with_persona`, REPL `/agent`) | Gated — added `with_delegator_tier`; tier check now applies even without a role allowlist (a pre-existing, separate gap in this path) |
| `ctrl/pm_task/dispatch/history.rs` (`ctrl_delegate_posture`, backs REPL/Slack/Telegram/API) | Gated for the `role == "assistant"` branch (forwards its own declared tier); the `role != "assistant"` (pm/ctrl-as-orchestrator) branch reports `L0Orchestration` deliberately — it sits outside the persona tier model, already fully trusted, already unreachable as a delegation target from any L1 persona (`orchestrator` was never in `ASSISTANT_ALLOWED_DELEGATE_ROLES`) |
| `runtime/pm_mode.rs::run_pm()` | Not gated, deliberately — builds its `DelegateToAgentTool` with **no** `config_dirs`, so pre-flight validation (including the new tier gate) is skipped entirely, byte-identical to before. Documented in a code comment at the call site; unreachable transitively from any L1 persona for the same role-allowlist reason as above |

**Multi-hop escalation.** Because the tier check re-resolves the CURRENT delegator's own tier at every hop (not a value threaded/copied across hops), no chain of L1→L1→…→L0 can succeed — proven by `delegate_multi_hop_l1_peer_to_l0_is_refused` (assistant → izzie → orchestration-target, hop 2 refused). Worker roles (`engineer`, `qa-agent`, …) never register `delegate_to_agent` at all, closing the other multi-hop avenue structurally.

**A regression I caught and fixed during implementation:** my first pass made `delegator_tier` a plain `AgentTier` (default `L1Standard`) and forced full `AgentConfig` resolution whenever it wasn't `L0Orchestration` — this broke two pre-existing tests using bare/incomplete fixture TOMLs that only need the cheap existence-only check. Fixed by making the field `Option<AgentTier>`: `None` (never opted in) preserves the exact pre-#4169 cheap-path behavior; the tier gate activates when EITHER `allowed_target_roles` OR `delegator_tier` is explicitly set, with a fail-closed `L1Standard` default for a caller that set one but not the other. See `no_tier_and_no_role_gate_preserves_cheap_existence_check` for the regression guard.

## Not in scope (deliberately)

No L0 persona instance created, no `~/.trusty-agents/agents/` changes, no GitHub/PR/CI tooling, no session-state read, no cross-project scoping, no shell/build/test grant — those are #4170-#4173, and landing the boundary before the grants is the point (the reverse order would create a live escalation target).

## Test plan

- [x] `cargo fmt --check -p trusty-agents` — clean
- [x] `cargo clippy -p trusty-agents --lib --tests -- -D warnings` — clean
- [x] `cargo test -p trusty-agents --lib` — 2832 passed, 0 failed, 11 ignored (1 known-flaky, environment-only `python_skill` test that also fails in isolation runs on unrelated `uv`/venv build contention — reproduced as passing standalone both before and after this diff)
- [x] `bash scripts/check_line_cap.sh` — 0 violations
- [x] `bash scripts/check_test_pointers.sh` — 0 dangling pointers
- [x] `bash scripts/check_sld.sh` — 0 errors/warnings
- [x] `bash scripts/check_claude_md_not_tracked.sh` / `check_instruction_floor.sh` — pass
- [x] The single most important test: `delegate_l1_to_l0_is_refused`
- [x] Counter-test: `delegate_l0_to_l1_succeeds`
- [x] Transitive/multi-hop: `delegate_multi_hop_l1_peer_to_l0_is_refused`
- [x] Fail-closed tier parsing: `agent_tier_defaults_to_l1_when_absent`, `agent_tier_unknown_value_fails_closed_to_l1`, `agent_tier_blank_value_fails_closed_to_l1`
- [x] `extends` composition: `extends_tier_child_inherits_l0_from_base_when_omitted`, `extends_tier_child_can_downgrade_l0_base_to_l1`
- [x] End-to-end through real production wiring (`agents_dir_candidates()` + `build_assistant_tier_registry`, not hand-built args): `assistant_tier_registry_delegator_tier_blocks_l0_target_end_to_end`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
