### PR TITLE
chore(release): tga 2.10.0 + trusty-analyze 0.8.0 + trusty-memory 0.22.0 — clear version-parity drift and a patch-level SemVer break

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11269,7 +11269,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-analyze"
-version = "0.7.5"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -11634,7 +11634,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-memory"
-version = "0.21.3"
+version = "0.22.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10302,7 +10302,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.9.4"
+version = "2.10.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,7 @@ trusty-embedderd = { path = "crates/trusty-embedderd", version = "0.3.10" }
 trusty-bm25-daemon = { path = "crates/trusty-bm25-daemon", version = "0.1.3" }
 # tga: trusty-git-analytics — developer productivity analytics.
 # Referenced by trusty-review for contributor-profile data pipeline (#558).
-tga = { path = "crates/trusty-git-analytics", version = "2.9.4" }
+tga = { path = "crates/trusty-git-analytics", version = "2.10" }
 # trusty-mpm: unified crate (replaces the former trusty-mpm-{core,mcp,client,
 # daemon,cli,tui,telegram} sub-crates). The gui sub-crate is kept separate
 # because it owns Tauri's build.rs and tauri.conf.json.

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- `trusty-memory` requirement raised to `^0.22` (was `^0.21.1`). trusty-memory
+  goes 0.21.3 -> 0.22.0 because it publicly re-exports `trusty_common::palace_id`
+  items and its `trusty-common` requirement moved to `^0.27`; `^0.21.1` resolves
+  to `>=0.21.1, <0.22.0` and would not have admitted the new version. Requirement
+  edit only — this crate's own version is unchanged.
+
 ### Security
 
 - **Defined the L0/L1 persona privilege tier and made the L1->L0 delegation

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -65,7 +65,7 @@ trusty-common = { workspace = true, features = ["mcp", "symgraph-parser", "memor
 #      `default-features = false` drops the `axum-server` feature so we don't
 #      compile the trusty-memory HTTP daemon code paths just to pick up a
 #      zero-sized service descriptor.
-trusty-memory = { path = "../trusty-memory", version = "0.21.1", default-features = false }
+trusty-memory = { path = "../trusty-memory", version = "0.22", default-features = false }
 trusty-search = { path = "../trusty-search", version = "0.40" }
 # Gmail/Calendar eventstream listeners (#3820, DOC-54 SPEC-AGENTS-06) call
 # trusty-gworkspace's connector layer (`api::client::BaseClient` +

--- a/crates/trusty-analyze/CHANGELOG.md
+++ b/crates/trusty-analyze/CHANGELOG.md
@@ -11,13 +11,37 @@ Versions correspond to `Cargo.toml` patch releases.
 
 ---
 
-## [0.7.5] — 2026-07-27
+## [0.8.0] — 2026-07-27
+
+MINOR, not the patch 0.7.5 this was originally staged as (#4177). This crate
+publicly re-exports `trusty-common` types — `src/types/entity.rs:14-15`:
+
+```rust
+pub use trusty_common::symgraph::contracts::EdgeKind;
+pub use trusty_common::symgraph::{fact_hash_str, EntityType, RawEntity};
+```
+
+surfaced unconditionally as `trusty_analyze::types::{EntityType, RawEntity,
+EdgeKind, fact_hash_str}` (`lib.rs:82 pub mod types` → `types/mod.rs:14 pub mod
+entity` → `types/mod.rs:21 pub use entity::{…}`; no `cfg`, and the
+`trusty-common/symgraph` feature is enabled unconditionally). Raising the
+`trusty-common` requirement from `^0.26` to `^0.27` therefore changes the
+*identity* of publicly re-exported types.
+
+At patch level that is a break shipped silently: `^0.7.4` re-resolves
+already-published consumers onto the new type identity, and a consumer that
+also depends on `trusty-common 0.26` directly gets two semver-incompatible
+copies linked at once and mismatched-type errors against
+`trusty_analyze::types::EntityType`. That is bit-for-bit the defect that forced
+the **0.7.3 yank** on this very crate. `^0.7` excludes 0.8.0, so published
+consumers keep resolving to 0.7.4 and stay installable.
 
 ### Changed
 
 - `trusty-common` requirement raised to `^0.27` (was `^0.26`, inherited from
   `[workspace.dependencies]`): 0.27.0 makes `ChatEvent` `#[non_exhaustive]`,
-  which a `^0.26` requirement cannot express.
+  which a `^0.26` requirement cannot express. Because the re-exports above are
+  public, this requirement change is itself the reason for the MINOR level.
 
 ### Fixed
 

--- a/crates/trusty-analyze/Cargo.toml
+++ b/crates/trusty-analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "trusty-analyze"
-version     = "0.7.5"
+version     = "0.8.0"
 edition     = "2021"
 license.workspace    = true
 authors.workspace    = true

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -7,6 +7,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [2.10.0] — 2026-07-27
+
+MINOR, not patch. The JIRA ingestion work (#3966, #4084) landed on `main`
+without a version bump while 2.9.4 was already live on crates.io, so the
+version-parity guard (#3366) went red: 11 files added and 9 modified under a
+published version number. The drift is purely additive but it is *public API*,
+not internals — `tga` auto-detects `src/lib.rs` as a library target, so these
+are real SemVer-relevant additions:
+
+- `collect::errors::CollectError` gained `Throttled`, `IncompleteChangelog`
+  and `PagingBudgetExceeded`, and became `#[non_exhaustive]`.
+- `collect::jira` gained public modules `http`, `jql_time`, `model`, `paging`,
+  `retry`, `sync`, and re-exports `ChangelogIssue`, `ChangelogWalk`,
+  `JiraComment`, `JiraTransition`, `RetryPolicy`.
+- `core::db` gained the public `jira_facts` module and its re-exports.
+- `commands` gained the public `jira` module; `commands::args` gained
+  `JiraSubcommandArgs` / `JiraSubcommand`.
+- `core::config::JiraConfig` gained a `timezone` field.
+
+Nothing was removed and no existing public signature changed, so this is not a
+major bump. The one published consumer, `trusty-review` (optional `profile`
+feature), only constructs `CollectError` through `#[from]` and never matches on
+it exhaustively, so `#[non_exhaustive]` costs it nothing.
+
+No crates are published by this change.
+
 ### Added
 
 - JIRA changelog + comment extraction client, covering issue transition history and per-comment detail (closes [#3966](https://github.com/bobmatnyc/trusty-tools/issues/3966)).

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.9.4"
+version = "2.10.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.91) per #254. Required for

--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -10,12 +10,38 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
-## [0.21.3] — 2026-07-27
+## [0.22.0] — 2026-07-27
+
+MINOR, not the patch 0.21.3 this was originally staged as (#4177). This crate
+publicly re-exports `trusty-common` items — `src/palace_id_derive.rs:19`:
+
+```rust
+pub use trusty_common::palace_id::{
+    derive_palace_id, owner_repo_from_git_remote, palace_override_from_env,
+    parent_dir_slug, PALACE_OVERRIDE_ENV,
+};
+```
+
+The module is declared `pub mod palace_id_derive;` at `lib.rs:140` with no
+`cfg` gate and no feature guard, so the whole shim is unconditional public API.
+Raising the `trusty-common` requirement from `^0.26.2` to `^0.27` changes the
+identity of publicly re-exported items, which at patch level would let `^0.21.2`
+re-resolve already-published consumers onto the new identity — the same shape
+that forced the trusty-analyze 0.7.3 yank. `^0.21` excludes 0.22.0, so
+published consumers keep resolving to 0.21.2 and stay installable.
+
+Consumer pin updated in the same change: `trusty-agents` required
+`trusty-memory = "0.21.1"`, i.e. `^0.21.1` = `>=0.21.1, <0.22.0`, which 0.22.0
+does **not** satisfy — left alone it would have traded one red for another. It
+is now `"0.22"`. `trusty-agents` is unpublished (0.38.6), so this is a
+requirement edit only and its own version is untouched.
 
 ### Changed
 
 - `trusty-common` requirement raised to `^0.27` (was `^0.26.2`): 0.27.0 makes
   `ChatEvent` `#[non_exhaustive]`, which a `^0.26` requirement cannot express.
+  Because the re-exports above are public, this requirement change is itself
+  the reason for the MINOR level.
 
 ### Fixed
 

--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-memory"
-version = "0.21.3"
+version = "0.22.0"
 edition = "2021"
 description = "MCP server (stdio + HTTP/SSE) for trusty-memory"
 license.workspace = true


### PR DESCRIPTION
## Why

`main` is red on **Publish-version parity** (the #3366 guard). The JIRA
ingestion work (#4067 / #4155, closing #3966 and #4084) landed **11 added and
9 modified** files in `crates/trusty-git-analytics` while **2.9.4 was already
live on crates.io**. tga was not part of the six-crate bump wave (#4177), so
nothing corrected it. This predates #4177 — it also failed on `5bf231b9` and
`ada4d351`.

The guard's own stated remedy is to bump `crates/trusty-git-analytics/Cargo.toml`.

## Version level: MINOR (2.10.0), not patch

`tga` has no explicit `[lib]` section, but **`src/lib.rs` exists**, so Cargo
auto-detects a library target — the drift is public API, not internals.
Diffing the local tree against the actual published 2.9.4 tarball, every
public change is **additive**:

| Surface | Change |
|---|---|
| `collect::errors::CollectError` | gained `Throttled`, `IncompleteChangelog`, `PagingBudgetExceeded`; became `#[non_exhaustive]` |
| `collect::jira` | new pub modules `http`, `jql_time`, `model`, `paging`, `retry`, `sync`; re-exports `ChangelogIssue`, `ChangelogWalk`, `JiraComment`, `JiraTransition`, `RetryPolicy` |
| `core::db` | new pub module `jira_facts` + re-exports |
| `commands` | new pub module `jira`; `commands::args` gained `JiraSubcommandArgs`, `JiraSubcommand` |
| `core::config::JiraConfig` | gained a `timezone` field |

Shipping this as **2.9.5 is bit-for-bit the shape that forced the
trusty-analyze 0.7.3 yank** — `^2.9.4` would re-resolve already-published
consumers onto a changed public surface. `^2.9` still admits 2.10.0, but the
version number now truthfully signals the surface grew.

**Not major:** the published-vs-local diff contains **zero `-` lines touching a
`pub` item** — nothing removed, nothing re-signatured.

## `#[non_exhaustive]` check

Already applied where warranted. `CollectError` **and** `ChangelogIssue` both
gained it in #4084, so no further hardening is needed in this PR. The one
published consumer, `trusty-review` (optional `profile` feature), reaches
`CollectError` only through a `#[from]` variant at
`crates/trusty-review/src/profile/error.rs:55` and never matches it
exhaustively. There is **no exhaustive `match` on `CollectError` anywhere
outside tga**, so the attribute costs consumers nothing.

## Dependent pin

`trusty-review` is the only in-workspace consumer. The
`[workspace.dependencies]` entry moves `"2.9.4"` -> `"2.10"`, matching the pin
style #4177 used for its MINOR bumps (`trusty-common "0.27"`,
`trusty-review "0.11"`). `^2.9.4` would already have admitted 2.10.0, so this
breaks no resolution — it keeps the manifest honest. Consumers stay
resolvable; this does not trade one red for another.

## Lockfile

**Deliberately NOT refreshed.** No `cargo update`. The delta is **exactly 2
lines** — the single `tga` version string:

```
 [[package]]
 name = "tga"
-version = "2.9.4"
+version = "2.10.0"
```

No third-party churn, no MSRV movement (the trap that turned the MSRV leg red
on installer 0.4.10).

Full diffstat — 4 files, +30/-3:

```
 Cargo.lock                               |  2 +-
 Cargo.toml                               |  2 +-
 crates/trusty-git-analytics/CHANGELOG.md | 27 +++++++++++++++++++++++++++
 crates/trusty-git-analytics/Cargo.toml   |  2 +-
```

## Verification

`Version parity` is `push: [main]` + `workflow_dispatch` only — it has **no
`pull_request` trigger** (by design: it compares against the live registry, so
it is only meaningful for what landed on main). It therefore cannot appear in
this PR's check rollup. Verified by running the identical guard locally from
this branch:

```
$ bash scripts/check-version-parity.sh
[ OK ] tga 2.10.0 — not yet published, nothing to compare
publish-guard: checked 21 publishable crate(s) — 0 drifted, 0 unverifiable.
publish-guard: OK — no version-parity drift detected.
$ echo $?
0
```

`cargo metadata --locked` exits 0, proving Cargo.lock is consistent with the
edited manifests (it would fail with "lock file needs to be updated"
otherwise).

Confirmed before choosing the number: crates.io `max_version` for `tga` is
`2.9.4`, `2.10.0` is unpublished, and no `2.10.0` tag exists locally or on
origin — so this is not working around a registry or tag collision.

## Publishing

**Nothing is published by this PR.** No `cargo publish`, not even
`--dry-run`, and no release tags. The publish chain remains deferred.


---

# Scope extension: two more version corrections (patch-level SemVer break staged by #4177)

An independent verification of the just-merged #4177 found a latent break of the
**same shape as the one that forced the trusty-analyze 0.7.3 yank**. Folded in
here since this PR is already editing version numbers.

**The problem:** #4177 staged `trusty-analyze` at **0.7.5** and `trusty-memory`
at **0.21.3** — both PATCH — while moving each crate's `trusty-common`
requirement from `^0.26` to `^0.27`. Both crates **publicly re-export
trusty-common types**, so that requirement change alters the identity of their
own public API. A breaking change shipped at patch level.

## I verified both re-export sites myself — both are genuinely public

**`trusty-analyze` — `crates/trusty-analyze/src/types/entity.rs:14-15`**

```rust
pub use trusty_common::symgraph::contracts::EdgeKind;
pub use trusty_common::symgraph::{fact_hash_str, EntityType, RawEntity};
```

Reachable unconditionally as `trusty_analyze::types::{EntityType, RawEntity, …}`:
`lib.rs:82 pub mod types` → `types/mod.rs:14 pub mod entity` → `types/mod.rs:21
pub use entity::{fact_hash_str, EdgeKind, EntityType, RawEntity}`.

> Worth calling out, since this was the one plausible "it's actually gated"
> escape: `lib.rs:80` does carry `#[cfg(feature = "http-server")]` — but it
> gates `pub mod service;` on line **81**, not `pub mod types;` on line **82**.
> No cfg on `types` or `entity`. The `trusty-common/symgraph` feature is also
> enabled unconditionally by trusty-analyze's own dep line, so the types are
> always present.

**`trusty-memory` — `crates/trusty-memory/src/palace_id_derive.rs:19`**

```rust
pub use trusty_common::palace_id::{
    derive_palace_id, owner_repo_from_git_remote, palace_override_from_env,
    parent_dir_slug, PALACE_OVERRIDE_ENV,
};
```

Declared `pub mod palace_id_derive;` at `lib.rs:140` — no cfg, no feature guard.
The entire shim is unconditional public API.

**Confirmed. Both bumped to MINOR:**

| Crate | Was (staged by #4177) | Now |
|---|---|---|
| `trusty-analyze` | 0.7.5 (patch) | **0.8.0** |
| `trusty-memory` | 0.21.3 (patch) | **0.22.0** |

`^0.7` excludes 0.8.0 and `^0.21` excludes 0.22.0, so already-published
consumers keep resolving to trusty-analyze 0.7.4 / trusty-memory 0.21.2 and stay
installable. At patch level, `^0.7.4` / `^0.21.2` would have re-resolved them
onto the new type identity; a consumer also depending on trusty-common 0.26
directly would link two semver-incompatible copies and fail to compile.

## A dependent pin the bump WOULD have broken

`crates/trusty-agents/Cargo.toml:68` required:

```toml
trusty-memory = { path = "../trusty-memory", version = "0.21.1", … }
```

`^0.21.1` resolves to `>=0.21.1, <0.22.0` — which **0.22.0 does not satisfy**.
Left alone this would have traded one red for another. Updated to `"0.22"`.
`trusty-agents` is unpublished (0.38.6), so this is a requirement edit only and
its own version is untouched — matching how #4177 handled
trusty-agents/gworkspace. **Nothing pins `trusty-analyze` anywhere in the
workspace.**

## Zero registry consequence

crates.io `max_version` is **0.7.4** for trusty-analyze and **0.21.2** for
trusty-memory — neither 0.7.5 nor 0.21.3 was ever published. This is pure
version-string editing; after a publish it would have needed a yank. No 0.8.0 or
0.22.0 tags exist on origin.

## Updated totals

**Cargo.lock: 6 changed lines across all three crates** — the version strings
only, nothing else:

```
-version = "2.9.4"     +version = "2.10.0"    # tga
-version = "0.7.5"     +version = "0.8.0"     # trusty-analyze
-version = "0.21.3"    +version = "0.22.0"    # trusty-memory
```

No `cargo update`, no third-party churn, no MSRV movement.

Re-verified from this branch after the extension:

```
$ bash scripts/check-version-parity.sh
[ OK ] trusty-analyze 0.8.0 — not yet published, nothing to compare
[ OK ] tga 2.10.0 — not yet published, nothing to compare
[ OK ] trusty-memory 0.22.0 — not yet published, nothing to compare
publish-guard: checked 21 publishable crate(s) — 0 drifted, 0 unverifiable.
publish-guard: OK — no version-parity drift detected.
$ echo $?
0
```

`cargo metadata --locked` exits 0, which is also what proves the `trusty-agents`
pin edit resolves.

**Still nothing published — no `cargo publish`, no `--dry-run`, no tags.**

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
