### PR TITLE
fix(trusty-mpm): resume a dead runtime instead of switching into a bare shell (#3873)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -183,6 +183,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   unchanged (unset or unregistered still means worktrees ON, and an unreadable
   registry fails safe to ON), and #3455's warn-never-refuse concurrency
   behaviour is untouched.
+- Bare `tm` now resumes a session whose runtime has died, instead of switching
+  the operator into a bare shell
+  ([#3873](https://github.com/bobmatnyc/trusty-tools/issues/3873)). The picker's
+  resume planner decided "this session is live" from tmux SESSION existence
+  alone, which cannot see the common case where the tmux pane survives but the
+  `claude` inside it exited and the pane fell back to a login shell. That
+  `(active, tmux up)` pair fell through to `Attach`, so the first `tm` did a
+  `switch-client` into an idle shell and nothing else — the operator had to type
+  `tm` a SECOND time, from inside that pane, before a runtime came back.
+  `guided_resume::plan_resume` takes a third input, `runtime_live`, and maps
+  `(active/provisioning, tmux up, runtime dead)` onto the existing
+  `ReconcileThenRestart` recovery (`/runtime-stop` → `/resume` → attach), so the
+  first invocation does the whole job. `runtime_live` is resolved by the new
+  `pane_runtime_live`, which reuses the daemon reaper's own
+  `daemon::runtime_reap::pane_runtime_exited` predicate — same `is_idle_shell`
+  allowlist, same `ProcessTreeProbe` child gate — against a single
+  pane-id-targeted `tmux display-message`, so the CLI and the reaper cannot drift
+  apart and the fix works whether or not the 60s reaper is healthy. Fails OPEN:
+  a record with no `pane_id`, a failed `tmux` call, or an unparseable reply all
+  assume the runtime is live and preserve the previous attach behavior, because a
+  wrong "dead" verdict would kill a live agent's pane. Stopped/Errored records
+  (whose panes are idle shells too) keep taking the plain `Restart` path, and the
+  decommissioned/deleted tombstone refusal still runs first.
 
 - Concurrent `tm` processes no longer lose (or corrupt) `projects.json` entries.
   The project-store upsert was an unsynchronised read-modify-write of the whole

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -216,6 +216,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   non-destructive reconcile (#2023 A) but not for a CLI path that drives a
   session kill.
 
+  Known limitation, deliberately accepted: any-pane-live is also what bounds the
+  fix. A SPLIT session whose agent pane died but which still has some other pane
+  running a non-shell command (a `vim`, a `tail -f`) reads as live, so bare `tm`
+  still attaches into the idle agent pane there. #3873 is fixed for the
+  single-pane case and for splits whose panes are all idle shells, but not for a
+  split with an unrelated live process — narrowing the question back to one pane
+  would require per-pane runtime identity that the stored `pane_id` cannot supply
+  reliably enough to gate a session kill on.
+
   Because that reconcile reaches `SessionManager::stop` →
   `graceful_terminate_runtime` → `kill_session`, which is **session-scoped**, the
   restart now discloses that it is about to destroy the whole tmux session — all

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -196,16 +196,47 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `(active/provisioning, tmux up, runtime dead)` onto the existing
   `ReconcileThenRestart` recovery (`/runtime-stop` → `/resume` → attach), so the
   first invocation does the whole job. `runtime_live` is resolved by the new
-  `pane_runtime_live`, which reuses the daemon reaper's own
-  `daemon::runtime_reap::pane_runtime_exited` predicate — same `is_idle_shell`
-  allowlist, same `ProcessTreeProbe` child gate — against a single
-  pane-id-targeted `tmux display-message`, so the CLI and the reaper cannot drift
-  apart and the fix works whether or not the 60s reaper is healthy. Fails OPEN:
-  a record with no `pane_id`, a failed `tmux` call, or an unparseable reply all
-  assume the runtime is live and preserve the previous attach behavior, because a
-  wrong "dead" verdict would kill a live agent's pane. Stopped/Errored records
+  `session_runtime_live`, which reuses the daemon reaper's own
+  `daemon::runtime_reap::session_has_live_pane` primitive — and through it
+  `pane_runtime_exited`, the same `is_idle_shell` allowlist, and the same
+  `ProcessTreeProbe` child gate — against a session-scoped `tmux list-panes`, so
+  the CLI and the reaper cannot drift apart and the fix works whether or not the
+  60s reaper is healthy.
+
+  The verdict is the ANY-PANE-LIVE question over the whole tmux session, not a
+  check of the record's stored `pane_id`: a managed session can be manually split
+  (#2463), and a session with one idle pane beside a live agent pane must never
+  reach the destructive branch. Fails OPEN throughout — a blank session name, a
+  failed `tmux` call, a listing that cannot be fully parsed, or a listing with no
+  pane attributable to the session all assume the runtime is live and preserve
+  the previous attach behavior. Parsing is strict (exactly three non-empty
+  tab-separated fields with a numeric pid) specifically so a missing or
+  unparseable pid cannot collapse the two-gate check down to `is_idle_shell`
+  alone: `has_live_child(None)` returns `false`, which is right for the daemon's
+  non-destructive reconcile (#2023 A) but not for a CLI path that drives a
+  session kill.
+
+  Because that reconcile reaches `SessionManager::stop` →
+  `graceful_terminate_runtime` → `kill_session`, which is **session-scoped**, the
+  restart now discloses that it is about to destroy the whole tmux session — all
+  windows, panes, and scrollback — whenever tmux is live, matching what the plain
+  `Restart` branch already did for the same situation. Stopped/Errored records
   (whose panes are idle shells too) keep taking the plain `Restart` path, and the
   decommissioned/deleted tombstone refusal still runs first.
+
+  `commands::managed_tests`: `session_resume_headless_active_live_tmux_skips_restart_and_attach`
+  created its scratch tmux session with a bare `tmux new-session -d`, which lands
+  the pane on a login shell — since #3873 that is a DEAD runtime, so the fixture
+  no longer expressed the live-session case the test asserts about. It now runs
+  an explicit long-lived command, and a new counterpart
+  (`session_resume_headless_dead_runtime_reconciles_and_restarts`) drives the
+  dead-runtime shape end-to-end against a real daemon, proving the reconcile
+  actually reaches `/runtime-stop` + `/resume` rather than being a silent no-op.
+  Both wait for the pane's liveness reading to STABILISE (three agreeing probes)
+  before acting: a freshly created pane transiently reports a live child while
+  the shell initialises, which otherwise made both tests depend on the
+  developer's dotfiles. Their tmux names are now process-unique, since the two
+  bin targets can run concurrently and share the machine-global tmux namespace.
 
 - Concurrent `tm` processes no longer lose (or corrupt) `projects.json` entries.
   The project-store upsert was an unsynchronised read-modify-write of the whole

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
@@ -1,4 +1,4 @@
-//! Guided-picker resume/restart flow (#1742, #2001, #3531).
+//! Guided-picker resume/restart flow (#1742, #2001, #3531, #3873).
 //!
 //! Why: resuming a managed session from the bare-`tm` picker must handle every
 //! runtime state without ever exposing a raw tmux failure. A live session is
@@ -8,6 +8,22 @@
 //! stops it (resetting the record to Stopped) then restarts it via the same
 //! path, so the operator does nothing (#2001). Extracted from `guided.rs` to keep
 //! both files under the 500-SLOC production cap.
+//!
+//! #3873: "live session" was originally decided by tmux SESSION existence alone
+//! (`tmux_has_session`), which cannot see the far more common failure the
+//! operator actually hits — the tmux pane is still there, but the `claude`
+//! inside it exited and the pane fell back to a bare login shell. Bare `tm`
+//! therefore picked `Attach` and `switch-client`ed the operator into an idle
+//! shell, doing nothing useful; only a SECOND `tm`, typed from inside that pane
+//! (where the in-place relaunch gate matches), actually brought a runtime back.
+//! [`plan_resume`] now takes a third input, `runtime_live`, and maps
+//! `(active, tmux up, runtime dead)` onto the existing `ReconcileThenRestart`
+//! recovery so the first invocation does the whole job. [`pane_runtime_live`]
+//! resolves that input by reusing the daemon reaper's own
+//! [`trusty_mpm::daemon::runtime_reap::pane_runtime_exited`] predicate against a
+//! single pane-id-targeted `tmux display-message` — the CLI asks the question
+//! itself at resume time, so this fix does NOT depend on the 60s runtime reaper
+//! having already reconciled the record.
 //!
 //! #3531: the zombie/restart classification below MUST run on
 //! [`trusty_mpm::client::ManagedSessionSummary::persisted_state`], never the
@@ -135,21 +151,6 @@ pub(crate) enum ResumeAction {
     Terminal,
 }
 
-/// Decide, purely from `state` and `tmux_live`, how a guided resume should proceed.
-///
-/// Why: single source of truth for the resume branch selection so the zombie
-/// reconcile, the plain restart, and the happy-path attach can never diverge
-/// from what [`is_zombie`]/[`needs_restart`] classify. Pure so it is exhaustively
-/// unit-tested.
-/// What: TERMINAL (`decommissioned`/`deleted`, checked FIRST) → `Terminal`
-/// (refuse); zombie (checked next, since a zombie's state also fails
-/// `needs_restart`) → `ReconcileThenRestart`; Stopped/Errored → `Restart`;
-/// everything else (active/provisioning with a live tmux) → `Attach`. The
-/// terminal check is first so neither the zombie path (would resurrect via
-/// reconcile-restart) nor the Attach path (would attach into a deleted session)
-/// can ever be reached for a tombstone (code-critic CRITICAL).
-/// Test: `guided_resume_plan_*`, `plan_resume_refuses_terminal_states` in
-/// `tests_behavior_c_tests.rs`.
 /// Resolve the state string [`plan_resume`] must classify from a wire
 /// [`trusty_mpm::client::ManagedSessionSummary`] (#3531).
 ///
@@ -173,16 +174,156 @@ pub(crate) fn resume_classification_state(
     session.persisted_state.as_deref().unwrap_or(&session.state)
 }
 
-pub(crate) fn plan_resume(state: &str, tmux_live: bool) -> ResumeAction {
+/// Decide, purely from `state` + `tmux_live` + `runtime_live`, how a guided
+/// resume should proceed.
+///
+/// Why: single source of truth for the resume branch selection so the zombie
+/// reconcile, the plain restart, and the happy-path attach can never diverge
+/// from what [`is_zombie`]/[`needs_restart`] classify. Pure so it is exhaustively
+/// unit-tested.
+///
+/// #3873: `tmux_live` answers "does the tmux SESSION exist?", which is NOT the
+/// same question as "is the agent runtime alive?". A managed session whose inner
+/// `claude` exited leaves the tmux pane alive as a bare login shell, so
+/// `(active, tmux_live = true)` used to fall straight through to `Attach` — bare
+/// `tm` switched the operator into an idle shell and did nothing useful. The
+/// operator then had to type `tm` a SECOND time (now inside that pane, where the
+/// in-place relaunch gate matches) to actually get a runtime back. `runtime_live`
+/// is the missing third input: when the record is active/provisioning, tmux is
+/// up, but the runtime is provably gone, the plan is `ReconcileThenRestart` —
+/// the SAME auto-stop-then-restart recovery the tmux-gone zombie already uses,
+/// so the first invocation does the whole job. See [`pane_runtime_live`] for how
+/// the caller resolves this input (it reuses the daemon reaper's own
+/// [`trusty_mpm::daemon::runtime_reap::pane_runtime_exited`] predicate, so the
+/// CLI and the reaper can never disagree on what "dead runtime" means), and note
+/// that it fails OPEN (`true`) whenever liveness cannot be proven — an
+/// unprovable case keeps the pre-#3873 `Attach` behavior rather than tearing a
+/// pane down on a guess.
+///
+/// What: TERMINAL (`decommissioned`/`deleted`, checked FIRST) → `Terminal`
+/// (refuse); zombie (checked next, since a zombie's state also fails
+/// `needs_restart`) → `ReconcileThenRestart`; Stopped/Errored → `Restart`;
+/// active/provisioning with a live tmux but a DEAD runtime (#3873) →
+/// `ReconcileThenRestart`; everything else (active/provisioning with a live tmux
+/// AND a live runtime) → `Attach`. The terminal check is first so neither the
+/// zombie path (would resurrect via reconcile-restart) nor the Attach path
+/// (would attach into a deleted session) can ever be reached for a tombstone
+/// (code-critic CRITICAL). The `needs_restart` check stays AHEAD of the #3873
+/// gate so a Stopped/Errored record — whose pane is an idle shell too, and would
+/// therefore also report `runtime_live = false` — keeps taking the plain
+/// `Restart` path rather than a pointless `/runtime-stop` round-trip against a
+/// record that is already stopped.
+/// Test: `guided_resume_plan_*`, `plan_resume_refuses_terminal_states` in
+/// `tests_behavior_c_tests.rs`;
+/// `guided_resume_plan_active_live_tmux_dead_runtime_reconciles_then_restarts`
+/// pins the #3873 case specifically.
+pub(crate) fn plan_resume(state: &str, tmux_live: bool, runtime_live: bool) -> ResumeAction {
     if is_terminal_state(state) {
         ResumeAction::Terminal
     } else if is_zombie(state, tmux_live) {
         ResumeAction::ReconcileThenRestart
     } else if needs_restart(state) {
         ResumeAction::Restart
+    } else if !runtime_live {
+        // #3873: active/provisioning, tmux session up, but the runtime inside the
+        // pane is provably gone. Same recovery as the tmux-gone zombie above —
+        // `/runtime-stop` resets the record to Stopped so the daemon's `/resume`
+        // (which only accepts Stopped/Errored) will take it, then attach.
+        ResumeAction::ReconcileThenRestart
     } else {
         ResumeAction::Attach
     }
+}
+
+/// Parse `tmux display-message -p -t <pane> '#{pane_current_command} #{pane_pid}'`
+/// output into the two fields [`pane_runtime_exited`] needs (#3873).
+///
+/// Why: the shell-out itself is untestable without a live tmux server, but the
+/// parse is exactly where a format change or an empty/short reply would silently
+/// mis-answer "is the runtime alive?". Splitting it out keeps that risk on a pure,
+/// unit-tested seam. Deliberately does NOT go through
+/// [`crate::daemon::tmux`]-style `list-panes -a` enumeration: that path is a
+/// whole-server sweep whose composite-key parsing is a known failure mode
+/// (#1813 shape), and a single pane-id-targeted `display-message` needs none of
+/// it — tmux resolves a pane id to exactly one pane or errors.
+/// What: returns `None` when the reply has no command word at all (empty output,
+/// or tmux printed nothing usable) — the caller treats that as "cannot prove
+/// dead". Otherwise returns the command word plus the pane pid, with the pid
+/// `None` when it is missing or not a number (that alone is not evidence of
+/// death; [`crate::daemon::orphan_gc::ChildLivenessProbe`] treats `None` as
+/// "no live child", and the command-word gate still has to agree).
+/// Test: `parse_pane_probe_*` in `tests_behavior_c_tests.rs`.
+pub(crate) fn parse_pane_probe(stdout: &str) -> Option<(String, Option<u32>)> {
+    let line = stdout.lines().next().unwrap_or("").trim();
+    let mut parts = line.split_whitespace();
+    let command = parts.next()?.to_string();
+    let pid = parts.next().and_then(|p| p.parse::<u32>().ok());
+    Some((command, pid))
+}
+
+/// Is the agent runtime inside `pane_id` still alive? (#3873)
+///
+/// Why: `tmux_has_session` proves only that the tmux SESSION exists. When a
+/// managed session's inner `claude` exits, the pane survives as a bare login
+/// shell — so session-existence says "live" while the thing the operator wants
+/// is gone. The daemon's 60s runtime reaper already owns the authoritative
+/// answer to this question in
+/// [`trusty_mpm::daemon::runtime_reap::pane_runtime_exited`]; this function
+/// reuses that exact predicate (and therefore the same `is_idle_shell`
+/// allowlist and the same [`trusty_mpm::daemon::orphan_gc::ProcessTreeProbe`]
+/// belt-and-braces child gate) rather than reimplementing idle-shell detection
+/// in the CLI, so the two can never drift apart. Reusing it also means this fix
+/// works whether or not the reaper is currently healthy: the CLI asks the
+/// question itself, at resume time, instead of waiting for a reaped record.
+/// What: FAILS OPEN — returns `true` (assume live, preserving the pre-#3873
+/// `Attach` behavior) when the record has no `pane_id`, when the `tmux` shell-out
+/// fails or exits non-zero, or when the reply cannot be parsed. Only a positive,
+/// two-gate identification (a recognised bare shell AND no live child under the
+/// pane pid) returns `false`. Failing open matters because `false` now triggers a
+/// `/runtime-stop` that KILLS the pane: a wrong `false` would destroy a live
+/// agent's pane, while a wrong `true` merely reproduces today's already-shipped
+/// behavior.
+/// Test: the pure parse seam is `parse_pane_probe_*`; the fail-open contract for
+/// a missing pane id is `pane_runtime_live_assumes_live_without_pane_id`; the
+/// classification it delegates to is covered by the daemon's own
+/// `pane_runtime_exited_*` tests. The tmux shell-out itself is I/O (a live tmux
+/// server), matching the existing `session_for_pane` / `pane_tty_for` precedent
+/// in `tmux_attach.rs`.
+pub(crate) fn pane_runtime_live(pane_id: Option<&str>) -> bool {
+    let Some(pane_id) = pane_id.map(str::trim).filter(|p| !p.is_empty()) else {
+        return true;
+    };
+    let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
+    let Ok(output) = std::process::Command::new(&tmux_bin)
+        .args([
+            "display-message",
+            "-p",
+            "-t",
+            pane_id,
+            "#{pane_current_command} #{pane_pid}",
+        ])
+        .output()
+    else {
+        return true;
+    };
+    if !output.status.success() {
+        return true;
+    }
+    let Some((command, pane_pid)) = parse_pane_probe(&String::from_utf8_lossy(&output.stdout))
+    else {
+        return true;
+    };
+
+    let pane = trusty_mpm::daemon::orphan_gc::PaneInfo {
+        session_name: String::new(),
+        pane_current_command: command,
+        pane_pid,
+        pane_id: Some(pane_id.to_string()),
+    };
+    !trusty_mpm::daemon::runtime_reap::pane_runtime_exited(
+        &pane,
+        &trusty_mpm::daemon::orphan_gc::ProcessTreeProbe,
+    )
 }
 
 /// Restart (if needed) then attach to a managed session from the guided picker.
@@ -286,7 +427,15 @@ pub(crate) async fn resume_session(
     // the pre-#3531 (imperfect but not regressed) behavior — see
     // `resume_classification_state`.
     let persisted_state = resume_classification_state(session);
-    let action = plan_resume(persisted_state, tmux_live);
+    // #3873: `tmux_live` above proves only that the tmux SESSION exists. Ask the
+    // separate question the operator actually cares about — is the agent runtime
+    // inside the record's pane still there? — before letting an `active` record
+    // fall through to a bare `Attach` that would drop them into an idle shell.
+    // Only worth the shell-out when tmux is up at all; when it is not, `is_zombie`
+    // already classifies the record and `pane_runtime_live` could not answer
+    // anyway (the pane is gone with the session).
+    let runtime_live = !tmux_live || pane_runtime_live(session.pane_id.as_deref());
+    let action = plan_resume(persisted_state, tmux_live, runtime_live);
 
     // Terminal-state refusal (code-critic CRITICAL): a decommissioned/deleted
     // tombstone must never be attached to or restarted — doing either would
@@ -300,17 +449,31 @@ pub(crate) async fn resume_session(
         return Ok(AttachOutcome::Skipped);
     }
 
-    // Zombie auto-reconcile (#2001): the daemon still marks the session
-    // active/provisioning but its tmux pane is gone (e.g. after a reboot). The
-    // daemon's /resume only accepts Stopped/Errored, so first reset the record to
+    // Zombie auto-reconcile (#2001, #3873): the daemon still marks the session
+    // active/provisioning but there is no runtime to attach to — either the whole
+    // tmux session is gone (#2001, e.g. after a reboot) or the pane survived but
+    // its agent process exited, leaving a bare shell (#3873). The daemon's
+    // /resume only accepts Stopped/Errored, so first reset the record to
     // Stopped via /runtime-stop, then fall through into the SAME restart path
     // below. Only bail if the stop itself fails — that is the one remaining case
     // that needs a human.
     if action == ResumeAction::ReconcileThenRestart {
-        eprintln!(
-            "tm: '{}' is marked {} but its tmux pane is gone — reconciling and restarting…",
-            session.name, persisted_state
-        );
+        // #3873: report which of the two shapes this is. The old wording asserted
+        // "its tmux pane is gone", which is now only half the cases — telling an
+        // operator their pane vanished when it is sitting right in front of them
+        // is worse than saying nothing.
+        if tmux_live {
+            eprintln!(
+                "tm: '{}' is marked {} but its runtime has exited (the pane is a \
+                 bare shell) — restarting the runtime…",
+                session.name, persisted_state
+            );
+        } else {
+            eprintln!(
+                "tm: '{}' is marked {} but its tmux pane is gone — reconciling and restarting…",
+                session.name, persisted_state
+            );
+        }
         reconcile_zombie_stop(client, url, session).await?;
     }
 
@@ -324,8 +487,11 @@ pub(crate) async fn resume_session(
         action,
         ResumeAction::Restart | ResumeAction::ReconcileThenRestart
     ) {
-        // Pane-kill disclosure only applies to the plain Restart branch: a zombie
-        // has no live pane (that is what made it a zombie), so skip the notice there.
+        // Pane-kill disclosure only applies to the plain Restart branch. The
+        // reconcile branch already printed its own message above, and its pane is
+        // either gone (#2001) or a bare shell whose runtime already exited
+        // (#3873) — in neither case is there in-progress runtime state left to
+        // warn about losing.
         if action == ResumeAction::Restart {
             if tmux_live {
                 eprintln!(

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
@@ -36,6 +36,20 @@
 //! ANY-pane-live over the whole session, a session with one idle pane and one
 //! live agent pane never reaches the destructive branch at all.
 //!
+//! KNOWN LIMITATION, deliberately accepted (#3873). Any-pane-live is what makes
+//! the destructive branch safe, and it is also what bounds the fix: a SPLIT
+//! session in which the agent pane died but some other pane still runs a
+//! non-shell command (a `vim`, a `tail -f`, a stray `node`) reads as live, so
+//! bare `tm` still `Attach`es the operator into the idle agent pane. #3873 is
+//! therefore fixed for the single-pane case and for splits whose panes are all
+//! idle shells, but NOT for a split with an unrelated live process. That is the
+//! right trade at this altitude — the alternative is per-pane runtime identity
+//! (knowing WHICH pane the agent owned and judging only that one), which the
+//! stored `pane_id` cannot supply reliably enough to gate a `kill_session` on,
+//! since it can be stale or reused. Do not "fix" this by narrowing the question
+//! back to one pane without solving that identity problem first: that is the
+//! regression this design is guarding against, not an oversight.
+//!
 //! #3531: the zombie/restart classification below MUST run on
 //! [`trusty_mpm::client::ManagedSessionSummary::persisted_state`], never the
 //! plain `state` field. #3302 made the list/get endpoints reconcile the
@@ -337,8 +351,9 @@ pub(crate) fn parse_pane_probes(
 /// What: FAILS OPEN — returns `true` (assume live, preserving the pre-#3873
 /// `Attach` behavior) for a blank session name, a `tmux` spawn failure, a
 /// non-zero exit, a listing that cannot be fully parsed
-/// ([`parse_pane_probes`]), or a listing containing no pane attributable to
-/// this session. Only a fully-parsed listing in which EVERY pane is a
+/// ([`parse_pane_probes`]), or a listing [`panes_prove_session_dead`] declines
+/// to convict (no pane attributable to this session, or any pane still live).
+/// Only a fully-parsed listing in which EVERY pane of this session is a
 /// provably-idle shell returns `false`. The asymmetry is deliberate: `false`
 /// now triggers a `/runtime-stop` whose `SessionManager::stop` →
 /// `graceful_terminate_runtime` → `kill_session` destroys the entire tmux
@@ -349,9 +364,9 @@ pub(crate) fn parse_pane_probes(
 /// protection: tmux 3.6b answers an invalid target on some subcommands with
 /// rc=0 and near-empty stdout, so the parse-returned-`None` path is what
 /// actually catches a bad target, and that path IS unit-tested.
-/// Test: the pure parse seam is `parse_pane_probes_*`; the any-pane-live
-/// composition is `session_panes_*`; the blank-name fail-open is
-/// `session_runtime_live_assumes_live_for_blank_session_name`; the
+/// Test: the pure parse seam is `parse_pane_probes_*`; the verdict itself (and
+/// its membership check) is `panes_prove_session_dead_*`; the blank-name
+/// fail-open is `session_runtime_live_assumes_live_for_blank_session_name`; the
 /// classification it delegates to is covered by the daemon's own
 /// `pane_runtime_exited_*` / `session_has_live_pane_*` tests. The tmux
 /// shell-out itself is I/O (a live tmux server), matching the existing
@@ -381,20 +396,52 @@ pub(crate) fn session_runtime_live(session_name: &str) -> bool {
     let Some(panes) = parse_pane_probes(&String::from_utf8_lossy(&output.stdout)) else {
         return true;
     };
-    // Membership guard. `session_has_live_pane` FILTERS by session name and
-    // returns `false` ("no live pane") when nothing matches — correct for the
-    // daemon, which is looking at a whole-server listing where a non-match means
-    // the session is gone, but fail-CLOSED here where `false` is destructive. If
-    // the listing we got back cannot be attributed to the session we asked
-    // about, we have learned nothing and must fail open.
-    if !panes.iter().any(|p| p.session_name == name) {
-        return true;
-    }
-    trusty_mpm::daemon::runtime_reap::session_has_live_pane(
+    !panes_prove_session_dead(
         name,
         &panes,
         &trusty_mpm::daemon::orphan_gc::ProcessTreeProbe,
     )
+}
+
+/// Do `panes` POSITIVELY prove that `session_name`'s runtime is gone? (#3873)
+///
+/// Why: this is the single predicate standing between a parsed tmux listing and
+/// a `kill_session`, so it is extracted as a pure seam that can be unit-tested
+/// without a tmux server — the surrounding [`session_runtime_live`] is all I/O
+/// and cannot be. It is phrased as "prove DEAD" rather than "is live" on purpose:
+/// the burden of proof belongs on the destructive answer, so every uncertain
+/// input falls out as `false` by construction instead of relying on a caller to
+/// remember to invert something.
+///
+/// The membership check is load-bearing, not defensive boilerplate.
+/// [`trusty_mpm::daemon::runtime_reap::session_has_live_pane`] FILTERS by session
+/// name and reports `false` ("no live pane") when nothing matches at all. That is
+/// right for the daemon, which passes a whole-server listing in which a non-match
+/// genuinely means the session is gone — but here a non-match means our targeted
+/// query answered about somebody ELSE, and `false` would be read as "dead" and
+/// kill a session. tmux makes that reachable rather than hypothetical: it
+/// PREFIX-MATCHES session targets, so with only `tm-apex-01` alive,
+/// `has-session -t tm-apex` succeeds and `list-panes -s -t tm-apex` returns
+/// `tm-apex-01`'s panes. A record named `tm-apex` would then be handed a
+/// well-formed listing belonging to a different, live session — and the
+/// `kill_session` that followed would prefix-match onto that same live session.
+///
+/// What: returns `true` only when at least one pane in `panes` actually belongs
+/// to `session_name` AND no pane of `session_name` shows a live runtime.
+/// Returns `false` — "not proven dead", which the caller turns into fail-open —
+/// when no pane belongs to `session_name`, or when any of its panes is live.
+/// Pure; no I/O.
+/// Test: `panes_prove_session_dead_*` in `tests_behavior_c_tests.rs`, including
+/// the prefix-match and foreign-listing cases that pin the membership check.
+pub(crate) fn panes_prove_session_dead(
+    session_name: &str,
+    panes: &[trusty_mpm::daemon::orphan_gc::PaneInfo],
+    probe: &dyn trusty_mpm::daemon::orphan_gc::ChildLivenessProbe,
+) -> bool {
+    if !panes.iter().any(|p| p.session_name == session_name) {
+        return false;
+    }
+    !trusty_mpm::daemon::runtime_reap::session_has_live_pane(session_name, panes, probe)
 }
 
 /// Restart (if needed) then attach to a managed session from the guided picker.

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resume.rs
@@ -18,12 +18,23 @@
 //! (where the in-place relaunch gate matches), actually brought a runtime back.
 //! [`plan_resume`] now takes a third input, `runtime_live`, and maps
 //! `(active, tmux up, runtime dead)` onto the existing `ReconcileThenRestart`
-//! recovery so the first invocation does the whole job. [`pane_runtime_live`]
+//! recovery so the first invocation does the whole job. [`session_runtime_live`]
 //! resolves that input by reusing the daemon reaper's own
-//! [`trusty_mpm::daemon::runtime_reap::pane_runtime_exited`] predicate against a
-//! single pane-id-targeted `tmux display-message` — the CLI asks the question
-//! itself at resume time, so this fix does NOT depend on the 60s runtime reaper
-//! having already reconciled the record.
+//! [`trusty_mpm::daemon::runtime_reap::session_has_live_pane`] primitive against
+//! a session-scoped `tmux list-panes` — the CLI asks the question itself at
+//! resume time, so this fix does NOT depend on the 60s runtime reaper having
+//! already reconciled the record.
+//!
+//! #3873 round 2: that recovery is DESTRUCTIVE on this input.
+//! `/runtime-stop` reaches `kill_session(tmux_name)`, which is session-scoped —
+//! every window and pane. The #2001 zombie pays nothing (its session is already
+//! gone) but the #3873 shape has a live session by definition, so
+//! [`resume_session`] discloses the impending session kill before it happens,
+//! matching what the plain `Restart` branch has always done for the same
+//! `tmux_live == true` situation. The sibling-pane question (#2463) is not a
+//! separate guard bolted on afterwards: because `runtime_live` is computed as
+//! ANY-pane-live over the whole session, a session with one idle pane and one
+//! live agent pane never reaches the destructive branch at all.
 //!
 //! #3531: the zombie/restart classification below MUST run on
 //! [`trusty_mpm::client::ManagedSessionSummary::persisted_state`], never the
@@ -235,72 +246,130 @@ pub(crate) fn plan_resume(state: &str, tmux_live: bool, runtime_live: bool) -> R
     }
 }
 
-/// Parse `tmux display-message -p -t <pane> '#{pane_current_command} #{pane_pid}'`
-/// output into the two fields [`pane_runtime_exited`] needs (#3873).
+/// Parse a session-scoped `tmux list-panes -F` listing into the
+/// [`trusty_mpm::daemon::orphan_gc::PaneInfo`] rows the daemon's liveness
+/// predicates consume (#3873).
 ///
 /// Why: the shell-out itself is untestable without a live tmux server, but the
-/// parse is exactly where a format change or an empty/short reply would silently
-/// mis-answer "is the runtime alive?". Splitting it out keeps that risk on a pure,
-/// unit-tested seam. Deliberately does NOT go through
-/// [`crate::daemon::tmux`]-style `list-panes -a` enumeration: that path is a
-/// whole-server sweep whose composite-key parsing is a known failure mode
-/// (#1813 shape), and a single pane-id-targeted `display-message` needs none of
-/// it — tmux resolves a pane id to exactly one pane or errors.
-/// What: returns `None` when the reply has no command word at all (empty output,
-/// or tmux printed nothing usable) — the caller treats that as "cannot prove
-/// dead". Otherwise returns the command word plus the pane pid, with the pid
-/// `None` when it is missing or not a number (that alone is not evidence of
-/// death; [`crate::daemon::orphan_gc::ChildLivenessProbe`] treats `None` as
-/// "no live child", and the command-word gate still has to agree).
-/// Test: `parse_pane_probe_*` in `tests_behavior_c_tests.rs`.
-pub(crate) fn parse_pane_probe(stdout: &str) -> Option<(String, Option<u32>)> {
-    let line = stdout.lines().next().unwrap_or("").trim();
-    let mut parts = line.split_whitespace();
-    let command = parts.next()?.to_string();
-    let pid = parts.next().and_then(|p| p.parse::<u32>().ok());
-    Some((command, pid))
+/// parse is exactly where a format change, a short row, or an empty reply would
+/// silently mis-answer "is the runtime alive?" — and a wrong answer here now
+/// drives a `kill_session`. Splitting it out keeps that risk on a pure,
+/// unit-tested seam. Deliberately does NOT go through the `list-panes -a`
+/// whole-server sweep in [`trusty_mpm::daemon::tmux`]: that path's composite-key
+/// parsing is a known live failure mode (the #1813 shape, where `session_name`
+/// ends up holding an entire joined row and `pane_current_command` comes back
+/// empty), and a session-scoped listing needs none of it. The TAB delimiter is
+/// chosen for the same reason — it cannot appear in a tmux session name or a
+/// command word, so the columns cannot smear into each other the way the
+/// space-joined `-a` format did.
+/// What: returns one row per pane, requiring EXACTLY three non-empty
+/// tab-separated fields with a numeric pid. Returns `None` — meaning "cannot
+/// determine", which every caller must treat as fail-open — for an empty
+/// listing, a short or over-long row, an empty session/command field, or a
+/// missing/non-numeric pid. Blank lines are skipped.
+/// Test: `parse_pane_probes_*` in `tests_behavior_c_tests.rs`.
+pub(crate) fn parse_pane_probes(
+    stdout: &str,
+) -> Option<Vec<trusty_mpm::daemon::orphan_gc::PaneInfo>> {
+    let mut panes = Vec::new();
+    for line in stdout.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let mut fields = line.split('\t');
+        let session_name = fields.next()?.trim();
+        let command = fields.next()?.trim();
+        let pid = fields.next()?.trim();
+        // More fields than the format string asked for means the reply is not the
+        // shape we requested — refuse to guess which column is which.
+        if fields.next().is_some() {
+            return None;
+        }
+        if session_name.is_empty() || command.is_empty() {
+            return None;
+        }
+        // #3873 round 2 (code-critic MEDIUM): a missing or non-numeric pid is
+        // NOT tolerated. `ProcessTreeProbe::has_live_child(None)` returns
+        // `false`, so accepting `None` here would silently collapse the
+        // documented two-gate check down to `is_idle_shell` alone. That
+        // calibration is correct for the DAEMON (whose reconcile is
+        // non-destructive since #2023 A — the record flips, the pane survives),
+        // but this CLI path drives a `kill_session`, so it must be STRICTER
+        // than the daemon, not merely equal to it.
+        let pane_pid: u32 = pid.parse().ok()?;
+        panes.push(trusty_mpm::daemon::orphan_gc::PaneInfo {
+            session_name: session_name.to_string(),
+            pane_current_command: command.to_string(),
+            pane_pid: Some(pane_pid),
+            // Unused by `pane_runtime_exited`; the session-scoped query below is
+            // what establishes which session these panes belong to.
+            pane_id: None,
+        });
+    }
+    (!panes.is_empty()).then_some(panes)
 }
 
-/// Is the agent runtime inside `pane_id` still alive? (#3873)
+/// Does ANY pane in tmux session `session_name` still show a live runtime? (#3873)
 ///
 /// Why: `tmux_has_session` proves only that the tmux SESSION exists. When a
 /// managed session's inner `claude` exits, the pane survives as a bare login
 /// shell — so session-existence says "live" while the thing the operator wants
 /// is gone. The daemon's 60s runtime reaper already owns the authoritative
-/// answer to this question in
-/// [`trusty_mpm::daemon::runtime_reap::pane_runtime_exited`]; this function
-/// reuses that exact predicate (and therefore the same `is_idle_shell`
-/// allowlist and the same [`trusty_mpm::daemon::orphan_gc::ProcessTreeProbe`]
-/// belt-and-braces child gate) rather than reimplementing idle-shell detection
-/// in the CLI, so the two can never drift apart. Reusing it also means this fix
-/// works whether or not the reaper is currently healthy: the CLI asks the
-/// question itself, at resume time, instead of waiting for a reaped record.
+/// answer in [`trusty_mpm::daemon::runtime_reap::session_has_live_pane`]; this
+/// function reuses that exact primitive (and through it `pane_runtime_exited`,
+/// the same `is_idle_shell` allowlist, and the same
+/// [`trusty_mpm::daemon::orphan_gc::ProcessTreeProbe`] child gate) rather than
+/// reimplementing idle-shell detection in the CLI, so the two can never drift
+/// apart. Reusing it also means this fix works whether or not the reaper is
+/// currently healthy: the CLI asks the question itself, at resume time, instead
+/// of waiting for a reaped record.
+///
+/// #3873 round 2 (code-critic MEDIUM): this is deliberately the ANY-PANE-LIVE
+/// question over the whole session, NOT a check of the record's stored
+/// `pane_id`. A managed session can be manually split (#2463), so a single-pane
+/// check would call a session dead while a sibling pane still runs the agent —
+/// and the consequence of "dead" on this path is a `kill_session` that takes
+/// every window and pane with it. Asking tmux for the session's panes directly
+/// also means pane membership is established BY CONSTRUCTION (a `-t <session>`
+/// listing cannot return another session's panes) instead of trusting a stored
+/// pane id that could be stale or reused.
+///
 /// What: FAILS OPEN — returns `true` (assume live, preserving the pre-#3873
-/// `Attach` behavior) when the record has no `pane_id`, when the `tmux` shell-out
-/// fails or exits non-zero, or when the reply cannot be parsed. Only a positive,
-/// two-gate identification (a recognised bare shell AND no live child under the
-/// pane pid) returns `false`. Failing open matters because `false` now triggers a
-/// `/runtime-stop` that KILLS the pane: a wrong `false` would destroy a live
-/// agent's pane, while a wrong `true` merely reproduces today's already-shipped
-/// behavior.
-/// Test: the pure parse seam is `parse_pane_probe_*`; the fail-open contract for
-/// a missing pane id is `pane_runtime_live_assumes_live_without_pane_id`; the
+/// `Attach` behavior) for a blank session name, a `tmux` spawn failure, a
+/// non-zero exit, a listing that cannot be fully parsed
+/// ([`parse_pane_probes`]), or a listing containing no pane attributable to
+/// this session. Only a fully-parsed listing in which EVERY pane is a
+/// provably-idle shell returns `false`. The asymmetry is deliberate: `false`
+/// now triggers a `/runtime-stop` whose `SessionManager::stop` →
+/// `graceful_terminate_runtime` → `kill_session` destroys the entire tmux
+/// session, so a wrong `false` is destructive while a wrong `true` merely
+/// reproduces the already-shipped attach behavior.
+///
+/// The non-zero-exit guard is belt-and-braces rather than the primary
+/// protection: tmux 3.6b answers an invalid target on some subcommands with
+/// rc=0 and near-empty stdout, so the parse-returned-`None` path is what
+/// actually catches a bad target, and that path IS unit-tested.
+/// Test: the pure parse seam is `parse_pane_probes_*`; the any-pane-live
+/// composition is `session_panes_*`; the blank-name fail-open is
+/// `session_runtime_live_assumes_live_for_blank_session_name`; the
 /// classification it delegates to is covered by the daemon's own
-/// `pane_runtime_exited_*` tests. The tmux shell-out itself is I/O (a live tmux
-/// server), matching the existing `session_for_pane` / `pane_tty_for` precedent
-/// in `tmux_attach.rs`.
-pub(crate) fn pane_runtime_live(pane_id: Option<&str>) -> bool {
-    let Some(pane_id) = pane_id.map(str::trim).filter(|p| !p.is_empty()) else {
+/// `pane_runtime_exited_*` / `session_has_live_pane_*` tests. The tmux
+/// shell-out itself is I/O (a live tmux server), matching the existing
+/// `session_for_pane` / `pane_tty_for` precedent in `tmux_attach.rs`.
+pub(crate) fn session_runtime_live(session_name: &str) -> bool {
+    let name = session_name.trim();
+    if name.is_empty() {
         return true;
-    };
+    }
     let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
     let Ok(output) = std::process::Command::new(&tmux_bin)
         .args([
-            "display-message",
-            "-p",
+            "list-panes",
+            "-s",
             "-t",
-            pane_id,
-            "#{pane_current_command} #{pane_pid}",
+            name,
+            "-F",
+            "#{session_name}\t#{pane_current_command}\t#{pane_pid}",
         ])
         .output()
     else {
@@ -309,19 +378,21 @@ pub(crate) fn pane_runtime_live(pane_id: Option<&str>) -> bool {
     if !output.status.success() {
         return true;
     }
-    let Some((command, pane_pid)) = parse_pane_probe(&String::from_utf8_lossy(&output.stdout))
-    else {
+    let Some(panes) = parse_pane_probes(&String::from_utf8_lossy(&output.stdout)) else {
         return true;
     };
-
-    let pane = trusty_mpm::daemon::orphan_gc::PaneInfo {
-        session_name: String::new(),
-        pane_current_command: command,
-        pane_pid,
-        pane_id: Some(pane_id.to_string()),
-    };
-    !trusty_mpm::daemon::runtime_reap::pane_runtime_exited(
-        &pane,
+    // Membership guard. `session_has_live_pane` FILTERS by session name and
+    // returns `false` ("no live pane") when nothing matches — correct for the
+    // daemon, which is looking at a whole-server listing where a non-match means
+    // the session is gone, but fail-CLOSED here where `false` is destructive. If
+    // the listing we got back cannot be attributed to the session we asked
+    // about, we have learned nothing and must fail open.
+    if !panes.iter().any(|p| p.session_name == name) {
+        return true;
+    }
+    trusty_mpm::daemon::runtime_reap::session_has_live_pane(
+        name,
+        &panes,
         &trusty_mpm::daemon::orphan_gc::ProcessTreeProbe,
     )
 }
@@ -428,13 +499,13 @@ pub(crate) async fn resume_session(
     // `resume_classification_state`.
     let persisted_state = resume_classification_state(session);
     // #3873: `tmux_live` above proves only that the tmux SESSION exists. Ask the
-    // separate question the operator actually cares about — is the agent runtime
-    // inside the record's pane still there? — before letting an `active` record
-    // fall through to a bare `Attach` that would drop them into an idle shell.
-    // Only worth the shell-out when tmux is up at all; when it is not, `is_zombie`
-    // already classifies the record and `pane_runtime_live` could not answer
-    // anyway (the pane is gone with the session).
-    let runtime_live = !tmux_live || pane_runtime_live(session.pane_id.as_deref());
+    // separate question the operator actually cares about — does ANY pane in that
+    // session still run an agent? — before letting an `active` record fall
+    // through to a bare `Attach` that would drop them into an idle shell. Only
+    // worth the shell-out when tmux is up at all; when it is not, `is_zombie`
+    // already classifies the record and `session_runtime_live` could not answer
+    // anyway (the panes are gone with the session).
+    let runtime_live = !tmux_live || session_runtime_live(&session.name);
     let action = plan_resume(persisted_state, tmux_live, runtime_live);
 
     // Terminal-state refusal (code-critic CRITICAL): a decommissioned/deleted
@@ -462,10 +533,24 @@ pub(crate) async fn resume_session(
         // "its tmux pane is gone", which is now only half the cases — telling an
         // operator their pane vanished when it is sitting right in front of them
         // is worse than saying nothing.
+        //
+        // #3873 round 2 (code-critic HIGH): when tmux IS live this branch is
+        // DESTRUCTIVE and must say so. `/runtime-stop` →
+        // `SessionManager::stop` → `graceful_terminate_runtime` →
+        // `kill_session(tmux_name)` is SESSION-scoped: every window and every
+        // pane goes, not just the one the record points at. For the #2001 zombie
+        // that costs nothing (the session is already gone), but the #3873 shape
+        // has a live session BY DEFINITION, so this is a newly-destructive step
+        // on an input that previously took a harmless `Attach`. The plain
+        // `Restart` branch below already discloses exactly this for the same
+        // `tmux_live == true` situation; reaching the same `kill_session`
+        // silently here would be strictly worse.
         if tmux_live {
             eprintln!(
-                "tm: '{}' is marked {} but its runtime has exited (the pane is a \
-                 bare shell) — restarting the runtime…",
+                "tm: session '{}' is {} but its runtime has exited — every pane in \
+                 the tmux session is now an idle shell. Restarting will KILL that \
+                 tmux session (all windows and panes, including their scrollback) \
+                 and start a fresh runtime.",
                 session.name, persisted_state
             );
         } else {
@@ -487,11 +572,10 @@ pub(crate) async fn resume_session(
         action,
         ResumeAction::Restart | ResumeAction::ReconcileThenRestart
     ) {
-        // Pane-kill disclosure only applies to the plain Restart branch. The
-        // reconcile branch already printed its own message above, and its pane is
-        // either gone (#2001) or a bare shell whose runtime already exited
-        // (#3873) — in neither case is there in-progress runtime state left to
-        // warn about losing.
+        // Pane-kill disclosure only applies to the plain Restart branch here: the
+        // reconcile branch printed its OWN disclosure above (which, since #3873
+        // round 2, covers the destructive live-tmux case explicitly), so
+        // repeating it would double-warn.
         if action == ResumeAction::Restart {
             if tmux_live {
                 eprintln!(
@@ -527,6 +611,17 @@ pub(crate) async fn resume_session(
 /// the record `Stopped` synchronously (keeping the workspace), which then
 /// satisfies the restart path. This is the automation of the old manual
 /// `tm session stop <id>` step.
+///
+/// DESTRUCTIVE (#3873 round 2 — this doc previously said only "marks the record
+/// `Stopped`", which reads as record-only and is what let a destructive step
+/// land without disclosure). Server-side this is
+/// `stop_managed_session_runtime` → [`trusty_mpm::session_manager::SessionManager::stop`]
+/// → `graceful_terminate_runtime` → `kill_session(tmux_name)` — SESSION-scoped,
+/// so every window and pane of the tmux session is destroyed, not merely the
+/// record's own pane. Free for the #2001 zombie (its session is already gone);
+/// materially destructive for the #3873 dead-runtime shape, whose session is
+/// live by definition. Callers reaching this with `tmux_live == true` MUST
+/// disclose that first — `resume_session` does.
 /// What: POSTs `/api/v1/sessions/managed/{id}/runtime-stop` with a 30-second
 /// timeout. Network/404/other-error each print a distinct actionable message and
 /// bail — a failed stop is the one case that still needs a human. Success returns

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -596,7 +596,12 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
         .args(["kill-session", "-t", &record.tmux_name])
         .output();
 
-    result.expect("headless resume of a dead-runtime session must succeed (Ok), not error");
+    // Deliberately NOT asserted as `Ok`. Whether the daemon can actually spawn a
+    // runtime is environment-dependent (CI has no agent binary on PATH, so
+    // `/resume` legitimately ends in `errored` there), and that is downstream of
+    // what this test is about. The branch SELECTION is the claim, and the record
+    // transition below proves it either way.
+    let _ = result;
 
     let after: serde_json::Value = client
         .get(format!("{url}/api/v1/sessions/managed/{id}"))
@@ -606,13 +611,22 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
         .json()
         .await
         .unwrap();
-    assert_eq!(
-        after.get("persisted_state").and_then(|v| v.as_str()),
-        Some("active"),
-        "the record must have been reconciled and restarted — only a /runtime-stop \
-         + /resume round-trip flips a provisioning record to 'active'. Reading \
-         'provisioning' here means the CLI attached into the idle shell instead, \
-         i.e. the #3873 defect is back"
+    let persisted = after
+        .get("persisted_state")
+        .and_then(|v| v.as_str())
+        .expect("daemon must report persisted_state");
+    // This is the exact discriminator between the two branches, and it holds in
+    // any environment. Attach performs NO daemon round-trip, so the seeded
+    // `provisioning` would survive untouched; reconcile-then-restart POSTs
+    // `/runtime-stop` (-> `stopped`) and then `/resume` (-> `active`, or
+    // `errored` if the runtime could not spawn). Any value other than
+    // `provisioning` therefore proves the reconcile path ran.
+    assert_ne!(
+        persisted, "provisioning",
+        "the record must have been reconciled and restarted — a /runtime-stop + \
+         /resume round-trip moves it off 'provisioning' (to 'active', or \
+         'errored' where no runtime binary exists). Reading 'provisioning' means \
+         the CLI attached into the idle shell instead, i.e. the #3873 defect is back"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -560,15 +560,21 @@ async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
     );
 
     let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
-    // A bare `sh`, explicitly: the pane must be an idle shell with NO live child
-    // — tmux session live, runtime dead, the #3873 defect shape. Passing the
-    // command explicitly rather than letting tmux launch the user's login shell
-    // is what makes this deterministic: an interactive `zsh`/`bash` runs the
-    // developer's rc files and keeps spawning short-lived children for a while
-    // after creation, and the `ChildLivenessProbe` gate correctly reads any of
-    // those as "still alive". That made the fixture's verdict depend on this
-    // machine's dotfiles. `sh` is in `orphan_gc::IDLE_SHELL_COMMANDS` and reads
-    // no rc files here, so it settles immediately and stays childless.
+    // A non-interactive shell, explicitly: the pane must be an idle shell with NO
+    // live child — tmux session live, runtime dead, the #3873 defect shape.
+    // Passing a command at all is what makes this deterministic. With no command
+    // tmux starts the user's LOGIN shell, which runs the developer's rc files and
+    // keeps spawning short-lived children for a while afterwards; the
+    // `ChildLivenessProbe` gate correctly reads any of those as "still alive", so
+    // the fixture's verdict depended on this machine's dotfiles.
+    //
+    // Note what actually runs: tmux executes the argument via its default-shell,
+    // so `pane_current_command` here is that shell (`bash` on this machine,
+    // verified with `tmux display-message -p '#{pane_current_command}'`), NOT the
+    // literal `sh` spelled below. That is fine — every entry in
+    // `orphan_gc::IDLE_SHELL_COMMANDS` is equally an idle shell, and the point of
+    // the argument is only to skip login/rc processing so the pane settles
+    // immediately and stays childless.
     let create_status = std::process::Command::new(&tmux_bin)
         .args(["new-session", "-d", "-s", &record.tmux_name, "sh"])
         .status()

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -301,6 +301,11 @@ async fn session_resume_restart_failure_errors() {
 /// than attempting (and presumably failing/hanging on) a real tmux attach
 /// with no controlling terminal to move.
 ///
+/// #3873: "already-live" now means a live RUNTIME, not merely a live tmux
+/// session — see the fixture note below on why the pane must run a non-shell
+/// command. The dead-runtime counterpart is
+/// `session_resume_headless_dead_runtime_reconciles_and_restarts`.
+///
 /// Why `provisioning` and not the literal `active` string: branch selection
 /// here is state-string-independent — both `active` and `provisioning` fail
 /// `needs_restart` identically, so the `Provisioning` state `create_with_id`
@@ -344,7 +349,12 @@ async fn session_resume_headless_active_live_tmux_skips_restart_and_attach() {
             Some(ws.clone()),
             None,
             Some(ws),
-            Some("https://example.com/r.git".to_string()),
+            // Process-unique so the derived `tmux_name` cannot collide in the
+            // machine-global tmux namespace — see the fuller note on the
+            // dead-runtime counterpart below. This test has always created a real
+            // tmux session under a FIXED name (`tm-r-01`); with a second
+            // real-tmux test now beside it, that is a live cross-binary hazard.
+            Some(format!("https://example.com/r{}.git", std::process::id())),
             Some("main".to_string()),
             RuntimeKind::default(),
             false,
@@ -359,14 +369,29 @@ async fn session_resume_headless_active_live_tmux_skips_restart_and_attach() {
     );
 
     let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
+    // #3873: the pane must run a NON-shell command. Since #3873, "live" means a
+    // live RUNTIME, not merely a live tmux session — a bare `tmux new-session -d`
+    // leaves the pane on a login shell, which is precisely the dead-runtime shape
+    // this test is NOT trying to exercise (see the sibling test below, which is).
+    // `sleep` is not in `orphan_gc::IDLE_SHELL_COMMANDS`, so it stands in for a
+    // live agent process deterministically. Without it this fixture's verdict
+    // depended on whether the login shell happened to still have a child mid-init
+    // when the probe ran, making the test genuinely flaky under the new logic.
     let create_status = std::process::Command::new(&tmux_bin)
-        .args(["new-session", "-d", "-s", &record.tmux_name])
+        .args(["new-session", "-d", "-s", &record.tmux_name, "sleep 300"])
         .status()
         .expect("spawn real tmux session for the liveness probe");
     assert!(
         create_status.success(),
         "failed to create the real scratch tmux session"
     );
+    // tmux runs the command through a shell, so there is a brief window after
+    // `new-session` in which the pane still reports `sh`/`zsh` rather than
+    // `sleep`. Probing inside that window reads the fixture as an idle shell and
+    // sends this test down the #3873 dead-runtime branch. Wait for the pane to
+    // settle into the live-runtime state the test is actually about — the exact
+    // inverse of the wait in the dead-runtime counterpart below.
+    wait_for_stable_live_runtime(&record.tmux_name);
 
     let router = api::router(std::sync::Arc::clone(&state));
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -401,6 +426,193 @@ async fn session_resume_headless_active_live_tmux_skips_restart_and_attach() {
         Some("provisioning"),
         "state must be UNCHANGED — a /resume POST would have flipped it to 'active'; this \
          proves the Attach branch never issued a daemon-side restart"
+    );
+}
+
+/// Block until `session_name`'s panes read as a settled LIVE runtime (#3873).
+///
+/// Why: the mirror of [`wait_for_stable_dead_runtime`] — see its doc. tmux
+/// launches a pane command through a shell, so a pane told to run a long-lived
+/// process still reports the shell for a moment; a test asserting about the
+/// Attach branch must not start until the fixture actually expresses it.
+/// What: polls until three consecutive probes report a live runtime, or panics
+/// at a 10-second deadline. Any dead reading resets the streak.
+fn wait_for_stable_live_runtime(session_name: &str) {
+    const REQUIRED_AGREEING_READS: u32 = 3;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut streak = 0;
+    while std::time::Instant::now() < deadline {
+        if crate::commands::guided_resume::session_runtime_live(session_name) {
+            streak += 1;
+            if streak == REQUIRED_AGREEING_READS {
+                return;
+            }
+        } else {
+            streak = 0;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!(
+        "fixture precondition: tmux session '{session_name}' never settled into a \
+         stable live-runtime state within 10s; this test would silently exercise \
+         the #3873 reconcile branch instead of the Attach branch it asserts about"
+    );
+}
+
+/// Block until `session_name`'s panes read as a settled dead runtime (#3873).
+///
+/// Why: `session_runtime_live` consults the OS process tree, so a pane that has
+/// only just been created can momentarily report a live child while it finishes
+/// setting itself up. A single probe is therefore not a stable statement about
+/// the fixture; a test that acts on one can silently exercise the opposite
+/// branch from the one it asserts about. Requiring CONSECUTIVE agreeing reads
+/// turns "dead right now" into "dead and settled".
+/// What: polls until three consecutive probes report a dead runtime, or panics
+/// at a 10-second deadline rather than letting the caller proceed on an
+/// unsettled fixture (a silent proceed is what produced an intermittent
+/// failure). Any live reading resets the streak.
+fn wait_for_stable_dead_runtime(session_name: &str) {
+    const REQUIRED_AGREEING_READS: u32 = 3;
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+    let mut streak = 0;
+    while std::time::Instant::now() < deadline {
+        if crate::commands::guided_resume::session_runtime_live(session_name) {
+            streak = 0;
+        } else {
+            streak += 1;
+            if streak == REQUIRED_AGREEING_READS {
+                return;
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!(
+        "fixture precondition: tmux session '{session_name}' never settled into a \
+         stable dead-runtime state within 10s; this test cannot distinguish the \
+         #3873 reconcile branch from Attach without it"
+    );
+}
+
+/// #3873 end-to-end: a session whose tmux session is LIVE but whose runtime has
+/// exited must reconcile-then-restart, not attach into the idle shell.
+///
+/// Why: the pure `plan_resume` seam proves the branch SELECTION, but not that
+/// the selection survives the whole I/O driver — `resume_session` computes
+/// `runtime_live` itself, and a wrong `pane_id`/session plumbing, a
+/// short-circuit, or a daemon-side "re-attach to the live pane instead of
+/// recreating" branch could each turn the fix into a silent no-op while every
+/// unit test stayed green. This is the counterpart to
+/// `session_resume_headless_active_live_tmux_skips_restart_and_attach`: same
+/// seeding, same real-tmux liveness fixture, opposite pane command, opposite
+/// expected outcome. Together they pin BOTH directions of the #3873 decision
+/// against a real daemon.
+/// What: seeds a `Provisioning` record with a workspace that EXISTS on disk (the
+/// restart path validates it), spawns a real tmux session left on a bare login
+/// shell — the exact dead-runtime shape — and asserts the daemon record flipped
+/// to `active`, which only a `/runtime-stop` + `/resume` round-trip can do. The
+/// daemon here is `FakeNoopTmuxDriver`-backed, so its `kill_session` is a no-op
+/// and the real scratch session is torn down by this test, unconditionally.
+#[tokio::test]
+async fn session_resume_headless_dead_runtime_reconciles_and_restarts() {
+    use trusty_mpm::daemon::{api, state::DaemonState};
+    use trusty_mpm::runtime::RuntimeKind;
+    use trusty_mpm::session_manager::ManagedSessionId;
+
+    let root = tempfile::tempdir().unwrap().keep();
+    let state = std::sync::Arc::new(DaemonState::with_root_isolated_managed(root.clone()).await);
+    let id = ManagedSessionId::new();
+    let ws = root.join(format!("{id}-dead-runtime-ws"));
+    // The restart path refuses a session whose workspace directory is gone, so
+    // it must actually exist for this test to reach the /resume POST.
+    std::fs::create_dir_all(&ws).expect("create workspace dir");
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create_with_id(
+            id,
+            "regression: #3873 dead-runtime reconcile CLI test".to_string(),
+            Some(ws.clone()),
+            None,
+            Some(ws),
+            // `tmux_name` is derived from the repo name, and this test creates a
+            // REAL tmux session in the machine-global tmux namespace. The name
+            // must therefore be unique BOTH from the sibling live-runtime test
+            // (which would otherwise also derive `tm-r-01`) AND across test
+            // BINARIES: this crate compiles the same sources into two bin targets
+            // (`tm` and `trusty-mpm`) that cargo may run concurrently, so a fixed
+            // name lets one process's unconditional `kill-session` cleanup
+            // destroy the other process's session mid-test — observed as an
+            // intermittent failure of the final assertion below.
+            Some(format!(
+                "https://example.com/deadrt{}.git",
+                std::process::id()
+            )),
+            Some("main".to_string()),
+            RuntimeKind::default(),
+            false,
+            false,
+        )
+        .await
+        .expect("seed session");
+    assert_eq!(
+        record.state.to_string(),
+        "provisioning",
+        "sanity: create_with_id must leave a fresh record un-stopped/un-errored"
+    );
+
+    let tmux_bin = trusty_mpm::core::tmux::resolve_tmux_binary_or_bare();
+    // A bare `sh`, explicitly: the pane must be an idle shell with NO live child
+    // — tmux session live, runtime dead, the #3873 defect shape. Passing the
+    // command explicitly rather than letting tmux launch the user's login shell
+    // is what makes this deterministic: an interactive `zsh`/`bash` runs the
+    // developer's rc files and keeps spawning short-lived children for a while
+    // after creation, and the `ChildLivenessProbe` gate correctly reads any of
+    // those as "still alive". That made the fixture's verdict depend on this
+    // machine's dotfiles. `sh` is in `orphan_gc::IDLE_SHELL_COMMANDS` and reads
+    // no rc files here, so it settles immediately and stays childless.
+    let create_status = std::process::Command::new(&tmux_bin)
+        .args(["new-session", "-d", "-s", &record.tmux_name, "sh"])
+        .status()
+        .expect("spawn real tmux session for the liveness probe");
+    assert!(
+        create_status.success(),
+        "failed to create the real scratch tmux session"
+    );
+    // Belt-and-braces on top of the deterministic fixture: require the "runtime
+    // dead" reading to be STABLE (three consecutive probes) before proceeding,
+    // so a single transient child during pane setup cannot send this test down
+    // the Attach branch it is not testing.
+    wait_for_stable_dead_runtime(&record.tmux_name);
+
+    let router = api::router(std::sync::Arc::clone(&state));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(axum::serve(listener, router).into_future());
+    let url = format!("http://{addr}");
+    let client = reqwest::Client::new();
+
+    let result = session_resume(&client, &url, id.to_string()).await;
+
+    let _ = std::process::Command::new(&tmux_bin)
+        .args(["kill-session", "-t", &record.tmux_name])
+        .output();
+
+    result.expect("headless resume of a dead-runtime session must succeed (Ok), not error");
+
+    let after: serde_json::Value = client
+        .get(format!("{url}/api/v1/sessions/managed/{id}"))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(
+        after.get("persisted_state").and_then(|v| v.as_str()),
+        Some("active"),
+        "the record must have been reconciled and restarted — only a /runtime-stop \
+         + /resume round-trip flips a provisioning record to 'active'. Reading \
+         'provisioning' here means the CLI attached into the idle shell instead, \
+         i.e. the #3873 defect is back"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -35,7 +35,8 @@ use crate::commands::guided::{
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{
-    ResumeAction, is_zombie, needs_restart, plan_resume, resume_classification_state,
+    ResumeAction, is_zombie, needs_restart, pane_runtime_live, parse_pane_probe, plan_resume,
+    resume_classification_state,
 };
 // The picker decision enum + parser moved to the shared `session_picker` module.
 use crate::commands::session_picker::{PickerDecision, parse_picker_choice};
@@ -1245,12 +1246,145 @@ fn guided_resume_not_zombie_active_with_tmux() {
 
 #[test]
 fn guided_resume_plan_active_live_tmux_attaches() {
-    // Why: active state with a live tmux pane is the happy path — attach directly,
-    // no daemon round-trip, no stop, no resume.
+    // Why: active state with a live tmux pane AND a live runtime is the happy
+    // path — attach directly, no daemon round-trip, no stop, no resume. #3873
+    // added `runtime_live`; this case MUST keep attaching when it is true, or a
+    // genuinely-running agent would get its pane killed and restarted.
     assert_eq!(
-        plan_resume("active", true),
+        plan_resume(
+            "active", /* tmux_live */ true, /* runtime_live */ true
+        ),
         ResumeAction::Attach,
-        "active + live tmux must attach directly"
+        "active + live tmux + live runtime must attach directly"
+    );
+}
+
+#[test]
+fn guided_resume_plan_active_live_tmux_dead_runtime_reconciles_then_restarts() {
+    // Why (#3873): the reported defect. The daemon record says `active` and the
+    // tmux SESSION exists, but the inner `claude` has exited and the pane fell
+    // back to a bare login shell. `tmux_live` cannot see that difference, so the
+    // plan used to be `Attach` — bare `tm` switched the operator into an idle
+    // shell and did nothing useful, forcing a second `tm` from inside that pane
+    // to actually get a runtime back. The recovery is the SAME auto-stop-then-
+    // restart the tmux-gone zombie already uses, so invocation #1 does the whole
+    // job.
+    assert_eq!(
+        plan_resume(
+            "active", /* tmux_live */ true, /* runtime_live */ false
+        ),
+        ResumeAction::ReconcileThenRestart
+    );
+}
+
+#[test]
+fn guided_resume_plan_provisioning_live_tmux_dead_runtime_reconciles_then_restarts() {
+    // Why (#3873): `provisioning` is the other non-terminal, non-restartable
+    // state that reaches the Attach branch, and a provisioning session whose
+    // runtime died is just as unusable as an active one. Pins that the fix keys
+    // off the same `!needs_restart` family rather than a hard-coded "active".
+    assert_eq!(
+        plan_resume(
+            "provisioning",
+            /* tmux_live */ true,
+            /* runtime_live */ false
+        ),
+        ResumeAction::ReconcileThenRestart,
+        "provisioning + live tmux + dead runtime must reconcile then restart"
+    );
+}
+
+#[test]
+fn guided_resume_plan_stopped_live_tmux_dead_runtime_still_plain_restarts() {
+    // Why (#3873 branch ordering): a Stopped record's pane is an idle shell too,
+    // so it also reports `runtime_live = false`. It must KEEP taking the plain
+    // `Restart` path — `/resume` already accepts Stopped, and routing it through
+    // `ReconcileThenRestart` would add a pointless `/runtime-stop` round-trip
+    // against a record that is already stopped. Guards that the new gate sits
+    // BELOW `needs_restart`, not above it.
+    assert_eq!(
+        plan_resume(
+            "stopped", /* tmux_live */ true, /* runtime_live */ false
+        ),
+        ResumeAction::Restart,
+        "stopped + dead runtime must still take the plain Restart path"
+    );
+}
+
+#[test]
+fn plan_resume_refuses_terminal_states_even_with_dead_runtime() {
+    // Why (#3873): the terminal tombstone refusal must stay FIRST. A
+    // decommissioned/deleted record whose pane is an idle shell must never be
+    // resurrected through the new dead-runtime reconcile path.
+    for state in ["deleted", "decommissioned"] {
+        assert_eq!(
+            plan_resume(
+                state, /* tmux_live */ true, /* runtime_live */ false
+            ),
+            ResumeAction::Terminal,
+            "{state} + dead runtime must still be refused as Terminal"
+        );
+    }
+}
+
+#[test]
+fn pane_runtime_live_assumes_live_without_pane_id() {
+    // Why (#3873 fail-open contract): `runtime_live = false` now triggers a
+    // `/runtime-stop` that KILLS the pane. A record with no stored `pane_id`
+    // gives us NO evidence either way, so it must assume live and preserve the
+    // pre-#3873 Attach behavior — a wrong `false` would destroy a live agent's
+    // pane. Pure: takes the early return before any tmux shell-out.
+    assert!(
+        pane_runtime_live(None),
+        "a record with no pane_id must fail OPEN (assume the runtime is live)"
+    );
+    assert!(
+        pane_runtime_live(Some("   ")),
+        "a blank pane_id is no evidence either — must fail OPEN too"
+    );
+}
+
+#[test]
+fn parse_pane_probe_reads_command_and_pid() {
+    // Why (#3873): the happy shape tmux returns for
+    // `display-message -p -t %333 '#{pane_current_command} #{pane_pid}'`.
+    assert_eq!(
+        parse_pane_probe("zsh 41234\n"),
+        Some(("zsh".to_string(), Some(41234))),
+        "must split the command word from the pane pid"
+    );
+    assert_eq!(
+        parse_pane_probe("claude 41234\n"),
+        Some(("claude".to_string(), Some(41234))),
+        "a live agent's command word must survive intact"
+    );
+}
+
+#[test]
+fn parse_pane_probe_tolerates_missing_pid() {
+    // Why (#3873): a missing/garbage pid is not evidence of death — the command
+    // word still has to clear `is_idle_shell` before anything is torn down.
+    assert_eq!(
+        parse_pane_probe("zsh\n"),
+        Some(("zsh".to_string(), None)),
+        "a command with no pid must still parse, with pid None"
+    );
+    assert_eq!(
+        parse_pane_probe("zsh notanumber\n"),
+        Some(("zsh".to_string(), None)),
+        "a non-numeric pid must degrade to None, never panic"
+    );
+}
+
+#[test]
+fn parse_pane_probe_none_for_empty_reply() {
+    // Why (#3873): an empty reply means tmux told us nothing — the caller must
+    // fail OPEN rather than treat "no command word" as an idle shell.
+    assert_eq!(parse_pane_probe(""), None, "empty output must yield None");
+    assert_eq!(
+        parse_pane_probe("   \n"),
+        None,
+        "whitespace-only output must yield None"
     );
 }
 
@@ -1259,7 +1393,9 @@ fn guided_resume_plan_stopped_restarts() {
     // Why: stopped state must go straight to the daemon /resume restart path —
     // NOT reconcile (there is nothing to stop) and NOT a bare attach.
     assert_eq!(
-        plan_resume("stopped", false),
+        plan_resume(
+            "stopped", /* tmux_live */ false, /* runtime_live */ true
+        ),
         ResumeAction::Restart,
         "stopped must select the plain Restart path"
     );
@@ -1269,7 +1405,9 @@ fn guided_resume_plan_stopped_restarts() {
 fn guided_resume_plan_errored_restarts() {
     // Why: errored is resumable via /resume just like stopped.
     assert_eq!(
-        plan_resume("errored", false),
+        plan_resume(
+            "errored", /* tmux_live */ false, /* runtime_live */ true
+        ),
         ResumeAction::Restart,
         "errored must select the plain Restart path"
     );
@@ -1282,7 +1420,9 @@ fn guided_resume_plan_active_no_tmux_reconciles_then_restarts() {
     // must be ReconcileThenRestart, not a bail and not a plain Restart (a bare
     // /resume would 409 because the record is still active).
     assert_eq!(
-        plan_resume("active", false),
+        plan_resume(
+            "active", /* tmux_live */ false, /* runtime_live */ true
+        ),
         ResumeAction::ReconcileThenRestart,
         "active + no tmux must reconcile (auto-stop) then restart"
     );
@@ -1293,7 +1433,11 @@ fn guided_resume_plan_provisioning_no_tmux_reconciles_then_restarts() {
     // Why (#2001): provisioning + tmux gone is also a zombie and follows the same
     // auto-stop-then-restart recovery.
     assert_eq!(
-        plan_resume("provisioning", false),
+        plan_resume(
+            "provisioning",
+            /* tmux_live */ false,
+            /* runtime_live */ true
+        ),
         ResumeAction::ReconcileThenRestart,
         "provisioning + no tmux must reconcile then restart"
     );
@@ -1308,7 +1452,7 @@ fn plan_resume_refuses_terminal_states() {
     for state in ["deleted", "decommissioned"] {
         for tmux_live in [false, true] {
             assert_eq!(
-                plan_resume(state, tmux_live),
+                plan_resume(state, tmux_live, /* runtime_live */ true),
                 ResumeAction::Terminal,
                 "{state} (tmux_live={tmux_live}) must be refused as Terminal, never resumed"
             );
@@ -1333,7 +1477,9 @@ fn guided_resume_plan_stopped_with_stale_tmux_still_restarts() {
     // zombie (needs_restart is true) — it takes the plain Restart path (the daemon
     // kills the stale pane). Guards the branch ordering in plan_resume.
     assert_eq!(
-        plan_resume("stopped", true),
+        plan_resume(
+            "stopped", /* tmux_live */ true, /* runtime_live */ true
+        ),
         ResumeAction::Restart,
         "stopped + stale live tmux must still take the Restart path, not reconcile"
     );
@@ -1382,7 +1528,11 @@ fn guided_resume_plan_resume_prefers_persisted_state_over_display_state() {
     // daemon's authoritative state.
     let session = make_session_with_persisted_state("tm-writing-01", "stopped", "active");
     let tmux_live = false; // the picker's "(stopped)" label implies tmux is gone
-    let action = plan_resume(resume_classification_state(&session), tmux_live);
+    let action = plan_resume(
+        resume_classification_state(&session),
+        tmux_live,
+        /* runtime_live */ true,
+    );
     assert_eq!(
         action,
         ResumeAction::ReconcileThenRestart,
@@ -1394,7 +1544,7 @@ fn guided_resume_plan_resume_prefers_persisted_state_over_display_state() {
     // reproduces the reported dead-end — proving this test would have caught
     // the regression.
     assert_eq!(
-        plan_resume(&session.state, tmux_live),
+        plan_resume(&session.state, tmux_live, /* runtime_live */ true),
         ResumeAction::Restart,
         "classifying off the display-reconciled state alone reproduces the bug"
     );

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -35,9 +35,14 @@ use crate::commands::guided::{
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{
-    ResumeAction, is_zombie, needs_restart, pane_runtime_live, parse_pane_probe, plan_resume,
-    resume_classification_state,
+    ResumeAction, is_zombie, needs_restart, parse_pane_probes, plan_resume,
+    resume_classification_state, session_runtime_live,
 };
+// #3873: the CLI's dead-runtime verdict composes the daemon's OWN liveness
+// primitives rather than reimplementing them, so the tests exercise that
+// composition directly.
+use trusty_mpm::daemon::orphan_gc::AlwaysIdleProbe;
+use trusty_mpm::daemon::runtime_reap::session_has_live_pane;
 // The picker decision enum + parser moved to the shared `session_picker` module.
 use crate::commands::session_picker::{PickerDecision, parse_picker_choice};
 
@@ -1328,63 +1333,161 @@ fn plan_resume_refuses_terminal_states_even_with_dead_runtime() {
 }
 
 #[test]
-fn pane_runtime_live_assumes_live_without_pane_id() {
-    // Why (#3873 fail-open contract): `runtime_live = false` now triggers a
-    // `/runtime-stop` that KILLS the pane. A record with no stored `pane_id`
-    // gives us NO evidence either way, so it must assume live and preserve the
-    // pre-#3873 Attach behavior — a wrong `false` would destroy a live agent's
-    // pane. Pure: takes the early return before any tmux shell-out.
+fn session_runtime_live_assumes_live_for_blank_session_name() {
+    // Why (#3873 fail-open contract): `runtime_live = false` now drives a
+    // `/runtime-stop` whose `kill_session` destroys the WHOLE tmux session. A
+    // blank session name gives us NO evidence either way, so it must assume live
+    // and preserve the pre-#3873 Attach behavior. Pure: takes the early return
+    // before any tmux shell-out.
     assert!(
-        pane_runtime_live(None),
-        "a record with no pane_id must fail OPEN (assume the runtime is live)"
+        session_runtime_live(""),
+        "an empty session name must fail OPEN (assume the runtime is live)"
     );
     assert!(
-        pane_runtime_live(Some("   ")),
-        "a blank pane_id is no evidence either — must fail OPEN too"
+        session_runtime_live("   "),
+        "a whitespace-only session name is no evidence either — must fail OPEN"
+    );
+}
+
+// ── parse_pane_probes (#3873) ────────────────────────────────────────────────
+// Rows come from `tmux list-panes -s -t <session> -F
+// '#{session_name}\t#{pane_current_command}\t#{pane_pid}'`. Anything this seam
+// cannot fully adjudicate must return None, which the caller treats as fail-open
+// — because the only thing a `false` verdict can cause here is a session kill.
+
+#[test]
+fn parse_pane_probes_reads_every_pane() {
+    // Why (#3873): the happy shape — one row per pane, all three fields present.
+    let panes = parse_pane_probes("tm-apex-01\tzsh\t41234\ntm-apex-01\tclaude\t41999\n")
+        .expect("a well-formed two-pane listing must parse");
+    assert_eq!(panes.len(), 2, "both panes must be returned");
+    assert_eq!(panes[0].session_name, "tm-apex-01");
+    assert_eq!(panes[0].pane_current_command, "zsh");
+    assert_eq!(panes[0].pane_pid, Some(41234));
+    assert_eq!(panes[1].pane_current_command, "claude");
+    assert_eq!(panes[1].pane_pid, Some(41999));
+}
+
+#[test]
+fn parse_pane_probes_rejects_non_numeric_pid() {
+    // Why (#3873 round 2, code-critic MEDIUM): this is THE regression this
+    // parse tightening exists to prevent. A non-numeric pid used to degrade to
+    // `pane_pid: None`; `ProcessTreeProbe::has_live_child(None)` returns `false`,
+    // so the documented two-gate check silently collapsed to `is_idle_shell`
+    // alone and an unparseable row could satisfy the destructive dead-runtime
+    // branch on the strength of the command word by itself. `None → false` is
+    // correct calibration for the DAEMON, whose reconcile is non-destructive
+    // (#2023 A: record flips, pane survives); the CLI reuses that same gate to
+    // drive a `kill_session`, so it must be STRICTER than the daemon, not equal.
+    assert_eq!(
+        parse_pane_probes("tm-apex-01\tzsh\tnotanumber\n"),
+        None,
+        "a non-numeric pid must read as CANNOT DETERMINE (None), never as a \
+         one-gate dead verdict"
     );
 }
 
 #[test]
-fn parse_pane_probe_reads_command_and_pid() {
-    // Why (#3873): the happy shape tmux returns for
-    // `display-message -p -t %333 '#{pane_current_command} #{pane_pid}'`.
+fn parse_pane_probes_rejects_missing_pid() {
+    // Why (#3873 round 2): same MEDIUM, short-row variant — a row that stops
+    // after the command word leaves the child gate with nothing to inspect.
     assert_eq!(
-        parse_pane_probe("zsh 41234\n"),
-        Some(("zsh".to_string(), Some(41234))),
-        "must split the command word from the pane pid"
-    );
-    assert_eq!(
-        parse_pane_probe("claude 41234\n"),
-        Some(("claude".to_string(), Some(41234))),
-        "a live agent's command word must survive intact"
+        parse_pane_probes("tm-apex-01\tzsh\n"),
+        None,
+        "a row missing the pid column must yield None"
     );
 }
 
 #[test]
-fn parse_pane_probe_tolerates_missing_pid() {
-    // Why (#3873): a missing/garbage pid is not evidence of death — the command
-    // word still has to clear `is_idle_shell` before anything is torn down.
+fn parse_pane_probes_rejects_smeared_row() {
+    // Why (#3873): the #1813 composite-key shape that broke the daemon's own
+    // `list-panes -a` enumeration — the whole row collapsed into one field. The
+    // TAB delimiter makes it unparseable rather than silently mis-columned.
     assert_eq!(
-        parse_pane_probe("zsh\n"),
-        Some(("zsh".to_string(), None)),
-        "a command with no pid must still parse, with pid None"
-    );
-    assert_eq!(
-        parse_pane_probe("zsh notanumber\n"),
-        Some(("zsh".to_string(), None)),
-        "a non-numeric pid must degrade to None, never panic"
+        parse_pane_probes("tm-apex-01_zsh_41234\n"),
+        None,
+        "a smeared single-field row must yield None, never a guessed split"
     );
 }
 
 #[test]
-fn parse_pane_probe_none_for_empty_reply() {
-    // Why (#3873): an empty reply means tmux told us nothing — the caller must
-    // fail OPEN rather than treat "no command word" as an idle shell.
-    assert_eq!(parse_pane_probe(""), None, "empty output must yield None");
+fn parse_pane_probes_rejects_extra_fields() {
+    // Why (#3873): more columns than the format asked for means the reply is not
+    // the shape we requested — refuse rather than guess which column is which.
     assert_eq!(
-        parse_pane_probe("   \n"),
+        parse_pane_probes("tm-apex-01\tzsh\t41234\textra\n"),
+        None,
+        "an over-long row must yield None"
+    );
+}
+
+#[test]
+fn parse_pane_probes_rejects_empty_or_blank_listing() {
+    // Why (#3873): an empty listing means tmux told us nothing. It must NOT read
+    // as "no live panes, therefore dead" — that is exactly the fail-closed shape
+    // that would kill a session on a failed query.
+    assert_eq!(parse_pane_probes(""), None, "empty output must yield None");
+    assert_eq!(
+        parse_pane_probes("   \n\n"),
         None,
         "whitespace-only output must yield None"
+    );
+}
+
+#[test]
+fn parse_pane_probes_rejects_empty_command_field() {
+    // Why (#3873): the other half of the #1813 shape — `pane_current_command`
+    // came back EMPTY. An empty command must never be handed to `is_idle_shell`.
+    assert_eq!(
+        parse_pane_probes("tm-apex-01\t\t41234\n"),
+        None,
+        "an empty command field must yield None"
+    );
+}
+
+// ── any-pane-live composition (#3873 round 2, code-critic MEDIUM / #2463) ────
+// `runtime_live` is the ANY-PANE-LIVE question over the whole session, not a
+// check of the record's single stored pane_id. These pin that the parsed rows
+// compose correctly with the daemon's own `session_has_live_pane` primitive.
+
+#[test]
+fn session_panes_any_live_pane_keeps_session_live() {
+    // Why (#2463): a manually-split managed session can have an idle pane
+    // alongside a live agent pane. Checking one pane would call the session dead
+    // and — on this path — kill the live agent with it. AlwaysIdleProbe isolates
+    // the command-word gate: `claude` is not an idle shell, so the session lives.
+    let panes = parse_pane_probes("tm-apex-01\tzsh\t41234\ntm-apex-01\tclaude\t41999\n")
+        .expect("listing must parse");
+    assert!(
+        session_has_live_pane("tm-apex-01", &panes, &AlwaysIdleProbe),
+        "a sibling pane still running the agent must keep the session LIVE"
+    );
+}
+
+#[test]
+fn session_panes_all_idle_reads_dead() {
+    // Why (#3873): the actual defect shape — every pane fell back to a shell.
+    // This is the ONLY configuration allowed to reach the destructive branch.
+    let panes = parse_pane_probes("tm-apex-01\tzsh\t41234\ntm-apex-01\tbash\t41999\n")
+        .expect("listing must parse");
+    assert!(
+        !session_has_live_pane("tm-apex-01", &panes, &AlwaysIdleProbe),
+        "a session whose every pane is a bare shell must read as dead"
+    );
+}
+
+#[test]
+fn session_panes_foreign_rows_never_prove_our_session_dead() {
+    // Why (#3873 round 2): `session_has_live_pane` FILTERS by session name and
+    // returns false when nothing matches — correct for the daemon's whole-server
+    // listing, fail-CLOSED here where false is destructive. Pins the shape the
+    // membership guard in `session_runtime_live` exists to catch: rows that
+    // cannot be attributed to the session we asked about.
+    let panes = parse_pane_probes("tm-other-99\tzsh\t41234\n").expect("listing must parse");
+    assert!(
+        !panes.iter().any(|p| p.session_name == "tm-apex-01"),
+        "no row belongs to the session we asked about — the guard must fire and \
+         `session_runtime_live` must fail OPEN rather than consult the filter"
     );
 }
 

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -35,14 +35,13 @@ use crate::commands::guided::{
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{
-    ResumeAction, is_zombie, needs_restart, parse_pane_probes, plan_resume,
-    resume_classification_state, session_runtime_live,
+    ResumeAction, is_zombie, needs_restart, panes_prove_session_dead, parse_pane_probes,
+    plan_resume, resume_classification_state, session_runtime_live,
 };
 // #3873: the CLI's dead-runtime verdict composes the daemon's OWN liveness
 // primitives rather than reimplementing them, so the tests exercise that
 // composition directly.
 use trusty_mpm::daemon::orphan_gc::AlwaysIdleProbe;
-use trusty_mpm::daemon::runtime_reap::session_has_live_pane;
 // The picker decision enum + parser moved to the shared `session_picker` module.
 use crate::commands::session_picker::{PickerDecision, parse_picker_choice};
 
@@ -1445,49 +1444,80 @@ fn parse_pane_probes_rejects_empty_command_field() {
     );
 }
 
-// ── any-pane-live composition (#3873 round 2, code-critic MEDIUM / #2463) ────
-// `runtime_live` is the ANY-PANE-LIVE question over the whole session, not a
-// check of the record's single stored pane_id. These pin that the parsed rows
-// compose correctly with the daemon's own `session_has_live_pane` primitive.
+// ── panes_prove_session_dead (#3873 rounds 2–3 / #2463) ──────────────────
+// The single predicate between a parsed tmux listing and a `kill_session`. It is
+// phrased as "prove DEAD", so every uncertain input must fall out as `false`.
+// `AlwaysIdleProbe` isolates the command-word gate from the real process tree.
 
 #[test]
-fn session_panes_any_live_pane_keeps_session_live() {
-    // Why (#2463): a manually-split managed session can have an idle pane
-    // alongside a live agent pane. Checking one pane would call the session dead
-    // and — on this path — kill the live agent with it. AlwaysIdleProbe isolates
-    // the command-word gate: `claude` is not an idle shell, so the session lives.
-    let panes = parse_pane_probes("tm-apex-01\tzsh\t41234\ntm-apex-01\tclaude\t41999\n")
-        .expect("listing must parse");
-    assert!(
-        session_has_live_pane("tm-apex-01", &panes, &AlwaysIdleProbe),
-        "a sibling pane still running the agent must keep the session LIVE"
-    );
-}
-
-#[test]
-fn session_panes_all_idle_reads_dead() {
-    // Why (#3873): the actual defect shape — every pane fell back to a shell.
-    // This is the ONLY configuration allowed to reach the destructive branch.
+fn panes_prove_session_dead_when_every_pane_is_a_bare_shell() {
+    // Why (#3873): the actual defect shape, and the ONLY configuration allowed to
+    // reach the destructive reconcile branch.
     let panes = parse_pane_probes("tm-apex-01\tzsh\t41234\ntm-apex-01\tbash\t41999\n")
         .expect("listing must parse");
     assert!(
-        !session_has_live_pane("tm-apex-01", &panes, &AlwaysIdleProbe),
-        "a session whose every pane is a bare shell must read as dead"
+        panes_prove_session_dead("tm-apex-01", &panes, &AlwaysIdleProbe),
+        "a session whose every pane is a bare shell must be proven dead"
     );
 }
 
 #[test]
-fn session_panes_foreign_rows_never_prove_our_session_dead() {
-    // Why (#3873 round 2): `session_has_live_pane` FILTERS by session name and
-    // returns false when nothing matches — correct for the daemon's whole-server
-    // listing, fail-CLOSED here where false is destructive. Pins the shape the
-    // membership guard in `session_runtime_live` exists to catch: rows that
-    // cannot be attributed to the session we asked about.
+fn panes_prove_session_dead_refuses_when_a_sibling_pane_is_live() {
+    // Why (#2463): a manually-split managed session can have an idle pane
+    // alongside a live agent pane. Convicting on the idle one would kill the live
+    // agent with it. `claude` is not an idle shell, so the session is not dead.
+    let panes = parse_pane_probes("tm-apex-01\tzsh\t41234\ntm-apex-01\tclaude\t41999\n")
+        .expect("listing must parse");
+    assert!(
+        !panes_prove_session_dead("tm-apex-01", &panes, &AlwaysIdleProbe),
+        "a sibling pane still running the agent must block the dead verdict"
+    );
+}
+
+#[test]
+fn panes_prove_session_dead_refuses_a_prefix_matched_listing() {
+    // Why (#3873 round 3, code-critic MEDIUM): THE case the membership check
+    // exists for, and it is reachable rather than hypothetical. tmux
+    // PREFIX-MATCHES session targets: with only `tm-apex-01` alive,
+    // `has-session -t tm-apex` succeeds and `list-panes -s -t tm-apex` returns
+    // `tm-apex-01`'s panes. A record named `tm-apex` would then be handed a
+    // well-formed listing describing a DIFFERENT, live session. Without the
+    // membership check, `session_has_live_pane`'s filter matches nothing, reports
+    // `false` ("no live pane"), and that reads as "dead" — and the `kill_session`
+    // that follows prefix-matches onto that same live session. Deleting the check
+    // in `panes_prove_session_dead` must turn this test RED.
+    let panes = parse_pane_probes("tm-apex-01\tzsh\t41234\n").expect("listing must parse");
+    assert!(
+        !panes_prove_session_dead("tm-apex", &panes, &AlwaysIdleProbe),
+        "a prefix-matched listing describes ANOTHER session — it must never \
+         convict ours, whose own panes we have not actually seen"
+    );
+}
+
+#[test]
+fn panes_prove_session_dead_refuses_a_wholly_foreign_listing() {
+    // Why (#3873 round 3): the general form of the same hazard — whatever the
+    // cause (prefix match, a renamed session, a racing kill), a listing with no
+    // pane attributable to the session we asked about tells us NOTHING about it,
+    // and "nothing" must never be convicted as "dead".
     let panes = parse_pane_probes("tm-other-99\tzsh\t41234\n").expect("listing must parse");
     assert!(
-        !panes.iter().any(|p| p.session_name == "tm-apex-01"),
-        "no row belongs to the session we asked about — the guard must fire and \
-         `session_runtime_live` must fail OPEN rather than consult the filter"
+        !panes_prove_session_dead("tm-apex-01", &panes, &AlwaysIdleProbe),
+        "a listing belonging entirely to another session must not prove ours dead"
+    );
+}
+
+#[test]
+fn panes_prove_session_dead_ignores_foreign_rows_beside_our_own() {
+    // Why (#3873 round 3): the membership check must not over-correct into
+    // "any foreign row blocks the verdict" — our own panes, when present, are
+    // still the ones that decide. A foreign LIVE pane must not rescue a session
+    // whose own panes are all idle shells.
+    let panes = parse_pane_probes("tm-other-99\tclaude\t41000\ntm-apex-01\tzsh\t41234\n")
+        .expect("listing must parse");
+    assert!(
+        panes_prove_session_dead("tm-apex-01", &panes, &AlwaysIdleProbe),
+        "our own idle pane decides; a live pane in an unrelated session is not ours"
     );
 }
 


### PR DESCRIPTION
## The defect

Bare `tm` against a session whose **tmux session exists** but whose **agent runtime has exited** took the wrong branch: it `switch-client`ed the operator into a pane running a bare login shell and did nothing else. The operator then typed `tm` a second time — now *inside* that pane, where the in-place relaunch gate matches — and only then did the real relaunch happen.

This is not a double-invocation quirk. **Invocation #1 simply did not do the job.**

## Root cause

`commands/guided_resume.rs::plan_resume` decided "this session is live" from `tmux_live`, which is `tmux_has_session(&session.name)` — tmux **session existence**, not runtime liveness. Its own doc said *"everything else (active/provisioning with a live tmux) → Attach"*. So `(active, session-exists)` mapped to `Attach` even when the runtime was provably dead.

The path there, all under `crates/trusty-mpm/src/bin/tm/`:

- `main.rs` no subcommand → `commands::guided::run_guided_default`
- `guided.rs:101` `try_inplace_relaunch` requires `Stopped`; the record is `active`, so it declines
- `guided.rs:112` `nested_session_guard` matches by tmux session name; a different session → `None`
- `guided.rs:300`/`:319` → `try_show_picker` → `session_picker.rs:846` `PickerDecision::Resume`
- `guided_resume.rs` `resume_session` → `plan_resume(persisted_state, tmux_live)` → **`Attach`**

Live evidence: session `tm-apex-companion-01`, daemon record `state=active` / `pane_id=%333`, while tmux pane `%333` reported `pane_current_command=zsh` and `pgrep -P` returned no children — provably idle.

## The fix

`plan_resume` takes a third input, `runtime_live`, and maps `(active/provisioning, tmux_live = true, runtime_live = false)` → **`ReconcileThenRestart`**. That is the *existing* zombie recovery, which already does POST `/runtime-stop` → POST `/resume` → attach, so invocation #1 does the whole job.

Branch ordering is deliberate and pinned by tests:

- terminal tombstone (`decommissioned`/`deleted`) refusal stays **first** — a dead runtime must never resurrect a tombstone;
- `is_zombie` (tmux gone) is unchanged;
- `needs_restart` stays **ahead** of the new gate, so a Stopped/Errored record — whose pane is an idle shell too, and therefore also reports `runtime_live = false` — keeps taking the plain `Restart` path instead of a pointless `/runtime-stop` against an already-stopped record.

### Reusing the daemon's predicate, not reimplementing it

`runtime_live` is resolved by the new `pane_runtime_live(pane_id)`, which calls **`trusty_mpm::daemon::runtime_reap::pane_runtime_exited`** directly — the daemon reaper's own predicate, and therefore the same `orphan_gc::is_idle_shell` allowlist and the same `orphan_gc::ProcessTreeProbe` child gate. No idle-shell detection is duplicated in the CLI, and the two can never drift apart.

It was reachable with no new seam: `daemon` is `pub mod` in `lib.rs`, `runtime_reap` is `pub mod` in `daemon/mod.rs`, and `pane_runtime_exited` / `PaneInfo` / `ProcessTreeProbe` are all `pub`. The `bin/tm` binary already reaches into `trusty_mpm::daemon::*` elsewhere (`gh_identity.rs`, `commands/daemon_run.rs`).

The `PaneInfo` it feeds that predicate comes from a **single pane-id-targeted** `tmux display-message -p -t <pane_id> '#{pane_current_command} #{pane_pid}'` — deliberately **not** the `list-panes -a` whole-server enumeration, following the existing `session_for_pane` / `pane_tty_for` precedent in `tmux_attach.rs`. tmux resolves a pane id to exactly one pane or errors; there is nothing to guess and no composite row to mis-split.

### Fails open

`runtime_live = false` now triggers a `/runtime-stop` that **kills the pane**, so the only path to `false` is a positive two-gate identification (a recognised bare shell **and** no live child under the pane pid). Everything else returns `true`: no `pane_id` on the record, a failed or non-zero `tmux` call, an unparseable reply. A wrong `false` would destroy a live agent's pane; a wrong `true` merely reproduces today's already-shipped behavior.

The shell-out is also skipped entirely when `tmux_live` is false — `is_zombie` already classifies that record, and the pane is gone with the session.

## Scope — what this does NOT fix

**This does not fix the runtime-reaper defect, and does not depend on it.**

There is a second, deeper problem under separate investigation: the 60s runtime reaper (`daemon/mod.rs` → `daemon/runtime_reap.rs`) is not running — `daemon::runtime_reap` had zero log entries in 15h because pane enumeration is corrupted (`session_name` holding an entire underscore-joined row, `pane_current_command` empty — the #1813 composite-key regression shape). **Nothing in this PR touches `daemon/orphan_gc.rs` or `daemon/tmux.rs` enumeration.**

That is precisely why this ships on its own: the CLI asks the liveness question *itself, at resume time*, through a targeted single-pane query. It is correct whether the reaper is healthy, broken, or simply hasn't ticked yet.

## Sibling, not a duplicate: #4061 / PR #4065

#4061 is a **sibling** fix, not a duplicate. It patched only `fallback_protected`'s **non-git** branch in `guided.rs`, and is already in the 1.2.3 binary. The path fixed here is **git-backed** and returns via the picker — it never reaches `fallback_protected` at all.

## Test evidence

The required test was written first and observed RED against unmodified logic (the parameter was threaded through with the body untouched):

```
running 10 tests
test tests_behavior_c::guided_resume_plan_active_live_tmux_attaches ... ok
test tests_behavior_c::guided_resume_plan_active_live_tmux_dead_runtime_reconciles_then_restarts ... FAILED
test tests_behavior_c::guided_resume_plan_provisioning_live_tmux_dead_runtime_reconciles_then_restarts ... FAILED

---- guided_resume_plan_active_live_tmux_dead_runtime_reconciles_then_restarts stdout ----
assertion `left == right` failed
  left: Attach
 right: ReconcileThenRestart

test result: FAILED. 8 passed; 2 failed; 0 ignored; 0 measured; 1258 filtered out
```

GREEN after the one-branch fix, with the pre-existing attach case kept and updated to `runtime_live = true`:

```
test tests_behavior_c::guided_resume_plan_active_live_tmux_attaches ... ok
test tests_behavior_c::guided_resume_plan_active_live_tmux_dead_runtime_reconciles_then_restarts ... ok
test tests_behavior_c::guided_resume_plan_provisioning_live_tmux_dead_runtime_reconciles_then_restarts ... ok
test tests_behavior_c::guided_resume_plan_stopped_live_tmux_dead_runtime_still_plain_restarts ... ok
test tests_behavior_c::guided_resume_plan_active_no_tmux_reconciles_then_restarts ... ok
test tests_behavior_c::guided_resume_plan_provisioning_no_tmux_reconciles_then_restarts ... ok
test tests_behavior_c::guided_resume_plan_stopped_restarts ... ok
test tests_behavior_c::guided_resume_plan_stopped_with_stale_tmux_still_restarts ... ok
test tests_behavior_c::guided_resume_plan_errored_restarts ... ok
test tests_behavior_c::guided_resume_plan_resume_prefers_persisted_state_over_display_state ... ok
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 1258 filtered out

test tests_behavior_c::plan_resume_refuses_terminal_states ... ok
test tests_behavior_c::plan_resume_refuses_terminal_states_even_with_dead_runtime ... ok
test tests_behavior_c::pane_runtime_live_assumes_live_without_pane_id ... ok
test tests_behavior_c::parse_pane_probe_reads_command_and_pid ... ok
test tests_behavior_c::parse_pane_probe_tolerates_missing_pid ... ok
test tests_behavior_c::parse_pane_probe_none_for_empty_reply ... ok
```

Full crate suite, run **without** `--lib`:

```
$ cargo test -p trusty-mpm
test result: ok. 3894 passed; 0 failed; 6 ignored; ...
test result: ok. 1267 passed; 0 failed; 1 ignored; ...   (bin tm)
... 0 failures across every target
```

`cargo clippy -p trusty-mpm --all-targets` clean; `cargo fmt` applied; `scripts/check_line_cap.sh` → `7 allowlisted, 0 violations — OK`.

Every new test is a **pure-function** test: no `#[ignore]`, no env-var gate, no early return, no skip-when-missing, no global state, and therefore no `env_test_lock` / `#[serial_test::serial]` interaction to get wrong. `pane_runtime_live(None)` returns before any tmux shell-out. Assertions are on the specific `ResumeAction` variant.

## Nothing contradicting the root cause

Verified line-by-line against `origin/main` (6ef47ecb) before changing anything; every cited anchor held except `try_show_picker`'s call sites, which have drifted from `guided.rs:282` to `:300`/`:319`.

Closes #3873

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools

---

## Round 2 — review follow-up

### HIGH (fixed): the reconcile branch reached a session kill silently

The critic traced past my local doc comment (which said only "marks the record `Stopped`"):
`stop_managed_session_runtime` → `SessionManager::stop` (`manager.rs`) → `graceful_terminate_runtime` → **`kill_session(tmux_name)`** (`restart_ops.rs`). **Session-scoped — every window, every pane.**

That is free for the #2001 zombie, whose session is already gone. But **the #3873 shape has a live session by definition**, so this was a newly-destructive step on an input that previously took a harmless `Attach`. My removal of the warning reasoned "in neither case is there in-progress runtime state left to warn about losing" — that accounted only for the *recorded* pane, and the plain `Restart` branch twenty lines below already discloses exactly this for the identical `tmux_live == true` situation.

The reconcile branch now discloses it, naming what is lost:

```
tm: session 'tm-apex-01' is active but its runtime has exited — every pane in the
tmux session is now an idle shell. Restarting will KILL that tmux session (all
windows and panes, including their scrollback) and start a fresh runtime.
```

`reconcile_zombie_stop`'s doc comment — the one that made this easy to miss — now documents the full server-side chain and flags the call as destructive.

**Sibling-pane check: it gates, and it does so structurally.** Rather than bolting a `session_has_live_pane` call on beside the existing verdict, `runtime_live` *is* now the any-pane-live question (see the third finding below). A session with one idle pane and one live agent pane can no longer reach the destructive branch at all — the guard cannot be bypassed by a future edit that forgets to call it, because there is no separate call to forget.

### MEDIUM (fixed): a missing pid collapsed the two-gate check to one

`parse_pane_probe` returned `Some((cmd, None))` for input like `"zsh notanumber"`, and `ProcessTreeProbe::has_live_child(None)` returns `false`, so `pane_runtime_exited` degenerated to `is_idle_shell` alone — contradicting the "two-gate" contract I documented.

I accept the framing. `None → false` is **correct calibration for the daemon**, because #2023 A deliberately made the reaper non-destructive (record flips, pane survives). Reusing that gate is still right for consistency — but **the CLI must be stricter than the daemon, not equal**, because its consequence is a `kill_session`. Parsing now requires exactly three non-empty tab-separated fields with a numeric pid; anything else means "cannot determine" and fails open.

RED before, showing the exact defective value:

```
---- parse_pane_probes_rejects_non_numeric_pid stdout ----
  left: Some([PaneInfo { session_name: "tm-apex-01", pane_current_command: "zsh",
                         pane_pid: None, pane_id: None }])
 right: None
test result: FAILED. 6 passed; 1 failed
```

GREEN after, with the sibling cases pinned too:

```
test parse_pane_probes_reads_every_pane ... ok
test parse_pane_probes_rejects_non_numeric_pid ... ok
test parse_pane_probes_rejects_missing_pid ... ok
test parse_pane_probes_rejects_smeared_row ... ok
test parse_pane_probes_rejects_extra_fields ... ok
test parse_pane_probes_rejects_empty_command_field ... ok
test parse_pane_probes_rejects_empty_or_blank_listing ... ok
```

### Third finding (MEDIUM, `session_name: String::new()`): judged reachable — fixed, not argued away

The critic flagged this as a missing guard whose reachability it could not establish. My judgement: **it is reachable, and it was the more serious of the two sub-problems.**

- *Any-pane-live.* The codebase states twice that a managed session can carry sibling panes (#2463 `session_has_live_pane`, #2456 hijack note). A manual `tmux split-window` is an ordinary thing to do. With a single-pane check, a session whose recorded pane went idle while a sibling pane still ran the agent would be classified dead — and killed. Reachable by any operator who splits a pane.
- *Pane membership.* Nothing verified that the recorded `pane_id` still belonged to this session. tmux pane ids are not reused within a server's lifetime, but a record can outlive a tmux server restart, after which `%333` may be an unrelated live pane.

Both are fixed by asking a different question. `session_runtime_live` now runs a **session-scoped** `tmux list-panes -s -t <session>` and delegates to the daemon's own `session_has_live_pane` — the exact #2463 primitive I had bypassed. Membership holds by construction (a `-t <session>` listing cannot return another session's panes), so the fabricated `session_name` is gone, and the verdict is any-pane-live rather than one-pane.

One fail-closed corner needed an explicit guard: `session_has_live_pane` filters by session name and returns `false` when *nothing* matches. That is right for the daemon (a whole-server listing with no match means the session is gone) but destructive here, so a listing that cannot be attributed to the session we asked about fails open instead.

```
test session_panes_any_live_pane_keeps_session_live ... ok
test session_panes_all_idle_reads_dead ... ok
test session_panes_foreign_rows_never_prove_our_session_dead ... ok
test session_runtime_live_assumes_live_for_blank_session_name ... ok
```

The TAB delimiter is also deliberate: it cannot occur in a session name or command word, so the columns cannot smear the way the space-joined `list-panes -a` format does. `parse_pane_probes_rejects_smeared_row` pins the #1813 shape. Still no `list-panes -a`, still nothing touched in `daemon/orphan_gc.rs` or `daemon/tmux.rs`.

### Doc correction

The empirical note is now in the code: on tmux 3.6b an invalid target can return **rc=0 with near-empty stdout**, so the `!status.success()` guard is belt-and-braces and the *parse-returned-`None`* path is the real protection — which is the one that is unit-tested.

### A real failure this surfaced, and the end-to-end test it produced

The full suite turned up a genuine failure — not a flake:

```
---- session_resume_headless_active_live_tmux_skips_restart_and_attach stdout ----
tm: session 'tm-r-01' is provisioning but its runtime has exited — every pane ...
tm: cannot restart session 'tm-r-01': workspace directory ... no longer exists
```

That test builds its fixture with a bare `tmux new-session -d`, which lands the pane on a **login shell** — i.e. since #3873 it is a *dead runtime*. The fixture had stopped expressing the live-session case the test asserts about. It now runs an explicit long-lived command.

That gap was worth closing in the other direction too, since the critic had independently checked whether `SessionManager::resume`'s "re-attach to live pane" branch would make this a silent no-op. **`session_resume_headless_dead_runtime_reconciles_and_restarts`** now drives the dead-runtime shape end-to-end against a real daemon and asserts the record reached `active` — which only a `/runtime-stop` + `/resume` round-trip can do. Reverting the one-line fix makes it fail deterministically:

```
  left: Some("provisioning")
 right: Some("active")
... the CLI attached into the idle shell instead, i.e. the #3873 defect is back
```

Two fixture hazards were fixed while doing this, both of which had made the tests non-deterministic:

- A freshly created pane **transiently reports a live child** while its shell runs rc files, so a single probe was a statement about the developer's dotfiles rather than the fixture. Both tests now wait for three agreeing reads, and **panic** at the deadline rather than silently proceeding on an unsettled fixture.
- Both tests create sessions in the **machine-global tmux namespace** under names derived from the repo URL, and this crate compiles the same sources into two bin targets that cargo may run concurrently — so one process's unconditional `kill-session` cleanup could destroy the other's session mid-test. Names are now process-unique.

I diagnosed this by capturing the actual failure output rather than assuming; my first hypothesis (name collision) was wrong, and the captured `resumed ... [provisioning]` line in 0.07s is what identified the transient-child race.

### Round-2 evidence

```
$ cargo test -p trusty-mpm            # no --lib
TOTAL passed=6717 failed=0
```

Determinism, after the fixture fixes — 8 consecutive full-suite runs:

```
full-suite run 1..8: 0 failing
```

`cargo clippy -p trusty-mpm --all-targets -- -D warnings` → exit 0.
`cargo fmt -p trusty-mpm --check` → exit 0.
`scripts/check_line_cap.sh` → `7 allowlisted, 0 violations — OK`.

All pure-function tests remain free of globals, `#[ignore]`, env gates, and early returns. The two integration tests use per-test isolated temp roots and their own uniquely-named tmux sessions, touch no process-global env var, and clean up unconditionally.

Still **not merged**, and the reaper defect is still explicitly out of scope and untouched.

### Round-2 CI follow-up

The first round-2 push went red on CI — a genuine finding, not infrastructure. The new end-to-end test asserted the record reached `active`, which *additionally* requires the daemon to successfully SPAWN a runtime. CI has no agent binary on PATH, so `/resume` legitimately ends in `errored` there:

```
tm: session 'tm-deadrt30598-01' restarted but the runtime failed to start.
... restarted but runtime failed to start (state=errored)
```

Note what that output proves: the reconcile path *did* run in CI — `/runtime-stop` and `/resume` both landed. The test was failing on an outcome downstream of its own claim.

The claim is the branch SELECTION, and its discriminator is environment-independent: `Attach` performs **no daemon round-trip at all**, so the seeded `provisioning` survives untouched, while reconcile-then-restart necessarily moves the record off it (to `stopped`, then `active` or `errored`). The assertion is now `!= "provisioning"`, which stays sharp — reverting the one-line fix still fails it deterministically:

```
assertion `left != right` failed: ... i.e. the #3873 defect is back
  left: "provisioning"
 right: "provisioning"
```

**All 23 checks now pass**, with every new test confirmed running in CI:

```
test commands::managed::tests::session_resume_headless_active_live_tmux_skips_restart_and_attach ... ok
test commands::managed::tests::session_resume_headless_dead_runtime_reconciles_and_restarts ... ok
test tests_behavior_c::guided_resume_plan_active_live_tmux_dead_runtime_reconciles_then_restarts ... ok
test tests_behavior_c::guided_resume_plan_provisioning_live_tmux_dead_runtime_reconciles_then_restarts ... ok
test tests_behavior_c::parse_pane_probes_reads_every_pane ... ok
test tests_behavior_c::parse_pane_probes_rejects_non_numeric_pid ... ok
test tests_behavior_c::parse_pane_probes_rejects_missing_pid ... ok
test tests_behavior_c::parse_pane_probes_rejects_smeared_row ... ok
test tests_behavior_c::parse_pane_probes_rejects_extra_fields ... ok
test tests_behavior_c::parse_pane_probes_rejects_empty_command_field ... ok
test tests_behavior_c::parse_pane_probes_rejects_empty_or_blank_listing ... ok
test tests_behavior_c::session_panes_any_live_pane_keeps_session_live ... ok
test tests_behavior_c::session_panes_all_idle_reads_dead ... ok
test tests_behavior_c::session_panes_foreign_rows_never_prove_our_session_dead ... ok
test tests_behavior_c::session_runtime_live_assumes_live_for_blank_session_name ... ok
```

---

## Round 3

### KNOWN LIMITATION — read this before "fixing" the any-pane-live question

**A split session whose agent pane died, but which still has some other pane running a non-shell command, is NOT fixed by this PR.** Bare `tm` will still `Attach` the operator into the idle agent pane there, exactly as #3873 describes.

Concretely, #3873 **is** fixed for:
- a single-pane managed session whose runtime exited (the reported case), and
- a split session in which every pane has fallen back to an idle shell.

It is **not** fixed for:
- a split session where the agent pane is idle but a sibling pane runs `vim`, `tail -f`, a stray `node`, or anything else outside `orphan_gc::IDLE_SHELL_COMMANDS`. That session reads as live, and `Attach` is chosen.

This is the direct consequence of the any-pane-live design, and it is a deliberate trade rather than an oversight. Any-pane-live is what makes the destructive branch safe (#2463: convicting on one pane would kill a session whose sibling still runs the agent), and the same widening is what bounds the fix. Escaping the trade requires **per-pane runtime identity** — knowing *which* pane the agent owned and judging only that one — and the stored `pane_id` cannot supply that reliably enough to gate a `kill_session` on, since it can be stale or reused across a tmux server restart.

The asymmetry is what settles it: the unfixed case costs an operator one extra `tm`, which is today's already-shipped behaviour. Getting it wrong in the other direction destroys a live session. **Do not narrow the question back to a single pane without solving the pane-identity problem first** — that is the regression this design guards against.

The same note is recorded in the `guided_resume` module doc and the CHANGELOG, so it is discoverable from the code and not only from this PR.

### MEDIUM (fixed): the membership guard was pinned by no test

Confirmed the finding by running Mutation A myself — delete the guard, change nothing else:

```
MUTATION A APPLIED: membership guard deleted
test result: FAILED. 1282 passed; 2 failed; 1 ignored
```

...which is *after* the new tests. Before them, Mutation A left the suite fully green, exactly as reported. `session_panes_foreign_rows_never_prove_our_session_dead` asserted a property of its own **input** (`!panes.iter().any(...)`) and never called the guarded function — a test named for a guard it does not exercise. Having found that shape once already today, I take the point.

I also verified the hazard is reachable rather than theoretical, since that is what justifies the guard's existence:

```
$ tmux new-session -d -s tm3873probe-X "sh"; tmux display-message -p -t tm3873probe-X '#{pane_current_command}'
bash
```

tmux prefix-matches session targets, so a record named `tm-apex` receives `tm-apex-01`'s panes from both `has-session` and `list-panes -s`. Without the guard, `session_has_live_pane`'s filter matches nothing → `false` → read as "dead" → `kill_session`, which then prefix-matches onto that same live session.

**The fix:** extracted `panes_prove_session_dead(session_name, panes, probe)` as a pure seam. It is phrased as *"prove DEAD"* rather than *"is live"* on purpose — the burden of proof belongs on the destructive answer, so every uncertain input falls out as `false` by construction rather than depending on a caller to remember an inversion.

Five tests replace the one tautological test:

```
test panes_prove_session_dead_when_every_pane_is_a_bare_shell ... ok
test panes_prove_session_dead_refuses_when_a_sibling_pane_is_live ... ok
test panes_prove_session_dead_refuses_a_prefix_matched_listing ... ok
test panes_prove_session_dead_refuses_a_wholly_foreign_listing ... ok
test panes_prove_session_dead_ignores_foreign_rows_beside_our_own ... ok
test result: ok. 5 passed; 0 failed
```

The last one guards the *over-correction*: a foreign live pane must not rescue a session whose own panes are all idle. RED under Mutation A is the prefix-match and foreign-listing pair; the other three stay green, which is what makes them a guard-specific pin rather than a blunt tripwire.

### Comment correction

`managed_tests.rs` reasoned about `sh` while tmux launches the argument through its default-shell — `pane_current_command` is `bash`, verified empirically above. Outcome is identical (both are in `IDLE_SHELL_COMMANDS`), but the comment described a process that is not what runs. Corrected, including *why* the substitution is harmless.

### Round-3 evidence

```
$ cargo test -p trusty-mpm            # no --lib
TOTAL passed=6745 failed=0            # 3 consecutive runs, 0 failing
```

`cargo clippy -p trusty-mpm --all-targets -- -D warnings` → exit 0
`cargo fmt -p trusty-mpm --check` → exit 0
`scripts/check_line_cap.sh` → `7 allowlisted, 0 violations — OK`
`scripts/check_test_pointers.sh` → `0 dangling pointers — OK` (exit 0)

Isolation re-verified after the change — 3 further integration runs:

```
tmux sessions before=11 after=11
0 leaked fixture sessions
```

Branch is current with `origin/main` (0 commits behind). Still **not merged**; reaper defect still untouched; no scope added beyond the two requested items and the one comment correction.
