### PR TITLE
feat(trusty-agents): L0-only shell/build/test execution grant (#4173)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -47,6 +47,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`l0_shell_exec` — a shell/build/test executor granted to the L0
+  orchestration tier ONLY** (#4173, epic #4167). `tools::l0_exec` returns an
+  empty tool vector for `AgentTier::L1Standard`, so an L1 persona never has the
+  tool *registered* — it cannot be reached by declaring it (or `l0_*`, or `*`)
+  in `[tools].allow`, cannot be reached through a delegation taint (which only
+  ever intersects with what the child registry already holds), and cannot be
+  reached transitively (the #4200 tier gate refuses every L1 → L0 hop). The
+  grant follows the spawned agent's OWN resolved tier — never a delegator's —
+  and `AgentInfo::tier()`'s fail-closed resolver means an absent, blank or
+  unrecognized `tier =` resolves to L1 and therefore to nothing. RBAC still
+  applies on top: the tool is refused for the `ReadOnly` and `Analytics`
+  service tiers. Per-call `working_dir` is contained to the project root
+  (absolute escapes, `..` traversal and symlink escapes are rejected); the
+  catastrophic-pattern predicate is reused from `tools::run_bash` rather than
+  re-invented, and is documented as defense-in-depth, not the boundary. The
+  tier gate is the boundary.
 - **`GET /api/agents/:name/kg`, `/kg/subjects`, `/kg/all` and `/kg/count` — a
   read-only proxy onto the Knowledge Graph of the memory palace the agent binds
   via `[[stores]].palace`** (#4290). trusty-memory already owns every one of

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1973,6 +1973,23 @@ fn bundled_assistant_personas_resolve_l0_and_gain_nothing() {
                          becoming L0 would GRANT it, which is a capability change this \
                          PR does not carry. Review it deliberately."
                     );
+                    // #4173: the same zero-delta claim for the L0-only
+                    // shell/build/test executor. Matched as a GLOB, not by
+                    // equality, because `[tools].allow` entries are glob
+                    // patterns — a persona declaring `l0_*` or `*` would reach
+                    // the shell just as surely as one naming it outright, and
+                    // an equality check would miss both.
+                    assert!(
+                        !crate::ctrl::pm_task::match_any_glob(
+                            crate::tools::l0_exec::L0_SHELL_EXEC,
+                            std::slice::from_ref(granted)
+                        ),
+                        "'{name}' declares '{granted}' in [tools].allow, which matches the \
+                         L0-only execution grant '{}' — as an L0 persona it would hold a \
+                         real shell. That is a capability change, not a side effect: \
+                         review it deliberately.",
+                        crate::tools::l0_exec::L0_SHELL_EXEC
+                    );
                 }
             }
         } else {

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -550,6 +550,23 @@ pub(super) fn build_registry_for_agent(
 /// assistant persona now ships a seeded `[subagents].delegate_allowed`.
 /// Test: `assistant_tier_registry_delegation_honors_the_reachable_whitelist`,
 /// `assistant_tier_registry_delegation_fails_closed_without_a_whitelist`.
+///
+/// `delegator_tier` ALSO decides the #4173 execution grant (epic #4167): it is
+/// the ONLY input to `tools::l0_exec::l0_execution_tools`, which registers
+/// `l0_shell_exec` for `AgentTier::L0Orchestration` and NOTHING for
+/// `AgentTier::L1Standard`. That makes the grant unreachable for L1 by
+/// construction rather than by allow-list convention, and unreachable
+/// transitively too: the grant follows the SPAWNED agent's own resolved tier,
+/// `DelegateToAgentTool`'s gate already refuses every L1->L0 hop, and an
+/// inbound delegation taint can only ever intersect with what a registry
+/// actually holds (`scope_for_delegation`), so a tainted spawn into an L1
+/// registry cannot conjure a tool that registry never registered.
+/// Test: `l0_grant_absent_from_l1_assistant_registry`,
+/// `l0_grant_present_in_l0_assistant_registry`,
+/// `l1_persona_declaring_the_l0_grant_does_not_receive_it`,
+/// `l0_grant_fails_closed_for_malformed_tier_declaration`,
+/// `tainted_delegation_cannot_widen_into_the_l0_grant`,
+/// `l1_cannot_reach_the_l0_grant_through_an_untiered_intermediary`.
 pub(crate) fn build_assistant_tier_registry(
     delegator_allow: Option<&[String]>,
     delegator_tier: crate::agents::AgentTier,
@@ -646,6 +663,22 @@ pub(crate) fn build_assistant_tier_registry(
     // via `scope_assistant_allowed_tools` (only izzie opts in), so other
     // assistant-tier personas are unaffected.
     for tool in crate::tools::izzie::izzie_tools() {
+        reg.register(tool);
+    }
+
+    // #4173 (epic #4167): the L0-orchestration shell/build/test grant. Unlike
+    // every other block in this function, this one is NOT "register it and let
+    // `[tools].allow` decide" — `l0_execution_tools` returns an EMPTY vector
+    // for `AgentTier::L1Standard`, so an L1 persona that declares
+    // `l0_shell_exec` in its `[tools].allow` (or matches it with a `*` glob)
+    // still gets nothing: the name never enters `schemas()`, so it cannot
+    // survive `scope_assistant_allowed_tools`'s intersection, and `dispatch`
+    // has nothing registered under it either. The tier reaching us here is
+    // `AgentInfo::tier()`, which fails closed — absent/blank/unrecognized
+    // `tier` values are already `L1Standard` by the time they arrive. See
+    // `tools::l0_exec` for why the tier gate (not the command text) is the
+    // security boundary.
+    for tool in crate::tools::l0_exec::l0_execution_tools(delegator_tier, cwd.clone()) {
         reg.register(tool);
     }
 

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -1249,6 +1249,396 @@ async fn assistant_tier_registry_l0_delegator_tier_reaches_l0_target_end_to_end(
     );
 }
 
+// ============================================================================
+// #4173 (epic #4167) — the L0-orchestration shell/build/test execution grant.
+//
+// Shell execution is the capability that made #4126 a P0 (untrusted content ->
+// persona -> delegation -> ungated shell). PR #4161 closed that path and
+// PR #4200 added the L0/L1 tier boundary; #4173 deliberately hands shell back
+// to exactly ONE tier. These tests exercise the REAL registry-construction
+// path (`build_registry_for_agent` / `build_assistant_tier_registry`), the
+// REAL glob-scoping and taint composition (`scope_assistant_allowed_tools` /
+// `scope_for_delegation`), the REAL config loader (`AgentConfig::by_name_in`)
+// and the REAL dispatch surface (`ToolRegistry::dispatch*`) — never a
+// hand-rolled restatement of the gate.
+// ============================================================================
+
+/// Build the assistant-tier registry the way `run_subagent` does, for a
+/// persona whose declared `tier` string is `raw` — resolved by the REAL
+/// loader + the REAL fail-closed resolver, not by a hand-built `AgentTier`.
+fn registry_for_declared_tier(raw: Option<&str>) -> (tempfile::TempDir, ToolRegistry) {
+    registry_for_declared_tier_and_role("assistant", raw)
+}
+
+/// As above, but with the persona's `role` under test too — needed since
+/// ADR-0024 decision 3 made an undeclared tier a function of the KIND.
+fn registry_for_declared_tier_and_role(
+    role: &str,
+    raw: Option<&str>,
+) -> (tempfile::TempDir, ToolRegistry) {
+    let dir = tempfile::tempdir().unwrap();
+    let tier_line = raw.map(|t| format!("tier = \"{t}\"")).unwrap_or_default();
+    std::fs::write(
+        dir.path().join("fixture-persona.toml"),
+        format!(
+            "[agent]\nname = \"fixture-persona\"\nrole = \"{role}\"\nmodel = \"m\"\n\
+             description = \"d\"\n{tier_line}\n\n[llm]\ntemperature = 0.2\n\
+             max_tokens = 1024\n\n[system_prompt]\ncontent = \"x\"\n"
+        ),
+    )
+    .unwrap();
+    let cfg =
+        crate::agents::AgentConfig::by_name_in(&[dir.path().to_path_buf()], "fixture-persona")
+            .expect("fixture agent loads");
+    let reg = build_registry_for_agent(
+        "fixture-persona",
+        &cfg.agent.role,
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+        cfg.agent.tier(),
+        None,
+    )
+    .expect("assistant-tier agent builds a registry");
+    (dir, reg)
+}
+
+/// An L1 (standard) persona's registry must not contain the execution grant
+/// at all — not merely be denied it at dispatch. L1 holds the full
+/// Gmail/Drive/Calendar surface, which is exactly why it never gets a shell.
+#[test]
+fn l0_grant_absent_from_l1_assistant_registry() {
+    let reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+        crate::agents::AgentTier::L1Standard,
+        None,
+    )
+    .expect("assistant-tier agent builds a registry");
+    assert!(
+        !reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+        "an L1 persona must not have the L0 execution grant registered"
+    );
+    // The pre-#4173 curated surface is untouched.
+    assert!(reg.contains("delegate_to_agent"));
+    assert!(reg.contains("web_search"));
+}
+
+/// The counter-test: an L0 (orchestration) persona does get it, through the
+/// same real construction path.
+#[test]
+fn l0_grant_present_in_l0_assistant_registry() {
+    let reg = build_registry_for_agent(
+        "orchestration-assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+        crate::agents::AgentTier::L0Orchestration,
+        None,
+    )
+    .expect("assistant-tier agent builds a registry");
+    assert!(
+        reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+        "an L0 persona must receive the execution grant"
+    );
+}
+
+/// THE requirement: an L1 persona that DECLARES the grant in `[tools].allow`
+/// — by exact name, or by a wildcard that would match it — still does not
+/// receive it. Exercised through the real glob-scoping gate and then through
+/// the real dispatch surface, both layers.
+#[tokio::test]
+async fn l1_persona_declaring_the_l0_grant_does_not_receive_it() {
+    let reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+        crate::agents::AgentTier::L1Standard,
+        None,
+    )
+    .expect("assistant-tier agent builds a registry");
+
+    for allow in [
+        vec![
+            crate::tools::l0_exec::L0_SHELL_EXEC.to_string(),
+            "web_search".to_string(),
+        ],
+        vec!["*".to_string()],
+        vec!["l0_*".to_string()],
+    ] {
+        let kept =
+            scope_assistant_allowed_tools(true, None, Some(&allow), Some(&reg)).unwrap_or_default();
+        assert!(
+            !kept
+                .iter()
+                .any(|n| n == crate::tools::l0_exec::L0_SHELL_EXEC),
+            "declaring {allow:?} must not surface the L0 grant to an L1 persona, got: {kept:?}"
+        );
+        // Layer 2: even if a caller ignored the scoped list, dispatch has
+        // nothing registered under the name.
+        let denied = reg
+            .dispatch_gated(
+                crate::tools::l0_exec::L0_SHELL_EXEC,
+                serde_json::json!({"command": "echo pwned"}),
+                Some(&kept),
+            )
+            .await;
+        assert!(
+            denied.is_error(),
+            "dispatch must refuse: {}",
+            denied.content()
+        );
+        let unregistered = reg
+            .dispatch(
+                crate::tools::l0_exec::L0_SHELL_EXEC,
+                serde_json::json!({"command": "echo pwned"}),
+            )
+            .await;
+        assert!(
+            unregistered.content().contains("no tool registered"),
+            "the tool must not exist in an L1 registry at all, got: {}",
+            unregistered.content()
+        );
+    }
+}
+
+/// Fail-closed on a malformed tier DECLARATION: a typo, or a near-miss that
+/// merely CONTAINS "l0" (the shape a typo takes), resolves to L1 through the
+/// real loader, so the registry it produces carries no grant.
+///
+/// ADR-0024 decision 3 (PR #4296) made an ABSENT/blank tier derive from the
+/// agent's KIND instead, so those spellings are no longer "indeterminate" and
+/// are covered by `l0_grant_follows_the_kind_derivation` below. What must NOT
+/// happen — and is what this test pins — is a declared-but-unrecognized string
+/// falling THROUGH to that derivation and quietly electing an assistant to L0
+/// by way of a typo. The fixture is assistant-kind precisely so that
+/// fall-through would be visible here.
+#[test]
+fn l0_grant_fails_closed_for_malformed_tier_declaration() {
+    for raw in [
+        Some("bogus"),
+        Some("l0-ish"),
+        Some("not-l0"),
+        Some("l1"),
+        Some("L2"),
+    ] {
+        let (_dir, reg) = registry_for_declared_tier(raw);
+        assert!(
+            !reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+            "declared tier {raw:?} is unrecognized and must be DENIED the execution grant"
+        );
+    }
+    // And the positive control through the same helper, so a broken fixture
+    // cannot make the assertions above vacuously pass.
+    let (_dir, reg) = registry_for_declared_tier(Some("l0"));
+    assert!(reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC));
+}
+
+/// With no usable declaration the grant follows ADR-0024 decision 3's KIND
+/// derivation, through the real registry-construction path: assistant-kind
+/// registers it, every sub-agent kind does not.
+///
+/// The registration is not by itself a capability — reachability still requires
+/// the persona's own `[tools].allow` to name the tool, which no bundled
+/// assistant does (pinned by
+/// `agents::tests::loading::bundled_assistant_personas_resolve_l0_and_gain_nothing`,
+/// extended by this PR to cover the execution grant).
+#[test]
+fn l0_grant_follows_the_kind_derivation() {
+    for raw in [None, Some(""), Some("   ")] {
+        let (_dir, reg) = registry_for_declared_tier_and_role("assistant", raw);
+        assert!(
+            reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+            "assistant-kind with tier {raw:?} derives L0 and registers the grant"
+        );
+
+        for role in ["engineer", "researcher", "planner"] {
+            let (_dir, reg) = registry_for_declared_tier_and_role(role, raw);
+            assert!(
+                !reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+                "sub-agent kind {role:?} with tier {raw:?} must be denied the grant"
+            );
+        }
+    }
+}
+
+/// The taint must still NARROW, never widen. When an L0 persona delegates
+/// downward to an L1 target, the child is tainted with the L0 delegator's own
+/// `[tools].allow` — which legitimately names the execution grant. The child's
+/// registry is an L1 registry and never registered that tool, so the real
+/// `scope_for_delegation` intersection cannot conjure it: the taint grants
+/// only what the child's registry already holds.
+#[test]
+fn tainted_delegation_cannot_widen_into_the_l0_grant() {
+    let child_reg = build_registry_for_agent(
+        "assistant",
+        "assistant",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+        crate::agents::AgentTier::L1Standard,
+        None,
+    )
+    .expect("assistant-tier agent builds a registry");
+
+    let l0_delegator_allow = vec![
+        crate::tools::l0_exec::L0_SHELL_EXEC.to_string(),
+        "web_search".to_string(),
+        "delegate_to_agent".to_string(),
+    ];
+    let scoped = scope_for_delegation(
+        true,
+        true,
+        None,
+        None,
+        Some(&l0_delegator_allow),
+        Some(&child_reg),
+    )
+    .unwrap_or_default();
+
+    assert!(
+        !scoped
+            .iter()
+            .any(|n| n == crate::tools::l0_exec::L0_SHELL_EXEC),
+        "a taint carrying the L0 grant must not widen an L1 child into it, got: {scoped:?}"
+    );
+    assert!(
+        scoped.iter().any(|n| n == "web_search"),
+        "the taint must still admit tools the child registry does hold, got: {scoped:?}"
+    );
+
+    // Composition, at the pattern level, is likewise narrowing-only: an L1
+    // agent's own native allow-list intersected with an inbound taint can
+    // never gain a pattern neither side held.
+    let composed =
+        compose_delegation_taint(Some(&["web_search".to_string()]), Some(&l0_delegator_allow))
+            .unwrap_or_default();
+    assert_eq!(composed, vec!["web_search".to_string()]);
+}
+
+/// Transitive reach: an L1 persona must not obtain the grant by delegating
+/// through an intermediary. Both legs are checked on the real paths — the
+/// intermediary's OWN registry (built from its real resolved tier) never
+/// carries the grant, and its `delegate_to_agent` refuses the L0 target that
+/// would.
+#[tokio::test]
+async fn l1_cannot_reach_the_l0_grant_through_an_untiered_intermediary() {
+    use crate::agents::tests::loading::ENV_LOCK;
+
+    let _guard = ENV_LOCK.lock().await;
+    let tmp = tempfile::tempdir().unwrap();
+    // The intermediary is an assistant that EXPLICITLY declares L1 — after
+    // ADR-0024 decision 3 (PR #4296) that declaration is the only way an
+    // assistant-kind persona is L1, since an absent tier now derives L0 from
+    // the kind. The escalation target is an L0 assistant that DOES hold the
+    // grant.
+    std::fs::write(
+        tmp.path().join("peer-assistant.toml"),
+        "[agent]\nname = \"peer-assistant\"\nrole = \"assistant\"\ntier = \"l1\"\n\
+         model = \"m\"\ndescription = \"d\"\n\n[llm]\ntemperature = 0.2\n\
+         max_tokens = 1024\n\n[system_prompt]\ncontent = \"x\"\n",
+    )
+    .unwrap();
+    std::fs::write(
+        tmp.path().join("orchestration-assistant.toml"),
+        "[agent]\nname = \"orchestration-assistant\"\nrole = \"assistant\"\n\
+         tier = \"orchestration\"\nmodel = \"m\"\ndescription = \"d\"\n\n[llm]\n\
+         temperature = 0.2\nmax_tokens = 1024\n\n[system_prompt]\ncontent = \"x\"\n",
+    )
+    .unwrap();
+
+    // Hop 1: what the L1 intermediary itself receives. Its real resolved tier
+    // is L1, so its registry never registers the grant it could pass along.
+    let peer_cfg =
+        crate::agents::AgentConfig::by_name_in(&[tmp.path().to_path_buf()], "peer-assistant")
+            .expect("intermediary loads");
+    assert_eq!(peer_cfg.agent.tier(), crate::agents::AgentTier::L1Standard);
+
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", tmp.path());
+    }
+    let seed = vec!["orchestration-assistant".to_string()];
+    let peer_reg = build_assistant_tier_registry(None, peer_cfg.agent.tier(), Some(&seed));
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+    }
+    assert!(
+        !peer_reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+        "the intermediary must not carry the grant it could pass along"
+    );
+
+    // Hop 2: from that intermediary, reaching the persona that DOES carry the
+    // grant is refused by the real delegation gates — even with the target
+    // explicitly whitelisted in the reachable set, so the refusal is a gate
+    // and not merely an unlisted name.
+    let refused = peer_reg
+        .dispatch(
+            "delegate_to_agent",
+            serde_json::json!({
+                "agent_name": "orchestration-assistant",
+                "task": "run cargo test and push the fix"
+            }),
+        )
+        .await;
+    assert!(
+        refused.is_error(),
+        "reaching an L0 grant-holder must be refused at hop 2, got: {}",
+        refused.content()
+    );
+    // Either gate refusing is a correct outcome — the KIND rule (assistants
+    // never delegate to a peer assistant, ADR-0024 clause 6) is checked before
+    // the tier gate, so it is the one that speaks for this pair. Asserting
+    // "refused, for a stated boundary reason" rather than pinning which gate
+    // fired keeps this test about the escalation property, not about the
+    // ordering of two rules that both deny.
+    assert!(
+        refused.content().contains("peer assistant")
+            || (refused.content().contains("L0") && refused.content().contains("L1")),
+        "the refusal should name the boundary it enforced, got: {}",
+        refused.content()
+    );
+    assert!(
+        !peer_reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+        "a refused escalation must leave the intermediary's surface unchanged"
+    );
+
+    // The other transitive leg, after decision 3: a SUB-AGENT kind is L1 by
+    // derivation, and its registry holds neither the grant nor the delegation
+    // tool that could chase it — there is no hop to make.
+    let sub_reg = build_registry_for_agent(
+        "research-agent",
+        "researcher",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+        crate::agents::AgentTier::L1Standard,
+        None,
+    )
+    .expect("sub-agent builds a registry");
+    assert!(
+        !sub_reg.contains(crate::tools::l0_exec::L0_SHELL_EXEC),
+        "a sub-agent kind must never hold the execution grant"
+    );
+}
+
 // --- `build_assistant_tier_registry`'s `delegator_subagents` wiring
 // (ADR-0024 decision 4, owner ratification 2026-07-29) ---
 //

--- a/crates/trusty-agents/src/skills/manifest/builtin/ops.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/ops.rs
@@ -304,4 +304,18 @@ pub(super) static TABLE: &[SkillDef] = &[
         System,
         None,
     ),
+    // --- L0 orchestration execution grant (#4173, epic #4167) -------------
+    // One skill per tool, per the owner ruling. Listing the skill here does
+    // NOT grant it: `tools::l0_exec::l0_execution_tools` refuses to register
+    // the tool at all for any agent that is not L0-orchestration tier, so an
+    // L1 persona naming this skill (or the tool) resolves to nothing.
+    tool_skill(
+        "orchestration-shell-run",
+        "Run a Build, Test or Shell Command",
+        "Run a build, test suite, or shell command in the project working tree \
+         and return the exit code with combined output. Orchestration tier only.",
+        "l0_shell_exec",
+        Action,
+        None,
+    ),
 ];

--- a/crates/trusty-agents/src/tools/l0_exec.rs
+++ b/crates/trusty-agents/src/tools/l0_exec.rs
@@ -1,0 +1,289 @@
+//! `l0_shell_exec` — the L0-orchestration-tier shell/build/test execution
+//! grant (#4173, epic #4167).
+//!
+//! Why: L0 ("orchestration assistant") has to orchestrate fix rounds, verify
+//! in-flight PRs and run build/test commands; #4167's gap analysis names "no
+//! shell/build/test execution grant" as one of the four reasons an L1 persona
+//! cannot do PM-tier work. Shell execution is ALSO the capability that made
+//! #4126 a P0: untrusted Gmail/Drive content reached a persona, the persona
+//! delegated to `engineer`, and `engineer` had an ungated shell under
+//! `runner = "claude-code"` — prompt injection to code execution. PR #4161
+//! closed that path and PR #4200 added the L0/L1 tier boundary; this module
+//! deliberately hands shell BACK to exactly one tier, and does it behind a
+//! single code-level gate rather than a convention.
+//!
+//! THE SECURITY BOUNDARY IS THE TIER GATE — [`l0_execution_tools`] — NOT the
+//! command text. L0 is the owner's explicitly-accepted YOLO tier and is
+//! deliberately NOT sandboxed (#4167); what makes an unsandboxed shell
+//! acceptable there is that L0 must never ingest untrusted content (no
+//! Gmail/Drive/Calendar surface), whereas L1 holds the full Google surface and
+//! therefore never gets this tool. Two narrower, independent guards are layered
+//! on top and are NOT the boundary either: the catastrophic-pattern predicate
+//! reused from [`crate::tools::run_bash::is_dangerous_command`] (defense in
+//! depth) and the cwd containment in [`resolve_working_dir`] (a per-call
+//! starting-directory check — a general shell can still `cd` once it is
+//! running, which is inherent to granting a shell at all and is why the tier
+//! gate, not this function, is what keeps L1 out).
+//!
+//! What: [`L0ShellExecTool`] implements `ToolExecutor` under the name
+//! `l0_shell_exec` (a name distinct from the existing `run_bash` /
+//! `shell_exec` / `pytest_exec` executors so the L0-only surface is greppable
+//! and can never be confused with a grant some other agent already holds).
+//! [`l0_execution_tools`] is the ONE place that decides whether that tool
+//! exists in a registry at all: it returns it for
+//! [`AgentTier::L0Orchestration`] and an empty vector for
+//! [`AgentTier::L1Standard`].
+//! Test: `l0_execution_tools_denies_l1_tier`,
+//! `l0_execution_tools_grants_l0_tier`,
+//! `l0_execution_tools_denies_every_fail_closed_tier_string`,
+//! `l0_shell_exec_runs_echo`,
+//! `l0_shell_exec_refuses_working_dir_outside_the_root`,
+//! `l0_shell_exec_denied_to_read_only_service_tier` (all in the sibling
+//! `l0_exec_tests.rs`); registry-construction and delegation-composition
+//! coverage lives alongside the gate it wires, in
+//! `runtime/tool_registry_tests.rs`.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+use tokio::process::Command;
+
+use crate::agents::AgentTier;
+use crate::rbac::ServiceTier;
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// The dispatch name of the L0 execution grant.
+///
+/// Why: Referenced by the registry-construction gate, its tests, and the
+/// `skills/manifest/builtin/ops.rs` catalog row; a `const` keeps those from
+/// drifting apart by a typo.
+pub const L0_SHELL_EXEC: &str = "l0_shell_exec";
+
+/// Per-command wall-clock budget.
+///
+/// Why: `run_bash`'s 30s is tuned for coordinator one-liners (`git status`)
+/// and would time out on the very commands #4173 exists for — `cargo build`,
+/// `cargo test -p <crate>`. 10 minutes covers a cold workspace test run while
+/// still bounding a hung command. Raising `run_bash`'s own constant instead was
+/// rejected: it is shared with `ctrl`/`pm` and changing their timeout is not
+/// this issue's business.
+const COMMAND_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// Combined stdout+stderr cap.
+///
+/// Why: #4173 asks for output that is "legible and unfiltered"; a build/test
+/// log is far larger than `run_bash`'s 8 KiB coordinator cap, so this is 4x
+/// wider — but still bounded, because an unbounded `cargo test` log would blow
+/// the context window and the truncation marker tells the model what it lost.
+const MAX_OUTPUT_CHARS: usize = 32_768;
+
+/// The L0-tier execution tool set for a registry rooted at `root`.
+///
+/// Why: THE gate. #4173's hard requirement is that this grant is L0-only
+/// *enforced in code through #4200's fail-closed tier resolver*, never by
+/// convention or by documentation, and never reachable by an L1 persona that
+/// merely declares the tool in its `[tools].allow`. Concentrating the decision
+/// in one function means every assembly point (today
+/// `runtime::tool_registry::build_assistant_tier_registry`) shares one
+/// definition of "who gets a shell", and a reviewer has exactly one place to
+/// check. Fail-closed comes free from [`crate::agents::AgentInfo::tier`]:
+/// absent, blank and unrecognized `tier` values all resolve to
+/// [`AgentTier::L1Standard`] before they ever reach this function, so an
+/// indeterminate tier is DENIED.
+/// What: `L0Orchestration` -> a one-element vector holding
+/// [`L0ShellExecTool`] rooted at `root`; `L1Standard` -> an empty vector, so
+/// the tool is never registered, never appears in `ToolRegistry::schemas()`,
+/// and therefore can never survive the `[tools].allow` glob intersection in
+/// `runtime::tool_registry::scope_assistant_allowed_tools` (nor be reached by
+/// `dispatch`, which has nothing registered under the name). The match is
+/// deliberately exhaustive with NO wildcard arm: adding a third tier must be a
+/// compile error that forces an explicit grant/deny decision here, not a
+/// silent fall-through in either direction.
+/// Test: `l0_execution_tools_denies_l1_tier`,
+/// `l0_execution_tools_grants_l0_tier`,
+/// `l0_execution_tools_denies_every_fail_closed_tier_string`.
+pub fn l0_execution_tools(tier: AgentTier, root: PathBuf) -> Vec<Arc<dyn ToolExecutor>> {
+    match tier {
+        AgentTier::L0Orchestration => vec![Arc::new(L0ShellExecTool::new(root))],
+        AgentTier::L1Standard => Vec::new(),
+    }
+}
+
+/// Shell/build/test executor for the L0 orchestration tier.
+///
+/// Why: See the module docs — this exists so L0 can run `cargo test`, drive a
+/// fix round and verify a PR without telling the owner to run the command.
+/// What: Holds the project `root` that every command starts in. Commands run
+/// via `sh -c` with [`COMMAND_TIMEOUT`]; stdout and stderr are combined and
+/// truncated at [`MAX_OUTPUT_CHARS`]; the exit code is always reported.
+/// Test: See the module-level `Test:` pointer.
+pub struct L0ShellExecTool {
+    /// The project root every command starts in, and the containment boundary
+    /// for a caller-supplied `working_dir` (see [`resolve_working_dir`]).
+    pub root: PathBuf,
+}
+
+impl L0ShellExecTool {
+    /// Construct the tool rooted at `root`.
+    ///
+    /// Why: Binding the root at construction (rather than reading the process
+    /// CWD inside `execute`) means the containment check cannot be moved by a
+    /// later `set_current_dir` anywhere else in the process.
+    /// What: Stores `root` verbatim; it is canonicalized per call so a root
+    /// that is created or replaced after construction still resolves.
+    /// Test: `l0_shell_exec_runs_in_the_root_by_default`.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+}
+
+/// Resolve the directory a command should run in, refusing anything outside
+/// `root`.
+///
+/// Why: #4173 asks for execution "scoped to project directories" that "cannot
+/// escape (containment via cwd)". A pure predicate keeps that rule unit-
+/// testable and keeps the traversal cases (`..`, an absolute path elsewhere, a
+/// symlink pointing out of the tree) in one place. It is a per-call STARTING
+/// directory check, not a sandbox: see the module docs.
+/// What: `None`/blank -> `root`. Otherwise the request is joined onto `root`
+/// when relative, then both sides are canonicalized (which resolves `..` and
+/// symlinks) and the result must be `root` itself or a descendant. A path that
+/// does not exist, or one that escapes, returns `Err(reason)`. The reason
+/// names the offending REQUEST, never the absolute root, so the message stays
+/// safe to surface.
+/// Test: `l0_shell_exec_accepts_working_dir_inside_the_root`,
+/// `l0_shell_exec_refuses_working_dir_outside_the_root`,
+/// `l0_shell_exec_refuses_parent_traversal_working_dir`,
+/// `l0_shell_exec_refuses_nonexistent_working_dir`,
+/// `resolve_working_dir_defaults_to_the_root`.
+pub fn resolve_working_dir(root: &Path, requested: Option<&str>) -> Result<PathBuf, String> {
+    let canonical_root = root
+        .canonicalize()
+        .map_err(|e| format!("project root is not resolvable: {e}"))?;
+    let Some(req) = requested.map(str::trim).filter(|r| !r.is_empty()) else {
+        return Ok(canonical_root);
+    };
+    let candidate = {
+        let p = Path::new(req);
+        if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            canonical_root.join(p)
+        }
+    };
+    let canonical = candidate
+        .canonicalize()
+        .map_err(|e| format!("working_dir '{req}' is not a resolvable directory: {e}"))?;
+    if !canonical.starts_with(&canonical_root) {
+        return Err(format!(
+            "working_dir '{req}' resolves outside the project root; \
+             execution is contained to the project tree"
+        ));
+    }
+    Ok(canonical)
+}
+
+#[async_trait]
+impl ToolExecutor for L0ShellExecTool {
+    fn name(&self) -> &str {
+        L0_SHELL_EXEC
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": L0_SHELL_EXEC,
+                "description": "Run a shell command in the project working tree — builds, \
+                                test suites, git and gh operations, scripts. Returns the exit \
+                                code with stdout and stderr combined and unfiltered. Commands \
+                                start in the project root; an optional working_dir must stay \
+                                inside it.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "command": {
+                            "type": "string",
+                            "description": "The shell command to run, e.g. 'cargo test -p trusty-agents'."
+                        },
+                        "working_dir": {
+                            "type": "string",
+                            "description": "Optional directory to run in. Relative to the project root; must resolve inside it."
+                        }
+                    },
+                    "required": ["command"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    /// Deny the two non-operator transports outright.
+    ///
+    /// Why: An independent second dimension from the persona tier gate. Even
+    /// inside a legitimately L0 session, a request arriving over a read-only
+    /// or analytics-only transport (an unauthenticated HTTP caller, a guest
+    /// Slack user — see `crate::rbac`) must not reach an unsandboxed shell.
+    /// Mirrors `tools::pm_bridge`'s owner-locked posture and is enforced at
+    /// the dispatch boundary by `ToolRegistry::dispatch_for_user`, so no
+    /// transport author can bypass it by forgetting to pre-filter.
+    /// What: Only `ServiceTier::All` (the authenticated operator/controller)
+    /// may invoke this tool.
+    /// Test: `l0_shell_exec_denied_to_read_only_service_tier`,
+    /// `l0_shell_exec_denied_to_analytics_service_tier`,
+    /// `l0_shell_exec_allowed_for_operator_service_tier`.
+    fn restricted_tiers(&self) -> &[ServiceTier] {
+        &[ServiceTier::ReadOnly, ServiceTier::Analytics]
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let command = match args.get("command").and_then(Value::as_str) {
+            Some(c) if !c.trim().is_empty() => c.to_string(),
+            _ => return ToolResult::err("l0_shell_exec: 'command' is required"),
+        };
+
+        // Defense in depth, NOT the security boundary (see module docs). The
+        // predicate is reused from `run_bash` rather than re-listed here so
+        // there is one catastrophic-pattern list in the crate.
+        if let Err(reason) = crate::tools::run_bash::is_dangerous_command(&command) {
+            return ToolResult::err(format!("l0_shell_exec blocked: {reason}"));
+        }
+
+        let work_dir = match resolve_working_dir(
+            &self.root,
+            args.get("working_dir").and_then(Value::as_str),
+        ) {
+            Ok(dir) => dir,
+            Err(reason) => return ToolResult::err(format!("l0_shell_exec: {reason}")),
+        };
+
+        let spawn = Command::new("sh")
+            .arg("-c")
+            .arg(&command)
+            .current_dir(&work_dir)
+            .output();
+
+        match tokio::time::timeout(COMMAND_TIMEOUT, spawn).await {
+            Err(_) => ToolResult::err(format!(
+                "l0_shell_exec: command timed out after {}s",
+                COMMAND_TIMEOUT.as_secs()
+            )),
+            Ok(Err(e)) => ToolResult::err(format!("l0_shell_exec: failed to spawn: {e}")),
+            Ok(Ok(output)) => {
+                let stdout = String::from_utf8_lossy(&output.stdout);
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                let code = output.status.code().unwrap_or(-1);
+                let combined = format!("{stdout}{stderr}");
+                let body = crate::tools::run_bash::truncate(&combined, MAX_OUTPUT_CHARS);
+                ToolResult::ok(format!("[exit {code}]\n{body}"))
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "l0_exec_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/tools/l0_exec_tests.rs
+++ b/crates/trusty-agents/src/tools/l0_exec_tests.rs
@@ -1,0 +1,413 @@
+//! Unit + async tests for the L0 execution grant (`super::l0_exec`, #4173).
+//!
+//! Why: Split out of `l0_exec.rs` so that module stays well under the 500-SLOC
+//! production cap, matching the sibling `delegate.rs` / `delegate_tests.rs`
+//! idiom (`#[path]` does not change the module hierarchy, so `super::*` still
+//! resolves to `l0_exec`).
+//! What: The tier gate itself, the containment predicate, the RBAC
+//! service-tier denial, and real `execute()` behaviour (including the
+//! `echo "hello"` smoke check #4173's acceptance criteria name).
+//! Test: this file IS the test module for `l0_exec`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use serde_json::json;
+
+use super::*;
+use crate::rbac::UserIdentity;
+use crate::tools::ToolRegistry;
+
+// ---------------------------------------------------------------------------
+// The tier gate — the security boundary.
+// ---------------------------------------------------------------------------
+
+/// L1 (standard tier, the fail-closed default and the tier that holds the
+/// Gmail/Drive/Calendar surface) gets NO execution tool at all. This is the
+/// invariant #4126 exists to protect: untrusted content reaching an L1
+/// persona must not be one tool call away from code execution.
+#[test]
+fn l0_execution_tools_denies_l1_tier() {
+    let tools = l0_execution_tools(AgentTier::L1Standard, PathBuf::from("."));
+    assert!(
+        tools.is_empty(),
+        "L1 must receive no execution tool, got: {:?}",
+        tools.iter().map(|t| t.name()).collect::<Vec<_>>()
+    );
+}
+
+/// L0 (orchestration tier, YOLO posture explicitly accepted by the owner, no
+/// untrusted-content surface) does get the shell.
+#[test]
+fn l0_execution_tools_grants_l0_tier() {
+    let tools = l0_execution_tools(AgentTier::L0Orchestration, PathBuf::from("."));
+    let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+    assert_eq!(names, vec![L0_SHELL_EXEC]);
+}
+
+/// Resolve a persona's tier the way production does: write a real
+/// `agent.toml`, load it through `AgentConfig::by_name_in` (the same loader
+/// `delegate_to_agent` and `run_subagent` use), and read `AgentInfo::tier()`.
+/// Deliberately NOT a hand-built `AgentTier` value — a regression in the
+/// loader or in the fail-closed resolver must fail these tests too.
+fn tier_from_declared_for_role(role: &str, raw: Option<&str>) -> (tempfile::TempDir, AgentTier) {
+    let dir = tempfile::tempdir().unwrap();
+    let tier_line = raw.map(|t| format!("tier = \"{t}\"")).unwrap_or_default();
+    std::fs::write(
+        dir.path().join("fixture-persona.toml"),
+        format!(
+            r#"
+[agent]
+name = "fixture-persona"
+role = "{role}"
+model = "anthropic/claude-sonnet-4-6"
+description = "test fixture"
+{tier_line}
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#
+        ),
+    )
+    .unwrap();
+    let cfg =
+        crate::agents::AgentConfig::by_name_in(&[dir.path().to_path_buf()], "fixture-persona")
+            .expect("fixture agent loads");
+    let tier = cfg.agent.tier();
+    (dir, tier)
+}
+
+/// The assistant-kind spelling of the helper above, for the tests whose subject
+/// is the declared string rather than the role.
+fn tier_from_declared(raw: Option<&str>) -> (tempfile::TempDir, AgentTier) {
+    tier_from_declared_for_role("assistant", raw)
+}
+
+/// Fail-closed end to end through the REAL loader + resolver: every EXPLICITLY
+/// DECLARED `tier` string that is not a recognized L0 alias — a typo, a
+/// plausible near-miss, even values that CONTAIN "l0" — must produce an empty
+/// tool set, for EITHER population.
+///
+/// Checked against the assistant kind as well as a sub-agent kind, because
+/// ADR-0024 decision 3 (PR #4296) made an ABSENT tier derive from the role: a
+/// declared-but-unrecognized string must still fail closed to `L1Standard` and
+/// must NOT fall through to the assistant-kind derivation. That fall-through
+/// would be a silent escalation, so it is pinned here for both roles.
+#[test]
+fn l0_execution_tools_denies_every_fail_closed_tier_string() {
+    for role in ["assistant", "engineer"] {
+        for raw in [
+            "l1",
+            "standard",
+            "L2",
+            "bogus",
+            "l0-ish",
+            "not-l0",
+            "orchestrator",
+        ] {
+            let (_dir, tier) = tier_from_declared_for_role(role, Some(raw));
+            assert_eq!(
+                tier,
+                AgentTier::L1Standard,
+                "role {role:?} + declared tier {raw:?} must resolve L1"
+            );
+            assert!(
+                l0_execution_tools(tier, PathBuf::from(".")).is_empty(),
+                "role {role:?} + declared tier {raw:?} must fail closed and grant nothing"
+            );
+        }
+    }
+}
+
+/// The DERIVED case, after ADR-0024 decision 3 (PR #4296, on `main`): with no
+/// usable `tier =` declaration the tier is a function of the agent's KIND —
+/// assistant-kind resolves L0 and therefore holds the grant; every sub-agent
+/// kind stays L1 and holds nothing.
+///
+/// Why this test exists in this file: the grant itself is unchanged — it is
+/// still "L0 only, by construction, an empty vector otherwise". What decision 3
+/// changed is the POPULATION that resolves L0. That is exactly the kind of
+/// upstream change that would otherwise silently redefine this tool's blast
+/// radius with no test failing, so the derivation is pinned at the grant site
+/// rather than only at the resolver. The observable capability delta for the
+/// shipped roster is separately pinned by
+/// `agents::tests::loading::bundled_assistant_personas_resolve_l0_and_gain_nothing`,
+/// which asserts no bundled assistant's `[tools].allow` can actually reach it.
+#[test]
+fn l0_execution_tools_follow_the_kind_derivation_when_no_tier_is_declared() {
+    for raw in [None, Some(""), Some("   ")] {
+        let (_dir, tier) = tier_from_declared_for_role("assistant", raw);
+        assert_eq!(
+            tier,
+            AgentTier::L0Orchestration,
+            "assistant-kind with tier {raw:?} derives L0 (ADR-0024 decision 3)"
+        );
+        assert_eq!(
+            l0_execution_tools(tier, PathBuf::from(".")).len(),
+            1,
+            "an L0-derived assistant registers the grant"
+        );
+
+        for role in ["engineer", "researcher", "qa", "planner", ""] {
+            let (_dir, tier) = tier_from_declared_for_role(role, raw);
+            assert_eq!(
+                tier,
+                AgentTier::L1Standard,
+                "sub-agent kind {role:?} with tier {raw:?} must stay L1"
+            );
+            assert!(
+                l0_execution_tools(tier, PathBuf::from(".")).is_empty(),
+                "sub-agent kind {role:?} must be granted nothing"
+            );
+        }
+    }
+}
+
+/// The counterpart: the aliases the resolver DOES recognize (in any case,
+/// with surrounding whitespace) elevate — again through the real loader.
+#[test]
+fn l0_execution_tools_grants_the_recognized_l0_aliases() {
+    for raw in ["l0", "L0", "orchestration", "Orchestration", "  l0  "] {
+        let (_dir, tier) = tier_from_declared(Some(raw));
+        assert_eq!(tier, AgentTier::L0Orchestration, "tier {raw:?} must be L0");
+        assert_eq!(
+            l0_execution_tools(tier, PathBuf::from(".")).len(),
+            1,
+            "tier {raw:?} must grant the execution tool"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Containment (cwd scoping).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_working_dir_defaults_to_the_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let resolved = resolve_working_dir(tmp.path(), None).unwrap();
+    assert_eq!(resolved, tmp.path().canonicalize().unwrap());
+    // Blank / whitespace is treated as "not supplied", never as "/".
+    assert_eq!(
+        resolve_working_dir(tmp.path(), Some("   ")).unwrap(),
+        tmp.path().canonicalize().unwrap()
+    );
+}
+
+#[tokio::test]
+async fn l0_shell_exec_accepts_working_dir_inside_the_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(tmp.path().join("crates")).unwrap();
+    let tool = L0ShellExecTool::new(tmp.path().to_path_buf());
+    let r = tool
+        .execute(json!({"command": "pwd", "working_dir": "crates"}))
+        .await;
+    assert!(!r.is_error(), "unexpected error: {}", r.content());
+    assert!(
+        r.content().contains("crates"),
+        "expected to run inside the subdirectory, got: {}",
+        r.content()
+    );
+}
+
+#[tokio::test]
+async fn l0_shell_exec_refuses_working_dir_outside_the_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    let tool = L0ShellExecTool::new(tmp.path().to_path_buf());
+    let r = tool
+        .execute(json!({"command": "pwd", "working_dir": "/"}))
+        .await;
+    assert!(r.is_error(), "an absolute escape must be refused");
+    assert!(
+        r.content().contains("outside the project root"),
+        "got: {}",
+        r.content()
+    );
+}
+
+#[tokio::test]
+async fn l0_shell_exec_refuses_parent_traversal_working_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir(tmp.path().join("inside")).unwrap();
+    let tool = L0ShellExecTool::new(tmp.path().join("inside"));
+    let r = tool
+        .execute(json!({"command": "pwd", "working_dir": "../.."}))
+        .await;
+    assert!(r.is_error(), "`..` traversal must be refused");
+    assert!(
+        r.content().contains("outside the project root"),
+        "got: {}",
+        r.content()
+    );
+}
+
+#[tokio::test]
+async fn l0_shell_exec_refuses_nonexistent_working_dir() {
+    let tmp = tempfile::tempdir().unwrap();
+    let tool = L0ShellExecTool::new(tmp.path().to_path_buf());
+    let r = tool
+        .execute(json!({"command": "pwd", "working_dir": "no/such/dir"}))
+        .await;
+    assert!(r.is_error());
+    assert!(
+        r.content().contains("not a resolvable directory"),
+        "got: {}",
+        r.content()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Execution behaviour (#4173 acceptance criteria).
+// ---------------------------------------------------------------------------
+
+/// #4173 acceptance criterion: "Simple test confirms shell execution works
+/// (e.g. `echo "hello"`)".
+#[tokio::test]
+async fn l0_shell_exec_runs_echo() {
+    let tmp = tempfile::tempdir().unwrap();
+    let tool = L0ShellExecTool::new(tmp.path().to_path_buf());
+    let r = tool.execute(json!({"command": "echo hello"})).await;
+    assert!(!r.is_error(), "unexpected error: {}", r.content());
+    assert!(r.content().contains("hello"), "got: {}", r.content());
+    assert!(r.content().contains("[exit 0]"), "got: {}", r.content());
+}
+
+#[tokio::test]
+async fn l0_shell_exec_runs_in_the_root_by_default() {
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("marker.txt"), "x").unwrap();
+    let tool = L0ShellExecTool::new(tmp.path().to_path_buf());
+    let r = tool.execute(json!({"command": "ls"})).await;
+    assert!(!r.is_error(), "unexpected error: {}", r.content());
+    assert!(r.content().contains("marker.txt"), "got: {}", r.content());
+}
+
+/// A failing build/test command must come back with its real exit code and
+/// its stderr — #4173 asks for output that is "legible and unfiltered", which
+/// is what makes the tool usable for driving a fix round.
+#[tokio::test]
+async fn l0_shell_exec_reports_exit_code_and_stderr() {
+    let tmp = tempfile::tempdir().unwrap();
+    let tool = L0ShellExecTool::new(tmp.path().to_path_buf());
+    let r = tool
+        .execute(json!({"command": "echo boom 1>&2; exit 3"}))
+        .await;
+    assert!(
+        !r.is_error(),
+        "a non-zero exit is a result, not a tool error"
+    );
+    assert!(r.content().contains("[exit 3]"), "got: {}", r.content());
+    assert!(r.content().contains("boom"), "got: {}", r.content());
+}
+
+#[tokio::test]
+async fn l0_shell_exec_rejects_missing_command() {
+    let tool = L0ShellExecTool::new(PathBuf::from("."));
+    let r = tool.execute(json!({})).await;
+    assert!(r.is_error());
+    assert!(r.content().contains("required"), "got: {}", r.content());
+}
+
+/// The catastrophic-pattern predicate is defense in depth (the tier gate is
+/// the boundary), but it is wired up and must stay wired up.
+#[tokio::test]
+async fn l0_shell_exec_blocks_catastrophic_pattern() {
+    let tool = L0ShellExecTool::new(PathBuf::from("."));
+    let r = tool.execute(json!({"command": "rm -rf /"})).await;
+    assert!(r.is_error());
+    assert!(
+        r.content().contains("blocked pattern"),
+        "got: {}",
+        r.content()
+    );
+}
+
+// ---------------------------------------------------------------------------
+// RBAC service tier — the second, independent dimension.
+// ---------------------------------------------------------------------------
+
+/// A read-only transport user (unauthenticated HTTP, guest Slack) must be
+/// refused at the REAL dispatch boundary (`ToolRegistry::dispatch_for_user`),
+/// even when the persona itself is L0 and the tool is therefore registered.
+#[tokio::test]
+async fn l0_shell_exec_denied_to_read_only_service_tier() {
+    let mut reg = ToolRegistry::new();
+    for tool in l0_execution_tools(AgentTier::L0Orchestration, PathBuf::from(".")) {
+        reg.register(tool);
+    }
+    let user = UserIdentity::new("guest", "guest", ServiceTier::ReadOnly);
+    let r = reg
+        .dispatch_for_user(L0_SHELL_EXEC, json!({"command": "echo hello"}), None, &user)
+        .await;
+    assert!(r.is_error(), "read-only users must not reach the shell");
+    assert!(r.content().contains("access tier"), "got: {}", r.content());
+}
+
+#[tokio::test]
+async fn l0_shell_exec_denied_to_analytics_service_tier() {
+    let mut reg = ToolRegistry::new();
+    for tool in l0_execution_tools(AgentTier::L0Orchestration, PathBuf::from(".")) {
+        reg.register(tool);
+    }
+    let user = UserIdentity::new("analyst", "analyst", ServiceTier::Analytics);
+    let r = reg
+        .dispatch_for_user(L0_SHELL_EXEC, json!({"command": "echo hello"}), None, &user)
+        .await;
+    assert!(r.is_error(), "analytics users must not reach the shell");
+}
+
+#[tokio::test]
+async fn l0_shell_exec_allowed_for_operator_service_tier() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut reg = ToolRegistry::new();
+    for tool in l0_execution_tools(AgentTier::L0Orchestration, tmp.path().to_path_buf()) {
+        reg.register(tool);
+    }
+    let user = UserIdentity::new("owner", "owner", ServiceTier::All);
+    let r = reg
+        .dispatch_for_user(
+            L0_SHELL_EXEC,
+            json!({"command": "echo hello"}),
+            Some(&[L0_SHELL_EXEC.to_string()]),
+            &user,
+        )
+        .await;
+    assert!(!r.is_error(), "unexpected error: {}", r.content());
+    assert!(r.content().contains("hello"));
+}
+
+/// The schema the model sees must name the tool it dispatches, or the LLM
+/// emits a call no registry can route.
+#[test]
+fn schema_matches_the_dispatch_name() {
+    let tool = L0ShellExecTool::new(PathBuf::from("."));
+    let schema = tool.schema();
+    assert_eq!(schema["function"]["name"], L0_SHELL_EXEC);
+    assert_eq!(tool.name(), L0_SHELL_EXEC);
+    let required = schema["function"]["parameters"]["required"]
+        .as_array()
+        .unwrap();
+    assert_eq!(required.len(), 1);
+    assert_eq!(required[0], "command");
+}
+
+/// Guard against a future edit accidentally aliasing this grant onto a tool
+/// name some other agent already holds (`run_bash` is granted to `ctrl`/`pm`,
+/// `shell_exec` to `local-ops-agent`, `pytest_exec` to `qa-agent`). The L0
+/// surface must stay its own greppable name.
+#[test]
+fn l0_grant_does_not_alias_an_existing_shell_tool_name() {
+    let tools: Vec<Arc<dyn ToolExecutor>> =
+        l0_execution_tools(AgentTier::L0Orchestration, PathBuf::from("."));
+    for t in &tools {
+        assert!(
+            !["run_bash", "shell_exec", "pytest_exec"].contains(&t.name()),
+            "the L0 grant must not reuse an existing shell tool name: {}",
+            t.name()
+        );
+    }
+}

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -23,6 +23,8 @@ pub mod format_translator;
 pub mod fs_reader;
 pub mod git_tools;
 pub mod izzie;
+// #4173 (epic #4167): the L0-orchestration-tier-only shell/build/test grant.
+pub mod l0_exec;
 pub mod mcp_live;
 pub mod mcp_service_tools;
 pub mod mcp_tools;

--- a/crates/trusty-agents/src/tools/run_bash.rs
+++ b/crates/trusty-agents/src/tools/run_bash.rs
@@ -90,8 +90,12 @@ pub fn is_dangerous_command(cmd: &str) -> Result<(), String> {
 /// Why: Capping output keeps a noisy command from blowing past the LLM's
 /// context window. char-based truncation avoids splitting multi-byte UTF-8.
 /// What: Returns `s` unchanged when short; otherwise "<head>… [truncated N chars]".
+///
+/// `pub(crate)` (#4173): `tools::l0_exec` reuses this verbatim for its own
+/// (wider) output cap rather than shipping a second truncation routine with a
+/// subtly different marker string.
 /// Test: `truncate_noop_when_short`, `truncate_caps_long_output`.
-fn truncate(s: &str, max: usize) -> String {
+pub(crate) fn truncate(s: &str, max: usize) -> String {
     let count = s.chars().count();
     if count <= max {
         return s.to_string();


### PR DESCRIPTION
Grants the L0 orchestration tier a shell/build/test executor, `l0_shell_exec`,
behind a single code-level tier gate. L1 (standard) personas get nothing —
not "get it and are denied at dispatch", but **never have it registered**.

Closes #4173. Part of epic #4167 (L0/L1 tier model). Builds directly on
#4200 (`ada4d351`, the `AgentTier` resolver + one-directional delegation gate)
and #4161 (`56337097`, the delegation taint that shut the
prompt-injection-to-code-execution path in #4126). Shell execution is the exact capability
that made #4126 a P0, so this PR hands it back to precisely one tier and does
it in code.

## This IS a general shell — stated explicitly

#4173's acceptance criteria ask for shell command execution in the project
working tree, `cargo test` / build commands, "output legible and unfiltered",
and an `echo "hello"` smoke check. That cannot be met by a constrained
build/test-only verb, so this is a general executor and the PR says so rather
than implying a narrower surface. Two narrowings were applied where the issue
allowed them:

* **One tool, not three.** #4173 lists `shell_exec`, `run_test` and `run_build`
  but explicitly permits the latter two "or invoke via shell". One executor is
  one new execution surface instead of three.
* **No new command-content policy.** The catastrophic-pattern predicate is
  *reused* from `tools::run_bash::is_dangerous_command` (already documented
  there as "defense in depth, not a security boundary"), not re-invented. No
  prefix allowlist: the epic's L0 row is "Git operations: ✅ Full (clone, pull,
  rebase, force-push)", which an allowlist would break.

### Exactly who can reach it

An agent reaches `l0_shell_exec` only if **all** of the following hold:

1. Its `role` is the assistant tier, so it is built by
   `runtime::tool_registry::build_assistant_tier_registry`; **and**
2. `AgentInfo::tier()` resolves its own declared `tier` to
   `AgentTier::L0Orchestration` — i.e. the TOML literally says `tier = "l0"`
   or `tier = "orchestration"` (#4200's resolver: absent, blank, whitespace and
   every unrecognized string fail closed to `L1Standard`); **and**
3. Its own `[tools].allow` admits the name through the existing glob scoping;
   **and**
4. The caller's RBAC `ServiceTier` is `All` — the tool declares
   `restricted_tiers() = [ReadOnly, Analytics]`, so a guest Slack user or an
   unauthenticated HTTP caller is refused at `ToolRegistry::dispatch_for_user`
   even inside a legitimately L0 session.

Condition 2 is the boundary. `tools::l0_exec::l0_execution_tools` returns an
empty vector for `L1Standard`, so for an L1 persona the name never enters
`ToolRegistry::schemas()`, cannot survive `scope_assistant_allowed_tools`'
glob intersection (a declared `l0_shell_exec`, an `l0_*`, or even a bare `*`
all yield nothing), and `dispatch` answers "no tool registered".

**The tier gate is the security boundary — not the command text and not the
cwd containment.** L0 is the owner's explicitly-accepted YOLO tier and is
deliberately not sandboxed (#4167); what makes that acceptable is that L0 must
never ingest untrusted content, while L1 holds the full Gmail/Drive/Calendar
surface and therefore never receives this tool. The `working_dir` containment
in `resolve_working_dir` is a per-call *starting-directory* check (rejects
absolute escapes, `..` traversal, symlinks out of the tree); a general shell
can still `cd` once running, which is inherent to granting a shell at all and
is why the doc comments say so plainly instead of overclaiming a sandbox.

### Privilege is not acquirable via delegation

No change was made to the tier gate or to taint composition. The grant
composes with them:

* The grant follows the **spawned agent's own** resolved tier, so it is never
  inherited from a delegator.
* `DelegateToAgentTool` already refuses every L1 → L0 hop (#4200), at every
  hop, including through an intermediary that declares no tier (which fails
  closed to L1).
* `compose_delegation_taint` intersects and `scope_for_delegation` intersects
  the inbound taint **with what the child registry actually holds**. So when an
  L0 persona legitimately delegates down to an L1 target, the taint carries
  `l0_shell_exec` as a *pattern* and the L1 child still gets nothing — a taint
  cannot conjure a tool the child's registry never registered. Narrowing-only
  is preserved in both directions.

## Tests

All exercise the real construction/loader/dispatch paths — real
`build_registry_for_agent` / `build_assistant_tier_registry`, real
`AgentConfig::by_name_in` fixtures, real `scope_assistant_allowed_tools` /
`scope_for_delegation` / `compose_delegation_taint`, real `ToolRegistry`
dispatch — not hand-built helper arguments.

`runtime/tool_registry_tests.rs`
* `l0_grant_absent_from_l1_assistant_registry`
* `l0_grant_present_in_l0_assistant_registry`
* `l1_persona_declaring_the_l0_grant_does_not_receive_it` — declares the tool
  by exact name, by `l0_*`, and by `*`; asserts at the scoping layer *and* at
  both dispatch layers
* `l0_grant_fails_closed_for_malformed_tier_declaration` — absent, blank,
  whitespace, `bogus`, `l0-ish`, with a positive control so it cannot pass
  vacuously
* `tainted_delegation_cannot_widen_into_the_l0_grant`
* `l1_cannot_reach_the_l0_grant_through_an_untiered_intermediary` — the
  transitive case, both legs

`tools/l0_exec_tests.rs`
* `l0_execution_tools_denies_l1_tier`, `l0_execution_tools_grants_l0_tier`
* `l0_execution_tools_denies_every_fail_closed_tier_string` and
  `l0_execution_tools_grants_the_recognized_l0_aliases` — ten deny cases and
  five grant cases, each resolved through a real on-disk agent TOML
* containment: `..._accepts_working_dir_inside_the_root`,
  `..._refuses_working_dir_outside_the_root`,
  `..._refuses_parent_traversal_working_dir`,
  `..._refuses_nonexistent_working_dir`, `resolve_working_dir_defaults_to_the_root`
* execution: `l0_shell_exec_runs_echo` (the issue's acceptance criterion),
  `..._runs_in_the_root_by_default`, `..._reports_exit_code_and_stderr`,
  `..._rejects_missing_command`, `..._blocks_catastrophic_pattern`
* RBAC: `..._denied_to_read_only_service_tier`,
  `..._denied_to_analytics_service_tier`,
  `..._allowed_for_operator_service_tier`
* `l0_grant_does_not_alias_an_existing_shell_tool_name`,
  `schema_matches_the_dispatch_name`

## Footprint

Deliberately small and additive, because #4170/#4171 land in the same files:
one new `pub mod` line in `tools/mod.rs`, one registration block in
`build_assistant_tier_registry`, one skill row appended to
`skills/manifest/builtin/ops.rs` (one skill per tool, per the owner ruling),
and `run_bash::truncate` widened to `pub(crate)` so the output cap is reused
rather than re-implemented. No persona under `~/.trusty-agents/agents/` is
created or modified; no tier-gate or taint-composition logic is touched.

## Finding for the epic — NOT fixed here, needs an owner decision

`run_bash` (a general shell with **no** cwd containment — it accepts any
absolute `working_dir`) is registered **unconditionally for every persona** on
the in-process persona-chat dispatch path
(`ctrl/pm_task/dispatch/persona.rs:437-440`, from #3285), gated only by the
persona's `[tools].allow`. It is **not** tier-gated. No shipped L1 persona
(`assistant`, `cto-assistant`, `izzie`) declares it, so nothing is live today —
but an L1 persona that declared `run_bash` would obtain shell on that path,
which is the same class #4173's "L1 personas cannot execute shell commands"
criterion is about.

It was left alone deliberately, because closing it is not a mechanical change:

* `ctrl.toml` declares `role = "assistant"` with **no** `tier`, so it resolves
  to L1, and it declares no `[tools].allow` at all (unrestricted). Its own
  prompt instructs it to use `run_bash`. `run_pm_task_with_persona("ctrl", …)`
  is the live path for the REPL, Telegram, Slack and the API server — so
  tier-gating `run_bash` there would break `ctrl` outright.
* Resolving that means deciding whether `ctrl` is L0 (it is reachable from
  Telegram/Slack, which has its own consequences) or whether `run_bash`'s
  registration needs a different gate. That is an owner/epic decision, not a
  side effect of this ticket.
* Mechanically, `persona.rs` is also at exactly 500 SLOC — the line-cap gate's
  production limit — so any additive change there needs a matching removal.

Recommend a follow-up issue under #4167 before the epic is called done.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
