### PR TITLE
feat(trusty-agents): L0-only read-only session-state visibility (#4171)

### DIFF
--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/mod.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/mod.rs
@@ -11,6 +11,9 @@
 mod classification;
 mod history;
 mod persona;
+// #4171 (epic #4167): pure gating helpers split out of `persona.rs`, which
+// sits exactly at the 500-SLOC production cap.
+mod persona_gate;
 mod persona_memory;
 
 pub use history::run_pm_task_with_history;

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -16,7 +16,7 @@ use crate::agents::AgentConfig;
 use crate::llm;
 use crate::subprocess::SubprocessAgentRunner;
 use crate::tools::registry::dead_scope;
-use crate::tools::registry::scope::{Scope, ScopePattern, agent_can_use};
+use crate::tools::registry::scope::ScopePattern;
 use crate::tools::{AgentRunner, ToolRegistry, delegate::DelegateToAgentTool};
 
 use super::super::super::claude_cli::run_pm_task_via_claude_cli;
@@ -29,119 +29,11 @@ use super::super::super::handlers::{
     SetActiveProjectTool, StopTaskTool, register_ticketing_tools,
 };
 use super::super::super::state::ConversationTurn;
-use super::super::helpers::match_any_glob;
 use super::classification;
+use super::persona_gate::{
+    filter_persona_tool_names_for_tier, persona_allowed_tools, persona_max_turns,
+};
 use super::persona_memory;
-
-/// Narrow a persona's full candidate tool-name list down to what it may
-/// actually reach on this turn (#3285).
-///
-/// Why: `run_pm_task_with_persona` now registers the FULL delegation/CTRL/
-/// filesystem/search/shell/MCP tool surface into every persona's registry —
-/// tool parity with the session path. Without a second, independent gate a
-/// persona would suddenly gain every tool the PM has, regardless of what its
-/// TOML declares. This function is that gate: it is the single place that
-/// decides which of the registered tools are actually advertised to the LLM,
-/// so it is pulled out as a pure function precisely so the allow/scope
-/// security property can be pinned by fast unit tests instead of only being
-/// exercised end-to-end.
-/// What: Keeps a name only when it matches at least one glob in `patterns`
-/// (a persona's `[tools].allow` list — see `match_any_glob`) AND is present
-/// in `allowed_by_tier` (the RBAC-tier filter derived from
-/// `registry.filter_tools_for_user`) AND, for tools that declare an OpenRPC
-/// scope (#3208; see `tool_scopes`), that scope is covered by at least one
-/// of the persona's own declared `[tools].scopes` patterns
-/// (`agent_scope_patterns`). A tool absent from `tool_scopes` (the trait
-/// default — every in-process tool) is not part of the scoped surface and
-/// passes this third gate unconditionally; a tool that DOES declare a scope
-/// is denied by default when `agent_scope_patterns` is empty (fail closed —
-/// `agent_can_use` denies all on an empty pattern list). Order-preserving;
-/// all three gates must pass independently, mirroring how
-/// `registry`+`allowed_tools` combine in `chat_with_tools_gated`.
-/// Test: `filter_persona_tool_names_respects_allow_globs`,
-/// `filter_persona_tool_names_new_delegation_tools_require_explicit_allow`,
-/// `filter_persona_tool_names_delegation_tools_surface_when_allowed`,
-/// `filter_persona_tool_names_respects_rbac_tier`,
-/// `filter_persona_tool_names_respects_declared_scopes`,
-/// `filter_persona_tool_names_denies_scoped_tool_when_agent_declares_no_scopes`.
-fn filter_persona_tool_names(
-    all_names: Vec<String>,
-    patterns: &[String],
-    allowed_by_tier: &std::collections::HashSet<String>,
-    tool_scopes: &std::collections::HashMap<String, String>,
-    agent_scope_patterns: &[ScopePattern],
-) -> Vec<String> {
-    all_names
-        .into_iter()
-        .filter(|name| {
-            match_any_glob(name, patterns)
-                && allowed_by_tier.contains(name)
-                && match tool_scopes.get(name) {
-                    Some(scope) => agent_can_use(agent_scope_patterns, &Scope::new(scope.clone())),
-                    None => true,
-                }
-        })
-        .collect()
-}
-
-/// Default `max_turns` ceiling for a tool-using persona chat turn when
-/// `[llm].persona_max_turns` is not set in the agent's TOML.
-///
-/// Why: named separately from the literal so the demo-day rationale (raised
-/// from a hardcoded 4 after a persona doing two sequential tool calls plus a
-/// summary exhausted that budget) is documented once, at the definition, not
-/// re-explained at every read site.
-const DEFAULT_PERSONA_TOOL_MAX_TURNS: u32 = 8;
-
-/// Effective `max_turns` ceiling for a persona chat turn.
-///
-/// Why: `run_pm_task_with_persona` is a separate call site from the general
-/// subagent tool loop (`agents::in_process_runner` et al., which already
-/// honor `LlmParams::max_turns`) — it hardcoded its own ceiling (2 turns with
-/// no tools, 4 with tools) since #254 and never consulted config at all. A
-/// persona running a couple of sequential tool calls (e.g. grep twice, then
-/// summarize) routinely exhausted the 4-turn budget and failed with
-/// `chat_with_tools exceeded max_turns`. Pulled into its own function
-/// (mirroring `filter_persona_tool_names` above) so the default-vs-override
-/// behavior is unit-testable without a live LLM call.
-/// What: No tools -> 2 (unchanged current behavior). With tools ->
-/// `llm.persona_max_turns` when set, else [`DEFAULT_PERSONA_TOOL_MAX_TURNS`]
-/// (8, raised from the prior hardcoded 4).
-/// Test: `persona_max_turns_no_tools_is_two`,
-/// `persona_max_turns_with_tools_defaults_to_eight`,
-/// `persona_max_turns_with_tools_honors_config_override`.
-fn persona_max_turns(has_tools: bool, llm: &crate::agents::LlmParams) -> u32 {
-    if !has_tools {
-        return 2;
-    }
-    llm.persona_max_turns
-        .unwrap_or(DEFAULT_PERSONA_TOOL_MAX_TURNS)
-}
-
-/// Compute the `allowed_tools` argument passed to `chat_with_tools_gated` for
-/// a persona whose surface is gated by a declared `[tools].allow` list
-/// (#3208 regression guard).
-///
-/// Why: `ToolRegistry::dispatch_gated`'s allowlist semantics treat `None` as
-/// "no restriction — every registered tool is callable", which is CORRECT
-/// for the coding-agent session path that never sets an allow list. A
-/// persona reaching this helper, however, has ALWAYS opted into restriction
-/// by declaring `[tools].allow` — the caller only reaches this branch in
-/// that case (see the `if let Some(patterns) = persona_cfg.tools.allow`
-/// split in `run_pm_task_with_persona`). If every candidate tool got
-/// filtered away (an allow-glob that matches nothing, or an RBAC tier / scope
-/// check that denies everything), collapsing that to `None` would silently
-/// REOPEN the persona's full registered tool surface — delegate_to_agent,
-/// run_bash, move_file, create_dir, and everything else registered above —
-/// the exact opposite of "deny by default". Always returning `Some(names)`,
-/// even when empty, keeps `dispatch_gated` denying every call in that case
-/// (an empty `Some` list matches nothing).
-/// What: Identity wrapper — deliberately never returns `None`.
-/// Test: `persona_allowed_tools_denies_dispatch_when_empty`,
-/// `persona_allowed_tools_permits_dispatch_when_non_empty`.
-fn persona_allowed_tools(names: Vec<String>) -> Option<Vec<String>> {
-    Some(names)
-}
 
 /// Run a single conversation turn against a persona agent (#254).
 ///
@@ -521,6 +413,25 @@ pub async fn run_pm_task_with_persona(
                 registry.register(tool);
             }
 
+            // #4171 (epic #4167): L0-only read-only session-state tools, kept
+            // in sync with `runtime::tool_registry::build_assistant_tier_registry`
+            // (the #3745-item-C discipline: a capability model that holds on
+            // only one dispatch path is a bug that surfaces as "it works in
+            // chat"). CONDITIONAL, unlike every block above:
+            // `session_state_tools` returns an empty vector for any tier other
+            // than L0, so an L1 persona's registry never contains these
+            // executors and the duplicate-name `debug_assert!` in
+            // `ToolRegistry::register` can never fire against the
+            // trusty-mpm-proxied `session_list`/`session_status` registered
+            // higher up (different names by design — see
+            // `tools::session_state`).
+            for tool in crate::tools::session_state::session_state_tools(
+                project_path,
+                persona_cfg.agent.tier(),
+            ) {
+                registry.register(tool);
+            }
+
             for plugin in crate::tools::agent_plugin::plugins_for_persona(persona_name) {
                 for tool in &plugin.tools {
                     registry.register(std::sync::Arc::clone(tool));
@@ -623,12 +534,27 @@ pub async fn run_pm_task_with_persona(
                     ),
                 ),
             );
-            let kept = filter_persona_tool_names(
+            // #4171 (epic #4167): `_for_tier` is `filter_persona_tool_names`
+            // plus the L0-only read-only session-state strip — a FOURTH,
+            // independent, DENY-ONLY gate keyed on the persona's TIER rather
+            // than on its declared allow/scope posture. It is applied to
+            // `kept` because that is the single value reaching BOTH the
+            // advertised schema list and `ToolRegistry::dispatch_gated` (via
+            // `persona_allowed_tools`). Deliberately NOT given the
+            // `role != "assistant"` escape the delegation gate has above:
+            // every persona reaching this path must declare `tier = "l0"` to
+            // keep a session-state name, and no shipped persona declares one
+            // today (pinned by
+            // `assistant_tier_grants_delegation_and_blackboxes_internal_tools`),
+            // so this strips nothing that currently works. See
+            // `persona_gate::filter_persona_tool_names_for_tier`.
+            let kept = filter_persona_tool_names_for_tier(
                 all_names,
                 &patterns,
                 &allowed_by_tier,
                 &tool_scopes,
                 &agent_scope_patterns,
+                persona_cfg.agent.tier(),
             );
             tracing::info!(
                 persona = %persona_name,

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
@@ -1,0 +1,177 @@
+//! Pure per-turn gating helpers for the persona-chat dispatch path.
+//!
+//! Why: `persona.rs` sits exactly at the 500-SLOC production cap enforced by
+//! `scripts/check_line_cap.sh`, so #4171 could not add its tier gate there
+//! without a split. These four items were the natural extraction: they are
+//! the only PURE functions in that file — no I/O, no LLM, no registry
+//! construction — and they are precisely the ones the unit tests exercise, so
+//! moving them puts the testable logic in one place and leaves `persona.rs`
+//! as the assembly point it is. Moved VERBATIM (same names, same signatures,
+//! same behavior); `persona_tests.rs` reaches them unchanged through its
+//! `use super::*`, because `persona.rs` re-imports them.
+//! What: `filter_persona_tool_names` (allow-glob + RBAC-tier + scope gate),
+//! `filter_persona_tool_names_for_tier` (that gate plus #4171's L0-only
+//! session-state strip), `persona_max_turns`, and `persona_allowed_tools`.
+//! Test: `persona_tests.rs` — `filter_persona_tool_names_*`,
+//! `persona_max_turns_*`, `persona_allowed_tools_*`; #4171's own coverage
+//! lives in `tools::session_state::tests`.
+
+use crate::tools::registry::scope::{Scope, ScopePattern, agent_can_use};
+
+use super::super::helpers::match_any_glob;
+
+/// Narrow a persona's full candidate tool-name list down to what it may
+/// actually reach on this turn (#3285).
+///
+/// Why: `run_pm_task_with_persona` now registers the FULL delegation/CTRL/
+/// filesystem/search/shell/MCP tool surface into every persona's registry —
+/// tool parity with the session path. Without a second, independent gate a
+/// persona would suddenly gain every tool the PM has, regardless of what its
+/// TOML declares. This function is that gate: it is the single place that
+/// decides which of the registered tools are actually advertised to the LLM,
+/// so it is pulled out as a pure function precisely so the allow/scope
+/// security property can be pinned by fast unit tests instead of only being
+/// exercised end-to-end.
+/// What: Keeps a name only when it matches at least one glob in `patterns`
+/// (a persona's `[tools].allow` list — see `match_any_glob`) AND is present
+/// in `allowed_by_tier` (the RBAC-tier filter derived from
+/// `registry.filter_tools_for_user`) AND, for tools that declare an OpenRPC
+/// scope (#3208; see `tool_scopes`), that scope is covered by at least one
+/// of the persona's own declared `[tools].scopes` patterns
+/// (`agent_scope_patterns`). A tool absent from `tool_scopes` (the trait
+/// default — every in-process tool) is not part of the scoped surface and
+/// passes this third gate unconditionally; a tool that DOES declare a scope
+/// is denied by default when `agent_scope_patterns` is empty (fail closed —
+/// `agent_can_use` denies all on an empty pattern list). Order-preserving;
+/// all three gates must pass independently, mirroring how
+/// `registry`+`allowed_tools` combine in `chat_with_tools_gated`.
+/// Test: `filter_persona_tool_names_respects_allow_globs`,
+/// `filter_persona_tool_names_new_delegation_tools_require_explicit_allow`,
+/// `filter_persona_tool_names_delegation_tools_surface_when_allowed`,
+/// `filter_persona_tool_names_respects_rbac_tier`,
+/// `filter_persona_tool_names_respects_declared_scopes`,
+/// `filter_persona_tool_names_denies_scoped_tool_when_agent_declares_no_scopes`.
+pub(super) fn filter_persona_tool_names(
+    all_names: Vec<String>,
+    patterns: &[String],
+    allowed_by_tier: &std::collections::HashSet<String>,
+    tool_scopes: &std::collections::HashMap<String, String>,
+    agent_scope_patterns: &[ScopePattern],
+) -> Vec<String> {
+    all_names
+        .into_iter()
+        .filter(|name| {
+            match_any_glob(name, patterns)
+                && allowed_by_tier.contains(name)
+                && match tool_scopes.get(name) {
+                    Some(scope) => agent_can_use(agent_scope_patterns, &Scope::new(scope.clone())),
+                    None => true,
+                }
+        })
+        .collect()
+}
+
+/// Default `max_turns` ceiling for a tool-using persona chat turn when
+/// `[llm].persona_max_turns` is not set in the agent's TOML.
+///
+/// Why: named separately from the literal so the demo-day rationale (raised
+/// from a hardcoded 4 after a persona doing two sequential tool calls plus a
+/// summary exhausted that budget) is documented once, at the definition, not
+/// re-explained at every read site.
+pub(super) const DEFAULT_PERSONA_TOOL_MAX_TURNS: u32 = 8;
+
+/// Effective `max_turns` ceiling for a persona chat turn.
+///
+/// Why: `run_pm_task_with_persona` is a separate call site from the general
+/// subagent tool loop (`agents::in_process_runner` et al., which already
+/// honor `LlmParams::max_turns`) — it hardcoded its own ceiling (2 turns with
+/// no tools, 4 with tools) since #254 and never consulted config at all. A
+/// persona running a couple of sequential tool calls (e.g. grep twice, then
+/// summarize) routinely exhausted the 4-turn budget and failed with
+/// `chat_with_tools exceeded max_turns`. Pulled into its own function
+/// (mirroring `filter_persona_tool_names` above) so the default-vs-override
+/// behavior is unit-testable without a live LLM call.
+/// What: No tools -> 2 (unchanged current behavior). With tools ->
+/// `llm.persona_max_turns` when set, else [`DEFAULT_PERSONA_TOOL_MAX_TURNS`]
+/// (8, raised from the prior hardcoded 4).
+/// Test: `persona_max_turns_no_tools_is_two`,
+/// `persona_max_turns_with_tools_defaults_to_eight`,
+/// `persona_max_turns_with_tools_honors_config_override`.
+pub(super) fn persona_max_turns(has_tools: bool, llm: &crate::agents::LlmParams) -> u32 {
+    if !has_tools {
+        return 2;
+    }
+    llm.persona_max_turns
+        .unwrap_or(DEFAULT_PERSONA_TOOL_MAX_TURNS)
+}
+
+/// Compute the `allowed_tools` argument passed to `chat_with_tools_gated` for
+/// a persona whose surface is gated by a declared `[tools].allow` list
+/// (#3208 regression guard).
+///
+/// Why: `ToolRegistry::dispatch_gated`'s allowlist semantics treat `None` as
+/// "no restriction — every registered tool is callable", which is CORRECT
+/// for the coding-agent session path that never sets an allow list. A
+/// persona reaching this helper, however, has ALWAYS opted into restriction
+/// by declaring `[tools].allow` — the caller only reaches this branch in
+/// that case (see the `if let Some(patterns) = persona_cfg.tools.allow`
+/// split in `run_pm_task_with_persona`). If every candidate tool got
+/// filtered away (an allow-glob that matches nothing, or an RBAC tier / scope
+/// check that denies everything), collapsing that to `None` would silently
+/// REOPEN the persona's full registered tool surface — delegate_to_agent,
+/// run_bash, move_file, create_dir, and everything else registered above —
+/// the exact opposite of "deny by default". Always returning `Some(names)`,
+/// even when empty, keeps `dispatch_gated` denying every call in that case
+/// (an empty `Some` list matches nothing).
+/// What: Identity wrapper — deliberately never returns `None`.
+/// Test: `persona_allowed_tools_denies_dispatch_when_empty`,
+/// `persona_allowed_tools_permits_dispatch_when_non_empty`.
+pub(super) fn persona_allowed_tools(names: Vec<String>) -> Option<Vec<String>> {
+    Some(names)
+}
+/// `filter_persona_tool_names` plus the L0-only session-state strip (#4171,
+/// epic #4167).
+///
+/// Why: the three gates in `filter_persona_tool_names` all answer "what did
+/// this persona DECLARE?". #4171 needs a fourth that answers a different
+/// question — "what is this persona's TIER allowed to hold at all?" — and it
+/// must be the last word, because the trusty-mpm-proxied `session_list` /
+/// `session_status` / `project_list` / `console_metrics` executors are
+/// registered into EVERY persona's registry (`tools::mcp_service_tools`,
+/// `tools::mcp_live`) and `system_status` natively, so until now the L1
+/// black-box posture held them back only by their ABSENCE from each
+/// persona's `[tools].allow` — a convention any personalization overlay could
+/// union away. Wrapping rather than extending `filter_persona_tool_names`
+/// keeps that function's signature (and its eight existing call sites in
+/// `persona_tests.rs`) untouched while giving the composition one name the
+/// dispatch path calls.
+/// What: applies `filter_persona_tool_names`, then
+/// `tools::session_state::retain_tier_permitted`, which is DENY-ONLY — it can
+/// remove a name, never add one, so an L0 persona still gets exactly what it
+/// declares. Fail-closed on an indeterminate tier: `AgentInfo::tier()`
+/// (#4168/#4200) resolves an absent, blank or unrecognized `tier = …` to
+/// `AgentTier::L1Standard`, which is the stripping arm.
+/// Test: `l1_persona_declaring_session_state_tools_gets_none`,
+/// `l0_persona_declaring_session_state_tools_gets_them`,
+/// `indeterminate_tier_fails_closed_to_no_session_state_tools`,
+/// `persona_tier_gate_strips_session_state_for_l1`,
+/// `persona_tier_gate_keeps_session_state_for_l0`.
+pub(super) fn filter_persona_tool_names_for_tier(
+    all_names: Vec<String>,
+    patterns: &[String],
+    allowed_by_tier: &std::collections::HashSet<String>,
+    tool_scopes: &std::collections::HashMap<String, String>,
+    agent_scope_patterns: &[ScopePattern],
+    tier: crate::agents::AgentTier,
+) -> Vec<String> {
+    crate::tools::session_state::retain_tier_permitted(
+        filter_persona_tool_names(
+            all_names,
+            patterns,
+            allowed_by_tier,
+            tool_scopes,
+            agent_scope_patterns,
+        ),
+        tier,
+    )
+}

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -13,6 +13,13 @@
 //! for which test pins which behavior.
 
 use super::*;
+// #4171: the pure gating helpers moved to `persona_gate` (see that
+// module's doc comment for why); imported directly so these tests keep
+// exercising the same functions, unchanged.
+use super::super::persona_gate::filter_persona_tool_names;
+// `persona.rs` no longer imports `Scope` (its only user moved to
+// `persona_gate`), but these tests still construct one directly.
+use crate::tools::registry::scope::Scope;
 
 /// #3223: `run_pm_task_with_persona` now resolves the agent via
 /// `AgentConfig::by_name_async` instead of a hand-rolled `.toml`-only
@@ -757,4 +764,70 @@ fn shipped_agents_with_live_google_patterns_are_not_flagged() {
             "{name}: the extends union produced duplicate scope patterns: {scopes:?}"
         );
     }
+}
+
+/// #4171 (epic #4167): an L1 persona that DECLARES the session-state tools
+/// still gets none of them out of the persona-chat gate.
+///
+/// Why: `session_list`, `session_status`, `project_list` and
+/// `console_metrics` are registered into every persona's registry by the
+/// trusty-mpm MCP service, and `system_status` natively; before #4171 the L1
+/// black-box posture held them back only by their ABSENCE from each persona's
+/// `[tools].allow`. This test pins the enforcement that replaced that
+/// convention, at the exact function `run_pm_task_with_persona` calls.
+/// What: an allow-list naming every gated tool plus `git_log`, an
+/// unrestricted RBAC tier and no scope requirements — so the first three
+/// gates admit everything — leaves only `git_log` once the tier gate runs at
+/// `AgentTier::L1Standard`.
+/// Test: this function IS the test.
+#[test]
+fn persona_tier_gate_strips_session_state_for_l1() {
+    let all_names: Vec<String> = crate::tools::session_state::L0_ONLY_SESSION_STATE_TOOLS
+        .iter()
+        .map(|s| s.to_string())
+        .chain(std::iter::once("git_log".to_string()))
+        .collect();
+    let patterns = vec!["*".to_string()];
+    let allowed_by_tier: std::collections::HashSet<String> = all_names.iter().cloned().collect();
+
+    let kept = super::super::persona_gate::filter_persona_tool_names_for_tier(
+        all_names,
+        &patterns,
+        &allowed_by_tier,
+        &std::collections::HashMap::new(),
+        &[],
+        crate::agents::AgentTier::L1Standard,
+    );
+
+    assert_eq!(kept, vec!["git_log".to_string()]);
+}
+
+/// #4171 counter-test: the identical declaration on an L0 persona keeps every
+/// session-state tool, so the gate is a tier boundary and not a blanket deny.
+///
+/// Why: a gate that denies everyone is not a grant — issue #4171's acceptance
+/// criterion is that L0 CAN reach session state.
+/// What: same inputs as `persona_tier_gate_strips_session_state_for_l1` with
+/// `AgentTier::L0Orchestration`; nothing is removed.
+/// Test: this function IS the test.
+#[test]
+fn persona_tier_gate_keeps_session_state_for_l0() {
+    let all_names: Vec<String> = crate::tools::session_state::L0_ONLY_SESSION_STATE_TOOLS
+        .iter()
+        .map(|s| s.to_string())
+        .chain(std::iter::once("git_log".to_string()))
+        .collect();
+    let patterns = vec!["*".to_string()];
+    let allowed_by_tier: std::collections::HashSet<String> = all_names.iter().cloned().collect();
+
+    let kept = super::super::persona_gate::filter_persona_tool_names_for_tier(
+        all_names.clone(),
+        &patterns,
+        &allowed_by_tier,
+        &std::collections::HashMap::new(),
+        &[],
+        crate::agents::AgentTier::L0Orchestration,
+    );
+
+    assert_eq!(kept, all_names);
 }

--- a/crates/trusty-agents/src/runtime/subagent_mode.rs
+++ b/crates/trusty-agents/src/runtime/subagent_mode.rs
@@ -465,6 +465,27 @@ pub(super) async fn run_subagent(name: &str) -> Result<()> {
         delegation_taint_allow.as_deref(),
         registry.as_ref(),
     );
+    // #4171 (epic #4167): the L0-only read-only session-state gate. Applied
+    // AFTER `scope_for_delegation` because it must be the last word on this
+    // path's allowlist: `build_assistant_tier_registry` already withholds the
+    // native `session_state_*` executors from a non-L0 agent, but the
+    // live-MCP discovery step above registers whatever the trusty-mpm service
+    // advertises (`session_list`, `session_status`, `project_list`,
+    // `console_metrics`) into the SAME registry, where a persona's own
+    // `[tools].allow` — or a personalization overlay unioned into it — could
+    // otherwise resolve them. Restricted to the assistant tier for the same
+    // reason `delegator_tier` is at the persona-chat site (#4169): a
+    // non-assistant-tier role is outside the persona tier model entirely and
+    // is never gated by the L0/L1 boundary. Deny-only — it can remove names,
+    // never add one — so an L0 agent still gets exactly what it declares.
+    if is_assistant_tier {
+        if let Some(allowed) = cfg.tools.allowed.take() {
+            cfg.tools.allowed = Some(crate::tools::session_state::retain_tier_permitted(
+                allowed,
+                cfg.agent.tier(),
+            ));
+        }
+    }
     if is_assistant_tier || is_tainted_delegation {
         tracing::info!(
             agent = %name,

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -493,7 +493,18 @@ pub(super) fn build_registry_for_agent(
 /// `with_allowed_target_roles` is always called here too — see
 /// `DelegateToAgentTool::delegator_tier`'s doc comment for the
 /// belt-and-suspenders rule), never silently skip it.
-pub(super) fn build_assistant_tier_registry(
+///
+/// `delegator_tier` also selects the READ-ONLY SESSION-STATE surface (#4171,
+/// epic #4167): `crate::tools::session_state::session_state_tools` returns
+/// `session_state_list`/`session_state_status`/`session_state_snapshot` for
+/// an L0 agent and NOTHING for an L1 one, so the L1 black-box posture — which
+/// excludes session-state tools by name — becomes structural on this path
+/// rather than a convention held only by each persona's `[tools].allow`.
+/// Test: `assistant_tier_registry_omits_session_state_tools_for_l1`,
+/// `assistant_tier_registry_includes_session_state_tools_for_l0`,
+/// `l1_persona_declaring_session_state_tools_gets_none`,
+/// `l0_persona_declaring_session_state_tools_gets_them`.
+pub(crate) fn build_assistant_tier_registry(
     delegator_allow: Option<&[String]>,
     delegator_tier: crate::agents::AgentTier,
 ) -> ToolRegistry {
@@ -583,6 +594,22 @@ pub(super) fn build_assistant_tier_registry(
         reg.register(tool);
     }
 
+    // #4171 (epic #4167): L0-only read-only session-state tools. Unlike every
+    // other block in this function, registration here is CONDITIONAL —
+    // `session_state_tools` returns an empty vector for any tier other than
+    // `AgentTier::L0Orchestration`, so an L1 registry never contains these
+    // executors at all and `scope_assistant_allowed_tools` (which intersects a
+    // persona's `[tools].allow` globs against THIS registry's schema names)
+    // cannot resolve them even for a persona that declares them verbatim. The
+    // name-level gate in `crate::tools::session_state::retain_tier_permitted`,
+    // applied by `runtime::subagent_mode` after scoping, is the second,
+    // independent barrier that also covers names arriving from live MCP
+    // discovery. Rooted at CWD, matching the `git_tools` block above — the
+    // project the subprocess dispatch was launched in.
+    for tool in crate::tools::session_state::session_state_tools(&cwd, delegator_tier) {
+        reg.register(tool);
+    }
+
     reg
 }
 
@@ -622,7 +649,7 @@ pub(super) fn build_assistant_tier_registry(
 /// `[tools].allow`) or a registry that failed to build must never silently
 /// grant full access. `scope_for_delegation`'s `!is_tainted` branch is the
 /// caller that exercises this in practice — see its own doc comment.
-pub(super) fn scope_assistant_allowed_tools(
+pub(crate) fn scope_assistant_allowed_tools(
     is_assistant_tier: bool,
     existing_allowed: Option<Vec<String>>,
     allow: Option<&[String]>,

--- a/crates/trusty-agents/src/skills/manifest/builtin/ops.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/ops.rs
@@ -142,6 +142,36 @@ pub(super) static TABLE: &[SkillDef] = &[
         System,
         None,
     ),
+    // --- L0 read-only session state (#4171, epic #4167) ------------------
+    // One skill per tool (owner ruling). These three wrap the L0-ONLY
+    // read-only session-state executors; the tier gate lives in
+    // `tools::session_state`, not here — a skill grant can never widen past
+    // it, because `retain_tier_permitted` runs on the compiled-down tool
+    // names AFTER `[skills].allow` has been expanded.
+    tool_skill(
+        "session-state-list",
+        "List Orchestration Sessions",
+        "List the orchestration sessions recorded on this machine, most recently active first.",
+        "session_state_list",
+        System,
+        None,
+    ),
+    tool_skill(
+        "session-state-status",
+        "Orchestration Session Status",
+        "Report one orchestration session's recorded state, branch, workspace and pending decision.",
+        "session_state_status",
+        System,
+        None,
+    ),
+    tool_skill(
+        "session-state-snapshot",
+        "Read Session Snapshots",
+        "List or read this project's own recorded session artefacts (scrollback, instructions, write-ups).",
+        "session_state_snapshot",
+        System,
+        None,
+    ),
     // --- tmux session control -------------------------------------------
     tool_skill(
         "tmux-session-list",

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -38,6 +38,8 @@ pub mod pm_bridge_backend;
 pub mod python_skill;
 pub mod registry;
 pub mod run_bash;
+// #4171 (epic #4167): L0-only read-only session-state visibility.
+pub mod session_state;
 pub mod shell;
 pub mod shell_exec;
 pub mod skill_loader;

--- a/crates/trusty-agents/src/tools/session_state/list.rs
+++ b/crates/trusty-agents/src/tools/session_state/list.rs
@@ -1,0 +1,235 @@
+//! `session_state_list` — read-only enumeration of managed sessions (#4171).
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+use super::store::{SessionView, default_store_path, load_sessions};
+
+/// Default number of sessions returned when the caller names no `limit`.
+///
+/// Why: the shipped store on a working machine holds hundreds of records
+/// (including long-dead ones); returning all of them would bury the in-flight
+/// work an orchestrator actually asked about and burn the turn's context.
+/// Twenty-five is roughly a screen of the most-recently-active sessions.
+/// What: the `limit` default; `limit` is clamped to [`MAX_LIMIT`].
+/// Test: `list_defaults_to_twenty_five_rows`.
+const DEFAULT_LIMIT: usize = 25;
+
+/// Hard ceiling on `limit`, whatever the caller asks for.
+///
+/// Why: a model that passes `limit = 100000` should get a large answer, not an
+/// unbounded one — this tool's output goes straight into the next LLM request.
+/// What: the clamp applied to any caller-supplied `limit`.
+/// Test: `list_clamps_an_oversized_limit`.
+const MAX_LIMIT: usize = 200;
+
+/// How much of a session's free-text task description is shown per row.
+///
+/// Why: task strings are frequently a full paragraph of pasted instructions;
+/// a one-line-per-session listing has to truncate to stay legible.
+/// What: characters kept before an ellipsis is appended.
+/// Test: `list_truncates_long_task_text`.
+const TASK_PREVIEW_CHARS: usize = 100;
+
+/// `session_state_list` — list managed sessions, read-only.
+///
+/// Why: The first thing PM orchestration needs is "what is in flight?". This
+/// tool answers it from the on-disk session store without a daemon, a
+/// subprocess or a socket, so it works (and is testable) whether or not the
+/// orchestration harness is currently running.
+/// What: renders one line per session — id, tmux name, state, branch,
+/// last activity, truncated task — newest activity first. Optional `state`
+/// and `project` filters and a `limit` narrow the result. L0-ONLY: this
+/// executor is constructed exclusively by
+/// [`super::session_state_tools`] for [`crate::agents::AgentTier::L0Orchestration`],
+/// and its name is additionally stripped for every other tier by
+/// [`super::retain_tier_permitted`].
+/// Test: `list_renders_sessions_newest_first`, `list_filters_by_state`,
+/// `list_filters_by_project_substring`, `list_defaults_to_twenty_five_rows`,
+/// `list_clamps_an_oversized_limit`, `list_truncates_long_task_text`,
+/// `list_reports_empty_store_legibly`.
+pub struct SessionStateListTool {
+    /// Overrides the default store location. `None` in production; set by
+    /// tests so they never read the developer's real store.
+    store_path: Option<std::path::PathBuf>,
+}
+
+impl SessionStateListTool {
+    /// Construct the production tool, reading the canonical store path.
+    pub fn new() -> Self {
+        Self { store_path: None }
+    }
+
+    /// Construct a tool bound to an explicit store file (tests only).
+    ///
+    /// Why: the executors resolve `~/.trusty-mpm/session-manager/sessions.json`
+    /// lazily at `execute` time, which is right for production but untestable
+    /// without mutating process-global `HOME`. An explicit override keeps the
+    /// tests hermetic and parallel-safe.
+    /// What: stores `path` and uses it instead of [`default_store_path`].
+    /// Test: every `list_*` test in `tests.rs` constructs through this.
+    #[cfg(test)]
+    pub fn with_store_path(path: std::path::PathBuf) -> Self {
+        Self {
+            store_path: Some(path),
+        }
+    }
+
+    /// Resolve the store file to read.
+    fn path(&self) -> Option<std::path::PathBuf> {
+        self.store_path.clone().or_else(default_store_path)
+    }
+}
+
+impl Default for SessionStateListTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Render one session as a single legible line.
+///
+/// Why: pulled out of `execute` so the row format is unit-testable without
+/// building a store file, and so `session_state_status`'s multi-line detail
+/// view cannot accidentally diverge from the list's field names.
+/// What: `<id-12>  <tmux_name>  [<state>]  <branch>  <last-activity>  <task>`,
+/// with absent optional fields rendered as `-`.
+/// Test: `list_renders_sessions_newest_first`, `list_truncates_long_task_text`.
+fn render_row(s: &SessionView) -> String {
+    let id_short: String = s.id.chars().take(12).collect();
+    let task = truncate(&s.task, TASK_PREVIEW_CHARS);
+    format!(
+        "{id_short}  {}  [{}]  branch={}  active={}  {}",
+        if s.tmux_name.is_empty() {
+            "-"
+        } else {
+            s.tmux_name.as_str()
+        },
+        if s.state.is_empty() {
+            "unknown"
+        } else {
+            s.state.as_str()
+        },
+        s.branch.as_deref().unwrap_or("-"),
+        s.last_activity_at.as_deref().unwrap_or("-"),
+        if task.is_empty() { "-".into() } else { task },
+    )
+}
+
+/// Cut `text` to `max` characters, appending an ellipsis when cut.
+///
+/// Why: `char`-based (not byte-based) so a multi-byte task description cannot
+/// panic the renderer mid-character.
+/// What: returns `text` unchanged when short enough, else the first `max`
+/// chars plus `…`. Newlines are collapsed so one session stays one line.
+/// Test: `list_truncates_long_task_text`.
+fn truncate(text: &str, max: usize) -> String {
+    let flat = text.replace(['\n', '\r'], " ");
+    if flat.chars().count() <= max {
+        return flat;
+    }
+    let kept: String = flat.chars().take(max).collect();
+    format!("{kept}…")
+}
+
+#[async_trait]
+impl ToolExecutor for SessionStateListTool {
+    fn name(&self) -> &str {
+        "session_state_list"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "session_state_list",
+                "description": "List the orchestration sessions recorded on this machine, most recently active first. Read-only: this reports state and never starts, stops, messages or modifies a session. Use it to answer 'what work is in flight?' before reconciling against git/PR/CI.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "description": "Keep only sessions whose lifecycle state matches this value, case-insensitively (e.g. running, paused, stopped)."
+                        },
+                        "project": {
+                            "type": "string",
+                            "description": "Keep only sessions whose project identity, working directory or workspace path contains this substring."
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "description": "Maximum rows to return. Defaults to 25, capped at 200.",
+                            "minimum": 1
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(path) = self.path() else {
+            return ToolResult::err(
+                "cannot resolve the session store: no home directory".to_string(),
+            );
+        };
+        let sessions = match load_sessions(&path) {
+            Ok(s) => s,
+            Err(e) => return ToolResult::err(e.to_string()),
+        };
+        let state_filter = args
+            .get("state")
+            .and_then(Value::as_str)
+            .map(str::to_ascii_lowercase);
+        let project_filter = args
+            .get("project")
+            .and_then(Value::as_str)
+            .map(str::to_ascii_lowercase);
+        let limit = args
+            .get("limit")
+            .and_then(Value::as_u64)
+            .map(|n| (n as usize).clamp(1, MAX_LIMIT))
+            .unwrap_or(DEFAULT_LIMIT);
+
+        let matched: Vec<&SessionView> = sessions
+            .iter()
+            .filter(|s| match &state_filter {
+                Some(want) => s.state.to_ascii_lowercase() == *want,
+                None => true,
+            })
+            .filter(|s| match &project_filter {
+                Some(want) => {
+                    let haystack = format!(
+                        "{} {} {}",
+                        s.source_id.as_deref().unwrap_or(""),
+                        s.cwd,
+                        s.workspace_path.as_deref().unwrap_or("")
+                    )
+                    .to_ascii_lowercase();
+                    haystack.contains(want)
+                }
+                None => true,
+            })
+            .collect();
+
+        if matched.is_empty() {
+            return ToolResult::ok(
+                "No orchestration sessions matched. (The session store is empty, absent, or every \
+                 record was filtered out.)"
+                    .to_string(),
+            );
+        }
+        let shown = matched.len().min(limit);
+        let mut out = format!(
+            "{} session(s) matched; showing {shown} (most recently active first):\n",
+            matched.len()
+        );
+        for s in matched.iter().take(limit) {
+            out.push_str(&render_row(s));
+            out.push('\n');
+        }
+        ToolResult::ok(out)
+    }
+}

--- a/crates/trusty-agents/src/tools/session_state/mod.rs
+++ b/crates/trusty-agents/src/tools/session_state/mod.rs
@@ -1,0 +1,192 @@
+//! Read-only session-state visibility for the L0 orchestration tier
+//! (#4171, epic #4167).
+//!
+//! Why: L0 ("orchestration assistant") exists to do PM work — reconcile a
+//! paused session against live git/PR/CI state, verify in-flight work, drive
+//! fix rounds. None of that is possible while the agent cannot SEE session
+//! state. L1 ("standard assistant") is the opposite case: its documented
+//! BLACK-BOX POSTURE excludes `session_list`, `session_status`,
+//! `project_list`, `console_metrics` and `system_status` BY NAME (see
+//! `.trusty-agents/agents/assistant/agent.toml`, `cto-assistant/agent.toml`)
+//! precisely so a persona that ingests untrusted Gmail/Drive/web content
+//! never recites internal trusty-* daemon/session mechanics to the user — and
+//! never gains a foothold on the orchestration surface. So the SAME names
+//! this module grants to L0 are the names L1 is deliberately denied, which
+//! makes tier enforcement the entire point of this module, not a detail of it.
+//!
+//! Until now the L1 exclusion was a CONVENTION: the names were simply absent
+//! from each persona's `[tools].allow`. Nothing stopped an L1 persona (or a
+//! personalization overlay unioned into one) from re-adding them, and the
+//! persona-chat dispatch path registers the trusty-mpm-proxied `session_list`
+//! / `session_status` / `project_list` / `console_metrics` executors into
+//! EVERY persona's registry (`tools::mcp_service_tools`), gated only by that
+//! allow-list. [`retain_tier_permitted`] turns the convention into
+//! enforcement: a second, independent, DENY-ONLY gate that strips every
+//! L0-only session-state name unless the agent resolves to
+//! [`AgentTier::L0Orchestration`] through #4200's fail-closed resolver.
+//!
+//! What:
+//! - [`L0_ONLY_SESSION_STATE_TOOLS`] — the gated name set (read-only only).
+//! - [`retain_tier_permitted`] — the deny-only tier gate, applied on BOTH
+//!   assistant dispatch paths (`ctrl::pm_task::dispatch::persona` and
+//!   `runtime::subagent_mode`).
+//! - [`session_state_tools`] — the three NATIVE read-only executors this PR
+//!   adds, returned only for L0 so an L1 registry never contains them at all.
+//!
+//! READ-ONLY BY CONSTRUCTION. Every executor here opens files and returns
+//! text. Nothing in this module writes, spawns a process, or talks to a
+//! daemon, so there is no code path by which it could mutate, message, stop
+//! or decommission a session. `session_send`, `session_stop`,
+//! `session_resume`, `session_new`, `session_prune`, `session_delete`,
+//! `session_decommission*`, `session_proxy_message`/`_focus`/`_unfocus`,
+//! `agent_delegate`, `mcp_enable` and `mcp_disable` are DELIBERATELY absent
+//! from [`L0_ONLY_SESSION_STATE_TOOLS`] — issue #4171's acceptance criterion
+//! is "output is read-only (no state modification)", so this module grants no
+//! mutation and gates none. Adding a mutating tool to that list would be a
+//! separate, separately-reviewed decision.
+//! Test: `tests.rs` — see `l0_only_list_contains_no_mutating_tool`,
+//! `l1_persona_declaring_session_state_tools_gets_none`,
+//! `l0_persona_declaring_session_state_tools_gets_them`,
+//! `indeterminate_tier_fails_closed_to_no_session_state_tools`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::agents::AgentTier;
+use crate::tools::traits::ToolExecutor;
+
+mod list;
+mod snapshot;
+mod status;
+mod store;
+
+pub use list::SessionStateListTool;
+pub use snapshot::SessionStateSnapshotTool;
+pub use status::SessionStateStatusTool;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+/// Every tool name that only an [`AgentTier::L0Orchestration`] agent may
+/// reach (#4171, epic #4167).
+///
+/// Why: One list, consulted by one function ([`retain_tier_permitted`]), so
+/// "what counts as session state" can never drift between the two assistant
+/// dispatch paths that enforce it. The set is the UNION of two groups, and
+/// the distinction matters when reading it:
+///
+/// 1. The three native executors this PR adds (`session_state_*`). These are
+///    registered only for L0 ([`session_state_tools`]), so for L1 the gate is
+///    belt-and-suspenders rather than the only barrier.
+/// 2. Names that ALREADY existed and are ALREADY excluded by name from the
+///    L1 black-box allowlists (`session_list`, `session_status`,
+///    `session_proxy_summary`, `project_list`, `console_metrics`,
+///    `system_status`). For these the gate is the only mechanical barrier —
+///    they are registered into every persona registry by
+///    `tools::mcp_service_tools` (the trusty-mpm static service), by
+///    `tools::mcp_live` (live discovery), or natively
+///    (`tools::system_status`), and were held back purely by each persona's
+///    `[tools].allow` omission.
+///
+/// This list therefore does not WIDEN anything for L1 — no shipped persona
+/// declares any of these names (pinned by
+/// `agents::tests::loading::assistant_tier_grants_delegation_and_blackboxes_internal_tools`)
+/// — it makes the existing omission unbypassable.
+///
+/// What: names only, matched exactly (not as globs). A persona's
+/// `[tools].allow` globs are resolved to concrete names BEFORE this gate
+/// runs, so `session_*` in an L1 allow-list expands to the concrete
+/// `session_list`/`session_status` names and is then stripped here.
+/// Test: `l0_only_list_contains_no_mutating_tool`,
+/// `l0_only_list_covers_every_native_session_state_tool`,
+/// `l0_only_list_covers_the_l1_blackbox_exclusions`.
+pub const L0_ONLY_SESSION_STATE_TOOLS: &[&str] = &[
+    // --- native, added by #4171 (read-only, registered for L0 only) ------
+    "session_state_list",
+    "session_state_status",
+    "session_state_snapshot",
+    // --- pre-existing, excluded by name from the L1 black-box allowlists --
+    "session_list",
+    "session_status",
+    "session_proxy_summary",
+    "project_list",
+    "console_metrics",
+    "system_status",
+];
+
+/// Whether `name` is gated to the L0 orchestration tier.
+///
+/// Why: A named predicate reads better than an inline `.contains()` at the
+/// call sites and gives the tests one thing to pin.
+/// What: exact-name membership in [`L0_ONLY_SESSION_STATE_TOOLS`].
+/// Test: `is_l0_only_matches_exact_names_only`.
+pub fn is_l0_only_session_state_tool(name: &str) -> bool {
+    L0_ONLY_SESSION_STATE_TOOLS.contains(&name)
+}
+
+/// Strip every L0-only session-state name from an already-resolved tool
+/// allowlist unless the agent is L0 (#4171, epic #4167).
+///
+/// Why: THE enforcement point. Both assistant dispatch paths end up holding a
+/// concrete `Vec<String>` of the tool names an agent may actually call —
+/// `ctrl::pm_task::dispatch::persona`'s `filter_persona_tool_names` result
+/// (which feeds both the advertised schema list AND
+/// `ToolRegistry::dispatch_gated`) and `runtime::subagent_mode`'s
+/// `cfg.tools.allowed` (ditto). Applying the tier gate to that final list —
+/// rather than only at registration — is what makes it unbypassable: a name
+/// that reaches the list from ANY source (the static trusty-mpm MCP service,
+/// live MCP discovery, a native registration, a personalization overlay that
+/// unions `session_*` into an L1 persona's `[tools].allow`) is removed.
+/// What: DENY-ONLY and order-preserving. `AgentTier::L0Orchestration` returns
+/// `names` unchanged — this function never ADDS a tool, so an L0 persona
+/// still only gets what its own `[tools].allow` names. Every other tier —
+/// which, per #4200's fail-closed resolver, is where an absent, blank or
+/// unrecognized `tier = …` declaration lands — has every
+/// [`L0_ONLY_SESSION_STATE_TOOLS`] entry removed. Matching on the enum
+/// (rather than a boolean the caller computes) is deliberate: a future third
+/// tier is denied by default until someone edits this match arm.
+/// Test: `l1_persona_declaring_session_state_tools_gets_none`,
+/// `l0_persona_declaring_session_state_tools_gets_them`,
+/// `indeterminate_tier_fails_closed_to_no_session_state_tools`,
+/// `retain_tier_permitted_never_adds_a_tool`,
+/// `retain_tier_permitted_preserves_unrelated_tools_and_order`.
+pub fn retain_tier_permitted(names: Vec<String>, tier: AgentTier) -> Vec<String> {
+    match tier {
+        AgentTier::L0Orchestration => names,
+        AgentTier::L1Standard => names
+            .into_iter()
+            .filter(|n| !is_l0_only_session_state_tool(n))
+            .collect(),
+    }
+}
+
+/// The native read-only session-state executors, for an L0 agent only.
+///
+/// Why: Registration is the FIRST of the two barriers (the second is
+/// [`retain_tier_permitted`]). Returning an empty vector for any non-L0 tier
+/// means an L1 agent's registry never contains these executors at all, so
+/// `runtime::tool_registry::scope_assistant_allowed_tools` — which intersects
+/// a persona's `[tools].allow` globs against the REGISTRY's schema names —
+/// cannot resolve them even if the persona declares them verbatim. Putting
+/// the tier decision inside this constructor (rather than at each call site)
+/// keeps both dispatch paths a one-line, identical, un-forgettable call.
+/// What: for [`AgentTier::L0Orchestration`], one
+/// [`SessionStateListTool`], [`SessionStateStatusTool`] and
+/// [`SessionStateSnapshotTool`], the last one rooted at `project_root` (see
+/// its doc comment for the path-scoping rules). For every other tier, an
+/// empty vector.
+/// Test: `session_state_tools_are_empty_for_l1`,
+/// `session_state_tools_present_for_l0`,
+/// `assistant_tier_registry_omits_session_state_tools_for_l1`,
+/// `assistant_tier_registry_includes_session_state_tools_for_l0`.
+pub fn session_state_tools(project_root: &Path, tier: AgentTier) -> Vec<Arc<dyn ToolExecutor>> {
+    match tier {
+        AgentTier::L1Standard => Vec::new(),
+        AgentTier::L0Orchestration => vec![
+            Arc::new(SessionStateListTool::new()),
+            Arc::new(SessionStateStatusTool::new()),
+            Arc::new(SessionStateSnapshotTool::new(project_root.to_path_buf())),
+        ],
+    }
+}

--- a/crates/trusty-agents/src/tools/session_state/snapshot.rs
+++ b/crates/trusty-agents/src/tools/session_state/snapshot.rs
@@ -1,0 +1,260 @@
+//! `session_state_snapshot` — path-scoped read of a project's `.trusty-mpm/`
+//! session artefacts (#4171, epic #4167).
+//!
+//! Why: the session STORE (see `store.rs`) records what a session is; the
+//! per-project `.trusty-mpm/` directory records what it DID — the pane
+//! scrollback, the last instructions it was handed, the session write-ups
+//! under `.trusty-mpm/sessions/`. That is the "in-flight work tracking" half
+//! of issue #4171, and reconciling a paused session against live git/PR/CI
+//! needs it.
+//!
+//! SECURITY — WHY THIS IS NOT A FILE READER. A session-state tool that took a
+//! model-supplied directory would be an arbitrary-filesystem read wearing a
+//! session-state name: `project_dir = "/Users/x"` plus
+//! `file = "../.ssh/id_ed25519"` and the black-box/L0 distinction stops
+//! mattering. So the root is NOT a parameter. It is fixed at construction
+//! from the dispatch path's own project root, and the ONLY model-supplied
+//! input is a path RELATIVE to `<root>/.trusty-mpm/`, which
+//! [`resolve_within_snapshot_dir`] confines with two independent checks:
+//!
+//! 1. **Syntactic.** Every component of the relative path must be
+//!    `Component::Normal`. An absolute path, a drive prefix, a leading `/`,
+//!    or any `..` anywhere is rejected before touching the filesystem.
+//! 2. **Post-canonicalization containment.** The resolved target and the
+//!    snapshot directory are BOTH canonicalized (which resolves symlinks) and
+//!    the target must still be prefixed by the directory. This is what
+//!    defeats a symlink planted inside `.trusty-mpm/` pointing at
+//!    `~/.aws/credentials` — a check that only inspected the literal path
+//!    would pass it.
+//!
+//! Reads are additionally refused for anything that is not a regular file and
+//! are truncated to a byte ceiling, so a directory or a multi-gigabyte log
+//! cannot be pulled into the turn.
+//! Test: `snapshot_lists_directory_entries`, `snapshot_reads_a_named_file`,
+//! `snapshot_rejects_parent_traversal`, `snapshot_rejects_absolute_path`,
+//! `snapshot_rejects_symlink_escape`, `snapshot_rejects_a_directory_target`,
+//! `snapshot_truncates_a_large_file`,
+//! `snapshot_absent_directory_is_a_recoverable_error`,
+//! `snapshot_takes_no_root_parameter`.
+
+use std::path::{Component, Path, PathBuf};
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+/// Name of the per-project session-artefact directory.
+const SNAPSHOT_DIR: &str = ".trusty-mpm";
+
+/// Bytes returned from a single snapshot file before truncation.
+///
+/// Why: `.trusty-mpm/scrollback.txt` is an unbounded pane dump and the session
+/// write-ups can be long; the result goes straight into the next LLM request,
+/// so the ceiling is a context-budget guard, not a filesystem one.
+/// What: the default `max_bytes`, and its hard cap.
+/// Test: `snapshot_truncates_a_large_file`.
+const DEFAULT_MAX_BYTES: usize = 32 * 1024;
+
+/// `session_state_snapshot` — list or read this project's `.trusty-mpm/`
+/// session artefacts, read-only and path-scoped.
+///
+/// Why / What / security posture: see the module doc comment above — the root
+/// is fixed at construction and the relative path is doubly confined.
+/// L0-ONLY: constructed exclusively by `super::session_state_tools` for
+/// `crate::agents::AgentTier::L0Orchestration`, and its name is stripped for
+/// every other tier by `super::retain_tier_permitted`.
+/// Test: see the module doc comment's Test line.
+pub struct SessionStateSnapshotTool {
+    /// The project root whose `.trusty-mpm/` subtree this tool may read. Set
+    /// once at construction from the dispatch path's project root; never
+    /// influenced by tool arguments.
+    root: PathBuf,
+}
+
+impl SessionStateSnapshotTool {
+    /// Bind the tool to one project root.
+    ///
+    /// Why: the root is a construction-time capability, not a parameter —
+    /// that is the whole path-scoping story (see the module doc comment).
+    /// What: stores `root`; the readable subtree is `root/.trusty-mpm`.
+    /// Test: `snapshot_takes_no_root_parameter`.
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    /// The single directory this tool may read from.
+    fn snapshot_dir(&self) -> PathBuf {
+        self.root.join(SNAPSHOT_DIR)
+    }
+}
+
+/// Confine a model-supplied relative path to `dir`.
+///
+/// Why: THE path-scoping enforcement point for this tool. See the module doc
+/// comment for why both checks are needed and what each one defeats.
+/// What: returns `Err` with a legible reason when `rel` is absolute, carries a
+/// path prefix or root, contains any `..` or `.` component, or when the
+/// canonicalized join escapes the canonicalized `dir` (the symlink case).
+/// Returns the canonicalized target otherwise. `dir` itself must exist and
+/// canonicalize; a missing snapshot directory is reported as such.
+/// Test: `snapshot_rejects_parent_traversal`, `snapshot_rejects_absolute_path`,
+/// `snapshot_rejects_symlink_escape`,
+/// `snapshot_absent_directory_is_a_recoverable_error`,
+/// `resolve_within_snapshot_dir_accepts_a_nested_normal_path`.
+pub(super) fn resolve_within_snapshot_dir(dir: &Path, rel: &str) -> Result<PathBuf, String> {
+    let rel_path = Path::new(rel);
+    for component in rel_path.components() {
+        match component {
+            Component::Normal(_) => {}
+            other => {
+                return Err(format!(
+                    "refused: '{rel}' must be a plain relative path inside {SNAPSHOT_DIR}/ \
+                     (rejected component {other:?})"
+                ));
+            }
+        }
+    }
+    if rel_path.components().next().is_none() {
+        return Err(format!("refused: empty path inside {SNAPSHOT_DIR}/"));
+    }
+    let base = dir.canonicalize().map_err(|e| {
+        format!(
+            "no session snapshots for this project: cannot open {} ({e})",
+            dir.display()
+        )
+    })?;
+    let target = base.join(rel_path).canonicalize().map_err(|e| {
+        format!(
+            "refused: cannot open '{rel}' inside {} ({e})",
+            dir.display()
+        )
+    })?;
+    if !target.starts_with(&base) {
+        return Err(format!(
+            "refused: '{rel}' resolves outside {SNAPSHOT_DIR}/ (symlink escape)"
+        ));
+    }
+    Ok(target)
+}
+
+/// Render the snapshot directory's entries.
+///
+/// Why: the model needs to discover which artefacts exist before naming one,
+/// and a listing is a cheaper first call than a blind read.
+/// What: one `name  <size>  [dir|file]` line per entry, sorted by name,
+/// non-recursive (a nested directory is named, not walked).
+/// Test: `snapshot_lists_directory_entries`.
+fn render_listing(dir: &Path) -> Result<String, String> {
+    let mut rows: Vec<String> = Vec::new();
+    let entries = std::fs::read_dir(dir).map_err(|e| {
+        format!(
+            "no session snapshots for this project: cannot list {} ({e})",
+            dir.display()
+        )
+    })?;
+    for entry in entries.flatten() {
+        let name = entry.file_name().to_string_lossy().to_string();
+        let (kind, size) = match entry.metadata() {
+            Ok(m) if m.is_dir() => ("dir", 0),
+            Ok(m) => ("file", m.len()),
+            Err(_) => ("unknown", 0),
+        };
+        rows.push(format!("{name}  {size} bytes  [{kind}]"));
+    }
+    rows.sort();
+    if rows.is_empty() {
+        return Ok(format!("{} is empty\n", dir.display()));
+    }
+    Ok(format!(
+        "{} entries in {}:\n{}\n",
+        rows.len(),
+        dir.display(),
+        rows.join("\n")
+    ))
+}
+
+#[async_trait]
+impl ToolExecutor for SessionStateSnapshotTool {
+    fn name(&self) -> &str {
+        "session_state_snapshot"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "session_state_snapshot",
+                "description": "List or read this project's own recorded session artefacts (pane scrollback, last instructions, session write-ups). Read-only, and confined to this project's session-artefact directory: there is no parameter for choosing another directory, and a relative path that tries to escape is refused. Call with no arguments to see what is available.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "file": {
+                            "type": "string",
+                            "description": "Relative path of one artefact to read, as shown by a no-argument call (e.g. 'scrollback.txt' or 'sessions/session-20260727-123342.md'). Omit to list the directory."
+                        },
+                        "max_bytes": {
+                            "type": "integer",
+                            "description": "Bytes to return before truncating. Defaults to 32768, which is also the maximum.",
+                            "minimum": 1
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let dir = self.snapshot_dir();
+        let Some(rel) = args
+            .get("file")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            return match render_listing(&dir) {
+                Ok(text) => ToolResult::ok(text),
+                Err(e) => ToolResult::err(e),
+            };
+        };
+        let target = match resolve_within_snapshot_dir(&dir, rel) {
+            Ok(p) => p,
+            Err(e) => return ToolResult::err(e),
+        };
+        match std::fs::metadata(&target) {
+            Ok(m) if !m.is_file() => {
+                return ToolResult::err(format!(
+                    "refused: '{rel}' is not a regular file; call with no arguments to list the \
+                     directory"
+                ));
+            }
+            Err(e) => return ToolResult::err(format!("cannot stat '{rel}': {e}")),
+            Ok(_) => {}
+        }
+        let max_bytes = args
+            .get("max_bytes")
+            .and_then(Value::as_u64)
+            .map(|n| (n as usize).clamp(1, DEFAULT_MAX_BYTES))
+            .unwrap_or(DEFAULT_MAX_BYTES);
+        let bytes = match std::fs::read(&target) {
+            Ok(b) => b,
+            Err(e) => return ToolResult::err(format!("cannot read '{rel}': {e}")),
+        };
+        let total = bytes.len();
+        let truncated = total > max_bytes;
+        let head = if truncated {
+            &bytes[..max_bytes]
+        } else {
+            &bytes[..]
+        };
+        let text = String::from_utf8_lossy(head);
+        let mut out = format!("{rel} ({total} bytes");
+        if truncated {
+            out.push_str(&format!(", showing first {max_bytes}"));
+        }
+        out.push_str("):\n");
+        out.push_str(&text);
+        ToolResult::ok(out)
+    }
+}

--- a/crates/trusty-agents/src/tools/session_state/status.rs
+++ b/crates/trusty-agents/src/tools/session_state/status.rs
@@ -1,0 +1,165 @@
+//! `session_state_status` — read-only detail for one managed session (#4171).
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+use super::store::{SessionView, default_store_path, load_sessions};
+
+/// `session_state_status` — report one session's recorded state, read-only.
+///
+/// Why: after `session_state_list` narrows the field, PM orchestration needs
+/// the full record for ONE session — which branch, which workspace, whether a
+/// decision is pending — to reconcile it against live git/PR/CI. Reading the
+/// store directly (no daemon, no subprocess) keeps this a pure file read and
+/// therefore incapable of mutating anything.
+/// What: resolves `session` by exact id, exact tmux name, or an id prefix of
+/// at least six characters (see [`SessionView::matches`]) and renders the
+/// record as labelled lines. An ambiguous prefix is reported as such rather
+/// than silently resolving to the first hit. L0-ONLY: constructed exclusively
+/// by [`super::session_state_tools`] for
+/// [`crate::agents::AgentTier::L0Orchestration`], and its name is stripped
+/// for every other tier by [`super::retain_tier_permitted`].
+/// Test: `status_renders_full_record`, `status_matches_by_id_tmux_name_and_id_prefix`,
+/// `status_rejects_too_short_a_prefix`, `status_reports_ambiguous_prefix`,
+/// `status_unknown_session_is_a_recoverable_error`,
+/// `status_requires_the_session_argument`.
+pub struct SessionStateStatusTool {
+    /// Overrides the default store location. `None` in production; set by
+    /// tests so they never read the developer's real store.
+    store_path: Option<std::path::PathBuf>,
+}
+
+impl SessionStateStatusTool {
+    /// Construct the production tool, reading the canonical store path.
+    pub fn new() -> Self {
+        Self { store_path: None }
+    }
+
+    /// Construct a tool bound to an explicit store file (tests only).
+    ///
+    /// Why: same hermetic-test rationale as `SessionStateListTool`'s own
+    /// `with_store_path` — see that constructor's doc comment.
+    /// What: stores `path` and uses it instead of [`default_store_path`].
+    /// Test: every `status_*` test in `tests.rs` constructs through this.
+    #[cfg(test)]
+    pub fn with_store_path(path: std::path::PathBuf) -> Self {
+        Self {
+            store_path: Some(path),
+        }
+    }
+
+    /// Resolve the store file to read.
+    fn path(&self) -> Option<std::path::PathBuf> {
+        self.store_path.clone().or_else(default_store_path)
+    }
+}
+
+impl Default for SessionStateStatusTool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Render one session record as labelled lines.
+///
+/// Why: separated from `execute` so the field set is pinned by a test that
+/// needs no store file, and so a field added to [`SessionView`] that nobody
+/// renders is visible as a gap rather than hidden inside a match arm.
+/// What: one `key: value` line per field, absent optionals shown as `-`.
+/// Test: `status_renders_full_record`.
+fn render_detail(s: &SessionView) -> String {
+    let mut out = String::new();
+    let mut line = |k: &str, v: &str| {
+        out.push_str(k);
+        out.push_str(": ");
+        out.push_str(if v.is_empty() { "-" } else { v });
+        out.push('\n');
+    };
+    line("id", &s.id);
+    line("tmux_name", &s.tmux_name);
+    line("state", &s.state);
+    line("branch", s.branch.as_deref().unwrap_or(""));
+    line("cwd", &s.cwd);
+    line("workspace_path", s.workspace_path.as_deref().unwrap_or(""));
+    line("project", s.source_id.as_deref().unwrap_or(""));
+    line("created_at", &s.created_at);
+    line(
+        "last_activity_at",
+        s.last_activity_at.as_deref().unwrap_or(""),
+    );
+    line(
+        "pending_decision",
+        s.pending_decision.as_deref().unwrap_or(""),
+    );
+    line("task", &s.task);
+    out
+}
+
+#[async_trait]
+impl ToolExecutor for SessionStateStatusTool {
+    fn name(&self) -> &str {
+        "session_state_status"
+    }
+
+    fn schema(&self) -> Value {
+        json!({
+            "type": "function",
+            "function": {
+                "name": "session_state_status",
+                "description": "Report the recorded state of ONE orchestration session — lifecycle state, git branch, workspace path, task, and any pending decision. Read-only: it never starts, stops, messages or modifies a session.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "session": {
+                            "type": "string",
+                            "description": "The session id, its tmux name, or an id prefix of at least 6 characters."
+                        }
+                    },
+                    "required": ["session"],
+                    "additionalProperties": false
+                }
+            }
+        })
+    }
+
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(needle) = args
+            .get("session")
+            .and_then(Value::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        else {
+            return ToolResult::err(
+                "session_state_status requires a non-empty `session` argument (an id, a tmux name, \
+                 or an id prefix of at least 6 characters)"
+                    .to_string(),
+            );
+        };
+        let Some(path) = self.path() else {
+            return ToolResult::err(
+                "cannot resolve the session store: no home directory".to_string(),
+            );
+        };
+        let sessions = match load_sessions(&path) {
+            Ok(s) => s,
+            Err(e) => return ToolResult::err(e.to_string()),
+        };
+        let hits: Vec<&SessionView> = sessions.iter().filter(|s| s.matches(needle)).collect();
+        match hits.len() {
+            0 => ToolResult::err(format!(
+                "no orchestration session matches '{needle}'; call session_state_list to see what \
+                 is recorded"
+            )),
+            1 => ToolResult::ok(render_detail(hits[0])),
+            n => {
+                let ids: Vec<&str> = hits.iter().map(|s| s.id.as_str()).collect();
+                ToolResult::err(format!(
+                    "'{needle}' is ambiguous — it matches {n} sessions ({}); pass a longer id",
+                    ids.join(", ")
+                ))
+            }
+        }
+    }
+}

--- a/crates/trusty-agents/src/tools/session_state/store.rs
+++ b/crates/trusty-agents/src/tools/session_state/store.rs
@@ -1,0 +1,180 @@
+//! Read-only reader for the managed-session store (#4171, epic #4167).
+//!
+//! Why: `session_state_list` / `session_state_status` need the same session
+//! facts the orchestration harness persists, but `trusty-agents` deliberately
+//! does NOT depend on the `trusty-mpm` crate — see the rationale on
+//! `mcp::config::tests::render_tests::trusty_mpm_service_tool_names_match_expected_curated_list`,
+//! which declined the dependency because it would pull a full
+//! daemon/tui/telegram/slack graph into every `cargo test -p trusty-agents`.
+//! So this module reads the on-disk JSON directly through its OWN minimal,
+//! maximally-permissive view types. That keeps the read a pure file open (no
+//! daemon, no subprocess, no socket — read-only by construction) and means a
+//! schema addition on the writer's side can never break the reader.
+//! What: [`SessionView`] (the subset of fields these tools surface, every one
+//! `#[serde(default)]` so an older or newer record still deserializes) and
+//! [`load_sessions`], which reads `{"sessions": {"<id>": {…}}}` and returns
+//! the records sorted most-recently-active first. [`default_store_path`]
+//! resolves `~/.trusty-mpm/session-manager/sessions.json`.
+//! Test: `load_sessions_reads_records_and_sorts_by_activity`,
+//! `load_sessions_tolerates_unknown_and_missing_fields`,
+//! `load_sessions_absent_store_is_empty_not_an_error`,
+//! `load_sessions_malformed_json_is_an_error`.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+/// The subset of a managed-session record these read-only tools surface.
+///
+/// Why: Naming only what is displayed keeps the reader decoupled from the
+/// writer's evolving record shape, and keeps the tool output free of fields
+/// (workspace-ownership flags, provisioning internals) that answer no
+/// orchestration question. Every field is `#[serde(default)]` so neither a
+/// field added by a newer writer nor one absent in an older record can turn a
+/// legible session list into a parse error.
+/// What: identity (`id`, `tmux_name`), placement (`cwd`, `workspace_path`,
+/// `branch`, `source_id`), intent (`task`), lifecycle (`state`,
+/// `created_at`, `last_activity_at`) and any surfaced pending decision.
+/// Test: `load_sessions_tolerates_unknown_and_missing_fields`.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(super) struct SessionView {
+    /// Managed session id (stringified UUID).
+    #[serde(default)]
+    pub id: String,
+    /// tmux session name, e.g. `tm-quiet-falcon`.
+    #[serde(default)]
+    pub tmux_name: String,
+    /// Working directory the session was started in.
+    #[serde(default)]
+    pub cwd: String,
+    /// Human-readable task description supplied at creation.
+    #[serde(default)]
+    pub task: String,
+    /// Lifecycle state as persisted (e.g. `running`, `paused`, `stopped`).
+    #[serde(default)]
+    pub state: String,
+    /// RFC3339 creation timestamp.
+    #[serde(default)]
+    pub created_at: String,
+    /// RFC3339 last-activity timestamp, when the writer recorded one.
+    #[serde(default)]
+    pub last_activity_at: Option<String>,
+    /// Isolated workspace path, when the session has one.
+    #[serde(default)]
+    pub workspace_path: Option<String>,
+    /// Git branch / ref the workspace is checked out at.
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// Project identity (e.g. `owner/repo`) when the session carries one.
+    #[serde(default)]
+    pub source_id: Option<String>,
+    /// A decision the harness is waiting on, when one is pending.
+    #[serde(default)]
+    pub pending_decision: Option<String>,
+}
+
+impl SessionView {
+    /// The sort key used to order the session list, newest activity first.
+    ///
+    /// Why: an orchestrator asking "what is in flight?" wants the sessions
+    /// that moved most recently at the top. Falling back to `created_at` (not
+    /// to the empty string) keeps a never-active session ordered by age
+    /// instead of collapsing every one of them into an arbitrary clump.
+    /// What: `last_activity_at` when present, else `created_at`. RFC3339
+    /// timestamps sort correctly as plain strings, so no date parsing (and no
+    /// parse-failure branch) is needed.
+    /// Test: `load_sessions_reads_records_and_sorts_by_activity`.
+    pub fn activity_key(&self) -> &str {
+        self.last_activity_at
+            .as_deref()
+            .unwrap_or(self.created_at.as_str())
+    }
+
+    /// Whether `needle` identifies this session.
+    ///
+    /// Why: `session_state_status` is called by a model that has just read a
+    /// `session_state_list` line, so it may hold either the id or the tmux
+    /// name — and often an abbreviated id. Accepting both, plus an id prefix,
+    /// avoids a pointless "not found" round trip.
+    /// What: case-insensitive equality against `id` or `tmux_name`, or a
+    /// case-insensitive `id` prefix of at least 6 characters (short enough to
+    /// be convenient, long enough that a match is not accidental). The prefix
+    /// slice goes through `str::get` rather than `[..n]` so a store record
+    /// carrying a non-ASCII id can never panic the reader on a char boundary.
+    /// Test: `status_matches_by_id_tmux_name_and_id_prefix`,
+    /// `status_rejects_too_short_a_prefix`.
+    pub fn matches(&self, needle: &str) -> bool {
+        const MIN_PREFIX: usize = 6;
+        if self.id.eq_ignore_ascii_case(needle) || self.tmux_name.eq_ignore_ascii_case(needle) {
+            return true;
+        }
+        needle.len() >= MIN_PREFIX
+            && self
+                .id
+                .get(..needle.len())
+                .is_some_and(|p| p.eq_ignore_ascii_case(needle))
+    }
+}
+
+/// The on-disk envelope: a map from session id to record.
+#[derive(Debug, Default, Deserialize)]
+struct StoredData {
+    /// All managed sessions, keyed by stringified id.
+    #[serde(default)]
+    sessions: std::collections::HashMap<String, SessionView>,
+}
+
+/// Canonical location of the managed-session store.
+///
+/// Why: one definition, so the two tools cannot disagree about where state
+/// lives, and so a test can compare against the same expression production
+/// uses instead of re-deriving it.
+/// What: `~/.trusty-mpm/session-manager/sessions.json`, or `None` when the
+/// platform reports no home directory.
+/// Test: `default_store_path_is_under_home`.
+pub(super) fn default_store_path() -> Option<PathBuf> {
+    Some(
+        dirs::home_dir()?
+            .join(".trusty-mpm")
+            .join("session-manager")
+            .join("sessions.json"),
+    )
+}
+
+/// Read every managed-session record from `path`, most-recently-active first.
+///
+/// Why: The tools need one read helper with one error policy so their output
+/// is predictable. The policy distinguishes the two failure modes that mean
+/// different things to a caller: a store that does not exist yet (no
+/// orchestration harness has ever run here — legitimately "no sessions", not
+/// a fault) versus a store that exists but cannot be parsed (real corruption,
+/// which must be reported rather than silently rendered as an empty list).
+/// What: an absent file yields `Ok(vec![])`. A present file yields its
+/// records sorted by [`SessionView::activity_key`] descending, with the map
+/// key used as `id` whenever the record's own `id` field is empty (older
+/// writers keyed the map without repeating the id inside). An unreadable or
+/// unparseable file yields `Err`.
+/// Test: `load_sessions_reads_records_and_sorts_by_activity`,
+/// `load_sessions_absent_store_is_empty_not_an_error`,
+/// `load_sessions_malformed_json_is_an_error`.
+pub(super) fn load_sessions(path: &Path) -> anyhow::Result<Vec<SessionView>> {
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let raw = std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("cannot read session store {}: {e}", path.display()))?;
+    let data: StoredData = serde_json::from_str(&raw)
+        .map_err(|e| anyhow::anyhow!("session store {} is not valid JSON: {e}", path.display()))?;
+    let mut out: Vec<SessionView> = data
+        .sessions
+        .into_iter()
+        .map(|(key, mut view)| {
+            if view.id.is_empty() {
+                view.id = key;
+            }
+            view
+        })
+        .collect();
+    out.sort_by(|a, b| b.activity_key().cmp(a.activity_key()));
+    Ok(out)
+}

--- a/crates/trusty-agents/src/tools/session_state/tests.rs
+++ b/crates/trusty-agents/src/tools/session_state/tests.rs
@@ -1,0 +1,783 @@
+//! Tests for the L0-only read-only session-state surface (#4171, epic #4167).
+//!
+//! Why: this module grants EXACTLY the tools the L1 black-box posture excludes
+//! by name, so tier enforcement is the property under test, not a side
+//! concern. The security tests therefore go through the REAL registry
+//! construction (`runtime::tool_registry::build_assistant_tier_registry`) and
+//! the REAL scoping gates (`scope_assistant_allowed_tools` on the subprocess
+//! path, `filter_persona_tool_names` + `retain_tier_permitted` on the
+//! persona-chat path) rather than hand-built argument lists, so a regression
+//! in the wiring — not just in the predicate — fails here.
+//! What: gate-list well-formedness, the deny-only tier gate, real-path L0/L1
+//! registry construction, the store reader, and the `.trusty-mpm/`
+//! path-scoping refusals.
+//! Test: this file.
+
+use std::path::PathBuf;
+
+use serde_json::json;
+
+use super::*;
+use crate::tools::traits::ToolExecutor;
+
+// --------------------------------------------------------------------------
+// Gate-list well-formedness
+// --------------------------------------------------------------------------
+
+/// Every tool name in this crate that can mutate or terminate a session.
+///
+/// Why: issue #4171's acceptance criterion is "output is read-only (no state
+/// modification)". Naming the mutating surface explicitly turns that sentence
+/// into a gate: if a later change adds one of these to the L0 grant list,
+/// `l0_only_list_contains_no_mutating_tool` fails and the decision has to be
+/// made deliberately rather than by autocompletion.
+/// What: the trusty-mpm session/agent verbs that write, plus the MCP admin
+/// verbs that reconfigure the service surface.
+const MUTATING_TOOL_NAMES: &[&str] = &[
+    "session_send",
+    "session_stop",
+    "session_new",
+    "session_resume",
+    "session_prune",
+    "session_delete",
+    "session_decommission",
+    "session_decommission_ephemeral",
+    "session_proxy_message",
+    "session_proxy_focus",
+    "session_proxy_unfocus",
+    "agent_delegate",
+    "mcp_enable",
+    "mcp_disable",
+];
+
+#[test]
+fn l0_only_list_contains_no_mutating_tool() {
+    for name in MUTATING_TOOL_NAMES {
+        assert!(
+            !is_l0_only_session_state_tool(name),
+            "{name} mutates session state and must not be part of the read-only L0 grant (#4171)"
+        );
+    }
+}
+
+#[test]
+fn l0_only_list_covers_every_native_session_state_tool() {
+    for tool in session_state_tools(&PathBuf::from("/tmp"), AgentTier::L0Orchestration) {
+        assert!(
+            is_l0_only_session_state_tool(tool.name()),
+            "native tool {} is registered for L0 but is not in the tier gate list",
+            tool.name()
+        );
+    }
+}
+
+/// The names the L1 BLACK-BOX POSTURE comment excludes must all be gated.
+///
+/// Why: those names are the reason this module exists. If one is dropped from
+/// `L0_ONLY_SESSION_STATE_TOOLS`, an L1 persona could reach it again through
+/// the trusty-mpm MCP proxy simply by declaring it — the exact black-box
+/// violation the exclusions were written to prevent.
+/// What: asserts membership for every session-state name named in
+/// `.trusty-agents/agents/assistant/agent.toml` and `cto-assistant/agent.toml`.
+/// Test: this function IS the test.
+#[test]
+fn l0_only_list_covers_the_l1_blackbox_exclusions() {
+    for name in [
+        "session_list",
+        "session_status",
+        "project_list",
+        "console_metrics",
+        "system_status",
+    ] {
+        assert!(
+            is_l0_only_session_state_tool(name),
+            "{name} is excluded by name from the L1 allowlists and must stay tier-gated"
+        );
+    }
+}
+
+#[test]
+fn is_l0_only_matches_exact_names_only() {
+    assert!(is_l0_only_session_state_tool("session_list"));
+    assert!(!is_l0_only_session_state_tool("session_lis"));
+    assert!(!is_l0_only_session_state_tool("session_list_extra"));
+    assert!(!is_l0_only_session_state_tool("SESSION_LIST"));
+}
+
+// --------------------------------------------------------------------------
+// The deny-only tier gate
+// --------------------------------------------------------------------------
+
+fn names(v: &[&str]) -> Vec<String> {
+    v.iter().map(|s| s.to_string()).collect()
+}
+
+/// A minimal persona TOML carrying `tier_line` verbatim.
+///
+/// Why: the fail-closed test must go through the REAL resolver
+/// (`AgentInfo::tier`, #4200/#4168) reached the way production reaches it —
+/// by parsing a persona TOML — not through a hand-constructed enum value that
+/// would pass even if the resolver regressed.
+/// What: the same shape `agents::tests::agent_toml_with_tier` uses.
+/// Test: `indeterminate_tier_fails_closed_to_no_session_state_tools`,
+/// `declared_l0_tier_keeps_session_state_tools`.
+fn persona_toml(tier_line: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "x"
+role = "assistant"
+model = "x"
+description = "x"
+{tier_line}
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#
+    )
+}
+
+#[test]
+fn indeterminate_tier_fails_closed_to_no_session_state_tools() {
+    // An absent / blank / unrecognized `tier = …` resolves to L1Standard via
+    // #4200's fail-closed resolver; that is the value the gate must strip on.
+    for tier_line in [
+        "",
+        r#"tier = """#,
+        r#"tier = "   ""#,
+        r#"tier = "L2""#,
+        r#"tier = "yolo""#,
+    ] {
+        let cfg: crate::agents::AgentConfig =
+            toml::from_str(&persona_toml(tier_line)).expect("parses");
+        assert_eq!(
+            cfg.agent.tier(),
+            AgentTier::L1Standard,
+            "{tier_line:?} must resolve fail-closed"
+        );
+        let kept = retain_tier_permitted(names(&["session_list", "git_log"]), cfg.agent.tier());
+        assert_eq!(
+            kept,
+            names(&["git_log"]),
+            "{tier_line:?} must strip the session-state name"
+        );
+        assert!(
+            session_state_tools(&PathBuf::from("/tmp"), cfg.agent.tier()).is_empty(),
+            "{tier_line:?} must register no session-state executor"
+        );
+    }
+}
+
+#[test]
+fn declared_l0_tier_keeps_session_state_tools() {
+    for tier_line in [r#"tier = "l0""#, r#"tier = "Orchestration""#] {
+        let cfg: crate::agents::AgentConfig =
+            toml::from_str(&persona_toml(tier_line)).expect("parses");
+        assert_eq!(cfg.agent.tier(), AgentTier::L0Orchestration);
+        let kept = retain_tier_permitted(names(&["session_list", "git_log"]), cfg.agent.tier());
+        assert_eq!(kept, names(&["session_list", "git_log"]));
+    }
+}
+
+#[test]
+fn retain_tier_permitted_never_adds_a_tool() {
+    let kept = retain_tier_permitted(names(&["git_log"]), AgentTier::L0Orchestration);
+    assert_eq!(kept, names(&["git_log"]));
+}
+
+#[test]
+fn retain_tier_permitted_preserves_unrelated_tools_and_order() {
+    let input = names(&[
+        "a_tool",
+        "session_status",
+        "b_tool",
+        "system_status",
+        "c_tool",
+    ]);
+    let kept = retain_tier_permitted(input, AgentTier::L1Standard);
+    assert_eq!(kept, names(&["a_tool", "b_tool", "c_tool"]));
+}
+
+#[test]
+fn session_state_tools_are_empty_for_l1() {
+    assert!(
+        session_state_tools(&PathBuf::from("/tmp"), AgentTier::L1Standard).is_empty(),
+        "an L1 registry must never contain a session-state executor"
+    );
+}
+
+#[test]
+fn session_state_tools_present_for_l0() {
+    let got: Vec<String> = session_state_tools(&PathBuf::from("/tmp"), AgentTier::L0Orchestration)
+        .iter()
+        .map(|t| t.name().to_string())
+        .collect();
+    assert_eq!(
+        got,
+        names(&[
+            "session_state_list",
+            "session_state_status",
+            "session_state_snapshot"
+        ])
+    );
+}
+
+// --------------------------------------------------------------------------
+// The REAL registry-construction path (subprocess / `--direct` dispatch)
+// --------------------------------------------------------------------------
+
+/// Tool names the real assistant-tier registry builds for a given tier.
+///
+/// Why: the security claim is about the production assembly point, not about a
+/// helper, so these tests call `build_assistant_tier_registry` — the function
+/// `runtime::subagent_mode` itself calls — and read the names back off the
+/// schemas it emits.
+/// What: constructs the registry and returns its tool names.
+/// Test: used by `assistant_tier_registry_*` and `l*_persona_declaring_*`.
+fn registry_names(tier: AgentTier) -> Vec<String> {
+    crate::runtime::tool_registry::build_assistant_tier_registry(None, tier)
+        .schemas()
+        .into_iter()
+        .filter_map(|s| {
+            s.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .map(String::from)
+        })
+        .collect()
+}
+
+#[test]
+fn assistant_tier_registry_omits_session_state_tools_for_l1() {
+    let got = registry_names(AgentTier::L1Standard);
+    for name in [
+        "session_state_list",
+        "session_state_status",
+        "session_state_snapshot",
+    ] {
+        assert!(
+            !got.contains(&name.to_string()),
+            "L1 assistant-tier registry must not register {name}"
+        );
+    }
+}
+
+#[test]
+fn assistant_tier_registry_includes_session_state_tools_for_l0() {
+    let got = registry_names(AgentTier::L0Orchestration);
+    for name in [
+        "session_state_list",
+        "session_state_status",
+        "session_state_snapshot",
+    ] {
+        assert!(
+            got.contains(&name.to_string()),
+            "L0 assistant-tier registry must register {name}"
+        );
+    }
+}
+
+/// An L1 persona that DECLARES the session-state tools still gets none.
+///
+/// Why: this is hard requirement 1 of #4171 and the whole point of the tier
+/// gate — a persona's `[tools].allow` must not be able to buy back what the
+/// black-box posture excludes.
+/// What: runs the real `build_assistant_tier_registry` +
+/// `scope_assistant_allowed_tools` composition — exactly what
+/// `runtime::subagent_mode` runs — with an allow-list that names every gated
+/// tool plus a `session_*` wildcard, then applies the tier gate as the
+/// dispatch path does, and asserts nothing survives.
+/// Test: this function IS the test.
+#[test]
+fn l1_persona_declaring_session_state_tools_gets_none() {
+    let allow = names(&[
+        "session_*",
+        "session_state_list",
+        "session_state_status",
+        "session_state_snapshot",
+        "session_list",
+        "session_status",
+        "project_list",
+        "console_metrics",
+        "system_status",
+        "git_log",
+    ]);
+    let reg = crate::runtime::tool_registry::build_assistant_tier_registry(
+        Some(&allow),
+        AgentTier::L1Standard,
+    );
+    let scoped = crate::runtime::tool_registry::scope_assistant_allowed_tools(
+        true,
+        None,
+        Some(&allow),
+        Some(&reg),
+    )
+    .expect("assistant tier always resolves to Some");
+    let gated = retain_tier_permitted(scoped, AgentTier::L1Standard);
+    for name in L0_ONLY_SESSION_STATE_TOOLS {
+        assert!(
+            !gated.contains(&name.to_string()),
+            "an L1 persona declaring {name} must not receive it"
+        );
+    }
+}
+
+/// The same declaration on an L0 persona DOES yield the session-state tools.
+///
+/// Why: a gate that denies everyone is not a grant. This is the counter-test
+/// that proves the L0 path actually works through the same production
+/// composition.
+/// What: identical to `l1_persona_declaring_session_state_tools_gets_none`
+/// except for the tier, asserting the three native tools survive.
+/// Test: this function IS the test.
+#[test]
+fn l0_persona_declaring_session_state_tools_gets_them() {
+    let allow = names(&[
+        "session_state_list",
+        "session_state_status",
+        "session_state_snapshot",
+    ]);
+    let reg = crate::runtime::tool_registry::build_assistant_tier_registry(
+        Some(&allow),
+        AgentTier::L0Orchestration,
+    );
+    let scoped = crate::runtime::tool_registry::scope_assistant_allowed_tools(
+        true,
+        None,
+        Some(&allow),
+        Some(&reg),
+    )
+    .expect("assistant tier always resolves to Some");
+    let mut gated = retain_tier_permitted(scoped, AgentTier::L0Orchestration);
+    gated.sort();
+    assert_eq!(
+        gated,
+        names(&[
+            "session_state_list",
+            "session_state_snapshot",
+            "session_state_status"
+        ])
+    );
+}
+
+// --------------------------------------------------------------------------
+// Store reader
+// --------------------------------------------------------------------------
+
+fn write_store(dir: &std::path::Path, body: &str) -> PathBuf {
+    let path = dir.join("sessions.json");
+    std::fs::write(&path, body).unwrap();
+    path
+}
+
+const TWO_SESSIONS: &str = r#"{
+  "sessions": {
+    "aaaaaaaa-1111-2222-3333-444444444444": {
+      "id": "aaaaaaaa-1111-2222-3333-444444444444",
+      "tmux_name": "tm-older",
+      "cwd": "/work/alpha",
+      "task": "older task",
+      "state": "paused",
+      "created_at": "2026-07-01T00:00:00Z",
+      "last_activity_at": "2026-07-02T00:00:00Z",
+      "branch": "feat/alpha",
+      "source_id": "acme/alpha"
+    },
+    "bbbbbbbb-5555-6666-7777-888888888888": {
+      "id": "bbbbbbbb-5555-6666-7777-888888888888",
+      "tmux_name": "tm-newer",
+      "cwd": "/work/beta",
+      "task": "newer task",
+      "state": "running",
+      "created_at": "2026-07-03T00:00:00Z",
+      "last_activity_at": "2026-07-09T00:00:00Z",
+      "branch": "feat/beta",
+      "source_id": "acme/beta"
+    }
+  }
+}"#;
+
+#[test]
+fn load_sessions_reads_records_and_sorts_by_activity() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let got = super::store::load_sessions(&path).unwrap();
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].tmux_name, "tm-newer", "newest activity first");
+    assert_eq!(got[1].tmux_name, "tm-older");
+}
+
+#[test]
+fn load_sessions_tolerates_unknown_and_missing_fields() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(
+        tmp.path(),
+        r#"{"sessions":{"only-a-key":{"a_field_from_the_future":42}}}"#,
+    );
+    let got = super::store::load_sessions(&path).unwrap();
+    assert_eq!(got.len(), 1);
+    assert_eq!(got[0].id, "only-a-key", "map key backfills an empty id");
+    assert_eq!(got[0].state, "");
+}
+
+#[test]
+fn load_sessions_absent_store_is_empty_not_an_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let got = super::store::load_sessions(&tmp.path().join("nope.json")).unwrap();
+    assert!(got.is_empty());
+}
+
+#[test]
+fn load_sessions_malformed_json_is_an_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), "{ not json");
+    assert!(super::store::load_sessions(&path).is_err());
+}
+
+#[test]
+fn default_store_path_is_under_home() {
+    let Some(p) = super::store::default_store_path() else {
+        return; // no home dir on this platform; nothing to assert
+    };
+    assert!(p.ends_with("sessions.json"));
+    assert!(p.to_string_lossy().contains(".trusty-mpm"));
+}
+
+// --------------------------------------------------------------------------
+// session_state_list / session_state_status behaviour
+// --------------------------------------------------------------------------
+
+fn list_tool(path: PathBuf) -> SessionStateListTool {
+    SessionStateListTool::with_store_path(path)
+}
+
+fn status_tool(path: PathBuf) -> SessionStateStatusTool {
+    SessionStateStatusTool::with_store_path(path)
+}
+
+#[tokio::test]
+async fn list_renders_sessions_newest_first() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let r = list_tool(path).execute(json!({})).await;
+    assert!(!r.is_error(), "{}", r.content());
+    let body = r.content().to_string();
+    let newer = body.find("tm-newer").expect("newer row present");
+    let older = body.find("tm-older").expect("older row present");
+    assert!(newer < older, "most recently active session first:\n{body}");
+    assert!(body.contains("branch=feat/beta"));
+}
+
+#[tokio::test]
+async fn list_filters_by_state() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let r = list_tool(path).execute(json!({"state": "RUNNING"})).await;
+    let body = r.content().to_string();
+    assert!(body.contains("tm-newer"));
+    assert!(!body.contains("tm-older"));
+}
+
+#[tokio::test]
+async fn list_filters_by_project_substring() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let r = list_tool(path).execute(json!({"project": "alpha"})).await;
+    let body = r.content().to_string();
+    assert!(body.contains("tm-older"));
+    assert!(!body.contains("tm-newer"));
+}
+
+/// Build a store with `n` sessions so the row-count defaults can be pinned.
+fn many_sessions(n: usize, task: &str) -> String {
+    let rows: Vec<String> = (0..n)
+        .map(|i| {
+            format!(
+                r#""id-{i:04}": {{"id":"id-{i:04}","tmux_name":"tm-{i:04}","task":"{task}","state":"running","created_at":"2026-07-{:02}T00:00:00Z"}}"#,
+                (i % 28) + 1
+            )
+        })
+        .collect();
+    format!("{{\"sessions\":{{{}}}}}", rows.join(","))
+}
+
+#[tokio::test]
+async fn list_defaults_to_twenty_five_rows() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), &many_sessions(40, "t"));
+    let r = list_tool(path).execute(json!({})).await;
+    let rows = r.content().lines().filter(|l| l.contains("tm-")).count();
+    assert_eq!(rows, 25);
+}
+
+#[tokio::test]
+async fn list_clamps_an_oversized_limit() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), &many_sessions(250, "t"));
+    let r = list_tool(path).execute(json!({"limit": 100000})).await;
+    let rows = r.content().lines().filter(|l| l.contains("tm-")).count();
+    assert_eq!(rows, 200, "limit is capped at MAX_LIMIT");
+}
+
+#[tokio::test]
+async fn list_truncates_long_task_text() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let long = "x".repeat(400);
+    let path = write_store(tmp.path(), &many_sessions(1, &long));
+    let r = list_tool(path).execute(json!({})).await;
+    let body = r.content().to_string();
+    assert!(body.contains('…'), "long task text must be elided:\n{body}");
+    assert!(!body.contains(&"x".repeat(200)));
+}
+
+#[tokio::test]
+async fn list_reports_empty_store_legibly() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let r = list_tool(tmp.path().join("absent.json"))
+        .execute(json!({}))
+        .await;
+    assert!(!r.is_error());
+    assert!(r.content().contains("No orchestration sessions matched"));
+}
+
+#[tokio::test]
+async fn status_renders_full_record() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let r = status_tool(path)
+        .execute(json!({"session": "tm-newer"}))
+        .await;
+    assert!(!r.is_error(), "{}", r.content());
+    let body = r.content().to_string();
+    for key in [
+        "id:",
+        "tmux_name:",
+        "state:",
+        "branch:",
+        "cwd:",
+        "workspace_path:",
+        "project:",
+        "created_at:",
+        "last_activity_at:",
+        "pending_decision:",
+        "task:",
+    ] {
+        assert!(body.contains(key), "missing field {key} in:\n{body}");
+    }
+}
+
+#[tokio::test]
+async fn status_matches_by_id_tmux_name_and_id_prefix() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    for needle in ["bbbbbbbb-5555-6666-7777-888888888888", "tm-newer", "BBBBBB"] {
+        let r = status_tool(path.clone())
+            .execute(json!({ "session": needle }))
+            .await;
+        assert!(!r.is_error(), "{needle}: {}", r.content());
+        assert!(r.content().contains("tm-newer"), "{needle}");
+    }
+}
+
+#[tokio::test]
+async fn status_rejects_too_short_a_prefix() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let r = status_tool(path).execute(json!({"session": "bbb"})).await;
+    assert!(r.is_error(), "a 3-char prefix must not resolve");
+}
+
+#[tokio::test]
+async fn status_reports_ambiguous_prefix() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(
+        tmp.path(),
+        r#"{"sessions":{
+            "prefix-one":{"id":"prefix-one","tmux_name":"a","created_at":"2026-07-01T00:00:00Z"},
+            "prefix-two":{"id":"prefix-two","tmux_name":"b","created_at":"2026-07-01T00:00:00Z"}
+        }}"#,
+    );
+    let r = status_tool(path)
+        .execute(json!({"session": "prefix"}))
+        .await;
+    assert!(r.is_error());
+    assert!(r.content().contains("ambiguous"), "{}", r.content());
+}
+
+#[tokio::test]
+async fn status_unknown_session_is_a_recoverable_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let r = status_tool(path)
+        .execute(json!({"session": "nothing-here"}))
+        .await;
+    assert!(r.is_error());
+    assert!(r.content().contains("no orchestration session matches"));
+}
+
+#[tokio::test]
+async fn status_requires_the_session_argument() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let path = write_store(tmp.path(), TWO_SESSIONS);
+    let r = status_tool(path).execute(json!({})).await;
+    assert!(r.is_error());
+    assert!(r.content().contains("session"));
+}
+
+// --------------------------------------------------------------------------
+// session_state_snapshot — path scoping
+// --------------------------------------------------------------------------
+
+/// A project root with a populated `.trusty-mpm/` and a secret OUTSIDE it.
+///
+/// Why: the escape tests need a real file the tool must never return, placed
+/// as a sibling of the snapshot directory so `..` traversal and a symlink both
+/// have somewhere plausible to aim.
+/// What: returns the tempdir plus the project root inside it.
+/// Test: used by every `snapshot_*` test.
+fn snapshot_fixture() -> (tempfile::TempDir, PathBuf) {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let root = tmp.path().join("project");
+    let snap = root.join(".trusty-mpm");
+    std::fs::create_dir_all(snap.join("sessions")).unwrap();
+    std::fs::write(snap.join("scrollback.txt"), "pane dump\n").unwrap();
+    std::fs::write(snap.join("sessions").join("session-1.md"), "# write-up\n").unwrap();
+    std::fs::write(root.join("SECRET.txt"), "do not leak\n").unwrap();
+    (tmp, root)
+}
+
+#[tokio::test]
+async fn snapshot_lists_directory_entries() {
+    let (_tmp, root) = snapshot_fixture();
+    let r = SessionStateSnapshotTool::new(root).execute(json!({})).await;
+    assert!(!r.is_error(), "{}", r.content());
+    let body = r.content().to_string();
+    assert!(body.contains("scrollback.txt"));
+    assert!(body.contains("sessions"));
+    assert!(
+        !body.contains("SECRET.txt"),
+        "listing must not leave the dir"
+    );
+}
+
+#[tokio::test]
+async fn snapshot_reads_a_named_file() {
+    let (_tmp, root) = snapshot_fixture();
+    let r = SessionStateSnapshotTool::new(root)
+        .execute(json!({"file": "sessions/session-1.md"}))
+        .await;
+    assert!(!r.is_error(), "{}", r.content());
+    assert!(r.content().contains("# write-up"));
+}
+
+#[tokio::test]
+async fn snapshot_rejects_parent_traversal() {
+    let (_tmp, root) = snapshot_fixture();
+    let tool = SessionStateSnapshotTool::new(root);
+    for attempt in ["../SECRET.txt", "sessions/../../SECRET.txt", "..", "./x"] {
+        let r = tool.execute(json!({ "file": attempt })).await;
+        assert!(r.is_error(), "{attempt} must be refused");
+        assert!(
+            !r.content().contains("do not leak"),
+            "{attempt} leaked content"
+        );
+    }
+}
+
+#[tokio::test]
+async fn snapshot_rejects_absolute_path() {
+    let (tmp, root) = snapshot_fixture();
+    let absolute = tmp.path().join("project").join("SECRET.txt");
+    let r = SessionStateSnapshotTool::new(root)
+        .execute(json!({ "file": absolute.to_string_lossy() }))
+        .await;
+    assert!(r.is_error());
+    assert!(!r.content().contains("do not leak"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn snapshot_rejects_symlink_escape() {
+    let (_tmp, root) = snapshot_fixture();
+    let link = root.join(".trusty-mpm").join("escape.txt");
+    std::os::unix::fs::symlink(root.join("SECRET.txt"), &link).unwrap();
+    // The literal path is syntactically clean — only post-canonicalization
+    // containment catches this one.
+    let r = SessionStateSnapshotTool::new(root)
+        .execute(json!({"file": "escape.txt"}))
+        .await;
+    assert!(
+        r.is_error(),
+        "symlink escape must be refused: {}",
+        r.content()
+    );
+    assert!(!r.content().contains("do not leak"));
+}
+
+#[tokio::test]
+async fn snapshot_rejects_a_directory_target() {
+    let (_tmp, root) = snapshot_fixture();
+    let r = SessionStateSnapshotTool::new(root)
+        .execute(json!({"file": "sessions"}))
+        .await;
+    assert!(r.is_error());
+    assert!(r.content().contains("not a regular file"));
+}
+
+#[tokio::test]
+async fn snapshot_truncates_a_large_file() {
+    let (_tmp, root) = snapshot_fixture();
+    std::fs::write(
+        root.join(".trusty-mpm").join("big.txt"),
+        "y".repeat(100 * 1024),
+    )
+    .unwrap();
+    let r = SessionStateSnapshotTool::new(root)
+        .execute(json!({"file": "big.txt"}))
+        .await;
+    assert!(!r.is_error(), "{}", r.content());
+    assert!(r.content().contains("showing first"));
+    assert!(r.content().len() < 64 * 1024);
+}
+
+#[tokio::test]
+async fn snapshot_absent_directory_is_a_recoverable_error() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let r = SessionStateSnapshotTool::new(tmp.path().join("no-project"))
+        .execute(json!({}))
+        .await;
+    assert!(r.is_error());
+    assert!(r.content().contains("no session snapshots"));
+}
+
+/// The tool's schema exposes no way to point it at another directory.
+///
+/// Why: path scoping rests on the root being a construction-time capability.
+/// A future edit that added a `project_dir`/`root`/`path` parameter would turn
+/// a session-state tool into an arbitrary filesystem reader; this test is the
+/// tripwire for that.
+/// What: asserts the schema's property set is exactly `file` + `max_bytes`.
+/// Test: this function IS the test.
+#[test]
+fn snapshot_takes_no_root_parameter() {
+    let schema = SessionStateSnapshotTool::new(PathBuf::from("/tmp")).schema();
+    let props = schema["function"]["parameters"]["properties"]
+        .as_object()
+        .expect("object schema");
+    let mut keys: Vec<&str> = props.keys().map(String::as_str).collect();
+    keys.sort();
+    assert_eq!(keys, vec!["file", "max_bytes"]);
+}
+
+#[test]
+fn resolve_within_snapshot_dir_accepts_a_nested_normal_path() {
+    let (_tmp, root) = snapshot_fixture();
+    let dir = root.join(".trusty-mpm");
+    let got = super::snapshot::resolve_within_snapshot_dir(&dir, "sessions/session-1.md")
+        .expect("a plain nested path is accepted");
+    assert!(got.ends_with("session-1.md"));
+}


### PR DESCRIPTION
Closes #4171. Part of epic #4167 (L0/L1 tier model); builds directly on #4200 (`AgentTier` + fail-closed resolver) and #4169's one-directional delegation gate.

## The tension this PR had to resolve

The tools #4171 asks for are **exactly** the ones the L1 BLACK-BOX POSTURE excludes **by name**: `.trusty-agents/agents/assistant/agent.toml` and `cto-assistant/agent.toml` both call out `session_list`, `session_status`, `project_list`, `console_metrics`, `system_status` (and the MCP admin verbs) with an in-file rationale — an L1 persona ingests untrusted Gmail/Drive/web content and must never recite internal trusty-* daemon/session mechanics to the user, nor gain a foothold on the orchestration surface.

So granting them to L0 is only safe if L1 provably cannot get them. **This PR does not weaken a single L1 exclusion — it converts them from convention into enforcement**, then grants the same surface to L0.

Before this PR the exclusion was *only* the absence of those names from each persona's `[tools].allow`. Nothing enforced it:

- `ctrl::pm_task::dispatch::persona` registers the trusty-mpm-proxied `session_list` / `session_status` / `project_list` / `console_metrics` executors (`tools::mcp_service_tools`, plus `tools::mcp_live` discovery) into **every** persona's registry, and `system_status` natively.
- A personalization overlay unions its `[tools].allow` into the base persona's (`extends::merge_extends`), so re-adding `session_*` to an L1 persona was a one-line edit away from working.

## What lands

**1. Enforcement — a fourth, independent, DENY-ONLY tier gate.**
`tools::session_state::retain_tier_permitted(names, tier)` strips every `L0_ONLY_SESSION_STATE_TOOLS` entry unless the agent resolves to `AgentTier::L0Orchestration` through #4200's fail-closed resolver. It is applied to the FINAL allowlist on **both** assistant dispatch paths, which is what makes it unbypassable — that list is the single value feeding both the advertised schemas and `ToolRegistry::dispatch_gated`:

| path | site |
|---|---|
| persona chat (`/agent`) | `persona_gate::filter_persona_tool_names_for_tier`, called by `run_pm_task_with_persona` |
| `--direct` / `--agent` subprocess | `runtime::subagent_mode`, immediately after `scope_for_delegation` |

Gated names: the three new native tools plus `session_list`, `session_status`, `session_proxy_summary`, `project_list`, `console_metrics`, `system_status`.

**Fail-closed on indeterminate tier.** The gate matches on the `AgentTier` enum, not a caller-computed boolean: an absent, blank or unrecognized `tier = …` resolves to `L1Standard` (#4200) and is stripped, and a future third tier is denied until someone edits the match arm. The persona-chat site deliberately does **not** get the `role != "assistant"` escape the delegation gate has — every persona on that path must declare `tier = "l0"` to keep a session-state name.

**Deny-only, so this cannot become a grant by accident.** `retain_tier_permitted` removes names; it never adds one. An L0 persona still gets exactly what its own `[tools].allow` declares.

**2. Capability — three native, read-only session-state tools, registered for L0 only.**

| tool | what it reads |
|---|---|
| `session_state_list` | managed sessions, most recently active first, with `state`/`project`/`limit` filters |
| `session_state_status` | one session's record (state, branch, workspace, task, pending decision), resolved by id / tmux name / ≥6-char id prefix |
| `session_state_snapshot` | this project's own `.trusty-mpm/` artefacts — scrollback, last instructions, session write-ups |

`tools::session_state::session_state_tools(root, tier)` returns an **empty vector** for any non-L0 tier, so an L1 registry never contains these executors at all and `scope_assistant_allowed_tools` — which intersects a persona's globs against the registry's schema names — cannot resolve them even when the persona declares them verbatim. That is barrier one; the name gate is barrier two.

**Why new names rather than reusing `session_list`/`session_status`.** `ToolRegistry::register` carries a `debug_assert!` that panics on a duplicate name, and the persona-chat registry already contains the trusty-mpm-proxied `session_list`/`session_status`. Registering a second executor under those names would panic every debug build with the trusty-mpm MCP service enabled. The gate covers **both** name sets, so an L0 persona can declare either and an L1 persona can declare neither.

**3. READ-ONLY, by construction — no mutation is granted or gated.**
Every executor opens files and returns text. Nothing writes, spawns a process, or opens a socket, so there is no code path by which one could mutate or terminate a session. `session_send`, `session_stop`, `session_new`, `session_resume`, `session_prune`, `session_delete`, `session_decommission*`, `session_proxy_message`/`_focus`/`_unfocus`, `agent_delegate`, `mcp_enable`, `mcp_disable` are deliberately absent from the grant list — pinned by `l0_only_list_contains_no_mutating_tool`, which fails if any of them is ever added. **No mutation gate was needed and none was added.**

**4. `.trusty-mpm/` reads are path-scoped — this is not a file reader.**
The root is **not a parameter**. It is fixed at construction from the dispatch path's own project root (`project_path` on the persona path, CWD on the subprocess path, matching the existing `git_tools` block). The only model-supplied input is a path relative to `<root>/.trusty-mpm/`, confined by two independent checks in `resolve_within_snapshot_dir`:

1. **Syntactic** — every `Path::components()` entry must be `Component::Normal`. Absolute paths, drive prefixes, root, `..` and `.` are rejected before touching the filesystem.
2. **Post-canonicalization containment** — target and base are BOTH `canonicalize()`d (resolving symlinks) and the target must still be prefixed by the base. This is what defeats a symlink planted inside `.trusty-mpm/` pointing at `~/.aws/credentials`; a literal-path check alone would pass it.

Non-regular-file targets are refused and reads are truncated to 32 KiB. `snapshot_takes_no_root_parameter` asserts the schema's property set is exactly `{file, max_bytes}`, so a future edit adding a `project_dir` parameter fails CI.

**5. Store reads are decoupled from `trusty-mpm`.**
`trusty-agents` deliberately does not depend on the `trusty-mpm` crate (see `trusty_mpm_service_tool_names_match_expected_curated_list`'s rationale). `session_state/store.rs` reads `~/.trusty-mpm/session-manager/sessions.json` through its own minimal view type with every field `#[serde(default)]`, so a schema change on the writer's side degrades a field rather than breaking the reader. An absent store is "no sessions" (`Ok`); a corrupt one is an error, never a silently-empty list.

**6. One skill per tool** (owner ruling): `session-state-list`, `session-state-status`, `session-state-snapshot` in `skills/manifest/builtin/ops.rs`, satisfying the `every_tool_declared_in_source_has_a_skill` coverage tripwire.

## Note on scope

Issue #4171's scope item 1 says "extend the L0 persona tool allowlist in `agent.toml`". **No persona was created or modified** — no L0 persona exists in the repo yet (#4174 owns the persona and its owner-responsibility header). This PR lands the crate-side capability plus its tier enforcement; a persona declaring `tier = "l0"` picks it up with no further code change. Every L1 persona TOML is untouched, and `assistant_tier_grants_delegation_and_blackboxes_internal_tools` still passes.

**Zero behavior change today.** No shipped persona declares any gated name, so nothing that currently works is stripped. The only behavioral delta is for a persona that declares `tier = "l0"` — of which there are none yet.

## Refactor: `persona.rs` was exactly at the 500-SLOC cap

`crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs` sits at **exactly 500 SLOC** on `main`, so no code line could be added to it. The four pure helpers (`filter_persona_tool_names`, `DEFAULT_PERSONA_TOOL_MAX_TURNS`, `persona_max_turns`, `persona_allowed_tools`) moved **verbatim** — same names, same signatures, same behavior — into a new `persona_gate.rs`, following the `persona.rs`/`persona_tests.rs` precedent. They are the only pure functions in that file and the ones the unit tests exercise. All eight existing `filter_persona_tool_names` call sites in `persona_tests.rs` are unchanged.

Sibling PRs on #4170 / #4172 / #4173 that need to add lines to `persona.rs` will hit the same wall; this split gives ~30 SLOC of headroom.

## Tests

New, in `tools/session_state/tests.rs` (26) and `dispatch/persona_tests.rs` (2). The security tests run the **real** production composition, not hand-built helper arguments:

- `l1_persona_declaring_session_state_tools_gets_none` — real `build_assistant_tier_registry` + real `scope_assistant_allowed_tools` + the tier gate, with an allow-list naming every gated tool **plus a `session_*` wildcard**. Nothing survives.
- `l0_persona_declaring_session_state_tools_gets_them` — identical composition, L0 tier, all three tools survive. (A gate that denies everyone is not a grant.)
- `indeterminate_tier_fails_closed_to_no_session_state_tools` — parses five real persona TOMLs (absent / `""` / `"   "` / `"L2"` / `"yolo"`) through `AgentInfo::tier()` and asserts both the strip and the empty registration.
- `persona_tier_gate_strips_session_state_for_l1` / `..._keeps_session_state_for_l0` — the persona-chat gate at the exact function `run_pm_task_with_persona` calls.
- `assistant_tier_registry_omits_session_state_tools_for_l1` / `..._includes_..._for_l0` — registration-level barrier.
- Path scoping: `snapshot_rejects_parent_traversal`, `snapshot_rejects_absolute_path`, `snapshot_rejects_symlink_escape` (unix), `snapshot_rejects_a_directory_target`, `snapshot_takes_no_root_parameter` — each asserts the secret file's content never appears in the result.
- `l0_only_list_contains_no_mutating_tool`, `l0_only_list_covers_the_l1_blackbox_exclusions`, `l0_only_list_covers_every_native_session_state_tool` — the grant list's own invariants.

Every test name cited in a doc comment exists (`scripts/check_test_pointers.sh` clean).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
