### PR TITLE
fix(trusty-common): exempt slash-separated PR-number lists from the secret scanner

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -9,6 +9,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **The `memory_remember` secret scanner no longer false-positives on
+  slash-separated issue/PR-number lists (issue #2800).** A checkpoint
+  enumerating tickets as `#2763/#2774/#2780/#2782/#2790` was rejected as a
+  "likely secret/credential token": the `/` separators set the base64-symbol
+  flag and the digits set the digit flag, so the base64-blob branch of
+  `looks_like_secret` fired on a token containing no letters at all. Observed
+  live twice; agents worked around it by rewording or dropping detail, silently
+  degrading session-checkpoint fidelity. `looks_like_secret` now allowlists
+  tokens built only from `#`, `/`, and ASCII digits, alongside the existing
+  git-SHA carve-out. The exemption is charset-scoped and strictly narrower than
+  the SHA allowlist — a single alphabetic character, or a `+`, takes a token
+  back onto the normal heuristic path, so every credential shape the module
+  already blocked stays blocked.
+
 - **`project_index_id` documentation corrected**
   ([#4269](https://github.com/bobmatnyc/trusty-tools/issues/4269), amended under
   [#4288](https://github.com/bobmatnyc/trusty-tools/issues/4288)). The module

--- a/crates/trusty-common/src/memory_core/filter.rs
+++ b/crates/trusty-common/src/memory_core/filter.rs
@@ -673,6 +673,11 @@ fn looks_like_secret(token: &str) -> bool {
     if is_git_sha_like(token) {
         return false;
     }
+    // Allowlist issue/PR-number lists — issue #2800, same spirit as the SHA
+    // carve-out above.
+    if is_issue_number_list(token) {
+        return false;
+    }
     let lower = token.to_ascii_lowercase();
     if SECRET_PREFIXES.iter().any(|p| lower.starts_with(p)) {
         return true;
@@ -711,6 +716,44 @@ fn looks_like_secret(token: &str) -> bool {
     // fires for tokens shaped like an actual bare credential (alphanumeric
     // plus the `-`/`_`/`.` separators used by JWTs and slug-style API keys).
     has_lower && has_upper && has_digit && is_plausible_credential_charset(token)
+}
+
+/// True when `token` is a slash-separated issue/PR-number list — built only
+/// from `#`, `/`, and ASCII digits, with at least one digit.
+///
+/// Why (issue #2800, observed live twice): PM session checkpoints routinely
+/// enumerate tickets as `#2763/#2774/#2780/#2782/#2790`. Such a token carries
+/// no letters at all, but the `/` separators set `has_b64_sym` and the digits
+/// set `has_digit`, so the base64-blob branch of [`looks_like_secret`] fired
+/// and the whole memory was rejected. The slash-path branch of
+/// [`is_structural_token`] does not rescue it because `#` is deliberately
+/// excluded from `is_word_segment` — and widening *that* set would loosen the
+/// structural bypass for every path and `key=value` token, which is a much
+/// larger blast radius than this false positive warrants. Agents worked around
+/// the rejection by rewording or dropping detail, silently degrading
+/// checkpoint fidelity.
+///
+/// Why this is safe as an allowlist: the `{#, /, 0-9}` charset has no
+/// character-class spread — no letters, so no base64, hex, or base32 alphabet
+/// can be expressed in it, and every known credential format contains letters
+/// (and none contains `#`). A single alphabetic character takes a token out of
+/// this exemption and back onto the normal heuristic path. The exemption is
+/// therefore a keyhole, not a hole: it is strictly narrower than the git-SHA
+/// carve-out above, which admits the full hex alphabet.
+///
+/// What: returns `true` iff `token` is non-empty, every char is `#`, `/`, or an
+/// ASCII digit, and at least one char is a digit. Note that
+/// [`find_secret_token`] trims a leading `#` before classification, so the
+/// trimmed form (`2763/#2774/…`) must satisfy this predicate too — it does,
+/// since the charset is closed under that trim.
+/// Test: `slash_separated_pr_number_list_not_flagged`,
+/// `real_secrets_still_blocked_after_2800_exemption`.
+fn is_issue_number_list(token: &str) -> bool {
+    !token.is_empty()
+        && token.bytes().any(|b| b.is_ascii_digit())
+        && token
+            .bytes()
+            .all(|b| b.is_ascii_digit() || matches!(b, b'#' | b'/'))
 }
 
 /// True when every character in `token` could plausibly appear in a bare

--- a/crates/trusty-common/src/memory_core/filter_tests.rs
+++ b/crates/trusty-common/src/memory_core/filter_tests.rs
@@ -933,3 +933,100 @@ fn colon_bearing_credential_is_flagged() {
         cfg.apply(&content, false)
     );
 }
+
+// ---- Issue #2800: slash-separated issue/PR-number lists ----
+
+/// Why (issue #2800, observed live twice): a PM session checkpoint enumerating
+/// PRs as `#2763/#2774/#2780/#2782/#2790` was rejected as a secret. The token
+/// carries no letters at all, but the `/` separators set `has_b64_sym` and the
+/// digits set `has_digit`, so the base64-blob branch of `looks_like_secret`
+/// fired. `is_structural_token`'s slash-path branch does not rescue it because
+/// the `#` in each segment fails `is_word_segment`.
+/// What: asserts the EXACT token from the issue body passes both the token
+/// predicate and the end-to-end gate, in the prose shape it was written in.
+/// Test: itself.
+#[test]
+fn slash_separated_pr_number_list_not_flagged() {
+    let tok = "#2763/#2774/#2780/#2782/#2790";
+    assert!(
+        !looks_like_secret(tok),
+        "slash-separated PR-number list must NOT be flagged as secret: {tok}"
+    );
+    // `find_secret_token` trims the leading `#`, yielding the 28-char token
+    // quoted in the issue's rejection message — cover that shape too.
+    let content = format!("Merged {tok} closing the eviction epic");
+    assert!(
+        find_secret_token(&content).is_none(),
+        "PR-number list in prose must NOT be flagged; got {:?}",
+        find_secret_token(&content)
+    );
+    let cfg = FilterConfig::default();
+    assert!(
+        cfg.apply(&content, true).is_ok(),
+        "gate must ACCEPT the PR-number list; got {:?}",
+        cfg.apply(&content, true)
+    );
+}
+
+/// Why (issue #2800): the digit/separator exemption must be a keyhole, not a
+/// hole. Anything with an alphabetic character is outside the exemption, so
+/// every real-credential shape the module already blocks must still be blocked
+/// — including ones that sit next to a PR-number list in the same content, and
+/// including the adversarial case of a credential that is *mostly* digits and
+/// slashes with only a few letters smuggled in.
+/// What: asserts known-prefix, base64-blob, connection-string, and
+/// digits-plus-letters credentials all remain flagged after the exemption.
+/// Test: itself.
+#[test]
+fn real_secrets_still_blocked_after_2800_exemption() {
+    let cfg = FilterConfig::default();
+
+    // 1. Known-prefix credential sharing content with an allowlisted PR list —
+    //    the exemption must not shadow other tokens in the same memory.
+    let mixed = "Checkpoint #2763/#2774/#2780/#2782/#2790 deploy key \
+                 sk-abcdefghijklmnopqrstuvwxyz01234567890123"; // pragma: allowlist secret
+    assert!(
+        matches!(
+            cfg.apply(mixed, false),
+            Err(FilterReject::PotentialSecret { .. })
+        ),
+        "known-prefix credential must still be rejected beside a PR list; got {:?}",
+        cfg.apply(mixed, false)
+    );
+
+    // 2. LOAD-BEARING: a token that is `#`/digit/slash-shaped EXCEPT for a
+    //    smuggled alphabetic segment. One letter must take it out of the
+    //    exemption and back onto the normal heuristic path. If the exemption
+    //    were written as "contains only digits and separators, ignoring
+    //    letters" — or applied before the charset was fully checked — this is
+    //    the token that would slip through.
+    let sneaky = "#2763/#2774/#abcd/#2782/#2790"; // pragma: allowlist secret
+    assert!(
+        looks_like_secret(sneaky),
+        "a `#`/digit/slash token containing letters must NOT be exempted: {sneaky}"
+    );
+
+    // 3. LOAD-BEARING: `+` is the unambiguous base64 indicator. It is outside
+    //    the exemption charset, so a digit-and-slash token carrying one must
+    //    stay flagged even though it has no letters at all.
+    let with_plus = "1234/5678/9012+3456/7890/1234"; // pragma: allowlist secret
+    assert!(
+        looks_like_secret(with_plus),
+        "`+` (base64 indicator) must defeat the exemption: {with_plus}"
+    );
+
+    // 4. Base64 blob with `=` padding — the same `has_b64_sym` branch the
+    //    exemption short-circuits. Letters present, so still flagged.
+    let b64 = "dGhpcyBpcyBhIHZlcnkgbG9uZyBzZWNyZXQgdG9rZW4="; // pragma: allowlist secret
+    assert!(
+        looks_like_secret(b64),
+        "padded base64 blob must still be flagged: {b64}"
+    );
+
+    // 5. Connection string — `/`-bearing and digit-bearing, letters present.
+    let conn = "postgres://user:pass@host/dbname12345678901234567890"; // pragma: allowlist secret
+    assert!(
+        looks_like_secret(conn),
+        "connection-string-shaped token must still be flagged: {conn}"
+    );
+}


### PR DESCRIPTION
## What

`remember_with_options` rejected an ordinary PM checkpoint that enumerated
tickets as `#2763/#2774/#2780/#2782/#2790`, reporting it as a "likely
secret/credential token". Observed live twice.

## Root cause

The token contains **no letters at all**, but in `looks_like_secret`:

- the `/` separators set `has_b64_sym`
- the digits set `has_digit`

…so the base64-blob branch fires. `is_structural_token`'s slash-path branch
does not rescue it, because `#` is deliberately excluded from
`is_word_segment`.

Note that `find_secret_token` trims the leading `#` before classification,
which is why the rejection message quoted a 28-char token rather than the
29-char original.

## Fix

Allowlist `[#/0-9]`-only tokens in `looks_like_secret`, next to the existing
git-SHA carve-out and using the same early-return shape.

**Alternative rejected:** adding `#` to `is_word_segment`. That would have
loosened the structural bypass for *every* path and `key=value` token — a much
larger blast radius than this false positive warrants.

**Why this is a keyhole, not a hole:** the `{#, /, 0-9}` charset has no
character-class spread, so no base64, hex, or base32 alphabet can be expressed
in it, and no known credential format contains `#`. The exemption is strictly
*narrower* than the git-SHA carve-out it sits beside, which admits the full hex
alphabet.

## Tests

| Test | Before | After |
|---|---|---|
| `slash_separated_pr_number_list_not_flagged` | **FAILS** | passes |
| `real_secrets_still_blocked_after_2800_exemption` | passes | passes |

The first uses the exact string from the issue body, at the token level and
end-to-end through `FilterConfig::apply`.

The second is the load-bearing guard and passes in **both** directions by
design — it asserts that things which were blocked stay blocked. Its two
critical cases:

- `#2763/#2774/#abcd/#2782/#2790` — one alphabetic segment smuggled into an
  otherwise `#`/digit/slash token must leave the exemption.
- `1234/5678/9012+3456/7890/1234` — a `+` must defeat the exemption even
  though the token has no letters.

Plus padded-base64, connection-string, and known-prefix (`sk-`) cases, the last
sharing content with an allowlisted PR list to prove the exemption does not
shadow other tokens in the same memory.

While writing the guard I empirically probed pre-fix verdicts rather than
reasoning about them, and found two assumptions wrong: `aGVsbG8v…/Zm9v…` and
`9012/3456/7890/abcd/…` are **already** exempt pre-fix via the slash-path
structural branch (a pre-existing, separately-documented false negative around
slash-bearing credentials). Those assertions were dropped rather than shipped
as vacuous guards. That pre-existing FN is untouched here.

## Gate

- `cargo fmt --all --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — **19698 passed, 5 failed**

All 5 failures are pre-existing and environmental, in `trusty-agents`
(untouched by this PR): 4 × `api_e2e` ("api server did not become healthy
within 5s") and 1 × `python_skill` (broken `/opt/homebrew/bin/python3` uv
cache). Both were reproduced identically on a clean `origin/main` checkout in
this same environment before being attributed.

Clippy and test used CI's own GUI exclusion list from `ci.yml`
(`--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude
trusty-agents-ui`), as those are Tauri apps excluded from the headless
workspace jobs. `SKIP_UI_BUILD=1` per CI; the `build.rs` guard was not touched.

Closes #2800

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
