### PR TITLE
feat(trusty-agents): L0-only cross-project git/search scoping (#4172)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -62,6 +62,31 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **Cross-project git/search scoping granted to the L0 orchestration tier
+  ONLY** (#4172, epic #4167). New `agents::cross_project::CrossProjectScope` is
+  the single resolution point for "which repo roots and which search indexes
+  may THIS agent touch". An L0 agent's allow-set is its own home project root
+  plus every `~/.trusty-agents/projects.json` entry that is *simultaneously*
+  `Active`, a real project (no `/tmp`, `/var/folders`, `.tmp*`), existing, and
+  a git repository root. An L1 agent gets its home root and nothing else —
+  byte-identical to previous behaviour. **DOC-54 §5.1's one-OKG-store-per-agent
+  ceiling is untouched for either tier**: nothing here reads, writes, unions or
+  widens `[[stores]]`, and `extends`' replace-not-union rule is unchanged;
+  cross-project reach is resolved as *paths and tier-2 index ids*
+  (`[tools].search_indexes`, #3232), which is where multiplicity already
+  belongs. Containment is component-wise `Path::starts_with` against
+  *canonicalized* roots, so `..` traversal, symlink escape, and `/a/bc` vs
+  `/a/b` prefix-lookalike siblings are all refused; a relative candidate is
+  refused outright rather than joined to the cwd. Because libgit2's
+  `Repository::discover` walks *upward*, `open_scoped_repo` re-validates the
+  discovered work tree after discovery — a permitted seed cannot land on an
+  ancestor outside the allow-set. Registry failure denies reach: no `$HOME`, a
+  missing file, or malformed JSON yields an empty snapshot, collapsing even an
+  L0 agent to its home root. The per-call `repo` argument is advertised in the
+  JSON schema only when the scope is actually cross-project, so an L1 persona
+  is never shown a knob it cannot turn. Every refusal is logged at `warn` with
+  the same `tier=… cross_project=… roots=[…] indexes=[…]` audit line emitted at
+  construction. No per-project credential is read, copied, or forwarded.
 - **A read-only GitHub PR/CI inspection surface granted to the L0
   orchestration tier ONLY** (#4170, epic #4167). Five tools in a new
   `tools::gh_tools` — `gh_pr_list`, `gh_pr_view`, `gh_pr_checks`,

--- a/crates/trusty-agents/src/agents/cross_project/mod.rs
+++ b/crates/trusty-agents/src/agents/cross_project/mod.rs
@@ -1,0 +1,491 @@
+//! L0-only cross-project git/search scoping (#4172, epic #4167).
+//!
+//! Why: The owner's tiered persona model (#4167, resolver landed in #4200)
+//! gives L0 ("orchestration") the PM-tier reach an L1 ("standard") assistant
+//! must never have. One of those grants is **cross-project reach**: an
+//! orchestration persona reconciling a snapshot against live state has to
+//! read git status across several repos and search corpora outside its own
+//! project, while every L1 persona stays exactly as single-tenant as it is
+//! today.
+//!
+//! **The one-store rule is NOT relaxed — for either tier.** DOC-54 §5.1
+//! ("Stores (Knowledge): One per agent", Bob 2026-07-24) governs
+//! `[[stores]]`: the agent's ONE dedicated, curated OKG store — its OKF
+//! knowledge tree plus the search index over that tree. That ceiling, and
+//! the `extends` replace-not-union rule that protects it
+//! (`crate::agents::extends`), are untouched by this module: nothing here
+//! reads, writes, unions, or widens `[[stores]]`.
+//!
+//! The multiplicity #4172 asks for already has a sanctioned home. Epic
+//! #4007's tier-2 mechanism — `[tools].search_indexes` (#3232) — exists
+//! precisely for "also let me search the APEX repo", and its own field docs
+//! (`ToolsConfig::search_indexes`) state the split: "`[[stores]]` is the
+//! CURATED tier — exactly one OKG store per agent by the 2026-07-24 owner
+//! decision, and that ceiling stays. The multiplicity an agent needs …
+//! belongs to a second, uncurated tier." So cross-project *reach* is a
+//! tier-2 + filesystem question, not a `[[stores]]` question, and #4172 is
+//! implementable without touching a normative constraint.
+//!
+//! What: [`CrossProjectScope`] — the single resolution point for "which repo
+//! roots and which search indexes may THIS agent touch". It is built from a
+//! real [`AgentInfo`] (so the tier comes from #4200's fail-closed
+//! `AgentInfo::tier`, never a local guess) plus the agent's home project
+//! root, and it answers two questions:
+//!
+//! - [`CrossProjectScope::resolve_repo_root`] — turn an optional caller-
+//!   supplied `repo` path into a permitted absolute root, or refuse.
+//! - [`CrossProjectScope::effective_search_indexes`] — widen an agent's
+//!   declared tier-2 index list with the cross-project index ids it may
+//!   query.
+//!
+//! **The bound (requirement: not "any path on disk").** An L0 agent's
+//! allow-set is:
+//!
+//! > its own home project root, PLUS every entry of the trusty-agents
+//! > project registry (`~/.trusty-agents/projects.json`) that is
+//! > simultaneously (a) `ProjectStatus::Active`, (b)
+//! > `ProjectEntry::is_real_project()` (no temp dirs), (c) an existing
+//! > directory, and (d) a git repository root (carries a `.git` entry).
+//!
+//! Every one of those four conditions is mechanical and re-checked at
+//! resolution time; a path satisfying none of them is unreachable. An L1
+//! agent's allow-set is its home root and nothing else — byte-identically
+//! today's behaviour. Containment is component-wise
+//! ([`Path::starts_with`]) against CANONICALIZED roots, so `..` traversal
+//! and symlink indirection cannot smuggle a path in, and a sibling
+//! directory that merely shares a string prefix (`/a/bc` vs `/a/b`) is not
+//! a match.
+//!
+//! Auditability: [`CrossProjectScope::audit_summary`] renders the resolved
+//! tier and full allow-set as one line, emitted at `tracing::info` on
+//! construction; every refusal is emitted at `tracing::warn` and returned
+//! to the model as an error naming the allow-set.
+//!
+//! Why the trusty-agents registry and not trusty-mpm's: trusty-mpm's
+//! curated project registry is unreachable from this crate as Rust types
+//! (`trusty-agents` has no `trusty-mpm` dependency — the sanctioned access
+//! pattern is a loopback HTTP GET, per `crate::system_status::daemons`), it
+//! carries **no local filesystem path** at all (records are keyed on
+//! `name`/`repo_url`), and a local path can only be *fabricated* from it by
+//! the `~/trusty-mpm-projects/<owner>/<repo>` layout convention. A security
+//! allow-set must not depend on a sibling daemon being up, nor on a
+//! conventionally-guessed path: a wedged daemon would silently change the
+//! boundary. The in-crate registry is on-disk, deterministic, inspectable by
+//! the user (`list_projects`), and already documented as "the single source
+//! of truth for 'what projects does this user have?'" (`crate::registry`).
+//!
+//! No credential surface is widened here: this module resolves *paths* and
+//! *index ids* only. Cross-project git operations run through the same
+//! ambient git credential helper the home project already uses — no
+//! per-project secret is read, copied, or forwarded.
+//!
+//! Test: `l1_scope_allows_only_its_home_root`,
+//! `l0_scope_includes_registered_git_projects`,
+//! `l0_resolve_repo_root_refuses_unregistered_sibling`,
+//! `unrecognized_tier_declaration_resolves_to_single_tenant_scope`,
+//! `undeclared_tier_follows_the_kind_derivation`.
+
+#[cfg(test)]
+mod tests;
+
+use std::path::{Path, PathBuf};
+
+use crate::agents::{AgentInfo, AgentTier};
+use crate::registry::{ProjectEntry, ProjectRegistry, ProjectStatus};
+
+/// The resolved cross-project reach of ONE agent (#4172).
+///
+/// Why: Both consumers — the git tool surface and `vector_search`'s tier-2
+/// index allowlist — must agree on what "this agent's projects" means. One
+/// value carrying the resolved tier plus the canonicalized allow-set is what
+/// keeps them from drifting, and is what makes the boundary auditable in a
+/// single log line.
+/// What: An immutable value. `allowed_roots` always begins with the home
+/// root; for [`AgentTier::L1Standard`] it contains ONLY the home root.
+/// `cross_project_indexes` is empty for L1.
+/// Test: `l1_scope_allows_only_its_home_root`,
+/// `l0_scope_includes_registered_git_projects`.
+#[derive(Debug, Clone)]
+pub struct CrossProjectScope {
+    /// The tier this scope was resolved for, straight from
+    /// [`AgentInfo::tier`] (#4200) — never re-derived locally.
+    tier: AgentTier,
+    /// The agent's own project root, VERBATIM as the construction site
+    /// supplied it.
+    ///
+    /// Why: This is what a tool bound to this scope acts on when the caller
+    /// names no `repo`, so it must be the byte-identical value the
+    /// pre-#4172 call site passed to `git_tools(root)` — canonicalizing it
+    /// here would silently retarget every existing registration (on macOS
+    /// `/tmp/x` becomes `/private/tmp/x`). Containment comparisons use
+    /// `allowed_roots`, which IS canonicalized, so the two concerns stay
+    /// separate.
+    home_root: PathBuf,
+    /// Canonicalized roots this agent may operate in. Canonical home root
+    /// first, then (L0 only) the admitted registry projects in registry
+    /// order.
+    allowed_roots: Vec<PathBuf>,
+    /// trusty-search index ids for the non-home allowed roots (L0 only),
+    /// derived by [`trusty_common::derive_index_id`].
+    cross_project_indexes: Vec<String>,
+}
+
+impl CrossProjectScope {
+    /// The single-tenant scope: one root, no cross-project reach (#4172).
+    ///
+    /// Why: This is BOTH the L1 shape and the pre-#4172 behaviour of every
+    /// existing call site. `git_tools(root)` keeps its signature by
+    /// delegating through this constructor, so no path that has not been
+    /// deliberately migrated changes behaviour at all.
+    /// What: Tier is the fail-closed [`AgentTier::L1Standard`]; the allow-set
+    /// is exactly `[canonical(root)]`; no cross-project indexes.
+    /// Test: `single_tenant_scope_is_not_cross_project`,
+    /// `l1_scope_allows_only_its_home_root`.
+    pub fn single_tenant(root: PathBuf) -> Self {
+        Self {
+            tier: AgentTier::L1Standard,
+            allowed_roots: vec![canonical_or_verbatim(&root)],
+            home_root: root,
+            cross_project_indexes: Vec::new(),
+        }
+    }
+
+    /// Resolve an agent's scope against an already-loaded registry snapshot
+    /// (#4172).
+    ///
+    /// Why: The pure core, so the boundary is testable without touching
+    /// `$HOME` or the real `projects.json`. [`Self::from_registry`] is the
+    /// thin I/O wrapper over it.
+    /// What: Reads the tier via [`AgentInfo::tier`] — #4200's fail-closed
+    /// accessor, so an absent, blank, or unrecognized `tier` value lands on
+    /// [`AgentTier::L1Standard`] and this returns exactly
+    /// [`Self::single_tenant`]. For [`AgentTier::L0Orchestration`], admits
+    /// each `entries` record passing all four conditions in the module docs,
+    /// skipping the home root itself and any duplicate.
+    /// Test: `l0_scope_includes_registered_git_projects`,
+    /// `l0_scope_excludes_non_git_and_inactive_and_temp_entries`,
+    /// `unrecognized_tier_declaration_resolves_to_single_tenant_scope`,
+    /// `undeclared_tier_follows_the_kind_derivation`.
+    pub fn resolve(agent: &AgentInfo, home_root: &Path, entries: &[ProjectEntry]) -> Self {
+        let tier = agent.tier();
+        let canonical_home = canonical_or_verbatim(home_root);
+        let home_root = home_root.to_path_buf();
+        if tier != AgentTier::L0Orchestration {
+            let scope = Self {
+                tier,
+                allowed_roots: vec![canonical_home],
+                home_root,
+                cross_project_indexes: Vec::new(),
+            };
+            tracing::info!(target: "trusty_agents::cross_project", "{}", scope.audit_summary());
+            return scope;
+        }
+
+        let mut allowed_roots = vec![canonical_home];
+        let mut cross_project_indexes: Vec<String> = Vec::new();
+        for entry in entries {
+            if entry.status != ProjectStatus::Active || !entry.is_real_project() {
+                continue;
+            }
+            if !is_git_repo_root(&entry.path) {
+                continue;
+            }
+            let root = canonical_or_verbatim(&entry.path);
+            if allowed_roots.contains(&root) {
+                continue;
+            }
+            let index_id = trusty_common::derive_index_id(&root);
+            allowed_roots.push(root);
+            if !index_id.is_empty() && !cross_project_indexes.contains(&index_id) {
+                cross_project_indexes.push(index_id);
+            }
+        }
+
+        let scope = Self {
+            tier,
+            home_root,
+            allowed_roots,
+            cross_project_indexes,
+        };
+        tracing::info!(target: "trusty_agents::cross_project", "{}", scope.audit_summary());
+        scope
+    }
+
+    /// Resolve an agent's scope, loading the on-disk project registry
+    /// (#4172).
+    ///
+    /// Why: The production entry point. Registry I/O can only ever SHRINK
+    /// the allow-set: no `$HOME`, a missing file, or malformed JSON all yield
+    /// an EMPTY snapshot, which collapses even an L0 agent to its home root.
+    /// Failing closed on a read problem is the only safe direction for a
+    /// privilege boundary. (`ProjectRegistry::list_active` already degrades a
+    /// parse failure to an empty map itself; the `unwrap_or_else` below is
+    /// belt-and-braces for any error it does surface.)
+    /// What: `ProjectRegistry::new().list_active()`, then [`Self::resolve`].
+    /// Test: `from_registry_fails_closed_when_registry_is_unreadable`,
+    /// `from_registry_loads_active_entries_for_l0`.
+    pub async fn from_registry(agent: &AgentInfo, home_root: &Path) -> Self {
+        let entries = match ProjectRegistry::new() {
+            Ok(reg) => reg.list_active().await.unwrap_or_else(|e| {
+                tracing::warn!(
+                    target: "trusty_agents::cross_project",
+                    "project registry unreadable ({e:#}); cross-project reach denied"
+                );
+                Vec::new()
+            }),
+            Err(e) => {
+                tracing::warn!(
+                    target: "trusty_agents::cross_project",
+                    "project registry unavailable ({e:#}); cross-project reach denied"
+                );
+                Vec::new()
+            }
+        };
+        Self::resolve(agent, home_root, &entries)
+    }
+
+    /// Same as [`Self::from_registry`] but against an explicit registry file
+    /// (#4172).
+    ///
+    /// Why: `ProjectRegistry::new()` hardcodes `$HOME`, and mutating `HOME`
+    /// from a test is process-global and races every other test in the
+    /// binary. An explicit path lets the boundary tests drive the REAL
+    /// registry loader over a real `projects.json` in a tempdir, rather than
+    /// hand-building `ProjectEntry` values and skipping the loader entirely.
+    /// What: Identical to [`Self::from_registry`], including its fail-closed
+    /// error handling, but reads `registry_path`.
+    /// Test: `from_registry_loads_active_entries_for_l0`,
+    /// `from_registry_fails_closed_when_registry_is_unreadable`.
+    pub async fn from_registry_path(
+        agent: &AgentInfo,
+        home_root: &Path,
+        registry_path: PathBuf,
+    ) -> Self {
+        let entries = ProjectRegistry::with_registry_path(registry_path)
+            .list_active()
+            .await
+            .unwrap_or_else(|e| {
+                tracing::warn!(
+                    target: "trusty_agents::cross_project",
+                    "project registry unreadable ({e:#}); cross-project reach denied"
+                );
+                Vec::new()
+            });
+        Self::resolve(agent, home_root, &entries)
+    }
+
+    /// The tier this scope was resolved for.
+    ///
+    /// Test: `unrecognized_tier_declaration_resolves_to_single_tenant_scope`,
+    /// `undeclared_tier_follows_the_kind_derivation`.
+    pub fn tier(&self) -> AgentTier {
+        self.tier
+    }
+
+    /// The agent's own project root — the default target of every tool bound
+    /// to this scope.
+    ///
+    /// Test: `l1_scope_allows_only_its_home_root`.
+    pub fn home_root(&self) -> &Path {
+        &self.home_root
+    }
+
+    /// Every root this agent may operate in, home root first.
+    ///
+    /// Test: `l0_scope_includes_registered_git_projects`.
+    pub fn allowed_roots(&self) -> &[PathBuf] {
+        &self.allowed_roots
+    }
+
+    /// Whether this scope reaches beyond its home root at all.
+    ///
+    /// Why: The git tool schemas advertise a `repo` argument ONLY when this
+    /// is true, so an L1 persona's tool surface is unchanged down to the
+    /// JSON schema — the model is never shown a knob it cannot turn.
+    /// What: True exactly when more than one root is permitted (L0 with at
+    /// least one admitted registry project).
+    /// Test: `single_tenant_scope_is_not_cross_project`,
+    /// `l0_scope_includes_registered_git_projects`.
+    pub fn is_cross_project(&self) -> bool {
+        self.allowed_roots.len() > 1
+    }
+
+    /// The cross-project trusty-search index ids this agent may query
+    /// (#4172, epic #4007 tier-2).
+    ///
+    /// Test: `l0_cross_project_indexes_are_derived_from_allowed_roots`.
+    pub fn cross_project_indexes(&self) -> &[String] {
+        &self.cross_project_indexes
+    }
+
+    /// Widen an agent's DECLARED tier-2 index list with its cross-project
+    /// reach (#4172).
+    ///
+    /// Why: `vector_search` derives both its schema enumeration and its
+    /// (opt-in) fail-closed allowlist from one list
+    /// (`VectorSearchTool::allowed_index_ids`). Folding cross-project ids in
+    /// at that one input is what makes "L0 can search other projects' code"
+    /// true without a second, divergent allowlist. Note the asymmetry this
+    /// preserves: `[[stores]]` — the ONE curated OKG store, DOC-54 §5.1 — is
+    /// not consulted or altered here; only the uncurated tier-2 list is
+    /// widened.
+    /// What: For any tier but L0, returns `declared` verbatim — byte-
+    /// identical to pre-#4172. For L0, appends the cross-project ids after
+    /// the declared ones (declaration order preserved, dedup, blanks
+    /// dropped) so an explicitly declared index always keeps its priority.
+    /// Test: `l1_effective_search_indexes_are_declared_list_verbatim`,
+    /// `l0_effective_search_indexes_append_cross_project_ids`,
+    /// `l0_effective_search_indexes_do_not_duplicate_declared_ids`.
+    pub fn effective_search_indexes(&self, declared: Vec<String>) -> Vec<String> {
+        if self.tier != AgentTier::L0Orchestration {
+            return declared;
+        }
+        let mut out: Vec<String> = Vec::new();
+        for id in declared
+            .iter()
+            .map(String::as_str)
+            .chain(self.cross_project_indexes.iter().map(String::as_str))
+        {
+            let id = id.trim();
+            if id.is_empty() || out.iter().any(|e| e == id) {
+                continue;
+            }
+            out.push(id.to_string());
+        }
+        out
+    }
+
+    /// Resolve a caller-supplied `repo` into a permitted absolute root, or
+    /// refuse (#4172).
+    ///
+    /// Why: This is THE enforcement point for the filesystem half of #4172 —
+    /// the one function every scoped tool calls, so "bounded to the
+    /// allow-set" is a property of one reviewable check rather than of
+    /// twelve tool bodies.
+    /// What: `None` / blank → the home root. Otherwise the path must be
+    /// ABSOLUTE (a relative path is refused rather than joined, so the
+    /// process cwd can never move the boundary), must canonicalize (an
+    /// unresolvable path cannot be PROVEN contained, so it is refused), and
+    /// must then be equal to or a component-wise descendant of one of
+    /// [`Self::allowed_roots`]. Canonicalizing first is what defeats `..`
+    /// traversal and symlinks; component-wise [`Path::starts_with`] is what
+    /// stops `/a/bc` from matching root `/a/b`. Every refusal is logged and
+    /// names the allow-set.
+    /// Test: `resolve_repo_root_defaults_to_home_root`,
+    /// `l1_resolve_repo_root_refuses_another_project`,
+    /// `l0_resolve_repo_root_accepts_registered_project`,
+    /// `l0_resolve_repo_root_accepts_subdirectory_of_registered_project`,
+    /// `l0_resolve_repo_root_refuses_unregistered_sibling`,
+    /// `l0_resolve_repo_root_refuses_parent_traversal_escape`,
+    /// `l0_resolve_repo_root_refuses_symlink_escape`,
+    /// `resolve_repo_root_refuses_relative_path`,
+    /// `resolve_repo_root_refuses_prefix_lookalike_sibling`.
+    pub fn resolve_repo_root(&self, requested: Option<&str>) -> Result<PathBuf, String> {
+        let Some(raw) = requested.map(str::trim).filter(|s| !s.is_empty()) else {
+            return Ok(self.home_root.clone());
+        };
+        let candidate = Path::new(raw);
+        if !candidate.is_absolute() {
+            return Err(self.denial(raw, "path is not absolute"));
+        }
+        let Ok(resolved) = candidate.canonicalize() else {
+            return Err(self.denial(raw, "path does not resolve to an existing directory"));
+        };
+        if self.permits(&resolved) {
+            return Ok(resolved);
+        }
+        Err(self.denial(raw, "path is outside this agent's project allow-set"))
+    }
+
+    /// Whether `path` lies inside this scope's allow-set (#4172).
+    ///
+    /// Why: A SECOND enforcement need that [`Self::resolve_repo_root`] alone
+    /// cannot cover. `crate::git::GitRepo::open` uses libgit2's
+    /// `Repository::discover`, which walks UPWARD from its seed — so a
+    /// permitted seed path can still resolve to a repository whose work tree
+    /// is an ANCESTOR outside the allow-set. The git tool surface re-checks
+    /// the discovered work tree through this predicate before acting on it,
+    /// closing that hop.
+    /// What: Canonicalizes `path` (falling back to it verbatim) and tests
+    /// component-wise containment against every allowed root.
+    /// Test: `permits_accepts_home_root_and_descendants`,
+    /// `l0_permits_registered_project_but_not_its_parent`.
+    pub fn permits(&self, path: &Path) -> bool {
+        let resolved = canonical_or_verbatim(path);
+        self.allowed_roots.iter().any(|r| resolved.starts_with(r))
+    }
+
+    /// One-line audit record of this scope's resolved boundary (#4172).
+    ///
+    /// Why: Requirement that the widening be auditable. Emitted at
+    /// construction so a session log always states which roots an agent was
+    /// granted, and reused verbatim in every refusal message so the model —
+    /// and the operator reading the transcript — sees the same allow-set the
+    /// gate applied.
+    /// What: `tier=<L0|L1> cross_project=<bool> roots=[…] indexes=[…]`.
+    /// Test: `audit_summary_names_tier_and_allowed_roots`.
+    pub fn audit_summary(&self) -> String {
+        let tier = match self.tier {
+            AgentTier::L0Orchestration => "L0Orchestration",
+            AgentTier::L1Standard => "L1Standard",
+        };
+        let roots = self
+            .allowed_roots
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        format!(
+            "cross-project scope: tier={tier} cross_project={} roots=[{roots}] indexes=[{}]",
+            self.is_cross_project(),
+            self.cross_project_indexes.join(", ")
+        )
+    }
+
+    /// Build (and log) the refusal message for a rejected `repo` argument.
+    ///
+    /// Why: Keeps the `tracing::warn!` audit line and the model-facing error
+    /// string in lockstep — a denial that is reported to the model but not
+    /// logged (or vice versa) is exactly the gap "auditable" has to close.
+    /// What: Logs at warn and returns the same text.
+    /// Test: `l1_resolve_repo_root_refuses_another_project`.
+    fn denial(&self, raw: &str, reason: &str) -> String {
+        let msg = format!("repo '{raw}' denied: {reason}. {}", self.audit_summary());
+        tracing::warn!(target: "trusty_agents::cross_project", "{msg}");
+        msg
+    }
+}
+
+/// Canonicalize `path`, falling back to it verbatim.
+///
+/// Why: The allow-set and the candidate must be compared in the SAME
+/// representation or containment is meaningless (macOS APFS is
+/// case-insensitive/case-preserving, and a symlinked home alias reaches the
+/// same directory by a different string on every platform). Canonicalizing
+/// both sides collapses those to one form. A root that cannot be
+/// canonicalized (deleted between registry write and now) is kept verbatim
+/// rather than dropped, which is safe in the restrictive direction: a
+/// candidate IS canonicalized, so it can only ever match a verbatim root
+/// that was already canonical.
+/// What: `std::fs::canonicalize` or the input.
+/// Test: `l0_resolve_repo_root_accepts_registered_project`,
+/// `l0_resolve_repo_root_refuses_symlink_escape`.
+fn canonical_or_verbatim(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Whether `path` is the root of a git repository.
+///
+/// Why: Condition (d) of the allow-set. A registry entry is a directory the
+/// user connected trusty-agents to; requiring a `.git` entry keeps the
+/// git-tool allow-set to actual repositories instead of every such
+/// directory, and matches the "must be a real git checkout" bar
+/// `trusty-code`'s own project roster already applies.
+/// What: `path.join(".git").exists()` — true for both a normal repo
+/// (directory) and a worktree/submodule (gitfile), which is deliberate:
+/// `.base/.worktrees/*` checkouts are exactly the roots an orchestration
+/// persona works in.
+/// Test: `l0_scope_excludes_non_git_and_inactive_and_temp_entries`.
+fn is_git_repo_root(path: &Path) -> bool {
+    path.join(".git").exists()
+}

--- a/crates/trusty-agents/src/agents/cross_project/tests.rs
+++ b/crates/trusty-agents/src/agents/cross_project/tests.rs
@@ -1,0 +1,706 @@
+//! Boundary tests for the L0-only cross-project scope (#4172, epic #4167).
+//!
+//! Why: These are privilege-boundary tests, so they must exercise the REAL
+//! resolution paths rather than hand-built helper arguments:
+//! - the tier always comes from a real `agent.toml` parsed by the real
+//!   loader (`AgentConfig::by_name_in`), so #4200's fail-closed
+//!   `AgentInfo::tier` is the thing under test — never a locally
+//!   constructed `AgentTier`;
+//! - the project allow-set always comes from a real `projects.json` read by
+//!   the real registry loader (`ProjectRegistry::list_active`), via
+//!   `CrossProjectScope::from_registry_path`;
+//! - containment is always asserted through the public entry points
+//!   (`resolve_repo_root` / `permits` / `effective_search_indexes`) that the
+//!   git tools and `vector_search` actually call.
+//!
+//! What: Four groups — L1 scoping is unchanged; L0's widening is bounded to
+//! the registry allow-set and cannot escape it; a declared-but-unrecognized
+//! tier fails closed to L1 for either role; and an UNDECLARED tier follows
+//! ADR-0024 decision 3's kind derivation (PR #4296) — assistant-kind resolves
+//! L0, every sub-agent kind stays L1 and single-tenant.
+//! Test: this module.
+
+use std::path::{Path, PathBuf};
+
+use serde_json::{Value, json};
+use tempfile::TempDir;
+
+use super::CrossProjectScope;
+use crate::agents::{AgentConfig, AgentTier};
+
+/// A scratch directory the project registry will accept as a real project.
+///
+/// Why: `ProjectEntry::is_real_project` — condition (b) of the allow-set —
+/// deliberately rejects `/tmp/…`, `/private/tmp/…`, `/var/folders/…`,
+/// `/private/var/…` and any path whose basename starts with `.tmp`. That is
+/// EVERY default `tempfile::TempDir` on both macOS (`/var/folders/…`) and
+/// Linux (`/tmp/…`), and `TempDir`'s own default prefix is `.tmp`. Testing
+/// the real predicate therefore requires scratch space outside those
+/// patterns, so these tests root their temp dirs in the workspace `target/`
+/// directory (gitignored, always present during a test run) with a
+/// non-`.tmp` prefix.
+/// What: A `TempDir` under `<workspace>/target/t4172/x4172-*`.
+/// Test: used by every case in this module.
+fn scratch() -> TempDir {
+    let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("..")
+        .join("..")
+        .join("target")
+        .join("t4172");
+    std::fs::create_dir_all(&base).expect("mkdir scratch base");
+    tempfile::Builder::new()
+        .prefix("x4172-")
+        .tempdir_in(&base)
+        .expect("tempdir")
+}
+
+/// Write a package-layout `agent.toml` and load it through the REAL loader.
+///
+/// Why: `AgentConfig::by_name_in` is the production resolution path (it is
+/// what `by_name` delegates to), so a tier read out of a config built this
+/// way is the tier production would see — including the fail-closed arms for
+/// an absent or unrecognized `tier` value.
+/// What: Creates `<dir>/<name>/agent.toml` with the given `tier` line (empty
+/// string = omit the key entirely) and returns the loaded config.
+/// Test: used by every case in this module.
+fn load_agent_with_tier(dir: &Path, name: &str, tier_line: &str) -> AgentConfig {
+    load_agent_with_tier_and_role(dir, name, "assistant", tier_line)
+}
+
+/// As above, but with the persona's `role` under test too.
+///
+/// Why: ADR-0024 decision 3 (PR #4296) made an undeclared `tier` a function of
+/// the agent's KIND, so a fixture that hardcodes `role = "assistant"` can no
+/// longer express the "derives L1" case at all.
+fn load_agent_with_tier_and_role(
+    dir: &Path,
+    name: &str,
+    role: &str,
+    tier_line: &str,
+) -> AgentConfig {
+    let agent_dir = dir.join(name);
+    std::fs::create_dir_all(&agent_dir).expect("mkdir agent dir");
+    let toml = format!(
+        r#"[agent]
+name = "{name}"
+role = "{role}"
+description = "test persona for #4172"
+model = "claude-sonnet-4-5"
+{tier_line}
+
+[llm]
+temperature = 0.2
+max_tokens = 4096
+"#
+    );
+    std::fs::write(agent_dir.join("agent.toml"), toml).expect("write agent.toml");
+    // The package layout requires a sibling `persona.md`; the loader reads it
+    // as the persona prose.
+    std::fs::write(agent_dir.join("persona.md"), "Test persona prose.\n")
+        .expect("write persona.md");
+    AgentConfig::by_name_in(&[dir.to_path_buf()], name).expect("load agent config")
+}
+
+/// Create a directory that looks like a git repository root.
+///
+/// Why: Condition (d) of the allow-set is "carries a `.git` entry"; the
+/// tests must produce that condition the same way the predicate reads it.
+/// What: `mkdir -p <parent>/<name>/.git` and returns the CANONICAL root.
+/// Test: used by the L0 admission cases.
+fn make_repo(parent: &Path, name: &str) -> PathBuf {
+    let root = parent.join(name);
+    std::fs::create_dir_all(root.join(".git")).expect("mkdir repo/.git");
+    std::fs::canonicalize(&root).expect("canonicalize repo root")
+}
+
+/// Write a real `projects.json` in the registry's on-disk shape.
+///
+/// Why: So `ProjectRegistry::load` / `list_active` — the production loader,
+/// including its `status == Active` filter — is what produces the entry list
+/// the scope is built from.
+/// What: A JSON map keyed by canonical path string, matching
+/// `HashMap<String, ProjectEntry>`. Each tuple is `(path, status)`.
+/// Test: used by the L0 admission cases.
+fn write_registry(path: &Path, entries: &[(&Path, &str)]) {
+    let mut map = serde_json::Map::new();
+    for (p, status) in entries {
+        map.insert(
+            p.display().to_string(),
+            json!({
+                "path": p.display().to_string(),
+                "name": p.file_name().and_then(|s| s.to_str()).unwrap_or("x"),
+                "last_run": null,
+                "status": status,
+            }),
+        );
+    }
+    let body = serde_json::to_string(&Value::Object(map)).expect("serialize registry");
+    std::fs::write(path, body).expect("write projects.json");
+}
+
+// ---------------------------------------------------------------------------
+// L1: scoping unchanged (single-tenant)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn single_tenant_scope_is_not_cross_project() {
+    let tmp = scratch();
+    let scope = CrossProjectScope::single_tenant(tmp.path().to_path_buf());
+    assert_eq!(scope.tier(), AgentTier::L1Standard);
+    assert!(!scope.is_cross_project());
+    assert_eq!(scope.allowed_roots().len(), 1);
+    assert!(scope.cross_project_indexes().is_empty());
+    // The default target must be the value the caller passed, verbatim —
+    // pre-#4172 call sites depend on it.
+    assert_eq!(scope.home_root(), tmp.path());
+}
+
+#[tokio::test]
+async fn l1_scope_allows_only_its_home_root() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let other = make_repo(tmp.path(), "other-project");
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &[(other.as_path(), "active")]);
+
+    let cfg_dir = tmp.path().join("agents");
+    // `tier = "l1"` — an EXPLICIT standard-tier persona.
+    let cfg = load_agent_with_tier(&cfg_dir, "l1-explicit", "tier = \"l1\"");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+
+    assert_eq!(scope.tier(), AgentTier::L1Standard);
+    assert!(!scope.is_cross_project());
+    assert_eq!(scope.allowed_roots(), std::slice::from_ref(&home));
+    assert!(scope.cross_project_indexes().is_empty());
+}
+
+#[tokio::test]
+async fn l1_resolve_repo_root_refuses_another_project() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let other = make_repo(tmp.path(), "other-project");
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &[(other.as_path(), "active")]);
+
+    let cfg_dir = tmp.path().join("agents");
+    let cfg = load_agent_with_tier(&cfg_dir, "l1-refuses", "tier = \"standard\"");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+
+    let err = scope
+        .resolve_repo_root(Some(other.to_str().unwrap()))
+        .expect_err("L1 must not reach a second project");
+    assert!(
+        err.contains("outside this agent's project allow-set"),
+        "{err}"
+    );
+    // The refusal names the allow-set it applied (auditability).
+    assert!(err.contains("tier=L1Standard"), "{err}");
+}
+
+#[tokio::test]
+async fn l1_effective_search_indexes_are_declared_list_verbatim() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let other = make_repo(tmp.path(), "other-project");
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &[(other.as_path(), "active")]);
+
+    let cfg_dir = tmp.path().join("agents");
+    let cfg = load_agent_with_tier(&cfg_dir, "l1-indexes", "tier = \"l1\"");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+
+    let declared = vec!["cto-assistant".to_string(), "apex".to_string()];
+    assert_eq!(
+        scope.effective_search_indexes(declared.clone()),
+        declared,
+        "L1's tier-2 index list must be byte-identical to what it declared"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// L0: widened reach, bounded to the registry allow-set
+// ---------------------------------------------------------------------------
+
+/// Build an L0 scope over a temp world.
+///
+/// Why: Every L0 case needs the same four-step setup (repos, registry file,
+/// `agent.toml`, resolve); duplicating it obscures what each case asserts.
+/// What: Returns `(tmp, home_root, scope)`. `extra` names additional repos to
+/// create AND register as active.
+/// Test: used by the L0 cases below.
+async fn l0_world(extra: &[&str]) -> (TempDir, PathBuf, CrossProjectScope) {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let mut created: Vec<PathBuf> = Vec::new();
+    for name in extra {
+        created.push(make_repo(tmp.path(), name));
+    }
+    let rows: Vec<(&Path, &str)> = created.iter().map(|p| (p.as_path(), "active")).collect();
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &rows);
+
+    let cfg_dir = tmp.path().join("agents");
+    let cfg = load_agent_with_tier(&cfg_dir, "l0-orchestrator", "tier = \"l0\"");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+    (tmp, home, scope)
+}
+
+#[tokio::test]
+async fn l0_scope_includes_registered_git_projects() {
+    let (_tmp, home, scope) = l0_world(&["alpha", "beta"]).await;
+    assert_eq!(scope.tier(), AgentTier::L0Orchestration);
+    assert!(scope.is_cross_project());
+    assert_eq!(
+        scope.allowed_roots().len(),
+        3,
+        "{:?}",
+        scope.allowed_roots()
+    );
+    assert_eq!(scope.allowed_roots()[0], home);
+}
+
+#[tokio::test]
+async fn l0_cross_project_indexes_are_derived_from_allowed_roots() {
+    let (_tmp, _home, scope) = l0_world(&["alpha", "beta"]).await;
+    let ids = scope.cross_project_indexes();
+    assert!(ids.contains(&"alpha".to_string()), "{ids:?}");
+    assert!(ids.contains(&"beta".to_string()), "{ids:?}");
+    // The agent's OWN root is never advertised as a cross-project index —
+    // that is `[[stores]]`'s job (DOC-54 §5.1), untouched here.
+    assert!(!ids.contains(&"home-project".to_string()), "{ids:?}");
+}
+
+#[tokio::test]
+async fn l0_effective_search_indexes_append_cross_project_ids() {
+    let (_tmp, _home, scope) = l0_world(&["alpha"]).await;
+    let out = scope.effective_search_indexes(vec!["cto-assistant".to_string()]);
+    assert_eq!(out, vec!["cto-assistant".to_string(), "alpha".to_string()]);
+}
+
+#[tokio::test]
+async fn l0_effective_search_indexes_do_not_duplicate_declared_ids() {
+    let (_tmp, _home, scope) = l0_world(&["alpha"]).await;
+    let out = scope.effective_search_indexes(vec!["alpha".to_string(), "  ".to_string()]);
+    assert_eq!(out, vec!["alpha".to_string()]);
+}
+
+#[tokio::test]
+async fn l0_resolve_repo_root_accepts_registered_project() {
+    let (tmp, _home, scope) = l0_world(&["alpha"]).await;
+    let alpha = std::fs::canonicalize(tmp.path().join("alpha")).unwrap();
+    let got = scope
+        .resolve_repo_root(Some(alpha.to_str().unwrap()))
+        .expect("L0 may reach a registered project");
+    assert_eq!(got, alpha);
+}
+
+#[tokio::test]
+async fn l0_resolve_repo_root_accepts_subdirectory_of_registered_project() {
+    let (tmp, _home, scope) = l0_world(&["alpha"]).await;
+    let sub = tmp.path().join("alpha").join("crates");
+    std::fs::create_dir_all(&sub).unwrap();
+    let sub = std::fs::canonicalize(&sub).unwrap();
+    let got = scope
+        .resolve_repo_root(Some(sub.to_str().unwrap()))
+        .expect("a descendant of an allowed root is allowed");
+    assert_eq!(got, sub);
+}
+
+#[tokio::test]
+async fn l0_resolve_repo_root_refuses_unregistered_sibling() {
+    let (tmp, _home, scope) = l0_world(&["alpha"]).await;
+    // A real git repo sitting right next to `alpha`, but absent from the
+    // registry — the bound is the registry, not "any repo on disk".
+    let rogue = make_repo(tmp.path(), "rogue");
+    let err = scope
+        .resolve_repo_root(Some(rogue.to_str().unwrap()))
+        .expect_err("an unregistered repo must be refused even for L0");
+    assert!(
+        err.contains("outside this agent's project allow-set"),
+        "{err}"
+    );
+    assert!(err.contains("tier=L0Orchestration"), "{err}");
+}
+
+#[tokio::test]
+async fn l0_resolve_repo_root_refuses_parent_traversal_escape() {
+    let (tmp, _home, scope) = l0_world(&["alpha"]).await;
+    // `<tmp>/alpha/..` is `<tmp>`, which is NOT an allowed root. Canonicalizing
+    // before the containment test is what catches this.
+    let escape = tmp.path().join("alpha").join("..");
+    let err = scope
+        .resolve_repo_root(Some(escape.to_str().unwrap()))
+        .expect_err("`..` must not walk out of the allow-set");
+    assert!(
+        err.contains("outside this agent's project allow-set"),
+        "{err}"
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn l0_resolve_repo_root_refuses_symlink_escape() {
+    let (tmp, _home, scope) = l0_world(&["alpha"]).await;
+    let outside = make_repo(tmp.path(), "outside-not-registered");
+    let link = tmp.path().join("alpha").join("sneaky");
+    std::os::unix::fs::symlink(&outside, &link).expect("symlink");
+    // The link LIVES inside an allowed root but POINTS outside it.
+    let err = scope
+        .resolve_repo_root(Some(link.to_str().unwrap()))
+        .expect_err("a symlink target outside the allow-set must be refused");
+    assert!(
+        err.contains("outside this agent's project allow-set"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn l0_scope_excludes_non_git_and_inactive_and_temp_entries() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    // (a) active + git   -> admitted
+    let good = make_repo(tmp.path(), "good");
+    // (b) active but NOT a git repo -> rejected by condition (d)
+    let plain = tmp.path().join("plain");
+    std::fs::create_dir_all(&plain).unwrap();
+    let plain = std::fs::canonicalize(&plain).unwrap();
+    // (c) a git repo whose registry status is `removed` -> rejected by (a)
+    let stale = make_repo(tmp.path(), "stale");
+    // (d) a registered path that does not exist -> rejected by (c)
+    let ghost = tmp.path().join("ghost");
+    // (e) a real git repo under a temp-dir pattern -> rejected by (b),
+    //     `ProjectEntry::is_real_project`.
+    let temp_shaped = PathBuf::from("/tmp").join("x4172-not-a-real-project");
+    std::fs::create_dir_all(temp_shaped.join(".git")).expect("mkdir /tmp repo");
+
+    let registry = tmp.path().join("projects.json");
+    write_registry(
+        &registry,
+        &[
+            (good.as_path(), "active"),
+            (plain.as_path(), "active"),
+            (stale.as_path(), "removed"),
+            (ghost.as_path(), "active"),
+            (temp_shaped.as_path(), "active"),
+        ],
+    );
+
+    let cfg_dir = tmp.path().join("agents");
+    let cfg = load_agent_with_tier(&cfg_dir, "l0-filter", "tier = \"orchestration\"");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+
+    assert_eq!(scope.allowed_roots(), &[home, good.clone()]);
+    for rejected in [plain, stale, ghost, temp_shaped] {
+        assert!(
+            scope
+                .resolve_repo_root(Some(rejected.to_str().unwrap()))
+                .is_err(),
+            "must not admit {}",
+            rejected.display()
+        );
+    }
+}
+
+#[tokio::test]
+async fn l0_permits_registered_project_but_not_its_parent() {
+    let (tmp, _home, scope) = l0_world(&["alpha"]).await;
+    assert!(scope.permits(&tmp.path().join("alpha")));
+    assert!(!scope.permits(tmp.path()));
+}
+
+// ---------------------------------------------------------------------------
+// Fail-closed behaviour
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn unrecognized_tier_declaration_resolves_to_single_tenant_scope() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let other = make_repo(tmp.path(), "other-project");
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &[(other.as_path(), "active")]);
+    let cfg_dir = tmp.path().join("agents");
+
+    // Every DECLARED spelling #4200's resolver fails closed on — an
+    // unrecognized value, including "l2", which must NOT be read as "more
+    // privileged than l1". Checked against the assistant kind as well as a
+    // sub-agent kind: after ADR-0024 decision 3 (PR #4296) an ABSENT tier
+    // derives from the role, and a declared-but-unrecognized string must NOT
+    // fall through to that derivation and quietly widen an assistant's reach.
+    for role in ["assistant", "engineer"] {
+        for (name, tier_line) in [
+            ("bogus-tier", "tier = \"level-zero\""),
+            ("l2-tier", "tier = \"l2\""),
+            ("l1-tier", "tier = \"l1\""),
+        ] {
+            let name = format!("{role}-{name}");
+            let cfg = load_agent_with_tier_and_role(&cfg_dir, &name, role, tier_line);
+            let scope =
+                CrossProjectScope::from_registry_path(&cfg.agent, &home, registry.clone()).await;
+            assert_eq!(
+                scope.tier(),
+                AgentTier::L1Standard,
+                "{name} must fail closed to L1"
+            );
+            assert!(!scope.is_cross_project(), "{name} must stay single-tenant");
+            assert!(
+                scope
+                    .resolve_repo_root(Some(other.to_str().unwrap()))
+                    .is_err(),
+                "{name} must not reach a second project"
+            );
+            assert!(
+                scope.cross_project_indexes().is_empty(),
+                "{name} must have no cross-project indexes"
+            );
+        }
+    }
+}
+
+/// The DERIVED case, after ADR-0024 decision 3 (PR #4296, on `main`): with no
+/// usable `tier =` declaration the tier is a function of the agent's KIND.
+///
+/// Why this test exists: #4172 was written when an absent tier meant L1, so
+/// the spellings below used to be single-tenant. They are now cross-project
+/// for assistant-kind — not because this PR widened the bound (the allow-set
+/// is still exactly "home root, plus active + real + existing + git-root
+/// entries of `projects.json`"), but because `main` changed which personas are
+/// L0. Pinning the derivation here means a future change to that population
+/// fails loudly instead of silently redefining every persona's reach.
+#[tokio::test]
+async fn undeclared_tier_follows_the_kind_derivation() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let other = make_repo(tmp.path(), "other-project");
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &[(other.as_path(), "active")]);
+    let cfg_dir = tmp.path().join("agents");
+
+    for (name, tier_line) in [
+        ("no-tier", ""),
+        ("blank-tier", "tier = \"\""),
+        ("space-tier", "tier = \"   \""),
+    ] {
+        // Assistant kind derives L0 and therefore reaches the registered,
+        // active sibling — but still ONLY that: the bound is unchanged.
+        let a_name = format!("assistant-{name}");
+        let cfg = load_agent_with_tier_and_role(&cfg_dir, &a_name, "assistant", tier_line);
+        let scope =
+            CrossProjectScope::from_registry_path(&cfg.agent, &home, registry.clone()).await;
+        assert_eq!(
+            scope.tier(),
+            AgentTier::L0Orchestration,
+            "{a_name} is assistant-kind and derives L0 (ADR-0024 decision 3)"
+        );
+        assert!(scope.is_cross_project(), "{a_name} must be cross-project");
+        assert!(
+            scope
+                .resolve_repo_root(Some(other.to_str().unwrap()))
+                .is_ok(),
+            "{a_name} must reach the registered active sibling"
+        );
+        // The bound still holds: an unregistered path is refused.
+        let unregistered = make_repo(tmp.path(), "unregistered-project");
+        assert!(
+            scope
+                .resolve_repo_root(Some(unregistered.to_str().unwrap()))
+                .is_err(),
+            "{a_name} must NOT reach a project absent from the registry"
+        );
+
+        // Sub-agent kinds stay L1 and single-tenant.
+        for role in ["engineer", "researcher", "planner"] {
+            let s_name = format!("{role}-{name}");
+            let cfg = load_agent_with_tier_and_role(&cfg_dir, &s_name, role, tier_line);
+            let scope =
+                CrossProjectScope::from_registry_path(&cfg.agent, &home, registry.clone()).await;
+            assert_eq!(
+                scope.tier(),
+                AgentTier::L1Standard,
+                "{s_name} is a sub-agent kind and must stay L1"
+            );
+            assert!(
+                !scope.is_cross_project(),
+                "{s_name} must stay single-tenant"
+            );
+            assert!(
+                scope
+                    .resolve_repo_root(Some(other.to_str().unwrap()))
+                    .is_err(),
+                "{s_name} must not reach a second project"
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn from_registry_loads_active_entries_for_l0() {
+    // Guards the loader wiring itself: the widening must come from a real
+    // `projects.json` read, so a scope built over a registry file that
+    // exists and lists an active repo is cross-project.
+    let (_tmp, _home, scope) = l0_world(&["alpha"]).await;
+    assert!(scope.is_cross_project());
+}
+
+#[tokio::test]
+async fn from_registry_fails_closed_when_registry_is_unreadable() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let alpha = make_repo(tmp.path(), "alpha");
+    let registry = tmp.path().join("projects.json");
+    // Malformed JSON: the loader cannot produce entries, so the L0 widening
+    // must collapse to the home root rather than proceed on a
+    // partially-parsed allow-set.
+    std::fs::write(&registry, "{ this is not json").unwrap();
+
+    let cfg_dir = tmp.path().join("agents");
+    let cfg = load_agent_with_tier(&cfg_dir, "l0-broken-registry", "tier = \"l0\"");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+
+    assert_eq!(scope.tier(), AgentTier::L0Orchestration);
+    assert!(
+        !scope.is_cross_project(),
+        "unreadable registry must deny reach"
+    );
+    assert!(
+        scope
+            .resolve_repo_root(Some(alpha.to_str().unwrap()))
+            .is_err(),
+        "no reach may survive an unreadable registry"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Shared path-resolution rules
+// ---------------------------------------------------------------------------
+
+#[test]
+fn resolve_repo_root_defaults_to_home_root() {
+    let tmp = scratch();
+    let scope = CrossProjectScope::single_tenant(tmp.path().to_path_buf());
+    assert_eq!(scope.resolve_repo_root(None).unwrap(), tmp.path());
+    assert_eq!(scope.resolve_repo_root(Some("")).unwrap(), tmp.path());
+    assert_eq!(scope.resolve_repo_root(Some("   ")).unwrap(), tmp.path());
+}
+
+#[tokio::test]
+async fn resolve_repo_root_refuses_relative_path() {
+    let (_tmp, _home, scope) = l0_world(&["alpha"]).await;
+    let err = scope
+        .resolve_repo_root(Some("alpha"))
+        .expect_err("a relative path must be refused, not joined to the cwd");
+    assert!(err.contains("not absolute"), "{err}");
+}
+
+#[tokio::test]
+async fn resolve_repo_root_refuses_prefix_lookalike_sibling() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let alpha = make_repo(tmp.path(), "alpha");
+    // `alpha-extra` shares a STRING prefix with the allowed `alpha` but is a
+    // different directory; component-wise containment must reject it.
+    let lookalike = make_repo(tmp.path(), "alpha-extra");
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &[(alpha.as_path(), "active")]);
+
+    let cfg_dir = tmp.path().join("agents");
+    let cfg = load_agent_with_tier(&cfg_dir, "l0-lookalike", "tier = \"l0\"");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+
+    assert!(
+        scope
+            .resolve_repo_root(Some(alpha.to_str().unwrap()))
+            .is_ok()
+    );
+    assert!(
+        scope
+            .resolve_repo_root(Some(lookalike.to_str().unwrap()))
+            .is_err(),
+        "a string-prefix sibling must not be treated as contained"
+    );
+}
+
+#[test]
+fn permits_accepts_home_root_and_descendants() {
+    let tmp = scratch();
+    let home = tmp.path().join("home");
+    let sub = home.join("crates").join("inner");
+    std::fs::create_dir_all(&sub).unwrap();
+    let scope = CrossProjectScope::single_tenant(home.clone());
+    assert!(scope.permits(&home));
+    assert!(scope.permits(&sub));
+    assert!(!scope.permits(tmp.path()));
+}
+
+#[test]
+fn audit_summary_names_tier_and_allowed_roots() {
+    let tmp = scratch();
+    let scope = CrossProjectScope::single_tenant(tmp.path().to_path_buf());
+    let line = scope.audit_summary();
+    assert!(line.contains("tier=L1Standard"), "{line}");
+    assert!(line.contains("cross_project=false"), "{line}");
+    assert!(
+        line.contains(
+            &std::fs::canonicalize(tmp.path())
+                .unwrap()
+                .display()
+                .to_string()
+        ),
+        "{line}"
+    );
+}
+
+/// The SHIPPED-PERSONA consequence of this PR landing after ADR-0024
+/// decision 3 (PR #4296) — recorded as a reviewed fact, not left implicit.
+///
+/// Why: ADR-0024's "Capability grants: zero observable delta" analysis was
+/// written while #4170/#4172/#4173 were still open, and it holds for the other
+/// two — their tools are gated by NAME, and no bundled assistant's
+/// `[tools].allow` matches one. It does NOT hold for this PR. `git_log` and
+/// `git_status` ARE in the shipped `izzie` / `personal-assistant` allow-lists,
+/// so those personas — assistant-kind, therefore L0 by derivation — go from a
+/// single-tenant git surface to a cross-project one bounded by the operator's
+/// own `projects.json`. That is a real, if bounded, widening of what an
+/// untrusted-content-ingesting persona can read, and it should fail this test
+/// (and be re-reviewed) rather than change silently again.
+///
+/// What: an assistant-kind persona with no declared tier, over a registry
+/// holding one active sibling repo, resolves a CROSS-PROJECT scope that
+/// reaches that sibling — and still refuses anything the registry does not
+/// list. Read-only vs write is a `[tools].allow` question, not a scope
+/// question, and is covered by `git_write_tools_refuse_repo_outside_allow_set`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn shipped_assistant_kind_gains_bounded_cross_project_git_reach() {
+    let tmp = scratch();
+    let home = make_repo(tmp.path(), "home-project");
+    let sibling = make_repo(tmp.path(), "registered-sibling");
+    let unregistered = make_repo(tmp.path(), "unregistered-sibling");
+    let registry = tmp.path().join("projects.json");
+    write_registry(&registry, &[(sibling.as_path(), "active")]);
+    let cfg_dir = tmp.path().join("agents");
+
+    // No `tier =` line — exactly how every bundled assistant ships, since
+    // decision 3 forbids hand-declaring it.
+    let cfg = load_agent_with_tier_and_role(&cfg_dir, "izzie-shaped", "assistant", "");
+    let scope = CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await;
+
+    assert_eq!(scope.tier(), AgentTier::L0Orchestration);
+    assert!(
+        scope.is_cross_project(),
+        "a shipped-shaped assistant persona now resolves a cross-project scope — \
+         this is the #4172 + #4296 delta and is deliberate"
+    );
+    assert!(
+        scope
+            .resolve_repo_root(Some(sibling.to_str().unwrap()))
+            .is_ok(),
+        "it reaches the registered active sibling"
+    );
+    assert!(
+        scope
+            .resolve_repo_root(Some(unregistered.to_str().unwrap()))
+            .is_err(),
+        "and NOTHING beyond the registry — the bound is what makes the delta acceptable"
+    );
+}

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -16,6 +16,8 @@ pub mod claude_code_runner;
 pub mod claude_mpm_loader;
 mod config;
 pub mod context_filter;
+// #4172 (epic #4167): L0-only cross-project git/search scoping.
+pub mod cross_project;
 // ADR-0024: the KIND delegation predicate. `pub(crate)` — it is an
 // enforcement primitive, not part of the crate's public surface.
 pub(crate) mod delegation;
@@ -44,6 +46,8 @@ pub use params::{
     AgentCompressConfig, AgentPluginsConfig, LlmParams, RbacConfig, RunnerConfig,
     SessionCompressionConfig, ToolChoice, WorkstreamContextConfig,
 };
+// #4172: the L0-only cross-project scope resolver (epic #4167).
+pub use cross_project::CrossProjectScope;
 // #3936: the `[permissions]` section (DOC-57 §7).
 pub use permissions::{
     AutonomyMode, GrantMode, PermissionGrant, PermissionsConfig, effective_scopes,

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -223,12 +223,21 @@ pub async fn run_pm_task_with_persona(
                     }
                 }
             }
-            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-            if let Ok(repo) = crate::git::GitRepo::open(&cwd) {
-                for tool in crate::tools::git_tools::git_tools(repo.root.clone()) {
-                    registry.register(tool);
-                }
-            }
+            // #4172 (epic #4167): resolve THIS persona's cross-project reach
+            // once, and hand the same value to both consumers below — the git
+            // tool surface and `vector_search`'s tier-2 index list. The tier
+            // comes from #4200's fail-closed `AgentInfo::tier`, so an L1
+            // persona (and any persona whose `tier` is absent, blank, or
+            // unrecognized) resolves to the single-tenant scope and every
+            // downstream surface is byte-identical to pre-#4172. The allow-set
+            // for an L0 persona is bounded to the on-disk project registry —
+            // see `crate::agents::cross_project` for the full rule and for why
+            // `[[stores]]`'s one-store ceiling (DOC-54 §5.1) is untouched.
+            let cross_project_scope = crate::tools::git_tools::register_scoped_git_tools(
+                &mut registry,
+                &persona_cfg.agent,
+            )
+            .await;
             register_ticketing_tools(&mut registry).await;
             // #4170 (epic #4167): the L0-only GitHub PR/CI inspection surface.
             // Registered on BOTH assistant dispatch paths — this one and
@@ -368,15 +377,25 @@ pub async fn run_pm_task_with_persona(
             // the persona opts in with `enforce_search_indexes = true`. A
             // persona declaring neither gets `(vec![], false)` — identical to
             // the pre-#3232 registration above.
+            //
+            // #4172 (epic #4167): for an L0 persona the declared tier-2 list
+            // is widened with the trusty-search index ids of its registered
+            // projects, so cross-project corpora are both DISCOVERABLE (they
+            // are enumerated in the schema) and, when this persona opts into
+            // `enforce_search_indexes`, queryable. For every other tier
+            // `effective_search_indexes` returns `resolved_search_indexes()`
+            // verbatim. `[[stores]]` — the ONE curated OKG store, DOC-54
+            // §5.1 — is neither read nor widened by that call.
+            let bound_index = persona_cfg
+                .stores
+                .default_search_index()
+                .map(str::to_string);
+            let attached = cross_project_scope
+                .effective_search_indexes(persona_cfg.tools.resolved_search_indexes());
             registry.register(Arc::new(
                 crate::tools::memory::VectorSearchTool::new()
-                    .with_default_index(
-                        persona_cfg
-                            .stores
-                            .default_search_index()
-                            .map(str::to_string),
-                    )
-                    .with_attached_indexes(persona_cfg.tools.resolved_search_indexes())
+                    .with_default_index(bound_index)
+                    .with_attached_indexes(attached)
                     .with_index_enforcement(persona_cfg.tools.search_indexes_enforced()),
             ));
 

--- a/crates/trusty-agents/src/registry/store.rs
+++ b/crates/trusty-agents/src/registry/store.rs
@@ -37,6 +37,23 @@ impl ProjectRegistry {
         })
     }
 
