### PR TITLE
fix(tga): gate Tier-3/4 identity fuzzy fallback on alias-table presence (#4251)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10302,7 +10302,7 @@ dependencies = [
 
 [[package]]
 name = "tga"
-version = "2.10.0"
+version = "2.11.0"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/crates/trusty-git-analytics/CHANGELOG.md
+++ b/crates/trusty-git-analytics/CHANGELOG.md
@@ -7,6 +7,48 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+MINOR, not patch. `Config` gained a public field and its fields are all public
+with no `#[non_exhaustive]`, and the new default flips identity-resolution
+behaviour for every existing `aliases_file` deployment on upgrade.
+
+### Fixed
+
+- Identity resolution no longer runs the Tier-3/4 Jaro-Winkler fuzzy fallback
+  when a comprehensive `aliases_file` is configured (#4251). As the alias
+  roster grew from 130 to 177 entries, the fuzzy tiers began collapsing
+  distinct people onto similarly-spelled colleagues — `Cristian Dominguez` →
+  `Crislaine Tripoli`, `Ravi Chandrasekaran` → `Ravi Pandey`, `Gauri Saykar` →
+  `Gaurav Sharma`, `Josh Taylor` and `Joseph Ku` → `Joshua Lepage` — none of
+  which had a declared alias explaining the match. An author that matches no
+  declared alias is now reported under its own raw name instead of being
+  guessed. Tier-1/2 exact alias resolution and the #2253 email-domain gate are
+  unchanged.
+
+### Added
+
+- `fuzzy_identity_fallback` config key (#4251). Unset (default) disables the
+  Tier-3/4 fuzzy fallback only when a declared `aliases_file` successfully
+  loaded a non-empty alias table; `true` forces it on, `false` forces it off.
+  A declared `aliases_file` that fails to load, or resolves empty, leaves the
+  fallback ON and logs at `error!` rather than silently fragmenting every
+  identity. `IdentityResolver` gained the matching `with_fuzzy_fallback()`
+  builder and `fuzzy_fallback()` accessor for callers that construct a
+  resolver outside `from_config`.
+- The behaviour flip is announced once at `info!` when it takes effect.
+
+### Internal
+
+- Identity resolver tests now use `tempfile::TempDir` instead of a hand-rolled
+  `process::id() + SystemTime` directory name. The old scheme was not unique
+  within a test binary — `process::id()` is constant across parallel tests and
+  the `SystemTime` remainder is coarser than a nanosecond — so tests collided
+  and each one's cleanup deleted a directory another was still using. Because
+  `Config::resolved_aliases()` swallows alias-file load errors, the victim got
+  a resolver with zero members, which returns every input unchanged and so
+  satisfied the #4251 pass-through assertions *vacuously*. Measured at 10
+  failures per 100 runs. The affected tests now also carry an explicit
+  non-vacuity assertion that the roster loaded.
+
 ---
 ## [2.10.0] — 2026-07-27
 

--- a/crates/trusty-git-analytics/Cargo.toml
+++ b/crates/trusty-git-analytics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tga"
-version = "2.10.0"
+version = "2.11.0"
 publish = true
 edition = "2021"
 # Aligned with the workspace MSRV (1.91) per #254. Required for

--- a/crates/trusty-git-analytics/src/collect/identity/resolver.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/resolver.rs
@@ -6,12 +6,17 @@
 //! 2. Fuzzy match against team member canonical emails/names using
 //!    Jaro-Winkler similarity above a configurable threshold.
 //! 3. Fall through and return the raw pair unchanged.
+//!
+//! The fuzzy tiers are a *fallback for undeclared identities*, not a
+//! supplement to a declared roster: when the project supplies a comprehensive
+//! alias table they are switched off (issue #4251). See
+//! [`IdentityResolver::fuzzy_fallback`].
 
 use std::collections::HashMap;
 
 use rusqlite::params;
 use strsim::jaro_winkler;
-use tracing::debug;
+use tracing::{debug, error, info};
 
 use crate::core::config::TeamConfig;
 use crate::core::db::Database;
@@ -99,6 +104,13 @@ pub struct IdentityResolver {
     /// the stored canonical email. See [`Self::upsert_author`] for the
     /// selection policy.
     canonical_domain: Option<String>,
+    /// Whether the Tier-3/4 Jaro-Winkler fuzzy fallback may run (issue #4251).
+    ///
+    /// `true` preserves the historical behaviour. `false` stops resolution
+    /// after the exact Tier-1/2 alias lookups, so an identity that is not
+    /// declared in the alias table passes through unchanged instead of being
+    /// guessed onto the nearest-spelled roster member.
+    fuzzy_fallback: bool,
 }
 
 impl IdentityResolver {
@@ -130,6 +142,7 @@ impl IdentityResolver {
             members,
             threshold: DEFAULT_SIMILARITY_THRESHOLD,
             canonical_domain,
+            fuzzy_fallback: true,
         }
     }
 
@@ -166,12 +179,19 @@ impl IdentityResolver {
             members,
             threshold: DEFAULT_SIMILARITY_THRESHOLD,
             canonical_domain: None,
+            fuzzy_fallback: true,
         }
     }
 
     /// Construct a resolver from a [`crate::core::config::Config`], preferring
     /// the Python-compatible `developer_aliases` map when present, falling
     /// back to `team.members`.
+    ///
+    /// Also decides whether the Tier-3/4 fuzzy fallback runs (issue #4251):
+    /// an explicit `fuzzy_identity_fallback` in the config wins; otherwise the
+    /// fallback is disabled only when a declared `aliases_file` actually
+    /// resolved to a non-empty alias table. A declared-but-unloadable file
+    /// leaves the fallback ON and logs at `error!`.
     pub fn from_config(config: &crate::core::config::Config) -> Self {
         let map = config.resolved_aliases();
         let mut resolver = if !map.is_empty() {
@@ -191,6 +211,47 @@ impl IdentityResolver {
                     .filter(|d| !d.is_empty());
             }
         }
+        // Gate on whether the alias table actually LOADED, not merely on whether
+        // one was declared. `Config::resolved_aliases` deliberately swallows
+        // alias-file load errors, so keying on `aliases_file.is_some()` alone
+        // would let a typo'd or unreadable file produce the worst possible
+        // state: an empty alias table AND a disabled fallback, fragmenting every
+        // author with nothing but a debug line to show for it.
+        let alias_table_loaded = match &config.aliases_file {
+            None => false,
+            Some(_) => match config.resolved_alias_map(config.config_dir()) {
+                Ok(m) if !m.is_empty() => true,
+                Ok(_) => {
+                    error!(
+                        "aliases_file is configured but resolved to an EMPTY alias table; \
+                         keeping the Tier-3/4 fuzzy fallback enabled"
+                    );
+                    false
+                }
+                Err(e) => {
+                    error!(
+                        error = %e,
+                        "aliases_file is configured but could not be loaded; identity \
+                         resolution will fall back to fuzzy matching — fix the config"
+                    );
+                    false
+                }
+            },
+        };
+        resolver.fuzzy_fallback = config
+            .fuzzy_identity_fallback
+            .unwrap_or(!alias_table_loaded);
+        if !resolver.fuzzy_fallback {
+            // Announce at info!, not debug!: this flips resolution behaviour for
+            // every existing `aliases_file` deployment on upgrade, and an
+            // operator comparing two runs needs to see why the numbers moved.
+            info!(
+                members = resolver.members.len(),
+                "Tier-3/4 fuzzy identity fallback DISABLED (alias table supplied); \
+                 authors with no declared alias will be reported under their raw \
+                 name. Set `fuzzy_identity_fallback: true` to restore guessing."
+            );
+        }
         resolver
     }
 
@@ -198,6 +259,28 @@ impl IdentityResolver {
     pub fn with_threshold(mut self, threshold: f64) -> Self {
         self.threshold = threshold;
         self
+    }
+
+    /// Enable or disable the Tier-3/4 Jaro-Winkler fuzzy fallback (issue #4251).
+    ///
+    /// Why: [`Self::from_config`] derives the flag from config, but resolvers
+    /// built from a bare alias map ([`Self::from_alias_map`]) or a
+    /// [`crate::core::config::TeamConfig`] have no config to read. Those
+    /// callers — currently `trusty-review`'s profile selector and the benches —
+    /// keep the historical fuzzy-on default and can opt out through this
+    /// builder if they ever need to. No caller sets it today; it exists so the
+    /// switch is reachable without routing through `Config`.
+    /// What: sets the flag consulted by [`Self::resolve`] after the exact
+    /// Tier-1/2 alias lookups.
+    /// Test: see `resolver_tests::with_fuzzy_fallback_false_suppresses_tier34`.
+    pub fn with_fuzzy_fallback(mut self, enabled: bool) -> Self {
+        self.fuzzy_fallback = enabled;
+        self
+    }
+
+    /// Report whether the Tier-3/4 fuzzy fallback is active on this resolver.
+    pub fn fuzzy_fallback(&self) -> bool {
+        self.fuzzy_fallback
     }
 
     /// Register an alias → canonical-name mapping after construction.
@@ -257,6 +340,17 @@ impl IdentityResolver {
             if let Some((cn, ce)) = self.find_member_by_name(canon_name) {
                 return (cn, ce);
             }
+        }
+
+        // Issue #4251: Tiers 3 and 4 guess. When the project has declared a
+        // comprehensive alias table, an inbound pair that reached this point is
+        // by definition NOT on the roster, and every additional roster entry
+        // only widens the set of near-spellings it can be captured by
+        // (`Cristian Dominguez` → `Crislaine Tripoli`). Stop here and let the
+        // identity pass through unresolved — a visibly-unmapped author is
+        // recoverable by adding an alias; a silently-misattributed one is not.
+        if !self.fuzzy_fallback {
+            return (name.to_string(), email.to_string());
         }
 
         // 3. Fuzzy match against member names/emails (Jaro-Winkler).

--- a/crates/trusty-git-analytics/src/collect/identity/resolver_tests.rs
+++ b/crates/trusty-git-analytics/src/collect/identity/resolver_tests.rs
@@ -199,21 +199,17 @@ fn multiple_emails_same_person() {
 /// `configs/duetto-contractors.yaml` setup. This guards against
 /// regressions in YAML schema, path resolution, or resolver wiring.
 ///
-/// The fixture is materialized into a temp dir so the test is
+/// The fixture is materialized into a `tempfile::TempDir` so the test is
 /// hermetic: it does not depend on absolute paths outside the repo
-/// (which would fail in CI).
+/// (which would fail in CI). Previously this built its own `pid + nanos`
+/// directory name, the same scheme that raced in the #4251 helper below —
+/// `process::id()` is constant within a test binary and the `SystemTime`
+/// remainder is coarser than a nanosecond, so the name is not actually
+/// unique. `TempDir` also cleans up on panic, which the manual path did not.
 #[test]
 fn duetto_contractors_config_resolves() {
-    let unique = format!(
-        "tga-duetto-contractors-{}-{}",
-        std::process::id(),
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .map(|d| d.as_nanos())
-            .unwrap_or(0)
-    );
-    let tmp = std::env::temp_dir().join(unique);
-    std::fs::create_dir_all(&tmp).expect("create tmp");
+    let tmpdir = tempfile::TempDir::new().expect("create tmp");
+    let tmp = tmpdir.path();
 
     // Aliases file with a subset of the real Duetto contractor map,
     // including the cases the assertions below exercise (case-folding,
@@ -260,8 +256,6 @@ developers:
     // Non-email login handle alias.
     let (n, _) = r.resolve("jangareddy-duetto", "noise@nowhere.test");
     assert_eq!(n, "Janga Vinod Kumar Reddy");
-
-    let _ = std::fs::remove_dir_all(&tmp);
 }
 
 #[test]
@@ -461,6 +455,436 @@ fn tier3_still_matches_same_domain_near_identical_local_parts() {
     let (name, email) = r.resolve("acoopr", "alice.coopr@acme.com");
     assert_eq!(name, "Alice Cooper");
     assert_eq!(email, "alice.cooper@acme.com");
+}
+
+// ---------------------------------------------------------------------------
+// Issue #4251 — Tier-3/4 fuzzy fallback must not fire when a comprehensive
+// `aliases_file` is supplied.
+// ---------------------------------------------------------------------------
+
+/// Roster excerpt from the production Duetto alias map (177 entries) — only the
+/// members implicated in the #4251 misattributions, plus two entries whose
+/// explicit aliases must keep resolving through Tiers 1/2.
+const ISSUE_4251_ALIASES_YAML: &str = r#"
+developers:
+  - name: "Crislaine Tripoli"
+    primary_email: "crislaine.tripoli@duettoresearch.com"
+    aliases: []
+  - name: "Ravi Pandey"
+    primary_email: "ravi.pandey@duettoresearch.com"
+    aliases: []
+  - name: "Gaurav Sharma"
+    primary_email: "gaurav.sharma@duettoresearch.com"
+    aliases: []
+  - name: "Joshua Lepage"
+    primary_email: "joshua.lepage@duettoresearch.com"
+    aliases: []
+  - name: "Joshua McCartney"
+    primary_email: "joshua.mccartney@duettoresearch.com"
+    aliases: []
+  - name: "Akash Arora"
+    primary_email: "akash.arora@duettoresearch.com"
+    aliases:
+      - "Akash.Arora-c@duettoresearch.com"
+      - "akash-duetto"
+  - name: "Andre Ramos"
+    primary_email: "andre.ramos@duettoresearch.com"
+    aliases:
+      - "129991831+andreramosduetto@users.noreply.github.com"
+"#;
+
+/// The `(author_name, author_email)` pairs observed in production `tga.db` that
+/// #4251 reports as misattributed, paired with the roster member each was
+/// wrongly collapsed onto.
+const ISSUE_4251_MISATTRIBUTIONS: &[(&str, &str, &str)] = &[
+    (
+        "Cristian Dominguez",
+        "cristian.dominguez@duettoresearch.com",
+        "Crislaine Tripoli",
+    ),
+    (
+        "Ravi Chandrasekaran",
+        "ravi.chandrasekaran@duettoresearch.com",
+        "Ravi Pandey",
+    ),
+    (
+        "Gauri Saykar",
+        "gauri.saykar@duettoresearch.com",
+        "Gaurav Sharma",
+    ),
+    ("Josh Taylor", "josh@duettoresearch.com", "Joshua Lepage"),
+    ("Joseph Ku", "joseph.ku@duettoresearch.com", "Joshua Lepage"),
+];
+
+/// Materialize a `config.yaml` + external `aliases_file` pair into a private
+/// temp directory and load it through the real
+/// [`crate::core::config::Config::load`] path, returning `(resolver, tmpdir)`.
+/// The caller must keep `tmpdir` alive for the duration of the test.
+///
+/// Why: #4251 is a *config-shape* defect — it only manifests when the alias map
+/// arrives via `aliases_file`. Constructing the resolver by hand would bypass
+/// the very wiring under test.
+///
+/// Uses [`tempfile::TempDir`] rather than a hand-rolled `pid + nanos` name.
+/// Tests in one binary share a process, so `process::id()` is constant, and the
+/// `SystemTime` remainder is coarser than a nanosecond on macOS: hand-rolled
+/// names collided across the parallel tests below, and each test's cleanup then
+/// deleted a directory another test was still using. Because
+/// `Config::resolved_aliases()` swallows alias-file load errors, the victim
+/// silently got a resolver with ZERO members — which returns every input
+/// unchanged and so satisfied the primary #4251 assertion *vacuously*.
+/// `TempDir` gives a kernel-guaranteed unique name and RAII cleanup that also
+/// runs on panic.
+fn resolver_from_aliases_file(extra_config_yaml: &str) -> (IdentityResolver, tempfile::TempDir) {
+    let tmp = tempfile::TempDir::new().unwrap();
+
+    let aliases_path = tmp.path().join("aliases.yaml");
+    std::fs::write(&aliases_path, ISSUE_4251_ALIASES_YAML).unwrap();
+
+    let config_yaml = format!(
+        "version: \"1.0\"\naliases_file: \"{}\"\n{extra_config_yaml}",
+        aliases_path.to_string_lossy()
+    );
+    let config_path = tmp.path().join("config.yaml");
+    std::fs::write(&config_path, config_yaml).unwrap();
+
+    let cfg = crate::core::config::Config::load(&config_path).unwrap();
+    (IdentityResolver::from_config(&cfg), tmp)
+}
+
+/// Assert the roster actually loaded.
+///
+/// Why: a resolver built from a failed alias load has zero members and returns
+/// **every** input unchanged — which is exactly what the #4251 pass-through
+/// assertions check. Without this positive control those assertions can pass
+/// against a resolver that never read the alias file. `fuzzy_fallback()` is not
+/// a substitute: it is derived from config, not from load success.
+fn assert_roster_loaded(r: &IdentityResolver) {
+    assert_eq!(
+        r.resolve("whoever", "crislaine.tripoli@duettoresearch.com"),
+        (
+            "Crislaine Tripoli".to_string(),
+            "crislaine.tripoli@duettoresearch.com".to_string()
+        ),
+        "non-vacuity: the roster must actually be loaded, otherwise a \
+         pass-through result proves nothing"
+    );
+    assert_eq!(
+        r.resolve("akash-duetto", "noise@nowhere.test").0,
+        "Akash Arora",
+        "non-vacuity: declared login-handle aliases must be present"
+    );
+}
+
+/// Issue #4251 (primary reproduction): with a comprehensive `aliases_file`
+/// supplied, an author who has no alias entry must pass through UNCHANGED
+/// rather than being fuzzy-guessed onto the nearest-spelled roster member.
+///
+/// Each pair below is a real production misattribution. The precondition
+/// assertions prove the fuzzy tiers genuinely clear their thresholds on these
+/// inputs, so the test cannot pass vacuously.
+#[test]
+fn aliases_file_disables_tier34_name_fuzzy() {
+    let (r, _tmp) = resolver_from_aliases_file("");
+    assert!(
+        !r.fuzzy_fallback(),
+        "supplying an aliases_file must disable the fuzzy fallback"
+    );
+    // MUST come first: everything below asserts pass-through, which a
+    // zero-member resolver would also satisfy.
+    assert_roster_loaded(&r);
+
+    // Collect every resolution before asserting so a failure reports the whole
+    // misattribution set, not just the first pair to trip.
+    let mut observed: Vec<String> = Vec::new();
+    let mut expected: Vec<String> = Vec::new();
+    for (name, email, wrong_target) in ISSUE_4251_MISATTRIBUTIONS {
+        // Precondition: at least one fuzzy tier really does score this pair
+        // above its acceptance threshold, i.e. the defect is live in the
+        // scoring functions and this assertion is guarding real behaviour.
+        let raw_name = jaro_winkler(&name.to_lowercase(), &wrong_target.to_lowercase());
+        let norm_local = jaro_winkler(
+            &normalize_for_fuzzy(&email_local_part(email)),
+            &normalize_for_fuzzy(wrong_target),
+        );
+        assert!(
+            raw_name >= DEFAULT_SIMILARITY_THRESHOLD
+                || norm_local >= NORMALIZED_SIMILARITY_THRESHOLD,
+            "precondition: {name} vs {wrong_target} must be fuzzy-reachable \
+             (tier3 name={raw_name:.4}, tier4 normalized={norm_local:.4})"
+        );
+
+        let (resolved_name, resolved_email) = r.resolve(name, email);
+        observed.push(format!(
+            "{name} <{email}> => {resolved_name} <{resolved_email}>"
+        ));
+        // Correct behaviour: an undeclared identity is returned untouched.
+        expected.push(format!("{name} <{email}> => {name} <{email}>"));
+    }
+    assert_eq!(
+        observed, expected,
+        "#4251: undeclared authors must pass through, not be guessed onto the \
+         nearest-spelled roster member"
+    );
+}
+
+/// The #4251 gate must not cost us the alias-table resolutions that the
+/// 130 → 177 entry expansion was made FOR. Every genuine correction rides on
+/// Tiers 1/2 (exact alias / canonical email / login handle), which the gate
+/// leaves untouched.
+#[test]
+fn aliases_file_gate_preserves_tier12_declared_resolutions() {
+    let (r, _tmp) = resolver_from_aliases_file("");
+
+    // Declared secondary email (the `-c` contractor variant) → canonical pair.
+    let (n, e) = r.resolve("whoever", "Akash.Arora-c@duettoresearch.com");
+    assert_eq!(n, "Akash Arora");
+    assert_eq!(e, "akash.arora@duettoresearch.com");
+
+    // Declared non-email login handle.
+    let (n, e) = r.resolve("akash-duetto", "noise@nowhere.test");
+    assert_eq!(n, "Akash Arora");
+    assert_eq!(e, "akash.arora@duettoresearch.com");
+
+    // Declared GitHub noreply alias.
+    let (n, e) = r.resolve(
+        "andreramosduetto",
+        "129991831+andreramosduetto@users.noreply.github.com",
+    );
+    assert_eq!(n, "Andre Ramos");
+    assert_eq!(e, "andre.ramos@duettoresearch.com");
+
+    // Canonical email, case-folded.
+    let (n, e) = r.resolve("whoever", "CRISLAINE.TRIPOLI@DUETTORESEARCH.COM");
+    assert_eq!(n, "Crislaine Tripoli");
+    assert_eq!(e, "crislaine.tripoli@duettoresearch.com");
+}
+
+/// `fuzzy_identity_fallback: true` is the documented escape hatch: a project
+/// that wants the old guessing behaviour alongside its alias file can say so,
+/// and then the reported misattributions come back.
+#[test]
+fn explicit_opt_in_reenables_fuzzy_with_aliases_file() {
+    let (r, _tmp) = resolver_from_aliases_file("fuzzy_identity_fallback: true\n");
+    assert!(
+        r.fuzzy_fallback(),
+        "explicit opt-in must re-enable Tier 3/4"
+    );
+    assert_roster_loaded(&r);
+
+    // With fuzzy back on, `Gauri Saykar` collapses onto `Gaurav Sharma` again —
+    // the exact defect #4251 reports, proving the flag is load-bearing and the
+    // primary test above is not passing for some unrelated reason.
+    let (n, _) = r.resolve("Gauri Saykar", "gauri.saykar@duettoresearch.com");
+    assert_eq!(n, "Gaurav Sharma");
+}
+
+/// The non-vacuity control must actually reject a resolver that never loaded
+/// the roster.
+///
+/// Why: `assert_roster_loaded` is the only thing standing between a zero-member
+/// resolver and a vacuously-green #4251 proof. Measured on the pre-fix helper,
+/// a zero-member resolver satisfied **every** assertion of
+/// `aliases_file_disables_tier34_name_fuzzy`, including `!fuzzy_fallback()` —
+/// pass-through is what an empty resolver does. A guard nobody proves is
+/// load-bearing is not a guard, so this pins it.
+#[test]
+#[should_panic(expected = "non-vacuity")]
+fn non_vacuity_control_rejects_zero_member_resolver() {
+    let empty: HashMap<String, Vec<String>> = HashMap::new();
+    let r = IdentityResolver::from_alias_map(&empty);
+    // Sanity: this resolver passes everything through, exactly like the racing
+    // zero-member resolver did.
+    assert_eq!(
+        r.resolve(
+            "Cristian Dominguez",
+            "cristian.dominguez@duettoresearch.com"
+        ),
+        (
+            "Cristian Dominguez".to_string(),
+            "cristian.dominguez@duettoresearch.com".to_string()
+        )
+    );
+    assert_roster_loaded(&r); // must panic
+}
+
+/// A declared-but-unloadable `aliases_file` must NOT disable the fallback.
+///
+/// Why: `Config::resolved_aliases` swallows alias-file load errors. If the gate
+/// keyed on the mere presence of the `aliases_file` key, a typo'd path would
+/// produce an empty alias table AND a disabled fallback — every author
+/// fragments to its raw identity and nothing in the resolution path says why.
+/// Gating on a successful, non-empty load means a broken config degrades to the
+/// documented pre-#4251 behaviour instead of to silent fragmentation.
+#[test]
+fn broken_aliases_file_keeps_fuzzy_enabled() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let missing = tmp.path().join("does-not-exist.yaml");
+    let config_yaml = format!(
+        "version: \"1.0\"\naliases_file: \"{}\"\n",
+        missing.to_string_lossy()
+    );
+    let config_path = tmp.path().join("config.yaml");
+    std::fs::write(&config_path, config_yaml).unwrap();
+
+    let cfg = crate::core::config::Config::load(&config_path).unwrap();
+    // Precondition: the alias map really did fail to load, and the failure
+    // really is swallowed — this is the trap being guarded.
+    assert!(cfg.resolved_alias_map(cfg.config_dir()).is_err());
+    assert!(cfg.resolved_aliases().is_empty());
+
+    let r = IdentityResolver::from_config(&cfg);
+    assert!(
+        r.fuzzy_fallback(),
+        "a declared aliases_file that failed to load must not be treated as a \
+         comprehensive alias table"
+    );
+}
+
+/// An `aliases_file` that loads but declares no developers is equally not a
+/// comprehensive table, and must not disable the fallback either.
+#[test]
+fn empty_aliases_file_keeps_fuzzy_enabled() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let aliases_path = tmp.path().join("aliases.yaml");
+    std::fs::write(&aliases_path, "developers: []\n").unwrap();
+    let config_yaml = format!(
+        "version: \"1.0\"\naliases_file: \"{}\"\n",
+        aliases_path.to_string_lossy()
+    );
+    let config_path = tmp.path().join("config.yaml");
+    std::fs::write(&config_path, config_yaml).unwrap();
+
+    let cfg = crate::core::config::Config::load(&config_path).unwrap();
+    assert!(cfg.resolved_alias_map(cfg.config_dir()).unwrap().is_empty());
+
+    let r = IdentityResolver::from_config(&cfg);
+    assert!(r.fuzzy_fallback());
+}
+
+/// A non-empty INLINE `developer_aliases` map must not disable the fallback.
+///
+/// Why: this pins the gate to `aliases_file` specifically, which is what #4251
+/// asks for. A gate written as `map.is_empty() && aliases_file.is_none()` would
+/// silently flip every inline-alias deployment to fuzzy-off — a behaviour
+/// change well outside the issue's scope. This test fails under that form.
+#[test]
+fn inline_developer_aliases_do_not_disable_fuzzy() {
+    let yaml = r#"
+version: "1.0"
+developer_aliases:
+  "Gaurav Sharma":
+    - "gaurav.sharma@duettoresearch.com"
+"#;
+    let cfg: crate::core::config::Config = serde_yaml::from_str(yaml).unwrap();
+    assert!(
+        !cfg.resolved_aliases().is_empty(),
+        "inline map must be loaded"
+    );
+    let r = IdentityResolver::from_config(&cfg);
+    assert!(
+        r.fuzzy_fallback(),
+        "#4251 gates on aliases_file, not on any non-empty alias map"
+    );
+    // Historical fuzzy behaviour is intact for these deployments.
+    let (n, _) = r.resolve("Gauri Saykar", "gauri.saykar@duettoresearch.com");
+    assert_eq!(n, "Gaurav Sharma");
+}
+
+/// `fuzzy_identity_fallback: false` turns the fallback off even when no
+/// `aliases_file` is present (inline `developer_aliases` deployments).
+#[test]
+fn explicit_opt_out_disables_fuzzy_without_aliases_file() {
+    let yaml = r#"
+version: "1.0"
+fuzzy_identity_fallback: false
+developer_aliases:
+  "Gaurav Sharma":
+    - "gaurav.sharma@duettoresearch.com"
+"#;
+    let cfg: crate::core::config::Config = serde_yaml::from_str(yaml).unwrap();
+    let r = IdentityResolver::from_config(&cfg);
+    assert!(!r.fuzzy_fallback());
+    let (n, e) = r.resolve("Gauri Saykar", "gauri.saykar@duettoresearch.com");
+    assert_eq!(n, "Gauri Saykar");
+    assert_eq!(e, "gauri.saykar@duettoresearch.com");
+}
+
+/// No `aliases_file` and no explicit flag → historical behaviour is preserved
+/// exactly. This is the compatibility guarantee for every existing deployment
+/// that relies on fuzzy resolution.
+#[test]
+fn no_aliases_file_keeps_fuzzy_enabled_by_default() {
+    let yaml = r#"
+version: "1.0"
+developer_aliases:
+  "Bob Matsuoka":
+    - "bob.matsuoka@duettoresearch.com"
+"#;
+    let cfg: crate::core::config::Config = serde_yaml::from_str(yaml).unwrap();
+    let r = IdentityResolver::from_config(&cfg);
+    assert!(r.fuzzy_fallback());
+    let (n, _) = r.resolve("Bob M", "bob.matsuoka@otherdomain.com");
+    assert_eq!(n, "Bob Matsuoka");
+}
+
+/// The builder switch works for callers that never touch `Config`
+/// (`trusty-review`'s profile selector, `feed_azdo_users`, benches).
+#[test]
+fn with_fuzzy_fallback_false_suppresses_tier34() {
+    let r = IdentityResolver::new(Some(&make_team()));
+    // Baseline: fuzzy on, "Bob Smyth" collapses onto "Bob Smith".
+    assert_eq!(
+        r.resolve("Bob Smyth", "unknown@elsewhere.com").0,
+        "Bob Smith"
+    );
+
+    let r = IdentityResolver::new(Some(&make_team())).with_fuzzy_fallback(false);
+    let (n, e) = r.resolve("Bob Smyth", "unknown@elsewhere.com");
+    assert_eq!(n, "Bob Smyth");
+    assert_eq!(e, "unknown@elsewhere.com");
+    // Exact alias resolution is untouched by the switch.
+    assert_eq!(r.resolve("bobby", "x@y.com").0, "Bob Smith");
+}
+
+/// Issue #2253 regression guard, re-asserted under #4251: the email-domain
+/// gate is orthogonal to the new switch and must still hold on a resolver with
+/// fuzzy ENABLED (no `aliases_file`), which is the configuration #2253 fixed.
+#[test]
+fn issue_2253_domain_gate_intact_when_fuzzy_enabled() {
+    let team = TeamConfig {
+        members: vec![
+            TeamMember {
+                name: "Jenkins CI".into(),
+                email: "jenkins@duettoresearch.com".into(),
+                aliases: vec![],
+            },
+            TeamMember {
+                name: "Alice Cooper".into(),
+                email: "alice.cooper@acme.com".into(),
+                aliases: vec![],
+            },
+        ],
+        aliases: HashMap::new(),
+        canonical_domain: None,
+    };
+    let r = IdentityResolver::new(Some(&team));
+    assert!(r.fuzzy_fallback(), "no aliases_file → fuzzy stays on");
+
+    // Shared domain suffix alone must NOT merge two unrelated bots (#2253).
+    assert!(
+        jaro_winkler("ops+snyk@duettoresearch.com", "jenkins@duettoresearch.com")
+            >= DEFAULT_SIMILARITY_THRESHOLD,
+        "precondition: full-string similarity clears the threshold"
+    );
+    let (n, e) = r.resolve("Snyk Bot", "ops+snyk@duettoresearch.com");
+    assert_eq!(n, "Snyk Bot");
+    assert_eq!(e, "ops+snyk@duettoresearch.com");
+
+    // ...while a genuine same-domain, near-identical local-part still matches.
+    let (n, e) = r.resolve("acoopr", "alice.coopr@acme.com");
+    assert_eq!(n, "Alice Cooper");
+    assert_eq!(e, "alice.cooper@acme.com");
 }
 
 #[test]

--- a/crates/trusty-git-analytics/src/core/config/mod.rs
+++ b/crates/trusty-git-analytics/src/core/config/mod.rs
@@ -230,6 +230,23 @@ pub struct Config {
     #[serde(default)]
     pub aliases_file: Option<String>,
 
+    /// Explicit control over the Tier-3/4 fuzzy identity fallback (issue #4251).
+    ///
+    /// Why: the Jaro-Winkler fallback in
+    /// [`crate::collect::identity::resolver::IdentityResolver::resolve`] exists
+    /// to guess identities a project has *not* declared. Once a project supplies
+    /// a comprehensive [`Self::aliases_file`], every extra roster entry enlarges
+    /// the fuzzy haystack and the guesser starts producing cross-identity false
+    /// positives (`Cristian Dominguez` → `Crislaine Tripoli`). A fallback must
+    /// not fire when the authoritative answer is already on file.
+    /// What: `None` (the default) means "enable the fallback only when no
+    /// `aliases_file` is configured". `Some(true)` forces it on even with an
+    /// alias file; `Some(false)` forces it off even without one.
+    /// Test: see `resolver_tests::aliases_file_disables_tier34_name_fuzzy` and
+    /// `resolver_tests::explicit_opt_in_reenables_fuzzy_with_aliases_file`.
+    #[serde(default)]
+    pub fuzzy_identity_fallback: Option<bool>,
+
     /// Analysis settings (ML categorization, etc.).
     ///
     /// Parsed for forward compatibility; individual sub-features gate their

--- a/docs/trusty-git-analytics/requirements/configuration.md
+++ b/docs/trusty-git-analytics/requirements/configuration.md
@@ -12,6 +12,9 @@ database: ~               # path  — SQLite DB override (added v2.2.2, issue #4
 llm: {}                   # LlmConfig — top-level LLM section (added v2.2.2, issue #407)
 github: {}                # GitHubConfig
 bitbucket: {}             # BitbucketConfig (Cloud only)
+developer_aliases: {}     # dict[str, list[str]] — inline identity alias map
+aliases_file: ~           # path — external YAML alias file
+fuzzy_identity_fallback: ~ # bool — Tier-3/4 fuzzy identity fallback (issue #4251)
 analysis: {}              # AnalysisConfig
 output: {}                # OutputConfig
 cache: {}                 # CacheConfig
@@ -212,6 +215,45 @@ State mapping into the shared `pull_requests` table:
 `DECLINED` and `SUPERSEDED` collapse onto `closed` because the shared schema
 has no richer variants. Reports that need to distinguish them must consult
 the raw Bitbucket payload, which is currently not persisted.
+
+### Identity resolution — alias table and fuzzy fallback
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `developer_aliases` | dict[string, list[string]] | {} | Inline alias map: canonical name → emails / login handles |
+| `aliases_file` | path | None | External YAML alias file, merged over `developer_aliases` (supports `~`) |
+| `fuzzy_identity_fallback` | bool | see below | Override for the Tier-3/4 Jaro-Winkler fallback (added v2.11.0, issue #4251) |
+
+`tga` resolves each observed `(author_name, author_email)` pair in four tiers:
+
+1. exact alias match on the email,
+2. exact alias match on the display name,
+3. Jaro-Winkler similarity ≥ 0.85 against canonical names, and against email
+   local-parts **when both addresses share the same domain** (issue #2253),
+4. Jaro-Winkler ≥ 0.82 against punctuation-normalized names / local-parts.
+
+Tiers 3 and 4 exist to *guess* identities that were never declared. Once a
+project supplies a comprehensive `aliases_file`, every additional roster entry
+enlarges the fuzzy haystack, and the guesser starts collapsing distinct people
+onto similarly-spelled colleagues (`Cristian Dominguez` → `Crislaine Tripoli`,
+`Gauri Saykar` → `Gaurav Sharma`). So:
+
+- **`fuzzy_identity_fallback` unset (default)** — Tiers 3/4 run unless a
+  declared `aliases_file` **successfully loaded a non-empty alias table**. With
+  such a table present, an author that matches no declared alias is reported
+  under its own raw name. A declared `aliases_file` that is missing, unreadable,
+  malformed, or empty leaves Tiers 3/4 **on** and logs at `error!` — a broken
+  config degrades to the previous behaviour rather than to silent
+  fragmentation. An inline `developer_aliases` map does not disable the tiers;
+  use `fuzzy_identity_fallback: false` for that.
+- **`fuzzy_identity_fallback: true`** — force Tiers 3/4 on even with an alias
+  file (pre-2.11.0 behaviour).
+- **`fuzzy_identity_fallback: false`** — force Tiers 3/4 off even without an
+  alias file (useful for exhaustive inline `developer_aliases` maps).
+
+An undeclared author showing up under its own name is a visible, fixable gap —
+add an alias. A silently misattributed one corrupts every per-developer metric
+downstream with no signal that it happened.
 
 ### `analysis` — AnalysisConfig
 


### PR DESCRIPTION
## Problem

`IdentityResolver::resolve` runs four tiers. Tiers 1/2 are exact alias lookups;
Tiers 3/4 are Jaro-Winkler fuzzy guesses. The fuzzy tiers exist to catch
identities a project never declared — but they ran unconditionally, including
when the project had already supplied an exhaustive `aliases_file`.

Once cto-reports moved its ~130-entry roster into a 177-entry `aliases_file`,
every additional roster entry enlarged the fuzzy haystack, and the guesser
started collapsing distinct people onto similarly-spelled colleagues. None of
these targets has a declared alias explaining the match:

| Observed author | Wrongly resolved to |
|---|---|
| `Cristian Dominguez <cristian.dominguez@…>` | `Crislaine Tripoli` |
| `Ravi Chandrasekaran` | `Ravi Pandey` |
| `Gauri Saykar` | `Gaurav Sharma` |
| `Josh Taylor` | `Joshua Lepage` |
| `Joseph Ku` | `Joshua Lepage` |

## Design decision

**Presence of an `aliases_file` disables Tiers 3/4 by default, with an explicit
opt-in flag to re-enable.** This is the owner's recommendation and option #3
from the original #2253 discussion. Concretely, a new top-level config key:

| `fuzzy_identity_fallback` | Behaviour |
|---|---|
| unset (**default**) | Tiers 3/4 run unless a declared `aliases_file` **successfully loaded a non-empty alias table** |
| `true` | force Tiers 3/4 on even with an alias file (pre-2.11.0 behaviour) |
| `false` | force Tiers 3/4 off even without an alias file (exhaustive inline `developer_aliases`) |

Explicitly **not** implemented: a "comprehensiveness score" / coverage
threshold. A heuristic that guesses whether the alias table is complete enough
to stop guessing is a second guessing layer stacked on the first — it would
turn a reproducible bug into a threshold-tuning problem. Presence of the file
is a fact the operator states; coverage is not.

Rationale for the direction of the failure mode: an undeclared author showing
up under its own raw name is a **visible, fixable** gap — add an alias. A
silently misattributed author corrupts every per-developer metric downstream
with no signal that it happened.

Scope preserved exactly as required:
- **Tier 1/2** exact alias / canonical-email / login-handle resolution: untouched,
  and re-asserted by `aliases_file_gate_preserves_tier12_declared_resolutions`.
- **#2253 email-domain gating**: untouched. `email_domain()`, the
  domain-equality gate and the local-part comparison are byte-identical; the
  new flag short-circuits *before* Tier 3 rather than modifying it. Re-asserted
  by `issue_2253_domain_gate_intact_when_fuzzy_enabled` (both directions: the
  Snyk/Jenkins false positive stays suppressed, and the genuine
  `acoopr` → `Alice Cooper` same-domain match still resolves).

## Before / after test observation

`aliases_file_disables_tier34_name_fuzzy` builds a `config.yaml` + external
`aliases_file` on disk, loads it through the real `Config::load` path, and
resolves the five reported pairs. Each pair carries a precondition assertion
that the fuzzy score genuinely clears its threshold, so the test cannot pass
vacuously.

**BEFORE the fix** — production code reverted to `origin/main`, `cargo clean -p tga`
first to rule out any stale artifact:

```
test collect::identity::resolver::tests::aliases_file_disables_tier34_name_fuzzy ... FAILED

assertion `left == right` failed: #4251: undeclared authors must pass through, not be guessed onto the nearest-spelled roster member
  left: ["Cristian Dominguez <cristian.dominguez@duettoresearch.com> => Crislaine Tripoli <crislaine.tripoli@duettoresearch.com>",
         "Ravi Chandrasekaran <ravi.chandrasekaran@duettoresearch.com> => Ravi Pandey <ravi.pandey@duettoresearch.com>",
         "Gauri Saykar <gauri.saykar@duettoresearch.com> => Gaurav Sharma <gaurav.sharma@duettoresearch.com>",
         "Josh Taylor <josh@duettoresearch.com> => Joshua Lepage <joshua.lepage@duettoresearch.com>",
         "Joseph Ku <joseph.ku@duettoresearch.com> => Joshua Lepage <joshua.lepage@duettoresearch.com>"]
 right: [... each pair resolving to itself ...]

test result: FAILED. 24 passed; 1 failed; 0 ignored; 0 measured; 742 filtered out
```

All five reported misattributions reproduce exactly. Note that
`aliases_file_gate_preserves_tier12_declared_resolutions` and
`issue_2253_domain_gate_intact_when_fuzzy_enabled` **pass** in this pre-fix run
— the test targets the defect, it does not fail everything.

**AFTER the fix** — `cargo test -p tga` (full suite, **no** `--lib`):

```
test collect::identity::resolver::tests::aliases_file_disables_tier34_name_fuzzy ... ok
test collect::identity::resolver::tests::aliases_file_gate_preserves_tier12_declared_resolutions ... ok
test collect::identity::resolver::tests::explicit_opt_in_reenables_fuzzy_with_aliases_file ... ok
test collect::identity::resolver::tests::explicit_opt_out_disables_fuzzy_without_aliases_file ... ok
test collect::identity::resolver::tests::no_aliases_file_keeps_fuzzy_enabled_by_default ... ok
test collect::identity::resolver::tests::with_fuzzy_fallback_false_suppresses_tier34 ... ok
test collect::identity::resolver::tests::issue_2253_domain_gate_intact_when_fuzzy_enabled ... ok
test collect::identity::resolver::tests::tier3_does_not_merge_bots_sharing_domain_suffix ... ok
test collect::identity::resolver::tests::tier3_still_matches_same_domain_near_identical_local_parts ... ok

     Running unittests src/lib.rs
test result: ok. 770 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 6.88s
     Running unittests src/main.rs
test result: ok. 151 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.30s
     Running tests/bitbucket_live.rs
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/config_mount.rs
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/integration_test.rs
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
   Doc-tests tga
test result: ok. 5 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

The single ignored lib test is the pre-existing
`core::effort::tests::effort_cross_validate`, not introduced here. No new test
uses `#[ignore]`, an env-var gate, an early `return`, or a skip-when-missing
guard; fixtures use `.unwrap()` so a load failure fails the test.

`explicit_opt_in_reenables_fuzzy_with_aliases_file` asserts that with
`fuzzy_identity_fallback: true` the `Gauri Saykar` → `Gaurav Sharma`
misattribution comes **back** — proof the flag is load-bearing and the primary
test is not passing for an unrelated reason.

## Measured behaviour change, and effect on the 77 changed resolutions

Behaviour changes **only** for configs that set `aliases_file` (or explicitly
set the new key). Every other deployment — inline `developer_aliases`,
`team.members`, `trusty-review`'s `from_alias_map` profile selector, the
benches — keeps the previous behaviour bit-for-bit, guarded by
`no_aliases_file_keeps_fuzzy_enabled_by_default`.

Within an `aliases_file` config, the change is strictly a *narrowing*: Tiers
1/2 produce identical output, and only pairs that would have fallen through to
a fuzzy guess now pass through instead.

**None of the genuine corrections in the 77 changed resolutions are undone.**
Those corrections came from the 130 → 177 alias-map expansion, i.e. from newly
*declared* entries resolving at Tiers 1/2 — the tier this change does not
touch. The ~27 display-name-only normalizations likewise ride on declared
canonical names. Concretely re-asserted in
`aliases_file_gate_preserves_tier12_declared_resolutions`: the `-c` contractor
email variant, a non-email login handle, a GitHub `users.noreply` alias, and a
case-folded canonical email all still resolve to their canonical pair with the
gate active. The #2244/#2253 improvements are email-*domain* gating in Tier 3,
which is only reachable when fuzzy is enabled and is verified intact there.

## Note: the defect is broader than "name similarity"

Worth flagging for the record — measured, not assumed. The issue attributes the
false positives to name-similarity, but scoring the reported pairs shows the
`#2253`-compliant **email local-part** path is equally implicated whenever the
roster uses `firstname.lastname@domain` addresses and the author is on the same
domain (the domain gate is open, and the local-part comparison is then
isomorphic to the name comparison):

| Pair | Tier 3 name | Tier 3 email (domain-gated) | Tier 4 normalized |
|---|---|---|---|
| Cristian Dominguez → Crislaine Tripoli | 0.8412 | 0.8412 | 0.8412 **hit** |
| Ravi Chandrasekaran → Ravi Pandey | 0.8584 **hit** | 0.8584 **hit** | 0.8584 **hit** |
| Gauri Saykar → Gaurav Sharma | 0.8662 **hit** | 0.8662 **hit** | 0.8662 **hit** |
| Josh Taylor `<josh@…>` → Joshua Lepage | 0.6773 | 0.8615 **hit** | 0.8615 **hit** |
| Joseph Ku → Joshua Lepage | 0.8260 | 0.8260 | 0.8260 **hit** |

(thresholds: Tier 3 = 0.85, Tier 4 = 0.82)

A fix that gated *only* the name-similarity term would have left
`Ravi Chandrasekaran` and `Gauri Saykar` broken via the email path, and
`Josh Taylor` broken outright. Gating the whole fuzzy fallback — which is what
the issue's suggested fix literally says — is what actually clears all five.

Two further corrections to the issue's description:

1. **`Josh Taylor` does not reproduce from the display name.**
   `jaro_winkler("josh taylor", "joshua lepage")` = 0.6773, well under
   threshold. It reproduces from the *email local-part* `josh`, which scores
   0.8615 against `Joshua Lepage` and 0.8500 against `Joshua McCartney` — both
   over threshold. The fixture uses `Josh Taylor <josh@duettoresearch.com>`
   accordingly.

2. **The "inconsistent across runs" behaviour has a concrete cause.**
   `from_alias_map` iterates a `HashMap`, so `members` ordering is
   nondeterministic per process, and both fuzzy loops tie-break with
   `score > best` (strictly greater) — so on an exact score tie the
   first-encountered member wins, and which member that is varies run to run.
   With `josh` the two Joshuas score differently (0.8615 vs 0.8500) so Lepage
   wins deterministically, but any exactly-tied pair in the full 177-entry
   roster flips between runs. This PR removes the symptom for `aliases_file`
   configs; the underlying nondeterministic tie-break still exists on the
   opt-in path and in `from_alias_map` callers, and is worth a follow-up if
   anyone re-enables fuzzy deliberately.

## Round 2 — changes after the BLOCK on #4291

All four findings addressed. Evidence for each below; nothing here is asserted
without a command behind it.

### 1. CRITICAL — the racing test helper (fixed, and the race measured both ways)

`resolver_from_aliases_file` now uses `tempfile::TempDir` (kernel-unique name,
RAII cleanup that also runs on panic). The three manual `remove_dir_all` calls
are gone. I applied the same fix to the **pre-existing**
`duetto_contractors_config_resolves`, which carried the identical broken
`pid + nanos` scheme.

I reproduced the race before fixing it, at the exact committed state
(`ded54b76`), 100 runs, filter `collect::identity::resolver::`:

```
=== PRE-FIX HELPER, 100 RUNS ===
OK:   88
FAIL: 12
```

Both of the critic's captured modes reproduced, with counts:

```
   6  left: "whoever"  right: "Akash Arora"      <- zero-member resolver (:619)
   3  supplying an aliases_file must disable the fuzzy fallback  (:568)
   2  Config::load unwrap panic (:554) / create_dir unwrap panic (:542)
```

12/100 against the critic's 10/100 — same defect, same rate.

**And I confirmed the dangerous direction directly**, rather than inferring it.
A throwaway diagnostic on the pre-fix code, pointing `aliases_file` at a missing
file to simulate exactly what the race produces:

```
resolved_aliases() empty? true
fuzzy_fallback()        = false
--- primary test's assertions against this resolver ---
assert!(!r.fuzzy_fallback())  -> PASSED
  Cristian Dominguez     => Cristian Dominguez (wrong_target=Crislaine Tripoli)
  Ravi Chandrasekaran    => Ravi Chandrasekaran (wrong_target=Ravi Pandey)
  Gauri Saykar           => Gauri Saykar (wrong_target=Gaurav Sharma)
  Josh Taylor            => Josh Taylor (wrong_target=Joshua Lepage)
  Joseph Ku              => Joseph Ku (wrong_target=Joshua Lepage)
ALL PRIMARY ASSERTIONS PASSED against a ZERO-MEMBER resolver.
```

The critic's read was exactly right: a zero-member resolver satisfied **every**
assertion of the primary #4251 test, `!fuzzy_fallback()` included. That
diagnostic was removed; the permanent guards are:

- `assert_roster_loaded()` — a positive control asserting a known roster member
  resolves, called **first** in all three `aliases_file` tests, before anything
  that asserts pass-through.
- `non_vacuity_control_rejects_zero_member_resolver` — a `#[should_panic]` test
  pinning that the control actually rejects a zero-member resolver. A guard
  nobody proves is load-bearing is not a guard.

**Post-fix: 100 consecutive runs, 0 failures**, each run required to execute
exactly 33 tests (a run executing 0 tests is scored a FAILURE by the harness,
not a pass):

```
=== FINAL CODE, 100 RUNS, filter 'collect::identity::resolver::', 33 tests required each run ===
OK:   100
FAIL: 0
run 100 OK (33 passed)
```

No leaked temp dirs: I checked `$TMPDIR`, `/tmp` and `/private/tmp` for
`tga-issue-4251-*` and `tga-duetto-contractors-*` and found 0 in this
environment (the 56 were from the reviewer's own stress runs). `TempDir` makes
recurrence impossible regardless, including on panic.

### 2. HIGH — `Closes #4251` → `Refs #4251`

Done, in both the PR body and the commit message (the branch was rewritten to a
single commit so no `Closes #4251` survives anywhere in history and a squash
merge cannot pick it up). The critic's reasoning is correct and I withdraw my
round-1 claim about the tie-break: I asserted the `score > best` tie-break could
flip `Josh Taylor` between the two Joshuas, but the two scores are **distinct**
(0.8615 vs 0.8500), and a keep-the-max scan is order-independent for distinct
scores. My claim was wrong. The live nondeterminism is the last-writer-wins
`HashMap` alias insert one tier up, which this PR does not touch. #4293 carries it.

### 3. HIGH — gate on the load, not the declaration

Fixed, and I deviated from the suggested one-liner deliberately. The suggested
form:

```rust
.unwrap_or(map.is_empty() && config.aliases_file.is_none())
```

does not do what the finding asks. With a broken alias file it yields
`true && false` = `false` — fuzzy still **off**, i.e. the reported bug is
unchanged. And with a non-empty inline `developer_aliases` map and no
`aliases_file` it yields `false && true` = `false`, silently flipping every
inline-alias deployment to fuzzy-off — well outside #4251's scope.

Implemented instead:

```rust
let alias_table_loaded = match &config.aliases_file {
    None => false,
    Some(_) => match config.resolved_alias_map(config.config_dir()) {
        Ok(m) if !m.is_empty() => true,
        Ok(_)  => { error!(...); false }   // declared but empty
        Err(e) => { error!(error = %e, ...); false }   // declared but unloadable
    },
};
resolver.fuzzy_fallback = config.fuzzy_identity_fallback.unwrap_or(!alias_table_loaded);
```

A declared-but-broken alias file now degrades to the documented pre-#4251
behaviour and logs at `error!`, instead of to silent total fragmentation. Three
new tests pin all three branches, including one that fails under the suggested
one-liner:

- `broken_aliases_file_keeps_fuzzy_enabled` — asserts `resolved_alias_map()` is
  `Err` **and** `resolved_aliases()` is empty (pinning that the swallow is real),
  then that fuzzy stays on.
- `empty_aliases_file_keeps_fuzzy_enabled`
- `inline_developer_aliases_do_not_disable_fuzzy`

### 4. MEDIUM — version and visibility

- `crates/trusty-git-analytics/Cargo.toml` bumped **2.10.0 → 2.11.0**; docs and
  changelog now say v2.11.0. `Cargo.lock` moved by exactly one line (the `tga`
  version) — no dependency refresh.
- The behaviour flip is announced at `info!` with the remediation inline
  (`Set 'fuzzy_identity_fallback: true' to restore guessing`), not `debug!`.
- LOW: the `with_fuzzy_fallback` doc no longer claims `trusty-review`'s selector
  calls it. It now states plainly that no caller sets it today and why it exists.

### 5. My round-1 "stale build" anomaly — retracted, root-caused

The critic was right to reject it. The **temp-dir race** is what I hit, in the
zero-member vacuous-pass mode demonstrated above. The mechanism, confirmed by
reading the code: `Config::load` does **not** read the alias file — resolution
is lazy, in `resolved_aliases()` called later by `from_config`. So the victim
test loads `config.yaml` successfully, the colliding test's cleanup then deletes
the directory, and the lazy alias load fails into the swallowed-error path. That
explains both halves of my anomalous run: the primary test passed vacuously
while the Tier-1/2 test, which had already loaded, passed normally.

The `#[path]` trap the critic raised is **real and I confirmed it**, but it is
not what I hit:

```
filter 'collect::identity::resolver_tests' -> test result: ok. 0 passed; 0 failed; 774 filtered out
filter 'collect::identity::resolver::'     -> test result: ok. 33 passed; 0 failed; 742 filtered out
```

One character of path drift does turn red into "ok". My captured logs from that
run show `running 25 tests` with the target test printing `... ok`, so zero-tests
was not the mechanism. I have made it unable to hide either way: the stress
harness scores any run not executing the expected test count as a FAILURE, and
every count is reported above.

### Red-before / green-after, re-run after the tempfile change

Exact filter: **`cargo test -p tga --lib 'collect::identity::resolver::'`** —
33 tests, count asserted.

BEFORE (gate mutated out of `resolve()`, `cargo clean -p tga` first, everything
else including the tempfile helper and the non-vacuity control left in place):

```
test ...aliases_file_disables_tier34_name_fuzzy ... FAILED
  left: ["Cristian Dominguez <…> => Crislaine Tripoli <…>",
         "Ravi Chandrasekaran <…> => Ravi Pandey <…>",
         "Gauri Saykar <…> => Gaurav Sharma <…>",
         "Josh Taylor <josh@…> => Joshua Lepage <…>",
         "Joseph Ku <…> => Joshua Lepage <…>"]
test ...explicit_opt_out_disables_fuzzy_without_aliases_file ... FAILED
test ...with_fuzzy_fallback_false_suppresses_tier34 ... FAILED

test result: FAILED. 30 passed; 3 failed; 0 ignored; 742 filtered out
```

All five misattributions reproduce **with the non-vacuity control passing**, so
this red is not the zero-member artifact.

AFTER (gate restored):

```
test result: ok. 33 passed; 0 failed; 0 ignored; 742 filtered out
```

## Verification

- `cargo test -p tga` (full suite, no `--lib`): 774 passed / 0 failed / 1 ignored
  (lib), 151/0/0 (bin), 1+2+1 integration, 5 passed / 2 ignored doc-tests. The
  ignored lib test is the pre-existing `core::effort::tests::effort_cross_validate`.
- 100 consecutive runs of `collect::identity::resolver::` — 100 OK, 0 FAIL,
  33 tests executed each run.
- `cargo clippy -p tga --all-targets -- -D warnings` — exit 0.
- `cargo fmt -p tga --check` — exit 0.
- `cargo check -p trusty-review --all-targets` — exit 0 (only downstream
  consumer of `tga`; unaffected, it uses `from_alias_map`).
- `./scripts/check_line_cap.sh` — `7 allowlisted, 0 violations — OK`.

`crates/trusty-git-analytics/CHANGELOG.md` updated under `## [Unreleased]`.
`docs/trusty-git-analytics/requirements/configuration.md` documents the four
tiers and the new key.

Added: 423 / Removed: 0 / Net: +423 (of which 293 are tests, 40 docs,
33 changelog; ~57 production lines, mostly doc comments).

Refs #4251 — the run-to-run inconsistency #4251 also reports is a Tier-1/2
defect this PR does not touch; it is tracked on #4293. Do **not** auto-close
#4251 on merge.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
