### PR TITLE
feat(trusty-common): project-derived index identity as a partitioning key (#4207)

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -10,8 +10,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - **`project_index_id` — project-derived trusty-search index identity (#4207).**
-  New `ProjectIdentity` (origin + root + gh user) with a pure, deterministic
-  `index_id()`, plus `derive_project_index_id()` and `resolve_gh_user()`. Unlike
+  New `ProjectIdentity` (origin + root + operator) with a pure, deterministic
+  `index_id()`, plus `derive_project_index_id()` and
+  `resolve_operator_identity()`. Unlike
   the basename rule in `index_id` (which collides for unrelated checkouts sharing
   a directory name) and the session-worktree UUID (which binds service identity to
   ephemeral writer isolation), this id *partitions*: the canonical content-tree
@@ -20,6 +21,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   into `ensure_project_indexed`, `trusty-search serve`, or the daemon's resolution
   path; registry reconciliation and migration of existing indexes are separate
   slices of #4207. No behaviour change for any existing caller.
+
+  Derivation is hermetic: it reads no environment variable, so two callers on one
+  tree (e.g. the launchd daemon and a shell CLI) cannot derive different ids. The
+  `index_id()` docs enumerate exactly which inputs are mutable — `origin` moves on
+  the first commit, on `git remote add origin`, and on a new root commit — each
+  pinned by a test, so the migration slice inherits a true guarantee rather than an
+  assumption of permanence.
 
 ---
 ## [0.27.0] — 2026-07-27

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`project_index_id` — project-derived trusty-search index identity (#4207).**
+  New `ProjectIdentity` (origin + root + gh user) with a pure, deterministic
+  `index_id()`, plus `derive_project_index_id()` and `resolve_gh_user()`. Unlike
+  the basename rule in `index_id` (which collides for unrelated checkouts sharing
+  a directory name) and the session-worktree UUID (which binds service identity to
+  ephemeral writer isolation), this id *partitions*: the canonical content-tree
+  root is a hashed component, so sibling clones, linked worktrees, and differing
+  accounts derive distinct ids by construction. Derivation only — nothing is wired
+  into `ensure_project_indexed`, `trusty-search serve`, or the daemon's resolution
+  path; registry reconciliation and migration of existing indexes are separate
+  slices of #4207. No behaviour change for any existing caller.
+
 ---
 ## [0.27.0] — 2026-07-27
 

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -456,9 +456,9 @@ pub use index_id::{derive_index_id, find_git_root, resolve_project_root};
 /// compute the identical id — the same single-source-of-truth rule `index_id`
 /// was hoisted here for (#1373). Unconditional (not feature-gated) because an
 /// identity that varies with a feature flag is worse than none.
-/// What: exposes [`project_index_id::ProjectIdentity`] (origin + root + gh user,
+/// What: exposes [`project_index_id::ProjectIdentity`] (origin + root + operator,
 /// with a pure `index_id()`), [`project_index_id::derive_project_index_id`], and
-/// [`project_index_id::resolve_gh_user`]. Derivation only — deliberately wired
+/// [`project_index_id::resolve_operator_identity`]. Derivation only — wired
 /// into no resolution path; registry reconciliation and migration of existing
 /// indexes are separate slices of #4207.
 /// Test: `cargo test -p trusty-common -- project_index_id`.

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -444,6 +444,27 @@ pub use slug::slugify_string;
 pub mod index_id;
 pub use index_id::{derive_index_id, find_git_root, resolve_project_root};
 
+/// Project-derived trusty-search index identity — the PARTITIONING key
+/// (epic #4207; supersedes the approach closed as won't-do in #4063).
+///
+/// Why: [`index_id::derive_index_id`]'s bare basename collides for unrelated
+/// checkouts sharing a directory name, and a tm session gets its worktree UUID
+/// as the id — so service identity is bound to ephemeral writer isolation and
+/// BASE_PM's "pass the project name" instruction 404s. Both need ONE id derived
+/// from the PROJECT. It lives here, beside `index_id`/`repo_identity`/`slug`,
+/// because trusty-mpm, trusty-search, trusty-review and trusty-code must all
+/// compute the identical id — the same single-source-of-truth rule `index_id`
+/// was hoisted here for (#1373). Unconditional (not feature-gated) because an
+/// identity that varies with a feature flag is worse than none.
+/// What: exposes [`project_index_id::ProjectIdentity`] (origin + root + gh user,
+/// with a pure `index_id()`), [`project_index_id::derive_project_index_id`], and
+/// [`project_index_id::resolve_gh_user`]. Derivation only — deliberately wired
+/// into no resolution path; registry reconciliation and migration of existing
+/// indexes are separate slices of #4207.
+/// Test: `cargo test -p trusty-common -- project_index_id`.
+pub mod project_index_id;
+pub use project_index_id::{ProjectIdentity, derive_project_index_id};
+
 /// Shared best-effort trusty-search "ensure this project is indexed" helper
 /// (issues #1373 / #1908), gated behind the `search-index` feature.
 ///

--- a/crates/trusty-common/src/project_index_id.rs
+++ b/crates/trusty-common/src/project_index_id.rs
@@ -1,0 +1,373 @@
+//! Project-derived trusty-search index identity — a PARTITIONING key
+//! (epic #4207, replacing the approach closed as won't-do in #4063).
+//!
+//! Why: the index id in use today is either the bare directory basename
+//! ([`crate::index_id::derive_index_id`]) — which collides for any two
+//! unrelated checkouts that happen to share a directory name — or, for a
+//! tm-managed session, the session/worktree UUID, which binds a service
+//! identity to ephemeral writer isolation: N concurrent writers on one repo
+//! produce N independently-stale indexes, none shareable, and the id is
+//! unguessable so BASE_PM's instruction to pass the project name silently
+//! 404s. Both defects need ONE deterministic id derived from the PROJECT.
+//!
+//! **The contract that sank the previous attempt — state it before reading
+//! any code.** trusty-search's registry is one-`root_path`-per-id (see
+//! `trusty-mpm`'s `session_manager::search_gc`), so an index id must
+//! *partition*: one id maps to exactly ONE content tree. [`RepoIdentity`]'s
+//! own module doc says it is a *grouping* key — deliberately shared by every
+//! facet (live checkout, `.base` clone, each session worktree) of one repo.
+//! #4063 promoted that grouping key into the partitioning slot, and each
+//! review round found another pair of genuinely different roots sharing it:
+//! linked worktrees, then sibling clones of one repo, then the
+//! daemon-unreachable path resolving forward onto the new id. This module
+//! partitions **by construction** instead of by patching cases: the canonical
+//! content-tree root path is a hashed component of every id, so two distinct
+//! trees can never collide no matter how their git metadata relates. The
+//! grouping key is retained as a *component* (and as the public
+//! [`ProjectIdentity::origin`] field), not as the whole id.
+//!
+//! What: [`ProjectIdentity`] is the three-part identity the owner specified on
+//! #4207 — origin (which repository), root (which content tree of it), and
+//! gh user (which account operates it). [`ProjectIdentity::derive`] is the one
+//! I/O entry point (git shell-outs + one `canonicalize`);
+//! [`ProjectIdentity::index_id`] is a pure, dependency-free function over
+//! those three fields, so every collision case is testable without a daemon,
+//! a registry, or live state. [`derive_project_index_id`] is the one-call
+//! convenience wrapper. Nothing here is wired into `ensure_project_indexed`,
+//! `trusty-search serve`, or the daemon's resolution path — this slice is the
+//! derivation only.
+//!
+//! **Constraint inherited by the migration slice (do NOT implement here).**
+//! The ~7 currently-registered indexes must be migrated by rename/alias, never
+//! by re-index (this workspace alone is ~105k chunks / 2.1 GB redb). Whatever
+//! resolver performs that migration MUST fail **safe**: when the daemon or the
+//! persisted registry cannot be consulted, fall back to the known-good LEGACY
+//! id. It must never fail *forward* onto an id that does not exist yet —
+//! #4063 did exactly that at `search_index.rs:106-108` and silently orphaned a
+//! session's search for the session's entire life, with no self-heal.
+//!
+//! Discoverability note: because the id is always suffixed, it is not
+//! guessable from the project name alone. That is deliberate — a guessable id
+//! cannot partition. The #4207 self-description slice (MCP `instructions` at
+//! initialize, `404` → available-index signpost) is what makes ids findable;
+//! the two changes are complements, and neither substitutes for the other.
+//!
+//! Test: `cargo test -p trusty-common -- project_index_id` — the sibling
+//! `project_index_id_tests.rs` covers sibling clones, linked worktrees,
+//! differing gh users, remoteless directories, symlinked roots, determinism,
+//! and the id charset.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::repo_identity::RepoIdentity;
+use crate::slug::slugify_string;
+
+/// Version tag mixed into every digest preimage.
+///
+/// Why: the derivation rule will eventually change (a new component, a
+/// different framing). Mixing a version tag in means a future `v2` produces a
+/// wholly different id space rather than silently re-pointing existing ids at
+/// new content, so the migration slice can tell the two apart.
+/// What: the literal `"v1"`.
+const SCHEME_VERSION: &str = "v1";
+
+/// Maximum length of the human-readable label prefix of an index id.
+///
+/// Why: an index id is a single URL path segment and appears in filenames and
+/// log lines; an unbounded owner/repo pair makes both unwieldy. Truncation is
+/// safe because uniqueness lives entirely in the digest suffix, never in the
+/// label.
+/// What: 48 characters.
+const MAX_LABEL_LEN: usize = 48;
+
+/// Placeholder label used when a project yields no slug-able name at all.
+///
+/// Why: `index_id` must never return a string that starts with `-` or is only
+/// a digest; a stable placeholder keeps the id readable and well-formed.
+/// What: the literal `"project"`.
+const FALLBACK_LABEL: &str = "project";
+
+/// The three-part identity of one indexable project.
+///
+/// Why: #4207 specifies identity as origin + root + gh user. Modelling those as
+/// explicit fields — rather than folding them into an opaque derivation — makes
+/// each component's job checkable in isolation and lets [`Self::index_id`] stay
+/// a pure function, so the collision cases that killed #4063 are testable
+/// without any live daemon or registry state.
+/// What: `origin` is the repo-level GROUPING key ([`RepoIdentity`], `None`
+/// outside a git repo); `root` is the canonical absolute content-tree root and
+/// is the component that makes the derived id a PARTITIONING key; `gh_user` is
+/// the account operating this checkout. All three are hashed; only `origin`
+/// (or the root basename) contributes to the readable label.
+/// Test: `sibling_clones_of_same_repo_derive_distinct_ids`,
+/// `linked_worktrees_of_same_repo_derive_distinct_ids`,
+/// `different_gh_users_derive_distinct_ids`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectIdentity {
+    /// Repo-level grouping key from the git origin remote, `None` outside a
+    /// git repo. Deliberately NOT sufficient on its own to identify an index.
+    pub origin: Option<RepoIdentity>,
+    /// Canonical absolute root of THIS content tree (a clone root, or a linked
+    /// worktree root — each is its own tree). The partitioning component.
+    pub root: PathBuf,
+    /// The account operating this checkout, `None` when unresolvable offline.
+    pub gh_user: Option<String>,
+}
+
+impl ProjectIdentity {
+    /// Derive the identity of the project containing `start`.
+    ///
+    /// Why: the three components must be gathered by ONE rule wherever an id is
+    /// computed (trusty-mpm at session launch, trusty-search's `detect_project`,
+    /// trusty-review's report enrichment) or the callers silently diverge — the
+    /// same failure mode `index_id` was centralised here to prevent (#1373).
+    /// What: canonicalises `start` (resolving symlinks, so two paths naming one
+    /// tree derive one id), walks to the enclosing git root via
+    /// [`crate::index_id::resolve_project_root`] — which lands on the *linked
+    /// worktree* root for a worktree, because its `.git` is a file there, so
+    /// each worktree is correctly treated as its own content tree — then reads
+    /// the origin via [`RepoIdentity::derive`] and the account via
+    /// [`resolve_gh_user`]. Best-effort and offline: every component degrades to
+    /// `None` rather than failing, and `canonicalize` falls back to the input
+    /// path when it cannot resolve. No network, no daemon, no registry.
+    /// Test: `derivation_is_deterministic_across_calls`,
+    /// `directory_without_git_origin_derives_stable_id`,
+    /// `symlinked_root_derives_same_id_as_real_root`.
+    pub fn derive(start: &Path) -> ProjectIdentity {
+        // #4207: canonicalise BEFORE the git-root walk so a symlinked start
+        // path and the real path resolve to the same content tree.
+        let canonical_start = std::fs::canonicalize(start).unwrap_or_else(|_| start.to_path_buf());
+        let root = crate::index_id::resolve_project_root(&canonical_start);
+        ProjectIdentity {
+            origin: RepoIdentity::derive(&root),
+            gh_user: resolve_gh_user(&root),
+            root,
+        }
+    }
+
+    /// Render this identity as a trusty-search index id.
+    ///
+    /// Why: this is the PARTITIONING key defined at the top of this module —
+    /// one id, exactly one content tree — and it must hold *by construction*,
+    /// for sibling clones and linked worktrees alike, because trusty-search's
+    /// registry stores a single `root_path` per id and silently degrades a
+    /// second registration to a *find* against the first tree's root.
+    /// What: `"<label>-<digest>"`, where `label` is the slugified
+    /// `owner-repo` (falling back to the root basename, then [`FALLBACK_LABEL`],
+    /// truncated to [`MAX_LABEL_LEN`]) and `digest` is 16 lowercase hex digits
+    /// over an injectively-framed, version-tagged encoding of ALL THREE fields.
+    /// The label is cosmetic; every bit of uniqueness is in the digest, so
+    /// two projects sharing a label still get different ids. Pure — no I/O, no
+    /// global state, no daemon lookup — which is what makes the collision cases
+    /// testable and keeps resolution independent of mutable live state.
+    /// Guarantees: non-empty; a single URL path segment matching
+    /// `[a-z0-9][a-z0-9-]*`; stable across processes, machines with the same
+    /// three inputs, and daemon restarts.
+    /// Known limitation: `root` is machine-local, so the same repo cloned on
+    /// two machines derives two ids. That is correct for a partitioning key —
+    /// each machine holds its own physical index — and is why "stable across
+    /// machines" holds only for identical inputs.
+    /// Test: `index_id_is_a_single_url_safe_segment`,
+    /// `label_ambiguity_does_not_collide`, `empty_label_falls_back_to_placeholder`,
+    /// `index_id_is_pinned_for_a_known_input`,
+    /// `long_label_is_truncated_without_losing_uniqueness`.
+    pub fn index_id(&self) -> String {
+        format!("{}-{:016x}", self.label(), self.digest())
+    }
+
+    /// Build the cosmetic, human-readable prefix of the id.
+    ///
+    /// Why: an id of pure hex is unreadable in logs and `tm` output; a label
+    /// keeps `bobmatnyc-trusty-tools-…` recognisable at a glance. It carries no
+    /// uniqueness guarantee — deliberately, so a label collision is harmless.
+    /// What: `owner-repo` for a GitHub origin, else the root basename; slugified
+    /// via [`slugify_string`], truncated to [`MAX_LABEL_LEN`] on a character
+    /// boundary with any trailing `-` trimmed, and replaced by
+    /// [`FALLBACK_LABEL`] when empty.
+    /// Test: `label_ambiguity_does_not_collide`,
+    /// `empty_label_falls_back_to_placeholder`.
+    fn label(&self) -> String {
+        let raw = match &self.origin {
+            Some(RepoIdentity::GitHub(gp)) => format!("{}-{}", gp.owner, gp.repo),
+            // A content-hash origin is opaque hex; the directory name reads
+            // better and the digest still carries the uniqueness.
+            _ => self
+                .root
+                .file_name()
+                .unwrap_or_default()
+                .to_string_lossy()
+                .into_owned(),
+        };
+        let mut label: String = slugify_string(&raw).chars().take(MAX_LABEL_LEN).collect();
+        while label.ends_with('-') {
+            label.pop();
+        }
+        if label.is_empty() {
+            FALLBACK_LABEL.to_string()
+        } else {
+            label
+        }
+    }
+
+    /// Hash all three identity components into a stable 64-bit digest.
+    ///
+    /// Why: the digest is the whole partitioning guarantee. Its preimage must be
+    /// *injective* — #4063 shipped a bare `format!("{owner}-{repo}")` join where
+    /// `foo-bar`/`baz` and `foo`/`bar-baz` produced one string — so every field
+    /// here is length-prefixed and every `Option` carries a presence tag, making
+    /// two different field tuples impossible to encode identically.
+    /// What: length-framed `<len>:<bytes>` records for the scheme version, the
+    /// origin's canonical form (`+`/`-` presence tag), the root path's raw
+    /// bytes (not lossy UTF-8, so non-UTF-8 paths stay distinct), and the gh
+    /// user, run through [`fnv1a_64`].
+    /// Test: `label_ambiguity_does_not_collide`,
+    /// `unrelated_projects_sharing_a_basename_derive_distinct_ids`.
+    fn digest(&self) -> u64 {
+        let mut buf: Vec<u8> = Vec::with_capacity(256);
+        push_field(&mut buf, SCHEME_VERSION.as_bytes());
+        push_opt(&mut buf, self.origin.as_ref().map(|o| o.canonical()));
+        push_field(&mut buf, &path_bytes(&self.root));
+        push_opt(&mut buf, self.gh_user.clone());
+        fnv1a_64(&buf)
+    }
+}
+
+/// Derive the trusty-search index id for the project containing `start`.
+///
+/// Why: nearly every call site wants the id, not the identity; a one-call
+/// wrapper keeps them from re-implementing the two-step derive-then-render and
+/// drifting apart. Callers that also need the repo-level grouping key (to relate
+/// several indexes of one repo) should use [`ProjectIdentity::derive`] and read
+/// [`ProjectIdentity::origin`] instead of deriving it a second time.
+/// What: [`ProjectIdentity::derive`] followed by [`ProjectIdentity::index_id`].
+/// Performs the same best-effort git I/O as `derive`; never panics.
+/// Test: `derivation_is_deterministic_across_calls`,
+/// `sibling_clones_of_same_repo_derive_distinct_ids`.
+pub fn derive_project_index_id(start: &Path) -> String {
+    ProjectIdentity::derive(start).index_id()
+}
+
+/// Resolve the GitHub account operating the checkout at `root`, offline.
+///
+/// Why: #4207 specifies the account as an identity component, but the id must be
+/// derivable with no network — `gh api user` would make every derivation a round
+/// trip and a flake. Git's own configured identity is the offline signal that
+/// actually varies per account, and a repo-local `user.email` override is
+/// precisely how a second account's checkout is configured in practice.
+/// What: `TRUSTY_GH_USER` when set and non-empty (an explicit ops/test
+/// override), else `git -C <root> config --get user.email`, which already
+/// applies git's repo-local-over-global precedence. `None` when neither
+/// resolves. Stability caveat for the migration slice: changing the configured
+/// identity changes the derived id, so migration must alias rather than assume
+/// permanence.
+/// Test: `resolve_gh_user_reads_repo_local_git_identity`.
+pub fn resolve_gh_user(root: &Path) -> Option<String> {
+    if let Ok(v) = std::env::var("TRUSTY_GH_USER") {
+        let v = v.trim().to_string();
+        if !v.is_empty() {
+            return Some(v);
+        }
+    }
+    let output = Command::new("git")
+        .arg("-C")
+        .arg(root)
+        .args(["config", "--get", "user.email"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .next()
+        .map(str::trim)
+        .filter(|l| !l.is_empty())
+        .map(str::to_string)
+}
+
+/// Append one length-framed record to a digest preimage.
+///
+/// Why: concatenating fields with a separator is not injective — the exact
+/// defect flagged on #4063's `owner-repo` join. An explicit byte length makes
+/// the boundary unambiguous regardless of the field's own contents.
+/// What: writes `<decimal len>:<bytes>` to `buf`.
+/// Test: covered by `label_ambiguity_does_not_collide`.
+fn push_field(buf: &mut Vec<u8>, value: &[u8]) {
+    buf.extend_from_slice(value.len().to_string().as_bytes());
+    buf.push(b':');
+    buf.extend_from_slice(value);
+}
+
+/// Append an optional field with an explicit presence tag.
+///
+/// Why: `None` and `Some("")` must not encode identically, or a project with no
+/// origin would share a digest with one whose origin resolved to an empty
+/// string.
+/// What: `Some(v)` writes `+` then [`push_field`]; `None` writes a bare `-`.
+/// Test: covered by `directory_without_git_origin_derives_stable_id`.
+fn push_opt(buf: &mut Vec<u8>, value: Option<String>) {
+    match value {
+        Some(v) => {
+            buf.push(b'+');
+            push_field(buf, v.as_bytes());
+        }
+        None => buf.push(b'-'),
+    }
+}
+
+/// Return a path's raw bytes for hashing.
+///
+/// Why: `to_string_lossy` maps every invalid byte sequence to the same
+/// replacement character, so two genuinely different non-UTF-8 paths could hash
+/// identically — a partitioning-key violation, however rare. Hashing the raw
+/// OS bytes removes the case entirely on unix.
+/// What: the underlying `OsStr` bytes on unix; the lossy UTF-8 encoding
+/// elsewhere (Windows `OsStr` is UTF-16 and has no byte view).
+/// Test: covered by `sibling_clones_of_same_repo_derive_distinct_ids`.
+fn path_bytes(p: &Path) -> Vec<u8> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::ffi::OsStrExt;
+        p.as_os_str().as_bytes().to_vec()
+    }
+    #[cfg(not(unix))]
+    {
+        p.to_string_lossy().as_bytes().to_vec()
+    }
+}
+
+/// FNV-1a 64-bit digest with a final avalanche mix.
+///
+/// Why: the id must be byte-identical across processes, machines, and toolchain
+/// versions, which rules out `std`'s `DefaultHasher` (explicitly not
+/// stability-guaranteed). A cryptographic digest would work but `sha2` is an
+/// *optional* dependency of this crate, and an identity that changes with a
+/// feature flag is worse than no identity at all — so this stays dependency-free
+/// and unconditional. Not a security boundary: nothing here defends against a
+/// chosen-preimage attacker, only against accidental collision.
+/// (`memory_core::analytics::fnv1a_hash` is the same algorithm but lives behind
+/// the `memory-core` feature and takes `&str`, so it is unusable here.)
+/// What: standard FNV-1a over `bytes`, then a splitmix64 finalizer so that
+/// paths differing in a single character still differ in most output bits.
+/// Test: `digest_is_stable_for_identical_inputs`.
+fn fnv1a_64(bytes: &[u8]) -> u64 {
+    const OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let mut hash = OFFSET_BASIS;
+    for b in bytes {
+        hash ^= u64::from(*b);
+        hash = hash.wrapping_mul(PRIME);
+    }
+    // splitmix64 finalizer — FNV-1a alone avalanches poorly on inputs that
+    // differ only in their final bytes, which is exactly the sibling-path case.
+    hash ^= hash >> 30;
+    hash = hash.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    hash ^= hash >> 27;
+    hash = hash.wrapping_mul(0x94d0_49bb_1331_11eb);
+    hash ^ (hash >> 31)
+}
+
+#[cfg(test)]
+#[path = "project_index_id_tests.rs"]
+mod tests;

--- a/crates/trusty-common/src/project_index_id.rs
+++ b/crates/trusty-common/src/project_index_id.rs
@@ -28,7 +28,9 @@
 //!
 //! What: [`ProjectIdentity`] is the three-part identity the owner specified on
 //! #4207 — origin (which repository), root (which content tree of it), and
-//! gh user (which account operates it). [`ProjectIdentity::derive`] is the one
+//! operator (which account operates it — the triple's "gh user", realised
+//! offline as git's configured `user.email`, not a GitHub login).
+//! [`ProjectIdentity::derive`] is the one
 //! I/O entry point (git shell-outs + one `canonicalize`);
 //! [`ProjectIdentity::index_id`] is a pure, dependency-free function over
 //! those three fields, so every collision case is testable without a daemon,
@@ -54,8 +56,9 @@
 //!
 //! Test: `cargo test -p trusty-common -- project_index_id` — the sibling
 //! `project_index_id_tests.rs` covers sibling clones, linked worktrees,
-//! differing gh users, remoteless directories, symlinked roots, determinism,
-//! and the id charset.
+//! differing operators, remoteless directories, symlinked roots, determinism,
+//! the id charset, and the origin/operator drift cases enumerated in
+//! [`ProjectIdentity::index_id`]'s `Known limitation` block.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -66,10 +69,15 @@ use crate::slug::slugify_string;
 /// Version tag mixed into every digest preimage.
 ///
 /// Why: the derivation rule will eventually change (a new component, a
-/// different framing). Mixing a version tag in means a future `v2` produces a
-/// wholly different id space rather than silently re-pointing existing ids at
-/// new content, so the migration slice can tell the two apart.
-/// What: the literal `"v1"`.
+/// different framing). Mixing a version tag into the digest preimage means a
+/// future `v2` can never re-point an ALREADY-REGISTERED id at different
+/// content — every id moves wholesale into a disjoint space. That is the
+/// property the migration slice actually needs.
+/// What: the literal `"v1"`. Note what this does NOT give you: the emitted id
+/// carries no version marker, so a v1 id and a v2 id are indistinguishable by
+/// inspection. A migration that must classify ids has to track the scheme
+/// out-of-band (or a future version must emit the tag in the id itself).
+/// Test: `index_id_is_pinned_for_a_known_input` fails if this value changes.
 const SCHEME_VERSION: &str = "v1";
 
 /// Maximum length of the human-readable label prefix of an index id.
@@ -97,22 +105,34 @@ const FALLBACK_LABEL: &str = "project";
 /// without any live daemon or registry state.
 /// What: `origin` is the repo-level GROUPING key ([`RepoIdentity`], `None`
 /// outside a git repo); `root` is the canonical absolute content-tree root and
-/// is the component that makes the derived id a PARTITIONING key; `gh_user` is
+/// is the component that makes the derived id a PARTITIONING key; `operator` is
 /// the account operating this checkout. All three are hashed; only `origin`
 /// (or the root basename) contributes to the readable label.
+///
+/// Only `root` is immutable for the life of a content tree. `origin` and
+/// `operator` are both mutable git state — see the `Known limitation` block on
+/// [`Self::index_id`] for the enumerated drift cases and what they cost.
 /// Test: `sibling_clones_of_same_repo_derive_distinct_ids`,
 /// `linked_worktrees_of_same_repo_derive_distinct_ids`,
-/// `different_gh_users_derive_distinct_ids`.
+/// `different_operators_derive_distinct_ids`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ProjectIdentity {
     /// Repo-level grouping key from the git origin remote, `None` outside a
     /// git repo. Deliberately NOT sufficient on its own to identify an index.
+    /// MUTABLE: `git remote add origin` and the first commit both change it.
     pub origin: Option<RepoIdentity>,
     /// Canonical absolute root of THIS content tree (a clone root, or a linked
-    /// worktree root — each is its own tree). The partitioning component.
+    /// worktree root — each is its own tree). The partitioning component, and
+    /// the only component that does not move under ordinary git operations.
     pub root: PathBuf,
-    /// The account operating this checkout, `None` when unresolvable offline.
-    pub gh_user: Option<String>,
+    /// The #4207 identity triple's "gh user" component, realised offline as
+    /// git's configured operator identity.
+    ///
+    /// VALUE SHAPE: this is a `git config user.email` value (e.g.
+    /// `bob@example.com`), NOT a GitHub login. Do not compare it against
+    /// `gh api user`. `None` when git resolves no identity. See
+    /// [`resolve_operator_identity`] for precedence and stability caveats.
+    pub operator: Option<String>,
 }
 
 impl ProjectIdentity {
@@ -122,15 +142,22 @@ impl ProjectIdentity {
     /// computed (trusty-mpm at session launch, trusty-search's `detect_project`,
     /// trusty-review's report enrichment) or the callers silently diverge — the
     /// same failure mode `index_id` was centralised here to prevent (#1373).
-    /// What: canonicalises `start` (resolving symlinks, so two paths naming one
-    /// tree derive one id), walks to the enclosing git root via
-    /// [`crate::index_id::resolve_project_root`] — which lands on the *linked
-    /// worktree* root for a worktree, because its `.git` is a file there, so
-    /// each worktree is correctly treated as its own content tree — then reads
-    /// the origin via [`RepoIdentity::derive`] and the account via
-    /// [`resolve_gh_user`]. Best-effort and offline: every component degrades to
-    /// `None` rather than failing, and `canonicalize` falls back to the input
-    /// path when it cannot resolve. No network, no daemon, no registry.
+    /// What: canonicalises `start` — which resolves **symlinks**, so a symlinked
+    /// path and its target derive one id — then walks to the enclosing git root
+    /// via [`crate::index_id::resolve_project_root`], which lands on the *linked
+    /// worktree* root for a worktree because its `.git` is a file there, so each
+    /// worktree is correctly treated as its own content tree. Finally reads the
+    /// origin via [`RepoIdentity::derive`] and the operator via
+    /// [`resolve_operator_identity`]. Best-effort and offline: every component
+    /// degrades to `None` rather than failing, and `canonicalize` falls back to
+    /// the input path when it cannot resolve. No network, no daemon, no registry.
+    ///
+    /// Known limitation — canonicalisation resolves symlinks ONLY. macOS
+    /// firmlinks and Linux bind mounts are NOT resolved (`/Users/x` and
+    /// `/System/Volumes/Data/Users/x` each canonicalise to themselves), so one
+    /// content tree reached through both derives two ids and therefore two
+    /// indexes over identical content. This is inherent to any path-based
+    /// partitioning key, not specific to this derivation.
     /// Test: `derivation_is_deterministic_across_calls`,
     /// `directory_without_git_origin_derives_stable_id`,
     /// `symlinked_root_derives_same_id_as_real_root`.
@@ -141,7 +168,7 @@ impl ProjectIdentity {
         let root = crate::index_id::resolve_project_root(&canonical_start);
         ProjectIdentity {
             origin: RepoIdentity::derive(&root),
-            gh_user: resolve_gh_user(&root),
+            operator: resolve_operator_identity(&root),
             root,
         }
     }
@@ -161,13 +188,42 @@ impl ProjectIdentity {
     /// two projects sharing a label still get different ids. Pure — no I/O, no
     /// global state, no daemon lookup — which is what makes the collision cases
     /// testable and keeps resolution independent of mutable live state.
-    /// Guarantees: non-empty; a single URL path segment matching
-    /// `[a-z0-9][a-z0-9-]*`; stable across processes, machines with the same
-    /// three inputs, and daemon restarts.
-    /// Known limitation: `root` is machine-local, so the same repo cloned on
-    /// two machines derives two ids. That is correct for a partitioning key —
-    /// each machine holds its own physical index — and is why "stable across
-    /// machines" holds only for identical inputs.
+    /// Guarantees (exactly these, and no more): non-empty; a single URL path
+    /// segment matching `[a-z0-9][a-z0-9-]*`; and a pure function of the three
+    /// fields — identical fields yield an identical id in every process, on
+    /// every machine, across daemon restarts, forever. Stability of the *id for
+    /// a given project* is therefore only as strong as the stability of the
+    /// three inputs, and two of them move. Read the next block before assuming
+    /// permanence.
+    ///
+    /// **Known limitation — which inputs are mutable, and what changes an id.**
+    /// Only `root` is fixed for the life of a content tree. Both other
+    /// components are live git/user state, so ordinary actions re-derive a
+    /// different id for the SAME tree. Each row is pinned by a test:
+    ///
+    /// | Action | Component | Test |
+    /// |---|---|---|
+    /// | The repo's first commit (`None` → `ContentHash`) | `origin` | `id_changes_when_first_commit_lands` |
+    /// | `git remote add origin …` (`ContentHash` → `GitHub`) | `origin` | `id_changes_when_origin_remote_is_added` |
+    /// | A new root commit (`git checkout --orphan`) on a remoteless repo | `origin` | `id_changes_on_orphan_root_commit` |
+    /// | Changing the configured `user.email` | `operator` | `different_operators_derive_distinct_ids` |
+    ///
+    /// Row 2 is the everyday `git init` → work → `gh repo create` sequence. It
+    /// changes both the label and the digest, so under a
+    /// one-`root_path`-per-id registry an index registered before the remote is
+    /// added is ORPHANED the moment it is added, with no self-heal — the same
+    /// silent-orphan shape this module's header warns the migration slice about.
+    /// This is a strictly weaker hazard than the #4063 failure (one tree
+    /// deriving two ids over time wastes an index; two trees deriving one id
+    /// merges unrelated codebases), and it cannot bite while the module has no
+    /// call sites — but the wiring slice MUST NOT read this function as
+    /// permanent. Recommended shape for that slice: reconcile on `root`, which
+    /// is the only component that does not move, and treat an origin/operator
+    /// change as an alias-and-carry-forward rather than a new index.
+    ///
+    /// Also machine-local: `root` is an absolute path, so the same repo cloned
+    /// on two machines derives two ids. That is correct for a partitioning key
+    /// — each machine holds its own physical index.
     /// Test: `index_id_is_a_single_url_safe_segment`,
     /// `label_ambiguity_does_not_collide`, `empty_label_falls_back_to_placeholder`,
     /// `index_id_is_pinned_for_a_known_input`,
@@ -219,8 +275,8 @@ impl ProjectIdentity {
     /// two different field tuples impossible to encode identically.
     /// What: length-framed `<len>:<bytes>` records for the scheme version, the
     /// origin's canonical form (`+`/`-` presence tag), the root path's raw
-    /// bytes (not lossy UTF-8, so non-UTF-8 paths stay distinct), and the gh
-    /// user, run through [`fnv1a_64`].
+    /// bytes (not lossy UTF-8, so non-UTF-8 paths stay distinct), and the
+    /// operator, run through [`fnv1a_64`].
     /// Test: `label_ambiguity_does_not_collide`,
     /// `unrelated_projects_sharing_a_basename_derive_distinct_ids`.
     fn digest(&self) -> u64 {
@@ -228,7 +284,7 @@ impl ProjectIdentity {
         push_field(&mut buf, SCHEME_VERSION.as_bytes());
         push_opt(&mut buf, self.origin.as_ref().map(|o| o.canonical()));
         push_field(&mut buf, &path_bytes(&self.root));
-        push_opt(&mut buf, self.gh_user.clone());
+        push_opt(&mut buf, self.operator.clone());
         fnv1a_64(&buf)
     }
 }
@@ -248,27 +304,38 @@ pub fn derive_project_index_id(start: &Path) -> String {
     ProjectIdentity::derive(start).index_id()
 }
 
-/// Resolve the GitHub account operating the checkout at `root`, offline.
+/// Resolve the operator identity for the checkout at `root`, offline.
 ///
 /// Why: #4207 specifies the account as an identity component, but the id must be
 /// derivable with no network — `gh api user` would make every derivation a round
 /// trip and a flake. Git's own configured identity is the offline signal that
 /// actually varies per account, and a repo-local `user.email` override is
 /// precisely how a second account's checkout is configured in practice.
-/// What: `TRUSTY_GH_USER` when set and non-empty (an explicit ops/test
-/// override), else `git -C <root> config --get user.email`, which already
-/// applies git's repo-local-over-global precedence. `None` when neither
-/// resolves. Stability caveat for the migration slice: changing the configured
-/// identity changes the derived id, so migration must alias rather than assume
-/// permanence.
-/// Test: `resolve_gh_user_reads_repo_local_git_identity`.
-pub fn resolve_gh_user(root: &Path) -> Option<String> {
-    if let Ok(v) = std::env::var("TRUSTY_GH_USER") {
-        let v = v.trim().to_string();
-        if !v.is_empty() {
-            return Some(v);
-        }
-    }
+///
+/// **Deliberately reads NO environment variable.** An earlier revision honoured
+/// a `TRUSTY_GH_USER` override; it was removed rather than merely tested,
+/// because it made derivation non-hermetic in the one way that matters here —
+/// two live callers on the SAME tree at the SAME instant deriving different ids
+/// purely from differing process environments. The trusty-mpm daemon (launchd
+/// plist env) and a `tm` CLI (shell env) are exactly that pair, so the override
+/// would have re-created the "callers silently diverge" failure (#1373) that is
+/// this module's whole reason to exist. Covering both branches with tests would
+/// have pinned the divergence, not removed it. Eliminating the branch removes
+/// the failure class.
+/// What: `git -C <root> config --get user.email`, which already applies git's
+/// repo-local-over-global precedence. `None` when git resolves no identity or is
+/// unavailable. Returns a git email address, NOT a GitHub login.
+///
+/// Residual non-hermeticity, disclosed rather than claimed away: git's own
+/// config resolution still depends on `HOME` / `GIT_CONFIG_GLOBAL`, so callers
+/// running under materially different environments can still disagree when the
+/// repo sets no local `user.email`; and `--get` on a multi-valued key returns
+/// the LAST entry. The wiring slice must therefore guarantee uniform
+/// environment inheritance across daemon and CLI — a partial rollout partitions
+/// one tree into two indexes.
+/// Test: `resolve_operator_identity_prefers_repo_local_git_identity`,
+/// `resolve_operator_identity_ignores_ambient_env_override`.
+pub fn resolve_operator_identity(root: &Path) -> Option<String> {
     let output = Command::new("git")
         .arg("-C")
         .arg(root)

--- a/crates/trusty-common/src/project_index_id_tests.rs
+++ b/crates/trusty-common/src/project_index_id_tests.rs
@@ -4,14 +4,22 @@
 //! `project_index_id.rs`, the pattern `search_index_tests.rs` already uses in
 //! this crate) so the derivation module stays inside the 500-SLOC production
 //! cap while the collision suite can be as exhaustive as the design demands.
-//! The cases below are not generic coverage — each one is a specific way
-//! #4063's grouping-key-as-partitioning-key approach was proven to collide.
+//! The cases below are not generic coverage — each one is either a specific way
+//! #4063's grouping-key-as-partitioning-key approach was proven to collide, or
+//! a pinned drift case the migration slice will inherit.
 //!
 //! What: real synthetic git topologies (`git init`, `git clone`,
-//! `git worktree add` in temp dirs) for the cases that depend on git
-//! behaviour, and direct construction of [`ProjectIdentity`] for the cases
-//! that are pure. Nothing here touches a live daemon, the index registry, or
-//! any currently-registered index.
+//! `git worktree add` in temp dirs) for the cases that depend on git behaviour,
+//! and direct construction of [`ProjectIdentity`] for the cases that are pure.
+//! Nothing here touches a live daemon, the index registry, or any
+//! currently-registered index.
+//!
+//! **No test in this file may pass vacuously.** An earlier revision let six
+//! git-topology tests `return` — reporting `ok` — whenever any git step failed,
+//! including the two that carry the entire partitioning guarantee. A guard that
+//! can silently not-run is not a guard. [`git`] therefore panics on a failed
+//! spawn or a non-zero exit, so a runner with no git, or with a hostile
+//! `safe.directory` / hook / signing configuration, goes RED rather than green.
 //!
 //! Test: this file.
 
@@ -19,52 +27,71 @@ use super::*;
 use crate::github_path::GithubPath;
 
 // ---------------------------------------------------------------------------
-// Helpers
+// Helpers — every one of these fails loudly; none skip.
 // ---------------------------------------------------------------------------
 
-/// Run a git subcommand in `dir`, reporting whether it succeeded.
-fn git_ok(dir: &Path, args: &[&str]) -> bool {
-    Command::new("git")
+/// Run a git subcommand in `dir`, panicking with full context on any failure.
+///
+/// Why: see the "no test may pass vacuously" note above. Returns stdout so
+/// callers can assert on it.
+fn git(dir: &Path, args: &[&str]) -> String {
+    let out = Command::new("git")
         .arg("-C")
         .arg(dir)
         .args(args)
         .output()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+        .unwrap_or_else(|e| {
+            panic!(
+                "git {args:?} in {dir:?} could not spawn: {e}. These tests guard \
+                 the #4207 partitioning key and must never pass without running."
+            )
+        });
+    assert!(
+        out.status.success(),
+        "git {args:?} in {dir:?} exited {}: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
 }
 
-/// Initialise a committed git repo at `dir` with `origin` pointing at `url`.
+/// Create `dir` and `git init` it with a deterministic, signing-free identity.
 ///
-/// Returns `false` when git is unusable on this runner, so callers can skip
-/// cleanly rather than fail (matching `repo_identity`'s existing convention).
-fn init_repo(dir: &Path, url: &str) -> bool {
-    if std::fs::create_dir_all(dir).is_err() {
-        return false;
-    }
-    if !git_ok(dir, &["-c", "init.defaultBranch=main", "init"]) {
-        return false;
-    }
-    let _ = git_ok(dir, &["config", "user.email", "t@t.test"]);
-    let _ = git_ok(dir, &["config", "user.name", "t"]);
-    if std::fs::write(dir.join("README.md"), "hi").is_err() {
-        return false;
-    }
-    let _ = git_ok(dir, &["add", "."]);
-    if !git_ok(dir, &["commit", "-m", "init"]) {
-        return false;
-    }
-    git_ok(dir, &["remote", "add", "origin", url])
+/// `commit.gpgsign=false` is forced per-repo so a developer's global signing
+/// config cannot fail these tests for an unrelated reason — they fail loudly
+/// now, so every avoidable environmental failure must be designed out rather
+/// than skipped around.
+fn init_empty_repo(dir: &Path) {
+    std::fs::create_dir_all(dir).expect("create repo dir");
+    git(dir, &["-c", "init.defaultBranch=main", "init"]);
+    git(dir, &["config", "user.email", "t@t.test"]);
+    git(dir, &["config", "user.name", "t"]);
+    git(dir, &["config", "commit.gpgsign", "false"]);
+}
+
+/// Write `name` into `dir` and commit it.
+fn commit_file(dir: &Path, name: &str, body: &str) {
+    std::fs::write(dir.join(name), body).expect("write file");
+    git(dir, &["add", "."]);
+    git(dir, &["commit", "-m", "commit"]);
+}
+
+/// Initialise a committed repo at `dir` whose `origin` points at `url`.
+fn init_repo(dir: &Path, url: &str) {
+    init_empty_repo(dir);
+    commit_file(dir, "README.md", "hi");
+    git(dir, &["remote", "add", "origin", url]);
 }
 
 /// A pure identity with every field supplied — no filesystem, no git.
-fn identity(owner: &str, repo: &str, root: &str, gh_user: Option<&str>) -> ProjectIdentity {
+fn identity(owner: &str, repo: &str, root: &str, operator: Option<&str>) -> ProjectIdentity {
     ProjectIdentity {
         origin: Some(RepoIdentity::GitHub(GithubPath {
             owner: owner.into(),
             repo: repo.into(),
         })),
         root: PathBuf::from(root),
-        gh_user: gh_user.map(str::to_string),
+        operator: operator.map(str::to_string),
     }
 }
 
@@ -86,17 +113,15 @@ fn identity(owner: &str, repo: &str, root: &str, gh_user: Option<&str>) -> Proje
 fn sibling_clones_of_same_repo_derive_distinct_ids() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let upstream = tmp.path().join("origin.git");
-    if std::fs::create_dir_all(&upstream).is_err() || !git_ok(&upstream, &["init", "--bare"]) {
-        return; // no usable git on this runner
-    }
+    std::fs::create_dir_all(&upstream).expect("create upstream dir");
+    git(&upstream, &["init", "--bare"]);
     let upstream_url = upstream.to_string_lossy().into_owned();
+
     let seed = tmp.path().join("seed");
-    if !init_repo(&seed, &upstream_url) {
-        return;
-    }
-    if !git_ok(&seed, &["push", "origin", "HEAD:refs/heads/main"]) {
-        return;
-    }
+    init_empty_repo(&seed);
+    commit_file(&seed, "README.md", "hi");
+    git(&seed, &["remote", "add", "origin", &upstream_url]);
+    git(&seed, &["push", "origin", "HEAD:refs/heads/main"]);
 
     // Two real clones at different paths, both re-pointed at the same GitHub
     // origin — exactly the topology proven to collide on #4063.
@@ -104,23 +129,16 @@ fn sibling_clones_of_same_repo_derive_distinct_ids() {
     let b = tmp.path().join("widget-review");
     for dest in [&a, &b] {
         let dest_arg = dest.to_string_lossy().into_owned();
-        let ok = Command::new("git")
-            .args(["clone", &upstream_url, &dest_arg])
-            .output()
-            .map(|o| o.status.success())
-            .unwrap_or(false);
-        if !ok {
-            return;
-        }
-        assert!(git_ok(
+        git(tmp.path(), &["clone", &upstream_url, &dest_arg]);
+        git(
             dest,
             &[
                 "remote",
                 "set-url",
                 "origin",
-                "git@github.com:acme/widget.git"
-            ]
-        ));
+                "git@github.com:acme/widget.git",
+            ],
+        );
     }
 
     // The grouping key DOES collide — this is what made #4063's approach unsafe.
@@ -153,16 +171,13 @@ fn sibling_clones_of_same_repo_derive_distinct_ids() {
 fn linked_worktrees_of_same_repo_derive_distinct_ids() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let main = tmp.path().join("repo");
-    if !init_repo(&main, "git@github.com:acme/widget.git") {
-        return;
-    }
+    init_repo(&main, "git@github.com:acme/widget.git");
+
     let wt_a = tmp.path().join("wt-a");
     let wt_b = tmp.path().join("wt-b");
     for (dir, branch) in [(&wt_a, "feat-a"), (&wt_b, "feat-b")] {
         let dir_arg = dir.to_string_lossy().into_owned();
-        if !git_ok(&main, &["worktree", "add", "-b", branch, &dir_arg]) {
-            return;
-        }
+        git(&main, &["worktree", "add", "-b", branch, &dir_arg]);
     }
 
     // Precondition: all three facets share the grouping key.
@@ -182,17 +197,17 @@ fn linked_worktrees_of_same_repo_derive_distinct_ids() {
     assert_ne!(ids[1], ids[2], "worktree A vs worktree B: {ids:?}");
 }
 
-/// Why: the account is the third component of the #4207 identity triple. Two
-/// checkouts that agree on origin and root but are operated by different GitHub
+/// Why: the operator is the third component of the #4207 identity triple. Two
+/// checkouts that agree on origin and root but are operated by different
 /// accounts must not share an index.
 /// Test: itself.
 #[test]
-fn different_gh_users_derive_distinct_ids() {
+fn different_operators_derive_distinct_ids() {
     let one = identity("acme", "widget", "/srv/widget", Some("a@example.test"));
     let two = identity("acme", "widget", "/srv/widget", Some("b@example.test"));
     assert_ne!(one.index_id(), two.index_id());
 
-    // An unresolved account must also be distinct from any resolved one — the
+    // An unresolved operator must also be distinct from any resolved one — the
     // presence tag in the digest preimage is what guarantees this.
     let none = identity("acme", "widget", "/srv/widget", None);
     assert_ne!(none.index_id(), one.index_id());
@@ -208,12 +223,12 @@ fn unrelated_projects_sharing_a_basename_derive_distinct_ids() {
     let a = ProjectIdentity {
         origin: None,
         root: PathBuf::from("/srv/alpha/docs"),
-        gh_user: None,
+        operator: None,
     };
     let b = ProjectIdentity {
         origin: None,
         root: PathBuf::from("/srv/beta/docs"),
-        gh_user: None,
+        operator: None,
     };
     assert_ne!(a.index_id(), b.index_id());
     // Both keep the readable label; only the digest separates them.
@@ -235,19 +250,118 @@ fn label_ambiguity_does_not_collide() {
 }
 
 // ---------------------------------------------------------------------------
+// Pinned DRIFT cases — one tree deriving different ids over time (PR #4262 HIGH)
+//
+// These are not bugs being fixed; they are known, accepted consequences of
+// deriving identity partly from mutable git state, pinned here so the migration
+// slice inherits a TRUE guarantee instead of a surprise. Each corresponds to a
+// row in the `Known limitation` table on `ProjectIdentity::index_id`. If one of
+// these ever starts asserting equality, the derivation changed and that table
+// is stale.
+// ---------------------------------------------------------------------------
+
+/// Why: a fresh `git init` has no remote AND no commits, so `origin` is `None`;
+/// the first commit gives `RepoIdentity` a root-commit hash to return. An index
+/// registered in that window is orphaned by the first commit.
+/// Test: itself.
+#[test]
+fn id_changes_when_first_commit_lands() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("nocommit");
+    init_empty_repo(&repo);
+
+    let before = ProjectIdentity::derive(&repo);
+    assert_eq!(before.origin, None, "no commits, no remote ⇒ no origin");
+
+    commit_file(&repo, "README.md", "hi");
+    let after = ProjectIdentity::derive(&repo);
+    assert!(
+        matches!(after.origin, Some(RepoIdentity::ContentHash(_))),
+        "first commit must yield a content-hash origin, got {:?}",
+        after.origin
+    );
+    assert_ne!(
+        before.index_id(),
+        after.index_id(),
+        "KNOWN DRIFT: the first commit re-derives the id for the same tree"
+    );
+}
+
+/// Why: the everyday `git init` → work → `gh repo create` sequence. It moves
+/// `origin` from `ContentHash` to `GitHub`, changing BOTH the label and the
+/// digest — so an index registered before the remote exists is silently
+/// orphaned the moment it is added, with no self-heal. This is the single most
+/// important row of the drift table for the migration slice.
+/// Test: itself.
+#[test]
+fn id_changes_when_origin_remote_is_added() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("nocommit");
+    init_empty_repo(&repo);
+    commit_file(&repo, "README.md", "hi");
+
+    let before = ProjectIdentity::derive(&repo);
+    assert!(matches!(before.origin, Some(RepoIdentity::ContentHash(_))));
+
+    git(
+        &repo,
+        &["remote", "add", "origin", "git@github.com:acme/widget.git"],
+    );
+    let after = ProjectIdentity::derive(&repo);
+    assert!(matches!(after.origin, Some(RepoIdentity::GitHub(_))));
+
+    assert_ne!(
+        before.index_id(),
+        after.index_id(),
+        "KNOWN DRIFT: adding the origin remote re-derives the id"
+    );
+    // The label changes too, not merely the digest.
+    assert!(before.index_id().starts_with("nocommit-"));
+    assert!(after.index_id().starts_with("acme-widget-"));
+}
+
+/// Why: for a remoteless repo the origin is the FIRST root-commit sha, so a new
+/// root commit (`git checkout --orphan`) moves it. Narrower than the two rows
+/// above — it needs a remoteless repo — but pinned for completeness.
+/// Test: itself.
+#[test]
+fn id_changes_on_orphan_root_commit() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("orphan");
+    init_empty_repo(&repo);
+    commit_file(&repo, "README.md", "hi");
+
+    let before = ProjectIdentity::derive(&repo);
+    git(&repo, &["checkout", "--orphan", "second-root"]);
+    commit_file(&repo, "OTHER.md", "other");
+    let after = ProjectIdentity::derive(&repo);
+
+    assert_ne!(
+        before.origin, after.origin,
+        "precondition: the root commit must actually have moved"
+    );
+    assert_ne!(
+        before.index_id(),
+        after.index_id(),
+        "KNOWN DRIFT: a new root commit re-derives the id for a remoteless repo"
+    );
+}
+
+// ---------------------------------------------------------------------------
 // Stability, degradation, and format
 // ---------------------------------------------------------------------------
 
-/// Why: an index id that changes between runs orphans the index it names. The
-/// derivation must be reproducible for an unchanged project.
+/// Why: an index id that changes between runs orphans the index it names. For an
+/// UNCHANGED project the derivation must be reproducible — the drift tests above
+/// enumerate exactly which changes are allowed to move it, and this pins that
+/// nothing else does.
 /// Test: itself.
 #[test]
 fn derivation_is_deterministic_across_calls() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let repo = tmp.path().join("repo");
-    if !init_repo(&repo, "git@github.com:acme/widget.git") {
-        return;
-    }
+    init_repo(&repo, "git@github.com:acme/widget.git");
+
     let first = derive_project_index_id(&repo);
     let second = derive_project_index_id(&repo);
     assert_eq!(first, second);
@@ -259,8 +373,9 @@ fn derivation_is_deterministic_across_calls() {
 
 /// Why: the id rule is a stored contract — every already-registered index is
 /// named by it. A golden value turns an accidental change to the framing, the
-/// hash, or the field order into a test failure instead of a silent mass
-/// orphaning. Update it ONLY together with `SCHEME_VERSION` and a migration.
+/// hash, the field order, or `SCHEME_VERSION` into a test failure instead of a
+/// silent mass orphaning. Update it ONLY together with `SCHEME_VERSION` and a
+/// migration.
 /// Test: itself.
 #[test]
 fn index_id_is_pinned_for_a_known_input() {
@@ -291,22 +406,21 @@ fn directory_without_git_origin_derives_stable_id() {
     assert_eq!(derive_project_index_id(&plain), id, "must be reproducible");
 }
 
-/// Why: two paths naming ONE content tree (a symlink and its target) must derive
-/// one id — otherwise a caller reaching the project through a symlinked path
-/// would create a second index over identical content.
+/// Why: two paths naming ONE content tree via a SYMLINK must derive one id —
+/// otherwise a caller reaching the project through a symlinked path would create
+/// a second index over identical content. Note the deliberately narrow scope:
+/// `canonicalize` does NOT resolve macOS firmlinks or Linux bind mounts, which
+/// [`ProjectIdentity::derive`] documents as a known limitation.
 /// Test: itself.
 #[cfg(unix)]
 #[test]
 fn symlinked_root_derives_same_id_as_real_root() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let real = tmp.path().join("repo");
-    if !init_repo(&real, "git@github.com:acme/widget.git") {
-        return;
-    }
+    init_repo(&real, "git@github.com:acme/widget.git");
+
     let link = tmp.path().join("repo-link");
-    if std::os::unix::fs::symlink(&real, &link).is_err() {
-        return;
-    }
+    std::os::unix::fs::symlink(&real, &link).expect("create symlink");
     assert_eq!(
         derive_project_index_id(&link),
         derive_project_index_id(&real)
@@ -345,7 +459,7 @@ fn empty_label_falls_back_to_placeholder() {
     let ident = ProjectIdentity {
         origin: None,
         root: PathBuf::from("/"),
-        gh_user: None,
+        operator: None,
     };
     assert_eq!(ident.label(), FALLBACK_LABEL);
     assert!(ident.index_id().starts_with("project-"));
@@ -353,7 +467,7 @@ fn empty_label_falls_back_to_placeholder() {
     let unicode = ProjectIdentity {
         origin: None,
         root: PathBuf::from("/srv/プロジェクト"),
-        gh_user: None,
+        operator: None,
     };
     assert!(unicode.index_id().starts_with("project-"));
     // Distinct roots still partition even when both fall back to the label.
@@ -389,25 +503,59 @@ fn digest_is_stable_for_identical_inputs() {
 }
 
 /// Why: per-account checkouts are configured with a repo-local `user.email`
-/// override, so the account component must honour git's repo-local-over-global
+/// override, so the operator component must honour git's repo-local-over-global
 /// precedence rather than reading only the global identity.
 /// Test: itself.
 #[test]
-fn resolve_gh_user_reads_repo_local_git_identity() {
-    if std::env::var("TRUSTY_GH_USER").is_ok() {
-        return; // an explicit override is in effect; the git path is shadowed
-    }
+fn resolve_operator_identity_prefers_repo_local_git_identity() {
     let tmp = tempfile::TempDir::new().expect("tempdir");
     let repo = tmp.path().join("repo");
-    if !init_repo(&repo, "git@github.com:acme/widget.git") {
-        return;
-    }
-    assert!(git_ok(
-        &repo,
-        &["config", "user.email", "local@example.test"]
-    ));
+    init_repo(&repo, "git@github.com:acme/widget.git");
+
+    git(&repo, &["config", "user.email", "local@example.test"]);
     assert_eq!(
-        resolve_gh_user(&repo),
+        resolve_operator_identity(&repo),
         Some("local@example.test".to_string())
+    );
+}
+
+/// Why: an earlier revision honoured a `TRUSTY_GH_USER` environment override,
+/// which let two live callers on the SAME tree at the SAME instant derive
+/// different ids purely from differing process environments (the trusty-mpm
+/// daemon's launchd env vs a `tm` CLI's shell env) — re-creating the #1373
+/// "callers silently diverge" failure this module exists to prevent. The
+/// override was REMOVED rather than merely tested; this pins that it is gone, so
+/// a future convenience re-adding an env read fails here instead of silently
+/// re-partitioning one tree into two indexes.
+///
+/// Asserted against the source text rather than by setting the variable:
+/// `std::env::set_var` is process-global (and `unsafe` in edition 2024), so a
+/// test that set it would corrupt every other test running in parallel.
+/// Test: itself.
+#[test]
+fn resolve_operator_identity_ignores_ambient_env_override() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    init_repo(&repo, "git@github.com:acme/widget.git");
+    git(&repo, &["config", "user.email", "local@example.test"]);
+    assert_eq!(
+        resolve_operator_identity(&repo),
+        Some("local@example.test".to_string()),
+        "the git identity is the only operator source"
+    );
+
+    // The production module must contain no environment read at all — an env
+    // lookup is exactly the non-hermetic branch that was removed.
+    let src = include_str!("project_index_id.rs");
+    let reads_env = src
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            !t.starts_with("//") && !t.starts_with("*")
+        })
+        .any(|l| l.contains("env::var") || l.contains("env!("));
+    assert!(
+        !reads_env,
+        "derivation must stay hermetic: no environment reads in project_index_id.rs"
     );
 }

--- a/crates/trusty-common/src/project_index_id_tests.rs
+++ b/crates/trusty-common/src/project_index_id_tests.rs
@@ -1,0 +1,413 @@
+//! Tests for [`super`] — project-derived index identity (#4207).
+//!
+//! Why: isolated in a sibling file (declared via `#[path = ...]` from
+//! `project_index_id.rs`, the pattern `search_index_tests.rs` already uses in
+//! this crate) so the derivation module stays inside the 500-SLOC production
+//! cap while the collision suite can be as exhaustive as the design demands.
+//! The cases below are not generic coverage — each one is a specific way
+//! #4063's grouping-key-as-partitioning-key approach was proven to collide.
+//!
+//! What: real synthetic git topologies (`git init`, `git clone`,
+//! `git worktree add` in temp dirs) for the cases that depend on git
+//! behaviour, and direct construction of [`ProjectIdentity`] for the cases
+//! that are pure. Nothing here touches a live daemon, the index registry, or
+//! any currently-registered index.
+//!
+//! Test: this file.
+
+use super::*;
+use crate::github_path::GithubPath;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Run a git subcommand in `dir`, reporting whether it succeeded.
+fn git_ok(dir: &Path, args: &[&str]) -> bool {
+    Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+/// Initialise a committed git repo at `dir` with `origin` pointing at `url`.
+///
+/// Returns `false` when git is unusable on this runner, so callers can skip
+/// cleanly rather than fail (matching `repo_identity`'s existing convention).
+fn init_repo(dir: &Path, url: &str) -> bool {
+    if std::fs::create_dir_all(dir).is_err() {
+        return false;
+    }
+    if !git_ok(dir, &["-c", "init.defaultBranch=main", "init"]) {
+        return false;
+    }
+    let _ = git_ok(dir, &["config", "user.email", "t@t.test"]);
+    let _ = git_ok(dir, &["config", "user.name", "t"]);
+    if std::fs::write(dir.join("README.md"), "hi").is_err() {
+        return false;
+    }
+    let _ = git_ok(dir, &["add", "."]);
+    if !git_ok(dir, &["commit", "-m", "init"]) {
+        return false;
+    }
+    git_ok(dir, &["remote", "add", "origin", url])
+}
+
+/// A pure identity with every field supplied — no filesystem, no git.
+fn identity(owner: &str, repo: &str, root: &str, gh_user: Option<&str>) -> ProjectIdentity {
+    ProjectIdentity {
+        origin: Some(RepoIdentity::GitHub(GithubPath {
+            owner: owner.into(),
+            repo: repo.into(),
+        })),
+        root: PathBuf::from(root),
+        gh_user: gh_user.map(str::to_string),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The collision cases that killed #4063
+// ---------------------------------------------------------------------------
+
+/// Why: THE case #4063 never fixed. Two independent clones of one repo are each
+/// a main working tree, so no worktree suffix applies and the origin-derived
+/// grouping key is identical — yet they are two different content trees, on
+/// possibly different branches. Under a one-`root_path`-per-id registry, sharing
+/// an id means the second clone's registration silently degrades to a *find*
+/// against the first clone's root and every subsequent search, reindex, and
+/// incremental update targets the wrong tree. This test asserts both halves:
+/// the grouping key really does collide (so the test is exercising the real
+/// hazard, not a strawman) and the derived index ids nonetheless do not.
+/// Test: itself.
+#[test]
+fn sibling_clones_of_same_repo_derive_distinct_ids() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let upstream = tmp.path().join("origin.git");
+    if std::fs::create_dir_all(&upstream).is_err() || !git_ok(&upstream, &["init", "--bare"]) {
+        return; // no usable git on this runner
+    }
+    let upstream_url = upstream.to_string_lossy().into_owned();
+    let seed = tmp.path().join("seed");
+    if !init_repo(&seed, &upstream_url) {
+        return;
+    }
+    if !git_ok(&seed, &["push", "origin", "HEAD:refs/heads/main"]) {
+        return;
+    }
+
+    // Two real clones at different paths, both re-pointed at the same GitHub
+    // origin — exactly the topology proven to collide on #4063.
+    let a = tmp.path().join("widget");
+    let b = tmp.path().join("widget-review");
+    for dest in [&a, &b] {
+        let dest_arg = dest.to_string_lossy().into_owned();
+        let ok = Command::new("git")
+            .args(["clone", &upstream_url, &dest_arg])
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        if !ok {
+            return;
+        }
+        assert!(git_ok(
+            dest,
+            &[
+                "remote",
+                "set-url",
+                "origin",
+                "git@github.com:acme/widget.git"
+            ]
+        ));
+    }
+
+    // The grouping key DOES collide — this is what made #4063's approach unsafe.
+    let group_a = RepoIdentity::derive(&a).map(|r| r.canonical());
+    let group_b = RepoIdentity::derive(&b).map(|r| r.canonical());
+    assert_eq!(
+        group_a, group_b,
+        "precondition: sibling clones must share the repo-level grouping key"
+    );
+    assert_eq!(group_a, Some("acme/widget".to_string()));
+
+    // The partitioning key does NOT.
+    let id_a = derive_project_index_id(&a);
+    let id_b = derive_project_index_id(&b);
+    assert_ne!(
+        id_a, id_b,
+        "sibling clones are distinct content trees and must not share an index id"
+    );
+    // Both still carry the readable repo label.
+    assert!(id_a.starts_with("acme-widget-"), "unexpected id: {id_a}");
+    assert!(id_b.starts_with("acme-widget-"), "unexpected id: {id_b}");
+}
+
+/// Why: the second collision #4063 hit. `git config remote.origin.url` read from
+/// a linked worktree transparently returns the SHARED repo config, so every
+/// worktree of one repo derives the same origin. Under the 1.3.0 one-worktree-
+/// per-writing-agent model this is the common case, not an edge case.
+/// Test: itself.
+#[test]
+fn linked_worktrees_of_same_repo_derive_distinct_ids() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let main = tmp.path().join("repo");
+    if !init_repo(&main, "git@github.com:acme/widget.git") {
+        return;
+    }
+    let wt_a = tmp.path().join("wt-a");
+    let wt_b = tmp.path().join("wt-b");
+    for (dir, branch) in [(&wt_a, "feat-a"), (&wt_b, "feat-b")] {
+        let dir_arg = dir.to_string_lossy().into_owned();
+        if !git_ok(&main, &["worktree", "add", "-b", branch, &dir_arg]) {
+            return;
+        }
+    }
+
+    // Precondition: all three facets share the grouping key.
+    let group: Vec<_> = [&main, &wt_a, &wt_b]
+        .into_iter()
+        .map(|d| RepoIdentity::derive(d).map(|r| r.canonical()))
+        .collect();
+    assert_eq!(group[0], group[1]);
+    assert_eq!(group[1], group[2]);
+
+    let ids: Vec<String> = [&main, &wt_a, &wt_b]
+        .into_iter()
+        .map(|d| derive_project_index_id(d))
+        .collect();
+    assert_ne!(ids[0], ids[1], "main checkout vs worktree A: {ids:?}");
+    assert_ne!(ids[0], ids[2], "main checkout vs worktree B: {ids:?}");
+    assert_ne!(ids[1], ids[2], "worktree A vs worktree B: {ids:?}");
+}
+
+/// Why: the account is the third component of the #4207 identity triple. Two
+/// checkouts that agree on origin and root but are operated by different GitHub
+/// accounts must not share an index.
+/// Test: itself.
+#[test]
+fn different_gh_users_derive_distinct_ids() {
+    let one = identity("acme", "widget", "/srv/widget", Some("a@example.test"));
+    let two = identity("acme", "widget", "/srv/widget", Some("b@example.test"));
+    assert_ne!(one.index_id(), two.index_id());
+
+    // An unresolved account must also be distinct from any resolved one — the
+    // presence tag in the digest preimage is what guarantees this.
+    let none = identity("acme", "widget", "/srv/widget", None);
+    assert_ne!(none.index_id(), one.index_id());
+    assert_ne!(none.index_id(), two.index_id());
+}
+
+/// Why: the original defect this epic exists to fix — the bare-basename id
+/// collides for any two unrelated projects whose directories share a name
+/// (`docs`, `web`, `api` are the everyday cases).
+/// Test: itself.
+#[test]
+fn unrelated_projects_sharing_a_basename_derive_distinct_ids() {
+    let a = ProjectIdentity {
+        origin: None,
+        root: PathBuf::from("/srv/alpha/docs"),
+        gh_user: None,
+    };
+    let b = ProjectIdentity {
+        origin: None,
+        root: PathBuf::from("/srv/beta/docs"),
+        gh_user: None,
+    };
+    assert_ne!(a.index_id(), b.index_id());
+    // Both keep the readable label; only the digest separates them.
+    assert!(a.index_id().starts_with("docs-"));
+    assert!(b.index_id().starts_with("docs-"));
+}
+
+/// Why: #4063 shipped a bare `format!("{owner}-{repo}")` join, so `foo-bar`/`baz`
+/// and `foo`/`bar-baz` produced one id for two different repos. The label here is
+/// deliberately allowed to collide; the length-framed digest preimage is what
+/// must not.
+/// Test: itself.
+#[test]
+fn label_ambiguity_does_not_collide() {
+    let a = identity("foo-bar", "baz", "/srv/x", None);
+    let b = identity("foo", "bar-baz", "/srv/x", None);
+    assert_eq!(a.label(), b.label(), "precondition: labels collide");
+    assert_ne!(a.index_id(), b.index_id(), "digests must not collide");
+}
+
+// ---------------------------------------------------------------------------
+// Stability, degradation, and format
+// ---------------------------------------------------------------------------
+
+/// Why: an index id that changes between runs orphans the index it names. The
+/// derivation must be reproducible for an unchanged project.
+/// Test: itself.
+#[test]
+fn derivation_is_deterministic_across_calls() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    if !init_repo(&repo, "git@github.com:acme/widget.git") {
+        return;
+    }
+    let first = derive_project_index_id(&repo);
+    let second = derive_project_index_id(&repo);
+    assert_eq!(first, second);
+    // A nested subdirectory resolves to the same project root, hence same id.
+    let nested = repo.join("src/deep");
+    std::fs::create_dir_all(&nested).expect("nested dir");
+    assert_eq!(derive_project_index_id(&nested), first);
+}
+
+/// Why: the id rule is a stored contract — every already-registered index is
+/// named by it. A golden value turns an accidental change to the framing, the
+/// hash, or the field order into a test failure instead of a silent mass
+/// orphaning. Update it ONLY together with `SCHEME_VERSION` and a migration.
+/// Test: itself.
+#[test]
+fn index_id_is_pinned_for_a_known_input() {
+    let pinned = identity(
+        "bobmatnyc",
+        "trusty-tools",
+        "/Users/me/code/trusty-tools",
+        Some("bob@example.test"),
+    );
+    assert_eq!(pinned.index_id(), "bobmatnyc-trusty-tools-f3ef22158eced5cb");
+}
+
+/// Why: a directory with no git origin at all (scratch dirs, unpacked archives)
+/// must still receive a stable, well-formed id rather than panicking or
+/// degrading to the empty string.
+/// Test: itself.
+#[test]
+fn directory_without_git_origin_derives_stable_id() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let plain = tmp.path().join("loose-files");
+    std::fs::create_dir_all(&plain).expect("dir");
+
+    let ident = ProjectIdentity::derive(&plain);
+    assert_eq!(ident.origin, None, "no git repo means no grouping key");
+
+    let id = ident.index_id();
+    assert!(id.starts_with("loose-files-"), "unexpected id: {id}");
+    assert_eq!(derive_project_index_id(&plain), id, "must be reproducible");
+}
+
+/// Why: two paths naming ONE content tree (a symlink and its target) must derive
+/// one id — otherwise a caller reaching the project through a symlinked path
+/// would create a second index over identical content.
+/// Test: itself.
+#[cfg(unix)]
+#[test]
+fn symlinked_root_derives_same_id_as_real_root() {
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let real = tmp.path().join("repo");
+    if !init_repo(&real, "git@github.com:acme/widget.git") {
+        return;
+    }
+    let link = tmp.path().join("repo-link");
+    if std::os::unix::fs::symlink(&real, &link).is_err() {
+        return;
+    }
+    assert_eq!(
+        derive_project_index_id(&link),
+        derive_project_index_id(&real)
+    );
+}
+
+/// Why: the id is interpolated into an axum `/indexes/{id}` route and into
+/// filenames; a slash, space, or uppercase byte would break routing or produce
+/// two ids that differ only by case.
+/// Test: itself.
+#[test]
+fn index_id_is_a_single_url_safe_segment() {
+    let id = identity("Acme Corp", "My_Widget!", "/srv/x", Some("a@b.test")).index_id();
+    assert!(!id.is_empty());
+    assert!(
+        id.chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+        "id must be lowercase alnum + hyphen: {id}"
+    );
+    assert!(
+        !id.starts_with('-') && !id.ends_with('-'),
+        "bad edges: {id}"
+    );
+    assert!(
+        id.starts_with("acme-corp-my-widget-"),
+        "unexpected id: {id}"
+    );
+}
+
+/// Why: a project that slugifies to nothing (a filesystem root, or a purely
+/// non-ASCII directory name) must not yield an id that begins with the digest
+/// separator or is otherwise malformed.
+/// Test: itself.
+#[test]
+fn empty_label_falls_back_to_placeholder() {
+    let ident = ProjectIdentity {
+        origin: None,
+        root: PathBuf::from("/"),
+        gh_user: None,
+    };
+    assert_eq!(ident.label(), FALLBACK_LABEL);
+    assert!(ident.index_id().starts_with("project-"));
+
+    let unicode = ProjectIdentity {
+        origin: None,
+        root: PathBuf::from("/srv/プロジェクト"),
+        gh_user: None,
+    };
+    assert!(unicode.index_id().starts_with("project-"));
+    // Distinct roots still partition even when both fall back to the label.
+    assert_ne!(ident.index_id(), unicode.index_id());
+}
+
+/// Why: a very long owner/repo pair must not produce an unbounded id; the label
+/// truncates while the digest keeps uniqueness intact.
+/// Test: itself.
+#[test]
+fn long_label_is_truncated_without_losing_uniqueness() {
+    let long = "x".repeat(200);
+    let a = identity(&long, "repo", "/srv/a", None);
+    let b = identity(&long, "repo", "/srv/b", None);
+    let (id_a, id_b) = (a.index_id(), b.index_id());
+    assert_eq!(a.label().chars().count(), MAX_LABEL_LEN);
+    assert_ne!(id_a, id_b);
+    assert_eq!(id_a.len(), MAX_LABEL_LEN + 1 + 16);
+}
+
+/// Why: the digest is the whole uniqueness guarantee; identical inputs must
+/// produce an identical value within and across processes.
+/// Test: itself.
+#[test]
+fn digest_is_stable_for_identical_inputs() {
+    let a = identity("acme", "widget", "/srv/x", Some("a@b.test"));
+    let b = identity("acme", "widget", "/srv/x", Some("a@b.test"));
+    assert_eq!(a.digest(), b.digest());
+    assert_eq!(a.index_id(), b.index_id());
+    // fnv1a_64 itself: same bytes in, same value out; different bytes, different.
+    assert_eq!(fnv1a_64(b"abc"), fnv1a_64(b"abc"));
+    assert_ne!(fnv1a_64(b"abc"), fnv1a_64(b"abd"));
+}
+
+/// Why: per-account checkouts are configured with a repo-local `user.email`
+/// override, so the account component must honour git's repo-local-over-global
+/// precedence rather than reading only the global identity.
+/// Test: itself.
+#[test]
+fn resolve_gh_user_reads_repo_local_git_identity() {
+    if std::env::var("TRUSTY_GH_USER").is_ok() {
+        return; // an explicit override is in effect; the git path is shadowed
+    }
+    let tmp = tempfile::TempDir::new().expect("tempdir");
+    let repo = tmp.path().join("repo");
+    if !init_repo(&repo, "git@github.com:acme/widget.git") {
+        return;
+    }
+    assert!(git_ok(
+        &repo,
+        &["config", "user.email", "local@example.test"]
+    ));
+    assert_eq!(
+        resolve_gh_user(&repo),
+        Some("local@example.test".to_string())
+    );
+}


### PR DESCRIPTION
Epic #4207, Track B — **the identity-derivation slice only.** Registry
reconciliation and migration of the ~7 currently-registered indexes are
deliberately deferred to separate slices. **Nothing is wired over** in this PR.

## Why the previous attempt failed, and what changed

PR #4063 was closed won't-do after three BLOCK rounds. The root cause was a
design error, not a bug queue: it promoted `RepoIdentity` — whose own module doc
states it is a **GROUPING** key, deliberately shared across every facet of one
repo — into the **PARTITIONING** slot that trusty-search's
one-`root_path`-per-id registry requires. Each review round found another pair of
genuinely different roots sharing that value: linked worktrees (patched with a
worktree-name suffix), sibling clones of one repo (never fixed, proven live), and
the daemon-unreachable path resolving forward onto the new id.

This derivation **partitions by construction** rather than by patching cases: the
canonical content-tree root path is a hashed component of every id, so two
distinct trees can never collide however their git metadata relates. The grouping
key is retained as a *component* and as the public `ProjectIdentity::origin`
field — not as the whole id.

## What this adds

`crates/trusty-common/src/project_index_id.rs`:

- `ProjectIdentity { origin, root, gh_user }` — the three-part identity the owner
  specified on #4207. `origin` = which repository (grouping, via `RepoIdentity`);
  `root` = which content tree of it (**the partitioning component**); `gh_user` =
  which account operates it.
- `ProjectIdentity::derive()` — the single I/O entry point (git shell-outs + one
  `canonicalize`), offline, best-effort, never panics.
- `ProjectIdentity::index_id()` — **pure**. `<label>-<16 hex>`, e.g.
  `bobmatnyc-trusty-tools-f3ef22158eced5cb`. Because it is pure, every collision
  case is testable with no daemon, no registry, and no live state — and
  resolution can never depend on mutable daemon state, which is what made
  #4063's alias-fallback fragile.
- `derive_project_index_id()`, `resolve_gh_user()`.

Not a worktree UUID (explicitly ruled out by the owner), and not the bare
basename.

**Placement:** `trusty-common`, beside the `index_id` / `repo_identity` /
`github_path` / `slug` modules it builds on rather than duplicates. Index ids are
computed by trusty-mpm, trusty-search, trusty-review and trusty-code, which is
the same single-source-of-truth reason `index_id` was hoisted here in #1373. It
is **unconditional** (not feature-gated) — an identity that varies with a feature
flag is worse than no identity.

**Note on the epic's scope note:** it directs reusing "the shared project
registry's existing function". That function does not exist. Verified:
`project::record::derive_name_from_url` keys purely on the repo-URL basename (no
root, no gh user) and `RepoIdentity::derive` is origin-only. Neither takes three
inputs. This was built, not wired up.

## Collision cases tested

Real synthetic git topologies (`git init` / `git clone` / `git worktree add` in
temp dirs), 14 tests, all passing:

| Case | Test |
|---|---|
| **Sibling clones of one repo** — the case #4063 never fixed | `sibling_clones_of_same_repo_derive_distinct_ids` |
| Linked worktrees of one repo | `linked_worktrees_of_same_repo_derive_distinct_ids` |
| Same repo, different gh users | `different_gh_users_derive_distinct_ids` |
| Directory with no git origin | `directory_without_git_origin_derives_stable_id` |
| Unrelated projects sharing a basename (the original defect) | `unrelated_projects_sharing_a_basename_derive_distinct_ids` |
| Non-injective `{owner}-{repo}` join (#4063 MEDIUM) | `label_ambiguity_does_not_collide` |
| Symlinked root ⇒ *same* id (one tree, one index) | `symlinked_root_derives_same_id_as_real_root` |
| Determinism across calls / from a nested subdir | `derivation_is_deterministic_across_calls` |
| Frozen golden id (guards the stored contract) | `index_id_is_pinned_for_a_known_input` |
| URL-safe single path segment | `index_id_is_a_single_url_safe_segment` |

The two git-topology tests assert **both halves**: that the repo-level grouping
key genuinely *does* collide for those roots (so the test exercises the real
hazard, not a strawman) and that the derived index ids nonetheless do not.

The digest preimage is length-framed with presence tags — closing the
non-injective join flagged on #4063 — and carries a `SCHEME_VERSION` so a future
rule change becomes a distinct id space rather than a silent re-point.

## Explicitly out of scope

- Registry reconciliation (dual-registry) — separate slice.
- Migration of currently-registered indexes — separate slice. **No live index is
  renamed or re-registered by this PR.**
- Wiring into `ensure_project_indexed`, `trusty-search serve`, or the daemon's
  resolution path. Switching over without migration is exactly how #4063 orphaned
  sessions. `git grep` confirms zero call sites outside the new module.

**Constraint documented for the migration slice** (in the module header, not
implemented here): migration must be rename/alias, never re-index (~105k chunks /
2.1 GB redb for this workspace alone), and must fail **SAFE** — fall back to the
known-good legacy id when the daemon or persisted registry cannot be consulted,
**never** forward onto an id that does not exist yet. #4063 failed forward at
`search_index.rs:106-108` and silently orphaned a session's search for its entire
life with no self-heal.

The module also notes the interaction with the epic's self-description item: an
always-suffixed id is not guessable from the project name, which is deliberate
(a guessable id cannot partition). MCP `instructions`-at-initialize and the
`404` → available-index signpost are the complementary fix; neither substitutes
for the other.

## Gates (SPRINT phase, crate-scoped)

```
cargo test -p trusty-common --lib -- project_index_id
  test result: ok. 14 passed; 0 failed; 0 ignored; 203 filtered out

cargo test -p trusty-common
  test result: ok. 211 passed; 0 failed; 6 ignored          (exit 0)

cargo clippy -p trusty-common --all-targets -- -D warnings   exit 0
cargo fmt --check                                            exit 0
bash scripts/check_line_cap.sh
  line-cap: 7 allowlisted, 0 violations — OK.                exit 0

cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui
  Finished `dev` profile                                     exit 0
```

The two excluded crates are Tauri GUIs that fail on a missing prebuilt
`ui/dist` (`frontendDist ... doesn't exist`) — pre-existing and environmental,
unrelated to this change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools