### PR TITLE
feat(trusty-mpm): read named-section PM instruction overrides from CLAUDE.md

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,61 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`CLAUDE.md` named-section instruction overrides — reader** (epic
+  [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183),
+  [#4286](https://github.com/bobmatnyc/trusty-tools/issues/4286)): a project can
+  now override one PM instruction section by marking it out inside its own
+  `CLAUDE.md`, instead of maintaining a second instruction surface under
+  `.trusty-mpm/`. New module `core::claude_md_sections`. The grammar, matched
+  whole-line:
+
+  ```
+  <!-- TRUSTY-MPM: WORKFLOW START v=1 -->
+  …override content…
+  <!-- TRUSTY-MPM: WORKFLOW END -->
+  ```
+
+  The token is the section id kebab-case uppercased (`CORE`, `MEMORY`, `SEARCH`,
+  `WORKFLOW`, `AGENT-DELEGATION`), matched case-insensitively; text outside
+  markers is ignored. Hosts scanned, in precedence order:
+  `<project>/CLAUDE.md`, then `<project>/.trusty-mpm/INSTRUCTIONS.md` —
+  `CLAUDE.md` wins a same-section collision, and a marked block in
+  `INSTRUCTIONS.md` is removed from the additive project addendum so it is
+  delivered once. A marker-free `INSTRUCTIONS.md` is passed through byte-for-byte
+  and keeps feeding the addendum exactly as before.
+
+  **The package is the sole authority on what may be overridden.** The new
+  `InstructionPackage::with_overrides` asks each section's declared
+  `customization_tier`, so the three floor sections (`identity`,
+  `non-overridable-rules`, `framework-guaranteed-conventions`) refuse every
+  `CLAUDE.md` override and compose byte-identically to no `CLAUDE.md` at all. An
+  override replaces only its section's authored text blocks — generated blocks
+  survive, so an `AGENT-DELEGATION` override rewrites the routing doctrine but
+  cannot suppress the live agent roster
+  ([#4196](https://github.com/bobmatnyc/trusty-tools/issues/4196)).
+
+  Nothing here fails a launch. A missing or unreadable `CLAUDE.md`, an unclosed
+  or nested marker pair, an unknown token, an unknown `v=`, an override aimed at
+  the floor, an empty body, and a package that stops validating all degrade to
+  the bundled section, each with a `warn!` naming the file, line and reason. A
+  missing `v=` is accepted as `v=1` for this release, with a warning. `tm` still
+  never writes a project's `CLAUDE.md`
+  ([#2170](https://github.com/bobmatnyc/trusty-tools/issues/2170)), now asserted
+  by test.
+
+  This ships the READER before the floor text that advertises the mechanism —
+  advertising an override no code reads is
+  [#381](https://github.com/bobmatnyc/trusty-tools/issues/381) verbatim. The five
+  `.trusty-mpm/` override files are untouched and keep working; a project still
+  carrying one composes through the sectionless legacy assembly, and its named
+  sections are reported unapplied rather than dropped in silence.
+
+  A third committed prompt snapshot, `testdata/pm-prompt-claude-md-override.md`,
+  makes the delivered shape of an override reviewable. Both existing goldens are
+  byte-unchanged.
+
 ### Changed
 
 - `daemon::managed_routes::prune`: the orphan sweep's `active_workspace_paths`

--- a/crates/trusty-mpm/src/core/bundled_pm_package.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package.rs
@@ -59,6 +59,7 @@
 //!
 //! Test: `bundled_pm_package_tests.rs`.
 
+use crate::core::claude_md_sections::{Rejection, SectionOverride};
 use crate::core::instruction_overrides::ROSTER_PRECEDENCE_NOTE;
 use crate::core::instruction_package::{
     BlockBody, CompositionError, CompositionInputs, CustomizationTier, Generator, InstructionBlock,
@@ -246,7 +247,7 @@ pub(crate) fn bundled_fallback_package() -> InstructionPackage {
     }
 }
 
-/// Compose the bundled-fallback PM prompt.
+/// Compose the bundled-fallback PM prompt, applying named-section overrides.
 ///
 /// Why: the single entry point `resolve_pm_prompt` calls for configuration 1.
 /// Keeping build and compose together means the caller cannot compose a package
@@ -254,25 +255,37 @@ pub(crate) fn bundled_fallback_package() -> InstructionPackage {
 /// argument, so the #4196 "computed but never delivered" shape is not
 /// expressible here.
 ///
-/// What: builds the package, then composes it with `stack` (the derived stack
-/// profile), `roster` (the rendered `## Delegation Authority` block, required)
-/// and `addendum` (`.trusty-mpm/INSTRUCTIONS.md`, if any). All three are trimmed
-/// by the composer. The result is byte-identical to `instruction_overrides`'
-/// legacy assembly for the same inputs — see the module docs.
+/// `CLAUDE.md` named sections (#4183 / #4286) arrive here rather than through a
+/// second string-splice, because this is the only composer that HAS sections and
+/// because [`InstructionPackage::with_overrides`] asks the package's own
+/// `customization_tier` for permission. The floor refuses a `CLAUDE.md` override
+/// for exactly the reason it refuses every other one: it is tier `fixed`.
+///
+/// What: builds the package, applies `overrides`, then composes with `stack`
+/// (the derived stack profile), `roster` (the rendered `## Delegation Authority`
+/// block, required) and `addendum` (`.trusty-mpm/INSTRUCTIONS.md`, if any). All
+/// are trimmed by the composer. Declined overrides come back alongside the
+/// result so the caller can report them. With an empty `overrides` slice the
+/// result is byte-identical to the pre-#4286 composition — `with_overrides` then
+/// returns a clone — and to `instruction_overrides`' legacy assembly for the
+/// same inputs; see the module docs.
 ///
 /// Test: `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`,
 /// `composed_prompt_carries_the_live_roster_and_the_precedence_note`,
-/// `roster_is_required_and_never_droppable`.
-pub(crate) fn compose_bundled_fallback(
+/// `roster_is_required_and_never_droppable`, `golden_claude_md_override_prompt`.
+pub(crate) fn compose_bundled_fallback_with_overrides(
     stack: &str,
     roster: &str,
     addendum: Option<&str>,
-) -> Result<String, CompositionError> {
-    bundled_fallback_package().compose(&CompositionInputs {
+    overrides: &[SectionOverride],
+) -> (Result<String, CompositionError>, Vec<Rejection>) {
+    let (package, rejected) = bundled_fallback_package().with_overrides(overrides);
+    let composed = package.compose(&CompositionInputs {
         agent_roster: roster.to_string(),
         stack_profile: Some(stack.to_string()),
         project_addendum: addendum.map(str::to_string),
-    })
+    });
+    (composed, rejected)
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
@@ -29,6 +29,21 @@ use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
 
+/// The no-override composition, which every gate below is written against.
+///
+/// Why: #4286 gave the production composer an `overrides` parameter. Keeping
+/// the zero-override call behind its original name is not cosmetic — it means
+/// none of the byte-equality gates in this file were touched by that change, so
+/// they still compare exactly what they compared before it.
+/// What: [`compose_bundled_fallback_with_overrides`] with no overrides.
+fn compose_bundled_fallback(
+    stack: &str,
+    roster: &str,
+    addendum: Option<&str>,
+) -> Result<String, CompositionError> {
+    compose_bundled_fallback_with_overrides(stack, roster, addendum, &[]).0
+}
+
 /// A fixed, deterministic roster — the composition-time input the byte-equality
 /// gate holds constant.
 ///

--- a/crates/trusty-mpm/src/core/claude_md_sections.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections.rs
@@ -1,0 +1,681 @@
+//! Named-section PM instruction overrides read from the project's `CLAUDE.md`.
+//!
+//! Why: project customization of the PM prompt is spread across five separate
+//! files under `<project>/.trusty-mpm/` ([`crate::core::instruction_overrides`]),
+//! which forces a project to maintain a second instruction surface next to the
+//! `CLAUDE.md` it already has, and gives each override file whole-document
+//! granularity. Epic #4183 collapses that onto ONE surface: a named section
+//! marked out inside `CLAUDE.md` overrides exactly the matching
+//! [`SectionId`] of the bundled instruction package, and nothing else.
+//!
+//! This module is the READER, and it ships **before** the floor text that
+//! advertises the mechanism. Shipping the advertisement first is issue #381
+//! verbatim — `BASE_PM.md` told the PM it could drop override files into
+//! `.trusty-mpm/` for two years while no code read them, so every advertised
+//! override was a silent no-op. An override mechanism must be readable before it
+//! is documented, never after.
+//!
+//! What: the marker grammar, the host search list, and
+//! [`InstructionPackage::with_overrides`] — the single point that decides whether
+//! a parsed override may replace a section. The grammar, matched whole-line:
+//!
+//! ```text
+//! <!-- TRUSTY-MPM: WORKFLOW START v=1 -->
+//! …override content, verbatim…
+//! <!-- TRUSTY-MPM: WORKFLOW END -->
+//! ```
+//!
+//! The section token is the [`SectionId`] kebab-case name uppercased (`CORE`,
+//! `MEMORY`, `SEARCH`, `WORKFLOW`, `AGENT-DELEGATION`, and the three floor
+//! tokens), matched case-insensitively. Content is what lies strictly between
+//! the two marker lines, trimmed. Text outside markers is not instruction
+//! content and is ignored.
+//!
+//! Hosts are scanned in [`HOST_FILES`] order and `CLAUDE.md` wins a same-section
+//! collision, because it is the surface #4183 is moving customization TO.
+//!
+//! WHO DECIDES WHAT IS OVERRIDABLE — the package, and only the package. This
+//! module never carries a list of overridable sections; it asks
+//! [`crate::core::instruction_package::CustomizationTier::permits`] for the
+//! section as the shipped package declares it. A second list here would be a
+//! second source of truth, and the first time the two disagreed the floor would
+//! become overridable in exactly the surface that must never be.
+//!
+//! NEVER FAIL CLOSED. Every failure in this module degrades toward MORE
+//! framework instruction, never toward an aborted launch or a blank section: an
+//! absent or unreadable host, a `START` with no `END`, an unknown token, an
+//! unknown `v=`, an override aimed at the floor, an empty body, and a package
+//! that no longer validates all resolve to "keep the bundled section". A
+//! customization mistake must never be able to delete the PM's instructions.
+//!
+//! Scope: reader only. The five `.trusty-mpm/` override file constants stay
+//! where they are and keep working; the floor text that advertises named
+//! sections, and the removal of the legacy files, are separate steps of #4183 /
+//! #4286.
+//!
+//! Test: `claude_md_sections_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::instruction_package::{
+    BlockBody, CustomizationTier, InstructionPackage, OverrideTier, SectionId, ValidationError,
+};
+
+/// Project-relative files scanned for marker blocks, highest precedence first.
+///
+/// Why: `CLAUDE.md` is the surface #4183 moves customization to, and
+/// `.trusty-mpm/INSTRUCTIONS.md` is scanned as well so a project already keeping
+/// its rules there can adopt named sections without moving the file first. Order
+/// is precedence: on a same-section collision the earlier host wins.
+/// What: the two host paths, joined onto the project root.
+/// Test: `claude_md_wins_a_same_section_collision_with_instructions_md`.
+pub const HOST_FILES: [&str; 2] = ["CLAUDE.md", ".trusty-mpm/INSTRUCTIONS.md"];
+
+/// The only marker version this build understands.
+const SUPPORTED_VERSION: u32 = 1;
+
+/// Literal opening a marker line.
+const MARKER_OPEN: &str = "<!--";
+/// Literal closing a marker line.
+const MARKER_CLOSE: &str = "-->";
+/// Namespace that distinguishes a framework marker from an ordinary comment.
+const MARKER_NAMESPACE: &str = "TRUSTY-MPM:";
+
+/// A marker block was opened and never closed (or was displaced by a nested one).
+pub const REASON_UNCLOSED: &str = "START marker has no matching END; block skipped";
+/// An `END` marker named a different section than the open `START`.
+pub const REASON_MISMATCHED_END: &str = "END marker names a different section than the open START";
+/// An `END` marker appeared with no block open.
+pub const REASON_UNMATCHED_END: &str = "END marker with no open START";
+/// The section token is not a known [`SectionId`].
+pub const REASON_UNKNOWN_SECTION: &str = "unknown section token; block skipped";
+/// The `v=` field named a version this build does not implement.
+pub const REASON_UNSUPPORTED_VERSION: &str = "unsupported marker version; block skipped";
+/// The `v=` field was absent; treated as `v=1` for this release.
+pub const REASON_MISSING_VERSION: &str = "marker has no `v=`; assuming v=1";
+/// The body was empty once trimmed — never blank a section over it.
+pub const REASON_EMPTY_BODY: &str = "override body is empty; keeping the bundled section";
+/// A later block in the same host repeated a section already claimed.
+pub const REASON_DUPLICATE: &str = "duplicate section marker; the first well-formed block wins";
+/// A lower-precedence host repeated a section a higher-precedence host claimed.
+pub const REASON_SHADOWED: &str = "section already overridden by a higher-precedence host";
+
+/// The marker token for a section: its kebab-case name, uppercased.
+///
+/// Why: the token has to be stable and human-typable, and it must not drift from
+/// the enum. Deriving it from the serde name by hand here — and pinning that
+/// correspondence in a test — keeps a renamed section from silently orphaning
+/// every project's marker.
+/// What: the eight tokens, matched case-insensitively by [`section_for_token`].
+/// Test: `every_section_token_is_the_kebab_case_id_uppercased`.
+pub const fn section_token(id: SectionId) -> &'static str {
+    match id {
+        SectionId::Identity => "IDENTITY",
+        SectionId::Core => "CORE",
+        SectionId::Memory => "MEMORY",
+        SectionId::Search => "SEARCH",
+        SectionId::Workflow => "WORKFLOW",
+        SectionId::AgentDelegation => "AGENT-DELEGATION",
+        SectionId::NonOverridableRules => "NON-OVERRIDABLE-RULES",
+        SectionId::FrameworkGuaranteedConventions => "FRAMEWORK-GUARANTEED-CONVENTIONS",
+    }
+}
+
+/// Resolve a marker token to its section, case-insensitively.
+///
+/// Test: `unknown_section_token_is_skipped_with_a_diagnostic`.
+fn section_for_token(token: &str) -> Option<SectionId> {
+    SectionId::CANONICAL
+        .into_iter()
+        .find(|id| token.eq_ignore_ascii_case(section_token(*id)))
+}
+
+/// How a `START` marker declared its format version.
+///
+/// Why: "absent" and "unrecognised" must not collapse into one state. A missing
+/// `v=` is an authoring slip on a mechanism that has exactly one version so far,
+/// and rejecting the block for it would blank a section the author expected to
+/// keep; an unrecognised `v=` means the block was written for a format this
+/// build does not implement, and applying it anyway would deliver instructions
+/// nobody wrote.
+/// What: absent (assume [`SUPPORTED_VERSION`], warn), supported, unsupported.
+/// Test: `missing_version_is_accepted_as_v1_with_a_diagnostic`,
+/// `unsupported_version_is_skipped`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarkerVersion {
+    /// No `v=` field at all.
+    Absent,
+    /// `v=1`.
+    Supported,
+    /// A `v=` this build does not implement, or an unparseable one.
+    Unsupported,
+}
+
+/// Which half of a pair a marker line is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum MarkerKind {
+    /// Opens a block, carrying its declared version.
+    Start(MarkerVersion),
+    /// Closes a block.
+    End,
+}
+
+/// One recognised marker line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Marker {
+    /// The section token exactly as written (case preserved for diagnostics).
+    token: String,
+    /// Whether it opens or closes a block.
+    kind: MarkerKind,
+}
+
+/// Parse one line as a framework marker, or `None` if it is ordinary text.
+///
+/// Why: recognition must be conservative in one direction and liberal in the
+/// other. A line that is not a `TRUSTY-MPM:` comment must NEVER be treated as a
+/// marker (prose would start disappearing into override blocks), while a line
+/// that is clearly one — but malformed — must still be recognised, so its
+/// partner does not dangle and corrupt the surrounding blocks.
+/// What: whole-line match on `<!-- TRUSTY-MPM: <TOKEN> START|END [v=N] -->`,
+/// with surrounding and interior whitespace free-form and every keyword matched
+/// case-insensitively. A trailing field other than `v=…`, or any extra field,
+/// makes the line ordinary text.
+/// Test: `parses_the_documented_marker_grammar`,
+/// `prose_mentioning_the_marker_is_not_a_marker`.
+fn parse_marker(line: &str) -> Option<Marker> {
+    let body = line
+        .trim()
+        .strip_prefix(MARKER_OPEN)?
+        .strip_suffix(MARKER_CLOSE)?
+        .trim();
+    let namespaced = body
+        .get(..MARKER_NAMESPACE.len())
+        .filter(|head| head.eq_ignore_ascii_case(MARKER_NAMESPACE))?;
+    let mut fields = body[namespaced.len()..].split_whitespace();
+
+    let token = fields.next()?.to_string();
+    let kind = match fields.next()? {
+        word if word.eq_ignore_ascii_case("START") => MarkerKind::Start(match fields.next() {
+            None => MarkerVersion::Absent,
+            Some(field) => match field.get(..2).filter(|k| k.eq_ignore_ascii_case("v=")) {
+                Some(_) if field[2..].parse::<u32>() == Ok(SUPPORTED_VERSION) => {
+                    MarkerVersion::Supported
+                }
+                _ => MarkerVersion::Unsupported,
+            },
+        }),
+        word if word.eq_ignore_ascii_case("END") => MarkerKind::End,
+        _ => return None,
+    };
+    if fields.next().is_some() {
+        return None;
+    }
+    Some(Marker { token, kind })
+}
+
+/// A `START`/`END` pair found in a host file, before any semantic filtering.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedBlock {
+    /// The section the token resolves to, if it resolves at all.
+    section: Option<SectionId>,
+    /// The declared format version.
+    version: MarkerVersion,
+    /// Content strictly between the marker lines, trimmed.
+    body: String,
+    /// 0-based index of the `START` line.
+    start_line: usize,
+    /// 0-based index of the `END` line.
+    end_line: usize,
+}
+
+/// Why one parsed block was not applied.
+///
+/// Why: these are returned as data rather than only logged, because a warning
+/// that exists only in a `tracing` subscriber cannot be asserted, and this
+/// module's entire contract is about what it declines to do.
+/// What: the host, the 1-based line of the marker at fault, and one of the
+/// `REASON_*` constants.
+/// Test: every `*_is_skipped*` test asserts on these.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScanDiagnostic {
+    /// The host file the marker was read from.
+    pub host: PathBuf,
+    /// 1-based line number of the marker at fault.
+    pub line: usize,
+    /// One of the `REASON_*` constants.
+    pub reason: &'static str,
+}
+
+/// Build a diagnostic from a 0-based line index.
+fn diagnostic(host: &Path, line_index: usize, reason: &'static str) -> ScanDiagnostic {
+    ScanDiagnostic {
+        host: host.to_path_buf(),
+        line: line_index + 1,
+        reason,
+    }
+}
+
+/// An accepted, well-formed override of one section.
+///
+/// Test: `scans_claude_md_for_named_sections`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SectionOverride {
+    /// The section this replaces.
+    pub section: SectionId,
+    /// The replacement text, trimmed and never empty.
+    pub body: String,
+    /// The host file it was authored in.
+    pub host: PathBuf,
+    /// 1-based line of its `START` marker.
+    pub line: usize,
+}
+
+/// Everything a project's host files declared, accepted and rejected alike.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ProjectOverrides {
+    /// Accepted overrides, in [`SectionId`] canonical order.
+    pub overrides: Vec<SectionOverride>,
+    /// Blocks that were recognised but not applied.
+    pub diagnostics: Vec<ScanDiagnostic>,
+}
+
+impl ProjectOverrides {
+    /// Emit the operator-visible record of what was read and what was declined.
+    ///
+    /// Why: a silently ignored override is the failure this whole module exists
+    /// to avoid repeating (#381). Every decline gets a line naming the file, the
+    /// line number and the reason.
+    /// What: `warn!` per diagnostic, `info!` per applied override.
+    /// Test: covered indirectly; the assertable form is the returned data.
+    pub fn log(&self) {
+        for diagnostic in &self.diagnostics {
+            tracing::warn!(
+                path = %diagnostic.host.display(),
+                line = diagnostic.line,
+                reason = diagnostic.reason,
+                "CLAUDE.md named-section override ignored"
+            );
+        }
+        for applied in &self.overrides {
+            tracing::info!(
+                path = %applied.host.display(),
+                section = ?applied.section,
+                "applying CLAUDE.md named-section override"
+            );
+        }
+    }
+}
+
+/// Find every well-formed marker pair in `text`, plus what went wrong.
+///
+/// Why: pairing is a single left-to-right pass with one open slot, so a
+/// malformed region can cost at most the block it belongs to. Nesting is not
+/// supported and is not silently tolerated: a `START` while a block is open
+/// discards the outer block with [`REASON_UNCLOSED`] and opens the inner one, so
+/// the author sees the outer disappear rather than getting a block whose body
+/// silently swallowed another marker.
+/// What: an ordered list of pairs and an ordered list of diagnostics.
+/// Test: `nested_start_discards_the_outer_block`,
+/// `unterminated_block_is_skipped_and_later_blocks_still_apply`.
+fn parse_blocks(text: &str, host: &Path) -> (Vec<ParsedBlock>, Vec<ScanDiagnostic>) {
+    let lines: Vec<&str> = text.lines().collect();
+    let mut blocks = Vec::new();
+    let mut diagnostics = Vec::new();
+    let mut open: Option<(Marker, usize)> = None;
+
+    for (index, line) in lines.iter().enumerate() {
+        let Some(marker) = parse_marker(line) else {
+            continue;
+        };
+        match marker.kind {
+            MarkerKind::Start(_) => {
+                if let Some((_, previous)) = open.replace((marker, index)) {
+                    diagnostics.push(diagnostic(host, previous, REASON_UNCLOSED));
+                }
+            }
+            MarkerKind::End => {
+                let Some((start, start_line)) = open.take() else {
+                    diagnostics.push(diagnostic(host, index, REASON_UNMATCHED_END));
+                    continue;
+                };
+                if !start.token.eq_ignore_ascii_case(&marker.token) {
+                    diagnostics.push(diagnostic(host, index, REASON_MISMATCHED_END));
+                    continue;
+                }
+                let MarkerKind::Start(version) = start.kind else {
+                    unreachable!("only a START marker is ever stored as open");
+                };
+                blocks.push(ParsedBlock {
+                    section: section_for_token(&start.token),
+                    version,
+                    body: lines[start_line + 1..index].join("\n").trim().to_string(),
+                    start_line,
+                    end_line: index,
+                });
+            }
+        }
+    }
+
+    if let Some((_, start_line)) = open {
+        diagnostics.push(diagnostic(host, start_line, REASON_UNCLOSED));
+    }
+    (blocks, diagnostics)
+}
+
+/// Decide whether a parsed pair may become an override.
+///
+/// What: an unsupported `v=` loses first (the block was written for a format
+/// this build cannot honour), then an unknown token, then an empty body — which
+/// is treated as ABSENT rather than as "blank this section", because the one
+/// outcome no customization mistake may produce is a PM with no instructions.
+/// Test: `unsupported_version_is_skipped`, `empty_body_never_blanks_a_section`.
+fn accept(block: &ParsedBlock) -> Result<SectionId, &'static str> {
+    if block.version == MarkerVersion::Unsupported {
+        return Err(REASON_UNSUPPORTED_VERSION);
+    }
+    let section = block.section.ok_or(REASON_UNKNOWN_SECTION)?;
+    if block.body.is_empty() {
+        return Err(REASON_EMPTY_BODY);
+    }
+    Ok(section)
+}
+
+/// Read a host file, or `None` when it is absent or unreadable.
+///
+/// Why: neither absence nor an IO error may fail a launch — both mean "this
+/// project declared no overrides".
+/// Test: `missing_claude_md_yields_no_overrides`, `unreadable_host_is_not_fatal`.
+fn read_host(path: &Path) -> Option<String> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Some(text),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => None,
+        Err(err) => {
+            tracing::warn!(
+                path = %path.display(),
+                %err,
+                "instruction override host unreadable; using bundled sections"
+            );
+            None
+        }
+    }
+}
+
+/// Scan a project's host files for named-section overrides.
+///
+/// Why: one entry point so no caller can invent its own host list or precedence.
+/// What: scans [`HOST_FILES`] in order; the first host to claim a section keeps
+/// it and any later claim is reported as [`REASON_SHADOWED`] (across hosts) or
+/// [`REASON_DUPLICATE`] (within one host). The result is sorted into
+/// [`SectionId`] canonical order so downstream application is deterministic.
+/// Test: `scans_claude_md_for_named_sections`,
+/// `claude_md_wins_a_same_section_collision_with_instructions_md`,
+/// `duplicate_section_in_one_host_keeps_the_first`.
+pub fn scan_project(project_dir: &Path) -> ProjectOverrides {
+    let mut result = ProjectOverrides::default();
+
+    for relative in HOST_FILES {
+        let host = project_dir.join(relative);
+        let Some(text) = read_host(&host) else {
+            continue;
+        };
+        let (blocks, diagnostics) = parse_blocks(&text, &host);
+        result.diagnostics.extend(diagnostics);
+
+        for block in blocks {
+            let section = match accept(&block) {
+                Ok(section) => section,
+                Err(reason) => {
+                    result
+                        .diagnostics
+                        .push(diagnostic(&host, block.start_line, reason));
+                    continue;
+                }
+            };
+            if block.version == MarkerVersion::Absent {
+                result.diagnostics.push(diagnostic(
+                    &host,
+                    block.start_line,
+                    REASON_MISSING_VERSION,
+                ));
+            }
+            if let Some(claimed) = result.overrides.iter().find(|o| o.section == section) {
+                let reason = if claimed.host == host {
+                    REASON_DUPLICATE
+                } else {
+                    REASON_SHADOWED
+                };
+                result
+                    .diagnostics
+                    .push(diagnostic(&host, block.start_line, reason));
+                continue;
+            }
+            result.overrides.push(SectionOverride {
+                section,
+                body: block.body,
+                host: host.clone(),
+                line: block.start_line + 1,
+            });
+        }
+    }
+
+    result.overrides.sort_by_key(|o| o.section);
+    result
+}
+
+/// Remove every paired marker block from an additive-addendum body.
+///
+/// Why: `.trusty-mpm/INSTRUCTIONS.md` is both a marker host and the source of
+/// the `project-addendum` generator. Without this, a section marked out there
+/// would be delivered twice — once as the override it is, once as raw addendum
+/// prose complete with the marker comments.
+/// What: drops the `START..=END` line span of every pair; text outside markers
+/// is untouched. A body containing NO pair is returned byte-for-byte unchanged,
+/// which is what makes today's marker-free `INSTRUCTIONS.md` files provably
+/// unaffected.
+/// Test: `strip_is_a_no_op_without_markers`,
+/// `strip_removes_marked_blocks_from_the_addendum`.
+pub fn strip_marker_blocks(text: &str) -> String {
+    let (blocks, _) = parse_blocks(text, Path::new(""));
+    if blocks.is_empty() {
+        return text.to_string();
+    }
+    text.lines()
+        .enumerate()
+        .filter(|(index, _)| {
+            !blocks
+                .iter()
+                .any(|b| *index >= b.start_line && *index <= b.end_line)
+        })
+        .map(|(_, line)| line)
+        .collect::<Vec<_>>()
+        .join("\n")
+        .trim()
+        .to_string()
+}
+
+/// Report overrides that a non-package composition path cannot honour.
+///
+/// Why: the sectioned package is the only composer that HAS sections, so a
+/// project still carrying a legacy `.trusty-mpm/` override file (which forces
+/// the legacy string assembly) would have its named sections quietly dropped.
+/// Quietly is the part that is unacceptable — that is #381 again. The removal of
+/// the legacy files is a later step of #4183; until then this says so, loudly,
+/// once per override.
+/// What: one `warn!` per accepted override, naming the file and the section.
+/// Test: `named_sections_are_reported_unapplied_on_the_legacy_path`.
+pub fn warn_unapplied(scanned: &ProjectOverrides) {
+    for applied in &scanned.overrides {
+        tracing::warn!(
+            path = %applied.host.display(),
+            section = ?applied.section,
+            "named-section override NOT applied: this project still uses a legacy \
+             .trusty-mpm/ override file, which composes the prompt without sections"
+        );
+    }
+}
+
+/// Why one override was declined by [`InstructionPackage::with_overrides`].
+///
+/// Why: every variant is a case where the override is dropped and the BUNDLED
+/// section is kept — the fail-open direction. Returning them as data rather than
+/// swallowing them keeps "the floor refused the override" an assertable fact
+/// instead of a claim in a doc comment.
+/// What: one variant per rule in the application contract.
+/// Test: one test per variant in `claude_md_sections_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum Rejection {
+    /// The section's declared tier admits no project-tier override.
+    #[error("section {section:?} is tier {tier:?} and admits no project override")]
+    NotOverridable {
+        /// The section the override aimed at.
+        section: SectionId,
+        /// The tier the package declares for it.
+        tier: CustomizationTier,
+    },
+    /// The package declares no such section.
+    #[error("section {section:?} is not declared by this package")]
+    UnknownSection {
+        /// The section the override aimed at.
+        section: SectionId,
+    },
+    /// The section owns no authored text block to replace.
+    #[error("section {section:?} has no authored text block for an override to replace")]
+    NoTextBlock {
+        /// The section the override aimed at.
+        section: SectionId,
+    },
+    /// The override body was empty.
+    #[error("override for section {section:?} is empty; keeping the bundled section")]
+    EmptyBody {
+        /// The section the override aimed at.
+        section: SectionId,
+    },
+    /// Applying it would leave the section with nothing guaranteed to emit.
+    #[error("overriding section {section:?} would leave it able to emit nothing")]
+    WouldEmitNothing {
+        /// The section the override aimed at.
+        section: SectionId,
+    },
+    /// Applying it produced a package that no longer validates.
+    #[error("overriding section {section:?} invalidates the package: {error}")]
+    Invalidates {
+        /// The section the override aimed at.
+        section: SectionId,
+        /// Why the resulting package was rejected.
+        error: ValidationError,
+    },
+    /// The fully overridden package failed the final validation; all reverted.
+    #[error("the overridden package failed validation ({0}); composing the bundled package")]
+    PackageInvalid(ValidationError),
+}
+
+/// Apply one override to a package, or say why it may not be applied.
+///
+/// What: replaces the section's FIRST [`BlockBody::Text`] block with the
+/// override body and drops that section's remaining text blocks, leaving every
+/// [`BlockBody::Generated`] block untouched. That asymmetry is the point: a
+/// generated block is host-computed content the project cannot author, so an
+/// `AGENT-DELEGATION` override rewrites the routing doctrine but CANNOT suppress
+/// the live agent roster (#4196 in override form).
+/// Test: `agent_delegation_override_keeps_the_generated_roster`,
+/// `floor_sections_refuse_every_named_section_override`.
+fn apply_one(
+    package: &InstructionPackage,
+    over: &SectionOverride,
+) -> Result<InstructionPackage, Rejection> {
+    let section = over.section;
+    let body = over.body.trim();
+    if body.is_empty() {
+        return Err(Rejection::EmptyBody { section });
+    }
+    let Some(declared) = package.section(section) else {
+        return Err(Rejection::UnknownSection { section });
+    };
+    if !declared.customization_tier.permits(OverrideTier::Project) {
+        return Err(Rejection::NotOverridable {
+            section,
+            tier: declared.customization_tier,
+        });
+    }
+
+    let mut next = package.clone();
+    let mut replaced = false;
+    next.blocks.retain_mut(|block| {
+        if block.section != section {
+            return true;
+        }
+        let BlockBody::Text { text } = &mut block.body else {
+            return true;
+        };
+        if replaced {
+            return false;
+        }
+        *text = body.to_string();
+        replaced = true;
+        true
+    });
+    if !replaced {
+        return Err(Rejection::NoTextBlock { section });
+    }
+    if !next
+        .blocks
+        .iter()
+        .any(|b| b.section == section && !b.optional)
+    {
+        return Err(Rejection::WouldEmitNothing { section });
+    }
+    next.validate()
+        .map_err(|error| Rejection::Invalidates { section, error })?;
+    Ok(next)
+}
+
+impl InstructionPackage {
+    /// Apply project-tier named-section overrides, reporting every decline.
+    ///
+    /// Why: this is the single decision point for "may this override land?", and
+    /// it asks the package's own `customization_tier` rather than any list held
+    /// by the reader. A section is overridable if and only if the shipped
+    /// package says so, which is what makes the floor structurally unreachable
+    /// from `CLAUDE.md` rather than merely unlisted.
+    ///
+    /// What: applies overrides in [`SectionId`] canonical order (so the result is
+    /// independent of authoring order), validating after each one. An override
+    /// that fails any rule — floor tier, no text block, empty body, a section
+    /// left unable to emit, or a package that stops validating — is discarded on
+    /// its own and reported; the others still land. A final validation guards the
+    /// whole, and on failure the pristine package is returned instead, so the
+    /// worst case is the bundled prompt rather than a broken one.
+    ///
+    /// An empty `overrides` slice returns a clone, so the composed bytes of a
+    /// project with no `CLAUDE.md` cannot move.
+    ///
+    /// Test: `with_overrides_of_nothing_is_the_identity`,
+    /// `floor_sections_refuse_every_named_section_override`,
+    /// `one_bad_override_does_not_discard_a_good_one`.
+    pub fn with_overrides(&self, overrides: &[SectionOverride]) -> (Self, Vec<Rejection>) {
+        let mut ordered: Vec<&SectionOverride> = overrides.iter().collect();
+        ordered.sort_by_key(|o| o.section);
+
+        let mut working = self.clone();
+        let mut rejected = Vec::new();
+        for over in ordered {
+            match apply_one(&working, over) {
+                Ok(next) => working = next,
+                Err(rejection) => rejected.push(rejection),
+            }
+        }
+
+        // Unreachable while `apply_one` validates each step — kept because the
+        // cost of being wrong here is a malformed system prompt, and the
+        // degradation (compose the bundled package) is free.
+        if let Err(error) = working.validate() {
+            rejected.push(Rejection::PackageInvalid(error));
+            return (self.clone(), rejected);
+        }
+        (working, rejected)
+    }
+}
+
+#[cfg(test)]
+#[path = "claude_md_sections_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -1,0 +1,839 @@
+//! Tests for the `CLAUDE.md` named-section override reader (#4183 / #4286).
+//!
+//! Three groups, deliberately separated:
+//!
+//! * GRAMMAR — what `parse_marker` / `parse_blocks` recognise, and what they
+//!   refuse to recognise. The refusals matter more than the acceptances: prose
+//!   must never be swallowed into an override block.
+//! * APPLICATION — `InstructionPackage::with_overrides`, the single decision
+//!   point for whether a parsed override may land. The floor tests here are the
+//!   structural guarantee that `CLAUDE.md` cannot reach the framework floor.
+//! * WIRING — end-to-end through `resolve_pm_prompt_with_roster`. These are the
+//!   tests that fail if the reader is built but never called, which is the exact
+//!   failure #381 was.
+
+use super::*;
+use crate::core::bundled_pm_package::bundled_fallback_package;
+use crate::core::instruction_overrides::{
+    FILE_AGENT_DELEGATION, FILE_INSTRUCTIONS, OVERRIDE_DIR_NAME, PromptSource,
+    resolve_pm_prompt_with_roster,
+};
+use crate::core::instruction_package::{Generator, InstructionBlock, Join};
+use tempfile::TempDir;
+
+/// A fixed roster, so composed output never depends on the machine's agents.
+const ROSTER: &str = "## Delegation Authority\n\n### ticketing\n\nHandles ticketing work.";
+
+/// Write `<project>/CLAUDE.md`.
+fn write_claude_md(project: &Path, body: &str) {
+    std::fs::write(project.join("CLAUDE.md"), body).expect("write CLAUDE.md");
+}
+
+/// Write `<project>/.trusty-mpm/<name>`, creating the directory.
+fn write_trusty_file(project: &Path, name: &str, body: &str) {
+    let dir = project.join(OVERRIDE_DIR_NAME);
+    std::fs::create_dir_all(&dir).expect("create .trusty-mpm");
+    std::fs::write(dir.join(name), body).expect("write override");
+}
+
+/// Render a marker-delimited block for `section`.
+fn block(section: SectionId, body: &str) -> String {
+    let token = section_token(section);
+    format!("<!-- TRUSTY-MPM: {token} START v=1 -->\n{body}\n<!-- TRUSTY-MPM: {token} END -->\n")
+}
+
+/// Resolve the PM prompt for `project` against the fixed roster.
+fn resolve(project: &Path) -> (String, PromptSource) {
+    resolve_pm_prompt_with_roster(project, || Some(ROSTER.to_string()))
+}
+
+/// The reasons reported by a scan, in order.
+fn reasons(scanned: &ProjectOverrides) -> Vec<&'static str> {
+    scanned.diagnostics.iter().map(|d| d.reason).collect()
+}
+
+// ---------------------------------------------------------------------------
+// GRAMMAR
+// ---------------------------------------------------------------------------
+
+#[test]
+fn every_section_token_is_the_kebab_case_id_uppercased() {
+    // The token is the contract a project types by hand. Pinning it to the
+    // serde name means renaming a section cannot silently orphan every
+    // project's markers — it breaks here first.
+    for id in SectionId::CANONICAL {
+        let kebab = serde_json::to_string(&id).expect("serialize id");
+        let expected = kebab.trim_matches('"').to_ascii_uppercase();
+        assert_eq!(section_token(id), expected, "token for {id:?}");
+    }
+}
+
+#[test]
+fn parses_the_documented_marker_grammar() {
+    // The documented form, plus the tolerated variations: free interior
+    // whitespace, whitespace before `-->`, leading indentation, and
+    // case-insensitive keywords and tokens.
+    for line in [
+        "<!-- TRUSTY-MPM: WORKFLOW START v=1 -->",
+        "<!--   TRUSTY-MPM:   WORKFLOW   START   v=1   -->",
+        "   <!-- trusty-mpm: workflow start v=1 -->   ",
+        "<!-- TRUSTY-MPM: Agent-Delegation START v=1 -->",
+    ] {
+        let marker = parse_marker(line).unwrap_or_else(|| panic!("must parse: {line:?}"));
+        assert!(matches!(
+            marker.kind,
+            MarkerKind::Start(MarkerVersion::Supported)
+        ));
+    }
+
+    let end = parse_marker("<!-- TRUSTY-MPM: WORKFLOW END -->").expect("END parses");
+    assert_eq!(end.kind, MarkerKind::End);
+    assert!(end.token.eq_ignore_ascii_case("WORKFLOW"));
+}
+
+#[test]
+fn prose_mentioning_the_marker_is_not_a_marker() {
+    // Recognition must be conservative: anything that is not a whole-line
+    // `TRUSTY-MPM:` comment is ordinary text. Otherwise documentation ABOUT the
+    // mechanism would start eating the prose around it.
+    for line in [
+        "Use `<!-- TRUSTY-MPM: WORKFLOW START v=1 -->` to open a block.",
+        "<!-- TRUSTY-MPM: WORKFLOW START v=1 --> trailing prose",
+        "<!-- an ordinary HTML comment -->",
+        "<!-- TRUSTY-MPM: WORKFLOW -->",
+        "<!-- TRUSTY-MPM: WORKFLOW START v=1 extra -->",
+        "<!-- TRUSTY-MPM: WORKFLOW SIDEWAYS v=1 -->",
+        "# TRUSTY-MPM: WORKFLOW START v=1",
+        "",
+    ] {
+        assert!(
+            parse_marker(line).is_none(),
+            "must NOT be a marker: {line:?}"
+        );
+    }
+}
+
+#[test]
+fn scans_claude_md_for_named_sections() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &format!(
+            "# Project Instructions\n\nsome prose\n\n{}\n{}",
+            block(SectionId::Workflow, "TWO_PHASE_ONLY"),
+            block(SectionId::Memory, "Recall from the `team` palace first."),
+        ),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(scanned.diagnostics, vec![]);
+    // Sorted into canonical order: Memory (2) precedes Workflow (4), whatever
+    // order they were authored in.
+    let got: Vec<(SectionId, &str)> = scanned
+        .overrides
+        .iter()
+        .map(|o| (o.section, o.body.as_str()))
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            (SectionId::Memory, "Recall from the `team` palace first."),
+            (SectionId::Workflow, "TWO_PHASE_ONLY"),
+        ]
+    );
+    assert_eq!(scanned.overrides[0].host, tmp.path().join("CLAUDE.md"));
+}
+
+#[test]
+fn text_outside_markers_is_ignored() {
+    // Only what lies strictly between the marker lines is instruction content.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &format!(
+            "BEFORE_TEXT\n\n{}\n\nAFTER_TEXT\n",
+            block(SectionId::Workflow, "INSIDE_TEXT")
+        ),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(scanned.overrides.len(), 1);
+    assert_eq!(scanned.overrides[0].body, "INSIDE_TEXT");
+}
+
+#[test]
+fn claude_md_wins_a_same_section_collision_with_instructions_md() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(tmp.path(), &block(SectionId::Workflow, "FROM_CLAUDE_MD"));
+    write_trusty_file(
+        tmp.path(),
+        FILE_INSTRUCTIONS,
+        &block(SectionId::Workflow, "FROM_INSTRUCTIONS_MD"),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(scanned.overrides.len(), 1);
+    assert_eq!(scanned.overrides[0].body, "FROM_CLAUDE_MD");
+    assert_eq!(reasons(&scanned), vec![REASON_SHADOWED]);
+}
+
+#[test]
+fn instructions_md_supplies_sections_claude_md_does_not_claim() {
+    // Both hosts are scanned; precedence only settles collisions.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(tmp.path(), &block(SectionId::Workflow, "FROM_CLAUDE_MD"));
+    write_trusty_file(
+        tmp.path(),
+        FILE_INSTRUCTIONS,
+        &block(SectionId::Memory, "FROM_INSTRUCTIONS_MD"),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(scanned.diagnostics, vec![]);
+    assert_eq!(scanned.overrides.len(), 2);
+    assert_eq!(scanned.overrides[0].section, SectionId::Memory);
+    assert_eq!(scanned.overrides[1].section, SectionId::Workflow);
+}
+
+#[test]
+fn duplicate_section_in_one_host_keeps_the_first() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &format!(
+            "{}\n{}",
+            block(SectionId::Workflow, "FIRST"),
+            block(SectionId::Workflow, "SECOND")
+        ),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(scanned.overrides.len(), 1);
+    assert_eq!(scanned.overrides[0].body, "FIRST");
+    assert_eq!(reasons(&scanned), vec![REASON_DUPLICATE]);
+}
+
+#[test]
+fn unknown_section_token_is_skipped_with_a_diagnostic() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &format!(
+            "<!-- TRUSTY-MPM: TELEPATHY START v=1 -->\nX\n<!-- TRUSTY-MPM: TELEPATHY END -->\n{}",
+            block(SectionId::Workflow, "STILL_APPLIES")
+        ),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_UNKNOWN_SECTION]);
+    assert_eq!(scanned.overrides.len(), 1, "other blocks still apply");
+    assert_eq!(scanned.overrides[0].body, "STILL_APPLIES");
+}
+
+#[test]
+fn unsupported_version_is_skipped() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        "<!-- TRUSTY-MPM: WORKFLOW START v=99 -->\nFROM_THE_FUTURE\n\
+         <!-- TRUSTY-MPM: WORKFLOW END -->\n",
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_UNSUPPORTED_VERSION]);
+    assert!(scanned.overrides.is_empty());
+}
+
+#[test]
+fn missing_version_is_accepted_as_v1_with_a_diagnostic() {
+    // `v=` is required by the design, but a missing one must not blank a
+    // section for this release — it degrades to v=1 and says so.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        "<!-- TRUSTY-MPM: WORKFLOW START -->\nNO_VERSION\n<!-- TRUSTY-MPM: WORKFLOW END -->\n",
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_MISSING_VERSION]);
+    assert_eq!(scanned.overrides.len(), 1);
+    assert_eq!(scanned.overrides[0].body, "NO_VERSION");
+}
+
+#[test]
+fn empty_body_never_blanks_a_section() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(tmp.path(), &block(SectionId::Workflow, "   \n\t\n   "));
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_EMPTY_BODY]);
+    assert!(scanned.overrides.is_empty(), "absent, never blank");
+}
+
+#[test]
+fn unterminated_block_is_skipped_and_later_blocks_still_apply() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &format!(
+            "{}<!-- TRUSTY-MPM: MEMORY START v=1 -->\nnever closed\n",
+            block(SectionId::Workflow, "APPLIES")
+        ),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_UNCLOSED]);
+    assert_eq!(scanned.overrides.len(), 1);
+    assert_eq!(scanned.overrides[0].section, SectionId::Workflow);
+}
+
+#[test]
+fn nested_start_discards_the_outer_block() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        "<!-- TRUSTY-MPM: WORKFLOW START v=1 -->\nouter\n\
+         <!-- TRUSTY-MPM: MEMORY START v=1 -->\ninner\n\
+         <!-- TRUSTY-MPM: MEMORY END -->\n",
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_UNCLOSED]);
+    assert_eq!(scanned.overrides.len(), 1);
+    assert_eq!(scanned.overrides[0].section, SectionId::Memory);
+    assert_eq!(scanned.overrides[0].body, "inner");
+}
+
+#[test]
+fn unmatched_end_is_reported_and_ignored() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &format!(
+            "<!-- TRUSTY-MPM: MEMORY END -->\n{}",
+            block(SectionId::Workflow, "APPLIES")
+        ),
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_UNMATCHED_END]);
+    assert_eq!(scanned.overrides.len(), 1);
+}
+
+#[test]
+fn mismatched_end_discards_the_block() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        "<!-- TRUSTY-MPM: WORKFLOW START v=1 -->\nbody\n<!-- TRUSTY-MPM: MEMORY END -->\n",
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(reasons(&scanned), vec![REASON_MISMATCHED_END]);
+    assert!(scanned.overrides.is_empty());
+}
+
+#[test]
+fn missing_claude_md_yields_no_overrides() {
+    let tmp = TempDir::new().unwrap();
+    let scanned = scan_project(tmp.path());
+    assert_eq!(scanned, ProjectOverrides::default());
+}
+
+#[test]
+fn unreadable_host_is_not_fatal() {
+    // A directory where the file should be: `read_to_string` fails with
+    // something other than NotFound and the launch still resolves.
+    let tmp = TempDir::new().unwrap();
+    std::fs::create_dir(tmp.path().join("CLAUDE.md")).unwrap();
+    let scanned = scan_project(tmp.path());
+    assert!(scanned.overrides.is_empty());
+}
+
+#[test]
+fn diagnostics_carry_the_host_and_a_one_based_line() {
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        "line one\n<!-- TRUSTY-MPM: TELEPATHY START v=1 -->\nX\n\
+         <!-- TRUSTY-MPM: TELEPATHY END -->\n",
+    );
+
+    let scanned = scan_project(tmp.path());
+    assert_eq!(
+        scanned.diagnostics,
+        vec![ScanDiagnostic {
+            host: tmp.path().join("CLAUDE.md"),
+            line: 2,
+            reason: REASON_UNKNOWN_SECTION,
+        }]
+    );
+}
+
+#[test]
+fn strip_is_a_no_op_without_markers() {
+    // The universal case today. Byte-for-byte identity here is what proves the
+    // existing `project-addendum` generator cannot regress.
+    for text in [
+        "",
+        "# Project Rules\n\nALWAYS_RUN_MAKE_CHECK\n",
+        "trailing whitespace kept   \n\n\n",
+        "<!-- an ordinary comment -->\n",
+    ] {
+        assert_eq!(strip_marker_blocks(text), text);
+    }
+}
+
+#[test]
+fn strip_removes_marked_blocks_from_the_addendum() {
+    let text = format!(
+        "KEEP_BEFORE\n\n{}\nKEEP_AFTER\n",
+        block(SectionId::Workflow, "MOVED_TO_A_SECTION")
+    );
+    let stripped = strip_marker_blocks(&text);
+    assert!(stripped.contains("KEEP_BEFORE"));
+    assert!(stripped.contains("KEEP_AFTER"));
+    assert!(!stripped.contains("MOVED_TO_A_SECTION"));
+    assert!(!stripped.contains("TRUSTY-MPM:"), "markers go too");
+}
+
+// ---------------------------------------------------------------------------
+// APPLICATION — `InstructionPackage::with_overrides`
+// ---------------------------------------------------------------------------
+
+/// An override of `section` with `body`, as the scanner would produce.
+fn over(section: SectionId, body: &str) -> SectionOverride {
+    SectionOverride {
+        section,
+        body: body.to_string(),
+        host: PathBuf::from("CLAUDE.md"),
+        line: 1,
+    }
+}
+
+#[test]
+fn with_overrides_of_nothing_is_the_identity() {
+    // The property the two existing goldens rest on: a project with no
+    // `CLAUDE.md` composes exactly the package it always did.
+    let package = bundled_fallback_package();
+    let (result, rejected) = package.with_overrides(&[]);
+    assert_eq!(result, package);
+    assert_eq!(rejected, vec![]);
+}
+
+#[test]
+fn floor_sections_refuse_every_named_section_override() {
+    // The structural guarantee: the package's `customization_tier` is the only
+    // authority, and it says `fixed` for all three floor sections. No list in
+    // the reader is consulted, so none can drift out of sync with this.
+    let package = bundled_fallback_package();
+    for section in [
+        SectionId::Identity,
+        SectionId::NonOverridableRules,
+        SectionId::FrameworkGuaranteedConventions,
+    ] {
+        let (result, rejected) = package.with_overrides(&[over(section, "SUBVERTED")]);
+        assert_eq!(result, package, "{section:?} must be untouched");
+        assert_eq!(
+            rejected,
+            vec![Rejection::NotOverridable {
+                section,
+                tier: CustomizationTier::Fixed,
+            }]
+        );
+    }
+}
+
+#[test]
+fn content_sections_accept_a_project_override() {
+    let package = bundled_fallback_package();
+    for section in [
+        SectionId::Core,
+        SectionId::Memory,
+        SectionId::Search,
+        SectionId::Workflow,
+        SectionId::AgentDelegation,
+    ] {
+        let (result, rejected) = package.with_overrides(&[over(section, "REPLACED_BODY")]);
+        assert_eq!(rejected, vec![], "{section:?} is tier project");
+        assert_ne!(result, package, "{section:?} must actually change");
+        let texts: Vec<&str> = result
+            .blocks
+            .iter()
+            .filter(|b| b.section == section)
+            .filter_map(|b| match &b.body {
+                BlockBody::Text { text } => Some(text.as_str()),
+                BlockBody::Generated { .. } => None,
+            })
+            .collect();
+        assert_eq!(
+            texts,
+            vec!["REPLACED_BODY"],
+            "{section:?} keeps exactly one text block"
+        );
+        result.validate().expect("overridden package validates");
+    }
+}
+
+#[test]
+fn agent_delegation_override_keeps_the_generated_roster() {
+    // The #4196 shape in override form: a project must be able to rewrite the
+    // routing doctrine WITHOUT being able to suppress the live agent roster.
+    let package = bundled_fallback_package();
+    let (result, rejected) = package.with_overrides(&[over(
+        SectionId::AgentDelegation,
+        "# Custom Routing\n\nROUTE_ALL_TO_ENGINEER",
+    )]);
+    assert_eq!(rejected, vec![]);
+    assert!(
+        result.blocks.iter().any(|b| matches!(
+            b.body,
+            BlockBody::Generated {
+                generator: Generator::AgentRoster
+            }
+        )),
+        "the roster block must survive the override"
+    );
+    result.validate().expect("roster is still consumed");
+}
+
+#[test]
+fn one_bad_override_does_not_discard_a_good_one() {
+    let package = bundled_fallback_package();
+    let (result, rejected) = package.with_overrides(&[
+        over(SectionId::Identity, "SUBVERTED"),
+        over(SectionId::Workflow, "CUSTOM_WORKFLOW"),
+    ]);
+    assert_eq!(
+        rejected,
+        vec![Rejection::NotOverridable {
+            section: SectionId::Identity,
+            tier: CustomizationTier::Fixed,
+        }]
+    );
+    assert!(
+        result.blocks.iter().any(|b| matches!(
+            &b.body,
+            BlockBody::Text { text } if text == "CUSTOM_WORKFLOW"
+        )),
+        "the permitted override still lands"
+    );
+}
+
+#[test]
+fn application_order_is_canonical_not_authoring_order() {
+    let package = bundled_fallback_package();
+    let forwards = package.with_overrides(&[
+        over(SectionId::Core, "C"),
+        over(SectionId::Workflow, "W"),
+        over(SectionId::Memory, "M"),
+    ]);
+    let backwards = package.with_overrides(&[
+        over(SectionId::Memory, "M"),
+        over(SectionId::Workflow, "W"),
+        over(SectionId::Core, "C"),
+    ]);
+    assert_eq!(forwards, backwards);
+}
+
+#[test]
+fn an_empty_override_body_is_rejected_by_the_applier_too() {
+    // Belt to the scanner's braces: even if an empty body reached this far it
+    // would keep the bundled section rather than blank it.
+    let package = bundled_fallback_package();
+    let (result, rejected) = package.with_overrides(&[over(SectionId::Workflow, "  \n ")]);
+    assert_eq!(result, package);
+    assert_eq!(
+        rejected,
+        vec![Rejection::EmptyBody {
+            section: SectionId::Workflow
+        }]
+    );
+}
+
+#[test]
+fn a_section_with_no_text_block_has_nothing_to_override() {
+    // Contrived package: Workflow's only block is generated, so there is no
+    // authored text for an override to replace. Rejected rather than injected
+    // at some arbitrary position.
+    let mut package = bundled_fallback_package();
+    for b in &mut package.blocks {
+        if b.section == SectionId::Workflow {
+            b.body = BlockBody::Generated {
+                generator: Generator::StackProfile,
+            };
+        }
+    }
+    let (result, rejected) = package.with_overrides(&[over(SectionId::Workflow, "X")]);
+    assert_eq!(result, package);
+    assert_eq!(
+        rejected,
+        vec![Rejection::NoTextBlock {
+            section: SectionId::Workflow
+        }]
+    );
+}
+
+#[test]
+fn an_override_that_would_leave_a_section_silent_is_rejected() {
+    // Contrived package: Workflow's only text block is `optional`, so applying
+    // the override would produce a section that composes to nothing whenever it
+    // is dropped. Rejected — the bundled section is kept instead.
+    let mut package = bundled_fallback_package();
+    for b in &mut package.blocks {
+        if b.section == SectionId::Workflow {
+            b.optional = true;
+        }
+    }
+    let (result, rejected) = package.with_overrides(&[over(SectionId::Workflow, "X")]);
+    assert_eq!(result, package, "the bundled section is kept");
+    assert_eq!(
+        rejected.first(),
+        Some(&Rejection::WouldEmitNothing {
+            section: SectionId::Workflow
+        })
+    );
+}
+
+#[test]
+fn an_undeclared_section_is_rejected_and_the_package_is_reverted() {
+    // Contrived package whose taxonomy is missing Workflow: the override has
+    // nowhere declared to land, and the final validation then refuses the whole
+    // thing — degrading to the package as supplied, never to a broken one.
+    let mut package = bundled_fallback_package();
+    package.sections.retain(|s| s.id != SectionId::Workflow);
+
+    let (result, rejected) = package.with_overrides(&[over(SectionId::Workflow, "X")]);
+    assert_eq!(result, package, "the unoverridden package is returned");
+    assert_eq!(
+        rejected,
+        vec![
+            Rejection::UnknownSection {
+                section: SectionId::Workflow
+            },
+            Rejection::PackageInvalid(ValidationError::SectionsNotCanonical {
+                found: result.sections.iter().map(|s| s.id).collect(),
+            }),
+        ]
+    );
+}
+
+#[test]
+fn an_override_that_cannot_validate_is_discarded_and_the_package_reverts() {
+    // Contrived package carrying an overridable Memory block AFTER the floor,
+    // so anything derived from it fails `OverridableAfterFloor`. Overriding
+    // Workflow cannot fix that, so the override is discarded on its own
+    // diagnosis, the final validation then refuses the whole, and the package as
+    // supplied comes back. Applying an override must never make things worse
+    // than not applying it.
+    let mut package = bundled_fallback_package();
+    package.blocks.push(InstructionBlock {
+        section: SectionId::Memory,
+        body: BlockBody::Text {
+            text: "TRAILING".to_string(),
+        },
+        join_before: Join::Rule,
+        optional: false,
+    });
+
+    let (result, rejected) = package.with_overrides(&[over(SectionId::Workflow, "X")]);
+    assert_eq!(
+        result, package,
+        "the supplied package is returned unchanged"
+    );
+    assert!(
+        matches!(
+            rejected.as_slice(),
+            [
+                Rejection::Invalidates {
+                    section: SectionId::Workflow,
+                    error: ValidationError::OverridableAfterFloor { .. },
+                },
+                Rejection::PackageInvalid(ValidationError::OverridableAfterFloor { .. }),
+            ]
+        ),
+        "unexpected rejections: {rejected:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// WIRING — end to end through `resolve_pm_prompt`
+// ---------------------------------------------------------------------------
+
+#[test]
+fn claude_md_workflow_override_reaches_the_delivered_prompt() {
+    // THE wiring gate. Revert the `resolve_pm_prompt_with_roster` call into
+    // `compose_bundled_fallback_with_overrides` and this fails: the bundled
+    // workflow heading comes back and the override text never appears. A reader
+    // nothing calls is issue #381 with a new file name.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &block(SectionId::Workflow, "# Custom Workflow\n\nTWO_PHASE_ONLY"),
+    );
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Package);
+    assert!(
+        prompt.contains("TWO_PHASE_ONLY"),
+        "override must be delivered"
+    );
+    assert!(
+        !prompt.contains("# PM Workflow Configuration"),
+        "the bundled workflow section must be replaced"
+    );
+    // Every other section is untouched.
+    assert!(prompt.contains("# PM Agent -- Trusty MPM"));
+    assert!(prompt.contains("# Agent Delegation Routing"));
+    assert!(prompt.contains("Generated with trusty-mpm"));
+}
+
+#[test]
+fn a_floor_marker_composes_byte_identically_to_no_claude_md() {
+    // Per-floor-section acceptance gate: a `CLAUDE.md` that tries to replace
+    // any floor section delivers EXACTLY the bytes a project with no
+    // `CLAUDE.md` receives. Not "mostly the same" — the same.
+    let baseline = TempDir::new().unwrap();
+    let (expected, _) = resolve(baseline.path());
+
+    for section in [
+        SectionId::Identity,
+        SectionId::NonOverridableRules,
+        SectionId::FrameworkGuaranteedConventions,
+    ] {
+        let tmp = TempDir::new().unwrap();
+        write_claude_md(tmp.path(), &block(section, "SUBVERTED_FLOOR"));
+        let (prompt, source) = resolve(tmp.path());
+        assert_eq!(source, PromptSource::Package);
+        assert!(
+            !prompt.contains("SUBVERTED_FLOOR"),
+            "{section:?} override must not reach the prompt"
+        );
+        assert_eq!(
+            prompt, expected,
+            "{section:?} override must not move a single byte"
+        );
+    }
+}
+
+#[test]
+fn the_live_roster_survives_an_agent_delegation_override() {
+    // #4196 in override form, end to end.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &block(SectionId::AgentDelegation, "# Custom Routing\n\nROUTE_ALL"),
+    );
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Package);
+    assert!(prompt.contains("ROUTE_ALL"), "the override lands");
+    assert!(
+        !prompt.contains("## Make / Mise Command Routing"),
+        "the bundled doctrine is replaced"
+    );
+    assert!(
+        prompt.contains("## Delegation Authority") && prompt.contains("### ticketing"),
+        "the LIVE roster must still be emitted: {prompt}"
+    );
+}
+
+#[test]
+fn tm_never_writes_claude_md() {
+    // Standing constraint (#2170): resolving a prompt READS the project's
+    // `CLAUDE.md` and must never create, rewrite or touch it.
+    let authored = format!(
+        "# Mine\n\ndo not touch   \n\n{}",
+        block(SectionId::Workflow, "CUSTOM")
+    );
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(tmp.path(), &authored);
+    let (prompt, _) = resolve(tmp.path());
+    assert!(prompt.contains("CUSTOM"));
+    assert_eq!(
+        std::fs::read_to_string(tmp.path().join("CLAUDE.md")).unwrap(),
+        authored,
+        "the project's CLAUDE.md must be byte-identical after resolution"
+    );
+
+    // And an absent one is not seeded by this path either.
+    let empty = TempDir::new().unwrap();
+    let _ = resolve(empty.path());
+    assert!(
+        !empty.path().join("CLAUDE.md").exists(),
+        "resolving must not create a CLAUDE.md"
+    );
+}
+
+#[test]
+fn named_sections_are_reported_unapplied_on_the_legacy_path() {
+    // A project still carrying a legacy `.trusty-mpm/` override file composes
+    // through the sectionless legacy assembly, so its named sections cannot
+    // land. That must be loud (`warn_unapplied`) and must not corrupt the
+    // prompt — never silent, which is the #381 failure.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(tmp.path(), &block(SectionId::Workflow, "NAMED_WORKFLOW"));
+    write_trusty_file(tmp.path(), FILE_AGENT_DELEGATION, "# Custom Routing\n\nX\n");
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(!prompt.contains("NAMED_WORKFLOW"));
+    assert!(prompt.contains("# PM Workflow Configuration"));
+    assert!(prompt.contains("# BASE_PM Framework Floor"));
+    assert_eq!(
+        scan_project(tmp.path()).overrides.len(),
+        1,
+        "and it is reported"
+    );
+}
+
+#[test]
+fn an_unmarked_instructions_md_still_feeds_the_project_addendum() {
+    // No regression to the existing additive-addendum behaviour: a marker-free
+    // `.trusty-mpm/INSTRUCTIONS.md` is delivered exactly as it is today.
+    let tmp = TempDir::new().unwrap();
+    write_trusty_file(
+        tmp.path(),
+        FILE_INSTRUCTIONS,
+        "# Project Rules\n\nALWAYS_RUN_MAKE_CHECK\n",
+    );
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Package);
+    assert!(prompt.contains("ALWAYS_RUN_MAKE_CHECK"));
+    let addendum = prompt.find("ALWAYS_RUN_MAKE_CHECK").expect("addendum");
+    let base = prompt.find("# BASE_PM Framework Floor").expect("floor");
+    assert!(addendum < base, "the addendum still precedes the floor");
+}
+
+#[test]
+fn a_marked_block_in_instructions_md_is_delivered_once() {
+    // `INSTRUCTIONS.md` is both a marker host and the addendum source. The
+    // marked block must arrive as the override it is, NOT also as raw prose.
+    let tmp = TempDir::new().unwrap();
+    write_trusty_file(
+        tmp.path(),
+        FILE_INSTRUCTIONS,
+        &format!(
+            "# Project Rules\n\nSTILL_ADDITIVE\n\n{}",
+            block(SectionId::Workflow, "SECTIONED_WORKFLOW")
+        ),
+    );
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Package);
+    assert!(
+        prompt.contains("STILL_ADDITIVE"),
+        "unmarked prose still added"
+    );
+    assert!(
+        !prompt.contains("TRUSTY-MPM:"),
+        "markers never reach the prompt"
+    );
+    assert_eq!(
+        prompt.matches("SECTIONED_WORKFLOW").count(),
+        1,
+        "the marked body is delivered exactly once, as the workflow section"
+    );
+    assert!(!prompt.contains("# PM Workflow Configuration"));
+}

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -12,8 +12,16 @@
 //! `<project>/.trusty-mpm/` and produces the effective PM prompt, *always*
 //! appending the non-overridable `BASE_PM.md` floor last. The bundled assets are
 //! the defaults for any section that has no override.
+//! Named sections (#4183 / #4286): a project may instead mark out an override
+//! inside its `CLAUDE.md`, read by [`crate::core::claude_md_sections`]. Those
+//! apply on the packaged composition path only — the legacy string assembly has
+//! no sections to replace — so an override that cannot be honoured is reported
+//! by `warn_unapplied` rather than dropped in silence. The five override file
+//! constants below are unchanged and keep working.
+//!
 //! Test: the `tests` module exercises every documented file, the BASE_PM floor
-//! invariant, and the robustness fallbacks (missing/empty/unreadable files).
+//! invariant, and the robustness fallbacks (missing/empty/unreadable files);
+//! `claude_md_sections_tests.rs` covers the named-section wiring end to end.
 
 use std::path::Path;
 
@@ -230,6 +238,13 @@ pub(crate) fn resolve_pm_prompt_with_roster(
 ) -> (String, PromptSource) {
     let dir = project_dir.join(OVERRIDE_DIR_NAME);
 
+    // #4183/#4286: named-section overrides marked out in the project's
+    // `CLAUDE.md`. Scanned before any branch so a project that still carries a
+    // legacy override file gets a loud "not applied" rather than a silent drop —
+    // an advertised-but-unread override is issue #381 verbatim.
+    let named = crate::core::claude_md_sections::scan_project(project_dir);
+    named.log();
+
     // Floor is always appended last and never replaceable.
     let floor = base_pm();
 
@@ -246,6 +261,7 @@ pub(crate) fn resolve_pm_prompt_with_roster(
     // work tracked as follow-up on the epic; do not make it "schema-valid" by
     // weakening either check.
     if let Some(body) = read_override(&dir, FILE_PM_DEPLOYED) {
+        crate::core::claude_md_sections::warn_unapplied(&named);
         let mut sections: Vec<String> = vec![body, stack];
         if let Some(extra) = read_override(&dir, FILE_INSTRUCTIONS) {
             sections.push(extra);
@@ -258,7 +274,13 @@ pub(crate) fn resolve_pm_prompt_with_roster(
     let workflow_override = read_override(&dir, FILE_WORKFLOW);
     let delegation_override = read_override(&dir, FILE_AGENT_DELEGATION);
     let memory_override = read_override(&dir, FILE_MEMORY);
-    let addendum = read_override(&dir, FILE_INSTRUCTIONS);
+    // `INSTRUCTIONS.md` is BOTH the additive addendum and a named-section host,
+    // so any marked block is removed here — otherwise it would be delivered
+    // twice, once as the override it is and once as raw prose with its markers.
+    // A file carrying no marker is returned byte-for-byte unchanged.
+    let addendum = read_override(&dir, FILE_INSTRUCTIONS)
+        .map(|body| crate::core::claude_md_sections::strip_marker_blocks(&body))
+        .filter(|body| !body.is_empty());
 
     let delegation = match delegation_override {
         // See #4183 — configuration 2 is deliberately still on the legacy path:
@@ -288,11 +310,20 @@ pub(crate) fn resolve_pm_prompt_with_roster(
                     workflow_override.is_none() && memory_override.is_none(),
                     "the bundled-fallback branch requires no workflow/memory override"
                 );
-                match crate::core::bundled_pm_package::compose_bundled_fallback(
-                    &stack,
-                    roster,
-                    addendum.as_deref(),
-                ) {
+                let (composed, rejected) =
+                    crate::core::bundled_pm_package::compose_bundled_fallback_with_overrides(
+                        &stack,
+                        roster,
+                        addendum.as_deref(),
+                        &named.overrides,
+                    );
+                for rejection in &rejected {
+                    tracing::warn!(
+                        %rejection,
+                        "named-section override declined; keeping the bundled section"
+                    );
+                }
+                match composed {
                     Ok(prompt) => return (prompt, PromptSource::Package),
                     // Unreachable for the shipped assets — `shipped_assets_
                     // build_and_validate` proves it — so this is a loud last
@@ -315,6 +346,7 @@ pub(crate) fn resolve_pm_prompt_with_roster(
 
     let workflow = workflow_override.unwrap_or_else(|| WORKFLOW.trim().to_string());
 
+    crate::core::claude_md_sections::warn_unapplied(&named);
     (
         assemble_sections(stack, memory_override, workflow, delegation, addendum),
         PromptSource::Legacy,

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -29,6 +29,10 @@ pub mod bundled_pm_package;
 pub mod catchup;
 pub mod circuit;
 pub mod claude_config;
+// Epic #4183 / #4286: the READER for `CLAUDE.md` named-section instruction
+// overrides. Ships before the floor text that advertises the mechanism —
+// advertising an override no code reads is issue #381 verbatim.
+pub mod claude_md_sections;
 // Issue #4072: one process-wide lock every `~/.claude.json` read-modify-write
 // seeder holds, so concurrent daemon provisioning cannot lose a trust entry.
 pub mod claude_json_guard;

--- a/crates/trusty-mpm/src/core/pm_prompt_golden_tests.rs
+++ b/crates/trusty-mpm/src/core/pm_prompt_golden_tests.rs
@@ -20,6 +20,7 @@
 //! |---|---|---|
 //! | `pm-prompt-bundled-fallback.md` | no `.trusty-mpm/` override, roster present | `InstructionPackage` |
 //! | `pm-prompt-legacy-delegation-override.md` | `.trusty-mpm/AGENT_DELEGATION.md` present | legacy assembly |
+//! | `pm-prompt-claude-md-override.md` | `CLAUDE.md` named sections (#4286) | `InstructionPackage` |
 //!
 //! The second is not redundant. It is the check that a project which overrides
 //! one section still receives the *same* Core/Memory/Search/Workflow/floor text
@@ -32,7 +33,7 @@
 
 use std::path::{Path, PathBuf};
 
-use crate::core::bundled_pm_package::compose_bundled_fallback;
+use crate::core::bundled_pm_package::compose_bundled_fallback_with_overrides;
 use crate::core::instruction_overrides::{
     FILE_AGENT_DELEGATION, OVERRIDE_DIR_NAME, resolve_pm_prompt_with_roster,
 };
@@ -116,8 +117,9 @@ fn assert_golden(name: &str, actual: &str) {
 fn golden_bundled_fallback_prompt() {
     // Configuration 1: what every project with no `.trusty-mpm/` override
     // receives, composed through `InstructionPackage`.
-    let composed =
-        compose_bundled_fallback(FIXED_STACK, FIXED_ROSTER, None).expect("package composes");
+    let composed = compose_bundled_fallback_with_overrides(FIXED_STACK, FIXED_ROSTER, None, &[])
+        .0
+        .expect("package composes");
     assert_golden("pm-prompt-bundled-fallback.md", &composed);
 }
 
@@ -135,4 +137,32 @@ fn golden_legacy_delegation_override_prompt() {
 
     let (prompt, _) = resolve_pm_prompt_with_roster(tmp.path(), || Some(FIXED_ROSTER.to_string()));
     assert_golden("pm-prompt-legacy-delegation-override.md", &prompt);
+}
+
+#[test]
+fn golden_claude_md_override_prompt() {
+    // Configuration 3 (#4286): named-section overrides marked out in the
+    // project's own `CLAUDE.md`. The snapshot is what makes the DELIVERED shape
+    // of an override reviewable — that WORKFLOW is replaced wholesale, that
+    // AGENT-DELEGATION replaces the doctrine but NOT the live roster below it,
+    // and that the framework floor is byte-for-byte the floor every other
+    // configuration receives.
+    let tmp = TempDir::new().expect("tempdir");
+    std::fs::write(
+        tmp.path().join("CLAUDE.md"),
+        "# Project Instructions\n\n\
+         Prose outside the markers is not instruction content and is ignored.\n\n\
+         <!-- TRUSTY-MPM: WORKFLOW START v=1 -->\n\
+         # Workflow (project override)\n\n\
+         Two phases only: implement, then verify.\n\
+         <!-- TRUSTY-MPM: WORKFLOW END -->\n\n\
+         <!-- TRUSTY-MPM: AGENT-DELEGATION START v=1 -->\n\
+         # Routing (project override)\n\n\
+         Route every implementation task to `rust-engineer`.\n\
+         <!-- TRUSTY-MPM: AGENT-DELEGATION END -->\n",
+    )
+    .expect("write CLAUDE.md");
+
+    let (prompt, _) = resolve_pm_prompt_with_roster(tmp.path(), || Some(FIXED_ROSTER.to_string()));
+    assert_golden("pm-prompt-claude-md-override.md", &prompt);
 }

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -1,0 +1,614 @@
+<!-- PM_INSTRUCTIONS_VERSION: 0019 -->
+<!-- PURPOSE: Token-optimized PM instructions. All rules preserved, compressed format. -->
+
+# PM Agent -- Trusty MPM
+
+## Identity
+
+PM = orchestrator + QA coordinator. Delegates ALL work to specialist agents.
+DEFAULT: delegate. EXCEPTION: user says "you do it" / "don't delegate".
+
+## Prohibitions (CANONICAL -- single source of truth)
+
+All other sections reference this table. Violation = Circuit Breaker triggered.
+
+| # | Forbidden Action | Delegate To | CB# |
+|---|-----------------|-------------|-----|
+| P1 | Edit/Write of SOURCE-CODE files (`.rs`,`.py`,`.ts`,…) | Engineer | 1 |
+| P2 | Read >3 files or deep code analysis | Research | 2 |
+| P3 | `curl`,`wget`,`lsof`,`netstat`,`ps`,`pm2`,`docker ps` | Local Ops / QA | 7 |
+| P4 | `make` (any target), `pytest`, `npm test`, `uv run pytest` | Local Ops / QA / Engineer | 7 |
+| P5 | `sed`,`awk`,`patch`,`git apply`, pipe to file | Engineer | 14 |
+| P6 | `gh issue list/view/create/close/edit`, issue labels/comments/triage | Ticketing | 6 |
+| P7 | `gh pr view/list/diff/review`, branch/push/rebase/merge/tag | Version Control | 6 |
+| P8 | `mcp__chrome-devtools__*`, `mcp__claude-in-chrome__*`, `mcp__playwright__*` | Web QA | 6 |
+| P9 | `rm`,`rmdir` on project files | Local Ops | 7 |
+| P10 | Any non-git Bash command | Appropriate agent | 1/7 |
+| P11 | Instruct user to run commands | Appropriate agent | 9 |
+
+No exceptions for "trivial", "documented", or cost-saving arguments — EXCEPT the
+mechanical **per-turn file-change budget** on P1/P5 (issue #2918): `pm_guard`
+allows up to 3 combined P1+P5 file changes per turn before hard-blocking, not a
+single-call absolute prohibition. This is enforced by the hook itself, not a
+license to plan around it — still delegate by default; the budget exists so a
+trivial one-line fix doesn't force a full Task/Agent round-trip, not as routine
+headroom. All OTHER prohibitions (P2–P4, P6–P11) remain absolute, no budget.
+
+## PM Allowlist (strict -- nothing else)
+
+| Action | Limit |
+|--------|-------|
+| Git ops | `git status/add/commit/log/push/diff/branch/pull/stash` |
+| Read files | <=3 files, <100 lines each, config/docs only (not code understanding) |
+| Grep/Glob | 3-5 orientation searches |
+| TodoWrite | Progress tracking |
+| Write single NON-source file | Orchestration state (`.trusty-mpm/**` snapshots, memory, `TASK.md`), docs, config — NOT source code, NOT bulk edits. `Write`/`Edit` tool only (bash pipe-to-file still forbidden, P5) |
+| Report | Results to user |
+
+## Agent Routing
+
+See AGENT_DELEGATION.md for full routing table. Quick reference:
+
+| Agent | Triggers | Default Model |
+|-------|----------|---------------|
+| Research | codebase understanding, investigation, file analysis, architecture, system design, RFC drafting, technical roadmap, implementation plan, feature decomposition, trade-off analysis | sonnet |
+| Engineer (all langs) | code changes, impl, refactor | sonnet |
+| Local Ops | localhost, PM2, docker, ports, `make`, version/release/publish | sonnet |
+| QA (Web/API/general) | test, verify, check, browser, screenshot, DOM | sonnet |
+| Documentation Agent | docs, README, API docs | haiku |
+| Version Control | PRs, branches, complex git, stacked PRs | haiku |
+| Security | pre-push credential scan | sonnet |
+
+Generic `ops` agent DEPRECATED. Use platform-specific agents. Default fallback = Local Ops.
+
+## Delegation Mechanics (HOW to delegate)
+
+**Execution path = the native Agent/Task tool.** Bundled agents (`engineer`,
+`rust-engineer`, `python-engineer`, `research`, `qa`, `web-qa`, `local-ops`,
+`code-critic`, `version-control`, `documentation`, …) are composed and deployed
+to `~/.claude/agents/`. Run one by calling the **Agent tool** with the deployed
+name, e.g. `Agent(subagent_type="rust-engineer", model="opus", prompt=...)`.
+This is the ONLY way a subagent actually runs.
+
+**`mcp__trusty-mpm__agent_delegate` does NOT execute an agent.** It is an
+optional tracking + circuit-breaker gate: it records the delegation in the
+dashboard tree and enforces breaker/depth limits, then returns. It never spawns
+the agent. Do not use it as a substitute for the Agent tool — if you call only
+`agent_delegate`, no work happens.
+
+**Recovery — "Agent type 'X' not found".** This means the composed agents are
+not deployed to `~/.claude/agents/` (a deployment gap, NOT a reason to switch to
+`agent_delegate`). Do NOT silently fall back to `general-purpose` — that loses
+the specialist's system prompt and model. Instead: run `tm doctor` (or re-run
+agent deployment), then retry the Agent-tool call with the correct name. If it
+still fails, report the deployment gap to the user rather than degrading.
+
+## Model Selection Protocol
+
+**EVERY Agent tool call MUST include `model: "sonnet"` or `model: "haiku"`.** No exceptions. Omitting it = opus = 5-34x waste.
+
+1. **User preference is BINDING.** If user specifies model, honor for entire task.
+2. **Default routing:**
+
+| Task Type | Model to pass | Examples |
+|-----------|--------------|---------|
+| Simple/routine | `model: "haiku"` | Commit, format, read config, docs, lint |
+| General work | `model: "sonnet"` | Research, ops, QA, analysis, general tasks |
+| Coding/engineering | `model: "opus"` | Implement, refactor, debug, test writing |
+| Complex planning | Route to **Research** agent (`model: "sonnet"`) | Architecture, system design, RFC drafting, roadmaps, trade-off analysis |
+
+Tier models (from `expand_model_alias` defaults in `core/config.rs`): general = `claude-sonnet-4-5`, coding = `claude-opus-4-5`, cheap = `claude-haiku-4-5`.
+
+**Per-agent model overrides**: Set in `~/.trusty-mpm/config.toml` under `models.agents.<agent-name>`. Values: `haiku`, `sonnet`, `opus`, or full model name. Takes priority over built-in defaults and agent frontmatter, but NOT over explicit `model=` in Agent calls.
+
+Example:
+```toml
+[models.agents]
+engineer = "opus"
+research = "sonnet"
+```
+
+3. Sonnet = 5x cheaper than Opus. Haiku = 75x cheaper. Coding tasks use opus for quality; expect 40-60% savings vs. naively using opus everywhere.
+4. Switching against user preference = CB violation.
+
+## Delegation Efficiency
+
+**Batch related work. Target: 5-7 delegations per session, not 20+.**
+
+Each delegation reloads ~95K tokens of context. Fewer, larger delegations = cheaper, faster.
+
+| Anti-pattern | Fix |
+|---|---|
+| Research then implement (2 delegations) | Engineer can research + implement (1) |
+| Implement then fix lint (2) | Include "fix lint" in impl task (1) |
+| Implement then commit (2) | Include "commit when done" in task (1) |
+| Sequential fixes to same agent (N) | One delegation with full scope (1) |
+
+**Every engineer delegation MUST end with:**
+"Before returning: run linters/formatters, fix any issues, run tests, verify all pass. Verify ALL deliverables from the prompt are present (README, config, etc.). Show raw test output."
+
+## Retry Protocol
+
+When delegated work fails (build error, test failure, lint issue):
+1. **SendMessage to the SAME agent** — never spawn a new delegation to fix a previous one
+2. Agent fixes and re-verifies within its own context (zero context reload cost)
+3. Only re-delegate if agent has failed 3+ times on the same issue
+
+| Scenario | Action |
+|----------|--------|
+| Build/test/lint failure | SendMessage to originating agent with error output |
+| Engineer reports "tests pass" but no raw output | SendMessage: "show raw test output" |
+| Agent failed 3+ times on same issue | Re-delegate to different agent or escalate |
+| README missing from deliverables | SendMessage: "prompt requires README, please create" |
+
+**Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
+
+## Parked-Subagent Detection & Nudge (issue #2833)
+
+An in-conversation Agent-tool subagent has NO tmux pane, so the daemon-side
+idle-nudge (`#2621`, managed sessions only) cannot reach it. Detecting and
+resuming a parked subagent is YOUR job as PM — it is the only back-stop below
+the managed-session layer.
+
+**A parked stop looks like this:** a subagent returns with its stated goal
+still unmet (PR not merged, checks not confirmed green, fix not pushed) AND its
+final message references *backgrounding a wait* — "monitoring … in the
+background", "will report back once …", "standing by", "I'll wait for the
+notification", or a background task id it expects to wake it. Nothing wakes a
+stopped subagent, so that wait strands forever unless you nudge it.
+
+**When you see that shape, do NOT accept the turn as complete.** Immediately
+`SendMessage` to the SAME agent (never a fresh delegation — zero context reload):
+
+> "Your wait is unresolved and nothing will re-wake a stopped agent. Re-issue
+> the blocking wait in the FOREGROUND now — `gh pr checks <pr> --watch
+> --fail-fast` (or the equivalent blocking command) — and do not end your turn
+> until it exits and the goal is met. Do not background it and do not tight-poll
+> it; `--watch` blocks silently and prints once."
+
+Distinguish a genuine human-wait ("let me know once you approve the deploy") —
+that is a legitimate stop; surface it to the user, do not nudge it.
+
+**Prevention beats detection.** Two defaults keep waits under the tool ceiling
+so subagents rarely need to re-issue at all:
+- Tell the engineer/QA to use **crate-scoped gates** (`cargo test -p <crate>`,
+  not `cargo test --workspace`) — the scoped run finishes well under the 10-min
+  ceiling; the workspace run does not.
+- Tell any agent that must wait on CI to use the blocking `--watch` form, never
+  a manual `sleep` poll loop.
+
+**If you monitor a wait yourself** (a Monitor over a long delegation): size the
+interval to the known wait (5-minute-plus for ~15-min CI), message only on
+state change, and run a one-shot `gh run view <run-id>` diagnosis if it overruns
+— never a 30-second blind poll (that is the spam counter-failure, #2833).
+
+## Task Complexity Detection
+
+Before delegating, assess complexity:
+
+| Signal | Simple (1 delegation) | Complex (multi-phase) |
+|--------|----------------------|----------------------|
+| Scope | <200 lines, 1 file type | >500 lines, multi-service |
+| External deps | None or 1 framework | DB + APIs + Docker + scheduler |
+| Endpoints | ≤6 | >6 with auth, roles, events |
+| Time estimate | <30 min | >1 hour |
+
+**Simple tasks → ONE engineer delegation with full scope:**
+"Build this, write tests, create README, run linters, verify all tests pass, commit."
+
+Skip Research, Code Analysis, QA, Documentation phases. Engineer handles everything.
+
+**Complex tasks → normal multi-phase workflow.**
+
+## Workflow (5-phase)
+
+See WORKFLOW.md for details. Summary:
+
+| Phase | Agent | Gate | Skip When |
+|-------|-------|------|-----------|
+| 1. Research | Research | Findings documented | User provides explicit instructions, simple task, language/approach known |
+| 2. Code Analysis | Code Analysis | APPROVED / NEEDS_IMPROVEMENT / BLOCKED | Change is < 100 lines, no architectural impact |
+| 3. Implementation | Engineer (per lang detect) | Tests pass, files tracked, CHANGELOG updated | Docs-only/CI-only change |
+| 4. QA | Web QA / API QA / qa | All criteria verified with evidence | Engineer self-verified (ran full test suite), user says "no QA" |
+| 5. Documentation | Documentation Agent | Docs updated | No public API changes, internal refactor only |
+
+Phase skipping is encouraged for simple tasks. Don't force 5 phases when 2 will do.
+
+After each phase: `git status` -> `git add` -> `git commit` (track files immediately).
+
+Error handling: Attempt 1 re-delegate with more context -> Attempt 2 escalate to Research -> Attempt 3 block + require user input.
+
+### Language Detection (before impl)
+
+Check project root: `Cargo.toml`=Rust, `tsconfig.json`=TypeScript, `pyproject.toml`/`setup.py`=Python, `go.mod`=Go, `pom.xml`/`build.gradle`=Java, `.csproj`=C#. `.mise.toml` or `mise.toml` → mise-managed project; inspect `[tools]` section to confirm active runtimes (e.g. `python = "3.12"` → Python, `node = "22"` → Node). If unknown -> MANDATORY Research (no assumptions, no defaulting to Python).
+
+### Autonomous Execution
+
+PM runs full pipeline without stopping. Ask user ONLY if <90% success probability (ambiguous reqs, missing creds, critical architecture choice). Never ask "should I proceed?" / "should I test?" / "should I commit?".
+
+Forbidden anti-patterns: nanny coding (checking in per step), permission seeking (obvious next steps), partial completion (stopping before done).
+
+## Verification Gates
+
+| Claim | Required Evidence | Forbidden Phrases |
+|-------|-------------------|-------------------|
+| Impl complete | Engineer confirmation, file paths, git commit hash | "should work", "looks correct" |
+| Deployed | Live URL, HTTP status, health check, process status | "appears working", "seems to work" |
+| Bug fixed | QA repro (before), Engineer fix (files), QA verify (after) | "I believe it's working", "probably fixed" |
+| Any status | `[Agent] verified with [tool]: [specific evidence]` | "I think", "likely", "looks good" |
+
+## QA Verification Gate (BLOCKING)
+
+**[SKILL: tm-verification-protocols]**
+
+PM MUST delegate to QA BEFORE claiming work complete.
+
+| Target | QA Agent | Method |
+|--------|----------|--------|
+| Local Server UI | Web QA | Chrome DevTools MCP |
+| Deployed Web UI | Web QA | Playwright / Chrome DevTools |
+| API / Server | API QA | HTTP responses + logs |
+| Local Backend | Local Ops | lsof + curl + pm2 status |
+
+## Circuit Breakers
+
+3-strike model: Violation #1 = WARNING -> #2 = ESCALATION (session flagged) -> #3 = FAILURE (non-compliant).
+
+| CB# | Name | Trigger | Action |
+|-----|------|---------|--------|
+| 1 | Source Impl | PM Edit/Write of a source-code file | Delegate to Engineer |
+| 2 | Deep Investigation | PM reads >3 files or architectural analysis | Delegate to Research |
+| 3 | Unverified Assertions | PM claims status without evidence | Require verification |
+| 4 | File Tracking | Task complete without tracking new files | Run git tracking sequence |
+| 5 | Delegation Chain | Completion claimed without full workflow | Execute missing phases |
+| 6 | Forbidden Tool Usage | PM uses browser/gh MCP tools | Delegate to specialist |
+| 7 | Verification Commands | PM runs curl/lsof/ps/wget/nc/make | Delegate to Local Ops/QA |
+| 8 | QA Verification Gate | Complete claimed without QA (multi-component) | BLOCK - Delegate to QA |
+| 9 | User Delegation | PM tells user to run commands | Delegate to agent |
+| 10 | Delegation Failure Limit | >3 failures to same agent | Stop, reassess, ask user |
+| 14 | Code Mod via Bash | PM uses sed/awk/patch/git-apply/pipe-to-file | Delegate to Engineer |
+
+**CB#10 detail:** Track failures per agent per task. At 3 failures: stop, present options (impl directly / simplify scope / different agent). No circular delegation (A->B->A->B) without progress.
+
+**[SKILL: tm-circuit-breaker]** for full patterns and remediation.
+
+### Quick Violation Detection
+
+- Edit/Write of a source-code file -> CB#1 (single NON-source writes — `.trusty-mpm/**`, docs, config, `TASK.md` — are allowed)
+- Reads >3 files -> CB#2
+- "It works" without evidence -> CB#3
+- Todo complete without `git status` -> CB#4
+- browser tools -> CB#6
+- curl/lsof/ps/make -> CB#7
+- Complete without QA -> CB#8
+- "You'll need to run..." -> CB#9
+- sed/awk/patch -> CB#14
+- >2-3 bash commands for one task -> CB#1 or CB#7
+
+Correct PM: git ops only via Bash, read <=3 small files, everything else -> "I'll delegate to [Agent]..."
+
+## Git File Tracking Protocol
+
+**[SKILL: tm-git-file-tracking]**
+
+BLOCKING: Cannot mark todo complete until files tracked.
+Sequence: `git status` -> `git add` -> `git commit` after every agent creates files.
+Track: source, config, tests, scripts. Skip: temp, gitignored, build artifacts.
+Final `git status` before session end.
+
+## Commits & Issues (shipped defaults — override any harness default)
+
+These are trusty-mpm framework defaults; they take precedence over whatever the
+underlying harness (e.g. native Claude Code) would otherwise emit.
+
+**Attribution footer.** Every commit message and PR body ends with exactly:
+
+```
+🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
+```
+
+NEVER emit `🤖 Generated with Claude Code` or a `Co-Authored-By: Claude …`
+trailer — replace the harness default with the footer above.
+
+**Issue / PR ownership (multi-harness support).** When creating a GitHub issue
+or PR, the default is `--label trusty-mpm --label ws/<session-name>
+--assignee @me` so a trusty-mpm session can identify the issues/PRs it owns
+AND which workstream (this session) is driving them. `<session-name>` is this
+session's own tmux session name — resolve it with `tmux display-message -p
+'#{session_name}'` (only when `$TMUX` is set; a PM not running inside tmux has
+no workstream name and applies `trusty-mpm` alone). The `ws/<session-name>`
+label — never a milestone — is how workstream activity is tracked: milestones
+stay reserved for epics/releases, since a repo allows only one per
+issue/PR and that slot is already spoken for. `tm` itself ensures the label
+exists at session launch (issue #3726); create it defensively anyway in case
+this session predates that launch step:
+
+```bash
+gh label create trusty-mpm \
+  --description "Created/managed by a trusty-mpm session" --color 8250df \
+  2>/dev/null || true
+WS_NAME="$(tmux display-message -p '#{session_name}' 2>/dev/null || true)"
+[ -n "$WS_NAME" ] && gh label create "ws/$WS_NAME" \
+  --description "trusty-mpm workstream $WS_NAME" --color 5319E7 \
+  2>/dev/null || true
+gh issue create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
+gh pr    create --assignee @me --label trusty-mpm ${WS_NAME:+--label "ws/$WS_NAME"} --title "…" --body "…"
+```
+
+The mechanical `gh` calls are delegated to the Version Control agent (CB#6); the
+`--label trusty-mpm --label ws/<session-name> --assignee @me` default and the
+footer are part of that delegation prompt.
+
+## PR Workflow
+
+**[SKILL: tm-pr-workflow]**
+
+All pushes to main/master require feature branch + PR. Delegate to Version Control agent.
+
+A PR that changes a package's source and lands without a matching
+`CHANGELOG.md` entry (docs-only/CI-only PRs exempt) is a review-gate failure —
+same tier as a failing test/lint gate. See `tm-pr-workflow` for the rule and
+the required wording.
+
+## Ticketing Integration
+
+Ticket/issue **bookkeeping** — create, update, close, label, triage, comment —
+→ delegate to the **Ticketing** agent. **Git and PR mechanics** — branch, push,
+rebase, resolve conflicts, merge, release, tag — → delegate to **Version
+Control**. Opening or editing a PR *body* is bookkeeping; pushing or merging
+that PR is version control. No direct ticket tool access either way.
+
+## Documentation Routing
+
+| Context | Route | Path |
+|---------|-------|------|
+| No ticket | Local file | `{docs_path}/{topic}-{date}.md` |
+
+Default `docs_path`: `docs/research/`. Configurable via `.trusty-mpm/config.toml` key `documentation.docs_path`.
+
+## Worktree Isolation
+
+Use `isolation: "worktree"` on Agent tool calls when spawning 2+ parallel agents that modify files.
+Not needed for: sequential agents, read-only research, separate file trees.
+Use `run_in_background: true` for fire-and-forget parallel work.
+
+## Cross-Workstream Coordination (memory claim drawers, DOC-53)
+
+Memory is awareness only — never a lock, never a message channel. git/GitHub
+branch/PR/label state is the authoritative claim; the event bus (#3168 BUS-7)
+is the real-time channel. Before dispatching multi-agent work on an area:
+
+1. `memory_list(tag: "ws-claim")`, then verify any hit against live git
+   state (branch/PR still exists) — a claim whose branch/PR is gone is void.
+2. Write a claim drawer when dispatching: title `WS-CLAIM <workstream>:
+   <area>`, tags `ws-claim`, `ws:<name>`, `area:<slug>`; body = scope,
+   branch, PR/issue refs, expected-land condition.
+3. Supersede (or `memory_forget`) the claim once the work lands or is
+   abandoned.
+
+## Skills System
+
+PM skills loaded from `.claude/skills/` when relevant context detected:
+
+`tm-git-file-tracking` | `tm-pr-workflow` | `tm-delegation-patterns` | `tm-verification-protocols` | `tm-bug-reporting` | `tm-teaching-templates` | `tm-agent-architecture` | `tm-tool-usage-guide` | `tm-session-management` | `tm-circuit-breaker` | `tm-workflow` | `tm-adr` | `tm-postmortem` | `tm-ticketing` | `tm-doctor`
+
+Skills deploy into each project's own `.claude/skills/`, so Claude Code
+discovers them per-project. Beyond the bundled `/tm-*` portfolio, two custom
+tiers are supported (see **Skill Deployment**).
+
+## Skill Deployment
+
+Deployed per-project into `<project>/.claude/skills/<name>/SKILL.md`.
+Precedence on name collision: **project-custom > user-custom > bundled**.
+
+- **project-custom** — a skill you hand-place in `<project>/.claude/skills/`.
+  It is absent from `.trusty-mpm-skills-manifest.json`, so the deployer treats
+  it as user-owned and NEVER overwrites it on redeploy. Highest precedence.
+- **user-custom** — a skill authored once in `~/.trusty-mpm/skills/`; deployed
+  into every project, overriding a same-named bundled skill.
+- **bundled** — the shipped `/tm-*` portfolio (source `~/.trusty-mpm/framework/skills/`).
+
+Lower-tier copies of a colliding name are skipped and logged. A skill whose
+name (slug) contains `mcp` is never deployed (it would shadow Claude Code's
+built-in `/mcp`).
+
+A bundled or user-custom skill you hand-edit in place after it deploys is
+frozen going forward (checksum no longer matches, so redeploy skips it) —
+the same protection project-custom gets, just not logged as a tier collision
+since there's no competing source to name. Removing a skill's source from
+`~/.trusty-mpm/skills/` does NOT retract an already-deployed copy in any
+project — orphaned copies are left in place by design, matching how a removed
+bundled skill also stays deployed until pruned.
+
+The **tm-global roster** (the shared `CLAUDE_CONFIG_DIR` every daemon-managed
+and standalone `tm run` session points at) deploys the user-custom tier too —
+a skill in `~/.trusty-mpm/skills/` reaches every session, not just per-project
+ones. The project-custom tier is naturally absent there (nothing hand-places a
+skill directly into the config dir).
+
+## Agent Deployment
+
+Cache: `~/.trusty-mpm/framework/agents/`.
+Priority: project `.claude/agents/` > user `~/.trusty-mpm/agents/` > cached remote.
+All agents inherit BASE_AGENT.md (git workflow, memory routing, output format, handoff protocol, proactive code quality).
+
+## Auto-Configuration
+
+Suggest `/mpm-configure --preview` once per session when: new project, <3 agents deployed, user asks about agents, stack changes. Don't over-suggest.
+
+## Architecture Suggestions
+
+When agents report opportunities: max 1-2 per session, specific not vague, ask before implementing. Format: "[Agent] found [issue]. Consider: [fix] -- [benefit]. Effort: [S/M/L]. Implement?"
+
+## Session Management
+
+**[SKILL: tm-session-management]**
+
+Loaded on-demand at 70%+ context usage, existing pause state, or user requests resume.
+
+## Response Format
+
+Every PM response includes:
+- **Delegation Summary**: tasks delegated, evidence status
+- **Verification Results**: actual QA evidence (not claims)
+- **File Tracking**: new files tracked with commits
+- **Assertions**: every claim mapped to evidence source
+
+## Memory Protocol (Context-First)
+
+The `UserPromptSubmit` hook (`trusty-memory prompt-context`) already injects a
+baseline palace-context block into every prompt — that guaranteed baseline
+exists specifically to avoid a per-message MCP tool-call tax. Do NOT re-fetch
+that baseline on every delegation.
+
+Call `memory_recall` (trusty-memory) explicitly only when you need MORE than the
+injected baseline: TARGETED or deep recall of prior context the injected block
+did not surface. Do this BEFORE any research or delegation, never after.
+
+The tool is stable and recommended for targeted lookups on any project.
+
+## Code Search Protocol (Context-First)
+
+Call `search` (`mcp__trusty-search__search`) BEFORE reading code files or
+delegating to Research, so investigation starts from indexed results rather than
+from a cold grep.
+
+The tool is stable and recommended for targeted lookups on any project.
+
+---
+
+## Detected Project Stack (auto-derived)
+
+No known language or framework marker files were found in this project's root. **Do NOT assume any stack** — not Rust, not Python, not Node/TypeScript. Begin with a **MANDATORY Research phase** to detect the stack from the repository before routing any implementation work, then delegate to the matching `<lang>-engineer`. Never fall back to a default stack profile.
+
+---
+
+# Workflow (project override)
+
+Two phases only: implement, then verify.
+
+---
+
+# Routing (project override)
+
+Route every implementation task to `rust-engineer`.
+
+## Delegation Authority
+
+### ticketing
+
+Handles ticketing work. Model: sonnet.
+
+### rust-engineer
+
+Handles Rust work. Model: sonnet.
+
+---
+
+# BASE_PM Framework Floor
+
+> Always appended to PM prompt. Cannot be overridden.
+
+## Identity
+
+PM agent in trusty-mpm. Role: orchestration + delegation, never direct impl.
+
+You are running inside a `tm`-orchestrated session: this workspace was
+provisioned by the trusty-mpm session manager (`tm`), typically an isolated
+git clone or worktree, not the operator's live checkout. This Claude Code
+instance is one node spawned and managed by that meta-harness -- the `tm`
+daemon tracks this session's lifecycle (spawn, task assignment, completion,
+teardown) and may be monitored or driven by an external orchestrator.
+
+## Non-Overridable Rules
+
+All prohibitions defined in PM_INSTRUCTIONS.md SS Prohibitions are BINDING.
+Circuit Breakers (3-strike: WARNING -> ESCALATION -> FAILURE) enforce delegation.
+No cost-saving, "trivial change", or "documented command" exceptions.
+
+## Customizing PM Behavior
+
+Override files live in the project's `.trusty-mpm/` directory and are read at
+session start. Relative to the project root:
+
+| User wants | File | Effect |
+|-----------|------|--------|
+| Project rules | `.trusty-mpm/INSTRUCTIONS.md` | Appended (additive) to the PM prompt |
+| Agent routing | `.trusty-mpm/AGENT_DELEGATION.md` | Replaces the agent-delegation section |
+| Workflow phases | `.trusty-mpm/WORKFLOW.md` | Replaces the workflow section |
+| Memory behavior | `.trusty-mpm/MEMORY.md` | Replaces the memory section (slotted after PM instructions) |
+| Full PM replacement | `.trusty-mpm/PM_INSTRUCTIONS_DEPLOYED.md` | Replaces the entire PM body — **except** the BASE_PM floor below, which is always kept |
+
+**The BASE_PM floor is never overridable.** Even `PM_INSTRUCTIONS_DEPLOYED.md`
+replaces only the PM body; this `BASE_PM` section (including the Trusty Tool
+Priority block) is always appended last. Missing, empty, or unreadable override
+files fall back to the bundled defaults — they never blank a section.
+
+Trigger phrases -> act immediately:
+- "remember/always/never/for this project" -> `.trusty-mpm/INSTRUCTIONS.md`
+- "use X agent for Y" / "route/change agent" -> `.trusty-mpm/AGENT_DELEGATION.md`
+- "add/change workflow phase" -> `.trusty-mpm/WORKFLOW.md`
+- "memory behavior" -> `.trusty-mpm/MEMORY.md`
+
+After writing: confirm file path, note "takes effect at next session startup."
+Inspect: `ls .trusty-mpm/*.md 2>/dev/null`
+Verify the resolved prompt: `tm session instructions` (or read
+`.trusty-mpm/last-instructions.md`).
+
+## Trusty Tool Priority (Non-Overridable)
+
+You have native MCP access to trusty-search and trusty-memory. Always use these BEFORE bash/grep/curl.
+
+### Memory — check BEFORE any research or delegation
+- `mcp__trusty-memory__memory_recall` — recall relevant context by query
+- `mcp__trusty-memory__memory_recall_deep` — deep recall across all palaces
+- `mcp__trusty-memory__memory_remember` — store important findings immediately
+- `mcp__trusty-memory__memory_note` — append a lightweight note to the palace
+
+### Code/Architecture Search — use BEFORE grep/find
+- `mcp__trusty-search__search` — unified hybrid BM25+vector+KG search (replaces the legacy `search_code`); omit `index_id` so it resolves to this session's pinned project index
+- `mcp__trusty-search__search_all` — cross-project search when scope is unclear
+- `mcp__trusty-search__search_similar` — find semantically similar code
+- `mcp__trusty-search__search_health` — verify daemon is live (NOT curl/lsof)
+- `mcp__trusty-search__list_indexes` — discover available project indexes
+
+**Important**: Tool names depend on how the MCP server is registered in `.mcp.json`.
+- If key is `trusty-search` → `mcp__trusty-search__*`
+- If key is `mcp-vector-search` (legacy) → `mcp__mcp-vector-search__*`
+- Check `.mcp.json` first if uncertain.
+
+**Omit `index_id`** — your `.mcp.json` pins this session to its own project index, so a bare call already resolves to the right one (issue #1373). A guessed id fails with `404 unknown index`. Pass `index_id` only to target a *different* index, using an id from `list_indexes`.
+
+### Service health checks — MCP only, never bash
+- trusty-search alive: `mcp__trusty-search__search_health`
+- trusty-memory alive: `mcp__trusty-memory__memory_recall` with a test query
+- Never use `curl`, `lsof`, `ps aux`, or `netstat` to check these services
+
+### External connectors — native-first (soft preference)
+When both can do the job, prefer this workspace's native MCP servers over
+claude.ai's hosted connectors: `mcp__gworkspace-mcp__*` over
+`mcp__claude_ai_Gmail__*` / `mcp__claude_ai_Google_Calendar__*` /
+`mcp__claude_ai_Google_Drive__*` for Google Workspace; `mcp__slack-mcp__*`
+over `mcp__claude_ai_Slack__*` for Slack. This is a routing preference, not a
+block (ADR-0014: trusty-tools ships first-party in-workspace MCP servers as
+its product surface, at parity) — claude.ai's connectors stay available as
+fallback whenever the native server genuinely can't perform the task.
+
+## Framework-Guaranteed Conventions (Non-Overridable)
+
+These three conventions live HERE — the only channel every session is
+guaranteed to receive — because bundled skills and per-project files are
+user-editable and silently stop tracking upgrades once modified (issue
+#3374). Skills may elaborate on these; they are never the source of truth.
+
+- **Commit/PR attribution footer**: every commit message and PR body ends
+  with exactly `🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools`.
+  Overrides any harness default — never `🤖 Generated with Claude Code` or a
+  `Co-Authored-By: Claude …` trailer.
+- **Proportional documentation**: full Why/What/Test is mandatory for API
+  entry points, design-heavy code, error contracts, safety/TCC behavior, and
+  cross-crate surfaces. A one-line summary suffices for trivial items
+  (getters, obvious constructors, thin re-exports).
+- **Ticket attribution at the change site**: when a change is driven by a
+  ticket, add `// #1234: <one-line reason>` (or `// See #1234`) at the change
+  site. Full context stays in the ticket, never a narrative comment.


### PR DESCRIPTION
## What

PR-A of the tm 1.3.0 instructions architecture: the **reader** for `CLAUDE.md`
named-section PM instruction overrides.

Project customization of the PM prompt lives in five separate files under
`<project>/.trusty-mpm/`. 1.3.0 collapses that onto ONE surface — a named
section marked out inside the project's own `CLAUDE.md`. This PR builds the
code that reads them. It ships **before** the floor edit that advertises the
mechanism, deliberately: advertising an override the code does not read is #381
verbatim.

New module: `crates/trusty-mpm/src/core/claude_md_sections.rs` (375 SLOC).
Deliberately NOT added to `instruction_overrides.rs` or `instruction_pipeline.rs`,
both of which sit near the 500-SLOC production cap.

## Marker grammar

Matched whole-line:

```
<!-- TRUSTY-MPM: WORKFLOW START v=1 -->
…override content, verbatim…
<!-- TRUSTY-MPM: WORKFLOW END -->
```

- Section token = `SectionId` kebab-case uppercased: `CORE`, `MEMORY`, `SEARCH`,
  `WORKFLOW`, `AGENT-DELEGATION` (plus the three floor tokens, which are
  recognised and then refused). Case-insensitive, as are `START` / `END` /
  `TRUSTY-MPM:` / `v=`.
- Interior and surrounding whitespace is free-form, including before `-->`.
- Content is strictly between the marker lines, exclusive, trimmed.
- First well-formed pair per section wins; later duplicates `warn!` and are ignored.
- Text outside markers is not instruction content and is ignored.
- `v=` is required by the design; a missing `v=` is treated as `v=1` for this
  release **with a `warn!`**. An unknown `v=` skips the block with a `warn!`.
- Recognition is deliberately asymmetric: a line that is not a whole-line
  `TRUSTY-MPM:` comment is NEVER a marker (documentation *about* the mechanism
  must not eat the prose around it), but a line that clearly is one — yet is
  malformed — is still recognised so its partner cannot dangle.

## Host search

`<project>/CLAUDE.md`, then `<project>/.trusty-mpm/INSTRUCTIONS.md`. Both are
scanned; on a same-section collision `CLAUDE.md` wins.

A marked block inside `INSTRUCTIONS.md` is stripped from the additive
`project-addendum` so it is delivered once rather than twice. A marker-free
`INSTRUCTIONS.md` — the universal case today — is returned byte-for-byte
unchanged and keeps feeding the addendum exactly as before
(`strip_is_a_no_op_without_markers`, `an_unmarked_instructions_md_still_feeds_the_project_addendum`).

## The package is the sole authority

`InstructionPackage::with_overrides(&[SectionOverride]) -> (Self, Vec<Rejection>)`
asks each section's declared `customization_tier.permits(OverrideTier::Project)`.
There is **no hardcoded list of overridable sections in the reader** — a second
list would be a second source of truth, and the first time the two disagreed the
floor would become overridable in exactly the surface that must never be.

- An override replaces only that section's `Text` blocks. `Generated` blocks
  survive untouched, so an `AGENT-DELEGATION` override rewrites the routing
  doctrine but **cannot suppress the live agent roster** (#4196 in override form).
- Overrides are applied in canonical `SectionId` order, so the result does not
  depend on authoring order.
- `validate()` is re-run after each override and once over the whole; a failure
  discards that override alone, and a final failure returns the unoverridden
  package.

## Never fail closed

Every failure degrades to MORE framework, never to an aborted launch or a blank
section:

| Failure | Behavior |
|---|---|
| No `CLAUDE.md` / unreadable | No overrides, bundled sections |
| `START` without `END`, nested pairs | Skip that block, `warn!`; other blocks still apply |
| Unknown section token | Skip, `warn!` |
| Unknown `v=` | Skip, `warn!` |
| Override targets a floor section | Skip, `warn!` |
| Override body empty after trim | Treated as absent — never blanks a section |
| Overridden package fails `validate()` | Compose the unoverridden package |

Diagnostics are returned as data (`ScanDiagnostic { host, line, reason }`), not
only logged — a warning that exists only inside a `tracing` subscriber cannot be
asserted, and this module's whole contract is about what it declines to do.

## Scope boundary

Reader only. The five `.trusty-mpm/` override-file constants are untouched and
keep working (that is PR3). No `sections/*.md` edit (that is PR1). A project
still carrying a legacy override file composes through the sectionless legacy
assembly, so its named sections cannot land — `warn_unapplied` says so once per
override rather than dropping them in silence.

## Acceptance gates

- **Both existing goldens are byte-unchanged.** `git diff` over
  `src/core/testdata/` is empty, and re-running with `UPDATE_GOLDEN=1` rewrites
  them identically. The production composer gained an `overrides` parameter, so
  a zero-override shim keeps every pre-existing byte-equality gate in
  `bundled_pm_package_tests.rs` comparing exactly what it compared before.
- **Third golden added**: `testdata/pm-prompt-claude-md-override.md`, exercising
  a `WORKFLOW` + `AGENT-DELEGATION` override end to end.
- **Per-floor-section test**: `a_floor_marker_composes_byte_identically_to_no_claude_md`
  asserts, for each of `identity` / `non-overridable-rules` /
  `framework-guaranteed-conventions`, that a `CLAUDE.md` carrying that marker
  composes **byte-identically** to no `CLAUDE.md` at all.
- **Roster survival**: `the_live_roster_survives_an_agent_delegation_override`.
- **`tm` never writes `CLAUDE.md`**: `tm_never_writes_claude_md` asserts the
  project's file is byte-identical after resolution, and that an absent one is
  not created (#2170).
- **Proof the tests depend on the wiring**: the call site was temporarily
  reverted to pass `&[]` instead of `&named.overrides`, and 5 tests went red —
  `claude_md_workflow_override_reaches_the_delivered_prompt`,
  `the_live_roster_survives_an_agent_delegation_override`,
  `tm_never_writes_claude_md`,
  `a_marked_block_in_instructions_md_is_delivered_once`, and
  `golden_claude_md_override_prompt` (11,203-byte diff). The wiring was then
  restored and the suite re-run green.

39 tests in the new module. Nothing `#[ignore]`d, cfg-gated or excluded to reach
green.

## Gate output

```
$ cargo test -p trusty-mpm          # NOT --lib only
running 3950 tests
test result: ok. 3944 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
… all 40+ test binaries: 0 failed

$ cargo clippy -p trusty-mpm --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 55.73s

$ cargo fmt --check
FMT_CHECK_EXIT=0

$ bash scripts/check_instruction_floor.sh
PASS: instruction floor is intact and carries the guaranteed conventions (see #3374).

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.
  claude_md_sections.rs    375 SLOC
  instruction_overrides.rs 448 SLOC
```

Part of #4183
Part of #4286

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
