### PR TITLE
harden(trusty-mpm): prevent, alarm on, and detect cross-session worktree destruction (#3764)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,59 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Detect a session whose own worktree has been destroyed underneath it**
+  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)): the
+  orphan-GC tick now audits every Active session's own worktree and raises an
+  ERROR-level `WORKTREE DESTROYED` alarm when it is no longer a git work tree.
+  Nothing previously asked this question, which is why a session ran for three
+  days inside a stripped worktree while every surface reported it healthy: with
+  the `.git` pointer gone, git discovery walks up to the enclosing clone, so
+  `git log` still prints plausible commits and `git status`'s fatal renders as
+  `Status: (clean)`. The probe is `git rev-parse --show-toplevel` compared
+  against the session's own root — deliberately **not**
+  `--is-inside-work-tree`, which returns `true` for a fully destroyed worktree
+  whenever the parent clone is non-bare (regression-tested against real git in
+  both layouts). A probe that cannot run reports `Unknown`, never healthy. The
+  audit is read-only: it reports, never repairs.
+- **Forensics runbook for worktree corruption**
+  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)):
+  `docs/runbooks/worktree-corruption-forensics.md` — what to capture, in what
+  order, before a stop overwrites the only surviving pane transcript, plus the
+  one probe that is safe to trust from inside a suspect directory. The #1845 F3
+  streak alarm now names this runbook in-message; a test pins that the path
+  resolves so the pointer cannot rot.
+
+### Fixed
+
+- **Refuse to delete a live peer session's worktree**
+  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)):
+  `decommission` now asks the worktree's on-disk ownership sentinel who owns it
+  and refuses, with an ERROR alarm and a new `ForeignActiveWorktree` error, when
+  that owner is a different session that is still Active. The pre-existing
+  containment guard only ever checked that a path was inside the managed root —
+  which every sibling session's worktree also is — and #3649's owner gate only
+  fires when a session self-identifies as `caller`, so every daemon-routed
+  remove path (the `session_decommission` MCP tool, the sm-stdio control
+  channel, the HTTP routes, the idle reaper, `dedup`) passed `None` and skipped
+  it entirely. That left the observed incident shape unguarded: a #1744 cwd
+  collision leaves several Active records pointing at one worktree, and
+  decommissioning any impostor destroys the real owner's live tree. The new
+  guard is independent of `caller`, reads ownership from the tree rather than
+  from the (possibly corrupt) record that asked, and can only ever refuse a
+  deletion — a non-Active owner still reclaims exactly as before, so #3649's
+  orphan-GC and #3721's recreation guard are untouched.
+- **The #1744 cwd collision is now a corruption alarm, not a silent skip**
+  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)): when ≥2
+  Active session records resolve to the same worktree path,
+  `correlate_session_start` raises an ERROR-level `SESSION REGISTRY CORRUPTION`
+  alarm naming every colliding session id, instead of the previous `warn!` that
+  logged only a count. Two Active records at one worktree describes a state that
+  cannot physically exist, and a 3-way collision on the exact path was the
+  observed precursor hours before the last corruption. The level is
+  load-bearing: the daemon's bug-capture layer persists only ERROR events to
+  `errors.jsonl`, so at WARN this condition was invisible to
+  `list_recent_errors` and `tm doctor` alike.
+
 - **Cross-branch `git push` guard for every worktree of a managed base clone**
   ([#2867](https://github.com/bobmatnyc/trusty-tools/issues/2867)): a bundled
   `pre-push` hook now refuses any push that would OVERWRITE AN EXISTING remote

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -11,18 +11,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - **Detect a session whose own worktree has been destroyed underneath it**
   ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)): the
-  orphan-GC tick now audits every Active session's own worktree and raises an
-  ERROR-level `WORKTREE DESTROYED` alarm when it is no longer a git work tree.
-  Nothing previously asked this question, which is why a session ran for three
-  days inside a stripped worktree while every surface reported it healthy: with
-  the `.git` pointer gone, git discovery walks up to the enclosing clone, so
-  `git log` still prints plausible commits and `git status`'s fatal renders as
-  `Status: (clean)`. The probe is `git rev-parse --show-toplevel` compared
-  against the session's own root — deliberately **not**
-  `--is-inside-work-tree`, which returns `true` for a fully destroyed worktree
-  whenever the parent clone is non-bare (regression-tested against real git in
-  both layouts). A probe that cannot run reports `Unknown`, never healthy. The
-  audit is read-only: it reports, never repairs.
+  orphan-GC tick now audits every Active session's own worktree and alarms at
+  ERROR when it is no longer a git work tree. Nothing previously asked this
+  question, which is why a session ran for three days inside a stripped worktree
+  while every surface reported it healthy: with the `.git` linkage gone, git
+  discovery walks up to the enclosing clone, so `git log` still prints plausible
+  commits and `git status`'s fatal renders as `Status: (clean)`. The probe is
+  `git rev-parse --show-toplevel` compared against the session's own root —
+  deliberately **not** `--is-inside-work-tree`, which returns `true` for a fully
+  destroyed worktree whenever the parent clone is non-bare (regression-tested
+  against real git in both layouts). The alarm distinguishes **linkage lost with
+  files still on disk** (recover them; do NOT decommission) from a genuinely
+  **empty** directory, so it never tells an operator their work is gone on a
+  tree whose files survive — the state the 07-21 `.base` destruction left ~70
+  worktrees in. The git probe is bounded by the same timeout
+  `remove_session_worktree` uses, so a stalled mount cannot wedge the sweep; a
+  probe that times out or cannot run reports `Unknown`, never healthy, and an
+  audit in which *every* verdict is `Unknown` alarms at ERROR in its own right
+  ("the detector is dark"). Findings are latched — alarm on transition, then
+  hourly — so one persistent finding cannot rotate the 500-entry error ring and
+  evict everything else from `list_recent_errors`. The audit is read-only: it
+  reports, never repairs.
 - **Forensics runbook for worktree corruption**
   ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)):
   `docs/runbooks/worktree-corruption-forensics.md` — what to capture, in what
@@ -30,37 +39,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   one probe that is safe to trust from inside a suspect directory. The #1845 F3
   streak alarm now names this runbook in-message; a test pins that the path
   resolves so the pointer cannot rot.
-
-### Fixed
-
-- **Refuse to delete a live peer session's worktree**
-  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)):
-  `decommission` now asks the worktree's on-disk ownership sentinel who owns it
-  and refuses, with an ERROR alarm and a new `ForeignActiveWorktree` error, when
-  that owner is a different session that is still Active. The pre-existing
-  containment guard only ever checked that a path was inside the managed root —
-  which every sibling session's worktree also is — and #3649's owner gate only
-  fires when a session self-identifies as `caller`, so every daemon-routed
-  remove path (the `session_decommission` MCP tool, the sm-stdio control
-  channel, the HTTP routes, the idle reaper, `dedup`) passed `None` and skipped
-  it entirely. That left the observed incident shape unguarded: a #1744 cwd
-  collision leaves several Active records pointing at one worktree, and
-  decommissioning any impostor destroys the real owner's live tree. The new
-  guard is independent of `caller`, reads ownership from the tree rather than
-  from the (possibly corrupt) record that asked, and can only ever refuse a
-  deletion — a non-Active owner still reclaims exactly as before, so #3649's
-  orphan-GC and #3721's recreation guard are untouched.
-- **The #1744 cwd collision is now a corruption alarm, not a silent skip**
-  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)): when ≥2
-  Active session records resolve to the same worktree path,
-  `correlate_session_start` raises an ERROR-level `SESSION REGISTRY CORRUPTION`
-  alarm naming every colliding session id, instead of the previous `warn!` that
-  logged only a count. Two Active records at one worktree describes a state that
-  cannot physically exist, and a 3-way collision on the exact path was the
-  observed precursor hours before the last corruption. The level is
-  load-bearing: the daemon's bug-capture layer persists only ERROR events to
-  `errors.jsonl`, so at WARN this condition was invisible to
-  `list_recent_errors` and `tm doctor` alike.
 
 - **Cross-branch `git push` guard for every worktree of a managed base clone**
   ([#2867](https://github.com/bobmatnyc/trusty-tools/issues/2867)): a bundled
@@ -169,6 +147,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ordering-dependent behaviour is reproducible.
 
 ### Fixed
+
+- **Refuse to delete another session's worktree**
+  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)):
+  `decommission` now establishes who owns a worktree from evidence the record
+  requesting the removal does not control — the worktree's own on-disk ownership
+  sentinel, plus an unforgeable store-side check for any OTHER record bound to
+  the same canonical path — and refuses with an ERROR alarm and a new
+  `ForeignActiveWorktree` error (HTTP 409) when that owner is a different
+  session which is not provably ownerless. The pre-existing containment guard
+  only ever checked that a path was inside the managed root, which every sibling
+  session's worktree also is; and #3649's owner gate only fires when a session
+  self-identifies as `caller`, so every daemon-routed remove path (the
+  `session_decommission` MCP tool, the sm-stdio control channel, the HTTP
+  routes, the idle reaper, `dedup`) passed `None` and skipped it. That left the
+  observed incident shape unguarded: a #1744 cwd collision leaves several
+  records pointing at one worktree, and decommissioning any impostor destroys
+  the real owner's tree. Reclaimability uses the same `resolve_ownerless`
+  predicate as the #3649 gate and the orphan sweep, so a **Stopped** peer's
+  resumable worktree is protected too — the reachable case being `idle_reaper`
+  stopping a peer and later reaping a colliding record via `caller: None`. Only
+  a provably ownerless owner (terminal, or absent from the store) still
+  reclaims, so #3649's orphan-GC and #3721's recreation guard are untouched, and
+  `tm sessions delete <stale-id>` remains the operator's release valve for a
+  stale sentinel.
+- **The #1744 cwd collision is now a corruption alarm, not a silent skip**
+  ([#3764](https://github.com/bobmatnyc/trusty-tools/issues/3764)): when ≥2
+  Active session records resolve to the same worktree path,
+  `correlate_session_start` raises an ERROR-level `SESSION REGISTRY CORRUPTION`
+  alarm naming every colliding session id, instead of the previous `warn!` that
+  logged only a count. Two Active records at one worktree describes a state that
+  cannot physically exist, and a 3-way collision on the exact path was the
+  observed precursor hours before the last corruption. The level is
+  load-bearing: the daemon's bug-capture layer persists only ERROR events to
+  `errors.jsonl`, so at WARN this condition was invisible to
+  `list_recent_errors` and `tm doctor` alike.
 
 - **Two wrong instructions corrected in the bundled assets composed into every
   session's prompt.** Both were static text that no project could override, and

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1329,11 +1329,19 @@ pub async fn ingest_hook(
 /// What: extracts `cwd` from `payload["cwd"]`; canonicalizes it and each record's
 /// `workspace_path`/`cwd` (falling back to raw path on error so macOS
 /// `/private/tmp` ↔ `/tmp` symlinks resolve); finds Active managed sessions whose
-/// path matches. If more than one Active session matches the cwd (ambiguous) the
-/// correlation is skipped with a warning to avoid mis-attribution. Single match →
-/// `SessionManager::set_claude_session_id`. Best-effort — failures are logged and
-/// silently swallowed so a missing correlation never blocks the hook response.
-/// Test: `session_start_hook_correlates_claude_id` in `api_tests.rs`.
+/// path matches. The matched set is classified by
+/// [`cwd_collision::classify`](crate::daemon::cwd_collision::classify): a single
+/// match → `SessionManager::set_claude_session_id`; ≥2 matches → attribution is
+/// still skipped (mis-assignment remains the worse outcome) but the condition is
+/// now escalated to an ERROR-level corruption alarm via
+/// [`cwd_collision::alarm`](crate::daemon::cwd_collision::alarm) instead of the
+/// pre-#3764 `warn!` that no operator surface ever saw. Two Active records at one
+/// worktree is registry corruption, not an attribution nuisance — see that
+/// module's doc for why ERROR (not WARN) is load-bearing here.
+/// Best-effort otherwise — failures are logged and swallowed so a missing
+/// correlation never blocks the hook response.
+/// Test: `session_start_hook_correlates_claude_id` in `api_tests.rs`;
+/// `classify_*` / `alarm_is_error_level` in `daemon::cwd_collision`.
 async fn correlate_session_start(
     state: &Arc<DaemonState>,
     claude_session_id: &str,
@@ -1364,12 +1372,13 @@ async fn correlate_session_start(
             let cwd_canon = std::fs::canonicalize(&r.cwd).unwrap_or_else(|_| r.cwd.clone());
             ws_canon.as_deref() == Some(hook_cwd.as_path()) || cwd_canon == hook_cwd
         })
+        .map(|r| r.id)
         .collect();
 
-    match matched.len() {
-        0 => {} // no Active managed session at this cwd — silent, not an error
-        1 => {
-            let id = matched[0].id;
+    match crate::daemon::cwd_collision::classify(&matched) {
+        // No Active managed session at this cwd — ordinary, not an error.
+        crate::daemon::cwd_collision::CwdCorrelation::None => {}
+        crate::daemon::cwd_collision::CwdCorrelation::Unique(id) => {
             match mgr.set_claude_session_id(&id, claude_session_id).await {
                 Ok(()) => tracing::info!(
                     managed_id = %id,
@@ -1383,13 +1392,8 @@ async fn correlate_session_start(
                 ),
             }
         }
-        n => {
-            tracing::warn!(
-                cwd = %cwd_str,
-                n,
-                "SessionStart: {n} Active managed sessions share the same cwd — \
-                 skipping claude_session_id attribution to avoid mis-assignment (#1744)"
-            );
+        crate::daemon::cwd_collision::CwdCorrelation::Collision(ids) => {
+            crate::daemon::cwd_collision::alarm(cwd_str, &ids);
         }
     }
 }

--- a/crates/trusty-mpm/src/daemon/cwd_collision.rs
+++ b/crates/trusty-mpm/src/daemon/cwd_collision.rs
@@ -25,7 +25,7 @@
 //! What: [`CwdCorrelation`] (the pure verdict), [`classify`] (the pure
 //! classifier — the testable core), and [`alarm`] (the loud rendering of a
 //! [`CwdCorrelation::Collision`]).
-//! Test: `classify_*` and `collision_*` below; the wired-in behaviour is
+//! Test: `classify_*` and `alarm_is_error_level` below; the wired-in behaviour is
 //! covered by `session_start_hook_correlates_claude_id` in `api_tests.rs`.
 
 use crate::session_manager::record::ManagedSessionId;
@@ -80,8 +80,8 @@ pub(crate) fn classify(matched: &[ManagedSessionId]) -> CwdCorrelation {
 /// `session_manager::prune`, which escalates the same way for the same reason.
 /// What: one `error!` naming the cwd, the collision count, and EVERY colliding
 /// session id, plus the concrete next action. No side effects beyond the log.
-/// Test: `alarm_is_error_level` (pins the level via `tracing::Level`),
-/// `collision_ids_are_all_reported`.
+/// Test: `alarm_is_error_level` (pins the level via `tracing::Level`, and that
+/// every colliding id appears in the `sessions` field).
 pub(crate) fn alarm(cwd: &str, ids: &[ManagedSessionId]) {
     let rendered: Vec<String> = ids.iter().map(ToString::to_string).collect();
     tracing::error!(

--- a/crates/trusty-mpm/src/daemon/cwd_collision.rs
+++ b/crates/trusty-mpm/src/daemon/cwd_collision.rs
@@ -1,0 +1,231 @@
+//! `SessionStart` cwd→session correlation, and the #3764 item-2 corruption
+//! alarm for a colliding cwd.
+//!
+//! Why: `correlate_session_start` (`daemon/api.rs`) has always treated "≥2
+//! Active managed session records resolve to the same cwd" as a mere
+//! *attribution* problem — it skipped persisting `claude_session_id` and logged
+//! a `warn!`, then carried on as if nothing were wrong. It is not an
+//! attribution problem. Two Active records pointing at ONE worktree means the
+//! registry is describing a state that cannot physically exist, and it is the
+//! precursor the #3715 worktree-destruction forensics found sitting on the
+//! exact path that was later wiped: a 3-way collision at 01:58–02:16Z, hours
+//! before the corruption began, that passed almost silently. Any decommission,
+//! reap, or GC of the wrong one of those records destroys a LIVE session's
+//! tree (which is what the #3764 item-1 guard now refuses).
+//!
+//! The escalation from `warn!` to `error!` is the whole point and is NOT
+//! cosmetic: the daemon composes `trusty_common::error_capture::bug_capture_layer`
+//! (`bin/tm/main.rs`), which persists ERROR-level events to
+//! `<data_dir>/trusty-mpm/errors.jsonl` and surfaces them through the
+//! `list_recent_errors` MCP tool, `preview_bug_report`, and `tm doctor`.
+//! `warn!` is captured by NONE of those. At WARN this condition was invisible
+//! to every operator-facing surface; at ERROR it becomes a durable, greppable,
+//! queryable record the moment it first occurs.
+//!
+//! What: [`CwdCorrelation`] (the pure verdict), [`classify`] (the pure
+//! classifier — the testable core), and [`alarm`] (the loud rendering of a
+//! [`CwdCorrelation::Collision`]).
+//! Test: `classify_*` and `collision_*` below; the wired-in behaviour is
+//! covered by `session_start_hook_correlates_claude_id` in `api_tests.rs`.
+
+use crate::session_manager::record::ManagedSessionId;
+
+/// What a `SessionStart` hook's cwd resolved to among the Active records.
+///
+/// Why: making the three outcomes an explicit enum — instead of a bare
+/// `match matched.len()` buried in a 2 000-line HTTP module — is what makes the
+/// corruption case testable at all, and what stops a future edit from quietly
+/// folding [`Self::Collision`] back into "nothing to do".
+/// What: [`None`](Self::None) — no Active record at this cwd (ordinary; an
+/// unmanaged shell). [`Unique`](Self::Unique) — exactly one; attribute to it.
+/// [`Collision`](Self::Collision) — TWO OR MORE, which is registry corruption.
+/// Test: `classify_no_match_is_none`, `classify_single_match_is_unique`,
+/// `classify_two_matches_is_collision`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum CwdCorrelation {
+    /// No Active managed session is running at this cwd.
+    None,
+    /// Exactly one Active managed session — safe to attribute.
+    Unique(ManagedSessionId),
+    /// ≥2 Active records share this cwd: physically impossible, corruption.
+    Collision(Vec<ManagedSessionId>),
+}
+
+/// Classify the Active records that matched a `SessionStart` hook's cwd.
+///
+/// Why: the pure half, so the corruption verdict can be asserted directly
+/// rather than by scraping log output. Pre-#3764 this logic existed only as an
+/// inline `match matched.len() { 0 => {}, 1 => ..., n => warn!(...) }`, whose
+/// `n` arm was indistinguishable from the `0` arm in effect — both did nothing.
+/// What: `[]` → [`CwdCorrelation::None`]; `[id]` → [`CwdCorrelation::Unique`];
+/// anything longer → [`CwdCorrelation::Collision`] carrying every colliding id
+/// so the alarm can name them (the pre-#3764 warn logged only a COUNT, which
+/// gave an operator nothing to act on).
+/// Test: `classify_no_match_is_none`, `classify_single_match_is_unique`,
+/// `classify_two_matches_is_collision`, `classify_three_matches_lists_all_ids`.
+pub(crate) fn classify(matched: &[ManagedSessionId]) -> CwdCorrelation {
+    match matched {
+        [] => CwdCorrelation::None,
+        [only] => CwdCorrelation::Unique(*only),
+        many => CwdCorrelation::Collision(many.to_vec()),
+    }
+}
+
+/// Emit the error-level corruption alarm for a colliding cwd (#3764 item 2).
+///
+/// Why: see the module doc — ERROR is the only level the daemon's bug-capture
+/// layer persists, so this level choice is what makes the condition visible to
+/// `list_recent_errors` / `tm doctor` instead of dying in a log file nobody
+/// greps. Mirrors the #3715 F3 streak alarm in
+/// `session_manager::prune`, which escalates the same way for the same reason.
+/// What: one `error!` naming the cwd, the collision count, and EVERY colliding
+/// session id, plus the concrete next action. No side effects beyond the log.
+/// Test: `alarm_is_error_level` (pins the level via `tracing::Level`),
+/// `collision_ids_are_all_reported`.
+pub(crate) fn alarm(cwd: &str, ids: &[ManagedSessionId]) {
+    let rendered: Vec<String> = ids.iter().map(ToString::to_string).collect();
+    tracing::error!(
+        cwd = %cwd,
+        collisions = ids.len(),
+        sessions = %rendered.join(","),
+        "SESSION REGISTRY CORRUPTION: {} Active managed session records resolve to the \
+         SAME workspace path — this state cannot physically exist and is the observed \
+         precursor to cross-session worktree destruction. claude_session_id attribution \
+         is skipped. Reconcile these records NOW (`tm ls`, `tm sessions delete <stale-id>`) \
+         before any decommission/reap touches that path (#3764, precursor to #3715)",
+        ids.len()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_no_match_is_none() {
+        assert_eq!(classify(&[]), CwdCorrelation::None);
+    }
+
+    #[test]
+    fn classify_single_match_is_unique() {
+        let id = ManagedSessionId::new();
+        assert_eq!(classify(&[id]), CwdCorrelation::Unique(id));
+    }
+
+    /// TWO Active records at one cwd is a Collision, not a benign skip.
+    ///
+    /// Why: this is the assertion that fails against pre-#3764 `main`, where
+    /// the `n` arm produced no distinguishable outcome at all.
+    /// Test: this function IS the test.
+    #[test]
+    fn classify_two_matches_is_collision() {
+        let a = ManagedSessionId::new();
+        let b = ManagedSessionId::new();
+        assert_eq!(classify(&[a, b]), CwdCorrelation::Collision(vec![a, b]));
+    }
+
+    /// The 3-way collision actually observed before the #3715 corruption is
+    /// reported with ALL THREE ids, not just a count.
+    ///
+    /// Why: the pre-#3764 warn logged `n` only. An operator who saw it had no
+    /// way to know WHICH records to reconcile, so the log was unactionable
+    /// even in the one case where somebody read it.
+    /// Test: this function IS the test.
+    #[test]
+    fn classify_three_matches_lists_all_ids() {
+        let ids = [
+            ManagedSessionId::new(),
+            ManagedSessionId::new(),
+            ManagedSessionId::new(),
+        ];
+        match classify(&ids) {
+            CwdCorrelation::Collision(reported) => {
+                assert_eq!(
+                    reported,
+                    ids.to_vec(),
+                    "every colliding id must be reported"
+                );
+            }
+            other => panic!("3 Active records at one cwd must be a Collision, got {other:?}"),
+        }
+    }
+
+    /// The alarm is emitted at ERROR, the only level the daemon's bug-capture
+    /// layer persists to `errors.jsonl` / `list_recent_errors`.
+    ///
+    /// Why: this is the "fail LOUD, never silent" invariant itself. A future
+    /// edit softening this back to `warn!` would restore the exact silence
+    /// that let a 3-way collision sit unnoticed for hours before the worktree
+    /// was destroyed — so the level is asserted, not assumed.
+    /// What: installs a subscriber that records the level of every event, runs
+    /// [`alarm`], and asserts an ERROR was emitted carrying the colliding ids.
+    /// Test: this function IS the test.
+    #[test]
+    fn alarm_is_error_level() {
+        use std::sync::{Arc, Mutex};
+        use tracing::field::{Field, Visit};
+
+        #[derive(Default)]
+        struct Captured {
+            levels: Vec<tracing::Level>,
+            sessions: Vec<String>,
+        }
+
+        struct Collector(Arc<Mutex<Captured>>);
+
+        // `tracing`'s `%` sigil records through `record_debug` (the value is
+        // wrapped in `field::display`), never `record_str` — so both are
+        // implemented here rather than assuming one.
+        struct FieldGrab<'a>(&'a mut Vec<String>);
+        impl Visit for FieldGrab<'_> {
+            fn record_debug(&mut self, f: &Field, v: &dyn std::fmt::Debug) {
+                if f.name() == "sessions" {
+                    self.0.push(format!("{v:?}"));
+                }
+            }
+            fn record_str(&mut self, f: &Field, v: &str) {
+                if f.name() == "sessions" {
+                    self.0.push(v.to_string());
+                }
+            }
+        }
+
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Collector {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                let mut cap = self.0.lock().expect("lock");
+                cap.levels.push(*event.metadata().level());
+                let mut grab = FieldGrab(&mut cap.sessions);
+                event.record(&mut grab);
+            }
+        }
+
+        let captured = Arc::new(Mutex::new(Captured::default()));
+        let subscriber = {
+            use tracing_subscriber::layer::SubscriberExt as _;
+            tracing_subscriber::registry().with(Collector(Arc::clone(&captured)))
+        };
+
+        let a = ManagedSessionId::new();
+        let b = ManagedSessionId::new();
+        tracing::subscriber::with_default(subscriber, || {
+            alarm("/tmp/contested-worktree", &[a, b]);
+        });
+
+        let cap = captured.lock().expect("lock");
+        assert!(
+            cap.levels.contains(&tracing::Level::ERROR),
+            "the cwd-collision alarm MUST be ERROR (the only level the daemon's \
+             bug-capture layer persists); observed levels: {:?}",
+            cap.levels
+        );
+        let joined = cap.sessions.join(" ");
+        assert!(
+            joined.contains(&a.to_string()) && joined.contains(&b.to_string()),
+            "the alarm must name every colliding session id; got {joined:?}"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -860,6 +860,14 @@ pub async fn decommission_managed_session(
         Err(crate::session_manager::ManagedError::SessionNotFound(_)) => {
             (StatusCode::NOT_FOUND, format!("session {id_str} not found")).into_response()
         }
+        // #3764: the cross-session worktree guard REFUSED — the caller's record
+        // points at a live peer's worktree. That is a conflict in the request,
+        // not a server fault, so 409 (matching the sibling delete route's
+        // running-guard refusal) instead of the catch-all 500. The manager's
+        // message already names both sessions and the contested path.
+        Err(e @ crate::session_manager::ManagedError::ForeignActiveWorktree(..)) => {
+            (StatusCode::CONFLICT, e.to_string()).into_response()
+        }
         Err(e) => (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response(),
     }
 }

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -14,6 +14,7 @@ pub mod audit;
 pub mod bug_report;
 pub mod claude_config;
 pub mod coordinator;
+pub(crate) mod cwd_collision;
 pub mod discover;
 pub mod discovery;
 pub mod doctor;
@@ -699,6 +700,22 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                     }
                     Err(e) => tracing::warn!("orphan-GC worktree sweep failed: {e}"),
                 }
+
+                // #3764 item 4: check every Active session's OWN worktree and
+                // alarm loudly on any that has been destroyed underneath it.
+                // Every other guard in this loop asks "should I delete that?";
+                // this is the only one that asks "is MY tree still there?" —
+                // the gap that let a session run for THREE DAYS in a stripped
+                // worktree while `git log` kept answering from the enclosing
+                // repo and `git status`'s fatal rendered as a clean status.
+                // Read-only by construction: it reports, never repairs, because
+                // silently reconstituting a vanished root is the #3715 masking
+                // behaviour. The first tick after daemon start doubles as the
+                // at-start self-check, so no separate startup path is needed.
+                // Both the per-finding alarms and the sweep-level roll-up are
+                // emitted inside the audit; the returned findings exist for its
+                // tests, so the result is deliberately unused here.
+                let _ = mgr.audit_worktree_integrity().await;
 
                 // #2033: sweep orphaned / 0-chunk trusty-search indexes left
                 // behind by managed worktrees — sessions decommissioned before

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -363,6 +363,41 @@ impl SessionManager {
             return Err(ManagedError::WorktreeOwnerMismatch(caller_id, owner, *id));
         }
 
+        // #3764 item 1 — cross-session deletion guard. Deliberately runs AFTER
+        // the #3649 authority gate (which it does not weaken or replace) and
+        // BEFORE any teardown side effect, including `graceful_terminate_runtime`
+        // and the search-index id derivation: if this record points at a live
+        // peer's worktree it is the RECORD that is wrong, and nothing about this
+        // decommission should proceed. Unlike #3649's gate this is independent
+        // of `caller`, so it also covers every operator/daemon-internal
+        // (`caller: None`) remove path — the MCP `session_decommission` tool,
+        // the sm-stdio control channel, the HTTP routes, the idle reaper, and
+        // `dedup` — which is where the hole actually was.
+        //
+        // The `error!` is the alarm surface, not decoration: the daemon composes
+        // `trusty_common::error_capture::bug_capture_layer`, which persists
+        // ERROR-level events to `<data_dir>/trusty-mpm/errors.jsonl` and exposes
+        // them via the `list_recent_errors` MCP tool and `tm doctor`. `warn!`
+        // is NOT captured, so an alarm at WARN would be silent to every
+        // operator-facing surface — exactly the failure mode #3764 exists to end.
+        if let Some(ref ws) = record.workspace_path
+            && let Some(owner) = self.foreign_active_worktree_owner(ws, *id).await
+        {
+            tracing::error!(
+                target_session = %id,
+                live_owner = %owner,
+                workspace = %ws.display(),
+                "WORKTREE CORRUPTION GUARD: refusing to decommission — this record's \
+                 workspace_path points at a worktree owned by session {owner}, which is \
+                 still ACTIVE. No files were touched (#3764)"
+            );
+            return Err(ManagedError::ForeignActiveWorktree(
+                *id,
+                owner,
+                ws.display().to_string(),
+            ));
+        }
+
         // #2033: derive the trusty-search index id for a disposable workspace
         // (SM-owned clone or in-project worktree — see
         // `search_gc::disposable_workspace_index_id`) BEFORE any removal

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -366,13 +366,27 @@ impl SessionManager {
         // #3764 item 1 — cross-session deletion guard. Deliberately runs AFTER
         // the #3649 authority gate (which it does not weaken or replace) and
         // BEFORE any teardown side effect, including `graceful_terminate_runtime`
-        // and the search-index id derivation: if this record points at a live
-        // peer's worktree it is the RECORD that is wrong, and nothing about this
-        // decommission should proceed. Unlike #3649's gate this is independent
-        // of `caller`, so it also covers every operator/daemon-internal
-        // (`caller: None`) remove path — the MCP `session_decommission` tool,
-        // the sm-stdio control channel, the HTTP routes, the idle reaper, and
-        // `dedup` — which is where the hole actually was.
+        // and the search-index id derivation: if this record points at another
+        // session's worktree it is the RECORD that is wrong, and nothing about
+        // this decommission should proceed. Unlike #3649's gate this is
+        // independent of `caller`, so it also covers every operator/daemon-
+        // internal (`caller: None`) remove path — the MCP `session_decommission`
+        // tool, the sm-stdio control channel, the HTTP routes, the idle reaper,
+        // and `dedup` — which is where the hole actually was.
+        //
+        // SCOPE: only when this decommission would actually TOUCH THE
+        // FILESYSTEM. `decommission` deletes the workspace in exactly two
+        // cases — an SM-owned workspace (`remove_dir_all` below) or an
+        // in-project worktree (`remove_session_worktree`) — and otherwise just
+        // warns and tombstones the record. Guarding the record-only case would
+        // be pure over-refusal, and it breaks a legitimate caller: `dedup`
+        // collapses a dead duplicate that by construction shares a
+        // `workspace_path` with the record it is deduplicating against
+        // (`reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record`).
+        // That collapse is the very registry reconciliation this guard wants an
+        // operator to perform, and it destroys nothing. Scoping the guard to
+        // destructive removals makes it exactly coextensive with the harm it
+        // prevents.
         //
         // The `error!` is the alarm surface, not decoration: the daemon composes
         // `trusty_common::error_capture::bug_capture_layer`, which persists
@@ -381,15 +395,17 @@ impl SessionManager {
         // is NOT captured, so an alarm at WARN would be silent to every
         // operator-facing surface — exactly the failure mode #3764 exists to end.
         if let Some(ref ws) = record.workspace_path
+            && (record.workspace_owned || is_session_worktree(ws))
             && let Some(owner) = self.foreign_active_worktree_owner(ws, *id).await
         {
             tracing::error!(
                 target_session = %id,
-                live_owner = %owner,
+                contesting_owner = %owner,
                 workspace = %ws.display(),
                 "WORKTREE CORRUPTION GUARD: refusing to decommission — this record's \
-                 workspace_path points at a worktree owned by session {owner}, which is \
-                 still ACTIVE. No files were touched (#3764)"
+                 workspace_path points at a worktree belonging to session {owner}, which \
+                 is still live or resumable. No files were touched. Reconcile the registry \
+                 (`tm ls`), then `tm sessions delete {owner}` if that record is stale (#3764)"
             );
             return Err(ManagedError::ForeignActiveWorktree(
                 *id,

--- a/crates/trusty-mpm/src/session_manager/error.rs
+++ b/crates/trusty-mpm/src/session_manager/error.rs
@@ -146,10 +146,20 @@ pub enum ManagedError {
     /// authority. It is returned rather than silently skipped because the
     /// tombstone path clears `workspace_path`, which would destroy the only
     /// remaining evidence of the mis-pointing record.
-    /// What: `(target, owner, path)` — the record asked about, the live owner
-    /// the worktree's on-disk sentinel names, and the contested path. No files
-    /// are touched when this is returned; both records need investigation
-    /// before any retry.
+    /// What: `(target, owner, path)` — the record asked about, the contesting
+    /// owner (named by the worktree's sentinel, or found in the store bound to
+    /// the same canonical path), and the contested path. No files are touched
+    /// when this is returned; both records need investigation before any retry.
+    ///
+    /// **Escape hatch.** The guard releases as soon as the contesting owner is
+    /// provably ownerless, so a stale or wrong owner is cleared with
+    /// `tm sessions delete <owner-id>` — that marks the record `Deleted`, which
+    /// is terminal, which `resolve_ownerless` accepts. No `force` flag is
+    /// needed and none is offered, deliberately: a flag would be reachable by
+    /// the same automated `caller: None` paths this guard exists to stop,
+    /// whereas reconciling the registry is exactly the corrective action the
+    /// operator should be taking. The message states this so the recourse is
+    /// visible at the point of refusal.
     #[error(
         "refusing to remove worktree {2} while decommissioning session {0}: its on-disk sentinel names session {1}, still ACTIVE — this record points at a LIVE peer's worktree (#3764)"
     )]

--- a/crates/trusty-mpm/src/session_manager/error.rs
+++ b/crates/trusty-mpm/src/session_manager/error.rs
@@ -1,0 +1,157 @@
+//! The session manager's error type (#3764 SLOC split).
+//!
+//! Why: [`ManagedError`] is a large, heavily-documented enum — its variant
+//! docs alone run well over a hundred lines. Adding the #3764
+//! [`ManagedError::ForeignActiveWorktree`] corruption-guard variant pushed
+//! `manager.rs` past the 500-SLOC production cap, so the enum moves out to its
+//! own module exactly as [`super::driver::ManagedTmuxDriver`] did under #1955.
+//! No behaviour changes: the type is re-exported from `manager` so every
+//! existing `super::manager::ManagedError` import path keeps resolving.
+//! What: the [`ManagedError`] enum and nothing else.
+//! Test: variants are exercised throughout the session-manager unit tests;
+//! the #3764 variant specifically by
+//! `decommission_refuses_to_delete_live_peer_worktree` in
+//! `super::worktree_identity_guard_tests`.
+
+use thiserror::Error;
+
+use crate::core::names::SessionNameError;
+
+use super::record::ManagedSessionId;
+use super::store::StoreError;
+
+/// Errors produced by the session manager.
+///
+/// Why: HTTP handlers dispatch on error variants to choose status codes;
+/// a typed enum keeps that mapping clean and avoids stringly-typed matching.
+/// What: one variant per failure mode: tmux problems, missing sessions,
+/// store I/O, miscellaneous I/O errors, and invalid state transitions.
+/// Test: `ManagedError` variants are exercised by the manager unit tests.
+#[derive(Debug, Error)]
+pub enum ManagedError {
+    /// tmux was unavailable or a tmux operation failed.
+    #[error("tmux error: {0}")]
+    TmuxUnavailable(String),
+
+    /// The requested session id was not present in the store.
+    #[error("session not found: {0}")]
+    SessionNotFound(String),
+
+    /// The session store operation failed.
+    #[error("store error: {0}")]
+    Store(#[from] StoreError),
+
+    /// A miscellaneous I/O error.
+    #[error("I/O error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// A name derived from the cwd hint collided with an existing session.
+    #[error("name already in use: {0} — use `tm session ls` to find it")]
+    NameCollision(String),
+
+    /// The operation is not valid for the current session state.
+    #[error("invalid state transition for session {0}: {1}")]
+    InvalidState(String, String),
+
+    /// Adoption was requested for a tmux session that does not exist on the host.
+    ///
+    /// Why: adoption CONNECTS to a pre-existing, unmanaged pane — there is nothing
+    /// to drive if the pane is absent. This is the inverse of [`NameCollision`]:
+    /// `create` fails when a name exists, `adopt_existing` fails when it does NOT.
+    #[error("tmux session does not exist: {0} — adoption requires a live pane")]
+    TmuxSessionMissing(String),
+
+    /// Adoption was requested for a tmux session this store already tracks.
+    ///
+    /// Why: re-adopting a session the manager already owns would create a second,
+    /// conflicting record for the same pane. The operator should drive the existing
+    /// record instead.
+    #[error("tmux session already adopted/registered: {0}")]
+    AlreadyAdopted(String),
+
+    /// A session-name derivation failure (currently: all 99 `tm-<leaf>-NN`
+    /// serials for a project are in use).
+    ///
+    /// Why (#1955, renamed in the #1966 review follow-up): the serial-numbered
+    /// naming scheme caps at two digits per project; this surfaces
+    /// [`SessionNameError`] through the same typed-error seam as every other
+    /// create-path failure instead of stringly-typed-wrapping it into
+    /// [`TmuxUnavailable`](Self::TmuxUnavailable). Named `SessionName` (not
+    /// `NameSerialExhausted`, its original name) and given a generic message
+    /// ("session name error", not "serial exhausted") because of the `#[from]`
+    /// below: [`SessionNameError`] currently has exactly one variant
+    /// ([`SessionNameError::SerialExhausted`]), but `#[from]` auto-converts
+    /// ANY future variant into this one — a name/message naming one specific
+    /// variant would silently mislabel a later, unrelated `SessionNameError`
+    /// variant.
+    #[error("session name error: {0}")]
+    SessionName(#[from] SessionNameError),
+
+    /// No fallback candidate for a session's workdir exists on disk during
+    /// `resume` (#2250).
+    ///
+    /// Why: prior to #2250, `resume()`'s recreate branch handed
+    /// `workspace_path` straight to tmux with no existence check — a
+    /// removed/stale worktree silently rooted the recreated pane at `$HOME`,
+    /// discarding the project-tier `.claude/` skills/persona/MCP config that
+    /// lives only under the real workspace. All three fallback candidates
+    /// (`last_cwd`, `workspace_path`, `cwd`) are now existence-checked by
+    /// [`super::resume_workdir::resolve_existing_workdir`]; when NONE exist,
+    /// failing loudly here beats silently spawning a pane at `$HOME`.
+    /// What: `(session_id, path)` — `path` is the most-informative candidate
+    /// considered (`workspace_path` if set, else `cwd`), surfaced in the error
+    /// message so the operator knows exactly which directory vanished.
+    #[error(
+        "workspace directory {1} no longer exists; cannot resume session {0} — the worktree may have been removed"
+    )]
+    WorkspaceMissing(String, String),
+
+    /// The session's recorded `pane_id` no longer exists, though its tmux
+    /// SESSION is still alive (sibling-window hijack, follow-up to #2456).
+    ///
+    /// Why: `resume`'s reuse branch previously trusted `session_exists` alone
+    /// to mean "the recorded pane survived" — but a tmux session stays alive
+    /// as long as ANY pane/window in it is open, including a sibling that has
+    /// nothing to do with this record. Recreating in that situation via the
+    /// existing `kill_session` + `create_and_verify_pane` path would destroy
+    /// the sibling too; silently respawning via a session-scoped target would
+    /// land the runtime in the sibling instead of failing. Neither is safe,
+    /// so this variant surfaces the ambiguity to the operator explicitly
+    /// rather than guessing.
+    /// What: `(session_id, pane_id)` — the missing pane's id, surfaced in the
+    /// error message so the operator knows exactly what vanished.
+    #[error(
+        "recorded pane {1} for session {0} no longer exists, but its tmux session is still \
+         alive (likely a sibling window) — refusing to respawn into an unrelated active pane; \
+         close the sibling window and delete/recreate this session, or manually verify pane \
+         state with `tmux list-panes`"
+    )]
+    PaneGone(String, String),
+
+    /// A `caller`-identified decommission refused because the target's
+    /// worktree has a KNOWN, non-ownerless owner that disagrees with the
+    /// caller (#3649). `(caller, owner, target)`.
+    #[error("session {0} refused to decommission {2}'s worktree — owned by session {1}")]
+    WorktreeOwnerMismatch(ManagedSessionId, ManagedSessionId, ManagedSessionId),
+
+    /// A decommission refused because the worktree ON DISK declares a
+    /// DIFFERENT, still-Active owner than the record being torn down (#3764).
+    ///
+    /// Why: distinct from [`Self::WorktreeOwnerMismatch`], which is the #3649
+    /// *authority* gate ("you, session X, may not tear down session Y's
+    /// worktree") and only fires for a self-identified `caller`. THIS variant
+    /// is the *corruption* gate: the record's own `workspace_path` points at a
+    /// live peer's worktree, so the record itself is wrong — the removal is
+    /// refused regardless of who asked, including operator/daemon-internal
+    /// authority. It is returned rather than silently skipped because the
+    /// tombstone path clears `workspace_path`, which would destroy the only
+    /// remaining evidence of the mis-pointing record.
+    /// What: `(target, owner, path)` — the record asked about, the live owner
+    /// the worktree's on-disk sentinel names, and the contested path. No files
+    /// are touched when this is returned; both records need investigation
+    /// before any retry.
+    #[error(
+        "refusing to remove worktree {2} while decommissioning session {0}: its on-disk sentinel names session {1}, still ACTIVE — this record points at a LIVE peer's worktree (#3764)"
+    )]
+    ForeignActiveWorktree(ManagedSessionId, ManagedSessionId, String),
+}

--- a/crates/trusty-mpm/src/session_manager/manager.rs
+++ b/crates/trusty-mpm/src/session_manager/manager.rs
@@ -22,11 +22,9 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use chrono::Utc;
-use thiserror::Error;
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 
-use crate::core::names::SessionNameError;
 use crate::core::sm::control::Submit;
 
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
@@ -34,120 +32,12 @@ use super::resume_workdir;
 use super::slots::SlotRegistry;
 use super::store::{SessionStore, StoreError};
 
-/// Errors produced by the session manager.
-///
-/// Why: HTTP handlers dispatch on error variants to choose status codes;
-/// a typed enum keeps that mapping clean and avoids stringly-typed matching.
-/// What: one variant per failure mode: tmux problems, missing sessions,
-/// store I/O, miscellaneous I/O errors, and invalid state transitions.
-/// Test: `ManagedError` variants are exercised by the manager unit tests.
-#[derive(Debug, Error)]
-pub enum ManagedError {
-    /// tmux was unavailable or a tmux operation failed.
-    #[error("tmux error: {0}")]
-    TmuxUnavailable(String),
-
-    /// The requested session id was not present in the store.
-    #[error("session not found: {0}")]
-    SessionNotFound(String),
-
-    /// The session store operation failed.
-    #[error("store error: {0}")]
-    Store(#[from] StoreError),
-
-    /// A miscellaneous I/O error.
-    #[error("I/O error: {0}")]
-    Io(#[from] std::io::Error),
-
-    /// A name derived from the cwd hint collided with an existing session.
-    #[error("name already in use: {0} — use `tm session ls` to find it")]
-    NameCollision(String),
-
-    /// The operation is not valid for the current session state.
-    #[error("invalid state transition for session {0}: {1}")]
-    InvalidState(String, String),
-
-    /// Adoption was requested for a tmux session that does not exist on the host.
-    ///
-    /// Why: adoption CONNECTS to a pre-existing, unmanaged pane — there is nothing
-    /// to drive if the pane is absent. This is the inverse of [`NameCollision`]:
-    /// `create` fails when a name exists, `adopt_existing` fails when it does NOT.
-    #[error("tmux session does not exist: {0} — adoption requires a live pane")]
-    TmuxSessionMissing(String),
-
-    /// Adoption was requested for a tmux session this store already tracks.
-    ///
-    /// Why: re-adopting a session the manager already owns would create a second,
-    /// conflicting record for the same pane. The operator should drive the existing
-    /// record instead.
-    #[error("tmux session already adopted/registered: {0}")]
-    AlreadyAdopted(String),
-
-    /// A session-name derivation failure (currently: all 99 `tm-<leaf>-NN`
-    /// serials for a project are in use).
-    ///
-    /// Why (#1955, renamed in the #1966 review follow-up): the serial-numbered
-    /// naming scheme caps at two digits per project; this surfaces
-    /// [`SessionNameError`] through the same typed-error seam as every other
-    /// create-path failure instead of stringly-typed-wrapping it into
-    /// [`TmuxUnavailable`](Self::TmuxUnavailable). Named `SessionName` (not
-    /// `NameSerialExhausted`, its original name) and given a generic message
-    /// ("session name error", not "serial exhausted") because of the `#[from]`
-    /// below: [`SessionNameError`] currently has exactly one variant
-    /// ([`SessionNameError::SerialExhausted`]), but `#[from]` auto-converts
-    /// ANY future variant into this one — a name/message naming one specific
-    /// variant would silently mislabel a later, unrelated `SessionNameError`
-    /// variant.
-    #[error("session name error: {0}")]
-    SessionName(#[from] SessionNameError),
-
-    /// No fallback candidate for a session's workdir exists on disk during
-    /// `resume` (#2250).
-    ///
-    /// Why: prior to #2250, `resume()`'s recreate branch handed
-    /// `workspace_path` straight to tmux with no existence check — a
-    /// removed/stale worktree silently rooted the recreated pane at `$HOME`,
-    /// discarding the project-tier `.claude/` skills/persona/MCP config that
-    /// lives only under the real workspace. All three fallback candidates
-    /// (`last_cwd`, `workspace_path`, `cwd`) are now existence-checked by
-    /// [`super::resume_workdir::resolve_existing_workdir`]; when NONE exist,
-    /// failing loudly here beats silently spawning a pane at `$HOME`.
-    /// What: `(session_id, path)` — `path` is the most-informative candidate
-    /// considered (`workspace_path` if set, else `cwd`), surfaced in the error
-    /// message so the operator knows exactly which directory vanished.
-    #[error(
-        "workspace directory {1} no longer exists; cannot resume session {0} — the worktree may have been removed"
-    )]
-    WorkspaceMissing(String, String),
-
-    /// The session's recorded `pane_id` no longer exists, though its tmux
-    /// SESSION is still alive (sibling-window hijack, follow-up to #2456).
-    ///
-    /// Why: `resume`'s reuse branch previously trusted `session_exists` alone
-    /// to mean "the recorded pane survived" — but a tmux session stays alive
-    /// as long as ANY pane/window in it is open, including a sibling that has
-    /// nothing to do with this record. Recreating in that situation via the
-    /// existing `kill_session` + `create_and_verify_pane` path would destroy
-    /// the sibling too; silently respawning via a session-scoped target would
-    /// land the runtime in the sibling instead of failing. Neither is safe,
-    /// so this variant surfaces the ambiguity to the operator explicitly
-    /// rather than guessing.
-    /// What: `(session_id, pane_id)` — the missing pane's id, surfaced in the
-    /// error message so the operator knows exactly what vanished.
-    #[error(
-        "recorded pane {1} for session {0} no longer exists, but its tmux session is still \
-         alive (likely a sibling window) — refusing to respawn into an unrelated active pane; \
-         close the sibling window and delete/recreate this session, or manually verify pane \
-         state with `tmux list-panes`"
-    )]
-    PaneGone(String, String),
-
-    /// A `caller`-identified decommission refused because the target's
-    /// worktree has a KNOWN, non-ownerless owner that disagrees with the
-    /// caller (#3649). `(caller, owner, target)`.
-    #[error("session {0} refused to decommission {2}'s worktree — owned by session {1}")]
-    WorktreeOwnerMismatch(ManagedSessionId, ManagedSessionId, ManagedSessionId),
-}
+// [`ManagedError`] lives in `error.rs` (#3764 SLOC split, same rationale as
+// the #1955 `ManagedTmuxDriver` move below — the enum's per-variant doc
+// comments alone run >130 lines and pushed this file past the 500-SLOC
+// production cap when the #3764 corruption-guard variant was added).
+// Re-exported here so existing `super::manager::ManagedError` paths resolve.
+pub use super::error::ManagedError;
 
 // [`ManagedTmuxDriver`] lives in `driver.rs` (issue #1955 SLOC split — the
 // trait's default-impl doc comments alone were ~130 lines, which pushed this

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -14,6 +14,7 @@ pub mod decommission;
 pub mod dedup;
 pub mod delete;
 pub mod driver;
+pub mod error;
 pub mod hook_sync;
 pub mod injection_status;
 pub mod manager;
@@ -33,6 +34,7 @@ pub mod snapshot;
 pub mod store;
 pub mod task_inject;
 pub mod workspace_guard;
+pub(crate) mod worktree_integrity;
 mod worktree_nested;
 pub(crate) mod worktree_ownership;
 pub mod worktree_safety;
@@ -51,6 +53,12 @@ mod backfill_tests;
 
 #[cfg(test)]
 mod decommission_worktree_tests;
+
+#[cfg(test)]
+mod worktree_identity_guard_tests;
+
+#[cfg(test)]
+mod worktree_integrity_tests;
 
 #[cfg(test)]
 mod delete_tests;

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -69,6 +69,24 @@ pub const MAX_EPHEMERAL_AGE_HOURS: i64 = 24;
 /// Test: `canonicalize_streak_escalates_at_threshold`.
 const CANONICALIZE_FAILURE_STREAK_THRESHOLD: u32 = 10;
 
+/// Repo-relative path to the worktree-corruption forensics runbook (#3764 item 3).
+///
+/// Why: when the #1845 F3 streak alarm fires, the operator has a window of
+/// minutes before the evidence is destroyed — a stop/reap runs
+/// `snapshot::write_scrollback`, which OVERWRITES the only surviving pane
+/// transcript, and in the #3715 incident every pre-incident transcript was lost
+/// that way before anyone looked. An alarm that says "investigate" without
+/// saying "capture these six things first, in this order" spends that window on
+/// the operator working out what to collect. Naming the runbook IN the alarm
+/// is the cheapest way to close that gap; the alternative (wiring automated
+/// capture into the sweep) was evaluated and rejected — see the runbook's
+/// final section for why.
+/// What: the path, emitted as a `runbook` field and interpolated into the
+/// message of the escalated `error!`.
+/// Test: `forensics_runbook_path_exists` below pins that the file is really
+/// there, so the pointer can never rot into a dead reference.
+const FORENSICS_RUNBOOK: &str = "docs/runbooks/worktree-corruption-forensics.md";
+
 /// In-memory, per-path consecutive-failure counter for the #1845 F3
 /// canonicalize fallback (#3715 item 3).
 ///
@@ -965,11 +983,13 @@ impl SessionManager {
                             session = %session_id,
                             path = %p.display(),
                             streak,
+                            runbook = FORENSICS_RUNBOOK,
                             "prune-worktrees: active session path has failed to \
                              canonicalize for {streak} consecutive real-sweep \
                              observations — sustained failure, investigate before \
                              a stop/reap silently reconstitutes this workspace \
-                             root (#3715)"
+                             root. CAPTURE FORENSICS NOW, before a stop overwrites \
+                             the pane transcript: see {FORENSICS_RUNBOOK} (#3715/#3764)"
                         );
                     } else {
                         warn!(

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -870,6 +870,35 @@ fn canonicalize_streak_escalates_at_threshold() {
     );
 }
 
+/// The forensics runbook the escalated F3 alarm points at must actually
+/// exist in the repo (#3764 item 3).
+///
+/// Why: the alarm's only value at 03:00 is that it names, in-message, the
+/// document telling the operator what to capture before a stop destroys the
+/// pane transcript. A dangling path turns that into a dead end at the worst
+/// possible moment — so the pointer is pinned mechanically rather than trusted
+/// to survive a future docs reshuffle.
+/// What: resolves [`FORENSICS_RUNBOOK`] against the workspace root (two levels
+/// up from this crate's `CARGO_MANIFEST_DIR`) and asserts the file is present
+/// and non-empty.
+/// Test: this function IS the test.
+#[test]
+fn forensics_runbook_path_exists() {
+    let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("crate dir must have a grandparent (the workspace root)");
+    let runbook = workspace_root.join(FORENSICS_RUNBOOK);
+    assert!(
+        runbook.is_file(),
+        "the F3 alarm points operators at {FORENSICS_RUNBOOK}, which must exist; \
+         looked at {}",
+        runbook.display()
+    );
+    let len = std::fs::metadata(&runbook).expect("stat runbook").len();
+    assert!(len > 0, "the forensics runbook must not be empty");
+}
+
 /// A single successful canonicalize must fully reset the streak for that
 /// path — a subsequent failure starts back at 1, not N+1 (#3715 item 3).
 ///

--- a/crates/trusty-mpm/src/session_manager/workspace_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/workspace_guard.rs
@@ -15,23 +15,23 @@
 //! three separate worktree-destruction incidents was a #1744 cwd collision in
 //! which THREE Active session records pointed at ONE worktree path; any
 //! decommission of the two impostor records would have taken the real owner's
-//! live tree with it, with containment passing cleanly. [`foreign_active_owner`]
+//! live tree with it, with containment passing cleanly. [`foreign_owner`]
 //! adds the missing identity half.
 //!
 //! What: [`is_safe_to_remove`] canonicalizes both paths and verifies that the
 //! workspace is strictly INSIDE the managed root, rejecting: path == root, path
 //! outside root, paths with too few components, and `$HOME`.
-//! [`foreign_active_owner`] is the pure decision half of the identity guard:
+//! [`foreign_owner`] is the pure decision half of the identity guard:
 //! given the owner DECLARED BY THE WORKTREE ITSELF (its on-disk ownership
 //! sentinel — not the possibly-corrupt session record that asked for the
 //! removal) it reports whether that owner is a different, still-Active session.
-//! Test: `is_safe_to_remove_*` and `foreign_active_owner_*` unit tests below.
+//! Test: `is_safe_to_remove_*` and `foreign_owner_*` unit tests below.
 
 use std::path::Path;
 
 use tracing::warn;
 
-use super::record::{ManagedSessionId, ManagedSessionState};
+use super::record::ManagedSessionId;
 
 /// Decide whether `workspace_path` is safe to `remove_dir_all` (#1511).
 ///
@@ -118,9 +118,9 @@ pub(crate) fn is_safe_to_remove(workspace_path: &Path, managed_root: &Path) -> b
     true
 }
 
-/// Identify a worktree whose ON-DISK owner is a DIFFERENT, still-Active session
-/// than the one being torn down (#3764 item 1) — the pure decision half of the
-/// cross-session deletion guard.
+/// Identify a worktree that belongs to a DIFFERENT session which is NOT provably
+/// ownerless (#3764 item 1) — the pure decision half of the cross-session
+/// deletion guard.
 ///
 /// Why: [`is_safe_to_remove`] answers "is this path inside the managed root?"
 /// and nothing else, so every cross-session deletion it is asked about passes.
@@ -129,53 +129,67 @@ pub(crate) fn is_safe_to_remove(workspace_path: &Path, managed_root: &Path) -> b
 /// (`daemon/mcp_session.rs`, `daemon/sm_stdio/control.rs`, the HTTP routes, the
 /// idle reaper, `dedup`) passes `caller: None` and therefore skips it entirely.
 /// That leaves the exact incident shape unguarded: a corrupt/colliding record
-/// whose `workspace_path` points at a PEER's live worktree gets decommissioned,
-/// and the peer's tree is destroyed under it while the peer keeps running.
-/// This guard is deliberately independent of `caller` — it asks the worktree
-/// ITSELF who owns it and refuses when that answer names a live peer, so it
-/// holds even for an operator-authority (`caller: None`) removal.
+/// whose `workspace_path` points at a PEER's worktree gets decommissioned, and
+/// the peer's tree is destroyed under it. This guard is deliberately
+/// independent of `caller`, so it holds even for an operator-authority
+/// (`caller: None`) removal.
 ///
-/// What: returns `Some(owner)` ONLY when all three hold — (a) the worktree's
-/// on-disk ownership sentinel names an owner at all, (b) that owner is not
-/// `target` (the session whose teardown is running), and (c) that owner's
-/// record is currently [`ManagedSessionState::Active`]. Every other case
+/// **Reclaimability is decided by [`SessionManager::resolve_ownerless`], NOT by
+/// `state == Active` (code-critic HIGH-1 on the #3764 PR).** The first draft of
+/// this guard refused only for an `Active` owner, which made it strictly WEAKER
+/// than the #3649 gate sitting twenty lines earlier in the same function — that
+/// gate refuses whenever `!resolve_ownerless(owner)`, which is `false` for
+/// `Stopped`/`Errored`/`Provisioning`. The result was backwards: `caller: Some`
+/// protected a Stopped peer's worktree while `caller: None` — every daemon path
+/// this guard exists to cover — happily deleted it. The reachable sequence:
+/// `idle_reaper` stops peer P, later reaps colliding record I via
+/// `decommission(&I, None)`, the sentinel names P, and P's RESUMABLE tree is
+/// destroyed. A Stopped session is precisely the one whose worktree must
+/// survive — it is going to be resumed. `prune.rs`'s adjacent orphan sweep
+/// already uses `resolve_ownerless_with_grace` for this same question, so
+/// anything else would be a third, disagreeing notion of "reclaimable".
+///
+/// What: returns `Some(owner)` ONLY when all three hold — (a) an owner is known
+/// at all, (b) that owner is not `target` (the session whose teardown is
+/// running), and (c) that owner is NOT provably ownerless. Every other case
 /// returns `None` (removal proceeds), deliberately:
 ///   * owner unknown (`None` — legacy pre-#3649 worktree, or an unparsable
 ///     sentinel) → no evidence of a peer; preserves backward compatibility.
+///     The store-side companion check in
+///     [`SessionManager::foreign_active_worktree_owner`] covers this case
+///     without needing any on-disk file.
 ///   * owner == target → the session is removing its OWN worktree; the normal case.
-///   * owner is Stopped / Errored / Provisioning / terminal / absent from the
-///     store → NOT Active, so #3649's orphan-GC and every existing reclaim
+///   * owner provably ownerless (terminal `Decommissioned`/`Deleted`, or absent
+///     from the store entirely) → #3649's orphan-GC and every existing reclaim
 ///     path keep working exactly as before. This guard can only ever REFUSE a
 ///     deletion the tree previously allowed; it never permits a new one.
 ///
-/// Test: `foreign_active_owner_blocks_live_peer`,
-/// `foreign_active_owner_allows_self`,
-/// `foreign_active_owner_allows_unknown_owner`,
-/// `foreign_active_owner_allows_stopped_peer`,
-/// `foreign_active_owner_allows_absent_peer` in this module; the wired-in
-/// behaviour is covered by
-/// `decommission_refuses_to_delete_live_peer_worktree` in
-/// `super::decommission::tests`.
-pub(crate) fn foreign_active_owner(
+/// Test: `foreign_owner_blocks_live_peer`, `foreign_owner_blocks_stopped_peer`,
+/// `foreign_owner_allows_self`, `foreign_owner_allows_unknown_owner`,
+/// `foreign_owner_allows_ownerless_peer` in this module; the wired-in behaviour
+/// is covered by `decommission_refuses_to_delete_live_peer_worktree` and
+/// `decommission_refuses_to_delete_stopped_peer_worktree` in
+/// `super::worktree_identity_guard_tests`.
+pub(crate) fn foreign_owner(
     declared_owner: Option<ManagedSessionId>,
     target: ManagedSessionId,
-    owner_state: Option<ManagedSessionState>,
+    owner_is_ownerless: bool,
 ) -> Option<ManagedSessionId> {
     let owner = declared_owner?;
     if owner == target {
         return None;
     }
-    match owner_state {
-        Some(ManagedSessionState::Active) => Some(owner),
-        _ => None,
+    if owner_is_ownerless {
+        return None;
     }
+    Some(owner)
 }
 
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
-    use super::{ManagedSessionId, ManagedSessionState, foreign_active_owner, is_safe_to_remove};
+    use super::{ManagedSessionId, foreign_owner, is_safe_to_remove};
 
     // ── is_safe_to_remove unit tests (#1511) ────────────────────────────────
 
@@ -281,87 +295,98 @@ mod tests {
         );
     }
 
-    // ── foreign_active_owner identity guard (#3764 item 1) ──────────────────
+    // ── foreign_owner identity guard (#3764 item 1) ─────────────────────────
+    //
+    // Reclaimability here is `resolve_ownerless`'s answer, passed in as a bool
+    // (see the function doc for why `state == Active` was wrong). The mapping
+    // these tests encode, matching `resolve_ownerless`:
+    //   Active / Stopped / Errored / Provisioning -> NOT ownerless -> REFUSE
+    //   Decommissioned / Deleted / absent record  -> ownerless     -> ALLOW
 
-    /// A worktree owned by a DIFFERENT, still-Active session is refused.
+    /// A worktree owned by a DIFFERENT, still-live session is refused.
     ///
     /// Why: this IS the incident shape — a corrupt/colliding record whose
     /// `workspace_path` points at a live peer's worktree. Before #3764 the
     /// containment guard passed and the peer's tree was destroyed.
     /// Test: this function IS the test.
     #[test]
-    fn foreign_active_owner_blocks_live_peer() {
+    fn foreign_owner_blocks_live_peer() {
         let peer = ManagedSessionId::new();
         let target = ManagedSessionId::new();
         assert_eq!(
-            foreign_active_owner(Some(peer), target, Some(ManagedSessionState::Active)),
+            foreign_owner(Some(peer), target, false),
             Some(peer),
             "a live peer's worktree must be refused"
         );
     }
 
-    /// A session removing its OWN worktree is allowed — the normal case.
+    /// A STOPPED peer's worktree is refused too (code-critic HIGH-1).
     ///
-    /// Why: the guard must not break every legitimate decommission.
+    /// Why: a Stopped session is resumable — its worktree is exactly the one
+    /// that must survive, because it is going to be resumed. The first draft
+    /// refused only for `Active`, which made this guard weaker than the #3649
+    /// gate beside it and let `idle_reaper`'s `caller: None` reap destroy a
+    /// stopped peer's tree. `resolve_ownerless` returns `false` for every
+    /// live/resumable state, so all of them land here.
     /// Test: this function IS the test.
     #[test]
-    fn foreign_active_owner_allows_self() {
+    fn foreign_owner_blocks_stopped_peer() {
+        let peer = ManagedSessionId::new();
+        let target = ManagedSessionId::new();
+        // `resolve_ownerless` == false for Stopped/Errored/Provisioning alike.
+        assert_eq!(
+            foreign_owner(Some(peer), target, false),
+            Some(peer),
+            "a resumable (Stopped/Errored/Provisioning) peer's worktree must be refused"
+        );
+    }
+
+    /// A session removing its OWN worktree is allowed — the normal case.
+    ///
+    /// Why: the guard must not break every legitimate decommission. Checked
+    /// even when the owner is NOT ownerless, since a live session tearing down
+    /// its own workspace is the ordinary path.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_owner_allows_self() {
         let id = ManagedSessionId::new();
         assert_eq!(
-            foreign_active_owner(Some(id), id, Some(ManagedSessionState::Active)),
+            foreign_owner(Some(id), id, false),
             None,
             "a session must always be able to remove its own worktree"
         );
     }
 
-    /// An owner-unknown worktree is allowed (legacy / unparsable sentinel).
+    /// An owner-unknown worktree is allowed by THIS predicate.
     ///
-    /// Why: pre-#3649 worktrees carry a zero-byte sentinel with no owner. The
-    /// guard must stay backward-compatible and never block on absent evidence.
+    /// Why: pre-#3649 worktrees carry a zero-byte sentinel with no owner, so
+    /// the sentinel half must stay backward-compatible and never block on
+    /// absent evidence. The store-side companion check in
+    /// `foreign_active_worktree_owner` is what covers this case — see
+    /// `decommission_refuses_when_store_shows_live_peer_without_sentinel`.
     /// Test: this function IS the test.
     #[test]
-    fn foreign_active_owner_allows_unknown_owner() {
+    fn foreign_owner_allows_unknown_owner() {
         assert_eq!(
-            foreign_active_owner(None, ManagedSessionId::new(), None),
+            foreign_owner(None, ManagedSessionId::new(), false),
             None,
-            "an owner-unknown worktree must not be blocked"
+            "an owner-unknown worktree must not be blocked by the sentinel half"
         );
     }
 
-    /// A peer in a non-Active state does NOT block removal.
+    /// A provably-ownerless peer does NOT block removal.
     ///
     /// Why: this is what keeps #3649's orphan-GC and every existing reclaim
-    /// path working unchanged — only a LIVE peer is protected.
+    /// path working unchanged — a terminal (`Decommissioned`/`Deleted`) or
+    /// absent owner is reclaimable, and `tm sessions delete <stale-id>` is
+    /// therefore the operator's escape hatch when a sentinel goes stale.
     /// Test: this function IS the test.
     #[test]
-    fn foreign_active_owner_allows_stopped_peer() {
-        let peer = ManagedSessionId::new();
-        for state in [
-            ManagedSessionState::Stopped,
-            ManagedSessionState::Errored,
-            ManagedSessionState::Provisioning,
-            ManagedSessionState::Decommissioned,
-            ManagedSessionState::Deleted,
-        ] {
-            assert_eq!(
-                foreign_active_owner(Some(peer), ManagedSessionId::new(), Some(state.clone())),
-                None,
-                "a peer in {state:?} must not block removal"
-            );
-        }
-    }
-
-    /// A peer with no record in the store at all does NOT block removal.
-    ///
-    /// Why: an absent record is the strongest available evidence that nothing
-    /// can contest the reclaim — matching `resolve_ownerless`'s existing rule.
-    /// Test: this function IS the test.
-    #[test]
-    fn foreign_active_owner_allows_absent_peer() {
+    fn foreign_owner_allows_ownerless_peer() {
         assert_eq!(
-            foreign_active_owner(Some(ManagedSessionId::new()), ManagedSessionId::new(), None),
+            foreign_owner(Some(ManagedSessionId::new()), ManagedSessionId::new(), true),
             None,
-            "a peer absent from the store must not block removal"
+            "a provably-ownerless peer must not block removal"
         );
     }
 }

--- a/crates/trusty-mpm/src/session_manager/workspace_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/workspace_guard.rs
@@ -1,4 +1,5 @@
-//! Path-containment guard for workspace deletion (#1511).
+//! Path-containment and session-identity guards for workspace deletion
+//! (#1511 containment, #3764 identity).
 //!
 //! Why: `SessionManager::decommission` previously `remove_dir_all`'d
 //! `workspace_path` unconditionally, which deleted a live user repo when the
@@ -6,14 +7,31 @@
 //! This module provides the belt-and-suspenders containment guard that prevents
 //! any path OUTSIDE the SM's managed workspace root from being deleted —
 //! regardless of the `workspace_owned` flag.
+//!
+//! Containment alone is NOT enough (#3764). Every SM worktree is inside the
+//! managed root, so [`is_safe_to_remove`] happily green-lights removing a
+//! SIBLING session's live worktree — it only ever asked "is this path mine to
+//! manage?", never "is this path SOMEONE ELSE's?". The observed precursor to
+//! three separate worktree-destruction incidents was a #1744 cwd collision in
+//! which THREE Active session records pointed at ONE worktree path; any
+//! decommission of the two impostor records would have taken the real owner's
+//! live tree with it, with containment passing cleanly. [`foreign_active_owner`]
+//! adds the missing identity half.
+//!
 //! What: [`is_safe_to_remove`] canonicalizes both paths and verifies that the
 //! workspace is strictly INSIDE the managed root, rejecting: path == root, path
 //! outside root, paths with too few components, and `$HOME`.
-//! Test: `is_safe_to_remove_*` unit tests below.
+//! [`foreign_active_owner`] is the pure decision half of the identity guard:
+//! given the owner DECLARED BY THE WORKTREE ITSELF (its on-disk ownership
+//! sentinel — not the possibly-corrupt session record that asked for the
+//! removal) it reports whether that owner is a different, still-Active session.
+//! Test: `is_safe_to_remove_*` and `foreign_active_owner_*` unit tests below.
 
 use std::path::Path;
 
 use tracing::warn;
+
+use super::record::{ManagedSessionId, ManagedSessionState};
 
 /// Decide whether `workspace_path` is safe to `remove_dir_all` (#1511).
 ///
@@ -100,11 +118,64 @@ pub(crate) fn is_safe_to_remove(workspace_path: &Path, managed_root: &Path) -> b
     true
 }
 
+/// Identify a worktree whose ON-DISK owner is a DIFFERENT, still-Active session
+/// than the one being torn down (#3764 item 1) — the pure decision half of the
+/// cross-session deletion guard.
+///
+/// Why: [`is_safe_to_remove`] answers "is this path inside the managed root?"
+/// and nothing else, so every cross-session deletion it is asked about passes.
+/// The #3649 owner gate closes part of the hole but only fires when a SESSION
+/// identifies itself as `caller`; every daemon-routed remove path in the tree
+/// (`daemon/mcp_session.rs`, `daemon/sm_stdio/control.rs`, the HTTP routes, the
+/// idle reaper, `dedup`) passes `caller: None` and therefore skips it entirely.
+/// That leaves the exact incident shape unguarded: a corrupt/colliding record
+/// whose `workspace_path` points at a PEER's live worktree gets decommissioned,
+/// and the peer's tree is destroyed under it while the peer keeps running.
+/// This guard is deliberately independent of `caller` — it asks the worktree
+/// ITSELF who owns it and refuses when that answer names a live peer, so it
+/// holds even for an operator-authority (`caller: None`) removal.
+///
+/// What: returns `Some(owner)` ONLY when all three hold — (a) the worktree's
+/// on-disk ownership sentinel names an owner at all, (b) that owner is not
+/// `target` (the session whose teardown is running), and (c) that owner's
+/// record is currently [`ManagedSessionState::Active`]. Every other case
+/// returns `None` (removal proceeds), deliberately:
+///   * owner unknown (`None` — legacy pre-#3649 worktree, or an unparsable
+///     sentinel) → no evidence of a peer; preserves backward compatibility.
+///   * owner == target → the session is removing its OWN worktree; the normal case.
+///   * owner is Stopped / Errored / Provisioning / terminal / absent from the
+///     store → NOT Active, so #3649's orphan-GC and every existing reclaim
+///     path keep working exactly as before. This guard can only ever REFUSE a
+///     deletion the tree previously allowed; it never permits a new one.
+///
+/// Test: `foreign_active_owner_blocks_live_peer`,
+/// `foreign_active_owner_allows_self`,
+/// `foreign_active_owner_allows_unknown_owner`,
+/// `foreign_active_owner_allows_stopped_peer`,
+/// `foreign_active_owner_allows_absent_peer` in this module; the wired-in
+/// behaviour is covered by
+/// `decommission_refuses_to_delete_live_peer_worktree` in
+/// `super::decommission::tests`.
+pub(crate) fn foreign_active_owner(
+    declared_owner: Option<ManagedSessionId>,
+    target: ManagedSessionId,
+    owner_state: Option<ManagedSessionState>,
+) -> Option<ManagedSessionId> {
+    let owner = declared_owner?;
+    if owner == target {
+        return None;
+    }
+    match owner_state {
+        Some(ManagedSessionState::Active) => Some(owner),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::path::PathBuf;
 
-    use super::is_safe_to_remove;
+    use super::{ManagedSessionId, ManagedSessionState, foreign_active_owner, is_safe_to_remove};
 
     // ── is_safe_to_remove unit tests (#1511) ────────────────────────────────
 
@@ -207,6 +278,90 @@ mod tests {
         assert!(
             !is_safe_to_remove(&nonexistent, root.path()),
             "a non-existent workspace path must return false (canonicalize fails)"
+        );
+    }
+
+    // ── foreign_active_owner identity guard (#3764 item 1) ──────────────────
+
+    /// A worktree owned by a DIFFERENT, still-Active session is refused.
+    ///
+    /// Why: this IS the incident shape — a corrupt/colliding record whose
+    /// `workspace_path` points at a live peer's worktree. Before #3764 the
+    /// containment guard passed and the peer's tree was destroyed.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_owner_blocks_live_peer() {
+        let peer = ManagedSessionId::new();
+        let target = ManagedSessionId::new();
+        assert_eq!(
+            foreign_active_owner(Some(peer), target, Some(ManagedSessionState::Active)),
+            Some(peer),
+            "a live peer's worktree must be refused"
+        );
+    }
+
+    /// A session removing its OWN worktree is allowed — the normal case.
+    ///
+    /// Why: the guard must not break every legitimate decommission.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_owner_allows_self() {
+        let id = ManagedSessionId::new();
+        assert_eq!(
+            foreign_active_owner(Some(id), id, Some(ManagedSessionState::Active)),
+            None,
+            "a session must always be able to remove its own worktree"
+        );
+    }
+
+    /// An owner-unknown worktree is allowed (legacy / unparsable sentinel).
+    ///
+    /// Why: pre-#3649 worktrees carry a zero-byte sentinel with no owner. The
+    /// guard must stay backward-compatible and never block on absent evidence.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_owner_allows_unknown_owner() {
+        assert_eq!(
+            foreign_active_owner(None, ManagedSessionId::new(), None),
+            None,
+            "an owner-unknown worktree must not be blocked"
+        );
+    }
+
+    /// A peer in a non-Active state does NOT block removal.
+    ///
+    /// Why: this is what keeps #3649's orphan-GC and every existing reclaim
+    /// path working unchanged — only a LIVE peer is protected.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_owner_allows_stopped_peer() {
+        let peer = ManagedSessionId::new();
+        for state in [
+            ManagedSessionState::Stopped,
+            ManagedSessionState::Errored,
+            ManagedSessionState::Provisioning,
+            ManagedSessionState::Decommissioned,
+            ManagedSessionState::Deleted,
+        ] {
+            assert_eq!(
+                foreign_active_owner(Some(peer), ManagedSessionId::new(), Some(state.clone())),
+                None,
+                "a peer in {state:?} must not block removal"
+            );
+        }
+    }
+
+    /// A peer with no record in the store at all does NOT block removal.
+    ///
+    /// Why: an absent record is the strongest available evidence that nothing
+    /// can contest the reclaim — matching `resolve_ownerless`'s existing rule.
+    /// Test: this function IS the test.
+    #[test]
+    fn foreign_active_owner_allows_absent_peer() {
+        assert_eq!(
+            foreign_active_owner(Some(ManagedSessionId::new()), ManagedSessionId::new(), None),
+            None,
+            "a peer absent from the store must not block removal"
         );
     }
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_identity_guard_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_identity_guard_tests.rs
@@ -204,15 +204,22 @@ async fn decommission_removes_own_worktree_despite_guard() {
     assert_eq!(record.state, ManagedSessionState::Decommissioned);
 }
 
-/// A peer in a NON-Active state does not block reclamation.
+/// A provably-ownerless (terminal) peer does not block reclamation.
 ///
 /// Why: #3649's orphan-GC and every operator-driven reclaim path depend on
-/// being able to tear down a worktree whose owner is Stopped/terminal. The
-/// guard must narrow to LIVE peers only — this test pins that it does not
-/// silently freeze the existing GC.
+/// being able to tear down a worktree whose owner is terminal or gone. The
+/// guard must narrow to peers that are NOT provably ownerless — this test pins
+/// that it does not freeze the existing GC.
+///
+/// This replaces an earlier `..._when_peer_is_stopped` test that asserted the
+/// OPPOSITE for a Stopped peer. That assertion encoded the HIGH-1 bug: a
+/// Stopped session is resumable, so its worktree must be protected, not
+/// reclaimed. Terminal is the correct boundary, and it is also the operator's
+/// escape hatch — `tm sessions delete <stale-id>` marks a record `Deleted`,
+/// which is terminal, which releases the guard.
 /// Test: this function IS the test.
 #[tokio::test]
-async fn decommission_allows_reclaim_when_peer_is_stopped() {
+async fn decommission_allows_reclaim_when_peer_is_terminal() {
     let dir = crate::test_support::hermetic_temp_dir();
     let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
         .await
@@ -225,9 +232,9 @@ async fn decommission_allows_reclaim_when_peer_is_stopped() {
     mgr.store
         .write()
         .await
-        .upsert(record_at(peer, ManagedSessionState::Stopped, None))
+        .upsert(record_at(peer, ManagedSessionState::Decommissioned, None))
         .await
-        .expect("upsert stopped peer");
+        .expect("upsert terminal peer");
 
     let reclaimer = ManagedSessionId::new();
     mgr.store
@@ -244,7 +251,209 @@ async fn decommission_allows_reclaim_when_peer_is_stopped() {
     let (_record, removed) = mgr
         .decommission_with_root(&reclaimer, managed_root.path(), None)
         .await
-        .expect("a stopped peer must not block reclamation");
+        .expect("a terminal peer must not block reclamation");
     assert!(removed, "reclamation must still remove the workspace");
     assert!(!ws.exists(), "the reclaimed worktree must be gone");
+}
+
+/// A STOPPED peer's worktree is refused — the HIGH-1 regression.
+///
+/// Why (code-critic HIGH-1): the first draft refused only for an `Active`
+/// owner, which made this `caller: None` guard strictly WEAKER than the #3649
+/// gate twenty lines earlier in the same function — that gate uses
+/// `resolve_ownerless`, which returns `false` for `Stopped`. The result was
+/// backwards: `caller: Some` protected a Stopped peer while `caller: None` —
+/// every daemon path this guard exists to cover — deleted it.
+///
+/// The reachable sequence in shipped code: `idle_reaper` stops peer P at the
+/// idle threshold; later it reaps colliding record I at the done threshold via
+/// `decommission(&I, None)`; the sentinel names P; P is Stopped; the guard
+/// passed; `remove_session_worktree` destroyed P's RESUMABLE tree. A stopped
+/// session's worktree is exactly the one that must survive — it is going to be
+/// resumed.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_refuses_to_delete_stopped_peer_worktree() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let peer = ManagedSessionId::new();
+    let ws = worktree_owned_by(managed_root.path(), peer);
+
+    // The peer is STOPPED — runtime not running, but workspace INTACT and
+    // RESUMABLE (see `ManagedSessionState::Stopped`).
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(
+            peer,
+            ManagedSessionState::Stopped,
+            Some(ws.clone()),
+        ))
+        .await
+        .expect("upsert stopped peer");
+
+    let impostor = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(
+            impostor,
+            ManagedSessionState::Active,
+            Some(ws.clone()),
+        ))
+        .await
+        .expect("upsert impostor");
+
+    let err = mgr
+        .decommission_with_root(&impostor, managed_root.path(), None)
+        .await
+        .expect_err("a STOPPED peer's resumable worktree must not be deleted");
+    match err {
+        ManagedError::ForeignActiveWorktree(target, owner, _path) => {
+            assert_eq!(target, impostor);
+            assert_eq!(owner, peer);
+        }
+        other => panic!("expected ForeignActiveWorktree, got {other:?}"),
+    }
+
+    assert!(
+        ws.join("live-work.txt").exists(),
+        "the stopped peer's work must survive — it is going to be resumed"
+    );
+    assert_eq!(
+        mgr.get(&peer).await.expect("get peer").state,
+        ManagedSessionState::Stopped,
+    );
+}
+
+/// The guard holds with NO sentinel at all, purely from store state.
+///
+/// Why (code-critic MEDIUM): the sentinel is a plain file inside the worktree
+/// that any agent in any session can write or delete, and pre-#3649 worktrees
+/// carry a zero-byte one naming nobody. On exactly those legacy paths the
+/// sentinel half is silently inert. The store-side check is unforgeable — two
+/// live records bound to one canonical path IS the #1744 collision shape — and
+/// this test removes the sentinel entirely to prove the guard does not depend
+/// on it.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_refuses_when_store_shows_live_peer_without_sentinel() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let peer = ManagedSessionId::new();
+    let ws = worktree_owned_by(managed_root.path(), peer);
+    // Legacy / tampered worktree: no ownership sentinel whatsoever.
+    std::fs::remove_file(ws.join(WORKTREE_SENTINEL_FILE)).expect("remove sentinel");
+
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(
+            peer,
+            ManagedSessionState::Active,
+            Some(ws.clone()),
+        ))
+        .await
+        .expect("upsert peer");
+
+    let impostor = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(
+            impostor,
+            ManagedSessionState::Active,
+            Some(ws.clone()),
+        ))
+        .await
+        .expect("upsert impostor");
+
+    let err = mgr
+        .decommission_with_root(&impostor, managed_root.path(), None)
+        .await
+        .expect_err("the store-side check must refuse even with no sentinel on disk");
+    match err {
+        ManagedError::ForeignActiveWorktree(_, owner, _) => assert_eq!(owner, peer),
+        other => panic!("expected ForeignActiveWorktree, got {other:?}"),
+    }
+    assert!(
+        ws.join("live-work.txt").exists(),
+        "the peer's work must survive a sentinel-less refusal"
+    );
+}
+
+/// A record-only collapse — no filesystem removal — is NOT blocked, even when
+/// a live peer shares the path.
+///
+/// Why: `decommission` only deletes a workspace when it is SM-owned or an
+/// in-project `.worktrees/` slice; otherwise it warns and merely tombstones the
+/// record. Guarding that case is pure over-refusal, and it breaks `dedup`, whose
+/// job is collapsing a dead duplicate that BY CONSTRUCTION shares a
+/// `workspace_path` with the record it deduplicates against — the reconciliation
+/// this guard actually wants an operator to perform. Scoping the guard to
+/// destructive removals keeps it exactly coextensive with the harm it prevents.
+///
+/// Caught by `reconcile_dedup_collapses_exact_workspace_duplicate_of_live_record`
+/// and `..._dead_duplicate_of_owned_record` when the guard was first wired
+/// unscoped; this test pins the boundary directly so the reason survives.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_allows_record_only_collapse_sharing_a_path() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    // A PLAIN directory: not SM-owned, not under `.worktrees/` — so
+    // `decommission` will not touch the filesystem at all.
+    let plain = crate::test_support::hermetic_temp_dir();
+    let ws = plain.path().join("proj").join("checkout");
+    std::fs::create_dir_all(&ws).expect("create plain workspace");
+    std::fs::write(ws.join("work.txt"), b"user work").expect("write");
+
+    let live = ManagedSessionId::new();
+    let mut live_rec = record_at(live, ManagedSessionState::Active, Some(ws.clone()));
+    live_rec.workspace_owned = false;
+    mgr.store
+        .write()
+        .await
+        .upsert(live_rec)
+        .await
+        .expect("upsert live");
+
+    let stale = ManagedSessionId::new();
+    let mut stale_rec = record_at(stale, ManagedSessionState::Stopped, Some(ws.clone()));
+    stale_rec.workspace_owned = false;
+    mgr.store
+        .write()
+        .await
+        .upsert(stale_rec)
+        .await
+        .expect("upsert stale");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let (record, removed) = mgr
+        .decommission_with_root(&stale, managed_root.path(), None)
+        .await
+        .expect("a record-only collapse must not be blocked by the worktree guard");
+
+    assert!(!removed, "no filesystem removal should have occurred");
+    assert_eq!(record.state, ManagedSessionState::Decommissioned);
+    assert!(
+        ws.join("work.txt").exists(),
+        "the shared directory and its contents must be untouched"
+    );
+    assert_eq!(
+        mgr.get(&live).await.expect("get live").state,
+        ManagedSessionState::Active,
+        "the live record must survive the collapse"
+    );
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_identity_guard_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_identity_guard_tests.rs
@@ -1,0 +1,250 @@
+//! Wired-in coverage for the #3764 item-1 cross-session worktree-deletion guard.
+//!
+//! Why: `workspace_guard::foreign_active_owner`'s unit tests pin the pure
+//! decision matrix, but the bug being fixed is a WIRING bug — the guard has to
+//! actually fire inside `decommission`, on the `caller: None` path that every
+//! daemon-routed remove site uses (`daemon/mcp_session.rs`,
+//! `daemon/sm_stdio/control.rs`, the HTTP routes, `daemon/idle_reaper.rs`,
+//! `session_manager/dedup.rs`). A guard that exists but is never consulted is
+//! exactly the "shipped guard that detects nothing" shape #3764 was filed over,
+//! so these tests drive the real `decommission_with_root` entry point against a
+//! real on-disk sentinel and assert on OBSERVABLE FILESYSTEM STATE, not just on
+//! the returned error.
+//! What: the refusal case (record points at a live peer's worktree), the
+//! must-not-regress case (a session removing its own worktree), and the
+//! must-not-weaken case (a peer in a non-Active state is still reclaimable).
+//! Test: this file IS the test.
+
+use super::decommission::WORKTREE_SENTINEL_FILE;
+use super::manager::{ManagedError, SessionManager};
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use super::worktree_ownership::WorktreeSentinel;
+
+/// Build an Active record whose `workspace_path` is `ws`.
+///
+/// Why: the incident shape needs TWO records pointing at ONE path, so the
+/// workspace path is a parameter rather than derived from the id.
+fn record_at(
+    id: ManagedSessionId,
+    state: ManagedSessionState,
+    ws: Option<std::path::PathBuf>,
+) -> SessionRecord {
+    SessionRecord {
+        id,
+        tmux_name: format!("tm-3764-{id}"),
+        cwd: std::path::PathBuf::from("/tmp"),
+        task: "task".into(),
+        state,
+        created_at: chrono::Utc::now(),
+        last_activity_at: None,
+        workspace_path: ws,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        // `true` deliberately: the OWNED branch of `decommission` is the one
+        // that calls `remove_dir_all` directly, so this is the strictest
+        // possible setting for a test that must prove nothing was deleted.
+        workspace_owned: true,
+        source_id: None,
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: Default::default(),
+        // Deliberately `None`: the impostor record does NOT name an owner, so
+        // the #3649 gate cannot fire and only the #3764 guard is under test.
+        worktree_owner: None,
+    }
+}
+
+/// Create a worktree directory whose on-disk ownership sentinel names `owner`.
+fn worktree_owned_by(root: &std::path::Path, owner: ManagedSessionId) -> std::path::PathBuf {
+    let ws = root
+        .join("owner")
+        .join("repo")
+        .join(".worktrees")
+        .join("wt");
+    std::fs::create_dir_all(&ws).expect("create worktree dir");
+    std::fs::write(
+        ws.join(WORKTREE_SENTINEL_FILE),
+        serde_json::to_vec(&WorktreeSentinel::new(owner)).expect("serialize sentinel"),
+    )
+    .expect("write sentinel");
+    // A real file inside the tree, so "the tree survived" is a positive
+    // assertion about CONTENT and not merely about the directory entry.
+    std::fs::write(ws.join("live-work.txt"), b"peer's uncommitted work").expect("write work file");
+    ws
+}
+
+/// Decommissioning a record whose `workspace_path` points at a LIVE peer's
+/// worktree is refused, and the peer's files survive untouched.
+///
+/// Why (#3764): this is the observed incident shape — a #1744 cwd collision
+/// left three Active records pointing at ONE worktree path. Before this guard,
+/// `is_safe_to_remove` passed (the path IS inside the managed root), the
+/// `caller: None` path skipped the #3649 gate entirely, and `remove_dir_all`
+/// destroyed the live owner's tree while that session kept running.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_refuses_to_delete_live_peer_worktree() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let peer = ManagedSessionId::new();
+    let ws = worktree_owned_by(managed_root.path(), peer);
+
+    // The real owner: Active, and it is the session the sentinel names.
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(
+            peer,
+            ManagedSessionState::Active,
+            Some(ws.clone()),
+        ))
+        .await
+        .expect("upsert peer");
+
+    // The impostor: a second record pointing at the SAME path (the collision).
+    let impostor = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(
+            impostor,
+            ManagedSessionState::Active,
+            Some(ws.clone()),
+        ))
+        .await
+        .expect("upsert impostor");
+
+    // `caller: None` — operator/daemon-internal authority, the path taken by
+    // every real daemon remove site and the one #3649's gate does not cover.
+    let err = mgr
+        .decommission_with_root(&impostor, managed_root.path(), None)
+        .await
+        .expect_err("decommission must refuse to delete a live peer's worktree");
+
+    match err {
+        ManagedError::ForeignActiveWorktree(target, owner, path) => {
+            assert_eq!(target, impostor, "target must be the impostor record");
+            assert_eq!(
+                owner, peer,
+                "owner must be the live peer named by the sentinel"
+            );
+            assert_eq!(path, ws.display().to_string());
+        }
+        other => panic!("expected ForeignActiveWorktree, got {other:?}"),
+    }
+
+    // The peer's work must still be on disk, byte for byte.
+    assert!(
+        ws.join("live-work.txt").exists(),
+        "the live peer's worktree contents must survive a refused decommission"
+    );
+    assert_eq!(
+        std::fs::read(ws.join("live-work.txt")).expect("read work file"),
+        b"peer's uncommitted work",
+    );
+
+    // Neither record may be tombstoned — the impostor is still Active, so the
+    // operator can see and fix the collision instead of it being erased.
+    assert_eq!(
+        mgr.get(&impostor).await.expect("get impostor").state,
+        ManagedSessionState::Active,
+    );
+    assert_eq!(
+        mgr.get(&peer).await.expect("get peer").state,
+        ManagedSessionState::Active,
+    );
+}
+
+/// A session decommissioning its OWN worktree is unaffected by the guard.
+///
+/// Why: the guard must not break the normal teardown path. This is the
+/// regression half — without it, a guard that refused everything would also
+/// pass the refusal test above.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_removes_own_worktree_despite_guard() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let id = ManagedSessionId::new();
+    let ws = worktree_owned_by(managed_root.path(), id);
+
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(id, ManagedSessionState::Active, Some(ws.clone())))
+        .await
+        .expect("upsert");
+
+    let (record, removed) = mgr
+        .decommission_with_root(&id, managed_root.path(), None)
+        .await
+        .expect("a session must be able to decommission its own worktree");
+
+    assert!(
+        removed,
+        "the owned workspace must actually have been removed"
+    );
+    assert!(!ws.exists(), "the session's own worktree must be gone");
+    assert_eq!(record.state, ManagedSessionState::Decommissioned);
+}
+
+/// A peer in a NON-Active state does not block reclamation.
+///
+/// Why: #3649's orphan-GC and every operator-driven reclaim path depend on
+/// being able to tear down a worktree whose owner is Stopped/terminal. The
+/// guard must narrow to LIVE peers only — this test pins that it does not
+/// silently freeze the existing GC.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_allows_reclaim_when_peer_is_stopped() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let peer = ManagedSessionId::new();
+    let ws = worktree_owned_by(managed_root.path(), peer);
+
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(peer, ManagedSessionState::Stopped, None))
+        .await
+        .expect("upsert stopped peer");
+
+    let reclaimer = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(record_at(
+            reclaimer,
+            ManagedSessionState::Active,
+            Some(ws.clone()),
+        ))
+        .await
+        .expect("upsert reclaimer");
+
+    let (_record, removed) = mgr
+        .decommission_with_root(&reclaimer, managed_root.path(), None)
+        .await
+        .expect("a stopped peer must not block reclamation");
+    assert!(removed, "reclamation must still remove the workspace");
+    assert!(!ws.exists(), "the reclaimed worktree must be gone");
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_integrity.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_integrity.rs
@@ -379,8 +379,7 @@ mod tests {
         let seen = Arc::new(Mutex::new(Vec::new()));
         let subscriber = tracing_subscriber::registry().with(Collector(Arc::clone(&seen)));
         tracing::subscriber::with_default(subscriber, body);
-        let levels = seen.lock().expect("lock").clone();
-        levels
+        seen.lock().expect("lock").clone()
     }
 
     fn finding(verdict: WorktreeIntegrity) -> IntegrityFinding {

--- a/crates/trusty-mpm/src/session_manager/worktree_integrity.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_integrity.rs
@@ -57,7 +57,9 @@
 
 use std::path::{Path, PathBuf};
 
-use super::decommission::is_session_worktree;
+use super::decommission::{
+    GIT_WORKTREE_REMOVE_TIMEOUT, WORKTREE_SENTINEL_FILE, is_session_worktree,
+};
 use super::manager::SessionManager;
 use super::record::{ManagedSessionId, ManagedSessionState};
 
@@ -68,88 +70,199 @@ use super::record::{ManagedSessionId, ManagedSessionState};
 /// third case — git could not be consulted — to be handled explicitly instead
 /// of collapsing into a false `Intact`.
 /// What: [`Resolved`](Self::Resolved) — git printed a work-tree root.
-/// [`NotAWorkTree`](Self::NotAWorkTree) — git RAN and refused (exit != 0;
-/// `fatal: this operation must be run in a work tree`, or `not a git
-/// repository`). [`Unavailable`](Self::Unavailable) — git could not be spawned
-/// at all, which proves nothing either way.
+/// [`NotAWorkTree`](Self::NotAWorkTree) — git RAN and gave one of the two
+/// answers that definitively mean "this is not its own worktree any more"
+/// (`not a work tree` / `not a git repository`).
+/// [`Unavailable`](Self::Unavailable) — git could not be spawned, timed out, or
+/// failed for some OTHER reason (dubious ownership, unreadable gitdir), none of
+/// which prove anything either way.
 /// Test: `classify_*` below.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum TopLevel {
     /// git resolved a work-tree root (already canonicalized by the caller).
     Resolved(PathBuf),
-    /// git ran and reported there is no work tree here.
+    /// git ran and definitively reported there is no work tree here.
     NotAWorkTree,
-    /// git could not be run — no evidence in either direction.
+    /// git could not be consulted — no evidence in either direction.
     Unavailable(String),
 }
 
 /// Verdict on whether a session's worktree is still a real worktree.
 ///
-/// Why: `Unknown` exists as a first-class variant precisely so an unobservable
-/// probe can never be reported as healthy. `bool` would have forced that lie.
-/// What: [`Intact`](Self::Intact), [`Destroyed`](Self::Destroyed) (with the
-/// human-readable evidence), [`Unknown`](Self::Unknown) (with the reason).
+/// Why: two distinctions are load-bearing here, and collapsing either one turns
+/// a detector into a destroyer.
+///
+/// * `Unknown` vs everything else: an unobservable probe must never be reported
+///   as healthy. `bool` would have forced that lie.
+/// * [`LinkageLost`](Self::LinkageLost) vs [`Destroyed`](Self::Destroyed)
+///   (code-critic HIGH-3 on the #3764 PR): "git metadata is gone" and "the files
+///   are gone" are different states with OPPOSITE remediations. The first draft
+///   had one variant whose alarm asserted *"Its uncommitted work is GONE. Stop
+///   the session and recreate it"* — advice that, followed on a tree whose files
+///   were entirely intact, would itself destroy the work. That is not
+///   hypothetical for this repo: when the `.base` bare clone was destroyed on
+///   07-21 it orphaned ~70 worktrees whose contents were **fully intact**, and
+///   every one of them would have alarmed that way. Deleting only the base's
+///   admin gitdir reproduces it exactly. Work is only ever claimed lost when the
+///   directory has been observed empty.
+///
+/// What: [`Intact`](Self::Intact), [`LinkageLost`](Self::LinkageLost) (git
+/// linkage gone, files still present — recover, do NOT decommission),
+/// [`Destroyed`](Self::Destroyed) (linkage gone AND the directory is empty),
+/// [`Unknown`](Self::Unknown) (probe inconclusive).
 /// Test: `classify_*` below.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum WorktreeIntegrity {
     /// The path is its own git work tree — healthy.
     Intact,
-    /// The path is NOT its own work tree any more. Carries the evidence.
+    /// Git linkage is gone but files SURVIVE on disk. Recoverable; must not be
+    /// decommissioned. `surviving` is the non-sentinel entry count, or `None`
+    /// when the directory could not be read (still never "work is gone").
+    LinkageLost {
+        detail: String,
+        surviving: Option<usize>,
+    },
+    /// Git linkage is gone AND the directory is empty or absent — work is lost.
     Destroyed(String),
     /// The probe could not be completed. NEVER treat as healthy.
     Unknown(String),
 }
 
-/// Decide integrity from a canonicalized root and a [`TopLevel`] probe result.
+impl WorktreeIntegrity {
+    /// True when this verdict warrants an ERROR-level alarm.
+    ///
+    /// Why: `LinkageLost` and `Destroyed` are both operator-actionable failures
+    /// that must reach `errors.jsonl`; `Intact` and `Unknown` are not (the
+    /// latter is warned per-finding and rolled up separately — see
+    /// [`alarm_rollup`]).
+    /// What: `matches!(self, LinkageLost { .. } | Destroyed(_))`.
+    /// Test: `rollup_reports_destroyed_sessions`,
+    /// `rollup_reports_linkage_lost`, `rollup_is_silent_for_single_unknown`.
+    pub(crate) fn is_alarm(&self) -> bool {
+        matches!(self, Self::LinkageLost { .. } | Self::Destroyed(_))
+    }
+}
+
+/// Decide integrity from a canonicalized root, a [`TopLevel`] probe result, and
+/// the root's surviving-entry count.
 ///
 /// Why: this is the whole detector, expressed with zero I/O so every branch —
-/// including the non-bare-parent case that defeats `--is-inside-work-tree` —
-/// can be pinned by a unit test.
+/// including the non-bare-parent case that defeats `--is-inside-work-tree`, and
+/// the files-intact case that must never be reported as lost work — can be
+/// pinned by a unit test.
 /// What: `root_canon == None` (the root does not resolve on disk at all) →
-/// `Destroyed`. Otherwise: `Unavailable` → `Unknown`; `NotAWorkTree` →
-/// `Destroyed`; `Resolved(t)` → `Intact` iff `t == root_canon`, else
-/// `Destroyed` naming where discovery escaped to.
+/// `Destroyed`, since a directory that is not there holds nothing. Otherwise:
+/// `Unavailable` → `Unknown`; `Resolved(t)` with `t == root` → `Intact`;
+/// `NotAWorkTree` or an escaped `Resolved(t)` → linkage is gone, and the
+/// `surviving` count decides which of the two failure verdicts applies —
+/// `Some(0)` → `Destroyed`, `Some(n>0)` or `None` (unreadable) →
+/// `LinkageLost`. The unreadable case deliberately lands on `LinkageLost`: not
+/// having counted the files is never grounds for telling an operator they are
+/// gone.
 /// Test: `classify_missing_root_is_destroyed`,
-/// `classify_not_a_work_tree_is_destroyed`,
-/// `classify_escaped_toplevel_is_destroyed`,
+/// `classify_empty_dir_is_destroyed`,
+/// `classify_surviving_files_is_linkage_lost`,
+/// `classify_unreadable_dir_is_linkage_lost_not_destroyed`,
+/// `classify_escaped_toplevel_with_files_is_linkage_lost`,
 /// `classify_matching_toplevel_is_intact`,
 /// `classify_unavailable_git_is_unknown_not_intact`.
-pub(crate) fn classify(root_canon: Option<&Path>, probe: &TopLevel) -> WorktreeIntegrity {
+pub(crate) fn classify(
+    root_canon: Option<&Path>,
+    probe: &TopLevel,
+    surviving: Option<usize>,
+) -> WorktreeIntegrity {
     let Some(root) = root_canon else {
         return WorktreeIntegrity::Destroyed(
             "workspace root does not exist on disk (cannot canonicalize)".into(),
         );
     };
-    match probe {
+    let detail = match probe {
         TopLevel::Unavailable(why) => {
-            WorktreeIntegrity::Unknown(format!("could not run git to verify the worktree: {why}"))
+            return WorktreeIntegrity::Unknown(format!(
+                "could not run git to verify the worktree: {why}"
+            ));
         }
-        TopLevel::NotAWorkTree => WorktreeIntegrity::Destroyed(
-            "git reports this path is not inside a work tree — its .git pointer is gone \
-             (git discovery fell through to the enclosing bare repo, which is why \
-             `git log` still appears to work here)"
-                .into(),
-        ),
-        TopLevel::Resolved(top) if top == root => WorktreeIntegrity::Intact,
-        TopLevel::Resolved(top) => WorktreeIntegrity::Destroyed(format!(
+        TopLevel::Resolved(top) if top == root => return WorktreeIntegrity::Intact,
+        TopLevel::NotAWorkTree => {
+            "git reports this path is not inside a work tree — its .git linkage is gone \
+             (git discovery falls through to the enclosing repo, which is why `git log` \
+             still appears to work here)"
+                .to_string()
+        }
+        TopLevel::Resolved(top) => format!(
             "git discovery escaped this directory and resolved to {} instead — this path \
              is no longer its own worktree (note: `git rev-parse --is-inside-work-tree` \
              reports `true` here and would MISS this)",
             top.display()
-        )),
+        ),
+    };
+    match surviving {
+        Some(0) => WorktreeIntegrity::Destroyed(format!("{detail}; the directory is EMPTY")),
+        other => WorktreeIntegrity::LinkageLost {
+            detail,
+            surviving: other,
+        },
     }
 }
 
-/// Run `git -C <root> rev-parse --show-toplevel` and canonicalize the answer.
+/// Count entries under `root`, ignoring the ownership sentinel.
+///
+/// Why: the sentinel is written by the session manager itself, so a directory
+/// holding nothing but a sentinel holds no USER work — counting it would make
+/// an empty, genuinely-destroyed worktree look recoverable and suppress the
+/// correct alarm. `None` (unreadable) is propagated rather than defaulted to 0,
+/// because defaulting would claim work is gone on no evidence.
+/// What: `read_dir(root)` counting entries whose file name is not
+/// [`WORKTREE_SENTINEL_FILE`]; `None` on any read error.
+/// Test: `classify_empty_dir_is_destroyed`,
+/// `linkage_lost_with_surviving_files_does_not_claim_work_gone` in
+/// `worktree_integrity_tests.rs`.
+pub(crate) fn count_surviving_entries(root: &Path) -> Option<usize> {
+    let entries = std::fs::read_dir(root).ok()?;
+    Some(
+        entries
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name() != WORKTREE_SENTINEL_FILE)
+            .count(),
+    )
+}
+
+/// The exact git stderr phrases that DEFINITIVELY mean "this path is not its
+/// own work tree" (#3764, code-critic HIGH-3).
+///
+/// Why: `probe_toplevel` originally mapped ANY non-zero exit to
+/// "not a work tree", which silently turned unrelated failures (dubious
+/// ownership, an unreadable gitdir, a git bug) into a destruction verdict —
+/// the root of the over-claiming alarm. Matching named phrases instead means an
+/// unrecognised failure falls through to `Unavailable`/`Unknown`, which is the
+/// safe direction: a detector that guesses "destroyed" tells operators to
+/// delete things.
+/// What: the three observed phrasings, matched case-insensitively as
+/// substrings. `must be run in a work tree` is what a BARE parent produces (this
+/// repo's `.base` layout); `not a git repository` is what a deleted admin gitdir
+/// produces; `not a work tree` covers the older wording.
+/// Test: `stripped_worktree_under_bare_parent_is_destroyed` and
+/// `linkage_lost_with_surviving_files_does_not_claim_work_gone` in
+/// `worktree_integrity_tests.rs` exercise the first two against real git.
+const NOT_A_WORKTREE_STDERR: &[&str] = &[
+    "must be run in a work tree",
+    "not a work tree",
+    "not a git repository",
+];
+
+/// Run `git -C <root> rev-parse --show-toplevel` and classify the answer.
 ///
 /// Why: the single I/O site, kept trivial so [`classify`] holds all the logic.
-/// What: a non-zero exit means git ran and refused → [`TopLevel::NotAWorkTree`]
-/// (definitive: git itself said there is no work tree here). A spawn failure
-/// means git never ran → [`TopLevel::Unavailable`]. Success canonicalizes the
-/// printed path so the comparison in [`classify`] is symlink-safe (macOS
-/// `/tmp` ↔ `/private/tmp`).
+/// What: success canonicalizes the printed path so the comparison in
+/// [`classify`] is symlink-safe (macOS `/tmp` ↔ `/private/tmp`). A non-zero exit
+/// is NOT blanket-treated as "no work tree" (code-critic HIGH-3): only stderr
+/// naming `not a work tree` / `not a git repository` is definitive; every other
+/// failure (dubious ownership, unreadable gitdir, a git bug) is
+/// [`TopLevel::Unavailable`], because misreading those as destruction is how a
+/// detector starts telling operators to delete intact work. A spawn failure
+/// means git never ran → `Unavailable`.
 /// Test: exercised end-to-end by `worktree_integrity_tests.rs` against real
-/// git worktrees.
+/// git worktrees, including the admin-gitdir-deleted case.
 pub(crate) fn probe_toplevel(root: &Path) -> TopLevel {
     let out = std::process::Command::new("git")
         .arg("-C")
@@ -162,22 +275,39 @@ pub(crate) fn probe_toplevel(root: &Path) -> TopLevel {
             let path = PathBuf::from(&raw);
             TopLevel::Resolved(path.canonicalize().unwrap_or(path))
         }
-        // git RAN and refused — definitive evidence, not an inconclusive error.
-        Ok(_) => TopLevel::NotAWorkTree,
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr).to_lowercase();
+            if NOT_A_WORKTREE_STDERR
+                .iter()
+                .any(|phrase| stderr.contains(phrase))
+            {
+                TopLevel::NotAWorkTree
+            } else {
+                TopLevel::Unavailable(format!(
+                    "git rev-parse failed ({}) without a definitive answer: {}",
+                    o.status,
+                    stderr.trim()
+                ))
+            }
+        }
         Err(e) => TopLevel::Unavailable(e.to_string()),
     }
 }
 
 /// Full integrity check for one worktree root.
 ///
-/// Why: the composition callers want — canonicalize, probe, classify.
-/// What: `classify(root.canonicalize().ok().as_deref(), &probe_toplevel(root))`.
+/// Why: the composition callers want — canonicalize, probe, count, classify.
+/// What: canonicalizes `root`, probes git against the ORIGINAL path
+/// (canonicalization may fail while the path is still traversable), counts
+/// surviving entries, and classifies.
 /// Test: `worktree_integrity_tests.rs`.
 pub(crate) fn check(root: &Path) -> WorktreeIntegrity {
     let canon = root.canonicalize().ok();
-    // Probe the ORIGINAL path: canonicalization may fail while the path is
-    // still traversable, and git resolves it the same way either way.
-    classify(canon.as_deref(), &probe_toplevel(root))
+    classify(
+        canon.as_deref(),
+        &probe_toplevel(root),
+        count_surviving_entries(root),
+    )
 }
 
 /// One session whose worktree failed the integrity check.
@@ -193,9 +323,66 @@ pub(crate) struct IntegrityFinding {
     pub verdict: WorktreeIntegrity,
 }
 
+/// Consecutive audit ticks a session stays in a bad state before the alarm
+/// repeats (#3764, code-critic HIGH-4).
+///
+/// Why: the first draft re-alarmed every tick with no latch. At the ~60 s
+/// orphan-GC cadence one persistent finding emits ~2 880 ERROR events/day into
+/// the 500-entry, NON-deduping capture ring (`error_capture/store.rs`), which
+/// fully rotates in about four hours — evicting every other captured error from
+/// `list_recent_errors`, `preview_bug_report`, and `tm doctor`. That degrades
+/// the exact surface this PR's whole ERROR-level argument depends on: the alarm
+/// would drown out everything, including itself. The last incident persisted
+/// three DAYS, so this is the expected case, not a corner.
+/// What: alarm on TRANSITION into the bad state (streak 1), then once every
+/// [`REALARM_EVERY_TICKS`] ticks — ~1 h at the default cadence, ~24 events/day
+/// instead of ~2 880, while still proving the condition is ongoing. Mirrors the
+/// per-path streak map `prune.rs` already uses for the #1845 F3 alarm.
+/// Test: `latch_alarms_on_transition_then_suppresses`,
+/// `latch_realarms_after_interval`, `latch_resets_when_session_recovers`.
+const REALARM_EVERY_TICKS: u32 = 60;
+
+/// Per-session consecutive-bad-tick counter backing the alarm latch (#3764).
+///
+/// Why: see [`REALARM_EVERY_TICKS`]. Deliberately in-process and unpersisted,
+/// exactly like `prune.rs`'s streak map — a daemon restart re-establishes a
+/// clean baseline and the first post-restart tick re-alarms, which is the
+/// correct behaviour for a condition that is still present.
+/// What: `record_bad` increments and returns whether THIS tick should alarm;
+/// `retain` drops sessions no longer in the audited set (recovered, stopped, or
+/// decommissioned) so a session that breaks again later alarms immediately
+/// rather than inheriting a suppressed streak.
+/// Test: `latch_alarms_on_transition_then_suppresses`,
+/// `latch_realarms_after_interval`, `latch_resets_when_session_recovers`.
+#[derive(Debug, Default)]
+pub(crate) struct AlarmLatch {
+    ticks: std::collections::HashMap<ManagedSessionId, u32>,
+}
+
+impl AlarmLatch {
+    /// Record one more consecutive bad tick for `id`; `true` = alarm now.
+    pub(crate) fn record_bad(&mut self, id: ManagedSessionId) -> bool {
+        let count = self.ticks.entry(id).or_insert(0);
+        *count += 1;
+        *count == 1 || (*count).is_multiple_of(REALARM_EVERY_TICKS)
+    }
+
+    /// Drop every tracked session not in `still_bad`.
+    pub(crate) fn retain(&mut self, still_bad: &std::collections::HashSet<ManagedSessionId>) {
+        self.ticks.retain(|id, _| still_bad.contains(id));
+    }
+}
+
+/// Process-global [`AlarmLatch`] shared by every audit call site.
+static ALARM_LATCH: std::sync::OnceLock<std::sync::Mutex<AlarmLatch>> = std::sync::OnceLock::new();
+
+fn alarm_latch() -> &'static std::sync::Mutex<AlarmLatch> {
+    ALARM_LATCH.get_or_init(|| std::sync::Mutex::new(AlarmLatch::default()))
+}
+
 impl SessionManager {
-    /// Check every Active session's own worktree and alarm on any that has been
-    /// destroyed (#3764 item 4).
+    /// Check every Active session's own worktree and alarm on any whose git
+    /// linkage or contents have been destroyed (#3764 item 4).
     ///
     /// Why: this is the detector that would have caught all three worktree-loss
     /// incidents within one GC interval instead of three days. It runs on the
@@ -210,18 +397,39 @@ impl SessionManager {
     /// finding would be invisible to every operator surface — the same silence
     /// that let the last incident run for three days.
     ///
-    /// What: scans Active records with a `workspace_path` that
-    /// [`is_session_worktree`] recognises (so local-path/adopted sessions on
-    /// plain directories are never misjudged), runs [`check`] on each inside
-    /// `spawn_blocking` (it shells out to git), `error!`s every `Destroyed`
-    /// verdict and `warn!`s every `Unknown` one, and returns all non-`Intact`
-    /// findings. It never mutates anything — a destroyed worktree is reported,
-    /// never "repaired", because silently recreating it is exactly the #3715
-    /// masking behaviour.
-    /// Test: `audit_flags_destroyed_worktree`,
-    /// `audit_passes_healthy_worktree`,
-    /// `audit_ignores_non_worktree_workspace` in `worktree_integrity_tests.rs`.
+    /// What: delegates to [`Self::audit_worktree_integrity_with_timeout`] with
+    /// the shared [`GIT_WORKTREE_REMOVE_TIMEOUT`] bound.
+    /// Test: `audit_flags_destroyed_worktree`, `audit_passes_healthy_worktree`,
+    /// `audit_ignores_non_worktree_workspace`,
+    /// `audit_times_out_into_unknown_never_destroyed` in
+    /// `worktree_integrity_tests.rs`.
     pub(crate) async fn audit_worktree_integrity(&self) -> Vec<IntegrityFinding> {
+        self.audit_worktree_integrity_with_timeout(GIT_WORKTREE_REMOVE_TIMEOUT)
+            .await
+    }
+
+    /// [`Self::audit_worktree_integrity`] with an injectable probe timeout.
+    ///
+    /// Why (code-critic HIGH-2): the probe shells out to `git`, and the first
+    /// draft awaited it unbounded from inside `orphan_gc_loop`. One worktree on
+    /// a stalled network mount would block the audit, everything after it in
+    /// that tick (the search-index sweep), and every future tick — indefinitely.
+    /// The timeout is the SAME [`GIT_WORKTREE_REMOVE_TIMEOUT`] constant
+    /// `remove_session_worktree` already uses for the same hazard under #1845
+    /// item 4, rather than a second independent knob. Injectable purely so the
+    /// elapsed branch is testable without a real hang.
+    /// What: per candidate, `tokio::time::timeout(probe_timeout, spawn_blocking(check))`.
+    /// An elapsed probe yields [`WorktreeIntegrity::Unknown`] — never a
+    /// destruction verdict, since a timeout is an absence of evidence, and never
+    /// `Intact`. Findings are latched (see [`AlarmLatch`]) so a persistent
+    /// condition cannot flood the error ring. Never mutates anything: a
+    /// destroyed worktree is reported, never "repaired", because silently
+    /// recreating it is exactly the #3715 masking behaviour.
+    /// Test: `audit_times_out_into_unknown_never_destroyed`.
+    pub(crate) async fn audit_worktree_integrity_with_timeout(
+        &self,
+        probe_timeout: std::time::Duration,
+    ) -> Vec<IntegrityFinding> {
         let candidates: Vec<(ManagedSessionId, PathBuf)> = self
             .list()
             .await
@@ -230,105 +438,241 @@ impl SessionManager {
             .filter_map(|r| r.workspace_path.map(|p| (r.id, p)))
             .filter(|(_, p)| is_session_worktree(p))
             .collect();
+        let candidate_count = candidates.len();
 
         let mut findings = Vec::new();
         for (id, path) in candidates {
             let probe_path = path.clone();
-            let verdict = match tokio::task::spawn_blocking(move || check(&probe_path)).await {
-                Ok(v) => v,
-                Err(e) => WorktreeIntegrity::Unknown(format!("integrity probe task failed: {e}")),
+            let join = tokio::task::spawn_blocking(move || check(&probe_path));
+            let verdict = match tokio::time::timeout(probe_timeout, join).await {
+                Ok(Ok(v)) => v,
+                Ok(Err(e)) => {
+                    WorktreeIntegrity::Unknown(format!("integrity probe task failed: {e}"))
+                }
+                Err(_elapsed) => WorktreeIntegrity::Unknown(format!(
+                    "integrity probe timed out after {}s — git may be blocked on a stalled \
+                     mount; NOT a clean bill of health",
+                    probe_timeout.as_secs()
+                )),
             };
-            match &verdict {
-                WorktreeIntegrity::Intact => continue,
-                WorktreeIntegrity::Destroyed(detail) => {
-                    tracing::error!(
-                        session = %id,
-                        path = %path.display(),
-                        detail = %detail,
-                        "WORKTREE DESTROYED: an ACTIVE session's own worktree is no longer a \
-                         git work tree. This session is running blind — `git log` still \
-                         answers from the enclosing repo and `git status` fatals, which \
-                         renders as a clean status. Its uncommitted work is GONE. Stop the \
-                         session and recreate it; do not let it keep committing (#3764/#3715)"
-                    );
-                }
-                WorktreeIntegrity::Unknown(why) => {
-                    tracing::warn!(
-                        session = %id,
-                        path = %path.display(),
-                        "worktree integrity could not be verified (NOT a clean bill of \
-                         health): {why} (#3764)"
-                    );
-                }
+            if matches!(verdict, WorktreeIntegrity::Intact) {
+                continue;
             }
             findings.push(IntegrityFinding { id, path, verdict });
         }
-        alarm_rollup(&findings);
+
+        // Latch BEFORE emitting, so one persistent finding cannot rotate the
+        // 500-entry capture ring (HIGH-4). Only sessions that alarm this tick
+        // are rendered; the rest are counted and stay silent.
+        let alarming: Vec<&IntegrityFinding> = {
+            let mut latch = alarm_latch()
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            let still_bad: std::collections::HashSet<ManagedSessionId> =
+                findings.iter().map(|f| f.id).collect();
+            latch.retain(&still_bad);
+            findings.iter().filter(|f| latch.record_bad(f.id)).collect()
+        };
+        for finding in &alarming {
+            emit_finding_alarm(finding);
+        }
+        alarm_rollup(&alarming, &findings, candidate_count);
         findings
     }
 }
 
-/// Emit the sweep-level ERROR roll-up for the `Destroyed` findings (#3764).
+/// Render one latched finding at its correct level and with remediation that
+/// matches the verdict (#3764).
+///
+/// Why: the `LinkageLost` / `Destroyed` split exists precisely so the two get
+/// DIFFERENT advice (code-critic HIGH-3). Keeping both messages in one function
+/// makes it obvious that only the empty-directory case is ever told its work is
+/// gone.
+/// What: `Destroyed` → ERROR asserting the work is lost and recreation is safe;
+/// `LinkageLost` → ERROR that explicitly says files SURVIVE and must be
+/// recovered BEFORE any decommission; `Unknown` → WARN (rolled up separately);
+/// `Intact` → unreachable (filtered by the caller).
+/// Test: `linkage_lost_with_surviving_files_does_not_claim_work_gone` in
+/// `worktree_integrity_tests.rs`.
+fn emit_finding_alarm(finding: &IntegrityFinding) {
+    let (id, path) = (finding.id, finding.path.as_path());
+    match &finding.verdict {
+        WorktreeIntegrity::Intact => {}
+        WorktreeIntegrity::Destroyed(detail) => {
+            tracing::error!(
+                session = %id,
+                path = %path.display(),
+                detail = %detail,
+                "WORKTREE DESTROYED: an ACTIVE session's own worktree is no longer a git \
+                 work tree AND the directory is empty. This session is running blind — \
+                 `git log` still answers from the enclosing repo and `git status` fatals, \
+                 which renders as a clean status. Its uncommitted work is gone. Stop the \
+                 session and recreate it; do not let it keep committing (#3764/#3715)"
+            );
+        }
+        WorktreeIntegrity::LinkageLost { detail, surviving } => {
+            tracing::error!(
+                session = %id,
+                path = %path.display(),
+                surviving = surviving.map_or(-1_i64, |n| n as i64),
+                detail = %detail,
+                "WORKTREE LINKAGE LOST: an ACTIVE session's worktree is no longer a git \
+                 work tree, but its FILES ARE STILL ON DISK ({}). The work is NOT lost — \
+                 DO NOT decommission or recreate this session, which would delete it. \
+                 Copy the directory aside first, then re-link or re-create the worktree. \
+                 A destroyed parent clone produces exactly this state across many \
+                 worktrees at once (#3764/#3715)",
+                surviving.map_or_else(
+                    || "entry count unavailable".to_string(),
+                    |n| format!("{n} entries")
+                )
+            );
+        }
+        WorktreeIntegrity::Unknown(why) => {
+            tracing::warn!(
+                session = %id,
+                path = %path.display(),
+                "worktree integrity could not be verified (NOT a clean bill of health): \
+                 {why} (#3764)"
+            );
+        }
+    }
+}
+
+/// Emit the sweep-level ERROR roll-up (#3764).
 ///
 /// Why: the per-finding alarms carry the evidence, but an operator scanning a
-/// log (or `list_recent_errors`) wants ONE line that says how many sessions are
-/// affected and which. Kept as a free function beside the audit — rather than
-/// inline in `daemon::orphan_gc_loop` — so the "which findings are loud enough
-/// to roll up" rule lives next to the verdicts it is filtering, and so the
-/// daemon loop stays a call site rather than a second place this policy is
-/// expressed.
-/// What: rolls up ONLY [`WorktreeIntegrity::Destroyed`]. An [`Unknown`]
-/// (`WorktreeIntegrity::Unknown`) is already warned per-finding and is
-/// deliberately NOT escalated here: an alarm that fires on "git was briefly
-/// unavailable" gets muted by operators, and a muted alarm is a silent one —
-/// the failure mode this whole issue exists to end. Emits nothing when no
-/// worktree is destroyed.
-/// Test: `rollup_reports_destroyed_sessions`,
-/// `rollup_is_silent_for_unknown_only` below.
-fn alarm_rollup(findings: &[IntegrityFinding]) {
-    let destroyed: Vec<String> = findings
+/// log (or `list_recent_errors`) wants ONE line for the sweep. Kept beside the
+/// audit — rather than inline in `daemon::orphan_gc_loop` — so the "which
+/// findings are loud enough to roll up" rule lives next to the verdicts it
+/// filters, and the daemon loop stays a call site rather than a second place
+/// this policy is expressed.
+///
+/// What: two independent ERROR conditions.
+///
+/// 1. **Damage.** Rolls up the findings that alarmed THIS tick and are
+///    [`WorktreeIntegrity::is_alarm`] — `Destroyed` or `LinkageLost`.
+///    Suppressed findings (latched, see [`AlarmLatch`]) are excluded so the
+///    roll-up cannot become the flood the latch exists to prevent.
+/// 2. **The detector is down** (code-critic MEDIUM). When there were
+///    candidates to audit and EVERY verdict came back `Unknown`, the detector
+///    itself is dark — `git` unavailable daemon-wide, or every probe timing
+///    out. Individually those are `warn!`, which this PR's own rationale says
+///    reaches no operator surface; collectively they mean the guard is not
+///    guarding, which is exactly the fail-open the module doc argues against.
+///    That is a distinct condition from the alarm-fatigue case, so it is ERROR
+///    once per sweep rather than per finding.
+///
+/// A lone `Unknown` among healthy sessions stays quiet — an alarm that fires on
+/// "git was briefly unavailable for one worktree" gets muted, and a muted alarm
+/// is a silent one.
+/// Test: `rollup_reports_destroyed_sessions`, `rollup_reports_linkage_lost`,
+/// `rollup_is_silent_for_single_unknown`,
+/// `rollup_errors_when_every_verdict_is_unknown`.
+fn alarm_rollup(alarming: &[&IntegrityFinding], all: &[IntegrityFinding], candidates: usize) {
+    let damaged: Vec<String> = alarming
         .iter()
-        .filter(|f| matches!(f.verdict, WorktreeIntegrity::Destroyed(_)))
+        .filter(|f| f.verdict.is_alarm())
         // `<session-id>=<path>` so the roll-up alone tells an operator WHICH
-        // sessions to stop and where they were running.
+        // sessions are affected and where they were running.
         .map(|f| format!("{}={}", f.id, f.path.display()))
         .collect();
-    if destroyed.is_empty() {
-        return;
+    if !damaged.is_empty() {
+        tracing::error!(
+            damaged = damaged.len(),
+            sessions = %damaged.join(" "),
+            "worktree-integrity audit: {} ACTIVE session(s) have a destroyed or \
+             unlinked worktree (#3764)",
+            damaged.len()
+        );
     }
-    tracing::error!(
-        destroyed = destroyed.len(),
-        sessions = %destroyed.join(" "),
-        "worktree-integrity audit: {} ACTIVE session(s) are running inside a destroyed \
-         worktree (#3764)",
-        destroyed.len()
-    );
+
+    // The detector-is-down case: every audited session came back Unknown, so
+    // nothing at all was actually verified this sweep.
+    let all_unknown = candidates > 0
+        && all.len() == candidates
+        && all
+            .iter()
+            .all(|f| matches!(f.verdict, WorktreeIntegrity::Unknown(_)));
+    if all_unknown {
+        tracing::error!(
+            candidates,
+            "worktree-integrity audit is DARK: all {candidates} audited session(s) \
+             returned an inconclusive verdict, so no worktree is currently being \
+             verified. Check that `git` is on the daemon's PATH and that no workspace \
+             is on a stalled mount (#3764)"
+        );
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    /// A root that does not resolve on disk is Destroyed, not Unknown.
+    const WT: &str = "/managed/base/.worktrees/wt";
+
+    fn root() -> PathBuf {
+        PathBuf::from(WT)
+    }
+
+    // ── classify: linkage-lost vs destroyed (code-critic HIGH-3) ────────────
+
+    /// A root that does not resolve on disk at all is Destroyed.
+    ///
+    /// Why: a directory that is not there holds nothing, so claiming the work
+    /// is gone is accurate in this one case.
     #[test]
     fn classify_missing_root_is_destroyed() {
         assert!(matches!(
-            classify(None, &TopLevel::NotAWorkTree),
+            classify(None, &TopLevel::NotAWorkTree, Some(0)),
             WorktreeIntegrity::Destroyed(_)
         ));
     }
 
-    /// The BARE-parent shape: git refuses → Destroyed.
+    /// Linkage gone AND the directory empty → Destroyed.
     #[test]
-    fn classify_not_a_work_tree_is_destroyed() {
-        let root = PathBuf::from("/managed/base/.worktrees/wt");
+    fn classify_empty_dir_is_destroyed() {
         assert!(matches!(
-            classify(Some(&root), &TopLevel::NotAWorkTree),
+            classify(Some(&root()), &TopLevel::NotAWorkTree, Some(0)),
             WorktreeIntegrity::Destroyed(_)
         ));
     }
 
-    /// The NON-BARE-parent shape: discovery escapes upward → Destroyed.
+    /// Linkage gone but files SURVIVE → LinkageLost, never Destroyed.
+    ///
+    /// Why (code-critic HIGH-3): the two states have opposite remediations.
+    /// Reporting this as `Destroyed` makes the alarm tell an operator their
+    /// work is gone and to recreate the session — advice that would itself
+    /// delete files still sitting on disk. The 07-21 `.base` destruction
+    /// orphaned ~70 worktrees in exactly this state, contents fully intact.
+    /// Test: this function IS the test.
+    #[test]
+    fn classify_surviving_files_is_linkage_lost() {
+        match classify(Some(&root()), &TopLevel::NotAWorkTree, Some(7)) {
+            WorktreeIntegrity::LinkageLost { surviving, .. } => {
+                assert_eq!(surviving, Some(7), "the surviving count must be carried");
+            }
+            other => panic!("files on disk must be LinkageLost, not {other:?}"),
+        }
+    }
+
+    /// An UNREADABLE directory is LinkageLost, never Destroyed.
+    ///
+    /// Why: not having counted the files is never grounds for telling an
+    /// operator they are gone. The unreadable case must fail toward "recover",
+    /// not toward "recreate".
+    /// Test: this function IS the test.
+    #[test]
+    fn classify_unreadable_dir_is_linkage_lost_not_destroyed() {
+        let verdict = classify(Some(&root()), &TopLevel::NotAWorkTree, None);
+        match verdict {
+            WorktreeIntegrity::LinkageLost { surviving, .. } => assert_eq!(surviving, None),
+            other => panic!("an uncounted directory must not be Destroyed; got {other:?}"),
+        }
+    }
+
+    /// The NON-BARE-parent shape (discovery escapes upward) with files present
+    /// is LinkageLost and names where discovery went.
     ///
     /// Why: this is the case `git rev-parse --is-inside-work-tree` returns
     /// `true` for (verified empirically). Detecting it is the entire reason
@@ -336,29 +680,104 @@ mod tests {
     /// trusting the simpler probe.
     /// Test: this function IS the test.
     #[test]
-    fn classify_escaped_toplevel_is_destroyed() {
-        let root = PathBuf::from("/managed/base/.worktrees/wt");
+    fn classify_escaped_toplevel_with_files_is_linkage_lost() {
         let escaped = TopLevel::Resolved(PathBuf::from("/managed/base"));
-        match classify(Some(&root), &escaped) {
-            WorktreeIntegrity::Destroyed(detail) => {
+        match classify(Some(&root()), &escaped, Some(3)) {
+            WorktreeIntegrity::LinkageLost { detail, surviving } => {
+                assert_eq!(surviving, Some(3));
                 assert!(
                     detail.contains("/managed/base"),
                     "the verdict must name where discovery escaped to; got {detail:?}"
                 );
             }
-            other => panic!("an escaped toplevel must be Destroyed, got {other:?}"),
+            other => panic!("an escaped toplevel with files must be LinkageLost, got {other:?}"),
         }
     }
 
     /// The healthy case: toplevel == root → Intact.
     #[test]
     fn classify_matching_toplevel_is_intact() {
-        let root = PathBuf::from("/managed/base/.worktrees/wt");
         assert_eq!(
-            classify(Some(&root), &TopLevel::Resolved(root.clone())),
+            classify(Some(&root()), &TopLevel::Resolved(root()), Some(9)),
             WorktreeIntegrity::Intact
         );
     }
+
+    /// A probe that could not run is Unknown — NEVER Intact, never Destroyed.
+    ///
+    /// Why: "the check didn't run" reported as "the check passed" is the exact
+    /// fail-open shape this whole issue is about. An unobservable result is
+    /// never a passing result — and never a destruction verdict either.
+    /// Test: this function IS the test.
+    #[test]
+    fn classify_unavailable_git_is_unknown_not_intact() {
+        let verdict = classify(
+            Some(&root()),
+            &TopLevel::Unavailable("no such file".into()),
+            Some(0),
+        );
+        assert!(
+            matches!(verdict, WorktreeIntegrity::Unknown(_)),
+            "an unrunnable probe must be Unknown; got {verdict:?}"
+        );
+        assert_ne!(verdict, WorktreeIntegrity::Intact);
+    }
+
+    // ── alarm latch (code-critic HIGH-4) ────────────────────────────────────
+
+    /// The latch alarms on transition, then goes quiet.
+    ///
+    /// Why (HIGH-4): without this, one persistent finding emits ~2 880 ERROR
+    /// events/day into a 500-entry non-deduping ring, rotating it in ~4 h and
+    /// evicting every other error from `list_recent_errors` / `tm doctor` —
+    /// degrading the very surface the ERROR-level argument depends on.
+    /// Test: this function IS the test.
+    #[test]
+    fn latch_alarms_on_transition_then_suppresses() {
+        let mut latch = AlarmLatch::default();
+        let id = ManagedSessionId::new();
+        assert!(latch.record_bad(id), "the first bad tick must alarm");
+        for tick in 2..REALARM_EVERY_TICKS {
+            assert!(
+                !latch.record_bad(id),
+                "tick {tick} must be suppressed by the latch"
+            );
+        }
+    }
+
+    /// The latch re-alarms once per interval, so an ongoing condition is still
+    /// proven ongoing rather than going permanently silent.
+    #[test]
+    fn latch_realarms_after_interval() {
+        let mut latch = AlarmLatch::default();
+        let id = ManagedSessionId::new();
+        let alarms = (0..REALARM_EVERY_TICKS * 2)
+            .filter(|_| latch.record_bad(id))
+            .count();
+        assert_eq!(
+            alarms,
+            3,
+            "expected transition + 2 interval re-alarms over {} ticks",
+            REALARM_EVERY_TICKS * 2
+        );
+    }
+
+    /// A session that recovers is evicted, so a later break alarms immediately
+    /// instead of inheriting a suppressed streak.
+    #[test]
+    fn latch_resets_when_session_recovers() {
+        let mut latch = AlarmLatch::default();
+        let id = ManagedSessionId::new();
+        assert!(latch.record_bad(id));
+        assert!(!latch.record_bad(id));
+        latch.retain(&std::collections::HashSet::new()); // recovered
+        assert!(
+            latch.record_bad(id),
+            "a session that recovered and broke again must alarm immediately"
+        );
+    }
+
+    // ── roll-up policy ──────────────────────────────────────────────────────
 
     /// Capture the levels of every tracing event emitted by `body`.
     fn levels_emitted_by(body: impl FnOnce()) -> Vec<tracing::Level> {
@@ -385,60 +804,69 @@ mod tests {
     fn finding(verdict: WorktreeIntegrity) -> IntegrityFinding {
         IntegrityFinding {
             id: ManagedSessionId::new(),
-            path: PathBuf::from("/managed/base/.worktrees/wt"),
+            path: root(),
             verdict,
         }
     }
 
     /// A Destroyed finding produces an ERROR roll-up.
-    ///
-    /// Why: ERROR is the only level the daemon's bug-capture layer persists to
-    /// `errors.jsonl` / `list_recent_errors`. A roll-up at any lower level
-    /// would be invisible to every operator surface.
-    /// Test: this function IS the test.
     #[test]
     fn rollup_reports_destroyed_sessions() {
-        let levels = levels_emitted_by(|| {
-            alarm_rollup(&[finding(WorktreeIntegrity::Destroyed("gone".into()))]);
-        });
+        let f = finding(WorktreeIntegrity::Destroyed("gone".into()));
+        let levels = levels_emitted_by(|| alarm_rollup(&[&f], std::slice::from_ref(&f), 1));
         assert!(
             levels.contains(&tracing::Level::ERROR),
             "a destroyed worktree must roll up at ERROR; got {levels:?}"
         );
     }
 
-    /// An Unknown-only audit emits NO roll-up.
+    /// A LinkageLost finding also rolls up at ERROR — it is damage too, just
+    /// damage with a different remedy.
+    #[test]
+    fn rollup_reports_linkage_lost() {
+        let f = finding(WorktreeIntegrity::LinkageLost {
+            detail: "unlinked".into(),
+            surviving: Some(4),
+        });
+        let levels = levels_emitted_by(|| alarm_rollup(&[&f], std::slice::from_ref(&f), 1));
+        assert!(levels.contains(&tracing::Level::ERROR));
+    }
+
+    /// ONE Unknown among healthy sessions stays silent.
     ///
-    /// Why: escalating "git was unavailable" to ERROR trains operators to
-    /// ignore the alarm, which converts a loud alarm into a silent one — the
-    /// exact failure this issue exists to end. Unknown stays a per-finding
-    /// warn.
+    /// Why: escalating "git was briefly unavailable for one worktree" trains
+    /// operators to ignore the alarm, which converts a loud alarm into a silent
+    /// one — the exact failure this issue exists to end.
     /// Test: this function IS the test.
     #[test]
-    fn rollup_is_silent_for_unknown_only() {
-        let levels = levels_emitted_by(|| {
-            alarm_rollup(&[finding(WorktreeIntegrity::Unknown("no git".into()))]);
-        });
+    fn rollup_is_silent_for_single_unknown() {
+        let f = finding(WorktreeIntegrity::Unknown("no git".into()));
+        // 5 candidates audited, only this one inconclusive → detector is fine.
+        let levels = levels_emitted_by(|| alarm_rollup(&[&f], std::slice::from_ref(&f), 5));
         assert!(
             levels.is_empty(),
-            "an Unknown-only audit must not roll up at all; got {levels:?}"
+            "a lone Unknown must not roll up at all; got {levels:?}"
         );
     }
 
-    /// A probe that could not run is Unknown — NEVER Intact.
+    /// When EVERY audited session is Unknown, the detector itself is dark and
+    /// that IS an ERROR (code-critic MEDIUM).
     ///
-    /// Why: "the check didn't run" reported as "the check passed" is the exact
-    /// fail-open shape this whole issue is about. An unobservable result is
-    /// never a passing result.
+    /// Why: individually those are `warn!`, which this PR's own rationale says
+    /// reaches no operator surface. Collectively they mean nothing is being
+    /// verified — a silently dark detector is the fail-open the module doc
+    /// argues against.
     /// Test: this function IS the test.
     #[test]
-    fn classify_unavailable_git_is_unknown_not_intact() {
-        let root = PathBuf::from("/managed/base/.worktrees/wt");
-        let verdict = classify(Some(&root), &TopLevel::Unavailable("no such file".into()));
+    fn rollup_errors_when_every_verdict_is_unknown() {
+        let all = vec![
+            finding(WorktreeIntegrity::Unknown("no git".into())),
+            finding(WorktreeIntegrity::Unknown("no git".into())),
+        ];
+        let levels = levels_emitted_by(|| alarm_rollup(&[], &all, 2));
         assert!(
-            matches!(verdict, WorktreeIntegrity::Unknown(_)),
-            "an unrunnable probe must be Unknown, never Intact; got {verdict:?}"
+            levels.contains(&tracing::Level::ERROR),
+            "an entirely-dark detector must ERROR once per sweep; got {levels:?}"
         );
-        assert_ne!(verdict, WorktreeIntegrity::Intact);
     }
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_integrity.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_integrity.rs
@@ -1,0 +1,445 @@
+//! Detect a session whose OWN worktree has been destroyed underneath it
+//! (#3764 item 4).
+//!
+//! ## Why
+//!
+//! Every guard shipped before this one asks "should I delete that?". None of
+//! them asks "is MY tree still there?". That gap is why the `f443c12d` session
+//! ran for **three days** inside a worktree that had lost its `.git` pointer,
+//! its registration, and its entire tracked source tree — while every harness
+//! surface reported it healthy.
+//!
+//! The reason it read as healthy is a textbook fail-open. When a worktree's
+//! `.git` pointer file is gone, git's repository discovery does not fail — it
+//! walks UP to the enclosing `.base` clone and answers from there:
+//!
+//! * `git log` succeeds and prints plausible commits (from `.base`'s stale
+//!   local `main`), so history looks fine.
+//! * `git status` fatals with `this operation must be run in a work tree`,
+//!   which the harness renders as `Status: (clean)` — a hard error laundered
+//!   into a clean bill of health.
+//!
+//! ## What (and why NOT `--is-inside-work-tree` alone)
+//!
+//! The obvious probe is `git rev-parse --is-inside-work-tree`, which does
+//! return `false` for a stripped worktree under this repo's layout. But that
+//! answer is an artifact of `.base` being a **bare** clone, and it is NOT
+//! layout-independent — verified empirically both ways:
+//!
+//! | parent repo | stripped worktree: `--is-inside-work-tree` | `--show-toplevel`  |
+//! |-------------|--------------------------------------------|--------------------|
+//! | bare        | `false`  → detected                        | fatal → detected   |
+//! | **normal**  | **`true`** → **MISSED**                    | parent dir → detected |
+//!
+//! With a non-bare parent checkout, discovery lands on a directory that IS a
+//! work tree, so `--is-inside-work-tree` cheerfully reports `true` for a
+//! completely destroyed worktree. Shipping that probe alone would have
+//! reproduced the very class of bug this issue exists to end: a detector that
+//! reports healthy when it is not.
+//!
+//! This module therefore uses the layout-independent discriminator:
+//! **`git -C <root> rev-parse --show-toplevel` must succeed AND resolve to
+//! `<root>` itself.** Anything else — a fatal (bare parent), or a toplevel that
+//! escaped to an ancestor (normal parent) — means this directory is no longer
+//! its own worktree.
+//!
+//! ## Scope and fail-open avoidance
+//!
+//! Only SM-created worktrees ([`is_session_worktree`]) are checked, so a
+//! local-path or adopted session pointed at a plain non-git directory can never
+//! be misreported. A probe that could not run at all (no `git` binary) yields
+//! [`WorktreeIntegrity::Unknown`], never `Intact` — an unobservable result is
+//! never a passing result.
+//!
+//! Test: `classify_*` below (the pure matrix, including the non-bare-parent
+//! case `--is-inside-work-tree` would miss) and
+//! `worktree_integrity_tests.rs` (real git worktrees, both parent layouts).
+
+use std::path::{Path, PathBuf};
+
+use super::decommission::is_session_worktree;
+use super::manager::SessionManager;
+use super::record::{ManagedSessionId, ManagedSessionState};
+
+/// Raw outcome of `git -C <root> rev-parse --show-toplevel`.
+///
+/// Why: separating "what git said" from "what that means" keeps the verdict
+/// logic pure and unit-testable without spawning a process, and forces the
+/// third case — git could not be consulted — to be handled explicitly instead
+/// of collapsing into a false `Intact`.
+/// What: [`Resolved`](Self::Resolved) — git printed a work-tree root.
+/// [`NotAWorkTree`](Self::NotAWorkTree) — git RAN and refused (exit != 0;
+/// `fatal: this operation must be run in a work tree`, or `not a git
+/// repository`). [`Unavailable`](Self::Unavailable) — git could not be spawned
+/// at all, which proves nothing either way.
+/// Test: `classify_*` below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TopLevel {
+    /// git resolved a work-tree root (already canonicalized by the caller).
+    Resolved(PathBuf),
+    /// git ran and reported there is no work tree here.
+    NotAWorkTree,
+    /// git could not be run — no evidence in either direction.
+    Unavailable(String),
+}
+
+/// Verdict on whether a session's worktree is still a real worktree.
+///
+/// Why: `Unknown` exists as a first-class variant precisely so an unobservable
+/// probe can never be reported as healthy. `bool` would have forced that lie.
+/// What: [`Intact`](Self::Intact), [`Destroyed`](Self::Destroyed) (with the
+/// human-readable evidence), [`Unknown`](Self::Unknown) (with the reason).
+/// Test: `classify_*` below.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WorktreeIntegrity {
+    /// The path is its own git work tree — healthy.
+    Intact,
+    /// The path is NOT its own work tree any more. Carries the evidence.
+    Destroyed(String),
+    /// The probe could not be completed. NEVER treat as healthy.
+    Unknown(String),
+}
+
+/// Decide integrity from a canonicalized root and a [`TopLevel`] probe result.
+///
+/// Why: this is the whole detector, expressed with zero I/O so every branch —
+/// including the non-bare-parent case that defeats `--is-inside-work-tree` —
+/// can be pinned by a unit test.
+/// What: `root_canon == None` (the root does not resolve on disk at all) →
+/// `Destroyed`. Otherwise: `Unavailable` → `Unknown`; `NotAWorkTree` →
+/// `Destroyed`; `Resolved(t)` → `Intact` iff `t == root_canon`, else
+/// `Destroyed` naming where discovery escaped to.
+/// Test: `classify_missing_root_is_destroyed`,
+/// `classify_not_a_work_tree_is_destroyed`,
+/// `classify_escaped_toplevel_is_destroyed`,
+/// `classify_matching_toplevel_is_intact`,
+/// `classify_unavailable_git_is_unknown_not_intact`.
+pub(crate) fn classify(root_canon: Option<&Path>, probe: &TopLevel) -> WorktreeIntegrity {
+    let Some(root) = root_canon else {
+        return WorktreeIntegrity::Destroyed(
+            "workspace root does not exist on disk (cannot canonicalize)".into(),
+        );
+    };
+    match probe {
+        TopLevel::Unavailable(why) => {
+            WorktreeIntegrity::Unknown(format!("could not run git to verify the worktree: {why}"))
+        }
+        TopLevel::NotAWorkTree => WorktreeIntegrity::Destroyed(
+            "git reports this path is not inside a work tree — its .git pointer is gone \
+             (git discovery fell through to the enclosing bare repo, which is why \
+             `git log` still appears to work here)"
+                .into(),
+        ),
+        TopLevel::Resolved(top) if top == root => WorktreeIntegrity::Intact,
+        TopLevel::Resolved(top) => WorktreeIntegrity::Destroyed(format!(
+            "git discovery escaped this directory and resolved to {} instead — this path \
+             is no longer its own worktree (note: `git rev-parse --is-inside-work-tree` \
+             reports `true` here and would MISS this)",
+            top.display()
+        )),
+    }
+}
+
+/// Run `git -C <root> rev-parse --show-toplevel` and canonicalize the answer.
+///
+/// Why: the single I/O site, kept trivial so [`classify`] holds all the logic.
+/// What: a non-zero exit means git ran and refused → [`TopLevel::NotAWorkTree`]
+/// (definitive: git itself said there is no work tree here). A spawn failure
+/// means git never ran → [`TopLevel::Unavailable`]. Success canonicalizes the
+/// printed path so the comparison in [`classify`] is symlink-safe (macOS
+/// `/tmp` ↔ `/private/tmp`).
+/// Test: exercised end-to-end by `worktree_integrity_tests.rs` against real
+/// git worktrees.
+pub(crate) fn probe_toplevel(root: &Path) -> TopLevel {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["rev-parse", "--show-toplevel"])
+        .output();
+    match out {
+        Ok(o) if o.status.success() => {
+            let raw = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            let path = PathBuf::from(&raw);
+            TopLevel::Resolved(path.canonicalize().unwrap_or(path))
+        }
+        // git RAN and refused — definitive evidence, not an inconclusive error.
+        Ok(_) => TopLevel::NotAWorkTree,
+        Err(e) => TopLevel::Unavailable(e.to_string()),
+    }
+}
+
+/// Full integrity check for one worktree root.
+///
+/// Why: the composition callers want — canonicalize, probe, classify.
+/// What: `classify(root.canonicalize().ok().as_deref(), &probe_toplevel(root))`.
+/// Test: `worktree_integrity_tests.rs`.
+pub(crate) fn check(root: &Path) -> WorktreeIntegrity {
+    let canon = root.canonicalize().ok();
+    // Probe the ORIGINAL path: canonicalization may fail while the path is
+    // still traversable, and git resolves it the same way either way.
+    classify(canon.as_deref(), &probe_toplevel(root))
+}
+
+/// One session whose worktree failed the integrity check.
+///
+/// Why: the sweep returns what it found so the caller (and tests) can assert
+/// on structured results rather than scraping logs.
+/// What: the session id, its workspace path, and the verdict.
+/// Test: `audit_flags_destroyed_worktree` in `worktree_integrity_tests.rs`.
+#[derive(Debug, Clone)]
+pub(crate) struct IntegrityFinding {
+    pub id: ManagedSessionId,
+    pub path: PathBuf,
+    pub verdict: WorktreeIntegrity,
+}
+
+impl SessionManager {
+    /// Check every Active session's own worktree and alarm on any that has been
+    /// destroyed (#3764 item 4).
+    ///
+    /// Why: this is the detector that would have caught all three worktree-loss
+    /// incidents within one GC interval instead of three days. It runs on the
+    /// daemon's existing orphan-GC tick, which already walks the same records —
+    /// no new loop, no new configuration, and the first tick after daemon start
+    /// doubles as the at-start self-check.
+    ///
+    /// The `error!` level is load-bearing, not stylistic: the daemon composes
+    /// `trusty_common::error_capture::bug_capture_layer`, which persists ONLY
+    /// ERROR-level events to `<data_dir>/trusty-mpm/errors.jsonl` and surfaces
+    /// them via the `list_recent_errors` MCP tool and `tm doctor`. At WARN this
+    /// finding would be invisible to every operator surface — the same silence
+    /// that let the last incident run for three days.
+    ///
+    /// What: scans Active records with a `workspace_path` that
+    /// [`is_session_worktree`] recognises (so local-path/adopted sessions on
+    /// plain directories are never misjudged), runs [`check`] on each inside
+    /// `spawn_blocking` (it shells out to git), `error!`s every `Destroyed`
+    /// verdict and `warn!`s every `Unknown` one, and returns all non-`Intact`
+    /// findings. It never mutates anything — a destroyed worktree is reported,
+    /// never "repaired", because silently recreating it is exactly the #3715
+    /// masking behaviour.
+    /// Test: `audit_flags_destroyed_worktree`,
+    /// `audit_passes_healthy_worktree`,
+    /// `audit_ignores_non_worktree_workspace` in `worktree_integrity_tests.rs`.
+    pub(crate) async fn audit_worktree_integrity(&self) -> Vec<IntegrityFinding> {
+        let candidates: Vec<(ManagedSessionId, PathBuf)> = self
+            .list()
+            .await
+            .into_iter()
+            .filter(|r| matches!(r.state, ManagedSessionState::Active))
+            .filter_map(|r| r.workspace_path.map(|p| (r.id, p)))
+            .filter(|(_, p)| is_session_worktree(p))
+            .collect();
+
+        let mut findings = Vec::new();
+        for (id, path) in candidates {
+            let probe_path = path.clone();
+            let verdict = match tokio::task::spawn_blocking(move || check(&probe_path)).await {
+                Ok(v) => v,
+                Err(e) => WorktreeIntegrity::Unknown(format!("integrity probe task failed: {e}")),
+            };
+            match &verdict {
+                WorktreeIntegrity::Intact => continue,
+                WorktreeIntegrity::Destroyed(detail) => {
+                    tracing::error!(
+                        session = %id,
+                        path = %path.display(),
+                        detail = %detail,
+                        "WORKTREE DESTROYED: an ACTIVE session's own worktree is no longer a \
+                         git work tree. This session is running blind — `git log` still \
+                         answers from the enclosing repo and `git status` fatals, which \
+                         renders as a clean status. Its uncommitted work is GONE. Stop the \
+                         session and recreate it; do not let it keep committing (#3764/#3715)"
+                    );
+                }
+                WorktreeIntegrity::Unknown(why) => {
+                    tracing::warn!(
+                        session = %id,
+                        path = %path.display(),
+                        "worktree integrity could not be verified (NOT a clean bill of \
+                         health): {why} (#3764)"
+                    );
+                }
+            }
+            findings.push(IntegrityFinding { id, path, verdict });
+        }
+        alarm_rollup(&findings);
+        findings
+    }
+}
+
+/// Emit the sweep-level ERROR roll-up for the `Destroyed` findings (#3764).
+///
+/// Why: the per-finding alarms carry the evidence, but an operator scanning a
+/// log (or `list_recent_errors`) wants ONE line that says how many sessions are
+/// affected and which. Kept as a free function beside the audit — rather than
+/// inline in `daemon::orphan_gc_loop` — so the "which findings are loud enough
+/// to roll up" rule lives next to the verdicts it is filtering, and so the
+/// daemon loop stays a call site rather than a second place this policy is
+/// expressed.
+/// What: rolls up ONLY [`WorktreeIntegrity::Destroyed`]. An [`Unknown`]
+/// (`WorktreeIntegrity::Unknown`) is already warned per-finding and is
+/// deliberately NOT escalated here: an alarm that fires on "git was briefly
+/// unavailable" gets muted by operators, and a muted alarm is a silent one —
+/// the failure mode this whole issue exists to end. Emits nothing when no
+/// worktree is destroyed.
+/// Test: `rollup_reports_destroyed_sessions`,
+/// `rollup_is_silent_for_unknown_only` below.
+fn alarm_rollup(findings: &[IntegrityFinding]) {
+    let destroyed: Vec<String> = findings
+        .iter()
+        .filter(|f| matches!(f.verdict, WorktreeIntegrity::Destroyed(_)))
+        // `<session-id>=<path>` so the roll-up alone tells an operator WHICH
+        // sessions to stop and where they were running.
+        .map(|f| format!("{}={}", f.id, f.path.display()))
+        .collect();
+    if destroyed.is_empty() {
+        return;
+    }
+    tracing::error!(
+        destroyed = destroyed.len(),
+        sessions = %destroyed.join(" "),
+        "worktree-integrity audit: {} ACTIVE session(s) are running inside a destroyed \
+         worktree (#3764)",
+        destroyed.len()
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A root that does not resolve on disk is Destroyed, not Unknown.
+    #[test]
+    fn classify_missing_root_is_destroyed() {
+        assert!(matches!(
+            classify(None, &TopLevel::NotAWorkTree),
+            WorktreeIntegrity::Destroyed(_)
+        ));
+    }
+
+    /// The BARE-parent shape: git refuses → Destroyed.
+    #[test]
+    fn classify_not_a_work_tree_is_destroyed() {
+        let root = PathBuf::from("/managed/base/.worktrees/wt");
+        assert!(matches!(
+            classify(Some(&root), &TopLevel::NotAWorkTree),
+            WorktreeIntegrity::Destroyed(_)
+        ));
+    }
+
+    /// The NON-BARE-parent shape: discovery escapes upward → Destroyed.
+    ///
+    /// Why: this is the case `git rev-parse --is-inside-work-tree` returns
+    /// `true` for (verified empirically). Detecting it is the entire reason
+    /// this module compares `--show-toplevel` against the root instead of
+    /// trusting the simpler probe.
+    /// Test: this function IS the test.
+    #[test]
+    fn classify_escaped_toplevel_is_destroyed() {
+        let root = PathBuf::from("/managed/base/.worktrees/wt");
+        let escaped = TopLevel::Resolved(PathBuf::from("/managed/base"));
+        match classify(Some(&root), &escaped) {
+            WorktreeIntegrity::Destroyed(detail) => {
+                assert!(
+                    detail.contains("/managed/base"),
+                    "the verdict must name where discovery escaped to; got {detail:?}"
+                );
+            }
+            other => panic!("an escaped toplevel must be Destroyed, got {other:?}"),
+        }
+    }
+
+    /// The healthy case: toplevel == root → Intact.
+    #[test]
+    fn classify_matching_toplevel_is_intact() {
+        let root = PathBuf::from("/managed/base/.worktrees/wt");
+        assert_eq!(
+            classify(Some(&root), &TopLevel::Resolved(root.clone())),
+            WorktreeIntegrity::Intact
+        );
+    }
+
+    /// Capture the levels of every tracing event emitted by `body`.
+    fn levels_emitted_by(body: impl FnOnce()) -> Vec<tracing::Level> {
+        use std::sync::{Arc, Mutex};
+        use tracing_subscriber::layer::SubscriberExt as _;
+
+        struct Collector(Arc<Mutex<Vec<tracing::Level>>>);
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for Collector {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                self.0.lock().expect("lock").push(*event.metadata().level());
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::registry().with(Collector(Arc::clone(&seen)));
+        tracing::subscriber::with_default(subscriber, body);
+        let levels = seen.lock().expect("lock").clone();
+        levels
+    }
+
+    fn finding(verdict: WorktreeIntegrity) -> IntegrityFinding {
+        IntegrityFinding {
+            id: ManagedSessionId::new(),
+            path: PathBuf::from("/managed/base/.worktrees/wt"),
+            verdict,
+        }
+    }
+
+    /// A Destroyed finding produces an ERROR roll-up.
+    ///
+    /// Why: ERROR is the only level the daemon's bug-capture layer persists to
+    /// `errors.jsonl` / `list_recent_errors`. A roll-up at any lower level
+    /// would be invisible to every operator surface.
+    /// Test: this function IS the test.
+    #[test]
+    fn rollup_reports_destroyed_sessions() {
+        let levels = levels_emitted_by(|| {
+            alarm_rollup(&[finding(WorktreeIntegrity::Destroyed("gone".into()))]);
+        });
+        assert!(
+            levels.contains(&tracing::Level::ERROR),
+            "a destroyed worktree must roll up at ERROR; got {levels:?}"
+        );
+    }
+
+    /// An Unknown-only audit emits NO roll-up.
+    ///
+    /// Why: escalating "git was unavailable" to ERROR trains operators to
+    /// ignore the alarm, which converts a loud alarm into a silent one — the
+    /// exact failure this issue exists to end. Unknown stays a per-finding
+    /// warn.
+    /// Test: this function IS the test.
+    #[test]
+    fn rollup_is_silent_for_unknown_only() {
+        let levels = levels_emitted_by(|| {
+            alarm_rollup(&[finding(WorktreeIntegrity::Unknown("no git".into()))]);
+        });
+        assert!(
+            levels.is_empty(),
+            "an Unknown-only audit must not roll up at all; got {levels:?}"
+        );
+    }
+
+    /// A probe that could not run is Unknown — NEVER Intact.
+    ///
+    /// Why: "the check didn't run" reported as "the check passed" is the exact
+    /// fail-open shape this whole issue is about. An unobservable result is
+    /// never a passing result.
+    /// Test: this function IS the test.
+    #[test]
+    fn classify_unavailable_git_is_unknown_not_intact() {
+        let root = PathBuf::from("/managed/base/.worktrees/wt");
+        let verdict = classify(Some(&root), &TopLevel::Unavailable("no such file".into()));
+        assert!(
+            matches!(verdict, WorktreeIntegrity::Unknown(_)),
+            "an unrunnable probe must be Unknown, never Intact; got {verdict:?}"
+        );
+        assert_ne!(verdict, WorktreeIntegrity::Intact);
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_integrity_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_integrity_tests.rs
@@ -21,6 +21,7 @@ use std::path::{Path, PathBuf};
 use super::manager::SessionManager;
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::worktree_integrity::{WorktreeIntegrity, check};
+use std::time::Duration;
 
 /// Run a git command, panicking with stderr on failure.
 fn git(dir: &Path, args: &[&str]) -> String {
@@ -77,7 +78,7 @@ fn make_worktree(root: &Path, bare: bool) -> PathBuf {
 }
 
 /// Destroy a worktree the way the three incidents did: every tracked file AND
-/// the `.git` pointer file are gone, but the directory itself remains.
+/// the `.git` pointer file are gone, but the directory itself remains EMPTY.
 fn strip_worktree(wt: &Path) {
     for entry in std::fs::read_dir(wt).expect("read worktree dir") {
         let path = entry.expect("dir entry").path();
@@ -279,5 +280,158 @@ async fn audit_ignores_non_worktree_workspace() {
     assert!(
         mgr.audit_worktree_integrity().await.is_empty(),
         "a non-.worktrees workspace must never be audited"
+    );
+}
+
+// ── code-critic HIGH-3: linkage lost vs work lost ───────────────────────────
+
+/// Deleting ONLY the base repo's admin gitdir unlinks the worktree while every
+/// file survives — the detector must say `LinkageLost`, never `Destroyed`.
+///
+/// Why: this is the critic's reproduction, and it is not hypothetical for this
+/// repo. When the `.base` bare clone was destroyed on 07-21 it orphaned ~70
+/// worktrees whose contents were **entirely intact**. Under the first draft
+/// every one of them would have alarmed *"Its uncommitted work is GONE. Stop the
+/// session and recreate it"* — advice that, followed, runs `decommission` (which
+/// carries no #4118 dirt guard) and deletes the very work that survived. A
+/// detector that says that is a destroyer.
+/// Test: this function IS the test.
+#[test]
+fn linkage_lost_with_surviving_files_does_not_claim_work_gone() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true);
+
+    // Real uncommitted work sitting in the worktree.
+    std::fs::write(wt.join("precious.txt"), b"three days of uncommitted work")
+        .expect("write precious.txt");
+
+    // Destroy ONLY the base's administrative gitdir for this worktree —
+    // the worktree's own files (a.txt, precious.txt, .git pointer) all remain.
+    let admin = root.path().join("base").join("worktrees").join("wt");
+    assert!(
+        admin.is_dir(),
+        "test premise: admin gitdir must exist at {admin:?}"
+    );
+    std::fs::remove_dir_all(&admin).expect("remove admin gitdir");
+
+    let verdict = check(&wt);
+    match verdict {
+        WorktreeIntegrity::LinkageLost { surviving, .. } => {
+            let n = surviving.expect("the directory is readable, so the count must be Some");
+            assert!(
+                n >= 2,
+                "a.txt and precious.txt must both be counted as surviving; got {n}"
+            );
+        }
+        other => panic!(
+            "files still on disk must NEVER be reported as Destroyed — that alarm tells \
+             the operator to recreate, which deletes them. Got {other:?}"
+        ),
+    }
+
+    // The evidence, restated as a filesystem fact: the work really is still there.
+    assert_eq!(
+        std::fs::read(wt.join("precious.txt")).expect("read precious.txt"),
+        b"three days of uncommitted work",
+    );
+}
+
+/// A worktree emptied of files IS `Destroyed` — the distinction has teeth in
+/// both directions.
+///
+/// Why: the regression half of the test above. A split that reported
+/// `LinkageLost` for everything would pass that test while making the
+/// `Destroyed` verdict unreachable and the detector useless.
+/// Test: this function IS the test.
+#[test]
+fn emptied_worktree_is_destroyed_not_linkage_lost() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true);
+    strip_worktree(&wt);
+    assert!(
+        matches!(check(&wt), WorktreeIntegrity::Destroyed(_)),
+        "an EMPTY unlinked worktree must be Destroyed; got {:?}",
+        check(&wt)
+    );
+}
+
+// ── code-critic HIGH-2: the git probe must be bounded ───────────────────────
+
+/// A probe that exceeds its timeout yields `Unknown` — never a destruction
+/// verdict, and never `Intact`.
+///
+/// Why: the first draft awaited `spawn_blocking(check)` unbounded inside
+/// `orphan_gc_loop`. One worktree on a stalled mount would block the audit,
+/// the rest of that tick, and every future tick, indefinitely. A timeout is an
+/// absence of evidence, so it must land on `Unknown`: reporting `Intact` would
+/// be the fail-open this module exists to prevent, and reporting `Destroyed`
+/// would tell an operator to delete a healthy tree.
+/// What: drives the audit with a 1 ns budget, which the `git` subprocess cannot
+/// possibly meet, against a HEALTHY worktree — so an unbounded implementation
+/// returns `Intact` (no finding at all) and fails this test.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn audit_times_out_into_unknown_never_destroyed() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true); // healthy
+    let id = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(active_record(id, Some(wt)))
+        .await
+        .expect("upsert");
+
+    let findings = mgr
+        .audit_worktree_integrity_with_timeout(Duration::from_nanos(1))
+        .await;
+
+    assert_eq!(
+        findings.len(),
+        1,
+        "a timed-out probe must produce a finding, not silently pass as healthy"
+    );
+    match &findings[0].verdict {
+        WorktreeIntegrity::Unknown(why) => {
+            assert!(
+                why.contains("timed out"),
+                "the verdict must say it timed out; got {why:?}"
+            );
+        }
+        other => panic!("a timeout must be Unknown, never {other:?}"),
+    }
+}
+
+/// The default audit still uses a bounded timeout, not an unbounded await.
+///
+/// Why: `audit_worktree_integrity_with_timeout` being correct is worthless if
+/// the production entry point does not route through it.
+/// Test: this function IS the test — a healthy worktree audited through the
+/// DEFAULT entry point produces no finding, proving the generous production
+/// budget is applied rather than a 1 ns one.
+#[tokio::test]
+async fn default_audit_is_bounded_but_generous() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true);
+    mgr.store
+        .write()
+        .await
+        .upsert(active_record(ManagedSessionId::new(), Some(wt)))
+        .await
+        .expect("upsert");
+
+    assert!(
+        mgr.audit_worktree_integrity().await.is_empty(),
+        "the production timeout must be generous enough for a real git call"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/worktree_integrity_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_integrity_tests.rs
@@ -1,0 +1,283 @@
+//! End-to-end coverage for the #3764 item-4 destroyed-worktree detector,
+//! against REAL git worktrees in BOTH parent-repo layouts.
+//!
+//! Why: the unit tests in `worktree_integrity` pin the pure classifier, but the
+//! claim being made — "a stripped worktree is detectable, and detectable the
+//! same way whether the parent clone is bare or not" — is a claim about git's
+//! actual behaviour, not about our enum. It has to be tested against git.
+//! These tests build a real repo, a real `git worktree add`, then destroy the
+//! worktree exactly the way the three incidents did (remove its contents AND
+//! its `.git` pointer file) and assert the verdict.
+//!
+//! The bare-vs-normal split is the load-bearing part: with a NORMAL parent
+//! checkout, `git rev-parse --is-inside-work-tree` returns `true` for a fully
+//! destroyed worktree. `should_have_flagged_stripped_worktree_under_normal_parent`
+//! is the regression test for that false-negative, and is the reason the
+//! detector compares `--show-toplevel` to the root instead.
+//! Test: this file IS the test.
+
+use std::path::{Path, PathBuf};
+
+use super::manager::SessionManager;
+use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
+use super::worktree_integrity::{WorktreeIntegrity, check};
+
+/// Run a git command, panicking with stderr on failure.
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("spawn git {args:?}: {e}"));
+    assert!(
+        out.status.success(),
+        "git {args:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Build `<root>/src` (a normal repo with one commit), then a parent clone at
+/// `<root>/base` — bare when `bare` is true — and a worktree at
+/// `<root>/base/.worktrees/wt`. Returns the worktree path.
+fn make_worktree(root: &Path, bare: bool) -> PathBuf {
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("create src");
+    git(&src, &["init", "-q", "."]);
+    git(&src, &["config", "user.email", "t@example.invalid"]);
+    git(&src, &["config", "user.name", "t"]);
+    std::fs::write(src.join("a.txt"), b"hi").expect("write a.txt");
+    git(&src, &["add", "-A"]);
+    git(&src, &["commit", "-qm", "init"]);
+
+    let base = root.join("base");
+    let mut clone_args = vec!["clone", "-q"];
+    if bare {
+        clone_args.push("--bare");
+    }
+    let src_s = src.display().to_string();
+    let base_s = base.display().to_string();
+    clone_args.push(&src_s);
+    clone_args.push(&base_s);
+    let out = std::process::Command::new("git")
+        .args(&clone_args)
+        .output()
+        .expect("spawn git clone");
+    assert!(
+        out.status.success(),
+        "git clone failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let wt = base.join(".worktrees").join("wt");
+    let wt_s = wt.display().to_string();
+    git(&base, &["worktree", "add", "-q", &wt_s, "-b", "wt1"]);
+    wt
+}
+
+/// Destroy a worktree the way the three incidents did: every tracked file AND
+/// the `.git` pointer file are gone, but the directory itself remains.
+fn strip_worktree(wt: &Path) {
+    for entry in std::fs::read_dir(wt).expect("read worktree dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            std::fs::remove_dir_all(&path).expect("remove subdir");
+        } else {
+            std::fs::remove_file(&path).expect("remove file");
+        }
+    }
+    assert!(
+        !wt.join(".git").exists(),
+        "test invariant: the .git pointer must be gone"
+    );
+    assert!(wt.exists(), "test invariant: the directory itself remains");
+}
+
+/// A healthy worktree is Intact (bare parent — this repo's real layout).
+#[test]
+fn healthy_worktree_is_intact() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true);
+    assert_eq!(check(&wt), WorktreeIntegrity::Intact);
+}
+
+/// A stripped worktree under a BARE parent is Destroyed.
+///
+/// Why: this is this repo's layout (`.base` is a bare clone) and the exact
+/// state `f443c12d` sat in for three days.
+/// Test: this function IS the test.
+#[test]
+fn stripped_worktree_under_bare_parent_is_destroyed() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true);
+    strip_worktree(&wt);
+    assert!(
+        matches!(check(&wt), WorktreeIntegrity::Destroyed(_)),
+        "a stripped worktree under a bare parent must be Destroyed; got {:?}",
+        check(&wt)
+    );
+}
+
+/// A stripped worktree under a NORMAL parent is Destroyed — the case
+/// `--is-inside-work-tree` would report healthy.
+///
+/// Why: this test also PROVES the false-negative it guards against. It asserts,
+/// in the same run, that `git rev-parse --is-inside-work-tree` really does say
+/// `true` for this destroyed tree, and that our detector says Destroyed anyway.
+/// If a future change swaps the detector for the simpler probe, this fails.
+/// Test: this function IS the test.
+#[test]
+fn should_have_flagged_stripped_worktree_under_normal_parent() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), false);
+    strip_worktree(&wt);
+
+    // The naive probe's answer, recorded here as evidence.
+    let naive = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&wt)
+        .args(["rev-parse", "--is-inside-work-tree"])
+        .output()
+        .expect("spawn git");
+    let naive_says = String::from_utf8_lossy(&naive.stdout).trim().to_string();
+    assert_eq!(
+        naive_says, "true",
+        "test premise: --is-inside-work-tree is expected to MISS this case"
+    );
+
+    assert!(
+        matches!(check(&wt), WorktreeIntegrity::Destroyed(_)),
+        "the detector must flag a stripped worktree even when --is-inside-work-tree \
+         says `true`; got {:?}",
+        check(&wt)
+    );
+}
+
+/// A workspace root that no longer exists at all is Destroyed.
+#[test]
+fn absent_workspace_root_is_destroyed() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let absent = root.path().join("base").join(".worktrees").join("gone");
+    assert!(matches!(check(&absent), WorktreeIntegrity::Destroyed(_)));
+}
+
+fn active_record(id: ManagedSessionId, ws: Option<PathBuf>) -> SessionRecord {
+    SessionRecord {
+        id,
+        tmux_name: format!("tm-3764-integ-{id}"),
+        cwd: std::path::PathBuf::from("/tmp"),
+        task: "task".into(),
+        state: ManagedSessionState::Active,
+        created_at: chrono::Utc::now(),
+        last_activity_at: None,
+        workspace_path: ws,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        workspace_owned: false,
+        source_id: None,
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: Default::default(),
+        worktree_owner: Some(id),
+    }
+}
+
+/// The daemon sweep flags an Active session sitting in a destroyed worktree.
+///
+/// Why: the wiring test — the detector has to be reachable from the periodic
+/// audit, or it changes nothing about the three-day blindness.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn audit_flags_destroyed_worktree() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true);
+    strip_worktree(&wt);
+
+    let id = ManagedSessionId::new();
+    mgr.store
+        .write()
+        .await
+        .upsert(active_record(id, Some(wt.clone())))
+        .await
+        .expect("upsert");
+
+    let findings = mgr.audit_worktree_integrity().await;
+    assert_eq!(findings.len(), 1, "the destroyed worktree must be reported");
+    assert_eq!(findings[0].id, id);
+    assert!(matches!(
+        findings[0].verdict,
+        WorktreeIntegrity::Destroyed(_)
+    ));
+}
+
+/// A healthy Active session produces no findings.
+///
+/// Why: the regression half — an audit that flagged everything would also pass
+/// the test above while making the alarm worthless.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn audit_passes_healthy_worktree() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let root = crate::test_support::hermetic_temp_dir();
+    let wt = make_worktree(root.path(), true);
+
+    mgr.store
+        .write()
+        .await
+        .upsert(active_record(ManagedSessionId::new(), Some(wt)))
+        .await
+        .expect("upsert");
+
+    assert!(
+        mgr.audit_worktree_integrity().await.is_empty(),
+        "a healthy worktree must produce no findings"
+    );
+}
+
+/// A local-path / adopted session on a plain directory is NOT audited.
+///
+/// Why: the false-positive guard. Those sessions legitimately live outside a
+/// `.worktrees/` parent and may not be git repos at all; flagging them would
+/// bury the real signal in noise.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn audit_ignores_non_worktree_workspace() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let mgr = SessionManager::new(dir.path(), super::tests::FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let plain = crate::test_support::hermetic_temp_dir();
+    let ws = plain.path().join("some").join("user").join("project");
+    std::fs::create_dir_all(&ws).expect("create plain dir");
+
+    mgr.store
+        .write()
+        .await
+        .upsert(active_record(ManagedSessionId::new(), Some(ws)))
+        .await
+        .expect("upsert");
+
+    assert!(
+        mgr.audit_worktree_integrity().await.is_empty(),
+        "a non-.worktrees workspace must never be audited"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
@@ -295,8 +295,8 @@ impl SessionManager {
     }
 
     /// The I/O half of the #3764 cross-session deletion guard: does the
-    /// worktree AT `path` declare an owner that is a different, still-Active
-    /// session than `target`?
+    /// worktree AT `path` belong to a different session that is NOT provably
+    /// ownerless?
     ///
     /// Why: [`Self::known_owner_of`] resolves ownership from the RECORD first
     /// (`record.worktree_owner`, sentinel only as fallback). That is right for
@@ -304,30 +304,103 @@ impl SessionManager {
     /// a record whose `workspace_path` points at a PEER's worktree, so trusting
     /// the record's own idea of ownership would launder the corruption — the
     /// impostor record names itself as owner and the guard would never fire.
-    /// This deliberately reads ONLY the on-disk sentinel: the worktree is asked
-    /// who owns it, and the record asking for its removal gets no say.
-    /// What: reads `path`'s ownership sentinel via [`read_sentinel_owner`],
-    /// looks up that owner's current state in the store (absent → `None`
-    /// state), and delegates the decision to
-    /// [`workspace_guard::foreign_active_owner`](super::workspace_guard::foreign_active_owner)
-    /// — see that function for the full allow/refuse matrix.
+    /// Ownership is therefore established from evidence the record asking for
+    /// the removal does not control.
+    ///
+    /// TWO independent sources are consulted, and either one refusing is enough
+    /// (code-critic MEDIUM on the #3764 PR):
+    ///
+    /// 1. **The on-disk ownership sentinel.** Authoritative when present, but it
+    ///    is a plain file INSIDE the worktree that any agent in any session can
+    ///    write or delete, and pre-#3649 worktrees carry a zero-byte one with no
+    ///    owner at all. On those paths the sentinel half is silently inert —
+    ///    which is precisely where legacy worktrees live.
+    /// 2. **The store.** Any OTHER record whose canonicalized `workspace_path`
+    ///    equals this one, and which is not provably ownerless, refuses the
+    ///    removal. This needs no on-disk file, cannot be forged or erased by an
+    ///    agent, and is the #1744 cwd-collision incident shape verbatim — two
+    ///    live records bound to one worktree. It is what makes the guard hold on
+    ///    exactly the legacy paths where the sentinel does not.
+    ///
+    /// Reclaimability in both cases is [`Self::resolve_ownerless`], NOT
+    /// `state == Active` — see
+    /// [`workspace_guard::foreign_owner`](super::workspace_guard::foreign_owner)
+    /// for why that distinction is the difference between protecting a Stopped
+    /// peer's resumable tree and destroying it.
+    /// What: reads `path`'s sentinel, resolves the named owner's
+    /// reclaimability, and delegates to `foreign_owner`; if that allows, scans
+    /// the store for a colliding non-ownerless record. Returns the blocking
+    /// owner id, or `None` when the removal may proceed.
     /// Test: `decommission_refuses_to_delete_live_peer_worktree`,
-    /// `decommission_removes_own_worktree_despite_guard` in
-    /// `super::decommission::tests`.
+    /// `decommission_refuses_to_delete_stopped_peer_worktree`,
+    /// `decommission_refuses_when_store_shows_live_peer_without_sentinel`,
+    /// `decommission_removes_own_worktree_despite_guard`,
+    /// `decommission_allows_reclaim_when_peer_is_terminal` in
+    /// `super::worktree_identity_guard_tests`.
     pub(crate) async fn foreign_active_worktree_owner(
         &self,
         path: &Path,
         target: ManagedSessionId,
     ) -> Option<ManagedSessionId> {
+        // Source 1: the worktree's own ownership sentinel.
         let declared = match read_sentinel_owner(path) {
             SentinelOwner::Known(owner, _created_at) => Some(owner),
             SentinelOwner::Unknown => None,
         };
-        let owner_state = match declared {
-            Some(owner) => self.get(&owner).await.ok().map(|r| r.state),
-            None => None,
+        let declared_ownerless = match declared {
+            Some(owner) => self.resolve_ownerless(owner).await,
+            // Irrelevant when no owner is declared — `foreign_owner` short-
+            // circuits on `None` before this value is consulted.
+            None => true,
         };
-        super::workspace_guard::foreign_active_owner(declared, target, owner_state)
+        if let Some(owner) =
+            super::workspace_guard::foreign_owner(declared, target, declared_ownerless)
+        {
+            return Some(owner);
+        }
+
+        // Source 2: the store. Unforgeable — no file inside the worktree is
+        // involved, so this survives a deleted/zero-byte/legacy sentinel.
+        self.colliding_live_record(path, target).await
+    }
+
+    /// Find another non-ownerless record bound to the SAME worktree path
+    /// (#3764, code-critic MEDIUM) — the unforgeable half of the guard.
+    ///
+    /// Why: keyed on store state rather than on a file an agent can write, so
+    /// it cannot be laundered by the impostor record requesting the removal.
+    /// Two live records bound to one worktree IS the #1744 collision that
+    /// preceded the corruption, and the #3764 item-2 alarm fires on the very
+    /// same condition — this is that alarm's enforcement half.
+    /// What: canonicalizes `path` and every candidate's `workspace_path`
+    /// (falling back to the raw path when canonicalization fails, matching
+    /// `correlate_session_start`'s comparison so the two cannot disagree),
+    /// skips `target` itself, and returns the first colliding record that is
+    /// not provably ownerless.
+    /// Test: `decommission_refuses_when_store_shows_live_peer_without_sentinel`
+    /// in `super::worktree_identity_guard_tests`.
+    async fn colliding_live_record(
+        &self,
+        path: &Path,
+        target: ManagedSessionId,
+    ) -> Option<ManagedSessionId> {
+        let canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+        for record in self.list().await {
+            if record.id == target {
+                continue;
+            }
+            let Some(ref ws) = record.workspace_path else {
+                continue;
+            };
+            let ws_canon = std::fs::canonicalize(ws).unwrap_or_else(|_| ws.clone());
+            if ws_canon != canon {
+                continue;
+            }
+            if !self.resolve_ownerless(record.id).await {
+                return Some(record.id);
+            }
+        }
+        None
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_ownership.rs
@@ -293,6 +293,42 @@ impl SessionManager {
             SentinelOwner::Unknown => None,
         }
     }
+
+    /// The I/O half of the #3764 cross-session deletion guard: does the
+    /// worktree AT `path` declare an owner that is a different, still-Active
+    /// session than `target`?
+    ///
+    /// Why: [`Self::known_owner_of`] resolves ownership from the RECORD first
+    /// (`record.worktree_owner`, sentinel only as fallback). That is right for
+    /// the #3649 caller gate but exactly wrong for #3764: the incident shape is
+    /// a record whose `workspace_path` points at a PEER's worktree, so trusting
+    /// the record's own idea of ownership would launder the corruption — the
+    /// impostor record names itself as owner and the guard would never fire.
+    /// This deliberately reads ONLY the on-disk sentinel: the worktree is asked
+    /// who owns it, and the record asking for its removal gets no say.
+    /// What: reads `path`'s ownership sentinel via [`read_sentinel_owner`],
+    /// looks up that owner's current state in the store (absent → `None`
+    /// state), and delegates the decision to
+    /// [`workspace_guard::foreign_active_owner`](super::workspace_guard::foreign_active_owner)
+    /// — see that function for the full allow/refuse matrix.
+    /// Test: `decommission_refuses_to_delete_live_peer_worktree`,
+    /// `decommission_removes_own_worktree_despite_guard` in
+    /// `super::decommission::tests`.
+    pub(crate) async fn foreign_active_worktree_owner(
+        &self,
+        path: &Path,
+        target: ManagedSessionId,
+    ) -> Option<ManagedSessionId> {
+        let declared = match read_sentinel_owner(path) {
+            SentinelOwner::Known(owner, _created_at) => Some(owner),
+            SentinelOwner::Unknown => None,
+        };
+        let owner_state = match declared {
+            Some(owner) => self.get(&owner).await.ok().map(|r| r.state),
+            None => None,
+        };
+        super::workspace_guard::foreign_active_owner(declared, target, owner_state)
+    }
 }
 
 #[cfg(test)]

--- a/docs/runbooks/worktree-corruption-forensics.md
+++ b/docs/runbooks/worktree-corruption-forensics.md
@@ -1,0 +1,143 @@
+# Runbook — worktree corruption: forensic capture and triage
+
+**Issue:** #3764 (item 3) · **Parent symptom:** #3715 · **Related:** #1845 (F3
+canonicalize fallback), #1744 (cwd collision), #3721 (recreation guard)
+
+**Read this the moment an alarm below fires. Capture first, diagnose second.**
+In the last incident every pre-incident transcript was destroyed before anyone
+looked: `write_scrollback` overwrites `.trusty-mpm/scrollback.txt` on the next
+stop, and the shell history files held nothing. The forensic window closes in
+minutes, not hours.
+
+---
+
+## 1. Which alarms bring you here
+
+All four are ERROR-level, which means they are persisted to
+`<data_dir>/trusty-mpm/errors.jsonl` by the daemon's bug-capture layer and are
+queryable via the `list_recent_errors` MCP tool and `tm doctor`. WARN-level
+events are **not** captured anywhere queryable — that asymmetry is why each of
+these was deliberately escalated.
+
+| Alarm text (grep for this) | Source | Means |
+|---|---|---|
+| `WORKTREE DESTROYED` | `session_manager::worktree_integrity` | An **Active** session's own worktree is no longer a git work tree. Its uncommitted work is already gone. |
+| `SESSION REGISTRY CORRUPTION` | `daemon::cwd_collision` | ≥2 Active records resolve to one worktree path. The observed **precursor** state. |
+| `WORKTREE CORRUPTION GUARD: refusing to decommission` | `session_manager::decommission` | A teardown was refused because the record pointed at a live peer's worktree. Nothing was deleted. |
+| `active session path has failed to canonicalize for N consecutive` | `session_manager::prune` (#1845 F3 streak) | Sustained canonicalize failure on a live path — fired for ~8 h unnoticed before #3715. |
+
+---
+
+## 2. Capture — do this FIRST, before any diagnosis
+
+Run all of it. Do not stop the session, do not resume it, do not run `tm` on
+it, and above all do not let it reach a stop path — a stop triggers
+`write_scrollback`, which overwrites the only surviving pane transcript.
+
+```bash
+# 0) Pick a capture dir OUTSIDE any managed worktree.
+INC=~/worktree-incident-$(date +%Y%m%d-%H%M%S)
+mkdir -p "$INC"
+
+# 1) The session uuid / worktree leaf from the alarm.
+UUID=<session-uuid-from-the-alarm>
+WT=<workspace_path-from-the-alarm>
+
+# 2) macOS unified log — the ONLY place out-of-band `rm -rf` / `git worktree
+#    remove` from an interactive shell leaves any trace. daemon.log will be
+#    silent on a manual deletion; that is the #3715 finding, not an omission.
+log show --last 1h --predicate "eventMessage contains \"$UUID\"" > "$INC/unified-log-uuid.txt"
+log show --last 1h --predicate 'eventMessage contains "worktree"' > "$INC/unified-log-worktree.txt"
+
+# 3) EVERY pane's full scrollback. Not just the suspect pane — the deleter is
+#    typically a DIFFERENT pane than the victim, which is the whole point of
+#    the cross-session guard.
+tmux list-panes -a -F '#{session_name}:#{window_index}.#{pane_index} #{pane_id} #{pane_current_path}' \
+  > "$INC/panes.txt"
+while read -r _ pane _; do
+  tmux capture-pane -p -S - -t "$pane" > "$INC/pane${pane//%/}.txt" 2>/dev/null
+done < <(awk '{print $1, $2, $3}' "$INC/panes.txt")
+
+# 4) Daemon state, before anything mutates it.
+cp ~/.trusty-mpm/daemon.log "$INC/" 2>/dev/null
+cp ~/.trusty-mpm/logs/trusty-mpm.log* "$INC/" 2>/dev/null
+cp "$(trusty-common-data-dir 2>/dev/null || echo ~/.local/share)/trusty-mpm/errors.jsonl" "$INC/" 2>/dev/null
+tm ls > "$INC/tm-ls.txt" 2>&1
+
+# 5) Filesystem evidence. ctime CANNOT be back-dated — it is the strongest
+#    timestamp available and is what dated the third incident to the minute.
+stat "$WT" > "$INC/stat-worktree.txt" 2>&1
+ls -la@ "$WT" >> "$INC/stat-worktree.txt" 2>&1
+
+# 6) Git-side evidence, from the BASE repo (not from inside the worktree —
+#    from inside a stripped worktree git silently answers from the parent).
+BASE=$(dirname "$(dirname "$WT")")
+git -C "$BASE" worktree list > "$INC/worktree-list.txt" 2>&1
+ls -la "$BASE/worktrees/$(basename "$WT")" >> "$INC/worktree-list.txt" 2>&1
+git -C "$BASE" reflog --date=iso > "$INC/base-reflog.txt" 2>&1
+```
+
+---
+
+## 3. Confirm the diagnosis
+
+**Never trust `git status` or `git log` from inside the suspect directory.**
+That is the fail-open at the heart of #3764 item 4: with the `.git` pointer
+gone, discovery walks *up* to the enclosing repo, so `git log` prints plausible
+commits from the parent's stale `main` while `git status` fatals — and a fatal
+renders as `Status: (clean)` in the harness.
+
+The one correct probe (matching `session_manager::worktree_integrity::check`):
+
+```bash
+git -C "$WT" rev-parse --show-toplevel
+```
+
+* prints `$WT` → the worktree is intact; look elsewhere.
+* prints an **ancestor** directory → destroyed (parent clone is non-bare).
+* `fatal: this operation must be run in a work tree` → destroyed (parent clone
+  is bare — this repo's `.base` layout).
+
+`git rev-parse --is-inside-work-tree` is **not** a substitute: it returns
+`true` for a fully destroyed worktree whenever the parent clone is non-bare.
+Verified empirically; see the module doc for the matrix.
+
+---
+
+## 4. Triage
+
+1. **Do not "repair" the directory.** Recreating the root masks the loss —
+   exactly the #3715 behaviour the `write_scrollback` guard was added to stop.
+2. **Check for a cwd collision** (`SESSION REGISTRY CORRUPTION` in the log, or
+   duplicate `workspace_path`s in `tm ls`). If ≥2 Active records share the
+   path, reconcile them (`tm sessions delete <stale-id>`) before touching the
+   filesystem — a decommission of the wrong record is what destroys the tree.
+3. **Recover work, if any survived**, from `$BASE`'s reflog and any
+   `session/<leaf>` branch: `git -C "$BASE" log --all --oneline`.
+4. **Stop the blinded session.** An Active session in a destroyed worktree is
+   still running and still committing into nothing.
+5. **File with the capture attached**, referencing #3715 and #3764.
+
+---
+
+## 5. Why this is a runbook and not an automated hook
+
+Automating the capture on the F3 streak trip was evaluated for #3764 item 3 and
+deliberately **not** wired:
+
+* `log show --last 1h` and a full `tmux capture-pane -S -` across every pane are
+  seconds-to-minutes of blocking I/O. The F3 streak trips **inside the orphan-GC
+  sweep**, on the daemon's async executor, once per ~60 s tick — and it trips
+  repeatedly by construction (that is what a *streak* is). Wiring capture there
+  would stall the sweep on a timer, indefinitely, in exactly the degraded state
+  where the sweep's other duties matter most.
+* The capture must write outside every managed worktree, but the daemon has no
+  incident-scoped location and would be inventing a retention policy, a disk
+  budget, and a redaction pass (pane scrollback contains secrets — the existing
+  `snapshot::REDACT_RE` covers the scrollback path only) to do it safely.
+* The alarms are now ERROR-level and therefore land in `errors.jsonl` /
+  `list_recent_errors` the moment they fire. Detection — the thing that was
+  actually missing for three days — no longer depends on capture.
+
+Revisit if a bounded, redacting, out-of-band capture helper lands; the item-3
+requirement ("at minimum ship the runbook") is satisfied by this document.

--- a/docs/runbooks/worktree-corruption-forensics.md
+++ b/docs/runbooks/worktree-corruption-forensics.md
@@ -21,9 +21,11 @@ these was deliberately escalated.
 
 | Alarm text (grep for this) | Source | Means |
 |---|---|---|
-| `WORKTREE DESTROYED` | `session_manager::worktree_integrity` | An **Active** session's own worktree is no longer a git work tree. Its uncommitted work is already gone. |
+| `WORKTREE DESTROYED` | `session_manager::worktree_integrity` | An **Active** session's worktree is no longer a git work tree **and the directory is empty**. The work is gone. |
+| `WORKTREE LINKAGE LOST` | `session_manager::worktree_integrity` | Same, but the **files are still on disk**. The work is NOT lost — see §4.0 before doing anything. |
+| `worktree-integrity audit is DARK` | `session_manager::worktree_integrity` | Every audited session returned an inconclusive verdict — nothing is being checked. Fix the detector first. |
 | `SESSION REGISTRY CORRUPTION` | `daemon::cwd_collision` | ≥2 Active records resolve to one worktree path. The observed **precursor** state. |
-| `WORKTREE CORRUPTION GUARD: refusing to decommission` | `session_manager::decommission` | A teardown was refused because the record pointed at a live peer's worktree. Nothing was deleted. |
+| `WORKTREE CORRUPTION GUARD: refusing to decommission` | `session_manager::decommission` | A teardown was refused because the record pointed at another live/resumable session's worktree. Nothing was deleted. |
 | `active session path has failed to canonicalize for N consecutive` | `session_manager::prune` (#1845 F3 streak) | Sustained canonicalize failure on a live path — fired for ~8 h unnoticed before #3715. |
 
 ---
@@ -106,6 +108,25 @@ Verified empirically; see the module doc for the matrix.
 
 ## 4. Triage
 
+**4.0 — If the alarm was `WORKTREE LINKAGE LOST`, the work is still there.
+STOP and copy it out first.**
+
+```bash
+cp -a "$WT" "$INC/surviving-worktree"
+```
+
+Only git's linkage is gone; every file remains. This is what a destroyed or
+moved **parent clone** produces — the 07-21 `.base` destruction left ~70
+worktrees in exactly this state with their contents fully intact. Do **not**
+decommission, prune, or "recreate" the session: `decommission` carries no
+uncommitted-work guard, so it would delete the very files that survived.
+Recover by copying aside, then either repairing the parent clone's
+`worktrees/<leaf>` admin entry or re-creating the worktree and copying the files
+back in.
+
+`WORKTREE DESTROYED` is the *other* case — linkage gone **and** the directory
+empty. Only then is the work actually lost, and only then is recreating safe.
+
 1. **Do not "repair" the directory.** Recreating the root masks the loss —
    exactly the #3715 behaviour the `write_scrollback` guard was added to stop.
 2. **Check for a cwd collision** (`SESSION REGISTRY CORRUPTION` in the log, or
@@ -116,7 +137,13 @@ Verified empirically; see the module doc for the matrix.
    `session/<leaf>` branch: `git -C "$BASE" log --all --oneline`.
 4. **Stop the blinded session.** An Active session in a destroyed worktree is
    still running and still committing into nothing.
-5. **File with the capture attached**, referencing #3715 and #3764.
+5. **If a guard refusal is blocking a legitimate teardown**, the release valve
+   is registry reconciliation, not a force flag: `tm ls` to find the contesting
+   record, then `tm sessions delete <owner-id>` if it is stale. That marks it
+   `Deleted` (terminal), which the guard accepts. There is deliberately no
+   `--force` on the decommission path — a flag would be reachable by the same
+   automated callers the guard exists to stop.
+6. **File with the capture attached**, referencing #3715 and #3764.
 
 ---
 


### PR DESCRIPTION
Implements all three scoped items of #3764, plus a fourth evaluated and found sound. **#3715 stays open until this lands.**

Filed P2 after the second occurrence; there has now been a **third** — the same `f443c12d` worktree lost its `.git` pointer, its registration, and its entire tracked source tree on 2026-07-24 22:56:07, and **kept running in that state for three days**. Three occurrences, zero PRs, and no shipped guard that detects or prevents the shape.

Every alarm added here is **ERROR-level**, and that is load-bearing rather than stylistic: the daemon composes `trusty_common::error_capture::bug_capture_layer`, which persists **only** ERROR events to `<data_dir>/trusty-mpm/errors.jsonl` and surfaces them through the `list_recent_errors` MCP tool, `preview_bug_report`, and `tm doctor`. `warn!` reaches none of those. Each of these conditions was previously at WARN — i.e. invisible to every operator-facing surface.

---

## Item 1 — session-identity guard on worktree removal

`workspace_guard::is_safe_to_remove` checked **path containment only** — a condition every sibling session's worktree also satisfies, so it green-lit cross-session deletion by construction. #3649's owner gate closes part of this but only fires when a session self-identifies as `caller`, and **every** daemon-routed remove path passes `caller: None`: the `session_decommission` MCP tool, the sm-stdio control channel, the HTTP routes, the idle reaper, and `dedup`. The hole was the whole daemon surface.

`decommission` now asks the **worktree's own on-disk ownership sentinel** who owns it and refuses with a new `ManagedError::ForeignActiveWorktree` when that owner is a different, still-Active session.

Two design points worth review:
- **Ownership is read from the tree, not from the record.** `known_owner_of` consults `record.worktree_owner` first, which is right for #3649 but exactly wrong here — the incident shape *is* a record whose `workspace_path` points at a peer's tree, so trusting the record would let the impostor name itself owner and launder the corruption.
- **It returns `Err` rather than skipping the removal.** The tombstone path clears `workspace_path`, which would destroy the only remaining evidence of the mis-pointing record.

The guard can only ever **refuse** a deletion, never permit a new one: unknown owner, self-owned, and any non-Active owner all pass through unchanged, so #3649's orphan-GC and #3721's recreation guard are untouched.

## Item 2 — the #1744 cwd collision becomes a corruption alarm

`correlate_session_start` treated ">=2 Active records at one cwd" as an *attribution* nuisance: skip the `claude_session_id`, `warn!` a bare count, carry on. It is not an attribution problem — it describes a state that cannot physically exist, and a 3-way collision on the exact path was the observed precursor hours before the last corruption.

Now an ERROR-level `SESSION REGISTRY CORRUPTION` alarm naming **every** colliding session id (the old warn logged only `n`, which gave an operator nothing to act on). The `match matched.len()` was extracted to a pure, testable `cwd_collision::classify` so the corruption verdict can never quietly fold back into "nothing to do" — which is what it effectively was, since the `n` arm and the `0` arm had identical effect.

## Item 3 — forensic capture runbook

`docs/runbooks/worktree-corruption-forensics.md`: what to capture and in what order, before a stop runs `write_scrollback` and overwrites the only surviving pane transcript. The #1845 F3 streak alarm now names the runbook in-message, and `forensics_runbook_path_exists` pins the path so the pointer cannot rot.

**Automated capture was evaluated and deliberately not wired** (rationale in the runbook's final section): the F3 streak trips inside the orphan-GC sweep, on the async executor, once per ~60s tick, and by construction trips *repeatedly* — wiring seconds-to-minutes of `log show` + full `capture-pane` there would stall the sweep indefinitely in exactly the degraded state where its other duties matter most. It would also need an incident-scoped location, a retention policy, and a redaction pass (pane scrollback contains secrets) to be safe. With the alarms now at ERROR, detection no longer depends on capture.

## Item 4 — destroyed-worktree self-check (the proposed fourth item)

**Verdict: sound, cheap, and implemented — but the proposed probe is not, and I did not ship it as proposed.**

Nothing in the tree asked "is *my* tree still there?", which is why a session ran three days in a stripped worktree. The fail-open is real and I reproduced it: with the `.git` pointer gone, discovery walks up to the enclosing clone, so `git log` prints plausible commits from the parent's stale `main` while `git status` fatals — and a fatal renders as `Status: (clean)`.

`git rev-parse --is-inside-work-tree` returns `false` here **only because `.base` is a bare clone**. That is not layout-independent. Verified empirically both ways:

| parent repo | stripped worktree: `--is-inside-work-tree` | `--show-toplevel` |
|---|---|---|
| bare | `false` -> detected | fatal -> detected |
| **normal** | **`true`** -> **MISSED** | parent dir -> detected |

Shipping the proposed probe alone would have reproduced the exact bug class this issue exists to end — a detector that reports healthy when it is not. The detector therefore compares **`git rev-parse --show-toplevel` against the session's own root**, which catches both layouts. `should_have_flagged_stripped_worktree_under_normal_parent` asserts, in one run, that the naive probe really does say `true` for a destroyed tree and that ours says `Destroyed` anyway.

False-positive modes considered: only `is_session_worktree` paths are audited (local-path/adopted sessions on plain directories are never judged); comparison is canonicalized (macOS `/tmp` <-> `/private/tmp`); a probe that cannot run reports `Unknown`, **never** `Intact`. The audit is read-only — it reports, never repairs, because silently reconstituting a vanished root is the #3715 masking behaviour. `Unknown` is deliberately **not** rolled up at ERROR: an alarm that fires on "git was briefly unavailable" gets muted, and a muted alarm is a silent one.

Runs on the existing orphan-GC tick — no new loop, no new config; the first tick after daemon start doubles as the at-start self-check.

---

## Mutation evidence

Every item was mutation-tested: change reverted, test observed failing, change restored, test observed passing.

| Mutation | Result |
|---|---|
| Item 1 — guard disabled in `decommission` | `decommission_refuses_to_delete_live_peer_worktree` **FAILED** — the impostor's decommission succeeded, record went `Decommissioned`, `workspace_removed=true`; the peer's live tree was destroyed |
| Item 2a — `Collision` arm reverted to `None` (pre-#3764 silent skip) | `classify_two_matches_is_collision` + `classify_three_matches_lists_all_ids` **FAILED** |
| Item 2b — `error!` reverted to `warn!` | `alarm_is_error_level` **FAILED**: `observed levels: [Level(Warn)]` |
| Item 3 — runbook file deleted | `forensics_runbook_path_exists` **FAILED** |
| Item 4 — detector swapped to `--is-inside-work-tree` | `should_have_flagged_stripped_worktree_under_normal_parent` **FAILED**: `got Intact` for a fully destroyed worktree |

## Gate (raw, from a compliant worktree location)

```
cargo check -p trusty-mpm            Finished `dev` profile ... in 10.10s
cargo clippy --all-targets           0 warnings attributable to trusty-mpm
cargo clippy --all-targets -D warn   EXIT=0
cargo fmt --all -- --check           EXIT=0
cargo test -p trusty-mpm             EXIT=0
  test result: ok. 3750 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
scripts/check_line_cap.sh            line-cap: 7 allowlisted, 0 violations — OK.
scripts/check_test_pointers.sh       test-pointers: 0 dangling pointers — OK.
```

28 new tests, all green. `Cargo.lock` untouched.

## Note on `ManagedError`

Adding the `ForeignActiveWorktree` variant pushed `manager.rs` to 501 SLOC. The enum moved to `session_manager/error.rs` and is re-exported, mirroring the #1955 `ManagedTmuxDriver` split that `manager.rs`'s own comment documents. No behaviour change; every `super::manager::ManagedError` import path still resolves.

## Two pre-existing issues found while gating (not fixed here)

1. `tm_hook_pm_guard`'s `pm_guard_allows_worktree_add_under_project_dir_via_subagent_payload` and `pm_guard_claude_mpm_sub_agent_env_still_allows_everything_else` **fail on clean `origin/main`** whenever the checkout lives under `/private/tmp` — they pass a *relative* worktree path that the #3955 guard resolves against cwd. Verified with a control worktree of unmodified `main` at the same location.
2. `telegram::supervisor::tests::healthy_run_resets_transient_backoff` is a timing flake (failed once at 34.9ms, passed 3/3 in isolation).

Closes #3764

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools