### PR TITLE
docs(trusty-mpm): correct stale `.invalid` fixture-convention pointer

### DIFF
--- a/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs
@@ -12,10 +12,17 @@
 //! directory do NOT exist, and one opted-in/unset control asserting the
 //! worktree IS created at its exact expected path.
 //! Fixture remotes: every origin here uses the non-resolvable `.invalid` TLD
-//! (RFC 2606) with fixture-only owner/repo names, following the convention
-//! `tests_behavior_c_tests.rs:1570-1580` documents. An earlier revision used
-//! the REAL `bobmatnyc/writing` and `bob-duetto/cto` remotes, and the
-//! guard-neutralised revert run proved why that is wrong: `ensure_base_clone`
+//! (RFC 2606) with fixture-only owner/repo names. THIS paragraph is the
+//! canonical statement of that convention — cite it (file + this `Fixture
+//! remotes:` heading, never a line range) from any new test that needs the
+//! rationale. A previous revision forwarded readers to a line range in
+//! `tests_behavior_c_tests.rs` instead; that pointer was always wrong (that
+//! file lives one directory up, its cited lines hold unrelated
+//! `guided_resume_plan_*` tests, and it does not contain the string
+//! `.invalid` anywhere), and the line range is exactly the part that rotted.
+//! An earlier revision of the FIXTURES used the REAL `bobmatnyc/writing` and
+//! `bob-duetto/cto` remotes, and the guard-neutralised revert run proved why
+//! that is wrong: `ensure_base_clone`
 //! genuinely cloned both private repos over the network (88.43s vs 0.28s
 //! baseline). The assertion under test is the opt-out DECISION, never that a
 //! clone succeeds, so a host that cannot resolve is lossless here and keeps


### PR DESCRIPTION
## Summary

Comment-only correction of a stale doc pointer in
`crates/trusty-mpm/src/bin/tm/commands/managed_workspace_tests.rs`.

Surfaced while working on #4305 (the double-provision leak). That is a
**separate, still-open** issue and this PR deliberately uses no closing
keyword for it — nothing here touches the leak.

## The defect (verified against `origin/main` @ `aed80140`)

The module doc said fixture remotes follow "the convention
`` `tests_behavior_c_tests.rs:1570-1580` `` documents". That pointer is wrong
on every axis:

| Claim | Reality on `aed80140` |
| --- | --- |
| sibling file `tests_behavior_c_tests.rs` | lives at `crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs` — one directory **up** from `commands/` |
| lines 1570-1580 document the convention | those lines hold `guided_resume_plan_provisioning_no_tmux_reconciles_then_restarts` and `plan_resume_refuses_terminal_states` — unrelated resume-planner tests |
| the convention lives there | `grep -c '\.invalid'` over that 2377-line file returns **0** |

**Where the convention actually lives:** in `managed_workspace_tests.rs`
itself, in the very `Fixture remotes:` paragraph that carried the bad
pointer (`:14-22` on main) — including the 88.43s-vs-0.28s network-clone
evidence for why real remotes were replaced with `.invalid` hosts. The
comment was forwarding readers away from its own answer.

This was actively misleading: the bogus reference had already been copied
into a ticket brief this week.

## The change

Rewrote the `Fixture remotes:` paragraph to state that it *is* the canonical
home of the convention, and to say what the dead pointer was so a reader who
has the old text in hand recognises it.

**Stable anchor over line range.** New citations are directed at
*file + the `Fixture remotes:` heading*, explicitly "never a line range" —
the line range is exactly the part that rotted here, and it rots on any
unrelated edit above it.

## Sweep

Swept for the same stale-pointer class, deliberately not wider:

- `git grep 'tests_behavior_c_tests'` — **28** references on main. Exactly
  **one** carried a line range: the one fixed here. Every other one is a
  bare filename or a `Test: <test_name>` citation, both valid forms.
- `git grep -i 'rfc ?2606|non-resolvable'` — **2** hits, both in the fixed
  paragraph. No other file documents or forwards to this convention.
- `git grep '\.invalid'` — all other hits are fixture *usages*
  (`ci@test.invalid`, `github.invalid/...`), no other convention pointers.

**Total stale pointers of this class found: 1. Fixed: 1.**

## Could `scripts/check_test_pointers.sh` have caught this? No.

The lint passes clean (`0 dangling pointers`) on `aed80140` **with the bad
pointer present**, and passes clean after. Two structural reasons:

1. It only scans annotations whose doc line starts with the literal
   `Test:`. This citation sat under a `Fixture remotes:` heading, so it was
   never even a candidate.
2. Even inside a `Test:` block it validates **test names only** — each
   backticked span is resolved via `git grep` for `fn <name>(` / `mod <name>`
   within the citing crate. It has no notion of a *file path* or a *line
   range*, so `foo.rs:1570-1580` is not a checkable citation shape at all.

That is a real gap: doc pointers of the form `file.rs:NNN-MMM` are
completely unlinted, and there are ~15 more of them across the workspace
(`agent_patch.rs:180-189`, `listeners/poll.rs:326-331`, …) whose validity
nobody has mechanically checked. **Not fixed in this PR** — flagged so it
can be triaged on its own.

## Verification

Zero behavior change — `git diff` touches only `//!` lines:

```
$ git diff -U0 | grep -E '^[+-]' | grep -vE '^(\+\+\+|---)' | grep -vE '^[+-]//!'
(empty)

$ git diff --stat
 .../src/bin/tm/commands/managed_workspace_tests.rs | 15 +++++++++++----
 1 file changed, 11 insertions(+), 4 deletions(-)
```

| Gate | Result |
| --- | --- |
| `cargo test -p trusty-mpm` (no `--lib`) | **exit 0** — 44 test binaries, **6745 passed, 0 failed** |
| `cargo fmt --check` | **exit 0** |
| `cargo clippy --all-targets -- -D warnings` | **exit 0** |
| `scripts/check_line_cap.sh` | **exit 0** — `7 allowlisted, 0 violations — OK.` |
| `scripts/check_test_pointers.sh` | **exit 0** — `0 dangling pointers — OK.` |

Both known-accepted flakes passed on this run:
`telegram::supervisor::tests::healthy_run_resets_transient_backoff` (load-sensitive
wall clock) and `tm_hook_pm_guard` (fails only from a `/private/tmp/...` cwd,
per the #3955 guard) — this run used an in-repo worktree.

No CHANGELOG entry: `CONTRIBUTING.md` states no per-PR changelog requirement
and the workspace `CHANGELOG.md` files are generated by `git-cliff`
(`cliff.toml`) from conventional commits at release time.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
