### PR TITLE
docs(trusty-agents): Sub-agents pane copy states the EFFECTIVE delegation rule

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **The Sub-agents pane no longer advertises delegation targets the gate
+  refuses.** Its copy said targets were *"fixed by the role allow-list
+  (engineer, qa, researcher, documentation, ops, planner, assistant)"* — true
+  of the constant, misleading as presented: `assistant` is in that list, but
+  ADR-0024's delegation KIND rule independently refuses every assistant →
+  assistant edge, so a reader took the list as a promise of reachability the
+  code denies. The pane now states the EFFECTIVE rule — role-eligible MINUS
+  kind-refused — quoting the allow-list as an eligibility filter, then saying
+  plainly that eligibility is not reachability and that a peer assistant is
+  never a delegation target (assistants communicate with each other rather
+  than delegating to one another). The refusal is attributed to the KIND rule
+  rather than the tier gate, which is what post-#4296 is actually true: with
+  assistants at L0 both endpoints of that edge are L0, so tier is vacuous for
+  it. Copy-only — no gate, payload or reachability logic changed, and
+  `ASSISTANT_ALLOWED_DELEGATE_ROLES` deliberately still carries `assistant`
+  (its doc comment records why the entry is kept: the constant also feeds the
+  `/subagents` route's `allowed_roles` report, and the kind rule must be
+  enforced by code, not by a curated list of names). The stale doc comments
+  that described the rule as "role allowlist + tier gate" were corrected to
+  name the kind rule too.
+
 ### Changed
 
 - **Assistants are tier L0 (ADR-0024 decision 3).** An agent whose `[agent].role`

--- a/crates/trusty-agents/src/api/server/agent_subagents.rs
+++ b/crates/trusty-agents/src/api/server/agent_subagents.rs
@@ -17,9 +17,12 @@
 //!   target set is NOT per-agent config at all: it is the hardcoded
 //!   `runtime::tool_registry::ASSISTANT_ALLOWED_DELEGATE_ROLES` role allowlist
 //!   applied to whatever resolves out of `agents::agents_dir_candidates()`,
-//!   further narrowed by #4169's one-directional L0/L1 tier gate. The role
-//!   `documentation` exists ONLY here — it is in no other allow-set in the
-//!   codebase.
+//!   further narrowed by ADR-0024's delegation KIND rule
+//!   (`agents::delegation::kind_refuses_delegation` — assistant → assistant is
+//!   refused) and by #4169's one-directional L0/L1 tier gate. Role
+//!   eligibility is therefore NOT reachability, and `allowed_roles` below is
+//!   the coarse pre-kind-gate list, not the answer. The role `documentation`
+//!   exists ONLY here — it is in no other allow-set in the codebase.
 //! - **`cross_product`** — `dispatch_task` (`crate::tools::pm_bridge`),
 //!   trusty-agents → trusty-code, out-of-process specialist dispatch. This one
 //!   DOES have a per-agent TOML binding: the optional `[subagents]` section
@@ -36,8 +39,15 @@
 //!   cross-product half (so the pane can never disagree with the bridge — the
 //!   OQ-7 requirement stated in #4029), and, for the in-product half, the same
 //!   `AgentConfig::by_name_in` resolution + `ASSISTANT_ALLOWED_DELEGATE_ROLES`
-//!   membership + `AgentInfo::tier()` comparison that
-//!   `DelegateToAgentTool::execute`'s pre-flight check performs, in that order.
+//!   membership + `agents::delegation::kind_refuses_delegation` call +
+//!   `AgentInfo::tier()` comparison that `DelegateToAgentTool::execute`'s
+//!   pre-flight check performs, in that order.
+//! - **The prose must be predictive, not just the cards.** Any user-visible
+//!   copy describing this mechanism states the EFFECTIVE rule — role-eligible
+//!   MINUS kind-refused — and names peer assistants as refused. Quoting
+//!   `allowed_roles` as "the targets" is the specific defect this rule
+//!   forbids: the array is true of the constant but advertises reachability
+//!   the kind gate denies, so a reader could not predict the pane's own cards.
 //! - **The tier gate is reflected, not re-litigated (#4169, epic #4167).** A
 //!   target that resolves to `AgentTier::L0Orchestration` is reported
 //!   `reachable: false` for any delegator that is not itself L0. This route
@@ -209,19 +219,31 @@ pub(super) async fn subagents_at(
 }
 
 /// The `in_product` half: `delegate_to_agent`'s reachable target set for this
