### PR TITLE
fix(trusty-mpm): stop two paths writing into a destroyed worktree (#4204)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -40,6 +40,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   — unmanaged files are skipped as user-owned, and managed files whose checksum
   drifted are skipped with a warning.
 
+- **Two paths no longer write into a destroyed worktree**
+  ([#4204](https://github.com/bobmatnyc/trusty-tools/issues/4204)):
+  `tm install --reset-agents --reset-agents-workspaces` and the bare-`tm`
+  in-place relaunch both gated on `workspace_path.is_dir()` alone, which a
+  gutted worktree — `.git` and source tree stripped, directory node surviving —
+  passes. The sweep recomposed 45 agent files into such a husk and the relaunch
+  exec'd `claude` into it. Both now share one predicate,
+  `core::workspace_liveness::workspace_liveness`, which skips ONLY on positive
+  evidence of death: it accepts `.git` as a FILE (the `gitdir:` pointer every
+  linked worktree carries, so no legitimate managed workspace is refused),
+  requires a `.git` only where one is owed (a tm-provisioned workspace or a
+  `.worktrees/<id>` path), and — at EVERY stat it performs, including the
+  initial existence check — reports a filesystem it could not interrogate as
+  `Indeterminate`, explicitly not dead, so a permission failure, a symlink
+  loop, or a stalled network mount can never silently stop servicing a live
+  workspace. A gutted workspace, and a session record whose workspace has
+  vanished, are both now reported to the operator with a skip reason rather
+  than dropped silently.
+
 ---
 ## [1.2.0] — 2026-07-27
 
@@ -167,23 +186,6 @@ so a 2.0.0 would signal a break that cannot reach anyone.
   ordering-dependent behaviour is reproducible.
 
 ### Fixed
-
-- **Two paths no longer write into a destroyed worktree**
-  ([#4204](https://github.com/bobmatnyc/trusty-tools/issues/4204)):
-  `tm install --reset-agents --reset-agents-workspaces` and the bare-`tm`
-  in-place relaunch both gated on `workspace_path.is_dir()` alone, which a
-  gutted worktree — `.git` and source tree stripped, directory node surviving —
-  passes. The sweep recomposed 45 agent files into such a husk and the relaunch
-  exec'd `claude` into it. Both now share one predicate,
-  `core::workspace_liveness::workspace_liveness`, which skips ONLY on positive
-  evidence of death: it accepts `.git` as a FILE (the `gitdir:` pointer every
-  linked worktree carries, so no legitimate managed workspace is refused),
-  requires a `.git` only where one is owed (a tm-provisioned workspace or a
-  `.worktrees/<id>` path), and reports an unreadable filesystem as
-  `Indeterminate` — explicitly not dead — so a permission or network-mount
-  failure can never silently stop servicing a live workspace. A gutted
-  workspace is now reported to the operator with a skip reason rather than
-  dropped silently.
 
 - **Two wrong instructions corrected in the bundled assets composed into every
   session's prompt.** Both were static text that no project could override, and

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -168,6 +168,23 @@ so a 2.0.0 would signal a break that cannot reach anyone.
 
 ### Fixed
 
+- **Two paths no longer write into a destroyed worktree**
+  ([#4204](https://github.com/bobmatnyc/trusty-tools/issues/4204)):
+  `tm install --reset-agents --reset-agents-workspaces` and the bare-`tm`
+  in-place relaunch both gated on `workspace_path.is_dir()` alone, which a
+  gutted worktree — `.git` and source tree stripped, directory node surviving —
+  passes. The sweep recomposed 45 agent files into such a husk and the relaunch
+  exec'd `claude` into it. Both now share one predicate,
+  `core::workspace_liveness::workspace_liveness`, which skips ONLY on positive
+  evidence of death: it accepts `.git` as a FILE (the `gitdir:` pointer every
+  linked worktree carries, so no legitimate managed workspace is refused),
+  requires a `.git` only where one is owed (a tm-provisioned workspace or a
+  `.worktrees/<id>` path), and reports an unreadable filesystem as
+  `Indeterminate` — explicitly not dead — so a permission or network-mount
+  failure can never silently stop servicing a live workspace. A gutted
+  workspace is now reported to the operator with a skip reason rather than
+  dropped silently.
+
 - **Two wrong instructions corrected in the bundled assets composed into every
   session's prompt.** Both were static text that no project could override, and
   both had demonstrably misrouted live sessions.

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -86,6 +86,7 @@
 //! pre-existing refuse+switch-client behavior instead.
 
 use anyhow::Context as _;
+use trusty_mpm::core::workspace_liveness::workspace_liveness;
 
 use super::guided_resume::ResumeAction;
 
@@ -467,14 +468,17 @@ pub(crate) enum InPlaceOutcome {
 /// (cwd/binary resolution) or post-reactivate (`exec` itself failing) alike
 /// — as a fall-back-to-reconnect condition, matching that call site's
 /// pre-#2453 behavior of never hard-failing.
-/// What, IN ORDER (#2027 exec-ordering fix, extended by #2790): (1) prints a
-/// one-line notice; (2) resolves the workdir; (2a) #2790 CRITICAL:
-/// verifies the resolved workdir EXISTS ON DISK — a Decommissioned record's
-/// workspace may have been removed by `decommission()` while the record's
-/// `workspace_path`/`cwd` still names it; a missing directory returns
-/// [`InPlaceOutcome::FallThrough`] here, BEFORE any daemon call, so a
-/// known-gone workspace can never be masked by a durably-committed `Active`
-/// record; (3) builds the resume argv via
+/// What, IN ORDER (#2027 exec-ordering fix, extended by #2790 and #4204): (1)
+/// prints a one-line notice; (2) resolves the workdir; (2a) #2790/#4204
+/// CRITICAL: verifies the resolved workdir IS STILL LIVE via
+/// [`trusty_mpm::core::workspace_liveness::workspace_liveness`] — a
+/// Decommissioned record's workspace may have been removed by `decommission()`
+/// while the record's `workspace_path`/`cwd` still names it, and (#4204) a
+/// worktree may have been GUTTED, keeping its directory node while losing its
+/// `.git` and source tree, which the previous bare `is_dir()` test could not
+/// see; either verdict returns [`InPlaceOutcome::FallThrough`] here, BEFORE any
+/// daemon call, so a dead workspace can never be masked by a durably-committed
+/// `Active` record nor exec'd into; (3) builds the resume argv via
 /// [`trusty_mpm::runtime::build_inplace_resume_command`] (the SAME
 /// `--resume`-existence-check → `--continue`/fresh-spawn fallback logic the
 /// tmux-pane resume path uses, #2013) — this is PURE/local (resolving the
@@ -484,11 +488,15 @@ pub(crate) enum InPlaceOutcome {
 /// [`reactivate_managed_session`]), immediately before exec — on a
 /// refused/failed reactivate this returns [`InPlaceOutcome::FallThrough`]
 /// rather than proceeding; (5) execs `claude` in place.
-/// Test: I/O path; not unit-tested (requires a live daemon + real `claude`).
-/// The workdir-existence gate (2a) is exercised via `run_inplace_relaunch`'s
-/// I/O surface only (needs the daemon + tmux + `claude`); the FSM invariant it
-/// protects is separately proven at the daemon layer (defense-in-depth, so the
-/// guard holds even for a future caller that skips this CLI-side check) by
+/// Test: `run_inplace_relaunch_never_reactivates_when_command_build_fails`,
+/// `run_inplace_relaunch_falls_through_on_gutted_worktree`,
+/// `run_inplace_relaunch_serves_live_linked_worktree`. The exec itself is not
+/// unit-tested (it replaces the process image); the gate-2a tests pin the
+/// decision by asserting the daemon mock records ZERO hits, which is only true
+/// when the fall-through happened before any daemon mutation. The FSM invariant
+/// gate 2a protects is separately proven at the daemon layer
+/// (defense-in-depth, so the guard holds even for a future caller that skips
+/// this CLI-side check) by
 /// `mark_reactivated_refuses_when_workspace_removed_by_decommission` in
 /// `session_manager::reactivate_tests`.
 pub(crate) async fn run_inplace_relaunch(
@@ -523,10 +531,25 @@ pub(crate) async fn run_inplace_relaunch(
     // missing workspace into `FallThrough` here — zero daemon calls made —
     // keeps the invariant intact and routes the operator to the same honest
     // self-relaunch hint a refused reactivate would.
-    if !cwd.is_dir() {
+    // #4204 EXTENSION of the #2790 gate above: `is_dir()` is not a liveness
+    // check. A worktree whose `.git` and source tree have been stripped keeps
+    // its directory node, so the bare `is_dir()` test passed and this function
+    // exec'd `claude` into the husk — observed 2026-07-27 with PID 63302 (plus
+    // four MCP children) still parked on the dead cwd of
+    // `.base/.worktrees/f443c12d-…`.
+    //
+    // `ManagedSessionSummary` carries no `workspace_owned` flag, so `false` is
+    // passed for it and the helper falls back to its NARROW path-shape rule
+    // (`.worktrees/<id>`). That is deliberate, not a shortcut: such a directory
+    // is only ever produced by `git worktree add`, so a missing `.git` there is
+    // unambiguous evidence of destruction — while an operator's plain,
+    // non-git working directory (reachable here via `record.cwd` or
+    // `current_dir()`) is owed no `.git` and is never refused.
+    let workspace_owned_unknown = false;
+    let liveness = workspace_liveness(&cwd, workspace_owned_unknown);
+    if liveness.is_dead() {
         eprintln!(
-            "tm: workspace for session {id} no longer exists on disk ({}) — cannot relaunch in \
-             place",
+            "tm: workspace for session {id} is {liveness} ({}) — cannot relaunch in place",
             cwd.display()
         );
         return InPlaceOutcome::FallThrough;

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -496,6 +496,143 @@ async fn reactivate_omits_caller_pane_id_query_when_absent() {
     );
 }
 
+/// A `ManagedSessionSummary` whose workspace is `workspace`, in the `stopped`
+/// shape `run_inplace_relaunch` is normally handed.
+///
+/// Why: the struct has ~20 fields and three #4204 tests need it; inlining it
+/// three more times would be pure noise.
+/// What: `TEST_ID`/`tm-test`/`stopped` with `workspace_path` set and every
+/// other field at its empty default.
+/// Test: used by `run_inplace_relaunch_falls_through_on_gutted_worktree` and
+/// `run_inplace_relaunch_serves_live_linked_worktree`.
+fn stopped_record_at(workspace: &std::path::Path) -> trusty_mpm::client::ManagedSessionSummary {
+    trusty_mpm::client::ManagedSessionSummary {
+        id: TEST_ID.to_string(),
+        name: "tm-test".to_string(),
+        state: "stopped".to_string(),
+        persisted_state: None,
+        workspace_path: Some(workspace.to_string_lossy().to_string()),
+        repo_url: None,
+        branch: None,
+        created_at: None,
+        last_activity_at: None,
+        pending_decision: None,
+        proposed_default: None,
+        source_id: None,
+        task: None,
+        cwd: None,
+        claude_session_id: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: None,
+        unresumable: false,
+        stale_assets: false,
+        attached: false,
+        slot: 0,
+        deleted: false,
+    }
+}
+
+#[tokio::test]
+async fn run_inplace_relaunch_falls_through_on_gutted_worktree() {
+    // ISSUE #4204: a worktree whose `.git` and source tree were stripped keeps
+    // its directory node, so the old `cwd.is_dir()` gate passed and this
+    // function exec'd `claude` into the husk (observed 2026-07-27: PID 63302
+    // plus four MCP children parked on the dead cwd of
+    // `.base/.worktrees/f443c12d-…`). It must now fall through to the picker
+    // instead, BEFORE any daemon mutation.
+    //
+    // The mock answers 409 so that even on pre-fix code — where `claude` may
+    // resolve and the flow would continue — the reactivate is REFUSED and the
+    // real `exec` (which would replace this test process) is never reached.
+    // The decisive assertion is therefore `hits == 0`, not the outcome alone:
+    // against main this test fails either way — with `claude` absent the
+    // outcome is `Result(Err(..))`, and with `claude` present the daemon is
+    // contacted and `hits == 1`.
+    let base = tempfile::tempdir().expect("tempdir");
+    let gutted = base
+        .path()
+        .join(".worktrees")
+        .join("f443c12d-2fb6-4ce1-9f70-2e7695306e47");
+    std::fs::create_dir_all(gutted.join(".claude")).expect("create gutted worktree");
+    assert!(
+        gutted.is_dir() && !gutted.join(".git").exists(),
+        "fixture must be exactly what the old is_dir() gate waved through"
+    );
+
+    let (url, hits) = spawn_mock("HTTP/1.1 409 Conflict").await;
+    let client = reqwest::Client::new();
+
+    let outcome = run_inplace_relaunch(
+        &client,
+        &url,
+        TEST_ID,
+        stopped_record_at(&gutted),
+        None,
+        false,
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, InPlaceOutcome::FallThrough),
+        "a gutted worktree must fall through to the picker, never be exec'd into"
+    );
+    assert_eq!(
+        hits.load(Ordering::SeqCst),
+        0,
+        "the liveness gate must abort BEFORE any daemon mutation (#2790/#4204)"
+    );
+}
+
+#[tokio::test]
+async fn run_inplace_relaunch_serves_live_linked_worktree() {
+    // THE ANTI-OVER-REFUSAL COUNTERPART. In a linked worktree `.git` is a FILE
+    // holding a `gitdir:` pointer — every managed workspace looks like this. A
+    // guard that assumed a `.git` DIRECTORY would fall through for all of them,
+    // silently breaking in-place relaunch entirely.
+    //
+    // The observable proof that the gate was PASSED is that control reached the
+    // next step: either command resolution failed (no `claude` on this machine)
+    // or the daemon was contacted. The one outcome that must NOT occur is the
+    // gutted signature — `FallThrough` with zero daemon hits.
+    let base = tempfile::tempdir().expect("tempdir");
+    let live = base
+        .path()
+        .join(".worktrees")
+        .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    std::fs::create_dir_all(&live).expect("create worktree");
+    std::fs::write(
+        live.join(".git"),
+        "gitdir: /repo/.base/.git/worktrees/live\n",
+    )
+    .expect("write .git pointer file");
+    assert!(
+        live.join(".git").is_file() && !live.join(".git").is_dir(),
+        "fixture must model the linked-worktree .git FILE this test exists for"
+    );
+
+    let (url, hits) = spawn_mock("HTTP/1.1 409 Conflict").await;
+    let client = reqwest::Client::new();
+
+    let outcome = run_inplace_relaunch(
+        &client,
+        &url,
+        TEST_ID,
+        stopped_record_at(&live),
+        None,
+        false,
+    )
+    .await;
+
+    let build_failed = matches!(outcome, InPlaceOutcome::Result(Err(_)));
+    let daemon_contacted = hits.load(Ordering::SeqCst) > 0;
+    assert!(
+        build_failed || daemon_contacted,
+        "a LIVE linked worktree must get past the liveness gate — it fell through \
+         with the daemon never contacted, which is the gutted-workspace verdict"
+    );
+}
+
 #[tokio::test]
 async fn run_inplace_relaunch_never_reactivates_when_command_build_fails() {
     // #2027 MEDIUM fix: command resolution (resolve `claude` + build the
@@ -515,31 +652,7 @@ async fn run_inplace_relaunch_never_reactivates_when_command_build_fails() {
     }
 
     let (url, hits) = spawn_mock("HTTP/1.1 200 OK").await;
-    let record = trusty_mpm::client::ManagedSessionSummary {
-        id: TEST_ID.to_string(),
-        name: "tm-test".to_string(),
-        state: "stopped".to_string(),
-        persisted_state: None,
-        workspace_path: Some(tmp.path().to_string_lossy().to_string()),
-        repo_url: None,
-        branch: None,
-        created_at: None,
-        last_activity_at: None,
-        pending_decision: None,
-        proposed_default: None,
-        source_id: None,
-        task: None,
-        cwd: None,
-        claude_session_id: None,
-        deliverable_id: None,
-        pane_id: None,
-        injection_status: None,
-        unresumable: false,
-        stale_assets: false,
-        attached: false,
-        slot: 0,
-        deleted: false,
-    };
+    let record = stopped_record_at(tmp.path());
     let client = reqwest::Client::new();
 
     let outcome = run_inplace_relaunch(&client, &url, TEST_ID, record, None, false).await;

--- a/crates/trusty-mpm/src/core/agent_reset_workspace.rs
+++ b/crates/trusty-mpm/src/core/agent_reset_workspace.rs
@@ -138,10 +138,13 @@ pub enum WorkspaceSweepError {
 /// calls [`reset_project_agents`] with `names` and the plan's `agent_selected`
 /// predicate. Returns one [`WorkspaceResetOutcome`] per swept workspace, in
 /// session-store iteration order.
+/// A workspace whose liveness could NOT be determined is served, not skipped,
+/// and logged at WARN — see [`crate::core::workspace_liveness`]'s invariant.
 /// Test: `sweep_resets_intact_workspace`, `sweep_skips_decommissioned_session`,
 /// `sweep_skips_session_without_workspace`,
 /// `sweep_respects_per_workspace_manifest_exclude`,
-/// `sweep_skips_unowned_non_worktree_session`.
+/// `sweep_skips_unowned_non_worktree_session`,
+/// `sweep_reports_session_whose_workspace_vanished`.
 pub async fn reset_active_workspace_agents(
     fw_root: &Path,
     names: Option<&[String]>,
@@ -171,11 +174,28 @@ pub async fn reset_active_workspace_agents(
         // writing into a dead one.
         let liveness = workspace_liveness(workspace_path, session.workspace_owned);
         match &liveness {
-            // Pre-#4204 behavior, preserved verbatim: a never-provisioned or
-            // already-removed workspace is skipped silently — there is no
-            // `.claude/agents/` to reconcile and nothing for the operator to act
-            // on.
-            WorkspaceLiveness::Absent => continue,
+            // A DEFINITE observation that the path is gone (or is not a
+            // directory) — `workspace_liveness` routes an unreadable path to
+            // `Indeterminate`, so this arm can no longer be reached by a mere
+            // I/O failure. It is still REPORTED rather than skipped silently
+            // (the pre-#4204 behavior): a live session record pointing at a
+            // workspace that has vanished is a stale-record anomaly, and the
+            // returned outcome is what surfaces it to the operator running
+            // `tm install --reset-agents-workspaces`.
+            WorkspaceLiveness::Absent => {
+                tracing::warn!(
+                    workspace = %workspace_path.display(),
+                    session = %session.tmux_name,
+                    "session workspace is gone — skipping its agent reset"
+                );
+                outcomes.push(WorkspaceResetOutcome {
+                    tmux_name: session.tmux_name,
+                    workspace_path: workspace_path.clone(),
+                    result: ResetResult::default(),
+                    skipped_reason: Some(format!("skipped — {liveness}")),
+                });
+                continue;
+            }
             // The #4204 husk. Unlike `Absent` this IS reported, because a
             // surviving directory that lost its checkout is an anomaly the
             // operator should see (and is exactly what #3764 / PR #4202 detect).
@@ -398,6 +418,33 @@ mod tests {
             outcomes.is_empty(),
             "a decommissioned session has no workspace to reconcile"
         );
+    }
+
+    #[tokio::test]
+    async fn sweep_reports_session_whose_workspace_vanished() {
+        // An active record pointing at a path that is DEFINITELY gone. This is
+        // reported rather than skipped in silence, so the operator can see the
+        // stale record. (Before PR #4209's review fix this arm was also where
+        // an unreadable-but-live workspace landed; that case is now
+        // `Indeterminate` and is served, per
+        // `liveness_unreadable_parent_is_indeterminate_never_dead`.)
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+
+        let gone = fw_base.path().join("vanished-workspace");
+        assert!(!gone.exists());
+        seed_sessions(&fw_root, vec![intact_session("tm-vanished", &gone)]).await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+        assert_eq!(outcomes.len(), 1, "a vanished workspace must be reported");
+        assert_eq!(outcomes[0].tmux_name, "tm-vanished");
+        let reason = outcomes[0]
+            .skipped_reason
+            .as_deref()
+            .expect("a vanished workspace must carry a skip reason");
+        assert!(reason.contains("no longer exists"), "{reason}");
+        assert!(outcomes[0].result.recomposed.is_empty());
     }
 
     #[tokio::test]

--- a/crates/trusty-mpm/src/core/agent_reset_workspace.rs
+++ b/crates/trusty-mpm/src/core/agent_reset_workspace.rs
@@ -25,6 +25,16 @@
 //! writing a byte into a workspace's `.claude/agents/` — a sweep must never
 //! force-recompose the bundled roster into a real repository the operator
 //! did not hand to trusty-mpm to manage.
+//! SECOND SAFETY GATE — LIVENESS (#4204): ownership answers "may we write
+//! here?", not "is there still anything here to write to?" The original
+//! `workspace_path.is_dir()` filter conflated the two: a worktree whose `.git`
+//! and source tree had been stripped still passes `is_dir()`, and on 2026-07-27
+//! this sweep recomposed 45 agent files into exactly such a husk
+//! (`.base/.worktrees/f443c12d-…`, absent from `git worktree list`). The filter
+//! is now [`crate::core::workspace_liveness::workspace_liveness`], which skips
+//! ONLY on positive evidence of death and treats an unverifiable observation as
+//! live — see that module for why a naive `.join(".git").exists()` would have
+//! been wrong in both directions.
 //! What: [`reset_active_workspace_agents`] loads the on-disk session store
 //! (the SAME `sessions.json` the daemon and CLI both read — no live daemon
 //! required), filters to sessions with an intact `workspace_path`, SKIPS any
@@ -40,7 +50,9 @@
 //! Test: `sweep_resets_intact_workspace`, `sweep_skips_decommissioned_session`,
 //! `sweep_skips_session_without_workspace`,
 //! `sweep_respects_per_workspace_manifest_exclude`,
-//! `sweep_skips_unowned_non_worktree_session`.
+//! `sweep_skips_unowned_non_worktree_session`,
+//! `sweep_skips_gutted_worktree_whose_git_was_stripped`,
+//! `sweep_serves_live_linked_worktree_with_git_file`.
 
 use std::path::{Path, PathBuf};
 
@@ -48,6 +60,7 @@ use crate::core::agent_builder::AgentBuildError;
 use crate::core::agent_reset::{ResetResult, reset_project_agents};
 use crate::core::manifest::{HarnessPlan, ManifestSources, resolve_manifest};
 use crate::core::paths::FrameworkPaths;
+use crate::core::workspace_liveness::{WorkspaceLiveness, workspace_liveness};
 use crate::session_manager::decommission::is_session_worktree;
 use crate::session_manager::{ManagedSessionState, SessionStore, StoreError};
 
@@ -113,8 +126,10 @@ pub enum WorkspaceSweepError {
 /// adoption/backup semantics, each gated by its own project's manifest.
 /// What: loads the session store at `<fw_root>/session-manager/sessions.json`,
 /// keeps sessions whose `state` is not [`ManagedSessionState::Decommissioned`]
-/// and whose `workspace_path` still exists on disk (a decommissioned or
-/// never-provisioned session has no `.claude/agents/` to reconcile), and for
+/// and whose `workspace_path` is not positively dead per
+/// [`crate::core::workspace_liveness::workspace_liveness`] (#4204 — a
+/// decommissioned or never-provisioned session has no `.claude/agents/` to
+/// reconcile, and neither does a gutted worktree husk), and for
 /// each one: resolves the harness manifest via [`ManifestSources::resolve`]
 /// (project override > user config > catalog > default — identical precedence
 /// to a real launch), builds the [`HarnessPlan`] via
@@ -145,8 +160,43 @@ pub async fn reset_active_workspace_agents(
         let Some(workspace_path) = &session.workspace_path else {
             continue;
         };
-        if !workspace_path.is_dir() {
-            continue;
+        // CRITICAL (#4204): `is_dir()` alone is NOT a liveness check. A worktree
+        // whose `.git` and source tree have been stripped keeps its directory
+        // node, so the old gate waved it through and this sweep recomposed 45
+        // agent files into the husk (observed 2026-07-27 in
+        // `.base/.worktrees/f443c12d-…`). `workspace_liveness` skips ONLY on
+        // POSITIVE evidence of death — an unverifiable observation is reported
+        // as `Indeterminate` and deliberately still served, because silently
+        // declining to reset a live workspace is a far quieter failure than
+        // writing into a dead one.
+        let liveness = workspace_liveness(workspace_path, session.workspace_owned);
+        match &liveness {
+            // Pre-#4204 behavior, preserved verbatim: a never-provisioned or
+            // already-removed workspace is skipped silently — there is no
+            // `.claude/agents/` to reconcile and nothing for the operator to act
+            // on.
+            WorkspaceLiveness::Absent => continue,
+            // The #4204 husk. Unlike `Absent` this IS reported, because a
+            // surviving directory that lost its checkout is an anomaly the
+            // operator should see (and is exactly what #3764 / PR #4202 detect).
+            WorkspaceLiveness::Gutted => {
+                outcomes.push(WorkspaceResetOutcome {
+                    tmux_name: session.tmux_name,
+                    workspace_path: workspace_path.clone(),
+                    result: ResetResult::default(),
+                    skipped_reason: Some(format!("skipped — {liveness}")),
+                });
+                continue;
+            }
+            WorkspaceLiveness::Indeterminate(_) => {
+                tracing::warn!(
+                    workspace = %workspace_path.display(),
+                    liveness = %liveness,
+                    "workspace liveness unverifiable — proceeding with the reset \
+                     rather than treating an ambiguous observation as death"
+                );
+            }
+            WorkspaceLiveness::Live => {}
         }
 
         // CRITICAL (#1511 incident class): only ever write into a workspace
@@ -264,6 +314,27 @@ mod tests {
         }
     }
 
+    /// Make `dir` look like a LIVE linked git worktree (#4204).
+    ///
+    /// Why: every workspace this sweep legitimately serves was created by
+    /// `GitBackend::worktree_add`, which writes `.git` as a FILE holding a
+    /// `gitdir:` pointer — NOT a directory. The fixtures below must model that,
+    /// or they would silently prove the opposite of what they claim (and a
+    /// `.join(".git").is_dir()`-shaped guard would sail through them).
+    /// What: writes a one-line `gitdir:` pointer file, mirroring both real
+    /// `git worktree add` output and
+    /// `provisioner::workspace::FakeGitBackend::worktree_add`.
+    /// Test: used by `sweep_resets_intact_workspace`,
+    /// `sweep_serves_live_linked_worktree_with_git_file`,
+    /// `sweep_respects_per_workspace_manifest_exclude`.
+    fn make_linked_worktree(dir: &Path) {
+        fs::write(
+            dir.join(".git"),
+            "gitdir: /repo/.base/.git/worktrees/session\n",
+        )
+        .unwrap();
+    }
+
     /// Build a `.trusty-mpm`-named framework root under a fresh temp dir.
     ///
     /// Why: [`FrameworkPaths::from_root`] special-cases a root literally named
@@ -295,6 +366,7 @@ mod tests {
         let fw_root = fw_root_under(&fw_base);
         write_sources(&fw_root.join("framework").join("agents"));
         let workspace = TempDir::new().unwrap();
+        make_linked_worktree(workspace.path());
 
         seed_sessions(
             &fw_root,
@@ -407,6 +479,96 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn sweep_skips_gutted_worktree_whose_git_was_stripped() {
+        // ISSUE #4204, THE BUG. Observed 2026-07-27: worktree
+        // `.base/.worktrees/f443c12d-…` had no `.git`, no source tree, and was
+        // absent from `git worktree list` — yet `is_dir()` returned true, so
+        // this sweep wrote 45 files into its `.claude/agents/`. The husk must
+        // now be classified dead and left alone, AND reported (an anomaly the
+        // operator should see) rather than silently dropped.
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+
+        // A gutted worktree: correct `.worktrees/<id>` shape, directory node
+        // survives, `.claude/` survives — but `.git` is gone.
+        let base = TempDir::new().unwrap();
+        let gutted = base
+            .path()
+            .join(".worktrees")
+            .join("f443c12d-2fb6-4ce1-9f70-2e7695306e47");
+        let agents_dir = gutted.join(".claude").join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        assert!(
+            gutted.is_dir() && !gutted.join(".git").exists(),
+            "fixture must be exactly what the old is_dir() gate waved through"
+        );
+
+        seed_sessions(&fw_root, vec![intact_session("tm-gutted", &gutted)]).await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+
+        assert_eq!(outcomes.len(), 1, "a gutted husk must still be reported");
+        assert_eq!(outcomes[0].tmux_name, "tm-gutted");
+        let reason = outcomes[0]
+            .skipped_reason
+            .as_deref()
+            .expect("a gutted workspace must carry a skip reason");
+        assert!(reason.contains("gutted"), "reason = {reason:?}");
+        assert!(outcomes[0].result.recomposed.is_empty());
+
+        // The decisive assertion: not one byte was written into the husk.
+        assert!(
+            !agents_dir.join("engineer.md").exists(),
+            "the sweep must never recompose the roster into a destroyed worktree"
+        );
+        assert!(!agents_dir.join("base-agent.md").exists());
+        assert_eq!(
+            fs::read_dir(&agents_dir).unwrap().count(),
+            0,
+            "the husk's .claude/agents/ must be left completely untouched"
+        );
+    }
+
+    #[tokio::test]
+    async fn sweep_serves_live_linked_worktree_with_git_file() {
+        // THE ANTI-OVER-REFUSAL TEST, and it matters more than the one above.
+        // In a LINKED worktree — which is what `WorkspaceProvisioner` creates
+        // for every managed session — `.git` is a FILE containing a `gitdir:`
+        // pointer, not a directory. A guard written as
+        // `path.join(".git").is_dir()` would reject EVERY legitimate managed
+        // workspace: the exact inverse of #4204. This test fails loudly if the
+        // liveness predicate is ever tightened that way.
+        let fw_base = TempDir::new().unwrap();
+        let fw_root = fw_root_under(&fw_base);
+        write_sources(&fw_root.join("framework").join("agents"));
+
+        let base = TempDir::new().unwrap();
+        let live = base
+            .path()
+            .join(".worktrees")
+            .join("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+        fs::create_dir_all(&live).unwrap();
+        make_linked_worktree(&live);
+        assert!(
+            live.join(".git").is_file() && !live.join(".git").is_dir(),
+            "fixture must model the linked-worktree .git FILE this test exists for"
+        );
+
+        seed_sessions(&fw_root, vec![intact_session("tm-live-worktree", &live)]).await;
+
+        let outcomes = reset_active_workspace_agents(&fw_root, None).await.unwrap();
+
+        assert_eq!(outcomes.len(), 1);
+        assert_eq!(outcomes[0].skipped_reason, None, "must NOT be refused");
+        assert_eq!(outcomes[0].result.recomposed.len(), 2);
+        assert!(
+            live.join(".claude/agents/engineer.md").exists(),
+            "a live linked worktree must still be served"
+        );
+    }
+
+    #[tokio::test]
     async fn sweep_respects_per_workspace_manifest_exclude() {
         // Issue #2462/#2508: a workspace whose PROJECT manifest excludes
         // `engineer` must come back from the sweep WITHOUT engineer.md, and
@@ -415,6 +577,7 @@ mod tests {
         let fw_root = fw_root_under(&fw_base);
         write_sources(&fw_root.join("framework").join("agents"));
         let workspace = TempDir::new().unwrap();
+        make_linked_worktree(workspace.path());
         let project_manifest_dir = workspace.path().join(".trusty-mpm");
         fs::create_dir_all(&project_manifest_dir).unwrap();
         fs::write(

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -98,6 +98,7 @@ pub mod tmux;
 pub mod trusty_tools_config;
 pub mod update_check;
 pub mod version_staleness;
+pub mod workspace_liveness;
 pub mod workspace_scan;
 pub mod worktree_naming;
 

--- a/crates/trusty-mpm/src/core/workspace_liveness.rs
+++ b/crates/trusty-mpm/src/core/workspace_liveness.rs
@@ -1,0 +1,267 @@
+//! Positive-evidence liveness classification for a managed session's workspace
+//! directory (issue #4204).
+//!
+//! Why: two independent code paths — [`super::agent_reset_workspace::
+//! reset_active_workspace_agents`] and the `tm` binary's
+//! `commands::guided_inplace::run_inplace_relaunch` — gated on
+//! `workspace_path.is_dir()` alone and then acted on the directory as if it
+//! were live. `is_dir()` is blind to the failure mode #4204 observed on
+//! 2026-07-27: worktree `.base/.worktrees/f443c12d-…` had its `.git` and its
+//! entire source tree stripped and was absent from `git worktree list`, yet the
+//! directory node survived — so `is_dir()` returned `true`, and 45 files were
+//! recomposed into the husk's `.claude/agents/` while a `claude` process sat on
+//! the dead cwd. This module is the ONE predicate both call sites now share, so
+//! "is this workspace alive?" has a single definition rather than a per-call-
+//! site reinvention.
+//!
+//! THE INVARIANT — SKIP ONLY ON POSITIVE EVIDENCE OF DEATH. The obvious patch,
+//! `path.join(".git").exists()`, is wrong twice over and this module deliberately
+//! avoids both traps:
+//!
+//! 1. `.git` IS NOT A DIRECTORY IN A LINKED WORKTREE. `git worktree add` writes
+//!    `.git` as a FILE containing a `gitdir:` pointer (mirrored by
+//!    `provisioner::workspace::FakeGitBackend::worktree_add`). Every workspace
+//!    the provisioner creates is a linked worktree under
+//!    `<project>/.base/.worktrees/<session-id>`, so a guard spelled
+//!    `.join(".git").is_dir()` would reject EVERY legitimate managed workspace —
+//!    the exact inverse of the bug. This module stats the `.git` name and
+//!    accepts whatever it finds: file, directory, or symlink.
+//! 2. NOT EVERY WORKSPACE IS A GIT CHECKOUT, AND A FAILED OBSERVATION IS NOT A
+//!    DEATH. A missing `.git` is evidence of death only where a `.git` is
+//!    KNOWN to be owed (see [`workspace_liveness`]'s expectation rule), and an
+//!    I/O failure — permission denied, a stalled network mount, ENOTDIR — is
+//!    an ABSENCE OF EVIDENCE, reported as [`WorkspaceLiveness::Indeterminate`]
+//!    and explicitly NOT dead ([`WorkspaceLiveness::is_dead`] returns `false`
+//!    for it). Silently declining to serve a live workspace is a far quieter
+//!    failure than the bug being fixed, and is the over-refusal trap PR #4202's
+//!    first round fell into.
+//!
+//! What: [`WorkspaceLiveness`] — a four-valued classification with the
+//! dead/not-dead decision encoded in [`WorkspaceLiveness::is_dead`] so no caller
+//! has to re-derive it — and [`workspace_liveness`], which computes it.
+//! Test: `liveness_accepts_linked_worktree_git_file`,
+//! `liveness_accepts_clone_git_directory`,
+//! `liveness_reports_gutted_worktree_missing_git`,
+//! `liveness_never_requires_git_for_unowned_non_worktree_path`,
+//! `liveness_reports_absent_directory`, `liveness_indeterminate_is_never_dead`.
+
+use std::path::Path;
+
+use crate::session_manager::decommission::is_session_worktree;
+
+/// What an observation of a workspace directory established about its liveness.
+///
+/// Why: a two-valued `bool` cannot express the distinction this guard exists to
+/// preserve — "confirmed dead" versus "could not tell". Collapsing the two is
+/// precisely how a liveness guard turns into an over-refusal bug, so the
+/// ambiguous case gets its own variant and [`Self::is_dead`] answers `false`
+/// for it.
+/// What: `Live` (no evidence of death), `Absent` (the path itself is gone or is
+/// not a directory), `Gutted` (the directory survives but a `.git` that is owed
+/// is confirmed missing — the #4204 husk), and `Indeterminate` (the filesystem
+/// could not be interrogated; carries the reason for logging).
+/// Test: `liveness_indeterminate_is_never_dead` pins the invariant that only
+/// `Absent`/`Gutted` count as death.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum WorkspaceLiveness {
+    /// Nothing observed suggests this workspace is dead — act on it.
+    Live,
+    /// The path does not exist, or exists but is not a directory.
+    Absent,
+    /// The directory node survives but its git checkout has been stripped
+    /// (#4204). Positive evidence of death.
+    Gutted,
+    /// The filesystem could not be interrogated (permission denied, I/O error,
+    /// a stalled network mount). NEVER treated as death — see [`Self::is_dead`].
+    Indeterminate(String),
+}
+
+impl WorkspaceLiveness {
+    /// `true` only when the observation POSITIVELY established the workspace is
+    /// dead.
+    ///
+    /// Why: callers must skip on evidence of death, never on the absence of
+    /// evidence. Putting the rule here (rather than in each caller's `match`)
+    /// makes it impossible for one call site to quietly widen "dead" to include
+    /// [`Self::Indeterminate`].
+    /// What: `true` for [`Self::Absent`] and [`Self::Gutted`]; `false` for
+    /// [`Self::Live`] and [`Self::Indeterminate`].
+    /// Test: `liveness_indeterminate_is_never_dead`,
+    /// `liveness_reports_gutted_worktree_missing_git`,
+    /// `liveness_reports_absent_directory`.
+    pub fn is_dead(&self) -> bool {
+        matches!(self, Self::Absent | Self::Gutted)
+    }
+}
+
+impl std::fmt::Display for WorkspaceLiveness {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Live => f.write_str("live"),
+            Self::Absent => f.write_str("no longer exists on disk"),
+            Self::Gutted => f.write_str(
+                "gutted — the directory survives but its git checkout (.git) has been stripped",
+            ),
+            Self::Indeterminate(reason) => {
+                write!(
+                    f,
+                    "liveness could not be determined ({reason}) — treated as live"
+                )
+            }
+        }
+    }
+}
+
+/// Classify whether `path` is a workspace that is still safe to act on.
+///
+/// Why: see the module doc — this is the single #4204 predicate replacing the
+/// bare `is_dir()` check at both offending call sites.
+/// What, in order: (1) `path.is_dir()` — preserved verbatim from the code this
+/// replaces, so the pre-existing "gone / not a directory" skip keeps its exact
+/// semantics and this change adds no new abort paths; a `false` here is
+/// [`WorkspaceLiveness::Absent`]. (2) THE EXPECTATION RULE — a missing `.git`
+/// is evidence of death only where one is owed, which is true iff
+/// `workspace_owned || is_session_worktree(path)`: `workspace_owned` means
+/// `WorkspaceProvisioner::provision_in` created this directory (it takes a
+/// mandatory `repo_url` and always finishes with `GitBackend::worktree_add`, so
+/// an owned workspace is ALWAYS a checkout), and `is_session_worktree`'s
+/// `.worktrees/<id>` path shape is only ever produced by `git worktree add`.
+/// This is deliberately the SAME predicate the #1511 ownership gate uses — it
+/// adds no third notion of ownership — and outside it the answer is
+/// [`WorkspaceLiveness::Live`], so an adopted, non-git workspace is never
+/// refused service. (3) `symlink_metadata` on `path.join(".git")`: `Ok(_)`
+/// (file — the linked-worktree case — directory, or symlink) is
+/// [`WorkspaceLiveness::Live`]; `NotFound` is the confirmed absence that makes
+/// [`WorkspaceLiveness::Gutted`]; ANY OTHER error is
+/// [`WorkspaceLiveness::Indeterminate`], never death.
+///
+/// `is_session_worktree` is intentionally left as the pure path-shape heuristic
+/// it is: it answers "may trusty-mpm DELETE this?" (ownership) on paths that may
+/// legitimately be absent — `is_session_worktree_absent_path_is_noop` pins that
+/// — and teaching it about `.git` would make `decommission`/`search_gc` refuse
+/// to clean up the very husks #4204 is about. Ownership and liveness are
+/// orthogonal axes; this function composes them rather than conflating them.
+///
+/// Test: `liveness_accepts_linked_worktree_git_file`,
+/// `liveness_accepts_clone_git_directory`,
+/// `liveness_reports_gutted_worktree_missing_git`,
+/// `liveness_never_requires_git_for_unowned_non_worktree_path`,
+/// `liveness_reports_absent_directory`.
+pub fn workspace_liveness(path: &Path, workspace_owned: bool) -> WorkspaceLiveness {
+    if !path.is_dir() {
+        return WorkspaceLiveness::Absent;
+    }
+
+    if !(workspace_owned || is_session_worktree(path)) {
+        return WorkspaceLiveness::Live;
+    }
+
+    match std::fs::symlink_metadata(path.join(".git")) {
+        Ok(_) => WorkspaceLiveness::Live,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => WorkspaceLiveness::Gutted,
+        Err(e) => WorkspaceLiveness::Indeterminate(format!("cannot stat .git: {e}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// Build `<tmp>/.worktrees/<leaf>` so `is_session_worktree` matches, exactly
+    /// as `WorkspaceProvisioner::provision_in` lays a managed worktree out.
+    fn worktree_shaped(base: &TempDir, leaf: &str) -> std::path::PathBuf {
+        let p = base
+            .path()
+            .join(crate::session_manager::decommission::WORKTREES_DIRNAME)
+            .join(leaf);
+        fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    #[test]
+    fn liveness_accepts_linked_worktree_git_file() {
+        // THE ANTI-OVER-REFUSAL CASE. `git worktree add` writes `.git` as a
+        // FILE holding a `gitdir:` pointer, which is what EVERY managed
+        // workspace looks like. A guard spelled `.join(".git").is_dir()` would
+        // reject all of them.
+        let base = TempDir::new().unwrap();
+        let wt = worktree_shaped(&base, "f443c12d-2fb6-4ce1-9f70-2e7695306e47");
+        fs::write(
+            wt.join(".git"),
+            "gitdir: /repo/.base/.git/worktrees/f443c12d\n",
+        )
+        .unwrap();
+
+        let liveness = workspace_liveness(&wt, true);
+        assert_eq!(liveness, WorkspaceLiveness::Live, "{liveness}");
+        assert!(!liveness.is_dead());
+        assert!(
+            !wt.join(".git").is_dir(),
+            "fixture must model a .git FILE, not a directory — otherwise this \
+             test cannot catch an is_dir()-shaped guard"
+        );
+    }
+
+    #[test]
+    fn liveness_accepts_clone_git_directory() {
+        // A full clone (`.git` as a directory) is equally live.
+        let base = TempDir::new().unwrap();
+        let clone = base.path().join("checkout");
+        fs::create_dir_all(clone.join(".git")).unwrap();
+
+        assert_eq!(workspace_liveness(&clone, true), WorkspaceLiveness::Live);
+    }
+
+    #[test]
+    fn liveness_reports_gutted_worktree_missing_git() {
+        // The #4204 husk: the directory node survives (and even carries a
+        // `.claude/` tree) while `.git` and the source are gone.
+        let base = TempDir::new().unwrap();
+        let wt = worktree_shaped(&base, "f443c12d-2fb6-4ce1-9f70-2e7695306e47");
+        fs::create_dir_all(wt.join(".claude").join("agents")).unwrap();
+
+        assert!(wt.is_dir(), "the old is_dir() gate would have passed this");
+        let liveness = workspace_liveness(&wt, true);
+        assert_eq!(liveness, WorkspaceLiveness::Gutted);
+        assert!(liveness.is_dead());
+    }
+
+    #[test]
+    fn liveness_never_requires_git_for_unowned_non_worktree_path() {
+        // THE OTHER ANTI-OVER-REFUSAL CASE. A directory trusty-mpm did not
+        // provision and whose shape is not `.worktrees/<id>` is owed no `.git`
+        // at all — an operator may legitimately have adopted a plain,
+        // non-git directory. It must classify Live, not Gutted.
+        let plain = TempDir::new().unwrap();
+        assert!(!plain.path().join(".git").exists());
+
+        let liveness = workspace_liveness(plain.path(), false);
+        assert_eq!(liveness, WorkspaceLiveness::Live, "{liveness}");
+        assert!(!liveness.is_dead());
+    }
+
+    #[test]
+    fn liveness_reports_absent_directory() {
+        let base = TempDir::new().unwrap();
+        let gone = base.path().join("never-existed");
+
+        let liveness = workspace_liveness(&gone, true);
+        assert_eq!(liveness, WorkspaceLiveness::Absent);
+        assert!(liveness.is_dead());
+    }
+
+    #[test]
+    fn liveness_indeterminate_is_never_dead() {
+        // THE INVARIANT: an observation that FAILED is not evidence of death.
+        // Treating a permission/IO/network-mount failure as "dead" would
+        // silently stop serving live workspaces.
+        let unknown = WorkspaceLiveness::Indeterminate("permission denied".into());
+        assert!(
+            !unknown.is_dead(),
+            "an ambiguous observation must never be treated as death"
+        );
+        assert!(unknown.to_string().contains("treated as live"));
+    }
+}

--- a/crates/trusty-mpm/src/core/workspace_liveness.rs
+++ b/crates/trusty-mpm/src/core/workspace_liveness.rs
@@ -36,6 +36,17 @@
 //!    failure than the bug being fixed, and is the over-refusal trap PR #4202's
 //!    first round fell into.
 //!
+//!    THIS PROPERTY IS A PROPERTY OF EVERY STAT THIS MODULE PERFORMS, INCLUDING
+//!    THE FIRST. The reflex spelling of the existence check, `path.is_dir()`,
+//!    silently breaks it: `is_dir()` returns `false` for EACCES, ENOTDIR and a
+//!    hung mount just as it does for a genuinely missing path, so a live
+//!    worktree behind an unreadable parent directory would be classified dead.
+//!    Both stats here therefore go through `metadata`/`symlink_metadata` and
+//!    match on [`std::io::ErrorKind`], and ONLY `NotFound` — never a failure to
+//!    look — may produce a dead verdict. Convenience predicates on [`Path`]
+//!    that fold `Result` into `bool` (`is_dir`, `exists`, `is_file`) must not
+//!    be reintroduced into this decision.
+//!
 //! What: [`WorkspaceLiveness`] — a four-valued classification with the
 //! dead/not-dead decision encoded in [`WorkspaceLiveness::is_dead`] so no caller
 //! has to re-derive it — and [`workspace_liveness`], which computes it.
@@ -43,7 +54,9 @@
 //! `liveness_accepts_clone_git_directory`,
 //! `liveness_reports_gutted_worktree_missing_git`,
 //! `liveness_never_requires_git_for_unowned_non_worktree_path`,
-//! `liveness_reports_absent_directory`, `liveness_indeterminate_is_never_dead`.
+//! `liveness_reports_absent_directory`, `liveness_indeterminate_is_never_dead`,
+//! `liveness_unreadable_parent_is_indeterminate_never_dead`,
+//! `liveness_reports_non_directory_as_absent`.
 
 use std::path::Path;
 
@@ -66,7 +79,9 @@ use crate::session_manager::decommission::is_session_worktree;
 pub enum WorkspaceLiveness {
     /// Nothing observed suggests this workspace is dead — act on it.
     Live,
-    /// The path does not exist, or exists but is not a directory.
+    /// The path was DEFINITELY observed to be gone (`NotFound`), or was
+    /// successfully stat'd and is not a directory. A path that could not be
+    /// stat'd at all is [`Self::Indeterminate`], never this.
     Absent,
     /// The directory node survives but its git checkout has been stripped
     /// (#4204). Positive evidence of death.
@@ -116,10 +131,13 @@ impl std::fmt::Display for WorkspaceLiveness {
 ///
 /// Why: see the module doc — this is the single #4204 predicate replacing the
 /// bare `is_dir()` check at both offending call sites.
-/// What, in order: (1) `path.is_dir()` — preserved verbatim from the code this
-/// replaces, so the pre-existing "gone / not a directory" skip keeps its exact
-/// semantics and this change adds no new abort paths; a `false` here is
-/// [`WorkspaceLiveness::Absent`]. (2) THE EXPECTATION RULE — a missing `.git`
+/// What, in order: (1) `metadata(path)` — NOT `path.is_dir()`, which maps every
+/// I/O error to `false` and would therefore report a live-but-unreadable
+/// workspace as [`WorkspaceLiveness::Absent`], i.e. dead. Only a definite
+/// observation is death here: a successful stat of a non-directory, or
+/// `NotFound`. Any other error kind is [`WorkspaceLiveness::Indeterminate`].
+/// `metadata` follows symlinks just as `is_dir()` did, so a symlinked workspace
+/// is unaffected. (2) THE EXPECTATION RULE — a missing `.git`
 /// is evidence of death only where one is owed, which is true iff
 /// `workspace_owned || is_session_worktree(path)`: `workspace_owned` means
 /// `WorkspaceProvisioner::provision_in` created this directory (it takes a
@@ -146,10 +164,25 @@ impl std::fmt::Display for WorkspaceLiveness {
 /// `liveness_accepts_clone_git_directory`,
 /// `liveness_reports_gutted_worktree_missing_git`,
 /// `liveness_never_requires_git_for_unowned_non_worktree_path`,
-/// `liveness_reports_absent_directory`.
+/// `liveness_reports_absent_directory`,
+/// `liveness_unreadable_parent_is_indeterminate_never_dead`,
+/// `liveness_reports_non_directory_as_absent`.
 pub fn workspace_liveness(path: &Path, workspace_owned: bool) -> WorkspaceLiveness {
-    if !path.is_dir() {
-        return WorkspaceLiveness::Absent;
+    // NOT `path.is_dir()`. `Path::is_dir()` maps EVERY error — EACCES on a
+    // parent component, a stalled network mount, ENOTDIR — to `false`, and
+    // `false` here means `Absent`, which `is_dead()` reports as death. That is
+    // the same swallow-the-error defect as the `canonicalize().ok()` one this
+    // guard's predecessor was rejected for, merely moved one call earlier: a
+    // LIVE worktree behind a directory the process cannot traverse would
+    // classify as dead. `metadata` follows symlinks exactly as `is_dir()` did,
+    // so a symlinked workspace keeps its previous verdict.
+    match std::fs::metadata(path) {
+        Ok(md) if md.is_dir() => {}
+        // A definite observation: something is there, but it is not a
+        // directory, so there is no workspace to serve. Pre-#4204 behavior.
+        Ok(_) => return WorkspaceLiveness::Absent,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return WorkspaceLiveness::Absent,
+        Err(e) => return WorkspaceLiveness::Indeterminate(format!("cannot stat workspace: {e}")),
     }
 
     if !(workspace_owned || is_session_worktree(path)) {
@@ -248,6 +281,71 @@ mod tests {
         let gone = base.path().join("never-existed");
 
         let liveness = workspace_liveness(&gone, true);
+        assert_eq!(liveness, WorkspaceLiveness::Absent);
+        assert!(liveness.is_dead());
+    }
+
+    /// THE CRITIC'S PROBE (PR #4209 review, HIGH). A genuinely LIVE linked
+    /// worktree — `.git` pointer file present and all — sitting behind a parent
+    /// directory the process cannot traverse must NOT be classified dead.
+    ///
+    /// This is the exact case `path.is_dir()` got wrong: it answers `false` for
+    /// EACCES identically to how it answers `false` for a missing path, so the
+    /// original first branch returned `Absent`, whose `is_dead()` is `true`.
+    /// With the `is_dir()` gate restored in place of the `metadata` match, this
+    /// test fails on the first assertion with `Absent`/`is_dead=true`.
+    #[cfg(unix)]
+    #[test]
+    fn liveness_unreadable_parent_is_indeterminate_never_dead() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let base = TempDir::new().unwrap();
+        let wt = worktree_shaped(&base, "f443c12d-2fb6-4ce1-9f70-2e7695306e47");
+        fs::write(
+            wt.join(".git"),
+            "gitdir: /repo/.base/.git/worktrees/f443c12d\n",
+        )
+        .unwrap();
+        let parent = wt.parent().unwrap().to_path_buf();
+        let restore = fs::metadata(&parent).unwrap().permissions();
+
+        fs::set_permissions(&parent, fs::Permissions::from_mode(0o000)).unwrap();
+        // Root traverses regardless of mode, so the probe cannot be staged;
+        // assert nothing rather than assert something false.
+        let staged = fs::metadata(&wt).is_err();
+        let liveness = workspace_liveness(&wt, true);
+        // Restore BEFORE asserting so a failure still leaves a removable
+        // TempDir behind.
+        fs::set_permissions(&parent, restore).unwrap();
+
+        if !staged {
+            eprintln!("skipped: running privileged, EACCES could not be staged");
+            return;
+        }
+        assert!(
+            !liveness.is_dead(),
+            "a LIVE worktree that merely could not be stat'd must never be \
+             treated as dead — got {liveness:?}"
+        );
+        assert!(
+            matches!(liveness, WorkspaceLiveness::Indeterminate(_)),
+            "an unreadable path is an absence of evidence, not evidence of \
+             absence — got {liveness:?}"
+        );
+        // And the workspace really was alive all along.
+        assert_eq!(workspace_liveness(&wt, true), WorkspaceLiveness::Live);
+    }
+
+    #[test]
+    fn liveness_reports_non_directory_as_absent() {
+        // The other half of the first branch: a successful stat that finds a
+        // FILE is a definite observation, so it stays `Absent` — this is not
+        // collateral damage from making unreadable paths Indeterminate.
+        let base = TempDir::new().unwrap();
+        let file = base.path().join("not-a-dir");
+        fs::write(&file, "x").unwrap();
+
+        let liveness = workspace_liveness(&file, true);
         assert_eq!(liveness, WorkspaceLiveness::Absent);
         assert!(liveness.is_dead());
     }

--- a/crates/trusty-mpm/src/core/workspace_liveness.rs
+++ b/crates/trusty-mpm/src/core/workspace_liveness.rs
@@ -55,6 +55,7 @@
 //! `liveness_reports_gutted_worktree_missing_git`,
 //! `liveness_never_requires_git_for_unowned_non_worktree_path`,
 //! `liveness_reports_absent_directory`, `liveness_indeterminate_is_never_dead`,
+//! `liveness_symlink_loop_is_indeterminate_never_dead`,
 //! `liveness_unreadable_parent_is_indeterminate_never_dead`,
 //! `liveness_reports_non_directory_as_absent`.
 
@@ -165,6 +166,7 @@ impl std::fmt::Display for WorkspaceLiveness {
 /// `liveness_reports_gutted_worktree_missing_git`,
 /// `liveness_never_requires_git_for_unowned_non_worktree_path`,
 /// `liveness_reports_absent_directory`,
+/// `liveness_symlink_loop_is_indeterminate_never_dead`,
 /// `liveness_unreadable_parent_is_indeterminate_never_dead`,
 /// `liveness_reports_non_directory_as_absent`.
 pub fn workspace_liveness(path: &Path, workspace_owned: bool) -> WorkspaceLiveness {
@@ -275,14 +277,76 @@ mod tests {
         assert!(!liveness.is_dead());
     }
 
+    /// The `NotFound` half still means what it always meant.
+    ///
+    /// Why: THE MUTATION KILLER for the fix above. Routing every stat error to
+    /// `Indeterminate` would satisfy both ambiguity tests while making a dead
+    /// verdict unreachable — a liveness guard that can never report death,
+    /// which is the #4204 bug restored. The premise is asserted (the path is
+    /// genuinely absent, not merely unresolvable) so this cannot pass for the
+    /// wrong reason.
+    /// Test: this function IS the test.
     #[test]
     fn liveness_reports_absent_directory() {
         let base = TempDir::new().unwrap();
         let gone = base.path().join("never-existed");
+        assert_eq!(
+            std::fs::metadata(&gone).err().map(|e| e.kind()),
+            Some(std::io::ErrorKind::NotFound),
+            "test premise: the path must be absent, not merely unresolvable"
+        );
 
         let liveness = workspace_liveness(&gone, true);
         assert_eq!(liveness, WorkspaceLiveness::Absent);
         assert!(liveness.is_dead());
+    }
+
+    /// A workspace path that cannot be stat'd for a NON-`NotFound` reason is
+    /// [`WorkspaceLiveness::Indeterminate`] — never `Absent`, never dead.
+    ///
+    /// Why: this is the HIGH from PR #4209's review stated in its most general
+    /// form. `path.is_dir()` threw the error KIND away, mapping
+    /// `PermissionDenied`, `FilesystemLoop`, `NotADirectory` and a stalled
+    /// mount's `ESTALE` to `false` — i.e. to `Absent`, whose `is_dead()` is
+    /// `true` — so any ambiguous filesystem error stopped the caller servicing
+    /// a workspace that was, as far as anyone knew, alive.
+    /// What: a symlink loop, chosen over a permission trick because it produces
+    /// a non-`NotFound` error DETERMINISTICALLY FOR EVERY UID INCLUDING ROOT,
+    /// so this test can never pass vacuously in a privileged container the way
+    /// a `chmod 000` test can. Adapted from
+    /// `session_manager::worktree_integrity_tests::
+    /// symlink_loop_root_is_unknown_not_destroyed` (#3764), which fixed this
+    /// same defect shape in the detection path.
+    /// Test: this function IS the test.
+    #[cfg(unix)]
+    #[test]
+    fn liveness_symlink_loop_is_indeterminate_never_dead() {
+        let base = TempDir::new().unwrap();
+        let a = base.path().join("a");
+        let b = base.path().join("b");
+        std::os::unix::fs::symlink(&b, &a).expect("symlink a -> b");
+        std::os::unix::fs::symlink(&a, &b).expect("symlink b -> a");
+
+        // The premise, asserted rather than assumed.
+        let kind = std::fs::metadata(&a)
+            .expect_err("test premise: a symlink loop must not stat")
+            .kind();
+        assert_ne!(
+            kind,
+            std::io::ErrorKind::NotFound,
+            "test premise: the loop must produce a non-NotFound error kind"
+        );
+
+        let liveness = workspace_liveness(&a, true);
+        assert!(
+            !liveness.is_dead(),
+            "an ambiguous stat failure ({kind:?}) must never be treated as \
+             death; got {liveness:?}"
+        );
+        assert!(
+            matches!(liveness, WorkspaceLiveness::Indeterminate(_)),
+            "got {liveness:?}"
+        );
     }
 
     /// THE CRITIC'S PROBE (PR #4209 review, HIGH). A genuinely LIVE linked


### PR DESCRIPTION
## What

Two independent code paths gated on `workspace_path.is_dir()` alone and then
acted on the directory as if it were live. A worktree whose `.git` and source
tree have been stripped still passes that check, because the directory node
survives.

- `core::agent_reset_workspace::reset_active_workspace_agents` — recomposed
  45 agent files into a gutted worktree's `.claude/agents/`, reached via
  `tm install --reset-agents --reset-agents-workspaces`.
- `bin/tm/commands/guided_inplace::run_inplace_relaunch` — `exec`'d `claude`
  into the dead directory instead of falling through to the picker.

Both now share one predicate, `core::workspace_liveness::workspace_liveness`.

## Why this is not `&& path.join(".git").exists()`

The obvious patch is wrong in both directions, and the new module documents
each trap with a test that catches it:

1. **In a LINKED worktree, `.git` is a FILE, not a directory.** `git worktree
   add` writes a `gitdir:` pointer file, and `WorkspaceProvisioner` creates
   *every* managed workspace that way. A guard spelled
   `.join(".git").is_dir()` would reject every legitimate managed workspace —
   the exact inverse of the bug. The predicate stats the `.git` name and
   accepts a file, a directory, or a symlink.

2. **Not every workspace is owed a `.git`.** A missing marker is evidence of
   death only where one is owed — `workspace_owned || is_session_worktree(path)`,
   deliberately the SAME predicate the #1511 ownership gate already uses rather
   than a third notion. `workspace_owned` means `provision_in` created the
   directory (mandatory `repo_url`, always ends in `worktree_add`), and the
   `.worktrees/<id>` shape is only ever produced by `git worktree add`. Outside
   that, the verdict is `Live`, so an adopted non-git workspace is never
   refused. In `guided_inplace` the resolved path can be `record.cwd` or even
   `current_dir()`, so only the narrow path-shape rule applies there.

3. **A failed observation is not a death.** Permission denied, a stalled
   network mount, or any other I/O error yields `Indeterminate`, and
   `WorkspaceLiveness::is_dead()` returns `false` for it — the invariant is
   encoded in the type so no call site can quietly widen "dead". Silently
   declining to service a live workspace is a far quieter failure than the bug
   being fixed; this is the over-refusal trap PR #4202's round-1 fix fell into.

`path.is_dir()` is kept verbatim as step 1, so the pre-existing "gone / not a
directory" skip has identical semantics and this change adds no new abort paths.

## `is_session_worktree()` — decision: leave it alone

It stays the pure path-shape heuristic it is. It answers *"may trusty-mpm
DELETE this?"* (ownership) on paths that may legitimately be absent —
`is_session_worktree_absent_path_is_noop` pins that — and it backs
`decommission` and `search_gc`. Teaching it about `.git` would make those
paths refuse to clean up the very husks this issue is about, and would change
two unrelated call sites. Ownership and liveness are orthogonal axes;
`workspace_liveness` composes them rather than conflating them.

## Existing helper?

No reusable one exists on `main`. The closest are
`session_launch::worktree_sync::sync_worktree_with_upstream` (`.exists()`, and
its concern is "can I fast-forward this?") and `guided::cwd_owns_git_entry`
(`try_exists().unwrap_or(false)`); both fail CLOSED on an I/O error, which is
exactly the behavior this fix must avoid, and neither models the
owed-a-`.git` expectation rule.
`worktree_integrity.rs` — where PR #4202 is adding classification logic in
this same area — does **not** exist on `main`, so this is implemented locally
rather than depending on unmerged code. **Future consolidation:** once #4202
lands, `worktree_integrity`'s classifier and `core::workspace_liveness` should
be reconciled into a single module; they are the detection and prevention
halves of the same notion.

## Relationship to #4202 and the unattributed writer

This is the **PREVENTION** counterpart to PR #4202's **DETECTION**: #4202
recognises a gutted worktree, this stops the two known writers from acting on
one. They are complementary, not redundant.

**NOT addressed here:** the unattributed 21:28 writer from #4204 — the batch
that touched `settings.json`, `.trusty-mpm-skills-manifest.json`, and
`output-styles/*`. No workspace-wide sweep for skills/settings exists in the
codebase; that writer remains unidentified and this PR makes no claim about it.

## Tests

Each of the first three fails against `main` and passes here; the anti-over-
refusal tests additionally fail against a naive `.join(".git").is_dir()` guard
(verified by temporarily substituting one). No `#[ignore]`, no cfg-gates.

| Test | Proves |
| --- | --- |
| `sweep_skips_gutted_worktree_whose_git_was_stripped` | a gutted worktree is not written into, and is reported with a skip reason |
| `sweep_serves_live_linked_worktree_with_git_file` | a legitimate linked worktree (`.git` as a FILE) IS still served |
| `run_inplace_relaunch_falls_through_on_gutted_worktree` | the relaunch falls through, with the daemon mock at ZERO hits — no exec, no mutation |
| `run_inplace_relaunch_serves_live_linked_worktree` | a live linked worktree still gets past the gate |
| `core::workspace_liveness::tests::*` (6) | the predicate itself, including `liveness_indeterminate_is_never_dead` |

Two pre-existing sweep fixtures used a bare `TempDir` with no `.git`, which
did not model any workspace this code actually serves; they now write the
`gitdir:` pointer file a real worktree carries.

Closes #4204

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
