### PR TITLE
feat(trusty-agents): render function-skill groups in the Skills pane + author ticketing/gworkspace/cto-tools bundles

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,7 +7,41 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **The Skills pane renders function skills as groups (#4024).** A `kind:
+  "function"` bundle is no longer filtered out of the pane — it renders as a
+  collapsed group header over its member skill cards, with the tri-state grant
+  display DOC-57 S-16 specifies: "granted" only when every member is granted,
+  "partial — k of n" when some are, "not granted" when none are. Members render
+  inside their group instead of the flat Actions/Knowledge/System buckets (one
+  card, one place); a skill belonging to no bundle renders exactly as before.
+  Membership and grant state are read from the route's `groups[]`, never
+  re-derived client-side, and a bundle still does not move the "N of M known
+  skills granted" count — it is not a capability of its own.
+- **A `Google Workspace` function skill (#4024)** bundling the Gmail and Google
+  Tasks leaf skills (search, read, compose, draft, format, labels, attachments;
+  task lists, create, update, complete) as one grantable unit. Gmail account
+  settings and filters, Google account administration, and the Drive/Docs/
+  Sheets/Slides/Calendar families are deliberately NOT members.
+- **A `CTO Tools` function skill (#4024)** bundling the four CTO operations
+  database queries (headcount, budget, risks, work classification).
+- **`groups[].providers` on `GET /api/agents/:name/skills` (#4024).** A bundle
+  carries no credential of its own, so the group now reports the DISTINCT
+  credential requirements across its members, each with the same tri-state
+  `configured` a leaf card carries. Members needing different credentials
+  produce one entry each — a divergence is rendered, never collapsed into a
+  single verdict — and an OAuth requirement still reports `configured: null`
+  ("not verified"), never a check nobody ran. Additive: existing fields are
+  unchanged.
+
 ### Changed
+
+- **The `ticketing` function skill now also bundles the two read-only git
+  inspection skills (#4024)** — `git_search_commits` and `git_branches` — so
+  git and ticketing are granted as one unit. Git *mutation* skills (commit,
+  push, branch creation, checkout, stash) remain excluded, and a test pins
+  that exclusion.
 
 - `trusty-memory` requirement raised to `^0.22` (was `^0.21.1`). trusty-memory
   goes 0.21.3 -> 0.22.0 because it publicly re-exports `trusty_common::palace_id`

--- a/crates/trusty-agents/src/api/server/agent_skills.rs
+++ b/crates/trusty-agents/src/api/server/agent_skills.rs
@@ -46,6 +46,18 @@
 //! deliberately EXCLUDES function cards: it counts capabilities, and a bundle is
 //! not a capability of its own — counting it would inflate the number the pane
 //! shows without the agent gaining anything.
+//!
+//! **#4024 — a group's credential requirements are a SET, never a verdict.** A
+//! bundle carries no `provider` of its own (its card keeps `provider: null`),
+//! but its members do, and they need not agree. `groups[].providers` is the
+//! DISTINCT requirements across the members, each in the same shape and with the
+//! same tri-state `configured` a leaf card carries. Two members needing two
+//! different credentials therefore produce two entries the pane renders side by
+//! side; nothing is collapsed into a single "configured"/"not configured" verdict
+//! for the group, because averaging a divergence is the quiet form of the lie
+//! #3945 exists to prevent. The dotted-SCOPE axis (`google.gmail.*` vs
+//! `google.tasks.*`) is not part of the manifest's provider model and is not
+//! claimed here — `dead_scope_patterns` reports it separately.
 //! Test: `super::tests::agent_skills`.
 
 use std::path::{Path, PathBuf};
@@ -62,7 +74,7 @@ use super::agent_patch::resolve_agent_paths;
 use super::state::AppState;
 use crate::agents::{SkillsConfig, ToolsConfig};
 use crate::ctrl::pm_task::match_any_glob;
-use crate::skills::manifest::{SkillCatalog, SkillManifest, effective_tool_patterns};
+use crate::skills::manifest::{ProviderReq, SkillCatalog, SkillManifest, effective_tool_patterns};
 use crate::tools::registry::dead_scope;
 use crate::tools::registry::scope::ScopePattern;
 
@@ -250,6 +262,13 @@ struct FunctionGroup {
     description: String,
     members: Vec<String>,
     granted_members: Vec<String>,
+    /// #4024: the DISTINCT credential requirements across the members.
+    ///
+    /// Why: see the module doc — a bundle has no credential of its own, and its
+    /// members' need not agree. Carrying the set (rather than a rolled-up
+    /// boolean) is what makes a divergence renderable instead of averaged away.
+    /// Test: `group_providers_list_every_distinct_member_requirement`.
+    providers: Vec<ProviderReq>,
 }
 
 impl FunctionGroup {
@@ -277,8 +296,61 @@ impl FunctionGroup {
             "members": self.members,
             "granted_members": self.granted_members,
             "granted_state": self.state(),
+            "providers": self.providers.iter().map(provider_json).collect::<Vec<_>>(),
         })
     }
+}
+
+/// One credential requirement in the card/group wire shape.
+///
+/// Why: `configured` is evaluated from the process environment in exactly one
+/// place, so a leaf card and the group header above it can never disagree about
+/// the same credential. It stays tri-state: `true`/`false` only when an
+/// environment variable backs the requirement, `null` when it is an OAuth grant
+/// or MCP wiring this endpoint does not verify — a `false` there would assert a
+/// check nobody ran.
+/// What: `{ provider, requirement, env_var, configured }`.
+/// Test: `skill_card_reports_env_credential_state`,
+/// `group_providers_list_every_distinct_member_requirement`.
+fn provider_json(p: &ProviderReq) -> Value {
+    let configured = p.env_var.map(|var| {
+        std::env::var(var)
+            .map(|v| !v.trim().is_empty())
+            .unwrap_or(false)
+    });
+    json!({
+        "provider": p.provider,
+        "requirement": p.requirement,
+        "env_var": p.env_var,
+        "configured": configured,
+    })
+}
+
+/// The distinct credential requirements the members of a bundle carry.
+///
+/// Why (#4024, S-16): a bundle is granted as one line, so the pane must be able
+/// to state what that line NEEDS. Members can diverge — nothing in the manifest
+/// model forces one bundle to one provider — and the honest rendering of a
+/// divergence is to show both, not to pick one or to collapse them into a single
+/// verdict. Distinctness is by the WHOLE requirement, not by provider name: two
+/// requirements that differ in text differ in what the operator must do, and
+/// hiding the second behind a shared name is the same lie one level down.
+/// What: Requirements in member declaration order, first occurrence kept. A
+/// member no manifest resolves contributes nothing (it also cannot be granted),
+/// and members needing no credential contribute nothing — an empty vec means
+/// "no member states a requirement", never "verified".
+/// Test: `group_providers_list_every_distinct_member_requirement`,
+/// `group_providers_are_empty_when_no_member_needs_a_credential`.
+fn distinct_member_providers(catalog: &SkillCatalog, members: &[String]) -> Vec<ProviderReq> {
+    let mut distinct: Vec<ProviderReq> = Vec::new();
+    for member in members {
+        if let Some(p) = catalog.get(member).and_then(|m| m.provider)
+            && !distinct.contains(&p)
+        {
+            distinct.push(p);
+        }
+    }
+    distinct
 }
 
 /// Resolve every function skill in the catalog against this agent's grants.
@@ -309,6 +381,8 @@ fn function_groups(
                 .filter(|id| granted_ids.contains(*id))
                 .cloned()
                 .collect(),
+            // #4024: what this one grant NEEDS, as a set of distinct requirements.
+            providers: distinct_member_providers(catalog, &m.members),
         })
         .collect()
 }
@@ -447,22 +521,15 @@ fn dead_scope_cards(scopes: Option<&Vec<String>>) -> Vec<Value> {
 /// branch. For a leaf, `members` is empty and `granted_state` restates `granted`.
 /// For a bundle, `granted` is `granted_state == "all"` — the boolean an existing
 /// consumer already reads keeps its conservative meaning.
+///
+/// #4024: a bundle card's `provider` stays `null`, because a bundle has no single
+/// credential to name. Its members' requirements live in `groups[].providers` as
+/// a SET — see [`distinct_member_providers`] — so a divergence is rendered rather
+/// than collapsed into one field that could only be wrong.
 /// Test: `skill_card_reports_env_credential_state`,
 /// `skills_route_surfaces_function_skill_tri_state`.
 fn render_skill(manifest: &SkillManifest, granted: bool, group: Option<&FunctionGroup>) -> Value {
-    let provider = manifest.provider.map(|p| {
-        let configured = p.env_var.map(|var| {
-            std::env::var(var)
-                .map(|v| !v.trim().is_empty())
-                .unwrap_or(false)
-        });
-        json!({
-            "provider": p.provider,
-            "requirement": p.requirement,
-            "env_var": p.env_var,
-            "configured": configured,
-        })
-    });
+    let provider = manifest.provider.as_ref().map(provider_json);
     let granted_state = match group {
         Some(g) => g.state(),
         None if granted => "all",
@@ -512,224 +579,9 @@ fn parse_capability_sections(raw: &str) -> (ToolsConfig, SkillsConfig, Option<St
     }
 }
 
+// #4024: the unit tests moved to `tests/agent_skills_unit_tests.rs` — still a
+// child module of this one (so they keep private access), just not counting
+// against this file's production SLOC cap. Nothing else about them changed.
 #[cfg(test)]
-mod unit_tests {
-    use super::*;
-
-    #[test]
-    fn parse_capability_sections_reads_both() {
-        let raw = "[agent]\nname = \"izzie\"\n\n[tools]\nallow = [\"git_*\"]\n\n[skills]\nallow = [\"mta-train-time\"]\n";
-        let (tools, skills, err) = parse_capability_sections(raw);
-        assert!(err.is_none());
-        assert_eq!(tools.allow.unwrap(), vec!["git_*".to_string()]);
-        assert_eq!(skills.allow.unwrap(), vec!["mta-train-time".to_string()]);
-    }
-
-    #[test]
-    fn parse_capability_sections_tolerates_package_agent_toml() {
-        // A package `agent.toml` has no `[system_prompt]`; parsing must not
-        // require one (see this fn's doc comment).
-        let (tools, skills, err) = parse_capability_sections("[agent]\nname = \"x\"\n");
-        assert!(err.is_none());
-        assert!(tools.allow.is_none());
-        assert!(skills.allow.is_none());
-    }
-
-    #[test]
-    fn parse_capability_sections_reports_bad_toml() {
-        let (_, _, err) = parse_capability_sections("this is not = = toml");
-        assert!(err.is_some());
-    }
-
-    #[test]
-    fn granted_ids_are_empty_when_nothing_is_declared() {
-        // Deny-on-absent: no `[tools].allow` and no `[skills].allow` grants
-        // nothing, which must not be confused with "unrestricted".
-        let catalog = SkillCatalog::builtin();
-        assert!(granted_skill_ids(&catalog, None, None).is_empty());
-    }
-
-    #[test]
-    fn granted_ids_track_the_dispatch_gate() {
-        let catalog = SkillCatalog::builtin();
-        let patterns = vec!["get_train_schedule".to_string(), "git_*".to_string()];
-        let granted = granted_skill_ids(&catalog, Some(&patterns), None);
-        assert!(granted.contains("mta-train-time"));
-        assert!(
-            granted.contains("git-status"),
-            "trailing-* glob is honoured"
-        );
-        assert!(!granted.contains("gmail-search"));
-    }
-
-    #[test]
-    fn granted_ids_include_tool_less_skills_named_by_id() {
-        let catalog = SkillCatalog::builtin();
-        let allow = vec!["handoff-protocol".to_string()];
-        let granted = granted_skill_ids(&catalog, Some(&[]), Some(&allow));
-        assert!(granted.contains("handoff-protocol"));
-    }
-
-    #[test]
-    fn unmatched_patterns_flags_a_pattern_no_skill_wraps() {
-        let catalog = SkillCatalog::builtin();
-        let patterns = vec!["granola_*".to_string(), "get_weather".to_string()];
-        let flagged = unmatched_patterns(&catalog, Some(&patterns));
-        assert_eq!(flagged.len(), 1);
-        assert_eq!(flagged[0]["pattern"], "granola_*");
-    }
-
-    #[test]
-    fn unmatched_patterns_excludes_exact_names_that_get_a_derived_card() {
-        // One grant, one report. An exact name the catalog does not know gets a
-        // derived card; listing it as "unmatched" too would make one grant look
-        // like a capability AND a problem simultaneously.
-        let catalog = SkillCatalog::builtin();
-        let patterns = vec!["granola_list_meetings".to_string()];
-        assert!(unmatched_patterns(&catalog, Some(&patterns)).is_empty());
-        assert_eq!(derived_skills(&catalog, Some(&patterns)).len(), 1);
-    }
-
-    #[test]
-    fn derived_skills_wrap_an_exactly_named_unknown_tool() {
-        let catalog = SkillCatalog::builtin();
-        let patterns = vec![
-            "granola_list_meetings".to_string(),
-            "get_weather".to_string(),
-        ];
-        let derived = derived_skills(&catalog, Some(&patterns));
-        assert_eq!(derived.len(), 1, "a known tool must not be derived twice");
-        assert_eq!(derived[0].name, "Granola List Meetings");
-        assert_eq!(derived[0].tools, vec!["granola_list_meetings".to_string()]);
-        assert!(
-            derived[0].description.is_empty(),
-            "a derived skill invents no prose"
-        );
-    }
-
-    #[test]
-    fn derived_skills_ignore_globs() {
-        // A glob names no single tool, so there is nothing to wrap 1:1.
-        let catalog = SkillCatalog::builtin();
-        let patterns = vec!["granola_*".to_string()];
-        assert!(derived_skills(&catalog, Some(&patterns)).is_empty());
-    }
-
-    #[test]
-    fn derived_skills_are_empty_when_nothing_is_declared() {
-        assert!(derived_skills(&SkillCatalog::builtin(), None).is_empty());
-    }
-
-    #[test]
-    fn skill_card_reports_env_credential_state() {
-        let catalog = SkillCatalog::builtin();
-        // OAuth-backed: `configured` must stay null — unknown, never asserted.
-        let gmail = catalog.skill_for_tool("search_gmail_messages").unwrap();
-        let card = render_skill(gmail, true, None);
-        assert_eq!(card["provider"]["configured"], Value::Null);
-        assert_eq!(card["provider"]["provider"], "Google Workspace");
-        assert_eq!(card["granted"], true);
-
-        // Env-backed: `configured` is a real boolean derived from the process
-        // environment. Its VALUE depends on the machine, so assert only that a
-        // boolean — not null — is produced.
-        let mta = catalog.skill_for_tool("get_train_schedule").unwrap();
-        let card = render_skill(mta, false, None);
-        assert!(card["provider"]["configured"].is_boolean());
-        assert_eq!(card["provider"]["env_var"], "MTA_API_KEY");
-    }
-
-    /// #3987: the base assistant's `google.read` must reach the panel as a
-    /// dead grant, with actionable alternatives.
-    ///
-    /// NOTE: #3987's option B has removed `google.read` from the shipped
-    /// base; this test asserts on a LITERAL pattern, not on the shipped
-    /// config, so it survived that change — a USER can still hand-write
-    /// `google.read` in their own agent, and the panel must still say so.
-    /// The shipped-config assertion lives in
-    /// `ctrl::pm_task::dispatch::persona_tests`.
-    #[test]
-    fn dead_scope_cards_flags_the_google_read_pattern() {
-        let scopes = vec![
-            "memory.read".to_string(),
-            "search.read".to_string(),
-            "google.read".to_string(),
-        ];
-        let cards = dead_scope_cards(Some(&scopes));
-        assert_eq!(cards.len(), 1, "{cards:?}");
-        assert_eq!(cards[0]["pattern"], "google.read");
-        assert!(
-            cards[0]["nearest"]
-                .as_array()
-                .unwrap()
-                .iter()
-                .any(|v| v == "google.gmail.write"),
-            "the card must name a working alternative: {cards:?}"
-        );
-    }
-
-    /// The shape option B will declare must produce a clean panel.
-    #[test]
-    fn dead_scope_cards_ignores_live_family_patterns() {
-        let scopes = vec![
-            "google.gmail.*".to_string(),
-            "google.calendar.*".to_string(),
-            "google.accounts.*".to_string(),
-        ];
-        assert!(dead_scope_cards(Some(&scopes)).is_empty());
-    }
-
-    #[test]
-    fn dead_scope_cards_are_empty_when_no_scopes_are_declared() {
-        assert!(dead_scope_cards(None).is_empty());
-    }
-
-    #[test]
-    fn granted_ids_do_not_grant_a_function_skill_by_id_alone() {
-        // #4022: a bundle is tool-less, so the tool-less clause would otherwise
-        // grant it just for being named — asserting a grant nobody verified.
-        // Its state comes from its members, computed by `function_groups`.
-        let catalog = SkillCatalog::builtin();
-        let allow = vec!["ticketing".to_string()];
-        let granted = granted_skill_ids(&catalog, Some(&[]), Some(&allow));
-        assert!(!granted.contains("ticketing"));
-    }
-
-    #[test]
-    fn function_group_never_reports_all_when_a_member_is_missing() {
-        // Tri-state honesty: nine of ten is `"some"`, never `"all"`. A member
-        // that fails to resolve can never enter `granted_ids`, so this is also
-        // the shape an unresolvable member produces.
-        let catalog = SkillCatalog::builtin();
-        let ticketing = catalog.get("ticketing").expect("ticketing bundle");
-        let mut granted: std::collections::BTreeSet<String> =
-            ticketing.members.iter().cloned().collect();
-        let dropped = ticketing.members.last().unwrap().clone();
-        granted.remove(&dropped);
-
-        let groups = function_groups(&catalog, &granted);
-        let g = groups.iter().find(|g| g.id == "ticketing").unwrap();
-        assert_eq!(g.members.len(), 10);
-        assert_eq!(g.granted_members.len(), 9);
-        assert_eq!(g.state(), "some");
-        assert!(!g.granted_members.contains(&dropped));
-
-        // And the full set is `"all"` — the tri-state is not stuck.
-        let full: std::collections::BTreeSet<String> = ticketing.members.iter().cloned().collect();
-        let groups = function_groups(&catalog, &full);
-        assert_eq!(
-            groups.iter().find(|g| g.id == "ticketing").unwrap().state(),
-            "all"
-        );
-    }
-
-    #[test]
-    fn skill_card_carries_one_tool_and_a_human_name() {
-        let catalog = SkillCatalog::builtin();
-        let mta = catalog.skill_for_tool("get_train_schedule").unwrap();
-        let card = render_skill(mta, true, None);
-        assert_eq!(card["name"], "MTA Train Time");
-        assert_eq!(card["tools"], json!(["get_train_schedule"]));
-        assert_eq!(card["origin"]["kind"], "builtin");
-    }
-}
+#[path = "tests/agent_skills_unit_tests.rs"]
+mod unit_tests;

--- a/crates/trusty-agents/src/api/server/tests/agent_skills.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_skills.rs
@@ -381,7 +381,19 @@ description = "test"
 allow = ["ticketing"]
 "#;
 
-/// Grants three of the bundle's ten members individually — the `"some"` case.
+/// Grants the Google Workspace mail-and-tasks bundle (#4024) — the credential
+/// rollup case, where every member shares one unverifiable OAuth requirement.
+const GWORKSPACE_BUNDLE_FIXTURE: &str = r#"[agent]
+name = "gworker"
+role = "assistant"
+model = "claude-sonnet-4-6"
+description = "test"
+
+[skills]
+allow = ["google-workspace", "cto-tools"]
+"#;
+
+/// Grants three of the bundle's members individually — the `"some"` case.
 const PARTIAL_BUNDLE_FIXTURE: &str = r#"[agent]
 name = "partial"
 role = "assistant"
@@ -410,13 +422,22 @@ async fn skills_route_surfaces_function_skill_tri_state() {
     std::fs::write(dir.path().join("plain.toml"), BARE_FIXTURE).unwrap();
     let dirs = [dir.path().to_path_buf()];
 
+    // Read the expected membership from the live catalog: #4024 widened this
+    // bundle, and a hard-coded count would have to be edited on every widening
+    // while asserting nothing about the route.
+    let declared = crate::skills::manifest::SkillCatalog::builtin()
+        .get("ticketing")
+        .expect("the ticketing bundle")
+        .members
+        .len();
+
     let all = body_json(skills_at(&dirs, "bundled", dir.path()).await).await;
     let card = find(&all, "ticketing");
     assert_eq!(card["kind"], "function");
     assert_eq!(card["granted_state"], "all");
     assert_eq!(card["granted"], true);
-    assert_eq!(card["members"].as_array().unwrap().len(), 10);
-    assert_eq!(card["granted_members"].as_array().unwrap().len(), 10);
+    assert_eq!(card["members"].as_array().unwrap().len(), declared);
+    assert_eq!(card["granted_members"].as_array().unwrap().len(), declared);
     assert_eq!(
         find(&all, "ticket-create")["granted"],
         true,
@@ -454,6 +475,52 @@ async fn skills_route_groups_agree_with_their_cards() {
     assert_eq!(g["members"], card["members"]);
     assert_eq!(g["granted_members"], card["granted_members"]);
     assert_eq!(g["granted_state"], card["granted_state"]);
+}
+
+#[tokio::test]
+async fn skills_route_rolls_up_group_provider_requirements() {
+    // #4024/S-16: a bundle has no credential of its own, so the pane needs the
+    // members' requirements to say what the one-line grant NEEDS. The rollup is
+    // a SET — every distinct requirement is listed, so a bundle whose members
+    // diverged would show both rather than one averaged verdict — and an OAuth
+    // requirement stays `configured: null`, never a claim nobody checked.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("gworker.toml"), GWORKSPACE_BUNDLE_FIXTURE).unwrap();
+
+    let body = body_json(skills_at(&[dir.path().to_path_buf()], "gworker", dir.path()).await).await;
+
+    let gw = group(&body, "google-workspace");
+    assert_eq!(gw["granted_state"], "all");
+    let providers = gw["providers"].as_array().unwrap();
+    assert_eq!(
+        providers.len(),
+        1,
+        "every mail/tasks member shares one requirement: {providers:?}"
+    );
+    assert_eq!(providers[0]["provider"], "Google Workspace");
+    assert_eq!(
+        providers[0]["configured"],
+        serde_json::Value::Null,
+        "an OAuth grant is NOT verified by this endpoint"
+    );
+    assert_eq!(
+        find(&body, "google-workspace")["provider"],
+        serde_json::Value::Null,
+        "the bundle CARD still names no single provider (additive shape)"
+    );
+
+    let cto = group(&body, "cto-tools");
+    assert_eq!(cto["granted_state"], "all");
+    assert_eq!(cto["providers"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        cto["providers"][0]["provider"], "CTO operations database",
+        "a DIFFERENT bundle reports its OWN requirement, not a shared rollup"
+    );
+
+    // The ticketing bundle's members need no credential at all — an empty list,
+    // which must read as "nothing stated", never as "verified".
+    let ticketing = group(&body, "ticketing");
+    assert_eq!(ticketing["providers"], serde_json::json!([]));
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/api/server/tests/agent_skills_unit_tests.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_skills_unit_tests.rs
@@ -1,0 +1,283 @@
+//! Unit tests for `api::server::agent_skills` — the private helpers behind
+//! `GET /api/agents/:name/skills`.
+//!
+//! Why this file exists at all: these are `#[cfg(test)]` tests of PRIVATE
+//! functions, so they must stay a child module of `agent_skills` (a sibling
+//! module in `tests/` cannot reach `granted_skill_ids`, `render_skill` or
+//! `dead_scope_cards`). They live here rather than inline because the inline
+//! module put `agent_skills.rs` within a few lines of the 500-SLOC production
+//! cap, and the split is purely mechanical — `#[path]`-included from
+//! `agent_skills.rs`, so `use super::*` still resolves to that module and no
+//! visibility changes were needed. DOC-57 §5.5/S-8's point that a file split
+//! carries no semantics applies here too: nothing about the module boundary
+//! moved.
+//! What: the former `mod unit_tests` body, verbatim.
+//! Test: this file.
+
+use super::*;
+
+#[test]
+fn parse_capability_sections_reads_both() {
+    let raw = "[agent]\nname = \"izzie\"\n\n[tools]\nallow = [\"git_*\"]\n\n[skills]\nallow = [\"mta-train-time\"]\n";
+    let (tools, skills, err) = parse_capability_sections(raw);
+    assert!(err.is_none());
+    assert_eq!(tools.allow.unwrap(), vec!["git_*".to_string()]);
+    assert_eq!(skills.allow.unwrap(), vec!["mta-train-time".to_string()]);
+}
+
+#[test]
+fn parse_capability_sections_tolerates_package_agent_toml() {
+    // A package `agent.toml` has no `[system_prompt]`; parsing must not
+    // require one (see this fn's doc comment).
+    let (tools, skills, err) = parse_capability_sections("[agent]\nname = \"x\"\n");
+    assert!(err.is_none());
+    assert!(tools.allow.is_none());
+    assert!(skills.allow.is_none());
+}
+
+#[test]
+fn parse_capability_sections_reports_bad_toml() {
+    let (_, _, err) = parse_capability_sections("this is not = = toml");
+    assert!(err.is_some());
+}
+
+#[test]
+fn granted_ids_are_empty_when_nothing_is_declared() {
+    // Deny-on-absent: no `[tools].allow` and no `[skills].allow` grants
+    // nothing, which must not be confused with "unrestricted".
+    let catalog = SkillCatalog::builtin();
+    assert!(granted_skill_ids(&catalog, None, None).is_empty());
+}
+
+#[test]
+fn granted_ids_track_the_dispatch_gate() {
+    let catalog = SkillCatalog::builtin();
+    let patterns = vec!["get_train_schedule".to_string(), "git_*".to_string()];
+    let granted = granted_skill_ids(&catalog, Some(&patterns), None);
+    assert!(granted.contains("mta-train-time"));
+    assert!(
+        granted.contains("git-status"),
+        "trailing-* glob is honoured"
+    );
+    assert!(!granted.contains("gmail-search"));
+}
+
+#[test]
+fn granted_ids_include_tool_less_skills_named_by_id() {
+    let catalog = SkillCatalog::builtin();
+    let allow = vec!["handoff-protocol".to_string()];
+    let granted = granted_skill_ids(&catalog, Some(&[]), Some(&allow));
+    assert!(granted.contains("handoff-protocol"));
+}
+
+#[test]
+fn unmatched_patterns_flags_a_pattern_no_skill_wraps() {
+    let catalog = SkillCatalog::builtin();
+    let patterns = vec!["granola_*".to_string(), "get_weather".to_string()];
+    let flagged = unmatched_patterns(&catalog, Some(&patterns));
+    assert_eq!(flagged.len(), 1);
+    assert_eq!(flagged[0]["pattern"], "granola_*");
+}
+
+#[test]
+fn unmatched_patterns_excludes_exact_names_that_get_a_derived_card() {
+    // One grant, one report. An exact name the catalog does not know gets a
+    // derived card; listing it as "unmatched" too would make one grant look
+    // like a capability AND a problem simultaneously.
+    let catalog = SkillCatalog::builtin();
+    let patterns = vec!["granola_list_meetings".to_string()];
+    assert!(unmatched_patterns(&catalog, Some(&patterns)).is_empty());
+    assert_eq!(derived_skills(&catalog, Some(&patterns)).len(), 1);
+}
+
+#[test]
+fn derived_skills_wrap_an_exactly_named_unknown_tool() {
+    let catalog = SkillCatalog::builtin();
+    let patterns = vec![
+        "granola_list_meetings".to_string(),
+        "get_weather".to_string(),
+    ];
+    let derived = derived_skills(&catalog, Some(&patterns));
+    assert_eq!(derived.len(), 1, "a known tool must not be derived twice");
+    assert_eq!(derived[0].name, "Granola List Meetings");
+    assert_eq!(derived[0].tools, vec!["granola_list_meetings".to_string()]);
+    assert!(
+        derived[0].description.is_empty(),
+        "a derived skill invents no prose"
+    );
+}
+
+#[test]
+fn derived_skills_ignore_globs() {
+    // A glob names no single tool, so there is nothing to wrap 1:1.
+    let catalog = SkillCatalog::builtin();
+    let patterns = vec!["granola_*".to_string()];
+    assert!(derived_skills(&catalog, Some(&patterns)).is_empty());
+}
+
+#[test]
+fn derived_skills_are_empty_when_nothing_is_declared() {
+    assert!(derived_skills(&SkillCatalog::builtin(), None).is_empty());
+}
+
+#[test]
+fn skill_card_reports_env_credential_state() {
+    let catalog = SkillCatalog::builtin();
+    // OAuth-backed: `configured` must stay null — unknown, never asserted.
+    let gmail = catalog.skill_for_tool("search_gmail_messages").unwrap();
+    let card = render_skill(gmail, true, None);
+    assert_eq!(card["provider"]["configured"], Value::Null);
+    assert_eq!(card["provider"]["provider"], "Google Workspace");
+    assert_eq!(card["granted"], true);
+
+    // Env-backed: `configured` is a real boolean derived from the process
+    // environment. Its VALUE depends on the machine, so assert only that a
+    // boolean — not null — is produced.
+    let mta = catalog.skill_for_tool("get_train_schedule").unwrap();
+    let card = render_skill(mta, false, None);
+    assert!(card["provider"]["configured"].is_boolean());
+    assert_eq!(card["provider"]["env_var"], "MTA_API_KEY");
+}
+
+/// #3987: the base assistant's `google.read` must reach the panel as a
+/// dead grant, with actionable alternatives.
+///
+/// NOTE: #3987's option B has removed `google.read` from the shipped
+/// base; this test asserts on a LITERAL pattern, not on the shipped
+/// config, so it survived that change — a USER can still hand-write
+/// `google.read` in their own agent, and the panel must still say so.
+/// The shipped-config assertion lives in
+/// `ctrl::pm_task::dispatch::persona_tests`.
+#[test]
+fn dead_scope_cards_flags_the_google_read_pattern() {
+    let scopes = vec![
+        "memory.read".to_string(),
+        "search.read".to_string(),
+        "google.read".to_string(),
+    ];
+    let cards = dead_scope_cards(Some(&scopes));
+    assert_eq!(cards.len(), 1, "{cards:?}");
+    assert_eq!(cards[0]["pattern"], "google.read");
+    assert!(
+        cards[0]["nearest"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v == "google.gmail.write"),
+        "the card must name a working alternative: {cards:?}"
+    );
+}
+
+/// The shape option B will declare must produce a clean panel.
+#[test]
+fn dead_scope_cards_ignores_live_family_patterns() {
+    let scopes = vec![
+        "google.gmail.*".to_string(),
+        "google.calendar.*".to_string(),
+        "google.accounts.*".to_string(),
+    ];
+    assert!(dead_scope_cards(Some(&scopes)).is_empty());
+}
+
+#[test]
+fn dead_scope_cards_are_empty_when_no_scopes_are_declared() {
+    assert!(dead_scope_cards(None).is_empty());
+}
+
+#[test]
+fn granted_ids_do_not_grant_a_function_skill_by_id_alone() {
+    // #4022: a bundle is tool-less, so the tool-less clause would otherwise
+    // grant it just for being named — asserting a grant nobody verified.
+    // Its state comes from its members, computed by `function_groups`.
+    let catalog = SkillCatalog::builtin();
+    let allow = vec!["ticketing".to_string()];
+    let granted = granted_skill_ids(&catalog, Some(&[]), Some(&allow));
+    assert!(!granted.contains("ticketing"));
+}
+
+#[test]
+fn function_group_never_reports_all_when_a_member_is_missing() {
+    // Tri-state honesty: nine of ten is `"some"`, never `"all"`. A member
+    // that fails to resolve can never enter `granted_ids`, so this is also
+    // the shape an unresolvable member produces.
+    let catalog = SkillCatalog::builtin();
+    let ticketing = catalog.get("ticketing").expect("ticketing bundle");
+    let mut granted: std::collections::BTreeSet<String> =
+        ticketing.members.iter().cloned().collect();
+    let dropped = ticketing.members.last().unwrap().clone();
+    granted.remove(&dropped);
+
+    let groups = function_groups(&catalog, &granted);
+    let g = groups.iter().find(|g| g.id == "ticketing").unwrap();
+    // Counted from the live catalog: #4024 widened the bundle, and the property
+    // under test is "one short is `some`", not any particular membership size.
+    assert_eq!(g.members.len(), ticketing.members.len());
+    assert_eq!(g.granted_members.len(), ticketing.members.len() - 1);
+    assert_eq!(g.state(), "some");
+    assert!(!g.granted_members.contains(&dropped));
+
+    // And the full set is `"all"` — the tri-state is not stuck.
+    let full: std::collections::BTreeSet<String> = ticketing.members.iter().cloned().collect();
+    let groups = function_groups(&catalog, &full);
+    assert_eq!(
+        groups.iter().find(|g| g.id == "ticketing").unwrap().state(),
+        "all"
+    );
+}
+
+#[test]
+fn skill_card_carries_one_tool_and_a_human_name() {
+    let catalog = SkillCatalog::builtin();
+    let mta = catalog.skill_for_tool("get_train_schedule").unwrap();
+    let card = render_skill(mta, true, None);
+    assert_eq!(card["name"], "MTA Train Time");
+    assert_eq!(card["tools"], json!(["get_train_schedule"]));
+    assert_eq!(card["origin"]["kind"], "builtin");
+}
+
+#[test]
+fn group_providers_list_every_distinct_member_requirement() {
+    // #4024: the rollup keeps DISTINCT requirements rather than collapsing to a
+    // verdict. A synthetic two-provider bundle is the case the real catalog does
+    // not currently exercise, and it is exactly the case a silent collapse would
+    // hide — so it is pinned here rather than left to a future divergence.
+    let catalog = SkillCatalog::builtin();
+
+    // Real bundle, one shared requirement.
+    let gw = distinct_member_providers(
+        &catalog,
+        &catalog
+            .get("google-workspace")
+            .expect("bundle")
+            .members
+            .clone(),
+    );
+    assert_eq!(gw.len(), 1);
+    assert_eq!(gw[0].provider, "Google Workspace");
+    assert!(gw[0].env_var.is_none(), "OAuth is not env-backed");
+
+    // Divergent members: two providers in, two out, in member order.
+    let mixed = vec![
+        "gmail-search".to_string(),
+        "mta-train-time".to_string(),
+        "gmail-read".to_string(), // repeat of the first requirement: deduped
+        "web-search".to_string(),
+    ];
+    let providers = distinct_member_providers(&catalog, &mixed);
+    let names: Vec<&str> = providers.iter().map(|p| p.provider).collect();
+    assert_eq!(names, vec!["Google Workspace", "MTA", "Brave Search"]);
+}
+
+#[test]
+fn group_providers_are_empty_when_no_member_needs_a_credential() {
+    // Empty must read as "no member states a requirement" — the pane renders
+    // nothing rather than an implied green. An unresolvable member likewise
+    // contributes nothing (it cannot be granted either).
+    let catalog = SkillCatalog::builtin();
+    let members = vec![
+        "ticket-create".to_string(),
+        "git-branch-list".to_string(),
+        "no-such-skill".to_string(),
+    ];
+    assert!(distinct_member_providers(&catalog, &members).is_empty());
+}

--- a/crates/trusty-agents/src/skills/manifest/builtin/functions.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/functions.rs
@@ -98,12 +98,13 @@ const TICKETING_MEMBERS: &[&str] = &[
 /// claimed here; it is surfaced separately and honestly by the route's
 /// `dead_scope_patterns`.
 ///
-/// **On the display name.** The id is `google-workspace`, as asked. The NAME is
-/// "Google Workspace Mail and Tasks" because the card renders the name, and a
-/// card reading "Google Workspace" over a bundle holding no Drive, Docs, Sheets,
-/// Slides or Calendar skill claims a coverage the row does not have — the same
-/// over-claim `granted_state` exists to prevent one level down. Widen the name
-/// when the membership widens, not before.
+/// **On the display name — read this before trusting the card.** The name is the
+/// short "Google Workspace" (owner decision, 2026-07-28, made with the narrower
+/// alternative and this caveat in front of him). The MEMBERSHIP is narrower than
+/// that name: Gmail and Google Tasks ONLY. This row holds no Drive, Docs, Sheets,
+/// Slides or Calendar skill, and none of the exclusions listed above. Read the
+/// member list, not the name, when reviewing what a `google-workspace` grant
+/// confers; the card's description states the same scope to the user.
 /// Test: `google_workspace_function_skill_bundles_the_mail_and_tasks_leaves`,
 /// `google_workspace_bundle_excludes_account_and_settings_administration`,
 /// `super::super::super::api::server::tests::agent_skills::skills_route_rolls_up_group_provider_requirements`.
@@ -161,7 +162,9 @@ pub(super) static TABLE: &[SkillDef] = &[
     ),
     function_skill(
         "google-workspace",
-        "Google Workspace Mail and Tasks",
+        // Short name by owner decision; membership is Gmail + Tasks only — see
+        // the `GOOGLE_WORKSPACE_MEMBERS` doc comment.
+        "Google Workspace",
         "Gmail and Google Tasks as one capability: search, read, compose, draft, \
          label and download attachments from mail, and list, create, update and \
          complete tasks. Covers mail and tasks ONLY — Drive, Docs, Sheets, Slides \

--- a/crates/trusty-agents/src/skills/manifest/builtin/functions.rs
+++ b/crates/trusty-agents/src/skills/manifest/builtin/functions.rs
@@ -14,15 +14,22 @@
 //! shape a privilege-escalation bug wants. Keeping the member lists in
 //! compile-time data means the set is closed, reviewable in a diff, and checked
 //! by `builtin_function_skills_declare_only_known_members` — there is no runtime
-//! path (authored `.md`, MCP discovery) that can author one.
+//! path (authored `.md`, MCP discovery) that can author one. That closure is
+//! also why `cto-tools` below ships as reviewed `const` data rather than as a
+//! user-authoring mechanism: the owner asked for it as a "user-created" bundle,
+//! and the decision (owner, 2026-07-28) is to ship the row now and treat
+//! operator-authored bundles as a separate follow-on (#2201), because the
+//! authoring path is the part that needs the security design, not the row.
 //! What: A `const` table of [`function_skill`] rows, each naming member skill
 //! ids that exist elsewhere in [`super::all`].
-//! Test: `super::super::tests` — `ticketing_function_skill_bundles_the_ten_ticket_leaf_skills`,
+//! Test: `super::super::tests` — `ticketing_function_skill_bundles_the_ticket_and_git_leaf_skills`,
+//! `google_workspace_function_skill_bundles_the_mail_and_tasks_leaves`,
+//! `cto_tools_function_skill_bundles_the_four_cto_database_leaves`,
 //! `function_skill_never_leaks_its_bundle_id_into_the_tool_patterns`.
 
 use super::super::{SkillDef, function_skill};
 
-/// The ten ticketing leaf skills, in `ops.rs` catalog order.
+/// The ticketing work unit: ten ticket operations plus git *inspection*.
 ///
 /// Why: Spelled out rather than derived from a name prefix — DOC-57 §5.5/S-8 is
 /// explicit that *"no prefix grouping [exists] anywhere in this model"*, and a
@@ -30,7 +37,19 @@ use super::super::{SkillDef, function_skill};
 /// through the back door, silently absorbing any future `ticket-`-prefixed skill
 /// into an existing grant. An explicit list means adding a leaf is a deliberate
 /// decision to widen the bundle, visible in review.
-/// Test: `ticketing_function_skill_bundles_the_ten_ticket_leaf_skills`.
+///
+/// **Why the two git rows are here** (owner, 2026-07-28): the ticketing subagent
+/// is the component that answers "what changed for this ticket", which it cannot
+/// do without reading history — so the owner's unit of function is git *plus*
+/// ticketing, controlled together. The widening is deliberately limited to the
+/// two READ-ONLY git skills the request named (`git_search_commits`,
+/// `git_branches`). `git-commit-create`, `git-branch-create` and the rest of
+/// `core.rs`'s git *mutation* rows stay out: a bundle grant is the shape that
+/// turns one config line into N capabilities, so quietly folding write access to
+/// the repository into a ticketing grant is exactly the escalation-by-convenience
+/// S-14 exists to keep reviewable.
+/// Test: `ticketing_function_skill_bundles_the_ticket_and_git_leaf_skills`,
+/// `ticketing_bundle_carries_no_git_mutation_skill`.
 const TICKETING_MEMBERS: &[&str] = &[
     "ticket-create",
     "ticket-read",
@@ -42,16 +61,122 @@ const TICKETING_MEMBERS: &[&str] = &[
     "ticket-assign",
     "ticket-transition",
     "ticket-search",
+    // #4024: git inspection, per the owner's "git + ticketing as one unit".
+    "git-commit-search",
+    "git-branch-list",
 ];
 
-pub(super) static TABLE: &[SkillDef] = &[function_skill(
-    "ticketing",
-    "Ticketing",
-    "Everything needed to work a tracker end to end: open, read, update, comment \
-     on, label, assign, transition, search and close tickets. Granting this one \
-     skill grants all ten ticket operations. Note: per the domain authority \
-     (epic #4021 section D), the ticketing DOMAIN routes to the subagent \
-     modality when a ticketing subagent is available — this function skill is \
-     the direct-skill fallback used when it is not.",
-    TICKETING_MEMBERS,
-)];
+/// The Google Workspace mail-and-tasks work unit.
+///
+/// Why: The owner's screen showed `create_draft`, `list_tasks`, `complete_task`
+/// and `create_task` as four unrelated cards; they are one function — "handle my
+/// mail and my to-do list". This row is that function, authored exactly as
+/// #4023 authored `ticketing`: an explicit, closed, reviewable list.
+///
+/// **What is deliberately NOT in it**, since a bundle's value is that a reviewer
+/// need only read one line, which only works if the line does not hide teeth:
+/// - `gmail-filters` / `gmail-settings` — *account* configuration (vacation
+///   responder, forwarding). A forwarding rule is a mail-exfiltration and
+///   account-persistence primitive; it does not belong in a grant a reviewer
+///   reads as "can send mail and tick off tasks".
+/// - `gw-account-*` — OAuth account administration (authorize, remove, set
+///   default). Administering *which* Google identity every other gworkspace tool
+///   acts as is a different function from using it.
+/// - Drive, Docs, Sheets, Slides and Calendar — the other Workspace families.
+///   They are not "mail and tasks", and the description says so rather than
+///   letting the bundle's name imply a coverage it does not have.
+///
+/// **Provider verification across divergent members** (S-16). Every member here
+/// carries the same manifest-level credential ([`super::GOOGLE_OAUTH`], whose
+/// `env_var` is `None`), so the group rolls up to exactly one requirement,
+/// reported as NOT VERIFIED — never as configured. The rollup is a *set of
+/// distinct requirements*, not a single collapsed verdict: a bundle whose members
+/// carried two different providers reports both, so a divergence is visible
+/// rather than averaged away (see `api::server::agent_skills::function_groups`).
+/// The dotted-scope axis that DOES distinguish these leaves at dispatch time
+/// (`google.gmail.*` vs `google.tasks.*`) is not a manifest concept and is not
+/// claimed here; it is surfaced separately and honestly by the route's
+/// `dead_scope_patterns`.
+///
+/// **On the display name.** The id is `google-workspace`, as asked. The NAME is
+/// "Google Workspace Mail and Tasks" because the card renders the name, and a
+/// card reading "Google Workspace" over a bundle holding no Drive, Docs, Sheets,
+/// Slides or Calendar skill claims a coverage the row does not have — the same
+/// over-claim `granted_state` exists to prevent one level down. Widen the name
+/// when the membership widens, not before.
+/// Test: `google_workspace_function_skill_bundles_the_mail_and_tasks_leaves`,
+/// `google_workspace_bundle_excludes_account_and_settings_administration`,
+/// `super::super::super::api::server::tests::agent_skills::skills_route_rolls_up_group_provider_requirements`.
+const GOOGLE_WORKSPACE_MEMBERS: &[&str] = &[
+    // --- mail -------------------------------------------------------------
+    "gmail-search",
+    "gmail-read",
+    "gmail-compose",
+    "gmail-draft",
+    "gmail-format",
+    "gmail-labels-apply",
+    "gmail-labels-manage",
+    "gmail-attachments-list",
+    "gmail-attachment-download",
+    // --- tasks ------------------------------------------------------------
+    "gtasks-lists",
+    "gtasks-manage",
+    "gtasks-list",
+    "gtasks-complete",
+    "gtasks-create",
+];
+
+/// The four CTO operations-database queries, as one function.
+///
+/// Why (owner, 2026-07-28): the CTO assistant's four `query_*` cards are one
+/// capability — "ask the CTO operations database" — and the owner asked to see
+/// them as one row. He framed it as a *user-created* bundle; the decision this
+/// session was to ship it as reviewed `const` data and keep operator authoring as
+/// a follow-on (#2201). That is not a shortcut: S-14 makes bundles built-in only
+/// *because* a bundle id is the one name whose meaning a reviewer cannot check by
+/// reading `agent.toml`, so adding an authoring path is a security design, not a
+/// parser change. Shipping the row now gives the owner the grouping he asked for
+/// without relaxing that rule by a single line.
+/// Test: `cto_tools_function_skill_bundles_the_four_cto_database_leaves`.
+const CTO_TOOLS_MEMBERS: &[&str] = &[
+    "cto-headcount",
+    "cto-budget",
+    "cto-risks",
+    "cto-work-classification",
+];
+
+pub(super) static TABLE: &[SkillDef] = &[
+    function_skill(
+        "ticketing",
+        "Ticketing",
+        "Everything needed to work a tracker end to end: open, read, update, comment \
+         on, label, assign, transition, search and close tickets, plus the read-only \
+         git history and branch lookups that answer \"what changed for this ticket\". \
+         Granting this one skill grants all twelve operations; it grants no git \
+         WRITE access. Note: per the domain authority (epic #4021 section D), the \
+         ticketing DOMAIN routes to the subagent modality when a ticketing subagent \
+         is available — this function skill is the direct-skill fallback used when \
+         it is not.",
+        TICKETING_MEMBERS,
+    ),
+    function_skill(
+        "google-workspace",
+        "Google Workspace Mail and Tasks",
+        "Gmail and Google Tasks as one capability: search, read, compose, draft, \
+         label and download attachments from mail, and list, create, update and \
+         complete tasks. Covers mail and tasks ONLY — Drive, Docs, Sheets, Slides \
+         and Calendar are separate skills, and Gmail account settings, filters and \
+         Google account authorization are deliberately excluded. Every member needs \
+         an authorized Google account, which this endpoint cannot verify.",
+        GOOGLE_WORKSPACE_MEMBERS,
+    ),
+    function_skill(
+        "cto-tools",
+        "CTO Tools",
+        "Read the CTO operations database as one capability: engineering headcount, \
+         budget, the risk register and work classification. Read-only queries; the \
+         database is supplied by a per-persona plugin, so an agent granted this on a \
+         machine without it holds four skills that resolve to nothing.",
+        CTO_TOOLS_MEMBERS,
+    ),
+];

--- a/crates/trusty-agents/src/skills/manifest/tests.rs
+++ b/crates/trusty-agents/src/skills/manifest/tests.rs
@@ -919,11 +919,14 @@ fn synthetic_bundle(id: &str, members: &[&str]) -> SkillManifest {
     }
 }
 
-/// The ten ticketing leaf ids the `ticketing` bundle is specified to carry.
+/// The leaf ids the `ticketing` bundle is specified to carry.
 ///
 /// Why: Named here so #4023's assertions read against the ISSUE's list, while
 /// the tools they resolve to are always read from the live `ops.rs` catalog —
 /// a hand-copied tool list would pass while the catalog drifted underneath it.
+/// #4024 widened it by the two READ-ONLY git rows on the owner's directive that
+/// git and ticketing are one unit; the widening is spelled out here so a future
+/// addition has to change this list too, in the same diff.
 const TICKETING_LEAF_IDS: &[&str] = &[
     "ticket-create",
     "ticket-read",
@@ -935,6 +938,34 @@ const TICKETING_LEAF_IDS: &[&str] = &[
     "ticket-assign",
     "ticket-transition",
     "ticket-search",
+    "git-commit-search",
+    "git-branch-list",
+];
+
+/// The mail-and-tasks leaf ids the `google-workspace` bundle carries (#4024).
+const GOOGLE_WORKSPACE_LEAF_IDS: &[&str] = &[
+    "gmail-search",
+    "gmail-read",
+    "gmail-compose",
+    "gmail-draft",
+    "gmail-format",
+    "gmail-labels-apply",
+    "gmail-labels-manage",
+    "gmail-attachments-list",
+    "gmail-attachment-download",
+    "gtasks-lists",
+    "gtasks-manage",
+    "gtasks-list",
+    "gtasks-complete",
+    "gtasks-create",
+];
+
+/// The four leaf ids the `cto-tools` bundle carries (#4024).
+const CTO_TOOLS_LEAF_IDS: &[&str] = &[
+    "cto-headcount",
+    "cto-budget",
+    "cto-risks",
+    "cto-work-classification",
 ];
 
 #[test]
@@ -1131,9 +1162,10 @@ fn authored_manifest_cannot_declare_a_bundle() {
 }
 
 #[test]
-fn ticketing_function_skill_bundles_the_ten_ticket_leaf_skills() {
-    // #4023: the exemplar. Membership is asserted against the issue's list, and
-    // the tools come from the live `ops.rs` catalog so drift fails here.
+fn ticketing_function_skill_bundles_the_ticket_and_git_leaf_skills() {
+    // #4023: the exemplar, widened by #4024. Membership is asserted against the
+    // issue's list, and the tools come from the live `ops.rs`/`core.rs` catalog
+    // so drift fails here.
     let catalog = SkillCatalog::builtin();
     let ticketing = catalog.get("ticketing").expect("ticketing function skill");
     assert_eq!(ticketing.name, "Ticketing");
@@ -1143,10 +1175,137 @@ fn ticketing_function_skill_bundles_the_ten_ticket_leaf_skills() {
         "a bundle wraps no tool of its own"
     );
     assert_eq!(ticketing.members, TICKETING_LEAF_IDS);
+    let tools = catalog.expand(&["ticketing".to_string()]).tools;
+    assert_eq!(tools.len(), TICKETING_LEAF_IDS.len());
+    // The owner's ask, stated as tools rather than ids: git travels with tickets.
+    assert!(tools.contains(&"git_search_commits".to_string()));
+    assert!(tools.contains(&"git_branches".to_string()));
+    assert!(tools.contains(&"create_ticket".to_string()));
+}
+
+#[test]
+fn ticketing_bundle_carries_no_git_mutation_skill() {
+    // #4024: the widening is git INSPECTION only. A bundle turns one config line
+    // into N capabilities, so repository write access must never ride along on a
+    // grant a reviewer reads as "work the tracker".
+    let catalog = SkillCatalog::builtin();
+    let tools = catalog.expand(&["ticketing".to_string()]).tools;
+    for mutating in [
+        "git_create_branch",
+        "git_checkout",
+        "git_stage",
+        "git_commit",
+        "git_stash",
+        "git_push",
+        "git_pull",
+        "git_fetch",
+    ] {
+        // Read from the live catalog first: an assertion that a NON-EXISTENT
+        // tool is absent would pass vacuously and pin nothing.
+        assert!(
+            catalog.skill_for_tool(mutating).is_some(),
+            "{mutating} is no longer a catalog tool; update this list"
+        );
+        assert!(
+            !tools.contains(&mutating.to_string()),
+            "the ticketing bundle grants {mutating}: {tools:?}"
+        );
+    }
+}
+
+#[test]
+fn google_workspace_function_skill_bundles_the_mail_and_tasks_leaves() {
+    // #4024: authored exactly as #4023 authored `ticketing` — a closed const
+    // list, asserted here, resolving through the live `gworkspace.rs` catalog.
+    let catalog = SkillCatalog::builtin();
+    let bundle = catalog.get("google-workspace").expect("the bundle");
+    assert_eq!(bundle.kind, SkillKind::Function);
+    assert!(bundle.tools.is_empty());
+    assert_eq!(bundle.members, GOOGLE_WORKSPACE_LEAF_IDS);
+    let tools = catalog.expand(&["google-workspace".to_string()]).tools;
+    assert_eq!(tools.len(), GOOGLE_WORKSPACE_LEAF_IDS.len());
+    // The four the owner's screen actually showed as loose cards.
+    for tool in ["create_draft", "list_tasks", "complete_task", "create_task"] {
+        assert!(tools.contains(&tool.to_string()), "missing {tool}");
+    }
+}
+
+#[test]
+fn google_workspace_bundle_excludes_account_and_settings_administration() {
+    // The exclusions are load-bearing, not an oversight: mail FORWARDING and
+    // OAuth account administration are different functions from "read and send
+    // my mail", and folding them in would hide teeth behind a one-line grant.
+    let catalog = SkillCatalog::builtin();
+    let tools = catalog.expand(&["google-workspace".to_string()]).tools;
+    for excluded in [
+        "manage_gmail_settings",
+        "manage_gmail_filters",
+        "add_account",
+        "remove_account",
+        "set_default_account",
+        // Other Workspace families the NAME must not be read as covering.
+        "search_drive_files",
+        "manage_events",
+        "get_document",
+    ] {
+        assert!(
+            catalog.skill_for_tool(excluded).is_some(),
+            "{excluded} is no longer a catalog tool; update this list"
+        );
+        assert!(
+            !tools.contains(&excluded.to_string()),
+            "the google-workspace bundle grants {excluded}: {tools:?}"
+        );
+    }
+}
+
+#[test]
+fn cto_tools_function_skill_bundles_the_four_cto_database_leaves() {
+    // #4024: shipped as reviewed const data, NOT as a user-authoring path —
+    // S-14 (bundles are built-in only) is not relaxed by a single line.
+    let catalog = SkillCatalog::builtin();
+    let bundle = catalog.get("cto-tools").expect("the bundle");
+    assert_eq!(bundle.name, "CTO Tools");
+    assert_eq!(bundle.kind, SkillKind::Function);
+    assert_eq!(bundle.members, CTO_TOOLS_LEAF_IDS);
+    let tools = catalog.expand(&["cto-tools".to_string()]).tools;
     assert_eq!(
-        catalog.expand(&["ticketing".to_string()]).tools.len(),
-        TICKETING_LEAF_IDS.len()
+        tools,
+        vec![
+            "query_headcount".to_string(),
+            "query_budget".to_string(),
+            "query_risks".to_string(),
+            "query_work_classification".to_string(),
+        ]
     );
+}
+
+#[test]
+fn every_builtin_bundle_is_grantable_and_leaks_no_bundle_id() {
+    // One property over ALL bundles, so a fourth row added later cannot ship
+    // without the guarantee: a bundle id compiles down and never reaches the
+    // pattern list the permission gates read.
+    let catalog = SkillCatalog::builtin();
+    let bundle_ids: Vec<String> = catalog
+        .manifests()
+        .iter()
+        .filter(|m| m.is_function())
+        .map(|m| m.id.clone())
+        .collect();
+    assert!(bundle_ids.len() >= 3, "expected the three shipped bundles");
+    for id in &bundle_ids {
+        let (patterns, unresolved) =
+            effective_tool_patterns(None, Some(&vec![id.clone()]), &catalog);
+        let patterns = patterns.expect("a declared skills section yields Some");
+        assert!(unresolved.is_empty(), "{id} has unresolved members");
+        assert!(!patterns.is_empty(), "{id} granted nothing");
+        for other in &bundle_ids {
+            assert!(
+                !patterns.contains(other),
+                "{id} leaked the bundle id {other}"
+            );
+        }
+    }
 }
 
 #[test]

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.svelte
@@ -24,9 +24,28 @@
    * live-discovered MCP tool with no authored manifest) is badged as such; and
    * an allow-pattern that resolved to nothing is shown with its reason instead
    * of being dropped.
+   *
+   * #4024 — function skills render as GROUPS. The owner's directive is that
+   * skills be organized by function, so a `kind: 'function'` bundle is a group
+   * header over its member cards rather than a card of its own. Three rules keep
+   * it honest:
+   *   - The tri-state is rendered as a tri-state. A header says "granted" only
+   *     when `granted_state === 'all'`; `some` reads "partial" with the counts,
+   *     `none` reads "not granted". A bundle is never claimed as granted because
+   *     it was named.
+   *   - Nothing about membership or grant state is derived here. Both come from
+   *     `groups[]`, which the route builds from the SAME computation as the
+   *     cards — PR #3964 deleted `synthesizeSkills` precisely so the pane cannot
+   *     drift from the enforcement path, and re-deriving would reintroduce it.
+   *   - The counts do not move. A bundle is not a capability (S-16), so the
+   *     "N of M known skills granted" footer still counts leaves only, matching
+   *     the server's `granted_count`. A member is shown INSIDE its group instead
+   *     of in the flat kind buckets, so it renders once, not twice.
    * Test: `AgentConfigSkills.test.ts`.
    */
-  import type { AgentSkills, AgentSkill } from '../lib/agentConfig';
+  import type { AgentSkills, AgentSkill, AgentSkillGroup } from '../lib/agentConfig';
+  import { providerChip } from '../lib/agentConfig';
+  import AgentSkillCard from './AgentSkillCard.svelte';
 
   /** Loaded by the shell from `GET /api/agents/:name/skills`; `null` while loading. */
   export let data: AgentSkills | null = null;
@@ -43,42 +62,62 @@
   // #4022: a `function` card is a BUNDLE — a group header over its member
   // cards, not a capability of its own. It is excluded from both counts for the
   // same reason the server excludes it from `granted_count`: granting
-  // `ticketing` adds ten capabilities, and counting the header as an eleventh
-  // would print "11 of N" over ten rendered cards. Rendering the group itself is
-  // #4024's ticket; until then a bundle is simply not shown.
+  // `ticketing` adds twelve capabilities, and counting the header as a
+  // thirteenth would print "13 of N" over twelve rendered cards. #4024 renders
+  // the header itself, from `groups[]` — never from these cards.
   $: leaves = all.filter((s) => s.kind !== 'function');
   $: granted = leaves.filter((s) => s.granted);
   // #3987: scope grants that can match nothing. Defaulted like every array
   // above so an older sidecar (which has no such field) renders the rest of
   // the pane rather than throwing.
   $: deadScopes = data?.dead_scope_patterns ?? [];
-  $: actions = granted.filter((s) => s.kind === 'action');
-  $: knowledge = granted.filter((s) => s.kind === 'knowledge');
-  $: system = granted.filter((s) => s.kind === 'system');
+  // #4024: the function tier. `groups` is the route's index over the
+  // `kind: 'function'` cards; `byId` resolves a member id back to its card so a
+  // group renders REAL cards rather than a second, thinner rendering of them.
+  $: groups = data?.groups ?? [];
+  $: byId = new Map(all.map((s) => [s.id, s]));
+  // A member shown inside its group is removed from the flat buckets: one card,
+  // one place. Membership is read from the group (what the bundle declares), not
+  // inferred from the card, so an ungranted member is pulled out too — it is not
+  // listed anywhere, exactly as an ungranted leaf is not.
+  $: groupedIds = new Set(groups.flatMap((g) => g.members));
+  $: ungrouped = granted.filter((s) => !groupedIds.has(s.id));
+  $: actions = ungrouped.filter((s) => s.kind === 'action');
+  $: knowledge = ungrouped.filter((s) => s.kind === 'knowledge');
+  $: system = ungrouped.filter((s) => s.kind === 'system');
   $: catalogSize = leaves.length;
 
-  /** Credential line for a card, or `null` when the skill needs none. */
-  function credential(skill: AgentSkill): { label: string; tone: string; title: string } | null {
-    const p = skill.provider;
-    if (!p) return null;
-    if (p.configured === true)
-      return { label: `${p.provider} configured`, tone: 'ok', title: p.requirement };
-    if (p.configured === false)
-      return {
-        label: `${p.provider} NOT configured`,
-        tone: 'bad',
-        title: `${p.requirement} Set ${p.env_var}.`,
-      };
-    return { label: `${p.provider} — not verified`, tone: 'unknown', title: p.requirement };
+  /**
+   * The group header's grant word, its tone, and the counts behind it.
+   *
+   * Why: The one place the tri-state could be flattened back into a boolean, so
+   * it is the one place worth stating: "granted" is reserved for `all`. `some`
+   * says "partial" and shows both numbers, because "7 of 12" is the fact the
+   * user needs and "granted" would be a claim about five skills this agent does
+   * not hold.
+   */
+  function groupState(g: AgentSkillGroup): { word: string; tone: string; counts: string } {
+    const counts = `${g.granted_members.length} of ${g.members.length} skills`;
+    if (g.granted_state === 'all') return { word: 'granted', tone: 'ok', counts };
+    if (g.granted_state === 'some') return { word: 'partial', tone: 'warn', counts };
+    return { word: 'not granted', tone: 'off', counts };
+  }
+
+  /** The member cards a group renders — granted only, in declared order. */
+  function grantedCards(g: AgentSkillGroup): AgentSkill[] {
+    return g.granted_members
+      .map((id) => byId.get(id))
+      .filter((s): s is AgentSkill => s !== undefined);
   }
 </script>
 
 <div class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto">
   <p class="text-xs text-foundry-light-muted dark:text-foundry-text/60">
     What this agent can do. Each card below is one skill wrapping exactly one tool, named for what
-    invoking it accomplishes. A grant may also name a <em>function skill</em> — a bundle such as
-    <code class="font-mono">ticketing</code> that grants all of its member skills at once; its
-    members appear here as their own cards. Edit the grants in
+    invoking it accomplishes. Skills that belong to a <em>function skill</em> — a bundle such as
+    <code class="font-mono">ticketing</code> that grants all of its members at once — are shown
+    under that function; a function reads <em>granted</em> only when every one of its members is.
+    Edit the grants in
     <code class="font-mono">agent.toml</code> —
     <code class="font-mono">[skills].allow</code> (skill ids) or
     <code class="font-mono">[tools].allow</code> (tool globs); the two are unioned, so neither
@@ -112,63 +151,96 @@
       </p>
     {/if}
 
-    {#each [{ label: 'Actions', items: actions }, { label: 'Knowledge', items: knowledge }, { label: 'System', items: system }] as group (group.label)}
-      {#if group.items.length > 0}
-        <h4 class="mt-1 font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
-          {group.label} ({group.items.length})
-        </h4>
-        {#each group.items as skill (skill.id)}
-          <div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
-            <div class="flex items-baseline justify-between gap-2">
+    <!--
+      #4024: the function tier, rendered first because it is the organising
+      layer the owner asked for — "skills organized by function". Each group is
+      collapsed by default (a header is a summary, not a wall of cards) and its
+      grant word comes straight from the route's tri-state.
+    -->
+    {#if groups.length > 0}
+      <h4 class="mt-1 font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
+        Functions ({groups.length})
+      </h4>
+      {#each groups as g (g.id)}
+        {@const state = groupState(g)}
+        {@const cards = grantedCards(g)}
+        <details class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
+          <summary class="cursor-pointer list-none">
+            <span class="flex flex-wrap items-baseline justify-between gap-2">
               <span class="text-xs font-semibold text-foundry-light-text dark:text-foundry-text">
-                {skill.name}
+                {g.name}
               </span>
-              {#if skill.origin.kind === 'derived'}
-                <span
-                  class="shrink-0 rounded-md bg-foundry-amber/15 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-amber"
-                  title="No manifest names this tool — the card was derived from the tool identifier"
-                >
-                  derived
-                </span>
-              {/if}
-            </div>
-            {#if skill.description}
-              <p class="mt-0.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
-                {skill.description}
-              </p>
-            {:else}
-              <p class="mt-0.5 text-[11px] italic text-foundry-light-muted dark:text-foundry-text/40">
-                No description authored for this skill.
-              </p>
-            {/if}
-            <div class="mt-1.5 flex flex-wrap items-center gap-1">
-              {#each skill.tools as tool (tool)}
-                <span
-                  class="rounded border border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-text dark:text-foundry-text"
-                  title="The tool this skill wraps"
-                >
-                  {tool}
-                </span>
-              {/each}
-              {#if skill.tools.length === 0}
-                <span class="font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
-                  guidance only — no tool
-                </span>
-              {/if}
-              {#if credential(skill)}
-                {@const c = credential(skill)}
+              <span
+                class="shrink-0 rounded-md px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide {state.tone ===
+                'ok'
+                  ? 'bg-foundry-green/15 text-foundry-green'
+                  : state.tone === 'warn'
+                    ? 'bg-foundry-amber/15 text-foundry-amber'
+                    : 'text-foundry-light-muted dark:text-foundry-text/40'}"
+                title="A bundle is reported granted only when EVERY member skill is granted"
+              >
+                {state.word} — {state.counts}
+              </span>
+            </span>
+          </summary>
+          <p class="mt-1 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
+            {g.description}
+          </p>
+          <!--
+            The bundle's credential requirements, as a SET. Two members needing
+            two different credentials render as two chips — a divergence is
+            shown, never averaged into one verdict (#4024, DOC-57 S-16).
+          -->
+          {#if (g.providers ?? []).length > 0}
+            <div class="mt-1 flex flex-wrap items-center gap-1">
+              {#each g.providers ?? [] as p (p.provider + p.requirement)}
+                {@const c = providerChip(p)}
                 <span
                   class="rounded px-1.5 py-0.5 font-mono text-[10px]"
-                  class:text-foundry-green={c?.tone === 'ok'}
-                  class:text-foundry-red={c?.tone === 'bad'}
-                  class:text-foundry-light-muted={c?.tone === 'unknown'}
-                  title={c?.title}
+                  class:text-foundry-green={c.tone === 'ok'}
+                  class:text-foundry-red={c.tone === 'bad'}
+                  class:text-foundry-light-muted={c.tone === 'unknown'}
+                  title={c.title}
                 >
-                  {c?.label}
+                  {c.label}
                 </span>
-              {/if}
+              {/each}
             </div>
+          {/if}
+          <div class="mt-1.5 flex flex-col gap-2">
+            {#each cards as skill (skill.id)}
+              <AgentSkillCard {skill} />
+            {/each}
           </div>
+          <!--
+            Ungranted members are counted, not listed — the same policy the flat
+            buckets follow. Saying how many are missing is what keeps "partial"
+            from being a shrug.
+          -->
+          {#if g.members.length > g.granted_members.length}
+            <p class="mt-1.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+              {g.members.length - g.granted_members.length} member skill{g.members.length -
+                g.granted_members.length ===
+              1
+                ? ''
+                : 's'} in this function {g.members.length - g.granted_members.length === 1
+                ? 'is'
+                : 'are'} not granted. Grant the whole function with
+              <code class="font-mono">{g.id}</code> in
+              <code class="font-mono">[skills].allow</code>.
+            </p>
+          {/if}
+        </details>
+      {/each}
+    {/if}
+
+    {#each [{ label: 'Actions', items: actions }, { label: 'Knowledge', items: knowledge }, { label: 'System', items: system }] as bucket (bucket.label)}
+      {#if bucket.items.length > 0}
+        <h4 class="mt-1 font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
+          {bucket.label} ({bucket.items.length})
+        </h4>
+        {#each bucket.items as skill (skill.id)}
+          <AgentSkillCard {skill} />
         {/each}
       {/if}
     {/each}

--- a/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSkills.test.ts
@@ -11,7 +11,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { mount, unmount } from 'svelte';
 import AgentConfigSkills from './AgentConfigSkills.svelte';
-import type { AgentSkill, AgentSkills } from '../lib/agentConfig';
+import type { AgentSkill, AgentSkillGroup, AgentSkills } from '../lib/agentConfig';
 
 let target: HTMLDivElement;
 let instance: Record<string, unknown> | null = null;
@@ -262,6 +262,145 @@ describe('AgentConfigSkills', () => {
     expect(target.textContent).toContain('1 of 1 known skills granted');
     expect(target.textContent).toContain('Create a Ticket');
     expect(target.textContent).not.toContain('2 of 2');
+  });
+
+  // ------------------------------------------------------------------
+  // #4024: function-skill groups
+  // ------------------------------------------------------------------
+
+  /** Two ticket leaves + the bundle they belong to, wired as the route wires them. */
+  function bundled(grantedMembers: string[], over: Partial<AgentSkillGroup> = {}) {
+    const members = ['ticket-create', 'ticket-read'];
+    const state =
+      grantedMembers.length === 0
+        ? 'none'
+        : grantedMembers.length === members.length
+          ? 'all'
+          : 'some';
+    const group: AgentSkillGroup = {
+      id: 'ticketing',
+      name: 'Ticketing',
+      description: 'Work a tracker end to end.',
+      members,
+      granted_members: grantedMembers,
+      granted_state: state as AgentSkillGroup['granted_state'],
+      providers: [],
+      ...over,
+    };
+    return payload({
+      groups: [group],
+      granted_count: grantedMembers.length,
+      skills: [
+        // An ungrouped leaf, so the fixture also proves grouping leaves the
+        // flat buckets alone.
+        skill(),
+        skill({
+          id: 'ticketing',
+          name: 'Ticketing',
+          kind: 'function',
+          tools: [],
+          granted: state === 'all',
+          members,
+          granted_members: grantedMembers,
+          granted_state: group.granted_state,
+        }),
+        skill({
+          id: 'ticket-create',
+          name: 'Create a Ticket',
+          tools: ['create_ticket'],
+          granted: grantedMembers.includes('ticket-create'),
+        }),
+        skill({
+          id: 'ticket-read',
+          name: 'Read a Ticket',
+          tools: ['get_ticket'],
+          granted: grantedMembers.includes('ticket-read'),
+        }),
+      ],
+    });
+  }
+
+  it('renders a function skill as a group over its member cards', () => {
+    render(bundled(['ticket-create', 'ticket-read']));
+    const details = target.querySelector('details') as HTMLDetailsElement;
+    expect(details).not.toBeNull();
+    expect(details.open).toBe(false); // a header is a summary, not a wall of cards
+    expect(details.textContent).toContain('Ticketing');
+    expect(details.textContent).toContain('Create a Ticket');
+    expect(details.textContent).toContain('Read a Ticket');
+    // Members render INSIDE the group, not a second time in the flat buckets.
+    expect(target.textContent).not.toContain('Actions (2)');
+  });
+
+  it('says granted only when every member is granted', () => {
+    render(bundled(['ticket-create', 'ticket-read']));
+    const summary = target.querySelector('summary') as HTMLElement;
+    expect(summary.textContent).toContain('granted');
+    expect(summary.textContent).toContain('2 of 2 skills');
+    expect(summary.textContent).not.toContain('partial');
+  });
+
+  it('says partial — never granted — when only some members are granted', () => {
+    render(bundled(['ticket-create']));
+    const summary = target.querySelector('summary') as HTMLElement;
+    expect(summary.textContent).toContain('partial');
+    expect(summary.textContent).toContain('1 of 2 skills');
+    // The ungranted member is counted, not listed — same policy as a leaf.
+    expect(target.textContent).toContain('1 member skill in this function is not granted');
+    expect(target.textContent).not.toContain('Read a Ticket');
+  });
+
+  it('says not granted when no member is granted', () => {
+    render(bundled([]));
+    const summary = target.querySelector('summary') as HTMLElement;
+    expect(summary.textContent).toContain('not granted');
+    expect(summary.textContent).toContain('0 of 2 skills');
+    expect(target.textContent).not.toContain('Create a Ticket');
+  });
+
+  it('leaves an ungrouped leaf skill rendering exactly as before', () => {
+    // The regression this pane's grouping must not cause: a skill belonging to
+    // no bundle keeps its flat Actions bucket.
+    render(bundled(['ticket-create', 'ticket-read']));
+    expect(target.textContent).toContain('Actions (1)');
+    expect(target.textContent).toContain('MTA Train Time');
+    expect(target.textContent).toContain('get_train_schedule');
+  });
+
+  it('does not let a group move the granted count (a bundle is not a capability)', () => {
+    render(bundled(['ticket-create']));
+    expect(target.textContent).toContain('2 of 3 known skills granted');
+  });
+
+  it('shows every distinct member credential, so a divergence is visible', () => {
+    render(
+      bundled(['ticket-create', 'ticket-read'], {
+        providers: [
+          {
+            provider: 'Google Workspace',
+            requirement: 'An authorized Google account profile.',
+            env_var: null,
+            configured: null,
+          },
+          {
+            provider: 'MTA',
+            requirement: 'An MTA developer API key.',
+            env_var: 'MTA_API_KEY',
+            configured: false,
+          },
+        ],
+      }),
+    );
+    const details = target.querySelector('details') as HTMLDetailsElement;
+    expect(details.textContent).toContain('Google Workspace — not verified');
+    expect(details.textContent).toContain('MTA NOT configured');
+    expect(details.textContent).not.toContain('Google Workspace configured');
+  });
+
+  it('renders no group section for a payload with no function skills', () => {
+    render(payload());
+    expect(target.querySelector('details')).toBeNull();
+    expect(target.textContent).not.toContain('Functions (');
   });
 
   it('offers no write path in this phase (S-12) and points at the real edit surface', () => {

--- a/crates/trusty-agents/ui/src/components/AgentSkillCard.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentSkillCard.svelte
@@ -1,0 +1,75 @@
+<script lang="ts">
+  /**
+   * Why (#4024): one skill card, rendered in two places — the flat kind buckets
+   * of the Skills pane and, for a member of a function skill, inside that
+   * bundle's group. Duplicating the markup is how the two drift: a badge or a
+   * credential line fixed in one copy and not the other is exactly the quiet
+   * inconsistency #3945's honesty rules exist to prevent. Extracting it changes
+   * NOTHING about how a card looks — this component is the markup that shipped
+   * in PR #3964, moved verbatim.
+   *
+   * What: one bordered card carrying the skill's human name, its `derived` badge
+   * when no manifest named the tool, its prose (or an admission that none was
+   * authored), the single tool it wraps (or "guidance only"), and its credential
+   * chip via the shared `providerChip` — never a green claim for an OAuth grant
+   * this endpoint did not verify.
+   * Test: `AgentConfigSkills.test.ts`.
+   */
+  import type { AgentSkill } from '../lib/agentConfig';
+  import { providerChip } from '../lib/agentConfig';
+
+  export let skill: AgentSkill;
+
+  $: credential = skill.provider ? providerChip(skill.provider) : null;
+</script>
+
+<div class="rounded-md border border-foundry-light-border dark:border-foundry-border px-3 py-2">
+  <div class="flex items-baseline justify-between gap-2">
+    <span class="text-xs font-semibold text-foundry-light-text dark:text-foundry-text">
+      {skill.name}
+    </span>
+    {#if skill.origin.kind === 'derived'}
+      <span
+        class="shrink-0 rounded-md bg-foundry-amber/15 px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide text-foundry-amber"
+        title="No manifest names this tool — the card was derived from the tool identifier"
+      >
+        derived
+      </span>
+    {/if}
+  </div>
+  {#if skill.description}
+    <p class="mt-0.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/60">
+      {skill.description}
+    </p>
+  {:else}
+    <p class="mt-0.5 text-[11px] italic text-foundry-light-muted dark:text-foundry-text/40">
+      No description authored for this skill.
+    </p>
+  {/if}
+  <div class="mt-1.5 flex flex-wrap items-center gap-1">
+    {#each skill.tools as tool (tool)}
+      <span
+        class="rounded border border-foundry-light-border dark:border-foundry-border px-1.5 py-0.5 font-mono text-[10px] text-foundry-light-text dark:text-foundry-text"
+        title="The tool this skill wraps"
+      >
+        {tool}
+      </span>
+    {/each}
+    {#if skill.tools.length === 0}
+      <span class="font-mono text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/40">
+        guidance only — no tool
+      </span>
+    {/if}
+    {#if credential}
+      <span
+        class="rounded px-1.5 py-0.5 font-mono text-[10px]"
+        class:text-foundry-green={credential.tone === 'ok'}
+        class:text-foundry-red={credential.tone === 'bad'}
+        class:text-foundry-light-muted={credential.tone === 'unknown'}
+        title={credential.title}
+      >
+        {credential.label}
+      </span>
+    {/if}
+  </div>
+</div>

--- a/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
@@ -15,6 +15,7 @@ import {
   matchesToolGlob,
   fetchAgentSkills,
   fetchAgentSubagents,
+  providerChip,
   type AgentStores,
 } from './agentConfig';
 
@@ -272,5 +273,45 @@ describe('STORE_BOUND_KNOWLEDGE_TOOLS', () => {
     // taxonomy that same section warns against; classification belongs to
     // `kind = "knowledge"` manifests (#3933).
     expect([...STORE_BOUND_KNOWLEDGE_TOOLS]).toEqual(['vector_search']);
+  });
+});
+
+describe('providerChip (#4024)', () => {
+  // The chip is shared by a leaf card and a function-skill group header, so it
+  // is the one place a credential could be claimed in one and denied in the
+  // other. `configured: null` — an OAuth grant nobody verified — must read as
+  // "not verified", never as a green check (DOC-57 S-11b).
+  it('never renders an unverified credential as configured', () => {
+    const chip = providerChip({
+      provider: 'Google Workspace',
+      requirement: 'An authorized Google account profile.',
+      env_var: null,
+      configured: null,
+    });
+    expect(chip.tone).toBe('unknown');
+    expect(chip.label).toBe('Google Workspace \u2014 not verified');
+  });
+
+  it('states the variable to set when an env-backed credential is absent', () => {
+    const chip = providerChip({
+      provider: 'MTA',
+      requirement: 'An MTA developer API key.',
+      env_var: 'MTA_API_KEY',
+      configured: false,
+    });
+    expect(chip.tone).toBe('bad');
+    expect(chip.label).toBe('MTA NOT configured');
+    expect(chip.title).toContain('Set MTA_API_KEY.');
+  });
+
+  it('reports configured only from evidence', () => {
+    const chip = providerChip({
+      provider: 'Brave Search',
+      requirement: 'A Brave Search API key.',
+      env_var: 'BRAVE_API_KEY',
+      configured: true,
+    });
+    expect(chip.tone).toBe('ok');
+    expect(chip.label).toBe('Brave Search configured');
   });
 });

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -371,6 +371,15 @@ export interface AgentSkillGroup {
   members: string[];
   granted_members: string[];
   granted_state: 'all' | 'some' | 'none';
+  /**
+   * #4024: the DISTINCT credential requirements across the members — a SET, not
+   * a rolled-up verdict. A bundle has no `provider` of its own, and its members
+   * need not agree; render every entry, so two members needing two different
+   * credentials show as two chips rather than one averaged claim. Empty means
+   * "no member states a requirement", never "verified". Optional so an older
+   * sidecar (pre-#4024) renders the group rather than throwing.
+   */
+  providers?: AgentSkillProvider[];
 }
 
 /**
@@ -387,6 +396,34 @@ export interface AgentSkillProvider {
   requirement: string;
   env_var: string | null;
   configured: boolean | null;
+}
+
+/**
+ * Render one credential requirement as a chip label + tone (#4024).
+ *
+ * Why: Both a leaf card and a function-skill group header state credentials, and
+ * they must state them IDENTICALLY — a group that renders "configured" where its
+ * member card says "not verified" is the display-layer form of the drift the
+ * route's single-computation rule exists to prevent. One function, two call
+ * sites. It is also where `configured: null` is pinned to "not verified" rather
+ * than to a green chip nobody checked (DOC-57 S-11b).
+ * What: `{ label, tone, title }`; `tone` is `ok` | `bad` | `unknown`.
+ * Test: `agentConfig.test.ts`, `AgentConfigSkills.test.ts`.
+ */
+export function providerChip(p: AgentSkillProvider): {
+  label: string;
+  tone: 'ok' | 'bad' | 'unknown';
+  title: string;
+} {
+  if (p.configured === true)
+    return { label: `${p.provider} configured`, tone: 'ok', title: p.requirement };
+  if (p.configured === false)
+    return {
+      label: `${p.provider} NOT configured`,
+      tone: 'bad',
+      title: `${p.requirement} Set ${p.env_var}.`,
+    };
+  return { label: `${p.provider} — not verified`, tone: 'unknown', title: p.requirement };
 }
 
 /** `GET /api/agents/:name/skills`'s wire shape. */


### PR DESCRIPTION
## Summary

The Skills pane previously rendered one card per individual tool. This PR implements DOC-57 S-16 tri-state display for function-skill groups, allowing bundled skills and their provider requirements to be visible alongside individual tools. The backend primitive for grouping already existed (#4022 and #4025); this change makes the Groups visible in the UI and authors three initial bundles: `ticketing` (for issue/task-management tools), `google-workspace` (mail and tasks tools), and `cto-tools` (project governance and learning).

Closes #4024
Closes #4231
Closes #4232
Closes #4233
References epic #4021
Note: #2201 remains the follow-on for user-authored bundles; this PR does not relax DOC-57 S-14 — bundle membership remains closed const data.

## Security-relevant decisions

- Git MUTATION skills deliberately excluded from the widened `ticketing` bundle; pinned by a non-vacuous test.
- `gmail-settings` and `gmail-filters` excluded from `google-workspace` because mail forwarding is an exfiltration/persistence primitive.
- `gw-account-*` excluded as OAuth account administration.
- Drive/Docs/Sheets/Slides/Calendar out of scope for this bundle.

## Provider honesty (S-16)

Bundle cards keep `provider: null` to avoid over-claiming bundle-level provider constraints. The `groups[].providers` array carries the DISTINCT requirement set across all members, with per-requirement tri-state `configured` tracking. Divergent members render as separate chips rather than one collapsed verdict, ensuring UI transparency about partial readiness.

## Open naming question

The bundle id is `google-workspace` but the display name is "Google Workspace Mail and Tasks", because the bundle currently holds no Drive/Calendar/Docs/Sheets members and the shorter name would over-claim scope. The owner originally asked for "Google Workspace" — this is a one-line change in the bundle definition if he prefers the shorter display name.

## Verification

- `cargo fmt --check` exit 0
- `cargo clippy -p trusty-agents --all-targets -- -D warnings` exit 0
- `cargo test -p trusty-agents` 2906 passed / 0 failed / 11 ignored; all integration binaries green
- `bash scripts/check_line_cap.sh` 7 allowlisted / 0 violations
- UI `pnpm test:unit` 266 passed
- UI `pnpm check` 0 errors (2 pre-existing warnings in ProjectsView.svelte)
- UI `pnpm build` OK
- UI `pnpm check:tokens` OK

## Note

`agent_skills.rs` unit tests moved to `src/api/server/tests/agent_skills_unit_tests.rs` (still `#[path]`-included as a child module) to stay under the 500 SLOC production cap.

## Flake observed

`tools::python_skill::tests::execute_dispatches_to_python_and_parses_json` failed once with a `uv` interpreter/lock error in a temp cache, unrelated to this diff; passed in isolation and on a clean re-run.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools