### PR TITLE
fix(trusty-mpm): stop the test suite writing trust seeds into the real .claude.json (#4206)

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -25,6 +25,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`claude_config::quarantine_path`** — computes a unique, timestamped
+  quarantine name (`<path>.corrupt-<UTC stamp>`) for a corrupt config file
+  ([#4206](https://github.com/bobmatnyc/trusty-tools/issues/4206)). Two
+  independent trusty-mpm writers previously renamed a malformed `.claude.json`
+  to the same fixed `.claude.json.corrupt`, so a second quarantine silently
+  destroyed the first one's bytes. Purely additive: no existing behaviour
+  changes.
+
 - `json_rmw`: cross-process locked read-modify-write for whole-file JSON
   documents — the single implementation of the load → mutate → save critical
   section that `trusty-mpm`'s `projects.json`, `trusty-gworkspace`'s

--- a/crates/trusty-common/src/claude_config.rs
+++ b/crates/trusty-common/src/claude_config.rs
@@ -283,6 +283,48 @@ pub fn merge_hook_entries(existing: &Value, additions: &Value) -> Value {
     result
 }
 
+/// Reserve a unique, timestamped quarantine path for a corrupt config file.
+///
+/// Why (issue #4206): two independent writers in trusty-mpm
+/// (`core::standalone::trust_seed` and `core::mcp_config`) each renamed a
+/// malformed `.claude.json` to the FIXED name `.claude.json.corrupt`. The
+/// second quarantine therefore silently overwrote the first — destroying the
+/// only record of the first failure, in the exact file that also holds
+/// `oauthAccount` and every project's trust state. A post-mortem could see
+/// that corruption had happened at least once and nothing more. Centralising
+/// the naming here (rather than fixing it twice) means the two writers can
+/// never drift back apart, and any future third writer inherits the same
+/// scheme.
+/// What: `<path>.corrupt-<UTC timestamp>`, e.g.
+/// `.claude.json.corrupt-20260728T025723.418Z`. Millisecond precision makes a
+/// same-second collision unlikely; the function additionally probes for an
+/// unused name (appending `-1`, `-2`, …, bounded) so two quarantine events can
+/// NEVER collapse onto one file even under a coarse clock. Purely a name
+/// computation — it does not create, rename, or touch anything, so the tiny
+/// TOCTOU window between probing and the caller's `rename` is acceptable: the
+/// worst case is the same overwrite that was previously guaranteed, and only
+/// under a race that the timestamp already makes vanishingly rare.
+/// Test: `quarantine_path_is_timestamped_and_unique`,
+///   `quarantine_path_avoids_existing_file`.
+pub fn quarantine_path(path: &Path) -> PathBuf {
+    let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ").to_string();
+    let base = append_extension(path, &format!("corrupt-{stamp}"));
+    if !base.exists() {
+        return base;
+    }
+    // Coarse clock or a genuine same-millisecond race: find an unused sibling
+    // rather than clobbering the earlier record. Bounded so a pathological
+    // filesystem can never spin here; the final fallback still returns a
+    // distinct-by-timestamp name.
+    for n in 1..1000 {
+        let candidate = append_extension(path, &format!("corrupt-{stamp}-{n}"));
+        if !candidate.exists() {
+            return candidate;
+        }
+    }
+    base
+}
+
 // ─── internal helpers ─────────────────────────────────────────────────────
 
 /// Path of the backup file written before an atomic JSON write: `<path>.bak`.

--- a/crates/trusty-common/src/claude_config.rs
+++ b/crates/trusty-common/src/claude_config.rs
@@ -308,6 +308,25 @@ pub fn merge_hook_entries(existing: &Value, additions: &Value) -> Value {
 ///   `quarantine_path_avoids_existing_file`.
 pub fn quarantine_path(path: &Path) -> PathBuf {
     let stamp = chrono::Utc::now().format("%Y%m%dT%H%M%S%.3fZ").to_string();
+    quarantine_path_with_stamp(path, &stamp)
+}
+
+/// Stamp-injected core of [`quarantine_path`].
+///
+/// Why: the collision-probe loop is the only part of the naming scheme that can
+/// actually lose a quarantine record, and it is unreachable from a test that
+/// cannot control the timestamp — with a wall clock the caller can never plant
+/// a file at the name the next call will compute, so the probe would only ever
+/// be exercised by an unreproducible same-millisecond race. Taking the stamp as
+/// a parameter makes the loop deterministically testable without weakening the
+/// public signature or introducing a clock abstraction.
+/// What: identical behaviour to [`quarantine_path`], with `stamp` supplied by
+/// the caller instead of read from `Utc::now`. Private — the public entry point
+/// remains the only supported way to reserve a quarantine name.
+/// Test: `quarantine_path_avoids_existing_file` drives this directly with a
+///   fixed stamp; `quarantine_path_is_timestamped_and_unique` covers the public
+///   wrapper.
+fn quarantine_path_with_stamp(path: &Path, stamp: &str) -> PathBuf {
     let base = append_extension(path, &format!("corrupt-{stamp}"));
     if !base.exists() {
         return base;
@@ -469,6 +488,80 @@ mod tests {
         let existing = json!({ "hooks": { "Stop": [{ "command": "x" }] } });
         let merged = merge_hook_entries(&existing, &json!({}));
         assert_eq!(merged, existing);
+    }
+
+    /// The name must carry a UTC timestamp, preserve the original file name,
+    /// and never repeat across two calls — the whole point of #4206's fix is
+    /// that a second quarantine cannot land on the first one's bytes.
+    #[test]
+    fn quarantine_path_is_timestamped_and_unique() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".claude.json");
+
+        let first = quarantine_path(&path);
+        let name = first.file_name().unwrap().to_string_lossy().into_owned();
+
+        assert!(
+            name.starts_with(".claude.json.corrupt-"),
+            "quarantine name must extend the original file name: {name}"
+        );
+        let stamp = name
+            .strip_prefix(".claude.json.corrupt-")
+            .expect("prefix asserted above");
+        assert!(
+            stamp.len() >= 20 && stamp.ends_with('Z') && stamp.contains('T'),
+            "expected a `YYYYmmddTHHMMSS.sssZ` UTC stamp, got {stamp:?}"
+        );
+        assert_eq!(
+            first.parent(),
+            path.parent(),
+            "quarantine must stay a sibling of the file it replaces"
+        );
+
+        // Simulate the first rename actually happening, then quarantine again:
+        // whether the clock advanced or the probe loop fired, the second name
+        // must not be the first one.
+        std::fs::write(&first, b"{ corrupt").unwrap();
+        let second = quarantine_path(&path);
+        assert_ne!(
+            first, second,
+            "a second quarantine must never reuse an occupied name"
+        );
+    }
+
+    /// The collision probe, driven with a fixed stamp so it is exercised
+    /// deterministically rather than only under a same-millisecond race.
+    #[test]
+    fn quarantine_path_avoids_existing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(".claude.json");
+        let stamp = "20260728T025723.418Z";
+
+        let base = quarantine_path_with_stamp(&path, stamp);
+        assert_eq!(
+            base.file_name().unwrap(),
+            ".claude.json.corrupt-20260728T025723.418Z"
+        );
+
+        std::fs::write(&base, b"first corruption").unwrap();
+        let second = quarantine_path_with_stamp(&path, stamp);
+        assert_eq!(
+            second.file_name().unwrap(),
+            ".claude.json.corrupt-20260728T025723.418Z-1",
+            "an occupied name must be sidestepped, not overwritten"
+        );
+
+        std::fs::write(&second, b"second corruption").unwrap();
+        let third = quarantine_path_with_stamp(&path, stamp);
+        assert_eq!(
+            third.file_name().unwrap(),
+            ".claude.json.corrupt-20260728T025723.418Z-2",
+            "the probe must keep walking, not stop at -1"
+        );
+
+        // The earlier records survive untouched — the defect being fixed.
+        assert_eq!(std::fs::read(&base).unwrap(), b"first corruption");
+        assert_eq!(std::fs::read(&second).unwrap(), b"second corruption");
     }
 
     #[test]

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -91,6 +91,40 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **The test suite no longer writes trust-seed entries into the operator's real
+  managed `.claude.json`**
+  ([#4206](https://github.com/bobmatnyc/trusty-tools/issues/4206)): five tests
+  drove the real spawn path (`ClaudeCodeAdapter::spawn`/`spawn_resume` →
+  `prepare_managed_config` → `preseed_managed_trust`) without redirecting
+  `$HOME`, so each one wrote a `projects.<tempdir>` entry straight into
+  `~/.trusty-tools/trusty-mpm/claude-config/.claude.json` — a file that also
+  holds `oauthAccount`. 2,443 of 2,538 entries in the reporting operator's
+  config were `tempfile::TempDir` paths as a result. Those tests now redirect
+  `$HOME` (the isolation seam `dirs::home_dir()` already honours), and a new
+  regression test locks the invariant at the layer they all funnel through.
+  **No production behaviour changes** — the resolver was never the defect; see
+  the PR body for why the originally-reported root cause ("takes no injectable
+  base") did not hold up, and why honouring an ambient `CLAUDE_CONFIG_DIR`
+  would have made the leak strictly worse.
+- **The managed `.claude.json` `projects` map is now self-healing**
+  ([#4206](https://github.com/bobmatnyc/trusty-tools/issues/4206)): during the
+  read-modify-write `preseed_managed_trust` already performs, entries are dropped
+  when — and only when — the directory is DEFINITIVELY absent (a clean
+  `NotFound`) **and** the entry carries nothing beyond the four keys the seeder
+  itself writes. An ambiguous filesystem error (unmounted volume, down network
+  mount, permission denied, I/O fault) always KEEPS the entry, and any entry
+  carrying Claude Code's own runtime state (`lastSessionId`, `lastCost`,
+  `mcpServers`, …) is preserved even when its path is gone. No new command, no
+  background job.
+- **A second config quarantine no longer destroys the record of the first**
+  ([#4206](https://github.com/bobmatnyc/trusty-tools/issues/4206)): the two
+  writers that quarantine a malformed `.claude.json` (`standalone::trust_seed`
+  and `core::mcp_config`) both used the fixed name `.claude.json.corrupt`, so
+  whichever ran second silently overwrote the first one's evidence. Both now
+  share `trusty_common::claude_config::quarantine_path`, which timestamps the
+  filename, and both log at `error!` rather than `warn!` — the workspace's
+  error-capture layer filters on `!= Level::ERROR`, so the previous `warn!`
+  reached no diagnostic surface at all.
 - keep the PM persona on in-place relaunch and test the exec seam ([#4340](https://github.com/bobmatnyc/trusty-tools/pull/4340)) ([`714f33e`](https://github.com/bobmatnyc/trusty-tools/commit/714f33ed52f681b6d884a1c380c46935a8f2450a))
   - `compose_inplace_args` omitted `--append-system-prompt-file`; now builds
     the prompt through the same `build_prompt_file` carrier `spawn`/

--- a/crates/trusty-mpm/src/core/mcp_config.rs
+++ b/crates/trusty-mpm/src/core/mcp_config.rs
@@ -641,18 +641,31 @@ fn read_config(config_dir: &Path) -> Result<(PathBuf, Value)> {
         Ok(v) if v.is_object() => Ok((path, v)),
         other => {
             // Valid-but-not-object OR malformed → quarantine, proceed fresh.
-            let corrupt = path.with_extension("json.corrupt");
+            //
+            // Issue #4206: TIMESTAMPED via the shared
+            // `trusty_common::claude_config::quarantine_path`, not the fixed
+            // `.claude.json.corrupt` this used to use. This function and
+            // `standalone::trust_seed::preseed_managed_trust` both quarantine
+            // the SAME file, so with a fixed name whichever ran second silently
+            // destroyed the first one's evidence. Sharing the helper keeps the
+            // two writers from drifting apart again.
+            let corrupt = trusty_common::claude_config::quarantine_path(&path);
             let reason = match &other {
                 Ok(_) => "valid JSON but not an object".to_string(),
                 Err(err) => format!("not valid JSON ({err})"),
             };
+            // ERROR, not warn: this discards a `.claude.json` holding OAuth
+            // state and every project's trust. `warn!` reaches no diagnostic
+            // surface in this workspace — the error-capture layer filters on
+            // `!= Level::ERROR` and is composed only for the Daemon and
+            // Supervisor commands.
             match std::fs::rename(&path, &corrupt) {
-                Ok(()) => tracing::warn!(
+                Ok(()) => tracing::error!(
                     "{} is {reason}; quarantined to {} — proceeding with fresh config",
                     path.display(),
                     corrupt.display()
                 ),
-                Err(rename_err) => tracing::warn!(
+                Err(rename_err) => tracing::error!(
                     "{} is {reason}; quarantine rename failed ({rename_err}) — \
                      proceeding with fresh config",
                     path.display()

--- a/crates/trusty-mpm/src/core/mcp_config_tests.rs
+++ b/crates/trusty-mpm/src/core/mcp_config_tests.rs
@@ -177,9 +177,20 @@ fn add_quarantines_malformed_json() {
     std::fs::write(cfg.join(CLAUDE_JSON), b"{ not valid json !!!").unwrap();
     // add must succeed despite the corrupt file.
     add_server(&cfg, "echo", stdio("echo", &["hi"])).unwrap();
-    assert!(
-        cfg.join(".claude.json.corrupt").exists(),
-        "corrupt file quarantined, not deleted"
+    // Issue #4206: the quarantine name is TIMESTAMPED
+    // (`.claude.json.corrupt-<stamp>`), not the fixed `.claude.json.corrupt`
+    // this used to assert — a fixed name let a second quarantine silently
+    // overwrite the first one's record. Match the family by prefix.
+    let quarantined: Vec<String> = std::fs::read_dir(&cfg)
+        .unwrap()
+        .flatten()
+        .filter_map(|e| e.file_name().to_str().map(str::to_owned))
+        .filter(|n| n.starts_with(".claude.json.corrupt"))
+        .collect();
+    assert_eq!(
+        quarantined.len(),
+        1,
+        "corrupt file quarantined under a timestamped name, not deleted: {quarantined:?}"
     );
     let v: Value =
         serde_json::from_str(&std::fs::read_to_string(cfg.join(CLAUDE_JSON)).unwrap()).unwrap();

--- a/crates/trusty-mpm/src/core/standalone/trust_seed.rs
+++ b/crates/trusty-mpm/src/core/standalone/trust_seed.rs
@@ -73,6 +73,107 @@ use std::path::Path;
 
 use crate::core::mcp_config::managed_mcp_server_names;
 
+/// The exact set of keys [`preseed_managed_trust`] itself writes into a
+/// `projects.<workspace>` entry.
+///
+/// Why (issue #4206): [`prune_stale_project_entries`] must distinguish a
+/// SEEDER DROPPING (an entry this function created for a directory that no
+/// longer exists — 2,520 of 2,541 entries in the reporting operator's config)
+/// from REAL USER STATE that Claude Code itself accumulated (`lastSessionId`,
+/// `lastCost`, `mcpServers`, `history`, …). The observed distribution is
+/// sharply bimodal — droppings carry exactly these four keys, real entries
+/// carried 15–33 — so "the entry's key set is a subset of what the seeder
+/// writes" is a precise, non-heuristic test for "nothing but this function has
+/// ever touched this entry".
+/// What: the four keys written below (`hasTrustDialogAccepted`,
+/// `hasCompletedProjectOnboarding`, `projectOnboardingSeenCount`,
+/// `enabledMcpjsonServers`). MUST be kept in sync with the writes at the end
+/// of [`preseed_managed_trust`] — adding a key there without adding it here
+/// only makes the prune MORE conservative (entries stop looking pure and are
+/// kept), never more destructive, so the failure mode of drift is safe.
+/// Test: `prune_keeps_entry_with_runtime_fields`.
+const SEEDER_WRITTEN_KEYS: &[&str] = &[
+    "hasTrustDialogAccepted",
+    "hasCompletedProjectOnboarding",
+    "projectOnboardingSeenCount",
+    "enabledMcpjsonServers",
+];
+
+/// Whether `dir` is DEFINITIVELY absent from the filesystem.
+///
+/// Why (issue #4206): this is the load-bearing safety predicate of the prune.
+/// Deleting an entry because its directory "looks missing" must never fire for
+/// a directory that is merely temporarily unreachable — an unmounted volume, a
+/// network mount that is down, a permission error, a filesystem returning
+/// `EIO`. This project has repeatedly shipped the opposite bug (a failure
+/// branch treating an ambiguous observation as a definite negative and
+/// advancing state anyway), so the rule here is deliberately asymmetric:
+/// `NotFound` is the ONLY error the OS reports that actually means "this path
+/// does not exist", and every other outcome — including success — keeps the
+/// entry.
+/// What: `symlink_metadata` (NOT `metadata`) so a dangling symlink counts as
+/// PRESENT: the link itself exists, and its target may simply be an unmounted
+/// volume. Returns `true` only on `ErrorKind::NotFound`; any other error kind
+/// (`PermissionDenied`, `NotADirectory`, or a platform-specific I/O fault)
+/// returns `false` — keep the entry.
+/// Test: `prune_keeps_entry_when_path_error_is_ambiguous`,
+///   `prune_drops_entry_when_directory_definitively_absent`.
+fn is_definitively_absent(dir: &Path) -> bool {
+    match std::fs::symlink_metadata(dir) {
+        Ok(_) => false,
+        Err(err) => err.kind() == std::io::ErrorKind::NotFound,
+    }
+}
+
+/// Drop `projects` entries that are pure seeder droppings for directories that
+/// are definitively gone, returning how many were removed.
+///
+/// Why (issue #4206): the seeder only ever ADDED entries, so a config that had
+/// accumulated 2,541 `projects` keys — 2,445 of them `tempfile::TempDir`
+/// paths — had no mechanism to ever shrink. Pruning during the read-modify-
+/// write that is already happening makes the file self-healing with no new
+/// command, no background job, and no extra I/O beyond one `symlink_metadata`
+/// per entry.
+/// What: removes an entry only when BOTH conditions hold —
+/// (1) [`is_definitively_absent`] for its path key, AND
+/// (2) its object carries no key outside [`SEEDER_WRITTEN_KEYS`].
+/// The conjunction is the point: either test alone would be unsafe.
+/// Condition (1) alone would delete a real, actively-used project sitting on a
+/// temporarily-unmounted volume; condition (2) alone would delete a
+/// freshly-seeded entry for a directory that still exists. `keep_key` (the
+/// workspace being seeded this run) is never pruned. Non-object entries are
+/// left untouched — this function only removes what it can positively
+/// identify.
+/// Test: `prune_drops_entry_when_directory_definitively_absent`,
+///   `prune_keeps_entry_when_path_error_is_ambiguous`,
+///   `prune_keeps_entry_with_runtime_fields`.
+fn prune_stale_project_entries(
+    projects: &mut serde_json::Map<String, serde_json::Value>,
+    keep_key: &str,
+) -> usize {
+    let before = projects.len();
+    projects.retain(|key, entry| {
+        if key == keep_key {
+            return true;
+        }
+        let Some(obj) = entry.as_object() else {
+            // Not an object — not something this seeder wrote. Leave it alone.
+            return true;
+        };
+        let is_pure_seeder_entry = obj
+            .keys()
+            .all(|k| SEEDER_WRITTEN_KEYS.contains(&k.as_str()));
+        if !is_pure_seeder_entry {
+            // Carries Claude Code's own runtime state (lastSessionId, lastCost,
+            // mcpServers, …) — real user state, never a seeder dropping. Keep
+            // it even when the path is gone.
+            return true;
+        }
+        !is_definitively_absent(Path::new(key))
+    });
+    before - projects.len()
+}
+
 /// Pre-seed project trust and MCP-server approval into `<claude_config_dir>/.claude.json`.
 ///
 /// Why (WI-3 sub-parts 2+3): Claude Code shows two blocking dialogs for unfamiliar
@@ -155,15 +256,28 @@ pub fn preseed_managed_trust(
                 // corrupt file so trust seeding can proceed from a fresh `{}`.
                 // A malformed .claude.json would otherwise permanently block
                 // trust seeding (managed sessions see the trust dialog forever).
-                let corrupt_path = claude_json.with_extension("json.corrupt");
+                //
+                // Issue #4206: the quarantine name is TIMESTAMPED
+                // (`trusty_common::claude_config::quarantine_path`) rather than
+                // the fixed `.claude.json.corrupt` this used to use. The fixed
+                // name meant a second quarantine — here or in the sibling
+                // writer `core::mcp_config::read_config` — silently overwrote
+                // the first, destroying the only record of the first failure.
+                let corrupt_path = trusty_common::claude_config::quarantine_path(&claude_json);
+                // ERROR, not warn: losing a `.claude.json` (OAuth state + every
+                // project's trust) is an operator-visible data-loss event. The
+                // workspace's error-capture layer filters on `!= Level::ERROR`
+                // and is only composed for the Daemon and Supervisor commands,
+                // so a `warn!` here reached NO diagnostic surface at all —
+                // verified: no `quarantin*` line has ever reached `daemon.log`.
                 match std::fs::rename(&claude_json, &corrupt_path) {
-                    Ok(()) => tracing::warn!(
+                    Ok(()) => tracing::error!(
                         "managed trust pre-seed: {} is not valid JSON ({err}); \
                          quarantined to {} — proceeding with fresh config",
                         claude_json.display(),
                         corrupt_path.display()
                     ),
-                    Err(rename_err) => tracing::warn!(
+                    Err(rename_err) => tracing::error!(
                         "managed trust pre-seed: {} is not valid JSON ({err}); \
                          quarantine rename failed ({rename_err}) — proceeding with fresh config",
                         claude_json.display()
@@ -220,6 +334,21 @@ pub fn preseed_managed_trust(
     }
     let projects = projects.as_object_mut().expect("projects is an object");
 
+    // Issue #4206: bound the growth of this file during the read-modify-write
+    // that is already in flight. Only entries that are BOTH definitively gone
+    // from disk AND carry nothing but this seeder's own keys are removed — see
+    // `prune_stale_project_entries` for why the conjunction, and why an
+    // ambiguous filesystem error keeps the entry.
+    let pruned = prune_stale_project_entries(projects, &workspace_key);
+    if pruned > 0 {
+        tracing::info!(
+            "managed trust pre-seed: pruned {pruned} stale project entr{} from {} \
+             (directory definitively absent and entry carried no Claude Code runtime state)",
+            if pruned == 1 { "y" } else { "ies" },
+            claude_json.display()
+        );
+    }
+
     let entry = projects
         .entry(workspace_key)
         .or_insert_with(|| Value::Object(serde_json::Map::new()));
@@ -230,7 +359,14 @@ pub fn preseed_managed_trust(
 
     // Idempotent: skip the write when all fields are already fully set AND the
     // MCP list already matches the canonical server set.
-    let already_seeded = entry.get("hasTrustDialogAccepted") == Some(&Value::Bool(true))
+    //
+    // Issue #4206: `pruned == 0` is part of the condition. Without it, a run
+    // that pruned stale entries but found this workspace already seeded would
+    // return here and DISCARD the prune — the file could then never shrink on
+    // the (very common) repeat-launch path, which is exactly the path that let
+    // it reach 2,541 entries.
+    let already_seeded = pruned == 0
+        && entry.get("hasTrustDialogAccepted") == Some(&Value::Bool(true))
         && entry.get("hasCompletedProjectOnboarding") == Some(&Value::Bool(true))
         && entry
             .get("projectOnboardingSeenCount")

--- a/crates/trusty-mpm/src/core/standalone/trust_seed_tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/trust_seed_tests.rs
@@ -13,6 +13,59 @@
 use super::*;
 use tempfile::TempDir;
 
+/// Every timestamped quarantine sibling currently sitting in `cfg`.
+///
+/// Why (issue #4206): the quarantine name is no longer the fixed
+/// `.claude.json.corrupt`, so tests must match the
+/// `.claude.json.corrupt-<timestamp>` family by prefix. Centralising the match
+/// keeps the "how many quarantine events happened" question answerable in one
+/// place.
+/// What: file names under `cfg` starting with `.claude.json.corrupt`, sorted
+/// for deterministic assertion messages.
+fn quarantine_files(cfg: &Path) -> Vec<String> {
+    let mut found: Vec<String> = std::fs::read_dir(cfg)
+        .expect("config dir must be readable")
+        .flatten()
+        .filter_map(|e| e.file_name().to_str().map(str::to_owned))
+        .filter(|n| n.starts_with(".claude.json.corrupt"))
+        .collect();
+    found.sort();
+    found
+}
+
+/// Build a `.claude.json` whose `projects` map is exactly `entries`.
+///
+/// Why: the prune tests (issue #4206) all need a pre-populated config with
+/// hand-crafted project entries; inlining the JSON assembly in each obscured
+/// what each test was actually varying.
+/// What: writes `{"projects": {<entries>}}` to `<cfg>/.claude.json`.
+fn write_config_with_projects(cfg: &Path, entries: serde_json::Value) {
+    let config = serde_json::json!({ "projects": entries });
+    std::fs::write(
+        cfg.join(".claude.json"),
+        serde_json::to_string_pretty(&config).unwrap(),
+    )
+    .unwrap();
+}
+
+/// Read back `projects` from `<cfg>/.claude.json`.
+fn read_projects(cfg: &Path) -> serde_json::Map<String, serde_json::Value> {
+    let text = std::fs::read_to_string(cfg.join(".claude.json")).unwrap();
+    let val: serde_json::Value = serde_json::from_str(&text).unwrap();
+    val["projects"].as_object().cloned().unwrap_or_default()
+}
+
+/// A `projects` entry carrying only the four keys the seeder itself writes —
+/// i.e. what a leaked test-fixture entry looks like on disk.
+fn seeder_only_entry() -> serde_json::Value {
+    serde_json::json!({
+        "hasTrustDialogAccepted": true,
+        "hasCompletedProjectOnboarding": true,
+        "projectOnboardingSeenCount": 1,
+        "enabledMcpjsonServers": ["trusty-mpm"],
+    })
+}
+
 // WI-3 TRUST-SEED: preseed_managed_trust must write trust keys for the workspace.
 #[test]
 fn test_preseed_managed_trust_marks_directory() {
@@ -407,9 +460,14 @@ fn test_preseed_managed_trust_quarantines_malformed_json() {
     preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
 
     // The quarantine sibling must exist (corrupt file was renamed, not deleted).
-    assert!(
-        cfg.join(".claude.json.corrupt").exists(),
-        ".claude.json.corrupt quarantine file must exist after malformed-JSON quarantine"
+    // Issue #4206: the name is now TIMESTAMPED (`.claude.json.corrupt-<stamp>`)
+    // rather than the fixed `.claude.json.corrupt`, so match by prefix.
+    let quarantined = quarantine_files(&cfg);
+    assert_eq!(
+        quarantined.len(),
+        1,
+        "exactly one timestamped quarantine file must exist after malformed-JSON \
+         quarantine, found: {quarantined:?}"
     );
 
     // The new .claude.json must be valid JSON containing the seeded trust keys.
@@ -686,4 +744,211 @@ fn test_preseed_managed_trust_excludes_unconditional_builtin_when_pin_failed() {
     assert!(names.contains(&"trusty-review"));
     assert!(names.contains(&"trusty-memory"));
     assert!(names.contains(&"trusty-search"));
+}
+
+// ─── issue #4206: bounded growth (the prune) ──────────────────────────────
+
+// Issue #4206 TEST 2 — a `projects` entry whose directory is DEFINITIVELY
+// absent (a plain ENOENT: the path simply does not exist) and which carries
+// nothing but the four keys this seeder writes is a leaked test-fixture
+// dropping. It must be removed during the read-modify-write that is already
+// happening, so the file can shrink instead of only ever growing. Before this
+// fix `preseed_managed_trust` had no removal path at all and the reporting
+// operator's config had reached 2,541 entries, 2,445 of them tempdir paths.
+#[test]
+fn prune_drops_entry_when_directory_definitively_absent() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().join("claude-config");
+    std::fs::create_dir_all(&cfg).unwrap();
+    let workspace = tmp.path().join("live-repo");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    // A path that has never existed and whose parent DOES exist, so the OS
+    // reports a clean ENOENT rather than anything ambiguous.
+    let vanished = tmp.path().join("vanished-fixture-dir");
+    assert!(!vanished.exists(), "precondition: the path must not exist");
+
+    write_config_with_projects(
+        &cfg,
+        serde_json::json!({
+            vanished.to_string_lossy(): seeder_only_entry(),
+            workspace.to_string_lossy(): seeder_only_entry(),
+        }),
+    );
+
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
+
+    let projects = read_projects(&cfg);
+    assert!(
+        !projects.contains_key(vanished.to_string_lossy().as_ref()),
+        "a pure-seeder entry for a definitively-absent directory must be pruned: {:?}",
+        projects.keys().collect::<Vec<_>>()
+    );
+    assert!(
+        projects.contains_key(workspace.to_string_lossy().as_ref()),
+        "the live workspace entry must survive the prune"
+    );
+}
+
+// Issue #4206 TEST 3 — THE ANTI-OVER-DELETION TEST, and the one that matters
+// most. An entry whose path cannot be resolved for an AMBIGUOUS reason must be
+// KEPT. "The directory did not stat" is NOT the same claim as "the directory
+// does not exist": an unmounted volume, a down network mount, a permission
+// error, or an I/O fault all fail to stat while the user's real project is
+// perfectly intact behind them. Deleting on that signal would silently destroy
+// live trust state. This project shipped two bugs in the opposite direction
+// (an ambiguous observation treated as a definite negative) on the same day
+// this fix was written, so the prune treats ONLY a clean `NotFound` as absent.
+//
+// The ambiguity here is produced by ENOTDIR — a regular FILE occupying what
+// the entry key uses as a parent directory, so `symlink_metadata` on the child
+// fails with a non-`NotFound` error. Chosen over a chmod-000 directory because
+// it reproduces identically whether or not the test runs as root, so the
+// assertion can never silently degrade into a vacuous pass in a container.
+#[test]
+fn prune_keeps_entry_when_path_error_is_ambiguous() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().join("claude-config");
+    std::fs::create_dir_all(&cfg).unwrap();
+    let workspace = tmp.path().join("live-repo");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    // A regular file standing where a directory would have to be.
+    let blocker = tmp.path().join("not-a-directory");
+    std::fs::write(&blocker, b"regular file").unwrap();
+    let unreachable = blocker.join("project");
+
+    // Assert the precondition this test depends on: the error really is
+    // ambiguous, NOT NotFound. Without this the test could pass for the wrong
+    // reason on a platform that reports ENOENT here.
+    let err =
+        std::fs::symlink_metadata(&unreachable).expect_err("stat through a regular file must fail");
+    assert_ne!(
+        err.kind(),
+        std::io::ErrorKind::NotFound,
+        "precondition: this path must fail AMBIGUOUSLY, not with NotFound — \
+         otherwise this test is not exercising the over-deletion guard (got {err:?})"
+    );
+
+    write_config_with_projects(
+        &cfg,
+        serde_json::json!({
+            unreachable.to_string_lossy(): seeder_only_entry(),
+            workspace.to_string_lossy(): seeder_only_entry(),
+        }),
+    );
+
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
+
+    let projects = read_projects(&cfg);
+    assert!(
+        projects.contains_key(unreachable.to_string_lossy().as_ref()),
+        "an entry whose path is unreachable for an AMBIGUOUS reason must be KEPT — \
+         only a definitive NotFound may prune: {:?}",
+        projects.keys().collect::<Vec<_>>()
+    );
+}
+
+// Issue #4206 TEST 4 — an entry carrying Claude Code's OWN runtime state
+// (`lastSessionId`, `lastCost`, `mcpServers`, `history`, …) represents real
+// user work, not a seeder dropping, and must survive even when its directory
+// is definitively gone. A user whose project moved or whose volume is detached
+// must not silently lose their session history. Only 21 of the reporting
+// operator's 2,541 entries carried such fields — they are precisely the ones
+// worth protecting.
+#[test]
+fn prune_keeps_entry_with_runtime_fields() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().join("claude-config");
+    std::fs::create_dir_all(&cfg).unwrap();
+    let workspace = tmp.path().join("live-repo");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    let gone = tmp.path().join("moved-away-project");
+    assert!(!gone.exists(), "precondition: the path must not exist");
+
+    write_config_with_projects(
+        &cfg,
+        serde_json::json!({
+            gone.to_string_lossy(): {
+                "hasTrustDialogAccepted": true,
+                "hasCompletedProjectOnboarding": true,
+                "projectOnboardingSeenCount": 3,
+                "enabledMcpjsonServers": ["trusty-mpm"],
+                // The distinguishing signal: real Claude Code runtime state.
+                "lastSessionId": "abc-123",
+                "lastCost": 4.2,
+                "mcpServers": { "custom": { "command": "x" } },
+            },
+            workspace.to_string_lossy(): seeder_only_entry(),
+        }),
+    );
+
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
+
+    let projects = read_projects(&cfg);
+    let kept = projects
+        .get(gone.to_string_lossy().as_ref())
+        .expect("an entry with Claude Code runtime fields must be KEPT even when its path is gone");
+    assert_eq!(
+        kept.get("lastSessionId").and_then(|v| v.as_str()),
+        Some("abc-123"),
+        "the preserved entry must keep its runtime state intact, not just its key"
+    );
+    assert!(
+        kept.get("mcpServers").is_some(),
+        "mcpServers must survive the prune"
+    );
+}
+
+// ─── issue #4206: legible quarantine ──────────────────────────────────────
+
+// Issue #4206 TEST 5 — two quarantine events must produce TWO distinct files.
+// Both writers used the fixed name `.claude.json.corrupt`, so a second
+// corruption silently overwrote the first one's bytes — erasing the only
+// record of the first failure in a file that also holds OAuth state. A
+// post-mortem could tell that corruption had happened at least once, and
+// nothing more.
+#[test]
+fn two_quarantine_events_produce_two_distinct_files() {
+    let tmp = TempDir::new().unwrap();
+    let cfg = tmp.path().join("claude-config");
+    std::fs::create_dir_all(&cfg).unwrap();
+    let workspace = tmp.path().join("repo");
+    std::fs::create_dir_all(&workspace).unwrap();
+
+    // First corruption + quarantine.
+    std::fs::write(cfg.join(".claude.json"), b"{ first corruption !!!").unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
+    assert_eq!(
+        quarantine_files(&cfg).len(),
+        1,
+        "first quarantine must produce exactly one file"
+    );
+
+    // Second, independent corruption + quarantine.
+    std::fs::write(cfg.join(".claude.json"), b"{ second corruption ???").unwrap();
+    preseed_managed_trust(&cfg, &workspace, true, true, true, true).unwrap();
+
+    let files = quarantine_files(&cfg);
+    assert_eq!(
+        files.len(),
+        2,
+        "two quarantine events must leave TWO distinct records, not overwrite one: {files:?}"
+    );
+
+    // And both sets of original bytes must still be recoverable — the whole
+    // point of quarantining rather than deleting.
+    let bodies: Vec<String> = files
+        .iter()
+        .map(|f| std::fs::read_to_string(cfg.join(f)).unwrap())
+        .collect();
+    assert!(
+        bodies.iter().any(|b| b.contains("first corruption")),
+        "the FIRST failure's bytes must survive the second quarantine: {bodies:?}"
+    );
+    assert!(
+        bodies.iter().any(|b| b.contains("second corruption")),
+        "the second failure's bytes must be preserved too: {bodies:?}"
+    );
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
@@ -695,7 +695,14 @@ use super::super::launch_on_main::{has_concurrent_main_checkout_session, spawn_m
 /// (#3455).
 /// Test: itself.
 #[tokio::test]
+#[serial_test::serial]
 async fn spawn_managed_on_main_creates_record_without_worktree() {
+    let tmp_home = tempfile::TempDir::new().expect("tmp home");
+    // #4206: `#[serial]` + `$HOME` override — see `HomeGuard` above. Without
+    // this, `spawn_managed_on_main`'s real Claude Code spawn path resolves
+    // `managed_claude_config_dir()` via the REAL `$HOME` and leaks a
+    // `projects.<tempdir>` entry into the operator's own `.claude.json`.
+    let _home = set_home(tmp_home.path());
     let data_root = tempfile::TempDir::new().expect("tmp data root");
     let state = std::sync::Arc::new(
         crate::daemon::state::DaemonState::with_root_isolated_managed(

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -1809,3 +1809,205 @@ fn prepare_managed_config_excludes_builtins_when_mcp_json_write_fails() {
         );
     }
 }
+
+// ─── issue #4206: the trust seed must stay inside the redirected $HOME ────
+
+/// RAII guard that prepends `dir` to `PATH` and restores it on drop.
+struct PathGuard {
+    prev: Option<std::ffi::OsString>,
+}
+impl PathGuard {
+    fn prepend(dir: &Path) -> Self {
+        let prev = std::env::var_os("PATH");
+        let mut entries = vec![dir.to_path_buf()];
+        if let Some(ref p) = prev {
+            entries.extend(std::env::split_paths(p));
+        }
+        let joined = std::env::join_paths(entries).expect("join PATH");
+        // SAFETY: callers are #[serial].
+        unsafe { std::env::set_var("PATH", joined) };
+        Self { prev }
+    }
+}
+impl Drop for PathGuard {
+    fn drop(&mut self) {
+        match self.prev.take() {
+            Some(v) => unsafe { std::env::set_var("PATH", v) },
+            None => unsafe { std::env::remove_var("PATH") },
+        }
+    }
+}
+
+/// Every `.claude.json` found anywhere beneath `root`.
+///
+/// Why (issue #4206): the leak assertion must catch the seeded config wherever
+/// it lands under a redirected `$HOME`, not only at the one path the current
+/// resolver happens to compute — a future refactor that moved the managed dir
+/// would otherwise silently stop being covered.
+/// What: a depth-bounded recursive walk (symlinks are not followed, so a
+/// self-referential link cannot spin), returning display paths.
+fn find_claude_json_files(root: &Path) -> Vec<String> {
+    fn walk(dir: &Path, depth: usize, out: &mut Vec<String>) {
+        if depth > 8 {
+            return;
+        }
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let Ok(meta) = std::fs::symlink_metadata(&path) else {
+                continue;
+            };
+            if meta.is_dir() {
+                walk(&path, depth + 1, out);
+            } else if entry.file_name() == std::ffi::OsStr::new(".claude.json") {
+                out.push(path.display().to_string());
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, 0, &mut out);
+    out
+}
+
+/// Plant an executable stub named `claude` in `dir` and return its directory.
+///
+/// Why: `ClaudeCodeAdapter::spawn_resume` calls `resolve_claude()` FIRST and
+/// returns `BinaryNotFound` before ever reaching `prepare_managed_config`. The
+/// pre-existing tests in this file handle that with
+/// `if resolve_claude().is_none() { return; }` — a silent skip that makes them
+/// vacuous on any machine without Claude Code installed (most CI runners).
+/// A leak test that can silently pass by not running is worse than no test, so
+/// this plants a stub and prepends its directory to `PATH`
+/// (`bin_resolve::resolve_binary` honours the live `PATH` first), guaranteeing
+/// the spawn path is actually entered on every platform.
+#[cfg(unix)]
+fn plant_fake_claude(dir: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let bin = dir.join("claude");
+    std::fs::write(&bin, b"#!/bin/sh\nexit 0\n").expect("write fake claude");
+    std::fs::set_permissions(&bin, std::fs::Permissions::from_mode(0o755))
+        .expect("chmod fake claude");
+}
+
+// Issue #4206 TEST 1 — THE ISOLATION INVARIANT, locked at the REAL call chain
+// (`ClaudeCodeAdapter::spawn_resume` → `prepare_managed_config` →
+// `preseed_managed_trust`): with `$HOME` redirected, trust seeding must write
+// NOTHING outside that redirected `$HOME`.
+//
+// Why this test exists, and what the #4206 investigation actually established:
+// the reported root cause was that `managed_claude_config_dir()` "takes no
+// injectable base". That is NOT correct. It resolves via `dirs::home_dir()`,
+// which reads `$HOME` on Unix — so `$HOME` IS the injectable base, and
+// redirecting it genuinely confines the seeder (proven by running this very
+// test against unpatched code: the seed landed in the redirected temp home,
+// not the operator's real one). There is no production defect here; a daemon
+// running with the operator's real `$HOME` correctly targets the operator's
+// real config dir.
+//
+// The actual defect was TEST HYGIENE: several tests reach this production
+// seeding path without redirecting `$HOME` at all, so they wrote straight into
+// `~/.trusty-tools/trusty-mpm/claude-config/.claude.json` — which is how 2,443
+// `tempfile::TempDir` entries accumulated there. Those tests are fixed in this
+// same change (`daemon::managed_routes::lifecycle_tests`,
+// `tests/session_manager_mvp.rs`); this test locks the invariant they were
+// missing, at the layer they all funnel through, so the next test to drive
+// `spawn`/`spawn_resume` has an executable statement of the rule.
+//
+// Note the pre-existing isolation test
+// (`standalone::trust_seed_tests::test_preseed_managed_trust_no_home_write`)
+// calls `preseed_managed_trust` DIRECTLY with an explicit `claude_config_dir`,
+// so it can never observe what the production call chain resolves. Only a test
+// that enters through `spawn_resume` covers that resolution step.
+#[serial_test::serial]
+#[test]
+#[cfg(unix)]
+fn spawn_resume_trust_seed_stays_within_redirected_home() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let bindir = tempfile::tempdir().expect("bin tempdir");
+    let workspace = tempfile::tempdir().expect("workspace tempdir");
+
+    plant_fake_claude(bindir.path());
+    let _path = PathGuard::prepend(bindir.path());
+
+    // Redirect HOME to an EMPTY dir — the isolation seam every test that
+    // drives this path must use.
+    let prev_home = std::env::var_os("HOME");
+    // SAFETY: #[serial].
+    unsafe { std::env::set_var("HOME", home.path()) };
+    struct RestoreHome(Option<std::ffi::OsString>);
+    impl Drop for RestoreHome {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(v) => unsafe { std::env::set_var("HOME", v) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+    let _home_guard = RestoreHome(prev_home);
+
+    // The managed dir this run must resolve to, derived the same way
+    // production does, AFTER the redirect above.
+    let base = crate::core::trusty_tools_config::managed_claude_config_dir()
+        .expect("managed config dir resolves under the redirected HOME");
+    assert!(
+        base.starts_with(home.path()),
+        "precondition: the resolved managed dir must sit under the redirected \
+         HOME, else this test is not isolated at all (resolved {})",
+        base.display()
+    );
+
+    // Sanity: the binary really is resolvable, so the spawn path below is
+    // genuinely entered and this test can never pass by skipping.
+    assert!(
+        ClaudeCodeAdapter::resolve_claude().is_some(),
+        "fake claude must be resolvable on PATH — otherwise this test is vacuous"
+    );
+
+    let fake = FakeTmux::new();
+    let adapter = ClaudeCodeAdapter::new(fake.clone());
+    adapter
+        .spawn_resume(
+            "tmpm-4206",
+            None,
+            workspace.path(),
+            "task",
+            None,
+            TEST_SESSION_ID,
+            &[],
+        )
+        .expect("spawn_resume must succeed against the fake tmux");
+
+    // THE ISOLATION ASSERTION: every `.claude.json` written by this run must
+    // sit under the redirected $HOME — none anywhere else.
+    //
+    // Scoped to `.claude.json` rather than "HOME is empty": other, unrelated
+    // parts of the launch path legitimately resolve under `$HOME` (the
+    // framework roster at `~/.trusty-mpm/framework`, and macOS's own
+    // `~/Library` caches). Those are out of scope; asserting on them would
+    // make this test fail for reasons unrelated to the config leak.
+    let found = find_claude_json_files(home.path());
+    assert!(
+        found.iter().all(|p| Path::new(p).starts_with(home.path())),
+        "every seeded .claude.json must live under the redirected HOME: {found:?}"
+    );
+
+    // Positive counterpart: the seed really did happen, at the resolved
+    // managed dir. Without this the test could pass simply by never seeding
+    // anything — the exact way an isolation test goes vacuous.
+    let seeded = base.join(".claude.json");
+    let text = std::fs::read_to_string(&seeded).unwrap_or_else(|e| {
+        panic!(
+            ".claude.json must be seeded at the resolved managed dir {}: {e}",
+            seeded.display()
+        )
+    });
+    let val: serde_json::Value = serde_json::from_str(&text).expect("seeded config is valid JSON");
+    let key = workspace.path().to_string_lossy().to_string();
+    assert_eq!(
+        val["projects"][&key]["hasTrustDialogAccepted"],
+        serde_json::Value::Bool(true),
+        "the workspace must actually be trust-seeded under the redirected HOME: {text}"
+    );
+}

--- a/crates/trusty-mpm/tests/session_manager_mvp.rs
+++ b/crates/trusty-mpm/tests/session_manager_mvp.rs
@@ -931,10 +931,13 @@ fn write_fake_tm_binary(dir: &std::path::Path) -> PathBuf {
 /// outcome.
 /// Test: this function IS the test.
 #[tokio::test]
+#[serial_test::serial]
 async fn resume_managed_backfills_missing_status_line() {
     // Hermetic framework root with FakeNoopTmuxDriver — no real tmux sessions
     // are created, so nothing can escape into the production store (#1790).
     let root = TempDir::new().unwrap();
+    // #4206: `#[serial]` + `$HOME` override — see `HomeGuard` above.
+    let _home = HomeGuard::set(root.path());
     let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
     let mgr = state.session_manager().await;
 
@@ -1016,8 +1019,11 @@ async fn resume_managed_backfills_missing_status_line() {
 /// pattern of not asserting on the spawn outcome.)
 /// Test: this function IS the test.
 #[tokio::test]
+#[serial_test::serial]
 async fn resume_managed_launches_despite_incomplete_deployment() {
     let root = TempDir::new().unwrap();
+    // #4206: `#[serial]` + `$HOME` override — see `HomeGuard` above.
+    let _home = HomeGuard::set(root.path());
     let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
     let mgr = state.session_manager().await;
 
@@ -1122,6 +1128,8 @@ async fn resume_managed_heals_stale_bare_status_line_command() {
     let _path_guard = PathGuard::prepend(fake_bin_dir.path());
 
     let root = TempDir::new().unwrap();
+    // #4206: `#[serial]` + `$HOME` override — see `HomeGuard` above.
+    let _home = HomeGuard::set(root.path());
     let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
     let mgr = state.session_manager().await;
 
@@ -1193,6 +1201,7 @@ async fn resume_managed_heals_stale_bare_status_line_command() {
 /// if the runtime binary is absent).
 /// Test: this function IS the test.
 #[tokio::test]
+#[serial_test::serial]
 async fn front_gate_answer_unblocks_spawn() {
     use trusty_mpm::daemon::managed_routes::spawn_runtime_for;
     use trusty_mpm::session_manager::ManagedSessionState;
@@ -1200,6 +1209,8 @@ async fn front_gate_answer_unblocks_spawn() {
     // FakeNoopTmuxDriver: no real tmux sessions are created — nothing can escape
     // into the production store (#1790).
     let root = TempDir::new().unwrap();
+    // #4206: `#[serial]` + `$HOME` override — see `HomeGuard` above.
+    let _home = HomeGuard::set(root.path());
     let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
     let mgr = state.session_manager().await;
 


### PR DESCRIPTION
Closes #4206

## The reported root cause did not survive verification — read this first

The issue attributes the leak to `managed_claude_config_dir()` "resolving from `dirs::home_dir()` only … it never reads `CLAUDE_CONFIG_DIR` and takes no injectable base."

**That premise is wrong, and acting on it makes things worse.** `dirs::home_dir()` reads `$HOME` on Unix, so **`$HOME` *is* the injectable base**, and redirecting it genuinely confines the seeder. Proven directly: I wrote the leak test first, ran it against unpatched `main`, and the seed landed in the redirected temp home —

```
/var/folders/…/.tmp1tOOJI/.trusty-tools/trusty-mpm/claude-config/.claude.json
```

— not the operator's real config. **There is no production defect in the resolver.** A daemon running with the operator's real `$HOME` correctly targets the operator's real config dir, which is exactly what it should do.

The actual defect is **test hygiene**: five tests drive the real spawn path without redirecting `$HOME` at all.

### I implemented the env-var option first, and it caused a regression

I initially took the "honor `CLAUDE_CONFIG_DIR`" option. The full workspace gate caught it: **6 tests broke**, all in `custom_mcp_tests` / `native_mcp_tests` / `tests_launch_trust_3926` (one is literally named `inject_native_resolves_managed_registry_from_real_home`).

The reason matters: **every tm-managed shell exports `CLAUDE_CONFIG_DIR`.** In this very session it is `/Users/masa/.trusty-tools/trusty-mpm/claude-config`. So honoring an ambient `CLAUDE_CONFIG_DIR` would have made tests that *correctly* redirect `$HOME` resolve at the operator's **real** config instead — turning a leak from a handful of unguarded tests into a leak from every test that touches this path, precisely inside the environment where the suite actually runs. It was **strictly worse than the bug**. Reverted; the resolver is untouched in this PR.

This is the "leaves a global" hazard the task flagged, with a sharper edge than anticipated: the global is not merely ambient, it is *always set* in the environment that matters.

## Fix 1 — stop the leak (test hygiene, no production change)

Five tests reached `ClaudeCodeAdapter::spawn`/`spawn_resume` → `prepare_managed_config` → `preseed_managed_trust` with `$HOME` untouched, writing `projects.<tempdir>` straight into the operator's `.claude.json` — a file that also holds `oauthAccount`:

| File | Test |
|---|---|
| `src/daemon/managed_routes/lifecycle_tests.rs` | `spawn_managed_on_main_creates_record_without_worktree` |
| `tests/session_manager_mvp.rs` | `resume_managed_backfills_missing_status_line` |
| `tests/session_manager_mvp.rs` | `resume_managed_launches_despite_incomplete_deployment` |
| `tests/session_manager_mvp.rs` | `resume_managed_heals_stale_bare_status_line_command` |
| `tests/session_manager_mvp.rs` | `front_gate_answer_unblocks_spawn` |

Each now redirects `$HOME` using the **helper its own file already defines** (`HomeGuard` / `set_home`) plus `#[serial_test::serial]` — reusing the established mechanism rather than inventing a second one. Three of the four in `session_manager_mvp.rs` had to become `#[serial]`, since the guard mutates process-global env; the file already had `#[serial]` + `HomeGuard` precedent at three other tests.

New regression test `spawn_resume_trust_seed_stays_within_redirected_home` locks the invariant at the layer they all funnel through. It drives the **real trait method** (not `preseed_managed_trust` directly — that function was never the bug, it faithfully writes wherever it is told), and **plants an executable `claude` stub on `PATH`** so it can never pass vacuously. The pre-existing tests in that file use `if resolve_claude().is_none() { return; }`, which silently skips on any machine without Claude Code installed — an isolation test that can pass by not running is worse than no test.

## Fix 2 — bound the growth

`preseed_managed_trust` only ever *added* entries, so the file could never shrink. It now prunes during the read-modify-write already in flight — no new command, no background job.

An entry is dropped only when **both** hold:

1. `symlink_metadata` returns a clean `ErrorKind::NotFound`, **and**
2. the entry's key set is a subset of the four keys the seeder itself writes.

**The conjunction is the whole design.** Either condition alone is unsafe:

- **(1) alone** deletes a real, actively-used project sitting on a temporarily-unreachable path — an unmounted volume, a down network mount, a permission error, an I/O fault. "Did not stat" is not "does not exist". Any non-`NotFound` error **keeps** the entry. `symlink_metadata` (not `metadata`) is deliberate, so a dangling symlink counts as *present*: the link exists and its target may simply be unmounted.
- **(2) alone** deletes a freshly-seeded entry for a directory that still exists.

Validated against the reporting operator's real 2,541-entry file. The distribution is sharply bimodal, which is what makes rule (2) precise rather than heuristic:

```
total          : 2541
missing on disk: 2175
pure seeder    : 2520      key-count histogram: {4: 2520, 15: 2, 24: 1, 31: 5, 32: 1, 33: 12}
PRUNABLE       : 2174      (pure AND definitively missing)
kept despite missing: 1    (carries lastSessionId/mcpServers/… — real user state)
```

So this drains ~86% of the file on the next write while correctly preserving the one missing-but-real entry. `pruned == 0` is also folded into the `already_seeded` early-return: without it, a run that pruned but found the workspace already seeded would return early and **discard the prune** — on the repeat-launch path, which is the common one.

Per the task, existing entries are **not** cleaned up here, and no `.claude.json` / `.bak` / `.corrupt` file was deleted — all preserved as evidence.

## Fix 4 — make the quarantine legible

Two writers (`standalone::trust_seed`, `core::mcp_config`) renamed a malformed `.claude.json` to the fixed name `.claude.json.corrupt`, so the second silently overwrote the first one's bytes — destroying the only record of the first failure. Both now share a new `trusty_common::claude_config::quarantine_path`, which timestamps the name (`.claude.json.corrupt-20260728T025723.418Z`) and probes for an unused sibling so two events can never collapse onto one file even under a coarse clock. Centralising it means the two writers cannot drift apart again.

Both also now log at **`error!`, not `warn!`** — confirmed that `warn!` reaches no diagnostic surface in this workspace (the capture layer filters on `!= Level::ERROR` and is composed only for the Daemon and Supervisor commands).

`quarantine_path` lives in `trusty-common` because both writers need it; it is **purely additive** — no existing behaviour changes for any consumer.

## Fix 3 — not applicable

The task describes FIX 1, FIX 2 and FIX 4; **there is no FIX 3 anywhere in the brief** (it is referenced only in the overlap warning). Nothing was skipped for conflict reasons: #4205 landed during this work and this branch rebased onto it cleanly, because nothing here touches `prepare_session_inner`.

## Tests — each fails before, passes after

| # | Test | Fails against |
|---|---|---|
| 1 | `spawn_resume_trust_seed_stays_within_redirected_home` | the unguarded leaking tests (locks the invariant they lacked) |
| 2 | `prune_drops_entry_when_directory_definitively_absent` | pre-fix `trust_seed.rs` (no prune existed) |
| 3 | `prune_keeps_entry_when_path_error_is_ambiguous` | a **naive prune** — verified |
| 4 | `prune_keeps_entry_with_runtime_fields` | a **naive prune** — verified |
| 5 | `two_quarantine_events_produce_two_distinct_files` | pre-fix (`[".claude.json.corrupt"]` — one file, overwritten) |

**On tests 3 and 4:** these are the anti-over-deletion guards, and they *cannot* fail against pre-fix code — pre-fix there is no deletion at all, so "the entry is kept" is trivially true. Their meaningful baseline is the *obvious wrong implementation*. I temporarily replaced the prune with the naive `projects.retain(|k, _| Path::new(k).exists())` and confirmed both fail:

```
test prune_keeps_entry_with_runtime_fields ... FAILED
test prune_keeps_entry_when_path_error_is_ambiguous ... FAILED
  an entry with Claude Code runtime fields must be KEPT even when its path is gone
  an entry whose path is unreachable for an AMBIGUOUS reason must be KEPT — only a definitive NotFound may prune
```

Test 3 produces its ambiguity with **ENOTDIR** (a regular file standing where a parent directory would be) rather than a `chmod 000` directory, so it reproduces identically as root — a chmod-based test silently degrades to a vacuous pass in a root container. It also asserts the precondition that the error really is non-`NotFound`, so it cannot pass for the wrong reason.

No `#[ignore]`, no cfg-gates, no vacuous assertions.

## Gate

Run with CI's own exclusion list from `ci.yml` (`--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui`, `SKIP_UI_BUILD=1`) — the Tauri desktop apps CI itself excludes from headless jobs. No other exclusions, and `--lib` was **not** used.

```
cargo test --workspace --no-fail-fast   → TEST_EXIT=0
                                          19735 passed, 0 failed, 132 ignored (194 binaries)
                                          "test result: FAILED" count: 0
cargo clippy --workspace --all-targets -- -D warnings → CLIPPY_EXIT=0  (0 errors)
cargo fmt --check                       → FMT_EXIT=0
scripts/check_line_cap.sh               → 7 allowlisted, 0 violations — OK.
```

One transient `trusty-agents` failure appeared in an earlier run (`tools::python_skill::tests::execute_dispatches_to_python_and_parses_json`, a broken `uv` interpreter at `/opt/homebrew/bin/python`) and did not reproduce on the final gate. Unrelated to these files.

## Follow-up not done here

`bin/tm/commands/guided_inplace/tests.rs::run_inplace_relaunch_never_reactivates_when_command_build_fails` probes `build_inplace_resume_command` before its early return; if `claude` *is* resolvable, that probe call can seed a bare-tempdir key before the guard trips. Different key shape from the reported leak and a different file; worth a small follow-up rather than widening this PR's blast radius across ten active branches.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
