### PR TITLE
fix(trusty-mpm): keep the PM persona on in-place relaunch and test the exec seam

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -220,6 +220,26 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- The bare-`tm` in-place relaunch keeps the PM persona
+  ([#4336](https://github.com/bobmatnyc/trusty-tools/issues/4336)).
+  `compose_inplace_args` omitted `--append-system-prompt-file` by design, so the
+  one launch path that `exec`s `claude` directly — instead of sending a command
+  string to a tmux pane — restored the operator into vanilla Claude Code. It now
+  builds the prompt through the same `build_prompt_file` carrier `spawn` and
+  `spawn_resume` use (#2125, #2230), pushing the path as its own argv token
+  rather than through `prompt_file_flag`'s shell quoting, which would embed
+  literal quotes in a filename no shell is present to strip.
+- The argv and environment handed to that `exec` are now under test. The
+  `std::process::Command` construction moved out of `run_inplace_relaunch` into
+  a pure `build_inplace_exec_command`, leaving `exec` as a one-line untestable
+  tail. Previously the last step before process replacement — the step that
+  decides whether `--setting-sources project,local` and
+  `--dangerously-skip-permissions` reach `claude` at all — was the only launch
+  step in the codebase with no coverage, which is why #4336 could be reported
+  and not refuted from the suite. Guarded by
+  `inplace_exec_command_forwards_every_arg_in_order`,
+  `inplace_exec_command_scrubs_api_key_and_sets_auth_env`, and
+  `inplace_exec_command_carries_isolation_flags_and_persona_end_to_end`.
 - The per-project worktree opt-out is no longer silently conditional on the
   daemon being up ([#4300](https://github.com/bobmatnyc/trusty-tools/issues/4300)).
   `Project.worktree: false` ([#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455),

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -605,9 +605,9 @@ pub(crate) async fn run_inplace_relaunch(
 /// the tmux-pane spawn/resume paths so an in-place relaunch does not silently
 /// drop back into the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop the token
 /// exists to bypass. Pure — builds and returns, never spawns.
-/// Test: `inplace_exec_command_carries_isolation_flags`,
-/// `inplace_exec_command_carries_prompt_file_and_resume_selection`,
-/// `inplace_exec_command_scrubs_api_key_and_sets_config_dir`.
+/// Test: `inplace_exec_command_forwards_every_arg_in_order`,
+/// `inplace_exec_command_scrubs_api_key_and_sets_auth_env`,
+/// `inplace_exec_command_carries_isolation_flags_and_persona_end_to_end`.
 pub(crate) fn build_inplace_exec_command(
     resume: &trusty_mpm::runtime::InPlaceResumeCommand,
     cwd: &std::path::Path,

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -490,7 +490,9 @@ pub(crate) enum InPlaceOutcome {
 /// rather than proceeding; (5) execs `claude` in place.
 /// Test: `run_inplace_relaunch_never_reactivates_when_command_build_fails`,
 /// `run_inplace_relaunch_falls_through_on_gutted_worktree`,
-/// `run_inplace_relaunch_serves_live_linked_worktree`. The exec itself is not
+/// `run_inplace_relaunch_serves_live_linked_worktree`. The argv/environment the
+/// final step hands to `exec` is pinned by [`build_inplace_exec_command`]'s own
+/// tests (#4336). The exec CALL itself is still not
 /// unit-tested (it replaces the process image); the gate-2a tests pin the
 /// decision by asserting the daemon mock records ZERO hits, which is only true
 /// when the fall-through happened before any daemon mutation. The FSM invariant
@@ -578,22 +580,49 @@ pub(crate) async fn run_inplace_relaunch(
         return InPlaceOutcome::FallThrough;
     }
 
+    InPlaceOutcome::Result(exec_claude_in_place(build_inplace_exec_command(
+        &resume, &cwd,
+    )))
+}
+
+/// Assemble the [`std::process::Command`] the in-place relaunch execs — the
+/// pure, inspectable half of the exec seam (#4336).
+///
+/// Why: this construction used to be inlined immediately before
+/// [`exec_claude_in_place`], which is unavoidably untestable (it replaces the
+/// process image). That made the LAST step before `exec` — the one that decides
+/// what argv and environment `claude` actually receives — the only launch step
+/// in the codebase with no coverage at all, which is precisely why #4336 could
+/// be reported as "the in-place relaunch execs `claude` with zero args" and not
+/// be refutable from the test suite. Splitting the construction out leaves
+/// `exec` as a one-line untestable tail and puts everything that carries the
+/// isolation flags, the PM persona, and the auth environment under assertion.
+/// What: `Command` for `resume.claude_bin` with `resume.args` (the
+/// `compose_inplace_args` argv — `--append-system-prompt-file`, the isolation
+/// flags, and the resume/continue selection), rooted at `cwd`, with
+/// `ANTHROPIC_API_KEY` scrubbed and `CLAUDE_CONFIG_DIR` /
+/// `CLAUDE_CODE_OAUTH_TOKEN` set when resolved. Issue #2246: the token mirrors
+/// the tmux-pane spawn/resume paths so an in-place relaunch does not silently
+/// drop back into the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop the token
+/// exists to bypass. Pure — builds and returns, never spawns.
+/// Test: `inplace_exec_command_carries_isolation_flags`,
+/// `inplace_exec_command_carries_prompt_file_and_resume_selection`,
+/// `inplace_exec_command_scrubs_api_key_and_sets_config_dir`.
+pub(crate) fn build_inplace_exec_command(
+    resume: &trusty_mpm::runtime::InPlaceResumeCommand,
+    cwd: &std::path::Path,
+) -> std::process::Command {
     let mut cmd = std::process::Command::new(&resume.claude_bin);
     cmd.args(&resume.args)
-        .current_dir(&cwd)
+        .current_dir(cwd)
         .env_remove("ANTHROPIC_API_KEY");
     if let Some(dir) = &resume.config_dir {
         cmd.env("CLAUDE_CONFIG_DIR", dir);
     }
-    // Issue #2246: mirror the tmux-pane spawn/resume paths — inject the
-    // resolved CLAUDE_CODE_OAUTH_TOKEN (when available) so an in-place
-    // relaunch does not silently drop back into the CLAUDE_CONFIG_DIR-keyed
-    // Keychain login loop the token exists to bypass.
     if let Some(token) = &resume.oauth_token {
         cmd.env(trusty_mpm::core::oauth_token::OAUTH_TOKEN_ENV_VAR, token);
     }
-
-    InPlaceOutcome::Result(exec_claude_in_place(cmd))
+    cmd
 }
 
 /// Top-level entry point: try the in-place relaunch before any other bare-`tm`

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -667,3 +667,141 @@ async fn run_inplace_relaunch_never_reactivates_when_command_build_fails() {
         "reactivate must NEVER be called when command resolution fails first (#2027)"
     );
 }
+
+// ── #4336: the exec seam's argv/environment ───────────────────────────────
+
+/// Build a synthetic [`trusty_mpm::runtime::InPlaceResumeCommand`] so the
+/// exec-seam assertions below run on every machine.
+///
+/// Why: `build_inplace_resume_command` needs a real `claude` install, so a
+/// test built only on top of it is skipped on CI — exactly the coverage hole
+/// #4336 was reported into. Hand-constructing the struct pins
+/// [`build_inplace_exec_command`]'s own contract (does it forward EVERY arg,
+/// the cwd, and the env?) unconditionally.
+/// What: a fixed binary path plus `args`, with a config dir and oauth token.
+/// Test: used by the `inplace_exec_command_*` cases below.
+fn synthetic_resume(args: &[&str]) -> trusty_mpm::runtime::InPlaceResumeCommand {
+    trusty_mpm::runtime::InPlaceResumeCommand {
+        claude_bin: "/fake/bin/claude".to_owned(),
+        args: args.iter().map(|s| (*s).to_owned()).collect(),
+        config_dir: Some(std::path::PathBuf::from("/fake/config")),
+        oauth_token: Some("sk-ant-oat01-fake".to_owned()),
+    }
+}
+
+#[test]
+fn inplace_exec_command_forwards_every_arg_in_order() {
+    // #4336 core regression: the Command handed to `exec` must carry the
+    // composed argv VERBATIM. An empty (or truncated) `get_args()` here is
+    // precisely the reported "execs claude with zero args" defect.
+    let resume = synthetic_resume(&[
+        "--setting-sources",
+        "project,local",
+        "--dangerously-skip-permissions",
+        "--continue",
+    ]);
+    let cmd = build_inplace_exec_command(&resume, std::path::Path::new("/fake/cwd"));
+
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+    assert_eq!(
+        args,
+        vec![
+            "--setting-sources",
+            "project,local",
+            "--dangerously-skip-permissions",
+            "--continue"
+        ],
+        "the exec seam must forward the composed argv verbatim and in order"
+    );
+    assert_eq!(
+        cmd.get_program().to_string_lossy(),
+        "/fake/bin/claude",
+        "the resolved claude binary must be the exec target"
+    );
+    assert_eq!(
+        cmd.get_current_dir(),
+        Some(std::path::Path::new("/fake/cwd")),
+        "the relaunch must be rooted at the record's workspace"
+    );
+}
+
+#[test]
+fn inplace_exec_command_scrubs_api_key_and_sets_auth_env() {
+    // The env invariants `env_bin_prefix` encodes for the shell-string paths
+    // must hold identically on the exec path (DOC-34 + #2246).
+    let resume = synthetic_resume(&["--dangerously-skip-permissions"]);
+    let cmd = build_inplace_exec_command(&resume, std::path::Path::new("/fake/cwd"));
+
+    let envs: Vec<(String, Option<String>)> = cmd
+        .get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().into_owned(),
+                v.map(|v| v.to_string_lossy().into_owned()),
+            )
+        })
+        .collect();
+
+    assert!(
+        envs.contains(&("ANTHROPIC_API_KEY".to_owned(), None)),
+        "ANTHROPIC_API_KEY must be REMOVED (None) for the relaunched claude: {envs:?}"
+    );
+    assert!(
+        envs.contains(&(
+            "CLAUDE_CONFIG_DIR".to_owned(),
+            Some("/fake/config".to_owned())
+        )),
+        "the tm-owned CLAUDE_CONFIG_DIR must be injected: {envs:?}"
+    );
+    assert!(
+        envs.iter().any(
+            |(k, v)| k == trusty_mpm::core::oauth_token::OAUTH_TOKEN_ENV_VAR
+                && v.as_deref() == Some("sk-ant-oat01-fake")
+        ),
+        "#2246: the resolved oauth token must be injected: {envs:?}"
+    );
+}
+
+#[serial_test::serial]
+#[test]
+fn inplace_exec_command_carries_isolation_flags_and_persona_end_to_end() {
+    // #4336 end-to-end: composed through the REAL builder (not a synthetic
+    // struct), the argv that reaches `exec` must carry both isolation flags
+    // AND the PM system prompt. Before this fix `--append-system-prompt-file`
+    // was omitted by design, so an in-place relaunch restored the operator
+    // into vanilla Claude Code. Requires a real `claude` install; skip
+    // otherwise, matching this file's established convention.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let Ok(resume) = trusty_mpm::runtime::build_inplace_resume_command(tmp.path(), None) else {
+        return;
+    };
+    let cmd = build_inplace_exec_command(&resume, tmp.path());
+    let args: Vec<String> = cmd
+        .get_args()
+        .map(|a| a.to_string_lossy().into_owned())
+        .collect();
+
+    assert!(
+        args.windows(2)
+            .any(|w| w == ["--setting-sources", "project,local"]),
+        "--setting-sources project,local must survive to exec (#1269): {args:?}"
+    );
+    assert!(
+        args.iter().any(|a| a == "--dangerously-skip-permissions"),
+        "--dangerously-skip-permissions must survive to exec (#1269): {args:?}"
+    );
+    let prompt_idx = args
+        .iter()
+        .position(|a| a == "--append-system-prompt-file")
+        .expect("in-place relaunch must carry the PM system prompt (#4336)");
+    let prompt_path = args
+        .get(prompt_idx + 1)
+        .expect("--append-system-prompt-file must be followed by a path");
+    assert!(
+        std::path::Path::new(prompt_path).is_file(),
+        "the prompt-file argv token must name a readable file, unquoted: {prompt_path}"
+    );
+}

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -766,28 +766,50 @@ pub struct InPlaceResumeCommand {
 /// keeps the decision itself testable in every CI environment — mirroring how
 /// [`resume_command`]'s selection tests pass a fake `claude_bin` string rather
 /// than depending on [`ClaudeCodeAdapter::resolve_claude`].
-/// What: the isolation flags ([`crate::core::model_inject::SETTING_SOURCES_FLAG`]
-/// / [`crate::core::model_inject::PERMISSION_MODE_FLAG`], whitespace-split
+/// What: `--append-system-prompt-file <path>` when `prompt_file` is `Some`
+/// (#4336 — see below), then the isolation flags
+/// ([`crate::core::model_inject::SETTING_SOURCES_FLAG`] /
+/// [`crate::core::model_inject::PERMISSION_MODE_FLAG`], whitespace-split
 /// into argv tokens since both constants are simple space-separated flags with
 /// no embedded quoting) followed by `--resume <id>` (id exists under
 /// `config_dir`, per [`session_id_exists`]), `--continue` (no usable id but
 /// [`has_prior_conversation`] is true), or neither (fresh start) — the exact
 /// same three-way selection [`resume_command`] makes.
+///
+/// `prompt_file` (#4336): this path previously omitted the PM system prompt BY
+/// DESIGN, so an in-place relaunch silently restored the operator into vanilla
+/// Claude Code — the same defect #2125/#2230 fixed for the spawn and resume
+/// paths, left unfixed here because the exec seam is not a shell string. The
+/// path is pushed as its OWN argv token and is deliberately NOT run through
+/// [`shell_single_quote`] the way [`prompt_file_flag`] does: that helper exists
+/// because `spawn_command`/`resume_command` build a string a pane SHELL will
+/// re-split, whereas these tokens go straight to `execv` with no shell in
+/// between, so quoting them would embed literal quote characters in the
+/// filename claude then fails to open.
 /// Test: `compose_inplace_args_uses_resume_for_existing_id`,
 /// `compose_inplace_args_falls_back_for_missing_id`,
-/// `compose_inplace_args_uses_continue_when_no_id_but_prior_conv`.
+/// `compose_inplace_args_uses_continue_when_no_id_but_prior_conv`,
+/// `compose_inplace_args_carries_prompt_file_unquoted`,
+/// `compose_inplace_args_omits_prompt_flag_when_absent`.
 fn compose_inplace_args(
     cwd: &Path,
     config_dir: Option<&Path>,
     claude_session_id: Option<&str>,
+    prompt_file: Option<&Path>,
 ) -> Vec<String> {
     let effective_id = claude_session_id.filter(|id| session_id_exists(cwd, config_dir, id));
 
-    let mut args: Vec<String> = crate::core::model_inject::SETTING_SOURCES_FLAG
-        .split_whitespace()
-        .chain(crate::core::model_inject::PERMISSION_MODE_FLAG.split_whitespace())
-        .map(str::to_owned)
-        .collect();
+    let mut args: Vec<String> = Vec::new();
+    if let Some(prompt) = prompt_file {
+        args.push("--append-system-prompt-file".to_owned());
+        args.push(prompt.display().to_string());
+    }
+    args.extend(
+        crate::core::model_inject::SETTING_SOURCES_FLAG
+            .split_whitespace()
+            .chain(crate::core::model_inject::PERMISSION_MODE_FLAG.split_whitespace())
+            .map(str::to_owned),
+    );
 
     match effective_id {
         Some(id) => {
@@ -813,8 +835,12 @@ fn compose_inplace_args(
 /// missing), provisions/trust-seeds the managed `CLAUDE_CONFIG_DIR` via
 /// [`prepare_managed_config`] (logged under the synthetic session name
 /// `"in-place-relaunch"` — there is no tmux session name in this context),
-/// then delegates argv composition to [`compose_inplace_args`].
-/// Test: `build_inplace_resume_command_resolves_claude_binary`.
+/// builds the PM system-prompt file via [`build_prompt_file`] (#4336 — the
+/// SAME carrier `spawn`/`spawn_resume` use, previously missing from this path
+/// alone; non-fatal, a write failure omits the flag), then delegates argv
+/// composition to [`compose_inplace_args`].
+/// Test: `build_inplace_resume_command_resolves_claude_binary`,
+/// `build_inplace_resume_command_carries_prompt_file`.
 pub fn build_inplace_resume_command(
     cwd: &Path,
     claude_session_id: Option<&str>,
@@ -827,7 +853,13 @@ pub fn build_inplace_resume_command(
         )
     })?;
     let config_dir = prepare_managed_config("in-place-relaunch", cwd);
-    let args = compose_inplace_args(cwd, config_dir.as_deref(), claude_session_id);
+    let prompt_file = build_prompt_file(cwd);
+    let args = compose_inplace_args(
+        cwd,
+        config_dir.as_deref(),
+        claude_session_id,
+        prompt_file.as_deref(),
+    );
     let oauth_token = crate::core::oauth_token::resolve_oauth_token();
     Ok(InPlaceResumeCommand {
         claude_bin,

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -1480,7 +1480,7 @@ fn compose_inplace_args_uses_resume_for_existing_id() {
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(project_dir.join("existing-id.jsonl"), "{}").unwrap();
 
-    let args = compose_inplace_args(&cwd, Some(&config_dir), Some("existing-id"));
+    let args = compose_inplace_args(&cwd, Some(&config_dir), Some("existing-id"), None);
     assert!(
         args.windows(2).any(|w| w == ["--resume", "existing-id"]),
         "must select --resume <id> for an id that exists on disk: {args:?}"
@@ -1501,7 +1501,7 @@ fn compose_inplace_args_falls_back_for_missing_id() {
     std::fs::create_dir_all(&cwd).unwrap();
     let config_dir = tmp.path().join("config");
 
-    let args = compose_inplace_args(&cwd, Some(&config_dir), Some("stale-id"));
+    let args = compose_inplace_args(&cwd, Some(&config_dir), Some("stale-id"), None);
     assert!(
         !args.contains(&"--resume".to_owned()),
         "a stale id must not be passed to --resume: {args:?}"
@@ -1534,7 +1534,7 @@ fn compose_inplace_args_uses_continue_when_no_id_but_prior_conv() {
     std::fs::create_dir_all(&project_dir).unwrap();
     std::fs::write(project_dir.join("some-other-session.jsonl"), "{}").unwrap();
 
-    let args = compose_inplace_args(&cwd, None, Some("stale-id"));
+    let args = compose_inplace_args(&cwd, None, Some("stale-id"), None);
     assert!(
         !args.contains(&"--resume".to_owned()),
         "a stale id must not be passed to --resume: {args:?}"
@@ -1542,6 +1542,80 @@ fn compose_inplace_args_uses_continue_when_no_id_but_prior_conv() {
     assert!(
         args.contains(&"--continue".to_owned()),
         "prior conversation history exists: must fall back to --continue: {args:?}"
+    );
+}
+
+#[test]
+fn compose_inplace_args_carries_prompt_file_unquoted() {
+    // #4336: the in-place relaunch execs claude directly — no shell splits
+    // this argv — so the prompt path must be its OWN token and must NOT be
+    // shell-quoted the way `prompt_file_flag` quotes it for the pane-string
+    // paths. A path with a space is the case that would break if the quoting
+    // helper were reused here.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().join("workspace-prompt");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let prompt = tmp.path().join("system prompt.txt");
+    std::fs::write(&prompt, "PM").unwrap();
+
+    let args = compose_inplace_args(&cwd, None, None, Some(&prompt));
+
+    let idx = args
+        .iter()
+        .position(|a| a == "--append-system-prompt-file")
+        .expect("prompt flag must be present");
+    assert_eq!(
+        args[idx + 1],
+        prompt.display().to_string(),
+        "the path must be a single, UNQUOTED argv token: {args:?}"
+    );
+    assert!(
+        !args[idx + 1].contains('\''),
+        "shell quoting must not leak into an execv argv token: {args:?}"
+    );
+    assert!(
+        args.contains(&"--dangerously-skip-permissions".to_owned()),
+        "the isolation flags must still follow the prompt file: {args:?}"
+    );
+}
+
+#[test]
+fn compose_inplace_args_omits_prompt_flag_when_absent() {
+    // A prompt-file write failure is non-fatal: the flag is omitted rather
+    // than passed with an empty path (which claude would fail to open).
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let args = compose_inplace_args(tmp.path(), None, None, None);
+    assert!(
+        !args.contains(&"--append-system-prompt-file".to_owned()),
+        "no prompt file → no flag: {args:?}"
+    );
+    assert!(
+        args.contains(&"--setting-sources".to_owned()),
+        "isolation flags are unconditional: {args:?}"
+    );
+}
+
+#[serial_test::serial]
+#[test]
+fn build_inplace_resume_command_carries_prompt_file() {
+    // #4336: the PM persona must reach the in-place relaunch through the same
+    // `build_prompt_file` carrier `spawn`/`spawn_resume` use. Requires a real
+    // claude install (resolve_claude gates the builder); skip otherwise.
+    let _home = HomeGuard::set();
+    if ClaudeCodeAdapter::resolve_claude().is_none() {
+        return;
+    }
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let result = build_inplace_resume_command(tmp.path(), None).expect("build succeeds");
+    let idx = result
+        .args
+        .iter()
+        .position(|a| a == "--append-system-prompt-file")
+        .expect("in-place relaunch must carry the PM system prompt");
+    assert!(
+        std::path::Path::new(&result.args[idx + 1]).is_file(),
+        "the prompt token must name a written file: {:?}",
+        result.args
     );
 }
 


### PR DESCRIPTION
Closes #4336

## What the trace found

The reported mechanism — "`run_inplace_relaunch` execs claude with ZERO args" —
**is not reachable from this code.** `compose_inplace_args` cannot return empty
(both flag constants are non-empty literals prepended unconditionally), and it
has looked exactly like that since it was introduced in dba21950 (#2027), which
added the exec path and the flags in the same commit. Nothing between the
working and broken observations touched it: the only commits after 2026-07-27
against `guided_inplace.rs` / `claude_code.rs` / `model_inject.rs` are #4209 and
#4205, neither of which goes near the argv.

Live `ps -Eww` on the reporting machine confirms the flags survive the exec
seam. Three concurrent in-place relaunches, each with the signature of this path
(absolute `resolve_claude` binary, tm-owned `CLAUDE_CONFIG_DIR`, cwd = the
managed workspace):

```
21504  /Users/masa/.local/bin/claude --setting-sources project,local --dangerously-skip-permissions
93512  /Users/masa/.local/bin/claude --setting-sources project,local --dangerously-skip-permissions
70700  /Users/masa/.local/bin/claude --setting-sources project,local --dangerously-skip-permissions
```

That argv is byte-for-byte `compose_inplace_args`' output for the no-resume
case. The one bare `/Users/masa/.local/bin/claude` (PID 10166) differs from
those three in exactly one way: `CLAUDECODE=1` is present in its **exec-time**
environment, so it was exec'd from inside a Claude Code session rather than by
a `tm` invoked from the pane shell. No `tm` code path produces it — the other
two spawners build shell strings that also always carry the flags, and the only
other `Command::new` for claude (`internal-spawn-disclaimed`) forwards argv
verbatim and would appear as its own parent process. The likeliest remaining
producer is Claude Code's own `/exit`-background re-exec of `process.execPath`,
which is also the premise of #4335 and would explain the
`bypassPermissions` → `default` transcript evidence.

**So this PR does not "restore" dropped flags — nothing was dropping them.** It
fixes the defect that IS real in this path and closes the coverage hole that
made the report irrefutable.

## What is actually fixed

**1. The PM persona was genuinely dropped.** `compose_inplace_args` omitted
`--append-system-prompt-file` by design, so an in-place relaunch restored the
operator into vanilla Claude Code — the same defect #2125/#2230 fixed for spawn
and resume, left standing here. Visible in the same `ps` sweep: the spawn-path
process carries the prompt file, the in-place ones do not. It now sources the
prompt through the same `build_prompt_file` carrier, pushing the path as its own
argv token rather than through `prompt_file_flag`'s shell quoting — no shell
splits this argv, so quoting would embed literal quotes in the filename.

**2. The exec seam had no coverage.** `guided_inplace.rs:487` said so outright.
The `Command` construction moved out of `run_inplace_relaunch` into a pure
`build_inplace_exec_command`, leaving `exec` as a one-line untestable tail. The
step that decides what argv and environment `claude` receives is now asserted:

- `inplace_exec_command_forwards_every_arg_in_order` — argv verbatim, in order,
  plus program and cwd. An empty `get_args()` here is the reported defect.
- `inplace_exec_command_scrubs_api_key_and_sets_auth_env` — `ANTHROPIC_API_KEY`
  removed, `CLAUDE_CONFIG_DIR` + `CLAUDE_CODE_OAUTH_TOKEN` set (DOC-34, #2246).
- `inplace_exec_command_carries_isolation_flags_and_persona_end_to_end` — both
  flags AND a readable prompt file, composed through the real builder.
- `compose_inplace_args_carries_prompt_file_unquoted` — a path with a space
  stays one unquoted token.

`build_inplace_resume_command_carries_prompt_file` verified by mutation:
forcing `prompt_file` to `None` makes it FAIL.

## Quality gate

```
cargo fmt --check exit: 0

cargo clippy -p trusty-mpm --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 33.21s

cargo test -p trusty-mpm     (full suite, not --lib)   exit: 0
test result: ok. 3947 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 22.09s
test result: ok. 1287 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.64s
test result: ok. 1287 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 3.92s
(44 `test result: ok` lines total; zero FAILED, zero panics)

scripts/check_line_cap.sh: line-cap: 7 allowlisted, 0 violations — OK.
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