-/// agent, reflecting BOTH the role allowlist and #4169's tier gate.
+/// agent, reflecting the role allowlist, ADR-0024's delegation KIND rule, and
+/// #4169's tier gate.
 ///
 /// Why: this mechanism has no per-agent config to read, so the only honest
 /// source is the gate's own inputs. Every candidate is resolved with
 /// `AgentConfig::by_name_in` — the identical call
 /// `DelegateToAgentTool::execute` makes — and then subjected to the identical
-/// two checks in the identical order: `ASSISTANT_ALLOWED_DELEGATE_ROLES`
-/// membership on the target's resolved `role`, and the tier comparison
+/// checks in the identical order: `ASSISTANT_ALLOWED_DELEGATE_ROLES`
+/// membership on the target's resolved `role`, the kind predicate
+/// (`agents::delegation::kind_refuses_delegation`, called rather than
+/// re-derived), and the tier comparison
 /// (`target == L0Orchestration && delegator != L0Orchestration` ⇒ refused).
 /// A candidate that fails to resolve is reported as such rather than dropped,
 /// because the gate refuses those too (`Err` ⇒ `rejected`) and a target that
 /// silently vanished from the pane looks identical to one that was never
 /// declared.
+///
+/// The reported `allowed_roles` reflects only the FIRST of those checks — it
+/// still lists `assistant`, which the kind rule then refuses for an assistant
+/// delegator. That coarseness is intentional (the array is
+/// `ASSISTANT_ALLOWED_DELEGATE_ROLES` verbatim, and this report is one of the
+/// non-delegation consumers that constant's doc cites for keeping the entry),
+/// so any pane rendering it must describe the effective rule rather than
+/// present it as the reachable set. `targets[].reachable` is the only field
+/// that carries every gate.
 ///
 /// The ONE candidate that IS dropped rather than reported is a `hidden` one
 /// (#4235). That is deliberate and is the exception the paragraph above does

--- a/crates/trusty-agents/ui/src/components/AgentConfigSubagents.svelte
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSubagents.svelte
@@ -8,8 +8,10 @@
    *
    * The two are not variants of one thing and this pane never merges them:
    * `delegate_to_agent` is in-product (trusty-agents → trusty-agents), its
-   * target set a HARDCODED role allowlist crossed with the resolvable roster
-   * and narrowed by #4169's L0/L1 tier gate — no per-agent config at all;
+   * target set a HARDCODED role allowlist crossed with the resolvable roster,
+   * then narrowed by ADR-0024's delegation KIND rule (an assistant never
+   * delegates to a peer assistant) and by #4169's L0/L1 tier gate — no
+   * per-agent config at all;
    * `dispatch_task` is cross-product (trusty-agents → trusty-code), the one
    * with a real `[subagents].allowed` binding, intersected fail-closed with
    * the bridge's own `NON_CODING_TARGETS` floor (OQ-7). Their target
@@ -29,6 +31,15 @@
    * assistant reach that one" is answerable; and an unresolvable config renders
    * the denial plus the parse error, never a blank pane implying "nothing
    * configured".
+   *
+   * That honesty extends to the PROSE, not only the cards. `allowed_roles` is
+   * the coarse, PRE-kind-gate role list: it still carries `assistant`, kept
+   * deliberately — the Rust constant `ASSISTANT_ALLOWED_DELEGATE_ROLES` names
+   * this route's report as one of the non-delegation consumers holding that
+   * entry there — so quoting it as "the targets" advertised a reachability the
+   * kind gate denies. The copy below therefore states the EFFECTIVE rule
+   * (role-eligible MINUS kind-refused) and names peer assistants as refused,
+   * so a reader can predict the cards the pane draws.
    *
    * DOC-57 still documents five sections; #4182 amends it. This pane cites the
    * decision, it does not restate the spec.
@@ -71,8 +82,9 @@
     enforcement layers — they are shown separately because a name reachable through one is not
     reachable through the other. Read-only; edit
     <code class="font-mono">[subagents]</code> in <code class="font-mono">agent.toml</code>. The
-    in-product target set is not configurable at all — it is a fixed role allow-list plus the
-    L0/L1 delegation gate.
+    in-product target set is not configurable at all — it is a fixed role allow-list, minus every
+    peer assistant (assistants do not delegate to one another), minus whatever the L0/L1 gate
+    blocks.
   </p>
 
   {#if error}
@@ -102,10 +114,15 @@
         </span>
       </div>
       <p class="text-[11px] text-foundry-light-muted dark:text-foundry-text/50">
-        Another trusty-agents agent, run in-process. Targets are fixed by the role allow-list
-        <span class="font-mono">({(inProduct?.allowed_roles ?? []).join(', ')})</span> — not by this
-        agent's configuration — and further narrowed by the one-directional L0/L1 delegation gate.
-        This agent's own tier is <code class="font-mono">{inProduct?.delegator_tier ?? 'l1'}</code>.
+        Another trusty-agents agent, run in-process. This agent's configuration does not choose the
+        targets. A target's role must first appear in the role allow-list
+        <span class="font-mono">({(inProduct?.allowed_roles ?? []).join(', ')})</span>, but
+        eligibility is not reachability: the delegation kind rule then refuses every
+        <span class="font-mono">assistant</span> target — assistants communicate with each other
+        rather than delegating to one another (ADR-0024) — so what an assistant can actually
+        delegate to is the SUB-AGENT roles in that list, never a peer assistant. The
+        one-directional L0/L1 tier gate narrows it further. This agent's own tier is
+        <code class="font-mono">{inProduct?.delegator_tier ?? 'l1'}</code>.
       </p>
 
       {#if !inProduct?.tool_registered}

--- a/crates/trusty-agents/ui/src/components/AgentConfigSubagents.test.ts
+++ b/crates/trusty-agents/ui/src/components/AgentConfigSubagents.test.ts
@@ -75,6 +75,14 @@ function payload(over: Partial<AgentSubagents> = {}): AgentSubagents {
   };
 }
 
+/**
+ * The pane's rendered prose with runs of whitespace collapsed. Svelte emits the
+ * template's own line breaks and indentation into `textContent`, so asserting a
+ * sentence that wraps in the source would fail on formatting alone — a copy
+ * assertion must survive a re-wrap.
+ */
+const copy = () => (target.textContent ?? '').replace(/\s+/g, ' ');
+
 /** Every element whose own label is exactly the `reachable` badge. */
 const reachableBadges = () =>
   Array.from(target.querySelectorAll('span')).filter(
@@ -118,6 +126,30 @@ describe('AgentConfigSubagents — the two mechanisms', () => {
     // The allow-list is quoted verbatim so the operator can see the rule —
     // including `documentation`, the role that exists in NO other allow-set.
     expect(target.textContent).toContain('documentation');
+  });
+
+  // The copy defect these two pin shut: `allowed_roles` carries `assistant`
+  // (deliberately — `ASSISTANT_ALLOWED_DELEGATE_ROLES`'s Rust doc explains why
+  // the entry stays, and this route's report is one of the consumers holding
+  // it there), yet ADR-0024's delegation KIND rule refuses every assistant →
+  // assistant edge. Copy that quoted the array as "the targets" was true of
+  // the constant and MISLEADING as presented: it advertised a reachability the
+  // code denies, so a reader could not predict the pane's own cards.
+  it('describes the EFFECTIVE rule, naming peer assistants as refused', () => {
+    render(payload());
+    // Eligibility and reachability must read as different things …
+    expect(copy()).toContain('eligibility is not reachability');
+    // … and the refusal is attributed to the KIND rule, not the tier gate:
+    // post-#4296 both endpoints of an assistant edge are L0, so tier is
+    // vacuous for it and only the kind rule still refuses it.
+    expect(copy()).toContain('the delegation kind rule');
+    expect(copy()).toContain('never a peer assistant');
+    expect(copy()).toContain('ADR-0024');
+  });
+
+  it('never presents the allow-list as the set of reachable targets', () => {
+    render(payload());
+    expect(copy()).not.toContain('Targets are fixed by the role allow-list');
   });
 
   it('renders a reachable in-product target with its role and tier', () => {

--- a/crates/trusty-agents/ui/src/lib/agentConfig.ts
+++ b/crates/trusty-agents/ui/src/lib/agentConfig.ts
@@ -475,11 +475,13 @@ export async function fetchAgentSkills(name: string): Promise<AgentSkills | null
  * (#4029) — a trusty-agents agent this agent may hand a task to via
  * `delegate_to_agent`.
  *
- * `reachable` already accounts for #4169's one-directional L0/L1 tier gate, so a
- * pane must render `reachable === false` as DENIED with its `reason` and must
- * never present the card as callable. The server refuses to list targets the
- * gate would refuse; a card that arrives unreachable is one the operator needs
- * an explanation for, not one to hide.
+ * `reachable` already accounts for BOTH refusals the server applies —
+ * ADR-0024's delegation KIND rule (assistant → assistant is refused, read from
+ * roles, not tiers) and #4169's one-directional L0/L1 tier gate — so a pane
+ * must render `reachable === false` as DENIED with its `reason` and must never
+ * present the card as callable. The server refuses to list targets the gate
+ * would refuse; a card that arrives unreachable is one the operator needs an
+ * explanation for, not one to hide.
  */
 export interface SubagentInProductTarget {
   name: string;
@@ -508,7 +510,16 @@ export interface SubagentInProduct {
   tool_granted: boolean;
   /** THIS agent's own resolved tier — the left-hand side of the gate. */
   delegator_tier: string;
-  /** `ASSISTANT_ALLOWED_DELEGATE_ROLES`, verbatim, so the pane can state the rule. */
+  /**
+   * `ASSISTANT_ALLOWED_DELEGATE_ROLES`, verbatim — the COARSE, pre-kind-gate
+   * role eligibility filter, NOT the reachable set. It still contains
+   * `assistant` (deliberately kept in the Rust constant, whose doc explains
+   * why this report is one of the consumers holding it there), yet the kind
+   * rule refuses every assistant→assistant edge. A pane must therefore not
+   * present this array as "the targets": state the effective rule
+   * (role-eligible MINUS kind-refused) and read reachability off
+   * `targets[].reachable`, which is the only field that carries both gates.
+   */
   allowed_roles: string[];
   targets: SubagentInProductTarget[];
   /** Roster entries excluded by the role allowlist — counted, never named. */
@@ -564,8 +575,9 @@ export interface AgentSubagents {
  * HTTP — `parse_agent_toml` enumerates twelve fields and `subagents` is not one
  * of them — so the Sub-agents pane needs its own route rather than a derivation
  * from `AgentDetail`. Critically, the in-product target set is not config at
- * all: it is a hardcoded role allowlist crossed with the resolvable roster and
- * narrowed by #4169's tier gate, none of which a client can compute.
+ * all: it is a hardcoded role allowlist crossed with the resolvable roster,
+ * then narrowed by ADR-0024's delegation kind rule and #4169's tier gate, none
+ * of which a client can compute.
  * What: `null` on 404 (unknown agent) so a stale roster selection is a normal
  * outcome, not a thrown error — same contract as `fetchAgentSkills`.
  * Test: `fetchAgentSubagents_returns_null_on_404`.


### PR DESCRIPTION
## What

**Copy-only.** No gate, no payload field, no reachability logic changed. The Sub-agents pane's explanatory prose now describes the *effective* delegation rule — role-eligible MINUS kind-refused — instead of quoting a role list that promises reachability the code denies.

## The defect

The pane said delegation targets are *"fixed by the role allow-list (engineer, qa, researcher, documentation, ops, planner, **assistant**)"*. That is a true statement about `ASSISTANT_ALLOWED_DELEGATE_ROLES`, and misleading as presented: ADR-0024's delegation KIND rule (`agents::delegation::kind_refuses_delegation`) independently refuses **every** assistant → assistant edge. A user read `assistant` off that list and reasonably expected to be able to delegate to an assistant. They cannot. The pane's own cards then showed those targets under *"Refused by the delegation gate"* — contradicting the paragraph directly above them.

### Old wording

> Another trusty-agents agent, run in-process. Targets are fixed by the role allow-list
> `(engineer, qa, researcher, documentation, ops, planner, assistant)` — not by this agent's
> configuration — and further narrowed by the one-directional L0/L1 delegation gate. This agent's
> own tier is `l0`.

and, in the section intro:

> The in-product target set is not configurable at all — it is a fixed role allow-list plus the
> L0/L1 delegation gate.

### New wording

> Another trusty-agents agent, run in-process. This agent's configuration does not choose the
> targets. A target's role must first appear in the role allow-list
> `(engineer, qa, researcher, documentation, ops, planner, assistant)`, but **eligibility is not
> reachability**: the delegation kind rule then refuses every `assistant` target — assistants
> communicate with each other rather than delegating to one another (ADR-0024) — so what an
> assistant can actually delegate to is the SUB-AGENT roles in that list, never a peer assistant.
> The one-directional L0/L1 tier gate narrows it further. This agent's own tier is `l0`.

and, in the section intro:

> The in-product target set is not configurable at all — it is a fixed role allow-list, minus every
> peer assistant (assistants do not delegate to one another), minus whatever the L0/L1 gate blocks.

A reader can now predict the cards the pane draws.

### Why the refusal is attributed to KIND, not TIER

Deliberate, and it is what became true with #4296 (ADR-0024 decision 3, the direct predecessor of this PR). Now that assistants are tier L0, **both** endpoints of an assistant→assistant edge are L0, so the tier gate is vacuous for that edge. The refusal that still fires is the KIND gate, which reads roles, not tiers. Copy that blamed the tier gate would have been wrong in a new way.

## Why the constant was deliberately NOT changed

The obvious-looking "fix" is to delete `ASSISTANT_TIER_ROLE` from `ASSISTANT_ALLOWED_DELEGATE_ROLES`. That is the wrong fix and this PR does not do it. `crates/trusty-agents/src/runtime/tool_registry.rs:129-136` records why the entry is kept, verbatim:

> ADR-0024 note: `ASSISTANT_TIER_ROLE` remains in this list, but an assistant-to-assistant EDGE is
> now refused by the kind predicate inside `DelegateToAgentTool::execute` (`crate::agents::delegation`)
> — the peer-consult lane this entry was added for is closed. The entry is kept because this list is
> also read by non-delegation consumers (the `/subagents` route's `allowed_roles` report), and because
> the kind rule must be enforced by CODE, not by which names happen to appear in a curated list.

Removing it would change **reported semantics** (`agent_subagents.rs:364` and `:478` serialize the constant straight into the wire payload), not just copy — and it would move the peer prohibition back into a curated name list, which is precisely the enforcement posture ADR-0024 rejects.

Two adjacent things reviewed and deliberately left alone:

- The per-target `reachable` field (`agent_subagents.rs:316`) is already computed correctly as `!(kind_blocked || tier_blocked)`, calling the same `kind_refuses_delegation` the enforcement point calls. Correct; untouched.
- The top-level `allowed_roles` array is the coarse, pre-kind-gate list. That imprecision is intentional and now explicitly documented as such, rather than papered over.

## Files

- `crates/trusty-agents/ui/src/components/AgentConfigSubagents.svelte` — the two user-visible paragraphs, plus the component doc that stated the stale rule.
- `crates/trusty-agents/ui/src/components/AgentConfigSubagents.test.ts` — two new tests pin the new wording (`eligibility is not reachability`, `the delegation kind rule`, `never a peer assistant`, `ADR-0024`) and one asserts the misleading form cannot come back. Assertions run over whitespace-collapsed `textContent` so a re-wrap does not break them.
- `crates/trusty-agents/ui/src/lib/agentConfig.ts` — doc comments on `allowed_roles` (now says it is pre-kind-gate and must not be presented as the reachable set), on `SubagentInProductTarget.reachable` (names both gates), and on `fetchAgentSubagents`.
- `crates/trusty-agents/src/api/server/agent_subagents.rs` — **doc comments only**, zero SLOC change. The module doc and `in_product_surface`'s doc described the rule as "role allowlist + tier gate" and omitted the kind rule; both now name it, and a new honesty rule states that the prose must be predictive, not only the cards.
- `crates/trusty-agents/CHANGELOG.md` — `## [Unreleased] → ### Fixed` entry.

## Verification

No daemon was started (#4295 — a live `tagent --api` attaches real Gmail listeners). Verified by reading the code and by tests only.

```
cargo fmt --check                                    -> exit 0, no diffs
cargo clippy -p trusty-agents --all-targets -- -D warnings -> exit 0
cargo test -p trusty-agents                          -> 2928 passed; 1 failed; 11 ignored
bash scripts/check_line_cap.sh                       -> line-cap: 7 allowlisted, 0 violations — OK.
npm run test:unit  (crates/trusty-agents/ui)         -> 26 files, 292 tests passed
npm run check      (svelte-check)                    -> 1745 files, 0 ERRORS, 2 WARNINGS
```

The one Rust failure is `tools::python_skill::tests::execute_dispatches_to_python_and_parses_json`, pre-existing on every branch on this machine — a dangling Homebrew symlink (`Failed to inspect Python interpreter … /opt/homebrew/bin/python3 … No such file or directory`). Not a regression from this PR, which changes no executable Rust (the `.rs` diff is entirely `//!`/`///` comments). The 2 svelte-check warnings are pre-existing a11y warnings in the unrelated `ProjectsView.svelte`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
