### PR TITLE
fix(trusty-mpm): serialise projects.json writes across processes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11431,6 +11431,7 @@ dependencies = [
  "dirs 5.0.1",
  "dotenvy",
  "fastembed",
+ "fd-lock",
  "futures",
  "futures-util",
  "genco",

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- `json_rmw`: cross-process locked read-modify-write for whole-file JSON
+  documents — the single implementation of the load → mutate → save critical
+  section that `trusty-mpm`'s `projects.json`, `trusty-gworkspace`'s
+  `tokens.json` (#3502) and the epic #4207 worktree registry all need.
+  `json_rmw::update` takes an exclusive advisory lock on a `<path>.lock`
+  sidecar, re-reads the document under that lock (never trusting a caller's
+  stale copy), applies the mutation, and publishes atomically via a
+  per-writer-unique temp file + `fsync` + `rename` + directory `fsync`. Never
+  fails open: a failed lock, read, parse or write returns `Err` with the
+  document byte-for-byte unchanged, and only a genuinely absent file starts
+  from `Default`. Adds `fd-lock` as an unconditional dependency.
+
 ---
 ## [0.27.0] — 2026-07-27
 

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -91,6 +91,10 @@ tracing-subscriber = { workspace = true }
 # `Layer` impl in `log_buffer` also uses tracing-subscriber's `registry`
 # feature (enabled in the workspace dep).
 sysinfo = { workspace = true }
+# Cross-process advisory file locking for the `json_rmw` locked
+# read-modify-write critical section (trusty-mpm's projects.json lost-update
+# bug; same primitive trusty-gworkspace already uses for tokens.json, #3502).
+fd-lock = { workspace = true }
 dirs = { workspace = true }
 colored = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/trusty-common/src/json_rmw.rs
+++ b/crates/trusty-common/src/json_rmw.rs
@@ -1,0 +1,311 @@
+//! Cross-process read-modify-write for a whole-file JSON document.
+//!
+//! Why: several trusty crates persist a small JSON document that multiple
+//! independent PROCESSES mutate — `trusty-mpm`'s `projects.json` registry,
+//! `trusty-gworkspace`'s `tokens.json` (issue #3502), and the dual worktree
+//! registry epic #4207 will reconcile. Every one of them is a
+//! load → mutate → save-the-whole-file cycle. With no cross-process
+//! serialisation, two writers that interleave read/read/write/write silently
+//! lose one of the two updates and BOTH callers see success; worse, if they
+//! share one temp path they can publish a half-written document and corrupt the
+//! file outright. An in-process `Mutex` cannot fix either failure because the
+//! writers are separate processes. This module is the single implementation of
+//! that critical section so each call site inherits the fix instead of
+//! re-deriving it.
+//! What: [`update`] takes an advisory exclusive lock on a `<path>.lock` sidecar,
+//! re-reads the document from disk under that lock (never trusting a caller's
+//! possibly-stale copy), applies the caller's mutation, and publishes the result
+//! atomically — unique temp file, `fsync`, `rename`, `fsync` of the parent
+//! directory — before releasing the lock.
+//! Test: `cargo test -p trusty-common -- json_rmw::tests`.
+//!
+//! # Atomicity contract
+//!
+//! Guarantees a caller may rely on:
+//!
+//! 1. **Serialisation.** The read, the mutation and the write happen while one
+//!    writer holds an exclusive advisory lock, so no other [`update`] on the
+//!    same path can observe or overwrite the intermediate state. The lock is
+//!    `flock(2)`-style: it is held by the open file description, so it
+//!    serialises separate processes AND separate threads that each call
+//!    [`update`], on Unix and Windows alike.
+//! 2. **All-or-nothing publish.** Readers of `path` see either the complete
+//!    previous document or the complete new one, never a partial write. The
+//!    temp file carries the writer's pid and a nanosecond stamp, so concurrent
+//!    writers never share a scratch path even if one of them bypasses the lock.
+//! 3. **Never fail open.** Every failure — lock acquisition, read, parse,
+//!    serialise, write, rename — returns `Err` and leaves `path` byte-for-byte
+//!    unchanged. There is no path on which a failed update advances state, and
+//!    an unreadable-but-present file is never silently replaced with a default
+//!    (empty) document; only a genuinely absent file starts from
+//!    [`Default`].
+//! 4. **Crash safety.** A writer killed at any point leaves either the previous
+//!    document intact or an orphaned `*.tmp` file that no reader consults.
+//!
+//! Explicitly NOT guaranteed:
+//!
+//! - **Advisory, not mandatory.** A process that writes `path` without going
+//!   through [`update`] is not blocked. Every writer of a given file must use
+//!   this entry point.
+//! - **Not reentrant.** [`update`] must not be called from inside another
+//!   [`update`] closure on the same path: the second acquisition uses a
+//!   different file descriptor and will self-deadlock.
+//! - **Blocking.** Lock acquisition blocks the calling thread. Async callers
+//!   must run [`update`] on a blocking-safe thread (e.g.
+//!   `tokio::task::spawn_blocking`).
+
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+
+/// Failure modes of a locked JSON read-modify-write.
+///
+/// Why: callers must be able to tell a lock-contention/permission problem apart
+/// from a corrupt document, because the remedies differ (retry / operator
+/// intervention vs. restore the file). Every variant carries the path it
+/// concerns so a multi-file caller can report which document failed.
+/// What: one variant per stage of the cycle — lock, I/O, (de)serialisation.
+/// `Display`/`Error` are implemented by hand rather than derived: this crate
+/// keeps `thiserror` behind an optional feature (`default = []`), and `json_rmw`
+/// is an unconditional module, so deriving would force `thiserror` into every
+/// minimal build of `trusty-common`. Crates that own their own error types
+/// should still prefer `thiserror` and convert via [`From`].
+/// Test: `update_lock_path_unopenable_errors`, `update_corrupt_file_errors`.
+#[derive(Debug)]
+pub enum JsonRmwError {
+    /// The advisory lock could not be created or acquired.
+    Lock {
+        /// The document the lock guards (not the sidecar itself).
+        path: PathBuf,
+        /// The underlying OS error.
+        source: std::io::Error,
+    },
+
+    /// Reading, writing, renaming or syncing the document failed.
+    Io {
+        /// The document being read or published.
+        path: PathBuf,
+        /// The underlying OS error.
+        source: std::io::Error,
+    },
+
+    /// The document could not be parsed, or the new value could not be encoded.
+    Serialize {
+        /// The document being parsed or encoded.
+        path: PathBuf,
+        /// The `serde_json` message.
+        message: String,
+    },
+}
+
+impl std::fmt::Display for JsonRmwError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Lock { path, source } => write!(
+                f,
+                "could not acquire the update lock for {}: {source}",
+                path.display()
+            ),
+            Self::Io { path, source } => write!(
+                f,
+                "json read-modify-write I/O error on {}: {source}",
+                path.display()
+            ),
+            Self::Serialize { path, message } => write!(
+                f,
+                "json read-modify-write serialization error on {}: {message}",
+                path.display()
+            ),
+        }
+    }
+}
+
+impl std::error::Error for JsonRmwError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Lock { source, .. } | Self::Io { source, .. } => Some(source),
+            Self::Serialize { .. } => None,
+        }
+    }
+}
+
+impl JsonRmwError {
+    /// Wrap an I/O error against `path`.
+    fn io(path: &Path, source: std::io::Error) -> Self {
+        Self::Io {
+            path: path.to_path_buf(),
+            source,
+        }
+    }
+
+    /// Wrap a serde error against `path`.
+    fn serialize(path: &Path, e: serde_json::Error) -> Self {
+        Self::Serialize {
+            path: path.to_path_buf(),
+            message: e.to_string(),
+        }
+    }
+}
+
+/// Sidecar lock-file path for `path`.
+///
+/// Why: locking the document itself would mean opening it for write before we
+/// know whether the update will succeed, and would be lost across the `rename`
+/// that publishes a new version (the renamed-over inode, and any lock on it,
+/// is discarded). A stable sidecar survives every publish.
+/// What: appends `.lock` to the file name, keeping it in the same directory.
+/// Test: `lock_path_is_a_sidecar`.
+pub fn lock_path(path: &Path) -> PathBuf {
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(".lock");
+    path.with_file_name(name)
+}
+
+/// Scratch path for one publish attempt — unique per writer and per attempt.
+///
+/// Why: a SHARED temp name is itself a corruption bug. `trusty-mpm` used a fixed
+/// `projects.json.tmp`: two processes writing it at once interleaved into one
+/// file and then renamed the mangled result over the real registry, producing a
+/// `projects.json` that no longer parsed. Uniqueness per attempt removes that
+/// class of failure entirely, independently of the lock.
+/// What: `<file_name>.<pid>.<nanos>.tmp`, alongside the target so the publish is
+/// a same-filesystem `rename`.
+fn temp_path(path: &Path) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let mut name = path.file_name().unwrap_or_default().to_os_string();
+    name.push(format!(".{}.{nanos}.tmp", std::process::id()));
+    path.with_file_name(name)
+}
+
+/// Read and parse `path`, treating only genuine absence as an empty document.
+///
+/// Why: this is the "never fail open" hinge. If any I/O error were treated as
+/// "file absent", a transient permission or hardware fault would hand the caller
+/// an empty `T`, and the publish at the end of [`update`] would overwrite a
+/// perfectly good document with nothing — a total data loss dressed up as
+/// success.
+/// What: `NotFound` yields `T::default()`; every other error propagates.
+fn read_or_default<T: DeserializeOwned + Default>(path: &Path) -> Result<T, JsonRmwError> {
+    match std::fs::read(path) {
+        Ok(raw) => serde_json::from_slice(&raw).map_err(|e| JsonRmwError::serialize(path, e)),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(T::default()),
+        Err(e) => Err(JsonRmwError::io(path, e)),
+    }
+}
+
+/// Publish `bytes` at `path` atomically: unique temp, fsync, rename, fsync dir.
+///
+/// Why: `rename(2)` within a filesystem is atomic, so a reader sees the old file
+/// or the new one and never a partial write. The `fsync` of the temp file before
+/// the rename is what makes that true across a power loss rather than only
+/// across a process crash; the `fsync` of the directory makes the rename itself
+/// durable.
+/// What: writes to [`temp_path`], syncs it, renames it over `path`, then syncs
+/// the parent directory. Any failure removes the temp file and returns `Err`
+/// with `path` untouched.
+/// Test: `update_publishes_atomically_leaving_no_temp`,
+/// `update_write_failure_leaves_original_intact`.
+fn publish_atomic(path: &Path, bytes: &[u8]) -> Result<(), JsonRmwError> {
+    let parent = path.parent().unwrap_or_else(|| Path::new("."));
+    std::fs::create_dir_all(parent).map_err(|e| JsonRmwError::io(path, e))?;
+
+    let tmp = temp_path(path);
+    let write_result = (|| -> std::io::Result<()> {
+        let mut file = File::create(&tmp)?;
+        file.write_all(bytes)?;
+        // Durability of the CONTENT must precede the rename that publishes it.
+        file.sync_all()?;
+        Ok(())
+    })();
+    if let Err(e) = write_result {
+        // Never leave a half-written scratch file behind.
+        let _ = std::fs::remove_file(&tmp);
+        return Err(JsonRmwError::io(path, e));
+    }
+
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(JsonRmwError::io(path, e));
+    }
+
+    // Durability of the rename itself. Unix-only: Windows has no directory
+    // handle to sync, and its rename is already committed to the log.
+    #[cfg(unix)]
+    if let Ok(dir) = File::open(parent) {
+        let _ = dir.sync_all();
+    }
+    Ok(())
+}
+
+/// Run a read-modify-write on the JSON document at `path` under an exclusive
+/// cross-process lock.
+///
+/// Why: see the module-level rationale — this is the one place the
+/// load → mutate → save cycle is made safe against concurrent writers, so
+/// callers stop hand-rolling (and getting wrong) their own version of it.
+/// What: acquires the exclusive advisory lock on [`lock_path`] (blocking until
+/// it is available), re-reads and parses `path` under that lock (an absent file
+/// starts from [`Default`]; an unreadable or malformed one is an error, never a
+/// silent reset), calls `f` with the freshly-read value, and — only when `f`
+/// returns `Ok` — publishes the mutated document via [`publish_atomic`]. When
+/// `f` returns `Err` the document is left byte-for-byte unchanged and the error
+/// is propagated, so a rejected mutation cannot advance state. The lock is
+/// released by RAII on every exit path, including panics.
+///
+/// `f`'s error type `E` need only be constructible from [`JsonRmwError`], which
+/// lets a caller keep its own domain error as the single return type.
+///
+/// Blocking: acquisition blocks the calling thread; async callers must wrap this
+/// in `tokio::task::spawn_blocking`. Not reentrant — see the module docs.
+/// Test: `update_serialises_concurrent_threads`,
+/// `update_creates_file_when_absent`, `update_closure_error_does_not_write`,
+/// `update_lock_path_unopenable_errors`.
+pub fn update<T, R, E, F>(path: &Path, f: F) -> Result<R, E>
+where
+    T: DeserializeOwned + Serialize + Default,
+    E: From<JsonRmwError>,
+    F: FnOnce(&mut T) -> Result<R, E>,
+{
+    let lock = lock_path(path);
+    if let Some(parent) = lock.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| JsonRmwError::Lock {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    }
+    let lock_file = OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(&lock)
+        .map_err(|e| JsonRmwError::Lock {
+            path: path.to_path_buf(),
+            source: e,
+        })?;
+    let mut rw = fd_lock::RwLock::new(lock_file);
+    // Blocking exclusive acquisition. Failure is an error, never a bypass:
+    // proceeding unlocked is exactly the lost-update bug this module exists to
+    // remove.
+    let _guard = rw.write().map_err(|e| JsonRmwError::Lock {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    let mut value: T = read_or_default(path)?;
+    let result = f(&mut value)?;
+    let bytes = serde_json::to_vec_pretty(&value).map_err(|e| JsonRmwError::serialize(path, e))?;
+    publish_atomic(path, &bytes)?;
+    Ok(result)
+}
+
+#[cfg(test)]
+#[path = "json_rmw_tests.rs"]
+mod tests;

--- a/crates/trusty-common/src/json_rmw_tests.rs
+++ b/crates/trusty-common/src/json_rmw_tests.rs
@@ -1,0 +1,199 @@
+//! Unit tests for [`super`] — the cross-process locked JSON read-modify-write.
+//!
+//! Why: every guarantee in the module's atomicity contract needs a test that
+//! would fail if the guarantee were dropped, especially the two that are easy to
+//! regress silently: "never fail open" (a failed read must not publish an empty
+//! document) and "all-or-nothing publish".
+//! What: covers the sidecar path, absent-file creation, contention between
+//! concurrent writers, closure-rejection, and each error path.
+//! Test: this file IS the test module; run with `cargo test -p trusty-common`.
+
+use super::*;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+type Doc = HashMap<String, u64>;
+
+/// Read the document at `path`, panicking if it is absent or malformed.
+fn read_doc(path: &Path) -> Doc {
+    let raw = std::fs::read(path).expect("read doc");
+    serde_json::from_slice(&raw).expect("parse doc")
+}
+
+/// Insert `key = value`, the standard mutation used across these tests.
+fn insert(path: &Path, key: &str, value: u64) -> Result<(), JsonRmwError> {
+    update::<Doc, (), JsonRmwError, _>(path, |doc| {
+        doc.insert(key.to_string(), value);
+        Ok(())
+    })
+}
+
+#[test]
+fn lock_path_is_a_sidecar() {
+    let got = lock_path(Path::new("/data/projects.json"));
+    assert_eq!(got, Path::new("/data/projects.json.lock"));
+}
+
+/// An absent document starts from `Default` and is created by the first update.
+#[test]
+fn update_creates_file_when_absent() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("doc.json");
+    insert(&path, "a", 1).expect("first update");
+    assert_eq!(read_doc(&path).get("a"), Some(&1));
+}
+
+/// The publish is a rename from a unique temp path, and leaves no scratch file.
+#[test]
+fn update_publishes_atomically_leaving_no_temp() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("doc.json");
+    insert(&path, "a", 1).expect("update");
+    insert(&path, "b", 2).expect("update");
+
+    let leftovers: Vec<String> = std::fs::read_dir(dir.path())
+        .expect("read_dir")
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|n| n.ends_with(".tmp"))
+        .collect();
+    assert!(
+        leftovers.is_empty(),
+        "temp files left behind: {leftovers:?}"
+    );
+}
+
+/// Concurrent writers must each land; none may be silently dropped.
+///
+/// Why: this is the lost-update guarantee. Each thread opens its OWN descriptor
+/// on the sidecar, so the `flock` here is the same conflict the separate-process
+/// case relies on — no in-process mutex is involved.
+/// What: 8 threads each insert a distinct key into the same document; all 8
+/// must be present afterwards.
+/// Test: this IS the test.
+#[test]
+fn update_serialises_concurrent_threads() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("doc.json");
+
+    std::thread::scope(|scope| {
+        for i in 0..8u64 {
+            let path = path.clone();
+            scope.spawn(move || {
+                for round in 0..5u64 {
+                    insert(&path, &format!("k{i}-{round}"), i).expect("concurrent update");
+                }
+            });
+        }
+    });
+
+    let doc = read_doc(&path);
+    assert_eq!(doc.len(), 40, "lost concurrent updates: {doc:?}");
+}
+
+/// A closure that returns `Err` must leave the document byte-for-byte unchanged.
+#[test]
+fn update_closure_error_does_not_write() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("doc.json");
+    insert(&path, "keep", 7).expect("seed");
+    let before = std::fs::read(&path).expect("read before");
+
+    let result = update::<Doc, (), JsonRmwError, _>(&path, |doc| {
+        doc.insert("must-not-persist".into(), 1);
+        Err(JsonRmwError::Serialize {
+            path: path.clone(),
+            message: "rejected by caller".into(),
+        })
+    });
+    assert!(result.is_err(), "closure error must propagate");
+    assert_eq!(
+        std::fs::read(&path).expect("read after"),
+        before,
+        "a rejected mutation must not be published"
+    );
+}
+
+/// A malformed document is an error — never silently reset to `Default`.
+#[test]
+fn update_corrupt_file_errors() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("doc.json");
+    std::fs::write(&path, b"{ this is not json").expect("write corrupt");
+
+    let result = insert(&path, "a", 1);
+    assert!(
+        matches!(result, Err(JsonRmwError::Serialize { .. })),
+        "expected Serialize error, got {result:?}"
+    );
+    assert_eq!(
+        std::fs::read(&path).expect("read after"),
+        b"{ this is not json",
+        "a corrupt file must be preserved for the operator, not overwritten"
+    );
+}
+
+/// An unusable lock path is an error — the update must NOT proceed unlocked.
+#[test]
+fn update_lock_path_unopenable_errors() {
+    let dir = TempDir::new().expect("tempdir");
+    let path = dir.path().join("doc.json");
+    insert(&path, "keep", 7).expect("seed");
+    let before = std::fs::read(&path).expect("read before");
+
+    // A directory where the sidecar belongs makes the lock file unopenable.
+    // The seed above already created the sidecar as a regular file.
+    let sidecar = lock_path(&path);
+    std::fs::remove_file(&sidecar).expect("drop seeded sidecar");
+    std::fs::create_dir_all(&sidecar).expect("plant blocking dir");
+
+    let result = insert(&path, "new", 1);
+    assert!(
+        matches!(result, Err(JsonRmwError::Lock { .. })),
+        "expected Lock error, got {result:?}"
+    );
+    assert_eq!(
+        std::fs::read(&path).expect("read after"),
+        before,
+        "a failed lock must not fall through to an unsynchronised write"
+    );
+}
+
+/// A failed publish must leave the previous document intact.
+///
+/// Why: the "all-or-nothing" half of the contract. If the temp write fails after
+/// the document was read, an implementation that had already truncated the
+/// target would have destroyed it.
+/// What: makes the containing directory unwritable so the temp file cannot be
+/// created, then asserts the original content survives unchanged.
+/// Test: this IS the test.
+#[cfg(unix)]
+#[test]
+fn update_write_failure_leaves_original_intact() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let dir = TempDir::new().expect("tempdir");
+    let sub = dir.path().join("store");
+    std::fs::create_dir_all(&sub).expect("mkdir");
+    let path = sub.join("doc.json");
+    insert(&path, "keep", 7).expect("seed");
+    let before = std::fs::read(&path).expect("read before");
+
+    // r-xr-xr-x: existing files stay readable, new files cannot be created.
+    let restore = std::fs::metadata(&sub).expect("stat").permissions();
+    std::fs::set_permissions(&sub, std::fs::Permissions::from_mode(0o555)).expect("chmod ro");
+
+    let result = insert(&path, "new", 1);
+
+    std::fs::set_permissions(&sub, restore).expect("restore perms");
+
+    assert!(
+        matches!(result, Err(JsonRmwError::Io { .. })),
+        "expected Io error, got {result:?}"
+    );
+    assert_eq!(
+        std::fs::read(&path).expect("read after"),
+        before,
+        "a failed publish must leave the previous document intact"
+    );
+}

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -574,6 +574,19 @@ pub mod slack_format;
 /// Test: `cargo test -p trusty-common -- data_dir::tests`.
 pub mod data_dir;
 
+/// Cross-process locked read-modify-write for whole-file JSON documents.
+///
+/// Why: `trusty-mpm`'s `projects.json`, `trusty-gworkspace`'s `tokens.json`
+/// (#3502) and the worktree registry of epic #4207 are each a small JSON file
+/// mutated by several independent PROCESSES via load → mutate → save. Without
+/// cross-process serialisation those writers lose each other's updates, and a
+/// shared scratch path lets them publish a corrupt document. This module is the
+/// single implementation of that critical section.
+/// What: Exposes [`json_rmw::update`], [`json_rmw::lock_path`], and
+/// [`json_rmw::JsonRmwError`].
+/// Test: `cargo test -p trusty-common -- json_rmw::tests`.
+pub mod json_rmw;
+
 /// Shared CLI daemon-guard helper (probe + spinner + spawn).
 ///
 /// Why: trusty-search, trusty-memory, and trusty-analyze each had an identical

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -70,6 +70,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Concurrent `tm` processes no longer lose (or corrupt) `projects.json` entries.
+  The project-store upsert was an unsynchronised read-modify-write of the whole
+  file — two processes interleaving read/read/write/write silently dropped one
+  registration while both callers saw success, and because every writer shared
+  one fixed `projects.json.tmp` scratch path, overlapping writes could publish a
+  mangled document that no longer parsed. All mutations now run through
+  `ProjectStore::mutate`, which performs the whole cycle inside a cross-process
+  file lock and publishes atomically via `trusty_common::json_rmw`. `PATCH
+  /api/v1/projects/{name}` gets the same guarantee: its fetch→mutate→persist
+  runs under one held lock instead of two separate store calls. A failed lock is
+  an error, never an unsynchronised write.
+
 - Worktree discovery is derived from `git worktree list --porcelain` instead of
   walking five hard-coded location shapes, so a session worktree is found
   wherever it lives rather than only where someone remembered to look (#4207

--- a/crates/trusty-mpm/src/project/registry.rs
+++ b/crates/trusty-mpm/src/project/registry.rs
@@ -111,27 +111,25 @@ impl ProjectRegistry {
     /// already-"successful" field edit with no error ever surfacing to that
     /// caller. This is the exact lost-update hazard #2395 already fixed for
     /// `DeliverableManager::update_deliverable_with`.
-    /// What: acquires `self.store.write().await` ONCE and holds the guard for
-    /// the ENTIRE fetch→mutate→persist sequence. Fetches the CURRENT on-disk
-    /// record via the store's own reload-on-read `get` (`NotFound` propagates
-    /// unchanged), calls `f` with that freshly-reloaded record, persists `f`'s
-    /// (infallible — Project PATCH has no state-machine rejection path, unlike
-    /// Deliverable's §10.3 transitions) result, and returns it — all before
-    /// releasing the lock, so no other task can observe or clobber the
-    /// intermediate state.
+    /// What: acquires `self.store.write().await` ONCE (serialising tasks in THIS
+    /// process) and delegates the whole fetch→mutate→persist sequence to
+    /// [`ProjectStore::update_with`], which performs it inside a single
+    /// cross-process file-lock critical section. The in-process guard alone was
+    /// never sufficient: it cannot see a `tm` CLI or MCP process editing the same
+    /// `projects.json`, so the identical lost-update hazard survived across
+    /// processes until the store's write path was serialised. `NotFound`
+    /// propagates unchanged, without writing.
     /// Test: `update_with_serializes_concurrent_field_edits` (the concurrency
     /// regression test — proves two concurrent edits to DIFFERENT fields are
-    /// both present in the final persisted record, never one lost), and
-    /// `update_with_unknown_project_errors`.
+    /// both present in the final persisted record, never one lost),
+    /// `update_with_unknown_project_errors`, and the cross-process
+    /// `projects_json_multiprocess_upsert_no_lost_updates`.
     pub async fn update_with<F>(&self, name: &str, f: F) -> Result<Project, ProjectStoreError>
     where
-        F: FnOnce(Project) -> Project,
+        F: FnOnce(Project) -> Project + Send + 'static,
     {
         let mut guard = self.store.write().await;
-        let current = guard.get(name).await?;
-        let updated = f(current);
-        guard.upsert(updated.clone()).await?;
-        Ok(updated)
+        guard.update_with(name, f).await
     }
 
     /// Seed the registry from statically-declared `projects:` config entries.

--- a/crates/trusty-mpm/src/project/store.rs
+++ b/crates/trusty-mpm/src/project/store.rs
@@ -5,10 +5,40 @@
 //! well-known path gives crash recovery without requiring a database dependency,
 //! mirroring the session-store pattern.
 //! What: [`ProjectStore`] loads and saves a map of [`Project`]s from/to
-//! `~/.trusty-mpm/projects.json`, using atomic temp-file + rename writes and
+//! `~/.trusty-mpm/projects.json`. Every mutation runs through
+//! [`ProjectStore::mutate`], which delegates the whole read-modify-write cycle
+//! to [`trusty_common::json_rmw::update`] so concurrent `tm` processes serialise
+//! on a file lock and publish atomically. Reads stay lock-free and use
 //! reload-on-read freshness detection.
-//! Test: `store_load_save_round_trip`, `store_upsert_idempotent`,
-//! `store_list_and_get`, `store_reload_picks_up_external_write`.
+//! Test: `cargo test -p trusty-mpm -- project::store::tests` (unit) plus the
+//! cross-process `projects_json_multiprocess_upsert_no_lost_updates` and
+//! `projects_json_survives_killed_writer`.
+//!
+//! # Concurrency
+//!
+//! `projects.json` is written by several independent processes — the daemon, the
+//! `tm project …` CLI, and MCP tool calls. The mutation path used to be
+//! `reload_if_changed()` → mutate in memory → write the whole file back, with no
+//! synchronisation of any kind: `ProjectRegistry`'s `tokio::sync::RwLock` only
+//! serialises tasks WITHIN one process. Two processes interleaving
+//! read/read/write/write dropped one of the two entries while both callers saw
+//! `Ok`, and because every writer shared one fixed `projects.json.tmp` scratch
+//! path, overlapping writes could also publish a mangled document that no longer
+//! parsed. [`ProjectStore::mutate`] closes both holes.
+//!
+//! Lock discipline for anyone extending this module:
+//!
+//! - **One acquisition per operation.** Mutations must funnel through
+//!   [`ProjectStore::mutate`]; it takes the file lock exactly once. Never call a
+//!   mutating store method from inside a `mutate` closure — the nested
+//!   acquisition uses a fresh descriptor and self-deadlocks.
+//! - **Readers take no file lock.** [`ProjectStore::get`] / [`ProjectStore::all`]
+//!   read without locking, which is safe because every publish is an atomic
+//!   rename: a reader sees a complete old or complete new document, never a torn
+//!   one. This also means a reader can never deadlock against a writer.
+//! - **Lock ordering.** Where `ProjectRegistry` holds its async `RwLock`, that
+//!   lock is always taken BEFORE the file lock and the file lock is released
+//!   before the guard drops. No path acquires them in the other order.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -18,6 +48,7 @@ use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tokio::fs;
 use tracing::debug;
+use trusty_common::json_rmw::{self, JsonRmwError};
 
 use super::record::Project;
 
@@ -40,6 +71,33 @@ pub enum ProjectStoreError {
     /// The requested project name was not found in the store.
     #[error("project not found: {0}")]
     NotFound(String),
+
+    /// The cross-process write lock on `projects.json` could not be acquired.
+    ///
+    /// Why: a caller that sees this must NOT retry by writing unlocked — that is
+    /// precisely the lost-update bug. It is surfaced as its own variant so the
+    /// remedy (stale sidecar, permissions) is distinguishable from a data fault.
+    #[error("project store lock error: {0}")]
+    Lock(String),
+}
+
+/// Map the shared locked-RMW failure modes onto the store's own error type.
+///
+/// Why: `json_rmw::update` is generic over the caller's error so `ProjectStore`
+/// keeps ONE return type; this is the conversion that buys that. Preserving the
+/// underlying `io::Error` (rather than stringifying it) keeps `ErrorKind` intact
+/// for callers that branch on it.
+/// What: `Io` keeps its source error, `Lock` becomes [`ProjectStoreError::Lock`],
+/// and `Serialize` becomes [`ProjectStoreError::Serialize`].
+/// Test: `store_lock_failure_is_not_fail_open`, `store_other_io_error_propagates`.
+impl From<JsonRmwError> for ProjectStoreError {
+    fn from(e: JsonRmwError) -> Self {
+        match e {
+            JsonRmwError::Io { source, .. } => Self::Io(source),
+            JsonRmwError::Serialize { message, .. } => Self::Serialize(message),
+            lock @ JsonRmwError::Lock { .. } => Self::Lock(lock.to_string()),
+        }
+    }
 }
 
 /// In-memory representation of the serialized store file.
@@ -48,7 +106,7 @@ pub enum ProjectStoreError {
 /// map in a versioned struct makes future schema migrations possible.
 /// What: a flat map from project name to [`Project`].
 /// Test: round-tripped implicitly by `ProjectStore` tests.
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 struct StoredData {
     /// All projects, keyed by project name.
     projects: HashMap<String, Project>,
@@ -70,15 +128,18 @@ struct FileSig {
 
 /// Async, file-backed store for [`Project`] records.
 ///
-/// Why: the project registry must persist across daemon restarts, and both the
-/// daemon and CLI may read the same `projects.json`. Atomic writes (temp +
-/// rename) prevent torn reads, and reload-on-read freshness detection keeps the
-/// in-memory view current when another process writes.
+/// Why: the project registry must persist across daemon restarts, and the
+/// daemon, the CLI and MCP tool calls all read and WRITE the same
+/// `projects.json` from different processes. See the module-level `Concurrency`
+/// section for the lock discipline that makes those writes safe.
 /// What: holds the in-memory map, the path to `projects.json`, and the file
-/// signature observed at the last load/save. All mutations call `save()`
-/// immediately; reads call `reload_if_changed()` first.
+/// signature observed at the last load/write. All mutations go through
+/// [`ProjectStore::mutate`], which re-reads under an exclusive cross-process
+/// lock and publishes atomically; reads call `reload_if_changed()` first and
+/// take no lock.
 /// Test: `store_load_save_round_trip`, `store_upsert_idempotent`,
-/// `store_reload_picks_up_external_write`.
+/// `store_reload_picks_up_external_write`,
+/// `store_concurrent_tasks_do_not_lose_writes`.
 #[derive(Debug)]
 pub struct ProjectStore {
     data: StoredData,
@@ -171,41 +232,106 @@ impl ProjectStore {
         Ok(())
     }
 
-    /// Persist the current in-memory state to disk atomically.
+    /// Mutate the persisted project map under the cross-process write lock.
     ///
-    /// Why: every mutating operation must flush to disk for crash safety. Writing
-    /// a temp file and renaming atomically prevents concurrent readers from seeing
-    /// a torn (partially-written) file.
-    /// What: serializes `data` to JSON, writes a sibling `.tmp` file, then renames
-    /// it over the real path; records the resulting signature.
-    /// Test: verified by every mutating store test.
-    pub async fn save(&mut self) -> Result<(), ProjectStoreError> {
-        if let Some(parent) = self.path.parent() {
-            fs::create_dir_all(parent).await?;
-        }
-        let json = serde_json::to_string_pretty(&self.data)
-            .map_err(|e| ProjectStoreError::Serialize(e.to_string()))?;
-        let tmp = self.path.with_extension("json.tmp");
-        fs::write(&tmp, json).await?;
-        fs::rename(&tmp, &self.path).await?;
+    /// Why: this is the ONLY sanctioned write path, and the fix for the
+    /// `projects.json` lost-update race. The previous shape — `reload_if_changed`
+    /// then mutate in memory then write the whole file — left an unguarded window
+    /// between the read and the write in which another `tm` process could publish
+    /// its own version, which this process then clobbered. Nothing reported an
+    /// error: both writers returned `Ok` and one project simply vanished.
+    /// Centralising the cycle here means every mutation (registration, PATCH,
+    /// config seeding) inherits the guarantee instead of re-deriving it, and the
+    /// worktree registry of epic #4207 gets a primitive to build on.
+    /// What: runs [`trusty_common::json_rmw::update`] on a blocking-safe thread
+    /// (the advisory lock is a blocking syscall and must never park a runtime
+    /// worker). Under the lock the map is re-read from disk — a caller's
+    /// in-memory copy is never trusted — `f` is applied, and the result is
+    /// published by atomic rename. `f` returning `Err` aborts the write with the
+    /// file unchanged, so a rejected mutation cannot advance state. The refreshed
+    /// map is then adopted as this store's in-memory view. A failure at ANY stage
+    /// propagates; there is no path that proceeds unlocked or writes partially.
+    ///
+    /// Not reentrant: `f` must not call back into a mutating store method.
+    /// Test: `store_upsert_idempotent`, `store_lock_failure_is_not_fail_open`,
+    /// `store_concurrent_tasks_do_not_lose_writes`, and the cross-process
+    /// `projects_json_multiprocess_upsert_no_lost_updates`.
+    pub async fn mutate<R, F>(&mut self, f: F) -> Result<R, ProjectStoreError>
+    where
+        F: FnOnce(&mut HashMap<String, Project>) -> Result<R, ProjectStoreError> + Send + 'static,
+        R: Send + 'static,
+    {
+        let path = self.path.clone();
+        let joined = tokio::task::spawn_blocking(move || {
+            json_rmw::update::<StoredData, _, ProjectStoreError, _>(&path, move |data| {
+                let result = f(&mut data.projects)?;
+                // Hand the freshly-published map back so the caller's in-memory
+                // view is exact without a second read.
+                Ok((result, data.clone()))
+            })
+        })
+        .await;
+
+        // A panicked or cancelled blocking task is a failure, never a silent
+        // success — the write may not have happened.
+        let (result, snapshot) = match joined {
+            Ok(inner) => inner?,
+            Err(e) => {
+                return Err(ProjectStoreError::Io(std::io::Error::other(format!(
+                    "project store update task failed: {e}"
+                ))));
+            }
+        };
+
+        self.data = snapshot;
         self.last_sig = Self::sig_of(&self.path).await;
-        debug!(path = %self.path.display(), "project store saved");
-        Ok(())
+        debug!(path = %self.path.display(), "project store saved under write lock");
+        Ok(result)
     }
 
     /// Insert or update a project record, keyed by `project.name`.
     ///
     /// Why: registration is idempotent — re-registering a project with the same
-    /// name updates its fields rather than creating a duplicate. Reloading first
-    /// ensures concurrent writes from another process are not lost.
-    /// What: reloads from disk if changed, inserts or replaces the record keyed by
-    /// `name`, then saves.
+    /// name updates its fields rather than creating a duplicate.
+    /// What: inserts or replaces the record keyed by `name` inside a single
+    /// [`Self::mutate`] critical section, so a concurrent writer in another
+    /// process can neither be lost nor lose this one.
     /// Test: `store_upsert_idempotent`.
     pub async fn upsert(&mut self, project: Project) -> Result<(), ProjectStoreError> {
-        self.reload_if_changed().await?;
-        let key = project.name.clone();
-        self.data.projects.insert(key, project);
-        self.save().await
+        self.mutate(move |projects| {
+            projects.insert(project.name.clone(), project);
+            Ok(())
+        })
+        .await
+    }
+
+    /// Read-modify-persist a single named project under one held lock.
+    ///
+    /// Why: `PATCH /api/v1/projects/{name}` reads a record, edits some fields and
+    /// writes the whole record back. Splitting that across a `get` and a later
+    /// `upsert` reintroduces the lost-update race across processes even though
+    /// each half is individually safe — two PATCHes editing DIFFERENT fields
+    /// would each persist a record built from the same stale snapshot.
+    /// What: fetches `name` from the freshly-read map inside [`Self::mutate`]
+    /// (propagating [`ProjectStoreError::NotFound`] without writing), applies
+    /// `f`, stores the result and returns it — all before the lock is released.
+    /// Test: `update_with_serializes_concurrent_field_edits`,
+    /// `update_with_unknown_project_errors`.
+    pub async fn update_with<F>(&mut self, name: &str, f: F) -> Result<Project, ProjectStoreError>
+    where
+        F: FnOnce(Project) -> Project + Send + 'static,
+    {
+        let name = name.to_string();
+        self.mutate(move |projects| {
+            let current = projects
+                .get(&name)
+                .cloned()
+                .ok_or(ProjectStoreError::NotFound(name))?;
+            let updated = f(current);
+            projects.insert(updated.name.clone(), updated.clone());
+            Ok(updated)
+        })
+        .await
     }
 
     /// Look up a project by name, reloading from disk first if changed.
@@ -236,206 +362,5 @@ impl ProjectStore {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    fn make_project(name: &str) -> Project {
-        Project {
-            name: name.to_string(),
-            repo_url: format!("https://github.com/owner/{name}"),
-            default_branch: "main".to_string(),
-            stack_hint: None,
-            tags: vec![],
-            description: None,
-            gh_user: None,
-            gh_account: None,
-            github: None,
-            commit_name: None,
-            commit_email: None,
-            worktree: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn store_load_save_round_trip() {
-        let dir = TempDir::new().expect("tempdir");
-        let mut store = ProjectStore::load(dir.path()).await.expect("load empty");
-        assert!(store.all().await.expect("all").is_empty());
-
-        store.upsert(make_project("alpha")).await.expect("upsert");
-
-        let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
-        let p = store2.get("alpha").await.expect("get after reload");
-        assert_eq!(p.name, "alpha");
-    }
-
-    #[tokio::test]
-    async fn store_upsert_idempotent() {
-        let dir = TempDir::new().expect("tempdir");
-        let mut store = ProjectStore::load(dir.path()).await.expect("load");
-
-        let p1 = make_project("beta");
-        store.upsert(p1).await.expect("first upsert");
-
-        // Update the description — must replace, not duplicate.
-        let p2 = Project {
-            description: Some("updated".into()),
-            ..make_project("beta")
-        };
-        store.upsert(p2).await.expect("second upsert");
-
-        let all = store.all().await.expect("all");
-        assert_eq!(all.len(), 1, "idempotent upsert must not duplicate");
-        assert_eq!(all[0].description.as_deref(), Some("updated"));
-    }
-
-    #[tokio::test]
-    async fn store_list_and_get() {
-        let dir = TempDir::new().expect("tempdir");
-        let mut store = ProjectStore::load(dir.path()).await.expect("load");
-
-        store
-            .upsert(make_project("gamma"))
-            .await
-            .expect("upsert gamma");
-        store
-            .upsert(make_project("delta"))
-            .await
-            .expect("upsert delta");
-
-        let all = store.all().await.expect("all");
-        assert_eq!(all.len(), 2);
-
-        let p = store.get("gamma").await.expect("get gamma");
-        assert_eq!(p.name, "gamma");
-
-        let err = store.get("missing").await;
-        assert!(
-            matches!(err, Err(ProjectStoreError::NotFound(_))),
-            "expected NotFound"
-        );
-    }
-
-    #[tokio::test]
-    async fn store_reload_picks_up_external_write() {
-        let dir = TempDir::new().expect("tempdir");
-
-        let mut store_a = ProjectStore::load(dir.path()).await.expect("load A");
-        store_a
-            .upsert(make_project("epsilon"))
-            .await
-            .expect("seed A");
-
-        // Simulate a second process writing a new project.
-        let mut store_b = ProjectStore::load(dir.path()).await.expect("load B");
-        store_b.upsert(make_project("zeta")).await.expect("write B");
-
-        // Store A must pick up the external write on its next read.
-        let all = store_a.all().await.expect("all A after external write");
-        let names: Vec<&str> = all.iter().map(|p| p.name.as_str()).collect();
-        assert!(
-            names.contains(&"zeta"),
-            "store A must reload zeta: {names:?}"
-        );
-    }
-
-    #[tokio::test]
-    async fn store_reload_noop_when_unchanged() {
-        let dir = TempDir::new().expect("tempdir");
-        let mut store = ProjectStore::load(dir.path()).await.expect("load");
-        store.upsert(make_project("eta")).await.expect("upsert");
-
-        // No external write — reload must be a no-op that preserves data.
-        store.reload_if_changed().await.expect("reload no-op");
-        let p = store.get("eta").await.expect("get");
-        assert_eq!(p.name, "eta");
-    }
-
-    #[tokio::test]
-    async fn json_round_trip_preserves_all_fields() {
-        let dir = TempDir::new().expect("tempdir");
-        let mut store = ProjectStore::load(dir.path()).await.expect("load");
-
-        let full = Project {
-            name: "full-project".into(),
-            repo_url: "https://github.com/owner/full-project.git".into(),
-            default_branch: "develop".into(),
-            stack_hint: Some("typescript".into()),
-            tags: vec!["frontend".into(), "oss".into()],
-            description: Some("a fully-populated project".into()),
-            gh_user: Some("bobmatnyc".into()),
-            gh_account: Some("bobmatnyc".into()),
-            github: Some(crate::core::trusty_tools_config::GithubConfig {
-                config_dir: Some("/home/bob/.config/gh-full".into()),
-                token_env: None,
-                account: None,
-                host: Some("github.example.com".into()),
-            }),
-            commit_name: Some("Full Bot".into()),
-            commit_email: Some("full-bot@example.com".into()),
-            worktree: None,
-        };
-        store.upsert(full.clone()).await.expect("upsert full");
-
-        let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
-        let back = store2.get("full-project").await.expect("get");
-        assert_eq!(back, full);
-    }
-
-    /// Verify that a NotFound path still starts with an empty store (happy-path
-    /// absence handling) and that a subsequent upsert+reload round-trips correctly.
-    ///
-    /// Why: the bug fix narrows the "start fresh" arm to NotFound only; this test
-    /// confirms that the intended absent-file path still works as before.
-    /// What: loads from a directory that contains no `projects.json`, asserts the
-    /// store is empty, then writes and reloads to confirm persistence works.
-    /// Test: this IS the test.
-    #[tokio::test]
-    async fn store_not_found_starts_fresh() {
-        let dir = TempDir::new().expect("tempdir");
-        // No projects.json exists yet — load must return an empty store.
-        let mut store = ProjectStore::load(dir.path())
-            .await
-            .expect("not-found should start fresh");
-        assert!(
-            store.all().await.expect("all").is_empty(),
-            "fresh store must be empty"
-        );
-
-        // Confirm we can round-trip through a save after starting fresh.
-        store
-            .upsert(make_project("theta"))
-            .await
-            .expect("upsert after fresh load");
-        let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
-        assert_eq!(store2.get("theta").await.expect("get theta").name, "theta");
-    }
-
-    /// Verify that a non-NotFound I/O error (e.g. a directory occupying the file
-    /// path) is propagated rather than silently treated as absent.
-    ///
-    /// Why: the data-loss bug caused any I/O error to be swallowed, so the next
-    /// `save()` would overwrite projects.json with an empty store. This test
-    /// exercises the fix by pointing `read_file` at a directory, which produces
-    /// `IsADirectory` (or equivalent) — not `NotFound`.
-    /// What: creates a directory at `projects.json`'s expected path, then calls
-    /// `ProjectStore::load`; asserts the result is an `Io` error, not `Ok`.
-    /// Test: this IS the test.
-    #[tokio::test]
-    async fn store_other_io_error_propagates() {
-        let dir = TempDir::new().expect("tempdir");
-        // Plant a directory where projects.json would live so read_to_string
-        // returns an OS error that is NOT NotFound.
-        let blocking_dir = dir.path().join("projects.json");
-        tokio::fs::create_dir_all(&blocking_dir)
-            .await
-            .expect("create blocking dir");
-
-        let result = ProjectStore::load(dir.path()).await;
-        assert!(
-            matches!(result, Err(ProjectStoreError::Io(_))),
-            "expected Io error when path is a directory, got: {result:?}"
-        );
-    }
-}
+#[path = "store_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/project/store_tests.rs
+++ b/crates/trusty-mpm/src/project/store_tests.rs
@@ -1,0 +1,387 @@
+//! Unit tests for [`super::ProjectStore`].
+//!
+//! Why: extracted from `store.rs`'s inline `#[cfg(test)] mod tests` — the
+//! lost-update fix added concurrency coverage that pushed that file toward the
+//! 500-SLOC production cap (the whole file, prod + inline tests, counts against
+//! the production cap since its basename doesn't match the test-file naming
+//! convention). Follows this crate's established colocated-test-file pattern
+//! (`registry.rs` + `registry_tests.rs`). The pre-existing tests are pure code
+//! motion — no behavior or assertion change.
+//! What: load/save round-trip, idempotent upsert, list/get, reload-on-external-
+//! write, field-preserving JSON round-trip, the absent-file and non-NotFound I/O
+//! paths, and the concurrency guarantees of the locked write path.
+//! Test: this file IS the test module; run with `cargo test -p trusty-mpm`.
+
+use super::*;
+use tempfile::TempDir;
+
+fn make_project(name: &str) -> Project {
+    Project {
+        name: name.to_string(),
+        repo_url: format!("https://github.com/owner/{name}"),
+        default_branch: "main".to_string(),
+        stack_hint: None,
+        tags: vec![],
+        description: None,
+        gh_user: None,
+        gh_account: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
+        worktree: None,
+    }
+}
+
+#[tokio::test]
+async fn store_load_save_round_trip() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load empty");
+    assert!(store.all().await.expect("all").is_empty());
+
+    store.upsert(make_project("alpha")).await.expect("upsert");
+
+    let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
+    let p = store2.get("alpha").await.expect("get after reload");
+    assert_eq!(p.name, "alpha");
+}
+
+#[tokio::test]
+async fn store_upsert_idempotent() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load");
+
+    let p1 = make_project("beta");
+    store.upsert(p1).await.expect("first upsert");
+
+    // Update the description — must replace, not duplicate.
+    let p2 = Project {
+        description: Some("updated".into()),
+        ..make_project("beta")
+    };
+    store.upsert(p2).await.expect("second upsert");
+
+    let all = store.all().await.expect("all");
+    assert_eq!(all.len(), 1, "idempotent upsert must not duplicate");
+    assert_eq!(all[0].description.as_deref(), Some("updated"));
+}
+
+#[tokio::test]
+async fn store_list_and_get() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load");
+
+    store
+        .upsert(make_project("gamma"))
+        .await
+        .expect("upsert gamma");
+    store
+        .upsert(make_project("delta"))
+        .await
+        .expect("upsert delta");
+
+    let all = store.all().await.expect("all");
+    assert_eq!(all.len(), 2);
+
+    let p = store.get("gamma").await.expect("get gamma");
+    assert_eq!(p.name, "gamma");
+
+    let err = store.get("missing").await;
+    assert!(
+        matches!(err, Err(ProjectStoreError::NotFound(_))),
+        "expected NotFound"
+    );
+}
+
+#[tokio::test]
+async fn store_reload_picks_up_external_write() {
+    let dir = TempDir::new().expect("tempdir");
+
+    let mut store_a = ProjectStore::load(dir.path()).await.expect("load A");
+    store_a
+        .upsert(make_project("epsilon"))
+        .await
+        .expect("seed A");
+
+    // Simulate a second process writing a new project.
+    let mut store_b = ProjectStore::load(dir.path()).await.expect("load B");
+    store_b.upsert(make_project("zeta")).await.expect("write B");
+
+    // Store A must pick up the external write on its next read.
+    let all = store_a.all().await.expect("all A after external write");
+    let names: Vec<&str> = all.iter().map(|p| p.name.as_str()).collect();
+    assert!(
+        names.contains(&"zeta"),
+        "store A must reload zeta: {names:?}"
+    );
+}
+
+#[tokio::test]
+async fn store_reload_noop_when_unchanged() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load");
+    store.upsert(make_project("eta")).await.expect("upsert");
+
+    // No external write — reload must be a no-op that preserves data.
+    store.reload_if_changed().await.expect("reload no-op");
+    let p = store.get("eta").await.expect("get");
+    assert_eq!(p.name, "eta");
+}
+
+#[tokio::test]
+async fn json_round_trip_preserves_all_fields() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load");
+
+    let full = Project {
+        name: "full-project".into(),
+        repo_url: "https://github.com/owner/full-project.git".into(),
+        default_branch: "develop".into(),
+        stack_hint: Some("typescript".into()),
+        tags: vec!["frontend".into(), "oss".into()],
+        description: Some("a fully-populated project".into()),
+        gh_user: Some("bobmatnyc".into()),
+        gh_account: Some("bobmatnyc".into()),
+        github: Some(crate::core::trusty_tools_config::GithubConfig {
+            config_dir: Some("/home/bob/.config/gh-full".into()),
+            token_env: None,
+            account: None,
+            host: Some("github.example.com".into()),
+        }),
+        commit_name: Some("Full Bot".into()),
+        commit_email: Some("full-bot@example.com".into()),
+        worktree: None,
+    };
+    store.upsert(full.clone()).await.expect("upsert full");
+
+    let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
+    let back = store2.get("full-project").await.expect("get");
+    assert_eq!(back, full);
+}
+
+/// Verify that a NotFound path still starts with an empty store (happy-path
+/// absence handling) and that a subsequent upsert+reload round-trips correctly.
+///
+/// Why: the bug fix narrows the "start fresh" arm to NotFound only; this test
+/// confirms that the intended absent-file path still works as before.
+/// What: loads from a directory that contains no `projects.json`, asserts the
+/// store is empty, then writes and reloads to confirm persistence works.
+/// Test: this IS the test.
+#[tokio::test]
+async fn store_not_found_starts_fresh() {
+    let dir = TempDir::new().expect("tempdir");
+    // No projects.json exists yet — load must return an empty store.
+    let mut store = ProjectStore::load(dir.path())
+        .await
+        .expect("not-found should start fresh");
+    assert!(
+        store.all().await.expect("all").is_empty(),
+        "fresh store must be empty"
+    );
+
+    // Confirm we can round-trip through a save after starting fresh.
+    store
+        .upsert(make_project("theta"))
+        .await
+        .expect("upsert after fresh load");
+    let mut store2 = ProjectStore::load(dir.path()).await.expect("reload");
+    assert_eq!(store2.get("theta").await.expect("get theta").name, "theta");
+}
+
+/// Verify that a non-NotFound I/O error (e.g. a directory occupying the file
+/// path) is propagated rather than silently treated as absent.
+///
+/// Why: the data-loss bug caused any I/O error to be swallowed, so the next
+/// `save()` would overwrite projects.json with an empty store. This test
+/// exercises the fix by pointing `read_file` at a directory, which produces
+/// `IsADirectory` (or equivalent) — not `NotFound`.
+/// What: creates a directory at `projects.json`'s expected path, then calls
+/// `ProjectStore::load`; asserts the result is an `Io` error, not `Ok`.
+/// Test: this IS the test.
+#[tokio::test]
+async fn store_other_io_error_propagates() {
+    let dir = TempDir::new().expect("tempdir");
+    // Plant a directory where projects.json would live so read_to_string
+    // returns an OS error that is NOT NotFound.
+    let blocking_dir = dir.path().join("projects.json");
+    tokio::fs::create_dir_all(&blocking_dir)
+        .await
+        .expect("create blocking dir");
+
+    let result = ProjectStore::load(dir.path()).await;
+    assert!(
+        matches!(result, Err(ProjectStoreError::Io(_))),
+        "expected Io error when path is a directory, got: {result:?}"
+    );
+}
+
+/// Concurrent writers must not lose each other's entries, even in-process.
+///
+/// Why: the cross-process regression test lives in
+/// `crates/trusty-mpm/tests/projects_json_concurrency.rs`; this is its cheap
+/// in-crate companion. Each task owns a SEPARATE `ProjectStore` (hence a
+/// separate lock descriptor), so nothing but the file lock serialises them —
+/// against the pre-fix store this loses entries and can corrupt the file.
+/// What: 6 concurrent tasks each upsert 5 distinct projects into one directory;
+/// all 30 must be present afterwards.
+/// Test: this IS the test.
+#[tokio::test]
+async fn store_concurrent_tasks_do_not_lose_writes() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut handles = Vec::new();
+    for task in 0..6u32 {
+        let root = dir.path().to_path_buf();
+        handles.push(tokio::spawn(async move {
+            let mut store = ProjectStore::load(&root).await.expect("load");
+            for i in 0..5u32 {
+                store
+                    .upsert(make_project(&format!("t{task}-{i}")))
+                    .await
+                    .expect("concurrent upsert");
+            }
+        }));
+    }
+    for h in handles {
+        h.await.expect("task join");
+    }
+
+    let mut store = ProjectStore::load(dir.path()).await.expect("verify load");
+    let all = store.all().await.expect("all");
+    assert_eq!(
+        all.len(),
+        30,
+        "lost concurrent upserts: {} of 30",
+        all.len()
+    );
+}
+
+/// Repeated contention on the same store must complete, not deadlock.
+///
+/// Why: an exclusive lock taken on a path that is already held — or taken twice
+/// without release — hangs forever rather than failing. This test would time out
+/// (rather than fail) if `mutate` ever leaked a guard or became reentrant.
+/// What: hammers one directory with interleaved upserts and reads from several
+/// tasks, under a wall-clock timeout that is generous for the work but far
+/// shorter than a hang.
+/// Test: this IS the test.
+#[tokio::test]
+async fn store_lock_contention_does_not_deadlock() {
+    let dir = TempDir::new().expect("tempdir");
+    let work = async {
+        let mut handles = Vec::new();
+        for task in 0..4u32 {
+            let root = dir.path().to_path_buf();
+            handles.push(tokio::spawn(async move {
+                let mut store = ProjectStore::load(&root).await.expect("load");
+                for i in 0..10u32 {
+                    store
+                        .upsert(make_project(&format!("c{task}-{i}")))
+                        .await
+                        .expect("upsert");
+                    // Interleave a read; readers must never block on the writer.
+                    let _ = store.all().await.expect("all");
+                }
+            }));
+        }
+        for h in handles {
+            h.await.expect("task join");
+        }
+    };
+    tokio::time::timeout(std::time::Duration::from_secs(60), work)
+        .await
+        .expect("lock contention deadlocked");
+
+    let mut store = ProjectStore::load(dir.path()).await.expect("verify load");
+    assert_eq!(store.all().await.expect("all").len(), 40);
+}
+
+/// An unacquirable write lock must return an error, never write unlocked.
+///
+/// Why: the repo has a recurring bug shape where a failure branch advances state
+/// anyway and the alarms read healthy. A store that fell back to an
+/// unsynchronised write when locking failed would be exactly that: silently
+/// racy again, with no signal.
+/// What: plants a directory where the `projects.json.lock` sidecar belongs so it
+/// cannot be opened, then asserts the upsert errors AND that the pre-existing
+/// record is still intact.
+/// Test: this IS the test.
+#[tokio::test]
+async fn store_lock_failure_is_not_fail_open() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load");
+    store.upsert(make_project("kappa")).await.expect("seed");
+
+    let sidecar = dir.path().join("projects.json.lock");
+    let _ = tokio::fs::remove_file(&sidecar).await;
+    tokio::fs::create_dir_all(&sidecar)
+        .await
+        .expect("plant blocking dir");
+
+    let result = store.upsert(make_project("lambda")).await;
+    assert!(
+        matches!(result, Err(ProjectStoreError::Lock(_))),
+        "expected Lock error, got {result:?}"
+    );
+
+    // Remove the blocker and confirm the seeded record was never disturbed.
+    tokio::fs::remove_dir_all(&sidecar).await.expect("unblock");
+    let mut verify = ProjectStore::load(dir.path()).await.expect("verify load");
+    let all = verify.all().await.expect("all");
+    assert_eq!(all.len(), 1, "failed lock must not have written");
+    assert_eq!(all[0].name, "kappa");
+}
+
+/// A successful write leaves no scratch file behind.
+///
+/// Why: the pre-fix store wrote to one FIXED `projects.json.tmp` shared by every
+/// writer, which is how concurrent writers corrupted the registry. A leftover
+/// temp file is the visible symptom of that design.
+/// What: performs two upserts and asserts the directory holds no `*.tmp` entry.
+/// Test: this IS the test.
+#[tokio::test]
+async fn store_leaves_no_temp_file_behind() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load");
+    store.upsert(make_project("mu")).await.expect("upsert mu");
+    store.upsert(make_project("nu")).await.expect("upsert nu");
+
+    let mut leftovers = Vec::new();
+    let mut entries = tokio::fs::read_dir(dir.path()).await.expect("read_dir");
+    while let Some(entry) = entries.next_entry().await.expect("next entry") {
+        let name = entry.file_name().to_string_lossy().into_owned();
+        if name.ends_with(".tmp") {
+            leftovers.push(name);
+        }
+    }
+    assert!(
+        leftovers.is_empty(),
+        "temp files left behind: {leftovers:?}"
+    );
+}
+
+/// A stale temp file from a crashed writer must not affect a later write.
+///
+/// Why: crash recovery — an orphaned scratch file is expected debris after a
+/// killed writer and must never be mistaken for, or block, the real document.
+/// What: plants both a legacy fixed-name `projects.json.tmp` and a stale
+/// unique-name temp, then asserts a subsequent upsert succeeds and the registry
+/// still reads back correctly.
+/// Test: this IS the test.
+#[tokio::test]
+async fn store_survives_stale_temp_files() {
+    let dir = TempDir::new().expect("tempdir");
+    let mut store = ProjectStore::load(dir.path()).await.expect("load");
+    store.upsert(make_project("xi")).await.expect("seed");
+
+    tokio::fs::write(dir.path().join("projects.json.tmp"), b"{ garbage")
+        .await
+        .expect("plant legacy temp");
+    tokio::fs::write(dir.path().join("projects.json.999.1.tmp"), b"{ garbage")
+        .await
+        .expect("plant stale temp");
+
+    store.upsert(make_project("omicron")).await.expect("upsert");
+
+    let mut verify = ProjectStore::load(dir.path()).await.expect("verify load");
+    let all = verify.all().await.expect("all");
+    assert_eq!(all.len(), 2, "stale temp files disturbed the registry");
+}

--- a/crates/trusty-mpm/tests/projects_json_concurrency.rs
+++ b/crates/trusty-mpm/tests/projects_json_concurrency.rs
@@ -1,0 +1,267 @@
+//! Cross-PROCESS concurrency tests for the `projects.json` registry store.
+//!
+//! Why: `ProjectStore` is written by several independent `tm` processes (the
+//! daemon, `tm project …` CLI invocations, MCP tool calls). Its upsert path is a
+//! read-modify-write of the WHOLE file, so two processes that interleave
+//! read/read/write/write silently lose one of the two entries with no error
+//! surfaced to either caller. An in-process `Mutex`/`RwLock` cannot detect that;
+//! only a cross-process test can. These tests therefore spawn REAL child
+//! processes (re-exec of this same test binary) rather than threads, so the
+//! failure mode they observe is exactly the shipping one.
+//! What: two multi-process scenarios — a lost-update test where N children each
+//! write a disjoint set of project names and every name must survive, and a
+//! crash-safety test where a writing child is SIGKILLed mid-write and the file
+//! must still parse with its pre-existing entries intact. The `…_child_…`
+//! functions are `#[ignore]`d helpers: they are not tests in their own right,
+//! they are the child-process entry points re-invoked via
+//! `<test-binary> --ignored --exact <name>`.
+//! Test: `projects_json_multiprocess_upsert_no_lost_updates`,
+//! `projects_json_survives_killed_writer`.
+
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command};
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use trusty_mpm::project::record::Project;
+use trusty_mpm::project::store::ProjectStore;
+
+/// Data directory the child should point its `ProjectStore` at.
+const DIR_ENV: &str = "TM_PROJECTS_RACE_DIR";
+/// Per-child name prefix, so each child writes a disjoint key set.
+const TAG_ENV: &str = "TM_PROJECTS_RACE_TAG";
+
+/// Number of concurrent child writer processes.
+const CHILDREN: usize = 4;
+/// Upserts performed by each child.
+const WRITES_PER_CHILD: usize = 24;
+
+/// Longest we will wait for children to line up on the start barrier or exit.
+const CHILD_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// Build a minimal valid [`Project`] with the given name.
+fn project(name: &str) -> Project {
+    Project {
+        name: name.to_string(),
+        repo_url: format!("https://github.com/owner/{name}"),
+        default_branch: "main".to_string(),
+        stack_hint: None,
+        tags: vec![],
+        description: None,
+        gh_user: None,
+        gh_account: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
+        worktree: None,
+    }
+}
+
+/// Read the data directory / tag a child was launched with, or `None` when this
+/// process is not acting as a child (so a bare `--ignored` run is a clean no-op).
+fn child_env() -> Option<(PathBuf, String)> {
+    let dir = std::env::var(DIR_ENV).ok()?;
+    let tag = std::env::var(TAG_ENV).ok()?;
+    Some((PathBuf::from(dir), tag))
+}
+
+/// Spawn one child process running the named `#[ignore]`d helper test.
+fn spawn_child(helper: &str, dir: &Path, tag: &str) -> Child {
+    Command::new(std::env::current_exe().expect("current_exe"))
+        .args(["--ignored", "--exact", "--nocapture", helper])
+        .env(DIR_ENV, dir)
+        .env(TAG_ENV, tag)
+        .spawn()
+        .unwrap_or_else(|e| panic!("spawn child {helper}: {e}"))
+}
+
+/// Block until `pred` holds or [`CHILD_TIMEOUT`] elapses.
+fn wait_until(what: &str, mut pred: impl FnMut() -> bool) {
+    let deadline = Instant::now() + CHILD_TIMEOUT;
+    while Instant::now() < deadline {
+        if pred() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+    panic!("timed out waiting for {what}");
+}
+
+/// A single-threaded tokio runtime for driving the async store API.
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("build runtime")
+}
+
+/// Every child announces readiness here, then blocks on `go`.
+fn ready_marker(dir: &Path, tag: &str) -> PathBuf {
+    dir.join(format!("ready-{tag}"))
+}
+
+/// The start barrier: children spin until the parent creates this file.
+fn go_marker(dir: &Path) -> PathBuf {
+    dir.join("go")
+}
+
+/// Child entry point: upsert [`WRITES_PER_CHILD`] distinct projects.
+///
+/// Why: each child holds ONE long-lived `ProjectStore` across all its writes,
+/// which is exactly how the daemon uses it — so the read-modify-write window
+/// under test is the shipping one, not a synthetic one.
+/// What: signals readiness, waits on the shared start barrier so all children
+/// overlap, then upserts `<tag>-00 … <tag>-23`, yielding briefly between writes
+/// to widen the reload→save window across processes.
+/// Test: driven by `projects_json_multiprocess_upsert_no_lost_updates`.
+#[test]
+#[ignore = "child-process helper, driven by projects_json_multiprocess_upsert_no_lost_updates"]
+fn multiprocess_child_writer() {
+    let Some((dir, tag)) = child_env() else {
+        return;
+    };
+    std::fs::write(ready_marker(&dir, &tag), b"ready").expect("write ready marker");
+    let go = go_marker(&dir);
+    wait_until("start barrier", || go.exists());
+
+    runtime().block_on(async {
+        let mut store = ProjectStore::load(&dir).await.expect("child: load store");
+        for i in 0..WRITES_PER_CHILD {
+            store
+                .upsert(project(&format!("{tag}-{i:02}")))
+                .await
+                .expect("child: upsert");
+            tokio::time::sleep(Duration::from_millis(2)).await;
+        }
+    });
+}
+
+/// Child entry point: upsert in a tight loop forever, until killed.
+///
+/// Why: the crash-safety test needs a writer that is guaranteed to be mid-write
+/// when SIGKILL lands; an unbounded loop makes that certain without timing luck.
+/// What: signals readiness, then upserts `<tag>-<n>` without pause until the
+/// parent kills the process.
+/// Test: driven by `projects_json_survives_killed_writer`.
+#[test]
+#[ignore = "child-process helper, driven by projects_json_survives_killed_writer"]
+fn multiprocess_child_hammer() {
+    let Some((dir, tag)) = child_env() else {
+        return;
+    };
+    std::fs::write(ready_marker(&dir, &tag), b"ready").expect("write ready marker");
+
+    runtime().block_on(async {
+        let mut store = ProjectStore::load(&dir).await.expect("child: load store");
+        let mut n: u64 = 0;
+        loop {
+            store
+                .upsert(project(&format!("{tag}-{n}")))
+                .await
+                .expect("child: upsert");
+            n += 1;
+        }
+    });
+}
+
+/// Concurrent writer PROCESSES must not lose each other's `projects.json` entries.
+///
+/// Why: this is the lost-update defect. `ProjectStore::upsert` reloads the file,
+/// mutates its in-memory copy and writes the whole file back. With no
+/// cross-process serialisation, two `tm` processes interleaving
+/// read/read/write/write drop one entry entirely — and BOTH callers see `Ok`.
+/// What: launches [`CHILDREN`] child processes that all release from one barrier
+/// and each write [`WRITES_PER_CHILD`] disjoint project names; asserts every one
+/// of the `CHILDREN * WRITES_PER_CHILD` names is present afterwards. Fails
+/// against the unsynchronised store; passes once the upsert path is guarded.
+/// Test: this IS the test.
+#[test]
+fn projects_json_multiprocess_upsert_no_lost_updates() {
+    let dir = TempDir::new().expect("tempdir");
+    let tags: Vec<String> = (0..CHILDREN).map(|c| format!("p{c}")).collect();
+
+    let mut children: Vec<Child> = tags
+        .iter()
+        .map(|tag| spawn_child("multiprocess_child_writer", dir.path(), tag))
+        .collect();
+
+    // Real barrier: only release once every child is spun up and polling, so
+    // process-startup skew cannot serialise the writers by accident.
+    wait_until("all children ready", || {
+        tags.iter().all(|t| ready_marker(dir.path(), t).exists())
+    });
+    std::fs::write(go_marker(dir.path()), b"go").expect("release barrier");
+
+    for (child, tag) in children.iter_mut().zip(&tags) {
+        let status = child.wait().expect("wait for child");
+        assert!(status.success(), "child {tag} failed: {status}");
+    }
+
+    let all = runtime().block_on(async {
+        let mut store = ProjectStore::load(dir.path()).await.expect("parent: load");
+        store.all().await.expect("parent: all")
+    });
+
+    let mut missing: Vec<String> = Vec::new();
+    for tag in &tags {
+        for i in 0..WRITES_PER_CHILD {
+            let name = format!("{tag}-{i:02}");
+            if !all.iter().any(|p| p.name == name) {
+                missing.push(name);
+            }
+        }
+    }
+    assert!(
+        missing.is_empty(),
+        "lost {} of {} concurrent upserts (file holds {}): {:?}",
+        missing.len(),
+        CHILDREN * WRITES_PER_CHILD,
+        all.len(),
+        missing
+    );
+}
+
+/// A writer killed mid-write must never leave `projects.json` truncated,
+/// half-written, or emptied.
+///
+/// Why: the store publishes by writing a temp file and renaming it over the
+/// real path. If concurrent writers share one temp path, or the rename is not
+/// the only publish step, a crash can expose a partial file — turning a lost
+/// update into total registry loss. An existing valid file must survive any
+/// crash point.
+/// What: seeds a known project, spawns a child that upserts in a tight loop,
+/// SIGKILLs it once it is provably running, then asserts `projects.json` still
+/// parses, still contains the seeded record, and is not empty.
+/// Test: this IS the test.
+#[test]
+fn projects_json_survives_killed_writer() {
+    let dir = TempDir::new().expect("tempdir");
+    let rt = runtime();
+
+    rt.block_on(async {
+        let mut store = ProjectStore::load(dir.path()).await.expect("seed load");
+        store.upsert(project("seeded")).await.expect("seed upsert");
+    });
+
+    let mut child = spawn_child("multiprocess_child_hammer", dir.path(), "hammer");
+    wait_until("hammer ready", || {
+        ready_marker(dir.path(), "hammer").exists()
+    });
+    // Let it get well into its write loop, then kill it at an arbitrary point.
+    std::thread::sleep(Duration::from_millis(250));
+    child.kill().expect("kill hammer child");
+    let _ = child.wait();
+
+    // The file must still be readable as valid JSON and retain the seed.
+    let all = rt.block_on(async {
+        let mut store = ProjectStore::load(dir.path())
+            .await
+            .expect("projects.json must still parse after a killed writer");
+        store.all().await.expect("all after killed writer")
+    });
+    assert!(
+        all.iter().any(|p| p.name == "seeded"),
+        "a killed writer destroyed the pre-existing entry; file holds {} record(s)",
+        all.len()
+    );
+}


### PR DESCRIPTION
## The defect (confirmed before changing anything)

`crates/trusty-mpm/src/project/store.rs` — `ProjectStore::upsert` was an
unsynchronised read-modify-write of the whole registry file:

```rust
self.reload_if_changed().await?;              // read
self.data.projects.insert(key, project);      // mutate in memory
self.save().await                             // write the WHOLE file back
```

**No locking or atomicity existed today at the process level.** The only
synchronisation anywhere on this path was `ProjectRegistry`'s
`tokio::sync::RwLock`, which serialises tasks *within one process*.
`projects.json` is written concurrently by the daemon, `tm project …` CLI
invocations and MCP tool calls, so two processes interleaving
read/read/write/write dropped one registration entirely — and **both** callers
saw `Ok`.

A cross-process test found a **second, worse failure** from the same window
that the report did not mention: `save()` wrote to one *fixed* temp path,
`projects.json.tmp`, shared by every writer. Overlapping writes interleaved
into that single scratch file and the rename published the mangled result, so
`projects.json` stopped parsing altogether:

```
child: upsert: Serialize("trailing characters at line 19 column 2")
```

That is registry-wide loss, not a single lost entry.

## The fix — reused the existing primitive choice, added the missing shared entry point

I searched first. There is **no** existing file-locking / atomic-RMW helper in
`trusty-common`. What does exist is the precedent:
`trusty-gworkspace`'s `TokenStorage::update` solves the identical
`load()`→mutate→`save()` lost-update bug for `tokens.json` (#3502), and
`fd-lock` is already a `[workspace.dependencies]` entry added *for that exact
purpose*. But it is private to gworkspace and `anyhow`-based.

So rather than inline a one-off in `store.rs`, this adds
**`trusty_common::json_rmw`** — the single implementation of that critical
section, where epic #4207 slice 3 can build on it:

- exclusive advisory lock on a `<path>.lock` sidecar (a lock on the document
  itself would be discarded by the rename that publishes each new version);
- re-reads the document **under the lock** — a caller's in-memory copy is never
  trusted;
- publishes atomically: **per-writer-unique** temp file → `fsync` → `rename` →
  directory `fsync`. Uniqueness kills the shared-`.tmp` corruption class
  independently of the lock.

`ProjectStore` now funnels every mutation through one `mutate` entry point
built on it, run via `spawn_blocking` so the blocking lock syscall never parks
a runtime worker. The lock-bypassing `save()` is removed so no second write
path can reintroduce the race.

**Call sites checked for reentrancy / lock ordering.** `PATCH
/api/v1/projects/{name}` went through `ProjectRegistry::update_with`, which did
`get` → mutate → `upsert` — two separate store calls. Guarding only `upsert`
would have left that path racy across processes while looking fixed, so it now
delegates to `ProjectStore::update_with` and runs inside **one** held lock.
Nothing calls a mutating store method from inside a `mutate` closure (that
would self-deadlock, and the module docs say so). Lock ordering is uniform: the
async `RwLock` is always taken before the file lock, never the reverse.

**Does not fail open.** A lock that cannot be acquired returns the new
`ProjectStoreError::Lock` rather than proceeding unsynchronised; an
unreadable-but-present file is never silently replaced by an empty one (only a
genuine `NotFound` starts from `Default`); a closure returning `Err` aborts the
write with the file byte-for-byte unchanged. Readers deliberately take **no**
lock — atomic rename means they always see a complete document, so a reader can
never deadlock against a writer.

## Test evidence — failing before, passing after

`crates/trusty-mpm/tests/projects_json_concurrency.rs` spawns **real child
processes** (re-exec of the test binary via `#[ignore]`d helper entry points),
all released from a shared readiness barrier so startup skew cannot serialise
them by accident. Multi-process, not threads — the failure mode it observes is
the shipping one.

**Before the fix** (reproduced on every one of 3 consecutive runs):

```
thread 'multiprocess_child_writer' panicked at tests/projects_json_concurrency.rs:133:18:
child: upsert: Serialize("trailing characters at line 19 column 2")
...
thread 'projects_json_multiprocess_upsert_no_lost_updates' panicked at :197:9:
child p1 failed: exit status: 101
test result: FAILED. 1 passed; 1 failed; 2 ignored; 0 measured; 0 filtered out
```

**After the fix** (5 consecutive runs, all green):

```
test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 2.00s
test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 1.68s
test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 2.09s
test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 1.60s
test result: ok. 2 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 1.99s
```

Also covered, per the brief:

- `projects_json_survives_killed_writer` — a writer SIGKILLed mid-write leaves
  `projects.json` parseable with its pre-existing entry intact.
- `store_lock_contention_does_not_deadlock` — interleaved writers and readers
  complete under a wall-clock timeout.
- `store_lock_failure_is_not_fail_open` — an unopenable lock errors and the
  prior record is untouched (no unsynchronised fallback).
- `store_leaves_no_temp_file_behind`, `store_survives_stale_temp_files` — a
  valid file is never replaced by an empty or partial one.
- `json_rmw` unit tests cover each contract clause, including
  `update_write_failure_leaves_original_intact` and
  `update_corrupt_file_errors` (a corrupt file is preserved for the operator,
  never overwritten).

## Gates (raw output in the thread)

- `cargo test -p trusty-mpm` — **6601 passed; 0 failed; 16 ignored**, exit 0.
  (The 2 new ignores are the child-process helpers, which run only when spawned.)
- `cargo test -p trusty-common` — **205 passed; 0 failed**, exit 0.
- `cargo clippy -p trusty-mpm -p trusty-common --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `bash scripts/check_line_cap.sh` — `7 allowlisted, 0 violations — OK`.
- `bash scripts/check_sld.sh` — `0 error(s), 0 warning(s)`.

Store unit tests were moved to `store_tests.rs` (pure code motion, no assertion
changes) to keep `store.rs` under the 500-SLOC production cap, following the
existing `registry.rs` / `registry_tests.rs` pattern.

## Note for reviewers

`trusty-common` gates `thiserror` behind an optional feature (`default = []`),
and `json_rmw` is an unconditional module, so `JsonRmwError` implements
`Display`/`Error` by hand rather than forcing `thiserror` into every minimal
build. `ProjectStoreError` still uses `thiserror` and converts via `From`.

`Cargo.lock` changes by exactly one line (`fd-lock` under `trusty-common`) — no
lockfile refresh.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools