### PR TITLE
feat(trusty-agents): L0-only GitHub PR/CI inspection tool surface (#4170)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -47,6 +47,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **A read-only GitHub PR/CI inspection surface granted to the L0
+  orchestration tier ONLY** (#4170, epic #4167). Five tools in a new
+  `tools::gh_tools` — `gh_pr_list`, `gh_pr_view`, `gh_pr_checks`,
+  `gh_run_list`, `gh_run_view` — returning `gh`'s own output verbatim rather
+  than re-shaped JSON. **No mutating capability is granted**: there is no
+  `pr create`/`merge`/`edit`/`comment`/`close`, no `run rerun`, no
+  `workflow run`, and a test fails the build if a mutating verb ever appears
+  in a tool's name or description. The tier gate lives INSIDE the factory
+  (which returns an empty vector for any tier but `L0Orchestration`), so a
+  future call site that forgets to guard its loop still registers nothing,
+  and an L1 persona declaring `gh_pr_view`, `gh_*` or `*` matches nothing and
+  is granted nothing. Registered on BOTH assistant dispatch paths — the
+  `--direct`/`--agent` subprocess path and the persona-chat path — since
+  registering in only one is the divergence #3745 item C had to fix.
+  Every LLM-supplied operand is passed as argv, never through a shell, and
+  must be non-empty, ≤200 chars, free of a leading `-`, and drawn from
+  `[A-Za-z0-9._/#:@-]`; `repo` must be exactly `owner/repo`, `state`/`status`
+  are closed enums, and `limit` clamps to 1–100. `gh pr checks` reports check
+  state through its exit code, so a non-zero exit is returned as normal
+  output rather than an error — otherwise the most useful CI primitive would
+  report failure on exactly the state an orchestrator calls it to observe.
 - **`l0_shell_exec` — a shell/build/test executor granted to the L0
   orchestration tier ONLY** (#4173, epic #4167). `tools::l0_exec` returns an
   empty tool vector for `AgentTier::L1Standard`, so an L1 persona never has the

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1990,6 +1990,21 @@ fn bundled_assistant_personas_resolve_l0_and_gain_nothing() {
                          review it deliberately.",
                         crate::tools::l0_exec::L0_SHELL_EXEC
                     );
+                    // #4170: and for the L0-only GitHub PR/CI surface. Same
+                    // glob reasoning; every name checked, so a tool added to
+                    // `GH_TOOL_NAMES` is covered without editing this test.
+                    for gh in crate::tools::gh_tools::GH_TOOL_NAMES {
+                        assert!(
+                            !crate::ctrl::pm_task::match_any_glob(
+                                gh,
+                                std::slice::from_ref(granted)
+                            ),
+                            "'{name}' declares '{granted}' in [tools].allow, which matches \
+                             the L0-only GitHub tool '{gh}' — as an L0 persona it would \
+                             hold it. That is a capability change, not a side effect: \
+                             review it deliberately."
+                        );
+                    }
                 }
             }
         } else {

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -223,14 +223,26 @@ pub async fn run_pm_task_with_persona(
                     }
                 }
             }
-            if let Ok(repo) = crate::git::GitRepo::open(
-                &std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-            ) {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            if let Ok(repo) = crate::git::GitRepo::open(&cwd) {
                 for tool in crate::tools::git_tools::git_tools(repo.root.clone()) {
                     registry.register(tool);
                 }
             }
             register_ticketing_tools(&mut registry).await;
+            // #4170 (epic #4167): the L0-only GitHub PR/CI inspection surface.
+            // Registered on BOTH assistant dispatch paths — this one and
+            // `runtime::tool_registry::build_assistant_tier_registry` — because
+            // registering in only one is exactly the divergence #3745 item C
+            // had to fix for izzie's tools. Unlike `delegator_tier` below, this
+            // reads `persona_cfg.agent.tier()` DIRECTLY rather than through the
+            // `role == "assistant"` branch: this is a capability grant, not a
+            // delegation edge, so it must fail closed for every persona whose
+            // tier does not explicitly resolve to L0 — including one carrying
+            // an unexpected `role`. `gh_tools::register` denies any non-L0
+            // tier, so an L1 persona declaring `gh_*` finds nothing in
+            // `all_names` for `filter_persona_tool_names` to keep.
+            crate::tools::gh_tools::register(&mut registry, persona_cfg.agent.tier(), project_path);
 
             // #3285: tool parity with the session path
             // (`run_pm_task_with_history`) — delegation, CTRL

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -567,6 +567,19 @@ pub(super) fn build_registry_for_agent(
 /// `l0_grant_fails_closed_for_malformed_tier_declaration`,
 /// `tainted_delegation_cannot_widen_into_the_l0_grant`,
 /// `l1_cannot_reach_the_l0_grant_through_an_untiered_intermediary`.
+///
+/// `delegator_tier` ALSO decides whether the GitHub PR/CI inspection tools
+/// (#4170, epic #4167) are registered at all: `crate::tools::gh_tools::gh_tools`
+/// yields them only for `AgentTier::L0Orchestration` and an empty vector
+/// otherwise — the same tier-gated-at-construction shape #4171 uses for the
+/// session-state surface above. Registration is the enforcement boundary for
+/// that grant — see `tools::gh_tools`'s module doc comment.
+/// Test: `l1_persona_declaring_gh_tools_is_granted_none_through_the_real_path`,
+/// `l0_persona_declaring_gh_tools_is_granted_them_through_the_real_path`,
+/// `unrecognized_tier_declaration_denies_gh_tools_through_the_real_path`,
+/// `gh_tools_follow_the_kind_derivation_when_no_tier_is_declared`,
+/// `assistant_tier_registry_omits_gh_tools_for_l1`,
+/// `assistant_tier_registry_includes_gh_tools_for_l0`.
 pub(crate) fn build_assistant_tier_registry(
     delegator_allow: Option<&[String]>,
     delegator_tier: crate::agents::AgentTier,
@@ -582,6 +595,14 @@ pub(crate) fn build_assistant_tier_registry(
     }
 
     reg.register(Arc::new(BraveSearchTool::from_env()));
+
+    // #4170 (epic #4167): the L0-only GitHub PR/CI inspection surface. The
+    // tier gate is INSIDE `gh_tools`, which returns an empty vector for any
+    // tier other than `AgentTier::L0Orchestration` — so this loop is a no-op
+    // for every L1 persona, and an L1 persona declaring `gh_pr_view` (or
+    // `gh_*`, or `*`) in `[tools].allow` matches nothing in this registry and
+    // is granted nothing by `scope_assistant_allowed_tools` below.
+    crate::tools::gh_tools::register(&mut reg, delegator_tier, &cwd);
 
     // #3555 delegate-resolve follow-up: previously this was a single
     // hand-rolled `cwd.join(".trusty-agents").join("agents")` — invisible to

--- a/crates/trusty-agents/src/runtime/tool_registry_tests.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry_tests.rs
@@ -1744,3 +1744,236 @@ async fn assistant_tier_registry_delegation_fails_closed_without_a_whitelist() {
         result.content()
     );
 }
+
+// --- #4170 (epic #4167): the L0-only GitHub PR/CI surface, proven through the
+// REAL registry-construction path ---
+//
+// Why these are here and not only in `tools::gh_tools::tests`: the factory's
+// own tier check is easy to prove in isolation, and equally easy to render
+// irrelevant by a call site that never consults it. These tests therefore
+// exercise the SAME chain `run_subagent` executes for a persona —
+// `AgentConfig::by_name` (via a `TAGENT_CONFIG_DIR` override, exactly as
+// `deployed_assistant_config_survives_scoping_with_delegate_to_agent` does)
+// -> `cfg.agent.tier()` -> `build_registry_for_agent` -> the REAL
+// `scope_assistant_allowed_tools` glob translation — so the assertion is
+// about what a persona ACTUALLY receives, not about a helper's return value.
+
+/// Write a persona TOML whose `[tools].allow` asks for the whole GitHub
+/// surface plus the widest possible wildcard, and resolve it through the real
+/// loader + registry + scoping chain.
+///
+/// Why: `allow = ["*", "gh_*", <every literal name>]` is the most generous
+/// declaration a persona author could possibly write. If the tier gate holds
+/// against THAT, it holds against anything narrower — and using the literal
+/// names from `GH_TOOL_NAMES` means a tool added to the factory without a tier
+/// check is caught here rather than slipping through a stale hand-copied list.
+/// What: Returns the tool names the persona is actually granted.
+/// Test: used by `l1_persona_declaring_gh_tools_is_granted_none_through_the_real_path`,
+/// `l0_persona_declaring_gh_tools_is_granted_them_through_the_real_path`,
+/// `unrecognized_tier_declaration_denies_gh_tools_through_the_real_path`,
+/// `gh_tools_follow_the_kind_derivation_when_no_tier_is_declared`.
+fn granted_tools_for_persona_with_tier(tier_line: &str) -> Vec<String> {
+    use crate::agents::AgentConfig;
+    use crate::agents::tests::loading::ENV_LOCK;
+
+    let _guard = ENV_LOCK.blocking_lock();
+    let tmp = tempfile::tempdir().unwrap();
+    let allow = crate::tools::gh_tools::GH_TOOL_NAMES
+        .iter()
+        .map(|n| format!("\"{n}\""))
+        .collect::<Vec<_>>()
+        .join(", ");
+    std::fs::write(
+        tmp.path().join("gh-probe.toml"),
+        format!(
+            "[agent]\nname = \"gh-probe\"\nrole = \"assistant\"\n{tier_line}\
+             model = \"m\"\ndescription = \"d\"\n\n[llm]\ntemperature = 0.2\n\
+             max_tokens = 1024\n\n[tools]\nallow = [\"*\", \"gh_*\", {allow}]\n\n\
+             [system_prompt]\ncontent = \"x\"\n"
+        ),
+    )
+    .unwrap();
+
+    // SAFETY: guarded by ENV_LOCK, the same convention every other
+    // TAGENT_CONFIG_DIR mutator in this crate follows.
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", tmp.path());
+    }
+    let cfg = AgentConfig::by_name("gh-probe");
+    let cfg = cfg.expect("probe persona must resolve via the real loader");
+    let reg = build_registry_for_agent(
+        "gh-probe",
+        &cfg.agent.role,
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        cfg.tools.allow.as_deref(),
+        cfg.agent.tier(),
+        // The same expression `run_subagent` passes (#4314's editable
+        // reachable-set whitelist) — this probe declares no `[subagents]`
+        // section, so it resolves to `None` and reaches nothing, which is
+        // irrelevant to the gh surface but keeps the call on the real path.
+        cfg.subagents.delegate_allowed.as_deref(),
+    );
+    // SAFETY: see above.
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+    }
+    let reg = reg.expect("an assistant-role persona always gets a registry");
+    scope_assistant_allowed_tools(
+        true,
+        cfg.tools.allowed.clone(),
+        cfg.tools.allow.as_deref(),
+        Some(&reg),
+    )
+    .unwrap_or_default()
+}
+
+#[test]
+fn l1_persona_declaring_gh_tools_is_granted_none_through_the_real_path() {
+    // THE requirement: grantable to L0 only, enforced in code. This persona
+    // declares every GitHub tool by name AND `gh_*` AND `*`, and still gets
+    // none of them, because the registry it is scoped against never contained
+    // them.
+    let kept = granted_tools_for_persona_with_tier("tier = \"l1\"\n");
+    assert!(
+        !kept.is_empty(),
+        "sanity: an `allow = [\"*\"]` persona must be granted SOMETHING, else \
+         this test would pass vacuously"
+    );
+    for name in crate::tools::gh_tools::GH_TOOL_NAMES {
+        assert!(
+            !kept.iter().any(|k| k == name),
+            "an L1 persona obtained {name} despite the tier gate; granted: {kept:?}"
+        );
+    }
+}
+
+#[test]
+fn l0_persona_declaring_gh_tools_is_granted_them_through_the_real_path() {
+    // The counter-test that keeps the one above honest: the identical chain
+    // with `tier = "l0"` DOES yield the surface, so the L1 denial is the tier
+    // gate at work and not a registration bug affecting everyone.
+    let kept = granted_tools_for_persona_with_tier("tier = \"l0\"\n");
+    for name in crate::tools::gh_tools::GH_TOOL_NAMES {
+        assert!(
+            kept.iter().any(|k| k == name),
+            "an L0 persona must receive {name}; granted: {kept:?}"
+        );
+    }
+}
+
+#[test]
+fn unrecognized_tier_declaration_denies_gh_tools_through_the_real_path() {
+    // Fail closed: an unrecognized `tier =` value resolves to `L1Standard` via
+    // `AgentInfo::tier()` (#4200) and must therefore deny — never "grant
+    // because we could not tell", and never fall THROUGH to the assistant-kind
+    // derivation ADR-0024 decision 3 (PR #4296) added. This probe persona is
+    // assistant-kind, so a fall-through would show up here as a grant.
+    for tier_line in [
+        "tier = \"L0-ish\"\n",
+        "tier = \"not-l0\"\n",
+        "tier = \"bogus\"\n",
+        "tier = \"l1\"\n",
+    ] {
+        let kept = granted_tools_for_persona_with_tier(tier_line);
+        for name in crate::tools::gh_tools::GH_TOOL_NAMES {
+            assert!(
+                !kept.iter().any(|k| k == name),
+                "tier line {tier_line:?} granted {name}; an unrecognized tier must deny"
+            );
+        }
+    }
+}
+
+/// The DERIVED case, after ADR-0024 decision 3 (PR #4296, on `main`): with no
+/// usable `tier =` declaration the tier is a function of the agent's KIND.
+///
+/// Why this lives here: #4170 was written when an absent tier meant L1, so the
+/// spellings below used to be deny cases. They are now GRANT cases for
+/// assistant-kind — not because this PR widened anything (`gh_tools` still
+/// returns an empty vector for every tier but L0), but because `main` changed
+/// which personas are L0. Pinning it at the grant site means a future change to
+/// that population fails here instead of silently redefining this surface's
+/// reach. The tools remain read-only in every case — see
+/// `gh_surface_registers_no_mutating_tool_even_for_l0`.
+#[test]
+fn gh_tools_follow_the_kind_derivation_when_no_tier_is_declared() {
+    for tier_line in ["", "tier = \"\"\n", "tier = \"   \"\n"] {
+        let kept = granted_tools_for_persona_with_tier(tier_line);
+        for name in crate::tools::gh_tools::GH_TOOL_NAMES {
+            assert!(
+                kept.iter().any(|k| k == name),
+                "tier line {tier_line:?} on an assistant-kind persona derives L0 \
+                 (ADR-0024 decision 3) and must grant {name}; granted: {kept:?}"
+            );
+        }
+    }
+
+    // And the sub-agent kinds it must NOT reach. A researcher is L1 by
+    // derivation, and `build_registry_for_agent` does not even route it into
+    // the assistant-tier registry, so the surface is absent twice over.
+    let reg = build_registry_for_agent(
+        "research-agent",
+        "researcher",
+        None,
+        None,
+        empty_skill_registry(),
+        empty_tag_registry(),
+        None,
+        crate::agents::AgentTier::L1Standard,
+        None,
+    )
+    .expect("sub-agent builds a registry");
+    for name in crate::tools::gh_tools::GH_TOOL_NAMES {
+        assert!(
+            !reg.contains(name),
+            "a sub-agent kind must never hold {name}"
+        );
+    }
+}
+
+#[test]
+fn assistant_tier_registry_omits_gh_tools_for_l1() {
+    // The narrower registration-level statement, on the function the
+    // `--direct`/`--agent` subprocess path calls.
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L1Standard, None);
+    assert!(
+        reg.contains("git_log") || reg.contains("web_search"),
+        "sanity: the L1 registry is not empty"
+    );
+    for name in crate::tools::gh_tools::GH_TOOL_NAMES {
+        assert!(!reg.contains(name), "{name} must not be registered for L1");
+    }
+}
+
+#[test]
+fn assistant_tier_registry_includes_gh_tools_for_l0() {
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L0Orchestration, None);
+    for name in crate::tools::gh_tools::GH_TOOL_NAMES {
+        assert!(reg.contains(name), "{name} must be registered for L0");
+    }
+}
+
+#[test]
+fn gh_surface_registers_no_mutating_tool_even_for_l0() {
+    // #4170 forbids quietly granting merge power. Asserted against the real
+    // L0 registry rather than the factory, so a future edit that adds a
+    // mutating tool at THIS call site is caught too.
+    let reg = build_assistant_tier_registry(None, crate::agents::AgentTier::L0Orchestration, None);
+    for name in [
+        "gh_pr_merge",
+        "gh_pr_create",
+        "gh_pr_comment",
+        "gh_pr_edit",
+        "gh_pr_close",
+        "gh_workflow_run",
+        "gh_run_rerun",
+    ] {
+        assert!(
+            !reg.contains(name),
+            "{name} is a mutating capability and must not be registered"
+        );
+    }
+}

--- a/crates/trusty-agents/src/skills/manifest/builtin/github.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/github.rs
@@ -1,0 +1,80 @@
+//! Built-in skills for the L0-only GitHub PR/CI inspection surface (#4170).
+//!
+//! Why: The owner's ruling is one skill per tool — *"There can be other skills
+//! without tools, but each tool gets its own skill"* — and
+//! `every_tool_declared_in_source_has_a_skill` enforces it. These five rows
+//! wrap `crate::tools::gh_tools`. They live in their OWN family file rather
+//! than being appended to `ops.rs` so the GitHub surface can grow (or a
+//! mutating tier be added later under a separate decision) without touching a
+//! table three other tool families already share.
+//!
+//! A card here does NOT imply reachability: `gh_tools` refuses to construct
+//! these executors for any tier other than L0 orchestration, so an L1 persona
+//! naming one of these skill ids resolves to a tool that its registry never
+//! contains and is granted nothing. See `tools::gh_tools`'s module doc.
+//! What: A `const` table of one-tool [`SkillDef`] rows, all `Action` kind —
+//! these are things a user asks for by name ("check PR 4200's CI"), not
+//! internal plumbing to collapse away like the `System` rows in `ops.rs`.
+//! Test: `super::super::tests::every_tool_declared_in_source_has_a_skill`,
+//! `crate::tools::gh_tools::tests::every_gh_tool_has_a_skill_in_the_builtin_catalog`.
+
+use super::super::{ProviderReq, SkillDef, SkillKind::Action, tool_skill};
+
+/// The authenticated GitHub CLI these five skills all shell out to.
+///
+/// Why: #3945's honesty discipline — a PR-checks card must not imply it works
+/// when `gh` was never authenticated. `env_var` is `None` because `gh auth
+/// login` stores its grant in the system keyring, not an environment variable:
+/// there is nothing this process can probe, so the status stays unclaimed
+/// rather than being guessed. (`GH_TOKEN` is an alternative `gh` honours, but
+/// its ABSENCE says nothing about whether `gh` is authenticated, so reporting
+/// on it would be worse than reporting nothing.)
+pub(super) static GH_CLI: ProviderReq = ProviderReq {
+    provider: "GitHub CLI",
+    requirement: "An installed, authenticated GitHub CLI (`gh auth login`). \
+                  Not verified by this endpoint.",
+    env_var: None,
+};
+
+pub(super) static TABLE: &[SkillDef] = &[
+    tool_skill(
+        "github-pr-list",
+        "Browse Pull Requests",
+        "List a repository's pull requests by state or author.",
+        "gh_pr_list",
+        Action,
+        Some(&GH_CLI),
+    ),
+    tool_skill(
+        "github-pr-read",
+        "Read a Pull Request",
+        "Show one pull request's title, state, description and metadata.",
+        "gh_pr_view",
+        Action,
+        Some(&GH_CLI),
+    ),
+    tool_skill(
+        "github-pr-checks",
+        "Pull Request Check Status",
+        "Report every CI check run on one pull request, including red and pending ones.",
+        "gh_pr_checks",
+        Action,
+        Some(&GH_CLI),
+    ),
+    tool_skill(
+        "github-run-list",
+        "Browse CI Runs",
+        "List recent GitHub Actions runs for a repository, branch or workflow.",
+        "gh_run_list",
+        Action,
+        Some(&GH_CLI),
+    ),
+    tool_skill(
+        "github-run-read",
+        "Read a CI Run",
+        "Show one GitHub Actions run's jobs, their conclusions, and the failing steps' logs.",
+        "gh_run_view",
+        Action,
+        Some(&GH_CLI),
+    ),
+];

--- a/crates/trusty-agents/src/skills/manifest/builtin/mod.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/mod.rs
@@ -17,6 +17,8 @@ mod core;
 // #4022: the bundling tier — declared last so leaf rows are always inserted
 // before the bundles that name them.
 mod functions;
+// #4170 (epic #4167): the L0-only GitHub PR/CI surface.
+mod github;
 mod gworkspace;
 mod knowledge;
 mod ops;
@@ -70,6 +72,7 @@ pub fn all() -> Vec<&'static SkillDef> {
         .iter()
         .chain(ops::TABLE)
         .chain(knowledge::TABLE)
+        .chain(github::TABLE)
         .chain(gworkspace::TABLE)
         .chain(platform::TABLE)
         .chain(prose::TABLE)

--- a/crates/trusty-agents/src/tools/gh_tools/ci.rs
+++ b/crates/trusty-agents/src/tools/gh_tools/ci.rs
@@ -1,0 +1,186 @@
+//! Read-only GitHub Actions inspection tools: `gh_run_list`, `gh_run_view`
+//! (#4170).
+//!
+//! Why: `gh pr checks` answers "are this PR's checks green"; it does NOT
+//! answer "which job failed and why", nor "what has CI been doing on main".
+//! An orchestration turn reconciling a snapshot against live CI state needs
+//! both — the per-PR aggregate AND the run/job drill-down. `actions_status`
+//! (`tools::native_ticketing::actions`) is not a substitute: it requires a
+//! configured `TicketingClient`, takes a workflow FILE name rather than a run
+//! id, and returns re-shaped JSON rather than gh's own output.
+//! What: Two `ToolExecutor`s over `gh run list` / `gh run view`, argv built
+//! from validated operands only. Deliberately NOT included: `gh run watch`
+//! (blocks for the lifetime of a CI run, which a bounded tool turn cannot
+//! absorb — poll `gh_run_view` instead) and `gh run rerun`/`gh workflow run`
+//! (mutating; see this module's parent doc comment).
+//! Test: `gh_ci_tools_are_read_only_subcommands`,
+//! `gh_run_view_rejects_a_flag_shaped_run_id`,
+//! `gh_run_list_rejects_an_unknown_status`.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+use super::helpers::{enum_arg, fn_schema, limit_arg, plain_arg, repo_arg, run_gh};
+
+/// The `--status` values `gh run list` accepts.
+const RUN_STATUSES: &[&str] = &[
+    "queued",
+    "completed",
+    "in_progress",
+    "requested",
+    "waiting",
+    "pending",
+    "action_required",
+    "cancelled",
+    "failure",
+    "neutral",
+    "skipped",
+    "stale",
+    "startup_failure",
+    "success",
+    "timed_out",
+];
+
+/// `gh run list` — enumerate GitHub Actions runs.
+pub(super) struct GhRunListTool {
+    pub(super) root: PathBuf,
+}
+
+#[async_trait]
+impl ToolExecutor for GhRunListTool {
+    fn name(&self) -> &str {
+        "gh_run_list"
+    }
+    fn schema(&self) -> Value {
+        fn_schema(
+            "gh_run_list",
+            "List recent GitHub Actions workflow runs via the GitHub CLI (read-only). \
+             Returns gh's own table output verbatim.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "repo": {
+                        "type": "string",
+                        "description": "Optional 'owner/repo' to target. Omit to use the \
+                                        repository of the current working directory."
+                    },
+                    "branch": {
+                        "type": "string",
+                        "description": "Optional branch name to filter runs by."
+                    },
+                    "workflow": {
+                        "type": "string",
+                        "description": "Optional workflow file name (e.g. 'ci.yml') to \
+                                        filter runs by."
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": RUN_STATUSES,
+                        "description": "Optional run status to filter by."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max runs to return, 1-100 (default 20)."
+                    }
+                },
+                "required": [],
+                "additionalProperties": false
+            }),
+        )
+    }
+    async fn execute(&self, args: Value) -> ToolResult {
+        let mut argv = vec!["run".to_string(), "list".to_string()];
+        if let Some(repo) = args.get("repo").and_then(Value::as_str) {
+            match repo_arg(repo) {
+                Ok(v) => argv.extend(["--repo".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        if let Some(branch) = args.get("branch").and_then(Value::as_str) {
+            match plain_arg("branch", branch) {
+                Ok(v) => argv.extend(["--branch".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        if let Some(workflow) = args.get("workflow").and_then(Value::as_str) {
+            match plain_arg("workflow", workflow) {
+                Ok(v) => argv.extend(["--workflow".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        if let Some(status) = args.get("status").and_then(Value::as_str) {
+            match enum_arg("status", status, RUN_STATUSES) {
+                Ok(v) => argv.extend(["--status".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        let limit = limit_arg(args.get("limit").and_then(Value::as_u64), 20);
+        argv.extend(["--limit".to_string(), limit.to_string()]);
+        run_gh(&self.root, &argv, false).await
+    }
+}
+
+/// `gh run view` — read one Actions run, optionally a failing job's log.
+pub(super) struct GhRunViewTool {
+    pub(super) root: PathBuf,
+}
+
+#[async_trait]
+impl ToolExecutor for GhRunViewTool {
+    fn name(&self) -> &str {
+        "gh_run_view"
+    }
+    fn schema(&self) -> Value {
+        fn_schema(
+            "gh_run_view",
+            "Show one GitHub Actions run's jobs and their conclusions via the GitHub \
+             CLI (read-only). Set log_failed to also print the failed steps' logs. \
+             Returns gh's own output verbatim.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "run_id": {
+                        "type": "string",
+                        "description": "The workflow run id (as shown by gh_run_list)."
+                    },
+                    "repo": {
+                        "type": "string",
+                        "description": "Optional 'owner/repo' to target. Omit to use the \
+                                        repository of the current working directory."
+                    },
+                    "log_failed": {
+                        "type": "boolean",
+                        "description": "Include the log output of failed steps only \
+                                        (default false)."
+                    }
+                },
+                "required": ["run_id"],
+                "additionalProperties": false
+            }),
+        )
+    }
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(run_id) = args.get("run_id").and_then(Value::as_str) else {
+            return ToolResult::err("'run_id' is required");
+        };
+        let run_id = match plain_arg("run_id", run_id) {
+            Ok(v) => v,
+            Err(e) => return ToolResult::err(e),
+        };
+        let mut argv = vec!["run".to_string(), "view".to_string(), run_id];
+        if let Some(repo) = args.get("repo").and_then(Value::as_str) {
+            match repo_arg(repo) {
+                Ok(v) => argv.extend(["--repo".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        if args.get("log_failed").and_then(Value::as_bool) == Some(true) {
+            argv.push("--log-failed".to_string());
+        }
+        run_gh(&self.root, &argv, false).await
+    }
+}

--- a/crates/trusty-agents/src/tools/gh_tools/helpers.rs
+++ b/crates/trusty-agents/src/tools/gh_tools/helpers.rs
@@ -1,0 +1,237 @@
+//! Shared `gh` invocation, schema, and argument-validation helpers (#4170).
+//!
+//! Why: Every tool in this module shells out to the SAME binary with a FIXED
+//! subcommand and a handful of LLM-supplied operands. Two properties have to
+//! hold identically for all of them, so they live here once rather than being
+//! re-derived per tool: (1) no operand the model produces may ever be read by
+//! `gh` as a FLAG or smuggle a second argument — `gh` has no shell involved
+//! (argv is passed directly), so metacharacter escaping is a non-issue, but a
+//! value like `--json` or `-R attacker/repo` absolutely would be honoured; and
+//! (2) `gh`'s absence or a missing `gh auth login` must degrade into a legible
+//! tool error the model can act on, never a panic.
+//! What: [`fn_schema`] (the OpenAI envelope, mirroring
+//! `git_tools::helpers::fn_schema`), [`plain_arg`] / [`repo_arg`] / [`limit_arg`]
+//! / [`enum_arg`] (fail-closed operand validation), and [`run_gh`] (argv-only
+//! subprocess execution rooted at a working directory).
+//! Test: `plain_arg_rejects_flag_shaped_values`,
+//! `plain_arg_rejects_whitespace_and_control_characters`,
+//! `repo_arg_requires_owner_slash_repo`, `limit_arg_clamps_to_the_supported_range`,
+//! `enum_arg_rejects_unlisted_values`.
+
+use std::path::Path;
+
+use serde_json::{Value, json};
+use tokio::process::Command;
+
+/// Maximum accepted length for any single LLM-supplied operand.
+///
+/// Why: A branch name or PR selector is short. An unbounded string reaching
+/// argv is a denial-of-service shape (and an obvious sign the model is
+/// confused), so it is refused rather than forwarded.
+const MAX_ARG_LEN: usize = 200;
+
+/// Build an OpenAI-style function schema envelope.
+///
+/// Why: Identical in shape to `git_tools::helpers::fn_schema`; duplicated
+/// rather than shared because that one is `pub(super)` to the git module and
+/// widening its visibility to reach a second tool family would couple the two
+/// surfaces for three lines of JSON.
+/// What: Returns `{type, function:{name, description, parameters}}`.
+/// Test: `gh_pr_view_schema_has_the_expected_envelope`.
+pub(super) fn fn_schema(name: &str, description: &str, params: Value) -> Value {
+    json!({
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": params
+        }
+    })
+}
+
+/// Validate one LLM-supplied operand destined for `gh`'s argv.
+///
+/// Why: THE flag-injection gate. `gh` parses its own argv, so an operand of
+/// `--repo other/repo`, `-q .`, or `--template {{...}}` would be honoured as
+/// an option rather than the PR/branch/run the model meant to name. Because
+/// L0 is deliberately NOT sandboxed (epic #4167), a tool in this module is
+/// the last line of defence between model output and a real GitHub API call:
+/// it must refuse anything ambiguous instead of forwarding it and hoping.
+/// What: Accepts a non-empty value of at most [`MAX_ARG_LEN`] chars drawn from
+/// `[A-Za-z0-9._/#:@-]` that does NOT begin with `-`. Everything else — a
+/// leading dash, whitespace, control characters, quotes, `$`, `;`, `&`, `|`,
+/// non-ASCII — is rejected with a message naming the offending field.
+/// Test: `plain_arg_rejects_flag_shaped_values`,
+/// `plain_arg_rejects_whitespace_and_control_characters`,
+/// `plain_arg_accepts_ordinary_selectors`.
+pub(super) fn plain_arg(field: &str, raw: &str) -> Result<String, String> {
+    if raw.is_empty() {
+        return Err(format!("'{field}' must not be empty"));
+    }
+    if raw.len() > MAX_ARG_LEN {
+        return Err(format!(
+            "'{field}' is too long ({} chars, max {MAX_ARG_LEN})",
+            raw.len()
+        ));
+    }
+    if raw.starts_with('-') {
+        return Err(format!(
+            "'{field}' must not start with '-' (it would be parsed by gh as an option, not a value)"
+        ));
+    }
+    let ok = raw
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '/' | '#' | ':' | '@' | '-'));
+    if !ok {
+        return Err(format!(
+            "'{field}' may only contain letters, digits, and . _ / # : @ - \
+             (got {raw:?})"
+        ));
+    }
+    Ok(raw.to_string())
+}
+
+/// Validate an `owner/repo` selector.
+///
+/// Why: `--repo` is how an orchestration persona reaches a repository other
+/// than the one it happens to be rooted in — the cross-project half of the L0
+/// grant. It is also the single operand whose shape `gh` will not check for us
+/// in a useful way, so a malformed value produces a confusing remote error
+/// instead of an actionable one.
+/// What: Requires exactly one `/`, with a non-empty [`plain_arg`]-clean owner
+/// and repo on either side.
+/// Test: `repo_arg_requires_owner_slash_repo`.
+pub(super) fn repo_arg(raw: &str) -> Result<String, String> {
+    let value = plain_arg("repo", raw)?;
+    let mut parts = value.split('/');
+    let (Some(owner), Some(repo), None) = (parts.next(), parts.next(), parts.next()) else {
+        return Err(format!("'repo' must be exactly 'owner/repo' (got {raw:?})"));
+    };
+    if owner.is_empty() || repo.is_empty() {
+        return Err(format!("'repo' must be exactly 'owner/repo' (got {raw:?})"));
+    }
+    Ok(value)
+}
+
+/// Resolve and clamp a result-count operand.
+///
+/// Why: `gh`'s `--limit` accepts arbitrarily large values; an LLM asking for
+/// 100000 PRs would page the API for minutes and produce output no context
+/// window can hold. Clamping (rather than erroring) keeps the tool usable when
+/// the model over-asks.
+/// What: `None` -> `default`; otherwise clamped to `1..=100`.
+/// Test: `limit_arg_clamps_to_the_supported_range`.
+pub(super) fn limit_arg(raw: Option<u64>, default: u64) -> u64 {
+    raw.unwrap_or(default).clamp(1, 100)
+}
+
+/// Validate an operand against a closed set of accepted values.
+///
+/// Why: `--state`/`--status` operands map onto `gh`'s own enums. Passing an
+/// unrecognized value through would make `gh` fail with a message about flags
+/// the model never saw; rejecting it here names the accepted set instead.
+/// What: Case-sensitive membership test against `accepted`.
+/// Test: `enum_arg_rejects_unlisted_values`.
+pub(super) fn enum_arg(field: &str, raw: &str, accepted: &[&str]) -> Result<String, String> {
+    if accepted.contains(&raw) {
+        return Ok(raw.to_string());
+    }
+    Err(format!(
+        "'{field}' must be one of {} (got {raw:?})",
+        accepted.join(", ")
+    ))
+}
+
+/// Guidance appended when the `gh` binary cannot be spawned at all.
+const GH_MISSING_HINT: &str =
+    "The GitHub CLI must be installed and authenticated (`gh auth login`) for this tool to work.";
+
+/// Run `gh` with a fully pre-validated argv and return its output verbatim.
+///
+/// Why: #4170's acceptance criterion is "tool output is legible and unfiltered
+/// (full gh output format)" — so stdout is returned as-is, with no JSON
+/// re-shaping. `tolerate_nonzero` exists because `gh pr checks` uses its EXIT
+/// CODE to report check state (non-zero when any check failed or is still
+/// pending); treating that as a tool failure would make the single most
+/// useful CI primitive report `is_error` on every red or in-flight PR, which
+/// is precisely the state an orchestrator calls it to observe.
+/// What: Delegates to [`run_program`] with `"gh"` and the missing-binary hint.
+/// Test: `run_gh_surfaces_the_cli_state_legibly`.
+pub(super) async fn run_gh(
+    root: &Path,
+    args: &[String],
+    tolerate_nonzero: bool,
+) -> crate::tools::traits::ToolResult {
+    run_program("gh", GH_MISSING_HINT, root, args, tolerate_nonzero).await
+}
+
+/// Spawn `program` with a fixed argv and map its outcome onto a `ToolResult`.
+///
+/// Why: Split out of [`run_gh`] so the two behaviours that actually matter —
+/// non-zero-exit TOLERANCE and the missing-binary message — are testable
+/// deterministically on any POSIX host, without requiring `gh` to be installed
+/// and authenticated in CI. A test that can only ever skip proves nothing, and
+/// the tolerance rule is the one piece of logic here whose regression would be
+/// invisible (every red PR would silently start reading as a tool failure).
+/// What: Runs `program <args>` with `current_dir(root)`, never a shell. On
+/// success returns stdout (or a "no output" note when the program printed
+/// nothing). On non-zero exit returns an error carrying stderr — unless
+/// `tolerate_nonzero`, in which case stdout+stderr and the exit status are
+/// returned as a SUCCESS payload. A spawn failure appends `hint`.
+/// Test: `run_program_tolerates_a_nonzero_exit_when_asked`,
+/// `run_program_reports_a_nonzero_exit_as_an_error_by_default`,
+/// `run_program_reports_a_missing_binary_with_the_hint`,
+/// `run_program_notes_empty_output`.
+pub(super) async fn run_program(
+    program: &str,
+    hint: &str,
+    root: &Path,
+    args: &[String],
+    tolerate_nonzero: bool,
+) -> crate::tools::traits::ToolResult {
+    use crate::tools::traits::ToolResult;
+
+    let rendered = args.join(" ");
+    let output = match Command::new(program)
+        .args(args)
+        .current_dir(root)
+        .output()
+        .await
+    {
+        Ok(o) => o,
+        Err(e) => {
+            return ToolResult::err(format!("failed to run '{program} {rendered}': {e}. {hint}"));
+        }
+    };
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    if output.status.success() {
+        if stdout.trim().is_empty() {
+            return ToolResult::ok(format!("{program} {rendered}: no output"));
+        }
+        return ToolResult::ok(stdout);
+    }
+    if tolerate_nonzero {
+        // The exit status IS the answer here; report it alongside the output
+        // rather than discarding either.
+        return ToolResult::ok(format!(
+            "{program} {rendered} (exit {})\n{stdout}{stderr}",
+            output
+                .status
+                .code()
+                .map_or_else(|| "signal".to_string(), |c| c.to_string())
+        ));
+    }
+    ToolResult::err(format!(
+        "{program} {rendered} failed (exit {}): {}",
+        output
+            .status
+            .code()
+            .map_or_else(|| "signal".to_string(), |c| c.to_string()),
+        if stderr.trim().is_empty() {
+            stdout.trim()
+        } else {
+            stderr.trim()
+        }
+    ))
+}

--- a/crates/trusty-agents/src/tools/gh_tools/mod.rs
+++ b/crates/trusty-agents/src/tools/gh_tools/mod.rs
@@ -1,0 +1,134 @@
+//! GitHub PR/CI inspection tool surface, grantable to L0 ONLY (#4170, epic
+//! #4167).
+//!
+//! Why: Epic #4167's gap analysis names this as the FIRST reason an L1 persona
+//! cannot do PM-tier orchestration work: *"GitHub PR/CI tooling is absent — no
+//! `gh pr list/view/checks`, no check-run status queries."* Verified against
+//! the tree before writing this module: `crate::tools::git_tools` is twelve
+//! LOCAL git operations (`git_log`, `git_status`, `git_branches`,
+//! `git_search_commits`, …) with no GitHub API reach at all; the only `gh`
+//! invocations anywhere in the crate are the ISSUE-tracker adapter
+//! (`ticketing::gh_cli`, driving `gh issue …` behind the `TicketingClient`
+//! trait) and `ticketing::actions` (a workflow-file-keyed
+//! trigger/status pair). Nothing resembling `gh pr view`, `gh pr checks`, or a
+//! check-run status primitive existed.
+//!
+//! **The tier gate.** [`gh_tools`] takes the caller's resolved
+//! [`AgentTier`](crate::agents::AgentTier) and returns an EMPTY vector for
+//! anything other than [`AgentTier::L0Orchestration`](crate::agents::AgentTier::L0Orchestration).
+//! The gate lives INSIDE the factory rather than at each registration site on
+//! purpose: a future call site that forgets to guard its `for tool in
+//! gh_tools(...)` loop still registers nothing, and the tier value it must
+//! supply is the fail-closed [`AgentInfo::tier`](crate::agents::AgentInfo::tier)
+//! resolution from #4200 — absent, blank, or unrecognized `tier =` in an
+//! `agent.toml` resolves to `L1Standard` and therefore to no tools. There is
+//! no code path by which an L1 persona obtains these tools: because the two
+//! persona dispatch paths derive an agent's callable set by INTERSECTING its
+//! `[tools].allow` globs with the names actually present in the registry
+//! (`runtime::tool_registry::scope_assistant_allowed_tools` and
+//! `ctrl::pm_task::dispatch::persona::filter_persona_tool_names`), an L1
+//! persona that declares `gh_pr_view` — or `gh_*`, or `*` — matches nothing
+//! and is granted nothing.
+//!
+//! **Read-only by construction.** Every tool here wraps an INSPECTION
+//! subcommand: `gh pr list`, `gh pr view`, `gh pr checks`, `gh run list`,
+//! `gh run view`. No mutating capability is provided — no `pr create`,
+//! `pr merge`, `pr edit`, `pr comment`, `pr close`, `run rerun`, or
+//! `workflow run`. #4170's scope list does mention several of those; they are
+//! DEFERRED rather than implemented, because merge/comment authority on an
+//! explicitly un-sandboxed tier is an owner decision that should be granted
+//! deliberately and separately, not folded into the read surface that closes
+//! the stated gap. `gh issue view`/`gh issue list` are likewise absent because
+//! they are ALREADY present under different names — `get_ticket` /
+//! `list_tickets` / `ticket_search`, which resolve to `gh issue …` through
+//! `ticketing::gh_cli::GhCliClient` — and adding a second spelling would
+//! violate the one-skill-per-tool catalog's 1:1 rule for no new capability.
+//!
+//! **Credentials.** Each tool shells out to the user's own authenticated `gh`
+//! CLI (argv only, never a shell). No `GITHUB_TOKEN` is read or handled here.
+//! A missing or unauthenticated `gh` degrades to a legible tool error.
+//! What: [`gh_tools`] returns the five `ToolExecutor`s bound to a working-tree
+//! `root` (used as `gh`'s current directory for repository auto-detection; a
+//! per-call `repo` operand overrides it).
+//! Test: `gh_tools_are_denied_to_l1`, `gh_tools_are_denied_by_default_tier`,
+//! `gh_tools_are_granted_to_l0`, `gh_tools_expose_only_read_only_subcommands`,
+//! and the real-registry-path tests in
+//! `crate::runtime::tool_registry_tests` (search `gh_`).
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use crate::agents::AgentTier;
+use crate::tools::ToolRegistry;
+use crate::tools::traits::ToolExecutor;
+
+mod ci;
+mod helpers;
+mod pr;
+
+#[cfg(test)]
+mod tests;
+
+use ci::{GhRunListTool, GhRunViewTool};
+use pr::{GhPrChecksTool, GhPrListTool, GhPrViewTool};
+
+/// Every tool name this module can register, in stable order.
+///
+/// Why: The skill catalog (`skills::manifest::builtin::github`) and the
+/// registry tests both need to speak about "the L0 GitHub surface" as a set
+/// rather than five hand-copied literals that can drift apart. Naming it once
+/// here means a sixth tool added to [`gh_tools`] without a matching skill row
+/// fails `every_tool_declared_in_source_has_a_skill`, and a name typo'd in a
+/// test fails at compile time.
+/// Test: `gh_tool_names_match_the_factory_output`.
+pub const GH_TOOL_NAMES: &[&str] = &[
+    "gh_pr_list",
+    "gh_pr_view",
+    "gh_pr_checks",
+    "gh_run_list",
+    "gh_run_view",
+];
+
+/// Build the GitHub PR/CI inspection tools — L0 ONLY, fail-closed.
+///
+/// Why: The tier check is here, at the single point of construction, so it
+/// cannot be forgotten by a caller. See this module's doc comment for why
+/// registration is the enforcement boundary and why that is sufficient to keep
+/// an L1 persona from obtaining these tools even when it declares them.
+/// What: Returns the five read-only executors when `tier` is
+/// [`AgentTier::L0Orchestration`]; returns an EMPTY vector for
+/// [`AgentTier::L1Standard`] — which is also what a missing, blank, or
+/// unrecognized `tier =` declaration resolves to via `AgentInfo::tier()`, so
+/// an indeterminate tier denies. `root` becomes `gh`'s working directory for
+/// repository auto-detection.
+/// Test: `gh_tools_are_denied_to_l1`, `gh_tools_are_denied_by_default_tier`,
+/// `gh_tools_are_granted_to_l0`, `gh_tool_names_match_the_factory_output`.
+pub fn gh_tools(tier: AgentTier, root: PathBuf) -> Vec<Arc<dyn ToolExecutor>> {
+    if tier != AgentTier::L0Orchestration {
+        return Vec::new();
+    }
+    vec![
+        Arc::new(GhPrListTool { root: root.clone() }),
+        Arc::new(GhPrViewTool { root: root.clone() }),
+        Arc::new(GhPrChecksTool { root: root.clone() }),
+        Arc::new(GhRunListTool { root: root.clone() }),
+        Arc::new(GhRunViewTool { root }),
+    ]
+}
+
+/// Register the GitHub PR/CI tools into `reg` — L0 ONLY, fail-closed.
+///
+/// Why: Both persona dispatch paths (`runtime::tool_registry::
+/// build_assistant_tier_registry` and `ctrl::pm_task::dispatch::persona::
+/// run_pm_task_with_persona`) must register the SAME set, or they diverge the
+/// way #3745 item C had to fix for izzie's tools. A single registration
+/// helper — rather than a `for` loop copied into each — makes that one line at
+/// each site and leaves exactly one place the gate can be reasoned about.
+/// What: Delegates to [`gh_tools`], which yields nothing for any tier other
+/// than [`AgentTier::L0Orchestration`], so this is a no-op for L1 callers.
+/// Test: `register_is_a_no_op_for_l1`, `register_adds_the_full_surface_for_l0`.
+pub fn register(reg: &mut ToolRegistry, tier: AgentTier, root: &Path) {
+    for tool in gh_tools(tier, root.to_path_buf()) {
+        reg.register(tool);
+    }
+}

--- a/crates/trusty-agents/src/tools/gh_tools/pr.rs
+++ b/crates/trusty-agents/src/tools/gh_tools/pr.rs
@@ -1,0 +1,203 @@
+//! Read-only pull-request inspection tools: `gh_pr_list`, `gh_pr_view`,
+//! `gh_pr_checks` (#4170).
+//!
+//! Why: These three close the exact gap epic #4167's gap analysis names —
+//! "GitHub PR/CI tooling is absent — no `gh pr list/view/checks`, no check-run
+//! status queries." `git_log`/`git_status`/`git_branches` are local and
+//! read-only; none of them can answer "is PR #4200 mergeable and are its
+//! checks green", which is the first question a PM-tier orchestration turn
+//! asks.
+//! What: One `ToolExecutor` per `gh` subcommand, argv built from validated
+//! operands only, output returned verbatim. NOTHING here mutates: no
+//! `pr create`, `pr merge`, `pr edit`, `pr comment`, or `pr close`.
+//! Test: `gh_pr_tools_are_read_only_subcommands`,
+//! `gh_pr_view_schema_has_the_expected_envelope`,
+//! `gh_pr_view_rejects_a_flag_shaped_selector`,
+//! `gh_pr_list_rejects_an_unknown_state`.
+
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use serde_json::{Value, json};
+
+use crate::tools::traits::{ToolExecutor, ToolResult};
+
+use super::helpers::{enum_arg, fn_schema, limit_arg, plain_arg, repo_arg, run_gh};
+
+/// Shared `repo` property text, so all five tools describe it identically.
+fn repo_property() -> Value {
+    json!({
+        "type": "string",
+        "description": "Optional 'owner/repo' to target. Omit to use the repository \
+                        of the current working directory."
+    })
+}
+
+/// `gh pr list` — enumerate pull requests.
+pub(super) struct GhPrListTool {
+    pub(super) root: PathBuf,
+}
+
+#[async_trait]
+impl ToolExecutor for GhPrListTool {
+    fn name(&self) -> &str {
+        "gh_pr_list"
+    }
+    fn schema(&self) -> Value {
+        fn_schema(
+            "gh_pr_list",
+            "List pull requests via the GitHub CLI (read-only). Returns gh's own \
+             table output verbatim.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "repo": repo_property(),
+                    "state": {
+                        "type": "string",
+                        "enum": ["open", "closed", "merged", "all"],
+                        "description": "Filter by PR state (default 'open')."
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max PRs to return, 1-100 (default 20)."
+                    },
+                    "author": {
+                        "type": "string",
+                        "description": "Optional GitHub login to filter by author."
+                    }
+                },
+                "required": [],
+                "additionalProperties": false
+            }),
+        )
+    }
+    async fn execute(&self, args: Value) -> ToolResult {
+        let mut argv = vec!["pr".to_string(), "list".to_string()];
+        if let Some(repo) = args.get("repo").and_then(Value::as_str) {
+            match repo_arg(repo) {
+                Ok(v) => argv.extend(["--repo".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        let state = args.get("state").and_then(Value::as_str).unwrap_or("open");
+        match enum_arg("state", state, &["open", "closed", "merged", "all"]) {
+            Ok(v) => argv.extend(["--state".to_string(), v]),
+            Err(e) => return ToolResult::err(e),
+        }
+        if let Some(author) = args.get("author").and_then(Value::as_str) {
+            match plain_arg("author", author) {
+                Ok(v) => argv.extend(["--author".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        let limit = limit_arg(args.get("limit").and_then(Value::as_u64), 20);
+        argv.extend(["--limit".to_string(), limit.to_string()]);
+        run_gh(&self.root, &argv, false).await
+    }
+}
+
+/// `gh pr view` — read one pull request.
+pub(super) struct GhPrViewTool {
+    pub(super) root: PathBuf,
+}
+
+#[async_trait]
+impl ToolExecutor for GhPrViewTool {
+    fn name(&self) -> &str {
+        "gh_pr_view"
+    }
+    fn schema(&self) -> Value {
+        fn_schema(
+            "gh_pr_view",
+            "Show one pull request's title, state, body, and metadata via the GitHub \
+             CLI (read-only). Returns gh's own output verbatim.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "pr": {
+                        "type": "string",
+                        "description": "PR number, branch name, or PR URL."
+                    },
+                    "repo": repo_property(),
+                    "comments": {
+                        "type": "boolean",
+                        "description": "Include the PR's comments (default false)."
+                    }
+                },
+                "required": ["pr"],
+                "additionalProperties": false
+            }),
+        )
+    }
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(pr) = args.get("pr").and_then(Value::as_str) else {
+            return ToolResult::err("'pr' is required");
+        };
+        let pr = match plain_arg("pr", pr) {
+            Ok(v) => v,
+            Err(e) => return ToolResult::err(e),
+        };
+        let mut argv = vec!["pr".to_string(), "view".to_string(), pr];
+        if let Some(repo) = args.get("repo").and_then(Value::as_str) {
+            match repo_arg(repo) {
+                Ok(v) => argv.extend(["--repo".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        if args.get("comments").and_then(Value::as_bool) == Some(true) {
+            argv.push("--comments".to_string());
+        }
+        run_gh(&self.root, &argv, false).await
+    }
+}
+
+/// `gh pr checks` — the check-run aggregation primitive.
+pub(super) struct GhPrChecksTool {
+    pub(super) root: PathBuf,
+}
+
+#[async_trait]
+impl ToolExecutor for GhPrChecksTool {
+    fn name(&self) -> &str {
+        "gh_pr_checks"
+    }
+    fn schema(&self) -> Value {
+        fn_schema(
+            "gh_pr_checks",
+            "Show every CI check run for one pull request, with its state and \
+             duration, via the GitHub CLI (read-only). Reports red and pending \
+             checks as normal output, not as a tool failure.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "pr": {
+                        "type": "string",
+                        "description": "PR number, branch name, or PR URL."
+                    },
+                    "repo": repo_property()
+                },
+                "required": ["pr"],
+                "additionalProperties": false
+            }),
+        )
+    }
+    async fn execute(&self, args: Value) -> ToolResult {
+        let Some(pr) = args.get("pr").and_then(Value::as_str) else {
+            return ToolResult::err("'pr' is required");
+        };
+        let pr = match plain_arg("pr", pr) {
+            Ok(v) => v,
+            Err(e) => return ToolResult::err(e),
+        };
+        let mut argv = vec!["pr".to_string(), "checks".to_string(), pr];
+        if let Some(repo) = args.get("repo").and_then(Value::as_str) {
+            match repo_arg(repo) {
+                Ok(v) => argv.extend(["--repo".to_string(), v]),
+                Err(e) => return ToolResult::err(e),
+            }
+        }
+        // `gh pr checks` exits non-zero for failing/pending checks — see
+        // `run_gh`'s `tolerate_nonzero` rationale.
+        run_gh(&self.root, &argv, true).await
+    }
+}

--- a/crates/trusty-agents/src/tools/gh_tools/tests.rs
+++ b/crates/trusty-agents/src/tools/gh_tools/tests.rs
@@ -1,0 +1,428 @@
+//! Unit tests for the L0-only GitHub PR/CI tool surface (#4170).
+//!
+//! Why: Two families of property are pinned here — the TIER GATE (an L1 or
+//! indeterminate tier gets no tools from the factory, an L0 tier gets exactly
+//! five) and OPERAND VALIDATION (no LLM-supplied string can become a `gh`
+//! flag). The complementary proof that the gate holds through the REAL
+//! registry-construction path — not just this factory — lives in
+//! `crate::runtime::tool_registry_tests`.
+//! What: Factory/tier tests, name-set agreement, schema shape, read-only
+//! subcommand assertions, and validator rejection cases.
+//! Test: this file.
+
+use super::helpers::{enum_arg, limit_arg, plain_arg, repo_arg, run_gh, run_program};
+use super::*;
+use serde_json::json;
+
+fn root() -> PathBuf {
+    std::env::current_dir().unwrap()
+}
+
+fn l0_tools() -> Vec<Arc<dyn ToolExecutor>> {
+    gh_tools(AgentTier::L0Orchestration, root())
+}
+
+// --------------------------------------------------------------------------
+// The tier gate
+// --------------------------------------------------------------------------
+
+#[test]
+fn gh_tools_are_denied_to_l1() {
+    // The headline requirement of #4170: these tools are grantable to L0 ONLY,
+    // enforced in code. An L1 caller gets nothing to register, so no
+    // `[tools].allow` entry an L1 persona can write has anything to match.
+    assert!(
+        gh_tools(AgentTier::L1Standard, root()).is_empty(),
+        "an L1-tier caller must receive no GitHub tools"
+    );
+}
+
+#[test]
+fn gh_tools_are_denied_by_default_tier() {
+    // Fail-closed on an indeterminate tier. `AgentTier::default()` is what
+    // `AgentInfo::tier()` resolves to for an absent, blank, or unrecognized
+    // `tier =` declaration (#4200), so this is the "tier could not be
+    // determined" case stated at the type level.
+    assert_eq!(AgentTier::default(), AgentTier::L1Standard);
+    assert!(
+        gh_tools(AgentTier::default(), root()).is_empty(),
+        "an undeclared/unresolvable tier must deny, never grant"
+    );
+}
+
+#[test]
+fn gh_tools_are_granted_to_l0() {
+    let tools = l0_tools();
+    assert_eq!(tools.len(), GH_TOOL_NAMES.len());
+}
+
+#[test]
+fn register_is_a_no_op_for_l1() {
+    let mut reg = ToolRegistry::new();
+    register(&mut reg, AgentTier::L1Standard, &root());
+    for name in GH_TOOL_NAMES {
+        assert!(!reg.contains(name), "{name} leaked into an L1 registry");
+    }
+}
+
+#[test]
+fn register_adds_the_full_surface_for_l0() {
+    let mut reg = ToolRegistry::new();
+    register(&mut reg, AgentTier::L0Orchestration, &root());
+    for name in GH_TOOL_NAMES {
+        assert!(reg.contains(name), "{name} missing from an L0 registry");
+    }
+}
+
+#[test]
+fn gh_tool_names_match_the_factory_output() {
+    // `GH_TOOL_NAMES` is what the skill catalog and the registry tests read;
+    // drift between it and the factory would make those tests assert about
+    // tools that no longer exist.
+    let tools = l0_tools();
+    let produced: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+    assert_eq!(produced, GH_TOOL_NAMES);
+}
+
+#[test]
+fn every_gh_tool_has_a_skill_in_the_builtin_catalog() {
+    // The one-skill-per-tool rule (owner ruling, #3933) asserted against the
+    // live catalog for THIS family specifically, so a missing row fails here
+    // with a precise name rather than only in the crate-wide source scan.
+    let catalog = crate::skills::manifest::SkillCatalog::builtin();
+    for name in GH_TOOL_NAMES {
+        assert!(
+            catalog.skill_for_tool(name).is_some(),
+            "{name} has no skill wrapping it"
+        );
+    }
+}
+
+// --------------------------------------------------------------------------
+// Read-only posture
+// --------------------------------------------------------------------------
+
+#[test]
+fn gh_tools_expose_only_read_only_subcommands() {
+    // A mutating verb must never appear in a tool NAME or in the DESCRIPTION
+    // the model reads to decide what a tool does. #4170 explicitly forbids
+    // quietly granting merge power; this is the tripwire for a future edit
+    // that adds one to this module.
+    //
+    // Scoped to name + description deliberately: `gh_pr_list`'s `state`
+    // parameter legitimately offers the value `"merged"` (a FILTER over
+    // existing PRs, not an action), so scanning the whole schema JSON would
+    // flag a read-only capability. What must stay clean is what the tool
+    // claims to DO.
+    for tool in l0_tools() {
+        let schema = tool.schema();
+        let description = schema["function"]["description"]
+            .as_str()
+            .expect("every tool declares a description")
+            .to_lowercase();
+        let text = format!("{} {description}", tool.name());
+        for forbidden in [
+            "merge", "create", "comment", "close", "edit", "rerun", "delete", "approve", "trigger",
+        ] {
+            assert!(
+                !text.contains(forbidden),
+                "{} mentions the mutating verb {forbidden:?} in its name/description; \
+                 this module is read-only",
+                tool.name()
+            );
+        }
+    }
+}
+
+#[test]
+fn gh_pr_tools_are_read_only_subcommands() {
+    let tools = l0_tools();
+    let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+    assert!(names.contains(&"gh_pr_list"));
+    assert!(names.contains(&"gh_pr_view"));
+    assert!(names.contains(&"gh_pr_checks"));
+    assert!(
+        !names.iter().any(|n| n.contains("merge")),
+        "no merge tool may be registered: {names:?}"
+    );
+}
+
+#[test]
+fn gh_ci_tools_are_read_only_subcommands() {
+    let tools = l0_tools();
+    let names: Vec<&str> = tools.iter().map(|t| t.name()).collect();
+    assert!(names.contains(&"gh_run_list"));
+    assert!(names.contains(&"gh_run_view"));
+    // `gh run watch` blocks for the life of a run; see `ci.rs`'s doc comment.
+    assert!(!names.iter().any(|n| n.contains("watch")));
+}
+
+// --------------------------------------------------------------------------
+// Schemas
+// --------------------------------------------------------------------------
+
+fn tool_named(name: &str) -> Arc<dyn ToolExecutor> {
+    l0_tools()
+        .into_iter()
+        .find(|t| t.name() == name)
+        .unwrap_or_else(|| panic!("{name} not registered"))
+}
+
+#[test]
+fn gh_pr_view_schema_has_the_expected_envelope() {
+    let s = tool_named("gh_pr_view").schema();
+    assert_eq!(s["type"], "function");
+    assert_eq!(s["function"]["name"], "gh_pr_view");
+    let required: Vec<&str> = s["function"]["parameters"]["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(required, vec!["pr"]);
+    assert!(
+        s["function"]["parameters"]["properties"]
+            .get("repo")
+            .is_some(),
+        "cross-repo reach is part of the L0 grant"
+    );
+}
+
+#[test]
+fn gh_run_view_requires_a_run_id() {
+    let s = tool_named("gh_run_view").schema();
+    let required: Vec<&str> = s["function"]["parameters"]["required"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert_eq!(required, vec!["run_id"]);
+}
+
+#[test]
+fn list_tools_require_no_arguments() {
+    for name in ["gh_pr_list", "gh_run_list"] {
+        let s = tool_named(name).schema();
+        assert!(
+            s["function"]["parameters"]["required"]
+                .as_array()
+                .unwrap()
+                .is_empty(),
+            "{name} should be callable with no arguments"
+        );
+    }
+}
+
+// --------------------------------------------------------------------------
+// Operand validation — the flag-injection gate
+// --------------------------------------------------------------------------
+
+#[test]
+fn plain_arg_rejects_flag_shaped_values() {
+    for bad in ["--json", "-q", "--template", "-R"] {
+        let err = plain_arg("pr", bad).expect_err("must be rejected");
+        assert!(err.contains("must not start with '-'"), "{err}");
+    }
+}
+
+#[test]
+fn plain_arg_rejects_whitespace_and_control_characters() {
+    for bad in [
+        "4200 --json",
+        "a\tb",
+        "a\nb",
+        "a b",
+        "a;b",
+        "a|b",
+        "a&b",
+        "$(x)",
+        "`x`",
+        "café",
+    ] {
+        assert!(plain_arg("pr", bad).is_err(), "{bad:?} must be rejected");
+    }
+    assert!(plain_arg("pr", "").is_err(), "empty must be rejected");
+    assert!(
+        plain_arg("pr", &"9".repeat(500)).is_err(),
+        "an over-long operand must be rejected"
+    );
+}
+
+#[test]
+fn plain_arg_accepts_ordinary_selectors() {
+    for good in [
+        "4200",
+        "feat/4170-l0-github-pr-ci",
+        "https://github.com/bobmatnyc/trusty-tools/pull/4200",
+        "bobmatnyc",
+        "ci.yml",
+    ] {
+        assert!(plain_arg("pr", good).is_ok(), "{good:?} must be accepted");
+    }
+}
+
+#[test]
+fn repo_arg_requires_owner_slash_repo() {
+    assert_eq!(
+        repo_arg("bobmatnyc/trusty-tools").unwrap(),
+        "bobmatnyc/trusty-tools"
+    );
+    for bad in ["trusty-tools", "a/b/c", "/b", "a/", "--repo=a/b", "a b/c"] {
+        assert!(repo_arg(bad).is_err(), "{bad:?} must be rejected");
+    }
+}
+
+#[test]
+fn limit_arg_clamps_to_the_supported_range() {
+    assert_eq!(limit_arg(None, 20), 20);
+    assert_eq!(limit_arg(Some(0), 20), 1);
+    assert_eq!(limit_arg(Some(5), 20), 5);
+    assert_eq!(limit_arg(Some(100_000), 20), 100);
+}
+
+#[test]
+fn enum_arg_rejects_unlisted_values() {
+    assert_eq!(enum_arg("state", "open", &["open", "all"]).unwrap(), "open");
+    let err = enum_arg("state", "merged; rm -rf /", &["open", "all"]).expect_err("rejected");
+    assert!(err.contains("must be one of open, all"), "{err}");
+}
+
+// --------------------------------------------------------------------------
+// Execution — argument rejection happens BEFORE any subprocess spawn, so
+// these run without `gh` installed or authenticated.
+// --------------------------------------------------------------------------
+
+#[tokio::test]
+async fn gh_pr_view_rejects_a_flag_shaped_selector() {
+    let out = tool_named("gh_pr_view")
+        .execute(json!({"pr": "--repo=attacker/repo"}))
+        .await;
+    assert!(out.is_error(), "got: {}", out.content());
+    assert!(out.content().contains("must not start with '-'"));
+}
+
+#[tokio::test]
+async fn gh_pr_view_rejects_a_missing_selector() {
+    let out = tool_named("gh_pr_view").execute(json!({})).await;
+    assert!(out.is_error());
+    assert!(out.content().contains("'pr' is required"));
+}
+
+#[tokio::test]
+async fn gh_pr_list_rejects_an_unknown_state() {
+    let out = tool_named("gh_pr_list")
+        .execute(json!({"state": "everything"}))
+        .await;
+    assert!(out.is_error());
+    assert!(out.content().contains("'state' must be one of"));
+}
+
+#[tokio::test]
+async fn gh_pr_list_rejects_a_malformed_repo() {
+    let out = tool_named("gh_pr_list")
+        .execute(json!({"repo": "not-a-slug"}))
+        .await;
+    assert!(out.is_error());
+    assert!(
+        out.content()
+            .contains("'repo' must be exactly 'owner/repo'")
+    );
+}
+
+#[tokio::test]
+async fn gh_run_view_rejects_a_flag_shaped_run_id() {
+    let out = tool_named("gh_run_view")
+        .execute(json!({"run_id": "-1 --json url"}))
+        .await;
+    assert!(out.is_error());
+}
+
+#[tokio::test]
+async fn gh_run_list_rejects_an_unknown_status() {
+    let out = tool_named("gh_run_list")
+        .execute(json!({"status": "green"}))
+        .await;
+    assert!(out.is_error());
+    assert!(out.content().contains("'status' must be one of"));
+}
+
+#[tokio::test]
+async fn gh_run_view_rejects_a_missing_run_id() {
+    let out = tool_named("gh_run_view").execute(json!({})).await;
+    assert!(out.is_error());
+    assert!(out.content().contains("'run_id' is required"));
+}
+
+// --------------------------------------------------------------------------
+// Subprocess outcome mapping — exercised via `run_program` against POSIX
+// utilities so the tolerance rule is pinned WITHOUT requiring an installed,
+// authenticated `gh` (a test that can only skip in CI proves nothing).
+// --------------------------------------------------------------------------
+
+#[tokio::test]
+async fn run_program_tolerates_a_nonzero_exit_when_asked() {
+    // THE rule `gh pr checks` depends on: a non-zero exit is check STATE, not
+    // a tool failure. If this regresses, every red or pending PR starts
+    // reading as `is_error` to the model.
+    let out = run_program("false", "hint", &root(), &[], true).await;
+    assert!(
+        !out.is_error(),
+        "a tolerated non-zero exit must stay a success: {}",
+        out.content()
+    );
+    assert!(out.content().contains("(exit 1)"), "{}", out.content());
+}
+
+#[tokio::test]
+async fn run_program_reports_a_nonzero_exit_as_an_error_by_default() {
+    let out = run_program("false", "hint", &root(), &[], false).await;
+    assert!(out.is_error());
+    assert!(
+        out.content().contains("failed (exit 1)"),
+        "{}",
+        out.content()
+    );
+}
+
+#[tokio::test]
+async fn run_program_reports_a_missing_binary_with_the_hint() {
+    let out = run_program(
+        "trusty-no-such-binary-4170",
+        "install it first",
+        &root(),
+        &[],
+        false,
+    )
+    .await;
+    assert!(out.is_error());
+    assert!(
+        out.content().contains("install it first"),
+        "{}",
+        out.content()
+    );
+}
+
+#[tokio::test]
+async fn run_program_notes_empty_output() {
+    let out = run_program("true", "hint", &root(), &[], false).await;
+    assert!(!out.is_error());
+    assert!(out.content().contains("no output"), "{}", out.content());
+}
+
+#[tokio::test]
+async fn run_gh_surfaces_the_cli_state_legibly() {
+    // Environment-tolerant but non-vacuous: whichever branch this host takes,
+    // the payload must be one a model can act on — never a panic and never an
+    // empty message.
+    let out = run_gh(&root(), &["--version".to_string()], false).await;
+    if out.is_error() {
+        assert!(
+            out.content().contains("gh auth login") || out.content().contains("failed (exit"),
+            "unhelpful gh failure: {}",
+            out.content()
+        );
+    } else {
+        assert!(!out.content().trim().is_empty());
+    }
+}

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -21,6 +21,8 @@ pub mod file_filter;
 pub mod finish_task;
 pub mod format_translator;
 pub mod fs_reader;
+// #4170 (epic #4167): GitHub PR/CI inspection, grantable to L0 only.
+pub mod gh_tools;
 pub mod git_tools;
 pub mod izzie;
 // #4173 (epic #4167): the L0-orchestration-tier-only shell/build/test grant.


### PR DESCRIPTION
Closes #4170. Part of epic #4167. Builds directly on #4200 (squash `ada4d351`), which established the `AgentTier` resolver this PR gates on.

## The gap this closes

Verified against the tree before building: the persona tool surface had **no** GitHub PR/CI capability at all.

- `crate::tools::git_tools` is twelve **local** git operations (`git_log`, `git_status`, `git_branches`, `git_search_commits`, …) with no GitHub API reach.
- The only `gh` invocations anywhere in the crate were the **issue-tracker** adapter (`ticketing::gh_cli`, driving `gh issue …` behind the `TicketingClient` trait) and `ticketing::actions` (a workflow-**file**-keyed trigger/status pair that needs a configured `TicketingClient` and returns re-shaped JSON).
- Nothing resembling `gh pr view`, `gh pr checks`, or a check-run status primitive existed.

## What this adds

Five **read-only** tools in a new `crate::tools::gh_tools` module:

| Tool | `gh` subcommand |
|---|---|
| `gh_pr_list` | `gh pr list` |
| `gh_pr_view` | `gh pr view` |
| `gh_pr_checks` | `gh pr checks` (the check-run aggregation primitive) |
| `gh_run_list` | `gh run list` |
| `gh_run_view` | `gh run view` (with `--log-failed`) |

Output is returned **verbatim** — gh's own human format, no JSON re-shaping — per #4170's "legible and unfiltered" acceptance criterion.

## ⚠️ NO MUTATING CAPABILITY IS GRANTED — read this before approving

**This PR grants no merge power, and no write power of any kind.** There is no `pr create`, `pr merge`, `pr edit`, `pr comment`, `pr close`, `run rerun`, or `workflow run` tool in it.

#4170's scope list *does* mention `gh pr create`, `gh pr merge`, `gh pr comment`, and `gh workflow run`. Those are **deliberately deferred, not overlooked**: merge/comment authority on a tier that is explicitly *not* sandboxed is an owner decision that should be granted knowingly and separately, rather than folded into the read surface that closes the stated gap. **If you want L0 to hold merge authority, that is a follow-up issue and a separate review** — say so and it will be filed.

`gh issue view` / `gh issue list` are also absent, for a different reason: they are **already present under other names** — `get_ticket` / `list_tickets` / `ticket_search`, which resolve to `gh issue …` through `ticketing::gh_cli::GhCliClient`. Adding a second spelling would break the catalog's 1:1 skill/tool rule for zero new capability.

A test (`gh_tools_expose_only_read_only_subcommands`) fails the build if a mutating verb ever appears in a tool's name or description, and `gh_surface_registers_no_mutating_tool_even_for_l0` asserts the same against the real L0 registry.

## Hard requirement 1 — grantable to L0 ONLY, enforced in code

`gh_tools(tier, root)` returns an **empty vector** for anything other than `AgentTier::L0Orchestration`. It consumes the fail-closed resolver from #4200 (`AgentInfo::tier()`): an absent, blank, or unrecognized `tier =` resolves to `L1Standard` and therefore to **no tools**. Indeterminate ⇒ deny.

The gate lives **inside the factory**, not at each registration site, so a future call site that forgets to guard its loop still registers nothing.

**Why registration is a sufficient enforcement boundary:** both persona dispatch paths derive an agent's callable set by *intersecting* its `[tools].allow` globs with the names actually present in the registry — `runtime::tool_registry::scope_assistant_allowed_tools` and `ctrl::pm_task::dispatch::persona::filter_persona_tool_names`. An L1 persona that declares `gh_pr_view`, or `gh_*`, or even `*`, matches nothing and is granted nothing.

Registered on **both** assistant dispatch paths (the `--direct`/`--agent` subprocess path and the persona-chat path). Registering in only one is exactly the divergence #3745 item C had to fix for izzie's tools.

The persona-chat site reads `persona_cfg.agent.tier()` **directly** rather than through the `role == "assistant"` branch used for `delegator_tier`: this is a capability grant, not a delegation edge, so it must fail closed for every persona whose tier does not explicitly resolve to L0 — including one carrying an unexpected `role`.

## Operand validation (the tool-level attack surface)

L0 is deliberately un-sandboxed, so these tools are the last thing between model output and a real GitHub API call. Argv is passed directly — **never a shell** — and every LLM-supplied operand must be non-empty, ≤200 chars, free of a leading `-`, and drawn from `[A-Za-z0-9._/#:@-]`. A value like `--json`, `-R attacker/repo`, or a smuggled second argument is refused with a message naming the field, before any spawn. `repo` must be exactly `owner/repo`; `state`/`status` are closed enums; `limit` clamps to 1–100.

`gh pr checks` reports check state through its **exit code** (non-zero when any check is red or pending). That is tolerated and returned as normal output — otherwise the single most useful CI primitive would report `is_error` on exactly the state an orchestrator calls it to observe.

## Not touched, per scope

The tier gate itself, `ASSISTANT_ALLOWED_DELEGATE_ROLES`, `NON_CODING_TARGETS`, and every persona under `~/.trusty-agents/agents/`. No L0 persona instance is created by this PR.

## One skill per tool (hard requirement 3)

Five rows in a new `skills/manifest/builtin/github.rs`, each declaring the `gh` CLI credential requirement with `env_var: None` — a `gh auth login` grant lives in the system keyring and is not probeable, so status stays *unclaimed* rather than guessed (#3945's honesty discipline). A new family file rather than appending to `ops.rs` keeps the collision surface with concurrent tier work to two lines in `builtin/mod.rs`.

## Tests — 30 new, all green

The three required proofs run through the **real registry-construction path**, not hand-built helper arguments: a persona TOML written to disk, loaded via `AgentConfig::by_name` under a `TAGENT_CONFIG_DIR` override (the same entry point `run_subagent` calls), then `cfg.agent.tier()` → `build_registry_for_agent` → the real `scope_assistant_allowed_tools` glob translation.

- `l1_persona_declaring_gh_tools_is_granted_none_through_the_real_path` — the probe persona declares `allow = ["*", "gh_*", <every literal tool name>]` and receives none of them. Includes a non-vacuity assertion: the `*` grant must yield *something*, or the test would pass for the wrong reason.
- `l0_persona_declaring_gh_tools_is_granted_them_through_the_real_path` — the counter-test that keeps the above honest.
- `indeterminate_tier_denies_gh_tools_through_the_real_path` — absent, empty, whitespace-only, and garbage `tier =` values all deny.
- Plus `assistant_tier_registry_omits_gh_tools_for_l1` / `..._includes_gh_tools_for_l0`, `gh_surface_registers_no_mutating_tool_even_for_l0`, and 24 module-level tests covering the factory gate, name/catalog agreement, schemas, flag-injection rejection, and subprocess outcome mapping (the non-zero-tolerance rule is pinned against POSIX `true`/`false` so it is deterministic without an installed, authenticated `gh` — a test that can only skip in CI proves nothing).

## Quality gate

| Gate | Result |
|---|---|
| `cargo fmt --check` | exit 0 |
| `cargo clippy -- -D warnings` | exit 0 |
| `cargo test -p trusty-agents` (lib) | **2870 passed, 0 failed**, 11 ignored |
| `scripts/check_line_cap.sh` | 7 allowlisted, 0 violations — OK |
| `scripts/check_test_pointers.sh` | 0 dangling pointers — OK |

`tests/api_e2e.rs` fails locally under parallel test threads with *"api server did not become healthy within 5s"* — four `--api` children racing a 5 s startup budget on a loaded dev machine. It passes cleanly at `--test-threads=1` (4 passed, 0 failed). Unrelated to this change, which adds nothing to `--api` startup.

`crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs` sits at **exactly** 500 SLOC on `main` — the cap — so any code addition would fail the line-cap gate. The change there is net-zero SLOC: the existing git-tools block was tightened by one line (hoisting the `current_dir()` call into a `cwd` binding) to make room for the one-line `gh_tools::register` call.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
