### PR TITLE
feat(trusty-agents): Costs UI — usage aggregation, /api/costs, and the Cost tab (#4098)

### DIFF
--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -86,7 +86,6 @@ crates/trusty-agents/src/memory/store.rs	evict_then_warm_returns_same_results
 crates/trusty-agents/src/perf/mod.rs	collector_records_skills_considered
 crates/trusty-agents/src/perf/mod.rs	collector_totals_sum_phases
 crates/trusty-agents/src/perf/mod.rs	cost_usd_known_model
-crates/trusty-agents/src/perf/pricing.rs	cost_usd_known_model
 crates/trusty-agents/src/plugins/manager.rs	global_returns_none_before_init
 crates/trusty-agents/src/plugins/manager.rs	global_returns_some_after_init
 crates/trusty-agents/src/plugins/manager.rs	status_reports_active

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -36,6 +36,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   line is shaped so #4260's commit SHA appends to it (`v0.38.6 · abc1234`)
   without a redesign; the meaningless `build #N` counter from
   `tagent --version` is deliberately not shown.
+- **A `Cost` tab showing spend by agent, model, and day (#4098).** The new
+  `CostsView` renders `GET /api/costs`, which folds
+  `.trusty-agents/state/usage.jsonl` on request into a grand total plus three
+  breakdowns. It refuses to render a confident `$0.00` over a usage log that
+  does not exist: a missing log is reported as "no usage has been recorded",
+  naming the file it looked for, and is visibly distinct from an empty-but-
+  present log, from a read failure, and from still-loading. Lines that fail to
+  parse are counted and surfaced as a warning that the totals are incomplete,
+  rather than silently dropped. Charts are plain CSS bars — no charting
+  dependency was added.
+- **`GET /api/costs` (#4098).** Optional `?days=<n>` narrows the window,
+  anchored on the newest recorded row. Returns `200` with `available: false`
+  when no log exists, `500` when a log exists but cannot be read, and always
+  reports `records` / `malformed_lines` so a partial total is identifiable as
+  one. Aggregation is read-time; the durable rollup tables of #4104/#4105 are
+  NOT implemented.
 - **The Skills pane renders function skills as groups (#4024).** A `kind:
   "function"` bundle is no longer filtered out of the pane — it renders as a
   collapsed group header over its member skill cards, with the tri-state grant
@@ -90,6 +106,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Cost figures were priced at Haiku rates for every model (#4098).**
+  `usage::daily` carried a second, hardcoded two-constant rate table that the
+  REPL statusline and the persisted daily total both used, so a Sonnet session
+  — the default — displayed roughly a twelfth of its real cost. The duplicate
+  table is deleted, not corrected; `perf::pricing::cost_usd` is now the single
+  pricing entry point for the statusline, the daily total, the perf collector,
+  and the new Costs tab. Its token counts widened from `u32` to `u64` so the
+  aggregate callers cannot saturate a total.
 - **The Sub-agents pane no longer offers `hidden` agents as delegation targets
   (#4235).** `GET /api/agents/:name/subagents` filtered its in-product target
   list by role and by the kind/tier gate but never by `hidden`, so

--- a/crates/trusty-agents/src/api/server/costs.rs
+++ b/crates/trusty-agents/src/api/server/costs.rs
@@ -88,9 +88,42 @@ pub(super) struct CostsQuery {
 ///
 /// Why/What: see the module doc. The project root is the daemon's CWD, matching
 /// `usage::project_dir`'s convention and the sibling routes' resolution.
-/// Test: `super::tests::costs::costs_route_is_wired_into_router`.
+///
+/// **Why `spawn_blocking`:** [`costs_at`] is synchronous and genuinely blocking
+/// — `aggregate_usage` does a whole-file `std::fs::read_to_string` followed by a
+/// `serde_json::from_str` per line. Running that inline on a tokio worker thread
+/// stalls the whole executor for the duration, not just this request, so a
+/// handful of concurrent Costs loads would degrade every other route on the
+/// daemon. That makes the executor, NOT the fold's own cost, the first thing to
+/// bite: the module doc's ~100k-row read-time ceiling assumes the work is off
+/// the reactor, and without this wrapper the ceiling would arrive far sooner
+/// under any real concurrency. Matches the crate's existing convention for
+/// blocking filesystem work (`interaction_log`, `session_record`,
+/// `system_status::registry_counts`).
+///
+/// A `JoinError` means the blocking task panicked or was cancelled. It is mapped
+/// to a `500` rather than unwrapped: a panic inside the fold must not take the
+/// daemon down with it, and it is a real fault, so it is NOT degraded into the
+/// "no data" answer that a project without a log gets.
+/// Test: `super::tests::costs::costs_route_is_wired_into_router`,
+/// `super::tests::costs::costs_route_answers_through_the_blocking_pool`.
 pub(super) async fn get_costs(Query(q): Query<CostsQuery>) -> Response {
-    costs_at(&crate::usage::project_dir(), q.days)
+    let dir = crate::usage::project_dir();
+    let days = q.days;
+    match tokio::task::spawn_blocking(move || costs_at(&dir, days)).await {
+        Ok(response) => response,
+        Err(e) => {
+            tracing::error!(error = %e, "costs: aggregation task failed to join");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "available": false,
+                    "error": format!("cost aggregation task failed: {e}"),
+                })),
+            )
+                .into_response()
+        }
+    }
 }
 
 /// Aggregate `project_dir`'s usage log into an HTTP response.

--- a/crates/trusty-agents/src/api/server/costs.rs
+++ b/crates/trusty-agents/src/api/server/costs.rs
@@ -1,0 +1,157 @@
+//! `GET /api/costs` — aggregated usage cost for the Costs tab (#4098).
+//!
+//! Why: The Costs tab (COST-09, formerly #4108) needs totals plus a breakdown
+//! by agent, model and day, and nothing exposed the per-dispatch usage log over
+//! HTTP. This route is that surface. It owns no arithmetic of its own: the fold
+//! is `usage::aggregate::aggregate_usage` and the rates are
+//! `perf::pricing::cost_usd`, so the API can never report a number the CLI or a
+//! future report would disagree with.
+//!
+//! **Honesty rules, and why each is load-bearing.** A cost view is only worth
+//! having if a number on it is a claim you can act on, so every state that
+//! ISN'T "here are your costs" gets its own distinguishable answer:
+//!
+//! - **No log yet → `200` with `available: false` and a `reason`, never a zero
+//!   summary.** `$0.00` and "nothing has been recorded" are different claims,
+//!   and the first one, made wrongly, is the failure mode that makes an
+//!   operator stop trusting the whole tab. The GUI renders the reason.
+//! - **A log that exists but cannot be read → `500`.** That is a real fault
+//!   (permissions, a truncated mount) and is not degraded into "no data".
+//! - **Unparseable lines → `200`, aggregated without them, with
+//!   `malformed_lines > 0`.** Partial data is still useful; presenting a short
+//!   total as a whole one is not. The GUI warns when the count is non-zero.
+//! - **An empty-but-present log → `200`, `available: true`, `records: 0`.** The
+//!   project has state and simply has not dispatched — a real, different answer
+//!   from both of the above.
+//!
+//! Response shape (a single object, not COST-08's bare array):
+//!
+//! ```json
+//! {
+//!   "available": true,
+//!   "source": "/proj/.trusty-agents/state/usage.jsonl",
+//!   "records": 128, "malformed_lines": 0,
+//!   "first_ts": "...", "last_ts": "...", "window_days": 7,
+//!   "totals":   { "key": "total", "input_tokens": 0, "output_tokens": 0,
+//!                 "cost_usd": 0.0, "dispatch_count": 0, "duration_ms": 0 },
+//!   "by_agent": [ ... ], "by_model": [ ... ], "by_date": [ ... ]
+//! }
+//! ```
+//!
+//! Two deliberate deviations from COST-08's stated criteria, both consequences
+//! of building on read-time aggregation rather than #4104's unimplemented
+//! rollup tables (see `usage::aggregate`'s module doc and the PR body):
+//!
+//! - `?range=day|week|month` is not implemented — week/month rollups are
+//!   COST-07 (#4105) and there is nothing to query. `?days=<n>` narrows the
+//!   window instead, and `by_date` gives daily granularity.
+//! - `?group_by=` is not implemented. All three breakdowns ship in one payload
+//!   so the tab switches grouping without a refetch AND so the three can never
+//!   disagree — they are folds of one pass over one set of rows.
+//!
+//! What: [`get_costs`] is the axum handler; [`costs_at`] is the testable core
+//! that takes an explicit project dir.
+//! Test: `super::tests::costs`.
+
+use axum::{
+    Json,
+    extract::Query,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::Deserialize;
+use serde_json::json;
+
+use crate::usage::aggregate::{AggregateError, aggregate_usage};
+
+/// Upper bound on `?days=`, so a hostile or fat-fingered value cannot ask for
+/// a window wider than any plausible log. Purely defensive — the fold reads the
+/// whole file regardless; this only bounds the reported `window_days`.
+const MAX_WINDOW_DAYS: u32 = 3650;
+
+/// Query string for `GET /api/costs`.
+///
+/// Why: One optional knob. See the module doc for why `range`/`group_by` from
+/// COST-08 are absent rather than stubbed — a parameter that silently ignores
+/// its value is worse than one that isn't there.
+/// What: `days` — keep only rows within N days of the newest recorded row.
+/// Omitted (or 0) means "everything".
+/// Test: `costs_window_narrows_the_report`.
+#[derive(Debug, Default, Deserialize)]
+pub(super) struct CostsQuery {
+    /// Window in days, anchored on the newest recorded row.
+    #[serde(default)]
+    days: Option<u32>,
+}
+
+/// `GET /api/costs` — HTTP entry point.
+///
+/// Why/What: see the module doc. The project root is the daemon's CWD, matching
+/// `usage::project_dir`'s convention and the sibling routes' resolution.
+/// Test: `super::tests::costs::costs_route_is_wired_into_router`.
+pub(super) async fn get_costs(Query(q): Query<CostsQuery>) -> Response {
+    costs_at(&crate::usage::project_dir(), q.days)
+}
+
+/// Aggregate `project_dir`'s usage log into an HTTP response.
+///
+/// Why: Split from the axum shim so the four states this route distinguishes
+/// (recorded / not recorded / unreadable / malformed) are testable against a
+/// tempdir without standing up a server or mutating the process CWD.
+/// What: Calls `aggregate_usage`, maps `NotRecorded` to a `200` "no data"
+/// envelope and `Read` to a `500`, and otherwise serializes the summary with
+/// `available: true` spliced in.
+/// Test: `costs_reports_no_data_for_missing_log`,
+/// `costs_returns_totals_and_breakdowns`, `costs_surfaces_malformed_line_count`,
+/// `costs_reports_an_unreadable_log_as_a_server_error`.
+pub(super) fn costs_at(project_dir: &std::path::Path, days: Option<u32>) -> Response {
+    let window = days.filter(|d| *d > 0).map(|d| d.min(MAX_WINDOW_DAYS));
+    match aggregate_usage(project_dir, window) {
+        Ok(summary) => {
+            let mut body = match serde_json::to_value(&summary) {
+                Ok(serde_json::Value::Object(map)) => map,
+                _ => {
+                    // Unreachable: `CostSummary` is a plain struct. Answering
+                    // 500 rather than unwrapping keeps the daemon alive if it
+                    // ever becomes reachable.
+                    return (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({ "error": "could not serialize cost summary" })),
+                    )
+                        .into_response();
+                }
+            };
+            body.insert("available".to_string(), json!(true));
+            (StatusCode::OK, Json(serde_json::Value::Object(body))).into_response()
+        }
+        // Not an error: a project that has never dispatched has no log. The
+        // caller gets an explicit "nothing recorded", never a zero total.
+        Err(AggregateError::NotRecorded { path }) => (
+            StatusCode::OK,
+            Json(json!({
+                "available": false,
+                "reason": "no usage has been recorded for this project yet",
+                "source": path.display().to_string(),
+                "records": 0,
+                "malformed_lines": 0,
+                "window_days": window,
+                "totals": crate::usage::aggregate::CostRow {
+                    key: "total".to_string(),
+                    ..Default::default()
+                },
+                "by_agent": [], "by_model": [], "by_date": [],
+            })),
+        )
+            .into_response(),
+        // A log that exists but will not read is a real fault. Degrading it to
+        // "no data" would hide a broken cost trail behind an innocent message.
+        Err(e @ AggregateError::Read { .. }) => {
+            tracing::warn!(error = %e, "costs: usage log unreadable");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({ "available": false, "error": e.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/crates/trusty-agents/src/api/server/mod.rs
+++ b/crates/trusty-agents/src/api/server/mod.rs
@@ -12,6 +12,9 @@
 //!   - `routes`       → router assembly + `serve*` bootstrap
 //!   - `handlers`     → task / health / docs core handlers
 //!   - `cancel`       → task cancellation (`DELETE /api/task/:id`, #3063)
+//!   - `costs`        → aggregated usage cost (`GET /api/costs`, #4098): totals
+//!     + by-agent/model/date breakdowns folded read-time from
+//!     `.trusty-agents/state/usage.jsonl`
 //!   - `models`       → inference provider catalog (`GET /api/models`, #3243)
 //!   - `projects`     → project / session / agent listing handlers
 //!   - `agent_patch`  → per-agent model/provider write path
@@ -42,6 +45,7 @@ mod agent_stores;
 mod agent_subagents;
 mod auth;
 mod cancel;
+mod costs;
 mod ctrl_sessions;
 mod events_sse;
 mod handlers;

--- a/crates/trusty-agents/src/api/server/routes.rs
+++ b/crates/trusty-agents/src/api/server/routes.rs
@@ -30,6 +30,7 @@ use super::agent_stores::agent_stores_route;
 use super::agent_subagents::agent_subagents_route;
 use super::auth::{ApiClientConfig, ApiConfig, AuthState, auth_middleware};
 use super::cancel::cancel_task;
+use super::costs::get_costs;
 use super::ctrl_sessions::{
     attach_ctrl_session_handler, create_ctrl_session_handler, get_ctrl_session_handler,
     list_ctrl_sessions_handler, terminate_ctrl_session_handler,
@@ -195,6 +196,12 @@ pub fn build_router_with_origins(
             "/api/agents/{name}/subagents",
             axum::routing::get(agent_subagents_route),
         )
+        // #4098: aggregated usage cost for the Costs tab — totals plus
+        // by-agent/by-model/by-date breakdowns, folded read-time from
+        // `.trusty-agents/state/usage.jsonl` and priced through the single
+        // pricing table (`perf::pricing`). Distinguishes "no log yet"
+        // (200 + `available: false`) from "$0.00" — see `costs`'s module doc.
+        .route("/api/costs", get(get_costs))
         .route("/api/workstreams", get(list_workstreams_route))
         .route(
             "/api/workstreams/{name}/history",

--- a/crates/trusty-agents/src/api/server/tests/costs.rs
+++ b/crates/trusty-agents/src/api/server/tests/costs.rs
@@ -56,6 +56,35 @@ async fn costs_route_is_wired_into_router() {
     assert_ne!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
 }
 
+/// Why (#4098): `get_costs` runs the blocking fold on `spawn_blocking` so a
+/// whole-file read + per-line parse cannot stall the tokio executor for every
+/// other route. That wrapper adds a join seam the direct `costs_at` tests never
+/// touch — a botched join (or a body that never resolves) would surface as a
+/// hang or a `500` only through the real handler.
+/// What: Drives the actual async handler on a MULTI-THREAD runtime and asserts
+/// it round-trips a well-formed envelope. The assertion is on the envelope, not
+/// on a dollar figure, because the daemon's CWD during tests may or may not
+/// carry a usage log — both answers are `200` and both carry `available`.
+/// Test: this test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn costs_route_answers_through_the_blocking_pool() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/api/costs?days=7")
+        .body(Body::empty())
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    let (status, body) = read(resp).await;
+    assert_eq!(status, StatusCode::OK, "got body {body}");
+    assert!(
+        body["available"].is_boolean(),
+        "handler must return the documented envelope, got {body}"
+    );
+    // The join seam must not swallow the query string on its way to the pool.
+    // Both 200 branches (recorded and not-recorded) echo the window back.
+    assert_eq!(body["window_days"], 7, "got body {body}");
+}
+
 /// Why (#4098): the Costs tab binds directly to these field names, so the
 /// payload shape is a contract, not an implementation detail.
 /// What: Every documented field is present and the breakdowns carry the

--- a/crates/trusty-agents/src/api/server/tests/costs.rs
+++ b/crates/trusty-agents/src/api/server/tests/costs.rs
@@ -1,0 +1,232 @@
+//! `GET /api/costs` response-shape and state-distinction tests (#4098).
+//!
+//! Why: The route's whole value is that it tells four states apart — costs,
+//! nothing recorded, nothing dispatched, and unreadable. Collapsing any pair of
+//! them produces the confident-`$0.00`-over-a-missing-file failure the Costs
+//! tab exists to avoid, and no other test would catch it.
+//! What: `costs_at` exercised against tempdir fixtures for the payload shape and
+//! each state, plus one router-level check that the path is actually wired.
+//! Test: this file.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+use super::test_router;
+use crate::api::server::costs::costs_at;
+
+/// Read an axum `Response` into a JSON value plus its status.
+async fn read(resp: axum::response::Response) -> (StatusCode, serde_json::Value) {
+    let status = resp.status();
+    let bytes = axum::body::to_bytes(resp.into_body(), 1 << 20)
+        .await
+        .expect("body");
+    let json = serde_json::from_slice(&bytes).expect("json body");
+    (status, json)
+}
+
+/// Write `lines` as a project's usage log and return the tempdir.
+fn log_with(lines: &[&str]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = dir.path().join(".trusty-agents").join("state");
+    std::fs::create_dir_all(&state).expect("mkdir");
+    std::fs::write(state.join("usage.jsonl"), lines.join("\n")).expect("write");
+    dir
+}
+
+fn row(ts: &str, agent: &str, model: &str, input: u32, output: u32) -> String {
+    format!(
+        r#"{{"ts":"{ts}","agent":"{agent}","model":"{model}","runner":"openrouter","input_tokens":{input},"output_tokens":{output},"duration_ms":10,"task_prefix":"t"}}"#
+    )
+}
+
+/// Why (#4098): a route that exists in a module but not in the router is a
+/// 404 the GUI cannot tell from a broken build.
+/// What: `GET /api/costs` against the real router is not 404/405.
+/// Test: this test.
+#[tokio::test]
+async fn costs_route_is_wired_into_router() {
+    let app = test_router();
+    let req = Request::builder()
+        .uri("/api/costs")
+        .body(Body::empty())
+        .expect("request");
+    let resp = app.oneshot(req).await.expect("response");
+    assert_ne!(resp.status(), StatusCode::NOT_FOUND, "/api/costs unrouted");
+    assert_ne!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+/// Why (#4098): the Costs tab binds directly to these field names, so the
+/// payload shape is a contract, not an implementation detail.
+/// What: Every documented field is present and the breakdowns carry the
+/// documented row shape.
+/// Test: this test.
+#[tokio::test]
+async fn costs_returns_totals_and_breakdowns() {
+    let dir = log_with(&[
+        &row(
+            "2026-07-27T10:00:00Z",
+            "assistant",
+            "anthropic/claude-sonnet-4-6",
+            1_000_000,
+            0,
+        ),
+        &row(
+            "2026-07-28T10:00:00Z",
+            "ctrl",
+            "anthropic/claude-haiku-4",
+            1_000_000,
+            0,
+        ),
+    ]);
+    let (status, body) = read(costs_at(dir.path(), None)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["available"], true);
+    assert_eq!(body["records"], 2);
+    assert_eq!(body["malformed_lines"], 0);
+    assert!(body["source"].is_string());
+    assert_eq!(body["first_ts"], "2026-07-27T10:00:00Z");
+    assert_eq!(body["last_ts"], "2026-07-28T10:00:00Z");
+    assert!(body["window_days"].is_null());
+
+    // Sonnet $3/M + Haiku $0.80/M.
+    let total = body["totals"]["cost_usd"].as_f64().expect("total cost");
+    assert!((total - 3.80).abs() < 1e-6, "got {total}");
+    assert_eq!(body["totals"]["key"], "total");
+    assert_eq!(body["totals"]["dispatch_count"], 2);
+
+    for group in ["by_agent", "by_model", "by_date"] {
+        let rows = body[group].as_array().expect(group);
+        assert_eq!(rows.len(), 2, "{group}");
+        for r in rows {
+            for field in [
+                "key",
+                "input_tokens",
+                "output_tokens",
+                "cost_usd",
+                "dispatch_count",
+                "duration_ms",
+            ] {
+                assert!(r.get(field).is_some(), "{group} row missing {field}");
+            }
+        }
+    }
+    // Descending by cost — Sonnet's agent leads.
+    assert_eq!(body["by_agent"][0]["key"], "assistant");
+    // Ascending by date.
+    assert_eq!(body["by_date"][0]["key"], "2026-07-27");
+}
+
+/// Why (#4098): THE load-bearing behavior. A missing log must not render as
+/// `$0.00` — the endpoint says so explicitly and the GUI repeats it.
+/// What: A project with no state dir answers 200 with `available: false`, a
+/// human-readable `reason`, and a zeroed-but-clearly-unavailable envelope.
+/// Test: this test.
+#[tokio::test]
+async fn costs_reports_no_data_for_missing_log() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let (status, body) = read(costs_at(dir.path(), None)).await;
+    assert_eq!(status, StatusCode::OK, "absent data is not an HTTP error");
+    assert_eq!(body["available"], false);
+    assert!(
+        body["reason"]
+            .as_str()
+            .expect("reason")
+            .contains("no usage has been recorded"),
+        "got {body}"
+    );
+    assert_eq!(body["records"], 0);
+    assert_eq!(body["totals"]["cost_usd"], 0.0);
+    assert!(body["by_agent"].as_array().expect("by_agent").is_empty());
+    assert!(
+        body["source"]
+            .as_str()
+            .expect("source")
+            .contains("usage.jsonl")
+    );
+}
+
+/// Why (#4098): a log that EXISTS but is empty is a different fact from one
+/// that does not exist — the project has state and simply has not dispatched.
+/// Conflating them would make "not set up" indistinguishable from "idle".
+/// What: An empty file answers `available: true` with zero records.
+/// Test: this test.
+#[tokio::test]
+async fn costs_distinguishes_empty_log_from_missing_log() {
+    let dir = log_with(&[]);
+    let (status, body) = read(costs_at(dir.path(), None)).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["available"], true, "the log exists — it is just empty");
+    assert_eq!(body["records"], 0);
+    assert!(body.get("reason").is_none());
+}
+
+/// Why (#4098): totals over a partially-unreadable log are incomplete, and the
+/// GUI can only warn about that if the count reaches it.
+/// What: A log with two good rows and two bad ones reports both counts.
+/// Test: this test.
+#[tokio::test]
+async fn costs_surfaces_malformed_line_count() {
+    let dir = log_with(&[
+        &row("2026-07-27T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+        "{ not json",
+        r#"{"agent":"a","model":"m"}"#,
+        &row("2026-07-27T11:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+    ]);
+    let (status, body) = read(costs_at(dir.path(), None)).await;
+    assert_eq!(status, StatusCode::OK, "partial data is still served");
+    assert_eq!(body["records"], 2);
+    assert_eq!(body["malformed_lines"], 2);
+    let total = body["totals"]["cost_usd"].as_f64().expect("cost");
+    assert!((total - 1.60).abs() < 1e-6, "got {total}");
+}
+
+/// Why (#4098): `?days=` is the only query knob the route implements, so its
+/// effect on the payload is the contract the GUI's range control binds to.
+/// What: `days=1` narrows a three-day log to its newest day and echoes the
+/// window back; `days=0` is treated as "everything".
+/// Test: this test.
+#[tokio::test]
+async fn costs_window_narrows_the_report() {
+    let dir = log_with(&[
+        &row("2026-07-26T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+        &row("2026-07-27T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+        &row("2026-07-28T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+    ]);
+    let (_, all) = read(costs_at(dir.path(), None)).await;
+    assert_eq!(all["records"], 3);
+
+    let (status, one) = read(costs_at(dir.path(), Some(1))).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(one["records"], 1);
+    assert_eq!(one["window_days"], 1);
+    assert_eq!(one["by_date"].as_array().expect("by_date").len(), 1);
+
+    // `days=0` is meaningless as a window; treat it as unrestricted rather
+    // than as "show nothing".
+    let (_, zero) = read(costs_at(dir.path(), Some(0))).await;
+    assert_eq!(zero["records"], 3);
+    assert!(zero["window_days"].is_null());
+}
+
+/// Why (#4098): an unreadable-but-present log is a real fault (permissions, a
+/// truncated mount). Degrading it to "no data" would hide a broken cost trail
+/// behind an innocent message.
+/// What: A `usage.jsonl` that is a DIRECTORY reads as an I/O error → 500.
+/// Test: this test.
+#[tokio::test]
+async fn costs_reports_an_unreadable_log_as_a_server_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // A directory where the file should be: exists, but never reads as text.
+    std::fs::create_dir_all(dir.path().join(".trusty-agents/state/usage.jsonl")).expect("mkdir");
+    let (status, body) = read(costs_at(dir.path(), None)).await;
+    assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    assert_eq!(body["available"], false);
+    assert!(
+        body["error"]
+            .as_str()
+            .expect("error")
+            .contains("could not read usage log"),
+        "got {body}"
+    );
+}

--- a/crates/trusty-agents/src/api/server/tests/mod.rs
+++ b/crates/trusty-agents/src/api/server/tests/mod.rs
@@ -13,6 +13,7 @@ mod agent_skills;
 mod agent_stores;
 mod agent_subagents;
 mod cancel;
+mod costs;
 mod ctrl_sessions;
 mod events_sse;
 mod guard;

--- a/crates/trusty-agents/src/perf/mod.rs
+++ b/crates/trusty-agents/src/perf/mod.rs
@@ -193,12 +193,14 @@ impl PerfCollector {
     /// `PhaseRecord`.
     /// Test: `collector_records_phases`.
     pub fn record_phase(&mut self, name: &str, duration_ms: u64, model: &str, usage: &TokenUsage) {
+        // #4098: `cost_usd` counts widened to u64 for the shared aggregate
+        // surfaces; `TokenUsage` stays u32, so widen at the seam.
         let cost = cost_usd(
             model,
-            usage.prompt_tokens,
-            usage.completion_tokens,
-            usage.cache_read_tokens,
-            usage.cache_creation_tokens,
+            usage.prompt_tokens.into(),
+            usage.completion_tokens.into(),
+            usage.cache_read_tokens.into(),
+            usage.cache_creation_tokens.into(),
         );
         self.phases.push(PhaseRecord {
             name: name.to_string(),

--- a/crates/trusty-agents/src/perf/pricing.rs
+++ b/crates/trusty-agents/src/perf/pricing.rs
@@ -3,6 +3,16 @@
 //! Why: The pricing table + cost math is mechanically independent of the
 //! collector's lifecycle; isolating it keeps `mod.rs` focused on recording
 //! and persisting performance records.
+//!
+//! **#4098 (COST-05, formerly #4103): this is the SINGLE pricing entry point.**
+//! A second, Haiku-only rate table used to live in `usage::daily`, which meant
+//! the REPL statusline and the persisted daily total priced every Sonnet turn
+//! at Haiku rates — every cost the operator saw was ~12x too low. That table
+//! is gone; `usage::daily::cost_from_tokens`, `usage::aggregate` and
+//! `perf::PerfCollector` all route through [`cost_usd`] here. Do not add a
+//! second table: a rate that disagrees with this one is a defect, not a
+//! variant.
+//!
 //! What: `cost_usd` (public), the `pricing_for`/`per_million` rate helpers, and
 //! the `filename_stamp` / `truncate_preview` formatters used by the collector.
 //! Test: `cost_usd_*` / `filename_stamp_format` / `truncate_preview_*` in
@@ -13,20 +23,29 @@
 ///
 /// Why: (#47) We hard-code the pricing table rather than hit a live endpoint
 /// so offline/CI runs still produce comparable cost figures. Pricing is
-/// per-million-tokens as published by Anthropic and OpenRouter.
+/// per-million-tokens as published by Anthropic and OpenRouter. (#4098) This
+/// is the one entry point every cost surface must call — see the module doc
+/// for the duplicate table it replaced.
 /// What: Substring-matches the model string (e.g. "anthropic/claude-sonnet-4-5"
 /// or "claude-haiku-4") and multiplies each token bucket by its rate.
-/// Test: `cost_usd_known_model`, `cost_usd_unknown_defaults_to_sonnet`.
+///
+/// Counts are `u64` rather than `u32` (#4098) because the aggregate surfaces
+/// that now share this entry point — a whole day of dispatches in
+/// `usage::aggregate`, a whole REPL session in `usage::daily` — sum well past
+/// `u32::MAX`, and a saturating cast at each of those call sites would
+/// silently under-report exactly the totals the Costs tab exists to show.
+/// Test: `cost_usd_known_sonnet`, `cost_usd_known_haiku`,
+/// `cost_usd_unknown_defaults_to_sonnet`, `cost_usd_accepts_counts_beyond_u32`.
 pub fn cost_usd(
     model: &str,
-    prompt_tokens: u32,
-    completion_tokens: u32,
-    cache_read: u32,
-    cache_creation: u32,
+    prompt_tokens: u64,
+    completion_tokens: u64,
+    cache_read: u64,
+    cache_creation: u64,
 ) -> f64 {
     // Rates in USD per token (not per million).
     let (rate_in, rate_out, rate_cache_r, rate_cache_w) = pricing_for(model);
-    let to_usd = |tokens: u32, rate: f64| tokens as f64 * rate;
+    let to_usd = |tokens: u64, rate: f64| tokens as f64 * rate;
     to_usd(prompt_tokens, rate_in)
         + to_usd(completion_tokens, rate_out)
         + to_usd(cache_read, rate_cache_r)

--- a/crates/trusty-agents/src/perf/tests.rs
+++ b/crates/trusty-agents/src/perf/tests.rs
@@ -91,6 +91,20 @@ fn cost_usd_unknown_defaults_to_sonnet() {
     assert!((u - 3.0).abs() < 1e-9);
 }
 
+/// Why (#4098): the counts widened to `u64` precisely so the shared aggregate
+/// callers (`usage::aggregate`, `usage::daily`) can sum a whole corpus without
+/// a saturating cast that would silently under-report the total.
+/// What: 10 billion prompt tokens — well past `u32::MAX` — prices linearly.
+/// Test: this test.
+#[test]
+fn cost_usd_accepts_counts_beyond_u32() {
+    let beyond = u64::from(u32::MAX) + 1;
+    let c = cost_usd("anthropic/claude-sonnet-4-6", beyond, 0, 0, 0);
+    let expected = beyond as f64 * 3.0 / 1_000_000.0;
+    assert!((c - expected).abs() < 1e-6, "expected {expected}, got {c}");
+    assert!(c.is_finite());
+}
+
 #[test]
 fn collector_records_phases() {
     let mut c = PerfCollector::new(7, "prescriptive", "write x");

--- a/crates/trusty-agents/src/repl/tui/status.rs
+++ b/crates/trusty-agents/src/repl/tui/status.rs
@@ -76,7 +76,10 @@ pub(crate) fn build_rich_statusline(app: &ReplApp) -> Line<'static> {
         let display = m.strip_prefix("ollama/").unwrap_or(m);
         format!("local: {display}")
     });
-    let session_cost = crate::usage::daily::cost_from_tokens(app.tokens_in, app.tokens_out);
+    // #4098: price the session at the model actually in use, not the retired
+    // Haiku-only table that under-billed every Sonnet turn ~12x.
+    let session_cost =
+        crate::usage::daily::cost_from_tokens(&app.model_name, app.tokens_in, app.tokens_out);
     let daily_cost = app.daily_cost_start + session_cost;
     // Show the daily-total segment only when there was prior usage today —
     // i.e. the "today" total exceeds the in-flight session cost. On a fresh
@@ -89,7 +92,11 @@ pub(crate) fn build_rich_statusline(app: &ReplApp) -> Line<'static> {
                 chunks.push(format!("{} session", format_cost_value(session_cost)));
                 chunks.push(format!("{} today", format_cost_value(daily_cost)));
             } else {
-                chunks.push(format_cost_chunk(app.tokens_in, app.tokens_out));
+                chunks.push(format_cost_chunk(
+                    &app.model_name,
+                    app.tokens_in,
+                    app.tokens_out,
+                ));
             }
         }
         chunks.push((*chunk).to_string());
@@ -144,13 +151,15 @@ pub(crate) fn format_token_chunk(tokens_in: u64, tokens_out: u64) -> String {
 
 /// Format the `$0.0034` estimated-cost chunk for the statusline.
 ///
-/// Why: Surfaces approximate spend at-a-glance using OpenRouter haiku
-/// pricing (a reasonable default for the most-common harness model).
-/// What: Cost = prompt_tokens * $0.00000025 + completion_tokens * $0.00000125.
-/// Format with 4 decimals if <$0.01, 3 decimals otherwise.
-/// Test: `format_cost_chunk_thresholds`.
-pub(crate) fn format_cost_chunk(tokens_in: u64, tokens_out: u64) -> String {
-    let cost = crate::usage::daily::cost_from_tokens(tokens_in, tokens_out);
+/// Why: Surfaces approximate spend at-a-glance. (#4098) It used to price
+/// every session at Haiku rates regardless of the model in use — the
+/// statusline is the operator's only live cost signal, so a wrong-by-12x
+/// figure there is worse than none.
+/// What: Prices `tokens_in`/`tokens_out` for `model` through the single
+/// pricing entry point, then formats with 4 decimals if <$0.01, 3 otherwise.
+/// Test: `format_cost_chunk_thresholds`, `format_cost_chunk_is_model_aware`.
+pub(crate) fn format_cost_chunk(model: &str, tokens_in: u64, tokens_out: u64) -> String {
+    let cost = crate::usage::daily::cost_from_tokens(model, tokens_in, tokens_out);
     format_cost_value(cost)
 }
 
@@ -188,7 +197,10 @@ pub(crate) fn persist_daily_usage_if_due(app: &mut ReplApp) {
     if !due {
         return;
     }
-    let session_cost = crate::usage::daily::cost_from_tokens(app.tokens_in, app.tokens_out);
+    // #4098: same model-aware pricing the statusline renders, so the persisted
+    // daily total and the on-screen figure can never disagree.
+    let session_cost =
+        crate::usage::daily::cost_from_tokens(&app.model_name, app.tokens_in, app.tokens_out);
     let record = crate::usage::daily::DailyUsage {
         date: crate::usage::daily::today_local(),
         // Note: prompt_tokens / completion_tokens are *daily* totals on disk.

--- a/crates/trusty-agents/src/repl/tui/tests_render.rs
+++ b/crates/trusty-agents/src/repl/tui/tests_render.rs
@@ -577,13 +577,28 @@ fn format_token_chunk_compacts_thousands() {
 /// Test: deterministic boundary check.
 #[test]
 fn format_cost_chunk_thresholds() {
-    // 1000 prompt + 1000 completion @ haiku rates =
-    //   1000 * 0.00000025 + 1000 * 0.00000125 = 0.0015
-    let s = format_cost_chunk(1000, 1000);
-    assert_eq!(s, "$0.0015");
-    // 100k prompt + 100k completion = 0.025 + 0.125 = 0.150 → 3 decimals.
-    let s = format_cost_chunk(100_000, 100_000);
-    assert_eq!(s, "$0.150");
+    // #4098: rates now come from the single pricing table, keyed by model.
+    // 1000 prompt + 1000 completion @ haiku ($0.80/$4 per M) =
+    //   1000 * 0.0000008 + 1000 * 0.000004 = 0.0048
+    let s = format_cost_chunk("claude-haiku-4", 1000, 1000);
+    assert_eq!(s, "$0.0048");
+    // 10k prompt + 10k completion @ haiku = 0.008 + 0.04 = 0.048 → 3 decimals.
+    let s = format_cost_chunk("claude-haiku-4", 10_000, 10_000);
+    assert_eq!(s, "$0.048");
+}
+
+/// Why (#4098, COST-05): the statusline used to bill every model at Haiku
+/// rates. A threshold test alone would still pass under that bug, so pin the
+/// property the bug violated: the same token counts must cost more on Sonnet.
+/// What: Same counts, two models, compare the rendered strings numerically.
+/// Test: this test.
+#[test]
+fn format_cost_chunk_is_model_aware() {
+    let haiku = format_cost_chunk("claude-haiku-4", 1_000_000, 0);
+    let sonnet = format_cost_chunk("anthropic/claude-sonnet-4-6", 1_000_000, 0);
+    assert_eq!(haiku, "$0.800");
+    assert_eq!(sonnet, "$3.000");
+    assert_ne!(haiku, sonnet, "model must change the rendered cost");
 }
 
 /// Why: Activity row 1 must include elapsed time and the cycling status

--- a/crates/trusty-agents/src/usage/aggregate/mod.rs
+++ b/crates/trusty-agents/src/usage/aggregate/mod.rs
@@ -1,0 +1,384 @@
+//! Read-time cost aggregation over `.trusty-agents/state/usage.jsonl` (#4098).
+//!
+//! Why: The Costs tab needs totals and a breakdown by agent, model and day,
+//! and the only usage data that exists is the append-only JSONL log
+//! `usage::append_usage` writes. Two shapes were available:
+//!
+//!   1. **Read-time aggregation** (this module) — parse the log on request and
+//!      fold it. One code path, no schema, no migration, no second writer, and
+//!      no way for a rollup to disagree with the raw rows it was derived from,
+//!      because there is no rollup. The whole failure surface is "the file is
+//!      missing or a line does not parse", both of which are reported rather
+//!      than smoothed over.
+//!   2. **A persistent rollup store** (SQLite/redb; the shape COST-06/#4104
+//!      specifies) — durable `usage_daily`/`usage_weekly`/`usage_monthly`
+//!      tables, a scheduled rollup job, upsert/transaction handling, and the
+//!      standing obligation to keep derived totals reconcilable with
+//!      `usage_raw` across crashes and concurrent writers.
+//!
+//! This slice takes (1) deliberately. The epic's "Done when" is about
+//! trustworthiness — *"every displayed amount traces to valid raw rows and one
+//! pricing table"* — and folding the raw rows on demand satisfies that by
+//! construction, where a rollup satisfies it only as long as its refresh job
+//! is correct. #4104 remains open and unimplemented; when durable rollups are
+//! built, this fold is the reference they must reproduce. **This is a
+//! deliberate deviation from COST-06/#4104's acceptance criteria, not an
+//! oversight** — see the PR body.
+//!
+//! Volume assumption, stated so the ceiling is falsifiable rather than
+//! implied: a `UsageRecord` line is ~200 bytes, and this reads + parses the
+//! whole file per request. At ~10k dispatches (~2 MB) a fold costs single-digit
+//! milliseconds; at ~1M dispatches (~200 MB) it is hundreds of milliseconds and
+//! the whole file is resident. **Past roughly 100k records — or once the Costs
+//! tab polls rather than loads on demand — read-time aggregation stops being
+//! adequate and #4104's durable rollup becomes the right shape.**
+//! [`CostSummary::records`] is reported in the payload so that threshold can be
+//! observed rather than guessed at.
+//!
+//! What: [`aggregate_usage`] folds the log into a [`CostSummary`] — totals plus
+//! three [`CostRow`] breakdowns (by agent, by model, by UTC date) — pricing
+//! every row through the single entry point `crate::perf::cost_usd`.
+//! [`AggregateError`] separates "no log yet" from "the log could not be read",
+//! because a Costs view that renders a confident `$0.00` over a missing file is
+//! worse than one that says it has no data.
+//! Test: `super::aggregate::tests`.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+use super::UsageRecord;
+
+/// Filename of the per-dispatch usage log, relative to the state dir.
+const USAGE_LOG: &str = "usage.jsonl";
+
+/// Why aggregation could not produce a summary.
+///
+/// Why: The two failure modes need different answers from the API. A log that
+/// does not exist yet is the normal state of a fresh project and must read as
+/// "no data recorded", never as "$0.00 spent". A log that exists but cannot be
+/// read is a real fault and must surface as one.
+/// What: `NotRecorded` carries the path we looked for; `Read` wraps the I/O
+/// error alongside it.
+/// Test: `aggregate_reports_not_recorded_for_missing_log`.
+#[derive(Debug, thiserror::Error)]
+pub enum AggregateError {
+    /// No usage log exists at this path — nothing has been dispatched yet.
+    #[error("no usage log recorded at {}", .path.display())]
+    NotRecorded {
+        /// Absolute path of the log we looked for.
+        path: PathBuf,
+    },
+    /// The log exists but could not be read.
+    #[error("could not read usage log {}: {source}", .path.display())]
+    Read {
+        /// Absolute path of the log that failed to read.
+        path: PathBuf,
+        /// Underlying I/O failure.
+        #[source]
+        source: std::io::Error,
+    },
+}
+
+/// One aggregate bucket — a total for some grouping key.
+///
+/// Why: The three breakdowns (agent, model, date) differ only in what `key`
+/// means, so they share one row type instead of three near-identical structs
+/// the GUI would have to special-case.
+/// What: The key plus summed tokens, summed USD cost, dispatch count and
+/// summed wall-clock duration. `cost_usd` is the sum of PER-ROW costs, never a
+/// re-price of summed tokens: rows may carry different models, and pricing the
+/// aggregate would silently apply one model's rate to another's tokens.
+/// Test: `aggregate_groups_by_agent_and_model`, `aggregate_prices_per_row`.
+#[derive(Debug, Clone, Default, PartialEq, Serialize)]
+pub struct CostRow {
+    /// Agent name, model id, or `YYYY-MM-DD`, depending on the breakdown.
+    pub key: String,
+    /// Summed prompt/input tokens.
+    pub input_tokens: u64,
+    /// Summed completion/output tokens.
+    pub output_tokens: u64,
+    /// Summed USD cost of the rows in this bucket.
+    pub cost_usd: f64,
+    /// Number of dispatches folded into this bucket.
+    pub dispatch_count: u64,
+    /// Summed wall-clock milliseconds.
+    pub duration_ms: u64,
+}
+
+impl CostRow {
+    /// Fold one usage record into this bucket.
+    fn add(&mut self, record: &UsageRecord, cost: f64) {
+        self.input_tokens += u64::from(record.input_tokens);
+        self.output_tokens += u64::from(record.output_tokens);
+        self.cost_usd += cost;
+        self.dispatch_count += 1;
+        self.duration_ms += record.duration_ms;
+    }
+}
+
+/// The full aggregation result served by `GET /api/costs`.
+///
+/// Why: One payload carrying totals AND all three breakdowns lets the Costs
+/// tab switch its group-by without a refetch, and — more importantly — keeps
+/// the three views arithmetically consistent, since they are folds of the same
+/// pass over the same rows. It also carries its own provenance: which file was
+/// read, how many rows were counted, and how many were skipped.
+/// What: `source`/`records`/`malformed_lines`/`first_ts`/`last_ts` describe the
+/// data; `totals` and the three `by_*` vectors describe the costs. Breakdowns
+/// are sorted by descending cost (by ascending date for `by_date`), so the GUI
+/// renders a stable order without sorting.
+/// Test: `aggregate_reports_malformed_lines`, `aggregate_sorts_breakdowns`.
+#[derive(Debug, Clone, Serialize)]
+pub struct CostSummary {
+    /// Absolute path of the log that was read.
+    pub source: String,
+    /// Valid rows folded into the totals.
+    pub records: u64,
+    /// Lines skipped because they did not parse as a `UsageRecord`.
+    ///
+    /// Non-zero means the totals below are INCOMPLETE. Reported rather than
+    /// swallowed so the GUI can say so instead of presenting a short total as
+    /// a whole one.
+    pub malformed_lines: u64,
+    /// Earliest `ts` among the folded rows, if any.
+    pub first_ts: Option<String>,
+    /// Latest `ts` among the folded rows, if any.
+    pub last_ts: Option<String>,
+    /// Window applied to the fold, in days, or `None` for "everything".
+    pub window_days: Option<u32>,
+    /// Grand totals. `key` is `"total"`.
+    pub totals: CostRow,
+    /// Per-agent breakdown, descending by cost.
+    pub by_agent: Vec<CostRow>,
+    /// Per-model breakdown, descending by cost.
+    pub by_model: Vec<CostRow>,
+    /// Per-UTC-date breakdown, ascending by date.
+    pub by_date: Vec<CostRow>,
+}
+
+/// Resolve `<project_dir>/.trusty-agents/state/usage.jsonl`.
+///
+/// Why: The aggregator and `append_usage` must agree on the path or the Costs
+/// tab reads an empty file next to a populated one.
+/// What: Mirrors `append_usage`'s join, exposed so callers can report the exact
+/// path they looked at.
+/// Test: `usage_log_path_matches_writer`.
+pub fn usage_log_path(project_dir: &Path) -> PathBuf {
+    project_dir
+        .join(".trusty-agents")
+        .join("state")
+        .join(USAGE_LOG)
+}
+
+/// Fold the project's usage log into a [`CostSummary`].
+///
+/// Why: (#4098) The single aggregation for every cost surface — the HTTP route
+/// and any future CLI report call this rather than each re-deriving totals.
+/// What: Reads the log at [`usage_log_path`], parses each non-blank line as a
+/// [`UsageRecord`], prices it through `crate::perf::cost_usd`, and folds it
+/// into the grand total plus three grouped breakdowns. `window_days`, when set,
+/// keeps only rows whose UTC date is within that many days of the newest row in
+/// the file (not of wall-clock "now" — a log whose last entry is a week old
+/// should still render its last day of activity rather than an empty chart).
+///
+/// Honesty rules, each of which exists because the alternative silently lies:
+///
+/// - A missing log is [`AggregateError::NotRecorded`], never an all-zero
+///   summary. `$0.00` and "nothing recorded" are different claims.
+/// - A line that does not parse is counted in `malformed_lines` and skipped —
+///   never defaulted into a zero-cost row that would inflate `dispatch_count`
+///   with rows we could not read.
+/// - A row whose computed cost is not finite is treated as malformed. Token
+///   counts are integers and the rates are finite, so this is unreachable
+///   today; it is enforced anyway because the epic's "Done when" requires that
+///   NaN/Inf cannot enter a persisted total, and an unchecked `+=` of a NaN
+///   would poison every bucket it touches irrecoverably.
+/// Test: `aggregate_folds_totals_and_breakdowns`,
+/// `aggregate_reports_not_recorded_for_missing_log`,
+/// `aggregate_empty_file_is_zero_rows_not_an_error`,
+/// `aggregate_reports_malformed_lines`, `aggregate_window_filters_by_date`.
+pub fn aggregate_usage(
+    project_dir: &Path,
+    window_days: Option<u32>,
+) -> Result<CostSummary, AggregateError> {
+    let path = usage_log_path(project_dir);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Err(AggregateError::NotRecorded { path });
+        }
+        Err(source) => return Err(AggregateError::Read { path, source }),
+    };
+
+    let mut records: Vec<(UsageRecord, f64)> = Vec::new();
+    let mut malformed_lines = 0u64;
+    for line in contents.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(record) = serde_json::from_str::<UsageRecord>(line) else {
+            malformed_lines += 1;
+            continue;
+        };
+        // #4098: one pricing table for the whole crate — see perf::pricing.
+        // Cache buckets are 0 until #4101 threads cache tokens into the
+        // record; they are absent from the log today, not dropped here.
+        let cost = crate::perf::cost_usd(
+            &record.model,
+            u64::from(record.input_tokens),
+            u64::from(record.output_tokens),
+            0,
+            0,
+        );
+        if !cost.is_finite() {
+            malformed_lines += 1;
+            continue;
+        }
+        records.push((record, cost));
+    }
+
+    let cutoff = window_days.and_then(|days| window_cutoff(&records, days));
+    Ok(fold(&path, records, malformed_lines, window_days, cutoff))
+}
+
+/// Compute the inclusive lower-bound date for a `window_days` filter.
+///
+/// Why: Anchoring the window on the newest RECORDED row rather than on
+/// wall-clock "now" means a log that stopped a week ago still renders its final
+/// days of activity instead of an honest-but-useless empty window. The Costs
+/// tab is a retrospective, not a live meter.
+/// What: Takes the max `ts` date present, subtracts `days - 1`, and returns the
+/// resulting `YYYY-MM-DD`. `None` when no row carries a parseable date.
+/// Test: `aggregate_window_filters_by_date`, `aggregate_window_anchors_on_newest_row`.
+fn window_cutoff(records: &[(UsageRecord, f64)], days: u32) -> Option<String> {
+    let newest = records
+        .iter()
+        .filter_map(|(r, _)| parse_date(&r.ts))
+        .max()?;
+    let span = chrono::Duration::days(i64::from(days.max(1)) - 1);
+    Some((newest - span).format("%Y-%m-%d").to_string())
+}
+
+/// Parse an RFC3339 `ts` into its UTC calendar date.
+///
+/// Why: Grouping and windowing are per-day, and the log stores a full
+/// timestamp. UTC (not local) so the same log aggregates identically on two
+/// machines in different zones — a report that changes when you fly is not
+/// reproducible, which the epic's "rollups are reproducible" requires.
+/// What: `DateTime::parse_from_rfc3339` → `naive_utc().date()`. `None` for an
+/// unparseable stamp, which the caller treats as an ungrouped row.
+/// Test: `aggregate_groups_by_date_in_utc`.
+fn parse_date(ts: &str) -> Option<chrono::NaiveDate> {
+    chrono::DateTime::parse_from_rfc3339(ts)
+        .ok()
+        .map(|dt| dt.naive_utc().date())
+}
+
+/// Fold priced records into the summary, applying the date `cutoff`.
+///
+/// Why: Split from `aggregate_usage` so the I/O and the arithmetic are
+/// separately readable, and so the fold stays under the file's share of the
+/// 500-SLOC cap.
+/// What: One pass building the grand total and three keyed maps, then sorts.
+/// Test: covered via `aggregate_usage`'s tests.
+fn fold(
+    path: &Path,
+    records: Vec<(UsageRecord, f64)>,
+    malformed_lines: u64,
+    window_days: Option<u32>,
+    cutoff: Option<String>,
+) -> CostSummary {
+    let mut totals = CostRow {
+        key: "total".to_string(),
+        ..CostRow::default()
+    };
+    let mut by_agent: Vec<CostRow> = Vec::new();
+    let mut by_model: Vec<CostRow> = Vec::new();
+    let mut by_date: Vec<CostRow> = Vec::new();
+    let mut first_ts: Option<String> = None;
+    let mut last_ts: Option<String> = None;
+    let mut counted = 0u64;
+
+    for (record, cost) in &records {
+        let date = parse_date(&record.ts).map(|d| d.format("%Y-%m-%d").to_string());
+        if let (Some(min), Some(d)) = (cutoff.as_deref(), date.as_deref())
+            && d < min
+        {
+            continue;
+        }
+        counted += 1;
+        totals.add(record, *cost);
+        bucket(&mut by_agent, label(&record.agent, "(unattributed)")).add(record, *cost);
+        bucket(&mut by_model, label(&record.model, "(unknown model)")).add(record, *cost);
+        bucket(
+            &mut by_date,
+            date.unwrap_or_else(|| "(undated)".to_string()),
+        )
+        .add(record, *cost);
+        if first_ts.as_deref().is_none_or(|t| record.ts.as_str() < t) {
+            first_ts = Some(record.ts.clone());
+        }
+        if last_ts.as_deref().is_none_or(|t| record.ts.as_str() > t) {
+            last_ts = Some(record.ts.clone());
+        }
+    }
+
+    by_agent.sort_by(cost_desc);
+    by_model.sort_by(cost_desc);
+    by_date.sort_by(|a, b| a.key.cmp(&b.key));
+
+    CostSummary {
+        source: path.display().to_string(),
+        records: counted,
+        malformed_lines,
+        first_ts,
+        last_ts,
+        window_days,
+        totals,
+        by_agent,
+        by_model,
+        by_date,
+    }
+}
+
+/// Replace an empty grouping key with an explicit placeholder.
+///
+/// Why: An empty `agent` is missing attribution, and the epic requires missing
+/// attribution be EXPLICIT. A blank legend entry reads as a rendering bug; a
+/// row labelled `(unattributed)` reads as the fact it is.
+fn label(value: &str, placeholder: &str) -> String {
+    if value.trim().is_empty() {
+        placeholder.to_string()
+    } else {
+        value.to_string()
+    }
+}
+
+/// Find-or-append the bucket for `key`.
+///
+/// Why: A `Vec` scan rather than a `HashMap` — these breakdowns have tens of
+/// distinct agents/models/days, so the linear probe is faster than hashing and
+/// keeps insertion order available for a deterministic sort tiebreak.
+fn bucket(rows: &mut Vec<CostRow>, key: String) -> &mut CostRow {
+    if let Some(i) = rows.iter().position(|r| r.key == key) {
+        return &mut rows[i];
+    }
+    rows.push(CostRow {
+        key,
+        ..CostRow::default()
+    });
+    let last = rows.len() - 1;
+    &mut rows[last]
+}
+
+/// Descending by cost, then ascending by key so ties are deterministic.
+fn cost_desc(a: &CostRow, b: &CostRow) -> std::cmp::Ordering {
+    b.cost_usd
+        .partial_cmp(&a.cost_usd)
+        .unwrap_or(std::cmp::Ordering::Equal)
+        .then_with(|| a.key.cmp(&b.key))
+}
+
+#[cfg(test)]
+mod tests;

--- a/crates/trusty-agents/src/usage/aggregate/mod.rs
+++ b/crates/trusty-agents/src/usage/aggregate/mod.rs
@@ -35,6 +35,14 @@
 //! [`CostSummary::records`] is reported in the payload so that threshold can be
 //! observed rather than guessed at.
 //!
+//! That ceiling is about the fold's own cost and assumes the work is NOT on the
+//! async reactor. This function is deliberately synchronous and blocking; every
+//! caller is responsible for keeping it off a tokio worker thread. The HTTP
+//! route does so with `spawn_blocking` (see `api::server::costs::get_costs`).
+//! Called inline from an async context instead, the executor — not the file
+//! size — becomes the binding constraint, and the ceiling above arrives far
+//! sooner under concurrency.
+//!
 //! What: [`aggregate_usage`] folds the log into a [`CostSummary`] — totals plus
 //! three [`CostRow`] breakdowns (by agent, by model, by UTC date) — pricing
 //! every row through the single entry point `crate::perf::cost_usd`.

--- a/crates/trusty-agents/src/usage/aggregate/tests.rs
+++ b/crates/trusty-agents/src/usage/aggregate/tests.rs
@@ -1,0 +1,363 @@
+//! Aggregation correctness for the Costs surface (#4098).
+//!
+//! Why: Every figure the Costs tab shows is this fold's output, so the tests
+//! that matter are the ones that pin the honesty rules — a missing log is not
+//! `$0.00`, an unreadable line is counted rather than swallowed, and a
+//! multi-model log is priced per row rather than at one blended rate.
+//! What: Fixture logs written to a tempdir, folded, and asserted field by
+//! field.
+//! Test: this file.
+
+use super::*;
+
+/// Write `lines` as the project's usage log and return the tempdir.
+fn log_with(lines: &[&str]) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let state = dir.path().join(".trusty-agents").join("state");
+    std::fs::create_dir_all(&state).expect("mkdir");
+    std::fs::write(state.join("usage.jsonl"), lines.join("\n")).expect("write log");
+    dir
+}
+
+/// One JSONL row in the exact shape `append_usage` writes.
+fn row(ts: &str, agent: &str, model: &str, input: u32, output: u32) -> String {
+    format!(
+        r#"{{"ts":"{ts}","agent":"{agent}","model":"{model}","runner":"openrouter","input_tokens":{input},"output_tokens":{output},"duration_ms":1000,"task_prefix":"t"}}"#
+    )
+}
+
+/// Why: The aggregator and `append_usage` must read/write the same file, or
+/// the Costs tab reports an empty log next to a populated one.
+/// What: The resolved path matches the writer's documented location.
+/// Test: this test.
+#[test]
+fn usage_log_path_matches_writer() {
+    let p = usage_log_path(Path::new("/proj"));
+    assert!(p.ends_with(".trusty-agents/state/usage.jsonl"), "got {p:?}");
+}
+
+/// Why (#4098): the core fold — totals must equal the sum of the breakdowns,
+/// and each breakdown must equal the sum of its own rows, or the GUI shows
+/// three mutually contradictory numbers.
+/// What: Two agents, two models, two days; assert every bucket.
+/// Test: this test.
+#[test]
+fn aggregate_folds_totals_and_breakdowns() {
+    let dir = log_with(&[
+        &row(
+            "2026-07-27T10:00:00Z",
+            "assistant",
+            "anthropic/claude-sonnet-4-6",
+            1_000_000,
+            0,
+        ),
+        &row(
+            "2026-07-27T11:00:00Z",
+            "ctrl",
+            "anthropic/claude-haiku-4",
+            1_000_000,
+            0,
+        ),
+        &row(
+            "2026-07-28T09:00:00Z",
+            "assistant",
+            "anthropic/claude-sonnet-4-6",
+            1_000_000,
+            0,
+        ),
+    ]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+
+    assert_eq!(s.records, 3);
+    assert_eq!(s.malformed_lines, 0);
+    // Sonnet $3/M x2 + Haiku $0.80/M x1 = $6.80.
+    assert!((s.totals.cost_usd - 6.80).abs() < 1e-6, "{s:?}");
+    assert_eq!(s.totals.input_tokens, 3_000_000);
+    assert_eq!(s.totals.dispatch_count, 3);
+    assert_eq!(s.first_ts.as_deref(), Some("2026-07-27T10:00:00Z"));
+    assert_eq!(s.last_ts.as_deref(), Some("2026-07-28T09:00:00Z"));
+
+    // Every breakdown must sum back to the grand total.
+    for rows in [&s.by_agent, &s.by_model, &s.by_date] {
+        let sum: f64 = rows.iter().map(|r| r.cost_usd).sum();
+        assert!(
+            (sum - s.totals.cost_usd).abs() < 1e-6,
+            "breakdown sums to {sum}, total is {}",
+            s.totals.cost_usd
+        );
+        let count: u64 = rows.iter().map(|r| r.dispatch_count).sum();
+        assert_eq!(count, s.totals.dispatch_count);
+    }
+}
+
+/// Why (#4098, COST-05): a log spanning two models must price each row at its
+/// own rate. Blending — pricing summed tokens once — was the exact class of bug
+/// the retired Haiku table caused.
+/// What: Equal token counts on Sonnet and Haiku produce unequal bucket costs.
+/// Test: this test.
+#[test]
+fn aggregate_prices_per_row() {
+    let dir = log_with(&[
+        &row(
+            "2026-07-27T10:00:00Z",
+            "a",
+            "claude-sonnet-4-6",
+            1_000_000,
+            0,
+        ),
+        &row("2026-07-27T10:01:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+    ]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    let sonnet = s
+        .by_model
+        .iter()
+        .find(|r| r.key == "claude-sonnet-4-6")
+        .expect("sonnet bucket");
+    let haiku = s
+        .by_model
+        .iter()
+        .find(|r| r.key == "claude-haiku-4")
+        .expect("haiku bucket");
+    assert!((sonnet.cost_usd - 3.0).abs() < 1e-6, "{sonnet:?}");
+    assert!((haiku.cost_usd - 0.80).abs() < 1e-6, "{haiku:?}");
+    assert!(sonnet.cost_usd > haiku.cost_usd);
+}
+
+/// Why (#4098): grouping keys are what the legend renders, so agent and model
+/// must not be conflated or transposed.
+/// What: Two agents on one model group into two agent buckets, one model bucket.
+/// Test: this test.
+#[test]
+fn aggregate_groups_by_agent_and_model() {
+    let dir = log_with(&[
+        &row("2026-07-27T10:00:00Z", "assistant", "m1", 100, 10),
+        &row("2026-07-27T10:01:00Z", "ctrl", "m1", 100, 10),
+        &row("2026-07-27T10:02:00Z", "ctrl", "m1", 100, 10),
+    ]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    assert_eq!(s.by_agent.len(), 2);
+    assert_eq!(s.by_model.len(), 1);
+    let ctrl = s
+        .by_agent
+        .iter()
+        .find(|r| r.key == "ctrl")
+        .expect("ctrl bucket");
+    assert_eq!(ctrl.dispatch_count, 2);
+    assert_eq!(ctrl.input_tokens, 200);
+    assert_eq!(ctrl.output_tokens, 20);
+}
+
+/// Why (#4098): a Costs view that renders a confident `$0.00` over a log that
+/// does not exist is worse than one that says it has no data. This is the
+/// single most important behavior in the module.
+/// What: A project with no `.trusty-agents/state` yields `NotRecorded` carrying
+/// the path, not an all-zero summary.
+/// Test: this test.
+#[test]
+fn aggregate_reports_not_recorded_for_missing_log() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let err = aggregate_usage(dir.path(), None).expect_err("must not succeed");
+    match err {
+        AggregateError::NotRecorded { path } => {
+            assert!(path.ends_with("usage.jsonl"), "got {path:?}");
+        }
+        other => panic!("expected NotRecorded, got {other:?}"),
+    }
+    assert!(
+        aggregate_usage(dir.path(), None)
+            .unwrap_err()
+            .to_string()
+            .contains("no usage log recorded")
+    );
+}
+
+/// Why (#4098): an EXISTING but empty log is a different fact from a missing
+/// one — the project has a state dir and simply has not dispatched yet. It must
+/// aggregate cleanly to zero rows rather than erroring.
+/// What: An empty file (and one of only blank lines) yields `records == 0` with
+/// no error and no malformed count.
+/// Test: this test.
+#[test]
+fn aggregate_empty_file_is_zero_rows_not_an_error() {
+    let dir = log_with(&[]);
+    let s = aggregate_usage(dir.path(), None).expect("empty log must aggregate");
+    assert_eq!(s.records, 0);
+    assert_eq!(s.malformed_lines, 0);
+    assert_eq!(s.totals.cost_usd, 0.0);
+    assert!(s.by_agent.is_empty() && s.by_model.is_empty() && s.by_date.is_empty());
+    assert!(s.first_ts.is_none() && s.last_ts.is_none());
+
+    let blanks = log_with(&["", "   ", ""]);
+    let s = aggregate_usage(blanks.path(), None).expect("blank lines must aggregate");
+    assert_eq!(s.records, 0);
+    assert_eq!(s.malformed_lines, 0);
+}
+
+/// Why (#4098): the totals over a partially-unreadable log are INCOMPLETE, and
+/// presenting a short total as a whole one is the failure the epic's honesty
+/// requirement targets. Malformed lines are counted so the GUI can say so.
+/// What: Truncated JSON, non-JSON text, a JSON non-object, and an object
+/// missing a required attribution field are each skipped and counted; the valid
+/// rows still fold.
+/// Test: this test.
+#[test]
+fn aggregate_reports_malformed_lines() {
+    let dir = log_with(&[
+        &row("2026-07-27T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+        r#"{"ts":"2026-07-27T10:01:00Z","agent":"a","#, // truncated
+        "not json at all",
+        "[1,2,3]",                                      // valid JSON, wrong shape
+        r#"{"agent":"a","model":"m"}"#,                 // no ts — unplaceable
+        r#"{"ts":"2026-07-27T10:02:00Z","model":"m"}"#, // no agent — unattributable
+        &row("2026-07-27T10:03:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+    ]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    assert_eq!(s.records, 2, "only the two well-formed rows count");
+    assert_eq!(s.malformed_lines, 5, "every unreadable line is reported");
+    assert!((s.totals.cost_usd - 1.60).abs() < 1e-6, "{s:?}");
+    assert_eq!(
+        s.totals.dispatch_count, 2,
+        "unreadable rows must not inflate the dispatch count"
+    );
+}
+
+/// Why (#4098): a row written by an older binary lacks fields a newer one
+/// writes. Those rows are real usage and must still count — only the three
+/// attribution fields are load-bearing enough to reject a row over.
+/// What: A row with just `ts`/`agent`/`model` parses with zeroed counts.
+/// Test: this test.
+#[test]
+fn aggregate_tolerates_rows_missing_optional_fields() {
+    let dir = log_with(&[r#"{"ts":"2026-07-27T10:00:00Z","agent":"a","model":"m"}"#]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    assert_eq!(s.records, 1);
+    assert_eq!(s.malformed_lines, 0);
+    assert_eq!(s.totals.input_tokens, 0);
+    assert_eq!(s.totals.cost_usd, 0.0);
+}
+
+/// Why (#4098): an empty `agent` is MISSING attribution, which the epic
+/// requires be explicit. A blank legend entry reads as a rendering bug.
+/// What: A row with an empty agent lands in an `(unattributed)` bucket.
+/// Test: this test.
+#[test]
+fn aggregate_labels_missing_attribution_explicitly() {
+    let dir = log_with(&[&row("2026-07-27T10:00:00Z", "", "claude-haiku-4", 100, 0)]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    assert_eq!(s.by_agent[0].key, "(unattributed)");
+}
+
+/// Why (#4098): the date breakdown is the chart's X axis, and it must be UTC so
+/// the same log renders identically regardless of the reader's timezone —
+/// "rollups are reproducible" in the epic's Done-when.
+/// What: Two stamps that fall on different local days but the same UTC day
+/// group together.
+/// Test: this test.
+#[test]
+fn aggregate_groups_by_date_in_utc() {
+    let dir = log_with(&[
+        &row("2026-07-27T23:30:00Z", "a", "m", 100, 0),
+        &row("2026-07-27T20:30:00-04:00", "a", "m", 100, 0), // = 2026-07-28T00:30Z
+    ]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    let dates: Vec<&str> = s.by_date.iter().map(|r| r.key.as_str()).collect();
+    assert_eq!(dates, vec!["2026-07-27", "2026-07-28"], "{s:?}");
+}
+
+/// Why (#4098): `?days=N` narrows the report. Anchoring on the NEWEST RECORDED
+/// row rather than wall-clock now means a log that stopped last week still
+/// renders its final days instead of an honest-but-useless empty window.
+/// What: `days=1` over a three-day log keeps only the newest day.
+/// Test: this test.
+#[test]
+fn aggregate_window_filters_by_date() {
+    let dir = log_with(&[
+        &row("2026-07-26T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+        &row("2026-07-27T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+        &row("2026-07-28T10:00:00Z", "a", "claude-haiku-4", 1_000_000, 0),
+    ]);
+    let all = aggregate_usage(dir.path(), None).expect("aggregate");
+    assert_eq!(all.records, 3);
+    assert_eq!(all.window_days, None);
+
+    let one = aggregate_usage(dir.path(), Some(1)).expect("aggregate");
+    assert_eq!(one.records, 1);
+    assert_eq!(one.window_days, Some(1));
+    assert_eq!(one.by_date.len(), 1);
+    assert_eq!(one.by_date[0].key, "2026-07-28");
+
+    let two = aggregate_usage(dir.path(), Some(2)).expect("aggregate");
+    assert_eq!(two.records, 2, "a 2-day window is inclusive of both ends");
+}
+
+/// Why (#4098): see `aggregate_window_filters_by_date` — the anchor choice is
+/// the surprising half, so it gets its own assertion.
+/// What: A log whose newest row is long past still returns rows for `days=1`.
+/// Test: this test.
+#[test]
+fn aggregate_window_anchors_on_newest_row() {
+    let dir = log_with(&[&row("1999-01-01T10:00:00Z", "a", "m", 100, 0)]);
+    let s = aggregate_usage(dir.path(), Some(1)).expect("aggregate");
+    assert_eq!(s.records, 1, "a stale log must not window down to nothing");
+}
+
+/// Why (#4098): the GUI renders breakdowns in payload order, so the order is
+/// part of the contract rather than an accident of the fold.
+/// What: Agent/model rows descend by cost; date rows ascend by date.
+/// Test: this test.
+#[test]
+fn aggregate_sorts_breakdowns() {
+    let dir = log_with(&[
+        &row("2026-07-28T10:00:00Z", "cheap", "claude-haiku-4", 1_000, 0),
+        &row(
+            "2026-07-26T10:00:00Z",
+            "pricey",
+            "claude-sonnet-4-6",
+            1_000_000,
+            0,
+        ),
+        &row(
+            "2026-07-27T10:00:00Z",
+            "middle",
+            "claude-haiku-4",
+            500_000,
+            0,
+        ),
+    ]);
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    let agents: Vec<&str> = s.by_agent.iter().map(|r| r.key.as_str()).collect();
+    assert_eq!(agents, vec!["pricey", "middle", "cheap"]);
+    let dates: Vec<&str> = s.by_date.iter().map(|r| r.key.as_str()).collect();
+    assert_eq!(dates, vec!["2026-07-26", "2026-07-27", "2026-07-28"]);
+}
+
+/// Why (#4098): the aggregator must read back exactly what the writer emits —
+/// a reader with its own DTO would drift silently. This is the end-to-end
+/// proof that they share one shape.
+/// What: `append_usage` writes two records; the aggregator folds both.
+/// Test: this test.
+#[tokio::test]
+async fn aggregate_reads_what_append_usage_wrote() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let r1 = UsageRecord::new(
+        "assistant",
+        "claude-sonnet-4-6",
+        "openrouter",
+        1000,
+        200,
+        50,
+        "a",
+    );
+    let r2 = UsageRecord::new("ctrl", "claude-haiku-4", "openrouter", 400, 100, 25, "b");
+    super::super::append_usage(dir.path(), &r1).await;
+    super::super::append_usage(dir.path(), &r2).await;
+
+    let s = aggregate_usage(dir.path(), None).expect("aggregate");
+    assert_eq!(s.records, 2);
+    assert_eq!(s.malformed_lines, 0);
+    assert_eq!(s.totals.input_tokens, 1400);
+    assert_eq!(s.totals.output_tokens, 300);
+    assert_eq!(s.totals.duration_ms, 75);
+    assert_eq!(s.by_agent.len(), 2);
+    assert!(s.totals.cost_usd > 0.0 && s.totals.cost_usd.is_finite());
+}

--- a/crates/trusty-agents/src/usage/daily.rs
+++ b/crates/trusty-agents/src/usage/daily.rs
@@ -13,20 +13,27 @@
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-/// Haiku pricing — kept here so both the live statusline and the persisted
-/// daily total agree on the rate. Mirrors the constants in
-/// `src/repl/tui.rs::format_cost_chunk`.
-pub const PROMPT_RATE: f64 = 0.00000025;
-pub const COMPLETION_RATE: f64 = 0.00000125;
-
-/// Compute USD cost from token counts using the haiku rate table.
+/// Compute USD cost for `model` from prompt/completion token counts.
 ///
-/// Why: Centralized so daily aggregation never drifts from the per-session
-/// number rendered on the statusline.
-/// What: prompt * $0.00000025 + completion * $0.00000125.
-/// Test: `cost_from_tokens_matches_published_rates`.
-pub fn cost_from_tokens(prompt: u64, completion: u64) -> f64 {
-    (prompt as f64) * PROMPT_RATE + (completion as f64) * COMPLETION_RATE
+/// Why: (#4098, COST-05) This function used to own a SECOND pricing table —
+/// two hardcoded Haiku constants (`$0.25`/`$1.25` per million) applied to
+/// every model. The REPL statusline and the persisted `usage.json` daily
+/// total both went through it, so a Sonnet session (the actual default, see
+/// the provider-policy note in `llm/`) was billed on screen at roughly a
+/// twelfth of its real cost. The table is deleted, not corrected: a second
+/// rate table is a defect regardless of the numbers in it, because nothing
+/// keeps it in step with `perf::pricing`. This is now a thin adapter, kept
+/// only so the two statusline call sites and the daily-total writer share one
+/// spelling of "cost for this session".
+/// What: Delegates to [`crate::perf::cost_usd`] — the single pricing entry
+/// point — passing `0` for both cache buckets. The REPL's `TokenUpdate` feed
+/// carries only in/out counts today; when #4101 threads cache tokens through
+/// `UsageRecord`, this call gains them rather than growing a rate of its own.
+/// Test: `cost_from_tokens_prices_sonnet_above_haiku`,
+/// `cost_from_tokens_matches_pricing_entry_point`.
+pub fn cost_from_tokens(model: &str, prompt: u64, completion: u64) -> f64 {
+    // #4098: one pricing table for the whole crate — see perf::pricing's doc.
+    crate::perf::cost_usd(model, prompt, completion, 0, 0)
 }
 
 /// Persisted shape of `.trusty-agents/state/usage.json`.
@@ -126,11 +133,30 @@ pub fn save_atomic(project_dir: &Path, record: &DailyUsage) -> std::io::Result<(
 mod tests {
     use super::*;
 
+    /// #4098 (COST-05) regression guard: the deleted local table priced every
+    /// model at Haiku rates, so this assertion could not have held before.
     #[test]
-    fn cost_from_tokens_matches_published_rates() {
-        // 1000 prompt + 1000 completion = 0.00025 + 0.00125 = 0.0015
-        let c = cost_from_tokens(1000, 1000);
-        assert!((c - 0.0015).abs() < 1e-9, "got {c}");
+    fn cost_from_tokens_prices_sonnet_above_haiku() {
+        let sonnet = cost_from_tokens("anthropic/claude-sonnet-4-6", 1_000_000, 1_000_000);
+        let haiku = cost_from_tokens("anthropic/claude-haiku-4", 1_000_000, 1_000_000);
+        // Sonnet: $3 + $15 = $18. Haiku: $0.80 + $4 = $4.80.
+        assert!((sonnet - 18.0).abs() < 1e-6, "sonnet got {sonnet}");
+        assert!((haiku - 4.80).abs() < 1e-6, "haiku got {haiku}");
+        assert!(sonnet > haiku, "sonnet must not be billed at haiku rates");
+    }
+
+    /// #4098 (COST-05): the statusline path and the pricing table must be the
+    /// same number, not two numbers that happen to agree today.
+    #[test]
+    fn cost_from_tokens_matches_pricing_entry_point() {
+        for model in ["anthropic/claude-sonnet-4-6", "claude-haiku-4", "mystery/x"] {
+            let via_daily = cost_from_tokens(model, 12_345, 6_789);
+            let via_pricing = crate::perf::cost_usd(model, 12_345, 6_789, 0, 0);
+            assert!(
+                (via_daily - via_pricing).abs() < f64::EPSILON,
+                "{model}: daily={via_daily} pricing={via_pricing}"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusty-agents/src/usage/mod.rs
+++ b/crates/trusty-agents/src/usage/mod.rs
@@ -13,9 +13,10 @@
 //! Test: see `tests` module — round-trip serialization, task_prefix
 //! truncation, file create + append semantics.
 
+pub mod aggregate;
 pub mod daily;
 
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::path::Path;
 use tokio::io::AsyncWriteExt;
 
@@ -25,8 +26,20 @@ use tokio::io::AsyncWriteExt;
 /// grep-able and trivially loadable into pandas / DuckDB / jq.
 /// What: ts (RFC3339), agent name, model, runner tag, token counts,
 /// duration, and a 60-char task prefix.
-/// Test: `usage_record_serializes_to_valid_jsonl`.
-#[derive(Debug, Clone, Serialize)]
+///
+/// `Deserialize` (#4098) makes this the SINGLE shape for the log — the
+/// aggregator in [`aggregate`] reads back exactly what `append_usage` wrote
+/// rather than carrying its own DTO that could drift from the writer. The
+/// three attribution fields (`ts`, `agent`, `model`) are REQUIRED on read: a
+/// row missing any of them cannot be placed on a timeline or attributed to
+/// anything, so it is reported as malformed rather than defaulted into a
+/// plausible-looking bucket. Everything else defaults, so rows written by an
+/// older binary (or by a newer one, once #4101 adds cache-token fields) still
+/// parse instead of invalidating the whole file.
+/// Test: `usage_record_serializes_to_valid_jsonl`,
+/// `usage_record_round_trips_through_jsonl`,
+/// `usage_record_requires_attribution_fields`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UsageRecord {
     /// RFC3339 timestamp in UTC of when the dispatch *completed*.
     pub ts: String,
@@ -37,16 +50,21 @@ pub struct UsageRecord {
     /// Model id as actually dispatched (e.g. `anthropic/claude-sonnet-4-6`).
     pub model: String,
     /// One of `"claude-code" | "anthropic-direct" | "openrouter" | "bedrock"`.
+    #[serde(default)]
     pub runner: String,
     /// Prompt / input tokens reported by the provider. `0` when unavailable
     /// (e.g. older `claude` CLI versions that omit the `usage` block).
+    #[serde(default)]
     pub input_tokens: u32,
     /// Completion / output tokens. `0` when unavailable.
+    #[serde(default)]
     pub output_tokens: u32,
     /// Wall-clock milliseconds for the LLM call.
+    #[serde(default)]
     pub duration_ms: u64,
     /// First 60 chars of the task string. Strictly for human readability
     /// when tailing the log; not load-bearing for any tooling.
+    #[serde(default)]
     pub task_prefix: String,
 }
 
@@ -177,6 +195,61 @@ mod tests {
         assert_eq!(parsed["output_tokens"], 312);
         assert_eq!(parsed["duration_ms"], 4800);
         assert_eq!(parsed["task_prefix"], "fix credential routing");
+    }
+
+    /// Why (#4098): `usage::aggregate` reads the log back through THIS struct
+    /// rather than a reader DTO of its own, so a serialize/deserialize
+    /// asymmetry would silently drop usage from every cost figure.
+    /// What: Write a record, parse it back, compare every field.
+    /// Test: this test.
+    #[test]
+    fn usage_record_round_trips_through_jsonl() {
+        let r = UsageRecord::new(
+            "engineer",
+            "claude-sonnet-4-6",
+            "openrouter",
+            12,
+            34,
+            56,
+            "t",
+        );
+        let json = serde_json::to_string(&r).expect("serialize");
+        let back: UsageRecord = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(back.ts, r.ts);
+        assert_eq!(back.agent, r.agent);
+        assert_eq!(back.model, r.model);
+        assert_eq!(back.runner, r.runner);
+        assert_eq!(back.input_tokens, r.input_tokens);
+        assert_eq!(back.output_tokens, r.output_tokens);
+        assert_eq!(back.duration_ms, r.duration_ms);
+        assert_eq!(back.task_prefix, r.task_prefix);
+    }
+
+    /// Why (#4098): a row missing `ts`, `agent` or `model` cannot be placed on
+    /// a timeline or attributed to anything. It must FAIL to parse so the
+    /// aggregator counts it as malformed, rather than defaulting into a
+    /// plausible-looking zero-cost row. Optional fields must still default, so
+    /// rows from an older binary keep counting.
+    /// What: Each of the three required fields, omitted in turn, fails; a row
+    /// carrying only those three succeeds.
+    /// Test: this test.
+    #[test]
+    fn usage_record_requires_attribution_fields() {
+        for missing in [
+            r#"{"agent":"a","model":"m"}"#,
+            r#"{"ts":"2026-07-27T00:00:00Z","model":"m"}"#,
+            r#"{"ts":"2026-07-27T00:00:00Z","agent":"a"}"#,
+        ] {
+            assert!(
+                serde_json::from_str::<UsageRecord>(missing).is_err(),
+                "must reject {missing}"
+            );
+        }
+        let minimal: UsageRecord =
+            serde_json::from_str(r#"{"ts":"2026-07-27T00:00:00Z","agent":"a","model":"m"}"#)
+                .expect("required fields alone must parse");
+        assert_eq!(minimal.input_tokens, 0);
+        assert_eq!(minimal.runner, "");
     }
 
     #[test]

--- a/crates/trusty-agents/src/workflow/engine/executor/phase_loop.rs
+++ b/crates/trusty-agents/src/workflow/engine/executor/phase_loop.rs
@@ -401,12 +401,13 @@ impl WorkflowEngine {
 
             // #84: Compute this phase's cost for the ticket comment and
             // accumulate into the workflow total.
+            // #4098: `cost_usd` counts widened to u64; `TokenUsage` is u32.
             let phase_cost = crate::perf::cost_usd(
                 &phase_model,
-                output.usage.prompt_tokens,
-                output.usage.completion_tokens,
-                output.usage.cache_read_tokens,
-                output.usage.cache_creation_tokens,
+                output.usage.prompt_tokens.into(),
+                output.usage.completion_tokens.into(),
+                output.usage.cache_read_tokens.into(),
+                output.usage.cache_creation_tokens.into(),
             );
             total_cost_usd += phase_cost;
 

--- a/crates/trusty-agents/ui/src/App.svelte
+++ b/crates/trusty-agents/ui/src/App.svelte
@@ -9,6 +9,9 @@
   // has to be a sibling of the group rather than nested in the chat column.
   import ChatPane from './components/ChatPane.svelte';
   import EventsView from './components/EventsView.svelte';
+  // #4098 (COST-09): the Costs tab — spend by agent/model/day from
+  // `GET /api/costs`. Owns its own fetch; see the component's doc comment.
+  import CostsView from './components/CostsView.svelte';
   // #3819: `ProjectsView`/`PersonalityPanel` are no longer routed — Bob's
   // nav reshape drops the Projects/Personality top tabs entirely. Left
   // unimported/unrouted rather than deleted pending a decision on their
@@ -54,9 +57,10 @@
   // (reached via `ChatHeader`'s gear icon) saves each section independently
   // on its own explicit Save button, so there is no cross-tab discard risk
   // to guard against here anymore.
-  let activeView: 'chat' | 'events' = 'chat';
+  // #4098: 'costs' added for the Costs tab (COST-09).
+  let activeView: 'chat' | 'events' | 'costs' = 'chat';
 
-  function switchView(view: 'chat' | 'events') {
+  function switchView(view: 'chat' | 'events' | 'costs') {
     // #3894: leaving Chat abandons any open configuration takeover, so the
     // top-level tabs always mean what they say — coming back to Chat shows
     // chat, never a config surface the user left behind minutes ago.
@@ -412,6 +416,9 @@
            whole app. -->
       {#if activeView === 'chat'}
         <ChatPane />
+      {:else if activeView === 'costs'}
+        <!-- #4098 (COST-09): Costs tab. -->
+        <CostsView />
       {:else}
         <EventsView />
       {/if}

--- a/crates/trusty-agents/ui/src/components/CostsView.svelte
+++ b/crates/trusty-agents/ui/src/components/CostsView.svelte
@@ -1,0 +1,277 @@
+<script lang="ts">
+  /**
+   * Why (#4098, COST-09 formerly #4108): the Costs tab — what this project has
+   * spent, by agent, by model, and by day. It renders `GET /api/costs`, which
+   * folds `.trusty-agents/state/usage.jsonl` read-time through the single
+   * pricing table (see the Rust modules `usage::aggregate` and `perf::pricing`).
+   *
+   * The pane's whole posture is that a cost figure the operator cannot trust is
+   * worse than no figure, so it never collapses a state it can distinguish:
+   *  - LOADING is its own state — never an empty chart that looks like $0.
+   *  - NO LOG YET says so, and names the file it looked for. A confident
+   *    `$0.00` over a missing usage log is the failure this tab exists to
+   *    avoid; it is the reason `lib/costs.ts` refuses the sibling clients'
+   *    return-`[]`-on-failure convention.
+   *  - AN EMPTY BUT PRESENT LOG is a different, real answer — the project has
+   *    state and simply has not dispatched.
+   *  - MALFORMED LINES raise a visible warning, because totals that skipped
+   *    rows are incomplete and presenting them as whole is the same lie in a
+   *    quieter voice.
+   *  - AN ERROR shows the server's message, not an empty dataset.
+   *
+   * Charting: rendered with plain CSS bars, NOT a charting library. The UI has
+   * no charting dependency today (`package.json` carries only `lucide-svelte`
+   * for icons), and COST-09's "reuse existing (likely Recharts)" is mistaken —
+   * there is no Recharts here, and this is a Svelte app, not React. A relative
+   * horizontal bar per row needs one `<div>` and a width percentage; adding a
+   * charting dependency to the shipped bundle to draw it would be a poor trade.
+   * Stacked bars (COST-09's literal ask) are NOT implemented — see the PR body.
+   *
+   * Colors come from the Foundry token scale only (`foundry-*` classes, both
+   * light and dark variants), never hardcoded hex.
+   * Test: `CostsView.test.ts`.
+   */
+  import { onMount } from 'svelte';
+  import { AlertCircle, AlertTriangle, Loader2, RefreshCw } from 'lucide-svelte';
+  import {
+    barPercent,
+    fetchCosts,
+    formatCount,
+    formatUsd,
+    type CostRow,
+    type CostsState,
+  } from '../lib/costs';
+
+  /**
+   * Injected by tests to render a fixed state without a network round-trip.
+   * `null` in the app, which triggers the `onMount` load.
+   */
+  export let state: CostsState | null = null;
+
+  type GroupBy = 'agent' | 'model' | 'date';
+  const GROUPS: { id: GroupBy; label: string }[] = [
+    { id: 'agent', label: 'By agent' },
+    { id: 'model', label: 'By model' },
+    { id: 'date', label: 'By day' },
+  ];
+  const WINDOWS: { days: number; label: string }[] = [
+    { days: 0, label: 'All' },
+    { days: 30, label: '30d' },
+    { days: 7, label: '7d' },
+    { days: 1, label: '1d' },
+  ];
+
+  let groupBy: GroupBy = 'agent';
+  let windowDays = 0;
+  let loading = false;
+
+  async function load() {
+    loading = true;
+    state = await fetchCosts(windowDays);
+    loading = false;
+  }
+
+  function selectWindow(days: number) {
+    windowDays = days;
+    void load();
+  }
+
+  onMount(() => {
+    // A test-supplied state stands in for the fetch; the app always loads.
+    if (state === null) void load();
+  });
+
+  $: summary = state?.kind === 'ok' ? state.summary : null;
+  $: rows =
+    summary === null
+      ? []
+      : groupBy === 'agent'
+        ? summary.by_agent
+        : groupBy === 'model'
+          ? summary.by_model
+          : summary.by_date;
+  $: maxCost = rows.reduce((m: number, r: CostRow) => Math.max(m, r.cost_usd), 0);
+</script>
+
+<div class="flex flex-1 flex-col overflow-hidden">
+  <div
+    class="flex flex-col gap-2 border-b border-foundry-light-border dark:border-foundry-border px-4 py-2.5"
+  >
+    <div class="flex flex-wrap items-center gap-2">
+      <div class="flex items-center gap-1" role="group" aria-label="Group by">
+        {#each GROUPS as g (g.id)}
+          <button
+            type="button"
+            aria-pressed={groupBy === g.id}
+            class="rounded-md border px-2 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide transition-colors {groupBy ===
+            g.id
+              ? 'border-foundry-light-primary dark:border-foundry-primary bg-foundry-light-primary/15 dark:bg-foundry-primary/15 text-foundry-light-primary dark:text-foundry-primary'
+              : 'border-foundry-light-border dark:border-foundry-border text-foundry-light-muted dark:text-foundry-text/50'}"
+            on:click={() => (groupBy = g.id)}
+          >
+            {g.label}
+          </button>
+        {/each}
+      </div>
+
+      <div class="flex items-center gap-1" role="group" aria-label="Time window">
+        {#each WINDOWS as w (w.days)}
+          <button
+            type="button"
+            aria-pressed={windowDays === w.days}
+            class="rounded-md border px-2 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide transition-colors {windowDays ===
+            w.days
+              ? 'border-foundry-light-primary dark:border-foundry-primary bg-foundry-light-primary/15 dark:bg-foundry-primary/15 text-foundry-light-primary dark:text-foundry-primary'
+              : 'border-foundry-light-border dark:border-foundry-border text-foundry-light-muted dark:text-foundry-text/50'}"
+            on:click={() => selectWindow(w.days)}
+          >
+            {w.label}
+          </button>
+        {/each}
+      </div>
+
+      <button
+        type="button"
+        class="ml-auto flex items-center gap-1.5 rounded-md border border-foundry-light-border dark:border-foundry-border px-2 py-1 font-mono text-[11px] font-semibold uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50 hover:text-foundry-light-primary dark:hover:text-foundry-primary"
+        on:click={() => void load()}
+      >
+        <RefreshCw class="h-3 w-3 {loading ? 'animate-spin' : ''}" aria-hidden="true" />
+        Refresh
+      </button>
+    </div>
+
+    {#if summary}
+      <div class="flex flex-wrap items-baseline gap-x-5 gap-y-1">
+        <span class="font-mono text-lg font-semibold text-foundry-light-primary dark:text-foundry-primary">
+          {formatUsd(summary.totals.cost_usd)}
+        </span>
+        <span class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+          {summary.totals.dispatch_count} dispatches · {formatCount(summary.totals.input_tokens)} in
+          · {formatCount(summary.totals.output_tokens)} out
+        </span>
+        {#if summary.first_ts && summary.last_ts}
+          <span class="font-mono text-[10px] text-foundry-light-muted dark:text-foundry-text/40">
+            {summary.first_ts.slice(0, 10)} → {summary.last_ts.slice(0, 10)}
+          </span>
+        {/if}
+      </div>
+      <p class="text-[10px] text-foundry-light-muted dark:text-foundry-text/40">
+        Estimated from recorded token counts at published list rates — not a billed invoice. Cache
+        tokens are not yet recorded (#4101), so cached turns are priced as uncached.
+      </p>
+    {/if}
+  </div>
+
+  <div class="flex-1 overflow-y-auto px-4 py-3">
+    {#if state === null || (loading && summary === null)}
+      <p
+        class="flex items-center justify-center gap-2 py-8 text-sm text-foundry-light-muted dark:text-foundry-text/50"
+      >
+        <Loader2 class="h-4 w-4 animate-spin" aria-hidden="true" /> Loading cost data…
+      </p>
+    {:else if state.kind === 'error'}
+      <p
+        class="flex items-start gap-1.5 rounded-md border border-red-500/40 bg-red-500/10 px-3 py-2 text-xs text-red-500 dark:text-red-400"
+      >
+        <AlertCircle class="mt-0.5 h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+        Could not read cost data: {state.message}
+      </p>
+    {:else if state.kind === 'no-data'}
+      <div
+        class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-4 py-6 text-center"
+      >
+        <p class="text-sm text-foundry-light-text dark:text-foundry-text">
+          No usage has been recorded for this project yet.
+        </p>
+        <p class="mt-1.5 text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
+          This is not $0.00 — nothing has been written to the usage log. It appears after the first
+          dispatch.
+        </p>
+        {#if state.source}
+          <p class="mt-1 font-mono text-[10px] text-foundry-light-muted dark:text-foundry-text/40">
+            {state.source}
+          </p>
+        {/if}
+      </div>
+    {:else}
+      {#if state.summary.malformed_lines > 0}
+        <p
+          class="mb-3 flex items-start gap-1.5 rounded-md border border-foundry-amber/40 bg-foundry-amber/10 px-3 py-2 text-[11px] text-foundry-amber"
+        >
+          <AlertTriangle class="mt-0.5 h-3 w-3 shrink-0" aria-hidden="true" />
+          {state.summary.malformed_lines} line{state.summary.malformed_lines === 1 ? '' : 's'} of the
+          usage log could not be parsed and {state.summary.malformed_lines === 1 ? 'is' : 'are'} not
+          included below — these totals are incomplete.
+        </p>
+      {/if}
+
+      {#if rows.length === 0}
+        <p
+          class="rounded-md border border-dashed border-foundry-light-border dark:border-foundry-border px-4 py-6 text-center text-sm text-foundry-light-muted dark:text-foundry-text/50"
+        >
+          No cost data for this period. The usage log exists but holds no dispatches in the selected
+          window.
+        </p>
+      {:else}
+        <table class="w-full border-collapse text-left text-xs">
+          <thead>
+            <tr
+              class="border-b border-foundry-light-border dark:border-foundry-border text-[10px] uppercase tracking-wide text-foundry-light-muted dark:text-foundry-text/50"
+            >
+              <th scope="col" class="py-1.5 pr-3 font-mono font-semibold">
+                {groupBy === 'date' ? 'Day' : groupBy}
+              </th>
+              <th scope="col" class="py-1.5 pr-3 font-mono font-semibold">Share</th>
+              <th scope="col" class="py-1.5 pr-3 text-right font-mono font-semibold">Cost</th>
+              <th scope="col" class="py-1.5 pr-3 text-right font-mono font-semibold">Calls</th>
+              <th scope="col" class="py-1.5 pr-3 text-right font-mono font-semibold">In</th>
+              <th scope="col" class="py-1.5 text-right font-mono font-semibold">Out</th>
+            </tr>
+          </thead>
+          <tbody>
+            {#each rows as row (row.key)}
+              <tr class="border-b border-foundry-light-border/50 dark:border-foundry-border/50">
+                <td
+                  class="max-w-[16rem] truncate py-1.5 pr-3 font-mono text-[11px] text-foundry-light-text dark:text-foundry-text"
+                  title={row.key}
+                >
+                  {row.key}
+                </td>
+                <td class="w-1/3 py-1.5 pr-3">
+                  <div
+                    class="h-2 w-full overflow-hidden rounded-sm bg-foundry-light-border/50 dark:bg-foundry-border/50"
+                  >
+                    <div
+                      class="h-full rounded-sm bg-foundry-light-primary dark:bg-foundry-primary"
+                      style="width: {barPercent(row.cost_usd, maxCost)}%"
+                    ></div>
+                  </div>
+                </td>
+                <td
+                  class="py-1.5 pr-3 text-right font-mono text-[11px] text-foundry-light-text dark:text-foundry-text"
+                >
+                  {formatUsd(row.cost_usd)}
+                </td>
+                <td
+                  class="py-1.5 pr-3 text-right font-mono text-[11px] text-foundry-light-muted dark:text-foundry-text/50"
+                >
+                  {row.dispatch_count}
+                </td>
+                <td
+                  class="py-1.5 pr-3 text-right font-mono text-[11px] text-foundry-light-muted dark:text-foundry-text/50"
+                >
+                  {formatCount(row.input_tokens)}
+                </td>
+                <td
+                  class="py-1.5 text-right font-mono text-[11px] text-foundry-light-muted dark:text-foundry-text/50"
+                >
+                  {formatCount(row.output_tokens)}
+                </td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {/if}
+    {/if}
+  </div>
+</div>

--- a/crates/trusty-agents/ui/src/components/CostsView.test.ts
+++ b/crates/trusty-agents/ui/src/components/CostsView.test.ts
@@ -1,0 +1,156 @@
+// Costs pane rendering tests (#4098, COST-09).
+//
+// Why: the pane's value is that it tells four states apart. The one that
+// matters most is NO LOG YET — a confident `$0.00` there is the failure this
+// tab exists to avoid — so it gets an explicit assertion that no dollar figure
+// is rendered at all. The rest pin that loading, empty-but-present, malformed
+// and error each keep their own voice.
+// What: Mounts `CostsView` with an injected `state` prop (standing in for the
+// fetch) and asserts the rendered text.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mount, unmount } from 'svelte';
+import CostsView from './CostsView.svelte';
+import type { CostRow, CostSummary, CostsState } from '../lib/costs';
+
+let target: HTMLDivElement;
+let instance: Record<string, unknown> | null = null;
+
+function row(key: string, cost: number, calls = 1): CostRow {
+  return {
+    key,
+    input_tokens: 1_000_000,
+    output_tokens: 2_000,
+    cost_usd: cost,
+    dispatch_count: calls,
+    duration_ms: 100,
+  };
+}
+
+function summary(over: Partial<CostSummary> = {}): CostSummary {
+  return {
+    available: true,
+    source: '/p/.trusty-agents/state/usage.jsonl',
+    records: 2,
+    malformed_lines: 0,
+    first_ts: '2026-07-27T10:00:00Z',
+    last_ts: '2026-07-28T10:00:00Z',
+    window_days: null,
+    totals: row('total', 3.8, 2),
+    by_agent: [row('assistant', 3.0), row('ctrl', 0.8)],
+    by_model: [row('anthropic/claude-sonnet-4-6', 3.0), row('anthropic/claude-haiku-4', 0.8)],
+    by_date: [row('2026-07-27', 3.0), row('2026-07-28', 0.8)],
+    ...over,
+  };
+}
+
+function render(state: CostsState) {
+  instance = mount(CostsView, { target, props: { state } }) as unknown as Record<string, unknown>;
+}
+
+/**
+ * Rendered text with all runs of whitespace collapsed to single spaces.
+ *
+ * Why: Svelte emits the template's own newlines and indentation into
+ * `textContent`, so a sentence that wraps across source lines — the malformed-
+ * lines warning does — is NOT a contiguous substring of the raw text even
+ * though it renders as one to a reader. Asserting on the raw value makes a
+ * passing test depend on where the markup happens to wrap, which is a
+ * formatting detail, not behaviour.
+ * What: `textContent` with `\s+` collapsed and the ends trimmed.
+ */
+function text(): string {
+  return (target.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+beforeEach(() => {
+  target = document.createElement('div');
+  document.body.appendChild(target);
+});
+
+afterEach(() => {
+  if (instance) {
+    unmount(instance);
+    instance = null;
+  }
+  target.remove();
+});
+
+describe('CostsView — populated', () => {
+  it('renders the grand total and the by-agent breakdown by default', () => {
+    render({ kind: 'ok', summary: summary() });
+    expect(text()).toContain('$3.80');
+    expect(text()).toContain('2 dispatches');
+    expect(text()).toContain('assistant');
+    expect(text()).toContain('ctrl');
+    // Not the model grouping until the control is switched.
+    expect(text()).not.toContain('claude-sonnet-4-6');
+  });
+
+  it('draws bars scaled to the largest row, with no charting dependency', () => {
+    render({ kind: 'ok', summary: summary() });
+    const bars = target.querySelectorAll('div[style*="width"]');
+    expect(bars.length).toBeGreaterThan(0);
+    const widths = Array.from(bars).map((b) => (b as HTMLElement).style.width);
+    expect(widths).toContain('100%');
+  });
+
+  it('labels the estimate as an estimate, not an invoice', () => {
+    render({ kind: 'ok', summary: summary() });
+    expect(text()).toContain('not a billed invoice');
+  });
+});
+
+describe('CostsView — the four states', () => {
+  it('shows a loading state rather than an empty chart', () => {
+    render(null as unknown as CostsState);
+    expect(text()).toContain('Loading cost data');
+    expect(text()).not.toContain('$0.00');
+  });
+
+  it('says NO DATA for a missing log and never renders a dollar figure', () => {
+    render({
+      kind: 'no-data',
+      reason: 'no usage has been recorded for this project yet',
+      source: '/p/.trusty-agents/state/usage.jsonl',
+    });
+    expect(text()).toContain('No usage has been recorded');
+    expect(text()).toContain('This is not $0.00');
+    expect(text()).toContain('usage.jsonl');
+    // The load-bearing assertion: no total, no table, no confident zero.
+    expect(text()).not.toContain('dispatches');
+    expect(target.querySelector('table')).toBeNull();
+  });
+
+  it('distinguishes an empty-but-present log from a missing one', () => {
+    render({
+      kind: 'ok',
+      summary: summary({ records: 0, totals: row('total', 0, 0), by_agent: [], by_model: [], by_date: [] }),
+    });
+    expect(text()).toContain('No cost data for this period');
+    expect(text()).toContain('usage log exists');
+    expect(text()).not.toContain('No usage has been recorded');
+  });
+
+  it('surfaces the server error instead of an empty dataset', () => {
+    render({ kind: 'error', message: 'could not read usage log /p/usage.jsonl: permission denied' });
+    expect(text()).toContain('Could not read cost data');
+    expect(text()).toContain('permission denied');
+    expect(target.querySelector('table')).toBeNull();
+  });
+});
+
+describe('CostsView — incomplete data', () => {
+  it('warns that totals are incomplete when lines failed to parse', () => {
+    render({ kind: 'ok', summary: summary({ malformed_lines: 3 }) });
+    expect(text()).toContain('3 lines of the usage log could not be parsed');
+    expect(text()).toContain('totals are incomplete');
+    // Still renders what it could read.
+    expect(text()).toContain('$3.80');
+  });
+
+  it('does not warn when every line parsed', () => {
+    render({ kind: 'ok', summary: summary() });
+    expect(text()).not.toContain('could not be parsed');
+  });
+});

--- a/crates/trusty-agents/ui/src/components/Header.svelte
+++ b/crates/trusty-agents/ui/src/components/Header.svelte
@@ -65,7 +65,8 @@
   // pane's own header — title + selector + gear all live together there
   // now); `ModelSwitcher` stays here since model/provider is a separate,
   // unrelated axis Bob's directive didn't touch.
-  export let activeView: 'chat' | 'events' = 'chat';
+  // #4098: 'costs' added for the Costs tab (COST-09).
+  export let activeView: 'chat' | 'events' | 'costs' = 'chat';
   export let apiReady = false;
 
   const desktop = isDesktop();
@@ -74,6 +75,8 @@
   const tabs: { id: typeof activeView; label: string }[] = [
     { id: 'chat', label: 'Chat' },
     { id: 'events', label: 'Events' },
+    // #4098: spend by agent/model/day, from GET /api/costs.
+    { id: 'costs', label: 'Cost' },
   ];
 
   function switchView(view: typeof activeView) {

--- a/crates/trusty-agents/ui/src/lib/costs.test.ts
+++ b/crates/trusty-agents/ui/src/lib/costs.test.ts
@@ -1,0 +1,143 @@
+// Costs API client + formatter tests (#4098, COST-09).
+//
+// Why: `fetchCosts` deliberately breaks the sibling clients' return-`[]`-on-
+// failure convention, because an empty dataset is indistinguishable from "$0
+// spent" — the one claim this tab must never make falsely. That divergence is
+// only worth anything if each failure keeps its identity, so these tests pin
+// the mapping from every backend answer to a `CostsState` variant.
+// What: `fetchCosts` against a stubbed `fetch`, plus the pure formatters.
+// Test: this file.
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { barPercent, fetchCosts, formatCount, formatUsd } from './costs';
+
+function stubFetch(status: number, body: unknown) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => body,
+    })),
+  );
+}
+
+const SUMMARY = {
+  available: true,
+  source: '/p/.trusty-agents/state/usage.jsonl',
+  records: 2,
+  malformed_lines: 0,
+  first_ts: '2026-07-27T10:00:00Z',
+  last_ts: '2026-07-28T10:00:00Z',
+  window_days: null,
+  totals: {
+    key: 'total',
+    input_tokens: 2_000_000,
+    output_tokens: 0,
+    cost_usd: 3.8,
+    dispatch_count: 2,
+    duration_ms: 20,
+  },
+  by_agent: [],
+  by_model: [],
+  by_date: [],
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('fetchCosts', () => {
+  it('maps a populated payload to ok', async () => {
+    stubFetch(200, SUMMARY);
+    const state = await fetchCosts();
+    expect(state.kind).toBe('ok');
+    if (state.kind === 'ok') expect(state.summary.totals.cost_usd).toBe(3.8);
+  });
+
+  it('maps available:false to no-data, never to an empty ok', async () => {
+    stubFetch(200, {
+      available: false,
+      reason: 'no usage has been recorded for this project yet',
+      source: '/p/.trusty-agents/state/usage.jsonl',
+    });
+    const state = await fetchCosts();
+    expect(state.kind).toBe('no-data');
+    if (state.kind === 'no-data') {
+      expect(state.reason).toContain('no usage has been recorded');
+      expect(state.source).toContain('usage.jsonl');
+    }
+  });
+
+  it('maps a 500 to error carrying the server message', async () => {
+    stubFetch(500, { available: false, error: 'could not read usage log /p/usage.jsonl' });
+    const state = await fetchCosts();
+    expect(state.kind).toBe('error');
+    if (state.kind === 'error') expect(state.message).toContain('could not read usage log');
+  });
+
+  it('maps a thrown network error to error, not to empty data', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('connection refused');
+      }),
+    );
+    const state = await fetchCosts();
+    expect(state.kind).toBe('error');
+    if (state.kind === 'error') expect(state.message).toBe('connection refused');
+  });
+
+  it('sends ?days= only for a positive window', async () => {
+    stubFetch(200, SUMMARY);
+    await fetchCosts(7);
+    await fetchCosts(0);
+    await fetchCosts();
+    const urls = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls.map((c) => String(c[0]));
+    expect(urls[0]).toContain('?days=7');
+    expect(urls[1]).not.toContain('days=');
+    expect(urls[2]).not.toContain('days=');
+  });
+});
+
+describe('formatUsd', () => {
+  it('keeps sub-cent amounts visible instead of rounding them to $0.00', () => {
+    expect(formatUsd(0.0004)).toBe('$0.0004');
+    expect(formatUsd(0.009)).toBe('$0.0090');
+  });
+
+  it('uses two decimals at or above a cent', () => {
+    expect(formatUsd(0.01)).toBe('$0.01');
+    expect(formatUsd(3.8)).toBe('$3.80');
+    expect(formatUsd(1234.5)).toBe('$1234.50');
+  });
+
+  it('renders a non-finite cost as a dash rather than NaN', () => {
+    expect(formatUsd(Number.NaN)).toBe('—');
+    expect(formatUsd(Number.POSITIVE_INFINITY)).toBe('—');
+  });
+});
+
+describe('formatCount', () => {
+  it('compacts thousands and millions', () => {
+    expect(formatCount(999)).toBe('999');
+    expect(formatCount(1500)).toBe('1.5k');
+    expect(formatCount(2_400_000)).toBe('2.4M');
+  });
+});
+
+describe('barPercent', () => {
+  it('scales relative to the largest row', () => {
+    expect(barPercent(5, 10)).toBe(50);
+    expect(barPercent(10, 10)).toBe(100);
+  });
+
+  it('returns 0 rather than NaN for an all-zero breakdown', () => {
+    expect(barPercent(0, 0)).toBe(0);
+    expect(barPercent(1, Number.NaN)).toBe(0);
+  });
+
+  it('clamps out-of-range values', () => {
+    expect(barPercent(20, 10)).toBe(100);
+    expect(barPercent(-5, 10)).toBe(0);
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/costs.ts
+++ b/crates/trusty-agents/ui/src/lib/costs.ts
@@ -1,0 +1,136 @@
+// Costs tab API client + pure presentation helpers (#4098, COST-09).
+//
+// Why: `CostsView.svelte` must distinguish four backend states — costs,
+// nothing recorded, nothing dispatched, and a fault — and it must never render
+// a confident `$0.00` over a missing usage log. Keeping the fetch + the state
+// discrimination here (rather than inline in the component) makes both
+// unit-testable without mounting Svelte, and keeps the component to rendering.
+//
+// Note the deliberate deviation from the sibling clients (`workstreams.ts`,
+// `agentConfig.ts`): those swallow failures and return `[]`, which is right for
+// a convenience sidebar. It is WRONG here. An empty array is
+// indistinguishable from "$0 spent", which is the single claim this tab must
+// never make falsely, so `fetchCosts` returns a discriminated result and lets
+// the view say which failure it hit.
+//
+// What: `CostRow`/`CostSummary` mirror `usage::aggregate`'s serialized shape;
+// `fetchCosts` wraps `GET /api/costs`; `formatUsd`/`formatCount`/`barPercent`
+// are pure formatters the view and its tests share.
+// Test: `costs.test.ts`.
+
+import { apiBase } from './api-config';
+import { getCurrentApiToken } from '../stores/app';
+
+/** One aggregate bucket. `key` is an agent name, model id, or `YYYY-MM-DD`. */
+export interface CostRow {
+  key: string;
+  input_tokens: number;
+  output_tokens: number;
+  cost_usd: number;
+  dispatch_count: number;
+  duration_ms: number;
+}
+
+/** The `GET /api/costs` payload. Mirrors `usage::aggregate::CostSummary`. */
+export interface CostSummary {
+  available: boolean;
+  source: string;
+  records: number;
+  malformed_lines: number;
+  first_ts: string | null;
+  last_ts: string | null;
+  window_days: number | null;
+  totals: CostRow;
+  by_agent: CostRow[];
+  by_model: CostRow[];
+  by_date: CostRow[];
+  /** Present only when `available` is false — why there is nothing to show. */
+  reason?: string;
+}
+
+/**
+ * The four states the view renders, kept as a discriminated union so no branch
+ * can be silently skipped:
+ *  - `ok`        — real aggregated costs (possibly zero rows, but a real log).
+ *  - `no-data`   — no usage log exists yet. NOT `$0.00`.
+ *  - `error`     — the log exists and could not be read, or the request failed.
+ */
+export type CostsState =
+  | { kind: 'ok'; summary: CostSummary }
+  | { kind: 'no-data'; reason: string; source: string }
+  | { kind: 'error'; message: string };
+
+function authHeaders(): Record<string, string> {
+  const token = getCurrentApiToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+/**
+ * `GET /api/costs`, mapped to a [`CostsState`].
+ *
+ * Why: See the module note — this deliberately does NOT degrade a failure into
+ * an empty dataset. A cost figure the operator cannot trust is worse than no
+ * figure, so every non-success path keeps its identity all the way to the view.
+ * What: Issues the request with the optional `?days=` window, maps a non-OK
+ * status or a thrown network error to `error`, and an `available: false` body
+ * to `no-data` carrying the server's own reason string.
+ * Test: `fetchCosts` cases in `costs.test.ts`.
+ */
+export async function fetchCosts(days?: number): Promise<CostsState> {
+  const query = days && days > 0 ? `?days=${days}` : '';
+  try {
+    const r = await fetch(`${apiBase()}/api/costs${query}`, { headers: authHeaders() });
+    const body = (await r.json().catch(() => null)) as (CostSummary & { error?: string }) | null;
+    if (!r.ok) {
+      return { kind: 'error', message: body?.error ?? `GET /api/costs failed: ${r.status}` };
+    }
+    if (!body) return { kind: 'error', message: 'GET /api/costs returned an unreadable body' };
+    if (body.available === false) {
+      return {
+        kind: 'no-data',
+        reason: body.reason ?? 'no usage has been recorded for this project yet',
+        source: body.source ?? '',
+      };
+    }
+    return { kind: 'ok', summary: body };
+  } catch (e) {
+    return { kind: 'error', message: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/**
+ * Format a USD amount at a precision that does not imply false certainty.
+ *
+ * Why: Sub-cent dispatch costs round to `$0.00` at two decimals, which reads as
+ * "free" for a column of real spend. The statusline already solved this the
+ * same way (`repl::tui::status::format_cost_value`), so the two surfaces agree.
+ * What: 4 decimals below $0.01, 2 decimals at or above.
+ * Test: `formatUsd` cases in `costs.test.ts`.
+ */
+export function formatUsd(cost: number): string {
+  if (!Number.isFinite(cost)) return '—';
+  return cost < 0.01 ? `$${cost.toFixed(4)}` : `$${cost.toFixed(2)}`;
+}
+
+/** Compact integer with a `k`/`M` suffix — token counts get long fast. */
+export function formatCount(n: number): string {
+  if (!Number.isFinite(n)) return '—';
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return `${n}`;
+}
+
+/**
+ * Bar width as a percentage of the largest row in the same breakdown.
+ *
+ * Why: The bars are relative magnitude, not absolute scale, so the chart stays
+ * readable whether the day's spend is cents or hundreds of dollars.
+ * What: `cost / max * 100`, clamped to [0, 100]; `0` when `max` is not a
+ * positive finite number (an all-zero breakdown draws no bars rather than
+ * dividing by zero into `NaN%`).
+ * Test: `barPercent` cases in `costs.test.ts`.
+ */
+export function barPercent(cost: number, max: number): number {
+  if (!Number.isFinite(cost) || !Number.isFinite(max) || max <= 0) return 0;
+  return Math.max(0, Math.min(100, (cost / max) * 100));
+}


### PR DESCRIPTION
Builds the Costs vertical slice for epic #4098 — pricing consolidation, read-time aggregation, `GET /api/costs`, and the `Cost` tab. 23 files, two commits.

Rebased onto `6ef47ecb`. **This does not close #4098** — it implements three of the epic's ten leaves, two of them partially.

## What is here

| Leaf | Title | Status |
|---|---|---|
| COST-05 (#4103) | Consolidate pricing to a single source of truth | ✅ **Complete** |
| COST-08 (#4107) | `GET /api/costs` | 🟡 **Partial** — endpoint ships; `range=`/`group_by=` deliberately absent |
| COST-09 (#4108) | `CostsView.svelte` + tab wiring | 🟡 **Partial** — pane, controls, table and bars ship; stacked bars and workstream grouping do not |
| COST-01 (#4099) | `ChatEvent::Usage` on streaming dispatch | ❌ Not done |
| COST-02 (#4100) | Thread explicit agent name (vs. process-global env var) | ❌ Not done |
| COST-03 (#4101) | `UsageRecord` carries `session_id` + cache tokens | ❌ Not done |
| COST-04 (#4102) | Workstream attribution via `ws:<label>` tags | ❌ Not done |
| COST-06 (#4104) | SQLite/redb usage store + daily rollup | ❌ **Not done — deliberately, see below** |
| COST-07 (#4105) | Weekly/monthly rollup | ❌ Not done (depends on #4104) |
| COST-10 (#4109) | `claude_code_runner` cache-token parity | ❌ Not done (its fix rolls into #4101) |

**#4106 is NOT a COST leaf** despite sitting inside the #4099–#4109 range — it is an unrelated `trusty-embedderd-py` release bug. The ten leaves are #4099–#4105 and #4107–#4109.

### Consequences of what is missing, stated plainly

- **Costs OVER-ESTIMATE cache-heavy workloads.** #4101 has not landed, so `UsageRecord` carries no cache-token buckets and every cached turn is priced as uncached. The pane says this on screen. The aggregator already passes `0` into the cache arguments at one call site, so #4101 lands as a one-line change here.
- **No workstream breakdown.** #4102 has not landed, so there is no workstream axis to group by. The pane offers agent / model / day only.
- **Agent attribution is only as good as `UsageRecord.agent`.** #4100's process-global-env-var bug is untouched, so under multi-persona concurrency the by-agent breakdown can misattribute. Not introduced here, not fixed here.

## Pricing consolidation (COST-05) — this was a live bug on `main`

`usage/daily.rs` carried a **second, hardcoded Haiku-only rate table** (`PROMPT_RATE`/`COMPLETION_RATE`, `$0.25`/`$1.25` per million) applied to every model regardless of which model ran. Both the REPL statusline and the persisted `usage.json` daily total went through it, so a **Sonnet session — the default — displayed roughly 1/12 of its true cost.**

The table is **deleted, not corrected.** A second rate table is a defect whatever numbers are in it, because nothing keeps it in step with the first. `perf::pricing::cost_usd` is now the single entry point for the statusline, the daily total, the perf collector, and the Costs surfaces. Its token counts widened `u32` → `u64` (two `.into()` at the `TokenUsage` seam) so aggregate callers cannot saturate a total.

`cost_from_tokens_matches_pricing_entry_point` asserts the two former call sites now produce an identical number across three models; `format_cost_chunk_is_model_aware` and `cost_from_tokens_prices_sonnet_above_haiku` pin the property the bug violated.

## Aggregation strategy: read-time, not a rollup store

**Decision: read-time fold over `usage.jsonl`. No persistent rollup store.**

- The epic's *"Done when"* is a trustworthiness bar — *"every displayed amount traces to valid raw rows and one pricing table"*. Folding raw rows on demand satisfies that **by construction**. A rollup satisfies it only for as long as its refresh job stays correct, and adds a standing obligation to keep derived totals reconcilable with `usage_raw` across crashes and concurrent writers.
- One code path: no schema, no migration, no second writer, no scheduled job. The whole failure surface is "the file is missing or a line does not parse", and both are reported rather than smoothed over.

**This conflicts with COST-06 (#4104), which explicitly specifies SQLite tables and a scheduled rollup.** Flagging rather than silently substituting: **#4104's acceptance criteria are not met and it stays open.** When durable rollups are built, `usage::aggregate::aggregate_usage` is the reference the rollup must reproduce.

**The volume ceiling, stated so it is falsifiable:** a record line is ~200 bytes and the whole file is read and parsed per request. At ~10k dispatches (~2 MB) a fold is single-digit milliseconds; at ~1M (~200 MB) it is hundreds of milliseconds with the file resident. **Past roughly 100k records — or once the tab polls rather than loading on demand — read-time stops being adequate and #4104 becomes the right shape.** The payload reports `records` so that threshold is observable rather than guessed at.

## The fold runs on `spawn_blocking`, not the reactor

Second commit, from adversarial review. `get_costs` was an `async fn` calling the synchronous `costs_at` inline, so `aggregate_usage`'s whole-file `read_to_string` plus per-line `serde_json::from_str` loop ran **on a tokio worker thread** — stalling the executor for every other route on the daemon, not just this request.

That made the **executor**, not the fold's own cost, the first constraint to bite: the ~100k-row ceiling above assumes the work is off the reactor, and without the wrapper it would have arrived far sooner under any real concurrency. Now wrapped in `tokio::task::spawn_blocking`, matching the crate's existing convention for blocking filesystem work (`interaction_log`, `session_record`, `system_status::registry_counts`).

A `JoinError` — a panic or cancellation inside the fold — maps to a **500**, not an `unwrap()`: a panic must not take the daemon down, and it is a real fault, so it is **not** degraded into the "no data" answer a project without a log gets. `costs_at` stays synchronous and remains the testable core, so the state tests are unchanged; `costs_route_answers_through_the_blocking_pool` covers the new join seam on a multi-thread runtime, asserting the handler round-trips the documented envelope and that `?days=` survives the trip to the pool. `usage::aggregate`'s volume note now also records where this function must not run — it previously quantified the fold's cost without saying that.

## Empty and error states

A Costs view that renders a confident `$0.00` over a missing data file is worse than one that says it has no data. Four states, each kept distinct end to end (aggregator → endpoint → pane):

| Situation | Endpoint | Pane |
|---|---|---|
| No `usage.jsonl` at all | `200`, `available: false`, `reason`, `source` | "No usage has been recorded… **This is not $0.00**", names the file. No table, no total. |
| Log exists, zero rows | `200`, `available: true`, `records: 0` | "No cost data for this period. The usage log exists but holds no dispatches…" |
| Log exists, some lines unparseable | `200`, aggregated without them, `malformed_lines: N` | Amber warning: "N lines… could not be parsed… these totals are incomplete", plus the partial data |
| Log exists, cannot be read | `500`, `{ available: false, error }` | "Could not read cost data: &lt;server message&gt;". No table. |
| Aggregation task panicked | `500`, `{ available: false, error }` | Same error state — not "no data" |
| Request in flight | — | Explicit loading state, never an empty chart |

Supporting choices:
- `lib/costs.ts` deliberately **breaks** the sibling clients' (`workstreams.ts`, `agentConfig.ts`) return-`[]`-on-failure convention. An empty array is indistinguishable from "$0 spent" — the one claim this tab must never make falsely — so it returns a discriminated union instead.
- Rows missing `ts`/`agent`/`model` **fail** to parse (counted as malformed) rather than defaulting into a plausible-looking zero-cost bucket. Every other field defaults, so rows from an older binary still count.
- An empty `agent` renders as `(unattributed)`, per the epic's "missing attribution is explicit".
- Non-finite computed costs are rejected as malformed. Unreachable today (integer tokens × finite rates), enforced anyway because an unchecked `+=` of a NaN poisons every bucket irrecoverably.

## API shape and its two deviations from COST-08

`GET /api/costs?days=<n>` returns ONE object: `available`, `source`, `records`, `malformed_lines`, `first_ts`, `last_ts`, `window_days`, `totals`, and `by_agent` / `by_model` / `by_date` (each an array of `{key, input_tokens, output_tokens, cost_usd, dispatch_count, duration_ms}`).

- **`range=day|week|month` not implemented** — week/month rollups are COST-07 and there is nothing to query. `?days=<n>` narrows the window instead, anchored on the **newest recorded row** rather than wall-clock now (a log that stopped last week should still render its final days, not an empty chart). `by_date` gives daily granularity.
- **`group_by=` not implemented** — all three breakdowns ship in one payload so the tab switches grouping without a refetch, and so the three can never disagree: they are folds of one pass over one set of rows.

A parameter that silently ignores its value is worse than one that isn't there.

## ⚠️ Dangling spec reference — needs a separate fix

The epic and every leaf cite **DOC-59 §2–§6 (SPEC-COST-01…05)** as their spec. **That reference is dangling.** `docs/specs/DOC-59-*` on `main` is the PM instruction-pipeline restructure doc, entirely unrelated to costs, and no costs spec exists anywhere in `docs/specs/` or `docs/adr/`. No costs spec was invented to fill the gap — **this was built against the epic body and the leaf-ticket acceptance criteria only.** The citation should be corrected or the spec written, separately from this PR.

## Two judgement calls for a reviewer

- **The tab label is `Cost`, singular**, as specified in the build request. Flagging it because `Chat` / `Events` / `Costs` might read better; it is a one-word change in `Header.svelte` plus the CHANGELOG line.
- **No charting dependency was added.** COST-09 says "reuse existing (likely Recharts)" — that is mistaken: `ui/package.json` has no charting library at all (only `lucide-svelte` for icons), and this is a Svelte app, not React. Relative horizontal bars are one `<div>` and a width percentage. **Stacked bars — COST-09's literal ask — are therefore NOT implemented.**

## Rebase note

`Header.svelte` was edited concurrently by another agent to add a build-version line; that work landed on `main` as **#4292** while this branch was in flight, and this branch is rebased on top of it. The header carries **both** the build-provenance line and the new tab — the `activeView` unions in `Header.svelte` and `App.svelte` are identical and there is no duplicated logic or half-applied rename. Also rebased past #4296 and #4291.

## Test coverage added

- **Aggregation** — totals reconcile against all three breakdowns; per-row pricing (Sonnet ≠ Haiku in one file); missing log → `NotRecorded`; empty file and blank-lines-only → zero rows, no error; four flavours of malformed line counted not swallowed; rows missing optional fields still count; `(unattributed)` labelling; UTC date grouping across a timezone boundary; window filtering and its newest-row anchor; sort order; and an end-to-end check that the aggregator reads exactly what `append_usage` writes.
- **Pricing consolidation** — both former call sites agree with the entry point across three models; Sonnet costs more than Haiku; `u64` counts beyond `u32::MAX`.
- **Endpoint** — route wired; the async handler round-trips through the blocking pool with `?days=` intact; full payload shape; all four states distinguished; `?days=` narrowing including `days=0`; a directory-where-the-file-should-be forced into the `500` path.
- **UI** — `fetchCosts` mapping for ok / no-data / 500 / thrown-network / query building; formatter edge cases including non-finite; and pane rendering for every state, with an explicit assertion that the no-data state renders **no** dollar figure and no table.

## Gate output (raw, on `116659c9`)

```
$ cargo fmt --check
(no output — clean)

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
(no errors)

$ cargo test -p trusty-agents --no-fail-fast
     Running unittests src/lib.rs
test result: FAILED. 2955 passed; 1 failed; 11 ignored; 0 measured; 0 filtered out; finished in 34.41s
     Running unittests src/main.rs
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
     Running tests/api_e2e.rs
test result: ok. 4 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 4.62s
     Running tests/cli_project.rs
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.55s
     Running tests/config_mount.rs
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
     Running tests/inference_shared_adapter_e2e.rs
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.18s
     Running tests/plain_cli_repl.rs
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.52s
     Running tests/system_status_cli.rs
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.67s

$ cargo test -p trusty-agents --lib costs
test api::server::tests::costs::costs_reports_no_data_for_missing_log ... ok
test api::server::tests::costs::costs_distinguishes_empty_log_from_missing_log ... ok
test api::server::tests::costs::costs_surfaces_malformed_line_count ... ok
test api::server::tests::costs::costs_reports_an_unreadable_log_as_a_server_error ... ok
test api::server::tests::costs::costs_returns_totals_and_breakdowns ... ok
test api::server::tests::costs::costs_route_is_wired_into_router ... ok
test api::server::tests::costs::costs_route_answers_through_the_blocking_pool ... ok
test api::server::tests::costs::costs_window_narrows_the_report ... ok
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 2951 filtered out

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 50 spec doc(s) + 2944 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_doc_numbers.sh
doc-numbers: 4 grandfathered, 0 violations — OK.

$ pnpm run test:unit
 Test Files  26 passed (26)
      Tests  291 passed (291)

$ pnpm run check   (svelte-check)
COMPLETED 1741 FILES 0 ERRORS 2 WARNINGS 1 FILES_WITH_PROBLEMS
   (both warnings pre-existing in ProjectsView.svelte, untouched by this PR)

$ pnpm run check:tokens
All enforced crates match the canonical token source.

$ pnpm build
✓ 1704 modules transformed.
✓ built in 3.08s
```

**On the one local `--lib` failure:** `tools::python_skill::tests::execute_dispatches_to_python_and_parses_json` is a pre-existing local environment flake — a stale `.venv`/uv cache under this worktree (`ModuleNotFoundError: No module named 'python'`). It **passes in isolation** on the same tree (`cargo test -p trusty-agents --lib python_skill` → `8 passed; 0 failed`) and fails only under full-suite parallelism. **This branch touches no python or skill file** — `git diff --name-only origin/main | grep -iE 'python|skill'` returns nothing. CI runs on a clean checkout; see the checks on this PR for the authoritative result.

The four `api_e2e` tests also fail on a cold run against their 5s health-check budget while the debug binary is still linking, and pass warm (shown above). Not related to this change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
