### PR TITLE
fix(trusty-review): refuse to confirm registry claims nothing looked up (#4081)

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -9,6 +9,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **A hallucinated dependency-version finding wore `code_provable: true` +
+  `verified: "confirmed"` and drove a false `BLOCK`/`F`** (closes
+  [#4081](https://github.com/bobmatnyc/trusty-tools/issues/4081)).
+  - A review of a one-line CI change (`ruff>=0.6.0` → `ruff==0.16.0`) reported
+    that `0.16.0` "does not exist on PyPI", reasoning explicitly from the
+    reviewer model's training cutoff. It was the current latest release, and all
+    ten checks on that PR were green on that exact dependency. Nothing in the
+    pipeline performs a registry lookup, so nothing had checked the claim — yet
+    it carried both signals a consumer reads to decide a finding is trustworthy,
+    and hard-clamped the verdict to `BLOCK`/`F`. A hallucination wearing a
+    confirmation is worse than no finding at all, and this failure mode is
+    concentrated on dependency bumps — the one diff shape where a reviewer's
+    version knowledge is stale by construction.
+  - New `pipeline::claim_grounding` pass (wired into
+    `finding_hygiene::sanitize_findings`, so both the unified and map-reduce
+    paths get it) demotes any finding whose text makes a package-registry
+    assertion — version absent, withdrawn, deprecated, "latest release is…",
+    "as of my knowledge cutoff" — to the advisory tier: `code_provable` cleared,
+    `effort` capped at Medium, `confidence` capped at the advisory band, and
+    `verified` pre-stamped with a new `VerifyOutcome::Unverifiable { reason }`.
+    `verify::select_candidates` now skips any finding whose outcome is already
+    decided, so such a claim is never put to the verifier LLM — a second model
+    with the same stale training knowledge would only launder the recollection
+    into a `"confirmed"`.
+  - **Refuse-to-confirm, not look-up.** Querying PyPI/npm/crates.io was
+    considered and rejected: it buys nothing the reported harm needs, and adds a
+    live network dependency, rate limits, and a new way for the review path
+    itself to hang. The principle encoded is stronger than any lookup — a claim
+    may be marked `verified: "confirmed"` only when something actually verified
+    it.
+  - **The finding is never dropped.** It still surfaces, verbatim, with an
+    advisory note telling the author nothing checked it and to confirm the pin
+    themselves. Only its grading weight is removed. A genuine, diff-provable
+    finding alongside it keeps full weight and still drives `BLOCK`.
+
 - **A live trusty-search was reported as `"unreachable"`, and a degraded verdict
   was indistinguishable from a complete one** (closes
   [#4086](https://github.com/bobmatnyc/trusty-tools/issues/4086)).

--- a/crates/trusty-review/src/models/mod.rs
+++ b/crates/trusty-review/src/models/mod.rs
@@ -181,6 +181,29 @@ pub enum VerifyOutcome {
     /// The finding was below the verification confidence threshold; not sent
     /// to the verifier.
     Skipped,
+    /// The finding makes a claim NOTHING in this pipeline can verify, so it was
+    /// deliberately never sent to the verifier and may never be marked
+    /// `Confirmed` (#4081).
+    ///
+    /// Why: `Confirmed` is the trust signal consumers read to decide a finding
+    /// is real. A package-registry assertion ("version X does not exist", "X is
+    /// deprecated") rests on the model's training-cutoff recollection, and the
+    /// verifier is the SAME kind of oracle — asking it launders a stale
+    /// recollection into a confirmation. Recording the un-verifiability
+    /// explicitly is honest where `Skipped` (which means "below the confidence
+    /// threshold") would be a lie about why the verifier was not consulted.
+    /// What: set by `pipeline::claim_grounding::demote_ungrounded_registry_claims`
+    /// BEFORE the verification round; `verify::select_candidates` skips any
+    /// finding whose outcome is already decided, so it can never be overwritten
+    /// with `Confirmed`. Unlike the refutation variants it is NOT excluded from
+    /// the verdict floor — the finding survives as an advisory note (it is the
+    /// demotion of `effort`/`confidence`/`code_provable` that keeps it from
+    /// escalating), because "we could not check this" is not "this is false".
+    Unverifiable {
+        /// Human-readable reason the claim is unverifiable (e.g.
+        /// `"package-registry version claim; no registry lookup performed"`).
+        reason: String,
+    },
 }
 
 // ─── Finding category ──────────────────────────────────────────────────────────

--- a/crates/trusty-review/src/pipeline/claim_grounding.rs
+++ b/crates/trusty-review/src/pipeline/claim_grounding.rs
@@ -1,0 +1,289 @@
+//! Grounding guard for package-registry / version-existence claims (#4081).
+//!
+//! Why: `review_pr` emitted a `code_provable: true`, `verified: "confirmed"`,
+//! `confidence: 0.82` finding asserting that a pinned dependency version does
+//! not exist —
+//!
+//! > "The CI workflow pins `ruff==0.16.0`, but ruff's versioning scheme uses a
+//! > `0.x.y` format where the latest stable releases are in the `0.4.x`–`0.9.x`
+//! > range as of mid-2026. Version `0.16.0` does not exist on PyPI."
+//!
+//! — and rolled it up to `verdict: BLOCK` / `grade: F`. `ruff==0.16.0` was the
+//! CURRENT latest release, and all ten checks on the PR were green on that exact
+//! dependency. The claim came from the reviewer model's training-cutoff
+//! recollection; **nothing in this pipeline performs a registry lookup**, so
+//! nothing verified it.
+//!
+//! Two things went wrong, and only the second is fixable here:
+//!
+//!  1. The model recalled a stale fact. Unfixable by construction — a package
+//!     registry moves continuously, and a model's version knowledge is stale the
+//!     day it ships.
+//!  2. The claim wore the pipeline's two strongest trust signals (`code_provable:
+//!     true`, `verified: "confirmed"`) without anything having checked it, and
+//!     those signals let it hard-clamp the verdict. **This is the defect.** A
+//!     hallucination wearing a confirmation is worse than no finding at all: it
+//!     inverts the signal consumers use to decide what to trust.
+//!
+//! And it lands precisely where it does the most damage. A dependency-bump diff
+//! is the single shape where the reviewer's version knowledge is guaranteed
+//! stale, and the shape whose author most expects to sail through.
+//!
+//! ## What: refuse to confirm, do not look up
+//!
+//! The obvious alternative — actually query PyPI/npm/crates.io — was considered
+//! and rejected. It buys nothing the reported harm needs: the false BLOCK is
+//! cured by declining to mark an unchecked claim as checked, and a lookup adds a
+//! live network dependency, rate limits, per-ecosystem client code, and a fresh
+//! way for the review path itself to hang or fail. The general principle this
+//! module encodes is narrower and stronger than any lookup:
+//!
+//! > **A claim may be marked `verified: "confirmed"` only when something actually
+//! > verified it.**
+//!
+//! So [`demote_ungrounded_registry_claims`] finds findings whose own text makes a
+//! registry-currency assertion and demotes each to the advisory tier:
+//!
+//!  - `verified = Unverifiable { reason }` — pre-stamped BEFORE the verification
+//!    round, and `verify::select_candidates` skips findings whose outcome is
+//!    already decided, so the verifier LLM is never asked a question it cannot
+//!    answer and can never stamp `Confirmed` over it.
+//!  - `code_provable = false` — a registry fact is by definition not provable
+//!    from the diff. This alone drops the finding out of
+//!    `grade::drives_block_floor`.
+//!  - `effort` capped at `Medium` — the same demotion
+//!    `finding_hygiene::demote_diff_absent_speculation` applies (#4043).
+//!  - `confidence` capped at [`UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE`] — see that
+//!    constant for why the exact value matters to `grade.rs`.
+//!  - an advisory note appended to `description`, so a human reading the review
+//!    is told the claim is unchecked rather than silently handed a weaker one.
+//!
+//! ## What it deliberately does NOT do
+//!
+//! It never drops the finding. "trusty-review could not check this version"
+//! is real, useful information for the author — a nudge to confirm the pin
+//! themselves. Over-suppression would trade a false BLOCK for a false silence.
+//! The finding stays in the rendered review verbatim (plus the note); only its
+//! grading weight is removed.
+//!
+//! Test: `claim_grounding_tests.rs` (unit) and
+//! `tests/registry_claim_4081_regression.rs` (the issue's verbatim finding,
+//! end-to-end through the grade derivation).
+
+use tracing::warn;
+
+use crate::models::{Effort, Finding, VerifyOutcome};
+
+/// Confidence a demoted ungrounded registry claim is capped at.
+///
+/// Why: the value is load-bearing against two thresholds in `grade.rs`, and sits
+/// in the only band that satisfies both:
+///
+///  - It must be `<= grade::LOW_CONFIDENCE_THRESHOLD` (0.65 — "the advisory-batch
+///    collapse line"). `derive_verdict_with`'s low-confidence override returns
+///    APPROVE when every substantive finding sits at or below that line and none
+///    drives the BLOCK floor. That is what dissolves the model's OWN self-reported
+///    `verdict: "BLOCK"` — the severity floor alone cannot, because
+///    `stricter_of(model_proposed, floor)` can only ever RAISE toward the floor.
+///    Reusing the existing override rather than adding a parallel relaxation is
+///    deliberate: #4057 established that mechanism-per-defect proliferation is the
+///    thing to avoid here.
+///  - It must stay high enough to keep the finding VISIBLE. Nothing in the render
+///    path filters on confidence today, but `constants::FIX_ISSUE_MIN_CONFIDENCE`
+///    (0.60) is the documented review-include gate, so staying at or above it
+///    keeps the anti-over-suppression guarantee true even if that gate is wired
+///    up later.
+///
+/// It also lands below `constants::BLOCK_ISSUE_MIN_CONFIDENCE` (0.75), so an
+/// unchecked registry claim can never open a tracker issue either.
+///
+/// What: applied with `min`, never `max` — a finding the model already rated
+/// lower keeps its lower value; this is a ceiling, not an assignment.
+/// Test: `advisory_confidence_sits_in_the_visible_but_non_escalating_band`.
+pub const UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE: f32 = 0.65;
+
+/// Sentinel opening the advisory note appended to a demoted finding.
+///
+/// Why: [`demote_ungrounded_registry_claims`] runs once per pipeline path today,
+/// but the note it appends itself contains registry vocabulary — re-running the
+/// pass over already-demoted findings would otherwise append the note again.
+/// Matching on this sentinel makes the pass idempotent by construction rather
+/// than by call-site discipline.
+/// What: the literal prefix of [`UNGROUNDED_CLAIM_NOTE`].
+/// Test: `pass_is_idempotent`.
+const UNGROUNDED_CLAIM_NOTE_SENTINEL: &str = "_Unverified registry claim (#4081)";
+
+/// Advisory note appended to the `description` of a demoted finding.
+///
+/// Why: demoting silently would leave the author reading a confident-sounding
+/// claim with no hint that nothing checked it. The note names the specific reason
+/// and tells them what to do about it.
+/// What: deliberately phrased to avoid every marker string in
+/// `finding_hygiene`'s `SELF_NEGATION_MARKERS` / `DIFF_ABSENT_SPECULATION_MARKERS`
+/// (no "does not exist", no "not a finding", no "appears correct") so appending it
+/// can never cause a later hygiene pass to drop the finding it is annotating.
+/// Test: `advisory_note_does_not_trip_finding_hygiene_markers`.
+const UNGROUNDED_CLAIM_NOTE: &str = "_Unverified registry claim (#4081): this \
+     finding asserts a package-registry fact — that a pinned version is absent \
+     from the registry, was withdrawn, or is out of date. trusty-review performs \
+     no registry lookup, and a reviewer model's version knowledge is stale by \
+     construction, so nothing here checked it. Confirm against the registry \
+     directly before acting. Demoted to advisory: it cannot drive a blocking \
+     verdict._";
+
+/// Reason recorded in [`VerifyOutcome::Unverifiable`] for a demoted claim.
+const UNVERIFIABLE_REASON: &str =
+    "package-registry version/deprecation claim; no registry lookup is performed by this pipeline";
+
+/// Case-insensitive substrings naming a package registry, a package manifest, or
+/// an install command — the SUBJECT half of a registry claim.
+///
+/// Why: the assertion half alone ("does not exist", "latest version") is far too
+/// generic to key on — plenty of legitimate code findings use those words about
+/// a variable, a route, or a config key. Requiring the finding to ALSO be talking
+/// about a package registry is what keeps the guard from firing on ordinary
+/// correctness findings.
+/// What: matched via `str::contains` after lowercasing the finding's combined
+/// text. Covers the five registries a reviewer model most often mis-recalls plus
+/// the manifests/commands that unambiguously scope a claim to one of them.
+/// Test: `does_not_demote_ordinary_finding_using_existence_words`.
+const REGISTRY_SUBJECT_MARKERS: &[&str] = &[
+    "pypi",
+    "npmjs",
+    "npm registry",
+    "crates.io",
+    "rubygems",
+    "packagist",
+    "maven central",
+    "nuget",
+    "go module proxy",
+    "package registry",
+    "package index",
+    "pip install",
+    "npm install",
+    "yarn add",
+    "cargo add",
+    "requirements.txt",
+    "pyproject.toml",
+    "package.json",
+    "package-lock.json",
+    "cargo.toml",
+    "go.mod",
+    "gemfile",
+    "poetry.lock",
+    "uv.lock",
+];
+
+/// Case-insensitive substrings asserting a registry FACT the model cannot know —
+/// the ASSERTION half of a registry claim.
+///
+/// Why: every entry is a claim about the state of a live, continuously-moving
+/// registry at review time (does this version exist / is it the newest / was it
+/// withdrawn / is it deprecated), or an explicit appeal to the model's own
+/// training cutoff. Those are exactly the assertions a training-cutoff
+/// recollection cannot support. The first five are verbatim from #4081's own
+/// output ("does not exist on PyPI", "No matching distribution found", "the
+/// latest stable releases are ... as of mid-2026").
+/// What: matched via `str::contains` after lowercasing, and required to co-occur
+/// with a [`REGISTRY_SUBJECT_MARKERS`] hit.
+/// Test: `demotes_the_verbatim_4081_finding`, `demotes_each_assertion_marker`.
+const REGISTRY_ASSERTION_MARKERS: &[&str] = &[
+    "does not exist",
+    "doesn't exist",
+    "no matching distribution",
+    "non-existent",
+    "nonexistent",
+    "no such version",
+    "not published",
+    "never published",
+    "unpublished",
+    "was yanked",
+    "has been yanked",
+    "is yanked",
+    "latest stable",
+    "latest release",
+    "latest version",
+    "most recent release",
+    "is deprecated",
+    "has been deprecated",
+    "deprecated in version",
+    "as of my knowledge",
+    "as of my training",
+    "knowledge cutoff",
+];
+
+/// Return the assertion marker that makes `f` an unverifiable registry claim, if
+/// it is one.
+///
+/// Why: exposed (rather than folded into the demotion loop) so the classification
+/// can be asserted directly in tests and reused by any future caller that needs
+/// to ask "is this a registry claim?" without mutating anything.
+/// What: requires BOTH a [`REGISTRY_SUBJECT_MARKERS`] hit and a
+/// [`REGISTRY_ASSERTION_MARKERS`] hit in the lowercased concatenation of `kind`,
+/// `description`, and `consequence`; returns the assertion marker that matched.
+/// Test: `demotes_the_verbatim_4081_finding`,
+/// `does_not_demote_ordinary_finding_using_existence_words`,
+/// `does_not_demote_registry_mention_without_an_assertion`.
+pub fn registry_claim_marker(f: &Finding) -> Option<&'static str> {
+    let haystack = format!("{} {} {}", f.kind, f.description, f.consequence).to_lowercase();
+    if !REGISTRY_SUBJECT_MARKERS
+        .iter()
+        .any(|m| haystack.contains(m))
+    {
+        return None;
+    }
+    REGISTRY_ASSERTION_MARKERS
+        .iter()
+        .find(|m| haystack.contains(*m))
+        .copied()
+}
+
+/// Demote every ungrounded package-registry claim to the advisory tier (#4081).
+///
+/// Why: see the module doc — a claim nothing verified may not wear the
+/// pipeline's verification signals nor drive a blocking verdict, but it must
+/// still reach the author.
+/// What: for each finding [`registry_claim_marker`] identifies and that has not
+/// already been demoted (see [`UNGROUNDED_CLAIM_NOTE_SENTINEL`]): stamps
+/// `verified = Unverifiable`, clears `code_provable`, caps `effort` at `Medium`
+/// and `confidence` at [`UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE`], and appends
+/// [`UNGROUNDED_CLAIM_NOTE`] to the description. Returns how many were demoted.
+/// Never drops a finding and never touches a non-registry finding.
+/// Test: `demotes_the_verbatim_4081_finding`, `pass_is_idempotent`,
+/// `does_not_demote_ordinary_finding_using_existence_words`.
+pub fn demote_ungrounded_registry_claims(findings: &mut [Finding]) -> usize {
+    let mut demoted = 0usize;
+    for f in findings.iter_mut() {
+        if f.description.contains(UNGROUNDED_CLAIM_NOTE_SENTINEL) {
+            continue;
+        }
+        let Some(marker) = registry_claim_marker(f) else {
+            continue;
+        };
+        warn!(
+            file = %f.file,
+            line = ?f.line,
+            kind = %f.kind,
+            marker,
+            prior_confidence = f.confidence,
+            prior_effort = %f.effort,
+            prior_code_provable = f.code_provable,
+            "claim-grounding: demoting unverified package-registry claim to advisory (#4081)"
+        );
+        f.verified = Some(VerifyOutcome::Unverifiable {
+            reason: UNVERIFIABLE_REASON.to_string(),
+        });
+        f.code_provable = false;
+        if f.effort == Effort::High {
+            f.effort = Effort::Medium;
+        }
+        f.confidence = f.confidence.min(UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE);
+        f.description = format!("{}\n\n{}", f.description, UNGROUNDED_CLAIM_NOTE);
+        demoted += 1;
+    }
+    demoted
+}
+
+#[cfg(test)]
+#[path = "claim_grounding_tests.rs"]
+mod tests;

--- a/crates/trusty-review/src/pipeline/claim_grounding_tests.rs
+++ b/crates/trusty-review/src/pipeline/claim_grounding_tests.rs
@@ -1,0 +1,233 @@
+//! Unit tests for `claim_grounding` (#4081).
+//!
+//! Fixtures use the VERBATIM finding #4081 reports (the `ruff==0.16.0` claim
+//! against `duettoresearch/APEX` PR 1717) so they stay traceable to the reported
+//! evidence, plus the negative cases that keep the guard from over-firing.
+
+use super::*;
+use crate::config::constants::{BLOCK_ISSUE_MIN_CONFIDENCE, FIX_ISSUE_MIN_CONFIDENCE};
+use crate::models::Finding;
+
+/// The finding #4081 reports, field for field.
+fn ruff_finding() -> Finding {
+    let mut f = Finding::new(
+        ".github/workflows/repos-all-advisory.yml",
+        "ruff pinned to non-existent version 0.16.0",
+        "The CI workflow pins `ruff==0.16.0`, but ruff's versioning scheme uses a \
+         `0.x.y` format where the latest stable releases are in the `0.4.x`–`0.9.x` \
+         range as of mid-2026. Version `0.16.0` does not exist on PyPI. This will \
+         cause the `pip install` step to fail with a \"No matching distribution \
+         found\" error, breaking CI for every PR that touches the linted files.",
+        "Pin a ruff version that exists.",
+        0.82,
+        Effort::High,
+    );
+    f.line = Some(41);
+    f.consequence = "CI pip install step fails with 'No matching distribution found', \
+                     breaking the advisory workflow on every run"
+        .to_string();
+    f.code_provable = true;
+    f
+}
+
+// ─── The reported defect ─────────────────────────────────────────────────────
+
+#[test]
+fn demotes_the_verbatim_4081_finding() {
+    let mut findings = vec![ruff_finding()];
+    assert_eq!(demote_ungrounded_registry_claims(&mut findings), 1);
+
+    let f = &findings[0];
+    assert!(
+        !f.code_provable,
+        "an unchecked registry fact is not provable from the diff"
+    );
+    assert_eq!(
+        f.effort,
+        Effort::Medium,
+        "capped out of the BLOCK-floor tier"
+    );
+    assert!(
+        (f.confidence - UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE).abs() < f32::EPSILON,
+        "confidence capped at the advisory band, got {}",
+        f.confidence
+    );
+    assert!(
+        matches!(f.verified, Some(VerifyOutcome::Unverifiable { .. })),
+        "must be pre-stamped Unverifiable, got {:?}",
+        f.verified
+    );
+}
+
+#[test]
+fn demoted_finding_still_surfaces_with_an_advisory_note() {
+    // Anti-over-suppression: the finding must still be PRESENT and still carry
+    // the model's original prose — only its grading weight is removed.
+    let mut findings = vec![ruff_finding()];
+    demote_ungrounded_registry_claims(&mut findings);
+
+    assert_eq!(findings.len(), 1, "the finding must not be dropped");
+    let f = &findings[0];
+    assert!(
+        f.description
+            .contains("Version `0.16.0` does not exist on PyPI."),
+        "the original claim text must survive verbatim: {}",
+        f.description
+    );
+    assert!(
+        f.description.contains(UNGROUNDED_CLAIM_NOTE_SENTINEL),
+        "the reader must be told nothing checked it: {}",
+        f.description
+    );
+    assert!(
+        f.confidence >= FIX_ISSUE_MIN_CONFIDENCE,
+        "must stay at or above the review-include gate ({FIX_ISSUE_MIN_CONFIDENCE}), \
+         got {}",
+        f.confidence
+    );
+}
+
+#[test]
+fn demotes_each_assertion_marker() {
+    // Every assertion marker, paired with a registry subject, must trip the guard.
+    for marker in REGISTRY_ASSERTION_MARKERS {
+        let mut findings = vec![Finding::new(
+            "requirements.txt",
+            "dependency",
+            format!("The pinned package in requirements.txt {marker} — check the pin."),
+            "fix",
+            0.9,
+            Effort::High,
+        )];
+        assert_eq!(
+            demote_ungrounded_registry_claims(&mut findings),
+            1,
+            "assertion marker {marker:?} must be demoted"
+        );
+    }
+}
+
+// ─── Over-firing guards ──────────────────────────────────────────────────────
+
+#[test]
+fn does_not_demote_ordinary_finding_using_existence_words() {
+    // "does not exist" about a CODE symbol, with no registry subject anywhere —
+    // an ordinary correctness finding that must keep its full weight.
+    let mut findings = vec![Finding::new(
+        "src/router.ts",
+        "logic-error",
+        "The handler dispatches to `resolveTenant`, but that export does not exist \
+         in `src/tenant.ts` — this is a compile error.",
+        "Add the export.",
+        0.9,
+        Effort::High,
+    )];
+    findings[0].code_provable = true;
+
+    assert_eq!(demote_ungrounded_registry_claims(&mut findings), 0);
+    assert_eq!(findings[0].effort, Effort::High);
+    assert!(findings[0].code_provable);
+    assert!(findings[0].verified.is_none());
+}
+
+#[test]
+fn does_not_demote_registry_mention_without_an_assertion() {
+    // A real, checkable finding ABOUT a manifest file: it argues from the diff,
+    // not from a recollection of registry state.
+    let mut findings = vec![Finding::new(
+        "package.json",
+        "build-break",
+        "This diff removes `react-dom` from package.json dependencies while \
+         `src/index.tsx` still imports it — the build will not resolve.",
+        "Restore the dependency.",
+        0.88,
+        Effort::High,
+    )];
+    findings[0].code_provable = true;
+
+    assert_eq!(demote_ungrounded_registry_claims(&mut findings), 0);
+    assert_eq!(findings[0].effort, Effort::High);
+    assert!(findings[0].code_provable);
+}
+
+#[test]
+fn does_not_raise_a_lower_confidence() {
+    // The cap is a ceiling, never an assignment — a claim the model itself rated
+    // low must not be *promoted* to the advisory band.
+    let mut findings = vec![ruff_finding()];
+    findings[0].confidence = 0.21;
+    demote_ungrounded_registry_claims(&mut findings);
+    assert!(
+        (findings[0].confidence - 0.21).abs() < f32::EPSILON,
+        "got {}",
+        findings[0].confidence
+    );
+}
+
+#[test]
+fn does_not_promote_a_low_effort_claim() {
+    let mut findings = vec![ruff_finding()];
+    findings[0].effort = Effort::Low;
+    demote_ungrounded_registry_claims(&mut findings);
+    assert_eq!(findings[0].effort, Effort::Low, "Low must stay Low");
+}
+
+#[test]
+fn pass_is_idempotent() {
+    let mut findings = vec![ruff_finding()];
+    assert_eq!(demote_ungrounded_registry_claims(&mut findings), 1);
+    let after_first = findings[0].description.clone();
+
+    assert_eq!(
+        demote_ungrounded_registry_claims(&mut findings),
+        0,
+        "a second run must be a no-op"
+    );
+    assert_eq!(
+        findings[0].description, after_first,
+        "the advisory note must not be appended twice"
+    );
+}
+
+// ─── Constant / note invariants ──────────────────────────────────────────────
+
+/// The advisory-band invariants, as compile-time assertions.
+///
+/// Written as `const _: () = assert!(..)` (the idiom `config::constants`'s own
+/// `threshold_ordering` test uses) so a bad edit to
+/// [`UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE`] fails the BUILD rather than one test
+/// run — the value is load-bearing against thresholds in two other modules.
+#[test]
+fn advisory_confidence_sits_in_the_visible_but_non_escalating_band() {
+    // At or above the review-include gate, or the finding vanishes — that would
+    // trade #4081's false BLOCK for a false silence.
+    const _: () = assert!(UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE >= FIX_ISSUE_MIN_CONFIDENCE);
+    // Below the tracker-issue gate: an unchecked claim must not open an issue.
+    const _: () = assert!(UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE < BLOCK_ISSUE_MIN_CONFIDENCE);
+    // At or below `grade.rs`'s advisory-batch collapse line — that override is
+    // what dissolves a model self-reported BLOCK. The constant is private there,
+    // so assert against its documented value (0.65); a change there trips this
+    // rather than silently un-fixing #4081.
+    const _: () = assert!(UNGROUNDED_CLAIM_ADVISORY_CONFIDENCE <= 0.65);
+}
+
+#[test]
+fn advisory_note_does_not_trip_finding_hygiene_markers() {
+    // The note is appended to `description`; if it contained a hygiene marker,
+    // a later pass would drop or re-demote the very finding it annotates.
+    let mut findings = vec![ruff_finding()];
+    demote_ungrounded_registry_claims(&mut findings);
+    let mut annotated: Vec<Finding> = findings.clone();
+
+    let counts = crate::pipeline::finding_hygiene::sanitize_findings(&mut annotated);
+    assert_eq!(counts.dropped_self_negated, 0, "note must not self-negate");
+    assert_eq!(
+        counts.demoted_diff_absent, 0,
+        "note must not read as speculation"
+    );
+    assert_eq!(
+        counts.demoted_ungrounded_registry, 0,
+        "the sentinel must stop the note re-triggering its own pass"
+    );
+    assert_eq!(annotated.len(), 1);
+}

--- a/crates/trusty-review/src/pipeline/finding_hygiene.rs
+++ b/crates/trusty-review/src/pipeline/finding_hygiene.rs
@@ -26,7 +26,7 @@
 //!    document ... no implementation ... is present", "if implementation
 //!    follows the interface literally") and reason past it anyway.
 //!
-//! What: [`sanitize_findings`] runs two independent, marker-based passes, both
+//! What: [`sanitize_findings`] runs three independent, marker-based passes, all
 //! reusing the SAME shape — the finding's own text is the signal, no LLM
 //! double-check required:
 //!
@@ -44,6 +44,17 @@
 //!     structurally prevents it from ever driving BLOCK
 //!     (`grade::drives_block_floor` requires `Effort::High`), while leaving it
 //!     as an advisory note.
+//!  3. [`claim_grounding::demote_ungrounded_registry_claims`] (#4081) — DEMOTES
+//!     (does not drop) any finding asserting a package-registry fact nothing in
+//!     this pipeline looked up, and pre-stamps it `Unverifiable` so the verifier
+//!     round can never mark it `Confirmed`. Same defect family as the two above —
+//!     the system asserting a state it never observed — but a distinct signal
+//!     (registry vocabulary, not self-admission), so it lives in its own module
+//!     with its own marker sets and test surface, exactly as `citation_check`
+//!     does. See `claim_grounding` for the full rationale.
+//!
+//! [`claim_grounding::demote_ungrounded_registry_claims`]:
+//!     crate::pipeline::claim_grounding::demote_ungrounded_registry_claims
 //!
 //! Both passes run BEFORE `citation_check::enforce_citation_integrity` (see
 //! `runner.rs` / `mapreduce/mod.rs`) so a self-negated finding never
@@ -117,19 +128,42 @@ const DIFF_ABSENT_SPECULATION_MARKERS: &[&str] = &[
     "is not yet implemented code",
 ];
 
+/// Counts returned by [`sanitize_findings`], one per pass.
+///
+/// Why: a bare tuple stopped reading clearly once a third pass (#4081) joined
+/// the two original ones — `(usize, usize, usize)` at a call site says nothing
+/// about which count is which.
+/// What: plain public counters; every field is "how many findings this pass
+/// acted on".
+/// Test: `sanitize_findings_runs_every_pass`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct HygieneCounts {
+    /// Findings dropped as self-negated / chain-of-thought-leaking (#4044).
+    pub dropped_self_negated: usize,
+    /// Findings demoted as diff-absent speculation (#4043).
+    pub demoted_diff_absent: usize,
+    /// Findings demoted as unverified package-registry claims (#4081).
+    pub demoted_ungrounded_registry: usize,
+}
+
 /// Run every output-hygiene pass over `findings`, in place.
 ///
-/// Why: a single call site for both #4043 and #4044's fixes keeps `runner.rs`
+/// Why: a single call site for #4043, #4044 and #4081's fixes keeps `runner.rs`
 /// and `mapreduce/mod.rs` from having to know the internal pass ordering.
 /// What: drops self-negated/leaked findings FIRST (so they never participate
 /// in downstream checks — e.g. `citation_check`'s mutual-contradiction pass),
-/// then demotes any surviving diff-absent-speculation High finding. Returns
-/// `(dropped, demoted)`.
-/// Test: `sanitize_findings_runs_both_passes`.
-pub fn sanitize_findings(findings: &mut Vec<Finding>) -> (usize, usize) {
-    let dropped = drop_self_negated_or_leaked_findings(findings);
-    let demoted = demote_diff_absent_speculation(findings);
-    (dropped, demoted)
+/// then demotes any surviving diff-absent-speculation High finding, then demotes
+/// any surviving unverified package-registry claim (`claim_grounding`, #4081 —
+/// last, because the advisory note it appends contains registry vocabulary the
+/// earlier marker passes have no business re-reading).
+/// Test: `sanitize_findings_runs_every_pass`.
+pub fn sanitize_findings(findings: &mut Vec<Finding>) -> HygieneCounts {
+    HygieneCounts {
+        dropped_self_negated: drop_self_negated_or_leaked_findings(findings),
+        demoted_diff_absent: demote_diff_absent_speculation(findings),
+        demoted_ungrounded_registry:
+            crate::pipeline::claim_grounding::demote_ungrounded_registry_claims(findings),
+    }
 }
 
 /// Drop any finding whose `kind`/`description`/`consequence` contains a

--- a/crates/trusty-review/src/pipeline/finding_hygiene_tests.rs
+++ b/crates/trusty-review/src/pipeline/finding_hygiene_tests.rs
@@ -243,7 +243,7 @@ fn does_not_demote_legitimate_implementation_grounded_finding() {
 // ─── Orchestration ─────────────────────────────────────────────────────────────
 
 #[test]
-fn sanitize_findings_runs_both_passes() {
+fn sanitize_findings_runs_every_pass() {
     let mut findings = vec![
         finding(
             Effort::Medium,
@@ -253,14 +253,25 @@ fn sanitize_findings_runs_both_passes() {
             Effort::High,
             "If implementation follows the interface literally, this breaks.",
         ),
+        finding(
+            Effort::High,
+            "The workflow runs `pip install \"ruff==0.16.0\"`, but version 0.16.0 \
+             does not exist on PyPI.",
+        ),
         finding(Effort::High, "Real SQL injection provable from the diff."),
     ];
-    let (dropped, demoted) = sanitize_findings(&mut findings);
-    assert_eq!(dropped, 1);
-    assert_eq!(demoted, 1);
-    assert_eq!(findings.len(), 2);
+    let counts = sanitize_findings(&mut findings);
+    assert_eq!(counts.dropped_self_negated, 1);
+    assert_eq!(counts.demoted_diff_absent, 1);
+    assert_eq!(counts.demoted_ungrounded_registry, 1, "#4081 pass is wired");
+    assert_eq!(findings.len(), 3);
     assert_eq!(findings[0].effort, Effort::Medium, "demoted, not dropped");
-    assert_eq!(findings[1].effort, Effort::High, "untouched real finding");
+    assert_eq!(
+        findings[1].effort,
+        Effort::Medium,
+        "#4081 demoted, not dropped"
+    );
+    assert_eq!(findings[2].effort, Effort::High, "untouched real finding");
 }
 
 // ─── relax_verdict_if_evidence_wiped (#4042, #4044) ───────────────────────────

--- a/crates/trusty-review/src/pipeline/mod.rs
+++ b/crates/trusty-review/src/pipeline/mod.rs
@@ -25,6 +25,11 @@
 //! Test: each submodule carries its own unit tests.
 
 pub mod citation_check;
+// Why: the grounding guard for package-registry / version-existence claims
+// (#4081) — kept separate from `finding_hygiene` (self-admission markers) and
+// `citation_check` (path/content verification) because it keys on a different
+// signal entirely and carries its own marker sets and test surface.
+pub mod claim_grounding;
 pub mod context_gate;
 pub mod diff;
 pub mod diff_analyzer;

--- a/crates/trusty-review/src/pipeline/verify.rs
+++ b/crates/trusty-review/src/pipeline/verify.rs
@@ -367,8 +367,18 @@ fn verdict_min(a: Verdict, b: Verdict) -> Verdict {
 /// finding with `confidence >= VERIFY_CANDIDATE_MIN_CONFIDENCE` (0.50).  For
 /// APPROVE / APPROVE*: only findings with `confidence >= BLOCK_VERDICT_MIN_CONFIDENCE`
 /// (0.90).  UNKNOWN never reaches here (handled by the caller).
+///
+/// A finding that ALREADY carries a `verified` outcome is never a candidate
+/// (#4081).  Nothing set that field before the round until `claim_grounding`
+/// began pre-stamping `Unverifiable` on package-registry claims the pipeline
+/// cannot check; sending one to the verifier would let a second model with the
+/// same stale training knowledge launder the recollection into
+/// `verified: "confirmed"` — the exact trust-signal inversion #4081 reports.
+/// The rule is stated generally rather than as an `Unverifiable` special case:
+/// an outcome that is already decided is not a question worth re-asking.
 /// Test: `select_candidates_block_uses_wide_net`,
-/// `select_candidates_approve_uses_block_tier_only`.
+/// `select_candidates_approve_uses_block_tier_only`,
+/// `select_candidates_skips_findings_with_a_decided_outcome`.
 pub fn select_candidates(primary_verdict: Verdict, findings: &[Finding]) -> Vec<usize> {
     let floor = match primary_verdict {
         Verdict::RequestChanges | Verdict::Block => VERIFY_CANDIDATE_MIN_CONFIDENCE,
@@ -380,7 +390,7 @@ pub fn select_candidates(primary_verdict: Verdict, findings: &[Finding]) -> Vec<
     findings
         .iter()
         .enumerate()
-        .filter(|(_, f)| f.confidence >= floor)
+        .filter(|(_, f)| f.verified.is_none() && f.confidence >= floor)
         .map(|(i, _)| i)
         .collect()
 }

--- a/crates/trusty-review/src/pipeline/verify_tests.rs
+++ b/crates/trusty-review/src/pipeline/verify_tests.rs
@@ -138,6 +138,29 @@ fn select_candidates_request_changes_uses_wide_net() {
 }
 
 #[test]
+fn select_candidates_skips_findings_with_a_decided_outcome() {
+    // #4081: a finding whose `verified` outcome is already decided is not a
+    // question worth re-asking. `claim_grounding` pre-stamps `Unverifiable` on a
+    // package-registry claim precisely so the verifier — a second model with the
+    // same stale training knowledge — can never launder it into `Confirmed`.
+    let mut findings = vec![finding(Effort::High, 0.95), finding(Effort::High, 0.95)];
+    assert_eq!(
+        select_candidates(Verdict::Block, &findings),
+        vec![0, 1],
+        "precondition: both clear the confidence net"
+    );
+
+    findings[0].verified = Some(VerifyOutcome::Unverifiable {
+        reason: "no registry lookup performed".to_string(),
+    });
+    assert_eq!(
+        select_candidates(Verdict::Block, &findings),
+        vec![1],
+        "an already-decided outcome must not be re-verified"
+    );
+}
+
+#[test]
 fn select_candidates_approve_uses_block_tier_only() {
     // On an APPROVE* verdict only blocking-tier (>= 0.90) findings are verified.
     let findings = vec![

--- a/crates/trusty-review/tests/registry_claim_4081_regression.rs
+++ b/crates/trusty-review/tests/registry_claim_4081_regression.rs
@@ -1,0 +1,232 @@
+//! Regression tests for #4081: a hallucinated dependency-version finding wore
+//! `code_provable: true` + `verified: "confirmed"` and drove `BLOCK` / `F`.
+//!
+//! The fixture is the reported case verbatim — `duettoresearch/APEX` PR 1717's
+//! one-line CI change (`ruff>=0.6.0` → `ruff==0.16.0`) and the finding text
+//! #4081 quotes in full. `ruff==0.16.0` was in fact the CURRENT latest release,
+//! and all ten checks on that PR were green on that exact dependency; the claim
+//! came from the reviewer model's training-cutoff recollection and nothing in
+//! the pipeline looked it up.
+//!
+//! Three things are locked in:
+//!  (a) the claim is NOT marked `verified: "confirmed"` and does NOT drive a
+//!      BLOCK — including the model's own self-reported `verdict: "BLOCK"`,
+//!      which rested on the same unchecked evidence;
+//!  (b) it still SURFACES, as an advisory carrying the model's original prose
+//!      plus a note saying nothing checked it — the anti-over-suppression half,
+//!      asserted as PRESENCE, not absence;
+//!  (c) a finding that IS backed by verification still confirms and still drives
+//!      BLOCK — the capability is retained, not traded away for (a).
+//!
+//! Verified failing before the fix: with `demote_ungrounded_registry_claims`
+//! neutered to a no-op, four of the five tests fail — the verdict stays BLOCK,
+//! the claim is still selected as a verification candidate, and no advisory note
+//! reaches the reader. Only (c), the control, passes in both states, which is
+//! exactly what makes it a control.
+
+use trusty_review::models::{Effort, Finding, Verdict, VerifyOutcome};
+use trusty_review::pipeline::derive_verdict;
+use trusty_review::pipeline::finding_hygiene::sanitize_findings;
+use trusty_review::pipeline::select_candidates;
+
+/// The finding #4081 reports, field for field (its JSON is quoted verbatim in
+/// the issue's "Actual output" section).
+fn ruff_version_finding() -> Finding {
+    let mut f = Finding::new(
+        ".github/workflows/repos-all-advisory.yml",
+        "ruff pinned to non-existent version 0.16.0",
+        "The CI workflow pins `ruff==0.16.0`, but ruff's versioning scheme uses a \
+         `0.x.y` format where the latest stable releases are in the `0.4.x`–`0.9.x` \
+         range as of mid-2026. Version `0.16.0` does not exist on PyPI. This will \
+         cause the `pip install` step to fail with a \"No matching distribution \
+         found\" error, breaking CI for every PR that touches the linted files.",
+        "Pin ruff to a version that exists on PyPI.",
+        0.82,
+        Effort::High,
+    );
+    f.line = Some(41);
+    f.consequence = "CI pip install step fails with 'No matching distribution found', \
+                     breaking the advisory workflow on every run"
+        .to_string();
+    f.code_provable = true;
+    f
+}
+
+/// A genuine, diff-provable correctness finding on the same PR — the control.
+fn genuine_finding() -> Finding {
+    let mut f = Finding::new(
+        "src/apex/loader.py",
+        "logic-error",
+        "`load_config` indexes `argv[1]` before checking `len(argv)`, so running \
+         the loader with no arguments raises IndexError instead of printing usage.",
+        "Guard the length before indexing.",
+        0.9,
+        Effort::High,
+    );
+    f.line = Some(12);
+    f.code_provable = true;
+    f
+}
+
+// ─── (a) the false BLOCK ─────────────────────────────────────────────────────
+
+#[test]
+fn ungrounded_version_claim_is_not_confirmed_and_does_not_block() {
+    let mut findings = vec![ruff_version_finding()];
+
+    // Precondition — this is exactly what #4081 reports: on unmodified code the
+    // claim's self-declared `code_provable: true` + High effort hard-clamps the
+    // deterministic floor to BLOCK, from a clean APPROVE baseline.
+    assert_eq!(
+        derive_verdict(Verdict::Approve, &findings),
+        Verdict::Block,
+        "precondition: the ungrounded claim forces BLOCK before the guard runs"
+    );
+
+    let demoted = sanitize_findings(&mut findings).demoted_ungrounded_registry;
+    assert_eq!(demoted, 1, "the registry claim must be demoted");
+
+    // The trust signals are withdrawn...
+    let f = &findings[0];
+    assert!(
+        !f.code_provable,
+        "a claim nothing looked up is not provable from the diff"
+    );
+    assert!(
+        !matches!(f.verified, Some(VerifyOutcome::Confirmed)),
+        "must never be marked confirmed, got {:?}",
+        f.verified
+    );
+    assert!(
+        matches!(f.verified, Some(VerifyOutcome::Unverifiable { .. })),
+        "must record WHY it is unverifiable, got {:?}",
+        f.verified
+    );
+
+    // ...and it can no longer drive a blocking verdict from either direction:
+    // not via the deterministic floor...
+    assert_eq!(
+        derive_verdict(Verdict::Approve, &findings),
+        Verdict::Approve,
+        "the demoted claim must not floor the verdict"
+    );
+    // ...and not via the model's OWN self-reported BLOCK, which rested on the
+    // same unchecked evidence (#4081 reports `verdict: BLOCK`, `grade: F`).
+    assert_eq!(
+        derive_verdict(Verdict::Block, &findings),
+        Verdict::Approve,
+        "a self-reported BLOCK resting solely on the unchecked claim must dissolve"
+    );
+}
+
+#[test]
+fn ungrounded_version_claim_is_never_sent_to_the_verifier() {
+    // The `verified: "confirmed"` in #4081's output came from the verifier round.
+    // The verifier is the same kind of oracle as the reviewer, so asking it a
+    // registry question just launders a stale recollection into a confirmation.
+    let mut findings = vec![ruff_version_finding()];
+
+    assert_eq!(
+        select_candidates(Verdict::Block, &findings),
+        vec![0],
+        "precondition: on a blocking verdict the wide net picks it up"
+    );
+
+    sanitize_findings(&mut findings);
+
+    assert!(
+        select_candidates(Verdict::Block, &findings).is_empty(),
+        "a claim the pipeline cannot check must not be put to the verifier"
+    );
+}
+
+// ─── (b) anti-over-suppression ───────────────────────────────────────────────
+
+#[test]
+fn ungrounded_version_claim_still_surfaces_as_advisory() {
+    let mut findings = vec![ruff_version_finding()];
+    sanitize_findings(&mut findings);
+
+    assert_eq!(findings.len(), 1, "the finding must NOT be dropped");
+    let f = &findings[0];
+
+    assert_eq!(f.file, ".github/workflows/repos-all-advisory.yml");
+    assert_eq!(f.line, Some(41));
+    assert_eq!(f.kind, "ruff pinned to non-existent version 0.16.0");
+    assert!(
+        f.description
+            .contains("Version `0.16.0` does not exist on PyPI."),
+        "the model's original claim must survive verbatim so the author can judge \
+         it themselves: {}",
+        f.description
+    );
+    assert!(
+        f.description.contains("#4081"),
+        "the reader must be told nothing verified the claim: {}",
+        f.description
+    );
+    assert!(
+        f.description.contains("no registry lookup"),
+        "the note must name the specific reason: {}",
+        f.description
+    );
+    assert!(
+        f.confidence > 0.0,
+        "demoted to advisory, not zeroed out: {}",
+        f.confidence
+    );
+}
+
+// ─── (c) the capability is retained ──────────────────────────────────────────
+
+#[test]
+fn verification_backed_finding_still_confirms_and_still_blocks() {
+    let mut findings = vec![genuine_finding()];
+
+    sanitize_findings(&mut findings);
+    assert_eq!(findings.len(), 1, "a genuine finding is untouched");
+    assert!(findings[0].code_provable, "keeps its diff-provable flag");
+    assert_eq!(findings[0].effort, Effort::High, "keeps its severity");
+    assert!(
+        findings[0].verified.is_none(),
+        "left open for the verifier to decide"
+    );
+
+    // It is still put to the verifier...
+    assert_eq!(
+        select_candidates(Verdict::Block, &findings),
+        vec![0],
+        "a checkable finding must still be verified"
+    );
+
+    // ...and a CONFIRMED outcome still drives BLOCK.
+    findings[0].verified = Some(VerifyOutcome::Confirmed);
+    assert_eq!(
+        derive_verdict(Verdict::Approve, &findings),
+        Verdict::Block,
+        "a confirmed, diff-provable High finding must still block"
+    );
+}
+
+#[test]
+fn a_genuine_finding_alongside_a_registry_claim_still_blocks() {
+    // The demotion must be scoped to the unchecked claim: a real defect found on
+    // the SAME PR keeps its full weight, so the guard cannot be used to smuggle a
+    // bug past review inside a dependency bump.
+    let mut findings = vec![ruff_version_finding(), genuine_finding()];
+
+    let counts = sanitize_findings(&mut findings);
+    assert_eq!(
+        counts.demoted_ungrounded_registry, 1,
+        "only the registry claim"
+    );
+    assert_eq!(findings.len(), 2, "both findings surface");
+    assert_eq!(findings[1].effort, Effort::High);
+    assert!(findings[1].code_provable);
+
+    assert_eq!(
+        derive_verdict(Verdict::Approve, &findings),
+        Verdict::Block,
+        "the genuine finding independently drives BLOCK"
+    );
+}


### PR DESCRIPTION
## Summary

`review_pr` emitted a `code_provable: true`, `verified: "confirmed"`,
`confidence: 0.82` finding claiming a pinned dependency version does not exist,
and rolled it up to `verdict: BLOCK` / `grade: F`. The version was the current
latest release, and all ten checks on the reviewed PR were green on that exact
dependency.

Closes #4081.

## Root cause

Two things went wrong, and only the second is fixable:

1. **The model recalled a stale fact.** Unfixable by construction — a package
   registry moves continuously, so a reviewer model's version knowledge is stale
   the day it ships. #4081's own finding text says so out loud: *"the latest
   stable releases are in the `0.4.x`–`0.9.x` range **as of mid-2026**"*.
2. **The claim wore the pipeline's two strongest trust signals without anything
   having checked it.** Nothing in trusty-review performs a registry lookup —
   `code_provable` is self-declared by the model, and `verified: "confirmed"`
   came from the verifier round, which is a second LLM with the same
   training-cutoff problem. **This is the defect.** A hallucination wearing a
   confirmation is worse than no finding at all: it inverts the exact signal
   consumers use to decide what to trust.

And it lands where it does the most damage. A dependency-bump diff is the one
shape where the reviewer's version knowledge is guaranteed stale, and the shape
whose author most expects to sail through. This repo's own open version-bump PR
#4177 was a prime target.

## Fix shape — refuse to confirm, do not look up

Actually querying PyPI/npm/crates.io was considered and **rejected**. It buys
nothing the reported harm needs (the false BLOCK is cured by declining to mark
an unchecked claim as checked) and it adds a live network dependency, rate
limits, per-ecosystem client code, and a fresh way for the review path itself to
hang or fail. The principle encoded here is narrower and stronger than any
lookup:

> A claim may be marked `verified: "confirmed"` only when something actually
> verified it.

New `pipeline::claim_grounding`, following #4057's precedent of one module per
distinct signal (`citation_check` = path/content verification, `finding_hygiene`
= self-admission markers, `claim_grounding` = registry vocabulary). It is wired
into `finding_hygiene::sanitize_findings` — the single seam #4057 established
for exactly this — so the unified (`runner.rs`) and map-reduce
(`mapreduce/mod.rs`) paths both get it with no call-site changes.

A finding is demoted when its text pairs a **registry subject** (PyPI, npm,
crates.io, `requirements.txt`, `package.json`, `pip install`, …) with a
**registry-state assertion** (version absent, withdrawn, deprecated, "latest
release is…", "as of my knowledge cutoff"). Requiring both halves is what keeps
the guard off an ordinary correctness finding that happens to say "does not
exist" about a code symbol.

Demotion, in full:

| field | change | why |
|---|---|---|
| `verified` | → new `VerifyOutcome::Unverifiable { reason }` | pre-stamped BEFORE the verification round; `select_candidates` now skips a finding whose outcome is already decided, so the verifier LLM is never asked a question it cannot answer and can never stamp `Confirmed` over it |
| `code_provable` | → `false` | a registry fact is not provable from the diff; drops it out of `grade::drives_block_floor` |
| `effort` | capped at `Medium` | same demotion `demote_diff_absent_speculation` applies (#4043) |
| `confidence` | capped at `0.65` | at/above the review-include gate (0.60) so it stays visible; at/below `grade.rs`'s advisory-collapse line (0.65), which is what dissolves the model's **own** self-reported BLOCK — the severity floor alone cannot, since `stricter_of(model, floor)` only ever raises |
| `description` | advisory note appended | the author is told nothing checked it, and to confirm the pin themselves |

Reusing `grade.rs`'s existing low-confidence override rather than adding a
parallel relaxation is deliberate — #4057's lesson was that
mechanism-per-defect proliferation is the thing to avoid.

**It never drops the finding.** "trusty-review could not check this version" is
real information for the author. Over-suppression would trade a false BLOCK for
a false silence.

## Proof by execution

`tests/registry_claim_4081_regression.rs` uses #4081's finding verbatim, field
for field. Verified failing before the fix: with
`demote_ungrounded_registry_claims` neutered to a no-op, **4 of 5 fail** —
verdict stays BLOCK, the claim is still selected as a verification candidate,
and no advisory note reaches the reader. The 5th is the control, which passes in
both states by design.

| test | asserts |
|---|---|
| `ungrounded_version_claim_is_not_confirmed_and_does_not_block` | not `Confirmed`; `derive_verdict(APPROVE, …)` → APPROVE **and** `derive_verdict(BLOCK, …)` → APPROVE (the self-reported BLOCK dissolves too) |
| `ungrounded_version_claim_is_never_sent_to_the_verifier` | was a candidate before, is not after |
| `ungrounded_version_claim_still_surfaces_as_advisory` | **presence**, not absence — file/line/kind intact, original claim text verbatim, note added, confidence non-zero |
| `verification_backed_finding_still_confirms_and_still_blocks` | the capability is retained: a genuine finding is untouched, still verified, still BLOCKs |
| `a_genuine_finding_alongside_a_registry_claim_still_blocks` | the demotion is scoped — a real defect on the same PR keeps full weight, so the guard cannot smuggle a bug past review inside a dependency bump |

Plus 10 unit tests in `claim_grounding_tests.rs`: every assertion marker fires;
an ordinary "does not exist" code finding does not; a manifest finding that
argues from the diff does not; the cap is a ceiling never a promotion; the pass
is idempotent; and the advisory note provably does not trip `finding_hygiene`'s
own marker sets.

No `#[ignore]`, no cfg-gates.

## Not fixed here (reported, not silently skipped)

- **The CI cross-check (#4081 suggestion 2) is not implemented.** trusty-review
  fetches PR metadata and the diff — it never fetches check runs, so there is no
  observed CI status "already in hand" to cross-check against. Adding one means
  a new network call in the review path, which is the same dependency this PR's
  central design decision declines to take on. Worth its own issue.
- **`source_citation` is grammar-checked, never resolved.**
  `grade::is_escalation_eligible` accepts any string matching
  `CITATION_GRAMMAR_RE` (`path:line` / `TICKET-123` / `#123` / `§ 4.2`). Nothing
  confirms the ticket exists or says what the finding claims — so a
  well-formatted invented citation still unlocks the BLOCK floor. Same defect
  family as this one.
- **`status: "degraded"` still permits a hard BLOCK.** The reported run
  self-declared `"review produced WITHOUT code context"` and emitted BLOCK/F
  anyway; `runner.rs` only prepends a banner and sets `error`, leaving the
  verdict untouched. #4081's own "Secondary issue" section, adjacent to #4044.

## Verification

- `cargo test --workspace` (no `--lib`, CI's `ci.yml` exclusion list for the
  three Tauri GUI crates), `cargo clippy --workspace --all-targets -D warnings`
  (same exclusions), `cargo fmt --all --check`, `scripts/check_line_cap.sh` — all
  green. Raw output in the PR thread.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
