### PR TITLE
fix(installer): probe daemon health over HTTP instead of a nonexistent CLI verb (#4246)

### DIFF
--- a/crates/trusty-installer/src/commands/ensure/mod.rs
+++ b/crates/trusty-installer/src/commands/ensure/mod.rs
@@ -34,15 +34,17 @@ pub mod report;
 
 /// Process-wide lock serialising tests that mutate global env vars.
 ///
-/// Why: several ensure submodule tests set/remove `TRUSTY_DATA_DIR_OVERRIDE`,
-/// `TCTL_ENSURE_WAIT_*`, etc. Those are process-global, so tests in different
-/// modules would race each other. A single crate-shared lock — held for the
-/// duration of each env-mutating test across every ensure submodule — serialises
-/// them so the assertions are deterministic.
-/// What: a `Mutex<()>` accessible to every ensure submodule's test code.
+/// Why: this used to be defined here, because `ensure`'s submodules were the
+/// only env-mutating tests in the crate. #4246 gave `probe_http` and
+/// `verify_tail` the same need, so the lock (and the stub-server helpers that go
+/// with it) moved to `commands::test_support`. Re-exported under the original
+/// path so the existing `use crate::commands::ensure::ENV_TEST_LOCK` imports in
+/// `daemon`, `project_setup` and `readiness` keep working — there is still
+/// exactly ONE lock in the process, which is the whole point.
+/// What: a re-export of [`crate::commands::test_support::ENV_TEST_LOCK`].
 /// Test: used by the env-mutating tests in `daemon`, `project_setup`, `readiness`.
 #[cfg(test)]
-pub(crate) static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+pub(crate) use crate::commands::test_support::ENV_TEST_LOCK;
 
 use crate::commands::runtime::block_on;
 use mcp_patch::MCP_FILE;

--- a/crates/trusty-installer/src/commands/ensure/project_setup.rs
+++ b/crates/trusty-installer/src/commands/ensure/project_setup.rs
@@ -244,87 +244,11 @@ pub async fn run_stages(project_root: &std::path::Path) -> Vec<StageOutcome> {
 mod tests {
     use super::*;
     use crate::commands::ensure::ENV_TEST_LOCK as ENV_LOCK;
-    use trusty_common::DATA_DIR_OVERRIDE_ENV;
-
-    /// Spawn a one-shot TCP server that answers the first request with a fixed
-    /// HTTP response, and return its `host:port`.
-    ///
-    /// Why: standing up a real `reqwest` round-trip against a controlled
-    /// response lets the stage logic be tested end-to-end without a live daemon.
-    /// What: binds an ephemeral loopback port, accepts one connection, reads the
-    /// request, writes `response_body` wrapped in a 200 (or the raw status line
-    /// when `raw` is set), and returns the bound address.
-    async fn stub_once(status_line: &'static str, body: &'static str) -> String {
-        stub_seq(vec![(status_line, body)]).await
-    }
-
-    /// Spawn a TCP server that answers a *sequence* of requests, one fixed
-    /// response per accepted connection in order.
-    ///
-    /// Why: the palace-create stage issues two requests (an existence GET then a
-    /// create POST); covering the "created" branch needs a stub that 404s the
-    /// GET then 200s the POST.
-    /// What: binds an ephemeral loopback port, accepts `responses.len()`
-    /// connections, and writes each `(status_line, body)` in turn.
-    async fn stub_seq(responses: Vec<(&'static str, &'static str)>) -> String {
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let addr = listener.local_addr().unwrap().to_string();
-        tokio::spawn(async move {
-            use tokio::io::{AsyncReadExt, AsyncWriteExt};
-            for (status_line, body) in responses {
-                if let Ok((mut sock, _)) = listener.accept().await {
-                    // Drain the request up to (and including) the end-of-headers
-                    // marker before replying. A single fixed-size read can split
-                    // a request whose `root_path` body is long, which used to
-                    // race the write and flake CI; reading until `\r\n\r\n` (or
-                    // EOF) consumes the whole header block deterministically. We
-                    // don't need the body — only that the request is fully sent.
-                    let mut acc = Vec::with_capacity(2048);
-                    let mut chunk = [0u8; 2048];
-                    loop {
-                        match sock.read(&mut chunk).await {
-                            Ok(0) => break,
-                            Ok(n) => {
-                                acc.extend_from_slice(&chunk[..n]);
-                                if acc.windows(4).any(|w| w == b"\r\n\r\n") {
-                                    break;
-                                }
-                            }
-                            Err(_) => break,
-                        }
-                    }
-                    let resp = format!(
-                        "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
-                        body.len()
-                    );
-                    let _ = sock.write_all(resp.as_bytes()).await;
-                    let _ = sock.shutdown().await;
-                } else {
-                    break;
-                }
-            }
-        });
-        addr
-    }
-
-    fn stub_data_dir(app: &str, addr: &str) -> std::path::PathBuf {
-        let tmp = std::env::temp_dir().join(format!(
-            "tctl-ensure-setup-{}-{}-{}",
-            app,
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&tmp).unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::set_var(DATA_DIR_OVERRIDE_ENV, &tmp);
-        }
-        trusty_common::write_daemon_addr(app, addr).unwrap();
-        tmp
-    }
+    // #4246: the stub-server + stubbed-data-dir vehicle these tests grew is now
+    // shared with `probe_http`/`verify_tail` — one copy, in `test_support`.
+    use crate::commands::test_support::{
+        clear_data_dir_override, stub_data_dir, stub_empty_data_dir, stub_once, stub_seq,
+    };
 
     /// Why: a fresh registration (`created:true`) must report `changed = true`.
     /// What: stub returns `{"created":true}`; assert the outcome.
@@ -338,11 +262,7 @@ mod tests {
         let out = register_index(&client, std::path::Path::new("/tmp/proj"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+        clear_data_dir_override(&dir);
         assert_eq!(out.stage, STAGE_INDEX);
         assert!(out.ok);
         assert!(out.changed);
@@ -361,11 +281,7 @@ mod tests {
         let out = register_index(&client, std::path::Path::new("/tmp/proj"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+        clear_data_dir_override(&dir);
         assert!(out.ok);
         assert!(!out.changed);
     }
@@ -383,11 +299,7 @@ mod tests {
         let out = register_index(&client, std::path::Path::new("/tmp/proj"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+        clear_data_dir_override(&dir);
         assert!(!out.ok);
     }
 
@@ -398,28 +310,12 @@ mod tests {
     #[tokio::test]
     async fn register_index_daemon_down() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let tmp = std::env::temp_dir().join(format!(
-            "tctl-ensure-down-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&tmp).unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::set_var(DATA_DIR_OVERRIDE_ENV, &tmp);
-        }
+        let tmp = stub_empty_data_dir("tctl-ensure-down");
         let client = build_client().unwrap();
         let out = register_index(&client, std::path::Path::new("/tmp/proj"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&tmp);
+        clear_data_dir_override(&tmp);
         assert!(out.ok);
         assert!(!out.changed);
         assert!(out.detail.contains("not running"));
@@ -432,28 +328,12 @@ mod tests {
     #[tokio::test]
     async fn create_palace_daemon_down() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        let tmp = std::env::temp_dir().join(format!(
-            "tctl-ensure-pdown-{}-{}",
-            std::process::id(),
-            std::time::SystemTime::now()
-                .duration_since(std::time::UNIX_EPOCH)
-                .map(|d| d.as_nanos())
-                .unwrap_or(0)
-        ));
-        std::fs::create_dir_all(&tmp).unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::set_var(DATA_DIR_OVERRIDE_ENV, &tmp);
-        }
+        let tmp = stub_empty_data_dir("tctl-ensure-pdown");
         let client = build_client().unwrap();
         let out = create_palace(&client, std::path::Path::new("/tmp/widget"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&tmp);
+        clear_data_dir_override(&tmp);
         assert_eq!(out.stage, STAGE_PALACE);
         assert!(out.ok);
         assert!(!out.changed);
@@ -477,11 +357,7 @@ mod tests {
         let out = create_palace(&client, std::path::Path::new("/tmp/widget"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+        clear_data_dir_override(&dir);
         assert_eq!(out.stage, STAGE_PALACE);
         assert!(out.ok, "detail: {}", out.detail);
         assert!(out.changed);
@@ -500,11 +376,7 @@ mod tests {
         let out = create_palace(&client, std::path::Path::new("/tmp/widget"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+        clear_data_dir_override(&dir);
         assert!(out.ok);
         assert!(!out.changed);
         assert!(out.detail.contains("already exists"));
@@ -528,11 +400,7 @@ mod tests {
         let out = create_palace(&client, std::path::Path::new("/tmp/widget"))
             .await
             .unwrap();
-        unsafe {
-            // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
-            std::env::remove_var(DATA_DIR_OVERRIDE_ENV);
-        }
-        let _ = std::fs::remove_dir_all(&dir);
+        clear_data_dir_override(&dir);
         assert!(!out.ok);
     }
 }

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -28,6 +28,8 @@ pub mod plist_label;
 pub mod port;
 pub mod prereqs;
 pub mod probe;
+// #4246: the HTTP `/health` transport behind every health verdict.
+pub mod probe_http;
 pub mod progress_ui;
 pub mod runtime;
 pub mod self_update;

--- a/crates/trusty-installer/src/commands/mod.rs
+++ b/crates/trusty-installer/src/commands/mod.rs
@@ -37,6 +37,9 @@ pub mod sign;
 pub mod stable_set;
 pub mod stack;
 pub mod status;
+// #4246: stub servers + stubbed data dir shared by the probe/verify tests.
+#[cfg(test)]
+pub mod test_support;
 pub mod tmux_gap;
 pub mod ui;
 pub mod up;

--- a/crates/trusty-installer/src/commands/probe.rs
+++ b/crates/trusty-installer/src/commands/probe.rs
@@ -1,145 +1,39 @@
 //! Shared member-probing primitives (health, version envelope, config spawn).
 //!
-//! Why: `status`, `stack health`, `stack doctor`, `doctor --self-check`, and
-//! `config` all shell out to a member's DOC-1 contract verbs and classify the
-//! result. Hoisting the spawn + parse + classification into one module keeps the
-//! command handlers thin and means the (pure) classification logic is unit-tested
-//! once rather than duplicated per command (DRY; CLAUDE.md 500-SLOC cap).
+//! Why: `status`, `stack health`, `stack doctor`, `doctor --self-check`, `up` and
+//! the install verify tail all need one member's health verdict, and `config` /
+//! `doctor` also forward a member's `--json` contract verb. Hoisting resolution +
+//! probe + classification into one module keeps the command handlers thin and
+//! means the decision logic is unit-tested once rather than per command (DRY;
+//! CLAUDE.md 500-SLOC cap).
+//!
+//! #4246: [`probe_member_health`] used to spawn `<binary> health --json` — a
+//! contract no shipped daemon implements — and collapse every failure into
+//! `down`, which then drove `launchctl kickstart -k` against healthy daemons. It
+//! now delegates to the HTTP `/health` transport in [`super::probe_http`] and
+//! returns a TYPED [`ProbeOutcome`] so the destructive repair can be gated on a
+//! real transport-level observation. `classify_health_json` and the
+//! `output_with_timeout` subprocess wrapper it needed were deleted with the
+//! transport they served.
 //!
 //! What:
-//! - [`probe_member_health`] / [`classify_health_json`] / [`health_string`]:
-//!   the launchd-daemon health probe (`<binary> health --json`), strategy-aware
-//!   so process-managed members (trusty-mpm) that lack a `health --json` verb
-//!   are reported `unknown` rather than falsely `down`.
+//! - [`probe_member_health`] / [`health_string`]: the strategy-aware daemon
+//!   health probe. Process-managed members (trusty-mpm) are reported
+//!   `Unprobeable` rather than falsely `down`.
 //! - [`spawn_member_json`]: spawn `<binary> <verb> --json` and return parsed JSON.
 //! - [`validate_version_envelope`]: the DOC-1 conformance check used by
 //!   `doctor --self-check` (asserts `contract_version` + `verbs[]`).
 //!
-//! Test: `tests` covers `classify_health_json`, `health_string`,
-//! `validate_version_envelope`, and the strategy gating in `probe_member_health`
-//! (the parse/classify halves; the subprocess spawn itself is side-effecting).
+//! Test: `tests` covers `health_string`, `validate_version_envelope`, the
+//! strategy gating in `probe_member_health`, and (against a stub server) the
+//! launchd arm end-to-end — a path no test executed before #4246.
 
-use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::{Duration, Instant};
 
+use super::probe_http::{probe_member_http_blocking, ProbeOutcome};
 use super::stable_set::ManageStrategy;
 use super::up::member::MemberHealth;
-use super::up::system_runner::classify_status;
-
-/// Bound on how long a single `<binary> health --json` subprocess may run
-/// before it is treated as a hung probe (#3875).
-///
-/// Why: [`super::verify_tail`]'s poll-until-ready loop bounds the NUMBER of
-/// probe attempts (`bounded_attempts`/`POLL_MAX_ATTEMPTS`) and the AGGREGATE
-/// wall-clock budget across all members, but every one of those bounds
-/// assumed a single probe call itself returns promptly. VM evidence (#3875)
-/// showed `tctl install` hanging >6 minutes at "waiting for trusty-search to
-/// start..." with a genuinely-dead daemon: the child `health --json` process
-/// itself never exited (e.g. blocked on a half-open socket to the dead
-/// daemon), so `Command::output()` — which blocks until EOF on both pipes —
-/// never returned, defeating every attempt/aggregate bound above it.
-/// What: 10s — generous for a live daemon's near-instant `health --json`
-/// reply, short enough that a single hung probe can never itself consume more
-/// than a small slice of `verify_tail`'s ~120s aggregate budget.
-const HEALTH_PROBE_TIMEOUT: Duration = Duration::from_secs(10);
-
-/// Run `cmd`, killing it and returning a timeout error if it has not exited
-/// within `timeout` (#3875).
-///
-/// Why: `std::process::Command::output()` has no built-in timeout — a hung
-/// child (dead daemon, wedged health check) blocks the caller forever. This
-/// wraps spawn + a bounded `try_wait` poll, killing the child on expiry, so
-/// no caller of a subprocess health probe can hang indefinitely.
-/// What: spawns `cmd` with piped stdout/stderr, drains both pipes
-/// concurrently on background threads (so a chatty child can never deadlock
-/// on a full pipe buffer while we're only polling `try_wait`), and polls
-/// `try_wait` every 25ms. On timeout, kills + reaps the child, then gives the
-/// reader threads a short (200ms) bounded grace period to observe EOF (killing
-/// the child closes our end of its pipes, so this is normally near-instant)
-/// before giving up and detaching them — a genuinely stuck grandchild-held
-/// pipe never turns a bounded probe into an unbounded one. On normal exit,
-/// joins the reader threads and returns the collected `Output`.
-/// Test: `tests::output_with_timeout_returns_output_for_fast_command`,
-/// `tests::output_with_timeout_kills_hung_command`,
-/// `tests::output_with_timeout_repeated_timeouts_stay_bounded`.
-fn output_with_timeout(
-    mut cmd: Command,
-    timeout: Duration,
-) -> std::io::Result<std::process::Output> {
-    cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::piped());
-    let mut child = cmd.spawn()?;
-
-    let stdout_pipe = child.stdout.take();
-    let stderr_pipe = child.stderr.take();
-    let stdout_handle = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut p) = stdout_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        buf
-    });
-    let stderr_handle = std::thread::spawn(move || {
-        let mut buf = Vec::new();
-        if let Some(mut p) = stderr_pipe {
-            let _ = p.read_to_end(&mut buf);
-        }
-        buf
-    });
-
-    let start = Instant::now();
-    let status = loop {
-        if let Some(status) = child.try_wait()? {
-            break status;
-        }
-        if start.elapsed() >= timeout {
-            let _ = child.kill();
-            let _ = child.wait();
-            // #3897 code-critic LOW: reclaim the reader threads on the
-            // timeout path too, not just the success path below — otherwise
-            // every timed-out probe silently detaches two threads. `kill` +
-            // `wait` above closes OUR end of the pipes; in the overwhelmingly
-            // common case (no grandchild inherited the fd) that alone makes
-            // the readers' `read_to_end` see EOF within microseconds, so a
-            // short bounded grace period reclaims them without making the
-            // timeout path itself block noticeably longer. If a grandchild
-            // somehow still holds the pipe open past the grace period, we
-            // deliberately stop waiting (never turn a bounded probe into an
-            // unbounded one) — the readers are dropped/detached and the
-            // process is short-lived (`tctl` exits once verify_tail
-            // finishes), so the worst case is a handful of stray threads for
-            // the remainder of THIS invocation, never an unbounded
-            // accumulation across probes.
-            let join_deadline = Instant::now() + Duration::from_millis(200);
-            while Instant::now() < join_deadline
-                && (!stdout_handle.is_finished() || !stderr_handle.is_finished())
-            {
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            if stdout_handle.is_finished() {
-                let _ = stdout_handle.join();
-            }
-            if stderr_handle.is_finished() {
-                let _ = stderr_handle.join();
-            }
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::TimedOut,
-                format!("command timed out after {timeout:?}"),
-            ));
-        }
-        std::thread::sleep(Duration::from_millis(25));
-    };
-
-    let stdout = stdout_handle.join().unwrap_or_default();
-    let stderr = stderr_handle.join().unwrap_or_default();
-    Ok(std::process::Output {
-        status,
-        stdout,
-        stderr,
-    })
-}
 
 /// Whether `path` exists and is executable (unix) / a regular file (other
 /// platforms) — the concrete-file half of [`resolve_binary_path`]'s #3876
@@ -201,25 +95,6 @@ pub mod health_str {
     pub const UNKNOWN: &str = "unknown";
 }
 
-/// Classify a daemon's `health --json` stdout bytes into a [`MemberHealth`].
-///
-/// Why: Isolating the parse + classification as a pure function makes the
-/// fallback policy testable without spawning a subprocess. Unparseable output is
-/// `Down`, not `HealthyStale` — "if in doubt, degraded".
-/// What: Parses `bytes` as JSON; on success maps the `status` field via
-/// `classify_status` (defaulting to `down` when the field is absent). On a parse
-/// failure returns `Down`.
-/// Test: `tests::unparseable_health_is_down`, `tests::parsed_status_classifies`.
-pub fn classify_health_json(bytes: &[u8]) -> MemberHealth {
-    match serde_json::from_slice::<serde_json::Value>(bytes) {
-        Ok(v) => {
-            let status = v.get("status").and_then(|s| s.as_str()).unwrap_or("down");
-            classify_status(status)
-        }
-        Err(_) => MemberHealth::Down,
-    }
-}
-
 /// Map a [`MemberHealth`] to the rollup commands' coarse string.
 ///
 /// Why: The reports use a flat string vocabulary; centralise the mapping so
@@ -238,38 +113,47 @@ pub fn health_string(h: MemberHealth) -> &'static str {
 
 /// Probe a member's health, honouring its lifecycle [`ManageStrategy`].
 ///
-/// Why: The launchd daemons advertise `<binary> health --json`, but a
-/// process-managed member (trusty-mpm) has NO top-level `health --json` verb
-/// (verified in `crates/trusty-mpm/src/bin/tm/cli.rs`). Probing it with the
-/// standard verb would always fail and falsely report `down`; returning a flat
-/// `unknown` string instead keeps the rollup honest without claiming a false
-/// verdict in either direction.
-/// What: returns `not_installed` when [`resolve_binary_path`] finds the binary
-/// neither on `PATH` NOR in the default install directory (#3876). For a
-/// `Launchd` member, spawns `<resolved path> health --json` under a bounded
-/// timeout (#3875) and classifies the envelope. For an `OwnVerb` member,
-/// returns `unknown` (health is not probeable via the standard contract). For
-/// `None` (non-daemon), returns `unknown` too (callers should not ask, but it
-/// is a safe default).
-/// Test: `tests::own_verb_member_is_unknown`; the launchd spawn is side-effecting
-/// and its parse half is covered by `classify_health_json`.
-pub fn probe_member_health(binary: &str, manage: ManageStrategy) -> String {
-    let Some(bin_path) = resolve_binary_path(binary) else {
-        return health_str::NOT_INSTALLED.to_owned();
-    };
+/// Why (#4246): this is THE health probe every `tctl` rollup and the install
+/// verify tail agree on. It used to spawn `<binary> health --json`, a contract no
+/// shipped daemon implements, so every daemon read `down` while every one of them
+/// was answering `GET /health` — and that false `down` drove `launchctl kickstart
+/// -k`, hard-restarting a healthy stack on every `tctl install`. It now probes
+/// over HTTP and returns a TYPED outcome instead of a flat `String`, because the
+/// only safe basis for a destructive repair is a transport-level observation
+/// ([`ProbeOutcome::is_confirmed_down`]) — a distinction a `String` cannot carry.
+///
+/// # Postconditions
+/// - A binary resolvable on neither `PATH` nor the default install directory is
+///   [`ProbeOutcome::NotInstalled`] (#3876) — the probe never runs.
+/// - A `Launchd` member is probed over HTTP via [`super::probe_http`].
+/// - An `OwnVerb`/`None` member is [`ProbeOutcome::Unprobeable`], rendering
+///   `unknown`, and can therefore never be kickstarted.
+///
+/// What: resolves the binary, then dispatches on `manage`. The `app` name handed
+/// to the transport is the BINARY name — the `http_addr` discovery file is keyed
+/// by app name, and `crate_name == binary == app name` holds for every stable-set
+/// daemon (see `stable_set`; the one member where it does not, trusty-mpm which
+/// ships both `tm` and `trusty-mpm`, takes the `OwnVerb` arm and is never
+/// probed).
+/// Test: `tests::own_verb_member_is_unknown`,
+/// `tests::probe_member_health_serves_from_http_addr`,
+/// `tests::probe_member_health_refused_when_nothing_listens`.
+pub fn probe_member_health(binary: &str, manage: ManageStrategy) -> ProbeOutcome {
+    if resolve_binary_path(binary).is_none() {
+        return ProbeOutcome::NotInstalled;
+    }
     match manage {
-        ManageStrategy::Launchd => {
-            let mut cmd = Command::new(&bin_path);
-            cmd.args(["health", "--json"]);
-            let out = output_with_timeout(cmd, HEALTH_PROBE_TIMEOUT);
-            let health = match out {
-                Ok(out) if out.status.success() => classify_health_json(&out.stdout),
-                Ok(_) | Err(_) => MemberHealth::Down,
-            };
-            health_string(health).to_owned()
-        }
-        // Process-managed (mpm) / non-daemon: no standard health verb.
-        ManageStrategy::OwnVerb | ManageStrategy::None => health_str::UNKNOWN.to_owned(),
+        ManageStrategy::Launchd => probe_member_http_blocking(binary, binary),
+        // #4246: trusty-mpm (`OwnVerb`) is DELIBERATELY left unprobed and
+        // reported `unknown`, even though it does answer `/health` on 7880.
+        // It is `required: true` (`stable_set`), and `unknown` is the only
+        // verdict `VerifyTailReport::build` and `status`'s exit code tolerate —
+        // so probing it would flip `tctl status` to exit 2 and `tctl install` to
+        // NOT VERIFIED for every user who simply has not started mpm. Enabling
+        // it is a separate, user-visible policy change, tracked separately.
+        // `None` (non-daemon) never reaches here in production (callers filter on
+        // `m.daemon`) but shares the safe default.
+        ManageStrategy::OwnVerb | ManageStrategy::None => ProbeOutcome::Unprobeable,
     }
 }
 
@@ -354,31 +238,6 @@ pub fn validate_version_envelope(v: &serde_json::Value) -> VersionConformance {
 mod tests {
     use super::*;
 
-    /// Why: Unparseable health output means the daemon is BROKEN, not stale.
-    /// What: Feeds non-JSON / empty bytes; asserts `Down`.
-    /// Test: This is the test.
-    #[test]
-    fn unparseable_health_is_down() {
-        assert_eq!(classify_health_json(b"not json"), MemberHealth::Down);
-        assert_eq!(classify_health_json(b""), MemberHealth::Down);
-    }
-
-    /// Why: Valid JSON must classify via the shared `classify_status` vocabulary.
-    /// What: Feeds healthy / stale / field-less JSON; asserts each mapping.
-    /// Test: This is the test.
-    #[test]
-    fn parsed_status_classifies() {
-        assert_eq!(
-            classify_health_json(br#"{"status":"healthy"}"#),
-            MemberHealth::HealthyVersionOk
-        );
-        assert_eq!(
-            classify_health_json(br#"{"status":"stale"}"#),
-            MemberHealth::HealthyStale
-        );
-        assert_eq!(classify_health_json(br#"{"x":1}"#), MemberHealth::Down);
-    }
-
     /// Why: The health-string mapping is the rollup vocabulary; pin it.
     /// What: Asserts each `MemberHealth` → string.
     /// Test: This is the test.
@@ -390,87 +249,92 @@ mod tests {
         assert_eq!(health_string(MemberHealth::NotInstalled), "not_installed");
     }
 
-    /// Why: A process-managed member (mpm) lacks a `health --json` verb, so its
-    /// health must be `unknown`, never a false `down`/`healthy`. Pin the gating
-    /// independent of whether the binary happens to be installed by skipping the
-    /// PATH check via the strategy branch (we only assert the OwnVerb arm).
-    /// What: When the binary is absent it reads `not_installed`; when present it
-    /// would read `unknown`. We assert the value is one of those two — never a
-    /// launchd verdict — to keep the test environment-independent.
+    /// Why: an absent binary must short-circuit to `NotInstalled` BEFORE any
+    /// probe runs — resolution failure is a fact about the filesystem, not
+    /// evidence about a daemon, and probing anyway would waste a connect bound
+    /// per member on a partially-installed stack.
+    /// What: a deliberately-fake binary name yields `NotInstalled` for every
+    /// strategy.
+    /// Test: This is the test.
+    #[test]
+    fn absent_binary_is_not_installed_for_every_strategy() {
+        for manage in [
+            ManageStrategy::Launchd,
+            ManageStrategy::OwnVerb,
+            ManageStrategy::None,
+        ] {
+            assert_eq!(
+                probe_member_health("definitely-not-a-real-binary-xyz", manage),
+                ProbeOutcome::NotInstalled,
+                "{manage:?}"
+            );
+        }
+    }
+
+    /// Why (#4246): trusty-mpm is `required: true`, and `unknown` is the only
+    /// verdict `VerifyTailReport::build` and `status`'s exit code tolerate — so
+    /// the `OwnVerb` arm staying `Unprobeable` is what keeps `tctl status` from
+    /// exiting 2, and `tctl install` from printing NOT VERIFIED, for every user
+    /// who has simply not started mpm. Deliberately unchanged by this fix; pin
+    /// it so a well-meaning follow-up cannot flip it silently.
+    /// What: an INSTALLED binary probed with `OwnVerb` is `Unprobeable` and
+    /// renders `unknown`, never a launchd verdict.
     /// Test: This is the test.
     #[test]
     fn own_verb_member_is_unknown() {
-        let h = probe_member_health("definitely-not-a-real-binary-xyz", ManageStrategy::OwnVerb);
-        // Absent binary short-circuits to not_installed before the strategy arm.
-        assert_eq!(h, health_str::NOT_INSTALLED);
-    }
-
-    /// Why (#3875): a fast, well-behaved command must return its real output
-    /// through the timeout wrapper — the wrapper must not alter normal
-    /// (non-hung) behaviour.
-    /// What: runs `/bin/echo hello` (or `cmd /C echo hello` on non-unix) under
-    /// a generous timeout; asserts success + the expected stdout.
-    /// Test: This is the test.
-    #[test]
-    fn output_with_timeout_returns_output_for_fast_command() {
-        let mut cmd = Command::new("echo");
-        cmd.arg("hello");
-        let out = output_with_timeout(cmd, Duration::from_secs(5)).expect("echo should run");
-        assert!(out.status.success());
-        assert_eq!(String::from_utf8_lossy(&out.stdout).trim(), "hello");
-    }
-
-    /// Why (#3875): the entire point of the wrapper is that a hung child must
-    /// never block the caller past the bound — this is the regression test for
-    /// the VM hang (`tctl install` stuck >6 min at "waiting for trusty-search
-    /// to start...").
-    /// What: runs `sleep 60` under a 1s timeout; asserts the call returns
-    /// (rather than hanging) and yields a `TimedOut` error, well within a
-    /// generous wall-clock assertion.
-    /// Test: This is the test.
-    #[test]
-    fn output_with_timeout_kills_hung_command() {
-        let mut cmd = Command::new("sleep");
-        cmd.arg("60");
-        let start = Instant::now();
-        let err = output_with_timeout(cmd, Duration::from_secs(1))
-            .expect_err("a 60s sleep must not complete within a 1s timeout");
-        assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
-        assert!(
-            start.elapsed() < Duration::from_secs(10),
-            "timeout wrapper took far longer than its 1s bound: {:?}",
-            start.elapsed()
+        let outcome = probe_member_health(
+            crate::commands::test_support::PROBEABLE_BINARY,
+            ManageStrategy::OwnVerb,
         );
+        assert_eq!(outcome, ProbeOutcome::Unprobeable);
+        assert_eq!(outcome.health_string(), health_str::UNKNOWN);
+        assert!(!outcome.is_confirmed_down());
     }
 
-    /// Why (#3897 code-critic LOW): a timed-out probe must reclaim its
-    /// reader threads within a small bounded grace period, not just detach
-    /// them forever — otherwise every kickstart/verify probe against a
-    /// genuinely-dead daemon leaks two threads. Killing the child closes our
-    /// end of its pipes, so (absent a grandchild inheriting the fd) the
-    /// readers see EOF almost immediately; running several timeouts back to
-    /// back proves the per-call grace period isn't itself compounding into
-    /// unbounded wall-clock growth.
-    /// What: runs 3 back-to-back 1s-bound timeouts against `sleep 60`;
-    /// asserts each is `TimedOut` and the TOTAL elapsed stays well under
-    /// `3 * (timeout + grace-period + overhead)`, i.e. no call is silently
-    /// blocking on the previous call's reader threads.
+    /// Why (#4246): THE path no test in this crate ever executed — the launchd
+    /// arm end-to-end, from `resolve_binary_path` through `http_addr` discovery
+    /// to the HTTP round trip. `tctl status` reported six healthy daemons as
+    /// `down` for months precisely because nothing exercised it.
+    /// What: plants an `http_addr` pointing at a stub answering
+    /// `{"status":"ok"}` and asserts the probe reports it serving/`healthy`.
     /// Test: This is the test.
     #[test]
-    fn output_with_timeout_repeated_timeouts_stay_bounded() {
-        let start = Instant::now();
-        for _ in 0..3 {
-            let mut cmd = Command::new("sleep");
-            cmd.arg("60");
-            let err = output_with_timeout(cmd, Duration::from_secs(1))
-                .expect_err("a 60s sleep must not complete within a 1s timeout");
-            assert_eq!(err.kind(), std::io::ErrorKind::TimedOut);
-        }
-        assert!(
-            start.elapsed() < Duration::from_secs(15),
-            "3 sequential 1s timeouts took far longer than expected: {:?}",
-            start.elapsed()
+    fn probe_member_health_serves_from_http_addr() {
+        use crate::commands::test_support as ts;
+        let _guard = ts::ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let addr = ts::stub_seq_blocking(vec![("HTTP/1.1 200 OK", r#"{"status":"ok"}"#)]);
+        let dir = ts::stub_data_dir(ts::PROBEABLE_BINARY, &addr);
+        let outcome = probe_member_health(ts::PROBEABLE_BINARY, ManageStrategy::Launchd);
+        ts::clear_data_dir_override(&dir);
+
+        assert_eq!(
+            outcome,
+            ProbeOutcome::Serving {
+                status: "ok".to_owned(),
+                version: None,
+            }
         );
+        assert_eq!(outcome.health_string(), health_str::HEALTHY);
+    }
+
+    /// Why (#4246): the mirror — a member whose recorded address refuses must
+    /// still reach `Refused`, or the fix would trade a false `down` for a stack
+    /// that is never repaired. This is the ONLY outcome (with `Timeout`) allowed
+    /// to authorise a kickstart.
+    /// What: plants an `http_addr` pointing at a released ephemeral port and
+    /// asserts `Refused` + `is_confirmed_down`.
+    /// Test: This is the test.
+    #[test]
+    fn probe_member_health_refused_when_nothing_listens() {
+        use crate::commands::test_support as ts;
+        let _guard = ts::ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = ts::stub_data_dir(ts::PROBEABLE_BINARY, &ts::dead_addr());
+        let outcome = probe_member_health(ts::PROBEABLE_BINARY, ManageStrategy::Launchd);
+        ts::clear_data_dir_override(&dir);
+
+        assert_eq!(outcome, ProbeOutcome::Refused);
+        assert!(outcome.is_confirmed_down());
+        assert_eq!(outcome.health_string(), health_str::DOWN);
     }
 
     /// Why (#3876): the verify table must not report a genuinely-installed

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -485,7 +485,7 @@ async fn probe_url(client: &reqwest::Client, base: &str) -> ProbeOutcome {
 /// be `None`. A read error is treated as "no recorded address" — it is not
 /// evidence about the daemon.
 /// Test: `tests::resolve_probe_bases_reads_http_addr`,
-/// `tests::resolve_probe_bases_none_for_unknown_binary`.
+/// `tests::probe_no_address_when_nothing_resolves`.
 pub fn resolve_probe_bases(app: &str, binary: &str) -> (Option<String>, Option<String>) {
     let recorded = trusty_common::read_daemon_addr(app)
         .ok()

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -1,0 +1,609 @@
+//! HTTP `GET /health` daemon probe — the transport behind every `tctl` health
+//! verdict (#4246).
+//!
+//! Why: `tctl` used to probe a daemon by spawning `<binary> health --json` — a
+//! contract NO shipped daemon implements. Every distinct failure (clap exit 2
+//! for a missing subcommand, an unsupported `--json` flag, a schema mismatch, a
+//! hung child) collapsed into a single `MemberHealth::Down`, so `tctl status`
+//! reported six healthy daemons as `down`. That false `down` then drove
+//! `verify_tail::needs_kickstart` into `launchctl kickstart -k`, meaning **every
+//! `tctl install` hard-restarted a fully healthy stack** — the real harm behind
+//! #4246, up to and including a SIGKILL of trusty-search mid-index-flush (the
+//! shared plist renderer emits no `ExitTimeOut`, so launchd's default 20s bound
+//! fires well inside search's ≥30s-per-index flush budget).
+//!
+//! Every one of those daemons *does* answer `GET /health` over loopback today,
+//! so this module replaces the subprocess contract with the transport that
+//! actually exists. Three properties are load-bearing and each has a named
+//! regression test — remove any one of them and #4246 comes straight back:
+//!
+//! 1. **[`build_probe_client`] calls `.no_proxy()`.** reqwest 0.12 honours
+//!    `HTTP_PROXY`/`http_proxy`/`ALL_PROXY` for `127.0.0.1` — hyper-util's proxy
+//!    matcher has no loopback exemption, so a developer with a proxy exported
+//!    reproduces the identical false `down` through the NEW transport.
+//! 2. **Dual resolution with an explicit precedence rule** — see [`reconcile`].
+//!    A daemon that port-walked off its documented default (trusty-memory walks
+//!    `7070..=7079`) makes the fixed-port leg refuse while it is perfectly
+//!    healthy; treating that refusal as authoritative would kickstart a healthy
+//!    daemon, i.e. re-ship the bug.
+//! 3. **Classification reads the BODY and accepts non-2xx** — see
+//!    [`classify_response`]. trusty-analyze answers **HTTP 503** with
+//!    `status:"degraded"` when search is unreachable; a 2xx-only liveness check
+//!    (`ensure::daemon::health_ok`) calls that `down` and kickstarts it, while
+//!    trusty-review answers **200** + the same `degraded` for the identical
+//!    condition.
+//!
+//! What:
+//! - [`ProbeOutcome`] — the typed verdict, replacing the old flat `String`. It
+//!   keeps *why* a probe failed (`Refused` vs `Timeout` vs `HttpError` vs
+//!   `BadEnvelope`) instead of collapsing them, which is what lets `verify_tail`
+//!   gate its destructive repair on a genuine TCP-level observation.
+//! - [`probe_member_http_blocking`] — the sync entry point `super::probe` calls.
+//! - [`resolve_probe_bases`] / [`probe_bases`] / [`reconcile`] /
+//!   [`classify_response`] / [`effective_status`] / [`fixed_port_for`] — the
+//!   composable halves, unit-tested without a live daemon.
+//!
+//! Test: `tests` (sibling `probe_http_tests.rs`) — covers the proxy immunity,
+//! the port-walk precedence rule, 503+degraded, envelope rejection, the
+//! failure-cause table, and a table over the six REAL daemon payloads captured
+//! off a live stack.
+
+use std::time::Duration;
+
+use super::up::member::MemberHealth;
+use super::up::system_runner::classify_status;
+
+/// TCP connect bound for one probe leg.
+///
+/// Why: a closed loopback port refuses instantly, but a firewalled or wedged one
+/// can hang for the OS default (~75s) — far past `verify_tail`'s whole ~120s
+/// aggregate budget. Bounding connect separately from the total request keeps a
+/// dead leg cheap.
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// Whole-request bound for one probe leg (connect + headers + body).
+///
+/// Why: a live daemon answers `/health` in single-digit milliseconds; 5s is
+/// generous for a loaded one and short enough that both legs of a dual probe
+/// (run concurrently) can never exceed it.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// The health endpoint every trusty daemon mounts.
+const HEALTH_PATH: &str = "/health";
+
+/// How much of an unusable response body [`ProbeOutcome::BadEnvelope`] keeps.
+///
+/// Why: the sample exists to make a misconfiguration diagnosable, not to dump a
+/// megabyte of a squatter's HTML into a status row.
+const ENVELOPE_SAMPLE_LEN: usize = 120;
+
+/// The status word a serving-but-not-yet-usable daemon is reported as.
+const DEGRADED: &str = "degraded";
+
+/// The documented default loopback port for a stable-set daemon.
+///
+/// Why: the `http_addr` discovery file is the primary resolution path, but it is
+/// not universally reliable — trusty-search deliberately no-ops the shared write
+/// under `TRUSTY_DATA_DIR`, and a daemon that exited uncleanly can leave a stale
+/// one. The documented fixed port is the independent second leg (see
+/// [`reconcile`] for how the two are combined).
+/// What: the `docs/architecture/port-assignments.md` table, restricted to the
+/// stable-set daemons `tctl` probes. `None` for anything else — a member with
+/// neither a recorded address nor a known default yields
+/// [`ProbeOutcome::NoAddress`] rather than a guessed port (a wrong guessed port
+/// fails worse than a clean skip: it invites the #3364 squatter class).
+/// Test: `tests::fixed_ports_match_port_assignments_doc`.
+pub fn fixed_port_for(binary: &str) -> Option<u16> {
+    match binary {
+        "trusty-memory" => Some(7070),
+        "trusty-console" => Some(7788),
+        "trusty-search" => Some(7878),
+        "trusty-analyze" => Some(7879),
+        "trusty-mpm" => Some(7880),
+        "trusty-review" => Some(7891),
+        _ => None,
+    }
+}
+
+/// The typed result of probing one member's health (#4246).
+///
+/// Why: the pre-#4246 probe returned a bare `String` in which clap's exit 2, a
+/// connection refusal, a hung daemon and a schema mismatch were all literally
+/// the same value — `"down"`. `verify_tail` then fired `launchctl kickstart -k`
+/// on that, so an *unimplemented CLI contract* was indistinguishable from a
+/// *dead process* and healthy daemons got hard-restarted. Keeping the cause
+/// makes the destructive repair gateable on a genuine TCP-level observation
+/// ([`Self::is_confirmed_down`]) instead of on "something went wrong".
+/// What: one variant per distinguishable cause. Two derived views keep the
+/// existing call sites honest: [`Self::health_string`] is the flat display
+/// vocabulary `status`/`stack` render, and [`Self::member_health`] is the
+/// orchestration vocabulary `tctl up`'s `ensure_member` acts on.
+/// Test: `tests::probe_distinguishes_failure_causes`,
+/// `tests::health_string_maps_every_variant`,
+/// `tests::only_transport_failures_are_confirmed_down`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ProbeOutcome {
+    /// The binary is on neither `PATH` nor the default install dir (#3876).
+    NotInstalled,
+    /// Health is not probeable through the standard contract for this member's
+    /// lifecycle strategy (trusty-mpm — see `super::probe::probe_member_health`).
+    Unprobeable,
+    /// Neither an `http_addr` discovery file nor a documented default port
+    /// resolved, so there was nothing to probe.
+    NoAddress,
+    /// TCP connect was refused — nothing is listening. A genuine "down".
+    Refused,
+    /// The connect or the request exceeded its bound — a wedged daemon. Also a
+    /// genuine "down" for repair purposes.
+    Timeout,
+    /// A non-2xx response whose body was not a usable trusty health envelope.
+    /// (A non-2xx WITH a usable envelope is [`Self::Serving`] — trusty-analyze
+    /// answers 503 + `status:"degraded"` by design.)
+    HttpError {
+        /// The HTTP status code received.
+        status: u16,
+    },
+    /// Something answered, but the body is not a trusty health envelope (no
+    /// string `status` field). A squatter, a proxy error page, or a schema
+    /// change — never a reason to restart anything.
+    BadEnvelope {
+        /// A bounded sample of what was received, for diagnosis.
+        got: String,
+    },
+    /// The probe could not be performed locally (HTTP client or async runtime
+    /// could not be constructed). Says nothing about the daemon.
+    ProbeFailed {
+        /// The local failure detail.
+        detail: String,
+    },
+    /// A trusty health envelope was received and understood.
+    Serving {
+        /// The EFFECTIVE status (see [`effective_status`] — a `warming` daemon
+        /// reporting `status:"ok"` is reported `degraded`, not fully serving).
+        status: String,
+        /// The daemon's self-reported version, when the payload carries one
+        /// (trusty-mpm's does not).
+        version: Option<String>,
+    },
+}
+
+impl ProbeOutcome {
+    /// Map to the flat health-string vocabulary `status` / `stack` / the verify
+    /// tail render.
+    ///
+    /// Why: six call sites already render a one-word health per member and
+    /// serialise it into `--json` contracts; this shim keeps that output stable
+    /// while the transport underneath changes.
+    /// What: `Serving` routes through the shared [`classify_status`] vocabulary;
+    /// `NotInstalled`/`Unprobeable` keep their own words; **every** remaining
+    /// variant is `down`.
+    ///
+    /// `BadEnvelope` deliberately maps to `down`, NOT `unknown`: `unknown` is
+    /// tolerated by `VerifyTailReport::build` and by `status`'s exit code, so
+    /// mapping it there would print `VERIFIED` / exit 0 for a stack about which
+    /// we hold no actual health information. `down` is the honest verdict — and
+    /// it is now safe to say, because the kickstart is gated on
+    /// [`Self::is_confirmed_down`], not on this string.
+    /// Test: `tests::health_string_maps_every_variant`.
+    pub fn health_string(&self) -> &'static str {
+        use super::probe::health_str;
+        match self {
+            Self::NotInstalled => health_str::NOT_INSTALLED,
+            Self::Unprobeable => health_str::UNKNOWN,
+            Self::Serving { status, .. } => super::probe::health_string(classify_status(status)),
+            Self::NoAddress
+            | Self::Refused
+            | Self::Timeout
+            | Self::HttpError { .. }
+            | Self::BadEnvelope { .. }
+            | Self::ProbeFailed { .. } => health_str::DOWN,
+        }
+    }
+
+    /// Map to the `tctl up` orchestration vocabulary.
+    ///
+    /// Why: `ensure_member` (DOC-12 §3.4) branches on `MemberHealth`, not on a
+    /// string. `Unprobeable` maps to `Down` here — NOT to a health verdict —
+    /// deliberately preserving today's `tctl up` behaviour for trusty-mpm (it
+    /// falls through to `start`, which is idempotent). `ensure_member` treats
+    /// `Down` and `HealthyStale` identically, so nothing in `up`'s action set
+    /// turns on that choice.
+    /// What: `Serving` via [`classify_status`]; `NotInstalled` preserved; every
+    /// other variant `Down`.
+    /// Test: `tests::member_health_maps_every_variant`.
+    pub fn member_health(&self) -> MemberHealth {
+        match self {
+            Self::NotInstalled => MemberHealth::NotInstalled,
+            Self::Serving { status, .. } => classify_status(status),
+            _ => MemberHealth::Down,
+        }
+    }
+
+    /// Whether this outcome is a CONFIRMED-down observation — the only thing
+    /// that may authorise a destructive repair (#4246).
+    ///
+    /// Why: this is the gate that stops `tctl install` hard-restarting healthy
+    /// daemons. `launchctl kickstart -k` is not a polite restart — the shared
+    /// plist renderer emits no `ExitTimeOut`, so launchd SIGKILLs 20s after
+    /// SIGTERM, while trusty-search's graceful index flush budgets ≥30s per
+    /// index. A restart triggered by a schema mismatch or a squatter on a
+    /// default port therefore costs unflushed HNSW vectors. Only an observation
+    /// at the TRANSPORT layer — nothing accepted the connection, or nothing
+    /// answered in time — is evidence a process is actually not serving. Every
+    /// other failure means *something* answered, so restarting is at best a
+    /// guess.
+    ///
+    /// This was unobservable before the transport change: a subprocess probe
+    /// cannot produce a `Refused` (that is a TCP concept), and a fast clap error
+    /// never hits the timeout — which is exactly why the gate and the transport
+    /// had to land together rather than in sequence.
+    /// What: `true` iff `Refused` or `Timeout`.
+    /// Test: `tests::only_transport_failures_are_confirmed_down`,
+    /// `verify_tail::tests::verify_one_does_not_kickstart_a_healthy_launchd_daemon`.
+    pub fn is_confirmed_down(&self) -> bool {
+        matches!(self, Self::Refused | Self::Timeout)
+    }
+}
+
+/// Build the HTTP client used for every health probe.
+///
+/// Why: **`.no_proxy()` is load-bearing, not hygiene.** reqwest 0.12 routes
+/// `127.0.0.1` through `HTTP_PROXY`/`http_proxy`/`ALL_PROXY` when they are
+/// exported — hyper-util's proxy matcher (`client/proxy/matcher.rs`) has no
+/// runtime loopback exemption, and the only bypass is an explicit `NO_PROXY`
+/// entry the user is not required to have. Without this call a developer with a
+/// proxy exported gets every daemon reported `down` through the new transport,
+/// and (pre-gate) every healthy daemon kickstarted — the exact #4246 signature,
+/// reintroduced. There is no other `.no_proxy()` in this workspace, so this is
+/// also the first place the property is asserted at all. The client is built per
+/// probe rather than cached because reqwest reads the proxy environment at BUILD
+/// time; a cached client would make the behaviour depend on process start order.
+/// What: a client with proxies disabled and both a connect and a whole-request
+/// bound.
+/// Test: `tests::probe_ignores_http_proxy_env` — sets `HTTP_PROXY` to a dead
+/// address and asserts the stub is still reached, AND that a client built
+/// *without* `.no_proxy()` fails under the same environment.
+pub fn build_probe_client() -> reqwest::Result<reqwest::Client> {
+    build_probe_client_with(CONNECT_TIMEOUT, REQUEST_TIMEOUT)
+}
+
+/// [`build_probe_client`] with caller-chosen bounds.
+///
+/// Why: the `Timeout` arm of the failure taxonomy has to be provable, and a test
+/// that waits out the production [`REQUEST_TIMEOUT`] would add 5 seconds to
+/// every run. Parameterising the bounds keeps the production defaults in ONE
+/// place ([`build_probe_client`]) while letting the timeout test drive a
+/// sub-second bound against a deliberately silent peer.
+/// What: same client as [`build_probe_client`] — `.no_proxy()` included, since
+/// the proxy test needs both bounds AND the flag — with `connect`/`request`
+/// substituted.
+/// Test: `tests::probe_distinguishes_failure_causes`.
+pub fn build_probe_client_with(
+    connect: Duration,
+    request: Duration,
+) -> reqwest::Result<reqwest::Client> {
+    reqwest::Client::builder()
+        .no_proxy()
+        .connect_timeout(connect)
+        .timeout(request)
+        .build()
+}
+
+/// Map a reqwest transport error to the outcome that names its cause.
+///
+/// Why: the whole point of #4246's taxonomy is that "refused" and "answered with
+/// garbage" must not be the same value — only the former may authorise a
+/// kickstart.
+/// What: a timeout (connect or request) → `Timeout`; a connect failure →
+/// `Refused`; anything else happened AFTER a connection was established (body
+/// decode, malformed response) so it is `BadEnvelope`, which never kickstarts.
+/// Test: `tests::probe_distinguishes_failure_causes`.
+fn classify_transport_error(e: &reqwest::Error) -> ProbeOutcome {
+    if e.is_timeout() {
+        ProbeOutcome::Timeout
+    } else if e.is_connect() {
+        ProbeOutcome::Refused
+    } else {
+        ProbeOutcome::BadEnvelope {
+            got: sample(e.to_string().as_bytes()),
+        }
+    }
+}
+
+/// Bound an arbitrary byte slice into a short, printable diagnosis sample.
+fn sample(bytes: &[u8]) -> String {
+    let text = String::from_utf8_lossy(bytes);
+    let trimmed = text.trim();
+    if trimmed.chars().count() <= ENVELOPE_SAMPLE_LEN {
+        return trimmed.to_owned();
+    }
+    trimmed.chars().take(ENVELOPE_SAMPLE_LEN).collect()
+}
+
+/// Derive the EFFECTIVE status from a parsed health envelope.
+///
+/// Why: `/health` returning 200 `{"status":"ok"}` does not mean the daemon can
+/// serve. trusty-memory reports `status:"ok"` with `daemon_state:"warming"`
+/// while its embedder is still initialising, and trusty-search reports
+/// `status:"ok"` with `embedder:"initializing"`/`"stalled"`/`"error"` — both say
+/// so out loud in their handlers precisely so a probe can read it. Calling such
+/// a daemon fully healthy hides a real capability gap; calling it `down` would
+/// be worse (it IS up, and a kickstart would only restart the warm-up).
+/// `degraded` is the honest middle, and it maps to `stale`, which
+/// `VerifyTailReport::build` already tolerates.
+/// What: returns the raw `status` unchanged unless it is a HEALTHY word AND a
+/// readiness sub-field says otherwise, in which case `"degraded"`. Readiness
+/// sub-fields read: `daemon_state` (trusty-memory) and `embedder` /
+/// `embedder_status` (trusty-search — the wire field is `embedder`;
+/// `embedder_status` is accepted too so a rename cannot silently defeat this).
+/// A daemon that carries none of them, or whose sub-field is not a string, is
+/// unaffected.
+/// Test: `tests::warming_daemon_is_degraded_not_serving`,
+/// `tests::real_daemon_payloads_are_never_down`.
+pub fn effective_status(v: &serde_json::Value) -> String {
+    let raw = v.get("status").and_then(|s| s.as_str()).unwrap_or_default();
+    if classify_status(raw) != MemberHealth::HealthyVersionOk {
+        // Already degraded/down by its own account — never upgrade a verdict.
+        return raw.to_owned();
+    }
+    for key in ["daemon_state", "embedder", "embedder_status"] {
+        let Some(state) = v.get(key).and_then(|x| x.as_str()) else {
+            continue;
+        };
+        if !matches!(state.to_ascii_lowercase().as_str(), "ready" | "ok") {
+            return DEGRADED.to_owned();
+        }
+    }
+    raw.to_owned()
+}
+
+/// Classify one HTTP response into a [`ProbeOutcome`] — on the BODY, not the
+/// status code.
+///
+/// Why: the two daemons that compute real dependency status disagree about HTTP
+/// semantics. trusty-analyze answers **503** + `status:"degraded"` when
+/// trusty-search is unreachable; trusty-review answers **200** + the same
+/// `status:"degraded"`. A 2xx-only liveness check (`ensure::daemon::health_ok`)
+/// therefore reads one healthy daemon as `degraded` and the other as `down` for
+/// the identical condition — and pre-gate, would have kickstarted analyze every
+/// time search was slow. The body is the signal; the status code is not.
+///
+/// The envelope check (a string `status` field) is what stops a stale
+/// `http_addr` plus an unrelated squatter on a default loopback port reading as
+/// healthy. It is not a complete defence — a squatter emitting a generic
+/// `{"status":"ok"}` still passes, the #3364 collision class. Closing that needs
+/// a `service` discriminator in each daemon's payload, which is deliberately out
+/// of scope here and tracked separately.
+///
+/// What: parses `body` as JSON. With a string `status` field → `Serving` (status
+/// via [`effective_status`], `version` when present) REGARDLESS of
+/// `status_code`. Without one → `HttpError { status }` if the code was non-2xx
+/// (the code is then the most informative thing we have), else
+/// `BadEnvelope { got }`.
+/// Test: `tests::probe_accepts_503_degraded`,
+/// `tests::probe_rejects_non_trusty_envelope`,
+/// `tests::classify_response_prefers_status_code_for_unusable_5xx`.
+pub fn classify_response(status_code: u16, body: &[u8]) -> ProbeOutcome {
+    let parsed = serde_json::from_slice::<serde_json::Value>(body).ok();
+    let envelope = parsed
+        .as_ref()
+        .filter(|v| v.get("status").and_then(|s| s.as_str()).is_some());
+    match envelope {
+        Some(v) => ProbeOutcome::Serving {
+            status: effective_status(v),
+            version: v.get("version").and_then(|x| x.as_str()).map(str::to_owned),
+        },
+        None if !(200..300).contains(&status_code) => ProbeOutcome::HttpError {
+            status: status_code,
+        },
+        None => ProbeOutcome::BadEnvelope { got: sample(body) },
+    }
+}
+
+/// Combine the outcomes of the dual-resolution legs into ONE verdict — the
+/// precedence rule (#4246).
+///
+/// Why: this is the rule that stops the fix re-shipping the bug. The two legs
+/// are EXPECTED to disagree in normal operation, not just in edge cases:
+/// trusty-memory port-walks `7070..=7079`, so a daemon that found 7070 taken and
+/// bound 7071 has a `Serving` `http_addr` leg and a `Refused` fixed-port leg
+/// while being perfectly healthy. Treating the refusal as authoritative would
+/// hard-restart it — precisely the harm this issue exists to remove.
+/// Symmetrically, trusty-search no-ops the shared `http_addr` write under
+/// `TRUSTY_DATA_DIR`, so an isolated daemon has only the fixed-port leg.
+///
+/// # Postconditions
+/// - If ANY leg is `Serving`, the result is a `Serving` — so another leg's
+///   `Refused`/`Timeout` can NEVER reach [`ProbeOutcome::is_confirmed_down`] and
+///   therefore never feed `needs_kickstart`.
+/// - If any leg got an ANSWER that was not a usable envelope
+///   (`BadEnvelope`/`HttpError`), that outranks a refusal on the other leg:
+///   something is listening, so restarting is a guess, not a repair.
+/// - `Refused`/`Timeout` win only when NO leg saw anything at all.
+/// - An empty leg set is `NoAddress`.
+///
+/// What: picks the minimum-rank outcome — healthy `Serving` (0) < degraded
+/// `Serving` (1) < `BadEnvelope` (2) < `HttpError` (3) < `Timeout` (4) <
+/// `Refused` (5) < everything else (6).
+/// Test: `tests::reconcile_serving_leg_beats_refused_leg`,
+/// `tests::reconcile_answered_leg_beats_refused_leg`,
+/// `tests::reconcile_all_refused_stays_refused`,
+/// `tests::probe_port_walked_daemon_is_healthy`.
+pub fn reconcile(outcomes: Vec<ProbeOutcome>) -> ProbeOutcome {
+    fn rank(o: &ProbeOutcome) -> u8 {
+        match o {
+            ProbeOutcome::Serving { status, .. } => {
+                if classify_status(status) == MemberHealth::HealthyVersionOk {
+                    0
+                } else {
+                    1
+                }
+            }
+            ProbeOutcome::BadEnvelope { .. } => 2,
+            ProbeOutcome::HttpError { .. } => 3,
+            ProbeOutcome::Timeout => 4,
+            ProbeOutcome::Refused => 5,
+            _ => 6,
+        }
+    }
+    outcomes
+        .into_iter()
+        .min_by_key(rank)
+        .unwrap_or(ProbeOutcome::NoAddress)
+}
+
+/// Issue `GET {base}/health` against one resolved base URL.
+///
+/// Why: one leg of [`probe_bases`]' dual resolution.
+/// What: sends the request, then classifies the transport error, or the status +
+/// body via [`classify_response`].
+/// Test: exercised by every stub-server test in `tests`.
+async fn probe_url(client: &reqwest::Client, base: &str) -> ProbeOutcome {
+    let url = format!("{base}{HEALTH_PATH}");
+    let resp = match client.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => return classify_transport_error(&e),
+    };
+    let status_code = resp.status().as_u16();
+    match resp.bytes().await {
+        Ok(body) => classify_response(status_code, &body),
+        Err(e) => classify_transport_error(&e),
+    }
+}
+
+/// Resolve a daemon's base URL BOTH ways: recorded `http_addr` first, documented
+/// default port second.
+///
+/// Why: neither path is individually sufficient. `http_addr` is the primary — it
+/// survives `--port` overrides and auto-port-walking — but trusty-search
+/// deliberately skips writing it under `TRUSTY_DATA_DIR`, and an uncleanly-exited
+/// daemon can leave a stale one. The documented default covers those, but misses
+/// every port-walked daemon.
+/// What: returns `(recorded, fixed)`; `recorded` is
+/// `http://<trusty_common::read_daemon_addr(app)>` when the file exists and is
+/// non-empty, `fixed` is `http://127.0.0.1:<fixed_port_for(binary)>`. Either may
+/// be `None`. A read error is treated as "no recorded address" — it is not
+/// evidence about the daemon.
+/// Test: `tests::resolve_probe_bases_reads_http_addr`,
+/// `tests::resolve_probe_bases_none_for_unknown_binary`.
+pub fn resolve_probe_bases(app: &str, binary: &str) -> (Option<String>, Option<String>) {
+    let recorded = trusty_common::read_daemon_addr(app)
+        .ok()
+        .flatten()
+        .map(|a| a.trim().to_owned())
+        .filter(|a| !a.is_empty())
+        .map(|a| format!("http://{a}"));
+    let fixed = fixed_port_for(binary).map(|p| format!("http://127.0.0.1:{p}"));
+    (recorded, fixed)
+}
+
+/// Probe both resolved legs concurrently and apply [`reconcile`]'s precedence
+/// rule.
+///
+/// Why: kept separate from [`resolve_probe_bases`] so the precedence rule can be
+/// exercised over the REAL HTTP transport with both legs staged independently —
+/// a serving stub on one leg and a genuinely-refusing address on the other. That
+/// combination is the port-walk case, and it is the one that must never
+/// kickstart; testing it through `probe_daemon_http` alone would require a
+/// developer's live daemon to be absent from its documented port.
+/// What: dedupes when both legs resolve to the same address (the common case),
+/// otherwise runs them concurrently on the caller's runtime. `(None, None)` →
+/// [`ProbeOutcome::NoAddress`].
+/// Test: `tests::probe_port_walked_daemon_is_healthy`,
+/// `tests::probe_accepts_503_degraded`, `tests::probe_distinguishes_failure_causes`.
+pub async fn probe_bases(
+    client: &reqwest::Client,
+    recorded: Option<String>,
+    fixed: Option<String>,
+) -> ProbeOutcome {
+    let outcomes = match (recorded, fixed) {
+        (Some(a), Some(b)) if a == b => vec![probe_url(client, &a).await],
+        (Some(a), Some(b)) => {
+            let (x, y) = tokio::join!(probe_url(client, &a), probe_url(client, &b));
+            vec![x, y]
+        }
+        (Some(only), None) | (None, Some(only)) => vec![probe_url(client, &only).await],
+        (None, None) => return ProbeOutcome::NoAddress,
+    };
+    reconcile(outcomes)
+}
+
+/// Resolve a daemon's address both ways and probe it (#4246).
+///
+/// Why: the async entry point — [`resolve_probe_bases`] plus [`probe_bases`]
+/// plus the one client build, in the order a caller wants them.
+/// What: builds the probe client (a build failure is
+/// [`ProbeOutcome::ProbeFailed`] — a LOCAL failure, never a daemon verdict, and
+/// so never a reason to kickstart), resolves both legs for `app`/`binary`, and
+/// probes them.
+/// Test: `tests::probe_uses_http_addr_when_fixed_port_unknown`,
+/// `tests::probe_no_address_when_nothing_resolves`.
+pub async fn probe_daemon_http(app: &str, binary: &str) -> ProbeOutcome {
+    let client = match build_probe_client() {
+        Ok(c) => c,
+        Err(e) => {
+            return ProbeOutcome::ProbeFailed {
+                detail: format!("build probe client: {e}"),
+            }
+        }
+    };
+    let (recorded, fixed) = resolve_probe_bases(app, binary);
+    probe_bases(&client, recorded, fixed).await
+}
+
+/// Synchronous entry point for [`probe_daemon_http`].
+///
+/// Why: `tctl`'s command dispatch is synchronous, and the probe is called from
+/// `status`, `stack health`, `stack doctor`, `verify_tail` and `up` — none of
+/// which run inside a reactor. The probe runs on a dedicated thread with its own
+/// current-thread runtime rather than calling `Runtime::block_on` in place: that
+/// makes it unconditionally safe to call even if a future caller *is* inside a
+/// runtime (building a runtime and blocking on it from within another runtime's
+/// worker thread panics), and a current-thread runtime is far cheaper to spin up
+/// than `runtime::block_on`'s multi-thread one — which matters because
+/// `verify_tail`'s poll loop can probe a single member a dozen times.
+/// `tokio::join!` still runs both legs concurrently on it.
+/// What: spawns the probe thread, joins it, and returns its outcome. A thread
+/// that cannot be spawned, or that panics, is reported as
+/// [`ProbeOutcome::ProbeFailed`] — never as a daemon verdict.
+/// Test: `super::probe::tests::probe_member_health_*` and
+/// `verify_tail::tests::verify_one_*` drive this path against a stub server.
+pub fn probe_member_http_blocking(app: &str, binary: &str) -> ProbeOutcome {
+    let app = app.to_owned();
+    let binary = binary.to_owned();
+    match std::thread::Builder::new()
+        .name("tctl-health-probe".to_owned())
+        .spawn(move || probe_on_new_runtime(&app, &binary))
+    {
+        Ok(handle) => handle.join().unwrap_or_else(|_| ProbeOutcome::ProbeFailed {
+            detail: "health-probe thread panicked".to_owned(),
+        }),
+        Err(e) => ProbeOutcome::ProbeFailed {
+            detail: format!("spawn health-probe thread: {e}"),
+        },
+    }
+}
+
+/// Drive [`probe_daemon_http`] on a fresh current-thread runtime.
+///
+/// Why: the body of [`probe_member_http_blocking`]'s worker thread, extracted so
+/// the runtime-construction failure path is expressible without nesting two
+/// `match`es inside a closure.
+/// What: builds a current-thread runtime and blocks on the probe; a runtime that
+/// cannot be built is [`ProbeOutcome::ProbeFailed`].
+/// Test: as [`probe_member_http_blocking`].
+fn probe_on_new_runtime(app: &str, binary: &str) -> ProbeOutcome {
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt.block_on(probe_daemon_http(app, binary)),
+        Err(e) => ProbeOutcome::ProbeFailed {
+            detail: format!("build probe runtime: {e}"),
+        },
+    }
+}
+
+#[cfg(test)]
+#[path = "probe_http_tests.rs"]
+mod tests;

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -1,0 +1,723 @@
+//! Unit tests for the `probe_http` HTTP `/health` transport (#4246).
+//!
+//! Why: kept in a sibling file so `probe_http.rs` stays under the 500-SLOC
+//! production cap (CLAUDE.md / `scripts/check_line_cap.sh`) — mirrors the
+//! `verify_tail.rs` / `verify_tail_tests.rs` and `install.rs` /
+//! `install_tests.rs` splits.
+//!
+//! These are the tests that PROVE #4246 is fixed rather than moved. Before this
+//! module, `probe_member_health`'s launchd arm was never executed by any test in
+//! a crate with 483 green ones, and two of those tests actively asserted the bug
+//! was correct behaviour.
+//!
+//! Test: `cargo test -p trusty-installer` runs everything here.
+
+use super::*;
+use crate::commands::test_support::{dead_addr, stub_hang, stub_once, ENV_TEST_LOCK};
+
+/// The status line for a plain 200.
+const OK_LINE: &str = "HTTP/1.1 200 OK";
+
+// ── The six REAL `/health` payloads ─────────────────────────────────────────
+//
+// Captured verbatim off a live stack (`curl --noproxy '*'
+// http://127.0.0.1:<port>/health`) while `tctl status` was reporting every one
+// of these daemons as `down`. They are the ground truth this fix is measured
+// against: any classifier that reads ANY of them as `down` has reproduced #4246.
+
+/// trusty-memory, port 7070 — carries the `daemon_state` readiness sub-field.
+const REAL_MEMORY: &str = r#"{"status":"ok","version":"0.21.0","rss_mb":3255,"disk_bytes":288721838,"cpu_pct":0.027932314,"uptime_secs":241434,"addr":"127.0.0.1:7070","open_fds":55,"fd_soft_limit":8192,"daemon_state":"ready"}"#;
+
+/// trusty-console, port 7788 — the minimal shared-handler envelope.
+const REAL_CONSOLE: &str = r#"{"status":"ok","version":"0.4.0"}"#;
+
+/// trusty-search, port 7878 — carries the `embedder` readiness sub-field, and is
+/// the daemon whose exit-0 CLI payload (`{"daemon":"running",…}`, no `status`
+/// key) the old `classify_health_json` read as `down`.
+const REAL_SEARCH: &str = r#"{"status":"ok","version":"0.39.0","indexes":11,"uptime_secs":164212,"embedder":"ready","embedder_recent_timeout_count":0,"rss_mb":779,"rss_limit_mb":16384,"disk_bytes":719841751,"cpu_pct":4.8715587,"embedder_info":{"dimension":384,"provider":"MPS","quantized":false,"model":"all-MiniLM-L6-v2","backend":"python"},"background_reindex_queue_depth":0,"update_available":"0.39.1","indexes_kg_disabled":0,"indexes_vector_disabled":0,"embedder_bootstrap":"ready"}"#;
+
+/// trusty-analyze, port 7879 — the daemon that answers 503 when search is down.
+const REAL_ANALYZE: &str = r#"{"status":"ok","version":"0.7.4","search_reachable":true}"#;
+
+/// trusty-mpm, port 7880 — the only payload with NO `version` field.
+const REAL_MPM: &str = r#"{"status":"ok","catalog_stale":true,"catalog_unknown":false,"catalog_changes":["agent dart-engineer: new"],"supervised":false}"#;
+
+/// trusty-review, port 7891 — answers 200 + `degraded` when search is down.
+const REAL_REVIEW: &str = r#"{"status":"ok","version":"0.10.1","dry_run":true,"reviewer_model":"us.anthropic.claude-sonnet-4-6","inference":"ok","deps":{"trusty_search":{"required":true,"reachable":true,"state":"ok"}}}"#;
+
+/// Every real payload, paired with the daemon it came from.
+fn real_payloads() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("trusty-memory", REAL_MEMORY),
+        ("trusty-console", REAL_CONSOLE),
+        ("trusty-search", REAL_SEARCH),
+        ("trusty-analyze", REAL_ANALYZE),
+        ("trusty-mpm", REAL_MPM),
+        ("trusty-review", REAL_REVIEW),
+    ]
+}
+
+// ── The ground-truth table ──────────────────────────────────────────────────
+
+/// Why: THE #4246 acceptance test. Six daemons answering `/health` with
+/// `status:"ok"` were all reported `down`; classifying any of their REAL payloads
+/// as `down` means the bug is back. Also asserts the negative that matters
+/// operationally: none of them may be `is_confirmed_down`, because that is what
+/// authorises `launchctl kickstart -k`.
+/// What: table over the six verbatim payloads at HTTP 200; asserts each is
+/// `Serving`, renders `healthy`, and is not confirmed-down.
+/// Test: This is the test.
+#[test]
+fn real_daemon_payloads_are_never_down() {
+    for (daemon, body) in real_payloads() {
+        let outcome = classify_response(200, body.as_bytes());
+        assert!(
+            matches!(outcome, ProbeOutcome::Serving { .. }),
+            "{daemon}'s real /health payload must classify as Serving, got {outcome:?}"
+        );
+        assert_eq!(
+            outcome.health_string(),
+            "healthy",
+            "{daemon} must render `healthy`, not `down`"
+        );
+        assert!(
+            !outcome.is_confirmed_down(),
+            "{daemon} must never authorise a kickstart"
+        );
+    }
+}
+
+/// Why: the `version` column of `tctl status` / the verify rows reads the
+/// envelope's version, and trusty-mpm's payload has none — an absent version must
+/// be `None`, never a reason to downgrade the health verdict (that conflation is
+/// the version-skew trap deliberately left out of #4246's scope).
+/// What: asserts search reports its version and mpm reports `None`, both still
+/// `Serving`.
+/// Test: This is the test.
+#[test]
+fn missing_version_does_not_degrade_the_verdict() {
+    let search = classify_response(200, REAL_SEARCH.as_bytes());
+    assert_eq!(
+        search,
+        ProbeOutcome::Serving {
+            status: "ok".to_owned(),
+            version: Some("0.39.0".to_owned()),
+        }
+    );
+    let mpm = classify_response(200, REAL_MPM.as_bytes());
+    assert_eq!(
+        mpm,
+        ProbeOutcome::Serving {
+            status: "ok".to_owned(),
+            version: None,
+        }
+    );
+}
+
+// ── Body-over-status-code classification ────────────────────────────────────
+
+/// Why: trusty-analyze answers **HTTP 503** with `status:"degraded"` when
+/// trusty-search is unreachable (`service/routes.rs`), while trusty-review
+/// answers **200** with the same `degraded` for the identical condition. A
+/// 2xx-only liveness check (`ensure::daemon::health_ok`, which this module
+/// deliberately does NOT reuse) reads one as degraded and the other as `down` —
+/// and pre-gate would have kickstarted analyze every time search was slow. Prove
+/// the transport accepts the non-2xx and reads the body.
+/// What: a stub answering `503` + `{"status":"degraded",…}` must yield
+/// `Serving{degraded}`, render `stale` (which `VerifyTailReport::build`
+/// tolerates), and NOT be confirmed-down.
+/// Test: This is the test.
+#[tokio::test]
+async fn probe_accepts_503_degraded() {
+    let addr = stub_once(
+        "HTTP/1.1 503 Service Unavailable",
+        r#"{"status":"degraded","version":"0.7.4","search_reachable":false}"#,
+    )
+    .await;
+    let client = build_probe_client().expect("probe client builds");
+    let outcome = probe_bases(&client, Some(format!("http://{addr}")), None).await;
+
+    assert_eq!(
+        outcome,
+        ProbeOutcome::Serving {
+            status: "degraded".to_owned(),
+            version: Some("0.7.4".to_owned()),
+        },
+        "503 with a usable envelope must read `degraded`, never `down`"
+    );
+    assert_eq!(outcome.health_string(), "stale");
+    assert!(
+        !outcome.is_confirmed_down(),
+        "a degraded-but-answering daemon must never be kickstarted"
+    );
+}
+
+/// Why: the envelope check is what stops a stale `http_addr` (or a squatter on a
+/// documented default port — the #3364 collision class) reading as a healthy
+/// trusty daemon. It must also NOT be treated as a down observation: something
+/// IS listening, so restarting the member is a guess, not a repair.
+/// What: a stub answering 200 + `{"hello":"world"}` must yield `BadEnvelope`,
+/// must not render `healthy`, and must not be confirmed-down.
+/// Test: This is the test.
+#[tokio::test]
+async fn probe_rejects_non_trusty_envelope() {
+    let addr = stub_once(OK_LINE, r#"{"hello":"world"}"#).await;
+    let client = build_probe_client().expect("probe client builds");
+    let outcome = probe_bases(&client, Some(format!("http://{addr}")), None).await;
+
+    assert!(
+        matches!(outcome, ProbeOutcome::BadEnvelope { .. }),
+        "a body with no string `status` is not a trusty health envelope, got {outcome:?}"
+    );
+    assert_ne!(outcome.health_string(), "healthy");
+    assert!(
+        !outcome.is_confirmed_down(),
+        "a schema/envelope problem must NEVER authorise a kickstart — that is the \
+         #4246 regression, in which an unimplemented contract looked like a dead process"
+    );
+}
+
+/// Why: when a non-2xx body is ALSO unusable, the status code is the most
+/// informative thing available and must survive into the outcome for diagnosis —
+/// but still without becoming a confirmed-down.
+/// What: `classify_response(500, "<html>…")` → `HttpError { status: 500 }`;
+/// `classify_response(200, "<html>…")` → `BadEnvelope`.
+/// Test: This is the test.
+#[test]
+fn classify_response_prefers_status_code_for_unusable_5xx() {
+    let five = classify_response(500, b"<html>Bad Gateway</html>");
+    assert_eq!(five, ProbeOutcome::HttpError { status: 500 });
+    assert!(!five.is_confirmed_down());
+
+    let two = classify_response(200, b"<html>squatter</html>");
+    assert!(matches!(two, ProbeOutcome::BadEnvelope { .. }));
+}
+
+/// Why: the `BadEnvelope` sample exists to make a misconfiguration diagnosable,
+/// not to paste a megabyte of a squatter's HTML into a status row.
+/// What: a body far longer than the sample bound is truncated to it.
+/// Test: This is the test.
+#[test]
+fn bad_envelope_sample_is_bounded() {
+    let long = "x".repeat(10_000);
+    let ProbeOutcome::BadEnvelope { got } = classify_response(200, long.as_bytes()) else {
+        panic!("a long non-JSON body must be a BadEnvelope");
+    };
+    assert_eq!(got.chars().count(), ENVELOPE_SAMPLE_LEN);
+}
+
+// ── Readiness sub-fields ────────────────────────────────────────────────────
+
+/// Why: `/health` returning 200 `{"status":"ok"}` does not mean the daemon can
+/// serve — trusty-memory reports `daemon_state:"warming"` and trusty-search
+/// reports `embedder:"initializing"`/`"stalled"`/`"error"` alongside a cheerful
+/// `status:"ok"`. Reporting such a daemon fully serving hides a real capability
+/// gap; reporting it `down` would be worse (it IS up, and a kickstart would only
+/// restart the warm-up). `degraded` is the honest middle.
+/// What: table over the readiness sub-fields and states; a non-ready value
+/// degrades an `ok` envelope, `ready`/`ok` leaves it alone, a non-string
+/// sub-field is ignored, and an already-degraded verdict is never upgraded.
+/// Test: This is the test.
+#[test]
+fn warming_daemon_is_degraded_not_serving() {
+    for key in ["daemon_state", "embedder", "embedder_status"] {
+        for state in ["warming", "initializing", "stalled", "error"] {
+            let v = serde_json::json!({ "status": "ok", key: state });
+            assert_eq!(
+                effective_status(&v),
+                "degraded",
+                "`{key}: {state}` must degrade an `ok` envelope"
+            );
+        }
+        for state in ["ready", "ok", "OK"] {
+            let v = serde_json::json!({ "status": "ok", key: state });
+            assert_eq!(
+                effective_status(&v),
+                "ok",
+                "`{key}: {state}` must leave a serving verdict alone"
+            );
+        }
+    }
+
+    // A non-string sub-field carries no readiness signal; it must be ignored.
+    let obj = serde_json::json!({ "status": "ok", "embedder": { "model": "mini" } });
+    assert_eq!(effective_status(&obj), "ok");
+
+    // An already-degraded envelope is never upgraded by a ready sub-field.
+    let already = serde_json::json!({ "status": "degraded", "daemon_state": "ready" });
+    assert_eq!(effective_status(&already), "degraded");
+}
+
+// ── The dual-resolution precedence rule ─────────────────────────────────────
+
+/// Why: THE rule that stops the fix re-shipping the bug. trusty-memory port-walks
+/// `7070..=7079`, so a daemon that found 7070 taken and bound 7071 has a
+/// `Serving` `http_addr` leg and a `Refused` fixed-port leg *while being
+/// perfectly healthy*. Treating that refusal as authoritative would hard-restart
+/// it. This test drives BOTH legs over the real HTTP transport — a live stub on
+/// the recorded address, a genuinely-refusing address on the documented port.
+/// What: asserts the reconciled verdict is `Serving`, renders `healthy`, and —
+/// the operationally load-bearing part — is NOT confirmed-down, so
+/// `needs_kickstart` cannot fire.
+/// Test: This is the test.
+#[tokio::test]
+async fn probe_port_walked_daemon_is_healthy() {
+    let walked = stub_once(OK_LINE, r#"{"status":"ok","version":"0.21.0"}"#).await;
+    let documented = dead_addr();
+    let client = build_probe_client().expect("probe client builds");
+
+    let outcome = probe_bases(
+        &client,
+        Some(format!("http://{walked}")),
+        Some(format!("http://{documented}")),
+    )
+    .await;
+
+    assert!(
+        matches!(outcome, ProbeOutcome::Serving { .. }),
+        "a port-walked daemon is healthy; got {outcome:?}"
+    );
+    assert_eq!(outcome.health_string(), "healthy");
+    assert!(
+        !outcome.is_confirmed_down(),
+        "a Refused on the documented-port leg must NEVER feed needs_kickstart \
+         while the other leg is Serving — that would kickstart a healthy daemon"
+    );
+}
+
+/// Why: pins the precedence rule as a pure function so the postconditions in
+/// `reconcile`'s doc are executable, in both leg orders (a `min_by_key` that
+/// happened to favour the first element would pass one order and fail the other).
+/// What: `Serving` beats `Refused`/`Timeout` regardless of position; a healthy
+/// `Serving` beats a degraded one.
+/// Test: This is the test.
+#[test]
+fn reconcile_serving_leg_beats_refused_leg() {
+    let serving = ProbeOutcome::Serving {
+        status: "ok".to_owned(),
+        version: None,
+    };
+    for other in [ProbeOutcome::Refused, ProbeOutcome::Timeout] {
+        assert_eq!(
+            reconcile(vec![serving.clone(), other.clone()]),
+            serving,
+            "serving-first must win"
+        );
+        assert_eq!(
+            reconcile(vec![other, serving.clone()]),
+            serving,
+            "serving-second must win too"
+        );
+    }
+
+    let degraded = ProbeOutcome::Serving {
+        status: "degraded".to_owned(),
+        version: None,
+    };
+    assert_eq!(
+        reconcile(vec![degraded.clone(), serving.clone()]),
+        serving,
+        "a fully-serving leg outranks a degraded one"
+    );
+    assert!(!reconcile(vec![degraded, ProbeOutcome::Refused]).is_confirmed_down());
+}
+
+/// Why: `something answered, but with garbage` still means a process is
+/// listening, so it must outrank the other leg's refusal — restarting on it would
+/// be a guess, and (for a squatter on a documented default port) would restart
+/// the wrong member's neighbour for no reason.
+/// What: `BadEnvelope` and `HttpError` both beat `Refused`, and neither is
+/// confirmed-down.
+/// Test: This is the test.
+#[test]
+fn reconcile_answered_leg_beats_refused_leg() {
+    for answered in [
+        ProbeOutcome::BadEnvelope {
+            got: "squatter".to_owned(),
+        },
+        ProbeOutcome::HttpError { status: 500 },
+    ] {
+        let verdict = reconcile(vec![ProbeOutcome::Refused, answered.clone()]);
+        assert_eq!(verdict, answered);
+        assert!(
+            !verdict.is_confirmed_down(),
+            "an answering leg must suppress the other leg's confirmed-down"
+        );
+    }
+}
+
+/// Why: the mirror safety property — the fix must not become "never repair
+/// anything". When NO leg saw a peer at all, the verdict must stay a
+/// confirmed-down so `verify_tail` still kickstarts a genuinely dead daemon (the
+/// #2498 failure signature the machinery exists for).
+/// What: all-refused and refused+timeout both stay confirmed-down; an empty leg
+/// set is `NoAddress` and is NOT confirmed-down (nothing was observed).
+/// Test: This is the test.
+#[test]
+fn reconcile_all_refused_stays_refused() {
+    assert_eq!(
+        reconcile(vec![ProbeOutcome::Refused, ProbeOutcome::Refused]),
+        ProbeOutcome::Refused
+    );
+    assert!(reconcile(vec![ProbeOutcome::Refused, ProbeOutcome::Timeout]).is_confirmed_down());
+    assert_eq!(reconcile(Vec::new()), ProbeOutcome::NoAddress);
+    assert!(!ProbeOutcome::NoAddress.is_confirmed_down());
+}
+
+// ── The failure taxonomy ────────────────────────────────────────────────────
+
+/// Why: THE reason `ProbeOutcome` exists. Before #4246 every one of these four
+/// situations was literally the string `"down"`, and `launchctl kickstart -k`
+/// fired on all of them — so an unimplemented CLI contract was indistinguishable
+/// from a dead process. Each must now be its OWN variant, and only the two
+/// transport-level ones may authorise a repair.
+/// What: table over a refusing address, a 500 with an unusable body, a 200 with a
+/// non-JSON body, and a peer that accepts then goes silent; asserts four distinct
+/// variants and the correct confirmed-down flag for each.
+/// Test: This is the test.
+#[tokio::test]
+async fn probe_distinguishes_failure_causes() {
+    // Sub-second bounds so the Timeout case does not add the production 5s to
+    // every test run; `build_probe_client_with` keeps `.no_proxy()`.
+    let client = build_probe_client_with(Duration::from_millis(500), Duration::from_millis(400))
+        .expect("probe client builds");
+
+    let refused = dead_addr();
+    let five_hundred = stub_once("HTTP/1.1 500 Internal Server Error", r#"{"error":"boom"}"#).await;
+    let garbage = stub_once(OK_LINE, "not json at all").await;
+    let silent = stub_hang().await;
+
+    let cases: Vec<(&str, String, ProbeOutcome, bool)> = vec![
+        (
+            "nothing listening",
+            refused,
+            ProbeOutcome::Refused,
+            true, // a genuine TCP observation — may repair
+        ),
+        (
+            "answered 500 with an unusable body",
+            five_hundred,
+            ProbeOutcome::HttpError { status: 500 },
+            false,
+        ),
+        (
+            "answered 200 with a non-JSON body",
+            garbage,
+            ProbeOutcome::BadEnvelope {
+                got: "not json at all".to_owned(),
+            },
+            false,
+        ),
+        (
+            "accepted then never answered",
+            silent,
+            ProbeOutcome::Timeout,
+            true, // a wedged daemon is not serving — may repair
+        ),
+    ];
+
+    for (label, addr, want, confirmed_down) in cases {
+        let got = probe_bases(&client, Some(format!("http://{addr}")), None).await;
+        assert_eq!(got, want, "case `{label}` classified wrongly");
+        assert_eq!(
+            got.is_confirmed_down(),
+            confirmed_down,
+            "case `{label}`: wrong kickstart authorisation"
+        );
+    }
+}
+
+// ── Proxy immunity ──────────────────────────────────────────────────────────
+
+/// Why: `.no_proxy()` is the single most load-bearing line in this module and
+/// there is no other `.no_proxy()` anywhere in the workspace. reqwest 0.12
+/// honours `HTTP_PROXY`/`http_proxy`/`ALL_PROXY` for `127.0.0.1` — hyper-util's
+/// proxy matcher has no runtime loopback exemption — so a developer with a proxy
+/// exported reproduces the identical #4246 false `down` through the NEW
+/// transport, and (pre-gate) gets every healthy daemon kickstarted.
+///
+/// This asserts BOTH halves, so it fails loudly if someone deletes the flag as
+/// "hygiene": a client built WITHOUT it does not reach the stub under an exported
+/// proxy, and the production client does.
+/// What: exports `HTTP_PROXY` pointing at a dead address, probes a live stub
+/// twice — once with a proxy-honouring client, once with
+/// [`build_probe_client`] — and restores the environment. Holds
+/// [`ENV_TEST_LOCK`] because `HTTP_PROXY` is process-global.
+/// Test: This is the test.
+///
+/// If a future reqwest DOES exempt loopback from proxies, the first assertion
+/// below becomes obsolete and should be deleted — but `.no_proxy()` itself must
+/// stay, because the crate cannot pin every consumer's reqwest patch level.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn probe_ignores_http_proxy_env() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let addr = stub_once(OK_LINE, r#"{"status":"ok","version":"0.39.0"}"#).await;
+    let base = format!("http://{addr}");
+    let dead_proxy = dead_addr();
+    let previous = std::env::var("HTTP_PROXY").ok();
+    unsafe {
+        // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
+        std::env::set_var("HTTP_PROXY", format!("http://{dead_proxy}"));
+    }
+
+    // A proxy-honouring client reproduces the bug: loopback goes to the dead proxy.
+    let leaky = reqwest::Client::builder()
+        .connect_timeout(Duration::from_millis(500))
+        .timeout(Duration::from_millis(500))
+        .build()
+        .expect("client builds");
+    let leaked = probe_bases(&leaky, Some(base.clone()), None).await;
+
+    // The production client must reach the stub regardless of the environment.
+    let guarded = build_probe_client().expect("probe client builds");
+    let guarded_outcome = probe_bases(&guarded, Some(base), None).await;
+
+    unsafe {
+        // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
+        match previous {
+            Some(v) => std::env::set_var("HTTP_PROXY", v),
+            None => std::env::remove_var("HTTP_PROXY"),
+        }
+    }
+
+    assert!(
+        !matches!(leaked, ProbeOutcome::Serving { .. }),
+        "a client WITHOUT .no_proxy() is expected to be diverted through HTTP_PROXY \
+         (this is the #4246 mechanism); got {leaked:?}"
+    );
+    assert!(
+        matches!(guarded_outcome, ProbeOutcome::Serving { .. }),
+        ".no_proxy() must make the probe immune to an exported HTTP_PROXY; got \
+         {guarded_outcome:?}"
+    );
+}
+
+// ── Resolution ──────────────────────────────────────────────────────────────
+
+/// Why: the fixed-port leg is transcribed from
+/// `docs/architecture/port-assignments.md`, which is the workspace's
+/// single cross-cutting inventory and has already been the subject of three
+/// collision incidents. Pin every value so a silent drift is a test failure
+/// rather than a probe pointed at another daemon.
+/// What: asserts the six stable-set daemon ports and that a non-member resolves
+/// to `None` (so no address is ever guessed).
+/// Test: This is the test.
+#[test]
+fn fixed_ports_match_port_assignments_doc() {
+    assert_eq!(fixed_port_for("trusty-memory"), Some(7070));
+    assert_eq!(fixed_port_for("trusty-console"), Some(7788));
+    assert_eq!(fixed_port_for("trusty-search"), Some(7878));
+    assert_eq!(fixed_port_for("trusty-analyze"), Some(7879));
+    assert_eq!(fixed_port_for("trusty-mpm"), Some(7880));
+    assert_eq!(fixed_port_for("trusty-review"), Some(7891));
+    // Never guess: `tga` is not a daemon, and `trusty-installer` binds nothing.
+    assert_eq!(fixed_port_for("tga"), None);
+    assert_eq!(fixed_port_for("trusty-installer"), None);
+    // 7881 (mpm supervisor metrics) and 7882 (tcode) belong to other processes
+    // and must not be probed as stable-set members.
+    assert!(!matches!(fixed_port_for("trusty-code"), Some(7882)));
+}
+
+/// Why: `http_addr` is the PRIMARY discovery path — it is what survives a
+/// `--port` override and auto-port-walking — so the resolver must read the real
+/// file written by `trusty_common::write_daemon_addr`, not a mock.
+/// What: plants an `http_addr` under a stubbed data dir and asserts both legs
+/// resolve as documented (recorded from the file, fixed from the table).
+/// Test: This is the test.
+#[test]
+fn resolve_probe_bases_reads_http_addr() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = crate::commands::test_support::stub_data_dir("trusty-memory", "127.0.0.1:7071");
+    let (recorded, fixed) = resolve_probe_bases("trusty-memory", "trusty-memory");
+    crate::commands::test_support::clear_data_dir_override(&dir);
+
+    assert_eq!(recorded.as_deref(), Some("http://127.0.0.1:7071"));
+    assert_eq!(fixed.as_deref(), Some("http://127.0.0.1:7070"));
+}
+
+/// Why: a member with neither a recorded address nor a documented default must
+/// yield `NoAddress` — a clean "nothing to probe" — rather than a guessed port.
+/// `NoAddress` is deliberately NOT confirmed-down: we observed nothing, so there
+/// is no evidence to restart on.
+/// What: an empty data dir plus a binary absent from the port table resolves to
+/// two `None`s, and `probe_bases` on them is `NoAddress`.
+/// Test: This is the test.
+#[tokio::test]
+#[allow(clippy::await_holding_lock)]
+async fn probe_no_address_when_nothing_resolves() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = crate::commands::test_support::stub_empty_data_dir("probe-noaddr");
+    let (recorded, fixed) = resolve_probe_bases("nobody-home-4246", "nobody-home-4246");
+    assert_eq!(recorded, None);
+    assert_eq!(fixed, None);
+
+    let client = build_probe_client().expect("probe client builds");
+    let outcome = probe_bases(&client, recorded, fixed).await;
+    crate::commands::test_support::clear_data_dir_override(&dir);
+
+    assert_eq!(outcome, ProbeOutcome::NoAddress);
+    assert!(!outcome.is_confirmed_down());
+}
+
+/// Why: the end-to-end async entry point must actually wire resolution to the
+/// transport — the two halves being individually correct does not prove
+/// `probe_daemon_http` composes them. Uses a binary absent from the port table so
+/// the ONLY leg is the `http_addr` the test plants, making the assertion
+/// independent of whatever daemons are running on the developer's machine.
+/// What: plants an `http_addr` pointing at a live stub and asserts
+/// `probe_daemon_http` reports it serving.
+/// Test: This is the test.
+#[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn probe_uses_http_addr_when_fixed_port_unknown() {
+    let _guard = ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let addr = stub_once(OK_LINE, r#"{"status":"ok","version":"1.2.3"}"#).await;
+    let app = "probe-http-e2e-4246";
+    let dir = crate::commands::test_support::stub_data_dir(app, &addr);
+    let outcome = probe_daemon_http(app, app).await;
+    crate::commands::test_support::clear_data_dir_override(&dir);
+
+    assert_eq!(
+        outcome,
+        ProbeOutcome::Serving {
+            status: "ok".to_owned(),
+            version: Some("1.2.3".to_owned()),
+        }
+    );
+}
+
+// ── The derived views ───────────────────────────────────────────────────────
+
+/// Why: six existing call sites render `health_string()` into human tables and
+/// `--json` contracts, and `VerifyTailReport::build` / `status`'s exit code both
+/// branch on the exact words. Pin every variant's mapping so the vocabulary
+/// cannot drift silently.
+///
+/// The `BadEnvelope` → `down` choice is deliberate and load-bearing: mapping it
+/// to `unknown` (which `verified` tolerates) would print `VERIFIED` / exit 0 for
+/// a stack about which we hold no health information at all.
+/// What: asserts the string for each variant.
+/// Test: This is the test.
+#[test]
+fn health_string_maps_every_variant() {
+    assert_eq!(ProbeOutcome::NotInstalled.health_string(), "not_installed");
+    assert_eq!(ProbeOutcome::Unprobeable.health_string(), "unknown");
+    assert_eq!(ProbeOutcome::NoAddress.health_string(), "down");
+    assert_eq!(ProbeOutcome::Refused.health_string(), "down");
+    assert_eq!(ProbeOutcome::Timeout.health_string(), "down");
+    assert_eq!(
+        ProbeOutcome::HttpError { status: 502 }.health_string(),
+        "down"
+    );
+    assert_eq!(
+        ProbeOutcome::BadEnvelope {
+            got: "?".to_owned()
+        }
+        .health_string(),
+        "down",
+        "a bad envelope must not be laundered into a tolerated `unknown`"
+    );
+    assert_eq!(
+        ProbeOutcome::ProbeFailed {
+            detail: "?".to_owned()
+        }
+        .health_string(),
+        "down"
+    );
+    assert_eq!(
+        ProbeOutcome::Serving {
+            status: "ok".to_owned(),
+            version: None
+        }
+        .health_string(),
+        "healthy"
+    );
+    assert_eq!(
+        ProbeOutcome::Serving {
+            status: "degraded".to_owned(),
+            version: None
+        }
+        .health_string(),
+        "stale"
+    );
+}
+
+/// Why: `tctl up`'s `ensure_member` branches on `MemberHealth`, not on a string.
+/// `Unprobeable` must map to `Down` (not to a health verdict) so trusty-mpm keeps
+/// falling through to its idempotent `start`, exactly as before #4246.
+/// What: asserts the `MemberHealth` for each variant.
+/// Test: This is the test.
+#[test]
+fn member_health_maps_every_variant() {
+    assert_eq!(
+        ProbeOutcome::NotInstalled.member_health(),
+        MemberHealth::NotInstalled
+    );
+    assert_eq!(
+        ProbeOutcome::Unprobeable.member_health(),
+        MemberHealth::Down,
+        "mpm must keep falling through to `start`, as it did pre-#4246"
+    );
+    for down in [
+        ProbeOutcome::NoAddress,
+        ProbeOutcome::Refused,
+        ProbeOutcome::Timeout,
+        ProbeOutcome::HttpError { status: 500 },
+        ProbeOutcome::BadEnvelope {
+            got: "?".to_owned(),
+        },
+        ProbeOutcome::ProbeFailed {
+            detail: "?".to_owned(),
+        },
+    ] {
+        assert_eq!(down.member_health(), MemberHealth::Down, "{down:?}");
+    }
+    assert_eq!(
+        ProbeOutcome::Serving {
+            status: "running".to_owned(),
+            version: None
+        }
+        .member_health(),
+        MemberHealth::HealthyVersionOk
+    );
+}
+
+/// Why: THE gate. `launchctl kickstart -k` is destructive — no `ExitTimeOut` in
+/// the shared plist renderer means launchd SIGKILLs 20s after SIGTERM, inside
+/// trusty-search's ≥30s-per-index flush budget — so only an observation at the
+/// TRANSPORT layer may authorise it. Everything else means *something* answered,
+/// or that we never looked.
+/// What: exhaustive over every variant: exactly `Refused` and `Timeout` are
+/// confirmed-down.
+/// Test: This is the test.
+#[test]
+fn only_transport_failures_are_confirmed_down() {
+    assert!(ProbeOutcome::Refused.is_confirmed_down());
+    assert!(ProbeOutcome::Timeout.is_confirmed_down());
+    for benign in [
+        ProbeOutcome::NotInstalled,
+        ProbeOutcome::Unprobeable,
+        ProbeOutcome::NoAddress,
+        ProbeOutcome::HttpError { status: 503 },
+        ProbeOutcome::BadEnvelope {
+            got: "clap: unexpected argument '--json'".to_owned(),
+        },
+        ProbeOutcome::ProbeFailed {
+            detail: "no runtime".to_owned(),
+        },
+        ProbeOutcome::Serving {
+            status: "ok".to_owned(),
+            version: None,
+        },
+        ProbeOutcome::Serving {
+            status: "degraded".to_owned(),
+            version: None,
+        },
+    ] {
+        assert!(
+            !benign.is_confirmed_down(),
+            "{benign:?} must never authorise a destructive kickstart"
+        );
+    }
+}

--- a/crates/trusty-installer/src/commands/stable_set.rs
+++ b/crates/trusty-installer/src/commands/stable_set.rs
@@ -100,21 +100,43 @@ impl StableMember {
     /// [`ManageStrategy::Launchd`]. `required` is passed straight through —
     /// see [`stable_set`] for the current REQUIRED/OPTIONAL assignment.
     /// Test: Exercised by [`stable_set`] and `tests::mpm_uses_own_verb`.
+    ///
+    /// #4246: the strategy derivation itself moved out to
+    /// [`manage_strategy_for`], because `tctl up`'s `BootMember` (which carries no
+    /// `manage` field) now needs the SAME rule to route through the one shared
+    /// probe — two copies of "is this member launchd or self-managed?" is exactly
+    /// how the two divergent probes came about.
     fn new(crate_name: &str, binary: &str, daemon: bool, required: bool) -> Self {
-        let manage = if !daemon {
-            ManageStrategy::None
-        } else if binary == "trusty-mpm" {
-            ManageStrategy::OwnVerb
-        } else {
-            ManageStrategy::Launchd
-        };
         Self {
             crate_name: crate_name.to_owned(),
             binary: binary.to_owned(),
             daemon,
-            manage,
+            manage: manage_strategy_for(binary, daemon),
             required,
         }
+    }
+}
+
+/// Derive a member's lifecycle [`ManageStrategy`] from its binary name and
+/// daemon flag.
+///
+/// Why: `tctl status`/`stack`/the verify tail read `StableMember::manage`, but
+/// `tctl up` works from a `BootMember`, which has no such field — so routing `up`
+/// through the one shared health probe (#4246) needs the rule as a standalone
+/// function rather than a `StableMember` constructor detail. Keeping it in ONE
+/// place is the point: the divergent `SystemRunner::probe` this replaces existed
+/// precisely because "how is this member managed?" was answered twice.
+/// What: a non-daemon is [`ManageStrategy::None`]; trusty-mpm is
+/// [`ManageStrategy::OwnVerb`] (process-managed, not launchd); every other daemon
+/// is [`ManageStrategy::Launchd`].
+/// Test: `tests::manage_strategy_for_matches_the_stable_set`.
+pub fn manage_strategy_for(binary: &str, daemon: bool) -> ManageStrategy {
+    if !daemon {
+        ManageStrategy::None
+    } else if binary == "trusty-mpm" {
+        ManageStrategy::OwnVerb
+    } else {
+        ManageStrategy::Launchd
     }
 }
 
@@ -317,6 +339,35 @@ mod tests {
     /// NOT launchd-managed (#1332 decision 3); its lifecycle strategy must be
     /// `OwnVerb` so `tctl start|stop|restart` drives `trusty-mpm start|stop`
     /// rather than a non-existent launchd job.
+    /// Why (#4246): `manage_strategy_for` is now the single rule two callers
+    /// share — `StableMember::new` and `tctl up`'s `SystemRunner::probe`. If they
+    /// ever disagreed, `tctl up` would probe trusty-mpm over HTTP while
+    /// `tctl status` reported it `unknown`, which is the divergence this
+    /// extraction exists to make impossible.
+    /// What: asserts the function agrees with every `manage` field the canonical
+    /// [`stable_set`] carries, plus the non-daemon case.
+    /// Test: This is the test.
+    #[test]
+    fn manage_strategy_for_matches_the_stable_set() {
+        for m in stable_set() {
+            assert_eq!(
+                manage_strategy_for(&m.binary, m.daemon),
+                m.manage,
+                "{} disagrees with its own stable-set entry",
+                m.binary
+            );
+        }
+        assert_eq!(
+            manage_strategy_for("trusty-mpm", true),
+            ManageStrategy::OwnVerb
+        );
+        assert_eq!(
+            manage_strategy_for("trusty-search", true),
+            ManageStrategy::Launchd
+        );
+        assert_eq!(manage_strategy_for("tga", false), ManageStrategy::None);
+    }
+
     /// What: Asserts mpm is in the set, is a daemon, and uses `OwnVerb`.
     /// Test: This is the test.
     #[test]

--- a/crates/trusty-installer/src/commands/stack/doctor.rs
+++ b/crates/trusty-installer/src/commands/stack/doctor.rs
@@ -127,7 +127,10 @@ fn diagnose(m: &StableMember) -> MemberDoctor {
         Ok(Some(a)) if !a.is_empty()
     );
     MemberDoctor {
-        health: probe_member_health(&m.binary, m.manage),
+        // #4246: typed probe; the doctor row renders the flat word.
+        health: probe_member_health(&m.binary, m.manage)
+            .health_string()
+            .to_owned(),
         on_path,
         plist_installed,
         port_recorded,

--- a/crates/trusty-installer/src/commands/stack/health.rs
+++ b/crates/trusty-installer/src/commands/stack/health.rs
@@ -96,7 +96,10 @@ pub fn run_health(json: bool) -> i32 {
         .into_iter()
         .filter(|m| m.daemon)
         .map(|m| HealthRow {
-            health: probe_member_health(&m.binary, m.manage),
+            // #4246: typed probe; the rollup renders the flat word.
+            health: probe_member_health(&m.binary, m.manage)
+                .health_string()
+                .to_owned(),
             member: m.crate_name,
         })
         .collect();

--- a/crates/trusty-installer/src/commands/stack/health.rs
+++ b/crates/trusty-installer/src/commands/stack/health.rs
@@ -4,7 +4,8 @@
 //! strategy-aware health probe across every stable-set daemon and reduces the
 //! per-member verdicts to one overall verdict.
 //!
-//! What: probes each daemon member via `probe::probe_member_health`, builds a
+//! What: probes each daemon member via `probe::probe_member_health` (an HTTP
+//! `GET /health` probe since #4246, not a `health --json` subprocess), builds a
 //! [`HealthReport`], renders a human matrix or `--json` envelope, and returns an
 //! exit code (0 ready, 2 when any daemon is `down`).
 //!
@@ -53,7 +54,7 @@ impl HealthReport {
     /// to `degraded`. A `down` daemon is the running-but-broken failure signal; a
     /// `not_installed` member is a real gap in the resolved stable set (an
     /// operator after a failed install must NOT see green). Only a genuinely
-    /// `unknown` member (e.g. trusty-mpm, which has no `health --json` verb) does
+    /// `unknown` member (e.g. trusty-mpm, deliberately left unprobed — #4246) does
     /// NOT degrade — its health is unprobeable, not absent. `stale` also stays
     /// non-degrading (running, just below the version floor).
     /// Test: `tests::verdict_down_is_degraded`,

--- a/crates/trusty-installer/src/commands/status.rs
+++ b/crates/trusty-installer/src/commands/status.rs
@@ -106,7 +106,13 @@ pub fn run(json: bool) -> i32 {
     for m in stable_set() {
         let installed = installed_version(&m.binary);
         let (health, daemon) = if m.daemon {
-            (probe_member_health(&m.binary, m.manage), true)
+            // #4246: the probe is now typed; `status` renders only the flat word.
+            (
+                probe_member_health(&m.binary, m.manage)
+                    .health_string()
+                    .to_owned(),
+                true,
+            )
         } else {
             (
                 if installed.is_some() {

--- a/crates/trusty-installer/src/commands/status.rs
+++ b/crates/trusty-installer/src/commands/status.rs
@@ -6,8 +6,9 @@
 //!
 //! What: For each stable-set member, reports the installed version (via
 //! `<binary> --version`) and — for daemons — a coarse health verdict (via the
-//! shared `probe::probe_member_health`, strategy-aware so process-managed
-//! members like trusty-mpm report `unknown` rather than a false `down`).
+//! shared `probe::probe_member_health` — an HTTP `GET /health` probe since
+//! #4246, strategy-aware so process-managed members like trusty-mpm report
+//! `unknown` rather than a false `down`).
 //! Renders a human table or a `--json` envelope. Returns exit 0 when every
 //! daemon is healthy (or absent/unknown-but-reported), 2 when a daemon is down.
 //!

--- a/crates/trusty-installer/src/commands/test_support.rs
+++ b/crates/trusty-installer/src/commands/test_support.rs
@@ -1,0 +1,178 @@
+//! Crate-wide test-only helpers: stub HTTP servers, a stubbed data dir, and the
+//! process-global env-var lock (#4246).
+//!
+//! Why: `trusty-installer` ships an EMPTY `[dev-dependencies]` — there is no
+//! `wiremock`, and adding one is out of scope. The `ensure::project_setup` tests
+//! had already grown the only real test vehicle in the crate: a raw
+//! `tokio::net::TcpListener` answering fixed responses, plus a `TRUSTY_DATA_DIR_
+//! OVERRIDE`-stubbed data dir holding a real `http_addr` file. #4246 needs that
+//! exact vehicle from TWO more modules (`probe_http` and `verify_tail`), so it is
+//! promoted here rather than copied a third time.
+//!
+//! What: [`ENV_TEST_LOCK`] (the process-global serialiser every env-mutating
+//! test must hold), [`stub_once`] / [`stub_seq`] (one-shot and sequenced
+//! loopback servers), and [`stub_data_dir`] / [`stub_empty_data_dir`] /
+//! [`clear_data_dir_override`] (a throwaway data dir with or without a planted
+//! `http_addr`).
+//!
+//! Test: this module IS test support; it is exercised by every test that imports
+//! it (`ensure::project_setup`, `probe_http`, `verify_tail`).
+
+/// Process-wide lock serialising tests that mutate global env vars.
+///
+/// Why: `TRUSTY_DATA_DIR_OVERRIDE`, `HTTP_PROXY`, `TCTL_ENSURE_WAIT_*` are all
+/// process-global, so tests in different modules would race each other — and
+/// `cargo test` runs them on a thread pool by default. A single crate-shared
+/// lock, held for the whole duration of each env-mutating test, is what makes
+/// those assertions deterministic.
+/// What: a `Mutex<()>` reachable from every module's test code. Poisoning is
+/// irrelevant here (the guarded data is `()`), so callers take it with
+/// `.unwrap_or_else(|e| e.into_inner())`.
+/// Test: used by the env-mutating tests in `ensure::{daemon, project_setup,
+/// readiness}`, `probe_http`, and `verify_tail`.
+pub(crate) static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Spawn a one-shot TCP server that answers the first request with a fixed
+/// HTTP response, and return its `host:port`.
+///
+/// Why: standing up a real `reqwest` round-trip against a controlled response
+/// lets request-issuing logic be tested end-to-end without a live daemon.
+/// What: binds an ephemeral loopback port, accepts one connection, drains the
+/// request headers, writes `body` behind `status_line`, and returns the bound
+/// address.
+/// Test: used by every stub-server test in the crate.
+pub(crate) async fn stub_once(status_line: &'static str, body: &'static str) -> String {
+    stub_seq(vec![(status_line, body)]).await
+}
+
+/// Spawn a TCP server that answers a *sequence* of requests, one fixed response
+/// per accepted connection in order.
+///
+/// Why: some flows issue two requests (`ensure`'s palace-create does an
+/// existence GET then a create POST); covering those needs a stub that can
+/// answer differently per connection.
+/// What: binds an ephemeral loopback port, accepts `responses.len()`
+/// connections, and writes each `(status_line, body)` in turn.
+/// Test: used by `ensure::project_setup::tests::create_palace_created`.
+pub(crate) async fn stub_seq(responses: Vec<(&'static str, &'static str)>) -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        for (status_line, body) in responses {
+            if let Ok((mut sock, _)) = listener.accept().await {
+                // Drain the request up to (and including) the end-of-headers
+                // marker before replying. A single fixed-size read can split
+                // a request whose body is long, which used to race the write
+                // and flake CI; reading until `\r\n\r\n` (or EOF) consumes the
+                // whole header block deterministically. We don't need the body
+                // — only that the request is fully sent.
+                let mut acc = Vec::with_capacity(2048);
+                let mut chunk = [0u8; 2048];
+                loop {
+                    match sock.read(&mut chunk).await {
+                        Ok(0) => break,
+                        Ok(n) => {
+                            acc.extend_from_slice(&chunk[..n]);
+                            if acc.windows(4).any(|w| w == b"\r\n\r\n") {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+                let resp = format!(
+                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                    body.len()
+                );
+                let _ = sock.write_all(resp.as_bytes()).await;
+                let _ = sock.shutdown().await;
+            } else {
+                break;
+            }
+        }
+    });
+    addr
+}
+
+/// Point `resolve_data_dir` at a throwaway directory with NO `http_addr` in it.
+///
+/// Why: "the daemon never started" is a distinct, load-bearing state — `ensure`
+/// must report an idempotent skip rather than a failure, and the #4246 probe
+/// must fall back to the documented default port rather than inventing an
+/// address. Staging it means an EMPTY data dir, so it cannot reuse
+/// [`stub_data_dir`].
+///
+/// # Preconditions
+/// The caller MUST be holding [`ENV_TEST_LOCK`].
+/// # Postconditions
+/// Returns the created directory; teardown is [`clear_data_dir_override`].
+/// Test: used by `ensure::project_setup::tests::register_index_daemon_down`,
+/// `create_palace_daemon_down`.
+pub(crate) fn stub_empty_data_dir(tag: &str) -> std::path::PathBuf {
+    let tmp = std::env::temp_dir().join(format!(
+        "tctl-test-empty-{}-{}-{}",
+        tag,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    unsafe {
+        // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
+        std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, &tmp);
+    }
+    tmp
+}
+
+/// Point `resolve_data_dir` at a throwaway directory and plant `app`'s
+/// `http_addr` inside it.
+///
+/// Why: this exercises the PRIMARY daemon-discovery path for real — a genuine
+/// `http_addr` file written by `trusty_common::write_daemon_addr` and read back
+/// by `trusty_common::read_daemon_addr` — rather than mocking the resolver away.
+///
+/// # Preconditions
+/// The caller MUST be holding [`ENV_TEST_LOCK`]: `TRUSTY_DATA_DIR_OVERRIDE` is
+/// process-global.
+/// # Postconditions
+/// Returns the created directory; the caller is responsible for
+/// [`clear_data_dir_override`] and removing it.
+/// Test: used by `ensure::project_setup`, `probe_http`, `verify_tail`.
+pub(crate) fn stub_data_dir(app: &str, addr: &str) -> std::path::PathBuf {
+    let tmp = std::env::temp_dir().join(format!(
+        "tctl-test-{}-{}-{}",
+        app,
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0)
+    ));
+    std::fs::create_dir_all(&tmp).unwrap();
+    unsafe {
+        // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
+        std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, &tmp);
+    }
+    trusty_common::write_daemon_addr(app, addr).unwrap();
+    tmp
+}
+
+/// Remove the `TRUSTY_DATA_DIR_OVERRIDE` set by [`stub_data_dir`] and delete
+/// `dir`.
+///
+/// Why: leaving the override set would leak into whichever test acquires
+/// [`ENV_TEST_LOCK`] next; centralising the teardown (and its one `unsafe`
+/// justification) keeps that from being re-argued per test.
+/// # Preconditions
+/// The caller is still holding [`ENV_TEST_LOCK`].
+/// Test: used by every test that calls [`stub_data_dir`].
+pub(crate) fn clear_data_dir_override(dir: &std::path::Path) {
+    unsafe {
+        // SAFETY: serialised by ENV_TEST_LOCK; no concurrent env access in this crate's tests.
+        std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
+    }
+    let _ = std::fs::remove_dir_all(dir);
+}

--- a/crates/trusty-installer/src/commands/test_support.rs
+++ b/crates/trusty-installer/src/commands/test_support.rs
@@ -10,13 +10,15 @@
 //! promoted here rather than copied a third time.
 //!
 //! What: [`ENV_TEST_LOCK`] (the process-global serialiser every env-mutating
-//! test must hold), [`stub_once`] / [`stub_seq`] (one-shot and sequenced
-//! loopback servers), and [`stub_data_dir`] / [`stub_empty_data_dir`] /
+//! test must hold), [`stub_once`] / [`stub_seq`] / [`stub_hang`] /
+//! [`stub_seq_blocking`] (loopback servers: one-shot, sequenced, silent, and one
+//! hosted on its own thread for callers that block), [`dead_addr`] (an address
+//! guaranteed to refuse), and [`stub_data_dir`] / [`stub_empty_data_dir`] /
 //! [`clear_data_dir_override`] (a throwaway data dir with or without a planted
 //! `http_addr`).
 //!
 //! Test: this module IS test support; it is exercised by every test that imports
-//! it (`ensure::project_setup`, `probe_http`, `verify_tail`).
+//! it (`ensure::project_setup`, `probe`, `probe_http`, `verify_tail`).
 
 /// Process-wide lock serialising tests that mutate global env vars.
 ///
@@ -31,6 +33,26 @@
 /// Test: used by the env-mutating tests in `ensure::{daemon, project_setup,
 /// readiness}`, `probe_http`, and `verify_tail`.
 pub(crate) static ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// A member binary name that is guaranteed resolvable on PATH, has NO documented
+/// default port, and is not a real trusty daemon (#4246).
+///
+/// Why: `probe::probe_member_health` short-circuits to
+/// `ProbeOutcome::NotInstalled` before it ever reaches the HTTP transport when
+/// `resolve_binary_path` finds nothing — so a test that wants to exercise the
+/// probe→kickstart-gate path cannot use a made-up binary name. Using a REAL
+/// member name instead (`trusty-search`, …) is worse: `fixed_port_for` would
+/// resolve its documented port and the probe's second leg would hit whatever
+/// daemon happens to be running on the developer's machine, making the test
+/// environment-dependent. `sh` satisfies all three constraints: always present
+/// on the unix targets this crate's tests already assume (they spawn `echo` and
+/// `sleep` unconditionally), absent from
+/// [`crate::commands::probe_http::fixed_port_for`], and never a daemon — so the
+/// ONLY address that resolves is the `http_addr` the test itself plants.
+/// What: `"sh"`.
+/// Test: used by `probe::tests::probe_member_health_*` and
+/// `verify_tail::tests::verify_one_*`.
+pub(crate) const PROBEABLE_BINARY: &str = "sh";
 
 /// Spawn a one-shot TCP server that answers the first request with a fixed
 /// HTTP response, and return its `host:port`.
@@ -51,47 +73,151 @@ pub(crate) async fn stub_once(status_line: &'static str, body: &'static str) -> 
 /// Why: some flows issue two requests (`ensure`'s palace-create does an
 /// existence GET then a create POST); covering those needs a stub that can
 /// answer differently per connection.
-/// What: binds an ephemeral loopback port, accepts `responses.len()`
-/// connections, and writes each `(status_line, body)` in turn.
+///
+/// # Preconditions
+/// The caller must remain on a runtime that can poll the spawned accept loop —
+/// i.e. it must `await` rather than block. A caller that blocks its own runtime
+/// thread (the #4246 sync probe bridge) must use [`stub_seq_blocking`] instead,
+/// or the accept loop never runs and the probe times out.
+/// What: binds an ephemeral loopback port, `tokio::spawn`s the accept loop, and
+/// returns the bound address.
 /// Test: used by `ensure::project_setup::tests::create_palace_created`.
 pub(crate) async fn stub_seq(responses: Vec<(&'static str, &'static str)>) -> String {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap().to_string();
-    tokio::spawn(async move {
-        use tokio::io::{AsyncReadExt, AsyncWriteExt};
-        for (status_line, body) in responses {
-            if let Ok((mut sock, _)) = listener.accept().await {
-                // Drain the request up to (and including) the end-of-headers
-                // marker before replying. A single fixed-size read can split
-                // a request whose body is long, which used to race the write
-                // and flake CI; reading until `\r\n\r\n` (or EOF) consumes the
-                // whole header block deterministically. We don't need the body
-                // — only that the request is fully sent.
-                let mut acc = Vec::with_capacity(2048);
-                let mut chunk = [0u8; 2048];
-                loop {
-                    match sock.read(&mut chunk).await {
-                        Ok(0) => break,
-                        Ok(n) => {
-                            acc.extend_from_slice(&chunk[..n]);
-                            if acc.windows(4).any(|w| w == b"\r\n\r\n") {
-                                break;
-                            }
-                        }
-                        Err(_) => break,
+    tokio::spawn(serve_fixed(listener, responses));
+    addr
+}
+
+/// Answer `responses.len()` connections on `listener`, one fixed response each.
+///
+/// Why: the shared body of [`stub_seq`] and [`stub_seq_blocking`] — the two
+/// differ only in WHERE the accept loop is driven, never in what it answers, and
+/// a second copy of the header-draining logic would be free to drift.
+/// What: for each `(status_line, body)`, accepts one connection, drains the
+/// request headers, writes the response with a correct `Content-Length`, and
+/// shuts the socket down.
+/// Test: exercised by every stub-server test in the crate.
+async fn serve_fixed(
+    listener: tokio::net::TcpListener,
+    responses: Vec<(&'static str, &'static str)>,
+) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    for (status_line, body) in responses {
+        let Ok((mut sock, _)) = listener.accept().await else {
+            break;
+        };
+        // Drain the request up to (and including) the end-of-headers marker
+        // before replying. A single fixed-size read can split a request whose
+        // body is long, which used to race the write and flake CI; reading until
+        // `\r\n\r\n` (or EOF) consumes the whole header block deterministically.
+        // We don't need the body — only that the request is fully sent.
+        let mut acc = Vec::with_capacity(2048);
+        let mut chunk = [0u8; 2048];
+        loop {
+            match sock.read(&mut chunk).await {
+                Ok(0) => break,
+                Ok(n) => {
+                    acc.extend_from_slice(&chunk[..n]);
+                    if acc.windows(4).any(|w| w == b"\r\n\r\n") {
+                        break;
                     }
                 }
-                let resp = format!(
-                    "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
-                    body.len()
-                );
-                let _ = sock.write_all(resp.as_bytes()).await;
-                let _ = sock.shutdown().await;
-            } else {
-                break;
+                Err(_) => break,
             }
         }
+        let resp = format!(
+            "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let _ = sock.write_all(resp.as_bytes()).await;
+        let _ = sock.shutdown().await;
+    }
+}
+
+/// [`stub_seq`], but hosted on its own thread and callable from sync code
+/// (#4246).
+///
+/// Why: `probe_http::probe_member_http_blocking` BLOCKS its caller — that is its
+/// contract, because `tctl`'s dispatch is synchronous. A stub whose accept loop
+/// lives on the *test's* runtime would therefore deadlock: the test blocks
+/// waiting for a response the runtime cannot produce because the test is holding
+/// it. Hosting the stub on a wholly separate thread + runtime removes the shared
+/// resource, which is what lets `verify_one`'s kickstart-gate tests be plain
+/// `#[test]` functions driving the REAL probe.
+/// What: spawns a thread with its own current-thread runtime that binds the
+/// listener, reports the address back over a channel, then serves `responses`.
+/// The thread exits once every response is written.
+/// Test: used by `probe::tests::probe_member_health_*` and
+/// `verify_tail::tests::verify_one_*`.
+pub(crate) fn stub_seq_blocking(responses: Vec<(&'static str, &'static str)>) -> String {
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        else {
+            return;
+        };
+        rt.block_on(async move {
+            let Ok(listener) = tokio::net::TcpListener::bind("127.0.0.1:0").await else {
+                return;
+            };
+            let Ok(addr) = listener.local_addr() else {
+                return;
+            };
+            if tx.send(addr.to_string()).is_err() {
+                return;
+            }
+            serve_fixed(listener, responses).await;
+        });
     });
+    rx.recv()
+        .expect("stub server must report its bound address")
+}
+
+/// Spawn a TCP server that ACCEPTS connections and then never answers, and
+/// return its `host:port` (#4246).
+///
+/// Why: `ProbeOutcome::Timeout` and `ProbeOutcome::Refused` must be
+/// distinguishable — that distinction is the whole basis of the confirmed-down
+/// kickstart gate. A refusal is easy to stage ([`dead_addr`]); a timeout needs a
+/// peer that completes the TCP handshake and then goes silent, which is exactly
+/// the wedged-daemon shape the bound exists for.
+/// What: binds an ephemeral loopback port and holds every accepted socket open
+/// (never writing) until the test process ends. Returns the bound address.
+/// Test: `probe_http::tests::probe_distinguishes_failure_causes`.
+pub(crate) async fn stub_hang() -> String {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((sock, _)) = listener.accept().await {
+            // Keep the socket alive — dropping it would send FIN and turn the
+            // timeout under test into a connection-closed error instead.
+            held.push(sock);
+        }
+    });
+    addr
+}
+
+/// A loopback `host:port` guaranteed to REFUSE a connection.
+///
+/// Why: the confirmed-down half of the probe taxonomy needs a deterministic
+/// "nothing is listening" address. Hardcoding a port risks colliding with a real
+/// daemon on the developer's machine (this workspace has had three port
+/// collisions); binding an ephemeral port and immediately releasing it yields an
+/// address the OS has just confirmed is free. Deliberately sync (`std::net`) so
+/// it is usable from both `#[test]` and `#[tokio::test]`.
+/// What: binds `127.0.0.1:0`, records the address, drops the listener, and
+/// returns the address.
+/// Test: `probe_http::tests::probe_distinguishes_failure_causes`,
+/// `probe_http::tests::probe_port_walked_daemon_is_healthy`,
+/// `verify_tail::tests::verify_one_kickstarts_a_genuinely_down_launchd_daemon`.
+pub(crate) fn dead_addr() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap().to_string();
+    drop(listener);
     addr
 }
 

--- a/crates/trusty-installer/src/commands/up/member.rs
+++ b/crates/trusty-installer/src/commands/up/member.rs
@@ -1,10 +1,12 @@
 //! Per-member ensure: CHECK → act → VERIFY (DOC-12 §3 STAGE ensure).
 //!
 //! Why: Every always-on stage step follows the identical idempotent shape from
-//! DOC-12 §3.4: CHECK `<binary> health --json` → if healthy no-op; if down
+//! DOC-12 §3.4: CHECK the member's health → if healthy no-op; if down
 //! `<binary> start`; if missing auto-install (always-on only); then VERIFY with
-//! `<binary> health --json`. Centralising the shape keeps the stage code thin
-//! and lets the actual process execution be mocked for unit tests.
+//! a second health check. Centralising the shape keeps the stage code thin and
+//! lets the actual process execution be mocked for unit tests. (#4246: the CHECK
+//! is an HTTP `GET /health` via the one shared probe, not the `health --json`
+//! subprocess verb this doc used to name — no daemon implements that.)
 //!
 //! What: Defines the `Runner` trait (probe presence / health / start / install
 //! a member) so the orchestrator can run against the real OS or a test double,
@@ -43,7 +45,7 @@ pub enum MemberHealth {
 /// Abstraction over the OS actions `ensure_member` performs on a member binary.
 ///
 /// Why: The orchestrator shells out to each member's contract verbs
-/// (`health --json`, `start`) and to the installer. Hiding that behind a trait
+/// (health probe, `start`) and to the installer. Hiding that behind a trait
 /// makes the §3.4 control flow unit-testable without spawning real daemons.
 ///
 /// What: Three operations, each keyed by the member's `binary` / `id`:
@@ -52,10 +54,11 @@ pub enum MemberHealth {
 ///
 /// Test: `super::tests::ScriptedRunner` implements this for the matrix tests.
 pub trait Runner {
-    /// Probe the member's liveness via its `health --json` contract verb.
+    /// Probe the member's liveness.
     ///
     /// Why: This is both the CHECK (before acting) and the VERIFY (after acting)
-    /// step of §3.4.
+    /// step of §3.4. #4246: `SystemRunner` implements it over HTTP `/health` via
+    /// the one shared probe; the test doubles script it directly.
     /// What: Returns the `MemberHealth` verdict for `member`.
     /// Test: scripted in `super::tests`.
     fn probe(&self, member: &BootMember) -> MemberHealth;

--- a/crates/trusty-installer/src/commands/up/system_runner.rs
+++ b/crates/trusty-installer/src/commands/up/system_runner.rs
@@ -41,19 +41,35 @@ impl SystemRunner {
     }
 }
 
-/// Map a DOC-1 `health --json` `status` string to a `MemberHealth` verdict.
+/// Map a daemon `/health` envelope's `status` string to a `MemberHealth` verdict.
 ///
-/// Why: The probe parses the contract envelope's `status` field; isolating the
-/// mapping makes the (otherwise side-effecting) probe partially unit-testable.
+/// Why: the probe classifies the envelope's `status` field; isolating the
+/// mapping makes the (otherwise side-effecting) probe unit-testable and keeps
+/// ONE vocabulary shared by `tctl up`, `status`, `stack` and the verify tail.
 ///
-/// What: `"healthy"`/`"ok"`/`"ready"` → `HealthyVersionOk`;
-/// `"stale"`/`"version_below_floor"`/`"degraded"` → `HealthyStale`; anything
-/// else (including `"down"`/`"error"`) → `Down`.
+/// #4246: `"running"`/`"serving"` were missing, so a daemon reporting the
+/// DOC-1 D4 vocabulary literally (`running | degraded | down`) fell through to
+/// `Down` — a false negative baked into the vocabulary itself, and one the test
+/// suite defended (`up::tests` asserted `"anything-else" → Down` where
+/// `"running"` IS "anything-else"). No shipped daemon emits `running` today
+/// (all six emit `ok`), so adding it changes nothing observable now and closes
+/// the trap for the next daemon that follows the spec.
 ///
-/// Test: `super::tests::classify_status_maps_known_values`.
+/// What: `"healthy"`/`"ok"`/`"ready"`/`"running"`/`"serving"` →
+/// `HealthyVersionOk`; `"stale"`/`"version_below_floor"`/`"degraded"` →
+/// `HealthyStale`; anything else (including `"down"`/`"error"`) → `Down`.
+///
+/// A genuinely unrecognised word still maps to `Down`, deliberately: that is a
+/// DISPLAY verdict only. Since #4246 the destructive repair is gated on
+/// [`super::super::probe_http::ProbeOutcome::is_confirmed_down`] — a
+/// transport-level observation — so an unknown status word can no longer
+/// kickstart anything.
+///
+/// Test: `super::tests::classify_status_maps_known_values`,
+/// `super::tests::classify_status_accepts_spec_vocabulary`.
 pub fn classify_status(status: &str) -> MemberHealth {
     match status.to_ascii_lowercase().as_str() {
-        "healthy" | "ok" | "ready" => MemberHealth::HealthyVersionOk,
+        "healthy" | "ok" | "ready" | "running" | "serving" => MemberHealth::HealthyVersionOk,
         "stale" | "version_below_floor" | "degraded" => MemberHealth::HealthyStale,
         _ => MemberHealth::Down,
     }

--- a/crates/trusty-installer/src/commands/up/system_runner.rs
+++ b/crates/trusty-installer/src/commands/up/system_runner.rs
@@ -1,19 +1,25 @@
-//! Real `Runner` backed by the OS (process spawns + PATH probes).
+//! Real `Runner` backed by the OS (process spawns + the shared health probe).
 //!
 //! Why: `ensure_member` (member.rs) is transport-agnostic; this is the concrete
-//! implementation that actually probes each member's DOC-1 contract verbs over
-//! the OS — `which <binary>` for presence, `<binary> health --json` for
-//! liveness, `<binary> start` to bring it up, and `tctl install <member>` to
-//! auto-install an always-on member (RESOLVED Q1).
+//! implementation that actually brings members up over the OS — `<binary> start`
+//! to start one, and `tctl install <member>` to auto-install an always-on member
+//! (RESOLVED Q1).
 //!
-//! What: `SystemRunner` implements `Runner`. `probe` resolves the binary on
-//! PATH then parses the `health --json` envelope's `status` field into a
-//! `MemberHealth`; `start` and `install` spawn the corresponding command and
-//! map a non-zero exit into an `Err` with context.
+//! #4246: `probe` used to be its OWN health probe — a second copy of the
+//! `<binary> health --json` shell-out that `commands::probe` also had, divergent
+//! in two respects and wrong in the same way. It now delegates to the single
+//! shared probe, so `tctl up` and `tctl status` can never disagree about whether
+//! a daemon is up.
 //!
-//! Test: This file is side-effect-only (it spawns real subprocesses); its logic
-//! is covered indirectly by the `super::tests` matrix run against the mock
-//! `Runner`, and the JSON-status mapping is unit-tested via `classify_status`.
+//! What: `SystemRunner` implements `Runner`. `probe` delegates to
+//! `commands::probe::probe_member_health`; `start` and `install` spawn the
+//! corresponding command and map a non-zero exit into an `Err` with context.
+//! [`classify_status`] — the shared `status`-word vocabulary — lives here for
+//! historical reasons and is used by `probe_http` as well as by `up`.
+//!
+//! Test: the spawning halves are side-effect-only; their control flow is covered
+//! by the `super::tests` matrix run against the mock `Runner`, and
+//! `classify_status` is unit-tested directly.
 
 use std::process::Command;
 
@@ -76,32 +82,27 @@ pub fn classify_status(status: &str) -> MemberHealth {
 }
 
 impl Runner for SystemRunner {
+    /// #4246: routes through the ONE shared probe
+    /// (`commands::probe::probe_member_health`) instead of carrying a second,
+    /// divergent copy of the same idea. The deleted version shelled out to
+    /// `<binary> health --json` — the contract no daemon implements — and differed
+    /// from the shared probe in two ways that were both bugs: it used bare
+    /// `which::which` for presence (so an installed-but-off-PATH binary read
+    /// `NotInstalled` and triggered a spurious full auto-reinstall, the #3876
+    /// failure class), and it mapped an unparseable 0-exit envelope to
+    /// `HealthyStale` rather than `Down`.
+    ///
+    /// Neither divergence could change what `tctl up` *does*: `ensure_member`
+    /// treats `HealthyStale` and `Down` identically (both fall through to
+    /// `start`). What DOES change, and is the point, is that a genuinely healthy
+    /// daemon now reads `HealthyVersionOk` and is reported a no-op instead of
+    /// being handed a redundant `start` — the same false-`down` class as the
+    /// verify tail's spurious kickstart, one layer up. trusty-mpm keeps its
+    /// pre-#4246 behaviour exactly: `OwnVerb` → `Unprobeable` → `Down` → `start`,
+    /// which is idempotent.
     fn probe(&self, member: &BootMember) -> MemberHealth {
-        // Presence first: a binary not on PATH is NotInstalled (drives auto-install).
-        if which::which(&member.binary).is_err() {
-            return MemberHealth::NotInstalled;
-        }
-        // CHECK / VERIFY: `<binary> health --json`. A non-2xx contract or an
-        // unparseable envelope means "not healthy" → Down (so the act step runs).
-        let out = Command::new(&member.binary)
-            .args(["health", "--json"])
-            .output();
-        let Ok(out) = out else {
-            return MemberHealth::Down;
-        };
-        if !out.status.success() {
-            return MemberHealth::Down;
-        }
-        let parsed: Result<serde_json::Value, _> = serde_json::from_slice(&out.stdout);
-        match parsed {
-            Ok(v) => {
-                let status = v.get("status").and_then(|s| s.as_str()).unwrap_or("down");
-                classify_status(status)
-            }
-            // A 0-exit `health` with no/odd JSON: treat as alive-but-unknown =>
-            // stale rather than down so we do not bounce a possibly-healthy daemon.
-            Err(_) => MemberHealth::HealthyStale,
-        }
+        let manage = crate::commands::stable_set::manage_strategy_for(&member.binary, true);
+        crate::commands::probe::probe_member_health(&member.binary, manage).member_health()
     }
 
     fn start(&self, member: &BootMember) -> anyhow::Result<()> {

--- a/crates/trusty-installer/src/commands/up/tests.rs
+++ b/crates/trusty-installer/src/commands/up/tests.rs
@@ -450,8 +450,31 @@ fn classify_status_maps_known_values() {
     assert_eq!(classify_status("healthy"), MemberHealth::HealthyVersionOk);
     assert_eq!(classify_status("OK"), MemberHealth::HealthyVersionOk);
     assert_eq!(classify_status("stale"), MemberHealth::HealthyStale);
+    assert_eq!(classify_status("degraded"), MemberHealth::HealthyStale);
     assert_eq!(classify_status("down"), MemberHealth::Down);
-    assert_eq!(classify_status("anything-else"), MemberHealth::Down);
+    // #4246: an unrecognised word is a DISPLAY `down` only — it can no longer
+    // authorise a kickstart (see `ProbeOutcome::is_confirmed_down`). The token
+    // here is deliberately gibberish; it used to be "anything-else", which
+    // silently asserted that spec words like "running" were down too.
+    assert_eq!(classify_status("zzz-not-a-status-word"), MemberHealth::Down);
+}
+
+/// Why (#4246): the pre-fix vocabulary omitted `running`/`serving`, so a daemon
+/// reporting DOC-1 D4's literal status vocabulary read as `down` — a false
+/// negative built into the classifier, which the old
+/// `classify_status("anything-else") == Down` assertion defended.
+/// What: asserts every word the spec + the six shipped daemons actually use
+/// classifies as serving, case-insensitively.
+/// Test: This is the test.
+#[test]
+fn classify_status_accepts_spec_vocabulary() {
+    for word in ["ok", "OK", "healthy", "ready", "running", "Serving"] {
+        assert_eq!(
+            classify_status(word),
+            MemberHealth::HealthyVersionOk,
+            "`{word}` must classify as serving, not down"
+        );
+    }
 }
 
 // ── §6 claude-code flow ─────────────────────────────────────────────────────────

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -77,6 +77,7 @@ use std::time::{Duration, Instant};
 use serde::Serialize;
 
 use super::probe::{health_str, probe_member_health};
+use super::probe_http::ProbeOutcome;
 use super::stable_set::{ManageStrategy, StableMember};
 use super::verify_launchd_state::{classify_down_state, DownState};
 
@@ -203,16 +204,70 @@ impl VerifyTailReport {
     }
 }
 
-/// Whether a member's health verdict warrants a #2498 kickstart retry.
+/// Whether a member's probe outcome warrants a #2498 kickstart retry.
 ///
 /// Why: only a `down` LAUNCHD daemon is the #2498 failure signature
-/// (`launchctl bootstrap` succeeded, `RunAtLoad` never fired); a
-/// `not_installed` member, an `unknown` process-managed member (trusty-mpm),
-/// or a non-launchd member must never trigger a kickstart attempt.
-/// What: `true` iff `health == "down"` AND `manage == Launchd`.
-/// Test: `tests::needs_kickstart_only_for_down_launchd`.
-pub fn needs_kickstart(health: &str, manage: ManageStrategy) -> bool {
-    health == health_str::DOWN && manage == ManageStrategy::Launchd
+/// (`launchctl bootstrap` succeeded, `RunAtLoad` never fired); a `not_installed`
+/// member, an `unknown` process-managed member (trusty-mpm), or a non-launchd
+/// member must never trigger a kickstart attempt.
+///
+/// #4246: this predicate was never wrong — `probe_member_health` MANUFACTURED
+/// the `down` it fired on, by shelling out to a `health --json` verb no daemon
+/// implements. So the input changed from a flat string to a typed
+/// [`ProbeOutcome`], and the condition from "reads down" to
+/// [`ProbeOutcome::is_confirmed_down`]: `Refused` or `Timeout`, i.e. a
+/// TRANSPORT-level observation that nothing accepted the connection or nothing
+/// answered in time. A schema mismatch, an unusable body, or a squatter on a
+/// documented port all mean *something* answered, so restarting is a guess — and
+/// `kickstart -k` is not a polite restart (no `ExitTimeOut` in the shared plist
+/// renderer, so launchd SIGKILLs 20s after SIGTERM, inside trusty-search's
+/// ≥30s-per-index flush budget). That gate is only expressible now that the
+/// transport is HTTP: a subprocess probe cannot produce a `Refused`.
+///
+/// The mirror property matters just as much: a genuinely dead daemon still
+/// yields `Refused`, so the #2498 repair path is preserved rather than deleted.
+/// What: `true` iff `outcome.is_confirmed_down()` AND `manage == Launchd`.
+/// Test: `tests::needs_kickstart_only_for_confirmed_down_launchd`,
+/// `tests::needs_kickstart_never_fires_on_a_schema_problem`.
+pub fn needs_kickstart(outcome: &ProbeOutcome, manage: ManageStrategy) -> bool {
+    outcome.is_confirmed_down() && manage == ManageStrategy::Launchd
+}
+
+/// The destructive repair [`verify_one`] may perform, behind a seam (#4246).
+///
+/// Why: `verify_one` was untestable in the direction that mattered. The existing
+/// `needs_kickstart_only_for_down_launchd` test passed the whole time the bug was
+/// live, because it fed the predicate a hand-typed `"down"` — nothing exercised
+/// the real probe and the real decision together, so nothing could catch
+/// `probe_member_health` manufacturing that `down`. Injecting the kickstart lets
+/// `tests::verify_one_does_not_kickstart_a_healthy_launchd_daemon` run the REAL
+/// probe against a stubbed healthy daemon and then assert ZERO restarts — the
+/// only shape of test that closes the loop. Mirrors the `ServiceEnv` seam already
+/// in this file (see [`apply_not_loaded_fallback`], tested against
+/// `tests::FakeServiceEnv`).
+/// What: one operation — force-start a member's launchd job — returning whether
+/// it succeeded.
+/// Test: [`RealKickstarter`] is side-effecting; the decision that calls it is
+/// covered against `tests::FakeKickstarter`.
+pub trait Kickstarter {
+    /// Force-start `binary`'s launchd job, returning whether the command
+    /// succeeded. A `false` does NOT by itself mean the daemon is unreachable —
+    /// see [`kickstart`].
+    fn kickstart(&self, binary: &str) -> bool;
+}
+
+/// The production [`Kickstarter`] — the only thing that runs real `launchctl`.
+///
+/// Why: keeps `launchctl kickstart -k` reachable from exactly one place, so a
+/// test can never invoke it by forgetting to pass a fake.
+/// What: delegates to [`kickstart`].
+/// Test: side-effecting; not invoked in the test suite.
+pub struct RealKickstarter;
+
+impl Kickstarter for RealKickstarter {
+    fn kickstart(&self, binary: &str) -> bool {
+        kickstart(binary)
+    }
 }
 
 /// Run `launchctl kickstart -k gui/<uid>/<label>` for a member (macOS only).
@@ -524,22 +579,35 @@ fn apply_not_loaded_fallback_real(
 /// from `start.elapsed()` rather than reusing the raw parameter, so it
 /// correctly reflects whatever the kickstart poll immediately above already
 /// spent within this SAME member's turn.
-/// Test: side-effecting (subprocess + sleep); the decision halves are
-/// `needs_kickstart`, `poll_until_not_down`, `bounded_attempts`,
-/// `classify_down_state_from_entry`, `apply_not_loaded_fallback`.
-fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
+/// #4246: takes `kickstarter: &dyn Kickstarter` rather than calling
+/// [`kickstart`] directly, so the probe→gate→repair decision is testable against
+/// a fake — see [`Kickstarter`] for why that is the only test shape that could
+/// have caught this bug. [`verify_one`] is the real-wiring shell; this mirrors
+/// the `apply_not_loaded_fallback` / `apply_not_loaded_fallback_real` split
+/// immediately above.
+/// Test: `tests::verify_one_does_not_kickstart_a_healthy_launchd_daemon`,
+/// `tests::verify_one_kickstarts_a_genuinely_down_launchd_daemon`; the remaining
+/// decision halves are `needs_kickstart`, `poll_until_not_down`,
+/// `bounded_attempts`, `classify_down_state_from_entry`,
+/// `apply_not_loaded_fallback`.
+fn verify_one_with(
+    m: &StableMember,
+    remaining_budget: Duration,
+    kickstarter: &dyn Kickstarter,
+) -> VerifyRow {
     let start = Instant::now();
-    let mut health = probe_member_health(&m.binary, m.manage)
-        .health_string()
-        .to_owned();
+    // #4246: keep the TYPED outcome — `health` is for display, `outcome` is what
+    // may authorise a restart. Collapsing them is the bug.
+    let outcome = probe_member_health(&m.binary, m.manage);
+    let mut health = outcome.health_string().to_owned();
     let mut kickstarted = false;
     let mut budget_exhausted = false;
-    if needs_kickstart(&health, m.manage) {
+    if needs_kickstart(&outcome, m.manage) {
         if remaining_budget.is_zero() {
             budget_exhausted = true;
         } else {
             kickstarted = true;
-            let _ = kickstart(&m.binary);
+            let _ = kickstarter.kickstart(&m.binary);
             eprintln!("  waiting for {} to start...", m.binary);
             let (polled_health, _attempts) = poll_until_not_down(
                 || {
@@ -584,6 +652,19 @@ fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
         down_state,
         verify_bootstrapped,
     }
+}
+
+/// Real-wiring shell for [`verify_one_with`] — the only place that names
+/// [`RealKickstarter`].
+///
+/// Why: keeps [`run_verify_tail`]'s fold free of the seam, and keeps
+/// `launchctl kickstart -k` reachable from exactly one call site (mirrors
+/// `apply_not_loaded_fallback_real`'s split from `apply_not_loaded_fallback`).
+/// What: delegates to [`verify_one_with`] with the production kickstarter.
+/// Test: side-effecting (real `launchctl` + sleep); the decision it wraps is
+/// `verify_one_with`'s own test suite.
+fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
+    verify_one_with(m, remaining_budget, &RealKickstarter)
 }
 
 /// Run the post-install verify tail over the selected members (#2560).

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -472,7 +472,11 @@ fn apply_not_loaded_fallback_real(
         binary,
         manage,
         remaining_budget,
-        || probe_member_health(binary, manage),
+        || {
+            probe_member_health(binary, manage)
+                .health_string()
+                .to_owned()
+        },
         || std::thread::sleep(POLL_INTERVAL),
         || classify_down_state(binary),
     )
@@ -525,7 +529,9 @@ fn apply_not_loaded_fallback_real(
 /// `classify_down_state_from_entry`, `apply_not_loaded_fallback`.
 fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
     let start = Instant::now();
-    let mut health = probe_member_health(&m.binary, m.manage);
+    let mut health = probe_member_health(&m.binary, m.manage)
+        .health_string()
+        .to_owned();
     let mut kickstarted = false;
     let mut budget_exhausted = false;
     if needs_kickstart(&health, m.manage) {
@@ -536,7 +542,11 @@ fn verify_one(m: &StableMember, remaining_budget: Duration) -> VerifyRow {
             let _ = kickstart(&m.binary);
             eprintln!("  waiting for {} to start...", m.binary);
             let (polled_health, _attempts) = poll_until_not_down(
-                || probe_member_health(&m.binary, m.manage),
+                || {
+                    probe_member_health(&m.binary, m.manage)
+                        .health_string()
+                        .to_owned()
+                },
                 || std::thread::sleep(POLL_INTERVAL),
                 bounded_attempts(remaining_budget),
             );

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -17,14 +17,19 @@
 //!    reimplemented; only the CLI-level render is skipped so `--json` install
 //!    output stays a single JSON object).
 //! 2. Probes health for every selected daemon member.
-//! 3. For any `down` LAUNCHD daemon (the #2498 failure signature: `launchctl
-//!    bootstrap` succeeds but `RunAtLoad` doesn't fire), issues one
+//! 3. For any CONFIRMED-down LAUNCHD daemon (the #2498 failure signature:
+//!    `launchctl bootstrap` succeeds but `RunAtLoad` doesn't fire), issues one
 //!    `launchctl kickstart -k gui/<uid>/<label>` and then, instead of a single
 //!    instant re-probe (#3833 — this raced trusty-search's first-boot
 //!    embedding-model download and reported a false `NOT VERIFIED`),
 //!    [`poll_until_not_down`] re-probes on a bounded ~60s schedule so a
 //!    slow-but-healthy daemon is given real wall-clock time to come up before
 //!    the verdict is finalised.
+//!    "Confirmed" is load-bearing (#4246): the kickstart fires only on
+//!    [`ProbeOutcome::is_confirmed_down`] — a TCP refusal or a timeout — never on
+//!    a schema/envelope problem. Before that gate, `tctl install` hard-restarted
+//!    every healthy daemon on every run, because the probe shelled out to a
+//!    `health --json` verb no daemon implements and read the failure as `down`.
 //! 4. A member still `down` after that wait is classified into one of three
 //!    distinct end states via `super::verify_launchd_state::classify_down_state`
 //!    — [`DownState::NotLoaded`], [`DownState::Crashed`], or

--- a/crates/trusty-installer/src/commands/verify_tail_tests.rs
+++ b/crates/trusty-installer/src/commands/verify_tail_tests.rs
@@ -35,22 +35,189 @@ fn optional_row(member: &str, health: &str) -> VerifyRow {
     }
 }
 
-/// Why: only a `down` LAUNCHD daemon is the #2498 failure signature.
-/// What: asserts the truth table across health x manage-strategy.
+/// A [`StableMember`] shaped like the launchd daemons #4246 is about.
+///
+/// Why: the two `verify_one_with` tests need a member whose strategy is
+/// `Launchd` (so the kickstart branch is reachable) and whose binary is
+/// resolvable but has no documented port or live daemon — see
+/// `test_support::PROBEABLE_BINARY` for why that combination is required.
+fn launchd_member(binary: &str) -> StableMember {
+    StableMember {
+        crate_name: binary.to_owned(),
+        binary: binary.to_owned(),
+        daemon: true,
+        manage: ManageStrategy::Launchd,
+        required: true,
+    }
+}
+
+/// Recording [`Kickstarter`] fake (#4246) — the seam that makes "did this
+/// restart a healthy daemon?" an assertable question. Never touches `launchctl`.
+#[derive(Default)]
+struct FakeKickstarter {
+    calls: std::cell::RefCell<Vec<String>>,
+}
+
+impl Kickstarter for FakeKickstarter {
+    fn kickstart(&self, binary: &str) -> bool {
+        self.calls.borrow_mut().push(binary.to_owned());
+        true
+    }
+}
+
+/// Why: only a CONFIRMED-down LAUNCHD daemon is the #2498 failure signature.
+/// #4246 changed the input from a hand-typed string to a typed `ProbeOutcome`
+/// and the condition to `is_confirmed_down` — a transport-level observation.
+/// What: asserts the truth table across outcome x manage-strategy, including the
+/// mirror property that a genuinely-refusing daemon IS still repaired.
 /// Test: This is the test.
 #[test]
-fn needs_kickstart_only_for_down_launchd() {
-    assert!(needs_kickstart(health_str::DOWN, ManageStrategy::Launchd));
+fn needs_kickstart_only_for_confirmed_down_launchd() {
+    for confirmed in [ProbeOutcome::Refused, ProbeOutcome::Timeout] {
+        assert!(
+            needs_kickstart(&confirmed, ManageStrategy::Launchd),
+            "{confirmed:?} on a launchd member must still be repaired"
+        );
+        assert!(!needs_kickstart(&confirmed, ManageStrategy::OwnVerb));
+        assert!(!needs_kickstart(&confirmed, ManageStrategy::None));
+    }
+
+    let serving = ProbeOutcome::Serving {
+        status: "ok".to_owned(),
+        version: None,
+    };
+    assert!(!needs_kickstart(&serving, ManageStrategy::Launchd));
     assert!(!needs_kickstart(
-        health_str::HEALTHY,
+        &ProbeOutcome::NotInstalled,
         ManageStrategy::Launchd
     ));
     assert!(!needs_kickstart(
-        health_str::NOT_INSTALLED,
+        &ProbeOutcome::Unprobeable,
         ManageStrategy::Launchd
     ));
-    assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::OwnVerb));
-    assert!(!needs_kickstart(health_str::DOWN, ManageStrategy::None));
+}
+
+/// Why: THE #4246 gate. A schema mismatch, an unusable response, a squatter on a
+/// documented port, or a local probe failure all mean *something* answered (or
+/// that we never looked) — restarting on any of them is a guess, and
+/// `kickstart -k` costs trusty-search's unflushed HNSW vectors. Before the fix
+/// every one of these was literally the string `"down"` and fired the restart.
+/// What: asserts each non-transport outcome is refused a kickstart even on a
+/// `Launchd` member — the strategy that CAN be kickstarted.
+/// Test: This is the test.
+#[test]
+fn needs_kickstart_never_fires_on_a_schema_problem() {
+    for benign in [
+        ProbeOutcome::BadEnvelope {
+            got: r#"{"daemon":"running"}"#.to_owned(),
+        },
+        ProbeOutcome::HttpError { status: 500 },
+        ProbeOutcome::NoAddress,
+        ProbeOutcome::ProbeFailed {
+            detail: "no runtime".to_owned(),
+        },
+        ProbeOutcome::Serving {
+            status: "degraded".to_owned(),
+            version: None,
+        },
+    ] {
+        assert!(
+            !needs_kickstart(&benign, ManageStrategy::Launchd),
+            "{benign:?} must never authorise `launchctl kickstart -k`"
+        );
+    }
+}
+
+/// Why: **THE regression test for #4246's actual harm.** Every `tctl install`
+/// hard-restarted a fully healthy stack, because `probe_member_health` shelled
+/// out to a `health --json` verb no daemon implements, read the failure as
+/// `down`, and `verify_one` kickstarted on it. The pre-existing
+/// `needs_kickstart_only_for_down_launchd` passed the whole time, because it fed
+/// the predicate a hand-typed `"down"` — the predicate was never wrong; the probe
+/// manufactured its input. Only a test that runs the REAL probe against a stubbed
+/// healthy daemon and then asserts the restart decision closes that loop.
+///
+/// What: plants a real `http_addr` pointing at a stub answering
+/// `200 {"status":"ok"}`, runs `verify_one_with` for a `Launchd` member with the
+/// full poll budget, and asserts ZERO kickstart calls — plus a `healthy` row with
+/// no down-state diagnosis and no bootstrap fallback, so no `launchctl` was
+/// touched at all.
+/// Test: This is the test.
+#[test]
+fn verify_one_does_not_kickstart_a_healthy_launchd_daemon() {
+    use crate::commands::test_support as ts;
+    let _guard = ts::ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let addr = ts::stub_seq_blocking(vec![(
+        "HTTP/1.1 200 OK",
+        r#"{"status":"ok","version":"0.39.0"}"#,
+    )]);
+    let dir = ts::stub_data_dir(ts::PROBEABLE_BINARY, &addr);
+
+    let kicks = FakeKickstarter::default();
+    let row = verify_one_with(
+        &launchd_member(ts::PROBEABLE_BINARY),
+        AGGREGATE_POLL_BUDGET,
+        &kicks,
+    );
+    ts::clear_data_dir_override(&dir);
+
+    assert!(
+        kicks.calls.borrow().is_empty(),
+        "a healthy daemon must NEVER be kickstarted — got {:?}",
+        kicks.calls.borrow()
+    );
+    assert_eq!(row.health, health_str::HEALTHY);
+    assert!(!row.kickstarted);
+    assert_eq!(row.down_state, None, "a healthy member needs no diagnosis");
+    assert!(!row.verify_bootstrapped);
+    assert!(!row.budget_exhausted);
+}
+
+/// Why: the mirror of the test above, so the fix cannot degenerate into "never
+/// repair anything" — the #2498 failure signature (`launchctl bootstrap`
+/// succeeded, `RunAtLoad` never fired) must STILL be repaired. This is the
+/// regression that a naive "gate on confirmed-down without changing the
+/// transport" would have shipped: an outage that persists.
+///
+/// What: plants an `http_addr` pointing at a released ephemeral port (so the
+/// probe genuinely observes `Refused`), and asserts exactly one kickstart for
+/// this member. `remaining_budget` is 1s deliberately: `bounded_attempts(1s)` is
+/// 1, so the post-kickstart poll takes exactly one more probe and ZERO
+/// `POLL_INTERVAL` sleeps, keeping the test fast. The trailing `NotLoaded`
+/// diagnosis comes from a read-only `launchctl list` against a label that exists
+/// nowhere, and the #3841 fallback is a no-op because no plist is present — so
+/// nothing here bootstraps or restarts a real service.
+/// Test: This is the test.
+#[test]
+fn verify_one_kickstarts_a_genuinely_down_launchd_daemon() {
+    use crate::commands::test_support as ts;
+    let _guard = ts::ENV_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = ts::stub_data_dir(ts::PROBEABLE_BINARY, &ts::dead_addr());
+
+    let kicks = FakeKickstarter::default();
+    let row = verify_one_with(
+        &launchd_member(ts::PROBEABLE_BINARY),
+        Duration::from_secs(1),
+        &kicks,
+    );
+    ts::clear_data_dir_override(&dir);
+
+    assert_eq!(
+        kicks.calls.borrow().as_slice(),
+        [ts::PROBEABLE_BINARY.to_owned()],
+        "a genuinely refusing daemon must still get its one #2498 kickstart"
+    );
+    assert!(row.kickstarted);
+    assert_eq!(row.health, health_str::DOWN);
+    assert_eq!(
+        row.down_state,
+        Some(DownState::NotLoaded),
+        "an unloaded label diagnoses as NotLoaded on every platform"
+    );
+    assert!(
+        !row.verify_bootstrapped,
+        "with no plist on disk the #3841 fallback must not run"
+    );
 }
 
 /// Why: the JSON envelope is a contract; pin its shape.


### PR DESCRIPTION
Fixes the reported symptom of #4246 and the active harm behind it.

## Problem

`tctl status` reported every daemon as `down` while all were healthy. `probe_member_health` probed by shelling out to `<binary> health --json` — a contract **no daemon implements** — and collapsed every distinct failure (clap exit 2, unsupported flag, schema mismatch, timeout) into a single `Down`.

The false `down` then drove `needs_kickstart` → `launchctl kickstart -k`, so **every `tctl install` hard-restarted healthy daemons.** With no `ExitTimeOut` in the plist renderer and a ≥30s-per-index flush budget, that restart is a SIGKILL mid-flush — see the analysis comments on #4246 for the index-degradation detail. That is why this was P1 rather than cosmetic.

A secondary consequence: `tctl install` could never pass its own verify gate, since trusty-search/memory/review are `required: true` and all read `down`. The exit code CI would gate on was permanently failing.

## Change

HTTP `/health` probe, local to `trusty-installer`. No daemon crate is touched.

- **Typed `ProbeOutcome`** replaces the `String` return — `NotInstalled`, `Refused`, `Timeout`, `HttpError`, `BadEnvelope`, `Serving`, `Unprobeable`. A `health_string()` shim keeps the 6 existing call sites compiling and `--json` keys unchanged.
- **`.no_proxy()` on the probe client.** reqwest 0.12.28 routes `127.0.0.1` through `HTTP_PROXY`/`ALL_PROXY` (hyper-util's matcher has no loopback exemption), so without this the new probe reproduces the identical false-`down`. This is the first `.no_proxy()` in the workspace.
- **Dual resolution with an explicit precedence rule.** Both `{data_dir}/http_addr` and the documented fixed port are probed; `reconcile()` ranks `Serving` strictly below `Refused`/`Timeout` and takes the minimum, so **an answering leg always suppresses a refusing leg.** This matters because trusty-memory port-walks `7070..=7079` — a daemon on 7071 makes the fixed-port leg refuse while being perfectly healthy. Without this rule the fix would restart healthy daemons.
- **Body-based classification that accepts non-2xx.** trusty-analyze returns **503 + `status:"degraded"`** when search is unreachable; that classifies `degraded`, not `down`. `daemon_state`/`embedder_status` are read so a warming daemon is not reported as fully serving.
- **Kickstart gated on `is_confirmed_down`** = `Refused | Timeout` only. A schema or envelope problem can never authorise a destructive `launchctl kickstart -k`.
- **Duplicate probe collapsed** — `SystemRunner::probe` deleted, `tctl up` routed through the shared probe.
- **`Kickstarter` seam** on `verify_one`, mirroring the existing `ServiceEnv` seam in the same file, so the no-kickstart property is testable at all.

## Result

Before:
```
tctl status — stack summary
  trusty-search      0.39.0       down
  trusty-memory      0.21.0       down
  trusty-analyze     0.7.4        down
  trusty-review      0.10.1       down
  tga                2.9.4        n/a
  trusty-console     0.4.0        down
  trusty-mpm         0.19.21      unknown
verdict: degraded (exit 2)
```
After:
```
tctl status — stack summary
  trusty-search      0.39.0       healthy
  trusty-memory      0.21.0       healthy
  trusty-analyze     0.7.4        healthy
  trusty-review      0.10.1       healthy
  tga                2.9.4        n/a
  trusty-console     0.4.0        healthy
  trusty-mpm         0.19.21      unknown
verdict: ready (exit 0)
```
Byte-identical with `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` exported at a dead address.

## Tests

483 → 506. Two pre-existing tests **asserted the bug was correct** and were fixed:
- `classify_status("anything-else") == Down` — `"running"` was `anything-else`
- `classify_health_json(br#"{"x":1}"#) == Down` — `{"x":1}` is the shape of trusty-search's real exit-0 payload

New coverage, using the existing in-repo stub-server vehicle promoted to a shared `test_support` module (no new dev-dependency; `[dev-dependencies]` is still empty):
- `verify_one_does_not_kickstart_a_healthy_launchd_daemon` — **the test that proves the P1 harm is fixed.** The pre-existing `needs_kickstart` test passed while the bug was live, because it fed the predicate a hand-typed `"down"`; the predicate was never wrong. Only running the real probe against a stubbed healthy daemon and then asserting the kickstart decision closes the loop.
- `verify_one_kickstarts_a_genuinely_down_launchd_daemon` — so this cannot regress into never repairing.
- `probe_ignores_http_proxy_env`, `probe_port_walked_daemon_is_healthy`, `probe_accepts_503_degraded`, `probe_rejects_non_trusty_envelope`, `probe_distinguishes_failure_causes`, `real_daemon_payloads_are_never_down` (over the six payloads captured live), `health_string_maps_every_variant`, `only_transport_failures_are_confirmed_down`, `needs_kickstart_never_fires_on_a_schema_problem`, `reconcile_serving_leg_beats_refused_leg`.

Mutation-checked: deleting `.no_proxy()` fails `probe_ignores_http_proxy_env`; widening `is_confirmed_down` to include `HttpError` fails 5 tests, and to include `BadEnvelope` as well fails 6.

Independently verified by a separate QA pass: status table cross-checked against live `curl /health` on all six ports, proxy immunity reproduced, all named tests confirmed present and passing individually, both mutations reproduced, and **daemon PID continuity confirmed — trusty-memory stayed PID 1795 and trusty-search PID 28070 throughout, so no kickstart fired during development.**

## Two reviewer call-outs

1. **`classify_status` now accepts `running`/`serving`** in addition to `ok`/`healthy`/`ready`. DOC-1 D4 mandates this vocabulary, but no shipped daemon emits `running` (all six emit `ok`), so this changes nothing observable today and the catch-all still maps to `Down`. My own analysis comment on #4246 called this "a spec-vs-reality question to settle in the ADR" — flagging it explicitly so a reviewer can object. One line to revert.
2. **`tctl up` behaviour changes slightly more than predicted.** Collapsing the duplicate probe was cleared as behaviour-neutral because `ensure_member` treats `HealthyStale` and `Down` identically — true, but the real change is `Down → HealthyVersionOk`: a healthy daemon is now a reported no-op instead of being handed a redundant `<binary> start`. Same false-`down` class one layer up, and desirable, but it is a behaviour change.

`BadEnvelope` maps to `down` rather than `unknown` deliberately: `unknown` is tolerated by both `VerifyTailReport::build` and `status`'s exit code, so mapping there would print VERIFIED / exit 0 for a stack we hold no health information about. `down` is honest, and now safe because the kickstart is gated on the outcome variant rather than the string.

## Deliberately out of scope

Tracked in #4246's analysis comments for follow-up:
- `service` field in health envelopes (squatter defence, #3364 class) — touches 6 daemon crates
- trusty-mpm's `OwnVerb` arm still returns `unknown`. Probing it would flip `tctl status` to exit 2 and `tctl install` to NOT VERIFIED for anyone not running mpm, since mpm is `required: true`
- Version-skew/`stale` detection, `-v` wiring
- `ExitTimeOut` in the plist renderer, the `indexed_head_sha` stamp-before-embed ordering in trusty-search, and the data-dir-blind orphan reaper — all independent of this PR and reachable from other entry points
- Workspace-wide `.no_proxy()` (133 client-builder sites; `tctl ensure` is broken today for proxy users)

## Note on CI

`cargo clippy --workspace --all-targets -- -D warnings` fails on `trusty-code-gui` and `trusty-mpm-gui` for a missing untracked `ui/dist`. Confirmed pre-existing and unrelated: the same failure reproduces on a clean `origin/main` checkout, and neither crate depends on `trusty-installer`. `cargo clippy -p trusty-installer --all-targets -- -D warnings` and `cargo fmt --check` are both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
