### PR TITLE
fix(trusty-mpm): honour the per-project worktree opt-out in both CLI paths

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -165,6 +165,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The per-project worktree opt-out is no longer silently conditional on the
+  daemon being up ([#4300](https://github.com/bobmatnyc/trusty-tools/issues/4300)).
+  `Project.worktree: false` ([#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455),
+  [#3781](https://github.com/bobmatnyc/trusty-tools/pull/3781)) was consulted at
+  exactly one decision point, inside the daemon's spawn route. Both CLI paths
+  that provision worktrees in the `tm` process itself — `tm launch`, which never
+  asks the daemon, and the daemon-unreachable bare-`tm` fallback, which runs
+  *because* the daemon is down — created a base clone and a per-session worktree
+  regardless. Both now consult the registry BEFORE `ensure_base_clone`, matching
+  the daemon's deliberate ordering, so an opted-out project gets neither a clone
+  nor a worktree and runs in its own checkout exactly as `spawn_managed_on_main`
+  would have given it. The decision itself moved from the `pub(super)`
+  `daemon::managed_routes::launch_on_main::worktree_enabled_for_origin` to
+  `project::worktree_policy`, which serves the daemon in-process and the CLI
+  out-of-process off the same `projects.json`. The `unwrap_or(true)` default is
+  unchanged (unset or unregistered still means worktrees ON, and an unreadable
+  registry fails safe to ON), and #3455's warn-never-refuse concurrency
+  behaviour is untouched.
+
 - Concurrent `tm` processes no longer lose (or corrupt) `projects.json` entries.
   The project-store upsert was an unsynchronised read-modify-write of the whole
   file — two processes interleaving read/read/write/write silently dropped one

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -1082,10 +1082,13 @@ pub(crate) fn managed_pane_settle_pending_message(id: &str) -> String {
 /// if cwd is inside a git working tree (at ANY depth), it is never written to.
 /// What: three-way dispatch on cwd:
 ///   (1) Inside a GitHub-backed git working tree → delegate to
-///       [`redirect_to_managed_clone`] which provisions (or reuses) the protected
+///       [`launch_protected_workspace`] which provisions (or reuses) the protected
 ///       base clone and per-session worktree, then calls `launch()` against THAT
 ///       workspace, never the live checkout. Uses the repo ROOT (not cwd) to
-///       read the origin remote — correct even from subdirectories.
+///       read the origin remote — correct even from subdirectories. #4300: a
+///       project registered with `worktree: false` (#3455) gets neither clone
+///       nor worktree and launches in the repo root instead, matching what the
+///       daemon's `spawn_managed_on_main` would have done had it been up.
 ///   (2) Inside a non-GitHub git working tree (non-GitHub remote or no remote)
 ///       → return an actionable `Err`; the live checkout is never touched.
 ///   (3) Not inside any git working tree (plain directory or bare repo) →
@@ -1161,8 +1164,9 @@ pub(crate) async fn fallback_protected(
     if let Some(ref raw_url) = origin_url
         && is_github_remote(raw_url)
     {
-        // GitHub project: redirect deploy to the protected managed clone.
-        return redirect_to_managed_clone(client, url, cwd, raw_url).await;
+        // GitHub project: redirect deploy to the protected managed clone
+        // (or, when the project opted out of worktrees, to the repo root).
+        return launch_protected_workspace(client, url, &git_root, raw_url).await;
     }
 
     // Non-GitHub remote or no remote: refuse to write to the live tree.
@@ -1179,84 +1183,41 @@ pub(crate) async fn fallback_protected(
     );
 }
 
-/// Redirect the guided-default fallback to the protected managed-clone workspace.
+/// Launch the guided-default fallback in the workspace this project is
+/// entitled to — the protected managed clone, or its own main checkout.
 ///
 /// Why: when the daemon is unreachable and the current directory is a GitHub-backed
 /// git project, framework files must go into the managed-clone workspace
 /// (`~/trusty-mpm-projects/<owner>/<repo>/.worktrees/<session-id>/`), never
-/// into the operator's live checkout (#1724, #1803).
-/// What: (1) parses `owner/repo` from `origin_url`; (2) ensures the protected
-/// base clone exists (`ensure_base_clone` is idempotent — returns immediately when
-/// the clone already exists); (3) creates a per-session git worktree inside the
-/// base clone; (4) calls `launch()` with the worktree path as the target directory.
-/// If any step fails (unparseable URL, clone error, worktree error), the function
-/// returns `Err` with an actionable message — the live checkout is never touched.
-/// Test: `guided_fallback_never_pollutes_github_git_checkout`.
-async fn redirect_to_managed_clone(
+/// into the operator's live checkout (#1724, #1803) — UNLESS the project is
+/// registered with `worktree: false` (#3455), which is the operator saying
+/// "run in my main checkout" and which the daemon honours via
+/// `spawn_managed_on_main`. Before #4300 this path never consulted that
+/// setting, so the opt-out silently held only while the daemon was up.
+/// What: delegates the whole decision to
+/// [`super::managed_workspace::provision_for_fallback`] — which reads the
+/// registry BEFORE `ensure_base_clone`, so an opted-out project gets neither a
+/// clone nor a worktree — then calls `launch()` against the resolved workspace.
+/// On any failure (unparseable URL, clone error, worktree error) it returns
+/// `Err` with an actionable message and the live checkout is never touched.
+/// Test: `guided_fallback_never_pollutes_github_git_checkout`,
+/// `guided_fallback_redirect_success_worktree_not_live_checkout`; the #4300
+/// opt-out cases live in `managed_workspace_tests.rs`.
+async fn launch_protected_workspace(
     client: &reqwest::Client,
     url: &str,
-    cwd: &std::path::Path,
+    git_root: &std::path::Path,
     origin_url: &str,
 ) -> anyhow::Result<()> {
-    use trusty_mpm::daemon::managed_routes::inproject;
-    use trusty_mpm::session_manager::ManagedSessionId;
+    let session_id = trusty_mpm::session_manager::ManagedSessionId::new();
+    let workspace = super::managed_workspace::provision_for_fallback(
+        &trusty_mpm::project::registry_data_dir(),
+        origin_url,
+        git_root,
+        &session_id,
+    )
+    .await?;
 
-    // Parse owner/repo from the GitHub remote URL.
-    let Some(gh) = trusty_common::github_path::parse_github_path(origin_url) else {
-        eprintln!(
-            "tm: cannot determine GitHub project from remote URL '{origin_url}'.\n\
-             Start the daemon first with `tm start`, then run `tm` again."
-        );
-        anyhow::bail!(
-            "daemon unreachable: cannot parse GitHub remote URL as owner/repo — run `tm start` first"
-        );
-    };
-
-    // Ensure the protected base clone exists. Idempotent: returns Ok immediately
-    // when the clone is already present; clones once on first invocation.
-    let base = inproject::base_clone_path(&gh.owner, &gh.repo);
-    eprintln!(
-        "tm: daemon unreachable — redirecting to protected managed clone\n\
-         tm: base clone: {}",
-        base.display()
-    );
-    if let Err(e) = inproject::ensure_base_clone(origin_url, &base) {
-        eprintln!(
-            "tm: could not set up base clone for {}/{}: {e}\n\
-             Start the daemon first with `tm start`, then run `tm` again.",
-            gh.owner, gh.repo
-        );
-        anyhow::bail!("failed to set up managed base clone: {e}");
-    }
-
-    // Create a per-session worktree branched from the base clone.
-    let session_id = ManagedSessionId::new();
-    // NOTE (#2032): this daemon-unreachable fallback path is NOT the managed
-    // SessionManager spawn flow — it has no session manager to resolve a
-    // semantic tmux name from, so it deliberately keeps the pre-#2032
-    // UUID-named worktree here. Only the daemon's `spawn_managed_inproject`
-    // path (`daemon::managed_routes::lifecycle`) uses the new semantic-name
-    // worktree layout.
-    let worktree =
-        match inproject::create_session_worktree(&base, &session_id.to_string(), &session_id) {
-            Ok(p) => p,
-            Err(e) => {
-                eprintln!(
-                    "tm: could not create per-session worktree: {e}\n\
-                 Start the daemon first with `tm start`, then run `tm` again."
-                );
-                anyhow::bail!("failed to create session worktree: {e}");
-            }
-        };
-
-    eprintln!(
-        "tm: launching in protected workspace (live checkout at {} is untouched)\n\
-         tm: session worktree: {}",
-        cwd.display(),
-        worktree.display()
-    );
-
-    // Launch in the session worktree — not the live checkout.
-    let dir = worktree.to_string_lossy().to_string();
+    let dir = workspace.path().to_string_lossy().to_string();
     super::launch::launch(client, url, Some(dir), None).await
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -786,9 +786,17 @@ pub(crate) fn is_github_remote(url: &str) -> bool {
 /// (plain directory or bare repo). Bare repos (`--git-dir` succeeds but
 /// `--show-toplevel` does not) are treated as non-git — deploying into a bare
 /// repo has no live-checkout to protect.
+///
+/// `pub(crate)` since #4300: `managed_workspace::provision_for_launch` must
+/// resolve the repo root the SAME way this path does. `tm launch` has no
+/// `classify_cwd_project` pre-pass, so without a shared definition the two CLI
+/// entry points answered "which directory is this project?" differently and
+/// `tm launch` from a subdirectory deployed into that subdirectory.
 /// Test: `guided_fallback_blocks_github_git_from_subdirectory` calls
-/// `fallback_protected` from a nested subdir and asserts the protection fires.
-fn find_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
+/// `fallback_protected` from a nested subdir and asserts the protection fires;
+/// `provision_for_launch_from_subdirectory_targets_repo_root` covers the
+/// `tm launch` side.
+pub(crate) fn find_git_root(cwd: &std::path::Path) -> Option<std::path::PathBuf> {
     let out = std::process::Command::new("git")
         .arg("-C")
         .arg(cwd)

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -155,53 +155,34 @@ pub(crate) async fn launch(
         return Ok(());
     }
 
-    // 5. Warn about uncommitted local changes (one-time; non-fatal).
-    eprintln!(
-        "note: uncommitted local changes are not carried into the managed clone. \
-         Use `tm connect` if you need to work from the live checkout."
-    );
-
-    // 6. --style is not yet honoured in managed mode.
+    // 5. --style is not yet honoured in managed mode.
     if style.is_some() {
         tracing::warn!("--style not yet supported for managed launches; ignoring style flag");
         // TODO(follow-up): prepare_session_with_repo_url_and_style
     }
 
-    // 7. Provision the managed workspace using the shared base-clone + per-session
+    // 6. Provision the managed workspace using the shared base-clone + per-session
     //    worktree mechanism (#1803). This matches what `tm` (guided default) does
-    //    via the daemon's `spawn_managed_inproject` path — both now converge on the
+    //    via the daemon's `spawn_managed_inproject` path — both converge on the
     //    SAME base clone at `~/trusty-mpm-projects/<owner>/<repo>/` and the SAME
     //    per-session worktree at `<base>/.worktrees/<session-id>/`.
-    //    Step 7a creates or reuses the shared base clone (idempotent); step 7b adds
-    //    a fresh git worktree for this session; step 7c deploys `.claude` into the
-    //    worktree so the session has the framework available.
-    eprintln!("provisioning managed workspace...");
+    //    #4300: `provision_for_launch` consults the per-project `worktree`
+    //    opt-out (#3455) FIRST — a project registered with `worktree: false`
+    //    gets neither a base clone nor a worktree here, exactly as the daemon's
+    //    `spawn_managed_on_main` gives it neither. It also owns the
+    //    uncommitted-changes notice, which only applies when there IS a clone.
     let session_uuid = trusty_mpm::session_manager::ManagedSessionId::new();
-
-    // 7a. Ensure the shared base clone exists. Idempotent: returns immediately when
-    //     `<project_dir>/.git` is already present so a second `tm launch` reuses
-    //     the existing clone rather than re-cloning.
-    trusty_mpm::daemon::managed_routes::inproject::ensure_base_clone(&origin_url, &project_dir)
-        .map_err(|e| anyhow::anyhow!("failed to provision base clone: {e}"))?;
-
-    // 7b. Create a per-session git worktree at `<project_dir>/.worktrees/<session-id>/`.
-    //     Each session gets an isolated branch so concurrent sessions never collide.
-    //     NOTE (#2032): `tm launch` is a standalone CLI flow, not the daemon's
-    //     managed `SessionManager` spawn path — the tmux name here is derived
-    //     from the live folder AFTER the worktree already exists (see
-    //     `folder_name`/`fallback_session_name` below), so there is no
-    //     resolved semantic name available yet at worktree-creation time.
-    //     This keeps the pre-#2032 UUID-named worktree; only
-    //     `spawn_managed_inproject` (the daemon's HTTP/MCP spawn path) uses
-    //     the new semantic-name layout.
-    let managed_path = trusty_mpm::daemon::managed_routes::inproject::create_session_worktree(
+    let workspace = super::managed_workspace::provision_for_launch(
+        &trusty_mpm::project::registry_data_dir(),
+        &origin_url,
         &project_dir,
-        &session_uuid.to_string(),
+        &live_path,
         &session_uuid,
     )
-    .map_err(|e| anyhow::anyhow!("failed to create session worktree: {e}"))?;
+    .await?;
+    let managed_path = workspace.path().to_path_buf();
 
-    // 7c. Deploy the `.claude` framework into the worktree (best-effort).
+    // 7. Deploy the `.claude` framework into the worktree (best-effort).
     //     Non-fatal: a deploy failure never aborts the session — the operator can
     //     run `tm install` / `tm catalog sync` to populate agents manually.
     //     #4203: deploy through the isolated seam so the roster lands in the

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -169,8 +169,11 @@ pub(crate) async fn launch(
     //    #4300: `provision_for_launch` consults the per-project `worktree`
     //    opt-out (#3455) FIRST — a project registered with `worktree: false`
     //    gets neither a base clone nor a worktree here, exactly as the daemon's
-    //    `spawn_managed_on_main` gives it neither. It also owns the
-    //    uncommitted-changes notice, which only applies when there IS a clone.
+    //    `spawn_managed_on_main` gives it neither. It also resolves the repo
+    //    ROOT of `live_path` (so `tm launch` from a subdirectory of an
+    //    opted-out project deploys to the project, not the subdirectory) and
+    //    owns the uncommitted-changes notice, which only applies when there
+    //    IS a clone.
     let session_uuid = trusty_mpm::session_manager::ManagedSessionId::new();
     let workspace = super::managed_workspace::provision_for_launch(
         &trusty_mpm::project::registry_data_dir(),

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
@@ -21,6 +21,15 @@
 //! [`trusty_mpm::project::worktree_enabled_for_origin_at`], and passes the
 //! answer down — so the operator-facing notice and the filesystem action can
 //! never disagree.
+//! Known redundancy, accepted: the daemon-unreachable fallback ends by
+//! calling `launch()`, so on that composed path the registry is read twice —
+//! once by [`provision_for_fallback`] and once by [`provision_for_launch`].
+//! Collapsing it would mean threading a pre-resolved `ManagedWorkspace`
+//! through `launch()`'s signature, a restructure that buys one avoided
+//! `read_to_string` of an atomically-published file whose read path takes no
+//! lock and fails open to isolation-ON. Both reads see the same bytes; the
+//! only operator-visible symptom was a duplicated notice, and that is fixed
+//! in [`provision_for_fallback`] directly.
 //! Scope note: this deliberately does NOT change #3455's concurrency
 //! behaviour. `spawn_managed_on_main` WARNS (never refuses) on a second
 //! session against one main checkout, and that stays the rule here — nothing
@@ -118,21 +127,34 @@ async fn provision(
 /// Why: `tm launch` runs the whole provisioning flow in-process and never
 /// asks the daemon, so it is the CLI path that most visibly ignored the
 /// opt-out before this.
-/// What: reads the opt-out from the registry at `registry_dir`, prints the
-/// notice for whichever branch applies, then delegates to [`provision`] with
-/// the caller-resolved `base_path` (`inproject::base_clone_path(owner, repo)`)
-/// and the operator's live checkout as the opt-out target. Errors are mapped
-/// to `tm launch`'s wording.
+/// What: resolves the REPO ROOT of `cwd` and reads the opt-out from the
+/// registry at `registry_dir`, prints the notice for whichever branch applies,
+/// then delegates to [`provision`] with the caller-resolved `base_path`
+/// (`inproject::base_clone_path(owner, repo)`). Errors are mapped to `tm
+/// launch`'s wording.
+///
+/// The root resolution matters and is not incidental: `get_origin_url`
+/// succeeds at ANY depth, so `cd repo/src && tm launch` on an opted-out
+/// project would otherwise deploy `.claude`, the project hooks and the tmux
+/// cwd into `repo/src` rather than `repo` — landing tm's furniture exactly
+/// where the operator did not ask for it, which is the failure mode the
+/// opt-out exists to prevent. [`super::guided::find_git_root`] is the SAME
+/// helper the daemon-unreachable fallback's classifier uses, so both CLI
+/// entry points cannot disagree about which directory the project is. A `cwd`
+/// that is not inside a working tree (or a machine with no `git` on PATH)
+/// falls back to `cwd` itself — the pre-#4300 behaviour, never worse.
 /// Test: `provision_for_launch_opted_out_creates_no_clone_and_no_worktree`,
+/// `provision_for_launch_from_subdirectory_targets_repo_root`,
 /// `provision_for_launch_unset_creates_worktree`,
 /// `provision_for_launch_unregistered_origin_creates_worktree`.
 pub(crate) async fn provision_for_launch(
     registry_dir: &Path,
     origin_url: &str,
     base_path: &Path,
-    live_path: &Path,
+    cwd: &Path,
     session_id: &ManagedSessionId,
 ) -> anyhow::Result<ManagedWorkspace> {
+    let main_checkout = super::guided::find_git_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
     let isolate =
         trusty_mpm::project::worktree_enabled_for_origin_at(registry_dir, origin_url).await;
     if isolate {
@@ -145,11 +167,11 @@ pub(crate) async fn provision_for_launch(
         eprintln!(
             "tm: worktree isolation is disabled for this project (#3455) — \
              launching directly in {} (no managed clone, no worktree)",
-            live_path.display()
+            main_checkout.display()
         );
     }
 
-    provision(isolate, origin_url, base_path, live_path, session_id)
+    provision(isolate, origin_url, base_path, &main_checkout, session_id)
         .await
         .map_err(|e| anyhow::anyhow!("failed to provision managed workspace: {e}"))
 }
@@ -197,10 +219,15 @@ pub(crate) async fn provision_for_fallback(
             base.display()
         );
     } else {
+        // Deliberately terse: this path ends in `launch()`, which calls
+        // `provision_for_launch` and prints the full "worktree isolation is
+        // disabled … no managed clone, no worktree" line itself. Repeating it
+        // here showed the operator the same sentence twice. What is NOT
+        // redundant is the daemon-unreachable context, which only this path
+        // knows.
         eprintln!(
-            "tm: daemon unreachable — worktree isolation is disabled for this project (#3455), \
-             so there is nothing to redirect to; launching in {} (no managed clone, no worktree)",
-            git_root.display()
+            "tm: daemon unreachable — this project opted out of worktrees (#3455), \
+             so there is nothing to redirect to."
         );
     }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
@@ -125,7 +125,7 @@ async fn provision(
 /// to `tm launch`'s wording.
 /// Test: `provision_for_launch_opted_out_creates_no_clone_and_no_worktree`,
 /// `provision_for_launch_unset_creates_worktree`,
-/// `provision_for_launch_opted_in_creates_worktree`.
+/// `provision_for_launch_unregistered_origin_creates_worktree`.
 pub(crate) async fn provision_for_launch(
     registry_dir: &Path,
     origin_url: &str,
@@ -168,7 +168,7 @@ pub(crate) async fn provision_for_launch(
 /// "start the daemon" remediation.
 /// Test: `provision_for_fallback_opted_out_creates_no_clone_and_no_worktree`,
 /// `provision_for_fallback_unset_creates_worktree_not_live_checkout`,
-/// `provision_for_fallback_rejects_unparseable_remote`.
+/// `provision_for_fallback_other_projects_optout_does_not_leak`.
 pub(crate) async fn provision_for_fallback(
     registry_dir: &Path,
     origin_url: &str,

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace.rs
@@ -1,0 +1,232 @@
+//! CLI-side managed-workspace provisioning that honours the #3455 worktree
+//! opt-out (#4300).
+//!
+//! Why: two `tm` entry points create base clones and per-session worktrees
+//! entirely IN THE CLI PROCESS — `tm launch` (which never asks the daemon)
+//! and the daemon-unreachable guided fallback (which runs precisely because
+//! the daemon is down). Both predate #3455's per-project `worktree: false`
+//! opt-out and neither consulted it, so the setting was silently conditional
+//! on the daemon being up: a project registered with `worktree: false` still
+//! got a clone and a worktree from either path. Concentrating the decision
+//! and the provisioning here means the opt-out is read once per launch, in
+//! the SAME order the daemon uses (`managed_routes::lifecycle`, ahead of
+//! `try_inproject_spawn`) — BEFORE `ensure_base_clone`, so an opted-out
+//! project creates neither a worktree nor a base clone.
+//! What: [`ManagedWorkspace`] names the two outcomes; [`provision`] is the
+//! shared dispatcher that acts on an already-resolved decision;
+//! [`provision_for_launch`] serves `tm launch` (which has already resolved
+//! the base-clone path) and [`provision_for_fallback`] serves the guided
+//! fallback (which parses `owner/repo` itself and reports daemon-specific
+//! remediation). Each entry point reads the registry EXACTLY once, via
+//! [`trusty_mpm::project::worktree_enabled_for_origin_at`], and passes the
+//! answer down — so the operator-facing notice and the filesystem action can
+//! never disagree.
+//! Scope note: this deliberately does NOT change #3455's concurrency
+//! behaviour. `spawn_managed_on_main` WARNS (never refuses) on a second
+//! session against one main checkout, and that stays the rule here — nothing
+//! in this module refuses a launch.
+//! Test: `managed_workspace_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use trusty_mpm::daemon::managed_routes::inproject;
+use trusty_mpm::session_manager::ManagedSessionId;
+
+/// Where a CLI-provisioned managed session will actually run.
+///
+/// Why: the two outcomes have materially different lifecycles — a worktree is
+/// framework-owned and disposable, the operator's main checkout is neither —
+/// so callers are forced to distinguish them rather than receiving a bare
+/// `PathBuf` that hides which one they got.
+/// What: `Worktree` carries `<base>/.worktrees/<session-id>`; `MainCheckout`
+/// carries the operator's own checkout root, returned only when the project is
+/// registered with `worktree: false`.
+/// Test: `managed_workspace_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ManagedWorkspace {
+    /// A per-session git worktree under the protected base clone (the default).
+    Worktree(PathBuf),
+    /// The project's own main checkout — no clone, no worktree (#3455 opt-out).
+    MainCheckout(PathBuf),
+}
+
+impl ManagedWorkspace {
+    /// The directory the session should run in, whichever variant this is.
+    ///
+    /// Why: callers that only need the cwd should not have to re-match.
+    /// What: the inner path.
+    /// Test: `managed_workspace_tests.rs`.
+    pub(crate) fn path(&self) -> &Path {
+        match self {
+            Self::Worktree(p) | Self::MainCheckout(p) => p,
+        }
+    }
+
+    /// True when this workspace is a per-session worktree.
+    ///
+    /// Why: callers tailor operator-facing notices — "the live checkout is
+    /// untouched" is a lie when the session IS the live checkout.
+    /// What: `matches!(self, Self::Worktree(_))`.
+    /// Test: `managed_workspace_tests.rs`.
+    pub(crate) fn is_worktree(&self) -> bool {
+        matches!(self, Self::Worktree(_))
+    }
+}
+
+/// Act on an already-resolved isolation decision.
+///
+/// Why: the opt-out check MUST run before [`inproject::ensure_base_clone`].
+/// Checking afterwards would still leave a full base clone on disk for a
+/// project that asked for no isolation at all — the wasted-disk complaint
+/// #3455 was filed about; the daemon's `spawn_managed_routed` documents the
+/// same ordering for the same reason. Taking `isolate` as a parameter (rather
+/// than re-reading the registry here) guarantees the notice each caller
+/// printed describes the action actually taken.
+/// What: `isolate == false` returns [`ManagedWorkspace::MainCheckout`] having
+/// touched nothing on disk; otherwise ensures the base clone and adds a
+/// UUID-named per-session worktree. Errors are the raw `inproject` strings so
+/// each caller can wrap them with its own remediation text.
+/// Test: `managed_workspace_tests.rs`.
+async fn provision(
+    isolate: bool,
+    origin_url: &str,
+    base_path: &Path,
+    main_checkout: &Path,
+    session_id: &ManagedSessionId,
+) -> Result<ManagedWorkspace, String> {
+    if !isolate {
+        tracing::info!(
+            origin = %origin_url,
+            path = %main_checkout.display(),
+            "project has worktree isolation disabled (#3455); no base clone, no worktree"
+        );
+        return Ok(ManagedWorkspace::MainCheckout(main_checkout.to_path_buf()));
+    }
+
+    inproject::ensure_base_clone(origin_url, base_path)?;
+    // NOTE (#2032): the CLI flows have no `SessionManager` to resolve a
+    // semantic tmux name from, so they keep the pre-#2032 UUID-named
+    // worktree; only the daemon's `spawn_managed_inproject` uses the
+    // semantic-name layout.
+    let worktree =
+        inproject::create_session_worktree(base_path, &session_id.to_string(), session_id)?;
+    Ok(ManagedWorkspace::Worktree(worktree))
+}
+
+/// Provision the workspace for `tm launch` (#4300 call site 1).
+///
+/// Why: `tm launch` runs the whole provisioning flow in-process and never
+/// asks the daemon, so it is the CLI path that most visibly ignored the
+/// opt-out before this.
+/// What: reads the opt-out from the registry at `registry_dir`, prints the
+/// notice for whichever branch applies, then delegates to [`provision`] with
+/// the caller-resolved `base_path` (`inproject::base_clone_path(owner, repo)`)
+/// and the operator's live checkout as the opt-out target. Errors are mapped
+/// to `tm launch`'s wording.
+/// Test: `provision_for_launch_opted_out_creates_no_clone_and_no_worktree`,
+/// `provision_for_launch_unset_creates_worktree`,
+/// `provision_for_launch_opted_in_creates_worktree`.
+pub(crate) async fn provision_for_launch(
+    registry_dir: &Path,
+    origin_url: &str,
+    base_path: &Path,
+    live_path: &Path,
+    session_id: &ManagedSessionId,
+) -> anyhow::Result<ManagedWorkspace> {
+    let isolate =
+        trusty_mpm::project::worktree_enabled_for_origin_at(registry_dir, origin_url).await;
+    if isolate {
+        eprintln!(
+            "note: uncommitted local changes are not carried into the managed clone. \
+             Use `tm connect` if you need to work from the live checkout."
+        );
+        eprintln!("provisioning managed workspace...");
+    } else {
+        eprintln!(
+            "tm: worktree isolation is disabled for this project (#3455) — \
+             launching directly in {} (no managed clone, no worktree)",
+            live_path.display()
+        );
+    }
+
+    provision(isolate, origin_url, base_path, live_path, session_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to provision managed workspace: {e}"))
+}
+
+/// Provision the workspace for the daemon-unreachable guided fallback
+/// (#4300 call site 2).
+///
+/// Why: bare `tm` with the daemon down must still never write framework files
+/// into a live checkout it was not told it could (#1724) — but a project
+/// registered with `worktree: false` HAS told us exactly that, and the daemon
+/// would have honoured it via `spawn_managed_on_main`. Consulting the same
+/// registry here is what makes the setting independent of daemon liveness.
+/// What: parses `owner/repo` from `origin_url`, reads the opt-out, and
+/// delegates to [`provision`] with `git_root` (the repo ROOT, not the
+/// possibly-nested cwd) as the opt-out target; errors carry the fallback's
+/// "start the daemon" remediation.
+/// Test: `provision_for_fallback_opted_out_creates_no_clone_and_no_worktree`,
+/// `provision_for_fallback_unset_creates_worktree_not_live_checkout`,
+/// `provision_for_fallback_rejects_unparseable_remote`.
+pub(crate) async fn provision_for_fallback(
+    registry_dir: &Path,
+    origin_url: &str,
+    git_root: &Path,
+    session_id: &ManagedSessionId,
+) -> anyhow::Result<ManagedWorkspace> {
+    let Some(gh) = trusty_common::github_path::parse_github_path(origin_url) else {
+        eprintln!(
+            "tm: cannot determine GitHub project from remote URL '{origin_url}'.\n\
+             Start the daemon first with `tm start`, then run `tm` again."
+        );
+        anyhow::bail!(
+            "daemon unreachable: cannot parse GitHub remote URL as owner/repo — run `tm start` first"
+        );
+    };
+
+    // #4300: ask BEFORE naming (let alone creating) the base clone, so an
+    // opted-out project never sees a clone directory appear.
+    let isolate =
+        trusty_mpm::project::worktree_enabled_for_origin_at(registry_dir, origin_url).await;
+    let base = inproject::base_clone_path(&gh.owner, &gh.repo);
+    if isolate {
+        eprintln!(
+            "tm: daemon unreachable — redirecting to protected managed clone\n\
+             tm: base clone: {}",
+            base.display()
+        );
+    } else {
+        eprintln!(
+            "tm: daemon unreachable — worktree isolation is disabled for this project (#3455), \
+             so there is nothing to redirect to; launching in {} (no managed clone, no worktree)",
+            git_root.display()
+        );
+    }
+
+    let workspace = match provision(isolate, origin_url, &base, git_root, session_id).await {
+        Ok(w) => w,
+        Err(e) => {
+            eprintln!(
+                "tm: could not set up managed workspace for {}/{}: {e}\n\
+                 Start the daemon first with `tm start`, then run `tm` again.",
+                gh.owner, gh.repo
+            );
+            anyhow::bail!("failed to set up managed workspace: {e}");
+        }
+    };
+
+    if workspace.is_worktree() {
+        eprintln!(
+            "tm: launching in protected workspace (live checkout at {} is untouched)\n\
+             tm: session worktree: {}",
+            git_root.display(),
+            workspace.path().display()
+        );
+    }
+    Ok(workspace)
+}
+
+#[cfg(test)]
+#[path = "managed_workspace_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
@@ -1,0 +1,395 @@
+//! #4300 acceptance: the CLI paths honour the #3455 per-project worktree
+//! opt-out — no worktree AND no base clone.
+//!
+//! Why: before #4300 the opt-out was consulted at exactly one decision point,
+//! inside the daemon. `tm launch` runs in-process and never asks the daemon;
+//! the guided fallback runs precisely BECAUSE the daemon is unreachable. Both
+//! provisioned a clone and a worktree for projects registered with `worktree:
+//! false` (live for `bobmatnyc/writing` and `bob-duetto/cto`). These tests
+//! pin both paths, and the `unwrap_or(true)` default they must not regress.
+//! What: per CLI path — one opted-out case asserting the SPECIFIC main-checkout
+//! path is returned and that the base-clone directory and the `.worktrees`
+//! directory do NOT exist, and one opted-in/unset control asserting the
+//! worktree IS created at its exact expected path.
+//! Concurrency: the fallback tests read `TRUSTY_MPM_REPOS_ROOT` (a
+//! process-global) through `inproject::base_clone_path`, so they are
+//! `#[serial_test::serial]` and restore the previous value via an RAII guard
+//! that runs on panic-driven unwind too. Nothing here deletes anything: the
+//! only filesystem writes are `git init`/`git worktree add` under
+//! test-owned `TempDir`s, so a clobbered global can make a test FAIL but can
+//! never make it destructive.
+//! Test: this file.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+use trusty_mpm::daemon::managed_routes::inproject;
+use trusty_mpm::project::{Project, ProjectRegistry};
+use trusty_mpm::session_manager::ManagedSessionId;
+
+use super::{ManagedWorkspace, provision_for_fallback, provision_for_launch};
+
+/// RAII override of `TRUSTY_MPM_REPOS_ROOT`, restored on drop (incl. unwind).
+///
+/// Why: `inproject::base_clone_path` reads this global, and a test that
+/// panicked mid-assertion must not leave the rest of the binary pointed at a
+/// deleted `TempDir`.
+/// What: sets the var on construction, restores the prior value (or removes
+/// it) on drop. Callers MUST be `#[serial_test::serial]`.
+/// Test: used by the fallback tests below.
+struct ReposRootGuard {
+    prev: Option<std::ffi::OsString>,
+}
+
+impl ReposRootGuard {
+    fn set(path: &Path) -> Self {
+        let prev = std::env::var_os(inproject::REPOS_ROOT_ENV);
+        // SAFETY: every caller is `#[serial_test::serial]`, so no other test
+        // thread races this set/restore.
+        unsafe { std::env::set_var(inproject::REPOS_ROOT_ENV, path) };
+        Self { prev }
+    }
+}
+
+impl Drop for ReposRootGuard {
+    fn drop(&mut self) {
+        // SAFETY: see `set`.
+        match self.prev.take() {
+            Some(v) => unsafe { std::env::set_var(inproject::REPOS_ROOT_ENV, v) },
+            None => unsafe { std::env::remove_var(inproject::REPOS_ROOT_ENV) },
+        }
+    }
+}
+
+/// Build a registry directory containing one project with the given opt-out.
+///
+/// Why: both paths resolve the opt-out by reading `projects.json` out of
+/// process, so the fixture must be a REAL on-disk registry, not a stub.
+/// What: writes `<tmp>/projects.json` via `ProjectRegistry` and returns the
+/// owning `TempDir`. Any failure `unwrap`s — a fixture that cannot be built is
+/// a test failure, never a skip.
+/// Test: used by every test below.
+async fn registry_with(repo_url: &str, worktree: Option<bool>) -> TempDir {
+    let dir = tempfile::tempdir().unwrap();
+    let registry = ProjectRegistry::load(dir.path()).await.unwrap();
+    registry
+        .register(Project {
+            name: "fixture".into(),
+            repo_url: repo_url.into(),
+            default_branch: "main".into(),
+            stack_hint: None,
+            tags: vec![],
+            description: None,
+            gh_user: None,
+            gh_account: None,
+            github: None,
+            commit_name: None,
+            commit_email: None,
+            worktree,
+        })
+        .await
+        .unwrap();
+    assert!(
+        dir.path().join("projects.json").is_file(),
+        "fixture precondition: projects.json must exist at {}",
+        dir.path().display()
+    );
+    dir
+}
+
+/// Create a real git repository at `path` with one empty commit.
+///
+/// Why: `create_session_worktree` runs `git worktree add`, which requires a
+/// HEAD commit; the opted-IN control tests must reach that code for real.
+/// What: `git init` + identity config + `commit --allow-empty`, asserting each
+/// step succeeded. No skip path — a missing `git` fails the test.
+/// Test: used by the opted-in control tests.
+fn init_git_repo(path: &Path) {
+    std::fs::create_dir_all(path).unwrap();
+    let run = |args: &[&str]| {
+        let status = std::process::Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .status()
+            .unwrap_or_else(|e| panic!("git {args:?} failed to spawn: {e}"));
+        assert!(
+            status.success(),
+            "git {args:?} failed in {}",
+            path.display()
+        );
+    };
+    run(&["init"]);
+    run(&["config", "user.email", "ci@test.invalid"]);
+    run(&["config", "user.name", "CI"]);
+    run(&["commit", "--allow-empty", "-m", "init"]);
+}
+
+/// Assert `base` shows no trace of provisioning: no clone, no worktrees dir.
+///
+/// Why: the acceptance bar is "neither a worktree NOR a base clone", and the
+/// daemon's ordering exists precisely so the clone is not created either.
+/// What: asserts the base-clone directory itself, its `.git`, and its
+/// `.worktrees` child are all absent.
+/// Test: used by both opted-out tests.
+fn assert_nothing_provisioned(base: &Path) {
+    assert!(
+        !base.exists(),
+        "#4300: base clone dir must NOT be created for an opted-out project: {}",
+        base.display()
+    );
+    assert!(
+        !base.join(".git").exists(),
+        "#4300: base clone must NOT be initialised: {}",
+        base.join(".git").display()
+    );
+    assert!(
+        !base.join(".worktrees").exists(),
+        "#4300: worktree dir must NOT be created: {}",
+        base.join(".worktrees").display()
+    );
+}
+
+/// Path a UUID-named session worktree lands at under `base`.
+///
+/// Why: the tests assert on the SPECIFIC path, not on `is_ok()`.
+/// What: `<base>/.worktrees/<session-id>`.
+/// Test: used by the opted-in control tests.
+fn expected_worktree(base: &Path, session_id: &ManagedSessionId) -> PathBuf {
+    base.join(".worktrees").join(session_id.to_string())
+}
+
+// ── Path (a): `tm launch` ────────────────────────────────────────────────────
+
+/// `tm launch` against a project registered with `worktree: false` must create
+/// NEITHER a base clone NOR a worktree, and must run in the live checkout.
+///
+/// Why (#4300): `tm launch` provisions in-process and never asks the daemon,
+/// so before this fix the opt-out was ignored outright on this path.
+/// What: registers `worktree: false`, calls the exact function `launch()`
+/// calls, and asserts the returned workspace is the live checkout while the
+/// caller-supplied base-clone path stays untouched.
+/// Test: itself. RED with the guard reverted (a clone + worktree appear).
+#[tokio::test]
+async fn provision_for_launch_opted_out_creates_no_clone_and_no_worktree() {
+    let origin = "git@github.com:bobmatnyc/writing.git";
+    let registry = registry_with("https://github.com/bobmatnyc/writing", Some(false)).await;
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let base = repos_root.path().join("bobmatnyc").join("writing");
+    let live = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_launch(registry.path(), origin, &base, live.path(), &session_id)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::MainCheckout(live.path().to_path_buf()),
+        "#4300: an opted-out project must launch in its own checkout"
+    );
+    assert_nothing_provisioned(&base);
+    assert!(
+        !expected_worktree(&base, &session_id).exists(),
+        "#4300: the per-session worktree must NOT exist"
+    );
+}
+
+/// A project with NO `worktree` key still gets a worktree — the `unwrap_or(true)`
+/// default must not regress.
+///
+/// Why: 31 of the 33 registered projects carry no `worktree` key; a fix that
+/// silently flipped them to main-checkout mode would be far worse than the bug.
+/// What: registers the project with `worktree: None`, provisions, and asserts
+/// the worktree exists at its exact expected path inside the base clone.
+/// Test: itself.
+#[tokio::test]
+async fn provision_for_launch_unset_creates_worktree() {
+    let origin = "https://github.com/bobmatnyc/trusty-tools";
+    let registry = registry_with("https://github.com/bobmatnyc/trusty-tools", None).await;
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let base = repos_root.path().join("bobmatnyc").join("trusty-tools");
+    init_git_repo(&base);
+    let live = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_launch(registry.path(), origin, &base, live.path(), &session_id)
+        .await
+        .unwrap();
+
+    let expected = expected_worktree(&base, &session_id);
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::Worktree(expected.clone()),
+        "a project with no `worktree` key must still get a worktree"
+    );
+    assert!(
+        expected.is_dir(),
+        "the worktree directory must exist at {}",
+        expected.display()
+    );
+}
+
+/// An UNREGISTERED origin also keeps worktree isolation — the default applies
+/// to projects the registry has never heard of, not just to unset keys.
+///
+/// Why: the registry holds 33 of the machine's projects; every other repo the
+/// operator runs `tm launch` in resolves through the "no match" branch.
+/// What: builds a registry holding a DIFFERENT project's opt-out, then
+/// provisions for an unrelated origin and asserts the worktree is created.
+/// Test: itself.
+#[tokio::test]
+async fn provision_for_launch_unregistered_origin_creates_worktree() {
+    let registry = registry_with("https://github.com/bobmatnyc/writing", Some(false)).await;
+
+    let origin = "https://github.com/acme/unregistered";
+    let repos_root = tempfile::tempdir().unwrap();
+    let base = repos_root.path().join("acme").join("unregistered");
+    init_git_repo(&base);
+    let live = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_launch(registry.path(), origin, &base, live.path(), &session_id)
+        .await
+        .unwrap();
+
+    let expected = expected_worktree(&base, &session_id);
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::Worktree(expected.clone()),
+        "another project's opt-out must not leak onto an unrelated origin"
+    );
+    assert!(
+        expected.is_dir(),
+        "worktree must exist at {}",
+        expected.display()
+    );
+}
+
+// ── Path (b): the daemon-unreachable bare-`tm` fallback ─────────────────────
+
+/// The daemon-unreachable fallback must ALSO honour the opt-out: no base
+/// clone, no worktree, launch in the repo root.
+///
+/// Why (#4300): this path runs precisely because the daemon is down, so it can
+/// never be served by the daemon's own check — the setting was silently
+/// conditional on daemon liveness.
+/// What: points `TRUSTY_MPM_REPOS_ROOT` at an empty temp dir, registers
+/// `worktree: false`, and asserts the fallback returns the repo ROOT while the
+/// repos root stays completely empty.
+/// Test: itself. RED with the guard reverted (a clone + worktree appear).
+#[tokio::test]
+#[serial_test::serial]
+async fn provision_for_fallback_opted_out_creates_no_clone_and_no_worktree() {
+    let origin = "https://github.com/bob-duetto/cto.git";
+    let registry = registry_with("https://github.com/bob-duetto/cto", Some(false)).await;
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let _guard = ReposRootGuard::set(repos_root.path());
+    let git_root = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_fallback(registry.path(), origin, git_root.path(), &session_id)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::MainCheckout(git_root.path().to_path_buf()),
+        "#4300: the daemon-unreachable fallback must launch in the repo root"
+    );
+    assert_nothing_provisioned(&repos_root.path().join("bob-duetto").join("cto"));
+    assert_eq!(
+        std::fs::read_dir(repos_root.path()).unwrap().count(),
+        0,
+        "#4300: the managed repos root must stay empty for an opted-out project"
+    );
+}
+
+/// The fallback's default path is unchanged: an unset `worktree` still gets a
+/// per-session worktree inside the protected base clone, never the live
+/// checkout (#1724 invariant preserved).
+///
+/// Why: this is the control that proves the new guard did not turn the whole
+/// fallback into a live-checkout launcher.
+/// What: pre-creates a real base clone at the path `base_clone_path` resolves
+/// to, registers the project with no `worktree` key, and asserts the returned
+/// workspace is the worktree at its exact expected path.
+/// Test: itself.
+#[tokio::test]
+#[serial_test::serial]
+async fn provision_for_fallback_unset_creates_worktree_not_live_checkout() {
+    let origin = "https://github.com/bob-duetto/cto.git";
+    let registry = registry_with("https://github.com/bob-duetto/cto", None).await;
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let _guard = ReposRootGuard::set(repos_root.path());
+    let base = repos_root.path().join("bob-duetto").join("cto");
+    init_git_repo(&base);
+    let git_root = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_fallback(registry.path(), origin, git_root.path(), &session_id)
+        .await
+        .unwrap();
+
+    let expected = expected_worktree(&base, &session_id);
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::Worktree(expected.clone()),
+        "an unset `worktree` key must still redirect to a protected worktree"
+    );
+    assert!(
+        expected.is_dir(),
+        "worktree must exist at {}",
+        expected.display()
+    );
+    assert!(
+        !git_root.path().join(".worktrees").exists(),
+        "#1724: nothing may be provisioned inside the live checkout"
+    );
+}
+
+/// Another project's opt-out must not leak onto an unrelated origin on the
+/// fallback path either — the registry lookup is keyed by `repo_url`.
+///
+/// Why: the fallback reads the SAME 33-entry registry, only two of whose
+/// entries carry `worktree: false`; a lookup that matched too eagerly would
+/// strip isolation from every other project when the daemon happens to be down.
+/// What: registers only `bobmatnyc/writing` as opted out, then provisions for
+/// `bob-duetto/cto` and asserts the worktree IS created.
+/// Test: itself.
+#[tokio::test]
+#[serial_test::serial]
+async fn provision_for_fallback_other_projects_optout_does_not_leak() {
+    let registry = registry_with("https://github.com/bobmatnyc/writing", Some(false)).await;
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let _guard = ReposRootGuard::set(repos_root.path());
+    let base = repos_root.path().join("bob-duetto").join("cto");
+    init_git_repo(&base);
+    let git_root = tempfile::tempdir().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_fallback(
+        registry.path(),
+        "https://github.com/bob-duetto/cto.git",
+        git_root.path(),
+        &session_id,
+    )
+    .await
+    .unwrap();
+
+    let expected = expected_worktree(&base, &session_id);
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::Worktree(expected.clone()),
+        "an unrelated project's opt-out must not disable isolation here"
+    );
+    assert!(
+        expected.is_dir(),
+        "worktree must exist at {}",
+        expected.display()
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
@@ -11,6 +11,15 @@
 //! path is returned and that the base-clone directory and the `.worktrees`
 //! directory do NOT exist, and one opted-in/unset control asserting the
 //! worktree IS created at its exact expected path.
+//! Fixture remotes: every origin here uses the non-resolvable `.invalid` TLD
+//! (RFC 2606) with fixture-only owner/repo names, following the convention
+//! `tests_behavior_c_tests.rs:1570-1580` documents. An earlier revision used
+//! the REAL `bobmatnyc/writing` and `bob-duetto/cto` remotes, and the
+//! guard-neutralised revert run proved why that is wrong: `ensure_base_clone`
+//! genuinely cloned both private repos over the network (88.43s vs 0.28s
+//! baseline). The assertion under test is the opt-out DECISION, never that a
+//! clone succeeds, so a host that cannot resolve is lossless here and keeps
+//! the suite hermetic and fast whether the guard is present or not.
 //! Concurrency: the fallback tests read `TRUSTY_MPM_REPOS_ROOT` (a
 //! process-global) through `inproject::base_clone_path`, so they are
 //! `#[serial_test::serial]` and restore the previous value via an RAII guard
@@ -171,17 +180,24 @@ fn expected_worktree(base: &Path, session_id: &ManagedSessionId) -> PathBuf {
 /// Test: itself. RED with the guard reverted (a clone + worktree appear).
 #[tokio::test]
 async fn provision_for_launch_opted_out_creates_no_clone_and_no_worktree() {
-    let origin = "git@github.com:bobmatnyc/writing.git";
-    let registry = registry_with("https://github.com/bobmatnyc/writing", Some(false)).await;
+    let origin = "git@github.invalid:fixture-owner/optout-repo.git";
+    let registry = registry_with(
+        "https://github.invalid/fixture-owner/optout-repo",
+        Some(false),
+    )
+    .await;
 
     let repos_root = tempfile::tempdir().unwrap();
-    let base = repos_root.path().join("bobmatnyc").join("writing");
+    let base = repos_root.path().join("fixture-owner").join("optout-repo");
     let live = tempfile::tempdir().unwrap();
     let session_id = ManagedSessionId::new();
 
     let workspace = provision_for_launch(registry.path(), origin, &base, live.path(), &session_id)
         .await
-        .unwrap();
+        .expect(
+            "#4300: an opted-out project must not attempt a clone at all — a clone \
+             error here means the opt-out was never consulted",
+        );
 
     assert_eq!(
         workspace,
@@ -195,6 +211,70 @@ async fn provision_for_launch_opted_out_creates_no_clone_and_no_worktree() {
     );
 }
 
+/// `tm launch` from a SUBDIRECTORY of an opted-out project must deploy into
+/// the repo ROOT, never the subdirectory.
+///
+/// Why (code-critic MEDIUM on PR #4303): `get_origin_url` succeeds at any
+/// depth, so `cd repo/src && tm launch` on an opted-out project passed `cwd`
+/// straight through as the workspace — `.claude`, the project hooks, the tmux
+/// cwd and the daemon's `project_path` all landed in `repo/src`. That is
+/// precisely the "tm furniture somewhere the operator did not intend" failure
+/// the opt-out exists to prevent, and it was introduced by this PR: the
+/// pre-#4300 code always redirected to a worktree, so `cwd` never became a
+/// deploy target. The daemon-unreachable fallback already resolved the root
+/// via `classify_cwd_project`; this pins that `tm launch` agrees.
+/// What: builds a REAL git repo (so `git rev-parse --show-toplevel` has a root
+/// to find), registers it opted-out, calls `provision_for_launch` with a
+/// nested subdirectory as `cwd`, and asserts the returned workspace is the
+/// canonical repo root and explicitly NOT the subdirectory.
+/// Test: itself. RED if `provision_for_launch` passes `cwd` through.
+#[tokio::test]
+async fn provision_for_launch_from_subdirectory_targets_repo_root() {
+    let origin = "https://github.invalid/fixture-owner/optout-repo.git";
+    let registry = registry_with(
+        "https://github.invalid/fixture-owner/optout-repo",
+        Some(false),
+    )
+    .await;
+
+    let repos_root = tempfile::tempdir().unwrap();
+    let base = repos_root.path().join("fixture-owner").join("optout-repo");
+
+    // A real git working tree, with a nested subdirectory to launch from.
+    let live = tempfile::tempdir().unwrap();
+    init_git_repo(live.path());
+    let subdir = live.path().join("crates").join("inner");
+    std::fs::create_dir_all(&subdir).unwrap();
+    // `git rev-parse --show-toplevel` canonicalises symlinks (macOS `/var` →
+    // `/private/var`), so the expectation must be canonical too.
+    let repo_root = live.path().canonicalize().unwrap();
+    let session_id = ManagedSessionId::new();
+
+    let workspace = provision_for_launch(registry.path(), origin, &base, &subdir, &session_id)
+        .await
+        .expect(
+            "#4300: an opted-out project must not attempt a clone at all — a clone \
+             error here means the opt-out was never consulted",
+        );
+
+    assert_eq!(
+        workspace,
+        ManagedWorkspace::MainCheckout(repo_root.clone()),
+        "#4300: `tm launch` from a subdirectory must target the repo ROOT"
+    );
+    assert_ne!(
+        workspace.path(),
+        subdir.as_path(),
+        "#4300: the subdirectory must NEVER become the deploy target"
+    );
+    assert!(
+        !subdir.join(".claude").exists(),
+        "nothing may be provisioned inside the subdirectory: {}",
+        subdir.display()
+    );
+    assert_nothing_provisioned(&base);
+}
+
 /// A project with NO `worktree` key still gets a worktree — the `unwrap_or(true)`
 /// default must not regress.
 ///
@@ -205,11 +285,14 @@ async fn provision_for_launch_opted_out_creates_no_clone_and_no_worktree() {
 /// Test: itself.
 #[tokio::test]
 async fn provision_for_launch_unset_creates_worktree() {
-    let origin = "https://github.com/bobmatnyc/trusty-tools";
-    let registry = registry_with("https://github.com/bobmatnyc/trusty-tools", None).await;
+    let origin = "https://github.invalid/fixture-owner/isolated-repo";
+    let registry = registry_with("https://github.invalid/fixture-owner/isolated-repo", None).await;
 
     let repos_root = tempfile::tempdir().unwrap();
-    let base = repos_root.path().join("bobmatnyc").join("trusty-tools");
+    let base = repos_root
+        .path()
+        .join("fixture-owner")
+        .join("isolated-repo");
     init_git_repo(&base);
     let live = tempfile::tempdir().unwrap();
     let session_id = ManagedSessionId::new();
@@ -241,11 +324,18 @@ async fn provision_for_launch_unset_creates_worktree() {
 /// Test: itself.
 #[tokio::test]
 async fn provision_for_launch_unregistered_origin_creates_worktree() {
-    let registry = registry_with("https://github.com/bobmatnyc/writing", Some(false)).await;
+    let registry = registry_with(
+        "https://github.invalid/fixture-owner/optout-repo",
+        Some(false),
+    )
+    .await;
 
-    let origin = "https://github.com/acme/unregistered";
+    let origin = "https://github.invalid/fixture-owner/never-registered";
     let repos_root = tempfile::tempdir().unwrap();
-    let base = repos_root.path().join("acme").join("unregistered");
+    let base = repos_root
+        .path()
+        .join("fixture-owner")
+        .join("never-registered");
     init_git_repo(&base);
     let live = tempfile::tempdir().unwrap();
     let session_id = ManagedSessionId::new();
@@ -282,8 +372,12 @@ async fn provision_for_launch_unregistered_origin_creates_worktree() {
 #[tokio::test]
 #[serial_test::serial]
 async fn provision_for_fallback_opted_out_creates_no_clone_and_no_worktree() {
-    let origin = "https://github.com/bob-duetto/cto.git";
-    let registry = registry_with("https://github.com/bob-duetto/cto", Some(false)).await;
+    let origin = "https://github.invalid/fixture-owner/fallback-repo.git";
+    let registry = registry_with(
+        "https://github.invalid/fixture-owner/fallback-repo",
+        Some(false),
+    )
+    .await;
 
     let repos_root = tempfile::tempdir().unwrap();
     let _guard = ReposRootGuard::set(repos_root.path());
@@ -292,14 +386,22 @@ async fn provision_for_fallback_opted_out_creates_no_clone_and_no_worktree() {
 
     let workspace = provision_for_fallback(registry.path(), origin, git_root.path(), &session_id)
         .await
-        .unwrap();
+        .expect(
+            "#4300: an opted-out project must not attempt a clone at all — a clone \
+             error here means the opt-out was never consulted",
+        );
 
     assert_eq!(
         workspace,
         ManagedWorkspace::MainCheckout(git_root.path().to_path_buf()),
         "#4300: the daemon-unreachable fallback must launch in the repo root"
     );
-    assert_nothing_provisioned(&repos_root.path().join("bob-duetto").join("cto"));
+    assert_nothing_provisioned(
+        &repos_root
+            .path()
+            .join("fixture-owner")
+            .join("fallback-repo"),
+    );
     assert_eq!(
         std::fs::read_dir(repos_root.path()).unwrap().count(),
         0,
@@ -320,12 +422,15 @@ async fn provision_for_fallback_opted_out_creates_no_clone_and_no_worktree() {
 #[tokio::test]
 #[serial_test::serial]
 async fn provision_for_fallback_unset_creates_worktree_not_live_checkout() {
-    let origin = "https://github.com/bob-duetto/cto.git";
-    let registry = registry_with("https://github.com/bob-duetto/cto", None).await;
+    let origin = "https://github.invalid/fixture-owner/fallback-repo.git";
+    let registry = registry_with("https://github.invalid/fixture-owner/fallback-repo", None).await;
 
     let repos_root = tempfile::tempdir().unwrap();
     let _guard = ReposRootGuard::set(repos_root.path());
-    let base = repos_root.path().join("bob-duetto").join("cto");
+    let base = repos_root
+        .path()
+        .join("fixture-owner")
+        .join("fallback-repo");
     init_git_repo(&base);
     let git_root = tempfile::tempdir().unwrap();
     let session_id = ManagedSessionId::new();
@@ -363,18 +468,25 @@ async fn provision_for_fallback_unset_creates_worktree_not_live_checkout() {
 #[tokio::test]
 #[serial_test::serial]
 async fn provision_for_fallback_other_projects_optout_does_not_leak() {
-    let registry = registry_with("https://github.com/bobmatnyc/writing", Some(false)).await;
+    let registry = registry_with(
+        "https://github.invalid/fixture-owner/optout-repo",
+        Some(false),
+    )
+    .await;
 
     let repos_root = tempfile::tempdir().unwrap();
     let _guard = ReposRootGuard::set(repos_root.path());
-    let base = repos_root.path().join("bob-duetto").join("cto");
+    let base = repos_root
+        .path()
+        .join("fixture-owner")
+        .join("fallback-repo");
     init_git_repo(&base);
     let git_root = tempfile::tempdir().unwrap();
     let session_id = ManagedSessionId::new();
 
     let workspace = provision_for_fallback(
         registry.path(),
-        "https://github.com/bob-duetto/cto.git",
+        "https://github.invalid/fixture-owner/fallback-repo.git",
         git_root.path(),
         &session_id,
     )

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -34,6 +34,7 @@ pub(crate) mod launchd_probe;
 pub(crate) mod managed;
 pub(crate) mod managed_root;
 pub(crate) mod managed_route;
+pub(crate) mod managed_workspace;
 pub(crate) mod manager;
 pub(crate) mod mcp;
 pub(crate) mod meta;

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_b_tests.rs
@@ -1543,7 +1543,7 @@ async fn guided_fallback_blocks_github_git_from_subdirectory() {
     );
 }
 
-/// Why (#1724 success path): proves that when `redirect_to_managed_clone` succeeds
+/// Why (#1724 success path): proves that when `launch_protected_workspace` succeeds
 /// (base clone exists as a real git repo so `create_session_worktree` can create a
 /// worktree), `launch()` is called with `Some(worktree)` — not `None` — so
 /// framework files go to the worktree, never to the live checkout.

--- a/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
@@ -10,11 +10,14 @@
 //! only caller) can route to them; the shared spawn helpers they reuse
 //! (`write_task_md`/`prepare_inproject_session`/`front_gate_or_escalate`/
 //! `resolve_gh_env`) stay owned by `lifecycle` and are called back into.
-//! What: [`worktree_enabled_for_origin`] (registry-keyed isolation decision),
-//! [`has_concurrent_main_checkout_session`] (pure collision detector), and
-//! [`spawn_managed_on_main`] (the no-worktree spawn flow).
-//! Test: `worktree_enabled_for_origin_*`,
-//! `spawn_managed_on_main_creates_record_without_worktree`, and
+//! What: [`has_concurrent_main_checkout_session`] (pure collision detector)
+//! and [`spawn_managed_on_main`] (the no-worktree spawn flow). The registry
+//! lookup that DECIDES whether isolation is on used to live here too, as a
+//! `pub(super)` `worktree_enabled_for_origin`; #4300 moved it to
+//! [`crate::project::worktree_policy`] because the `tm` CLI provisions
+//! worktrees in its OWN process and could not reach a `daemon::`-scoped
+//! function — the daemon now calls the shared one.
+//! Test: `spawn_managed_on_main_creates_record_without_worktree` and
 //! `spawn_managed_on_main_warns_on_concurrent_main_checkout_session` in
 //! `lifecycle_tests.rs` (this module's tests live with `lifecycle`'s, since
 //! the opt-out is a branch of the same spawn surface).
@@ -28,35 +31,8 @@ use super::lifecycle::{
     SpawnParams, front_gate_or_escalate, prepare_inproject_session, resolve_gh_env, write_task_md,
 };
 use crate::daemon::state::DaemonState;
-use crate::project::ProjectRegistry;
 use crate::runtime::RuntimeKind;
 use crate::session_manager::{ManagedSessionId, ManagedSessionState, SessionRecord};
-
-/// Resolve whether per-session worktree isolation is enabled for the
-/// registered project whose `repo_url` matches `origin` (#3455).
-///
-/// Why: mirrors `core::gh_account::find_pinned_gh_account` — the registry
-/// (not the static `config.yaml`, which only ever SEEDS the registry via
-/// `seed_from_config`) is the source of truth consulted at spawn time, keyed
-/// by `repo_url` identity so lookup works regardless of the registry's
-/// `name` key or how the project got registered (explicit `tm projects
-/// register`, config-seeded, or auto-registered from session history).
-/// What: `true` (worktree isolation ON, the default — no regression) when no
-/// registered project matches `origin`, the registry is unreachable, or the
-/// matched project's `worktree` field is unset/`Some(true)`; `false` only
-/// when a matched project has `worktree == Some(false)`.
-/// Test: `worktree_enabled_for_origin_defaults_true_when_unregistered`,
-/// `worktree_enabled_for_origin_honors_registered_false`.
-pub(super) async fn worktree_enabled_for_origin(registry: &ProjectRegistry, origin: &str) -> bool {
-    let Ok(projects) = registry.list().await else {
-        return true;
-    };
-    projects
-        .iter()
-        .find(|p| crate::project::record::repo_url_matches(&p.repo_url, origin))
-        .map(|p| p.worktree_enabled())
-        .unwrap_or(true)
-}
 
 /// Return the FIRST already-`Active` session whose cwd is EXACTLY
 /// `local_path`, if any (#3455 collision detector).

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -374,7 +374,7 @@ async fn spawn_managed_routed(
             && let Some(gh) = trusty_common::github_path::parse_github_path(&origin_url)
         {
             let registry = state.project_registry().await;
-            if !super::launch_on_main::worktree_enabled_for_origin(&registry, &origin_url).await {
+            if !crate::project::worktree_enabled_for_origin(&registry, &origin_url).await {
                 info!(
                     id = %session_id,
                     path = %local_path.display(),

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
@@ -682,67 +682,12 @@ fn ensure_deployment_complete_does_not_abort_when_no_carrier_reachable() {
 // `launch_on_main` module (500-SLOC cap on `lifecycle.rs`); their tests stay
 // here with the rest of the spawn-surface tests and reach them via the
 // managed_routes-scoped `pub(super)` path.
-use super::super::launch_on_main::{
-    has_concurrent_main_checkout_session, spawn_managed_on_main, worktree_enabled_for_origin,
-};
-
-/// A project with no registry entry (or no `worktree` field set) defaults to
-/// worktree isolation ON — the no-regression default #3455 requires.
-/// Test: itself.
-#[tokio::test]
-async fn worktree_enabled_for_origin_defaults_true_when_unregistered() {
-    let data_root = tempfile::TempDir::new().expect("tmp data root");
-    let state = crate::daemon::state::DaemonState::with_root_isolated_managed(
-        data_root.path().to_path_buf(),
-    )
-    .await;
-    let registry = state.project_registry().await;
-
-    assert!(
-        worktree_enabled_for_origin(&registry, "https://github.com/acme/unregistered").await,
-        "an unregistered repo must default to worktree isolation ON"
-    );
-}
-
-/// A registered project with `worktree: Some(false)` disables isolation for
-/// its own `repo_url` only — a DIFFERENT repo is unaffected (#3455).
-/// Test: itself.
-#[tokio::test]
-async fn worktree_enabled_for_origin_honors_registered_false() {
-    let data_root = tempfile::TempDir::new().expect("tmp data root");
-    let state = crate::daemon::state::DaemonState::with_root_isolated_managed(
-        data_root.path().to_path_buf(),
-    )
-    .await;
-    let registry = state.project_registry().await;
-
-    registry
-        .register(crate::project::Project {
-            name: "writing".into(),
-            repo_url: "https://github.com/bobmatnyc/writing".into(),
-            default_branch: "main".into(),
-            stack_hint: None,
-            tags: vec![],
-            description: None,
-            gh_user: None,
-            gh_account: None,
-            github: None,
-            commit_name: None,
-            commit_email: None,
-            worktree: Some(false),
-        })
-        .await
-        .expect("register writing project");
-
-    assert!(
-        !worktree_enabled_for_origin(&registry, "https://github.com/bobmatnyc/writing.git").await,
-        "the registered project's opt-out must be honored (repo_url matching tolerates .git suffix)"
-    );
-    assert!(
-        worktree_enabled_for_origin(&registry, "https://github.com/bobmatnyc/trusty-tools").await,
-        "a DIFFERENT repo must be unaffected by another project's opt-out"
-    );
-}
+//
+// #4300 moved the registry-keyed `worktree_enabled_for_origin` decision (and
+// its two tests) out to `crate::project::worktree_policy`, so the CLI paths
+// that provision worktrees in their own process can consult the SAME rule;
+// what remains here is the daemon-side spawn surface.
+use super::super::launch_on_main::{has_concurrent_main_checkout_session, spawn_managed_on_main};
 
 /// `spawn_managed_on_main` creates a normal `Active` session record rooted
 /// DIRECTLY at `local_path` — no worktree, no clone, `workspace_owned =

--- a/crates/trusty-mpm/src/daemon/state/core.rs
+++ b/crates/trusty-mpm/src/daemon/state/core.rs
@@ -888,7 +888,10 @@ impl DaemonState {
         let sm = self.session_manager().await;
         self.project_registry
             .get_or_init(|| async {
-                let data_dir = self.framework_root.join("project-registry");
+                // #4300: one shared helper names this directory so the
+                // out-of-process `tm` CLI reader can never point at a
+                // different file than the daemon writes.
+                let data_dir = crate::project::registry_data_dir_under(&self.framework_root);
                 let registry = match crate::project::ProjectRegistry::load(&data_dir).await {
                     Ok(r) => r,
                     Err(e) => {

--- a/crates/trusty-mpm/src/project/mod.rs
+++ b/crates/trusty-mpm/src/project/mod.rs
@@ -12,6 +12,8 @@
 //! - `store`  — [`ProjectStore`] on-disk JSON persistence.
 //! - `registry` — [`ProjectRegistry`] lifecycle manager.
 //! - `resolver` — NL→project resolver, session↔project binding, fleet grouping.
+//! - `worktree_policy` — the registry-keyed `worktree` opt-out decision
+//!   (#3455), shared by the daemon and the out-of-process `tm` CLI (#4300).
 //! Test: each submodule carries inline unit tests; run with
 //! `cargo test -p trusty-mpm`.
 
@@ -19,6 +21,7 @@ pub mod record;
 pub mod registry;
 pub mod resolver;
 pub mod store;
+pub mod worktree_policy;
 
 pub use record::{Project, derive_name_from_url};
 pub use registry::ProjectRegistry;
@@ -27,3 +30,7 @@ pub use resolver::{
     ResolutionReason, ResolverError, fleet_by_project, resolve_project, resolve_session_project,
 };
 pub use store::ProjectStoreError;
+pub use worktree_policy::{
+    registry_data_dir, registry_data_dir_under, worktree_enabled_for_origin,
+    worktree_enabled_for_origin_at, worktree_enabled_in,
+};

--- a/crates/trusty-mpm/src/project/worktree_policy.rs
+++ b/crates/trusty-mpm/src/project/worktree_policy.rs
@@ -1,0 +1,139 @@
+//! The registry-keyed per-project worktree-isolation decision (#3455, #4300).
+//!
+//! Why: `Project::worktree` is a property of the PROJECT RECORD, so the
+//! question "does this origin get a per-session worktree?" belongs next to
+//! the record — not inside the daemon's spawn route, where #3455 first put it
+//! (`daemon::managed_routes::launch_on_main::worktree_enabled_for_origin`,
+//! `pub(super)`-scoped to `daemon::managed_routes`). That scoping was correct
+//! while the daemon was the only decision point; #4300 proved it was not —
+//! `tm launch` and the daemon-unreachable bare-`tm` fallback both provision
+//! worktrees IN THE CLI PROCESS, could not reach the check, and silently
+//! ignored the opt-out. Hoisting the decision here (rather than merely
+//! relaxing the daemon module's visibility) keeps the CLI from reaching into
+//! `daemon::` for what is a registry query, and gives the out-of-process
+//! callers a supported entry point that reads the same `projects.json` the
+//! daemon does.
+//! What: [`worktree_enabled_in`] is the pure core (a matched project's
+//! [`Project::worktree_enabled`], else the `true` default);
+//! [`worktree_enabled_for_origin`] is the in-process form used by the daemon,
+//! which already holds a live [`ProjectRegistry`];
+//! [`worktree_enabled_for_origin_at`] is the out-of-process form used by the
+//! `tm` CLI, which has no daemon state and loads the registry from disk;
+//! [`registry_data_dir_under`]/[`registry_data_dir`] name the on-disk
+//! directory ONCE so the daemon and the CLI can never read different files.
+//! Every fallible step resolves to `true` (isolation ON, the pre-#3455
+//! behaviour) so an unreadable registry can never silently strip a project of
+//! its worktrees.
+//! Test: `worktree_enabled_for_origin_defaults_true_when_unregistered`,
+//! `worktree_enabled_for_origin_honors_registered_false`,
+//! `worktree_enabled_at_reads_registry_from_disk`,
+//! `worktree_enabled_at_defaults_true_when_registry_absent`,
+//! `registry_data_dir_under_matches_daemon_layout` in `worktree_policy_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use super::record::{Project, repo_url_matches};
+use super::registry::ProjectRegistry;
+
+/// Directory name, under the framework root, holding `projects.json`.
+///
+/// Why: the daemon (`DaemonState::project_registry`) and the CLI
+/// (`registry_data_dir`) must agree on this byte-for-byte; a divergence would
+/// make the CLI read an empty registry and silently answer `true` for every
+/// project — re-opening #4300 without any test noticing.
+/// What: `"project-registry"`.
+/// Test: `registry_data_dir_under_matches_daemon_layout`.
+pub const REGISTRY_DIR_NAME: &str = "project-registry";
+
+/// Resolve the project-registry data directory under an explicit framework root.
+///
+/// Why: the daemon holds its framework root as state and must not re-derive it
+/// from `$HOME`; taking it as a parameter keeps [`registry_data_dir`] (the
+/// `$HOME`-derived CLI form) a thin wrapper rather than a second source of
+/// truth.
+/// What: `<framework_root>/project-registry`.
+/// Test: `registry_data_dir_under_matches_daemon_layout`.
+pub fn registry_data_dir_under(framework_root: &Path) -> PathBuf {
+    framework_root.join(REGISTRY_DIR_NAME)
+}
+
+/// Resolve the project-registry data directory for a process with no daemon state.
+///
+/// Why: `tm launch` and the daemon-unreachable guided fallback run entirely in
+/// the CLI process and still must honour the opt-out (#4300). They have no
+/// `DaemonState`, so they resolve the same framework root the daemon would.
+/// What: `FrameworkPaths::default().root` joined with [`REGISTRY_DIR_NAME`].
+/// Test: `registry_data_dir_under_matches_daemon_layout` pins the join; the
+/// `$HOME`-derived root itself is covered by `core::paths`' own tests.
+pub fn registry_data_dir() -> PathBuf {
+    registry_data_dir_under(&crate::core::paths::FrameworkPaths::default().root)
+}
+
+/// Pure core: is worktree isolation enabled for `origin` given `projects`?
+///
+/// Why: isolating the matching rule from all I/O makes the two defaults that
+/// matter — "no match ⇒ `true`" and "match ⇒ [`Project::worktree_enabled`]" —
+/// directly assertable, and lets both the daemon and the CLI share one
+/// definition of "the same project".
+/// What: finds the first project whose `repo_url` matches `origin` under
+/// [`repo_url_matches`] (which normalises SSH vs HTTPS and a `.git` suffix via
+/// `parse_github_path`) and returns its `worktree_enabled()`; returns `true`
+/// when nothing matches.
+/// Test: `worktree_enabled_in_defaults_true`, `worktree_enabled_in_honors_false`,
+/// `worktree_enabled_in_matches_ssh_form`.
+pub fn worktree_enabled_in(projects: &[Project], origin: &str) -> bool {
+    projects
+        .iter()
+        .find(|p| repo_url_matches(&p.repo_url, origin))
+        .map(|p| p.worktree_enabled())
+        .unwrap_or(true)
+}
+
+/// Resolve worktree isolation for `origin` against a live in-process registry.
+///
+/// Why: the daemon already holds a `ProjectRegistry`; re-loading it from disk
+/// per spawn would drop the shared reload/lock discipline `ProjectStore`
+/// provides.
+/// What: delegates to [`worktree_enabled_in`] over `registry.list()`, treating
+/// an unreadable registry as `true` (isolation ON — no regression).
+/// Test: `worktree_enabled_for_origin_defaults_true_when_unregistered`,
+/// `worktree_enabled_for_origin_honors_registered_false`.
+pub async fn worktree_enabled_for_origin(registry: &ProjectRegistry, origin: &str) -> bool {
+    let Ok(projects) = registry.list().await else {
+        return true;
+    };
+    worktree_enabled_in(&projects, origin)
+}
+
+/// Resolve worktree isolation for `origin` by reading `projects.json` directly.
+///
+/// Why (#4300): the `tm` CLI provisions worktrees in its own process — `tm
+/// launch` never asks the daemon at all, and the guided fallback runs
+/// precisely BECAUSE the daemon is unreachable — so neither can be served by
+/// [`worktree_enabled_for_origin`]. `ProjectStore` is explicitly designed for
+/// multi-process readers (see its module `Concurrency` note), so an
+/// out-of-process read is the supported way in, not a workaround.
+/// What: loads a [`ProjectRegistry`] from `registry_dir` and delegates to
+/// [`worktree_enabled_for_origin`]; a registry that fails to load (absent,
+/// unreadable, malformed) resolves to `true` — an unreadable registry must
+/// never strip a project of the isolation it had before #3455.
+/// Test: `worktree_enabled_at_reads_registry_from_disk`,
+/// `worktree_enabled_at_defaults_true_when_registry_absent`,
+/// `worktree_enabled_at_defaults_true_on_malformed_registry`.
+pub async fn worktree_enabled_for_origin_at(registry_dir: &Path, origin: &str) -> bool {
+    match ProjectRegistry::load(registry_dir).await {
+        Ok(registry) => worktree_enabled_for_origin(&registry, origin).await,
+        Err(e) => {
+            tracing::warn!(
+                dir = %registry_dir.display(),
+                "worktree opt-out: project registry unreadable ({e}); \
+                 defaulting to worktree isolation ON"
+            );
+            true
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "worktree_policy_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/project/worktree_policy.rs
+++ b/crates/trusty-mpm/src/project/worktree_policy.rs
@@ -28,7 +28,7 @@
 //! `worktree_enabled_for_origin_honors_registered_false`,
 //! `worktree_enabled_at_reads_registry_from_disk`,
 //! `worktree_enabled_at_defaults_true_when_registry_absent`,
-//! `registry_data_dir_under_matches_daemon_layout` in `worktree_policy_tests.rs`.
+//! `registry_dir_name_is_frozen` in `worktree_policy_tests.rs`.
 
 use std::path::{Path, PathBuf};
 
@@ -42,7 +42,7 @@ use super::registry::ProjectRegistry;
 /// make the CLI read an empty registry and silently answer `true` for every
 /// project — re-opening #4300 without any test noticing.
 /// What: `"project-registry"`.
-/// Test: `registry_data_dir_under_matches_daemon_layout`.
+/// Test: `registry_dir_name_is_frozen`.
 pub const REGISTRY_DIR_NAME: &str = "project-registry";
 
 /// Resolve the project-registry data directory under an explicit framework root.
@@ -52,7 +52,7 @@ pub const REGISTRY_DIR_NAME: &str = "project-registry";
 /// `$HOME`-derived CLI form) a thin wrapper rather than a second source of
 /// truth.
 /// What: `<framework_root>/project-registry`.
-/// Test: `registry_data_dir_under_matches_daemon_layout`.
+/// Test: `registry_dir_name_is_frozen`.
 pub fn registry_data_dir_under(framework_root: &Path) -> PathBuf {
     framework_root.join(REGISTRY_DIR_NAME)
 }
@@ -63,7 +63,7 @@ pub fn registry_data_dir_under(framework_root: &Path) -> PathBuf {
 /// the CLI process and still must honour the opt-out (#4300). They have no
 /// `DaemonState`, so they resolve the same framework root the daemon would.
 /// What: `FrameworkPaths::default().root` joined with [`REGISTRY_DIR_NAME`].
-/// Test: `registry_data_dir_under_matches_daemon_layout` pins the join; the
+/// Test: `registry_dir_name_is_frozen` pins the directory name; the
 /// `$HOME`-derived root itself is covered by `core::paths`' own tests.
 pub fn registry_data_dir() -> PathBuf {
     registry_data_dir_under(&crate::core::paths::FrameworkPaths::default().root)

--- a/crates/trusty-mpm/src/project/worktree_policy_tests.rs
+++ b/crates/trusty-mpm/src/project/worktree_policy_tests.rs
@@ -231,21 +231,36 @@ async fn worktree_enabled_at_defaults_true_on_malformed_registry() {
     );
 }
 
-/// The CLI and the daemon must derive the SAME registry directory from a
-/// framework root — a divergence here would make the CLI read an empty
-/// registry and answer `true` for every project, silently re-opening #4300.
+/// Freeze the on-disk directory name `projects.json` lives in.
+///
+/// Why: this is a COMPATIBILITY pin, not a divergence check. Renaming
+/// `project-registry` orphans every existing `~/.trusty-mpm/project-registry/
+/// projects.json` — 33 registered projects on the maintainer's machine —
+/// which would present as "every project silently forgot its settings",
+/// including its `worktree` opt-out.
+/// What it does NOT pin (stated plainly rather than implied): that the daemon
+/// and the CLI agree on the path. An earlier revision asserted
+/// `registry_data_dir_under(root) == root.join(REGISTRY_DIR_NAME)`, which is a
+/// tautology — it restates the one-line function body. Agreement is instead
+/// STRUCTURAL: `DaemonState::project_registry` and `registry_data_dir` both
+/// call `registry_data_dir_under`, so there is no second copy of the join to
+/// drift. The function is the protection; this test only guards the literal.
 /// Test: itself.
 #[test]
-fn registry_data_dir_under_matches_daemon_layout() {
-    let root = Path::new("/tmp/tm-test-framework-root/.trusty-mpm");
-    assert_eq!(
-        registry_data_dir_under(root),
-        root.join(REGISTRY_DIR_NAME),
-        "registry dir must be <framework_root>/{REGISTRY_DIR_NAME}"
-    );
+fn registry_dir_name_is_frozen() {
     assert_eq!(
         REGISTRY_DIR_NAME, "project-registry",
-        "the directory name is the daemon's on-disk layout — changing it \
-         orphans every existing projects.json"
+        "renaming this orphans every existing projects.json on disk"
+    );
+    // The literal must also be what a caller actually lands on — a path
+    // component, not a nested or absolute path that would escape the root.
+    let root = Path::new("/tmp/tm-test-framework-root/.trusty-mpm");
+    let resolved = registry_data_dir_under(root);
+    assert_eq!(
+        resolved.strip_prefix(root).ok(),
+        Some(Path::new("project-registry")),
+        "the registry dir must be a single component directly under the \
+         framework root, got {}",
+        resolved.display()
     );
 }

--- a/crates/trusty-mpm/src/project/worktree_policy_tests.rs
+++ b/crates/trusty-mpm/src/project/worktree_policy_tests.rs
@@ -1,0 +1,251 @@
+//! Unit tests for the registry-keyed worktree-isolation decision (#3455, #4300).
+//!
+//! Why: these pin the two defaults the whole opt-out rests on — an unmatched
+//! origin resolves to `true` (no regression for the 31 of 33 registered
+//! projects that carry no `worktree` key) and a matched `worktree: false`
+//! resolves to `false` — plus the out-of-process (`_at`) reader the CLI paths
+//! added by #4300 depend on.
+//! What: pure-core cases against [`super::worktree_enabled_in`], live-registry
+//! cases against [`super::worktree_enabled_for_origin`], and on-disk cases
+//! against [`super::worktree_enabled_for_origin_at`].
+//! Test: this file.
+
+use std::path::Path;
+
+use super::{
+    REGISTRY_DIR_NAME, registry_data_dir_under, worktree_enabled_for_origin,
+    worktree_enabled_for_origin_at, worktree_enabled_in,
+};
+use crate::project::{Project, ProjectRegistry};
+
+/// Build a `Project` with only the fields these tests care about.
+///
+/// Why: `Project` has eleven fields and no `Default`; spelling them out in
+/// every test would bury the two that matter (`repo_url`, `worktree`).
+/// What: a project named `name` at `repo_url` with the given opt-out value.
+/// Test: used by every test below.
+fn project(name: &str, repo_url: &str, worktree: Option<bool>) -> Project {
+    Project {
+        name: name.into(),
+        repo_url: repo_url.into(),
+        default_branch: "main".into(),
+        stack_hint: None,
+        tags: vec![],
+        description: None,
+        gh_user: None,
+        gh_account: None,
+        github: None,
+        commit_name: None,
+        commit_email: None,
+        worktree,
+    }
+}
+
+/// An origin that matches no registered project keeps worktree isolation ON.
+/// Test: itself.
+#[test]
+fn worktree_enabled_in_defaults_true() {
+    let projects = vec![project(
+        "writing",
+        "https://github.com/bobmatnyc/writing",
+        Some(false),
+    )];
+    assert!(
+        worktree_enabled_in(&projects, "https://github.com/acme/unregistered"),
+        "an unmatched origin must default to worktree isolation ON"
+    );
+    assert!(
+        worktree_enabled_in(&[], "https://github.com/acme/anything"),
+        "an EMPTY registry must default to worktree isolation ON"
+    );
+}
+
+/// A matched project's explicit `worktree` value wins; `None` still means ON.
+/// Test: itself.
+#[test]
+fn worktree_enabled_in_honors_false() {
+    let opted_out = vec![project(
+        "cto",
+        "https://github.com/bob-duetto/cto",
+        Some(false),
+    )];
+    assert!(
+        !worktree_enabled_in(&opted_out, "https://github.com/bob-duetto/cto"),
+        "worktree: false must disable isolation for the matched project"
+    );
+
+    let unset = vec![project("cto", "https://github.com/bob-duetto/cto", None)];
+    assert!(
+        worktree_enabled_in(&unset, "https://github.com/bob-duetto/cto"),
+        "an absent `worktree` key must resolve to ON (unwrap_or(true))"
+    );
+
+    let opted_in = vec![project(
+        "cto",
+        "https://github.com/bob-duetto/cto",
+        Some(true),
+    )];
+    assert!(
+        worktree_enabled_in(&opted_in, "https://github.com/bob-duetto/cto"),
+        "worktree: true must resolve to ON"
+    );
+}
+
+/// Matching goes through `repo_url_matches`, so SSH/HTTPS/`.git` forms of the
+/// SAME repo all resolve to the same answer — and a different repo does not.
+/// Test: itself.
+#[test]
+fn worktree_enabled_in_matches_ssh_form() {
+    let projects = vec![project(
+        "writing",
+        "https://github.com/bobmatnyc/writing",
+        Some(false),
+    )];
+    for origin in [
+        "git@github.com:bobmatnyc/writing.git",
+        "https://github.com/bobmatnyc/writing.git",
+        "https://github.com/BobMatNYC/Writing",
+    ] {
+        assert!(
+            !worktree_enabled_in(&projects, origin),
+            "{origin} must match the registered project's opt-out"
+        );
+    }
+    assert!(
+        worktree_enabled_in(&projects, "https://github.com/bobmatnyc/trusty-tools"),
+        "a DIFFERENT repo must be unaffected by another project's opt-out"
+    );
+}
+
+/// A project with no registry entry defaults to worktree isolation ON — the
+/// no-regression default #3455 requires (moved here from `lifecycle_tests.rs`
+/// when #4300 hoisted the decision out of `daemon::managed_routes`).
+/// Test: itself.
+#[tokio::test]
+async fn worktree_enabled_for_origin_defaults_true_when_unregistered() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+
+    assert!(
+        worktree_enabled_for_origin(&registry, "https://github.com/acme/unregistered").await,
+        "an unregistered repo must default to worktree isolation ON"
+    );
+}
+
+/// A registered project with `worktree: Some(false)` disables isolation for
+/// its own `repo_url` only — a DIFFERENT repo is unaffected (#3455).
+/// Test: itself.
+#[tokio::test]
+async fn worktree_enabled_for_origin_honors_registered_false() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let registry = ProjectRegistry::load(dir.path()).await.expect("load");
+    registry
+        .register(project(
+            "writing",
+            "https://github.com/bobmatnyc/writing",
+            Some(false),
+        ))
+        .await
+        .expect("register writing project");
+
+    assert!(
+        !worktree_enabled_for_origin(&registry, "https://github.com/bobmatnyc/writing.git").await,
+        "the registered project's opt-out must be honored (repo_url matching tolerates .git suffix)"
+    );
+    assert!(
+        worktree_enabled_for_origin(&registry, "https://github.com/bobmatnyc/trusty-tools").await,
+        "a DIFFERENT repo must be unaffected by another project's opt-out"
+    );
+}
+
+/// The out-of-process reader (#4300) sees an opt-out written by ANOTHER
+/// process — the CLI's whole reason for existing on this path.
+/// Test: itself.
+#[tokio::test]
+async fn worktree_enabled_at_reads_registry_from_disk() {
+    let dir = crate::test_support::hermetic_temp_dir();
+
+    // Writer "process": register the opt-out and drop the handle entirely.
+    {
+        let writer = ProjectRegistry::load(dir.path())
+            .await
+            .expect("load writer");
+        writer
+            .register(project(
+                "writing",
+                "https://github.com/bobmatnyc/writing",
+                Some(false),
+            ))
+            .await
+            .expect("register");
+        writer
+            .register(project(
+                "trusty-tools",
+                "https://github.com/bobmatnyc/trusty-tools",
+                None,
+            ))
+            .await
+            .expect("register");
+    }
+
+    assert!(
+        !worktree_enabled_for_origin_at(dir.path(), "git@github.com:bobmatnyc/writing.git").await,
+        "a reader with no daemon state must see the on-disk opt-out"
+    );
+    assert!(
+        worktree_enabled_for_origin_at(dir.path(), "https://github.com/bobmatnyc/trusty-tools")
+            .await,
+        "a project with no `worktree` key must still resolve to ON"
+    );
+}
+
+/// An absent registry directory is the fresh-install case: isolation stays ON.
+/// Test: itself.
+#[tokio::test]
+async fn worktree_enabled_at_defaults_true_when_registry_absent() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let missing = dir.path().join("does-not-exist");
+    assert!(
+        !missing.exists(),
+        "fixture precondition: {} must not exist",
+        missing.display()
+    );
+
+    assert!(
+        worktree_enabled_for_origin_at(&missing, "https://github.com/bobmatnyc/writing").await,
+        "an absent registry must never disable worktree isolation"
+    );
+}
+
+/// A corrupt `projects.json` must fail SAFE (isolation ON), never silently
+/// strip a project of its worktrees.
+/// Test: itself.
+#[tokio::test]
+async fn worktree_enabled_at_defaults_true_on_malformed_registry() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    std::fs::write(dir.path().join("projects.json"), "{ not json").expect("write malformed");
+
+    assert!(
+        worktree_enabled_for_origin_at(dir.path(), "https://github.com/bobmatnyc/writing").await,
+        "a malformed registry must default to worktree isolation ON"
+    );
+}
+
+/// The CLI and the daemon must derive the SAME registry directory from a
+/// framework root — a divergence here would make the CLI read an empty
+/// registry and answer `true` for every project, silently re-opening #4300.
+/// Test: itself.
+#[test]
+fn registry_data_dir_under_matches_daemon_layout() {
+    let root = Path::new("/tmp/tm-test-framework-root/.trusty-mpm");
+    assert_eq!(
+        registry_data_dir_under(root),
+        root.join(REGISTRY_DIR_NAME),
+        "registry dir must be <framework_root>/{REGISTRY_DIR_NAME}"
+    );
+    assert_eq!(
+        REGISTRY_DIR_NAME, "project-registry",
+        "the directory name is the daemon's on-disk layout — changing it \
+         orphans every existing projects.json"
+    );
+}


### PR DESCRIPTION
## The defect

PR #3781 (issue #3455) added a per-project worktree opt-out (`Project.worktree: Option<bool>`) and consulted it at exactly **one** decision point — inside the daemon's spawn route, deliberately ahead of `try_inproject_spawn` so an opted-out project gets neither a worktree nor a base clone.

Two `tm` entry points provision worktrees **entirely in the CLI process** and never reached that check:

- `bin/tm/commands/launch.rs` — `tm launch` runs `ensure_base_clone` → `create_session_worktree` in-process and never asks the daemon.
- `bin/tm/commands/guided.rs` — `redirect_to_managed_clone`, reached from `fallback_protected`, is the **daemon-unreachable** fallback for bare `tm`; it runs precisely *because* the daemon is down.

Result: `worktree: false` was silently conditional on the daemon being up. Live today for the two registry entries that carry it — `bobmatnyc/writing` and `bob-duetto/cto`.

## The seam I chose, and why not `pub(super)`

The issue suggested relaxing `worktree_enabled_for_origin`'s `pub(super)` visibility. I did not; I **moved the decision** to a new `crate::project::worktree_policy`, and the daemon now calls it too.

`launch_on_main.rs:9`'s module doc states the `pub(super)` scoping is deliberate — "the functions are `pub(super)` so `lifecycle::spawn_managed_routed` (the only caller) can route to them". That premise is exactly what #4300 falsifies: there is now a second and third caller, in a different process. Given that, two options:

1. Widen `daemon::managed_routes::launch_on_main::worktree_enabled_for_origin` to `pub`. This leaves the `tm` CLI reaching into `daemon::` to answer *"what does this project record say?"* — a registry query with no daemon in it — and leaves the module doc's stated rationale false.
2. Put the decision next to the record it reads.

I took (2). `Project::worktree` is a property of the project record, so `project::worktree_policy` owns:

- `worktree_enabled_in(&[Project], origin)` — the pure matching core, so the two defaults that matter are directly assertable;
- `worktree_enabled_for_origin(&ProjectRegistry, origin)` — the in-process form the daemon already had;
- `worktree_enabled_for_origin_at(registry_dir, origin)` — the out-of-process form the CLI needs (`ProjectStore`'s module doc already declares multi-process readers a supported pattern, so this is the front door, not a workaround);
- `registry_data_dir_under(framework_root)` / `registry_data_dir()` — the directory name in **one** place. Previously `DaemonState::project_registry` hardcoded `"project-registry"`; a CLI-side copy that drifted would read an empty registry and answer `true` for every project, re-opening this bug with nothing failing. `DaemonState` now calls the shared helper.

`launch_on_main` keeps its `pub(super)` scoping for everything that genuinely is daemon spawn surface (`has_concurrent_main_checkout_session`, `spawn_managed_on_main`); its module doc is updated to record why the registry lookup left.

On the CLI side both call sites route through one new `commands::managed_workspace`, whose `provision` reads the opt-out **before** `ensure_base_clone` and returns a two-variant `ManagedWorkspace { Worktree, MainCheckout }` so a caller cannot confuse "the disposable worktree" with "the operator's own checkout". Each entry point reads the registry exactly once and passes the answer down, so the operator-facing notice can never describe an action other than the one taken.

## Behaviour

- Opted out → no clone, no `session/<name>` branch, no worktree; the session runs in the repo root, matching `spawn_managed_on_main`. `workspace_owned` is unaffected: `decommission_with_root` only removes a non-owned path when `is_session_worktree` recognises it as living under `.worktrees/`, which a main checkout never does.
- `unwrap_or(true)` preserved. Unset, unregistered, **and** an unreadable/malformed registry all resolve to worktrees ON — an unreadable registry must never strip isolation.
- Matching goes through `repo_url_matches` unchanged (SSH/HTTPS/`.git`/case).
- The guided fallback now targets the repo **root** rather than `cwd`, so a bare `tm` from a subdirectory of an opted-out project deploys to the project root, not the subdirectory.
- **Concurrency untouched.** #3455's WARN-never-refuse stands; nothing here refuses a launch.

## Red / green

### `tm launch` and the guided fallback, guard neutralised (`if false && !isolate`)

Both opted-out tests go RED — and the revert genuinely reproduced the bug: it cloned `bobmatnyc/writing` over SSH and created a worktree.

```
---- provision_for_launch_opted_out_creates_no_clone_and_no_worktree stdout ----
assertion `left == right` failed: #4300: an opted-out project must launch in its own checkout
  left: Worktree(".../bobmatnyc/writing/.worktrees/4a0f7f0e-685a-41a1-9284-b019f6398195")
 right: MainCheckout("/var/folders/.../.tmplIF1kB")

---- provision_for_fallback_opted_out_creates_no_clone_and_no_worktree stdout ----
assertion `left == right` failed: #4300: the daemon-unreachable fallback must launch in the repo root
  left: Worktree(".../bob-duetto/cto/.worktrees/72cbe05f-5d04-4a71-b44f-a954b317b41d")
 right: MainCheckout("/var/folders/.../.tmpzHHr6O")

test result: FAILED. 4 passed; 2 failed; 0 ignored
```

The four opted-in/unset controls stayed green, as they must — they do not depend on the guard.

### Ordering is load-bearing too (guard moved *after* `ensure_base_clone`)

```
---- provision_for_fallback_opted_out_creates_no_clone_and_no_worktree stdout ----
#4300: base clone dir must NOT be created for an opted-out project: /var/folders/.../.tmpygV26P/bob-duetto/cto
test result: FAILED. 0 passed; 1 failed
```

A check-after-clone still returns the right path — the base-clone assertion is what catches it. This is the ordering the daemon comment calls deliberate.

### Green, fix restored

```
test commands::managed_workspace::tests::provision_for_launch_opted_out_creates_no_clone_and_no_worktree ... ok
test commands::managed_workspace::tests::provision_for_launch_unset_creates_worktree ... ok
test commands::managed_workspace::tests::provision_for_launch_unregistered_origin_creates_worktree ... ok
test commands::managed_workspace::tests::provision_for_fallback_opted_out_creates_no_clone_and_no_worktree ... ok
test commands::managed_workspace::tests::provision_for_fallback_unset_creates_worktree_not_live_checkout ... ok
test commands::managed_workspace::tests::provision_for_fallback_other_projects_optout_does_not_leak ... ok
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 1260 filtered out

test project::worktree_policy::tests::worktree_enabled_in_defaults_true ... ok
test project::worktree_policy::tests::worktree_enabled_in_honors_false ... ok
test project::worktree_policy::tests::worktree_enabled_in_matches_ssh_form ... ok
test project::worktree_policy::tests::worktree_enabled_for_origin_defaults_true_when_unregistered ... ok
test project::worktree_policy::tests::worktree_enabled_for_origin_honors_registered_false ... ok
test project::worktree_policy::tests::worktree_enabled_at_reads_registry_from_disk ... ok
test project::worktree_policy::tests::worktree_enabled_at_defaults_true_when_registry_absent ... ok
test project::worktree_policy::tests::worktree_enabled_at_defaults_true_on_malformed_registry ... ok
test project::worktree_policy::tests::registry_data_dir_under_matches_daemon_layout ... ok
test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 3898 filtered out
```

### Full surface — `cargo test -p trusty-mpm` (no `--lib`)

```
Running unittests src/lib.rs        test result: ok. 3901 passed; 0 failed; 6 ignored
Running unittests src/bin/tm/main.rs test result: ok. 1265 passed; 0 failed; 1 ignored
Running unittests src/bin/tm/main.rs test result: ok. 1265 passed; 0 failed; 1 ignored
... 30 integration targets, all ok ...
Running tests/tm_hook_pm_guard.rs   test result: FAILED. 31 passed; 2 failed
```

Those two `tm_hook_pm_guard` failures are an artifact of **where this worktree lives**, not of this diff. The tests assert `git worktree add .claude/worktrees/wt-x` is *allowed*; the path is relative, `run_pm_guard` sets no `current_dir`, so it resolves against the crate dir — which is under `/private/tmp/claude-502/...`, a path the #3955 guard denies by design. Running the same compiled binary from a cwd outside the scratchpad:

```
test result: ok. 33 passed; 0 failed; 0 ignored
```

CI checks out under `/home/runner/work`, so this will be green there. Nothing in this diff touches `pm_guard`, hooks, or the guard's path list.

One transient: `telegram::supervisor::tests::healthy_run_resets_transient_backoff` failed once under full-suite parallel load (a wall-clock backoff assertion: `21.79ms` vs `~base`), passed 5/5 in isolation and on the next full run. It is structurally load-sensitive and this diff touches nothing under `telegram/`. Flagging it rather than burying it.

`cargo fmt --check`, `cargo clippy --all-targets -D warnings`, and `scripts/check_line_cap.sh` are clean. `guided.rs` drops 484 → 449 SLOC.

## Test-hygiene notes

No `#[ignore]`, no env gate, no early `return`, no skip-when-fixture-missing — a fixture that cannot be built `unwrap`s and fails. Assertions are on specific paths and on the **absence** of the base-clone directory, its `.git`, and its `.worktrees` child, plus an exact-equality assertion on the returned `ManagedWorkspace` variant. Tests live in the bin target, so `--lib` would skip them; the full run above is without `--lib`.

Blast radius: only the three fallback tests touch a process-global (`TRUSTY_MPM_REPOS_ROOT`), and they are `#[serial_test::serial]` with an RAII guard that restores on panic-driven unwind. The `tm launch` tests take `base_path` as a parameter and touch no global at all. Nothing in this file deletes anything — the only filesystem writes are `git init` / `git worktree add` under test-owned `TempDir`s — so a clobbered global can make a test fail, never make it destructive.

## Contradicting the issue's description

The issue says the guided path bails when the URL is unparseable, implying `parse_github_path` is a real gate. It is not: `parse_github_path("not-a-url")` returns `Some(unknown-owner/not-a-url)`, so that `else` arm is effectively dead for non-URL input, and a test I initially wrote against it did a real `git clone not-a-url`. I dropped that test rather than pin dead behaviour. In production the arm is unreachable anyway — `fallback_protected` gates on `is_github_remote` first. Out of scope here; worth a separate look at whether `parse_github_path`'s permissiveness masks bad remotes elsewhere.

Context: #3455, #3781 (not closed by this PR).

Closes #4300

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
