### PR TITLE
feat(trusty-agents): register an agent's declared [[plugins.python]] tools

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -49,6 +49,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`[[plugins.python]]` tools declared by an agent are finally registered and
+  callable (#446, epic #3052).** The `PythonToolPlugin` subprocess primitive
+  (spawn `python3 <script>`, one NDJSON `tool_call` in / one `tool_result`
+  out, per-call timeout, fail-closed RBAC tier guard) has shipped fully
+  unit-tested since #446, and `AgentConfig` has parsed `[plugins]` for just as
+  long — but nothing in the workspace ever called
+  `PythonToolPlugin::from_config`, so an agent or skill package declaring a
+  `[[plugins.python]]` tool had its declaration parsed and then silently
+  dropped: never registered, never advertised, never callable, no warning.
+  `run_pm_task_with_persona` now reads `persona_cfg.plugins.python` and
+  registers each entry via a new `persona_plugins::register_python_plugins`
+  helper, resolving a package-relative `script` / `schema_file` against the
+  agent/skill package dir (the same `config_dir` the delegation runner is
+  handed), so `script = "../skills/foo/foo.py"` reaches a co-located skill
+  package. Registration is not a grant: the `[tools].allow` glob filter, the
+  RBAC tier filter and the scope gate all still decide whether the tool
+  reaches the model. Two non-fatal skip paths keep one bad line in one agent
+  TOML from taking down a chat turn — an entry `from_config` rejects (e.g. an
+  unknown `restricted_tiers` string, fail-closed since #3236) is logged and
+  skipped, and an entry whose name is already taken by a native or MCP tool is
+  refused rather than registered (`ToolRegistry::register` overwrites silently
+  in release and `debug_assert!`s in debug, so an unguarded registration would
+  have made a debug-build panic reachable straight from user-authored config).
+  SECURITY NOTE, unchanged by this PR and worth restating now that the path is
+  live: the Python subprocess has NO OS-level sandbox — RBAC gates WHO may call
+  the tool, not WHAT the script does once spawned. KNOWN GAP: this wires the
+  in-process persona-chat dispatch path only; the subprocess `--agent` path
+  (`runtime::tool_registry::build_assistant_tier_registry`, which takes no
+  `AgentConfig`) still ignores `[[plugins.python]]` and needs its own change.
 - **The app header shows the running daemon's version.** A quiet provenance
   line sits beside the brand lockup, read from `GET /api/health` — the version
   of the daemon the UI is actually talking to, not what the frontend was

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/mod.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/mod.rs
@@ -15,6 +15,9 @@ mod persona;
 // sits exactly at the 500-SLOC production cap.
 mod persona_gate;
 mod persona_memory;
+// #446 (epic #3052): `[[plugins.python]]` registration, split out of
+// `persona.rs` for the same SLOC-cap reason as `persona_gate`.
+mod persona_plugins;
 
 pub use history::run_pm_task_with_history;
 pub use persona::run_pm_task_with_persona;

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona.rs
@@ -35,6 +35,7 @@ use super::persona_gate::{
     persona_max_turns,
 };
 use super::persona_memory;
+use super::persona_plugins::register_python_plugins;
 
 /// Run a single conversation turn against a persona agent (#254).
 ///
@@ -428,6 +429,29 @@ pub async fn run_pm_task_with_persona(
                 for tool in &plugin.tools {
                     registry.register(std::sync::Arc::clone(tool));
                 }
+            }
+
+            // #446 (epic #3052): the agent's OWN `[[plugins.python]]` tools.
+            // Registered LAST among the in-process sources and BEFORE live MCP
+            // discovery below, so a user-authored plugin can shadow neither a
+            // native tool (guarded inside the helper) nor be shadowed by a
+            // late-discovered MCP tool (the `existing_names` seed below already
+            // contains it by then). `config_dir` is the base for a
+            // package-relative `script` — the same agent/skill package dir the
+            // delegation runner was handed above, so `script = "../skills/
+            // foo/foo.py"` reaches a co-located skill package.
+            let python_plugin_names = register_python_plugins(
+                &mut registry,
+                &persona_cfg.plugins.python,
+                &config_dir,
+                persona_name,
+            );
+            if !python_plugin_names.is_empty() {
+                tracing::info!(
+                    persona = %persona_name,
+                    plugins = ?python_plugin_names,
+                    "registered [[plugins.python]] tools"
+                );
             }
 
             // #3238: live-discover MCP servers (`[[mcp.services]] discover =

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_plugins.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_plugins.rs
@@ -1,0 +1,95 @@
+//! `[[plugins.python]]` registration for the persona-chat dispatch path (#446).
+//!
+//! Why: the `PythonToolPlugin` subprocess primitive
+//! (`plugins::python_tool` — spawn `python3 <script>`, one NDJSON `tool_call`
+//! in / one `tool_result` out, per-call timeout, fail-closed RBAC tier guard)
+//! has been fully built and unit-tested since #446, and `AgentConfig` has
+//! parsed `[plugins]` into `AgentPluginsConfig` for just as long — but NOTHING
+//! in the workspace ever called `PythonToolPlugin::from_config`. An agent or
+//! skill package declaring a `[[plugins.python]]` tool therefore had its
+//! declaration parsed and then silently dropped: the tool was never
+//! registered, never advertised, never callable, and no warning was emitted.
+//! This module is that missing seam. It lives in its own file rather than
+//! inline in `persona.rs` for the same reason `persona_gate` does — `persona.rs`
+//! sits just under the 500-SLOC production cap enforced by
+//! `scripts/check_line_cap.sh` — and, like `build_persona_delegate_tool`, it
+//! returns/mutates the EXACT value `run_pm_task_with_persona` uses so the unit
+//! tests drive the production construction rather than a re-derived copy.
+//! What: [`register_python_plugins`] — builds each declared entry via
+//! `PythonToolPlugin::from_config`, resolving a package-relative `script` /
+//! `schema_file` against the caller's `base_dir`, and registers it into the
+//! persona's `ToolRegistry`. Two independent skip paths, both non-fatal:
+//! a name already taken by an earlier registration, and a config
+//! `from_config` rejects (e.g. an unknown `restricted_tiers` string, which
+//! #3236 made fail closed). Registration is NOT a grant — the `[tools].allow`
+//! glob filter, the RBAC tier filter and the scope gate in
+//! `persona_gate::filter_persona_tool_names_for_tier` all still run afterwards
+//! and decide whether the tool reaches the LLM.
+//! Test: `persona_python_plugin_registers_callable_tool`,
+//! `persona_python_plugin_bad_config_is_skipped`,
+//! `persona_python_plugin_does_not_shadow_an_existing_tool`,
+//! `persona_python_plugin_empty_list_registers_nothing`; the CALL SITE in
+//! `run_pm_task_with_persona` is pinned end-to-end by
+//! `persona_python_plugin_is_registered_by_the_dispatch_path`
+//! (`tests/persona_python_plugin_wiring.rs`).
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::plugins::{PythonPluginConfig, PythonToolPlugin};
+use crate::tools::ToolRegistry;
+
+/// Register a persona's declared `[[plugins.python]]` entries as callable
+/// tools (#446, epic #3052).
+///
+/// Why: this is the whole fix — see the module doc for why the declaration
+/// was inert before. Written as a standalone function taking `&mut
+/// ToolRegistry` (rather than building a fresh registry, or returning
+/// executors for the caller to register) so the tests can assert on the same
+/// registry type the dispatch path arms and then actually DISPATCH through it,
+/// proving the tool is callable and not merely present in a list.
+/// What: for each entry, in declaration order — skip (WARN) when `base` already
+/// holds a tool of that name, so a user-authored plugin can never shadow a
+/// native/MCP tool the persona also holds (`ToolRegistry::register` overwrites
+/// silently in release and `debug_assert!`s in debug, so an unguarded
+/// registration here would be a debug-build panic triggerable from agent TOML);
+/// skip (WARN) when `PythonToolPlugin::from_config` rejects the entry, so one
+/// typo costs one tool rather than the whole chat turn; otherwise register it.
+/// Returns the names actually registered, in order, so the caller logs what it
+/// got rather than what was asked for.
+/// Test: `persona_python_plugin_registers_callable_tool` (registered AND
+/// dispatchable, with a package-relative `script`),
+/// `persona_python_plugin_bad_config_is_skipped`,
+/// `persona_python_plugin_does_not_shadow_an_existing_tool`,
+/// `persona_python_plugin_empty_list_registers_nothing`.
+pub(super) fn register_python_plugins(
+    registry: &mut ToolRegistry,
+    plugins: &[PythonPluginConfig],
+    base_dir: &Path,
+    persona_name: &str,
+) -> Vec<String> {
+    let mut registered = Vec::with_capacity(plugins.len());
+    for cfg in plugins {
+        let plugin_name = cfg.name.clone();
+        if registry.contains(&plugin_name) {
+            tracing::warn!(
+                persona = %persona_name,
+                plugin = %plugin_name,
+                "skipping [[plugins.python]] entry: a tool of that name is already registered"
+            );
+            continue;
+        }
+        match PythonToolPlugin::from_config(cfg.clone(), base_dir) {
+            Ok(plugin) => {
+                registry.register(Arc::new(plugin));
+                registered.push(plugin_name);
+            }
+            Err(e) => tracing::warn!(
+                persona = %persona_name,
+                plugin = %plugin_name,
+                "skipping [[plugins.python]] entry: {e}"
+            ),
+        }
+    }
+    registered
+}

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_tests.rs
@@ -1051,3 +1051,209 @@ async fn persona_delegate_tool_leaves_non_assistant_roles_ungated() {
     assert!(!is_error, "non-assistant persona must stay ungated: {msg}");
     assert_eq!(spawned, 1, "runner must be reached exactly once");
 }
+
+// ---------------------------------------------------------------------------
+// #446 (epic #3052): `[[plugins.python]]` registration — `persona_plugins`.
+// ---------------------------------------------------------------------------
+
+/// Whether the interpreter `PythonToolPlugin` will actually spawn is
+/// invokable, so the dispatch test below skips rather than fails on a
+/// Rust-only box.
+///
+/// Why: mirrors `plugins::python_tool::tests::python_available` verbatim
+/// (same env-var override, same `--version` probe) instead of hardcoding
+/// `python3`, so this test resolves the SAME interpreter the plugin does.
+fn persona_python3_available() -> bool {
+    let python = crate::env_compat::env_var("TAGENT_PYTHON", "OPEN_MPM_PYTHON")
+        .unwrap_or_else(|_| "python3".to_string());
+    std::process::Command::new(&python)
+        .arg("--version")
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+/// Registered tool names (schema `function.name`) for a registry.
+fn registered_tool_names(registry: &crate::tools::ToolRegistry) -> Vec<String> {
+    registry
+        .schemas()
+        .into_iter()
+        .filter_map(|s| {
+            s.get("function")
+                .and_then(|f| f.get("name"))
+                .and_then(|n| n.as_str())
+                .map(String::from)
+        })
+        .collect()
+}
+
+/// A `[[plugins.python]]` entry with a PACKAGE-RELATIVE `script` becomes a
+/// registered, CALLABLE tool (#446).
+///
+/// Why: the whole defect was that `run_pm_task_with_persona` never called
+/// `PythonToolPlugin::from_config`, so the declaration parsed and vanished. A
+/// test that only asserted the name appears in `schemas()` would pass over a
+/// plugin whose `script` was resolved against the wrong base and could never
+/// run — so this dispatches through the production `ToolRegistry` and asserts
+/// on the script's real NDJSON `tool_result` content. That pins BOTH halves:
+/// relative-`script` resolution against `base_dir` (the `config_dir` the
+/// dispatch path passes) and end-to-end callability.
+/// What: writes a minimal NDJSON-contract script into a temp package dir,
+/// declares it by a bare relative filename, registers via
+/// `register_python_plugins`, then dispatches and asserts the echoed payload.
+/// Skipped (not failed) when no python interpreter is on PATH.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn persona_python_plugin_registers_callable_tool() {
+    if !persona_python3_available() {
+        eprintln!("SKIP persona_python_plugin_registers_callable_tool: no python interpreter");
+        return;
+    }
+    let pkg_dir = tempfile::tempdir().expect("temp package dir");
+    // Reads one `tool_call` line, echoes one `tool_result` line embedding the
+    // `symbol` param — the same envelope `plugins::python_tool` speaks.
+    std::fs::write(
+        pkg_dir.path().join("price.py"),
+        "import sys, json\n\
+call = json.loads(sys.stdin.readline())\n\
+sym = call.get('params', {}).get('symbol', '?')\n\
+print(json.dumps({'type': 'tool_result', 'id': call.get('id'), \
+'status': 'success', 'content': 'price of ' + sym + ': 42'}))\n",
+    )
+    .expect("write script");
+
+    let cfg: crate::plugins::PythonPluginConfig = toml::from_str(
+        "name = \"coin_price\"\n\
+description = \"Get a coin price\"\n\
+script = \"price.py\"\n",
+    )
+    .expect("plugin config parses");
+
+    let mut registry = crate::tools::ToolRegistry::new();
+    let registered = register_python_plugins(
+        &mut registry,
+        std::slice::from_ref(&cfg),
+        pkg_dir.path(),
+        "demo-assistant",
+    );
+
+    assert_eq!(registered, vec!["coin_price".to_string()]);
+    let names = registered_tool_names(&registry);
+    assert!(
+        names.iter().any(|n| n == "coin_price"),
+        "python plugin must register under its declared name, got {names:?}"
+    );
+
+    let result = registry
+        .dispatch("coin_price", serde_json::json!({"symbol": "bitcoin"}))
+        .await;
+    assert!(
+        !result.is_error(),
+        "python plugin dispatch errored: {}",
+        result.content()
+    );
+    assert_eq!(result.content(), "price of bitcoin: 42");
+}
+
+/// A malformed `[[plugins.python]]` entry is skipped, never fatal (#446).
+///
+/// Why: `PythonToolPlugin::from_config` fails CLOSED on an unrecognized
+/// `restricted_tiers` string (#3236). If that error propagated out of the
+/// registration helper, one typo in one agent's TOML would abort the entire
+/// chat turn — a config error escalating into a total outage for that persona.
+/// What: an entry with a bogus tier is absent from the registry afterwards and
+/// the helper still returns normally.
+/// Test: this function IS the test.
+#[test]
+fn persona_python_plugin_bad_config_is_skipped() {
+    let cfg: crate::plugins::PythonPluginConfig = toml::from_str(
+        "name = \"broken\"\n\
+description = \"bad tier\"\n\
+script = \"x.py\"\n\
+restricted_tiers = [\"not_a_real_tier\"]\n",
+    )
+    .expect("config itself parses; only from_config rejects the bad tier");
+
+    let mut registry = crate::tools::ToolRegistry::new();
+    let registered = register_python_plugins(
+        &mut registry,
+        std::slice::from_ref(&cfg),
+        std::path::Path::new("/tmp"),
+        "demo-assistant",
+    );
+
+    assert!(
+        registered.is_empty(),
+        "a rejected entry must not be reported"
+    );
+    let names = registered_tool_names(&registry);
+    assert!(
+        !names.iter().any(|n| n == "broken"),
+        "a plugin with an invalid config must be skipped, not registered: {names:?}"
+    );
+}
+
+/// A `[[plugins.python]]` entry may not take over a name already registered
+/// (#446).
+///
+/// Why: `run_pm_task_with_persona` registers this path's plugins AFTER the
+/// full native/CTRL/filesystem/search surface. `ToolRegistry::register`
+/// overwrites silently in release and `debug_assert!`s in debug, so an
+/// unguarded registration would let an agent TOML either hijack `create_dir`
+/// in production or panic every debug build that loads it — a crash reachable
+/// from user-authored config. The helper must refuse instead.
+/// What: pre-register the real `CreateDirTool`, then declare a python plugin
+/// called `create_dir`; the surviving executor is still the native one.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn persona_python_plugin_does_not_shadow_an_existing_tool() {
+    let cfg: crate::plugins::PythonPluginConfig = toml::from_str(
+        "name = \"create_dir\"\n\
+description = \"impostor\"\n\
+script = \"impostor.py\"\n",
+    )
+    .expect("plugin config parses");
+
+    let mut registry = crate::tools::ToolRegistry::new();
+    registry.register(std::sync::Arc::new(CreateDirTool));
+    let registered = register_python_plugins(
+        &mut registry,
+        std::slice::from_ref(&cfg),
+        std::path::Path::new("/tmp"),
+        "demo-assistant",
+    );
+
+    assert!(
+        registered.is_empty(),
+        "a colliding entry must be skipped, not reported as registered"
+    );
+    let schema = registry
+        .schemas()
+        .into_iter()
+        .find(|s| s.pointer("/function/name").and_then(|n| n.as_str()) == Some("create_dir"))
+        .expect("create_dir must still be registered");
+    let description = schema
+        .pointer("/function/description")
+        .and_then(|d| d.as_str())
+        .unwrap_or_default();
+    assert!(
+        !description.contains("impostor"),
+        "the native create_dir must survive; got description {description:?}"
+    );
+}
+
+/// A persona with no `[plugins]` section registers nothing and warns about
+/// nothing (#446) — the no-op that keeps every existing agent unchanged.
+///
+/// Test: this function IS the test.
+#[test]
+fn persona_python_plugin_empty_list_registers_nothing() {
+    let mut registry = crate::tools::ToolRegistry::new();
+    let registered =
+        register_python_plugins(&mut registry, &[], std::path::Path::new("/tmp"), "izzie");
+
+    assert!(registered.is_empty());
+    assert!(registry.schemas().is_empty());
+}

--- a/crates/trusty-agents/tests/persona_python_plugin_wiring.rs
+++ b/crates/trusty-agents/tests/persona_python_plugin_wiring.rs
@@ -14,9 +14,11 @@
 //! `$HOME` at it, captures `trusty_agents` tracing output, and calls the
 //! dispatch function. The LLM leg is deliberately routed at a local (absent)
 //! Ollama endpoint via `SessionOverrides::provider = "local"`, so the turn
-//! fails AFTER the registry is built, with no external network call and no
-//! credential of any kind required — the assertions are on the captured
-//! registry, not on a model reply. Two things are asserted: the plugin was
+//! fails AFTER the registry is built and no external network call is made; a
+//! placeholder `OPENROUTER_API_KEY` satisfies `llm::create_client`'s
+//! before-the-registry credential check without ever being transmitted. The
+//! assertions are on the captured registry, not on a model reply. Two things
+//! are asserted: the plugin was
 //! registered, and it SURVIVED the `[tools].allow` / RBAC / scope gate into the
 //! set advertised to the model — a plugin registered but gated away would be
 //! just as useless as one never registered.
@@ -123,15 +125,25 @@ content = "Probe persona. Call demo_python_echo."
     // `AgentConfig::by_name_async` resolve our throwaway package (and nothing
     // from the developer's real `~/.trusty-agents`); `HOME` sandboxes the
     // second resolution tier and the global MCP config for the same reason.
+    //
+    // `OPENROUTER_API_KEY` is a PLACEHOLDER and is never transmitted: the
+    // `provider = "local"` override below routes the chat leg at a local
+    // Ollama endpoint, which sends no auth header. It is set because
+    // `llm::create_client` runs BEFORE the registry is built and hard-fails
+    // when no credential of any kind resolves — which is exactly how the first
+    // CI run of this test failed while passing on a developer box that happened
+    // to have a real key exported. Set unconditionally (not only when unset) so
+    // the test behaves identically in both environments.
     unsafe {
         std::env::set_var("TAGENT_CONFIG_DIR", &agents_dir);
         std::env::set_var("HOME", project.path());
+        std::env::set_var("OPENROUTER_API_KEY", "placeholder-never-transmitted");
     }
 
-    // `provider = "local"` forces the Ollama routing branch: no credential is
-    // required, and the eventual chat call targets localhost rather than any
-    // paid or external endpoint. It cannot short-circuit to the claude-cli
-    // path, so the registry below is always built.
+    // `provider = "local"` forces the Ollama routing branch, so the eventual
+    // chat call targets localhost rather than any paid or external endpoint. It
+    // cannot short-circuit to the claude-cli path, so the registry below is
+    // always built.
     let overrides = SessionOverrides {
         provider: Some("local".to_string()),
         ..Default::default()

--- a/crates/trusty-agents/tests/persona_python_plugin_wiring.rs
+++ b/crates/trusty-agents/tests/persona_python_plugin_wiring.rs
@@ -1,0 +1,172 @@
+//! Call-site regression test for `[[plugins.python]]` wiring (#446, epic #3052).
+//!
+//! Why: the unit tests in `ctrl::pm_task::dispatch::persona_plugins`' test
+//! module prove the registration HELPER works, but the defect this PR fixes
+//! was never in a helper — it was that `run_pm_task_with_persona` never called
+//! one. A helper-only test would have passed just as happily against the
+//! broken tree. This test therefore drives the REAL dispatch entry point (the
+//! same `trusty_agents::ctrl::run_pm_task_with_persona` the REPL `/agent`
+//! command, the HTTP API, Slack and Telegram all funnel persona chat into) and
+//! asserts on what that function actually built. Delete the call site and this
+//! test goes red while everything else stays green.
+//! What: writes a throwaway agent package declaring one `[[plugins.python]]`
+//! tool with a package-relative `script`, points `TAGENT_CONFIG_DIR` and
+//! `$HOME` at it, captures `trusty_agents` tracing output, and calls the
+//! dispatch function. The LLM leg is deliberately routed at a local (absent)
+//! Ollama endpoint via `SessionOverrides::provider = "local"`, so the turn
+//! fails AFTER the registry is built, with no external network call and no
+//! credential of any kind required — the assertions are on the captured
+//! registry, not on a model reply. Two things are asserted: the plugin was
+//! registered, and it SURVIVED the `[tools].allow` / RBAC / scope gate into the
+//! set advertised to the model — a plugin registered but gated away would be
+//! just as useless as one never registered.
+//! Test: `persona_python_plugin_is_registered_by_the_dispatch_path` — this
+//! file IS the test.
+
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use trusty_agents::ctrl::{SessionOverrides, run_pm_task_with_persona};
+
+/// `tracing_subscriber` writer that appends every formatted event to a shared
+/// buffer, so the test can assert on what the production code logged.
+#[derive(Clone)]
+struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+impl std::io::Write for CaptureWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+            .write(buf)
+            .map(|_| buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+    type Writer = CaptureWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// A persona declaring `[[plugins.python]]` gets that tool registered AND
+/// advertised by the production dispatch path (#446).
+///
+/// Why: see the module doc — this is the only assertion in the suite that
+/// fails if the `register_python_plugins` CALL in `run_pm_task_with_persona`
+/// is removed while the helper itself survives.
+/// What: drives the real entry point against a sandboxed agent package and
+/// asserts on the two tracing events the registry build emits. The dispatch
+/// result is intentionally ignored: the turn is expected to fail at the LLM
+/// leg (no model server), which happens long after the registry is built.
+/// Test: this function IS the test.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn persona_python_plugin_is_registered_by_the_dispatch_path() {
+    let buffer = Arc::new(Mutex::new(Vec::<u8>::new()));
+    let _ = tracing_subscriber::fmt()
+        .with_writer(CaptureWriter(Arc::clone(&buffer)))
+        .with_env_filter(tracing_subscriber::EnvFilter::new("trusty_agents=info"))
+        .with_ansi(false)
+        .try_init();
+
+    let project = tempfile::tempdir().expect("temp project dir");
+    let agents_dir = project.path().join(".trusty-agents").join("agents");
+    std::fs::create_dir_all(&agents_dir).expect("create agents dir");
+
+    // The bundled script, referenced below by a PACKAGE-RELATIVE path — the
+    // co-located-with-its-package layout the plugin model is built around.
+    std::fs::write(
+        agents_dir.join("echo_tool.py"),
+        "import sys, json\n\
+call = json.loads(sys.stdin.readline())\n\
+print(json.dumps({'type': 'tool_result', 'id': call.get('id'), \
+'status': 'success', 'content': 'ok'}))\n",
+    )
+    .expect("write plugin script");
+
+    std::fs::write(
+        agents_dir.join("pyplug-probe.toml"),
+        r#"
+[agent]
+name = "pyplug-probe"
+role = "assistant"
+model = "llama3"
+description = "throwaway persona for the [[plugins.python]] wiring test"
+
+[llm]
+temperature = 0.0
+max_tokens = 64
+
+[tools]
+allow = ["demo_python_echo"]
+
+[[plugins.python]]
+name = "demo_python_echo"
+description = "Echo tool bundled with this agent package."
+script = "echo_tool.py"
+timeout_secs = 5
+
+[system_prompt]
+content = "Probe persona. Call demo_python_echo."
+"#,
+    )
+    .expect("write agent toml");
+
+    // SAFETY: this integration test is the ONLY test in its binary, so nothing
+    // else in this process can observe the mutation. `TAGENT_CONFIG_DIR` makes
+    // `AgentConfig::by_name_async` resolve our throwaway package (and nothing
+    // from the developer's real `~/.trusty-agents`); `HOME` sandboxes the
+    // second resolution tier and the global MCP config for the same reason.
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", &agents_dir);
+        std::env::set_var("HOME", project.path());
+    }
+
+    // `provider = "local"` forces the Ollama routing branch: no credential is
+    // required, and the eventual chat call targets localhost rather than any
+    // paid or external endpoint. It cannot short-circuit to the claude-cli
+    // path, so the registry below is always built.
+    let overrides = SessionOverrides {
+        provider: Some("local".to_string()),
+        ..Default::default()
+    };
+
+    // The turn is EXPECTED to fail (no local model server). The registry is
+    // built well before that, which is all this test observes. A generous
+    // timeout keeps a hung network probe from wedging CI instead of failing.
+    let _ = tokio::time::timeout(
+        Duration::from_secs(120),
+        run_pm_task_with_persona(
+            project.path(),
+            "pyplug-probe",
+            "call the echo tool",
+            &[],
+            None,
+            overrides,
+        ),
+    )
+    .await;
+
+    let logs =
+        String::from_utf8_lossy(&buffer.lock().unwrap_or_else(|e| e.into_inner())).to_string();
+
+    assert!(
+        logs.contains("registered [[plugins.python]] tools") && logs.contains("demo_python_echo"),
+        "run_pm_task_with_persona must register the agent's declared \
+         [[plugins.python]] tools; captured logs:\n{logs}"
+    );
+    assert!(
+        logs.contains("persona tool registry built")
+            && logs.lines().any(
+                |l| l.contains("persona tool registry built") && l.contains("demo_python_echo")
+            ),
+        "the registered python plugin must survive the [tools].allow / RBAC / \
+         scope gate into the advertised tool set; captured logs:\n{logs}"
+    );
+}


### PR DESCRIPTION
## The defect

`[[plugins.python]]` declared in an agent or skill package was **parsed and
then silently dropped**. `PythonToolPlugin::from_config` had zero production
call sites anywhere in the workspace — the primitive was fully built and
unit-tested, `AgentConfig` parsed `[plugins]` into `AgentPluginsConfig`, and
nothing ever turned that config into a registered tool. No error, no warning:
the declaration just did nothing.

```
$ rg 'PythonToolPlugin::from_config' crates/   # before this PR
crates/trusty-agents/src/plugins/python_tool/tests.rs:132
crates/trusty-agents/src/plugins/python_tool/tests.rs:159
crates/trusty-agents/src/plugins/python_tool/tests.rs:336
crates/trusty-agents/src/plugins/python_tool/tests.rs:357
```

Four hits, all tests.

## The fix

`run_pm_task_with_persona` now reads `persona_cfg.plugins.python` and registers
each entry through a new `persona_plugins::register_python_plugins`. A
package-relative `script` / `schema_file` resolves against the agent/skill
package dir — the same `config_dir` the delegation runner is already handed —
so `script = "../skills/foo/foo.py"` reaches a co-located skill package.

The helper lives in its own module for the same reason `persona_gate` does:
`persona.rs` sits just under the 500-SLOC production cap. Like
`build_persona_delegate_tool`, it mutates the **exact** registry the dispatch
path arms, so the tests drive the production construction rather than a
re-derived copy of it.

Registration is not a grant. The `[tools].allow` glob filter, the RBAC tier
filter and the scope gate in `filter_persona_tool_names_for_tier` all still run
afterwards and decide whether the tool reaches the model.

Two non-fatal skip paths, so one bad line in one agent TOML costs one tool
rather than the whole chat turn:

- an entry `from_config` rejects (e.g. an unknown `restricted_tiers` string,
  fail-closed since #3236) is logged and skipped;
- an entry whose name is **already registered** is refused.
  `ToolRegistry::register` overwrites silently in release and `debug_assert!`s
  in debug, so an unguarded registration here would have made a debug-build
  panic reachable straight from user-authored config — and a production
  hijack of `create_dir` / `run_bash` reachable the same way. This guard is
  new relative to the abandoned draft this work started from.

## Tests

Four unit tests on the helper (`persona_tests.rs`):

| test | pins |
|---|---|
| `persona_python_plugin_registers_callable_tool` | registered **and dispatchable** through the real `ToolRegistry`, with a package-relative `script` |
| `persona_python_plugin_bad_config_is_skipped` | a rejected entry does not abort the turn |
| `persona_python_plugin_does_not_shadow_an_existing_tool` | the native `create_dir` survives an impostor declaration |
| `persona_python_plugin_empty_list_registers_nothing` | no-op for every existing agent |

Plus `tests/persona_python_plugin_wiring.rs`, which drives the **real**
`run_pm_task_with_persona` against a sandboxed throwaway agent package
(`TAGENT_CONFIG_DIR` + `$HOME` redirected to a tempdir) and asserts on the
tracing output that the plugin was registered *and* survived the allow / RBAC /
scope gate into the advertised set. The LLM leg is routed at a local absent
Ollama endpoint via `SessionOverrides::provider = "local"`, so it needs no
credential and makes no external call — the assertions are on the registry the
function built, not on a model reply.

### Proof the test is not vacuous

The unit tests would pass against a tree where the helper exists but nothing
calls it — which is exactly the shape of the original defect. The integration
test is the one that closes that. Removing **only** the call site from
`persona.rs` (helper and unit tests untouched):

```
test persona_python_plugin_is_registered_by_the_dispatch_path ... FAILED

run_pm_task_with_persona must register the agent's declared
[[plugins.python]] tools; captured logs:
...
INFO trusty_agents::ctrl::pm_task::dispatch::persona: persona tool registry built
     persona=pyplug-probe tools=[] rbac_user=cli rbac_tier=All
```

`tools=[]` — the declared plugin reached the model as nothing at all, which is
precisely the production bug. Call site restored → green in 7.2s.

## Gate

```
cargo test -p trusty-agents        2960 passed; 0 failed; 11 ignored  (lib)
                                   + 28 passed across 8 integration binaries
cargo clippy -p trusty-agents --all-targets -- -D warnings   clean
cargo fmt --all --check                                      clean
scripts/check_line_cap.sh          7 allowlisted, 0 violations — OK
scripts/check_test_pointers.sh     0 dangling pointers — OK
scripts/check_sld.sh               0 errors, 0 warnings
```

Nothing was `#[ignore]`d, cfg-gated, or excluded to reach green.

## Scope notes

**SECURITY** (unchanged by this PR, restated because the path is now live): the
Python subprocess has **no OS-level sandbox**. RBAC gates *who* may call the
tool, not *what* the script does once spawned. Reaching it still requires an
explicit `[[plugins.python]]` declaration **and** an explicit `[tools].allow`
entry — file presence alone executes nothing — but the review / allowlisting /
`uv`-isolation model in epic #3235 is **not** implemented here and that epic
stays open.

**KNOWN GAP**: this wires the in-process persona-chat dispatch path only. The
subprocess `--agent` path (`runtime::tool_registry::build_assistant_tier_registry`,
which takes no `AgentConfig`) still ignores `[[plugins.python]]` — the #3745
item-C "a capability model that holds on only one dispatch path" hazard, called
out in the CHANGELOG and left for a follow-up rather than folded in here.

Relates to epic #3052 and epic #3235. Deliberately **no** closing keyword: the
`#446` referenced throughout this code is a pre-migration issue number from a
different repo's sequence (this repo's #446 is an unrelated merged
trusty-memory PR), and neither open epic is fully closed by this change.

## Fixtures deliberately not included

The draft this work started from also carried a `demo-assistant.toml` agent and
a two-file `crypto-price` skill (CoinGecko + offline fallback), wired to an
`#[ignore]`d live-LLM e2e test. Skipped: they are demo scaffolding, not
coverage — the `#[ignore]` meant they gated nothing, and shipping a
`.trusty-agents/` package inside the crate would add an unreferenced agent with
a network dependency to the published artifact. Both tests here build their own
minimal NDJSON-contract fixtures at runtime instead.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools