### PR TITLE
perf(trusty-mpm): stop probing stopped sessions and parallelize the tm ls asset-staleness fan-out

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,7 +7,35 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Performance
+
+- `tm ls` no longer re-reads the whole fleet's deployed agent/skill trees on
+  every invocation ([#4322](https://github.com/bobmatnyc/trusty-tools/issues/4322)).
+  Two changes, both in `daemon::managed_routes::summary`:
+  - **`Stopped` sessions are no longer asset-staleness-probed on the LIST
+    path.** The probe costs ~95 `read_to_string` calls against a session's own
+    `.claude/{agents,skills}` tree, uncached, per invocation. On a measured
+    32-session fleet, 20 of those sessions were stopped and idle for days —
+    56% of the I/O — for a marker that is only actionable at resume. The
+    single-session `GET …/managed/{id}` path (what `tm session resume` reads)
+    still probes every meaningful state, so the signal is unchanged where it
+    is acted on. Measured on that fleet: 3,040 → 1,140 read attempts and
+    35.7 MiB → 15.0 MiB per listing.
+  - **The remaining per-session comparisons now run concurrently** on the
+    blocking pool via `JoinSet::spawn_blocking`, mirroring the `unresumable`
+    fan-out already used alongside them. The shared `CatalogHashes` compute
+    (#2444) stays a single sequential step — fanning it out would reinstate
+    the per-session recompose it exists to prevent.
+
 ### Changed
+
+- `tm ls` STATE column: a row the daemon did not probe now renders
+  `[assets ?]` rather than nothing, so the absence of `[stale-assets]` can
+  never be misread as "assets fresh"
+  ([#4322](https://github.com/bobmatnyc/trusty-tools/issues/4322)). Backed by a
+  new additive wire field, `SessionSummary::stale_assets_unchecked`, whose
+  `false` default keeps an older daemon's (authoritative) verdicts rendering
+  exactly as before.
 
 - `daemon::managed_routes::prune`: the orphan sweep's `active_workspace_paths`
   set is now documented as DELIBERATELY unfiltered by session state, and pinned

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -527,6 +527,7 @@ fn stopped_record_at(workspace: &std::path::Path) -> trusty_mpm::client::Managed
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_resolver_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_resolver_tests.rs
@@ -47,6 +47,7 @@ fn make_session(
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -200,7 +200,9 @@ pub(crate) async fn session_ls(
 /// actionable remedy is `tm session rm`. It also appends `[stale-assets]`
 /// (#2444) when the server-computed `stale_assets` flag is set — the
 /// session's deployed agents/skills have drifted from the catalog; the remedy
-/// is `tm sessions sync-assets <id>`.
+/// is `tm sessions sync-assets <id>` — or `[assets ?]` (#4322) when the daemon
+/// skipped the probe for that row (`stopped` sessions), so the operator reads
+/// "undetermined" rather than mistaking a missing marker for "assets fresh".
 /// Test: `ls_source_id_filter_selects_correct_slug` covers the scoping seam; the
 /// table bytes are exercised by `tests/session_manager_mvp.rs`;
 /// `format_state_column_appends_dead_marker` and
@@ -257,7 +259,8 @@ pub(crate) fn render_session_table(sessions: &[ManagedSessionSummary], source_id
         } else {
             s.state.as_str()
         };
-        let state = format_state_column(base_state, s.unresumable, s.stale_assets);
+        let unchecked = s.stale_assets_unchecked;
+        let state = format_state_column(base_state, s.unresumable, s.stale_assets, unchecked);
         println!(
             // #1841 Fix 5: truncate name with ellipsis when it exceeds column width.
             "{:<5}  {:<36}  {:<14}  {:<24}  {:<30}  {}{}",
@@ -290,15 +293,23 @@ fn format_tombstone_row(slot: u32) -> String {
 /// What: renders the base state (`deleted` → the `--deleted--` marker, #2012;
 /// every other state verbatim), then appends `" [dead]"` when `unresumable` is
 /// `true` (the session is `stopped`/`errored` with no workdir candidate left on
-/// disk, so a resume is guaranteed to fail), and/or `" [stale-assets]"` when
-/// `stale_assets` is `true` (the session's deployed agents/skills have drifted
-/// from the catalog — `tm sessions sync-assets <id>` fixes it). Markers can
-/// appear together.
+/// disk, so a resume is guaranteed to fail), and `" [stale-assets]"` when
+/// `stale` (the summary's `stale_assets`) is `true` — the session's deployed
+/// agents/skills have drifted from the catalog and `tm sessions sync-assets
+/// <id>` fixes it — or `" [assets ?]"` when `unchecked` (the summary's
+/// `stale_assets_unchecked`) is `true` (#4322: the daemon
+/// did not probe this row — the list path skips `stopped` sessions — so
+/// staleness is UNDETERMINED, not known-fresh; `tm sessions sync-assets <id>`
+/// is still the remedy, and resuming the session determines it). The two asset
+/// markers are mutually exclusive — an unprobed row has no verdict to report —
+/// so a stale verdict always wins if both flags somehow arrive set. Markers can
+/// otherwise appear together.
 /// Test: `format_state_column_appends_dead_marker`,
 /// `format_state_column_appends_stale_assets_marker`,
+/// `format_state_column_appends_unchecked_assets_marker`,
 /// `format_state_column_leaves_healthy_state_unchanged`,
 /// `format_state_column_renders_deleted_marker`.
-fn format_state_column(state: &str, unresumable: bool, stale_assets: bool) -> String {
+fn format_state_column(state: &str, unresumable: bool, stale: bool, unchecked: bool) -> String {
     // A `deleted` record (soft-deleted via `tm sessions delete`) renders as the
     // `--deleted--` marker so the master list REFLECTS the deletion instead of
     // the row silently vanishing (#2012 marker).
@@ -310,8 +321,10 @@ fn format_state_column(state: &str, unresumable: bool, stale_assets: bool) -> St
     if unresumable {
         out.push_str(" [dead]");
     }
-    if stale_assets {
+    if stale {
         out.push_str(" [stale-assets]");
+    } else if unchecked {
+        out.push_str(" [assets ?]");
     }
     out
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed_tests.rs
@@ -45,11 +45,11 @@ fn truncate_clips_and_appends_ellipsis() {
 #[test]
 fn format_state_column_appends_dead_marker() {
     assert_eq!(
-        format_state_column("stopped", true, false),
+        format_state_column("stopped", true, false, false),
         "stopped [dead]"
     );
     assert_eq!(
-        format_state_column("errored", true, false),
+        format_state_column("errored", true, false, false),
         "errored [dead]"
     );
 }
@@ -59,13 +59,35 @@ fn format_state_column_appends_dead_marker() {
 #[test]
 fn format_state_column_appends_stale_assets_marker() {
     assert_eq!(
-        format_state_column("active", false, true),
+        format_state_column("active", false, true, false),
         "active [stale-assets]"
     );
     assert_eq!(
-        format_state_column("stopped", true, true),
+        format_state_column("stopped", true, true, false),
         "stopped [dead] [stale-assets]",
         "both markers must be able to appear together"
+    );
+}
+
+/// #4322: a row the daemon did NOT probe must say so — `[assets ?]`, not
+/// silence — so an operator cannot mistake a skipped check for a clean bill of
+/// health. It composes with `[dead]`, and a real `stale` verdict always wins
+/// over "undetermined" if both flags somehow arrive set.
+#[test]
+fn format_state_column_appends_unchecked_assets_marker() {
+    assert_eq!(
+        format_state_column("stopped", false, false, true),
+        "stopped [assets ?]"
+    );
+    assert_eq!(
+        format_state_column("stopped", true, false, true),
+        "stopped [dead] [assets ?]",
+        "the dead marker and the undetermined-assets marker must compose"
+    );
+    assert_eq!(
+        format_state_column("stopped", false, true, true),
+        "stopped [stale-assets]",
+        "a real stale verdict must win over 'undetermined' — never both"
     );
 }
 
@@ -73,10 +95,13 @@ fn format_state_column_appends_stale_assets_marker() {
 /// unchanged — no regression for the common case.
 #[test]
 fn format_state_column_leaves_healthy_state_unchanged() {
-    assert_eq!(format_state_column("active", false, false), "active");
-    assert_eq!(format_state_column("stopped", false, false), "stopped");
+    assert_eq!(format_state_column("active", false, false, false), "active");
     assert_eq!(
-        format_state_column("provisioning", false, false),
+        format_state_column("stopped", false, false, false),
+        "stopped"
+    );
+    assert_eq!(
+        format_state_column("provisioning", false, false, false),
         "provisioning"
     );
 }
@@ -93,10 +118,13 @@ fn format_tombstone_row_shows_slot_and_placeholder() {
 fn format_state_column_renders_deleted_marker() {
     // A soft-deleted record renders the `--deleted--` marker (#2012) instead of
     // the raw `deleted` state, so the master list REFLECTS the deletion.
-    assert_eq!(format_state_column("deleted", false, false), "--deleted--");
+    assert_eq!(
+        format_state_column("deleted", false, false, false),
+        "--deleted--"
+    );
     // Markers still compose on top of the deleted base.
     assert_eq!(
-        format_state_column("deleted", true, false),
+        format_state_column("deleted", true, false, false),
         "--deleted-- [dead]"
     );
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_tests.rs
@@ -41,6 +41,7 @@ fn session(name: &str, state: &str, slot: u32) -> ManagedSessionSummary {
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot,
         deleted: false,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -1074,6 +1074,7 @@ fn make_session(
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -955,6 +955,7 @@ fn ls_test_session(
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,

--- a/crates/trusty-mpm/src/client/http_client/tests.rs
+++ b/crates/trusty-mpm/src/client/http_client/tests.rs
@@ -526,6 +526,31 @@ fn managed_session_summary_deserializes_stale_assets_flag() {
     );
 }
 
+/// #4322: `stale_assets_unchecked` must round-trip when present, and default
+/// `false` when omitted — the polarity that matters for wire compatibility.
+/// An OLDER daemon probed every meaningful state, so its (field-less)
+/// responses ARE authoritative verdicts; defaulting to `false` is what keeps a
+/// new client from painting `[assets ?]` across every row it serves.
+#[test]
+fn managed_session_summary_defaults_stale_assets_unchecked_false() {
+    let with_flag = serde_json::json!({
+        "id": "x", "name": "n", "state": "stopped", "stale_assets_unchecked": true
+    });
+    let s: ManagedSessionSummary = serde_json::from_value(with_flag).unwrap();
+    assert!(
+        s.stale_assets_unchecked,
+        "stale_assets_unchecked: true must deserialize to true"
+    );
+
+    let omitted = serde_json::json!({"id": "x", "name": "n", "state": "stopped"});
+    let s: ManagedSessionSummary = serde_json::from_value(omitted).unwrap();
+    assert!(
+        !s.stale_assets_unchecked,
+        "an older daemon omitting `stale_assets_unchecked` probed everything — \
+         its verdicts must stay authoritative, not be repainted as unknown"
+    );
+}
+
 #[test]
 fn managed_list_response_deserializes() {
     let json = serde_json::json!({

--- a/crates/trusty-mpm/src/client/http_client/types.rs
+++ b/crates/trusty-mpm/src/client/http_client/types.rs
@@ -526,6 +526,24 @@ pub struct ManagedSessionSummary {
     /// Test: `managed_session_summary_deserializes_stale_assets_flag`.
     #[serde(default)]
     pub stale_assets: bool,
+    /// True when the daemon did NOT determine `stale_assets` for this session
+    /// even though checking it would be meaningful (issue #4322). Mirrors
+    /// `daemon::managed_routes::SessionSummary::stale_assets_unchecked`
+    /// field-for-field.
+    ///
+    /// Why: the fleet list stopped probing `Stopped` sessions (their
+    /// per-session filesystem comparison dominated cold `tm ls` latency), so
+    /// `stale_assets: false` on those rows means "not determined", NOT
+    /// "fresh". Carrying that distinction on the wire is what lets
+    /// `render_session_table` print an honest `[assets ?]` instead of silently
+    /// implying freshness. `#[serde(default)]` keeps the client tolerant of an
+    /// OLDER daemon that omits the field — `false` is exactly right there,
+    /// since such a daemon probed every meaningful state.
+    /// What: a plain bool, `true` only for `stopped` rows from a daemon that
+    /// carries this fix.
+    /// Test: `managed_session_summary_defaults_stale_assets_unchecked_false`.
+    #[serde(default)]
+    pub stale_assets_unchecked: bool,
     /// True when a tmux client is currently ATTACHED to this session (live-tmux
     /// reconciliation; mirrors `daemon::managed_routes::SessionSummary::attached`).
     ///

--- a/crates/trusty-mpm/src/client/resolver.rs
+++ b/crates/trusty-mpm/src/client/resolver.rs
@@ -190,6 +190,7 @@ mod tests {
             injection_status: None,
             unresumable: false,
             stale_assets: false,
+            stale_assets_unchecked: false,
             attached: false,
             slot: 0,
             deleted: false,

--- a/crates/trusty-mpm/src/core/update_check/mod.rs
+++ b/crates/trusty-mpm/src/core/update_check/mod.rs
@@ -376,6 +376,51 @@ pub struct CatalogHashes {
     skill_hashes: HashMap<String, String>,
 }
 
+/// Test-only call log for [`CatalogHashes::compute`], keyed by the exact
+/// `(catalog_agents, catalog_skills)` pair each invocation was called with.
+///
+/// Why (issue #4326 review, HIGH — empirically proven): the anti-regression
+/// pin for the shared-catalog invariant
+/// (`staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc`)
+/// only asserted the `Arc`-sharing structure of `staleness_inputs` directly —
+/// it never exercised `stale_assets_for_many` (the actual hot path `tm ls`
+/// calls), so moving `compute` inside that function's per-session
+/// `JoinSet::spawn_blocking` fan-out left every existing test green. A LOG
+/// (rather than a bare atomic counter) records the exact paths each call
+/// used, so a test can filter to just the source pair IT constructed —
+/// keyed by that test's own unique `fake_home()`-scoped temp directory — and
+/// get a reliable exact-count assertion even though `cargo test` runs many
+/// unrelated tests that also reach `compute` (directly or via
+/// `detect_staleness`) concurrently in the same binary.
+/// What: a process-wide `Mutex<Vec<(PathBuf, PathBuf)>>`, appended to by
+/// every real `compute()` call; [`reset_compute_call_log`] clears it and
+/// [`compute_calls_for`] counts entries matching one specific pair.
+/// Test: `stale_assets_for_many_computes_catalog_exactly_once_per_source_pair`
+/// in `daemon::managed_routes::tests`.
+#[cfg(test)]
+pub(crate) static COMPUTE_CALL_LOG: std::sync::LazyLock<
+    std::sync::Mutex<Vec<(std::path::PathBuf, std::path::PathBuf)>>,
+> = std::sync::LazyLock::new(|| std::sync::Mutex::new(Vec::new()));
+
+/// Clear [`COMPUTE_CALL_LOG`] — call before the fan-out under test so earlier
+/// tests' entries can never be mistaken for this test's calls.
+#[cfg(test)]
+pub(crate) fn reset_compute_call_log() {
+    COMPUTE_CALL_LOG.lock().unwrap().clear();
+}
+
+/// Count logged [`CatalogHashes::compute`] calls for exactly one
+/// `(catalog_agents, catalog_skills)` pair.
+#[cfg(test)]
+pub(crate) fn compute_calls_for(catalog_agents: &Path, catalog_skills: &Path) -> usize {
+    COMPUTE_CALL_LOG
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(a, s)| a == catalog_agents && s == catalog_skills)
+        .count()
+}
+
 impl CatalogHashes {
     /// Compute the catalog-side hashes for one `(catalog_agents,
     /// catalog_skills)` pair.
@@ -385,9 +430,17 @@ impl CatalogHashes {
     /// source pair and reuses via [`Self::detect`].
     /// What: `unknown: true` (empty maps) when NEITHER source tree exists —
     /// identical short-circuit to [`detect_staleness`]'s original
-    /// never-synced check; otherwise computes both maps.
-    /// Test: `catalog_hashes_compute_is_unknown_without_either_source`.
+    /// never-synced check; otherwise computes both maps. Under `cfg(test)`,
+    /// every call (regardless of outcome) is appended to
+    /// [`COMPUTE_CALL_LOG`] before either branch runs.
+    /// Test: `catalog_hashes_compute_is_unknown_without_either_source`,
+    /// `stale_assets_for_many_computes_catalog_exactly_once_per_source_pair`.
     pub fn compute(catalog_agents: &Path, catalog_skills: &Path) -> Self {
+        #[cfg(test)]
+        COMPUTE_CALL_LOG
+            .lock()
+            .unwrap()
+            .push((catalog_agents.to_path_buf(), catalog_skills.to_path_buf()));
         if !catalog_agents.is_dir() && !catalog_skills.is_dir() {
             return Self {
                 unknown: true,

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_summary.rs
@@ -159,8 +159,11 @@ pub struct SessionSummary {
     /// that already reads this endpoint (`tm sessions ls`, the picker) flag a
     /// session that needs `tm sessions sync-assets` run against it. Always
     /// `false` for `provisioning`/`decommissioned` sessions — see
-    /// [`crate::core::session_assets::session_assets_stale`]'s gate in
-    /// `checked_summaries` for exactly which states are probed.
+    /// `summary::staleness_meaningful_for` for exactly which states are worth
+    /// probing — and, on the FLEET LIST path only, also `false` for `stopped`
+    /// sessions, which that path no longer probes for latency (#4322). Such a
+    /// row sets [`Self::stale_assets_unchecked`], so a `false` here means "not
+    /// determined", NOT "fresh".
     /// What: computed by `checked_summaries`/`record_to_summary_checked` via
     /// [`crate::core::session_assets::session_assets_stale`]; every other
     /// handler that builds a `SessionSummary` via `record_to_summary` leaves it

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_summary.rs
@@ -169,6 +169,31 @@ pub struct SessionSummary {
     /// `super::tests`.
     #[serde(default)]
     pub stale_assets: bool,
+    /// True when this response did NOT determine `stale_assets` for a session
+    /// whose assets it WOULD be meaningful to check (issue #4322).
+    ///
+    /// Why: the fleet LIST path stopped probing `Stopped` sessions — their
+    /// per-session filesystem comparison (~95 reads each) dominated cold `tm
+    /// ls` latency while telling the operator nothing they could not learn at
+    /// resume time. But a bare `stale_assets: false` on those rows would be a
+    /// LIE by omission: it is indistinguishable from a genuine "checked, and
+    /// fresh" verdict, and an operator (or a future consumer) reading absence
+    /// as freshness would be wrong. This flag makes "we did not look" an
+    /// explicit, first-class third state on the wire so the CLI can render
+    /// `[assets ?]` rather than silence. Polarity is chosen so the DEFAULT
+    /// (`false`) means "this verdict is authoritative" — an OLDER daemon that
+    /// omits the field probed everything, so `#[serde(default)]` deserializes
+    /// its responses to exactly the right answer.
+    /// What: `true` only on the LIST path, only for `Stopped` records (states
+    /// where `summary::staleness_meaningful_for` holds but
+    /// `summary::probe_staleness_in_list` does not). Always `false` for
+    /// `Provisioning`/`Decommissioned`/tombstone rows — nothing to check
+    /// there — and always `false` on the single-session GET, which still
+    /// probes every meaningful state.
+    /// Test: `checked_summaries_does_not_probe_stopped_sessions` in
+    /// `super::tests`.
+    #[serde(default)]
+    pub stale_assets_unchecked: bool,
     /// True when a tmux client is currently ATTACHED to this session's tmux
     /// session (a live probe reconciled against real tmux, not the persisted
     /// `state`).

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -375,11 +375,15 @@ fn probe_staleness_in_list(state: &ManagedSessionState) -> bool {
 /// the catalog compose are filesystem-bound, so this function is
 /// synchronous/blocking.
 /// What: returns one [`StalenessInput`] per record, in input order, each
-/// carrying a shared `Arc` handle to its catalog hashes.
-/// Test: `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`,
+/// carrying a shared `Arc` handle to its catalog hashes. `pub(super)` only so
+/// the invariant test below can assert the SHARING structurally.
+/// Test: `staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc`
+/// (the anti-regression pin: same source pair ⇒ pointer-equal `Arc`, so no
+/// second compute exists for a spawned task to perform),
+/// `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`,
 /// `checked_summaries_flags_stale_assets_only_for_relevant_states` in
 /// `super::tests`.
-fn staleness_inputs(records: Vec<SessionRecord>) -> Vec<StalenessInput> {
+pub(super) fn staleness_inputs(records: Vec<SessionRecord>) -> Vec<StalenessInput> {
     let mut cache: HashMap<(PathBuf, PathBuf), Arc<CatalogHashes>> = HashMap::new();
     let mut out = Vec::with_capacity(records.len());
     for record in records {
@@ -445,6 +449,13 @@ async fn stale_assets_for_many(records: Vec<SessionRecord>) -> HashMap<ManagedSe
         .unwrap_or_default();
     let mut probes = tokio::task::JoinSet::new();
     for (id, fw, plan, catalog) in inputs {
+        // INVARIANT: a spawned task receives an ALREADY-COMPUTED
+        // `Arc<CatalogHashes>` and must never call `CatalogHashes::compute`
+        // itself. Moving the catalog work in here would give every session its
+        // own recompose — the exact N-times recompose #2444's review removed,
+        // traded back for concurrency. Only the cheap deployed-side half (this
+        // session's own manifest + on-disk file reads, which is where the
+        // 35.7 MiB actually goes) belongs in the fan-out.
         probes.spawn_blocking(move || {
             (
                 id,

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -441,9 +441,18 @@ type StalenessInput = (
 /// panicking task is simply absent from the returned map, leaving that
 /// summary at its `false` default rather than failing the whole listing.
 /// Test: `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`,
-/// `checked_summaries_flags_stale_assets_only_for_relevant_states` in
-/// `super::tests`.
-async fn stale_assets_for_many(records: Vec<SessionRecord>) -> HashMap<ManagedSessionId, bool> {
+/// `checked_summaries_flags_stale_assets_only_for_relevant_states`,
+/// `stale_assets_for_many_computes_catalog_exactly_once_per_source_pair`
+/// (issue #4326 review HIGH: the prior pin only exercised [`staleness_inputs`]
+/// directly, never this actual hot path, and stayed green when
+/// `CatalogHashes::compute` was moved into the fan-out below) in
+/// `super::tests`. `pub(super)` (rather than private) so that regression test
+/// can call this function directly instead of the higher-level
+/// `checked_summaries`, which would also exercise the unrelated `unresumable`
+/// fan-out.
+pub(super) async fn stale_assets_for_many(
+    records: Vec<SessionRecord>,
+) -> HashMap<ManagedSessionId, bool> {
     let inputs = tokio::task::spawn_blocking(move || staleness_inputs(records))
         .await
         .unwrap_or_default();

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -14,9 +14,12 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use axum::http::StatusCode;
 
+use crate::core::manifest::HarnessPlan;
+use crate::core::paths::FrameworkPaths;
 use crate::core::session_assets::{session_asset_staleness_with_catalog, session_plan};
 use crate::core::update_check::CatalogHashes;
 use crate::session_manager::{
@@ -121,6 +124,7 @@ pub(super) fn record_to_summary(r: &SessionRecord) -> SessionSummary {
         injection_status: injection_status_wire(r.injection_status),
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         // `attached` is a live-tmux reconciliation only the list handler
         // computes (see [`super::list_managed_sessions`]); every other summary
         // builder leaves it at its `false` default.
@@ -292,34 +296,67 @@ pub(super) fn tombstone_summary(slot: u32) -> SessionSummary {
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot,
         deleted: true,
     }
 }
 
-/// Whether a record's state is one [`session_assets_stale`] is worth probing.
+/// Whether a record's state has a deployed workspace whose asset staleness is
+/// MEANINGFUL to compute at all.
 ///
-/// Why: shared by [`record_to_summary_checked`] and [`checked_summaries`] so
-/// the two never disagree on which states get the asset-staleness probe.
-/// Provisioning workspaces have not deployed yet (every managed artifact would
-/// spuriously read as "new"/stale) and decommissioned ones have no workspace
-/// left to probe — both would only add noise, not signal.
+/// Why: `Provisioning` workspaces have not deployed yet (every managed
+/// artifact would spuriously read as "new"/stale) and `Decommissioned` ones
+/// have no workspace left to probe — both would only add noise, not signal.
+/// This is the same state set `sync_assets::syncable` gates the actual
+/// redeploy on, so "we can tell you it's stale" and "we can fix it" never
+/// disagree. It is the gate for the ON-DEMAND single-session path
+/// ([`record_to_summary_checked`], which `tm session resume` reads); the fleet
+/// LIST path applies the stricter [`probe_staleness_in_list`] on top of it.
 /// What: `true` for `Active`, `Stopped`, and `Errored`.
-/// Test: `checked_summaries_flags_stale_assets_only_for_relevant_states`.
-fn probe_staleness_for(state: &ManagedSessionState) -> bool {
+/// Test: `checked_summaries_flags_stale_assets_only_for_relevant_states`,
+/// `record_to_summary_checked_still_flags_stale_stopped_session`.
+fn staleness_meaningful_for(state: &ManagedSessionState) -> bool {
     matches!(
         state,
         ManagedSessionState::Active | ManagedSessionState::Stopped | ManagedSessionState::Errored
     )
 }
 
-/// Compute `stale_assets` for every record in `records`, sharing the
-/// catalog-side compose/hash work across ALL of them (issue #2444 review,
-/// MEDIUM finding: `checked_summaries` originally called
-/// `session_assets_stale` — a full, independent catalog recompose — once PER
-/// SESSION on every `tm sessions ls`, recomposing the same ~40+ catalog
-/// agents redundantly for every session sharing the default source).
+/// Whether a record gets the asset-staleness probe on the FLEET LIST path.
+///
+/// Why (issue #4322): the probe is filesystem-bound — ~95 `read_to_string`
+/// calls and tens of megabytes per session, uncached — and `tm ls` paid it for
+/// every `Active`/`Stopped`/`Errored` record on EVERY invocation. On a real
+/// fleet the majority of those records are `Stopped` sessions idle for days
+/// (20 of 32 in the reported measurement, ~56% of the total I/O) whose
+/// deployed assets cannot possibly have drifted since the last listing —
+/// nothing writes to a stopped session's workspace. Staleness is only
+/// ACTIONABLE at resume time, and that path fetches the session individually
+/// (`GET …/managed/{id}` → [`record_to_summary_checked`]), which still probes
+/// under [`staleness_meaningful_for`]. Dropping `Stopped` from the LIST fan-out
+/// removes that work from the interactive, per-keystroke-latency surface
+/// without removing the signal from the surface that acts on it.
+/// What: `true` for `Active` and `Errored` only. A `Stopped` record's summary
+/// therefore carries `stale_assets: false` — which is NOT a "fresh" verdict,
+/// so [`super::SessionSummary::stale_assets_unchecked`] is set instead and the
+/// CLI renders an explicit `[assets ?]` marker rather than silence.
+/// Test: `checked_summaries_does_not_probe_stopped_sessions`.
+fn probe_staleness_in_list(state: &ManagedSessionState) -> bool {
+    matches!(
+        state,
+        ManagedSessionState::Active | ManagedSessionState::Errored
+    )
+}
+
+/// Resolve every record's plan and compute ONE [`CatalogHashes`] per distinct
+/// `(agent_source, skill_source)` pair — the SHARED half of the staleness
+/// comparison (issue #2444 review, MEDIUM finding: `checked_summaries`
+/// originally called `session_assets_stale` — a full, independent catalog
+/// recompose — once PER SESSION on every `tm sessions ls`, recomposing the
+/// same ~40+ catalog agents redundantly for every session sharing the default
+/// source).
 ///
 /// Why: a staleness comparison splits into an expensive CATALOG-side half
 /// (composing agents, reading skill bodies — identical for every session
@@ -331,38 +368,106 @@ fn probe_staleness_for(state: &ManagedSessionState) -> bool {
 /// SINGLE compute for the common case where every session resolves the
 /// shared default bundled/catalog source, and stays exactly correct for the
 /// rare session carrying its own project-level manifest override — removes
-/// the N-times recompose entirely. Both the manifest resolution and the
-/// catalog compose are filesystem-bound, so this whole function is
-/// synchronous/blocking; callers run it via [`tokio::task::spawn_blocking`].
-/// What: returns `record.id -> stale` for every record passed in (typically
-/// pre-filtered to [`probe_staleness_for`]'s syncable subset by the caller).
+/// the N-times recompose entirely. This half is deliberately kept SEQUENTIAL
+/// and run in a single blocking task by [`stale_assets_for_many`]: fanning it
+/// out would race N tasks into the same empty cache and reinstate exactly the
+/// N-times recompose it exists to prevent. Both the manifest resolution and
+/// the catalog compose are filesystem-bound, so this function is
+/// synchronous/blocking.
+/// What: returns one [`StalenessInput`] per record, in input order, each
+/// carrying a shared `Arc` handle to its catalog hashes.
 /// Test: `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`,
 /// `checked_summaries_flags_stale_assets_only_for_relevant_states` in
 /// `super::tests`.
-fn stale_assets_for_many(records: Vec<SessionRecord>) -> HashMap<ManagedSessionId, bool> {
-    let mut cache: HashMap<(PathBuf, PathBuf), CatalogHashes> = HashMap::new();
-    let mut result = HashMap::with_capacity(records.len());
+fn staleness_inputs(records: Vec<SessionRecord>) -> Vec<StalenessInput> {
+    let mut cache: HashMap<(PathBuf, PathBuf), Arc<CatalogHashes>> = HashMap::new();
+    let mut out = Vec::with_capacity(records.len());
     for record in records {
         let (fw, plan) = session_plan(&record);
         let key = (plan.agent_source.clone(), plan.skill_source.clone());
         let catalog = cache
             .entry(key)
-            .or_insert_with(|| CatalogHashes::compute(&plan.agent_source, &plan.skill_source));
-        let stale = session_asset_staleness_with_catalog(&fw, &plan, catalog).stale;
-        result.insert(record.id, stale);
+            .or_insert_with(|| {
+                Arc::new(CatalogHashes::compute(
+                    &plan.agent_source,
+                    &plan.skill_source,
+                ))
+            })
+            .clone();
+        out.push((record.id, fw, plan, catalog));
+    }
+    out
+}
+
+/// One session's fully-resolved staleness comparison inputs: its id, its
+/// workspace-scoped paths and plan, and a SHARED handle to the catalog-side
+/// hashes for its resolved `(agent_source, skill_source)` pair.
+///
+/// Why: [`stale_assets_for_many`] hands one of these to each per-session
+/// blocking task. `Arc<CatalogHashes>` (rather than a clone of the hashes) is
+/// what lets the expensive catalog compose stay shared across the fan-out
+/// while each task still owns everything it needs — the whole point of the
+/// #2444 split, preserved under parallelism.
+type StalenessInput = (
+    ManagedSessionId,
+    FrameworkPaths,
+    HarnessPlan,
+    Arc<CatalogHashes>,
+);
+
+/// Compute `stale_assets` for every record, sharing the catalog work and
+/// running the per-session comparisons CONCURRENTLY on the blocking pool
+/// (issue #4322).
+///
+/// Why: the shared-catalog design (#2444) removed the redundant per-session
+/// RECOMPOSE, but left the remaining per-session work — ~95 `read_to_string`
+/// calls against that session's own `.claude/{agents,skills}` tree — running
+/// SERIALLY inside a single `spawn_blocking`. Those reads are independent
+/// across sessions and entirely I/O-bound (the daemon burns a constant ~0.13 s
+/// of CPU while `tm ls` blocks for 5–9 s cold), so serializing them makes cold
+/// latency scale linearly in fleet size for no reason. This mirrors the
+/// `unresumable` fan-out [`checked_summaries`] already performs — same
+/// `JoinSet` pattern, `spawn_blocking` instead of `spawn` because the work is
+/// synchronous filesystem I/O rather than `tokio::fs`.
+/// What: resolves every session's plan and computes one [`CatalogHashes`] per
+/// distinct source pair in ONE blocking task ([`staleness_inputs`] — the
+/// sharing that must NOT be parallelized, or each task would redundantly
+/// recompose the same catalog), then spawns one blocking task per session for
+/// the cheap deployed-side [`session_asset_staleness_with_catalog`] half. A
+/// panicking task is simply absent from the returned map, leaving that
+/// summary at its `false` default rather than failing the whole listing.
+/// Test: `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`,
+/// `checked_summaries_flags_stale_assets_only_for_relevant_states` in
+/// `super::tests`.
+async fn stale_assets_for_many(records: Vec<SessionRecord>) -> HashMap<ManagedSessionId, bool> {
+    let inputs = tokio::task::spawn_blocking(move || staleness_inputs(records))
+        .await
+        .unwrap_or_default();
+    let mut probes = tokio::task::JoinSet::new();
+    for (id, fw, plan, catalog) in inputs {
+        probes.spawn_blocking(move || {
+            (
+                id,
+                session_asset_staleness_with_catalog(&fw, &plan, &catalog).stale,
+            )
+        });
+    }
+    let mut result = HashMap::with_capacity(probes.len());
+    while let Some(res) = probes.join_next().await {
+        if let Ok((id, stale)) = res {
+            result.insert(id, stale);
+        }
     }
     result
 }
 
-/// Run [`stale_assets_for_many`] on the blocking pool for a single record —
-/// the `record_to_summary_checked` (single-session GET) call site, which has
-/// no batching benefit (N=1) but still needs the same blocking-pool handoff
-/// [`checked_summaries`] uses for the multi-session path.
+/// Run [`stale_assets_for_many`] for a single record — the
+/// `record_to_summary_checked` (single-session GET) call site, which has no
+/// batching benefit (N=1) but reuses the same blocking-pool handoff.
 async fn probe_stale_assets(record: SessionRecord) -> bool {
     let id = record.id;
-    tokio::task::spawn_blocking(move || stale_assets_for_many(vec![record]))
+    stale_assets_for_many(vec![record])
         .await
-        .unwrap_or_default()
         .get(&id)
         .copied()
         .unwrap_or(false)
@@ -377,12 +482,21 @@ async fn probe_stale_assets(record: SessionRecord) -> bool {
 /// bodies a single line each (`mod.rs` sits at its 500-SLOC production cap).
 /// What: [`record_to_summary`], then overwrites `unresumable` via
 /// `session_manager::resume_workdir::is_unresumable`.
+///
+/// Staleness (#4322): this SINGLE-session path keeps the full
+/// [`staleness_meaningful_for`] gate — including `Stopped`, which the fleet
+/// LIST path now skips. `GET …/managed/{id}` is what `tm session resume`
+/// reads, and resume is precisely the moment a stopped session's asset drift
+/// becomes actionable; paying ~95 file reads for ONE session on an explicit,
+/// infrequent fetch is not the cost that made `tm ls` slow.
 /// Test: `list_marks_dead_stopped_session_unresumable`,
-/// `list_leaves_live_and_healthy_stopped_sessions_unmarked` in `super::tests`.
+/// `list_leaves_live_and_healthy_stopped_sessions_unmarked`,
+/// `record_to_summary_checked_still_flags_stale_stopped_session` in
+/// `super::tests`.
 pub(super) async fn record_to_summary_checked(r: &SessionRecord) -> SessionSummary {
     let mut summary = record_to_summary(r);
     summary.unresumable = crate::session_manager::resume_workdir::is_unresumable(r).await;
-    if probe_staleness_for(&r.state) {
+    if staleness_meaningful_for(&r.state) {
         summary.stale_assets = probe_stale_assets(r.clone()).await;
     }
     summary
@@ -434,21 +548,24 @@ pub(super) async fn checked_summaries(records: &[SessionRecord]) -> Vec<SessionS
         }
     }
 
-    // Second, independent pass for the #2444 asset-staleness probe. Unlike
-    // `unresumable` above, this is a SINGLE `spawn_blocking` call over every
-    // syncable record rather than one task per record — `stale_assets_for_many`
-    // shares the expensive catalog-side compose across all of them (issue
-    // #2444 review MEDIUM finding), which a per-record `JoinSet` fan-out
-    // would defeat (each task would redundantly recompose the same catalog).
-    let syncable: Vec<SessionRecord> = records
+    // Second, independent pass for the #2444 asset-staleness probe.
+    // `stale_assets_for_many` computes the shared catalog half ONCE and then
+    // fans the per-session deployed-side comparisons across the blocking pool
+    // (#4322). `Stopped` records are deliberately EXCLUDED here (see
+    // `probe_staleness_in_list`) — their summaries carry
+    // `stale_assets_unchecked` instead, so "no marker" is never silently read
+    // as "assets fresh".
+    for (idx, r) in records.iter().enumerate() {
+        summaries[idx].stale_assets_unchecked =
+            staleness_meaningful_for(&r.state) && !probe_staleness_in_list(&r.state);
+    }
+    let probed: Vec<SessionRecord> = records
         .iter()
-        .filter(|r| probe_staleness_for(&r.state))
+        .filter(|r| probe_staleness_in_list(&r.state))
         .cloned()
         .collect();
-    if !syncable.is_empty() {
-        let stale_map = tokio::task::spawn_blocking(move || stale_assets_for_many(syncable))
-            .await
-            .unwrap_or_default();
+    if !probed.is_empty() {
+        let stale_map = stale_assets_for_many(probed).await;
         for (idx, r) in records.iter().enumerate() {
             if let Some(&stale) = stale_map.get(&r.id) {
                 summaries[idx].stale_assets = stale;

--- a/crates/trusty-mpm/src/daemon/managed_routes/sync_assets.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/sync_assets.rs
@@ -115,9 +115,13 @@ pub struct SyncAllAssetsResponse {
 ///
 /// Why: shared by both routes below so the per-session and fleet-wide paths
 /// can never disagree on which sessions `sync-assets` applies to — the same
-/// state set `summary.rs`'s private `probe_staleness_for` gates the
+/// state set `summary.rs`'s private `staleness_meaningful_for` gates the
 /// `stale_assets` marker on (a `Provisioning` session has not deployed yet,
-/// and a `Decommissioned` one has no workspace left).
+/// and a `Decommissioned` one has no workspace left) — so "we can tell you
+/// it's stale" and "we can fix it" can never disagree. Note the FLEET LIST
+/// path additionally skips `Stopped` for latency (#4322,
+/// `summary::probe_staleness_in_list`); that is a display-side decision only
+/// and deliberately does NOT narrow what `sync-assets` will act on.
 /// What: `true` for `Active`, `Stopped`, and `Errored`.
 /// Test: `sync_all_route_skips_provisioning_and_decommissioned`.
 fn syncable(state: &ManagedSessionState) -> bool {

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -494,6 +494,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,
@@ -533,6 +534,7 @@ fn decommission_workspace_removed_reflects_ownership() {
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,
@@ -763,6 +765,105 @@ async fn checked_summaries_flags_stale_assets_only_for_relevant_states() {
     assert!(
         !summaries[1].stale_assets,
         "a Provisioning session must never be probed — it has not deployed yet"
+    );
+    assert!(
+        !summaries[0].stale_assets_unchecked && !summaries[1].stale_assets_unchecked,
+        "neither an Active (probed) nor a Provisioning (nothing to check) row \
+         may claim an UNDETERMINED asset verdict"
+    );
+}
+
+/// Deploy `stem`.md into `workspace`'s `.claude/agents` from the (fake-home)
+/// bundled source, then drift the catalog underneath it — leaving that
+/// workspace GENUINELY stale relative to the catalog.
+///
+/// Why: three staleness tests below need the identical "deployed at v1,
+/// catalog moved to v2" setup; sharing it keeps them asserting about the
+/// PROBE rather than re-deriving the fixture, and guarantees the stopped-vs-
+/// on-demand pair below compare the exact same on-disk condition.
+fn deploy_then_drift_catalog(workspace: &std::path::Path) {
+    let fw = crate::core::paths::FrameworkPaths::default();
+    let bundled = fw.agent_source_dir();
+    std::fs::create_dir_all(&bundled).unwrap();
+    std::fs::write(bundled.join("rust-engineer.md"), "v1").unwrap();
+    std::fs::create_dir_all(workspace).unwrap();
+    let session_fw = crate::core::paths::FrameworkPaths::for_managed_workspace(workspace);
+    crate::core::agent_deployer::deploy_agents_filtered(
+        &bundled,
+        &session_fw.claude_agents_dir(),
+        |_| true,
+    )
+    .unwrap();
+    std::fs::write(bundled.join("rust-engineer.md"), "v2 — catalog moved").unwrap();
+}
+
+/// Issue #4322: the FLEET LIST path must not probe `Stopped` sessions — that
+/// probe is ~95 filesystem reads per session and dominated cold `tm ls`
+/// latency, while telling the operator nothing actionable until resume.
+///
+/// This pins BOTH halves of the contract, because either alone would be a
+/// silent regression:
+///   1. a genuinely stale STOPPED session is NOT flagged `stale_assets` by
+///      `checked_summaries` (proving the probe really was skipped — this
+///      assertion FAILS if `probe_staleness_in_list` is reverted to include
+///      `Stopped`), and
+///   2. that row carries `stale_assets_unchecked`, so its `stale_assets:
+///      false` can never be read as a "checked, and fresh" verdict.
+/// The companion `record_to_summary_checked_still_flags_stale_stopped_session`
+/// proves the SIGNAL itself was not deleted — the same record, fetched
+/// individually (the resume path), still reports stale.
+#[tokio::test]
+#[serial_test::serial]
+async fn checked_summaries_does_not_probe_stopped_sessions() {
+    let (home, _guard) = fake_home();
+    let workspace = home.path().join("stopped-drifted");
+    deploy_then_drift_catalog(&workspace);
+
+    let mut stopped = make_record(None);
+    stopped.state = ManagedSessionState::Stopped;
+    stopped.workspace_path = Some(workspace);
+
+    let summaries = checked_summaries(std::slice::from_ref(&stopped)).await;
+
+    assert!(
+        !summaries[0].stale_assets,
+        "the fleet list must NOT probe a Stopped session — a `true` here means \
+         the per-session filesystem probe ran anyway (#4322 regression)"
+    );
+    assert!(
+        summaries[0].stale_assets_unchecked,
+        "an unprobed Stopped row must advertise that its asset verdict is \
+         UNDETERMINED — absence of `[stale-assets]` must never read as 'fresh'"
+    );
+}
+
+/// Issue #4322 correctness gate: skipping the probe on the LIST path must not
+/// delete the SIGNAL. The single-session fetch (`GET …/managed/{id}`, which
+/// `tm session resume` reads — the exact moment a stopped session's drift
+/// becomes actionable) must still flag the very same genuinely-stale STOPPED
+/// record its list row leaves undetermined.
+#[tokio::test]
+#[serial_test::serial]
+async fn record_to_summary_checked_still_flags_stale_stopped_session() {
+    let (home, _guard) = fake_home();
+    let workspace = home.path().join("stopped-drifted-on-demand");
+    deploy_then_drift_catalog(&workspace);
+
+    let mut stopped = make_record(None);
+    stopped.state = ManagedSessionState::Stopped;
+    stopped.workspace_path = Some(workspace);
+
+    let summary = super::summary::record_to_summary_checked(&stopped).await;
+
+    assert!(
+        summary.stale_assets,
+        "the on-demand single-session path must still detect a Stopped \
+         session's deployed-asset drift — a fast `tm ls` that never detects \
+         staleness anywhere is a regression, not a fix"
+    );
+    assert!(
+        !summary.stale_assets_unchecked,
+        "the on-demand path DID check, so its verdict is authoritative"
     );
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -837,6 +837,43 @@ async fn checked_summaries_does_not_probe_stopped_sessions() {
     );
 }
 
+/// Issue #4322 anti-regression pin: parallelizing the staleness fan-out must
+/// NOT reinstate the per-session catalog recompose #2444's review removed.
+///
+/// The guard is structural rather than a call counter: `staleness_inputs`
+/// resolves the SHARED catalog half sequentially and hands each session an
+/// `Arc` to it, and the spawned tasks only ever borrow that `Arc`. So proving
+/// that every session resolving the same `(agent_source, skill_source)` pair
+/// receives a POINTER-EQUAL handle proves there is exactly one compute per
+/// group — and that no second one exists for a spawned task to perform. Move
+/// `CatalogHashes::compute` inside the fan-out and this fails immediately.
+#[tokio::test]
+#[serial_test::serial]
+async fn staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc() {
+    let (home, _guard) = fake_home();
+    let records: Vec<SessionRecord> = (0..3)
+        .map(|i| {
+            let ws = home.path().join(format!("shared-catalog-{i}"));
+            std::fs::create_dir_all(&ws).unwrap();
+            let mut r = make_record(None);
+            r.state = ManagedSessionState::Active;
+            r.workspace_path = Some(ws);
+            r
+        })
+        .collect();
+
+    let inputs = super::summary::staleness_inputs(records);
+
+    assert_eq!(inputs.len(), 3, "one input per record, in input order");
+    assert!(
+        std::sync::Arc::ptr_eq(&inputs[0].3, &inputs[1].3)
+            && std::sync::Arc::ptr_eq(&inputs[0].3, &inputs[2].3),
+        "every session resolving the SAME catalog source pair must share ONE \
+         computed CatalogHashes — a distinct Arc per session means the catalog \
+         was recomposed per session (#2444 regression)"
+    );
+}
+
 /// Issue #4322 correctness gate: skipping the probe on the LIST path must not
 /// delete the SIGNAL. The single-session fetch (`GET …/managed/{id}`, which
 /// `tm session resume` reads — the exact moment a stopped session's drift

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 
-use super::summary::{reconcile_against_tmux, reconcile_live_state};
+use super::summary::{reconcile_against_tmux, reconcile_live_state, stale_assets_for_many};
 use super::{checked_summaries, record_to_json, record_to_summary};
 use crate::session_manager::{
     InjectionStatus, ManagedError, ManagedSessionId, ManagedSessionState, ManagedTmuxDriver,
@@ -871,6 +871,65 @@ async fn staleness_inputs_computes_one_catalog_per_source_pair_shared_by_arc() {
         "every session resolving the SAME catalog source pair must share ONE \
          computed CatalogHashes — a distinct Arc per session means the catalog \
          was recomposed per session (#2444 regression)"
+    );
+}
+
+/// Issue #4326 review, HIGH (empirically proven): the pin above only ever
+/// called [`super::summary::staleness_inputs`] directly — it never exercised
+/// [`stale_assets_for_many`], the function `checked_summaries` (and therefore
+/// `tm ls`) actually calls. The critic proved this gap by moving
+/// `CatalogHashes::compute` INSIDE `stale_assets_for_many`'s per-session
+/// `JoinSet::spawn_blocking` fan-out — reinstating the exact #2444 per-session
+/// recompose — and every existing test, including the pin above, stayed
+/// green.
+///
+/// Why this test closes the gap: it calls `stale_assets_for_many` itself (the
+/// real hot path) with three records that all resolve to the SAME
+/// `(agent_source, skill_source)` pair (the shared default, anchored at this
+/// test's `fake_home()`-scoped `$HOME`), and asserts via
+/// [`crate::core::update_check::compute_calls_for`] — a call LOG keyed by the
+/// exact catalog paths, not a bare counter, so unrelated tests reaching
+/// `CatalogHashes::compute` through their own unrelated temp paths can never
+/// pollute this assertion — that `compute` ran EXACTLY ONCE for that pair.
+/// Reinstating the per-session compose inside the fan-out (the critic's
+/// mutation) makes this assert `3`, not `1`, and fail.
+/// What: resets the log, resolves this test's own catalog source pair via
+/// `FrameworkPaths::default()` (identical resolution `staleness_inputs` uses
+/// internally), runs the real fan-out, and asserts one compute for that pair.
+/// Test: this function; mutation-verified per the PR report (temporarily
+/// reinstating the per-task compute reproduces the critic's failure, then
+/// reverted).
+#[tokio::test]
+#[serial_test::serial]
+async fn stale_assets_for_many_computes_catalog_exactly_once_per_source_pair() {
+    let (home, _guard) = fake_home();
+    crate::core::update_check::reset_compute_call_log();
+
+    let fw = crate::core::paths::FrameworkPaths::default();
+    let agent_source = fw.agent_source_dir();
+    let skill_source = fw.skill_source_dir();
+
+    let records: Vec<SessionRecord> = (0..3)
+        .map(|i| {
+            let ws = home.path().join(format!("hot-path-shared-catalog-{i}"));
+            std::fs::create_dir_all(&ws).unwrap();
+            let mut r = make_record(None);
+            r.state = ManagedSessionState::Active;
+            r.workspace_path = Some(ws);
+            r
+        })
+        .collect();
+
+    let result = stale_assets_for_many(records).await;
+
+    assert_eq!(result.len(), 3, "every record gets a result");
+    assert_eq!(
+        crate::core::update_check::compute_calls_for(&agent_source, &skill_source),
+        1,
+        "three sessions sharing one (agent_source, skill_source) pair must \
+         share exactly ONE CatalogHashes::compute — more than one means the \
+         per-session recompose #2444's review removed was reinstated inside \
+         the fan-out (#4326 review HIGH)"
     );
 }
 

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/rows.rs
@@ -216,6 +216,7 @@ mod tests {
             injection_status: None,
             unresumable: false,
             stale_assets: false,
+            stale_assets_unchecked: false,
             attached: false,
             slot: 0,
             deleted: false,

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
@@ -40,6 +40,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -57,6 +57,7 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
         injection_status: None,
         unresumable: false,
         stale_assets: false,
+        stale_assets_unchecked: false,
         attached: false,
         slot: 0,
         deleted: false,


### PR DESCRIPTION
## Problem

`tm ls` cold: **4.9–9.4 s**; warm: 0.15 s. Daemon CPU is a constant 0.128 s
regardless of wall time — this is blocking filesystem I/O, not computation.

`daemon::managed_routes::summary::stale_assets_for_many` ran **one**
`spawn_blocking` containing a serial `for record in records` loop. Each
iteration re-read that session's whole deployed `.claude/{agents,skills}`
tree. On the measured fleet that is **3,040 `read_to_string` calls and
35.7 MiB per invocation**, uncached — the `CatalogHashes` map was a local,
dropped on return. Cost is linear in session count, and the output is a
cosmetic `[stale-assets]` marker in the STATE column.

**20 of the 32 probed sessions were `stopped` and idle for days — 56% of the
work.**

Refs #4322. This PR does **not** implement the memoization cache or the
background precompute that issue also lists, so it does not close it.

## Fix 1 — stop probing stopped sessions on the LIST path

`probe_staleness_for` is split into two predicates:

| predicate | states | used by |
|---|---|---|
| `staleness_meaningful_for` | `Active`, `Stopped`, `Errored` | `record_to_summary_checked` — the single-session `GET …/managed/{id}` that `tm session resume` reads |
| `probe_staleness_in_list` | `Active`, `Errored` | `checked_summaries` — the fleet list behind `tm ls` |

Staleness is only actionable at resume, and resume fetches the session
individually — so the signal is computed on demand, exactly where it is
acted on, and dropped from the interactive latency path.

### What a stopped session displays now

A stopped row's `stale_assets: false` would otherwise be indistinguishable
from a genuine "checked, and fresh" verdict. So the wire gains an additive
`stale_assets_unchecked` flag and the CLI renders a **distinct third state**:

```
stopped [assets ?]              # not probed — verdict UNDETERMINED
stopped [dead] [assets ?]       # composes with the #2595 dead marker
active  [stale-assets]          # probed, and genuinely stale
stopped                         # (older daemon: probed everything — unchanged)
```

`[stale-assets]` and `[assets ?]` are mutually exclusive; a real stale
verdict always wins. The flag's `false` default is the compat-safe polarity:
an older daemon that omits the field probed every state, so its verdicts stay
authoritative rather than being repainted as unknown.

### Callers checked

`stale_assets` has exactly one non-test consumer: `format_state_column` in
`bin/tm/commands/managed.rs`. `tm doctor`, the resume path, the picker and
the TUI never read it (verified by grep across `crates/`). The single-session
GET keeps its full probe regardless, so nothing that could have depended on
it loses the value.

## Fix 2 — parallelize `stale_assets_for_many`

Same pattern already applied to the `unresumable` probe beside it, with
`spawn_blocking` instead of `spawn` because the work is synchronous
filesystem I/O:

1. `staleness_inputs` (one blocking task) resolves every session's plan and
   computes **one `CatalogHashes` per distinct `(agent_source, skill_source)`
   pair**, handed out as `Arc`. This half stays sequential *on purpose* —
   fanning it out would race N tasks into an empty cache and reinstate the
   per-session recompose #2444 removed.
2. The cheap deployed-side comparison then fans out one blocking task per
   session via `JoinSet::spawn_blocking`.

A panicking task is simply absent from the returned map, leaving that summary
at its `false` default rather than failing the whole listing.

## Measurements

See the follow-up comment on this PR for the cold-timing runs (idle-then-time
method, 3 samples per side, both sides served by a release build of this
worktree so the comparison is apples-to-apples).

Static per-invocation I/O, computed against the live 57-session store
(25 decommissioned / 20 stopped / 12 active):

| | sessions probed | read attempts | bytes |
|---|---|---|---|
| before | 32 | 3,040 | 35.7 MiB |
| after | 12 | 1,140 | 15.0 MiB |

## Tests

- `checked_summaries_does_not_probe_stopped_sessions` — **required test**: a
  genuinely stale STOPPED session is not flagged by the list path, and its
  row advertises `stale_assets_unchecked`. Verified to FAIL without the fix
  (predicate temporarily reverted to include `Stopped`; it panicked on the
  first assertion, then the fix was restored).
- `record_to_summary_checked_still_flags_stale_stopped_session` —
  **correctness gate**: the same genuinely-stale stopped record, fetched
  individually, is still reported stale. A `tm ls` that is fast because it
  never detects staleness would fail here.
- `checked_summaries_flags_stale_assets_only_for_relevant_states` and
  `checked_summaries_stale_assets_independent_per_session_sharing_one_catalog`
  (pre-existing) now exercise the parallel path and pin that a stale ACTIVE
  session is still detected and that catalog sharing never cross-contaminates
  per-session verdicts.
- `format_state_column_appends_unchecked_assets_marker`,
  `managed_session_summary_defaults_stale_assets_unchecked_false`.

Nothing `#[ignore]`d or cfg-gated.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
