### PR TITLE
fix(trusty-mpm): stop a subagent SessionStart from clobbering claude_session_id

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -220,6 +220,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- A subagent's `SessionStart` hook can no longer overwrite a managed session's
+  `claude_session_id` with its OWN Claude session UUID
+  ([#4337](https://github.com/bobmatnyc/trusty-tools/issues/4337)). A subagent
+  sharing the PM's cwd is its own top-level Claude Code process and fires its
+  own `SessionStart`, which `correlate_session_start` matched to the PM's sole
+  Active managed session by cwd alone and blindly overwrote — so the next
+  in-place `--resume` would resume the subagent's transcript instead of the
+  PM's conversation. `correlate_session_start` (`daemon/api.rs`) now trusts only
+  the FIRST correlation for a record; a later `SessionStart` reporting a
+  DIFFERENT id for the same cwd is refused and logged, while re-reporting the
+  SAME id (a legitimate `--resume` relaunch) remains a no-op success.
 - The per-project worktree opt-out is no longer silently conditional on the
   daemon being up ([#4300](https://github.com/bobmatnyc/trusty-tools/issues/4300)).
   `Project.worktree: false` ([#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455),

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -221,16 +221,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - A subagent's `SessionStart` hook can no longer overwrite a managed session's
-  `claude_session_id` with its OWN Claude session UUID
+  `claude_session_id` with its OWN Claude session UUID, and a legitimately
+  diverged id can no longer stay wrong forever
   ([#4337](https://github.com/bobmatnyc/trusty-tools/issues/4337)). A subagent
   sharing the PM's cwd is its own top-level Claude Code process and fires its
   own `SessionStart`, which `correlate_session_start` matched to the PM's sole
   Active managed session by cwd alone and blindly overwrote — so the next
   in-place `--resume` would resume the subagent's transcript instead of the
-  PM's conversation. `correlate_session_start` (`daemon/api.rs`) now trusts only
-  the FIRST correlation for a record; a later `SessionStart` reporting a
-  DIFFERENT id for the same cwd is refused and logged, while re-reporting the
-  SAME id (a legitimate `--resume` relaunch) remains a no-op success.
+  PM's conversation. `correlate_session_start` (moved to the new
+  `daemon::api::session_start_correlation` module to stay under `api.rs`'s
+  frozen SLOC budget) now trusts only the FIRST correlation for a record; a
+  later `SessionStart` reporting a DIFFERENT id for the same cwd is accepted
+  only when the stored id's transcript no longer resolves to a live session
+  (`runtime::session_id_exists`, the same staleness check `spawn_resume`
+  already trusts) — otherwise refused and logged — while re-reporting the
+  SAME id (a legitimate `--resume` relaunch) remains a no-op success. The
+  common divergence case is handled even earlier: `SessionEnd` now clears the
+  field via the new exact-match-guarded `SessionManager::clear_claude_session_id_if`
+  (so a later, unrelated `SessionStart` is never compared against a dead id),
+  and `SessionManager::mark_reactivated` clears it outright, since a
+  reactivation always precedes a fresh top-level relaunch into that pane.
 - The per-project worktree opt-out is no longer silently conditional on the
   daemon being up ([#4300](https://github.com/bobmatnyc/trusty-tools/issues/4300)).
   `Project.worktree: false` ([#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455),

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -1338,7 +1338,33 @@ pub async fn ingest_hook(
 /// correlation is skipped with a warning to avoid mis-attribution. Single match →
 /// `SessionManager::set_claude_session_id`. Best-effort — failures are logged and
 /// silently swallowed so a missing correlation never blocks the hook response.
-/// Test: `session_start_hook_correlates_claude_id` in `api_tests.rs`.
+///
+/// # Subagent overwrite guard (#4337)
+///
+/// A subagent dispatched from a managed session's own pane (native `Task`/
+/// `Agent` tool, or any other `claude` invocation that happens to share the
+/// PM's cwd) is its OWN top-level Claude Code process from Claude Code's point
+/// of view: it gets its own internal session UUID and fires its own
+/// `SessionStart`, which lands here with the SAME `cwd` as the PM's managed
+/// session — because trusty-mpm never registers a subagent as its own managed
+/// session, cwd-matching alone finds exactly one (the PM's) record, the
+/// pre-#4337 ambiguity guard above never triggers, and the subagent's id
+/// silently clobbers the PM's own. The next in-place `--resume` would then
+/// resume the SUBAGENT's transcript instead of the PM's conversation.
+///
+/// The fix: once a record already carries a `claude_session_id`, a `SessionStart`
+/// reporting a DIFFERENT id for the same cwd is refused rather than accepted —
+/// only the FIRST correlation for a given record is trusted. A matching id is a
+/// harmless no-op write. This does mean a record's id can go stale if Claude
+/// Code ever legitimately reassigns a new UUID to the same pane's top-level
+/// conversation (e.g. a `--continue` fallback instead of `--resume`); that is
+/// an acceptable trade — the resume path (`runtime::claude_code::spawn_resume`)
+/// already treats a stored id as advisory and falls back to `--continue` via
+/// its own `session_id_exists` check when the stored id no longer resolves, so
+/// the worst case is a graceful fallback, never resuming the wrong transcript.
+/// Test: `session_start_hook_correlates_claude_id`,
+/// `session_start_hook_does_not_overwrite_with_different_id`,
+/// `session_start_hook_reasserting_same_id_is_a_noop` in `api_tests.rs`.
 async fn correlate_session_start(
     state: &Arc<DaemonState>,
     claude_session_id: &str,
@@ -1374,7 +1400,28 @@ async fn correlate_session_start(
     match matched.len() {
         0 => {} // no Active managed session at this cwd — silent, not an error
         1 => {
-            let id = matched[0].id;
+            let record = matched[0];
+            let id = record.id;
+
+            // #4337: an already-correlated record keeps its FIRST id. A report
+            // of a different id — most likely a subagent sharing this cwd, not
+            // the pane's own top-level process — is refused rather than
+            // silently accepted, so a subagent can never clobber the PM's id.
+            if let Some(existing) = record.claude_session_id.as_deref() {
+                if existing != claude_session_id {
+                    tracing::warn!(
+                        managed_id = %id,
+                        existing_claude_session_id = %existing,
+                        reported_claude_session_id = %claude_session_id,
+                        cwd = %cwd_str,
+                        "SessionStart: refusing to overwrite an already-correlated \
+                         claude_session_id with a different one — likely a subagent \
+                         sharing this cwd, not the pane's top-level process (#4337)"
+                    );
+                }
+                return;
+            }
+
             match mgr.set_claude_session_id(&id, claude_session_id).await {
                 Ok(()) => tracing::info!(
                     managed_id = %id,

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -57,6 +57,24 @@ pub use control_routes::{
 pub mod claude_config_routes;
 pub use claude_config_routes::*;
 
+/// `SessionStart`/`SessionEnd` hook correlation (#1744, #4337).
+///
+/// Why: this cluster grew the #4337 subagent-overwrite guard + stale-id
+/// re-sync logic past what `api.rs`'s frozen 1272-SLOC allowlist budget
+/// (`.line-cap-allowlist.tsv`) could absorb. It is cohesive and
+/// self-contained — both hook handlers are called only from `ingest_hook`
+/// below — so it moves out, mirroring `control_routes`/`claude_config_routes`.
+/// Not `pub`: unlike those two, nothing outside `api.rs` calls these handlers
+/// directly (`ingest_hook` is the only public entry point), so a private
+/// `use` is enough to bring the names into `api.rs`'s own scope — and, via
+/// `api_tests.rs`'s `use super::*;`, into the test module too.
+mod session_start_correlation;
+use session_start_correlation::{correlate_session_start, handle_session_end};
+// Only `api_tests.rs` (via `use super::*;`) calls this directly — a plain
+// `use` would be flagged `unused_imports` on the non-test lib target.
+#[cfg(test)]
+use session_start_correlation::session_end_pane_still_live;
+
 /// The cross-session coordinator routes (`/api/v1/sessions/context` + `/chat`).
 ///
 /// Why: the coordinator's context and chat endpoints form their own cohesive
@@ -1319,260 +1337,6 @@ pub async fn ingest_hook(
         _ => Ok(Json(HookAcceptedResponse {
             accepted: post.event,
         })),
-    }
-}
-
-/// Link a `SessionStart` Claude session UUID to the right managed session record.
-///
-/// Why (#1744): when `resume` calls `spawn_resume` with `--resume <id>`, it needs
-/// the Claude Code internal session UUID persisted on the `SessionRecord`. The only
-/// reliable source is the `SessionStart` hook, which fires as Claude Code starts
-/// and delivers `CLAUDE_SESSION_ID` via the environment. The hook handler
-/// (`tm hook`) now also embeds the caller's `cwd` in the payload (issue #1744);
-/// this function uses that `cwd` to find the Active managed session running in that
-/// directory and persists the UUID.
-/// What: extracts `cwd` from `payload["cwd"]`; canonicalizes it and each record's
-/// `workspace_path`/`cwd` (falling back to raw path on error so macOS
-/// `/private/tmp` ↔ `/tmp` symlinks resolve); finds Active managed sessions whose
-/// path matches. If more than one Active session matches the cwd (ambiguous) the
-/// correlation is skipped with a warning to avoid mis-attribution. Single match →
-/// `SessionManager::set_claude_session_id`. Best-effort — failures are logged and
-/// silently swallowed so a missing correlation never blocks the hook response.
-///
-/// # Subagent overwrite guard (#4337)
-///
-/// A subagent dispatched from a managed session's own pane (native `Task`/
-/// `Agent` tool, or any other `claude` invocation that happens to share the
-/// PM's cwd) is its OWN top-level Claude Code process from Claude Code's point
-/// of view: it gets its own internal session UUID and fires its own
-/// `SessionStart`, which lands here with the SAME `cwd` as the PM's managed
-/// session — because trusty-mpm never registers a subagent as its own managed
-/// session, cwd-matching alone finds exactly one (the PM's) record, the
-/// pre-#4337 ambiguity guard above never triggers, and the subagent's id
-/// silently clobbers the PM's own. The next in-place `--resume` would then
-/// resume the SUBAGENT's transcript instead of the PM's conversation.
-///
-/// The fix: once a record already carries a `claude_session_id`, a `SessionStart`
-/// reporting a DIFFERENT id for the same cwd is refused rather than accepted —
-/// only the FIRST correlation for a given record is trusted. A matching id is a
-/// harmless no-op write. This does mean a record's id can go stale if Claude
-/// Code ever legitimately reassigns a new UUID to the same pane's top-level
-/// conversation (e.g. a `--continue` fallback instead of `--resume`); that is
-/// an acceptable trade — the resume path (`runtime::claude_code::spawn_resume`)
-/// already treats a stored id as advisory and falls back to `--continue` via
-/// its own `session_id_exists` check when the stored id no longer resolves, so
-/// the worst case is a graceful fallback, never resuming the wrong transcript.
-/// Test: `session_start_hook_correlates_claude_id`,
-/// `session_start_hook_does_not_overwrite_with_different_id`,
-/// `session_start_hook_reasserting_same_id_is_a_noop` in `api_tests.rs`.
-async fn correlate_session_start(
-    state: &Arc<DaemonState>,
-    claude_session_id: &str,
-    payload: &serde_json::Value,
-) {
-    let cwd_str = match payload["cwd"].as_str() {
-        Some(s) if !s.is_empty() => s,
-        _ => return,
-    };
-    // Canonicalize hook cwd (resolves /tmp ↔ /private/tmp on macOS).
-    let hook_cwd =
-        std::fs::canonicalize(cwd_str).unwrap_or_else(|_| std::path::PathBuf::from(cwd_str));
-
-    let mgr = state.session_manager().await;
-    let records = mgr.list().await;
-
-    // Collect ALL matching Active sessions to detect ambiguous cwd.
-    let matched: Vec<_> = records
-        .iter()
-        .filter(|r| {
-            if !matches!(r.state, crate::session_manager::ManagedSessionState::Active) {
-                return false;
-            }
-            let ws_canon = r
-                .workspace_path
-                .as_ref()
-                .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()));
-            let cwd_canon = std::fs::canonicalize(&r.cwd).unwrap_or_else(|_| r.cwd.clone());
-            ws_canon.as_deref() == Some(hook_cwd.as_path()) || cwd_canon == hook_cwd
-        })
-        .collect();
-
-    match matched.len() {
-        0 => {} // no Active managed session at this cwd — silent, not an error
-        1 => {
-            let record = matched[0];
-            let id = record.id;
-
-            // #4337: an already-correlated record keeps its FIRST id. A report
-            // of a different id — most likely a subagent sharing this cwd, not
-            // the pane's own top-level process — is refused rather than
-            // silently accepted, so a subagent can never clobber the PM's id.
-            if let Some(existing) = record.claude_session_id.as_deref() {
-                if existing != claude_session_id {
-                    tracing::warn!(
-                        managed_id = %id,
-                        existing_claude_session_id = %existing,
-                        reported_claude_session_id = %claude_session_id,
-                        cwd = %cwd_str,
-                        "SessionStart: refusing to overwrite an already-correlated \
-                         claude_session_id with a different one — likely a subagent \
-                         sharing this cwd, not the pane's top-level process (#4337)"
-                    );
-                }
-                return;
-            }
-
-            match mgr.set_claude_session_id(&id, claude_session_id).await {
-                Ok(()) => tracing::info!(
-                    managed_id = %id,
-                    claude_session_id = %claude_session_id,
-                    cwd = %cwd_str,
-                    "SessionStart: linked Claude session to managed session (#1744)"
-                ),
-                Err(e) => tracing::warn!(
-                    managed_id = %id,
-                    "SessionStart: failed to persist claude_session_id: {e}"
-                ),
-            }
-        }
-        n => {
-            tracing::warn!(
-                cwd = %cwd_str,
-                n,
-                "SessionStart: {n} Active managed sessions share the same cwd — \
-                 skipping claude_session_id attribution to avoid mis-assignment (#1744)"
-            );
-        }
-    }
-}
-
-/// Pure decision: should `handle_session_end` DEFER its `Stopped` transition
-/// because the record's own tmux pane still shows a live runtime? (#2454)
-///
-/// Why: `SessionEnd` firing is Claude Code self-reporting that its session is
-/// "ending / being torn down" ([`crate::core::hook::HookEvent::SessionEnd`])
-/// — NOT proof the OS process (and therefore the tmux pane) has already fully
-/// exited; the hook POST can race the pane's actual fall-back to a bare idle
-/// shell. `SessionManager::resume` decides pane reuse purely on
-/// `tmux.session_exists()`, so flipping the record to `Stopped` while the
-/// pane is still occupied could let a `resume` (manual or the auto-resume
-/// supervisor) type into a pane the outgoing runtime hasn't relinquished yet.
-/// This reuses the EXACT SAME classification the 60-second runtime-exit
-/// reaper already trusts for this question —
-/// [`crate::daemon::runtime_reap::session_has_live_pane`] (any-pane-live
-/// aggregation over the idle-shell allowlist and the [`ChildLivenessProbe`]
-/// fail-closed gate) — instead of inventing a second one, so the two call
-/// sites can never disagree about what "exited" means.
-/// What: delegates directly to
-/// [`session_has_live_pane`](crate::daemon::runtime_reap::session_has_live_pane),
-/// which returns `true` (defer) when ANY pane whose `session_name` matches
-/// `tmux_name` is NOT yet exited. Fixed by #2463: this previously used
-/// `panes.iter().find(...)` — the FIRST matching pane only — which
-/// misclassified a manually-split, multi-pane managed session as idle
-/// whenever `tmux list-panes -a` happened to return an idle pane ahead of a
-/// live one. When no matching pane is found (already gone, or tmux/pane
-/// enumeration was unavailable and `panes` is empty) this returns `false`
-/// (proceed) — there is nothing to protect from a destructive teardown here,
-/// since `mark_runtime_exited_stopped` never touches the pane either way; a
-/// genuinely vanished session is left to the #1744 reaper as before. Pure —
-/// no I/O — so it is unit-testable without a live tmux.
-/// Test: `session_end_pane_still_live_true_for_running_agent`,
-/// `session_end_pane_still_live_false_for_idle_shell`,
-/// `session_end_pane_still_live_false_when_pane_missing`,
-/// `session_end_pane_still_live_true_when_any_of_multiple_panes_live`,
-/// `session_end_pane_still_live_false_when_all_of_multiple_panes_idle` in
-/// `api_tests.rs`.
-fn session_end_pane_still_live(
-    tmux_name: &str,
-    panes: &[crate::daemon::orphan_gc::PaneInfo],
-    probe: &dyn crate::daemon::orphan_gc::ChildLivenessProbe,
-) -> bool {
-    crate::daemon::runtime_reap::session_has_live_pane(tmux_name, panes, probe)
-}
-
-/// Immediately mark a managed session Stopped on `SessionEnd`, WITHOUT killing
-/// its tmux pane (#2454).
-///
-/// Why (#1744, revised #2454): without this, a managed session that exits
-/// ungracefully (tmux pane killed, terminal closed) stays `Active` in the store
-/// until the 60-second reap loop fires. On `SessionEnd`, Claude Code's internal
-/// session has already ended; marking the managed session `Stopped` immediately
-/// keeps the daemon's view consistent and lets the operator see the correct
-/// state right away. This originally called [`SessionManager::stop`], which is
-/// the EXPLICIT-stop contract (`tm session stop`) and therefore also
-/// `graceful_terminate_runtime`s / `kill_session`s the tmux pane — but a
-/// `SessionEnd` correlation is a self-healing state reconcile, not a
-/// human/client teardown request, exactly like the 60-second runtime-exit
-/// reaper (see [`crate::daemon::runtime_reap`] #2023 A). Routing it through
-/// `stop` could destroy a pane the operator was still attached to, purely
-/// because the daemon correlated the exit a few hundred milliseconds before
-/// they noticed. This now mirrors the reaper and calls
-/// [`SessionManager::mark_runtime_exited_stopped`] instead, leaving the pane
-/// alive. It also gates that transition behind
-/// [`session_end_pane_still_live`] (#2454 follow-up): the hook can race the
-/// pane's actual teardown, so if the pane is found and still shows a live
-/// runtime the transition is DEFERRED for this hook receipt — the 60-second
-/// reaper will pick the session up once its pane is genuinely idle. This gate
-/// is best-effort: it needs a real `tmux` binary to enumerate panes, so on a
-/// host with no `tmux` (or a `list_managed_panes` failure) it fails OPEN and
-/// proceeds with the transition unchecked, same as pre-gate behavior.
-/// What: searches Active managed sessions for one whose `claude_session_id`
-/// matches the hook's `session_id`. If found, best-effort discovers the live
-/// tmux panes ([`crate::daemon::tmux::TmuxDriver::discover`] +
-/// `list_managed_panes`) and calls [`session_end_pane_still_live`]; when that
-/// reports the pane is still live, logs and returns WITHOUT transitioning.
-/// Otherwise calls `SessionManager::mark_runtime_exited_stopped`, which marks
-/// the record `Stopped` and persists WITHOUT calling
-/// `graceful_terminate_runtime` / `kill_session`. Best-effort — failures are
-/// logged and swallowed so the hook response is unaffected.
-/// Test: `session_end_hook_marks_managed_stopped` and
-/// `session_end_hook_does_not_kill_pane` in `api_tests.rs` cover the
-/// transition itself (tmux is unavailable/pane-not-found in that harness, so
-/// the gate fails open); the gate's own decision logic is covered by the
-/// `session_end_pane_still_live_*` unit tests above.
-async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
-    let mgr = state.session_manager().await;
-    let records = mgr.list().await;
-    let matched = records.iter().find(|r| {
-        matches!(r.state, crate::session_manager::ManagedSessionState::Active)
-            && r.claude_session_id.as_deref() == Some(claude_session_id)
-    });
-    if let Some(r) = matched {
-        let id = r.id;
-        let tmux_name = r.tmux_name.clone();
-
-        // #2454: best-effort gate — defer if the pane still shows a live
-        // runtime. Fails open (proceeds) when tmux is unavailable or pane
-        // enumeration fails, matching the transition's own non-destructive
-        // nature (nothing here ever touches the pane regardless).
-        if let Ok(driver) = crate::daemon::tmux::TmuxDriver::discover()
-            && let Ok(panes) = driver.list_managed_panes()
-            && session_end_pane_still_live(
-                &tmux_name,
-                &panes,
-                &crate::daemon::orphan_gc::ProcessTreeProbe,
-            )
-        {
-            tracing::info!(
-                managed_id = %id,
-                claude_session_id = %claude_session_id,
-                name = %tmux_name,
-                "SessionEnd: deferring Stopped transition — pane still shows a live runtime (#2454); the 60s reaper will retry once idle"
-            );
-            return;
-        }
-
-        match mgr.mark_runtime_exited_stopped(&id).await {
-            Ok(_) => tracing::info!(
-                managed_id = %id,
-                claude_session_id = %claude_session_id,
-                "SessionEnd: marked managed session Stopped immediately (#1744, pane left alive #2454)"
-            ),
-            Err(e) => tracing::warn!(
-                managed_id = %id,
-                "SessionEnd: failed to mark managed session Stopped: {e}"
-            ),
-        }
     }
 }
 

--- a/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
+++ b/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
@@ -1,0 +1,332 @@
+//! `SessionStart`/`SessionEnd` hook correlation: linking a Claude Code session
+//! UUID to the right managed session record (#1744, #4337).
+//!
+//! Why: `api.rs` was at its frozen 1272-SLOC allowlist budget
+//! (`.line-cap-allowlist.tsv`); adding the #4337 re-sync logic there would
+//! have breached it. This cluster — `correlate_session_start`,
+//! `handle_session_end`, and the pure `session_end_pane_still_live` gate it
+//! uses — is cohesive and self-contained (both hook handlers, called only
+//! from `ingest_hook`), so it moves out wholesale, mirroring how
+//! `control_routes.rs` / `claude_config_routes.rs` already keep `api.rs`
+//! focused on routing.
+//! What: two `pub(super)` async fns wired into `api::ingest_hook`'s
+//! `SessionStart`/`SessionEnd` branches, plus the private pure liveness gate.
+//! Test: the `#[cfg(test)]` suite in `api_tests.rs` (brought into scope there
+//! via `api.rs`'s `use session_start_correlation::*;` and `use super::*;`).
+
+use std::sync::Arc;
+
+use crate::daemon::state::DaemonState;
+
+/// Link a `SessionStart` Claude session UUID to the right managed session record.
+///
+/// Why (#1744): when `resume` calls `spawn_resume` with `--resume <id>`, it needs
+/// the Claude Code internal session UUID persisted on the `SessionRecord`. The only
+/// reliable source is the `SessionStart` hook, which fires as Claude Code starts
+/// and delivers `CLAUDE_SESSION_ID` via the environment. The hook handler
+/// (`tm hook`) now also embeds the caller's `cwd` in the payload (issue #1744);
+/// this function uses that `cwd` to find the Active managed session running in that
+/// directory and persists the UUID.
+/// What: extracts `cwd` from `payload["cwd"]`; canonicalizes it and each record's
+/// `workspace_path`/`cwd` (falling back to raw path on error so macOS
+/// `/private/tmp` ↔ `/tmp` symlinks resolve); finds Active managed sessions whose
+/// path matches. If more than one Active session matches the cwd (ambiguous) the
+/// correlation is skipped with a warning to avoid mis-attribution. Single match →
+/// `SessionManager::set_claude_session_id`. Best-effort — failures are logged and
+/// silently swallowed so a missing correlation never blocks the hook response.
+///
+/// # Subagent overwrite guard + re-sync (#4337)
+///
+/// A subagent dispatched from a managed session's own pane (native `Task`/
+/// `Agent` tool, or any other `claude` invocation that happens to share the
+/// PM's cwd) is its OWN top-level Claude Code process from Claude Code's point
+/// of view: it gets its own internal session UUID and fires its own
+/// `SessionStart`, which lands here with the SAME `cwd` as the PM's managed
+/// session — because trusty-mpm never registers a subagent as its own managed
+/// session, cwd-matching alone finds exactly one (the PM's) record, the
+/// pre-#4337 ambiguity guard above never triggers, and the subagent's id
+/// could silently clobber the PM's own. The next in-place `--resume` would
+/// then resume the SUBAGENT's transcript instead of the PM's conversation.
+///
+/// The fix: once a record already carries a `claude_session_id`, a
+/// `SessionStart` reporting a DIFFERENT id for the same cwd is accepted ONLY
+/// when the STORED id no longer resolves to a live session transcript
+/// ([`stored_id_still_live`], reusing the exact staleness check
+/// `runtime::claude_code::session_id_exists` the resume path already trusts
+/// for the same question) — otherwise it is refused and logged. A subagent's
+/// own transcript DOES exist and is live for as long as it runs, so its
+/// report is refused; a genuinely stale id (the prior conversation's
+/// transcript was pruned, or it never made it to disk) is accepted, so the
+/// record can recover. The common case — the prior conversation cleanly
+/// ending — is handled even earlier and more precisely by
+/// [`handle_session_end`] clearing the field outright (and by
+/// `SessionManager::mark_reactivated`, #4337, doing the same on an in-place
+/// reactivate), so this staleness check is the residual, narrower safety net
+/// for when that clear did not happen (a crash, a missed hook, or a request
+/// that raced ahead of it).
+/// Test: `session_start_hook_correlates_claude_id`,
+/// `session_start_hook_does_not_overwrite_with_different_id`,
+/// `session_start_hook_reasserting_same_id_is_a_noop`,
+/// `session_start_hook_re_correlates_a_stale_id`,
+/// `session_start_hook_still_refuses_a_live_subagent_id` in `api_tests.rs`.
+pub(super) async fn correlate_session_start(
+    state: &Arc<DaemonState>,
+    claude_session_id: &str,
+    payload: &serde_json::Value,
+) {
+    let cwd_str = match payload["cwd"].as_str() {
+        Some(s) if !s.is_empty() => s,
+        _ => return,
+    };
+    // Canonicalize hook cwd (resolves /tmp ↔ /private/tmp on macOS).
+    let hook_cwd =
+        std::fs::canonicalize(cwd_str).unwrap_or_else(|_| std::path::PathBuf::from(cwd_str));
+
+    let mgr = state.session_manager().await;
+    let records = mgr.list().await;
+
+    // Collect ALL matching Active sessions to detect ambiguous cwd.
+    let matched: Vec<_> = records
+        .iter()
+        .filter(|r| {
+            if !matches!(r.state, crate::session_manager::ManagedSessionState::Active) {
+                return false;
+            }
+            let ws_canon = r
+                .workspace_path
+                .as_ref()
+                .map(|p| std::fs::canonicalize(p).unwrap_or_else(|_| p.clone()));
+            let cwd_canon = std::fs::canonicalize(&r.cwd).unwrap_or_else(|_| r.cwd.clone());
+            ws_canon.as_deref() == Some(hook_cwd.as_path()) || cwd_canon == hook_cwd
+        })
+        .collect();
+
+    match matched.len() {
+        0 => {} // no Active managed session at this cwd — silent, not an error
+        1 => {
+            let record = matched[0];
+            let id = record.id;
+
+            if let Some(existing) = record.claude_session_id.as_deref() {
+                if existing == claude_session_id {
+                    return; // no-op: already correlated to this id
+                }
+                if stored_id_still_live(&hook_cwd, existing) {
+                    tracing::warn!(
+                        managed_id = %id,
+                        existing_claude_session_id = %existing,
+                        reported_claude_session_id = %claude_session_id,
+                        cwd = %cwd_str,
+                        "SessionStart: refusing to overwrite a still-live claude_session_id \
+                         with a different one — likely a subagent sharing this cwd, not the \
+                         pane's top-level process (#4337)"
+                    );
+                    return;
+                }
+                tracing::info!(
+                    managed_id = %id,
+                    stale_claude_session_id = %existing,
+                    claude_session_id = %claude_session_id,
+                    cwd = %cwd_str,
+                    "SessionStart: stored claude_session_id no longer resolves to a live \
+                     session — re-correlating to the new id (#4337)"
+                );
+            }
+
+            match mgr.set_claude_session_id(&id, claude_session_id).await {
+                Ok(()) => tracing::info!(
+                    managed_id = %id,
+                    claude_session_id = %claude_session_id,
+                    cwd = %cwd_str,
+                    "SessionStart: linked Claude session to managed session (#1744)"
+                ),
+                Err(e) => tracing::warn!(
+                    managed_id = %id,
+                    "SessionStart: failed to persist claude_session_id: {e}"
+                ),
+            }
+        }
+        n => {
+            tracing::warn!(
+                cwd = %cwd_str,
+                n,
+                "SessionStart: {n} Active managed sessions share the same cwd — \
+                 skipping claude_session_id attribution to avoid mis-assignment (#1744)"
+            );
+        }
+    }
+}
+
+/// Whether a previously-stored `claude_session_id` still resolves to a live
+/// Claude Code session transcript for `cwd` (#4337 re-sync gate).
+///
+/// Why: reuses `runtime::claude_code::session_id_exists` — the SAME
+/// staleness check `spawn_resume` already trusts before honoring a stored id
+/// with `--resume` — so the two call sites can never disagree about what
+/// "stale" means. A subagent's transcript exists and is live for as long as
+/// it runs, so this returns `true` for it; a genuinely stale id (pruned,
+/// moved, or never flushed to disk) returns `false`.
+/// What: resolves the managed `CLAUDE_CONFIG_DIR` via
+/// [`crate::core::trusty_tools_config::managed_claude_config_dir`] and
+/// delegates to [`crate::runtime::session_id_exists`].
+/// Test: `session_start_hook_re_correlates_a_stale_id`,
+/// `session_start_hook_still_refuses_a_live_subagent_id` in `api_tests.rs`.
+fn stored_id_still_live(cwd: &std::path::Path, id: &str) -> bool {
+    let config_dir = crate::core::trusty_tools_config::managed_claude_config_dir();
+    crate::runtime::session_id_exists(cwd, config_dir.as_deref(), id)
+}
+
+/// Pure decision: should `handle_session_end` DEFER its `Stopped` transition
+/// because the record's own tmux pane still shows a live runtime? (#2454)
+///
+/// Why: `SessionEnd` firing is Claude Code self-reporting that its session is
+/// "ending / being torn down" ([`crate::core::hook::HookEvent::SessionEnd`])
+/// — NOT proof the OS process (and therefore the tmux pane) has already fully
+/// exited; the hook POST can race the pane's actual fall-back to a bare idle
+/// shell. `SessionManager::resume` decides pane reuse purely on
+/// `tmux.session_exists()`, so flipping the record to `Stopped` while the
+/// pane is still occupied could let a `resume` (manual or the auto-resume
+/// supervisor) type into a pane the outgoing runtime hasn't relinquished yet.
+/// This reuses the EXACT SAME classification the 60-second runtime-exit
+/// reaper already trusts for this question —
+/// [`crate::daemon::runtime_reap::session_has_live_pane`] (any-pane-live
+/// aggregation over the idle-shell allowlist and the [`ChildLivenessProbe`]
+/// fail-closed gate) — instead of inventing a second one, so the two call
+/// sites can never disagree about what "exited" means.
+/// What: delegates directly to
+/// [`session_has_live_pane`](crate::daemon::runtime_reap::session_has_live_pane),
+/// which returns `true` (defer) when ANY pane whose `session_name` matches
+/// `tmux_name` is NOT yet exited. Fixed by #2463: this previously used
+/// `panes.iter().find(...)` — the FIRST matching pane only — which
+/// misclassified a manually-split, multi-pane managed session as idle
+/// whenever `tmux list-panes -a` happened to return an idle pane ahead of a
+/// live one. When no matching pane is found (already gone, or tmux/pane
+/// enumeration was unavailable and `panes` is empty) this returns `false`
+/// (proceed) — there is nothing to protect from a destructive teardown here,
+/// since `mark_runtime_exited_stopped` never touches the pane either way; a
+/// genuinely vanished session is left to the #1744 reaper as before. Pure —
+/// no I/O — so it is unit-testable without a live tmux.
+/// Test: `session_end_pane_still_live_true_for_running_agent`,
+/// `session_end_pane_still_live_false_for_idle_shell`,
+/// `session_end_pane_still_live_false_when_pane_missing`,
+/// `session_end_pane_still_live_true_when_any_of_multiple_panes_live`,
+/// `session_end_pane_still_live_false_when_all_of_multiple_panes_idle` in
+/// `api_tests.rs`.
+pub(super) fn session_end_pane_still_live(
+    tmux_name: &str,
+    panes: &[crate::daemon::orphan_gc::PaneInfo],
+    probe: &dyn crate::daemon::orphan_gc::ChildLivenessProbe,
+) -> bool {
+    crate::daemon::runtime_reap::session_has_live_pane(tmux_name, panes, probe)
+}
+
+/// Immediately mark a managed session Stopped on `SessionEnd`, WITHOUT killing
+/// its tmux pane (#2454).
+///
+/// Why (#1744, revised #2454): without this, a managed session that exits
+/// ungracefully (tmux pane killed, terminal closed) stays `Active` in the store
+/// until the 60-second reap loop fires. On `SessionEnd`, Claude Code's internal
+/// session has already ended; marking the managed session `Stopped` immediately
+/// keeps the daemon's view consistent and lets the operator see the correct
+/// state right away. This originally called [`SessionManager::stop`], which is
+/// the EXPLICIT-stop contract (`tm session stop`) and therefore also
+/// `graceful_terminate_runtime`s / `kill_session`s the tmux pane — but a
+/// `SessionEnd` correlation is a self-healing state reconcile, not a
+/// human/client teardown request, exactly like the 60-second runtime-exit
+/// reaper (see [`crate::daemon::runtime_reap`] #2023 A). Routing it through
+/// `stop` could destroy a pane the operator was still attached to, purely
+/// because the daemon correlated the exit a few hundred milliseconds before
+/// they noticed. This now mirrors the reaper and calls
+/// [`SessionManager::mark_runtime_exited_stopped`] instead, leaving the pane
+/// alive. It also gates that transition behind
+/// [`session_end_pane_still_live`] (#2454 follow-up): the hook can race the
+/// pane's actual teardown, so if the pane is found and still shows a live
+/// runtime the transition is DEFERRED for this hook receipt — the 60-second
+/// reaper will pick the session up once its pane is genuinely idle. This gate
+/// is best-effort: it needs a real `tmux` binary to enumerate panes, so on a
+/// host with no `tmux` (or a `list_managed_panes` failure) it fails OPEN and
+/// proceeds with the transition unchecked, same as pre-gate behavior.
+///
+/// #4337: BEFORE that pane-liveness gate, this ALSO clears the record's
+/// `claude_session_id` via `SessionManager::clear_claude_session_id_if` — an
+/// exact-match, race-safe clear (a concurrent fresher correlation is never
+/// clobbered). `SessionEnd` is Claude Code's own unambiguous signal that
+/// THIS conversation ended, independent of whether the pane still shows a
+/// live runtime (that gate is about the TMUX PANE, not the Claude session),
+/// so the id is stale from this point on regardless of the deferral below.
+/// Clearing it here means the record's NEXT `SessionStart` — the real
+/// relaunch — takes the plain "no existing id" branch in
+/// [`correlate_session_start`] rather than depending on a later subagent's
+/// report ever satisfying the narrower stale-transcript re-sync gate.
+/// What: searches Active managed sessions for one whose `claude_session_id`
+/// matches the hook's `session_id`. If found, clears that id (best-effort),
+/// then best-effort discovers the live tmux panes
+/// ([`crate::daemon::tmux::TmuxDriver::discover`] + `list_managed_panes`) and
+/// calls [`session_end_pane_still_live`]; when that reports the pane is
+/// still live, logs and returns WITHOUT transitioning. Otherwise calls
+/// `SessionManager::mark_runtime_exited_stopped`, which marks the record
+/// `Stopped` and persists WITHOUT calling `graceful_terminate_runtime` /
+/// `kill_session`. Best-effort — failures are logged and swallowed so the
+/// hook response is unaffected.
+/// Test: `session_end_hook_marks_managed_stopped` and
+/// `session_end_hook_does_not_kill_pane` in `api_tests.rs` cover the
+/// transition itself (tmux is unavailable/pane-not-found in that harness, so
+/// the gate fails open); the gate's own decision logic is covered by the
+/// `session_end_pane_still_live_*` unit tests above;
+/// `session_end_hook_clears_claude_session_id` covers the #4337 clear.
+pub(super) async fn handle_session_end(state: &Arc<DaemonState>, claude_session_id: &str) {
+    let mgr = state.session_manager().await;
+    let records = mgr.list().await;
+    let matched = records.iter().find(|r| {
+        matches!(r.state, crate::session_manager::ManagedSessionState::Active)
+            && r.claude_session_id.as_deref() == Some(claude_session_id)
+    });
+    if let Some(r) = matched {
+        let id = r.id;
+        let tmux_name = r.tmux_name.clone();
+
+        // #4337: this Claude session has genuinely ended — un-correlate it so
+        // a later, unrelated SessionStart is never compared against a dead
+        // id. Exact-match guarded, so a concurrent fresher correlation (a
+        // real relaunch that already landed) is never clobbered.
+        if let Err(e) = mgr.clear_claude_session_id_if(&id, claude_session_id).await {
+            tracing::warn!(
+                managed_id = %id,
+                "SessionEnd: failed to clear claude_session_id: {e}"
+            );
+        }
+
+        // #2454: best-effort gate — defer if the pane still shows a live
+        // runtime. Fails open (proceeds) when tmux is unavailable or pane
+        // enumeration fails, matching the transition's own non-destructive
+        // nature (nothing here ever touches the pane regardless).
+        if let Ok(driver) = crate::daemon::tmux::TmuxDriver::discover()
+            && let Ok(panes) = driver.list_managed_panes()
+            && session_end_pane_still_live(
+                &tmux_name,
+                &panes,
+                &crate::daemon::orphan_gc::ProcessTreeProbe,
+            )
+        {
+            tracing::info!(
+                managed_id = %id,
+                claude_session_id = %claude_session_id,
+                name = %tmux_name,
+                "SessionEnd: deferring Stopped transition — pane still shows a live runtime (#2454); the 60s reaper will retry once idle"
+            );
+            return;
+        }
+
+        match mgr.mark_runtime_exited_stopped(&id).await {
+            Ok(_) => tracing::info!(
+                managed_id = %id,
+                claude_session_id = %claude_session_id,
+                "SessionEnd: marked managed session Stopped immediately (#1744, pane left alive #2454)"
+            ),
+            Err(e) => tracing::warn!(
+                managed_id = %id,
+                "SessionEnd: failed to mark managed session Stopped: {e}"
+            ),
+        }
+    }
+}

--- a/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
+++ b/crates/trusty-mpm/src/daemon/api/session_start_correlation.rs
@@ -65,10 +65,9 @@ use crate::daemon::state::DaemonState;
 /// for when that clear did not happen (a crash, a missed hook, or a request
 /// that raced ahead of it).
 /// Test: `session_start_hook_correlates_claude_id`,
-/// `session_start_hook_does_not_overwrite_with_different_id`,
+/// `session_start_hook_still_refuses_a_live_subagent_id`,
 /// `session_start_hook_reasserting_same_id_is_a_noop`,
-/// `session_start_hook_re_correlates_a_stale_id`,
-/// `session_start_hook_still_refuses_a_live_subagent_id` in `api_tests.rs`.
+/// `session_start_hook_re_correlates_a_stale_id` in `api_tests.rs`.
 pub(super) async fn correlate_session_start(
     state: &Arc<DaemonState>,
     claude_session_id: &str,

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1663,6 +1663,83 @@ async fn session_start_hook_correlates_claude_id() {
 }
 
 #[tokio::test]
+async fn session_start_hook_does_not_overwrite_with_different_id() {
+    // Why (#4337): a managed session's record was observed carrying a
+    // SUBAGENT's Claude session id instead of the PM's own — a later
+    // `SessionStart` from any `claude` process sharing the PM's cwd (e.g. a
+    // dispatched subagent, which is its own top-level Claude Code process from
+    // Claude Code's point of view) used to silently clobber an
+    // already-correlated `claude_session_id`. This reproduces exactly that:
+    // correlate once (the PM's own SessionStart), then fire a second
+    // SessionStart with a DIFFERENT id from the same cwd (the subagent), and
+    // assert the ORIGINAL id survives.
+    let ws = std::path::PathBuf::from("/tmp/test-ws-correlate-no-overwrite");
+    let (state, managed_id, _) = make_state_with_active_managed(ws.clone()).await;
+
+    let pm_claude_id = "550e8400-e29b-41d4-a716-446655440010";
+    let post = HookPost {
+        session_id: pm_claude_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("PM SessionStart must succeed");
+
+    // A subagent's own SessionStart, reported from the SAME cwd with a
+    // DIFFERENT session id — this must be refused, not accepted.
+    let subagent_claude_id = "550e8400-e29b-41d4-a716-446655440011";
+    let post = HookPost {
+        session_id: subagent_claude_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("subagent SessionStart must still be accepted at the HTTP layer");
+
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&managed_id).await.expect("get managed session");
+    assert_eq!(
+        record.claude_session_id.as_deref(),
+        Some(pm_claude_id),
+        "a later SessionStart reporting a DIFFERENT id must never overwrite the \
+         already-correlated PM claude_session_id (#4337)"
+    );
+}
+
+#[tokio::test]
+async fn session_start_hook_reasserting_same_id_is_a_noop() {
+    // Why (#4337): the guard must not be so strict that it breaks the
+    // legitimate case — a `--resume <id>` relaunch preserves the SAME Claude
+    // Code session UUID, so its SessionStart re-reports the identical id. That
+    // must still succeed (as a no-op write), not be treated as a conflicting
+    // report.
+    let ws = std::path::PathBuf::from("/tmp/test-ws-correlate-reassert-same");
+    let (state, managed_id, _) = make_state_with_active_managed(ws.clone()).await;
+
+    let claude_id = "550e8400-e29b-41d4-a716-446655440012";
+    for _ in 0..2 {
+        let post = HookPost {
+            session_id: claude_id.to_string(),
+            event: HookEvent::SessionStart,
+            payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+        };
+        let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+            .await
+            .expect("SessionStart must succeed");
+    }
+
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&managed_id).await.expect("get managed session");
+    assert_eq!(
+        record.claude_session_id.as_deref(),
+        Some(claude_id),
+        "reasserting the SAME claude_session_id must remain a no-op success, not be blocked (#4337)"
+    );
+}
+
+#[tokio::test]
 async fn session_end_hook_marks_managed_stopped() {
     // Why (#1744): ingest_hook(SessionEnd) must call handle_session_end, which
     // immediately transitions the Active managed session to Stopped. This is the

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1662,51 +1662,11 @@ async fn session_start_hook_correlates_claude_id() {
     );
 }
 
-#[tokio::test]
-async fn session_start_hook_does_not_overwrite_with_different_id() {
-    // Why (#4337): a managed session's record was observed carrying a
-    // SUBAGENT's Claude session id instead of the PM's own — a later
-    // `SessionStart` from any `claude` process sharing the PM's cwd (e.g. a
-    // dispatched subagent, which is its own top-level Claude Code process from
-    // Claude Code's point of view) used to silently clobber an
-    // already-correlated `claude_session_id`. This reproduces exactly that:
-    // correlate once (the PM's own SessionStart), then fire a second
-    // SessionStart with a DIFFERENT id from the same cwd (the subagent), and
-    // assert the ORIGINAL id survives.
-    let ws = std::path::PathBuf::from("/tmp/test-ws-correlate-no-overwrite");
-    let (state, managed_id, _) = make_state_with_active_managed(ws.clone()).await;
-
-    let pm_claude_id = "550e8400-e29b-41d4-a716-446655440010";
-    let post = HookPost {
-        session_id: pm_claude_id.to_string(),
-        event: HookEvent::SessionStart,
-        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
-    };
-    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
-        .await
-        .expect("PM SessionStart must succeed");
-
-    // A subagent's own SessionStart, reported from the SAME cwd with a
-    // DIFFERENT session id — this must be refused, not accepted.
-    let subagent_claude_id = "550e8400-e29b-41d4-a716-446655440011";
-    let post = HookPost {
-        session_id: subagent_claude_id.to_string(),
-        event: HookEvent::SessionStart,
-        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
-    };
-    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
-        .await
-        .expect("subagent SessionStart must still be accepted at the HTTP layer");
-
-    let mgr = state.session_manager().await;
-    let record = mgr.get(&managed_id).await.expect("get managed session");
-    assert_eq!(
-        record.claude_session_id.as_deref(),
-        Some(pm_claude_id),
-        "a later SessionStart reporting a DIFFERENT id must never overwrite the \
-         already-correlated PM claude_session_id (#4337)"
-    );
-}
+// `session_start_hook_does_not_overwrite_with_different_id` (the original
+// #4337 fix's test) is superseded by `session_start_hook_still_refuses_a_live_subagent_id`
+// below, which additionally seeds a real transcript fixture so the id is
+// genuinely "live" under the #4337 re-sync gate added in review — a fake id
+// with no on-disk transcript would otherwise read as stale and get accepted.
 
 #[tokio::test]
 async fn session_start_hook_reasserting_same_id_is_a_noop() {
@@ -1736,6 +1696,239 @@ async fn session_start_hook_reasserting_same_id_is_a_noop() {
         record.claude_session_id.as_deref(),
         Some(claude_id),
         "reasserting the SAME claude_session_id must remain a no-op success, not be blocked (#4337)"
+    );
+}
+
+/// RAII guard that redirects `$HOME` to a temp dir and restores it on drop
+/// (including panic) — mirrors `runtime::claude_code_tests::HomeGuard`.
+///
+/// Why (#4337): `stored_id_still_live` (`session_start_correlation.rs`)
+/// resolves the managed `CLAUDE_CONFIG_DIR` via `dirs::home_dir()`. Tests
+/// that need to fabricate a "this id's transcript still exists" fixture must
+/// redirect `$HOME` to a throwaway dir instead of writing under the
+/// developer's real `~/.trusty-tools`. Pair with `#[serial]` since it
+/// mutates process-global env.
+struct HomeGuard {
+    prev: Option<String>,
+    tmp: tempfile::TempDir,
+}
+impl HomeGuard {
+    fn set() -> Self {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let prev = std::env::var("HOME").ok();
+        // SAFETY: callers are #[serial], so no other test thread reads HOME
+        // concurrently; Drop restores the prior value even on panic.
+        unsafe { std::env::set_var("HOME", tmp.path()) };
+        Self { prev, tmp }
+    }
+    fn path(&self) -> &std::path::Path {
+        self.tmp.path()
+    }
+}
+impl Drop for HomeGuard {
+    fn drop(&mut self) {
+        match self.prev {
+            Some(ref p) => unsafe { std::env::set_var("HOME", p) },
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}
+
+/// Seed a fake Claude Code session transcript file so
+/// `runtime::session_id_exists` (and therefore `stored_id_still_live`)
+/// reports `id` as still live for `cwd`, under the `$HOME` a [`HomeGuard`]
+/// redirected.
+///
+/// What: `<home>/.trusty-tools/trusty-mpm/claude-config/projects/<encoded
+/// cwd>/<id>.jsonl`, mirroring `managed_claude_config_dir` +
+/// `encode_project_dir`'s `/` → `-` encoding.
+fn seed_fake_transcript(home: &std::path::Path, cwd: &std::path::Path, id: &str) {
+    let encoded = cwd.to_str().expect("utf8 cwd").replace('/', "-");
+    let dir = home
+        .join(".trusty-tools")
+        .join("trusty-mpm")
+        .join("claude-config")
+        .join("projects")
+        .join(encoded);
+    std::fs::create_dir_all(&dir).expect("create fake projects dir");
+    std::fs::write(dir.join(format!("{id}.jsonl")), "{}").expect("write fake transcript");
+}
+
+#[tokio::test]
+#[serial]
+async fn session_start_hook_still_refuses_a_live_subagent_id() {
+    // Why (#4337, critic finding 2): the subagent-overwrite guard must hold
+    // even with the stale-id re-sync gate in place — a subagent's own
+    // transcript exists and is live for as long as it runs, so its
+    // SessionStart must still be refused, never mistaken for a stale-id
+    // re-sync.
+    let home = HomeGuard::set();
+    let ws = std::path::PathBuf::from("/tmp/test-ws-correlate-live-refused");
+    let (state, managed_id, _) = make_state_with_active_managed(ws.clone()).await;
+
+    let pm_claude_id = "550e8400-e29b-41d4-a716-446655440020";
+    let post = HookPost {
+        session_id: pm_claude_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("PM SessionStart must succeed");
+
+    // Simulate the PM's own transcript actually existing and being LIVE.
+    seed_fake_transcript(home.path(), &ws, pm_claude_id);
+
+    let subagent_claude_id = "550e8400-e29b-41d4-a716-446655440021";
+    let post = HookPost {
+        session_id: subagent_claude_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("subagent SessionStart must still be accepted at the HTTP layer");
+
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&managed_id).await.expect("get managed session");
+    assert_eq!(
+        record.claude_session_id.as_deref(),
+        Some(pm_claude_id),
+        "a subagent's SessionStart must be refused while the PM's own transcript is still \
+         live, even with the #4337 stale-id re-sync gate in place"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn session_start_hook_re_correlates_a_stale_id() {
+    // Why (#4337, critic finding 2): once the stored id's transcript no
+    // longer resolves (pruned, moved, or never made it to disk), a
+    // differently-reported SessionStart must be ACCEPTED, not refused
+    // forever — otherwise a legitimately-diverged id (e.g. a `--continue`
+    // fallback assigning a new UUID) could never self-heal.
+    let _home = HomeGuard::set();
+    let ws = std::path::PathBuf::from("/tmp/test-ws-correlate-stale-resync");
+    let (state, managed_id, _) = make_state_with_active_managed(ws.clone()).await;
+
+    let stale_id = "550e8400-e29b-41d4-a716-446655440030";
+    let post = HookPost {
+        session_id: stale_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("first SessionStart must succeed");
+
+    // No transcript file is ever seeded for `stale_id` under the redirected
+    // $HOME — it never resolves, simulating a pruned/never-flushed session.
+    let new_id = "550e8400-e29b-41d4-a716-446655440031";
+    let post = HookPost {
+        session_id: new_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("second SessionStart must succeed");
+
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&managed_id).await.expect("get managed session");
+    assert_eq!(
+        record.claude_session_id.as_deref(),
+        Some(new_id),
+        "a differently-reported id must be accepted once the stored one no longer \
+         resolves to a live transcript (#4337)"
+    );
+}
+
+#[tokio::test]
+async fn session_end_hook_clears_claude_session_id() {
+    // Why (#4337): SessionEnd is Claude Code's own signal that this
+    // conversation ended — the daemon must clear claude_session_id so a
+    // LATER, unrelated SessionStart is never compared against a dead id
+    // (which the stale-id re-sync gate could otherwise keep refusing forever
+    // if that dead id happened to still resolve on disk).
+    let ws = std::path::PathBuf::from("/tmp/test-ws-session-end-clears-id");
+    let (state, managed_id, _) = make_state_with_active_managed(ws.clone()).await;
+
+    let claude_id = "550e8400-e29b-41d4-a716-446655440040";
+    {
+        let mgr = state.session_manager().await;
+        mgr.set_claude_session_id(&managed_id, claude_id)
+            .await
+            .expect("set claude_session_id");
+    }
+
+    let post = HookPost {
+        session_id: claude_id.to_string(),
+        event: HookEvent::SessionEnd,
+        payload: serde_json::json!({}),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("ingest_hook(SessionEnd) must succeed");
+
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .get(&managed_id)
+        .await
+        .expect("get managed session after SessionEnd");
+    assert_eq!(
+        record.claude_session_id, None,
+        "SessionEnd must clear claude_session_id (#4337)"
+    );
+}
+
+#[tokio::test]
+async fn session_start_hook_ordering_race_self_heals_via_session_end() {
+    // Why (#4337, critic finding 3): if a subagent's SessionStart wins the
+    // race and lands FIRST — the record has no claude_session_id yet, so its
+    // id is (unavoidably) taken as the first correlation — the wrong id must
+    // not stay locked in forever. Once that SAME subagent's own SessionEnd
+    // later fires, the record must self-heal back to `None` (a safe state
+    // that falls back to `--continue` on the next resume), rather than
+    // permanently squatting on a subagent's transcript.
+    let ws = std::path::PathBuf::from("/tmp/test-ws-ordering-race-self-heal");
+    let (state, managed_id, _) = make_state_with_active_managed(ws.clone()).await;
+
+    let subagent_claude_id = "550e8400-e29b-41d4-a716-446655440050";
+    let post = HookPost {
+        session_id: subagent_claude_id.to_string(),
+        event: HookEvent::SessionStart,
+        payload: serde_json::json!({ "cwd": ws.to_str().unwrap() }),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("subagent SessionStart (winning the race) must succeed");
+
+    {
+        let mgr = state.session_manager().await;
+        let record = mgr.get(&managed_id).await.expect("get after race");
+        assert_eq!(
+            record.claude_session_id.as_deref(),
+            Some(subagent_claude_id),
+            "the first correlation for a fresh record is unavoidably whoever wins the race"
+        );
+    }
+
+    // The subagent's own SessionEnd later fires — the record must self-heal.
+    let post = HookPost {
+        session_id: subagent_claude_id.to_string(),
+        event: HookEvent::SessionEnd,
+        payload: serde_json::json!({}),
+    };
+    let _ = ingest_hook(State(Arc::clone(&state)), Json(post))
+        .await
+        .expect("subagent SessionEnd must succeed");
+
+    let mgr = state.session_manager().await;
+    let record = mgr.get(&managed_id).await.expect("get after self-heal");
+    assert_eq!(
+        record.claude_session_id, None,
+        "a race-won wrong id must self-heal to None once its own session ends, not stay \
+         locked in forever (#4337)"
     );
 }
 

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -509,7 +509,13 @@ fn projects_dir_for(config_dir: Option<&Path>) -> Option<std::path::PathBuf> {
 /// Test: `session_id_exists_true_for_real_jsonl_file`,
 /// `session_id_exists_false_for_missing_id`,
 /// `session_id_exists_false_when_projects_dir_absent`.
-fn session_id_exists(cwd: &Path, config_dir: Option<&Path>, id: &str) -> bool {
+///
+/// `pub(crate)` (#4337): the daemon's `SessionStart` correlation
+/// (`daemon::api::session_start_correlation`) reuses this SAME staleness
+/// check to decide whether a managed session's already-stored
+/// `claude_session_id` may be replaced by a differently-reported one, so the
+/// two call sites can never disagree about what "stale" means.
+pub(crate) fn session_id_exists(cwd: &Path, config_dir: Option<&Path>, id: &str) -> bool {
     match projects_dir_for(config_dir) {
         Some(projects_dir) => session_id_exists_in(cwd, &projects_dir, id),
         None => false,

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -19,6 +19,7 @@ mod tcode;
 #[cfg(test)]
 pub(crate) mod test_helpers;
 
+pub(crate) use claude_code::session_id_exists;
 pub use claude_code::{ClaudeCodeAdapter, InPlaceResumeCommand, build_inplace_resume_command};
 pub use tcode::TcodeAdapter;
 

--- a/crates/trusty-mpm/src/session_manager/hook_sync.rs
+++ b/crates/trusty-mpm/src/session_manager/hook_sync.rs
@@ -5,9 +5,16 @@
 //! would breach the cap. Following the same pattern as `adopt.rs` (a sibling
 //! `impl SessionManager` block), this file isolates the one write-path needed
 //! by the hook relay — keeping all other files under their SLOC budgets.
-//! What: one inherent method `SessionManager::set_claude_session_id` — looks
-//! up the record, writes `claude_session_id`, and persists atomically.
-//! Test: `claude_session_id_persists_on_session` in `super::tests`.
+//! What: two inherent methods — `SessionManager::set_claude_session_id` looks
+//! up the record, writes `claude_session_id`, and persists atomically;
+//! `SessionManager::clear_claude_session_id_if` (#4337) clears it again, but
+//! only when the stored value still matches an expected id, so a
+//! `SessionEnd` can safely un-correlate its OWN session without racing a
+//! concurrent, fresher correlation.
+//! Test: `claude_session_id_persists_on_session`,
+//! `clear_claude_session_id_if_clears_on_exact_match`,
+//! `clear_claude_session_id_if_leaves_a_different_id_untouched` in
+//! `super::tests`.
 
 use super::manager::{ManagedError, SessionManager};
 use super::record::ManagedSessionId;
@@ -32,6 +39,37 @@ impl SessionManager {
     ) -> Result<(), ManagedError> {
         let mut r = self.get(id).await?;
         r.claude_session_id = Some(claude_session_id.to_owned());
+        self.store.write().await.upsert(r).await.map_err(Into::into)
+    }
+
+    /// Clear a managed record's `claude_session_id`, but ONLY if it still
+    /// equals `expected` (#4337).
+    ///
+    /// Why: `SessionEnd` is Claude Code's own signal that `expected`'s
+    /// conversation has ended, so the id is guaranteed stale from that point
+    /// on — leaving it in place would let a later `SessionStart` from an
+    /// unrelated process (or a stale resume) be silently compared against a
+    /// dead id forever, permanently blocking re-correlation. Clearing it here
+    /// lets the NEXT `SessionStart` for this record's cwd freely take the
+    /// "no existing id" branch in `daemon::api::session_start_correlation`.
+    /// The exact-match guard prevents clobbering a FRESHER id that a
+    /// concurrent, later `SessionStart` may have already written between the
+    /// caller's own match check and this call.
+    /// What: no-op (`Ok(())`) when the record is missing, already `None`, or
+    /// holds a DIFFERENT id than `expected`. Test:
+    /// `clear_claude_session_id_if_clears_on_exact_match`,
+    /// `clear_claude_session_id_if_leaves_a_different_id_untouched` in
+    /// `super::tests`.
+    pub async fn clear_claude_session_id_if(
+        &self,
+        id: &ManagedSessionId,
+        expected: &str,
+    ) -> Result<(), ManagedError> {
+        let mut r = self.get(id).await?;
+        if r.claude_session_id.as_deref() != Some(expected) {
+            return Ok(());
+        }
+        r.claude_session_id = None;
         self.store.write().await.upsert(r).await.map_err(Into::into)
     }
 }

--- a/crates/trusty-mpm/src/session_manager/reactivate.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate.rs
@@ -63,10 +63,19 @@ impl SessionManager {
     /// when that resolved directory no longer exists on disk, so a corrupted
     /// `Active` ghost record (workspace gone, state says running) can never be
     /// committed to the store.
+    ///
+    /// Also clears `claude_session_id` back to `None` (#4337): a reactivation
+    /// always precedes the client `exec`-ing a fresh `claude` into this SAME
+    /// pane, so the next `SessionStart` is guaranteed to be that pane's own
+    /// new top-level process. Clearing the old id lets that correlation land
+    /// via the plain "no existing id" path in
+    /// `daemon::api::session_start_correlation` instead of relying on the
+    /// narrower stale-transcript re-sync gate.
     /// Test: `mark_reactivated_flips_stopped_to_active`,
     /// `mark_reactivated_flips_decommissioned_to_active`,
     /// `mark_reactivated_rejects_non_stopped`,
-    /// `mark_reactivated_refuses_when_workspace_removed_by_decommission`.
+    /// `mark_reactivated_refuses_when_workspace_removed_by_decommission`,
+    /// `mark_reactivated_clears_stale_claude_session_id`.
     pub async fn mark_reactivated(
         &self,
         id: &ManagedSessionId,
@@ -102,6 +111,14 @@ impl SessionManager {
 
         record.state = ManagedSessionState::Active;
         record.last_activity_at = Some(Utc::now());
+        // #4337: a reactivation always precedes the client `exec`-ing a fresh
+        // `claude` back into this SAME pane, guaranteeing a genuinely NEW
+        // top-level `SessionStart` is imminent. Clearing the old id here
+        // means that `SessionStart`'s correlation lands via the plain
+        // "no existing id" branch instead of needing the (narrower) staleness
+        // re-sync gate — and prevents a lingering pre-reactivation id from
+        // ever being compared against a later, unrelated report.
+        record.claude_session_id = None;
         self.store.write().await.upsert(record.clone()).await?;
         info!(
             id = %id,

--- a/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
@@ -73,6 +73,49 @@ async fn mark_reactivated_flips_stopped_to_active() {
     assert_eq!(after.state, ManagedSessionState::Active);
 }
 
+/// `mark_reactivated` must clear a lingering `claude_session_id` (#4337).
+///
+/// Why: a reactivation always precedes the client `exec`-ing a fresh `claude`
+/// back into this SAME pane, so the id captured before the pane went idle is
+/// guaranteed to belong to a conversation that already ended. Leaving it in
+/// place would let the daemon's `SessionStart` correlation compare the
+/// pane's brand-new top-level session against a dead id under the (narrower)
+/// stale-transcript re-sync gate instead of taking the plain "no existing
+/// id" path.
+/// What: creates a session, stops it, sets `claude_session_id`, reactivates,
+/// and asserts the reloaded record's id is `None`.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn mark_reactivated_clears_stale_claude_session_id() {
+    let dir = TempDir::new().unwrap();
+    let workspace_dir = TempDir::new().unwrap();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(workspace_dir.path().to_owned()),
+            None,
+            Some(workspace_dir.path().to_owned()),
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    mgr.set_claude_session_id(&record.id, "uuid-pre-reactivate")
+        .await
+        .expect("set_claude_session_id");
+    mgr.stop(&record.id).await.expect("stop");
+
+    mgr.mark_reactivated(&record.id).await.expect("reactivate");
+
+    let after = mgr.get(&record.id).await.unwrap();
+    assert_eq!(
+        after.claude_session_id, None,
+        "mark_reactivated must clear claude_session_id (#4337)"
+    );
+}
+
 /// `mark_reactivated` must also flip a `Decommissioned` record back to `Active`
 /// IN PLACE, with no tmux mutation (#2777).
 ///

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -2294,3 +2294,71 @@ async fn claude_session_id_persists_on_session() {
         "claude_session_id must survive a store reload (#1744)"
     );
 }
+
+#[tokio::test]
+async fn clear_claude_session_id_if_clears_on_exact_match() {
+    // Why (#4337): SessionEnd must be able to un-correlate its OWN ended
+    // session so the NEXT SessionStart can freely re-correlate, instead of a
+    // stale id blocking re-correlation forever.
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/wt")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    mgr.set_claude_session_id(&record.id, "uuid-abc-123")
+        .await
+        .expect("set_claude_session_id");
+
+    mgr.clear_claude_session_id_if(&record.id, "uuid-abc-123")
+        .await
+        .expect("clear_claude_session_id_if");
+
+    let reloaded = mgr.get(&record.id).await.expect("get after clear");
+    assert_eq!(
+        reloaded.claude_session_id, None,
+        "an exact-match clear must remove claude_session_id (#4337)"
+    );
+}
+
+#[tokio::test]
+async fn clear_claude_session_id_if_leaves_a_different_id_untouched() {
+    // Why (#4337): a SessionEnd for an id that is NO LONGER the stored one
+    // (a fresher SessionStart already overwrote it) must never clobber the
+    // fresher value — the exact-match guard is the whole point.
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+    let record = mgr
+        .create(
+            "task".into(),
+            Some(PathBuf::from("/tmp/wt")),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("create");
+    mgr.set_claude_session_id(&record.id, "uuid-current")
+        .await
+        .expect("set_claude_session_id");
+
+    // A stale/unrelated id no longer matches the stored one — must be a no-op.
+    mgr.clear_claude_session_id_if(&record.id, "uuid-stale")
+        .await
+        .expect("clear_claude_session_id_if");
+
+    let reloaded = mgr.get(&record.id).await.expect("get after no-op clear");
+    assert_eq!(
+        reloaded.claude_session_id.as_deref(),
+        Some("uuid-current"),
+        "clearing with a non-matching expected id must leave the stored id untouched (#4337)"
+    );
+}


### PR DESCRIPTION
## Summary

- The daemon's `correlate_session_start` (`crates/trusty-mpm/src/daemon/api.rs`) matched an incoming `SessionStart` hook to a managed session purely by cwd. A subagent sharing the PM's cwd is its own top-level Claude Code process and fires its own `SessionStart`, which matched the PM's sole Active managed session and silently overwrote the PM's own `claude_session_id` with the subagent's — the next in-place `--resume` would then resume the subagent's transcript instead of the PM's conversation. Observed live: managed session `2eb72dca-...` carrying subagent session id `2d4df8a7-...`.
- Fix: only the FIRST correlation for a record is now trusted. A later `SessionStart` reporting a DIFFERENT id for the same cwd is refused and logged (likely a subagent); re-reporting the SAME id (a legitimate `--resume` relaunch, which preserves the Claude Code session UUID) remains a no-op success. The resume path already falls back to `--continue` via its own `session_id_exists` check when a stored id goes stale, so refusing an overwrite trades a possibly-stale id for never resuming the wrong transcript.
- Added two regression tests in `daemon/api_tests.rs`: `session_start_hook_does_not_overwrite_with_different_id` (reproduces the reported defect) and `session_start_hook_reasserting_same_id_is_a_noop` (proves the legitimate relaunch case still works).

## Root cause

`crates/trusty-mpm/src/daemon/api.rs`, `correlate_session_start` (~line 1342, the `matched.len() == 1` arm): it called `mgr.set_claude_session_id(&id, claude_session_id)` unconditionally on every `SessionStart` matching a record's cwd, with no check for whether the record already had a *different* id set.

## Test plan

- [x] `cargo fmt --check -p trusty-mpm`
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- [x] `cargo test -p trusty-mpm` (full suite, lib + all integration binaries) — 0 failures
- [x] New tests pass: `daemon::api::tests::session_start_hook_does_not_overwrite_with_different_id`, `daemon::api::tests::session_start_hook_reasserting_same_id_is_a_noop`

Closes #4337

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools