### PR TITLE
docs: delegation model ADR + bus messaging and canonical agent standard specs

### DIFF
--- a/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
+++ b/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
@@ -1,0 +1,877 @@
+# 0024. Assistants Are Level-0 Delegators; Sub-Agents Are In-Process, Single-Edge Leaves That Never Delegate
+
+- **Status:** Proposed
+- **Date:** 2026-07-28
+- **Scope:** crate `trusty-agents` (the `delegate_to_agent` / `dispatch_task` boundary; the L0/L1 tier model, #4167/#4200; touches the `trusty-code` cross-product bridge target and the Sub-agents API/pane, `#4029`/`#4211`)
+- **Reversibility Cost:** High — reverses/re-scopes shipped, tested, owner-directed machinery from epic #4021 (#4026/#4027/#4028/#4211, merged within 48 hours of this ADR), INVERTS the population assignment of the L0/L1 tier model merged the SAME DAY as this decision (PR #4200, squash `ada4d351`), and requires new, currently nonexistent machinery (an editable sub-agent whitelist, an assistant-to-assistant messaging primitive, and a tool-call-counted skill/delegate router)
+- **Decision Drivers:** Product framing clarity (the Sub-agents pane could not honestly present a name that means two different things), the owner's rejection of a UI-only fix, the owner's explicit generalization of the YOLO risk posture to every assistant, a documentation gap (DOC-57 does not yet cover Sub-agents at all, #4182), and the owner's own PM/trusty-mpm prior art as an explicit analogy with an owner-named limit
+- **Supersedes / Superseded by:** — this ADR's OWN prior revision (same document, same day) recommended a hand-authored constant (`ASSISTANT_ALLOWED_DELEGATE_ROLES`-style) as the reachable-target model; decision 2 below explicitly supersedes that recommendation in favor of an editable config whitelist. See "Conflicts and open questions" for the still-unresolved tension with the owner's 2026-07-26 ruling on epic #4021's OQ-2.
+
+## Context
+
+### 1. Five decisions, verbatim, in the order they were given
+
+This ADR was originally drafted against a single decision (item 1 below). A
+routing error meant four more, given in the same review, did not reach the
+first draft. All five are recorded here as one coherent whole; the first
+draft's Context/Consequences on item 1 are retained and NOT softened, per
+explicit instruction — they are extended, not replaced, by what follows.
+
+1. *"This isn't a UI thing. Let's make an ADR. Sub-Agents are always
+   in-process, Assistants can communicate with each other, but never
+   delegate."*
+2. *"Let's make agents a configuration with a whitelist (editable), and
+   re-use existing agents."*
+3. *"So let's also firm up the distinction. Assistants are a level 0 agent,
+   like a PM, that can delegate to sub-agents and communicate with each
+   other."*
+4. *"Sub-agents can never delegate and talk out of processes. The only
+   respond to an assistant."* [sic; read as "They only respond to an
+   assistant."]
+5. *"Yes on the YOLO."* — ratifying, on direct question, that the YOLO risk
+   posture (previously scoped to a single, rare, not-yet-instantiated L0
+   orchestration persona, #4167) generalizes to every assistant now that
+   every assistant is L0 under decision 3.
+
+Plus, on the skill-vs-delegate routing question: *"The answer is that it
+depends on the complexity of the task,"* then *"Let's use our 3 tool call
+threshold."*
+
+**The complete ratified model**, stated as one whole:
+
+- **ASSISTANT = tier L0, PM-like.** Delegates DOWN to sub-agents.
+  Communicates LATERALLY with other assistants, never delegates to them.
+  Holds YOLO/owner-accepted responsibility. Calls skills DIRECTLY as well
+  as delegating.
+- **SUB-AGENT = tier L1.** Always in-process. LEAF NODE: never delegates
+  (not up, not lateral, not at all); never talks out-of-process; responds
+  only to its invoking assistant. Exactly one edge.
+- **REACHABLE SUB-AGENT SET = an editable config whitelist over EXISTING
+  host agents** — not a hand-authored Rust constant. This supersedes this
+  same document's earlier recommendation (see the header's "Supersedes"
+  note and "Conflicts and open questions").
+- **ROUTING** between an assistant's own skill and its sub-agent for the
+  same domain = task complexity, measured by a 3-tool-call threshold: ≤3
+  expected tool calls, call the skill directly; more, delegate to the
+  sub-agent that owns that domain.
+
+### 2. Current state: two delegation mechanisms exist today (retained from the first draft)
+
+**`delegate_to_agent` — in-process, lane 2.**
+`crates/trusty-agents/src/tools/delegate.rs` implements `DelegateToAgentTool`,
+gated by two independent checks at one choke point (`delegate.rs:346-448`):
+a role allowlist, `runtime::tool_registry::ASSISTANT_ALLOWED_DELEGATE_ROLES`
+(`tool_registry.rs:137-145`: `engineer`, `qa`, `researcher`, `documentation`,
+`ops`, `planner`, and `ASSISTANT_TIER_ROLE` — "assistant" — itself, the
+constant this decision's clause about lateral communication directly
+contradicts), and the L0/L1 tier gate (#4169/#4200, detailed in §3 below).
+The role allowlist is applied at only two of the three sites that construct
+a `DelegateToAgentTool` for an assistant-tier caller —
+`runtime::tool_registry::build_assistant_tier_registry`
+(`tool_registry.rs:556-566`) and
+`ctrl::pm_task::dispatch::history::ctrl_delegate_posture`
+(`history.rs:412-417`) — while the third,
+`ctrl::pm_task::dispatch::persona::run_pm_task_with_persona`
+(`persona.rs:307-310`, backing the REPL `/agent` command), never calls
+`.with_allowed_target_roles(...)`. **This gap is now independently confirmed
+in issue #4201's second comment (2026-07-28), filed during this ADR's
+research:** neither the role allowlist NOR the tier gate is effective on
+that path — the tier gate is "structurally in place" but inert, because no
+bundled agent declares `tier = "l0"`, so the target-tier check
+(`target_tier == L0Orchestration`) never fires. Concretely, today, the REPL
+`/agent` path can delegate an assistant persona into `pm` (role
+`orchestrator`), gated by nothing.
+
+**`dispatch_task` — out-of-process, lane 3, the "cross-product bridge."**
+`crates/trusty-agents/src/tools/pm_bridge.rs` / `cross_product.rs`. A
+bridge-owned floor, `NON_CODING_TARGETS = ["research", "ticketing"]`
+(`cross_product.rs:63`), intersected with a per-agent `[subagents].allowed`
+TOML list (`SubagentAllowSet`, `agents::config::SubagentsConfig`,
+`config.rs:239-243`) — absent config denies everything, deny-by-default.
+Results are wrapped in a structurally-enforced `ProposalEnvelope` that can
+never carry `Disposition::Action` (`cross_product.rs:375-399`), per DOC-41
+§5.5's absolute propose-not-authorize rule. `ticketing-agent` declares
+`role = "ticketing"` (`.trusty-agents/agents/ticketing-agent.toml:3`), not a
+member of `ASSISTANT_ALLOWED_DELEGATE_ROLES` — unreachable in-process today,
+reachable only via this cross-product leg (ported into `trusty-code`'s own
+roster by #4027, closed/merged: `crates/trusty-code/src/assets/agents/
+ticketing.md`). `GET /api/agents/:name/subagents` (`agent_subagents.rs`,
+#4029/#4211) is the pane that surfaced this asymmetry and, in its own module
+doc, calls both mechanisms "the two delegation mechanisms an agent may
+reach" — the terminology decision 1 overturns.
+
+### 3. The L0/L1 tier model as SHIPPED (PR #4200) — and how decision 3 inverts its population
+
+Epic #4167's owner decision (2026-07-27, quoted in the issue): *"Let's
+create a level 0 - orchestration assistant for this purpose, with a YOLO
+responsibility on the owner. Standard assistants are level 1, tied to
+option 2."* The shipped model (`config.rs:680-713`, PR #4200, squash
+`ada4d351` — the tip commit on this branch's history at the time of this
+ADR):
+
+- `AgentTier::L1Standard` is `#[default]` — "every accessor that falls back
+  to `Default::default()`... lands on the restricted tier."
+- `AgentTier::L0Orchestration` — "PM-tier grants; YOLO risk posture...
+  Only reachable by an EXPLICIT `tier = "l0"`... declaration — never a
+  default, never inferred from `role`."
+- Crucially, the doc comment states plainly: *"L1 ('standard assistant') is
+  TODAY'S `assistant`/`cto-assistant`/`izzie`"* (`config.rs:687-688`,
+  emphasis added). **Under the model as merged hours before this decision,
+  the entire existing assistant-persona population is L1 — the RESTRICTED
+  tier — and L0 was reserved for a new, not-yet-authored, rare orchestration
+  persona.** No bundled agent declares `tier = "l0"` anywhere in
+  `.trusty-agents/agents/*.toml`; cross-checked directly against the live
+  Sub-agents pane, which — per the routing coordinator — "renders tier l1"
+  for every agent, `cto-assistant` included.
+- The one-directional gate (`delegate.rs:361-438`) blocks exactly one
+  direction: `target_tier == L0Orchestration && delegator_tier !=
+  L0Orchestration`. Its purpose, as shipped, was to stop an untrusted,
+  content-ingesting L1 STANDARD ASSISTANT from delegating into a trusted,
+  YOLO-authorized L0 orchestration persona.
+- Capability grants were explicitly deferred: *"This PR defines the tier and
+  its one-directional delegation boundary ONLY; it grants L0 no actual
+  capabilities (those are #4170-#4173) and creates no L0 persona
+  instance"* (`config.rs:691-693`). Checking those four follow-ups: **only
+  #4171 (session-state read access) is CLOSED/shipped** — the other three,
+  #4170 (GitHub PR/CI tool surface), #4172 (cross-project store/git
+  scoping), and #4173 (shell/build/test execution grant), are all still
+  OPEN. Concretely, the only tier-conditioned capability delta that exists
+  in code today is `crate::tools::session_state::session_state_tools`
+  returning real tools for L0 and an empty vector for L1
+  (`tool_registry.rs:597-611`, #4171). The 12-tool git surface
+  (`tools::git_tools::git_tools`, including `commit`/`push`/`pull`/
+  `checkout`/`create_branch`) is registered UNCONDITIONALLY inside
+  `build_assistant_tier_registry` for every assistant-tier persona regardless
+  of tier (`tool_registry.rs:514-518`) — broader than the module doc's own
+  gloss, which undersells it as "`git_log`/`git_status`" only
+  (`tool_registry.rs:450`) — and no shell/bash tool is registered for the
+  assistant tier at all. **Decision 3 inverts this model's population
+  assignment: it does not create a new, rare L0 persona above the existing
+  assistants — it declares the EXISTING assistant population (izzie,
+  cto-assistant, personal-assistant, ctrl) to BE L0.** See "Consequences"
+  for whether the one-directional gate, unchanged, still expresses a
+  coherent rule once the population it protects is inverted.
+
+### 4. The two-days-prior owner ruling this decision revises (retained)
+
+Epic #4021's OQ-2 asked whether cross-product delegation should return as a
+legitimate runtime delegation primitive. On 2026-07-26 the owner ruled
+(issue #4021 comment): **"OQ-2 this directive supersedes #3816's subagent
+drop (external cross-product delegation returns; the drop applied to
+internal machinery)."** Two days before decision 1, the owner explicitly
+called cross-product delegation a legitimate sub-agent mechanism — the
+opposite of "Sub-Agents are always in-process." The same 2026-07-28 review
+thread that produced this ADR's decisions (issue #4021, second comment)
+independently confirms, in the owner's own words, that `ticketing-agent`
+"has `role = "ticketing"` which is NOT in `ASSISTANT_ALLOWED_DELEGATE_ROLES`
+so it is unreachable in-product today," alongside a proposal to curate a
+starting Sub-agents set including "Research Agent," "Ticketing Agent,"
+"MacOS Manager," and "AWS Manager" — the latter two not existing in any
+form yet, and decision 2's "re-use existing agents" clause directly bears
+on that gap (see "Consequences").
+
+### 5. "Communicate" — checked against the codebase, not invented (retained)
+
+No agent-to-agent MESSAGING primitive (distinct from delegation) exists in
+`trusty-agents` today. `TmSendMessageTool` (`tm_tools/control.rs:105`)
+targets a **trusty-mpm** tmux session, not a trusty-agents persona.
+**ADR-0019** (Accepted, 2026-07-21) designs a unified, role-addressed,
+durable cross-agent IPC bus, but its own Consequences section states the
+bus "remains unimplemented. No code has landed since [2026-07-18]"
+(`0019:112`) and its role model is built on **ADR-0016**'s SINGLETON
+"ASSISTANT" (the one holder of user authority, `0016:47-50`) — a different
+sense of "assistant" than `trusty-agents`' plural `role = "assistant"`
+persona population, the exact population decisions 3/4 now formally place
+at tier L0. The product spec's decision log (2026-07-24,
+`trusty-agents-product-spec.md:485`, Bob: *"we can allow agents to talk to
+each other"*) is the only other prior ruling on record, and the SAME spec
+lists the protocol as an open, undesigned question on the same date
+(`:495`).
+
+### 6. DOC-57 does not yet cover Sub-agents (retained)
+
+`docs/specs/agent-config-five-sections.md` (DOC-57) never mentions a
+Sub-agents section; issue #4182 is open and unaddressed. This ADR remains
+the first normative text on the subject, now covering five ratified
+decisions rather than one.
+
+### 7. Prior art: the trusty-mpm PM, and the limit the owner himself named
+
+The owner offered the trusty-mpm PM as precedent: *"[the model] is
+logically consistent, and similar to what we've done with the PM in our
+harnesses."* Checked directly against `crates/trusty-mpm/src/assets/
+instructions/`:
+
+- `BASE_PM.md:7`: *"PM agent in trusty-mpm. Role: orchestration +
+  delegation, **never direct impl**."* (emphasis added).
+- `PM_INSTRUCTIONS.md:8-9`: *"PM = orchestrator + QA coordinator. Delegates
+  ALL work to specialist agents. DEFAULT: delegate. EXCEPTION: user says
+  'you do it' / 'don't delegate'."*
+- `PM_INSTRUCTIONS.md:134`: *"Each delegation reloads ~95K tokens of
+  context. Fewer, larger delegations = cheaper, faster."* — the concrete
+  cost that makes the PM's DEFAULT posture "delegate," full stop: every
+  delegation is a fresh ~95K-token context reload, so the PM economizes by
+  delegating in large, batched units and otherwise doing almost nothing
+  itself (a narrow allowlist: git ops, reading ≤3 small config files, 3-5
+  orientation greps — `PM_INSTRUCTIONS.md:37-46`).
+
+**The owner named the limit of this analogy himself**, and it is real and
+load-bearing: the PM is delegation-ONLY specifically *for context economy*
+— it never acts directly on source code (P1 in its own prohibitions table,
+`PM_INSTRUCTIONS.md:17`) because every direct action it might take is
+better done by a specialist whose OWN context is scoped to the task, and
+reloading that specialist repeatedly is the expensive part the PM's
+posture is designed to minimize. **The trusty-agents assistant's context is
+not reloaded per turn the way a fresh delegation is — it is a persistent,
+effectively unbounded conversation** (the product spec's own "ONE
+continuous conversation per agent" decision,
+`trusty-agents-product-spec.md`, decision log, 2026-07-24). That is exactly
+why decision 3 grants the assistant something the PM structurally cannot
+have: the right to call skills DIRECTLY, not only delegate. The analogy
+holds for the SHAPE of the hierarchy (a trusted top-tier orchestrator that
+delegates downward to narrower-scoped workers) but does not hold, and was
+never claimed by the owner to hold, for the ECONOMICS that make the PM
+delegate ALWAYS rather than SOMETIMES. Any implementer reusing PM
+instruction patterns (e.g. the circuit-breaker table, `AGENT_DELEGATION.md`)
+as a template for assistant routing must not import the "always delegate"
+default along with the hierarchy shape — decision 3+5's routing model is
+deliberately a SOMETIMES-delegate design, and that departure is the whole
+point of the analogy's stated limit.
+
+### 8. The "3 tool call threshold" — prior art, not a literal reuse
+
+Two existing "3"-shaped conventions were checked; neither is what decision 5
+literally reuses, though both are the number's likely ancestry:
+
+- `PM_INSTRUCTIONS.md:302`: *"\>2-3 bash commands for one task -> CB#1 or
+  CB#7"* — a RETROSPECTIVE violation-detection heuristic in the PM's "Quick
+  Violation Detection" table: it recognizes, after the fact, that the PM
+  should have delegated instead of running that many bash commands itself.
+  It is scoped to Bash commands specifically, not to "tool calls" in
+  general, and it is not a prospective routing gate between two named
+  alternatives.
+- `PM_INSTRUCTIONS.md:29-35` (the `pm_guard` hook, issue #2918): a
+  MECHANICALLY-ENFORCED per-turn budget of "up to 3 combined P1+P5 file
+  changes" — the closer structural analog (a hard integer cap that decides
+  whether the actor may act directly or must hand off), but scoped to
+  SOURCE-FILE EDIT COUNT specifically, and existing for the opposite stated
+  reason: to let a trivial one-line fix skip a delegation round-trip, not
+  to gate a skill-vs-sub-agent choice by estimated tool-call count.
+
+**Honest assessment: decision 5's "3 tool call threshold" borrows the
+NUMBER and the general shape (a small-integer cap distinguishing "handle it
+myself" from "hand it off") from these two conventions, but reuses neither
+rule's code, scope, or trigger condition verbatim.** It is a new threshold,
+inspired by, not identical to, prior art. See "Consequences" for the
+harder problem this raises: unlike the PM's rules (which count something
+already OBSERVED — bash commands run, files changed), the assistant's
+threshold must be applied BEFORE the work happens, to route it in the first
+place.
+
+## Decision
+
+We adopt, as **Proposed**, pending the owner's ratification of the specific
+implementation mechanics this document flags as open, the complete model
+stated in Context §1:
+
+1. A sub-agent is always in-process (unchanged from the first draft).
+2. **Assistant = tier L0.** Delegates down to sub-agents; communicates
+   laterally with other assistants (never delegates to them); holds the
+   YOLO/owner-accepted posture; may call skills directly as an alternative
+   to delegating.
+3. **Sub-agent = tier L1.** In-process only; a leaf node with exactly one
+   edge (responds to its invoking assistant); never delegates in any
+   direction; never reaches outside the process.
+4. **The reachable sub-agent set is an editable configuration whitelist**
+   over agents that already exist in the roster — not a hand-authored Rust
+   constant, and not net-new agent authoring for the purpose of populating
+   the whitelist.
+5. **Routing between an assistant's own skill and delegating to the
+   sub-agent that owns the same domain is decided by task complexity,
+   measured against a 3-tool-call threshold**: ≤3 expected tool calls,
+   call the skill directly; more, delegate.
+6. **Delegation authority is governed by KIND (assistant vs. sub-agent),
+   never by tier order.** Formalized as a normative rule, not merely an
+   observed consequence, in the section immediately below — added by owner
+   instruction after clauses 1-5 were ratified, in direct response to this
+   ADR's own finding that the shipped tier gate (§3, PR #4200) cannot
+   express the peer prohibition clauses 2-4 require.
+
+This ADR does not yet decide, and defers to the owner (see "Consequences"
+and "Conflicts and open questions"), the mechanics each clause raises but
+does not itself answer — enumerated in the Consequences sections below,
+each ending in an explicit recommendation marked owner-ratify.
+
+## Normative Rule: Delegation Authority Is Governed by Kind, Not by Tier Order
+
+This section formalizes, as a binding architectural rule rather than an
+observed defect, the finding first raised in this document's "Does the
+one-directional L0/L1 gate, as implemented, still express the intended
+rule?" consequence (retained below, unchanged, as the motivating analysis).
+The owner instructed that this finding be recorded normatively so an
+implementer can check conformance against it directly, independent of
+which specific lines a fix lands on.
+
+### The structural claim
+
+**A total order cannot express a peer prohibition.** Any mechanism of the
+shape "delegation is permitted iff `tier(source)` dominates `tier(target)`
+in some fixed ordering" is structurally incapable of forbidding an edge
+BETWEEN two nodes at the SAME rank, for any numbering whatsoever — not
+because the shipped numbering (`L0Orchestration` > `L1Standard`) was chosen
+badly, but because no numbering can encode "these two are peers who may
+not delegate to each other" using only "is my rank higher than yours." The
+shipped gate (`delegate.rs:373-374`: `target_tier == L0Orchestration &&
+delegator_tier != L0Orchestration`) worked, before decision 3, only because
+tier happened to coincide with the property the rule actually cares about:
+every assistant was L1 and L0 was an empty, unpopulated tier, so "assistant
+delegating to assistant" and "L1 delegating to L1" were the same event, and
+the tier check was never asked to adjudicate an L0-vs-L0 edge because no
+such edge could exist. Decision 3 breaks that coincidence on purpose (every
+assistant becomes L0); the tier check does not know this happened, because
+it was never a check ABOUT assistants and sub-agents — it was, and remains,
+a check about tier numbers. **This is why renumbering cannot fix it, and
+why any future fix that leans on tier values reintroduces the same defect
+under a different set of labels.**
+
+### The rule, as a conjunction of predicates on the edge (source, target)
+
+Delegation from `source` to `target` is authorized if and only if all three
+hold:
+
+1. **`KIND(source) = assistant`.** Only assistants may delegate at all.
+   `KIND` here is the existing `agent.role` field — specifically,
+   `role == ASSISTANT_TIER_ROLE` (`tool_registry.rs:98`) — not a new
+   attribute; this predicate already has a partial structural analog in
+   shipped code (`build_registry_for_agent` never registers
+   `DelegateToAgentTool` for any other role, `tool_registry.rs:188-193`,
+   confirmed in "Consequences" below). **Scope caveat, checked against the
+   code:** `pm`/`ctrl`-as-orchestrator (role `orchestrator`) also delegates
+   today, unrestricted, through a THIRD and FOURTH construction site this
+   predicate deliberately does not cover —
+   `ctrl_delegate_posture`'s `role != "assistant"` branch
+   (`history.rs:395-397`, returning no taint and no role allowlist) and
+   `runtime::pm_mode::run_pm`'s direct, config-dir-less
+   `DelegateToAgentTool::new(runner)` (`pm_mode.rs:111-113`, documented
+   inline as deliberate: "`pm`... is the trusted top-level orchestrator,
+   already unreachable as a delegation TARGET from any L1 persona"). Both
+   are pre-existing, separately-trusted actors OUTSIDE the assistant/
+   sub-agent model this ADR defines, by the code's own documented design.
+   This predicate set governs the ASSISTANT/SUB-AGENT graph only; it
+   neither constrains nor is threatened by `pm`/`ctrl`'s own orchestrator-
+   kind delegation, which is a different, older capability this ADR does
+   not revisit.
+2. **`KIND(target) ≠ assistant`**, i.e. target is a sub-agent. **This single
+   predicate subsumes both the peer-prohibition case (assistant-to-
+   assistant) and the now-vacuous L0-to-L0 case** — there is no need for a
+   separate "no lateral delegation" rule once the target's kind is checked
+   directly, because "not an assistant" already excludes every assistant,
+   including ones that happen to share the source's tier.
+3. **Tier ordering holds** (`target_tier != L0Orchestration ||
+   delegator_tier == L0Orchestration` — the existing, unmodified gate).
+   **Retained as defense-in-depth, not as the primary carrier of the
+   rule.** Given predicates 1 and 2 are correctly enforced AND the ratified
+   tier assignment holds (every assistant declares `tier = "l0"`, every
+   sub-agent remains `L1Standard` by the existing fail-closed default),
+   predicate 3 is checked but never itself the reason a call is refused —
+   the source is always L0 (predicate 1) and the target is always L1
+   (predicate 2 + the ratified assignment), so the tier condition is always
+   already satisfied by the time it runs. **This redundancy is
+   deliberate, not vestigial**: predicate 3 is evaluated over a DIFFERENT
+   piece of config (the `tier` field) than predicates 1-2 (the `role`
+   field), read by independent code paths. If a future defect in the
+   role/kind check (predicate 1 or 2) ever let an assistant-kind target
+   slip through — and that target's `tier` was correctly declared `l0`
+   as this rollout requires — predicate 3 still catches it. A bug in one
+   layer does not, by itself, open the graph.
+
+### The permitted graph
+
+The predicates above are derivable from, and should be read as consequences
+of, this closed graph — the owner has now ratified every edge in it:
+
+- **`user <-> assistant`** — assistants are always user-instantiated; the
+  user converses with an assistant directly.
+- **`assistant -> sub-agent`** — delegation (predicates 1+2+3 above).
+- **`sub-agent -> its invoking assistant`** — response only; not a new
+  outbound edge, the return path of the delegation above.
+- **`assistant <-> assistant`** — COMMUNICATION only, never delegation.
+  Currently UNIMPLEMENTED (see "Consequences," "'Communicate' has to be
+  built, not renamed").
+
+**No other edges exist.** Sub-agents are leaves: no outbound delegation
+(enforced structurally today — see "Consequences," "Is 'sub-agents never
+delegate' enforced, or merely conventional?"), no out-of-process
+communication (decision 1). The `pm`/`ctrl`-as-orchestrator edges named in
+predicate 1's scope caveat are explicitly OUTSIDE this graph — a separate,
+pre-existing capability this ADR does not fold in, revisit, or constrain.
+
+### Why this class of error recurs
+
+Concretely, not moralizing: **an authority rule encoded against a proxy
+attribute (tier) rather than the attribute it is actually about (kind)
+will hold exactly as long as the proxy correlates with the real thing, and
+fail silently the moment a product decision decorrelates them.** Three
+specific, checked facts about why THIS instance was silent, not loud:
+
+- **No log fires on the permitted path.** `delegate.rs`'s `execute()` logs
+  a `tracing::warn!` when `tier_blocked` is true (`delegate.rs:376`) and
+  `tracing::debug!` when a role is disallowed or a name fails to resolve
+  (`delegate.rs:389`, `403`, `412`), but the SUCCESS path — falling
+  through the `if tier_blocked` / `if rejected` checks straight to
+  `let final_task = ...` and `self.runner.run(...)` (`delegate.rs:448-456`)
+  — emits no
+  tracing statement at all recording which gate combination let the call
+  through. An operator watching logs sees rejections; a permitted
+  assistant-to-assistant delegation, once the population inverts, looks
+  identical in the logs to any other successful delegation.
+- **No test exercises the newly-real case.** `delegate_tests.rs` has
+  `delegate_l1_to_l0_is_refused` and `delegate_l0_to_l1_succeeds`
+  (`delegate_tests.rs:554-619`) but no `delegate_l0_to_l0_is_refused` —
+  grepped directly, no such test exists. This is not an oversight in test
+  coverage discipline; before decision 3, an L0-to-L0 scenario had no
+  realistic fixture to write a test against (L0 was unpopulated), so the
+  gap in the test suite exactly mirrors the gap in the rule, for the same
+  underlying reason.
+- **The regression is invisible to `cargo test` by construction.** Because
+  the tier gate's CODE did not change between "L0 empty" and "L0 = every
+  assistant" — only the DATA (which personas declare which tier) changed —
+  no test suite run, no diff review of `delegate.rs` itself, and no CI
+  green/red signal was ever going to catch this. This is why the finding
+  surfaced only through a fresh architectural read of the predicate against
+  the NEW population, not through any mechanical check — which is exactly
+  the situation a proxy-attribute rule produces: it is not that testing
+  was inadequate, but that the wrong thing was being tested because the
+  wrong thing was being CHECKED, in the shipped code.
+
+**A second, independently-found instance of the same class**, checked
+rather than merely asserted, and named per the owner's instruction rather
+than left unsearched: `cross_product::NON_CODING_TARGETS`
+(`cross_product.rs:63`) authorizes cross-product reach by AGENT NAME
+membership in a hardcoded list, standing in for a capability the codebase
+does not yet have a field for — "is this agent actually non-coding" (no
+`is_coding: bool`, no capability tag exists on `AgentConfig` today). The
+module's own doc comment already names this as deliberate and temporary:
+"#4030's runtime-built domain authority is what will eventually FEED this
+set, and until it exists an exact list is the only honest source"
+(`cross_product.rs:59-60`). Its failure mode differs from the tier-gate
+case (a name list fails by silently OMITTING a newly-eligible agent, never
+by silently ADMITTING an ineligible one — the opposite polarity, and a
+safer one), but the root pattern — a security-relevant property encoded via
+a coincidentally-correlated stand-in rather than the property itself — is
+the same. No third instance was found; this ADR looked (`grep`-searched
+name-based and tier-based conditionals across `crates/trusty-agents/src`
+for further authority-relevant special-casing) and is reporting a negative
+result for anything beyond these two, not an absence of looking.
+
+### Conformance
+
+An engineer is implementing this finding on branch
+`fix/persona-dispatch-role-allowlist` (kind-primary, tier retained as
+defense-in-depth, per the coordinator). **This ADR could not locate that
+branch pushed to `origin` at the time of this revision** and is not
+claiming to have reviewed its diff; the checklist below is written so
+conformance can be checked against the RULE stated above, independent of
+which lines the implementation touches:
+
+- [ ] The predicate-2 check (`target KIND != assistant`, when
+  `source KIND == assistant`) is enforced **unconditionally inside
+  `DelegateToAgentTool::execute`**, not merely by curating the contents of
+  decision 4's editable whitelist. A whitelist is caller-supplied config;
+  if the kind exclusion lives ONLY in "which names happen to be listed,"
+  the same class of silent gap reopens the moment a whitelist is
+  misconfigured to include an assistant-role name. The kind check must be
+  a property of the CODE, not of the data an operator is trusted to curate
+  correctly.
+- [ ] The fix closes the gap at **all** sites that construct a
+  `DelegateToAgentTool` for an assistant-tier caller — today that is
+  `history.rs`, `persona.rs`, and `tool_registry.rs`'s
+  `build_assistant_tier_registry` (the `pm_mode.rs` site is explicitly
+  OUT of scope — it is the `pm`/`ctrl`-as-orchestrator case predicate 1's
+  caveat excludes). Per-call-site opt-in (`.with_allowed_target_roles(...)`
+  as a builder method each caller must remember to call) is exactly the
+  shape that produced #4201's gap; moving the kind check into the shared
+  choke point (`execute()` itself, unconditional whenever the delegator's
+  OWN role is `ASSISTANT_TIER_ROLE`) removes the opt-in entirely rather
+  than adding a fourth site that could someday forget it too.
+- [ ] A test named for the KIND relationship, not the tier labels — e.g.
+  `delegate_assistant_to_assistant_is_refused` rather than
+  `delegate_l0_to_l0_is_refused` — asserts the peer-prohibition case, and
+  is written against role/kind fixtures. Per the coordinator: this test
+  must keep passing if assistants and sub-agents are ever renumbered again
+  (tiers swapped, a third tier introduced, labels changed) — which is only
+  possible if the test's fixture setup and its assertion are both phrased
+  in terms of KIND, never in terms of which tier enum variant currently
+  happens to represent that kind.
+- [ ] The now-logged success path (if added) records which predicate
+  combination authorized a delegation, closing the "no log fires on the
+  permitted path" gap named above — an operator should be able to observe
+  from logs alone that predicate 3 was redundant-as-designed on a given
+  call, not have to infer it.
+- [ ] The PR's own description states, explicitly, that predicate 3 (tier
+  ordering) is retained as defense-in-depth and is NOT expected to block
+  anything additional once predicates 1-2 are correct — so a future reader
+  of that PR does not conclude the tier gate was the fix and quietly let
+  predicates 1-2 rot.
+
+## Consequences
+
+### The cross-product bridge is no longer a "sub-agent" mechanism (retained, options unchanged)
+
+Three options remain as drafted: (A) deprecate `dispatch_task`'s
+named-specialist widening entirely; (B) retain it, re-scoped and renamed
+away from "sub-agent"/"cross-product" language (the owner's own 2026-07-28
+review independently asked to "remove 'cross-product' as user-facing
+terminology" — item (c) in that review); (C) build a genuine in-process
+ticketing capability and retire the cross-product leg for ticketing
+specifically. **Recommendation (unchanged, owner must ratify): Option B.**
+One additional benefit surfaces now that decision 4 introduces a NEW
+editable `[subagents]`-shaped whitelist for the in-process mechanism (see
+below): renaming the cross-product TOML section away from `[subagents]`
+frees that name for the in-process whitelist, resolving the naming
+collision this document's first draft flagged against DOC-41's older,
+unbuilt `subagents.allowed` design.
+
+### `ASSISTANT_TIER_ROLE` in the allowlist is a behavior change, and breaks a tested feature (retained, reframed)
+
+Unchanged from the first draft: removing `assistant` from
+`ASSISTANT_ALLOWED_DELEGATE_ROLES` breaks
+`delegate_assistant_role_gate_allows_peer_assistant_role`
+(`delegate_tests.rs:411-435`, the Izzie↔cto-assistant peer-consult lane) and
+must land in the SAME change that builds the lateral "communicate"
+mechanism, not as a bare removal — assistants would otherwise lose peer
+interaction entirely for however long the gap lasts. Now reframed correctly
+under decision 3's L0/L1 assignment: this is not merely "removing one
+constant entry," it is removing the ONLY EXISTING peer-interaction path for
+a population (assistants) that decision 3 newly and explicitly requires to
+have one (laterally, non-delegated). The persona.rs gap (§2/#4201) must be
+closed in the SAME change — landing the fix at the two protected sites
+while leaving the third unpatched would let the REPL `/agent` path continue
+to permit exactly the lateral (and worse, upward — to `pm`) delegation this
+decision forbids.
+
+### `ticketing-agent` is unreachable in-process — decision 2 changes the fix (retained, reframed)
+
+The three prior options (widen the const, recategorize the role, or build a
+new in-process capability) are now subsumed by decision 2's mandate: the
+FIX must be an editable config-whitelist ENTRY (adding `ticketing-agent`'s
+name to whichever assistant's whitelist should reach it), not a Rust source
+change. This removes the "widens a global constant for every caller
+simultaneously" cost the first draft flagged — the whitelist is per-agent
+config, not a shared constant — but see the "editable" consequence below
+for a NEW cost this introduces (write-time widening past a floor).
+"MacOS Manager"/"AWS Manager" (the owner's 2026-07-28 curated-set proposal)
+remain net-new authoring regardless of decision 2's "re-use existing
+agents" framing, since no such agents exist anywhere in the roster today —
+decision 2 supplies the REACHABILITY mechanism, not the missing agents
+themselves.
+
+### "Communicate" has to be built, not renamed (retained)
+
+Unchanged: no code path implements assistant-to-assistant messaging today.
+The two candidate foundations (ADR-0019's unbuilt bus, built on ADR-0016's
+singleton-Assistant addressing; or a minimal purpose-built messaging tool
+scoped to `role = "assistant"` targets) remain unreconciled. This ADR still
+does not choose between them.
+
+### Does the one-directional L0/L1 gate, as implemented, still express the intended rule? (new)
+
+**The gate is written in terms of TIER ORDERING, not specific roles**
+(`delegate.rs:373-374`: `target_tier == L0Orchestration && delegator_tier
+!= L0Orchestration`) — it has never known or cared which role occupies
+which tier. That is precisely why decision 3's population inversion changes
+its effective meaning without changing one line of its code:
+
+- **Assistant(L0) → sub-agent(L1): still correctly ALLOWED** — the gate
+  never blocks a delegation into a non-L0 target, and under decision 3
+  every sub-agent is L1 by the existing fail-closed default (no code
+  change needed here; this is the one case where the shipped gate and the
+  new model happen to agree).
+- **Assistant(L0) → assistant(L0), i.e. LATERAL delegation between
+  assistants: NOT blocked by the gate as coded.** The condition requires
+  `delegator_tier != L0Orchestration`; once every assistant is L0 (decision
+  3), the delegator IS L0 in exactly the case decision 4 wants forbidden,
+  so the tier check evaluates false and nothing refuses the call. **The
+  gate that was built to protect the (formerly rare, formerly untouchable)
+  L0 tier from below now structurally cannot protect L0 from ITSELF**,
+  because the shipped model only ever conceived of one L0 actor at a time,
+  never many peers at the same tier.
+- **Sub-agent(L1) → anything: not something the tier gate needs to
+  block**, because — see the next consequence — it is already impossible
+  through a separate mechanism.
+
+**This is not a "reads backwards" bug in the strict sense (it never
+inverts a comparison), but it is now VACUOUS for the scenario it was built
+for and SILENT on the scenario decision 4 actually needs guarded.** The
+gate's original threat model (an untrusted L1 escalating into a trusted,
+rare L0) no longer maps onto the population it will be evaluated against
+(many mutually-lateral L0 peers, none of them untrusted-content-holding in
+quite the old sense, since untrusted-content ingestion is an L1-only
+constraint that decision 3 does not relax). A NEW, role-aware or
+identity-aware check is required to enforce "L0 may never delegate to
+another L0" — the existing tier-ordering gate cannot express it without a
+second axis (e.g. comparing delegator identity to target identity, or a
+distinct "peer" relation orthogonal to tier). This is implementation work,
+not a documentation fix.
+
+### Is "sub-agents never delegate" enforced, or merely conventional? (new)
+
+Checked directly: `runtime::tool_registry::build_registry_for_agent`
+(`tool_registry.rs:178-427`) is the ONLY place `DelegateToAgentTool` is ever
+registered into an agent's native tool registry, and it does so EXCLUSIVELY
+inside the `role == ASSISTANT_TIER_ROLE` branch
+(`build_assistant_tier_registry`, line 188-193). Every other named branch —
+`research-agent`, `analysis-agent`, `code-agent`, `plan-agent`, `qa-agent`,
+`local-ops-agent`, `docs-agent` — and the `_` catch-all (lines 414-426)
+build a registry with NO `DelegateToAgentTool` entry at all. **A sub-agent
+spawned via `run_subagent`** (`subagent_mode.rs:116`, which calls
+`build_registry_for_agent` at line 382 for every spawn, regardless of
+whether it was reached by `--direct`/`--agent` or by an assistant's
+`delegate_to_agent` call) **structurally cannot call `delegate_to_agent`,
+because the tool is never in its own registry to begin with — not merely
+denied by a scope/allowlist check, but absent.** This means "sub-agents
+never delegate" is **already enforced today**, by construction, for the
+native trusty-agents tool-calling loop — this is required work only for the
+LATERAL and UPWARD directions the model already permits assistants (via the
+allowlist gap above), not for sub-agents, which have no path to delegate at
+all under the current registry-construction code. One caveat, not fully
+traced in the time available: agents with `runner = "claude-code"` dispatch
+through a separate `ClaudeCodeAgentRunner` that shells out to the actual
+`claude` CLI, a process with its own independent tool surface; this ADR
+does not claim to have verified whether any MCP bridge could expose
+`delegate_to_agent` to that subprocess, only that the trusty-agents-native
+`ToolRegistry` path — the mechanism the question was asked about — does
+not.
+
+### The absent-whitelist default is a breaking change for every existing assistant (new, owner-ratify)
+
+Today, in-process reachability for an assistant-tier caller is an
+UNFILTERED SCAN: every agent in `agents::agents_dir_candidates()` whose
+`role` is in `ASSISTANT_ALLOWED_DELEGATE_ROLES` is a target, no per-agent
+config required — confirmed directly by the owner's own 2026-07-28 review
+comment on #4021 ("it currently shows all 18 role-eligible agents... with
+no per-agent narrowing possible today") and by `in_product_surface`
+(`agent_subagents.rs:232-309`), which scans the WHOLE catalog and includes
+any role-eligible match. By contrast, the EXISTING cross-product mechanism
+this ADR's decision 4 explicitly takes as its shape — `SubagentAllowSet`,
+built from `[subagents].allowed` — treats an ABSENT config section as
+EMPTY, deny-by-default (`cross_product.rs:119-131`, `SubagentAllowSet::
+empty`: "an absent `[subagents]` section is NOT a silent capability
+grant"). **If decision 4's editable whitelist reuses that same
+absent-means-empty posture for the IN-PROCESS mechanism, every existing
+assistant persona — none of which has ever needed to declare a
+`[subagents]` section, because none exists for this purpose today — drops
+from ~18 reachable targets to 0 the moment this ships, with no migration.**
+Options:
+
+- **(a) Ship a pre-populated default `[subagents].allowed` list in every
+  bundled persona TOML** (`izzie.toml`, `cto-assistant.toml`,
+  `personal-assistant.toml`, `ctrl.toml`) at rollout, listing today's
+  effective role-eligible set. Cost: a one-time content migration across
+  the shipped roster; any user-AUTHORED custom persona still gets the
+  honest deny-by-default (no section = no targets), which is arguably the
+  correct behavior for a NEW agent.
+- **(b) Treat "absent `[subagents]`" as "grandfather in the current
+  role-scan behavior"** rather than empty. Cost: this creates TWO different
+  absent-semantics for a structurally identical config shape, depending on
+  which mechanism reads it (cross-product: absent = empty; in-process:
+  absent = full legacy scan) — a durable, confusing inconsistency baked
+  into the same product surface that will need explaining forever.
+- **(c) Accept the breaking change outright and require every assistant
+  persona to be re-configured before this ships**, treating it as a hard
+  cutover coordinated with the rollout. Cost: highest short-term
+  disruption; cleanest long-term posture (one absent-semantics rule,
+  matching the cross-product precedent exactly).
+
+**Recommendation (owner must ratify): Option (a).** It preserves the
+deny-by-default principle for every future agent while avoiding both the
+silent capability loss of doing nothing and the semantic split of Option
+(b).
+
+### "Editable" means the GUI starts writing agent config — can a write widen past a floor? (new, owner-ratify)
+
+The nearest existing precedent for a GUI-driven agent-config write is
+`PATCH /api/agents/:name` (`agent_patch.rs:159-170`), specifically its
+`tools_allow` field (added by #3819): *"overwrites `[tools].allow`... with
+this exact list"* (`agent_patch.rs:140-147`). **Checked directly: the
+write path applies NO validation against any floor or capability ceiling.**
+`patch_agent_at` inserts the caller-supplied array into `[tools].allow`
+verbatim (`agent_patch.rs:380-392`) — there is no check that the new
+patterns are a subset of anything, no comparison against a role-derived or
+tier-derived maximum. **A `PATCH` call today can WIDEN a persona's declared
+tool-allow list arbitrarily far**, subject only to which registered tools
+actually exist to match against (the SEPARATE, unrelated
+`scope_assistant_allowed_tools` gate narrows what's GRANTED at dispatch
+time, but that is a read-time computation over whatever `[tools].allow`
+currently says — it does not stop the write itself from saying something
+broader than before). **This is the opposite of `SubagentAllowSet`'s
+design**, which is explicit that config "can only ever narrow that floor,
+never widen it" (`cross_product.rs:213-215`, `agents::config::
+SubagentsConfig`'s own doc: "`allowed` list is intersected with
+`tools::cross_product::NON_CODING_TARGETS`... config can only ever narrow
+that floor, never widen it"). **If decision 4's editable whitelist is
+implemented by following the `tools_allow` PATCH precedent literally, a
+GUI write could widen an assistant's reachable sub-agent set past whatever
+floor exists (e.g. past the role-eligibility check, or past whatever
+replaces `ASSISTANT_ALLOWED_DELEGATE_ROLES`) with no server-side
+enforcement — a materially different, and weaker, security posture than
+the fail-closed, floor-only design OQ-7 established for the cross-product
+mechanism it is meant to parallel.** Recommendation (owner must ratify):
+the new whitelist's write path must intersect against a server-owned floor
+the SAME way `SubagentAllowSet::resolve` does — the floor can still be
+"any agent currently in the resolvable roster" (decision 2's "re-use
+existing agents"), but role-ineligible or otherwise-disqualified agents
+(e.g. `pm`, `ctrl`, any future genuinely L0-only orchestration persona)
+must be rejected by the WRITE endpoint itself, not merely left unreachable
+by a downstream read-time filter that a future refactor could silently
+drop.
+
+### The 3-tool-call threshold is not knowable before the work is done — raised, not decided (new, owner-ratify)
+
+Two readings are both defensible and produce different architectures:
+
+- **A-priori estimate**: the assistant, before acting, predicts how many
+  tool calls the task will take and routes on the prediction. Problem: this
+  is an LLM self-estimate with no ground truth to check it against —
+  routing correctness depends entirely on estimation accuracy, which is
+  neither measured nor bounded anywhere in this decision.
+- **Reactive handoff-at-3-calls**: the assistant starts calling its own
+  skill directly and, on exceeding 3 tool calls WITHIN that attempt, hands
+  the remainder off to the sub-agent. This avoids the estimation problem
+  but creates a genuine **state-transfer question this ADR does not
+  answer**: what does the assistant pass to the sub-agent at the handoff
+  point (the 3 calls' results? a summary? nothing, and the sub-agent
+  restarts from the original task)? And is work REPEATED — does the
+  sub-agent redo the first 3 calls' worth of work because it has no memory
+  of them, or does the handoff need a `HandoffContext`-shaped payload
+  (mirroring `cross_product::HandoffContext`, `cross_product.rs:211-222`,
+  the EXISTING pattern for handing state across exactly this kind of
+  boundary) built for this specific transition?
+
+There is also a second-order consequence, noted but not resolved here: the
+"call a skill directly" half of the routing decision presumes skills are
+INVOKABLE, tool-shaped, and countable per call. `build_assistant_tier_
+registry`'s own doc comment currently states the opposite design intent —
+that assistant-tier personas "never need... a catalog-browsing tool"
+because their skills are already "injected as system-prompt CONTENT"
+(`tool_registry.rs:440-449`), and the function deliberately OMITS
+`list_skills`/`load_skill` for this tier. Decision 3's "calls skills
+directly" and decision 5's "3 tool call threshold" together imply skills
+must become invokable, countable actions for the assistant tier — a
+different mechanism than what is built, not a rewording of it.
+
+**Recommendation (owner must ratify): the reactive reading**, because it
+does not depend on an unverifiable LLM estimate, PROVIDED the state-transfer
+question is answered as part of the same implementation — reusing
+`HandoffContext`'s existing shape (summary/relevant_state/constraints, 4
+KiB cap) for the skill-to-sub-agent handoff is the natural fit, since it
+already exists, is already tested, and already solves an adjacent
+boundary-crossing problem. This ADR flags the question; it does not resolve
+it.
+
+### The YOLO generalization's actual blast radius, as coded today (new)
+
+Decision 5 ratifies generalizing YOLO from a single, rare, not-yet-
+instantiated L0 orchestration persona to the entire assistant population.
+**What that concretely unlocks in shipped code, right now, is narrower than
+epic #4167's original four-item table promised**: of #4170 (GitHub PR/CI
+tool surface), #4171 (session-state read access), #4172 (cross-project
+store/git scoping), and #4173 (shell/build/test execution grant), **only
+#4171 is closed/shipped**. The other three remain open. So today, flipping
+every assistant persona's declared `tier` to `l0` grants, in practice, only
+`session_state_list`/`session_state_status`/`session_state_snapshot`
+(`tool_registry.rs:597-611`) — plus removes the ONE existing tier-gated
+restriction (delegation into an L0 target) that these personas already
+happened to satisfy trivially once they are themselves L0. It does NOT (yet)
+grant shell execution, GitHub PR/CI access, or cross-project reach, because
+those grants are unbuilt. The blast radius the owner ratified is real but
+currently small; it will grow as #4170/#4172/#4173 land, and each of those
+follow-ups should be read, from this point forward, as extending a grant to
+the ENTIRE assistant population rather than to a single rare persona —
+which changes their own risk calculus and may warrant the owner re-reviewing
+them individually rather than assuming the 2026-07-27/2026-07-28 rulings
+already cover their specifics.
+
+## Conflicts and open questions
+
+- **This decision revises the owner's own 2026-07-26 ruling on epic
+  #4021's OQ-2** (retained, unresolved — see Context §4). Not smoothed
+  over by any option above; the owner should see both rulings side by side
+  before ratifying.
+- **This decision, dated 2026-07-28, inverts the population assignment of
+  the L0/L1 tier model merged the SAME DAY** (PR #4200, squash `ada4d351`)
+  — L0 was built as "a new, rare orchestration persona above today's
+  assistants"; decision 3 makes L0 "today's assistants, all of them." This
+  is not a contradiction requiring resolution so much as a FAST reversal —
+  worth the owner's explicit awareness that the tier model he approved
+  hours earlier in the day is being redefined, not merely extended, by the
+  same day's later decisions. See Context §3 and the "one-directional gate"
+  consequence above for the concrete mechanism this leaves inert/vacuous
+  until patched.
+- **DOC-41 §5.5's propose-not-authorize guarantee is not cross-product-
+  specific** (retained from the first draft, unchanged) — the in-process
+  path satisfies it via manifest-level `user_authority` non-inheritance;
+  the cross-product path satisfies it via the explicit `ProposalEnvelope`.
+  Collapsing the boundary does not remove the guarantee; it changes which
+  mechanism carries it.
+- **"Assistant" is overloaded across ADR-0016/0019 and this ADR** (retained)
+  — ADR-0016's singleton hierarchy role vs. `trusty-agents`' plural
+  persona-tier population, now formally the L0 population under this
+  decision. Not resolved here.
+- **The `[subagents]` TOML naming collision** (retained) — resolved in
+  direction, not yet in code: Option B (cross-product renamed away from
+  "subagents") frees the name for decision 4's new in-process whitelist,
+  which is the natural place for it, but this requires the cross-product
+  rename to land first or concurrently, or the collision persists.
+- **The persona-gate role-allowlist finding is now independently confirmed
+  by issue #4201's comment thread** (upgraded from "surfaced during this
+  ADR's own research" to "cross-verified against a separate, pre-existing
+  issue"), and remains a pre-existing, security-relevant finding
+  independent of this ADR's ratification — it should be fixed regardless
+  of how the rest of this document resolves.
+- **This ADR's own first draft is partially superseded by decision 2**,
+  explicitly marked at the top of this document and in the relevant
+  Consequences sections — this is noted here too because "Related
+  Decisions" vetting protocol (DOC-46 §3) calls for surfacing self-
+  supersession exactly like inter-ADR supersession, not silently editing
+  the earlier recommendation out.
+- **This ADR is still the first normative text on "Sub-agents" anywhere in
+  the spec corpus** (retained) — DOC-57 (#4182, open) has never documented
+  the section.
+
+## Related Decisions
+
+Vetted against prior ADRs (`docs/adr/INDEX.md`) on 2026-07-28 (revision 2):
+
+- **ADR-0004 (Three harnesses, shared event-driven common):** Consistent —
+  unchanged from the first draft's vetting.
+- **ADR-0015 (Unified agent composition, Proposed):** Consistent, with the
+  same note as the first draft — this ADR's purpose-level distinctions
+  (in-process leaf sub-agent / cross-product dispatch / lateral
+  communication) are not yet named in ADR-0015.
+- **ADR-0016 (Orchestration Hierarchy: Lead/PM/Assistant, Proposed):**
+  Extends, with the SAME flagged naming collision as the first draft, now
+  sharper: ADR-0016's singleton "ASSISTANT" and this ADR's newly-formal L0
+  "assistant" population are still different things sharing one name.
+  Additionally, §7 above uses ADR-0016's PM-analogy sibling (the trusty-mpm
+  PM, not ADR-0016 itself) as prior art — worth a forward cross-reference
+  from ADR-0016 once this ADR is accepted.
+- **ADR-0018 (Loopback-only doctrine, Accepted):** Consistent — unchanged.
+- **ADR-0019 (Unified IPC messaging, Accepted, unimplemented):** Extends —
+  unchanged, still the most likely foundation for the "communicate"
+  primitive, still unreconciled with ADR-0016's singleton addressing.
+- **ADR-0020, ADR-0021 (Slack gateway), ADR-0022:** No interaction —
+  unchanged.
+- **Conflict, not yet resolved by any ADR mechanism:** the owner's
+  2026-07-26 OQ-2 ruling (never itself an ADR) remains in direct tension
+  with decision 1. Unchanged from the first draft: not marked as
+  "Supersedes" because there is no ADR to formally supersede, but the
+  tension must reach the owner before acceptance.
+- **New: this ADR's own first-draft recommendation is explicitly
+  superseded by decision 2** (see header and "Conflicts and open
+  questions") — recorded here per DOC-46 §3's self-consistency
+  expectation, even though it is an intra-document, not inter-ADR,
+  supersession.
+
+No prior ADR formally addresses tiered agent delegation population
+assignment or an editable reachability whitelist; this remains the first.

--- a/docs/specs/DOC-60-bus-based-agent-messaging.md
+++ b/docs/specs/DOC-60-bus-based-agent-messaging.md
@@ -1,0 +1,556 @@
+# DOC-60 — Bus-Based Agent Messaging
+
+**Status:** Draft
+**Spec ID:** `SPEC-AGENTBUS-01~draft`
+**Subsystem:** trusty-mpm (bus host, daemon) — trusty-agents (assistants, sub-agents, ctrl) — trusty-channels (Slack/Telegram/etc.) — trusty-memory (consolidation target) — trusty-search (index target)
+
+## 1. Summary
+
+This spec defines **one** addressed, durable, searchable message bus for every
+cross-boundary message in the system — user↔assistant, assistant↔sub-agent,
+assistant↔assistant, and inbound/outbound channel traffic — and retires the
+five independent broadcast implementations that exist today because none of
+them address the unit that actually needs addressing: an **agent instance**.
+
+The bus is hosted by the `tm` (trusty-mpm) daemon. This makes `tm` a hard,
+already-accepted runtime dependency of `trusty-agents` (§4). Delivery follows
+a strict two-level tree rooted at a user action (§5), per the ratified
+orchestration model in
+[ADR-0024](../adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md):
+assistants are Level-0, always user-instantiated, and may communicate
+laterally with other assistants; sub-agents are Level-1, in-process leaves
+that never delegate and never talk out-of-process. Three distinct identifiers
+— agent definition, agent instance, and caller — are established for the
+first time (§6), because none of the five existing buses carries more than an
+ad hoc subset of them. Channels (Slack, Telegram, …) are a **transport that
+originates a user-identity message**, not a fourth participant kind, and they
+ride this same bus rather than a parallel path (§8). The bus **is** the
+searchable log; memory consolidation is the only sanctioned bridge from bus
+traffic into `trusty-memory`'s curated index, and a promoted memory carries a
+provenance pointer back to the message that produced it (§10).
+
+This is a DRAFT. It resolves what is answerable from the current codebase and
+flags the rest explicitly in §12 for the owner.
+
+## 2. Current state: five buses, zero of them addressed at agent granularity
+
+Five independent, mutually-unaware broadcast implementations exist. None
+imports or consumes another.
+
+1. **trusty-mpm global hook/event bus.** `DaemonState.event_tx:
+   broadcast::Sender<serde_json::Value>`
+   (`crates/trusty-mpm/src/daemon/state/core.rs:192`). Untyped JSON,
+   process-global, no addressing.
+2. **trusty-mpm per-session `SessionEvent` bus.**
+   `crates/trusty-mpm/src/control/event.rs` (`SessionEvent` enum, `actor.rs`
+   holds the `broadcast::Sender<SessionEvent>`). Session-scoped by
+   construction, but see the substring-match caveat below.
+3. **`trusty-agents-common::events::bus`.** `HarnessEvent` /
+   `HarnessPayload` over a process-global `OnceLock`-backed
+   `broadcast::Sender` (`crates/trusty-agents-common/src/events/bus.rs`).
+   Its own module doc calls out the ADR-0005 lineage; a repo-wide search for
+   importers of `events::bus` outside its own crate returns **zero** —
+   ORPHANED.
+4. **trusty-agents `events.rs` bus.** A single `Event` enum with 20+
+   variants (`SessionStarted`, `AgentMessage`, `ToolCalled`,
+   `SlackMessageReceived`, `ListenerEventReceived`, …,
+   `crates/trusty-agents/src/events.rs`) — the richest domain vocabulary of
+   the five, but still a flat, unaddressed broadcast.
+5. **trusty-code `events.rs` bus.** `SessionEventEnvelope` over a
+   `OnceLock`-backed `broadcast::Sender`
+   (`crates/trusty-code/src/events.rs`), session-scoped like #2 but a
+   separate implementation in a separate crate.
+
+**One genuinely ADDRESSED bus exists, at the wrong granularity.**
+`crates/trusty-agents/src/bus/mod.rs` is a Unix-domain-socket `MessageBus`
+whose `BusEnvelope` carries `source_project` and `target_project` (`None` =
+broadcast). It is wired and live: `MessageBus::start` binds
+`~/.trusty-agents/sockets/<id>.sock` and is called from `ctrl/repl/mod.rs`
+and `runtime/startup.rs`. It addresses **projects**, not agents or personas —
+useful prior art for the transport shape (NDJSON-over-socket, envelope +
+broadcast fan-out) but not a foundation to extend, since project identity and
+agent-instance identity are different axes (§6).
+
+**Apparent per-session routing is not routing.** `GET /sessions/{id}/events`
+(`crates/trusty-mpm/src/daemon/api.rs:166`,
+`stream_session_events`) subscribes to the *same* global `event_tx` and
+filters by testing whether the session UUID string appears inside the
+serialized JSON payload (`crates/trusty-mpm/src/core/provisioning_stage.rs:129`
+documents this explicitly as the existing substring-match mechanism, and
+`api_tests.rs::session_events_sse_filters_by_session` pins the behavior).
+Producers do not address a recipient; consumers filter client-side after the
+fact. This is adequate for a debug SSE stream and inadequate as the addressing
+primitive for a messaging bus.
+
+**Durable audit logging already exists, but is scoped to the wrong thing.**
+`crates/trusty-mpm/src/daemon/audit.rs` (`AuditLogger`) appends `AuditEntry`
+records as JSONL to `<logs_dir>/overseer/YYYY-MM-DD.jsonl`, held on
+`DaemonState.audit`. It is a working, durable, greppable append-only log —
+exactly the shape §9 needs — but it only ever receives overseer allow/block/
+respond/flag decisions, never bus traffic. Pointing it at bus envelopes is a
+redirect of existing machinery, not new machinery.
+
+**Personas are not tmux sessions.** trusty-agents personas run in-process
+(ctrl-hosted async tasks / the `delegate_to_agent` and `dispatch_task`
+mechanisms described in ADR-0024 §2), not as `tm`-managed tmux panes. `tm`'s
+existing tmux-pane-based delivery (`tm sessions send`, per ADR-0019 built on
+two literal `tmux send-keys` subprocess calls) has no pane to send keys to for
+a trusty-agents persona and **cannot** be the transport for this spec's
+delivery model. ADR-0019 already reached the adjacent conclusion for
+`tm`-native IPC (superseding ADR-0005's deferred phases with a unified,
+acknowledged, durable bus for `tm sessions send` and
+`memory_send_message`) — this spec is the trusty-agents-side counterpart,
+sharing the same host (§4) rather than re-deriving a second transport.
+
+## 3. Bus retirement table
+
+A spec that adds a sixth bus without retiring any of the five is a failure.
+Verdicts:
+
+| # | Bus | Verdict | Rationale |
+|---|-----|---------|-----------|
+| 1 | trusty-mpm global hook/event bus (`event_tx`) | **SURVIVES**, scope-narrowed | Stays as `tm`'s process-local debug/SSE fan-out for UI streaming (`GET /events`). It is not addressed and is not asked to become addressed — the new bus (§5) carries agent messaging; this bus keeps carrying UI telemetry. Its consumers (coordinator TUI, `GET /events`) are unaffected. |
+| 2 | trusty-mpm per-session `SessionEvent` bus | **SURVIVES**, scope-narrowed | Same rationale as #1: session-lifecycle telemetry (backend spawn, stop reasons, stream-json passthrough) stays here. Cross-agent *messaging* moves off the substring-match `/sessions/{id}/events` path onto the new bus's addressed delivery (§5); the SSE endpoint keeps working for what it is actually good at — a debug tail. |
+| 3 | `trusty-agents-common::events::bus` (`HarnessEvent`) | **DELETED** | Zero consumers by its own module doc and confirmed by a workspace-wide import search. Nothing to migrate. Delete the module; do not carry its `HarnessPayload` vocabulary forward — the new bus's envelope (§11) is defined fresh from actual delivery requirements, not backfilled from an unused design. |
+| 4 | trusty-agents `events.rs` bus (20+-variant `Event`) | **SUBSUMED** | This is the richest existing domain vocabulary (`AgentMessage`, `ToolCalled`, `SlackMessageReceived`, `ListenerEventReceived`, …) and the closest thing to a real requirements list for the new bus's payload union. It does not survive as a separate transport: its UI-facing consumers (`repl/event_display.rs`, the SSE relay in `api/server/relay.rs`) are repointed to subscribe to the new bus, and its variant set seeds — but does not freeze — the new envelope's payload enum. |
+| 5 | trusty-code `events.rs` bus (`SessionEventEnvelope`) | **SURVIVES**, scope-narrowed | Same shape as #1/#2: it is trusty-code's session-attach replay/live continuity mechanism (`seq` is deliberately per-session, per its own module doc), not a cross-agent messaging path. It stays for that job. Any trusty-code-originated agent message (a workstream update that should reach an assistant) is published to the new bus, not re-derived from this one. |
+| — | `crates/trusty-agents/src/bus/mod.rs` (project-scoped `MessageBus`) | **SUBSUMED** | The one bus that was already addressed, just at the wrong granularity (project, not agent instance). Its transport shape (Unix socket, NDJSON envelope, broadcast fan-out per connection) is the strongest prior art in the codebase for the new bus's local delivery mechanics, but project-level routing does not compose with the per-instance addressing §6 requires. `ctrl/repl/mod.rs` and `runtime/startup.rs` are repointed to the new bus; `source_project`/`target_project` become one addressing dimension inside the new envelope (§11), not a separate wire format. |
+| — | `crates/trusty-mpm/src/daemon/audit.rs` (`AuditLogger`) | **SURVIVES**, target widened | Not a messaging bus — the durable JSONL sink §9 needs already exists. Widened to also receive bus envelopes (a second `logs_dir/bus/YYYY-MM-DD.jsonl` stream alongside the existing `overseer/` one), not rewritten. |
+
+Net: **two buses deleted or subsumed outright** (#3, #4, plus the
+project-scoped `MessageBus`), **three narrowed to the telemetry job they
+already do well** (#1, #2, #5), and **one piece of existing durability
+machinery reused** (audit logger). One new bus is added, hosted by `tm`.
+
+## 4. Hard dependency on tm: absence/version-skew behavior
+
+The owner has accepted that hosting the bus in `tm` makes `tm` a hard
+dependency of `trusty-agents`. Three failure modes need one coherent answer
+each.
+
+**Daemon absent or stopped: FAIL-CLOSED for cross-instance delivery, degrade
+(not refuse) for local operation.** An assistant or sub-agent MUST still be
+able to start, run, and answer its invoking caller with no bus connection —
+delegation within a single L0→L1 edge (§5) is in-process Rust, not a bus
+round-trip, and does not need `tm` alive to function. What fails closed is
+specifically: (a) publishing a message to any recipient other than the
+in-process caller, (b) any lateral assistant↔assistant message, (c) any
+inbound channel message, all of which return an explicit
+`BusUnavailable`-shaped error to the caller rather than silently dropping.
+This mirrors the existing precedent at
+`crates/trusty-agents/src/bus/mod.rs`, where socket-connect failure is a
+surfaced `Result`, not a swallowed no-op. Justification: a silent drop
+recreates exactly the failure mode ADR-0019 was written to eliminate
+("no way to distinguish 'message never sent' from 'sent but recipient never
+polled'"); refusing outright to start would make every trusty-agents
+persona unusable whenever `tm` is mid-restart, which is disproportionate to
+what is actually broken (routing, not the persona's own reasoning loop).
+
+**Version skew: the daemon publishes a bus protocol version at connect time;
+a client on an incompatible major refuses to publish (fail-closed) but may
+still consume in read-only/best-effort mode.** The existing `tm doctor`
+diagnostic surface and `mcp__trusty-mpm__supervisor_status` tool are the
+natural place to surface a skew warning to the operator; this spec does not
+invent a second health-check path.
+
+**Startup ordering:** `trusty-agents` processes MUST NOT block their own
+startup on the bus becoming available — connect is attempted asynchronously
+and retried with backoff, consistent with how `MessageBus::start` today binds
+its socket without blocking the caller on a peer being reachable.
+
+## 5. Delivery model: the two-level tree
+
+Per [ADR-0024](../adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md)
+(ratified, same-day as this draft), the net shape is a strict two-level tree
+rooted at a user action:
+
+```
+                 user
+                  |  (bidirectional: user <-> assistant)
+              assistant (L0) ---- lateral ---- assistant (L0)
+                  |  (bidirectional: assistant <-> sub-agent)
+              sub-agent (L1, leaf)
+```
+
+- **User ↔ assistant/PM.** Bidirectional. Every assistant is ALWAYS
+  instantiated by a user action (interactive session, a scheduled/cron
+  trigger acting with delegated user authority, or an inbound channel
+  message treated as a user action — §8). This edge rides the bus so the
+  user-facing surface (CLI, TUI, GUI, channel) can be swapped without the
+  assistant knowing which one is listening.
+- **Assistant/PM ↔ sub-agent.** Bidirectional. A sub-agent is an in-process
+  LEAF: it never delegates further (not up, not laterally, not to another
+  sub-agent), never talks out-of-process, and only ever responds to the one
+  assistant that invoked it. This edge is the in-process `delegate_to_agent`
+  / `dispatch_task` call today (ADR-0024 §2); this spec does **not** move
+  it onto the network bus — an in-process call has no addressing problem to
+  solve, and forcing it through the daemon would add a round-trip and a
+  `tm`-availability dependency to a path that today has neither. What DOES
+  go on the bus is the **record** of that exchange (§9) — durability and
+  search, not delivery mechanics — so the sub-agent's request/response is
+  bus-searchable without the sub-agent process itself being a bus
+  publisher.
+- **Assistant ↔ assistant, laterally.** ADR-0024 decision 1 & 3: assistants
+  "can communicate with each other, but never delegate." **Decision: this
+  lateral edge DOES ride the same bus** as user↔assistant, not a private
+  side-channel. Rationale: (a) it needs the identical guarantees — durable,
+  acknowledged, searchable, addressed by agent instance — that motivated
+  ADR-0019's rejection of `tm sessions send` and `memory_send_message` for
+  the equivalent `tm`-side problem; inventing a second unaddressed channel
+  for assistant-to-assistant traffic would reproduce exactly the bug this
+  spec exists to fix. (b) A lateral message and a user message look
+  identical from the receiving assistant's side — both are "a message from
+  a caller I must address a reply to" (§6) — so one delivery path handles
+  both without a special case. The only distinction the bus enforces is
+  that a lateral message's caller identity is another assistant's instance
+  id, never granting delegate authority (an assistant cannot make another
+  assistant delegate on its behalf — communication, not command).
+
+**What is explicitly NOT a node in this tree:** a channel (Slack, Telegram)
+is not a third participant kind; it is a transport that originates a
+user-identity message onto the `user ↔ assistant` edge (§8). trusty-search,
+trusty-memory, and the audit log are not tree nodes either — they are
+consumers of the bus's durable log (§9, §10), never producers a message is
+addressed to.
+
+## 6. Identity model
+
+Three identifiers, three lifecycles. None of the five existing buses carries
+all three; establishing all three together is new work.
+
+| Identifier | What it names | Lifecycle | Exists today? |
+|---|---|---|---|
+| **(a) Agent DEFINITION id** | The `agent.toml` / persona config (e.g. `izzie`, `cto-assistant`) | Static — versioned with the config file, changes only on edit | **Yes.** This is the agent name used throughout `crates/trusty-agents` config, `AgentConfig`, the deploy pipeline (DOC-42/agent-bundled-skills), and `tm agent show <agent>`. |
+| **(b) Agent INSTANCE id** | One running invocation of a definition; the same definition may run many times concurrently (two users each running `izzie`, or one user running `izzie` twice) | Ephemeral — born at instantiation, dies at process/task exit | **Partial.** Session ids (`crates/trusty-mpm/src/control` `SessionEvent`, trusty-code's `session_id`) are the closest analogue but are scoped to `tm`'s own session model, not to a trusty-agents persona invocation as such. There is no single instance id that is stable across `tm`, trusty-agents ctrl, and trusty-code today. **This spec introduces one**: an instance id minted at the moment an assistant is instantiated (by a user action) or a sub-agent is spawned (by its invoking assistant), carried in every bus envelope as the addressable recipient/sender. |
+| **(c) CALLER identity** | Who sent THIS message — a user, an assistant instance, or a channel-originated identity (§8) | Per-message — one caller identity per envelope, not a session-lived value | **No.** None of the five existing buses carries a caller field distinct from whatever ad hoc source tag its own envelope happens to define (`BusEnvelope.source_project`, `HarnessEvent`'s source metadata, etc. — all different shapes). This spec's envelope (§11) makes caller identity a normative, uniform field. |
+
+**Why all three, not two.** Definition id alone cannot address "the specific
+`izzie` I'm talking to right now" when two are running. Instance id alone
+cannot answer "who may send this instance a message" or attribute a reply.
+Caller identity alone, without instance id, cannot express "this reply goes
+to the specific assistant instance that asked, not just any instance of that
+definition." The three compose: a message is addressed `to: instance_id`
+(resolved from a `definition_id` at send time only when no live instance is
+targeted — see wake semantics, §7), and stamped `from: caller_identity`
+which itself references an instance_id when the caller is an agent.
+
+## 7. Wake semantics
+
+A stopped or idle agent cannot receive anything by definition — the question
+is what happens to a message addressed to one. One coherent answer, covering
+both edges of the tree (§5):
+
+**Sub-agent invocation (assistant → sub-agent): delivery spawns an instance,
+always.** A sub-agent has no durable existence between calls — `dispatch_task`
+/ `delegate_to_agent` IS the instantiation event (ADR-0024 §2). There is no
+"queued to an idle sub-agent" state to design for, because a sub-agent is
+never idle-and-addressable; it exists only for the duration of one invoking
+call. Wake semantics for this edge are therefore already fully answered by
+existing machinery and this spec adds nothing here.
+
+**Message to an assistant instance that is still running: direct delivery,
+no wake needed.** The bus's local delivery mechanics (subscriber fan-out,
+per the `MessageBus` prior art in §2/§3) push the envelope straight to the
+subscribed instance.
+
+**Message to an assistant DEFINITION with no running instance (stopped, or
+never started): queued to a durable per-definition inbox — delivery does
+NOT spawn an instance.** This is the deliberate asymmetry with the
+sub-agent case, and it is deliberate for a specific reason: an assistant is
+ALWAYS user-instantiated (§5) — spawning one is a decision with resource,
+identity, and (per ADR-0024 decision 5) YOLO-risk-posture consequences that
+must stay attached to an explicit user action, never to an implicit side
+effect of someone else's message arriving. Auto-spawning an assistant on
+message arrival would silently manufacture a user-instantiation event with
+no user behind it. The queued message is delivered when: (a) the user (or a
+lateral assistant's caller-visible request) next instantiates that
+definition and the bus replays its durable inbox on connect, or (b) an
+operator-configured auto-resume policy (existing precedent:
+`mcp__trusty-mpm__auto_resume_set`) explicitly opts a definition into
+spawn-on-message — an opt-in escape hatch, not the default.
+
+**Inbound channel message (§8): does NOT unconditionally count as the user
+instantiating an assistant.** It counts as a user-identity message arriving
+on the `user ↔ assistant` edge (§5) addressed to a specific assistant
+definition (channel routing determines which — e.g. a Telegram chat bound to
+one assistant, a Slack channel bound to another, per existing per-agent
+listener bindings, DOC-57 §6.1). Two sub-cases, both resolved by the same
+rule as the paragraph above:
+
+- **A running instance is already addressable for that user+definition
+  pair** (the common case for an ongoing conversation): the channel message
+  routes to it directly, no new instantiation.
+- **No running instance exists:** the message is queued to the durable inbox
+  (same mechanism as above), UNLESS that definition has an auto-resume /
+  always-on policy configured (the existing pattern for a persistent
+  channel-bound assistant, e.g. a Telegram-facing persona meant to always be
+  reachable) — in which case arrival spawns the instance. This makes the
+  channel case a specific, config-driven instance of the general assistant
+  rule, not a separate design.
+
+**Explicit non-goal:** this spec does not change sub-agent lifetime or add a
+"durable sub-agent inbox" — ADR-0024 forecloses that by construction
+(sub-agents have exactly one edge and no independent existence to queue
+against).
+
+## 8. Channels ride the bus
+
+**Today:** an inbound Slack message reaches an agent through
+`crates/trusty-agents/src/slack/handlers.rs`, which is one of the concrete
+producers of the trusty-agents `events.rs` bus's `SlackMessageReceived`
+variant (§2 item 4); a reply goes out via the paired `SlackReplySent`
+variant and `api/server/relay.rs`. `trusty-channels` exists as a separate
+crate but the live Slack path runs inside `trusty-agents` directly — the two
+are not yet unified, which is itself part of the problem this spec is asked
+to close (owner requirement 5: "not a parallel one").
+
+**Decision: a channel is a transport that originates a user-identity
+message, not a third participant kind.** It is not a tree node (§5). An
+inbound Slack/Telegram message is translated, at the channel adapter
+boundary, into exactly the same envelope shape (§11) a CLI/TUI/GUI-originated
+user message would produce, addressed to whichever assistant definition that
+channel/workspace/chat is bound to. This is what "same messaging path, not a
+parallel one" means concretely: `trusty-channels` becomes the adapter that
+produces bus envelopes, and the current `Slack*` variants in trusty-agents'
+`events.rs` are subsumed into the bus payload union (§3, retirement #4)
+rather than surviving as a Slack-specific side path.
+
+**Caller identity carried by an inbound channel message (§6c):** three
+values, all present, none collapsed into one — a channel message is
+NOT anonymous the way a bare CLI keystroke is:
+
+- `human_sender` — the platform-native sender identity (Slack user id,
+  Telegram user id). This is the actual accountable human.
+- `channel` — the platform conversation the message arrived on (Slack
+  channel id, Telegram chat id) — needed for routing the reply back to the
+  same place.
+- `workspace` — the platform tenant/org (Slack workspace id, Telegram bot's
+  own scope) — needed to disambiguate identically-named channels/users
+  across tenants and to resolve which assistant binding applies.
+
+All three are carried in the envelope's caller field as a structured
+channel-origin identity, not flattened to a string — resolving "which local
+user does this map to" (if any) is a separate, existing RBAC concern
+(`ServiceTier`, `SLACK_RBAC_USERS`, DOC-57 §7.1 table row 3) that this spec
+does not re-derive; the bus carries the channel-native identity faithfully
+and lets the RBAC layer resolve it.
+
+**Reconciling with the listener architecture (DOC-57 §6.1: listeners are API
+connections, not MCP tools, with two-stage per-agent event filtering —
+harness-level ingestion filter, then per-agent wake filter):** the two
+mechanisms are **adjacent, not one subsuming the other.** A listener is how
+an agent *reacts* to an external event stream it has opted into watching
+(Gmail arriving, a calendar update) — the event is not, in general, addressed
+to that agent by a caller; the agent's own `AgentListenerBinding.filter`
+decides relevance. An inbound channel message in this spec's sense is
+different in kind: it IS addressed, by a human sender, to a specific
+assistant, exactly like a CLI message — there is no relevance filter to
+apply because the human already chose the recipient by which channel/chat
+they used. Concretely: Gmail/Calendar stay on the listener path (§ DOC-57
+§6); a direct Slack DM or a bound Telegram chat's message is bus traffic
+under this spec. The boundary is address-by-sender vs. filter-by-subscriber,
+and it is possible for the *same* connector (Slack) to have both a listener
+binding (watching a channel for mentions/keywords) and a bus-carried direct
+message (a DM to the bot) simultaneously — they are not mutually exclusive
+uses of one connector.
+
+## 9. Searchability: storage, retention, indexing, query surface
+
+**Storage: redirect the existing audit logger, don't build a new store.**
+`crates/trusty-mpm/src/daemon/audit.rs`'s `AuditLogger` already writes
+append-only, daily-rotated JSONL under `<logs_dir>/<subsystem>/YYYY-MM-DD.jsonl`
+with a proven never-fail-the-hot-path write discipline (`AuditLogger::log`
+never propagates IO errors). This spec adds a sibling stream,
+`<logs_dir>/bus/YYYY-MM-DD.jsonl`, fed by every envelope that crosses the bus
+(§11) — request, response, and delivery-state transitions alike. No new
+storage engine, no new dependency: the durability requirement is met by
+widening a component that already meets it for a narrower case.
+
+**Retention:** daily-rotated JSONL files age out on the same policy surface
+`tm`'s existing log-pruning already uses (DOC-33, tm meta-harness logging —
+per-delegation observability with a documented pruning story); this spec
+does not invent a second retention knob. Default retention window is an open
+question (§12) — cost-sensitive, not a design question this spec can settle
+from code alone.
+
+**Indexing: the bus exposes its own query/replay API; trusty-search does
+NOT index it as a first-class corpus.** Reasoning: trusty-search's cost model
+(per prior work: eager warm-boot, BM25 second-copy, one-way HNSW promotion —
+see the trusty-search memory-footprint findings already on file) is tuned for
+relatively low-churn source-code and document corpora, indexed once and
+queried many times. Bus traffic is the opposite shape — high-churn,
+append-only, time-ordered, and the dominant query pattern is "everything
+between t0 and t1 for instance X" (a replay), not semantic similarity search.
+A dedicated replay API over the JSONL stream (linear scan bounded by date
+partition + in-file binary search on the RFC3339 timestamp prefix, mirroring
+`AuditLogger`'s existing per-day file layout) is cheap, requires no daemon
+beyond `tm` itself, and matches the access pattern. **Concrete cost
+comparison:** indexing 100% of bus traffic into trusty-search's HNSW+BM25
+pipeline pays embedding cost on every message and holds a live in-memory
+index over data that is read almost exclusively by timestamp range, not by
+similarity — the wrong tool for the dominant query. The JSONL replay API pays
+approximately zero marginal cost beyond the write `tm` already performs.
+
+**Query surface:** a new `tm bus` (or daemon HTTP) surface —
+`GET /bus/replay?instance=<id>&since=<ts>&until=<ts>` and
+`GET /bus/thread?message_id=<id>` (walk `in_reply_to`, §11) — modeled
+directly on the existing `GET /sessions/{id}/events/poll` pattern
+(`crates/trusty-mpm/src/bin/tm/commands/session.rs:204`) rather than
+inventing a new HTTP idiom. **Exception, not contradiction:** if a later
+product need emerges for semantic search *over* bus history (e.g. "what did
+we ever discuss about X"), that is a `trusty-search` *attached index* per
+DOC-58's already-shipped K-d attached-index mechanism — pointed at the same
+JSONL files as a read-only secondary corpus, opt-in, not the default query
+path. This keeps the mandatory cost (JSONL write) flat and makes the
+expensive path (semantic indexing) something an operator turns on, not
+something every message pays for.
+
+## 10. Messages vs. memories
+
+**Normative constraint, restated as a rule this spec is bound by:** the bus
+is the log; `trusty-memory` is the curated index; consolidation is the ONLY
+sanctioned bridge between them. Nothing in this spec's design writes every
+bus message into memory. `trusty-memory`'s existing blocklist, dedup window,
+and short-content gates exist precisely because unscoped auto-capture already
+flooded the palace once — this spec's bus is a second, larger-volume source
+than whatever produced that flood, so respecting those gates is load-bearing,
+not optional politeness.
+
+**What actually happens to bus traffic by default: nothing, beyond §9's
+JSONL log.** Promotion to memory is an explicit act, performed by the
+existing consolidation surface (`mcp__trusty-memory__dream_consolidate_room`
+/ `palace_dream`), which already runs against a room's accumulated content on
+its own schedule and through its own gates. This spec's only change to that
+picture is making bus history one more thing consolidation *can* read from —
+via the replay API (§9), not a new firehose subscription — when a room's
+consolidation pass runs. Bus messages are not memory-eligible by default;
+they become eligible the same way any other room content does, subject to
+the same blocklist/dedup/short-content gates already enforced.
+
+**Provenance pointer: YES, required.** A memory promoted from bus content
+MUST retain a pointer back to the originating message(s) — concretely, the
+memory record carries the bus `message_id` (§11) (or a small ordered set,
+for a consolidation that merges several messages into one memory) it was
+derived from. This closes the gap the seed findings call out explicitly:
+neither system today can answer "why do I believe this?" A provenance
+pointer is cheap to carry (one more indexed field) and is the only way a
+future audit, correction, or "who said this and when" query resolves without
+re-deriving it by hand. This spec does not design the memory-record schema
+change itself (that is `trusty-memory`'s surface) — it specifies the
+requirement and the field the bus side must expose (`message_id`,
+globally unique, stable across the JSONL log's rotation) for
+`trusty-memory` to reference.
+
+## 11. Envelope schema (illustrative)
+
+Not normative wire format — illustrates how §6's three identifiers, §5's
+tree edges, and §8's channel-origin identity compose into one envelope
+shape, seeded from the existing `BusEnvelope` (§2/§3) and the `events.rs`
+payload vocabulary (§3 retirement #4) rather than invented from scratch.
+
+```jsonc
+{
+  "message_id": "01J...",                 // ULID/UUID, globally unique, stable — the §10 provenance key
+  "ts": "2026-07-28T13:00:00Z",
+  "in_reply_to": "01J... | null",          // threads a reply chain for §9's /bus/thread
+
+  "edge": "user_assistant | assistant_subagent | assistant_assistant",
+
+  "from": {                                // caller identity, §6c
+    "kind": "user | assistant_instance | channel",
+    "instance_id": "izzie#a1b2c3 | null",  // §6b, present when kind = assistant_instance
+    "definition_id": "izzie | null",       // §6a
+    "channel_origin": {                    // §8, present only when kind = channel
+      "connector": "slack | telegram",
+      "human_sender": "U012ABC",
+      "channel": "C0123",
+      "workspace": "T0123"
+    }
+  },
+
+  "to": {
+    "instance_id": "cto-assistant#d4e5f6 | null",  // resolved recipient, when live
+    "definition_id": "cto-assistant"               // always present — resolves via §7 wake rules when instance_id is null
+  },
+
+  "delivery_state": "queued | delivered | acked | dropped",  // ADR-0019's acknowledgment requirement, carried into this bus too
+
+  "payload": { "type": "chat_text | tool_call | ... ", "...": "..." }  // seeded from events.rs's variant union, §3 #4
+}
+```
+
+## 12. Open questions
+
+These cannot be resolved from the current codebase; the owner answers them,
+not this spec.
+
+1. **Retention window for `<logs_dir>/bus/*.jsonl`.** §9 reuses DOC-33's
+   pruning surface but does not set a default number of days — bus volume at
+   steady state (especially once channels, §8, ride it) is unknown without
+   production data, and this trades directly against disk cost.
+2. **Version-skew policy specifics (§4).** This spec establishes fail-closed
+   on publish / best-effort on consume for an incompatible major version, but
+   does not define the actual version negotiation handshake or what counts
+   as "incompatible" (major-only, or a finer compatibility matrix).
+3. **Auto-resume opt-in mechanics for channel-bound assistants (§7).** The
+   spec reuses `mcp__trusty-mpm__auto_resume_set` as the existing precedent
+   for spawn-on-message, but does not design the config surface that marks a
+   specific assistant definition as "always-on for channel X." Is this
+   per-definition, per-channel-binding, or both?
+4. **Cross-project lateral messaging.** §5's assistant↔assistant edge is
+   scoped to "communicate, never delegate," but does not resolve whether an
+   assistant in project A can address an assistant instance in project B
+   (the old `MessageBus`'s actual job, §2/§3) — or whether lateral
+   communication is scoped to one project's roster only.
+5. **Bus protocol version negotiation transport.** Where does a client learn
+   the daemon's bus protocol version — a new field on an existing
+   `supervisor_status`-shaped response, or a dedicated handshake message on
+   first connect? Not decided here.
+6. **Definition-id uniqueness across the whole system vs. per-project.**
+   §6a treats definition id as effectively global (`izzie`), but agent
+   configs are deployed per-project (DOC-42/agent-bundled-skills) — whether
+   two projects' same-named definitions are the same identity for bus
+   addressing purposes, or namespaced by project, is unresolved.
+7. **What triggers consolidation to actually read bus history (§10).**
+   Today's `dream_consolidate_room` runs against a room's existing content
+   on its own schedule; whether/how it is pointed at the bus replay API (poll
+   on a cadence, triggered by a threshold, or manual) is not designed here.
+
+## 13. DOC-N numbering note
+
+Per DOC-38 §4.1's scan-before-claim rule, `docs/specs/README.md`'s catalog was
+scanned before assigning this spec's number, rather than trusting its own
+"next free" hint blindly. That scan found the hint (`DOC-60`, noted
+2026-07-27) still correct, and surfaced **two already-double-booked numbers**
+that a naive scan could re-collide with:
+
+- **`DOC-42` is double-booked.** `docs/specs/agent-bundled-skills.md` (merged,
+  main) self-labels `DOC-42` — Agent-Bundled Skills. Separately, PR #3006
+  ("DOC-42: Engineering Lead / Virtual Twin Cross-Tool Orchestration
+  Architecture", branch `spec-twin-lead-architecture`, now CLOSED) also
+  claimed `DOC-42`, and `docs/adr/0016-orchestration-hierarchy-lead-pm-assistant.md`
+  still textually references "DOC-42 (Engineering Lead / Virtual Twin
+  architecture, PR #3006...)" as an open reconciliation item. The
+  `spec-twin-lead-architecture` branch's live claim has since moved to
+  `DOC-44`/`DOC-45` (per the README's own catalog note), but the stale
+  `DOC-42` reference in ADR-0016 is not corrected in this PR — out of scope,
+  flagged here per this task's instruction not to claim `DOC-42`.
+- **`DOC-46` is double-booked.** `docs/specs/DOC-46-adr-standard.md` (merged
+  via PR #3172) is the catalog's canonical `DOC-46` (ADR standard). But
+  **issue #3169** ("[BUS-13] File DOC-46: Control Bus Architecture spec doc",
+  still OPEN) reserved `DOC-46` for exactly the topic of this spec — a
+  control-bus architecture doc, written last "once the shape has proven out
+  in code (BUS-1 through BUS-6 stabilized)." PR #3172 landed first and took
+  the number issue #3169 had reserved. Issue #3169 is the direct predecessor
+  of this spec's subject matter but its claimed number is no longer free;
+  this spec supersedes issue #3169's intent under a new number rather than
+  reopening the `DOC-46` collision a second time. A follow-up should close
+  or retarget #3169 to point at `DOC-60`.
+
+**Number claimed by this spec: `DOC-60`** — the next free slot after the
+highest cataloged entry (`DOC-59`), confirmed free by: no file in
+`docs/specs/` self-labels it, no merged or open PR title references it
+(`gh pr list --search "DOC-60 in:title"` — empty), and no open issue title
+references it. A catalog row should be added to `docs/specs/README.md` when
+this spec leaves DRAFT status (not done in this PR, matching this task's
+draft-only, no-commit scope).

--- a/docs/specs/DOC-61-canonical-agent-standard.md
+++ b/docs/specs/DOC-61-canonical-agent-standard.md
@@ -1,0 +1,731 @@
+---
+spec_refs: []
+---
+
+# DOC-61 — Canonical Agent Standard: A Shared Source Model for trusty-mpm, trusty-code, and trusty-agents
+
+**Status:** DRAFT
+**Spec ID:** `SPEC-AGENTSTD-01~draft`
+**Subsystem:** cross-crate — trusty-mpm (source model owner today), trusty-code (per-product builder, prospective), trusty-agents (assistant/sub-agent split, `agents::config`)
+**Owner:** Architecture / Technical Leadership
+**DOC-N claim:** `DOC-61`, scan-before-claim per DOC-38 §4.1. `DOC-60` is left open — a bus-messaging spec is being authored concurrently by another agent in this same review round and is expected to claim it; this document deliberately claims one number past it to avoid a collision. `DOC-42` is explicitly NOT reused: it is currently claimed by `docs/specs/agent-bundled-skills.md` (retiring) and is reserved for ADR-0016's Engineering Lead / Virtual Twin architecture (PR #3006) per owner instruction. See docs/specs/README.md's "next free DOC-N" note for the full collision ledger (DOC-42, DOC-46 both currently double-booked, neither touched by this document).
+
+## 1. Executive Summary {#SPEC-AGENTSTD-01~draft}
+
+This spec proposes a **canonical sub-agent standard** shared by trusty-mpm,
+trusty-code, and trusty-agents, built by reusing — not reinventing — the
+compose-chain model trusty-mpm already ships: Markdown-with-YAML-frontmatter
+source files, `extends:`-chain inheritance flattened at build time, bundled
+skill references carried in frontmatter, and a checksum-tracked deploy
+manifest that never clobbers a hand-edited output file. This is an explicit
+owner directive ("It's like to re-use the model tm defines... We define core
+agents by type, they inherit bundled skills and properties in the tree"),
+verified in this document against the actual Rust implementation
+(`crates/trusty-agents-common/src/agents/{builder,deployer,manifest}.rs`,
+moved there from `trusty-mpm::core::agent_*` under issue #2892 specifically
+so a second harness could reuse it), not reconstructed from prose or the
+`tm-agent-architecture` skill summary alone.
+
+The standard splits cleanly into two halves that must not be conflated:
+
+1. **A shared source model and compose semantics** — the `extends:` chain,
+   the frontmatter merge rules, the bundled-skills union — is authoring-time
+   and product-agnostic. This is the part this document standardizes.
+2. **A per-product builder and per-runtime build artifact** is downstream and
+   product-specific. trusty-mpm's builder emits Claude Code subagent files
+   because Claude Code is trusty-mpm's runtime; trusty-code and trusty-agents
+   have their own runtimes and therefore get their own builders and their own
+   artifact shapes. Nothing in this document requires trusty-code or
+   trusty-agents to emit a Claude Code subagent file.
+
+Scope is **sub-agents only** (tier L1, in-process leaves, drawn from a typed
+catalog). Assistants (tier L0 — `pm`, `izzie`, `cto-assistant`,
+`personal-assistant`, `ctrl`) are a **distinct object kind** with their own
+five-section schema (personality / knowledge / skills / listeners /
+permissions, DOC-57) and are explicitly out of scope here, per the owner's
+own framing and the freshly-drafted ADR-0024
+(`docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md`,
+Proposed, not edited by this document).
+
+Two findings surfaced during verification are significant enough to flag up
+front, both expanded in §7:
+
+- The claim "sub-agents are never hand-edited, never hand-installed" is true
+  today only in the sense that no hand-install *entry point* exists. The
+  **mechanism** that would need to detect and preserve a hand-edited deployed
+  agent file already exists and is already active: `deploy_agents_filtered`
+  classifies any deployed `.md` whose checksum no longer matches its manifest
+  entry as user-modified and silently skips re-deploying it
+  (`crates/trusty-agents-common/src/agents/deployer.rs:276-288`). This is a
+  latent hazard, not a hypothetical one.
+- Neither of the two formats actually in use today is literally "YAML" in the
+  sense the owner's declarative-only decision states it. Sub-agents are
+  Markdown-with-YAML-*frontmatter* (a hand-rolled line parser, not a full YAML
+  library — see §6). Assistants are TOML (`agent.toml` + `persona.md`
+  packages), not YAML, at every layer checked in this repository. §9
+  addresses this honestly rather than silently rounding either format up to
+  "YAML."
+
+Status: **DRAFT**. This document does not commit any code and does not open
+a PR.
+
+## 2. Scope and Non-Goals {#SPEC-AGENTSTD-02~draft}
+
+**In scope:**
+
+- The source authoring model for **sub-agents** (tier L1 per ADR-0024): the
+  `extends:` inheritance chain, frontmatter merge semantics, bundled-skill
+  references, and the compose→deploy pipeline that turns sources into a
+  per-product build artifact.
+- The build pipeline shape: one shared composer, N per-product builders, N
+  per-runtime artifacts — and the versioning/determinism/partial-failure
+  questions that shape raises.
+- The migration path from today's per-product ad hoc agent definitions to
+  this standard.
+
+**Explicitly out of scope (per owner decision 3):**
+
+- Assistants/PM. Each assistant is a unique, user-instantiated entity, not a
+  member of a typed catalog with an inheritance tree. Its configuration
+  schema (five sections + a sub-agents whitelist) is governed by DOC-57 and
+  ADR-0024, not by this document. Where this document must reference the
+  assistant side (to justify treating the two as distinct schemas rather than
+  one schema with a flag, §5), it defers to those documents rather than
+  restating them.
+- The specific mechanics ADR-0024 leaves to the owner (the reachable
+  sub-agent whitelist's write-time floor, the 3-tool-call routing threshold,
+  the lateral-assistant delegation gate). This document does not re-litigate
+  those; it assumes ADR-0024's Decision 4 (an editable whitelist *over* the
+  sub-agent catalog this document standardizes) as a downstream consumer of
+  the catalog, not as something this document itself designs.
+- Runtime tool-calling, permission scopes, and dispatch — those are
+  per-runtime concerns downstream of the build artifact, not part of the
+  source model.
+
+## 3. tm's Actual Compose-Chain Model (Verified Against Code) {#SPEC-AGENTSTD-03~draft}
+
+Verified directly against `crates/trusty-agents-common/src/agents/{builder,deployer,manifest}.rs`
+(the implementation `trusty-mpm::core::agent_{builder,deployer}` now re-exports
+verbatim, moved there under issue #2892 "so a second harness can reuse the
+same composer instead of forking it" — `agent_builder.rs:1-16` is a pure
+`pub use` shim). This is the actual, current mechanism, not the
+`tm-agent-architecture` skill's summary of it — the skill is directionally
+correct but this section is the primary source.
+
+### 3.1 On-disk source format
+
+A source agent is one Markdown file: an optional `---`-delimited frontmatter
+block of `key: value` lines, followed by free-form instruction prose as the
+body. Base templates live alongside concrete agents in the same source
+directory, named with UPPERCASE stems (`BASE-AGENT.md`, `BASE-ENGINEER.md`,
+`BASE-QA.md`, ...); concrete agents declare `extends: base-engineer` in
+**lowercase**. Because macOS's default filesystem is case-insensitive and
+Linux's is not, resolution never does a raw path join — `build_source_map`
+(`builder.rs:161-177`) scans the directory once into a
+`HashMap<lowercased_stem, PathBuf>`, and every lookup goes through that map.
+
+### 3.2 Inheritance resolution
+
+`resolve` (`builder.rs:839-866`) walks `extends:` recursively, base-first,
+with two guards: a visited-path cycle check and a hard `MAX_DEPTH = 8`
+(`builder.rs:42`). It returns two parallel base-first vectors — frontmatter
+structs and body strings — which `render_composed` (`builder.rs:880-891`)
+folds into one document: a single merged frontmatter block, then the bodies
+concatenated with a blank line between each. `compose_agent`
+(`builder.rs:906-911`) is the public entry point most callers use; a
+disk-free variant, `compose_agent_in_memory` (issue #2958 Slice E1), shares
+the identical walk/cycle/depth logic through the `SourceLookup` trait
+(`builder.rs:130-150`) so an embedded-asset backend never forks the algorithm
+— a concrete precedent for how a second product could plug in its own source
+location without forking the composer itself.
+
+### 3.3 Frontmatter merge semantics (this is the part a "canonical standard" must standardize)
+
+`merge_frontmatter` (`builder.rs:708-823`) folds the chain base-first with
+**per-field merge policy**, not a single blanket rule:
+
+| Field | Merge policy | Rationale (from code comments) |
+|---|---|---|
+| `name`, `role`, `description`, `model`, `initialPrompt`, `resource_tier` | scalar, **child wins** | a concrete agent's own value must survive over its base's |
+| `max_tokens` | scalar, **child wins** | same as `model` |
+| `skills:` | **union**, de-duplicated, first-seen (base-first) order | "a list of dependencies naturally accumulates through inheritance the way body text concatenates" (`builder.rs:690-693`) — DOC-42 |
+| `tools:` | **override**, keyed on `Option` presence not emptiness | a restrictive leaf must be able to narrow a permissive base's tool set to zero (`tools: []` is `Some(vec![])`, deliberately distinct from an omitted key, which is `None` and inherits) — issue #2897, code-critic finding on PR #2952 |
+
+Two deploy-time enrichments are applied only after the chain merge, never
+per-file: `model` is derived from `resource_tier` when no explicit `model`
+survived (`tier_to_model`, `builder.rs:254-261`: `intensive→opus`,
+`lightweight→haiku`, everything else including unrecognized values
+`→sonnet`), and `initialPrompt` is derived from `role` when the source set
+none (`default_initial_prompt`, `builder.rs:273-298`, a fixed per-role table;
+interactive/special-purpose roles get no injected prompt).
+
+The parser is deliberately **not a general YAML parser**. It handles the
+subset trusty-mpm's own frontmatter needs: scalar `key: value` lines, an
+inline flow-array grammar shared by `skills:`/`tools:` (`parse_list_value`),
+and — since issue #2906's review — the YAML **block-sequence** form for
+`skills:` specifically (`- item` continuation lines under a bare `skills:`
+key, `builder.rs:334-405`, added because "every realistic upstream
+`claude-mpm-agents` asset" uses block style, not inline flow style). A
+malformed value warns and degrades to empty rather than hard-failing the
+whole file (`builder.rs:419-436`), except an unterminated frontmatter block,
+which is a hard `FrontmatterParse` error (`builder.rs:407-411`).
+
+Every freshly composed file is quoted-on-emit where a plain YAML scalar would
+be ambiguous or unsafe (`needs_quoting`/`render_scalar`, `builder.rs:596-676`
+— empty values, YAML indicator characters, embedded `": "`/trailing `:`/
+mid-string `" #"` comment starts, the YAML null tokens) and then **strictly
+re-validated** against `serde_yaml` before it is ever written
+(`crate::agents::frontmatter::validate_frontmatter`, invoked at
+`deployer.rs:224`) — because trusty-mpm's own lenient reader accepting a
+composition is not proof a strict downstream consumer (trusty-agents'
+`serde_yaml`-based `.md` loader) will. This two-tier validation (lenient
+compose, strict pre-write gate) exists precisely because issue #3556 found a
+composition that round-tripped through the lenient parser but was invalid
+YAML — recomposing alone could never have fixed it, because the bug was in
+what was *emitted*, not what was read.
+
+### 3.4 Deployment and the manifest
+
+`deploy_agents_filtered` (`deployer.rs:150-340`) is the write path. For every
+source agent whose stem the `select` predicate accepts, it composes, strict-
+validates, and classifies the corresponding target file into exactly one of:
+
+- **not present** → write it, record a fresh `ManifestEntry` (`source_chain`,
+  `checksum`, `deployed_at`, `origin: Bundled`).
+- **present, not manifest-tracked** → compare its checksum to the fresh
+  composition; if byte-identical, **silently adopt** it into the manifest
+  (issue #2504) with no rewrite; if it differs, **skip conservatively** and
+  flag it as `untracked_modified` (surfaced once, aggregated, pointing at
+  `tm install --reset-agents`).
+- **present, manifest-tracked, checksum matches manifest** → safe to
+  refresh; overwrite if the fresh composition differs, otherwise leave
+  untouched (`unchanged`).
+- **present, manifest-tracked, checksum does NOT match manifest** → the user
+  hand-edited it → **skip**, preserving their edit (`deployer.rs:284-288`).
+
+A single malformed source agent (unterminated frontmatter, a strict-YAML
+failure) is isolated — logged, recorded in `DeployResult::failed`, and the
+rest of the roster still deploys (`deployer.rs:202-236`, `failed`, `#2906`
+review CRITICAL finding: "a single malformed agent asset... must never abort
+the ENTIRE roster deploy"). §4.4 generalizes this per-agent isolation
+guarantee to the cross-product build question.
+
+Deployment priority — project `.claude/agents/` over user `~/.trusty-mpm/agents/`
+over cached remote — is a **selection-of-source-directory** concern upstream
+of `deploy_agents_filtered` (which agents/*sources* are visible to compose in
+the first place), not part of the merge/write logic itself; this document
+does not re-derive that precedence chain, which is `tm-agent-architecture`'s
+domain and was not found to differ from the skill's description in the code
+paths checked here.
+
+### 3.5 Where documented behavior and actual behavior diverge
+
+- The `tm-agent-architecture` skill's phrase "a hand-edited deployed file is
+  detected via checksum mismatch and left alone, never clobbered" is
+  accurate for the *documented* update workflow (edit source, rebuild,
+  redeploy) but understates a consequence: that same detection also silently
+  preserves a hand-edit made *without* going through the documented workflow
+  at all — there is no distinction in the code between "an operator
+  deliberately bypassed the official-agent rule" and "a future hand-install
+  feature wrote here." See §7.
+- No source or composed frontmatter field carries a **schema version**
+  today. The only version present anywhere in this pipeline is the
+  manifest's own top-level `"version": 1` (verified: this project's own
+  `.claude/agents/.trusty-mpm-manifest.json`), which versions the *manifest
+  file format*, not the *agent source schema*. §4.2 treats this as an open
+  gap this standard should close, not a solved problem to restate.
+
+## 4. Source Model vs. Build Artifact: One Model, Per-Product Builders {#SPEC-AGENTSTD-04~draft}
+
+Owner directive, verbatim: *"we BUILD tm agents to the claude code standard,
+we can have a custom builder if necessary."* The pipeline this standard
+specifies is:
+
+```
+one shared source model + compose semantics (§3)
+        │
+        ├─▶ trusty-mpm builder ──▶ Claude Code subagent file (~/.claude/agents/*.md)
+        ├─▶ trusty-code builder ─▶ trusty-code's own AgentConfig / runtime shape
+        └─▶ trusty-agents builder ▶ trusty-agents' own AgentConfig / runtime shape
+```
+
+**This is not purely aspirational** — trusty-code already has a real,
+narrower precedent for exactly this shape. `crates/trusty-code/src/plugins/agents.rs`
+(`discover_plugin_agents`, Phase-1 plugin agent ingestion, issue #3539)
+explicitly reuses trusty-mpm's own frontmatter/body parser
+(`trusty_agents_common::agents::metadata::agent_metadata_from_str`,
+`agents::md_loader::extract_body`) rather than forking it, and projects the
+result into trusty-code's *own* `AgentConfig` type
+(`agents::md_loader::project_to_agent_config`) — a different artifact shape
+than a Claude Code subagent file. Its own module doc states the point
+directly: *"a plugin's `agents/*.md` files are the exact same
+Markdown+frontmatter format `agents::md_loader` already parses... the only
+new work is namespacing and two Phase-1 leaf-only guarantees."* Two of those
+guarantees are directly relevant to this standard: unsupported trusty-mpm
+frontmatter fields (`effort`, `maxTurns`, `memory`, `isolation`,
+`disallowedTools` — `agents.rs:38-44`) are dropped with one aggregated
+warning rather than failing the load, and an `extends:` chain is **not**
+composed for a plugin agent — Phase 1 locks every plugin agent as a leaf.
+This is real, working evidence that a second product's builder can consume
+the same source format without adopting the first product's full compose
+semantics wholesale — exactly the "custom builder if necessary" the owner
+described — but it also shows the compose-chain (§3.2) is not yet
+universally shared: today, only trusty-mpm's own builder actually resolves
+`extends:`.
+
+### 4.1 What triggers a rebuild
+
+`tm install` (and, per-session, the HR-2 selective deploy path via
+`deploy_agents_filtered`'s `select` predicate) is the only trigger found in
+this codebase. There is no file-watcher or on-save auto-rebuild; a source
+edit is inert until the next explicit install/deploy call. This standard
+does not propose changing that trigger model — it is out of scope for a
+source-model spec — but flags it as a fact any per-product builder inherits:
+whichever event triggers *that* product's builder (its own install command,
+a CI step, a first-launch check) is that product's choice to make, not
+something this shared layer prescribes.
+
+### 4.2 Is the source model versioned?
+
+**No, not today**, per §3.5. This is a gap, not a design decision — nothing
+in `Frontmatter` (`builder.rs:189-239`) or the manifest schema
+(`manifest.rs`, top-level `"version": 1` only) carries a per-agent-source
+schema version. Recommendation: a canonical standard shared across three
+products should add an explicit, optional `schema_version:` (or similarly
+named) frontmatter key, absent-means-`1` for backward compatibility with
+every source file that exists today, so a future builder can refuse
+(loudly, not silently) to compose a source file declaring a schema version
+newer than that builder understands, rather than either crashing on an
+unrecognized field or silently misinterpreting it. This is new work, not
+already built — flagged as an open question in §10 for the owner to confirm
+priority against the migration converter (§8), which would be the natural
+place to stamp the version on every converted file.
+
+### 4.3 Is the build deterministic?
+
+**Yes, verified two ways.** First, `compose_agent` is a pure function of its
+inputs (source directory contents) with no non-determinism in the merge
+logic itself — the dedicated test `fs_and_in_memory_compose_are_byte_equivalent`
+(`builder_in_memory.rs`, cited from `render_composed`'s own doc comment,
+`builder.rs:868-879`) exists specifically to assert the fs-backed and
+in-memory-backed composers produce byte-identical output for identical
+input. Second, and more concretely: **this very repository's own deployed
+build artifacts are gitignored**, not checked in — `.claude/agents/` is
+re-included early in `.gitignore` (line 27-28) for a now-superseded reason,
+then unconditionally re-ignored by a later "auto-managed by tm" block
+(`.gitignore:106-108`, `git check-ignore -v .claude/agents/BASE-AGENT.md` →
+`.gitignore:106`, confirmed directly). A build artifact that is safe to
+regenerate on every machine without ever diffing against a checked-in copy
+is, by construction, being treated as deterministic-and-disposable in
+practice, not merely in theory. **Recommendation: per-product build
+artifacts should be gitignored**, matching this precedent, with the source
+directory (this standard's actual subject) as the only checked-in tree.
+
+### 4.4 Partial build failure: skip the product, or fail the whole build?
+
+`deploy_agents_filtered` already answers this question for the *existing*
+single-product (trusty-mpm) case: a per-agent compose or strict-validation
+failure is isolated — logged, recorded, skipped — and the rest of the roster
+still deploys (`deployer.rs:202-236`, §3.4). **Recommendation: generalize the
+same isolation policy one level up, per (agent × product) rather than only
+per agent.** If a source agent's frontmatter converts cleanly (composes,
+strict-YAML-validates) but a specific product's builder rejects it — e.g. a
+field that product's `AgentConfig` cannot represent, mirroring trusty-code's
+own `UNSUPPORTED_AGENT_FIELDS` drop-with-warning precedent (§4 above) at a
+stricter fail level — that product's build for that one agent should be
+skipped with a loud, aggregated warning, not abort that product's entire
+roster, and definitely not abort a *different* product's build. The existing
+`DeployResult::failed` shape (`"<name>: <error>"` strings, `deployer.rs:93`)
+is a reasonable model to extend with a product dimension rather than
+redesigning from scratch.
+
+## 5. Two Distinct Object Kinds: Assistant (L0) vs. Sub-Agent (L1) {#SPEC-AGENTSTD-05~draft}
+
+Owner directive, verbatim: *"For subagents only, the PM/Assistant is
+unique."* This is not a new position invented for this document — it is
+ADR-0024's own ratified model (Proposed, `docs/adr/0024-...md`, not edited
+here), restated in this spec's terms because a canonical agent standard has
+to say explicitly which of the two kinds it governs.
+
+| | **Assistant** (tier L0) | **Sub-agent** (tier L1) |
+|---|---|---|
+| Population | Unique, user-instantiated (`pm`, `izzie`, `cto-assistant`, `personal-assistant`, `ctrl`) | Drawn from a typed catalog; many instances of the same type |
+| Delegation | Delegates DOWN to sub-agents; communicates LATERALLY with other assistants (never delegates to them, ADR-0024 decision 2) | Never delegates in any direction — a leaf with exactly one edge (responds only to its invoking assistant), **already structurally enforced today**: `DelegateToAgentTool` is registered only inside the `role == ASSISTANT_TIER_ROLE` branch of `build_registry_for_agent`; every other role branch omits it entirely (ADR-0024 §"Is 'sub-agents never delegate' enforced, or merely conventional?") |
+| Configuration schema | Five sections — personality / knowledge / skills / listeners / permissions (DOC-57) — plus a sub-agents whitelist section (ADR-0024 decision 4) | This standard's compose-chain frontmatter + body (§3) |
+| Authored by | GUI-driven config writes (e.g. `PATCH /api/agents/:name`) and hand-edited prose (`persona.md`) | Source `.md` files under version control; never GUI-written, never (today) hand-installed |
+| Governed by | DOC-57 + ADR-0024 | This document |
+
+**Recommendation: two distinct object kinds with two distinct schemas, not
+one schema with a `kind`/`tier` flag.** The two rows above do not differ by
+one toggle — they differ in population shape (unique vs. catalog-typed),
+delegation direction (down-and-lateral vs. none), authoring surface (GUI +
+prose vs. version-controlled source), and consequently in every downstream
+question this document raises (versioning, determinism, round-trip
+preservation, §6-§7). Collapsing them into one schema with a flag would force
+the sub-agent format to carry accommodations (round-trip-safe editing,
+GUI-writable fields, a whitelist section) it structurally does not need, and
+would force the assistant format to pretend it participates in an
+inheritance tree it does not — ADR-0024 is explicit that assistants
+"communicate," not "extend," each other. This document's compose-chain
+standard applies to the sub-agent schema only; it takes the assistant
+schema's existence and shape as given from DOC-57/ADR-0024 and does not
+restate or modify it.
+
+## 6. On-Disk Format {#SPEC-AGENTSTD-06~draft}
+
+The owner declined to choose a format and said "whatever the tm standard
+is." Verified per §3.1: **Markdown with a `---`-delimited YAML-flavored
+frontmatter block, body as free-form instruction prose.** This document
+adopts that format as the canonical sub-agent source format, unmodified in
+shape, for all three products' sub-agent catalogs.
+
+**Flagged consequences of adopting this format as-is, honestly, rather than
+silently deviating:**
+
+- **The frontmatter parser is not a general YAML parser.** It is a hand-
+  rolled `key: value` line reader (`parse_kv_line`) plus a purpose-built
+  block-sequence reader added specifically for `skills:` (§3.3). A second
+  product's builder that wants to add a new structured (non-scalar,
+  non-flat-list) frontmatter field will either need the same kind of
+  bespoke block-reading code added to this shared parser, or will need to
+  restrict itself to scalars and flat lists. This is a real constraint on
+  the format's extensibility, not a hypothetical one — it already required
+  one purpose-built carve-out (the `skills:` block form) to match real
+  upstream agent assets.
+- **Quoting correctness was a real, shipped bug** (issue #3556): a
+  composition could pass trusty-mpm's own lenient reader while being invalid
+  strict YAML, and recomposing alone could not fix it because the bug was in
+  what the composer *emitted*. The fix (`needs_quoting`/`render_scalar`,
+  §3.3) is now in place, but any new per-product builder that re-serializes
+  frontmatter (rather than only reading it) inherits the same class of risk
+  and should reuse `render_scalar`/`escape_yaml_double_quoted` rather than
+  re-deriving quoting rules.
+- **No schema version field** — restated from §4.2, because it is as much an
+  on-disk-format gap as a build-pipeline gap: a canonical format shared by
+  three products needs a way for a reader to know which version of the
+  schema a given file was authored against.
+- **The format has no place for the assistant-side five sections.** Per §5,
+  this is by design, not a gap — the sub-agent format is not asked to
+  represent personality/knowledge/listeners/permissions, because sub-agents
+  do not have them. Flagged here only so a future reader does not mistake
+  the omission for an oversight.
+
+No alternative format was found to solve these problems better without
+abandoning the "reuse what tm already ships" directive, so this document
+recommends adopting the format as-is with the version-field addition from
+§4.2, rather than deviating.
+
+## 7. Editability and the Round-Trip Boundary {#SPEC-AGENTSTD-07~draft}
+
+Owner position: sub-agents are built artifacts — never hand-edited, never
+hand-installed (no entry point exists), never machine-written back — so
+there is no round-trip-preservation requirement for them, and YAML
+comment/ordering destruction is a non-issue. Assistants have editable
+instruction bodies and GUI-written config; the round-trip concern applies
+there, and only there.
+
+**This document agrees with the principle** (conflating the two would
+over-constrain the sub-agent format for accommodations it does not need,
+§5) **and recommends one format for sub-agents (no round-trip requirement,
+free to regenerate byte-for-byte) and a format for assistants that
+independently satisfies DOC-57/ADR-0024's round-trip needs** — not
+necessarily the same format, and this document does not prescribe the
+assistant format (out of scope, §2).
+
+### 7.1 Verifying the "never hand-installed" claim against the deployer
+
+**The claim is true about entry points and false about mechanism.** No code
+path in this repository lets an operator hand-install a sub-agent file into
+a deploy target the way, e.g., a skill can be manually dropped into a skills
+directory. But `deploy_agents_filtered`'s classification logic (§3.4,
+`deployer.rs:247-289`) is **identical in shape** to the skill deployer's
+checksum-based skip the task description asked this be verified against —
+and it is not merely analogous, it is the same manifest-ownership pattern
+applied to agents specifically:
+
+- A deployed agent file whose checksum no longer matches its manifest entry
+  is classified as user-modified and **left alone, never overwritten**
+  (`deployer.rs:276-288`).
+- An untracked deployed file that happens to differ from the fresh
+  composition is **also skipped**, conservatively, on the theory it might be
+  user-owned (`deployer.rs:256-273`).
+
+**This is a real, already-shipped latent hazard, not a hypothetical one
+introduced by a future feature.** Nothing distinguishes, in this code, "an
+operator manually edited a file in `~/.claude/agents/` by hand, bypassing
+the documented source-edit-then-rebuild workflow" from "a future
+hand-install feature legitimately wrote here." Today this matters only in a
+narrow, low-consequence way — an operator who edits a deployed file directly
+(against the documented workflow, but not prevented by any tooling) finds
+their edit silently preserved across the next `tm install`, which looks like
+correct, protective behavior and mostly is. **The hazard "becomes real" the
+moment any hand-installation entry point ships**, exactly as this task
+description anticipated: at that point, the SAME skip logic that today only
+protects an edge-case manual edit will be the mechanism a legitimate,
+sanctioned hand-install feature also passes through, and the standard will
+need to decide — explicitly, not by default — whether a hand-installed
+sub-agent is meant to survive future rebuilds (in which case this is the
+correct, intended behavior and should be documented as such) or whether
+hand-installed agents should be a visibly distinct, separately-tracked
+category (e.g. a manifest `origin` value distinct from `Bundled`, which the
+manifest schema already supports as an enum — `Origin::Bundled` is one
+variant of a type built to have more than one).
+
+**Recommendation:** this standard should not build new machinery to close
+this gap now (no hand-install feature exists yet to close it for), but
+should record the finding so the eventual hand-install design treats it as a
+known, load-bearing decision rather than rediscovering it under time
+pressure. Flagged for §10.
+
+## 8. Migration: Hard Cut + Converter {#SPEC-AGENTSTD-08~draft}
+
+Owner decision: one release converts every agent definition; old-format
+support is removed. No dual-read compatibility layer.
+
+### 8.1 Converter design
+
+- **Reads:** every sub-agent source recognized by any of the three products'
+  current ad hoc formats — trusty-mpm's existing Markdown+frontmatter
+  sources (already this standard's target format, so this is close to a
+  no-op pass for that side), and trusty-code's/trusty-agents' own current
+  sub-agent-shaped definitions (whatever pre-standard format each has today,
+  outside this document's own verified scope — the converter's per-product
+  read adapters are per-product work this standard hands off, not something
+  this document itself has fully audited across all three codebases).
+- **Writes:** this standard's canonical Markdown+YAML-frontmatter format
+  (§6), stamped with the `schema_version:` field this document recommends
+  adding (§4.2), so every converted file is unambiguously versioned from the
+  moment the converter first runs — closing the "no schema version today"
+  gap and the migration in the same change, rather than two.
+- **`extends:` chain handling:** carried over unchanged in *shape* — a
+  converted child still declares `extends: <parent-stem>` — but every stem
+  it references must resolve inside the converter's *combined* output set
+  (a source that `extends:` a base template the converter did not also
+  convert is a converter error for that agent, not a silent dangling
+  reference). The converter should run the existing `resolve`/cycle/depth
+  logic (§3.2) against its own converted output as a self-check before
+  declaring success, since that logic already exists and already does
+  exactly this validation.
+- **Package-vs-flat-file duality:** today this duality exists on the
+  *assistant* side only (`agents/<name>/agent.toml` directory package wins
+  over a flat `<name>.toml`, per DOC-57 §"P-1" and `loader.rs:163`) — it is
+  out of this document's scope by §5/§2, and the converter does not need to
+  resolve it for sub-agents, which have no packaged form today. If a future
+  per-product sub-agent source ever grows a packaged form, the converter
+  should apply the same win-precedence rule assistants already use, for
+  consistency, rather than inventing a second precedence rule.
+- **An agent the converter cannot convert:** flagged and skipped, not a
+  fatal converter run — mirroring the per-agent isolation principle §3.4/§4.4
+  already establish for compose and per-product build failures respectively.
+  The converter should report every skipped agent by name and reason in one
+  aggregated summary (matching the existing `DeployResult::failed` /
+  `untracked_modified` aggregated-warning pattern, §3.4) rather than either
+  aborting the whole run or failing silently.
+- **When it runs:** **recommend an explicit CLI command** (e.g. `tm agents
+  convert` or product-equivalent), run once per install as part of the
+  release that ships the hard cut, with a `--dry-run` mode that reports what
+  would convert/skip without writing anything. Recommend against install-time
+  automatic conversion with no operator visibility (a hard cut with no
+  fallback is exactly the case where an operator should see the before/after
+  diff, not have it happen invisibly during an unrelated `tm install`), and
+  against first-load lazy auto-convert (it would leave the on-disk state
+  ambiguous about whether "not yet converted" and "converted, using the old
+  format because conversion produced this" are distinguishable — an explicit,
+  logged, one-time command is not).
+- **Reversibility:** **not reversible** as a hard cut — old-format support is
+  removed in the same release, so there is no dual-format fallback to revert
+  to. The mitigating fact the task description names is real and load-
+  bearing: because deployed sub-agent artifacts are **derived** (§4.3), the
+  actual blast radius of an imperfect conversion is the *source* definitions
+  only — a corrupted or lossy conversion of one source file does not corrupt
+  any already-deployed artifact for any other agent, and re-running the
+  builder against a corrected source regenerates the artifact cleanly. This
+  is a genuinely different risk profile than migrating, say, a database
+  schema: the "data" here is mostly re-derivable, not append-only state.
+
+### 8.2 Breakage cost — live agents affected
+
+Per the task's own enumeration, live agent definitions on disk today include
+`assistant`, `cto-assistant`, `izzie`, `researcher`, `ticketing-agent`,
+`local-ops-agent`, plus every in-repo bundled definition under
+`crates/trusty-mpm/src/assets/agents/` (42 composed files in this
+repository's own `.claude/agents/` at the time of writing — §4.3). Per §5,
+`assistant`/`cto-assistant`/`izzie` are **assistants (L0)**, out of this
+converter's scope entirely — their config format (TOML `agent.toml` +
+`persona.md`) is untouched by a sub-agent-format hard cut. `researcher`,
+`ticketing-agent`, `local-ops-agent`, and the bundled trusty-mpm roster are
+**sub-agents (L1)** and are exactly this converter's subject.
+
+### 8.3 Per-field carry-over table
+
+| Field | Carries over unchanged | Changes shape | Dies |
+|---|---|---|---|
+| `extends` chain | Yes — same grammar, same base-first walk (§8.1) | | |
+| package-vs-flat-file duality | | N/A to sub-agents today (§8.1); assistants keep their own existing duality, untouched by this document | |
+| `hidden` | | | **Dies** — not present in trusty-mpm's current `Frontmatter` struct (`builder.rs:189-239` has no such field); found only in trusty-code's plugin-agent `UNSUPPORTED_AGENT_FIELDS` drop list (`agents.rs:38-44`) as a field trusty-mpm's own schema has no slot for today. Not carried forward unless the owner explicitly reintroduces it. |
+| `display_name` | | | **Dies** — same evidence as `hidden`; not present in the verified `Frontmatter` struct. |
+| `role` | Yes — scalar, child-wins, drives `initialPrompt` derivation (§3.3) | | |
+| `tier` | | **Changes shape** — `tier` as ADR-0024/`AgentTier` defines it (`config.rs:680-713`, `l0`/`l1`) is an **assistant-side** concept describing delegation authority, not a sub-agent frontmatter field. A sub-agent is unconditionally L1 by construction (no field needed, §5) — carrying a `tier:` key into the sub-agent schema would be a category error under ADR-0024's own model. | |
+| `[skills].allow` | | **Changes shape** — becomes the `skills:` frontmatter list (§3.3, union-across-chain), which is a *declaration of dependency*, not an *allow-list gate*; DOC-42's own model treats it as co-deployment input, not a permission surface. | |
+| `[subagents].allowed` | | **Changes shape, and lives on the assistant side, not here** — this is ADR-0024 decision 4's editable whitelist *over* the sub-agent catalog this document produces; it is consumed by, not part of, the sub-agent source format. Out of scope by §2/§5. | |
+
+Recommendation: the converter's own summary output should restate this table
+per-agent (which fields it read, which it dropped, which it reshaped) rather
+than only reporting success/skip, since `hidden`/`display_name` dying
+silently is exactly the kind of loss an operator should see named, not
+infer.
+
+## 9. Relationship to the Declarative-Only Decision {#SPEC-AGENTSTD-09~draft}
+
+Standing owner decision: agents are declarative-only — no coded agents,
+defined entirely as instructions with YAML primitive bindings. The question
+this section must answer honestly: is adopting the compose-chain format
+(§6) that decision *finally landing*, or a *new* decision?
+
+**Mostly the former, with one honest correction.** The "no coded agents,
+instructions + declarative bindings" half of the standing decision is
+already exactly what §3 verified: a sub-agent source is Markdown prose (the
+instructions) plus a frontmatter block of scalar/list bindings (`role`,
+`model`, `skills:`, `tools:`) — there is no code, no conditional logic, no
+programmatic agent definition anywhere in the pipeline checked in this
+document. Adopting this format as the *canonical, shared* standard is best
+read as **the declarative-only decision landing across all three products**,
+not a new decision requiring separate ratification — it generalizes an
+already-shipped trusty-mpm reality rather than introducing a new constraint.
+
+**The correction:** the standing decision's own wording — "YAML primitive
+bindings" — does not literally match either format verified in this
+codebase. Sub-agents are Markdown with YAML-*flavored* frontmatter (a
+hand-rolled subset parser, §6, not a full YAML library, and strict-YAML-
+validated only at the final pre-write gate). Assistants are **TOML**
+(`agent.toml` + `persona.md` packages, verified via DOC-57's own citations —
+`agent.toml`'s `[[stores]]`, `[tools].allow`, `[tools].scopes` tables,
+`persona.rs`, `loader.rs:163`), not YAML, at every layer this document
+checked. Neither side of the product today is literally "YAML" end to end.
+
+This document recommends **not** forcing a literal-YAML rewrite of either
+format to make the standing decision's wording true by letter rather than by
+spirit — §6 already found real, working reasons to keep the sub-agent format
+as-is, and the assistant side's TOML choice is DOC-57/ADR-0024's decision to
+revisit, not this document's. Recommendation: treat "YAML primitive
+bindings" as shorthand for "declarative, structured, non-programmatic key-
+value + list bindings" (which both formats genuinely are), and either amend
+the standing decision's wording to say so explicitly, or accept the
+imprecision as understood-but-not-literal. This is flagged for the owner in
+§10 rather than resolved unilaterally here.
+
+## 10. Open Questions for the Owner {#SPEC-AGENTSTD-10~draft}
+
+These cannot be resolved from code alone; each names the section that raised
+it.
+
+1. **Schema versioning (§4.2, §8.1):** approve adding a `schema_version:`
+   frontmatter key (absent = `1`), stamped by the migration converter, so a
+   future builder can refuse a source it does not understand rather than
+   silently misreading it?
+2. **Deterministic-artifact gitignore precedent (§4.3):** confirm that
+   per-product deployed sub-agent artifacts (trusty-code's, trusty-agents'
+   own build outputs, not only trusty-mpm's) should be gitignored by default,
+   matching this repository's own existing `.claude/agents/` precedent,
+   rather than checked in per product?
+3. **Partial-product build failure (§4.4):** confirm the recommended policy
+   — isolate per (agent × product), skip that one agent for that one
+   product with a loud warning, never abort a whole product's roster or a
+   different product's build — as the intended behavior, and confirm whether
+   the existing `DeployResult::failed` shape should be extended in place or
+   a new cross-product result type introduced.
+4. **The hand-install / checksum-skip hazard (§7.1):** now that it is
+   verified as an already-shipped mechanism (not a hypothetical), decide
+   explicitly — when a hand-install entry point eventually ships, should a
+   hand-installed sub-agent be (a) silently preserved across rebuilds
+   exactly like an accidental hand-edit is today, or (b) tracked under a
+   visibly distinct manifest `origin` so it is never confused with a bundled
+   artifact? This document takes no position; it only surfaces that the
+   mechanism enabling (a) already exists whether or not (b) is chosen.
+5. **Converter timing and command surface (§8.1):** confirm `tm agents
+   convert` (or a product-appropriate equivalent name) with a `--dry-run`
+   mode, run explicitly once per product as part of the hard-cut release, is
+   the intended migration UX — versus, e.g., folding it silently into the
+   next `tm install` with no separate command.
+6. **`hidden`/`display_name` (§8.3):** confirm these standing claude-mpm-era
+   fields are intentionally dropped (not reintroduced) under the canonical
+   standard, since no current trusty-mpm `Frontmatter` field represents
+   them and no owner decision reviewed here calls for reviving them.
+7. **"YAML primitive bindings" wording (§9):** amend the standing
+   declarative-only decision's wording to acknowledge neither verified
+   format (sub-agent YAML-frontmatter, assistant TOML) is literally YAML end
+   to end, or treat the imprecision as already understood and not requiring
+   a wording change?
+8. **trusty-code's and trusty-agents' current sub-agent formats (§8.1):**
+   this document verified trusty-mpm's compose-chain implementation in
+   detail and trusty-code's Phase-1 plugin-agent *reader* (which already
+   reuses the same frontmatter parser, §4), but did not fully audit every
+   pre-standard sub-agent definition format trusty-code and trusty-agents
+   use today outside that one plugin path. The converter's per-product read
+   adapters (§8.1) are real, non-trivial per-product work this document
+   flags but does not scope in detail — worth a follow-up research pass
+   per product before implementation begins.
+
+## 11. References {#SPEC-AGENTSTD-11~draft}
+
+**Code (verified directly in this repository, this worktree):**
+
+- `crates/trusty-agents-common/src/agents/builder.rs` — compose-chain
+  implementation: `Frontmatter`, `split_frontmatter`, `merge_frontmatter`,
+  `resolve`, `render_composed`, `compose_agent`, `source_chain`,
+  `needs_quoting`/`render_scalar` quoting-on-emit (issue #3556).
+- `crates/trusty-agents-common/src/agents/deployer.rs` — `deploy_agents`,
+  `deploy_agents_filtered`, `DeployResult`, checksum-based manifest
+  classification, per-agent failure isolation (#2906).
+- `crates/trusty-agents-common/src/agents/manifest.rs` — `AgentManifest`,
+  `ManifestEntry`, `Origin`, `checksum`, `atomic_write`.
+- `crates/trusty-mpm/src/core/{agent_builder,agent_deployer}.rs` —
+  source-compatibility re-export shims (#2892).
+- `crates/trusty-code/src/plugins/agents.rs` — Phase-1 plugin agent
+  ingestion, the concrete precedent for a second product's builder reusing
+  the shared frontmatter parser (#3539).
+- `crates/trusty-agents/src/agents/config.rs` — `AgentTier`,
+  `SubagentsConfig`, the assistant-side TOML config model (`config.rs:240,
+  680-790`).
+- `.gitignore` (this repository) — the deployed-artifact gitignore
+  precedent (§4.3), `git check-ignore -v .claude/agents/BASE-AGENT.md` →
+  `.gitignore:106`.
+- `.claude/agents/.trusty-mpm-manifest.json` (this repository) — a live
+  manifest instance, cited for its `"version": 1` top-level field and
+  per-entry `source_chain`/`checksum`/`origin` shape.
+
+**Specs and ADRs:**
+
+- `docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md`
+  — the L0/assistant vs. L1/sub-agent tier model this document takes as
+  given (§5). Proposed, not edited by this document.
+- `docs/adr/0016-orchestration-hierarchy-lead-pm-assistant.md` — the
+  singleton-"ASSISTANT" hierarchy role ADR-0024 §5 distinguishes from
+  trusty-agents' plural assistant population; also the reservation target
+  for DOC-42 (not claimed by this document).
+- `docs/specs/agent-config-five-sections.md` (DOC-57) — the assistant-side
+  five-section schema this document defers to rather than restates (§2, §5).
+- `docs/specs/agent-bundled-skills.md` (DOC-42) — the `skills:`
+  co-deployment model §3.3's `skills:` union merge implements.
+- `docs/specs/README.md` — the DOC-N catalog and scan-before-claim
+  collision ledger (DOC-42, DOC-46 both currently double-booked; DOC-58/
+  DOC-59 the most recently claimed numbers at the time this document claimed
+  DOC-61).
+- `.claude/skills/tm-agent-architecture/SKILL.md` (skill content) — the
+  official-vs-custom-agent workflow summary this document verifies against
+  and, in §3.5, notes one place it understates.
+
+**Related open work referenced but not resolved here:** ADR-0024's own open
+questions (the reachable-sub-agent-whitelist write-time floor, the
+3-tool-call routing threshold, the lateral-delegation gate fix, issue
+#4201's persona.rs gap) — all downstream consumers of, not part of, the
+sub-agent catalog this document standardizes.
+
+## 12. Change Log {#SPEC-AGENTSTD-12~draft}
+
+- 2026-07-28 — Initial DRAFT. Claims `DOC-61` (scan-before-claim, DOC-38
+  §4.1; `DOC-60` deliberately left for a concurrently-authored bus-messaging
+  spec; `DOC-42` explicitly not reused). Sub-agent scope only, per ADR-0024
+  and owner decision 3. Compose-chain model (§3) verified directly against
+  `crates/trusty-agents-common/src/agents/{builder,deployer,manifest}.rs`
+  and this repository's own live `.claude/agents/` deployment.

--- a/docs/specs/DOC-61-canonical-agent-standard.md
+++ b/docs/specs/DOC-61-canonical-agent-standard.md
@@ -8,6 +8,7 @@ spec_refs: []
 **Spec ID:** `SPEC-AGENTSTD-01~draft`
 **Subsystem:** cross-crate — trusty-mpm (source model owner today), trusty-code (per-product builder, prospective), trusty-agents (assistant/sub-agent split, `agents::config`)
 **Owner:** Architecture / Technical Leadership
+**Last-updated:** 2026-07-28
 **DOC-N claim:** `DOC-61`, scan-before-claim per DOC-38 §4.1. `DOC-60` is left open — a bus-messaging spec is being authored concurrently by another agent in this same review round and is expected to claim it; this document deliberately claims one number past it to avoid a collision. `DOC-42` is explicitly NOT reused: it is currently claimed by `docs/specs/agent-bundled-skills.md` (retiring) and is reserved for ADR-0016's Engineering Lead / Virtual Twin architecture (PR #3006) per owner instruction. See docs/specs/README.md's "next free DOC-N" note for the full collision ledger (DOC-42, DOC-46 both currently double-booked, neither touched by this document).
 
 ## 1. Executive Summary {#SPEC-AGENTSTD-01~draft}

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -75,6 +75,8 @@ normative grammar — this note does not restate it.
 | DOC-57 | `SPEC-AGENTCFG-01~draft` … `-09~draft` | [Five-Section Agent Configuration: Personality / Knowledge / Skills / Listeners / Permissions](./agent-config-five-sections.md) | trusty-agents — agent configuration model, capability declaration (tool→skill wrapping), permissions surface, GUI config pane (**supersedes DOC-54 §5**) |
 | DOC-58 | `SPEC-KDIDX-01~draft` … `-06~draft` | [Knowledge Section Addendum: K-d Attached Search Indexes](./DOC-58-knowledge-kd-attached-indexes.md) | trusty-agents — Knowledge section (DOC-57 §4) fourth sub-surface, `tools.search_indexes` config; trusty-search — arbitrary attached indexes (**extends DOC-57 §4 and amends #3935's scope; edits neither in place**) |
 | DOC-59 | `SPEC-PMINSTR-01~draft` … `-07~draft` | [P1/P2 Instruction Restructure: Tiered, Cache-Stable, Customizable PM System Prompt Composition](./SPEC-PMINSTR-01-p1-p2-instruction-restructure.md) | trusty-mpm — PM instruction pipeline (`instruction_pipeline.rs`, `instruction_overrides.rs`, `stack_profile.rs`); session-manager (workstream/session persistence) — motivated by issue #4071 |
+| DOC-60 | `SPEC-AGENTBUS-01~draft` | [Bus-Based Agent Messaging](./DOC-60-bus-based-agent-messaging.md) | trusty-mpm (bus host, daemon) — trusty-agents (assistants, sub-agents, ctrl) — trusty-channels (Slack/Telegram/etc.) — trusty-memory (consolidation target) — trusty-search (index target) |
+| DOC-61 | `SPEC-AGENTSTD-01~draft` | [Canonical Agent Standard: A Shared Source Model for trusty-mpm, trusty-code, and trusty-agents](./DOC-61-canonical-agent-standard.md) | cross-crate — trusty-mpm (source model owner today), trusty-code (per-product builder, prospective), trusty-agents (assistant/sub-agent split, `agents::config`) |
 
 > **Catalog note — `DOC-34` gap.** `DOC-34` (`SPEC-CFGDIR-01~draft`…`-05~draft`,
 > [Managed sessions launch with a tm-owned `CLAUDE_CONFIG_DIR`](./managed-session-config-dir.md))
@@ -88,7 +90,9 @@ normative grammar — this note does not restate it.
 > file is **not** in this catalog. The collision is flagged here rather than resolved by
 > renumbering the file in-place (its self-label and any inbound references are left
 > untouched); a follow-up should assign it the next free `DOC-N` and add a catalog row.
-> **Next free `DOC-N` = `DOC-60`** (updated 2026-07-27 — DOC-59 claimed by
+> **Next free `DOC-N` = `DOC-62`** (updated 2026-07-28 — DOC-60 claimed by
+> [Bus-Based Agent Messaging](./DOC-60-bus-based-agent-messaging.md) and DOC-61 by
+> [Canonical Agent Standard](./DOC-61-canonical-agent-standard.md); DOC-59 claimed by
 > [P1/P2 Instruction Restructure](./SPEC-PMINSTR-01-p1-p2-instruction-restructure.md),
 > DOC-58 claimed by
 > [Knowledge Section Addendum: K-d Attached Search Indexes](./DOC-58-knowledge-kd-attached-indexes.md),


### PR DESCRIPTION
## Summary

Captures three design documents for review and recoverability. **This is a DOCS-ONLY PR** — no source code changes, so the per-PR CHANGELOG requirement does not apply.

- **ADR-0024** — `docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md` (Status: **Proposed**): proposes that assistants are level-0 delegators, and sub-agents are in-process, single-edge leaves that never delegate — a model for who may delegate to whom.
- **DOC-60** — `docs/specs/DOC-60-bus-based-agent-messaging.md` (Status: **DRAFT**): spec for bus-based agent messaging, built on top of ADR-0024's delegation model.
- **DOC-61** — `docs/specs/DOC-61-canonical-agent-standard.md` (Status: **DRAFT**): spec for a canonical agent standard (sub-agent source format / compose-chain frontmatter), building on DOC-57 and ADR-0024.

## Status note — not a ratification

ADR-0024 is Status **Proposed** and DOC-60/DOC-61 are Status **DRAFT**. Merging this PR captures them for review and gives them a durable, recoverable location in the repo — it does **not** ratify the decisions or specs they record. ADR-0024 remains Proposed pending owner acceptance.

Open-question sections still needing owner answers:
- ADR-0024: the conflicts/open-questions section (unresolved questions on enforcement and scope)
- DOC-60 §12: 7 open items
- DOC-61 §10: 8 open items

## Renumbering note (0023 -> 0024)

The ADR was originally drafted as ADR-0023, but by the time this branch was cut from `main`, `main` already carried an unrelated, separately-merged ADR-0023 (`docs/adr/0023-worktree-authority-existence-vs-ownership.md`, "worktree authority: existence vs ownership", #4237). To avoid a numbering collision, the file and all internal cross-references across the three documents were mechanically renumbered 0023 -> 0024 at commit time. No content was otherwise changed; the ADR's decision content and title are unaffected beyond the number.

## References

- Epic #4021
- Issue #4201
- Issue #4182
- Issue #3169 — DOC-60 supersedes #3169's DOC-46 intent

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools