### PR TITLE
feat(trusty-mpm): reconcile worktrees on a git-derived key, report-only (#4288)

### DIFF
--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -7,6 +7,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`project_index_id` documentation corrected**
+  ([#4269](https://github.com/bobmatnyc/trusty-tools/issues/4269), amended under
+  [#4288](https://github.com/bobmatnyc/trusty-tools/issues/4288)). The module
+  stated without qualification that `root` is immutable and recommended that the
+  wiring/migration slice "reconcile on `root`". Four routine actions move it —
+  `mv proj`, a GitHub repo rename, a repo transfer, and `git remote remove
+  origin` — and reconciling on it would reintroduce the silent-orphan class the
+  identity work exists to remove. The immutability claims are now qualified
+  ("under ordinary git operations"), the four movers are documented, and the
+  recommendation points at a git-maintained anchor instead. The CHANGELOG's
+  hermeticity claim is likewise corrected: two callers CAN derive different ids
+  when `HOME`/`GIT_CONFIG_GLOBAL` differ and the repo sets no local
+  `user.email`. Documentation only — no code change.
+
 ### Added
 
 - `json_rmw`: cross-process locked read-modify-write for whole-file JSON
@@ -34,8 +50,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   path; registry reconciliation and migration of existing indexes are separate
   slices of #4207. No behaviour change for any existing caller.
 
-  Derivation is hermetic: it reads no environment variable, so two callers on one
-  tree (e.g. the launchd daemon and a shell CLI) cannot derive different ids. The
+  Derivation reads no environment variable of its own, but it is NOT fully
+  hermetic (corrected, #4269): `resolve_operator_identity` shells out to `git
+  config`, so two callers on one tree CAN derive different ids when `HOME` or
+  `GIT_CONFIG_GLOBAL` differ and the repo sets no local `user.email` — see
+  `project_index_id.rs`'s own note. The launchd daemon and a shell CLI are
+  precisely that pair, since the daemon runs under a plist environment while CLI
+  invocations inherit the shell's. Set a repo-local `user.email` to pin it. The
   `index_id()` docs enumerate exactly which inputs are mutable — `origin` moves on
   the first commit, on `git remote add origin`, and on a new root commit — each
   pinned by a test, so the migration slice inherits a true guarantee rather than an

--- a/crates/trusty-common/src/project_index_id.rs
+++ b/crates/trusty-common/src/project_index_id.rs
@@ -109,9 +109,11 @@ const FALLBACK_LABEL: &str = "project";
 /// the account operating this checkout. All three are hashed; only `origin`
 /// (or the root basename) contributes to the readable label.
 ///
-/// Only `root` is immutable for the life of a content tree. `origin` and
-/// `operator` are both mutable git state — see the `Known limitation` block on
-/// [`Self::index_id`] for the enumerated drift cases and what they cost.
+/// `root` is the most stable of the three, but it is NOT immutable — it is
+/// fixed only under ordinary GIT operations (#4269). Renaming or moving the
+/// directory moves it, and `origin` and `operator` are both live git state.
+/// See the `Known limitation` block on [`Self::index_id`] for the enumerated
+/// drift cases and what each costs.
 /// Test: `sibling_clones_of_same_repo_derive_distinct_ids`,
 /// `linked_worktrees_of_same_repo_derive_distinct_ids`,
 /// `different_operators_derive_distinct_ids`.
@@ -197,9 +199,12 @@ impl ProjectIdentity {
     /// permanence.
     ///
     /// **Known limitation — which inputs are mutable, and what changes an id.**
-    /// Only `root` is fixed for the life of a content tree. Both other
-    /// components are live git/user state, so ordinary actions re-derive a
-    /// different id for the SAME tree. Each row is pinned by a test:
+    /// `root` is fixed only under ordinary GIT operations — NOT for the life of
+    /// a content tree (#4269). It moves whenever the directory does, and `mv` is
+    /// routine. Both other components are live git/user state, so ordinary
+    /// actions re-derive a different id for the SAME tree. Each row below is
+    /// pinned by a test; the four `root`/whole-triple movers named after the
+    /// table are pinned in #4269, not here:
     ///
     /// | Action | Component | Test |
     /// |---|---|---|
@@ -217,9 +222,36 @@ impl ProjectIdentity {
     /// deriving two ids over time wastes an index; two trees deriving one id
     /// merges unrelated codebases), and it cannot bite while the module has no
     /// call sites — but the wiring slice MUST NOT read this function as
-    /// permanent. Recommended shape for that slice: reconcile on `root`, which
-    /// is the only component that does not move, and treat an origin/operator
-    /// change as an alias-and-carry-forward rather than a new index.
+    /// permanent.
+    ///
+    /// **Do NOT reconcile on `root`** (#4269, corrected #4288). An earlier
+    /// version of this paragraph recommended exactly that, on the false premise
+    /// that `root` does not move. Four routine actions move it or the whole
+    /// triple, none of them a row in the table above, each verified against
+    /// this crate:
+    ///
+    /// | Action | Observed |
+    /// |---|---|
+    /// | `mv proj proj-renamed` | `acme-widget-88e6…` → `acme-widget-0bd2…` |
+    /// | GitHub repo rename | `acme-widget-6370…` → `acme-widget-renamed-b138…` |
+    /// | GitHub repo transfer | `acme-widget-6370…` → `newowner-widget-4d1e…` |
+    /// | `git remote remove origin` | `newowner-widget-4d1e…` → `widget-fa2a…` |
+    ///
+    /// The directory rename is the significant one: it is routine, it orphans
+    /// the registered index, and it removes the exact anchor the migration
+    /// slice was being told to reconcile on. `ProjectIdentity::digest` hashes
+    /// `path_bytes(&self.root)` and `label()` falls back to the root
+    /// basename, so `mv` moves BOTH halves of the id at once.
+    ///
+    /// Recommended shape for that slice instead: reconcile on an anchor GIT
+    /// itself maintains, and treat an origin/operator change as an
+    /// alias-and-carry-forward rather than a new index. The worktree
+    /// reconciliation in `trusty-mpm`'s `session_manager::worktree_reconcile`
+    /// (#4288) uses `(git rev-parse --git-common-dir, admin-dir basename)` for
+    /// this reason: it survives a directory move, a repo rename, a transfer,
+    /// and `git remote remove origin`, and when it does break — the repository
+    /// directory moved without `git worktree repair` — it breaks LOUDLY, where
+    /// a `root`-keyed scheme fails silently by re-deriving a fresh id.
     ///
     /// Also machine-local: `root` is an absolute path, so the same repo cloned
     /// on two machines derives two ids. That is correct for a partitioning key

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,28 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Added
+
+- **`tm session reconcile-worktrees` — report-only worktree reconciliation on a
+  git-derived key** ([#4288](https://github.com/bobmatnyc/trusty-tools/issues/4288),
+  slice 3 of [#4207](https://github.com/bobmatnyc/trusty-tools/issues/4207)).
+  Reconciles every git-registered worktree against `sessions.json` on the pair
+  `(git rev-parse --git-common-dir, admin-dir basename)` — git's own registry
+  identity — rather than on a path shape, which was measured misclassifying 34
+  of 118 worktrees (29%) on the dogfood machine. Each row is classified
+  `LIVE` / `ORPHANED` / `UNKNOWN` with the reason that produced it; `UNKNOWN`
+  dominates, so a path whose git identity cannot be established is never
+  reported reclaimable no matter what else points at it.
+  - The report includes the **excluded** set — 33 of the 118, invisible to every
+    other worktree surface today, six of them holding uncommitted work.
+  - It also **names** the worktrees a later slice would adopt, with the evidence
+    behind each inference. Nothing is written: no deletions, no sentinel writes,
+    no registry or record mutation, and the verb has no `--force`.
+  - Worktree enumeration now orders a NESTED worktree before the worktree that
+    contains it. The previous lexicographic order put a parent first, so
+    removing it took its children's directories and left dangling registry
+    entries behind.
+
 ### Performance
 
 - `tm ls` no longer re-reads the whole fleet's deployed agent/skill trees on

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/cli.md
@@ -139,6 +139,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `prune` — Prune managed sessions by state + compact tombstones (#1508)
   - `prune-idle` — Reclaim idle managed sessions: stop idle, decommission done (#1313)
   - `prune-worktrees` — Remove orphaned per-session git worktree directories (#1840)
+  - `reconcile-worktrees` — Report every git-registered worktree against `sessions.json` (#4288)
   - `rename` — Rename a managed session — from the list OR from within a session
   - `resume` — Resume a stopped/paused session (managed or project session)
   - `run` — Send a command to a session's tmux pane
@@ -171,6 +172,7 @@ Generated from `Cli::command()` (clap's command-tree introspection) — every `t
   - `prune` — Prune managed sessions by state + compact tombstones (#1508)
   - `prune-idle` — Reclaim idle managed sessions: stop idle, decommission done (#1313)
   - `prune-worktrees` — Remove orphaned per-session git worktree directories (#1840)
+  - `reconcile-worktrees` — Report every git-registered worktree against `sessions.json` (#4288)
   - `rename` — Rename a managed session — from the list OR from within a session
   - `resume` — Resume a stopped/paused session (managed or project session)
   - `run` — Send a command to a session's tmux pane

--- a/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/actions/session.rs
@@ -490,4 +490,22 @@ pub(crate) enum SessionAction {
         #[arg(long)]
         discard_dirty: bool,
     },
+    /// Report every git-registered worktree against `sessions.json` (#4288).
+    ///
+    /// Why: `prune-worktrees` shows only the reclaim CANDIDATES, so the
+    /// worktrees it excludes — 33 of 118 on the machine this was measured on,
+    /// six of them holding uncommitted work — are invisible. This verb reports
+    /// the whole inventory, keyed on git's own registry identity rather than on
+    /// a path shape (which misclassified 29% of them).
+    /// What: GETs `/api/v1/sessions/managed/reconcile-worktrees` and prints one
+    /// line per worktree — state, path, reason — plus the worktrees a later
+    /// slice would adopt. READ-ONLY: there is no `--force`, because there is
+    /// nothing here to force. Nothing is deleted, written, or migrated.
+    /// Test: `cli_parses_session_reconcile_worktrees`,
+    /// `cli_reconcile_worktrees_takes_no_destructive_flag`.
+    ReconcileWorktrees {
+        /// Print the full report as JSON instead of the one-line-per-row form.
+        #[arg(long)]
+        json: bool,
+    },
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -50,6 +50,7 @@ pub(crate) mod project;
 pub(crate) mod projects;
 pub(crate) mod prune;
 pub(crate) mod push_guard;
+pub(crate) mod reconcile_worktrees;
 pub(crate) mod rename;
 pub(crate) mod repair;
 pub(crate) mod serve_stdio;

--- a/crates/trusty-mpm/src/bin/tm/commands/reconcile_worktrees.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/reconcile_worktrees.rs
@@ -1,0 +1,99 @@
+//! `tm session reconcile-worktrees` — render the report-only worktree
+//! inventory (#4207 slice 3, #4288).
+//!
+//! Why: `managed.rs` sits against the 500-SLOC production cap, and this is a
+//! self-contained renderer rather than another managed-lifecycle verb — it
+//! issues one GET and formats the result, sharing no state with anything else
+//! in that file.
+//! What: one client function; see its doc for the output shape.
+//! Test: `cli_parses_session_reconcile_worktrees`,
+//! `cli_reconcile_worktrees_takes_no_destructive_flag`.
+
+/// `tm session reconcile-worktrees` — print the report-only worktree
+/// inventory (#4207 slice 3, #4288).
+///
+/// Why: an operator's only worktree view today is the reclaim-candidate list,
+/// which hides every excluded worktree — including a `workspace_path` that is
+/// really an ordinary subdirectory of a live checkout, and worktrees nested
+/// inside a live one. Both are landmines precisely because nothing prints them.
+/// What: GETs the reconcile route and prints `STATE  path` followed by the
+/// reason, then the proposed-adoption list (names only — this slice writes
+/// nothing). `--json` emits the raw report for scripting. There is no
+/// destructive form of this command.
+/// Test: `cli_parses_session_reconcile_worktrees`,
+/// `cli_reconcile_worktrees_takes_no_destructive_flag`.
+pub(crate) async fn session_reconcile_worktrees(
+    client: &reqwest::Client,
+    url: &str,
+    json: bool,
+) -> anyhow::Result<()> {
+    let resp = client
+        .get(format!("{url}/api/v1/sessions/managed/reconcile-worktrees"))
+        .send()
+        .await?;
+    let body: serde_json::Value = resp.error_for_status()?.json().await?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+        return Ok(());
+    }
+
+    let str_at = |v: &serde_json::Value, key: &str| -> String {
+        v.get(key)
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("<unreported>")
+            .to_owned()
+    };
+    let entries = body
+        .get("entries")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for e in &entries {
+        // Deepest-first, as the report orders them: a nested worktree is always
+        // listed before the worktree that contains it.
+        println!(
+            "{:<9} {}",
+            str_at(e, "state").to_uppercase(),
+            str_at(e, "path")
+        );
+        println!("          {}", str_at(e, "reason"));
+    }
+    let n = |key: &str| -> u64 {
+        body.pointer(&format!("/counts/{key}"))
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or_default()
+    };
+    println!(
+        "{} worktree(s): {} live, {} orphaned, {} unknown \
+         ({} reclaim candidates, {} excluded, {} named only by sessions.json)",
+        n("total"),
+        n("live"),
+        n("orphaned"),
+        n("unknown"),
+        n("admitted"),
+        n("excluded"),
+        n("record_only"),
+    );
+
+    let adoptions = body
+        .get("proposed_adoptions")
+        .and_then(serde_json::Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if adoptions.is_empty() {
+        return Ok(());
+    }
+    println!(
+        "\nwould be adopted by a later slice ({} — NOTHING was written):",
+        adoptions.len()
+    );
+    for a in &adoptions {
+        println!("  {}", str_at(a, "path"));
+        println!(
+            "    owner {} — {}",
+            str_at(a, "inferred_owner"),
+            str_at(a, "evidence")
+        );
+    }
+    Ok(())
+}

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -401,6 +401,12 @@ pub(crate) async fn session(
             crate::commands::managed::session_prune_worktrees(client, url, !force, discard_dirty)
                 .await?
         }
+        // #4288: the report-only inventory. No `force`/`dry_run` argument
+        // exists because the verb has no destructive form.
+        SessionAction::ReconcileWorktrees { json } => {
+            crate::commands::reconcile_worktrees::session_reconcile_worktrees(client, url, json)
+                .await?
+        }
         // #2444: re-sync a live session's (or every syncable session's)
         // deployed assets against the current catalog. Fleet-wide store
         // operation like `Prune`/`DecommissionEphemeral` above — direct HTTP,

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -585,6 +585,44 @@ fn cli_prune_worktrees_discard_dirty_is_opt_in() {
     }
 }
 
+/// #4288: `reconcile-worktrees` parses, and defaults to the human-readable
+/// form.
+#[test]
+fn cli_parses_session_reconcile_worktrees() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "reconcile-worktrees"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Session {
+            action: SessionAction::ReconcileWorktrees { json },
+        } => assert!(!json, "the default must be the readable report, not JSON"),
+        other => panic!("expected session reconcile-worktrees, got {other:?}"),
+    }
+    let as_json =
+        Cli::try_parse_from(["trusty-mpm", "session", "reconcile-worktrees", "--json"]).unwrap();
+    match as_json.command.unwrap() {
+        Command::Session {
+            action: SessionAction::ReconcileWorktrees { json },
+        } => assert!(json),
+        other => panic!("expected session reconcile-worktrees, got {other:?}"),
+    }
+}
+
+/// #4288: the reconcile verb has NO destructive flag — not `--force`, not
+/// `--discard-dirty`, not `--dry-run`.
+///
+/// Why: slice 3 is report-only, and the way a reporting verb stops being
+/// report-only is that someone adds a flag to it. `clap` rejecting these at
+/// parse time is the mechanical form of "there is no destructive form of this
+/// command", and this test turns any such addition red.
+#[test]
+fn cli_reconcile_worktrees_takes_no_destructive_flag() {
+    for flag in ["--force", "--discard-dirty", "--dry-run"] {
+        assert!(
+            Cli::try_parse_from(["trusty-mpm", "session", "reconcile-worktrees", flag]).is_err(),
+            "`reconcile-worktrees {flag}` must not parse — slice 3 writes nothing"
+        );
+    }
+}
+
 #[test]
 fn cli_parses_sessions_sync_assets() {
     // #2444: `sync-assets <id>` re-syncs ONE session.

--- a/crates/trusty-mpm/src/daemon/api.rs
+++ b/crates/trusty-mpm/src/daemon/api.rs
@@ -134,9 +134,9 @@ use super::managed_routes::{
     decommission_managed_session, delete_managed_session, fleet_by_project_route, get_attach_cmd,
     get_managed_session, get_project_registry_route, get_session_activity, list_managed_sessions,
     list_projects_registry_route, patch_project_registry_route, project_status_route, proxy_router,
-    prune_managed_route, prune_worktrees_route, reactivate_managed_session,
-    register_project_registry_route, rename_managed_session, resume_managed_session,
-    send_to_session, spawn_session, stop_managed_session, stop_managed_session_runtime,
+    prune_managed_route, reactivate_managed_session, register_project_registry_route,
+    rename_managed_session, resume_managed_session, send_to_session, spawn_session,
+    stop_managed_session, stop_managed_session_runtime,
 };
 // Layer-3 portfolio manager surface (`/api/v1/manager/*`, epic #2109, DOC-36),
 // and the peer message bus (`/api/v1/bus/*`, DOC-60 §5.3) — both self-contained
@@ -276,12 +276,10 @@ pub fn router(state: Arc<DaemonState>) -> Router {
             post(decommission_ephemeral_route),
         )
         .route("/api/v1/sessions/managed/prune", post(prune_managed_route))
-        // #1840: orphaned worktree prune. Literal segment registered BEFORE the
-        // `/{id}` param route.
-        .route(
-            "/api/v1/sessions/managed/prune-worktrees",
-            post(prune_worktrees_route),
-        )
+        // #1840 orphaned-worktree prune + #4288 report-only reconcile, owned as
+        // a pair by `managed_routes::reconcile`. Both are literal segments, so
+        // they are matched ahead of the `/{id}` param route below.
+        .merge(super::managed_routes::reconcile::worktree_routes())
         // #1586: fleet-by-project view. Literal `/fleet` registered BEFORE the
         // `/{id}` param route so it is never captured as an id (axum prefers
         // literal matches, but ordering makes the intent explicit).

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -42,6 +42,7 @@ pub mod provision_status;
 pub mod proxy;
 pub mod prune;
 mod reactivate;
+pub mod reconcile;
 pub mod rename;
 mod resume_error;
 mod session_summary;

--- a/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
@@ -40,7 +40,7 @@ use crate::daemon::state::DaemonState;
 /// axum matches them ahead of the `…/managed/{id}` param route regardless of
 /// where this sub-router is merged.
 /// Test: `reconcile_worktrees_route_reports_without_mutating`;
-/// `prune_worktrees_route_dry_run` covers the prune half.
+/// `prune_spares_a_stopped_records_workspace` covers the prune half.
 pub fn worktree_routes() -> Router<Arc<DaemonState>> {
     Router::new()
         .route(

--- a/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reconcile.rs
@@ -1,0 +1,88 @@
+//! GET /api/v1/sessions/managed/reconcile-worktrees — the report-only
+//! worktree inventory (#4207 slice 3, #4288).
+//!
+//! Why: the reconciled inventory is worthless if nothing surfaces it. Every
+//! existing worktree surface (`tm doctor`, `tm session prune-worktrees`) shows
+//! only the ADMITTED reclaim candidates, so 33 of the 118 registered worktrees
+//! on the dogfood machine — six of them holding uncommitted work, including
+//! both landmines #4288 documents — are invisible to an operator today.
+//!
+//! What: a GET with no body and no side effects. It reads the session store and
+//! runs `git worktree list` / `git rev-parse`; it writes nothing, deletes
+//! nothing, and takes no `dry_run` parameter because there is no non-dry-run
+//! form of it. This is deliberately a separate route from `prune-worktrees`
+//! rather than a flag on it: a reporting verb that shares an entry point with a
+//! destructive one eventually grows a `force` flag.
+//! Test: `reconcile_worktrees_route_reports_without_mutating`.
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+};
+use tracing::warn;
+
+use crate::daemon::state::DaemonState;
+
+/// The two worktree routes as one sub-router (#4288).
+///
+/// Why: `api.rs` is 1,200+ SLOC and grandfathered under a frozen line-cap
+/// budget, so a new route may not simply be appended there. Owning both
+/// worktree verbs in one place also keeps them registered as a pair — the
+/// destructive one and the read-only one are meant to be read together, and a
+/// reviewer looking at either sees the other.
+/// What: `POST …/prune-worktrees` (the pre-existing reclaimer, unchanged) and
+/// `GET …/reconcile-worktrees` (this module). Both are literal segments, so
+/// axum matches them ahead of the `…/managed/{id}` param route regardless of
+/// where this sub-router is merged.
+/// Test: `reconcile_worktrees_route_reports_without_mutating`;
+/// `prune_worktrees_route_dry_run` covers the prune half.
+pub fn worktree_routes() -> Router<Arc<DaemonState>> {
+    Router::new()
+        .route(
+            "/api/v1/sessions/managed/prune-worktrees",
+            post(super::prune::prune_worktrees_route),
+        )
+        .route(
+            "/api/v1/sessions/managed/reconcile-worktrees",
+            get(reconcile_worktrees_route),
+        )
+}
+
+/// GET /api/v1/sessions/managed/reconcile-worktrees (#4288).
+///
+/// Why: see the module doc — this is the only surface that reports the excluded
+/// set, the three-state classification with a reason per row, and the
+/// proposed-adoption list.
+/// What: delegates to
+/// [`SessionManager::reconcile_worktree_inventory`](crate::session_manager::SessionManager::reconcile_worktree_inventory)
+/// against the configured managed workspace root and returns the
+/// [`ReconcileReport`](crate::session_manager::worktree_reconcile::ReconcileReport)
+/// as JSON. A scan panic becomes a 500 rather than a silently empty inventory —
+/// an empty report reads as "nothing to reconcile", which is the worst possible
+/// lie for this surface.
+/// Test: `reconcile_worktrees_route_reports_without_mutating`.
+pub async fn reconcile_worktrees_route(State(state): State<Arc<DaemonState>>) -> impl IntoResponse {
+    let mgr = state.session_manager().await;
+    let config = crate::core::trusty_tools_config::TrustyToolsConfig::load();
+    let repos_root = crate::core::trusty_tools_config::workspace_root(&config);
+    match mgr.reconcile_worktree_inventory(&repos_root).await {
+        Ok(report) => Json(report).into_response(),
+        Err(e) => {
+            warn!("reconcile-worktrees route: inventory scan failed: {e}");
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("worktree reconciliation failed: {e}"),
+            )
+                .into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+#[path = "reconcile_tests.rs"]
+mod reconcile_tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/reconcile_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/reconcile_tests.rs
@@ -1,0 +1,141 @@
+//! Tests for the report-only reconcile-worktrees route (#4207 slice 3, #4288).
+//!
+//! Why: the route's two claims are that it SURFACES the excluded set (invisible
+//! on every other worktree surface) and that it MUTATES NOTHING. Both are
+//! asserted against a real git fixture — a mocked git could not tell an
+//! admitted worktree from an excluded one, which is the whole distinction.
+//! What: the manager method in isolation, then the HTTP route end-to-end.
+//! Test: this file IS the test module.
+
+use super::*;
+
+use crate::daemon::state::DaemonState;
+use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+
+/// The inventory reports admitted AND excluded worktrees, and touches nothing.
+///
+/// Why: `enumerate_registered_worktrees` returns only admitted paths, so the
+/// locked worktree below — the operator's explicit "do not remove this" — is
+/// invisible to every existing surface. An operator who cannot see it cannot
+/// reason about it. And because this is the slice that must not act, the
+/// on-disk state is asserted unchanged rather than assumed.
+#[tokio::test]
+async fn reconcile_inventory_reports_without_mutating_anything() {
+    let fx = GitWorktreeFixture::new();
+    let admitted = fx.add_worktree("plain-candidate");
+    let locked = fx.add_worktree("operator-locked");
+    fx.lock_worktree(&locked);
+    let sentinel = admitted.join(crate::session_manager::decommission::WORKTREE_SENTINEL_FILE);
+
+    let root = crate::test_support::hermetic_temp_dir();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+
+    let report = mgr
+        .reconcile_worktree_inventory(&fx.repos_root)
+        .await
+        .expect("inventory must not error");
+
+    let canonical = |p: &std::path::Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.into());
+    let entry = |p: &std::path::Path| {
+        let want = canonical(p);
+        report
+            .entries
+            .iter()
+            .find(|e| e.path == want)
+            .unwrap_or_else(|| panic!("{} must be reported", want.display()))
+    };
+
+    assert_eq!(report.counts.admitted, 1, "got {:?}", report.entries);
+    assert_eq!(
+        entry(&admitted).admission,
+        Some(crate::session_manager::worktree_registry::Admission::Admitted)
+    );
+    assert_eq!(
+        entry(&locked).admission,
+        Some(crate::session_manager::worktree_registry::Admission::Locked),
+        "the excluded set must be REPORTED — it is invisible everywhere else"
+    );
+    assert!(
+        entry(&locked).reason.contains("locked"),
+        "every row carries its reason; got {}",
+        entry(&locked).reason
+    );
+
+    // Report-only: nothing removed, nothing written.
+    assert!(admitted.is_dir() && locked.is_dir());
+    assert!(
+        !sentinel.exists(),
+        "reconciliation must never WRITE an ownership sentinel"
+    );
+}
+
+/// The HTTP route returns the same inventory as JSON and deletes nothing.
+///
+/// `await_holding_lock` is the point, not an oversight: the route reads the
+/// workspace root from the process environment, so the crate-wide
+/// `env_test_lock` must span the awaited route call or a sibling env test can
+/// clobber the override mid-request.
+#[allow(clippy::await_holding_lock)]
+#[serial_test::serial]
+#[tokio::test]
+async fn reconcile_worktrees_route_reports_without_mutating() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("surfaced-by-the-route");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+
+    let root = crate::test_support::hermetic_temp_dir();
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+
+    let _env = crate::core::trusty_tools_config::env_test_lock();
+    // SAFETY: guarded by env_test_lock; removed immediately after the call.
+    unsafe {
+        std::env::set_var(
+            crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV,
+            &fx.repos_root,
+        )
+    };
+    let resp = reconcile_worktrees_route(axum::extract::State(state))
+        .await
+        .into_response();
+    // SAFETY: guarded by env_test_lock, still held.
+    unsafe { std::env::remove_var(crate::core::trusty_tools_config::WORKSPACE_ROOT_ENV) };
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let bytes = axum::body::to_bytes(resp.into_body(), usize::MAX)
+        .await
+        .expect("route body must be readable");
+    let body: serde_json::Value = serde_json::from_slice(&bytes).expect("route body must be JSON");
+
+    let canonical = std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone());
+    let entries = body
+        .get("entries")
+        .and_then(serde_json::Value::as_array)
+        .unwrap_or_else(|| panic!("body must carry `entries`: {body}"));
+    let row = entries
+        .iter()
+        .find(|e| e.get("path").and_then(serde_json::Value::as_str) == canonical.to_str())
+        .unwrap_or_else(|| panic!("{} must be reported: {body}", canonical.display()));
+    assert_eq!(
+        row.get("state").and_then(serde_json::Value::as_str),
+        Some("orphaned"),
+        "row was {row}"
+    );
+    assert!(
+        !row.get("reason")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or_default()
+            .is_empty(),
+        "every row must carry a reason: {row}"
+    );
+    assert_eq!(
+        body.pointer("/counts/orphaned")
+            .and_then(serde_json::Value::as_u64),
+        Some(1),
+        "body was {body}"
+    );
+    assert!(
+        wt.is_dir(),
+        "a reporting route must never remove a worktree"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -35,6 +35,7 @@ pub mod task_inject;
 pub mod workspace_guard;
 mod worktree_nested;
 pub(crate) mod worktree_ownership;
+pub(crate) mod worktree_reconcile;
 pub(crate) mod worktree_registry;
 pub mod worktree_safety;
 

--- a/crates/trusty-mpm/src/session_manager/worktree_reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reconcile.rs
@@ -1,0 +1,764 @@
+//! Report-only worktree reconciliation on a GIT-DERIVED key (#4207 slice 3,
+//! issue #4288).
+//!
+//! Why: worktree reconciliation had nothing to reconcile WITH. Measured on the
+//! dogfood machine 2026-07-28: 118 registered worktrees across two disjoint git
+//! registries (`.base` bare clone 60, sibling non-bare clone 58, intersection
+//! ZERO), against 56 `sessions.json` records of which 31 carry a
+//! `workspace_path` — and only THREE of the 118 worktrees have a matching
+//! session record. Nothing in the store could say which registry a worktree
+//! belonged to, so every consumer inferred it from the path.
+//!
+//! Path shape is provably the wrong discriminator: it misclassifies 34 of the
+//! 118 (29%). Fourteen paths containing `/.base/` are registered in the SIBLING
+//! registry; twenty paths NOT containing `/.base/` are registered in the BASE
+//! one. Two sibling directories sharing a prefix land in different registries:
+//!
+//! ```text
+//! .base/.worktrees/fix-3822-sessions-list-empty  -> common-dir <proj>/.git
+//! .base/.worktrees/2eb72dca-de08-…               -> common-dir <proj>/.base
+//! ```
+//!
+//! # The key
+//!
+//! [`WorktreeKey`] is the pair
+//!
+//! ```text
+//! ( canonicalize(git -C <wt> rev-parse --path-format=absolute --git-common-dir),
+//!   basename of <wt>'s admin dir, read from the `gitdir:` line of <wt>/.git )
+//! ```
+//!
+//! asserting `git -C <wt> rev-parse --show-toplevel == canonicalize(<wt>)`.
+//! This is git's OWN registry identity: derived entirely from git, dependent on
+//! no path convention, and — decisively for #4269 — it does not contain `root`.
+//! Every other anchor loses to something (measured, #4288):
+//!
+//! | Candidate | `mv proj` | GH rename | GH transfer | `remote remove origin` |
+//! |---|---|---|---|---|
+//! | `root` (which `project_index_id` used to advise) | **silently moves** | stable | stable | stable |
+//! | origin URL | stable | **moves** | **moves** | **vanishes** |
+//! | initial-commit SHA | stable | stable | stable | **not partitioning** |
+//! | id file in the worktree | stable | stable | stable | **not git-derived** |
+//! | common-dir + admin-dir name | **breaks LOUDLY** | stable | stable | stable |
+//!
+//! Named residuals, none of which this slice hides:
+//!
+//! 1. Moving the repository directory. `gitdir:` pointers are ABSOLUTE, so `mv`
+//!    breaks them until `git worktree repair`. That failure is LOUD — git
+//!    errors, the record goes `prunable`, `show-toplevel` stops matching — where
+//!    a `root`-keyed scheme fails SILENTLY by re-deriving a fresh key and
+//!    orphaning the old one. A loud break classifies [`ReconcileState::Unknown`]
+//!    and is never reclaimed.
+//! 2. macOS firmlinks / bind mounts: one tree, two common-dirs. Inherent to any
+//!    path-based key; the same limitation is disclosed at
+//!    `trusty_common::project_index_id`.
+//! 3. A hand-copied admin directory (`cp -r`): two paths, one key. Caught by the
+//!    `show-toplevel` assertion, classified `Unknown`.
+//!
+//! # Three states, because two cannot say "I could not observe this"
+//!
+//! `worktree_registry`'s rule — "an unanswerable probe is never a verdict" —
+//! applies with more force here, because reconciliation reads paths nobody
+//! provisioned. [`ReconcileState`] is therefore LIVE / ORPHANED / UNKNOWN, and
+//! UNKNOWN DOMINATES: if the git-derived key does not resolve, no other signal
+//! is allowed to promote the entry, because we have not established that the
+//! path is a worktree at all. That is what keeps the second landmine safe —
+//! `…/.worktrees/tm-trusty-tools-01` is a `workspace_path` in `sessions.json`,
+//! has no `.git` file, and `rev-parse --show-toplevel` from inside it resolves
+//! to the PARENT checkout. Any "workspace_path not in `git worktree list` =>
+//! orphan => remove" rule deletes files inside a live checkout, invisibly.
+//!
+//! Every LIVE signal is a VETO on reclamation, never a vote for it. Liveness has
+//! no single trustworthy source: session `2eb72dca-…` was measured RUNNING in
+//! tmux pane `%981` while recorded `state: "stopped"`; "no tmux pane => orphan"
+//! would mark 116 of 118 orphaned; mtime is useless (107 of 118 touched within
+//! 7 days, none older than 30). The sentinel is the only signal with real
+//! provenance and it covers 3 of 85 admitted candidates, two of those
+//! zero-byte.
+//!
+//! # Scope: REPORT-ONLY. Zero new destructive code paths.
+//!
+//! Nothing in this module writes, deletes, or mutates anything — not
+//! `sessions.json`, not a sentinel, not git. [`reconcile_worktrees`] is a pure
+//! function of (registry scan, store snapshot, live cwds, clock).
+//! [`ReconcileReport::proposed_adoptions`] NAMES the worktrees a later slice
+//! would adopt, with the evidence for each inference, and writes none of them.
+//! The reclaimer already exists, is already dry-run by default, and already
+//! reclaims nothing; arming it is a later slice reviewed on its own merits.
+//!
+//! What: [`WorktreeKey`] + [`worktree_key`] (the key), [`ReconcileState`] /
+//! [`WorktreeCategory`] / [`ReconciledWorktree`] (one classified entry),
+//! [`ProposedAdoption`], [`ReconcileCounts`], [`ReconcileReport`], and
+//! [`reconcile_worktrees`] (the whole inventory).
+//! Test: `worktree_reconcile_tests`.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::{Path, PathBuf};
+
+use chrono::{DateTime, Utc};
+use serde::Serialize;
+
+use super::record::{ManagedSessionId, SessionRecord};
+use super::worktree_ownership::{OWNERLESS_GRACE, SentinelOwner, read_sentinel_owner};
+use super::worktree_registry::{Admission, ScannedWorktree, scan_registered_worktrees};
+use super::worktree_safety::{git_command, inspect_dirt};
+
+/// Git's own identity for a worktree's registry entry (#4288).
+///
+/// Why: see the module doc's anchor-comparison table — this is the only
+/// candidate that survives a directory rename, a GitHub rename, a transfer, and
+/// `git remote remove origin`, and the only one that breaks LOUDLY rather than
+/// silently when it does break.
+/// What: `common_dir` is the canonicalized shared git directory every worktree
+/// of a repository points at (`<root>/.git` for a normal checkout, the bare
+/// directory itself for a bare clone) — it is what PARTITIONS the two disjoint
+/// registries. `admin_dir` is the basename of this worktree's own
+/// `<common_dir>/worktrees/<name>` administrative directory, read from the
+/// `gitdir:` line of the worktree's `.git` FILE — it is what IDENTIFIES the
+/// entry within that registry. `None` means the `.git` entry is a directory,
+/// i.e. a main checkout rather than a linked worktree.
+/// Test: `reconcile_keys_on_the_git_registry_not_the_path` (baseline plus all
+/// four mutations), `key_is_none_for_a_plain_directory_inside_a_checkout`.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub struct WorktreeKey {
+    /// Canonicalized `git rev-parse --git-common-dir` — the registry.
+    pub common_dir: PathBuf,
+    /// Basename of `<common_dir>/worktrees/<name>` — the entry in it.
+    pub admin_dir: Option<String>,
+}
+
+/// Derive [`WorktreeKey`] for `candidate`, or `None` if it cannot be
+/// established (#4288).
+///
+/// Why: a `None` here is the load-bearing safety result, not a degenerate case.
+/// It is returned for the plain-subdirectory-inside-a-live-checkout shape
+/// (landmine 2), for a hand-copied admin directory, and for a repository that
+/// has been `mv`d without `git worktree repair` — and [`reconcile_worktrees`]
+/// turns every `None` into [`ReconcileState::Unknown`], which is never
+/// reclaimable.
+/// What: canonicalizes `candidate`; asserts
+/// `git rev-parse --path-format=absolute --show-toplevel` canonicalizes to the
+/// SAME path (this is the assertion that rejects a subdirectory, whose
+/// toplevel is its enclosing checkout); then reads `--git-common-dir` and the
+/// `gitdir:` line of `<candidate>/.git`. Any failed probe yields `None` — never
+/// a guessed key.
+/// Test: `reconcile_keys_on_the_git_registry_not_the_path`,
+/// `key_is_none_for_a_plain_directory_inside_a_checkout`.
+pub fn worktree_key(candidate: &Path) -> Option<WorktreeKey> {
+    let canonical = std::fs::canonicalize(candidate).ok()?;
+    let toplevel = git_rev_parse_path(&canonical, "--show-toplevel")?;
+    if std::fs::canonicalize(&toplevel).ok()? != canonical {
+        return None;
+    }
+    let common_dir = git_rev_parse_path(&canonical, "--git-common-dir")?;
+    Some(WorktreeKey {
+        common_dir: std::fs::canonicalize(&common_dir).ok()?,
+        admin_dir: admin_dir_name(&canonical),
+    })
+}
+
+/// One absolute path from `git rev-parse`, or `None` on any failure.
+///
+/// Why: both halves of the key come from the same hardened invocation
+/// (`worktree_safety::git_command` strips the environment variables that could
+/// redirect git at another repository), and an empty stdout must read as "could
+/// not observe", not as an empty path.
+/// What: `git -C <dir> rev-parse --path-format=absolute <flag>`.
+/// Test: covered by `reconcile_keys_on_the_git_registry_not_the_path` and
+/// `key_is_none_for_a_plain_directory_inside_a_checkout`.
+fn git_rev_parse_path(dir: &Path, flag: &str) -> Option<PathBuf> {
+    let out = git_command(dir, &["rev-parse", "--path-format=absolute", flag])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let raw = String::from_utf8_lossy(&out.stdout);
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(trimmed))
+    }
+}
+
+/// Basename of the worktree's administrative directory (#4288).
+///
+/// Why: `common_dir` alone identifies the REGISTRY, not the ENTRY — every
+/// worktree of one repository shares it. The admin-dir name is git's own
+/// per-entry handle, it is assigned at `git worktree add` time, and `git
+/// worktree move` does NOT change it, which is what makes the key survive a
+/// move.
+/// What: reads `<worktree>/.git` as a file and returns the final component of
+/// its `gitdir:` line. A main checkout's `.git` is a DIRECTORY, so the read
+/// fails and this returns `None` — the correct answer, not an error.
+/// Test: `reconcile_keys_on_the_git_registry_not_the_path` (mutation 1).
+fn admin_dir_name(worktree: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(worktree.join(".git")).ok()?;
+    let gitdir = content
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("gitdir:"))?
+        .trim();
+    Path::new(gitdir)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+}
+
+/// The three-state verdict for one reconciled worktree (#4288).
+///
+/// Why: two states cannot express "I could not observe this", and 82 of the 85
+/// admitted candidates on the dogfood machine are exactly that. Collapsing them
+/// into either of the other two would be a fabricated verdict about a directory
+/// that may hold the only copy of somebody's work.
+/// What: [`Live`](Self::Live) — some signal VETOES reclamation. [`Orphaned`](Self::Orphaned)
+/// — every gate the existing reclaimer applies passes. [`Unknown`](Self::Unknown)
+/// — everything else, including every unanswerable probe. Report, never act.
+/// Test: `stopped_records_workspace_is_live_not_orphaned`,
+/// `clean_ownerless_admitted_worktree_is_orphaned`,
+/// `record_pointing_at_a_plain_directory_is_unknown`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReconcileState {
+    /// A liveness signal vetoes reclamation.
+    Live,
+    /// Provably reclaimable under the gates the existing reclaimer applies.
+    Orphaned,
+    /// Not established. Reported, never acted on.
+    Unknown,
+}
+
+/// A DESCRIPTIVE label for what a worktree appears to be (#4288).
+///
+/// Why: an operator reading a 118-row inventory needs to know at a glance which
+/// rows are their own checkouts and which are agent scratch. But note what this
+/// is NOT: it is derived partly from path shape, and path shape misclassifies
+/// 29% of worktrees' REGISTRY membership. So this label is report text only —
+/// it is never an input to [`ReconcileState`], never gates reclamation, and no
+/// consumer may promote it to one. The classification uses git, the store, and
+/// the sentinel; the category exists so a human can skim.
+/// What: [`SessionOwned`](Self::SessionOwned) is the one EVIDENCE-based variant
+/// (a store record or a sentinel names an owner); the rest are shape hints.
+/// Test: `categories_are_descriptive_and_do_not_gate_state`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorktreeCategory {
+    /// A session record or an ownership sentinel names an owner. Evidence-based.
+    SessionOwned,
+    /// Lives under a `.claude/worktrees` agent-runtime directory.
+    HarnessAgent,
+    /// Lives under a temp root (`/tmp`, `/private/tmp`, `/private/var/folders`).
+    TmpScratchpad,
+    /// A repository's main checkout.
+    ProjectCheckout,
+    /// Registered, but outside the managed project — an operator's own tree.
+    OperatorCheckout,
+    /// None of the above.
+    Unclassified,
+}
+
+/// One reconciled worktree: the union of what git, the store, and the sentinel
+/// each say about one path (#4288).
+///
+/// Why: the report has to be actionable per ROW, so every field a reader would
+/// otherwise have to go and derive by hand is carried here — above all the
+/// `reason`, because a verdict without its reason is exactly the "false
+/// reclaimable preview" #4288 names as a defect in its own right.
+/// What: `admission` is `None` when git registers no such worktree at all (the
+/// entry came only from a `SessionRecord.workspace_path`); `dirty` is populated
+/// only for entries that reached the dirt gate (see [`reconcile_worktrees`]);
+/// `contains_other_entry` marks a worktree with another inventory entry nested
+/// inside it, which bars it from [`ReconcileReport::proposed_adoptions`].
+/// Test: `report_unions_registry_and_session_records`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReconciledWorktree {
+    /// Canonical path (raw when it would not canonicalize).
+    pub path: PathBuf,
+    /// Git's identity for this worktree, or `None` if not established.
+    pub key: Option<WorktreeKey>,
+    /// The three-state verdict.
+    pub state: ReconcileState,
+    /// Why that verdict, in one operator-facing line.
+    pub reason: String,
+    /// Descriptive label. Never an input to `state`.
+    pub category: WorktreeCategory,
+    /// Git's admission verdict, or `None` when git registers no such worktree.
+    pub admission: Option<Admission>,
+    /// Sessions whose `workspace_path` is this path, whatever their state.
+    pub sessions: Vec<ManagedSessionId>,
+    /// Owner named by the on-disk ownership sentinel, if it parsed.
+    pub sentinel_owner: Option<ManagedSessionId>,
+    /// Checked-out branch, when git reported one.
+    pub branch: Option<String>,
+    /// Dirt reason, when the dirt gate ran and reported unsaved work.
+    pub dirty: Option<String>,
+    /// Another inventory entry is nested inside this one.
+    pub contains_other_entry: bool,
+}
+
+/// A worktree a later slice WOULD adopt, named with its evidence (#4288 item 3).
+///
+/// Why: the open decision on #4288 resolved to (b) — name the adoption set,
+/// write nothing. Naming it is what makes the later backfill slice reviewable
+/// against a list an operator has already seen, instead of a set of writes
+/// nobody enumerated first.
+/// What: the path, the inferred owning session, and the sentence explaining
+/// which observation produced that inference. Nothing here is persisted.
+/// Test: `proposed_adoptions_name_owner_and_evidence`,
+/// `proposed_adoptions_refuse_a_worktree_containing_another_entry`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ProposedAdoption {
+    /// The worktree that would be adopted.
+    pub path: PathBuf,
+    /// The session that would be recorded as its owner.
+    pub inferred_owner: ManagedSessionId,
+    /// The observation behind that inference.
+    pub evidence: String,
+}
+
+/// Row counts for the reconciled inventory (#4288).
+///
+/// Why: the headline an operator reads first, and the numbers a test can assert
+/// on without depending on iteration order.
+/// What: `total` counts every row; `admitted`/`excluded` split them by whether
+/// git's registry scan made them reclaim candidates; `record_only` counts rows
+/// that exist solely because a `SessionRecord` points at them.
+/// Test: `report_unions_registry_and_session_records`.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize)]
+pub struct ReconcileCounts {
+    /// Every row in the inventory.
+    pub total: usize,
+    /// Rows whose state is [`ReconcileState::Live`].
+    pub live: usize,
+    /// Rows whose state is [`ReconcileState::Orphaned`].
+    pub orphaned: usize,
+    /// Rows whose state is [`ReconcileState::Unknown`].
+    pub unknown: usize,
+    /// Rows git admitted as reclaim candidates.
+    pub admitted: usize,
+    /// Rows git registered but excluded, with a reason on each row.
+    pub excluded: usize,
+    /// Rows present only in `sessions.json`, registered by no git registry.
+    pub record_only: usize,
+}
+
+/// The whole report (#4288).
+///
+/// Why: one value the HTTP route and the CLI both render, so the two surfaces
+/// cannot drift into disagreeing about what was found.
+/// What: `entries` sorted DEEPEST-FIRST so a nested worktree always precedes
+/// its container; `proposed_adoptions`; `counts`.
+/// Test: `entries_are_ordered_deepest_first`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ReconcileReport {
+    /// Every reconciled worktree, deepest path first.
+    pub entries: Vec<ReconciledWorktree>,
+    /// Names only — this slice writes nothing.
+    pub proposed_adoptions: Vec<ProposedAdoption>,
+    /// Headline counts.
+    pub counts: ReconcileCounts,
+}
+
+/// Reconcile every git-registered worktree under `repos_root` against
+/// `records`, report-only (#4288).
+///
+/// Why: this is slice 3. It answers, for the first time, "which of these 118
+/// directories does this daemon actually know about?" — on a key git itself
+/// maintains, so the answer does not silently change when a project directory
+/// is renamed.
+/// What: unions the full registry scan
+/// ([`super::worktree_registry::scan_registered_worktrees`], which reports the
+/// EXCLUDED set too) with every `SessionRecord.workspace_path`, derives
+/// [`worktree_key`] per path, and classifies each into [`ReconcileState`].
+/// `live_cwds` is the set of observed live working directories (tmux pane
+/// `pane_current_path` values) — each is a veto. `now` is injected so the
+/// [`OWNERLESS_GRACE`] window is testable.
+///
+/// The dirt probe ([`inspect_dirt`]) is deliberately run ONLY on entries that
+/// have already passed the sentinel + ownerless gates: it walks nested
+/// repositories and would otherwise cost minutes across 118 worktrees, and it
+/// can only ever move an entry from ORPHANED to UNKNOWN, never the reverse.
+///
+/// PURE AND READ-ONLY: this function writes nothing. Its worst possible failure
+/// is an inaccurate report.
+/// Test: `report_unions_registry_and_session_records`,
+/// `stopped_records_workspace_is_live_not_orphaned`,
+/// `record_pointing_at_a_plain_directory_is_unknown`,
+/// `clean_ownerless_admitted_worktree_is_orphaned`,
+/// `reconcile_keys_on_the_git_registry_not_the_path`.
+pub fn reconcile_worktrees(
+    repos_root: &Path,
+    records: &[SessionRecord],
+    live_cwds: &[PathBuf],
+    now: DateTime<Utc>,
+) -> ReconcileReport {
+    let scanned: BTreeMap<PathBuf, ScannedWorktree> = scan_registered_worktrees(repos_root)
+        .into_iter()
+        .map(|s| (s.path.clone(), s))
+        .collect();
+    let mut by_workspace: BTreeMap<PathBuf, Vec<&SessionRecord>> = BTreeMap::new();
+    for r in records {
+        if let Some(ws) = r.workspace_path.as_deref() {
+            let key = std::fs::canonicalize(ws).unwrap_or_else(|_| ws.to_path_buf());
+            by_workspace.entry(key).or_default().push(r);
+        }
+    }
+    let universe: BTreeSet<PathBuf> = scanned.keys().chain(by_workspace.keys()).cloned().collect();
+
+    let mut entries: Vec<ReconciledWorktree> = universe
+        .iter()
+        .map(|path| {
+            classify(
+                path,
+                scanned.get(path),
+                by_workspace.get(path).map_or(&[][..], Vec::as_slice),
+                records,
+                live_cwds,
+                now,
+            )
+        })
+        .collect();
+
+    // Deepest first (#4288 item 4): a nested worktree must precede the worktree
+    // that contains it, so a reader — and any later reclaimer — sees the child
+    // before the parent whose removal would take the child's directory with it.
+    entries.sort_by(|a, b| {
+        b.path
+            .components()
+            .count()
+            .cmp(&a.path.components().count())
+            .then_with(|| a.path.cmp(&b.path))
+    });
+    for entry in &mut entries {
+        entry.contains_other_entry = universe
+            .iter()
+            .any(|other| other != &entry.path && other.starts_with(&entry.path));
+    }
+
+    let proposed_adoptions = propose_adoptions(&entries, records);
+    let counts = count(&entries);
+    ReconcileReport {
+        entries,
+        proposed_adoptions,
+        counts,
+    }
+}
+
+/// Tally [`ReconcileCounts`] over the classified rows.
+///
+/// Why: keeps [`reconcile_worktrees`] readable and makes the counting rule one
+/// thing rather than seven ad-hoc accumulators.
+/// What: one pass over `entries`.
+/// Test: `report_unions_registry_and_session_records`.
+fn count(entries: &[ReconciledWorktree]) -> ReconcileCounts {
+    let mut c = ReconcileCounts {
+        total: entries.len(),
+        ..ReconcileCounts::default()
+    };
+    for e in entries {
+        match e.state {
+            ReconcileState::Live => c.live += 1,
+            ReconcileState::Orphaned => c.orphaned += 1,
+            ReconcileState::Unknown => c.unknown += 1,
+        }
+        match e.admission {
+            Some(Admission::Admitted) => c.admitted += 1,
+            Some(_) => c.excluded += 1,
+            None => c.record_only += 1,
+        }
+    }
+    c
+}
+
+/// Classify one path into a [`ReconciledWorktree`] (#4288).
+///
+/// Why: the ORDER of the tests below is the safety property, and it only reads
+/// as deliberate in one place. UNKNOWN dominates — an unresolved git key stops
+/// classification dead, before any liveness signal can promote the row, because
+/// a path we cannot prove is a worktree is a path we know nothing about.
+/// Landmine 2 (`workspace_path` pointing at an ordinary subdirectory of a live
+/// checkout) is exactly that row, and it must never be reported reclaimable.
+/// What: key first; then the LIVE vetoes (a store record of ANY state, a live
+/// cwd at or under the path, a sentinel owner that is not provably ownerless);
+/// then ORPHANED only for an ADMITTED entry whose sentinel names a provably
+/// ownerless owner and whose tree is clean; else UNKNOWN with the reason.
+/// Test: `stopped_records_workspace_is_live_not_orphaned`,
+/// `record_pointing_at_a_plain_directory_is_unknown`,
+/// `clean_ownerless_admitted_worktree_is_orphaned`.
+fn classify(
+    path: &Path,
+    scanned: Option<&ScannedWorktree>,
+    owners: &[&SessionRecord],
+    records: &[SessionRecord],
+    live_cwds: &[PathBuf],
+    now: DateTime<Utc>,
+) -> ReconciledWorktree {
+    let key = worktree_key(path);
+    let sentinel = read_sentinel_owner(path);
+    let sentinel_owner = match sentinel {
+        SentinelOwner::Known(owner, _) => Some(owner),
+        SentinelOwner::Unknown => None,
+    };
+    let mut entry = ReconciledWorktree {
+        path: path.to_path_buf(),
+        key: key.clone(),
+        state: ReconcileState::Unknown,
+        reason: String::new(),
+        category: categorize(
+            path,
+            scanned,
+            !owners.is_empty() || sentinel_owner.is_some(),
+        ),
+        admission: scanned.map(|s| s.admission),
+        sessions: owners.iter().map(|r| r.id).collect(),
+        sentinel_owner,
+        branch: scanned.and_then(|s| s.branch.clone()),
+        dirty: None,
+        contains_other_entry: false,
+    };
+
+    // 1. UNKNOWN dominates: no git identity, no verdict.
+    if key.is_none() {
+        entry.reason = match scanned {
+            Some(_) => "no git-derived key: `rev-parse --show-toplevel` disagrees this path is \
+                        its own worktree root, or git could not answer — repair the registry \
+                        (`git worktree repair`) before trusting any verdict here"
+                .to_string(),
+            None => "no git-derived key AND no git registry entry: this path is not a worktree \
+                     (it may be an ordinary directory inside a live checkout) — never treat it \
+                     as an orphan"
+                .to_string(),
+        };
+        return entry;
+    }
+
+    // 2. LIVE vetoes. Each is a veto on reclamation, never a vote for it.
+    if let Some(r) = owners.first() {
+        entry.reason = format!(
+            "live: session {} records this as its workspace_path (recorded state {:?}, which is \
+             bookkeeping and NOT a liveness signal — the veto holds in every state)",
+            r.id, r.state
+        );
+        entry.state = ReconcileState::Live;
+        return entry;
+    }
+    if let Some(cwd) = live_cwds.iter().find(|c| c.starts_with(path)) {
+        entry.reason = format!(
+            "live: an observed working directory sits at or under it ({})",
+            cwd.display()
+        );
+        entry.state = ReconcileState::Live;
+        return entry;
+    }
+    if let SentinelOwner::Known(owner, created_at) = sentinel
+        && !provably_ownerless(owner, created_at, records, now)
+    {
+        entry.reason = format!(
+            "live: ownership sentinel names {owner}, which is neither terminal nor aged out"
+        );
+        entry.state = ReconcileState::Live;
+        return entry;
+    }
+
+    // 3. ORPHANED, only for an admitted entry that clears every existing gate.
+    if entry.admission != Some(Admission::Admitted) {
+        entry.reason = scanned.map_or_else(
+            || "unknown: a session record points here but no git registry lists it".to_string(),
+            |s| format!("unknown: {}", s.admission.reason()),
+        );
+        return entry;
+    }
+    let SentinelOwner::Known(owner, _) = sentinel else {
+        entry.reason = "unknown: no ownership sentinel (absent, empty, or unparsable) — never \
+                        auto-reclaimable, this is the 82-of-85 case"
+            .to_string();
+        return entry;
+    };
+    if let Some(dirt) = inspect_dirt(path) {
+        entry.reason = format!("unknown: holds unsaved work — {}", dirt.reason);
+        entry.dirty = Some(dirt.reason);
+        return entry;
+    }
+    entry.reason = format!(
+        "orphaned: sentinel owner {owner} is provably ownerless, git admitted the path, and the \
+         tree is clean"
+    );
+    entry.state = ReconcileState::Orphaned;
+    entry
+}
+
+/// Is `owner` provably ownerless, against a store SNAPSHOT (#4288)?
+///
+/// Why: `SessionManager::resolve_ownerless_with_grace` is the authority, but it
+/// is `async` and reads the live store; reconciliation classifies against one
+/// consistent snapshot so every row in a report agrees with every other. The
+/// RULE is copied exactly — divergence here would mean the report disagrees
+/// with what the reclaimer would actually do, which is the false-preview defect.
+/// What: a found record is ownerless iff its state is terminal; an absent
+/// record is ownerless only once the sentinel is older than [`OWNERLESS_GRACE`]
+/// (the sentinel is written BEFORE the record is persisted, so a young absent
+/// owner is a creation race, not a deletion).
+/// Test: `young_absent_sentinel_owner_is_live_not_orphaned`.
+fn provably_ownerless(
+    owner: ManagedSessionId,
+    sentinel_created_at: DateTime<Utc>,
+    records: &[SessionRecord],
+    now: DateTime<Utc>,
+) -> bool {
+    match records.iter().find(|r| r.id == owner) {
+        Some(record) => record.state.is_terminal(),
+        None => now - sentinel_created_at > OWNERLESS_GRACE,
+    }
+}
+
+/// The DESCRIPTIVE [`WorktreeCategory`] for one path.
+///
+/// Why/What: see [`WorktreeCategory`] — report text only, never an input to
+/// [`ReconcileState`]. Evidence (a record or a sentinel) outranks every shape
+/// hint, so `SessionOwned` is tested first.
+/// Test: `categories_are_descriptive_and_do_not_gate_state`.
+fn categorize(path: &Path, scanned: Option<&ScannedWorktree>, has_owner: bool) -> WorktreeCategory {
+    if has_owner {
+        return WorktreeCategory::SessionOwned;
+    }
+    let admission = scanned.map(|s| s.admission);
+    if admission == Some(Admission::MainCheckout) {
+        return WorktreeCategory::ProjectCheckout;
+    }
+    let is_agent_dir = path
+        .components()
+        .zip(path.components().skip(1))
+        .any(|(a, b)| a.as_os_str() == ".claude" && b.as_os_str() == "worktrees");
+    if is_agent_dir {
+        return WorktreeCategory::HarnessAgent;
+    }
+    // "Temp scratchpad" is a claim about a worktree parked OUTSIDE any managed
+    // project. Applying it by prefix alone would mislabel every worktree in a
+    // repos root that itself lives under a temp directory — which is exactly the
+    // shape every test fixture has, and a shape a user can trivially create.
+    let inside_project = matches!(
+        admission,
+        Some(
+            Admission::Admitted
+                | Admission::Bare
+                | Admission::Prunable
+                | Admission::Locked
+                | Admission::Unresolvable
+        )
+    );
+    let text = path.to_string_lossy();
+    let temp_rooted = text.starts_with("/tmp/")
+        || text.starts_with("/private/tmp/")
+        || text.starts_with("/var/folders/")
+        || text.starts_with("/private/var/folders/");
+    if !inside_project && temp_rooted {
+        return WorktreeCategory::TmpScratchpad;
+    }
+    match admission {
+        Some(Admission::OutsideProject | Admission::OutsideReposRoot) => {
+            WorktreeCategory::OperatorCheckout
+        }
+        _ => WorktreeCategory::Unclassified,
+    }
+}
+
+/// Name the worktrees a later slice would adopt, with the evidence (#4288 item 3).
+///
+/// Why: adoption is the write this slice deliberately does not perform. Listing
+/// it is what lets the write be reviewed before it exists.
+/// What: proposes only for ADMITTED entries with a resolved git key that do NOT
+/// already carry a sentinel owner, and NEVER for a worktree containing another
+/// inventory entry (#4288 item 4 — proposing a container is how a parent
+/// removal takes its children). Evidence sources, strongest first: a
+/// `SessionRecord.workspace_path`; a `SessionRecord.branch` equal to the
+/// worktree's checked-out branch. Writes nothing.
+/// Test: `proposed_adoptions_name_owner_and_evidence`,
+/// `proposed_adoptions_refuse_a_worktree_containing_another_entry`.
+fn propose_adoptions(
+    entries: &[ReconciledWorktree],
+    records: &[SessionRecord],
+) -> Vec<ProposedAdoption> {
+    let mut out = Vec::new();
+    for e in entries {
+        if e.admission != Some(Admission::Admitted)
+            || e.key.is_none()
+            || e.sentinel_owner.is_some()
+            || e.contains_other_entry
+        {
+            continue;
+        }
+        if let Some(id) = e.sessions.first() {
+            out.push(ProposedAdoption {
+                path: e.path.clone(),
+                inferred_owner: *id,
+                evidence: format!(
+                    "sessions.json: session {id} records this exact path as its workspace_path"
+                ),
+            });
+            continue;
+        }
+        if let Some(branch) = e.branch.as_deref()
+            && let Some(r) = records
+                .iter()
+                .find(|r| r.branch.as_deref() == Some(branch) && r.workspace_path.is_none())
+        {
+            out.push(ProposedAdoption {
+                path: e.path.clone(),
+                inferred_owner: r.id,
+                evidence: format!(
+                    "branch match: session {} records branch `{branch}` and has no workspace_path \
+                     of its own",
+                    r.id
+                ),
+            });
+        }
+    }
+    out
+}
+
+impl super::manager::SessionManager {
+    /// Gather the live inputs and produce the reconciled inventory (#4288).
+    ///
+    /// Why: [`reconcile_worktrees`] is pure so it can be tested against real
+    /// git without a daemon; this is the thin layer that fetches the store
+    /// snapshot and the observed live working directories. Keeping the git and
+    /// filesystem work on a blocking thread matters — the scan runs `git` once
+    /// per anchor and `rev-parse` twice per worktree, which is not something to
+    /// do on the async runtime.
+    /// What: snapshots every record, collects `pane_current_path` for each
+    /// record whose tmux session is alive, and runs the reconcile on a blocking
+    /// thread. Reads only; writes nothing anywhere.
+    ///
+    /// KNOWN INCOMPLETENESS, stated rather than hidden: the live-cwd set covers
+    /// panes of MANAGED sessions only. A pane in an unmanaged tmux session, and
+    /// a bare process `cwd`, are both signals #4288 names and neither is
+    /// observed here. A missed LIVE veto cannot by itself make anything
+    /// reclaimable — [`ReconcileState::Orphaned`] additionally requires a
+    /// sentinel naming a provably-gone owner AND a clean tree — but it does
+    /// mean a row can read `Unknown` where a richer observer would read `Live`.
+    /// That is another reason this slice acts on nothing.
+    /// Test: `reconcile_inventory_reports_without_mutating_anything`.
+    pub(crate) async fn reconcile_worktree_inventory(
+        &self,
+        repos_root: &Path,
+    ) -> Result<ReconcileReport, anyhow::Error> {
+        let records = self.list().await;
+        let mut live_cwds: Vec<PathBuf> = Vec::new();
+        for r in &records {
+            if self.tmux.session_exists(&r.tmux_name)
+                && let Some(cwd) = self.tmux.get_pane_cwd(&r.tmux_name)
+            {
+                live_cwds.push(std::fs::canonicalize(&cwd).unwrap_or(cwd));
+            }
+        }
+        let repos_root = repos_root.to_path_buf();
+        tokio::task::spawn_blocking(move || {
+            reconcile_worktrees(&repos_root, &records, &live_cwds, Utc::now())
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("reconcile-worktrees: inventory scan panicked: {e}"))
+    }
+}
+
+#[cfg(test)]
+#[path = "worktree_reconcile_tests.rs"]
+mod worktree_reconcile_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reconcile.rs
@@ -283,6 +283,12 @@ pub struct ReconciledWorktree {
     pub category: WorktreeCategory,
     /// Git's admission verdict, or `None` when git registers no such worktree.
     pub admission: Option<Admission>,
+    /// The checkout whose `git worktree list` produced THIS row. With
+    /// `contested`, it is what distinguishes two rows sharing one path.
+    pub registry_root: Option<PathBuf>,
+    /// More than one git registry lists this path — see [`classify`]. Every row
+    /// for a contested path carries this, and none of them is reclaimable.
+    pub contested: bool,
     /// Sessions whose `workspace_path` is this path, whatever their state.
     pub sessions: Vec<ManagedSessionId>,
     /// Owner named by the on-disk ownership sentinel, if it parsed.
@@ -391,10 +397,15 @@ pub fn reconcile_worktrees(
     live_cwds: &[PathBuf],
     now: DateTime<Utc>,
 ) -> ReconcileReport {
-    let scanned: BTreeMap<PathBuf, ScannedWorktree> = scan_registered_worktrees(repos_root)
-        .into_iter()
-        .map(|s| (s.path.clone(), s))
-        .collect();
+    // Grouped by path, but every (path, registry root) CLAIM is kept. Collapsing
+    // to one entry per path — which this did until the #4382 review — makes a
+    // last-writer-wins map silently discard one registry's verdict, and a
+    // disagreement between two registries about one path is precisely the state
+    // this whole slice exists to surface. See `classify`'s contested branch.
+    let mut scanned: BTreeMap<PathBuf, Vec<ScannedWorktree>> = BTreeMap::new();
+    for s in scan_registered_worktrees(repos_root) {
+        scanned.entry(s.path.clone()).or_default().push(s);
+    }
     let mut by_workspace: BTreeMap<PathBuf, Vec<&SessionRecord>> = BTreeMap::new();
     for r in records {
         if let Some(ws) = r.workspace_path.as_deref() {
@@ -404,19 +415,30 @@ pub fn reconcile_worktrees(
     }
     let universe: BTreeSet<PathBuf> = scanned.keys().chain(by_workspace.keys()).cloned().collect();
 
-    let mut entries: Vec<ReconciledWorktree> = universe
-        .iter()
-        .map(|path| {
-            classify(
+    let mut entries: Vec<ReconciledWorktree> = Vec::new();
+    for path in &universe {
+        let claims = scanned.get(path).map_or(&[][..], Vec::as_slice);
+        let owners = by_workspace.get(path).map_or(&[][..], Vec::as_slice);
+        if claims.is_empty() {
+            entries.push(classify(path, None, owners, records, live_cwds, now, false));
+            continue;
+        }
+        // One row per claiming registry. `contested` is computed once for the
+        // path and applied to EVERY row, so neither row can be read as the
+        // authoritative one.
+        let contested = claims.len() > 1;
+        for claim in claims {
+            entries.push(classify(
                 path,
-                scanned.get(path),
-                by_workspace.get(path).map_or(&[][..], Vec::as_slice),
+                Some(claim),
+                owners,
                 records,
                 live_cwds,
                 now,
-            )
-        })
-        .collect();
+                contested,
+            ));
+        }
+    }
 
     // Deepest first (#4288 item 4): a nested worktree must precede the worktree
     // that contains it, so a reader — and any later reclaimer — sees the child
@@ -483,7 +505,9 @@ fn count(entries: &[ReconciledWorktree]) -> ReconcileCounts {
 /// ownerless owner and whose tree is clean; else UNKNOWN with the reason.
 /// Test: `stopped_records_workspace_is_live_not_orphaned`,
 /// `reconcile_keys_on_the_git_registry_not_the_path`,
-/// `clean_ownerless_admitted_worktree_is_orphaned`.
+/// `clean_ownerless_admitted_worktree_is_orphaned`,
+/// `a_bare_clone_reports_its_bare_verdict_not_a_repair_instruction`,
+/// `two_registries_claiming_one_path_keep_both_verdicts`.
 fn classify(
     path: &Path,
     scanned: Option<&ScannedWorktree>,
@@ -491,6 +515,7 @@ fn classify(
     records: &[SessionRecord],
     live_cwds: &[PathBuf],
     now: DateTime<Utc>,
+    contested: bool,
 ) -> ReconciledWorktree {
     let key = worktree_key(path);
     let sentinel = read_sentinel_owner(path);
@@ -509,6 +534,8 @@ fn classify(
             !owners.is_empty() || sentinel_owner.is_some(),
         ),
         admission: scanned.map(|s| s.admission),
+        registry_root: scanned.map(|s| s.registry_root.clone()),
+        contested,
         sessions: owners.iter().map(|r| r.id).collect(),
         sentinel_owner,
         branch: scanned.and_then(|s| s.branch.clone()),
@@ -518,7 +545,20 @@ fn classify(
 
     // 1. UNKNOWN dominates: no git identity, no verdict.
     if key.is_none() {
-        entry.reason = match scanned {
+        entry.reason = match entry.admission {
+            Some(a @ (Admission::Bare | Admission::Prunable | Admission::Unresolvable)) => {
+                format!(
+                    "{} — no working tree to key on, which is git answering correctly rather \
+                     than a registry to repair",
+                    a.reason()
+                )
+            }
+            // These three verdicts ALREADY explain why there is no key, and the
+            // explanation is not a broken registry. A bare repository has no
+            // working tree at all, so `rev-parse --show-toplevel` failing is
+            // git answering correctly — every managed project has a `.base`
+            // clone, so telling an operator to run `git worktree repair` on it
+            // would be wrong on the most common row in the whole report.
             Some(_) => "no git-derived key: `rev-parse --show-toplevel` disagrees this path is \
                         its own worktree root, or git could not answer — repair the registry \
                         (`git worktree repair`) before trusting any verdict here"
@@ -528,6 +568,19 @@ fn classify(
                      as an orphan"
                 .to_string(),
         };
+        return entry;
+    }
+
+    // 1b. Two registries claim this path. Both rows are reported, and NEITHER
+    // may be reclaimable: the key names exactly one registry, so at most one
+    // claim can be right and nothing here can say which. Ambiguity resolves the
+    // same way an unanswerable probe does.
+    if contested {
+        entry.reason = "contested: more than one git registry lists this path; the git-derived \
+                        key names only ONE of them, so at most one claim is right and nothing \
+                        here can say which — resolve the duplicate registration (this is the \
+                        hand-copied-admin-directory shape) before acting on any row for this path"
+            .to_string();
         return entry;
     }
 
@@ -683,6 +736,10 @@ fn propose_adoptions(
             || e.key.is_none()
             || e.sentinel_owner.is_some()
             || e.contains_other_entry
+            // A path two registries claim would otherwise be proposed once per
+            // claim, naming the same owner twice for a registration nobody has
+            // resolved yet.
+            || e.contested
         {
             continue;
         }

--- a/crates/trusty-mpm/src/session_manager/worktree_reconcile.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reconcile.rs
@@ -215,7 +215,7 @@ fn admin_dir_name(worktree: &Path) -> Option<String> {
 /// — everything else, including every unanswerable probe. Report, never act.
 /// Test: `stopped_records_workspace_is_live_not_orphaned`,
 /// `clean_ownerless_admitted_worktree_is_orphaned`,
-/// `record_pointing_at_a_plain_directory_is_unknown`.
+/// `reconcile_keys_on_the_git_registry_not_the_path`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ReconcileState {
@@ -382,7 +382,7 @@ pub struct ReconcileReport {
 /// is an inaccurate report.
 /// Test: `report_unions_registry_and_session_records`,
 /// `stopped_records_workspace_is_live_not_orphaned`,
-/// `record_pointing_at_a_plain_directory_is_unknown`,
+/// `reconcile_keys_on_the_git_registry_not_the_path`,
 /// `clean_ownerless_admitted_worktree_is_orphaned`,
 /// `reconcile_keys_on_the_git_registry_not_the_path`.
 pub fn reconcile_worktrees(
@@ -482,7 +482,7 @@ fn count(entries: &[ReconciledWorktree]) -> ReconcileCounts {
 /// then ORPHANED only for an ADMITTED entry whose sentinel names a provably
 /// ownerless owner and whose tree is clean; else UNKNOWN with the reason.
 /// Test: `stopped_records_workspace_is_live_not_orphaned`,
-/// `record_pointing_at_a_plain_directory_is_unknown`,
+/// `reconcile_keys_on_the_git_registry_not_the_path`,
 /// `clean_ownerless_admitted_worktree_is_orphaned`.
 fn classify(
     path: &Path,

--- a/crates/trusty-mpm/src/session_manager/worktree_reconcile_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reconcile_tests.rs
@@ -76,6 +76,34 @@ fn record_at(state: ManagedSessionState, workspace: Option<PathBuf>) -> SessionR
     }
 }
 
+/// Register `worktree` a SECOND time, in the `.base` clone's registry.
+///
+/// Why: git will not create this state through its own porcelain — a worktree
+/// belongs to one repository — but the state is real and #4288 names it as
+/// residual 3: a hand-copied administrative directory (`cp -r`) leaves two
+/// registries listing one path. Forging the admin directory by hand is the only
+/// way to reach it, and it is exactly what `cp -r` produces.
+/// What: writes `<repo>/.base/worktrees/<dup>/{gitdir,commondir,HEAD}` pointing
+/// at `worktree`, which is all `git worktree list` reads to enumerate an entry.
+fn forge_duplicate_registration(repo: &std::path::Path, worktree: &std::path::Path) {
+    let admin = repo.join(".base").join("worktrees").join("forged-dup");
+    std::fs::create_dir_all(&admin).expect("create the forged admin dir");
+    std::fs::write(
+        admin.join("gitdir"),
+        format!("{}\n", worktree.join(".git").display()),
+    )
+    .expect("write gitdir");
+    std::fs::write(admin.join("commondir"), "../..\n").expect("write commondir");
+    let head = Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .expect("resolve HEAD");
+    assert!(head.status.success(), "fixture: rev-parse HEAD failed");
+    std::fs::write(admin.join("HEAD"), head.stdout).expect("write HEAD");
+}
+
 /// The entry for `path` in `report`, or a panic naming what WAS reported.
 fn entry_for<'a>(report: &'a ReconcileReport, path: &std::path::Path) -> &'a ReconciledWorktree {
     let want = canonical(path);
@@ -275,6 +303,78 @@ fn key_is_none_for_a_plain_directory_inside_a_checkout() {
     assert!(worktree_key(&wt).is_some());
 }
 
+/// Two registries listing one path keep BOTH verdicts, and neither is
+/// reclaimable (#4382 review).
+///
+/// Why: the inventory grouped scanned rows into a map keyed on path alone, so a
+/// second registry's claim silently overwrote the first — last writer wins, no
+/// trace. A disagreement between two registries about one path is precisely the
+/// state this slice exists to surface, so losing one side is the one outcome
+/// that cannot be allowed. Both rows now survive, each naming the registry that
+/// produced it, and the ambiguity resolves the same way an unanswerable probe
+/// does: UNKNOWN, never ORPHANED.
+///
+/// Non-vacuity: `uncontested` is an otherwise identical worktree with an
+/// identical session record, and it IS proposed for adoption — so the contested
+/// path's absence from that list is attributable to the contest and nothing
+/// else.
+#[test]
+fn two_registries_claiming_one_path_keep_both_verdicts() {
+    let fx = GitWorktreeFixture::new();
+    fx.add_base_clone_worktree("seed");
+    let contested = fx.add_worktree("claimed-twice");
+    forge_duplicate_registration(&fx.repo, &contested);
+    let uncontested = fx.add_worktree("claimed-once");
+    let records = vec![
+        record_at(ManagedSessionState::Active, Some(contested.clone())),
+        record_at(ManagedSessionState::Active, Some(uncontested.clone())),
+    ];
+
+    let report = reconcile_worktrees(&fx.repos_root, &records, &[], Utc::now());
+    let want = canonical(&contested);
+    let rows: Vec<&ReconciledWorktree> = report.entries.iter().filter(|e| e.path == want).collect();
+    assert_eq!(
+        rows.len(),
+        2,
+        "both registries' claims must survive; got {rows:?}"
+    );
+
+    let mut got_roots: Vec<PathBuf> = rows
+        .iter()
+        .filter_map(|r| r.registry_root.clone())
+        .collect();
+    got_roots.sort();
+    let mut want_roots = vec![canonical(&fx.repo), canonical(&fx.repo.join(".base"))];
+    want_roots.sort();
+    assert_eq!(
+        got_roots, want_roots,
+        "each row must name the registry that produced it"
+    );
+    assert!(
+        rows.iter()
+            .all(|r| r.admission == Some(Admission::Admitted)),
+        "both verdicts must be preserved, not collapsed; got {rows:?}"
+    );
+    assert!(
+        rows.iter()
+            .all(|r| r.contested && r.state == ReconcileState::Unknown),
+        "an ambiguous path is never reclaimable; got {rows:?}"
+    );
+    assert!(rows.iter().all(|r| r.reason.contains("contested")));
+    assert_eq!(report.counts.orphaned, 0);
+
+    let proposed: Vec<PathBuf> = report
+        .proposed_adoptions
+        .iter()
+        .map(|p| p.path.clone())
+        .collect();
+    assert_eq!(
+        proposed,
+        vec![canonical(&uncontested)],
+        "the uncontested twin IS proposed, the contested path is not; got {proposed:?}"
+    );
+}
+
 // ── three-state classification ───────────────────────────────────────────
 
 /// A `Stopped` record's workspace is LIVE, never ORPHANED (#4288).
@@ -402,6 +502,72 @@ fn a_dirty_ownerless_worktree_is_unknown_not_orphaned() {
     );
     assert!(entry.dirty.is_some(), "the dirt reason must be reported");
     assert_eq!(report.counts.orphaned, 0);
+}
+
+/// A bare clone reports its `Bare` verdict, not an instruction to repair
+/// something that is not broken (#4382 review).
+///
+/// Why: a bare repository HAS no working tree, so `rev-parse --show-toplevel`
+/// exiting 128 is git answering correctly. The row was falling into the generic
+/// no-key branch and printing "repair the registry (`git worktree repair`)"
+/// while discarding the `Admission::Bare` verdict it already held. Every managed
+/// project has a `.base` clone, so that wrong line would appear on one of the
+/// most common rows in the report — and on the real machine, where ~95% of rows
+/// are UNKNOWN, the reason line is the only text distinguishing them.
+///
+/// The same applies to a worktree whose directory is gone: git already said why
+/// there is no key, and it is not a repair.
+#[test]
+fn a_bare_clone_reports_its_bare_verdict_not_a_repair_instruction() {
+    let fx = GitWorktreeFixture::new();
+    fx.add_base_clone_worktree("seed");
+    let base = fx.repo.join(".base");
+    let vanished = fx.add_worktree("directory-removed");
+    std::fs::remove_dir_all(&vanished).expect("remove the worktree directory");
+
+    let report = reconcile_worktrees(&fx.repos_root, &[], &[], Utc::now());
+
+    let bare = entry_for(&report, &base);
+    assert_eq!(
+        bare.admission,
+        Some(Admission::Bare),
+        "the Bare verdict must survive, not be discarded"
+    );
+    assert!(
+        bare.key.is_none(),
+        "a bare repo has no working tree, so it has no key — that is the point"
+    );
+    assert_eq!(bare.state, ReconcileState::Unknown);
+    assert!(
+        bare.reason.contains("bare repository record"),
+        "the reason must name the real verdict; got {}",
+        bare.reason
+    );
+    assert!(
+        !bare.reason.contains("worktree repair"),
+        "a bare clone is not a broken registry; got {}",
+        bare.reason
+    );
+
+    // The directory-is-gone row lands in the same branch for the same reason.
+    let gone = report
+        .entries
+        .iter()
+        .find(|e| e.path.ends_with("directory-removed"))
+        .unwrap_or_else(|| panic!("the removed worktree must still be reported"));
+    assert!(
+        matches!(
+            gone.admission,
+            Some(Admission::Prunable | Admission::Unresolvable)
+        ),
+        "got {:?}",
+        gone.admission
+    );
+    assert!(
+        !gone.reason.contains("worktree repair"),
+        "a directory git already reports as gone is not a repair job; got {}",
+        gone.reason
+    );
 }
 
 // ── the inventory shape ──────────────────────────────────────────────────

--- a/crates/trusty-mpm/src/session_manager/worktree_reconcile_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reconcile_tests.rs
@@ -1,0 +1,567 @@
+//! Tests for report-only worktree reconciliation (#4207 slice 3, #4288).
+//!
+//! Why: the claim this module makes is that worktree identity comes from GIT,
+//! not from a path shape — and path shape misclassifies 29% of the worktrees on
+//! the dogfood machine. A mocked git could not distinguish the two, so every
+//! test here drives REAL `git worktree add` inside a `tempfile::TempDir`.
+//! There is no env-var gate and no `#[ignore]`: if `git` is unavailable the
+//! fixture panics and these tests FAIL, they do not skip.
+//! What: the git-derived key and its four adversarial mutations, the
+//! three-state classification (including both #4288 landmines), the
+//! deepest-first ordering, and the proposed-adoption list.
+//! Test: this file IS the test module.
+
+use super::*;
+
+use crate::session_manager::record::ManagedSessionState;
+use crate::session_manager::worktree_git_fixture::GitWorktreeFixture;
+use std::process::Command;
+
+/// Run `git -C <dir> <args>`, panicking with git's own stderr on failure.
+///
+/// Why: a fixture step that silently no-ops produces a test that passes for the
+/// wrong reason. The mutations below (`worktree move`, `remote set-url`,
+/// `remote remove`) are the whole point of the AC test — a skipped mutation
+/// would leave every assertion trivially true.
+fn git_ok(dir: &std::path::Path, args: &[&str]) {
+    let out = Command::new("git")
+        .arg("-C")
+        .arg(dir)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("`git {}` could not be run: {e}", args.join(" ")));
+    assert!(
+        out.status.success(),
+        "`git {}` failed in {}: {}",
+        args.join(" "),
+        dir.display(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn canonical(p: &std::path::Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf())
+}
+
+/// A `SessionRecord` in `state`, optionally pointing at `workspace`.
+///
+/// Why: `SessionRecord` has 22 fields and every test here needs one or two;
+/// building them inline would bury the two fields that actually matter.
+fn record_at(state: ManagedSessionState, workspace: Option<PathBuf>) -> SessionRecord {
+    SessionRecord {
+        id: ManagedSessionId::new(),
+        tmux_name: "tm-reconcile-test".into(),
+        cwd: PathBuf::from("/tmp"),
+        task: "reconcile test".into(),
+        state,
+        created_at: Utc::now(),
+        last_activity_at: None,
+        workspace_path: workspace,
+        repo_url: None,
+        branch: None,
+        pending_decision: None,
+        proposed_default: None,
+        correlation: Default::default(),
+        runtime: Default::default(),
+        ephemeral: false,
+        workspace_owned: false,
+        source_id: None,
+        claude_session_id: None,
+        scrollback_path: None,
+        last_cwd: None,
+        deliverable_id: None,
+        pane_id: None,
+        injection_status: Default::default(),
+        worktree_owner: None,
+    }
+}
+
+/// The entry for `path` in `report`, or a panic naming what WAS reported.
+fn entry_for<'a>(report: &'a ReconcileReport, path: &std::path::Path) -> &'a ReconciledWorktree {
+    let want = canonical(path);
+    report
+        .entries
+        .iter()
+        .find(|e| e.path == want)
+        .unwrap_or_else(|| {
+            let got: Vec<_> = report.entries.iter().map(|e| &e.path).collect();
+            panic!(
+                "{} must appear in the inventory; got {got:?}",
+                want.display()
+            )
+        })
+}
+
+// ── the acceptance test (#4288) ──────────────────────────────────────────
+
+/// Reconciliation keys on git's registry, and survives every mutation that
+/// breaks the alternative anchors (#4288 acceptance criteria).
+///
+/// Why: #4288's whole resolution rests on one claim — that
+/// `(git-common-dir, admin-dir name)` is the only anchor that survives a
+/// directory move, a remote rename, and a remote removal, and that no
+/// "workspace_path not in `git worktree list` => orphan" rule may exist. This
+/// test is the mechanical form of that claim. Its fixture is the decisive
+/// counterexample from the issue: two worktrees under the SAME path prefix
+/// (`<proj>/.base/.worktrees/`), registered in two DIFFERENT registries.
+///
+/// It goes RED when: a path-shape rule maps `B` to `.base`; only one anchor is
+/// probed so `B` is missing; the key is path-derived (the `root` failure #4269
+/// names) so a move changes it; the key derives from `RepoIdentity`, the origin
+/// URL, or `project_index_id` so a remote change moves it; or any rule treats a
+/// `workspace_path` absent from `git worktree list` as an orphan.
+#[test]
+fn reconcile_keys_on_the_git_registry_not_the_path() {
+    let fx = GitWorktreeFixture::new();
+
+    // A is registered in the `.base` BARE clone's registry; B is registered in
+    // the PROJECT checkout's registry — and both live under the identical
+    // `<proj>/.base/.worktrees/` prefix.
+    let a = fx.add_base_clone_worktree("A");
+    let base_worktrees = fx.repo.join(".base").join(".worktrees");
+    let b = fx.add_worktree_at(&base_worktrees, "B");
+
+    let base_common = canonical(&fx.repo.join(".base"));
+    let repo_common = canonical(&fx.repo.join(".git"));
+    assert_ne!(
+        base_common, repo_common,
+        "the two registries must genuinely differ, or this fixture proves nothing"
+    );
+
+    // ── baseline ─────────────────────────────────────────────────────────
+    let key_a = worktree_key(&a).expect("A must have a git-derived key");
+    let key_b = worktree_key(&b).expect("B must have a git-derived key");
+    assert_eq!(
+        key_a.common_dir, base_common,
+        "A is registered in the .base clone; its common-dir must be .base"
+    );
+    assert_eq!(
+        key_b.common_dir, repo_common,
+        "B lives under the .base/ prefix but is registered in the PROJECT \
+         checkout — a path-shape rule gets this one wrong"
+    );
+    assert_eq!(key_a.admin_dir.as_deref(), Some("A"));
+    assert_eq!(key_b.admin_dir.as_deref(), Some("B"));
+    assert_ne!(key_a, key_b);
+
+    let report = reconcile_worktrees(&fx.repos_root, &[], &[], Utc::now());
+    let admitted: Vec<PathBuf> = report
+        .entries
+        .iter()
+        .filter(|e| e.admission == Some(Admission::Admitted))
+        .map(|e| e.path.clone())
+        .collect();
+    assert_eq!(
+        admitted.len(),
+        2,
+        "exactly A and B are reclaim candidates; got {admitted:?}"
+    );
+    assert!(admitted.contains(&canonical(&a)), "got {admitted:?}");
+    assert!(admitted.contains(&canonical(&b)), "got {admitted:?}");
+    assert_eq!(report.counts.admitted, 2);
+    // In-scope item 2: the EXCLUDED set is reported too — here the project's
+    // main checkout and the bare `.base` record, each with its own reason.
+    assert_eq!(
+        report.counts.excluded, 2,
+        "the excluded set must be REPORTED, not silently dropped; got {:?}",
+        report.entries
+    );
+    assert_eq!(
+        entry_for(&report, &fx.repo).admission,
+        Some(Admission::MainCheckout)
+    );
+    assert_eq!(
+        entry_for(&report, &fx.repo.join(".base")).admission,
+        Some(Admission::Bare)
+    );
+
+    // ── mutation 1: `git worktree move` ──────────────────────────────────
+    let elsewhere = fx.repo.join("elsewhere");
+    std::fs::create_dir_all(&elsewhere).expect("create move destination parent");
+    let a2 = elsewhere.join("A2");
+    git_ok(
+        &fx.repo.join(".base"),
+        &[
+            "worktree",
+            "move",
+            a.to_str().expect("utf8 A"),
+            a2.to_str().expect("utf8 A2"),
+        ],
+    );
+    assert!(
+        a2.is_dir() && !a.exists(),
+        "the move must really have happened"
+    );
+    assert_eq!(
+        worktree_key(&a2).expect("A2 must still have a key"),
+        key_a,
+        "the key must survive a worktree move — a path-derived key does not"
+    );
+
+    // ── mutation 2: origin rename, then origin removal ───────────────────
+    git_ok(
+        &fx.repo,
+        &["remote", "set-url", "origin", "/nonexistent/renamed.git"],
+    );
+    assert_eq!(
+        worktree_key(&b).expect("B keeps its key"),
+        key_b,
+        "renaming origin must not move the key (it moves RepoIdentity/origin-URL anchors)"
+    );
+    git_ok(&fx.repo, &["remote", "remove", "origin"]);
+    assert_eq!(
+        worktree_key(&b).expect("B keeps its key with no remote at all"),
+        key_b,
+        "removing origin must not move the key — the anchor that vanishes here \
+         is the origin URL, which is why it is not the anchor"
+    );
+
+    // ── mutation 3: the `tm-trusty-tools-01` landmine ────────────────────
+    // A plain directory inside a live checkout, named by a SessionRecord.
+    let fake = fx.repo.join(".worktrees").join("fake");
+    std::fs::create_dir_all(&fake).expect("create the fake worktree dir");
+    std::fs::write(fake.join("f"), b"the only copy of somebody's work\n").expect("write file");
+    assert!(
+        worktree_key(&fake).is_none(),
+        "a plain directory inside a checkout has NO git-derived key — its \
+         `rev-parse --show-toplevel` resolves to the enclosing checkout"
+    );
+
+    let rec = record_at(ManagedSessionState::Active, Some(fake.clone()));
+    let report = reconcile_worktrees(&fx.repos_root, std::slice::from_ref(&rec), &[], Utc::now());
+    let fake_entry = entry_for(&report, &fake);
+    assert_eq!(
+        fake_entry.state,
+        ReconcileState::Unknown,
+        "reason was: {}",
+        fake_entry.reason
+    );
+    assert!(
+        fake_entry.admission.is_none(),
+        "git registers no such worktree, so there is no admission verdict"
+    );
+    assert_eq!(report.counts.record_only, 1);
+    let orphaned: Vec<PathBuf> = report
+        .entries
+        .iter()
+        .filter(|e| e.state == ReconcileState::Orphaned)
+        .map(|e| e.path.clone())
+        .collect();
+    assert!(
+        !orphaned.contains(&canonical(&fake)),
+        "a `workspace_path` absent from `git worktree list` must NEVER be an \
+         orphan — that rule deletes files inside a live checkout; got {orphaned:?}"
+    );
+    assert!(fake.join("f").exists(), "reconciliation must write nothing");
+}
+
+// ── the key, in isolation ────────────────────────────────────────────────
+
+/// The `show-toplevel` assertion is what rejects the landmine shape (#4288).
+///
+/// Why: without it, `rev-parse --git-common-dir` run inside an ordinary
+/// subdirectory of a checkout happily answers with the ENCLOSING repository's
+/// common dir, manufacturing a perfectly plausible key for a directory that is
+/// not a worktree at all.
+#[test]
+fn key_is_none_for_a_plain_directory_inside_a_checkout() {
+    let fx = GitWorktreeFixture::new();
+    let plain = fx.repo.join("docs").join("notes");
+    std::fs::create_dir_all(&plain).expect("create plain dir");
+    assert!(worktree_key(&plain).is_none());
+    // Control: a real worktree in the same repository DOES get a key, so the
+    // `None` above cannot be blamed on the fixture or a missing git.
+    let wt = fx.add_worktree("real-one");
+    assert!(worktree_key(&wt).is_some());
+}
+
+// ── three-state classification ───────────────────────────────────────────
+
+/// A `Stopped` record's workspace is LIVE, never ORPHANED (#4288).
+///
+/// Why: session `2eb72dca-…` was measured RUNNING in tmux pane `%981` while
+/// `sessions.json` recorded `state: "stopped"`, holding 12 modified tracked
+/// files, 31 untracked files and 1 unpushed commit. A record's state is
+/// bookkeeping, not a liveness signal. This is the reconcile-side sibling of
+/// `prune_spares_a_stopped_records_workspace`; it goes RED the moment anyone
+/// adds a state filter to the record scan in `reconcile_worktrees`.
+#[test]
+fn stopped_records_workspace_is_live_not_orphaned() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("stopped-but-running");
+    // Make it otherwise fully reclaimable, so ONLY the record veto spares it.
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+    let rec = record_at(ManagedSessionState::Stopped, Some(wt.clone()));
+
+    let report = reconcile_worktrees(&fx.repos_root, std::slice::from_ref(&rec), &[], Utc::now());
+    let entry = entry_for(&report, &wt);
+    assert_eq!(
+        entry.state,
+        ReconcileState::Live,
+        "reason: {}",
+        entry.reason
+    );
+    assert!(entry.reason.contains("workspace_path"), "{}", entry.reason);
+    assert_eq!(entry.sessions, vec![rec.id]);
+    assert_eq!(
+        report.counts.orphaned, 0,
+        "nothing may be orphaned here; got {:?}",
+        report.entries
+    );
+}
+
+/// The control case: a clean, admitted worktree whose sentinel owner is
+/// provably gone IS classified ORPHANED.
+///
+/// Why: without this, every other test in this file could pass by classifying
+/// literally everything UNKNOWN — a report that is safe and useless.
+#[test]
+fn clean_ownerless_admitted_worktree_is_orphaned() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("genuinely-stale");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+
+    let report = reconcile_worktrees(&fx.repos_root, &[], &[], Utc::now());
+    let entry = entry_for(&report, &wt);
+    assert_eq!(
+        entry.state,
+        ReconcileState::Orphaned,
+        "reason: {}",
+        entry.reason
+    );
+    assert_eq!(report.counts.orphaned, 1);
+    assert!(wt.exists(), "report-only: nothing may be removed");
+}
+
+/// A live cwd at or under a worktree vetoes reclamation (#4288).
+#[test]
+fn an_observed_live_cwd_vetoes_reclamation() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("has-a-live-pane");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+    let inside = canonical(&wt).join("crates");
+
+    let report = reconcile_worktrees(&fx.repos_root, &[], &[inside], Utc::now());
+    let entry = entry_for(&report, &wt);
+    assert_eq!(
+        entry.state,
+        ReconcileState::Live,
+        "reason: {}",
+        entry.reason
+    );
+    assert_eq!(report.counts.orphaned, 0);
+}
+
+/// A sentinel naming an unregistered owner is LIVE while it is still young
+/// (#3649 creation race), and ORPHANED only once it ages out.
+///
+/// Why: both sentinel write sites write the sentinel BEFORE the owning record
+/// is persisted. Without the grace window a sweep landing in that gap reads a
+/// brand-new worktree as ownerless.
+#[test]
+fn young_absent_sentinel_owner_is_live_not_orphaned() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("mid-provisioning");
+    let payload = serde_json::to_vec(&super::super::worktree_ownership::WorktreeSentinel {
+        owner_session_id: ManagedSessionId::new(),
+        created_at: Utc::now(),
+    })
+    .expect("serialize sentinel");
+    std::fs::write(
+        wt.join(super::super::decommission::WORKTREE_SENTINEL_FILE),
+        payload,
+    )
+    .expect("write sentinel");
+
+    let now = Utc::now();
+    let fresh = reconcile_worktrees(&fx.repos_root, &[], &[], now);
+    assert_eq!(entry_for(&fresh, &wt).state, ReconcileState::Live);
+
+    // Same sentinel, clock advanced past the grace window.
+    let later = now + OWNERLESS_GRACE + chrono::Duration::minutes(1);
+    let aged = reconcile_worktrees(&fx.repos_root, &[], &[], later);
+    assert_eq!(entry_for(&aged, &wt).state, ReconcileState::Orphaned);
+}
+
+/// A worktree holding unsaved work is UNKNOWN, never ORPHANED (#4091 gate,
+/// inherited unchanged).
+#[test]
+fn a_dirty_ownerless_worktree_is_unknown_not_orphaned() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("has-unsaved-work");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&wt);
+    std::fs::write(wt.join("README.md"), "edited but never committed\n").expect("dirty it");
+
+    let report = reconcile_worktrees(&fx.repos_root, &[], &[], Utc::now());
+    let entry = entry_for(&report, &wt);
+    assert_eq!(
+        entry.state,
+        ReconcileState::Unknown,
+        "reason: {}",
+        entry.reason
+    );
+    assert!(entry.dirty.is_some(), "the dirt reason must be reported");
+    assert_eq!(report.counts.orphaned, 0);
+}
+
+// ── the inventory shape ──────────────────────────────────────────────────
+
+/// The inventory is the UNION of git's registries and `sessions.json`.
+///
+/// Why: on the dogfood machine only 3 of 118 registered worktrees have a
+/// matching session record, and `sessions.json` holds 31 `workspace_path`s
+/// pointing at things git does not list. Either source alone reports a
+/// fictional picture.
+#[test]
+fn report_unions_registry_and_session_records() {
+    let fx = GitWorktreeFixture::new();
+    let registered = fx.add_worktree("registered-only");
+    let record_only = fx.repo.join("not-a-worktree");
+    std::fs::create_dir_all(&record_only).expect("create record-only dir");
+    let rec = record_at(ManagedSessionState::Active, Some(record_only.clone()));
+
+    let report = reconcile_worktrees(&fx.repos_root, std::slice::from_ref(&rec), &[], Utc::now());
+    assert_eq!(
+        entry_for(&report, &registered).admission,
+        Some(Admission::Admitted)
+    );
+    assert!(entry_for(&report, &record_only).admission.is_none());
+    assert_eq!(report.counts.admitted, 1);
+    assert_eq!(report.counts.record_only, 1);
+    assert_eq!(report.counts.excluded, 1, "the project's main checkout");
+    assert_eq!(
+        report.counts.total,
+        report.counts.live + report.counts.orphaned + report.counts.unknown,
+        "every row carries exactly one state"
+    );
+    assert_eq!(report.counts.total, 3);
+}
+
+/// A nested worktree precedes its container, and the container is flagged
+/// (#4288 in-scope item 4).
+///
+/// Why: nine registered worktrees on the dogfood machine sit inside another
+/// registered worktree. A parent-first order removes the parent's directory and
+/// takes its children with it, leaving dangling registry entries behind.
+#[test]
+fn entries_are_ordered_deepest_first() {
+    let fx = GitWorktreeFixture::new();
+    let parent = fx.add_worktree("container");
+    let child = fx.add_nested_worktree(&parent, ".claude/worktrees", "nested");
+
+    let report = reconcile_worktrees(&fx.repos_root, &[], &[], Utc::now());
+    let idx = |p: &std::path::Path| {
+        let want = canonical(p);
+        report
+            .entries
+            .iter()
+            .position(|e| e.path == want)
+            .unwrap_or_else(|| panic!("{} must be in the inventory", want.display()))
+    };
+    assert!(
+        idx(&child) < idx(&parent),
+        "the nested worktree must precede its container"
+    );
+    assert!(entry_for(&report, &parent).contains_other_entry);
+    assert!(!entry_for(&report, &child).contains_other_entry);
+}
+
+// ── categories are descriptive only ──────────────────────────────────────
+
+/// The descriptive category never gates the three-state verdict (#4288).
+///
+/// Why: the category is derived partly from path shape, and path shape
+/// misclassifies 29% of registry membership. If a consumer ever promoted it to
+/// a gate, the whole issue's finding would be re-introduced through the report.
+/// The assertion runs in BOTH directions: two entries with DIFFERENT
+/// categories reach the SAME state, and two entries with the SAME category
+/// reach DIFFERENT states. Either alone could be satisfied by accident.
+#[test]
+fn categories_are_descriptive_and_do_not_gate_state() {
+    let fx = GitWorktreeFixture::new();
+    // Same evidence (none), different categories.
+    let agent = fx.add_worktree_at(&fx.repo.join(".claude").join("worktrees"), "agent-x");
+    let plain = fx.add_worktree("plain-no-sentinel");
+    // Both carry owner EVIDENCE, so both are `SessionOwned` — but one is
+    // reclaimable and one is vetoed.
+    let stale = fx.add_worktree("sentinel-ownerless");
+    GitWorktreeFixture::stamp_reclaimable_sentinel(&stale);
+    let owned = fx.add_worktree("owned-one");
+    let rec = record_at(ManagedSessionState::Active, Some(owned.clone()));
+
+    let report = reconcile_worktrees(&fx.repos_root, std::slice::from_ref(&rec), &[], Utc::now());
+    let category = |p: &std::path::Path| entry_for(&report, p).category;
+    let state = |p: &std::path::Path| entry_for(&report, p).state;
+
+    assert_eq!(category(&agent), WorktreeCategory::HarnessAgent);
+    assert_eq!(category(&plain), WorktreeCategory::Unclassified);
+    assert_eq!(category(&stale), WorktreeCategory::SessionOwned);
+    assert_eq!(category(&owned), WorktreeCategory::SessionOwned);
+    assert_eq!(category(&fx.repo), WorktreeCategory::ProjectCheckout);
+
+    // Different categories, identical state — the label decided nothing.
+    assert_eq!(state(&agent), ReconcileState::Unknown);
+    assert_eq!(state(&plain), ReconcileState::Unknown);
+    // Identical category, different states — the EVIDENCE decided, not the label.
+    assert_eq!(state(&stale), ReconcileState::Orphaned);
+    assert_eq!(state(&owned), ReconcileState::Live);
+}
+
+// ── proposed adoptions (names only, writes nothing) ──────────────────────
+
+/// Adoptions are NAMED with their evidence, and nothing is written (#4288
+/// item 3, open decision (b)).
+#[test]
+fn proposed_adoptions_name_owner_and_evidence() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("adoptable");
+    let rec = record_at(ManagedSessionState::Active, Some(wt.clone()));
+
+    let report = reconcile_worktrees(&fx.repos_root, std::slice::from_ref(&rec), &[], Utc::now());
+    assert_eq!(
+        report.proposed_adoptions.len(),
+        1,
+        "got {:?}",
+        report.proposed_adoptions
+    );
+    let proposal = &report.proposed_adoptions[0];
+    assert_eq!(proposal.path, canonical(&wt));
+    assert_eq!(proposal.inferred_owner, rec.id);
+    assert!(
+        proposal.evidence.contains("workspace_path"),
+        "the evidence must name the observation; got {}",
+        proposal.evidence
+    );
+    assert!(
+        !wt.join(crate::session_manager::decommission::WORKTREE_SENTINEL_FILE)
+            .exists(),
+        "naming an adoption must not WRITE a sentinel — this slice writes nothing"
+    );
+}
+
+/// A worktree containing another inventory entry is never proposed for
+/// adoption (#4288 in-scope item 4).
+///
+/// Why: adopting a container is how a later reclaim takes its children's
+/// directories with it. The sibling worktree in this test has identical
+/// evidence and IS proposed, so the refusal is attributable to the nesting and
+/// nothing else.
+#[test]
+fn proposed_adoptions_refuse_a_worktree_containing_another_entry() {
+    let fx = GitWorktreeFixture::new();
+    let container = fx.add_worktree("has-a-nested-worktree");
+    fx.add_nested_worktree(&container, ".claude/worktrees", "nested");
+    let sibling = fx.add_worktree("has-nothing-nested");
+    let container_rec = record_at(ManagedSessionState::Active, Some(container.clone()));
+    let sibling_rec = record_at(ManagedSessionState::Active, Some(sibling.clone()));
+    let records = vec![container_rec, sibling_rec];
+
+    let report = reconcile_worktrees(&fx.repos_root, &records, &[], Utc::now());
+    let proposed: Vec<PathBuf> = report
+        .proposed_adoptions
+        .iter()
+        .map(|p| p.path.clone())
+        .collect();
+    assert_eq!(proposed, vec![canonical(&sibling)], "got {proposed:?}");
+    assert!(entry_for(&report, &container).contains_other_entry);
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_registry.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry.rs
@@ -25,10 +25,14 @@
 //! What: [`RegisteredWorktree`] (one porcelain record),
 //! [`parse_worktree_list`] (the pure parser), [`registry_root_for`] (replaces
 //! grandparent-as-repo-root inference), [`list_registered_worktrees`] (what
-//! git says about the repository owning a path), and
-//! [`enumerate_registered_worktrees`] (every registered worktree living INSIDE
-//! a managed project under the repos root — see that function's "positive
-//! assertion" section for the structural boundary that bounds the sweep).
+//! git says about the repository owning a path),
+//! [`scan_registered_worktrees`] (#4288 — EVERY registered worktree under the
+//! repos root, each carrying the [`Admission`] verdict that says whether it is
+//! a reclaim candidate and, when it is not, WHY), and
+//! [`enumerate_registered_worktrees`] (the admitted subset — every registered
+//! worktree living INSIDE a managed project under the repos root; see that
+//! function's "positive assertion" section for the structural boundary that
+//! bounds the sweep).
 //!
 //! # An unanswerable probe is never a verdict
 //!
@@ -226,7 +230,7 @@ pub(crate) fn list_registered_worktrees(anchor: &Path) -> Option<Vec<RegisteredW
 /// without it, `git -C <non-repo>` walks UP the filesystem and would report an
 /// unrelated enclosing repository's worktrees. Records that are bare, main,
 /// already prunable, or git-`locked` are dropped, as is any worktree failing
-/// the [`collect_from_anchor`] containment rule. Results are canonicalized (so
+/// the [`scan_from_anchor`] containment rule. Results are canonicalized (so
 /// they compare cleanly against the canonicalized active-session set) and
 /// returned sorted and de-duplicated, since both anchors may report the same
 /// worktree.
@@ -304,8 +308,141 @@ pub(crate) fn list_registered_worktrees(anchor: &Path) -> Option<Vec<RegisteredW
 /// `enumerate_excludes_a_worktree_parked_beside_the_project`,
 /// `enumerate_excludes_a_locked_worktree`.
 pub(crate) fn enumerate_registered_worktrees(repos_root: &Path) -> Vec<PathBuf> {
+    let admitted: BTreeSet<PathBuf> = scan_registered_worktrees(repos_root)
+        .into_iter()
+        .filter(|s| s.admission == Admission::Admitted)
+        .map(|s| s.path)
+        .collect();
+    let mut out: Vec<PathBuf> = admitted.into_iter().collect();
+    sort_deepest_first(&mut out);
+    out
+}
+
+/// Order `paths` so a NESTED worktree always precedes the worktree that
+/// contains it (#4288, in-scope item 4).
+///
+/// Why: the pre-#4288 order came straight out of a `BTreeSet<PathBuf>`, which
+/// sorts lexicographically — so `…/parent` sorts BEFORE `…/parent/child`.
+/// Nine registered worktrees on the dogfood machine are nested inside another
+/// registered worktree, and removing a parent first takes its children's
+/// directories with it: the child's own removal then finds nothing to remove
+/// and git is left holding a dangling registry entry for a path that no longer
+/// exists. Reversing the order makes each nested worktree removed by
+/// `git worktree remove` (which de-registers it) before its parent is touched.
+///
+/// This changes ORDER only. It cannot admit a path the containment rules
+/// already rejected, and it cannot cause a removal that would not otherwise
+/// have happened — every element was already in the returned list.
+/// What: sorts by path DEPTH descending (component count), breaking ties
+/// lexicographically so the result stays deterministic. Depth-descending is
+/// sufficient for the containment property: a descendant always has strictly
+/// more components than its ancestor.
+/// Test: `enumerate_orders_nested_worktree_before_its_parent`.
+fn sort_deepest_first(paths: &mut [PathBuf]) {
+    paths.sort_by(|a, b| {
+        b.components()
+            .count()
+            .cmp(&a.components().count())
+            .then_with(|| a.cmp(b))
+    });
+}
+
+/// Why a registered worktree is, or is not, an orphan-reclaim CANDIDATE (#4288).
+///
+/// Why: `enumerate_registered_worktrees` returns only the admitted paths, so
+/// everything it drops is invisible — and on the dogfood machine that is 33 of
+/// 118 registered worktrees, 6 of which hold uncommitted work, including the
+/// two landmines #4288 documents (a `workspace_path` that is an ordinary
+/// subdirectory of a live checkout, and worktrees nested inside a live one).
+/// Reconciliation cannot report what enumeration silently discards, so the
+/// verdict is now a VALUE the scan carries rather than a `continue` statement.
+/// What: [`Admitted`](Self::Admitted) is the reclaim-candidate set — identical
+/// to what `enumerate_registered_worktrees` returned before #4288. Every other
+/// variant names one exclusion, in the order the scan applies them.
+/// Test: `scan_reports_the_excluded_set_with_reasons`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum Admission {
+    /// Inside a managed project, not bare/main/prunable/locked — a candidate.
+    Admitted,
+    /// A bare repository record: no working tree to reclaim.
+    Bare,
+    /// The repository's main checkout: never a candidate.
+    MainCheckout,
+    /// Git already considers the directory gone.
+    Prunable,
+    /// The operator ran `git worktree lock` — an explicit removal veto.
+    Locked,
+    /// The path could not be canonicalized, so nothing about it is comparable.
+    Unresolvable,
+    /// Registered, but not a strict descendant of the managed project.
+    OutsideProject,
+    /// Registered, but outside the managed repos root.
+    OutsideReposRoot,
+}
+
+impl Admission {
+    /// A short, operator-facing phrase naming this verdict (#4288).
+    ///
+    /// Why: the reconcile report prints one reason per entry, and building
+    /// that string at each call site would let the wordings drift.
+    /// What: a `&'static str` per variant.
+    /// Test: `scan_reports_the_excluded_set_with_reasons`.
+    pub(crate) fn reason(self) -> &'static str {
+        match self {
+            Self::Admitted => "admitted: registered inside a managed project",
+            Self::Bare => "excluded: bare repository record (no working tree)",
+            Self::MainCheckout => "excluded: the repository's main checkout",
+            Self::Prunable => "excluded: git reports the directory is already gone",
+            Self::Locked => "excluded: git-locked by the operator",
+            Self::Unresolvable => "excluded: path could not be canonicalized",
+            Self::OutsideProject => "excluded: not inside the managed project that registered it",
+            Self::OutsideReposRoot => "excluded: outside the managed repos root",
+        }
+    }
+}
+
+/// One registered worktree plus everything the scan learned about it (#4288).
+///
+/// Why: reconciliation needs the registry that named a worktree (that is half
+/// the git-derived key), the project bounding it, and the admission verdict —
+/// none of which survive `enumerate_registered_worktrees`' `Vec<PathBuf>`.
+/// What: `path` is canonical when it resolved (raw otherwise, so an
+/// [`Admission::Unresolvable`] entry can still be REPORTED); `project` is the
+/// managed project directory; `registry_root` is the checkout whose
+/// `git worktree list` named it; `branch` and `admission` complete the record.
+/// Test: `scan_reports_the_excluded_set_with_reasons`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ScannedWorktree {
+    /// Canonical worktree path (raw when canonicalization failed).
+    pub path: PathBuf,
+    /// The managed project directory `<repos_root>/<owner>/<repo>`.
+    pub project: PathBuf,
+    /// The checkout whose registry listed this worktree.
+    pub registry_root: PathBuf,
+    /// Short branch name, or `None` when detached.
+    pub branch: Option<String>,
+    /// Whether this is an orphan-reclaim candidate, and if not, why not.
+    pub admission: Admission,
+}
+
+/// Every worktree BOTH managed anchors register under `repos_root`, admitted
+/// or not (#4288).
+///
+/// Why: this is [`enumerate_registered_worktrees`] with the `continue`
+/// statements turned into values, so reconciliation reports the excluded set
+/// instead of inheriting enumeration's blind spot. Sharing one traversal is
+/// the point — a second, parallel enumerator is exactly the drift that let the
+/// pre-#4207 five-shape walk disagree with itself.
+/// What: for each `<repos_root>/<owner>/<repo>/`, interrogates `<repo>` and
+/// `<repo>/.base` (each only after [`registry_root_for`] confirms the anchor
+/// IS that repository's root), and returns one [`ScannedWorktree`] per
+/// porcelain record, deduplicated on (path, registry root) and sorted.
+/// Test: `scan_reports_the_excluded_set_with_reasons`,
+/// `scan_reports_both_registries_for_the_same_path_prefix`.
+pub(crate) fn scan_registered_worktrees(repos_root: &Path) -> Vec<ScannedWorktree> {
     let canonical_root = std::fs::canonicalize(repos_root).unwrap_or_else(|_| repos_root.into());
-    let mut found: BTreeSet<PathBuf> = BTreeSet::new();
+    let mut found: BTreeSet<(PathBuf, PathBuf, ScannedKey)> = BTreeSet::new();
     let Ok(owner_entries) = std::fs::read_dir(repos_root) else {
         return Vec::new();
     };
@@ -328,36 +465,62 @@ pub(crate) fn enumerate_registered_worktrees(repos_root: &Path) -> Vec<PathBuf> 
                 continue;
             };
             for anchor in [repo_path.clone(), repo_path.join(BASE_CLONE_DIRNAME)] {
-                collect_from_anchor(&anchor, &canonical_root, &canonical_project, &mut found);
+                scan_from_anchor(&anchor, &canonical_root, &canonical_project, &mut found);
             }
         }
     }
-    found.into_iter().collect()
+    found
+        .into_iter()
+        .map(|(path, registry_root, key)| ScannedWorktree {
+            path,
+            project: key.project,
+            registry_root,
+            branch: key.branch,
+            admission: key.admission,
+        })
+        .collect()
 }
 
-/// Add every reclaimable-shaped worktree registered at `anchor` to `found`.
+/// The non-key remainder of a [`ScannedWorktree`], carried through the dedup
+/// `BTreeSet` (#4288).
 ///
-/// Why: extracted so [`enumerate_registered_worktrees`]' two anchors share one
-/// rule rather than duplicating the root-confirmation, filtering, and
-/// containment logic — the duplication that let the old walk's five shapes
-/// drift apart from each other.
+/// Why: deduplication is on (path, registry root) — the identity of the entry —
+/// but `BTreeSet` needs the WHOLE tuple to be `Ord`, and the payload has to
+/// ride along. Keeping it in a named struct rather than a bare tuple keeps
+/// `scan_registered_worktrees`' final `map` readable.
+/// What: the fields of [`ScannedWorktree`] that are not part of its identity.
+/// Test: covered by every `scan_*` test.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct ScannedKey {
+    project: PathBuf,
+    branch: Option<String>,
+    admission: Admission,
+}
+
+/// Record every worktree registered at `anchor`, with its admission verdict.
+///
+/// Why: extracted so [`scan_registered_worktrees`]' two anchors share one rule
+/// rather than duplicating the root-confirmation, filtering, and containment
+/// logic — the duplication that let the old walk's five shapes drift apart
+/// from each other.
 /// What: no-ops unless `anchor` is a directory that is ITSELF the root of the
