### PR TITLE
fix(trusty-mpm): daemon boot no longer resurrects deleted sessions; decommission no longer force-deletes dirty worktrees

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -220,6 +220,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Daemon boot reconciliation no longer resurrects soft-deleted sessions.
+  `reconcile_on_boot` hand-rolled a
+  `matches!(record.state, ManagedSessionState::Decommissioned)` check instead
+  of asking the record's own `is_terminal()`, so every `Deleted` record (no
+  live tmux session, by definition) fell through to the "gone" branch and was
+  marked `Stopped` — resurrected — on every daemon restart. `is_terminal()` is
+  now the single source of truth, covering both `Decommissioned` and
+  `Deleted`.
+- `decommission` (and therefore `tm sessions prune --state stopped`, which
+  calls it per matching record) no longer force-deletes a dirty in-project
+  worktree. Removing an SM-created `.worktrees/<id>` ran `git worktree remove
+  --force` (falling back to `fs::remove_dir_all`) with no dirty check at all —
+  a live data-loss path for uncommitted/untracked work. This reuses the same
+  `worktree_safety::inspect_dirt` check the orphan-worktree sweep uses (the
+  #4091 dirty-worktree guard): a dirty candidate is now refused and reported,
+  and the session record still tombstones to `Decommissioned` so the skip is
+  never silent.
 - The per-project worktree opt-out is no longer silently conditional on the
   daemon being up ([#4300](https://github.com/bobmatnyc/trusty-tools/issues/4300)).
   `Project.worktree: false` ([#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455),

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -236,7 +236,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   `worktree_safety::inspect_dirt` check the orphan-worktree sweep uses (the
   #4091 dirty-worktree guard): a dirty candidate is now refused and reported,
   and the session record still tombstones to `Decommissioned` so the skip is
-  never silent.
+  never silent. Two follow-ups close the gap between that refusal and where
+  an operator would actually see it: (1) the tombstone no longer nulls
+  `workspace_path` when nothing was removed — every "skip removal" branch in
+  `decommission` leaves real content in place, and blanking the pointer would
+  strand it with nothing but a transient log line as a trail back to it; (2)
+  `tm sessions prune --state stopped` (and the underlying `PruneAction`) now
+  has a distinct `decommissioned_worktree_retained` outcome, with the
+  retained path echoed back, instead of printing the same `decommissioned`
+  line whether or not the worktree was actually deleted.
 - The per-project worktree opt-out is no longer silently conditional on the
   daemon being up ([#4300](https://github.com/bobmatnyc/trusty-tools/issues/4300)).
   `Project.worktree: false` ([#3455](https://github.com/bobmatnyc/trusty-tools/issues/3455),

--- a/crates/trusty-mpm/src/bin/tm/commands/managed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/managed.rs
@@ -692,6 +692,19 @@ pub(crate) async fn session_prune(
             .and_then(serde_json::Value::as_str)
             .unwrap_or("?");
         println!("{action} {id} {name} [{prior}]");
+        // #4344 review: `decommissioned_worktree_retained` means the record
+        // was tombstoned but its in-project worktree held unsaved work and
+        // was deliberately NOT deleted (see `worktree_safety::inspect_dirt`).
+        // Without a distinct, visible line here, this printed identically to
+        // an ordinary `decommissioned` row and the refusal was invisible at
+        // the one surface an operator actually reads.
+        if action == "decommissioned_worktree_retained" {
+            let retained_path = s
+                .get("retained_workspace_path")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("?");
+            println!("  ! worktree retained (dirty, not deleted): {retained_path}");
+        }
     }
     let verb = if dry_run { "would prune" } else { "pruned" };
     println!("{verb} {} session(s) (filter={state})", sessions.len());

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -22,6 +22,7 @@ use super::manager::{ManagedError, SessionManager};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::search_gc;
 use super::workspace_guard::is_safe_to_remove;
+use super::worktree_safety::{DirtyWorktree, inspect_dirt};
 
 /// Sentinel file written by [`create_session_worktree`] into every SM-created
 /// per-session git worktree (#1845 item 5).
@@ -411,34 +412,71 @@ impl SessionManager {
                 // the git ref is also pruned.  The base clone directory is NEVER
                 // touched — only the leaf worktree path.
                 if is_session_worktree(ws) {
-                    // Item 4 (#1845): wrap the blocking `git worktree remove`
-                    // call in spawn_blocking + tokio::time::timeout so a hung
-                    // git process cannot stall the async executor indefinitely.
-                    let ws_clone = ws.clone();
-                    let join =
-                        tokio::task::spawn_blocking(move || remove_session_worktree(&ws_clone));
-                    workspace_removed =
-                        match tokio::time::timeout(GIT_WORKTREE_REMOVE_TIMEOUT, join).await {
-                            Ok(Ok(removed)) => removed,
-                            Ok(Err(e)) => {
-                                warn!(
-                                    id = %id,
-                                    workspace = %ws.display(),
-                                    "decommission: remove_session_worktree task panicked: {e}"
-                                );
-                                false
-                            }
-                            Err(_elapsed) => {
-                                warn!(
-                                    id = %id,
-                                    workspace = %ws.display(),
-                                    timeout_secs = GIT_WORKTREE_REMOVE_TIMEOUT.as_secs(),
-                                    "decommission: git worktree remove timed out; \
-                                     worktree may require manual cleanup"
-                                );
-                                false
-                            }
-                        };
+                    // Data-safety gate (#4091-style, decommission-side): before
+                    // this, `remove_session_worktree` ran `git worktree remove
+                    // --force` (falling back to `fs::remove_dir_all`)
+                    // unconditionally, with NO dirty check at all — a live
+                    // data-loss path for `tm sessions prune --state stopped`
+                    // (which calls `decommission` per matching record). Reuse
+                    // the same `worktree_safety::inspect_dirt` check the
+                    // orphan-worktree sweep (`prune_orphaned_worktrees`)
+                    // already uses: refuse (and report) a candidate holding
+                    // uncommitted/untracked work or unpushed commits. Runs on
+                    // spawn_blocking since it shells out to git, same as the
+                    // removal itself; a panicked check is treated as dirty
+                    // (fail-safe) rather than a green light to delete.
+                    let ws_for_check = ws.clone();
+                    let dirt = tokio::task::spawn_blocking(move || inspect_dirt(&ws_for_check))
+                        .await
+                        .unwrap_or_else(|e| {
+                            Some(DirtyWorktree::new(
+                                ws,
+                                format!("dirty-check task panicked: {e}"),
+                                0,
+                                0,
+                            ))
+                        });
+
+                    if let Some(dirt) = dirt {
+                        warn!(
+                            id = %id,
+                            workspace = %ws.display(),
+                            reason = %dirt.reason,
+                            "decommission: refusing to remove worktree — it holds \
+                             unsaved work; leaving it on disk (the record below is \
+                             still tombstoned)"
+                        );
+                        // workspace_removed stays false — nothing was deleted.
+                    } else {
+                        // Item 4 (#1845): wrap the blocking `git worktree remove`
+                        // call in spawn_blocking + tokio::time::timeout so a hung
+                        // git process cannot stall the async executor indefinitely.
+                        let ws_clone = ws.clone();
+                        let join =
+                            tokio::task::spawn_blocking(move || remove_session_worktree(&ws_clone));
+                        workspace_removed =
+                            match tokio::time::timeout(GIT_WORKTREE_REMOVE_TIMEOUT, join).await {
+                                Ok(Ok(removed)) => removed,
+                                Ok(Err(e)) => {
+                                    warn!(
+                                        id = %id,
+                                        workspace = %ws.display(),
+                                        "decommission: remove_session_worktree task panicked: {e}"
+                                    );
+                                    false
+                                }
+                                Err(_elapsed) => {
+                                    warn!(
+                                        id = %id,
+                                        workspace = %ws.display(),
+                                        timeout_secs = GIT_WORKTREE_REMOVE_TIMEOUT.as_secs(),
+                                        "decommission: git worktree remove timed out; \
+                                         worktree may require manual cleanup"
+                                    );
+                                    false
+                                }
+                            };
+                    }
                 } else {
                     warn!(
                         id = %id,

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -539,9 +539,20 @@ impl SessionManager {
             search_gc::delete_search_index_best_effort(&index_id).await;
         }
 
-        // Tombstone: clear workspace_path, mark Decommissioned, persist.
-        record.workspace_path = None;
-        record.workspace_owned = false;
+        // Tombstone: mark Decommissioned, persist. `workspace_path`/
+        // `workspace_owned` are cleared ONLY when nothing is left on disk —
+        // every "skip removal" branch above (the dirty-worktree refusal,
+        // unowned/local-path, the containment guard) deliberately leaves real
+        // content in place, and blanking the pointer here would strand that
+        // retained directory with nothing but the transient warn! log line
+        // above as a trail back to it (#4344 review). A record whose
+        // workspace really was removed (or was already absent) still nulls
+        // both fields exactly as before.
+        let workspace_still_on_disk = record.workspace_path.as_deref().is_some_and(|p| p.exists());
+        if !workspace_still_on_disk {
+            record.workspace_path = None;
+            record.workspace_owned = false;
+        }
         record.state = ManagedSessionState::Decommissioned;
         self.store.write().await.upsert(record.clone()).await?;
         info!(id = %id, name = %record.tmux_name, "managed session decommissioned");

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -244,7 +244,10 @@ fn push_to_bare_remote(repo: &std::path::Path) {
 /// Asserts: (1) `workspace_removed` is `false`; (2) the record still
 /// tombstones to `Decommissioned` (consistent with every other "skip
 /// removal" branch in `decommission_with_root`); (3) the worktree directory
-/// AND the untracked file both survive on disk.
+/// AND the untracked file both survive on disk; (4) the tombstone record
+/// KEEPS `workspace_path` pointing at the retained directory (#4344 review) —
+/// nulling it here would strand the retained work with nothing but a
+/// transient warn! log line as a trail back to it.
 /// Test: this function IS the test.
 #[tokio::test]
 async fn manager_decommission_refuses_dirty_worktree() {
@@ -303,5 +306,106 @@ async fn manager_decommission_refuses_dirty_worktree() {
     assert!(
         worktree_path.join("uncommitted-work.txt").exists(),
         "the uncommitted file itself must survive the refused decommission"
+    );
+    assert_eq!(
+        tombstone.workspace_path.as_deref(),
+        Some(worktree_path.as_path()),
+        "workspace_path must survive on the tombstone when removal was refused \
+         (#4344 review) — it is the only durable pointer back to the retained work"
+    );
+}
+
+/// `tm sessions prune --state stopped` (via `prune_managed`) surfaces a
+/// dirty-worktree refusal through its own report, instead of printing the
+/// same `decommissioned` line whether or not the worktree was actually
+/// removed (#4344 review).
+///
+/// Why: `prune_managed` discarded the `bool` half of `decommission`'s
+/// `(SessionRecord, bool)` return, and `PruneAction` had no variant for
+/// "refused, worktree retained" — so `tm sessions prune --state stopped`
+/// gave no visible signal, at the ONE surface an operator actually reads,
+/// that a worktree was silently kept dirty on disk instead of removed.
+/// What: seeds a `Stopped` record (via the real `stop()` teardown, mirroring
+/// how a genuinely stopped session gets there) pointing at a real,
+/// dirtied in-project worktree, runs
+/// `prune_managed(PruneFilter::Stopped, …)`, and asserts the single
+/// returned row is `PruneAction::DecommissionedWorktreeRetained` with
+/// `retained_workspace_path` set to the worktree's path — plus the usual
+/// on-disk survival assertions.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn prune_reports_dirty_worktree_retained() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake)
+        .await
+        .expect("manager");
+
+    let fixture = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
+    let session_name = "test-session-prune-dirty";
+    let worktree_path = fixture.add_worktree(session_name);
+    std::fs::write(worktree_path.join(WORKTREE_SENTINEL_FILE), b"").expect("write sentinel");
+    std::fs::write(
+        worktree_path.join("uncommitted-work.txt"),
+        b"unsaved work\n",
+    )
+    .expect("write uncommitted file");
+
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "task".into(),
+            Some(worktree_path.clone()),
+            None,
+            Some(worktree_path.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            false, // owned: false — in-project worktree, not a full clone
+        )
+        .await
+        .expect("create");
+
+    // Transition to Stopped exactly like a real "runtime exited" session —
+    // `prune --state stopped` only ever targets genuinely Stopped records.
+    mgr.stop(&record.id).await.expect("stop");
+
+    let outcome = mgr
+        .prune_managed(
+            crate::session_manager::PruneFilter::Stopped,
+            false,
+            false,
+            None,
+        )
+        .await
+        .expect("prune stopped");
+
+    assert_eq!(
+        outcome.count(),
+        1,
+        "the dirty stopped session is the only candidate"
+    );
+    let pruned = &outcome.sessions[0];
+    assert_eq!(
+        pruned.action,
+        crate::session_manager::PruneAction::DecommissionedWorktreeRetained,
+        "a dirty in-project worktree must report as retained, not a plain decommission; got {:?}",
+        pruned.action
+    );
+    assert_eq!(
+        pruned.retained_workspace_path.as_deref(),
+        Some(worktree_path.as_path()),
+        "the prune report must echo back WHERE the retained work lives"
+    );
+
+    // The usual on-disk guarantees still hold at the prune surface too.
+    assert!(
+        worktree_path.exists(),
+        "the dirty worktree must survive a prune sweep"
+    );
+    assert!(
+        worktree_path.join("uncommitted-work.txt").exists(),
+        "the uncommitted file must survive a prune sweep"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -87,6 +87,15 @@ async fn manager_decommission_removes_real_git_worktree() {
         return;
     }
 
+    // ── Give the base clone a remote and push (the #4400-style dirty gate) ──
+    // Without ANY remote, `worktree_safety::inspect_dirt`'s unpushed-commit
+    // check treats every commit as unpushed (there is nothing to exclude via
+    // `--not --remotes`), which would make this "clean happy path" fixture
+    // spuriously dirty and refuse removal. Push to a real bare remote so the
+    // ONLY thing under test in this function is the ordinary clean-removal
+    // path; the dirty-refusal path has its own fixture/test below.
+    push_to_bare_remote(&base);
+
     // ── Real `git worktree add` under <base>/.worktrees/<session-name> ───────
     // Branch is `session/<session_name>` (issue #2032 fix) — this MUST mirror
     // the exact convention `create_session_worktree`/`worktree_branch_for`
@@ -178,5 +187,121 @@ async fn manager_decommission_removes_real_git_worktree() {
     assert!(
         branch_stdout.trim().is_empty(),
         "the session branch ref must be deleted after decommission; got: {branch_stdout}"
+    );
+}
+
+/// Push `repo`'s current `HEAD` to a fresh bare remote and fetch it back.
+///
+/// Why: `worktree_safety::inspect_dirt`'s unpushed-commit check treats a
+/// repository with NO remote at all as fully unpushed (there is nothing for
+/// `--not --remotes` to exclude), which would make a "clean happy path"
+/// fixture built with a bare `git init` + one commit spuriously dirty. Tests
+/// that need a genuinely CLEAN worktree call this immediately after the base
+/// clone's first commit.
+/// What: `git init --bare` a throwaway remote, `remote add origin`, `push
+/// origin HEAD`, `fetch origin` — panics with git's stderr on any failure.
+/// Test: `manager_decommission_removes_real_git_worktree`.
+fn push_to_bare_remote(repo: &std::path::Path) {
+    let remote_dir = crate::test_support::hermetic_temp_dir();
+    let remote = remote_dir.path().to_path_buf();
+    let remote_str = remote.to_str().expect("utf8 remote path");
+    let repo_str = repo.to_str().expect("utf8 repo path");
+
+    let init_ok = std::process::Command::new("git")
+        .args(["init", "--bare"])
+        .current_dir(&remote)
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    assert!(init_ok, "git init --bare must succeed for the test remote");
+
+    for args in [
+        vec!["-C", repo_str, "remote", "add", "origin", remote_str],
+        vec!["-C", repo_str, "push", "origin", "HEAD"],
+        vec!["-C", repo_str, "fetch", "origin"],
+    ] {
+        let ok = std::process::Command::new("git")
+            .args(&args)
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        assert!(ok, "git {args:?} must succeed");
+    }
+}
+
+/// `decommission` refuses to remove an in-project worktree that holds unsaved
+/// (uncommitted/untracked) work — the data-loss fix.
+///
+/// Why: before this fix, `remove_session_worktree` ran `git worktree remove
+/// --force` (falling back to `fs::remove_dir_all`) with NO dirty check at
+/// all. `tm sessions prune --state stopped` calls `decommission` for every
+/// matching record, so a stopped session with uncommitted/untracked work in
+/// its in-project worktree was silently destroyed. This reuses
+/// `worktree_safety::inspect_dirt` (the same check the orphan-worktree sweep
+/// uses) to gate removal.
+/// What: builds a real, clean, pushed git worktree (so the ONLY dirt is the
+/// file this test adds), drops an untracked file into it, then decommissions.
+/// Asserts: (1) `workspace_removed` is `false`; (2) the record still
+/// tombstones to `Decommissioned` (consistent with every other "skip
+/// removal" branch in `decommission_with_root`); (3) the worktree directory
+/// AND the untracked file both survive on disk.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_decommission_refuses_dirty_worktree() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake)
+        .await
+        .expect("manager");
+
+    let fixture = crate::session_manager::worktree_git_fixture::GitWorktreeFixture::new();
+    let session_name = "test-session-dirty";
+    let worktree_path = fixture.add_worktree(session_name);
+
+    // Write the SM ownership sentinel, mirroring `create_session_worktree`.
+    std::fs::write(worktree_path.join(WORKTREE_SENTINEL_FILE), b"").expect("write sentinel");
+
+    // Dirty the worktree: an untracked file `git status` will report. This is
+    // the ONLY source of dirt — the fixture's base repo is already pushed.
+    std::fs::write(
+        worktree_path.join("uncommitted-work.txt"),
+        b"unsaved work\n",
+    )
+    .expect("write uncommitted file");
+
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "task".into(),
+            Some(worktree_path.clone()),
+            None,
+            Some(worktree_path.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            false, // owned: false — in-project worktree, not a full clone
+        )
+        .await
+        .expect("create");
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let (tombstone, workspace_removed) = mgr
+        .decommission_with_root(&record.id, managed_root.path(), None)
+        .await
+        .expect("decommission");
+
+    assert!(
+        !workspace_removed,
+        "workspace_removed must be false when the worktree holds unsaved work"
+    );
+    assert_eq!(tombstone.state, ManagedSessionState::Decommissioned);
+    assert!(
+        worktree_path.exists(),
+        "a dirty worktree must survive on disk — decommission must refuse to delete it"
+    );
+    assert!(
+        worktree_path.join("uncommitted-work.txt").exists(),
+        "the uncommitted file itself must survive the refused decommission"
     );
 }

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -234,17 +234,34 @@ impl fmt::Display for PruneFilter {
 /// Why: `decommission` (tear down a live/stopped session) and `remove` (drop an
 /// existing tombstone from the store) are semantically distinct outcomes; the
 /// caller wants to know which happened per session so a dry-run report is precise.
+/// A THIRD outcome exists since the decommission-side dirty-worktree guard: a
+/// record can be tombstoned while its in-project worktree is deliberately left
+/// on disk because it held unsaved work. Before this variant existed,
+/// `prune_managed` discarded the `bool` half of `decommission`'s
+/// `(SessionRecord, bool)` return, so `tm sessions prune --state stopped`
+/// printed the identical `decommissioned` line whether the worktree was
+/// removed or silently retained — the refusal was invisible at the one
+/// surface an operator actually reads.
 /// What: [`Decommissioned`](PruneAction::Decommissioned) — killed runtime +
-/// removed workspace + tombstoned; [`Removed`](PruneAction::Removed) — an existing
-/// `Decommissioned` tombstone was deleted from the store (compaction).
+/// removed workspace (or the workspace was already gone/never SM-owned) +
+/// tombstoned; [`DecommissionedWorktreeRetained`](PruneAction::DecommissionedWorktreeRetained)
+/// — tombstoned, but the worktree held unsaved work and was deliberately NOT
+/// removed (its path is echoed back on [`PrunedSession::retained_workspace_path`]);
+/// [`Removed`](PruneAction::Removed) — an existing `Decommissioned`/`Deleted`
+/// tombstone was deleted from the store (compaction).
 /// Test: asserted by `decommission_all_ephemeral_ignores_non_ephemeral` (the
-/// `Decommissioned` action) and `prune_decommissioned_compacts` (the `Removed`
-/// action).
+/// `Decommissioned` action), `prune_decommissioned_compacts` (the `Removed`
+/// action), and `prune_reports_dirty_worktree_retained` (the new variant).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum PruneAction {
     /// The session was torn down (runtime killed, workspace removed, tombstoned).
     Decommissioned,
+    /// The session was tombstoned, but its in-project worktree held unsaved
+    /// work and was deliberately NOT removed — see
+    /// `worktree_safety::inspect_dirt`. The worktree remains on disk; its path
+    /// is echoed on `PrunedSession::retained_workspace_path`.
+    DecommissionedWorktreeRetained,
     /// An existing tombstone was deleted from the store (compaction).
     Removed,
 }
@@ -253,11 +270,14 @@ impl PruneAction {
     /// The canonical lowercase name of this action (for wire/log rendering).
     ///
     /// Why: HTTP/MCP responses and the CLI dry-run render the action per row.
-    /// What: `Decommissioned` → `"decommissioned"`, `Removed` → `"removed"`.
+    /// What: `Decommissioned` → `"decommissioned"`,
+    /// `DecommissionedWorktreeRetained` → `"decommissioned_worktree_retained"`,
+    /// `Removed` → `"removed"`.
     /// Test: `prune_outcome_serializes`.
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Decommissioned => "decommissioned",
+            Self::DecommissionedWorktreeRetained => "decommissioned_worktree_retained",
             Self::Removed => "removed",
         }
     }
@@ -269,7 +289,8 @@ impl PruneAction {
 /// id, tmux name, and prior state — before anything is destroyed.
 /// What: the session id, tmux name, the state the record was in, and the
 /// [`PruneAction`] applied (or that would be applied under `dry_run`).
-/// Test: `prune_dry_run_reports_without_mutating`.
+/// Test: `prune_dry_run_reports_without_mutating`,
+/// `prune_reports_dirty_worktree_retained`.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct PrunedSession {
     /// Managed session id (UUID string).
@@ -280,6 +301,18 @@ pub struct PrunedSession {
     pub state: String,
     /// What the prune did (or would do under `dry_run`).
     pub action: PruneAction,
+    /// The workspace path left on disk when `action` is
+    /// [`PruneAction::DecommissionedWorktreeRetained`]; `None` for every other
+    /// action (including a clean `Decommissioned`, whose workspace was
+    /// removed and therefore has no on-disk path left to report).
+    ///
+    /// Why: the previous version of this struct had no way to tell a caller
+    /// WHERE the retained work is — `decommission` itself now keeps
+    /// `workspace_path` on a retained record for exactly this reason (see
+    /// `decommission_with_root`'s tombstone comment), so this field just
+    /// surfaces that same path at the prune report.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retained_workspace_path: Option<std::path::PathBuf>,
 }
 
 /// The result of a prune: which sessions were (or would be) affected (#1508).
@@ -552,11 +585,18 @@ impl SessionManager {
                 record.state,
                 ManagedSessionState::Decommissioned | ManagedSessionState::Deleted
             );
-            let action = if is_tombstone {
+            // Predicted action for the `dry_run` preview, and the default for
+            // a real run — overwritten below by the ACTUAL `decommission`
+            // result. A dry-run cannot know in advance whether a worktree
+            // will turn out dirty (`inspect_dirt` only runs as part of a real
+            // teardown attempt), so the preview stays optimistic here exactly
+            // as it did before this fix.
+            let mut action = if is_tombstone {
                 PruneAction::Removed
             } else {
                 PruneAction::Decommissioned
             };
+            let mut retained_workspace_path = None;
 
             if !dry_run {
                 if is_tombstone {
@@ -565,9 +605,27 @@ impl SessionManager {
                         warn!(id = %record.id, "prune: compaction remove failed: {e}; skipping");
                         continue;
                     }
-                } else if let Err(e) = self.decommission(&record.id, caller).await {
-                    warn!(id = %record.id, "prune: decommission failed: {e}; skipping");
-                    continue;
+                } else {
+                    match self.decommission(&record.id, caller).await {
+                        Ok((tombstone, workspace_removed)) => {
+                            // The dirty-worktree guard in `decommission` can
+                            // tombstone a record while deliberately leaving its
+                            // in-project worktree on disk. Surface that here
+                            // instead of reporting the same `Decommissioned`
+                            // line regardless of whether the worktree was
+                            // actually removed — the previous version of this
+                            // loop discarded the `bool` half of
+                            // `decommission`'s return entirely.
+                            if !workspace_removed && tombstone.workspace_path.is_some() {
+                                action = PruneAction::DecommissionedWorktreeRetained;
+                                retained_workspace_path = tombstone.workspace_path.clone();
+                            }
+                        }
+                        Err(e) => {
+                            warn!(id = %record.id, "prune: decommission failed: {e}; skipping");
+                            continue;
+                        }
+                    }
                 }
             }
 
@@ -576,6 +634,7 @@ impl SessionManager {
                 tmux_name: record.tmux_name.clone(),
                 state: record.state.to_string(),
                 action,
+                retained_workspace_path,
             });
         }
 

--- a/crates/trusty-mpm/src/session_manager/reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/reconcile.rs
@@ -71,8 +71,14 @@ impl SessionManager {
 
         // Reconcile store records against live sessions.
         for mut record in all_records {
-            // Decommissioned tombstones are never touched by reconciliation.
-            if matches!(record.state, ManagedSessionState::Decommissioned) {
+            // Terminal tombstones (`Decommissioned` OR `Deleted`) are never
+            // touched by reconciliation. Previously this only checked
+            // `Decommissioned` by hand, so every soft-deleted (`Deleted`)
+            // record was silently resurrected to `Stopped` on daemon boot —
+            // `is_terminal()` is the single source of truth for "terminal"
+            // and must be used here so a future terminal variant can never
+            // slip past this check again the way `Deleted` did.
+            if record.state.is_terminal() {
                 continue;
             }
 

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -1941,6 +1941,38 @@ async fn prune_outcome_serializes() {
         v["sessions"][0]["action"],
         serde_json::json!("decommissioned")
     );
+
+    // #4344 review (critic MEDIUM): pin the NEW `DecommissionedWorktreeRetained`
+    // variant's wire form too, so a future rename/reorder of the enum is
+    // caught here rather than only by the `prune_reports_dirty_worktree_retained`
+    // integration test in `decommission_worktree_tests.rs`.
+    assert_eq!(
+        serde_json::to_value(crate::session_manager::PruneAction::DecommissionedWorktreeRetained)
+            .expect("serialize action"),
+        serde_json::json!("decommissioned_worktree_retained")
+    );
+    let retained = crate::session_manager::PrunedSession {
+        id: "id".into(),
+        tmux_name: "tmux".into(),
+        state: "stopped".into(),
+        action: crate::session_manager::PruneAction::DecommissionedWorktreeRetained,
+        retained_workspace_path: Some(PathBuf::from("/tmp/retained-ws")),
+    };
+    let retained_v = serde_json::to_value(&retained).expect("serialize retained row");
+    assert_eq!(
+        retained_v["retained_workspace_path"],
+        serde_json::json!("/tmp/retained-ws"),
+        "retained_workspace_path must serialize as a plain path string when present"
+    );
+    let clean = crate::session_manager::PrunedSession {
+        retained_workspace_path: None,
+        ..retained.clone()
+    };
+    let clean_v = serde_json::to_value(&clean).expect("serialize clean row");
+    assert!(
+        clean_v.get("retained_workspace_path").is_none(),
+        "retained_workspace_path must be OMITTED (not null) when there is nothing retained"
+    );
 }
 
 /// `compact_record` deletes a tombstone from the store (#1508).

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -917,6 +917,75 @@ async fn manager_reconcile_skips_decommissioned() {
     assert_eq!(after.state, ManagedSessionState::Decommissioned);
 }
 
+/// A soft-deleted (`Deleted`) record must survive daemon boot/reconcile
+/// without being resurrected — the same terminal-tombstone guarantee as
+/// `Decommissioned`.
+///
+/// Why: `reconcile_on_boot` used to hand-roll
+/// `matches!(record.state, ManagedSessionState::Decommissioned)` instead of
+/// asking the record's own `is_terminal()`, so a `Deleted` record (no live
+/// tmux session, by definition) fell through to the "gone" branch and was
+/// resurrected to `Stopped` on every daemon boot. `is_terminal()` covers
+/// BOTH `Decommissioned` and `Deleted`, so this is the regression test for
+/// the second terminal variant the hand-rolled check missed.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn manager_reconcile_skips_deleted() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let fake = FakeTmuxDriver::new();
+    let mgr = SessionManager::new(dir.path(), fake.clone()).await.unwrap();
+
+    let deleted = SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: "tmpm-deleted".into(),
+        cwd: PathBuf::from("/tmp"),
+        task: "deleted task".into(),
+        state: ManagedSessionState::Deleted,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: None,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        workspace_owned: false,
+        source_id: None,
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: Default::default(),
+        worktree_owner: None,
+    };
+    {
+        let mut store = mgr.store.write().await;
+        store.upsert(deleted.clone()).await.unwrap();
+    }
+
+    let report = mgr.reconcile_on_boot(false).await.expect("reconcile");
+
+    // Tombstone must not appear in adopted or stopped lists — a resurrection
+    // would show up as this record's id in `report.stopped`.
+    assert!(!report.adopted.contains(&deleted.tmux_name));
+    assert!(
+        !report.stopped.contains(&deleted.id.to_string()),
+        "a Deleted record must never be resurrected to Stopped by reconcile; report: {:?}",
+        report
+    );
+
+    // State must remain Deleted after reconcile — never resurrected.
+    let after = mgr.get(&deleted.id).await.unwrap();
+    assert_eq!(
+        after.state,
+        ManagedSessionState::Deleted,
+        "a Deleted record must survive daemon boot/reconcile without being resurrected"
+    );
+}
+
 #[tokio::test]
 async fn manager_send_input() {
     let dir = crate::test_support::hermetic_temp_dir();


### PR DESCRIPTION
## Summary

Two related daemon-safety fixes.

- **Fix A — reconcile resurrects soft-deleted sessions.**
  `crates/trusty-mpm/src/session_manager/reconcile.rs:75` hand-rolled
  `matches!(record.state, ManagedSessionState::Decommissioned)` instead of
  asking the record's own `is_terminal()`. Every soft-deleted (`Deleted`)
  record fell through to the "gone" branch and was marked `Stopped` —
  resurrected — on every daemon boot. Switched to `is_terminal()`, which
  covers both `Decommissioned` and `Deleted`.

- **Fix B — decommission force-deletes dirty worktrees with no check.**
  `crates/trusty-mpm/src/session_manager/decommission.rs` (the
  `is_session_worktree` branch of `decommission_with_root`) ran `git worktree
  remove --force` (falling back to `fs::remove_dir_all`) unconditionally.
  `tm sessions prune --state stopped` calls `decommission` per matching
  record, so a stopped session with uncommitted/untracked work in its
  in-project worktree was silently destroyed. Reused the existing
  `worktree_safety::inspect_dirt` check (the same one `prune_orphaned_worktrees`
  already uses for the orphan-worktree sweep, from the #4091 dirty-worktree
  guard) to gate this second, previously-uncovered removal path: a dirty
  candidate is now refused and reported (the record still tombstones to
  `Decommissioned`, consistent with every other "skip removal" branch in this
  function).

  The existing happy-path test
  (`manager_decommission_removes_real_git_worktree`) built its base clone with
  no remote at all, which `inspect_dirt`'s unpushed-commit check treats as
  fully unpushed (nothing for `--not --remotes` to exclude) — so it needed a
  bare-remote push added to stay genuinely clean under the new gate.

## Test plan

- [x] `cargo fmt --check -p trusty-mpm`
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- [x] `cargo test -p trusty-mpm` (full suite, not `--lib`-only) — 3946 + 1284×2
      + integration-binary tests, 0 failed
- [x] New regression tests:
  - `session_manager::tests::manager_reconcile_skips_deleted` — a `Deleted`
    record survives `reconcile_on_boot` without being resurrected
  - `session_manager::decommission_worktree_tests::manager_decommission_refuses_dirty_worktree` —
    a real git worktree holding an untracked file survives `decommission`,
    `workspace_removed` is `false`, and the record still tombstones

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools