### PR TITLE
feat(trusty-mpm): compose the bundled-fallback PM prompt via InstructionPackage (#4183)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- `core::instruction_overrides`: the DEFAULT PM prompt — the bundled-fallback
+  configuration every project without a `.trusty-mpm/` section override receives
+  — is now composed through the typed `InstructionPackage`
+  (epic [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183)) instead
+  of a four-asset string concatenation. The new `core::bundled_pm_package` cuts
+  `PM_INSTRUCTIONS.md` into Core/Memory/Search blocks and `BASE_PM.md` into the
+  three absorbed floor blocks *at runtime*, deriving each block's join from the
+  exact bytes it removed, so re-sectioning an asset cannot move a byte and the
+  eight-section taxonomy now describes the prompt that actually ships. The
+  composed prompt is byte-identical to the previous assembly, gated by
+  `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`, which
+  reports the first differing byte offset with surrounding context on failure.
+  Scope is the bundled fallback ONLY: an `AGENT_DELEGATION.md` override
+  (replaces the section, so never consumes the computed roster) and
+  `PM_INSTRUCTIONS_DEPLOYED.md` (opaque body, no delegation section) are
+  currently inexpressible in the schema and stay on the legacy path by design —
+  neither `RosterNotConsumed` nor `SectionWithoutBlocks` is weakened to
+  accommodate them. `resolve_pm_prompt` now scans the deployed-agent tiers
+  exactly once whichever path it takes.
+
 ### Added
 
 - `core::instruction_package`: the sectioned-JSON instruction-package schema

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -26,8 +26,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `PM_INSTRUCTIONS_DEPLOYED.md` (opaque body, no delegation section) are
   currently inexpressible in the schema and stay on the legacy path by design —
   neither `RosterNotConsumed` nor `SectionWithoutBlocks` is weakened to
-  accommodate them. `resolve_pm_prompt` now scans the deployed-agent tiers
-  exactly once whichever path it takes.
+  accommodate them. The gate is asserted through `resolve_pm_prompt` itself with
+  a project-tier agent deployed, so the composed branch is a property of the test
+  rather than of the machine's `~/.claude/agents`, and `resolve_pm_prompt` now
+  reports which composer produced the prompt — the two are byte-identical by
+  contract, so the delivered string alone cannot tell you.
 
 ### Added
 

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -29,8 +29,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   accommodate them. The gate is asserted through `resolve_pm_prompt` itself with
   a project-tier agent deployed, so the composed branch is a property of the test
   rather than of the machine's `~/.claude/agents`, and `resolve_pm_prompt` now
-  reports which composer produced the prompt — the two are byte-identical by
-  contract, so the delivered string alone cannot tell you.
+  logs which composer produced the prompt — the two are byte-identical by
+  contract, so the delivered string alone cannot tell you. The gate injects a
+  fixed roster rather than scanning the agent tiers per side: those tiers are
+  machine-global mutable state that live `tm` sessions rewrite at launch, so
+  scanning twice made the gate itself intermittently red with a message
+  indistinguishable from a real prompt regression.
 
 ### Added
 

--- a/crates/trusty-mpm/src/core/bundled_pm_package.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package.rs
@@ -1,0 +1,462 @@
+//! The bundled-fallback PM prompt, expressed as an [`InstructionPackage`].
+//!
+//! Why: #4184 landed the sectioned-JSON package type with zero call sites — a
+//! schema nothing composes from is a schema nothing validates. This module is
+//! the first real producer (#4183, carrying the scope formerly tracked as
+//! #4186): it re-sources the DEFAULT PM prompt — the one every project with no
+//! `.trusty-mpm/` override receives — through
+//! [`InstructionPackage::compose`], so the eight-section taxonomy and its
+//! `fixed | project | user` tiers describe the prompt that actually ships
+//! rather than a parallel model.
+//!
+//! Scope — deliberately ONE of the three configurations
+//! [`crate::core::instruction_overrides::resolve_pm_prompt`] can emit:
+//!
+//! | # | configuration | path |
+//! |---|---|---|
+//! | 1 | bundled fallback, roster present | **this module** |
+//! | 2 | `.trusty-mpm/AGENT_DELEGATION.md` override | legacy, unchanged |
+//! | 3 | `.trusty-mpm/PM_INSTRUCTIONS_DEPLOYED.md` | legacy, unchanged |
+//!
+//! Configurations 2 and 3 are not merely unported, they are currently
+//! *inexpressible*: an `AGENT_DELEGATION.md` override replaces the whole
+//! delegation section and so never consumes the computed roster
+//! ([`crate::core::instruction_package::ValidationError::RosterNotConsumed`]),
+//! and `PM_INSTRUCTIONS_DEPLOYED.md` replaces the entire body with opaque
+//! prose that contributes no delegation section at all (additionally
+//! `SectionWithoutBlocks`). Both are tracked as follow-up work on epic #4183;
+//! neither is weakened here.
+//!
+//! What: [`compose_bundled_fallback`] builds the package for the compiled-in
+//! assets and composes it with the three host-supplied inputs (rendered agent
+//! roster, stack profile, project addendum).
+//!
+//! THE BYTE-EQUALITY CONTRACT. The composed prompt is byte-identical to what
+//! the legacy concatenation in `instruction_overrides` produces for the same
+//! inputs — not "semantically equivalent". Nothing resolves later: the agent
+//! roster is fixed at session launch and Claude Code cannot change the agent
+//! set afterwards, so the composed string IS the delivered prompt and any
+//! divergence is a delivered-prompt regression. Two mechanisms hold the line:
+//!
+//! * every block that comes from a bundled asset is *cut out of that asset at
+//!   runtime* by [`split_asset`], which derives each block's [`Join`] from the
+//!   exact bytes it removed. Reassembling the pieces therefore reproduces the
+//!   asset by construction — re-sectioning an asset cannot move a byte, and
+//!   editing an asset cannot silently change the composed output;
+//! * [`Join::Rule`] is `"\n\n---\n\n"`, the same literal as
+//!   [`crate::core::instruction_pipeline::SECTION_SEPARATOR`], so top-level
+//!   section boundaries match the legacy `join_sections` join.
+//!
+//! Test: `bundled_pm_package_tests.rs` — in particular
+//! `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`, which
+//! diffs the two strings and reports the first differing byte offset.
+
+use crate::core::instruction_overrides::ROSTER_PRECEDENCE_NOTE;
+use crate::core::instruction_package::{
+    BlockBody, CompositionError, CompositionInputs, CustomizationTier, Generator, InstructionBlock,
+    InstructionPackage, InstructionSection, Join, SCHEMA_VERSION, SectionId,
+};
+use crate::core::instruction_pipeline::{AGENT_DELEGATION, BASE_PM, PM_INSTRUCTIONS, WORKFLOW};
+
+/// Stable identity of the package this module builds.
+pub(crate) const PACKAGE_ID: &str = "trusty-mpm.pm.bundled-fallback";
+
+/// A failure building or composing the bundled-fallback package.
+///
+/// Why: both variants mean the delivered PM prompt would be wrong, so neither
+/// may be swallowed. `MarkerNotFound` in particular fires when a bundled asset
+/// was edited so that a section boundary this module cuts on no longer exists
+/// — a loud error there is what stops a silently re-sectioned prompt.
+/// What: a missing cut marker, or a composition failure from the package type.
+/// Test: `missing_cut_marker_is_an_error`, and
+/// `shipped_assets_build_and_validate` proves neither occurs for what we ship.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum PackageError {
+    /// A cut marker is absent from the asset it is supposed to split.
+    #[error("asset {asset} no longer contains the section cut marker {marker:?}")]
+    MarkerNotFound {
+        /// The asset file name.
+        asset: &'static str,
+        /// The marker that could not be located.
+        marker: &'static str,
+    },
+    /// Composing the built package failed.
+    #[error(transparent)]
+    Compose(#[from] CompositionError),
+}
+
+/// One section boundary inside a bundled markdown asset.
+///
+/// `start_marker` is the literal text that begins the piece; the first cut of
+/// an asset uses `""` to mean "start of asset". Markers are searched forward
+/// from the previous cut, so they need only be unique in the remaining text.
+struct Cut {
+    /// Section the resulting block is attributed to.
+    section: SectionId,
+    /// Literal text that starts this piece (`""` for the first piece).
+    start_marker: &'static str,
+}
+
+/// How `PM_INSTRUCTIONS.md` divides into Core / Memory / Search blocks.
+///
+/// Why: the taxonomy needs a Memory and a Search section, and the asset's
+/// "Context-First Protocol" block is exactly that guidance — item 1 is the
+/// memory protocol, item 2 the code-search protocol. Cutting mid-list looks
+/// odd but is precisely what the two-array block model exists for: a section is
+/// lifted out of the middle of a legacy document without moving a byte. The
+/// asset's own `## Identity` heading stays in `Core`, NOT
+/// [`SectionId::Identity`] — that section is the non-overridable floor's
+/// identity block, and attributing an overridable block to it would make every
+/// later block "overridable after the floor".
+/// What: four pieces — Core prologue, Memory, Search, Core remainder.
+/// Test: `pm_instructions_cuts_reassemble_the_asset`.
+const PM_INSTRUCTIONS_CUTS: &[Cut] = &[
+    Cut {
+        section: SectionId::Core,
+        start_marker: "",
+    },
+    Cut {
+        section: SectionId::Memory,
+        start_marker: "## Context-First Protocol",
+    },
+    Cut {
+        section: SectionId::Search,
+        start_marker: "2. `search` (`mcp__trusty-search__search`)",
+    },
+    Cut {
+        section: SectionId::Core,
+        start_marker: "## Agent Routing",
+    },
+];
+
+/// How `BASE_PM.md` divides into the three absorbed floor sections.
+///
+/// Why: the mapping is the one documented on
+/// [`crate::core::instruction_package::SectionId`]. The resulting block stream
+/// runs `Identity, NonOverridableRules, FrameworkGuaranteedConventions,
+/// NonOverridableRules` — a canonical-order inversion, because the asset places
+/// the tool-priority block last. That is exactly the shape
+/// `validate_floor_is_last` deliberately permits.
+/// What: four pieces; `## Customizing PM Behavior` rides with
+/// `## Non-Overridable Rules`, and `## Trusty Tool Priority` returns to it.
+/// Test: `base_pm_cuts_reassemble_the_asset`, `floor_blocks_are_the_contiguous_tail`.
+const BASE_PM_CUTS: &[Cut] = &[
+    Cut {
+        section: SectionId::Identity,
+        start_marker: "",
+    },
+    Cut {
+        section: SectionId::NonOverridableRules,
+        start_marker: "## Non-Overridable Rules",
+    },
+    Cut {
+        section: SectionId::FrameworkGuaranteedConventions,
+        start_marker: "## Framework-Guaranteed Conventions (Non-Overridable)",
+    },
+    Cut {
+        section: SectionId::NonOverridableRules,
+        start_marker: "## Trusty Tool Priority (Non-Overridable)",
+    },
+];
+
+/// The declared eight-section taxonomy with the tiers this build ships.
+///
+/// Why: tiers are not decoration — they are the machine-readable statement of
+/// which `.trusty-mpm/` override files `BASE_PM.md` advertises. The five content
+/// sections are `project` because every advertised override file is project
+/// scoped; the three floor sections are `fixed` because
+/// `resolve_pm_prompt` appends the floor last under every branch.
+/// What: [`SectionId::CANONICAL`] paired with its tier and title.
+/// Test: `shipped_assets_build_and_validate`.
+fn sections() -> Vec<InstructionSection> {
+    let declare = |id: SectionId, title: &str, tier: CustomizationTier| InstructionSection {
+        id,
+        title: title.to_string(),
+        customization_tier: tier,
+        description: None,
+    };
+    vec![
+        declare(SectionId::Identity, "Identity", CustomizationTier::Fixed),
+        declare(
+            SectionId::Core,
+            "Core PM Instructions",
+            CustomizationTier::Project,
+        ),
+        declare(
+            SectionId::Memory,
+            "Memory Protocol",
+            CustomizationTier::Project,
+        ),
+        declare(
+            SectionId::Search,
+            "Code Search Protocol",
+            CustomizationTier::Project,
+        ),
+        declare(SectionId::Workflow, "Workflow", CustomizationTier::Project),
+        declare(
+            SectionId::AgentDelegation,
+            "Agent Delegation",
+            CustomizationTier::Project,
+        ),
+        declare(
+            SectionId::NonOverridableRules,
+            "Non-Overridable Rules",
+            CustomizationTier::Fixed,
+        ),
+        declare(
+            SectionId::FrameworkGuaranteedConventions,
+            "Framework-Guaranteed Conventions",
+            CustomizationTier::Fixed,
+        ),
+    ]
+}
+
+/// The exact bytes between two adjacent pieces, as a declared [`Join`].
+///
+/// Why: byte-equality requires every boundary to be declared rather than
+/// inferred; naming the two common gaps keeps a composed package readable
+/// while `Literal` guarantees fidelity for anything else.
+/// What: maps the removed gap bytes onto the closest [`Join`] variant.
+/// Test: `pm_instructions_cuts_reassemble_the_asset`.
+fn join_for_gap(gap: &str) -> Join {
+    match gap {
+        "" => Join::None,
+        "\n\n" => Join::Blank,
+        "\n\n---\n\n" => Join::Rule,
+        other => Join::Literal(other.to_string()),
+    }
+}
+
+/// Cut a bundled asset into per-section blocks without moving a byte.
+///
+/// Why: the alternative — pasting asset text into a hand-authored package —
+/// makes the byte-equality gate a thing someone must re-verify after every
+/// asset edit. Cutting at runtime makes reassembly true by construction: each
+/// block carries the literal gap that was removed before it, so concatenating
+/// the blocks with their joins reproduces `asset.trim()` exactly.
+/// What: locates each cut's `start_marker` (searching forward from the previous
+/// cut), slices the asset, trims each piece, and records the removed whitespace
+/// as the next block's [`Join`]. `lead_join` is the join before the FIRST
+/// piece, i.e. the boundary with whatever precedes this asset in the stream.
+/// Test: `pm_instructions_cuts_reassemble_the_asset`, `base_pm_cuts_reassemble_the_asset`,
+/// `missing_cut_marker_is_an_error`.
+fn split_asset(
+    asset: &'static str,
+    raw: &str,
+    cuts: &'static [Cut],
+    lead_join: Join,
+) -> Result<Vec<InstructionBlock>, PackageError> {
+    let text = raw.trim();
+
+    // Resolve each cut to an absolute byte offset, forward-only.
+    let mut offsets: Vec<usize> = Vec::with_capacity(cuts.len());
+    let mut search_from = 0usize;
+    for (index, cut) in cuts.iter().enumerate() {
+        if index == 0 {
+            offsets.push(0);
+            continue;
+        }
+        let Some(relative) = text
+            .get(search_from..)
+            .and_then(|t| t.find(cut.start_marker))
+        else {
+            return Err(PackageError::MarkerNotFound {
+                asset,
+                marker: cut.start_marker,
+            });
+        };
+        let absolute = search_from + relative;
+        offsets.push(absolute);
+        search_from = absolute + cut.start_marker.len();
+    }
+
+    let mut blocks: Vec<InstructionBlock> = Vec::with_capacity(cuts.len());
+    for (index, cut) in cuts.iter().enumerate() {
+        let start = offsets.get(index).copied().unwrap_or(0);
+        let end = offsets.get(index + 1).copied().unwrap_or(text.len());
+        let piece = text.get(start..end).unwrap_or_default();
+        let body = piece.trim();
+        if body.is_empty() {
+            // An empty piece means two cut markers are adjacent — a mis-authored
+            // cut table, not valid content. `validate` would reject it anyway;
+            // failing here names the asset.
+            return Err(PackageError::MarkerNotFound {
+                asset,
+                marker: cut.start_marker,
+            });
+        }
+
+        let join_before = if index == 0 {
+            lead_join.clone()
+        } else {
+            let previous = text.get(offsets.get(index - 1).copied().unwrap_or(0)..start);
+            let trailing = previous
+                .map(|p| p.get(p.trim_end().len()..).unwrap_or_default())
+                .unwrap_or_default();
+            let leading = piece
+                .get(..piece.len() - piece.trim_start().len())
+                .unwrap_or_default();
+            join_for_gap(&format!("{trailing}{leading}"))
+        };
+
+        blocks.push(InstructionBlock {
+            section: cut.section,
+            body: BlockBody::Text {
+                text: body.to_string(),
+            },
+            join_before,
+            optional: false,
+        });
+    }
+
+    Ok(blocks)
+}
+
+/// A block whose content arrives at composition time from a named generator.
+fn generated(
+    section: SectionId,
+    generator: Generator,
+    join_before: Join,
+    optional: bool,
+) -> InstructionBlock {
+    InstructionBlock {
+        section,
+        body: BlockBody::Generated { generator },
+        join_before,
+        optional,
+    }
+}
+
+/// A block of literal text authored outside the bundled markdown assets.
+fn literal(section: SectionId, text: &str, join_before: Join) -> InstructionBlock {
+    InstructionBlock {
+        section,
+        body: BlockBody::Text {
+            text: text.trim().to_string(),
+        },
+        join_before,
+        optional: false,
+    }
+}
+
+/// Build the bundled-fallback package from the compiled-in assets.
+///
+/// Why: this is the executable statement of what the DEFAULT PM prompt is made
+/// of. Reviewing this one function answers "which section does this text belong
+/// to, and who may override it?" — a question the previous four-`include_str!`
+/// concatenation could not be asked.
+///
+/// What: `PM_INSTRUCTIONS.md` cut into Core/Memory/Search, the derived stack
+/// profile, `WORKFLOW.md`, then the delegation section — bundled doctrine, the
+/// roster-precedence note, and the live roster — then the optional project
+/// addendum, then `BASE_PM.md` cut into the three floor sections. Block order
+/// is emission order and mirrors today's `join_sections` argument order
+/// exactly; the two generator-backed project inputs are `optional` because the
+/// legacy assembly likewise drops an empty section rather than emitting a
+/// dangling `---`. The agent roster is NOT optional — losing it is #4196.
+///
+/// Test: `shipped_assets_build_and_validate`,
+/// `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`.
+pub(crate) fn bundled_fallback_package() -> Result<InstructionPackage, PackageError> {
+    let mut blocks = split_asset(
+        "PM_INSTRUCTIONS.md",
+        PM_INSTRUCTIONS,
+        PM_INSTRUCTIONS_CUTS,
+        Join::Rule,
+    )?;
+
+    // Auto-derived framework context, not a user override (#1971). Optional
+    // only so an empty profile is dropped exactly as `join_sections` drops it.
+    blocks.push(generated(
+        SectionId::Core,
+        Generator::StackProfile,
+        Join::Rule,
+        true,
+    ));
+
+    blocks.push(literal(SectionId::Workflow, WORKFLOW, Join::Rule));
+
+    // Delegation: bundled doctrine, the precedence note, then the LIVE roster
+    // (#4069/#4196). The roster block is non-optional by contract.
+    blocks.push(literal(
+        SectionId::AgentDelegation,
+        AGENT_DELEGATION,
+        Join::Rule,
+    ));
+    blocks.push(literal(
+        SectionId::AgentDelegation,
+        ROSTER_PRECEDENCE_NOTE,
+        Join::Blank,
+    ));
+    blocks.push(generated(
+        SectionId::AgentDelegation,
+        Generator::AgentRoster,
+        Join::Blank,
+        false,
+    ));
+
+    // Additive `.trusty-mpm/INSTRUCTIONS.md` rules, when the project has any.
+    blocks.push(generated(
+        SectionId::Core,
+        Generator::ProjectAddendum,
+        Join::Rule,
+        true,
+    ));
+
+    blocks.extend(split_asset(
+        "BASE_PM.md",
+        BASE_PM,
+        BASE_PM_CUTS,
+        Join::Rule,
+    )?);
+
+    Ok(InstructionPackage {
+        schema_version: SCHEMA_VERSION,
+        package_id: PACKAGE_ID.to_string(),
+        description: Some(
+            "Default PM instruction package: bundled assets plus the live agent roster."
+                .to_string(),
+        ),
+        // `resolve_pm_prompt` emits no trailing newline; the prompt is embedded,
+        // not written as a file.
+        trailing_newline: false,
+        sections: sections(),
+        blocks,
+    })
+}
+
+/// Compose the bundled-fallback PM prompt.
+///
+/// Why: the single entry point `resolve_pm_prompt` calls for configuration 1.
+/// Keeping build and compose together means the caller cannot compose a package
+/// it did not build, and cannot forget an input — the roster is a required
+/// argument, so the #4196 "computed but never delivered" shape is not
+/// expressible here.
+///
+/// What: builds the package, then composes it with `stack` (the derived stack
+/// profile), `roster` (the rendered `## Delegation Authority` block, required)
+/// and `addendum` (`.trusty-mpm/INSTRUCTIONS.md`, if any). All three are
+/// trimmed by the composer. The result is byte-identical to
+/// `instruction_overrides`' legacy assembly for the same inputs — see the
+/// module docs.
+///
+/// Test: `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`,
+/// `composed_prompt_carries_the_live_roster_and_the_precedence_note`,
+/// `roster_is_required_and_never_droppable`.
+pub(crate) fn compose_bundled_fallback(
+    stack: &str,
+    roster: &str,
+    addendum: Option<&str>,
+) -> Result<String, PackageError> {
+    let package = bundled_fallback_package()?;
+    let inputs = CompositionInputs {
+        agent_roster: roster.to_string(),
+        stack_profile: Some(stack.to_string()),
+        project_addendum: addendum.map(str::to_string),
+    };
+    Ok(package.compose(&inputs)?)
+}
+
+#[cfg(test)]
+#[path = "bundled_pm_package_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/bundled_pm_package.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package.rs
@@ -41,15 +41,29 @@
 //! * every block that comes from a bundled asset is *cut out of that asset at
 //!   runtime* by [`split_asset`], which derives each block's [`Join`] from the
 //!   exact bytes it removed. Reassembling the pieces therefore reproduces the
-//!   asset by construction — re-sectioning an asset cannot move a byte, and
-//!   editing an asset cannot silently change the composed output;
+//!   asset by construction, so re-sectioning an asset cannot move a byte;
 //! * [`Join::Rule`] is `"\n\n---\n\n"`, the same literal as
 //!   [`crate::core::instruction_pipeline::SECTION_SEPARATOR`], so top-level
 //!   section boundaries match the legacy `join_sections` join.
 //!
+//! WHAT BYTE-EQUALITY DOES NOT COVER, stated precisely because the reassembly
+//! property cuts both ways: composed output equals `asset.trim()` **wherever the
+//! cuts land**, so the byte gate is structurally incapable of catching a cut
+//! placed at the wrong offset. Bytes would be fine; the section *attribution* —
+//! the thing this module exists to establish, and which #4247 will act on —
+//! would be silently wrong. Two guards cover that instead of the byte gate:
+//! [`split_asset`] requires every marker to occur EXACTLY ONCE in its asset
+//! ([`PackageError::MarkerNotUnique`]), which makes a duplicated marker red
+//! rather than silent; and the cut tests pin each block's opening content, not
+//! merely the section-id sequence. A marker that is deleted is
+//! [`PackageError::MarkerNotFound`]; one that moves in a way that reorders the
+//! sections fails the same way, because marker search is forward-only.
+//!
 //! Test: `bundled_pm_package_tests.rs` — in particular
 //! `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`, which
-//! diffs the two strings and reports the first differing byte offset.
+//! diffs the two strings and reports the first differing byte offset, and
+//! `resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly`, which asserts
+//! the same through the production entry point.
 
 use crate::core::instruction_overrides::ROSTER_PRECEDENCE_NOTE;
 use crate::core::instruction_package::{
@@ -63,13 +77,15 @@ pub(crate) const PACKAGE_ID: &str = "trusty-mpm.pm.bundled-fallback";
 
 /// A failure building or composing the bundled-fallback package.
 ///
-/// Why: both variants mean the delivered PM prompt would be wrong, so neither
-/// may be swallowed. `MarkerNotFound` in particular fires when a bundled asset
-/// was edited so that a section boundary this module cuts on no longer exists
-/// — a loud error there is what stops a silently re-sectioned prompt.
-/// What: a missing cut marker, or a composition failure from the package type.
-/// Test: `missing_cut_marker_is_an_error`, and
-/// `shipped_assets_build_and_validate` proves neither occurs for what we ship.
+/// Why: every variant means the delivered PM prompt, or the section model
+/// behind it, would be wrong — so none may be swallowed. The two marker
+/// variants are the guards that make a mis-cut asset loud, since the
+/// byte-equality gate cannot see one (see the module docs).
+/// What: an absent cut marker, an ambiguous (duplicated) one, an empty piece, or
+/// a composition failure from the package type.
+/// Test: `missing_cut_marker_is_an_error`, `duplicated_cut_marker_is_an_error`,
+/// `adjacent_cut_markers_report_an_empty_piece`, and
+/// `shipped_assets_build_and_validate` proves none occurs for what we ship.
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum PackageError {
     /// A cut marker is absent from the asset it is supposed to split.
@@ -80,6 +96,31 @@ pub(crate) enum PackageError {
         /// The marker that could not be located.
         marker: &'static str,
     },
+    /// A cut marker occurs more than once, so the cut location is ambiguous.
+    ///
+    /// This is the guard the byte gate cannot provide: a duplicated marker still
+    /// reassembles to identical bytes while attributing the wrong text to a
+    /// section.
+    #[error(
+        "asset {asset} contains the section cut marker {marker:?} {count} times; \
+         a cut marker must occur exactly once or the section boundary is ambiguous"
+    )]
+    MarkerNotUnique {
+        /// The asset file name.
+        asset: &'static str,
+        /// The ambiguous marker.
+        marker: &'static str,
+        /// How many times it occurs.
+        count: usize,
+    },
+    /// Two cut markers are adjacent, so a block would carry no content.
+    #[error("asset {asset} yields an empty piece starting at marker {marker:?}")]
+    EmptyPiece {
+        /// The asset file name.
+        asset: &'static str,
+        /// The marker that starts the empty piece.
+        marker: &'static str,
+    },
     /// Composing the built package failed.
     #[error(transparent)]
     Compose(#[from] CompositionError),
@@ -88,8 +129,10 @@ pub(crate) enum PackageError {
 /// One section boundary inside a bundled markdown asset.
 ///
 /// `start_marker` is the literal text that begins the piece; the first cut of
-/// an asset uses `""` to mean "start of asset". Markers are searched forward
-/// from the previous cut, so they need only be unique in the remaining text.
+/// an asset uses `""` to mean "start of asset". [`split_asset`] requires each
+/// marker to occur exactly once in its asset and searches forward from the
+/// previous cut, so both a duplicated marker and a reordering edit are errors
+/// rather than a silent re-cut.
 struct Cut {
     /// Section the resulting block is attributed to.
     section: SectionId,
@@ -108,8 +151,21 @@ struct Cut {
 /// [`SectionId::Identity`] — that section is the non-overridable floor's
 /// identity block, and attributing an overridable block to it would make every
 /// later block "overridable after the floor".
+///
+/// CONSTRAINT FOR #4247, recorded here because the declaration that creates it
+/// is here. Memory and Search declare tier `project` — a machine-readable claim
+/// that a project may replace either independently — but the underlying asset
+/// text is one numbered list. Replacing Memory alone would delete item `1.` and
+/// leave Search opening on a bare `2.`, and the closing sentence "Both tools are
+/// stable and recommended…" refers to *both* tools while sitting in the Search
+/// block. Harmless today (nothing honours the tiers yet), a malformed system
+/// prompt the moment #4247 does. Memory and Search are therefore NOT
+/// independently overridable until `PM_INSTRUCTIONS.md` gives each its own
+/// heading; #4247 must either restructure the asset first or ship those two
+/// sections as a single override unit.
 /// What: four pieces — Core prologue, Memory, Search, Core remainder.
-/// Test: `pm_instructions_cuts_reassemble_the_asset`.
+/// Test: `pm_instructions_cuts_reassemble_the_asset`,
+/// `pm_instructions_cut_locations_are_pinned_by_content`.
 const PM_INSTRUCTIONS_CUTS: &[Cut] = &[
     Cut {
         section: SectionId::Core,
@@ -139,7 +195,8 @@ const PM_INSTRUCTIONS_CUTS: &[Cut] = &[
 /// `validate_floor_is_last` deliberately permits.
 /// What: four pieces; `## Customizing PM Behavior` rides with
 /// `## Non-Overridable Rules`, and `## Trusty Tool Priority` returns to it.
-/// Test: `base_pm_cuts_reassemble_the_asset`, `floor_blocks_are_the_contiguous_tail`.
+/// Test: `base_pm_cuts_reassemble_the_asset`, `floor_blocks_are_the_contiguous_tail`,
+/// `base_pm_cut_locations_are_pinned_by_content`.
 const BASE_PM_CUTS: &[Cut] = &[
     Cut {
         section: SectionId::Identity,
@@ -234,12 +291,16 @@ fn join_for_gap(gap: &str) -> Join {
 /// asset edit. Cutting at runtime makes reassembly true by construction: each
 /// block carries the literal gap that was removed before it, so concatenating
 /// the blocks with their joins reproduces `asset.trim()` exactly.
-/// What: locates each cut's `start_marker` (searching forward from the previous
-/// cut), slices the asset, trims each piece, and records the removed whitespace
-/// as the next block's [`Join`]. `lead_join` is the join before the FIRST
-/// piece, i.e. the boundary with whatever precedes this asset in the stream.
+/// What: first requires every marker to occur EXACTLY ONCE in the asset — the
+/// guard against a cut silently relocating to a duplicate, which reassembly
+/// alone cannot detect — then locates each marker (searching forward from the
+/// previous cut, so a reordering edit also fails), slices the asset, trims each
+/// piece, and records the removed whitespace as the next block's [`Join`].
+/// `lead_join` is the join before the FIRST piece, i.e. the boundary with
+/// whatever precedes this asset in the stream.
 /// Test: `pm_instructions_cuts_reassemble_the_asset`, `base_pm_cuts_reassemble_the_asset`,
-/// `missing_cut_marker_is_an_error`.
+/// `missing_cut_marker_is_an_error`, `duplicated_cut_marker_is_an_error`,
+/// `adjacent_cut_markers_report_an_empty_piece`.
 fn split_asset(
     asset: &'static str,
     raw: &str,
@@ -247,6 +308,27 @@ fn split_asset(
     lead_join: Join,
 ) -> Result<Vec<InstructionBlock>, PackageError> {
     let text = raw.trim();
+
+    // Ambiguity check BEFORE any cutting. A marker that occurs twice would cut
+    // at the first hit, attribute the wrong text to a section, and still
+    // reassemble to identical bytes — invisible to the byte-equality gate.
+    for cut in cuts.iter().skip(1) {
+        let count = text.matches(cut.start_marker).count();
+        if count != 1 {
+            return Err(if count == 0 {
+                PackageError::MarkerNotFound {
+                    asset,
+                    marker: cut.start_marker,
+                }
+            } else {
+                PackageError::MarkerNotUnique {
+                    asset,
+                    marker: cut.start_marker,
+                    count,
+                }
+            });
+        }
+    }
 
     // Resolve each cut to an absolute byte offset, forward-only.
     let mut offsets: Vec<usize> = Vec::with_capacity(cuts.len());
@@ -260,6 +342,8 @@ fn split_asset(
             .get(search_from..)
             .and_then(|t| t.find(cut.start_marker))
         else {
+            // Unique but behind the previous cut: the asset reordered its
+            // sections, so the declared cut order no longer holds.
             return Err(PackageError::MarkerNotFound {
                 asset,
                 marker: cut.start_marker,
@@ -277,10 +361,11 @@ fn split_asset(
         let piece = text.get(start..end).unwrap_or_default();
         let body = piece.trim();
         if body.is_empty() {
-            // An empty piece means two cut markers are adjacent — a mis-authored
-            // cut table, not valid content. `validate` would reject it anyway;
-            // failing here names the asset.
-            return Err(PackageError::MarkerNotFound {
+            // Two cut markers are adjacent — a mis-authored cut table, not valid
+            // content. Distinct from `MarkerNotFound`: the marker WAS found, so
+            // reporting it as missing would send the reader hunting for a string
+            // that is present.
+            return Err(PackageError::EmptyPiece {
                 asset,
                 marker: cut.start_marker,
             });

--- a/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
@@ -8,8 +8,17 @@
 //! join that changed.
 
 use super::*;
-use crate::core::instruction_overrides::{assemble_sections, delegation_with_roster};
+use crate::core::delegation_authority::deployed_roster_section;
+use crate::core::instruction_overrides::{
+    FILE_AGENT_DELEGATION, FILE_INSTRUCTIONS, FILE_MEMORY, FILE_WORKFLOW, OVERRIDE_DIR_NAME,
+    PromptSource, assemble_sections, delegation_with_roster, resolve_pm_prompt,
+    resolve_pm_prompt_with_source,
+};
 use crate::core::instruction_package::ValidationError;
+use crate::core::stack_profile::stack_profile_section;
+use std::fs;
+use std::path::Path;
+use tempfile::TempDir;
 
 /// A fixed, deterministic roster — the composition-time input the byte-equality
 /// gate holds constant.
@@ -233,6 +242,213 @@ fn floor_blocks_are_the_contiguous_tail() {
     assert_eq!(package.blocks.len() - first_floor, BASE_PM_CUTS.len());
 }
 
+// ---------------------------------------------------------------------------
+// The gate at the production entry point (#4183 review, HIGH-1).
+//
+// Everything above compares `compose_bundled_fallback` against
+// `assemble_sections` given hand-supplied arguments. That proves the two
+// composers agree, but NOT that `resolve_pm_prompt` hands the package the same
+// inputs it would have handed the legacy assembly — and the wiring is where a
+// delivered-prompt regression actually lives. The review demonstrated two live
+// mutations at that seam surviving a fully green suite:
+//
+//   * `addendum.as_deref()` → `None`, silently dropping every project's
+//     `.trusty-mpm/INSTRUCTIONS.md` from the delivered prompt;
+//   * deleting the `workflow_override.is_none() && memory_override.is_none()`
+//     filter, silently discarding a `WORKFLOW.md` / `MEMORY.md` override.
+//
+// Both survived because the composed branch requires a roster, and no
+// `resolve_pm_prompt` test deployed an agent — so on a clean CI runner every one
+// of them took the LEGACY branch. The tests below deploy a project-tier agent
+// first, which makes `deployed_roster_section` return `Some` regardless of the
+// machine's `~/.claude/agents`, so the composed branch is a property of the test
+// rather than of the developer's `$HOME`. No `$HOME` manipulation is involved,
+// deliberately — the project tier is sufficient, and scoping `$HOME` would
+// reintroduce the cross-test `HOME_LOCK` race for no added coverage.
+// ---------------------------------------------------------------------------
+
+/// Deploy a composed agent into the PROJECT tier (`<project>/.claude/agents`).
+///
+/// The project tier is the highest-precedence roster source and the one the
+/// daemon managed-spawn path deploys into, so writing here guarantees
+/// `deployed_roster_section` returns `Some` without depending on — or
+/// forbidding — the machine's `~/.claude/agents`.
+fn deploy_agent(project: &Path, name: &str) {
+    let dir = project.join(".claude").join("agents");
+    fs::create_dir_all(&dir).expect("create .claude/agents");
+    fs::write(
+        dir.join(format!("{name}.md")),
+        format!(
+            "---\nname: {name}\nrole: {name}\ndescription: Handles {name} work.\n\
+             model: sonnet\n---\n\n# {name}\n"
+        ),
+    )
+    .expect("write agent");
+}
+
+/// Write `<project>/.trusty-mpm/<name>`.
+fn write_override(project: &Path, name: &str, content: &str) {
+    let dir = project.join(OVERRIDE_DIR_NAME);
+    fs::create_dir_all(&dir).expect("create .trusty-mpm");
+    fs::write(dir.join(name), content).expect("write override");
+}
+
+/// A project with one deployed agent, so the composed branch is guaranteed.
+fn project_with_roster() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    deploy_agent(tmp.path(), "ticketing");
+    tmp
+}
+
+#[test]
+fn resolve_pm_prompt_takes_the_package_path_when_a_roster_is_deployed() {
+    // Without this, every assertion below would still pass if the package branch
+    // were deleted outright — the two composers are byte-identical, so the
+    // delivered string cannot reveal which one ran. This is the positive
+    // statement that the composed path is the one under test.
+    let tmp = project_with_roster();
+    let (_, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(
+        source,
+        PromptSource::Package,
+        "a deployed roster with no section override must compose via InstructionPackage"
+    );
+}
+
+#[test]
+fn resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly() {
+    // THE ACCEPTANCE GATE, at the layer that ships the prompt (#4183). Both the
+    // stack profile and the roster are recomputed from the same project, so the
+    // comparison is deterministic whatever the ambient agent tiers hold; what is
+    // under test is the WIRING — that `resolve_pm_prompt` hands the package
+    // exactly the inputs the legacy assembly would have received.
+    let tmp = project_with_roster();
+
+    let (composed, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(source, PromptSource::Package);
+
+    let roster = deployed_roster_section(tmp.path()).expect("a deployed agent yields a roster");
+    let legacy = legacy_bundled_fallback(&stack_profile_section(tmp.path()), &roster, None);
+
+    assert_byte_identical(&legacy, &composed);
+}
+
+#[test]
+fn resolve_pm_prompt_is_byte_identical_with_a_project_addendum() {
+    // Kills the `addendum.as_deref()` → `None` mutation: the legacy oracle reads
+    // INSTRUCTIONS.md, so dropping it at the call site diverges the two.
+    let tmp = project_with_roster();
+    write_override(
+        tmp.path(),
+        FILE_INSTRUCTIONS,
+        "# Project Rules\n\nALWAYS_RUN_MAKE_CHECK\n",
+    );
+
+    let (composed, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(source, PromptSource::Package);
+    assert!(
+        composed.contains("ALWAYS_RUN_MAKE_CHECK"),
+        "the project addendum must reach the delivered prompt on the composed path"
+    );
+
+    let roster = deployed_roster_section(tmp.path()).expect("roster");
+    let legacy = legacy_bundled_fallback(
+        &stack_profile_section(tmp.path()),
+        &roster,
+        Some("# Project Rules\n\nALWAYS_RUN_MAKE_CHECK"),
+    );
+    assert_byte_identical(&legacy, &composed);
+}
+
+#[test]
+fn workflow_override_forces_the_legacy_path_even_with_a_roster() {
+    // Kills half the "delete the override filter" mutation. With the filter gone
+    // the composed branch would run and silently substitute the BUNDLED
+    // workflow, discarding the project's override.
+    let tmp = project_with_roster();
+    write_override(
+        tmp.path(),
+        FILE_WORKFLOW,
+        "# Custom Workflow\n\nTWO_PHASE_ONLY\n",
+    );
+
+    let (prompt, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(
+        source,
+        PromptSource::Legacy,
+        "a WORKFLOW.md override is not expressible in the package; it must stay legacy"
+    );
+    assert!(prompt.contains("TWO_PHASE_ONLY"));
+    assert!(
+        !prompt.contains("# PM Workflow Configuration"),
+        "the bundled workflow must not survive a WORKFLOW.md override"
+    );
+}
+
+#[test]
+fn memory_override_forces_the_legacy_path_even_with_a_roster() {
+    // The other half. A MEMORY.md override slots a delimited block after
+    // PM_INSTRUCTIONS, which the package model has no generator for.
+    let tmp = project_with_roster();
+    write_override(
+        tmp.path(),
+        FILE_MEMORY,
+        "Recall from the `team` palace first.\n",
+    );
+
+    let (prompt, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(prompt.contains("## Memory Behavior (project override)"));
+    assert!(prompt.contains("Recall from the `team` palace first."));
+}
+
+#[test]
+fn delegation_override_forces_the_legacy_path_even_with_a_roster() {
+    // Configuration 2 (#4247): the override replaces the whole section, so the
+    // roster is deliberately NOT re-appended and the package — which requires
+    // the roster to be consumed — cannot express it.
+    let tmp = project_with_roster();
+    write_override(
+        tmp.path(),
+        FILE_AGENT_DELEGATION,
+        "# Custom Routing\n\nROUTE_ALL_TO_ENGINEER\n",
+    );
+
+    let (prompt, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(prompt.contains("ROUTE_ALL_TO_ENGINEER"));
+    assert!(
+        !prompt.contains("### ticketing"),
+        "an override replaces the section outright — the roster is not re-appended"
+    );
+}
+
+#[test]
+fn deployed_prompt_override_forces_the_legacy_path_even_with_a_roster() {
+    // Configuration 3 (#4247): a full body replacement contributes no delegation
+    // section at all.
+    let tmp = project_with_roster();
+    write_override(
+        tmp.path(),
+        crate::core::instruction_overrides::FILE_PM_DEPLOYED,
+        "# Wholly Custom PM\n\nDO_EXACTLY_THIS\n",
+    );
+
+    let (prompt, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(prompt.contains("DO_EXACTLY_THIS"));
+    assert!(prompt.contains("# BASE_PM Framework Floor"));
+}
+
+#[test]
+fn resolve_pm_prompt_wrapper_matches_the_source_reporting_form() {
+    // The public entry point must return exactly what the seam returns — the
+    // logging wrapper may not alter the prompt.
+    let tmp = project_with_roster();
+    let (with_source, _) = resolve_pm_prompt_with_source(tmp.path());
+    assert_byte_identical(&resolve_pm_prompt(tmp.path()), &with_source);
+}
+
 #[test]
 fn missing_cut_marker_is_an_error() {
     // An asset edited so a cut marker no longer exists must fail loudly. The
@@ -253,6 +469,147 @@ fn missing_cut_marker_is_an_error() {
             marker: "## Context-First Protocol",
         }
     );
+}
+
+#[test]
+fn duplicated_cut_marker_is_an_error() {
+    // The failure the byte-equality gate STRUCTURALLY CANNOT catch. Reassembly
+    // reproduces `asset.trim()` wherever the cuts land, so a second
+    // `## Agent Routing` would relocate the fourth cut, move "Both tools are
+    // stable…" from Search into Core, and leave every byte and every existing
+    // assertion unchanged — a silently wrong section model that #4247 would then
+    // act on. Uniqueness is what makes it red.
+    let doctored = PM_INSTRUCTIONS.replace(
+        "Both tools are stable",
+        "## Agent Routing\n\nBoth tools are stable",
+    );
+
+    let err = split_asset(
+        "PM_INSTRUCTIONS.md",
+        &doctored,
+        PM_INSTRUCTIONS_CUTS,
+        Join::Rule,
+    )
+    .expect_err("an ambiguous cut marker must not compose");
+
+    assert_eq!(
+        err,
+        PackageError::MarkerNotUnique {
+            asset: "PM_INSTRUCTIONS.md",
+            marker: "## Agent Routing",
+            count: 2,
+        }
+    );
+}
+
+#[test]
+fn adjacent_cut_markers_report_an_empty_piece() {
+    // The marker WAS found here; reporting `MarkerNotFound` would send the reader
+    // hunting for a string that is present.
+    let doctored = "## Context-First Protocol\n\n2. `search` (`mcp__trusty-search__search`)\n\n\
+         ## Agent Routing\n\nbody\n";
+
+    let err = split_asset(
+        "PM_INSTRUCTIONS.md",
+        doctored,
+        PM_INSTRUCTIONS_CUTS,
+        Join::Rule,
+    )
+    .expect_err("an empty leading piece must not compose");
+
+    assert_eq!(
+        err,
+        PackageError::EmptyPiece {
+            asset: "PM_INSTRUCTIONS.md",
+            marker: "",
+        }
+    );
+}
+
+#[test]
+fn shipped_cut_markers_each_occur_exactly_once() {
+    // States the property as a standalone fact about what we ship, so a future
+    // asset edit that introduces a duplicate fails here with the marker named
+    // rather than deep inside a composition error.
+    for (asset, text, cuts) in [
+        ("PM_INSTRUCTIONS.md", PM_INSTRUCTIONS, PM_INSTRUCTIONS_CUTS),
+        ("BASE_PM.md", BASE_PM, BASE_PM_CUTS),
+    ] {
+        for cut in cuts.iter().skip(1) {
+            assert_eq!(
+                text.matches(cut.start_marker).count(),
+                1,
+                "{asset}: cut marker {:?} must occur exactly once",
+                cut.start_marker
+            );
+        }
+    }
+}
+
+#[test]
+fn pm_instructions_cut_locations_are_pinned_by_content() {
+    // Reassembly plus the section-id sequence is NOT enough: both hold for cuts
+    // at the wrong offsets. Pinning each block's opening content is what makes a
+    // relocated cut visible.
+    let blocks = split_asset(
+        "PM_INSTRUCTIONS.md",
+        PM_INSTRUCTIONS,
+        PM_INSTRUCTIONS_CUTS,
+        Join::Rule,
+    )
+    .expect("cuts resolve");
+
+    assert!(block_text(&blocks, 0).starts_with("<!-- PM_INSTRUCTIONS_VERSION:"));
+    assert!(block_text(&blocks, 0).contains("## Prohibitions (CANONICAL"));
+
+    let memory = block_text(&blocks, 1);
+    assert!(memory.starts_with("## Context-First Protocol"));
+    assert!(memory.contains("`memory_recall` (trusty-memory)"));
+    assert!(
+        memory.ends_with("the injected block did not surface."),
+        "the Memory block must stop before the search item, got tail {:?}",
+        &memory[memory.len().saturating_sub(60)..]
+    );
+
+    let search = block_text(&blocks, 2);
+    assert!(search.starts_with("2. `search` (`mcp__trusty-search__search`)"));
+    assert!(
+        search.contains("Both tools are stable"),
+        "the closing sentence rides with Search — see the #4247 constraint on PM_INSTRUCTIONS_CUTS"
+    );
+
+    assert!(block_text(&blocks, 3).starts_with("## Agent Routing"));
+}
+
+#[test]
+fn base_pm_cut_locations_are_pinned_by_content() {
+    let blocks =
+        split_asset("BASE_PM.md", BASE_PM, BASE_PM_CUTS, Join::Rule).expect("cuts resolve");
+
+    assert!(block_text(&blocks, 0).starts_with("# BASE_PM Framework Floor"));
+    assert!(block_text(&blocks, 0).contains("## Identity"));
+
+    let rules = block_text(&blocks, 1);
+    assert!(rules.starts_with("## Non-Overridable Rules"));
+    assert!(
+        rules.contains("## Customizing PM Behavior"),
+        "the customization contract rides with the non-overridable rules"
+    );
+
+    assert!(
+        block_text(&blocks, 2).starts_with("## Framework-Guaranteed Conventions (Non-Overridable)")
+    );
+    assert!(block_text(&blocks, 2).contains("Generated with trusty-mpm"));
+
+    assert!(block_text(&blocks, 3).starts_with("## Trusty Tool Priority (Non-Overridable)"));
+}
+
+/// The text of a text block, for pinning cut locations.
+fn block_text(blocks: &[InstructionBlock], index: usize) -> &str {
+    match blocks.get(index).map(|b| &b.body) {
+        Some(BlockBody::Text { text }) => text,
+        other => panic!("block {index} is not a text block: {other:?}"),
+    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
@@ -8,11 +8,10 @@
 //! join that changed.
 
 use super::*;
-use crate::core::delegation_authority::deployed_roster_section;
 use crate::core::instruction_overrides::{
     FILE_AGENT_DELEGATION, FILE_INSTRUCTIONS, FILE_MEMORY, FILE_WORKFLOW, OVERRIDE_DIR_NAME,
     PromptSource, assemble_sections, delegation_with_roster, resolve_pm_prompt,
-    resolve_pm_prompt_with_source,
+    resolve_pm_prompt_with_roster, resolve_pm_prompt_with_source,
 };
 use crate::core::instruction_package::ValidationError;
 use crate::core::stack_profile::stack_profile_section;
@@ -184,6 +183,14 @@ fn pm_instructions_cuts_reassemble_the_asset() {
 
     assert_eq!(blocks.len(), PM_INSTRUCTIONS_CUTS.len());
     assert_eq!(reassemble(&blocks), PM_INSTRUCTIONS.trim());
+    // `reassemble` skips the first block's join by design; pin it separately so
+    // "reproduces the asset exactly" is a complete statement rather than one
+    // with an unexamined hole.
+    assert_eq!(
+        blocks.first().map(|b| &b.join_before),
+        Some(&Join::Rule),
+        "the lead join is the boundary with the preceding asset, not part of this one"
+    );
 
     // The asset's own `## Identity` heading stays in `Core`. Attributing it to
     // `SectionId::Identity` would open the floor at block 0 and make every later
@@ -209,6 +216,7 @@ fn base_pm_cuts_reassemble_the_asset() {
         split_asset("BASE_PM.md", BASE_PM, BASE_PM_CUTS, Join::Rule).expect("cuts resolve");
 
     assert_eq!(reassemble(&blocks), BASE_PM.trim());
+    assert_eq!(blocks.first().map(|b| &b.join_before), Some(&Join::Rule));
     let sections: Vec<SectionId> = blocks.iter().map(|b| b.section).collect();
     assert_eq!(
         sections,
@@ -315,49 +323,116 @@ fn resolve_pm_prompt_takes_the_package_path_when_a_roster_is_deployed() {
     );
 }
 
-#[test]
-fn resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly() {
-    // THE ACCEPTANCE GATE, at the layer that ships the prompt (#4183). Both the
-    // stack profile and the roster are recomputed from the same project, so the
-    // comparison is deterministic whatever the ambient agent tiers hold; what is
-    // under test is the WIRING — that `resolve_pm_prompt` hands the package
-    // exactly the inputs the legacy assembly would have received.
-    let tmp = project_with_roster();
+/// Run the entry-point gate for one project, with the roster pinned.
+///
+/// Why: `deployed_roster_section` unions three tiers on every call, two of them
+/// machine-global and rewritten by live `tm` sessions, so scanning once per side
+/// of a byte comparison is a race — observed red 1 run in 4, with a message
+/// indistinguishable from a real prompt regression. Both sides here take
+/// [`FIXED_ROSTER`], so the only thing that can differ is the wiring, which is
+/// what the gate is for. No `$HOME` scoping, hence no `HOME_LOCK` serialisation.
+fn assert_entry_point_gate(project: &Path, addendum: Option<&str>) {
+    let (composed, source) =
+        resolve_pm_prompt_with_roster(project, || Some(FIXED_ROSTER.to_string()));
+    assert_eq!(
+        source,
+        PromptSource::Package,
+        "the gate must run against the COMPOSED path, or it proves nothing"
+    );
 
-    let (composed, source) = resolve_pm_prompt_with_source(tmp.path());
-    assert_eq!(source, PromptSource::Package);
-
-    let roster = deployed_roster_section(tmp.path()).expect("a deployed agent yields a roster");
-    let legacy = legacy_bundled_fallback(&stack_profile_section(tmp.path()), &roster, None);
-
+    let legacy = legacy_bundled_fallback(&stack_profile_section(project), FIXED_ROSTER, addendum);
     assert_byte_identical(&legacy, &composed);
 }
 
 #[test]
+fn resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly() {
+    // THE ACCEPTANCE GATE, at the layer that ships the prompt (#4183). What is
+    // under test is the WIRING — that `resolve_pm_prompt` hands the package
+    // exactly the inputs the legacy assembly would have received.
+    let tmp = TempDir::new().expect("tempdir");
+    assert_entry_point_gate(tmp.path(), None);
+}
+
+#[test]
 fn resolve_pm_prompt_is_byte_identical_with_a_project_addendum() {
-    // Kills the `addendum.as_deref()` → `None` mutation: the legacy oracle reads
-    // INSTRUCTIONS.md, so dropping it at the call site diverges the two.
-    let tmp = project_with_roster();
+    // Kills the `addendum.as_deref()` → `None` mutation: the legacy oracle takes
+    // the addendum, so dropping it at the call site diverges the two.
+    let tmp = TempDir::new().expect("tempdir");
     write_override(
         tmp.path(),
         FILE_INSTRUCTIONS,
         "# Project Rules\n\nALWAYS_RUN_MAKE_CHECK\n",
     );
 
-    let (composed, source) = resolve_pm_prompt_with_source(tmp.path());
-    assert_eq!(source, PromptSource::Package);
+    let (composed, _) =
+        resolve_pm_prompt_with_roster(tmp.path(), || Some(FIXED_ROSTER.to_string()));
     assert!(
         composed.contains("ALWAYS_RUN_MAKE_CHECK"),
         "the project addendum must reach the delivered prompt on the composed path"
     );
 
-    let roster = deployed_roster_section(tmp.path()).expect("roster");
-    let legacy = legacy_bundled_fallback(
-        &stack_profile_section(tmp.path()),
-        &roster,
-        Some("# Project Rules\n\nALWAYS_RUN_MAKE_CHECK"),
+    assert_entry_point_gate(tmp.path(), Some("# Project Rules\n\nALWAYS_RUN_MAKE_CHECK"));
+}
+
+#[test]
+fn gate_is_deterministic_across_repeated_runs() {
+    // The gate's own flake guard. The previous revision scanned the ambient agent
+    // tiers once per side and compared the results; this asserts the replacement
+    // is stable under repetition, and that the composed prompt for a fixed
+    // (project, roster) pair is a pure function of its inputs.
+    let tmp = TempDir::new().expect("tempdir");
+    let first = resolve_pm_prompt_with_roster(tmp.path(), || Some(FIXED_ROSTER.to_string())).0;
+    for _ in 0..32 {
+        assert_entry_point_gate(tmp.path(), None);
+        let again = resolve_pm_prompt_with_roster(tmp.path(), || Some(FIXED_ROSTER.to_string())).0;
+        assert_byte_identical(&first, &again);
+    }
+}
+
+#[test]
+fn injected_roster_does_not_change_which_path_runs() {
+    // The seam must not become a back door that alters routing: injecting a
+    // roster changes only WHICH roster, never whether the composed branch is
+    // eligible. With a delegation override the roster is irrelevant and the
+    // legacy path must still win.
+    let tmp = TempDir::new().expect("tempdir");
+    write_override(tmp.path(), FILE_AGENT_DELEGATION, "# Custom Routing\n\nX\n");
+    let (_, source) = resolve_pm_prompt_with_roster(tmp.path(), || Some(FIXED_ROSTER.to_string()));
+    assert_eq!(source, PromptSource::Legacy);
+
+    // And a `None` roster is not composable, injected or scanned.
+    let bare = TempDir::new().expect("tempdir");
+    let (_, source) = resolve_pm_prompt_with_roster(bare.path(), || None);
+    assert_eq!(source, PromptSource::Legacy);
+}
+
+#[test]
+fn injected_roster_is_lazy_for_the_override_configurations() {
+    // The roster source stays a closure so an `AGENT_DELEGATION.md` override
+    // short-circuits before any tier scan — the pre-PR behaviour, which a plain
+    // `Option<String>` parameter would have silently regressed into an
+    // unconditional scan on every launch.
+    use std::cell::Cell;
+    let scans = Cell::new(0usize);
+
+    let tmp = TempDir::new().expect("tempdir");
+    write_override(tmp.path(), FILE_AGENT_DELEGATION, "# Custom Routing\n\nX\n");
+    let _ = resolve_pm_prompt_with_roster(tmp.path(), || {
+        scans.set(scans.get() + 1);
+        Some(FIXED_ROSTER.to_string())
+    });
+    assert_eq!(
+        scans.get(),
+        0,
+        "a delegation override must not scan the tiers"
     );
-    assert_byte_identical(&legacy, &composed);
+
+    let plain = TempDir::new().expect("tempdir");
+    let _ = resolve_pm_prompt_with_roster(plain.path(), || {
+        scans.set(scans.get() + 1);
+        Some(FIXED_ROSTER.to_string())
+    });
+    assert_eq!(scans.get(), 1, "the bundled fallback scans exactly once");
 }
 
 #[test]
@@ -444,8 +519,20 @@ fn deployed_prompt_override_forces_the_legacy_path_even_with_a_roster() {
 fn resolve_pm_prompt_wrapper_matches_the_source_reporting_form() {
     // The public entry point must return exactly what the seam returns — the
     // logging wrapper may not alter the prompt.
-    let tmp = project_with_roster();
-    let (with_source, _) = resolve_pm_prompt_with_source(tmp.path());
+    //
+    // Uses a delegation override deliberately: both calls below scan the ambient
+    // agent tiers independently, and on this configuration the override replaces
+    // the whole delegation section, so no roster byte reaches either output and
+    // the comparison cannot race a concurrent agent redeploy.
+    let tmp = TempDir::new().expect("tempdir");
+    write_override(
+        tmp.path(),
+        FILE_AGENT_DELEGATION,
+        "# Custom Routing\n\nROUTE_ALL_TO_ENGINEER\n",
+    );
+
+    let (with_source, source) = resolve_pm_prompt_with_source(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
     assert_byte_identical(&resolve_pm_prompt(tmp.path()), &with_source);
 }
 
@@ -523,6 +610,48 @@ fn adjacent_cut_markers_report_an_empty_piece() {
             asset: "PM_INSTRUCTIONS.md",
             marker: "",
         }
+    );
+}
+
+#[test]
+fn derived_joins_survive_irregular_whitespace_around_cuts() {
+    // Automated-review MEDIUM: the concern was that `previous.trim_end()` reads
+    // the trailing whitespace of the WHOLE previous slice rather than just the
+    // inter-piece gap, so a piece ending in whitespace before a marker — "a
+    // fenced block with a blank line before the next heading" — would derive a
+    // wrong `Join`.
+    //
+    // It does not, and this is the named case. `trim_end` removes only from the
+    // END, so `p[p.trim_end().len()..]` IS exactly the trailing run; the gap is
+    // that run plus the current piece's leading run, which telescopes back to
+    // the original for ANY cut offsets. Asserted here rather than argued,
+    // against gaps the real assets do not currently contain: a fenced block, a
+    // blank line carrying spaces, and a three-newline separation.
+    let asset = "# Head\n\n\
+         ```markdown\ncode\n```\n   \n\n\
+         ## Context-First Protocol\n\nmemory\n\n\n\
+         2. `search` (`mcp__trusty-search__search`)\n\nsearch\n\t\n\
+         ## Agent Routing\n\nrouting\n";
+
+    let blocks = split_asset("SYNTHETIC.md", asset, PM_INSTRUCTIONS_CUTS, Join::Rule)
+        .expect("irregular whitespace still cuts");
+
+    assert_eq!(
+        reassemble(&blocks),
+        asset.trim(),
+        "derived joins must reproduce the asset byte-for-byte across irregular gaps"
+    );
+
+    // The gaps are genuinely irregular — otherwise this would prove nothing.
+    let joins: Vec<&Join> = blocks.iter().skip(1).map(|b| &b.join_before).collect();
+    assert_eq!(
+        joins,
+        vec![
+            &Join::Literal("\n   \n\n".to_string()),
+            &Join::Literal("\n\n\n".to_string()),
+            &Join::Literal("\n\t\n".to_string()),
+        ],
+        "each derived join must be the exact removed bytes, not a normalised guess"
     );
 }
 
@@ -682,6 +811,13 @@ fn empty_stack_profile_is_dropped_without_a_dangling_rule() {
 ///
 /// Only valid for text-only block slices — generated blocks have no body until
 /// composition time.
+///
+/// The FIRST block's `join_before` is deliberately excluded, matching
+/// `InstructionPackage::compose`, which never emits a join before the first
+/// emitted block. For an asset slice that join is `lead_join` — the boundary
+/// with the PRECEDING asset in the full stream, not part of this asset — so what
+/// this reproduces is `asset.trim()`, exactly and by definition, rather than
+/// "everything the blocks carry". Callers assert `lead_join` separately.
 fn reassemble(blocks: &[InstructionBlock]) -> String {
     let mut out = String::new();
     for (index, block) in blocks.iter().enumerate() {

--- a/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
@@ -1,0 +1,342 @@
+//! Tests for the bundled-fallback PM instruction package (#4183).
+//!
+//! The load-bearing test here is
+//! [`composed_package_is_byte_identical_to_the_legacy_bundled_fallback`]: the
+//! re-sourced composition must reproduce today's delivered prompt exactly, not
+//! approximately. Everything else exists to localise a failure of that test —
+//! a cut marker that stopped matching, an asset that no longer reassembles, a
+//! join that changed.
+
+use super::*;
+use crate::core::instruction_overrides::{assemble_sections, delegation_with_roster};
+use crate::core::instruction_package::ValidationError;
+
+/// A fixed, deterministic roster — the composition-time input the byte-equality
+/// gate holds constant.
+///
+/// Why: the real roster is scanned from disk and varies per machine, which
+/// would make the gate environment-dependent. Nothing about the comparison
+/// depends on the roster's *content*, only that both sides receive the same
+/// bytes; a literal makes the test hermetic.
+const FIXED_ROSTER: &str = "## Delegation Authority\n\n\
+     ### ticketing\n\nHandles ticketing work. Model: sonnet.\n\n\
+     ### rust-engineer\n\nHandles Rust work. Model: sonnet.";
+
+/// A fixed stack-profile block, standing in for `stack_profile_section`.
+const FIXED_STACK: &str =
+    "## Project Stack Profile\n\nDetected stack: Rust. Route implementation to `rust-engineer`.";
+
+/// A fixed `.trusty-mpm/INSTRUCTIONS.md` addendum.
+const FIXED_ADDENDUM: &str = "# Project Rules\n\nALWAYS_RUN_MAKE_CHECK";
+
+/// Today's legacy assembly for the bundled-fallback configuration.
+///
+/// Calls the same production [`assemble_sections`] / [`delegation_with_roster`]
+/// pair that `resolve_pm_prompt` still uses for configurations 2 and 3, so the
+/// oracle cannot rot into a private reimplementation of what it is checking.
+fn legacy_bundled_fallback(stack: &str, roster: &str, addendum: Option<&str>) -> String {
+    assemble_sections(
+        stack.to_string(),
+        None,
+        WORKFLOW.trim().to_string(),
+        delegation_with_roster(Some(roster)),
+        addendum.map(str::to_string),
+    )
+}
+
+/// Assert two prompts are byte-identical, reporting the first divergence.
+///
+/// Why: a bare `assert_eq!` on two ~40 KB strings prints both in full and tells
+/// the reader nothing about where they parted company. This reports the byte
+/// offset plus a window of context on each side, which is what a reviewer needs
+/// to see which join or cut moved.
+fn assert_byte_identical(expected: &str, actual: &str) {
+    if expected == actual {
+        return;
+    }
+
+    let (e, a) = (expected.as_bytes(), actual.as_bytes());
+    let at = e
+        .iter()
+        .zip(a.iter())
+        .position(|(x, y)| x != y)
+        .unwrap_or_else(|| e.len().min(a.len()));
+
+    /// Bytes of context shown either side of the divergence.
+    const WINDOW: usize = 120;
+    let from = at.saturating_sub(WINDOW);
+    let window =
+        |s: &[u8]| String::from_utf8_lossy(&s[from..s.len().min(at + WINDOW)]).replace('\n', "\\n");
+
+    panic!(
+        "composed prompt is NOT byte-identical to the legacy assembly.\n\
+         first difference at byte offset {at} (expected {} bytes, actual {} bytes)\n\
+         expected [{from}..]: {}\n\
+         actual   [{from}..]: {}\n",
+        e.len(),
+        a.len(),
+        window(e),
+        window(a),
+    );
+}
+
+#[test]
+fn composed_package_is_byte_identical_to_the_legacy_bundled_fallback() {
+    // THE ACCEPTANCE GATE (#4183). Nothing resolves after this point: the agent
+    // roster is fixed at session launch and Claude Code cannot change the agent
+    // set afterwards, so the composed string IS the delivered prompt. Strict
+    // byte-equality is therefore the correct gate, not a reviewed diff — any
+    // divergence here is a change to what every PM receives.
+    let composed =
+        compose_bundled_fallback(FIXED_STACK, FIXED_ROSTER, None).expect("package composes");
+    let legacy = legacy_bundled_fallback(FIXED_STACK, FIXED_ROSTER, None);
+
+    assert_byte_identical(&legacy, &composed);
+}
+
+#[test]
+fn composed_package_is_byte_identical_with_a_project_addendum() {
+    // The additive `.trusty-mpm/INSTRUCTIONS.md` rules are the one project input
+    // the bundled-fallback configuration still carries; they ride a
+    // `ProjectAddendum` generator block and must land in the same position with
+    // the same separator as the legacy assembly.
+    let composed = compose_bundled_fallback(FIXED_STACK, FIXED_ROSTER, Some(FIXED_ADDENDUM))
+        .expect("package composes");
+    let legacy = legacy_bundled_fallback(FIXED_STACK, FIXED_ROSTER, Some(FIXED_ADDENDUM));
+
+    assert_byte_identical(&legacy, &composed);
+    assert!(composed.contains("ALWAYS_RUN_MAKE_CHECK"));
+}
+
+#[test]
+fn shipped_assets_build_and_validate() {
+    // The package built from the compiled-in assets must satisfy every
+    // structural invariant. This is what makes the `tracing::error!` fallback in
+    // `resolve_pm_prompt` unreachable rather than routine.
+    let package = bundled_fallback_package().expect("shipped assets build a package");
+    assert_eq!(package.validate(), Ok(()));
+    assert_eq!(package.package_id, PACKAGE_ID);
+    assert!(!package.trailing_newline);
+
+    // Every canonical section is declared exactly once, in canonical order.
+    let ids: Vec<SectionId> = package.sections.iter().map(|s| s.id).collect();
+    assert_eq!(ids, SectionId::CANONICAL.to_vec());
+
+    // Floor sections are `fixed`; the five content sections are `project`,
+    // matching the override files `BASE_PM.md` advertises.
+    for section in &package.sections {
+        let expected = if section.id.is_floor() {
+            CustomizationTier::Fixed
+        } else {
+            CustomizationTier::Project
+        };
+        assert_eq!(
+            section.customization_tier, expected,
+            "section {:?} declares the wrong tier",
+            section.id
+        );
+    }
+}
+
+#[test]
+fn package_round_trips_through_json() {
+    // The composed prompt must survive serialization: a package that cannot be
+    // written out and read back is not a source format, and the JSON form is
+    // what #4183's authoring work will edit.
+    let package = bundled_fallback_package().expect("build");
+    let json = package.to_json().expect("serialize");
+    let parsed = InstructionPackage::from_json(&json).expect("deserialize");
+    assert_eq!(parsed, package);
+
+    let inputs = CompositionInputs {
+        agent_roster: FIXED_ROSTER.to_string(),
+        stack_profile: Some(FIXED_STACK.to_string()),
+        project_addendum: None,
+    };
+    assert_eq!(
+        parsed.compose(&inputs).expect("compose round-tripped"),
+        package.compose(&inputs).expect("compose original"),
+    );
+}
+
+#[test]
+fn pm_instructions_cuts_reassemble_the_asset() {
+    // Cutting an asset must not move a byte: concatenating the pieces with the
+    // joins the splitter derived reproduces the trimmed asset exactly. This is
+    // the mechanism the byte-equality gate rests on, asserted directly so a
+    // failure names the asset instead of a 40 KB diff.
+    let blocks = split_asset(
+        "PM_INSTRUCTIONS.md",
+        PM_INSTRUCTIONS,
+        PM_INSTRUCTIONS_CUTS,
+        Join::Rule,
+    )
+    .expect("cuts resolve");
+
+    assert_eq!(blocks.len(), PM_INSTRUCTIONS_CUTS.len());
+    assert_eq!(reassemble(&blocks), PM_INSTRUCTIONS.trim());
+
+    // The asset's own `## Identity` heading stays in `Core`. Attributing it to
+    // `SectionId::Identity` would open the floor at block 0 and make every later
+    // block "overridable after the floor".
+    let sections: Vec<SectionId> = blocks.iter().map(|b| b.section).collect();
+    assert_eq!(
+        sections,
+        vec![
+            SectionId::Core,
+            SectionId::Memory,
+            SectionId::Search,
+            SectionId::Core
+        ]
+    );
+}
+
+#[test]
+fn base_pm_cuts_reassemble_the_asset() {
+    // Same guarantee for the floor, whose block stream is a canonical-order
+    // inversion (Identity, NonOverridable, FrameworkConventions, NonOverridable)
+    // because `## Trusty Tool Priority` sits last in the asset.
+    let blocks =
+        split_asset("BASE_PM.md", BASE_PM, BASE_PM_CUTS, Join::Rule).expect("cuts resolve");
+
+    assert_eq!(reassemble(&blocks), BASE_PM.trim());
+    let sections: Vec<SectionId> = blocks.iter().map(|b| b.section).collect();
+    assert_eq!(
+        sections,
+        vec![
+            SectionId::Identity,
+            SectionId::NonOverridableRules,
+            SectionId::FrameworkGuaranteedConventions,
+            SectionId::NonOverridableRules
+        ]
+    );
+    assert!(blocks.iter().all(|b| b.section.is_floor()));
+}
+
+#[test]
+fn floor_blocks_are_the_contiguous_tail() {
+    // The floor's guarantee is that it has the last word. `validate` enforces
+    // it, but asserting the shape here localises a regression to block ordering
+    // rather than to a validation error message.
+    let package = bundled_fallback_package().expect("build");
+    let first_floor = package
+        .blocks
+        .iter()
+        .position(|b| b.section.is_floor())
+        .expect("the floor is present");
+    assert!(
+        package.blocks[first_floor..]
+            .iter()
+            .all(|b| b.section.is_floor()),
+        "nothing overridable may follow the framework floor"
+    );
+    assert_eq!(package.blocks.len() - first_floor, BASE_PM_CUTS.len());
+}
+
+#[test]
+fn missing_cut_marker_is_an_error() {
+    // An asset edited so a cut marker no longer exists must fail loudly. The
+    // silent alternative — re-sectioning whatever text happens to be there — is
+    // the #4196 shape: composition reports success, the prompt is wrong.
+    let err = split_asset(
+        "PM_INSTRUCTIONS.md",
+        "# Rewritten asset\n\nNo cut markers here at all.",
+        PM_INSTRUCTIONS_CUTS,
+        Join::Rule,
+    )
+    .expect_err("a missing marker must not compose");
+
+    assert_eq!(
+        err,
+        PackageError::MarkerNotFound {
+            asset: "PM_INSTRUCTIONS.md",
+            marker: "## Context-First Protocol",
+        }
+    );
+}
+
+#[test]
+fn roster_is_required_and_never_droppable() {
+    // #4196 regression gate at the package level: the computed roster must reach
+    // the composed prompt. An empty roster is a hard error, not a quiet drop.
+    let package = bundled_fallback_package().expect("build");
+    assert_ne!(package.validate(), Err(ValidationError::RosterNotConsumed));
+
+    let roster_block = package
+        .blocks
+        .iter()
+        .find(|b| {
+            matches!(
+                b.body,
+                BlockBody::Generated {
+                    generator: Generator::AgentRoster
+                }
+            )
+        })
+        .expect("a block consumes the roster");
+    assert!(
+        !roster_block.optional,
+        "the roster block must not be optional"
+    );
+
+    let err = compose_bundled_fallback(FIXED_STACK, "   \n\t", None)
+        .expect_err("an empty roster must not compose");
+    assert!(
+        matches!(
+            err,
+            PackageError::Compose(CompositionError::MissingGeneratedInput {
+                generator: Generator::AgentRoster,
+                ..
+            })
+        ),
+        "expected a missing-roster composition error, got {err:?}"
+    );
+}
+
+#[test]
+fn composed_prompt_carries_the_live_roster_and_the_precedence_note() {
+    // The delivered prompt must contain the doctrine, the note that resolves the
+    // doctrine-vs-roster contradiction, and the roster — in that order (#4069).
+    let composed =
+        compose_bundled_fallback(FIXED_STACK, FIXED_ROSTER, None).expect("package composes");
+
+    let doctrine = composed
+        .find("# Agent Delegation Routing")
+        .expect("doctrine");
+    let note = composed.find("trust the roster").expect("note");
+    let roster = composed.find("### ticketing").expect("roster");
+    let floor = composed.find("# BASE_PM Framework Floor").expect("floor");
+    assert!(doctrine < note && note < roster && roster < floor);
+}
+
+#[test]
+fn empty_stack_profile_is_dropped_without_a_dangling_rule() {
+    // The legacy `join_sections` filters empty sections so a missing one never
+    // leaves a bare `---`. The stack-profile block is `optional` precisely to
+    // reproduce that, and the two must still agree byte-for-byte.
+    let composed = compose_bundled_fallback("", FIXED_ROSTER, None).expect("package composes");
+    let legacy = legacy_bundled_fallback("", FIXED_ROSTER, None);
+
+    assert_byte_identical(&legacy, &composed);
+    assert!(!composed.contains("\n\n---\n\n---\n\n"));
+}
+
+/// Concatenate blocks with their declared joins, as `compose` would.
+///
+/// Only valid for text-only block slices — generated blocks have no body until
+/// composition time.
+fn reassemble(blocks: &[InstructionBlock]) -> String {
+    let mut out = String::new();
+    for (index, block) in blocks.iter().enumerate() {
+        if index > 0 {
+            out.push_str(block.join_before.as_str());
+        }
+        match &block.body {
+            BlockBody::Text { text } => out.push_str(text),
+            BlockBody::Generated { generator } => {
+                panic!("reassemble() saw a generated block for {generator:?}")
+            }
+        }
+    }
+    out
+}

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -153,6 +153,43 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 /// `stack_profile_present_when_detected`, `stack_profile_neutral_when_undetected`,
 /// and the robustness tests.
 pub fn resolve_pm_prompt(project_dir: &Path) -> String {
+    let (prompt, source) = resolve_pm_prompt_with_source(project_dir);
+    tracing::debug!(?source, "resolved the PM system prompt");
+    prompt
+}
+
+/// Which composer produced a resolved prompt.
+///
+/// Why: the two composers are byte-identical by contract (#4183), so the
+/// delivered string cannot tell you which one ran. That is exactly the property
+/// that let a call-site mutation survive a green suite — a test asserting
+/// byte-equality through [`resolve_pm_prompt`] would keep passing even if the
+/// package branch were deleted outright. Reporting the source turns "the
+/// composed path was actually taken" into an assertable fact, and gives the
+/// operator a log line saying which model produced their prompt.
+/// What: [`PromptSource::Package`] for the re-sourced bundled fallback,
+/// [`PromptSource::Legacy`] for the two override configurations and for the
+/// compose-error degradation.
+/// Test: `resolve_pm_prompt_takes_the_package_path_when_a_roster_is_deployed`,
+/// `workflow_override_forces_the_legacy_path_even_with_a_roster`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PromptSource {
+    /// Composed via [`crate::core::bundled_pm_package`] / `InstructionPackage`.
+    Package,
+    /// Assembled by the legacy string concatenation.
+    Legacy,
+}
+
+/// [`resolve_pm_prompt`], additionally reporting which composer ran.
+///
+/// Why: see [`PromptSource`] — byte-identical outputs make the path
+/// unobservable from the result alone, so the seam is what keeps the acceptance
+/// gate anchored to the branch it claims to cover.
+/// What: the resolved prompt plus its source. All composition logic lives here;
+/// [`resolve_pm_prompt`] is a thin logging wrapper.
+/// Test: `resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly`,
+/// `resolve_pm_prompt_takes_the_package_path_when_a_roster_is_deployed`.
+pub(crate) fn resolve_pm_prompt_with_source(project_dir: &Path) -> (String, PromptSource) {
     let dir = project_dir.join(OVERRIDE_DIR_NAME);
 
     // Floor is always appended last and never replaceable.
@@ -176,7 +213,7 @@ pub fn resolve_pm_prompt(project_dir: &Path) -> String {
             sections.push(extra);
         }
         sections.push(floor.trim().to_string());
-        return join_sections(sections);
+        return (join_sections(sections), PromptSource::Legacy);
     }
 
     // Branch 2: section-by-section assembly with per-section overrides.
@@ -207,7 +244,7 @@ pub fn resolve_pm_prompt(project_dir: &Path) -> String {
                     roster,
                     addendum.as_deref(),
                 ) {
-                    Ok(prompt) => return prompt,
+                    Ok(prompt) => return (prompt, PromptSource::Package),
                     // Unreachable for the shipped assets — `shipped_assets_
                     // build_and_validate` proves it — so this is a loud last
                     // resort, never a routine fallback. The legacy assembly
@@ -228,7 +265,10 @@ pub fn resolve_pm_prompt(project_dir: &Path) -> String {
 
     let workflow = workflow_override.unwrap_or_else(|| WORKFLOW.trim().to_string());
 
-    assemble_sections(stack, memory_override, workflow, delegation, addendum)
+    (
+        assemble_sections(stack, memory_override, workflow, delegation, addendum),
+        PromptSource::Legacy,
+    )
 }
 
 /// The legacy section-by-section assembly (branch 2).

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -133,10 +133,17 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 /// authoritative, later-and-more-specific memory instruction.
 ///
 /// Delegation roster: the DEFAULT delegation section is composed by
-/// [`bundled_delegation`], which appends the LIVE deployed-agent roster to the
-/// bundled asset (#4069). Like the stack profile it is auto-derived framework
+/// [`delegation_with_roster`], which appends the LIVE deployed-agent roster to
+/// the bundled asset (#4069). Like the stack profile it is auto-derived framework
 /// context — but unlike it, it lives inside the overridable delegation section,
 /// so an `AGENT_DELEGATION.md` override still replaces section and roster alike.
+///
+/// Composition source (#4183): the BUNDLED-FALLBACK configuration — no
+/// delegation, workflow or memory override, and a roster present — is composed
+/// through [`crate::core::bundled_pm_package`] and its typed
+/// [`crate::core::instruction_package::InstructionPackage`], byte-identically to
+/// the legacy assembly below. Every other configuration is deliberately still
+/// assembled by [`assemble_sections`]; see the branch comment for why.
 ///
 /// Test: `no_overrides_uses_bundled`, `instructions_appended`,
 /// `workflow_override_replaces`, `agent_delegation_override_replaces`,
@@ -157,7 +164,12 @@ pub fn resolve_pm_prompt(project_dir: &Path) -> String {
     // configured from that project's detected stack, never a hardcoded default.
     let stack = crate::core::stack_profile::stack_profile_section(project_dir);
 
-    // Branch 1: full replacement short-circuit. BASE_PM still floors it.
+    // Branch 1 (configuration 3): full replacement short-circuit. BASE_PM still
+    // floors it. See #4183 — deliberately still on the legacy path: a deployed
+    // body is opaque prose contributing no delegation section, so it fails both
+    // `SectionWithoutBlocks` and `RosterNotConsumed`. Porting it needs schema
+    // work tracked as follow-up on the epic; do not make it "schema-valid" by
+    // weakening either check.
     if let Some(body) = read_override(&dir, FILE_PM_DEPLOYED) {
         let mut sections: Vec<String> = vec![body, stack];
         if let Some(extra) = read_override(&dir, FILE_INSTRUCTIONS) {
@@ -168,15 +180,80 @@ pub fn resolve_pm_prompt(project_dir: &Path) -> String {
     }
 
     // Branch 2: section-by-section assembly with per-section overrides.
-    let workflow =
-        read_override(&dir, FILE_WORKFLOW).unwrap_or_else(|| WORKFLOW.trim().to_string());
-    let delegation = read_override(&dir, FILE_AGENT_DELEGATION)
-        .unwrap_or_else(|| bundled_delegation(project_dir));
+    let workflow_override = read_override(&dir, FILE_WORKFLOW);
+    let delegation_override = read_override(&dir, FILE_AGENT_DELEGATION);
+    let memory_override = read_override(&dir, FILE_MEMORY);
+    let addendum = read_override(&dir, FILE_INSTRUCTIONS);
 
+    let delegation = match delegation_override {
+        // See #4183 — configuration 2 is deliberately still on the legacy path:
+        // an `AGENT_DELEGATION.md` override replaces the whole section and so
+        // never consumes the computed roster, which `RosterNotConsumed` exists
+        // to forbid. Follow-up on the epic, not a check to relax.
+        Some(body) => body,
+        None => {
+            let roster = crate::core::delegation_authority::deployed_roster_section(project_dir);
+
+            // #4183: configuration 1 (bundled fallback) composes through the
+            // typed InstructionPackage. Gated on there being no section
+            // override and a roster to consume — the only shape the schema can
+            // express — and byte-identical to the assembly below.
+            let bundled_fallback = roster
+                .as_deref()
+                .filter(|_| workflow_override.is_none() && memory_override.is_none());
+            if let Some(roster) = bundled_fallback {
+                match crate::core::bundled_pm_package::compose_bundled_fallback(
+                    &stack,
+                    roster,
+                    addendum.as_deref(),
+                ) {
+                    Ok(prompt) => return prompt,
+                    // Unreachable for the shipped assets — `shipped_assets_
+                    // build_and_validate` proves it — so this is a loud last
+                    // resort, never a routine fallback. The legacy assembly
+                    // below is byte-identical, so degrading to it still
+                    // delivers the right prompt; the error is what says the
+                    // package model drifted from the assets.
+                    Err(err) => tracing::error!(
+                        %err,
+                        "bundled PM instruction package failed to compose; \
+                         falling back to the legacy assembly"
+                    ),
+                }
+            }
+
+            delegation_with_roster(roster.as_deref())
+        }
+    };
+
+    let workflow = workflow_override.unwrap_or_else(|| WORKFLOW.trim().to_string());
+
+    assemble_sections(stack, memory_override, workflow, delegation, addendum)
+}
+
+/// The legacy section-by-section assembly (branch 2).
+///
+/// Why: extracted so the configurations #4183 leaves on the legacy path share
+/// one implementation with the byte-equality oracle the package path is tested
+/// against — an oracle that is dead test code proves nothing.
+/// What: `PM_INSTRUCTIONS` → stack profile → optional memory block → workflow →
+/// delegation → optional addendum → the non-overridable floor, joined with
+/// [`SECTION_SEPARATOR`] and with empty sections dropped.
+/// Test: `no_overrides_uses_bundled`, `workflow_override_replaces`,
+/// `memory_override_is_slotted_after_pm_instructions`, and
+/// `composed_package_is_byte_identical_to_the_legacy_bundled_fallback` in
+/// `bundled_pm_package_tests.rs`.
+pub(crate) fn assemble_sections(
+    stack: String,
+    memory_override: Option<String>,
+    workflow: String,
+    delegation: String,
+    addendum: Option<String>,
+) -> String {
     let mut sections: Vec<String> = vec![PM_INSTRUCTIONS.trim().to_string(), stack];
 
     // MEMORY override slots in right after PM_INSTRUCTIONS as a delimited block.
-    if let Some(memory) = read_override(&dir, FILE_MEMORY) {
+    if let Some(memory) = memory_override {
         sections.push(format!("{MEMORY_OVERRIDE_HEADING}\n\n{memory}"));
     }
 
@@ -184,12 +261,12 @@ pub fn resolve_pm_prompt(project_dir: &Path) -> String {
     sections.push(delegation);
 
     // Additive project rules.
-    if let Some(extra) = read_override(&dir, FILE_INSTRUCTIONS) {
+    if let Some(extra) = addendum {
         sections.push(extra);
     }
 
     // Non-overridable floor, always last.
-    sections.push(floor.trim().to_string());
+    sections.push(BASE_PM.trim().to_string());
 
     join_sections(sections)
 }
@@ -218,8 +295,11 @@ pub fn resolve_pm_prompt(project_dir: &Path) -> String {
 ///
 /// What: a Markdown blockquote stating the roster wins on WHICH agents exist,
 /// and to re-route rather than retry on an unknown-agent-type error.
+///
+/// `pub(crate)` since #4183: [`crate::core::bundled_pm_package`] emits it as its
+/// own delegation-section block, so both composers use the identical literal.
 /// Test: `bundled_delegation_appends_deployed_roster`.
-const ROSTER_PRECEDENCE_NOTE: &str = "\
+pub(crate) const ROSTER_PRECEDENCE_NOTE: &str = "\
 > The live roster below is authoritative for WHICH agents exist and what each handles; the \
 tables above are routing doctrine only. Where the two disagree, trust the roster.\n\
 >\n\
@@ -245,15 +325,18 @@ not retry the same agent.";
 /// This is the FALLBACK only: a project/user `AGENT_DELEGATION.md` override
 /// still replaces the whole section, unchanged, exactly as documented.
 ///
-/// What: returns the trimmed bundled asset, with
-/// [`crate::core::delegation_authority::deployed_roster_section`]'s rendered
-/// `## Delegation Authority` block appended when any agent is deployed. With no
-/// deployed agents the asset is returned alone (pre-#4069 behaviour).
+/// What: returns the trimmed bundled asset, with the rendered
+/// `## Delegation Authority` block from
+/// [`crate::core::delegation_authority::deployed_roster_section`] appended when
+/// any agent is deployed. With no deployed agents the asset is returned alone
+/// (pre-#4069 behaviour). Takes the already-rendered roster rather than scanning
+/// itself (#4183) so `resolve_pm_prompt` scans the agent tiers exactly once
+/// whichever composition path it takes.
 /// Test: `bundled_delegation_appends_deployed_roster`,
 /// `no_overrides_uses_bundled`, `agent_delegation_override_replaces`.
-fn bundled_delegation(project_dir: &Path) -> String {
+pub(crate) fn delegation_with_roster(roster: Option<&str>) -> String {
     let bundled = AGENT_DELEGATION.trim();
-    match crate::core::delegation_authority::deployed_roster_section(project_dir) {
+    match roster {
         Some(roster) => format!("{bundled}\n\n{ROSTER_PRECEDENCE_NOTE}\n\n{}", roster.trim()),
         None => bundled.to_string(),
     }

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -154,7 +154,12 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 /// and the robustness tests.
 pub fn resolve_pm_prompt(project_dir: &Path) -> String {
     let (prompt, source) = resolve_pm_prompt_with_source(project_dir);
-    tracing::debug!(?source, "resolved the PM system prompt");
+    // `info!`, deliberately: this is the operator-visible record of WHICH
+    // composer produced the session's prompt, and the two are byte-identical by
+    // contract so nothing else can reveal it. `debug!` sits below the default
+    // filter in both subscriber setups, which would make the claim false as
+    // shipped. Matches `delegation_authority`'s analogous roster-source event.
+    tracing::info!(?source, "resolved the PM system prompt");
     prompt
 }
 
@@ -185,11 +190,44 @@ pub(crate) enum PromptSource {
 /// Why: see [`PromptSource`] — byte-identical outputs make the path
 /// unobservable from the result alone, so the seam is what keeps the acceptance
 /// gate anchored to the branch it claims to cover.
-/// What: the resolved prompt plus its source. All composition logic lives here;
-/// [`resolve_pm_prompt`] is a thin logging wrapper.
-/// Test: `resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly`,
-/// `resolve_pm_prompt_takes_the_package_path_when_a_roster_is_deployed`.
+/// What: the resolved prompt plus its source, with the deployed-agent roster
+/// scanned from the real tiers.
+/// Test: `resolve_pm_prompt_takes_the_package_path_when_a_roster_is_deployed`,
+/// `workflow_override_forces_the_legacy_path_even_with_a_roster`.
 pub(crate) fn resolve_pm_prompt_with_source(project_dir: &Path) -> (String, PromptSource) {
+    resolve_pm_prompt_with_roster(project_dir, || {
+        crate::core::delegation_authority::deployed_roster_section(project_dir)
+    })
+}
+
+/// [`resolve_pm_prompt_with_source`] with the agent roster supplied by the
+/// caller.
+///
+/// Why: the roster is the one composition input this function cannot control
+/// and cannot re-derive. [`crate::core::delegation_authority::deployed_roster_section`]
+/// unions three tiers — the project tier, `$CLAUDE_CONFIG_DIR/agents` and
+/// `~/.claude/agents` — on EVERY call, and the latter two are machine-global
+/// mutable state that live `tm` sessions rewrite at launch; `scan_agents` also
+/// drops a file silently on a transient read failure. Two successive scans can
+/// therefore disagree. A byte-equality test that scans once per side is
+/// consequently racing, and it fails with a message indistinguishable from a
+/// genuine delivered-prompt regression — observed at ~1 red in 4 full-suite
+/// runs on a provisioned workstation, and invisible in CI, where no ambient
+/// tier exists. Injecting the roster gives both sides of that comparison ONE
+/// value without touching `$HOME` (which would cost the serial `HOME_LOCK`) and
+/// without altering the wiring under test.
+///
+/// What: identical to [`resolve_pm_prompt_with_source`] except that
+/// `roster_source` supplies the rendered `## Delegation Authority` block. It is
+/// a closure, not a value, so it stays LAZY: an `AGENT_DELEGATION.md` override
+/// short-circuits before any scan, exactly as before.
+/// Test: `resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly`,
+/// `resolve_pm_prompt_is_byte_identical_with_a_project_addendum`,
+/// `gate_is_deterministic_across_repeated_runs`.
+pub(crate) fn resolve_pm_prompt_with_roster(
+    project_dir: &Path,
+    roster_source: impl FnOnce() -> Option<String>,
+) -> (String, PromptSource) {
     let dir = project_dir.join(OVERRIDE_DIR_NAME);
 
     // Floor is always appended last and never replaceable.
@@ -229,7 +267,7 @@ pub(crate) fn resolve_pm_prompt_with_source(project_dir: &Path) -> (String, Prom
         // to forbid. Follow-up on the epic, not a check to relax.
         Some(body) => body,
         None => {
-            let roster = crate::core::delegation_authority::deployed_roster_section(project_dir);
+            let roster = roster_source();
 
             // #4183: configuration 1 (bundled fallback) composes through the
             // typed InstructionPackage. Gated on there being no section
@@ -239,6 +277,17 @@ pub(crate) fn resolve_pm_prompt_with_source(project_dir: &Path) -> (String, Prom
                 .as_deref()
                 .filter(|_| workflow_override.is_none() && memory_override.is_none());
             if let Some(roster) = bundled_fallback {
+                // PRECONDITION, established by the `filter` directly above and
+                // relied on by the error arm: on this branch `workflow_override`
+                // and `memory_override` are both `None`. That is what makes the
+                // degradation below byte-identical rather than merely "close" —
+                // the legacy assembly reached on error must be the SAME
+                // configuration the package was composing. If the filter ever
+                // widens, the error path silently stops being equivalent.
+                debug_assert!(
+                    workflow_override.is_none() && memory_override.is_none(),
+                    "the bundled-fallback branch requires no workflow/memory override"
+                );
                 match crate::core::bundled_pm_package::compose_bundled_fallback(
                     &stack,
                     roster,
@@ -247,10 +296,11 @@ pub(crate) fn resolve_pm_prompt_with_source(project_dir: &Path) -> (String, Prom
                     Ok(prompt) => return (prompt, PromptSource::Package),
                     // Unreachable for the shipped assets — `shipped_assets_
                     // build_and_validate` proves it — so this is a loud last
-                    // resort, never a routine fallback. The legacy assembly
-                    // below is byte-identical, so degrading to it still
-                    // delivers the right prompt; the error is what says the
-                    // package model drifted from the assets.
+                    // resort, never a routine fallback. Given the precondition
+                    // above, the legacy assembly below composes the identical
+                    // configuration and is byte-identical to it, so degrading
+                    // still delivers the right prompt; the error is what says
+                    // the package model drifted from the assets.
                     Err(err) => tracing::error!(
                         %err,
                         "bundled PM instruction package failed to compose; \

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -21,6 +21,10 @@ pub mod artifact;
 pub mod auto_resume;
 pub mod budget;
 pub mod bundle;
+// Epic #4183: the DEFAULT (bundled-fallback) PM prompt, re-sourced through
+// `instruction_package`. Byte-identical to the legacy assembly it replaces; the
+// override configurations stay on that legacy path by design.
+pub mod bundled_pm_package;
 // DOC-28 cutover bridge: incremental catch-up runtime — CUTOVER BRIDGE — remove post-migration (#1762)
 pub mod catchup;
 pub mod circuit;
@@ -53,7 +57,7 @@ pub mod idle_nudge;
 pub mod idle_parking;
 pub mod instruction_overrides;
 // Issue #4184 / epic #4183: the sectioned-JSON instruction package schema. Types
-// + validation only — nothing in the launch path composes from it yet (#4186).
+// + validation only; `bundled_pm_package` is its first composing call site.
 pub mod instruction_package;
 pub mod instruction_pipeline;
 pub mod ipc;


### PR DESCRIPTION
Epic [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183) (milestone tm 1.3.0), carrying the scope formerly tracked as #4186.

Re-sources the PM instruction prompt composition through the `InstructionPackage` type landed by #4223, **for the bundled-fallback configuration only**.

## Scope — one of three configurations, deliberately

| # | configuration | path after this PR |
|---|---|---|
| 1 | bundled fallback (roster present, no section override) | **`InstructionPackage::compose`** |
| 2 | `.trusty-mpm/AGENT_DELEGATION.md` override | legacy, unchanged **by design** |
| 3 | `.trusty-mpm/PM_INSTRUCTIONS_DEPLOYED.md` | legacy, unchanged **by design** |

Configurations 2 and 3 are not merely unported — they are currently *inexpressible* in the schema. An `AGENT_DELEGATION.md` override replaces the whole delegation section and therefore never consumes the computed roster (`RosterNotConsumed`, the #4196 guard); `PM_INSTRUCTIONS_DEPLOYED.md` replaces the body with opaque prose that contributes no delegation section at all (`SectionWithoutBlocks` as well). Both keep flowing through exactly the code they do today, marked with `See #4183` at the branch points. **Neither validation check is weakened to accommodate them** — [#4247](https://github.com/bobmatnyc/trusty-tools/issues/4247) tracks the decision.

## The acceptance gate: strict byte-equality, at the entry point

The composed prompt is byte-for-byte what `resolve_pm_prompt` produced before this PR. Nothing resolves after composition — the agent roster is fixed at session launch and Claude Code cannot change the agent set afterwards — so the composed string IS the delivered prompt, and any divergence is a delivered-prompt regression.

Following review, the gate is asserted **through `resolve_pm_prompt` itself** (`resolve_pm_prompt_is_byte_identical_to_the_legacy_assembly`), not just between the two composers given hand-supplied arguments. Each entry-point test deploys a project-tier agent first, so the composed branch is a property of the test rather than of the machine's `~/.claude/agents` — on a clean CI runner the older tests all took the *legacy* branch. No `$HOME` scoping is used, deliberately: the project tier is sufficient and scoping `$HOME` would reintroduce the cross-test `HOME_LOCK` race for no added coverage.

`resolve_pm_prompt` now also reports which composer ran. The two are byte-identical by contract, so the delivered string cannot reveal the path — without that seam a byte-equality assertion through the entry point would keep passing even if the package branch were deleted outright. The source is logged, so it is operator-visible rather than test-only.

**Mutation evidence** (each applied to the call site, suite re-run, then reverted):

| mutation | result |
|---|---|
| `addendum.as_deref()` → `None` (drops every project's `INSTRUCTIONS.md`) | RED — `resolve_pm_prompt_is_byte_identical_with_a_project_addendum`: *"the project addendum must reach the delivered prompt on the composed path"* |
| delete the `workflow_override.is_none() && memory_override.is_none()` filter | RED — `workflow_override_forces_the_legacy_path_even_with_a_roster` and `memory_override_forces_the_legacy_path_even_with_a_roster`: `left: Package, right: Legacy` |
| force the composed branch never to run | RED — all three `resolve_pm_prompt_*` tests: `left: Legacy, right: Package` |
| `Join::Blank` → `Join::Rule` on the roster note | RED — `first difference at byte offset 33520 (expected 40126 bytes, actual 40131 bytes)` |

## How byte-equality is held — and what it does not cover

`bundled_pm_package` does not paste asset text into a hand-authored package. It **cuts the assets at runtime**: `PM_INSTRUCTIONS.md` into Core / Memory / Search, `BASE_PM.md` into Identity / Non-Overridable Rules / Framework-Guaranteed Conventions, deriving each block's `Join` from the exact bytes removed. Reassembly is true by construction, so re-sectioning cannot move a byte. `Join::Rule` is the same literal as `instruction_pipeline::SECTION_SEPARATOR`, so top-level boundaries match the legacy join.

That property cuts both ways, and the earlier revision of this description overstated it. Composed output equals `asset.trim()` **wherever the cuts land**, so the byte gate is structurally incapable of catching a cut placed at the wrong offset: bytes would be fine while the section *attribution* — the thing this PR exists to establish — was silently wrong. Two guards cover that instead:

- `split_asset` requires every marker to occur **exactly once** per asset (`MarkerNotUnique`), turning a duplicated marker from silent to red; a deleted marker is `MarkerNotFound`, and a move that reorders sections fails the same way because marker search is forward-only;
- the cut tests pin each block's **opening content**, not merely the section-id sequence.

Notes: the floor block stream is `Identity, NonOverridable, FrameworkConventions, NonOverridable` — the canonical-order inversion `validate_floor_is_last` deliberately permits, because `## Trusty Tool Priority` sits last in the asset. `output_style::inject_style_into_prompt` stays an outer wrapper applied by `build_system_prompt_for_with_style_and_native`; it is not pulled into the package model and not part of the comparison.

Recorded on #4247 ([comment](https://github.com/bobmatnyc/trusty-tools/issues/4247#issuecomment-5109187627)) and on `PM_INSTRUCTIONS_CUTS`: Memory and Search are two halves of one numbered list while both declaring tier `project`, so they are **not independently overridable** until `PM_INSTRUCTIONS.md` gives each its own heading.

## Verification

- `cargo test -p trusty-mpm` — exit 0, **3829 lib tests passed, 0 failed**, 6614 passed across the whole crate, 0 failures anywhere; 24 tests in `bundled_pm_package_tests.rs`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `scripts/check_line_cap.sh` — `7 allowlisted, 0 violations — OK` (`instruction_overrides.rs` 421, `bundled_pm_package.rs` 293 — both under the 500 prod cap; `bundled_pm_package_tests.rs` 482, under the 3000 test cap)
- every `Test:` doc pointer added here resolves to a real `fn`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools