### PR TITLE
fix(trusty-memory,trusty-mpm): make doctor observe worker liveness, not process liveness

### DIFF
--- a/crates/trusty-memory/CHANGELOG.md
+++ b/crates/trusty-memory/CHANGELOG.md
@@ -8,6 +8,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`/health` now reports live worker-pool occupancy (issue #4001).** The
+  payload carries a `worker` block — `in_flight`, `oldest_age_secs`, and a
+  `wedged` verdict — and the top-level `status` becomes `"wedged"` when the
+  oldest in-flight palace operation has outlived
+  `TRUSTY_WEDGE_THRESHOLD_SECS` (default: twice `open_queue_timeout()`).
+  Backed by a new `worker_liveness` module: a fixed-size, lock-free slot table
+  of operation start timestamps, registered from `open_palace_handle` (the
+  choke point every `memory_recall` / `memory_remember` passes through, and
+  where the #3992 wedge actually occurred). One CAS in and one store out per
+  operation, no allocation and no syscall on the hot path, so the gauge cannot
+  become the load problem it exists to detect. Registration is RAII, so the
+  `?` and panic paths release it as reliably as the success path.
+
+### Fixed
+
+- **`trusty-memory doctor` no longer reports HEALTHY while the daemon is
+  wedged (issue #4001).** During the #3992 incident six threads sat parked in
+  `concurrent_open::backoff_sleep_ms` with a `memory_remember` hung ~1800 s,
+  and doctor reported healthy throughout — it checked HTTP liveness, fastembed
+  cache state, and lock-file staleness, none of which can observe a wedged
+  worker pool. The daemon-health check now reads the `/health` body and fails
+  on a reported wedge, naming the age and in-flight count.
+
+- **`trusty-memory doctor` distinguishes "could not determine" from "down"
+  (issue #4005).** New `CheckStatus::Unknown`, rendered `❔` and counted in its
+  own summary column rather than folded into `passed`. A probe that times out
+  now reports Unknown instead of a hard failure, and a 2xx whose body carries
+  no worker observation (an older daemon, or an unreadable body) is Unknown
+  rather than a pass doctor cannot support. The `/health` probe budget also
+  rose from 2 s to 10 s: the default handler samples RSS/CPU behind a mutex and
+  enumerates open file descriptors, work the MCP request path never does, so
+  under load it could miss a 2 s budget that real traffic never approached.
+
 ---
 
 ## [0.22.0] — 2026-07-27

--- a/crates/trusty-memory/src/commands/doctor/checks.rs
+++ b/crates/trusty-memory/src/commands/doctor/checks.rs
@@ -15,6 +15,22 @@ use std::time::Duration;
 
 use super::CheckResult;
 
+/// Per-request budget for the `/health` probe.
+///
+/// Why (issue #4005): the old budget was 2 s, and on 2026-07-26 that produced
+/// a hard "unreachable" verdict against a daemon whose MCP surface was
+/// verifiably serving `memory_recall` / `memory_remember` in the same minutes.
+/// The default `/health` handler is cheap but not free — it samples process
+/// RSS/CPU through a `tokio::Mutex` and enumerates the process's open file
+/// descriptors, neither of which is on the MCP request path. Under load those
+/// can exceed 2 s while ordinary MCP calls sail through, so the probe was
+/// measuring its own impatience rather than the daemon's health. 10 s is
+/// comfortably above the observed worst case while still bounding the check.
+/// The budget is only half the fix: a timeout now yields
+/// [`super::CheckStatus::Unknown`] instead of a false failure.
+/// Test: `slow_but_serving_daemon_is_not_reported_unreachable`.
+const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
 /// Verify the fastembed model cache exists and is readable.
 ///
 /// Why: GH #58/#62 — when the daemon can't reach a writable cache path it
@@ -143,13 +159,14 @@ pub async fn check_daemon_health() -> CheckResult {
     let label = "HTTP daemon".to_string();
 
     // Build a reusable reqwest client for the probes below.
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-    {
+    let client = match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
         Ok(c) => c,
         Err(e) => return CheckResult::fail(label, format!("could not build HTTP client: {e}")),
     };
+
+    // Issue #4005: set when any probe times out (as opposed to being refused).
+    // A timeout means we learned nothing; a refusal means nothing is there.
+    let mut timed_out = false;
 
     // Primary probe: use the recorded addr file when present.
     let recorded_url = match trusty_common::read_daemon_addr("trusty-memory") {
@@ -174,7 +191,13 @@ pub async fn check_daemon_health() -> CheckResult {
         let url = format!("{base}/health");
         match client.get(&url).send().await {
             Ok(resp) if resp.status().is_success() => {
-                return CheckResult::pass(label, format!("{} → {}", url, resp.status()));
+                let status = resp.status();
+                // Issue #4001: a 2xx proves the LISTENER is alive, nothing
+                // more. Read what the daemon actually reported about its
+                // worker pool before calling this a pass — during #3992 this
+                // exact branch returned Pass while every worker was parked.
+                let body = resp.json::<serde_json::Value>().await.ok();
+                return interpret_health_body(label, &url, status.as_u16(), body.as_ref());
             }
             Ok(resp) => {
                 // Non-2xx from the recorded addr: continue to fallback.
@@ -183,11 +206,18 @@ pub async fn check_daemon_health() -> CheckResult {
                     resp.status()
                 );
             }
-            Err(_) => {
-                // Connection refused or timeout: recorded addr is stale.
-                // Continue to default-port fallback below.
+            Err(e) => {
+                // Issue #4005: a TIMEOUT is not the same as a refusal. A
+                // refused connection proves nothing is listening; a timeout
+                // proves only that the daemon did not answer within OUR
+                // budget, which a busy-but-healthy daemon can miss. Remember
+                // which one happened so the terminal verdict below can be
+                // honest rather than defaulting to "unreachable".
+                if e.is_timeout() {
+                    timed_out = true;
+                }
                 tracing::debug!(
-                    "doctor: recorded addr {url} unreachable (stale?); trying fallback ports"
+                    "doctor: recorded addr {url} did not answer ({e}); trying fallback ports"
                 );
             }
         }
@@ -203,29 +233,48 @@ pub async fn check_daemon_health() -> CheckResult {
         let url = format!("http://127.0.0.1:{port}/health");
         match client.get(&url).send().await {
             Ok(resp) if resp.status().is_success() => {
-                let note = if recorded_url.is_some() {
-                    format!(
-                        "{url} → {} (addr file was stale — daemon is live on fallback port {port})",
-                        resp.status()
-                    )
+                let status = resp.status();
+                let origin = if recorded_url.is_some() {
+                    "addr file was stale — daemon is live on fallback port"
                 } else {
-                    format!(
-                        "{url} → {} (no addr file; found daemon on default port {port})",
-                        resp.status()
-                    )
+                    "no addr file; found daemon on default port"
                 };
-                return CheckResult::pass(label, note);
+                let body = resp.json::<serde_json::Value>().await.ok();
+                let note_url = format!("{url} ({origin} {port})");
+                return interpret_health_body(label, &note_url, status.as_u16(), body.as_ref());
+            }
+            Err(e) if e.is_timeout() => {
+                timed_out = true;
+                continue;
             }
             _ => continue,
         }
     }
 
-    // All probes failed.
+    // Every probe came back empty. Issue #4005: distinguish "nothing is
+    // listening anywhere" (a real, actionable failure) from "something was
+    // listening but never answered in time" (we simply do not know). Only the
+    // former justifies telling the operator to start the daemon — the latter
+    // used to produce that same advice and send them down the wrong path while
+    // a perfectly healthy daemon served MCP traffic beside them.
+    if timed_out {
+        return CheckResult::unknown(
+            label,
+            format!(
+                "no /health response within {}s on the recorded address or ports 7070-7079, \
+                 but at least one probe TIMED OUT rather than being refused — the daemon may be \
+                 alive and slow. Could not determine health. Re-run when load subsides, or check \
+                 the MCP surface directly before restarting anything.",
+                PROBE_TIMEOUT.as_secs()
+            ),
+        );
+    }
+
     if recorded_url.is_some() {
         CheckResult::fail(
             label,
-            "recorded address unreachable and no daemon found on default ports 7070-7079 \
-             — start with `trusty-memory service start`"
+            "recorded address unreachable (connection refused) and no daemon found on default \
+             ports 7070-7079 — start with `trusty-memory service start`"
                 .to_string(),
         )
     } else {
@@ -236,6 +285,117 @@ pub async fn check_daemon_health() -> CheckResult {
                 .to_string(),
         )
     }
+}
+
+/// Turn a 2xx `/health` payload into a verdict (issues #4001, #4005).
+///
+/// Why: this function is the fix's thesis in one place. A 2xx from `/health`
+/// proves that a listener accepted a socket and returned bytes — it does not
+/// prove the daemon is doing work. Doctor used to stop at the status code,
+/// which is how #3992 stayed green for the length of an incident. The body now
+/// carries an observation of the worker pool, and this maps that observation
+/// to a status, keeping "observed healthy" separate from "could not determine".
+/// What: `Fail` when the daemon reports a wedged worker pool, `Warn` when it
+/// reports `degraded` or is still warming up, `Unknown` when the body is
+/// missing or unparseable (a 2xx with no readable body tells us nothing about
+/// the workers), and `Pass` only when the daemon positively reported a healthy
+/// worker pool.
+/// Test: `wedged_body_is_fail`, `warming_body_is_warn`,
+/// `unparseable_body_is_unknown`, `healthy_body_is_pass`.
+pub(super) fn interpret_health_body(
+    label: String,
+    url: &str,
+    status: u16,
+    body: Option<&serde_json::Value>,
+) -> CheckResult {
+    let Some(body) = body else {
+        return CheckResult::unknown(
+            label,
+            format!(
+                "{url} → {status}, but the response body could not be read or parsed. The \
+                 listener is up; whether its workers are making progress is UNKNOWN."
+            ),
+        );
+    };
+
+    // Worker-pool observation (issue #4001) — the signal that would have
+    // caught #3992. Checked first: a wedge outranks every other reading.
+    let worker = body.get("worker");
+    let wedged = worker
+        .and_then(|w| w.get("wedged"))
+        .and_then(serde_json::Value::as_bool);
+    let oldest = worker
+        .and_then(|w| w.get("oldest_age_secs"))
+        .and_then(serde_json::Value::as_u64);
+    let in_flight = worker
+        .and_then(|w| w.get("in_flight"))
+        .and_then(serde_json::Value::as_u64);
+
+    match wedged {
+        Some(true) => {
+            return CheckResult::fail(
+                label,
+                format!(
+                    "{url} → {status} BUT the daemon reports a WEDGED worker pool: oldest \
+                     in-flight palace operation has been running {}s with {} in flight. The \
+                     HTTP listener answering does not mean writes are progressing (issue \
+                     #3992). Inspect with a thread sample before restarting.",
+                    oldest.unwrap_or_default(),
+                    in_flight.unwrap_or_default()
+                ),
+            );
+        }
+        None => {
+            // No `worker` block: an older daemon build. Say so rather than
+            // silently reporting a pass we cannot actually support.
+            return CheckResult::unknown(
+                label,
+                format!(
+                    "{url} → {status}, but this daemon does not report worker-pool occupancy \
+                     (pre-#4001 build). Liveness is confirmed; whether workers are making \
+                     progress is UNKNOWN. Upgrade the daemon to get a real answer."
+                ),
+            );
+        }
+        Some(false) => {}
+    }
+
+    let daemon_state = body.get("daemon_state").and_then(|v| v.as_str());
+    let reported = body.get("status").and_then(|v| v.as_str());
+
+    // Issue #4005: a warming daemon is a normal post-restart state, not a
+    // failure. It is also not fully healthy, so it warns rather than passes.
+    if daemon_state == Some("warming") {
+        return CheckResult::warn(
+            label,
+            format!(
+                "{url} → {status}, daemon is WARMING UP (embedder still initialising). This is \
+                 normal shortly after a restart — recall falls back to the non-embedder path \
+                 until it finishes."
+            ),
+        );
+    }
+
+    if reported == Some("degraded") {
+        let detail = body
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .unwrap_or("no detail reported");
+        return CheckResult::warn(
+            label,
+            format!("{url} → {status}, daemon reports DEGRADED: {detail}"),
+        );
+    }
+
+    let occupancy = match (in_flight, oldest) {
+        (Some(n), Some(secs)) => format!(", {n} in flight, oldest {secs}s"),
+        (Some(n), None) => format!(", {n} in flight"),
+        _ => String::new(),
+    };
+    CheckResult::pass(
+        label,
+        format!("{url} → {status}, workers progressing{occupancy}"),
+    )
 }
 
 /// Scan the data directory for stray `*.lock` files left over from a

--- a/crates/trusty-memory/src/commands/doctor/checks.rs
+++ b/crates/trusty-memory/src/commands/doctor/checks.rs
@@ -27,8 +27,11 @@ use super::CheckResult;
 /// measuring its own impatience rather than the daemon's health. 10 s is
 /// comfortably above the observed worst case while still bounding the check.
 /// The budget is only half the fix: a timeout now yields
-/// [`super::CheckStatus::Unknown`] instead of a false failure.
-/// Test: `slow_but_serving_daemon_is_not_reported_unreachable`.
+/// [`super::CheckStatus::Unknown`] instead of a false failure. The
+/// slow-but-serving case is covered end-to-end against a real listener by
+/// `trusty-mpm`'s `memory_slow_but_serving_daemon_is_ok`, which exercises the
+/// same timeout/refusal split from the `tm doctor` side.
+/// Test: `check_daemon_health_fails_cleanly_with_stale_addr_and_no_listener`.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Verify the fastembed model cache exists and is readable.
@@ -301,7 +304,9 @@ pub async fn check_daemon_health() -> CheckResult {
 /// the workers), and `Pass` only when the daemon positively reported a healthy
 /// worker pool.
 /// Test: `wedged_body_is_fail`, `warming_body_is_warn`,
-/// `unparseable_body_is_unknown`, `healthy_body_is_pass`.
+/// `indeterminate_probe_renders_as_unknown_not_pass`,
+/// `body_without_worker_block_is_unknown`, `healthy_body_is_pass`,
+/// `degraded_body_is_warn`.
 pub(super) fn interpret_health_body(
     label: String,
     url: &str,

--- a/crates/trusty-memory/src/commands/doctor/mod.rs
+++ b/crates/trusty-memory/src/commands/doctor/mod.rs
@@ -48,6 +48,20 @@ pub(super) enum CheckStatus {
     Pass,
     Warn,
     Fail,
+    /// The probe could not determine the answer (issue #4005).
+    ///
+    /// Why: this is the missing third state, and the whole reason #4005 and
+    /// #4001 are the same bug in opposite directions. A probe that times out
+    /// has learned NOTHING — the daemon may be perfectly healthy and merely
+    /// slow (which is exactly what happened on 2026-07-26, when `/health`
+    /// missed a 2 s budget while MCP calls against the same daemon succeeded).
+    /// Rendering that as `Fail` is a false negative; rendering it as `Pass`
+    /// would be a false positive. Neither is honest, so it gets its own state.
+    /// The rule this variant encodes: a health check must report what it
+    /// actually observed, and "could not determine" must never render as
+    /// healthy.
+    /// Test: `indeterminate_probe_renders_as_unknown_not_pass`.
+    Unknown,
 }
 
 /// A single doctor check result.
@@ -87,16 +101,35 @@ impl CheckResult {
         }
     }
 
+    /// Build an "could not determine" result (issue #4005).
+    ///
+    /// Why: see [`CheckStatus::Unknown`]. Callers reach for this when the probe
+    /// itself failed to produce evidence — a timeout, an unparseable body —
+    /// rather than when it produced evidence of a problem.
+    /// What: a [`CheckStatus::Unknown`] result carrying the reason.
+    /// Test: `indeterminate_probe_renders_as_unknown_not_pass`.
+    pub(super) fn unknown(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            status: CheckStatus::Unknown,
+            label: label.into(),
+            detail: Some(detail.into()),
+        }
+    }
+
     pub(super) fn print(&self) {
         let glyph = match self.status {
             CheckStatus::Pass => "✅".to_string(),
             CheckStatus::Warn => "⚠️ ".to_string(),
             CheckStatus::Fail => "❌".to_string(),
+            // Deliberately NOT a green/✅ glyph: an indeterminate probe must
+            // never read as healthy at a glance (issue #4005).
+            CheckStatus::Unknown => "❔".to_string(),
         };
         let label = match self.status {
             CheckStatus::Pass => self.label.green().to_string(),
             CheckStatus::Warn => self.label.yellow().to_string(),
             CheckStatus::Fail => self.label.red().to_string(),
+            CheckStatus::Unknown => self.label.yellow().to_string(),
         };
         match &self.detail {
             Some(d) => println!("{glyph} {label} — {}", d.dimmed()),
@@ -257,25 +290,23 @@ pub async fn handle_doctor() -> Result<()> {
         .iter()
         .filter(|r| r.status == CheckStatus::Warn)
         .count();
+    let unknown = results
+        .iter()
+        .filter(|r| r.status == CheckStatus::Unknown)
+        .count();
+
+    // Issue #4005: indeterminate checks are reported in their own column
+    // rather than being folded into `passed`. Folding them in is what let a
+    // probe that learned nothing contribute to a healthy-looking tally.
+    let summary =
+        format!("{passed} passed, {warned} warnings, {unknown} undetermined, {failed} failed.");
 
     println!();
     if failed == 0 {
-        println!(
-            "{} {} passed, {} warnings, {} failed.",
-            "✓".green(),
-            passed,
-            warned,
-            failed
-        );
+        println!("{} {summary}", "✓".green());
         Ok(())
     } else {
-        eprintln!(
-            "{} {} passed, {} warnings, {} failed.",
-            "✗".red(),
-            passed,
-            warned,
-            failed
-        );
+        eprintln!("{} {summary}", "✗".red());
         std::process::exit(1);
     }
 }
@@ -553,11 +584,19 @@ mod tests {
         drop(_guard);
 
         // With a stale addr AND no daemon on 7070-7079 (except possibly the
-        // live daemon under test), result must be Fail or Pass.
+        // live daemon under test), result must be Fail, Pass, or — since
+        // issue #4001 — Unknown. Unknown is the honest answer when the
+        // fallback DOES find a live daemon that predates the worker-occupancy
+        // block: liveness is confirmed, but progress is unobservable, and this
+        // check may no longer claim a pass it cannot support.
         assert!(
-            result.status == CheckStatus::Fail || result.status == CheckStatus::Pass,
-            "unexpected status {:?}; expected Fail (stale addr, no listener) \
-             or Pass (fallback found live daemon)",
+            matches!(
+                result.status,
+                CheckStatus::Fail | CheckStatus::Pass | CheckStatus::Unknown
+            ),
+            "unexpected status {:?}; expected Fail (stale addr, no listener), \
+             Pass (fallback found a live #4001-aware daemon), or Unknown \
+             (fallback found a live pre-#4001 daemon)",
             result.status,
         );
         if result.status == CheckStatus::Fail {
@@ -596,9 +635,14 @@ mod tests {
         }
         drop(_guard);
 
-        // Either Fail (no daemon found anywhere) or Pass (live daemon on 7070).
+        // Fail (no daemon found anywhere), Pass (live #4001-aware daemon on
+        // 7070), or Unknown (live pre-#4001 daemon on 7070 — liveness
+        // confirmed, worker progress unobservable).
         assert!(
-            result.status == CheckStatus::Fail || result.status == CheckStatus::Pass,
+            matches!(
+                result.status,
+                CheckStatus::Fail | CheckStatus::Pass | CheckStatus::Unknown
+            ),
             "unexpected status: {:?}",
             result.status
         );
@@ -609,5 +653,105 @@ mod tests {
                 "detail must hint at the absence: {detail:?}"
             );
         }
+    }
+
+    // ---- Issues #4001 / #4005: interpret what the daemon reported ----
+
+    use super::checks::interpret_health_body;
+
+    fn interpret(body: serde_json::Value) -> CheckResult {
+        interpret_health_body(
+            "HTTP daemon".to_string(),
+            "http://x/health",
+            200,
+            Some(&body),
+        )
+    }
+
+    /// Why (issue #4001): `trusty-memory doctor` reported HEALTHY throughout
+    /// the #3992 hang because a 2xx was the entire test. A daemon reporting a
+    /// wedged pool must fail even though the HTTP layer is perfectly fine.
+    /// What: asserts `Fail` plus a message naming the wedge and its age.
+    /// Test: itself.
+    #[test]
+    fn wedged_body_is_fail() {
+        let r = interpret(serde_json::json!({
+            "status": "ok",
+            "daemon_state": "ready",
+            "worker": {"in_flight": 6, "oldest_age_secs": 1800, "wedged": true},
+        }));
+        assert_eq!(r.status, CheckStatus::Fail);
+        let d = r.detail.as_deref().unwrap_or("");
+        assert!(d.contains("WEDGED"), "must name the wedge: {d}");
+        assert!(d.contains("1800"), "must carry the observed age: {d}");
+    }
+
+    /// Why (issue #4005): post-restart warm-up is a normal transient state.
+    /// Reporting it as a hard failure is the false negative; reporting it as a
+    /// clean pass would hide that recall is on its fallback path.
+    /// What: asserts `Warn`.
+    /// Test: itself.
+    #[test]
+    fn warming_body_is_warn() {
+        let r = interpret(serde_json::json!({
+            "status": "ok",
+            "daemon_state": "warming",
+            "worker": {"in_flight": 0, "wedged": false},
+        }));
+        assert_eq!(r.status, CheckStatus::Warn);
+        assert!(r.detail.as_deref().unwrap_or("").contains("WARMING"));
+    }
+
+    /// Why (the unifying principle): doctor must never claim health it did not
+    /// observe. A 2xx whose body cannot be read tells us the listener is up
+    /// and nothing else.
+    /// What: asserts an absent body is `Unknown`, explicitly not `Pass`.
+    /// Test: itself.
+    #[test]
+    fn indeterminate_probe_renders_as_unknown_not_pass() {
+        let r = interpret_health_body("HTTP daemon".to_string(), "http://x/health", 200, None);
+        assert_eq!(r.status, CheckStatus::Unknown);
+        assert_ne!(r.status, CheckStatus::Pass, "unknown must never be healthy");
+        assert!(r.detail.as_deref().unwrap_or("").contains("UNKNOWN"));
+    }
+
+    /// Why (issue #4001, forward-compatibility): a daemon predating the worker
+    /// block gives doctor no observation to base a pass on.
+    /// What: asserts a body with no `worker` key is `Unknown`.
+    /// Test: itself.
+    #[test]
+    fn body_without_worker_block_is_unknown() {
+        let r = interpret(serde_json::json!({"status": "ok", "daemon_state": "ready"}));
+        assert_eq!(r.status, CheckStatus::Unknown);
+    }
+
+    /// Why: the fix must still let a genuinely healthy daemon pass, or it
+    /// would trade one false verdict for another.
+    /// What: asserts a ready daemon with a quiet pool is `Pass`.
+    /// Test: itself.
+    #[test]
+    fn healthy_body_is_pass() {
+        let r = interpret(serde_json::json!({
+            "status": "ok",
+            "daemon_state": "ready",
+            "worker": {"in_flight": 2, "oldest_age_secs": 1, "wedged": false},
+        }));
+        assert_eq!(r.status, CheckStatus::Pass);
+    }
+
+    /// Why (issue #71 preserved): the deep-probe degraded signal must survive
+    /// the new worker-block logic rather than being masked by it.
+    /// What: asserts a degraded round-trip still warns.
+    /// Test: itself.
+    #[test]
+    fn degraded_body_is_warn() {
+        let r = interpret(serde_json::json!({
+            "status": "degraded",
+            "detail": "store failed: disk full",
+            "daemon_state": "ready",
+            "worker": {"in_flight": 0, "wedged": false},
+        }));
+        assert_eq!(r.status, CheckStatus::Warn);
+        assert!(r.detail.as_deref().unwrap_or("").contains("disk full"));
     }
 }

--- a/crates/trusty-memory/src/lib.rs
+++ b/crates/trusty-memory/src/lib.rs
@@ -95,6 +95,16 @@ pub mod fd_metrics;
 /// bound resident RSS. Wired in `spawn_startup_tasks` next to the dream
 /// scheduler; configured via `TRUSTY_MEMORY_IDLE_EVICT_SECS`.
 pub mod idle_evict;
+/// Live worker-occupancy gauge for the palace open/write path.
+///
+/// Why (issue #4001): doctor could only observe *process* liveness — an HTTP
+/// listener that answers and lock files that look clean — so a daemon with
+/// every worker parked in `concurrent_open::backoff_sleep_ms` still reported
+/// HEALTHY. This tracks how long the oldest in-flight operation has been
+/// running, which is the cheapest signal that actually distinguishes "the
+/// process is up" from "work is moving".
+/// Test: `worker_liveness::tests`.
+pub mod worker_liveness;
 // Why (issue #226): `chat` and `web` are pure axum HTTP/SSE handler
 //      surfaces. Gating them behind the `axum-server` feature is what lets
 //      library consumers (e.g. `open-mpm` linking only `MemoryMcpService`)
@@ -454,6 +464,33 @@ pub struct AppState {
     /// `tests::emit_persists_mutations_but_skips_status_changed` call
     /// `flush_activity_writes` to drain the counter before reading the log.
     pub pending_activity_writes: Arc<AtomicUsize>,
+    /// Live occupancy gauge for the palace open path (issue #4001).
+    ///
+    /// Why: during the #3992 incident six daemon threads sat parked in
+    /// `concurrent_open::backoff_sleep_ms` with a `memory_remember` hung
+    /// ~1800 s, while both doctors reported HEALTHY. Every existing signal —
+    /// HTTP liveness, fastembed cache state, lock-file staleness — describes
+    /// the *process*, not the *work*. This is the one field that can answer
+    /// "is anything actually moving?", and `/health` surfaces it so an
+    /// out-of-process doctor can report what the daemon actually observed
+    /// instead of inferring health from a cheap proxy.
+    /// What: an [`worker_liveness::WorkerLiveness`] slot table; one CAS on
+    /// entry and one store on exit per tracked operation, so the gauge cannot
+    /// itself become the load problem it exists to detect.
+    /// Test: `web::tests::health_tests::health_reports_wedged_worker_pool`.
+    pub worker_liveness: Arc<worker_liveness::WorkerLiveness>,
+    /// How long an operation may run before the pool is called wedged.
+    ///
+    /// Why this is state rather than an env read on the request path: `/health`
+    /// is polled once a second, so re-reading (and re-parsing) an environment
+    /// variable per request is needless work; resolving it once at construction
+    /// also makes the value a property of the daemon instead of a process-wide
+    /// global, which is what lets tests drive the wedge condition
+    /// deterministically instead of mutating shared env state and racing each
+    /// other.
+    /// What: defaults to [`worker_liveness::wedge_threshold`].
+    /// Test: `web::tests::health_tests::health_reports_wedged_worker_pool`.
+    pub wedge_threshold: std::time::Duration,
     /// In-memory cache mapping palace id → `Palace.name` (issue #228).
     ///
     /// Why: every `memory_remember` / `memory_note` write used to call
@@ -597,6 +634,8 @@ impl AppState {
             bm25_supervisor: None,
             palace_write_locks: Arc::new(dashmap::DashMap::new()),
             pending_activity_writes: Arc::new(AtomicUsize::new(0)),
+            worker_liveness: Arc::new(worker_liveness::WorkerLiveness::new()),
+            wedge_threshold: worker_liveness::wedge_threshold(),
             palace_names: Arc::new(dashmap::DashMap::new()),
             pin_project_map: Arc::new(dashmap::DashMap::new()),
             bm25_index_tx,

--- a/crates/trusty-memory/src/tools/helpers.rs
+++ b/crates/trusty-memory/src/tools/helpers.rs
@@ -288,10 +288,22 @@ pub(crate) fn parse_room(s: Option<&str>) -> RoomType {
 }
 
 /// Resolve (or lazily open) the palace handle for a tool call.
+///
+/// Why the liveness guard (issue #4001): this is the single choke point every
+/// `memory_recall` / `memory_remember` passes through, and it is exactly where
+/// the #3992 wedge occurred — `open_palace` serialises on a per-palace mutex
+/// and, on a miss, drops into `concurrent_open`'s redb retry/backoff loop.
+/// Registering the operation here is what lets `/health` (and therefore both
+/// doctors) observe that work has stopped moving. The guard is RAII, so the
+/// `?` on the line below releases it just as reliably as the success path.
+/// What: unchanged behaviour, plus a [`crate::worker_liveness`] registration
+/// held for the duration of the open.
+/// Test: `worker_liveness::tests`, `web::tests::health_tests`.
 pub(crate) fn open_palace_handle(
     state: &AppState,
     palace_id: &str,
 ) -> Result<std::sync::Arc<trusty_common::memory_core::PalaceHandle>> {
+    let _tracked = state.worker_liveness.track();
     let pid = PalaceId::new(palace_id);
     state
         .registry

--- a/crates/trusty-memory/src/web/health.rs
+++ b/crates/trusty-memory/src/web/health.rs
@@ -161,6 +161,39 @@ pub(super) struct HealthResponse {
     /// What: `"warming"` until the embedder init succeeds; `"ready"` once
     /// `spawn_startup_tasks` flips `AppState::daemon_readiness`.
     pub(super) daemon_state: String,
+    /// Live worker-pool occupancy (issue #4001).
+    ///
+    /// Why: this is the field that makes `/health` report what it OBSERVED
+    /// rather than what it assumed. Every other field describes the process;
+    /// this one describes the work. Without it an out-of-process doctor has no
+    /// way to tell a busy-but-healthy daemon from one whose every worker is
+    /// parked, which is why #3992 read as HEALTHY for the whole incident.
+    /// What: see [`WorkerHealth`].
+    pub(super) worker: WorkerHealth,
+}
+
+/// Worker-pool occupancy block of the `/health` payload (issue #4001).
+///
+/// Why: doctor must be able to distinguish three states, not two — healthy,
+/// wedged, and *unknown*. Reporting the raw `oldest_age_secs` alongside the
+/// `wedged` verdict lets a consumer form its own opinion, and lets an operator
+/// see a pool trending toward a wedge before it trips.
+/// What: in-flight count, age of the oldest outstanding operation (absent when
+/// idle), and the threshold-crossed verdict.
+/// Test: `health_reports_idle_worker_pool`, `health_reports_wedged_worker_pool`.
+#[derive(serde::Serialize)]
+pub(super) struct WorkerHealth {
+    /// Operations currently inside the palace open path.
+    pub(super) in_flight: usize,
+    /// Seconds the oldest outstanding operation has been running. Absent when
+    /// nothing is in flight — an idle pool has no age to report, and reporting
+    /// `0` would be indistinguishable from "a request just started".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(super) oldest_age_secs: Option<u64>,
+    /// True when `oldest_age_secs` exceeds
+    /// [`crate::worker_liveness::wedge_threshold`] — i.e. an operation has
+    /// blown past the bound that was supposed to release it.
+    pub(super) wedged: bool,
 }
 
 /// `GET /health[?probe=true]` — unauthenticated liveness probe with optional
@@ -218,6 +251,20 @@ pub(super) async fn health(
     // explicitly requests it via ?probe=true or ?deep=true. Without either
     // flag the handler returns "ok" immediately — cheap enough for 1 s LB
     // polling without ONNX embedder calls.
+    // Issue #4001: observe the worker pool BEFORE deciding the status. This is
+    // the whole point of the fix — a listener that answers proves the process
+    // is alive, not that work is moving, so the verdict must be derived from
+    // an actual observation of outstanding work. Reading the gauge is a
+    // handful of relaxed atomic loads; it adds no I/O and takes no lock, so it
+    // is safe on the cheap (non-probe) path that monitors poll every second.
+    let wedge_threshold = state.wedge_threshold;
+    let oldest_age = state.worker_liveness.oldest_age();
+    let worker = WorkerHealth {
+        in_flight: state.worker_liveness.in_flight(),
+        oldest_age_secs: oldest_age.map(|d| d.as_secs()),
+        wedged: oldest_age.is_some_and(|age| age > wedge_threshold),
+    };
+
     let (status, detail) = if query.wants_deep_probe() {
         match run_health_round_trip(&state).await {
             Ok(()) => ("ok".to_string(), None),
@@ -228,6 +275,31 @@ pub(super) async fn health(
         }
     } else {
         ("ok".to_string(), None)
+    };
+
+    // A wedged pool outranks whatever the round-trip concluded: if the oldest
+    // in-flight operation has blown past its bound, the daemon is not healthy
+    // no matter how cheerful the rest of the payload looks. Reported on the
+    // cheap path too — #3992 was invisible precisely because nobody was
+    // passing ?probe=true during the incident.
+    let (status, detail) = if worker.wedged {
+        let secs = worker.oldest_age_secs.unwrap_or_default();
+        tracing::warn!(
+            oldest_age_secs = secs,
+            in_flight = worker.in_flight,
+            "/health: worker pool appears wedged"
+        );
+        (
+            "wedged".to_string(),
+            Some(format!(
+                "oldest in-flight palace operation has been running {secs}s \
+                 (threshold {}s, {} in flight) — workers are not making progress",
+                wedge_threshold.as_secs(),
+                worker.in_flight
+            )),
+        )
+    } else {
+        (status, detail)
     };
 
     let update_available = state.update_available.lock().ok().and_then(|g| g.clone());
@@ -252,6 +324,7 @@ pub(super) async fn health(
         fd_soft_limit,
         update_available,
         daemon_state,
+        worker,
     })
 }
 

--- a/crates/trusty-memory/src/web/tests/health_tests.rs
+++ b/crates/trusty-memory/src/web/tests/health_tests.rs
@@ -117,6 +117,126 @@ async fn health_endpoint_cheap_by_default() {
     );
 }
 
+// ---- Issue #4001: /health must observe the worker pool ----
+
+/// Why (issue #4001): doctor cannot report what `/health` never tells it. An
+/// idle daemon must publish a worker block so an out-of-process probe can see
+/// that it positively observed zero outstanding work — as opposed to a
+/// pre-#4001 daemon, where the absence of the block means "unknown".
+/// What: asserts the cheap path carries `worker.in_flight`/`worker.wedged`,
+/// and omits `oldest_age_secs` when idle.
+/// Test: this test.
+#[tokio::test]
+async fn health_reports_idle_worker_pool() {
+    let state = test_state();
+    let app = router().with_state(state);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = to_bytes(resp.into_body(), 4096).await.unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(v["worker"]["in_flight"], 0, "idle pool; got {v:?}");
+    assert_eq!(v["worker"]["wedged"], false, "idle pool; got {v:?}");
+    assert!(
+        v["worker"].get("oldest_age_secs").is_none(),
+        "an idle pool has no age to report; got {v:?}"
+    );
+}
+
+/// Why (issue #4001): THE regression lock. During the #3992 incident the HTTP
+/// listener answered normally while six threads sat parked and a
+/// `memory_remember` had been hung ~1800 s, and `/health` reported `"ok"` —
+/// which is what let both doctors report HEALTHY. Here the listener is equally
+/// live; the only difference is that an operation has been outstanding past
+/// the wedge threshold. `/health` must say so.
+/// What: registers a tracked operation and drives this daemon's wedge
+/// threshold to zero so the test is deterministic and instant (no sleeping for
+/// minutes). The threshold is per-`AppState`, not an env var, so this test
+/// cannot race the sibling test below.
+/// Test: this test.
+#[tokio::test]
+async fn health_reports_wedged_worker_pool() {
+    let mut state = test_state();
+    state.wedge_threshold = std::time::Duration::ZERO;
+    // Hold an in-flight operation open across the request, exactly as a
+    // wedged `open_palace_handle` would.
+    let _stuck = state.worker_liveness.track();
+    // Let at least one millisecond elapse so the age strictly exceeds zero.
+    tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+
+    let app = router().with_state(state.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = to_bytes(resp.into_body(), 4096).await.unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+
+    assert_eq!(
+        v["worker"]["wedged"], true,
+        "a stuck operation past the threshold must read as wedged; got {v:?}"
+    );
+    assert_eq!(
+        v["status"], "wedged",
+        "top-level status must NOT be ok while workers are stuck; got {v:?}"
+    );
+    assert_ne!(
+        v["status"], "ok",
+        "this is the #3992 false positive; got {v:?}"
+    );
+    assert_eq!(v["worker"]["in_flight"], 1, "got {v:?}");
+    assert!(
+        v["detail"].as_str().unwrap_or_default().contains("wedged")
+            || v["detail"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("not making progress"),
+        "detail must explain the wedge; got {v:?}"
+    );
+}
+
+/// Why (issue #4001): the wedge signal must clear on its own. If a completed
+/// operation left the gauge tripped, the fix would trade a false positive for
+/// a sticky one and operators would learn to ignore it.
+/// What: tracks and drops an operation, then asserts `/health` is back to ok.
+/// Test: this test.
+#[tokio::test]
+async fn health_wedge_signal_clears_when_work_completes() {
+    let mut state = test_state();
+    state.wedge_threshold = std::time::Duration::ZERO;
+    {
+        let _stuck = state.worker_liveness.track();
+        tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+    } // operation completes here
+
+    let app = router().with_state(state.clone());
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let bytes = to_bytes(resp.into_body(), 4096).await.unwrap();
+    let v: Value = serde_json::from_slice(&bytes).unwrap();
+
+    assert_eq!(v["worker"]["wedged"], false, "got {v:?}");
+    assert_eq!(v["status"], "ok", "got {v:?}");
+}
+
 /// Why: the fd-exhaustion gauge must appear in the `/health` response on
 /// Unix platforms so operators can monitor fd consumption vs. the ceiling.
 /// What: drives `/health` through the router and asserts that `open_fds`

--- a/crates/trusty-memory/src/worker_liveness.rs
+++ b/crates/trusty-memory/src/worker_liveness.rs
@@ -1,0 +1,217 @@
+//! Live worker-occupancy gauge for the palace open/write path (issue #4001).
+//!
+//! Why: during the #3992 incident six daemon threads were parked in
+//! `concurrent_open::backoff_sleep_ms` with a `memory_remember` hung ~1800 s,
+//! and BOTH `tm doctor` and `trusty-memory doctor` reported HEALTHY the whole
+//! time. Doctor observed only *process* liveness — an HTTP listener that still
+//! answers, and lock files that still look clean — neither of which can see a
+//! wedged worker pool. This module supplies the missing observation: how long
+//! the oldest in-flight palace operation has been running. That is the cheapest
+//! signal that actually distinguishes "the process is up" from "work is moving".
+//!
+//! What: a fixed-size, lock-free slot table of operation start timestamps. An
+//! operation claims a slot on entry and releases it on drop; the probe reads
+//! the table and reports the age of the oldest occupied slot. No allocation, no
+//! mutex, and no syscall on the hot path — one CAS in and one store out — so
+//! the gauge can never itself become the load problem it exists to detect.
+//! Test: see `worker_liveness_tests.rs`.
+
+use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::time::{Duration, Instant};
+
+/// Number of concurrently-trackable operations.
+///
+/// Why: the table is scanned linearly on both claim and probe, so it must stay
+/// small enough that a scan is trivial (64 relaxed atomic loads is ~nothing)
+/// while comfortably exceeding realistic in-flight concurrency for a
+/// single-user memory daemon. Operations beyond this count are still *counted*
+/// via the overflow gauge — they simply do not contribute an age sample, which
+/// degrades the signal gracefully instead of blocking or allocating.
+/// Test: `overflow_is_counted_when_slots_exhausted`.
+const SLOTS: usize = 64;
+
+/// Sentinel meaning "this slot is free". Real timestamps are offsets from the
+/// tracker's epoch and are stored as `millis + 1`, so 0 is never a valid entry.
+const FREE: u64 = 0;
+
+/// How long the oldest in-flight operation may run before the pool is called
+/// wedged.
+///
+/// Why: this must sit ABOVE every legitimately-bounded wait, or healthy load
+/// would read as a wedge. The longest such bound on the palace open path is
+/// `memory_core::timeouts::open_queue_timeout()` (default 60 s, issue #3992),
+/// after which `open_palace` gives up and returns an error. Doubling it means
+/// any operation still outstanding has already blown through the bound that
+/// was supposed to release it — which is precisely the #3992 signature, where
+/// a `memory_remember` ran ~1800 s. Env-overridable so an operator running a
+/// deliberately long `open_queue_timeout` can move the wedge line with it.
+/// What: `TRUSTY_WEDGE_THRESHOLD_SECS` if set and parseable, else
+/// `2 × open_queue_timeout()`.
+/// Test: `wedge_threshold_exceeds_the_open_queue_bound`.
+pub fn wedge_threshold() -> Duration {
+    if let Some(secs) = std::env::var("TRUSTY_WEDGE_THRESHOLD_SECS")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+    {
+        return Duration::from_secs(secs);
+    }
+    trusty_common::memory_core::timeouts::open_queue_timeout() * 2
+}
+
+/// Tracks how long the oldest in-flight palace operation has been running.
+///
+/// Why (issue #4001): see the module docs — this is the signal that would have
+/// revealed the #3992 wedge. Alternatives considered and rejected: sampling
+/// thread state (needs platform-specific debugging APIs and is expensive),
+/// mutex wait-time histograms (needs instrumenting `parking_lot` internals),
+/// and a plain in-flight *count* (a count alone cannot distinguish healthy
+/// concurrency from a wedge — only the *age* of outstanding work can).
+/// What: a slot table of start timestamps plus an overflow counter. Cloneable
+/// and `Send`/`Sync` via the caller's `Arc`.
+/// Test: `worker_liveness_tests.rs`.
+#[derive(Debug)]
+pub struct WorkerLiveness {
+    /// Start timestamps as `epoch.elapsed().as_millis() + 1`; [`FREE`] when
+    /// the slot is unoccupied.
+    slots: [AtomicU64; SLOTS],
+    /// Operations in flight that could not claim a slot. Contributes to the
+    /// in-flight count but not to the oldest-age sample.
+    overflow: AtomicUsize,
+    /// Reference point for every stored timestamp. Using a monotonic `Instant`
+    /// rather than wall-clock time keeps the gauge immune to clock steps.
+    epoch: Instant,
+}
+
+impl Default for WorkerLiveness {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkerLiveness {
+    /// Create an empty tracker.
+    ///
+    /// Why: `AtomicU64` is not `Copy`, so the slot array cannot be built with
+    /// `[AtomicU64::new(0); SLOTS]`; `from_fn` is the idiomatic construction.
+    /// What: all slots [`FREE`], overflow zero, epoch = now.
+    /// Test: `idle_tracker_reports_no_work`.
+    pub fn new() -> Self {
+        Self {
+            slots: std::array::from_fn(|_| AtomicU64::new(FREE)),
+            overflow: AtomicUsize::new(0),
+            epoch: Instant::now(),
+        }
+    }
+
+    /// Register the start of an operation, returning a guard that unregisters
+    /// it on drop.
+    ///
+    /// Why: the release MUST be drop-driven rather than an explicit call. The
+    /// operations being tracked are exactly the ones that fail, time out, and
+    /// `?`-propagate mid-function; an explicit `finish()` would be skipped on
+    /// every error path and leak slots, which would then be misread as a
+    /// permanent wedge — turning this fix into a new false positive.
+    /// What: claims the first [`FREE`] slot via a relaxed CAS, storing the
+    /// current offset from `epoch`. Falls back to the overflow counter when
+    /// every slot is taken.
+    /// Test: `guard_releases_slot_on_drop`, `guard_releases_slot_on_panic`.
+    pub fn track(&self) -> WorkGuard<'_> {
+        // `+ 1` keeps 0 reserved as the FREE sentinel, so an operation
+        // starting in the tracker's first millisecond is still distinguishable
+        // from an empty slot.
+        let now = self.epoch.elapsed().as_millis() as u64 + 1;
+        for (idx, slot) in self.slots.iter().enumerate() {
+            if slot
+                .compare_exchange(FREE, now, Ordering::AcqRel, Ordering::Relaxed)
+                .is_ok()
+            {
+                return WorkGuard {
+                    tracker: self,
+                    slot: Some(idx),
+                };
+            }
+        }
+        self.overflow.fetch_add(1, Ordering::AcqRel);
+        WorkGuard {
+            tracker: self,
+            slot: None,
+        }
+    }
+
+    /// Number of operations currently in flight.
+    ///
+    /// What: occupied slots plus the overflow count.
+    /// Test: `in_flight_counts_active_operations`.
+    pub fn in_flight(&self) -> usize {
+        let occupied = self
+            .slots
+            .iter()
+            .filter(|s| s.load(Ordering::Acquire) != FREE)
+            .count();
+        occupied + self.overflow.load(Ordering::Acquire)
+    }
+
+    /// Age of the oldest in-flight operation, or `None` when idle.
+    ///
+    /// Why: this is the actual health signal. A daemon with zero in-flight work
+    /// is trivially not wedged; a daemon whose oldest operation has been
+    /// running for minutes is wedged regardless of what the HTTP listener says.
+    /// What: scans for the smallest occupied timestamp and returns the elapsed
+    /// duration since it. Returns `None` when every slot is free — note that
+    /// overflow-only operations produce `None` here by design, since no age
+    /// sample exists for them.
+    /// Test: `oldest_age_tracks_the_earliest_operation`.
+    pub fn oldest_age(&self) -> Option<Duration> {
+        let oldest = self
+            .slots
+            .iter()
+            .map(|s| s.load(Ordering::Acquire))
+            .filter(|&v| v != FREE)
+            .min()?;
+        let now = self.epoch.elapsed().as_millis() as u64 + 1;
+        Some(Duration::from_millis(now.saturating_sub(oldest)))
+    }
+
+    /// True when the oldest in-flight operation has exceeded `threshold`.
+    ///
+    /// Why: turns the raw age into the verdict doctor reports. Keeping the
+    /// threshold a parameter (rather than a constant baked in here) lets the
+    /// caller pick a bound derived from the real operation timeout, and lets
+    /// tests drive the wedge condition deterministically without sleeping.
+    /// What: `oldest_age() > threshold`; `false` when idle.
+    /// Test: `wedged_when_oldest_exceeds_threshold`.
+    pub fn is_wedged(&self, threshold: Duration) -> bool {
+        self.oldest_age().is_some_and(|age| age > threshold)
+    }
+}
+
+/// RAII registration for one in-flight operation.
+///
+/// Why: see [`WorkerLiveness::track`] — drop-driven release is what makes the
+/// gauge correct across the `?` and panic paths that a wedge actually travels.
+/// What: releases its slot (or decrements overflow) on drop.
+/// Test: `guard_releases_slot_on_drop`, `guard_releases_slot_on_panic`.
+#[derive(Debug)]
+pub struct WorkGuard<'a> {
+    tracker: &'a WorkerLiveness,
+    /// `Some(idx)` when a slot was claimed, `None` when the operation landed
+    /// in the overflow bucket.
+    slot: Option<usize>,
+}
+
+impl Drop for WorkGuard<'_> {
+    fn drop(&mut self) {
+        match self.slot {
+            Some(idx) => {
+                self.tracker.slots[idx].store(FREE, Ordering::Release);
+            }
+            None => {
+                self.tracker.overflow.fetch_sub(1, Ordering::AcqRel);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "worker_liveness_tests.rs"]
+mod tests;

--- a/crates/trusty-memory/src/worker_liveness_tests.rs
+++ b/crates/trusty-memory/src/worker_liveness_tests.rs
@@ -1,0 +1,151 @@
+//! Unit tests for the [`super::WorkerLiveness`] occupancy gauge (issue #4001).
+//!
+//! Why: split out of `worker_liveness.rs` so the production module stays under
+//! the 500-SLOC cap. Wired back in via `#[path] mod tests;`.
+//! What: covers the idle case, age tracking, drop/panic release, overflow, and
+//! the wedge verdict.
+//! Test: this *is* the test file.
+
+use super::*;
+
+#[test]
+fn idle_tracker_reports_no_work() {
+    let t = WorkerLiveness::new();
+    assert_eq!(t.in_flight(), 0);
+    assert_eq!(t.oldest_age(), None);
+    // An idle daemon is never wedged, no matter how small the threshold.
+    assert!(!t.is_wedged(Duration::from_millis(0)));
+}
+
+#[test]
+fn in_flight_counts_active_operations() {
+    let t = WorkerLiveness::new();
+    let a = t.track();
+    assert_eq!(t.in_flight(), 1);
+    let b = t.track();
+    assert_eq!(t.in_flight(), 2);
+    drop(a);
+    assert_eq!(t.in_flight(), 1);
+    drop(b);
+    assert_eq!(t.in_flight(), 0);
+}
+
+#[test]
+fn guard_releases_slot_on_drop() {
+    let t = WorkerLiveness::new();
+    {
+        let _g = t.track();
+        assert_eq!(t.in_flight(), 1);
+    }
+    assert_eq!(t.in_flight(), 0);
+    assert_eq!(t.oldest_age(), None);
+}
+
+/// Why (issue #4001): the operations this gauge tracks are exactly the ones
+/// that fail and unwind. If a slot leaked on the panic path, the gauge would
+/// report a permanent phantom wedge — trading the original false positive for
+/// a new one. Drop-driven release is what prevents that, and this test is the
+/// proof.
+/// What: panics inside a tracked scope and asserts the slot came back.
+/// Test: itself.
+#[test]
+fn guard_releases_slot_on_panic() {
+    let t = WorkerLiveness::new();
+    let res = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        let _g = t.track();
+        assert_eq!(t.in_flight(), 1);
+        panic!("simulated failure inside a tracked operation");
+    }));
+    assert!(res.is_err(), "the panic must propagate");
+    assert_eq!(
+        t.in_flight(),
+        0,
+        "slot must be released when the operation unwinds"
+    );
+}
+
+#[test]
+fn oldest_age_tracks_the_earliest_operation() {
+    let t = WorkerLiveness::new();
+    let _old = t.track();
+    std::thread::sleep(Duration::from_millis(30));
+    let _new = t.track();
+    let age = t.oldest_age().expect("two operations are in flight");
+    assert!(
+        age >= Duration::from_millis(30),
+        "oldest_age must report the EARLIEST operation, got {age:?}"
+    );
+}
+
+#[test]
+fn oldest_age_recovers_when_the_slow_operation_finishes() {
+    let t = WorkerLiveness::new();
+    let old = t.track();
+    std::thread::sleep(Duration::from_millis(30));
+    drop(old);
+    let _fresh = t.track();
+    let age = t.oldest_age().expect("one operation is in flight");
+    assert!(
+        age < Duration::from_millis(30),
+        "age must drop back once the slow operation completes, got {age:?}"
+    );
+}
+
+/// Why (issue #4001): this is the verdict doctor reports. A pool with work
+/// outstanding longer than the bound is wedged even though the process is
+/// alive and its HTTP listener still answers.
+/// What: asserts the threshold comparison in both directions.
+/// Test: itself.
+#[test]
+fn wedged_when_oldest_exceeds_threshold() {
+    let t = WorkerLiveness::new();
+    let _g = t.track();
+    std::thread::sleep(Duration::from_millis(30));
+    assert!(
+        t.is_wedged(Duration::from_millis(10)),
+        "an operation older than the threshold must read as wedged"
+    );
+    assert!(
+        !t.is_wedged(Duration::from_secs(60)),
+        "the same operation must NOT read as wedged under a generous threshold"
+    );
+}
+
+/// Why: the gauge must degrade gracefully rather than block or allocate when
+/// concurrency exceeds the slot table. Overflow operations still count toward
+/// `in_flight` so the daemon never under-reports its load.
+/// What: fills every slot plus two extra and checks both the count and the
+/// clean return to zero.
+/// Test: itself.
+/// Why: the wedge line must sit ABOVE every legitimately-bounded wait, or
+/// healthy load reads as a wedge and operators learn to ignore the signal. The
+/// longest bound on the palace open path is `open_queue_timeout()` (issue
+/// #3992), after which `open_palace` gives up on its own.
+/// What: asserts the default threshold strictly exceeds that bound. Skipped
+/// when the env override is set, since it deliberately decouples the two.
+/// Test: itself.
+#[test]
+fn wedge_threshold_exceeds_the_open_queue_bound() {
+    if std::env::var("TRUSTY_WEDGE_THRESHOLD_SECS").is_ok() {
+        return; // operator override in effect; the relationship is theirs to pick
+    }
+    let bound = trusty_common::memory_core::timeouts::open_queue_timeout();
+    assert!(
+        wedge_threshold() > bound,
+        "wedge threshold {:?} must exceed the open-queue bound {bound:?}, or normal \
+         contention would read as a wedge",
+        wedge_threshold()
+    );
+}
+
+#[test]
+fn overflow_is_counted_when_slots_exhausted() {
+    let t = WorkerLiveness::new();
+    let guards: Vec<_> = (0..SLOTS + 2).map(|_| t.track()).collect();
+    assert_eq!(t.in_flight(), SLOTS + 2);
+    // An age sample still exists — the slot table is full of real timestamps.
+    assert!(t.oldest_age().is_some());
+    drop(guards);
+    assert_eq!(t.in_flight(), 0, "overflow must unwind cleanly");
+    assert_eq!(t.oldest_age(), None);
+}

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -91,6 +91,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **`tm doctor` no longer reports a serving daemon as unreachable (issue
+  #4005).** On 2026-07-26 it printed "trusty-memory unreachable at
+  127.0.0.1:7070" while MCP `memory_recall` / `memory_remember` succeeded
+  against that same daemon in the same minutes. Two causes, both fixed:
+  the probe was single-shot with a 2 s budget, and trusty-memory's `/health`
+  samples RSS/CPU behind a mutex and enumerates open file descriptors — work
+  the MCP path never touches — so under load `/health` could exceed a budget
+  real traffic never approached. The probe now allows 10 s, retries up to 3
+  times, and above all distinguishes a TIMEOUT (which proves nothing, so it
+  reports `Unknown`) from a REFUSED connection (which proves nothing is
+  listening, so it still reports `Fail`). Post-restart warm-up
+  (`daemon_state: "warming"`) now reports `Warn` rather than a hard failure.
+
+- **`tm doctor` no longer reports HEALTHY while the memory daemon is wedged
+  (issue #4001).** A 2xx from `/health` proves a listener accepted a socket,
+  not that the daemon is doing work — which is how doctor stayed green through
+  the entire #3992 incident. The memory probe now reads the daemon's own
+  worker-occupancy observation out of the response body and fails on a
+  reported wedge. A daemon too old to report that block is `Unknown`, not a
+  pass: doctor no longer claims health it has not observed.
+
 - **The test suite no longer writes trust-seed entries into the operator's real
   managed `.claude.json`**
   ([#4206](https://github.com/bobmatnyc/trusty-tools/issues/4206)): five tests
@@ -242,6 +263,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- **`core::doctor::CheckStatus` gained an `Unknown` variant (issues #4005,
+  #4001).** This is a BREAKING change for any downstream exhaustive `match`
+  over the enum (E0004) and needs a MINOR bump, not a patch — the same trap
+  that forced the `trusty-analyze` 0.7.3 yank. Four in-workspace match sites
+  (Slack + Telegram formatters, the `tm doctor` CLI renderer) gained an arm.
+  `Unknown` ranks above `Warn` and below `Fail`, so a single indeterminate
+  check can never leave the aggregate report reading healthy.
 - bump to 1.2.3 ([#4229](https://github.com/bobmatnyc/trusty-tools/pull/4229)) ([`7c4f056`](https://github.com/bobmatnyc/trusty-tools/commit/7c4f05643508bd9ad04b9cf5ba77dead3cb4cfcb))
 
 ### Documentation

--- a/crates/trusty-mpm/src/bin/tm/commands/misc.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/misc.rs
@@ -169,6 +169,10 @@ pub(crate) async fn doctor(url: &str, prune_stale_skills: bool) -> anyhow::Resul
                 match overall {
                     CheckStatus::Ok => "all checks passed",
                     CheckStatus::Warn => "passed with warnings",
+                    // Issue #4005: deliberately not phrased as a pass. A
+                    // check that could not be determined has not passed.
+                    CheckStatus::Unknown =>
+                        "one or more checks could not be determined — health is UNKNOWN",
                     CheckStatus::Fail => "one or more checks failed",
                 },
             );
@@ -366,13 +370,16 @@ pub(crate) async fn health(url: &str) -> anyhow::Result<()> {
 /// Why: the `tm doctor` table marks each check with a glanceable symbol; one
 /// helper keeps the mapping consistent between the per-check lines and the
 /// overall verdict.
-/// What: `Ok → ✅`, `Warn → ⚠️`, `Fail → ❌`.
+/// What: `Ok → ✅`, `Warn → ⚠️`, `Unknown → ❔`, `Fail → ❌`.
 /// Test: covered indirectly by the `doctor` output.
 fn status_icon(status: trusty_mpm::core::doctor::CheckStatus) -> &'static str {
     use trusty_mpm::core::doctor::CheckStatus;
     match status {
         CheckStatus::Ok => "\u{2705}",
         CheckStatus::Warn => "\u{26a0}\u{fe0f}",
+        // Never ✅ (issue #4005): an indeterminate check must not read as
+        // healthy at a glance.
+        CheckStatus::Unknown => "\u{2754}",
         CheckStatus::Fail => "\u{274c}",
     }
 }

--- a/crates/trusty-mpm/src/core/doctor.rs
+++ b/crates/trusty-mpm/src/core/doctor.rs
@@ -28,6 +28,19 @@ pub enum CheckStatus {
     Ok,
     /// The probe found a degraded-but-usable condition worth flagging.
     Warn,
+    /// The probe could not determine the component's state (issue #4005).
+    ///
+    /// Why: a probe that times out has learned nothing. On 2026-07-26 the
+    /// memory probe missed its 2 s budget and reported `Fail` —
+    /// "trusty-memory unreachable at 127.0.0.1:7070" — while MCP
+    /// `memory_recall` / `memory_remember` calls against that same daemon
+    /// succeeded in the same minutes. Reporting that as `Fail` sends the
+    /// operator to restart a healthy daemon; reporting it as `Ok` would hide a
+    /// real outage. Both are dishonest, so "could not determine" gets its own
+    /// state. It ranks ABOVE `Warn` because an unknown is strictly less
+    /// trustworthy than a known-but-minor problem, and it must never render as
+    /// healthy.
+    Unknown,
     /// The probe failed — the component is broken or unreachable.
     Fail,
 }
@@ -37,13 +50,18 @@ impl CheckStatus {
     ///
     /// Why: the aggregate report status is the *worst* of every check; ranking
     /// the variants lets [`worst`](Self::worst) compare them with a plain `max`.
-    /// What: `Ok = 0`, `Warn = 1`, `Fail = 2`.
-    /// Test: `worst_picks_the_most_severe`.
+    /// What: `Ok = 0`, `Warn = 1`, `Unknown = 2`, `Fail = 3`.
+    /// Test: `worst_picks_the_most_severe`, `unknown_never_aggregates_to_ok`.
     fn rank(self) -> u8 {
         match self {
             CheckStatus::Ok => 0,
             CheckStatus::Warn => 1,
-            CheckStatus::Fail => 2,
+            // Above Warn (issue #4005): an unknown is less trustworthy than a
+            // known-but-minor problem. Critically, ranking it above Ok is what
+            // guarantees a single indeterminate check can never leave the
+            // aggregate report reading healthy.
+            CheckStatus::Unknown => 2,
+            CheckStatus::Fail => 3,
         }
     }
 

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -83,8 +83,34 @@ use doctor_push_guard::check_push_guard;
 /// Per-probe network timeout.
 ///
 /// Why: a sidecar that is down or wedged must not stall the whole diagnostic;
-/// a short bound turns "hung" into a clean `Fail`.
-pub const PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+/// a bounded probe turns "hung" into a clean verdict.
+///
+/// Raised from 2 s to 10 s for issue #4005. The old bound produced
+/// "trusty-memory unreachable at 127.0.0.1:7070" against a daemon whose MCP
+/// surface was verifiably serving in the same minutes: trusty-memory's
+/// `/health` samples process RSS/CPU behind a mutex and enumerates open file
+/// descriptors, none of which the MCP request path touches, so under load
+/// `/health` can exceed a budget that real traffic never approaches. The probe
+/// was measuring its own impatience. Note that the timeout is only half the
+/// fix — a timeout now resolves to [`CheckStatus::Unknown`] rather than a
+/// false `Fail` (see [`probe_health`]).
+pub const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Number of attempts a health probe makes before giving up.
+///
+/// Why (issue #4005): the probe was single-shot, so one unlucky sample — a GC
+/// pause, a burst of concurrent MCP traffic, the warm-up window right after a
+/// `tm` restart that the issue explicitly calls out — became a hard failure
+/// verdict with no second opinion. Two retries cost nothing on the healthy
+/// path (the first attempt succeeds and returns immediately) and remove the
+/// single-sample fragility on the unhealthy one.
+const PROBE_ATTEMPTS: usize = 3;
+
+/// Delay between health-probe attempts.
+///
+/// Why: long enough to let a transient spike pass, short enough that three
+/// attempts stay well inside an interactive `tm doctor` run.
+const PROBE_RETRY_DELAY: Duration = Duration::from_millis(500);
 
 /// The trusty-search index `tm doctor` expects to exist for this repo.
 const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
@@ -454,10 +480,11 @@ async fn check_worktrees(
 ///
 /// Why: memory recall and store route through trusty-memory; if it is down the
 /// PM silently loses its long-term memory, so the operator must know.
-/// What: resolves the service address via [`discover_addr`], issues a
-/// `GET /health` bounded by [`PROBE_TIMEOUT`], and reports `Ok` on a 2xx,
-/// `Fail` on any other status or a transport error.
-/// Test: `memory_unreachable_is_fail`.
+/// What: resolves the service address via [`discover_addr`], then delegates to
+/// [`probe_health`], which retries, distinguishes a refusal from a timeout, and
+/// reads the daemon's own worker-pool observation out of the response body.
+/// Test: `memory_unreachable_is_fail`, `memory_timeout_is_unknown_not_fail`,
+/// `memory_wedged_worker_pool_is_not_ok`, `memory_warming_is_warn_not_fail`.
 async fn check_memory(home: &Path) -> DoctorCheck {
     let dir = home.join(".trusty-memory");
     let default = TRUSTY_MEMORY_DEFAULT_ADDR
@@ -465,23 +492,226 @@ async fn check_memory(home: &Path) -> DoctorCheck {
         .expect("static default is valid");
     let env = std::env::var("TRUSTY_MEMORY_ADDR").ok();
     let addr = discover_addr(&dir, default, env.as_deref()).await;
-    match http_get_ok(&format!("http://{addr}/health")).await {
-        Ok(true) => DoctorCheck::new(
-            "memory",
-            CheckStatus::Ok,
-            format!("trusty-memory healthy at {addr}"),
-        ),
-        Ok(false) => DoctorCheck::new(
-            "memory",
-            CheckStatus::Fail,
-            format!("trusty-memory at {addr} returned a non-2xx status"),
-        ),
-        Err(e) => DoctorCheck::new(
-            "memory",
-            CheckStatus::Fail,
-            format!("trusty-memory unreachable at {addr}: {e}"),
-        ),
+    probe_health(
+        "memory",
+        "trusty-memory",
+        &format!("http://{addr}/health"),
+        &addr.to_string(),
+    )
+    .await
+}
+
+/// Outcome of one `/health` request attempt.
+///
+/// Why (issue #4005): the old code collapsed every non-success into a single
+/// `Err`, which is what made "timed out" and "connection refused" produce the
+/// same "unreachable" verdict despite meaning opposite things operationally.
+/// Naming the cases is what lets the caller be honest about which it saw.
+/// What: a 2xx with its parsed body, a non-2xx, a timeout, or a refusal.
+enum ProbeOutcome {
+    /// 2xx. The body is `None` when it could not be read or parsed as JSON.
+    Success(Option<serde_json::Value>),
+    /// The service answered, but not with a 2xx.
+    NonSuccess(u16),
+    /// No answer within [`PROBE_TIMEOUT`] — we learned nothing.
+    TimedOut,
+    /// Connection refused / DNS / other transport failure — nothing is there.
+    Unreachable(String),
+}
+
+/// Issue one `/health` request and classify the outcome.
+async fn probe_health_once(url: &str) -> ProbeOutcome {
+    let client = match reqwest::Client::builder().timeout(PROBE_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => return ProbeOutcome::Unreachable(e.to_string()),
+    };
+    match client.get(url).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            ProbeOutcome::Success(resp.json::<serde_json::Value>().await.ok())
+        }
+        Ok(resp) => ProbeOutcome::NonSuccess(resp.status().as_u16()),
+        Err(e) if e.is_timeout() => ProbeOutcome::TimedOut,
+        Err(e) => ProbeOutcome::Unreachable(e.to_string()),
     }
+}
+
+/// Probe a sidecar's `/health` and turn what was actually observed into a
+/// [`DoctorCheck`] (issues #4005, #4001).
+///
+/// Why: this function encodes the principle both issues share. Doctor used to
+/// infer health from a cheap proxy — "the socket answered" — instead of
+/// observing the thing it claims to report. That produced a false NEGATIVE
+/// when the proxy was merely slow (#4005) and a false POSITIVE when the
+/// listener was fine but every worker was parked (#4001). So: retry before
+/// concluding anything, separate "nothing is listening" from "nothing
+/// answered in time", and prefer the daemon's own observation of its workers
+/// over our inference from the status code.
+/// What: up to [`PROBE_ATTEMPTS`] attempts. Returns `Ok` only when the daemon
+/// positively reports a healthy worker pool; `Fail` on a refusal, a non-2xx,
+/// or a reported wedge; `Warn` while warming or degraded; and `Unknown` when
+/// every attempt timed out or the body carried no worker observation.
+/// Test: `memory_unreachable_is_fail`, `memory_timeout_is_unknown_not_fail`,
+/// `memory_wedged_worker_pool_is_not_ok`, `memory_warming_is_warn_not_fail`,
+/// `memory_slow_but_serving_daemon_is_ok`.
+async fn probe_health(check: &str, service: &str, url: &str, addr: &str) -> DoctorCheck {
+    let mut last_timeout = false;
+    let mut last_err: Option<String> = None;
+    let mut last_status: Option<u16> = None;
+
+    for attempt in 0..PROBE_ATTEMPTS {
+        match probe_health_once(url).await {
+            ProbeOutcome::Success(body) => {
+                return interpret_health(check, service, addr, body.as_ref());
+            }
+            ProbeOutcome::NonSuccess(code) => {
+                last_status = Some(code);
+                last_timeout = false;
+            }
+            ProbeOutcome::TimedOut => {
+                last_timeout = true;
+            }
+            ProbeOutcome::Unreachable(e) => {
+                last_err = Some(e);
+                last_timeout = false;
+            }
+        }
+        if attempt + 1 < PROBE_ATTEMPTS {
+            tokio::time::sleep(PROBE_RETRY_DELAY).await;
+        }
+    }
+
+    if last_timeout {
+        // Issue #4005: THE false negative. Do not claim the daemon is down —
+        // we never established that. A slow /health is exactly what a healthy
+        // daemon under load looks like from here.
+        return DoctorCheck::new(
+            check,
+            CheckStatus::Unknown,
+            format!(
+                "{service} at {addr} did not answer /health within {}s across {PROBE_ATTEMPTS} \
+                 attempts, but the connection was NOT refused — the daemon may be alive and \
+                 merely slow. Health could not be determined. Check the MCP surface before \
+                 restarting anything.",
+                PROBE_TIMEOUT.as_secs()
+            ),
+        );
+    }
+
+    if let Some(code) = last_status {
+        return DoctorCheck::new(
+            check,
+            CheckStatus::Fail,
+            format!("{service} at {addr} returned HTTP {code}"),
+        );
+    }
+
+    DoctorCheck::new(
+        check,
+        CheckStatus::Fail,
+        format!(
+            "{service} unreachable at {addr}: {}",
+            last_err.unwrap_or_else(|| "connection refused".to_string())
+        ),
+    )
+}
+
+/// Map a 2xx `/health` body to a status (issues #4001, #4005).
+///
+/// Why: a 2xx proves a listener accepted a socket, not that the daemon is
+/// doing work — which is precisely how #3992 kept `tm doctor` green for the
+/// duration of an incident in which six threads were parked and a
+/// `memory_remember` had been hung for ~1800 s. When the daemon reports its
+/// own worker occupancy, that observation wins over our inference.
+/// What: `Fail` on a reported wedge, `Warn` while warming or degraded,
+/// `Unknown` when no worker block is present (an older daemon, or an
+/// unreadable body — we cannot claim health we did not observe), `Ok`
+/// otherwise.
+/// Test: `memory_wedged_worker_pool_is_not_ok`, `memory_warming_is_warn_not_fail`,
+/// `health_body_without_worker_block_is_unknown`.
+fn interpret_health(
+    check: &str,
+    service: &str,
+    addr: &str,
+    body: Option<&serde_json::Value>,
+) -> DoctorCheck {
+    let Some(body) = body else {
+        return DoctorCheck::new(
+            check,
+            CheckStatus::Unknown,
+            format!(
+                "{service} at {addr} answered /health but the body was unreadable — the \
+                 listener is up; whether its workers are progressing is UNKNOWN"
+            ),
+        );
+    };
+
+    let worker = body.get("worker");
+    let wedged = worker
+        .and_then(|w| w.get("wedged"))
+        .and_then(serde_json::Value::as_bool);
+
+    match wedged {
+        Some(true) => {
+            let oldest = worker
+                .and_then(|w| w.get("oldest_age_secs"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_default();
+            let in_flight = worker
+                .and_then(|w| w.get("in_flight"))
+                .and_then(serde_json::Value::as_u64)
+                .unwrap_or_default();
+            return DoctorCheck::new(
+                check,
+                CheckStatus::Fail,
+                format!(
+                    "{service} at {addr} is answering /health BUT reports a WEDGED worker \
+                     pool: oldest in-flight operation {oldest}s, {in_flight} in flight. The \
+                     listener responding does not mean writes are progressing (issue #3992)."
+                ),
+            );
+        }
+        None => {
+            return DoctorCheck::new(
+                check,
+                CheckStatus::Unknown,
+                format!(
+                    "{service} at {addr} is reachable but does not report worker-pool \
+                     occupancy (pre-#4001 build) — liveness confirmed, progress UNKNOWN"
+                ),
+            );
+        }
+        Some(false) => {}
+    }
+
+    // Issue #4005 explicitly calls out post-restart warm-up: it is a normal
+    // transient state, not a failure, and must not read as fully healthy either.
+    if body.get("daemon_state").and_then(|v| v.as_str()) == Some("warming") {
+        return DoctorCheck::new(
+            check,
+            CheckStatus::Warn,
+            format!(
+                "{service} at {addr} is WARMING UP (embedder initialising) — normal shortly after a restart"
+            ),
+        );
+    }
+
+    if body.get("status").and_then(|v| v.as_str()) == Some("degraded") {
+        let detail = body
+            .get("detail")
+            .and_then(|v| v.as_str())
+            .unwrap_or("no detail reported");
+        return DoctorCheck::new(
+            check,
+            CheckStatus::Warn,
+            format!("{service} at {addr} reports DEGRADED: {detail}"),
+        );
+    }
+
+    DoctorCheck::new(
+        check,
+        CheckStatus::Ok,
+        format!("{service} healthy at {addr}, workers progressing"),
+    )
 }
 
 /// Probe the trusty-search sidecar's health and the `trusty-mpm` index.

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -297,3 +297,264 @@ async fn worktrees_with_orphan_is_warn() {
     assert!(check.message.contains("1 orphaned"));
     assert!(check.message.contains("tm session prune --worktrees"));
 }
+
+// ---- Issues #4005 / #4001: doctor must observe, not infer ----
+
+/// Spawn a throwaway HTTP listener that answers `GET /health` with `body`
+/// after waiting `delay`.
+///
+/// Why: the existing probe tests bind port 0 (which only ever refuses), so
+/// nothing in this suite could express "a daemon that IS serving". Both #4005
+/// (a serving daemon reported unreachable) and #4001 (a wedged daemon reported
+/// healthy) are about what doctor concludes from a REAL response, so the tests
+/// need a real socket. Hand-rolled over `TcpListener` to avoid pulling an HTTP
+/// server dependency into the test graph.
+/// What: binds an ephemeral port, returns its `host:port`, and serves the
+/// canned JSON to every connection until the test ends.
+/// Test: used by the #4005/#4001 tests below.
+async fn spawn_health_listener(body: serde_json::Value, delay: std::time::Duration) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut sock, _)) = listener.accept().await else {
+                return;
+            };
+            let body = body.to_string();
+            tokio::spawn(async move {
+                let mut buf = [0u8; 1024];
+                let _ = sock.read(&mut buf).await;
+                tokio::time::sleep(delay).await;
+                let resp = format!(
+                    "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.flush().await;
+            });
+        }
+    });
+    addr
+}
+
+/// A `/health` body from a healthy, fully-ready daemon.
+fn healthy_body() -> serde_json::Value {
+    serde_json::json!({
+        "status": "ok",
+        "daemon_state": "ready",
+        "worker": {"in_flight": 0, "wedged": false},
+    })
+}
+
+/// Why (issue #4001): THE false positive. During the #3992 incident six
+/// trusty-memory threads were parked in `concurrent_open::backoff_sleep_ms`
+/// with a `memory_remember` hung ~1800 s, and `tm doctor` reported HEALTHY the
+/// entire time — because it only ever asked "did the socket answer?". Here the
+/// listener is fully live and returns a clean HTTP 200; only the body reveals
+/// the wedge. Before this change doctor returned `Ok` for exactly this input.
+/// What: asserts a wedge-reporting daemon is NOT `Ok`, and that the message
+/// names the wedge so an operator is not sent looking elsewhere.
+/// Test: itself.
+#[tokio::test]
+async fn memory_wedged_worker_pool_is_not_ok() {
+    let body = serde_json::json!({
+        "status": "ok",
+        "daemon_state": "ready",
+        "worker": {"in_flight": 6, "oldest_age_secs": 1800, "wedged": true},
+    });
+    let addr = spawn_health_listener(body, std::time::Duration::ZERO).await;
+    let check = probe_health(
+        "memory",
+        "trusty-memory",
+        &format!("http://{addr}/health"),
+        &addr,
+    )
+    .await;
+
+    assert_ne!(
+        check.status,
+        CheckStatus::Ok,
+        "a live listener over a wedged worker pool must NOT report healthy: {}",
+        check.message
+    );
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(
+        check.message.contains("WEDGED"),
+        "message must name the wedge: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("1800"),
+        "message must carry the observed age: {}",
+        check.message
+    );
+}
+
+/// Why (issue #4005): THE false negative. A daemon that is genuinely serving
+/// must not be called unreachable just because `/health` is slower than the
+/// probe's budget — `/health` samples RSS/CPU and enumerates file descriptors,
+/// work the MCP path never does. This listener answers correctly but takes
+/// 2.5 s, which the old 2 s single-shot budget turned into
+/// "trusty-memory unreachable at ...".
+/// What: asserts a slow-but-serving daemon reports `Ok`.
+/// Test: itself.
+#[tokio::test]
+async fn memory_slow_but_serving_daemon_is_ok() {
+    let addr = spawn_health_listener(healthy_body(), std::time::Duration::from_millis(2500)).await;
+    let check = probe_health(
+        "memory",
+        "trusty-memory",
+        &format!("http://{addr}/health"),
+        &addr,
+    )
+    .await;
+
+    assert_eq!(
+        check.status,
+        CheckStatus::Ok,
+        "a serving daemon that is merely slow must not be reported unreachable: {}",
+        check.message
+    );
+    assert!(
+        !check.message.contains("unreachable"),
+        "message must not claim unreachable: {}",
+        check.message
+    );
+}
+
+/// Why (issue #4005, warm-up case): the issue explicitly notes the failure may
+/// only reproduce right after a `tm` restart, and asks that the fix handle
+/// warm-up specifically rather than reporting a hard failure. A warming daemon
+/// is serving (recall falls back to the non-embedder path) so it is not a
+/// failure; it is not fully ready either, so it is not `Ok`.
+/// What: asserts warm-up is `Warn` — neither `Fail` nor `Ok`.
+/// Test: itself.
+#[tokio::test]
+async fn memory_warming_is_warn_not_fail() {
+    let body = serde_json::json!({
+        "status": "ok",
+        "daemon_state": "warming",
+        "worker": {"in_flight": 1, "oldest_age_secs": 2, "wedged": false},
+    });
+    let addr = spawn_health_listener(body, std::time::Duration::ZERO).await;
+    let check = probe_health(
+        "memory",
+        "trusty-memory",
+        &format!("http://{addr}/health"),
+        &addr,
+    )
+    .await;
+
+    assert_eq!(
+        check.status,
+        CheckStatus::Warn,
+        "post-restart warm-up must be a warning, not a failure: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("WARMING"),
+        "message must name the warm-up: {}",
+        check.message
+    );
+}
+
+/// Why (the unifying principle): a probe that times out has learned NOTHING.
+/// Rendering that as `Fail` is the #4005 false negative; rendering it as `Ok`
+/// would be a false positive. It must render as its own state, and that state
+/// must never be healthy.
+/// What: points the probe at a listener that accepts the connection and then
+/// never answers, and asserts `Unknown` — explicitly neither `Ok` nor `Fail`.
+/// Test: itself.
+#[tokio::test]
+async fn memory_timeout_is_unknown_not_fail() {
+    // Accept connections but never respond, so the probe times out rather
+    // than being refused.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((sock, _)) = listener.accept().await {
+            held.push(sock); // hold the socket open, answer nothing
+        }
+    });
+
+    let check = tokio::time::timeout(
+        std::time::Duration::from_secs(90),
+        probe_health(
+            "memory",
+            "trusty-memory",
+            &format!("http://{addr}/health"),
+            &addr,
+        ),
+    )
+    .await
+    .expect("probe must stay bounded");
+
+    assert_eq!(
+        check.status,
+        CheckStatus::Unknown,
+        "a timed-out probe must be UNKNOWN, not a verdict: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("could not be determined"),
+        "message must say so plainly: {}",
+        check.message
+    );
+}
+
+/// Why (issue #4001, forward-compatibility): a daemon too old to report worker
+/// occupancy cannot support a healthy verdict — doctor has no observation to
+/// base one on. Claiming `Ok` there would reintroduce exactly the inference
+/// this fix removes.
+/// What: asserts a 2xx body with no `worker` block is `Unknown`.
+/// Test: itself.
+#[tokio::test]
+async fn health_body_without_worker_block_is_unknown() {
+    let body = serde_json::json!({"status": "ok", "daemon_state": "ready"});
+    let addr = spawn_health_listener(body, std::time::Duration::ZERO).await;
+    let check = probe_health(
+        "memory",
+        "trusty-memory",
+        &format!("http://{addr}/health"),
+        &addr,
+    )
+    .await;
+
+    assert_eq!(
+        check.status,
+        CheckStatus::Unknown,
+        "no worker observation means health is undetermined: {}",
+        check.message
+    );
+}
+
+/// Why: the aggregate verdict is what an operator actually reads. If a single
+/// `Unknown` could still fold into an `Ok` report, the third state would be
+/// cosmetic.
+/// What: asserts `Unknown` outranks `Ok` and `Warn` but not `Fail`.
+/// Test: itself.
+#[test]
+fn unknown_never_aggregates_to_ok() {
+    let report = DoctorReport::from_checks(vec![
+        DoctorCheck::new("a", CheckStatus::Ok, "fine"),
+        DoctorCheck::new("b", CheckStatus::Unknown, "no idea"),
+    ]);
+    assert_eq!(report.overall, CheckStatus::Unknown);
+
+    let with_warn = DoctorReport::from_checks(vec![
+        DoctorCheck::new("a", CheckStatus::Warn, "meh"),
+        DoctorCheck::new("b", CheckStatus::Unknown, "no idea"),
+    ]);
+    assert_eq!(with_warn.overall, CheckStatus::Unknown);
+
+    // A real failure still outranks an unknown — a known problem is more
+    // actionable than an undetermined one.
+    let with_fail = DoctorReport::from_checks(vec![
+        DoctorCheck::new("a", CheckStatus::Unknown, "no idea"),
+        DoctorCheck::new("b", CheckStatus::Fail, "broken"),
+    ]);
+    assert_eq!(with_fail.overall, CheckStatus::Fail);
+}

--- a/crates/trusty-mpm/src/slack/formatter/mod.rs
+++ b/crates/trusty-mpm/src/slack/formatter/mod.rs
@@ -430,13 +430,16 @@ fn format_health(report: &HealthReport) -> String {
 /// The emoji icon for a doctor check status.
 ///
 /// Why: the `/doctor` message marks each check with a glanceable status symbol.
-/// What: `Ok → ✅`, `Warn → ⚠️`, `Fail → ❌`.
+/// What: `Ok → ✅`, `Warn → ⚠️`, `Unknown → ❔`, `Fail → ❌`.
 /// Test: covered by `format_doctor_report_lists_each_check`.
 fn status_icon(status: crate::core::doctor::CheckStatus) -> &'static str {
     use crate::core::doctor::CheckStatus;
     match status {
         CheckStatus::Ok => "✅",
         CheckStatus::Warn => "⚠️",
+        // Never ✅ (issue #4005): an indeterminate check must not read as
+        // healthy at a glance.
+        CheckStatus::Unknown => "❔",
         CheckStatus::Fail => "❌",
     }
 }
@@ -444,13 +447,15 @@ fn status_icon(status: crate::core::doctor::CheckStatus) -> &'static str {
 /// A one-word label for a doctor check status.
 ///
 /// Why: the overall verdict reads better with a word than a bare icon.
-/// What: `Ok → "healthy"`, `Warn → "warnings"`, `Fail → "failed"`.
+/// What: `Ok → "healthy"`, `Warn → "warnings"`, `Unknown → "undetermined"`,
+/// `Fail → "failed"`.
 /// Test: covered by `format_doctor_report_lists_each_check`.
 fn status_word(status: crate::core::doctor::CheckStatus) -> &'static str {
     use crate::core::doctor::CheckStatus;
     match status {
         CheckStatus::Ok => "healthy",
         CheckStatus::Warn => "warnings",
+        CheckStatus::Unknown => "undetermined",
         CheckStatus::Fail => "failed",
     }
 }

--- a/crates/trusty-mpm/src/telegram/formatter/mod.rs
+++ b/crates/trusty-mpm/src/telegram/formatter/mod.rs
@@ -532,13 +532,16 @@ fn format_health(report: &HealthReport) -> String {
 /// The emoji icon for a doctor [`CheckStatus`](crate::core::doctor::CheckStatus).
 ///
 /// Why: the `/doctor` message marks each check with a glanceable status symbol.
-/// What: `Ok → ✅`, `Warn → ⚠️`, `Fail → ❌`.
+/// What: `Ok → ✅`, `Warn → ⚠️`, `Unknown → ❔`, `Fail → ❌`.
 /// Test: covered by `format_doctor_report_lists_each_check`.
 fn status_icon(status: crate::core::doctor::CheckStatus) -> &'static str {
     use crate::core::doctor::CheckStatus;
     match status {
         CheckStatus::Ok => "✅",
         CheckStatus::Warn => "⚠️",
+        // Never ✅ (issue #4005): an indeterminate check must not read as
+        // healthy at a glance.
+        CheckStatus::Unknown => "❔",
         CheckStatus::Fail => "❌",
     }
 }
@@ -546,13 +549,15 @@ fn status_icon(status: crate::core::doctor::CheckStatus) -> &'static str {
 /// A one-word label for a doctor [`CheckStatus`](crate::core::doctor::CheckStatus).
 ///
 /// Why: the overall verdict reads better with a word than a bare icon.
-/// What: `Ok → "healthy"`, `Warn → "warnings"`, `Fail → "failed"`.
+/// What: `Ok → "healthy"`, `Warn → "warnings"`, `Unknown → "undetermined"`,
+/// `Fail → "failed"`.
 /// Test: covered by `format_doctor_report_lists_each_check`.
 fn status_word(status: crate::core::doctor::CheckStatus) -> &'static str {
     use crate::core::doctor::CheckStatus;
     match status {
         CheckStatus::Ok => "healthy",
         CheckStatus::Warn => "warnings",
+        CheckStatus::Unknown => "undetermined",
         CheckStatus::Fail => "failed",
     }
 }


### PR DESCRIPTION
## The two issues are one defect

**#4001 (false positive)** — during the #3992 incident six trusty-memory
threads sat parked in `concurrent_open::backoff_sleep_ms` with a
`memory_remember` hung ~1800s, and both `tm doctor` and `trusty-memory doctor`
reported HEALTHY throughout. They checked HTTP liveness, fastembed cache state,
and lock-file staleness — every one of which describes the **process**, none of
which can see a wedged **worker pool**.

**#4005 (false negative)** — `tm doctor` reported "trusty-memory unreachable at
127.0.0.1:7070" while MCP `memory_recall`/`memory_remember` succeeded against
that same daemon in the same minutes.

Both are the same bug: **doctor inferred health from a cheap proxy instead of
observing the thing it claims to report.** Fixing either alone trades one false
verdict for the other, which is why they land together.

## Investigation

**#4005 root cause — `/health` does different work than the MCP path.** The
default (non-`?probe=true`) handler is cheap but not free: it takes
`sys_metrics.lock().await` and calls `.sample()` (a sysinfo RSS/CPU refresh),
and calls `count_open_fds()`, which enumerates `/dev/fd`. **Neither is on the
MCP request path.** Under load those can exceed a 2s budget that ordinary MCP
calls never approach. Combined with a **single-shot** probe and **no
discrimination between a timeout and a refusal**, one unlucky sample became a
hard "unreachable" verdict.

I confirmed the deep `?probe=true` path *can* also block (it goes through the
same `open_locks`/`open_queue_timeout` machinery as a real write) — but `tm
doctor` never passes that flag, so it was **not** the cause here. Left alone.

**#4001 — what signal would have revealed the wedge.** I chose **the age of the
oldest in-flight operation**, registered at `open_palace_handle`: the single
choke point every `memory_recall`/`memory_remember` passes through, and exactly
where the #3992 wedge occurred (`open_palace` serialises on a per-palace mutex
and drops into `concurrent_open`'s redb retry/backoff loop on a miss).

Why age and not the alternatives:

| Candidate | Verdict |
|---|---|
| **Oldest in-flight age** | **Chosen.** Directly observes that work has stopped moving. |
| In-flight count alone | Rejected — cannot distinguish healthy concurrency from a wedge. |
| Time since last completion | Rejected — a stream of fast recalls masks one wedged writer. |
| Thread-state sampling | Rejected — platform debugging APIs, expensive. |
| Mutex wait-time histogram | Rejected — needs `parking_lot` internals. |

Cost: a fixed 64-slot lock-free table of start timestamps — **one CAS in, one
store out**, no allocation, no syscall, no lock on the hot path. It cannot
become the load problem it exists to detect. Registration is **RAII**, because
the tracked operations are exactly the ones that fail and unwind; an explicit
release would leak slots on the `?` path and read as a *permanent phantom
wedge*. There is a test for the panic path specifically.

`/health` publishes the observation as a `worker` block so an out-of-process
doctor can read it; the wedge threshold defaults to `2 × open_queue_timeout()`
so it always sits above the longest legitimately-bounded wait.

## The third state (the part worth keeping if nothing else survives)

Both doctors gained an indeterminate status, rendered `❔` — **never `✅`**. In
`trusty-mpm` it ranks above `Warn`, so a single indeterminate check can never
leave the aggregate report reading healthy. A **timeout** yields `Unknown`
(we learned nothing); a **refused connection** still yields `Fail` (nothing is
listening); a 2xx carrying **no worker observation** — an older daemon, an
unreadable body — is `Unknown` rather than a pass doctor cannot support.

Also: budget 2s → 10s, 3 attempts, and post-restart warm-up reports `Warn` per
the issue's explicit request.

## Before/after evidence

I reproduced the **pre-fix algorithm verbatim** (2s, single shot, any 2xx ⇒ Ok)
against the same test listeners, to prove the new tests genuinely fail on the
old code rather than merely being new:

```
OLD wedged-pool           => Ok                    <-- #4001 false positive
OLD slow-but-serving      => Fail(unreachable)     <-- #4005 false negative
OLD warming               => Ok
```

(That probe was temporary scaffolding and is **not** in the diff.)

## Tests

All fail before / pass after. No `#[ignore]`, no cfg-gates.

**`trusty-mpm` — `daemon::doctor::tests`** (real ephemeral TCP listeners; the
existing tests only ever bound port 0, which can only refuse, so nothing here
could previously express "a daemon that IS serving"):

- `memory_wedged_worker_pool_is_not_ok` — #4001. Live listener, clean 200; only
  the body reveals the wedge. Old code: `Ok`.
- `memory_slow_but_serving_daemon_is_ok` — #4005. Answers correctly but takes
  2.5s. Old code: `Fail(unreachable)`.
- `memory_warming_is_warn_not_fail` — #4005 warm-up case.
- `memory_timeout_is_unknown_not_fail` — accepts the socket, never answers.
- `health_body_without_worker_block_is_unknown`
- `unknown_never_aggregates_to_ok`

**`trusty-memory` — `web::tests::health_tests`:**
- `health_reports_wedged_worker_pool` — asserts `status != "ok"`, the #3992
  false positive.
- `health_wedge_signal_clears_when_work_completes` — the signal must not stick.
- `health_reports_idle_worker_pool`

**`trusty-memory` — `commands::doctor::tests`:** `wedged_body_is_fail`,
`warming_body_is_warn`, `indeterminate_probe_renders_as_unknown_not_pass`,
`body_without_worker_block_is_unknown`, `healthy_body_is_pass`,
`degraded_body_is_warn`

**`trusty-memory` — `worker_liveness::tests`:** `idle_tracker_reports_no_work`,
`in_flight_counts_active_operations`, `guard_releases_slot_on_drop`,
`guard_releases_slot_on_panic`, `oldest_age_tracks_the_earliest_operation`,
`oldest_age_recovers_when_the_slow_operation_finishes`,
`wedged_when_oldest_exceeds_threshold`, `overflow_is_counted_when_slots_exhausted`,
`wedge_threshold_exceeds_the_open_queue_bound`

Two pre-existing environment-tolerant tests
(`check_daemon_health_fails_*_no_listener`) were widened to accept `Unknown`:
a live **pre-#4001** daemon on 7070 is genuinely undetermined, which is the new
correct answer. Rationale is in the test.

## ⚠️ BREAKING — needs a MINOR bump

`core::doctor::CheckStatus` gained a variant, so downstream exhaustive matches
hit **E0004**. This is the same trap that forced the `trusty-analyze` 0.7.3
yank — **`trusty-mpm` must go MINOR, not patch.** Four in-workspace match sites
(Slack + Telegram formatters, `tm doctor` CLI renderer) gained an arm; the
compiler found them all.

## Investigated and deliberately NOT changed

- **The `?probe=true` deep path.** It genuinely can block on
  `open_palace`/`open_queue_timeout`, but `tm doctor` never sets the flag, so
  it is not #4005's cause. Out of scope.
- **`concurrent_open`'s retry/backoff itself.** PR #3996 bounded it; this PR is
  strictly about *observability*, per #4001's framing.
- **`open_locks` / `open_queue_timeout` semantics** — untouched.
- **The `SKIP_UI_BUILD` guard (`build.rs:33-79`)** — untouched, as instructed.
- **`/health` still returns HTTP 200 even when wedged** — monitors keyed on
  status code depend on it; the body is the authority. Changing it would be a
  separate, wider decision.
- **`trusty-search`'s probe** — shares `probe_health` and so inherits the retry
  and timeout/refusal split, but I did not add a worker block to trusty-search;
  that crate is owned by other in-flight work (#4122, #4123/#4110).

## Gate

- `cargo fmt --all --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0
- `cargo test --workspace --no-fail-fast` — **19724 passed, 1 failed**
- `scripts/check_line_cap.sh` — `7 allowlisted, 0 violations — OK`

The single failure is pre-existing and environmental:
`trusty-agents::tools::python_skill::tests::execute_dispatches_to_python_and_parses_json`
(broken `/opt/homebrew/bin/python3` uv cache — `Failed to inspect Python
interpreter`), reproduced on a clean `origin/main` checkout in this environment
before being attributed. Untouched by this PR.

Clippy and test used CI's own GUI exclusion list from `ci.yml`
(`--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude
trusty-agents-ui`) with `SKIP_UI_BUILD=1`, matching the headless workspace jobs.

Closes #4005
Closes #4001

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
