### PR TITLE
docs: record the virtual-twin authority rationale for ADR-0024

### DIFF
--- a/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
+++ b/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
@@ -335,20 +335,15 @@ stipulating it:
   assistants, never to sub-agents** (decision 5): responsibility follows
   authority, and only assistants hold any.
 
-**Terminology note — "virtual twin" already names something else in this
-corpus.** DOC-42 ("Engineering Lead / Virtual Twin Cross-Tool Orchestration
+**Terminology note.** "Virtual twin" also appears elsewhere in this corpus —
+DOC-42 ("Engineering Lead / Virtual Twin Cross-Tool Orchestration
 Architecture," PR #3006, closed unmerged, its live claim since moved to
-DOC-44) and ADR-0016 (which cites DOC-42) use "virtual twin" to name the
-**Engineering Lead** — a single, persistent, portfolio-level supervisor role
-that sits ABOVE PM, not the plural `role = "assistant"` population this ADR
-governs. Issue #3011 states it directly: *"This is the 'virtual twin'
-itself... a persistent lead agent... spawns liaisons."* The owner's rationale
-above uses "virtual twin" as a PROPERTY every assistant instance holds
-(authority over its own actions), not as a name for one Lead role. These are
-two distinct usages of the same term, live in the same corpus at the same
-time. This ADR does not reconcile them and flags the collision rather than
-silently picking one — a future pass across ADR-0016/DOC-44/this ADR should
-resolve whether one term should be renamed.
+DOC-44) and ADR-0016 (which cites DOC-42) use it as a **role name** for the
+Engineering Lead, a persistent, portfolio-level supervisor above PM. Here,
+by contrast, "virtual twin" is **philosophical framing, not a technical
+identifier**: it names the sense in which each assistant owns its own
+actions, motivating the authority principle above. The two usages coexist
+and neither constrains the other.
 
 ## Normative Rule: Delegation Authority Is Governed by Kind, Not by Tier Order
 
@@ -903,10 +898,9 @@ Vetted against prior ADRs (`docs/adr/INDEX.md`) on 2026-07-28 (revision 2):
   "assistant" population are still different things sharing one name.
   Additionally, §7 above uses ADR-0016's PM-analogy sibling (the trusty-mpm
   PM, not ADR-0016 itself) as prior art — worth a forward cross-reference
-  from ADR-0016 once this ADR is accepted. A SECOND, separate naming
-  collision now exists too: "Rationale" above uses "virtual twin" for a
-  property of every assistant, while ADR-0016 (via DOC-42/DOC-44) uses it as
-  the Engineering Lead's role name — flagged there, not resolved here.
+  from ADR-0016 once this ADR is accepted. "Rationale" above also uses
+  "virtual twin" in a philosophical sense distinct from ADR-0016's Engineering
+  Lead role name of the same phrase; the two are not in tension.
 - **ADR-0018 (Loopback-only doctrine, Accepted):** Consistent — unchanged.
 - **ADR-0019 (Unified IPC messaging, Accepted, unimplemented):** Extends —
   unchanged, still the most likely foundation for the "communicate"

--- a/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
+++ b/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
@@ -4,7 +4,8 @@
 - **Date:** 2026-07-28
 - **Scope:** crate `trusty-agents` (the `delegate_to_agent` / `dispatch_task` boundary; the L0/L1 tier model, #4167/#4200; touches the `trusty-code` cross-product bridge target and the Sub-agents API/pane, `#4029`/`#4211`)
 - **Reversibility Cost:** High — reverses/re-scopes shipped, tested, owner-directed machinery from epic #4021 (#4026/#4027/#4028/#4211, merged within 48 hours of this ADR), INVERTS the population assignment of the L0/L1 tier model merged the SAME DAY as this decision (PR #4200, squash `ada4d351`), and requires new, currently nonexistent machinery (an editable sub-agent whitelist, an assistant-to-assistant messaging primitive, and a tool-call-counted skill/delegate router)
-- **Decision Drivers:** Product framing clarity (the Sub-agents pane could not honestly present a name that means two different things), the owner's rejection of a UI-only fix, the owner's explicit generalization of the YOLO risk posture to every assistant, a documentation gap (DOC-57 does not yet cover Sub-agents at all, #4182), and the owner's own PM/trusty-mpm prior art as an explicit analogy with an owner-named limit
+- **Decision Drivers:** Product framing clarity (the Sub-agents pane could not honestly present a name that means two different things), the owner's rejection of a UI-only fix, the owner's explicit generalization of the YOLO risk posture to every assistant, a documentation gap (DOC-57 does not yet cover Sub-agents at all, #4182), the owner's own PM/trusty-mpm prior art as an explicit analogy with an owner-named limit, and — underlying all of the above — the owner's virtual-twin authority principle (see "Rationale" below): each assistant must take authority over its own actions, and that authority is not transferable between assistants
+
 - **Supersedes / Superseded by:** — this ADR's OWN prior revision (same document, same day) recommended a hand-authored constant (`ASSISTANT_ALLOWED_DELEGATE_ROLES`-style) as the reachable-target model; decision 2 below explicitly supersedes that recommendation in favor of an editable config whitelist. See "Conflicts and open questions" for the still-unresolved tension with the owner's 2026-07-26 ruling on epic #4021's OQ-2.
 
 ## Context
@@ -301,6 +302,53 @@ This ADR does not yet decide, and defers to the owner (see "Consequences"
 and "Conflicts and open questions"), the mechanics each clause raises but
 does not itself answer — enumerated in the Consequences sections below,
 each ending in an explicit recommendation marked owner-ratify.
+
+## Rationale: The Virtual-Twin Authority Principle
+
+The owner gave the underlying reason the boundary above falls exactly where
+it does, in these words:
+
+> "assistants and COMMUNICATE with each other, the difference is each
+> assistant is a virtual twin that must take authority over its own
+> actions."
+
+**The principle:** each assistant is a virtual twin — it must take authority
+over its own actions. Delegation TRANSFERS authority: one agent commanding
+another to act on its behalf. Communication transfers nothing: it is an
+exchange between two parties, each still acting under its own authority. Two
+twins cannot command each other, because neither can surrender authority
+over its own actions — that authority is not transferable.
+
+This DERIVES the boundary stated in the Decision above, rather than merely
+stipulating it:
+
+- **A sub-agent holds no independent authority.** It is an in-process
+  extension of the assistant that invoked it (single-edge leaf, Context §2),
+  so delegating to it exercises the assistant's OWN authority rather than
+  transferring authority to a second, independent holder. Delegation is
+  coherent for this edge.
+- **An assistant owns its own actions.** One assistant commanding another
+  would require the target to surrender authority over its own actions to
+  the source — the one thing a virtual twin cannot do. Only communication
+  (decisions 1/3/4 above; DOC-60 §5.3) is coherent on this edge.
+- **This is also why YOLO / owner-accepted responsibility attaches to
+  assistants, never to sub-agents** (decision 5): responsibility follows
+  authority, and only assistants hold any.
+
+**Terminology note — "virtual twin" already names something else in this
+corpus.** DOC-42 ("Engineering Lead / Virtual Twin Cross-Tool Orchestration
+Architecture," PR #3006, closed unmerged, its live claim since moved to
+DOC-44) and ADR-0016 (which cites DOC-42) use "virtual twin" to name the
+**Engineering Lead** — a single, persistent, portfolio-level supervisor role
+that sits ABOVE PM, not the plural `role = "assistant"` population this ADR
+governs. Issue #3011 states it directly: *"This is the 'virtual twin'
+itself... a persistent lead agent... spawns liaisons."* The owner's rationale
+above uses "virtual twin" as a PROPERTY every assistant instance holds
+(authority over its own actions), not as a name for one Lead role. These are
+two distinct usages of the same term, live in the same corpus at the same
+time. This ADR does not reconcile them and flags the collision rather than
+silently picking one — a future pass across ADR-0016/DOC-44/this ADR should
+resolve whether one term should be renamed.
 
 ## Normative Rule: Delegation Authority Is Governed by Kind, Not by Tier Order
 
@@ -855,7 +903,10 @@ Vetted against prior ADRs (`docs/adr/INDEX.md`) on 2026-07-28 (revision 2):
   "assistant" population are still different things sharing one name.
   Additionally, §7 above uses ADR-0016's PM-analogy sibling (the trusty-mpm
   PM, not ADR-0016 itself) as prior art — worth a forward cross-reference
-  from ADR-0016 once this ADR is accepted.
+  from ADR-0016 once this ADR is accepted. A SECOND, separate naming
+  collision now exists too: "Rationale" above uses "virtual twin" for a
+  property of every assistant, while ADR-0016 (via DOC-42/DOC-44) uses it as
+  the Engineering Lead's role name — flagged there, not resolved here.
 - **ADR-0018 (Loopback-only doctrine, Accepted):** Consistent — unchanged.
 - **ADR-0019 (Unified IPC messaging, Accepted, unimplemented):** Extends —
   unchanged, still the most likely foundation for the "communicate"

--- a/docs/specs/DOC-60-bus-based-agent-messaging.md
+++ b/docs/specs/DOC-60-bus-based-agent-messaging.md
@@ -3,7 +3,13 @@
 **Status:** Draft
 **Spec ID:** `SPEC-AGENTBUS-01~draft`
 **Subsystem:** trusty-mpm (bus host, daemon) — trusty-agents (assistants, sub-agents, ctrl) — trusty-channels (Slack/Telegram/etc.) — trusty-memory (consolidation target) — trusty-search (index target)
-**Last-updated:** 2026-07-28 (Rev 1: unified all three communication edges — user↔assistant, assistant↔sub-agent, assistant↔assistant — into equally-specified first-class sections per owner instruction; documents assistant↔assistant as the replacement for the delegation lane closed by PR #4240/ADR-0024)
+**Last-updated:** 2026-07-28 (Rev 2: §12 Open Question 9, decline-ability of a
+peer request, moved into §5.3 as a normative consequence derived from
+ADR-0024's virtual-twin authority principle; remaining open questions
+renumbered. Rev 1: unified all three communication edges — user↔assistant,
+assistant↔sub-agent, assistant↔assistant — into equally-specified
+first-class sections per owner instruction; documents assistant↔assistant as
+the replacement for the delegation lane closed by PR #4240/ADR-0024)
 
 ## 1. Summary
 
@@ -328,6 +334,20 @@ cto-assistant lane.
   not memory-eligible by default and is promoted only through consolidation,
   carrying the same `message_id` provenance pointer. No special-casing for
   the peer edge is introduced.
+- **Decline-ability.** Answered by derivation, not left open: per
+  [ADR-0024](../adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md)'s
+  virtual-twin authority principle — each assistant must take authority over
+  its own actions, and that authority is not transferable — a peer message
+  that carries a request for action MUST be decline-able. A non-decline-able
+  request would compel the recipient to act on the sender's behalf, which is
+  delegation under another name and indistinguishable in effect from the
+  assistant→assistant edge ADR-0024 forbids. The envelope (§11) therefore
+  needs an explicit accept/decline response shape for a peer *request*, as
+  distinct from a plain informational message — the recipient's standing
+  authority to decline is what keeps this edge coherent as communication
+  rather than command. The exact wire shape of that accept/decline response
+  is left to §11's eventual normative revision; this spec settles only that
+  decline-ability itself is required, not optional.
 
 **What is explicitly NOT a node in this tree:** a channel (Slack, Telegram)
 is not a third participant kind; it is a transport that originates a
@@ -648,19 +668,17 @@ not this spec.
    knows a specific peer instance's id (e.g. from a prior reply on the same
    thread) may address that instance directly, bypassing definition-level
    resolution, is not decided here.
-9. **May a peer message carry a request the recipient can decline (§5.3)?**
-   ADR-0024 is explicit that lateral communication never carries delegate
-   authority — a peer cannot compel another peer to act. Whether the
-   envelope (§11) needs an explicit accept/decline response shape for a
-   peer-to-peer *request* (as distinct from a plain informational message),
-   and what a declined request looks like on the bus, is unresolved.
-10. **Is there any ordering or delivery guarantee between peers (§5.3)?**
-    §11's `delivery_state` field tracks a single envelope's own lifecycle
-    (queued/delivered/acked/dropped), but does not establish whether two
-    peer messages from the same sending instance to the same target are
-    guaranteed to arrive in send order, or whether a peer conversation may
-    interleave with messages from other senders with no ordering guarantee
-    at all. This spec does not resolve it.
+9. **Is there any ordering or delivery guarantee between peers (§5.3)?**
+   §11's `delivery_state` field tracks a single envelope's own lifecycle
+   (queued/delivered/acked/dropped), but does not establish whether two
+   peer messages from the same sending instance to the same target are
+   guaranteed to arrive in send order, or whether a peer conversation may
+   interleave with messages from other senders with no ordering guarantee
+   at all. This spec does not resolve it.
+
+   *(Former Open Question 9 — whether a peer request may be decline-able —
+   is no longer open: it is answered by derivation from ADR-0024's
+   virtual-twin authority principle and is now normative text in §5.3.)*
 
 ## 13. DOC-N numbering note
 


### PR DESCRIPTION
## Summary

Records the owner's underlying RATIONALE for ADR-0024's assistants-communicate-never-delegate rule, which previously stated the boundary as a rule without its principle.

**The owner's words, verbatim:** "assistants and COMMUNICATE with each other, the difference is each assistant is a virtual twin that must take authority over its own actions."

**The principle recorded** (new `## Rationale: The Virtual-Twin Authority Principle` section in ADR-0024, between the Decision and the Normative Rule sections): each assistant is a virtual twin — it must take authority over its own actions. Delegation transfers authority; communication does not. Two twins cannot command each other because neither can surrender authority over its own actions — that authority is not transferable. This DERIVES, rather than stipulates, the boundary:

- A sub-agent holds no independent authority — it is an extension of the invoking assistant, so delegating to it exercises authority rather than transferring it.
- An assistant owns its own actions, so one assistant commanding another would transfer non-transferable authority. Only communication is coherent on that edge.
- It also explains why YOLO / owner-accepted responsibility attaches to assistants, never sub-agents: responsibility follows authority, and only assistants hold any.

## "Virtual twin" also appears in ADR-0016 — owner clarified, no collision

ADR-0016 cites DOC-42 ("Engineering Lead / Virtual Twin Cross-Tool Orchestration Architecture," PR #3006, closed unmerged, live claim since moved to DOC-44), which uses "virtual twin" as a **role name** for the Engineering Lead — a single portfolio-level supervisor above PM. My first pass treated this as an unresolved terminology divergence needing reconciliation.

The owner corrected that reading: *"That's a philosophical distinction, not a technical term."* ADR-0024's "virtual twin" is philosophical framing for the authority principle above — the sense in which each assistant owns its own actions — not a competing technical identifier. ADR-0016's usage IS a role name. The two senses coexist and neither constrains the other; there is nothing to resolve. ADR-0024 now carries a brief, neutral clarification of this (not a "needs a decision" flag), and the matching note in ADR-0024's ADR-0016 vetting entry ("Related Decisions") was softened to match — no language implying either document needs renaming.

## DOC-60 §12 Open Question 9 — answered by derivation

DOC-60's Q9 asked whether a peer message may carry a decline-able request. That is now answered: **yes, necessarily** — if a twin must take authority over its own actions, a peer request must be decline-able, because a non-decline-able request would be delegation under another name. Moved out of Open Questions into §5.3 as a new "Decline-ability" normative bullet, citing ADR-0024. **Q8** (definition-vs-instance addressing) and **Q10** (renumbered to Q9; ordering/delivery guarantees) are untouched and remain genuinely open — the owner's to answer.

## "Known regression" wording check

Grepped ADR-0024 and DOC-60 for "regression" and similar loaded framing of the closed Izzie <-> cto-assistant peer lane (the owner corrected an earlier agent's PR #4240 body framing from "regression" to "design decision"). **Neither normative document carries that framing** — ADR-0024's one "regression" hit is about an unrelated silent-authority-check defect class, and DOC-60 already describes the lane closure neutrally ("closed... as the direct, owner-authorized consequence of ADR-0024's kind-based delegation gate"). No change was needed or made.

## Status

ADR-0024 remains **Proposed** — merging this PR does not ratify it. DOC-60 remains **Draft**.

## Gates

```
$ bash scripts/check_sld.sh
sld-lint: scanned 50 spec doc(s) + 2924 code file(s); 0 error(s), 0 warning(s)

$ cargo test -p trusty-sld-lint --test lint_real_tree
running 1 test
test lints_real_tree_clean_default_mode ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.60s
```

Docs-only change — no CHANGELOG entry (per project convention for docs-only PRs).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools