### PR TITLE
fix: daemon logging and task error formatting (#4111, #4320)

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,44 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **The daemon now writes a real, best-effort log file, scoped per project
+  and port** (#4111). `--serve`'s detached child previously had
+  stdin/stdout/stderr all redirected to `/dev/null`, so a daemon crash was
+  completely undiagnosable — no `~/Library/Logs/trusty-agents/` directory
+  ever existed, unlike every other trusty-* daemon.
+  `service::start_service` now opens (and rotates, once past 10 MiB)
+  `~/Library/Logs/trusty-agents/daemon-<project-hash>-<port>.log` and
+  redirects the child's stderr to it instead of discarding it; stdin/stdout
+  are unchanged (`/dev/null` / `/dev/null`), preserving the existing "stdout
+  stays clean for MCP JSON-RPC framing" contract. Log setup is best-effort —
+  an unwritable log directory, a full disk, or a permissions problem falls
+  back to `Stdio::null()` rather than aborting the daemon spawn, so a
+  logging failure can never take down Concierge/Telegram/Slack with it. The
+  log path is keyed by BOTH a hash of the project root (mirroring
+  `pid_file_path()`'s own per-project identity — port alone didn't actually
+  prevent clobbering, since every project shares the same hardcoded default
+  port) and port, so two concurrently-running daemons don't interleave into
+  (or rotate-clobber) the same file. The daemon's own tracing setup
+  (`runtime::startup`) is unchanged — it already wrote to stderr in
+  non-interactive mode; the bug was purely the spawn call discarding that
+  stream.
+- **A failed task no longer renders a raw Rust error as if the assistant said
+  it, in either Tauri or browser/`pnpm dev` mode** (#4320). Both
+  `send_message` (Tauri `ui/src-tauri/src/task_commands.rs`) and its browser
+  fallback (`ui/src/lib/transport.ts`'s `fetchFallback` poll loop — the sole
+  narrative-delivery path in that mode) emitted `task-complete` for every
+  terminal poll response regardless of status, so a `status: "error"`
+  response's narrative — a raw failure string such as `subprocess exited
+  with status Some(1)`, or a Debug-formatted `anyhow::Error` — landed in
+  `ChatView.svelte`'s `task-complete` handler, which renders `narrative`
+  verbatim with no error framing. Both now emit `task-error` (the same
+  event, with the same `"Error: "`-prefixing handler, that transport
+  failures already use) for `status: "error"` responses; `partial`/
+  `cancelled` keep the existing `task-complete` framing since their
+  narratives are already user-facing text, not raw errors.
+
 ### Added
 
 - **`GET /api/agents/:name/kg`, `/kg/subjects`, `/kg/all` and `/kg/count` — a

--- a/crates/trusty-agents/src/service/mod.rs
+++ b/crates/trusty-agents/src/service/mod.rs
@@ -10,11 +10,14 @@
 //!
 //! What: A small struct (`ServiceState`) plus async helpers for
 //! pid-file IO, liveness probing, daemon spawn (detached child with
-//! null stdio), and graceful shutdown via `kill(1)`.
+//! stdin/stdout on `/dev/null` and stderr redirected to a rotating log
+//! file — see `daemon_log_path`, #4111), and graceful shutdown via
+//! `kill(1)`.
 //!
 //! Test: `cargo test --lib service::` covers pid-file roundtrip,
-//! port-default constants, and missing-file behavior. End-to-end
-//! daemon spawn is exercised manually via `trusty-agents --service start`.
+//! port-default constants, missing-file behavior, and log-rotation
+//! behavior. End-to-end daemon spawn is exercised manually via
+//! `trusty-agents --service start`.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -155,16 +158,189 @@ pub async fn is_service_running(port: u16) -> bool {
     health_ok(port).await
 }
 
+/// Directory the daemon's log file lives under: `~/Library/Logs/trusty-agents/`.
+///
+/// Why (#4111): every other trusty-* daemon in this workspace writes to
+/// `~/Library/Logs/<name>/` (e.g. trusty-search's `launchd_log_dir()` in
+/// `crates/trusty-search/src/commands/service.rs`), but trusty-agents isn't
+/// launchd-managed — it self-spawns via `start_service` below rather than
+/// running as a `LaunchAgent` — so it never got a log directory at all.
+/// This gives it the same directory naming convention without requiring
+/// launchd.
+/// What: `dirs::home_dir()` (falling back to `.` if unresolvable, matching
+/// the fallback already used elsewhere in this crate, e.g.
+/// `runtime::startup`'s REPL log path) joined with `Library/Logs/trusty-agents`.
+fn log_dir() -> PathBuf {
+    dirs::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join("Library")
+        .join("Logs")
+        .join("trusty-agents")
+}
+
+/// A short, stable, filesystem-safe discriminator for the CURRENT project —
+/// the SAME identity `pid_file_path()` already uses
+/// (`crate::ctrl::detect_self_project()`, falling back to cwd), hashed down
+/// to a fixed-width hex string so it can live in a flat filename.
+///
+/// Why (code-critic MEDIUM correction on #4111): the first cut of
+/// `daemon_log_path` was keyed on `port` alone. `DEFAULT_SERVICE_PORT` is a
+/// hardcoded `8080` shared by every project, so in the common case (no
+/// explicit `--port` override) every project's daemon still wrote
+/// `daemon-8080.log` — the exact clobbering #4111 was supposed to fix stayed
+/// unresolved, and the doc comment's "matches the per-project pid-file
+/// model" claim was false (the pid file is keyed on project path, this was
+/// keyed on port). Hashing `detect_self_project()`'s result gives the log
+/// path the SAME identity axis the pid file already uses.
+/// What: `DefaultHasher` over the canonicalized project root (or cwd),
+/// formatted as 16 lowercase hex digits. Not cryptographic — collision
+/// resistance for a handful of concurrently-open local projects is all this
+/// needs, and matches the low-stakes, best-effort nature of a log filename.
+/// Test: `project_log_discriminator_differs_by_project`,
+/// `project_log_discriminator_is_deterministic`.
+fn project_log_discriminator() -> String {
+    use std::hash::{Hash, Hasher};
+    let root = crate::ctrl::detect_self_project()
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
+    let canonical = std::fs::canonicalize(&root).unwrap_or(root);
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    canonical.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+/// Full path to the daemon's rotating log file for a given `port`.
+///
+/// Why: Single source of truth for both `start_service` (which opens it
+/// for the child's stderr) and any future `--service logs` / doctor check
+/// that wants to locate it. Scoped by BOTH project (`project_log_discriminator`,
+/// code-critic MEDIUM correction on #4111 — mirrors `pid_file_path()`'s own
+/// per-project identity) AND `port`, so neither two different projects on
+/// the shared default port, nor the same project running two ports at once,
+/// interleave their output into one file or clobber each other's rotation
+/// backup.
+/// What: `<log_dir>/daemon-<project-hash>-<port>.log`.
+/// Test: `daemon_log_path_ends_with_expected_components`,
+/// `daemon_log_path_differs_by_port`,
+/// `project_log_discriminator_is_deterministic`,
+/// `project_log_discriminator_is_16_lowercase_hex_chars`.
+pub fn daemon_log_path(port: u16) -> PathBuf {
+    log_dir().join(format!("daemon-{}-{port}.log", project_log_discriminator()))
+}
+
+/// Size threshold (bytes) at which `rotate_log_if_oversized` moves the
+/// current log out of the way. 10 MiB comfortably covers weeks of `info`-level
+/// daemon output before rotating.
+const ROTATE_AT_BYTES: u64 = 10 * 1024 * 1024;
+
+/// Rotate `path` out of the way if it has grown past `ROTATE_AT_BYTES`.
+///
+/// Why (#4111): `--serve` daemons commonly run for weeks, so a log file
+/// that is never rotated grows unbounded. Every other trusty-* daemon
+/// bounds its `~/Library/Logs/<name>/stderr.log` via a `newsyslog` config
+/// installed alongside its LaunchAgent (see
+/// `crates/trusty-search/src/commands/log_rotation.rs`: `ROTATION_SIZE_KB`
+/// / `ROTATION_KEEP`) — that mechanism can't be reused as-is here because
+/// it depends on launchd owning the file handle (an external tool rotates
+/// the inode; launchd reopens the path on next write). trusty-agents opens
+/// its own log file directly, so a rotate-on-(re)start check achieves a
+/// bounded-growth outcome for this daemon's shape without needing a
+/// LaunchAgent.
+///
+/// IMPORTANT (code-critic MEDIUM correction on #4111): this function is
+/// only called once, at spawn time in `start_service`, NOT periodically
+/// from inside the running daemon. The actual guarantee is therefore
+/// "bounded ACROSS restarts, not within a single run" — a daemon that
+/// stays up for weeks without ever being restarted still grows its log
+/// unbounded until the next `/service start`. A background rotator inside
+/// the running process would close that gap but isn't implemented; if the
+/// unbounded-single-run growth becomes a real problem, that's the fix to
+/// reach for.
+/// What: keeps exactly one previous generation (`daemon-<port>.log.1`,
+/// overwriting any older one) once the current file exceeds
+/// `ROTATE_AT_BYTES`. A file that doesn't exist yet, or any rename I/O
+/// error, is silently ignored — log housekeeping must never block daemon
+/// startup.
+/// Test: `rotate_log_renames_oversized_file`,
+/// `rotate_log_leaves_small_file_alone`.
+fn rotate_log_if_oversized(path: &Path) {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return; // doesn't exist yet — nothing to rotate
+    };
+    if meta.len() < ROTATE_AT_BYTES {
+        return;
+    }
+    let backup = path.with_extension("log.1");
+    let _ = std::fs::rename(path, &backup);
+}
+
+/// Attempt to open the daemon's log file for append, creating its parent
+/// directory and rotating an oversized generation first.
+///
+/// Why (code-critic HIGH-2 on #4111): log setup must never block daemon
+/// startup — the same "must never block startup" principle
+/// `rotate_log_if_oversized` already follows by swallowing its own I/O
+/// errors. An unwritable `~/Library/Logs`, a full disk, or a permissions
+/// problem must not abort the whole daemon spawn: EVERYTHING behind
+/// `start_service` (Concierge, Telegram, Slack) depends on it starting.
+/// Returning `Option` instead of `Result` — and never using `?` — makes
+/// "give up gracefully" the only path available to the caller; there is no
+/// error variant left to accidentally propagate.
+/// What: `None` on ANY failure (parent dir uncreatable, or the file
+/// unopenable) — logged once via `tracing::warn!` so the failure is at
+/// least visible if logging itself is reachable, but never returned as an
+/// error. `Some(file)` on success. The caller (`start_service`) falls back
+/// to `Stdio::null()` on `None` — exactly the pre-#4111 behavior.
+/// Test: `open_daemon_log_file_succeeds_for_writable_path`,
+/// `open_daemon_log_file_returns_none_when_parent_is_blocked_by_a_file`.
+fn open_daemon_log_file(log_path: &Path) -> Option<std::fs::File> {
+    let parent = log_path.parent()?;
+    if let Err(e) = std::fs::create_dir_all(parent) {
+        tracing::warn!(
+            error = %e,
+            dir = %parent.display(),
+            "could not create daemon log dir; daemon will run without a log file"
+        );
+        return None;
+    }
+    rotate_log_if_oversized(log_path);
+    match std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(log_path)
+    {
+        Ok(file) => Some(file),
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                path = %log_path.display(),
+                "could not open daemon log file; daemon will run without a log file"
+            );
+            None
+        }
+    }
+}
+
 /// Spawn `trusty-agents --serve` as a detached child process.
 ///
 /// Why: `/service start` should return immediately while the API
 /// continues serving in the background. Detached stdio + `std::process`
 /// (not tokio) avoids both terminal-control contamination and runtime
 /// re-entry from the REPL's tokio context.
-/// What: Resolves the current binary via `current_exe()`, spawns it
-/// with `--serve --port <port>`, redirects all three stdio streams to
-/// `/dev/null`, persists the pid file, then polls `/api/health` for up
-/// to 3 seconds. Returns the recorded `ServiceState` on success.
+/// What: Resolves the current binary via `current_exe()`, spawns it with
+/// `--serve --port <port>`. stdin/stdout stay redirected to `/dev/null`
+/// (`runtime::startup`'s tracing setup writes to stderr precisely so
+/// stdout stays clean for MCP JSON-RPC framing — nothing in `--serve` mode
+/// needs stdin, and this spawn call must not disturb that contract).
+/// stderr (#4111) is redirected to the rotating file at `daemon_log_path()`
+/// instead of `/dev/null` — the child's own tracing initialization is
+/// unchanged (it already writes to stderr in non-interactive mode; the bug
+/// was purely this spawn call discarding that stream). Log setup
+/// (`open_daemon_log_file`) is best-effort (code-critic HIGH-2 on #4111):
+/// any failure falls back to `Stdio::null()` rather than aborting the
+/// spawn, so an unwritable log directory can never prevent the daemon —
+/// and therefore Concierge/Telegram/Slack — from starting. Persists the
+/// pid file, then polls `/api/health` for up to 3 seconds. Returns the
+/// recorded `ServiceState` on success.
 pub async fn start_service(port: u16) -> Result<ServiceState> {
     if is_service_running(port).await {
         // Idempotent: if the service is already running on this port, treat
@@ -188,6 +364,16 @@ pub async fn start_service(port: u16) -> Result<ServiceState> {
     let exe = std::env::current_exe().context("resolving current executable path")?;
     let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
 
+    // #4111 (best-effort, code-critic HIGH-2): open (and rotate, if
+    // oversized) the daemon's log file BEFORE spawning, so the child
+    // inherits an already-open handle for its stderr. ANY failure here
+    // falls back to `Stdio::null()` — log housekeeping must never prevent
+    // the daemon from starting.
+    let log_path = daemon_log_path(port);
+    let stderr_stdio = open_daemon_log_file(&log_path)
+        .map(Stdio::from)
+        .unwrap_or_else(Stdio::null);
+
     let child = std::process::Command::new(&exe)
         .arg("--serve")
         .arg("--port")
@@ -195,7 +381,7 @@ pub async fn start_service(port: u16) -> Result<ServiceState> {
         .current_dir(&cwd)
         .stdin(Stdio::null())
         .stdout(Stdio::null())
-        .stderr(Stdio::null())
+        .stderr(stderr_stdio)
         .spawn()
         .with_context(|| format!("spawning {} --serve", exe.display()))?;
 
@@ -419,5 +605,123 @@ mod tests {
     async fn health_ok_returns_false_for_unbound_port() {
         // 1 is reserved + nothing should be listening on 1 at user level.
         assert!(!health_ok(1).await);
+    }
+
+    // ---- #4111: daemon log file ----
+
+    #[test]
+    fn daemon_log_path_ends_with_expected_components() {
+        let p = daemon_log_path(8080);
+        let s = p.to_string_lossy();
+        assert!(s.contains("Library/Logs/trusty-agents/daemon-"), "{s}");
+        assert!(s.ends_with("-8080.log"), "{s}");
+    }
+
+    #[test]
+    fn daemon_log_path_differs_by_port() {
+        // code-critic MEDIUM (#4111): two concurrently-running daemons on
+        // different ports must not share a log file (or a rotation backup).
+        assert_ne!(daemon_log_path(8080), daemon_log_path(8081));
+    }
+
+    #[test]
+    fn project_log_discriminator_is_deterministic() {
+        assert_eq!(project_log_discriminator(), project_log_discriminator());
+    }
+
+    #[test]
+    fn project_log_discriminator_is_16_lowercase_hex_chars() {
+        let d = project_log_discriminator();
+        assert_eq!(d.len(), 16, "{d}");
+        assert!(
+            d.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_uppercase()),
+            "{d}"
+        );
+    }
+
+    #[test]
+    fn rotate_log_leaves_small_file_alone() {
+        let dir = std::env::temp_dir().join(format!("ta-log-test-small-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("daemon.log");
+        std::fs::write(&path, b"tiny log line\n").unwrap();
+
+        rotate_log_if_oversized(&path);
+
+        assert!(path.exists(), "small file should not be rotated away");
+        assert!(!path.with_extension("log.1").exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rotate_log_renames_oversized_file() {
+        let dir = std::env::temp_dir().join(format!("ta-log-test-big-{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let path = dir.join("daemon.log");
+        // Write past ROTATE_AT_BYTES so rotation triggers.
+        let oversized = vec![b'x'; (ROTATE_AT_BYTES + 1) as usize];
+        std::fs::write(&path, &oversized).unwrap();
+
+        rotate_log_if_oversized(&path);
+
+        assert!(
+            !path.exists(),
+            "oversized log should have been renamed away"
+        );
+        let backup = path.with_extension("log.1");
+        assert!(backup.exists(), "rotated backup should exist");
+        assert_eq!(
+            std::fs::metadata(&backup).unwrap().len(),
+            oversized.len() as u64
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn rotate_log_missing_file_is_a_noop() {
+        let path = std::env::temp_dir().join(format!(
+            "ta-log-test-missing-{}-daemon.log",
+            std::process::id()
+        ));
+        // Doesn't exist — must not panic, and must not create anything.
+        rotate_log_if_oversized(&path);
+        assert!(!path.exists());
+    }
+
+    // ---- code-critic HIGH-2 (#4111): best-effort log open ----
+
+    #[test]
+    fn open_daemon_log_file_succeeds_for_writable_path() {
+        let dir = std::env::temp_dir().join(format!("ta-log-open-ok-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let path = dir.join("daemon.log");
+
+        let file = open_daemon_log_file(&path);
+
+        assert!(file.is_some(), "expected a file handle for a writable path");
+        assert!(path.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn open_daemon_log_file_returns_none_when_parent_is_blocked_by_a_file() {
+        // Empirically forces `create_dir_all` to fail: a regular file
+        // sitting where a directory component needs to be.
+        let dir = std::env::temp_dir().join(format!("ta-log-open-blocked-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let blocking_file = dir.join("blocking");
+        std::fs::write(&blocking_file, b"not a directory").unwrap();
+        let log_path = blocking_file.join("nested").join("daemon.log");
+
+        let file = open_daemon_log_file(&log_path);
+
+        assert!(
+            file.is_none(),
+            "expected None (never a propagated error) when a path component \
+             is a regular file, not a directory"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/crates/trusty-agents/src/service/mod.rs
+++ b/crates/trusty-agents/src/service/mod.rs
@@ -196,8 +196,8 @@ fn log_dir() -> PathBuf {
 /// formatted as 16 lowercase hex digits. Not cryptographic — collision
 /// resistance for a handful of concurrently-open local projects is all this
 /// needs, and matches the low-stakes, best-effort nature of a log filename.
-/// Test: `project_log_discriminator_differs_by_project`,
-/// `project_log_discriminator_is_deterministic`.
+/// Test: `project_log_discriminator_is_deterministic`,
+/// `project_log_discriminator_is_16_lowercase_hex_chars`.
 fn project_log_discriminator() -> String {
     use std::hash::{Hash, Hasher};
     let root = crate::ctrl::detect_self_project()

--- a/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
+++ b/crates/trusty-agents/ui/src-tauri/src/task_commands.rs
@@ -262,8 +262,7 @@ pub async fn send_message(
             continue;
         }
 
-        // Terminal state. Emit complete (even on error-status responses so
-        // ChatView can display the failure narrative).
+        // Terminal state.
         //
         // #3063: `PmResponse::cancelled()` (crates/trusty-agents/src/api/
         // types.rs) always sets narrative to the fixed string "Task
@@ -275,6 +274,30 @@ pub async fn send_message(
             .and_then(|v| v.as_str())
             .unwrap_or("")
             .to_string();
+
+        // #4320: a `status: "error"` response's narrative is a raw failure
+        // string (e.g. "subprocess exited with status Some(1)", or a
+        // Debug-formatted `anyhow::Error` — see
+        // `crates/trusty-agents/src/api/server/task_runner.rs`'s
+        // `run_task`), not user-facing prose. It must go through the SAME
+        // `task-error` framing this command already uses for the timeout
+        // branch above — ChatView's `task-complete` handler
+        // (`ui/src/components/ChatView.svelte`) renders `narrative` verbatim
+        // as if the assistant said it, while its `task-error` handler
+        // prefixes with "Error: ". `partial`/`cancelled` keep the existing
+        // `task-complete` framing: their narratives are already user-facing
+        // (a cancellation notice, or a best-effort partial result), not raw
+        // error text.
+        if status == "error" {
+            let _ = app.emit(
+                "task-error",
+                ErrorEvent {
+                    task_id: &task_id,
+                    error: &narrative,
+                },
+            );
+            return Err(narrative);
+        }
 
         let _ = app.emit("task-complete", &response);
         return Ok(narrative);

--- a/crates/trusty-agents/ui/src/lib/transport.test.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.test.ts
@@ -1,12 +1,18 @@
-// Unit tests for transport-layer pure helpers (#3745, critic MEDIUM-3).
+// Unit tests for transport-layer pure helpers (#3745, critic MEDIUM-3) and the
+// browser-fallback `send_message` error framing (#4320, code-critic MEDIUM).
 //
 // Why: `pollIntervalMs` drives the browser-fallback task-poll cadence; the
 // 250/500/20 backoff contract (and its 19/20 boundary) must be pinned without
 // standing up a live `tagent --api` sidecar. Kept in lock-step with
 // `poll_interval_ms` in `ui/src-tauri/src/task_commands.rs`.
+//
+// The `send_message` describe block pins the #4320 fix: a `status: "error"`
+// poll response must emit `task-error` (never `task-complete`) and reject —
+// this is the browser/`pnpm dev` twin of the Tauri fix in `task_commands.rs`,
+// and the ONLY narrative-delivery path in that mode.
 
-import { describe, expect, it } from 'vitest';
-import { FAST_POLL_MS, SLOW_POLL_MS, pollIntervalMs } from './transport';
+import { describe, expect, it, vi } from 'vitest';
+import { FAST_POLL_MS, SLOW_POLL_MS, invoke, listenEvent, pollIntervalMs } from './transport';
 
 describe('pollIntervalMs (#3745)', () => {
   it('uses 250ms for the first ~20 polls, then 500ms — incl. the 19/20 boundary', () => {
@@ -26,5 +32,86 @@ describe('pollIntervalMs (#3745)', () => {
   it('exposes the documented constants', () => {
     expect(FAST_POLL_MS).toBe(250);
     expect(SLOW_POLL_MS).toBe(500);
+  });
+});
+
+describe('send_message error framing (#4320 browser fallback)', () => {
+  it('emits task-error (never task-complete) and rejects on a status: "error" poll response', async () => {
+    const seen: Array<{ name: string; detail: unknown }> = [];
+    const unlistenError = await listenEvent('task-error', (p) =>
+      seen.push({ name: 'task-error', detail: p }),
+    );
+    const unlistenComplete = await listenEvent('task-complete', (p) =>
+      seen.push({ name: 'task-complete', detail: p }),
+    );
+
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith('/api/task') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: 'task-1', status: 'running' }), {
+          status: 200,
+        });
+      }
+      // Any subsequent call is the poll — return a raw-failure error status,
+      // mirroring `PmResponse::error`'s narrative shape.
+      return new Response(
+        JSON.stringify({
+          status: 'error',
+          narrative: 'subprocess exited with status Some(1)',
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      invoke('send_message', { content: 'do the thing that fails' }),
+    ).rejects.toThrow('subprocess exited with status Some(1)');
+
+    expect(seen.some((e) => e.name === 'task-error')).toBe(true);
+    expect(seen.some((e) => e.name === 'task-complete')).toBe(false);
+    const errorEvent = seen.find((e) => e.name === 'task-error');
+    expect(errorEvent?.detail).toMatchObject({
+      task_id: 'task-1',
+      error: 'subprocess exited with status Some(1)',
+    });
+
+    unlistenError();
+    unlistenComplete();
+    vi.unstubAllGlobals();
+  });
+
+  it('still emits task-complete for a non-error terminal status (e.g. success)', async () => {
+    const seen: Array<{ name: string; detail: unknown }> = [];
+    const unlistenError = await listenEvent('task-error', (p) =>
+      seen.push({ name: 'task-error', detail: p }),
+    );
+    const unlistenComplete = await listenEvent('task-complete', (p) =>
+      seen.push({ name: 'task-complete', detail: p }),
+    );
+
+    const fetchMock = vi.fn(async (url: unknown, init?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith('/api/task') && init?.method === 'POST') {
+        return new Response(JSON.stringify({ id: 'task-2', status: 'running' }), {
+          status: 200,
+        });
+      }
+      return new Response(
+        JSON.stringify({ status: 'success', narrative: 'All done.' }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await invoke('send_message', { content: 'do the thing that works' });
+
+    expect(result).toBe('All done.');
+    expect(seen.some((e) => e.name === 'task-complete')).toBe(true);
+    expect(seen.some((e) => e.name === 'task-error')).toBe(false);
+
+    unlistenError();
+    unlistenComplete();
+    vi.unstubAllGlobals();
   });
 });

--- a/crates/trusty-agents/ui/src/lib/transport.ts
+++ b/crates/trusty-agents/ui/src/lib/transport.ts
@@ -195,6 +195,21 @@ async function fetchFallback(command: string, args?: Record<string, unknown>): P
           // empty narrative.
           const rawNarrative = typeof resp.narrative === 'string' ? resp.narrative : '';
           const narrative = rawNarrative.length > 0 ? rawNarrative : JSON.stringify(resp);
+          // #4320 (browser-fallback twin of the Tauri `send_message` fix in
+          // `task_commands.rs`): a `status: "error"` response's narrative is
+          // a raw failure string (e.g. "subprocess exited with status
+          // Some(1)"), not user-facing prose. This poll loop is the SOLE
+          // narrative-delivery path in browser/dev mode — `eventBridge.ts`'s
+          // `session_done` deliberately emits nothing and defers here — so
+          // without this branch every failed task rendered its raw error as
+          // if the assistant said it, via the same `task-complete` handler
+          // that skips the "Error: " prefix. Route it through `task-error`
+          // (the same event/prefix the submit- and poll-failure branches
+          // above already use) and reject, instead of resolving.
+          if (resp.status === 'error') {
+            emitWeb('task-error', { task_id: id, error: narrative });
+            throw new Error(narrative);
+          }
           emitWeb('task-complete', {
             id,
             narrative,


### PR DESCRIPTION
## Summary
- **#4111**: trusty-agents daemon now writes rotating log file to `~/Library/Logs/trusty-agents/daemon.log` (scoped by project hash + port to avoid clobbering when concurrent daemons run). Log setup is best-effort; if directory/file can't open, daemon warns and falls back to `Stdio::null()` so startup is never blocked.
- **#4320**: Failed task error handling fixed — task errors now route through the existing `task-error` framing in both Tauri (`task_commands.rs`) and browser/dev-mode paths (`transport.ts`), with test coverage in `transport.test.ts`. Raw Debug-formatted Rust errors are no longer rendered as assistant chat.

Both fixes were split out of a larger branch; the intent classifier fix (#4319) is iterating separately.

Closes #4111
Closes #4320

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools