### PR TITLE
fix(trusty-mpm): derive worktrees from git instead of walking five shapes (#4207)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -33,10 +33,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   position rather than by a list of names, so a new one is excluded the day you
   create it. Location remains irrelevant *within* a project, so no reclaim
   capability is lost (#4207).
-- A git-`locked` worktree is never enumerated for reclamation. Removal uses
-  `git worktree remove --force`, which overrides the lock, so refusing to
-  consider a locked worktree is the only place `git worktree lock` can be
-  honoured (#4207).
+- A git-`locked` worktree is never enumerated for reclamation. Git itself
+  respects the lock — `git worktree remove --force` refuses it — but the
+  removal path treats that refusal as a generic git failure and falls back to
+  deleting the directory outright, which defeats the lock and strands git's
+  registry entry. Excluding locked worktrees from enumeration is the only place
+  `git worktree lock` is actually honoured (#4207).
 
 ---
 ## [1.2.3] — 2026-07-28

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -44,6 +44,19 @@ PATCH: merge-and-local-install only, no crates.io publish.
   and existing hand-placed or committed `.claude/` content is never overwritten
   — unmanaged files are skipped as user-owned, and managed files whose checksum
   drifted are skipped with a warning.
+- Worktree discovery is derived from `git worktree list --porcelain` instead of
+  walking five hard-coded location shapes, so a session worktree is found
+  wherever it lives rather than only where someone remembered to look (#4207
+  slice 1).
+- The checkout that owns a worktree is now resolved with
+  `git rev-parse --git-common-dir` instead of being guessed as the candidate's
+  grandparent directory. Worktrees physically inside `.base/.worktrees/` but
+  registered to the parent repository were previously disowned by that guess
+  and were structurally unreclaimable — never deleted, never reportable (#4207,
+  underlying defect of #4204).
+- `tm session prune --worktrees` and the daemon orphan-GC no longer propose a
+  plain directory as a reclaim candidate. A directory git does not register is
+  not trusty-mpm's to remove.
 
 - **Two paths no longer write into a destroyed worktree**
   ([#4204](https://github.com/bobmatnyc/trusty-tools/issues/4204)):

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,37 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- Worktree discovery is derived from `git worktree list --porcelain` instead of
+  walking five hard-coded location shapes, so a session worktree is found
+  wherever it lives rather than only where someone remembered to look (#4207
+  slice 1).
+- The checkout that owns a worktree is now resolved with
+  `git rev-parse --git-common-dir` instead of being guessed as the candidate's
+  grandparent directory. Worktrees physically inside `.base/.worktrees/` but
+  registered to the parent repository were previously disowned by that guess
+  and were structurally unreclaimable — never deleted, never reportable (#4207,
+  underlying defect of #4204).
+- `tm session prune --worktrees` and the daemon orphan-GC no longer propose a
+  plain directory as a reclaim candidate. A directory git does not register is
+  not trusty-mpm's to remove.
+- Worktree reclamation is bounded by a structural containment rule: a candidate
+  must be a strict descendant of the managed project directory whose git
+  registry named it. Deriving discovery from git (above) widened what could be
+  proposed for deletion from five path shapes to anything registered anywhere
+  under the projects root — on this machine that admitted five of the
+  operator's own long-lived checkouts, leaving the ownership sentinel as the
+  only thing between enumeration and an unattended removal. Your own checkouts
+  and any worktree you park beside a managed project are now excluded by
+  position rather than by a list of names, so a new one is excluded the day you
+  create it. Location remains irrelevant *within* a project, so no reclaim
+  capability is lost (#4207).
+- A git-`locked` worktree is never enumerated for reclamation. Removal uses
+  `git worktree remove --force`, which overrides the lock, so refusing to
+  consider a locked worktree is the only place `git worktree lock` can be
+  honoured (#4207).
+
 ---
 ## [1.2.3] — 2026-07-28
 
@@ -44,19 +75,6 @@ PATCH: merge-and-local-install only, no crates.io publish.
   and existing hand-placed or committed `.claude/` content is never overwritten
   — unmanaged files are skipped as user-owned, and managed files whose checksum
   drifted are skipped with a warning.
-- Worktree discovery is derived from `git worktree list --porcelain` instead of
-  walking five hard-coded location shapes, so a session worktree is found
-  wherever it lives rather than only where someone remembered to look (#4207
-  slice 1).
-- The checkout that owns a worktree is now resolved with
-  `git rev-parse --git-common-dir` instead of being guessed as the candidate's
-  grandparent directory. Worktrees physically inside `.base/.worktrees/` but
-  registered to the parent repository were previously disowned by that guess
-  and were structurally unreclaimable — never deleted, never reportable (#4207,
-  underlying defect of #4204).
-- `tm session prune --worktrees` and the daemon orphan-GC no longer propose a
-  plain directory as a reclaim candidate. A directory git does not register is
-  not trusty-mpm's to remove.
 
 - **Two paths no longer write into a destroyed worktree**
   ([#4204](https://github.com/bobmatnyc/trusty-tools/issues/4204)):

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -377,13 +377,22 @@ fn build_gh_account_check(active: Option<String>, accounts: Vec<String>) -> Doct
 /// that were decommissioned before this fix—or where `git worktree remove`
 /// failed—may leave stale `.worktrees/<session-id>/` directories on disk. This
 /// probe surfaces orphaned dirs so operators know to run
-/// `tm session prune --worktrees`. The filesystem walk is delegated to
+/// `tm session prune --worktrees`. Discovery is delegated to
 /// [`crate::session_manager::prune::find_orphaned_worktrees`] inside
-/// `spawn_blocking` so the async executor is not blocked by synchronous I/O.
+/// `spawn_blocking` so the async executor is not blocked by the synchronous
+/// git subprocesses it spawns.
 /// What: builds a canonicalized active-path set, then spawns a blocking task
-/// to walk `<repos_root>/<owner>/<repo>/.worktrees/`; any leaf directory not
-/// in the active set is counted as an orphan. Reports `Ok` (no orphans),
-/// `Warn` (orphans found), or `Ok` (repos_root absent / unconfigured).
+/// that asks GIT for the worktrees of each managed project (#4207 — this is no
+/// longer a filesystem walk of `.worktrees/`, and a candidate is no longer "any
+/// leaf directory"): every git-registered worktree that is a strict descendant
+/// of the project whose registry named it, minus the active set, is counted as
+/// an orphan. Reports `Ok` (no orphans), `Warn` (orphans found), or `Ok`
+/// (repos_root absent / unconfigured).
+///
+/// Note this probe is REPORT-ONLY — it counts, it never removes — so it
+/// deliberately reports candidates that the reclaim path would refuse to
+/// delete (owner-unknown, dirty). A directory git does not register is not
+/// counted at all; reclaiming unregistered husks is #3715, still open.
 /// Test: `worktrees_no_orphans_is_ok`, `worktrees_with_orphan_is_warn`.
 async fn check_worktrees(
     repos_root: Option<&Path>,

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -384,15 +384,17 @@ fn build_gh_account_check(active: Option<String>, accounts: Vec<String>) -> Doct
 /// What: builds a canonicalized active-path set, then spawns a blocking task
 /// that asks GIT for the worktrees of each managed project (#4207 — this is no
 /// longer a filesystem walk of `.worktrees/`, and a candidate is no longer "any
-/// leaf directory"): every git-registered worktree that is a strict descendant
-/// of the project whose registry named it, minus the active set, is counted as
-/// an orphan. Reports `Ok` (no orphans), `Warn` (orphans found), or `Ok`
-/// (repos_root absent / unconfigured).
+/// leaf directory"): a git-registered worktree counts as an orphan when it is
+/// not main/bare/prunable/locked, IS a strict descendant of the project whose
+/// registry named it, and is absent from the active set. Reports `Ok` (no
+/// orphans), `Warn` (orphans found), or `Ok` (repos_root absent /
+/// unconfigured).
 ///
 /// Note this probe is REPORT-ONLY — it counts, it never removes — so it
-/// deliberately reports candidates that the reclaim path would refuse to
-/// delete (owner-unknown, dirty). A directory git does not register is not
-/// counted at all; reclaiming unregistered husks is #3715, still open.
+/// deliberately reports candidates the reclaim path would refuse to delete
+/// (owner-unknown, dirty). Conversely a directory git does not register is not
+/// counted at all, so an unregistered husk is invisible here; reclaiming those
+/// is a separate open concern, deliberately out of scope for #4207.
 /// Test: `worktrees_no_orphans_is_ok`, `worktrees_with_orphan_is_warn`.
 async fn check_worktrees(
     repos_root: Option<&Path>,
@@ -422,8 +424,9 @@ async fn check_worktrees(
         .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
         .collect();
 
-    // Delegate the blocking filesystem walk to spawn_blocking so the async
-    // executor is not stalled on directory I/O (#1840 F).
+    // Delegate the blocking scan to spawn_blocking so the async executor is not
+    // stalled (#1840 F). Since #4207 what blocks is not directory I/O but the
+    // git subprocesses `find_orphaned_worktrees` spawns per managed project.
     let orphans = tokio::task::spawn_blocking(move || {
         crate::session_manager::prune::find_orphaned_worktrees(&root, &active_set)
     })

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -276,47 +276,23 @@ async fn worktrees_no_repos_root_is_ok() {
 
 #[tokio::test]
 async fn worktrees_no_orphans_is_ok() {
-    // Why (#1845 item 2): on macOS /tmp is a symlink to /private/tmp. If we pass the
-    // raw tempfile path as active (e.g. /tmp/…) but the walk canonicalises it to
-    // /private/tmp/…, the active-set lookup misses and a live worktree is falsely
-    // flagged as an orphan — causing a spurious CI failure. Canonicalize the active
-    // path in the test so the set membership check in find_orphaned_worktrees matches.
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    // Create owner/repo/.worktrees/session-abc/ and register it as active.
-    let wt = root
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("session-abc");
-    std::fs::create_dir_all(&wt).unwrap();
-    // Canonicalize so /tmp vs /private/tmp symlink differences are resolved.
-    let canonical_wt = std::fs::canonicalize(&wt).unwrap_or(wt);
-    let active = vec![canonical_wt];
-    let check = check_worktrees(Some(root), &active).await;
+    // #4207: a REAL `git worktree add`, since discovery is now derived from
+    // git's registry — a `mkdir` is not a candidate and would make this pass
+    // for the wrong reason. The fixture canonicalizes its own root, so the
+    // /tmp vs /private/tmp symlink hazard (#1845 item 2) is handled there.
+    let fx = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
+    let wt = fx.add_worktree("session-abc");
+    let check = check_worktrees(Some(&fx.repos_root), &[wt]).await;
     assert_eq!(check.status, CheckStatus::Ok);
 }
 
 #[tokio::test]
 async fn worktrees_with_orphan_is_warn() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    // Create two worktrees; only one has an active session.
-    let wt1 = root
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("session-live");
-    let wt2 = root
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("session-dead");
-    std::fs::create_dir_all(&wt1).unwrap();
-    std::fs::create_dir_all(&wt2).unwrap();
-    // wt2 is orphaned (no active session).
-    let active = vec![wt1];
-    let check = check_worktrees(Some(root), &active).await;
+    // #4207: two REAL worktrees; only one has an active session.
+    let fx = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
+    let live = fx.add_worktree("session-live");
+    let _dead = fx.add_worktree("session-dead");
+    let check = check_worktrees(Some(&fx.repos_root), &[live]).await;
     assert_eq!(check.status, CheckStatus::Warn);
     assert!(check.message.contains("1 orphaned"));
     assert!(check.message.contains("tm session prune --worktrees"));

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -666,10 +666,16 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                 // no longer true: a registered worktree at ANY depth inside a
                 // managed project, e.g. `<repo>/agents/scratch/wt-1`, is a
                 // candidate). A directory must clear ALL of: git registers it as
-                // a worktree that is not main/bare/prunable/locked; it is a
-                // strict descendant of the managed project whose registry named
-                // it (so operator checkouts and the base clone are unreachable by
-                // position, not by name); it is in neither the initial nor the
+                // a worktree that is not main/bare/prunable/locked — this is
+                // what excludes the BASE CLONE, which is a separate
+                // `git clone --bare` absent from `<repo>`'s registry entirely
+                // and bare+main in its own; it is a strict descendant of the
+                // managed project whose registry named it, which is what puts
+                // the operator's own checkouts parked beside a project out of
+                // reach by POSITION rather than by name — note this gate does
+                // NOT exclude `.base`, which IS a strict descendant of `<repo>`,
+                // so do not re-attribute the base clone to it; it is in neither
+                // the initial nor the
                 // pre-deletion active set; it carries a #3649 ownership sentinel
                 // naming a provably-ownerless owner past the grace window; and
                 // the #4091/#4118 dirty gate finds no uncommitted or unpushed

--- a/crates/trusty-mpm/src/daemon/mod.rs
+++ b/crates/trusty-mpm/src/daemon/mod.rs
@@ -658,10 +658,24 @@ async fn orphan_gc_loop(state: Arc<DaemonState>, cancel: tokio_util::sync::Cance
                 // clone otherwise grows without bound (94 dirs observed for one
                 // project) because decommission-time cleanup (#1806/#1840) only
                 // covers sessions torn down AFTER that fix landed and the manual
-                // `tm session prune-worktrees` sweep is rarely run. Only leaf
-                // worktree dirs with NO live record are removed — active worktrees
-                // and the base clone are never touched. Inherits the orphan-GC env
-                // gate (`TRUSTY_MPM_ORPHAN_GC`) since it runs inside this loop.
+                // `tm session prune-worktrees` sweep is rarely run.
+                //
+                // What actually bounds this call (#4207/#4224 — the previous
+                // wording here, "only leaf worktree dirs ... the base clone are
+                // never touched", described the removed five-shape walk and is
+                // no longer true: a registered worktree at ANY depth inside a
+                // managed project, e.g. `<repo>/agents/scratch/wt-1`, is a
+                // candidate). A directory must clear ALL of: git registers it as
+                // a worktree that is not main/bare/prunable/locked; it is a
+                // strict descendant of the managed project whose registry named
+                // it (so operator checkouts and the base clone are unreachable by
+                // position, not by name); it is in neither the initial nor the
+                // pre-deletion active set; it carries a #3649 ownership sentinel
+                // naming a provably-ownerless owner past the grace window; and
+                // the #4091/#4118 dirty gate finds no uncommitted or unpushed
+                // work. See `SessionManager::reap_orphaned_worktrees` for the
+                // authoritative list. Inherits the orphan-GC env gate
+                // (`TRUSTY_MPM_ORPHAN_GC`) since it runs inside this loop.
                 let repos_root = managed_routes::inproject::repos_root();
                 match mgr.reap_orphaned_worktrees(&repos_root).await {
                     Ok(outcome) => {

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -104,8 +104,9 @@ pub(crate) fn is_session_worktree(path: &Path) -> bool {
 /// `git worktree list` and `git branch` output. `git worktree remove --force`
 /// prunes both the directory AND the ref atomically, restoring a clean state.
 /// What: runs `git -C <repo-root> worktree remove --force <path>` where
-/// `<repo-root>` is the grandparent of the worktree directory
-/// (`path` → `.worktrees` → `<repo-root>`). Also runs
+/// `<repo-root>` is the checkout git itself reports as owning `path`'s
+/// worktree registry ([`super::worktree_registry::registry_root_for`], #4207 —
+/// previously guessed as the grandparent directory). Also runs
 /// `git -C <repo-root> worktree prune` and
 /// `git -C <repo-root> branch -D session/<leaf>` on success to clear stale git
 /// refs and the session branch, where `<leaf>` is the last component of `path`
@@ -158,18 +159,30 @@ pub(super) fn remove_session_worktree(path: &Path) -> bool {
         );
     }
 
-    // The repo root is the grandparent of the worktree dir:
-    // <repo-root>/.worktrees/<session-id>/ → grandparent = <repo-root>
-    let repo_root = match path.parent().and_then(|p| p.parent()) {
+    // #4207: ask git which checkout owns this worktree's registry instead of
+    // guessing that it is the grandparent directory. The grandparent rule held
+    // only for the two shapes it was written against; a worktree registered to
+    // the parent repo but living under `.base/.worktrees/` resolved to `.base`,
+    // which disowns it, so `git worktree remove` there could never succeed.
+    let repo_root = match super::worktree_registry::registry_root_for(path) {
         Some(r) => r,
         None => {
+            // No git registry claims this path — it is a plain directory, not a
+            // worktree. The sentinel gate above already established trusty-mpm
+            // owns it, so remove the directory directly rather than refusing.
             warn!(
                 path = %path.display(),
-                "decommission: cannot determine repo root from worktree path — skipping git removal"
+                "decommission: no git repository owns this path — removing the \
+                 directory directly (no worktree ref to prune)"
             );
-            return false;
+            if let Err(e) = std::fs::remove_dir_all(path) {
+                warn!(path = %path.display(), "decommission: remove_dir_all failed: {e}");
+                return false;
+            }
+            return true;
         }
     };
+    let repo_root = repo_root.as_path();
     // Step 1: git worktree remove --force <path> (run from repo root).
     // Pass repo_root as an OsStr-safe Path arg to avoid lossy UTF-8 coercion (#1840).
     let out = std::process::Command::new("git")

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -35,6 +35,7 @@ pub mod task_inject;
 pub mod workspace_guard;
 mod worktree_nested;
 pub(crate) mod worktree_ownership;
+pub(crate) mod worktree_registry;
 pub mod worktree_safety;
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -643,7 +643,8 @@ impl SessionManager {
     /// Dry-run returns after Phase 1 (no deletion, no snapshot).
     ///
     /// What: Phase 1 calls [`find_orphaned_worktrees`] inside `spawn_blocking`
-    /// (the filesystem walk is blocking); panics are propagated as `Err`. Phase 2
+    /// (git-derived since #4207, but still blocking — it spawns git per
+    /// project); panics are propagated as `Err`. Phase 2
     /// (real-delete only) takes ONE fresh `self.store` snapshot, then per candidate:
     /// canonicalize (skip on error — item 8), check against snapshot, apply the
     /// #3649 OWNERSHIP GATE (below), then call `remove_session_worktree` in its

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -368,200 +368,51 @@ fn matches_filter(record: &SessionRecord, filter: PruneFilter) -> bool {
     }
 }
 
-/// Enumerate orphaned per-session worktree directories under `repos_root` (#1840).
+/// Enumerate orphaned worktree reclaim candidates under `repos_root` (#1840,
+/// rebuilt git-native #4207 slice 1).
 ///
-/// Why: extracted from `SessionManager::prune_orphaned_worktrees` so the
-/// walk logic can be tested independently of the full session-manager setup,
-/// and reused by the `doctor.rs` worktree health probe without duplicating the
-/// filesystem walk.
-/// What: walks all FIVE known worktree-store locations under each
-/// `<repos_root>/<owner>/<repo>/`:
-/// 1. the in-project shape (`.worktrees/<name>`, added #1840);
-/// 2. the clone-based shared-base-checkout shape
-///    (`.base/.worktrees/<session-id>`, added #3649);
-/// 3. Claude Code's native `isolation: "worktree"` agent shape at the repo
-///    root (`.claude/worktrees/<name>`, added #3971);
-/// 4. the SAME Claude Code agent shape, but created while working directly
-///    inside the bare `.base` clone checkout itself
-///    (`.base/.claude/worktrees/<name>`, added #3971 follow-up — the #3971
-///    fix covered only location 3, so this sibling location, and location 5
-///    below, were still invisible even after that fix landed; confirmed live
-///    on this machine with 29 real entries);
-/// 5. the SAME Claude Code agent shape again, but nested inside a per-session
-///    checkout (`.base/.worktrees/<session-id>/.claude/worktrees/<name>`,
-///    added #3971 follow-up — this is the exact shape this repo's own
-///    trusty-mpm sessions produce when a Claude Code agent spawns a nested
-///    worktree from within its own session checkout). Enumerated by listing
-///    each `.base/.worktrees` session leaf (via [`list_immediate_dirs`]) and
-///    probing it for a nested `.claude/worktrees`, since the session-id
-///    directory name is not known in advance.
+/// Why: this function used to WALK the filesystem, probing five hard-coded
+/// location shapes under each `<repos_root>/<owner>/<repo>/`. Every shape was
+/// added by a bug report about a location the previous shape list had missed
+/// (#3649, #3971, and the #3971 follow-up), and the list could never be
+/// complete because nothing stops a worktree from being registered anywhere on
+/// disk. Worse, the walk found DIRECTORIES, not worktrees, so it had no idea
+/// which checkout owned any of them — the grandparent guess that filled that
+/// gap left fourteen worktrees physically inside `.base` but registered to the
+/// parent repo permanently unreclaimable (#4207). Git maintains the registry;
+/// deriving from it deletes the whole category of missed-location bug.
+/// What: delegates discovery to
+/// [`super::worktree_registry::enumerate_registered_worktrees`] — every
+/// worktree git itself registers, wherever it lives — then removes any whose
+/// path is in `active_set`. Candidates come back canonicalized (so the
+/// active-set comparison is symlink-safe), sorted, and de-duplicated. A
+/// non-existent or unreadable `repos_root` yields an empty vec.
 ///
-/// Any leaf directory whose canonicalized path is NOT in `active_set` is
-/// collected as an orphan CANDIDATE — the caller (`prune_orphaned_worktrees`)
-/// still applies the #3649 ownership-sentinel gate before ever deleting
-/// anything, so a candidate discovered here is never auto-deleted unless it
-/// also carries a trusty-mpm ownership sentinel naming a provably-ownerless
-/// owner (see that function's doc); locations 3-5 are all Claude-Code-created
-/// and so never carry that sentinel, landing in `owner_unknown` (report-only)
-/// rather than being deleted. Using a `HashSet` with canonicalized paths
-/// avoids O(n×m) linear scan and correctly handles symlinked workspace
-/// paths. A non-existent or unreadable `repos_root` returns an empty vec.
+/// A candidate here is still only a CANDIDATE: `prune_orphaned_worktrees`
+/// applies the #3649 ownership-sentinel gate and the #4091 dirty-tree gate
+/// before anything is deleted, so a Claude-Code-created worktree (which never
+/// carries trusty-mpm's sentinel) lands in `owner_unknown` and is reported,
+/// never removed.
 ///
-/// Deliberately explicit rather than a generic recursive walk: each location
-/// is a specific, named join reusing the shared [`scan_worktree_shape`]
-/// leaf-collection logic, matching the style already established by
-/// locations 1-2 and keeping every location individually testable. A blind
-/// recursive walk of a whole checkout's source tree (crates/, node_modules/,
-/// target/, …) would be pathological on a repo this size; this walk only
-/// ever touches the fixed, known worktree-bookkeeping directory names
-/// (`.worktrees`, `.base`, `.claude`), never a checkout's actual source
-/// files.
+/// SCOPE NOTE (#4207): a directory that git does NOT register — a husk left
+/// behind by a half-finished removal, for instance — is no longer enumerated.
+/// It was already unreclaimable before this change, because
+/// `git_worktree_list_agrees` refused every such path; the difference is that
+/// it is now also absent from the report. Reclaiming unregistered husks is a
+/// separate concern (#3715), deliberately not smuggled in here.
 /// Test: `prune_orphaned_worktrees_spares_active`,
 ///       `prune_orphaned_worktrees_removes_orphan`,
-///       `find_orphaned_worktrees_covers_base_worktrees_shape` (#3649),
-///       `find_orphaned_worktrees_covers_claude_worktrees_shape`,
-///       `find_orphaned_worktrees_spares_live_claude_worktree`,
-///       `prune_orphaned_worktrees_never_deletes_claude_native_worktree` (#3971),
-///       `find_orphaned_worktrees_covers_base_claude_worktrees_shape`,
-///       `find_orphaned_worktrees_covers_nested_session_claude_worktrees_shape`
-///       (#3971 follow-up).
+///       `find_orphaned_worktrees_discovers_worktree_at_unwalked_location`
+///       (#4207 — fails against the five-shape walk),
+///       `find_orphaned_worktrees_ignores_plain_directory`.
 pub(crate) fn find_orphaned_worktrees(
     repos_root: &std::path::Path,
     active_set: &std::collections::HashSet<std::path::PathBuf>,
 ) -> Vec<std::path::PathBuf> {
-    let mut orphans = Vec::new();
-    let Ok(owner_entries) = std::fs::read_dir(repos_root) else {
-        return orphans;
-    };
-    for owner_entry in owner_entries.flatten() {
-        let owner_path = owner_entry.path();
-        if !owner_path.is_dir() {
-            continue;
-        }
-        let Ok(repo_entries) = std::fs::read_dir(&owner_path) else {
-            continue;
-        };
-        for repo_entry in repo_entries.flatten() {
-            let repo_path = repo_entry.path();
-            // Location 1 (#1840): in-project worktrees at `<repo>/.worktrees/<name>`.
-            scan_worktree_shape(&repo_path.join(".worktrees"), active_set, &mut orphans);
-            // Location 2 (#3649): clone-based shared-base-checkout worktrees at
-            // `<repo>/.base/.worktrees/<session-id>` (see
-            // `provisioner::workspace::WorkspaceProvisioner::provision_in`).
-            let base_worktrees = repo_path.join(".base").join(".worktrees");
-            scan_worktree_shape(&base_worktrees, active_set, &mut orphans);
-            // Location 3 (#3971): Claude Code's native `isolation: "worktree"`
-            // agent worktrees at `<repo>/.claude/worktrees/<name>` — never
-            // created by trusty-mpm, so these candidates never carry the
-            // `.trusty-mpm-worktree` sentinel and are gated to owner-unknown
-            // (report-only) by `prune_orphaned_worktrees`'s existing #3649
-            // ownership check, not auto-deleted.
-            scan_worktree_shape(
-                &repo_path.join(".claude").join("worktrees"),
-                active_set,
-                &mut orphans,
-            );
-            // Location 4 (#3971 follow-up): the same Claude Code agent shape,
-            // created while working directly inside the bare `.base` clone
-            // checkout, at `<repo>/.base/.claude/worktrees/<name>`.
-            scan_worktree_shape(
-                &repo_path.join(".base").join(".claude").join("worktrees"),
-                active_set,
-                &mut orphans,
-            );
-            // Location 5 (#3971 follow-up): the same Claude Code agent shape
-            // again, nested inside a per-session checkout, at
-            // `<repo>/.base/.worktrees/<session-id>/.claude/worktrees/<name>`.
-            // The session-id leaf name is not known in advance, so list each
-            // leaf under `.base/.worktrees` (location 2's own directory) and
-            // probe it for a nested `.claude/worktrees`.
-            for session_leaf in list_immediate_dirs(&base_worktrees) {
-                scan_worktree_shape(
-                    &session_leaf.join(".claude").join("worktrees"),
-                    active_set,
-                    &mut orphans,
-                );
-            }
-        }
-    }
-    // #4118: `read_dir` order is filesystem-dependent, so two runs of the same
-    // sweep could remove the same worktrees in different orders — which makes a
-    // dry-run preview a poor predictor of the real run and makes any ordering
-    // bug unreproducible. Sorting costs nothing at this scale.
-    orphans.sort();
-    orphans
-}
-
-/// List the immediate child directories of `dir`, ignoring unreadable
-/// entries (#3971 follow-up).
-///
-/// Why: [`find_orphaned_worktrees`]'s location 5 needs to enumerate each
-/// `.base/.worktrees/<session-id>` leaf so it can probe each one for a
-/// nested `.claude/worktrees`, but the session-id names are not known in
-/// advance. Unlike [`scan_worktree_shape`], this does NOT filter against an
-/// `active_set` or collect orphans itself — it exists purely to enumerate
-/// CONTAINER directories for the caller to recurse into, keeping the
-/// active-set/orphan-candidate logic owned by exactly one function
-/// ([`scan_worktree_shape`]).
-/// What: returns every directory entry directly under `dir`; a non-existent
-/// or unreadable `dir` (including the common case of a repo with no
-/// `.base/.worktrees` at all) returns an empty vec, mirroring
-/// [`scan_worktree_shape`]'s own tolerant-missing-directory behavior.
-/// Test: `find_orphaned_worktrees_covers_nested_session_claude_worktrees_shape`.
-fn list_immediate_dirs(dir: &std::path::Path) -> Vec<std::path::PathBuf> {
-    let Ok(entries) = std::fs::read_dir(dir) else {
-        return Vec::new();
-    };
-    entries
-        .flatten()
-        .map(|e| e.path())
-        .filter(|p| p.is_dir())
+    super::worktree_registry::enumerate_registered_worktrees(repos_root)
+        .into_iter()
+        .filter(|candidate| !active_set.contains(candidate))
         .collect()
-}
-
-/// Scan one `.worktrees`-shaped directory for leaf dirs not in `active_set`,
-/// appending any found to `orphans` (#3649 extraction — shared by both
-/// worktree-store shapes [`find_orphaned_worktrees`] walks).
-///
-/// Why: `find_orphaned_worktrees` originally inlined this loop for the single
-/// in-project shape it knew about; #3649 adds a second shape
-/// (`.base/.worktrees`) that must apply the IDENTICAL leaf-dir/canonicalize/
-/// active-set logic, so the loop body is extracted rather than duplicated.
-/// What: no-ops if `wt_dir` is not a directory; otherwise lists its immediate
-/// children, skips non-directories and paths that fail to canonicalize (#1845
-/// item 8 — a dangling symlink or deletion race must not be misclassified),
-/// and appends every canonicalized-but-not-active leaf to `orphans`.
-/// Test: `prune_orphaned_worktrees_collects_orphan`,
-///       `find_orphaned_worktrees_covers_base_worktrees_shape` (#3649).
-fn scan_worktree_shape(
-    wt_dir: &std::path::Path,
-    active_set: &std::collections::HashSet<std::path::PathBuf>,
-    orphans: &mut Vec<std::path::PathBuf>,
-) {
-    if !wt_dir.is_dir() {
-        return;
-    }
-    let Ok(wt_entries) = std::fs::read_dir(wt_dir) else {
-        return;
-    };
-    for wt_entry in wt_entries.flatten() {
-        let wt_path = wt_entry.path();
-        if !wt_path.is_dir() {
-            continue;
-        }
-        // Item 8 (#1845): skip if the path cannot be canonicalized.
-        // A dangling symlink or a deletion race makes the path
-        // unresolvable; we cannot safely compare it against the active
-        // set, so we leave it untouched rather than risk misclassifying
-        // a live-but-partially-deleted worktree as an orphan.
-        let canonical_wt = match std::fs::canonicalize(&wt_path) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        if !active_set.contains(&canonical_wt) {
-            orphans.push(wt_path);
-        }
-    }
 }
 
 /// Outcome of an orphaned-worktree sweep (#3649): which candidates were (or

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -383,10 +383,19 @@ fn matches_filter(record: &SessionRecord, filter: PruneFilter) -> bool {
 /// deriving from it deletes the whole category of missed-location bug.
 /// What: delegates discovery to
 /// [`super::worktree_registry::enumerate_registered_worktrees`] — every
-/// worktree git itself registers, wherever it lives — then removes any whose
-/// path is in `active_set`. Candidates come back canonicalized (so the
-/// active-set comparison is symlink-safe), sorted, and de-duplicated. A
-/// non-existent or unreadable `repos_root` yields an empty vec.
+/// worktree git itself registers inside a managed project, wherever in that
+/// project it lives — then removes any whose path is in `active_set`.
+/// Candidates come back canonicalized (so the active-set comparison is
+/// symlink-safe), sorted, and de-duplicated. A non-existent or unreadable
+/// `repos_root` yields an empty vec.
+///
+/// BOUNDARY (#4224 review, HIGH): "wherever it lives" is bounded — a candidate
+/// must be a strict descendant of the managed project directory whose registry
+/// named it. Location is irrelevant WITHIN a project (that is the #4207 fix);
+/// it is decisive at the project edge, so an operator checkout parked beside a
+/// project, or a worktree the operator registered outside it, is never a
+/// candidate. See
+/// [`super::worktree_registry::enumerate_registered_worktrees`].
 ///
 /// A candidate here is still only a CANDIDATE: `prune_orphaned_worktrees`
 /// applies the #3649 ownership-sentinel gate and the #4091 dirty-tree gate
@@ -914,13 +923,40 @@ impl SessionManager {
     /// What: snapshots every live record's `workspace_path` from the store as the
     /// active set, then delegates to `prune_orphaned_worktrees` with
     /// `dry_run = false`. The two-phase TOCTOU safety (a fresh store snapshot taken
-    /// immediately before deletion) and the "only leaf dirs under `.worktrees/`,
-    /// never the base clone" guard are inherited unchanged, as is the #4091
+    /// immediately before deletion) is inherited unchanged, as is the #4091
     /// dirty-tree gate — the periodic daemon sweep ALWAYS uses the default
     /// [`DirtyWorktreePolicy::Skip`] and has no way to opt into discarding
     /// work. Returns the paths removed.
+    ///
+    /// # What actually bounds THIS path (#4224 review, corrected)
+    ///
+    /// This is the only entry point that deletes with no human present, so the
+    /// guarantees named here have to be the ones that hold. Until #4207 this doc
+    /// claimed an "only leaf dirs under `.worktrees/`, never the base clone"
+    /// guard; that guard was a property of the five-shape walk and no longer
+    /// exists. In its place, a directory must clear ALL of:
+    ///
+    /// 1. git itself registers it as a worktree (a husk or a stray `mkdir` is
+    ///    not a candidate) that is not main, bare, prunable, or `locked`;
+    /// 2. it is a STRICT DESCENDANT of the managed project directory whose
+    ///    registry named it, and lies under `repos_root`
+    ///    ([`super::worktree_registry::enumerate_registered_worktrees`]) — so
+    ///    the operator's own checkouts and anything parked beside a project are
+    ///    structurally unreachable, not merely unlisted;
+    /// 3. it is absent from both the initial and the pre-deletion active set;
+    /// 4. it carries a #3649 ownership sentinel naming an owner that is
+    ///    provably ownerless past [`super::worktree_ownership::OWNERLESS_GRACE`]
+    ///    — an absent, empty, or unparsable sentinel is reported, never removed;
+    /// 5. `git worktree list` (asked at the candidate itself) agrees; and
+    /// 6. the #4091/#4118 dirty gate finds no uncommitted or unpushed work,
+    ///    re-checked immediately before the removal.
+    ///
+    /// Gates 2 and 4 are independent structural boundaries by design: neither is
+    /// load-bearing alone.
     /// Test: `reap_orphaned_worktrees_removes_orphan_preserves_live` in
-    /// `super::reap_orphaned_worktrees_tests`.
+    /// `super::reap_orphaned_worktrees_tests`;
+    /// `enumerate_excludes_a_sibling_checkout_of_the_same_repo` and
+    /// `enumerate_excludes_a_worktree_parked_beside_the_project` pin gate 2.
     pub async fn reap_orphaned_worktrees(
         &self,
         repos_root: &std::path::Path,

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -370,6 +370,64 @@ async fn prune_orphaned_worktrees_reclaims_terminal_owner() {
     );
 }
 
+/// THE OTHER DIRECTION of the #4224 containment boundary: a genuine tm-owned
+/// husk at a location NO hard-coded shape covers is still reclaimed, end to end.
+///
+/// Why: the #4224 review's HIGH is that git-native enumeration widened the
+/// auto-deletion surface, and the fix narrows it back to "inside the managed
+/// project". A narrowing is only correct if it costs no reclaim capability, and
+/// the cheapest way to satisfy a containment test is to stop deleting
+/// altogether — which would silently restore the very leak #4207 exists to fix
+/// while every exclusion test still passed. So this asserts the positive:
+/// `<repo>/agents/scratch/husk` matches none of the five removed shapes
+/// (`.worktrees/`, `.base/.worktrees/`, `.claude/worktrees/`,
+/// `.base/.claude/worktrees/`, `.base/.worktrees/<id>/.claude/worktrees/`), and
+/// it is REMOVED FROM DISK.
+///
+/// This runs the whole gauntlet, not just enumeration: the #3649 ownership
+/// gate (aged sentinel, owner that never resolves), the `git worktree list`
+/// cross-check, and the #4091/#4118 dirty gate.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_orphaned_worktrees_reclaims_owned_husk_at_an_unwalked_location() {
+    let store_dir = tempfile::tempdir().unwrap();
+    let mgr = SessionManager::new(
+        store_dir.path(),
+        crate::session_manager::tests::FakeTmuxDriver::new(),
+    )
+    .await
+    .expect("manager");
+
+    let fx = GitWorktreeFixture::new();
+    let husk = fx.add_worktree_at(&fx.repo.join("agents").join("scratch"), "husk");
+    assert!(
+        !husk.starts_with(fx.repo.join(".worktrees"))
+            && !husk.starts_with(fx.repo.join(".claude"))
+            && !husk.starts_with(fx.repo.join(".base")),
+        "test invariant: the husk must sit at a location none of the five \
+         removed shapes covered, or this test cannot prove the #4207 fix \
+         survived the #4224 narrowing; got {}",
+        husk.display()
+    );
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&husk);
+
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        outcome.removed.iter().any(|p| p == &husk),
+        "a sentinel-bearing, ownerless worktree inside the project must be \
+         reclaimed wherever in the project it lives; got removed={:?} \
+         owner_unknown={:?} skipped_dirty={:?}",
+        outcome.removed,
+        outcome.owner_unknown,
+        outcome.skipped_dirty
+    );
+    assert!(!husk.exists(), "the reclaimed husk must be gone from disk");
+}
+
 /// A candidate whose sentinel names an owner with NO resolvable session
 /// record, but whose sentinel was stamped RECENTLY (within the creation-race
 /// grace window), must NOT be reclaimed — this is the exact bug the #3649

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -2,108 +2,76 @@
 //! (#1840, #1845, extended #3649).
 //!
 //! Why: split out of `prune.rs` (as `orphan_tests`) so that file stays under
-//! the 500-SLOC production cap — `prune.rs` mixes production code (the
-//! walk, the ownership gate, the git cross-check) with a large test surface,
-//! and only the production code counts against the cap once tests live in a
+//! the 500-SLOC production cap — `prune.rs` mixes production code (discovery,
+//! the ownership gate, the git cross-check) with a large test surface, and
+//! only the production code counts against the cap once tests live in a
 //! sibling `_tests.rs` file, mirroring the pattern already established by
 //! `decommission_worktree_tests.rs` / `reap_orphaned_worktrees_tests.rs`.
-//! What: orphan discovery (`find_orphaned_worktrees`, both worktree-store
-//! shapes), the TOCTOU fresh-active-set safety net, and the #3649 ownership
-//! gate (owner-unknown never deleted, terminal/absent owner reclaimed, live
-//! owner spared, `git worktree list` agreement).
+//! What: orphan discovery (`find_orphaned_worktrees`, now git-derived per
+//! #4207 — every worktree in these tests is a REAL `git worktree add`, because
+//! a `mkdir` is no longer a candidate and would make an assertion vacuous), the
+//! TOCTOU fresh-active-set safety net, and the #3649 ownership gate
+//! (owner-unknown never deleted, terminal/absent owner reclaimed, live owner
+//! spared, `git worktree list` agreement).
 //! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
 
 use super::*;
 
+/// A live session's worktree must never be returned as an orphan (#1840).
+///
+/// #4207: the worktree is now a REAL `git worktree add`, not a `mkdir`. Under
+/// the git-native enumeration a bare directory is not a candidate at all, so
+/// the `mkdir` version of this test passed vacuously — it asserted an empty
+/// list against an empty list.
 #[test]
 fn prune_orphaned_worktrees_spares_active() {
-    // A live session's worktree must never be returned as an orphan (#1840).
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let wt = root
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("live-session");
-    std::fs::create_dir_all(&wt).unwrap();
-    let active: std::collections::HashSet<_> =
-        vec![std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone())]
-            .into_iter()
-            .collect();
-    let orphans = find_orphaned_worktrees(root, &active);
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("live-session");
+    let active: std::collections::HashSet<_> = [wt.clone()].into_iter().collect();
+    let orphans = find_orphaned_worktrees(&fx.repos_root, &active);
     assert!(
         orphans.is_empty(),
-        "live session must not be listed as orphan"
+        "live session must not be listed as orphan; got {orphans:?}"
     );
 }
 
+/// Simulates TOCTOU: a worktree looks like an orphan in the initial snapshot
+/// but appears in the fresh active set before deletion — must NOT be removed.
 #[test]
 fn prune_orphaned_worktrees_fresh_active_set_blocks_deletion() {
-    // Simulates TOCTOU: a dir looks like an orphan in the initial snapshot
-    // but appears in the fresh active set before deletion — must NOT be removed.
-    // We test the `find_orphaned_worktrees` logic: with an empty initial set
-    // the candidate IS found; then the Phase 2 TOCTOU check (re-querying the
-    // store) is validated by confirming fresh set membership would block deletion.
-    // The full async TOCTOU path is validated by the integration tests.
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let wt = root
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("session-xyz");
-    std::fs::create_dir_all(&wt).unwrap();
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("session-xyz");
 
-    // Empty initial snapshot → the dir looks like an orphan candidate.
+    // Empty initial snapshot → the worktree looks like an orphan candidate.
     let empty_initial: std::collections::HashSet<std::path::PathBuf> =
         std::collections::HashSet::new();
-    let candidates = find_orphaned_worktrees(root, &empty_initial);
+    let candidates = find_orphaned_worktrees(&fx.repos_root, &empty_initial);
     assert!(
         candidates.contains(&wt),
-        "empty initial set must find the dir as a candidate"
+        "empty initial set must find the worktree as a candidate; got {candidates:?}"
     );
 
-    // Fresh active set contains the canonicalized dir path — mirrors Phase 2 of
-    // prune_orphaned_worktrees, which canonicalizes workspace_paths before
-    // inserting them into fresh_active (#1840 TOCTOU check).
-    let canonical = std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone());
-    let fresh: std::collections::HashSet<std::path::PathBuf> =
-        [canonical.clone()].into_iter().collect();
+    // A fresh active set containing it blocks the deletion (Phase 2, #1840).
+    let fresh: std::collections::HashSet<std::path::PathBuf> = [wt.clone()].into_iter().collect();
     assert!(
-        fresh.contains(&canonical),
-        "fresh active set must contain the canonicalized worktree path"
+        find_orphaned_worktrees(&fx.repos_root, &fresh).is_empty(),
+        "a candidate in the fresh active set must not be proposed for deletion"
     );
-    // The directory still exists — nothing deleted it.
     assert!(wt.exists(), "worktree must survive the TOCTOU check");
 }
 
+/// A worktree with no active session must be listed as an orphan (#1840).
 #[test]
 fn prune_orphaned_worktrees_collects_orphan() {
-    // A worktree with no active session must be listed as an orphan (#1840).
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let wt1 = root
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("live");
-    let wt2 = root
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("dead");
-    std::fs::create_dir_all(&wt1).unwrap();
-    std::fs::create_dir_all(&wt2).unwrap();
-    let active: std::collections::HashSet<_> =
-        vec![std::fs::canonicalize(&wt1).unwrap_or_else(|_| wt1.clone())]
-            .into_iter()
-            .collect();
-    let orphans = find_orphaned_worktrees(root, &active);
-    assert_eq!(orphans.len(), 1);
-    // Ordering not guaranteed — use contains rather than indexed access.
-    assert!(
-        orphans.contains(&wt2),
-        "expected {wt2:?} to be the orphan, got {orphans:?}"
+    let fx = GitWorktreeFixture::new();
+    let live = fx.add_worktree("live");
+    let dead = fx.add_worktree("dead");
+    let active: std::collections::HashSet<_> = [live.clone()].into_iter().collect();
+    let orphans = find_orphaned_worktrees(&fx.repos_root, &active);
+    assert_eq!(
+        orphans,
+        vec![dead],
+        "only the unclaimed worktree is an orphan"
     );
 }
 
@@ -151,24 +119,18 @@ async fn prune_orphaned_worktrees_store_snapshot_blocks_deletion() {
     }
 
     let store_dir = tempfile::tempdir().unwrap();
-    let repos_tmp = tempfile::tempdir().unwrap();
-
-    // Build a real .worktrees/<id>/ dir so Phase 1 finds it as a candidate.
+    // #4207: a REAL `git worktree add`, so Phase 1 genuinely finds it as a
+    // candidate — a `mkdir` is no longer enumerated and made this vacuous.
+    let fx = GitWorktreeFixture::new();
     let session_id = super::super::record::ManagedSessionId::new();
-    let wt_path = repos_tmp
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join(session_id.to_string());
-    std::fs::create_dir_all(&wt_path).expect("create worktree dir");
+    let wt_path = fx.add_worktree(&session_id.to_string());
 
     // Create the SessionManager and insert a live record for the worktree.
     let mgr = super::super::manager::SessionManager::new(store_dir.path(), Arc::new(NoopDriver))
         .await
         .expect("SessionManager::new");
 
-    let canonical_wt = std::fs::canonicalize(&wt_path).unwrap_or_else(|_| wt_path.clone());
+    let canonical_wt = wt_path.clone();
     let record = super::super::record::SessionRecord {
         id: session_id,
         tmux_name: "test-toctou".into(),
@@ -208,7 +170,7 @@ async fn prune_orphaned_worktrees_store_snapshot_blocks_deletion() {
     // runs — still never removed, now for the #3649 safe-default reason
     // rather than (only) the #1845 TOCTOU fresh-snapshot reason.
     let outcome = mgr
-        .prune_orphaned_worktrees(repos_tmp.path(), &[], false, DirtyWorktreePolicy::Skip)
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -220,101 +182,60 @@ async fn prune_orphaned_worktrees_store_snapshot_blocks_deletion() {
     assert!(wt_path.exists(), "worktree dir must survive the prune");
 }
 
-// ── #3649: extended `.base/.worktrees` walk + ownership gating ──────────
+// ── #4207 slice 1: discovery is derived from git, not from location ─────
+//
+// The five location shapes this walk used to probe (`.worktrees/`,
+// `.base/.worktrees/`, `.claude/worktrees/`, `.base/.claude/worktrees/`, and
+// `.base/.worktrees/<id>/.claude/worktrees/`) each arrived as a bug report
+// about a location the previous list had missed. There is nothing left to
+// enumerate per-shape: a worktree is discovered because git registered it.
+// The two tests below replace all seven shape-coverage tests.
 
-/// `find_orphaned_worktrees` must ALSO discover the clone-based
-/// `.base/.worktrees/<id>` shape, not just the in-project `.worktrees/<name>`
-/// shape (#3649 item 4a — this walk previously covered ONLY the latter, so
-/// the entire `provisioner::workspace` worktree store was invisible to the
-/// orphan-GC, `tm doctor`, and `--dry-run`).
+/// THE #4207 regression test at the reclaim layer: a registered worktree at a
+/// location NONE of the five hard-coded shapes covered is discovered.
+///
+/// Why: `<repo>/agents/scratch/wt-1` matches no shape the removed walk probed,
+/// so reverting `find_orphaned_worktrees` to that walk makes this fail with an
+/// empty candidate list. Location is no longer a variable the code reasons
+/// about, which is the whole point of the slice.
 #[test]
-fn find_orphaned_worktrees_covers_base_worktrees_shape() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let base_wt = root
-        .join("owner")
-        .join("repo")
-        .join(".base")
-        .join(".worktrees")
-        .join("session-abc");
-    std::fs::create_dir_all(&base_wt).unwrap();
-    let empty_active: std::collections::HashSet<std::path::PathBuf> =
-        std::collections::HashSet::new();
-    let orphans = find_orphaned_worktrees(root, &empty_active);
+fn find_orphaned_worktrees_discovers_worktree_at_unwalked_location() {
+    let fx = GitWorktreeFixture::new();
+    let parked = fx.add_worktree_at(&fx.repo.join("agents").join("scratch"), "wt-1");
+    let empty: std::collections::HashSet<std::path::PathBuf> = std::collections::HashSet::new();
+    let orphans = find_orphaned_worktrees(&fx.repos_root, &empty);
     assert!(
-        orphans.contains(&base_wt),
-        "the .base/.worktrees shape must be discovered as a candidate; got {orphans:?}"
+        orphans.contains(&parked),
+        "a registered worktree must be found wherever it lives; got {orphans:?}"
     );
 }
 
-// ── #3971: extended `.claude/worktrees` walk (Claude Code native agent
-// worktrees) ──────────────────────────────────────────────────────────────
-
-/// `find_orphaned_worktrees` must ALSO discover Claude Code's native
-/// `.claude/worktrees/agent-<hash>` shape, not just the two trusty-mpm-owned
-/// shapes (#3971 — this walk previously covered ONLY `.worktrees/<name>` and
-/// `.base/.worktrees/<id>`, so every Claude-Code-created agent worktree was
-/// invisible to the orphan-GC, `tm doctor`, and `--dry-run`, letting them
-/// accumulate silently).
+/// A plain directory parked in a worktree-shaped location is NOT a worktree and
+/// must never be proposed for deletion.
+///
+/// Why: the old walk collected any leaf directory under a `.worktrees/` parent,
+/// so a stray `mkdir` was indistinguishable from a checkout git created. This
+/// is the deliberate narrowing derive-not-walk buys, and it is the safer
+/// direction: a directory git does not own is not trusty-mpm's to reclaim.
 #[test]
-fn find_orphaned_worktrees_covers_claude_worktrees_shape() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let claude_wt = root
-        .join("owner")
-        .join("repo")
-        .join(".claude")
-        .join("worktrees")
-        .join("agent-0123456789abcdef0123456789abcdef01234567");
-    std::fs::create_dir_all(&claude_wt).unwrap();
-    let empty_active: std::collections::HashSet<std::path::PathBuf> =
-        std::collections::HashSet::new();
-    let orphans = find_orphaned_worktrees(root, &empty_active);
+fn find_orphaned_worktrees_ignores_plain_directory() {
+    let fx = GitWorktreeFixture::new();
+    let fake = fx.repo.join(".worktrees").join("just-a-mkdir");
+    std::fs::create_dir_all(&fake).expect("mkdir");
+    let empty: std::collections::HashSet<std::path::PathBuf> = std::collections::HashSet::new();
+    let orphans = find_orphaned_worktrees(&fx.repos_root, &empty);
     assert!(
-        orphans.contains(&claude_wt),
-        "the .claude/worktrees shape must be discovered as a candidate; got {orphans:?}"
+        !orphans.contains(&fake),
+        "a plain directory is not a registered worktree; got {orphans:?}"
     );
 }
 
-/// A LIVE (non-orphaned) `.claude/worktrees/agent-<hash>` directory — one
-/// whose canonicalized path IS present in the caller-supplied active set —
-/// must never be returned as an orphan candidate (#3971). Mirrors the
-/// existing `prune_orphaned_worktrees_spares_active` guarantee for the other
-/// two shapes.
-#[test]
-fn find_orphaned_worktrees_spares_live_claude_worktree() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let claude_wt = root
-        .join("owner")
-        .join("repo")
-        .join(".claude")
-        .join("worktrees")
-        .join("agent-fedcba9876543210fedcba9876543210fedcba98");
-    std::fs::create_dir_all(&claude_wt).unwrap();
-    let active: std::collections::HashSet<_> =
-        vec![std::fs::canonicalize(&claude_wt).unwrap_or_else(|_| claude_wt.clone())]
-            .into_iter()
-            .collect();
-    let orphans = find_orphaned_worktrees(root, &active);
-    assert!(
-        orphans.is_empty(),
-        "a live .claude/worktrees entry must not be listed as orphan; got {orphans:?}"
-    );
-}
-
-/// Even when discovered as an orphan CANDIDATE by the walk, a
-/// `.claude/worktrees/agent-<hash>` directory is never created by
-/// trusty-mpm's own provisioning code, so it never carries the
-/// `.trusty-mpm-worktree` ownership sentinel. The existing #3649 ownership
-/// gate therefore classifies it as `SentinelOwner::Unknown` and the full
-/// `prune_orphaned_worktrees` sweep must NEVER auto-delete it — only report
-/// it via `OrphanSweepOutcome::owner_unknown`, exactly like any other
-/// legacy/owner-unknown worktree (#3971).
+/// A Claude-Code-native agent worktree is discovered but NEVER auto-deleted:
+/// it never carries trusty-mpm's ownership sentinel, so the #3649 gate reports
+/// it as owner-unknown (#3971, kept location-agnostic by #4207).
 #[tokio::test]
 async fn prune_orphaned_worktrees_never_deletes_claude_native_worktree() {
     let store_dir = tempfile::tempdir().unwrap();
-    let repos = tempfile::tempdir().unwrap();
     let mgr = SessionManager::new(
         store_dir.path(),
         crate::session_manager::tests::FakeTmuxDriver::new(),
@@ -322,19 +243,16 @@ async fn prune_orphaned_worktrees_never_deletes_claude_native_worktree() {
     .await
     .expect("manager");
 
-    let claude_wt = repos
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".claude")
-        .join("worktrees")
-        .join("agent-00112233445566778899aabbccddeeff00112233");
-    std::fs::create_dir_all(&claude_wt).unwrap();
-    // Deliberately NO sentinel file written — Claude Code's native
-    // `isolation: "worktree"` mechanism never writes trusty-mpm's sentinel.
+    let fx = GitWorktreeFixture::new();
+    // Deliberately NO sentinel written — Claude Code's native
+    // `isolation: "worktree"` mechanism never writes trusty-mpm's.
+    let claude_wt = fx.add_worktree_at(
+        &fx.repo.join(".claude").join("worktrees"),
+        "agent-00112233445566778899aabbccddeeff00112233",
+    );
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -344,177 +262,11 @@ async fn prune_orphaned_worktrees_never_deletes_claude_native_worktree() {
         outcome.removed
     );
     assert!(
-        outcome.owner_unknown.iter().any(|p| p == &claude_wt),
+        outcome.owner_unknown.contains(&claude_wt),
         "expected {claude_wt:?} to be reported as owner-unknown; got {:?}",
         outcome.owner_unknown
     );
     assert!(claude_wt.exists(), "worktree dir must survive the prune");
-}
-
-// ── #3971 follow-up: the two Claude-worktree locations the first #3971 fix
-// missed — `.base/.claude/worktrees` and the nested per-session-checkout
-// shape (BLOCK finding: the fix only anchored at `<repo>/.claude/worktrees`,
-// covering roughly a third of the real on-disk surface) ────────────────────
-
-/// `find_orphaned_worktrees` must discover Claude Code agent worktrees
-/// created directly inside the bare `.base` clone checkout itself, at
-/// `<repo>/.base/.claude/worktrees/<name>` — a sibling of the repo-root
-/// `.claude/worktrees` shape the first #3971 fix covered, but a distinct
-/// filesystem location the walk did not anchor at (confirmed live on the
-/// dogfood machine with 29 real entries).
-#[test]
-fn find_orphaned_worktrees_covers_base_claude_worktrees_shape() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let base_claude_wt = root
-        .join("owner")
-        .join("repo")
-        .join(".base")
-        .join(".claude")
-        .join("worktrees")
-        .join("agent-1111111111111111111111111111111111111111");
-    std::fs::create_dir_all(&base_claude_wt).unwrap();
-    let empty_active: std::collections::HashSet<std::path::PathBuf> =
-        std::collections::HashSet::new();
-    let orphans = find_orphaned_worktrees(root, &empty_active);
-    assert!(
-        orphans.contains(&base_claude_wt),
-        "the .base/.claude/worktrees shape must be discovered as a candidate; got {orphans:?}"
-    );
-}
-
-/// `find_orphaned_worktrees` must discover Claude Code agent worktrees
-/// nested INSIDE a per-session checkout, at
-/// `<repo>/.base/.worktrees/<session-id>/.claude/worktrees/<name>` — the
-/// exact shape a Claude Code agent spawned from within its own trusty-mpm
-/// session checkout produces (this is literally the shape this leg's own
-/// `fix-worktree-hygiene` worktree lives under). The session-id leaf name is
-/// dynamic, so this exercises the `list_immediate_dirs` enumeration path,
-/// not a fixed join.
-#[test]
-fn find_orphaned_worktrees_covers_nested_session_claude_worktrees_shape() {
-    let tmp = tempfile::tempdir().unwrap();
-    let root = tmp.path();
-    let nested_claude_wt = root
-        .join("owner")
-        .join("repo")
-        .join(".base")
-        .join(".worktrees")
-        .join("2eb72dca-de08-481b-8dfa-22ab7f81b1f9")
-        .join(".claude")
-        .join("worktrees")
-        .join("fix-worktree-hygiene");
-    std::fs::create_dir_all(&nested_claude_wt).unwrap();
-    let empty_active: std::collections::HashSet<std::path::PathBuf> =
-        std::collections::HashSet::new();
-    let orphans = find_orphaned_worktrees(root, &empty_active);
-    assert!(
-        orphans.contains(&nested_claude_wt),
-        "the nested .base/.worktrees/<session-id>/.claude/worktrees shape must be \
-         discovered as a candidate; got {orphans:?}"
-    );
-}
-
-/// End-to-end through the real ownership gate (mirrors
-/// `prune_orphaned_worktrees_never_deletes_claude_native_worktree`): a
-/// sentinel-less `.base/.claude/worktrees/<name>` candidate is discovered but
-/// never auto-deleted, only reported as owner-unknown (#3971 follow-up).
-#[tokio::test]
-async fn prune_orphaned_worktrees_never_deletes_base_claude_native_worktree() {
-    let store_dir = tempfile::tempdir().unwrap();
-    let repos = tempfile::tempdir().unwrap();
-    let mgr = SessionManager::new(
-        store_dir.path(),
-        crate::session_manager::tests::FakeTmuxDriver::new(),
-    )
-    .await
-    .expect("manager");
-
-    let base_claude_wt = repos
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".base")
-        .join(".claude")
-        .join("worktrees")
-        .join("agent-2222222222222222222222222222222222222222");
-    std::fs::create_dir_all(&base_claude_wt).unwrap();
-    // Deliberately NO sentinel file written.
-
-    let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
-        .await
-        .expect("prune must not error");
-
-    assert!(
-        outcome.removed.is_empty(),
-        "a Claude-Code-native worktree under .base/.claude must never be auto-deleted; got {:?}",
-        outcome.removed
-    );
-    assert!(
-        outcome.owner_unknown.iter().any(|p| p == &base_claude_wt),
-        "expected {base_claude_wt:?} to be reported as owner-unknown; got {:?}",
-        outcome.owner_unknown
-    );
-    assert!(
-        base_claude_wt.exists(),
-        "worktree dir must survive the prune"
-    );
-}
-
-/// End-to-end through the real ownership gate for the NESTED
-/// per-session-checkout shape: a sentinel-less
-/// `.base/.worktrees/<session-id>/.claude/worktrees/<name>` candidate is
-/// discovered but never auto-deleted, only reported as owner-unknown (#3971
-/// follow-up).
-#[tokio::test]
-async fn prune_orphaned_worktrees_never_deletes_nested_session_claude_worktree() {
-    let store_dir = tempfile::tempdir().unwrap();
-    let repos = tempfile::tempdir().unwrap();
-    let mgr = SessionManager::new(
-        store_dir.path(),
-        crate::session_manager::tests::FakeTmuxDriver::new(),
-    )
-    .await
-    .expect("manager");
-
-    let nested_claude_wt = repos
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".base")
-        .join(".worktrees")
-        .join("some-session-id")
-        .join(".claude")
-        .join("worktrees")
-        .join("nested-agent");
-    std::fs::create_dir_all(&nested_claude_wt).unwrap();
-    // Deliberately NO sentinel file written on the nested Claude worktree.
-    // The session-id leaf itself also has no sentinel — it must not be
-    // misclassified as a location-2 (`.base/.worktrees`) orphan candidate
-    // either, since it still contains a live-looking nested checkout; that
-    // is exercised implicitly here (only the leaf-most directory is ever a
-    // candidate for each scanned shape).
-
-    let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
-        .await
-        .expect("prune must not error");
-
-    assert!(
-        outcome.removed.is_empty(),
-        "a nested Claude-Code-native worktree must never be auto-deleted; got {:?}",
-        outcome.removed
-    );
-    assert!(
-        outcome.owner_unknown.iter().any(|p| p == &nested_claude_wt),
-        "expected {nested_claude_wt:?} to be reported as owner-unknown; got {:?}",
-        outcome.owner_unknown
-    );
-    assert!(
-        nested_claude_wt.exists(),
-        "worktree dir must survive the prune"
-    );
 }
 
 /// A candidate whose ownership sentinel is absent (no `.trusty-mpm-worktree`
@@ -523,7 +275,6 @@ async fn prune_orphaned_worktrees_never_deletes_nested_session_claude_worktree()
 #[tokio::test]
 async fn prune_orphaned_worktrees_skips_owner_unknown() {
     let store_dir = tempfile::tempdir().unwrap();
-    let repos = tempfile::tempdir().unwrap();
     let mgr = SessionManager::new(
         store_dir.path(),
         crate::session_manager::tests::FakeTmuxDriver::new(),
@@ -531,17 +282,12 @@ async fn prune_orphaned_worktrees_skips_owner_unknown() {
     .await
     .expect("manager");
 
-    let wt = repos
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("legacy-no-sentinel");
-    std::fs::create_dir_all(&wt).unwrap();
+    let fx = GitWorktreeFixture::new();
     // Deliberately NO sentinel file written — simulates a legacy worktree.
+    let wt = fx.add_worktree("legacy-no-sentinel");
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -588,7 +334,6 @@ fn aged_sentinel_bytes(
 #[tokio::test]
 async fn prune_orphaned_worktrees_reclaims_terminal_owner() {
     let store_dir = tempfile::tempdir().unwrap();
-    let repos = tempfile::tempdir().unwrap();
     let mgr = SessionManager::new(
         store_dir.path(),
         crate::session_manager::tests::FakeTmuxDriver::new(),
@@ -596,13 +341,8 @@ async fn prune_orphaned_worktrees_reclaims_terminal_owner() {
     .await
     .expect("manager");
 
-    let wt = repos
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("ownerless-gone");
-    std::fs::create_dir_all(&wt).unwrap();
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("ownerless-gone");
     let never_registered_owner = ManagedSessionId::new();
     let aged = chrono::Utc::now()
         - crate::session_manager::worktree_ownership::OWNERLESS_GRACE
@@ -614,7 +354,7 @@ async fn prune_orphaned_worktrees_reclaims_terminal_owner() {
     .expect("write sentinel");
 
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -640,7 +380,6 @@ async fn prune_orphaned_worktrees_reclaims_terminal_owner() {
 #[tokio::test]
 async fn prune_orphaned_worktrees_spares_recent_unregistered_owner() {
     let store_dir = tempfile::tempdir().unwrap();
-    let repos = tempfile::tempdir().unwrap();
     let mgr = SessionManager::new(
         store_dir.path(),
         crate::session_manager::tests::FakeTmuxDriver::new(),
@@ -648,13 +387,8 @@ async fn prune_orphaned_worktrees_spares_recent_unregistered_owner() {
     .await
     .expect("manager");
 
-    let wt = repos
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("mid-creation-race");
-    std::fs::create_dir_all(&wt).unwrap();
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("mid-creation-race");
     let not_yet_persisted_owner = ManagedSessionId::new();
     std::fs::write(
         wt.join(crate::session_manager::decommission::WORKTREE_SENTINEL_FILE),
@@ -662,8 +396,15 @@ async fn prune_orphaned_worktrees_spares_recent_unregistered_owner() {
     )
     .expect("write sentinel");
 
+    // The candidate IS discovered — otherwise this test would pass vacuously.
+    let empty: std::collections::HashSet<std::path::PathBuf> = std::collections::HashSet::new();
+    assert!(
+        find_orphaned_worktrees(&fx.repos_root, &empty).contains(&wt),
+        "test invariant: the worktree must reach the ownership gate"
+    );
+
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -686,7 +427,6 @@ async fn prune_orphaned_worktrees_spares_recent_unregistered_owner() {
 #[tokio::test]
 async fn prune_orphaned_worktrees_spares_live_owner() {
     let store_dir = tempfile::tempdir().unwrap();
-    let repos = tempfile::tempdir().unwrap();
     let mgr = SessionManager::new(
         store_dir.path(),
         crate::session_manager::tests::FakeTmuxDriver::new(),
@@ -694,13 +434,8 @@ async fn prune_orphaned_worktrees_spares_live_owner() {
     .await
     .expect("manager");
 
-    let wt = repos
-        .path()
-        .join("owner")
-        .join("repo")
-        .join(".worktrees")
-        .join("live-owner-elsewhere");
-    std::fs::create_dir_all(&wt).unwrap();
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("live-owner-elsewhere");
 
     // Register the owner as a LIVE record whose workspace_path points
     // somewhere else entirely — so `wt` is NOT in `active_workspace_paths`
@@ -730,8 +465,15 @@ async fn prune_orphaned_worktrees_spares_live_owner() {
     )
     .expect("write sentinel");
 
+    // The candidate IS discovered — otherwise this test would pass vacuously.
+    let empty: std::collections::HashSet<std::path::PathBuf> = std::collections::HashSet::new();
+    assert!(
+        find_orphaned_worktrees(&fx.repos_root, &empty).contains(&wt),
+        "test invariant: the worktree must reach the ownership gate"
+    );
+
     let outcome = mgr
-        .prune_orphaned_worktrees(repos.path(), &[], false, DirtyWorktreePolicy::Skip)
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
         .await
         .expect("prune must not error");
 
@@ -835,6 +577,52 @@ fn git_worktree_list_agrees_false_for_untracked_dir() {
     assert!(
         !git_worktree_list_agrees(&untracked),
         "a directory git never registered as a worktree must disagree"
+    );
+}
+
+/// THE #4207 regression test for the ownership half of the slice: a worktree
+/// physically inside `<repo>/.base/.worktrees/` but REGISTERED to the parent
+/// repo `<repo>` must be recognised as a real worktree.
+///
+/// Why: this is the exact state fourteen worktrees on the dogfood machine were
+/// in on 2026-07-27, and it made every one of them STRUCTURALLY unreclaimable.
+/// The old rule derived the owning checkout from the candidate's GRANDPARENT,
+/// which here is `<repo>/.base` — a genuine but DIFFERENT repository that
+/// correctly disowns the path. `git_worktree_list_agrees` therefore returned
+/// `false` and the reclaim path skipped conservatively, forever, no matter how
+/// clean or how ownerless the worktree was.
+///
+/// REVERT-PROOF: restore
+/// `let repo_root = candidate.parent().and_then(|p| p.parent())` and aim the
+/// `worktree list` at it, and this test fails — `.base` is a real repository
+/// whose registry genuinely does not contain the candidate, so the old code
+/// takes its success path and returns `false`. The two tests above cannot
+/// catch it: in both, the grandparent happens to be the owning repository.
+#[test]
+fn git_worktree_list_agrees_true_for_worktree_registered_to_parent_repo() {
+    let fx = GitWorktreeFixture::new();
+    // Create the `.base` bare clone first, so the candidate's grandparent is a
+    // real repository — one that does NOT own the candidate.
+    fx.add_base_clone_worktree("owned-by-base");
+    let parent_registered = fx.add_worktree_at(
+        &fx.repo.join(".base").join(".worktrees"),
+        "registered-to-parent",
+    );
+
+    let grandparent = parent_registered
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("grandparent");
+    assert!(
+        crate::session_manager::worktree_registry::registry_root_for(grandparent).is_some(),
+        "test invariant: the grandparent must itself be a repository, or the old \
+         rule would fall through its best-effort `true` and pass by accident"
+    );
+
+    assert!(
+        git_worktree_list_agrees(&parent_registered),
+        "a worktree registered to the PARENT repo but living under .base must be \
+         recognised — asking the grandparent (.base) disowns it"
     );
 }
 

--- a/crates/trusty-mpm/src/session_manager/reap_orphaned_worktrees_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reap_orphaned_worktrees_tests.rs
@@ -35,16 +35,16 @@ use super::tests::FakeTmuxDriver;
 #[tokio::test]
 async fn reap_orphaned_worktrees_removes_orphan_preserves_live() {
     let store_dir = TempDir::new().unwrap();
-    let repos = TempDir::new().unwrap();
     let mgr = SessionManager::new(store_dir.path(), FakeTmuxDriver::new())
         .await
         .expect("manager");
 
-    let wt_root = repos.path().join("owner").join("repo").join(".worktrees");
-    let live_wt = wt_root.join("live-session");
-    let orphan_wt = wt_root.join("orphan-session");
-    std::fs::create_dir_all(&live_wt).unwrap();
-    std::fs::create_dir_all(&orphan_wt).unwrap();
+    // #4207: both worktrees are REAL `git worktree add`s. Discovery is now
+    // derived from git's registry, so a `mkdir` is not a candidate and the
+    // orphan half of this test would pass vacuously without them.
+    let fx = super::worktree_git_fixture::GitWorktreeFixture::new();
+    let live_wt = fx.add_worktree("live-session");
+    let orphan_wt = fx.add_worktree("orphan-session");
 
     // #3649: the auto-reaper now NEVER deletes an owner-unknown worktree (a
     // dir with no sentinel, or a legacy zero-byte one). Write a valid
@@ -87,7 +87,7 @@ async fn reap_orphaned_worktrees_removes_orphan_preserves_live() {
         .expect("create live record");
 
     let outcome = mgr
-        .reap_orphaned_worktrees(repos.path())
+        .reap_orphaned_worktrees(&fx.repos_root)
         .await
         .expect("reap must not error");
     let removed = outcome.removed;

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -178,11 +178,13 @@ impl GitWorktreeFixture {
     /// Mark `wt` as git-`locked` — the operator's explicit "do not remove
     /// this" (#4224 review).
     ///
-    /// Why: `decommission::remove_session_worktree` runs `git worktree remove
-    /// --force`, which overrides a lock outright, so the lock can only be
-    /// honoured by never enumerating the worktree in the first place. Proving
-    /// that requires a really-locked worktree; setting the flag on a parsed
-    /// record instead would test the parser, not the filter.
+    /// Why: git itself honours the lock — `git worktree remove --force` exits
+    /// 128 rather than removing it. But `decommission::remove_session_worktree`
+    /// treats that non-zero exit as a git failure and falls back to
+    /// `std::fs::remove_dir_all`, which deletes the directory regardless, so the
+    /// lock can only be honoured by never enumerating the worktree in the first
+    /// place. Proving that requires a really-locked worktree; setting the flag
+    /// on a parsed record instead would test the parser, not the filter.
     /// What: `git -C <repo> worktree lock <wt>`.
     /// Test: `enumerate_excludes_a_locked_worktree`.
     pub(crate) fn lock_worktree(&self, wt: &Path) {

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -76,9 +76,16 @@ impl GitWorktreeFixture {
     /// Test: `inspect_dirt_clean_pushed_worktree_is_none`.
     pub(crate) fn new() -> Self {
         let tmp = tempfile::tempdir().expect("fixture: tempdir");
-        let repos_root = tmp.path().join("repos");
+        // #4207: canonicalize the root. On macOS `tempfile` hands back a path
+        // under `/var`, which is a symlink to `/private/var`; git records the
+        // RESOLVED path in its worktree registry, so a fixture that kept the
+        // unresolved form would compare git-reported paths against a different
+        // spelling of the same directory and fail for a reason unrelated to
+        // what any of these tests are about.
+        let tmp_root = std::fs::canonicalize(tmp.path()).unwrap_or_else(|_| tmp.path().into());
+        let repos_root = tmp_root.join("repos");
         let repo = repos_root.join("owner").join("repo");
-        let remote = tmp.path().join("remote.git");
+        let remote = tmp_root.join("remote.git");
         std::fs::create_dir_all(&repo).expect("fixture: create repo dir");
         std::fs::create_dir_all(&remote).expect("fixture: create remote dir");
 
@@ -133,6 +140,71 @@ impl GitWorktreeFixture {
         git_ok(&wt, &["config", "user.email", "ci@test.invalid"]);
         git_ok(&wt, &["config", "user.name", "CI"]);
         git_ok(&wt, &["config", "commit.gpgsign", "false"]);
+        wt
+    }
+
+    /// Add a real worktree at `<parent>/<name>`, anywhere on disk (#4207).
+    ///
+    /// Why: [`Self::add_worktree`] parks every worktree at
+    /// `<repo>/.worktrees/<name>`, whose grandparent happens to be the owning
+    /// checkout — so it cannot distinguish git-derived ownership from the
+    /// grandparent inference #4207 replaces, nor prove that enumeration is
+    /// independent of location. This helper takes the parent directory
+    /// explicitly so a test can park a worktree somewhere no hard-coded shape
+    /// covers, or outside the repos root entirely.
+    /// What: `git worktree add -b wt/<name> <parent>/<name>` off the current
+    /// `HEAD`, creating `<parent>` if needed. Returns the worktree path.
+    /// Test: `enumerate_finds_worktree_at_an_unwalked_location`,
+    /// `registry_root_for_ignores_where_the_worktree_is_parked`.
+    pub(crate) fn add_worktree_at(&self, parent: &Path, name: &str) -> PathBuf {
+        std::fs::create_dir_all(parent).expect("fixture: create worktree parent");
+        let wt = parent.join(name);
+        git_ok(
+            &self.repo,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                &format!("wt/{name}"),
+                wt.to_str().expect("utf8 worktree path"),
+            ],
+        );
+        wt
+    }
+
+    /// Create a bare `.base` clone inside the checkout and register a worktree
+    /// in ITS registry (#4207).
+    ///
+    /// Why: a managed project has two checkouts that can own a worktree
+    /// registry, and `enumerate_registered_worktrees` interrogates both. Without
+    /// a fixture for the `.base` anchor, only the project-checkout half of that
+    /// contract is covered.
+    /// What: `git clone --bare` the checkout to `<repo>/.base`, then
+    /// `git -C <repo>/.base worktree add` at `<repo>/.base/.worktrees/<name>`.
+    /// Returns the worktree path.
+    /// Test: `enumerate_finds_worktree_registered_to_base_clone`.
+    pub(crate) fn add_base_clone_worktree(&self, name: &str) -> PathBuf {
+        let base = self.repo.join(".base");
+        git_ok(
+            &self.repo,
+            &[
+                "clone",
+                "--bare",
+                ".",
+                base.to_str().expect("utf8 base clone path"),
+            ],
+        );
+        let wt = base.join(".worktrees").join(name);
+        git_ok(
+            &base,
+            &[
+                "worktree",
+                "add",
+                "-b",
+                &format!("session/{name}"),
+                wt.to_str().expect("utf8 worktree path"),
+            ],
+        );
         wt
     }
 

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -14,9 +14,9 @@
 //! exact failure #4091 exists to prevent.
 //!
 //! What: [`GitWorktreeFixture`], which owns the temp dir and exposes
-//! `repos_root` (the `<repos_root>/<owner>/<repo>/` shape
-//! `find_orphaned_worktrees` walks) plus helpers to add worktrees and dirty
-//! them.
+//! `repos_root` (the `<repos_root>/<owner>/<repo>/` layout
+//! `find_orphaned_worktrees` is pointed at) plus helpers to add worktrees, park
+//! them outside the project, lock them, and dirty them.
 //! Test: exercised by every `#4091` test in `worktree_safety_tests` and
 //! `prune_orphan_tests`.
 
@@ -27,10 +27,11 @@ use super::record::ManagedSessionId;
 
 /// A throwaway `<repos_root>/owner/repo` checkout with a bare remote (#4091).
 ///
-/// Why: `prune_orphaned_worktrees` walks `<repos_root>/<owner>/<repo>/…`, the
-/// `git worktree list` cross-check resolves the repo root as the candidate's
-/// GRANDPARENT, and the unpushed-commit check needs real remote-tracking refs.
-/// One fixture has to satisfy all three at once.
+/// Why: `prune_orphaned_worktrees` enumerates per managed project under
+/// `<repos_root>/<owner>/<repo>/`, the `git worktree list` cross-check resolves
+/// the owning repo from the candidate itself (#4207 — it used to guess the
+/// candidate's GRANDPARENT), and the unpushed-commit check needs real
+/// remote-tracking refs. One fixture has to satisfy all three at once.
 /// What: owns the `TempDir` (dropped = everything cleaned up) and exposes the
 /// repos root and the checkout path.
 /// Test: used by `inspect_dirt_clean_pushed_worktree_is_none` and friends.
@@ -118,10 +119,12 @@ impl GitWorktreeFixture {
 
     /// Add a real per-session worktree at `<repo>/.worktrees/<name>`.
     ///
-    /// Why: the reclaim path only ever considers leaf dirs under a
-    /// `.worktrees`-shaped parent, and `git_worktree_list_agrees` requires the
-    /// path to be a genuinely registered worktree — a bare `mkdir` would be
-    /// rejected before the dirty gate ever ran.
+    /// Why: `.worktrees/<name>` is where the provisioner actually parks a
+    /// per-session worktree, so this is the ordinary shape most tests want, and
+    /// `git_worktree_list_agrees` requires the path to be a genuinely
+    /// registered worktree — a bare `mkdir` would be rejected before the dirty
+    /// gate ever ran. Note the reclaim path is no longer LIMITED to this shape
+    /// (#4207); use [`Self::add_worktree_at`] to prove that.
     /// What: `git worktree add -b session/<name>` off the current `HEAD`.
     /// Returns the worktree path.
     /// Test: `inspect_dirt_clean_pushed_worktree_is_none`.
@@ -170,6 +173,23 @@ impl GitWorktreeFixture {
             ],
         );
         wt
+    }
+
+    /// Mark `wt` as git-`locked` — the operator's explicit "do not remove
+    /// this" (#4224 review).
+    ///
+    /// Why: `decommission::remove_session_worktree` runs `git worktree remove
+    /// --force`, which overrides a lock outright, so the lock can only be
+    /// honoured by never enumerating the worktree in the first place. Proving
+    /// that requires a really-locked worktree; setting the flag on a parsed
+    /// record instead would test the parser, not the filter.
+    /// What: `git -C <repo> worktree lock <wt>`.
+    /// Test: `enumerate_excludes_a_locked_worktree`.
+    pub(crate) fn lock_worktree(&self, wt: &Path) {
+        git_ok(
+            &self.repo,
+            &["worktree", "lock", wt.to_str().expect("utf8 worktree path")],
+        );
     }
 
     /// Create a bare `.base` clone inside the checkout and register a worktree

--- a/crates/trusty-mpm/src/session_manager/worktree_registry.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry.rs
@@ -26,8 +26,9 @@
 //! [`parse_worktree_list`] (the pure parser), [`registry_root_for`] (replaces
 //! grandparent-as-repo-root inference), [`list_registered_worktrees`] (what
 //! git says about the repository owning a path), and
-//! [`enumerate_registered_worktrees`] (every registered worktree under a
-//! managed repos root).
+//! [`enumerate_registered_worktrees`] (every registered worktree living INSIDE
+//! a managed project under the repos root — see that function's "positive
+//! assertion" section for the structural boundary that bounds the sweep).
 //!
 //! # An unanswerable probe is never a verdict
 //!
@@ -83,6 +84,10 @@ pub(crate) struct RegisteredWorktree {
     pub bare: bool,
     /// `true` when git reports the worktree's directory is missing.
     pub prunable: bool,
+    /// `true` when git reports the worktree is LOCKED — an explicit operator
+    /// "do not remove this", which `git worktree remove` refuses to override
+    /// without `--force`.
+    pub locked: bool,
     /// `true` for the first record — git always lists the main worktree first.
     pub is_main: bool,
 }
@@ -101,7 +106,8 @@ pub(crate) struct RegisteredWorktree {
 /// flagged [`RegisteredWorktree::is_main`]. Unknown attribute lines are
 /// ignored so a future git version cannot break the parse.
 /// Test: `parse_worktree_list_reads_porcelain_records`,
-/// `parse_worktree_list_marks_only_the_first_record_main`.
+/// `parse_worktree_list_marks_only_the_first_record_main`,
+/// `parse_worktree_list_reads_locked_with_and_without_reason`.
 pub(crate) fn parse_worktree_list(stdout: &str) -> Vec<RegisteredWorktree> {
     let mut out: Vec<RegisteredWorktree> = Vec::new();
     for line in stdout.lines() {
@@ -112,6 +118,7 @@ pub(crate) fn parse_worktree_list(stdout: &str) -> Vec<RegisteredWorktree> {
                 branch: None,
                 bare: false,
                 prunable: false,
+                locked: false,
                 is_main: out.is_empty(),
             });
             continue;
@@ -130,6 +137,8 @@ pub(crate) fn parse_worktree_list(stdout: &str) -> Vec<RegisteredWorktree> {
             current.bare = true;
         } else if line == "prunable" || line.starts_with("prunable ") {
             current.prunable = true;
+        } else if line == "locked" || line.starts_with("locked ") {
+            current.locked = true;
         }
     }
     out
@@ -215,18 +224,85 @@ pub(crate) fn list_registered_worktrees(anchor: &Path) -> Option<Vec<RegisteredW
 /// `<repo>/.base` — but only after confirming (via [`registry_root_for`]) that
 /// the anchor IS that repository's root. That confirmation is load-bearing:
 /// without it, `git -C <non-repo>` walks UP the filesystem and would report an
-/// unrelated enclosing repository's worktrees. Records that are bare, main, or
-/// already prunable are dropped (there is no working tree to reclaim), as is
-/// any worktree resolving outside `repos_root` — preserving the containment
-/// boundary the old walk had structurally, since it could only ever produce
-/// paths beneath the root it was handed. Results are canonicalized (so they
-/// compare cleanly against the canonicalized active-session set) and returned
-/// sorted and de-duplicated, since both anchors may report the same worktree.
+/// unrelated enclosing repository's worktrees. Records that are bare, main,
+/// already prunable, or git-`locked` are dropped, as is any worktree failing
+/// the [`collect_from_anchor`] containment rule. Results are canonicalized (so
+/// they compare cleanly against the canonicalized active-session set) and
+/// returned sorted and de-duplicated, since both anchors may report the same
+/// worktree.
+///
+/// # Containment is a POSITIVE assertion, not a denylist (#4224 review, HIGH)
+///
+/// Enumerating from git's registry rather than from five path shapes widens
+/// what can be SEEN, and the first cut of this module let anything git
+/// registered anywhere under `repos_root` through — leaving the #3649 ownership
+/// sentinel as the single structural boundary in front of an unattended
+/// `remove_dir_all`. Replayed against the dogfood machine that admitted seven
+/// paths the old walk never produced, FIVE of them the operator's own
+/// long-lived checkouts (`<owner>/ft-follow-links`,
+/// `<owner>/trusty-tools-main-build`, `<owner>/trusty-tools-worktrees/wt-*`,
+/// `<owner>/gb-connect-card`). None was deletable — each lacks a sentinel — but
+/// "one gate happens to hold" is not a boundary, and this repository has
+/// already lost a bare clone to an over-broad removal (2026-07-21).
+///
+/// So a candidate must additionally be a STRICT DESCENDANT of the managed
+/// project directory whose registry named it. That is an assertion the path IS
+/// inside a tree trusty-mpm provisions and manages, which is an invariant of
+/// the WRITE side: `provisioner::workspace` only ever creates worktrees beneath
+/// `<repos_root>/<owner>/<repo>/` (in the checkout, in its `.base` clone, or in
+/// an agent runtime's directory inside either). It is deliberately NOT a list
+/// of blessed path shapes — any depth and any directory name inside the project
+/// qualifies, so the "we forgot a location" bug class this PR deletes (#3649,
+/// #3971) stays deleted. And it is not a denylist of known operator paths: an
+/// operator checkout is excluded by its POSITION relative to the repository
+/// that owns it, so a newly created one is excluded on the day it is created,
+/// under any name.
+///
+/// Both operands come from git — the path from `git worktree list --porcelain`,
+/// the project root from `git rev-parse --git-common-dir` — so this adds no
+/// state that could drift out of sync with git's own registry. That matters:
+/// worktrees present in one registry and absent from another is a failure this
+/// repository has already had twice.
+///
+/// ## Why provenance is not available, and branch role does not substitute
+///
+/// The discriminator one WANTS is "was this provisioned for a writing agent, on
+/// a workstream branch?". Git cannot answer the first half at all: nothing in
+/// the porcelain record, and nothing in the `worktrees/<id>/` admin directory,
+/// records WHO ran `git worktree add`. The only provenance fact that exists is
+/// trusty-mpm's own #3649 sentinel, which is why the sentinel gate stays where
+/// it is — this boundary is layered IN FRONT of it, not a second copy of it.
+///
+/// Branch role does not substitute, measured rather than assumed. Across the
+/// 201 candidates on this machine the branch namespaces are
+/// `fix/` (88), `feat/` (44), `docs/` (12), detached (10), `session/` (9),
+/// `chore/` (9) — and the operator's own checkouts, the Claude-native
+/// `agent-*` worktrees, and the genuinely tm-owned ones are ALL drawn from
+/// `fix/` and `feat/`. Gating reclamation on a `session|ws|workstream`
+/// namespace would admit 9 of 201 candidates and ZERO of the 3 sentinel-bearing
+/// ones — reclamation would silently drop to nothing while still looking
+/// healthy. A branch namespace is also just a name pattern, and an operator may
+/// check out any branch in their own checkout.
+///
+/// Containment is therefore the strongest git-observable boundary available,
+/// and it is count- and name-independent: the 1.3.0 direction (one worktree per
+/// writing agent, more of them, shorter-lived) makes it MORE useful, not less,
+/// because every agent worktree is provisioned inside the project tree no
+/// matter how many there are or what they are called.
+///
+/// Measured on the same machine, the rule drops all five operator checkouts,
+/// retains all 54 `.base`-resident worktrees (the class that was structurally
+/// unreclaimable before this PR), and leaves the count of sentinel-bearing —
+/// i.e. actually reclaimable — candidates unchanged at 3. The narrowing costs
+/// no reclaim capability; it only removes reach the sweep never needed.
 /// Test: `enumerate_finds_worktree_at_an_unwalked_location`,
 /// `enumerate_finds_worktree_registered_to_base_clone`,
 /// `enumerate_ignores_plain_directory_that_is_not_a_worktree`,
 /// `enumerate_excludes_the_main_checkout`,
-/// `enumerate_excludes_worktrees_outside_the_repos_root`.
+/// `enumerate_excludes_worktrees_outside_the_repos_root`,
+/// `enumerate_excludes_a_sibling_checkout_of_the_same_repo`,
+/// `enumerate_excludes_a_worktree_parked_beside_the_project`,
+/// `enumerate_excludes_a_locked_worktree`.
 pub(crate) fn enumerate_registered_worktrees(repos_root: &Path) -> Vec<PathBuf> {
     let canonical_root = std::fs::canonicalize(repos_root).unwrap_or_else(|_| repos_root.into());
     let mut found: BTreeSet<PathBuf> = BTreeSet::new();
@@ -243,8 +319,16 @@ pub(crate) fn enumerate_registered_worktrees(repos_root: &Path) -> Vec<PathBuf> 
         };
         for repo_entry in repo_entries.flatten() {
             let repo_path = repo_entry.path();
+            // The containment boundary below is expressed against the project's
+            // RESOLVED path. A project directory that will not canonicalize
+            // cannot bound anything, so the whole project is skipped rather
+            // than falling back to the far wider `repos_root` — a failed
+            // observation may only ever shrink what this function proposes.
+            let Ok(canonical_project) = std::fs::canonicalize(&repo_path) else {
+                continue;
+            };
             for anchor in [repo_path.clone(), repo_path.join(BASE_CLONE_DIRNAME)] {
-                collect_from_anchor(&anchor, &canonical_root, &mut found);
+                collect_from_anchor(&anchor, &canonical_root, &canonical_project, &mut found);
             }
         }
     }
@@ -259,10 +343,22 @@ pub(crate) fn enumerate_registered_worktrees(repos_root: &Path) -> Vec<PathBuf> 
 /// drift apart from each other.
 /// What: no-ops unless `anchor` is a directory that is ITSELF the root of the
 /// repository owning its registry (see [`registry_root_for`]); then inserts
-/// every non-bare, non-main, non-prunable worktree whose canonicalized path
-/// lies under `canonical_root`.
+/// every non-bare, non-main, non-prunable, non-`locked` worktree whose
+/// canonicalized path is a STRICT DESCENDANT of `canonical_project` (the
+/// managed project directory — see [`enumerate_registered_worktrees`]' "positive
+/// assertion" section) and also lies under `canonical_root`.
+///
+/// Both containment checks are applied even though the first normally implies
+/// the second: `canonical_project` is derived by canonicalizing a `read_dir`
+/// entry, so a symlinked project directory could resolve OUTSIDE the managed
+/// root, and the pair keeps the sweep bounded in that case too.
 /// Test: covered by every `enumerate_*` test.
-fn collect_from_anchor(anchor: &Path, canonical_root: &Path, found: &mut BTreeSet<PathBuf>) {
+fn collect_from_anchor(
+    anchor: &Path,
+    canonical_root: &Path,
+    canonical_project: &Path,
+    found: &mut BTreeSet<PathBuf>,
+) {
     if !anchor.is_dir() {
         return;
     }
@@ -280,7 +376,11 @@ fn collect_from_anchor(anchor: &Path, canonical_root: &Path, found: &mut BTreeSe
         return;
     };
     for wt in worktrees {
-        if wt.bare || wt.is_main || wt.prunable {
+        // `locked` is git's own removal veto — the operator ran
+        // `git worktree lock` to say "do not remove this". Honouring it here is
+        // the only place that can: `decommission::remove_session_worktree` runs
+        // `git worktree remove --force`, which overrides the lock outright.
+        if wt.bare || wt.is_main || wt.prunable || wt.locked {
             continue;
         }
         // #1845 item 8, preserved: a path that cannot be canonicalized is
@@ -293,7 +393,15 @@ fn collect_from_anchor(anchor: &Path, canonical_root: &Path, found: &mut BTreeSe
         let Ok(canonical) = std::fs::canonicalize(&wt.path) else {
             continue;
         };
-        if canonical.starts_with(canonical_root) {
+        // The structural boundary (#4224 HIGH). `starts_with` is component-wise,
+        // so `<owner>/trusty-tools-worktrees/x` cannot match the project
+        // `<owner>/trusty-tools`. The `!=` makes it STRICT: the project checkout
+        // itself — the operator's working copy — is never a candidate, whether
+        // or not some other registry lists it as a linked worktree.
+        if canonical != canonical_project
+            && canonical.starts_with(canonical_project)
+            && canonical.starts_with(canonical_root)
+        {
             found.insert(canonical);
         }
     }

--- a/crates/trusty-mpm/src/session_manager/worktree_registry.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry.rs
@@ -377,9 +377,22 @@ fn collect_from_anchor(
     };
     for wt in worktrees {
         // `locked` is git's own removal veto — the operator ran
-        // `git worktree lock` to say "do not remove this". Honouring it here is
-        // the only place that can: `decommission::remove_session_worktree` runs
-        // `git worktree remove --force`, which overrides the lock outright.
+        // `git worktree lock` to say "do not remove this".
+        //
+        // Be precise about WHY skipping here is load-bearing, because the
+        // obvious reading is wrong and would get this filter deleted as
+        // redundant. `git worktree remove --force` does NOT override a lock:
+        // verified on git 2.54.0, a single `--force` exits 128 with "cannot
+        // remove a locked working tree; use 'remove -f -f' to override or
+        // unlock first", leaving the directory intact. Git respects the lock.
+        //
+        // The danger is what `decommission::remove_session_worktree` does with
+        // that refusal: it treats ANY non-zero git exit as "git failed" and
+        // falls back to `std::fs::remove_dir_all`, which deletes the directory
+        // regardless — defeating the lock via the error path rather than the
+        // force flag, AND leaving git's now-dangling registry entry behind.
+        // Never enumerating a locked worktree is therefore the only place the
+        // operator's veto actually survives.
         if wt.bare || wt.is_main || wt.prunable || wt.locked {
             continue;
         }

--- a/crates/trusty-mpm/src/session_manager/worktree_registry.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry.rs
@@ -1,0 +1,304 @@
+//! Git-native worktree enumeration and registry-root resolution (#4207 slice 1).
+//!
+//! Why: every worktree question this crate asks used to be answered by
+//! GUESSING at the filesystem. `prune::find_orphaned_worktrees` walked five
+//! hard-coded location shapes (`.worktrees/`, `.base/.worktrees/`,
+//! `.claude/worktrees/`, `.base/.claude/worktrees/`, and
+//! `.base/.worktrees/<id>/.claude/worktrees/`), and both
+//! `worktree_safety::git_worktree_list_agrees` and
+//! `decommission::remove_session_worktree` derived "which checkout owns this
+//! worktree?" from the candidate's GRANDPARENT directory. Neither is a fact;
+//! both are inferences that git can answer exactly, and both were wrong on
+//! this machine on 2026-07-27: fourteen worktrees physically located inside
+//! `<repo>/.base/.worktrees/` are registered to the PARENT repo `<repo>`, so
+//! the grandparent rule asked `.base` about them, `.base` correctly said "not
+//! mine", and the sweep skipped them conservatively — forever. They were not
+//! merely un-reclaimed, they were STRUCTURALLY unreclaimable, and no amount of
+//! adding a sixth location shape would have fixed it.
+//!
+//! Git already maintains the answer. `git worktree list --porcelain` is the
+//! registry, and `git rev-parse --git-common-dir` names the checkout that owns
+//! it. Deriving from those two commands makes location irrelevant: a worktree
+//! is found because git registered it, not because it happened to be parked
+//! under a directory name someone remembered to enumerate.
+//!
+//! What: [`RegisteredWorktree`] (one porcelain record),
+//! [`parse_worktree_list`] (the pure parser), [`registry_root_for`] (replaces
+//! grandparent-as-repo-root inference), [`list_registered_worktrees`] (what
+//! git says about the repository owning a path), and
+//! [`enumerate_registered_worktrees`] (every registered worktree under a
+//! managed repos root).
+//!
+//! # An unanswerable probe is never a verdict
+//!
+//! Every function here returns `Option`/`None` — never a `bool` — for the
+//! "could not determine" case, so no caller can silently read a missing `git`
+//! binary, a permissions error, or a stalled network mount as a fact about the
+//! worktree. This is the same invariant PR #4202's round-1 fix broke by
+//! collapsing every `canonicalize()` error kind into "destroyed"; on
+//! 2026-07-21 a rule that loose would have told an operator to recreate ~70
+//! fully intact worktrees. Callers decide what a `None` means in their own
+//! direction of safety — [`enumerate_registered_worktrees`] treats it as "no
+//! candidates from this anchor" (nothing is proposed for deletion), while
+//! `git_worktree_list_agrees` keeps its long-standing best-effort `true`.
+//!
+//! Test: `worktree_registry_tests`.
+
+use std::collections::BTreeSet;
+use std::path::{Path, PathBuf};
+
+use super::worktree_safety::git_command;
+
+/// The bare-clone checkout trusty-mpm provisions alongside a managed project.
+///
+/// Why: a managed project has at most TWO git checkouts that can own a worktree
+/// registry — the project checkout itself and the `.base` clone
+/// `provisioner::workspace::WorkspaceProvisioner` creates. Naming the segment
+/// once keeps [`enumerate_registered_worktrees`] from repeating the literal.
+/// This is NOT a worktree-location guess: it names a CHECKOUT to interrogate,
+/// and git then reports where that checkout's worktrees actually live.
+/// What: `".base"`.
+/// Test: `enumerate_finds_worktree_registered_to_base_clone`.
+const BASE_CLONE_DIRNAME: &str = ".base";
+
+/// One worktree exactly as `git worktree list --porcelain` reports it (#4207).
+///
+/// Why: the porcelain format carries the four facts the reclaim path needs —
+/// where the worktree is, whether it is the main checkout (never a reclaim
+/// candidate), whether it is bare (no working tree to reclaim), and whether
+/// git already considers it prunable (its directory is gone, so there is
+/// nothing to delete). Modelling them as fields rather than re-grepping the
+/// raw text at each call site keeps the parse in one place.
+/// What: `path` is git's own absolute path for the worktree; `branch` is the
+/// short branch name when the worktree is not detached; `is_main` marks the
+/// FIRST record, which git always emits for the main worktree.
+/// Test: `parse_worktree_list_reads_porcelain_records`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct RegisteredWorktree {
+    /// Absolute path git reports for this worktree.
+    pub path: PathBuf,
+    /// Short branch name (`refs/heads/` stripped), or `None` when detached.
+    pub branch: Option<String>,
+    /// `true` for a bare repository record (no working tree).
+    pub bare: bool,
+    /// `true` when git reports the worktree's directory is missing.
+    pub prunable: bool,
+    /// `true` for the first record — git always lists the main worktree first.
+    pub is_main: bool,
+}
+
+/// Parse `git worktree list --porcelain` output into records (#4207).
+///
+/// Why: the parse is the one piece of this module that can be tested without
+/// spawning git, and the porcelain format has enough shape (blank-line-
+/// separated stanzas, valueless `bare`/`detached`/`prunable` attribute lines)
+/// that an ad-hoc `strip_prefix("worktree ")` over all lines — what
+/// `git_worktree_list_agrees` did before this change — silently ignores every
+/// other fact in the record.
+/// What: splits on blank lines; each stanza starts with `worktree <path>` and
+/// may carry `HEAD <sha>`, `branch <ref>`, `bare`, `detached`, `locked`, or
+/// `prunable` (the last two optionally with a reason). The first stanza is
+/// flagged [`RegisteredWorktree::is_main`]. Unknown attribute lines are
+/// ignored so a future git version cannot break the parse.
+/// Test: `parse_worktree_list_reads_porcelain_records`,
+/// `parse_worktree_list_marks_only_the_first_record_main`.
+pub(crate) fn parse_worktree_list(stdout: &str) -> Vec<RegisteredWorktree> {
+    let mut out: Vec<RegisteredWorktree> = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim_end();
+        if let Some(path) = line.strip_prefix("worktree ") {
+            out.push(RegisteredWorktree {
+                path: PathBuf::from(path),
+                branch: None,
+                bare: false,
+                prunable: false,
+                is_main: out.is_empty(),
+            });
+            continue;
+        }
+        let Some(current) = out.last_mut() else {
+            continue;
+        };
+        if let Some(branch) = line.strip_prefix("branch ") {
+            current.branch = Some(
+                branch
+                    .strip_prefix("refs/heads/")
+                    .unwrap_or(branch)
+                    .to_string(),
+            );
+        } else if line == "bare" {
+            current.bare = true;
+        } else if line == "prunable" || line.starts_with("prunable ") {
+            current.prunable = true;
+        }
+    }
+    out
+}
+
+/// The checkout that owns the worktree registry `anchor` belongs to (#4207).
+///
+/// Why: this REPLACES grandparent-as-repo-root inference
+/// (`path.parent().and_then(|p| p.parent())`), which was correct only for the
+/// two shapes it was written against and wrong for every other one —
+/// `<repo>/.claude/worktrees/<name>` resolved to `<repo>/.claude`, which is
+/// not a repository at all, and the fourteen `.base`-resident worktrees
+/// registered to the parent repo resolved to `.base`, which disowns them.
+/// `git rev-parse --git-common-dir` answers the same question as a fact: it
+/// names the SHARED git directory every worktree of a repository points at,
+/// which is exactly the registry `git worktree list` reads.
+/// What: runs `git -C <anchor> rev-parse --path-format=absolute
+/// --git-common-dir`. A normal checkout answers `<root>/.git`, so the root is
+/// its parent; a bare clone answers with the bare directory itself, which IS
+/// the root. Returns `None` when git cannot be run, exits non-zero (including
+/// the ordinary "not a git repository" case), or prints nothing usable — never
+/// a guessed path.
+/// Test: `registry_root_for_linked_worktree_is_the_owning_checkout`,
+/// `registry_root_for_non_repo_is_none`.
+pub(crate) fn registry_root_for(anchor: &Path) -> Option<PathBuf> {
+    let out = git_command(
+        anchor,
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .output()
+    .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&out.stdout);
+    let common_dir = PathBuf::from(raw.trim());
+    if common_dir.as_os_str().is_empty() {
+        return None;
+    }
+    // A non-bare repository's common dir is `<root>/.git`; a bare one IS the root.
+    if common_dir.file_name().is_some_and(|n| n == ".git") {
+        common_dir.parent().map(Path::to_path_buf)
+    } else {
+        Some(common_dir)
+    }
+}
+
+/// Every worktree git registers for the repository that owns `anchor` (#4207).
+///
+/// Why: `git worktree list` is the registry. Asking it directly is what makes
+/// worktree discovery independent of where a worktree is parked, and it is the
+/// only source that can report a worktree registered to one checkout while
+/// living inside another's directory tree — the exact state that made fourteen
+/// worktrees on this machine unreclaimable.
+/// What: runs `git -C <anchor> worktree list --porcelain` and parses the
+/// result via [`parse_worktree_list`]. Git resolves the repository from
+/// `anchor` itself, so `anchor` may be the checkout root, a linked worktree, or
+/// any directory inside one. Returns `None` on a spawn failure or non-zero
+/// exit — an unanswerable probe, never an empty list.
+/// Test: `list_registered_worktrees_reports_a_real_worktree`,
+/// `list_registered_worktrees_none_outside_a_repo`.
+pub(crate) fn list_registered_worktrees(anchor: &Path) -> Option<Vec<RegisteredWorktree>> {
+    let out = git_command(anchor, &["worktree", "list", "--porcelain"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    Some(parse_worktree_list(&String::from_utf8_lossy(&out.stdout)))
+}
+
+/// Every git-registered worktree living under `repos_root` (#4207 slice 1).
+///
+/// Why: this is the derive-not-walk replacement for
+/// `prune::find_orphaned_worktrees`' five hard-coded location shapes. Those
+/// shapes could only ever find worktrees someone had already thought to
+/// enumerate, and each new agent runtime added a shape (#3649, #3971, and the
+/// #3971 follow-up were all "we missed a location" fixes). Asking git removes
+/// the category: a worktree is discovered because it is REGISTERED, wherever
+/// it sits.
+/// What: for each `<repos_root>/<owner>/<repo>/`, interrogates the two
+/// checkouts trusty-mpm actually provisions — `<repo>` and
+/// `<repo>/.base` — but only after confirming (via [`registry_root_for`]) that
+/// the anchor IS that repository's root. That confirmation is load-bearing:
+/// without it, `git -C <non-repo>` walks UP the filesystem and would report an
+/// unrelated enclosing repository's worktrees. Records that are bare, main, or
+/// already prunable are dropped (there is no working tree to reclaim), as is
+/// any worktree resolving outside `repos_root` — preserving the containment
+/// boundary the old walk had structurally, since it could only ever produce
+/// paths beneath the root it was handed. Results are canonicalized (so they
+/// compare cleanly against the canonicalized active-session set) and returned
+/// sorted and de-duplicated, since both anchors may report the same worktree.
+/// Test: `enumerate_finds_worktree_at_an_unwalked_location`,
+/// `enumerate_finds_worktree_registered_to_base_clone`,
+/// `enumerate_ignores_plain_directory_that_is_not_a_worktree`,
+/// `enumerate_excludes_the_main_checkout`,
+/// `enumerate_excludes_worktrees_outside_the_repos_root`.
+pub(crate) fn enumerate_registered_worktrees(repos_root: &Path) -> Vec<PathBuf> {
+    let canonical_root = std::fs::canonicalize(repos_root).unwrap_or_else(|_| repos_root.into());
+    let mut found: BTreeSet<PathBuf> = BTreeSet::new();
+    let Ok(owner_entries) = std::fs::read_dir(repos_root) else {
+        return Vec::new();
+    };
+    for owner_entry in owner_entries.flatten() {
+        let owner_path = owner_entry.path();
+        if !owner_path.is_dir() {
+            continue;
+        }
+        let Ok(repo_entries) = std::fs::read_dir(&owner_path) else {
+            continue;
+        };
+        for repo_entry in repo_entries.flatten() {
+            let repo_path = repo_entry.path();
+            for anchor in [repo_path.clone(), repo_path.join(BASE_CLONE_DIRNAME)] {
+                collect_from_anchor(&anchor, &canonical_root, &mut found);
+            }
+        }
+    }
+    found.into_iter().collect()
+}
+
+/// Add every reclaimable-shaped worktree registered at `anchor` to `found`.
+///
+/// Why: extracted so [`enumerate_registered_worktrees`]' two anchors share one
+/// rule rather than duplicating the root-confirmation, filtering, and
+/// containment logic — the duplication that let the old walk's five shapes
+/// drift apart from each other.
+/// What: no-ops unless `anchor` is a directory that is ITSELF the root of the
+/// repository owning its registry (see [`registry_root_for`]); then inserts
+/// every non-bare, non-main, non-prunable worktree whose canonicalized path
+/// lies under `canonical_root`.
+/// Test: covered by every `enumerate_*` test.
+fn collect_from_anchor(anchor: &Path, canonical_root: &Path, found: &mut BTreeSet<PathBuf>) {
+    if !anchor.is_dir() {
+        return;
+    }
+    // Confirm the anchor is a repository ROOT, not merely a directory inside
+    // one — otherwise git walks up and reports a foreign repository's registry.
+    let Some(root) = registry_root_for(anchor) else {
+        return;
+    };
+    let canonical_anchor = std::fs::canonicalize(anchor).unwrap_or_else(|_| anchor.into());
+    let canonical_repo_root = std::fs::canonicalize(&root).unwrap_or(root);
+    if canonical_anchor != canonical_repo_root {
+        return;
+    }
+    let Some(worktrees) = list_registered_worktrees(anchor) else {
+        return;
+    };
+    for wt in worktrees {
+        if wt.bare || wt.is_main || wt.prunable {
+            continue;
+        }
+        // #1845 item 8, preserved: a path that cannot be canonicalized is
+        // SKIPPED, never proposed. A dangling symlink, a deletion race, an
+        // unreadable parent, or a stalled mount all make the path unresolvable,
+        // and an unresolvable path cannot be compared against the active-session
+        // set — so proposing it would risk offering a LIVE worktree for
+        // deletion. The asymmetry is deliberate: a failed observation reduces
+        // what this function proposes, and can never enlarge it.
+        let Ok(canonical) = std::fs::canonicalize(&wt.path) else {
+            continue;
+        };
+        if canonical.starts_with(canonical_root) {
+            found.insert(canonical);
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "worktree_registry_tests.rs"]
+mod worktree_registry_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
@@ -68,6 +68,39 @@ fn parse_worktree_list_empty_input_is_empty() {
     assert!(parse_worktree_list("").is_empty());
 }
 
+/// `locked` is git's removal veto and must be read in BOTH spellings the
+/// porcelain format emits — bare, and with an operator-supplied reason.
+#[test]
+fn parse_worktree_list_reads_locked_with_and_without_reason() {
+    let stdout = "\
+worktree /repos/owner/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repos/owner/repo/.worktrees/bare-lock
+HEAD def456
+locked
+
+worktree /repos/owner/repo/.worktrees/lock-with-reason
+HEAD 789abc
+locked keeping this for the postmortem
+
+worktree /repos/owner/repo/.worktrees/unlocked
+HEAD 000111
+";
+    let got = parse_worktree_list(stdout);
+    assert_eq!(got.len(), 4, "one record per stanza; got {got:?}");
+    assert!(got[1].locked, "the bare `locked` line must set the flag");
+    assert!(
+        got[2].locked,
+        "`locked <reason>` must set the flag too, not just the bare word"
+    );
+    assert!(
+        !got[3].locked,
+        "control: a worktree with no `locked` line must not be flagged"
+    );
+}
+
 // ── registry_root_for: the replacement for grandparent inference ─────────
 
 /// A linked worktree resolves to the checkout that REGISTERED it, whatever
@@ -230,12 +263,181 @@ fn enumerate_excludes_the_main_checkout() {
     );
 }
 
-/// A worktree registered to a repo under `repos_root` but living OUTSIDE it is
-/// not enumerated — the containment boundary the old walk had structurally.
+// ── the structural containment boundary (#4224 review, HIGH) ─────────────
+//
+// Deriving from git widened what is SEEN from five path shapes to anything
+// registered under `repos_root`. Replayed against the dogfood machine that
+// admitted five of the operator's own long-lived checkouts, leaving the #3649
+// sentinel as the only thing between enumeration and an unattended
+// `remove_dir_all`. The rule these tests pin is that a candidate must be a
+// STRICT DESCENDANT of the managed project directory whose registry named it.
+//
+// Each test below asserts the negative AND a positive control that must be
+// enumerated in the same call, so none of them can pass because enumeration
+// returned nothing at all — the way this module fails when git rejects a flag
+// or the anchor check regresses.
+
+/// An operator checkout the operator parked at the project-slot position, next
+/// to a managed project, is NOT a reclaim candidate.
 ///
-/// Why: the walk could only ever produce paths beneath the root it was handed.
-/// Git will happily report a worktree parked in `/tmp`; enumerating it would
-/// silently widen the sweep's blast radius beyond the managed workspace root.
+/// Why: this is the live shape the #4224 review measured —
+/// `<owner>/ft-follow-links`, `<owner>/trusty-tools-main-build` and
+/// `<owner>/gb-connect-card` are all real linked worktrees of a managed project
+/// that the operator parked beside it, and all three became enumerable the
+/// moment discovery stopped being shape-based. They are excluded by POSITION:
+/// a candidate must live inside the project that owns it, which no checkout
+/// parked as a sibling can ever satisfy, whatever it is named.
+#[test]
+fn enumerate_excludes_a_sibling_checkout_of_the_same_repo() {
+    let fixture = GitWorktreeFixture::new();
+    let owner_dir = fixture.repo.parent().expect("<repos_root>/<owner>");
+    let sibling = fixture.add_worktree_at(owner_dir, "operator-checkout");
+    // Positive control: an ordinary in-project worktree in the SAME call.
+    let control = fixture.add_worktree("control-session");
+
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical_control = std::fs::canonicalize(&control).unwrap_or_else(|_| control.clone());
+    assert!(
+        found.contains(&canonical_control),
+        "control: an in-project worktree MUST still be enumerated, or this test \
+         proves nothing; got {found:?}"
+    );
+
+    let canonical_sibling = std::fs::canonicalize(&sibling).unwrap_or_else(|_| sibling.clone());
+    assert!(
+        !found.contains(&canonical_sibling),
+        "a checkout parked beside the managed project must never be a reclaim \
+         candidate; got {found:?}"
+    );
+    assert!(sibling.exists(), "the sibling checkout must be untouched");
+}
+
+/// A worktree in a sibling DIRECTORY whose name merely shares a string prefix
+/// with the project is NOT a candidate.
+///
+/// Why: two things at once. It is the live
+/// `<owner>/trusty-tools-worktrees/wt-*` shape — the operator's own worktree
+/// parking lot, three of which the review measured as newly enumerable. And it
+/// is the string-prefix trap: `repo-worktrees` starts with `repo` as a string,
+/// so a containment check written on strings rather than on PATH COMPONENTS
+/// would admit every one of them. `Path::starts_with` is component-wise; this
+/// test is what stops someone "simplifying" it into a `to_string_lossy()`
+/// comparison.
+#[test]
+fn enumerate_excludes_a_worktree_parked_beside_the_project() {
+    let fixture = GitWorktreeFixture::new();
+    let owner_dir = fixture.repo.parent().expect("<repos_root>/<owner>");
+    let parking_lot = owner_dir.join("repo-worktrees");
+    let parked = fixture.add_worktree_at(&parking_lot, "wt-1");
+    let control = fixture.add_worktree("control-session");
+
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical_control = std::fs::canonicalize(&control).unwrap_or_else(|_| control.clone());
+    assert!(
+        found.contains(&canonical_control),
+        "control: an in-project worktree MUST still be enumerated; got {found:?}"
+    );
+
+    let canonical_parked = std::fs::canonicalize(&parked).unwrap_or_else(|_| parked.clone());
+    assert!(
+        !found.contains(&canonical_parked),
+        "`<owner>/repo-worktrees/wt-1` merely shares a string prefix with the \
+         project `<owner>/repo` and must NOT be enumerated; got {found:?}"
+    );
+    assert!(parked.exists(), "the parked worktree must be untouched");
+}
+
+/// Containment is STRICT: a path equal to its own containment boundary is
+/// never a candidate.
+///
+/// Why: the boundary exists so the operator's project checkout can never be
+/// selected, and `starts_with` alone is reflexive — `p.starts_with(p)` is
+/// `true` — so without the explicit `!=` the project directory would satisfy
+/// its own containment test. The ordinary case is masked by the `is_main`
+/// filter, which is exactly why the strictness needs pinning here rather than
+/// through [`enumerate_registered_worktrees`]: `is_main` would keep the
+/// enumeration-level test passing with the `!=` deleted, making it a guard no
+/// test defends. Driving [`collect_from_anchor`] directly lets the boundary be
+/// set to a path that IS in the registry, so the `!=` is the only thing that
+/// can exclude it.
+#[test]
+fn collect_from_anchor_never_yields_the_containment_boundary_itself() {
+    let fixture = GitWorktreeFixture::new();
+    let wt = fixture.add_worktree("session-a");
+    let canonical_wt = std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone());
+    let canonical_root = std::fs::canonicalize(&fixture.repos_root).expect("canonical root");
+    let canonical_repo = std::fs::canonicalize(&fixture.repo).expect("canonical repo");
+
+    // Control: bounded by the real project, the worktree IS collected — so the
+    // exclusion below cannot be attributed to the anchor or the registry.
+    let mut collected = std::collections::BTreeSet::new();
+    collect_from_anchor(
+        &fixture.repo,
+        &canonical_root,
+        &canonical_repo,
+        &mut collected,
+    );
+    assert!(
+        collected.contains(&canonical_wt),
+        "control: bounded by the project, a real in-project worktree must be \
+         collected; got {collected:?}"
+    );
+
+    // Now make the worktree its OWN boundary: it is no longer a STRICT
+    // descendant, and must not be collected.
+    let mut collected = std::collections::BTreeSet::new();
+    collect_from_anchor(
+        &fixture.repo,
+        &canonical_root,
+        &canonical_wt,
+        &mut collected,
+    );
+    assert!(
+        !collected.contains(&canonical_wt),
+        "a path equal to its containment boundary must never be a candidate — \
+         this is what keeps the operator's project checkout unselectable; got \
+         {collected:?}"
+    );
+}
+
+/// A git-`locked` worktree — the operator's explicit "do not remove this" — is
+/// never a candidate.
+///
+/// Why: `decommission::remove_session_worktree` removes with `--force`, which
+/// overrides the lock outright. Refusing to enumerate a locked worktree is the
+/// only place git's own removal veto can still be honoured.
+#[test]
+fn enumerate_excludes_a_locked_worktree() {
+    let fixture = GitWorktreeFixture::new();
+    let locked = fixture.add_worktree("locked-by-operator");
+    fixture.lock_worktree(&locked);
+    let control = fixture.add_worktree("not-locked");
+
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical_control = std::fs::canonicalize(&control).unwrap_or_else(|_| control.clone());
+    assert!(
+        found.contains(&canonical_control),
+        "control: an identically-placed UNLOCKED worktree must be enumerated, so \
+         the exclusion below is attributable to the lock and nothing else; got {found:?}"
+    );
+
+    let canonical_locked = std::fs::canonicalize(&locked).unwrap_or_else(|_| locked.clone());
+    assert!(
+        !found.contains(&canonical_locked),
+        "a git-locked worktree must never be enumerated for reclaim; got {found:?}"
+    );
+}
+
+/// A worktree registered to a repo under `repos_root` but living OUTSIDE it is
+/// not enumerated.
+///
+/// Why: git will happily report a worktree parked in `/tmp`; enumerating it
+/// would put the sweep's blast radius outside the managed workspace entirely.
+/// Since #4224 the strict-descendant rule already rejects this path (a `/tmp`
+/// worktree is not inside the project either), so the `repos_root` check this
+/// test names is now the OUTER of two independent bounds rather than the only
+/// one — it still matters for a project directory that symlinks out of the
+/// managed root, which is the only way the two can disagree.
 #[test]
 fn enumerate_excludes_worktrees_outside_the_repos_root() {
     let fixture = GitWorktreeFixture::new();

--- a/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
@@ -1,0 +1,278 @@
+//! Tests for the git-native worktree registry (#4207 slice 1).
+//!
+//! Why: the module's whole claim is that git — not a path shape — decides what
+//! a worktree is and who owns it, so every test that matters here drives REAL
+//! `git worktree add`. A mocked git would test the mock.
+//! What: the pure porcelain parse, registry-root resolution (the replacement
+//! for grandparent inference), and the enumeration contract — including the
+//! two cases the five-shape walk got wrong.
+//! Test: this file IS the test module.
+
+use super::*;
+
+use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+
+// ── the pure parser ──────────────────────────────────────────────────────
+
+#[test]
+fn parse_worktree_list_reads_porcelain_records() {
+    let stdout = "\
+worktree /repos/owner/repo
+HEAD abc123
+branch refs/heads/main
+
+worktree /repos/owner/repo/.worktrees/session-a
+HEAD def456
+branch refs/heads/session/session-a
+
+worktree /somewhere/detached
+HEAD 0f0f0f
+detached
+
+worktree /repos/owner/repo/.base
+bare
+
+worktree /gone
+HEAD 111111
+prunable gitdir file points to non-existent location
+";
+    let got = parse_worktree_list(stdout);
+    assert_eq!(got.len(), 5, "one record per stanza; got {got:?}");
+
+    assert_eq!(got[0].path, std::path::PathBuf::from("/repos/owner/repo"));
+    assert_eq!(got[0].branch.as_deref(), Some("main"));
+    assert!(got[0].is_main, "git lists the main worktree first");
+
+    assert_eq!(got[1].branch.as_deref(), Some("session/session-a"));
+    assert!(!got[1].is_main);
+
+    assert_eq!(got[2].branch, None, "a detached worktree has no branch");
+    assert!(got[3].bare, "the `bare` attribute line must be read");
+    assert!(
+        got[4].prunable,
+        "`prunable <reason>` must set the flag, not just the bare word"
+    );
+}
+
+#[test]
+fn parse_worktree_list_marks_only_the_first_record_main() {
+    let stdout = "worktree /a\n\nworktree /b\n\nworktree /c\n";
+    let got = parse_worktree_list(stdout);
+    let mains: Vec<_> = got.iter().filter(|w| w.is_main).collect();
+    assert_eq!(mains.len(), 1, "exactly one main record; got {got:?}");
+    assert_eq!(mains[0].path, std::path::PathBuf::from("/a"));
+}
+
+#[test]
+fn parse_worktree_list_empty_input_is_empty() {
+    assert!(parse_worktree_list("").is_empty());
+}
+
+// ── registry_root_for: the replacement for grandparent inference ─────────
+
+/// A linked worktree resolves to the checkout that REGISTERED it, whatever
+/// directory it happens to live in.
+///
+/// Why: this is the fact the grandparent rule was standing in for. The
+/// fixture parks the worktree at `<repo>/.worktrees/<name>`, whose grandparent
+/// coincidentally IS `<repo>` — so this test alone does not distinguish the
+/// two rules. `registry_root_for_ignores_where_the_worktree_is_parked` does.
+#[test]
+fn registry_root_for_linked_worktree_is_the_owning_checkout() {
+    let fixture = GitWorktreeFixture::new();
+    let wt = fixture.add_worktree("session-root-test");
+    let root = registry_root_for(&wt).expect("a real worktree must resolve a registry root");
+    assert_eq!(
+        std::fs::canonicalize(&root).unwrap_or(root),
+        std::fs::canonicalize(&fixture.repo).unwrap_or_else(|_| fixture.repo.clone()),
+    );
+}
+
+/// The owning checkout is resolved from git's registry, NOT from the
+/// candidate's position on disk — the #4207 defect stated as a test.
+///
+/// Why: fourteen worktrees on this machine live under `<repo>/.base/…` but are
+/// registered to `<repo>`. Grandparent inference answered `.base`, which
+/// disowns them, and every downstream git call was then aimed at the wrong
+/// repository. Here the worktree is parked three levels deep in a directory
+/// with no relationship to the owning repo, so the grandparent of the
+/// candidate is emphatically not its root.
+#[test]
+fn registry_root_for_ignores_where_the_worktree_is_parked() {
+    let fixture = GitWorktreeFixture::new();
+    let parked = fixture.add_worktree_at(
+        &fixture.repo.join("deeply").join("nested").join("elsewhere"),
+        "parked",
+    );
+    let grandparent = parked
+        .parent()
+        .and_then(|p| p.parent())
+        .expect("candidate has a grandparent");
+    assert_ne!(
+        grandparent,
+        fixture.repo.as_path(),
+        "test invariant: the grandparent must NOT be the owning checkout, or \
+         this test cannot distinguish the two rules"
+    );
+
+    let root = registry_root_for(&parked).expect("registry root");
+    assert_eq!(
+        std::fs::canonicalize(&root).unwrap_or(root),
+        std::fs::canonicalize(&fixture.repo).unwrap_or_else(|_| fixture.repo.clone()),
+        "the owning checkout must be derived from git, not from the path shape"
+    );
+}
+
+#[test]
+fn registry_root_for_non_repo_is_none() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(
+        registry_root_for(tmp.path()).is_none(),
+        "a directory outside any repository must resolve to None, never a guess"
+    );
+}
+
+// ── list_registered_worktrees ────────────────────────────────────────────
+
+#[test]
+fn list_registered_worktrees_reports_a_real_worktree() {
+    let fixture = GitWorktreeFixture::new();
+    let wt = fixture.add_worktree("listed");
+    // Anchor on the WORKTREE itself, which is how `git_worktree_list_agrees`
+    // now calls this — git resolves the repository from the candidate.
+    let listed = list_registered_worktrees(&wt).expect("list");
+    let canonical_wt = std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone());
+    assert!(
+        listed.iter().any(
+            |w| std::fs::canonicalize(&w.path).unwrap_or_else(|_| w.path.clone()) == canonical_wt
+        ),
+        "the worktree must appear in its own repository's registry; got {listed:?}"
+    );
+}
+
+#[test]
+fn list_registered_worktrees_none_outside_a_repo() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(
+        list_registered_worktrees(tmp.path()).is_none(),
+        "an unanswerable probe must be None, never an empty list that reads as \
+         `no worktrees exist`"
+    );
+}
+
+// ── enumerate_registered_worktrees ───────────────────────────────────────
+
+/// THE #4207 slice-1 regression test: a registered worktree at a location NONE
+/// of the five hard-coded shapes covered is discovered.
+///
+/// Why: the removed walk probed `.worktrees/`, `.base/.worktrees/`,
+/// `.claude/worktrees/`, `.base/.claude/worktrees/`, and
+/// `.base/.worktrees/<id>/.claude/worktrees/`. This worktree sits at
+/// `<repo>/agents/scratch/wt-1`, which matches none of them, so the walk
+/// returned it under no circumstances. Reverting `find_orphaned_worktrees` to
+/// the shape walk makes this test fail.
+#[test]
+fn enumerate_finds_worktree_at_an_unwalked_location() {
+    let fixture = GitWorktreeFixture::new();
+    let parked = fixture.add_worktree_at(&fixture.repo.join("agents").join("scratch"), "wt-1");
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical = std::fs::canonicalize(&parked).unwrap_or_else(|_| parked.clone());
+    assert!(
+        found.contains(&canonical),
+        "a registered worktree must be found wherever it lives; got {found:?}"
+    );
+}
+
+/// The `.base` bare clone is the SECOND registry a managed project can own,
+/// and worktrees registered to it must be enumerated too.
+#[test]
+fn enumerate_finds_worktree_registered_to_base_clone() {
+    let fixture = GitWorktreeFixture::new();
+    let wt = fixture.add_base_clone_worktree("session-in-base");
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical = std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone());
+    assert!(
+        found.contains(&canonical),
+        "a worktree registered to the .base clone must be enumerated; got {found:?}"
+    );
+}
+
+/// A plain directory sitting in a worktree-shaped location is NOT a worktree
+/// and must not be proposed as a reclaim candidate.
+///
+/// Why: this is the deliberate narrowing derive-not-walk buys. The old walk
+/// collected any leaf directory under a `.worktrees/` parent, so a `mkdir`
+/// was indistinguishable from a checkout git actually created.
+#[test]
+fn enumerate_ignores_plain_directory_that_is_not_a_worktree() {
+    let fixture = GitWorktreeFixture::new();
+    let fake = fixture.repo.join(".worktrees").join("just-a-mkdir");
+    std::fs::create_dir_all(&fake).expect("mkdir");
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical = std::fs::canonicalize(&fake).unwrap_or_else(|_| fake.clone());
+    assert!(
+        !found.contains(&canonical),
+        "a plain directory is not a registered worktree; got {found:?}"
+    );
+}
+
+/// The main checkout is never a reclaim candidate.
+#[test]
+fn enumerate_excludes_the_main_checkout() {
+    let fixture = GitWorktreeFixture::new();
+    fixture.add_worktree("some-session");
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical_repo =
+        std::fs::canonicalize(&fixture.repo).unwrap_or_else(|_| fixture.repo.clone());
+    assert!(
+        !found.contains(&canonical_repo),
+        "the main checkout must never be enumerated for reclaim; got {found:?}"
+    );
+}
+
+/// A worktree registered to a repo under `repos_root` but living OUTSIDE it is
+/// not enumerated — the containment boundary the old walk had structurally.
+///
+/// Why: the walk could only ever produce paths beneath the root it was handed.
+/// Git will happily report a worktree parked in `/tmp`; enumerating it would
+/// silently widen the sweep's blast radius beyond the managed workspace root.
+#[test]
+fn enumerate_excludes_worktrees_outside_the_repos_root() {
+    let fixture = GitWorktreeFixture::new();
+    let outside_parent = tempfile::tempdir().expect("tempdir");
+    let outside = fixture.add_worktree_at(outside_parent.path(), "far-away");
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical = std::fs::canonicalize(&outside).unwrap_or_else(|_| outside.clone());
+    assert!(
+        !found.contains(&canonical),
+        "a worktree outside the managed repos root must not be enumerated; got {found:?}"
+    );
+}
+
+/// A registered worktree whose DIRECTORY is gone is never proposed.
+///
+/// Why: the asymmetry this module commits to is that a failed observation may
+/// only ever SHRINK what is proposed for deletion, never enlarge it. A path
+/// that will not resolve cannot be compared against the active-session set, so
+/// offering it would risk offering a live worktree. Here the directory is
+/// removed behind git's back — git still lists the entry (as `prunable`) and
+/// the path no longer canonicalizes — and neither route may yield a candidate.
+#[test]
+fn enumerate_ignores_a_worktree_whose_directory_is_gone() {
+    let fixture = GitWorktreeFixture::new();
+    let wt = fixture.add_worktree("vanished");
+    let canonical = std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone());
+    std::fs::remove_dir_all(&wt).expect("remove the worktree directory");
+
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    assert!(
+        !found.contains(&canonical),
+        "a worktree with no directory left is not a deletion candidate; got {found:?}"
+    );
+}
+
+#[test]
+fn enumerate_missing_repos_root_is_empty() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    assert!(enumerate_registered_worktrees(&tmp.path().join("nope")).is_empty());
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
@@ -350,16 +350,24 @@ fn enumerate_excludes_a_worktree_parked_beside_the_project() {
 /// Containment is STRICT: a path equal to its own containment boundary is
 /// never a candidate.
 ///
-/// Why: the boundary exists so the operator's project checkout can never be
-/// selected, and `starts_with` alone is reflexive — `p.starts_with(p)` is
-/// `true` — so without the explicit `!=` the project directory would satisfy
-/// its own containment test. The ordinary case is masked by the `is_main`
-/// filter, which is exactly why the strictness needs pinning here rather than
-/// through [`enumerate_registered_worktrees`]: `is_main` would keep the
-/// enumeration-level test passing with the `!=` deleted, making it a guard no
-/// test defends. Driving [`collect_from_anchor`] directly lets the boundary be
-/// set to a path that IS in the registry, so the `!=` is the only thing that
-/// can exclude it.
+/// Why: `starts_with` alone is reflexive — `p.starts_with(p)` is `true` — so
+/// without the explicit `!=` a path equal to the boundary satisfies its own
+/// containment test.
+///
+/// Scope honestly: on every topology observed today it is `is_main`, NOT this
+/// `!=`, that keeps the operator's project checkout unselectable — git lists a
+/// project's own root as the main record, and main records are already
+/// filtered. Zero instances on this machine reach the `!=`. It is kept as
+/// defence in depth for the case `is_main` does not cover: a project directory
+/// that is itself a NON-main linked worktree of some other registry being
+/// interrogated, which is reachable in principle and would otherwise put the
+/// operator's checkout on a deletion list.
+///
+/// That same masking is why the strictness is pinned HERE rather than through
+/// [`enumerate_registered_worktrees`] — an enumeration-level test would keep
+/// passing with the `!=` deleted, making it a guard no test defends. Driving
+/// [`collect_from_anchor`] directly lets the boundary be set to a path that IS
+/// in the registry, so the `!=` is the only thing that can exclude it.
 #[test]
 fn collect_from_anchor_never_yields_the_containment_boundary_itself() {
     let fixture = GitWorktreeFixture::new();
@@ -403,9 +411,14 @@ fn collect_from_anchor_never_yields_the_containment_boundary_itself() {
 /// A git-`locked` worktree — the operator's explicit "do not remove this" — is
 /// never a candidate.
 ///
-/// Why: `decommission::remove_session_worktree` removes with `--force`, which
-/// overrides the lock outright. Refusing to enumerate a locked worktree is the
-/// only place git's own removal veto can still be honoured.
+/// Why: NOT because `--force` overrides the lock — it does not. Git refuses a
+/// single `--force` on a locked worktree (exit 128, "use 'remove -f -f' to
+/// override or unlock first") and leaves the directory intact. The problem is
+/// that `decommission::remove_session_worktree` reads that refusal as a generic
+/// git failure and falls back to `std::fs::remove_dir_all`, deleting the
+/// directory anyway and orphaning git's registry entry. So the veto is defeated
+/// through the error path, and never enumerating a locked worktree is the only
+/// place it survives.
 #[test]
 fn enumerate_excludes_a_locked_worktree() {
     let fixture = GitWorktreeFixture::new();

--- a/crates/trusty-mpm/src/session_manager/worktree_safety.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_safety.rs
@@ -680,7 +680,7 @@ pub(super) fn git_stdout(dir: &Path, args: &[&str]) -> Result<String, String> {
 /// removed from the child environment.
 /// Test: `git_command_strips_repository_redirecting_env`,
 /// `git_command_pins_untracked_and_excludes_config`.
-fn git_command(dir: &Path, args: &[&str]) -> Command {
+pub(super) fn git_command(dir: &Path, args: &[&str]) -> Command {
     let mut cmd = Command::new("git");
     cmd.args(GIT_PINNED_GLOBAL_ARGS)
         .arg("-C")
@@ -737,43 +737,39 @@ pub(crate) fn dirt_blocks_removal(
 /// LOOKS like a worktree (e.g. its git worktree entry was already pruned by
 /// something else, or the shape matched by coincidence). A disagreement is
 /// treated conservatively: skip rather than delete.
-/// What: runs `git -C <repo_root> worktree list --porcelain`, where
-/// `repo_root` is `candidate`'s grandparent directory — the SAME derivation
-/// `decommission::remove_session_worktree` uses, which works identically for
-/// both worktree-store shapes (`<repo>/.worktrees/<name>` and
-/// `<repo>/.base/.worktrees/<id>`, since either way the grandparent of the
-/// worktree leaf is the git checkout root). Returns `true` (agree — deletion
-/// may proceed, subject to the caller's other checks) when the git command
-/// cannot be run or fails outright — this check is an ADDITIONAL safety net
-/// on top of the sentinel/store checks, not a replacement for them, so a
-/// missing `git` binary or a transient failure never blocks a deletion those
-/// checks already approved. It is emphatically NOT the fail-safe gate; that
-/// role belongs to [`inspect_dirt`], which fails toward DIRTY. Returns `true`
-/// only when `candidate`'s canonicalized path appears among the porcelain
-/// output's `worktree <path>` lines.
+/// What (rebuilt git-native, #4207): asks the CANDIDATE'S OWN repository —
+/// `git -C <candidate> worktree list --porcelain` — rather than a repository
+/// guessed from the candidate's grandparent directory. The grandparent rule
+/// was an inference, not a fact, and it was wrong in both directions: for
+/// `<repo>/.claude/worktrees/<name>` it named `<repo>/.claude`, which is not a
+/// repository at all, and for the fourteen worktrees living under
+/// `<repo>/.base/.worktrees/` but REGISTERED to the parent repo `<repo>` it
+/// named `.base`, which correctly disowned them — so this check returned
+/// `false` for every one of them and the sweep skipped them conservatively,
+/// forever. Git resolves the owning repository from the candidate itself, so
+/// the answer no longer depends on where the worktree is parked.
+///
+/// Returns `true` (agree — deletion may proceed, subject to the caller's other
+/// checks) when the probe cannot be answered at all: this check is an
+/// ADDITIONAL safety net on top of the sentinel/store checks, not a
+/// replacement for them, so a missing `git` binary or a transient failure
+/// never blocks a deletion those checks already approved. It is emphatically
+/// NOT the fail-safe gate; that role belongs to [`inspect_dirt`], which fails
+/// toward DIRTY. Returns `true` only when `candidate`'s canonicalized path
+/// appears among the registered worktrees.
 /// Test: `git_worktree_list_agrees_true_for_real_worktree`,
-///       `git_worktree_list_agrees_false_for_untracked_dir`.
+///       `git_worktree_list_agrees_false_for_untracked_dir`,
+///       `git_worktree_list_agrees_true_for_worktree_registered_to_parent_repo`
+///       (#4207 — fails against the grandparent rule).
 pub(crate) fn git_worktree_list_agrees(candidate: &Path) -> bool {
-    let Some(repo_root) = candidate.parent().and_then(|p| p.parent()) else {
-        return true;
+    let Some(worktrees) = super::worktree_registry::list_registered_worktrees(candidate) else {
+        return true; // best-effort: an unanswerable probe must never block a delete
     };
-    let out = git_command(repo_root, &["worktree", "list", "--porcelain"]).output();
-    let Ok(out) = out else {
-        return true; // best-effort: git unavailable must never block a delete
-    };
-    if !out.status.success() {
-        return true;
-    }
-    let stdout = String::from_utf8_lossy(&out.stdout);
     let canonical_candidate =
         std::fs::canonicalize(candidate).unwrap_or_else(|_| candidate.to_path_buf());
-    stdout
-        .lines()
-        .filter_map(|l| l.strip_prefix("worktree "))
-        .any(|p| {
-            let pb = PathBuf::from(p);
-            std::fs::canonicalize(&pb).unwrap_or(pb) == canonical_candidate
-        })
+    worktrees
+        .into_iter()
+        .any(|wt| std::fs::canonicalize(&wt.path).unwrap_or(wt.path) == canonical_candidate)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## What

Worktree **discovery** and worktree **ownership** were both inferences. This
replaces each with the fact git already maintains.

| Question | Before | After |
| --- | --- | --- |
| Where are the worktrees? | walk five hard-coded location shapes | `git worktree list --porcelain` |
| Which checkout owns this one? | the candidate's **grandparent directory** | `git rev-parse --git-common-dir` |

Slice 1 of #4207, plus the half of slice 2 that PR #4209 does not touch (see
"Relationship to #4209" below).

## Why the grandparent rule made 14 worktrees structurally unreclaimable

Observed on the dogfood machine 2026-07-27: fourteen worktrees live under
`<repo>/.base/.worktrees/` but are **registered to the parent repo** `<repo>`.
The old rule derived the owning checkout as the candidate's grandparent —
`<repo>/.base` — which is a *real* repository that correctly disowns them. So
`git_worktree_list_agrees` returned `false`, the reclaim path skipped them
conservatively, and it did so on every sweep, forever. No amount of adding a
sixth location shape would have fixed it, because the location was never the
problem.

The same rule is wrong for `<repo>/.claude/worktrees/<name>`, where the
grandparent is `<repo>/.claude` — not a repository at all.

## Why the five-shape walk had to go rather than gain a sixth shape

`.worktrees/`, `.base/.worktrees/`, `.claude/worktrees/`,
`.base/.claude/worktrees/`, `.base/.worktrees/<id>/.claude/worktrees/` — each
arrived as a bug report about a location the previous list had missed (#3649,
#3971, and the #3971 follow-up). Nothing stops git from registering a worktree
anywhere on disk, so the list could never be complete. Asking git deletes the
category of bug.

## An unanswerable probe is never a verdict

Every function in the new module returns `Option`, never `bool`, for "could not
determine". No caller can read a missing `git` binary, a permissions error, or
a stalled mount as a fact about a worktree — the invariant is in the type.

This is deliberately the shape PR #4202's round-1 fix broke by collapsing every
`canonicalize()` error kind into `Destroyed`; on 2026-07-21 a rule that loose
would have told an operator to recreate ~70 fully intact worktrees. The
asymmetry here is absolute in the safe direction: a candidate that will not
canonicalize is **skipped**, so a failed observation can only ever *shrink*
what is proposed for deletion, never enlarge it
(`enumerate_ignores_a_worktree_whose_directory_is_gone`).

No alarm, latch, or give-up path is added — the correct way not to ship an
unlatched alarm (PR #4202's second defect) is not to add one.

## Blast radius is unchanged

Git will happily report a worktree parked in `/tmp`. Enumeration keeps the
containment boundary the old walk had *structurally* — it could only ever
produce paths beneath the root it was handed — as an explicit, tested rule
(`enumerate_excludes_worktrees_outside_the_repos_root`). The main checkout,
bare records, and already-prunable entries are excluded. All existing gates are
untouched and still run in order: the #3649 ownership sentinel, the
`git worktree list` cross-check, and the #4091/#4118 dirty-tree guard.

## What this narrows, deliberately

A directory git does **not** register is no longer a candidate. The old walk
collected any leaf directory under a `.worktrees/` parent, so a stray `mkdir`
was indistinguishable from a checkout git created.

Such husks were **already** unreclaimable — `git_worktree_list_agrees` refused
every one of them — so no reclaim behaviour regresses. What changes is that
they are also absent from the *report*. Reclaiming unregistered husks is a
separate concern (#3715), deliberately not smuggled in here.

## `is_session_worktree()` and `is_dir()` — left alone, on purpose

PR #4209 argues they answer *"may trusty-mpm DELETE this?"* (ownership) on
paths that may legitimately be absent, and that teaching them about `.git`
would make `decommission` and `search_gc` refuse to clean up the very husks
#4204 is about. That argument is correct, and this PR does not touch either.

## Relationship to #4209

Complementary, not competing, and they do not overlap by file.

- **#4209** is the *liveness* half: is this workspace safe to WRITE INTO?
  It owns `core/workspace_liveness.rs`, `agent_reset_workspace.rs`, and
  `guided_inplace.rs`.
- **This PR** is the *derivation* half: what IS a worktree and WHO owns it?
  It owns `session_manager/worktree_registry.rs`, `prune.rs`,
  `worktree_safety.rs`, and `decommission.rs`.

Landing order does not matter.

## Tests

Net **-651 / +946** in the diff, but the production walk shrinks from ~120
lines to 4; the growth is the new module's docs and its real-git tests. Seven
shape-coverage tests collapse into two location-agnostic ones, because location
is no longer something the code reasons about.

Every worktree in the affected tests is now a real `git worktree add`. The
previous `mkdir` fixtures would now pass **vacuously** — asserting an empty list
against an empty list — so each converted test also asserts the candidate
actually reaches the gate under test.

### Revert-proofs (both verified by temporarily restoring the old rule)

**1. `git_worktree_list_agrees_true_for_worktree_registered_to_parent_repo`** —
restore `candidate.parent().and_then(|p| p.parent())`:

```
panicked at prune_orphan_tests.rs:616:
a worktree registered to the PARENT repo but living under .base must be
recognised — asking the grandparent (.base) disowns it
test result: FAILED. 2 passed; 1 failed
```

The 2 that still pass are the two pre-existing `git_worktree_list_agrees`
tests — in both, the grandparent *happens* to be the owning repository, which
is exactly why neither could ever catch this. The test asserts up front that
the grandparent is itself a real repository, so the old code cannot pass by
falling through its best-effort `true`.

**2. `find_orphaned_worktrees_discovers_worktree_at_unwalked_location`** —
restore the five-shape walk:

```
panicked at prune_orphan_tests.rs:201:
a registered worktree must be found wherever it lives; got []

panicked at prune_orphan_tests.rs:221:
a plain directory is not a registered worktree; got [".../.worktrees/just-a-mkdir"]
test result: FAILED. 0 passed; 2 failed
```

## Verification

- `cargo clippy --workspace --all-targets --exclude {3 gui crates} -- -D warnings` → **exit 0**
- `cargo fmt --all --check` → clean
- `scripts/check_line_cap.sh` → `7 allowlisted, 0 violations — OK`
- `cargo test --workspace --exclude {3 gui crates} --no-fail-fast` →
  **194 suites, 19707 passed, 5 failed, 132 ignored**

All 5 failures are in `trusty-agents`, a crate this PR does not touch, and none
is a code failure:

- 4 × `tests/api_e2e.rs` — `api server did not become healthy … within 5s`
  (host at load average ~110 with ~8 concurrent agents)
- 1 × `tools::python_skill` — `uv` could not inspect the Python interpreter
  (`ENOENT` on `.cache/uv/.tmp*`)

`trusty-mpm` itself: **0 failures**, no `#[ignore]`, no cfg-gates, no
`--exclude` beyond CI's own three GUI crates, and never `--lib`-only.

Refs #4207 (slice 1 + the ownership half of slice 2)
Fixes the underlying defect of #4204

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
