### PR TITLE
fix(trusty-agents): apply delegate role allowlist on the persona dispatch path

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -52,7 +52,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Security
 
 - **Delegation authority is now governed by agent KIND, not by tier order
-  (ADR-0023).** The shipped L0/L1 gate expressed its rule as a tier
+  (ADR-0024, "Assistants Are Level-0 Delegators; Sub-Agents Are In-Process,
+  Single-Edge Leaves That Never Delegate" — cited by title as well as number
+  because the ADR is not on `main` yet; it lands with PR #4243).** The
+  shipped L0/L1 gate expressed its rule as a tier
   comparison, which is a proxy: a total order cannot forbid an edge WITHIN a
   rank, for any numbering. It appeared to work only because every assistant
   was L1 and L0 was empty. Under the ratified model — where all assistants

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -51,6 +51,32 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- **Delegation authority is now governed by agent KIND, not by tier order
+  (ADR-0023).** The shipped L0/L1 gate expressed its rule as a tier
+  comparison, which is a proxy: a total order cannot forbid an edge WITHIN a
+  rank, for any numbering. It appeared to work only because every assistant
+  was L1 and L0 was empty. Under the ratified model — where all assistants
+  become L0 and "assistants communicate with each other, but never delegate"
+  — that check becomes vacuous for exactly the case it must forbid, and no
+  renumbering fixes it. `DelegateToAgentTool::execute` now refuses any
+  assistant-to-assistant delegation edge by reading the two endpoints' `role`
+  (the KIND discriminator), never a tier. The check lives in the shared
+  `execute()` choke point every delegation traverses rather than in a
+  per-call-site builder method, and the delegator's role and tier are declared
+  through a single `with_delegator(role, tier)` call (superseding
+  `with_delegator_tier`), so no construction site can acquire one gate while
+  silently missing the other — the failure shape the persona-path fix above
+  was filed for. The tier gate is RETAINED unchanged as defense-in-depth over
+  a different config field. `pm`/`ctrl`-as-orchestrator are explicitly outside
+  this rule and are unaffected. The `GET /api/agents/:name/subagents` route
+  reports peer assistants as unreachable with the kind reason, reading the
+  same predicate the gate enforces rather than a second copy of it.
+
+  **Known regression, accepted by the owner:** this closes the Izzie <->
+  cto-assistant peer-consult lane, and the replacement mechanism
+  ("assistants communicate") does not exist yet — there is no implemented
+  agent-to-agent messaging path for trusty-agents personas today.
+
 - **Applied the `ASSISTANT_ALLOWED_DELEGATE_ROLES` gate on the persona-chat
   dispatch path (#4201).** The REPL `/agent` persona path built its
   `DelegateToAgentTool` with the #4169 L0/L1 tier gate but WITHOUT the role

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -51,6 +51,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Security
 
+- **Applied the `ASSISTANT_ALLOWED_DELEGATE_ROLES` gate on the persona-chat
+  dispatch path (#4201).** The REPL `/agent` persona path built its
+  `DelegateToAgentTool` with the #4169 L0/L1 tier gate but WITHOUT the role
+  allowlist its sibling ctrl/session path applies, so an assistant-tier
+  persona could delegate to `pm` (role `orchestrator`) or `ctrl` (role
+  `controller`) — roles that are not in the allowlist at all — and
+  `run_subagent` would arm the spawned subprocess from that child's own role,
+  handing an unrestricted orchestrator registry (shell, `write_file`,
+  unrestricted `delegate_to_agent`) to a persona that ingests untrusted
+  content. The tier gate did not cover for it: it can only refuse an
+  `L0Orchestration` TARGET and no bundled agent declares `tier = "l0"` today,
+  so on this path both defense-in-depth layers were ineffective. Both gates
+  are now applied from one place (`persona_gate::build_persona_delegate_tool`,
+  reusing the same single-source-of-truth constant the other paths use), which
+  the regression tests drive directly so a call-site regression cannot pass
+  silently. A persona whose own role is outside the assistant tier is
+  unaffected.
+
 - **Defined the L0/L1 persona privilege tier and made the L1->L0 delegation
   path structurally forbidden (#4168, #4169, epic #4167).** Added an
   explicit `AgentTier` (`AgentInfo::tier`, TOML `[agent].tier` / `.md`

--- a/crates/trusty-agents/src/agents/delegation.rs
+++ b/crates/trusty-agents/src/agents/delegation.rs
@@ -1,0 +1,138 @@
+//! Delegation authority as a function of agent KIND (ADR-0023).
+//!
+//! Why: the shipped delegation gate encoded its rule against TIER
+//! (`delegate.rs`: `target_tier == L0Orchestration && delegator_tier !=
+//! L0Orchestration`), which is a PROXY for kind. It worked only while tier
+//! happened to coincide with kind — every assistant was `L1Standard` and `L0`
+//! was an empty tier, so "assistant delegating to assistant" and "L1
+//! delegating to L1" were the same event and no L0-vs-L0 edge could exist.
+//! ADR-0023 decision 3 breaks that coincidence deliberately (every assistant
+//! becomes L0), and a total order over tiers is structurally incapable of
+//! forbidding an edge WITHIN a rank, for ANY numbering — so no renumbering
+//! fixes it and any future check leaning on tier values reintroduces the same
+//! defect under new labels. This module holds the rule expressed against the
+//! attribute it is actually about.
+//! What: [`is_assistant_kind`] and [`kind_refuses_delegation`] — the ONE
+//! definition of the kind predicate in this crate. Both the enforcement point
+//! (`tools::delegate::DelegateToAgentTool::execute`) and the reporting surface
+//! that must agree with it (`api::server::agent_subagents::in_product_surface`)
+//! call these rather than re-deriving the comparison, per the crate's "no
+//! second copy of any gate" principle: a route that advertises a target the
+//! gate refuses is the same class of drift as a gate a call site forgot.
+//! Test: `assistant_kind_is_read_from_role_not_tier`,
+//! `kind_refuses_assistant_to_assistant`,
+//! `kind_permits_assistant_to_sub_agent`,
+//! `kind_ignores_non_assistant_sources`; the behavioral coverage lives in
+//! `tools::delegate`'s tests (`delegate_assistant_to_assistant_is_refused*`).
+
+use crate::runtime::tool_registry::ASSISTANT_TIER_ROLE;
+
+/// Is `role` the assistant KIND?
+///
+/// Why: ADR-0023 predicate 1 fixes `KIND` as the EXISTING `agent.role` field —
+/// specifically `role == ASSISTANT_TIER_ROLE` — and not a new attribute.
+/// Deliberately NOT `AgentInfo::kind`: that field is picker-grouping metadata
+/// whose own doc comment forbids exactly this use ("Conflating any of the
+/// three would silently change dispatch/security behavior as a side effect of
+/// a display change"), and it defaults to `"assistant"` for every agent
+/// including workers, so it cannot discriminate anything. `role` is already
+/// the load-bearing security discriminator on this path — it selects the
+/// tool-registry branch (`build_registry_for_agent`) and drives
+/// `ASSISTANT_ALLOWED_DELEGATE_ROLES` — so reading it here adds no new
+/// meaning to an already-overloaded field, it reuses the meaning it has.
+/// What: exact match against `ASSISTANT_TIER_ROLE`. Every other role —
+/// `engineer`, `qa`, `researcher`, `documentation`, `ops`, `planner`
+/// (sub-agents), and `orchestrator`/`controller` (`pm`/`ctrl`, outside this
+/// model entirely) — is not the assistant kind.
+/// Test: `assistant_kind_is_read_from_role_not_tier`.
+pub(crate) fn is_assistant_kind(role: &str) -> bool {
+    role == ASSISTANT_TIER_ROLE
+}
+
+/// Does the KIND rule refuse a delegation edge from `source_role` to
+/// `target_role`? (ADR-0023 predicates 1 + 2.)
+///
+/// Why: "assistants communicate with each other, but never delegate" (owner,
+/// 2026-07-28). Expressed on the edge rather than on ranks, this is the ONLY
+/// formulation that survives the tier inversion: it refuses an assistant peer
+/// edge whether both endpoints are L1 (today), both L0 (after the inversion),
+/// or split across a renumbering nobody has proposed yet, because it never
+/// reads a tier at all.
+/// What: `true` — refuse — exactly when BOTH endpoints are the assistant kind.
+/// A non-assistant SOURCE is outside this rule's population entirely, which is
+/// deliberate and is ADR-0023 predicate 1's explicit scope caveat: `pm`/`ctrl`
+/// -as-orchestrator (role `orchestrator`/`controller`) delegate today through
+/// separately-trusted, pre-existing paths this rule does not revisit, so their
+/// edges are never refused here. A non-assistant TARGET (a sub-agent) is the
+/// permitted case predicate 2 names. This function does NOT evaluate the tier
+/// gate — that stays where it is, as an independently-computed
+/// defense-in-depth layer over a DIFFERENT config field, so a defect in one
+/// layer does not open the graph.
+/// Test: `kind_refuses_assistant_to_assistant`,
+/// `kind_permits_assistant_to_sub_agent`, `kind_ignores_non_assistant_sources`.
+pub(crate) fn kind_refuses_delegation(source_role: &str, target_role: &str) -> bool {
+    is_assistant_kind(source_role) && is_assistant_kind(target_role)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The discriminator is `role`, and nothing about it is derivable from a
+    /// tier value — the property that makes every caller of this module
+    /// renumbering-proof.
+    #[test]
+    fn assistant_kind_is_read_from_role_not_tier() {
+        assert!(is_assistant_kind("assistant"));
+        for sub_agent in [
+            "engineer",
+            "qa",
+            "researcher",
+            "documentation",
+            "ops",
+            "planner",
+        ] {
+            assert!(!is_assistant_kind(sub_agent), "{sub_agent} is a sub-agent");
+        }
+        for orchestrator in ["orchestrator", "controller"] {
+            assert!(
+                !is_assistant_kind(orchestrator),
+                "{orchestrator} is outside the assistant/sub-agent model"
+            );
+        }
+    }
+
+    /// ADR-0023 predicate 2, the peer prohibition.
+    #[test]
+    fn kind_refuses_assistant_to_assistant() {
+        assert!(kind_refuses_delegation("assistant", "assistant"));
+    }
+
+    /// The permitted edge: assistant -> sub-agent.
+    #[test]
+    fn kind_permits_assistant_to_sub_agent() {
+        for sub_agent in [
+            "engineer",
+            "qa",
+            "researcher",
+            "documentation",
+            "ops",
+            "planner",
+        ] {
+            assert!(
+                !kind_refuses_delegation("assistant", sub_agent),
+                "assistant -> {sub_agent} is the whole point of delegation"
+            );
+        }
+    }
+
+    /// Predicate 1's scope caveat: `pm`/`ctrl` are not governed by this rule
+    /// and must not be newly blocked by it.
+    #[test]
+    fn kind_ignores_non_assistant_sources() {
+        for source in ["orchestrator", "controller", "engineer"] {
+            assert!(!kind_refuses_delegation(source, "assistant"));
+            assert!(!kind_refuses_delegation(source, "engineer"));
+        }
+    }
+}

--- a/crates/trusty-agents/src/agents/delegation.rs
+++ b/crates/trusty-agents/src/agents/delegation.rs
@@ -1,4 +1,11 @@
-//! Delegation authority as a function of agent KIND (ADR-0023).
+//! Delegation authority as a function of agent KIND (ADR-0024).
+//!
+//! The governing decision is ADR-0024, "Assistants Are Level-0 Delegators;
+//! Sub-Agents Are In-Process, Single-Edge Leaves That Never Delegate" — cited
+//! by number AND title because it is not on `main` yet (it lands with PR
+//! #4243; it was drafted as ADR-0023 and renumbered when the worktree-
+//! authority ADR took that slot, so an older draft reference to "ADR-0023"
+//! elsewhere means a DIFFERENT document).
 //!
 //! Why: the shipped delegation gate encoded its rule against TIER
 //! (`delegate.rs`: `target_tier == L0Orchestration && delegator_tier !=
@@ -6,7 +13,7 @@
 //! happened to coincide with kind — every assistant was `L1Standard` and `L0`
 //! was an empty tier, so "assistant delegating to assistant" and "L1
 //! delegating to L1" were the same event and no L0-vs-L0 edge could exist.
-//! ADR-0023 decision 3 breaks that coincidence deliberately (every assistant
+//! ADR-0024 decision 3 breaks that coincidence deliberately (every assistant
 //! becomes L0), and a total order over tiers is structurally incapable of
 //! forbidding an edge WITHIN a rank, for ANY numbering — so no renumbering
 //! fixes it and any future check leaning on tier values reintroduces the same
@@ -29,7 +36,7 @@ use crate::runtime::tool_registry::ASSISTANT_TIER_ROLE;
 
 /// Is `role` the assistant KIND?
 ///
-/// Why: ADR-0023 predicate 1 fixes `KIND` as the EXISTING `agent.role` field —
+/// Why: ADR-0024 predicate 1 fixes `KIND` as the EXISTING `agent.role` field —
 /// specifically `role == ASSISTANT_TIER_ROLE` — and not a new attribute.
 /// Deliberately NOT `AgentInfo::kind`: that field is picker-grouping metadata
 /// whose own doc comment forbids exactly this use ("Conflating any of the
@@ -50,7 +57,7 @@ pub(crate) fn is_assistant_kind(role: &str) -> bool {
 }
 
 /// Does the KIND rule refuse a delegation edge from `source_role` to
-/// `target_role`? (ADR-0023 predicates 1 + 2.)
+/// `target_role`? (ADR-0024 predicates 1 + 2.)
 ///
 /// Why: "assistants communicate with each other, but never delegate" (owner,
 /// 2026-07-28). Expressed on the edge rather than on ranks, this is the ONLY
@@ -60,7 +67,7 @@ pub(crate) fn is_assistant_kind(role: &str) -> bool {
 /// reads a tier at all.
 /// What: `true` — refuse — exactly when BOTH endpoints are the assistant kind.
 /// A non-assistant SOURCE is outside this rule's population entirely, which is
-/// deliberate and is ADR-0023 predicate 1's explicit scope caveat: `pm`/`ctrl`
+/// deliberate and is ADR-0024 predicate 1's explicit scope caveat: `pm`/`ctrl`
 /// -as-orchestrator (role `orchestrator`/`controller`) delegate today through
 /// separately-trusted, pre-existing paths this rule does not revisit, so their
 /// edges are never refused here. A non-assistant TARGET (a sub-agent) is the
@@ -102,7 +109,7 @@ mod tests {
         }
     }
 
-    /// ADR-0023 predicate 2, the peer prohibition.
+    /// ADR-0024 predicate 2, the peer prohibition.
     #[test]
     fn kind_refuses_assistant_to_assistant() {
         assert!(kind_refuses_delegation("assistant", "assistant"));

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -16,7 +16,7 @@ pub mod claude_code_runner;
 pub mod claude_mpm_loader;
 mod config;
 pub mod context_filter;
-// ADR-0023: the KIND delegation predicate. `pub(crate)` — it is an
+// ADR-0024: the KIND delegation predicate. `pub(crate)` — it is an
 // enforcement primitive, not part of the crate's public surface.
 pub(crate) mod delegation;
 pub mod extends;

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -16,6 +16,9 @@ pub mod claude_code_runner;
 pub mod claude_mpm_loader;
 mod config;
 pub mod context_filter;
+// ADR-0023: the KIND delegation predicate. `pub(crate)` — it is an
+// enforcement primitive, not part of the crate's public surface.
+pub(crate) mod delegation;
 pub mod extends;
 pub mod harness_protocol;
 pub mod in_process_runner;

--- a/crates/trusty-agents/src/api/server/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/agent_subagents.rs
@@ -256,13 +256,32 @@ async fn in_product_surface(
                 let target_tier = target.agent.tier();
                 let tier_blocked = target_tier == AgentTier::L0Orchestration
                     && delegator_tier != AgentTier::L0Orchestration;
+                // ADR-0023: the KIND predicate the gate now enforces, read
+                // from the SAME function `DelegateToAgentTool::execute` calls
+                // — not a second copy of the comparison. Without this the
+                // pane would advertise every peer assistant as reachable
+                // while the gate refuses it, which is the drift this module's
+                // doc exists to forbid. Checked FIRST, matching the order
+                // `execute` reports refusals in.
+                let kind_blocked = crate::agents::delegation::kind_refuses_delegation(
+                    &cfg.agent.role,
+                    &target.agent.role,
+                );
                 targets.push(json!({
                     "name": target.agent.name,
                     "display_name": target.agent.display_label(),
                     "role": target.agent.role,
                     "tier": target_tier.wire_label(),
-                    "reachable": !tier_blocked,
-                    "reason": if tier_blocked {
+                    "reachable": !(kind_blocked || tier_blocked),
+                    "reason": if kind_blocked {
+                        Some(
+                            "refused by the delegation kind rule: this target is a peer \
+                             assistant, and assistants communicate with each other rather \
+                             than delegating to one another (ADR-0023). Delegation targets \
+                             are sub-agents (specialists)."
+                                .to_string(),
+                        )
+                    } else if tier_blocked {
                         Some(format!(
                             "refused by the L0/L1 delegation gate: this agent is tier \
                              {} and may not delegate into an L0-orchestration target \

--- a/crates/trusty-agents/src/api/server/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/agent_subagents.rs
@@ -256,7 +256,7 @@ async fn in_product_surface(
                 let target_tier = target.agent.tier();
                 let tier_blocked = target_tier == AgentTier::L0Orchestration
                     && delegator_tier != AgentTier::L0Orchestration;
-                // ADR-0023: the KIND predicate the gate now enforces, read
+                // ADR-0024: the KIND predicate the gate now enforces, read
                 // from the SAME function `DelegateToAgentTool::execute` calls
                 // — not a second copy of the comparison. Without this the
                 // pane would advertise every peer assistant as reachable
@@ -277,7 +277,7 @@ async fn in_product_surface(
                         Some(
                             "refused by the delegation kind rule: this target is a peer \
                              assistant, and assistants communicate with each other rather \
-                             than delegating to one another (ADR-0023). Delegation targets \
+                             than delegating to one another (ADR-0024). Delegation targets \
                              are sub-agents (specialists)."
                                 .to_string(),
                         )

--- a/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
@@ -151,10 +151,10 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
         .map(|t| t["name"].as_str().unwrap())
         .collect();
     assert!(named.contains(&"engineer"), "{named:?}");
-    // ADR-0023: a peer assistant is still REPORTED (role-eligible, so it is
+    // ADR-0024: a peer assistant is still REPORTED (role-eligible, so it is
     // not silently dropped) but is no longer REACHABLE — assistants
     // communicate with each other rather than delegating. This assertion
-    // replaces the pre-ADR-0023 one that treated izzie as a live target; the
+    // replaces the pre-ADR-0024 one that treated izzie as a live target; the
     // pane must never advertise a capability the gate refuses.
     let izzie = targets
         .iter()
@@ -220,7 +220,7 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
 /// config surface reporting it as reachable would advertise a capability the
 /// runtime denies.
 ///
-/// ADR-0023 update: the L0 fixture is now a SUB-AGENT (`engineer`), not an
+/// ADR-0024 update: the L0 fixture is now a SUB-AGENT (`engineer`), not an
 /// assistant. An assistant-role L0 target is refused by the kind predicate
 /// before the tier comparison is consulted, which would leave this test
 /// green while testing nothing about tier — the same isolation applied to
@@ -253,7 +253,7 @@ async fn subagents_route_hides_l0_target_from_l1_delegator() {
     assert!(reason.contains("L0/L1"), "{reason}");
     assert!(reason.contains("#4169"), "{reason}");
 
-    // Not a blanket denial: an L1 SUB-AGENT is still reachable. (Pre-ADR-0023
+    // Not a blanket denial: an L1 SUB-AGENT is still reachable. (Pre-ADR-0024
     // this assertion used the peer assistant `izzie`; a peer is now refused by
     // kind, so the "one-directional, not blanket" property is demonstrated
     // with a target the kind rule permits.)
@@ -266,7 +266,7 @@ async fn subagents_route_hides_l0_target_from_l1_delegator() {
 /// L1 ones). Without this, a bug that reported every L0 target as unreachable
 /// would pass the test above.
 ///
-/// ADR-0023 update: the L0 target is a sub-agent (`engineer` role) for the
+/// ADR-0024 update: the L0 target is a sub-agent (`engineer` role) for the
 /// same isolation reason as the test above — an assistant-role target would
 /// be refused by kind, so this would no longer prove anything about tier.
 #[tokio::test]
@@ -327,7 +327,7 @@ async fn subagents_route_tier_fails_closed_for_an_unrecognized_value() {
         &["delegate_to_agent"],
         None,
     );
-    // ADR-0023: sub-agent-kind L0 target, so the tier fail-closed posture is
+    // ADR-0024: sub-agent-kind L0 target, so the tier fail-closed posture is
     // what this test observes rather than the kind predicate.
     write_agent(dir.path(), "orch", "engineer", Some("l0"), &[], None);
 

--- a/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
@@ -151,9 +151,25 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
         .map(|t| t["name"].as_str().unwrap())
         .collect();
     assert!(named.contains(&"engineer"), "{named:?}");
+    // ADR-0023: a peer assistant is still REPORTED (role-eligible, so it is
+    // not silently dropped) but is no longer REACHABLE — assistants
+    // communicate with each other rather than delegating. This assertion
+    // replaces the pre-ADR-0023 one that treated izzie as a live target; the
+    // pane must never advertise a capability the gate refuses.
+    let izzie = targets
+        .iter()
+        .find(|t| t["name"] == "izzie")
+        .expect("peer assistant must still be reported, with a reason");
+    assert_eq!(
+        izzie["reachable"], false,
+        "peer assistant is not a delegation target: {izzie:?}"
+    );
     assert!(
-        named.contains(&"izzie"),
-        "peer assistant is a target: {named:?}"
+        izzie["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("peer assistant"),
+        "the pane must explain the kind rule: {izzie:?}"
     );
     // `documentation` is the role that exists ONLY in
     // `ASSISTANT_ALLOWED_DELEGATE_ROLES` — its presence here is what proves the
@@ -203,13 +219,20 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
 /// target". The gate (`tools::delegate`, #4169) refuses that delegation, so a
 /// config surface reporting it as reachable would advertise a capability the
 /// runtime denies.
+///
+/// ADR-0023 update: the L0 fixture is now a SUB-AGENT (`engineer`), not an
+/// assistant. An assistant-role L0 target is refused by the kind predicate
+/// before the tier comparison is consulted, which would leave this test
+/// green while testing nothing about tier — the same isolation applied to
+/// `delegate_l1_to_l0_is_refused` in `tools::delegate`'s tests.
 #[tokio::test]
 async fn subagents_route_hides_l0_target_from_l1_delegator() {
     let dir = tempfile::tempdir().unwrap();
     standard_roster(dir.path());
-    // An L0-orchestration peer assistant — role-eligible (`assistant`), so the
-    // ONLY thing that can keep it out of reach is the tier gate.
-    write_agent(dir.path(), "orch", "assistant", Some("l0"), &[], None);
+    // An L0-orchestration sub-agent — role-eligible (`engineer`) and NOT the
+    // assistant kind, so the ONLY thing that can keep it out of reach is the
+    // tier gate.
+    write_agent(dir.path(), "orch", "engineer", Some("l0"), &[], None);
 
     let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
     let body = body_json(resp).await;
@@ -230,16 +253,22 @@ async fn subagents_route_hides_l0_target_from_l1_delegator() {
     assert!(reason.contains("L0/L1"), "{reason}");
     assert!(reason.contains("#4169"), "{reason}");
 
-    // Every L1 peer is still reachable — the gate is one-directional, not a
-    // blanket denial.
-    let izzie = targets.iter().find(|t| t["name"] == "izzie").unwrap();
-    assert_eq!(izzie["tier"], "l1");
-    assert_eq!(izzie["reachable"], true);
+    // Not a blanket denial: an L1 SUB-AGENT is still reachable. (Pre-ADR-0023
+    // this assertion used the peer assistant `izzie`; a peer is now refused by
+    // kind, so the "one-directional, not blanket" property is demonstrated
+    // with a target the kind rule permits.)
+    let eng = targets.iter().find(|t| t["name"] == "engineer").unwrap();
+    assert_eq!(eng["tier"], "l1");
+    assert_eq!(eng["reachable"], true);
 }
 
 /// The counter-test: an L0 delegator DOES reach an L0 target (and still reaches
 /// L1 ones). Without this, a bug that reported every L0 target as unreachable
 /// would pass the test above.
+///
+/// ADR-0023 update: the L0 target is a sub-agent (`engineer` role) for the
+/// same isolation reason as the test above — an assistant-role target would
+/// be refused by kind, so this would no longer prove anything about tier.
 #[tokio::test]
 async fn subagents_route_shows_l0_target_to_l0_delegator() {
     let dir = tempfile::tempdir().unwrap();
@@ -254,7 +283,7 @@ async fn subagents_route_shows_l0_target_to_l0_delegator() {
     write_agent(
         dir.path(),
         "orch",
-        "assistant",
+        "engineer",
         Some("orchestration"),
         &[],
         None,
@@ -298,7 +327,9 @@ async fn subagents_route_tier_fails_closed_for_an_unrecognized_value() {
         &["delegate_to_agent"],
         None,
     );
-    write_agent(dir.path(), "orch", "assistant", Some("l0"), &[], None);
+    // ADR-0023: sub-agent-kind L0 target, so the tier fail-closed posture is
+    // what this test observes rather than the kind predicate.
+    write_agent(dir.path(), "orch", "engineer", Some("l0"), &[], None);
 
     let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
     let body = body_json(resp).await;

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -409,12 +409,12 @@ pub async fn run_pm_task_with_history(
     // #3737: thread the task's session id so a successful delegation emits
     // `AgentSpawned` and the API server can attribute the answer to the
     // specialist that produced it (chat-bubble responder attribution).
-    // ADR-0023: the delegator's IDENTITY (role = KIND, plus tier) is declared
+    // ADR-0024: the delegator's IDENTITY (role = KIND, plus tier) is declared
     // in one call, so this path gets the kind predicate and the tier gate
     // together and cannot acquire one without the other. `pm_cfg.agent.role`
     // verbatim: for `ctrl.toml` that is `assistant` (#3812) and the kind
     // predicate applies; for a resolved `pm.toml` it is `orchestrator`, which
-    // the predicate ignores by design (ADR-0023 predicate 1's scope caveat),
+    // the predicate ignores by design (ADR-0024 predicate 1's scope caveat),
     // so orchestrator delegation is unchanged.
     let mut delegate_tool = DelegateToAgentTool::new(runner)
         .with_config_dir(config_dir.clone())

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -409,10 +409,17 @@ pub async fn run_pm_task_with_history(
     // #3737: thread the task's session id so a successful delegation emits
     // `AgentSpawned` and the API server can attribute the answer to the
     // specialist that produced it (chat-bubble responder attribution).
+    // ADR-0023: the delegator's IDENTITY (role = KIND, plus tier) is declared
+    // in one call, so this path gets the kind predicate and the tier gate
+    // together and cannot acquire one without the other. `pm_cfg.agent.role`
+    // verbatim: for `ctrl.toml` that is `assistant` (#3812) and the kind
+    // predicate applies; for a resolved `pm.toml` it is `orchestrator`, which
+    // the predicate ignores by design (ADR-0023 predicate 1's scope caveat),
+    // so orchestrator delegation is unchanged.
     let mut delegate_tool = DelegateToAgentTool::new(runner)
         .with_config_dir(config_dir.clone())
         .with_session_id(sid.clone())
-        .with_delegator_tier(delegator_tier);
+        .with_delegator(pm_cfg.agent.role.clone(), delegator_tier);
     if let Some(roles) = allowed_target_roles {
         delegate_tool = delegate_tool.with_allowed_target_roles(roles);
     }

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -17,7 +17,7 @@ use crate::llm;
 use crate::subprocess::SubprocessAgentRunner;
 use crate::tools::registry::dead_scope;
 use crate::tools::registry::scope::ScopePattern;
-use crate::tools::{AgentRunner, ToolRegistry, delegate::DelegateToAgentTool};
+use crate::tools::{AgentRunner, ToolRegistry};
 
 use super::super::super::claude_cli::run_pm_task_via_claude_cli;
 use super::super::super::config::{
@@ -31,7 +31,8 @@ use super::super::super::handlers::{
 use super::super::super::state::ConversationTurn;
 use super::classification;
 use super::persona_gate::{
-    filter_persona_tool_names_for_tier, persona_allowed_tools, persona_max_turns,
+    build_persona_delegate_tool, filter_persona_tool_names_for_tier, persona_allowed_tools,
+    persona_max_turns,
 };
 use super::persona_memory;
 
@@ -279,36 +280,27 @@ pub async fn run_pm_task_with_persona(
             } else {
                 None
             };
-            // #4169 (epic #4167): the one-directional L0/L1 delegation gate.
-            // This persona-chat dispatch path (backing the REPL `/agent`
-            // command) is the SECOND site — besides `runtime::subagent_mode`
-            // — that builds a `DelegateToAgentTool` for a persona that may
-            // hold live external-content tools. `role == "assistant"` is the
-            // SAME population `delegation_taint` above already gates; a
-            // non-assistant-tier role here is treated the same way the
-            // taint above treats it — outside the persona tier model
-            // entirely (mirrors `ctrl_delegate_posture`'s `role !=
-            // "assistant"` branch in `history.rs`) — so it is never gated by
-            // the L1->L0 boundary, exactly as it is never tainted.
-            let delegator_tier = if persona_cfg.agent.role == "assistant" {
-                persona_cfg.agent.tier()
-            } else {
-                crate::agents::AgentTier::L0Orchestration
-            };
             let runner: Arc<dyn AgentRunner> = Arc::new(
                 SubprocessAgentRunner::new()
                     .with_config_dir(Some(config_dir.clone()))
                     .with_delegation_taint(delegation_taint),
             );
-            registry.register(Arc::new(
-                // #3737: thread the session id so a persona that delegates
-                // onward attributes the answer to the specialist that produced
-                // it (chat-bubble responder attribution).
-                DelegateToAgentTool::new(runner)
-                    .with_config_dir(config_dir.clone())
-                    .with_session_id(sid.clone())
-                    .with_delegator_tier(delegator_tier),
-            ));
+            // #4201: this path applied the #4169 L0/L1 tier gate but NOT the
+            // `ASSISTANT_ALLOWED_DELEGATE_ROLES` allowlist its sibling
+            // dispatch path applies (`history::ctrl_delegate_posture`), so an
+            // assistant-tier persona could delegate to `pm`/`ctrl`. Both gates
+            // now come from ONE place — `build_persona_delegate_tool`, which
+            // also owns the `role != "assistant"` (outside the tier model)
+            // branch this block used to compute inline, and which the
+            // regression tests drive directly so a call-site regression here
+            // cannot pass silently. See that function's doc comment.
+            registry.register(Arc::new(build_persona_delegate_tool(
+                runner,
+                config_dir.clone(),
+                sid.clone(),
+                &persona_cfg.agent.role,
+                persona_cfg.agent.tier(),
+            )));
             registry.register(Arc::new(AddProjectTool));
             registry.register(Arc::new(ListProjectsTool));
             registry.register(Arc::new(RemoveProjectTool));

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
@@ -77,10 +77,10 @@ pub(super) fn build_persona_delegate_tool(
     let tool = DelegateToAgentTool::new(runner)
         .with_config_dir(config_dir)
         .with_session_id(session_id);
-    if persona_role != crate::runtime::tool_registry::ASSISTANT_TIER_ROLE {
-        return tool.with_delegator_tier(crate::agents::AgentTier::L0Orchestration);
+    if !crate::agents::delegation::is_assistant_kind(persona_role) {
+        return tool.with_delegator(persona_role, crate::agents::AgentTier::L0Orchestration);
     }
-    tool.with_delegator_tier(declared_tier)
+    tool.with_delegator(persona_role, declared_tier)
         // #4201: the allowlist this path was missing — see the fn doc.
         .with_allowed_target_roles(
             crate::runtime::tool_registry::ASSISTANT_ALLOWED_DELEGATE_ROLES

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
@@ -63,7 +63,9 @@ use super::super::helpers::match_any_glob;
 /// Test: `persona_delegate_tool_refuses_orchestrator_role_target`,
 /// `persona_delegate_tool_refuses_controller_role_target`,
 /// `persona_delegate_tool_allows_worker_role_target`,
-/// `persona_delegate_tool_allows_peer_assistant_role_target`,
+/// `persona_delegate_tool_refuses_peer_assistant_target` (ADR-0024 renamed
+/// this from `..._allows_peer_assistant_role_target` when the peer-consult
+/// lane closed — the pointer must track the rename, not the old name),
 /// `persona_delegate_tool_leaves_non_assistant_roles_ungated`.
 pub(super) fn build_persona_delegate_tool(
     runner: Arc<dyn AgentRunner>,

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs
@@ -1,4 +1,4 @@
-//! Pure per-turn gating helpers for the persona-chat dispatch path.
+//! Per-turn gating helpers for the persona-chat dispatch path.
 //!
 //! Why: `persona.rs` sits exactly at the 500-SLOC production cap enforced by
 //! `scripts/check_line_cap.sh`, so #4171 could not add its tier gate there
@@ -11,14 +11,84 @@
 //! `use super::*`, because `persona.rs` re-imports them.
 //! What: `filter_persona_tool_names` (allow-glob + RBAC-tier + scope gate),
 //! `filter_persona_tool_names_for_tier` (that gate plus #4171's L0-only
-//! session-state strip), `persona_max_turns`, and `persona_allowed_tools`.
+//! session-state strip), `persona_max_turns`, `persona_allowed_tools`, and
+//! (#4201) `build_persona_delegate_tool` — the DELEGATION gate, which is the
+//! one non-pure item here: it returns a constructed `DelegateToAgentTool`
+//! rather than a decision, deliberately, so the regression test drives the
+//! exact value `persona.rs` registers instead of a re-derived copy of it.
 //! Test: `persona_tests.rs` — `filter_persona_tool_names_*`,
-//! `persona_max_turns_*`, `persona_allowed_tools_*`; #4171's own coverage
-//! lives in `tools::session_state::tests`.
+//! `persona_max_turns_*`, `persona_allowed_tools_*`,
+//! `persona_delegate_*`; #4171's own coverage lives in
+//! `tools::session_state::tests`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
 
 use crate::tools::registry::scope::{Scope, ScopePattern, agent_can_use};
+use crate::tools::{AgentRunner, delegate::DelegateToAgentTool};
 
 use super::super::helpers::match_any_glob;
+
+/// Build the `delegate_to_agent` tool the persona-chat dispatch path arms,
+/// with BOTH delegation gates applied (#4201).
+///
+/// Why: `run_pm_task_with_persona` built this tool inline with the L0/L1 tier
+/// gate (#4169) but WITHOUT the role allowlist (#3555 CRITICAL follow-up)
+/// that its sibling dispatch path applies via `history::ctrl_delegate_posture`
+/// — so an assistant-tier persona reached from the REPL `/agent` command could
+/// delegate to a target whose role is not in
+/// `ASSISTANT_ALLOWED_DELEGATE_ROLES` at all (`pm`, role `orchestrator`;
+/// `ctrl`, role `controller`), whose subprocess would then be armed from the
+/// SPAWNED child's own role by `run_subagent` — an unrestricted orchestrator
+/// registry (shell, `write_file`, unrestricted `delegate_to_agent`) obtained
+/// straight out of the sandboxed, untrusted-content-ingesting assistant tier.
+/// The tier gate did not cover for it: it can only refuse an `L0Orchestration`
+/// TARGET, and no bundled agent declares `tier = "l0"` today, so that layer is
+/// structurally present but inert and the defense-in-depth model collapsed to
+/// zero effective layers on this path. Extracted as a function (rather than
+/// fixed in place) for the same reason `ctrl_delegate_posture` was: it is the
+/// only way this security contract is testable without a live LLM turn, and a
+/// test that rebuilt the tool itself would keep passing if the call site
+/// regressed.
+/// What: `persona_role != ASSISTANT_TIER_ROLE` — a persona outside the
+/// assistant tier model entirely, exactly the population `run_pm_task_with_
+/// persona` also declines to taint and the mirror of `ctrl_delegate_posture`'s
+/// `role != "assistant"` branch — gets `L0Orchestration` as its DELEGATOR tier
+/// (never blocked by the one-directional gate) and NO role allowlist, byte-
+/// identical to the pre-#4201 behavior. The assistant tier gets its own
+/// `declared_tier` verbatim (fail-closed to `L1Standard` for every persona
+/// shipped before #4168) plus `ASSISTANT_ALLOWED_DELEGATE_ROLES` — the same
+/// single-source-of-truth constant `build_assistant_tier_registry` and
+/// `ctrl_delegate_posture` use, never a hand-copied second list.
+/// Test: `persona_delegate_tool_refuses_orchestrator_role_target`,
+/// `persona_delegate_tool_refuses_controller_role_target`,
+/// `persona_delegate_tool_allows_worker_role_target`,
+/// `persona_delegate_tool_allows_peer_assistant_role_target`,
+/// `persona_delegate_tool_leaves_non_assistant_roles_ungated`.
+pub(super) fn build_persona_delegate_tool(
+    runner: Arc<dyn AgentRunner>,
+    config_dir: PathBuf,
+    session_id: String,
+    persona_role: &str,
+    declared_tier: crate::agents::AgentTier,
+) -> DelegateToAgentTool {
+    // #3737: thread the session id so a persona that delegates onward
+    // attributes the answer to the specialist that produced it.
+    let tool = DelegateToAgentTool::new(runner)
+        .with_config_dir(config_dir)
+        .with_session_id(session_id);
+    if persona_role != crate::runtime::tool_registry::ASSISTANT_TIER_ROLE {
+        return tool.with_delegator_tier(crate::agents::AgentTier::L0Orchestration);
+    }
+    tool.with_delegator_tier(declared_tier)
+        // #4201: the allowlist this path was missing — see the fn doc.
+        .with_allowed_target_roles(
+            crate::runtime::tool_registry::ASSISTANT_ALLOWED_DELEGATE_ROLES
+                .iter()
+                .map(|s| s.to_string())
+                .collect(),
+        )
+}
 
 /// Narrow a persona's full candidate tool-name list down to what it may
 /// actually reach on this turn (#3285).

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -20,6 +20,9 @@ use super::super::persona_gate::filter_persona_tool_names;
 // `persona.rs` no longer imports `Scope` (its only user moved to
 // `persona_gate`), but these tests still construct one directly.
 use crate::tools::registry::scope::Scope;
+// #4201: the delegation-gate tests below EXECUTE the real tool this path
+// registers, so they need the trait that carries `execute`.
+use crate::tools::traits::ToolExecutor;
 
 /// #3223: `run_pm_task_with_persona` now resolves the agent via
 /// `AgentConfig::by_name_async` instead of a hand-rolled `.toml`-only
@@ -830,4 +833,206 @@ fn persona_tier_gate_keeps_session_state_for_l0() {
     );
 
     assert_eq!(kept, all_names);
+}
+
+// ---------------------------------------------------------------------------
+// #4201: the delegation gate on the PERSONA dispatch path.
+//
+// These tests deliberately drive `build_persona_delegate_tool` — the single
+// function `run_pm_task_with_persona` registers — and then `execute()` the
+// resulting tool against a spy runner, rather than re-asserting a posture
+// tuple. A test that rebuilt the tool itself would keep passing if the call
+// site dropped `.with_allowed_target_roles(...)` again, which is exactly the
+// regression #4201 filed. Verified non-vacuous: with that call removed from
+// `build_persona_delegate_tool`, the two refusal tests below fail (the spy
+// runner is invoked).
+// ---------------------------------------------------------------------------
+
+/// Spy runner: records every agent name a delegation actually reached a
+/// spawn for. An empty log is the proof a gate rejected BEFORE spawn.
+struct SpyRunner {
+    spawned: std::sync::Mutex<Vec<String>>,
+}
+
+#[async_trait::async_trait]
+impl AgentRunner for SpyRunner {
+    async fn run(
+        &self,
+        agent_name: &str,
+        _task: &str,
+    ) -> anyhow::Result<crate::tools::traits::AgentOutput> {
+        self.spawned
+            .lock()
+            .expect("spy runner lock poisoned")
+            .push(agent_name.to_string());
+        Ok(crate::tools::traits::AgentOutput {
+            content: "ok".into(),
+            summary: None,
+            usage: crate::perf::TokenUsage::default(),
+        })
+    }
+}
+
+/// Seed one resolvable agent TOML with an explicit `role` (and no `tier`, so
+/// it fails closed to `L1Standard` exactly like every bundled agent today).
+fn seed_agent_with_role(dir: &Path, name: &str, role: &str) {
+    std::fs::write(
+        dir.join(format!("{name}.toml")),
+        format!(
+            r#"[agent]
+name = "{name}"
+role = "{role}"
+model = "anthropic/claude-sonnet-4-6"
+description = "issue 4201 test fixture"
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#
+        ),
+    )
+    .expect("failed to seed agent fixture");
+}
+
+/// Run one delegation attempt through the persona path's own tool.
+///
+/// Returns `(is_error, message, spawn_count)`.
+async fn persona_delegate_attempt(
+    target_name: &str,
+    target_role: &str,
+    persona_role: &str,
+) -> (bool, String, usize) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    seed_agent_with_role(dir.path(), target_name, target_role);
+
+    let runner = Arc::new(SpyRunner {
+        spawned: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = super::super::persona_gate::build_persona_delegate_tool(
+        runner.clone(),
+        dir.path().to_path_buf(),
+        "sess-4201".to_string(),
+        persona_role,
+        // Every persona shipped today resolves to L1Standard — see the
+        // known-gap note: no bundled agent declares `tier = "l0"`, which is
+        // precisely why the tier gate cannot cover for the role allowlist.
+        crate::agents::AgentTier::L1Standard,
+    );
+
+    let result = tool
+        .execute(serde_json::json!({
+            "agent_name": target_name,
+            "task": "#4201 delegation attempt",
+        }))
+        .await;
+    let spawned = runner
+        .spawned
+        .lock()
+        .expect("spy runner lock poisoned")
+        .len();
+    (result.is_error(), result.content().to_string(), spawned)
+}
+
+/// #4201 PRIMARY regression: an assistant-tier persona on the REPL `/agent`
+/// path must NOT be able to delegate to `pm` (role `orchestrator`).
+///
+/// Why: `orchestrator` is not in `ASSISTANT_ALLOWED_DELEGATE_ROLES` at all;
+/// `run_subagent` arms the spawned child from ITS OWN role, so a successful
+/// spawn here hands an unrestricted orchestrator registry (shell,
+/// `write_file`, unrestricted `delegate_to_agent`) to a persona that ingests
+/// untrusted content. The #4169 tier gate does not catch this: the fixture
+/// declares no `tier`, so the target resolves to `L1Standard` and
+/// `tier_blocked` is false — the role allowlist is the ONLY thing standing
+/// between this call and the spawn.
+/// What: refuses before the runner is touched, and does not leak the target's
+/// role taxonomy in the message.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn persona_delegate_tool_refuses_orchestrator_role_target() {
+    let (is_error, msg, spawned) =
+        persona_delegate_attempt("pm", "orchestrator", "assistant").await;
+
+    assert!(
+        is_error,
+        "persona path must refuse a role=orchestrator target"
+    );
+    assert_eq!(spawned, 0, "runner must never be reached: {msg}");
+    assert!(
+        !msg.to_lowercase().contains("orchestrator"),
+        "refusal must not leak the target's role, got: {msg}"
+    );
+}
+
+/// Sibling of the above for `ctrl` (role `controller`) — the other privileged
+/// meta-agent the allowlist excludes.
+///
+/// Why: `controller` is likewise absent from
+/// `ASSISTANT_ALLOWED_DELEGATE_ROLES`; pinning both means a partial fix that
+/// special-cased only `pm` cannot pass.
+/// What: same refusal, same no-spawn guarantee.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn persona_delegate_tool_refuses_controller_role_target() {
+    let (is_error, msg, spawned) =
+        persona_delegate_attempt("ctrl", "controller", "assistant").await;
+
+    assert!(
+        is_error,
+        "persona path must refuse a role=controller target"
+    );
+    assert_eq!(spawned, 0, "runner must never be reached: {msg}");
+}
+
+/// The gate must not become a blanket denial: a worker role IS allowlisted
+/// and must still spawn.
+///
+/// Why: a refusal-only test would pass against a gate that broke every
+/// delegation, which would be a worse regression than the hole it closed.
+/// What: `engineer` (role `engineer`, in the allowlist) reaches the runner.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn persona_delegate_tool_allows_worker_role_target() {
+    let (is_error, msg, spawned) =
+        persona_delegate_attempt("engineer", "engineer", "assistant").await;
+
+    assert!(!is_error, "allowlisted worker role must pass: {msg}");
+    assert_eq!(spawned, 1, "runner must be reached exactly once");
+}
+
+/// The peer-consult lane (Izzie <-> cto-assistant) must survive the gate.
+///
+/// Why: `ASSISTANT_TIER_ROLE` is in the allowlist precisely so a peer spawn
+/// keeps working — safe because the peer is ALSO routed through the
+/// restricted assistant-tier registry, never an unrestricted one.
+/// What: role `assistant` reaches the runner.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn persona_delegate_tool_allows_peer_assistant_role_target() {
+    let (is_error, msg, spawned) =
+        persona_delegate_attempt("cto-assistant", "assistant", "assistant").await;
+
+    assert!(!is_error, "peer assistant role must pass: {msg}");
+    assert_eq!(spawned, 1, "runner must be reached exactly once");
+}
+
+/// A persona whose OWN role is outside the assistant tier model is unchanged
+/// by #4201 — no role allowlist, no tier gate.
+///
+/// Why: `build_persona_delegate_tool`'s `role != "assistant"` branch mirrors
+/// `ctrl_delegate_posture`'s, and this pins that the fix did not silently
+/// narrow a population it was never meant to touch (the same reason
+/// `delegate_without_role_gate_allows_any_resolvable_role` exists for the
+/// history path).
+/// What: a non-assistant persona delegating to `pm` still spawns.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn persona_delegate_tool_leaves_non_assistant_roles_ungated() {
+    let (is_error, msg, spawned) =
+        persona_delegate_attempt("pm", "orchestrator", "orchestrator").await;
+
+    assert!(!is_error, "non-assistant persona must stay ungated: {msg}");
+    assert_eq!(spawned, 1, "runner must be reached exactly once");
 }

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -1002,7 +1002,7 @@ async fn persona_delegate_tool_allows_worker_role_target() {
     assert_eq!(spawned, 1, "runner must be reached exactly once");
 }
 
-/// CONVERTED by ADR-0023 (was `persona_delegate_tool_allows_peer_assistant_
+/// CONVERTED by ADR-0024 (was `persona_delegate_tool_allows_peer_assistant_
 /// role_target`, asserting the OPPOSITE): the Izzie <-> cto-assistant
 /// peer-consult lane is CLOSED on this path too.
 ///

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -1002,20 +1002,35 @@ async fn persona_delegate_tool_allows_worker_role_target() {
     assert_eq!(spawned, 1, "runner must be reached exactly once");
 }
 
-/// The peer-consult lane (Izzie <-> cto-assistant) must survive the gate.
+/// CONVERTED by ADR-0023 (was `persona_delegate_tool_allows_peer_assistant_
+/// role_target`, asserting the OPPOSITE): the Izzie <-> cto-assistant
+/// peer-consult lane is CLOSED on this path too.
 ///
-/// Why: `ASSISTANT_TIER_ROLE` is in the allowlist precisely so a peer spawn
-/// keeps working — safe because the peer is ALSO routed through the
-/// restricted assistant-tier registry, never an unrestricted one.
-/// What: role `assistant` reaches the runner.
+/// Why: the owner ratified "assistants can communicate with each other, but
+/// never delegate". The persona path is where an L1/L0 assistant would reach
+/// a peer, so the kind rule must hold HERE and not only in `tools::delegate`'s
+/// own tests — the #3745-item-C discipline: a capability model that holds on
+/// one dispatch path is a bug that surfaces as "it works in chat". Kept
+/// rather than deleted so the history of this reversal stays legible.
+/// What: the persona path's own tool refuses an assistant-role target and
+/// never reaches the runner. Note the role allowlist this path applies STILL
+/// admits `assistant` — the refusal comes from the kind predicate in the
+/// shared `execute()` choke point, not from allowlist curation.
 /// Test: this function IS the test.
 #[tokio::test]
-async fn persona_delegate_tool_allows_peer_assistant_role_target() {
+async fn persona_delegate_tool_refuses_peer_assistant_target() {
     let (is_error, msg, spawned) =
         persona_delegate_attempt("cto-assistant", "assistant", "assistant").await;
 
-    assert!(!is_error, "peer assistant role must pass: {msg}");
-    assert_eq!(spawned, 1, "runner must be reached exactly once");
+    assert!(
+        is_error,
+        "an assistant persona must not be able to delegate to a peer assistant"
+    );
+    assert_eq!(spawned, 0, "runner must never be reached: {msg}");
+    assert!(
+        msg.contains("peer assistant"),
+        "the refusal must explain the kind rule, got: {msg}"
+    );
 }
 
 /// A persona whose OWN role is outside the assistant tier model is unchanged

--- a/crates/trusty-agents/src/runtime/pm_mode.rs
+++ b/crates/trusty-agents/src/runtime/pm_mode.rs
@@ -98,7 +98,7 @@ pub(super) async fn run_pm() -> Result<()> {
     // called here) — pre-flight validation, including the new one-directional
     // L0/L1 tier gate, is entirely skipped for it (see
     // `DelegateToAgentTool::execute`'s `config_dirs.is_empty()` guard), so
-    // `run_pm` needs no `with_delegator` call to be correct (ADR-0023: it
+    // `run_pm` needs no `with_delegator` call to be correct (ADR-0024: it
     // therefore also declares no delegator KIND, so the peer-assistant
     // predicate is a no-op here — deliberate, this is predicate 1's explicit
     // orchestrator scope caveat, and unreachable from any assistant anyway).

--- a/crates/trusty-agents/src/runtime/pm_mode.rs
+++ b/crates/trusty-agents/src/runtime/pm_mode.rs
@@ -98,7 +98,11 @@ pub(super) async fn run_pm() -> Result<()> {
     // called here) — pre-flight validation, including the new one-directional
     // L0/L1 tier gate, is entirely skipped for it (see
     // `DelegateToAgentTool::execute`'s `config_dirs.is_empty()` guard), so
-    // `run_pm` needs no `with_delegator_tier` call to be correct. This is
+    // `run_pm` needs no `with_delegator` call to be correct (ADR-0023: it
+    // therefore also declares no delegator KIND, so the peer-assistant
+    // predicate is a no-op here — deliberate, this is predicate 1's explicit
+    // orchestrator scope caveat, and unreachable from any assistant anyway).
+    // This is
     // deliberate, not an oversight: `pm` (role `orchestrator`) is the
     // trusted top-level orchestrator, already unreachable as a delegation
     // TARGET from any L1 persona (`orchestrator` was never in

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -94,7 +94,7 @@ use tools::{ToolRegistry, shell_exec::ShellExecTool};
 /// `role == ASSISTANT_TIER_ROLE` branch in `build_registry_for_agent` below.
 /// Reading the constant (rather than re-typing the literal `"assistant"`)
 /// keeps the config surface from claiming a mechanism the registry would not
-/// wire. ADR-0023 gave this constant a second reader of the same shape:
+/// wire. ADR-0024 gave this constant a second reader of the same shape:
 /// `crate::agents::delegation::is_assistant_kind`, the ONE definition of the
 /// assistant KIND, which `ctrl::pm_task::dispatch::persona_gate` now calls
 /// instead of comparing the literal inline.
@@ -119,14 +119,14 @@ pub(crate) const ASSISTANT_TIER_ROLE: &str = "assistant";
 /// `agent.toml` (NOT the agent/file name — `qa-agent.toml` declares
 /// `role = "qa"`, not `"qa-agent"`) plus [`ASSISTANT_TIER_ROLE`] itself. That
 /// last entry was added for the Izzie <-> cto-assistant peer-consult lane;
-/// ADR-0023 has since CLOSED that lane (see the note below), so it no longer
+/// ADR-0024 has since CLOSED that lane (see the note below), so it no longer
 /// admits any delegation edge on its own. Any role not in this list —
 /// including anything not yet declared in the bundled roster — is rejected.
 /// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
 /// `delegate_assistant_role_gate_rejects_controller_role`,
 /// `delegate_assistant_role_gate_allows_worker_role`,
 /// `delegate_peer_assistant_is_refused_despite_role_allowlist`
-/// (`src/tools/delegate.rs`). ADR-0023 note: `ASSISTANT_TIER_ROLE` remains in
+/// (`src/tools/delegate.rs`). ADR-0024 note: `ASSISTANT_TIER_ROLE` remains in
 /// this list, but an assistant-to-assistant EDGE is now refused by the kind
 /// predicate inside `DelegateToAgentTool::execute`
 /// (`crate::agents::delegation`) — the peer-consult lane this entry was added
@@ -571,7 +571,7 @@ pub(crate) fn build_assistant_tier_registry(
                     .map(|s| s.to_string())
                     .collect(),
             )
-            // ADR-0023: the delegator's KIND is `ASSISTANT_TIER_ROLE` by
+            // ADR-0024: the delegator's KIND is `ASSISTANT_TIER_ROLE` by
             // construction, not by assumption — `build_registry_for_agent`
             // (line ~188) routes into this function on exactly that role and
             // on no other, so every caller of this registry IS an assistant.

--- a/crates/trusty-agents/src/runtime/tool_registry.rs
+++ b/crates/trusty-agents/src/runtime/tool_registry.rs
@@ -92,9 +92,12 @@ use tools::{ToolRegistry, shell_exec::ShellExecTool};
 /// Sub-agents configuration section — must report whether `delegate_to_agent`
 /// is registered for a given agent AT ALL, which is exactly the
 /// `role == ASSISTANT_TIER_ROLE` branch in `build_registry_for_agent` below.
-/// Reading the constant (rather than re-typing the literal `"assistant"`, as
-/// `ctrl::pm_task::dispatch::persona` was forced to) keeps the config surface
-/// from claiming a mechanism the registry would not wire.
+/// Reading the constant (rather than re-typing the literal `"assistant"`)
+/// keeps the config surface from claiming a mechanism the registry would not
+/// wire. ADR-0023 gave this constant a second reader of the same shape:
+/// `crate::agents::delegation::is_assistant_kind`, the ONE definition of the
+/// assistant KIND, which `ctrl::pm_task::dispatch::persona_gate` now calls
+/// instead of comparing the literal inline.
 pub(crate) const ASSISTANT_TIER_ROLE: &str = "assistant";
 
 /// Fail-closed allowlist of `agent.role` values an assistant-tier
@@ -114,17 +117,23 @@ pub(crate) const ASSISTANT_TIER_ROLE: &str = "assistant";
 /// sandboxed assistant tier.
 /// What: the exact `role` field values declared in each bundled worker's
 /// `agent.toml` (NOT the agent/file name — `qa-agent.toml` declares
-/// `role = "qa"`, not `"qa-agent"`) plus [`ASSISTANT_TIER_ROLE`] itself, so
-/// the Izzie <-> cto-assistant peer-consult lane keeps working: spawning a
-/// peer assistant is safe because IT ALSO gets routed through
-/// `build_assistant_tier_registry` (the same restricted registry), never an
-/// unrestricted one. Any role not in this list — including anything not yet
-/// declared in the bundled roster — is rejected.
+/// `role = "qa"`, not `"qa-agent"`) plus [`ASSISTANT_TIER_ROLE`] itself. That
+/// last entry was added for the Izzie <-> cto-assistant peer-consult lane;
+/// ADR-0023 has since CLOSED that lane (see the note below), so it no longer
+/// admits any delegation edge on its own. Any role not in this list —
+/// including anything not yet declared in the bundled roster — is rejected.
 /// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
 /// `delegate_assistant_role_gate_rejects_controller_role`,
 /// `delegate_assistant_role_gate_allows_worker_role`,
-/// `delegate_assistant_role_gate_allows_peer_assistant_role`
-/// (`src/tools/delegate.rs`).
+/// `delegate_peer_assistant_is_refused_despite_role_allowlist`
+/// (`src/tools/delegate.rs`). ADR-0023 note: `ASSISTANT_TIER_ROLE` remains in
+/// this list, but an assistant-to-assistant EDGE is now refused by the kind
+/// predicate inside `DelegateToAgentTool::execute`
+/// (`crate::agents::delegation`) — the peer-consult lane this entry was added
+/// for is closed. The entry is kept because this list is also read by
+/// non-delegation consumers (the `/subagents` route's `allowed_roles`
+/// report), and because the kind rule must be enforced by CODE, not by which
+/// names happen to appear in a curated list.
 ///
 /// `pub(crate)` (security fix, third dispatch path, #4126): `ctrl::pm_task::
 /// dispatch::history::run_pm_task_with_history` builds its OWN
@@ -484,11 +493,11 @@ pub(super) fn build_registry_for_agent(
 ///
 /// `delegator_tier` (#4169, epic #4167 — one-directional L0/L1 delegation
 /// gate): this agent's own resolved `AgentInfo::tier()`, threaded into the
-/// `DelegateToAgentTool` via `with_delegator_tier` (always called here,
+/// `DelegateToAgentTool` via `with_delegator` (always called here,
 /// alongside `with_allowed_target_roles`) so its pre-flight check refuses
 /// any target that resolves to `AgentTier::L0Orchestration` unless THIS
 /// agent is itself L0. If a call to this function ever omitted the
-/// `with_delegator_tier` wiring, `DelegateToAgentTool` would STILL enforce
+/// `with_delegator` wiring, `DelegateToAgentTool` would STILL enforce
 /// the tier gate fail-closed to `AgentTier::L1Standard` (because
 /// `with_allowed_target_roles` is always called here too — see
 /// `DelegateToAgentTool::delegator_tier`'s doc comment for the
@@ -562,7 +571,13 @@ pub(crate) fn build_assistant_tier_registry(
                     .map(|s| s.to_string())
                     .collect(),
             )
-            .with_delegator_tier(delegator_tier),
+            // ADR-0023: the delegator's KIND is `ASSISTANT_TIER_ROLE` by
+            // construction, not by assumption — `build_registry_for_agent`
+            // (line ~188) routes into this function on exactly that role and
+            // on no other, so every caller of this registry IS an assistant.
+            // Declared together with the tier in one call so this site cannot
+            // acquire the tier gate while missing the kind predicate.
+            .with_delegator(ASSISTANT_TIER_ROLE, delegator_tier),
     ));
 
     // #3745 item C: register the izzie platform-hosted tools

--- a/crates/trusty-agents/src/tools/delegate.rs
+++ b/crates/trusty-agents/src/tools/delegate.rs
@@ -79,7 +79,7 @@ pub struct DelegateToAgentTool {
     /// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
     /// `delegate_assistant_role_gate_rejects_controller_role`,
     /// `delegate_assistant_role_gate_allows_worker_role`,
-    /// `delegate_peer_assistant_is_refused_despite_role_allowlist` (ADR-0023:
+    /// `delegate_peer_assistant_is_refused_despite_role_allowlist` (ADR-0024:
     /// this list still ADMITS the assistant role — the peer edge is refused
     /// by the kind predicate in `execute`, never by curating this list).
     allowed_target_roles: Option<Vec<String>>,
@@ -124,10 +124,10 @@ pub struct DelegateToAgentTool {
     /// `no_tier_and_no_role_gate_preserves_cheap_existence_check`,
     /// `delegator_identity_defaults_to_none_on_construction`.
     delegator_tier: Option<crate::agents::AgentTier>,
-    /// This instance's OWN `agent.role` — the DELEGATOR's KIND (ADR-0023,
+    /// This instance's OWN `agent.role` — the DELEGATOR's KIND (ADR-0024,
     /// issue #4201 follow-up).
     ///
-    /// Why: ADR-0023 makes delegation authority a function of KIND
+    /// Why: ADR-0024 makes delegation authority a function of KIND
     /// (assistant vs. sub-agent), never of tier order, because a total order
     /// over tiers cannot forbid an edge WITHIN a rank — see
     /// [`crate::agents::delegation`] for the structural argument. Enforcing
@@ -141,7 +141,7 @@ pub struct DelegateToAgentTool {
     /// where a per-gate builder method one call site simply forgot to call
     /// left that path ungated with nothing to catch it.
     /// What: `None` — no delegator identity was declared — means the kind
-    /// predicate does not run, byte-identical to pre-ADR-0023 behavior. That
+    /// predicate does not run, byte-identical to pre-ADR-0024 behavior. That
     /// population is `runtime::pm_mode::run_pm` (which also attaches no
     /// `config_dirs`, so it skips the entire pre-flight block regardless) and
     /// tests exercising unrelated resolution behavior. `Some(role)` means
@@ -283,10 +283,10 @@ impl DelegateToAgentTool {
     }
 
     /// Declare THIS instance's own delegator identity — its `agent.role`
-    /// (KIND, ADR-0023) and its `AgentInfo::tier()` (#4169, epic #4167).
+    /// (KIND, ADR-0024) and its `AgentInfo::tier()` (#4169, epic #4167).
     ///
     /// Why: See the `delegator_role` and `delegator_tier` field docs. Role and
-    /// tier are taken TOGETHER, in one call, on purpose (ADR-0023 conformance;
+    /// tier are taken TOGETHER, in one call, on purpose (ADR-0024 conformance;
     /// superseded the tier-only `with_delegator_tier`): they are two readings
     /// of one fact — who this delegator is — and the gates derived from them
     /// are meant to be indivisible. A per-gate builder method that each caller
@@ -444,7 +444,7 @@ impl ToolExecutor for DelegateToAgentTool {
                             }
                             None => true,
                         };
-                        // ADR-0023 predicates 1+2, the PRIMARY carrier of the
+                        // ADR-0024 predicates 1+2, the PRIMARY carrier of the
                         // rule: an assistant may never DELEGATE to another
                         // assistant ("assistants communicate with each other,
                         // but never delegate"). Enforced here, in the shared
@@ -470,7 +470,7 @@ impl ToolExecutor for DelegateToAgentTool {
                                 target_role = %cfg.agent.role,
                                 "delegate_to_agent: refusing an assistant-to-assistant \
                                  delegation — assistants communicate, they do not delegate \
-                                 to one another (ADR-0023)"
+                                 to one another (ADR-0024)"
                             );
                         }
                         (
@@ -499,7 +499,7 @@ impl ToolExecutor for DelegateToAgentTool {
                 (false, false, false)
             };
             if kind_blocked {
-                // ADR-0023 AC, same rationale as the tier message below: the
+                // ADR-0024 AC, same rationale as the tier message below: the
                 // assistant/sub-agent split is a product-level concept the
                 // owner named directly, so explaining it educates rather than
                 // leaking — it enumerates no roster entry beyond the one name
@@ -541,7 +541,7 @@ impl ToolExecutor for DelegateToAgentTool {
                      as tools instead of via delegate_to_agent."
                 ));
             }
-            // ADR-0023 observability gap: until now ONLY refusals logged, so a
+            // ADR-0024 observability gap: until now ONLY refusals logged, so a
             // gate that had silently stopped matching (exactly #4201's shape)
             // produced no signal at all — an operator could not tell an
             // authorized delegation from an unenforced one. One line on the

--- a/crates/trusty-agents/src/tools/delegate.rs
+++ b/crates/trusty-agents/src/tools/delegate.rs
@@ -79,7 +79,9 @@ pub struct DelegateToAgentTool {
     /// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
     /// `delegate_assistant_role_gate_rejects_controller_role`,
     /// `delegate_assistant_role_gate_allows_worker_role`,
-    /// `delegate_assistant_role_gate_allows_peer_assistant_role`.
+    /// `delegate_peer_assistant_is_refused_despite_role_allowlist` (ADR-0023:
+    /// this list still ADMITS the assistant role — the peer edge is refused
+    /// by the kind predicate in `execute`, never by curating this list).
     allowed_target_roles: Option<Vec<String>>,
     /// This instance's OWN privilege tier — the DELEGATOR's tier, not the
     /// target's (#4169, epic #4167 — one-directional L0/L1 delegation gate).
@@ -98,7 +100,7 @@ pub struct DelegateToAgentTool {
     /// `allowed_target_roles` is set OR this field is explicitly set (see
     /// `execute`'s `needs_full_resolution`).
     /// What: `None` (the default — every caller that constructs a
-    /// `DelegateToAgentTool` and never calls `with_delegator_tier`, which
+    /// `DelegateToAgentTool` and never calls `with_delegator`, which
     /// includes `pm`/`ctrl`-as-orchestrator's own unrestricted delegation
     /// and pre-#4169 tests exercising unrelated resolution behavior with
     /// bare/incomplete fixture TOMLs) means "this instance was never asked
@@ -113,15 +115,44 @@ pub struct DelegateToAgentTool {
     /// check still runs with a FAIL-CLOSED `AgentTier::L1Standard` default
     /// (via `unwrap_or_default()`) — belt-and-suspenders: the population
     /// that cares about role-gating can never silently skip tier-gating
-    /// too. Set explicitly via `with_delegator_tier`.
+    /// too. Set explicitly via `with_delegator`, together with the
+    /// delegator's role — see `delegator_role` for why they are indivisible.
     /// Test: `delegate_l1_to_l0_is_refused`, `delegate_l0_to_l1_succeeds`,
-    /// `delegate_l1_to_l1_is_unaffected_by_tier_gate`,
-    /// `delegate_multi_hop_l1_peer_to_l0_is_refused`,
+    /// `delegate_multi_hop_assistant_hop_is_refused`,
     /// `delegate_tier_gate_applies_even_without_role_allowlist`,
     /// `delegate_role_gate_without_declared_tier_fails_closed_to_l1`,
     /// `no_tier_and_no_role_gate_preserves_cheap_existence_check`,
-    /// `delegator_tier_defaults_to_none_on_construction`.
+    /// `delegator_identity_defaults_to_none_on_construction`.
     delegator_tier: Option<crate::agents::AgentTier>,
+    /// This instance's OWN `agent.role` — the DELEGATOR's KIND (ADR-0023,
+    /// issue #4201 follow-up).
+    ///
+    /// Why: ADR-0023 makes delegation authority a function of KIND
+    /// (assistant vs. sub-agent), never of tier order, because a total order
+    /// over tiers cannot forbid an edge WITHIN a rank — see
+    /// [`crate::agents::delegation`] for the structural argument. Enforcing
+    /// that rule needs the delegator's own kind, which this tool previously
+    /// never knew: it knew the delegator's TIER (`delegator_tier` above) and
+    /// nothing else. This field is deliberately set through the SAME builder
+    /// call as that tier ([`DelegateToAgentTool::with_delegator`]) rather than
+    /// through a separate opt-in method, so a call site cannot declare half of
+    /// its identity: whichever gates the choke point derives, it derives them
+    /// all, from one statement. That shape is the direct lesson of #4201,
+    /// where a per-gate builder method one call site simply forgot to call
+    /// left that path ungated with nothing to catch it.
+    /// What: `None` — no delegator identity was declared — means the kind
+    /// predicate does not run, byte-identical to pre-ADR-0023 behavior. That
+    /// population is `runtime::pm_mode::run_pm` (which also attaches no
+    /// `config_dirs`, so it skips the entire pre-flight block regardless) and
+    /// tests exercising unrelated resolution behavior. `Some(role)` means
+    /// "this delegator's kind is `role`"; when that role IS the assistant
+    /// kind, `execute` refuses any target that is also the assistant kind.
+    /// Test: `delegate_assistant_to_assistant_is_refused`,
+    /// `delegate_assistant_to_assistant_is_refused_at_every_tier_pairing`,
+    /// `delegate_assistant_to_sub_agent_still_succeeds`,
+    /// `delegate_kind_gate_does_not_touch_orchestrator_sources`,
+    /// `delegator_identity_defaults_to_none_on_construction`.
+    delegator_role: Option<String>,
     /// #3737 (per-message chat attribution, epic #3052): the id of the task
     /// whose turn this tool is delegating within, used as the `session_id` on
     /// the `AgentSpawned` event emitted on a successful delegation so the API
@@ -157,6 +188,7 @@ impl DelegateToAgentTool {
             config_dirs: Vec::new(),
             allowed_target_roles: None,
             delegator_tier: None,
+            delegator_role: None,
             session_id: None,
         }
     }
@@ -244,28 +276,43 @@ impl DelegateToAgentTool {
     /// Test: `delegate_assistant_role_gate_rejects_orchestrator_role`,
     /// `delegate_assistant_role_gate_rejects_controller_role`,
     /// `delegate_assistant_role_gate_allows_worker_role`,
-    /// `delegate_assistant_role_gate_allows_peer_assistant_role`.
+    /// `delegate_peer_assistant_is_refused_despite_role_allowlist`.
     pub fn with_allowed_target_roles(mut self, roles: Vec<String>) -> Self {
         self.allowed_target_roles = Some(roles);
         self
     }
 
-    /// Declare THIS instance's own delegator tier (#4169, epic #4167).
+    /// Declare THIS instance's own delegator identity — its `agent.role`
+    /// (KIND, ADR-0023) and its `AgentInfo::tier()` (#4169, epic #4167).
     ///
-    /// Why: See the `delegator_tier` field doc for the full rationale.
-    /// Every production call site that constructs a `DelegateToAgentTool`
-    /// for an assistant-tier (persona) caller must call this with that
-    /// caller's own resolved `AgentInfo::tier()` so the one-directional
-    /// L1->L0 gate has something to check against. Callers representing a
-    /// caller OUTSIDE the persona tier model entirely — `pm`/`ctrl`-as-
-    /// orchestrator, already fully trusted and already unaffected by
-    /// `allowed_target_roles` — pass [`crate::agents::AgentTier::L0Orchestration`]
-    /// explicitly to mean "this caller is not gated by the L0/L1 boundary",
-    /// not because it IS an L0 persona.
-    /// What: Stores `Some(tier)`, which — combined with `config_dirs` being
-    /// non-empty — forces full target resolution so the tier gate can run.
-    /// Test: `delegate_l1_to_l0_is_refused`, `delegate_l0_to_l1_succeeds`.
-    pub fn with_delegator_tier(mut self, tier: crate::agents::AgentTier) -> Self {
+    /// Why: See the `delegator_role` and `delegator_tier` field docs. Role and
+    /// tier are taken TOGETHER, in one call, on purpose (ADR-0023 conformance;
+    /// superseded the tier-only `with_delegator_tier`): they are two readings
+    /// of one fact — who this delegator is — and the gates derived from them
+    /// are meant to be indivisible. A per-gate builder method that each caller
+    /// must remember is precisely the shape that produced #4201's gap, where
+    /// one of three construction sites omitted `with_allowed_target_roles` and
+    /// nothing caught it; a caller can no longer opt into the tier gate while
+    /// silently skipping the kind gate, because there is no call that does
+    /// only one. Callers OUTSIDE the assistant/sub-agent model — `pm`/`ctrl`
+    /// -as-orchestrator, already fully trusted — pass their real role
+    /// (`orchestrator`/`controller`, which the kind predicate ignores by
+    /// design) with [`crate::agents::AgentTier::L0Orchestration`], meaning
+    /// "this caller is not gated by the L0/L1 boundary", not that it IS an L0
+    /// persona.
+    /// What: Stores `Some(role)` and `Some(tier)`, which — combined with
+    /// `config_dirs` being non-empty — forces full target resolution so both
+    /// the kind predicate and the tier gate can run against the resolved
+    /// target.
+    /// Test: `delegate_l1_to_l0_is_refused`, `delegate_l0_to_l1_succeeds`,
+    /// `delegate_assistant_to_assistant_is_refused`,
+    /// `delegator_identity_defaults_to_none_on_construction`.
+    pub fn with_delegator(
+        mut self,
+        role: impl Into<String>,
+        tier: crate::agents::AgentTier,
+    ) -> Self {
+        self.delegator_role = Some(role.into());
         self.delegator_tier = Some(tier);
         self
     }
@@ -360,7 +407,7 @@ impl ToolExecutor for DelegateToAgentTool {
             // `ctrl::pm_task::dispatch::persona`).
             let needs_full_resolution =
                 self.allowed_target_roles.is_some() || self.delegator_tier.is_some();
-            let (rejected, tier_blocked) = if needs_full_resolution {
+            let (rejected, tier_blocked, kind_blocked) = if needs_full_resolution {
                 // Fail-closed default (#4169 constraint 1): a caller that DID
                 // opt into role-gating but never declared its own tier is
                 // still checked as if it were L1Standard — the population
@@ -397,7 +444,40 @@ impl ToolExecutor for DelegateToAgentTool {
                             }
                             None => true,
                         };
-                        (tier_blocked || !role_ok, tier_blocked)
+                        // ADR-0023 predicates 1+2, the PRIMARY carrier of the
+                        // rule: an assistant may never DELEGATE to another
+                        // assistant ("assistants communicate with each other,
+                        // but never delegate"). Enforced here, in the shared
+                        // choke point every delegation traverses, rather than
+                        // via a per-call-site builder opt-in — see
+                        // `with_delegator`. It reads only ROLES, never tiers,
+                        // so it holds identically before and after the
+                        // ratified inversion that moves assistants to L0 and
+                        // makes the tier comparison below vacuous for this
+                        // case. `delegator_role` of `None` (no identity
+                        // declared) leaves this a no-op, and a non-assistant
+                        // source (`pm`/`ctrl`) is outside the rule entirely.
+                        let kind_blocked =
+                            self.delegator_role.as_deref().is_some_and(|source_role| {
+                                crate::agents::delegation::kind_refuses_delegation(
+                                    source_role,
+                                    &cfg.agent.role,
+                                )
+                            });
+                        if kind_blocked {
+                            tracing::warn!(
+                                agent_name,
+                                target_role = %cfg.agent.role,
+                                "delegate_to_agent: refusing an assistant-to-assistant \
+                                 delegation — assistants communicate, they do not delegate \
+                                 to one another (ADR-0023)"
+                            );
+                        }
+                        (
+                            tier_blocked || kind_blocked || !role_ok,
+                            tier_blocked,
+                            kind_blocked,
+                        )
                     }
                     Err(e) => {
                         tracing::debug!(
@@ -405,7 +485,7 @@ impl ToolExecutor for DelegateToAgentTool {
                             error = %format!("{e:#}"),
                             "delegate_to_agent: gated target failed to resolve"
                         );
-                        (true, false)
+                        (true, false, false)
                     }
                 }
             } else if !crate::agents::agent_name_resolves(&self.config_dirs, agent_name) {
@@ -414,10 +494,26 @@ impl ToolExecutor for DelegateToAgentTool {
                     config_dirs = ?self.config_dirs,
                     "delegate_to_agent: agent not found in any candidate directory"
                 );
-                (true, false)
+                (true, false, false)
             } else {
-                (false, false)
+                (false, false, false)
             };
+            if kind_blocked {
+                // ADR-0023 AC, same rationale as the tier message below: the
+                // assistant/sub-agent split is a product-level concept the
+                // owner named directly, so explaining it educates rather than
+                // leaking — it enumerates no roster entry beyond the one name
+                // the caller already supplied. Deliberately distinct from the
+                // generic roster-hiding message, and checked BEFORE the tier
+                // message so a peer edge is always reported as the peer
+                // prohibition it is, never as a tier accident.
+                return ToolResult::err(format!(
+                    "'{agent_name}' cannot be delegated to: it is a peer assistant, and \
+                     assistants communicate with each other rather than delegating to one \
+                     another. Delegation is for sub-agents (specialists). Handle this \
+                     yourself, or hand it to a specialist instead."
+                ));
+            }
             if tier_blocked {
                 // #4169 AC: "error message educates the user on the
                 // constraint" — deliberately DISTINCT from the generic
@@ -445,6 +541,26 @@ impl ToolExecutor for DelegateToAgentTool {
                      as tools instead of via delegate_to_agent."
                 ));
             }
+            // ADR-0023 observability gap: until now ONLY refusals logged, so a
+            // gate that had silently stopped matching (exactly #4201's shape)
+            // produced no signal at all — an operator could not tell an
+            // authorized delegation from an unenforced one. One line on the
+            // authorized path records which predicates were consulted, so
+            // predicate 3 being redundant-as-designed is observable rather
+            // than inferred. Identity metadata only: roles, tier, and the
+            // agent name the caller already supplied — never the task body,
+            // credentials, or any user content.
+            tracing::info!(
+                agent_name,
+                source_role = self.delegator_role.as_deref().unwrap_or("<undeclared>"),
+                source_is_assistant_kind = self
+                    .delegator_role
+                    .as_deref()
+                    .is_some_and(crate::agents::delegation::is_assistant_kind),
+                delegator_tier = ?self.delegator_tier,
+                role_allowlist_enforced = self.allowed_target_roles.is_some(),
+                "delegate_to_agent: delegation authorized (kind + role + tier predicates passed)"
+            );
         }
 
         // Detect coding persona + language idiom skill from the task and

--- a/crates/trusty-agents/src/tools/delegate_tests.rs
+++ b/crates/trusty-agents/src/tools/delegate_tests.rs
@@ -401,14 +401,25 @@ async fn delegate_assistant_role_gate_allows_worker_role() {
     assert_eq!(runner.invoked.lock().unwrap().len(), 1);
 }
 
-/// The other positive case: a PEER assistant (role `assistant`, e.g.
-/// `cto-assistant`) must still reach the runner — this is the
-/// Izzie <-> cto-assistant peer-consult lane the role gate must
-/// preserve. Spawning a peer is safe because IT ALSO gets routed
-/// through the restricted assistant-tier registry, never an
-/// unrestricted one.
+/// CONVERTED by ADR-0023 (was `delegate_assistant_role_gate_allows_peer_
+/// assistant_role`, which asserted the OPPOSITE): the Izzie <-> cto-assistant
+/// peer-consult lane is now CLOSED. The owner ratified "assistants can
+/// communicate with each other, but never delegate", so a peer assistant is
+/// no longer a delegation target.
+///
+/// Why this test is kept rather than deleted: it is the single most direct
+/// proof that the kind rule is a property of the CODE and not of the
+/// allowlist DATA. The allowlist here still contains `"assistant"` — exactly
+/// as `ASSISTANT_ALLOWED_DELEGATE_ROLES` still does — and the delegation is
+/// refused anyway. If the kind exclusion lived only in "which roles happen to
+/// be listed", the same class of silent gap #4201 filed would reopen the
+/// moment an operator or a future edit put an assistant role back in a list.
+/// What: role-allowlisted to admit `assistant`, delegator identity declared
+/// as assistant-kind; the peer target is refused and the runner is never
+/// reached.
+/// Test: this function IS the test.
 #[tokio::test]
-async fn delegate_assistant_role_gate_allows_peer_assistant_role() {
+async fn delegate_peer_assistant_is_refused_despite_role_allowlist() {
     let dir = tempfile::tempdir().unwrap();
     write_agent_toml_with_role(dir.path(), "cto-assistant", "assistant");
 
@@ -417,7 +428,10 @@ async fn delegate_assistant_role_gate_allows_peer_assistant_role() {
     });
     let tool = DelegateToAgentTool::new(runner.clone())
         .with_config_dirs(vec![dir.path().to_path_buf()])
-        .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()]);
+        // The allowlist DOES admit role `assistant` — the kind rule must
+        // refuse the edge regardless.
+        .with_allowed_target_roles(vec!["engineer".to_string(), "assistant".to_string()])
+        .with_delegator("assistant", crate::agents::AgentTier::L1Standard);
 
     let result = tool
         .execute(json!({
@@ -427,11 +441,14 @@ async fn delegate_assistant_role_gate_allows_peer_assistant_role() {
         .await;
 
     assert!(
-        !result.is_error(),
-        "peer assistant role must pass the gate: {}",
-        result.content()
+        result.is_error(),
+        "an assistant may not delegate to a peer assistant, even when the role \
+         allowlist admits the role"
     );
-    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+    assert!(
+        runner.invoked.lock().unwrap().is_empty(),
+        "runner must never be reached for a peer-assistant edge"
+    );
 }
 
 /// Without `with_allowed_target_roles` (pm/ctrl callers), the role gate
@@ -547,16 +564,22 @@ fn session_id_gate_normalizes_blank_to_none() {
 // reimplementation of the gate.
 // ============================================================================
 
-/// THE single most important test in this PR: an L1-tier delegator must be
-/// refused when the resolved target's own declared tier is L0
-/// (orchestration). The runner must never be invoked.
+/// An L1-tier delegator must be refused when the resolved target's own
+/// declared tier is L0 (orchestration). The runner must never be invoked.
+///
+/// ADR-0023 update: the L0 fixture's role is now `engineer`, not `assistant`.
+/// With an assistant-role target this test would be satisfied by the KIND
+/// predicate before the tier gate ever ran, silently becoming a duplicate of
+/// `delegate_assistant_to_assistant_is_refused` and leaving predicate 3 (the
+/// defense-in-depth tier layer) untested. A sub-agent-kind L0 target isolates
+/// the tier gate as the sole reason for refusal.
 #[tokio::test]
 async fn delegate_l1_to_l0_is_refused() {
     let dir = tempfile::tempdir().unwrap();
     write_agent_toml_with_role_and_tier(
         dir.path(),
-        "orchestration-assistant",
-        "assistant",
+        "orchestration-worker",
+        "engineer",
         Some("orchestration"),
     );
 
@@ -565,11 +588,11 @@ async fn delegate_l1_to_l0_is_refused() {
     });
     let tool = DelegateToAgentTool::new(runner.clone())
         .with_config_dirs(vec![dir.path().to_path_buf()])
-        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+        .with_delegator("assistant", crate::agents::AgentTier::L1Standard);
 
     let result = tool
         .execute(json!({
-            "agent_name": "orchestration-assistant",
+            "agent_name": "orchestration-worker",
             "task": "run cargo check and push a fix"
         }))
         .await;
@@ -590,23 +613,28 @@ async fn delegate_l1_to_l0_is_refused() {
 }
 
 /// The counter-test: an L0-tier delegator reaching an L1 (standard) target
-/// must succeed — this PR must not break legitimate downward delegation.
+/// must succeed — this must not break legitimate downward delegation.
+///
+/// ADR-0023 update: the target is now a sub-agent (`engineer`), not `izzie`
+/// (role `assistant`). An assistant target would now be refused by the kind
+/// predicate for reasons that have nothing to do with tier, which would make
+/// this tier test assert the opposite of what it is named for.
 #[tokio::test]
 async fn delegate_l0_to_l1_succeeds() {
     let dir = tempfile::tempdir().unwrap();
-    write_agent_toml_with_role(dir.path(), "izzie", "assistant");
+    write_agent_toml_with_role(dir.path(), "engineer", "engineer");
 
     let runner = Arc::new(RecordingRunner {
         invoked: std::sync::Mutex::new(Vec::new()),
     });
     let tool = DelegateToAgentTool::new(runner.clone())
         .with_config_dirs(vec![dir.path().to_path_buf()])
-        .with_delegator_tier(crate::agents::AgentTier::L0Orchestration);
+        .with_delegator("assistant", crate::agents::AgentTier::L0Orchestration);
 
     let result = tool
         .execute(json!({
-            "agent_name": "izzie",
-            "task": "consult on train schedules"
+            "agent_name": "engineer",
+            "task": "run cargo check"
         }))
         .await;
 
@@ -618,60 +646,31 @@ async fn delegate_l0_to_l1_succeeds() {
     assert_eq!(runner.invoked.lock().unwrap().len(), 1);
 }
 
-/// L1 -> L1 (a target with no `tier` declared, or explicitly `l1`) must be
-/// completely unaffected by the new gate — it existed before #4169 and must
-/// keep working.
-#[tokio::test]
-async fn delegate_l1_to_l1_is_unaffected_by_tier_gate() {
-    let dir = tempfile::tempdir().unwrap();
-    write_agent_toml_with_role(dir.path(), "cto-assistant", "assistant");
-
-    let runner = Arc::new(RecordingRunner {
-        invoked: std::sync::Mutex::new(Vec::new()),
-    });
-    let tool = DelegateToAgentTool::new(runner.clone())
-        .with_config_dirs(vec![dir.path().to_path_buf()])
-        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
-
-    let result = tool
-        .execute(json!({
-            "agent_name": "cto-assistant",
-            "task": "consult on architecture"
-        }))
-        .await;
-
-    assert!(
-        !result.is_error(),
-        "L1 -> L1 must be unaffected: {}",
-        result.content()
-    );
-    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
-}
-
-/// `delegator_tier` defaults to `None` on construction ("this instance was
-/// never asked to enforce the tier gate") — the field-level contract
-/// `with_delegator_tier` overrides. Mirrors
-/// `session_id_gate_normalizes_blank_to_none`'s same-module field check.
-/// The BEHAVIORAL consequence of `None` splits in two, covered separately:
-/// `no_tier_and_no_role_gate_preserves_cheap_existence_check` (neither gate
-/// opted in — untouched) and
-/// `delegate_role_gate_without_declared_tier_fails_closed_to_l1` (role gate
-/// opted in, tier forgotten — still fails closed to L1Standard).
+/// `delegator_role`/`delegator_tier` both default to `None` on construction
+/// ("this instance was never asked to enforce the kind or tier gates") and
+/// are both set by the single `with_delegator` call.
+///
+/// ADR-0023 update (was `delegator_tier_defaults_to_none_on_construction`):
+/// the two fields are asserted TOGETHER because the builder sets them
+/// together on purpose — a call site must not be able to declare its tier
+/// while leaving its kind undeclared, which is the structural property that
+/// replaced the per-gate opt-in #4201 exposed as fragile.
 #[test]
-fn delegator_tier_defaults_to_none_on_construction() {
+fn delegator_identity_defaults_to_none_on_construction() {
     let runner = Arc::new(RecordingRunner {
         invoked: std::sync::Mutex::new(Vec::new()),
     });
+    let bare = DelegateToAgentTool::new(runner.clone());
+    assert_eq!(bare.delegator_tier, None);
+    assert_eq!(bare.delegator_role, None);
+
+    let declared = DelegateToAgentTool::new(runner)
+        .with_delegator("assistant", crate::agents::AgentTier::L0Orchestration);
     assert_eq!(
-        DelegateToAgentTool::new(runner.clone()).delegator_tier,
-        None
-    );
-    assert_eq!(
-        DelegateToAgentTool::new(runner)
-            .with_delegator_tier(crate::agents::AgentTier::L0Orchestration)
-            .delegator_tier,
+        declared.delegator_tier,
         Some(crate::agents::AgentTier::L0Orchestration)
     );
+    assert_eq!(declared.delegator_role.as_deref(), Some("assistant"));
 }
 
 /// A target whose `tier` is malformed/unrecognized must resolve to L1 (per
@@ -688,7 +687,7 @@ async fn delegate_malformed_target_tier_resolves_l1_and_is_not_tier_blocked() {
     });
     let tool = DelegateToAgentTool::new(runner.clone())
         .with_config_dirs(vec![dir.path().to_path_buf()])
-        .with_delegator_tier(crate::agents::AgentTier::L1Standard)
+        .with_delegator("assistant", crate::agents::AgentTier::L1Standard)
         .with_allowed_target_roles(vec!["engineer".to_string()]);
 
     let result = tool
@@ -709,14 +708,16 @@ async fn delegate_malformed_target_tier_resolves_l1_and_is_not_tier_blocked() {
 /// specific regression #4169 exists to prevent: a dispatch path (like
 /// `ctrl::pm_task::dispatch::persona`, historically) that builds a
 /// `DelegateToAgentTool` with a `config_dir` but no role allowlist must
-/// still be tier-gated.
+/// still be tier-gated. (ADR-0023 update: sub-agent-kind L0 fixture, so the
+/// kind predicate cannot be what refuses this — see
+/// `delegate_l1_to_l0_is_refused`'s note.)
 #[tokio::test]
 async fn delegate_tier_gate_applies_even_without_role_allowlist() {
     let dir = tempfile::tempdir().unwrap();
     write_agent_toml_with_role_and_tier(
         dir.path(),
-        "orchestration-assistant",
-        "assistant",
+        "orchestration-worker",
+        "engineer",
         Some("orchestration"),
     );
 
@@ -726,11 +727,11 @@ async fn delegate_tier_gate_applies_even_without_role_allowlist() {
     // No `.with_allowed_target_roles(...)` call at all.
     let tool = DelegateToAgentTool::new(runner.clone())
         .with_config_dirs(vec![dir.path().to_path_buf()])
-        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+        .with_delegator("assistant", crate::agents::AgentTier::L1Standard);
 
     let result = tool
         .execute(json!({
-            "agent_name": "orchestration-assistant",
+            "agent_name": "orchestration-worker",
             "task": "do orchestration-tier things"
         }))
         .await;
@@ -742,70 +743,76 @@ async fn delegate_tier_gate_applies_even_without_role_allowlist() {
     assert!(runner.invoked.lock().unwrap().is_empty());
 }
 
-/// TRANSITIVE / multi-hop escalation: `assistant (L1) -> izzie (L1 peer) ->
-/// orchestration-assistant (L0)` must be impossible. This builds TWO real
-/// `DelegateToAgentTool` instances — one per hop — using the SAME
-/// construction shape production code uses (role-allowlisted,
-/// tier-declared), and drives them in sequence: hop 1 succeeds (peer-assistant
-/// delegation is legitimate), but when the spawned peer (izzie, itself L1)
-/// attempts hop 2 into the L0 target, ITS OWN `DelegateToAgentTool` (built
-/// with izzie's own L1 tier, exactly as `build_assistant_tier_registry`
-/// would build it for the real izzie subprocess) refuses. No chain of L1
-/// hops can ever reach L0.
+/// TRANSITIVE / multi-hop escalation must be impossible, and ADR-0023 now
+/// severs it at the FIRST edge rather than the second.
+///
+/// CONVERTED from `delegate_multi_hop_l1_peer_to_l0_is_refused`, whose hop 1
+/// (`assistant -> izzie`, a peer) asserted SUCCESS as "peer-assistant
+/// delegation is legitimate". That is no longer true: the owner ratified
+/// "assistants communicate with each other, but never delegate", so the peer
+/// hop is refused outright and the `assistant -> peer -> L0` chain has no
+/// first edge to stand on. Hop 2 is retained UNCHANGED in substance — an
+/// assistant reaching an L0 target directly is still tier-refused — because
+/// the two hops now pin two independent layers: hop 1 the KIND predicate,
+/// hop 2 the tier gate (predicate 3, defense-in-depth) over a sub-agent-kind
+/// L0 target the kind predicate deliberately does not cover.
+/// Test: this function IS the test.
 #[tokio::test]
-async fn delegate_multi_hop_l1_peer_to_l0_is_refused() {
+async fn delegate_multi_hop_assistant_hop_is_refused() {
     let dir = tempfile::tempdir().unwrap();
     write_agent_toml_with_role(dir.path(), "izzie", "assistant");
     write_agent_toml_with_role_and_tier(
         dir.path(),
-        "orchestration-assistant",
-        "assistant",
+        "orchestration-worker",
+        "engineer",
         Some("orchestration"),
     );
 
-    // Hop 1: assistant (L1) -> izzie (L1 peer). Legitimate; must succeed.
+    // Hop 1: assistant -> izzie (a PEER assistant). Now refused by kind, so
+    // the transitive path never gets its first edge.
     let hop1_runner = Arc::new(RecordingRunner {
         invoked: std::sync::Mutex::new(Vec::new()),
     });
     let hop1_tool = DelegateToAgentTool::new(hop1_runner.clone())
         .with_config_dirs(vec![dir.path().to_path_buf()])
         .with_allowed_target_roles(vec!["assistant".to_string()])
-        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+        .with_delegator("assistant", crate::agents::AgentTier::L1Standard);
     let hop1_result = hop1_tool
         .execute(json!({ "agent_name": "izzie", "task": "hand off to izzie" }))
         .await;
     assert!(
-        !hop1_result.is_error(),
-        "hop 1 (L1 -> L1 peer) must succeed: {}",
-        hop1_result.content()
+        hop1_result.is_error(),
+        "hop 1 (assistant -> peer assistant) must now be refused by the kind rule"
+    );
+    assert!(
+        hop1_runner.invoked.lock().unwrap().is_empty(),
+        "the peer's runner must never be invoked"
     );
 
-    // Hop 2: izzie (itself L1 — no tier declared, so `tier()` resolves
-    // L1Standard) attempts to reach the L0 target. Built exactly as
-    // `build_assistant_tier_registry` builds izzie's OWN delegate tool when
-    // izzie is spawned: role-allowlisted to `ASSISTANT_ALLOWED_DELEGATE_ROLES`-
-    // equivalent, tier-declared from izzie's OWN resolved config.
+    // Hop 2: an assistant attempting to reach an L0 SUB-AGENT directly.
+    // Outside the kind rule (the target is not an assistant), so this is the
+    // tier gate alone — the layer that must keep holding on its own.
     let hop2_runner = Arc::new(RecordingRunner {
         invoked: std::sync::Mutex::new(Vec::new()),
     });
     let hop2_tool = DelegateToAgentTool::new(hop2_runner.clone())
         .with_config_dirs(vec![dir.path().to_path_buf()])
-        .with_allowed_target_roles(vec!["assistant".to_string()])
-        .with_delegator_tier(crate::agents::AgentTier::L1Standard);
+        .with_allowed_target_roles(vec!["engineer".to_string()])
+        .with_delegator("assistant", crate::agents::AgentTier::L1Standard);
     let hop2_result = hop2_tool
         .execute(json!({
-            "agent_name": "orchestration-assistant",
+            "agent_name": "orchestration-worker",
             "task": "escalate to orchestration tier"
         }))
         .await;
 
     assert!(
         hop2_result.is_error(),
-        "hop 2 (L1 peer -> L0) must be refused — no chain of L1 hops may reach L0"
+        "hop 2 (L1 -> L0 sub-agent) must be refused by the tier gate"
     );
     assert!(
         hop2_runner.invoked.lock().unwrap().is_empty(),
-        "the L0 target's runner must never be invoked via the transitive path"
+        "the L0 target's runner must never be invoked"
     );
 }
 
@@ -876,6 +883,219 @@ async fn no_tier_and_no_role_gate_preserves_cheap_existence_check() {
     assert!(
         !result.is_error(),
         "a caller opted into neither gate must keep the cheap existence-only check: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+// ============================================================================
+// ADR-0023: delegation authority is governed by KIND, never by tier order.
+//
+// "Assistants can communicate with each other, but never delegate." These
+// tests are written entirely against ROLE/KIND fixtures. None of them
+// constructs an expectation from a tier value, which is the property that
+// makes them survive the ratified inversion moving assistants from L1 to L0 —
+// see `delegate_assistant_to_assistant_is_refused_at_every_tier_pairing`,
+// which pins that explicitly by sweeping every tier pairing at once.
+// ============================================================================
+
+/// The rule, in its most direct form: an assistant may not delegate to
+/// another assistant.
+///
+/// Why: a total order over tiers cannot forbid an edge WITHIN a rank, so the
+/// shipped tier gate was structurally incapable of expressing this — it only
+/// appeared to, while every assistant happened to be L1 and L0 was empty.
+/// This is the check that actually carries the rule.
+/// What: assistant source, assistant target, no tier involved in the setup
+/// beyond the fail-closed default; refused before the runner is touched.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn delegate_assistant_to_assistant_is_refused() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "izzie", "assistant");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_delegator("assistant", crate::agents::AgentTier::L1Standard);
+
+    let result = tool
+        .execute(json!({ "agent_name": "izzie", "task": "look into this for me" }))
+        .await;
+
+    assert!(
+        result.is_error(),
+        "an assistant must not be able to delegate to a peer assistant"
+    );
+    assert!(
+        runner.invoked.lock().unwrap().is_empty(),
+        "runner must never be reached: {}",
+        result.content()
+    );
+}
+
+/// THE renumbering-proof test. The peer prohibition must hold for EVERY
+/// pairing of delegator and target tier — including both-L0, the pairing the
+/// ratified inversion creates and the one a tier-ordering gate is
+/// structurally incapable of refusing.
+///
+/// Why: if a future change moves assistants from L1 to L0 (as ADR-0023
+/// decision 3 requires), or swaps the labels, or adds a third tier, a gate or
+/// a test phrased in tier values silently stops testing the real rule. This
+/// test cannot: its fixtures are built from ROLES, and it asserts the SAME
+/// refusal across all four tier combinations, so no renumbering can move it
+/// into a passing-but-vacuous state. A regression to proxy-based (tier)
+/// encoding fails here on at least the both-L0 and both-L1 rows.
+/// What: sweeps {L1,L0} x {L1,L0} for an assistant->assistant edge; every row
+/// must refuse and must not reach the runner.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn delegate_assistant_to_assistant_is_refused_at_every_tier_pairing() {
+    use crate::agents::AgentTier::{L0Orchestration, L1Standard};
+
+    for (delegator_tier, target_tier_decl) in [
+        (L1Standard, None),
+        (L1Standard, Some("l0")),
+        (L0Orchestration, None),
+        // The pairing the ratified inversion creates: BOTH endpoints L0. A
+        // tier-ordering gate permits this edge for any numbering whatsoever.
+        (L0Orchestration, Some("l0")),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_toml_with_role_and_tier(dir.path(), "peer", "assistant", target_tier_decl);
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone())
+            .with_config_dirs(vec![dir.path().to_path_buf()])
+            .with_delegator("assistant", delegator_tier);
+
+        let result = tool
+            .execute(json!({ "agent_name": "peer", "task": "peer work" }))
+            .await;
+
+        assert!(
+            result.is_error(),
+            "assistant -> assistant must be refused for delegator {delegator_tier:?} / \
+             target tier {target_tier_decl:?} — the rule is about KIND, not tier order"
+        );
+        assert!(
+            runner.invoked.lock().unwrap().is_empty(),
+            "runner must never be reached for delegator {delegator_tier:?} / target tier \
+             {target_tier_decl:?}"
+        );
+    }
+}
+
+/// The permitted edge must stay permitted: assistant -> sub-agent.
+///
+/// Why: a rule that refused everything would be a worse regression than the
+/// hole it closed. Delegation to specialists is the entire point of the
+/// mechanism.
+/// What: every sub-agent role in `ASSISTANT_ALLOWED_DELEGATE_ROLES` (minus
+/// the assistant kind itself) reaches the runner.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn delegate_assistant_to_sub_agent_still_succeeds() {
+    for (name, role) in [
+        ("engineer", "engineer"),
+        ("qa-agent", "qa"),
+        ("research-agent", "researcher"),
+        ("docs-agent", "documentation"),
+        ("local-ops-agent", "ops"),
+        ("plan-agent", "planner"),
+    ] {
+        let dir = tempfile::tempdir().unwrap();
+        write_agent_toml_with_role(dir.path(), name, role);
+
+        let runner = Arc::new(RecordingRunner {
+            invoked: std::sync::Mutex::new(Vec::new()),
+        });
+        let tool = DelegateToAgentTool::new(runner.clone())
+            .with_config_dirs(vec![dir.path().to_path_buf()])
+            .with_delegator("assistant", crate::agents::AgentTier::L1Standard);
+
+        let result = tool
+            .execute(json!({ "agent_name": name, "task": "do the specialist work" }))
+            .await;
+
+        assert!(
+            !result.is_error(),
+            "assistant -> {role} sub-agent must still succeed: {}",
+            result.content()
+        );
+        assert_eq!(
+            runner.invoked.lock().unwrap().len(),
+            1,
+            "the {role} sub-agent must be spawned"
+        );
+    }
+}
+
+/// ADR-0023 predicate 1's scope caveat, pinned: `pm`/`ctrl`-as-orchestrator
+/// sit OUTSIDE the assistant/sub-agent model and must NOT be newly blocked.
+///
+/// Why: this fix must not silently change orchestrator behavior. `pm`
+/// delegating to an assistant is a pre-existing, separately-trusted capability
+/// this rule does not revisit; a regression that "tightened" it would be a
+/// scope violation, not a bonus.
+/// What: an `orchestrator`-role delegator reaches an `assistant`-role target.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn delegate_kind_gate_does_not_touch_orchestrator_sources() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "izzie", "assistant");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_delegator("orchestrator", crate::agents::AgentTier::L0Orchestration);
+
+    let result = tool
+        .execute(json!({ "agent_name": "izzie", "task": "orchestrator hand-off" }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "an orchestrator source is outside the kind rule and must be unaffected: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// A delegator that declares no identity at all keeps pre-ADR-0023 behavior.
+///
+/// Why: `runtime::pm_mode::run_pm` constructs the tool with neither identity
+/// nor `config_dirs`; pinning the `None` semantics here documents that the
+/// kind predicate is opt-in ON IDENTITY (not on policy) and that nothing
+/// changed for that site.
+/// What: no `with_delegator` call, assistant-role target, still reaches the
+/// runner.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn delegate_without_declared_identity_skips_the_kind_gate() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "izzie", "assistant");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["assistant".to_string()]);
+
+    let result = tool
+        .execute(json!({ "agent_name": "izzie", "task": "undeclared caller" }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "an undeclared delegator identity must leave the kind gate a no-op: {}",
         result.content()
     );
     assert_eq!(runner.invoked.lock().unwrap().len(), 1);

--- a/crates/trusty-agents/src/tools/delegate_tests.rs
+++ b/crates/trusty-agents/src/tools/delegate_tests.rs
@@ -401,7 +401,7 @@ async fn delegate_assistant_role_gate_allows_worker_role() {
     assert_eq!(runner.invoked.lock().unwrap().len(), 1);
 }
 
-/// CONVERTED by ADR-0023 (was `delegate_assistant_role_gate_allows_peer_
+/// CONVERTED by ADR-0024 (was `delegate_assistant_role_gate_allows_peer_
 /// assistant_role`, which asserted the OPPOSITE): the Izzie <-> cto-assistant
 /// peer-consult lane is now CLOSED. The owner ratified "assistants can
 /// communicate with each other, but never delegate", so a peer assistant is
@@ -567,7 +567,7 @@ fn session_id_gate_normalizes_blank_to_none() {
 /// An L1-tier delegator must be refused when the resolved target's own
 /// declared tier is L0 (orchestration). The runner must never be invoked.
 ///
-/// ADR-0023 update: the L0 fixture's role is now `engineer`, not `assistant`.
+/// ADR-0024 update: the L0 fixture's role is now `engineer`, not `assistant`.
 /// With an assistant-role target this test would be satisfied by the KIND
 /// predicate before the tier gate ever ran, silently becoming a duplicate of
 /// `delegate_assistant_to_assistant_is_refused` and leaving predicate 3 (the
@@ -615,7 +615,7 @@ async fn delegate_l1_to_l0_is_refused() {
 /// The counter-test: an L0-tier delegator reaching an L1 (standard) target
 /// must succeed — this must not break legitimate downward delegation.
 ///
-/// ADR-0023 update: the target is now a sub-agent (`engineer`), not `izzie`
+/// ADR-0024 update: the target is now a sub-agent (`engineer`), not `izzie`
 /// (role `assistant`). An assistant target would now be refused by the kind
 /// predicate for reasons that have nothing to do with tier, which would make
 /// this tier test assert the opposite of what it is named for.
@@ -650,7 +650,7 @@ async fn delegate_l0_to_l1_succeeds() {
 /// ("this instance was never asked to enforce the kind or tier gates") and
 /// are both set by the single `with_delegator` call.
 ///
-/// ADR-0023 update (was `delegator_tier_defaults_to_none_on_construction`):
+/// ADR-0024 update (was `delegator_tier_defaults_to_none_on_construction`):
 /// the two fields are asserted TOGETHER because the builder sets them
 /// together on purpose — a call site must not be able to declare its tier
 /// while leaving its kind undeclared, which is the structural property that
@@ -708,7 +708,7 @@ async fn delegate_malformed_target_tier_resolves_l1_and_is_not_tier_blocked() {
 /// specific regression #4169 exists to prevent: a dispatch path (like
 /// `ctrl::pm_task::dispatch::persona`, historically) that builds a
 /// `DelegateToAgentTool` with a `config_dir` but no role allowlist must
-/// still be tier-gated. (ADR-0023 update: sub-agent-kind L0 fixture, so the
+/// still be tier-gated. (ADR-0024 update: sub-agent-kind L0 fixture, so the
 /// kind predicate cannot be what refuses this — see
 /// `delegate_l1_to_l0_is_refused`'s note.)
 #[tokio::test]
@@ -743,7 +743,7 @@ async fn delegate_tier_gate_applies_even_without_role_allowlist() {
     assert!(runner.invoked.lock().unwrap().is_empty());
 }
 
-/// TRANSITIVE / multi-hop escalation must be impossible, and ADR-0023 now
+/// TRANSITIVE / multi-hop escalation must be impossible, and ADR-0024 now
 /// severs it at the FIRST edge rather than the second.
 ///
 /// CONVERTED from `delegate_multi_hop_l1_peer_to_l0_is_refused`, whose hop 1
@@ -889,7 +889,7 @@ async fn no_tier_and_no_role_gate_preserves_cheap_existence_check() {
 }
 
 // ============================================================================
-// ADR-0023: delegation authority is governed by KIND, never by tier order.
+// ADR-0024: delegation authority is governed by KIND, never by tier order.
 //
 // "Assistants can communicate with each other, but never delegate." These
 // tests are written entirely against ROLE/KIND fixtures. None of them
@@ -941,7 +941,7 @@ async fn delegate_assistant_to_assistant_is_refused() {
 /// ratified inversion creates and the one a tier-ordering gate is
 /// structurally incapable of refusing.
 ///
-/// Why: if a future change moves assistants from L1 to L0 (as ADR-0023
+/// Why: if a future change moves assistants from L1 to L0 (as ADR-0024
 /// decision 3 requires), or swaps the labels, or adds a third tier, a gate or
 /// a test phrased in tier values silently stops testing the real rule. This
 /// test cannot: its fixtures are built from ROLES, and it asserts the SAME
@@ -1035,7 +1035,7 @@ async fn delegate_assistant_to_sub_agent_still_succeeds() {
     }
 }
 
-/// ADR-0023 predicate 1's scope caveat, pinned: `pm`/`ctrl`-as-orchestrator
+/// ADR-0024 predicate 1's scope caveat, pinned: `pm`/`ctrl`-as-orchestrator
 /// sit OUTSIDE the assistant/sub-agent model and must NOT be newly blocked.
 ///
 /// Why: this fix must not silently change orchestrator behavior. `pm`
@@ -1068,7 +1068,7 @@ async fn delegate_kind_gate_does_not_touch_orchestrator_sources() {
     assert_eq!(runner.invoked.lock().unwrap().len(), 1);
 }
 
-/// A delegator that declares no identity at all keeps pre-ADR-0023 behavior.
+/// A delegator that declares no identity at all keeps pre-ADR-0024 behavior.
 ///
 /// Why: `runtime::pm_mode::run_pm` constructs the tool with neither identity
 /// nor `config_dirs`; pinning the `None` semantics here documents that the


### PR DESCRIPTION
Closes #4201
Refs **ADR-0024**, "Assistants Are Level-0 Delegators; Sub-Agents Are In-Process, Single-Edge Leaves That Never Delegate".

> **ADR renumber note.** This work was implemented against the delegation ADR while it was numbered **0023**. An unrelated ADR — `0023-worktree-authority-existence-vs-ownership` (PR #4237) — took that slot on `main` during review, so the delegation ADR was committed as **0024** on branch `docs/delegation-model-and-agent-standard` (PR #4243, open, not yet merged). Commit `ddd18c7a` updates all 45 in-code references plus the CHANGELOG from ADR-0023 to ADR-0024, and cites the ADR by title where it anchors, since the file is not on `main` yet. **Commit `8b082082`'s message says "ADR-0023" and cannot be rewritten cleanly after pushing — read it as ADR-0024.** Every ADR reference in the working tree is correct.

Two delegation-gate defects, landed as two commits on one branch because they touch adjacent code.

---

## Commit 1 — `9b267069` — the persona path's missing role allowlist (#4201)

`crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs` built its `DelegateToAgentTool` with the #4169 L0/L1 tier gate but WITHOUT the role allowlist its sibling path applies:

```rust
// persona.rs (before)                    // history.rs (~415, correct)
DelegateToAgentTool::new(runner)          if let Some(roles) = allowed_target_roles {
    .with_config_dir(config_dir.clone())      delegate_tool = delegate_tool
    .with_session_id(sid.clone())                 .with_allowed_target_roles(roles);
    .with_delegator_tier(delegator_tier)  }
// .with_allowed_target_roles(...) MISSING
```

An assistant-tier persona could therefore delegate to `pm` (role `orchestrator`) or `ctrl` (role `controller`) — roles absent from `ASSISTANT_ALLOWED_DELEGATE_ROLES` entirely — and `run_subagent` arms the spawned subprocess from the CHILD's own role, handing an unrestricted orchestrator registry (shell, `write_file`, unrestricted `delegate_to_agent`) to a persona that ingests untrusted content.

**Both defense-in-depth layers were ineffective on this path.** The tier gate can only refuse an `L0Orchestration` TARGET, and no bundled agent declares `tier = "l0"`, so it was structurally present but inert.

`allowed_target_roles` was verified NOT to be in scope in `persona.rs` — it is computed inside `history.rs`'s private `ctrl_delegate_posture`. Rather than threading it, both gates now come from one function, `persona_gate::build_persona_delegate_tool`, reusing the same single-source-of-truth constant (`persona.rs` sits at 479/500 SLOC; `persona_gate.rs` already exists as its extraction point).

### Third construction site — checked, as asked

| Site | State |
| --- | --- |
| `ctrl/pm_task/dispatch/history.rs:412` | Correctly gated (via `ctrl_delegate_posture`) |
| `ctrl/pm_task/dispatch/persona.rs` | **Was ungated — fixed** |
| `runtime/pm_mode.rs:113` (`run_pm`) | **Correctly ungated, deliberately.** It attaches no `config_dirs` at all, so the entire pre-flight block is skipped; documented inline at `pm_mode.rs:96-110`. `pm` is the trusted top-level orchestrator and is unreachable as a delegation TARGET from any assistant. Left alone. |

A **fourth** site exists that the issue did not enumerate: `runtime/tool_registry.rs:557` (`build_assistant_tier_registry`, the `--direct`/`--agent` subprocess path). It was already correctly gated.

### Known remaining gap (out of scope, as instructed)

No bundled agent declares `tier = "l0"`, so every persona defaults to `L1Standard` and the #4200 tier gate's rejection arm (`target_tier == L0Orchestration && delegator_tier != L0Orchestration`) can never fire. **The tier gate stays inert until the in-flight tier-model change moving assistants to L0 lands.** Not fixed here.

---

## Commit 2 — `8b082082` — delegation authority governed by KIND, not tier order (ADR-0024)

### The defect

The tier gate is written in terms of TIER ORDERING. **A total order cannot forbid an edge WITHIN a rank, for any numbering whatsoever.** It only appeared to express the peer prohibition because every assistant was L1 and L0 was empty, making "assistant → assistant" and "L1 → L1" the same event. Under the ratified model (all assistants become L0) the check goes vacuous for exactly the case it must forbid — and `ASSISTANT_TIER_ROLE` is deliberately *in* `ASSISTANT_ALLOWED_DELEGATE_ROLES`, so assistant→assistant is permitted today and would stay permitted after the inversion.

### The fix

`agents/delegation.rs` (new) holds the predicate once:

```rust
pub(crate) fn is_assistant_kind(role: &str) -> bool { role == ASSISTANT_TIER_ROLE }
pub(crate) fn kind_refuses_delegation(source_role: &str, target_role: &str) -> bool {
    is_assistant_kind(source_role) && is_assistant_kind(target_role)
}
```

- **KIND is `agent.role`**, per ADR-0024 predicate 1 — the existing, already-load-bearing security discriminator. Deliberately **not** `AgentInfo::kind`: that field is picker-grouping metadata, its own doc comment forbids this use, and it defaults to `"assistant"` for every agent (including `engineer`), so it discriminates nothing. No kind attribute was invented.
- **Enforced in the shared `execute()` choke point**, not as a per-call-site builder opt-in — the ADR's explicit requirement, and the direct lesson of commit 1.
- **`with_delegator_tier` is superseded by `with_delegator(role, tier)`.** Identity is declared in ONE call, so a site cannot take the tier gate while missing the kind gate. This is the structural answer to "a forgotten call site cannot bypass it": there is no call that does only one.
- **No tier value is read** by the new predicate, which is what makes it survive renumbering.

### Predicate 3 (tier ordering) is retained as defense-in-depth and is NOT expected to block anything additional

Stating this explicitly so a future reader does not conclude the tier gate was the fix and let predicates 1–2 rot: with kind enforced and the ratified tier assignment in place, the source is always L0 and the target always L1, so the tier condition is already satisfied whenever it runs. It is kept because it reads a **different config field** (`tier`) through independent code, so a defect in the kind check does not by itself open the graph. It was NOT deleted as dead code.

### Sites changed

| Site | Change |
| --- | --- |
| `tools/delegate.rs` `execute()` | Kind predicate added — the single enforcement point |
| `ctrl/pm_task/dispatch/persona.rs` (via `persona_gate.rs`) | Routes through `with_delegator` |
| `ctrl/pm_task/dispatch/history.rs:412` | Routes through `with_delegator(pm_cfg.agent.role, …)` |
| `runtime/tool_registry.rs:557` | Routes through `with_delegator(ASSISTANT_TIER_ROLE, …)` — that role is structural, `build_registry_for_agent` routes into this function on exactly that role and no other |
| `api/server/agent_subagents.rs` | Reads the SAME predicate so the route cannot advertise a target the gate refuses ("no second copy of any gate") |
| `runtime/pm_mode.rs` | **Untouched.** No `config_dirs`, so the pre-flight block is skipped entirely; it is ADR-0024 predicate 1's explicit orchestrator scope caveat. |

**pm/ctrl orchestrator delegation is NOT blocked by this change** — verified and pinned by `delegate_kind_gate_does_not_touch_orchestrator_sources`. A non-assistant source is outside the rule's population.

### Observability gap closed

`delegate.rs`'s success path emitted no log at all — the mechanical reason a silently-non-matching gate produces zero signal. One `tracing::info!` now records source role, source-is-assistant-kind, delegator tier, and whether the role allowlist was enforced, on the authorized path. Identity metadata only: no task body, no credentials, no user content.

### Known regression — stated, not hidden

**This closes the Izzie ↔ cto-assistant peer-consult lane, and the replacement mechanism does not exist.** "Assistants communicate with each other" has no implemented agent-to-agent messaging path for trusty-agents personas today — ADR-0019 is accepted but unimplemented, and a bus-based messaging spec is being drafted separately. This removes a working capability with no immediate substitute. The owner was told this explicitly and authorized it anyway.

---

## Tests — verified non-vacuous

Every gate test was run against the **unfixed** code to confirm it fails.

**Commit 1** — with `.with_allowed_target_roles(...)` removed from `build_persona_delegate_tool`:

```
test persona_delegate_tool_refuses_controller_role_target ... FAILED
test persona_delegate_tool_refuses_orchestrator_role_target ... FAILED
test result: FAILED. 3 passed; 2 failed
```

**Commit 2** — with the kind predicate stubbed to `false`:

```
test ctrl::pm_task::dispatch::persona::tests::persona_delegate_tool_refuses_peer_assistant_target ... FAILED
test tools::delegate::tests::delegate_assistant_to_assistant_is_refused ... FAILED
test tools::delegate::tests::delegate_assistant_to_assistant_is_refused_at_every_tier_pairing ... FAILED
test tools::delegate::tests::delegate_multi_hop_assistant_hop_is_refused ... FAILED
test tools::delegate::tests::delegate_peer_assistant_is_refused_despite_role_allowlist ... FAILED
test result: FAILED. 38 passed; 5 failed
```

### The renumbering-proof test

`delegate_assistant_to_assistant_is_refused_at_every_tier_pairing` sweeps **all four** tier pairings — {L1,L0} × {L1,L0} — for an assistant→assistant edge and requires refusal in every row, including **both-L0**, the pairing the inversion creates and the one a tier-ordering gate permits for any numbering. Fixtures are built from ROLES; the assertion never mentions a tier variant. It is named for the rule, not the labels. It genuinely fails without the fix (row 1 above).

### Tests converted, not deleted

Each keeps a comment recording the reversal:

- `delegate_assistant_role_gate_allows_peer_assistant_role` → `delegate_peer_assistant_is_refused_despite_role_allowlist`. Kept deliberately: the allowlist still contains `"assistant"` and the edge is refused anyway — the direct proof that the kind rule is a property of the CODE, not of curated data.
- `delegate_multi_hop_l1_peer_to_l0_is_refused` → `delegate_multi_hop_assistant_hop_is_refused`. Its hop 1 asserted the peer lane SUCCEEDS; the chain is now severed at its first edge.
- `persona_delegate_tool_allows_peer_assistant_role_target` → `persona_delegate_tool_refuses_peer_assistant_target`.
- `delegate_l1_to_l0_is_refused`, `delegate_l0_to_l1_succeeds`, `delegate_tier_gate_applies_even_without_role_allowlist`, and three `/subagents` route tests had their L0/peer fixtures changed from `assistant` role to a **sub-agent role**, so the kind predicate cannot mask the tier gate and leave them green-but-vacuous.

---

## Commit 3 — `ddd18c7a` — CI lint fix + ADR renumber

**No behavior change.** Two corrections:

**(a) The `Test: doc-comment pointer lint` CI job failed** (`scripts/check_test_pointers.sh`), the one check of 24 that did not pass:

```
FAIL: crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_gate.rs:63: Test: pointer cites
`persona_delegate_tool_allows_peer_assistant_role_target` — no
`fn persona_delegate_tool_allows_peer_assistant_role_target(` or
`mod persona_delegate_tool_allows_peer_assistant_role_target` found in crate `crates/trusty-agents`.
test-pointers: 1 dangling pointer(s), 0 stale allowlist entries — FAILED.
```

The lint was right. Commit 2 renamed that test to `persona_delegate_tool_refuses_peer_assistant_target` when the peer-consult lane closed, but left `build_persona_delegate_tool`'s `Test:` pointer citing the old name. The pointer now cites the real test and records the rename inline. No doc comment was deleted, no allowlist entry added, the lint was not weakened.

**(b) ADR-0023 → ADR-0024** across 45 in-code references and the CHANGELOG (see the renumber note at the top). Deliberately left alone: `0023_jira_ingestion` in `trusty-git-analytics` (a SQL migration name) and float literals containing `0023` in `trusty-common`'s embedder test data — neither is an ADR reference.

## Gates

Re-run after commit `ddd18c7a`, including the gate CI caught that was not in the original local set:

```
bash scripts/check_test_pointers.sh                     → test-pointers: 0 dangling pointers — OK.   (exit 0)
cargo fmt --check                                       → clean                                       (exit 0)
cargo clippy -p trusty-agents --all-targets -D warnings → clean
cargo test -p trusty-agents                             → 2919 passed; 0 failed; 11 ignored           (exit 0)
bash scripts/check_line_cap.sh                          → 7 allowlisted, 0 violations — OK            (exit 0)
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