+    /// Create a registry handle pointing at an EXPLICIT `projects.json`
+    /// (#4172).
+    ///
+    /// Why: [`Self::new`] resolves `$HOME`, so any test that wants to drive
+    /// the real loader over a known registry file has to mutate `HOME` — a
+    /// process-global that races every other test in the binary. An explicit
+    /// path lets the #4172 cross-project boundary tests exercise the REAL
+    /// `load`/`list_active` code path over a real file in a tempdir instead
+    /// of hand-building `ProjectEntry` values and skipping the loader.
+    /// What: Same struct, no home-dir resolution, hence no failure mode.
+    /// Every read/write method behaves identically.
+    /// Test: `from_registry_loads_active_entries_for_l0`,
+    /// `from_registry_fails_closed_when_registry_is_unreadable`.
+    pub fn with_registry_path(registry_path: PathBuf) -> Self {
+        Self { registry_path }
+    }
+
     /// Load all registry entries from disk.
     ///
     /// Why: Callers need the full map to update and re-save it without losing

--- a/crates/trusty-agents/src/tools/git_tools/branch.rs
+++ b/crates/trusty-agents/src/tools/git_tools/branch.rs
@@ -1,17 +1,18 @@
 //! Branch-oriented git tools: list, create, and checkout branches.
 
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+use crate::agents::CrossProjectScope;
 use crate::git;
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
-use super::helpers::{fn_schema, open_repo};
+use super::helpers::{open_scoped_repo, scoped_root, scoped_schema};
 
 pub(super) struct GitBranchesTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -20,7 +21,8 @@ impl ToolExecutor for GitBranchesTool {
         "git_branches"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_branches",
             "List local branches (and optionally remote-tracking branches) with current-branch and upstream metadata.",
             json!({
@@ -38,7 +40,7 @@ impl ToolExecutor for GitBranchesTool {
             .get("include_remote")
             .and_then(Value::as_bool)
             .unwrap_or(false);
-        let repo = match open_repo(&self.root) {
+        let repo = match open_scoped_repo(&self.scope, &args, "git_branches") {
             Ok(r) => r,
             Err(e) => return ToolResult::err(e),
         };
@@ -61,7 +63,7 @@ impl ToolExecutor for GitBranchesTool {
 }
 
 pub(super) struct GitCreateBranchTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -70,7 +72,8 @@ impl ToolExecutor for GitCreateBranchTool {
         "git_create_branch"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_create_branch",
             "Create a new local branch from HEAD and check it out.",
             json!({
@@ -87,7 +90,11 @@ impl ToolExecutor for GitCreateBranchTool {
         let Some(name) = args.get("name").and_then(Value::as_str) else {
             return ToolResult::err("'name' is required");
         };
-        match git::branch::create_branch(name, &self.root).await {
+        let root = match scoped_root(&self.scope, &args, "git_create_branch") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
+        match git::branch::create_branch(name, &root).await {
             Ok(out) => ToolResult::ok(out),
             Err(e) => ToolResult::err(format!("git_create_branch failed: {e}")),
         }
@@ -95,7 +102,7 @@ impl ToolExecutor for GitCreateBranchTool {
 }
 
 pub(super) struct GitCheckoutTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -104,7 +111,8 @@ impl ToolExecutor for GitCheckoutTool {
         "git_checkout"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_checkout",
             "Check out an existing branch, tag, or commit.",
             json!({
@@ -121,7 +129,11 @@ impl ToolExecutor for GitCheckoutTool {
         let Some(target) = args.get("target").and_then(Value::as_str) else {
             return ToolResult::err("'target' is required");
         };
-        match git::branch::checkout(target, &self.root).await {
+        let root = match scoped_root(&self.scope, &args, "git_checkout") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
+        match git::branch::checkout(target, &root).await {
             Ok(out) => ToolResult::ok(out),
             Err(e) => ToolResult::err(format!("git_checkout failed: {e}")),
         }

--- a/crates/trusty-agents/src/tools/git_tools/helpers.rs
+++ b/crates/trusty-agents/src/tools/git_tools/helpers.rs
@@ -1,10 +1,15 @@
 //! Shared schema and repo-opening helpers for the git tool surface.
 
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use serde_json::{Value, json};
 
+use crate::agents::CrossProjectScope;
 use crate::git::GitRepo;
+
+/// The optional per-call repo selector added to every git tool schema when —
+/// and only when — the bound scope reaches more than one project (#4172).
+pub(super) const REPO_ARG: &str = "repo";
 
 /// Build an OpenAI-style function schema envelope.
 ///
@@ -23,6 +28,71 @@ pub(super) fn fn_schema(name: &str, description: &str, params: Value) -> Value {
     })
 }
 
+/// [`fn_schema`] plus the tier-gated `repo` selector (#4172, epic #4167).
+///
+/// Why: An L1 persona's git surface must be unchanged down to the JSON
+/// schema — showing it a `repo` knob it can never turn would both waste
+/// tokens and invite the model to keep retrying a call the gate will keep
+/// refusing. So the argument is advertised only when
+/// [`CrossProjectScope::is_cross_project`] is true, which by construction
+/// only an L0 persona with at least one admitted registry project can be.
+/// What: When the scope is single-tenant, returns [`fn_schema`] verbatim —
+/// byte-identical to pre-#4172. Otherwise injects an optional `repo` string
+/// property (documented with the allow-set) into `params.properties`.
+/// `additionalProperties: false` on every git schema means an L1 persona
+/// passing `repo` is a schema violation on top of the gate's refusal.
+/// Test: `git_schemas_omit_repo_arg_for_single_tenant_scope`,
+/// `git_schemas_offer_repo_arg_for_cross_project_scope`.
+pub(super) fn scoped_schema(
+    scope: &CrossProjectScope,
+    name: &str,
+    description: &str,
+    mut params: Value,
+) -> Value {
+    if scope.is_cross_project()
+        && let Some(props) = params.get_mut("properties").and_then(Value::as_object_mut)
+    {
+        let roots = scope
+            .allowed_roots()
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", ");
+        props.insert(
+            REPO_ARG.to_string(),
+            json!({
+                "type": "string",
+                "description": format!(
+                    "Absolute path of the project to act on. Defaults to this agent's own \
+                     project. Permitted roots: {roots}"
+                )
+            }),
+        );
+    }
+    fn_schema(name, description, params)
+}
+
+/// Resolve the repository root ONE git tool call should act on (#4172).
+///
+/// Why: The single enforcement point shared by all twelve tools, so
+/// "bounded to the allow-set" is a property of one reviewable call rather
+/// than of twelve tool bodies.
+/// What: Delegates to [`CrossProjectScope::resolve_repo_root`] with the
+/// call's `repo` argument (absent → the agent's own root, exactly as
+/// pre-#4172), prefixing the tool name onto any refusal so the model can see
+/// which call was denied.
+/// Test: `git_status_refuses_repo_outside_allow_set`,
+/// `git_status_accepts_repo_inside_allow_set`.
+pub(super) fn scoped_root(
+    scope: &CrossProjectScope,
+    args: &Value,
+    tool: &str,
+) -> std::result::Result<PathBuf, String> {
+    scope
+        .resolve_repo_root(args.get(REPO_ARG).and_then(Value::as_str))
+        .map_err(|e| format!("{tool}: {e}"))
+}
+
 /// Open the git repository rooted at `root`, mapping errors to tool-friendly
 /// strings.
 ///
@@ -32,4 +102,37 @@ pub(super) fn fn_schema(name: &str, description: &str, params: Value) -> Value {
 /// Test: Exercised indirectly by `git_status_executes_against_trusty_agents_repo`.
 pub(super) fn open_repo(root: &Path) -> std::result::Result<GitRepo, String> {
     GitRepo::open(root).map_err(|e| format!("failed to open git repo at {}: {e}", root.display()))
+}
+
+/// [`scoped_root`] + [`open_repo`] + a post-discovery containment re-check
+/// (#4172).
+///
+/// Why: `GitRepo::open` is libgit2's `Repository::discover`, which walks
+/// UPWARD from its seed. A permitted seed can therefore still resolve to a
+/// repository whose work tree is an ANCESTOR of the allow-set — a real
+/// escape hop that resolving the seed alone does not close. Re-checking the
+/// DISCOVERED work tree through [`CrossProjectScope::permits`] closes it.
+/// What: The re-check runs only when the caller named an explicit `repo`.
+/// Without one the tool targets the root its registration site bound it to,
+/// and upward discovery from that root is the pre-#4172 contract every
+/// existing call site relies on (`build_assistant_tier_registry` seeds the
+/// process cwd, which is routinely a subdirectory of the repo) — tightening
+/// THAT is a separate change, not #4172's cross-project widening.
+/// Test: `git_status_refuses_repo_outside_allow_set`,
+/// `git_status_accepts_repo_inside_allow_set`.
+pub(super) fn open_scoped_repo(
+    scope: &CrossProjectScope,
+    args: &Value,
+    tool: &str,
+) -> std::result::Result<GitRepo, String> {
+    let root = scoped_root(scope, args, tool)?;
+    let repo = open_repo(&root)?;
+    if args.get(REPO_ARG).and_then(Value::as_str).is_some() && !scope.permits(&repo.root) {
+        return Err(format!(
+            "{tool}: discovered work tree {} is outside this agent's project allow-set. {}",
+            repo.root.display(),
+            scope.audit_summary()
+        ));
+    }
+    Ok(repo)
 }

--- a/crates/trusty-agents/src/tools/git_tools/inspect.rs
+++ b/crates/trusty-agents/src/tools/git_tools/inspect.rs
@@ -1,17 +1,18 @@
 //! Read-only git tools: status, log, and commit search.
 
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+use crate::agents::CrossProjectScope;
 use crate::git;
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
-use super::helpers::{fn_schema, open_repo};
+use super::helpers::{open_scoped_repo, scoped_schema};
 
 pub(super) struct GitStatusTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -20,14 +21,15 @@ impl ToolExecutor for GitStatusTool {
         "git_status"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_status",
             "Show working-tree and index status (modified/added/deleted/untracked/renamed/conflicted files).",
             json!({"type":"object","properties":{},"required":[],"additionalProperties":false}),
         )
     }
-    async fn execute(&self, _args: Value) -> ToolResult {
-        let repo = match open_repo(&self.root) {
+    async fn execute(&self, args: Value) -> ToolResult {
+        let repo = match open_scoped_repo(&self.scope, &args, "git_status") {
             Ok(r) => r,
             Err(e) => return ToolResult::err(e),
         };
@@ -39,7 +41,7 @@ impl ToolExecutor for GitStatusTool {
 }
 
 pub(super) struct GitLogTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -48,7 +50,8 @@ impl ToolExecutor for GitLogTool {
         "git_log"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_log",
             "Show recent commits from HEAD. Optionally filter by substring search on commit messages.",
             json!({
@@ -69,7 +72,7 @@ impl ToolExecutor for GitLogTool {
             .map(|n| n as usize)
             .unwrap_or(10)
             .max(1);
-        let repo = match open_repo(&self.root) {
+        let repo = match open_scoped_repo(&self.scope, &args, "git_log") {
             Ok(r) => r,
             Err(e) => return ToolResult::err(e),
         };
@@ -86,7 +89,7 @@ impl ToolExecutor for GitLogTool {
 }
 
 pub(super) struct GitSearchCommitsTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -95,7 +98,8 @@ impl ToolExecutor for GitSearchCommitsTool {
         "git_search_commits"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_search_commits",
             "Search commit history for a substring in the commit message (case-insensitive).",
             json!({
@@ -119,7 +123,7 @@ impl ToolExecutor for GitSearchCommitsTool {
             .map(|n| n as usize)
             .unwrap_or(10)
             .max(1);
-        let repo = match open_repo(&self.root) {
+        let repo = match open_scoped_repo(&self.scope, &args, "git_search_commits") {
             Ok(r) => r,
             Err(e) => return ToolResult::err(e),
         };

--- a/crates/trusty-agents/src/tools/git_tools/mod.rs
+++ b/crates/trusty-agents/src/tools/git_tools/mod.rs
@@ -13,6 +13,7 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use crate::agents::CrossProjectScope;
 use crate::tools::traits::ToolExecutor;
 
 mod branch;
@@ -32,23 +33,106 @@ use write::{GitCommitTool, GitStageTool, GitStashTool};
 /// every tool is constructed with the same project root, so an
 /// LLM-instructed `git_status` and a follow-up `git_commit` both target
 /// the same repo.
-/// What: Returns an `Arc<dyn ToolExecutor>` for each of the 12 tools.
-/// Test: `git_tools_count_is_12`.
+/// What: Returns an `Arc<dyn ToolExecutor>` for each of the 12 tools, bound
+/// to the SINGLE-TENANT scope over `root` (#4172) — no `repo` argument in
+/// any schema, and every call targets `root`, exactly as before #4172. Call
+/// sites that want an L0 persona's cross-project reach use
+/// [`git_tools_scoped`] instead.
+/// Test: `git_tools_count_is_12`,
+/// `git_schemas_omit_repo_arg_for_single_tenant_scope`.
 pub fn git_tools(root: PathBuf) -> Vec<Arc<dyn ToolExecutor>> {
+    git_tools_scoped(Arc::new(CrossProjectScope::single_tenant(root)))
+}
+
+/// Build the 12 git tools bound to a resolved cross-project scope (#4172,
+/// epic #4167).
+///
+/// Why: An L0 orchestration persona has to reconcile state across several
+/// repos in one turn (#4172's "clone/pull repos outside the current
+/// project"). Handing every tool the SAME [`CrossProjectScope`] means the
+/// widening is decided once, by the tier resolver, rather than re-derived
+/// per tool — and means an L1 persona's twelve tools are provably identical
+/// to what they were, because [`CrossProjectScope::single_tenant`] is the
+/// shape `git_tools` still builds.
+/// What: Returns an `Arc<dyn ToolExecutor>` for each of the 12 tools, all
+/// sharing one `Arc<CrossProjectScope>`. When the scope reaches more than
+/// one project, each schema additionally advertises an optional absolute
+/// `repo` path; every call resolves it through
+/// [`CrossProjectScope::resolve_repo_root`], which refuses anything outside
+/// the allow-set.
+/// Test: `git_schemas_offer_repo_arg_for_cross_project_scope`,
+/// `git_status_refuses_repo_outside_allow_set`,
+/// `git_status_accepts_repo_inside_allow_set`.
+pub fn git_tools_scoped(scope: Arc<CrossProjectScope>) -> Vec<Arc<dyn ToolExecutor>> {
     vec![
-        Arc::new(GitStatusTool { root: root.clone() }),
-        Arc::new(GitLogTool { root: root.clone() }),
-        Arc::new(GitBranchesTool { root: root.clone() }),
-        Arc::new(GitCreateBranchTool { root: root.clone() }),
-        Arc::new(GitCheckoutTool { root: root.clone() }),
-        Arc::new(GitStageTool { root: root.clone() }),
-        Arc::new(GitCommitTool { root: root.clone() }),
-        Arc::new(GitPushTool { root: root.clone() }),
-        Arc::new(GitPullTool { root: root.clone() }),
-        Arc::new(GitFetchTool { root: root.clone() }),
-        Arc::new(GitStashTool { root: root.clone() }),
-        Arc::new(GitSearchCommitsTool { root }),
+        Arc::new(GitStatusTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitLogTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitBranchesTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitCreateBranchTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitCheckoutTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitStageTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitCommitTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitPushTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitPullTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitFetchTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitStashTool {
+            scope: scope.clone(),
+        }),
+        Arc::new(GitSearchCommitsTool { scope }),
     ]
+}
+
+/// Resolve a persona's cross-project scope and register its git tools
+/// (#4172, epic #4167).
+///
+/// Why: The persona-chat dispatch path needs BOTH halves of #4172 from one
+/// resolution — the git surface and `vector_search`'s tier-2 index list —
+/// and keeping the four-step sequence (resolve cwd's repo, resolve the
+/// scope, register, hand the scope back) here rather than inline at the call
+/// site keeps the boundary logic in the module that owns it.
+/// What: Discovers the repository containing the process cwd — the SAME
+/// seed the pre-#4172 call site used; the scope's home root is that
+/// repository's work tree when one is found (so every tool defaults to
+/// exactly the root it was bound to pre-#4172) and the cwd otherwise. Git
+/// tools are registered ONLY when a repository was found — unchanged from
+/// the pre-#4172 call site. Returns the scope so the caller can widen its
+/// search-index list with the same resolution.
+/// Test: `git_status_accepts_repo_inside_allow_set`,
+/// `single_tenant_git_tools_refuse_any_repo_argument`.
+pub async fn register_scoped_git_tools(
+    registry: &mut crate::tools::ToolRegistry,
+    agent: &crate::agents::AgentInfo,
+) -> Arc<CrossProjectScope> {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    let discovered = crate::git::GitRepo::open(&cwd).ok();
+    let home = discovered.as_ref().map(|r| r.root.clone()).unwrap_or(cwd);
+    let scope = Arc::new(CrossProjectScope::from_registry(agent, &home).await);
+    if discovered.is_some() {
+        for tool in git_tools_scoped(scope.clone()) {
+            registry.register(tool);
+        }
+    }
+    scope
 }
 
 #[cfg(test)]
@@ -170,5 +254,188 @@ mod tests {
         let out = tool.execute(json!({"action": "bogus"})).await;
         assert!(out.is_error());
         assert!(out.content().contains("bogus"));
+    }
+
+    // --- #4172 (epic #4167): tier-gated cross-project reach ---
+
+    /// Two real git repos plus the L0 scope that reaches both — built the
+    /// PRODUCTION way.
+    ///
+    /// Why: The cross-project cases need an actual repository to open (the
+    /// tools discover through libgit2 and shell out to `git -C`), and the
+    /// scope must come from the REAL resolution path, not a test-only
+    /// constructor: a real `agent.toml` parsed by `AgentConfig::by_name_in`
+    /// supplies the tier (via #4200's fail-closed `AgentInfo::tier`), and a
+    /// real `projects.json` read by `ProjectRegistry::list_active` supplies
+    /// the allow-set. A boundary proved against hand-built arguments proves
+    /// nothing about the boundary production uses.
+    /// What: Returns `(tempdir, home_root, second_root, scope)` where `scope`
+    /// permits both roots.
+    /// Test: used by the `git_*` cross-project cases below.
+    async fn two_repo_scope() -> (tempfile::TempDir, PathBuf, PathBuf, Arc<CrossProjectScope>) {
+        let base = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+            .join("target")
+            .join("t4172-git");
+        std::fs::create_dir_all(&base).unwrap();
+        let tmp = tempfile::Builder::new()
+            .prefix("x4172-")
+            .tempdir_in(&base)
+            .unwrap();
+        let home = init_repo(tmp.path(), "home-project");
+        let second = init_repo(tmp.path(), "second-project");
+
+        let registry = tmp.path().join("projects.json");
+        std::fs::write(
+            &registry,
+            json!({
+                second.display().to_string(): {
+                    "path": second.display().to_string(),
+                    "name": "second-project",
+                    "last_run": null,
+                    "status": "active"
+                }
+            })
+            .to_string(),
+        )
+        .unwrap();
+
+        let agents_dir = tmp.path().join("agents").join("l0-git");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+        std::fs::write(
+            agents_dir.join("agent.toml"),
+            "[agent]\nname = \"l0-git\"\nrole = \"assistant\"\n\
+             description = \"l0 fixture\"\n\
+             model = \"claude-sonnet-4-5\"\ntier = \"l0\"\n\n\
+             [llm]\ntemperature = 0.2\nmax_tokens = 4096\n",
+        )
+        .unwrap();
+        std::fs::write(agents_dir.join("persona.md"), "Orchestrator persona.\n").unwrap();
+        let cfg = crate::agents::AgentConfig::by_name_in(&[tmp.path().join("agents")], "l0-git")
+            .expect("load l0 agent config");
+
+        let scope =
+            Arc::new(CrossProjectScope::from_registry_path(&cfg.agent, &home, registry).await);
+        assert!(scope.is_cross_project(), "fixture must resolve to L0 reach");
+        (tmp, home, second, scope)
+    }
+
+    /// `git init` a real repository under `parent`.
+    ///
+    /// Test: used by `two_repo_scope`.
+    fn init_repo(parent: &std::path::Path, name: &str) -> PathBuf {
+        let root = parent.join(name);
+        std::fs::create_dir_all(&root).unwrap();
+        git2::Repository::init(&root).expect("git init");
+        std::fs::canonicalize(&root).unwrap()
+    }
+
+    #[test]
+    fn git_schemas_omit_repo_arg_for_single_tenant_scope() {
+        for tool in git_tools(cwd_root()) {
+            let s = tool.schema();
+            let props = &s["function"]["parameters"]["properties"];
+            assert!(
+                props.get("repo").is_none(),
+                "{} must not advertise `repo` on a single-tenant scope",
+                tool.name()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn git_schemas_offer_repo_arg_for_cross_project_scope() {
+        let (_tmp, _home, second, scope) = two_repo_scope().await;
+        for tool in git_tools_scoped(scope) {
+            let s = tool.schema();
+            let desc = s["function"]["parameters"]["properties"]["repo"]["description"]
+                .as_str()
+                .unwrap_or_else(|| panic!("{} must advertise `repo`", tool.name()));
+            assert!(
+                desc.contains(&second.display().to_string()),
+                "{} must name the allow-set: {desc}",
+                tool.name()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn git_status_accepts_repo_inside_allow_set() {
+        let (_tmp, _home, second, scope) = two_repo_scope().await;
+        let tools = git_tools_scoped(scope);
+        let tool = tools.iter().find(|t| t.name() == "git_status").unwrap();
+        let out = tool
+            .execute(json!({ "repo": second.to_str().unwrap() }))
+            .await;
+        assert!(!out.is_error(), "{}", out.content());
+    }
+
+    #[tokio::test]
+    async fn git_status_refuses_repo_outside_allow_set() {
+        let (tmp, _home, _second, scope) = two_repo_scope().await;
+        // A real repo that the scope was never granted.
+        let rogue = init_repo(tmp.path(), "rogue-project");
+        let tools = git_tools_scoped(scope);
+        for name in [
+            "git_status",
+            "git_log",
+            "git_branches",
+            "git_search_commits",
+        ] {
+            let tool = tools.iter().find(|t| t.name() == name).unwrap();
+            let out = tool
+                .execute(json!({ "repo": rogue.to_str().unwrap(), "query": "x" }))
+                .await;
+            assert!(out.is_error(), "{name} must refuse an unlisted repo");
+            assert!(
+                out.content()
+                    .contains("outside this agent's project allow-set"),
+                "{name}: {}",
+                out.content()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn git_write_tools_refuse_repo_outside_allow_set() {
+        let (tmp, _home, _second, scope) = two_repo_scope().await;
+        let rogue = init_repo(tmp.path(), "rogue-write");
+        let tools = git_tools_scoped(scope);
+        let repo = rogue.to_str().unwrap();
+        for (name, args) in [
+            ("git_create_branch", json!({"repo": repo, "name": "x"})),
+            ("git_checkout", json!({"repo": repo, "target": "main"})),
+            ("git_stage", json!({"repo": repo, "files": ["a.txt"]})),
+            ("git_commit", json!({"repo": repo, "message": "m"})),
+            ("git_stash", json!({"repo": repo, "action": "list"})),
+            ("git_push", json!({"repo": repo})),
+            ("git_pull", json!({"repo": repo})),
+            ("git_fetch", json!({"repo": repo})),
+        ] {
+            let tool = tools.iter().find(|t| t.name() == name).unwrap();
+            let out = tool.execute(args).await;
+            assert!(out.is_error(), "{name} must refuse an unlisted repo");
+            assert!(
+                out.content()
+                    .contains("outside this agent's project allow-set"),
+                "{name}: {}",
+                out.content()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn single_tenant_git_tools_refuse_any_repo_argument() {
+        let (tmp, home, second, _scope) = two_repo_scope().await;
+        // The L1 shape: `git_tools(root)` — the second repo exists and is a
+        // perfectly good repository, but this scope was never widened.
+        let tools = git_tools(home);
+        let tool = tools.iter().find(|t| t.name() == "git_status").unwrap();
+        let out = tool
+            .execute(json!({ "repo": second.to_str().unwrap() }))
+            .await;
+        assert!(out.is_error(), "L1 must not act on a second project");
+        drop(tmp);
     }
 }

--- a/crates/trusty-agents/src/tools/git_tools/remote.rs
+++ b/crates/trusty-agents/src/tools/git_tools/remote.rs
@@ -1,17 +1,18 @@
 //! Remote-interacting git tools: push, pull, and fetch.
 
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+use crate::agents::CrossProjectScope;
 use crate::git;
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
-use super::helpers::fn_schema;
+use super::helpers::{scoped_root, scoped_schema};
 
 pub(super) struct GitPushTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -20,7 +21,8 @@ impl ToolExecutor for GitPushTool {
         "git_push"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_push",
             "Push the current (or named) branch to origin.",
             json!({
@@ -35,7 +37,11 @@ impl ToolExecutor for GitPushTool {
     }
     async fn execute(&self, args: Value) -> ToolResult {
         let branch = args.get("branch").and_then(Value::as_str);
-        match git::remote::push(branch, &self.root).await {
+        let root = match scoped_root(&self.scope, &args, "git_push") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
+        match git::remote::push(branch, &root).await {
             Ok(out) => ToolResult::ok(out),
             Err(e) => ToolResult::err(format!("git_push failed: {e}")),
         }
@@ -43,7 +49,7 @@ impl ToolExecutor for GitPushTool {
 }
 
 pub(super) struct GitPullTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -52,7 +58,8 @@ impl ToolExecutor for GitPullTool {
         "git_pull"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_pull",
             "Pull from upstream. Defaults to rebase mode for linear history.",
             json!({
@@ -67,7 +74,11 @@ impl ToolExecutor for GitPullTool {
     }
     async fn execute(&self, args: Value) -> ToolResult {
         let rebase = args.get("rebase").and_then(Value::as_bool).unwrap_or(true);
-        match git::remote::pull(rebase, &self.root).await {
+        let root = match scoped_root(&self.scope, &args, "git_pull") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
+        match git::remote::pull(rebase, &root).await {
             Ok(out) => ToolResult::ok(out),
             Err(e) => ToolResult::err(format!("git_pull failed: {e}")),
         }
@@ -75,7 +86,7 @@ impl ToolExecutor for GitPullTool {
 }
 
 pub(super) struct GitFetchTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -84,14 +95,19 @@ impl ToolExecutor for GitFetchTool {
         "git_fetch"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_fetch",
             "Fetch refs from configured remotes without merging.",
             json!({"type":"object","properties":{},"required":[],"additionalProperties":false}),
         )
     }
-    async fn execute(&self, _args: Value) -> ToolResult {
-        match git::remote::fetch(&self.root).await {
+    async fn execute(&self, args: Value) -> ToolResult {
+        let root = match scoped_root(&self.scope, &args, "git_fetch") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
+        match git::remote::fetch(&root).await {
             Ok(out) => ToolResult::ok(out),
             Err(e) => ToolResult::err(format!("git_fetch failed: {e}")),
         }

--- a/crates/trusty-agents/src/tools/git_tools/write.rs
+++ b/crates/trusty-agents/src/tools/git_tools/write.rs
@@ -1,17 +1,18 @@
 //! Working-tree-mutating git tools: stage, commit, and stash.
 
-use std::path::PathBuf;
+use std::sync::Arc;
 
 use async_trait::async_trait;
 use serde_json::{Value, json};
 
+use crate::agents::CrossProjectScope;
 use crate::git;
 use crate::tools::traits::{ToolExecutor, ToolResult};
 
-use super::helpers::fn_schema;
+use super::helpers::{scoped_root, scoped_schema};
 
 pub(super) struct GitStageTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -20,7 +21,8 @@ impl ToolExecutor for GitStageTool {
         "git_stage"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_stage",
             "Stage one or more files for the next commit.",
             json!({
@@ -48,7 +50,11 @@ impl ToolExecutor for GitStageTool {
         if files.is_empty() {
             return ToolResult::err("'files' must contain at least one path");
         }
-        match git::commit::stage_files(&files, &self.root).await {
+        let root = match scoped_root(&self.scope, &args, "git_stage") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
+        match git::commit::stage_files(&files, &root).await {
             Ok(out) => {
                 let body = if out.is_empty() {
                     format!("Staged {} file(s)", files.len())
@@ -63,7 +69,7 @@ impl ToolExecutor for GitStageTool {
 }
 
 pub(super) struct GitCommitTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -72,7 +78,8 @@ impl ToolExecutor for GitCommitTool {
         "git_commit"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_commit",
             "Create a commit from staged changes. Honors hooks and signing via the git CLI.",
             json!({
@@ -89,7 +96,11 @@ impl ToolExecutor for GitCommitTool {
         let Some(message) = args.get("message").and_then(Value::as_str) else {
             return ToolResult::err("'message' is required");
         };
-        match git::commit::create_commit(message, &self.root).await {
+        let root = match scoped_root(&self.scope, &args, "git_commit") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
+        match git::commit::create_commit(message, &root).await {
             Ok(out) => ToolResult::ok(out),
             Err(e) => ToolResult::err(format!("git_commit failed: {e}")),
         }
@@ -97,7 +108,7 @@ impl ToolExecutor for GitCommitTool {
 }
 
 pub(super) struct GitStashTool {
-    pub(super) root: PathBuf,
+    pub(super) scope: Arc<CrossProjectScope>,
 }
 
 #[async_trait]
@@ -106,7 +117,8 @@ impl ToolExecutor for GitStashTool {
         "git_stash"
     }
     fn schema(&self) -> Value {
-        fn_schema(
+        scoped_schema(
+            &self.scope,
             "git_stash",
             "Stash management — push (save), pop (restore), or list.",
             json!({
@@ -125,13 +137,17 @@ impl ToolExecutor for GitStashTool {
             Some(a) => a,
             None => return ToolResult::err("'action' is required (push, pop, or list)"),
         };
+        let root = match scoped_root(&self.scope, &args, "git_stash") {
+            Ok(r) => r,
+            Err(e) => return ToolResult::err(e),
+        };
         let res = match action {
             "push" => {
                 let msg = args.get("message").and_then(Value::as_str);
-                git::stash::stash_push(msg, &self.root).await
+                git::stash::stash_push(msg, &root).await
             }
-            "pop" => git::stash::stash_pop(&self.root).await,
-            "list" => git::stash::stash_list(&self.root).await,
+            "pop" => git::stash::stash_pop(&root).await,
+            "list" => git::stash::stash_list(&root).await,
             other => {
                 return ToolResult::err(format!(
                     "unknown stash action '{other}' — expected push, pop, or list"


### PR DESCRIPTION
Closes #4172. Part of epic #4167 (L0/L1 persona tier model); builds directly on #4200 (`AgentTier` + fail-closed resolver).

## The normative tension, and why it dissolves

#4172 asks for cross-project store/index reach. `crates/trusty-agents/src/agents/extends/mod.rs` carries a hard constraint in the opposite direction — a child's `[[stores]]` REPLACES the parent's because **DOC-54 §5.1 allows exactly ONE OKG store per agent** (Bob, 2026-07-24).

**This PR does not relax that rule, for either tier.** DOC-54 §5.1 governs `[[stores]]`: the agent's ONE *dedicated, curated* OKG store — its OKF knowledge tree plus the index over that tree. Nothing in this PR reads, writes, unions, or widens `[[stores]]`, and the `extends` replace-not-union rule is untouched.

The multiplicity #4172 asks for already has a sanctioned home. Epic #4007's **tier-2** mechanism — `[tools].search_indexes` (#3232) — exists precisely for "also let me search the APEX repo", and its own field docs state the split verbatim:

> `[[stores]]` is the CURATED tier — exactly one OKG store per agent by the 2026-07-24 owner decision, **and that ceiling stays**. The multiplicity an agent needs … belongs to a second, uncurated tier.

So cross-project *reach* is a tier-2 + filesystem question, not a `[[stores]]` question, and #4172 is implementable without touching a normative spec constraint. No owner escalation needed.

## What the bound is, and how it is enforced

New `crate::agents::cross_project::CrossProjectScope` — the single resolution point for "which repo roots and which search indexes may THIS agent touch".

**L0 allow-set** = the agent's own home project root, PLUS every entry of `~/.trusty-agents/projects.json` that is *simultaneously*:

| # | Condition | Enforced by |
|---|-----------|-------------|
| a | `ProjectStatus::Active` | `ProjectRegistry::list_active` + explicit re-check |
| b | `ProjectEntry::is_real_project()` (no `/tmp`, `/var/folders`, `.tmp*`) | the registry's own predicate |
| c | the directory exists | `canonicalize` at resolution time |
| d | it is a git repository root (`.git` present) | `is_git_repo_root` |

**L1 allow-set** = its home root, and nothing else — byte-identically today's behaviour.

Enforcement details:
- **Tier is never re-derived.** `AgentInfo::tier()` (#4200) is the only source; absent / blank / unrecognized (incl. `"l2"`) → `L1Standard` → single-tenant scope.
- **Registry failure denies reach.** No `$HOME`, missing file, or malformed JSON ⇒ empty snapshot ⇒ even an L0 agent collapses to its home root.
- **Containment is component-wise** `Path::starts_with` against *canonicalized* roots. Candidates must be absolute (a relative path is refused, never joined to the cwd) and must canonicalize (unprovable ⇒ refused). This defeats `..` traversal, symlink escape, and `/a/bc` vs `/a/b` string-prefix siblings.
- **Post-discovery re-check.** `GitRepo::open` is libgit2's `Repository::discover`, which walks *upward* — a permitted seed can still land on an ancestor work tree outside the allow-set. `open_scoped_repo` re-validates the discovered work tree. It runs only when the caller named an explicit `repo`, so the pre-#4172 contract (registration sites seed the process cwd, routinely a subdirectory) is preserved exactly.

**Auditability:** `audit_summary()` renders `tier=… cross_project=… roots=[…] indexes=[…]`, logged at `tracing::info` on construction and repeated verbatim in every refusal — at `tracing::warn` and in the error returned to the model.

**Why the trusty-agents registry and not trusty-mpm's:** trusty-mpm's curated registry is unreachable from this crate as Rust types (no `trusty-mpm` dependency; the sanctioned pattern is a loopback HTTP GET), carries **no local filesystem path** (records are keyed on `name`/`repo_url`), and a path can only be *fabricated* from it via the `~/trusty-mpm-projects/<owner>/<repo>` convention. A privilege boundary must not depend on a sibling daemon being up, nor on a guessed path. The in-crate registry is on-disk, deterministic, and user-inspectable via `list_projects`.

**Credential leakage:** none introduced. This resolves *paths* and *index ids* only; cross-project git runs through the same ambient credential helper the home project already uses. No per-project secret is read, copied, or forwarded.

## Wiring

- `git_tools_scoped(scope)` builds the 12 git tools over a resolved scope. The optional per-call `repo` argument is advertised in the JSON schema **only** when the scope is cross-project (so an L1 persona is never shown a knob it cannot turn; `additionalProperties: false` makes passing it a schema violation on top of the gate's refusal), and every call resolves it through the gate.
- `git_tools(root)` keeps its exact signature and single-tenant behaviour, so the three other registration sites (`runtime/tool_registry.rs`, `runtime/pm_mode.rs`, `ctrl/handlers/registry.rs`) are unchanged by construction.
- The persona dispatch path resolves ONE scope and feeds it to both consumers: the git surface and `vector_search`'s tier-2 index list (`effective_search_indexes`, which returns the declared list verbatim for any tier but L0).
- `ProjectRegistry::with_registry_path` — additive test seam so boundary tests drive the real loader without mutating process-global `$HOME`.

The delegation tier gate (#4200) and `~/.trusty-agents/agents/` personas are untouched. No persona declares `tier = "l0"` yet, so this PR changes no shipped agent's behaviour.

## Tests (24 new + 6 git-surface cases)

All exercise **real resolution paths**, not hand-built helper arguments:
- tier from a real `agent.toml` through `AgentConfig::by_name_in`;
- allow-set from a real `projects.json` through `ProjectRegistry::list_active`;
- git cases against real `git init`ed repos, driven through the tools' own `execute`.

Coverage: L1 scoping unchanged (`l1_scope_allows_only_its_home_root`, `l1_resolve_repo_root_refuses_another_project`, `l1_effective_search_indexes_are_declared_list_verbatim`, `git_schemas_omit_repo_arg_for_single_tenant_scope`, `single_tenant_git_tools_refuse_any_repo_argument`); L0 bounded and inescapable (`l0_resolve_repo_root_refuses_unregistered_sibling`, `..._refuses_parent_traversal_escape`, `..._refuses_symlink_escape`, `resolve_repo_root_refuses_prefix_lookalike_sibling`, `resolve_repo_root_refuses_relative_path`, `l0_scope_excludes_non_git_and_inactive_and_temp_entries`, `git_status_refuses_repo_outside_allow_set`, `git_write_tools_refuse_repo_outside_allow_set`); fail-closed (`indeterminate_tier_resolves_to_single_tenant_scope` over 5 indeterminate spellings, `from_registry_fails_closed_when_registry_is_unreadable`).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
