### PR TITLE
fix(trusty-search): safe deregister on DELETE /indexes/:id (#4123) + restore-derived stages on POST /indexes (#4110)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -59,6 +59,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   vanished, are both now reported to the operator with a skip reason rather
   than dropped silently.
 
+- **Session index GC would have silently stopped reclaiming trusty-search disk**
+  ([#4123](https://github.com/bobmatnyc/trusty-tools/issues/4123)):
+  trusty-search's `DELETE /indexes/:id` now preserves on-disk data unless
+  `?delete_data=true` is passed. Both index-GC call sites in `search_gc.rs` —
+  decommission teardown and the periodic orphan sweep — now opt in explicitly.
+  Without this they would have kept removing the registration while leaving the
+  index data behind forever: the workspace each one describes is a disposable
+  worktree that is about to be deleted, so nothing will ever re-register at
+  that root and the preserved data would be unreachable garbage.
+
 ---
 ## [1.2.0] — 2026-07-27
 

--- a/crates/trusty-mpm/src/session_manager/search_gc.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc.rs
@@ -110,7 +110,12 @@ pub(super) async fn delete_search_index_best_effort(index_id: &str) {
             return;
         }
     };
-    let url = format!("{base}/indexes/{index_id}");
+    // Issue #4123: trusty-search's `DELETE /indexes/:id` now preserves on-disk
+    // data unless `delete_data=true` is passed. Opt in — the workspace this
+    // index describes is a disposable worktree that decommission is about to
+    // delete, so nothing will ever re-register at that root and preserved
+    // index data would be unreachable garbage on disk forever.
+    let url = format!("{base}/indexes/{index_id}?delete_data=true");
     match client.delete(&url).send().await {
         Ok(resp) if resp.status().is_success() => {
             info!(
@@ -322,7 +327,11 @@ impl SessionManager {
 
         let mut removed = Vec::new();
         for id in candidates {
-            let url = format!("{base}/indexes/{id}");
+            // Issue #4123: opt in to data deletion — same rationale as
+            // `delete_search_index_best_effort`. Every candidate here is a
+            // worktree-scoped index with no live session, so its data is
+            // unreachable garbage; a bare DELETE would silently leak it.
+            let url = format!("{base}/indexes/{id}?delete_data=true");
             match client.delete(&url).send().await {
                 Ok(resp) if resp.status().is_success() => {
                     info!(index_id = %id, "search-index-gc: removed orphaned/0-chunk index");

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (HTTP API): `DELETE /indexes/:id` no longer destroys on-disk data
+  by default** ([#4123](https://github.com/bobmatnyc/trusty-tools/issues/4123)).
+  The handler hardcoded `delete_data=true`, so every `DELETE` destroyed the
+  index's data directory and the HTTP surface offered NO way to merely
+  deregister. Registry hygiene was therefore impossible through the API: an
+  operator clearing 49 stale entries had to stop the daemon and hand-edit
+  `indexes.toml`, because one mis-typed id would have destroyed a real corpus.
+  A bare `DELETE` now deregisters only (the same safe path the orphan-reaper
+  has always used); destroying data requires an explicit
+  `?delete_data=true`. The response gained a `data_deleted` field so callers
+  can confirm which semantics ran. An unparseable `delete_data` value is
+  rejected with `400` rather than guessed at.
+
+  This also makes three long-standing pieces of documentation true rather than
+  false — all of them already promised the preserving behaviour that did not
+  exist: the API reference (`crates/trusty-search/CLAUDE.md`, "On-disk redb data
+  is preserved"), `trusty-search index remove`'s `--help` ("The on-disk redb /
+  HNSW snapshot is preserved — re-registering with the same path reuses it"),
+  and the UI's delete confirmation ("On-disk data is preserved.").
+
+  **Action required for callers that relied on `DELETE` reclaiming disk** —
+  they will silently stop reclaiming it and leave orphaned data behind. The
+  in-tree ones are updated in this change to pass `?delete_data=true`: the
+  `delete_index` MCP tool (its descriptor promises "and all its data"),
+  `trusty-search cleanup`, trusty-mpm's decommission + orphan-sweep index GC,
+  and the benchmark harnesses that require a clean slate. `trusty-search index
+  remove` and the UI are deliberately left on the new preserving default,
+  because that is what they already told users they did.
+
 ### Fixed
 
 - **An index whose durable corpus failed to open kept accepting watcher
@@ -36,6 +67,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   unchanged; corpus-failed indexes still return empty results (that is issue
   #4087, not fixed here).
 
+- **`POST /indexes` reported every stage `Pending` even when a colocated corpus
+  restore succeeded** ([#4110](https://github.com/bobmatnyc/trusty-tools/issues/4110)).
+  `create_index_handler` doubles as the "adopt an existing colocated corpus"
+  door — `build_indexer_from_entry` synchronously restores the redb corpus, the
+  HNSW snapshot and the symbol graph — but the handler then set
+  `lexical: pending(), semantic: pending()` unconditionally and threw that
+  outcome away. Since `search_capabilities` is derived from `stages`, a fully
+  intact index came up advertising no vector lane: semantic search hard-errored
+  with "requires Stage 2 (embeddings), which is not yet ready" and `search_all`
+  silently degraded to BM25-only, every hit reporting `match_reason="bm25"` —
+  indistinguishable from a genuinely dead vector lane. Only a daemon restart
+  cleared it, because the warm-boot path already classified correctly from the
+  same signals. The registration path now derives stages with
+  `derive_warm_boot_stages`, the same pure classifier warm-boot and
+  lazy-restore use, over the same signals read the same way, so the two can no
+  longer disagree about an identical on-disk state. A genuinely new index still
+  reports `created` (lexical `Pending`), not warm-boot's `walking`.
+
 ---
 ## [0.40.0] — 2026-07-27
 
@@ -50,7 +99,6 @@ MINOR, not patch: `service::lazy_loader::store`'s public
 - `trusty-common` requirement raised to `^0.27` (was `^0.26`): 0.27.0 makes
   `ChatEvent` `#[non_exhaustive]`, which a `^0.26` requirement cannot express.
   `service::ui`'s `ChatEvent` match gained a wildcard arm accordingly.
-
 
 ### Fixed
 

--- a/crates/trusty-search/CLAUDE.md
+++ b/crates/trusty-search/CLAUDE.md
@@ -154,13 +154,23 @@ Register a new (empty) index. Idempotent: re-registering an existing id returns
   { "id": "my-project", "created": false, "reason": "already exists" }
   ```
 
-##### `DELETE /indexes/:id`
+##### `DELETE /indexes/:id[?delete_data=true]`
 
-Drop an index from the in-memory registry. On-disk redb data is preserved —
-re-registering with the same id will reuse it.
+Drop an index from the in-memory registry and from `indexes.toml` / `roots.toml`.
+
+By default on-disk redb data is **preserved** — re-registering with the same id
+reuses it. This is the safe deregistration verb for registry hygiene. Pass
+`?delete_data=true` to also destroy the index's data directory.
+
+> **Behaviour change (issue #4123).** Before this, `DELETE` ALWAYS destroyed the
+> data directory and the documented "preserved" contract above was not what the
+> handler did. Callers that rely on `DELETE` reclaiming disk must now pass
+> `?delete_data=true` explicitly.
 
 - **Request body**: none.
-- **Response 200**: `{ "id": "my-project", "removed": true }`
+- **Query**: `delete_data` (bool, default `false`). An unparseable value is
+  rejected with `400` rather than silently defaulting either way.
+- **Response 200**: `{ "id": "my-project", "removed": true, "data_deleted": false }`
 
 ##### `GET /indexes/:id/status`
 

--- a/crates/trusty-search/src/commands/cleanup.rs
+++ b/crates/trusty-search/src/commands/cleanup.rs
@@ -140,7 +140,11 @@ pub async fn handle_cleanup(yes: bool, dry_run: bool) -> Result<()> {
     let mut removed = 0usize;
     let mut failed: Vec<(String, String)> = Vec::new();
     for e in &empties {
-        let url = format!("{}/indexes/{}", base, e.id);
+        // Issue #4123: `DELETE` preserves on-disk data unless `delete_data=true`
+        // is passed. Opt in so `cleanup` keeps fully reclaiming the stub — every
+        // candidate here is 0-chunk by construction (step 4 filters on
+        // `chunk_count == 0`), so nothing of value can be destroyed.
+        let url = format!("{}/indexes/{}?delete_data=true", base, e.id);
         match client.delete(&url).send().await {
             Ok(resp) if resp.status().is_success() => {
                 removed += 1;

--- a/crates/trusty-search/src/mcp/tools/index.rs
+++ b/crates/trusty-search/src/mcp/tools/index.rs
@@ -116,7 +116,16 @@ pub(super) async fn dispatch_index_tool(
                 Ok(v) => v,
                 Err(e) => return Some(Err(e)),
             };
-            Some(server.delete(&format!("/indexes/{index_id}")).await)
+            // Issue #4123: `DELETE /indexes/:id` now preserves on-disk data
+            // unless `delete_data=true` is passed. This tool's descriptor
+            // promises "Delete a registered index and all its data", so it
+            // opts in explicitly to keep that contract — without this the
+            // tool would silently stop reclaiming disk.
+            Some(
+                server
+                    .delete(&format!("/indexes/{index_id}?delete_data=true"))
+                    .await,
+            )
         }
         "reindex" => {
             let index_id = match required_index_id(server, args) {

--- a/crates/trusty-search/src/service/server/indexes.rs
+++ b/crates/trusty-search/src/service/server/indexes.rs
@@ -523,34 +523,89 @@ pub(super) async fn create_index_handler(
     // Issue #75: capture the current git HEAD SHA at registration; the search
     // response uses it to flag stale results when the working tree advances.
     let indexed_head_sha = crate::core::git::head_sha(&req.root_path);
-    // Issue #109, Phase 1: pre-mark semantic + graph as `Skipped` for
-    // lexical-only indexes so the search handler never tries the HNSW lane.
-    // Issue #313: pre-mark graph as `Skipped` for skip_kg indexes.
-    // Issue #2984 Phase 1: `skip_vector` pre-marks semantic as `Skipped`,
-    // independently of `skip_kg`'s graph gate — the two compose freely so
-    // every quadrant (both on, KG-only, vector-only, both off via
-    // `lexical_only`) is reachable from create time.
-    let stages = if lexical_only {
-        crate::core::registry::IndexStages {
-            lexical: crate::core::registry::StageState::pending(),
-            semantic: crate::core::registry::StageState::skipped(),
-            graph: crate::core::registry::StageState::skipped(),
-        }
-    } else {
-        crate::core::registry::IndexStages {
-            lexical: crate::core::registry::StageState::pending(),
-            semantic: if skip_vector {
-                crate::core::registry::StageState::skipped()
-            } else {
-                crate::core::registry::StageState::pending()
-            },
-            graph: if skip_kg {
-                crate::core::registry::StageState::skipped()
-            } else {
-                crate::core::registry::StageState::pending()
-            },
-        }
-    };
+    // Issue #4110: derive the stage state from what `build_indexer_from_entry`
+    // ACTUALLY restored, instead of asserting `Pending` and ignoring the
+    // outcome.
+    //
+    // Why: `POST /indexes` doubles as the "adopt an existing colocated corpus"
+    // door — the builder above synchronously restores the redb corpus, the
+    // HNSW snapshot and the symbol graph for `id` (the issue #85
+    // warm-restore-on-create path). Hardcoding `pending()` threw that result
+    // away, so a fully-intact index came up advertising no semantic lane:
+    // `search_capabilities` is computed from `stages`, so semantic search
+    // hard-errored with "requires Stage 2 (embeddings), which is not yet
+    // ready" and `search_all` silently degraded to BM25-only — every hit
+    // reporting `match_reason="bm25"`, indistinguishable from a genuinely dead
+    // vector lane. Only a daemon restart cleared it, because the warm-boot
+    // path (`commands/start_restore.rs`) already classified correctly.
+    // What: reuse `derive_warm_boot_stages` — the same pure classifier
+    // warm-boot and lazy-restore use — over the same signals read the same
+    // way, so registration and warm-boot can no longer disagree about an
+    // identical on-disk state. The `skip_*` / `lexical_only` config gates are
+    // honoured inside the classifier (config intent wins over on-disk state),
+    // so the pre-marking this replaces is preserved. `corpus_open_failed` is
+    // read rather than hardcoded `false` so the classifier's input contract is
+    // satisfied honestly — but note this is safe ONLY because the #2336 check
+    // above already 500s on that flag, so it is always `false` by the time we
+    // get here. It is NOT defensive: if that guard were moved or removed, the
+    // classifier's rule 1 would return lexical `Failed`, and the
+    // `restore_chunk_count == 0` override below would immediately clobber it
+    // back to `Pending` (a failed open reports 0 chunks), reporting a broken
+    // index as a healthy brand-new one. Moving that guard requires teaching
+    // the override to exempt `corpus_open_failed`.
+    // A genuinely brand-new index restores nothing: `chunk_count == 0` and no
+    // snapshot ⇒ semantic/graph `Pending` exactly as before.
+    let restore_chunk_count = indexer
+        .corpus_store()
+        .and_then(|c| c.chunk_count().ok())
+        .unwrap_or(0);
+    // Issue #2922: file existence alone is not proof the snapshot loaded —
+    // `hnsw_load_failed` catches the truncated/corrupt case that would
+    // otherwise report `semantic: ready` over an empty in-memory store.
+    let restore_hnsw_ready = !indexer.hnsw_load_failed
+        && crate::service::persistence::hnsw_path_for_entry(&init_entry)
+            .map(|p| crate::service::persistence::has_persisted_hnsw(&p))
+            .unwrap_or(false);
+    let restore_graph_nodes = indexer.snapshot_symbol_graph().await.node_count();
+    let mut stages = crate::service::warm_boot::derive_warm_boot_stages(
+        crate::service::warm_boot::WarmBootInputs {
+            chunk_count: restore_chunk_count,
+            hnsw_snapshot_ready: restore_hnsw_ready,
+            graph_node_count: restore_graph_nodes,
+            lexical_only,
+            skip_kg,
+            skip_vector,
+            corpus_open_failed: indexer.corpus_open_failed,
+        },
+    );
+    // The one deliberate divergence from warm-boot's classification. With no
+    // corpus restored, `derive_warm_boot_stages` calls lexical `InProgress`
+    // ("registered, empty, a catch-up will populate it") — right for a
+    // restart, wrong here: at registration nothing has started yet.
+    // `IndexStages::lifecycle_status` maps `InProgress` → "walking" and
+    // `Pending` → "created", so adopting it verbatim would make every
+    // brand-new index report "walking" before its first walk ever ran. Only
+    // the lexical stage is corrected; semantic/graph already agree (nothing
+    // restored ⇒ `Pending`), which is what keeps a failed/absent restore
+    // reporting `Pending` rather than a false-ready.
+    if restore_chunk_count == 0 {
+        stages.lexical = crate::core::registry::StageState::pending();
+    }
+    tracing::info!(
+        "create_index: '{}' registered — restored chunks={} hnsw_snapshot={} graph_nodes={} \
+         lexical_only={} skip_kg={} skip_vector={} → stages(lexical={:?}, semantic={:?}, \
+         graph={:?}) (issue #4110)",
+        req.id,
+        restore_chunk_count,
+        restore_hnsw_ready,
+        restore_graph_nodes,
+        lexical_only,
+        skip_kg,
+        skip_vector,
+        stages.lexical.status,
+        stages.semantic.status,
+        stages.graph.status,
+    );
     let handle = IndexHandle {
         id: id.clone(),
         indexer: Arc::new(tokio::sync::RwLock::new(indexer)),

--- a/crates/trusty-search/src/service/server/mod.rs
+++ b/crates/trusty-search/src/service/server/mod.rs
@@ -48,6 +48,10 @@ mod tests_2984;
 #[cfg(test)]
 mod tests_3304;
 #[cfg(test)]
+mod tests_4110;
+#[cfg(test)]
+mod tests_4123;
+#[cfg(test)]
 mod tests_829;
 #[cfg(test)]
 mod tests_chunks;

--- a/crates/trusty-search/src/service/server/search.rs
+++ b/crates/trusty-search/src/service/server/search.rs
@@ -8,10 +8,11 @@
 //! live in `routing.rs`. Global fan-out lives in `search_global.rs`.
 //! Test: `search_handler_meta_includes_stale_index_root_field` and related.
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     Json,
 };
+use serde::Deserialize;
 use std::sync::Arc;
 
 use crate::core::{classifier::QueryClassifier, indexer::SearchQuery, registry::IndexId};
@@ -29,13 +30,57 @@ use super::status::index_disk_and_mtime;
 // through the `search` path without knowing about `search_global`.
 pub(super) use super::search_global::global_search_handler;
 
+/// Query parameters for `DELETE /indexes/{id}` (issue #4123).
+///
+/// Why: before #4123 the handler hardcoded `delete_data=true`, so the HTTP
+/// surface had NO way to deregister an index while keeping its on-disk data.
+/// Registry hygiene (removing stale entries — issues #4094, #4095) therefore
+/// could not be done through the API at all: a mis-typed id destroyed a real
+/// corpus. An operator clearing 49 stale entries had to stop the daemon and
+/// hand-edit `indexes.toml` instead. Two callers had ALREADY documented the
+/// safe semantics that did not exist — the UI's confirm dialog ("On-disk data
+/// is preserved.", `ui/src/lib/views/Indexes.svelte`) and `trusty-search index
+/// remove`'s help ("The on-disk redb / HNSW snapshot is preserved") — so
+/// `false` restores the contract the product already advertised.
+/// What: a single optional `delete_data` flag, absent ⇒ `false` (deregister
+/// only). Destroying data is now strictly opt-in via `?delete_data=true`. An
+/// unparseable value (e.g. `?delete_data=maybe`) is rejected by axum's `Query`
+/// extractor with `400` rather than silently defaulting either way — a
+/// destructive toggle must never be guessed at.
+/// Test: `delete_index_without_param_preserves_data`,
+/// `delete_index_with_delete_data_true_destroys_data`.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct DeleteIndexParams {
+    /// Opt in to destroying the on-disk data directory alongside the
+    /// registration. Defaults to `false` — see the type's `Why`.
+    #[serde(default)]
+    delete_data: bool,
+}
+
+/// `DELETE /indexes/{id}` — deregister an index, optionally destroying its data.
+///
+/// Why: see [`DeleteIndexParams`]. BREAKING (issue #4123): a bare `DELETE` no
+/// longer deletes on-disk data. Callers that genuinely want the disk reclaimed
+/// must now pass `?delete_data=true`.
+/// What: delegates to [`unregister_index`] — the same function the
+/// orphan-reaper already drives with `delete_data=false` — and echoes
+/// `data_deleted` so a caller can confirm which of the two semantics ran
+/// instead of inferring it from the request it sent.
+/// Test: `delete_index_without_param_preserves_data`,
+/// `delete_index_with_delete_data_true_destroys_data`.
 pub(super) async fn delete_index_handler(
     State(state): State<Arc<SearchAppState>>,
     Path(id): Path<String>,
+    Query(params): Query<DeleteIndexParams>,
 ) -> Json<serde_json::Value> {
-    // The interactive DELETE also destroys the on-disk footprint (delete_data).
-    let removed = unregister_index(&state, &id, /*delete_data=*/ true).await;
-    Json(serde_json::json!({ "id": id, "removed": removed }))
+    let removed = unregister_index(&state, &id, params.delete_data).await;
+    Json(serde_json::json!({
+        "id": id,
+        "removed": removed,
+        // Only meaningful when something was actually removed: an unknown id
+        // deletes nothing regardless of the flag.
+        "data_deleted": removed && params.delete_data,
+    }))
 }
 
 /// Fully unregister an index from the running daemon.
@@ -44,9 +89,11 @@ pub(super) async fn delete_index_handler(
 /// automatic orphan-reaper ticker (orphan self-heal). Both must drop the
 /// in-memory registration, stop its filesystem watcher, and rewrite
 /// `indexes.toml` + `roots.toml` so the index cannot resurrect on the next
-/// warm-boot. The two callers differ only in whether the on-disk *data*
-/// directory is destroyed — the reaper passes `delete_data=false` so a
-/// false-positive orphan detection can never delete real index data.
+/// warm-boot. The callers differ only in whether the on-disk *data* directory
+/// is destroyed — the reaper passes `delete_data=false` so a false-positive
+/// orphan detection can never delete real index data, and since issue #4123
+/// the HTTP handler passes the request's `?delete_data` flag (default `false`,
+/// i.e. the same safe semantics the reaper has always used).
 /// What: atomically removes the handle from the registry (capturing its
 /// `root_path` in the same `remove` so a concurrent PATCH cannot make it stale
 /// — issue #1090/#1097), stops the watcher (issue #1621), deletes the registry

--- a/crates/trusty-search/src/service/server/tests_4110.rs
+++ b/crates/trusty-search/src/service/server/tests_4110.rs
@@ -1,0 +1,239 @@
+//! Regression tests for restore-derived stage status on `POST /indexes` (#4110).
+//!
+//! Why: `create_index_handler` doubles as the "adopt an existing colocated
+//! corpus" door — `build_indexer_from_entry` synchronously restores the redb
+//! corpus, the HNSW snapshot and the symbol graph — but the handler then
+//! asserted `lexical: pending(), semantic: pending()` unconditionally,
+//! throwing that outcome away. `search_capabilities` is derived from `stages`,
+//! so a fully-intact index came up advertising no vector lane: semantic search
+//! hard-errored with "requires Stage 2 (embeddings), which is not yet ready"
+//! and `search_all` silently degraded to BM25-only, every hit reporting
+//! `match_reason="bm25"` — indistinguishable from a genuinely dead lane. Only
+//! a daemon restart cleared it, because the warm-boot path already classified
+//! correctly from the same signals.
+//! What: both tests drive the REAL `create_index_handler` through a
+//! create → index content → unregister → re-register cycle, so the second
+//! registration performs a genuine colocated restore. The pair differs in ONE
+//! input — whether an HNSW snapshot was persisted before the re-register — so
+//! what is under test is the MAPPING from restore outcome to stage status, not
+//! a literal: the same handler must report `semantic: Ready` for one and
+//! `semantic: Pending` for the other. Both fail before the fix, which reports
+//! `Pending` for every stage regardless of what restored.
+//! Test: this module. Run with `cargo test -p trusty-search tests_4110`.
+
+use super::*;
+use crate::core::embed::Embedder;
+use crate::core::registry::{IndexId, IndexRegistry, StageStatus};
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::Json;
+use std::sync::Arc;
+
+/// A `CreateIndexRequest` with every optional field defaulted.
+///
+/// Why: mirrors `tests_2984::create_req_with_skip_kg` — this suite needs no
+/// per-field variation, only the full-pipeline defaults, so that the stage
+/// status observed comes from the restore and nothing else.
+fn create_req(id: &str, root_path: std::path::PathBuf) -> super::router::CreateIndexRequest {
+    super::router::CreateIndexRequest {
+        id: id.to_string(),
+        root_path,
+        include_paths: None,
+        exclude_globs: None,
+        extensions: None,
+        domain_terms: None,
+        path_filter: None,
+        include_docs: None,
+        respect_gitignore: None,
+        follow_links: None,
+        lexical_only: None,
+        skip_kg: None,
+        skip_vector: None,
+        defer_embed: None,
+        extra_skip_dirs: None,
+        data_file_max_bytes: None,
+        allow_sensitive_path: false,
+    }
+}
+
+/// Fresh registry with a mock embedder installed — enough for
+/// `create_index_handler` to run without a live daemon or network. The mock's
+/// 8 dimensions are used for BOTH registrations in a test, so a persisted
+/// snapshot always reloads at a matching dimension (a mismatch would set
+/// `hnsw_load_failed` and defeat the scenario under test).
+async fn mock_state() -> Arc<SearchAppState> {
+    let state = SearchAppState::new(IndexRegistry::new());
+    let embedder: Arc<dyn Embedder> = Arc::new(crate::core::embed::MockEmbedder::new(8));
+    state.install_embedder(embedder).await;
+    Arc::new(state)
+}
+
+/// Run the create → index-content → (optionally persist HNSW) → unregister →
+/// re-register cycle and return the stages the SECOND registration produced.
+///
+/// Why: the second `create_index_handler` call is the code path under test —
+/// the first exists only to lay down a real colocated corpus for it to
+/// restore. Sharing the driver between both tests is what makes the pair a
+/// controlled experiment: `persist_hnsw` is the single differing input.
+/// What: indexes two files with a caller→callee edge so the corpus is
+/// genuinely non-empty, optionally writes the HNSW snapshot to
+/// `<root>/.trusty-search/hnsw.usearch` via `save_vector_store`, then stops
+/// the watcher and unregisters (both required to release the redb file lock
+/// and clear the handler's "already exists" short-circuit — see `tests_2984`
+/// for the full rationale) before re-POSTing the same id/root.
+async fn stages_after_restore(
+    prefix: &str,
+    persist_hnsw: bool,
+) -> crate::core::registry::IndexStages {
+    let state = mock_state().await;
+    let (_dir, root) = super::test_support::allowlisted_index_root(prefix);
+    let id = IndexId::new(format!("{}restore", prefix));
+
+    let first = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req(&id.0, root.clone())),
+    )
+    .await;
+    assert_eq!(first.status(), StatusCode::OK, "first create must succeed");
+
+    {
+        let handle = state
+            .registry
+            .get(&id)
+            .expect("index must be registered after create");
+        let indexer = handle.indexer.read().await;
+        indexer
+            .index_files_batch(&[
+                ("src/caller.rs".into(), "fn caller() { callee(); }".into()),
+                ("src/callee.rs".into(), "fn callee() {}".into()),
+            ])
+            .await
+            .expect("index batch");
+        if persist_hnsw {
+            let hnsw_path = crate::service::colocated_storage::colocated_hnsw_path(&root)
+                .expect("colocated hnsw path");
+            assert!(
+                indexer
+                    .save_vector_store(&hnsw_path)
+                    .await
+                    .expect("save vector store"),
+                "sanity: a store must be wired, otherwise no snapshot is written \
+                 and the 'successful restore' scenario is vacuous"
+            );
+            assert!(
+                hnsw_path.exists(),
+                "sanity: the HNSW snapshot must exist on disk before re-register"
+            );
+        }
+    }
+
+    // Release the corpus Arc (and its redb file lock) and clear the handler's
+    // in-memory "already exists" early return, so the re-POST below actually
+    // reaches the restore path. See `tests_2984` for why both steps are
+    // required.
+    state.watcher_manager.stop_for_index(&id).await;
+    assert!(
+        state.registry.unregister(&id),
+        "index must have been registered to unregister"
+    );
+
+    let second = super::indexes::create_index_handler(
+        State(Arc::clone(&state)),
+        Json(create_req(&id.0, root.clone())),
+    )
+    .await;
+    assert_eq!(
+        second.status(),
+        StatusCode::OK,
+        "re-register over the existing colocated corpus must succeed"
+    );
+
+    let restored = state
+        .registry
+        .get(&id)
+        .expect("index must be registered after re-create");
+    let stages = restored.stages.read().await.clone();
+    state.watcher_manager.stop_for_index(&id).await;
+    stages
+}
+
+/// Issue #4110: a re-registration that successfully restores a colocated
+/// corpus WITH an HNSW snapshot must report the semantic stage ready.
+///
+/// Why: this is the reported defect. Before the fix the handler ignored the
+/// restore entirely and reported `Pending`, so semantic search hard-errored
+/// against a fully-intact index until the daemon was restarted.
+/// Test: this test.
+///
+/// `#[serial]` because `create_index_handler` persists to `indexes.toml` under
+/// whatever `TRUSTY_DATA_DIR` resolves to at that instant. Several suites in
+/// this binary (e.g. `tests_components::IsolatedDataDir`) redirect that env var
+/// for the duration of a serial test, so running unserialised would write this
+/// index's registry entry into THEIR sandbox and can fail their persistence
+/// assertions with a 500 — observed once under heavy parallel load.
+#[tokio::test]
+#[serial_test::serial]
+async fn create_index_successful_restore_reports_semantic_ready() {
+    let stages = stages_after_restore("ts-4110-with-hnsw-", true).await;
+
+    assert_eq!(
+        stages.semantic.status,
+        StageStatus::Ready,
+        "#4110: a restored HNSW snapshot must map to semantic Ready, not \
+         Pending — got {:?}",
+        stages.semantic.status
+    );
+    assert_eq!(
+        stages.lexical.status,
+        StageStatus::Ready,
+        "#4110: a restored non-empty corpus must map to lexical Ready — got {:?}",
+        stages.lexical.status
+    );
+    assert!(
+        stages.search_capabilities().contains(&"vector"),
+        "#4110: the vector lane must be advertised so search_all does not \
+         silently degrade to BM25-only; capabilities were {:?}",
+        stages.search_capabilities()
+    );
+}
+
+/// Issue #4110 (the other direction): a restore with NO HNSW snapshot must
+/// leave the semantic stage pending, while still reporting the lexical stage
+/// ready from the corpus that DID restore.
+///
+/// Why: guards the fix against over-correcting into a false-ready — the exact
+/// failure mode `derive_warm_boot_stages`' `#2922` / `#2203` guards exist to
+/// prevent. The lexical assertion is what makes this test non-vacuous: before
+/// the fix lexical was hardcoded `Pending`, so this fails too, proving the
+/// handler now genuinely reads the restore rather than emitting a constant
+/// that happens to match in one branch.
+/// Test: this test.
+///
+/// `#[serial]` for the same reason as its sibling above.
+#[tokio::test]
+#[serial_test::serial]
+async fn create_index_restore_without_hnsw_snapshot_stays_pending() {
+    let stages = stages_after_restore("ts-4110-no-hnsw-", false).await;
+
+    assert_eq!(
+        stages.semantic.status,
+        StageStatus::Pending,
+        "#4110: with no HNSW snapshot on disk the semantic stage must stay \
+         Pending, never a false-ready — got {:?}",
+        stages.semantic.status
+    );
+    assert_eq!(
+        stages.lexical.status,
+        StageStatus::Ready,
+        "#4110: the corpus DID restore, so lexical must be Ready — a Pending \
+         here means the handler is still ignoring the restore result entirely \
+         (got {:?})",
+        stages.lexical.status
+    );
+    assert!(
+        !stages.search_capabilities().contains(&"vector"),
+        "#4110: the vector lane must NOT be advertised without a snapshot; \
+         capabilities were {:?}",
+        stages.search_capabilities()
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_4123.rs
+++ b/crates/trusty-search/src/service/server/tests_4123.rs
@@ -1,0 +1,152 @@
+//! Regression tests for safe deregistration on `DELETE /indexes/{id}` (#4123).
+//!
+//! Why: the handler hardcoded `delete_data=true`, so every `DELETE` destroyed
+//! the on-disk data directory and the HTTP surface offered no way to merely
+//! deregister. Registry hygiene was therefore impossible through the API — an
+//! operator clearing 49 stale entries had to stop the daemon and hand-edit
+//! `indexes.toml`, because one mis-typed id would have destroyed a real
+//! corpus. Two callers had already documented the safe semantics that did not
+//! exist (the UI's "On-disk data is preserved." confirm dialog and `trusty-search
+//! index remove`'s help), so the destructive default was also a live
+//! documentation lie. These tests pin BOTH halves of the fix: the new default
+//! preserves, and the destructive capability is still reachable.
+//! What: drives the real router with `oneshot` so the `?delete_data=` query
+//! extractor and the route wiring are exercised end-to-end, not just the
+//! handler function. `TRUSTY_DATA_DIR` is redirected at a `TempDir` so
+//! `remove_index_data_dir` / `remove_index_registry_entry` / `remove_root` all
+//! act inside the sandbox; `#[serial_test::serial]` guards that process-wide
+//! env var against the other tests that mutate it.
+//! Test: this module. Run with `cargo test -p trusty-search tests_4123`.
+
+use super::build_router;
+use crate::core::indexer::CodeIndexer;
+use crate::core::registry::{IndexHandle, IndexId, IndexRegistry};
+use crate::service::server::SearchAppState;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tower::ServiceExt;
+
+/// Index id used by both tests. Deliberately `[A-Za-z0-9-]` only so
+/// `persistence::sanitize_id` is the identity function and the on-disk
+/// directory name is predictable.
+const INDEX_ID: &str = "delete-data-4123";
+
+/// Register `INDEX_ID` in a fresh router and materialise its app-data
+/// directory with a marker file.
+///
+/// Returns the router plus the path of the data directory the DELETE may or
+/// may not destroy. The marker file is what makes the assertions meaningful:
+/// an empty directory could vanish for unrelated reasons, a directory holding
+/// a known byte string cannot.
+fn router_with_index_and_data(data_root: &std::path::Path) -> (axum::Router, std::path::PathBuf) {
+    let registry = IndexRegistry::new();
+    let root_path = data_root.join("corpus-root");
+    std::fs::create_dir_all(&root_path).expect("create index root");
+    registry.register(IndexHandle::bare(
+        IndexId::new(INDEX_ID),
+        Arc::new(RwLock::new(CodeIndexer::new(INDEX_ID, root_path.clone()))),
+        root_path,
+    ));
+    let index_data_dir = data_root.join("indexes").join(INDEX_ID);
+    std::fs::create_dir_all(&index_data_dir).expect("create index data dir");
+    std::fs::write(index_data_dir.join("corpus.marker"), b"real corpus bytes")
+        .expect("write marker");
+    (build_router(SearchAppState::new(registry)), index_data_dir)
+}
+
+/// Issue the DELETE and return the decoded JSON body.
+/// Deliberately NOT named `delete_index`: that name is an allowlisted dangling
+/// doc-pointer in `mcp/tools/http.rs` (`Test: delete_index arm exercises this
+/// path`), and a helper by that name silently satisfies it — converting a
+/// KNOWN-dangling pointer into a falsely-resolved one and dropping the lint's
+/// signal. This helper drives the HTTP route; it does not exercise that arm.
+async fn send_delete_request(router: axum::Router, uri: &str) -> serde_json::Value {
+    let resp = router
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(uri)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::OK, "DELETE {uri} must succeed");
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    serde_json::from_slice(&bytes).expect("json body")
+}
+
+/// Issue #4123: `DELETE /indexes/{id}` with NO parameter must deregister the
+/// index while leaving its on-disk data directory intact.
+///
+/// Why: this is the safe deregistration verb the API never had. It is the
+/// whole point of the issue — before the fix this test fails because the
+/// marker file is destroyed along with the registration.
+/// Test: this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn delete_index_without_param_preserves_data() {
+    // RAII rather than a bare set_var/remove_var pair: the assertions below
+    // panic on failure, and an early unwind must not leave `TRUSTY_DATA_DIR`
+    // pointing at a deleted tempdir — that would cascade this one failure into
+    // every later serial test in the binary.
+    let isolated = super::tests_components::IsolatedDataDir::new();
+    let (router, index_data_dir) = router_with_index_and_data(isolated.path());
+    let marker = index_data_dir.join("corpus.marker");
+
+    let body = send_delete_request(router, &format!("/indexes/{INDEX_ID}")).await;
+
+    assert_eq!(
+        body["removed"], true,
+        "the registration must still be removed: {body}"
+    );
+    assert_eq!(
+        body["data_deleted"], false,
+        "a bare DELETE must report that it preserved data: {body}"
+    );
+    assert!(
+        marker.exists(),
+        "bare DELETE must NOT destroy on-disk data; {} is gone",
+        marker.display()
+    );
+    assert_eq!(
+        std::fs::read(&marker).expect("read marker"),
+        b"real corpus bytes",
+        "preserved data must be byte-identical, not merely present"
+    );
+}
+
+/// Issue #4123: the destructive behaviour must remain available and reachable
+/// over HTTP via `?delete_data=true`.
+///
+/// Why: making the default safe is only half the fix — callers that genuinely
+/// reclaim disk (the `delete_index` MCP tool, `trusty-search cleanup`,
+/// trusty-mpm's worktree index GC) must still be able to opt in, or the fix
+/// trades a data-loss bug for a disk-leak bug. Driving the real router proves
+/// the flag survives routing and query extraction, not just the function
+/// signature.
+/// Test: this test.
+#[tokio::test]
+#[serial_test::serial]
+async fn delete_index_with_delete_data_true_destroys_data() {
+    // RAII: see `delete_index_without_param_preserves_data`.
+    let isolated = super::tests_components::IsolatedDataDir::new();
+    let (router, index_data_dir) = router_with_index_and_data(isolated.path());
+
+    let body = send_delete_request(router, &format!("/indexes/{INDEX_ID}?delete_data=true")).await;
+
+    assert_eq!(body["removed"], true, "registration removed: {body}");
+    assert_eq!(
+        body["data_deleted"], true,
+        "an opted-in DELETE must report that it destroyed data: {body}"
+    );
+    assert!(
+        !index_data_dir.exists(),
+        "?delete_data=true must destroy the data dir; {} survived",
+        index_data_dir.display()
+    );
+}

--- a/crates/trusty-search/src/service/server/tests_components.rs
+++ b/crates/trusty-search/src/service/server/tests_components.rs
@@ -53,15 +53,24 @@ fn state_with_index(id: &str) -> Arc<SearchAppState> {
 /// default data dir (not just other `#[serial]`-tagged tests — serial_test's
 /// lock only excludes tests sharing its tag). See the module doc comment.
 /// What: sets `TRUSTY_DATA_DIR` in `new()`; `Drop` removes it.
-struct IsolatedDataDir {
-    _tmp: tempfile::TempDir,
+///
+/// Shared with `tests_4123` (issue #4123), which needs the same panic-safe
+/// restore — hence `pub(super)` and the [`Self::path`] accessor.
+pub(super) struct IsolatedDataDir {
+    tmp: tempfile::TempDir,
 }
 
 impl IsolatedDataDir {
-    fn new() -> Self {
+    pub(super) fn new() -> Self {
         let tmp = tempfile::tempdir().unwrap();
         unsafe { std::env::set_var("TRUSTY_DATA_DIR", tmp.path()) };
-        Self { _tmp: tmp }
+        Self { tmp }
+    }
+
+    /// The isolated dir itself, for tests that must also place fixtures inside
+    /// the sandbox they just pointed `TRUSTY_DATA_DIR` at.
+    pub(super) fn path(&self) -> &std::path::Path {
+        self.tmp.path()
     }
 }
 

--- a/crates/trusty-search/tests/benchmark_open_mpm.rs
+++ b/crates/trusty-search/tests/benchmark_open_mpm.rs
@@ -289,7 +289,9 @@ async fn fetch_rss_mb(client: &Client) -> u64 {
 /// Test: asserts 200 on POST; transport errors panic.
 async fn register_index(client: &Client) {
     let _ = client
-        .delete(format!("{DAEMON_URL}/indexes/{INDEX_NAME}"))
+        .delete(format!(
+            "{DAEMON_URL}/indexes/{INDEX_NAME}?delete_data=true"
+        ))
         .send()
         .await;
 
@@ -427,7 +429,9 @@ async fn fetch_status(client: &Client) -> Value {
 /// Test: failures print, not panic (cleanup is best-effort).
 async fn cleanup_index(client: &Client) {
     let resp = client
-        .delete(format!("{DAEMON_URL}/indexes/{INDEX_NAME}"))
+        .delete(format!(
+            "{DAEMON_URL}/indexes/{INDEX_NAME}?delete_data=true"
+        ))
         .send()
         .await;
     match resp {

--- a/crates/trusty-search/tests/benchmark_open_mpm_kg.rs
+++ b/crates/trusty-search/tests/benchmark_open_mpm_kg.rs
@@ -287,7 +287,9 @@ async fn probe_existing_index(client: &Client) -> Option<u64> {
 
 async fn register_index(client: &Client) {
     let _ = client
-        .delete(format!("{DAEMON_URL}/indexes/{INDEX_NAME}"))
+        .delete(format!(
+            "{DAEMON_URL}/indexes/{INDEX_NAME}?delete_data=true"
+        ))
         .send()
         .await;
 

--- a/crates/trusty-search/tests/benchmark_synthetic.rs
+++ b/crates/trusty-search/tests/benchmark_synthetic.rs
@@ -207,7 +207,9 @@ async fn assert_daemon_healthy(client: &Client) {
 async fn register_index(client: &Client) {
     // Delete first if it exists, to start from a clean slate.
     let _ = client
-        .delete(format!("{DAEMON_URL}/indexes/{INDEX_NAME}"))
+        .delete(format!(
+            "{DAEMON_URL}/indexes/{INDEX_NAME}?delete_data=true"
+        ))
         .send()
         .await;
 
@@ -304,7 +306,9 @@ async fn fetch_status(client: &Client) -> Value {
 /// Test: failures are printed, not panicked (cleanup is best-effort).
 async fn cleanup_index(client: &Client) {
     let resp = client
-        .delete(format!("{DAEMON_URL}/indexes/{INDEX_NAME}"))
+        .delete(format!(
+            "{DAEMON_URL}/indexes/{INDEX_NAME}?delete_data=true"
+        ))
         .send()
         .await;
     match resp {

--- a/docs/trusty-search/spec/ARCHITECTURE.md
+++ b/docs/trusty-search/spec/ARCHITECTURE.md
@@ -287,7 +287,7 @@ disabled, 500 internal).
 | Route | Purpose |
 |---|---|
 | `GET /health` | liveness/readiness (`{status, version, indexes, update_available?, embedder_error?}`) |
-| `GET /indexes[?format=tree][?details=true]`, `POST /indexes`, `DELETE /indexes/{id}` | registry management; `?details=true` returns `{id, size_bytes}` objects; `?format=tree` reflects the nested hierarchy (#404) |
+| `GET /indexes[?format=tree][?details=true]`, `POST /indexes`, `DELETE /indexes/{id}[?delete_data=true]` | registry management; `?details=true` returns `{id, size_bytes}` objects; `?format=tree` reflects the nested hierarchy (#404); `DELETE` deregisters only unless `?delete_data=true` (#4123) |
 | `GET /indexes/{id}/status` | chunk count + walk diagnostics (#280) |
 | `POST /indexes/{id}/search` | hybrid search (+ branch boost) |
 | `POST /indexes/{id}/search_similar` | code-to-code similarity (re-embeds seed on LRU miss for skip_kg indexes, #484) |


### PR DESCRIPTION
Fixes two defects in trusty-search's index-lifecycle HTTP handlers. Both were verified against current `main` before editing; no drift was found in the file/line references given in the issues, except that #4110 names `service/server/lifecycle.rs` as the reference implementation — that file does not exist; the real warm-boot classifier is `service/warm_boot/stages.rs::derive_warm_boot_stages`, driven from `commands/start_restore.rs:342`.

---

## ⚠️ BREAKING BEHAVIOUR CHANGE — `DELETE /indexes/:id` (#4123)

**Before:** every `DELETE` destroyed the index's on-disk data directory.
**After:** a bare `DELETE` deregisters ONLY. Destroying data requires `?delete_data=true`.

Any caller that relied on `DELETE` reclaiming disk will silently stop reclaiming it and leave orphaned data behind. Every in-tree caller was audited and is listed below.

`unregister_index` already took a `delete_data: bool` and the orphan-reaper already passed `false` (the `"root_path deleted (data preserved)"` log line). The handler simply hardcoded `true`; it now passes the request's flag.

### The default was already documented as `false` in three places

The destructive behaviour was not just unsafe, it contradicted every user-facing description of this endpoint:

| Artifact | What it already claimed |
|---|---|
| `crates/trusty-search/CLAUDE.md` (API reference) | "On-disk redb data is preserved — re-registering with the same id will reuse it." |
| `trusty-search index remove --help` (`main.rs:1013`) | "The on-disk redb / HNSW snapshot is preserved — re-registering with the same path reuses it." |
| UI delete confirm dialog (`ui/src/lib/views/Indexes.svelte:173`) | ``Delete index "${id}"? On-disk data is preserved.`` |

So `false` does not merely match the issue's stated intent — it restores the contract the product has been advertising all along. The UI has been telling operators their data was safe while the daemon deleted it.

### Every caller of `DELETE /indexes/:id`, and what was done

| # | Caller | Depends on destruction? | Action |
|---|---|---|---|
| 1 | `delete_index` MCP tool (`mcp/tools/index.rs:114`) | **Yes** — descriptor says "Delete a registered index and all its data" | **Updated** → `?delete_data=true` |
| 2 | `trusty-search cleanup` (`commands/cleanup.rs:143`) | **Yes** (reclamation intent) | **Updated** → `?delete_data=true`. Zero risk: every candidate is 0-chunk by construction. |
| 3 | trusty-mpm decommission GC (`session_manager/search_gc.rs:113`) | **Yes** | **Updated** → `?delete_data=true` |
| 4 | trusty-mpm orphan sweep (`session_manager/search_gc.rs:~325`) | **Yes** | **Updated** → `?delete_data=true` |
| 5 | Benchmark harnesses ×5 (`tests/benchmark_synthetic.rs` ×2, `benchmark_open_mpm.rs` ×2, `benchmark_open_mpm_kg.rs` ×1) | **Yes** — docs require "a clean slate" | **Updated** → `?delete_data=true` |
| 6 | `trusty-search index remove` (`commands/index_remove.rs:65`) | **No** — its `--help` promises preservation | **Left on the new default** (now truthful) |
| 7 | UI single-row + bulk delete (`ui/src/lib/api.js:69` → `Indexes.svelte:178`, `:258`) | **No** — dialog promises preservation | **Left on the new default** (now truthful) |
| 8 | Docs: `crates/trusty-search/CLAUDE.md:157`, `docs/trusty-search/spec/ARCHITECTURE.md:290` | — | **Updated** to document the parameter + the change |

For 3 and 4 the workspace being GC'd is a disposable worktree that is about to be deleted, so nothing will ever re-register at that root — preserving its data would leak it permanently.

Also added: the response now carries `data_deleted` so a caller can confirm which semantics ran. An unparseable `?delete_data=maybe` is rejected with `400` rather than silently guessed — a destructive toggle should never be inferred.

---

## Fix: `POST /indexes` ignored the restore outcome (#4110)

`create_index_handler` set `lexical: pending(), semantic: pending()` unconditionally, discarding the result of the colocated restore `build_indexer_from_entry` had just performed. Since `search_capabilities` is derived from `stages`, a fully intact index came up advertising no vector lane: semantic search hard-errored with "requires Stage 2 (embeddings), which is not yet ready" and `search_all` degraded to BM25-only with every hit reporting `match_reason="bm25"` — indistinguishable from a genuinely dead lane. Only a daemon restart cleared it.

Stages are now derived with `derive_warm_boot_stages` — the same pure classifier warm-boot and lazy-restore use, over the same three signals read the same way (`chunk_count`, `hnsw_load_failed` + snapshot presence, symbol-graph node count). Registration and warm-boot can no longer disagree about identical on-disk state, and the `skip_kg` / `skip_vector` / `lexical_only` config gates are preserved because the classifier already honours them.

**One deliberate divergence:** with nothing restored, warm-boot classifies lexical `InProgress`, which `IndexStages::lifecycle_status` maps to `"walking"`. At registration nothing has started yet, so adopting that verbatim would make every brand-new index report `"walking"` before its first walk. Lexical stays `Pending` (`"created"`) when `chunk_count == 0`, exactly as before.

---

## Tests

Four tests, each **verified failing before the fix and passing after** (proven by temporarily restoring the original handlers and re-running):

| Test | Asserts |
|---|---|
| `tests_4123::delete_index_without_param_preserves_data` | bare `DELETE` removes the registration but leaves the data dir byte-identical |
| `tests_4123::delete_index_with_delete_data_true_destroys_data` | `?delete_data=true` still destroys — capability retained and reachable |
| `tests_4110::create_index_successful_restore_reports_semantic_ready` | successful colocated restore **with** HNSW snapshot → semantic `Ready`, `vector` in capabilities |
| `tests_4110::create_index_restore_without_hnsw_snapshot_stays_pending` | restore **without** snapshot → semantic `Pending`, but lexical `Ready` |

No `#[ignore]`, no cfg-gates.

The #4110 pair is a controlled experiment rather than a literal check: both drive the **real** `create_index_handler` through a create → index-content → unregister → re-register cycle so the second registration performs a genuine colocated restore, and they differ in exactly ONE input — whether the HNSW snapshot was persisted. The same handler must map one to `Ready` and the other to `Pending`. The fourth test's `lexical: Ready` assertion is what keeps it non-vacuous: pre-fix, lexical was hardcoded `Pending`, so it fails too, proving the handler genuinely reads the restore rather than emitting a constant that happens to match in one branch.

The #4123 pair drives the real router via `oneshot`, so route wiring and the query extractor are exercised end-to-end, not just the handler signature.

Closes #4123
Closes #4110

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