-/// repository owning its registry (see [`registry_root_for`]); then inserts
-/// every non-bare, non-main, non-prunable, non-`locked` worktree whose
-/// canonicalized path is a STRICT DESCENDANT of `canonical_project` (the
-/// managed project directory — see [`enumerate_registered_worktrees`]' "positive
-/// assertion" section) and also lies under `canonical_root`.
+/// repository owning its registry (see [`registry_root_for`]); then records
+/// every worktree, marking [`Admission::Admitted`] only for the non-bare,
+/// non-main, non-prunable, non-`locked` ones whose canonicalized path is a
+/// STRICT DESCENDANT of `canonical_project` (the managed project directory —
+/// see [`enumerate_registered_worktrees`]' "positive assertion" section) and
+/// also lies under `canonical_root`.
 ///
 /// Both containment checks are applied even though the first normally implies
 /// the second: `canonical_project` is derived by canonicalizing a `read_dir`
 /// entry, so a symlinked project directory could resolve OUTSIDE the managed
 /// root, and the pair keeps the sweep bounded in that case too.
-/// Test: covered by every `enumerate_*` test.
-fn collect_from_anchor(
+/// Test: covered by every `enumerate_*` and `scan_*` test.
+fn scan_from_anchor(
     anchor: &Path,
     canonical_root: &Path,
     canonical_project: &Path,
-    found: &mut BTreeSet<PathBuf>,
+    found: &mut BTreeSet<(PathBuf, PathBuf, ScannedKey)>,
 ) {
     if !anchor.is_dir() {
         return;
@@ -376,6 +539,36 @@ fn collect_from_anchor(
         return;
     };
     for wt in worktrees {
+        let admission = admission_for(&wt, canonical_root, canonical_project);
+        let path = std::fs::canonicalize(&wt.path).unwrap_or_else(|_| wt.path.clone());
+        found.insert((
+            path,
+            canonical_repo_root.clone(),
+            ScannedKey {
+                project: canonical_project.to_path_buf(),
+                branch: wt.branch.clone(),
+                admission,
+            },
+        ));
+    }
+}
+
+/// The [`Admission`] verdict for one porcelain record (#4288).
+///
+/// Why: the exclusion rules were `continue` statements inside the scan loop, so
+/// nothing could name WHICH rule fired. Splitting them out makes each verdict
+/// reportable without changing any of them — the order and the conditions are
+/// exactly those `collect_from_anchor` applied before #4288.
+/// What: applies, in order, the git-reported vetoes, then canonicalization,
+/// then the two containment checks.
+/// Test: `scan_reports_the_excluded_set_with_reasons`,
+/// `enumerate_excludes_a_locked_worktree`.
+fn admission_for(
+    wt: &RegisteredWorktree,
+    canonical_root: &Path,
+    canonical_project: &Path,
+) -> Admission {
+    {
         // `locked` is git's own removal veto — the operator ran
         // `git worktree lock` to say "do not remove this".
         //
@@ -393,8 +586,17 @@ fn collect_from_anchor(
         // force flag, AND leaving git's now-dangling registry entry behind.
         // Never enumerating a locked worktree is therefore the only place the
         // operator's veto actually survives.
-        if wt.bare || wt.is_main || wt.prunable || wt.locked {
-            continue;
+        if wt.bare {
+            return Admission::Bare;
+        }
+        if wt.is_main {
+            return Admission::MainCheckout;
+        }
+        if wt.prunable {
+            return Admission::Prunable;
+        }
+        if wt.locked {
+            return Admission::Locked;
         }
         // #1845 item 8, preserved: a path that cannot be canonicalized is
         // SKIPPED, never proposed. A dangling symlink, a deletion race, an
@@ -404,19 +606,20 @@ fn collect_from_anchor(
         // deletion. The asymmetry is deliberate: a failed observation reduces
         // what this function proposes, and can never enlarge it.
         let Ok(canonical) = std::fs::canonicalize(&wt.path) else {
-            continue;
+            return Admission::Unresolvable;
         };
         // The structural boundary (#4224 HIGH). `starts_with` is component-wise,
         // so `<owner>/trusty-tools-worktrees/x` cannot match the project
         // `<owner>/trusty-tools`. The `!=` makes it STRICT: the project checkout
         // itself — the operator's working copy — is never a candidate, whether
         // or not some other registry lists it as a linked worktree.
-        if canonical != canonical_project
-            && canonical.starts_with(canonical_project)
-            && canonical.starts_with(canonical_root)
-        {
-            found.insert(canonical);
+        if canonical == canonical_project || !canonical.starts_with(canonical_project) {
+            return Admission::OutsideProject;
         }
+        if !canonical.starts_with(canonical_root) {
+            return Admission::OutsideReposRoot;
+        }
+        Admission::Admitted
     }
 }
 

--- a/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
@@ -366,45 +366,46 @@ fn enumerate_excludes_a_worktree_parked_beside_the_project() {
 /// That same masking is why the strictness is pinned HERE rather than through
 /// [`enumerate_registered_worktrees`] — an enumeration-level test would keep
 /// passing with the `!=` deleted, making it a guard no test defends. Driving
-/// [`collect_from_anchor`] directly lets the boundary be set to a path that IS
+/// [`scan_from_anchor`] directly lets the boundary be set to a path that IS
 /// in the registry, so the `!=` is the only thing that can exclude it.
+///
+/// #4288 strengthened this: the scan now carries the verdict as a VALUE, so the
+/// test asserts the exclusion RULE that fired ([`Admission::OutsideProject`])
+/// rather than mere absence from a set — a much harder assertion to satisfy by
+/// accident.
 #[test]
-fn collect_from_anchor_never_yields_the_containment_boundary_itself() {
+fn scan_from_anchor_never_admits_the_containment_boundary_itself() {
     let fixture = GitWorktreeFixture::new();
     let wt = fixture.add_worktree("session-a");
     let canonical_wt = std::fs::canonicalize(&wt).unwrap_or_else(|_| wt.clone());
     let canonical_root = std::fs::canonicalize(&fixture.repos_root).expect("canonical root");
     let canonical_repo = std::fs::canonicalize(&fixture.repo).expect("canonical repo");
 
-    // Control: bounded by the real project, the worktree IS collected — so the
+    let admission_under_boundary = |boundary: &std::path::Path| -> Admission {
+        let mut collected = std::collections::BTreeSet::new();
+        scan_from_anchor(&fixture.repo, &canonical_root, boundary, &mut collected);
+        collected
+            .into_iter()
+            .find(|(path, _, _)| path == &canonical_wt)
+            .map(|(_, _, key)| key.admission)
+            .expect("the worktree must be SCANNED under either boundary")
+    };
+
+    // Control: bounded by the real project, the worktree IS admitted — so the
     // exclusion below cannot be attributed to the anchor or the registry.
-    let mut collected = std::collections::BTreeSet::new();
-    collect_from_anchor(
-        &fixture.repo,
-        &canonical_root,
-        &canonical_repo,
-        &mut collected,
-    );
-    assert!(
-        collected.contains(&canonical_wt),
-        "control: bounded by the project, a real in-project worktree must be \
-         collected; got {collected:?}"
+    assert_eq!(
+        admission_under_boundary(&canonical_repo),
+        Admission::Admitted,
+        "control: bounded by the project, a real in-project worktree must be admitted"
     );
 
     // Now make the worktree its OWN boundary: it is no longer a STRICT
-    // descendant, and must not be collected.
-    let mut collected = std::collections::BTreeSet::new();
-    collect_from_anchor(
-        &fixture.repo,
-        &canonical_root,
-        &canonical_wt,
-        &mut collected,
-    );
-    assert!(
-        !collected.contains(&canonical_wt),
+    // descendant, and must not be admitted.
+    assert_eq!(
+        admission_under_boundary(&canonical_wt),
+        Admission::OutsideProject,
         "a path equal to its containment boundary must never be a candidate — \
-         this is what keeps the operator's project checkout unselectable; got \
-         {collected:?}"
+         this is what keeps the operator's project checkout unselectable"
     );
 }
 
@@ -490,4 +491,116 @@ fn enumerate_ignores_a_worktree_whose_directory_is_gone() {
 fn enumerate_missing_repos_root_is_empty() {
     let tmp = tempfile::tempdir().expect("tempdir");
     assert!(enumerate_registered_worktrees(&tmp.path().join("nope")).is_empty());
+}
+
+// ── the full scan and its exclusion reasons (#4288) ──────────────────────
+
+/// Every registered worktree the scan drops must come back with the reason it
+/// was dropped (#4288 in-scope item 2).
+///
+/// Why: `enumerate_registered_worktrees` returns only admitted paths, so 33 of
+/// the 118 registered worktrees on the dogfood machine — including the two
+/// landmines #4288 documents, six of them holding uncommitted work — are
+/// invisible to every operator surface. Reconciliation cannot report what
+/// enumeration silently discards. This asserts the scan reports BOTH sets and
+/// names the rule that fired, not just a count.
+#[test]
+fn scan_reports_the_excluded_set_with_reasons() {
+    let fixture = GitWorktreeFixture::new();
+    let admitted = fixture.add_worktree("admitted-one");
+    let locked = fixture.add_worktree("locked-one");
+    fixture.lock_worktree(&locked);
+    let outside = fixture.add_worktree_at(&fixture.repos_root.join("owner"), "beside-the-project");
+
+    let scan = scan_registered_worktrees(&fixture.repos_root);
+    let verdict = |p: &std::path::Path| -> Admission {
+        let c = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+        scan.iter()
+            .find(|s| s.path == c)
+            .unwrap_or_else(|| panic!("scan must report {}; got {scan:?}", c.display()))
+            .admission
+    };
+
+    assert_eq!(verdict(&admitted), Admission::Admitted);
+    assert_eq!(verdict(&locked), Admission::Locked);
+    assert_eq!(verdict(&outside), Admission::OutsideProject);
+    assert_eq!(verdict(&fixture.repo), Admission::MainCheckout);
+    assert_eq!(
+        Admission::Locked.reason(),
+        "excluded: git-locked by the operator"
+    );
+
+    // The admitted subset is exactly what `enumerate` still returns — the scan
+    // widened what is REPORTED, never what is proposed for deletion.
+    let enumerated = enumerate_registered_worktrees(&fixture.repos_root);
+    let admitted_from_scan: Vec<_> = scan
+        .iter()
+        .filter(|s| s.admission == Admission::Admitted)
+        .map(|s| s.path.clone())
+        .collect();
+    assert_eq!(admitted_from_scan.len(), 1, "got {admitted_from_scan:?}");
+    assert_eq!(enumerated.len(), 1, "got {enumerated:?}");
+    assert_eq!(enumerated[0], admitted_from_scan[0]);
+}
+
+/// Two worktrees under the SAME path prefix, registered in DIFFERENT
+/// registries, are each attributed to the registry that actually holds them
+/// (#4288).
+///
+/// Why: this is the decisive counterexample from #4288 — path shape
+/// misclassifies 29% of worktrees, and the proof is two sibling directories
+/// inside `.base/.worktrees/` whose registries differ. A rule reading `/.base/`
+/// out of the path maps both to the base clone and is wrong about one of them.
+#[test]
+fn scan_reports_both_registries_for_the_same_path_prefix() {
+    let fixture = GitWorktreeFixture::new();
+    let base_owned = fixture.add_base_clone_worktree("in-base-registry");
+    let base_worktrees_dir = fixture.repo.join(".base").join(".worktrees");
+    let repo_owned = fixture.add_worktree_at(&base_worktrees_dir, "in-repo-registry");
+
+    let scan = scan_registered_worktrees(&fixture.repos_root);
+    let registry_of = |p: &std::path::Path| -> std::path::PathBuf {
+        let c = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
+        scan.iter()
+            .find(|s| s.path == c)
+            .unwrap_or_else(|| panic!("scan must report {}", c.display()))
+            .registry_root
+            .clone()
+    };
+
+    let base_root = std::fs::canonicalize(fixture.repo.join(".base")).expect("canonical .base");
+    let repo_root = std::fs::canonicalize(&fixture.repo).expect("canonical repo");
+    assert_eq!(registry_of(&base_owned), base_root);
+    assert_eq!(registry_of(&repo_owned), repo_root);
+    assert_ne!(
+        base_root, repo_root,
+        "the two registries must genuinely differ, or this test proves nothing"
+    );
+}
+
+/// A worktree nested inside another worktree is enumerated BEFORE its
+/// container (#4288 in-scope item 4).
+///
+/// Why: the pre-#4288 order came out of a `BTreeSet<PathBuf>`, which sorts a
+/// parent before its children. Nine registered worktrees on the dogfood machine
+/// sit inside another registered worktree; removing the parent first takes the
+/// child's directory with it and leaves git holding a dangling registry entry.
+#[test]
+fn enumerate_orders_nested_worktree_before_its_parent() {
+    let fixture = GitWorktreeFixture::new();
+    let parent = fixture.add_worktree("outer");
+    let child = fixture.add_nested_worktree(&parent, ".claude/worktrees", "inner");
+
+    let found = enumerate_registered_worktrees(&fixture.repos_root);
+    let canonical = |p: &std::path::Path| std::fs::canonicalize(p).unwrap_or_else(|_| p.into());
+    let idx = |p: &std::path::Path| {
+        found
+            .iter()
+            .position(|f| f == &canonical(p))
+            .unwrap_or_else(|| panic!("{} must be enumerated; got {found:?}", p.display()))
+    };
+    assert!(
+        idx(&child) < idx(&parent),
+        "the nested worktree must precede its container; got {found:?}"
+    );
 }


### PR DESCRIPTION
Part of #4207 (slice 3). Constraining input: #4269. Follow-on: #4270.

## What this fixes

Reconciliation had nothing to reconcile with, and the discriminator every consumer used — the path — is provably wrong. On the dogfood machine: 118 registered worktrees across two disjoint git registries (`.base` 60, sibling clone 58, intersection zero), 56 session records, 3 worktrees with a matching record. Path shape misclassifies 34 of the 118 (29%): two sibling directories under `.base/.worktrees/` belong to *different* registries.

## The key

```
( canonicalize(git -C <wt> rev-parse --path-format=absolute --git-common-dir),
  basename of <wt>'s admin dir, from the `gitdir:` line of <wt>/.git )
```

asserting `rev-parse --show-toplevel == canonicalize(<wt>)`. Git's own registry identity: no path convention, and it does not contain `root`. It is the only anchor that survives `mv proj`, a GitHub rename, a transfer, and `git remote remove origin` — and when it breaks (repo moved without `git worktree repair`) it breaks **loudly**, where a `root`-keyed scheme fails silently by re-deriving a fresh key.

The `show-toplevel` assertion is what makes the second landmine safe. `…/.worktrees/tm-trusty-tools-01` is a `workspace_path` in `sessions.json` with no `.git` file, whose toplevel resolves to the **parent checkout**. Any "workspace_path not in `git worktree list` ⇒ orphan" rule deletes files inside a live checkout. Here it gets no key, and **UNKNOWN dominates** — a path whose git identity cannot be established is never reported reclaimable, no matter what else points at it.

## Scope: report-only. Zero new destructive code paths.

Nothing is written, deleted, or migrated. `reconcile_worktrees` is a pure function of (registry scan, store snapshot, live cwds, clock); the CLI verb has no `--force`, `--dry-run`, or `--discard-dirty`, and `cli_reconcile_worktrees_takes_no_destructive_flag` turns adding one red. The existing reclaimer, its gates, and its dry-run default are untouched.

## In-scope items

| # | Item | Where |
|---|---|---|
| 1 | Reconciled inventory on the git key, three-state, reason per row | `session_manager/worktree_reconcile.rs` |
| 2 | **The excluded set is reported** — 33 of 118 here, six holding uncommitted work, invisible on every other surface | `worktree_registry::Admission` is now a value, not a `continue` |
| 3 | Proposed-adoption list — path, inferred owner, evidence. Names only | `ReconcileReport::proposed_adoptions` |
| 4 | Children before parents; never propose a candidate containing another | `sort_deepest_first`, `contains_other_entry` |
| 5 | Pin the unfiltered active set | already landed in #4294 (merged) |
| 6 | Amend the #4269 doc defects | `trusty-common/src/project_index_id.rs`, its CHANGELOG |

Slice 3 deliberately does **not** wire `project_index_id`, and performs zero sentinel writes.

## Item 4 is a real fix, not bookkeeping

Enumeration returned a `BTreeSet<PathBuf>`, so a parent sorted **before** its children. Nine registered worktrees on the dogfood machine are nested inside another. Removing a parent first takes the child's directory with it and leaves git holding a dangling registry entry. Order is now depth-descending. This changes order only — it cannot admit a path the containment rules already rejected.

## Acceptance test

`reconcile_keys_on_the_git_registry_not_the_path` — real repos in a `TempDir`, no mocks, no env gate, no `#[ignore]`. Fixture is the issue's counterexample: worktree `A` registered in the `.base` bare clone, `B` registered in the project checkout, both under the identical `<proj>/.base/.worktrees/` prefix. Baseline plus three mutations (`git worktree move`, `remote set-url origin`, `remote remove origin`) plus the `fake`-directory landmine, each asserted on counts **and** specific paths.

```
test session_manager::worktree_reconcile::worktree_reconcile_tests::reconcile_keys_on_the_git_registry_not_the_path ... ok
```

## Gates

```
cargo fmt --check                                  exit 0
cargo clippy -p trusty-mpm --all-targets -- -D warnings   clean
cargo test -p trusty-mpm                           3970 passed; 0 failed; 6 ignored (lib)
                                                   + 1290, 1290, and 28 further binaries — 0 failed anywhere
bash scripts/check_line_cap.sh                     7 allowlisted, 0 violations — OK
bash scripts/check_test_pointers.sh                0 dangling pointers — OK
cargo test -p trusty-common                        223 passed; 0 failed; 6 ignored
```

Two files had to be split to stay under the caps: the CLI renderer moved to `commands/reconcile_worktrees.rs`, and both worktree routes now live in one merged sub-router, which takes `api.rs` from 1276 back to 1269 SLOC (below its frozen 1272 budget).

Closes #4288

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
