### PR TITLE
fix(trusty-mpm): make the nested-session guard survive a cold daemon

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -220,6 +220,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Bare `tm` no longer needs two runs after Claude Code backgrounds
+  ([#4335](https://github.com/bobmatnyc/trusty-tools/issues/4335)).
+  `nested_session_guard` fetched the managed-session list with a 2-second
+  timeout and a bare `.ok()?`. On a cold daemon the per-session `stale_assets`
+  pass over a large fleet exceeded that bound, the request was cancelled, and
+  the guard no-opped with nothing in any log to say it had not run — so bare
+  `tm` after an `/exit` (which BACKGROUNDS, never firing `SessionEnd`, leaving
+  the record `active` so the stopped-only gate correctly skips) fell through to
+  the picker and dead-ended on the #2678 switch-client refusal. A second run,
+  against a now-warm daemon, worked. Three changes, smallest lever first:
+  the managed-list endpoint takes `?slim=true` (folds into
+  [#4322](https://github.com/bobmatnyc/trusty-tools/issues/4322)) to skip the
+  `stale_assets` probe for callers that never read the flag — the guard reads
+  name/pane_id/state/id and was paying for a filesystem-bound catalog compose
+  it discards; the guard's timeout goes 2s → 8s, still bounding a hung daemon
+  while clearing a cold-start listing; and the error arm is logged at debug via
+  the new `guard_managed_sessions`. Absent or malformed `slim` keeps the full
+  probe, so no existing client changes shape. The stopped-only gate in
+  `plan_inplace` is deliberately unchanged.
 - The per-project worktree opt-out is no longer silently conditional on the
   daemon being up ([#4300](https://github.com/bobmatnyc/trusty-tools/issues/4300)).
   `Project.worktree: false` ([#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455),

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -432,11 +432,18 @@ pub(crate) fn derive_project(
 /// What: short-circuits to `None` when not inside tmux (nothing to guard
 /// against) or when the daemon is unreachable/errors (fail-open — matches
 /// every other daemon round-trip in this file, which falls through to the
-/// picker/autostart rather than blocking on a down daemon). Uses a 2-second
-/// timeout, matching the `guided_inplace` probe convention.
+/// picker/autostart rather than blocking on a down daemon). The fetch goes
+/// through [`guard_managed_sessions`], which (#4335) asks for the SLIM listing
+/// — the guard never reads `stale_assets` — allows 8 seconds rather than 2,
+/// and LOGS the failure arm instead of discarding it. Before that, a cold
+/// daemon's per-session staleness pass regularly blew the 2s bound and the
+/// guard silently no-opped, so bare `tm` after a backgrounded Claude Code fell
+/// to the picker and dead-ended on the #2678 refusal until a second run.
 /// Test: the pure decision is `nested_managed_match_*` in
-/// `tests_behavior_c_tests.rs`; this I/O wrapper is exercised by manual smoke
-/// tests and the e2e suite (requires a live daemon + tmux).
+/// `tests_behavior_c_tests.rs`; the fail-open arm is
+/// `guard_managed_sessions_returns_none_when_the_list_call_errors`; the rest of
+/// this I/O wrapper is exercised by manual smoke tests and the e2e suite
+/// (requires a live daemon + tmux).
 async fn nested_session_guard(
     client: &reqwest::Client,
     url: &str,
@@ -452,7 +459,8 @@ async fn nested_session_guard(
     // check) so it can also break a duplicate-name tie in `nested_managed_match`
     // itself — see that function's doc.
     let current_pane_id = super::tmux_attach::current_tmux_pane_id();
-    let all = list_all_managed_sessions(client, url).await.ok()?;
+    // #4335: fail-open, but LOUDLY — see `guard_managed_sessions`.
+    let all = guard_managed_sessions(client, url).await?;
     nested_managed_match(
         current_session_name.as_deref(),
         env_session_id.as_deref(),
@@ -592,22 +600,72 @@ pub(crate) fn inplace_self_relaunch_hint(
 /// Why: [`nested_session_guard`] must find a match even when the record's
 /// `source_id` is missing (#2157 item 5's failure mode), so it cannot reuse the
 /// source_id-filtered picker fetch ([`super::session_picker::fetch_live_sessions`]).
-/// What: GETs the managed-list endpoint with no `?source_id=` query and a
-/// 2-second timeout so a hung daemon cannot add a long stall to every bare
-/// `tm` invocation made from inside tmux.
-/// Test: I/O path; requires a live daemon.
+/// What: GETs the managed-list endpoint with no `?source_id=` query, with
+/// `?slim=true` and an 8-second timeout (#4335 — both explained below).
+///
+/// `?slim=true` (#4335, folds into #4322): the guard reads `name`, `pane_id`,
+/// `state`, and `id` — never `stale_assets`. That flag is the most expensive
+/// thing the endpoint computes (a filesystem-bound catalog compose plus a
+/// per-session manifest/on-disk comparison), so the guard was paying for a
+/// field it discards. Opting out is the actual fix; the timeout below is the
+/// belt to its braces.
+///
+/// The timeout is 8s, not the 2s this shared the `guided_inplace` probe
+/// convention with. On a COLD daemon the per-session `stale_assets` pass over
+/// a large fleet exceeded 2s, the request was cancelled, and the guard's
+/// `.ok()?` swallowed it without a single log line — so bare `tm` after a
+/// backgrounded Claude Code fell through to the picker and dead-ended on the
+/// #2678 switch-client refusal, while a second invocation (warm daemon) worked.
+/// A guard that silently stops guarding is worse than a slow one: the 2s bound
+/// existed to keep a HUNG daemon from stalling bare `tm`, and 8s still bounds
+/// that while clearing a cold-start listing.
+/// Test: I/O path; the fail-open decision is
+/// `guard_managed_sessions_returns_none_when_the_list_call_errors`.
 async fn list_all_managed_sessions(
     client: &reqwest::Client,
     url: &str,
 ) -> anyhow::Result<Vec<trusty_mpm::client::ManagedSessionSummary>> {
     let resp = client
-        .get(format!("{url}/api/v1/sessions/managed"))
-        .timeout(std::time::Duration::from_secs(2))
+        .get(format!("{url}/api/v1/sessions/managed?slim=true"))
+        .timeout(std::time::Duration::from_secs(8))
         .send()
         .await?
         .error_for_status()?;
     let body: trusty_mpm::client::ManagedListResponse = resp.json().await?;
     Ok(body.sessions)
+}
+
+/// [`list_all_managed_sessions`] for [`nested_session_guard`], with the
+/// fail-open arm LOGGED rather than silently swallowed (#4335).
+///
+/// Why: the guard used a bare `.ok()?`, so every failure mode — timeout,
+/// daemon down, malformed body — produced the identical observable behaviour
+/// as "no sessions matched": the guard no-opped and the flow fell through to
+/// the picker. #4335 took a live repro plus a code read to establish that the
+/// guard had not run at all, because there was nothing in any log to say so.
+/// One `tracing::debug!` on the error arm makes the difference between "guard
+/// ran, found nothing" and "guard never ran" visible under `RUST_LOG=debug`.
+/// What: `Some(sessions)` on success; `None` after logging the error. Keeps
+/// the fail-open contract — a down daemon must not block bare `tm` — but stops
+/// it from being invisible.
+/// Test: `guard_managed_sessions_returns_none_when_the_list_call_errors`,
+/// `guard_managed_sessions_returns_sessions_on_success`.
+pub(crate) async fn guard_managed_sessions(
+    client: &reqwest::Client,
+    url: &str,
+) -> Option<Vec<trusty_mpm::client::ManagedSessionSummary>> {
+    match list_all_managed_sessions(client, url).await {
+        Ok(sessions) => Some(sessions),
+        Err(e) => {
+            tracing::debug!(
+                error = %e,
+                "tm: nested-session guard: managed-session list failed — guard SKIPPED \
+                 (falling through to the ordinary guided default). A cold daemon that \
+                 exceeds the timeout lands here (#4335)."
+            );
+            None
+        }
+    }
 }
 
 // ── Display / TTY-gate helpers ────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_c_tests.rs
@@ -28,10 +28,10 @@ static ENV_MUTEX: Mutex<()> = Mutex::new(());
 use crate::commands::guided::{
     CwdProject, NestedFallbackAction, NonGitFallbackPlan, classify_cwd_project, cwd_owns_git_entry,
     derive_project, fallback_protected, format_project_context_row, github_host,
-    inplace_self_relaunch_hint, is_github_remote, ls_tree_reports_tracked_dir,
-    managed_pane_settle_pending_message, nested_fallback_action, nested_guard_notice,
-    non_github_refusal_message, plan_non_git_fallback, print_non_tty_hint, print_project_context,
-    tty_gate, untracked_ancestor_message,
+    guard_managed_sessions, inplace_self_relaunch_hint, is_github_remote,
+    ls_tree_reports_tracked_dir, managed_pane_settle_pending_message, nested_fallback_action,
+    nested_guard_notice, non_github_refusal_message, plan_non_git_fallback, print_non_tty_hint,
+    print_project_context, tty_gate, untracked_ancestor_message,
 };
 use crate::commands::guided_launch::spawn_progress_message;
 use crate::commands::guided_resume::{
@@ -2374,4 +2374,96 @@ fn inplace_self_relaunch_hint_never_suggests_bare_claude() {
             "hint must always point at the managed resume; sid={sid:?}: {hint:?}"
         );
     }
+}
+
+// ── #4335: the nested-session guard's fail-open arm ───────────────────────
+
+/// Serve one canned HTTP response on an ephemeral port, then stop.
+///
+/// Why: `guard_managed_sessions` is a thin I/O wrapper whose ONE interesting
+/// behaviour — what it does when the managed-list call fails — cannot be
+/// exercised without a server that fails. A real socket keeps reqwest's own
+/// status/decode handling in the loop, which is where the failure modes #4335
+/// cares about (5xx, unreachable, malformed body) actually surface.
+/// What: binds `127.0.0.1:0`, accepts exactly one connection, drains the
+/// request, writes `response`, and returns the base URL.
+/// Test: used by the `guard_managed_sessions_*` cases below.
+async fn serve_once(response: &'static str) -> String {
+    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    tokio::spawn(async move {
+        if let Ok((mut sock, _)) = listener.accept().await {
+            let mut buf = [0u8; 2048];
+            let _ = sock.read(&mut buf).await;
+            let _ = sock.write_all(response.as_bytes()).await;
+            let _ = sock.flush().await;
+        }
+    });
+    format!("http://{addr}")
+}
+
+#[tokio::test]
+async fn guard_managed_sessions_returns_none_when_the_list_call_errors() {
+    // #4335 core regression: a failing managed-list call must fail OPEN
+    // (None → the guard no-ops → bare `tm` still proceeds) rather than
+    // propagating an error or panicking. The behaviour is unchanged from the
+    // old `.ok()?`; what changed is that it is now LOGGED, and that this arm
+    // has a test at all — the absence of one is why the guard could stop
+    // guarding on a cold daemon without anyone noticing.
+    let url = serve_once("HTTP/1.1 500 Internal Server Error\r\ncontent-length: 0\r\n\r\n").await;
+    let client = reqwest::Client::new();
+
+    let result = guard_managed_sessions(&client, &url).await;
+
+    assert!(
+        result.is_none(),
+        "a 5xx from the daemon must fail open to None, not error out"
+    );
+}
+
+#[tokio::test]
+async fn guard_managed_sessions_returns_none_when_the_daemon_is_unreachable() {
+    // The other cold-daemon shape: nothing listening at all. Same fail-open
+    // contract — a down daemon must never block bare `tm`.
+    let client = reqwest::Client::new();
+
+    // Port 1 on loopback: reserved, never bound by a normal process.
+    let result = guard_managed_sessions(&client, "http://127.0.0.1:1").await;
+
+    assert!(
+        result.is_none(),
+        "an unreachable daemon must fail open to None"
+    );
+}
+
+#[tokio::test]
+async fn guard_managed_sessions_returns_sessions_on_success() {
+    // The positive half: a well-formed listing must reach the guard intact,
+    // so the fail-open arms above are proven to be FAILURE paths and not the
+    // function's only behaviour.
+    let body = concat!(
+        r#"{"sessions":[{"id":"11111111-2222-3333-4444-555555555555","#,
+        r#""name":"tm-demo-01","state":"active","#,
+        r#""created_at":"2026-07-29T00:00:00Z"}]}"#
+    );
+    let response: &'static str = Box::leak(
+        format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        )
+        .into_boxed_str(),
+    );
+    let url = serve_once(response).await;
+    let client = reqwest::Client::new();
+
+    let sessions = guard_managed_sessions(&client, &url)
+        .await
+        .expect("a well-formed listing must reach the guard");
+
+    assert_eq!(sessions.len(), 1, "the listing must survive intact");
+    assert_eq!(sessions[0].name, "tm-demo-01");
 }

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -574,8 +574,14 @@ pub async fn adopt_existing_session(
 /// count of stopped/errored sessions. Numbering is observed against the FULL,
 /// unfiltered record set BEFORE the `source_id` filter is applied — otherwise
 /// a session outside the current filter would go unobserved and receive a
-/// fresh number the next time it IS listed.
+/// fresh number the next time it IS listed. The optional `?slim=true` (or
+/// `slim=1`) query parameter (#4335, folds into #4322) skips the expensive
+/// per-session `stale_assets` probe for callers that never read that flag —
+/// every `stale_assets` then reports its `false` default, meaning "not
+/// computed", so only such a caller may pass it. Anything else (absent,
+/// `slim=false`, malformed) keeps the full probe.
 /// Test: list handler test; list-with-source-id-filter test;
+/// `checked_summaries_slim_skips_stale_assets_probe`;
 /// `list_marks_dead_stopped_session_unresumable`,
 /// `list_leaves_live_and_healthy_stopped_sessions_unmarked`,
 /// `list_assigns_stable_slot_numbers_and_tombstones_deleted_one` (integration
@@ -594,9 +600,13 @@ pub async fn list_managed_sessions(
     // `state`/`attached` reconciliation (#3302/#3531 — a running/attached
     // session must never read `(stopped)`) to the surviving rows, fail-closed
     // on a tmux probe error (see `reconcile_against_tmux`).
+    // #4335: `?slim=true` opts OUT of the expensive per-session `stale_assets`
+    // probe for callers that never read the flag (the nested-session guard).
+    // Absent/malformed → the full probe, so no existing client changes shape.
+    let slim = q.get("slim").is_some_and(|v| v == "true" || v == "1");
     let all_records = mgr.list().await;
     let numbered = mgr.numbered_snapshot(&all_records).await;
-    let sessions = numbered_summaries(numbered, mgr.tmux.as_ref(), sid_filter).await;
+    let sessions = numbered_summaries(numbered, mgr.tmux.as_ref(), sid_filter, !slim).await;
     Json(ListSessionsResponse { sessions })
 }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/summary.rs
@@ -413,6 +413,33 @@ pub(super) async fn record_to_summary_checked(r: &SessionRecord) -> SessionSumma
 /// `list_leaves_live_and_healthy_stopped_sessions_unmarked` in
 /// `tests/session_manager_mvp.rs`.
 pub(super) async fn checked_summaries(records: &[SessionRecord]) -> Vec<SessionSummary> {
+    checked_summaries_with(records, true).await
+}
+
+/// [`checked_summaries`] with the #2444 asset-staleness probe made optional
+/// (issue #4335, folds into #4322).
+///
+/// Why: `stale_assets` is the single most expensive thing this endpoint
+/// computes — a filesystem-bound catalog compose per distinct
+/// `(agent_source, skill_source)` pair plus a manifest+on-disk comparison per
+/// session — and on a COLD daemon (nothing cached, dozens of sessions) it
+/// pushes the whole response past the caller's timeout. Callers that never
+/// READ the flag were paying for it anyway and then failing open when it took
+/// too long, which is exactly how `guided::nested_session_guard` silently
+/// stopped guarding. Letting such a caller opt out is strictly better than
+/// raising every timeout to accommodate work nobody wants.
+/// What: identical to [`checked_summaries`] except that when `probe_assets` is
+/// `false` the entire second pass is skipped and every `stale_assets` stays at
+/// its `record_to_summary` default of `false`. The `unresumable` probe is NOT
+/// optional — it is cheap (state-gated, no I/O outside `Stopped`/`Errored`)
+/// and the guard's callers do read it. A `false` here means "not computed",
+/// not "computed and found current", so only a caller that ignores the field
+/// may pass it.
+/// Test: `checked_summaries_slim_skips_stale_assets_probe`.
+pub(super) async fn checked_summaries_with(
+    records: &[SessionRecord],
+    probe_assets: bool,
+) -> Vec<SessionSummary> {
     let mut summaries: Vec<SessionSummary> = records.iter().map(record_to_summary).collect();
 
     let mut probes = tokio::task::JoinSet::new();
@@ -440,9 +467,11 @@ pub(super) async fn checked_summaries(records: &[SessionRecord]) -> Vec<SessionS
     // shares the expensive catalog-side compose across all of them (issue
     // #2444 review MEDIUM finding), which a per-record `JoinSet` fan-out
     // would defeat (each task would redundantly recompose the same catalog).
+    // #4335: a slim caller skips this pass entirely — see
+    // [`checked_summaries_with`] for why opting out beats a longer timeout.
     let syncable: Vec<SessionRecord> = records
         .iter()
-        .filter(|r| probe_staleness_for(&r.state))
+        .filter(|r| probe_assets && probe_staleness_for(&r.state))
         .cloned()
         .collect();
     if !syncable.is_empty() {
@@ -487,6 +516,7 @@ pub(super) async fn numbered_summaries(
     numbered: Vec<NumberedSlot>,
     tmux: &dyn ManagedTmuxDriver,
     source_id_filter: Option<&str>,
+    probe_assets: bool,
 ) -> Vec<SessionSummary> {
     let filtered: Vec<NumberedSlot> = numbered
         .into_iter()
@@ -494,7 +524,7 @@ pub(super) async fn numbered_summaries(
         .collect();
     let live_records: Vec<SessionRecord> =
         filtered.iter().filter_map(|n| n.record.clone()).collect();
-    let mut live_summaries = checked_summaries(&live_records).await;
+    let mut live_summaries = checked_summaries_with(&live_records, probe_assets).await;
     reconcile_against_tmux(tmux, &mut live_summaries, &live_records);
     let mut live_summaries = live_summaries.into_iter();
     filtered

--- a/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/tests.rs
@@ -10,6 +10,7 @@ use std::path::PathBuf;
 
 use chrono::Utc;
 
+use super::summary::checked_summaries_with;
 use super::summary::{reconcile_against_tmux, reconcile_live_state};
 use super::{checked_summaries, record_to_json, record_to_summary};
 use crate::session_manager::{
@@ -763,6 +764,59 @@ async fn checked_summaries_flags_stale_assets_only_for_relevant_states() {
     assert!(
         !summaries[1].stale_assets,
         "a Provisioning session must never be probed — it has not deployed yet"
+    );
+}
+
+/// Issue #4335: `?slim=true` must actually SKIP the asset-staleness probe.
+///
+/// Why: asserting only that a slim listing reports `stale_assets: false` is
+/// vacuous — `false` is also the value a session with current assets gets.
+/// This builds the exact fixture
+/// `checked_summaries_flags_stale_assets_only_for_relevant_states` uses to
+/// produce a genuine `true`, then shows the slim path reports `false` for it.
+/// The difference can only come from the probe not running, which is the whole
+/// point of the flag: the guard's cold-daemon timeout was that probe's cost.
+#[tokio::test]
+#[serial_test::serial]
+async fn checked_summaries_slim_skips_stale_assets_probe() {
+    let (home, _guard) = fake_home();
+    let fw = crate::core::paths::FrameworkPaths::default();
+    let bundled = fw.agent_source_dir();
+    std::fs::create_dir_all(&bundled).unwrap();
+    std::fs::write(bundled.join("rust-engineer.md"), "v1").unwrap();
+
+    let workspace = home.path().join("workspace");
+    std::fs::create_dir_all(&workspace).unwrap();
+    let session_fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&workspace);
+    crate::core::agent_deployer::deploy_agents_filtered(
+        &bundled,
+        &session_fw.claude_agents_dir(),
+        |_| true,
+    )
+    .unwrap();
+    std::fs::write(bundled.join("rust-engineer.md"), "v2 — catalog moved").unwrap();
+
+    let mut active = make_record(None);
+    active.state = ManagedSessionState::Active;
+    active.workspace_path = Some(workspace);
+    let records = vec![active];
+
+    // Control: the full probe SEES the drift.
+    let full = checked_summaries_with(&records, true).await;
+    assert!(
+        full[0].stale_assets,
+        "fixture must genuinely be stale, else the slim assertion below is vacuous"
+    );
+
+    // Slim: same records, probe skipped, flag left at its default.
+    let slim = checked_summaries_with(&records, false).await;
+    assert!(
+        !slim[0].stale_assets,
+        "slim mode must skip the staleness probe entirely (#4335)"
+    );
+    assert_eq!(
+        slim[0].id, full[0].id,
+        "slim mode must still return every session — only the probe is skipped"
     );
 }
 


### PR DESCRIPTION
Closes #4335

## The failure

`nested_session_guard` fetched the managed-session list with a 2-second timeout
and a bare `.ok()?`. On a cold daemon the per-session `stale_assets` pass over a
large fleet exceeded that bound, the request was cancelled, and the guard
no-opped — with nothing in any log to say it had not run.

The rest follows from that. Claude Code's `/exit` BACKGROUNDS the session and
never fires `SessionEnd`, so the daemon record stays `active`; Gate A
(`plan_inplace`) correctly skips, because it requires `stopped`. Gate B was
supposed to catch it on `pane_id` — and silently didn't. The flow fell to the
picker, whose resume dead-ends on the #2678 switch-client refusal. Invocation 1
reconciled the record and warmed the daemon; invocation 2 worked.

A guard that silently stops guarding is worse than a slow one. #4335 needed a
live repro plus a code read to establish the guard had not run, because every
failure mode was observationally identical to "nothing matched".

## The fix — three changes, smallest lever first

**`?slim=true` on the managed-list endpoint** (folds into #4322). The guard
reads `name`, `pane_id`, `state`, and `id` — never `stale_assets`. That flag is
the most expensive thing the endpoint computes: a filesystem-bound catalog
compose per distinct `(agent_source, skill_source)` pair plus a per-session
manifest/on-disk comparison. The guard was paying for a field it discards.
Opting out is the actual fix. Absent, `slim=false`, or malformed keeps the full
probe, so no existing client changes shape.

**Timeout 2s → 8s** on that one call. The 2s bound exists to stop a *hung*
daemon stalling bare `tm`; 8s still bounds that while clearing a cold-start
listing. This is the belt to slim mode's braces, not the primary fix.

**The error arm is logged** at `tracing::debug!` via a new
`guard_managed_sessions`, which keeps the fail-open contract — a down daemon
must never block bare `tm` — but stops it from being invisible. Under
`RUST_LOG=debug` there is now a difference between "guard ran, found nothing"
and "guard never ran".

`plan_inplace`'s stopped-only gate is deliberately **not** widened, per the
issue.

## Tests

- `guard_managed_sessions_returns_none_when_the_list_call_errors` — 5xx from a
  real socket must fail open to `None`, not error out.
- `guard_managed_sessions_returns_none_when_the_daemon_is_unreachable` — the
  other cold-daemon shape: nothing listening.
- `guard_managed_sessions_returns_sessions_on_success` — proves the two above
  are failure paths, not the function's only behaviour.
- `checked_summaries_slim_skips_stale_assets_probe` — builds the fixture that
  genuinely reports `stale_assets: true` under the full probe, then shows the
  slim path reports `false` for it. Asserting the flag alone would be vacuous:
  `false` is also what a session with current assets gets.

## Quality gate

```
cargo fmt --check exit: 0

cargo clippy -p trusty-mpm --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 29.13s

cargo test -p trusty-mpm     (full suite, not --lib)   exit: 0
test result: ok. 3945 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 43.20s
test result: ok. 1287 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.81s
test result: ok. 1287 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 2.67s
(44 `test result: ok` lines total; zero FAILED, zero panics)

scripts/check_line_cap.sh: line-cap: 7 allowlisted, 0 violations — OK.
```

Stacked note: #4340 (#4336) touches `guided_inplace.rs` / `claude_code.rs`;
this touches `guided.rs` and the daemon summary path. No file overlap.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
