### PR TITLE
fix(trusty-agents): apply the hidden filter on the subagents delegation surface (#4235)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -49,6 +49,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   to `>=0.21.1, <0.22.0` and would not have admitted the new version. Requirement
   edit only — this crate's own version is unchanged.
 
+### Fixed
+
+- **The Sub-agents pane no longer offers `hidden` agents as delegation targets
+  (#4235).** `GET /api/agents/:name/subagents` filtered its in-product target
+  list by role and by the kind/tier gate but never by `hidden`, so
+  `assistant`, `personal-assistant` and `researcher` — all `hidden = true`
+  since #3819 — leaked back in as target cards, rendering a SECOND row
+  display-labelled "Izzie" beside `izzie`. The pane now applies the same
+  `!hidden` filter the picker/roster applies, through the same
+  `projects::is_hidden` predicate (promoted from private to `pub(super)`
+  rather than reimplemented, so the two surfaces cannot drift). A hidden agent
+  is OMITTED rather than shown with a reason — `hidden` is a listing-surface
+  flag, not a gate, and a labelled row would still draw the duplicate and
+  would name an id the pane's no-roster-dump posture keeps unnamed. It is
+  counted instead, in a new `in_product.hidden_excluded_count`, disjoint from
+  `role_excluded_count`, which keeps its existing meaning unchanged. The pane
+  renders that count on its own line ("N further agent(s) … are hidden"), so
+  the omission is stated rather than silent, and the two exclusion reasons stay
+  separate — they have different remedies. This weakens no gate: `hidden` has
+  only ever governed visibility, and delegating to a hidden agent by name is
+  unaffected.
+
 ### Security
 
 - **Delegation authority is now governed by agent KIND, not by tier order

--- a/crates/trusty-agents/src/api/server/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/agent_subagents.rs
@@ -53,10 +53,13 @@
 //!   and EMPTY target lists — never a guess assembled from a partial parse. An
 //!   agent whose config does not resolve does not run, so "it may delegate to
 //!   nothing" is the truthful answer as well as the safe one.
-//! - **The roster is not dumped.** Only role-ELIGIBLE agents become target
-//!   cards; everything else is counted (`role_excluded_count`), never named,
-//!   preserving the #3052 PR A CRITICAL-2 posture that the delegation surface
-//!   does not enumerate internal agent ids.
+//! - **The roster is not dumped.** Only role-ELIGIBLE, NON-HIDDEN agents become
+//!   target cards; everything else is counted (`role_excluded_count`,
+//!   `hidden_excluded_count`), never named, preserving the #3052 PR A
+//!   CRITICAL-2 posture that the delegation surface does not enumerate internal
+//!   agent ids. The `hidden` half is #4235: this pane is a LISTING surface and
+//!   must apply the same `!hidden` filter `projects::apply_roster_filters`
+//!   applies to the picker, via the same `projects::is_hidden` predicate.
 //!
 //! What: [`agent_subagents_route`] is the axum shim; [`subagents_at`] is the
 //! testable core. Unlike its four sibling section routes this one resolves
@@ -219,16 +222,33 @@ pub(super) async fn subagents_at(
 /// because the gate refuses those too (`Err` ⇒ `rejected`) and a target that
 /// silently vanished from the pane looks identical to one that was never
 /// declared.
+///
+/// The ONE candidate that IS dropped rather than reported is a `hidden` one
+/// (#4235). That is deliberate and is the exception the paragraph above does
+/// not cover: `hidden` is a LISTING-surface flag (`AgentInfo::hidden`), not a
+/// gate, so a hidden agent is not "refused by the gate with a reason to show"
+/// — it is an agent the operator removed from listing surfaces entirely.
+/// Rendering it as a card carrying a "hidden" reason would name the very id
+/// that was suppressed (against the module doc's no-roster-dump rule) and
+/// would still draw the duplicate "Izzie" row #3819 removed from the picker.
+/// So it is omitted and COUNTED in `hidden_excluded_count`, exactly the
+/// "counted but never named" treatment `role_excluded_count` already gives.
+/// The two counts are disjoint: `hidden` is checked first, so a hidden
+/// candidate never reaches the role check, and `role_excluded_count` keeps its
+/// pre-#4235 meaning of "role not in the allowlist" unchanged.
 /// What: `{mechanism, tool, tool_registered, tool_granted, delegator_tier,
-/// allowed_roles, targets, role_excluded_count, unresolved}`. `targets` carries
-/// only role-eligible agents (see the module doc's no-roster-dump rule), each
-/// with `reachable` plus a `reason` when refused. The agent itself is excluded:
-/// self-delegation is not a configuration surface.
+/// allowed_roles, targets, role_excluded_count, hidden_excluded_count,
+/// unresolved}`. `targets` carries only non-hidden, role-eligible agents (see
+/// the module doc's no-roster-dump rule), each with `reachable` plus a `reason`
+/// when refused. The agent itself is excluded: self-delegation is not a
+/// configuration surface.
 /// Test: `subagents_route_reports_both_mechanisms_for_an_assistant`,
 /// `subagents_route_hides_l0_target_from_l1_delegator`,
 /// `subagents_route_shows_l0_target_to_l0_delegator`,
 /// `subagents_route_reports_tool_not_registered_for_a_worker_role`,
-/// `subagents_route_reports_unresolvable_target_rather_than_dropping_it`.
+/// `subagents_route_reports_unresolvable_target_rather_than_dropping_it`,
+/// `subagents_route_omits_a_hidden_delegation_target`,
+/// `subagents_route_hidden_filter_leaves_the_role_count_untouched`.
 async fn in_product_surface(
     dirs: &[PathBuf],
     self_name: &str,
@@ -239,12 +259,23 @@ async fn in_product_surface(
     let mut targets: Vec<Value> = Vec::new();
     let mut unresolved: Vec<Value> = Vec::new();
     let mut role_excluded_count: usize = 0;
+    let mut hidden_excluded_count: usize = 0;
 
     for entry in super::projects::scan_agent_catalog(dirs).await {
         let Some(candidate) = entry.get("name").and_then(Value::as_str) else {
             continue;
         };
         if candidate.eq_ignore_ascii_case(self_name) {
+            continue;
+        }
+        // #4235: this pane is a listing surface, so it applies the SAME
+        // `!hidden` filter the picker applies via `apply_roster_filters` —
+        // through the same `projects::is_hidden` predicate on the same catalog
+        // entry, never a second copy of the check. Checked BEFORE resolution
+        // so a hidden agent is not named in `unresolved` either; counted, not
+        // named (see this fn's doc comment for the omit-not-label reasoning).
+        if super::projects::is_hidden(&entry) {
+            hidden_excluded_count += 1;
             continue;
         }
         match AgentConfig::by_name_in(dirs, candidate) {
@@ -323,6 +354,10 @@ async fn in_product_surface(
         "allowed_roles": ASSISTANT_ALLOWED_DELEGATE_ROLES,
         "targets": targets,
         "role_excluded_count": role_excluded_count,
+        // #4235: hidden candidates are counted here and NOT in
+        // `role_excluded_count`, so neither number double-counts and the pane
+        // can still say "N agents are not shown" truthfully.
+        "hidden_excluded_count": hidden_excluded_count,
         "unresolved": unresolved,
     })
 }
@@ -433,6 +468,10 @@ fn empty_in_product() -> Value {
         "allowed_roles": ASSISTANT_ALLOWED_DELEGATE_ROLES,
         "targets": Vec::<Value>::new(),
         "role_excluded_count": 0,
+        // #4235: keep the degraded payload's key set identical to the real
+        // one, or a pane reading `hidden_excluded_count` blanks out on a
+        // config error instead of rendering zero.
+        "hidden_excluded_count": 0,
         "unresolved": Vec::<Value>::new(),
     })
 }
@@ -475,6 +514,11 @@ mod unit_tests {
         assert_eq!(ip["tool_registered"], false);
         assert_eq!(ip["delegator_tier"], "l1", "fail-closed to the L1 default");
         assert!(ip["targets"].as_array().unwrap().is_empty());
+        // #4235: both suppression counters must be PRESENT (as zero), not
+        // absent — a pane keying off `hidden_excluded_count` would otherwise
+        // render `undefined` on the degraded payload.
+        assert_eq!(ip["role_excluded_count"], 0);
+        assert_eq!(ip["hidden_excluded_count"], 0);
 
         let cp = empty_cross_product();
         assert_eq!(cp["mechanism"], "cross_product");

--- a/crates/trusty-agents/src/api/server/projects.rs
+++ b/crates/trusty-agents/src/api/server/projects.rs
@@ -281,7 +281,29 @@ pub(super) fn is_assistant_role(v: &serde_json::Value) -> bool {
 /// True when a parsed catalog entry's `hidden` field is exactly `true`.
 /// Absent/non-bool defaults to `false` (visible) — see `AgentInfo::hidden`'s
 /// doc comment.
-fn is_hidden(v: &serde_json::Value) -> bool {
+///
+/// Why `pub(super)` rather than private to this module (#4235): this predicate
+/// is THE single decision point for "does this agent appear on a listing
+/// surface", and it now has a second caller —
+/// `super::agent_subagents::in_product_surface`, the Sub-agents pane. That
+/// pane shipped without any `hidden` filter, so `assistant`,
+/// `personal-assistant` and `researcher` (all `hidden = true`) leaked back in
+/// as delegation-target cards, rendering the duplicate "Izzie" row #3819's
+/// `hidden` flag was added to remove. Promoting this fn to the parent module
+/// keeps BOTH surfaces on one implementation: a second `v["hidden"]` read
+/// would be free to drift (and this repo treats a second independent
+/// implementation of a shared capability as a defect). It reads the SAME
+/// catalog `Value` shape both surfaces already enumerate via
+/// [`scan_agent_catalog`], so the pane and the picker cannot disagree about
+/// which agents are hidden.
+/// What: reads `v["hidden"]` as a bool; anything absent or non-bool is
+/// `false`. Pure; no side effects. Governs VISIBILITY only — a hidden agent is
+/// still fully resolvable and dispatchable by name (see `AgentInfo::hidden`),
+/// so this is not a security gate and filtering by it weakens nothing.
+/// Test: `apply_roster_filters_excludes_hidden_assistant`,
+/// `apply_roster_filters_includes_visible_assistant`,
+/// `super::tests::agent_subagents::subagents_route_omits_a_hidden_delegation_target`.
+pub(super) fn is_hidden(v: &serde_json::Value) -> bool {
     v.get("hidden").and_then(|h| h.as_bool()).unwrap_or(false)
 }
 

--- a/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
@@ -92,6 +92,36 @@ content = "test"
     .unwrap();
 }
 
+/// Write an agent TOML carrying `hidden = true` in `[agent]` (#4235).
+///
+/// Kept separate from [`write_agent`] rather than adding a seventh parameter:
+/// only the #4235 tests care about `hidden`, and threading `Option<bool>`
+/// through the other eleven call sites would make every existing fixture read
+/// as if visibility were part of what it is testing.
+fn write_hidden_agent(dir: &std::path::Path, name: &str, role: &str) {
+    std::fs::write(
+        dir.join(format!("{name}.toml")),
+        format!(
+            r#"
+[agent]
+name = "{name}"
+role = "{role}"
+model = "anthropic/claude-sonnet-4-6"
+description = "test fixture"
+hidden = true
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "test"
+"#
+        ),
+    )
+    .unwrap();
+}
+
 async fn body_json(resp: axum::response::Response) -> serde_json::Value {
     let bytes = axum::body::to_bytes(resp.into_body(), 4 * 1024 * 1024)
         .await
@@ -551,6 +581,99 @@ content = "test"
         research["granted"], true,
         "an inherited [subagents].allowed grant is enforced, so it must be shown: {body:?}"
     );
+}
+
+/// #4235, the reported bug: the pane offered `hidden = true` agents as
+/// delegation targets, so `personal-assistant` (hidden since #3819 precisely
+/// to remove it from listings) rendered a SECOND "Izzie" row beside `izzie`.
+/// A hidden agent must be omitted from `targets` entirely — not shown with a
+/// "hidden" reason, which would still draw the duplicate row AND name an id
+/// the module doc's no-roster-dump rule keeps unnamed — while a non-hidden
+/// agent of the same role is still offered.
+#[tokio::test]
+async fn subagents_route_omits_a_hidden_delegation_target() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent(
+        dir.path(),
+        "assistant-subject",
+        "assistant",
+        None,
+        &["delegate_to_agent"],
+        None,
+    );
+    // The visible control: same role as the hidden peer below, so the ONLY
+    // difference between them is the `hidden` flag.
+    write_agent(dir.path(), "izzie", "assistant", None, &[], None);
+    write_hidden_agent(dir.path(), "personal-assistant", "assistant");
+    // A hidden agent whose role IS delegable as a sub-agent — proves the
+    // filter is not accidentally piggybacking on the peer-assistant kind rule.
+    write_hidden_agent(dir.path(), "researcher", "researcher");
+    write_agent(dir.path(), "engineer", "engineer", None, &[], None);
+
+    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant-subject", dir.path()).await;
+    let body = body_json(resp).await;
+    let ip = &body["in_product"];
+
+    let named: Vec<&str> = ip["targets"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(
+        !named.contains(&"personal-assistant"),
+        "a hidden agent must not be a delegation-target card: {named:?}"
+    );
+    assert!(
+        !named.contains(&"researcher"),
+        "a hidden agent must not be a delegation-target card: {named:?}"
+    );
+    // …and it is not leaked through the OTHER naming channel either.
+    let unresolved: Vec<&str> = ip["unresolved"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["name"].as_str().unwrap())
+        .collect();
+    assert!(unresolved.is_empty(), "{unresolved:?}");
+
+    // Not a blanket suppression: visible agents of both roles still appear,
+    // so this is the `hidden` flag doing the work and nothing else.
+    assert!(named.contains(&"izzie"), "{named:?}");
+    assert!(named.contains(&"engineer"), "{named:?}");
+
+    // Counted, never named — the `role_excluded_count` treatment.
+    assert_eq!(
+        ip["hidden_excluded_count"], 2,
+        "personal-assistant + researcher: {ip:?}"
+    );
+}
+
+/// The two suppression counters must stay DISJOINT: adding a hidden agent may
+/// not move `role_excluded_count`, or the pane double-counts and its "N agents
+/// are not shown" line stops being true.
+#[tokio::test]
+async fn subagents_route_hidden_filter_leaves_the_role_count_untouched() {
+    let dir = tempfile::tempdir().unwrap();
+    standard_roster(dir.path());
+
+    // Baseline: the roster's two role-ineligible agents (pm, ticketing-agent)
+    // and nothing hidden.
+    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
+    let ip = body_json(resp).await["in_product"].clone();
+    assert_eq!(ip["role_excluded_count"], 2);
+    assert_eq!(ip["hidden_excluded_count"], 0);
+
+    // A hidden agent whose role is ALSO ineligible must land in exactly one
+    // bucket — the hidden one, because `hidden` is checked first.
+    write_hidden_agent(dir.path(), "ghost", "orchestrator");
+    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
+    let ip = body_json(resp).await["in_product"].clone();
+    assert_eq!(
+        ip["role_excluded_count"], 2,
+        "the role count keeps its pre-#4235 meaning: {ip:?}"
+    );
+    assert_eq!(ip["hidden_excluded_count"], 1, "{ip:?}");
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigPanel.test.ts
@@ -156,6 +156,7 @@ const SUBAGENTS_PAYLOAD = {
       },
     ],
     role_excluded_count: 2,
+    hidden_excluded_count: 0,
     unresolved: [],
   },
   cross_product: {
@@ -184,6 +185,7 @@ const BARE_SUBAGENTS_PAYLOAD = {
     allowed_roles: ['engineer', 'qa', 'researcher', 'documentation', 'ops', 'planner', 'assistant'],
     targets: [],
     role_excluded_count: 0,
+    hidden_excluded_count: 0,
     unresolved: [],
   },
   cross_product: {

--- a/crates/trusty-agents/ui/src/components/AgentConfigSubagents.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSubagents.svelte
@@ -176,6 +176,15 @@
           allow-list and are not delegation targets.
         </p>
       {/if}
+
+      <!-- #4235: hidden agents are omitted from the target cards above, so the
+           pane says how many rather than leaving them silently missing. -->
+      {#if (inProduct?.hidden_excluded_count ?? 0) > 0}
+        <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/40">
+          {inProduct?.hidden_excluded_count} further agent(s) on this host are hidden
+          (<code class="font-mono">hidden = true</code>) and are not listed here.
+        </p>
+      {/if}
     </section>
 
     <!-- ── Cross-product: dispatch_task ─────────────────────────────────── -->

--- a/crates/trusty-agents/ui/src/components/AgentConfigSubagents.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSubagents.test.ts
@@ -44,6 +44,7 @@ function inProduct(over: Partial<SubagentInProduct> = {}): SubagentInProduct {
     allowed_roles: ['engineer', 'qa', 'researcher', 'documentation', 'ops', 'planner', 'assistant'],
     targets: [inTarget()],
     role_excluded_count: 0,
+    hidden_excluded_count: 0,
     unresolved: [],
     ...over,
   };
@@ -288,5 +289,23 @@ describe('AgentConfigSubagents — honest degradation', () => {
     render(payload({ in_product: inProduct({ role_excluded_count: 4 }) }));
     expect(target.textContent).toContain('4 further agent(s)');
     expect(target.textContent).toContain('excluded by the role');
+  });
+
+  // #4235: the server omits `hidden` agents from `targets` entirely, so the
+  // pane must account for them rather than leaving them silently missing —
+  // and must keep the two exclusion reasons on separate lines, since the fix
+  // for each is a different field of the agent's TOML.
+  it('counts hidden roster entries separately from role-excluded ones', () => {
+    render(
+      payload({
+        in_product: inProduct({ role_excluded_count: 4, hidden_excluded_count: 2 }),
+      }),
+    );
+    expect(target.textContent).toContain('4 further agent(s)');
+    expect(target.textContent).toContain('excluded by the role');
+    expect(target.textContent).toContain('2 further agent(s)');
+    expect(target.textContent).toContain('are hidden');
+    // Counted, never named — the no-roster-dump posture.
+    expect(target.textContent).not.toContain('personal-assistant');
   });
 });

--- a/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.test.ts
@@ -212,6 +212,7 @@ describe('fetchAgentSubagents', () => {
           },
         ],
         role_excluded_count: 3,
+        hidden_excluded_count: 0,
         unresolved: [],
       },
       cross_product: {

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -513,6 +513,15 @@ export interface SubagentInProduct {
   targets: SubagentInProductTarget[];
   /** Roster entries excluded by the role allowlist — counted, never named. */
   role_excluded_count: number;
+  /**
+   * Roster entries excluded because they carry `[agent].hidden = true` (#4235)
+   * — counted, never named, exactly like `role_excluded_count`. Disjoint from
+   * it: the server checks `hidden` first, so an entry contributes to one
+   * counter or the other, never both. Rendered as its own line rather than
+   * summed with the role count, because the two have different remedies (edit
+   * the agent's `hidden` flag vs. its `role`).
+   */
+  hidden_excluded_count: number;
   unresolved: { name: string; reason: string }[];
 }
 


### PR DESCRIPTION
## The bug

`in_product_surface` (`crates/trusty-agents/src/api/server/agent_subagents.rs`)
filtered delegation-target candidates by `ASSISTANT_ALLOWED_DELEGATE_ROLES` and
by the ADR-0024 kind / #4169 tier gate — but never by `hidden`. The
picker/roster path *does* apply it (`projects::apply_roster_filters`), so the
bundled agents carrying `hidden = true` leaked back into the Sub-agents pane as
delegation targets:

- `crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml:31`
- `crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml:22`

`personal-assistant.toml` declares `display_name = "Izzie"` — the same label the
real `izzie` package agent uses — so the pane rendered TWO rows both reading
"Izzie". That is exactly the collision the file's own comment says `hidden =
true` was added under #3819 to remove.

## The fix

One line of policy, no second implementation:

```rust
// #4235: this pane is a listing surface, so it applies the SAME
// `!hidden` filter the picker applies via `apply_roster_filters` —
// through the same `projects::is_hidden` predicate on the same catalog
// entry, never a second copy of the check. …
if super::projects::is_hidden(&entry) {
    hidden_excluded_count += 1;
    continue;
}
```

**Shared helper promoted, not duplicated.** `apply_roster_filters` itself is
*not* reusable here — it composes `is_assistant_role` (`role == "assistant"`)
with `!is_hidden`, and the delegation surface deliberately admits a much wider
role set (`engineer`, `qa`, `researcher`, `documentation`, `ops`, `planner`,
`assistant`). The genuinely shared primitive is `is_hidden`, which was
**private** to `projects.rs`. It is **promoted to `pub(super)`** — both modules
are children of `api::server` — so the picker and the pane run the *same
predicate over the same catalog `Value`* and cannot drift. Its doc comment now
carries the Why/What/Test rationale for the promotion.

## Decision: omit, don't label

A hidden candidate is **dropped** from `targets` rather than rendered as an
unreachable card with a "hidden" reason. Reasoning:

1. **`hidden` is not a gate, so there is no refusal to explain.** Per
   `AgentInfo::hidden`'s doc comment it governs listing VISIBILITY only;
   `delegate_to_agent` resolves targets by name through
   `AgentConfig::by_name_in` and never consults this roster. Every other
   `reason` string in this payload names an enforcement layer that refused the
   call. "Hidden" would be the only one that names an operator preference, and
   the pane would be asserting a restriction nothing enforces — the exact drift
   this module's doc forbids.
2. **A labelled row is still a row.** The owner's report is a *duplicate
   "Izzie" row*. Rendering `personal-assistant` with a badge still draws it.
3. **Consistency with the existing posture.** The module already distinguishes
   "counted but never named" (`role_excluded_count`) from "named target card",
   preserving #3052 PR A CRITICAL-2's rule that the delegation surface does not
   enumerate internal agent ids (`agent_subagents.rs:56-59`). Naming an id the
   operator explicitly suppressed is the *last* thing this surface should do.

**The counts stay accurate.** A new `in_product.hidden_excluded_count` gives
hidden entries the same counted-never-named treatment. `hidden` is checked
FIRST — before `by_name_in` — so:

- the two counters are **disjoint**; nothing double-counts;
- `role_excluded_count` keeps its pre-#4235 meaning ("role not in the
  allowlist") byte-for-byte, pinned by a test;
- a hidden agent cannot leak through the *other* naming channel, `unresolved`,
  either.

The Svelte pane renders the new count on its own line ("N further agent(s) …
are hidden"), separate from the role line — the two have different remedies
(edit `hidden` vs. edit `role`) — so the omission is **stated, not silent**.
`empty_in_product()` carries the key too, so a degraded payload renders zero
rather than `undefined`.

## Tests

- `subagents_route_omits_a_hidden_delegation_target` — a hidden agent is not
  offered as a delegation target (and is not leaked via `unresolved`); a
  **non-hidden agent of the same role still is**; `hidden_excluded_count == 2`.
  Covers both a hidden *peer assistant* and a hidden *sub-agent role*, so the
  filter cannot be passing by accident on the ADR-0024 kind rule.
- `subagents_route_hidden_filter_leaves_the_role_count_untouched` — adding a
  hidden agent whose role is ALSO ineligible moves `hidden_excluded_count` and
  leaves `role_excluded_count` unchanged.
- `empty_payloads_carry_the_same_vocabulary_and_deny_everything` — extended:
  both counters present as zero on the degraded payload.
- UI: `counts hidden roster entries separately from role-excluded ones`.

## Local gate output (raw)

```
$ cargo fmt
Warning: can't set `group_imports = StdExternalCrate`, unstable features are only available in nightly channel.
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
=== fmt exit 0 ===

$ cargo check -p trusty-agents
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 58s

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 2m 17s
(no warnings emitted)

$ cargo test -p trusty-agents
test api::server::tests::agent_subagents::subagents_route_omits_a_hidden_delegation_target ... ok
test api::server::tests::agent_subagents::subagents_route_hidden_filter_leaves_the_role_count_untouched ... ok
test api::server::agent_subagents::unit_tests::empty_payloads_carry_the_same_vocabulary_and_deny_everything ... ok
test api::server::tests::listing::apply_roster_filters_excludes_hidden_assistant ... ok
test api::server::tests::listing::apply_roster_filters_requires_both_assistant_role_and_not_hidden ... ok
...
test result: FAILED. 2920 passed; 1 failed; 11 ignored; 0 measured; 0 filtered out; finished in 44.47s

failures:
    tools::python_skill::tests::execute_dispatches_to_python_and_parses_json
---- stdout ----
expected success against the bundled fixture db, got: python skill 'query_headcount' produced no stdout (exit Some(2)); stderr: error: Failed to inspect Python interpreter from first executable in the search path at `/opt/homebrew/bin/python3`
  Caused by: Failed to query Python interpreter
  Caused by: No such file or directory (os error 2) at path "/var/folders/.../.cache/uv/.tmp724TUE"
```

The single failure is **environmental and pre-existing** — `uv` cannot inspect
this machine's Homebrew `python3` (a dangling `../Cellar/python@3.14/...`
symlink) while writing its cache into the sandboxed temp dir. This PR does not
touch `crates/trusty-agents/src/tools/python_skill.rs`
(`git diff --stat origin/main -- …/python_skill.rs` is empty). Everything else
in the crate — all 2920 tests — passes.

```
$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 50 spec doc(s) + 2928 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_doc_numbers.sh
doc-numbers: 4 grandfathered, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.
```

UI gates (this PR touches `crates/trusty-agents/ui/`):

```
$ npm run test:unit
 Test Files  24 passed (24)
      Tests  267 passed (267)

$ npm run check
COMPLETED 1737 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
(both warnings are pre-existing a11y warnings in src/components/ProjectsView.svelte, untouched here)

$ npm run check:tokens
All enforced crates match the canonical token source.
```

## Not in scope

The issue also notes that `display_name` has **no uniqueness constraint**
anywhere (`agents/config.rs`, `display_label()`), which is what let two agents
both render as "Izzie" in the first place. Filtering `hidden` removes today's
collision but not the underlying possibility; the issue explicitly flags
duplicate-display-name detection as a **separate concern**, and it is left out
of this PR.

Closes #4235

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
