### PR TITLE
fix(trusty-mpm): deploy launch/connect/meta-launch agents into a tier --setting-sources loads

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -135,6 +135,24 @@ so a 2.0.0 would signal a break that cannot reach anyone.
 
 ### Fixed
 
+- **`tm launch` and `tm connect` deployed agents to a tier `--setting-sources`
+  excludes, so no tm-deployed agent ever loaded**
+  ([#4203](https://github.com/bobmatnyc/trusty-tools/issues/4203)): both CLI
+  paths built their `FrameworkPaths` with `default()`, which resolves against
+  `dirs::home_dir()` and writes the agent roster into `$HOME/.claude/agents` —
+  the `user` tier. Both then spawned `claude` carrying
+  `--setting-sources project,local`, a list that deliberately excludes `user`
+  (#1269). The deployed tier and the loaded tiers never intersected, so every
+  agent the launch step had just deployed was invisible to the session it was
+  deployed for. Both call sites now use
+  `FrameworkPaths::for_managed_workspace(<harness cwd>)` — the managed worktree
+  for `launch`, the live checkout for `connect` — landing the payload in
+  `<cwd>/.claude/{agents,skills}`, which the `project` and `local` tiers read.
+  This is the same fix the daemon's `spawn_managed_inproject` already carried
+  for the identical defect (#1931); the two CLI paths never received it. A
+  regression test asserts the RELATIONSHIP (deployed tier ∈ the tiers the flag
+  names), not a literal path, so it keeps biting if either side moves.
+
 - **Two wrong instructions corrected in the bundled assets composed into every
   session's prompt.** Both were static text that no project could override, and
   both had demonstrably misrouted live sessions.

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`tm launch`, `tm connect`, and `tm meta launch` deployed agents to a tier
+  `--setting-sources` excludes, so no tm-deployed agent ever loaded**
+  ([#4203](https://github.com/bobmatnyc/trusty-tools/issues/4203)): all three
+  CLI paths built their `FrameworkPaths` with `default()`, which resolves
+  against `dirs::home_dir()` and writes the agent roster into
+  `$HOME/.claude/agents` — the `user` tier. All three then spawned `claude`
+  carrying `--setting-sources project,local`, a list that deliberately excludes
+  `user` (#1269). The deployed tier and the loaded tiers never intersected, so
+  every agent the launch step had just deployed was invisible to the session it
+  was deployed for, and nothing reported it: the deploy genuinely succeeded and
+  the load silently found nothing.
+
+  These paths now deploy through a new `session_launch::prepare_isolated_session`
+  entry point, which resolves the layout itself rather than accepting one from
+  the caller — the harness cwd is the deploy base, so `<cwd>/.claude/{agents,skills}`
+  lands in a tier the `project`/`local` sources read. Removing the parameter
+  removes the defect: there is no longer a wrong `FrameworkPaths` for a call
+  site to pass. This is the same correction the daemon's `spawn_managed_inproject`
+  already carried (#1931); the three CLI paths never received it. `tm session
+  start` is deliberately unchanged — it spawns a bare `claude` with no
+  `--setting-sources`, so it does read the user tier and `default()` is correct
+  there.
+
+  **Operator-visible change:** `tm connect` now writes the agent roster, skills,
+  and output styles into the `.claude/` directory of your **live checkout**
+  rather than `$HOME/.claude/`, so they will show up in `git status` for that
+  repo. The scaffolding paths are added to `.gitignore` automatically (#3427),
+  and existing hand-placed or committed `.claude/` content is never overwritten
+  — unmanaged files are skipped as user-owned, and managed files whose checksum
+  drifted are skipped with a warning.
+
 ---
 ## [1.2.0] — 2026-07-27
 
@@ -134,24 +167,6 @@ so a 2.0.0 would signal a break that cannot reach anyone.
   ordering-dependent behaviour is reproducible.
 
 ### Fixed
-
-- **`tm launch` and `tm connect` deployed agents to a tier `--setting-sources`
-  excludes, so no tm-deployed agent ever loaded**
-  ([#4203](https://github.com/bobmatnyc/trusty-tools/issues/4203)): both CLI
-  paths built their `FrameworkPaths` with `default()`, which resolves against
-  `dirs::home_dir()` and writes the agent roster into `$HOME/.claude/agents` —
-  the `user` tier. Both then spawned `claude` carrying
-  `--setting-sources project,local`, a list that deliberately excludes `user`
-  (#1269). The deployed tier and the loaded tiers never intersected, so every
-  agent the launch step had just deployed was invisible to the session it was
-  deployed for. Both call sites now use
-  `FrameworkPaths::for_managed_workspace(<harness cwd>)` — the managed worktree
-  for `launch`, the live checkout for `connect` — landing the payload in
-  `<cwd>/.claude/{agents,skills}`, which the `project` and `local` tiers read.
-  This is the same fix the daemon's `spawn_managed_inproject` already carried
-  for the identical defect (#1931); the two CLI paths never received it. A
-  regression test asserts the RELATIONSHIP (deployed tier ∈ the tiers the flag
-  names), not a literal path, so it keeps biting if either side moves.
 
 - **Two wrong instructions corrected in the bundled assets composed into every
   session's prompt.** Both were static text that no project could override, and

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -204,12 +204,12 @@ pub(crate) async fn launch(
     // 7c. Deploy the `.claude` framework into the worktree (best-effort).
     //     Non-fatal: a deploy failure never aborts the session — the operator can
     //     run `tm install` / `tm catalog sync` to populate agents manually.
-    //     #4203: the destination is the worktree (the harness cwd, set at step
-    //     12), NOT `$HOME` — see [`session_framework_paths`].
+    //     #4203: deploy through the isolated seam so the roster lands in the
+    //     worktree (the harness cwd, set at step 12) rather than `$HOME` — the
+    //     `claude` spawned at step 13 carries `--setting-sources project,local`
+    //     and would never read a `$HOME/.claude` deploy.
     {
-        let fw = session_framework_paths(&managed_path);
-        match trusty_mpm::core::session_launch::prepare_session_with_repo_url(
-            &fw,
+        match trusty_mpm::core::session_launch::prepare_isolated_session(
             &managed_path,
             Some(&origin_url),
         ) {
@@ -469,10 +469,11 @@ pub(crate) async fn connect(
     //     under `path` — so a repo with no GitHub remote or with uncommitted
     //     changes still launches. Best-effort: a prep failure is logged and
     //     never aborts the connect.
-    //     #4203: the destination is the live checkout (the harness cwd, set at
-    //     step 4), NOT `$HOME` — see [`session_framework_paths`].
-    let fw = session_framework_paths(&path);
-    match trusty_mpm::core::session_launch::prepare_session(&fw, &path) {
+    //     #4203: deploy through the isolated seam so the roster lands in the
+    //     live checkout (the harness cwd, set at step 4) rather than `$HOME` —
+    //     the `claude` spawned at step 5 carries `--setting-sources
+    //     project,local` and would never read a `$HOME/.claude` deploy.
+    match trusty_mpm::core::session_launch::prepare_isolated_session(&path, None) {
         Ok(report) => {
             for err in &report.roster_errors {
                 tracing::error!("roster provisioning gap for {}: {err}", path.display());
@@ -595,33 +596,6 @@ pub(crate) async fn connect(
         g.disarm();
     }
     Ok(())
-}
-
-/// Resolve the [`FrameworkPaths`](trusty_mpm::core::paths::FrameworkPaths) a
-/// CLI-spawned session deploys its `.claude` payload through.
-///
-/// Why (issue #4203): both `launch` and `connect` used
-/// `FrameworkPaths::default()`, which resolves against `dirs::home_dir()` and
-/// therefore deploys the agent roster into `$HOME/.claude/agents` — the `user`
-/// tier. Both then spawn `claude` carrying
-/// [`SETTING_SOURCES_FLAG`](trusty_mpm::core::model_inject::SETTING_SOURCES_FLAG)
-/// (`--setting-sources project,local`), which EXCLUDES `user`. The deployed
-/// tier and the loaded tiers did not intersect, so no tm-deployed agent was
-/// ever visible to either CLI session. This is the same defect the daemon's
-/// `spawn_managed_inproject` already fixed for its own in-project spawn
-/// (issue #1931, `daemon/managed_routes/lifecycle.rs`), applied to the two CLI
-/// paths that never received the equivalent change.
-/// What: `FrameworkPaths::for_managed_workspace(harness_cwd)` — deploy
-/// DESTINATIONS become `<harness_cwd>/.claude/{agents,skills}` (read by the
-/// `project`/`local` tiers) while the framework SOURCE paths keep resolving
-/// from the home-relative install root, exactly as #1931 guarantees. Callers
-/// must pass the cwd the tmux pane is rooted at: the managed worktree for
-/// `launch`, the live checkout for `connect`.
-/// Test: `launch_and_connect_deploy_into_a_tier_setting_sources_loads`.
-pub(crate) fn session_framework_paths(
-    harness_cwd: &std::path::Path,
-) -> trusty_mpm::core::paths::FrameworkPaths {
-    trusty_mpm::core::paths::FrameworkPaths::for_managed_workspace(harness_cwd)
 }
 
 /// Compose the `claude` invocation `connect` sends to a freshly-created tmux pane.

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -204,8 +204,10 @@ pub(crate) async fn launch(
     // 7c. Deploy the `.claude` framework into the worktree (best-effort).
     //     Non-fatal: a deploy failure never aborts the session — the operator can
     //     run `tm install` / `tm catalog sync` to populate agents manually.
+    //     #4203: the destination is the worktree (the harness cwd, set at step
+    //     12), NOT `$HOME` — see [`session_framework_paths`].
     {
-        let fw = trusty_mpm::core::paths::FrameworkPaths::default();
+        let fw = session_framework_paths(&managed_path);
         match trusty_mpm::core::session_launch::prepare_session_with_repo_url(
             &fw,
             &managed_path,
@@ -467,7 +469,9 @@ pub(crate) async fn connect(
     //     under `path` — so a repo with no GitHub remote or with uncommitted
     //     changes still launches. Best-effort: a prep failure is logged and
     //     never aborts the connect.
-    let fw = trusty_mpm::core::paths::FrameworkPaths::default();
+    //     #4203: the destination is the live checkout (the harness cwd, set at
+    //     step 4), NOT `$HOME` — see [`session_framework_paths`].
+    let fw = session_framework_paths(&path);
     match trusty_mpm::core::session_launch::prepare_session(&fw, &path) {
         Ok(report) => {
             for err in &report.roster_errors {
@@ -591,6 +595,33 @@ pub(crate) async fn connect(
         g.disarm();
     }
     Ok(())
+}
+
+/// Resolve the [`FrameworkPaths`](trusty_mpm::core::paths::FrameworkPaths) a
+/// CLI-spawned session deploys its `.claude` payload through.
+///
+/// Why (issue #4203): both `launch` and `connect` used
+/// `FrameworkPaths::default()`, which resolves against `dirs::home_dir()` and
+/// therefore deploys the agent roster into `$HOME/.claude/agents` — the `user`
+/// tier. Both then spawn `claude` carrying
+/// [`SETTING_SOURCES_FLAG`](trusty_mpm::core::model_inject::SETTING_SOURCES_FLAG)
+/// (`--setting-sources project,local`), which EXCLUDES `user`. The deployed
+/// tier and the loaded tiers did not intersect, so no tm-deployed agent was
+/// ever visible to either CLI session. This is the same defect the daemon's
+/// `spawn_managed_inproject` already fixed for its own in-project spawn
+/// (issue #1931, `daemon/managed_routes/lifecycle.rs`), applied to the two CLI
+/// paths that never received the equivalent change.
+/// What: `FrameworkPaths::for_managed_workspace(harness_cwd)` — deploy
+/// DESTINATIONS become `<harness_cwd>/.claude/{agents,skills}` (read by the
+/// `project`/`local` tiers) while the framework SOURCE paths keep resolving
+/// from the home-relative install root, exactly as #1931 guarantees. Callers
+/// must pass the cwd the tmux pane is rooted at: the managed worktree for
+/// `launch`, the live checkout for `connect`.
+/// Test: `launch_and_connect_deploy_into_a_tier_setting_sources_loads`.
+pub(crate) fn session_framework_paths(
+    harness_cwd: &std::path::Path,
+) -> trusty_mpm::core::paths::FrameworkPaths {
+    trusty_mpm::core::paths::FrameworkPaths::for_managed_workspace(harness_cwd)
 }
 
 /// Compose the `claude` invocation `connect` sends to a freshly-created tmux pane.

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
@@ -3,7 +3,7 @@
 //!
 //! Why: the re-scoped POC drives a REAL `claude` CLI session through trusty-mpm's
 //! existing machinery rather than an in-process trusty-code orchestrator. This
-//! module owns the launch ritual — `prepare_session` (deploy agents/skills/
+//! module owns the launch ritual — `prepare_isolated_session` (deploy agents/skills/
 //! CLAUDE.md/PM-prompt/MCP) → `SessionManager::create_with_id` (tmux host rooted
 //! at the project dir) → `ClaudeCodeAdapter::spawn` (launch `claude`) → send the
 //! task into the pane — and the time-bounded poll that waits for the session to
@@ -25,8 +25,7 @@ use std::time::{Duration, Instant};
 use anyhow::{Context as _, Result};
 use tracing::{info, warn};
 
-use trusty_mpm::core::paths::FrameworkPaths;
-use trusty_mpm::core::session_launch::prepare_session;
+use trusty_mpm::core::session_launch::prepare_isolated_session;
 use trusty_mpm::runtime::{RuntimeKind, build_adapter};
 use trusty_mpm::session_manager::real_tmux::RealTmuxDriver;
 use trusty_mpm::session_manager::{ManagedSessionId, ManagedTmuxDriver, SessionManager};
@@ -155,10 +154,10 @@ pub(crate) async fn new_session_manager(state_dir: &Path) -> Result<SessionManag
 ///
 /// Why: this is the WI-A launch path (#1049) plus the WI-B poll (#1051), wired
 /// in-process with no daemon. It reuses the EXACT machinery a daemon launch uses
-/// ([`prepare_session`], [`SessionManager::create_with_id`], [`build_adapter`] →
+/// ([`prepare_isolated_session`], [`SessionManager::create_with_id`], [`build_adapter`] →
 /// `ClaudeCodeAdapter::spawn`) so the POC exercises the production path, not a
 /// parallel one.
-/// What: in order — (1) `prepare_session` deploys agents/skills/CLAUDE.md/PM
+/// What: in order — (1) `prepare_isolated_session` deploys agents/skills/CLAUDE.md/PM
 /// prompt/MCP into `project_dir` (a prep failure is non-fatal: logged, the launch
 /// proceeds); (2) creates a tmux session rooted at `project_dir` via
 /// `create_with_id` (cwd = project, so NO git clone happens — the `--no-provision`
@@ -180,8 +179,11 @@ pub(crate) async fn launch_and_wait(
 ) -> Result<LaunchReport> {
     // (1) Deploy the custom instructions. Non-fatal: a missing framework only
     // means the session launches without trusty-mpm agents/skills.
-    let fw = FrameworkPaths::default();
-    match prepare_session(&fw, project_dir) {
+    // #4203: deploy through the isolated seam — the pane created at (2) is
+    // rooted at `project_dir` and `ClaudeCodeAdapter::spawn` always appends
+    // `--setting-sources project,local` (`runtime/claude_code.rs`), so a
+    // `$HOME/.claude` deploy would never be read by the session it prepares.
+    match prepare_isolated_session(project_dir, None) {
         Ok(report) => info!(
             agents = report.deploy.deployed.len(),
             project = %project_dir.display(),
@@ -238,7 +240,7 @@ pub(crate) async fn launch_and_wait(
     info!(tmux = %record.tmux_name, "meta run: claude runtime spawned");
 
     // (4) Deliver the task to the session. `claude` reads the PM prompt from the
-    // `--append-system-prompt-file` set by `prepare_session`; the concrete task
+    // `--append-system-prompt-file` set by `prepare_isolated_session`; the concrete task
     // is typed into the pane through the shared readiness-gated injection seam
     // (`SessionManager::inject_task_when_ready`, #1903/#1299) — which polls for
     // the runtime to be ready instead of the blind fixed sleep this prototype

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -1680,51 +1680,63 @@ async fn guided_fallback_redirect_success_worktree_not_live_checkout() {
     );
 }
 
-/// Issue #4203: the tier `launch`/`connect` deploy agents INTO must be one of
-/// the tiers the spawn's `--setting-sources` flag actually loads.
+/// Issue #4203: every CLI path whose spawn carries `--setting-sources
+/// project,local` must deploy through `prepare_isolated_session`, never through
+/// a self-resolved `FrameworkPaths::default()`.
 ///
-/// Before the fix both paths built `FrameworkPaths::default()` (deploying to
-/// `$HOME/.claude/agents`, the `user` tier) and then spawned `claude` with
-/// `--setting-sources project,local` — a list that excludes `user` — so no
-/// tm-deployed agent was ever loaded by either CLI session. The assertion is on
-/// the RELATIONSHIP (deployed tier ∈ loaded tiers), not on a literal path, so it
-/// keeps biting if either the deploy destination or the flag's tier list moves.
+/// Why a SOURCE-TEXT guard rather than a behavioural one: `launch()`,
+/// `connect()`, and `launch_and_wait()` are async functions that create tmux
+/// sessions, register with the daemon over HTTP, and then block on
+/// `attach-session`, so none of them is reachable from a unit test. A test that
+/// exercises the deploy layout alone proves the layout is right while staying
+/// completely silent if a call site stops using it — which is exactly how the
+/// first version of this guard shipped green with the bug reintroduced in both
+/// call sites. Binding the CALL SITES is the whole point, so the guard reads the
+/// call sites. Source-text guards are the established idiom here
+/// (`scripts/check_line_cap.sh` and the tracked-file CI guards are the same
+/// shape).
+///
+/// What: asserts neither file constructs `FrameworkPaths::default()`, and that
+/// each still routes through the isolated seam the expected number of times.
+/// The counts are deliberately exact — a call site deleted or a fourth one added
+/// without thought fails here and forces the author to confirm its spawn posture.
 #[test]
-fn launch_and_connect_deploy_into_a_tier_setting_sources_loads() {
-    use trusty_mpm::core::model_inject::{
-        SETTING_SOURCES_FLAG, setting_source_tiers, settings_tier_of,
-    };
+fn launch_paths_prepare_through_the_isolated_seam() {
+    // `include_str!` is relative to THIS file (`src/bin/tm/`).
+    const LAUNCH_SRC: &str = include_str!("commands/launch.rs");
+    const META_LAUNCH_SRC: &str = include_str!("commands/meta/launch.rs");
 
-    // The cwd the tmux pane is rooted at, which is also the cwd `claude` is
-    // spawned with: the managed worktree for `launch` (step 12), the live
-    // checkout for `connect` (step 4). Both go through the same seam, so one
-    // synthetic cwd exercises the invariant for both paths.
-    let harness_cwd = std::path::Path::new("/work/some-checkout");
-    let fw = crate::commands::launch::session_framework_paths(harness_cwd);
+    for (name, src, expected_calls) in [
+        ("commands/launch.rs", LAUNCH_SRC, 2usize),
+        ("commands/meta/launch.rs", META_LAUNCH_SRC, 1usize),
+    ] {
+        assert!(
+            !src.contains("FrameworkPaths::default()"),
+            "{name} spawns `claude` with `{}`, which excludes the `user` tier \
+             `FrameworkPaths::default()` deploys into — deploy via \
+             `session_launch::prepare_isolated_session` instead (issue #4203)",
+            trusty_mpm::core::model_inject::SETTING_SOURCES_FLAG
+        );
+        assert_eq!(
+            src.matches("prepare_isolated_session(").count(),
+            expected_calls,
+            "{name} must deploy through `prepare_isolated_session` exactly \
+             {expected_calls}x (issue #4203); if a call site was added or removed, \
+             confirm its spawn's `--setting-sources` posture and update this count"
+        );
+    }
 
-    let tiers = setting_source_tiers();
+    // `commands/session/start.rs` is deliberately NOT in the list above: it
+    // spawns a bare `claude {PERMISSION_MODE_FLAG}` with no `--setting-sources`,
+    // so Claude Code reads its default tiers INCLUDING `user` and
+    // `FrameworkPaths::default()` is correct there. Pin that premise — if
+    // `start.rs` ever gains the flag, it acquires this defect and this
+    // assertion is what says so.
+    const START_SRC: &str = include_str!("commands/session/start.rs");
     assert!(
-        !tiers.is_empty(),
-        "SETTING_SOURCES_FLAG ({SETTING_SOURCES_FLAG}) must name at least one tier; \
-         an empty list would make this invariant vacuous"
-    );
-
-    let deployed_tier = settings_tier_of(&fw.claude_home_dir(), harness_cwd);
-    assert!(
-        tiers.contains(&deployed_tier),
-        "agents deploy into the `{deployed_tier}` tier ({}) but the spawned session carries \
-         `{SETTING_SOURCES_FLAG}`, loading only {tiers:?} — no tm-deployed agent would be \
-         visible to the session (issue #4203)",
-        fw.claude_agents_dir().display()
-    );
-
-    // The tier name is only meaningful if the destination really is under the
-    // harness cwd — guards against `settings_tier_of` being satisfied by a path
-    // that merely compares equal for an unrelated reason.
-    assert!(
-        fw.claude_agents_dir().starts_with(harness_cwd),
-        "deploy destination {} must lie under the harness cwd {}",
-        fw.claude_agents_dir().display(),
-        harness_cwd.display()
+        !START_SRC.contains("SETTING_SOURCES_FLAG"),
+        "commands/session/start.rs now carries a `--setting-sources` flag, so its \
+         `FrameworkPaths::default()` deploy has become the #4203 defect — route it \
+         through `prepare_isolated_session` and add it to the list above"
     );
 }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -1679,3 +1679,52 @@ async fn guided_fallback_redirect_success_worktree_not_live_checkout() {
          proving launch(Some(worktree)) was invoked rather than launch(None)"
     );
 }
+
+/// Issue #4203: the tier `launch`/`connect` deploy agents INTO must be one of
+/// the tiers the spawn's `--setting-sources` flag actually loads.
+///
+/// Before the fix both paths built `FrameworkPaths::default()` (deploying to
+/// `$HOME/.claude/agents`, the `user` tier) and then spawned `claude` with
+/// `--setting-sources project,local` — a list that excludes `user` — so no
+/// tm-deployed agent was ever loaded by either CLI session. The assertion is on
+/// the RELATIONSHIP (deployed tier ∈ loaded tiers), not on a literal path, so it
+/// keeps biting if either the deploy destination or the flag's tier list moves.
+#[test]
+fn launch_and_connect_deploy_into_a_tier_setting_sources_loads() {
+    use trusty_mpm::core::model_inject::{
+        SETTING_SOURCES_FLAG, setting_source_tiers, settings_tier_of,
+    };
+
+    // The cwd the tmux pane is rooted at, which is also the cwd `claude` is
+    // spawned with: the managed worktree for `launch` (step 12), the live
+    // checkout for `connect` (step 4). Both go through the same seam, so one
+    // synthetic cwd exercises the invariant for both paths.
+    let harness_cwd = std::path::Path::new("/work/some-checkout");
+    let fw = crate::commands::launch::session_framework_paths(harness_cwd);
+
+    let tiers = setting_source_tiers();
+    assert!(
+        !tiers.is_empty(),
+        "SETTING_SOURCES_FLAG ({SETTING_SOURCES_FLAG}) must name at least one tier; \
+         an empty list would make this invariant vacuous"
+    );
+
+    let deployed_tier = settings_tier_of(&fw.claude_home_dir(), harness_cwd);
+    assert!(
+        tiers.contains(&deployed_tier),
+        "agents deploy into the `{deployed_tier}` tier ({}) but the spawned session carries \
+         `{SETTING_SOURCES_FLAG}`, loading only {tiers:?} — no tm-deployed agent would be \
+         visible to the session (issue #4203)",
+        fw.claude_agents_dir().display()
+    );
+
+    // The tier name is only meaningful if the destination really is under the
+    // harness cwd — guards against `settings_tier_of` being satisfied by a path
+    // that merely compares equal for an unrelated reason.
+    assert!(
+        fw.claude_agents_dir().starts_with(harness_cwd),
+        "deploy destination {} must lie under the harness cwd {}",
+        fw.claude_agents_dir().display(),
+        harness_cwd.display()
+    );
+}

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -69,6 +69,45 @@ pub fn resolve_pm_model(config: &MpmConfig, explicit: Option<&str>) -> String {
 /// Test: `claude_command_includes_setting_sources`.
 pub const SETTING_SOURCES_FLAG: &str = "--setting-sources project,local";
 
+/// The settings tiers [`SETTING_SOURCES_FLAG`] actually enumerates.
+///
+/// Why (issue #4203): a deploy step that writes agents into a tier this list
+/// does NOT name is a silent no-op — Claude Code never loads them, and nothing
+/// reports an error. Parsing the flag instead of hard-coding
+/// `["project", "local"]` keeps that invariant honest if the flag's value ever
+/// changes: the tier check and the spawned command can never drift apart.
+/// What: splits [`SETTING_SOURCES_FLAG`] at its first space and then the
+/// comma-separated tier list, trimming each name.
+/// Test: `setting_source_tiers_parses_the_flag`.
+pub fn setting_source_tiers() -> Vec<&'static str> {
+    SETTING_SOURCES_FLAG
+        .split_once(' ')
+        .map(|(_, list)| list.split(',').map(str::trim).collect())
+        .unwrap_or_default()
+}
+
+/// Name the Claude Code settings tier a `.claude/` deploy destination lands in,
+/// relative to the cwd the harness is spawned with.
+///
+/// Why (issue #4203): `FrameworkPaths::default()` deploys agents into
+/// `$HOME/.claude` — the `user` tier — while every trusty-mpm spawn carries
+/// [`SETTING_SOURCES_FLAG`], which excludes `user`. Deploy and load never
+/// intersect. Naming the tier turns that mismatch into something a test can
+/// assert on directly, rather than comparing hard-coded path strings that would
+/// both pass vacuously if either side moved.
+/// What: `"project"` when `claude_home` IS the harness cwd (the payload lands
+/// in `<cwd>/.claude`, which both the `project` and `local` tiers read);
+/// `"user"` otherwise.
+/// Test: `settings_tier_of_names_project_for_the_harness_cwd`,
+/// `settings_tier_of_names_user_for_anything_else`.
+pub fn settings_tier_of(claude_home: &Path, harness_cwd: &Path) -> &'static str {
+    if claude_home == harness_cwd {
+        "project"
+    } else {
+        "user"
+    }
+}
+
 /// The permission-mode flag every trusty-mpm-spawned `claude` carries.
 ///
 /// Why: tm runs Claude Code in unattended orchestration mode; `--dangerously-skip-permissions`
@@ -252,5 +291,34 @@ mod tests {
         // Config per-agent override (haiku) wins over frontmatter (sonnet).
         let cmd = build_agent_command(&cfg, &agent, None, None);
         assert_eq!(cmd, format!("claude --model claude-haiku-4-5 {FLAGS}"));
+    }
+
+    #[test]
+    fn setting_source_tiers_parses_the_flag() {
+        // Derived from the flag itself, never hard-coded — the tier check and
+        // the spawned command must not be able to drift apart (issue #4203).
+        assert_eq!(setting_source_tiers(), vec!["project", "local"]);
+        assert!(
+            !setting_source_tiers().contains(&"user"),
+            "the `user` tier is deliberately excluded (issue #1269); a deploy \
+             landing there is invisible to the session"
+        );
+    }
+
+    #[test]
+    fn settings_tier_of_names_project_for_the_harness_cwd() {
+        // `<cwd>/.claude` is read by the project (and local) tiers.
+        let cwd = Path::new("/work/checkout");
+        assert_eq!(settings_tier_of(cwd, cwd), "project");
+    }
+
+    #[test]
+    fn settings_tier_of_names_user_for_anything_else() {
+        // What `FrameworkPaths::default()` produced: `$HOME/.claude`, a tier
+        // `--setting-sources project,local` never loads (issue #4203).
+        assert_eq!(
+            settings_tier_of(Path::new("/Users/someone"), Path::new("/work/checkout")),
+            "user"
+        );
     }
 }

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -350,6 +350,55 @@ pub fn prepare_session_with_repo_url(
     prepare_session_inner(fw, project_dir, None, native, repo_url)
 }
 
+/// The deploy layout for a session whose harness is spawned with
+/// [`SETTING_SOURCES_FLAG`](crate::core::model_inject::SETTING_SOURCES_FLAG).
+///
+/// Why (issue #4203): `--setting-sources project,local` makes Claude Code read
+/// ONLY the project and local tiers; the `user` tier (`$HOME/.claude`) is
+/// excluded deliberately (#1269). Deploying such a session's roster through
+/// `FrameworkPaths::default()` therefore writes it somewhere that session will
+/// never look — and nothing reports it, because the deploy genuinely succeeds
+/// and the load silently finds nothing. Naming the correct layout ONCE, here,
+/// is what lets every isolated caller share it instead of each re-deriving it
+/// (and three of them getting it wrong independently).
+/// What: `FrameworkPaths::for_managed_workspace(project_dir)` — the deploy
+/// DESTINATION becomes `<project_dir>/.claude/{agents,skills}`, which the
+/// `project` and `local` tiers read, while every framework SOURCE path still
+/// resolves from the home-relative install root (#1931).
+/// Test: `isolated_layout_deploys_into_a_tier_the_spawn_reads`,
+/// `isolated_layout_keeps_framework_source_at_the_install_root`.
+pub(crate) fn isolated_framework_paths(project_dir: &Path) -> FrameworkPaths {
+    FrameworkPaths::for_managed_workspace(project_dir)
+}
+
+/// Prepare a session whose harness will be spawned with
+/// [`SETTING_SOURCES_FLAG`](crate::core::model_inject::SETTING_SOURCES_FLAG).
+///
+/// Why (issue #4203): `tm launch`, `tm connect`, and `tm meta launch` each
+/// built their own `FrameworkPaths::default()` and each therefore deployed the
+/// agent roster into the one tier their own spawn flag excludes — three
+/// independent instances of the same defect, because each call site was free to
+/// resolve the layout itself. This entry point REMOVES that degree of freedom
+/// rather than checking it after the fact: an isolated caller supplies no
+/// `FrameworkPaths` at all, so there is no wrong value left to pass.
+/// Callers whose spawn does NOT carry the flag must keep using
+/// [`prepare_session`] with their own `fw` — notably `tm session start`, which
+/// spawns a bare `claude` (`commands/session/start.rs`) and so genuinely does
+/// read the user tier; pointing it here would be a regression, not a fix.
+/// What: resolves [`isolated_framework_paths`] for `project_dir` (the cwd the
+/// harness is spawned in) and delegates to [`prepare_session_with_repo_url`],
+/// which is exactly [`prepare_session`] when `repo_url` is `None`.
+/// Test: `isolated_layout_deploys_into_a_tier_the_spawn_reads`;
+/// `launch_paths_prepare_through_the_isolated_seam` (tm binary) binds the call
+/// sites to it.
+pub fn prepare_isolated_session(
+    project_dir: &Path,
+    repo_url: Option<&str>,
+) -> Result<PrepReport, PrepError> {
+    let fw = isolated_framework_paths(project_dir);
+    prepare_session_with_repo_url(&fw, project_dir, repo_url)
+}
+
 /// Defensively (re)write the `tm statusline` config for an EXISTING session
 /// workspace, without re-running the full preparation pipeline.
 ///
@@ -900,6 +949,17 @@ fn prepare_session_inner(
     // `fw.claude_home_dir()` (issue #1860) rather than `dirs::home_dir()`
     // directly so isolated `FrameworkPaths::under(tempdir)` callers (tests)
     // stay confined to the temp dir instead of leaking into the real `$HOME`.
+    //
+    // NOTE (#4203): "home tier" describes only the callers that pass a
+    // home-rooted `fw` — `tm session start`, `tm run`/standalone, `tm repair`.
+    // For an `isolated_framework_paths` caller (`tm launch`, `tm connect`,
+    // `tm meta launch`) and for the daemon's `for_managed_workspace` spawn
+    // (#1931), `fw.claude_home_dir()` IS `project_dir`, so this call and the
+    // project-tier one below write the same bytes to the same place — harmless
+    // and idempotent, but it means those commands do NOT refresh
+    // `$HOME/.claude/output-styles/`. Refreshing the real home tier is owned by
+    // `tm install` and `tm catalog apply`, which still resolve
+    // `FrameworkPaths::default()`.
     let output_style = match deploy_output_style(&fw.claude_home_dir()) {
         Ok(path) => Some(path),
         Err(err) => {

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -2213,3 +2213,90 @@ fn resolve_statusline_binary_with_falls_back_to_bare_name() {
         "must degrade to the bare literal when both sources fail"
     );
 }
+
+// ── Issue #4203: the isolated deploy layout must land in a tier the spawn reads ──
+
+/// Why (#4203): `tm launch`, `tm connect`, and `tm meta launch` all spawn a
+/// harness carrying `--setting-sources project,local` and then deploy the agent
+/// roster. If the deploy destination is not in a tier that flag names, the
+/// roster is invisible to the session it was deployed for — and nothing errors,
+/// because the deploy itself succeeds. This asserts the RELATIONSHIP between the
+/// two, with both sides derived from production code, so it keeps biting if
+/// either moves. `isolated_framework_paths` is the single layout every isolated
+/// caller now shares, so this one test covers all three CLI paths at once.
+#[test]
+fn isolated_layout_deploys_into_a_tier_the_spawn_reads() {
+    // Derive the tier list from the flag itself — never hard-coded, so the
+    // check and the spawned command cannot drift apart.
+    let (flag, tier_list) = crate::core::model_inject::SETTING_SOURCES_FLAG
+        .split_once(' ')
+        .expect("SETTING_SOURCES_FLAG must be `--setting-sources <tiers>`");
+    assert_eq!(flag, "--setting-sources");
+    let tiers: Vec<&str> = tier_list.split(',').map(str::trim).collect();
+    assert!(
+        !tiers.is_empty() && !tiers.contains(&"user"),
+        "this invariant is only meaningful while the flag names tiers and excludes \
+         `user` (#1269); got {tiers:?}"
+    );
+    assert!(
+        tiers.contains(&"project"),
+        "the isolated deploy targets the project tier, so the flag must name it; \
+         got {tiers:?}"
+    );
+
+    // `project_dir` is the cwd the harness is spawned in: the managed worktree
+    // for `launch`, the live checkout for `connect`, the project dir for
+    // `meta launch`.
+    let project_dir = std::path::Path::new("/work/some-checkout");
+    let fw = isolated_framework_paths(project_dir);
+
+    // `<cwd>/.claude` is exactly what the `project` (and `local`) tiers read.
+    assert_eq!(
+        fw.claude_home_dir(),
+        project_dir,
+        "the deploy base must BE the harness cwd — anything else is the `user`-tier \
+         mismatch of #4203"
+    );
+    assert_eq!(
+        fw.claude_agents_dir(),
+        project_dir.join(".claude").join("agents"),
+        "agents must land under the harness cwd, not $HOME"
+    );
+    assert_eq!(
+        fw.claude_skills_dir(),
+        project_dir.join(".claude").join("skills"),
+        "skills must land under the harness cwd, not $HOME"
+    );
+}
+
+/// Why (#1931, restated for #4203): only the deploy DESTINATION moves
+/// workspace-local. If the framework SOURCE paths moved with it, the isolated
+/// seam would deploy from an empty `<workspace>/.trusty-mpm` and every session
+/// would come up with a zero-agent roster — a worse failure than the one #4203
+/// fixes, and equally silent.
+///
+/// Why serial: reads `FrameworkPaths::default()`, which resolves
+/// `dirs::home_dir()`; serialized against the other `HOME`-redirecting tests in
+/// this binary (the #2461 sweep).
+#[test]
+#[serial_test::serial]
+fn isolated_layout_keeps_framework_source_at_the_install_root() {
+    let project_dir = std::path::Path::new("/work/some-checkout");
+    let fw = isolated_framework_paths(project_dir);
+
+    assert_eq!(
+        fw.root,
+        FrameworkPaths::default().root,
+        "the framework install root must NOT move workspace-local"
+    );
+    assert!(
+        !fw.agent_source_dir().starts_with(project_dir),
+        "agent SOURCE must never resolve inside the deploy destination; got {}",
+        fw.agent_source_dir().display()
+    );
+    assert!(
+        !fw.skill_source_dir().starts_with(project_dir),
+        "skill SOURCE must never resolve inside the deploy destination; got {}",
+        fw.skill_source_dir().display()
+    );
+}


### PR DESCRIPTION
## The defect

`tm launch` and `tm connect` deployed their agent roster into a settings tier the session they spawn does not read, so **no tm-deployed agent was ever loaded on either CLI path**.

Each link verified against `origin/main` before changing anything:

| Link | Evidence |
|---|---|
| Both call sites pass `FrameworkPaths::default()` | `launch.rs:208` (in-project worktree spawn), `launch.rs:470` (`connect`) |
| `default()` resolves to the USER tier | `paths.rs:108-111` resolves against `dirs::home_dir()`; `claude_agents_dir()` is `<base>/.claude/agents` per `claude_agents_dir_is_dotclaude_agents` (`paths.rs:790`) |
| The deploy really targets `fw`, not the project dir | `session_launch/mod.rs:508` — `deploy_agents_filtered(&plan.agent_source, &fw.claude_agents_dir(), …)` |
| `SETTING_SOURCES_FLAG` reaches the spawn on **both** paths | `launch` → `launch.rs:322` `build_claude_command(...)`; `connect` → `connect_claude_cmd` → `build_claude_command`. `build_claude_command` (`model_inject.rs:148-152`) *always* appends the flag — it is not conditional |

The deployed tier (`user`) and the enumerated setting sources (`project,local`) do not intersect. The `user` tier is excluded deliberately (#1269), so the flag is correct and the deploy destination is the bug.

## The fix

Both call sites now route through a new `session_framework_paths` seam backed by `FrameworkPaths::for_managed_workspace(<harness cwd>)` — the managed worktree for `launch`, the live checkout for `connect`. The payload lands in `<cwd>/.claude/{agents,skills}`, which the `project` and `local` tiers read. Deploy DESTINATIONS move workspace-local while the framework SOURCE paths keep resolving from the home-relative install root.

This is the established pattern, not a new one: the daemon's `spawn_managed_inproject` already fixed this exact bug for its own in-project spawn (`lifecycle.rs:963`, citing #1931). The two CLI paths never received the equivalent change.

## Regression test

`launch_and_connect_deploy_into_a_tier_setting_sources_loads` (`tests_behavior_b_tests.rs`).

It asserts the **relationship** — the deployed tier must be an element of the tiers the flag names — not a hardcoded path string that would pass vacuously if either side changed. Both inputs are derived from production code: the tier list is parsed out of `SETTING_SOURCES_FLAG` itself (`setting_source_tiers()`), and the destination comes from the same `session_framework_paths` seam both commands call. Neither `#[ignore]` nor any cfg-gate.

Verified failing against the pre-fix behavior by reverting only the seam's body to `FrameworkPaths::default()`:

```
test tests_behavior_b::launch_and_connect_deploy_into_a_tier_setting_sources_loads ... FAILED

agents deploy into the `user` tier (/Users/masa/.claude/agents) but the spawned session
carries `--setting-sources project,local`, loading only ["project", "local"] — no
tm-deployed agent would be visible to the session (issue #4203)

test result: FAILED. 0 passed; 1 failed; 0 ignored
```

Three supporting unit tests cover the new pure helpers: `setting_source_tiers_parses_the_flag`, `settings_tier_of_names_project_for_the_harness_cwd`, `settings_tier_of_names_user_for_anything_else`.

## Gate

Full workspace suite (no `--lib`), matching CI's own exclusion list for the three Tauri GUI crates that need a prebuilt frontend:

```
cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
  → exit 0 — 19706 passed; 0 failed; 132 ignored across 194 test binaries

cargo clippy --workspace --all-targets --exclude <same three> -- -D warnings  → exit 0
cargo fmt --check                                                             → exit 0
scripts/check_line_cap.sh   → line-cap: 7 allowlisted, 0 violations — OK.
```

All four new tests confirmed present as `... ok` in the run, not silently skipped. No files under `assets/agents/` are touched, so `check_agent_assets.sh` is not implicated.

Closes #4203

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools