### PR TITLE
test(trusty-mpm): pin the deliberately-unfiltered prune active reads, manual + automatic (#4288)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -20,6 +20,16 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   inviting `.filter(|r| r.state == Active)` tidy-up would make a live worktree
   an orphan candidate. The test drives the real route and fails if that filter
   is ever added.
+- `session_manager::prune`: the same pin extended to the two remaining unfiltered
+  reads on the AUTOMATIC orphan-GC path — the active set built in
+  `reap_orphaned_worktrees` (what the daemon's sweep loop calls on a timer, with
+  `dry_run: false` hardcoded and no preview) and the Phase 2 `fresh_active`
+  snapshot inside `prune_orphaned_worktrees` that re-reads the store immediately
+  before deletion. Both are now commented, and
+  `reap_spares_a_stopped_records_workspace` asserts end-to-end that a `Stopped`
+  record's worktree survives a real, deleting sweep. Measured and documented:
+  these two reads are defense-in-depth — neither is load-bearing alone, and only
+  narrowing BOTH actually deletes a live worktree. No behavior change.
 
 - **PM instructions are authored per section** (epic [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183)): the four monolithic assets (`PM_INSTRUCTIONS.md`, `WORKFLOW.md`, `AGENT_DELEGATION.md`, `BASE_PM.md`) are replaced by one markdown source per section under `src/assets/instructions/sections/`, and `core::bundled_pm_package` builds its blocks from those files instead of cutting the monoliths at runtime (the `split_asset` / `Cut` machinery is gone). `instruction_pipeline::pm_instructions()` and `base_pm()` reconstitute the two multi-section strings the legacy override assembly still needs, so a section edit reaches BOTH composers and a project with a `.trusty-mpm/` override can no longer be frozen on stale instructions. Every existing override file (`INSTRUCTIONS.md`, `WORKFLOW.md`, `AGENT_DELEGATION.md`, `MEMORY.md`, `PM_INSTRUCTIONS_DEPLOYED.md`) keeps resolving exactly as before.
 - **Delivered-prompt content changes** (same epic). The Memory and Search guidance is lifted out of the middle of the Core body into two self-contained sections with their own headings — they were two halves of one numbered list, which made their declared `project` tier a false claim (replacing Memory alone left Search opening on a bare `2.`); they are now genuinely independently overridable. `## Trusty Tool Priority (Non-Overridable)` moves to sit with the other non-overridable rules, so it now precedes the framework-guaranteed conventions instead of following them — position only, still inside the floor, wording unchanged. The workflow section gains a **Sprint, then Harden** doctrine (sprint to feature-complete with targeted tests and no CI iteration loops; harden with the full suite, critic and release gates before publishing), including the causal claim that slow release *causes* WIP, the hard line that going fast never licenses turning red green by deleting coverage, and the close-and-fold rule at 3+ review rounds.

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- `daemon::managed_routes::prune`: the orphan sweep's `active_workspace_paths`
+  set is now documented as DELIBERATELY unfiltered by session state, and pinned
+  by a new regression test `prune_spares_a_stopped_records_workspace`
+  ([#4288](https://github.com/bobmatnyc/trusty-tools/issues/4288),
+  [#4207](https://github.com/bobmatnyc/trusty-tools/issues/4207)). No behavior
+  change — the construction is untouched. A `SessionRecord`'s state is
+  bookkeeping, not a liveness signal (a session measured running in tmux was
+  recorded `stopped` while holding uncommitted and unpushed work), so the
+  inviting `.filter(|r| r.state == Active)` tidy-up would make a live worktree
+  an orphan candidate. The test drives the real route and fails if that filter
+  is ever added.
+
 - **PM instructions are authored per section** (epic [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183)): the four monolithic assets (`PM_INSTRUCTIONS.md`, `WORKFLOW.md`, `AGENT_DELEGATION.md`, `BASE_PM.md`) are replaced by one markdown source per section under `src/assets/instructions/sections/`, and `core::bundled_pm_package` builds its blocks from those files instead of cutting the monoliths at runtime (the `split_asset` / `Cut` machinery is gone). `instruction_pipeline::pm_instructions()` and `base_pm()` reconstitute the two multi-section strings the legacy override assembly still needs, so a section edit reaches BOTH composers and a project with a `.trusty-mpm/` override can no longer be frozen on stale instructions. Every existing override file (`INSTRUCTIONS.md`, `WORKFLOW.md`, `AGENT_DELEGATION.md`, `MEMORY.md`, `PM_INSTRUCTIONS_DEPLOYED.md`) keeps resolving exactly as before.
 - **Delivered-prompt content changes** (same epic). The Memory and Search guidance is lifted out of the middle of the Core body into two self-contained sections with their own headings — they were two halves of one numbered list, which made their declared `project` tier a false claim (replacing Memory alone left Search opening on a bare `2.`); they are now genuinely independently overridable. `## Trusty Tool Priority (Non-Overridable)` moves to sit with the other non-overridable rules, so it now precedes the framework-guaranteed conventions instead of following them — position only, still inside the floor, wording unchanged. The workflow section gains a **Sprint, then Harden** doctrine (sprint to feature-complete with targeted tests and no CI iteration loops; harden with the full suite, critic and release gates before publishing), including the causal claim that slow release *causes* WIP, the hard line that going fast never licenses turning red green by deleting coverage, and the close-and-fold rule at 3+ review rounds.
 - `core::pm_prompt_golden_tests`: committed snapshots of the fully composed PM prompt for both the packaged and legacy composers. #4249's byte-equality-against-the-old-prompt gate cannot survive a deliberate content change, so these replace it: any future edit to a section source surfaces as a reviewable prose diff in the PR rather than landing invisibly. Regenerate with `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden`.

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -20,6 +20,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   inviting `.filter(|r| r.state == Active)` tidy-up would make a live worktree
   an orphan candidate. The test drives the real route and fails if that filter
   is ever added.
+- `session_manager::prune`: `prune_orphaned_worktrees`'s `active_workspace_paths`
+  parameter is renamed **`in_use_workspace_paths`** (and its `initial_active` /
+  `fresh_active` locals to `initial_in_use` / `fresh_in_use`). Rename only, no
+  behavior change: the old name is what made `.filter(|r| r.state == Active)`
+  read as a tidy-up rather than a data-loss bug.
+- `session_manager::prune`: `phase2_fresh_snapshot_spares_a_record_the_caller_set_missed`
+  closes a pre-existing coverage hole — the Phase 2 `fresh_in_use` re-read, the
+  last check between a reclaimable candidate and deletion, had ZERO executed
+  coverage. The one test that named it builds its worktree with no ownership
+  sentinel, so the #3649 gate skipped it before Phase 2 ever ran; filtering
+  Phase 2 by state broke nothing in the suite.
 - `session_manager::prune`: the same pin extended to the two remaining unfiltered
   reads on the AUTOMATIC orphan-GC path — the active set built in
   `reap_orphaned_worktrees` (what the daemon's sweep loop calls on a timer, with

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -105,13 +105,37 @@ fn default_dry_run() -> bool {
 /// default, and so is skipping dirty worktrees — `discard_dirty: true` is the
 /// only path to a destructive removal of unsaved work.
 /// Test: `prune_worktrees_route_dry_run`,
-/// `prune_worktrees_request_defaults_to_skip_dirty`.
+/// `prune_worktrees_request_defaults_to_skip_dirty`,
+/// `prune_spares_a_stopped_records_workspace` (#4288).
 pub async fn prune_worktrees_route(
     State(state): State<Arc<DaemonState>>,
     Json(req): Json<PruneWorktreesRequest>,
 ) -> impl IntoResponse {
     let mgr = state.session_manager().await;
     let records = mgr.list().await;
+    // #4288 (item 4 of #4207): DELIBERATELY UNFILTERED. Do NOT "tidy this up"
+    // by adding `.filter(|r| r.state == ManagedSessionState::Active)` — every
+    // record with a `workspace_path` belongs in this set, whatever its state.
+    //
+    // Why: a `SessionRecord`'s state is bookkeeping, NOT a liveness signal. It
+    // is written by reconcile/stop/hook paths that can miss, race, or be
+    // skipped entirely, so live sessions are routinely observed carrying a
+    // terminal state. Measured on this repo 2026-07-28: session
+    // `2eb72dca-de08-481b-8dfa-22ab7f81b1f9` was RUNNING (tmux pane `%981`,
+    // `pane_current_path` inside its own worktree) while `sessions.json`
+    // recorded it as `state: "stopped"`, holding 12 modified tracked files,
+    // 31 untracked files, and 1 unpushed commit.
+    //
+    // What narrowing this set would cost: such a worktree stops being spared
+    // and becomes an orphan CANDIDATE. Everything after that is a gate that
+    // can be open — the #3649 ownership sentinel is the last one, and in the
+    // measured case it was ZERO BYTES (`worktree_ownership::read_sentinel_owner`
+    // correctly maps that to `SentinelOwner::Unknown`, which spares it — but a
+    // well-formed sentinel naming a purged owner does not). This set is what
+    // keeps a live-but-mislabelled worktree off the candidate list at all.
+    //
+    // Pinned by `prune_spares_a_stopped_records_workspace` in this file's test
+    // module — if you broke that test, this comment is what you tripped.
     let active_workspace_paths: Vec<std::path::PathBuf> = records
         .iter()
         .filter_map(|r| r.workspace_path.clone())
@@ -216,5 +240,181 @@ mod tests {
             serde_json::from_str(r#"{"dry_run":false,"discard_dirty":true}"#)
                 .expect("explicit body parses");
         assert!(explicit.discard_dirty, "the opt-in must round-trip");
+    }
+
+    /// Read a route response's JSON body.
+    async fn body_json(resp: axum::response::Response) -> serde_json::Value {
+        let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .expect("route body must be readable");
+        serde_json::from_slice(&bytes).expect("route body must be JSON")
+    }
+
+    /// #4288: a `Stopped` record's workspace is spared by the orphan sweep —
+    /// the active-set construction above must stay UNFILTERED by record state.
+    ///
+    /// Why: session state is not a liveness signal (see the comment at the
+    /// construction site — a live session was measured recorded as `stopped`
+    /// while holding 12 modified files and an unpushed commit). The obvious
+    /// tidy-up, `.filter(|r| r.state == Active)`, would drop that record's
+    /// workspace out of the spared set and hand a LIVE worktree to the
+    /// reclaim path. This test exists to turn that tidy-up red.
+    ///
+    /// Non-vacuity: the fixture is stamped with an aged, well-formed ownership
+    /// sentinel naming a never-registered owner, so EVERY downstream gate
+    /// (#3649 ownership, the `git worktree list` cross-check, the #4091 dirty
+    /// gate) already votes "reclaim". The CONTROL below asserts exactly that
+    /// against an EMPTY active set — so if a future change makes the fixture
+    /// unreclaimable for some unrelated reason, the control fails loudly
+    /// instead of letting the real assertions pass for the wrong reason.
+    /// Membership in `active_workspace_paths` is therefore the ONLY thing
+    /// under test here.
+    /// Test: this function IS the test.
+    ///
+    /// `await_holding_lock` is the point, not an oversight: the route reads the
+    /// workspace root from the process environment, so the crate-wide
+    /// `env_test_lock` must span the awaited route calls or a sibling env test
+    /// can clobber the override mid-request. Each `#[tokio::test]` gets its own
+    /// thread and current-thread runtime, so a blocking sync guard serialises
+    /// those threads without any chance of deadlocking the executor.
+    #[allow(clippy::await_holding_lock)]
+    #[tokio::test]
+    async fn prune_spares_a_stopped_records_workspace() {
+        use crate::session_manager::record::ManagedSessionId;
+        use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+        use crate::session_manager::{ManagedSessionState, SessionRecord};
+
+        let fx = GitWorktreeFixture::new();
+        let wt = fx.add_worktree("stopped-but-live");
+        GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+        let wt_str = wt.to_string_lossy().into_owned();
+
+        let root = crate::test_support::hermetic_temp_dir();
+        let state =
+            Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+        let mgr = state.session_manager().await;
+
+        // CONTROL: with an EMPTY active set the fixture IS reclaimable. Dry-run
+        // so nothing is deleted before the real assertions run.
+        let control = mgr
+            .prune_orphaned_worktrees(&fx.repos_root, &[], true, DirtyWorktreePolicy::Skip)
+            .await
+            .expect("control sweep must not error");
+        assert!(
+            control.removed.contains(&wt),
+            "CONTROL: {wt_str} must be reclaimable with an empty active set, \
+             otherwise this test proves nothing; removed={:?} owner_unknown={:?} \
+             skipped_dirty={:?}",
+            control.removed,
+            control.owner_unknown,
+            control.skipped_dirty
+        );
+
+        // Register the worktree to a record and drive it to `Stopped` — the
+        // exact shape observed on a session that was actually still running.
+        let record = mgr
+            .create_with_id(
+                ManagedSessionId::new(),
+                "pinned by #4288".into(),
+                Some(wt.clone()),
+                None,
+                Some(wt.clone()),
+                None,
+                None,
+                crate::runtime::RuntimeKind::default(),
+                false,
+                false,
+            )
+            .await
+            .expect("seed session record");
+        let stopped = SessionRecord {
+            state: ManagedSessionState::Stopped,
+            ..record
+        };
+        mgr.store
+            .write()
+            .await
+            .upsert(stopped)
+            .await
+            .expect("persist the Stopped record");
+
+        // Point the route's repos-root resolver at the fixture. Held under the
+        // crate-wide env lock and restored before any assertion, matching the
+        // existing env-mutating tests in this crate.
+        let _env = crate::core::trusty_tools_config::env_test_lock();
+        // SAFETY: guarded by env_test_lock; removed below before the asserts.
+        unsafe {
+            std::env::set_var(
+                crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV,
+                &fx.repos_root,
+            )
+        };
+
+        let preview = body_json(
+            prune_worktrees_route(
+                State(state.clone()),
+                Json(PruneWorktreesRequest {
+                    dry_run: true,
+                    discard_dirty: false,
+                }),
+            )
+            .await
+            .into_response(),
+        )
+        .await;
+        let real = body_json(
+            prune_worktrees_route(
+                State(state.clone()),
+                Json(PruneWorktreesRequest {
+                    dry_run: false,
+                    discard_dirty: false,
+                }),
+            )
+            .await
+            .into_response(),
+        )
+        .await;
+
+        // SAFETY: guarded by env_test_lock, still held.
+        unsafe { std::env::remove_var(crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV) };
+
+        let strings = |v: &serde_json::Value, key: &str| -> Vec<String> {
+            v.get(key)
+                .and_then(|x| x.as_array())
+                .unwrap_or_else(|| panic!("route body must carry `{key}`: {v}"))
+                .iter()
+                .map(|s| {
+                    s.as_str()
+                        .unwrap_or_else(|| panic!("`{key}` must hold strings: {v}"))
+                        .to_owned()
+                })
+                .collect()
+        };
+
+        // Dry-run `paths` IS the reclaimable set (see `prune_orphaned_worktrees`).
+        let preview_paths = strings(&preview, "paths");
+        assert!(
+            !preview_paths.contains(&wt_str),
+            "a Stopped record's workspace must NOT be reclaimable; \
+             {wt_str} appeared in the dry-run set {preview_paths:?}"
+        );
+        let preview_unknown = strings(&preview, "owner_unknown_paths");
+        assert!(
+            !preview_unknown.contains(&wt_str),
+            "a spared workspace is never even a candidate, so it must not be \
+             reported as owner-unknown either; got {preview_unknown:?}"
+        );
+
+        // And the real (deleting) run must leave it alone, on disk too.
+        let removed = strings(&real, "paths");
+        assert!(
+            !removed.contains(&wt_str),
+            "a Stopped record's workspace must NOT be removed; \
+             {wt_str} appeared in the removed set {removed:?}"
+        );
+        assert!(
+            wt.exists(),
+            "{wt_str} must still exist on disk after a real prune run"
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -142,7 +142,7 @@ pub async fn prune_worktrees_route(
     // module (which fails on the dry-run preview alone), and end-to-end on the
     // automatic GC path by `reap_spares_a_stopped_records_workspace` in
     // `session_manager::reap_orphaned_worktrees_tests`.
-    let active_workspace_paths: Vec<std::path::PathBuf> = records
+    let in_use_workspace_paths: Vec<std::path::PathBuf> = records
         .iter()
         .filter_map(|r| r.workspace_path.clone())
         .collect();
@@ -158,7 +158,7 @@ pub async fn prune_worktrees_route(
         DirtyWorktreePolicy::Skip
     };
     match mgr
-        .prune_orphaned_worktrees(&repos_root, &active_workspace_paths, req.dry_run, policy)
+        .prune_orphaned_worktrees(&repos_root, &in_use_workspace_paths, req.dry_run, policy)
         .await
     {
         Ok(outcome) => {
@@ -273,7 +273,7 @@ mod tests {
     /// against an EMPTY active set — so if a future change makes the fixture
     /// unreclaimable for some unrelated reason, the control fails loudly
     /// instead of letting the real assertions pass for the wrong reason.
-    /// Membership in `active_workspace_paths` is therefore the ONLY thing
+    /// Membership in `in_use_workspace_paths` is therefore the ONLY thing
     /// under test here.
     /// Test: this function IS the test.
     ///
@@ -284,6 +284,7 @@ mod tests {
     /// thread and current-thread runtime, so a blocking sync guard serialises
     /// those threads without any chance of deadlocking the executor.
     #[allow(clippy::await_holding_lock)]
+    #[serial_test::serial]
     #[tokio::test]
     async fn prune_spares_a_stopped_records_workspace() {
         use crate::session_manager::record::ManagedSessionId;
@@ -344,9 +345,21 @@ mod tests {
             .await
             .expect("persist the Stopped record");
 
-        // Point the route's repos-root resolver at the fixture. Held under the
-        // crate-wide env lock and restored before any assertion, matching the
-        // existing env-mutating tests in this crate.
+        // Point the route's repos-root resolver at the fixture.
+        //
+        // This test issues a DRY-RUN sweep only — it must never run a deleting
+        // sweep whose target root comes from a process-global env var. If a
+        // concurrent test restored that var mid-call, a destructive sweep would
+        // target the operator's real `~/trusty-mpm-projects`, and the
+        // three-read defense would NOT save it: the caller set and the Phase 2
+        // re-read both draw from this empty isolated store, so real worktrees
+        // are absent from both. The deleting half also bought zero mutation
+        // coverage (its assertions pass under the M1 mutation), so it is gone.
+        //
+        // BOTH guards are required and they do not interoperate:
+        // `env_test_lock` serialises the env-precedence tests, while
+        // `#[serial_test::serial]` serialises `connectors::tm_tests`, which
+        // mutates this same var in this same binary under `serial` alone.
         let _env = crate::core::trusty_tools_config::env_test_lock();
         // SAFETY: guarded by env_test_lock; removed below before the asserts.
         unsafe {
@@ -368,19 +381,6 @@ mod tests {
             .into_response(),
         )
         .await;
-        let real = body_json(
-            prune_worktrees_route(
-                State(state.clone()),
-                Json(PruneWorktreesRequest {
-                    dry_run: false,
-                    discard_dirty: false,
-                }),
-            )
-            .await
-            .into_response(),
-        )
-        .await;
-
         // SAFETY: guarded by env_test_lock, still held.
         unsafe { std::env::remove_var(crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV) };
 
@@ -409,18 +409,6 @@ mod tests {
             !preview_unknown.contains(&wt_str),
             "a spared workspace is never even a candidate, so it must not be \
              reported as owner-unknown either; got {preview_unknown:?}"
-        );
-
-        // And the real (deleting) run must leave it alone, on disk too.
-        let removed = strings(&real, "paths");
-        assert!(
-            !removed.contains(&wt_str),
-            "a Stopped record's workspace must NOT be removed; \
-             {wt_str} appeared in the removed set {removed:?}"
-        );
-        assert!(
-            wt.exists(),
-            "{wt_str} must still exist on disk after a real prune run"
         );
     }
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/prune.rs
@@ -126,16 +126,22 @@ pub async fn prune_worktrees_route(
     // recorded it as `state: "stopped"`, holding 12 modified tracked files,
     // 31 untracked files, and 1 unpushed commit.
     //
-    // What narrowing this set would cost: such a worktree stops being spared
-    // and becomes an orphan CANDIDATE. Everything after that is a gate that
-    // can be open — the #3649 ownership sentinel is the last one, and in the
-    // measured case it was ZERO BYTES (`worktree_ownership::read_sentinel_owner`
-    // correctly maps that to `SentinelOwner::Unknown`, which spares it — but a
-    // well-formed sentinel naming a purged owner does not). This set is what
-    // keeps a live-but-mislabelled worktree off the candidate list at all.
+    // What narrowing this set costs, measured rather than assumed (#4288):
+    // such a worktree stops being spared and becomes an orphan CANDIDATE, so
+    // this route's DRY-RUN preview reports a live worktree as reclaimable —
+    // a false report an operator may then act on. It does NOT by itself delete
+    // anything: the real (`dry_run: false`) path re-reads the store for
+    // `prune_orphaned_worktrees`'s Phase 2 `fresh_active` snapshot, itself
+    // deliberately unfiltered, and that second read still spares the candidate
+    // immediately before deletion. The two reads are defense-in-depth; data
+    // loss needs BOTH narrowed. Do not read that as permission to narrow one
+    // "because the other covers it" — that argument applied twice is exactly
+    // how a pair of independent boundaries collapses into none.
     //
     // Pinned by `prune_spares_a_stopped_records_workspace` in this file's test
-    // module — if you broke that test, this comment is what you tripped.
+    // module (which fails on the dry-run preview alone), and end-to-end on the
+    // automatic GC path by `reap_spares_a_stopped_records_workspace` in
+    // `session_manager::reap_orphaned_worktrees_tests`.
     let active_workspace_paths: Vec<std::path::PathBuf> = records
         .iter()
         .filter_map(|r| r.workspace_path.clone())

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -621,7 +621,7 @@ impl SessionManager {
     /// worktrees, but sessions decommissioned before the fix — or where the git
     /// command failed — leave stale `.worktrees/<session-id>/` directories. This
     /// sweep removes them without touching any directory that still corresponds to a
-    /// live session (i.e. whose path appears in `active_workspace_paths`).
+    /// live session (i.e. whose path appears in `in_use_workspace_paths`).
     ///
     /// SAFETY: only directories whose full canonicalized path is NOT in the active
     /// set are removed. Active session worktrees are NEVER touched. Paths are
@@ -629,7 +629,7 @@ impl SessionManager {
     ///
     /// TOCTOU safety (#1840, hardened #1845 item 9): the sweep runs in two phases.
     /// Phase 1 discovers orphan candidates using the caller-supplied
-    /// `active_workspace_paths` snapshot (which may have been taken moments before
+    /// `in_use_workspace_paths` snapshot (which may have been taken moments before
     /// this call). Phase 2 — the real deletion path — takes ONE fresh snapshot from
     /// the live session store immediately before the deletion loop (O(1) lock
     /// acquisitions vs. the prior O(n) per-candidate approach). The snapshot is
@@ -710,7 +710,7 @@ impl SessionManager {
     pub async fn prune_orphaned_worktrees(
         &self,
         repos_root: &std::path::Path,
-        active_workspace_paths: &[std::path::PathBuf],
+        in_use_workspace_paths: &[std::path::PathBuf],
         dry_run: bool,
         policy: DirtyWorktreePolicy,
     ) -> Result<OrphanSweepOutcome, anyhow::Error> {
@@ -720,7 +720,7 @@ impl SessionManager {
 
         let repos_root = repos_root.to_path_buf();
         // Build a canonicalized set for O(1) lookup and symlink safety.
-        let initial_active: HashSet<std::path::PathBuf> = active_workspace_paths
+        let initial_in_use: HashSet<std::path::PathBuf> = in_use_workspace_paths
             .iter()
             .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()))
             .collect();
@@ -729,8 +729,8 @@ impl SessionManager {
         // Propagate a spawn_blocking panic as Err (#1845 item 7) rather than
         // silently returning an empty candidate list.
         let candidates = tokio::task::spawn_blocking({
-            let initial_active = initial_active.clone();
-            move || find_orphaned_worktrees(&repos_root, &initial_active)
+            let initial_in_use = initial_in_use.clone();
+            move || find_orphaned_worktrees(&repos_root, &initial_in_use)
         })
         .await
         .map_err(|e| anyhow::anyhow!("prune-worktrees: orphan scan panicked: {e}"))?;
@@ -796,7 +796,7 @@ impl SessionManager {
         // (Finding 3 #1845: if canonicalize fails on the active side, keep the
         // raw path as a protective fallback so a canonicalize failure can never
         // cause an active worktree to be misidentified as an orphan and deleted).
-        let fresh_active: HashSet<std::path::PathBuf> = {
+        let fresh_in_use: HashSet<std::path::PathBuf> = {
             let mut set = HashSet::new();
             // Raw `workspace_path`s actually observed THIS sweep, used below to
             // evict stale streak entries (#3715 finding 2) — kept separate from
@@ -889,7 +889,7 @@ impl SessionManager {
             // (Finding 3 #1845: protects against active-path canonicalize failures
             // — if the active side couldn't be canonicalized, its raw path is in
             // the set and a raw-path match prevents accidental deletion).
-            if fresh_active.contains(&canonical_candidate) || fresh_active.contains(&candidate) {
+            if fresh_in_use.contains(&canonical_candidate) || fresh_in_use.contains(&candidate) {
                 info!(
                     path = %candidate.display(),
                     "prune-worktrees: skipping — active session appeared after initial snapshot"
@@ -996,7 +996,7 @@ impl SessionManager {
         // SCOPE OF THIS SET, measured rather than assumed (#4288): narrowing
         // THIS read alone does NOT delete anything. It makes a live-but-
         // mislabelled worktree an orphan CANDIDATE, but `prune_orphaned_worktrees`
-        // then re-reads the store for its Phase 2 `fresh_active` snapshot —
+        // then re-reads the store for its Phase 2 `fresh_in_use` snapshot —
         // itself deliberately unfiltered, see the comment there — and that
         // second read still spares the candidate immediately before deletion.
         // The two unfiltered reads are defense-in-depth: NEITHER is load-bearing
@@ -1008,17 +1008,26 @@ impl SessionManager {
         // preview mode to catch it.
         //
         // Pinned by `reap_spares_a_stopped_records_workspace` in
-        // `super::reap_orphaned_worktrees_tests`, which asserts a Stopped
-        // record's worktree survives a real sweep. That test goes red when BOTH
-        // reads are narrowed; it stays green under either single narrowing,
-        // because the other read genuinely still protects the worktree.
-        let active: Vec<std::path::PathBuf> = self
+        // `super::reap_orphaned_worktrees_tests`, which asserts a STOPPED
+        // record's worktree survives a real sweep, and by the pair property
+        // above: that test goes red when BOTH reads are narrowed, and stays
+        // green under either single narrowing because the other read genuinely
+        // still protects the worktree.
+        //
+        // Be precise about what that test does NOT add: the literal
+        // `== Active` tidy-up at THIS line was already caught before it existed,
+        // because `create_with_id` persists records as `Provisioning` (not
+        // `Active`), so `prune_orphaned_worktrees_removes_orphan_preserves_live`
+        // already fails on it. The new coverage here is the STOPPED case — a
+        // state that reads terminal but is routinely live — and the pair
+        // property, not the tidy-up as literally written.
+        let in_use: Vec<std::path::PathBuf> = self
             .list()
             .await
             .into_iter()
             .filter_map(|r| r.workspace_path)
             .collect();
-        self.prune_orphaned_worktrees(repos_root, &active, false, DirtyWorktreePolicy::Skip)
+        self.prune_orphaned_worktrees(repos_root, &in_use, false, DirtyWorktreePolicy::Skip)
             .await
     }
 

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -803,6 +803,22 @@ impl SessionManager {
             // `set` because `set` also accumulates canonicalized forms, which are
             // not the keys `CanonicalizeFailureStreaks` tracks.
             let mut checked_paths: HashSet<std::path::PathBuf> = HashSet::new();
+            // #4288: DELIBERATELY UNFILTERED by record state, exactly like the
+            // caller-supplied set this backstops. Do NOT add
+            // `if r.state != Active { continue; }` here — a `SessionRecord`'s
+            // state is bookkeeping, not a liveness signal (session
+            // `2eb72dca-…` was measured RUNNING in tmux pane `%981` while
+            // recorded `state: "stopped"`, holding 12 modified tracked files,
+            // 31 untracked files, and 1 unpushed commit).
+            //
+            // This read is the LAST thing standing between a reclaimable
+            // candidate and `remove_session_worktree`. It is what makes
+            // narrowing any single caller's active set survivable, so it is
+            // also the one whose loss is least visible: filter here and the
+            // callers' own unfiltered reads still hide the damage until one of
+            // them is tidied up too. Pinned by
+            // `reap_spares_a_stopped_records_workspace` (real sweep) — that
+            // test goes red once this read AND a caller's set are both narrowed.
             for r in self.store.read().await.cached_all() {
                 let session_id = r.id;
                 let Some(p) = r.workspace_path else {
@@ -954,7 +970,8 @@ impl SessionManager {
     ///
     /// Gates 2 and 4 are independent structural boundaries by design: neither is
     /// load-bearing alone.
-    /// Test: `reap_orphaned_worktrees_removes_orphan_preserves_live` in
+    /// Test: `reap_orphaned_worktrees_removes_orphan_preserves_live` and
+    /// `reap_spares_a_stopped_records_workspace` (#4288) in
     /// `super::reap_orphaned_worktrees_tests`;
     /// `enumerate_excludes_a_sibling_checkout_of_the_same_repo` and
     /// `enumerate_excludes_a_worktree_parked_beside_the_project` pin gate 2.
@@ -962,6 +979,39 @@ impl SessionManager {
         &self,
         repos_root: &std::path::Path,
     ) -> Result<OrphanSweepOutcome, anyhow::Error> {
+        // #4288 (item 4 of #4207): DELIBERATELY UNFILTERED, exactly as in the
+        // manual `prune_worktrees_route`. Do NOT "tidy this up" by adding
+        // `.filter(|r| r.state == ManagedSessionState::Active)` — every record
+        // with a `workspace_path` belongs in this set, whatever its state.
+        //
+        // Why: a `SessionRecord`'s state is bookkeeping, NOT a liveness signal.
+        // It is written by reconcile/stop/hook paths that can miss, race, or be
+        // skipped entirely, so live sessions are routinely observed carrying a
+        // terminal state. Measured on this repo 2026-07-28: session
+        // `2eb72dca-de08-481b-8dfa-22ab7f81b1f9` was RUNNING (tmux pane `%981`,
+        // `pane_current_path` inside its own worktree) while `sessions.json`
+        // recorded it as `state: "stopped"`, holding 12 modified tracked files,
+        // 31 untracked files, and 1 unpushed commit.
+        //
+        // SCOPE OF THIS SET, measured rather than assumed (#4288): narrowing
+        // THIS read alone does NOT delete anything. It makes a live-but-
+        // mislabelled worktree an orphan CANDIDATE, but `prune_orphaned_worktrees`
+        // then re-reads the store for its Phase 2 `fresh_active` snapshot —
+        // itself deliberately unfiltered, see the comment there — and that
+        // second read still spares the candidate immediately before deletion.
+        // The two unfiltered reads are defense-in-depth: NEITHER is load-bearing
+        // alone, and data loss requires narrowing BOTH. Do not read that as
+        // permission to narrow one "because the other covers it" — that reasoning
+        // applied twice is exactly how a pair of independent boundaries collapses
+        // into none, and this path is the one that runs unattended on a timer
+        // (`daemon::mod`'s orphan-GC loop) with `dry_run: false` hardcoded and no
+        // preview mode to catch it.
+        //
+        // Pinned by `reap_spares_a_stopped_records_workspace` in
+        // `super::reap_orphaned_worktrees_tests`, which asserts a Stopped
+        // record's worktree survives a real sweep. That test goes red when BOTH
+        // reads are narrowed; it stays green under either single narrowing,
+        // because the other read genuinely still protects the worktree.
         let active: Vec<std::path::PathBuf> = self
             .list()
             .await

--- a/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/prune_orphan_tests.rs
@@ -80,7 +80,7 @@ fn prune_orphaned_worktrees_collects_orphan() {
 ///
 /// Why: the existing sync test at `prune_orphaned_worktrees_fresh_active_set_blocks_deletion`
 /// only calls `find_orphaned_worktrees` directly, giving zero executed coverage of
-/// the Phase 2 `fresh_active` snapshot logic in the async method. This test goes
+/// the Phase 2 `fresh_in_use` snapshot logic in the async method. This test goes
 /// end-to-end through `prune_orphaned_worktrees` with a real `SessionManager`:
 /// Phase 1 finds the worktree as a candidate (empty initial snapshot), then Phase 2
 /// reads the live store and finds the matching record — skipping deletion.
@@ -496,7 +496,7 @@ async fn prune_orphaned_worktrees_spares_live_owner() {
     let wt = fx.add_worktree("live-owner-elsewhere");
 
     // Register the owner as a LIVE record whose workspace_path points
-    // somewhere else entirely — so `wt` is NOT in `active_workspace_paths`
+    // somewhere else entirely — so `wt` is NOT in `in_use_workspace_paths`
     // (it looks orphaned by the path-only check) but its sentinel's owner
     // is still genuinely alive.
     let owner_id = ManagedSessionId::new();
@@ -1221,4 +1221,103 @@ async fn prune_orphaned_worktrees_dry_run_reports_dirty_skip() {
         outcome.skipped_dirty
     );
     assert!(wt.exists(), "dry-run must not touch anything");
+}
+
+/// #4288 M3: the Phase 2 `fresh_in_use` snapshot spares a worktree whose record
+/// the CALLER's (stale) snapshot missed — the read that nothing else covers.
+///
+/// Why: `prune_orphaned_worktrees` protects a live worktree twice — once via
+/// the caller-supplied set, and again via the Phase 2 re-read of the store
+/// taken immediately before deletion. The Phase 2 read is the LAST thing
+/// between a reclaimable candidate and `remove_session_worktree`, and until
+/// this test it had ZERO executed coverage: the one test that names it
+/// (`prune_orphaned_worktrees_store_snapshot_blocks_deletion`) builds its
+/// worktree with NO ownership sentinel, so the #3649 gate classifies it
+/// owner-unknown and skips it BEFORE Phase 2 ever runs — as that test's own
+/// comment states. Filtering Phase 2 by `state` therefore broke nothing in the
+/// entire suite, which is exactly the invisible-loss shape this PR exists to
+/// close.
+///
+/// What: an EMPTY caller set models the realistic TOCTOU case Phase 2 was
+/// built for (#1845 item 9) — a snapshot taken before the record existed, or
+/// stale by the time the sweep reaches the deletion loop. Phase 1.5 still
+/// votes "reclaim" (the sentinel names a never-registered owner, unrelated to
+/// the record below), so Phase 2 is the ONLY thing that can spare it.
+///
+/// Non-vacuity: the CONTROL is the dry-run of the SAME sweep with the SAME
+/// record present. Dry-run returns before Phase 2, so it still lists the
+/// worktree as reclaimable — the delta between that and the real run below IS
+/// the Phase 2 protection, and it cannot be faked by a fixture that was simply
+/// never reclaimable.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn phase2_fresh_snapshot_spares_a_record_the_caller_set_missed() {
+    use crate::session_manager::record::{ManagedSessionState, SessionRecord};
+
+    let (mgr, _store, fx, wt) = reclaimable_fixture("stale-caller-set").await;
+
+    // Register the worktree to a record and drive it to `Stopped` — the shape
+    // observed on a session that was in fact still running.
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "pinned by #4288".into(),
+            Some(wt.clone()),
+            None,
+            Some(wt.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session record");
+    let stopped = SessionRecord {
+        state: ManagedSessionState::Stopped,
+        ..record
+    };
+    mgr.store
+        .write()
+        .await
+        .upsert(stopped)
+        .await
+        .expect("persist the Stopped record");
+
+    // CONTROL: dry-run returns BEFORE Phase 2, so the worktree is still a
+    // reclaimable candidate even with the record in the store. This proves
+    // every earlier gate votes "reclaim" and that only Phase 2 can save it.
+    let control = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], true, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("control sweep must not error");
+    assert!(
+        control.removed.contains(&wt),
+        "CONTROL: {} must reach Phase 2 as a reclaimable candidate, otherwise \
+         this test proves nothing; removed={:?} owner_unknown={:?} skipped_dirty={:?}",
+        wt.display(),
+        control.removed,
+        control.owner_unknown,
+        control.skipped_dirty
+    );
+
+    // THE PIN: the real (deleting) sweep, caller set still empty. Only the
+    // Phase 2 re-read of the store stands between this worktree and deletion.
+    let outcome = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], false, DirtyWorktreePolicy::Skip)
+        .await
+        .expect("prune must not error");
+
+    assert!(
+        !outcome.removed.contains(&wt),
+        "the Phase 2 fresh snapshot must spare a worktree backed by a store \
+         record the caller's set missed; {} appeared in the removed set {:?}",
+        wt.display(),
+        outcome.removed
+    );
+    assert!(
+        wt.exists(),
+        "{} must still exist on disk after the real sweep",
+        wt.display()
+    );
 }

--- a/crates/trusty-mpm/src/session_manager/reap_orphaned_worktrees_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reap_orphaned_worktrees_tests.rs
@@ -131,7 +131,7 @@ async fn reap_orphaned_worktrees_removes_orphan_preserves_live() {
 ///
 /// WHAT THIS TEST DOES AND DOES NOT CATCH — measured, not assumed. There are
 /// TWO deliberately-unfiltered reads on this path: the caller-supplied set
-/// built in `reap_orphaned_worktrees`, and the Phase 2 `fresh_active` snapshot
+/// built in `reap_orphaned_worktrees`, and the Phase 2 `fresh_in_use` snapshot
 /// that `prune_orphaned_worktrees` re-reads from the store immediately before
 /// deleting. They are defense-in-depth, and NEITHER is load-bearing alone:
 /// narrowing only the reap-side set leaves the worktree a candidate that
@@ -140,6 +140,13 @@ async fn reap_orphaned_worktrees_removes_orphan_preserves_live() {
 /// single narrowing and goes RED when BOTH are narrowed — verified in both
 /// directions. It pins the PAIR, which is the property that actually keeps a
 /// live worktree on disk; it is not a tripwire on either read in isolation.
+///
+/// Nor does it add coverage for the literal `== Active` tidy-up at the reap
+/// site: `create_with_id` persists records as `Provisioning`, not `Active`, so
+/// `reap_orphaned_worktrees_removes_orphan_preserves_live` above already fails
+/// on that mutation via its own live record. What is new here is the STOPPED
+/// case — a state that reads terminal but is routinely live — which no
+/// existing test covered on this path.
 ///
 /// Non-vacuity: the fixture carries an aged, well-formed ownership sentinel
 /// naming a NEVER-REGISTERED owner, so every downstream gate already votes

--- a/crates/trusty-mpm/src/session_manager/reap_orphaned_worktrees_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reap_orphaned_worktrees_tests.rs
@@ -117,3 +117,123 @@ async fn reap_orphaned_worktrees_removes_orphan_preserves_live() {
         outcome.owner_unknown
     );
 }
+
+/// #4288: the AUTOMATIC GC path spares a `Stopped` record's workspace — its
+/// active-set construction must stay UNFILTERED by record state.
+///
+/// Why: this is the sibling of `prune_spares_a_stopped_records_workspace`
+/// (which pins the manual HTTP route). `reap_orphaned_worktrees` is what the
+/// daemon's orphan-GC loop calls on a timer; it hardcodes `dry_run: false` and
+/// has no preview mode, so it is the path that would destroy a live worktree
+/// unattended. Session state is not a liveness signal: a session measured
+/// still running in tmux was recorded `stopped` while holding 12 modified
+/// files, 31 untracked files, and an unpushed commit.
+///
+/// WHAT THIS TEST DOES AND DOES NOT CATCH — measured, not assumed. There are
+/// TWO deliberately-unfiltered reads on this path: the caller-supplied set
+/// built in `reap_orphaned_worktrees`, and the Phase 2 `fresh_active` snapshot
+/// that `prune_orphaned_worktrees` re-reads from the store immediately before
+/// deleting. They are defense-in-depth, and NEITHER is load-bearing alone:
+/// narrowing only the reap-side set leaves the worktree a candidate that
+/// Phase 2 still spares; narrowing only Phase 2 leaves the worktree out of the
+/// candidate list entirely. This test therefore stays GREEN under either
+/// single narrowing and goes RED when BOTH are narrowed — verified in both
+/// directions. It pins the PAIR, which is the property that actually keeps a
+/// live worktree on disk; it is not a tripwire on either read in isolation.
+///
+/// Non-vacuity: the fixture carries an aged, well-formed ownership sentinel
+/// naming a NEVER-REGISTERED owner, so every downstream gate already votes
+/// "reclaim". That detail is load-bearing and not incidental — a sentinel
+/// naming the stopped session ITSELF would be spared at the #3649 gate
+/// (`resolve_ownerless_with_grace` treats `Stopped` as live/resumable, NOT
+/// terminal), so such a fixture would survive the mutation too and pin
+/// nothing. The CONTROL below asserts reclaimability against an EMPTY active
+/// set, so if a future change makes this fixture unreclaimable for an
+/// unrelated reason the control fails loudly instead of letting the real
+/// assertions pass for the wrong reason. Active-set membership is therefore
+/// the ONLY thing under test.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn reap_spares_a_stopped_records_workspace() {
+    use super::record::{ManagedSessionState, SessionRecord};
+    use super::worktree_git_fixture::GitWorktreeFixture;
+
+    let store_dir = TempDir::new().unwrap();
+    let mgr = SessionManager::new(store_dir.path(), FakeTmuxDriver::new())
+        .await
+        .expect("manager");
+
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("stopped-but-live");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+
+    // CONTROL: with an EMPTY active set this fixture IS reclaimable. Dry-run,
+    // so nothing is deleted before the real assertions run.
+    let control = mgr
+        .prune_orphaned_worktrees(&fx.repos_root, &[], true, super::DirtyWorktreePolicy::Skip)
+        .await
+        .expect("control sweep must not error");
+    assert!(
+        control.removed.contains(&wt),
+        "CONTROL: {} must be reclaimable with an empty active set, otherwise \
+         this test proves nothing; removed={:?} owner_unknown={:?} skipped_dirty={:?}",
+        wt.display(),
+        control.removed,
+        control.owner_unknown,
+        control.skipped_dirty
+    );
+
+    // Register the worktree to a record and drive it to `Stopped` — the exact
+    // shape observed on a session that was in fact still running.
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "pinned by #4288".into(),
+            Some(wt.clone()),
+            None,
+            Some(wt.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session record");
+    let stopped = SessionRecord {
+        state: ManagedSessionState::Stopped,
+        ..record
+    };
+    mgr.store
+        .write()
+        .await
+        .upsert(stopped)
+        .await
+        .expect("persist the Stopped record");
+
+    // The automatic sweep always really deletes (`dry_run: false` is hardcoded),
+    // so this is the destructive path, not a preview.
+    let outcome = mgr
+        .reap_orphaned_worktrees(&fx.repos_root)
+        .await
+        .expect("reap must not error");
+
+    assert!(
+        !outcome.removed.contains(&wt),
+        "a Stopped record's workspace must NOT be removed by the automatic \
+         orphan-GC sweep; {} appeared in the removed set {:?}",
+        wt.display(),
+        outcome.removed
+    );
+    assert!(
+        !outcome.owner_unknown.contains(&wt),
+        "a spared workspace is never even a candidate, so it must not be \
+         reported as owner-unknown either; got {:?}",
+        outcome.owner_unknown
+    );
+    assert!(
+        wt.exists(),
+        "{} must still exist on disk after the automatic sweep",
+        wt.display()
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/search_gc.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc.rs
@@ -187,7 +187,7 @@ pub(super) struct IndexSnapshot {
 /// named `.worktrees` (mirrors [`is_session_worktree`] — the sweep NEVER
 /// touches a manually-registered, persistent, non-session project index),
 /// (b) neither `entry.root_path` nor its canonicalized form appears in
-/// `active_workspace_paths` (a live session still claims this root), and (c)
+/// `in_use_workspace_paths` (a live session still claims this root), and (c)
 /// `entry.chunk_count == 0` OR `entry.root_path` no longer exists on disk.
 /// Test: `is_orphan_index_false_for_non_worktree_root`,
 /// `is_orphan_index_false_when_claimed_by_active_session`,
@@ -247,7 +247,7 @@ async fn fetch_chunk_count(client: &reqwest::Client, base: &str, id: &str) -> u6
 impl SessionManager {
     /// Snapshot every live managed session's workspace path, canonicalized
     /// (with a raw-path fallback for symlink-canonicalize failures — mirrors
-    /// `prune::prune_orphaned_worktrees`'s `fresh_active` construction).
+    /// `prune::prune_orphaned_worktrees`'s `fresh_in_use` construction).
     async fn active_workspace_path_set(&self) -> HashSet<PathBuf> {
         let mut set = HashSet::new();
         for p in self


### PR DESCRIPTION
## What

Pins the "deliberately unfiltered by session state" property of the orphan-worktree sweep with regression tests, explanatory comments, and one rename. **No behavior change.**

Standalone extraction of **item 4** of #4288, itself in-scope under #4207. #4288 stays **open** — this PR lands one item of it, not the rest of slice 3.

## The property

Three reads build "which workspaces are in use", none filtered by record state:

| # | Site | Role |
|---|---|---|
| M1 | `daemon/managed_routes/prune.rs` — `prune_worktrees_route` | caller set, manual HTTP route |
| M2 | `session_manager/prune.rs` — `reap_orphaned_worktrees` | caller set, **automatic** GC loop (`dry_run: false`, no preview) |
| M3 | `session_manager/prune.rs` — Phase 2 `fresh_in_use` in `prune_orphaned_worktrees` | re-read from the store immediately before each deletion |

**Session state is not a liveness signal.** Measured 2026-07-28: session `2eb72dca-…` was **running** (tmux pane `%981`, cwd inside its own worktree) while `sessions.json` recorded it `state: "stopped"`, holding 12 modified tracked files, 31 untracked files, and 1 unpushed commit.

These are **defense-in-depth: no single read is load-bearing.** Narrowing one alone never deletes; narrowing a caller set *and* Phase 2 does. The comments say so and warn against the failure mode this invites — narrowing one "because the other covers it", an argument that applied twice collapses a pair of independent boundaries into none.

## Changes

- **Comments** at all three reads, each naming the test that trips on it.
- **`prune_spares_a_stopped_records_workspace`** — drives the real route, dry-run only (see below).
- **`reap_spares_a_stopped_records_workspace`** — real deleting sweep on the automatic path.
- **`phase2_fresh_snapshot_spares_a_record_the_caller_set_missed`** — closes a pre-existing hole (below).
- **Rename** `active_workspace_paths` → `in_use_workspace_paths` (and `initial_active`/`fresh_active` → `initial_in_use`/`fresh_in_use`). Rename only. The old name is what made `state == Active` read as a tidy-up rather than a data-loss bug.
- `CHANGELOG.md`.

Deferred deliberately: folding the sites into a shared helper (behavior-affecting; this PR is not).

## Review round 2 — the BLOCK is addressed

**1. The destructive sweep is gone.** The site-1 test previously ran a real deleting sweep whose target root resolves inside the route from process-global `TRUSTY_MPM_WORKSPACE_ROOT` — which `connectors::tm_tests` mutates in the same binary under `#[serial_test::serial]`, a guard that does **not** interoperate with `env_test_lock`. A restore landing in that window would have pointed a deleting sweep at the operator's real `~/trusty-mpm-projects`, and the three-read defense cannot help there: the caller set and the Phase 2 re-read both draw from the same empty isolated store. It also bought **zero** mutation coverage — its assertions pass under M1. The test now issues exactly one route call, `dry_run: true`, and carries **both** guards (`env_test_lock` *and* `#[serial_test::serial]`). The dry-run assertions are what pin site 1.

**2. M3 now has a pin — and the hole was pre-existing.** The Phase 2 re-read is the last check between a reclaimable candidate and `remove_session_worktree`, and it had **zero executed coverage**. The only test naming it, `prune_orphaned_worktrees_store_snapshot_blocks_deletion`, builds its worktree with **no ownership sentinel**, so the #3649 gate classifies it owner-unknown and skips it *before* Phase 2 runs — as that test's own comment states. That is why filtering Phase 2 broke nothing. The new test uses an empty caller set (the TOCTOU case Phase 2 exists for, #1845 item 9) with a reclaimable sentinel; the **control** is the dry-run of the same sweep, which returns before Phase 2 and still lists the worktree — so the delta between control and real run *is* the Phase 2 protection, and cannot be faked by a fixture that was simply never reclaimable.

**3. Parameter renamed**, as above.

**Accuracy correction on site 2.** The literal `== Active` mutation at the reap site was **already** caught before this PR, because `create_with_id` persists records as `Provisioning`, not `Active`. Site 2's real value is the **Stopped** case — a state that reads terminal but is routinely live — and the pair property. The comment and test doc now say that rather than implying the test catches the tidy-up directly.

## Isolation matrix — re-run in full after the changes

| mutation | site-1 test | site-2 test | Phase 2 test | pre-existing reap test | suite |
|---|---|---|---|---|---|
| **pristine** | ok | ok | ok | ok | **3897 passed, 0 failed** |
| **M1** route set | **FAILED** | ok | ok | ok | red |
| **M2** reap set | ok | ok | ok | **FAILED** | red |
| **M3** Phase 2 | ok | ok | **FAILED** | ok | red |
| **M2+M3** | ok | **FAILED** | **FAILED** | **FAILED** | red |

**Every read is now caught by something in isolation.** M3 previously left the suite fully green.

### Gates

```
cargo test -p trusty-mpm          (without --lib)
test result: ok. 3897 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 32.10s
```

`cargo clippy -p trusty-mpm --all-targets -- -D warnings` → exit 0; `cargo fmt --check` → exit 0; `scripts/check_line_cap.sh` → 0 violations.

Diff vs merge-base: 6 files, +530 / −18 — comments, tests, the rename, and `CHANGELOG.md`.

Refs #4288, #4207

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

