### PR TITLE
feat(trusty-agents): assistants are tier L0 (ADR-0024 decision 3)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **Assistants are tier L0 (ADR-0024 decision 3).** An agent whose `[agent].role`
+  is `assistant` now resolves `AgentTier::L0Orchestration` instead of
+  `L1Standard`; sub-agent roles (`engineer`, `qa`, `researcher`, `documentation`,
+  `ops`, `planner`, …) stay `L1Standard`. The Sub-agents pane consequently
+  reports `tier l0` for the viewing assistant and for peer-assistant target
+  cards, and `tier l1` for sub-agents — it previously labelled every agent
+  `l1`, including assistant-kind ones. The tier is DERIVED from the agent's kind
+  by `AgentTier::for_kind`, so no agent TOML changed and none needs a
+  `tier = "l0"` line; an explicit `[agent].tier` declaration still wins in both
+  directions and is still fail-closed (an unrecognized value narrows to L1 and
+  can never elevate). No capability grant changes: delegation refusal keys on
+  agent KIND rather than tier order, and the one tier-conditioned surface
+  (#4171's read-only session-state tools) stays unreachable for every bundled
+  assistant because none names those tools in its `[tools].allow`.
+
 ### Added
 
 - **The Skills pane renders function skills as groups (#4024).** A `kind:

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -659,20 +659,23 @@ pub struct AgentInfo {
     /// specialist `role` can never accidentally grant it orchestration-tier
     /// delegation reach as a side effect.
     /// What: Raw TOML string (`"l0"` / `"orchestration"` for L0,
-    /// `"l1"` / `"standard"` for L1, case-insensitive). Resolved by
-    /// [`AgentInfo::tier`], which FAILS CLOSED: `None` (field absent —
-    /// every persona shipped before #4168, and the overwhelming majority
-    /// going forward), an unrecognized string, or a blank/whitespace-only
-    /// string all resolve to [`AgentTier::L1Standard`] — the most
-    /// restricted tier — NEVER [`AgentTier::L0Orchestration`]. This is a
-    /// privilege boundary, not a convenience default: every call site that
-    /// needs to know an agent's tier MUST call `AgentInfo::tier()`, never
-    /// match on this raw field.
+    /// `"l1"` / `"standard"` for L1, case-insensitive) — an OPTIONAL
+    /// OVERRIDE, not the primary source. Resolved by [`AgentInfo::tier`],
+    /// which since ADR-0024 decision 3 DERIVES the tier from the agent's
+    /// KIND ([`AgentTier::for_kind`]) whenever this field is absent or
+    /// blank, and honours an explicit declaration otherwise. A declaration
+    /// still FAILS CLOSED: an unrecognized string resolves to
+    /// [`AgentTier::L1Standard`], never [`AgentTier::L0Orchestration`], so a
+    /// typo can only ever narrow. This is a privilege boundary, not a
+    /// convenience default: every call site that needs to know an agent's
+    /// tier MUST call `AgentInfo::tier()`, never match on this raw field.
     /// Test: `agent_tier_defaults_to_l1_when_absent`,
     /// `agent_tier_parses_l0_orchestration_aliases`,
     /// `agent_tier_parses_l1_standard_aliases`,
     /// `agent_tier_unknown_value_fails_closed_to_l1`,
-    /// `agent_tier_blank_value_fails_closed_to_l1`.
+    /// `agent_tier_blank_value_fails_closed_to_l1`,
+    /// `agent_tier_derives_l0_for_the_assistant_kind`,
+    /// `agent_tier_explicit_declaration_overrides_the_derived_kind`.
     #[serde(default)]
     pub tier: Option<String>,
 }
@@ -691,6 +694,15 @@ pub struct AgentInfo {
 /// This PR defines the tier and its one-directional delegation boundary
 /// ONLY; it grants L0 no actual capabilities (those are #4170-#4173) and
 /// creates no L0 persona instance.
+///
+/// ADR-0024 decision 3 (ratified by the owner 2026-07-28) INVERTS that
+/// population assignment: every assistant IS L0, and L1 is the sub-agent
+/// population (`engineer`, `qa`, `documentation`, `ops`, `planner`,
+/// `researcher`, …). The paragraph above is retained verbatim as the record
+/// of what #4168 shipped; read it as history, not as the current population.
+/// The tier is now DERIVED from kind by [`AgentTier::for_kind`] — see
+/// [`AgentInfo::tier`] for why that replaced a per-file `tier = "l0"`
+/// literal on every assistant TOML.
 /// What: Two variants. `L1Standard` is `#[default]` — every accessor that
 /// falls back to `Default::default()` (or an explicit fail-closed match
 /// arm) lands on the restricted tier, never the elevated one.
@@ -745,6 +757,49 @@ impl AgentTier {
         }
     }
 
+    /// The tier every agent of this KIND holds (ADR-0024 decision 3).
+    ///
+    /// Why: ADR-0024 decision 3 — "assistants are a level 0 agent, like a PM,
+    /// that can delegate to sub-agents and communicate with each other" —
+    /// makes tier a FUNCTION of kind, not an independent per-file fact. The
+    /// two shapes available were a `tier = "l0"` literal in every bundled
+    /// assistant TOML, or this derivation. The literal loses: `izzie`,
+    /// `cto-assistant` and `ctrl` each ship TWO resolvable forms (a directory
+    /// package AND a flat `extends`-shadow-fallback TOML), so the literal
+    /// would have to be written six-plus times and kept in sync forever, and
+    /// a future assistant persona that forgot it would resolve L1 — silently
+    /// decorrelating the DATA from the model, which is the exact failure
+    /// class ADR-0024's "Why this class of error recurs" section is about.
+    /// Deriving cannot drift: there is no second place to forget.
+    ///
+    /// This narrows #4168's "never inferred from `role`" rule rather than
+    /// discarding it, and the property that rule protected is preserved: an
+    /// operator adding a NEW SPECIALIST role still lands on `L1Standard`,
+    /// because the derivation recognizes exactly one value — the assistant
+    /// kind — and nothing else. `role == "assistant"` is already the most
+    /// privileged non-orchestrator role in the crate (it is the ONLY role
+    /// `build_registry_for_agent` routes into `build_assistant_tier_registry`,
+    /// the one branch that registers `delegate_to_agent` and the git tool
+    /// surface at all), so deriving L0 from it restates a trust decision the
+    /// codebase already makes rather than creating a new escalation path.
+    /// What: [`AgentTier::L0Orchestration`] for the assistant kind (via
+    /// `delegation::is_assistant_kind`, the ONE definition of that predicate —
+    /// the same function `DelegateToAgentTool::execute` and the `/subagents`
+    /// route call), [`AgentTier::L1Standard`] for every other role, including
+    /// the empty string and `orchestrator`/`controller` (`pm`, which sits
+    /// outside this model and receives `L0Orchestration` explicitly from
+    /// `ctrl_delegate_posture` at dispatch time instead).
+    /// Test: `agent_tier_for_kind_is_l0_only_for_the_assistant_role`,
+    /// `agent_tier_derives_l0_for_the_assistant_kind`,
+    /// `agent_tier_derives_l1_for_every_sub_agent_kind`.
+    pub fn for_kind(role: &str) -> Self {
+        if crate::agents::delegation::is_assistant_kind(role) {
+            AgentTier::L0Orchestration
+        } else {
+            AgentTier::L1Standard
+        }
+    }
+
     /// The canonical lowercase wire label for this tier (`"l0"` / `"l1"`).
     ///
     /// Why: `GET /api/agents/:name/subagents` (#4029) reports both the
@@ -764,30 +819,55 @@ impl AgentTier {
 }
 
 impl AgentInfo {
-    /// Resolve this agent's privilege tier, fail-closed (#4168).
+    /// Resolve this agent's privilege tier: declared wins, else derived from
+    /// KIND (#4168; ADR-0024 decision 3).
     ///
-    /// Why: The single normalization point for the raw [`Self::tier`]
-    /// string — see that field's doc comment for the full fail-closed
-    /// rationale. Every consumer (the delegation gate, and any future
-    /// L0-gated capability) MUST call this rather than matching on the raw
-    /// field, so "what counts as L0" can never drift between call sites.
-    /// What: Case-insensitive, trimmed match against `"l0"`/`"orchestration"`
-    /// (-> [`AgentTier::L0Orchestration`]) and `"l1"`/`"standard"` (->
-    /// [`AgentTier::L1Standard`]); anything else — absent, blank, or an
-    /// unrecognized string — resolves to [`AgentTier::L1Standard`].
+    /// Why: The single resolution point for an agent's tier — see
+    /// [`Self::tier`]'s field doc and [`AgentTier::for_kind`] for the full
+    /// rationale. Every consumer (the delegation gate's defense-in-depth
+    /// layer, the `/subagents` route, the L0-only session-state surface) MUST
+    /// call this rather than matching on the raw field, so "what counts as L0"
+    /// can never drift between call sites.
+    ///
+    /// ADR-0024 decision 3: assistant-kind agents ARE L0. That is expressed
+    /// here as a derivation rather than as a `tier = "l0"` literal in each
+    /// bundled assistant TOML because there is no single such file — `izzie`,
+    /// `cto-assistant` and `ctrl` each ship a directory package AND a flat
+    /// fallback, and a literal that must be repeated is a literal that will
+    /// eventually disagree with itself. See `AgentTier::for_kind`.
+    /// What: An explicit, non-blank `[agent].tier` declaration WINS and is
+    /// parsed by [`AgentTier::from_declared`] — case-insensitive, trimmed,
+    /// fail-closed (an unrecognized value resolves to
+    /// [`AgentTier::L1Standard`], so a typo can only narrow, never elevate).
+    /// An ABSENT or blank declaration derives from `role` via
+    /// [`AgentTier::for_kind`]: the assistant kind resolves
+    /// [`AgentTier::L0Orchestration`], every other role
+    /// [`AgentTier::L1Standard`]. The explicit branch is retained so an
+    /// operator can still pin a genuinely-L0 non-assistant persona, or
+    /// deliberately narrow one assistant back to L1 — both are declared
+    /// intent, never an accident of omission.
     /// Test: `agent_tier_defaults_to_l1_when_absent`,
     /// `agent_tier_parses_l0_orchestration_aliases`,
     /// `agent_tier_parses_l1_standard_aliases`,
     /// `agent_tier_unknown_value_fails_closed_to_l1`,
-    /// `agent_tier_blank_value_fails_closed_to_l1`.
+    /// `agent_tier_blank_value_fails_closed_to_l1`,
+    /// `agent_tier_derives_l0_for_the_assistant_kind`,
+    /// `agent_tier_derives_l1_for_every_sub_agent_kind`,
+    /// `agent_tier_explicit_declaration_overrides_the_derived_kind`,
+    /// `bundled_assistant_personas_resolve_l0_and_gain_nothing`.
     ///
-    /// #4029: the match itself moved to [`AgentTier::from_declared`] so a
-    /// consumer holding only the raw declared string (the `/subagents` route,
-    /// which must report exactly the targets the #4169 gate admits) shares this
-    /// one parser instead of hand-rolling a second one. Behavior is unchanged —
-    /// the tests above are the proof and were not touched.
+    /// #4029: the DECLARED-string match lives in [`AgentTier::from_declared`]
+    /// so a consumer holding only a raw tier string shares one parser instead
+    /// of hand-rolling a second one. That function is deliberately left as a
+    /// pure parser of the raw value — it has no `role` to consult and must not
+    /// grow one; the kind derivation lives here, where the role is in scope.
     pub fn tier(&self) -> AgentTier {
-        AgentTier::from_declared(self.tier.as_deref())
+        match self.tier.as_deref().map(str::trim) {
+            Some(declared) if !declared.is_empty() => AgentTier::from_declared(Some(declared)),
+            // ADR-0024 decision 3: an assistant IS tier L0, derived from kind
+            // so the fact lives in one place instead of in every persona file.
+            _ => AgentTier::for_kind(&self.role),
+        }
     }
 
     /// The human-facing speaker label for this persona (#3738).

--- a/crates/trusty-agents/src/agents/registry/tests.rs
+++ b/crates/trusty-agents/src/agents/registry/tests.rs
@@ -307,8 +307,12 @@ body
     let path = dir.path().join("md-agent-no-tier.md");
     fs::write(&path, no_tier).unwrap();
     let cfg = parse_md_agent(&path).expect("md parses");
-    assert_eq!(cfg.agent.tier, None);
-    assert_eq!(cfg.agent.tier(), crate::agents::AgentTier::L1Standard);
+    assert_eq!(cfg.agent.tier, None, "no `tier:` key in the frontmatter");
+    // ADR-0024 decision 3: an absent declaration is DERIVED from kind, and
+    // this fixture's kind is `assistant` — so "absent" resolves L0 here, not
+    // the pre-decision-3 L1. The fail-closed contract for an unrecognized
+    // DECLARATION is unchanged and lives in `agents::tests`.
+    assert_eq!(cfg.agent.tier(), crate::agents::AgentTier::L0Orchestration);
 
     let with_tier = r#"---
 name: md-agent-l0

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -1856,3 +1856,129 @@ mod agent_name_resolves_tests {
         );
     }
 }
+
+/// ADR-0024 decision 3, asserted against the REAL bundled roster rather than a
+/// synthetic fixture: every assistant-kind persona resolves L0, every
+/// sub-agent stays L1, and the flip grants nothing today.
+///
+/// Why: decision 3 is a claim about a POPULATION, and every prior tier test in
+/// this crate is a claim about a parser. A parser test would stay green if the
+/// roster drifted — a new assistant persona, or an existing one having its
+/// `role` retyped — which is precisely the data/code decorrelation ADR-0024's
+/// "Why this class of error recurs" section is written about. This test reads
+/// the shipped files.
+///
+/// The third assertion is the safety claim the ADR's "YOLO generalization's
+/// actual blast radius" section makes and this PR relies on: the only
+/// tier-conditioned capability that exists in code today is #4171's read-only
+/// session-state surface, `retain_tier_permitted` is DENY-ONLY (it never adds a
+/// tool), and no bundled assistant names an `L0_ONLY_SESSION_STATE_TOOLS` entry
+/// in its resolved `[tools].allow` — so the L0 flip registers three executors
+/// that every shipped persona then intersects away, and the observable
+/// capability delta is zero. If a future persona edit changes that, this test
+/// fails and the grant becomes a reviewed decision instead of a side effect.
+/// What: walks `bundled_agents_dir()` for every resolvable agent name, loads it
+/// through the real `AgentConfig::by_name` dispatch loader, and asserts the
+/// kind/tier correspondence plus the empty capability delta.
+/// Test: This function IS the test.
+#[test]
+fn bundled_assistant_personas_resolve_l0_and_gain_nothing() {
+    let _guard = ENV_LOCK.blocking_lock();
+
+    // Every resolvable bundled agent name: flat `<name>.toml` plus directory
+    // packages `<name>/agent.toml`. Deduped, because `izzie`, `cto-assistant`
+    // and `ctrl` ship BOTH forms — the duplication that makes a per-file
+    // `tier = "l0"` literal the wrong mechanism (see `AgentTier::for_kind`).
+    let mut names: Vec<String> = Vec::new();
+    for entry in std::fs::read_dir(bundled_agents_dir()).expect("bundled agents dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        let name = if path.is_dir() {
+            if !path.join("agent.toml").exists() {
+                continue;
+            }
+            path.file_name().and_then(|n| n.to_str()).map(String::from)
+        } else if path.extension().and_then(|e| e.to_str()) == Some("toml") {
+            path.file_stem().and_then(|n| n.to_str()).map(String::from)
+        } else {
+            None
+        };
+        if let Some(name) = name
+            && !names.contains(&name)
+        {
+            names.push(name);
+        }
+    }
+    names.sort();
+    assert!(
+        names.len() > 15,
+        "sanity: the bundled roster should be substantial, got {names:?}"
+    );
+
+    let mut assistants: Vec<String> = Vec::new();
+    for name in &names {
+        clear_model_env(name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::set_var("TAGENT_CONFIG_DIR", bundled_agents_dir());
+        }
+        let cfg = AgentConfig::by_name(name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("TAGENT_CONFIG_DIR");
+        }
+        let cfg = cfg.unwrap_or_else(|e| panic!("'{name}' must resolve: {e}"));
+
+        assert_eq!(
+            cfg.agent.tier, None,
+            "'{name}' must NOT hand-declare a tier — decision 3 is derived from \
+             kind, and a literal here is the drift this design removes"
+        );
+
+        if cfg.agent.role == "assistant" {
+            assistants.push(name.clone());
+            assert_eq!(
+                cfg.agent.tier(),
+                crate::agents::AgentTier::L0Orchestration,
+                "'{name}' is assistant-kind and must resolve L0 (ADR-0024 decision 3)"
+            );
+            // The zero-delta claim: nothing this persona is allowed to call is
+            // gated on L0, so becoming L0 hands it no new tool.
+            if let Some(allow) = cfg.tools.allow.as_deref() {
+                for granted in allow {
+                    assert!(
+                        !crate::tools::session_state::is_l0_only_session_state_tool(granted),
+                        "'{name}' names the L0-gated tool '{granted}' in [tools].allow — \
+                         becoming L0 would GRANT it, which is a capability change this \
+                         PR does not carry. Review it deliberately."
+                    );
+                }
+            }
+        } else {
+            assert_eq!(
+                cfg.agent.tier(),
+                crate::agents::AgentTier::L1Standard,
+                "'{name}' (role '{}') is a sub-agent and must stay L1",
+                cfg.agent.role
+            );
+        }
+    }
+
+    // The roster the owner named, verified rather than assumed. `researcher`
+    // and `writing-assistant` are NOT in it: `research-agent` declares
+    // `role = "researcher"` (a sub-agent role) and no `writing-assistant`
+    // exists anywhere in the roster.
+    assistants.sort();
+    assert_eq!(
+        assistants,
+        vec![
+            "assistant".to_string(),
+            "cto-assistant".to_string(),
+            "ctrl".to_string(),
+            "izzie".to_string(),
+            "personal-assistant".to_string(),
+        ],
+        "the assistant-kind population is fixed by role, not by a guessed \
+         filename list; a new one must be a reviewed addition"
+    );
+}

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -777,6 +777,13 @@ fn agent_tier_from_declared_matches_agent_info_tier() {
     // produce the IDENTICAL result through both entry points. If the two ever
     // diverge, the config surface starts advertising a target the delegation
     // gate refuses (or hiding one it allows).
+    //
+    // ADR-0024 decision 3 scopes this equivalence: it holds for a DECLARED
+    // value always, and for an absent/blank value only when the role is not
+    // the assistant kind (the fixture's `role = "x"`), because `AgentInfo::
+    // tier()` now derives an absent value from kind while `from_declared`
+    // stays a pure parser with no role in scope. The assistant-kind divergence
+    // is pinned separately by `agent_tier_derives_l0_for_the_assistant_kind`.
     for raw in [
         None,
         Some(""),
@@ -825,4 +832,152 @@ fn agent_tier_wire_label_round_trips_through_from_declared() {
         "the SHORT alias is the wire value, matching what an operator writes"
     );
     assert_eq!(crate::agents::AgentTier::L1Standard.wire_label(), "l1");
+}
+
+// --- ADR-0024 decision 3: assistants are tier L0, derived from KIND -------
+//
+// Ratified by the owner 2026-07-28. The population #4168 shipped is inverted:
+// L0 is no longer a rare, unpopulated orchestration tier above the assistants
+// — it IS the assistant population, and L1 is the sub-agent population. These
+// tests pin the derivation itself; the pane's rendering of it is pinned in
+// `api::server::tests::agent_subagents`, and the delegation gate's KIND-first
+// behaviour in `tools::delegate`'s tests.
+
+/// Build a config with an explicit role and an optional tier line.
+fn agent_toml_with_role_and_tier(role: &str, tier_line: &str) -> String {
+    format!(
+        r#"
+[agent]
+name = "x"
+role = "{role}"
+model = "x"
+description = "x"
+{tier_line}
+
+[llm]
+temperature = 0.0
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#
+    )
+}
+
+#[test]
+fn agent_tier_for_kind_is_l0_only_for_the_assistant_role() {
+    // The derivation reads ONE value. Everything else — including the empty
+    // string, and including `orchestrator`/`controller` (which sit outside
+    // this model and are handed L0 explicitly at dispatch by
+    // `ctrl_delegate_posture`, not by this function) — lands on L1.
+    assert_eq!(
+        crate::agents::AgentTier::for_kind("assistant"),
+        crate::agents::AgentTier::L0Orchestration
+    );
+    for other in [
+        "",
+        "engineer",
+        "qa",
+        "researcher",
+        "documentation",
+        "ops",
+        "planner",
+        "ticketing",
+        "analysis",
+        "observer",
+        "orchestrator",
+        "controller",
+        "Assistant",
+        "assistant-tier",
+    ] {
+        assert_eq!(
+            crate::agents::AgentTier::for_kind(other),
+            crate::agents::AgentTier::L1Standard,
+            "role {other:?} must NOT derive the elevated tier"
+        );
+    }
+}
+
+#[test]
+fn agent_tier_derives_l0_for_the_assistant_kind() {
+    // The decision-3 case: an assistant-kind agent that declares no `tier` at
+    // all — the state of every bundled assistant TOML — resolves L0.
+    let cfg: AgentConfig =
+        toml::from_str(&agent_toml_with_role_and_tier("assistant", "")).expect("parses");
+    assert_eq!(cfg.agent.tier, None, "no literal is written to the file");
+    assert_eq!(
+        cfg.agent.tier(),
+        crate::agents::AgentTier::L0Orchestration,
+        "ADR-0024 decision 3: an assistant IS L0, with no per-file declaration"
+    );
+    // A blank declaration is "not declared", not "declared as something odd".
+    let blank: AgentConfig = toml::from_str(&agent_toml_with_role_and_tier(
+        "assistant",
+        r#"tier = "   ""#,
+    ))
+    .expect("parses");
+    assert_eq!(
+        blank.agent.tier(),
+        crate::agents::AgentTier::L0Orchestration
+    );
+}
+
+#[test]
+fn agent_tier_derives_l1_for_every_sub_agent_kind() {
+    // The other half of decision 3: sub-agents stay L1. Asserted over the
+    // whole `ASSISTANT_ALLOWED_DELEGATE_ROLES` sub-agent vocabulary rather
+    // than one sample, so widening that constant without thinking about tier
+    // fails here.
+    for role in [
+        "engineer",
+        "qa",
+        "researcher",
+        "documentation",
+        "ops",
+        "planner",
+    ] {
+        let cfg: AgentConfig =
+            toml::from_str(&agent_toml_with_role_and_tier(role, "")).expect("parses");
+        assert_eq!(
+            cfg.agent.tier(),
+            crate::agents::AgentTier::L1Standard,
+            "sub-agent role {role:?} must stay L1"
+        );
+    }
+}
+
+#[test]
+fn agent_tier_explicit_declaration_overrides_the_derived_kind() {
+    // The escape hatch, in BOTH directions, so the derivation is a default
+    // and not a hard-coded identity: an assistant can be deliberately narrowed
+    // to L1, and a non-assistant can be deliberately pinned to L0.
+    let narrowed: AgentConfig = toml::from_str(&agent_toml_with_role_and_tier(
+        "assistant",
+        r#"tier = "l1""#,
+    ))
+    .expect("parses");
+    assert_eq!(narrowed.agent.tier(), crate::agents::AgentTier::L1Standard);
+
+    let pinned: AgentConfig = toml::from_str(&agent_toml_with_role_and_tier(
+        "orchestrator",
+        r#"tier = "l0""#,
+    ))
+    .expect("parses");
+    assert_eq!(
+        pinned.agent.tier(),
+        crate::agents::AgentTier::L0Orchestration
+    );
+
+    // And the fail-closed rule survives the override: a typo on an assistant
+    // NARROWS to L1 rather than being ignored or silently elevating.
+    let typo: AgentConfig = toml::from_str(&agent_toml_with_role_and_tier(
+        "assistant",
+        r#"tier = "L0RCHESTRATION""#,
+    ))
+    .expect("parses");
+    assert_eq!(
+        typo.agent.tier(),
+        crate::agents::AgentTier::L1Standard,
+        "an unrecognized declaration can only ever narrow"
+    );
 }

--- a/crates/trusty-agents/src/api/server/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/agent_subagents.rs
@@ -285,6 +285,16 @@ async fn in_product_surface(
                     continue;
                 }
                 let target_tier = target.agent.tier();
+                // ADR-0024 decision 3: assistants are L0, so this comparison
+                // is no longer vacuous — the code is unchanged and its OUTPUT
+                // moved, which is the whole hazard the ADR names. For an
+                // assistant VIEWER it is still never the reason anything is
+                // refused (source and target-that-matters are both L0; the
+                // kind check below carries the peer prohibition). It DOES fire
+                // for a non-assistant viewer, which now sees assistant targets
+                // reported as tier-refused — honest, and display-only, since
+                // such a viewer never holds `delegate_to_agent` at all
+                // (`tool_registered` below is false for it).
                 let tier_blocked = target_tier == AgentTier::L0Orchestration
                     && delegator_tier != AgentTier::L0Orchestration;
                 // ADR-0024: the KIND predicate the gate now enforces, read

--- a/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/tests/agent_subagents.rs
@@ -7,9 +7,12 @@
 //!
 //! 1. **The tier interaction (#4169, epic #4167).** An L1 delegator must not be
 //!    shown an L0-orchestration target as reachable, and an L0 delegator must
-//!    be. Today NO shipped persona declares `tier` at all, so this is
-//!    exercisable only against synthetic fixtures — which is exactly why it
-//!    needs a test rather than a manual check.
+//!    be. Under ADR-0024 decision 3 the assistant kind DERIVES L0 (no persona
+//!    declares `tier` on disk, and none needs to), so the L1 side of this
+//!    property now needs a fixture that explicitly narrows an assistant with
+//!    `tier = "l1"` — see `subagents_route_hides_l0_target_from_l1_delegator`.
+//!    That is deliberate: without it, predicate 3 becomes an unexercised
+//!    branch, which is the state ADR-0024's conformance checklist forbids.
 //! 2. **Cross-product deny-by-default (OQ-7).** An agent with no `[subagents]`
 //!    section must see every floor target denied — the pane may not read an
 //!    absent section as a silent grant.
@@ -170,9 +173,13 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
     // `delegate_to_agent` is both registered (role == "assistant") and granted.
     assert_eq!(ip["tool_registered"], true);
     assert_eq!(ip["tool_granted"], true);
+    // ADR-0024 decision 3: the pane reports the VIEWING agent's own tier, and
+    // an assistant is L0 — derived from its kind, with no `tier = "l0"` line
+    // in the fixture. This is the label the owner was looking at when he
+    // reported the pane calling an assistant "tier l1".
     assert_eq!(
-        ip["delegator_tier"], "l1",
-        "no tier declared ⇒ fail-closed L1"
+        ip["delegator_tier"], "l0",
+        "an assistant-kind agent is tier L0 (ADR-0024 decision 3)"
     );
 
     let targets = ip["targets"].as_array().unwrap();
@@ -190,6 +197,10 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
         .iter()
         .find(|t| t["name"] == "izzie")
         .expect("peer assistant must still be reported, with a reason");
+    assert_eq!(
+        izzie["tier"], "l0",
+        "a peer assistant renders as tier l0 too (ADR-0024 decision 3): {izzie:?}"
+    );
     assert_eq!(
         izzie["reachable"], false,
         "peer assistant is not a delegation target: {izzie:?}"
@@ -210,6 +221,10 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
         .find(|t| t["name"] == "docs-agent")
         .expect("a documentation-role agent must be an in-product target");
     assert_eq!(docs["role"], "documentation");
+    assert_eq!(
+        docs["tier"], "l1",
+        "a sub-agent stays tier l1 (ADR-0024 decision 3): {docs:?}"
+    );
     assert_eq!(docs["reachable"], true);
     assert_eq!(docs["reason"], serde_json::Value::Null);
 
@@ -255,6 +270,14 @@ async fn subagents_route_reports_both_mechanisms_for_an_assistant() {
 /// before the tier comparison is consulted, which would leave this test
 /// green while testing nothing about tier — the same isolation applied to
 /// `delegate_l1_to_l0_is_refused` in `tools::delegate`'s tests.
+///
+/// ADR-0024 decision 3 update: the DELEGATOR now has to be explicitly narrowed
+/// to L1 (`tier = "l1"`), because an assistant otherwise derives L0 and the
+/// tier comparison would be vacuously satisfied. That is not a contrivance —
+/// an explicit narrowing is the only way an L1 delegate-capable agent exists
+/// under the ratified model, and it is exactly the population this gate is
+/// still defending. Keeping the test on that fixture is what stops predicate 3
+/// from rotting into an unexercised branch (ADR-0024 conformance item 5).
 #[tokio::test]
 async fn subagents_route_hides_l0_target_from_l1_delegator() {
     let dir = tempfile::tempdir().unwrap();
@@ -263,11 +286,27 @@ async fn subagents_route_hides_l0_target_from_l1_delegator() {
     // assistant kind, so the ONLY thing that can keep it out of reach is the
     // tier gate.
     write_agent(dir.path(), "orch", "engineer", Some("l0"), &[], None);
+    write_agent(
+        dir.path(),
+        "narrowed-assistant",
+        "assistant",
+        Some("l1"),
+        &["delegate_to_agent", "git_log"],
+        None,
+    );
 
-    let resp = subagents_at(&[dir.path().to_path_buf()], "assistant", dir.path()).await;
+    let resp = subagents_at(
+        &[dir.path().to_path_buf()],
+        "narrowed-assistant",
+        dir.path(),
+    )
+    .await;
     let body = body_json(resp).await;
     let ip = &body["in_product"];
-    assert_eq!(ip["delegator_tier"], "l1");
+    assert_eq!(
+        ip["delegator_tier"], "l1",
+        "an explicit `tier = \"l1\"` declaration overrides the derived kind"
+    );
 
     let targets = ip["targets"].as_array().unwrap();
     let orch = targets
@@ -466,6 +505,35 @@ async fn subagents_route_reports_tool_not_registered_for_a_worker_role() {
         "an engineer-role agent never registers delegate_to_agent"
     );
     assert_eq!(ip["tool_granted"], false, "and declares no allow-list");
+    // ADR-0024 decision 3, the one pane-reporting change beyond the labels: a
+    // NON-assistant viewer stays L1, so an assistant target — now L0 — reads as
+    // tier-blocked where it used to read as reachable. This is a display
+    // artifact on a card the pane already stamps `tool_registered: false`
+    // (an engineer never holds `delegate_to_agent` at all), and it is honest:
+    // if a worker-role agent somehow held the tool, the tier gate WOULD refuse
+    // that edge. Pinned so the next reader knows it is intended, not a bug.
+    assert_eq!(
+        ip["delegator_tier"], "l1",
+        "a worker role derives L1: {ip:?}"
+    );
+    let targets = ip["targets"].as_array().unwrap();
+    let izzie = targets
+        .iter()
+        .find(|t| t["name"] == "izzie")
+        .expect("an assistant-role agent is still role-eligible and still reported");
+    assert_eq!(izzie["tier"], "l0");
+    assert_eq!(
+        izzie["reachable"], false,
+        "an L1 viewer is shown the L0 target as refused: {izzie:?}"
+    );
+    assert!(
+        izzie["reason"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("L0/L1"),
+        "the tier gate, not the kind gate, is what refuses a non-assistant \
+         source's edge: {izzie:?}"
+    );
 }
 
 /// An agent declaring `[tools].allow` WITHOUT `delegate_to_agent` is registered

--- a/crates/trusty-agents/src/tools/delegate_tests.rs
+++ b/crates/trusty-agents/src/tools/delegate_tests.rs
@@ -1068,17 +1068,63 @@ async fn delegate_kind_gate_does_not_touch_orchestrator_sources() {
     assert_eq!(runner.invoked.lock().unwrap().len(), 1);
 }
 
-/// A delegator that declares no identity at all keeps pre-ADR-0024 behavior.
+/// A delegator that declares no identity at all leaves the KIND gate a no-op.
 ///
 /// Why: `runtime::pm_mode::run_pm` constructs the tool with neither identity
 /// nor `config_dirs`; pinning the `None` semantics here documents that the
 /// kind predicate is opt-in ON IDENTITY (not on policy) and that nothing
 /// changed for that site.
-/// What: no `with_delegator` call, assistant-role target, still reaches the
-/// runner.
+/// What: no `with_delegator` call, SUB-AGENT target, still reaches the runner.
+///
+/// ADR-0024 decision 3: the target is now `engineer`, not an assistant. An
+/// assistant target derives tier L0, and an undeclared delegator identity
+/// fails closed to `L1Standard` — so an assistant target would be refused by
+/// the TIER gate and this test would prove nothing about the kind gate being
+/// a no-op. That fail-closed refusal is real and is pinned separately by
+/// `delegate_without_declared_identity_is_tier_blocked_from_an_assistant`.
 /// Test: this function IS the test.
 #[tokio::test]
 async fn delegate_without_declared_identity_skips_the_kind_gate() {
+    let dir = tempfile::tempdir().unwrap();
+    write_agent_toml_with_role(dir.path(), "engineer", "engineer");
+
+    let runner = Arc::new(RecordingRunner {
+        invoked: std::sync::Mutex::new(Vec::new()),
+    });
+    let tool = DelegateToAgentTool::new(runner.clone())
+        .with_config_dirs(vec![dir.path().to_path_buf()])
+        .with_allowed_target_roles(vec!["engineer".to_string()]);
+
+    let result = tool
+        .execute(json!({ "agent_name": "engineer", "task": "undeclared caller" }))
+        .await;
+
+    assert!(
+        !result.is_error(),
+        "an undeclared delegator identity must leave the kind gate a no-op: {}",
+        result.content()
+    );
+    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+}
+
+/// ADR-0024 decision 3, the one enforcement-point behavior change: an
+/// UNDECLARED delegator identity is now refused when the target is an
+/// assistant.
+///
+/// Why: the population inversion made every assistant a tier-L0 target, and
+/// `execute` treats a caller that opted into role-gating but declared no tier
+/// as `L1Standard` (`delegator_tier.unwrap_or_default()`, #4169 constraint 1).
+/// L1 -> L0 is exactly what predicate 3 refuses. The polarity is fail-CLOSED —
+/// a call that used to be permitted is now refused, never the reverse — and no
+/// shipped construction site produces this combination (all three
+/// assistant-tier sites call `with_delegator`; `pm_mode` passes no
+/// `config_dirs` and so runs no gate at all). Pinned anyway, because an
+/// unpinned behavior change is how the NEXT population shift becomes invisible.
+/// What: role-gated, tier-undeclared caller, assistant target ⇒ refused with
+/// the tier message, runner never reached.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn delegate_without_declared_identity_is_tier_blocked_from_an_assistant() {
     let dir = tempfile::tempdir().unwrap();
     write_agent_toml_with_role(dir.path(), "izzie", "assistant");
 
@@ -1094,9 +1140,19 @@ async fn delegate_without_declared_identity_skips_the_kind_gate() {
         .await;
 
     assert!(
-        !result.is_error(),
-        "an undeclared delegator identity must leave the kind gate a no-op: {}",
+        result.is_error(),
+        "an undeclared caller is L1 by fail-closed default and may not reach an \
+         assistant (now L0): {}",
         result.content()
     );
-    assert_eq!(runner.invoked.lock().unwrap().len(), 1);
+    assert!(
+        result.content().contains("orchestration-tier"),
+        "the tier gate, not the kind gate, is what refuses here: {}",
+        result.content()
+    );
+    assert_eq!(
+        runner.invoked.lock().unwrap().len(),
+        0,
+        "the runner must never be reached"
+    );
 }

--- a/crates/trusty-agents/src/tools/session_state/tests.rs
+++ b/crates/trusty-agents/src/tools/session_state/tests.rs
@@ -120,13 +120,24 @@ fn names(v: &[&str]) -> Vec<String> {
 /// would pass even if the resolver regressed.
 /// What: the same shape `agents::tests::agent_toml_with_tier` uses.
 /// Test: `indeterminate_tier_fails_closed_to_no_session_state_tools`,
-/// `declared_l0_tier_keeps_session_state_tools`.
+/// `declared_l0_tier_keeps_session_state_tools`,
+/// `assistant_kind_without_a_declaration_keeps_session_state`.
 fn persona_toml(tier_line: &str) -> String {
+    persona_toml_with_role("assistant", tier_line)
+}
+
+/// [`persona_toml`] with the ROLE parameterized (ADR-0024 decision 3).
+///
+/// Why: tier is derived from kind now, so a fixture that hardcodes
+/// `role = "assistant"` can only exercise one side of the derivation.
+/// What: the same shape, with `role` supplied by the caller.
+/// Test: `sub_agent_kind_without_a_declaration_is_stripped`.
+fn persona_toml_with_role(role: &str, tier_line: &str) -> String {
     format!(
         r#"
 [agent]
 name = "x"
-role = "assistant"
+role = "{role}"
 model = "x"
 description = "x"
 {tier_line}
@@ -143,15 +154,17 @@ content = "base"
 
 #[test]
 fn indeterminate_tier_fails_closed_to_no_session_state_tools() {
-    // An absent / blank / unrecognized `tier = …` resolves to L1Standard via
-    // #4200's fail-closed resolver; that is the value the gate must strip on.
-    for tier_line in [
-        "",
-        r#"tier = """#,
-        r#"tier = "   ""#,
-        r#"tier = "L2""#,
-        r#"tier = "yolo""#,
-    ] {
+    // An UNRECOGNIZED `tier = …` resolves to L1Standard via #4200's fail-closed
+    // resolver; that is the value the gate must strip on.
+    //
+    // ADR-0024 decision 3 narrowed the input set this test covers. An ABSENT or
+    // blank declaration is no longer "indeterminate" — it means "derive from
+    // kind", and this fixture's `role = "assistant"` derives L0. Those two
+    // cases moved to `assistant_kind_without_a_declaration_keeps_session_state`
+    // below. What remains here is the property that actually matters: a
+    // MALFORMED declaration can only ever narrow, so a typo on an assistant
+    // costs it the L0 surface rather than silently keeping it.
+    for tier_line in [r#"tier = "L2""#, r#"tier = "yolo""#, r#"tier = "l2""#] {
         let cfg: crate::agents::AgentConfig =
             toml::from_str(&persona_toml(tier_line)).expect("parses");
         assert_eq!(
@@ -168,6 +181,72 @@ fn indeterminate_tier_fails_closed_to_no_session_state_tools() {
         assert!(
             session_state_tools(&PathBuf::from("/tmp"), cfg.agent.tier()).is_empty(),
             "{tier_line:?} must register no session-state executor"
+        );
+    }
+}
+
+/// ADR-0024 decision 3, stated where the capability actually lives: an
+/// assistant-kind persona with NO `tier` declaration derives L0 and therefore
+/// keeps an L0-only session-state name that reaches its resolved allow-list.
+///
+/// Why: this is the whole practical delta of decision 3 in shipped code. The
+/// delta is REGISTRATION-level only for today's roster — `retain_tier_permitted`
+/// is deny-only and never adds, and no bundled assistant persona names any
+/// `L0_ONLY_SESSION_STATE_TOOLS` entry in its `[tools].allow` (pinned by
+/// `agents::tests::loading::bundled_assistant_personas_resolve_l0_and_gain_nothing`),
+/// so nothing an operator can observe changes until a persona opts in. Pinning
+/// the mechanism separately from the roster means the day a persona DOES opt
+/// in, the grant is a deliberate config edit and not a surprise.
+/// What: absent and blank declarations on `role = "assistant"` both keep the
+/// name and both register the three executors.
+/// Test: this function IS the test.
+#[test]
+fn assistant_kind_without_a_declaration_keeps_session_state() {
+    for tier_line in ["", r#"tier = """#, r#"tier = "   ""#] {
+        let cfg: crate::agents::AgentConfig =
+            toml::from_str(&persona_toml(tier_line)).expect("parses");
+        assert_eq!(
+            cfg.agent.tier(),
+            AgentTier::L0Orchestration,
+            "{tier_line:?} on an assistant derives L0 (ADR-0024 decision 3)"
+        );
+        let kept = retain_tier_permitted(names(&["session_list", "git_log"]), cfg.agent.tier());
+        assert_eq!(
+            kept,
+            names(&["session_list", "git_log"]),
+            "{tier_line:?} must NOT strip the session-state name"
+        );
+        assert_eq!(
+            session_state_tools(&PathBuf::from("/tmp"), cfg.agent.tier()).len(),
+            3,
+            "{tier_line:?} must register the three read-only executors"
+        );
+    }
+}
+
+/// The other half: a SUB-AGENT with no declaration stays L1 and is stripped.
+#[test]
+fn sub_agent_kind_without_a_declaration_is_stripped() {
+    for role in [
+        "engineer",
+        "qa",
+        "researcher",
+        "documentation",
+        "ops",
+        "planner",
+    ] {
+        let cfg: crate::agents::AgentConfig =
+            toml::from_str(&persona_toml_with_role(role, "")).expect("parses");
+        assert_eq!(
+            cfg.agent.tier(),
+            AgentTier::L1Standard,
+            "sub-agent role {role:?} stays L1"
+        );
+        let kept = retain_tier_permitted(names(&["session_list", "git_log"]), cfg.agent.tier());
+        assert_eq!(kept, names(&["git_log"]), "role {role:?} must be stripped");
+        assert!(
+            session_state_tools(&PathBuf::from("/tmp"), cfg.agent.tier()).is_empty(),
+            "role {role:?} must register no session-state executor"
         );
     }
 }

--- a/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
+++ b/docs/adr/0024-subagents-in-process-only-assistants-communicate-not-delegate.md
@@ -1,7 +1,13 @@
 # 0024. Assistants Are Level-0 Delegators; Sub-Agents Are In-Process, Single-Edge Leaves That Never Delegate
 
-- **Status:** Proposed
-- **Date:** 2026-07-28
+- **Status:** Proposed — **partially ratified and partially implemented.** The
+  L0-assistant clause (Context §1 item 3 / Decision clause 2, "every assistant
+  is tier L0") and its kind-primary corollary (Decision clause 6) are RATIFIED
+  by the owner (2026-07-28) and IMPLEMENTED. Every other clause remains
+  Proposed. See "Implementation status" below for the clause-by-clause table —
+  read that, not this one-line summary, before assuming any clause has landed.
+- **Date:** 2026-07-28 (ratification of the L0-assistant clause recorded
+  2026-07-28)
 - **Scope:** crate `trusty-agents` (the `delegate_to_agent` / `dispatch_task` boundary; the L0/L1 tier model, #4167/#4200; touches the `trusty-code` cross-product bridge target and the Sub-agents API/pane, `#4029`/`#4211`)
 - **Reversibility Cost:** High — reverses/re-scopes shipped, tested, owner-directed machinery from epic #4021 (#4026/#4027/#4028/#4211, merged within 48 hours of this ADR), INVERTS the population assignment of the L0/L1 tier model merged the SAME DAY as this decision (PR #4200, squash `ada4d351`), and requires new, currently nonexistent machinery (an editable sub-agent whitelist, an assistant-to-assistant messaging primitive, and a tool-call-counted skill/delegate router)
 - **Decision Drivers:** Product framing clarity (the Sub-agents pane could not honestly present a name that means two different things), the owner's rejection of a UI-only fix, the owner's explicit generalization of the YOLO risk posture to every assistant, a documentation gap (DOC-57 does not yet cover Sub-agents at all, #4182), the owner's own PM/trusty-mpm prior art as an explicit analogy with an owner-named limit, and — underlying all of the above — the owner's virtual-twin authority principle (see "Rationale" below): each assistant must take authority over its own actions, and that authority is not transferable between assistants
@@ -124,6 +130,11 @@ ADR):
   `.trusty-agents/agents/*.toml`; cross-checked directly against the live
   Sub-agents pane, which — per the routing coordinator — "renders tier l1"
   for every agent, `cto-assistant` included.
+  **NOW SUPERSEDED IN CODE** (see "Implementation status"): no bundled agent
+  declares `tier = "l0"` STILL, and none needs to — `AgentInfo::tier()` derives
+  the tier from KIND, so the assistant population resolves L0 with the on-disk
+  files unchanged. Read this bullet as the record of what #4200 shipped, not as
+  current behavior; the pane now renders `tier l0` for `cto-assistant`.
 - The one-directional gate (`delegate.rs:361-438`) blocks exactly one
   direction: `target_tier == L0Orchestration && delegator_tier !=
   L0Orchestration`. Its purpose, as shipped, was to stop an untrusted,
@@ -302,6 +313,130 @@ This ADR does not yet decide, and defers to the owner (see "Consequences"
 and "Conflicts and open questions"), the mechanics each clause raises but
 does not itself answer — enumerated in the Consequences sections below,
 each ending in an explicit recommendation marked owner-ratify.
+
+## Implementation status
+
+**Numbering warning, because this document has two.** Context §1 numbers the
+owner's five verbatim quotes in the order given; the Decision section above
+renumbers the model into six normative clauses. They do not line up: the
+L0-assistant clause is Context §1 item **3** and Decision clause **2**; the
+editable whitelist is Context §1 item **2** and Decision clause **4**. This
+table is keyed by CONTENT so a reader cannot pick the wrong "decision 3".
+
+| Clause (by content) | Ctx §1 | Decision | Ratified | Implemented |
+|---|---|---|---|---|
+| Sub-agents are always in-process | 1 | 1 | yes | yes (pre-existing — see "Is 'sub-agents never delegate' enforced") |
+| **Every assistant is tier L0** | **3** | **2** | **yes, 2026-07-28** | **yes — this PR** |
+| Sub-agent = tier L1, single-edge leaf | 4 | 3 | yes | yes (L1 is the derived default for every non-assistant role) |
+| Reachable sub-agent set is an EDITABLE CONFIG WHITELIST | 2 | 4 | **NO** | **NO** — not in this PR, not designed; the two owner-ratify questions it raises ("The absent-whitelist default is a breaking change", "'Editable' means the GUI starts writing agent config") are both still open |
+| 3-tool-call skill-vs-delegate routing | (5th quote) | 5 | yes | **NO** — the a-priori-vs-reactive question below is unanswered |
+| Delegation authority is governed by KIND, not tier order | — | 6 | yes | yes (PR #4240 — `agents::delegation`, and the `execute()` choke point) |
+| Assistant-to-assistant COMMUNICATION primitive | 1 | — | yes | **NO** — nothing implements it; see "'Communicate' has to be built, not renamed" |
+
+### What the L0-assistant clause's implementation actually did
+
+**Tier is now DERIVED FROM KIND, not declared per file.** `AgentInfo::tier()`
+resolves an explicit, non-blank `[agent].tier` declaration first (unchanged,
+still fail-closed: an unrecognized value narrows to `L1Standard` and can never
+elevate), and otherwise derives from `role` via the new `AgentTier::for_kind` —
+`L0Orchestration` for the assistant kind, `L1Standard` for everything else.
+**Zero agent TOMLs were edited.** The alternative — a `tier = "l0"` literal in
+each bundled assistant persona — was rejected because there is no single file
+per persona to put it in: `izzie`, `cto-assistant` and `ctrl` each ship BOTH a
+directory package and a flat `extends`-shadow-fallback TOML, so the literal
+would have to be written six-plus times and stay in sync forever, and a future
+assistant persona that omitted it would silently resolve L1 — reintroducing,
+in the data, exactly the decorrelation the "Why this class of error recurs"
+section above is written about.
+
+This NARROWS #4168's "never inferred from `role`" rule rather than discarding
+it. The property that rule protected is preserved: an operator adding a new
+SPECIALIST role still lands on `L1Standard`, because the derivation recognizes
+one value and nothing else. And `role == "assistant"` was already the most
+privileged non-orchestrator role in the crate — it is the ONLY role
+`build_registry_for_agent` routes into `build_assistant_tier_registry`, the one
+branch that registers `delegate_to_agent` and the git tool surface at all — so
+deriving L0 from it restates a trust decision the codebase already makes rather
+than opening a new escalation path. An explicit declaration still wins in both
+directions, so a genuinely-L0 non-assistant persona can be pinned, and a single
+assistant can be deliberately narrowed back to L1; both are declared intent,
+never an accident of omission.
+
+**The assistant-kind population, verified against the roster rather than
+guessed:** `assistant`, `cto-assistant`, `ctrl`, `izzie`, `personal-assistant`
+— every agent whose `[agent].role` is `assistant`. Notably NOT `research-agent`
+(it declares `role = "researcher"`, a sub-agent role) and there is no
+`writing-assistant` in the roster at all; both appear on informal lists of
+"the assistants" and both are wrong. `agents::tests::loading::
+bundled_assistant_personas_resolve_l0_and_gain_nothing` walks the shipped
+roster and pins this set, so a new assistant is a reviewed addition.
+
+### The measured blast radius of the flip
+
+Enumerated across every `AgentTier` / `tier()` / `tier_blocked` / `wire_label`
+consumer in the workspace, and confirmed by the test suite:
+
+- **Delegation enforcement (`tools::delegate::execute`): no new refusal on any
+  shipped path.** The kind gate (Decision clause 6, PR #4240) already refused
+  assistant→assistant before the flip and still does, and it is checked FIRST,
+  so the peer message is unchanged. Assistant(L0)→sub-agent(L1) is permitted by
+  both gates before and after. Every other delegator that reaches the gate is
+  already handed `L0Orchestration` explicitly (`ctrl_delegate_posture` and
+  `persona_gate`'s `role != "assistant"` branches), and `pm_mode` passes no
+  `config_dirs` so it runs no gate at all. **Decision clause 6 was load-bearing
+  here: had refusal still keyed on tier order, this flip would have silently
+  opened the peer edge.** Verified, not assumed.
+- **One enforcement-point behavior change, fail-CLOSED and unreachable from any
+  shipped construction site:** a caller that opts into the role allowlist but
+  declares NO delegator identity is treated as `L1Standard`
+  (`delegator_tier.unwrap_or_default()`, #4169 constraint 1) and is now refused
+  when the target is an assistant, because assistants are L0 targets. All three
+  assistant-tier construction sites call `with_delegator`, so this shape exists
+  only in tests — pinned by
+  `delegate_without_declared_identity_is_tier_blocked_from_an_assistant`.
+- **Capability grants: zero observable delta.** The only tier-conditioned
+  capability in shipped code is #4171's read-only session-state surface
+  (`session_state_list`/`_status`/`_snapshot`); #4170/#4172/#4173 are still
+  open, so nothing else is tier-gated. The flip REGISTERS those three executors
+  into each assistant's registry, but `retain_tier_permitted` is deny-only (it
+  never adds a tool) and reachability still requires the persona's own
+  `[tools].allow` to name the tool: no bundled assistant names any
+  `L0_ONLY_SESSION_STATE_TOOLS` entry, none declares a `[skills]` section, and
+  none declares a glob broad enough to match one (`granola_*` is the only glob
+  in the entire assistant roster). `ctrl` declares no `[tools]` section at all,
+  and both of its dispatch paths fail closed on that — `scope_assistant_allowed
+  _tools` returns an empty allow-list, and the persona-chat path builds an empty
+  registry — so it gains nothing either. Pinned mechanically by
+  `bundled_assistant_personas_resolve_l0_and_gain_nothing`, which fails if a
+  future persona edit ever makes the grant real.
+- **The Sub-agents pane (`in_product_surface`) after the change:** an assistant
+  viewing it now reads `delegator_tier: "l0"` (the label the owner reported as
+  wrong), peer assistants render `tier l0` and stay `reachable: false` with the
+  unchanged KIND reason, and sub-agents render `tier l1` and stay reachable.
+  `tier_blocked` is no longer always false — but for an assistant viewer it is
+  still never the reason anything is refused, exactly as Decision clause 6
+  predicate 3 says (redundant-as-designed). It DOES become true in one case: a
+  NON-assistant viewer (a worker role, or `pm`) is L1 and now sees assistant
+  targets reported as tier-refused where they previously read as reachable.
+  That is display-only and honest — the pane already stamps `tool_registered:
+  false` for those viewers, since only `role == "assistant"` ever holds
+  `delegate_to_agent` — but it is a real change to the payload and is pinned by
+  `subagents_route_reports_tool_not_registered_for_a_worker_role`. One known
+  imprecision it exposes, pre-existing and deliberately NOT fixed here: the
+  pane reads `pm`'s declared tier (L1) while `ctrl_delegate_posture` hands
+  `pm`-as-orchestrator `L0Orchestration` at dispatch, so the pane under-reports
+  `pm`'s reach. `pm` sits outside this ADR's graph by predicate 1's scope
+  caveat; folding it in is separate work.
+
+### Explicitly NOT in this implementation
+
+The editable config whitelist (Context §1 item 2 / Decision clause 4) is **not
+ratified and not built**. Neither is the assistant-to-assistant communication
+primitive, nor the 3-tool-call routing rule. The `ASSISTANT_ALLOWED_DELEGATE
+_ROLES` constant still contains `assistant` and is unchanged — the peer edge is
+refused by the kind gate at `execute()`, not by removing that entry, which the
+"`ASSISTANT_TIER_ROLE` in the allowlist" consequence below explains must not
+happen until the lateral communication mechanism exists.
 
 ## Rationale: The Virtual-Twin Authority Principle
 
@@ -827,7 +962,19 @@ every assistant persona's declared `tier` to `l0` grants, in practice, only
 restriction (delegation into an L0 target) that these personas already
 happened to satisfy trivially once they are themselves L0. It does NOT (yet)
 grant shell execution, GitHub PR/CI access, or cross-project reach, because
-those grants are unbuilt. The blast radius the owner ratified is real but
+those grants are unbuilt.
+
+**Measured, post-implementation: the delta is not merely "narrow", it is
+ZERO for the shipped roster.** `retain_tier_permitted` is deny-only and never
+adds a tool, so becoming L0 only makes the three executors REGISTRABLE — a
+persona still has to name one in its own `[tools].allow` to reach it, and none
+does. No bundled assistant declares any `L0_ONLY_SESSION_STATE_TOOLS` entry, no
+`[skills]` section, and no glob wide enough to match one; `ctrl` declares no
+`[tools]` section at all and both of its dispatch paths fail closed on that.
+`bundled_assistant_personas_resolve_l0_and_gain_nothing` asserts this against
+the real files, so the day a persona edit makes the grant real, it fails.
+
+The blast radius the owner ratified is real but
 currently small; it will grow as #4170/#4172/#4173 land, and each of those
 follow-ups should be read, from this point forward, as extending a grant to
 the ENTIRE assistant population rather than to a single rare persona —
@@ -850,7 +997,16 @@ already cover their specifics.
   hours earlier in the day is being redefined, not merely extended, by the
   same day's later decisions. See Context §3 and the "one-directional gate"
   consequence above for the concrete mechanism this leaves inert/vacuous
-  until patched.
+  until patched. **RESOLVED as of the implementation**: the owner ratified
+  the inversion on 2026-07-28 and it has landed. The tier gate is now
+  redundant-as-designed for assistant sources (predicate 3), the peer
+  prohibition is carried by the kind gate, and #4200's own tests are intact
+  because its fail-closed DECLARATION contract is unchanged — only the
+  meaning of an ABSENT declaration moved. What remains genuinely open is
+  narrower and is recorded above: `pm`-as-orchestrator's tier is reported
+  from its declared value on the pane while dispatch hands it
+  `L0Orchestration`, an imprecision this ADR's predicate-1 scope caveat puts
+  outside the model rather than fixes.
 - **DOC-41 §5.5's propose-not-authorize guarantee is not cross-product-
   specific** (retained from the first draft, unchanged) — the in-process
   path satisfies it via manifest-level `user_authority` non-inheritance;


### PR DESCRIPTION
Implements ADR-0024's L0-assistant clause — **Context §1 item 3 / Decision clause 2**, ratified by the owner 2026-07-28. (The ADR has two numbering schemes; this PR adds an "Implementation status" table keyed by content so nobody picks the wrong "decision 3".)

The owner-visible symptom: the Sub-agents pane labelled every agent `tier l1`, including assistant-kind ones and the viewing assistant itself.

---

## Step 1 — blast-radius enumeration

Grepped every `AgentTier` / `L0Orchestration` / `L1Standard` / `tier()` / `wire_label` / `tier_blocked` site in the workspace. There are exactly **four** consumers of a resolved tier; everything else is a doc comment or a test.

### 1. `tools::delegate::execute` — the delegation gate

**No gate keys on tier order as its primary carrier — verified, not assumed.** PR #4240 landed `agents::delegation::kind_refuses_delegation` (role-based) and calls it unconditionally inside the shared `execute()` choke point, checked **before** the tier comparison. Edge-by-edge after the flip:

| edge | before | after | why |
|---|---|---|---|
| assistant → sub-agent | permitted | permitted | L0→L1 satisfies the tier gate; kind permits |
| assistant → assistant | refused (kind) | refused (kind) | kind gate is checked first; message unchanged |
| `pm`/`ctrl`-as-orchestrator → anything | permitted | permitted | `ctrl_delegate_posture` / `persona_gate` hand `orchestrator` `L0Orchestration` explicitly; kind rule ignores non-assistant sources |
| `pm_mode::run_pm` | ungated | ungated | passes no `config_dirs`, so `needs_full_resolution` is false and no gate runs |
| sub-agent → anything | impossible | impossible | `DelegateToAgentTool` is never registered into a non-assistant registry |

**Decision clause 6 was load-bearing.** Had refusal still keyed on tier order, this flip would have silently opened the assistant↔assistant edge — the ADR's central warning. It does not, because the rule is expressed on kind.

**One enforcement-point behavior change**, fail-CLOSED and unreachable from any shipped construction site: a caller that opts into `with_allowed_target_roles` but declares **no** delegator identity is treated as `L1Standard` (`delegator_tier.unwrap_or_default()`, #4169 constraint 1) and is now refused when the target is an assistant, because assistants are L0 targets. All three assistant-tier construction sites call `with_delegator`; `pm_mode` runs no gate. Test-only shape, pinned by `delegate_without_declared_identity_is_tier_blocked_from_an_assistant`.

### 2. `tools::session_state` — the only tier-conditioned CAPABILITY

`session_state_tools(tier)` and `retain_tier_permitted(names, tier)`. This is the whole elevated-capability surface that exists: #4171 shipped, #4170/#4172/#4173 are still open, so nothing else is tier-gated anywhere.

**The capability delta is ZERO, not merely "narrow".** Checked against the shipped files, not inferred:

- `retain_tier_permitted` is **deny-only** — it never adds a tool. Becoming L0 makes three executors *registrable*, and reachability still requires the persona's own `[tools].allow` to name one.
- No bundled assistant names any `L0_ONLY_SESSION_STATE_TOOLS` entry (`session_state_*`, `session_list`, `session_status`, `session_proxy_summary`, `project_list`, `console_metrics`, `system_status`). Every occurrence in those files is in a BLACK-BOX POSTURE comment saying *don't add these*.
- No assistant declares a `[skills]` section, so the `[skills].allow → tool names` resolver contributes nothing. (The `session-state-*` builtin skills exist but nobody grants them.)
- No glob is wide enough to match one: `granola_*` is the **only** glob in the entire assistant roster.
- `ctrl` declares **no `[tools]` section at all** — the one case that could have been a silent widening. Both of its dispatch paths fail closed on that: `scope_assistant_allowed_tools` returns `Some(vec![])`, and the persona-chat path's `if let Some(patterns) = effective_patterns` guard builds an empty registry with zero tools.

So there is **nothing to STOP and escalate on**. Pinned mechanically by `bundled_assistant_personas_resolve_l0_and_gain_nothing`, which fails if a future persona edit ever makes the grant real.

### 3. `api::server::agent_subagents::in_product_surface` — `tier_blocked`

Code unchanged; output moved. After this PR:

- An assistant viewer reads `delegator_tier: "l0"` (the label the owner reported as wrong).
- Peer-assistant target cards read `tier: "l0"`, `reachable: false`, with the unchanged **kind** reason.
- Sub-agent target cards read `tier: "l1"`, `reachable: true`.
- `tier_blocked` is **no longer always false** — but for an assistant viewer it is still never the reason anything is refused (predicate 3, redundant-as-designed).
- **The one real payload change:** a NON-assistant viewer (worker role, or `pm`) is L1 and now sees assistant targets reported as **tier-refused** where they previously read as reachable. Display-only and honest — the pane already stamps `tool_registered: false` for those viewers, since only `role == "assistant"` ever holds `delegate_to_agent`. Pinned by `subagents_route_reports_tool_not_registered_for_a_worker_role`.

**Known imprecision it exposes, pre-existing and deliberately not fixed here:** the pane reads `pm`'s *declared* tier (L1) while `ctrl_delegate_posture` hands `pm`-as-orchestrator `L0Orchestration` at dispatch, so the pane under-reports `pm`'s reach. `pm` sits outside ADR-0024's graph by predicate 1's scope caveat; folding it in is separate work. Recorded in the ADR.

### 4. `agents::extends::merge_extends`

Child-declares-wins, base inherits. Unaffected — its fixtures use `role = "agent"`, and the explicit-declaration branch is unchanged. All four `extends_tier_*` tests pass untouched.

**Nothing else grants elevated capability on tier.** No YOLO flag, owner-responsibility field, computer-use grant, or authority-holder gate reads `AgentTier` anywhere in the workspace — grepped. The `user_authority` / autonomy machinery is keyed on config fields unrelated to tier.

---

## Step 2 — per-file literal vs. derived default

**Chose: derived from kind.** `AgentInfo::tier()` honours an explicit, non-blank `[agent].tier` first (unchanged, still fail-closed — an unrecognized value narrows to `L1Standard` and can never elevate) and otherwise derives via the new `AgentTier::for_kind`. **Zero agent TOMLs edited.**

Why the literal loses: there is no single file per persona. `izzie`, `cto-assistant` and `ctrl` each ship **both** a directory package (`izzie/agent.toml`) and a flat `extends`-shadow-fallback (`izzie.toml`), so the literal would have to be written six-plus times and stay in sync forever — and a future assistant persona that omitted it would silently resolve L1, reintroducing in the *data* exactly the decorrelation ADR-0024's "Why this class of error recurs" section is written about. Deriving cannot drift: there is no second place to forget.

**Can it silently reclassify a future agent the wrong way?** No, in both directions:

- **Upward** — the derivation recognizes exactly one value (`role == "assistant"`, via the same `delegation::is_assistant_kind` the gate calls) and nothing else. A new *specialist* role still lands on `L1Standard`, which is the property #4168's "never inferred from `role`" rule actually protected. That rule is **narrowed, not discarded**, and the narrowing is exactly decision 3's content.
- **Not a new escalation path** — `role == "assistant"` was already the most privileged non-orchestrator role in the crate: it is the ONLY role `build_registry_for_agent` routes into `build_assistant_tier_registry`, the one branch that registers `delegate_to_agent` and the git tool surface at all. Deriving L0 from it restates a trust decision the codebase already makes.
- **Escape hatch preserved both ways** — an explicit declaration still wins, so a genuinely-L0 non-assistant persona can be pinned and a single assistant can be deliberately narrowed back to L1. Both are declared intent, never an accident of omission.
- **A typo can only narrow** — `tier = "L0RCHESTRATION"` on an assistant resolves L1, not L0.

`AgentTier::from_declared` is left as a **pure** parser of the raw string (it has no role in scope and must not grow one); the kind derivation lives in `AgentInfo::tier()`, where the role is available.

### Assistant-kind population — verified against the roster, not guessed

`assistant`, `cto-assistant`, `ctrl`, `izzie`, `personal-assistant` — every agent whose `[agent].role` is `assistant`.

The task's candidate list was wrong on two entries, which is why it was verified by role: **`research-agent` declares `role = "researcher"`** (a sub-agent role — it stays L1), and **no `writing-assistant` exists** anywhere in the roster. `agents::tests::loading::bundled_assistant_personas_resolve_l0_and_gain_nothing` walks the shipped files and pins this exact set, so a new assistant is a reviewed addition rather than a silent one.

---

## Step 3 — ADR update

Status is now `Proposed — partially ratified and partially implemented`, **not** flipped wholesale. Added an "Implementation status" section with a clause-by-clause table keyed by content (both numbering schemes cross-referenced), recording explicitly that:

- the **editable config whitelist** (Ctx §1 item 2 / Decision clause 4) is **NOT ratified and NOT built** — its two owner-ratify questions remain open;
- the **assistant-to-assistant communication primitive** is not built;
- the **3-tool-call routing rule** is not built;
- `ASSISTANT_ALLOWED_DELEGATE_ROLES` still contains `assistant` and is unchanged — the peer edge is refused by the kind gate at `execute()`, not by removing that entry, which must not happen until the lateral communication mechanism exists.

Three now-stale passages are annotated in place rather than rewritten (Context §3's "the entire existing assistant population is L1", the YOLO-blast-radius section, and the same-day-inversion open question), so the record of what #4200 shipped survives.

---

## Step 4 — tests

New: `agent_tier_for_kind_is_l0_only_for_the_assistant_role`, `agent_tier_derives_l0_for_the_assistant_kind`, `agent_tier_derives_l1_for_every_sub_agent_kind`, `agent_tier_explicit_declaration_overrides_the_derived_kind`, `bundled_assistant_personas_resolve_l0_and_gain_nothing`, `assistant_kind_without_a_declaration_keeps_session_state`, `sub_agent_kind_without_a_declaration_is_stripped`, `delegate_without_declared_identity_is_tier_blocked_from_an_assistant`.

Updated (each with the reason inline): the pane tests now assert `l0` for the viewer and for peer cards and `l1` for sub-agents; `subagents_route_hides_l0_target_from_l1_delegator` gains an explicitly-narrowed `tier = "l1"` assistant so predicate 3 stays an exercised branch rather than rotting; `indeterminate_tier_fails_closed_to_no_session_state_tools` is re-scoped to malformed declarations only (absent/blank is now "derive", not "indeterminate"); `delegate_without_declared_identity_skips_the_kind_gate` uses a sub-agent target so it still isolates the kind gate.

---

## Gates — raw output

```
$ cargo fmt --check
FMT OK                     (no diff; the two "unstable features" lines are the
                            workspace's pre-existing nightly-only rustfmt keys)

$ cargo check -p trusty-agents
    Finished `dev` profile [unoptimized + debuginfo] target(s)
    (no errors, no warnings)

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 02s
    (no lints; the two "present in multiple build targets" cargo warnings are
     pre-existing and are about trusty-mpm/trusty-installer, not this crate)

$ cargo test -p trusty-agents
test tools::python_skill::tests::execute_dispatches_to_python_and_parses_json ... FAILED
test result: FAILED. 2928 passed; 1 failed; 11 ignored; 0 measured; 0 filtered out; finished in 56.22s
```

The single failure is the **known, pre-existing, environment-local** one: Homebrew's `python3` symlink is dangling on this machine (`error: Failed to inspect Python interpreter from first executable in the search path at /opt/homebrew/bin/python3`). Confirmed untouched by this diff:

```
$ git diff --name-only | grep -i python_skill
python_skill.rs NOT in diff (pre-existing failure confirmed unrelated)
```

Baseline before this change was 2915 passed / 6 failed (5 tier-related + python_skill); it is now 2928 passed / 1 failed.

```
$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 50 spec doc(s) + 2931 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_doc_numbers.sh
doc-numbers: 4 grandfathered, 0 violations — OK.
```

No files under `ui/` are touched, so the UI checks do not apply. (The existing Svelte tests assert `tier l1` only against hand-written JSON fixtures, not against the route, so they are unaffected by the payload change.)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
