### PR TITLE
fix(trusty-search): quarantine incremental writes when the corpus open failed (#4122)

### DIFF
--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -25,6 +25,28 @@ MINOR, not patch: `service::lazy_loader::store`'s public
 
 ### Fixed
 
+- **An index whose durable corpus failed to open kept accepting watcher
+  writes, permanently destroying the corpus (issue #4122, P0 data loss).**
+  When `CorpusStore::open` failed at load time the loader set
+  `corpus_open_failed` but left the handle fully live, watcher included, so
+  ordinary unrelated file saves rebuilt a fresh PARTIAL corpus over the
+  never-opened original — in production `chunk_count` climbed `0 → 68 → 1334`
+  and the index came back "healthy" on the next restart holding the wrong
+  content. A `corpus_open_failed` index is now **write-quarantined**: every
+  incremental write path (`service::watch_loop`, `service::reconcile`, and
+  `POST /indexes/{id}/index-file`) is refused at the shared
+  `CodeIndexer::index_file` choke point, and the watcher additionally bails
+  before it reads and chunks the saved file. Refusals are emitted at ERROR
+  (the only level `trusty_common::error_capture` persists to `errors.jsonl` /
+  `list_recent_errors` / `tm doctor`), throttled to the 1st and every 100th,
+  and counted on `CodeIndexer::refused_incremental_writes`. The quarantine is
+  **not permanent**: a successful `set_corpus_store` lifts it and resets the
+  counter, so the clean-restart recovery path (the incident's `cto-duetto`,
+  restored at its full 200,090 chunks) is unaffected. Bulk reindex is
+  deliberately not gated — it is the documented way out of this state. Reads
+  are unchanged; corpus-failed indexes still return empty results (that is
+  issue #4087, not fixed here).
+
 - **Two more index-registration paths had no `root_path` collision guard —
   fourth occurrence of the #2305/#2336 `DatabaseAlreadyOpen` class (issue
   #3993).** An audit prompted by #3929 found `find_root_path_collision`

--- a/crates/trusty-search/CHANGELOG.md
+++ b/crates/trusty-search/CHANGELOG.md
@@ -7,6 +7,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **An index whose durable corpus failed to open kept accepting watcher
+  writes, permanently destroying the corpus (issue #4122, P0 data loss).**
+  When `CorpusStore::open` failed at load time the loader set
+  `corpus_open_failed` but left the handle fully live, watcher included, so
+  ordinary unrelated file saves rebuilt a fresh PARTIAL corpus over the
+  never-opened original — in production `chunk_count` climbed `0 → 68 → 1334`
+  and the index came back "healthy" on the next restart holding the wrong
+  content. A `corpus_open_failed` index is now **write-quarantined**: every
+  incremental write path (`service::watch_loop`, `service::reconcile`, and
+  `POST /indexes/{id}/index-file`) is refused at the shared
+  `CodeIndexer::index_file` choke point, and the watcher additionally bails
+  before it reads and chunks the saved file. Refusals are emitted at ERROR
+  (the only level `trusty_common::error_capture` persists to `errors.jsonl` /
+  `list_recent_errors` / `tm doctor`), throttled to the 1st and every 100th,
+  and counted on `CodeIndexer::refused_incremental_writes`. **Recovery is a
+  daemon restart** — only a successful `CorpusStore::open` lifts the
+  quarantine and it is attempted solely at load time, so the ERROR text says
+  so explicitly and warns that a reindex neither clears the state nor
+  persists anything (with no corpus wired it skips staging entirely). The
+  clean-restart path (the incident's `cto-duetto`, restored at its full
+  200,090 chunks) is unaffected. Bulk reindex is deliberately not gated,
+  which is safe because a quarantined index holds no `CorpusStore` — an
+  invariant now documented and pinned by `debug_assert!`s, since boot
+  reconcile auto-fires reindexes with no quarantine check. Reads are
+  unchanged; corpus-failed indexes still return empty results (that is issue
+  #4087, not fixed here).
+
 ---
 ## [0.40.0] — 2026-07-27
 
@@ -24,28 +53,6 @@ MINOR, not patch: `service::lazy_loader::store`'s public
 
 
 ### Fixed
-
-- **An index whose durable corpus failed to open kept accepting watcher
-  writes, permanently destroying the corpus (issue #4122, P0 data loss).**
-  When `CorpusStore::open` failed at load time the loader set
-  `corpus_open_failed` but left the handle fully live, watcher included, so
-  ordinary unrelated file saves rebuilt a fresh PARTIAL corpus over the
-  never-opened original — in production `chunk_count` climbed `0 → 68 → 1334`
-  and the index came back "healthy" on the next restart holding the wrong
-  content. A `corpus_open_failed` index is now **write-quarantined**: every
-  incremental write path (`service::watch_loop`, `service::reconcile`, and
-  `POST /indexes/{id}/index-file`) is refused at the shared
-  `CodeIndexer::index_file` choke point, and the watcher additionally bails
-  before it reads and chunks the saved file. Refusals are emitted at ERROR
-  (the only level `trusty_common::error_capture` persists to `errors.jsonl` /
-  `list_recent_errors` / `tm doctor`), throttled to the 1st and every 100th,
-  and counted on `CodeIndexer::refused_incremental_writes`. The quarantine is
-  **not permanent**: a successful `set_corpus_store` lifts it and resets the
-  counter, so the clean-restart recovery path (the incident's `cto-duetto`,
-  restored at its full 200,090 chunks) is unaffected. Bulk reindex is
-  deliberately not gated — it is the documented way out of this state. Reads
-  are unchanged; corpus-failed indexes still return empty results (that is
-  issue #4087, not fixed here).
 
 - **Two more index-registration paths had no `root_path` collision guard —
   fourth occurrence of the #2305/#2336 `DatabaseAlreadyOpen` class (issue

--- a/crates/trusty-search/src/core/indexer/ingest/commit.rs
+++ b/crates/trusty-search/src/core/indexer/ingest/commit.rs
@@ -332,6 +332,14 @@ impl CodeIndexer {
     /// What: clones the chunks plus entities, moves them onto a blocking worker,
     /// and writes both tables in one atomic transaction. Failures are logged at
     /// `warn` and swallowed.
+    ///
+    /// Issue #4122: this is the single durable redb write, and the `None` arm
+    /// below is what makes the UNGATED bulk-reindex path safe on a
+    /// write-quarantined index — NOT any assumption that reindexes are
+    /// operator-initiated (boot reconcile auto-fires them, see
+    /// `core::indexer::quarantine`'s module docs). The `debug_assert!` pins
+    /// that invariant so an in-process corpus reopen cannot silently
+    /// reintroduce the data-loss hole.
     /// Test: `tests::test_corpus_store_roundtrip`.
     pub(crate) async fn commit_corpus_to_redb(
         &self,
@@ -341,6 +349,14 @@ impl CodeIndexer {
         let Some(corpus) = self.corpus.clone() else {
             return;
         };
+        debug_assert!(
+            !self.corpus_open_failed,
+            "index '{}': INVARIANT VIOLATED — durable corpus write attempted while \
+             the index is write-quarantined (corpus_open_failed). A quarantined \
+             index must hold no CorpusStore; see core::indexer::quarantine (issue \
+             #4122).",
+            self.index_id
+        );
         let chunks = chunks.to_vec();
         let entities = entities_by_file.to_vec();
         let index_id = self.index_id.clone();

--- a/crates/trusty-search/src/core/indexer/ingest/mod.rs
+++ b/crates/trusty-search/src/core/indexer/ingest/mod.rs
@@ -228,8 +228,33 @@ impl CodeIndexer {
     /// What: chunk the file, batch-embed all chunks, commit vectors / BM25 /
     /// corpus, then enrich entities via the NLP helper and rebuild the
     /// symbol graph once.
-    /// Test: covered by every `index_file`-based test in `indexer::tests`.
+    ///
+    /// Issue #4122: this is the single choke point every INCREMENTAL write
+    /// funnels through — the file watcher (`service::watch_loop`), the
+    /// boot-time catch-up reconciler (`service::reconcile`), and the explicit
+    /// `POST /indexes/{id}/index-file` endpoint (`service::server::files`).
+    /// When the index is write-quarantined because its durable corpus failed
+    /// to open, every one of them must be refused: accepting them rebuilds a
+    /// fresh PARTIAL corpus over the never-opened original and destroys it.
+    /// The refusal is returned as an `Err` rather than a silent `Ok(())` so
+    /// the HTTP endpoint reports `500` instead of falsely answering
+    /// `"indexed": true` — the ERROR-level diagnostic is emitted by
+    /// `refuse_incremental_write` either way. The BULK path
+    /// (`index_files_batch*`, used by a full reindex) is intentionally NOT
+    /// gated: a reindex is an explicit operator action that rebuilds the
+    /// corpus wholesale and is the documented way out of this state.
+    /// Test: covered by every `index_file`-based test in `indexer::tests`;
+    /// the quarantine branch by
+    /// `quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero`.
     pub async fn index_file(&self, file_path: &str, content: &str) -> Result<()> {
+        if self.refuse_incremental_write("index_file", file_path) {
+            anyhow::bail!(
+                "index '{}' is write-quarantined: its durable corpus failed to open, so \
+                 incremental indexing of '{file_path}' was refused to avoid overwriting \
+                 the on-disk corpus (issue #4122)",
+                self.index_id
+            );
+        }
         let (mut chunks, entities) = chunk_ast(file_path, content);
 
         populate_virtual_terms(&mut chunks, &entities);

--- a/crates/trusty-search/src/core/indexer/ingest/mod.rs
+++ b/crates/trusty-search/src/core/indexer/ingest/mod.rs
@@ -241,8 +241,13 @@ impl CodeIndexer {
     /// `"indexed": true` — the ERROR-level diagnostic is emitted by
     /// `refuse_incremental_write` either way. The BULK path
     /// (`index_files_batch*`, used by a full reindex) is intentionally NOT
-    /// gated: a reindex is an explicit operator action that rebuilds the
-    /// corpus wholesale and is the documented way out of this state.
+    /// gated. Note this is NOT because reindexes are operator-initiated —
+    /// `service::reconcile` auto-fires them at boot with no
+    /// `corpus_open_failed` check. It is safe because of the invariant in
+    /// `core::indexer::quarantine`: a quarantined index holds no
+    /// `CorpusStore`, so `commit_corpus_to_redb` early-returns and
+    /// `staging::should_stage` is `false` — a bulk reindex on a quarantined
+    /// index writes nothing durable at all.
     /// Test: covered by every `index_file`-based test in `indexer::tests`;
     /// the quarantine branch by
     /// `quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero`.

--- a/crates/trusty-search/src/core/indexer/mod.rs
+++ b/crates/trusty-search/src/core/indexer/mod.rs
@@ -43,6 +43,7 @@ mod ingest;
 pub(crate) mod migrations;
 mod persist;
 mod persist_hnsw;
+mod quarantine;
 mod search;
 pub mod typeahead;
 mod types;
@@ -322,7 +323,28 @@ pub struct CodeIndexer {
     /// from a legitimately empty, freshly-created index.  This flag lets the
     /// classifier emit `StageStatus::Failed` with an actionable message instead
     /// of the misleading `InProgress` / "walking" state (closes #1158).
+    ///
+    /// Issue #4122: this flag is ALSO the write-quarantine predicate. While it
+    /// is `true` the index refuses every incremental/watcher write (see
+    /// `indexer::quarantine`), because building a fresh corpus on top of an
+    /// unopened one permanently destroys the original. Cleared by
+    /// [`Self::set_corpus_store`] when a corpus open finally succeeds, so the
+    /// quarantine is recoverable rather than terminal.
     pub corpus_open_failed: bool,
+
+    /// Issue #4122: monotonic count of incremental writes refused because
+    /// [`Self::corpus_open_failed`] was set.
+    ///
+    /// Why: the refusal needs an observable surface that is not a log line —
+    /// tests need a deterministic condition to await instead of a sleep, and
+    /// operators need "how many saves were dropped?" answered numerically.
+    /// What: bumped by `refuse_incremental_write`, reset to 0 by
+    /// `clear_corpus_open_failure`. Read via
+    /// [`Self::refused_incremental_writes`]. Atomic because `index_file`
+    /// takes `&self`.
+    /// Test: `quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero`
+    /// in `tests/corpus_open_quarantine_4122.rs`.
+    pub(super) incremental_writes_refused: AtomicU64,
 
     /// Issue #2922: `true` when a persisted HNSW snapshot existed on disk at
     /// warm-boot/lazy-load time but could NOT be restored (missing/corrupt
@@ -463,6 +485,7 @@ impl CodeIndexer {
             lane_degraded: Arc::new(AtomicBool::new(false)),
             last_rehydrate_cost_ms: Arc::new(AtomicU64::new(0)),
             corpus_open_failed: false,
+            incremental_writes_refused: AtomicU64::new(0),
             hnsw_load_failed: false,
             skip_kg: false,
         }
@@ -702,10 +725,16 @@ impl CodeIndexer {
     /// Why: the daemon resolves one `index.redb` per index and wires it in
     /// before warm-boot.
     /// What: stores the `Arc` so both the ingest commit path and the
-    /// fire-and-forget persist task can reach it.
-    /// Test: `tests::test_corpus_store_roundtrip`.
+    /// fire-and-forget persist task can reach it. Issue #4122: a successful
+    /// open is exactly the event that makes writes safe again, so this also
+    /// lifts any active write quarantine via `clear_corpus_open_failure`
+    /// (a no-op on the healthy-boot path, where the flag is already `false`).
+    /// Test: `tests::test_corpus_store_roundtrip`;
+    /// `successful_reopen_lifts_quarantine_and_leaves_corpus_intact` in
+    /// `tests/corpus_open_quarantine_4122.rs` covers the recovery transition.
     pub fn set_corpus_store(&mut self, corpus: Arc<crate::core::corpus::CorpusStore>) {
         self.corpus = Some(corpus);
+        self.clear_corpus_open_failure();
     }
 
     /// Swap in a new durable corpus store, returning the one it replaced

--- a/crates/trusty-search/src/core/indexer/quarantine.rs
+++ b/crates/trusty-search/src/core/indexer/quarantine.rs
@@ -31,6 +31,30 @@
 //! answering with silent empty results is issue #4087 and is deliberately out
 //! of scope here.
 //!
+//! # LOAD-BEARING INVARIANT: `corpus_open_failed == true` ⇒ `self.corpus == None`
+//!
+//! This — NOT "reindexes are operator-initiated" — is what makes the ungated
+//! BULK path safe. Boot reconcile auto-fires full reindexes
+//! (`service::reconcile`) with no `corpus_open_failed` check at all, so a
+//! quarantined index CAN be reindexed without any human involved. That is
+//! harmless only because every durable redb write funnels through
+//! `self.corpus` and short-circuits when it is `None`
+//! (`ingest::commit::commit_corpus_to_redb` early-returns on `None`), and
+//! because `service::reindex::staging::should_stage(has_corpus_store())` is
+//! `false` here, so such a reindex never even stages.
+//!
+//! The invariant holds because the only producer of `corpus_open_failed ==
+//! true` (`service::persistence_loader::build_indexer_from_entry`) is exactly
+//! the path that wires NO corpus, and the only way to wire one
+//! ([`CodeIndexer::set_corpus_store`]) clears the flag in the same call.
+//!
+//! **If you add an in-process corpus reopen/retry, you will break this.** A
+//! retry that wires a corpus without clearing the flag — or that sets the flag
+//! on an index that still holds one — re-opens the exact data-loss hole this
+//! module closes, and every existing test stays green while it does. The two
+//! `debug_assert!`s (in [`CodeIndexer::refuse_incremental_write`] and in
+//! `commit_corpus_to_redb`) exist to make that failure loud instead of silent.
+//!
 //! Test: `crates/trusty-search/tests/corpus_open_quarantine_4122.rs`.
 
 use std::sync::atomic::Ordering;
@@ -103,6 +127,19 @@ impl CodeIndexer {
         if !self.corpus_open_failed {
             return false;
         }
+        // Issue #4122, see the module-level invariant: a quarantined index must
+        // never hold a wired corpus. If it ever does, the ungated BULK reindex
+        // path (auto-fired by boot reconcile) would write durably to a corpus
+        // this module has declared unsafe — silently, with CI green.
+        debug_assert!(
+            self.corpus.is_none(),
+            "index '{}': INVARIANT VIOLATED — corpus_open_failed is set while a \
+             CorpusStore is wired. The ungated bulk-reindex path is safe only \
+             because a quarantined index has no corpus to write through. Did you \
+             add an in-process corpus reopen that skips set_corpus_store (issue \
+             #4122)?",
+            self.index_id
+        );
         let refused = self
             .incremental_writes_refused
             .fetch_add(1, Ordering::Relaxed)
@@ -120,10 +157,14 @@ impl CodeIndexer {
                  watcher/incremental writes against an unopened corpus builds a fresh \
                  PARTIAL corpus over the original and destroys it permanently (issue \
                  #4122). {refused} write(s) refused so far; the on-disk corpus is \
-                 untouched and still recoverable. Fix the underlying redb file \
-                 (permissions, stale lock, corruption) and restart the daemon — a \
-                 successful corpus open lifts the quarantine automatically. Saves \
-                 dropped while quarantined are picked up by the next reindex."
+                 untouched and still recoverable. TO RECOVER: fix the underlying redb \
+                 file (permissions, stale lock, corruption), then RESTART THE DAEMON — \
+                 only a successful CorpusStore::open lifts the quarantine, and it is \
+                 attempted solely at load time (there is no in-process reopen retry). \
+                 A reindex will NOT clear this state and will NOT persist anything: \
+                 with no corpus wired it skips staging entirely, so its results are \
+                 discarded at the next restart. Saves dropped while quarantined are \
+                 picked up by the first reindex AFTER a successful restart."
             );
         } else {
             tracing::debug!(

--- a/crates/trusty-search/src/core/indexer/quarantine.rs
+++ b/crates/trusty-search/src/core/indexer/quarantine.rs
@@ -1,0 +1,174 @@
+//! Corpus-open write quarantine for [`CodeIndexer`] (issue #4122).
+//!
+//! Why: when an index's durable redb corpus FAILS to open at load time the
+//! loader wires no `CorpusStore` at all, leaves the in-memory chunk map empty,
+//! and sets [`CodeIndexer::corpus_open_failed`] — but the handle otherwise
+//! stays fully live, watcher included. In the #4122 production incident that
+//! combination turned a *recoverable* outage into permanent data loss: the
+//! file watcher for `duettoresearch-hackathon-tm-hackathon-01` kept accepting
+//! incremental writes from unrelated file saves, so `chunk_count` climbed
+//! `0 → 68 → 1334` and a FRESH, PARTIAL corpus was persisted over the
+//! never-opened original. The sibling index `cto-duetto` hit the identical
+//! open failure in the same boot, took no watcher writes, and recovered all
+//! 200,090 chunks on the next restart. Watcher-writes-during-failure was the
+//! sole difference between full recovery and unrecoverable loss.
+//!
+//! What: this module gives `CodeIndexer` a small quarantine surface —
+//! [`CodeIndexer::is_write_quarantined`] (the predicate),
+//! [`CodeIndexer::refuse_incremental_write`] (the enforcement + diagnostic),
+//! [`CodeIndexer::refused_incremental_writes`] (the observable counter), and
+//! [`CodeIndexer::clear_corpus_open_failure`] (the way back out, driven by
+//! `set_corpus_store`). The quarantine is deliberately *asymmetric*: refusing
+//! a write costs an un-indexed file save that the next reindex picks up
+//! anyway, whereas accepting one destroys the corpus. So every corpus-open
+//! failure — transient I/O error, permission denial, stale redb file lock, an
+//! unresolvable storage path, or genuine corruption — quarantines, because at
+//! the point of failure they are indistinguishable and only one of the two
+//! possible mistakes is recoverable.
+//!
+//! Reads are NOT gated: a quarantined index still serves searches (returning
+//! whatever its empty in-memory corpus holds). Making failed indexes stop
+//! answering with silent empty results is issue #4087 and is deliberately out
+//! of scope here.
+//!
+//! Test: `crates/trusty-search/tests/corpus_open_quarantine_4122.rs`.
+
+use std::sync::atomic::Ordering;
+
+use super::CodeIndexer;
+
+/// Emit the full ERROR diagnostic on the 1st refusal and then every Nth.
+///
+/// Why: a busy worktree can fire thousands of watcher events while an index is
+/// quarantined. The first refusal must be loud (it is the operator's only
+/// warning that saves are being dropped), but repeating it per-event would
+/// flood `errors.jsonl` and drown every other captured error. Periodic
+/// re-emission keeps the condition visible for an operator who starts reading
+/// logs *after* the first event without turning the log into a firehose.
+/// What: refusal `n` logs at ERROR when `n == 1 || n % INTERVAL == 0`;
+/// every other refusal logs at DEBUG. The running total is carried in the
+/// ERROR record's `refused_writes` field, so no refusal is unaccounted for.
+/// Test: `quarantine_refusal_emits_error_level_diagnostic` asserts the first
+/// refusal is captured at ERROR.
+const QUARANTINE_ERROR_LOG_INTERVAL: u64 = 100;
+
+impl CodeIndexer {
+    /// True when this index's durable corpus failed to open and it must
+    /// therefore refuse incremental writes (issue #4122).
+    ///
+    /// Why: gives the watcher glue (`service::watch_loop`) a cheap predicate
+    /// so it can bail out *before* reading and chunking a saved file, and
+    /// gives tests/diagnostics a name for the state.
+    /// What: mirrors [`CodeIndexer::corpus_open_failed`], which is set by
+    /// `service::persistence_loader::build_indexer_from_entry` on exactly two
+    /// conditions — `open_corpus_with_retry` returned `Err`, or the redb
+    /// corpus path could not be resolved at all (#2847).
+    /// Test: `quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero`.
+    pub fn is_write_quarantined(&self) -> bool {
+        self.corpus_open_failed
+    }
+
+    /// Number of incremental writes refused since the index entered
+    /// quarantine (issue #4122).
+    ///
+    /// Why: the refusal must be observable from something other than a log
+    /// line — tests need a deterministic condition to wait on instead of a
+    /// sleep, and operators need a count rather than "some writes were
+    /// dropped".
+    /// What: monotonic counter, reset to 0 by
+    /// [`Self::clear_corpus_open_failure`] when the index recovers.
+    /// Test: `quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero`.
+    pub fn refused_incremental_writes(&self) -> u64 {
+        self.incremental_writes_refused.load(Ordering::Relaxed)
+    }
+
+    /// Refuse `op` against `target` when this index is quarantined, logging a
+    /// diagnostic that actually persists; returns `true` when the caller must
+    /// abandon the write (issue #4122).
+    ///
+    /// Why: a *silent* no-op would reproduce the original sin of this bug
+    /// class — the system reporting a state it does not have. In this
+    /// workspace only ERROR-level events reach `errors.jsonl` /
+    /// `list_recent_errors` / `tm doctor` (`trusty_common::error_capture`'s
+    /// `BugCaptureLayer` drops anything that is not `Level::ERROR`, and the
+    /// daemon installs it via `init_tracing_with_buffer_and_capture` in
+    /// `commands::start::daemon`), so `warn!` here would be invisible to
+    /// every diagnostic surface an operator actually reads. Hence ERROR.
+    /// What: no-op returning `false` when not quarantined. Otherwise bumps
+    /// [`Self::refused_incremental_writes`] and logs — ERROR on the first
+    /// refusal and every [`QUARANTINE_ERROR_LOG_INTERVAL`]th thereafter,
+    /// DEBUG in between — then returns `true`.
+    /// Test: `quarantine_refusal_emits_error_level_diagnostic`.
+    pub(crate) fn refuse_incremental_write(&self, op: &str, target: &str) -> bool {
+        if !self.corpus_open_failed {
+            return false;
+        }
+        let refused = self
+            .incremental_writes_refused
+            .fetch_add(1, Ordering::Relaxed)
+            + 1;
+        let index_id = &self.index_id;
+        if refused == 1 || refused.is_multiple_of(QUARANTINE_ERROR_LOG_INTERVAL) {
+            tracing::error!(
+                index_id = %index_id,
+                op = %op,
+                target = %target,
+                refused_writes = refused,
+                "index '{index_id}': REFUSING incremental write ({op} {target}) — this \
+                 index's durable redb corpus failed to open at load time \
+                 (corpus_open_failed), so the index is write-quarantined. Accepting \
+                 watcher/incremental writes against an unopened corpus builds a fresh \
+                 PARTIAL corpus over the original and destroys it permanently (issue \
+                 #4122). {refused} write(s) refused so far; the on-disk corpus is \
+                 untouched and still recoverable. Fix the underlying redb file \
+                 (permissions, stale lock, corruption) and restart the daemon — a \
+                 successful corpus open lifts the quarantine automatically. Saves \
+                 dropped while quarantined are picked up by the next reindex."
+            );
+        } else {
+            tracing::debug!(
+                index_id = %index_id,
+                op = %op,
+                target = %target,
+                refused_writes = refused,
+                "write-quarantined index refused an incremental write (issue #4122)"
+            );
+        }
+        true
+    }
+
+    /// Lift the write quarantine after a corpus open succeeds (issue #4122).
+    ///
+    /// Why: quarantining forever on one transient failure would be a new
+    /// outage, not a fix — the #4122 contrast case (`cto-duetto`) recovered
+    /// cleanly on the next boot and MUST keep doing so. A successful
+    /// `CorpusStore::open` is precisely the event that makes writes safe
+    /// again, so [`CodeIndexer::set_corpus_store`] — the single sink every
+    /// successful open funnels through — calls this. There is no separate
+    /// "unquarantine" lever to forget to pull.
+    /// What: no-op when not quarantined (the overwhelmingly common
+    /// healthy-boot call). Otherwise clears `corpus_open_failed`, resets the
+    /// refusal counter, and logs at WARN — the daemon's default stderr filter
+    /// is `warn`, so a recovery notice at INFO would not be printed at all.
+    /// Note `swap_corpus_store` deliberately does NOT call this: it replaces
+    /// an already-wired corpus (the reindex staging swap), which by
+    /// construction cannot happen on a quarantined index because
+    /// `has_corpus_store()` is `false` there.
+    /// Test: `successful_reopen_lifts_quarantine_and_leaves_corpus_intact`.
+    pub(crate) fn clear_corpus_open_failure(&mut self) {
+        if !self.corpus_open_failed {
+            return;
+        }
+        self.corpus_open_failed = false;
+        let refused = self.incremental_writes_refused.swap(0, Ordering::Relaxed);
+        tracing::warn!(
+            index_id = %self.index_id,
+            refused_writes = refused,
+            "index '{}': durable corpus opened successfully — lifting the #4122 write \
+             quarantine; incremental/watcher writes are accepted again ({} write(s) were \
+             refused while quarantined; run a reindex to pick them up)",
+            self.index_id,
+            refused
+        );
+    }
+}

--- a/crates/trusty-search/src/service/watch_loop.rs
+++ b/crates/trusty-search/src/service/watch_loop.rs
@@ -204,6 +204,25 @@ async fn handle_modified(
         return;
     }
 
+    // Issue #4122: refuse the write outright when this index is
+    // write-quarantined because its durable redb corpus failed to open. This
+    // is the exact path that caused unrecoverable data loss in production —
+    // ordinary saves in the worktree kept feeding a handle whose corpus had
+    // never opened, so a fresh PARTIAL corpus was built and persisted over
+    // the original. `CodeIndexer::index_file` carries the same guard (it is
+    // the choke point for the reconcile and HTTP incremental paths too);
+    // checking here as well means a quarantined index does not read and chunk
+    // every saved file just to throw the result away, and it keeps the
+    // refusal attributable to the watcher in the ERROR record's `op` field.
+    // Placed AFTER the exclusion filters so excluded saves — which would
+    // never have been indexed anyway — are not reported as refused writes.
+    {
+        let idx = indexer.read().await;
+        if idx.refuse_incremental_write("watcher-modified", &path.display().to_string()) {
+            return;
+        }
+    }
+
     // Issue #2923: pdf/docx/xls/xlsx/xlsm route through the office document
     // extractor instead of being treated as UTF-8 text — mirrors
     // `service::reindex::batch`'s dispatch so the watcher and the

--- a/crates/trusty-search/tests/corpus_open_quarantine_4122.rs
+++ b/crates/trusty-search/tests/corpus_open_quarantine_4122.rs
@@ -54,30 +54,49 @@ use trusty_search::service::watch_loop::spawn_watch_loop;
 ///
 /// Why: the watcher tests depend on OS filesystem notifications plus the
 /// 500 ms debounce window, so they need a real wall-clock budget — but the
-/// waits are condition-based (`await_condition`), not fixed sleeps, so a
-/// healthy machine finishes in well under a second.
+/// waits are condition-based (`await_condition_resaving`), not fixed sleeps,
+/// so a healthy machine finishes in well under a second.
 const WAIT_BUDGET: Duration = Duration::from_secs(30);
 
-/// Poll `cond` until it returns `true` or [`WAIT_BUDGET`] elapses.
+/// Poll `cond` while RE-SAVING `name` into every root in `roots`.
 ///
-/// Why: asserting "the watcher processed this event" with a fixed sleep is
-/// both slow and flaky. Every wait here has a concrete observable to latch
-/// onto (`chunk_count() > 0`, `refused_incremental_writes() > 0`), so poll
-/// for it instead.
-/// What: returns `true` if the condition held within the budget.
-async fn await_condition<F, Fut>(mut cond: F) -> bool
+/// Why: a single save is a ONE-SHOT event. If the OS watch registration has
+/// not finished when it lands — routine on a loaded CI runner, where this test
+/// first failed by burning its full 30 s budget with a control that never
+/// indexed — the event is lost permanently and no later event ever arrives, so
+/// the race becomes a hang and a red build. Re-saving keeps producing events
+/// for the whole budget, so the wait ends as soon as the watcher is genuinely
+/// live rather than depending on a startup sleep being long enough.
+///
+/// This STRENGTHENS the quarantine assertions rather than weakening them: the
+/// broken index gets MORE chances to wrongly accept a write, not fewer, and
+/// the control must still demonstrably index before the test proceeds.
+/// What: polls `cond` every 25 ms (so a healthy machine still finishes in well
+/// under a second) and rewrites the file once per 500 ms debounce window with
+/// CHANGING content, so no content-equality dedupe can swallow the rewrite.
+async fn await_condition_resaving<F, Fut>(roots: &[&Path], name: &str, mut cond: F) -> bool
 where
     F: FnMut() -> Fut,
     Fut: std::future::Future<Output = bool>,
 {
     let deadline = Instant::now() + WAIT_BUDGET;
+    let mut generation: u32 = 0;
+    let mut last_save: Option<Instant> = None;
     while Instant::now() < deadline {
         if cond().await {
             return true;
         }
+        if last_save.is_none_or(|t| t.elapsed() >= Duration::from_millis(500)) {
+            generation += 1;
+            let body = format!("pub fn quarantine_probe() -> u32 {{ 4122 + {generation} }}\n");
+            for root in roots {
+                save_source_file(root, name, &body);
+            }
+            last_save = Some(Instant::now());
+        }
         tokio::time::sleep(Duration::from_millis(25)).await;
     }
-    false
+    cond().await
 }
 
 fn mock_embedder() -> Arc<dyn Embedder> {
@@ -132,7 +151,11 @@ fn save_source_file(root: &Path, name: &str, content: &str) {
 /// reached the guard.
 /// Test: this IS the test. Against pre-fix code the quarantined index's
 /// `chunk_count()` grows past 0 exactly as it did in production.
-#[tokio::test]
+// `multi_thread` is REQUIRED, not stylistic: the watcher bridges its OS
+// notification thread into the async loop, and on the default current-thread
+// runtime that pipeline can starve — which is how this test passed on macOS
+// and failed on Linux CI. Mirrors `watch_loop::tests::modified_file_triggers_indexing`.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero() {
     let broken_dir = tempdir().expect("tempdir");
     let healthy_dir = tempdir().expect("tempdir");
@@ -176,15 +199,15 @@ async fn quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero() {
     let _healthy_watch = spawn_watch_loop(&healthy_root, Arc::clone(&healthy), IndexedFiles::new())
         .expect("spawn healthy watch loop");
 
-    // An ordinary, unrelated save in each worktree — the production trigger.
-    let source = "pub fn quarantine_probe() -> u32 { 4122 }\n";
-    save_source_file(&broken_root, "probe.rs", source);
-    save_source_file(&healthy_root, "probe.rs", source);
+    // Ordinary, unrelated saves in each worktree — the production trigger.
+    // Driven by `await_condition_resaving` so a save that lands before the OS
+    // watch is armed cannot strand the test (see that helper's docs).
+    let roots: [&Path; 2] = [&broken_root, &healthy_root];
 
     // Positive control: the watcher pipeline demonstrably works here.
     let healthy_indexed = {
         let healthy = Arc::clone(&healthy);
-        await_condition(move || {
+        await_condition_resaving(&roots, "probe.rs", move || {
             let healthy = Arc::clone(&healthy);
             async move { healthy.read().await.chunk_count() > 0 }
         })
@@ -203,7 +226,7 @@ async fn quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero() {
     // instead of a missing counter bump.
     let decided = {
         let broken = Arc::clone(&broken);
-        await_condition(move || {
+        await_condition_resaving(&roots, "probe.rs", move || {
             let broken = Arc::clone(&broken);
             async move {
                 let broken = broken.read().await;

--- a/crates/trusty-search/tests/corpus_open_quarantine_4122.rs
+++ b/crates/trusty-search/tests/corpus_open_quarantine_4122.rs
@@ -1,0 +1,436 @@
+//! Issue #4122 regression tests: an index whose durable corpus failed to open
+//! must REFUSE incremental/watcher writes until a corpus open succeeds.
+//!
+//! Why: in production, `duettoresearch-hackathon-tm-hackathon-01` failed its
+//! redb corpus open at warm boot (`corpus_open_failed: true`, `chunk_count:
+//! 0`) but its file watcher stayed `active: true`. Ordinary, unrelated file
+//! saves in the worktree kept flowing into the handle, so `chunk_count`
+//! climbed `0 → 68 → 1334` and a FRESH, PARTIAL corpus was persisted over the
+//! never-opened original — which is now unrecoverable. The sibling index
+//! `cto-duetto` hit the identical open failure in the same boot, took no
+//! watcher writes, and recovered all 200,090 chunks on the next restart.
+//! Watcher-writes-during-failure was the ONLY difference between clean
+//! recovery and permanent loss.
+//!
+//! What: three tests, mirroring the three halves of the fix.
+//!   1. `quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero`
+//!      — the corruption sequence, end to end through the real
+//!      `spawn_watch_loop` + OS watcher, with a healthy sibling index in the
+//!      same test as the positive control.
+//!   2. `successful_reopen_lifts_quarantine_and_leaves_corpus_intact`
+//!      — the `cto-duetto` recovery case. Guards against over-refusal: a
+//!      quarantine that never lifts is a new outage, not a fix.
+//!   3. `quarantine_refusal_emits_error_level_diagnostic`
+//!      — the refusal must reach a diagnostic surface operators actually
+//!      read. In this workspace only ERROR-level events reach
+//!      `errors.jsonl` / `list_recent_errors` / `tm doctor`, so this test
+//!      asserts capture through the REAL `BugCaptureLayer`, not merely that
+//!      some log line was emitted.
+//!
+//! Both failure modes are induced by production code paths rather than by
+//! poking `corpus_open_failed` directly: tests 1 and 3 put a DIRECTORY where
+//! `index.redb` belongs (portable I/O failure), and test 2 holds a live redb
+//! handle so the second open fails with `DatabaseAlreadyOpen` — the shape
+//! that leaves the original corpus fully intact on disk, exactly as in the
+//! incident.
+//!
+//! Test: `cargo test -p trusty-search --test corpus_open_quarantine_4122`
+
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tempfile::tempdir;
+use tokio::sync::RwLock;
+use trusty_common::embedder::MockEmbedder;
+use trusty_search::core::corpus::CorpusStore;
+use trusty_search::core::{chunk_ast, Embedder};
+use trusty_search::service::indexed_files::IndexedFiles;
+use trusty_search::service::persistence::PersistedIndex;
+use trusty_search::service::persistence_loader::build_indexer_from_entry;
+use trusty_search::service::watch_loop::spawn_watch_loop;
+
+/// Upper bound for every condition wait in this file.
+///
+/// Why: the watcher tests depend on OS filesystem notifications plus the
+/// 500 ms debounce window, so they need a real wall-clock budget — but the
+/// waits are condition-based (`await_condition`), not fixed sleeps, so a
+/// healthy machine finishes in well under a second.
+const WAIT_BUDGET: Duration = Duration::from_secs(30);
+
+/// Poll `cond` until it returns `true` or [`WAIT_BUDGET`] elapses.
+///
+/// Why: asserting "the watcher processed this event" with a fixed sleep is
+/// both slow and flaky. Every wait here has a concrete observable to latch
+/// onto (`chunk_count() > 0`, `refused_incremental_writes() > 0`), so poll
+/// for it instead.
+/// What: returns `true` if the condition held within the budget.
+async fn await_condition<F, Fut>(mut cond: F) -> bool
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = bool>,
+{
+    let deadline = Instant::now() + WAIT_BUDGET;
+    while Instant::now() < deadline {
+        if cond().await {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    false
+}
+
+fn mock_embedder() -> Arc<dyn Embedder> {
+    Arc::new(MockEmbedder::new(8))
+}
+
+/// Build a colocated `PersistedIndex` entry rooted at `root`.
+fn entry_at(id: &str, root: &Path) -> PersistedIndex {
+    PersistedIndex {
+        id: id.to_string(),
+        root_path: root.to_path_buf(),
+        colocated: true,
+        ..Default::default()
+    }
+}
+
+/// Sabotage the colocated redb path so `CorpusStore::open` fails on every OS.
+///
+/// Why: a DIRECTORY where redb expects a plain file makes
+/// `Database::create()` return an I/O error portably, without needing an
+/// incompatible-format fixture or Unix-only permission modes. This is the
+/// same technique the #1158 regression test uses.
+/// What: creates `<root>/.trusty-search/index.redb` as a directory.
+fn sabotage_corpus_path(root: &Path) {
+    let colocated = root.join(".trusty-search");
+    std::fs::create_dir_all(&colocated).expect("create colocated dir");
+    std::fs::create_dir_all(colocated.join("index.redb")).expect("create dir at redb path");
+}
+
+/// Write `content` to `<root>/src/<name>` (creating `src/`) — a plain source
+/// save, the exact event shape that destroyed the production corpus.
+fn save_source_file(root: &Path, name: &str, content: &str) {
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("create src dir");
+    std::fs::write(src.join(name), content).expect("write source file");
+}
+
+/// Issue #4122 — THE CORRUPTION SEQUENCE.
+///
+/// Why: this is the defect verbatim. An index whose corpus never opened keeps
+/// a live watcher; a save to an unrelated file in the worktree is accepted and
+/// starts building a brand-new partial corpus on top of the unopened one.
+/// After the fix the watcher path must refuse the write and `chunk_count` must
+/// stay at 0.
+/// What: boots TWO real watch loops on two temp roots — one index sabotaged
+/// into `corpus_open_failed`, one healthy. Saves an identical file into both.
+/// The healthy index is the positive control: waiting for ITS `chunk_count` to
+/// grow proves the watcher pipeline, the debounce window, and the OS
+/// notification all work in this environment, so a flat `chunk_count` on the
+/// quarantined index is a refusal and not merely a slow watcher. Waiting for
+/// the quarantined index's refusal counter to move proves the event actually
+/// reached the guard.
+/// Test: this IS the test. Against pre-fix code the quarantined index's
+/// `chunk_count()` grows past 0 exactly as it did in production.
+#[tokio::test]
+async fn quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero() {
+    let broken_dir = tempdir().expect("tempdir");
+    let healthy_dir = tempdir().expect("tempdir");
+    let broken_root = broken_dir.path().to_path_buf();
+    let healthy_root = healthy_dir.path().to_path_buf();
+    let embedder = mock_embedder();
+
+    // Force the corpus open to fail for the first index only.
+    sabotage_corpus_path(&broken_root);
+
+    let broken = build_indexer_from_entry(&entry_at("broken-4122", &broken_root), &embedder)
+        .await
+        .expect("build broken indexer");
+    let healthy = build_indexer_from_entry(&entry_at("healthy-4122", &healthy_root), &embedder)
+        .await
+        .expect("build healthy indexer");
+
+    assert!(
+        broken.corpus_open_failed,
+        "precondition: a directory at the redb path must fail the corpus open"
+    );
+    assert!(
+        broken.is_write_quarantined(),
+        "a corpus-open failure must put the index into write quarantine (#4122)"
+    );
+    assert!(
+        !healthy.corpus_open_failed && !healthy.is_write_quarantined(),
+        "precondition: the control index must open its corpus cleanly"
+    );
+    assert_eq!(
+        broken.chunk_count(),
+        0,
+        "precondition: broken index is empty"
+    );
+
+    let broken = Arc::new(RwLock::new(broken));
+    let healthy = Arc::new(RwLock::new(healthy));
+
+    let _broken_watch = spawn_watch_loop(&broken_root, Arc::clone(&broken), IndexedFiles::new())
+        .expect("spawn broken watch loop");
+    let _healthy_watch = spawn_watch_loop(&healthy_root, Arc::clone(&healthy), IndexedFiles::new())
+        .expect("spawn healthy watch loop");
+
+    // An ordinary, unrelated save in each worktree — the production trigger.
+    let source = "pub fn quarantine_probe() -> u32 { 4122 }\n";
+    save_source_file(&broken_root, "probe.rs", source);
+    save_source_file(&healthy_root, "probe.rs", source);
+
+    // Positive control: the watcher pipeline demonstrably works here.
+    let healthy_indexed = {
+        let healthy = Arc::clone(&healthy);
+        await_condition(move || {
+            let healthy = Arc::clone(&healthy);
+            async move { healthy.read().await.chunk_count() > 0 }
+        })
+        .await
+    };
+    assert!(
+        healthy_indexed,
+        "control failed: the healthy index never picked up the save, so this \
+         environment cannot distinguish a refusal from a stalled watcher"
+    );
+
+    // Wait until the broken index has DECIDED about the event — either it
+    // refused (fixed) or it accepted and grew a corpus (the bug). Latching on
+    // "decided" rather than on "refused" keeps the headline assertion below
+    // the one that fails, so a regression reports the corruption directly
+    // instead of a missing counter bump.
+    let decided = {
+        let broken = Arc::clone(&broken);
+        await_condition(move || {
+            let broken = Arc::clone(&broken);
+            async move {
+                let broken = broken.read().await;
+                broken.refused_incremental_writes() > 0 || broken.chunk_count() > 0
+            }
+        })
+        .await
+    };
+    assert!(
+        decided,
+        "the watcher event never reached the broken index at all — the test \
+         cannot distinguish a refusal from a dropped event"
+    );
+
+    // THE ASSERTION: no partial corpus was built over the unopened one.
+    let broken = broken.read().await;
+    assert_eq!(
+        broken.chunk_count(),
+        0,
+        "#4122: a write-quarantined index must not grow a chunk corpus from \
+         watcher writes — this is the 0 → 68 → 1334 climb that destroyed \
+         duettoresearch-hackathon-tm-hackathon-01"
+    );
+    assert!(
+        broken.refused_incremental_writes() > 0,
+        "the refusal must be counted so operators can see how many saves were \
+         dropped while the index was quarantined"
+    );
+    assert!(
+        broken.is_write_quarantined(),
+        "the index must remain quarantined until a corpus open succeeds"
+    );
+}
+
+/// Issue #4122 — THE RECOVERY CASE (anti-over-refusal).
+///
+/// Why: refusing writes forever on one transient failure would trade a data
+/// loss bug for an availability bug. The incident's contrast case
+/// (`cto-duetto`) failed its open in the same boot and recovered its full
+/// 200,090-chunk corpus on the next restart — that path must keep working.
+/// This test pins BOTH halves of the boundary: refused while broken, accepted
+/// again after a successful reopen, with the original corpus still intact.
+/// What: seeds a real redb corpus with the "original" chunks and keeps the
+/// handle open, so `build_indexer_from_entry`'s open fails with
+/// `DatabaseAlreadyOpen` — a transient failure that leaves the file perfectly
+/// readable. Asserts the write is refused and the durable corpus is untouched;
+/// then releases the lock, reopens, wires the store, and asserts writes flow
+/// again while every original chunk is still present.
+/// Test: this IS the test. Against pre-fix code the refusal assertions fail
+/// (the write is accepted); a fix that quarantines permanently fails the
+/// second half.
+#[tokio::test]
+async fn successful_reopen_lifts_quarantine_and_leaves_corpus_intact() {
+    let tmp = tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    let embedder = mock_embedder();
+
+    // ── The "original" durable corpus, as it existed before the bad boot ──
+    let colocated = root.join(".trusty-search");
+    std::fs::create_dir_all(&colocated).expect("create colocated dir");
+    let redb_path = colocated.join("index.redb");
+
+    let (original_chunks, _) = chunk_ast(
+        "src/original.rs",
+        "pub fn alpha() -> u32 { 1 }\npub fn beta() -> u32 { 2 }\n",
+    );
+    assert!(
+        !original_chunks.is_empty(),
+        "precondition: the fixture must produce at least one original chunk"
+    );
+    let original_ids: Vec<String> = original_chunks.iter().map(|c| c.id.clone()).collect();
+
+    let live_handle = CorpusStore::open(&redb_path).expect("open original corpus");
+    live_handle
+        .upsert_chunks(&original_chunks)
+        .expect("seed original corpus");
+    assert_eq!(
+        live_handle.chunk_count().expect("count original corpus"),
+        original_ids.len(),
+        "precondition: the original corpus must be seeded"
+    );
+
+    // ── The bad boot: the open fails because the file is already locked ──
+    let mut indexer = build_indexer_from_entry(&entry_at("recovery-4122", &root), &embedder)
+        .await
+        .expect("build indexer");
+    assert!(
+        indexer.corpus_open_failed,
+        "precondition: a concurrently-held redb must fail the second open \
+         (DatabaseAlreadyOpen)"
+    );
+    assert!(indexer.is_write_quarantined(), "the index must quarantine");
+
+    // ── Half 1: writes are refused while quarantined ──
+    let err = indexer
+        .index_file("src/unrelated.rs", "pub fn unrelated() {}\n")
+        .await
+        .expect_err("a quarantined index must refuse an incremental write");
+    assert!(
+        err.to_string().contains("write-quarantined"),
+        "the refusal must say why it refused, got: {err}"
+    );
+    assert_eq!(
+        indexer.chunk_count(),
+        0,
+        "#4122: no partial corpus may be built while quarantined"
+    );
+    assert_eq!(
+        indexer.refused_incremental_writes(),
+        1,
+        "the refusal must be counted"
+    );
+    assert_eq!(
+        live_handle.chunk_count().expect("count original corpus"),
+        original_ids.len(),
+        "the on-disk corpus must be untouched while quarantined"
+    );
+
+    // ── The restart: the lock is released and the corpus opens cleanly ──
+    drop(live_handle);
+    let reopened = CorpusStore::open(&redb_path).expect("reopen corpus after the lock is released");
+    indexer.set_corpus_store(Arc::new(reopened));
+
+    assert!(
+        !indexer.is_write_quarantined(),
+        "#4122: a successful corpus open MUST lift the quarantine — this is \
+         the cto-duetto recovery path and it must not be broken by the fix"
+    );
+    assert_eq!(
+        indexer.refused_incremental_writes(),
+        0,
+        "the refusal counter must reset when the quarantine lifts"
+    );
+
+    // ── Half 2: writes flow again, and the original corpus survived ──
+    indexer
+        .index_file("src/after_recovery.rs", "pub fn recovered() -> u32 { 7 }\n")
+        .await
+        .expect("writes must be accepted again after a successful reopen");
+    assert!(
+        indexer.chunk_count() > 0,
+        "a recovered index must accept incremental writes again"
+    );
+
+    let corpus = indexer.corpus_store().expect("corpus store must be wired");
+    let id_refs: Vec<&str> = original_ids.iter().map(String::as_str).collect();
+    let survivors = corpus.get_chunks(&id_refs).expect("read original chunks");
+    assert_eq!(
+        survivors.len(),
+        original_ids.len(),
+        "every original chunk must survive the quarantine-and-recover cycle \
+         intact — the whole point of refusing writes was to keep them"
+    );
+}
+
+/// Issue #4122 — THE REFUSAL MUST BE OBSERVABLE.
+///
+/// Why: a silent no-op would reproduce the original sin of this bug class —
+/// the system quietly holding a state it does not report. In this workspace
+/// `warn!` does NOT persist: `trusty_common::error_capture::BugCaptureLayer`
+/// (installed by the daemon via `init_tracing_with_buffer_and_capture`) drops
+/// every event that is not `Level::ERROR`, so a WARN refusal would never
+/// reach `errors.jsonl`, `list_recent_errors`, or `tm doctor`. This test
+/// therefore asserts capture through the REAL layer rather than asserting
+/// that some log line exists.
+/// What: builds a quarantined indexer FIRST (so the loader's own
+/// corpus-open ERROR is not in the store), then installs a scoped subscriber
+/// carrying a `BugCaptureLayer` backed by a temp-file `ErrorStore`, issues one
+/// refused write, and asserts a captured record naming the index, the issue,
+/// and the refusal.
+/// Test: this IS the test. Against pre-fix code no refusal happens at all, so
+/// no record is captured.
+#[tokio::test]
+async fn quarantine_refusal_emits_error_level_diagnostic() {
+    use tracing_subscriber::layer::SubscriberExt as _;
+    use trusty_common::error_capture::{BugCaptureLayer, ErrorStore};
+
+    let tmp = tempdir().expect("tempdir");
+    let root = tmp.path().to_path_buf();
+    sabotage_corpus_path(&root);
+
+    // Built before the capture layer is installed so the only record under
+    // test is the refusal itself, not the loader's corpus-open ERROR.
+    let indexer = build_indexer_from_entry(&entry_at("observable-4122", &root), &mock_embedder())
+        .await
+        .expect("build indexer");
+    assert!(indexer.is_write_quarantined(), "precondition: quarantined");
+
+    let store = ErrorStore::with_path(Some(tmp.path().join("errors.jsonl")), 64);
+    let layer = BugCaptureLayer::new(store.clone(), env!("CARGO_PKG_VERSION"));
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    assert!(
+        store.is_empty(),
+        "precondition: the capture store starts empty"
+    );
+
+    indexer
+        .index_file("src/refused.rs", "pub fn refused() {}\n")
+        .await
+        .expect_err("the write must be refused");
+
+    let captured = store.recent_errors(16);
+    let refusal = captured
+        .iter()
+        .find(|e| e.message.contains("#4122"))
+        .unwrap_or_else(|| {
+            panic!(
+                "#4122: the refusal must be emitted at ERROR so it persists to \
+                 errors.jsonl / list_recent_errors / tm doctor; captured \
+                 records were: {captured:?}"
+            )
+        });
+    assert!(
+        refusal.message.contains("REFUSING incremental write"),
+        "the captured record must state that a write was refused, got: {}",
+        refusal.message
+    );
+    assert!(
+        refusal.message.contains("observable-4122"),
+        "the captured record must name the affected index, got: {}",
+        refusal.message
+    );
+    assert!(
+        refusal.fields.contains("src/refused.rs"),
+        "the captured record must name the refused target, got: {}",
+        refusal.fields
+    );
+}


### PR DESCRIPTION
## What broke

An index whose durable redb corpus **failed to open** at load time was left fully live — watcher included. `service::persistence_loader` set `corpus_open_failed`, wired **no** `CorpusStore`, and left the in-memory chunk map empty, but nothing stopped incremental writes. Ordinary, unrelated file saves in the worktree kept flowing in, so a **fresh, PARTIAL corpus was built and persisted over the never-opened original**, turning a recoverable outage into permanent data loss.

The incident (#4122): `duettoresearch-hackathon-tm-hackathon-01` climbed `chunk_count` `0 → 68 → 1334` from unrelated saves and came back "healthy" on the next restart holding the *wrong* corpus. The sibling `cto-duetto` hit the **identical** open failure in the same boot, took no watcher writes, and recovered all **200,090** chunks cleanly. Watcher-writes-during-failure was the sole difference between full recovery and unrecoverable loss.

## The fix

A `corpus_open_failed` index is now **write-quarantined**.

| Path | Behaviour |
|---|---|
| `CodeIndexer::index_file` | Refuses with `Err`. This is the single choke point for **every** incremental write: the file watcher (`service::watch_loop`), the boot-time catch-up reconciler (`service::reconcile`), and `POST /indexes/{id}/index-file` (`service::server::files`). |
| `watch_loop::handle_modified` | Same guard, applied earlier, so a quarantined index does not read and chunk every saved file just to discard the result. Placed **after** the exclusion filters, so excluded saves are not reported as refused writes. |
| `index_files_batch*` (full reindex) | **Not gated — and not a real recovery path.** A reindex does not clear the quarantine and does not persist anything: reindex staging is skipped when there is no `CorpusStore` wired, so the whole rebuilt corpus evaporates at the next restart. It is also not an explicit operator action — boot reconcile auto-fires one from `service::reconcile` (`trigger_full_reindex` calls at reconcile.rs:367, :379, :458) whenever the delta is unknown or too large. The only way out of quarantine is **restarting the daemon**, which re-runs `persistence_loader::build_indexer_from_entry` and, on a successful corpus open, calls `set_corpus_store` → `clear_corpus_open_failure()`. |
| `handle_removed` / `remove_chunk` | **Not gated**, and provably a no-op: with `handle_modified` guarded, `indexed_files` never gets populated, and no durable corpus is wired, so removals can only touch an empty in-memory map. |

New module `core/indexer/quarantine.rs` holds the whole surface: `is_write_quarantined()`, `refused_incremental_writes()`, `refuse_incremental_write()`, `clear_corpus_open_failure()`.

### Err, not silent `Ok(())`

The issue says "log and no-op". The refusal is a no-op on state, but it returns `Err` rather than `Ok(())` so `POST /indexes/{id}/index-file` reports **500** instead of falsely answering `"indexed": true`. Answering 200 to a refused write would be the same "report a state you do not have" failure this bug is made of. The watcher and reconciler already tolerate an `Err` from `index_file` (they log and continue/count), so nothing else changes.

## Exactly what counts as "open failed"

The quarantine predicate is `CodeIndexer::corpus_open_failed`, and **nothing else**. It has exactly two producers, both in `service::persistence_loader::build_indexer_from_entry`:

1. **`open_corpus_with_retry(&redb_path)` returned `Err`** — covers redb corruption, incompatible page format, permission denial, `DatabaseAlreadyOpen` surviving the one 50 ms retry (stale file lock from a rapid restart, or a shared-root double-open), and any plain I/O error.
2. **`persistence::corpus_redb_path_for_entry(entry)` returned `Err`** — the storage path could not even be resolved (#2847: a colocated shadow dir that cannot be created, a broken symlink, permission denied).

I deliberately did **not** try to separate "transient I/O" from "permission" from "genuinely corrupt". At the point of failure they are indistinguishable, and the two possible mistakes are wildly asymmetric:

* **Over-refuse** → an un-indexed file save, which the next reindex picks up anyway. Recoverable.
* **Under-refuse** → the corpus is overwritten. Not recoverable — that is this ticket.

So every corpus-open failure quarantines. Note the asymmetry is the *opposite* of the sibling PR in this repo where over-refusal was itself the defect; that reasoning does not transfer here, and I have not let it soften the default.

What does **not** quarantine: an index with no corpus store wired but `corpus_open_failed == false` — a legitimately empty or BM25-only index. That distinction already exists and is pinned by `build_indexer_from_entry_does_not_flag_legitimately_empty_index_as_failed` (#2847).

## How a quarantined index becomes writable again

`CodeIndexer::set_corpus_store` — the single sink every successful `CorpusStore::open` funnels through — now calls `clear_corpus_open_failure()`, which clears the flag, resets the refusal counter, and logs at WARN (the daemon's default stderr filter is `warn`, so an INFO recovery notice would not print at all). There is no separate "unquarantine" lever anyone can forget to pull: **a successful open *is* the recovery event**.

In practice that means a daemon restart, or the loader retrying, or any code path that opens the corpus and wires it. `swap_corpus_store` deliberately does not clear — it replaces an *already-wired* corpus (the reindex staging swap), which by construction cannot happen on a quarantined index (`has_corpus_store()` is `false` there).

This is the anti-over-refusal boundary and it is directly tested: a quarantine that never lifts would be a new outage, not a fix, and would have broken the `cto-duetto` path.

## Observability — why ERROR, verified for this crate

A silent no-op would reproduce the original sin of this bug class. Verified for **this** crate's logging setup, not assumed:

* `commands/start/daemon.rs` installs the capture layer via `trusty_common::init_tracing_with_buffer_and_capture`.
* `trusty_common::error_capture::layer::BugCaptureLayer::on_event` starts with `if *meta.level() != tracing::Level::ERROR { return; }`.

So `warn!` genuinely does **not** reach `errors.jsonl` / `list_recent_errors` / `tm doctor` here. The refusal logs at **ERROR**, with `index_id`, `op`, `target`, and a running `refused_writes` count, plus the recovery instructions. To avoid flooding `errors.jsonl` when a busy worktree fires thousands of events, ERROR is emitted on the **1st** refusal and every **100th** thereafter (DEBUG in between); the running total rides on every ERROR record, so no refusal is unaccounted for. `refused_incremental_writes()` exposes the count programmatically.

## Relationship to #4087

**Not fixed here, and reads are not gated.** A quarantined index still answers searches from its (empty) in-memory corpus, i.e. it still returns a silent empty `200` — that is #4087. The only interaction: because the corpus can no longer grow from watcher writes, a corpus-failed index now *reliably* serves 0 results instead of partial garbage, which makes #4087 more consistently reproducible. It does not fix or regress it.

## Tests

Three tests in `crates/trusty-search/tests/corpus_open_quarantine_4122.rs`. No `#[ignore]`, no cfg-gates. Both failure modes are induced through **production code paths** rather than by poking `corpus_open_failed` directly.

1. **`quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero`** — the corruption sequence, end to end through the real `spawn_watch_loop` + OS watcher. Boots two watch loops: one index sabotaged into `corpus_open_failed` (a directory where `index.redb` belongs), one healthy as the **positive control** — waiting for *its* `chunk_count` to grow proves the watcher pipeline, debounce window, and OS notifications work in this environment, so a flat count on the quarantined index is a refusal and not a stalled watcher. Waits are condition-based, not sleeps.
2. **`successful_reopen_lifts_quarantine_and_leaves_corpus_intact`** — the `cto-duetto` recovery case, and the anti-over-refusal guard. Seeds a real redb corpus and holds the handle open so the second open fails with `DatabaseAlreadyOpen` — a transient failure that leaves the file perfectly readable, exactly as in the incident. Asserts the write is refused and the on-disk corpus is untouched; then releases the lock, reopens, wires the store, and asserts the quarantine lifts, the counter resets, writes flow again, **and every original chunk is still present**.
3. **`quarantine_refusal_emits_error_level_diagnostic`** — asserts capture through the **real** `BugCaptureLayer` + `ErrorStore`, not merely that some log line was emitted. The indexer is built *before* the capture layer is installed so the only record under test is the refusal itself.

### Failing before, passing after

Verified by temporarily neutralising both guards (`refuse_incremental_write` → always `false`, `clear_corpus_open_failure` → no-op) while keeping the API, so the pre-fix behaviour is reproduced exactly:

```
running 3 tests
test quarantine_refusal_emits_error_level_diagnostic ... FAILED
test successful_reopen_lifts_quarantine_and_leaves_corpus_intact ... FAILED
test quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero ... FAILED

---- quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero stdout ----
assertion `left == right` failed: #4122: a write-quarantined index must not grow a chunk
corpus from watcher writes — this is the 0 → 68 → 1334 climb that destroyed
duettoresearch-hackathon-tm-hackathon-01
  left: 1
 right: 0

---- successful_reopen_lifts_quarantine_and_leaves_corpus_intact stdout ----
a quarantined index must refuse an incremental write: ()

---- quarantine_refusal_emits_error_level_diagnostic stdout ----
the write must be refused: ()

test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 0 filtered out
```

After the fix:

```
running 3 tests
test quarantine_refusal_emits_error_level_diagnostic ... ok
test successful_reopen_lifts_quarantine_and_leaves_corpus_intact ... ok
test quarantined_index_refuses_watcher_write_and_chunk_count_stays_zero ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.11s
```

## Gate

`cargo test -p trusty-search --no-fail-fast` (all targets, **not** `--lib`): **`CARGO_EXIT=0`**, headline `test result: ok. 1366 passed; 0 failed; 1 ignored`, plus `319 passed` and every integration target green.

`cargo fmt --check`: clean. `scripts/check_line_cap.sh`: `7 allowlisted, 0 violations — OK.`

**Clippy substitution, disclosed:** a bare `cargo clippy --workspace --all-targets` hits the pre-existing Tauri `frontendDist` panic on `trusty-mpm-gui` / `trusty-code-gui`, so I ran **CI's own exclusion list, verbatim from `ci.yml` line 164** — no wider:

```
SKIP_UI_BUILD=1 cargo clippy --workspace --all-targets \
  --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
```

Result: clean (one real finding, `manual_is_multiple_of` in the new module, fixed).

**Two pre-existing failures in `trusty-agents`, not mine** — both proven by re-running with my changes **stashed** on clean `origin/main` (`5bf231b9`):

* `tests/api_e2e` (4 tests, "api server did not become healthy within 5s") — reproduces identically at baseline: `test result: FAILED. 0 passed; 4 failed` / `BASELINE_API_E2E_EXIT=101`.
* `tools::python_skill::tests::execute_dispatches_to_python_and_parses_json` — a transient uv/Python-interpreter probe failure under heavy machine load; passes on re-run (`8 passed; 0 failed`).

Neither touches `trusty-search`.

Closes #4122

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

