### PR TITLE
chore(trusty-mpm): bump to 1.2.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11674,7 +11674,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-mpm"
-version = "1.2.0"
+version = "1.2.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+---
+## [1.2.3] — 2026-07-28
+
+PATCH: merge-and-local-install only, no crates.io publish.
+
 ### Fixed
 
 - **`tm launch`, `tm connect`, and `tm meta launch` deployed agents to a tier
@@ -67,7 +72,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   Without this they would have kept removing the registration while leaving the
   index data behind forever: the workspace each one describes is a disposable
   worktree that is about to be deleted, so nothing will ever re-register at
-  that root and the preserved data would be unreachable garbage.
+  that root and the preserved data would be unreachable garbage. The same PR
+  ([#4218](https://github.com/bobmatnyc/trusty-tools/pull/4218)) also closes
+  [#4110](https://github.com/bobmatnyc/trusty-tools/issues/4110) — see the
+  bundled-fixes entry below for that half of the change.
+
+- **Bundled from `main`: trusty-search P0 corpus quarantine + stage-status fix**
+  ([#4122](https://github.com/bobmatnyc/trusty-tools/issues/4122),
+  [#4110](https://github.com/bobmatnyc/trusty-tools/issues/4110)): this
+  release is merge-and-local-install only (no crates.io publish), so a local
+  install built from this commit also picks up two trusty-search fixes that
+  landed on `main` alongside this bump. Neither touches trusty-mpm's own
+  source; both are called out here because this version bump is the vehicle
+  that carries them to the operator's next restart.
+
+  An index whose durable corpus failed to open at load time is now
+  write-quarantined (#4122): ordinary incremental writes (watcher, boot-time
+  reconciler, `POST /indexes/{id}/index-file`) now refuse rather than silently
+  building a fresh, partial corpus over the never-opened original — the shape
+  that took one production index from 0 to 1,334 chunks of wrong content
+  before coming back "healthy" on the next restart. The quarantine lifts
+  automatically once a subsequent restart's `CorpusStore::open` succeeds.
+
+  `POST /indexes/:id` no longer discards the outcome of the restore it just
+  performed (#4110): `search_capabilities` is now derived from the actual
+  post-restore stages via `derive_warm_boot_stages` (the same classifier
+  warm-boot and lazy-restore already use), so a fully intact index no longer
+  comes back advertising no vector lane — previously that meant semantic
+  search hard-errored and `search_all` silently degraded to BM25-only until
+  the next daemon restart.
 
 ---
 ## [1.2.0] — 2026-07-27

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-mpm"
-version = "1.2.0"
+version = "1.2.3"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Summary

Version bump only: trusty-mpm 1.2.0 → 1.2.3. Merge-and-local-install only —
this is the deploy target build; no crates.io publish, no git tag (tagging
stays a manual, human-in-the-loop step per repo convention).

This release ships the fixes for:
- #4122 — trusty-search: broken index handle keeps accepting incremental
  watcher writes, overwriting corpus (P0 corpus quarantine)
- #4204 — Two paths write into a destroyed worktree — is_dir() liveness
  check never inspects .git (workspace liveness guard)
- #4123 — trusty-search: DELETE /indexes/:id hardcodes delete_data=true —
  no way to deregister safely without destroying data
- #4110 — POST /indexes initializes stage status to Pending
  unconditionally, even when colocated corpus restore succeeded

All four issues are already closed by their respective merged PRs; this
bump is the vehicle that carries them into an operator's next local
install + restart. #4203 (tier fix) was already reflected in the
Unreleased changelog draft prior to this bump.

## Changes
- `crates/trusty-mpm/Cargo.toml`: `1.2.0` → `1.2.3`
- `Cargo.lock`: targeted `cargo update -p trusty-mpm --precise 1.2.3` only
  (single version-line diff, no third-party churn)
- `crates/trusty-mpm/CHANGELOG.md`: hand-written `## [Unreleased]` draft
  (covering #4203, #4204, #4123) retitled to `## [1.2.3] — 2026-07-28`,
  with #4110 cross-referenced against the #4123 bullet and a new bullet
  added for the bundled trusty-search #4122/#4110 fixes. A fresh empty
  `## [Unreleased]` heading is left above it for future accumulation.

## Notes on process
`scripts/bump-version.sh trusty-mpm patch` was read first per instruction.
Running it landed on 1.2.1 (not 1.2.3, since the last release was 1.2.0),
so the version was set explicitly to 1.2.3 and the lockfile re-synced with
a second targeted `cargo update -p trusty-mpm --precise 1.2.3`.

The script's changelog step also tripped its own duplicate-`## [Unreleased]`
stopgap (issue #2793): because `trusty-mpm-v1.2.0` was never tagged,
`git-cliff --unreleased` scoped against the last tag (`trusty-mpm-v1.0.2`)
and would have re-dumped dozens of already-released, pre-1.2.0 entries as a
second "Unreleased" section. That prepend was reverted; the changelog was
instead resolved by hand as described above, diffed against the
`--stdout` preview to confirm no new commit content was actually missed
beyond what the hand-written draft already covered in more detail.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-mpm` — 39/39 test binaries green, 0 failures
      (including the known `probe_history_limit_reads_back_configured_value`
      flake, which passed clean this run)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools