### PR TITLE
feat(trusty-agents): Sub-agents configuration section — union of both delegation mechanisms

### DIFF
--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -712,6 +712,57 @@ pub enum AgentTier {
     L0Orchestration,
 }
 
+impl AgentTier {
+    /// Resolve a RAW declared tier string, fail-closed (#4168; extracted #4029).
+    ///
+    /// Why: [`AgentInfo::tier`] was the only place this normalization lived,
+    /// which meant any consumer holding a declared tier string WITHOUT a full
+    /// [`AgentInfo`] — `GET /api/agents/:name/subagents` (#4029) reporting the
+    /// delegation targets the #4169 gate would actually admit is the first —
+    /// had to hand-roll the match and could silently drift from the gate. A
+    /// privilege boundary must have exactly one parser: if this function and
+    /// the gate ever disagreed, the config surface would advertise a target
+    /// the gate refuses (or hide one it allows), which is the whole failure
+    /// class #4029 exists to avoid. `AgentInfo::tier()` now delegates here, so
+    /// there is still only one match in the codebase.
+    /// What: Case-insensitive, trimmed match against `"l0"`/`"orchestration"`
+    /// (-> [`AgentTier::L0Orchestration`]); EVERYTHING else — `None`, blank, or
+    /// an unrecognized string — resolves to [`AgentTier::L1Standard`]. Byte-for
+    /// byte the behavior `AgentInfo::tier()` shipped in #4200, which its own
+    /// unchanged tests still pin.
+    /// Test: `agent_tier_defaults_to_l1_when_absent`,
+    /// `agent_tier_parses_l0_orchestration_aliases`,
+    /// `agent_tier_parses_l1_standard_aliases`,
+    /// `agent_tier_unknown_value_fails_closed_to_l1`,
+    /// `agent_tier_blank_value_fails_closed_to_l1`,
+    /// `agent_tier_from_declared_matches_agent_info_tier`.
+    pub fn from_declared(raw: Option<&str>) -> Self {
+        match raw.map(str::trim) {
+            Some(s) if s.eq_ignore_ascii_case("l0") || s.eq_ignore_ascii_case("orchestration") => {
+                AgentTier::L0Orchestration
+            }
+            _ => AgentTier::L1Standard,
+        }
+    }
+
+    /// The canonical lowercase wire label for this tier (`"l0"` / `"l1"`).
+    ///
+    /// Why: `GET /api/agents/:name/subagents` (#4029) reports both the
+    /// delegator's and each target's resolved tier, and a JSON consumer must
+    /// not have to parse `Debug` output (`"L0Orchestration"`) or re-derive the
+    /// alias set. Returning the SHORT alias — not the long one — keeps the wire
+    /// value identical to what an operator writes in `tier = "l0"`.
+    /// What: `"l0"` for [`AgentTier::L0Orchestration`], `"l1"` for
+    /// [`AgentTier::L1Standard`]. Round-trips through [`Self::from_declared`].
+    /// Test: `agent_tier_wire_label_round_trips_through_from_declared`.
+    pub fn wire_label(self) -> &'static str {
+        match self {
+            AgentTier::L0Orchestration => "l0",
+            AgentTier::L1Standard => "l1",
+        }
+    }
+}
+
 impl AgentInfo {
     /// Resolve this agent's privilege tier, fail-closed (#4168).
     ///
@@ -729,13 +780,14 @@ impl AgentInfo {
     /// `agent_tier_parses_l1_standard_aliases`,
     /// `agent_tier_unknown_value_fails_closed_to_l1`,
     /// `agent_tier_blank_value_fails_closed_to_l1`.
+    ///
+    /// #4029: the match itself moved to [`AgentTier::from_declared`] so a
+    /// consumer holding only the raw declared string (the `/subagents` route,
+    /// which must report exactly the targets the #4169 gate admits) shares this
+    /// one parser instead of hand-rolling a second one. Behavior is unchanged —
+    /// the tests above are the proof and were not touched.
     pub fn tier(&self) -> AgentTier {
-        match self.tier.as_deref().map(str::trim) {
-            Some(s) if s.eq_ignore_ascii_case("l0") || s.eq_ignore_ascii_case("orchestration") => {
-                AgentTier::L0Orchestration
-            }
-            _ => AgentTier::L1Standard,
-        }
+        AgentTier::from_declared(self.tier.as_deref())
     }
 
     /// The human-facing speaker label for this persona (#3738).

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -10,7 +10,7 @@
 pub(crate) mod loading;
 mod params;
 
-use crate::agents::{AgentConfig, ToolsConfig};
+use crate::agents::{AgentConfig, AgentInfo, ToolsConfig};
 
 #[test]
 fn llm_params_parses_model_override() {
@@ -763,4 +763,66 @@ fn agent_tier_default_trait_is_l1_standard() {
         crate::agents::AgentTier::default(),
         crate::agents::AgentTier::L1Standard
     );
+}
+
+// #4029: `AgentTier::from_declared` extracted `AgentInfo::tier()`'s match so
+// the `/api/agents/:name/subagents` route — which must report exactly the
+// targets #4169's gate admits — shares ONE parser with the gate instead of
+// hand-rolling a second one. These two tests exist to make that extraction a
+// pinned equivalence rather than an assumed one.
+
+#[test]
+fn agent_tier_from_declared_matches_agent_info_tier() {
+    // Every alias and every fail-closed case the tests above cover, asserted to
+    // produce the IDENTICAL result through both entry points. If the two ever
+    // diverge, the config surface starts advertising a target the delegation
+    // gate refuses (or hiding one it allows).
+    for raw in [
+        None,
+        Some(""),
+        Some("   "),
+        Some("l0"),
+        Some("L0"),
+        Some("  l0  "),
+        Some("orchestration"),
+        Some("Orchestration"),
+        Some("l1"),
+        Some("standard"),
+        Some("orchestrator"),
+        Some("l2"),
+        Some("yolo"),
+    ] {
+        let via_info = AgentInfo {
+            tier: raw.map(str::to_string),
+            ..toml::from_str::<AgentConfig>(&agent_toml_with_tier(""))
+                .expect("parses")
+                .agent
+        }
+        .tier();
+        assert_eq!(
+            crate::agents::AgentTier::from_declared(raw),
+            via_info,
+            "from_declared({raw:?}) must equal AgentInfo::tier() for the same raw value"
+        );
+    }
+}
+
+#[test]
+fn agent_tier_wire_label_round_trips_through_from_declared() {
+    for tier in [
+        crate::agents::AgentTier::L0Orchestration,
+        crate::agents::AgentTier::L1Standard,
+    ] {
+        assert_eq!(
+            crate::agents::AgentTier::from_declared(Some(tier.wire_label())),
+            tier,
+            "the wire label the API emits must parse back to the same tier"
+        );
+    }
+    assert_eq!(
+        crate::agents::AgentTier::L0Orchestration.wire_label(),
+        "l0",
+        "the SHORT alias is the wire value, matching what an operator writes"
+    );
+    assert_eq!(crate::agents::AgentTier::L1Standard.wire_label(), "l1");
 }

--- a/crates/trusty-agents/src/api/server/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/agent_subagents.rs
@@ -1,0 +1,550 @@
+//! `GET /api/agents/:name/subagents` — the Sub-agents configuration section
+//! (#4029, epic #4021 OQ-5): the UNION of the two delegation mechanisms an
+//! agent may reach, each labelled by kind, never flattened together.
+//!
+//! Why: OQ-5 was resolved by the owner on 2026-07-26 — *"Sub-agents is its own
+//! configuration section"* — and on 2026-07-27 the owner further required that
+//! the section show BOTH delegation mechanisms, which the specs had never
+//! reconciled. Neither was exposed over any API route: `parse_agent_toml`
+//! (`super::projects`) enumerates twelve `[agent]`/`[tools]` fields and
+//! `subagents` is not among them, so a Svelte pane alone could only have
+//! guessed. The two mechanisms are genuinely different things with different
+//! enforcement points, different failure polarities and a non-overlapping
+//! target vocabulary, so the payload keeps them apart:
+//!
+//! - **`in_product`** — `delegate_to_agent` (`crate::tools::delegate`),
+//!   trusty-agents → trusty-agents, in-process peer/worker delegation. Its
+//!   target set is NOT per-agent config at all: it is the hardcoded
+//!   `runtime::tool_registry::ASSISTANT_ALLOWED_DELEGATE_ROLES` role allowlist
+//!   applied to whatever resolves out of `agents::agents_dir_candidates()`,
+//!   further narrowed by #4169's one-directional L0/L1 tier gate. The role
+//!   `documentation` exists ONLY here — it is in no other allow-set in the
+//!   codebase.
+//! - **`cross_product`** — `dispatch_task` (`crate::tools::pm_bridge`),
+//!   trusty-agents → trusty-code, out-of-process specialist dispatch. This one
+//!   DOES have a per-agent TOML binding: the optional `[subagents]` section
+//!   (`agents::config::SubagentsConfig`), intersected with the bridge's own
+//!   `NON_CODING_TARGETS` floor by `SubagentAllowSet` — fail-closed per OQ-7,
+//!   with an absent section granting NOTHING.
+//!
+//! **Honesty rules this route holds to.** Every one exists because the
+//! alternative is a config pane that advertises a capability the enforcement
+//! layer refuses:
+//!
+//! - **No second copy of any gate.** Reachability is computed by calling the
+//!   SAME code the enforcement points call: `SubagentAllowSet::resolve` for the
+//!   cross-product half (so the pane can never disagree with the bridge — the
+//!   OQ-7 requirement stated in #4029), and, for the in-product half, the same
+//!   `AgentConfig::by_name_in` resolution + `ASSISTANT_ALLOWED_DELEGATE_ROLES`
+//!   membership + `AgentInfo::tier()` comparison that
+//!   `DelegateToAgentTool::execute`'s pre-flight check performs, in that order.
+//! - **The tier gate is reflected, not re-litigated (#4169, epic #4167).** A
+//!   target that resolves to `AgentTier::L0Orchestration` is reported
+//!   `reachable: false` for any delegator that is not itself L0. This route
+//!   changes no gate and grants nothing; it only refuses to advertise what the
+//!   gate would refuse.
+//! - **Registered ≠ granted.** `delegate_to_agent` is only registered for
+//!   `role == ASSISTANT_TIER_ROLE` (`build_registry_for_agent`), and even then
+//!   dispatch is gated by the agent's own resolved tool patterns. Both facts
+//!   are reported separately (`tool_registered` / `tool_granted`) rather than
+//!   collapsed into one green tick.
+//! - **Fail-closed on unresolvable config.** When the agent's own config cannot
+//!   be resolved the response is `200` with `resolved: false`, a `config_error`
+//!   and EMPTY target lists — never a guess assembled from a partial parse. An
+//!   agent whose config does not resolve does not run, so "it may delegate to
+//!   nothing" is the truthful answer as well as the safe one.
+//! - **The roster is not dumped.** Only role-ELIGIBLE agents become target
+//!   cards; everything else is counted (`role_excluded_count`), never named,
+//!   preserving the #3052 PR A CRITICAL-2 posture that the delegation surface
+//!   does not enumerate internal agent ids.
+//!
+//! What: [`agent_subagents_route`] is the axum shim; [`subagents_at`] is the
+//! testable core. Unlike its four sibling section routes this one resolves
+//! through `AgentConfig::by_name_in` rather than a partial `toml::from_str`,
+//! because the gate it must mirror does exactly that — which also means this
+//! route DOES see `extends` (the documented gap in `/skills`, `/knowledge` and
+//! `/permissions` is absent here).
+//!
+//! DOC-57 (`docs/specs/agent-config-five-sections.md`) still documents five
+//! sections and is amended by #4182, deliberately NOT by this change.
+//! Test: `super::tests::agent_subagents`.
+
+use std::path::PathBuf;
+
+use axum::{
+    Json,
+    extract::{Path as AxumPath, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde_json::{Value, json};
+
+use super::agent_patch::resolve_agent_paths;
+use super::state::AppState;
+use crate::agents::{AgentConfig, AgentTier};
+use crate::ctrl::pm_task::match_any_glob;
+use crate::runtime::tool_registry::{ASSISTANT_ALLOWED_DELEGATE_ROLES, ASSISTANT_TIER_ROLE};
+use crate::skills::manifest::{SkillCatalog, effective_tool_patterns};
+use crate::tools::cross_product::{NON_CODING_TARGETS, SubagentAllowSet, TargetDenied};
+
+/// The in-product delegation tool this section reports on.
+const DELEGATE_TOOL: &str = "delegate_to_agent";
+/// The cross-product delegation tool this section reports on.
+const DISPATCH_TOOL: &str = "dispatch_task";
+
+/// `GET /api/agents/:name/subagents` — HTTP entry point.
+///
+/// Why/What: see the module doc. Resolution roots mirror the sibling section
+/// routes (`agent_knowledge_route`, `agent_skills_route`): the agent search
+/// path is `agents::agents_dir_candidates()` — the exact multi-tier list
+/// `delegate_to_agent`'s pre-flight check and the real spawn both use — and the
+/// skill-source root is the project CWD.
+/// Test: `super::tests::agent_subagents::subagents_route_is_wired_into_router`.
+pub(super) async fn agent_subagents_route(
+    State(_state): State<AppState>,
+    AxumPath(name): AxumPath<String>,
+) -> Response {
+    let project_root = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    subagents_at(
+        &crate::agents::agents_dir_candidates(),
+        &name,
+        &project_root,
+    )
+    .await
+}
+
+/// Core sub-agent resolution against explicit dirs/roots.
+///
+/// Why: Same testability rationale as `agent_knowledge::knowledge_at` — the
+/// union logic, the tier interaction and the fail-closed cross-product default
+/// must be exercisable against a `tempfile::TempDir` roster without an HTTP
+/// server or the developer's real `~/.trusty-agents/agents/`.
+/// What: `400` for an invalid name, `404` for an unknown agent. Anything else
+/// is `200`: an unresolvable config degrades to `resolved: false` plus empty
+/// target lists and a `config_error` (see the module doc's fail-closed rule),
+/// never a `500` and never a partial-parse guess.
+/// Test: `subagents_route_reports_both_mechanisms_for_an_assistant`,
+/// `subagents_route_hides_l0_target_from_l1_delegator`,
+/// `subagents_route_shows_l0_target_to_l0_delegator`,
+/// `subagents_route_cross_product_denies_everything_without_the_section`,
+/// `subagents_route_unknown_agent_404`,
+/// `subagents_route_rejects_traversal_name`,
+/// `subagents_route_degrades_on_malformed_toml`.
+pub(super) async fn subagents_at(
+    dirs: &[PathBuf],
+    name: &str,
+    project_root: &std::path::Path,
+) -> Response {
+    if name.is_empty() || name.contains(['/', '\\']) || name == "." || name == ".." {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "invalid agent name" })),
+        )
+            .into_response();
+    }
+    if resolve_agent_paths(dirs, name).is_none() {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(json!({ "error": "unknown agent", "name": name })),
+        )
+            .into_response();
+    }
+
+    // Fail-closed: the gate this route mirrors resolves through
+    // `by_name_in`, so an agent this call cannot resolve is an agent that
+    // cannot delegate anywhere (it cannot even run). Reporting empty sets plus
+    // the parse error is both the honest and the safe answer — see the module
+    // doc. Deliberately NOT a partial `toml::from_str` fallback: reading
+    // `[subagents]` out of a file whose `[agent]` table failed to parse would
+    // report grants against an identity we could not establish.
+    let cfg = match AgentConfig::by_name_in(dirs, name) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            tracing::warn!(agent = name, error = %format!("{e:#}"), "subagents_at: config did not resolve");
+            return (
+                StatusCode::OK,
+                Json(json!({
+                    "resolved": false,
+                    "in_product": empty_in_product(),
+                    "cross_product": empty_cross_product(),
+                    "config_error": format!("{e:#}"),
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    // The agent's resolved tool-pattern surface, computed exactly as the
+    // Knowledge/Skills panes compute it (`[tools].allow` ∪ expanded
+    // `[skills].allow`), so "is this delegation tool actually granted" is
+    // answered by the same matcher the dispatch gate uses rather than by
+    // eyeballing the allow-list.
+    let catalog =
+        SkillCatalog::builtin().with_authored(crate::skills::manifest::authored::load_from_paths(
+            &crate::skills::sources::SkillSourceRegistry::load(project_root).resolved_paths(),
+        ));
+    let (patterns, _unresolved) = effective_tool_patterns(
+        cfg.tools.allow.as_ref(),
+        cfg.skills.allow.as_ref(),
+        &catalog,
+    );
+    let grants = |tool: &str| patterns.as_deref().is_some_and(|p| match_any_glob(tool, p));
+
+    let in_product = in_product_surface(dirs, name, &cfg, grants(DELEGATE_TOOL)).await;
+    let cross_product =
+        cross_product_surface(cfg.subagents.allowed.as_deref(), grants(DISPATCH_TOOL));
+
+    (
+        StatusCode::OK,
+        Json(json!({
+            "resolved": true,
+            "in_product": in_product,
+            "cross_product": cross_product,
+        })),
+    )
+        .into_response()
+}
+
+/// The `in_product` half: `delegate_to_agent`'s reachable target set for this
+/// agent, reflecting BOTH the role allowlist and #4169's tier gate.
+///
+/// Why: this mechanism has no per-agent config to read, so the only honest
+/// source is the gate's own inputs. Every candidate is resolved with
+/// `AgentConfig::by_name_in` — the identical call
+/// `DelegateToAgentTool::execute` makes — and then subjected to the identical
+/// two checks in the identical order: `ASSISTANT_ALLOWED_DELEGATE_ROLES`
+/// membership on the target's resolved `role`, and the tier comparison
+/// (`target == L0Orchestration && delegator != L0Orchestration` ⇒ refused).
+/// A candidate that fails to resolve is reported as such rather than dropped,
+/// because the gate refuses those too (`Err` ⇒ `rejected`) and a target that
+/// silently vanished from the pane looks identical to one that was never
+/// declared.
+/// What: `{mechanism, tool, tool_registered, tool_granted, delegator_tier,
+/// allowed_roles, targets, role_excluded_count, unresolved}`. `targets` carries
+/// only role-eligible agents (see the module doc's no-roster-dump rule), each
+/// with `reachable` plus a `reason` when refused. The agent itself is excluded:
+/// self-delegation is not a configuration surface.
+/// Test: `subagents_route_reports_both_mechanisms_for_an_assistant`,
+/// `subagents_route_hides_l0_target_from_l1_delegator`,
+/// `subagents_route_shows_l0_target_to_l0_delegator`,
+/// `subagents_route_reports_tool_not_registered_for_a_worker_role`,
+/// `subagents_route_reports_unresolvable_target_rather_than_dropping_it`.
+async fn in_product_surface(
+    dirs: &[PathBuf],
+    self_name: &str,
+    cfg: &AgentConfig,
+    tool_granted: bool,
+) -> Value {
+    let delegator_tier = cfg.agent.tier();
+    let mut targets: Vec<Value> = Vec::new();
+    let mut unresolved: Vec<Value> = Vec::new();
+    let mut role_excluded_count: usize = 0;
+
+    for entry in super::projects::scan_agent_catalog(dirs).await {
+        let Some(candidate) = entry.get("name").and_then(Value::as_str) else {
+            continue;
+        };
+        if candidate.eq_ignore_ascii_case(self_name) {
+            continue;
+        }
+        match AgentConfig::by_name_in(dirs, candidate) {
+            Ok(target) => {
+                if !ASSISTANT_ALLOWED_DELEGATE_ROLES.contains(&target.agent.role.as_str()) {
+                    role_excluded_count += 1;
+                    continue;
+                }
+                let target_tier = target.agent.tier();
+                let tier_blocked = target_tier == AgentTier::L0Orchestration
+                    && delegator_tier != AgentTier::L0Orchestration;
+                targets.push(json!({
+                    "name": target.agent.name,
+                    "display_name": target.agent.display_label(),
+                    "role": target.agent.role,
+                    "tier": target_tier.wire_label(),
+                    "reachable": !tier_blocked,
+                    "reason": if tier_blocked {
+                        Some(format!(
+                            "refused by the L0/L1 delegation gate: this agent is tier \
+                             {} and may not delegate into an L0-orchestration target \
+                             (#4169) — privilege cannot be acquired via delegation",
+                            delegator_tier.wire_label(),
+                        ))
+                    } else {
+                        None
+                    },
+                }));
+            }
+            Err(e) => unresolved.push(json!({
+                "name": candidate,
+                "reason": format!(
+                    "config did not resolve, so the delegation pre-flight check \
+                     refuses it: {e:#}"
+                ),
+            })),
+        }
+    }
+    targets.sort_by(|a, b| {
+        a["name"]
+            .as_str()
+            .unwrap_or_default()
+            .cmp(b["name"].as_str().unwrap_or_default())
+    });
+
+    json!({
+        "mechanism": "in_product",
+        "tool": DELEGATE_TOOL,
+        // `build_registry_for_agent` routes ONLY `role == "assistant"` into
+        // `build_assistant_tier_registry`, the one branch that registers
+        // `delegate_to_agent` with the role allowlist and the tier gate. A
+        // worker-role agent never gets the tool at all, so reporting its
+        // theoretical targets as reachable would be a fabrication.
+        "tool_registered": cfg.agent.role == ASSISTANT_TIER_ROLE,
+        "tool_granted": tool_granted,
+        "delegator_tier": delegator_tier.wire_label(),
+        "allowed_roles": ASSISTANT_ALLOWED_DELEGATE_ROLES,
+        "targets": targets,
+        "role_excluded_count": role_excluded_count,
+        "unresolved": unresolved,
+    })
+}
+
+/// The `cross_product` half: `dispatch_task`'s reachable specialist set,
+/// resolved through the bridge's OWN allow-set (OQ-7).
+///
+/// Why: #4029's test requirement is explicit — the pane must show "exactly the
+/// cross-product targets it is permitted to call, sourced from the same
+/// allow-set the bridge enforces … never a client-side list that can drift from
+/// what the bridge actually allows." So this calls
+/// [`SubagentAllowSet::resolve`] itself rather than re-implementing the
+/// intersection. Every floor target is listed with its grant state (the
+/// `/skills` precedent: report the whole vocabulary, not only the granted
+/// subset) so a denied specialist carries a reason instead of being invisible.
+/// What: `{mechanism, tool, tool_granted, declares_allowed, bridge_floor,
+/// targets, rejected}`. `declares_allowed` distinguishes "no `[subagents]`
+/// section" from "an empty one" for display purposes only — both grant nothing
+/// (`SubagentsConfig`'s doc comment makes that non-load-bearing). `rejected`
+/// carries declared names the bridge floor refuses, which is the one way a
+/// hand-written `[subagents].allowed` can silently do nothing.
+/// The #4169 tier gate is deliberately NOT applied here: it lives in
+/// `delegate_to_agent`, has no counterpart in the tcode bridge, and inventing
+/// one on this read path would report a restriction nothing enforces.
+///
+/// Takes the declared list rather than the whole `AgentConfig` so the union
+/// logic is unit-testable without constructing a full config (which requires
+/// `[agent]`/`[llm]`/`[system_prompt]` tables that have nothing to do with
+/// delegation).
+/// Test: `cross_product_surface_denies_everything_when_nothing_is_declared`,
+/// `cross_product_surface_grants_only_the_declared_floor_target`,
+/// `cross_product_surface_rejects_a_declared_coding_target`,
+/// `subagents_route_cross_product_denies_everything_without_the_section`,
+/// `subagents_route_cross_product_grants_a_declared_floor_target`.
+fn cross_product_surface(declared: Option<&[String]>, tool_granted: bool) -> Value {
+    let allow_set = SubagentAllowSet::from_allowed(declared);
+
+    let targets: Vec<Value> = NON_CODING_TARGETS
+        .iter()
+        .map(|floor_name| {
+            let outcome = allow_set.resolve(floor_name);
+            json!({
+                "name": floor_name,
+                "granted": outcome.is_ok(),
+                "reason": match &outcome {
+                    Ok(_) => None,
+                    // The bridge's own `TargetDenied: Display` is deliberately
+                    // generic ("not available to this agent") so a black-boxed
+                    // persona cannot probe the floor list. This is an
+                    // operator-facing config pane that already reports
+                    // `bridge_floor` in full, so it states the actionable
+                    // reason instead — the DECISION still comes from
+                    // `resolve()` above, only the wording is local.
+                    Err(TargetDenied::NotGranted(_)) => Some(
+                        "not listed in this agent's [subagents].allowed — absent or \
+                         unlisted denies (OQ-7, fail-closed)"
+                            .to_string(),
+                    ),
+                    Err(other) => Some(other.to_string()),
+                },
+            })
+        })
+        .collect();
+
+    let rejected: Vec<Value> = declared
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|raw| {
+            let normalized = raw.trim().to_ascii_lowercase();
+            match allow_set.resolve(raw) {
+                Ok(_) => None,
+                // `NotGranted` is unreachable for a name this agent itself
+                // declared, so anything left is the floor refusing it.
+                Err(TargetDenied::Blank) => Some(json!({
+                    "name": raw,
+                    "reason": TargetDenied::Blank.to_string(),
+                })),
+                Err(_) => Some(json!({
+                    "name": normalized,
+                    "reason": "not a permitted non-coding specialist — the bridge floor \
+                               (NON_CODING_TARGETS) hard-denies it regardless of this \
+                               declaration (OQ-7)",
+                })),
+            }
+        })
+        .collect();
+
+    json!({
+        "mechanism": "cross_product",
+        "tool": DISPATCH_TOOL,
+        "tool_granted": tool_granted,
+        "declares_allowed": declared.is_some(),
+        "bridge_floor": NON_CODING_TARGETS,
+        "targets": targets,
+        "rejected": rejected,
+    })
+}
+
+/// The `in_product` payload for an agent whose config did not resolve — empty,
+/// with the mechanism vocabulary still present so the pane renders its shell.
+fn empty_in_product() -> Value {
+    json!({
+        "mechanism": "in_product",
+        "tool": DELEGATE_TOOL,
+        "tool_registered": false,
+        "tool_granted": false,
+        "delegator_tier": AgentTier::default().wire_label(),
+        "allowed_roles": ASSISTANT_ALLOWED_DELEGATE_ROLES,
+        "targets": Vec::<Value>::new(),
+        "role_excluded_count": 0,
+        "unresolved": Vec::<Value>::new(),
+    })
+}
+
+/// The `cross_product` payload for an agent whose config did not resolve —
+/// every floor target denied, matching the fail-closed default.
+fn empty_cross_product() -> Value {
+    json!({
+        "mechanism": "cross_product",
+        "tool": DISPATCH_TOOL,
+        "tool_granted": false,
+        "declares_allowed": false,
+        "bridge_floor": NON_CODING_TARGETS,
+        "targets": NON_CODING_TARGETS
+            .iter()
+            .map(|n| json!({
+                "name": n,
+                "granted": false,
+                "reason": "this agent's config could not be resolved, so no grant could \
+                           be read (fail-closed)",
+            }))
+            .collect::<Vec<Value>>(),
+        "rejected": Vec::<Value>::new(),
+    })
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    /// The empty/degraded payloads must agree with the real ones on the
+    /// mechanism vocabulary — a pane keying off `mechanism`/`bridge_floor`
+    /// would otherwise blank out on a config error instead of rendering the
+    /// denial.
+    #[test]
+    fn empty_payloads_carry_the_same_vocabulary_and_deny_everything() {
+        let ip = empty_in_product();
+        assert_eq!(ip["mechanism"], "in_product");
+        assert_eq!(ip["tool"], DELEGATE_TOOL);
+        assert_eq!(ip["tool_registered"], false);
+        assert_eq!(ip["delegator_tier"], "l1", "fail-closed to the L1 default");
+        assert!(ip["targets"].as_array().unwrap().is_empty());
+
+        let cp = empty_cross_product();
+        assert_eq!(cp["mechanism"], "cross_product");
+        assert_eq!(cp["tool"], DISPATCH_TOOL);
+        let targets = cp["targets"].as_array().unwrap();
+        assert_eq!(targets.len(), NON_CODING_TARGETS.len());
+        assert!(targets.iter().all(|t| t["granted"] == false));
+    }
+
+    /// `cross_product_surface` must derive its grant decision from
+    /// `SubagentAllowSet::resolve`, so an absent `[subagents]` section denies
+    /// every floor target — the OQ-7 deny-by-default posture, asserted at the
+    /// payload level rather than only inside the bridge's own tests.
+    #[test]
+    fn cross_product_surface_denies_everything_when_nothing_is_declared() {
+        let body = cross_product_surface(None, false);
+        assert_eq!(body["declares_allowed"], false);
+        assert_eq!(body["tool_granted"], false);
+        let targets = body["targets"].as_array().unwrap();
+        assert_eq!(targets.len(), NON_CODING_TARGETS.len());
+        for t in targets {
+            assert_eq!(t["granted"], false, "{t:?}");
+            assert!(
+                t["reason"].as_str().unwrap().contains("fail-closed"),
+                "{t:?}"
+            );
+        }
+        assert!(body["rejected"].as_array().unwrap().is_empty());
+    }
+
+    /// A declared floor target is granted; the OTHER floor target is not — the
+    /// intersection must be per-name, not "declares anything ⇒ grants all".
+    #[test]
+    fn cross_product_surface_grants_only_the_declared_floor_target() {
+        let declared = vec!["research".to_string()];
+        let body = cross_product_surface(Some(&declared), true);
+        assert_eq!(body["declares_allowed"], true);
+        assert_eq!(body["tool_granted"], true);
+        let targets = body["targets"].as_array().unwrap();
+        let research = targets.iter().find(|t| t["name"] == "research").unwrap();
+        assert_eq!(research["granted"], true);
+        assert_eq!(research["reason"], Value::Null);
+        let ticketing = targets.iter().find(|t| t["name"] == "ticketing").unwrap();
+        assert_eq!(ticketing["granted"], false);
+        assert!(
+            ticketing["reason"]
+                .as_str()
+                .unwrap()
+                .contains("[subagents].allowed")
+        );
+    }
+
+    /// A permissive config naming a CODING target must never widen the floor —
+    /// the same invariant `non_coding_floor_rejects_a_coding_target_even_when_config_allows_it`
+    /// pins inside the bridge, asserted here at the surface that reports it.
+    #[test]
+    fn cross_product_surface_rejects_a_declared_coding_target() {
+        let declared = vec!["engineer".to_string(), "research".to_string()];
+        let body = cross_product_surface(Some(&declared), true);
+        let targets = body["targets"].as_array().unwrap();
+        assert!(
+            targets.iter().all(|t| t["name"] != "engineer"),
+            "a non-floor name must never become a target card: {targets:?}"
+        );
+        let rejected = body["rejected"].as_array().unwrap();
+        assert_eq!(rejected.len(), 1, "{rejected:?}");
+        assert_eq!(rejected[0]["name"], "engineer");
+        assert!(
+            rejected[0]["reason"]
+                .as_str()
+                .unwrap()
+                .contains("NON_CODING_TARGETS")
+        );
+    }
+
+    /// `documentation` is in `ASSISTANT_ALLOWED_DELEGATE_ROLES` and in NO other
+    /// allow-set in the codebase — in particular it is not a cross-product
+    /// target. If the two halves were ever flattened this assertion is the one
+    /// that breaks, which is why the payload keeps them apart.
+    #[test]
+    fn the_two_mechanisms_have_a_disjoint_target_vocabulary() {
+        assert!(ASSISTANT_ALLOWED_DELEGATE_ROLES.contains(&"documentation"));
+        assert!(!NON_CODING_TARGETS.contains(&"documentation"));
+        for floor in NON_CODING_TARGETS {
+            assert!(
+                !ASSISTANT_ALLOWED_DELEGATE_ROLES.contains(floor),
+                "{floor} appears in both allow-sets; the payload's kind labelling \
+                 would become ambiguous"
+            );
+        }
+    }
+}

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -39,6 +39,7 @@ mod agent_patch;
 mod agent_permissions;
 mod agent_skills;
 mod agent_stores;
+mod agent_subagents;
 mod auth;
 mod cancel;
 mod ctrl_sessions;

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -27,6 +27,7 @@ use super::agent_patch::{get_agent_persona_route, get_agent_route, patch_agent_r
 use super::agent_permissions::agent_permissions_route;
 use super::agent_skills::agent_skills_route;
 use super::agent_stores::agent_stores_route;
+use super::agent_subagents::agent_subagents_route;
 use super::auth::{ApiClientConfig, ApiConfig, AuthState, auth_middleware};
 use super::cancel::cancel_task;
 use super::ctrl_sessions::{
@@ -182,6 +183,17 @@ pub fn build_router_with_origins(
         .route(
             "/api/agents/{name}/knowledge",
             axum::routing::get(agent_knowledge_route),
+        )
+        // #4029 (epic #4021, OQ-5): the Sub-agents pane reads the UNION of the
+        // two delegation mechanisms — in-product `delegate_to_agent` targets
+        // (role allowlist + #4169's L0/L1 tier gate) and cross-product
+        // `dispatch_task` specialists (`[subagents].allowed` ∩ the bridge's
+        // `NON_CODING_TARGETS` floor) — labelled by kind, never flattened.
+        // A dedicated route rather than an extension of `GET /api/agents/:name`:
+        // see `agent_subagents`'s module doc. Read-only.
+        .route(
+            "/api/agents/{name}/subagents",
+            axum::routing::get(agent_subagents_route),
         )
         .route("/api/workstreams", get(list_workstreams_route))
         .route(

--- a/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
@@ -1,0 +1,579 @@
+//! `GET /api/agents/:name/subagents` handler tests (#4029, epic #4021 OQ-5).
+//!
+//! Why: this route's whole reason to exist is that it must never advertise a
+//! delegation target the enforcement layer would refuse. Three properties carry
+//! that weight and each is pinned here rather than left to the sibling
+//! mechanisms' own tests:
+//!
+//! 1. **The tier interaction (#4169, epic #4167).** An L1 delegator must not be
+//!    shown an L0-orchestration target as reachable, and an L0 delegator must
+//!    be. Today NO shipped persona declares `tier` at all, so this is
+//!    exercisable only against synthetic fixtures — which is exactly why it
+//!    needs a test rather than a manual check.
+//! 2. **Cross-product deny-by-default (OQ-7).** An agent with no `[subagents]`
+//!    section must see every floor target denied — the pane may not read an
+//!    absent section as a silent grant.
+//! 3. **The two mechanisms stay labelled and separate.** `documentation` is an
+//!    in-product role and nothing else; `research`/`ticketing` are
+//!    cross-product specialists and nothing else. A flattened list would lose
+//!    that and the pane could not say which enforcement layer applies.
+//!
+//! What: [`subagents_at`] driven against a `tempfile::TempDir` roster (the
+//! `agent_knowledge`/`agent_skills` pattern), plus one full-router test proving
+//! the route is wired. Fixtures use the `[agent]`+`[llm]`+`[system_prompt]`
+//! shape `AgentConfig::by_name_in` requires — the same shape
+//! `tools::delegate_tests::write_agent_toml_with_role_and_tier` uses, because
+//! this route mirrors that gate and therefore resolves configs the same way.
+//! Test: This module IS the test.
+
+use axum::Router;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use crate::api::server::agent_subagents::subagents_at;
+use crate::api::server::routes::build_router;
+use crate::api::server::state::AppState;
+
+/// Write a fully-parseable agent TOML. `tier` and `subagents_allowed` are
+/// omitted from the file entirely when `None`, so an "absent section" fixture is
+/// genuinely absent rather than an empty list.
+fn write_agent(
+    dir: &std::path::Path,
+    name: &str,
+    role: &str,
+    tier: Option<&str>,
+    tools_allow: &[&str],
+    subagents_allowed: Option<&[&str]>,
+) {
+    let tier_line = tier
+        .map(|t| format!("tier = \"{t}\"\n"))
+        .unwrap_or_default();
+    let tools_block = if tools_allow.is_empty() {
+        String::new()
+    } else {
+        let list = tools_allow
+            .iter()
+            .map(|t| format!("\"{t}\""))
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!("\n[tools]\nallow = [{list}]\n")
+    };
+    let subagents_block = match subagents_allowed {
+        None => String::new(),
+        Some(list) => {
+            let joined = list
+                .iter()
+                .map(|t| format!("\"{t}\""))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("\n[subagents]\nallowed = [{joined}]\n")
+        }
+    };
+    std::fs::write(
+        dir.join(format!("{name}.toml")),
+        format!(
+            r#"
+[agent]
+name = "{name}"
+role = "{role}"
+model = "anthropic/claude-sonnet-4-6"
+description = "test fixture"
+{tier_line}
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+{tools_block}{subagents_block}"#
+        ),
+    )
+    .unwrap();
+}
+
+async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
+        .await
+        .unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// A roster shaped like the real bundled one: one assistant-tier subject, one
+/// worker of each interesting role, and one agent whose role is NOT in
+/// `ASSISTANT_ALLOWED_DELEGATE_ROLES` (`orchestrator`, the escalation target
+/// #3555's role gate closed).
+fn standard_roster(dir: &std::path::Path) {
+    write_agent(
+        dir,
+        "assistant",
+        "assistant",
+        None,
+        &["delegate_to_agent", "git_log"],
+        None,
+    );
+    write_agent(dir, "engineer", "engineer", None, &[], None);
+    write_agent(dir, "docs-agent", "documentation", None, &[], None);
+    write_agent(dir, "izzie", "assistant", None, &[], None);
+    write_agent(dir, "pm", "orchestrator", None, &[], None);
+    write_agent(dir, "ticketing-agent", "ticketing", None, &[], None);
+}
+
+#[tokio::test]
+async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
+    let dir = tempfile::tempdir().unwrap();
+    standard_roster(dir.path());
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["resolved"], true);
+
+    // Both halves are present and LABELLED — never flattened into one list.
+    let ip = &body["in_product"];
+    let cp = &body["cross_product"];
+    assert_eq!(ip["mechanism"], "in_product");
+    assert_eq!(ip["tool"], "delegate_to_agent");
+    assert_eq!(cp["mechanism"], "cross_product");
+    assert_eq!(cp["tool"], "dispatch_task");
+
+    // `delegate_to_agent` is both registered (role == "assistant") and granted.
+    assert_eq!(ip["tool_registered"], true);
+    assert_eq!(ip["tool_granted"], true);
+    assert_eq!(
+        ip["delegator_tier"], "l1",
+        "no tier declared ⇒ fail-closed L1"
+    );
+
+    let targets = ip["targets"].as_array().unwrap();
+    let named: Vec<&str> = targets
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(named.contains(&"engineer"), "{named:?}");
+    assert!(
+        named.contains(&"izzie"),
+        "peer assistant is a target: {named:?}"
+    );
+    // `documentation` is the role that exists ONLY in
+    // `ASSISTANT_ALLOWED_DELEGATE_ROLES` — its presence here is what proves the
+    // in-product half is sourced from that constant and not from the
+    // cross-product floor.
+    let docs = targets
+        .iter()
+        .find(|t| t["name"] == "docs-agent")
+        .expect("a documentation-role agent must be an in-product target");
+    assert_eq!(docs["role"], "documentation");
+    assert_eq!(docs["reachable"], true);
+    assert_eq!(docs["reason"], serde_json::Value::Null);
+
+    // The role gate's exclusions are COUNTED, never named (no roster dump), and
+    // the subject itself never appears as its own target.
+    assert!(
+        !named.contains(&"pm") && !named.contains(&"ticketing-agent"),
+        "role-ineligible agents must not become target cards: {named:?}"
+    );
+    assert!(!named.contains(&"assistant"), "no self-delegation card");
+    assert_eq!(ip["role_excluded_count"], 2, "pm + ticketing-agent");
+
+    // The role allowlist is reported verbatim so the pane can explain the rule.
+    let roles: Vec<&str> = ip["allowed_roles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert!(roles.contains(&"documentation"));
+    assert!(!roles.contains(&"orchestrator"));
+
+    // Cross-product: nothing declared ⇒ nothing granted, and `dispatch_task` is
+    // not in this agent's allow-list either.
+    assert_eq!(cp["declares_allowed"], false);
+    assert_eq!(cp["tool_granted"], false);
+    let floor: Vec<&str> = cp["bridge_floor"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r.as_str().unwrap())
+        .collect();
+    assert_eq!(floor, vec!["research", "ticketing"]);
+}
+
+/// THE test #4029 names explicitly: "an L1 agent must not be shown an L0
+/// target". The gate (`tools::delegate`, #4169) refuses that delegation, so a
+/// config surface reporting it as reachable would advertise a capability the
+/// runtime denies.
+#[tokio::test]
+async fn subagents_route_hides_l0_target_from_l1_delegator() {
+    let dir = tempfile::tempdir().unwrap();
+    standard_roster(dir.path());
+    // An L0-orchestration peer assistant — role-eligible (`assistant`), so the
+    // ONLY thing that can keep it out of reach is the tier gate.
+    write_agent(dir.path(), "orch", "assistant", Some("l0"), &[], None);
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
+    let body = body_json(resp).await;
+    let ip = &body["in_product"];
+    assert_eq!(ip["delegator_tier"], "l1");
+
+    let targets = ip["targets"].as_array().unwrap();
+    let orch = targets
+        .iter()
+        .find(|t| t["name"] == "orch")
+        .expect("the L0 target must be REPORTED, with a reason — not silently dropped");
+    assert_eq!(orch["tier"], "l0");
+    assert_eq!(
+        orch["reachable"], false,
+        "an L1 delegator may not reach an L0 target: {orch:?}"
+    );
+    let reason = orch["reason"].as_str().unwrap();
+    assert!(reason.contains("L0/L1"), "{reason}");
+    assert!(reason.contains("#4169"), "{reason}");
+
+    // Every L1 peer is still reachable — the gate is one-directional, not a
+    // blanket denial.
+    let izzie = targets.iter().find(|t| t["name"] == "izzie").unwrap();
+    assert_eq!(izzie["tier"], "l1");
+    assert_eq!(izzie["reachable"], true);
+}
+
+/// The counter-test: an L0 delegator DOES reach an L0 target (and still reaches
+/// L1 ones). Without this, a bug that reported every L0 target as unreachable
+/// would pass the test above.
+#[tokio::test]
+async fn subagents_route_shows_l0_target_to_l0_delegator() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(
+        dir.path(),
+        "orchestrator-assistant",
+        "assistant",
+        Some("l0"),
+        &["delegate_to_agent"],
+        None,
+    );
+    write_agent(
+        dir.path(),
+        "orch",
+        "assistant",
+        Some("orchestration"),
+        &[],
+        None,
+    );
+    write_agent(dir.path(), "engineer", "engineer", None, &[], None);
+
+    let resp = subagents_at(
+        &[dir.path().to_path_buf()],
+        "orchestrator-assistant",
+        dir.path(),
+    )
+    .await;
+    let body = body_json(resp).await;
+    let ip = &body["in_product"];
+    assert_eq!(ip["delegator_tier"], "l0");
+
+    let targets = ip["targets"].as_array().unwrap();
+    let orch = targets.iter().find(|t| t["name"] == "orch").unwrap();
+    assert_eq!(
+        orch["tier"], "l0",
+        "the `orchestration` alias must resolve to l0 like `l0` does"
+    );
+    assert_eq!(orch["reachable"], true);
+    assert_eq!(orch["reason"], serde_json::Value::Null);
+    let eng = targets.iter().find(|t| t["name"] == "engineer").unwrap();
+    assert_eq!(eng["reachable"], true, "L0 → L1 is not restricted");
+}
+
+/// An unrecognized/blank `tier` string must fail closed to L1 on BOTH sides of
+/// the comparison — the same posture `AgentInfo::tier()` guarantees, asserted
+/// through this route so a future refactor of the wire label cannot quietly
+/// promote a typo to L0.
+#[tokio::test]
+async fn subagents_route_tier_fails_closed_for_an_unrecognized_value() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(
+        dir.path(),
+        "assistant",
+        "assistant",
+        Some("L0-ish"),
+        &["delegate_to_agent"],
+        None,
+    );
+    write_agent(dir.path(), "orch", "assistant", Some("l0"), &[], None);
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
+    let body = body_json(resp).await;
+    let ip = &body["in_product"];
+    assert_eq!(
+        ip["delegator_tier"], "l1",
+        "a typo'd tier must never be read as an L0 grant"
+    );
+    let targets = ip["targets"].as_array().unwrap();
+    let orch = targets.iter().find(|t| t["name"] == "orch").unwrap();
+    assert_eq!(
+        orch["reachable"], false,
+        "…and therefore the L0 target stays out of reach: {orch:?}"
+    );
+}
+
+/// #4029's deny-by-default requirement: no `[subagents]` section at all.
+#[tokio::test]
+async fn subagents_route_cross_product_denies_everything_without_the_section() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(dir.path(), "bare", "assistant", None, &[], None);
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "bare", dir.path()).await;
+    let body = body_json(resp).await;
+    let cp = &body["cross_product"];
+    assert_eq!(cp["declares_allowed"], false);
+    let targets = cp["targets"].as_array().unwrap();
+    assert_eq!(targets.len(), 2, "the whole floor is listed: {targets:?}");
+    for t in targets {
+        assert_eq!(t["granted"], false, "{t:?}");
+        assert!(
+            t["reason"].as_str().unwrap().contains("fail-closed"),
+            "{t:?}"
+        );
+    }
+    // An EMPTY declared list is the same posture, and must not read as a grant
+    // either.
+    write_agent(dir.path(), "empty", "assistant", None, &[], Some(&[]));
+    let resp = subagents_at(&[dir.path().to_path_buf()], "empty", dir.path()).await;
+    let body = body_json(resp).await;
+    assert_eq!(body["cross_product"]["declares_allowed"], true);
+    assert!(
+        body["cross_product"]["targets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|t| t["granted"] == false),
+        "an empty [subagents].allowed grants nothing: {body:?}"
+    );
+}
+
+/// The positive cross-product case, resolved through the bridge's OWN allow-set
+/// (OQ-7) — and a permissive declaration that names a coding target, which the
+/// floor must still refuse.
+#[tokio::test]
+async fn subagents_route_cross_product_grants_a_declared_floor_target() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(
+        dir.path(),
+        "researchy",
+        "assistant",
+        None,
+        &["dispatch_task"],
+        Some(&["research", "engineer"]),
+    );
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "researchy", dir.path()).await;
+    let body = body_json(resp).await;
+    let cp = &body["cross_product"];
+    assert_eq!(cp["declares_allowed"], true);
+    assert_eq!(cp["tool_granted"], true, "`dispatch_task` is allow-listed");
+
+    let targets = cp["targets"].as_array().unwrap();
+    let research = targets.iter().find(|t| t["name"] == "research").unwrap();
+    assert_eq!(research["granted"], true);
+    let ticketing = targets.iter().find(|t| t["name"] == "ticketing").unwrap();
+    assert_eq!(
+        ticketing["granted"], false,
+        "declaring one floor target must not grant the other"
+    );
+
+    // The coding target never becomes a card and IS reported as rejected — the
+    // one way a hand-written `[subagents].allowed` silently does nothing.
+    assert!(targets.iter().all(|t| t["name"] != "engineer"));
+    let rejected = cp["rejected"].as_array().unwrap();
+    assert_eq!(rejected.len(), 1, "{rejected:?}");
+    assert_eq!(rejected[0]["name"], "engineer");
+}
+
+/// Registered ≠ granted: a worker-role agent never gets `delegate_to_agent`
+/// registered at all (`build_registry_for_agent` routes only
+/// `role == "assistant"` into the tier registry), so the pane must say so
+/// instead of listing targets it could never call.
+#[tokio::test]
+async fn subagents_route_reports_tool_not_registered_for_a_worker_role() {
+    let dir = tempfile::tempdir().unwrap();
+    standard_roster(dir.path());
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "engineer", dir.path()).await;
+    let body = body_json(resp).await;
+    let ip = &body["in_product"];
+    assert_eq!(
+        ip["tool_registered"], false,
+        "an engineer-role agent never registers delegate_to_agent"
+    );
+    assert_eq!(ip["tool_granted"], false, "and declares no allow-list");
+}
+
+/// An agent declaring `[tools].allow` WITHOUT `delegate_to_agent` is registered
+/// but ungranted — the two flags must move independently, or the pane collapses
+/// "the tool exists" into "this agent may call it".
+#[tokio::test]
+async fn subagents_route_separates_registered_from_granted() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(dir.path(), "quiet", "assistant", None, &["git_log"], None);
+    write_agent(dir.path(), "engineer", "engineer", None, &[], None);
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "quiet", dir.path()).await;
+    let body = body_json(resp).await;
+    let ip = &body["in_product"];
+    assert_eq!(ip["tool_registered"], true);
+    assert_eq!(
+        ip["tool_granted"], false,
+        "`delegate_to_agent` is not in this agent's allow-list: {ip:?}"
+    );
+}
+
+/// A catalog entry whose config does not resolve is what the gate REFUSES
+/// (`by_name_in` → `Err` ⇒ rejected), so it must be reported as unresolved
+/// rather than dropped — a vanished target looks identical to one that was
+/// never there.
+#[tokio::test]
+async fn subagents_route_reports_unresolvable_target_rather_than_dropping_it() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(
+        dir.path(),
+        "assistant",
+        "assistant",
+        None,
+        &["delegate_to_agent"],
+        None,
+    );
+    // Parses as TOML (so it enters the catalog) but has no resolvable
+    // `[llm]`/`[system_prompt]`, so full resolution fails.
+    std::fs::write(
+        dir.path().join("halfbaked.toml"),
+        "[agent]\nname = \"halfbaked\"\nrole = \"engineer\"\n",
+    )
+    .unwrap();
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
+    let body = body_json(resp).await;
+    let ip = &body["in_product"];
+    let unresolved = ip["unresolved"].as_array().unwrap();
+    assert_eq!(unresolved.len(), 1, "{ip:?}");
+    assert_eq!(unresolved[0]["name"], "halfbaked");
+    assert!(
+        unresolved[0]["reason"]
+            .as_str()
+            .unwrap()
+            .contains("did not resolve")
+    );
+    assert!(
+        ip["targets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|t| t["name"] != "halfbaked"),
+        "an unresolvable agent is never a reachable target"
+    );
+}
+
+/// This route sees `extends` — unlike `/skills`, `/knowledge` and
+/// `/permissions`, whose partial parse cannot. It matters: the gate resolves
+/// through `by_name_in`, so a `[subagents]` grant inherited from a base IS
+/// enforced and must therefore be shown.
+#[tokio::test]
+async fn subagents_route_resolves_a_subagents_grant_inherited_via_extends() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(
+        dir.path(),
+        "base-assistant",
+        "assistant",
+        None,
+        &["dispatch_task"],
+        Some(&["research"]),
+    );
+    std::fs::write(
+        dir.path().join("child.toml"),
+        r#"
+[agent]
+name = "child"
+role = "assistant"
+model = "anthropic/claude-sonnet-4-6"
+description = "test fixture"
+extends = "base-assistant"
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#,
+    )
+    .unwrap();
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "child", dir.path()).await;
+    let body = body_json(resp).await;
+    let cp = &body["cross_product"];
+    let research = cp["targets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|t| t["name"] == "research")
+        .unwrap()
+        .clone();
+    assert_eq!(
+        research["granted"], true,
+        "an inherited [subagents].allowed grant is enforced, so it must be shown: {body:?}"
+    );
+}
+
+#[tokio::test]
+async fn subagents_route_unknown_agent_404() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp = subagents_at(&[dir.path().to_path_buf()], "nobody", dir.path()).await;
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn subagents_route_rejects_traversal_name() {
+    let dir = tempfile::tempdir().unwrap();
+    let resp = subagents_at(&[dir.path().to_path_buf()], "../etc", dir.path()).await;
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+/// A hand-edit typo must not 500 the panel — and must not be read as a grant
+/// either. `resolved: false` with empty target lists is the fail-closed answer.
+#[tokio::test]
+async fn subagents_route_degrades_on_malformed_toml() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("broken.toml"), "not = = toml").unwrap();
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "broken", dir.path()).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = body_json(resp).await;
+    assert_eq!(body["resolved"], false);
+    assert!(body["config_error"].is_string());
+    assert!(body["in_product"]["targets"].as_array().unwrap().is_empty());
+    assert_eq!(body["in_product"]["tool_registered"], false);
+    assert!(
+        body["cross_product"]["targets"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|t| t["granted"] == false),
+        "an unparseable config grants nothing: {body:?}"
+    );
+}
+
+/// Proves the route is wired into `build_router` (not just that the core
+/// function works).
+#[tokio::test]
+async fn subagents_route_is_wired_into_router() {
+    let app: Router = build_router(AppState::default());
+    let req = Request::builder()
+        .uri("/api/agents/definitely-not-an-agent-4029/subagents")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    let body = body_json(resp).await;
+    assert_eq!(
+        body["error"], "unknown agent",
+        "a 404 from the handler, not from an unrouted path"
+    );
+}

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -11,6 +11,7 @@ mod agent_patch;
 mod agent_permissions;
 mod agent_skills;
 mod agent_stores;
+mod agent_subagents;
 mod cancel;
 mod ctrl_sessions;
 mod events_sse;

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -87,7 +87,15 @@ use tools::{ToolRegistry, shell_exec::ShellExecTool};
 /// TOML/overlay sets `role = "assistant"` regardless of its display name.
 /// Test: `assistant_tier_registry_excludes_skill_catalog_tools`,
 /// `assistant_tier_registry_includes_curated_tools`.
-pub(super) const ASSISTANT_TIER_ROLE: &str = "assistant";
+///
+/// `pub(crate)` (#4029, fourth reader): `api::server::agent_subagents` — the
+/// Sub-agents configuration section — must report whether `delegate_to_agent`
+/// is registered for a given agent AT ALL, which is exactly the
+/// `role == ASSISTANT_TIER_ROLE` branch in `build_registry_for_agent` below.
+/// Reading the constant (rather than re-typing the literal `"assistant"`, as
+/// `ctrl::pm_task::dispatch::persona` was forced to) keeps the config surface
+/// from claiming a mechanism the registry would not wire.
+pub(crate) const ASSISTANT_TIER_ROLE: &str = "assistant";
 
 /// Fail-closed allowlist of `agent.role` values an assistant-tier
 /// `delegate_to_agent` call may target — see

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.svelte
@@ -53,15 +53,18 @@
     patchAgent,
     fetchAgentStores,
     fetchAgentSkills,
+    fetchAgentSubagents,
     matchesToolGlob,
     STORE_BOUND_KNOWLEDGE_TOOLS,
     type AgentDetail,
     type AgentSkills,
+    type AgentSubagents,
     type OkgStoreBinding,
   } from '../lib/agentConfig';
   import AgentConfigPersonality from './AgentConfigPersonality.svelte';
   import AgentConfigKnowledge from './AgentConfigKnowledge.svelte';
   import AgentConfigSkills from './AgentConfigSkills.svelte';
+  import AgentConfigSubagents from './AgentConfigSubagents.svelte';
   import AgentConfigListeners from './AgentConfigListeners.svelte';
   import AgentConfigPermissions from './AgentConfigPermissions.svelte';
 
@@ -84,11 +87,31 @@
   export let onExit: () => void;
 
   /** DOC-57 §2.1: the order is NORMATIVE, and it is not the pre-#3932 order
-   * (which put Permissions before Listeners). */
+   * (which put Permissions before Listeners).
+   *
+   * #4029 adds a SIXTH entry, `subagents`, per the owner's 2026-07-26 OQ-5
+   * ruling on epic #4021 ("Sub-agents is its own configuration section"). It is
+   * inserted between Skills and Listeners, and the choice is deliberate on both
+   * counts:
+   *
+   * - **The normative order is preserved, not overridden.** Every one of the
+   *   five existing sections keeps its position relative to every other; no pair
+   *   is swapped. §2.1 fixes the order of the five, and inserting a new section
+   *   between two of them leaves that order intact — unlike moving Permissions
+   *   back before Listeners, which §8.2's G-1 explicitly forbids.
+   * - **It continues §2.1's progression** (identity → knowledge → capability →
+   *   reactivity → constraint): Skills is what the agent can do ITSELF, and
+   *   Sub-agents is what it can hand off — the same "capability" beat, so the
+   *   two belong adjacent. Putting delegation after Listeners/Permissions would
+   *   separate the two halves of one question with two unrelated sections.
+   *
+   * #4182 amends DOC-57 to document the sixth section formally; this change
+   * deliberately does not touch the spec. */
   const SECTIONS = [
     ['personality', 'Personality'],
     ['knowledge', 'Knowledge'],
     ['skills', 'Skills'],
+    ['subagents', 'Sub-agents'],
     ['listeners', 'Listeners'],
     ['permissions', 'Permissions'],
   ] as const;
@@ -112,6 +135,10 @@
   /** Resolved one-skill-per-tool capability set (#3933) — `null` until loaded. */
   let skills: AgentSkills | null = null;
   let skillsError = '';
+
+  /** Resolved delegation reach, both mechanisms (#4029) — `null` until loaded. */
+  let subagents: AgentSubagents | null = null;
+  let subagentsError = '';
 
   let saving = false;
   let saveError = '';
@@ -233,6 +260,16 @@
       skills = null;
       skillsError = `${e}`;
     }
+    // #4029: its own leg for the same reason — the sub-agents route resolves
+    // every candidate agent's config, so it is the slowest of the three and a
+    // degraded roster must darken only this pane (C-07.2 / DOC-57 §8.3 G-5).
+    try {
+      subagentsError = '';
+      subagents = await fetchAgentSubagents(name);
+    } catch (e) {
+      subagents = null;
+      subagentsError = `${e}`;
+    }
   }
 
   $: load(agentName);
@@ -346,6 +383,8 @@
       />
     {:else if tab === 'skills'}
       <AgentConfigSkills data={skills} error={skillsError} />
+    {:else if tab === 'subagents'}
+      <AgentConfigSubagents data={subagents} error={subagentsError} />
     {:else if tab === 'listeners'}
       <AgentConfigListeners />
     {:else if tab === 'permissions'}

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
@@ -10,11 +10,14 @@
 // (2) The takeover needs exit affordances that actually call back out, and the
 // persona edit buffer must survive a SECTION SWITCH now that the body it lives
 // in is an unmounted-on-switch child (G-6a / C-07.4).
-// (3) The five sections and their order are normative (DOC-57 §2.1, C-07.1),
-// and every pane must render an explicit empty/error state rather than
-// fabricated content when its backend is absent or failing (G-4, C-07.2).
-// What: Mounts the real panel with `fetch` stubbed for the three routes it
-// loads (`/api/agents/:name`, `.../persona`, `.../stores`), then asserts the
+// (3) The five sections and their order are normative (DOC-57 §2.1, C-07.1) —
+// #4029 adds Sub-agents as a SIXTH section without reordering any of the five,
+// which is itself asserted below — and every pane must render an explicit
+// empty/error state rather than fabricated content when its backend is absent
+// or failing (G-4, C-07.2).
+// What: Mounts the real panel with `fetch` stubbed for the routes it
+// loads (`/api/agents/:name`, `.../persona`, `.../stores`, `.../skills`,
+// `.../subagents`), then asserts the
 // sizing invariants, the Back/Close wiring, the tab strip, and each pane's
 // degraded rendering. jsdom does no layout, so the "grows with the viewport"
 // half is asserted as the flex chain that produces it rather than as a measured
@@ -120,6 +123,83 @@ const SKILLS_PAYLOAD = {
   declares_capability: true,
 };
 
+/**
+ * `GET /api/agents/:name/subagents` (#4029) — the UNION of both delegation
+ * mechanisms, kept apart by kind. Mirrors the real route's shape, including a
+ * tier-blocked target so the panel test exercises the gate's rendering too.
+ */
+const SUBAGENTS_PAYLOAD = {
+  resolved: true,
+  in_product: {
+    mechanism: 'in_product',
+    tool: 'delegate_to_agent',
+    tool_registered: true,
+    tool_granted: true,
+    delegator_tier: 'l1',
+    allowed_roles: ['engineer', 'qa', 'researcher', 'documentation', 'ops', 'planner', 'assistant'],
+    targets: [
+      {
+        name: 'engineer',
+        display_name: 'Engineer',
+        role: 'engineer',
+        tier: 'l1',
+        reachable: true,
+        reason: null,
+      },
+      {
+        name: 'orch',
+        display_name: 'Orchestrator',
+        role: 'assistant',
+        tier: 'l0',
+        reachable: false,
+        reason: 'refused by the L0/L1 delegation gate (#4169)',
+      },
+    ],
+    role_excluded_count: 2,
+    unresolved: [],
+  },
+  cross_product: {
+    mechanism: 'cross_product',
+    tool: 'dispatch_task',
+    tool_granted: true,
+    declares_allowed: true,
+    bridge_floor: ['research', 'ticketing'],
+    targets: [
+      { name: 'research', granted: true, reason: null },
+      { name: 'ticketing', granted: false, reason: 'not listed in [subagents].allowed' },
+    ],
+    rejected: [],
+  },
+};
+
+/** The bare-agent counterpart: everything denied, fail-closed. */
+const BARE_SUBAGENTS_PAYLOAD = {
+  resolved: true,
+  in_product: {
+    mechanism: 'in_product',
+    tool: 'delegate_to_agent',
+    tool_registered: true,
+    tool_granted: false,
+    delegator_tier: 'l1',
+    allowed_roles: ['engineer', 'qa', 'researcher', 'documentation', 'ops', 'planner', 'assistant'],
+    targets: [],
+    role_excluded_count: 0,
+    unresolved: [],
+  },
+  cross_product: {
+    mechanism: 'cross_product',
+    tool: 'dispatch_task',
+    tool_granted: false,
+    declares_allowed: false,
+    bridge_floor: ['research', 'ticketing'],
+    targets: [
+      { name: 'research', granted: false, reason: 'fail-closed' },
+      { name: 'ticketing', granted: false, reason: 'fail-closed' },
+    ],
+    rejected: [],
+  },
+};
+
 function stubApi() {
   vi.stubGlobal(
     'fetch',
@@ -127,6 +207,8 @@ function stubApi() {
       const url = String(input);
       const json = url.includes('/persona')
         ? { content: PERSONA, editable: true }
+        : url.includes('/subagents')
+        ? SUBAGENTS_PAYLOAD
         : url.includes('/skills')
           ? SKILLS_PAYLOAD
           : url.includes('/stores')
@@ -155,6 +237,8 @@ function stubBareApiWithFailingStores() {
       if (url.includes('/stores')) return { ok: false, status: 503, json: async () => ({}) } as Response;
       const json = url.includes('/persona')
         ? { content: '', editable: false }
+        : url.includes('/subagents')
+        ? BARE_SUBAGENTS_PAYLOAD
         : url.includes('/skills')
           ? {
               skills: [],
@@ -296,11 +380,28 @@ describe('AgentConfigPanel — instructions editor sizing (#3894)', () => {
   });
 });
 
-describe('AgentConfigPanel — five sections (#3932, DOC-57 §8.2)', () => {
-  it('renders exactly five tabs in the normative order (C-07.1)', async () => {
+describe('AgentConfigPanel — six sections (#3932 + #4029, DOC-57 §8.2)', () => {
+  // #4029 (epic #4021, OQ-5 resolved by the owner 2026-07-26) adds Sub-agents
+  // as the sixth section. DOC-57 §2.1's ordering stays normative and stays
+  // SATISFIED: the five original sections keep their relative order exactly —
+  // Permissions is still last, Listeners still after Skills — and the new
+  // section is inserted rather than reordering any existing pair. #4182 amends
+  // the spec text.
+  it('renders exactly six tabs, the five normative ones in order (C-07.1)', async () => {
     mountPanel();
     await waitFor(() => editor() !== null);
     expect(tabLabels()).toEqual([
+      'Personality',
+      'Knowledge',
+      'Skills',
+      'Sub-agents',
+      'Listeners',
+      'Permissions',
+    ]);
+    // The normative five, with the insertion removed, must be byte-identical to
+    // DOC-57 §2.1's order — the property that would break if a future edit
+    // "made room" by moving one of them.
+    expect(tabLabels().filter((l) => l !== 'Sub-agents')).toEqual([
       'Personality',
       'Knowledge',
       'Skills',
@@ -331,6 +432,14 @@ describe('AgentConfigPanel — five sections (#3932, DOC-57 §8.2)', () => {
     expect(target.textContent).not.toContain('Gmail Search');
     expect(target.textContent).toContain('2 of 3 known skills granted');
 
+    // #4029: both delegation mechanisms, labelled separately, sourced from
+    // `GET .../subagents` — never derived client-side from `tools_allow`.
+    tabButton('Sub-agents').click();
+    await waitFor(() => target.textContent?.includes('delegate_to_agent') ?? false);
+    expect(target.textContent).toContain('Engineer');
+    expect(target.textContent).toContain('dispatch_task');
+    expect(target.textContent).toContain('1 of 2 cross-product specialists granted');
+
     tabButton('Listeners').click();
     await waitFor(() => target.textContent?.includes('Gmail') ?? false);
     expect(target.textContent).toContain('Google Calendar');
@@ -359,7 +468,7 @@ describe('AgentConfigPanel — degraded backends (#3932, C-07.2)', () => {
     vi.unstubAllGlobals();
     stubBareApiWithFailingStores();
     mountPanel(vi.fn(), 'bare');
-    await waitFor(() => tabLabels().length === 5);
+    await waitFor(() => tabLabels().length === 6);
 
     // Personality: no editable persona.md is a stated fact, not a blank box.
     await waitFor(() => target.textContent?.includes('no editable persona.md') ?? false);
@@ -378,6 +487,13 @@ describe('AgentConfigPanel — degraded backends (#3932, C-07.2)', () => {
     await waitFor(() => target.textContent?.includes('declares neither') ?? false);
     // An absent allow-list denies; the pane must not read as "unrestricted".
     expect(target.textContent).toContain('not "unrestricted"');
+
+    // #4029: a bare agent must be told that absent DENIES on both mechanisms —
+    // the pane may never read an absent `[subagents]` section as "all".
+    tabButton('Sub-agents').click();
+    await waitFor(() => target.textContent?.includes('declares no') ?? false);
+    expect(target.textContent).toContain('does not mean "all"');
+    expect(target.textContent).toContain('0 of 2 cross-product specialists granted');
 
     tabButton('Listeners').click();
     await waitFor(() => target.textContent?.includes('Scaffolding, not configuration') ?? false);

--- a/crates/trusty-agents/ui/src/components/AgentConfigSubagents.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSubagents.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+  /**
+   * Why (#4029, epic #4021): the SIXTH configuration section — "who else can
+   * this agent get to do the work". Owner decision, 2026-07-26, resolving
+   * OQ-5: *"Sub-agents is its own configuration section"*; refined 2026-07-27
+   * to require the UNION of BOTH delegation mechanisms, which no spec had
+   * previously reconciled.
+   *
+   * The two are not variants of one thing and this pane never merges them:
+   * `delegate_to_agent` is in-product (trusty-agents → trusty-agents), its
+   * target set a HARDCODED role allowlist crossed with the resolvable roster
+   * and narrowed by #4169's L0/L1 tier gate — no per-agent config at all;
+   * `dispatch_task` is cross-product (trusty-agents → trusty-code), the one
+   * with a real `[subagents].allowed` binding, intersected fail-closed with
+   * the bridge's own `NON_CODING_TARGETS` floor (OQ-7). Their target
+   * vocabularies do not overlap — `documentation` is an in-product role and
+   * appears nowhere else — so a single flat list could not tell an operator
+   * which enforcement layer applies to a given name.
+   *
+   * What: two labelled groups over `GET /api/agents/:name/subagents`, which
+   * resolves both through the SAME code the enforcement points call. Read-only,
+   * matching every other read-only section (DOC-57 §7.2's PM-4 rationale
+   * applies at least as strongly here: delegation reach is the escalation
+   * surface #3555 and #4169 exist to close).
+   *
+   * Honesty rules, mirroring the sibling panes: `tool_registered` and
+   * `tool_granted` render separately (registered ≠ granted); an unreachable
+   * target is SHOWN with the gate's reason rather than hidden, so "why can't my
+   * assistant reach that one" is answerable; and an unresolvable config renders
+   * the denial plus the parse error, never a blank pane implying "nothing
+   * configured".
+   *
+   * DOC-57 still documents five sections; #4182 amends it. This pane cites the
+   * decision, it does not restate the spec.
+   * Test: `AgentConfigSubagents.test.ts`.
+   */
+  import type { AgentSubagents } from '../lib/agentConfig';
+
+  /** Loaded by the shell from `GET /api/agents/:name/subagents`; `null` while loading. */
+  export let data: AgentSubagents | null = null;
+  /** Non-empty when the fetch itself failed. */
+  export let error = '';
+
+  // Every field is defaulted rather than assumed: an older sidecar (or a route
+  // that degraded) can return a payload missing a key, and a pane that throws on
+  // that shows the user nothing at all — strictly worse than showing what did
+  // arrive. Same posture as `AgentConfigSkills`.
+  $: inProduct = data?.in_product ?? null;
+  $: crossProduct = data?.cross_product ?? null;
+  $: inTargets = inProduct?.targets ?? [];
+  $: reachable = inTargets.filter((t) => t.reachable);
+  $: blocked = inTargets.filter((t) => !t.reachable);
+  $: unresolved = inProduct?.unresolved ?? [];
+  $: crossTargets = crossProduct?.targets ?? [];
+  $: crossGranted = crossTargets.filter((t) => t.granted);
+  $: rejected = crossProduct?.rejected ?? [];
+
+  const heading =
+    'shrink-0 font-mono text-[10px] font-semibold uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50';
+  const okChip =
+    'shrink-0 rounded-md bg-foundry-teal/15 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-teal';
+  const offChip =
+    'shrink-0 rounded-md bg-foundry-light-border/50 dark:bg-black/30 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50';
+  const tag =
+    'rounded border border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-text dark:text-foundry-text';
+</script>
+
+<div class="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto">
+  <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
+    Who this agent can hand work to. Two independent mechanisms with two different
+    enforcement layers — they are shown separately because a name reachable through one is not
+    reachable through the other. Read-only; edit
+    <code class="font-mono">[subagents]</code> in <code class="font-mono">agent.toml</code>. The
+    in-product target set is not configurable at all — it is a fixed role allow-list plus the
+    L0/L1 delegation gate.
+  </p>
+
+  {#if error}
+    <p class="rounded-md border border-foundry-red/40 px-3 py-2 text-[11px] text-foundry-red">
+      Could not load sub-agents: {error}
+    </p>
+  {:else if !data}
+    <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+      Resolving sub-agents…
+    </p>
+  {:else}
+    {#if data.config_error}
+      <p class="rounded-md border border-foundry-amber/40 px-3 py-2 text-[11px] text-foundry-amber">
+        <code class="font-mono">agent.toml</code> could not be resolved, so no delegation grant
+        could be read — everything below is denied, fail-closed: {data.config_error}
+      </p>
+    {/if}
+
+    <!-- ── In-product: delegate_to_agent ────────────────────────────────── -->
+    <section class="flex flex-col gap-2">
+      <div class="flex items-center justify-between gap-2">
+        <h3 class={heading}>
+          In-product · <code class="font-mono">{inProduct?.tool ?? 'delegate_to_agent'}</code>
+        </h3>
+        <span class={inProduct?.tool_granted ? okChip : offChip}>
+          {inProduct?.tool_granted ? 'granted' : 'not granted'}
+        </span>
+      </div>
+      <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+        Another trusty-agents agent, run in-process. Targets are fixed by the role allow-list
+        <span class="font-mono">({(inProduct?.allowed_roles ?? []).join(', ')})</span> — not by this
+        agent's configuration — and further narrowed by the one-directional L0/L1 delegation gate.
+        This agent's own tier is <code class="font-mono">{inProduct?.delegator_tier ?? 'l1'}</code>.
+      </p>
+
+      {#if !inProduct?.tool_registered}
+        <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+          <code class="font-mono">delegate_to_agent</code> is not registered for this agent's role
+          — only assistant-tier personas get it. Nothing below is callable.
+        </p>
+      {:else if !inProduct?.tool_granted}
+        <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-amber">
+          The tool is registered for this role but this agent's
+          <code class="font-mono">[tools].allow</code> does not grant it, so dispatch denies every
+          target below.
+        </p>
+      {/if}
+
+      {#if reachable.length === 0 && blocked.length === 0}
+        <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+          No agent with a delegatable role resolves on this host.
+        </p>
+      {/if}
+
+      {#each reachable as t (t.name)}
+        <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
+          <div class="flex items-baseline justify-between gap-2">
+            <span class="text-xs font-semibold text-foundry-light-text dark:text-foundry-text">
+              {t.display_name || t.name}
+            </span>
+            <span class={okChip}>reachable</span>
+          </div>
+          <div class="mt-1.5 flex flex-wrap items-center gap-1">
+            <span class={tag} title="The agent id delegate_to_agent names">{t.name}</span>
+            <span class={tag} title="The role the allow-list gates on">{t.role}</span>
+            <span class={tag} title="Privilege tier (#4168)">tier {t.tier}</span>
+          </div>
+        </div>
+      {/each}
+
+      {#if blocked.length > 0}
+        <div class="rounded-md border border-foundry-amber/40 px-3 py-2">
+          <h4 class="font-mono text-[10px] uppercase tracking-wide text-foundry-amber">
+            Refused by the delegation gate ({blocked.length})
+          </h4>
+          {#each blocked as t (t.name)}
+            <p class="mt-1 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
+              <code class="font-mono">{t.name}</code>
+              <span class="font-mono">(tier {t.tier})</span> — {t.reason}
+            </p>
+          {/each}
+        </div>
+      {/if}
+
+      {#if unresolved.length > 0}
+        <details class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2">
+          <summary class="cursor-pointer font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
+            {unresolved.length} agent{unresolved.length === 1 ? '' : 's'} whose config did not resolve
+          </summary>
+          {#each unresolved as u (u.name)}
+            <p class="mt-1 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
+              <code class="font-mono">{u.name}</code> — {u.reason}
+            </p>
+          {/each}
+        </details>
+      {/if}
+
+      {#if (inProduct?.role_excluded_count ?? 0) > 0}
+        <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+          {inProduct?.role_excluded_count} further agent(s) on this host are excluded by the role
+          allow-list and are not delegation targets.
+        </p>
+      {/if}
+    </section>
+
+    <!-- ── Cross-product: dispatch_task ─────────────────────────────────── -->
+    <section class="flex flex-col gap-2">
+      <div class="flex items-center justify-between gap-2">
+        <h3 class={heading}>
+          Cross-product · <code class="font-mono">{crossProduct?.tool ?? 'dispatch_task'}</code>
+        </h3>
+        <span class={crossProduct?.tool_granted ? okChip : offChip}>
+          {crossProduct?.tool_granted ? 'granted' : 'not granted'}
+        </span>
+      </div>
+      <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+        A NON-CODING specialist from trusty-code, run out-of-process; its result is always a
+        proposal, never an authorization. This is the half
+        <code class="font-mono">[subagents].allowed</code> configures — intersected with the
+        bridge's own floor
+        <span class="font-mono">({(crossProduct?.bridge_floor ?? []).join(', ')})</span>, which
+        configuration can narrow but never widen.
+      </p>
+
+      {#if !crossProduct?.declares_allowed}
+        <p class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-3 py-2 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+          This agent declares no <code class="font-mono">[subagents]</code> section. Absent grants
+          <strong>nothing</strong> — it does not mean "all" (OQ-7, fail-closed).
+        </p>
+      {/if}
+
+      {#each crossTargets as t (t.name)}
+        <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
+          <div class="flex items-baseline justify-between gap-2">
+            <span class="text-xs font-semibold text-foundry-light-text dark:text-foundry-text">
+              {t.name}
+            </span>
+            <span class={t.granted ? okChip : offChip}>
+              {t.granted ? 'granted' : 'denied'}
+            </span>
+          </div>
+          {#if t.reason}
+            <p class="mt-0.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
+              {t.reason}
+            </p>
+          {/if}
+        </div>
+      {/each}
+
+      {#if rejected.length > 0}
+        <div class="rounded-md border border-foundry-amber/40 px-3 py-2">
+          <h4 class="font-mono text-[10px] uppercase tracking-wide text-foundry-amber">
+            Declared but refused by the bridge floor ({rejected.length})
+          </h4>
+          {#each rejected as r (r.name)}
+            <p class="mt-1 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
+              <code class="font-mono">{r.name}</code> — {r.reason}
+            </p>
+          {/each}
+        </div>
+      {/if}
+
+      <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+        {crossGranted.length} of {crossTargets.length} cross-product specialists granted.
+      </p>
+    </section>
+  {/if}
+</div>

--- a/crates/trusty-agents/ui/src/components/AgentConfigSubagents.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSubagents.test.ts
@@ -1,0 +1,292 @@
+// Why (#4029, epic #4021 OQ-5): this pane is the first surface to render
+// delegation reach, and the failure mode that matters is showing a target the
+// runtime would refuse. The properties worth pinning are therefore about what it
+// must NOT do: never merge the two mechanisms into one list (their target
+// vocabularies are disjoint and their enforcement layers differ), never render a
+// tier-blocked target as callable, never read an absent `[subagents]` section as
+// a grant, never collapse "the tool is registered" into "this agent may call
+// it", and never collapse loading into empty (DOC-57 §8.3's G-4 three states).
+// What: Mounts the component directly with `AgentSubagents` wire shapes — the
+// shell owns the fetch, exactly as `AgentConfigSkills.test.ts` does.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import AgentConfigSubagents from './AgentConfigSubagents.svelte';
+import type {
+  AgentSubagents,
+  SubagentCrossProduct,
+  SubagentInProduct,
+  SubagentInProductTarget,
+} from '../lib/agentConfig';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+function inTarget(over: Partial<SubagentInProductTarget> = {}): SubagentInProductTarget {
+  return {
+    name: 'engineer',
+    display_name: 'Engineer',
+    role: 'engineer',
+    tier: 'l1',
+    reachable: true,
+    reason: null,
+    ...over,
+  };
+}
+
+function inProduct(over: Partial<SubagentInProduct> = {}): SubagentInProduct {
+  return {
+    mechanism: 'in_product',
+    tool: 'delegate_to_agent',
+    tool_registered: true,
+    tool_granted: true,
+    delegator_tier: 'l1',
+    allowed_roles: ['engineer', 'qa', 'researcher', 'documentation', 'ops', 'planner', 'assistant'],
+    targets: [inTarget()],
+    role_excluded_count: 0,
+    unresolved: [],
+    ...over,
+  };
+}
+
+function crossProduct(over: Partial<SubagentCrossProduct> = {}): SubagentCrossProduct {
+  return {
+    mechanism: 'cross_product',
+    tool: 'dispatch_task',
+    tool_granted: false,
+    declares_allowed: false,
+    bridge_floor: ['research', 'ticketing'],
+    targets: [
+      { name: 'research', granted: false, reason: 'not listed in [subagents].allowed' },
+      { name: 'ticketing', granted: false, reason: 'not listed in [subagents].allowed' },
+    ],
+    rejected: [],
+    ...over,
+  };
+}
+
+function payload(over: Partial<AgentSubagents> = {}): AgentSubagents {
+  return {
+    resolved: true,
+    in_product: inProduct(),
+    cross_product: crossProduct(),
+    ...over,
+  };
+}
+
+/** Every element whose own label is exactly the `reachable` badge. */
+const reachableBadges = () =>
+  Array.from(target.querySelectorAll('span')).filter(
+    (s) => s.textContent?.trim() === 'reachable',
+  );
+
+function render(data: AgentSubagents | null, error = '') {
+  instance = mount(AgentConfigSubagents, {
+    target,
+    props: { data, error },
+  }) as unknown as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+});
+
+describe('AgentConfigSubagents — the two mechanisms', () => {
+  it('labels both mechanisms separately rather than flattening them', () => {
+    render(payload());
+    expect(target.textContent).toContain('In-product');
+    expect(target.textContent).toContain('delegate_to_agent');
+    expect(target.textContent).toContain('Cross-product');
+    expect(target.textContent).toContain('dispatch_task');
+    // The two sections must be distinct elements, not one merged list.
+    expect(target.querySelectorAll('section').length).toBe(2);
+  });
+
+  it('states that the in-product target set is not configurable', () => {
+    render(payload());
+    expect(target.textContent).toContain('role allow-list');
+    // The allow-list is quoted verbatim so the operator can see the rule —
+    // including `documentation`, the role that exists in NO other allow-set.
+    expect(target.textContent).toContain('documentation');
+  });
+
+  it('renders a reachable in-product target with its role and tier', () => {
+    render(payload());
+    expect(target.textContent).toContain('Engineer');
+    expect(target.textContent).toContain('engineer');
+    expect(target.textContent).toContain('tier l1');
+    expect(target.textContent).toContain('reachable');
+  });
+
+  it('distinguishes loading from loaded from error (G-4)', () => {
+    render(null);
+    expect(target.textContent).toContain('Resolving sub-agents…');
+    unmount(instance!);
+
+    render(null, 'GET /api/agents/izzie/subagents failed: 503');
+    expect(target.textContent).toContain('Could not load sub-agents');
+    expect(target.textContent).not.toContain('Resolving sub-agents…');
+    unmount(instance!);
+
+    render(payload());
+    expect(target.textContent).not.toContain('Resolving sub-agents…');
+    expect(target.textContent).not.toContain('Could not load sub-agents');
+  });
+});
+
+describe('AgentConfigSubagents — the L0/L1 tier gate (#4169)', () => {
+  // The single most important rendering rule: a target the gate refuses must
+  // never read as callable. It is SHOWN (an operator needs to know why it is
+  // missing) but under a refusal heading, with the gate's own reason.
+  it('renders a tier-blocked target as refused, with its reason, not as reachable', () => {
+    render(
+      payload({
+        in_product: inProduct({
+          targets: [
+            inTarget(),
+            inTarget({
+              name: 'orch',
+              display_name: 'Orchestrator',
+              role: 'assistant',
+              tier: 'l0',
+              reachable: false,
+              reason: 'refused by the L0/L1 delegation gate (#4169)',
+            }),
+          ],
+        }),
+      }),
+    );
+    expect(target.textContent).toContain('Refused by the delegation gate (1)');
+    expect(target.textContent).toContain('orch');
+    expect(target.textContent).toContain('L0/L1');
+    // The reachable card and the refused entry must not be confusable: exactly
+    // ONE element carries the "reachable" badge, and it is not the L0 target.
+    // (Asserted on badge ELEMENTS, not on `textContent` — the section's
+    // explanatory prose legitimately uses the word too.)
+    expect(reachableBadges()).toHaveLength(1);
+  });
+
+  it('shows no refusal block when every target is reachable', () => {
+    render(payload());
+    expect(target.textContent).not.toContain('Refused by the delegation gate');
+  });
+
+  it("reports this agent's own tier, the left-hand side of the gate", () => {
+    render(payload({ in_product: inProduct({ delegator_tier: 'l0' }) }));
+    expect(target.textContent).toContain('l0');
+  });
+});
+
+describe('AgentConfigSubagents — registered vs granted', () => {
+  it('says the tool is not registered for a non-assistant role', () => {
+    render(payload({ in_product: inProduct({ tool_registered: false, tool_granted: false }) }));
+    expect(target.textContent).toContain('not registered for this agent');
+    expect(target.textContent).toContain('Nothing below is callable');
+  });
+
+  it('distinguishes registered-but-ungranted from not-registered', () => {
+    render(payload({ in_product: inProduct({ tool_registered: true, tool_granted: false }) }));
+    expect(target.textContent).toContain('registered for this role but');
+    expect(target.textContent).toContain('[tools].allow');
+    expect(target.textContent).not.toContain('not registered for this agent');
+  });
+});
+
+describe('AgentConfigSubagents — cross-product deny-by-default (OQ-7)', () => {
+  it('teaches that an absent [subagents] section grants nothing, not everything', () => {
+    render(payload());
+    expect(target.textContent).toContain('declares no');
+    expect(target.textContent).toContain('does not mean "all"');
+    expect(target.textContent).toContain('0 of 2 cross-product specialists granted');
+  });
+
+  it('renders every floor specialist with its grant state, denied ones included', () => {
+    render(payload());
+    expect(target.textContent).toContain('research');
+    expect(target.textContent).toContain('ticketing');
+    expect(target.textContent?.match(/denied/g)).toHaveLength(2);
+  });
+
+  it('grants only the declared floor target, leaving the other denied', () => {
+    render(
+      payload({
+        cross_product: crossProduct({
+          tool_granted: true,
+          declares_allowed: true,
+          targets: [
+            { name: 'research', granted: true, reason: null },
+            { name: 'ticketing', granted: false, reason: 'not listed in [subagents].allowed' },
+          ],
+        }),
+      }),
+    );
+    expect(target.textContent).toContain('1 of 2 cross-product specialists granted');
+    expect(target.textContent).not.toContain('does not mean "all"');
+  });
+
+  it('surfaces a declared name the bridge floor refuses instead of dropping it', () => {
+    render(
+      payload({
+        cross_product: crossProduct({
+          declares_allowed: true,
+          rejected: [
+            {
+              name: 'engineer',
+              reason: 'not a permitted non-coding specialist — the bridge floor hard-denies it',
+            },
+          ],
+        }),
+      }),
+    );
+    expect(target.textContent).toContain('Declared but refused by the bridge floor (1)');
+    expect(target.textContent).toContain('engineer');
+  });
+});
+
+describe('AgentConfigSubagents — honest degradation', () => {
+  it('renders the fail-closed denial plus the parse error, never a blank pane', () => {
+    render(
+      payload({
+        resolved: false,
+        config_error: 'expected an equals, found an equals at line 1',
+        in_product: inProduct({
+          tool_registered: false,
+          tool_granted: false,
+          targets: [],
+        }),
+        cross_product: crossProduct(),
+      }),
+    );
+    expect(target.textContent).toContain('could not be resolved');
+    expect(target.textContent).toContain('fail-closed');
+    expect(target.textContent).toContain('No agent with a delegatable role resolves');
+    expect(target.textContent).toContain('0 of 2 cross-product specialists granted');
+  });
+
+  it('lists agents whose config did not resolve rather than dropping them', () => {
+    render(
+      payload({
+        in_product: inProduct({
+          unresolved: [{ name: 'halfbaked', reason: 'config did not resolve' }],
+        }),
+      }),
+    );
+    expect(target.textContent).toContain('1 agent whose config did not resolve');
+    expect(target.textContent).toContain('halfbaked');
+  });
+
+  it('counts role-excluded roster entries without naming them', () => {
+    render(payload({ in_product: inProduct({ role_excluded_count: 4 }) }));
+    expect(target.textContent).toContain('4 further agent(s)');
+    expect(target.textContent).toContain('excluded by the role');
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
@@ -14,6 +14,7 @@ import {
   fetchAgentStores,
   matchesToolGlob,
   fetchAgentSkills,
+  fetchAgentSubagents,
   type AgentStores,
 } from './agentConfig';
 
@@ -172,6 +173,76 @@ describe('fetchAgentSkills', () => {
     globalThis.fetch = (async () =>
       new Response('{}', { status: 503 })) as unknown as typeof fetch;
     await expect(fetchAgentSkills('izzie')).rejects.toThrow('503');
+  });
+});
+
+describe('fetchAgentSubagents', () => {
+  // #4029: same 404→null contract as `fetchAgentSkills`/`fetchAgentStores`, so
+  // a stale roster selection darkens one pane rather than throwing at the shell.
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  it('returns null on 404 rather than throwing', async () => {
+    globalThis.fetch = (async () =>
+      new Response('{}', { status: 404 })) as unknown as typeof fetch;
+    await expect(fetchAgentSubagents('ghost')).resolves.toBeNull();
+  });
+
+  it('parses both mechanisms without flattening them', async () => {
+    const body = {
+      resolved: true,
+      in_product: {
+        mechanism: 'in_product',
+        tool: 'delegate_to_agent',
+        tool_registered: true,
+        tool_granted: true,
+        delegator_tier: 'l1',
+        allowed_roles: ['engineer', 'documentation'],
+        targets: [
+          {
+            name: 'docs-agent',
+            display_name: 'Docs',
+            role: 'documentation',
+            tier: 'l1',
+            reachable: true,
+            reason: null,
+          },
+        ],
+        role_excluded_count: 3,
+        unresolved: [],
+      },
+      cross_product: {
+        mechanism: 'cross_product',
+        tool: 'dispatch_task',
+        tool_granted: false,
+        declares_allowed: false,
+        bridge_floor: ['research', 'ticketing'],
+        targets: [
+          { name: 'research', granted: false, reason: 'fail-closed' },
+          { name: 'ticketing', granted: false, reason: 'fail-closed' },
+        ],
+        rejected: [],
+      },
+    };
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      })) as unknown as typeof fetch;
+    const got = await fetchAgentSubagents('assistant');
+    // The two halves stay distinct — `documentation` is an in-product role and
+    // is in NO cross-product list, which is exactly why they are not merged.
+    expect(got?.in_product.targets[0].role).toBe('documentation');
+    expect(got?.cross_product.bridge_floor).toEqual(['research', 'ticketing']);
+    expect(got?.cross_product.targets.every((t) => !t.granted)).toBe(true);
+  });
+
+  it('throws on a non-404 failure so the pane can say the route is down', async () => {
+    globalThis.fetch = (async () =>
+      new Response('{}', { status: 503 })) as unknown as typeof fetch;
+    await expect(fetchAgentSubagents('izzie')).rejects.toThrow('503');
   });
 });
 

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -432,3 +432,103 @@ export async function fetchAgentSkills(name: string): Promise<AgentSkills | null
   if (!r.ok) throw new Error(`GET /api/agents/${name}/skills failed: ${r.status}`);
   return (await r.json()) as AgentSkills;
 }
+
+/**
+ * One in-product delegation target from `GET /api/agents/:name/subagents`
+ * (#4029) — a trusty-agents agent this agent may hand a task to via
+ * `delegate_to_agent`.
+ *
+ * `reachable` already accounts for #4169's one-directional L0/L1 tier gate, so a
+ * pane must render `reachable === false` as DENIED with its `reason` and must
+ * never present the card as callable. The server refuses to list targets the
+ * gate would refuse; a card that arrives unreachable is one the operator needs
+ * an explanation for, not one to hide.
+ */
+export interface SubagentInProductTarget {
+  name: string;
+  display_name: string;
+  /** The target's resolved `[agent].role` — the field the allowlist gates on. */
+  role: string;
+  /** `l0` | `l1`, resolved fail-closed server-side. */
+  tier: string;
+  reachable: boolean;
+  /** Present iff `reachable === false`. Explains which gate refused it. */
+  reason: string | null;
+}
+
+/**
+ * The in-product half of the Sub-agents section: `delegate_to_agent`.
+ *
+ * `tool_registered` and `tool_granted` are deliberately separate. The tool is
+ * only registered for assistant-tier personas, and even then dispatch is gated
+ * by the agent's own resolved tool patterns — collapsing the two into one badge
+ * would report "can delegate" for an agent that holds no such grant.
+ */
+export interface SubagentInProduct {
+  mechanism: 'in_product';
+  tool: string;
+  tool_registered: boolean;
+  tool_granted: boolean;
+  /** THIS agent's own resolved tier — the left-hand side of the gate. */
+  delegator_tier: string;
+  /** `ASSISTANT_ALLOWED_DELEGATE_ROLES`, verbatim, so the pane can state the rule. */
+  allowed_roles: string[];
+  targets: SubagentInProductTarget[];
+  /** Roster entries excluded by the role allowlist — counted, never named. */
+  role_excluded_count: number;
+  unresolved: { name: string; reason: string }[];
+}
+
+/**
+ * The cross-product half: `dispatch_task` into trusty-code's non-coding roster.
+ *
+ * Every `bridge_floor` specialist appears in `targets` with its grant state
+ * (the `/skills` precedent — report the whole vocabulary, not only the granted
+ * subset), so a denied specialist carries a reason rather than being invisible.
+ * `rejected` holds declared names the bridge floor hard-denies, which is the one
+ * way a hand-written `[subagents].allowed` silently does nothing.
+ */
+export interface SubagentCrossProduct {
+  mechanism: 'cross_product';
+  tool: string;
+  tool_granted: boolean;
+  /** `false` when the agent declares no `[subagents]` section at all. */
+  declares_allowed: boolean;
+  /** `NON_CODING_TARGETS` — the bridge-owned floor config can only narrow. */
+  bridge_floor: string[];
+  targets: { name: string; granted: boolean; reason: string | null }[];
+  rejected: { name: string; reason: string }[];
+}
+
+/** `GET /api/agents/:name/subagents`'s wire shape (#4029). */
+export interface AgentSubagents {
+  /**
+   * `false` when the agent's own config could not be resolved. Both halves then
+   * arrive empty and deny-everything, with `config_error` set — fail-closed, not
+   * a partial-parse guess.
+   */
+  resolved: boolean;
+  in_product: SubagentInProduct;
+  cross_product: SubagentCrossProduct;
+  config_error?: string;
+}
+
+/**
+ * Why (#4029, epic #4021 OQ-5): neither delegation mechanism was reachable over
+ * HTTP — `parse_agent_toml` enumerates twelve fields and `subagents` is not one
+ * of them — so the Sub-agents pane needs its own route rather than a derivation
+ * from `AgentDetail`. Critically, the in-product target set is not config at
+ * all: it is a hardcoded role allowlist crossed with the resolvable roster and
+ * narrowed by #4169's tier gate, none of which a client can compute.
+ * What: `null` on 404 (unknown agent) so a stale roster selection is a normal
+ * outcome, not a thrown error — same contract as `fetchAgentSkills`.
+ * Test: `fetchAgentSubagents_returns_null_on_404`.
+ */
+export async function fetchAgentSubagents(name: string): Promise<AgentSubagents | null> {
+  const r = await fetch(`${apiBase()}/api/agents/${encodeURIComponent(name)}/subagents`, {
+    headers: authHeaders(),
+  });
+  if (r.status === 404) return null;
+  if (!r.ok) throw new Error(`GET /api/agents/${name}/subagents failed: ${r.status}`);
+  return (await r.json()) as AgentSubagents;
+}


### PR DESCRIPTION
## Summary

The **sixth** agent-configuration section, full-stack — a new API route plus the GUI pane. Owner decision, 2026-07-26, resolving epic #4021's OQ-5: *"Sub-agents is its own configuration section."* Refined 2026-07-27 to require the section show the **UNION of BOTH** delegation mechanisms — which no spec had reconciled, and neither of which was reachable over HTTP.

`parse_agent_toml` (`api/server/projects.rs`) enumerates twelve `[agent]`/`[tools]` fields; `subagents` is not among them. So a Svelte component alone could only have guessed, and — more importantly — the in-product half is **not config at all**, so no client could have computed it.

Closes #4029

## The two mechanisms, and why they are not flattened

| | `in_product` | `cross_product` |
|---|---|---|
| Tool | `delegate_to_agent` (`tools/delegate.rs`) | `dispatch_task` (`tools/pm_bridge.rs`) |
| Reach | trusty-agents → trusty-agents, in-process | trusty-agents → trusty-code, out-of-process |
| Target set | `ASSISTANT_ALLOWED_DELEGATE_ROLES` (hardcoded) × resolvable roster, narrowed by the L0/L1 tier gate | `[subagents].allowed` ∩ `NON_CODING_TARGETS` |
| Per-agent config? | **No** | **Yes** — `SubagentsConfig` |
| Enforcement | `DelegateToAgentTool::execute` pre-flight | `SubagentAllowSet::resolve` at the bridge (OQ-7) |

Their vocabularies are **disjoint** — `documentation` is an in-product role and appears in no other allow-set in the codebase; `research`/`ticketing` are cross-product specialists and appear in no role allowlist. `the_two_mechanisms_have_a_disjoint_target_vocabulary` pins exactly that. A single flat list could not tell an operator which enforcement layer applies to a given name, which is why the payload labels them by kind.

## Design decisions

**A dedicated route, not an extension of `GET /api/agents/:name`.** Four reasons:

1. **Precedent.** Every other section already has its own route — `/stores`, `/skills`, `/permissions`, `/knowledge`. One pane, one route is the established shape (DOC-57 §4.5/§5.7/§7.4).
2. **Different resolution cost and posture.** `parse_agent_toml` is a partial `toml::from_str` of ONE file. This route resolves *every candidate agent on the host* through `AgentConfig::by_name_in`, because that is what the gate does. Folding that into the detail route would put a roster-wide filesystem walk behind the panel's very first fetch and behind `PATCH`'s response.
3. **File-size cap.** `projects.rs` is already 799 lines (grandfathered under the 500-SLOC cap). Adding this there would grow an over-cap file — a hard CI failure.
4. **Degradation isolation.** DOC-57 §8.3's G-5: one degraded backend darkens one pane, never the panel. The shell fetches this on its own leg, like `/skills` and `/stores`.

**This route resolves `extends`; its siblings do not.** `/skills`, `/knowledge` and `/permissions` document a known gap — they read one file and perform no `extends` merge, so they show what an agent *declares*, not its resolved effective set. This route cannot afford that gap: the gate it mirrors resolves through `by_name_in`, so an inherited `[subagents].allowed` grant **is** enforced and must therefore be shown. Pinned by `subagents_route_resolves_a_subagents_grant_inherited_via_extends`.

**Section position: between Skills and Listeners.** DOC-57 §2.1 declares the existing order normative, and this change **preserves it rather than overriding it**: every one of the five keeps its position relative to every other — no pair is swapped, Permissions is still last, and §8.2's G-1 reorder prohibition is untouched. Inserting between two of them leaves the five-order intact. Semantically it continues §2.1's progression (identity → knowledge → capability → reactivity → constraint): Skills is what the agent can do *itself*, Sub-agents is what it *hands off* — the same capability beat, so the two belong adjacent. `renders_exactly_six_tabs…` asserts the five-with-the-insertion-removed are byte-identical to §2.1's order, so a future edit that "makes room" by moving one of them fails.

**#4182 amends DOC-57 to document the sixth section.** This PR deliberately does not touch the spec; it cites the decision instead.

## Respecting the #4200 tier model

The in-product half applies the **same two checks, in the same order**, that `DelegateToAgentTool::execute`'s pre-flight performs, using the **same** `AgentConfig::by_name_in` resolution:

1. target's resolved `role` ∈ `ASSISTANT_ALLOWED_DELEGATE_ROLES`;
2. `target.tier() == L0Orchestration && delegator.tier() != L0Orchestration` ⇒ refused.

An L0 target is reported `reachable: false` **with the gate's reason** for an L1 delegator, not silently dropped — an operator needs to know why a target is missing, and a vanished card looks identical to one that was never declared. A candidate that fails to resolve lands in `unresolved`, because the gate refuses those too (`Err` ⇒ rejected).

**One small refactor to eliminate a drift hazard.** `AgentTier::from_declared(Option<&str>)` extracts `AgentInfo::tier()`'s match; `AgentInfo::tier()` now delegates to it. Without this, a consumer holding only a declared tier string had to hand-roll the parse — and if the two ever disagreed, this surface would advertise a target the gate refuses (or hide one it allows). Behavior is byte-identical: #4200's five tier tests are untouched and still pass, and `agent_tier_from_declared_matches_agent_info_tier` asserts the two entry points agree across every alias and every fail-closed case. `ASSISTANT_TIER_ROLE` was widened `pub(super)` → `pub(crate)` so this route reads the constant rather than re-typing the literal `"assistant"` (as `ctrl/pm_task/dispatch/persona.rs` was forced to).

**Nothing was granted, widened, or gated differently.** No `ASSISTANT_ALLOWED_DELEGATE_ROLES` or `NON_CODING_TARGETS` membership change; no change to `delegate.rs`'s gate; no `~/.trusty-agents/agents/` persona touched. This is a read path that refuses to advertise what the gate would refuse.

## Honesty rules (each has a test)

- **Registered ≠ granted.** `delegate_to_agent` is only registered for `role == ASSISTANT_TIER_ROLE`; even then dispatch is gated by the agent's resolved tool patterns. Reported as two independent flags — `subagents_route_reports_tool_not_registered_for_a_worker_role`, `subagents_route_separates_registered_from_granted`.
- **Absent denies.** No `[subagents]` section ⇒ every floor target denied, and the pane says so in words ("does not mean 'all'"). An *empty* list is the same posture.
- **Fail-closed on unresolvable config.** `200` + `resolved: false` + `config_error` + empty, denied lists — never a partial-parse guess. An agent whose config does not resolve does not run, so "delegates to nothing" is both the truthful and the safe answer.
- **The roster is not dumped.** Only role-eligible agents become cards; the rest are counted (`role_excluded_count`), never named — preserving #3052 PR A CRITICAL-2's posture.
- **A declared name the floor refuses is surfaced,** not silently dropped — the one way a hand-written `[subagents].allowed` does nothing.

## Test plan

**Backend — 19 new tests, all passing** (`cargo test -p trusty-agents --lib agent_subagents`: 19 passed, 0 failed):

- The tier interaction #4029 names explicitly: `subagents_route_hides_l0_target_from_l1_delegator` (L1 must not be shown an L0 target), its counter-test `subagents_route_shows_l0_target_to_l0_delegator` (without which "always unreachable" would pass), and `subagents_route_tier_fails_closed_for_an_unrecognized_value`.
- Cross-product deny-by-default: `subagents_route_cross_product_denies_everything_without_the_section` (absent AND empty), `cross_product_surface_denies_everything_when_nothing_is_declared`.
- Union/labelling: `subagents_route_reports_both_mechanisms_for_an_assistant`, `the_two_mechanisms_have_a_disjoint_target_vocabulary`.
- Floor invariant: `cross_product_surface_rejects_a_declared_coding_target`, `subagents_route_cross_product_grants_a_declared_floor_target`.
- Degradation: `subagents_route_degrades_on_malformed_toml`, `subagents_route_reports_unresolvable_target_rather_than_dropping_it`, `subagents_route_unknown_agent_404`, `subagents_route_rejects_traversal_name`, `subagents_route_is_wired_into_router`.
- Tier-parser equivalence: `agent_tier_from_declared_matches_agent_info_tier`, `agent_tier_wire_label_round_trips_through_from_declared`.

**UI — 16 new component tests + 3 client tests + updated panel tests**, matching how the sibling sections are tested (mount the component directly with wire shapes; the shell owns the fetch):

- `AgentConfigSubagents.test.ts` — both mechanisms labelled separately (asserted as two `<section>` elements, not one merged list); a tier-blocked target renders under a refusal heading with exactly ONE `reachable` badge in the pane; loading/loaded/error three states (G-4); registered-vs-granted; deny-by-default wording; fail-closed degradation.
- `AgentConfigPanel.test.ts` — six tabs, and the five-with-the-insertion-removed equal §2.1's normative order; the new pane renders its data; the bare-agent path asserts absent-denies on both mechanisms.
- `agentConfig.test.ts` — `fetchAgentSubagents` 404→null / parse / non-404 throw.

Every test name cited in a doc comment exists (the doc-comment pointer lint gates exactly that).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
