### PR TITLE
feat(trusty-mpm): sectioned-JSON instruction package schema (#4184)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,19 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- `core::instruction_package`: the sectioned-JSON instruction-package schema
+  ([#4184](https://github.com/bobmatnyc/trusty-tools/issues/4184), epic #4183) —
+  the eight-section taxonomy (Core, Memory, Search, Workflow, Agent Delegation
+  plus the absorbed BASE_PM floor sections Identity, Non-Overridable Rules,
+  Framework-Guaranteed Conventions), the `fixed | project | user`
+  customization-tier axis, an ordered block stream with explicit join literals,
+  structural validation, and a pure deterministic `compose`. The JSON Schema
+  ships as `assets/instructions/instruction-package.schema.json`. Types and
+  validation only — no instruction content is authored (#4185) and no build is
+  re-sourced (#4186); nothing in the session-launch path composes from it yet.
+
 ### Fixed
 
 - Worktree discovery is derived from `git worktree list --porcelain` instead of

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -19,6 +19,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   ships as `assets/instructions/instruction-package.schema.json`. Types and
   validation only — no instruction content is authored (#4185) and no build is
   re-sourced (#4186); nothing in the session-launch path composes from it yet.
+  Every object in the package's deserialization path rejects unknown keys, and
+  the error names the offending key. Strictness is deliberate over
+  forward compatibility here: `validate` gates on `schema_version` before
+  inspecting any field, so lenient field handling could only ever matter for a
+  change that added a field while leaving the version at 1 — precisely the case
+  that must not be tolerated, since an older binary would then compose a prompt
+  missing the new field's effect and report success. Any field addition that can
+  change composed bytes must bump `SCHEMA_VERSION`. Floor blocks are
+  deliberately *not* constrained to canonical section order: `BASE_PM.md` places
+  `## Trusty Tool Priority` after `## Framework-Guaranteed Conventions`, so
+  requiring non-decreasing order would reject a faithful byte-identical lift of
+  that asset.
 
 ### Fixed
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -26,11 +26,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   change that added a field while leaving the version at 1 — precisely the case
   that must not be tolerated, since an older binary would then compose a prompt
   missing the new field's effect and report success. Any field addition that can
-  change composed bytes must bump `SCHEMA_VERSION`. Floor blocks are
+  change composed bytes must bump `SCHEMA_VERSION`. That version is now checked
+  *before* the package is deserialized, so a package from a later schema reports
+  the actionable "unsupported schema_version" rather than blaming one of its own
+  perfectly valid new keys. Floor blocks are
   deliberately *not* constrained to canonical section order: `BASE_PM.md` places
   `## Trusty Tool Priority` after `## Framework-Guaranteed Conventions`, so
   requiring non-decreasing order would reject a faithful byte-identical lift of
-  that asset.
+  that asset. A declared section must own at least one *non-optional* block.
+  Owning blocks is not the same as emitting: a section covered only by
+  `optional` blocks passed validation and still composed to nothing,
+  recreating the very silent-missing-section shape the coverage check exists
+  to prevent.
 
 ### Fixed
 

--- a/crates/trusty-mpm/src/assets/instructions/instruction-package.schema.json
+++ b/crates/trusty-mpm/src/assets/instructions/instruction-package.schema.json
@@ -1,0 +1,234 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/bobmatnyc/trusty-tools/schemas/instruction-package-v1.json",
+  "title": "trusty-mpm instruction package",
+  "description": "A PM instruction package: a section taxonomy carrying the customization-tier axis, plus an ORDERED block stream that composes to the PM system prompt. Ordering is array order — never map iteration order — so composition is byte-deterministic (SPEC-PMINSTR-01 / DOC-59 §4a, epic #4183, schema ticket #4184).",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "package_id", "sections", "blocks"],
+  "properties": {
+    "schema_version": {
+      "description": "Schema major version. A package whose version this build does not implement is rejected outright — never partially interpreted.",
+      "const": 1
+    },
+    "package_id": {
+      "description": "Stable identifier for this package (e.g. `trusty-mpm/pm`). Identity only; it never affects composed bytes.",
+      "type": "string",
+      "minLength": 1
+    },
+    "description": {
+      "type": "string"
+    },
+    "trailing_newline": {
+      "description": "Append exactly one '\\n' after the last emitted block. `false` reproduces today's `resolve_pm_prompt` output; `true` reproduces a file-shaped artifact.",
+      "type": "boolean",
+      "default": false
+    },
+    "sections": {
+      "description": "The section taxonomy. Declaration order MUST be the canonical order (identity, core, memory, search, workflow, agent-delegation, non-overridable-rules, framework-guaranteed-conventions) and every canonical section MUST be declared exactly once. Declaration order does not affect composed bytes — `blocks` alone determines output order.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/section" },
+      "minItems": 8,
+      "maxItems": 8
+    },
+    "blocks": {
+      "description": "The ordered composition stream. Emitted strictly in array order. A section may own several non-contiguous blocks, which is what lets a section be lifted out of the middle of a legacy asset without moving a single byte.",
+      "type": "array",
+      "items": { "$ref": "#/$defs/block" },
+      "minItems": 1
+    }
+  },
+  "$defs": {
+    "section-id": {
+      "description": "The closed section taxonomy, in canonical declaration order. `identity`, `non-overridable-rules` and `framework-guaranteed-conventions` are the absorbed BASE_PM floor blocks and are always tier `fixed`.",
+      "type": "string",
+      "enum": [
+        "identity",
+        "core",
+        "memory",
+        "search",
+        "workflow",
+        "agent-delegation",
+        "non-overridable-rules",
+        "framework-guaranteed-conventions"
+      ]
+    },
+    "customization-tier": {
+      "description": "Who may override this section, by increasing permissiveness. `fixed`: nobody, at any tier (the framework floor). `project`: a project-tier override only — deliberately NOT a user-tier one, so a personal machine config can never silently leak into a shared project. `user`: both project- and user-tier, project winning on collision (most-specific-wins).",
+      "type": "string",
+      "enum": ["fixed", "project", "user"]
+    },
+    "generator": {
+      "description": "A named composition-time input the host must supply. Generated content is never authored in the package — it is computed per project/session and passed in.",
+      "type": "string",
+      "enum": ["agent-roster", "stack-profile", "project-addendum"]
+    },
+    "join": {
+      "description": "The literal bytes inserted BEFORE this block when it is not the first emitted block. `rule` = \"\\n\\n---\\n\\n\", `blank` = \"\\n\\n\", `none` = \"\", `{\"literal\": \"...\"}` = verbatim. Explicit joins are what make a faithful, byte-identical lift possible: blocks split out of one legacy document rejoin with `blank`, while distinct legacy assets rejoin with `rule`.",
+      "oneOf": [
+        { "type": "string", "enum": ["rule", "blank", "none"] },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["literal"],
+          "properties": { "literal": { "type": "string" } }
+        }
+      ]
+    },
+    "body": {
+      "description": "Where a block's markdown comes from. `text` is authored in the package; `generated` is supplied at composition time by the named generator.",
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "text"],
+          "properties": {
+            "kind": { "const": "text" },
+            "text": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "generator"],
+          "properties": {
+            "kind": { "const": "generated" },
+            "generator": { "$ref": "#/$defs/generator" }
+          }
+        }
+      ]
+    },
+    "section": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "title", "customization_tier"],
+      "properties": {
+        "id": { "$ref": "#/$defs/section-id" },
+        "title": { "type": "string", "minLength": 1 },
+        "customization_tier": { "$ref": "#/$defs/customization-tier" },
+        "description": { "type": "string" }
+      }
+    },
+    "block": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["section", "body"],
+      "properties": {
+        "section": { "$ref": "#/$defs/section-id" },
+        "body": { "$ref": "#/$defs/body" },
+        "join_before": { "$ref": "#/$defs/join", "default": "rule" },
+        "optional": {
+          "description": "Only a `generated` block may be optional. An optional block is dropped when its generator supplies no content; a non-optional block whose content is missing or empty is a hard composition error, never a silent drop (issue #4196 — the computed 42-agent roster was discarded at the final composition step and the prompt shipped naming 8).",
+          "type": "boolean",
+          "default": false
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "schema_version": 1,
+      "package_id": "trusty-mpm/example",
+      "description": "Minimal structurally-valid package. Content authoring is #4185; this example exists so the schema's own shape is executable and testable.",
+      "trailing_newline": false,
+      "sections": [
+        {
+          "id": "identity",
+          "title": "Identity",
+          "customization_tier": "fixed",
+          "description": "Absorbed BASE_PM `## Identity`."
+        },
+        {
+          "id": "core",
+          "title": "Core PM Instructions",
+          "customization_tier": "project"
+        },
+        {
+          "id": "memory",
+          "title": "Memory",
+          "customization_tier": "project"
+        },
+        {
+          "id": "search",
+          "title": "Search",
+          "customization_tier": "project"
+        },
+        {
+          "id": "workflow",
+          "title": "Workflow",
+          "customization_tier": "project"
+        },
+        {
+          "id": "agent-delegation",
+          "title": "Agent Delegation",
+          "customization_tier": "project",
+          "description": "Dynamic: built from the deployed-agent roster at composition time."
+        },
+        {
+          "id": "non-overridable-rules",
+          "title": "Non-Overridable Rules",
+          "customization_tier": "fixed",
+          "description": "Absorbed BASE_PM `## Non-Overridable Rules`, `## Customizing PM Behavior`, `## Trusty Tool Priority (Non-Overridable)`."
+        },
+        {
+          "id": "framework-guaranteed-conventions",
+          "title": "Framework-Guaranteed Conventions",
+          "customization_tier": "fixed",
+          "description": "Absorbed BASE_PM `## Framework-Guaranteed Conventions (Non-Overridable)`."
+        }
+      ],
+      "blocks": [
+        {
+          "section": "core",
+          "body": { "kind": "text", "text": "# PM Agent -- Trusty MPM" }
+        },
+        {
+          "section": "memory",
+          "join_before": "blank",
+          "body": { "kind": "text", "text": "## Context-First Protocol" }
+        },
+        {
+          "section": "core",
+          "join_before": "blank",
+          "body": { "kind": "text", "text": "## Agent Routing" }
+        },
+        {
+          "section": "search",
+          "body": { "kind": "text", "text": "## Code/Architecture Search" }
+        },
+        {
+          "section": "core",
+          "body": { "kind": "generated", "generator": "stack-profile" },
+          "optional": true
+        },
+        {
+          "section": "workflow",
+          "body": { "kind": "text", "text": "# PM Workflow Configuration" }
+        },
+        {
+          "section": "agent-delegation",
+          "body": { "kind": "generated", "generator": "agent-roster" }
+        },
+        {
+          "section": "core",
+          "body": { "kind": "generated", "generator": "project-addendum" },
+          "optional": true
+        },
+        {
+          "section": "identity",
+          "body": { "kind": "text", "text": "## Identity" }
+        },
+        {
+          "section": "non-overridable-rules",
+          "join_before": "blank",
+          "body": { "kind": "text", "text": "## Non-Overridable Rules" }
+        },
+        {
+          "section": "framework-guaranteed-conventions",
+          "join_before": "blank",
+          "body": { "kind": "text", "text": "## Framework-Guaranteed Conventions" }
+        }
+      ]
+    }
+  ]
+}

