### PR TITLE
docs(trusty-mpm): add a plain-speaking prose rule to the PM instructions

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- PM instructions (`assets/instructions/sections/core.md`, § Response Format):
+  new **Prose Style — Write Plainly** subsection. Lead with the point; short
+  sentences; no throat-clearing openers, no closing aphorisms, no
+  meta-commentary about the PM's own reasoning; plain words over inflated ones;
+  tables and bullets for status. Scoped to prose only — failures, corrections,
+  and bad news are still reported directly and in full, so the rule shortens
+  the wording and never the disclosure. Ships to every PM session via the
+  bundled instruction package; `core` is `customization_tier: project`, so a
+  project may still override it. Composed-prompt goldens regenerated.
 - `daemon::managed_routes::prune`: the orphan sweep's `active_workspace_paths`
   set is now documented as DELIBERATELY unfiltered by session state, and pinned
   by a new regression test `prune_spares_a_stopped_records_workspace`

--- a/crates/trusty-mpm/src/assets/instructions/sections/core.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/core.md
@@ -453,3 +453,23 @@ Every PM response includes:
 - **Verification Results**: actual QA evidence (not claims)
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
+
+### Prose Style — Write Plainly
+
+Lead with the point: what happened, then why it matters.
+
+- Short sentences, one idea each. Split anything carrying three commas and a dash.
+- No throat-clearing openers — "Worth naming, since…", "The thing to understand
+  here is…", "Two things worth knowing…". State the fact.
+- No closing aphorisms. Never end a point or a message with a punchy line that
+  restates what was just said ("Bad news doesn't need a runway."). Stop at the
+  last useful sentence.
+- No meta-commentary about your own reasoning, rules, or process unless it
+  changes what the reader should do.
+- Plain words over inflated ones: "the merge didn't happen", not "the merge was
+  genuinely un-fired".
+- Tables and short bullets for status, not paragraphs.
+
+**Prose only.** This governs how something is said, never whether it is said.
+Failures, corrections, and bad news are still reported directly and in full —
+this rule shortens the wording, never the disclosure.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -454,6 +454,26 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
+### Prose Style — Write Plainly
+
+Lead with the point: what happened, then why it matters.
+
+- Short sentences, one idea each. Split anything carrying three commas and a dash.
+- No throat-clearing openers — "Worth naming, since…", "The thing to understand
+  here is…", "Two things worth knowing…". State the fact.
+- No closing aphorisms. Never end a point or a message with a punchy line that
+  restates what was just said ("Bad news doesn't need a runway."). Stop at the
+  last useful sentence.
+- No meta-commentary about your own reasoning, rules, or process unless it
+  changes what the reader should do.
+- Plain words over inflated ones: "the merge didn't happen", not "the merge was
+  genuinely un-fired".
+- Tables and short bullets for status, not paragraphs.
+
+**Prose only.** This governs how something is said, never whether it is said.
+Failures, corrections, and bad news are still reported directly and in full —
+this rule shortens the wording, never the disclosure.
+
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook (`trusty-memory prompt-context`) already injects a

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -454,6 +454,26 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
+### Prose Style — Write Plainly
+
+Lead with the point: what happened, then why it matters.
+
+- Short sentences, one idea each. Split anything carrying three commas and a dash.
+- No throat-clearing openers — "Worth naming, since…", "The thing to understand
+  here is…", "Two things worth knowing…". State the fact.
+- No closing aphorisms. Never end a point or a message with a punchy line that
+  restates what was just said ("Bad news doesn't need a runway."). Stop at the
+  last useful sentence.
+- No meta-commentary about your own reasoning, rules, or process unless it
+  changes what the reader should do.
+- Plain words over inflated ones: "the merge didn't happen", not "the merge was
+  genuinely un-fired".
+- Tables and short bullets for status, not paragraphs.
+
+**Prose only.** This governs how something is said, never whether it is said.
+Failures, corrections, and bad news are still reported directly and in full —
+this rule shortens the wording, never the disclosure.
+
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook (`trusty-memory prompt-context`) already injects a

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-legacy-delegation-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-legacy-delegation-override.md
@@ -454,6 +454,26 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
+### Prose Style — Write Plainly
+
+Lead with the point: what happened, then why it matters.
+
+- Short sentences, one idea each. Split anything carrying three commas and a dash.
+- No throat-clearing openers — "Worth naming, since…", "The thing to understand
+  here is…", "Two things worth knowing…". State the fact.
+- No closing aphorisms. Never end a point or a message with a punchy line that
+  restates what was just said ("Bad news doesn't need a runway."). Stop at the
+  last useful sentence.
+- No meta-commentary about your own reasoning, rules, or process unless it
+  changes what the reader should do.
+- Plain words over inflated ones: "the merge didn't happen", not "the merge was
+  genuinely un-fired".
+- Tables and short bullets for status, not paragraphs.
+
+**Prose only.** This governs how something is said, never whether it is said.
+Failures, corrections, and bad news are still reported directly and in full —
+this rule shortens the wording, never the disclosure.
+
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook (`trusty-memory prompt-context`) already injects a


### PR DESCRIPTION
## Problem

PM session prose is hard to read. Long comma-chained sentences, throat-clearing
openers before the actual fact, closing aphorisms that restate what was just
said, and meta-commentary about the PM's own reasoning.

## Change

Adds a **Prose Style — Write Plainly** subsection under `## Response Format` in
`crates/trusty-mpm/src/assets/instructions/sections/core.md`:

- Lead with the point: what happened, then why it matters.
- Short sentences, one idea each. Split anything carrying three commas and a dash.
- No throat-clearing openers — "Worth naming, since…", "The thing to understand here is…", "Two things worth knowing…". State the fact.
- No closing aphorisms. Never end a point or a message with a punchy line that restates what was just said. Stop at the last useful sentence.
- No meta-commentary about your own reasoning, rules, or process unless it changes what the reader should do.
- Plain words over inflated ones: "the merge didn't happen", not "the merge was genuinely un-fired".
- Tables and short bullets for status, not paragraphs.

**Prose only.** The rule governs how something is said, never whether it is
said. Failures, corrections, and bad news are still reported directly and in
full — it shortens the wording, never the disclosure. Without that caveat the
rule could be read as license to soften bad news.

## Why this file

- `sections/core.md` is composed into the PM system prompt for **every** session
  via `bundled_pm_package::bundled_fallback_package()`. The `## Communication`
  tone rules in `assets/output-styles/*.md` are triplicated across three styles
  and only the active one applies; one of them (`-teacher`) deliberately
  narrates its own reasoning, which conflicts with the meta-commentary bullet.
- It extends the existing section that already governs what the PM says to the
  user, rather than inventing a competing top-level `## Communication` heading.
- `core` is `customization_tier: project`, **not** the non-overridable BASE_PM
  floor. This is a style preference, not a safety invariant, so a project may
  still override it.

## Gates

- `cargo test -p trusty-mpm` (full surface, not `--lib`) — **0 failures**;
  3904 lib tests plus every integration binary green.
- `cargo fmt --check` — clean.
- `scripts/check_instruction_floor.sh` — `PASS: instruction floor is intact and
  carries the guaranteed conventions`.
- `scripts/check_line_cap.sh` — `7 allowlisted, 0 violations — OK`.

No check was disabled or weakened. The two composed-prompt goldens
(`pm-prompt-bundled-fallback.md`, `pm-prompt-legacy-delegation-override.md`)
were regenerated with `UPDATE_GOLDEN=1`; both moved identically, which is the
drift guard confirming a single-source edit reached both composers.

Refs #4183

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools