### PR TITLE
fix(trusty-mpm): tm ls/picker auto-prunes dead records + groups attached-active-stopped

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -51,6 +51,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`tm ls` / bare `tm` picker: auto-prune dead records + attached→active→stopped
+  ordering** (owner request 2026-07-29). Previously a session flagged
+  `unresumable` (its workspace verifiably gone from disk) sat in the picker
+  forever printing `DEAD: workspace removed; use [d<N>] to remove the record`
+  — the operator had to notice the row and type the number manually. The
+  picker's shared fetch path (`fetch_live_sessions`) now auto-decommissions
+  every `unresumable` record through the existing `/decommission` route (the
+  same dirty-worktree-gated teardown path
+  [#4344](https://github.com/bobmatnyc/trusty-tools/pull/4344) hardened —
+  never a raw `fs::remove` or a hand-edited store entry) and prints a one-line
+  `tm: pruned N dead record(s) (workspace gone)` summary. A record whose
+  worktree removal was previously refused because the tree was dirty retains
+  a `workspace_path` that still exists on disk, which means it can never read
+  `unresumable == true` in the first place — such records are structurally
+  excluded from auto-prune, never touched. Separately, `sort_sessions` (shared
+  by the static table and the picker) now groups rows attached → active →
+  everything else ABOVE whichever `recent`/`alpha` secondary order was
+  requested, so an attached or active session never scrolls below a
+  merely-recent stopped one.
 - **`CLAUDE.md` named-section instruction overrides — reader** (epic
   [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183),
   [#4286](https://github.com/bobmatnyc/trusty-tools/issues/4286)): a project can

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -52,24 +52,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - **`tm ls` / bare `tm` picker: auto-prune dead records + attached→active→stopped
-  ordering** (owner request 2026-07-29). Previously a session flagged
-  `unresumable` (its workspace verifiably gone from disk) sat in the picker
-  forever printing `DEAD: workspace removed; use [d<N>] to remove the record`
-  — the operator had to notice the row and type the number manually. The
-  picker's shared fetch path (`fetch_live_sessions`) now auto-decommissions
-  every `unresumable` record through the existing `/decommission` route (the
-  same dirty-worktree-gated teardown path
-  [#4344](https://github.com/bobmatnyc/trusty-tools/pull/4344) hardened —
-  never a raw `fs::remove` or a hand-edited store entry) and prints a one-line
-  `tm: pruned N dead record(s) (workspace gone)` summary. A record whose
-  worktree removal was previously refused because the tree was dirty retains
-  a `workspace_path` that still exists on disk, which means it can never read
-  `unresumable == true` in the first place — such records are structurally
-  excluded from auto-prune, never touched. Separately, `sort_sessions` (shared
-  by the static table and the picker) now groups rows attached → active →
-  everything else ABOVE whichever `recent`/`alpha` secondary order was
-  requested, so an attached or active session never scrolls below a
-  merely-recent stopped one.
+  ordering** (owner request 2026-07-29; hardened per code-critic WARN on
+  PR [#4384](https://github.com/bobmatnyc/trusty-tools/pull/4384)). Previously
+  a session flagged `unresumable` (its workspace verifiably gone from disk)
+  sat in the picker forever printing `DEAD: workspace removed; use [d<N>] to
+  remove the record` — the operator had to notice the row and type the number
+  manually. The picker's shared fetch path (`fetch_live_sessions`) now
+  auto-prunes `unresumable` records, hardened three ways after adversarial
+  review:
+  - **Record-only removal.** The auto-prune sweep POSTs the existing
+    `/decommission` route with `?record_only=true`, routing to the new
+    `SessionManager::decommission_record_only` — the removal branches are
+    skipped ENTIRELY, so the sweep can never delete filesystem content even
+    if a remounted volume brought a workspace back between the listing-time
+    probe and the decommission call. Manual `[d<N>]` keeps today's full
+    teardown behavior.
+  - **Two-sightings confirmation + a per-call cap.** A record is only
+    decommissioned once its `unresumable` flag has been observed on TWO
+    separate listings (tracked via a small persisted marker file under
+    `~/.trusty-mpm/`), and at most 5 confirmed records are decommissioned per
+    call — the rest are reported as "N more dead records pending
+    confirmation." A bad-mount day can no longer mass-tombstone an entire
+    fleet in one `tm ls`.
+  - **TTY gate.** `guided.rs`'s bare-`tm` picker now computes its
+    interactive/non-interactive decision BEFORE fetching sessions and passes
+    it through as `fetch_live_sessions`'s new `allow_auto_prune` parameter —
+    a scripted/piped/CI invocation of bare `tm` is now a pure read, exactly
+    like `tm ls`'s existing TTY gate.
+
+  A record whose worktree removal was previously refused because the tree
+  was dirty ([#4344](https://github.com/bobmatnyc/trusty-tools/pull/4344))
+  retains a `workspace_path` that still exists on disk, which means it can
+  never read `unresumable == true` in the first place — such records are
+  structurally excluded from auto-prune, never touched. Separately,
+  `sort_sessions` (shared by the static table and the picker) now groups rows
+  attached → active → everything else ABOVE whichever `recent`/`alpha`
+  secondary order was requested, so an attached or active session never
+  scrolls below a merely-recent stopped one.
 - **`CLAUDE.md` named-section instruction overrides — reader** (epic
   [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183),
   [#4286](https://github.com/bobmatnyc/trusty-tools/issues/4286)): a project can

--- a/crates/trusty-mpm/src/bin/tm/commands/guided.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided.rs
@@ -363,11 +363,24 @@ async fn try_show_picker(
     repo_url: &str,
     cwd: &std::path::Path,
 ) -> Option<anyhow::Result<()>> {
+    // Critic HIGH finding #3 (PR #4384 review): this TTY check must be
+    // computed BEFORE the fetch below, not only at the `tty_gate` call after
+    // it — a scripted/piped/non-interactive bare `tm` invocation (cron,
+    // healthcheck, CI step) must never trigger the destructive auto-prune
+    // sweep `fetch_live_sessions` can run. Mirrors `run_ls_connector`'s own
+    // `stdin_tty && stdout_tty` gate (`session_picker.rs`).
+    let interactive = std::io::stdin().is_terminal() && std::io::stdout().is_terminal();
     // #1809: exclude decommissioned tombstones from the picker by default. The
     // shared fetch path returns the same live-only list the static renderer uses.
-    let sessions = super::session_picker::fetch_live_sessions(client, url, Some(source_id), false)
-        .await
-        .ok()?;
+    let sessions = super::session_picker::fetch_live_sessions(
+        client,
+        url,
+        Some(source_id),
+        false,
+        interactive,
+    )
+    .await
+    .ok()?;
     if !tty_gate(
         std::io::stdin().is_terminal(),
         source_id,

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -58,6 +58,7 @@ pub(crate) mod services;
 pub(crate) mod sessctl;
 pub(crate) mod session;
 pub(crate) mod session_picker;
+pub(crate) mod session_picker_prune;
 pub(crate) mod session_picker_rename;
 pub(crate) mod session_picker_render;
 pub(crate) mod slack;

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -426,14 +426,19 @@ fn recency_key(s: &ManagedSessionSummary) -> &str {
 /// Why: the interactive picker (both call sites) needs the deserialized, filtered
 /// session list; combining the GET and the parse keeps re-fetch-after-detach a
 /// single call and guarantees identical scoping to the static list.
-/// What: [`fetch_managed_raw`] then [`parse_scoped_sessions`], then
+/// What: [`fetch_managed_raw`] then [`parse_scoped_sessions`], then — ONLY
+/// when `allow_auto_prune` is `true` —
 /// [`super::session_picker_prune::auto_prune_dead_records`] (owner request
-/// 2026-07-29) — every session the daemon flags `unresumable` (workspace
-/// verifiably gone) is torn down automatically instead of sitting in the list
-/// forever printing "use [d<N>] to remove the record". The picker always
-/// requests live-only (`all = false`) — a decommissioned tombstone is never a
-/// resume target, and is never `unresumable` either (see that function's
-/// doc), so auto-pruning runs unconditionally here regardless of `all`.
+/// 2026-07-29): every session the daemon flags `unresumable` (workspace
+/// verifiably gone) on TWO consecutive listings is torn down automatically
+/// (capped per call), instead of sitting in the list forever printing "use
+/// [d<N>] to remove the record". `allow_auto_prune` exists because auto-prune
+/// is destructive-adjacent — every call site MUST explicitly decide (critic
+/// HIGH finding #3): pass `true` only when the listing is genuinely
+/// interactive (a real TTY), never for a scripted/piped/non-interactive
+/// invocation. When `false`, this is a pure read: the raw parsed list is
+/// returned unchanged, no marker file is touched, no HTTP call beyond the
+/// initial GET is made.
 /// Test: HTTP path in `tests/session_manager_mvp.rs`; the parse/filter seam is
 /// unit-tested via `parse_scoped_sessions`; the auto-prune seam by
 /// `auto_prune_dead_records_*` in `tests_behavior_d_tests.rs`.
@@ -442,18 +447,29 @@ pub(crate) async fn fetch_live_sessions(
     url: &str,
     source_id: Option<&str>,
     all: bool,
+    allow_auto_prune: bool,
 ) -> anyhow::Result<Vec<ManagedSessionSummary>> {
     let raw = fetch_managed_raw(client, url, source_id).await?;
     let sessions = parse_scoped_sessions(&raw, all)?;
-    let (sessions, pruned) =
-        super::session_picker_prune::auto_prune_dead_records(client, url, sessions).await;
-    if pruned > 0 {
+    if !allow_auto_prune {
+        return Ok(sessions);
+    }
+    let outcome = super::session_picker_prune::auto_prune_dead_records(client, url, sessions).await;
+    if outcome.pruned > 0 {
         eprintln!(
-            "tm: pruned {pruned} dead record{} (workspace gone)",
-            if pruned == 1 { "" } else { "s" }
+            "tm: pruned {} dead record{} (workspace gone)",
+            outcome.pruned,
+            if outcome.pruned == 1 { "" } else { "s" }
         );
     }
-    Ok(sessions)
+    if outcome.pending > 0 {
+        eprintln!(
+            "tm: {} more dead record{} pending confirmation",
+            outcome.pending,
+            if outcome.pending == 1 { "" } else { "s" }
+        );
+    }
+    Ok(outcome.kept)
 }
 
 /// Find the 0-based position in `sessions` whose stable `slot` equals `n`
@@ -1003,7 +1019,11 @@ pub(crate) async fn run_tty_picker(
         // #1809: the shared fetch path applies the same live-only tombstone filter.
         // Issue TBD: re-apply the scope's filter/sort so the redisplayed menu
         // never drifts from the one the operator picked against.
-        sessions = fetch_live_sessions(client, url, scope.source_id.as_deref(), false).await?;
+        // `allow_auto_prune = true`: this loop only ever runs once the picker
+        // is ALREADY confirmed interactive (see `should_show_picker`/`tty_gate`
+        // at the call sites that reach here) — every re-fetch stays interactive.
+        sessions =
+            fetch_live_sessions(client, url, scope.source_id.as_deref(), false, true).await?;
         sessions = filter_sessions_by_term(sessions, scope.term.as_deref());
         sort_sessions(&mut sessions, scope.sort);
     }
@@ -1082,7 +1102,9 @@ pub(crate) async fn run_ls_connector(
     // Interactive stream: fetch the live sessions once. On any fetch error
     // (daemon unreachable, HTTP failure) fall back to the static renderer so the
     // operator sees the same actionable error rather than a bare picker crash.
-    let sessions = match fetch_live_sessions(client, url, sid.as_deref(), false).await {
+    // `allow_auto_prune = true`: `stdin_tty && stdout_tty` was just confirmed
+    // by the pre-gate above (critic HIGH finding #3).
+    let sessions = match fetch_live_sessions(client, url, sid.as_deref(), false, true).await {
         Ok(s) => s,
         Err(_) => {
             return super::managed::session_ls(

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker.rs
@@ -343,24 +343,60 @@ fn session_matches_term(s: &ManagedSessionSummary, needle_lower: &str) -> bool {
     .any(|field| field.to_lowercase().contains(needle_lower))
 }
 
-/// Sort `sessions` in place per [`SessionSortArg`] (#3483).
+/// The attached→active→everything-else group a session belongs in (owner
+/// request 2026-07-29).
+///
+/// Why: Bob's ask — the listing should group attached sessions first, then
+/// active ones, then the rest (stopped/errored/provisioning/etc.) — ABOVE
+/// whatever `recent`/`alpha` secondary order the operator picked, so a
+/// session they're actively connected to never scrolls below a merely-recent
+/// stopped one.
+/// What: `0` when `s.attached` (a client is connected RIGHT NOW — the
+/// strongest signal, mirrors [`session_picker_render::state_color`]'s own
+/// precedence); `1` for `state == "active"` (not attached); `2` for every
+/// other state. Lower sorts first.
+/// Test: `sort_sessions_recent_groups_attached_before_active_before_stopped`,
+/// `sort_sessions_alpha_groups_attached_before_active_before_stopped`.
+fn group_rank(s: &ManagedSessionSummary) -> u8 {
+    if s.attached {
+        0
+    } else if s.state == "active" {
+        1
+    } else {
+        2
+    }
+}
+
+/// Sort `sessions` in place per [`SessionSortArg`] (#3483), grouped
+/// attached→active→everything-else (owner request 2026-07-29).
 ///
 /// Why: shared by the static table (`tm ls` / `tm sessions ls`) and the
 /// interactive picker so both views order sessions identically.
-/// What: `Recent` sorts descending by [`recency_key`] (most recent first);
-/// `Alpha` sorts ascending, case-insensitively, by `name`. Both use the
-/// stable `sort_by`, so equal keys preserve the daemon's original relative
-/// order.
+/// What: primary key is [`group_rank`] (attached, then active, then the
+/// rest); within each group, `Recent` sorts descending by [`recency_key`]
+/// (most recent first) and `Alpha` sorts ascending, case-insensitively, by
+/// `name`. Both use the stable `sort_by`, so equal keys preserve the
+/// daemon's original relative order.
 /// Test: `sort_sessions_recent_orders_by_last_activity`,
 /// `sort_sessions_recent_falls_back_to_created_at`,
-/// `sort_sessions_alpha_orders_by_name_case_insensitive`.
+/// `sort_sessions_alpha_orders_by_name_case_insensitive`,
+/// `sort_sessions_recent_groups_attached_before_active_before_stopped`,
+/// `sort_sessions_alpha_groups_attached_before_active_before_stopped`.
 pub(crate) fn sort_sessions(sessions: &mut [ManagedSessionSummary], sort: SessionSortArg) {
     match sort {
         SessionSortArg::Recent => {
-            sessions.sort_by(|a, b| recency_key(b).cmp(recency_key(a)));
+            sessions.sort_by(|a, b| {
+                group_rank(a)
+                    .cmp(&group_rank(b))
+                    .then_with(|| recency_key(b).cmp(recency_key(a)))
+            });
         }
         SessionSortArg::Alpha => {
-            sessions.sort_by_key(|s| s.name.to_lowercase());
+            sessions.sort_by(|a, b| {
+                group_rank(a)
+                    .cmp(&group_rank(b))
+                    .then_with(|| a.name.to_lowercase().cmp(&b.name.to_lowercase()))
+            });
         }
     }
 }
@@ -390,11 +426,17 @@ fn recency_key(s: &ManagedSessionSummary) -> &str {
 /// Why: the interactive picker (both call sites) needs the deserialized, filtered
 /// session list; combining the GET and the parse keeps re-fetch-after-detach a
 /// single call and guarantees identical scoping to the static list.
-/// What: [`fetch_managed_raw`] then [`parse_scoped_sessions`]. The picker always
+/// What: [`fetch_managed_raw`] then [`parse_scoped_sessions`], then
+/// [`super::session_picker_prune::auto_prune_dead_records`] (owner request
+/// 2026-07-29) — every session the daemon flags `unresumable` (workspace
+/// verifiably gone) is torn down automatically instead of sitting in the list
+/// forever printing "use [d<N>] to remove the record". The picker always
 /// requests live-only (`all = false`) — a decommissioned tombstone is never a
-/// resume target.
+/// resume target, and is never `unresumable` either (see that function's
+/// doc), so auto-pruning runs unconditionally here regardless of `all`.
 /// Test: HTTP path in `tests/session_manager_mvp.rs`; the parse/filter seam is
-/// unit-tested via `parse_scoped_sessions`.
+/// unit-tested via `parse_scoped_sessions`; the auto-prune seam by
+/// `auto_prune_dead_records_*` in `tests_behavior_d_tests.rs`.
 pub(crate) async fn fetch_live_sessions(
     client: &reqwest::Client,
     url: &str,
@@ -402,7 +444,16 @@ pub(crate) async fn fetch_live_sessions(
     all: bool,
 ) -> anyhow::Result<Vec<ManagedSessionSummary>> {
     let raw = fetch_managed_raw(client, url, source_id).await?;
-    parse_scoped_sessions(&raw, all)
+    let sessions = parse_scoped_sessions(&raw, all)?;
+    let (sessions, pruned) =
+        super::session_picker_prune::auto_prune_dead_records(client, url, sessions).await;
+    if pruned > 0 {
+        eprintln!(
+            "tm: pruned {pruned} dead record{} (workspace gone)",
+            if pruned == 1 { "" } else { "s" }
+        );
+    }
+    Ok(sessions)
 }
 
 /// Find the 0-based position in `sessions` whose stable `slot` equals `n`

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
@@ -1,5 +1,6 @@
 //! Auto-prune definitively-dead (`unresumable`) managed-session records at
-//! listing time (owner request 2026-07-29).
+//! listing time (owner request 2026-07-29; hardened per code-critic WARN,
+//! PR #4384 review).
 //!
 //! Why: extracted out of `session_picker.rs` (which sits at the 500-SLOC
 //! production cap, mirroring why `session_picker_render.rs`/
@@ -9,26 +10,109 @@
 //! [d<N>] to remove the record` — the operator had to notice the row and type
 //! the number themselves, every time.
 //!
-//! What: [`auto_prune_dead_records`] is the pure-ish partition+drive seam
-//! (unit-testable up to its one I/O primitive); [`decommission_dead_record`]
-//! is that primitive — a best-effort POST to the existing `/decommission`
-//! route (the SAME dirty-worktree-gated teardown path #4344, `114de333`,
-//! hardened), never a raw `fs::remove` or a hand-edited store entry.
+//! The critic's WARN identified this feature's first cut as converting an
+//! advisory flag into an unconditional, unconfirmed, uncapped destructive
+//! action. Three independent hardenings close that gap:
+//!   1. **Record-only removal** — [`decommission_dead_record`] calls the
+//!      `/decommission` route with `record_only=true`
+//!      (`SessionManager::decommission_record_only`), which never touches
+//!      the filesystem. A remount between the listing-time probe and this
+//!      call can never lose data, because nothing is ever deleted here.
+//!   2. **Two-sightings confirmation** — [`auto_prune_dead_records_at`] only
+//!      acts on a session id whose `unresumable` flag was ALSO seen on a
+//!      strictly earlier call, tracked via a small persisted marker file
+//!      ([`load_seen`]/[`save_seen`]). A single-shot blip (one bad listing)
+//!      never triggers a prune.
+//!   3. **Per-call cap** — at most [`AUTO_PRUNE_CAP`] confirmed records are
+//!      decommissioned per call; the rest are reported as "pending
+//!      confirmation" rather than acted on. A bad-mount day cannot
+//!      mass-tombstone an entire fleet in one `tm ls`.
 //!
-//! Test: `auto_prune_dead_records_removes_unresumable_records`,
+//! What: [`auto_prune_dead_records`] is the production entry point (resolves
+//! the marker file under `~/.trusty-mpm`); [`auto_prune_dead_records_at`] is
+//! the testable core (explicit marker-file path); [`AutoPruneOutcome`] is the
+//! three-part result (`kept`, `pruned`, `pending`) `fetch_live_sessions`
+//! reports to the operator.
+//!
+//! Test: `auto_prune_dead_records_removes_confirmed_unresumable_records`,
+//! `auto_prune_dead_records_first_sighting_is_not_pruned`,
 //! `auto_prune_dead_records_keeps_workspace_present_records`,
-//! `auto_prune_dead_records_is_noop_when_nothing_is_dead` in
-//! `tests_behavior_d_tests.rs`.
+//! `auto_prune_dead_records_is_noop_when_nothing_is_dead`,
+//! `auto_prune_dead_records_honors_the_cap` in `tests_behavior_d_tests.rs`;
+//! the record-only server-side guarantee is pinned by
+//! `decommission_record_only_never_removes_existing_workspace`
+//! (`session_manager::tests`).
+
+use std::collections::HashMap;
+use std::path::Path;
 
 use trusty_mpm::client::ManagedSessionSummary;
 
+/// Maximum number of CONFIRMED dead records one call may decommission (critic
+/// HIGH finding #1, owner request 2026-07-29).
+///
+/// Why: "a bad-mount day must not mass-tombstone every session in one `tm
+/// ls`" — even a session flagged dead on two consecutive listings might all
+/// share one now-unmounted volume. Capping bounds the blast radius of any
+/// single call regardless of how many records are confirmed-eligible.
+const AUTO_PRUNE_CAP: usize = 5;
+
+/// Basename of the two-sightings confirmation marker file, under the
+/// framework root (`~/.trusty-mpm/` by default).
+const SEEN_MARKER_FILENAME: &str = "auto-prune-seen.json";
+
+/// Result of one [`auto_prune_dead_records`] / [`auto_prune_dead_records_at`]
+/// call.
+///
+/// Why: the caller (`fetch_live_sessions`) needs three independent numbers to
+/// report honestly — what it removed, what it left alone because a
+/// confirmation window or the cap wasn't met, and the surviving list to
+/// render — rather than collapsing them into a single count.
+pub(crate) struct AutoPruneOutcome {
+    /// Every session NOT successfully decommissioned this call — healthy
+    /// sessions, first-sightings awaiting confirmation, confirmed sessions
+    /// over the cap, and any record whose decommission attempt failed.
+    pub(crate) kept: Vec<ManagedSessionSummary>,
+    /// Count of records actually decommissioned this call (never more than
+    /// [`AUTO_PRUNE_CAP`]).
+    pub(crate) pruned: usize,
+    /// Count of `unresumable` records NOT acted on this call — either a
+    /// first sighting (not yet confirmed) or confirmed-but-over-the-cap.
+    pub(crate) pending: usize,
+}
+
+/// Production entry point: resolve the confirmation marker file under the
+/// default framework root and delegate to [`auto_prune_dead_records_at`].
+///
+/// Why: the framework root (`~/.trusty-mpm`) is where every other piece of
+/// `tm`'s per-user state already lives (`FrameworkPaths::default`);
+/// resolving it here (rather than inside the testable core) keeps the core
+/// injectable for tests without touching the real home directory.
+/// What: `FrameworkPaths::default().root` joined with
+/// [`SEEN_MARKER_FILENAME`].
+/// Test: covered transitively by every `fetch_live_sessions` call site; the
+/// decision logic itself is tested via [`auto_prune_dead_records_at`]
+/// directly.
+pub(crate) async fn auto_prune_dead_records(
+    client: &reqwest::Client,
+    url: &str,
+    sessions: Vec<ManagedSessionSummary>,
+) -> AutoPruneOutcome {
+    let marker_path = trusty_mpm::core::paths::FrameworkPaths::default()
+        .root
+        .join(SEEN_MARKER_FILENAME);
+    auto_prune_dead_records_at(client, url, sessions, &marker_path).await
+}
+
 /// Auto-prune definitively-dead (`unresumable`) session records at listing
-/// time (owner request 2026-07-29).
+/// time — the testable core (owner request 2026-07-29).
 ///
 /// Why: before this, an operator had to notice the `DEAD: workspace removed`
 /// row and manually type `d<N>` for every session whose workspace had been
 /// GC-pruned out from under it — Bob's ask was for the picker to just clean
-/// these up on its own.
+/// these up on its own. The critic's WARN required this to never be a
+/// single-observation, uncapped, disk-mutating action — see the module doc's
+/// three hardenings.
 ///
 /// SAFETY BOUNDARY (#4344, `114de333`): a record whose worktree removal was
 /// previously REFUSED because the tree was dirty keeps its `workspace_path`
@@ -37,54 +121,144 @@ use trusty_mpm::client::ManagedSessionSummary;
 /// path with `tokio::fs::try_exists` and returns `false` the instant ANY
 /// candidate (`last_cwd`/`workspace_path`/`cwd`) is found present — so a
 /// dirty-retained record can never read `unresumable == true` in the first
-/// place. This function's partition below is therefore sufficient on its own
-/// to keep such a record out of scope; no additional workspace-existence
-/// check is needed here.
-/// What: partitions `sessions` into `(keep, dead)` by `s.unresumable`; for
-/// each `dead` record, POSTs the existing `/decommission` route (the SAME
-/// dirty-worktree-gated teardown path #4344 hardened — never a raw
-/// `fs::remove` or a hand-edited store entry) via
-/// [`decommission_dead_record`]. Returns the `keep` list with every
-/// SUCCESSFULLY-decommissioned record dropped, plus the count actually
-/// removed. A record whose decommission attempt fails (network error,
-/// already gone, etc.) is kept in the returned list — best-effort, and it
-/// still carries its manual `[d<N>]` remedy rather than silently vanishing
-/// from the operator's view without ever having been removed.
-/// Test: `auto_prune_dead_records_removes_unresumable_records`,
+/// place, and never enters this function's `dead` partition at all.
+///
+/// What: partitions `sessions` into `(keep, dead)` by `s.unresumable`. Any
+/// `keep` session that still has a confirmation-marker entry has recovered
+/// (its workspace reappeared) — that entry is dropped so a later
+/// re-appearance starts a fresh confirmation window. Each `dead` record is
+/// then classified against the persisted marker file ([`load_seen`]): a
+/// fresh id is recorded as a first sighting (NOT acted on this call); an id
+/// already present (seen on a STRICTLY earlier call) is CONFIRMED-eligible.
+/// At most [`AUTO_PRUNE_CAP`] confirmed records are decommissioned via
+/// [`decommission_dead_record`] — the record-only route, never a raw
+/// `fs::remove` or a hand-edited store entry. Everything else (healthy,
+/// first-sighting, over-cap, or a failed decommission attempt) is returned
+/// in `kept`. The marker file is persisted only when it actually changed.
+/// Test: `auto_prune_dead_records_removes_confirmed_unresumable_records`,
+/// `auto_prune_dead_records_first_sighting_is_not_pruned`,
 /// `auto_prune_dead_records_keeps_workspace_present_records`,
-/// `auto_prune_dead_records_is_noop_when_nothing_is_dead`.
-pub(crate) async fn auto_prune_dead_records(
+/// `auto_prune_dead_records_is_noop_when_nothing_is_dead`,
+/// `auto_prune_dead_records_honors_the_cap`.
+pub(crate) async fn auto_prune_dead_records_at(
     client: &reqwest::Client,
     url: &str,
     sessions: Vec<ManagedSessionSummary>,
-) -> (Vec<ManagedSessionSummary>, usize) {
+    marker_path: &Path,
+) -> AutoPruneOutcome {
     let (dead, mut kept): (Vec<_>, Vec<_>) = sessions.into_iter().partition(|s| s.unresumable);
-    if dead.is_empty() {
-        return (kept, 0);
+
+    let mut seen = load_seen(marker_path);
+    let mut changed = false;
+
+    // A session that surfaced HEALTHY this call has recovered — clear any
+    // stale marker so a later re-appearance of unresumable starts fresh.
+    for s in &kept {
+        if seen.remove(&s.id).is_some() {
+            changed = true;
+        }
     }
-    let mut pruned = 0usize;
+
+    if dead.is_empty() {
+        if changed {
+            save_seen(marker_path, &seen);
+        }
+        return AutoPruneOutcome {
+            kept,
+            pruned: 0,
+            pending: 0,
+        };
+    }
+
+    let now = chrono::Utc::now().to_rfc3339();
+    let mut confirmed = Vec::new();
+    let mut first_sighting = Vec::new();
     for s in dead {
+        if seen.contains_key(&s.id) {
+            confirmed.push(s);
+        } else {
+            seen.insert(s.id.clone(), now.clone());
+            changed = true;
+            first_sighting.push(s);
+        }
+    }
+
+    let cap = AUTO_PRUNE_CAP.min(confirmed.len());
+    let to_prune: Vec<_> = confirmed.drain(..cap).collect();
+
+    let mut pruned = 0usize;
+    for s in to_prune {
         if decommission_dead_record(client, url, &s.id).await {
             pruned += 1;
+            seen.remove(&s.id);
+            changed = true;
         } else {
             kept.push(s);
         }
     }
-    (kept, pruned)
+
+    let pending = confirmed.len() + first_sighting.len();
+    kept.extend(confirmed);
+    kept.extend(first_sighting);
+
+    if changed {
+        save_seen(marker_path, &seen);
+    }
+
+    AutoPruneOutcome {
+        kept,
+        pruned,
+        pending,
+    }
 }
 
-/// POST the existing `/decommission` route for one dead record, best-effort.
+/// Load the persisted first-sighting map, tolerating a missing or corrupt
+/// file (treated as empty — a listing must never fail merely because its
+/// confirmation marker couldn't be read).
 ///
-/// Why: kept as the single I/O primitive behind [`auto_prune_dead_records`] so
-/// a per-record transport/HTTP failure can never abort the rest of the
+/// What: `{ "<session-id>": "<rfc3339 first-sighting timestamp>" }`.
+fn load_seen(path: &Path) -> HashMap<String, String> {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|raw| serde_json::from_str(&raw).ok())
+        .unwrap_or_default()
+}
+
+/// Best-effort persist of the first-sighting map; a write failure is logged
+/// to stderr and never propagated (the listing must never fail merely
+/// because the marker file couldn't be written).
+fn save_seen(path: &Path, seen: &HashMap<String, String>) {
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    match serde_json::to_string(seen) {
+        Ok(json) => {
+            if let Err(e) = std::fs::write(path, json) {
+                eprintln!("tm: auto-prune: failed to persist confirmation marker: {e}");
+            }
+        }
+        Err(e) => eprintln!("tm: auto-prune: failed to serialize confirmation marker: {e}"),
+    }
+}
+
+/// POST the existing `/decommission` route in RECORD-ONLY mode for one
+/// confirmed-dead record, best-effort (critic HIGH finding #1).
+///
+/// Why: kept as the single I/O primitive behind [`auto_prune_dead_records_at`]
+/// so a per-record transport/HTTP failure can never abort the rest of the
 /// listing — one stuck record must not hide every other session behind it.
-/// What: returns `true` only on a 2xx response; any other status or a
-/// transport error is logged to stderr and returns `false`.
-/// Test: `auto_prune_dead_records_removes_unresumable_records` drives this
-/// through a real loopback daemon.
+/// What: POSTs `?record_only=true`, which routes the daemon to
+/// `SessionManager::decommission_record_only` — the removal branches are
+/// skipped entirely, so this call can never delete filesystem content even
+/// if the workspace has reappeared since the listing-time probe. Returns
+/// `true` only on a 2xx response; any other status or a transport error is
+/// logged to stderr and returns `false`.
+/// Test: `auto_prune_dead_records_removes_confirmed_unresumable_records`
+/// drives this through a real loopback daemon.
 async fn decommission_dead_record(client: &reqwest::Client, url: &str, id: &str) -> bool {
     match client
         .post(format!("{url}/api/v1/sessions/managed/{id}/decommission"))
+        .query(&[("record_only", "true")])
         .send()
         .await
     {

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
@@ -10,9 +10,10 @@
 //! [d<N>] to remove the record` — the operator had to notice the row and type
 //! the number themselves, every time.
 //!
-//! The critic's WARN identified this feature's first cut as converting an
-//! advisory flag into an unconditional, unconfirmed, uncapped destructive
-//! action. Three independent hardenings close that gap:
+//! The critic's WARN (then BLOCK on re-review) identified this feature's
+//! first cut as converting an advisory flag into an unconditional,
+//! unconfirmed, uncapped, unverified destructive action. Four independent
+//! hardenings close that gap:
 //!   1. **Record-only removal** — [`decommission_dead_record`] calls the
 //!      `/decommission` route with `record_only=true`
 //!      (`SessionManager::decommission_record_only`), which never touches
@@ -27,6 +28,17 @@
 //!      decommissioned per call; the rest are reported as "pending
 //!      confirmation" rather than acted on. A bad-mount day cannot
 //!      mass-tombstone an entire fleet in one `tm ls`.
+//!   4. **Response-body verification (a daemon/client version-skew guard)**
+//!      — `record_only=true` alone is not proof of safety: a daemon process
+//!      still running a build older than this fix has no
+//!      `Query<DecommissionQuery>` extractor on the route at all, silently
+//!      ignores the param (axum drops query params a handler doesn't
+//!      declare), and falls through to the OLD unconditional full-teardown
+//!      path — which ALSO returns 200. [`decommission_dead_record`] parses
+//!      the response body and requires `workspace_removed == false` before
+//!      counting a call as safe; anything else trips
+//!      [`STALE_DAEMON_MARKER_KEY`], which disables further auto-prune
+//!      attempts for the rest of this invocation.
 //!
 //! What: [`auto_prune_dead_records`] is the production entry point (resolves
 //! the marker file under `~/.trusty-mpm`); [`auto_prune_dead_records_at`] is
@@ -38,9 +50,10 @@
 //! `auto_prune_dead_records_first_sighting_is_not_pruned`,
 //! `auto_prune_dead_records_keeps_workspace_present_records`,
 //! `auto_prune_dead_records_is_noop_when_nothing_is_dead`,
-//! `auto_prune_dead_records_honors_the_cap` in `tests_behavior_d_tests.rs`;
-//! the record-only server-side guarantee is pinned by
-//! `decommission_record_only_never_removes_existing_workspace`
+//! `auto_prune_dead_records_honors_the_cap`,
+//! `auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed`
+//! in `tests_behavior_d_tests.rs`; the record-only server-side guarantee is
+//! pinned by `decommission_record_only_never_removes_existing_workspace`
 //! (`session_manager::tests`).
 
 use std::collections::HashMap;
@@ -60,6 +73,32 @@ const AUTO_PRUNE_CAP: usize = 5;
 /// Basename of the two-sightings confirmation marker file, under the
 /// framework root (`~/.trusty-mpm/` by default).
 const SEEN_MARKER_FILENAME: &str = "auto-prune-seen.json";
+
+/// Reserved key inside the marker file recording "a stale daemon already
+/// proved it ignores `record_only`" (critic CRITICAL finding, 2026-07-30
+/// re-review of PR #4384).
+///
+/// Why: `?record_only=true` is read by a `Query<DecommissionQuery>`
+/// extractor this feature ADDS to the `/decommission` handler. Axum silently
+/// drops a query param a handler doesn't declare — a daemon process still
+/// running a build older than this fix has no such extractor and falls
+/// through to the OLD unconditional full-teardown `decommission()` for EVERY
+/// auto-prune call, regardless of the query string sent. The HTTP status
+/// alone cannot distinguish that from a genuine record-only success (both
+/// return 200) — only the response body's `workspace_removed` field can
+/// (see [`decommission_dead_record`]). Once that's observed, auto-prune must
+/// stay off for the rest of THIS invocation — the daemon does not un-stale
+/// itself mid-process, and the picker's own re-fetch loop calls
+/// [`auto_prune_dead_records_at`] repeatedly within one process. Storing this
+/// in the SAME marker file (rather than process-global state) keeps the
+/// behavior scoped to `marker_path` — exactly like every other piece of
+/// state this module tracks — so tests using distinct tempdir paths can
+/// never bleed into each other despite `cargo test` running many tests in
+/// one process.
+/// What: an unlikely-to-collide sentinel key (real session ids are UUIDs);
+/// its value is the RFC 3339 timestamp of first detection, for debugging.
+/// Test: `auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed`.
+const STALE_DAEMON_MARKER_KEY: &str = "__stale_daemon_detected__";
 
 /// Result of one [`auto_prune_dead_records`] / [`auto_prune_dead_records_at`]
 /// call.
@@ -186,15 +225,46 @@ pub(crate) async fn auto_prune_dead_records_at(
     let cap = AUTO_PRUNE_CAP.min(confirmed.len());
     let to_prune: Vec<_> = confirmed.drain(..cap).collect();
 
+    // Critic CRITICAL (2026-07-30): a daemon that already proved it ignores
+    // `record_only` (ANY earlier call this invocation) must never be asked
+    // to decommission again — see `STALE_DAEMON_MARKER_KEY`'s doc.
+    let already_stale_daemon = seen.contains_key(STALE_DAEMON_MARKER_KEY);
+    let mut newly_stale_daemon = false;
     let mut pruned = 0usize;
-    for s in to_prune {
-        if decommission_dead_record(client, url, &s.id).await {
-            pruned += 1;
-            seen.remove(&s.id);
-            changed = true;
-        } else {
-            kept.push(s);
+
+    if already_stale_daemon {
+        kept.extend(to_prune);
+    } else {
+        let mut iter = to_prune.into_iter();
+        for s in iter.by_ref() {
+            match decommission_dead_record(client, url, &s.id).await {
+                DecommissionOutcome::Pruned => {
+                    pruned += 1;
+                    seen.remove(&s.id);
+                    changed = true;
+                }
+                DecommissionOutcome::Failed => kept.push(s),
+                DecommissionOutcome::StaleDaemon => {
+                    newly_stale_daemon = true;
+                    kept.push(s);
+                    break;
+                }
+            }
         }
+        // `iter.by_ref()` leaves every un-visited item (after the `break`)
+        // in `iter` — collect them back rather than silently dropping them.
+        kept.extend(iter);
+    }
+
+    if newly_stale_daemon {
+        seen.insert(STALE_DAEMON_MARKER_KEY.to_string(), now);
+        changed = true;
+    }
+    if already_stale_daemon || newly_stale_daemon {
+        eprintln!(
+            "tm: auto-prune: daemon may be running an older build; skipping \
+             automatic pruning until it's restarted"
+        );
     }
 
     let pending = confirmed.len() + first_sighting.len();
@@ -241,38 +311,82 @@ fn save_seen(path: &Path, seen: &HashMap<String, String>) {
     }
 }
 
+/// Outcome of one [`decommission_dead_record`] call.
+///
+/// Why: an HTTP 200 alone is NOT proof that `record_only` was honored — a
+/// stale daemon lacking the `Query<DecommissionQuery>` extractor also
+/// returns 200 (from the OLD unconditional full-teardown path). Only the
+/// response body's `workspace_removed` field can tell the two apart, so the
+/// caller needs a THIRD outcome distinct from plain success/failure.
+enum DecommissionOutcome {
+    /// The daemon confirmed `workspace_removed == false` — genuinely
+    /// record-only, safe to count as pruned.
+    Pruned,
+    /// The response proves (or fails to rule out) that the daemon actually
+    /// removed the workspace — `workspace_removed == true`, the field was
+    /// missing, or the body didn't even parse as JSON. Only reachable on a
+    /// 2xx status; treated as "a stale daemon may have just deleted this,"
+    /// never assumed safe.
+    StaleDaemon,
+    /// Non-2xx status or a transport error — the call simply failed.
+    Failed,
+}
+
 /// POST the existing `/decommission` route in RECORD-ONLY mode for one
-/// confirmed-dead record, best-effort (critic HIGH finding #1).
+/// confirmed-dead record, best-effort (critic HIGH finding #1; response-body
+/// verification added per critic CRITICAL finding, 2026-07-30).
 ///
 /// Why: kept as the single I/O primitive behind [`auto_prune_dead_records_at`]
 /// so a per-record transport/HTTP failure can never abort the rest of the
 /// listing — one stuck record must not hide every other session behind it.
-/// What: POSTs `?record_only=true`, which routes the daemon to
-/// `SessionManager::decommission_record_only` — the removal branches are
-/// skipped entirely, so this call can never delete filesystem content even
-/// if the workspace has reappeared since the listing-time probe. Returns
-/// `true` only on a 2xx response; any other status or a transport error is
-/// logged to stderr and returns `false`.
+/// POSTing `?record_only=true` alone is NOT sufficient proof of safety: a
+/// daemon process still running a build that predates this route's
+/// `Query<DecommissionQuery>` extractor silently ignores the param (axum
+/// drops query params a handler doesn't declare) and falls through to the
+/// OLD unconditional full-teardown `decommission()` — which also returns
+/// 200. This project's daemon is long-lived by design (a CLI upgrade never
+/// bounces it), so that version skew is the ROUTINE case, not an edge case.
+/// What: POSTs `?record_only=true`; on a 2xx response, parses the JSON body
+/// and requires `workspace_removed == false` before returning
+/// [`DecommissionOutcome::Pruned`] — the ONLY outcome that proves nothing was
+/// deleted. `workspace_removed == true`, a missing field, or an unparseable
+/// body all return [`DecommissionOutcome::StaleDaemon`]. A non-2xx status or
+/// a transport error is logged to stderr and returns
+/// [`DecommissionOutcome::Failed`].
 /// Test: `auto_prune_dead_records_removes_confirmed_unresumable_records`
-/// drives this through a real loopback daemon.
-async fn decommission_dead_record(client: &reqwest::Client, url: &str, id: &str) -> bool {
-    match client
+/// drives the happy path through a real loopback daemon;
+/// `auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed`
+/// drives the stale-daemon path through a stub server that ignores
+/// `record_only` and always reports `workspace_removed: true`.
+async fn decommission_dead_record(
+    client: &reqwest::Client,
+    url: &str,
+    id: &str,
+) -> DecommissionOutcome {
+    let resp = match client
         .post(format!("{url}/api/v1/sessions/managed/{id}/decommission"))
         .query(&[("record_only", "true")])
         .send()
         .await
     {
-        Ok(resp) if resp.status().is_success() => true,
-        Ok(resp) => {
-            eprintln!(
-                "tm: auto-prune: failed to remove dead record {id}: HTTP {}",
-                resp.status()
-            );
-            false
-        }
+        Ok(resp) => resp,
         Err(e) => {
             eprintln!("tm: auto-prune: failed to remove dead record {id}: {e}");
-            false
+            return DecommissionOutcome::Failed;
         }
+    };
+    if !resp.status().is_success() {
+        eprintln!(
+            "tm: auto-prune: failed to remove dead record {id}: HTTP {}",
+            resp.status()
+        );
+        return DecommissionOutcome::Failed;
+    }
+    match resp.json::<serde_json::Value>().await {
+        Ok(body) => match body.get("workspace_removed").and_then(|v| v.as_bool()) {
+            Some(false) => DecommissionOutcome::Pruned,
+            _ => DecommissionOutcome::StaleDaemon,
+        },
+        Err(_) => DecommissionOutcome::StaleDaemon,
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
@@ -38,7 +38,11 @@
 //!      the response body and requires `workspace_removed == false` before
 //!      counting a call as safe; anything else trips
 //!      [`STALE_DAEMON_MARKER_KEY`], which disables further auto-prune
-//!      attempts for the rest of this invocation.
+//!      attempts until the sentinel expires ([`STALE_DAEMON_TTL_SECS`], 1
+//!      hour) — self-healing: one probe per hour against a genuinely stale
+//!      daemon, not a permanent lockout once it's restarted. Records held
+//!      back by this gate fold into [`AutoPruneOutcome::pending`], never
+//!      silently disappearing from the reported count.
 //!
 //! What: [`auto_prune_dead_records`] is the production entry point (resolves
 //! the marker file under `~/.trusty-mpm`); [`auto_prune_dead_records_at`] is
@@ -51,7 +55,8 @@
 //! `auto_prune_dead_records_keeps_workspace_present_records`,
 //! `auto_prune_dead_records_is_noop_when_nothing_is_dead`,
 //! `auto_prune_dead_records_honors_the_cap`,
-//! `auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed`
+//! `auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed`,
+//! `auto_prune_dead_records_stale_daemon_sentinel_expires_after_ttl`
 //! in `tests_behavior_d_tests.rs`; the record-only server-side guarantee is
 //! pinned by `decommission_record_only_never_removes_existing_workspace`
 //! (`session_manager::tests`).
@@ -96,9 +101,25 @@ const SEEN_MARKER_FILENAME: &str = "auto-prune-seen.json";
 /// never bleed into each other despite `cargo test` running many tests in
 /// one process.
 /// What: an unlikely-to-collide sentinel key (real session ids are UUIDs);
-/// its value is the RFC 3339 timestamp of first detection, for debugging.
-/// Test: `auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed`.
+/// its value is the RFC 3339 timestamp of first detection — checked against
+/// [`STALE_DAEMON_TTL_SECS`] by [`stale_daemon_sentinel_active`], not merely
+/// its presence.
+/// Test: `auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed`,
+/// `auto_prune_dead_records_stale_daemon_sentinel_expires_after_ttl`.
 const STALE_DAEMON_MARKER_KEY: &str = "__stale_daemon_detected__";
+
+/// TTL for the `STALE_DAEMON_MARKER_KEY` sentinel: 1 hour (owner request
+/// 2026-07-30 follow-up).
+///
+/// Why: a daemon that was stale an hour ago may have been restarted since —
+/// wedging auto-prune off permanently would defeat the point of a
+/// self-healing safeguard once the operator (or the daemon's own restart
+/// machinery) catches up. Expiring the sentinel lets the NEXT invocation
+/// retry; if the daemon is STILL stale, [`decommission_dead_record`]'s
+/// body-check trips again immediately and rewrites a fresh sentinel — one
+/// probe per hour against a genuinely stale daemon, never a permanent
+/// lockout.
+const STALE_DAEMON_TTL_SECS: i64 = 60 * 60;
 
 /// Result of one [`auto_prune_dead_records`] / [`auto_prune_dead_records_at`]
 /// call.
@@ -115,8 +136,11 @@ pub(crate) struct AutoPruneOutcome {
     /// Count of records actually decommissioned this call (never more than
     /// [`AUTO_PRUNE_CAP`]).
     pub(crate) pruned: usize,
-    /// Count of `unresumable` records NOT acted on this call — either a
-    /// first sighting (not yet confirmed) or confirmed-but-over-the-cap.
+    /// Count of `unresumable` records NOT acted on this call — a first
+    /// sighting (not yet confirmed), confirmed-but-over-the-cap, or held
+    /// back because the stale-daemon gate is active (owner request
+    /// 2026-07-30 follow-up — this must fold in here or the reported count
+    /// under-represents exactly the batch that gate is protecting).
     pub(crate) pending: usize,
 }
 
@@ -178,7 +202,8 @@ pub(crate) async fn auto_prune_dead_records(
 /// `auto_prune_dead_records_first_sighting_is_not_pruned`,
 /// `auto_prune_dead_records_keeps_workspace_present_records`,
 /// `auto_prune_dead_records_is_noop_when_nothing_is_dead`,
-/// `auto_prune_dead_records_honors_the_cap`.
+/// `auto_prune_dead_records_honors_the_cap`,
+/// `auto_prune_dead_records_stale_daemon_sentinel_expires_after_ttl`.
 pub(crate) async fn auto_prune_dead_records_at(
     client: &reqwest::Client,
     url: &str,
@@ -226,13 +251,23 @@ pub(crate) async fn auto_prune_dead_records_at(
     let to_prune: Vec<_> = confirmed.drain(..cap).collect();
 
     // Critic CRITICAL (2026-07-30): a daemon that already proved it ignores
-    // `record_only` (ANY earlier call this invocation) must never be asked
-    // to decommission again — see `STALE_DAEMON_MARKER_KEY`'s doc.
-    let already_stale_daemon = seen.contains_key(STALE_DAEMON_MARKER_KEY);
+    // `record_only` — within its 1-hour TTL — must never be asked to
+    // decommission again this call. An EXPIRED sentinel is cleared here so a
+    // now-current daemon isn't wedged off forever.
+    let already_stale_daemon = stale_daemon_sentinel_active(&seen);
+    if !already_stale_daemon && seen.remove(STALE_DAEMON_MARKER_KEY).is_some() {
+        changed = true;
+    }
     let mut newly_stale_daemon = false;
     let mut pruned = 0usize;
+    // Owner request 2026-07-30 follow-up: records held back by the
+    // stale-daemon gate (already-active OR newly-tripped-mid-loop) must fold
+    // into `pending` — otherwise "N more dead records pending confirmation"
+    // under-reports exactly the batch this gate is protecting.
+    let mut stale_daemon_held = 0usize;
 
     if already_stale_daemon {
+        stale_daemon_held = to_prune.len();
         kept.extend(to_prune);
     } else {
         let mut iter = to_prune.into_iter();
@@ -246,6 +281,7 @@ pub(crate) async fn auto_prune_dead_records_at(
                 DecommissionOutcome::Failed => kept.push(s),
                 DecommissionOutcome::StaleDaemon => {
                     newly_stale_daemon = true;
+                    stale_daemon_held += 1;
                     kept.push(s);
                     break;
                 }
@@ -253,7 +289,9 @@ pub(crate) async fn auto_prune_dead_records_at(
         }
         // `iter.by_ref()` leaves every un-visited item (after the `break`)
         // in `iter` — collect them back rather than silently dropping them.
-        kept.extend(iter);
+        let remainder: Vec<_> = iter.collect();
+        stale_daemon_held += remainder.len();
+        kept.extend(remainder);
     }
 
     if newly_stale_daemon {
@@ -267,7 +305,7 @@ pub(crate) async fn auto_prune_dead_records_at(
         );
     }
 
-    let pending = confirmed.len() + first_sighting.len();
+    let pending = confirmed.len() + first_sighting.len() + stale_daemon_held;
     kept.extend(confirmed);
     kept.extend(first_sighting);
 
@@ -280,6 +318,26 @@ pub(crate) async fn auto_prune_dead_records_at(
         pruned,
         pending,
     }
+}
+
+/// Whether the persisted `STALE_DAEMON_MARKER_KEY` sentinel is still within
+/// its [`STALE_DAEMON_TTL_SECS`] TTL (owner request 2026-07-30 follow-up).
+///
+/// Why: see [`STALE_DAEMON_TTL_SECS`]'s doc — a permanent lockout would
+/// outlive the daemon restart that fixes it.
+/// What: `true` only when the sentinel is present AND parses as an RFC 3339
+/// timestamp no more than [`STALE_DAEMON_TTL_SECS`] old. A missing, corrupt,
+/// or expired sentinel returns `false` (retry allowed) — the caller is
+/// responsible for clearing an expired entry from `seen` so it doesn't
+/// linger.
+/// Test: `auto_prune_dead_records_stale_daemon_sentinel_expires_after_ttl`.
+fn stale_daemon_sentinel_active(seen: &HashMap<String, String>) -> bool {
+    seen.get(STALE_DAEMON_MARKER_KEY)
+        .and_then(|ts| chrono::DateTime::parse_from_rfc3339(ts).ok())
+        .is_some_and(|ts| {
+            chrono::Utc::now().signed_duration_since(ts)
+                < chrono::Duration::seconds(STALE_DAEMON_TTL_SECS)
+        })
 }
 
 /// Load the persisted first-sighting map, tolerating a missing or corrupt

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
@@ -1,0 +1,104 @@
+//! Auto-prune definitively-dead (`unresumable`) managed-session records at
+//! listing time (owner request 2026-07-29).
+//!
+//! Why: extracted out of `session_picker.rs` (which sits at the 500-SLOC
+//! production cap, mirroring why `session_picker_render.rs`/
+//! `session_picker_rename.rs` were split out before it). Before this module
+//! existed, a session flagged `unresumable` (its workspace GC-pruned out from
+//! under it) sat in the picker forever printing `DEAD: workspace removed; use
+//! [d<N>] to remove the record` — the operator had to notice the row and type
+//! the number themselves, every time.
+//!
+//! What: [`auto_prune_dead_records`] is the pure-ish partition+drive seam
+//! (unit-testable up to its one I/O primitive); [`decommission_dead_record`]
+//! is that primitive — a best-effort POST to the existing `/decommission`
+//! route (the SAME dirty-worktree-gated teardown path #4344, `114de333`,
+//! hardened), never a raw `fs::remove` or a hand-edited store entry.
+//!
+//! Test: `auto_prune_dead_records_removes_unresumable_records`,
+//! `auto_prune_dead_records_keeps_workspace_present_records`,
+//! `auto_prune_dead_records_is_noop_when_nothing_is_dead` in
+//! `tests_behavior_d_tests.rs`.
+
+use trusty_mpm::client::ManagedSessionSummary;
+
+/// Auto-prune definitively-dead (`unresumable`) session records at listing
+/// time (owner request 2026-07-29).
+///
+/// Why: before this, an operator had to notice the `DEAD: workspace removed`
+/// row and manually type `d<N>` for every session whose workspace had been
+/// GC-pruned out from under it — Bob's ask was for the picker to just clean
+/// these up on its own.
+///
+/// SAFETY BOUNDARY (#4344, `114de333`): a record whose worktree removal was
+/// previously REFUSED because the tree was dirty keeps its `workspace_path`
+/// pointed at a directory that still genuinely exists on disk. `unresumable`
+/// (`session_manager::resume_workdir::is_unresumable`) probes that exact
+/// path with `tokio::fs::try_exists` and returns `false` the instant ANY
+/// candidate (`last_cwd`/`workspace_path`/`cwd`) is found present — so a
+/// dirty-retained record can never read `unresumable == true` in the first
+/// place. This function's partition below is therefore sufficient on its own
+/// to keep such a record out of scope; no additional workspace-existence
+/// check is needed here.
+/// What: partitions `sessions` into `(keep, dead)` by `s.unresumable`; for
+/// each `dead` record, POSTs the existing `/decommission` route (the SAME
+/// dirty-worktree-gated teardown path #4344 hardened — never a raw
+/// `fs::remove` or a hand-edited store entry) via
+/// [`decommission_dead_record`]. Returns the `keep` list with every
+/// SUCCESSFULLY-decommissioned record dropped, plus the count actually
+/// removed. A record whose decommission attempt fails (network error,
+/// already gone, etc.) is kept in the returned list — best-effort, and it
+/// still carries its manual `[d<N>]` remedy rather than silently vanishing
+/// from the operator's view without ever having been removed.
+/// Test: `auto_prune_dead_records_removes_unresumable_records`,
+/// `auto_prune_dead_records_keeps_workspace_present_records`,
+/// `auto_prune_dead_records_is_noop_when_nothing_is_dead`.
+pub(crate) async fn auto_prune_dead_records(
+    client: &reqwest::Client,
+    url: &str,
+    sessions: Vec<ManagedSessionSummary>,
+) -> (Vec<ManagedSessionSummary>, usize) {
+    let (dead, mut kept): (Vec<_>, Vec<_>) = sessions.into_iter().partition(|s| s.unresumable);
+    if dead.is_empty() {
+        return (kept, 0);
+    }
+    let mut pruned = 0usize;
+    for s in dead {
+        if decommission_dead_record(client, url, &s.id).await {
+            pruned += 1;
+        } else {
+            kept.push(s);
+        }
+    }
+    (kept, pruned)
+}
+
+/// POST the existing `/decommission` route for one dead record, best-effort.
+///
+/// Why: kept as the single I/O primitive behind [`auto_prune_dead_records`] so
+/// a per-record transport/HTTP failure can never abort the rest of the
+/// listing — one stuck record must not hide every other session behind it.
+/// What: returns `true` only on a 2xx response; any other status or a
+/// transport error is logged to stderr and returns `false`.
+/// Test: `auto_prune_dead_records_removes_unresumable_records` drives this
+/// through a real loopback daemon.
+async fn decommission_dead_record(client: &reqwest::Client, url: &str, id: &str) -> bool {
+    match client
+        .post(format!("{url}/api/v1/sessions/managed/{id}/decommission"))
+        .send()
+        .await
+    {
+        Ok(resp) if resp.status().is_success() => true,
+        Ok(resp) => {
+            eprintln!(
+                "tm: auto-prune: failed to remove dead record {id}: HTTP {}",
+                resp.status()
+            );
+            false
+        }
+        Err(e) => {
+            eprintln!("tm: auto-prune: failed to remove dead record {id}: {e}");
+            false
+        }
+    }
+}

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -1147,6 +1147,80 @@ fn sort_sessions_alpha_orders_by_name_case_insensitive() {
     assert_eq!(names, vec!["apple", "Mango", "Zebra"]);
 }
 
+// ── ordering: attached → active → stopped groups (owner request 2026-07-29) ─
+//
+// Bob's ask: the listing groups attached first, then active, then stopped —
+// ABOVE whatever `recent`/`alpha` secondary sort applies. These tests use a
+// deliberately-adversarial recency/alpha order within each group (the
+// stopped/attached/active rows are seeded so the OLD flat sort would have
+// interleaved them) to prove the grouping wins over the secondary key, not
+// merely coincide with it.
+
+/// `Recent` groups attached-first, then active, then everything else — even
+/// when a "stopped" row is more recently active than the "active" one.
+#[test]
+fn sort_sessions_recent_groups_attached_before_active_before_stopped() {
+    let mut stopped_but_newest = ls_test_session(
+        "stopped-newest",
+        "stopped",
+        Some("2026-07-01T00:00:00Z"),
+        None,
+        None,
+        None,
+    );
+    stopped_but_newest.attached = false;
+    let mut active_but_older = ls_test_session(
+        "active-older",
+        "active",
+        Some("2026-01-01T00:00:00Z"),
+        None,
+        None,
+        None,
+    );
+    active_but_older.attached = false;
+    let mut attached_but_oldest = ls_test_session(
+        "attached-oldest",
+        "active",
+        Some("2025-01-01T00:00:00Z"),
+        None,
+        None,
+        None,
+    );
+    attached_but_oldest.attached = true;
+
+    let mut sessions = vec![stopped_but_newest, active_but_older, attached_but_oldest];
+    sort_sessions(&mut sessions, SessionSortArg::Recent);
+    let names: Vec<&str> = sessions.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["attached-oldest", "active-older", "stopped-newest"],
+        "attached must lead regardless of recency, active must lead over \
+         stopped regardless of recency"
+    );
+}
+
+/// `Alpha` groups attached-first, then active, then everything else — even
+/// when a "stopped" row's name would otherwise sort first alphabetically.
+#[test]
+fn sort_sessions_alpha_groups_attached_before_active_before_stopped() {
+    let mut stopped_but_a = ls_test_session("aaa-stopped", "stopped", None, None, None, None);
+    stopped_but_a.attached = false;
+    let mut active_but_m = ls_test_session("mmm-active", "active", None, None, None, None);
+    active_but_m.attached = false;
+    let mut attached_but_z = ls_test_session("zzz-attached", "active", None, None, None, None);
+    attached_but_z.attached = true;
+
+    let mut sessions = vec![stopped_but_a, active_but_m, attached_but_z];
+    sort_sessions(&mut sessions, SessionSortArg::Alpha);
+    let names: Vec<&str> = sessions.iter().map(|s| s.name.as_str()).collect();
+    assert_eq!(
+        names,
+        vec!["zzz-attached", "mmm-active", "aaa-stopped"],
+        "attached must lead regardless of name, active must lead over \
+         stopped regardless of name"
+    );
+}
+
 /// Filter + sort combined: filtering first, then sorting the remaining rows.
 #[test]
 fn filter_and_sort_combined() {
@@ -1587,4 +1661,164 @@ fn local_session_needs_force_active_and_others_true() {
     assert!(local_session_needs_force(SessionStatus::AwaitingApproval));
     assert!(local_session_needs_force(SessionStatus::Detached));
     assert!(local_session_needs_force(SessionStatus::Paused));
+}
+
+// ── auto-prune dead (unresumable) records at listing time (owner request
+// 2026-07-29) ─────────────────────────────────────────────────────────────
+//
+// `auto_prune_dead_records` partitions on the daemon-computed `unresumable`
+// flag and, for anything dead, drives the REAL `/decommission` HTTP route
+// against a hermetic loopback daemon (mirroring `LocalTestServer` above) —
+// proving the wiring, not just the pure partition logic.
+
+use crate::commands::session_picker_prune::auto_prune_dead_records;
+
+/// A dead (`unresumable`) session record disappears after
+/// `auto_prune_dead_records`, and the daemon's own store reflects the
+/// teardown (state flips to `decommissioned`, which the default live view
+/// hides) — never a client-side-only illusion of removal.
+#[tokio::test]
+async fn auto_prune_dead_records_removes_unresumable_records() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+    let mgr = state.session_manager().await;
+
+    // A workspace path that is NEVER created — every workdir candidate is
+    // therefore verifiably absent from disk, exactly `is_unresumable`'s gate.
+    let gone = root.path().join("gone-workspace");
+    let id = trusty_mpm::session_manager::ManagedSessionId::new();
+    mgr.create_with_id(
+        id,
+        "regression: auto-prune dead record".to_string(),
+        Some(gone.clone()),
+        None,
+        Some(gone),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        trusty_mpm::runtime::RuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed dead session");
+    mgr.mark_errored(&id, "regression: simulate prior spawn failure")
+        .await
+        .expect("mark errored");
+
+    let server = LocalTestServer::spawn(state).await;
+    let client = reqwest::Client::new();
+    // Fetch via the RAW (non-auto-pruning) path first — `fetch_live_sessions`
+    // already runs `auto_prune_dead_records` internally, which would prune
+    // this record before the test gets to assert its pre-prune shape.
+    let raw = crate::commands::session_picker::fetch_managed_raw(&client, &server.url, None)
+        .await
+        .expect("fetch raw");
+    let sessions =
+        crate::commands::session_picker::parse_scoped_sessions(&raw, false).expect("parse");
+    let target = sessions
+        .iter()
+        .find(|s| s.id == id.to_string())
+        .expect("dead session must still surface on the raw fetch");
+    assert!(
+        target.unresumable,
+        "seeded session must be flagged unresumable before pruning"
+    );
+
+    let (kept, pruned) = auto_prune_dead_records(&client, &server.url, sessions).await;
+    assert_eq!(pruned, 1, "exactly the one dead record must be pruned");
+    assert!(
+        !kept.iter().any(|s| s.id == id.to_string()),
+        "the pruned record must not remain in the returned list"
+    );
+
+    // The daemon's own record must have been torn down for real (not merely
+    // dropped client-side) — decommission tombstones it, which the default
+    // live-only fetch hides.
+    let refetched =
+        crate::commands::session_picker::fetch_live_sessions(&client, &server.url, None, false)
+            .await
+            .expect("re-fetch after prune");
+    assert!(
+        !refetched.iter().any(|s| s.id == id.to_string()),
+        "the decommissioned record must no longer appear in the live listing"
+    );
+}
+
+/// #4344 boundary: a record whose worktree removal was refused because the
+/// tree was dirty RETAINS `workspace_path` pointing at a directory that still
+/// genuinely exists on disk — such a record must NEVER be flagged
+/// `unresumable` (the disk-existence probe finds it present) and therefore
+/// must never be auto-pruned. This test stands in for that retained-path
+/// shape directly: a stopped session whose `workspace_path` is a REAL,
+/// still-existing directory.
+#[tokio::test]
+async fn auto_prune_dead_records_keeps_workspace_present_records() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+    let mgr = state.session_manager().await;
+
+    let ws = root.path().join("still-here-workspace");
+    std::fs::create_dir_all(&ws).expect("create real workspace dir");
+    let id = trusty_mpm::session_manager::ManagedSessionId::new();
+    mgr.create_with_id(
+        id,
+        "regression: auto-prune keeps live workspace".to_string(),
+        Some(ws.clone()),
+        None,
+        Some(ws),
+        Some("https://example.com/r.git".to_string()),
+        Some("main".to_string()),
+        trusty_mpm::runtime::RuntimeKind::default(),
+        false,
+        false,
+    )
+    .await
+    .expect("seed session with real workspace");
+    mgr.stop(&id)
+        .await
+        .expect("stop session (workspace intact)");
+
+    let server = LocalTestServer::spawn(state).await;
+    let client = reqwest::Client::new();
+    let sessions =
+        crate::commands::session_picker::fetch_live_sessions(&client, &server.url, None, false)
+            .await
+            .expect("fetch live sessions");
+    let target = sessions
+        .iter()
+        .find(|s| s.id == id.to_string())
+        .expect("stopped session with a real workspace must surface");
+    assert!(
+        !target.unresumable,
+        "a stopped session whose workspace still exists on disk must never \
+         be flagged unresumable"
+    );
+
+    let (kept, pruned) = auto_prune_dead_records(&client, &server.url, sessions).await;
+    assert_eq!(
+        pruned, 0,
+        "a record with an existing workspace must never be pruned"
+    );
+    assert!(
+        kept.iter().any(|s| s.id == id.to_string()),
+        "the record must survive auto-prune untouched"
+    );
+}
+
+/// A list containing no `unresumable` records is a pure no-op — no HTTP call
+/// is even attempted (an unroutable URL would otherwise surface as an error,
+/// but the function never reaches it).
+#[tokio::test]
+async fn auto_prune_dead_records_is_noop_when_nothing_is_dead() {
+    let client = reqwest::Client::new();
+    let sessions = vec![ls_test_session("healthy", "active", None, None, None, None)];
+
+    let (kept, pruned) = auto_prune_dead_records(&client, "http://127.0.0.1:1", sessions).await;
+    assert_eq!(pruned, 0);
+    assert_eq!(kept.len(), 1);
+    assert_eq!(kept[0].name, "healthy");
 }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -1664,34 +1664,33 @@ fn local_session_needs_force_active_and_others_true() {
 }
 
 // ── auto-prune dead (unresumable) records at listing time (owner request
-// 2026-07-29) ─────────────────────────────────────────────────────────────
+// 2026-07-29; hardened per code-critic WARN, PR #4384 review) ──────────────
 //
-// `auto_prune_dead_records` partitions on the daemon-computed `unresumable`
-// flag and, for anything dead, drives the REAL `/decommission` HTTP route
-// against a hermetic loopback daemon (mirroring `LocalTestServer` above) —
-// proving the wiring, not just the pure partition logic.
+// `auto_prune_dead_records_at` partitions on the daemon-computed `unresumable`
+// flag and, for anything CONFIRMED dead (seen on two consecutive calls),
+// drives the REAL `/decommission?record_only=true` HTTP route against a
+// hermetic loopback daemon (mirroring `LocalTestServer` above) — proving the
+// wiring, not just the pure partition logic. Every test uses an explicit
+// tempdir-rooted marker path (`auto_prune_dead_records_at`), never the
+// production `auto_prune_dead_records` wrapper, which resolves the real
+// `~/.trusty-mpm` — tests must never touch the developer's real home dir.
 
-use crate::commands::session_picker_prune::auto_prune_dead_records;
+use crate::commands::session_picker_prune::auto_prune_dead_records_at;
 
-/// A dead (`unresumable`) session record disappears after
-/// `auto_prune_dead_records`, and the daemon's own store reflects the
-/// teardown (state flips to `decommissioned`, which the default live view
-/// hides) — never a client-side-only illusion of removal.
-#[tokio::test]
-async fn auto_prune_dead_records_removes_unresumable_records() {
-    let root = tempfile::TempDir::new().expect("tempdir");
-    let state = std::sync::Arc::new(
-        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
-    );
-    let mgr = state.session_manager().await;
-
-    // A workspace path that is NEVER created — every workdir candidate is
-    // therefore verifiably absent from disk, exactly `is_unresumable`'s gate.
-    let gone = root.path().join("gone-workspace");
+/// Seed one managed session whose workspace path is NEVER created on disk —
+/// every workdir candidate is therefore verifiably absent, exactly
+/// `is_unresumable`'s gate — and mark it `Errored` so it becomes
+/// `unresumable: true` on the next fetch. Returns the session id.
+async fn seed_dead_session(
+    mgr: &trusty_mpm::session_manager::SessionManager,
+    root: &std::path::Path,
+    label: &str,
+) -> trusty_mpm::session_manager::ManagedSessionId {
+    let gone = root.join(format!("gone-workspace-{label}"));
     let id = trusty_mpm::session_manager::ManagedSessionId::new();
     mgr.create_with_id(
         id,
-        "regression: auto-prune dead record".to_string(),
+        format!("regression: auto-prune dead record {label}"),
         Some(gone.clone()),
         None,
         Some(gone),
@@ -1706,40 +1705,103 @@ async fn auto_prune_dead_records_removes_unresumable_records() {
     mgr.mark_errored(&id, "regression: simulate prior spawn failure")
         .await
         .expect("mark errored");
+    id
+}
+
+/// Fetch the RAW (non-auto-pruning) live session list — bypasses
+/// `fetch_live_sessions`'s own internal auto-prune entirely, so a test can
+/// inspect pre-prune state or drive `auto_prune_dead_records_at` manually
+/// without a prior fetch silently consuming the record.
+async fn fetch_raw_live(
+    client: &reqwest::Client,
+    url: &str,
+) -> Vec<trusty_mpm::client::ManagedSessionSummary> {
+    let raw = crate::commands::session_picker::fetch_managed_raw(client, url, None)
+        .await
+        .expect("fetch raw");
+    crate::commands::session_picker::parse_scoped_sessions(&raw, false).expect("parse")
+}
+
+/// A FIRST sighting of an `unresumable` record is never pruned — only
+/// recorded as a candidate (critic HIGH finding #1: no single-observation
+/// destructive action).
+#[tokio::test]
+async fn auto_prune_dead_records_first_sighting_is_not_pruned() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+    let mgr = state.session_manager().await;
+    let id = seed_dead_session(&mgr, root.path(), "first").await;
 
     let server = LocalTestServer::spawn(state).await;
     let client = reqwest::Client::new();
-    // Fetch via the RAW (non-auto-pruning) path first — `fetch_live_sessions`
-    // already runs `auto_prune_dead_records` internally, which would prune
-    // this record before the test gets to assert its pre-prune shape.
-    let raw = crate::commands::session_picker::fetch_managed_raw(&client, &server.url, None)
-        .await
-        .expect("fetch raw");
-    let sessions =
-        crate::commands::session_picker::parse_scoped_sessions(&raw, false).expect("parse");
+    let marker_path = root.path().join("seen.json");
+
+    let sessions = fetch_raw_live(&client, &server.url).await;
     let target = sessions
         .iter()
         .find(|s| s.id == id.to_string())
         .expect("dead session must still surface on the raw fetch");
+    assert!(target.unresumable, "seeded session must be unresumable");
+
+    let outcome = auto_prune_dead_records_at(&client, &server.url, sessions, &marker_path).await;
+    assert_eq!(outcome.pruned, 0, "a first sighting must never be pruned");
+    assert_eq!(outcome.pending, 1, "a first sighting is reported pending");
     assert!(
-        target.unresumable,
-        "seeded session must be flagged unresumable before pruning"
+        outcome.kept.iter().any(|s| s.id == id.to_string()),
+        "the record must remain visible while awaiting confirmation"
     );
 
-    let (kept, pruned) = auto_prune_dead_records(&client, &server.url, sessions).await;
-    assert_eq!(pruned, 1, "exactly the one dead record must be pruned");
+    // The daemon-side record itself must be untouched — still Errored, not
+    // Decommissioned.
+    let still_there = fetch_raw_live(&client, &server.url).await;
+    let record = still_there
+        .iter()
+        .find(|s| s.id == id.to_string())
+        .expect("record must still be live");
+    assert_eq!(record.state, "errored");
+}
+
+/// A record confirmed dead on a SECOND (later) call is decommissioned via the
+/// record-only route, and the daemon's own store reflects the teardown
+/// (state flips to `decommissioned`, which the default live view hides) —
+/// never a client-side-only illusion of removal.
+#[tokio::test]
+async fn auto_prune_dead_records_removes_confirmed_unresumable_records() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+    let mgr = state.session_manager().await;
+    let id = seed_dead_session(&mgr, root.path(), "confirmed").await;
+
+    let server = LocalTestServer::spawn(state).await;
+    let client = reqwest::Client::new();
+    let marker_path = root.path().join("seen.json");
+
+    // First call: first sighting, not yet acted on.
+    let sessions = fetch_raw_live(&client, &server.url).await;
+    let first = auto_prune_dead_records_at(&client, &server.url, sessions, &marker_path).await;
+    assert_eq!(first.pruned, 0);
+
+    // Second call (a later, separate listing): now CONFIRMED — decommissioned.
+    let sessions = fetch_raw_live(&client, &server.url).await;
+    let second = auto_prune_dead_records_at(&client, &server.url, sessions, &marker_path).await;
+    assert_eq!(
+        second.pruned, 1,
+        "confirmed on a second listing must be pruned"
+    );
+    assert_eq!(second.pending, 0);
     assert!(
-        !kept.iter().any(|s| s.id == id.to_string()),
+        !second.kept.iter().any(|s| s.id == id.to_string()),
         "the pruned record must not remain in the returned list"
     );
 
     // The daemon's own record must have been torn down for real (not merely
     // dropped client-side) — decommission tombstones it, which the default
     // live-only fetch hides.
-    let refetched =
-        crate::commands::session_picker::fetch_live_sessions(&client, &server.url, None, false)
-            .await
-            .expect("re-fetch after prune");
+    let refetched = fetch_raw_live(&client, &server.url).await;
     assert!(
         !refetched.iter().any(|s| s.id == id.to_string()),
         "the decommissioned record must no longer appear in the live listing"
@@ -1784,10 +1846,8 @@ async fn auto_prune_dead_records_keeps_workspace_present_records() {
 
     let server = LocalTestServer::spawn(state).await;
     let client = reqwest::Client::new();
-    let sessions =
-        crate::commands::session_picker::fetch_live_sessions(&client, &server.url, None, false)
-            .await
-            .expect("fetch live sessions");
+    let marker_path = root.path().join("seen.json");
+    let sessions = fetch_raw_live(&client, &server.url).await;
     let target = sessions
         .iter()
         .find(|s| s.id == id.to_string())
@@ -1798,13 +1858,14 @@ async fn auto_prune_dead_records_keeps_workspace_present_records() {
          be flagged unresumable"
     );
 
-    let (kept, pruned) = auto_prune_dead_records(&client, &server.url, sessions).await;
+    let outcome = auto_prune_dead_records_at(&client, &server.url, sessions, &marker_path).await;
     assert_eq!(
-        pruned, 0,
+        outcome.pruned, 0,
         "a record with an existing workspace must never be pruned"
     );
+    assert_eq!(outcome.pending, 0);
     assert!(
-        kept.iter().any(|s| s.id == id.to_string()),
+        outcome.kept.iter().any(|s| s.id == id.to_string()),
         "the record must survive auto-prune untouched"
     );
 }
@@ -1815,10 +1876,95 @@ async fn auto_prune_dead_records_keeps_workspace_present_records() {
 #[tokio::test]
 async fn auto_prune_dead_records_is_noop_when_nothing_is_dead() {
     let client = reqwest::Client::new();
+    let marker_path = tempfile::TempDir::new()
+        .expect("tempdir")
+        .path()
+        .join("seen.json");
     let sessions = vec![ls_test_session("healthy", "active", None, None, None, None)];
 
-    let (kept, pruned) = auto_prune_dead_records(&client, "http://127.0.0.1:1", sessions).await;
-    assert_eq!(pruned, 0);
-    assert_eq!(kept.len(), 1);
-    assert_eq!(kept[0].name, "healthy");
+    let outcome =
+        auto_prune_dead_records_at(&client, "http://127.0.0.1:1", sessions, &marker_path).await;
+    assert_eq!(outcome.pruned, 0);
+    assert_eq!(outcome.pending, 0);
+    assert_eq!(outcome.kept.len(), 1);
+    assert_eq!(outcome.kept[0].name, "healthy");
+}
+
+/// The per-call cap (critic HIGH finding #1) limits a single call to at most
+/// 5 decommissions even when MORE records are confirmed-eligible — a
+/// bad-mount day must not mass-tombstone an entire fleet in one `tm ls`.
+#[tokio::test]
+async fn auto_prune_dead_records_honors_the_cap() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+    let mgr = state.session_manager().await;
+    for i in 0..6 {
+        seed_dead_session(&mgr, root.path(), &format!("cap-{i}")).await;
+    }
+
+    let server = LocalTestServer::spawn(state).await;
+    let client = reqwest::Client::new();
+    let marker_path = root.path().join("seen.json");
+
+    // First call: all 6 are first sightings — nothing pruned yet.
+    let sessions = fetch_raw_live(&client, &server.url).await;
+    assert_eq!(sessions.len(), 6);
+    let first = auto_prune_dead_records_at(&client, &server.url, sessions, &marker_path).await;
+    assert_eq!(first.pruned, 0);
+    assert_eq!(first.pending, 6);
+
+    // Second call: all 6 are now CONFIRMED, but the cap limits this call to 5.
+    let sessions = fetch_raw_live(&client, &server.url).await;
+    assert_eq!(sessions.len(), 6);
+    let second = auto_prune_dead_records_at(&client, &server.url, sessions, &marker_path).await;
+    assert_eq!(second.pruned, 5, "the cap must limit a single call to 5");
+    assert_eq!(
+        second.pending, 1,
+        "the 6th confirmed record must be reported pending, not silently dropped"
+    );
+    assert_eq!(second.kept.len(), 1);
+}
+
+/// `fetch_live_sessions(allow_auto_prune = false)` is a pure read — a
+/// non-interactive listing (scripted/cron/CI bare `tm` or `tm ls`) must never
+/// trigger the destructive auto-prune sweep (critic HIGH finding #3).
+#[tokio::test]
+async fn fetch_live_sessions_skips_auto_prune_when_disallowed() {
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let state = std::sync::Arc::new(
+        DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await,
+    );
+    let mgr = state.session_manager().await;
+    let id = seed_dead_session(&mgr, root.path(), "non-tty").await;
+
+    let server = LocalTestServer::spawn(state).await;
+    let client = reqwest::Client::new();
+
+    let sessions = crate::commands::session_picker::fetch_live_sessions(
+        &client,
+        &server.url,
+        None,
+        false,
+        false, // allow_auto_prune = false: the non-interactive case
+    )
+    .await
+    .expect("fetch live sessions");
+    assert!(
+        sessions.iter().any(|s| s.id == id.to_string()),
+        "a non-interactive fetch must return the dead record unchanged"
+    );
+
+    // The daemon-side record must be untouched — still Errored, never
+    // decommissioned, and no confirmation marker written.
+    let still_there = fetch_raw_live(&client, &server.url).await;
+    let record = still_there
+        .iter()
+        .find(|s| s.id == id.to_string())
+        .expect("record must still be live");
+    assert_eq!(
+        record.state, "errored",
+        "a non-interactive fetch must never decommission anything"
+    );
 }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -1996,6 +1996,100 @@ async fn auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_remov
         "both records must be left on the manual [d<N>] path once the stale \
          daemon is detected"
     );
+    assert_eq!(
+        outcome.pending, 2,
+        "both stale-daemon-held records must fold into `pending`, not vanish \
+         from the reported count"
+    );
+
+    handle.abort();
+}
+
+/// Owner request 2026-07-30 follow-up: the stale-daemon sentinel expires
+/// after its 1-hour TTL, so a daemon that gets restarted eventually stops
+/// being wedged out of auto-prune forever. A FRESH sentinel still blocks;
+/// an EXPIRED one lets the next call retry (and, since this stub daemon is
+/// still "stale," immediately re-trips a fresh sentinel — correct
+/// oscillation, one probe per hour, never a permanent lockout).
+#[tokio::test]
+async fn auto_prune_dead_records_stale_daemon_sentinel_expires_after_ttl() {
+    async fn stub_decommission(
+        axum::extract::Path(_id): axum::extract::Path<String>,
+    ) -> axum::Json<serde_json::Value> {
+        axum::Json(serde_json::json!({ "workspace_removed": true }))
+    }
+    let app = axum::Router::new().route(
+        "/api/v1/sessions/managed/{id}/decommission",
+        axum::routing::post(stub_decommission),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback port");
+    let addr = listener.local_addr().expect("resolve bound addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let url = format!("http://{addr}");
+
+    let client = reqwest::Client::new();
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let marker_path = root.path().join("seen.json");
+
+    let confirmed_session = || {
+        let mut s = ls_test_session("id-a", "errored", None, None, None, None);
+        s.id = "id-a".to_string();
+        s.unresumable = true;
+        s
+    };
+
+    // A FRESH sentinel (just now) must block — no decommission attempted.
+    let mut seen = std::collections::HashMap::new();
+    seen.insert("id-a".to_string(), "2020-01-01T00:00:00Z".to_string());
+    seen.insert(
+        "__stale_daemon_detected__".to_string(),
+        chrono::Utc::now().to_rfc3339(),
+    );
+    std::fs::write(&marker_path, serde_json::to_string(&seen).unwrap()).unwrap();
+
+    let outcome =
+        auto_prune_dead_records_at(&client, &url, vec![confirmed_session()], &marker_path).await;
+    assert_eq!(outcome.pruned, 0, "a fresh sentinel must still block");
+    assert_eq!(outcome.kept.len(), 1);
+    assert_eq!(outcome.pending, 1, "held record must fold into pending");
+
+    // An EXPIRED sentinel (well past the 1-hour TTL) must let this call
+    // retry. This stub always reports `workspace_removed: true`, so the
+    // retry immediately re-trips a FRESH sentinel — proving both halves:
+    // expiry allows a retry, and a still-stale daemon re-blocks right away.
+    let mut seen = std::collections::HashMap::new();
+    seen.insert("id-a".to_string(), "2020-01-01T00:00:00Z".to_string());
+    seen.insert(
+        "__stale_daemon_detected__".to_string(),
+        "2020-01-01T00:00:00Z".to_string(),
+    );
+    std::fs::write(&marker_path, serde_json::to_string(&seen).unwrap()).unwrap();
+
+    let outcome =
+        auto_prune_dead_records_at(&client, &url, vec![confirmed_session()], &marker_path).await;
+    assert_eq!(
+        outcome.pruned, 0,
+        "the stub is still stale, so the retry must not count as pruned"
+    );
+    assert_eq!(outcome.kept.len(), 1);
+
+    // The re-trip must have rewritten a FRESH sentinel — verified directly
+    // against the persisted marker file, not merely inferred from behavior.
+    let raw = std::fs::read_to_string(&marker_path).expect("read marker file");
+    let persisted: std::collections::HashMap<String, String> =
+        serde_json::from_str(&raw).expect("parse marker file");
+    let sentinel_ts = persisted
+        .get("__stale_daemon_detected__")
+        .expect("sentinel must be re-written after retry");
+    let parsed = chrono::DateTime::parse_from_rfc3339(sentinel_ts).expect("valid RFC 3339");
+    assert!(
+        chrono::Utc::now().signed_duration_since(parsed) < chrono::Duration::minutes(1),
+        "the re-tripped sentinel must be freshly timestamped, not the expired one"
+    );
 
     handle.abort();
 }

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -1927,6 +1927,79 @@ async fn auto_prune_dead_records_honors_the_cap() {
     assert_eq!(second.kept.len(), 1);
 }
 
+/// Critic CRITICAL (2026-07-30 re-review): a STALE daemon that silently
+/// ignores `?record_only=true` (no `Query<DecommissionQuery>` extractor —
+/// exactly what a pre-this-fix build looks like) and reports
+/// `workspace_removed: true` must NEVER be counted as a safe prune, and the
+/// sweep must stop attempting further decommissions for the rest of this
+/// call (and any later call sharing the same marker file).
+///
+/// Why: an HTTP 200 alone cannot distinguish "genuinely record-only" from
+/// "an old daemon ran the full destructive teardown anyway" — both return
+/// 200. Only the response body's `workspace_removed` field can, so this test
+/// drives a STUB server (not the real daemon/SessionManager) that mimics the
+/// old handler exactly: it accepts the POST, ignores every query param, and
+/// always reports `workspace_removed: true`.
+/// What: two CONFIRMED-dead session ids hit the stub in one call. The first
+/// one's stale response must trip the stop; the second must never even be
+/// attempted (it survives in `kept` untouched, `pruned` stays 0 for both).
+#[tokio::test]
+async fn auto_prune_dead_records_stops_sweep_when_daemon_reports_workspace_removed() {
+    // Stub daemon: mimics a PRE-#4384 build — no `Query<DecommissionQuery>`
+    // extractor on the route at all, so `record_only` is silently dropped by
+    // axum; always answers with the OLD full-teardown shape.
+    async fn stub_decommission(
+        axum::extract::Path(_id): axum::extract::Path<String>,
+    ) -> axum::Json<serde_json::Value> {
+        axum::Json(serde_json::json!({ "workspace_removed": true }))
+    }
+    let app = axum::Router::new().route(
+        "/api/v1/sessions/managed/{id}/decommission",
+        axum::routing::post(stub_decommission),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind loopback port");
+    let addr = listener.local_addr().expect("resolve bound addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    let url = format!("http://{addr}");
+
+    let client = reqwest::Client::new();
+    let root = tempfile::TempDir::new().expect("tempdir");
+    let marker_path = root.path().join("seen.json");
+
+    // Pre-seed BOTH ids as already-confirmed (first-sighted on a prior,
+    // separate call) so this test isolates the stale-daemon STOP behavior
+    // from the two-sightings confirmation logic covered elsewhere.
+    let mut seen = std::collections::HashMap::new();
+    seen.insert("id-a".to_string(), "2020-01-01T00:00:00Z".to_string());
+    seen.insert("id-b".to_string(), "2020-01-01T00:00:00Z".to_string());
+    std::fs::write(&marker_path, serde_json::to_string(&seen).unwrap()).unwrap();
+
+    let mut a = ls_test_session("id-a", "errored", None, None, None, None);
+    a.id = "id-a".to_string();
+    a.unresumable = true;
+    let mut b = ls_test_session("id-b", "errored", None, None, None, None);
+    b.id = "id-b".to_string();
+    b.unresumable = true;
+
+    let outcome = auto_prune_dead_records_at(&client, &url, vec![a, b], &marker_path).await;
+    assert_eq!(
+        outcome.pruned, 0,
+        "a stale daemon's workspace_removed=true must never count as pruned"
+    );
+    assert_eq!(
+        outcome.kept.len(),
+        2,
+        "both records must be left on the manual [d<N>] path once the stale \
+         daemon is detected"
+    );
+
+    handle.abort();
+}
+
 /// `fetch_live_sessions(allow_auto_prune = false)` is a pure read — a
 /// non-interactive listing (scripted/cron/CI bare `tm` or `tm ls`) must never
 /// trigger the destructive auto-prune sweep (critic HIGH finding #3).

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -825,20 +825,44 @@ pub async fn resume_managed_session(
     }
 }
 
+/// Query parameters for POST /api/v1/sessions/managed/{id}/decommission
+/// (owner request 2026-07-29, critic HIGH finding #1).
+///
+/// Why: the `tm ls`/bare `tm` auto-prune sweep must be structurally incapable
+/// of removing filesystem content — a remount between its listing-time probe
+/// and this call could otherwise reach a real `remove_dir_all`. Rather than
+/// trust every future caller to re-check, the route itself routes to a
+/// removal-free teardown when asked.
+/// What: `record_only` (default `false`, `#[serde(default)]` keeps every
+/// existing caller's plain POST unaffected) selects
+/// [`SessionManager::decommission_record_only`] instead of
+/// [`SessionManager::decommission`].
+/// Test: `decommission_record_only_never_removes_existing_workspace`
+/// (`session_manager::tests`).
+#[derive(Debug, serde::Deserialize)]
+pub struct DecommissionQuery {
+    #[serde(default)]
+    pub record_only: bool,
+}
+
 /// POST /api/v1/sessions/managed/{id}/decommission — full teardown.
 ///
 /// Why: the ONLY operation that removes the workspace from disk. Unlike `stop`,
 /// decommission is terminal — no further `resume` is possible.
 /// What: delegates to SessionManager::decommission (kills runtime, removes
-/// workspace dir when owned, marks record Decommissioned). Returns a
-/// [`DecommissionResponse`] that includes `workspace_removed` so callers can
-/// display an honest message reflecting whether the filesystem was actually
-/// mutated (e.g. adopted/local-path workspaces are NEVER deleted).
+/// workspace dir when owned, marks record Decommissioned) — or, when
+/// `?record_only=true`, to [`SessionManager::decommission_record_only`]
+/// (never touches disk). Returns a [`DecommissionResponse`] that includes
+/// `workspace_removed` so callers can display an honest message reflecting
+/// whether the filesystem was actually mutated (e.g. adopted/local-path
+/// workspaces are NEVER deleted).
 /// Test: `manager_decommission_removes_workspace`;
-/// `decommission_workspace_removed_reflects_ownership`.
+/// `decommission_workspace_removed_reflects_ownership`;
+/// `decommission_record_only_never_removes_existing_workspace`.
 pub async fn decommission_managed_session(
     State(state): State<Arc<DaemonState>>,
     AxumPath(id_str): AxumPath<String>,
+    axum::extract::Query(q): axum::extract::Query<DecommissionQuery>,
 ) -> impl IntoResponse {
     let id = match parse_id(&id_str) {
         Ok(id) => id,
@@ -852,7 +876,12 @@ pub async fn decommission_managed_session(
     let pre = mgr.get(&id).await.ok();
     let pre_owned = pre.as_ref().map(|r| r.workspace_owned).unwrap_or(false);
     let pre_ws = pre.and_then(|r| r.workspace_path);
-    match mgr.decommission(&id, None).await {
+    let outcome = if q.record_only {
+        mgr.decommission_record_only(&id).await
+    } else {
+        mgr.decommission(&id, None).await
+    };
+    match outcome {
         Ok((record, workspace_removed)) => {
             // workspace_path_was: only meaningful for owned sessions (those where
             // `decommission_with_root` might have removed the directory).

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -341,7 +341,36 @@ impl SessionManager {
     ) -> Result<(SessionRecord, bool), ManagedError> {
         let config = TrustyToolsConfig::load();
         let managed_root = workspace_root(&config);
-        self.decommission_with_root(id, &managed_root, caller).await
+        self.decommission_with_root(id, &managed_root, caller, false)
+            .await
+    }
+
+    /// Tombstone a record WITHOUT ever touching the filesystem (owner request
+    /// 2026-07-29, critic HIGH finding #1).
+    ///
+    /// Why: `tm ls`/bare `tm`'s auto-prune sweep only knows a workspace was
+    /// ABSENT at listing time — a remount (network/removable volume) between
+    /// that probe and a real `decommission()` call could otherwise reach
+    /// `remove_dir_all` with live content back in place. This wrapper skips
+    /// BOTH removal branches entirely (never the worktree path, never the
+    /// owned-directory path) — there is no re-check to race, because there is
+    /// no removal attempt at all. If the workspace is genuinely gone there is
+    /// nothing to remove; if it reappeared, nothing is deleted. `caller: None`
+    /// — this is a daemon-internal sweep, never a session acting on its own
+    /// behalf.
+    /// What: [`decommission_with_root`](Self::decommission_with_root) with
+    /// `record_only = true`. The returned `bool` is always `false` (nothing is
+    /// ever removed by this path).
+    /// Test: `decommission_record_only_never_removes_existing_workspace`
+    /// (remount-race stand-in — a REAL, populated directory survives the call).
+    pub async fn decommission_record_only(
+        &self,
+        id: &ManagedSessionId,
+    ) -> Result<(SessionRecord, bool), ManagedError> {
+        let config = TrustyToolsConfig::load();
+        let managed_root = workspace_root(&config);
+        self.decommission_with_root(id, &managed_root, None, true)
+            .await
     }
 
     /// Internal: decommission with an explicit managed root (test seam).
@@ -352,6 +381,9 @@ impl SessionManager {
     /// parallel tests; injecting the root avoids that entirely.
     /// What: identical teardown logic as the public `decommission` but resolves the
     /// managed root from the caller-supplied `managed_root` instead of the config.
+    /// `record_only` (owner request 2026-07-29): when `true`, BOTH removal
+    /// branches below are skipped unconditionally — see
+    /// [`decommission_record_only`](Self::decommission_record_only)'s doc.
     /// Returns `(SessionRecord, workspace_removed)` where `workspace_removed` is
     /// `true` ONLY when `remove_dir_all` actually ran — callers must not infer this
     /// from a post-call filesystem check (TOCTOU: owned workspace already absent
@@ -363,6 +395,7 @@ impl SessionManager {
         id: &ManagedSessionId,
         managed_root: &Path,
         caller: Option<ManagedSessionId>,
+        record_only: bool,
     ) -> Result<(SessionRecord, bool), ManagedError> {
         let mut record = self.get(id).await?;
 
@@ -403,8 +436,12 @@ impl SessionManager {
 
         // Guard: only remove the workspace directory if the SM provisioned it.
         // Track whether remove_dir_all ACTUALLY RAN (not inferred from filesystem).
+        // `record_only` (owner request 2026-07-29): skip BOTH removal branches
+        // below unconditionally — see `decommission_record_only`'s doc. The
+        // `workspace_still_on_disk` re-check further down still runs, so a
+        // genuinely-absent workspace is still cleared from the tombstone.
         let mut workspace_removed = false;
-        if let Some(ref ws) = record.workspace_path {
+        if !record_only && let Some(ref ws) = record.workspace_path {
             if !record.workspace_owned {
                 // Unowned workspace (local-path spawn or adopt): never bulk-delete.
                 // #1840: EXCEPTION — in-project per-session worktrees live under
@@ -743,7 +780,7 @@ mod tests {
         let session_a = ManagedSessionId::new();
         let managed_root = crate::test_support::hermetic_temp_dir();
         let err = mgr
-            .decommission_with_root(&session_b, managed_root.path(), Some(session_a))
+            .decommission_with_root(&session_b, managed_root.path(), Some(session_a), false)
             .await
             .expect_err("session A must be refused decommissioning session B's live worktree");
         match err {
@@ -782,7 +819,7 @@ mod tests {
 
         let managed_root = crate::test_support::hermetic_temp_dir();
         let (record, _workspace_removed) = mgr
-            .decommission_with_root(&session_id, managed_root.path(), Some(session_id))
+            .decommission_with_root(&session_id, managed_root.path(), Some(session_id), false)
             .await
             .expect("self-decommission must be allowed");
         assert_eq!(record.state, ManagedSessionState::Decommissioned);
@@ -815,7 +852,7 @@ mod tests {
 
         let caller = ManagedSessionId::new();
         let managed_root = crate::test_support::hermetic_temp_dir();
-        mgr.decommission_with_root(&target, managed_root.path(), Some(caller))
+        mgr.decommission_with_root(&target, managed_root.path(), Some(caller), false)
             .await
             .expect(
                 "decommissioning an already-terminal, provably-ownerless target must be allowed",
@@ -844,7 +881,7 @@ mod tests {
 
         let managed_root = crate::test_support::hermetic_temp_dir();
         let (record, _workspace_removed) = mgr
-            .decommission_with_root(&session_id, managed_root.path(), None)
+            .decommission_with_root(&session_id, managed_root.path(), None, false)
             .await
             .expect("operator (caller=None) decommission must never be gated");
         assert_eq!(record.state, ManagedSessionState::Decommissioned);

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -147,7 +147,7 @@ async fn manager_decommission_removes_real_git_worktree() {
     // API requires one — point it at an unrelated temp dir.
     let managed_root = crate::test_support::hermetic_temp_dir();
     let (tombstone, workspace_removed) = mgr
-        .decommission_with_root(&record.id, managed_root.path(), None)
+        .decommission_with_root(&record.id, managed_root.path(), None, false)
         .await
         .expect("decommission");
 
@@ -290,7 +290,7 @@ async fn manager_decommission_refuses_dirty_worktree() {
 
     let managed_root = crate::test_support::hermetic_temp_dir();
     let (tombstone, workspace_removed) = mgr
-        .decommission_with_root(&record.id, managed_root.path(), None)
+        .decommission_with_root(&record.id, managed_root.path(), None, false)
         .await
         .expect("decommission");
 

--- a/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/reactivate_tests.rs
@@ -184,7 +184,7 @@ async fn mark_reactivated_refuses_when_workspace_removed_by_decommission() {
         .expect("create");
 
     let (tombstone, workspace_removed) = mgr
-        .decommission_with_root(&record.id, managed_root.path(), None)
+        .decommission_with_root(&record.id, managed_root.path(), None, false)
         .await
         .expect("decommission");
     assert!(

--- a/crates/trusty-mpm/src/session_manager/tests.rs
+++ b/crates/trusty-mpm/src/session_manager/tests.rs
@@ -743,7 +743,7 @@ async fn manager_decommission_removes_workspace() {
 
     // Decommission using the injectable root — no unsafe env mutation.
     let (tombstone, workspace_removed) = mgr
-        .decommission_with_root(&record.id, managed_root.path(), None)
+        .decommission_with_root(&record.id, managed_root.path(), None, false)
         .await
         .expect("decommission");
 
@@ -773,6 +773,82 @@ async fn manager_decommission_removes_workspace() {
     let after = mgr.get(&record.id).await.unwrap();
     assert_eq!(after.state, ManagedSessionState::Decommissioned);
     assert!(after.workspace_path.is_none());
+}
+
+/// `decommission_record_only` (owner request 2026-07-29, critic HIGH finding
+/// #1) NEVER removes filesystem content — a remount-race stand-in: the
+/// workspace directory genuinely EXISTS (and holds real content) at call
+/// time, exactly as it would if a network/removable volume remounted between
+/// the `tm ls` auto-prune's listing-time probe and this call. The directory
+/// and its content must survive untouched, even though the record IS
+/// tombstoned to `Decommissioned`.
+///
+/// Why: this is the auto-prune sweep's actual safety net — [`is_unresumable`]
+/// can only observe "absent right now," never "will stay absent," so the
+/// call that ACTS on that observation must be structurally incapable of
+/// deleting anything, not merely re-check-and-hope.
+/// What: same fixture as [`manager_decommission_removes_workspace`] (a real,
+/// owned, populated workspace dir), but calls `decommission_with_root` with
+/// `record_only = true`. Asserts `workspace_removed == false`, the directory
+/// AND its sentinel file still exist on disk, the tombstone is
+/// `Decommissioned`, and — because the path is STILL on disk — the record's
+/// `workspace_path` is retained (not nulled), mirroring the #4344
+/// dirty-retained boundary.
+/// Test: this function IS the test.
+#[tokio::test]
+async fn decommission_record_only_never_removes_existing_workspace() {
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    let workspace_path = managed_root
+        .path()
+        .join("owner")
+        .join("repo")
+        .join("remount-race-session-id");
+    std::fs::create_dir_all(&workspace_path).unwrap();
+    std::fs::write(workspace_path.join("sentinel.txt"), "still here").unwrap();
+
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "task".into(),
+            Some(workspace_path.clone()),
+            None,
+            Some(workspace_path.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            true, // owned: SM provisioned via clone
+        )
+        .await
+        .expect("create");
+
+    let (tombstone, workspace_removed) = mgr
+        .decommission_with_root(&record.id, managed_root.path(), None, true)
+        .await
+        .expect("record-only decommission");
+
+    assert!(
+        !workspace_removed,
+        "record_only must never report a removal"
+    );
+    assert_eq!(tombstone.state, ManagedSessionState::Decommissioned);
+    assert!(
+        workspace_path.exists(),
+        "the workspace directory must survive a record-only decommission"
+    );
+    assert!(
+        workspace_path.join("sentinel.txt").exists(),
+        "real content inside the workspace must survive untouched"
+    );
+    assert_eq!(
+        tombstone.workspace_path.as_deref(),
+        Some(workspace_path.as_path()),
+        "workspace_path must be RETAINED (not nulled) since the directory is \
+         still genuinely on disk — mirrors the #4344 dirty-retained boundary"
+    );
 }
 
 // Build a minimal Active session record for reconcile tests (avoids repeating


### PR DESCRIPTION
## Summary

Owner request 2026-07-29. Two picker fixes:

1. **Auto-prune DEAD records.** Bob's pasted `tm ls` output showed rows like
   `[50] tm-tagents-dead-20260722 (stopped) — DEAD: workspace removed; use
   [d50] to remove the record`. Before this PR, that row sat forever — the
   operator had to notice it and manually type `d<N>`. `fetch_live_sessions`
   (the picker's shared fetch path — used by bare `tm`, `tm ls`'s interactive
   branch, and the picker's own re-fetch loop) now auto-decommissions every
   session the daemon flags `unresumable` and prints a one-line
   `tm: pruned N dead record(s) (workspace gone)` summary instead of prompting.

2. **Ordering.** The listing now groups **attached → active → everything else**
   ABOVE whichever `recent`/`alpha` secondary sort was requested (`tm ls
   recent|alpha` from #3485 is unchanged as the secondary key within each
   group).

## Safety boundary (#4344)

`unresumable` (`session_manager::resume_workdir::is_unresumable`) is already
the exact narrow predicate this needed: `true` only for a `stopped`/`errored`
record whose *every* workdir candidate (`last_cwd`, `workspace_path`, `cwd`)
is confirmed absent from disk via `tokio::fs::try_exists`.

#4344 (merged today, `114de333`) made a record whose worktree removal was
refused for being dirty retain its `workspace_path` pointing at a directory
that **still exists**. Because `is_unresumable` probes that exact path and
returns `false` the instant any candidate is found present, such a record can
never read `unresumable == true` in the first place — it is structurally
excluded from auto-prune before this PR's partition logic even runs. No
extra existence check was needed to enforce that boundary; a test
(`auto_prune_dead_records_keeps_workspace_present_records`) pins it directly
against a real stopped session with an on-disk workspace.

The actual removal is routed through the existing `/decommission` HTTP route
— the *same* dirty-worktree-gated teardown path #4344 hardened — never a raw
`fs::remove` or a hand-edited store entry.

## Changes

- `crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs` (new):
  `auto_prune_dead_records` (partition + drive) and `decommission_dead_record`
  (the one HTTP primitive, best-effort per record). Extracted out of
  `session_picker.rs` to keep it under the 500-SLOC production cap.
- `crates/trusty-mpm/src/bin/tm/commands/session_picker.rs`: wires the
  auto-prune into `fetch_live_sessions`; adds `group_rank` and updates
  `sort_sessions` to key on it first.
- `crates/trusty-mpm/src/bin/tm/commands/mod.rs`: registers the new module.
- `crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs`: new tests —
  `auto_prune_dead_records_removes_unresumable_records` (real loopback daemon,
  a genuinely dead record disappears and the daemon's own store reflects the
  teardown), `auto_prune_dead_records_keeps_workspace_present_records` (the
  #4344 boundary), `auto_prune_dead_records_is_noop_when_nothing_is_dead`,
  `sort_sessions_recent_groups_attached_before_active_before_stopped`,
  `sort_sessions_alpha_groups_attached_before_active_before_stopped`.
- `crates/trusty-mpm/CHANGELOG.md`: `[Unreleased]` entry.

No existing open issue covers either behavior (searched `tm ls dead`,
`picker order`, `auto prune record`) — this PR stands alone per direct owner
instruction.

## Follow-ups (not fixed here, deliberately deferred)

- `decommission.rs`'s owned/non-worktree removal branch still has no
  `inspect_dirt` gate — the sibling worktree branch got one from #4344, this
  one didn't. Not introduced or worsened by this PR (auto-prune's own
  exposure to it is now zero via `decommission_record_only`'s
  `record_only` skip, which bypasses both removal branches unconditionally);
  the gap is pre-existing since #4344 itself. Deferred here purely because
  `decommission.rs` has ~12 SLOC of headroom left under the 500-SLOC
  production cap after this PR's changes — not enough room for the ~25-SLOC
  mirror without a file split. Affects `decommission()`'s other callers
  (manual `tm session decommission`, `tm sessions prune --state stopped`).

## Test plan

- [x] `cargo fmt --check -p trusty-mpm`
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- [x] `cargo test -p trusty-mpm` (full suite: 3972 lib + 1295 bin/tm + all
      integration binaries — 0 failed)
- [x] `scripts/check_line_cap.sh` — 0 violations
- [x] `scripts/check_test_pointers.sh` — 0 dangling pointers

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