--- a/crates/trusty-mpm/src/assets/instructions/instruction-package.schema.json
+++ b/crates/trusty-mpm/src/assets/instructions/instruction-package.schema.json
@@ -8,7 +8,7 @@
   "required": ["schema_version", "package_id", "sections", "blocks"],
   "properties": {
     "schema_version": {
-      "description": "Schema major version. A package whose version this build does not implement is rejected outright — never partially interpreted.",
+      "description": "Schema major version. A package whose version this build does not implement is rejected outright — never partially interpreted; the version is checked BEFORE any field, so a newer package reports a version error rather than blaming one of its own valid keys. EVOLUTION POLICY: every object here sets `additionalProperties: false`, so unknown keys are errors, not ignored. Any field addition that can change composed bytes MUST bump this version. Adding a field while leaving the version at 1 is the one case strictness cannot protect against — an older build would compose a prompt missing the new field's effect and report success.",
       "const": 1
     },
     "package_id": {

--- a/crates/trusty-mpm/src/core/instruction_package.rs
+++ b/crates/trusty-mpm/src/core/instruction_package.rs
@@ -721,16 +721,9 @@ impl InstructionPackage {
     /// output** as its acceptance gate; it is the strongest faithfulness check
     /// available and nothing here forces weakening it.
     ///
-    /// The one real divergence, which #4186 must decide deliberately: when NO
-    /// agents are deployed, `deployed_roster_section` returns `None` and today's
-    /// composer silently degrades to the bundled asset alone. Under this schema
-    /// that case is a hard [`CompositionError::MissingGeneratedInput`], because
-    /// the roster block may not be marked `optional` ([`ValidationError::OptionalRoster`]).
-    /// That is a deliberate strengthening — the silent degradation *is* #4069's
-    /// failure shape — but it means byte-identity holds for the normal
-    /// agents-deployed case and intentionally does not hold for the zero-agent
-    /// case. #4186 must either guarantee a non-empty roster at the call site or
-    /// record an explicit decision for zero-agent projects.
+    /// Scope — including the other override configurations `resolve_pm_prompt`
+    /// can emit, and which of them this schema can reproduce — is tracked on
+    /// #4186, not here.
     /// Test: `todays_delegation_section_shape_is_expressible`.
     fn validate_roster(&self) -> Result<(), ValidationError> {
         let mut seen = false;

--- a/crates/trusty-mpm/src/core/instruction_package.rs
+++ b/crates/trusty-mpm/src/core/instruction_package.rs
@@ -469,12 +469,6 @@ pub enum ValidationError {
         /// The owning section.
         section: SectionId,
     },
-    /// A declared section contributes no block.
-    #[error("section {section:?} is declared but contributes no block")]
-    SectionWithoutBlocks {
-        /// The silent section.
-        section: SectionId,
-    },
     /// No block consumes [`Generator::AgentRoster`].
     #[error(
         "no block consumes the agent roster; the computed roster must reach the \
@@ -486,6 +480,21 @@ pub enum ValidationError {
     OptionalRoster {
         /// Index into `blocks`.
         index: usize,
+    },
+    /// A declared section contributes no block.
+    #[error("section {section:?} is declared but contributes no block")]
+    SectionWithoutBlocks {
+        /// The silent section.
+        section: SectionId,
+    },
+    /// A declared section's blocks are all `optional`, so it may emit nothing.
+    #[error(
+        "section {section:?} contributes only `optional` blocks, so it can emit nothing \
+         while still validating; give it at least one non-optional block"
+    )]
+    SectionOnlyOptionalBlocks {
+        /// The section that is not guaranteed to emit.
+        section: SectionId,
     },
     /// A non-floor block follows the first floor block.
     #[error(
@@ -550,10 +559,35 @@ impl InstructionPackage {
     /// Why: unknown fields are rejected (`deny_unknown_fields` throughout) so a
     /// typo in a key becomes a parse error rather than silently dropped
     /// instruction content.
-    /// What: `serde_json::from_str`, without validation — call [`Self::validate`]
-    /// or [`Self::compose`] for that.
-    /// Test: `schema_example_deserializes_validates_and_round_trips`, `rejects_unknown_fields_at_every_level_and_names_the_key`.
+    ///
+    /// The `schema_version` probe runs FIRST, before the package is
+    /// deserialized, because strictness and version-gating otherwise collide:
+    /// a package written against a later schema almost certainly carries a field
+    /// this build does not know, so plain deserialization would report `unknown
+    /// field \`whatever\`` — blaming a key that is perfectly valid in its own
+    /// schema — instead of the actionable "you need a newer trusty-mpm". The
+    /// probe deliberately ignores unknown fields; it reads nothing but the
+    /// version.
+    ///
+    /// What: version probe, then `serde_json::from_str`. No structural
+    /// validation — call [`Self::validate`] or [`Self::compose`] for that.
+    /// Test: `schema_example_deserializes_validates_and_round_trips`,
+    /// `rejects_unknown_fields_at_every_level_and_names_the_key`,
+    /// `later_schema_version_is_reported_as_a_version_error_not_a_field_error`.
     pub fn from_json(raw: &str) -> Result<Self, serde_json::Error> {
+        /// Reads only `schema_version`, tolerating every other key by design.
+        #[derive(Deserialize)]
+        struct VersionProbe {
+            schema_version: u32,
+        }
+
+        let probe: VersionProbe = serde_json::from_str(raw)?;
+        if probe.schema_version != SCHEMA_VERSION {
+            return Err(serde::de::Error::custom(format!(
+                "unsupported schema_version {}; this build implements {SCHEMA_VERSION}",
+                probe.schema_version
+            )));
+        }
         serde_json::from_str(raw)
     }
 
@@ -582,7 +616,9 @@ impl InstructionPackage {
     /// contract.
     /// What: version, identity, canonical section set/order, floor tiers,
     /// non-empty block stream, per-block text/optional sanity, every section
-    /// contributing, the roster being consumed and non-optional, and nothing
+    /// contributing *and being guaranteed to emit* (owning blocks is not
+    /// enough — a section covered only by `optional` blocks composes to
+    /// nothing), the roster being consumed and non-optional, and nothing
     /// overridable following the floor.
     /// Test: one test per [`ValidationError`] variant.
     pub fn validate(&self) -> Result<(), ValidationError> {
@@ -630,37 +666,72 @@ impl InstructionPackage {
             }
         }
 
+        // Roster checks run BEFORE section coverage so that an optional roster
+        // block reports the precise `OptionalRoster` (#4196) diagnosis rather
+        // than the broader "this section may emit nothing" one — both are true,
+        // but only the first names the actual mistake.
+        self.validate_roster()?;
+
+        // A section must not merely OWN blocks — it must own at least one block
+        // that is guaranteed to emit. A section covered only by `optional`
+        // blocks passes the ownership check and still composes to nothing,
+        // which is precisely the silent-missing-section shape this check exists
+        // to prevent (#4069/#4196: the taxonomy claims the content is
+        // delivered, the output does not contain it).
         let covered: BTreeSet<SectionId> = self.blocks.iter().map(|b| b.section).collect();
+        let guaranteed: BTreeSet<SectionId> = self
+            .blocks
+            .iter()
+            .filter(|b| !b.optional)
+            .map(|b| b.section)
+            .collect();
         for id in SectionId::CANONICAL {
             if !covered.contains(&id) {
                 return Err(ValidationError::SectionWithoutBlocks { section: id });
             }
+            if !guaranteed.contains(&id) {
+                return Err(ValidationError::SectionOnlyOptionalBlocks { section: id });
+            }
         }
 
-        self.validate_roster()?;
         self.validate_floor_is_last()
     }
 
     /// The roster must reach the output, and must not be droppable (#4196).
     ///
-    /// Scope limit #4186 must resolve explicitly, recorded here so it is a
-    /// decision rather than a mid-implementation discovery: this check makes the
-    /// roster's *consumption* structurally mandatory, but #4196's root cause was
-    /// upstream of composition. `instruction_overrides::resolve_pm_prompt` still
-    /// builds the launch prompt from the static `AGENT_DELEGATION` asset, while
-    /// the computed roster lands in `PipelineOutput::merged`, which the launch
-    /// path never reads. So #4186 must choose one of:
+    /// What today's launch path actually does, since #4186 lifts exactly these
+    /// bytes: `instruction_overrides::resolve_pm_prompt` resolves its delegation
+    /// section through `bundled_delegation`, which since #4196 (closing #4069)
+    /// appends the LIVE computed roster from
+    /// `delegation_authority::deployed_roster_section` to the bundled
+    /// `AGENT_DELEGATION` asset, separated by `ROSTER_PRECEDENCE_NOTE`. The
+    /// delivered prompt therefore already carries the real roster; the stale
+    /// `PipelineOutput::merged` path that originally caused #4069 is no longer
+    /// the launch path.
     ///
-    /// * pass the real computed roster — fixes #4196, but the output then
-    ///   *cannot* be byte-identical to today's `resolve_pm_prompt`; or
-    /// * pass the static `AGENT_DELEGATION.md` text as `agent_roster` — bytes
-    ///   match, but #4196 survives into the new format.
+    /// Consequence for #4186, stated because an earlier revision of this comment
+    /// got it wrong: byte-identity and roster consumption are **not** in
+    /// tension. Today's section is
+    /// `<asset>\n\n<ROSTER_PRECEDENCE_NOTE>\n\n<roster>`, which this schema
+    /// expresses directly as three blocks — [`BlockBody::Text`] for the asset, a
+    /// [`Join::Blank`] [`BlockBody::Text`] for the note, and a [`Join::Blank`]
+    /// [`BlockBody::Generated`] for [`Generator::AgentRoster`] — so a package can
+    /// be byte-identical to today's output AND consume the computed roster.
+    /// #4186 should therefore keep **strict byte-equality against today's
+    /// output** as its acceptance gate; it is the strongest faithfulness check
+    /// available and nothing here forces weakening it.
     ///
-    /// "Byte-identical to today's output" and "fixes #4196" are mutually
-    /// exclusive. #4186's acceptance criterion should therefore read
-    /// *byte-identical across runs for the same manifest and roster* — which
-    /// this module does fully guarantee — plus an explicitly reviewed diff
-    /// against today's bytes, not strict equality with the legacy output.
+    /// The one real divergence, which #4186 must decide deliberately: when NO
+    /// agents are deployed, `deployed_roster_section` returns `None` and today's
+    /// composer silently degrades to the bundled asset alone. Under this schema
+    /// that case is a hard [`CompositionError::MissingGeneratedInput`], because
+    /// the roster block may not be marked `optional` ([`ValidationError::OptionalRoster`]).
+    /// That is a deliberate strengthening — the silent degradation *is* #4069's
+    /// failure shape — but it means byte-identity holds for the normal
+    /// agents-deployed case and intentionally does not hold for the zero-agent
+    /// case. #4186 must either guarantee a non-empty roster at the call site or
+    /// record an explicit decision for zero-agent projects.
+    /// Test: `todays_delegation_section_shape_is_expressible`.
     fn validate_roster(&self) -> Result<(), ValidationError> {
         let mut seen = false;
         for (index, block) in self.blocks.iter().enumerate() {

--- a/crates/trusty-mpm/src/core/instruction_package.rs
+++ b/crates/trusty-mpm/src/core/instruction_package.rs
@@ -704,10 +704,10 @@ impl InstructionPackage {
     /// section through `bundled_delegation`, which since #4196 (closing #4069)
     /// appends the LIVE computed roster from
     /// `delegation_authority::deployed_roster_section` to the bundled
-    /// `AGENT_DELEGATION` asset, separated by `ROSTER_PRECEDENCE_NOTE`. The
-    /// delivered prompt therefore already carries the real roster; the stale
-    /// `PipelineOutput::merged` path that originally caused #4069 is no longer
-    /// the launch path.
+    /// `AGENT_DELEGATION` asset, separated by `ROSTER_PRECEDENCE_NOTE`. On this
+    /// path the delivered prompt therefore already carries the real roster; the
+    /// stale `PipelineOutput::merged` path that originally caused #4069 is no
+    /// longer the launch path.
     ///
     /// Consequence for #4186, stated because an earlier revision of this comment
     /// got it wrong: byte-identity and roster consumption are **not** in

--- a/crates/trusty-mpm/src/core/instruction_package.rs
+++ b/crates/trusty-mpm/src/core/instruction_package.rs
@@ -1,0 +1,719 @@
+//! Instruction package — the sectioned-JSON source format for the PM prompt.
+//!
+//! Why: the PM system prompt is composed today by concatenating four
+//! `include_str!` markdown assets plus a handful of project overrides
+//! ([`crate::core::instruction_pipeline`],
+//! [`crate::core::instruction_overrides`]). That shape has no place to record
+//! *who may override what*, and it has already shipped two composition bugs
+//! that a typed source format makes structurally hard to repeat: the delivered
+//! prompt named 8 agents because a computed 42-agent roster was dropped at the
+//! final composition step (#4196), and the non-overridable floor could not be
+//! reasoned about per-unit (#4194). Epic #4183 replaces the concatenated blobs
+//! with one JSON package; this module is the schema half of that work (#4184).
+//!
+//! What: the [`InstructionPackage`] type and its JSON schema
+//! (`assets/instructions/instruction-package.schema.json`, embedded as
+//! [`SCHEMA_JSON`]). A package has two arrays:
+//!
+//! * `sections` — the closed eight-member taxonomy (five content sections plus
+//!   the three absorbed BASE_PM floor sections) carrying the
+//!   `customization_tier` axis. Declaration order is fixed and canonical; it
+//!   has **no** effect on composed bytes.
+//! * `blocks` — the ordered composition stream. Output is `blocks` in array
+//!   order, and nothing else. A section may own several non-contiguous blocks,
+//!   which is what lets a section be lifted out of the middle of a legacy asset
+//!   without moving a byte.
+//!
+//! Determinism (the #4186 acceptance constraint — the composed prompt must be
+//! byte-identical for the same package and roster):
+//!
+//! * order comes from `Vec`, never from a map — no hash iteration order can
+//!   reach the output;
+//! * every inter-block boundary is an explicit [`Join`] literal, so whitespace
+//!   is declared rather than inferred;
+//! * [`InstructionPackage::compose`] is pure — no clock, env, filesystem or
+//!   randomness — so it is a total function of `(package, inputs)`;
+//! * dropping content requires an explicit `optional: true`; anything else that
+//!   would render empty is a hard error, so a roster can never be silently lost
+//!   the way #4196 lost it.
+//!
+//! Scope: this module defines and validates the shape. It authors no
+//! instruction content (#4185) and re-sources no build (#4186) — nothing in the
+//! session-launch path calls it yet.
+//!
+//! Test: `instruction_package_tests.rs`.
+
+use std::collections::BTreeSet;
+
+use serde::{Deserialize, Serialize};
+
+/// The schema major version this build implements.
+///
+/// Why: a package written against a future schema must be rejected outright
+/// rather than partially interpreted — a half-understood instruction package is
+/// a silently truncated system prompt.
+/// What: the integer matched against [`InstructionPackage::schema_version`].
+/// Test: `rejects_unsupported_schema_version`.
+pub const SCHEMA_VERSION: u32 = 1;
+
+/// The JSON Schema document describing this format, embedded at compile time.
+///
+/// Why: the schema is the artifact other tools (editors, validators, the
+/// forthcoming `tm` authoring commands) consume; embedding it keeps it from
+/// drifting away from the Rust types silently.
+/// What: the raw contents of `assets/instructions/instruction-package.schema.json`.
+/// Test: `schema_enums_match_rust_enums`, `schema_example_deserializes_validates_and_round_trips`.
+pub const SCHEMA_JSON: &str =
+    include_str!("../assets/instructions/instruction-package.schema.json");
+
+/// The closed instruction section taxonomy.
+///
+/// Why: a closed enum makes the taxonomy reviewable and makes "every section is
+/// accounted for" a compile-time-shaped question rather than a grep. Unknown
+/// ids fail deserialization loudly instead of being dropped.
+/// What: the five content sections (Core, Memory, Search, Workflow, Agent
+/// Delegation) plus the three BASE_PM floor sections absorbed by #4183
+/// (Identity, Non-Overridable Rules, Framework-Guaranteed Conventions).
+///
+/// Documented placement of each absorbed BASE_PM block:
+///
+/// | `BASE_PM.md` block | section |
+/// |---|---|
+/// | `## Identity` | [`SectionId::Identity`] |
+/// | `## Non-Overridable Rules` | [`SectionId::NonOverridableRules`] |
+/// | `## Customizing PM Behavior` | [`SectionId::NonOverridableRules`] |
+/// | `## Trusty Tool Priority (Non-Overridable)` | [`SectionId::NonOverridableRules`] |
+/// | `## Framework-Guaranteed Conventions (Non-Overridable)` | [`SectionId::FrameworkGuaranteedConventions`] |
+///
+/// The tool-priority block stays whole in the fixed floor deliberately: the
+/// *mandate* to reach for memory and code search before grep is non-overridable
+/// even though the memory/search *guidance* sections a project may tune are
+/// tier `project`.
+///
+/// Test: `canonical_order_is_sorted_and_complete`, `schema_enums_match_rust_enums`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum SectionId {
+    /// Absorbed BASE_PM `## Identity` — who the PM is. Floor, tier `fixed`.
+    Identity,
+    /// The PM's core operating instructions (today's `PM_INSTRUCTIONS.md` body).
+    Core,
+    /// Memory protocol guidance.
+    Memory,
+    /// Code/architecture search guidance.
+    Search,
+    /// The phase workflow (today's `WORKFLOW.md`).
+    Workflow,
+    /// Delegation routing — dynamic, built from the deployed-agent roster.
+    AgentDelegation,
+    /// Absorbed BASE_PM non-overridable rules + customization contract + the
+    /// Trusty tool-priority mandate. Floor, tier `fixed`.
+    NonOverridableRules,
+    /// Absorbed BASE_PM framework-guaranteed conventions (attribution footer,
+    /// documentation proportionality, ticket attribution). Floor, tier `fixed`.
+    FrameworkGuaranteedConventions,
+}
+
+impl SectionId {
+    /// Every section id, in canonical declaration order.
+    ///
+    /// Why: `sections` must be declared in this order so a package manifest
+    /// reads the same way in every project; the order is also the enum's `Ord`,
+    /// so the check is a simple sortedness test.
+    /// What: the eight ids, floor-first-and-last around the five content
+    /// sections.
+    /// Test: `canonical_order_is_sorted_and_complete`.
+    pub const CANONICAL: [SectionId; 8] = [
+        SectionId::Identity,
+        SectionId::Core,
+        SectionId::Memory,
+        SectionId::Search,
+        SectionId::Workflow,
+        SectionId::AgentDelegation,
+        SectionId::NonOverridableRules,
+        SectionId::FrameworkGuaranteedConventions,
+    ];
+
+    /// Whether this section is part of the absorbed BASE_PM framework floor.
+    ///
+    /// Why: the floor's defining property — nothing may override it, and
+    /// nothing overridable may follow it — has to be checkable per section, not
+    /// per file (#4194: a floor rule shipped a broken directive that every
+    /// obeying agent had to follow, with no per-unit handle on it).
+    /// What: true for [`SectionId::Identity`], [`SectionId::NonOverridableRules`]
+    /// and [`SectionId::FrameworkGuaranteedConventions`].
+    /// Test: `rejects_floor_section_that_is_not_fixed`, `rejects_overridable_block_after_the_floor`.
+    pub const fn is_floor(self) -> bool {
+        matches!(
+            self,
+            SectionId::Identity
+                | SectionId::NonOverridableRules
+                | SectionId::FrameworkGuaranteedConventions
+        )
+    }
+}
+
+/// Who may override a section, by increasing permissiveness.
+///
+/// Why: the override permission axis is the whole point of the sectioned
+/// format; encoding it as a type makes "can this be overridden, and by whom?" a
+/// question with one answer instead of a per-file convention.
+/// What: `Fixed < Project < User` (SPEC-PMINSTR-01 §4b). `Project` deliberately
+/// excludes user-tier override so one operator's machine config can never leak
+/// into a shared project; `User` implies project-tier may also override, with
+/// project winning on collision (most-specific-wins).
+/// Test: `tier_ordering_is_by_permissiveness`, `tier_permits_matrix`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CustomizationTier {
+    /// No override mechanism touches this section, at any tier.
+    Fixed,
+    /// A project-tier override may replace it. User tier may not.
+    Project,
+    /// Both project- and user-tier overrides may replace it.
+    User,
+}
+
+/// The tier an override arrives from.
+///
+/// Why: [`CustomizationTier::permits`] needs to distinguish the *declared*
+/// permission from the *incoming* attempt; conflating them is how "user config
+/// silently changed a shared project" bugs happen.
+/// What: the two writable tiers.
+/// Test: `tier_permits_matrix`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum OverrideTier {
+    /// An override authored in the project (`<project>/.trusty-mpm/`).
+    Project,
+    /// An override authored in the operator's home config (`~/.trusty-mpm/`).
+    User,
+}
+
+impl CustomizationTier {
+    /// Whether an override arriving from `from` may replace this section.
+    ///
+    /// Why: the single decision point for override permission, so no caller can
+    /// re-derive it differently.
+    /// What: `Fixed` permits nothing; `Project` permits only
+    /// [`OverrideTier::Project`]; `User` permits both.
+    /// Test: `tier_permits_matrix`.
+    pub const fn permits(self, from: OverrideTier) -> bool {
+        match (self, from) {
+            (CustomizationTier::Fixed, _) => false,
+            (CustomizationTier::Project, OverrideTier::Project) => true,
+            (CustomizationTier::Project, OverrideTier::User) => false,
+            (CustomizationTier::User, _) => true,
+        }
+    }
+}
+
+/// A named composition-time input the host must supply.
+///
+/// Why: dynamic content (the deployed-agent roster, the detected stack profile,
+/// the project's own addendum) cannot be authored in the package — it is
+/// computed per project and session. Naming each one in the schema makes it a
+/// declared dependency rather than something a composer may forget to pass.
+/// What: the three generators the composer resolves from
+/// [`CompositionInputs`].
+/// Test: `rejects_package_that_never_consumes_the_roster`, `composes_blocks_in_array_order_with_declared_joins`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Generator {
+    /// The rendered delegation roster built from the deployed agents.
+    AgentRoster,
+    /// The per-project detected stack profile.
+    StackProfile,
+    /// The project's additive instruction addendum.
+    ProjectAddendum,
+}
+
+/// The literal bytes inserted before a block when it is not emitted first.
+///
+/// Why: byte-identical composition is only achievable if every boundary is
+/// declared. Blocks split out of one legacy document must rejoin with a plain
+/// paragraph break; distinct legacy assets must rejoin with the `---` rule.
+/// Inferring that from context would make the output fragile.
+/// What: `Rule` = `"\n\n---\n\n"` (matching
+/// [`crate::core::instruction_pipeline::SECTION_SEPARATOR`]), `Blank` =
+/// `"\n\n"`, `None` = `""`, `Literal` = verbatim.
+/// Test: `join_literals_are_exact`, `composes_blocks_in_array_order_with_declared_joins`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Join {
+    /// A Markdown horizontal rule: `"\n\n---\n\n"`. The default — it matches
+    /// [`crate::core::instruction_pipeline::SECTION_SEPARATOR`], the boundary
+    /// today's composer uses between top-level sections.
+    #[default]
+    Rule,
+    /// A paragraph break: `"\n\n"`.
+    Blank,
+    /// No separator at all.
+    None,
+    /// Verbatim separator bytes.
+    Literal(String),
+}
+
+impl Join {
+    /// The exact bytes this join contributes.
+    ///
+    /// Test: `join_literals_are_exact`.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Join::Rule => "\n\n---\n\n",
+            Join::Blank => "\n\n",
+            Join::None => "",
+            Join::Literal(s) => s,
+        }
+    }
+}
+
+/// Where a block's markdown comes from.
+///
+/// Why: separating authored text from host-supplied generated content lets
+/// validation insist that generated content is actually consumed.
+/// What: `Text` carries markdown authored in the package; `Generated` names the
+/// generator that supplies it.
+/// Test: `schema_example_deserializes_validates_and_round_trips`, `composes_blocks_in_array_order_with_declared_joins`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "kebab-case")]
+pub enum BlockBody {
+    /// Markdown authored inline in the package.
+    Text {
+        /// The markdown body. Trimmed before emission.
+        text: String,
+    },
+    /// Markdown supplied at composition time by a named generator.
+    Generated {
+        /// Which composition-time input supplies this block.
+        generator: Generator,
+    },
+}
+
+/// One unit of the ordered composition stream.
+///
+/// Why: composition order is block order, so the block is the smallest thing
+/// that has a position. Attributing each block to a section (rather than
+/// nesting blocks under sections) is what lets one section contribute at
+/// several non-adjacent positions — the property a faithful, byte-identical
+/// lift of today's assets needs.
+/// What: the owning section, the body, the join preceding it, and whether it
+/// may be dropped when its generator has nothing to supply.
+/// Test: `schema_example_deserializes_validates_and_round_trips`, `optional_generated_block_is_dropped_with_its_join`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstructionBlock {
+    /// The section this block's content belongs to.
+    pub section: SectionId,
+    /// Where the content comes from.
+    pub body: BlockBody,
+    /// Separator emitted before this block (ignored for the first emitted
+    /// block). Defaults to [`Join::Rule`].
+    #[serde(default, skip_serializing_if = "is_default_join")]
+    pub join_before: Join,
+    /// Whether this block may be dropped when its generator supplies nothing.
+    ///
+    /// Only a [`BlockBody::Generated`] block may set this. Everything else that
+    /// would render empty is a hard [`CompositionError`], never a silent drop —
+    /// the structural guard against #4196.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub optional: bool,
+}
+
+/// Serde helper: skip serializing `join_before` when it is the default.
+fn is_default_join(join: &Join) -> bool {
+    *join == Join::Rule
+}
+
+/// Serde helper: skip serializing `optional` when false.
+fn is_false(b: &bool) -> bool {
+    !*b
+}
+
+/// A declared section: identity plus its customization tier.
+///
+/// Why: the taxonomy and the tier axis are the package's contract with
+/// override machinery; keeping them out of the block stream means a section's
+/// permission cannot vary by position.
+/// What: id, human title, tier, optional prose description.
+/// Test: `schema_example_deserializes_validates_and_round_trips`, `rejects_floor_section_that_is_not_fixed`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstructionSection {
+    /// Which section this is.
+    pub id: SectionId,
+    /// Human-readable title (documentation only; never emitted).
+    pub title: String,
+    /// Who may override this section.
+    pub customization_tier: CustomizationTier,
+    /// Optional prose describing the section's remit.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+}
+
+/// A complete PM instruction package.
+///
+/// Why: one versioned, validatable artifact replaces four `include_str!` blobs
+/// whose ordering and override semantics lived only in prose.
+/// What: schema version, identity, the eight-section taxonomy, and the ordered
+/// block stream. `trailing_newline` reproduces the exact tail byte of whichever
+/// legacy composer is being replaced.
+/// Test: the whole of `instruction_package_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct InstructionPackage {
+    /// Schema major version; must equal [`SCHEMA_VERSION`].
+    pub schema_version: u32,
+    /// Stable package identity. Never affects composed bytes.
+    pub package_id: String,
+    /// Optional prose describing the package.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Append exactly one `\n` after the last emitted block.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub trailing_newline: bool,
+    /// The section taxonomy, in canonical order, each id exactly once.
+    pub sections: Vec<InstructionSection>,
+    /// The ordered composition stream. Output order is exactly this order.
+    pub blocks: Vec<InstructionBlock>,
+}
+
+/// A structural defect in a package.
+///
+/// Why: every variant here is a defect that would otherwise surface as a
+/// quietly wrong system prompt — the failure mode #4194 and #4196 both had.
+/// What: the checks [`InstructionPackage::validate`] performs, in the order it
+/// performs them (first failure wins, deterministically).
+/// Test: one test per variant in `instruction_package_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ValidationError {
+    /// `schema_version` is not [`SCHEMA_VERSION`].
+    #[error("unsupported schema_version {found}; this build implements {SCHEMA_VERSION}")]
+    UnsupportedSchemaVersion {
+        /// The version the package declared.
+        found: u32,
+    },
+    /// `package_id` is empty or whitespace.
+    #[error("package_id must not be empty")]
+    EmptyPackageId,
+    /// `sections` is not exactly the canonical set in canonical order.
+    #[error(
+        "sections must list every canonical section exactly once, in canonical order; \
+         got {found:?}"
+    )]
+    SectionsNotCanonical {
+        /// The ids as declared.
+        found: Vec<SectionId>,
+    },
+    /// A floor section declared a tier other than `fixed`.
+    #[error("floor section {section:?} must be tier `fixed`, got {tier:?}")]
+    FloorNotFixed {
+        /// The offending section.
+        section: SectionId,
+        /// The tier it declared.
+        tier: CustomizationTier,
+    },
+    /// The package emits nothing.
+    #[error("blocks must not be empty")]
+    NoBlocks,
+    /// A `text` block whose content is blank.
+    #[error("block {index} ({section:?}) has empty text; remove it instead")]
+    EmptyText {
+        /// Index into `blocks`.
+        index: usize,
+        /// The owning section.
+        section: SectionId,
+    },
+    /// A `text` block marked optional.
+    #[error("block {index} ({section:?}) is a text block and may not be `optional`")]
+    OptionalTextBlock {
+        /// Index into `blocks`.
+        index: usize,
+        /// The owning section.
+        section: SectionId,
+    },
+    /// A declared section contributes no block.
+    #[error("section {section:?} is declared but contributes no block")]
+    SectionWithoutBlocks {
+        /// The silent section.
+        section: SectionId,
+    },
+    /// No block consumes [`Generator::AgentRoster`].
+    #[error(
+        "no block consumes the agent roster; the computed roster must reach the \
+         composed prompt (issue #4196)"
+    )]
+    RosterNotConsumed,
+    /// The roster block is marked optional.
+    #[error("block {index} consumes the agent roster and may not be `optional` (issue #4196)")]
+    OptionalRoster {
+        /// Index into `blocks`.
+        index: usize,
+    },
+    /// A non-floor block follows the first floor block.
+    #[error(
+        "block {index} ({section:?}) is overridable but follows the framework floor \
+         (first floor block at {floor_index}); nothing overridable may follow the floor"
+    )]
+    OverridableAfterFloor {
+        /// Index of the offending block.
+        index: usize,
+        /// The offending block's section.
+        section: SectionId,
+        /// Index of the first floor block.
+        floor_index: usize,
+    },
+}
+
+/// A failure while composing a validated package.
+///
+/// Why: composition failures must be loud. A missing generator input is the
+/// exact shape of #4196 — where the roster existed, was computed, and simply
+/// never reached the output.
+/// What: an invalid package, or a required generator that supplied nothing.
+/// Test: `missing_required_generator_input_is_a_hard_error`, `whitespace_only_generator_output_counts_as_absent`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CompositionError {
+    /// The package failed [`InstructionPackage::validate`].
+    #[error("invalid instruction package: {0}")]
+    Invalid(#[from] ValidationError),
+    /// A non-optional generated block had no content to emit.
+    #[error(
+        "block {index} requires generator {generator:?} but it supplied no content; \
+         mark the block `optional` if that is intended"
+    )]
+    MissingGeneratedInput {
+        /// Index into `blocks`.
+        index: usize,
+        /// The generator that came up empty.
+        generator: Generator,
+    },
+}
+
+/// The host-supplied, composition-time inputs.
+///
+/// Why: making the roster a required, non-`Option` field of the composer's
+/// input means a caller cannot compose without producing one — the final-step
+/// drop that caused #4196 is not expressible.
+/// What: the rendered roster (required) plus the two optional project inputs.
+/// Test: `composes_blocks_in_array_order_with_declared_joins`, `missing_required_generator_input_is_a_hard_error`.
+#[derive(Debug, Clone, Default)]
+pub struct CompositionInputs {
+    /// Rendered delegation roster. Required — see #4196.
+    pub agent_roster: String,
+    /// Rendered per-project stack profile, if the host derived one.
+    pub stack_profile: Option<String>,
+    /// The project's additive instruction addendum, if present.
+    pub project_addendum: Option<String>,
+}
+
+impl InstructionPackage {
+    /// Parse a package from JSON.
+    ///
+    /// Why: unknown fields are rejected (`deny_unknown_fields` throughout) so a
+    /// typo in a key becomes a parse error rather than silently dropped
+    /// instruction content.
+    /// What: `serde_json::from_str`, without validation — call [`Self::validate`]
+    /// or [`Self::compose`] for that.
+    /// Test: `schema_example_deserializes_validates_and_round_trips`, `rejects_unknown_fields`.
+    pub fn from_json(raw: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(raw)
+    }
+
+    /// Serialize back to pretty JSON.
+    ///
+    /// Why: round-tripping must be lossless so tooling can rewrite a package
+    /// without churning unrelated bytes.
+    /// What: `serde_json::to_string_pretty`; field order is struct declaration
+    /// order, and both arrays keep their order.
+    /// Test: `schema_example_deserializes_validates_and_round_trips`.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Look up a declared section.
+    ///
+    /// Test: `section_lookup_reports_declared_tier`.
+    pub fn section(&self, id: SectionId) -> Option<&InstructionSection> {
+        self.sections.iter().find(|s| s.id == id)
+    }
+
+    /// Check every structural invariant, first failure wins.
+    ///
+    /// Why: composition assumes these hold; checking them in one deterministic
+    /// order gives authors a stable error and reviewers one place to read the
+    /// contract.
+    /// What: version, identity, canonical section set/order, floor tiers,
+    /// non-empty block stream, per-block text/optional sanity, every section
+    /// contributing, the roster being consumed and non-optional, and nothing
+    /// overridable following the floor.
+    /// Test: one test per [`ValidationError`] variant.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.schema_version != SCHEMA_VERSION {
+            return Err(ValidationError::UnsupportedSchemaVersion {
+                found: self.schema_version,
+            });
+        }
+        if self.package_id.trim().is_empty() {
+            return Err(ValidationError::EmptyPackageId);
+        }
+
+        let declared: Vec<SectionId> = self.sections.iter().map(|s| s.id).collect();
+        if declared != SectionId::CANONICAL {
+            return Err(ValidationError::SectionsNotCanonical { found: declared });
+        }
+
+        for section in &self.sections {
+            if section.id.is_floor() && section.customization_tier != CustomizationTier::Fixed {
+                return Err(ValidationError::FloorNotFixed {
+                    section: section.id,
+                    tier: section.customization_tier,
+                });
+            }
+        }
+
+        if self.blocks.is_empty() {
+            return Err(ValidationError::NoBlocks);
+        }
+
+        for (index, block) in self.blocks.iter().enumerate() {
+            if let BlockBody::Text { text } = &block.body {
+                if text.trim().is_empty() {
+                    return Err(ValidationError::EmptyText {
+                        index,
+                        section: block.section,
+                    });
+                }
+                if block.optional {
+                    return Err(ValidationError::OptionalTextBlock {
+                        index,
+                        section: block.section,
+                    });
+                }
+            }
+        }
+
+        let covered: BTreeSet<SectionId> = self.blocks.iter().map(|b| b.section).collect();
+        for id in SectionId::CANONICAL {
+            if !covered.contains(&id) {
+                return Err(ValidationError::SectionWithoutBlocks { section: id });
+            }
+        }
+
+        self.validate_roster()?;
+        self.validate_floor_is_last()
+    }
+
+    /// The roster must reach the output, and must not be droppable (#4196).
+    fn validate_roster(&self) -> Result<(), ValidationError> {
+        let mut seen = false;
+        for (index, block) in self.blocks.iter().enumerate() {
+            if matches!(
+                block.body,
+                BlockBody::Generated {
+                    generator: Generator::AgentRoster
+                }
+            ) {
+                if block.optional {
+                    return Err(ValidationError::OptionalRoster { index });
+                }
+                seen = true;
+            }
+        }
+        if seen {
+            Ok(())
+        } else {
+            Err(ValidationError::RosterNotConsumed)
+        }
+    }
+
+    /// Once the floor starts, only floor blocks may follow.
+    ///
+    /// Why: the floor's guarantee is that it has the last word. Enforcing
+    /// "nothing overridable after the floor" preserves that without dictating a
+    /// single global order — which the byte-identical lift in #4186 needs to
+    /// stay free to choose.
+    fn validate_floor_is_last(&self) -> Result<(), ValidationError> {
+        let Some(floor_index) = self.blocks.iter().position(|b| b.section.is_floor()) else {
+            return Ok(());
+        };
+        for (index, block) in self.blocks.iter().enumerate().skip(floor_index + 1) {
+            if !block.section.is_floor() {
+                return Err(ValidationError::OverridableAfterFloor {
+                    index,
+                    section: block.section,
+                    floor_index,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Compose the package into the final prompt text.
+    ///
+    /// Why: this is the executable definition of the format's ordering and
+    /// whitespace semantics — the thing #4186 diffs against today's
+    /// `resolve_pm_prompt` output.
+    ///
+    /// What: validates, then walks `blocks` in array order. Each block's body is
+    /// resolved (authored text, or the named generator's input) and trimmed; a
+    /// block that resolves to nothing is dropped when `optional`, and is a hard
+    /// [`CompositionError::MissingGeneratedInput`] otherwise. Every emitted
+    /// block after the first is preceded by its declared [`Join`] bytes.
+    /// `trailing_newline` appends one `\n`.
+    ///
+    /// Determinism: pure function of `(self, inputs)` — no map iteration, no
+    /// clock, no environment, no filesystem. Two calls with equal arguments
+    /// return byte-identical strings.
+    ///
+    /// Test: `composes_blocks_in_array_order_with_declared_joins`,
+    /// `first_emitted_block_never_contributes_a_join`,
+    /// `compose_is_byte_identical_across_repeats_and_a_json_round_trip`.
+    pub fn compose(&self, inputs: &CompositionInputs) -> Result<String, CompositionError> {
+        self.validate()?;
+
+        let mut out = String::new();
+        let mut emitted = false;
+
+        for (index, block) in self.blocks.iter().enumerate() {
+            let resolved: Option<&str> = match &block.body {
+                BlockBody::Text { text } => Some(text.as_str()),
+                BlockBody::Generated { generator } => match generator {
+                    Generator::AgentRoster => Some(inputs.agent_roster.as_str()),
+                    Generator::StackProfile => inputs.stack_profile.as_deref(),
+                    Generator::ProjectAddendum => inputs.project_addendum.as_deref(),
+                },
+            };
+
+            let body = resolved.map(str::trim).unwrap_or("");
+            if body.is_empty() {
+                if block.optional {
+                    continue;
+                }
+                let BlockBody::Generated { generator } = &block.body else {
+                    // Blank text blocks are rejected by `validate`.
+                    unreachable!("validate rejects blank text blocks");
+                };
+                return Err(CompositionError::MissingGeneratedInput {
+                    index,
+                    generator: *generator,
+                });
+            }
+
+            if emitted {
+                out.push_str(block.join_before.as_str());
+            }
+            out.push_str(body);
+            emitted = true;
+        }
+
+        if self.trailing_newline && !out.is_empty() {
+            out.push('\n');
+        }
+        Ok(out)
+    }
+}
+
+#[cfg(test)]
+#[path = "instruction_package_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/instruction_package.rs
+++ b/crates/trusty-mpm/src/core/instruction_package.rs
@@ -37,6 +37,28 @@
 //!   would render empty is a hard error, so a roster can never be silently lost
 //!   the way #4196 lost it.
 //!
+//! Strictness, and why it beats forward compatibility here. Every object in the
+//! deserialization path carries `deny_unknown_fields`, so an unrecognised key is
+//! a named parse error rather than dropped instruction content. The usual
+//! argument against that — an older binary should be able to read a newer
+//! package — does not apply to this format, because [`Self::validate`] gates on
+//! [`SCHEMA_VERSION`] *before* any field is inspected: a package written against
+//! a later schema is already rejected outright. Lenient field handling could
+//! therefore only matter for a change that added a field while leaving
+//! `schema_version` at 1, and that is exactly the case that must not be
+//! tolerated — the old binary would compose a prompt missing the new field's
+//! effect, silently, and report success. Since this artifact *is* the
+//! instruction set for every PM and agent, a loud "unsupported schema_version"
+//! is strictly better than a quiet, subtly wrong system prompt.
+//!
+//! The resulting evolution policy, which #4185/#4186 and any later schema work
+//! must follow: **any field addition that can change composed bytes bumps
+//! [`SCHEMA_VERSION`]**. Strict rejection is what makes that policy enforceable
+//! rather than advisory.
+//!
+//! Floor block ordering is deliberately *not* constrained to canonical section
+//! order — see `validate_floor_is_last` for the asset evidence.
+//!
 //! Scope: this module defines and validates the shape. It authors no
 //! instruction content (#4185) and re-sources no build (#4186) — nothing in the
 //! session-launch path calls it yet.
@@ -274,9 +296,20 @@ impl Join {
 /// validation insist that generated content is actually consumed.
 /// What: `Text` carries markdown authored in the package; `Generated` names the
 /// generator that supplies it.
-/// Test: `schema_example_deserializes_validates_and_round_trips`, `composes_blocks_in_array_order_with_declared_joins`.
+///
+/// `deny_unknown_fields` is load-bearing, not decoration. Without it a key
+/// misplaced *inside* `body` — `{"kind":"text","text":"…","join_before":"blank"}`
+/// — was silently discarded, the block fell back to the [`Join::Rule`] default,
+/// and a spurious horizontal rule appeared in the composed system prompt while
+/// the package parsed, validated and composed without complaint. That is the
+/// #4196 failure shape (a package reporting success while composing the wrong
+/// instructions), and it also restores parity with the shipped JSON Schema,
+/// which sets `additionalProperties: false` on both `body` variants. The tag
+/// key itself (`kind`) is consumed by the internal tagging and never reported
+/// as unknown.
+/// Test: `rejects_unknown_fields_at_every_level_and_names_the_key`, `schema_document_closes_every_object`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(tag = "kind", rename_all = "kebab-case")]
+#[serde(tag = "kind", rename_all = "kebab-case", deny_unknown_fields)]
 pub enum BlockBody {
     /// Markdown authored inline in the package.
     Text {
@@ -356,8 +389,12 @@ pub struct InstructionSection {
 /// Why: one versioned, validatable artifact replaces four `include_str!` blobs
 /// whose ordering and override semantics lived only in prose.
 /// What: schema version, identity, the eight-section taxonomy, and the ordered
-/// block stream. `trailing_newline` reproduces the exact tail byte of whichever
-/// legacy composer is being replaced.
+/// block stream. Because the last block is trimmed before emission, the tail is
+/// always either `X` or `X\n`; `trailing_newline` selects between those two,
+/// which covers both legacy composers (`resolve_pm_prompt` emits none, a
+/// file-shaped artifact emits one). Two or more trailing newlines are
+/// deliberately inexpressible — if a future target needs them, they belong in a
+/// final block's [`Join`], not in this flag.
 /// Test: the whole of `instruction_package_tests.rs`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -515,7 +552,7 @@ impl InstructionPackage {
     /// instruction content.
     /// What: `serde_json::from_str`, without validation — call [`Self::validate`]
     /// or [`Self::compose`] for that.
-    /// Test: `schema_example_deserializes_validates_and_round_trips`, `rejects_unknown_fields`.
+    /// Test: `schema_example_deserializes_validates_and_round_trips`, `rejects_unknown_fields_at_every_level_and_names_the_key`.
     pub fn from_json(raw: &str) -> Result<Self, serde_json::Error> {
         serde_json::from_str(raw)
     }
@@ -605,6 +642,25 @@ impl InstructionPackage {
     }
 
     /// The roster must reach the output, and must not be droppable (#4196).
+    ///
+    /// Scope limit #4186 must resolve explicitly, recorded here so it is a
+    /// decision rather than a mid-implementation discovery: this check makes the
+    /// roster's *consumption* structurally mandatory, but #4196's root cause was
+    /// upstream of composition. `instruction_overrides::resolve_pm_prompt` still
+    /// builds the launch prompt from the static `AGENT_DELEGATION` asset, while
+    /// the computed roster lands in `PipelineOutput::merged`, which the launch
+    /// path never reads. So #4186 must choose one of:
+    ///
+    /// * pass the real computed roster — fixes #4196, but the output then
+    ///   *cannot* be byte-identical to today's `resolve_pm_prompt`; or
+    /// * pass the static `AGENT_DELEGATION.md` text as `agent_roster` — bytes
+    ///   match, but #4196 survives into the new format.
+    ///
+    /// "Byte-identical to today's output" and "fixes #4196" are mutually
+    /// exclusive. #4186's acceptance criterion should therefore read
+    /// *byte-identical across runs for the same manifest and roster* — which
+    /// this module does fully guarantee — plus an explicitly reviewed diff
+    /// against today's bytes, not strict equality with the legacy output.
     fn validate_roster(&self) -> Result<(), ValidationError> {
         let mut seen = false;
         for (index, block) in self.blocks.iter().enumerate() {
@@ -633,6 +689,33 @@ impl InstructionPackage {
     /// "nothing overridable after the floor" preserves that without dictating a
     /// single global order — which the byte-identical lift in #4186 needs to
     /// stay free to choose.
+    ///
+    /// Deliberately NOT enforced: that floor blocks run in [`SectionId`]
+    /// canonical order relative to each other. That constraint looks free — the
+    /// floor is the contiguous tail — but it would make a byte-identical lift of
+    /// `assets/instructions/BASE_PM.md` impossible. That file's headings run:
+    ///
+    /// | `BASE_PM.md` heading | section | canonical index |
+    /// |---|---|---|
+    /// | `## Identity` | `Identity` | 0 |
+    /// | `## Non-Overridable Rules` | `NonOverridableRules` | 6 |
+    /// | `## Customizing PM Behavior` | `NonOverridableRules` | 6 |
+    /// | `## Framework-Guaranteed Conventions (Non-Overridable)` | `FrameworkGuaranteedConventions` | 7 |
+    /// | `## Trusty Tool Priority (Non-Overridable)` | `NonOverridableRules` | 6 |
+    ///
+    /// The tool-priority block sits *after* framework-guaranteed-conventions in
+    /// the real asset, so the faithful block stream is `0, 6, 6, 7, 6` — a
+    /// canonical-order inversion. Requiring non-decreasing floor order would
+    /// reject the only lift this schema exists to enable, and would do it by
+    /// forcing #4186 to move bytes. The floor is in fact the sharpest example of
+    /// why `sections` and `blocks` are separate arrays: one section owning
+    /// non-contiguous positions is the normal case, not the exotic one.
+    ///
+    /// The residual risk — a semantically incoherent floor order that still
+    /// validates — is the same trade-off already accepted for the five content
+    /// sections, and is caught by #4186's byte comparison against today's
+    /// output rather than by structural validation.
+    /// Test: `base_pm_floor_block_order_is_valid`.
     fn validate_floor_is_last(&self) -> Result<(), ValidationError> {
         let Some(floor_index) = self.blocks.iter().position(|b| b.section.is_floor()) else {
             return Ok(());

--- a/crates/trusty-mpm/src/core/instruction_package_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_package_tests.rs
@@ -1,0 +1,663 @@
+//! Tests for the instruction-package schema (#4184).
+//!
+//! Split out of `instruction_package.rs` so the production file stays under the
+//! 500-SLOC cap enforced by `scripts/check_line_cap.sh`.
+
+use super::*;
+use crate::core::instruction_pipeline::SECTION_SEPARATOR;
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Build the canonical eight-section taxonomy with correct tiers.
+fn sections() -> Vec<InstructionSection> {
+    SectionId::CANONICAL
+        .iter()
+        .map(|id| InstructionSection {
+            id: *id,
+            title: format!("{id:?}"),
+            customization_tier: if id.is_floor() {
+                CustomizationTier::Fixed
+            } else {
+                CustomizationTier::Project
+            },
+            description: None,
+        })
+        .collect()
+}
+
+/// A text block owned by `section`.
+fn text(section: SectionId, body: &str) -> InstructionBlock {
+    InstructionBlock {
+        section,
+        body: BlockBody::Text {
+            text: body.to_string(),
+        },
+        join_before: Join::Rule,
+        optional: false,
+    }
+}
+
+/// A generated block owned by `section`.
+fn generated(section: SectionId, generator: Generator, optional: bool) -> InstructionBlock {
+    InstructionBlock {
+        section,
+        body: BlockBody::Generated { generator },
+        join_before: Join::Rule,
+        optional,
+    }
+}
+
+/// A minimal package that passes every structural check.
+///
+/// Block order deliberately interleaves `core` with `memory`/`search` and puts
+/// the floor last, mirroring the shape a faithful lift of today's assets needs.
+fn fixture() -> InstructionPackage {
+    InstructionPackage {
+        schema_version: SCHEMA_VERSION,
+        package_id: "trusty-mpm/test".to_string(),
+        description: None,
+        trailing_newline: false,
+        sections: sections(),
+        blocks: vec![
+            text(SectionId::Core, "CORE-A"),
+            text(SectionId::Memory, "MEMORY"),
+            text(SectionId::Core, "CORE-B"),
+            text(SectionId::Search, "SEARCH"),
+            generated(SectionId::Core, Generator::StackProfile, true),
+            text(SectionId::Workflow, "WORKFLOW"),
+            generated(SectionId::AgentDelegation, Generator::AgentRoster, false),
+            generated(SectionId::Core, Generator::ProjectAddendum, true),
+            text(SectionId::Identity, "IDENTITY"),
+            text(SectionId::NonOverridableRules, "RULES"),
+            text(SectionId::FrameworkGuaranteedConventions, "CONVENTIONS"),
+        ],
+    }
+}
+
+/// Composition inputs with every generator supplied.
+fn inputs() -> CompositionInputs {
+    CompositionInputs {
+        agent_roster: "ROSTER".to_string(),
+        stack_profile: Some("STACK".to_string()),
+        project_addendum: Some("ADDENDUM".to_string()),
+    }
+}
+
+/// The schema's own `examples[0]`, as raw JSON.
+fn schema_example() -> String {
+    let schema: serde_json::Value = serde_json::from_str(SCHEMA_JSON).expect("schema is JSON");
+    schema["examples"][0].to_string()
+}
+
+// ---------------------------------------------------------------------------
+// Schema document <-> Rust type parity
+// ---------------------------------------------------------------------------
+
+/// Serialize an enum value to its schema string form.
+fn wire(value: &impl serde::Serialize) -> String {
+    serde_json::to_value(value)
+        .expect("serializes")
+        .as_str()
+        .expect("enum serializes to a string")
+        .to_string()
+}
+
+/// Read a `$defs/<name>/enum` list out of the schema document.
+fn schema_enum(name: &str) -> Vec<String> {
+    let schema: serde_json::Value = serde_json::from_str(SCHEMA_JSON).expect("schema is JSON");
+    schema["$defs"][name]["enum"]
+        .as_array()
+        .unwrap_or_else(|| panic!("$defs/{name}/enum is an array"))
+        .iter()
+        .map(|v| v.as_str().expect("enum member is a string").to_string())
+        .collect()
+}
+
+#[test]
+fn schema_document_is_valid_json_and_versioned() {
+    // Why: the schema is the artifact external tooling consumes; a malformed or
+    // mis-versioned document is a silent interop break.
+    let schema: serde_json::Value = serde_json::from_str(SCHEMA_JSON).expect("schema is JSON");
+    assert_eq!(
+        schema["$schema"], "https://json-schema.org/draft/2020-12/schema",
+        "schema must declare draft 2020-12"
+    );
+    assert_eq!(
+        schema["properties"]["schema_version"]["const"],
+        serde_json::json!(SCHEMA_VERSION),
+        "schema's pinned version must match the Rust constant"
+    );
+}
+
+#[test]
+fn schema_enums_match_rust_enums() {
+    // Why: the JSON Schema and the Rust types are two spellings of one
+    // taxonomy. If they drift, a package validates in an editor and fails in
+    // trusty-mpm (or worse, the reverse). This is the drift gate.
+    let ids: Vec<String> = SectionId::CANONICAL.iter().map(wire).collect();
+    assert_eq!(
+        schema_enum("section-id"),
+        ids,
+        "schema section-id enum must match SectionId::CANONICAL, in order"
+    );
+
+    let tiers: Vec<String> = [
+        CustomizationTier::Fixed,
+        CustomizationTier::Project,
+        CustomizationTier::User,
+    ]
+    .iter()
+    .map(wire)
+    .collect();
+    assert_eq!(schema_enum("customization-tier"), tiers);
+
+    let generators: Vec<String> = [
+        Generator::AgentRoster,
+        Generator::StackProfile,
+        Generator::ProjectAddendum,
+    ]
+    .iter()
+    .map(wire)
+    .collect();
+    assert_eq!(schema_enum("generator"), generators);
+}
+
+#[test]
+fn schema_example_deserializes_validates_and_round_trips() {
+    // Why (acceptance criterion of #4184): the Rust types must deserialize the
+    // committed schema, and the round trip must be lossless — tooling that
+    // rewrites a package must not churn unrelated bytes.
+    let raw = schema_example();
+    let pkg = InstructionPackage::from_json(&raw).expect("schema example deserializes");
+    pkg.validate()
+        .expect("schema example is structurally valid");
+
+    let reserialized = pkg.to_json().expect("serializes");
+    let again = InstructionPackage::from_json(&reserialized).expect("re-deserializes");
+    assert_eq!(pkg, again, "round trip must be lossless");
+    assert_eq!(
+        reserialized,
+        again.to_json().expect("serializes"),
+        "serialization must be a fixed point"
+    );
+}
+
+#[test]
+fn rejects_unknown_fields() {
+    // Why: a typo'd key must be a loud parse error. Silently ignoring it is how
+    // a whole instruction block goes missing without anyone noticing (#4196's
+    // failure shape).
+    let mut value: serde_json::Value =
+        serde_json::from_str(&schema_example()).expect("example is JSON");
+    value["blocks"][0]["joinbefore"] = serde_json::json!("blank");
+    let err = InstructionPackage::from_json(&value.to_string()).unwrap_err();
+    assert!(
+        err.to_string().contains("joinbefore"),
+        "unknown field must be named in the error: {err}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Taxonomy + tier axis
+// ---------------------------------------------------------------------------
+
+#[test]
+fn canonical_order_is_sorted_and_complete() {
+    // Why: `validate` compares declaration order against `CANONICAL` using
+    // equality, and the enum's `Ord` is the documented tier-independent
+    // ordering; both rely on CANONICAL being the enum's own order with no gaps
+    // or repeats.
+    let mut sorted = SectionId::CANONICAL;
+    sorted.sort();
+    assert_eq!(sorted, SectionId::CANONICAL, "CANONICAL must be sorted");
+    let unique: std::collections::BTreeSet<_> = SectionId::CANONICAL.iter().collect();
+    assert_eq!(unique.len(), 8, "eight distinct sections");
+}
+
+#[test]
+fn floor_membership_is_exactly_the_absorbed_base_pm_blocks() {
+    // Why: #4183 absorbs three BASE_PM blocks as the floor. Anything else being
+    // floor would over-freeze content; anything less would let the floor be
+    // overridden.
+    let floor: Vec<SectionId> = SectionId::CANONICAL
+        .into_iter()
+        .filter(|s| s.is_floor())
+        .collect();
+    assert_eq!(
+        floor,
+        vec![
+            SectionId::Identity,
+            SectionId::NonOverridableRules,
+            SectionId::FrameworkGuaranteedConventions,
+        ]
+    );
+}
+
+#[test]
+fn tier_ordering_is_by_permissiveness() {
+    // SPEC-PMINSTR-01 §4b: fixed < project < user.
+    assert!(CustomizationTier::Fixed < CustomizationTier::Project);
+    assert!(CustomizationTier::Project < CustomizationTier::User);
+}
+
+#[test]
+fn tier_permits_matrix() {
+    // Why: `project` deliberately excludes user-tier override so a personal
+    // ~/.trusty-mpm config can never leak into a shared project.
+    use CustomizationTier::*;
+    use OverrideTier as O;
+    assert!(!Fixed.permits(O::Project));
+    assert!(!Fixed.permits(O::User));
+    assert!(Project.permits(O::Project));
+    assert!(!Project.permits(O::User));
+    assert!(User.permits(O::Project));
+    assert!(User.permits(O::User));
+}
+
+#[test]
+fn section_lookup_reports_declared_tier() {
+    let pkg = fixture();
+    assert_eq!(
+        pkg.section(SectionId::Identity)
+            .map(|s| s.customization_tier),
+        Some(CustomizationTier::Fixed)
+    );
+    assert_eq!(
+        pkg.section(SectionId::Core).map(|s| s.customization_tier),
+        Some(CustomizationTier::Project)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Join semantics
+// ---------------------------------------------------------------------------
+
+#[test]
+fn join_literals_are_exact() {
+    // Why: byte-identity is only provable if joins are literal, not inferred.
+    // `Rule` must be the same separator the legacy pipeline uses, or the
+    // re-sourced build (#4186) can never match today's bytes.
+    assert_eq!(Join::Rule.as_str(), "\n\n---\n\n");
+    assert_eq!(Join::Rule.as_str(), SECTION_SEPARATOR);
+    assert_eq!(Join::Blank.as_str(), "\n\n");
+    assert_eq!(Join::None.as_str(), "");
+    assert_eq!(Join::Literal("\n\n\n".to_string()).as_str(), "\n\n\n");
+    assert_eq!(Join::default(), Join::Rule);
+}
+
+#[test]
+fn join_serializes_as_string_or_literal_object() {
+    assert_eq!(serde_json::to_string(&Join::Rule).unwrap(), "\"rule\"");
+    assert_eq!(serde_json::to_string(&Join::Blank).unwrap(), "\"blank\"");
+    assert_eq!(serde_json::to_string(&Join::None).unwrap(), "\"none\"");
+    assert_eq!(
+        serde_json::to_string(&Join::Literal("x".to_string())).unwrap(),
+        "{\"literal\":\"x\"}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Validation — one test per defect class
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fixture_is_valid() {
+    fixture().validate().expect("fixture must be valid");
+}
+
+#[test]
+fn rejects_unsupported_schema_version() {
+    let mut pkg = fixture();
+    pkg.schema_version = SCHEMA_VERSION + 1;
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::UnsupportedSchemaVersion {
+            found: SCHEMA_VERSION + 1
+        }
+    );
+}
+
+#[test]
+fn rejects_empty_package_id() {
+    let mut pkg = fixture();
+    pkg.package_id = "   ".to_string();
+    assert_eq!(pkg.validate().unwrap_err(), ValidationError::EmptyPackageId);
+}
+
+#[test]
+fn rejects_reordered_sections() {
+    // Why: the manifest must read the same way in every project. Declaration
+    // order has no effect on output, so freezing it costs nothing.
+    let mut pkg = fixture();
+    pkg.sections.swap(1, 2);
+    assert!(matches!(
+        pkg.validate().unwrap_err(),
+        ValidationError::SectionsNotCanonical { .. }
+    ));
+}
+
+#[test]
+fn rejects_missing_section_declaration() {
+    let mut pkg = fixture();
+    pkg.sections.retain(|s| s.id != SectionId::Search);
+    assert!(matches!(
+        pkg.validate().unwrap_err(),
+        ValidationError::SectionsNotCanonical { .. }
+    ));
+}
+
+#[test]
+fn rejects_floor_section_that_is_not_fixed() {
+    // Why (#4194): the floor's non-overridable semantics must be representable
+    // AND enforced, not merely conventional.
+    let mut pkg = fixture();
+    for section in &mut pkg.sections {
+        if section.id == SectionId::NonOverridableRules {
+            section.customization_tier = CustomizationTier::Project;
+        }
+    }
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::FloorNotFixed {
+            section: SectionId::NonOverridableRules,
+            tier: CustomizationTier::Project,
+        }
+    );
+}
+
+#[test]
+fn rejects_empty_block_stream() {
+    let mut pkg = fixture();
+    pkg.blocks.clear();
+    assert_eq!(pkg.validate().unwrap_err(), ValidationError::NoBlocks);
+}
+
+#[test]
+fn rejects_blank_text_block() {
+    let mut pkg = fixture();
+    pkg.blocks[0] = text(SectionId::Core, "   \n\t ");
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::EmptyText {
+            index: 0,
+            section: SectionId::Core,
+        }
+    );
+}
+
+#[test]
+fn rejects_optional_text_block() {
+    // Why: `optional` exists only so a generator with nothing to supply can be
+    // dropped deliberately. An optional *text* block would be authored content
+    // that vanishes for no reason.
+    let mut pkg = fixture();
+    pkg.blocks[0].optional = true;
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::OptionalTextBlock {
+            index: 0,
+            section: SectionId::Core,
+        }
+    );
+}
+
+#[test]
+fn rejects_section_that_contributes_nothing() {
+    // Why: a declared-but-silent section is exactly the #4196 shape — the
+    // taxonomy claims the content is delivered, the output does not contain it.
+    let mut pkg = fixture();
+    pkg.blocks.retain(|b| b.section != SectionId::Search);
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::SectionWithoutBlocks {
+            section: SectionId::Search
+        }
+    );
+}
+
+#[test]
+fn rejects_package_that_never_consumes_the_roster() {
+    // Why (#4196): the delivered prompt named 8 agents because the computed
+    // 42-agent roster was dropped at the final composition step. A package that
+    // does not consume the roster is not a valid package.
+    let mut pkg = fixture();
+    for block in &mut pkg.blocks {
+        if matches!(
+            block.body,
+            BlockBody::Generated {
+                generator: Generator::AgentRoster
+            }
+        ) {
+            block.body = BlockBody::Text {
+                text: "STATIC ROSTER".to_string(),
+            };
+        }
+    }
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::RosterNotConsumed
+    );
+}
+
+#[test]
+fn rejects_optional_roster_block() {
+    // Why (#4196): the roster must never be droppable, even deliberately.
+    let mut pkg = fixture();
+    let index = pkg
+        .blocks
+        .iter()
+        .position(|b| {
+            matches!(
+                b.body,
+                BlockBody::Generated {
+                    generator: Generator::AgentRoster
+                }
+            )
+        })
+        .expect("roster block");
+    pkg.blocks[index].optional = true;
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::OptionalRoster { index }
+    );
+}
+
+#[test]
+fn rejects_overridable_block_after_the_floor() {
+    // Why: the floor's guarantee is that it has the last word. Enforcing this
+    // per-block preserves it without dictating one global order — which the
+    // byte-identical lift in #4186 needs to stay free to choose.
+    let mut pkg = fixture();
+    pkg.blocks.push(text(SectionId::Core, "SNEAKY"));
+    let err = pkg.validate().unwrap_err();
+    assert!(
+        matches!(
+            err,
+            ValidationError::OverridableAfterFloor {
+                section: SectionId::Core,
+                ..
+            }
+        ),
+        "got {err}"
+    );
+}
+
+#[test]
+fn floor_blocks_may_follow_each_other() {
+    // The floor may itself be several blocks; only non-floor content is barred.
+    let mut pkg = fixture();
+    pkg.blocks
+        .push(text(SectionId::FrameworkGuaranteedConventions, "MORE"));
+    pkg.validate().expect("floor-after-floor is fine");
+}
+
+// ---------------------------------------------------------------------------
+// Composition — ordering, joins, determinism
+// ---------------------------------------------------------------------------
+
+#[test]
+fn composes_blocks_in_array_order_with_declared_joins() {
+    // Why: output order is block-array order and nothing else — no map
+    // iteration can reach it. Interleaving `core` with `memory`/`search` proves
+    // a section can contribute at several non-adjacent positions, which is what
+    // makes a byte-identical lift out of the middle of a legacy asset possible.
+    let mut pkg = fixture();
+    pkg.blocks[1].join_before = Join::Blank;
+    pkg.blocks[2].join_before = Join::Blank;
+    let out = pkg.compose(&inputs()).expect("composes");
+    assert_eq!(
+        out,
+        [
+            "CORE-A\n\nMEMORY\n\nCORE-B",
+            "SEARCH",
+            "STACK",
+            "WORKFLOW",
+            "ROSTER",
+            "ADDENDUM",
+            "IDENTITY",
+            "RULES",
+            "CONVENTIONS",
+        ]
+        .join(SECTION_SEPARATOR)
+    );
+}
+
+#[test]
+fn first_emitted_block_never_contributes_a_join() {
+    let pkg = fixture();
+    let out = pkg.compose(&inputs()).expect("composes");
+    assert!(out.starts_with("CORE-A"), "no leading separator: {out:?}");
+    assert!(out.ends_with("CONVENTIONS"), "no trailing newline: {out:?}");
+}
+
+#[test]
+fn optional_generated_block_is_dropped_with_its_join() {
+    // Why: an optional generator with nothing to supply must leave no dangling
+    // separator behind.
+    let pkg = fixture();
+    let out = pkg
+        .compose(&CompositionInputs {
+            agent_roster: "ROSTER".to_string(),
+            stack_profile: None,
+            project_addendum: None,
+        })
+        .expect("composes");
+    assert!(!out.contains("STACK"));
+    assert!(!out.contains("ADDENDUM"));
+    assert!(
+        !out.contains("---\n\n---"),
+        "no dangling separator: {out:?}"
+    );
+    assert!(out.contains(&format!("WORKFLOW{SECTION_SEPARATOR}ROSTER")));
+}
+
+#[test]
+fn whitespace_only_generator_output_counts_as_absent() {
+    let pkg = fixture();
+    let out = pkg
+        .compose(&CompositionInputs {
+            agent_roster: "ROSTER".to_string(),
+            stack_profile: Some("   \n\n".to_string()),
+            project_addendum: None,
+        })
+        .expect("composes");
+    assert!(!out.contains("   \n\n"), "blank stack profile is dropped");
+}
+
+#[test]
+fn generated_bodies_are_trimmed() {
+    let pkg = fixture();
+    let out = pkg
+        .compose(&CompositionInputs {
+            agent_roster: "\n\n  ROSTER  \n\n".to_string(),
+            stack_profile: None,
+            project_addendum: None,
+        })
+        .expect("composes");
+    assert!(out.contains(&format!("WORKFLOW{SECTION_SEPARATOR}ROSTER")));
+}
+
+#[test]
+fn missing_required_generator_input_is_a_hard_error() {
+    // Why (#4196): a required generator that supplies nothing must fail the
+    // composition loudly. Under the old concatenation it produced a prompt that
+    // looked fine and named 8 of 42 agents.
+    let pkg = fixture();
+    let index = pkg
+        .blocks
+        .iter()
+        .position(|b| {
+            matches!(
+                b.body,
+                BlockBody::Generated {
+                    generator: Generator::AgentRoster
+                }
+            )
+        })
+        .expect("roster block");
+    let err = pkg
+        .compose(&CompositionInputs {
+            agent_roster: String::new(),
+            ..inputs()
+        })
+        .unwrap_err();
+    assert_eq!(
+        err,
+        CompositionError::MissingGeneratedInput {
+            index,
+            generator: Generator::AgentRoster,
+        }
+    );
+}
+
+#[test]
+fn compose_rejects_an_invalid_package() {
+    let mut pkg = fixture();
+    pkg.schema_version = 99;
+    assert!(matches!(
+        pkg.compose(&inputs()).unwrap_err(),
+        CompositionError::Invalid(ValidationError::UnsupportedSchemaVersion { found: 99 })
+    ));
+}
+
+#[test]
+fn compose_is_byte_identical_across_repeats_and_a_json_round_trip() {
+    // Why: this is the property #4186's acceptance test depends on — the same
+    // package and the same roster must produce the same bytes, including after
+    // the package has been serialized and read back.
+    let pkg = fixture();
+    let inputs = inputs();
+    let first = pkg.compose(&inputs).expect("composes");
+    let second = pkg.compose(&inputs).expect("composes");
+    assert_eq!(first, second, "compose must be a pure function");
+
+    let round_tripped =
+        InstructionPackage::from_json(&pkg.to_json().expect("serializes")).expect("deserializes");
+    assert_eq!(
+        first,
+        round_tripped.compose(&inputs).expect("composes"),
+        "a JSON round trip must not change a single byte of the output"
+    );
+}
+
+#[test]
+fn trailing_newline_appends_exactly_one_byte() {
+    // Why: the tail byte is the difference between today's `resolve_pm_prompt`
+    // output (none) and a file-shaped artifact (one). Both must be expressible.
+    let mut pkg = fixture();
+    let without = pkg.compose(&inputs()).expect("composes");
+    pkg.trailing_newline = true;
+    let with = pkg.compose(&inputs()).expect("composes");
+    assert_eq!(with, format!("{without}\n"));
+}
+
+#[test]
+fn schema_example_composes_deterministically() {
+    // The committed example is not just parseable — it composes.
+    let pkg = InstructionPackage::from_json(&schema_example()).expect("deserializes");
+    let out = pkg.compose(&inputs()).expect("composes");
+    assert!(out.contains("ROSTER"), "roster reaches the output: {out}");
+    assert_eq!(out, pkg.compose(&inputs()).expect("composes"));
+}

--- a/crates/trusty-mpm/src/core/instruction_package_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_package_tests.rs
@@ -304,7 +304,20 @@ fn join_rejects_an_unknown_key_alongside_literal() {
     // module, so nothing else would catch it regressing.
     let err = serde_json::from_str::<Join>(r#"{"literal":"x","bogus":1}"#)
         .expect_err("an extra key alongside `literal` must be rejected");
-    let _ = err;
+
+    // DEFERRED LOW (#4223 re-review): unlike the struct errors, this one does
+    // not NAME the offending key — serde's externally tagged representation
+    // reports "expected value" plus a position. Deferred rather than fixed: it
+    // is a REJECTION, not a silent drop, so the failure mode this PR exists to
+    // close is already shut; naming the key would need a hand-written
+    // Deserialize for `Join` purely to improve a message on the rarest variant
+    // (`Literal` is an escape hatch). Pin the POSITION instead, so the
+    // diagnostic can never degrade to something with no locator at all.
+    let msg = err.to_string();
+    assert!(
+        msg.contains("line") && msg.contains("column"),
+        "the error must at least locate the offending key: {msg}"
+    );
 
     // An unrecognised variant is named, in both spellings.
     let err = serde_json::from_str::<Join>(r#""rulez""#).unwrap_err();
@@ -514,6 +527,60 @@ fn rejects_optional_text_block() {
             index: 0,
             section: SectionId::Core,
         }
+    );
+}
+
+#[test]
+fn rejects_section_covered_only_by_optional_blocks() {
+    // Why (#4223 re-review MEDIUM): owning blocks is not the same as emitting.
+    // A section whose every block is `optional` passes the ownership check and
+    // still composes to nothing — the taxonomy claims the content is delivered
+    // and the output does not contain it, which is exactly the silent-missing-
+    // section shape the ownership check exists to prevent.
+    //
+    // The complement — a section with BOTH an optional and a non-optional block
+    // — must stay legal, and does: `fixture()`'s `core` owns two text blocks
+    // plus two optional generated ones, and `fixture_is_valid` covers it.
+    let mut pkg = fixture();
+    pkg.blocks.retain(|b| b.section != SectionId::Search);
+    pkg.blocks.insert(
+        3,
+        generated(SectionId::Search, Generator::ProjectAddendum, true),
+    );
+    assert_eq!(
+        pkg.validate().unwrap_err(),
+        ValidationError::SectionOnlyOptionalBlocks {
+            section: SectionId::Search
+        }
+    );
+}
+
+#[test]
+fn later_schema_version_is_reported_as_a_version_error_not_a_field_error() {
+    // Why (#4223 re-review LOW): the module promises that a package from a later
+    // schema is rejected with a loud "unsupported schema_version". That promise
+    // was not kept for the case that actually matters — a v2 package almost
+    // certainly carries a v2 field, and plain deserialization blamed THAT key
+    // ("unknown field `...`"), pointing the author at something perfectly valid
+    // in its own schema instead of telling them to upgrade trusty-mpm.
+    let mut value: serde_json::Value =
+        serde_json::from_str(&schema_example()).expect("example is JSON");
+    value["schema_version"] = serde_json::json!(SCHEMA_VERSION + 1);
+    value["blocks"][0]["field_added_in_v2"] = serde_json::json!("x");
+
+    let err = InstructionPackage::from_json(&value.to_string()).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("schema_version"),
+        "the VERSION must be blamed, got: {msg}"
+    );
+    assert!(
+        msg.contains(&(SCHEMA_VERSION + 1).to_string()),
+        "the offending version must be named, got: {msg}"
+    );
+    assert!(
+        !msg.contains("field_added_in_v2"),
+        "must NOT blame a key that is valid in its own schema, got: {msg}"
     );
 }
 
@@ -805,6 +872,69 @@ fn valid_package_with_non_contiguous_blocks_still_round_trips() {
         composed,
         again.compose(&inputs()).expect("composes"),
         "a JSON round trip must not change a single byte"
+    );
+}
+
+#[test]
+fn todays_delegation_section_shape_is_expressible() {
+    // Why: this pins the CORRECTION of a wrong conclusion an earlier revision of
+    // this PR drew and propagated to issue #4186 — that #4186 must choose
+    // between a byte-identical lift and consuming the computed roster.
+    //
+    // It does not have to choose. Since #4196 (closing #4069),
+    // `instruction_overrides::bundled_delegation` builds the section as
+    //
+    //     format!("{bundled}\n\n{ROSTER_PRECEDENCE_NOTE}\n\n{}", roster.trim())
+    //
+    // — bundled asset, blank line, precedence note, blank line, LIVE roster. So
+    // the delivered prompt ALREADY carries the real roster, and this schema
+    // expresses that exact shape with three blocks joined by `blank`. Byte
+    // identity and roster consumption are therefore compatible, and #4186 should
+    // keep strict byte-equality against today's output as its acceptance gate.
+    //
+    // (Stand-in strings, not the real assets: `ROSTER_PRECEDENCE_NOTE` is
+    // private to `instruction_overrides`. What is pinned here is the SHAPE
+    // `A\n\nB\n\n<generated roster>`, which is the load-bearing claim.)
+    let mut pkg = fixture();
+    let at = pkg
+        .blocks
+        .iter()
+        .position(|b| b.section == SectionId::AgentDelegation)
+        .expect("fixture has a delegation block");
+
+    let asset = text(SectionId::AgentDelegation, "BUNDLED-ASSET");
+    let mut note = text(SectionId::AgentDelegation, "PRECEDENCE-NOTE");
+    note.join_before = Join::Blank;
+    let mut roster = generated(SectionId::AgentDelegation, Generator::AgentRoster, false);
+    roster.join_before = Join::Blank;
+    pkg.blocks.splice(at..=at, [asset, note, roster]);
+
+    pkg.validate()
+        .expect("today's delegation shape must be a valid package");
+    let out = pkg.compose(&inputs()).expect("composes");
+    assert!(
+        out.contains("BUNDLED-ASSET\n\nPRECEDENCE-NOTE\n\nROSTER"),
+        "asset/note/roster must rejoin exactly as bundled_delegation writes them: {out:?}"
+    );
+
+    // And the roster is genuinely the generated block, not authored text --
+    // swapping it for static text must fail validation (#4196's whole point).
+    let mut static_roster = pkg.clone();
+    for block in &mut static_roster.blocks {
+        if matches!(
+            block.body,
+            BlockBody::Generated {
+                generator: Generator::AgentRoster
+            }
+        ) {
+            block.body = BlockBody::Text {
+                text: "STATIC ROSTER".to_string(),
+            };
+        }
+    }
+    assert_eq!(
+        static_roster.validate().unwrap_err(),
+        ValidationError::RosterNotConsumed
     );
 }
 

--- a/crates/trusty-mpm/src/core/instruction_package_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_package_tests.rs
@@ -184,19 +184,133 @@ fn schema_example_deserializes_validates_and_round_trips() {
     );
 }
 
+/// Index of the first block in the schema example whose body is `generated`.
+fn generated_block_index(value: &serde_json::Value) -> usize {
+    value["blocks"]
+        .as_array()
+        .expect("blocks is an array")
+        .iter()
+        .position(|b| b["body"]["kind"] == "generated")
+        .expect("the example has a generated block")
+}
+
 #[test]
-fn rejects_unknown_fields() {
-    // Why: a typo'd key must be a loud parse error. Silently ignoring it is how
-    // a whole instruction block goes missing without anyone noticing (#4196's
-    // failure shape).
-    let mut value: serde_json::Value =
+fn rejects_unknown_fields_at_every_level_and_names_the_key() {
+    // Why: a typo'd key must be a loud parse error naming the offender. A
+    // silently ignored key is how a whole instruction block changes meaning
+    // without anyone noticing (#4196's failure shape: report success, compose
+    // the wrong bytes) — and an error that merely says "invalid" leaves the
+    // typo almost as hard to find as a silent drop.
+    //
+    // This covers EVERY object in the deserialization path, not just the one
+    // struct that regressed. `BlockBody` (the `body` cases) is the #4223 HIGH:
+    // before `deny_unknown_fields` was added to it, a key misplaced inside
+    // `body` deserialized to `Ok(..)` with the key discarded, and the block
+    // silently fell back to the `Join::Rule` default.
+    let example: serde_json::Value =
         serde_json::from_str(&schema_example()).expect("example is JSON");
-    value["blocks"][0]["joinbefore"] = serde_json::json!("blank");
-    let err = InstructionPackage::from_json(&value.to_string()).unwrap_err();
+    let gen_index = generated_block_index(&example);
+
+    // (label, JSON pointer to the object that should reject, injected key)
+    let cases: [(&str, String, &str); 5] = [
+        ("package root", String::new(), "bogus_root_key"),
+        ("InstructionSection", "/sections/0".to_string(), "tier"),
+        ("InstructionBlock", "/blocks/0".to_string(), "joinbefore"),
+        (
+            "BlockBody::Text",
+            "/blocks/0/body".to_string(),
+            "join_before",
+        ),
+        (
+            "BlockBody::Generated",
+            format!("/blocks/{gen_index}/body"),
+            "optional",
+        ),
+    ];
+
+    for (label, pointer, key) in cases {
+        let mut value = example.clone();
+        let target = if pointer.is_empty() {
+            &mut value
+        } else {
+            value
+                .pointer_mut(&pointer)
+                .unwrap_or_else(|| panic!("{label}: pointer {pointer} resolves"))
+        };
+        target[key] = serde_json::json!("x");
+
+        let err = match InstructionPackage::from_json(&value.to_string()) {
+            Err(err) => err,
+            Ok(_) => panic!(
+                "{label}: unknown key `{key}` was SILENTLY ACCEPTED at {pointer:?}; \
+                 it must be a parse error"
+            ),
+        };
+        assert!(
+            err.to_string().contains(key),
+            "{label}: the error must NAME the offending key `{key}` so a typo is \
+             findable, got: {err}"
+        );
+    }
+}
+
+#[test]
+fn schema_document_closes_every_object() {
+    // Why: the Rust loader and the shipped JSON Schema are two spellings of one
+    // format. `rejects_unknown_fields_at_every_level_and_names_the_key` pins the
+    // Rust half; this pins the schema half, so an object added to the schema
+    // without `additionalProperties: false` cannot reintroduce the drift where a
+    // package validates strictly in trusty-mpm but loosely in an editor (or the
+    // reverse — which is how the #4223 HIGH shipped).
+    let schema: serde_json::Value = serde_json::from_str(SCHEMA_JSON).expect("schema is JSON");
+
+    /// Walk every subschema, collecting object-typed ones that stay open.
+    fn walk(node: &serde_json::Value, path: String, open: &mut Vec<String>) {
+        if let Some(map) = node.as_object() {
+            if map.get("type") == Some(&serde_json::json!("object"))
+                && map.get("additionalProperties") != Some(&serde_json::json!(false))
+            {
+                open.push(path.clone());
+            }
+            for (key, child) in map {
+                // `examples` holds package instances, not subschemas.
+                if path.is_empty() && key == "examples" {
+                    continue;
+                }
+                walk(child, format!("{path}/{key}"), open);
+            }
+        } else if let Some(items) = node.as_array() {
+            for (i, child) in items.iter().enumerate() {
+                walk(child, format!("{path}/{i}"), open);
+            }
+        }
+    }
+
+    let mut open = Vec::new();
+    walk(&schema, String::new(), &mut open);
     assert!(
-        err.to_string().contains("joinbefore"),
-        "unknown field must be named in the error: {err}"
+        open.is_empty(),
+        "every object in the schema must set `additionalProperties: false`; open: {open:?}"
     );
+}
+
+#[test]
+fn join_rejects_an_unknown_key_alongside_literal() {
+    // Why: `Join` is the one type in the graph that is NOT a `deny_unknown_fields`
+    // struct — it is an externally tagged enum, so the attribute does not apply.
+    // It is nonetheless closed: serde_json requires the variant object to hold
+    // exactly one key. Pinned here because that is a property of serde's
+    // externally-tagged representation rather than of anything written in this
+    // module, so nothing else would catch it regressing.
+    let err = serde_json::from_str::<Join>(r#"{"literal":"x","bogus":1}"#)
+        .expect_err("an extra key alongside `literal` must be rejected");
+    let _ = err;
+
+    // An unrecognised variant is named, in both spellings.
+    let err = serde_json::from_str::<Join>(r#""rulez""#).unwrap_err();
+    assert!(err.to_string().contains("rulez"), "got {err}");
+    let err = serde_json::from_str::<Join>(r#"{"litteral":"x"}"#).unwrap_err();
+    assert!(err.to_string().contains("litteral"), "got {err}");
 }
 
 // ---------------------------------------------------------------------------
@@ -651,6 +765,96 @@ fn trailing_newline_appends_exactly_one_byte() {
     pkg.trailing_newline = true;
     let with = pkg.compose(&inputs()).expect("composes");
     assert_eq!(with, format!("{without}\n"));
+}
+
+#[test]
+fn valid_package_with_non_contiguous_blocks_still_round_trips() {
+    // Why: the counterweight to the strictness tests. Closing unknown fields
+    // must not degenerate into "reject everything" — in particular it must not
+    // disturb the property this schema exists for: ONE SECTION OWNING SEVERAL
+    // NON-ADJACENT BLOCK POSITIONS, which is what lets `memory`/`search` be
+    // lifted out of the middle of PM_INSTRUCTIONS.md without moving a byte.
+    let raw = schema_example();
+    let pkg = InstructionPackage::from_json(&raw).expect("valid package must still deserialize");
+    pkg.validate().expect("valid package must still validate");
+
+    // The example genuinely exercises non-contiguity, so this test cannot pass
+    // vacuously on a package whose sections happen to be contiguous.
+    let core_positions: Vec<usize> = pkg
+        .blocks
+        .iter()
+        .enumerate()
+        .filter(|(_, b)| b.section == SectionId::Core)
+        .map(|(i, _)| i)
+        .collect();
+    assert!(
+        core_positions.len() >= 2,
+        "fixture must own several blocks: {core_positions:?}"
+    );
+    assert!(
+        core_positions.windows(2).any(|w| w[1] != w[0] + 1),
+        "`core` must own NON-ADJACENT positions or this test proves nothing: {core_positions:?}"
+    );
+
+    // Round trip is lossless and byte-stable through compose.
+    let composed = pkg.compose(&inputs()).expect("composes");
+    let again = InstructionPackage::from_json(&pkg.to_json().expect("serializes"))
+        .expect("re-deserializes");
+    assert_eq!(pkg, again, "round trip must be lossless");
+    assert_eq!(
+        composed,
+        again.compose(&inputs()).expect("composes"),
+        "a JSON round trip must not change a single byte"
+    );
+}
+
+#[test]
+fn base_pm_floor_block_order_is_valid() {
+    // Why: this pins the REFUTATION of a proposed constraint (#4223 review,
+    // MEDIUM: "require floor blocks to be in canonical section order relative to
+    // each other; it costs #4186 nothing"). It would in fact cost #4186 the
+    // whole lift. `assets/instructions/BASE_PM.md` runs its headings:
+    //
+    //   ## Identity                                     -> Identity                       (0)
+    //   ## Non-Overridable Rules                        -> NonOverridableRules             (6)
+    //   ## Customizing PM Behavior                      -> NonOverridableRules             (6)
+    //   ## Framework-Guaranteed Conventions             -> FrameworkGuaranteedConventions  (7)
+    //   ## Trusty Tool Priority (Non-Overridable)       -> NonOverridableRules             (6)
+    //
+    // i.e. 0, 6, 6, 7, 6 — a canonical-order inversion in the real asset. A
+    // non-decreasing-floor-order rule would reject a faithful lift of BASE_PM.md
+    // and force #4186 to move bytes. If someone adds that constraint later, this
+    // test fails and says why.
+    let mut pkg = fixture();
+    pkg.blocks.retain(|b| !b.section.is_floor());
+    pkg.blocks.extend([
+        text(SectionId::Identity, "IDENTITY"),
+        text(SectionId::NonOverridableRules, "NON-OVERRIDABLE RULES"),
+        text(SectionId::NonOverridableRules, "CUSTOMIZING PM BEHAVIOR"),
+        text(
+            SectionId::FrameworkGuaranteedConventions,
+            "FRAMEWORK-GUARANTEED CONVENTIONS",
+        ),
+        text(SectionId::NonOverridableRules, "TRUSTY TOOL PRIORITY"),
+    ]);
+
+    pkg.validate()
+        .expect("BASE_PM.md's real floor order must remain expressible");
+
+    let out = pkg.compose(&inputs()).expect("composes");
+    let parts: Vec<&str> = out.split(SECTION_SEPARATOR).collect();
+    let tail: Vec<&str> = parts[parts.len() - 5..].to_vec();
+    assert_eq!(
+        tail,
+        vec![
+            "IDENTITY",
+            "NON-OVERRIDABLE RULES",
+            "CUSTOMIZING PM BEHAVIOR",
+            "FRAMEWORK-GUARANTEED CONVENTIONS",
+            "TRUSTY TOOL PRIORITY",
+        ],
+        "floor blocks compose in declared array order, inversion included"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -52,6 +52,9 @@ pub mod hook;
 pub mod idle_nudge;
 pub mod idle_parking;
 pub mod instruction_overrides;
+// Issue #4184 / epic #4183: the sectioned-JSON instruction package schema. Types
+// + validation only — nothing in the launch path composes from it yet (#4186).
+pub mod instruction_package;
 pub mod instruction_pipeline;
 pub mod ipc;
 pub mod llm_overseer;


### PR DESCRIPTION
Defines the instruction section taxonomy and its JSON schema — the shape every other child of epic #4183 consumes, and the thing that blocks all of them.

Scope is schema, Rust types, serde, validation, and unit tests. **No instruction content is authored (#4185) and no build is re-sourced (#4186)** — nothing in the session-launch path composes from this yet. `instruction_pipeline.rs` and `instruction_overrides.rs` are untouched.

## The shape

A package has two arrays:

- **`sections`** — the closed eight-member taxonomy carrying the `fixed | project | user` customization tier. Declaration order is fixed and canonical and has **no** effect on composed bytes.
- **`blocks`** — the ordered composition stream. Output is `blocks` in array order and nothing else.

Splitting identity from position is the load-bearing decision. A section may own **several non-contiguous blocks**, so `memory` can be lifted out of the middle of `PM_INSTRUCTIONS.md` and still emit at exactly the offset it occupies today. A one-section-one-position model would have made a faithful, byte-identical lift impossible for #4185/#4186, because `memory` and `search` are drawn from two different legacy files at two different depths.

## How this guarantees byte-identical composition

The acceptance test in #4186 is that the composed prompt is byte-identical given the same manifest and roster. Four properties get it there:

1. **Order comes from `Vec`, never from a map.** There is no `HashMap` anywhere in the type graph; the only ordered containers are `Vec`, and the only set is a `BTreeSet` used for a coverage check that never reaches output.
2. **Every boundary is an explicit literal.** `Join::Rule` (`"\n\n---\n\n"`, asserted equal to the existing `SECTION_SEPARATOR`), `Blank` (`"\n\n"`), `None` (`""`), or `Literal(verbatim)`. Whitespace is declared, not inferred, and `trailing_newline` pins the tail byte — `false` reproduces today's `resolve_pm_prompt` (no trailing newline), `true` a file-shaped artifact.
3. **`compose` is pure.** A total function of `(package, inputs)`: no clock, env, filesystem or randomness. `compose_is_byte_identical_across_repeats_and_a_json_round_trip` asserts repeats match and that a serialize/deserialize cycle does not change a single output byte.
4. **Dropping content requires explicit permission.** Only a `generated` block may be `optional`. Anything else that would render empty is a hard `CompositionError`.

## Regression shapes this makes hard to reintroduce

**#4196** — the delivered prompt named 8 agents because the computed 42-agent roster was discarded at the final composition step. Three independent structural guards now:

- `CompositionInputs.agent_roster` is a required, non-`Option` field, so composition cannot be called without producing a roster;
- `validate()` rejects a package that never consumes `Generator::AgentRoster` (`RosterNotConsumed`) or that marks the roster block `optional` (`OptionalRoster`);
- a required generator supplying nothing is `MissingGeneratedInput`, a hard error — the old failure produced a prompt that looked fine.

A fourth, weaker guard generalises it: `SectionWithoutBlocks` rejects any declared section that contributes nothing, which is the same "the taxonomy claims it ships, the output does not contain it" shape.

**#4194** — the non-overridable floor ordered an `index_id` that 404s. Content correctness is not this ticket, but the floor's semantics are now representable and enforced per section rather than per file: `SectionId::is_floor()`, `FloorNotFixed` (a floor section must be tier `fixed`), and `OverridableAfterFloor` (nothing overridable may follow the floor). `CustomizationTier::permits(OverrideTier)` encodes the tier matrix — notably `project` excludes user-tier override, so a personal `~/.trusty-mpm` config can never leak into a shared project.

Also: `deny_unknown_fields` throughout, so a typo'd key is a loud parse error instead of a silently dropped instruction block.

## Documented placement of each absorbed BASE_PM block

| `BASE_PM.md` block | package section |
|---|---|
| `## Identity` | `identity` |
| `## Non-Overridable Rules` | `non-overridable-rules` |
| `## Customizing PM Behavior` | `non-overridable-rules` |
| `## Trusty Tool Priority (Non-Overridable)` | `non-overridable-rules` |
| `## Framework-Guaranteed Conventions (Non-Overridable)` | `framework-guaranteed-conventions` |

The tool-priority block stays whole in the fixed floor deliberately: the *mandate* to reach for memory and code search before grep must remain non-overridable, even though the memory/search *guidance* sections a project may tune are tier `project`.

Note the canonical section list is a **declaration** order, not an imposed output order — `validate()` constrains `blocks` only with `OverridableAfterFloor`. That deliberate looseness is what leaves #4186 free to order blocks so the output matches today's bytes exactly.

## Deliberately not enforced here

No override *engine*. The tier axis ships as a pure predicate (`CustomizationTier::permits`) rather than a merge algorithm, because resolving overrides belongs to the later children. DOC-59's P1/P2 priority axis is absent — epic #4183 supersedes it with the five-section model.

## Verification

- `cargo test -p trusty-mpm --lib instruction_package` → `35 passed; 0 failed`
- `cargo test -p trusty-mpm` → `3769 passed; 0 failed` + `1257 passed; 0 failed` and 37 further green targets
- `cargo clippy --workspace --all-targets` (CI's exclude list) → clean under `-D warnings`
- `cargo fmt --check` → exit 0
- `scripts/check_line_cap.sh` → `7 allowlisted, 0 violations — OK`
- full `cargo test --workspace` (CI's exclude list) → every `trusty-mpm` target green

Three failures on the local dev machine are outside `trusty-mpm` and environmental — `trusty-agents/tests/api_e2e.rs` (asserts `/api/tasks` starts empty against a machine with a populated task store; also flaked on a 5s health timeout), `trusty-common` `catchup::json` and `trusty-search` `root_hijack_tests` (both pass in isolation, fail only under parallel load). None of the three crates depends on `trusty-mpm`, and this diff touches only `crates/trusty-mpm`, so it cannot reach them.

Closes #4184

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
