### PR TITLE
feat(trusty-mpm): JSON instruction manifest (schema v2) with owner language rules

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -106,6 +106,58 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 
+- The bundled PM instruction package is now an **authored JSON manifest**, not a
+  Rust literal
+  ([#4318](https://github.com/bobmatnyc/trusty-tools/issues/4318), part of
+  [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183)). Sections,
+  customization tiers, block order, joins, the declared generators, and the
+  roster-precedence note all live in
+  `assets/instructions/pm-instruction-package.json`;
+  `bundled_pm_package::bundled_fallback_package()` parses that file instead of
+  constructing an `InstructionPackage` in code, so there is no second place a
+  join or a block order can be edited. `InstructionPackage::from_json` had zero
+  non-test call sites before this and the shipped JSON Schema had no instance
+  under it — both are now live.
+
+  **Instruction-package schema v2**: adds a `{"kind":"file","path":"…"}` body
+  variant alongside `text` and `generated`. Prose keeps living in reviewable
+  markdown under `sections/`; the manifest references it by path and resolves it
+  through a compile-time `include_str!` table
+  (`instruction_pipeline::SECTION_SOURCES`), so the build stays hermetic, a
+  renamed section is a compile error, and `check_instruction_floor.sh` keeps
+  grepping real files. Inlining the prose instead would have turned `core.md`
+  into one 23 KB JSON line. The version bump is required by the format's own
+  evolution policy: a v1 build reading a v2 manifest rejects it loudly rather
+  than composing a prompt missing the new field's effect.
+
+  The mechanism half is byte-identical — all three composed-prompt goldens passed
+  unchanged before the content below was added.
+
+- PM instructions: three owner language rules, authored as inline `text` blocks
+  in the manifest rather than in markdown (owner order, 2026-07-29 — the 1.3
+  rules belong in JSON). Same family as the plain-prose rule from
+  [#4316](https://github.com/bobmatnyc/trusty-tools/pull/4316).
+
+  | rule | section | substance |
+  |---|---|---|
+  | Clickable References | `core` | issue/PR/ticket/commit references always render as clickable markdown links, never bare numbers |
+  | Banned Word — "honest" | `core` | "honest" and every variation is banned from PM responses, delegation briefs and review instructions; a report states facts, and labelling them honest implies the alternative was considered |
+  | Opportunistic Fixes | `workflow` | an easy fix found while working on a file is noted on the CURRENT issue and made in the same work — never a new issue; new issues are for genuinely separable schedulable work |
+
+  Delivered to every launch path, not just the packaged composer:
+  `pm_instructions()`, `base_pm()`, the new `workflow_section()` and
+  `delegation_doctrine()` now project the manifest through
+  `InstructionPackage::authored_run` instead of rebuilding from the section
+  constants, so the legacy `.trusty-mpm/` override assembly and the roster-free
+  `assemble_system_prompt()` (what `tm install` writes and `tm launch` passes to
+  `--append-system-prompt-file`) carry the same rules. Rebuilding from the
+  constants would have delivered a manifest-authored rule to one composer and
+  silently withheld it from the others. `core` and `workflow` remain
+  `customization_tier: project`, so a `CLAUDE.md` named-section override still
+  replaces them wholesale — visible in the regenerated
+  `pm-prompt-claude-md-override.md`, which correctly does NOT carry the workflow
+  rule.
+
 - `tm ls` STATE column: a row the daemon did not probe now renders
   `[assets ?]` rather than nothing, so the absence of `[stale-assets]` can
   never be misread as "assets fresh"

--- a/crates/trusty-mpm/src/assets/instructions/instruction-package.schema.json
+++ b/crates/trusty-mpm/src/assets/instructions/instruction-package.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/bobmatnyc/trusty-tools/schemas/instruction-package-v1.json",
+  "$id": "https://github.com/bobmatnyc/trusty-tools/schemas/instruction-package-v2.json",
   "title": "trusty-mpm instruction package",
   "description": "A PM instruction package: a section taxonomy carrying the customization-tier axis, plus an ORDERED block stream that composes to the PM system prompt. Ordering is array order — never map iteration order — so composition is byte-deterministic (SPEC-PMINSTR-01 / DOC-59 §4a, epic #4183, schema ticket #4184).",
   "type": "object",
@@ -8,8 +8,8 @@
   "required": ["schema_version", "package_id", "sections", "blocks"],
   "properties": {
     "schema_version": {
-      "description": "Schema major version. A package whose version this build does not implement is rejected outright — never partially interpreted; the version is checked BEFORE any field, so a newer package reports a version error rather than blaming one of its own valid keys. EVOLUTION POLICY: every object here sets `additionalProperties: false`, so unknown keys are errors, not ignored. Any field addition that can change composed bytes MUST bump this version. Adding a field while leaving the version at 1 is the one case strictness cannot protect against — an older build would compose a prompt missing the new field's effect and report success.",
-      "const": 1
+      "description": "Schema major version. A package whose version this build does not implement is rejected outright — never partially interpreted; the version is checked BEFORE any field, so a newer package reports a version error rather than blaming one of its own valid keys. EVOLUTION POLICY: every object here sets `additionalProperties: false`, so unknown keys are errors, not ignored. Any field addition that can change composed bytes MUST bump this version. Adding a field while leaving the version unchanged is the one case strictness cannot protect against — an older build would compose a prompt missing the new field's effect and report success. HISTORY: v1 (#4184) shipped `text` and `generated` bodies; v2 (#4318) adds the `file` body kind so an authored JSON manifest can reference bundled markdown instead of inlining 23 KB of prose on one line.",
+      "const": 2
     },
     "package_id": {
       "description": "Stable identifier for this package (e.g. `trusty-mpm/pm`). Identity only; it never affects composed bytes.",
@@ -76,7 +76,7 @@
       ]
     },
     "body": {
-      "description": "Where a block's markdown comes from. `text` is authored in the package; `generated` is supplied at composition time by the named generator.",
+      "description": "Where a block's markdown comes from. `text` is authored inline in the package; `file` names a markdown source bundled with the build; `generated` is supplied at composition time by the named generator.",
       "oneOf": [
         {
           "type": "object",
@@ -85,6 +85,20 @@
           "properties": {
             "kind": { "const": "text" },
             "text": { "type": "string", "minLength": 1 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "path"],
+          "description": "Schema v2 (#4318). The path is resolved against the build's compile-time `include_str!` table (`instruction_pipeline::SECTION_SOURCES`), NOT against the filesystem at composition time — so the delivered prompt never depends on what happens to be on disk, and a renamed section is a compile error rather than a silent content drop. A path the build does not bundle is a hard validation error. Prose therefore keeps living in reviewable markdown while this document carries only the manifest; `text` remains available for a rule authored in the manifest itself.",
+          "properties": {
+            "kind": { "const": "file" },
+            "path": {
+              "description": "Path relative to `assets/instructions/`, e.g. `sections/core.md`.",
+              "type": "string",
+              "minLength": 1
+            }
           }
         },
         {
@@ -127,9 +141,9 @@
   },
   "examples": [
     {
-      "schema_version": 1,
+      "schema_version": 2,
       "package_id": "trusty-mpm/example",
-      "description": "Minimal structurally-valid package. Content authoring is #4185; this example exists so the schema's own shape is executable and testable.",
+      "description": "Minimal structurally-valid package, exercising all three body kinds. The shipped instance is `pm-instruction-package.json`; this example exists so the schema's own shape stays executable and testable.",
       "trailing_newline": false,
       "sections": [
         {
@@ -216,7 +230,7 @@
         },
         {
           "section": "identity",
-          "body": { "kind": "text", "text": "## Identity" }
+          "body": { "kind": "file", "path": "sections/identity.md" }
         },
         {
           "section": "non-overridable-rules",

--- a/crates/trusty-mpm/src/assets/instructions/pm-instruction-package.json
+++ b/crates/trusty-mpm/src/assets/instructions/pm-instruction-package.json
@@ -1,0 +1,148 @@
+{
+  "schema_version": 2,
+  "package_id": "trusty-mpm.pm.bundled-fallback",
+  "description": "The DEFAULT PM instruction package (#4318). This file — not a Rust literal — is the authored manifest: the section taxonomy with its customization tiers, the ordered block stream, every join, and the declared composition-time generators. Bulk prose lives in `sections/*.md` and is referenced by `file` bodies; a rule authored here rather than in a section file uses a `text` body. Composition is byte-deterministic for a given manifest and roster (see `instruction_package::InstructionPackage::compose`). Deliberately carries NO `$schema` key: every object in the format sets `additionalProperties: false` / `deny_unknown_fields`, so an unrecognised key is a hard parse error rather than dropped instruction content. Validate against `instruction-package.schema.json` out of band.",
+  "trailing_newline": false,
+  "sections": [
+    {
+      "id": "identity",
+      "title": "Identity",
+      "customization_tier": "fixed",
+      "description": "Who the PM is. Framework floor."
+    },
+    {
+      "id": "core",
+      "title": "Core PM Instructions",
+      "customization_tier": "project",
+      "description": "Core operating instructions, including response format and prose rules."
+    },
+    {
+      "id": "memory",
+      "title": "Memory Protocol",
+      "customization_tier": "project"
+    },
+    {
+      "id": "search",
+      "title": "Code Search Protocol",
+      "customization_tier": "project"
+    },
+    {
+      "id": "workflow",
+      "title": "Workflow",
+      "customization_tier": "project",
+      "description": "The phase workflow, including the sprint-then-harden doctrine."
+    },
+    {
+      "id": "agent-delegation",
+      "title": "Agent Delegation",
+      "customization_tier": "project",
+      "description": "Routing doctrine; the live roster is appended by the `agent-roster` generator."
+    },
+    {
+      "id": "non-overridable-rules",
+      "title": "Non-Overridable Rules",
+      "customization_tier": "fixed",
+      "description": "Non-overridable rules, the customization contract, and the Trusty tool-priority mandate. Framework floor."
+    },
+    {
+      "id": "framework-guaranteed-conventions",
+      "title": "Framework-Guaranteed Conventions",
+      "customization_tier": "fixed",
+      "description": "Attribution footer, documentation proportionality, ticket attribution. Framework floor."
+    }
+  ],
+  "blocks": [
+    {
+      "section": "core",
+      "join_before": "rule",
+      "body": { "kind": "file", "path": "sections/core.md" }
+    },
+    {
+      "section": "core",
+      "join_before": "blank",
+      "body": {
+        "kind": "text",
+        "text": "### Clickable References\n\nEvery reference to an issue, PR, ticket, or commit renders as a clickable markdown link — never a bare number.\n\n- Issues and PRs: `[#4318](https://github.com/<owner>/<repo>/issues/4318)`. GitHub resolves the `/issues/` form to a PR, so one shape covers both.\n- Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.\n- Tickets in another tracker: link to that tracker's issue URL.\n\nThis applies to every PM response and report, not only formal ones. \"Fixed in #4318\" with no link is a defect."
+      }
+    },
+    {
+      "section": "core",
+      "join_before": "blank",
+      "body": {
+        "kind": "text",
+        "text": "### Banned Word — \"honest\"\n\n\"Honest\" and every variation of it — honestly, honesty, dishonest, \"to be honest\", \"the honest answer\" — is banned from PM responses, delegation briefs, and review instructions.\n\nA report states facts. Labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel. State the fact.\n\n- Wrong: \"The honest answer is that the merge didn't happen.\"\n- Right: \"The merge didn't happen.\""
+      }
+    },
+    {
+      "section": "memory",
+      "join_before": "blank",
+      "body": { "kind": "file", "path": "sections/memory.md" }
+    },
+    {
+      "section": "search",
+      "join_before": "blank",
+      "body": { "kind": "file", "path": "sections/search.md" }
+    },
+    {
+      "section": "core",
+      "join_before": "rule",
+      "body": { "kind": "generated", "generator": "stack-profile" },
+      "optional": true
+    },
+    {
+      "section": "workflow",
+      "join_before": "rule",
+      "body": { "kind": "file", "path": "sections/workflow.md" }
+    },
+    {
+      "section": "workflow",
+      "join_before": "blank",
+      "body": {
+        "kind": "text",
+        "text": "## Opportunistic Fixes\n\nAn easy fix discovered while working on a file is noted on the CURRENT issue and made in the same work. Never file a new issue for it.\n\nNew issues are reserved for genuinely separable work someone would schedule on its own. Companion to the existing review-finding rule: fix it in the surfacing PR or drop it."
+      }
+    },
+    {
+      "section": "agent-delegation",
+      "join_before": "rule",
+      "body": { "kind": "file", "path": "sections/agent-delegation.md" }
+    },
+    {
+      "section": "agent-delegation",
+      "join_before": "blank",
+      "body": {
+        "kind": "text",
+        "text": "> The live roster below is authoritative for WHICH agents exist and what each handles; the tables above are routing doctrine only. Where the two disagree, trust the roster.\n>\n> Depending on how this session was launched, a listed agent may not be loadable. If a dispatch fails with an unknown agent type, re-route to the closest listed alternative — do not retry the same agent."
+      }
+    },
+    {
+      "section": "agent-delegation",
+      "join_before": "blank",
+      "body": { "kind": "generated", "generator": "agent-roster" }
+    },
+    {
+      "section": "core",
+      "join_before": "rule",
+      "body": { "kind": "generated", "generator": "project-addendum" },
+      "optional": true
+    },
+    {
+      "section": "identity",
+      "join_before": "rule",
+      "body": { "kind": "file", "path": "sections/identity.md" }
+    },
+    {
+      "section": "non-overridable-rules",
+      "join_before": "blank",
+      "body": { "kind": "file", "path": "sections/non-overridable-rules.md" }
+    },
+    {
+      "section": "framework-guaranteed-conventions",
+      "join_before": "blank",
+      "body": {
+        "kind": "file",
+        "path": "sections/framework-guaranteed-conventions.md"
+      }
+    }
+  ]
+}

--- a/crates/trusty-mpm/src/core/bundled_pm_package.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package.rs
@@ -1,24 +1,34 @@
-//! The bundled-fallback PM prompt, expressed as an [`InstructionPackage`].
+//! The bundled-fallback PM prompt, loaded from the authored JSON manifest.
 //!
-//! Why: #4184 landed the sectioned-JSON package type and #4249 made it the
-//! composer for the DEFAULT PM prompt — the one every project with no
-//! `.trusty-mpm/` override receives. Both steps were mechanical: the package was
-//! still built by *cutting the legacy monolithic assets at runtime*, so the
-//! eight-section taxonomy described text that was authored as four blobs. This
-//! module now builds the package from **per-section sources** — one markdown
-//! file per [`SectionId`] under `assets/instructions/sections/` — which is what
-//! makes a section an editable, independently overridable unit rather than a
-//! documented offset into someone else's file (#4183).
+//! Why: #4184 landed the sectioned-JSON package type, #4249 made it the composer
+//! for the DEFAULT PM prompt, and #4183 split the prose into one markdown file per
+//! [`SectionId`]. One thing stayed wrong through all three: the package itself was
+//! still a **Rust literal**. Sections, tiers, block order, joins and generators
+//! were expressed as a `vec![]` in this file, `InstructionPackage::from_json` had
+//! zero non-test call sites, and the shipped JSON Schema was a type contract with
+//! no instance under it — while other tickets recorded "the composed instructions
+//! payload is generated from the instruction package JSON" as settled fact. #4318
+//! makes that true: the manifest is now
+//! `assets/instructions/pm-instruction-package.json`, embedded here at compile
+//! time, and this module only parses and composes it.
 //!
-//! What changed with the sourcing swap, and what did not:
+//! What the swap changed, and what it did not:
 //!
-//! * GONE — `split_asset`, the `Cut` tables, and the marker-uniqueness guards.
-//!   A marker that could silently relocate cannot exist when there is no marker;
-//!   the section boundary is now the file boundary. A mis-authored section is
-//!   caught by [`InstructionPackage::validate`] instead (an empty file is
-//!   `EmptyText`, a missing one fails to compile at `include_str!`).
-//! * UNCHANGED — the block stream's order, joins, and the composition mechanism.
-//!   [`InstructionPackage::compose`] is untouched by this module.
+//! * GONE — the `sections()` / `authored()` / `generated()` builders. There is no
+//!   second place where block order or a join can be edited, so the manifest and
+//!   the delivered prompt cannot disagree.
+//! * NEW — `file` bodies (schema v2). The manifest names its prose by path and
+//!   resolves it through the compile-time
+//!   [`crate::core::instruction_pipeline::SECTION_SOURCES`] table, so the bulk
+//!   text keeps living in reviewable markdown, the build stays hermetic, and a
+//!   renamed section is a compile error rather than an empty block.
+//! * NEW — inline `text` bodies now carry authored RULES, not just the
+//!   roster-precedence note: the clickable-links, banned-word and
+//!   opportunistic-fix rules are authored in the manifest itself (owner order,
+//!   2026-07-29: the 1.3 rules belong in JSON, not markdown).
+//! * UNCHANGED — [`InstructionPackage::compose`], the block order, and every join.
+//!   The mechanism half of #4318 is byte-identical to what #4183 shipped; the
+//!   golden diff carries content only.
 //!
 //! Scope — deliberately ONE of the three configurations
 //! [`crate::core::instruction_overrides::resolve_pm_prompt`] can emit:
@@ -38,222 +48,112 @@
 //! check is weakened here, and both configurations keep resolving exactly as
 //! they do today.
 //!
-//! THE BYTE-EQUALITY CONTRACT, and why it survives a content change. #4249's
-//! acceptance gate was byte-equality against the *pre-#4249* prompt, and that
-//! gate is necessarily gone here: this PR changes the delivered prompt on
-//! purpose. What remains — and is still asserted — is byte-equality between the
-//! TWO COMPOSERS: the packaged path and the legacy assembly must agree for the
-//! same inputs. That stays true without any pasted duplication, because
-//! [`crate::core::instruction_pipeline::pm_instructions`] and
-//! [`crate::core::instruction_pipeline::base_pm`] reconstitute the legacy
-//! multi-section strings *from these same section files*, joining them with the
-//! literal [`Join::Blank`] emits. Editing a section therefore moves both
-//! composers together; it cannot move one.
+//! NO SPLIT-BRAIN, which is the thing #4318 could most easily have broken. Once a
+//! rule may be authored in the manifest, rebuilding the legacy multi-section
+//! strings from the `include_str!` constants would deliver that rule to
+//! package-composed sessions and withhold it from configurations 2 and 3 and from
+//! `assemble_system_prompt`. So those callers no longer rebuild from constants —
+//! [`crate::core::instruction_pipeline::pm_instructions`],
+//! [`crate::core::instruction_pipeline::base_pm`],
+//! [`crate::core::instruction_pipeline::workflow_section`] and
+//! [`crate::core::instruction_pipeline::delegation_doctrine`] project the SAME
+//! manifest through [`InstructionPackage::authored_run`]. Editing the manifest
+//! moves every composer together; it cannot move one.
 //!
-//! What replaces the removed gate for CONTENT is
-//! `pm_prompt_golden_tests.rs`: a committed snapshot of the fully composed
-//! prompt for both configurations. Every future edit to a section file shows up
-//! there as a reviewable prose diff, which is the property #4183's acceptance
-//! criteria ask for and which byte-equality against a frozen legacy string could
-//! never provide.
+//! FAILURE BEHAVIOUR. The manifest is embedded, and
+//! `bundled_manifest_parses_and_validates` proves it parses, validates and
+//! composes — so a shipped build cannot reach the error path. If it somehow did,
+//! [`bundled_fallback_package`] returns `Err` and `resolve_pm_prompt_with_roster`
+//! logs it loudly and degrades to the legacy assembly built from the retained
+//! `include_str!` constants: a prompt missing only the manifest-authored inline
+//! rules, never a truncated one.
+//!
+//! What guards CONTENT is `pm_prompt_golden_tests.rs`: a committed snapshot of the
+//! fully composed prompt for all three configurations. Every edit to a section
+//! file or to the manifest shows up there as a reviewable prose diff.
 //!
 //! Test: `bundled_pm_package_tests.rs`.
 
+use std::sync::LazyLock;
+
 use crate::core::claude_md_sections::{Rejection, SectionOverride};
-use crate::core::instruction_overrides::ROSTER_PRECEDENCE_NOTE;
 use crate::core::instruction_package::{
-    BlockBody, CompositionError, CompositionInputs, CustomizationTier, Generator, InstructionBlock,
-    InstructionPackage, InstructionSection, Join, SCHEMA_VERSION, SectionId,
-};
-use crate::core::instruction_pipeline::{
-    AGENT_DELEGATION, SECTION_CORE, SECTION_FRAMEWORK_CONVENTIONS, SECTION_IDENTITY,
-    SECTION_MEMORY, SECTION_NON_OVERRIDABLE_RULES, SECTION_SEARCH, WORKFLOW,
+    CompositionError, CompositionInputs, InstructionPackage, SectionId,
 };
 
-/// Stable identity of the package this module builds.
+/// Stable identity of the package this module ships.
+///
+/// Checked against the loaded manifest, so pointing [`PM_PACKAGE_JSON`] at the
+/// wrong JSON file is a named error rather than a differently-shaped prompt.
 pub(crate) const PACKAGE_ID: &str = "trusty-mpm.pm.bundled-fallback";
 
-/// The declared eight-section taxonomy with the tiers this build ships.
+/// The authored manifest, embedded at compile time.
 ///
-/// Why: tiers are not decoration — they are the machine-readable statement of
-/// which `.trusty-mpm/` override files the floor advertises, and they are what
-/// #4247 will enforce. Now that each section has its own source file, the claim
-/// "a project may replace this one" is finally true of the artifact as well as
-/// of the schema: replacing Memory alone no longer orphans half a numbered list,
-/// which was the constraint the runtime-cut model recorded and could not fix.
-/// What: [`SectionId::CANONICAL`] paired with its tier and title. The five
-/// content sections are `project` because every advertised override file is
-/// project-scoped; the three floor sections are `fixed` because
-/// `resolve_pm_prompt` appends the floor last under every branch.
-/// Test: `every_advertised_override_file_maps_to_an_overridable_section`,
-/// `floor_sections_refuse_every_override_tier`,
-/// `content_sections_admit_project_but_not_user_overrides`.
-fn sections() -> Vec<InstructionSection> {
-    let declare = |id: SectionId, title: &str, tier: CustomizationTier| InstructionSection {
-        id,
-        title: title.to_string(),
-        customization_tier: tier,
-        description: None,
-    };
-    vec![
-        declare(SectionId::Identity, "Identity", CustomizationTier::Fixed),
-        declare(
-            SectionId::Core,
-            "Core PM Instructions",
-            CustomizationTier::Project,
-        ),
-        declare(
-            SectionId::Memory,
-            "Memory Protocol",
-            CustomizationTier::Project,
-        ),
-        declare(
-            SectionId::Search,
-            "Code Search Protocol",
-            CustomizationTier::Project,
-        ),
-        declare(SectionId::Workflow, "Workflow", CustomizationTier::Project),
-        declare(
-            SectionId::AgentDelegation,
-            "Agent Delegation",
-            CustomizationTier::Project,
-        ),
-        declare(
-            SectionId::NonOverridableRules,
-            "Non-Overridable Rules",
-            CustomizationTier::Fixed,
-        ),
-        declare(
-            SectionId::FrameworkGuaranteedConventions,
-            "Framework-Guaranteed Conventions",
-            CustomizationTier::Fixed,
-        ),
-    ]
-}
+/// Why: embedding means the delivered system prompt never depends on what is on
+/// disk at launch, and a manifest deleted or renamed in a refactor is a build
+/// failure rather than a silently degraded prompt.
+/// What: the raw bytes of `assets/instructions/pm-instruction-package.json`.
+/// Test: `bundled_manifest_parses_and_validates`.
+pub(crate) const PM_PACKAGE_JSON: &str =
+    include_str!("../assets/instructions/pm-instruction-package.json");
 
-/// A block whose content is an authored section source, trimmed.
-fn authored(section: SectionId, text: &str, join_before: Join) -> InstructionBlock {
-    InstructionBlock {
-        section,
-        body: BlockBody::Text {
-            text: text.trim().to_string(),
-        },
-        join_before,
-        optional: false,
+/// The parsed manifest, or the parse/validation failure, computed once.
+///
+/// Parsing on every session launch would be wasted work, and re-parsing is the
+/// kind of thing that quietly becomes a per-message cost. `LazyLock` also means
+/// the failure is computed once and reported identically everywhere.
+static BUNDLED: LazyLock<Result<InstructionPackage, String>> = LazyLock::new(|| {
+    let package = InstructionPackage::from_json(PM_PACKAGE_JSON).map_err(|err| err.to_string())?;
+    if package.package_id != PACKAGE_ID {
+        return Err(format!(
+            "manifest declares package_id `{}`, expected `{PACKAGE_ID}`",
+            package.package_id
+        ));
     }
-}
+    package.validate().map_err(|err| err.to_string())?;
+    Ok(package)
+});
 
-/// A block whose content arrives at composition time from a named generator.
-fn generated(
-    section: SectionId,
-    generator: Generator,
-    join_before: Join,
-    optional: bool,
-) -> InstructionBlock {
-    InstructionBlock {
-        section,
-        body: BlockBody::Generated { generator },
-        join_before,
-        optional,
-    }
-}
-
-/// Build the bundled-fallback package from the authored section sources.
+/// The bundled-fallback instruction package.
 ///
-/// Why: this is the executable statement of what the DEFAULT PM prompt is made
-/// of. Reading this one function answers "which section does this text belong
-/// to, and who may override it?" — and, since #4183's sourcing swap, the answer
-/// is a file you can open rather than a byte range.
+/// Why: this is the single entry point to "what the DEFAULT PM prompt is made
+/// of". It returns a `Result` (#4318) because the answer now comes from a parsed
+/// artifact rather than from Rust code that could not fail — and a parse failure
+/// must be reportable rather than papered over with a partial package.
 ///
-/// What, in emission order: Core, Memory and Search (the former
-/// `PM_INSTRUCTIONS.md`, now three files); the derived stack profile; Workflow;
-/// the delegation section — bundled doctrine, the roster-precedence note, and
-/// the live roster; the optional project addendum; then the three floor
-/// sections. Infallible by construction: every source is `include_str!`d, so a
-/// missing section is a compile error rather than a runtime one — which is why
-/// this returns a package rather than a `Result`.
+/// What: the manifest parsed and structurally validated once, borrowed. `Err`
+/// carries the rendered parse or validation error. Unreachable for the shipped
+/// manifest; see the module docs for the degradation path.
 ///
-/// Joins are chosen so the composed output is byte-identical to
-/// [`crate::core::instruction_overrides::assemble_sections`] for the same
-/// inputs: [`Join::Rule`] at every top-level boundary (the literal
-/// [`crate::core::instruction_pipeline::SECTION_SEPARATOR`]), [`Join::Blank`]
-/// wherever a former monolith held two sections in one string. The two
-/// generator-backed project inputs are `optional` because the legacy assembly
-/// likewise drops an empty section rather than emitting a dangling `---`. The
-/// agent roster is NOT optional — losing it is #4196.
-///
-/// Test: `shipped_sections_build_and_validate`,
+/// Test: `bundled_manifest_parses_and_validates`,
+/// `shipped_sections_build_and_validate`,
 /// `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`.
-pub(crate) fn bundled_fallback_package() -> InstructionPackage {
-    let blocks = vec![
-        // The former `PM_INSTRUCTIONS.md`, now three independently editable
-        // sources. `Join::Blank` reproduces the paragraph break that separated
-        // them inside the monolith.
-        authored(SectionId::Core, SECTION_CORE, Join::Rule),
-        authored(SectionId::Memory, SECTION_MEMORY, Join::Blank),
-        authored(SectionId::Search, SECTION_SEARCH, Join::Blank),
-        // Auto-derived framework context, not a user override (#1971). Optional
-        // only so an empty profile is dropped exactly as `join_sections` drops it.
-        generated(SectionId::Core, Generator::StackProfile, Join::Rule, true),
-        authored(SectionId::Workflow, WORKFLOW, Join::Rule),
-        // Delegation: bundled doctrine, the precedence note, then the LIVE
-        // roster (#4069/#4196). The roster block is non-optional by contract.
-        authored(SectionId::AgentDelegation, AGENT_DELEGATION, Join::Rule),
-        authored(
-            SectionId::AgentDelegation,
-            ROSTER_PRECEDENCE_NOTE,
-            Join::Blank,
-        ),
-        generated(
-            SectionId::AgentDelegation,
-            Generator::AgentRoster,
-            Join::Blank,
-            false,
-        ),
-        // Additive `.trusty-mpm/INSTRUCTIONS.md` rules, when the project has any.
-        generated(
-            SectionId::Core,
-            Generator::ProjectAddendum,
-            Join::Rule,
-            true,
-        ),
-        // The non-overridable floor, always last. `Join::Blank` between the three
-        // reproduces the paragraph breaks that separated them inside `BASE_PM.md`.
-        authored(SectionId::Identity, SECTION_IDENTITY, Join::Rule),
-        authored(
-            SectionId::NonOverridableRules,
-            SECTION_NON_OVERRIDABLE_RULES,
-            Join::Blank,
-        ),
-        authored(
-            SectionId::FrameworkGuaranteedConventions,
-            SECTION_FRAMEWORK_CONVENTIONS,
-            Join::Blank,
-        ),
-    ];
+pub(crate) fn bundled_fallback_package() -> Result<&'static InstructionPackage, &'static str> {
+    BUNDLED.as_ref().map_err(String::as_str)
+}
 
-    InstructionPackage {
-        schema_version: SCHEMA_VERSION,
-        package_id: PACKAGE_ID.to_string(),
-        description: Some(
-            "Default PM instruction package: authored section sources plus the live agent roster."
-                .to_string(),
-        ),
-        // `resolve_pm_prompt` emits no trailing newline; the prompt is embedded,
-        // not written as a file.
-        trailing_newline: false,
-        sections: sections(),
-        blocks,
-    }
+/// The authored bytes of `sections`, projected out of the bundled manifest.
+///
+/// Why: the legacy assembly and the roster-free `assemble_system_prompt` need
+/// whole multi-section runs as one string and cannot call `compose`. Routing them
+/// through the manifest is what keeps a manifest-authored rule from reaching only
+/// the packaged path — see the module docs' split-brain note.
+/// What: [`InstructionPackage::authored_run`] over the bundled manifest, or `None`
+/// when the manifest is unreadable so the caller can fall back to its retained
+/// `include_str!` constants.
+/// Test: `pm_instructions_is_its_three_sections`, `base_pm_is_its_three_sections`.
+pub(crate) fn authored_run(sections: &[SectionId]) -> Option<String> {
+    bundled_fallback_package()
+        .ok()
+        .map(|package| package.authored_run(sections))
 }
 
 /// Compose the bundled-fallback PM prompt, applying named-section overrides.
 ///
 /// Why: the single entry point `resolve_pm_prompt` calls for configuration 1.
-/// Keeping build and compose together means the caller cannot compose a package
-/// it did not build, and cannot forget an input — the roster is a required
-/// argument, so the #4196 "computed but never delivered" shape is not
-/// expressible here.
+/// Keeping load and compose together means the caller cannot compose a package it
+/// did not load, and cannot forget an input — the roster is a required argument,
+/// so the #4196 "computed but never delivered" shape is not expressible here.
 ///
 /// `CLAUDE.md` named sections (#4183 / #4286) arrive here rather than through a
 /// second string-splice, because this is the only composer that HAS sections and
@@ -261,14 +161,12 @@ pub(crate) fn bundled_fallback_package() -> InstructionPackage {
 /// `customization_tier` for permission. The floor refuses a `CLAUDE.md` override
 /// for exactly the reason it refuses every other one: it is tier `fixed`.
 ///
-/// What: builds the package, applies `overrides`, then composes with `stack`
-/// (the derived stack profile), `roster` (the rendered `## Delegation Authority`
-/// block, required) and `addendum` (`.trusty-mpm/INSTRUCTIONS.md`, if any). All
-/// are trimmed by the composer. Declined overrides come back alongside the
-/// result so the caller can report them. With an empty `overrides` slice the
-/// result is byte-identical to the pre-#4286 composition — `with_overrides` then
-/// returns a clone — and to `instruction_overrides`' legacy assembly for the
-/// same inputs; see the module docs.
+/// What: loads the manifest, applies `overrides`, then composes with `stack` (the
+/// derived stack profile), `roster` (the rendered `## Delegation Authority` block,
+/// required) and `addendum` (`.trusty-mpm/INSTRUCTIONS.md`, if any). All are
+/// trimmed by the composer. Declined overrides come back alongside the result so
+/// the caller can report them. A manifest that failed to parse surfaces as
+/// [`CompositionError::Manifest`] with no rejections.
 ///
 /// Test: `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`,
 /// `composed_prompt_carries_the_live_roster_and_the_precedence_note`,
@@ -279,7 +177,11 @@ pub(crate) fn compose_bundled_fallback_with_overrides(
     addendum: Option<&str>,
     overrides: &[SectionOverride],
 ) -> (Result<String, CompositionError>, Vec<Rejection>) {
-    let (package, rejected) = bundled_fallback_package().with_overrides(overrides);
+    let bundled = match bundled_fallback_package() {
+        Ok(package) => package,
+        Err(err) => return (Err(CompositionError::Manifest(err.to_string())), Vec::new()),
+    };
+    let (package, rejected) = bundled.with_overrides(overrides);
     let composed = package.compose(&CompositionInputs {
         agent_roster: roster.to_string(),
         stack_profile: Some(stack.to_string()),

--- a/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
+++ b/crates/trusty-mpm/src/core/bundled_pm_package_tests.rs
@@ -23,11 +23,38 @@ use crate::core::instruction_overrides::{
     PromptSource, assemble_sections, delegation_with_roster, resolve_pm_prompt,
     resolve_pm_prompt_with_roster, resolve_pm_prompt_with_source,
 };
-use crate::core::instruction_package::{OverrideTier, ValidationError};
+use crate::core::instruction_package::{
+    BlockBody, CustomizationTier, Generator, InstructionBlock, OverrideTier, SCHEMA_VERSION,
+    ValidationError,
+};
+use crate::core::instruction_pipeline::{
+    AGENT_DELEGATION, SECTION_CORE, SECTION_FRAMEWORK_CONVENTIONS, SECTION_IDENTITY,
+    SECTION_MEMORY, SECTION_NON_OVERRIDABLE_RULES, SECTION_SEARCH, SECTION_SOURCES, WORKFLOW,
+    section_source, workflow_section,
+};
 use crate::core::stack_profile::stack_profile_section;
 use std::fs;
 use std::path::Path;
 use tempfile::TempDir;
+
+/// The shipped manifest, parsed — the subject of nearly every test here.
+///
+/// Why: [`bundled_fallback_package`] returns a `Result` since #4318 because the
+/// package is now a parsed artifact rather than Rust code. Unwrapping once behind
+/// a named helper keeps that plumbing out of every assertion, and
+/// `bundled_manifest_parses_and_validates` is the test that gives the unwrap its
+/// licence.
+fn package_ref() -> &'static InstructionPackage {
+    bundled_fallback_package().expect("the bundled manifest parses and validates")
+}
+
+/// The authored markdown a block carries, or `None` for a generated block.
+fn authored(block: &InstructionBlock) -> Option<&str> {
+    block
+        .body
+        .authored()
+        .map(|body| body.expect("source resolves"))
+}
 
 /// The no-override composition, which every gate below is written against.
 ///
@@ -71,7 +98,7 @@ fn legacy_bundled_fallback(stack: &str, roster: &str, addendum: Option<&str>) ->
     assemble_sections(
         stack.to_string(),
         None,
-        WORKFLOW.trim().to_string(),
+        workflow_section().to_string(),
         delegation_with_roster(Some(roster)),
         addendum.map(str::to_string),
     )
@@ -142,11 +169,97 @@ fn composed_package_is_byte_identical_with_a_project_addendum() {
 }
 
 #[test]
+fn bundled_manifest_parses_and_validates() {
+    // THE LICENCE FOR EVERY UNWRAP IN THIS FILE, and the reason the degradation in
+    // `resolve_pm_prompt` is unreachable rather than routine (#4318): the shipped
+    // JSON manifest must parse, validate, and compose. A manifest that fails any of
+    // the three is a red CI run, never a shipped prompt.
+    let package = InstructionPackage::from_json(PM_PACKAGE_JSON)
+        .expect("the shipped manifest is valid schema-v2 JSON");
+    assert_eq!(package.validate(), Ok(()));
+    assert_eq!(package.schema_version, SCHEMA_VERSION);
+    assert_eq!(&package, package_ref());
+    assert!(
+        compose_bundled_fallback(FIXED_STACK, FIXED_ROSTER, None).is_ok(),
+        "the shipped manifest must compose"
+    );
+}
+
+#[test]
+fn manifest_prose_lives_in_markdown_not_in_the_json() {
+    // The point of the v2 `file` body kind. Inlining the sections would turn
+    // `core.md` into a single 23 KB JSON line and move the floor text out of the
+    // files `scripts/check_instruction_floor.sh` greps, so the manifest must stay
+    // small and must reference its bulk prose by path. The inline `text` blocks it
+    // DOES carry are short authored rules, not lifted section bodies.
+    assert!(
+        PM_PACKAGE_JSON.len() < SECTION_CORE.len(),
+        "the manifest ({} bytes) must be smaller than core.md ({} bytes) — prose \
+         belongs in markdown",
+        PM_PACKAGE_JSON.len(),
+        SECTION_CORE.len()
+    );
+    for (path, _) in SECTION_SOURCES {
+        assert!(
+            PM_PACKAGE_JSON.contains(path),
+            "{path} must be referenced by a `file` body"
+        );
+    }
+    for block in &package_ref().blocks {
+        if let BlockBody::Text { text } = &block.body {
+            assert!(
+                text.len() < 1_500,
+                "inline manifest text must be a short authored rule, not lifted prose \
+                 ({} bytes in {:?})",
+                text.len(),
+                block.section
+            );
+        }
+    }
+}
+
+#[test]
+fn every_section_source_resolves() {
+    // The `file` body table is the only thing standing between a renamed section
+    // and an empty block, so assert both directions: every table key resolves, and
+    // a path outside the table does not.
+    for (path, body) in SECTION_SOURCES {
+        assert_eq!(section_source(path), Some(body), "{path} must resolve");
+        assert!(!body.trim().is_empty(), "{path} must not be blank");
+    }
+    assert_eq!(section_source("sections/does-not-exist.md"), None);
+}
+
+#[test]
+fn unknown_file_source_is_rejected() {
+    // A mistyped path must be a named validation error, never a silently empty
+    // block — the #4196 shape (content referenced but never delivered).
+    let mut package = package_ref().clone();
+    let index = package
+        .blocks
+        .iter()
+        .position(|b| matches!(b.body, BlockBody::File { .. }))
+        .expect("the manifest uses file bodies");
+    package.blocks[index].body = BlockBody::File {
+        path: "sections/typo.md".to_string(),
+    };
+    let section = package.blocks[index].section;
+    assert_eq!(
+        package.validate(),
+        Err(ValidationError::UnknownFileSource {
+            index,
+            section,
+            path: "sections/typo.md".to_string(),
+        })
+    );
+}
+
+#[test]
 fn shipped_sections_build_and_validate() {
     // The package built from the compiled-in assets must satisfy every
     // structural invariant. This is what makes the `tracing::error!` fallback in
     // `resolve_pm_prompt` unreachable rather than routine.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     assert_eq!(package.validate(), Ok(()));
     assert_eq!(package.package_id, PACKAGE_ID);
     assert!(!package.trailing_newline);
@@ -176,10 +289,10 @@ fn package_round_trips_through_json() {
     // The composed prompt must survive serialization: a package that cannot be
     // written out and read back is not a source format, and the JSON form is
     // what #4183's authoring work will edit.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     let json = package.to_json().expect("serialize");
     let parsed = InstructionPackage::from_json(&json).expect("deserialize");
-    assert_eq!(parsed, package);
+    assert_eq!(&parsed, package);
 
     let inputs = CompositionInputs {
         agent_roster: FIXED_ROSTER.to_string(),
@@ -197,7 +310,7 @@ fn floor_blocks_are_the_contiguous_tail() {
     // The floor's guarantee is that it has the last word. `validate` enforces
     // it, but asserting the shape here localises a regression to block ordering
     // rather than to a validation error message.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     let first_floor = package
         .blocks
         .iter()
@@ -506,7 +619,7 @@ fn resolve_pm_prompt_wrapper_matches_the_source_reporting_form() {
 fn roster_is_required_and_never_droppable() {
     // #4196 regression gate at the package level: the computed roster must reach
     // the composed prompt. An empty roster is a hard error, not a quiet drop.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     assert_ne!(package.validate(), Err(ValidationError::RosterNotConsumed));
 
     let roster_block = package
@@ -582,7 +695,7 @@ fn every_authored_block_is_exactly_its_section_source() {
     // Kills the regression this PR exists to prevent from coming back: a block
     // whose text is assembled, excerpted or re-derived rather than being the
     // file. Any such block fails here even though the composed bytes may be fine.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     let expected: Vec<(SectionId, &str)> = vec![
         (SectionId::Core, SECTION_CORE),
         (SectionId::Memory, SECTION_MEMORY),
@@ -601,10 +714,10 @@ fn every_authored_block_is_exactly_its_section_source() {
     ];
 
     for (section, source) in expected {
-        let found = package.blocks.iter().any(|b| {
-            b.section == section
-                && matches!(&b.body, BlockBody::Text { text } if text == source.trim())
-        });
+        let found = package
+            .blocks
+            .iter()
+            .any(|b| b.section == section && authored(b) == Some(source));
         assert!(
             found,
             "section {section:?} must contribute its source file verbatim"
@@ -620,16 +733,15 @@ fn memory_and_search_are_independently_overridable() {
     // `2.` and orphaned a sentence that spoke for both. Authored sources are
     // what make the declared tier honest, so assert the shape that proves it —
     // each block stands alone, with its own heading and no dangling list index.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     for section in [SectionId::Memory, SectionId::Search] {
         let text = package
             .blocks
             .iter()
-            .find_map(|b| match (&b.body, b.section == section) {
-                (BlockBody::Text { text }, true) => Some(text.as_str()),
-                _ => None,
-            })
-            .expect("section contributes a text block");
+            .filter(|b| b.section == section)
+            .find_map(authored)
+            .expect("section contributes an authored block")
+            .trim();
         assert!(
             text.starts_with("## "),
             "{section:?} must open with its own heading, got {:?}",
@@ -648,20 +760,16 @@ fn floor_carries_the_tool_priority_mandate() {
     // from after the framework conventions to inside the non-overridable rules
     // it belongs to. It must still be IN the floor — that is what makes the
     // mandate non-overridable — so assert membership, not position.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     let rules = package
         .blocks
         .iter()
         .find(|b| b.section == SectionId::NonOverridableRules)
         .expect("the rules section contributes a block");
     assert!(rules.section.is_floor());
-    match &rules.body {
-        BlockBody::Text { text } => {
-            assert!(text.contains("## Trusty Tool Priority (Non-Overridable)"));
-            assert!(text.contains("mcp__trusty-search__search"));
-        }
-        other => panic!("the rules block must be authored text, got {other:?}"),
-    }
+    let text = authored(rules).expect("the rules block must be authored, not generated");
+    assert!(text.contains("## Trusty Tool Priority (Non-Overridable)"));
+    assert!(text.contains("mcp__trusty-search__search"));
 }
 
 // ---------------------------------------------------------------------------
@@ -674,7 +782,7 @@ fn floor_sections_refuse_every_override_tier() {
     // tier — that is the entire content of the floor guarantee, and the check
     // #4247's resolver will consult. Stated over the SHIPPED package so it is a
     // fact about what we deliver, not about a hand-built fixture.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     for id in SectionId::CANONICAL.into_iter().filter(|id| id.is_floor()) {
         let tier = package.section(id).expect("declared").customization_tier;
         assert_eq!(tier, CustomizationTier::Fixed, "{id:?} must be fixed");
@@ -693,7 +801,7 @@ fn content_sections_admit_project_but_not_user_overrides() {
     // advertised override file is PROJECT-scoped, so a `project`-tier section
     // must accept a project override and REJECT a user-tier one. Getting this
     // backwards is how one operator's machine config leaks into a shared repo.
-    let package = bundled_fallback_package();
+    let package = package_ref();
     for id in SectionId::CANONICAL.into_iter().filter(|id| !id.is_floor()) {
         let tier = package.section(id).expect("declared").customization_tier;
         assert_eq!(tier, CustomizationTier::Project, "{id:?} must be project");
@@ -713,17 +821,13 @@ fn every_advertised_override_file_maps_to_an_overridable_section() {
     // promising an override it must refuse. Reading the advertisement out of the
     // shipped floor text — rather than restating it — is what makes the two
     // unable to drift.
-    let package = bundled_fallback_package();
-    let floor = match &package
+    let package = package_ref();
+    let floor = package
         .blocks
         .iter()
-        .find(|b| b.section == SectionId::NonOverridableRules)
-        .expect("rules block")
-        .body
-    {
-        BlockBody::Text { text } => text.clone(),
-        other => panic!("expected text, got {other:?}"),
-    };
+        .filter(|b| b.section == SectionId::NonOverridableRules)
+        .find_map(authored)
+        .expect("rules block");
 
     for (file, section) in [
         (FILE_WORKFLOW, SectionId::Workflow),

--- a/crates/trusty-mpm/src/core/claude_md_sections.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections.rs
@@ -571,14 +571,21 @@ pub enum Rejection {
 
 /// Apply one override to a package, or say why it may not be applied.
 ///
-/// What: replaces the section's FIRST [`BlockBody::Text`] block with the
-/// override body and drops that section's remaining text blocks, leaving every
-/// [`BlockBody::Generated`] block untouched. That asymmetry is the point: a
-/// generated block is host-computed content the project cannot author, so an
-/// `AGENT-DELEGATION` override rewrites the routing doctrine but CANNOT suppress
-/// the live agent roster (#4196 in override form).
+/// What: replaces the section's FIRST *authored* block — [`BlockBody::Text`] or,
+/// since schema v2, [`BlockBody::File`] — with the override body and drops that
+/// section's remaining authored blocks, leaving every [`BlockBody::Generated`]
+/// block untouched. That asymmetry is the point: a generated block is
+/// host-computed content the project cannot author, so an `AGENT-DELEGATION`
+/// override rewrites the routing doctrine but CANNOT suppress the live agent
+/// roster (#4196 in override form).
+///
+/// Matching on "authored" rather than on `Text` alone is load-bearing after
+/// #4318: every bundled section is now a `file` body, so a `Text`-only match would
+/// have made every section silently non-overridable — `NoTextBlock` for the whole
+/// taxonomy, an advertised-but-unread override, issue #381 verbatim.
 /// Test: `agent_delegation_override_keeps_the_generated_roster`,
-/// `floor_sections_refuse_every_named_section_override`.
+/// `floor_sections_refuse_every_named_section_override`,
+/// `content_sections_accept_a_project_override`.
 fn apply_one(
     package: &InstructionPackage,
     over: &SectionOverride,
@@ -601,16 +608,15 @@ fn apply_one(
     let mut next = package.clone();
     let mut replaced = false;
     next.blocks.retain_mut(|block| {
-        if block.section != section {
+        if block.section != section || block.body.authored().is_none() {
             return true;
         }
-        let BlockBody::Text { text } = &mut block.body else {
-            return true;
-        };
         if replaced {
             return false;
         }
-        *text = body.to_string();
+        block.body = BlockBody::Text {
+            text: body.to_string(),
+        };
         replaced = true;
         true
     });

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -415,9 +415,9 @@ fn over(section: SectionId, body: &str) -> SectionOverride {
 fn with_overrides_of_nothing_is_the_identity() {
     // The property the two existing goldens rest on: a project with no
     // `CLAUDE.md` composes exactly the package it always did.
-    let package = bundled_fallback_package();
+    let package = bundled_fallback_package().expect("manifest parses");
     let (result, rejected) = package.with_overrides(&[]);
-    assert_eq!(result, package);
+    assert_eq!(&result, package);
     assert_eq!(rejected, vec![]);
 }
 
@@ -426,14 +426,14 @@ fn floor_sections_refuse_every_named_section_override() {
     // The structural guarantee: the package's `customization_tier` is the only
     // authority, and it says `fixed` for all three floor sections. No list in
     // the reader is consulted, so none can drift out of sync with this.
-    let package = bundled_fallback_package();
+    let package = bundled_fallback_package().expect("manifest parses");
     for section in [
         SectionId::Identity,
         SectionId::NonOverridableRules,
         SectionId::FrameworkGuaranteedConventions,
     ] {
         let (result, rejected) = package.with_overrides(&[over(section, "SUBVERTED")]);
-        assert_eq!(result, package, "{section:?} must be untouched");
+        assert_eq!(&result, package, "{section:?} must be untouched");
         assert_eq!(
             rejected,
             vec![Rejection::NotOverridable {
@@ -446,7 +446,7 @@ fn floor_sections_refuse_every_named_section_override() {
 
 #[test]
 fn content_sections_accept_a_project_override() {
-    let package = bundled_fallback_package();
+    let package = bundled_fallback_package().expect("manifest parses");
     for section in [
         SectionId::Core,
         SectionId::Memory,
@@ -456,20 +456,31 @@ fn content_sections_accept_a_project_override() {
     ] {
         let (result, rejected) = package.with_overrides(&[over(section, "REPLACED_BODY")]);
         assert_eq!(rejected, vec![], "{section:?} is tier project");
-        assert_ne!(result, package, "{section:?} must actually change");
+        assert_ne!(&result, package, "{section:?} must actually change");
+        // Every bundled section is a schema-v2 `file` body, so this also pins the
+        // property #4318 could have silently broken: an override must replace an
+        // authored block whether that block is inline `text` or a `file`
+        // reference, and must collapse the section to exactly one authored block.
         let texts: Vec<&str> = result
             .blocks
             .iter()
             .filter(|b| b.section == section)
             .filter_map(|b| match &b.body {
                 BlockBody::Text { text } => Some(text.as_str()),
-                BlockBody::Generated { .. } => None,
+                BlockBody::File { .. } | BlockBody::Generated { .. } => None,
             })
             .collect();
         assert_eq!(
             texts,
             vec!["REPLACED_BODY"],
-            "{section:?} keeps exactly one text block"
+            "{section:?} keeps exactly one authored block, rewritten as inline text"
+        );
+        assert!(
+            !result
+                .blocks
+                .iter()
+                .any(|b| b.section == section && matches!(b.body, BlockBody::File { .. })),
+            "{section:?} must not keep a file body alongside the override"
         );
         result.validate().expect("overridden package validates");
     }
@@ -479,7 +490,7 @@ fn content_sections_accept_a_project_override() {
 fn agent_delegation_override_keeps_the_generated_roster() {
     // The #4196 shape in override form: a project must be able to rewrite the
     // routing doctrine WITHOUT being able to suppress the live agent roster.
-    let package = bundled_fallback_package();
+    let package = bundled_fallback_package().expect("manifest parses");
     let (result, rejected) = package.with_overrides(&[over(
         SectionId::AgentDelegation,
         "# Custom Routing\n\nROUTE_ALL_TO_ENGINEER",
@@ -499,7 +510,7 @@ fn agent_delegation_override_keeps_the_generated_roster() {
 
 #[test]
 fn one_bad_override_does_not_discard_a_good_one() {
-    let package = bundled_fallback_package();
+    let package = bundled_fallback_package().expect("manifest parses");
     let (result, rejected) = package.with_overrides(&[
         over(SectionId::Identity, "SUBVERTED"),
         over(SectionId::Workflow, "CUSTOM_WORKFLOW"),
@@ -522,7 +533,7 @@ fn one_bad_override_does_not_discard_a_good_one() {
 
 #[test]
 fn application_order_is_canonical_not_authoring_order() {
-    let package = bundled_fallback_package();
+    let package = bundled_fallback_package().expect("manifest parses");
     let forwards = package.with_overrides(&[
         over(SectionId::Core, "C"),
         over(SectionId::Workflow, "W"),
@@ -540,9 +551,9 @@ fn application_order_is_canonical_not_authoring_order() {
 fn an_empty_override_body_is_rejected_by_the_applier_too() {
     // Belt to the scanner's braces: even if an empty body reached this far it
     // would keep the bundled section rather than blank it.
-    let package = bundled_fallback_package();
+    let package = bundled_fallback_package().expect("manifest parses");
     let (result, rejected) = package.with_overrides(&[over(SectionId::Workflow, "  \n ")]);
-    assert_eq!(result, package);
+    assert_eq!(&result, package);
     assert_eq!(
         rejected,
         vec![Rejection::EmptyBody {
@@ -556,7 +567,7 @@ fn a_section_with_no_text_block_has_nothing_to_override() {
     // Contrived package: Workflow's only block is generated, so there is no
     // authored text for an override to replace. Rejected rather than injected
     // at some arbitrary position.
-    let mut package = bundled_fallback_package();
+    let mut package = bundled_fallback_package().expect("manifest parses").clone();
     for b in &mut package.blocks {
         if b.section == SectionId::Workflow {
             b.body = BlockBody::Generated {
@@ -579,7 +590,7 @@ fn an_override_that_would_leave_a_section_silent_is_rejected() {
     // Contrived package: Workflow's only text block is `optional`, so applying
     // the override would produce a section that composes to nothing whenever it
     // is dropped. Rejected — the bundled section is kept instead.
-    let mut package = bundled_fallback_package();
+    let mut package = bundled_fallback_package().expect("manifest parses").clone();
     for b in &mut package.blocks {
         if b.section == SectionId::Workflow {
             b.optional = true;
@@ -600,7 +611,7 @@ fn an_undeclared_section_is_rejected_and_the_package_is_reverted() {
     // Contrived package whose taxonomy is missing Workflow: the override has
     // nowhere declared to land, and the final validation then refuses the whole
     // thing — degrading to the package as supplied, never to a broken one.
-    let mut package = bundled_fallback_package();
+    let mut package = bundled_fallback_package().expect("manifest parses").clone();
     package.sections.retain(|s| s.id != SectionId::Workflow);
 
     let (result, rejected) = package.with_overrides(&[over(SectionId::Workflow, "X")]);
@@ -626,7 +637,7 @@ fn an_override_that_cannot_validate_is_discarded_and_the_package_reverts() {
     // diagnosis, the final validation then refuses the whole, and the package as
     // supplied comes back. Applying an override must never make things worse
     // than not applying it.
-    let mut package = bundled_fallback_package();
+    let mut package = bundled_fallback_package().expect("manifest parses").clone();
     package.blocks.push(InstructionBlock {
         section: SectionId::Memory,
         body: BlockBody::Text {

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -26,7 +26,7 @@
 use std::path::Path;
 
 use crate::core::instruction_pipeline::{
-    AGENT_DELEGATION, SECTION_SEPARATOR, WORKFLOW, base_pm, pm_instructions,
+    AGENT_DELEGATION, SECTION_SEPARATOR, base_pm, pm_instructions,
 };
 
 /// Directory under the project root that holds the override files.
@@ -344,7 +344,12 @@ pub(crate) fn resolve_pm_prompt_with_roster(
         }
     };
 
-    let workflow = workflow_override.unwrap_or_else(|| WORKFLOW.trim().to_string());
+    // The bundled workflow comes from the manifest, not the raw section constant:
+    // the manifest appends the opportunistic-fix rule as its own block, and a
+    // project that overrides nothing must receive the identical bytes here and on
+    // the packaged path (#4318).
+    let workflow = workflow_override
+        .unwrap_or_else(|| crate::core::instruction_pipeline::workflow_section().to_string());
 
     crate::core::claude_md_sections::warn_unapplied(&named);
     (
@@ -393,9 +398,10 @@ pub(crate) fn assemble_sections(
     join_sections(sections)
 }
 
-/// Note slotted between the bundled doctrine and the live roster.
+/// The DEFAULT delegation section: bundled routing doctrine + the live roster.
 ///
-/// Why: it resolves two ambiguities the append creates, both raised in review.
+/// THE ROSTER-PRECEDENCE NOTE, slotted between the doctrine and the roster,
+/// resolves two ambiguities the append creates, both raised in review.
 ///
 /// (1) PRECEDENCE. The retained asset contradicts the roster on concrete points
 /// — it calls the generic `ops` agent DEPRECATED while the roster lists `ops`,
@@ -415,21 +421,14 @@ pub(crate) fn assemble_sections(
 /// instruction is the shape that cannot silently under-advertise; a failed
 /// dispatch is self-correcting, a missing agent is not.
 ///
-/// What: a Markdown blockquote stating the roster wins on WHICH agents exist,
-/// and to re-route rather than retry on an unknown-agent-type error.
-///
-/// `pub(crate)` since #4183: [`crate::core::bundled_pm_package`] emits it as its
-/// own delegation-section block, so both composers use the identical literal.
-/// Test: `bundled_delegation_appends_deployed_roster`.
-pub(crate) const ROSTER_PRECEDENCE_NOTE: &str = "\
-> The live roster below is authoritative for WHICH agents exist and what each handles; the \
-tables above are routing doctrine only. Where the two disagree, trust the roster.\n\
->\n\
-> Depending on how this session was launched, a listed agent may not be loadable. If a \
-dispatch fails with an unknown agent type, re-route to the closest listed alternative — do \
-not retry the same agent.";
-
-/// The DEFAULT delegation section: bundled routing doctrine + the live roster.
+/// The note is a Markdown blockquote stating the roster wins on WHICH agents
+/// exist, and to re-route rather than retry on an unknown-agent-type error. Since
+/// #4318 its prose is authored in the instruction manifest
+/// (`assets/instructions/pm-instruction-package.json`) as the delegation section's
+/// second block, not as a Rust literal — so its position relative to the doctrine
+/// and the roster is *declared*, and both composers read the same bytes without a
+/// second copy. [`crate::core::instruction_pipeline::delegation_doctrine`]
+/// projects doctrine-plus-note back out as one string.
 ///
 /// Why (#4069): the delegation section is meant to be constructed from what is
 /// actually deployed, and `build_instructions` does compute that roster via
@@ -447,20 +446,24 @@ not retry the same agent.";
 /// This is the FALLBACK only: a project/user `AGENT_DELEGATION.md` override
 /// still replaces the whole section, unchanged, exactly as documented.
 ///
-/// What: returns the trimmed bundled asset, with the rendered
-/// `## Delegation Authority` block from
+/// What: returns the manifest's delegation doctrine (asset plus the precedence
+/// note) with the rendered `## Delegation Authority` block from
 /// [`crate::core::delegation_authority::deployed_roster_section`] appended when
-/// any agent is deployed. With no deployed agents the asset is returned alone
-/// (pre-#4069 behaviour). Takes the already-rendered roster rather than scanning
-/// itself (#4183) so `resolve_pm_prompt` scans the agent tiers exactly once
-/// whichever composition path it takes.
+/// any agent is deployed. With no deployed agents the asset is returned alone,
+/// without the note — the note only makes sense above a roster (pre-#4069
+/// behaviour). Takes the already-rendered roster rather than scanning itself
+/// (#4183) so `resolve_pm_prompt` scans the agent tiers exactly once whichever
+/// composition path it takes.
 /// Test: `bundled_delegation_appends_deployed_roster`,
 /// `no_overrides_uses_bundled`, `agent_delegation_override_replaces`.
 pub(crate) fn delegation_with_roster(roster: Option<&str>) -> String {
-    let bundled = AGENT_DELEGATION.trim();
     match roster {
-        Some(roster) => format!("{bundled}\n\n{ROSTER_PRECEDENCE_NOTE}\n\n{}", roster.trim()),
-        None => bundled.to_string(),
+        Some(roster) => format!(
+            "{}\n\n{}",
+            crate::core::instruction_pipeline::delegation_doctrine(),
+            roster.trim()
+        ),
+        None => AGENT_DELEGATION.trim().to_string(),
     }
 }
 

--- a/crates/trusty-mpm/src/core/instruction_package.rs
+++ b/crates/trusty-mpm/src/core/instruction_package.rs
@@ -56,6 +56,22 @@
 //! [`SCHEMA_VERSION`]**. Strict rejection is what makes that policy enforceable
 //! rather than advisory.
 //!
+//! Version history:
+//!
+//! | version | change | ticket |
+//! |---|---|---|
+//! | 1 | initial format: `text` and `generated` bodies | #4184 |
+//! | 2 | adds the `file` body kind | #4318 |
+//!
+//! v2 exists because #4318 made the bundled package an *authored JSON artifact*
+//! rather than a Rust literal, and inlining every section's prose would have
+//! turned `sections/core.md` into a single 23 KB JSON line. A `file` body names a
+//! bundled markdown source instead; resolution goes through the compile-time
+//! [`crate::core::instruction_pipeline::SECTION_SOURCES`] table, so the build
+//! stays hermetic and a renamed section is a compile error. The bump is mandatory
+//! under the policy above: a v1 build reading a v2 manifest would reject the
+//! unknown `kind`, which is the correct loud failure.
+//!
 //! Floor block ordering is deliberately *not* constrained to canonical section
 //! order — see `validate_floor_is_last` for the asset evidence.
 //!
@@ -76,7 +92,7 @@ use serde::{Deserialize, Serialize};
 /// a silently truncated system prompt.
 /// What: the integer matched against [`InstructionPackage::schema_version`].
 /// Test: `rejects_unsupported_schema_version`.
-pub const SCHEMA_VERSION: u32 = 1;
+pub const SCHEMA_VERSION: u32 = 2;
 
 /// The JSON Schema document describing this format, embedded at compile time.
 ///
@@ -294,8 +310,20 @@ impl Join {
 ///
 /// Why: separating authored text from host-supplied generated content lets
 /// validation insist that generated content is actually consumed.
-/// What: `Text` carries markdown authored in the package; `Generated` names the
-/// generator that supplies it.
+/// What: `Text` carries markdown authored in the package; `File` names a bundled
+/// markdown source resolved through the compile-time
+/// [`crate::core::instruction_pipeline::SECTION_SOURCES`] table; `Generated`
+/// names the generator that supplies it.
+///
+/// `File` is the schema-v2 addition (#4318). It exists because the two obvious
+/// alternatives are both bad: inlining `sections/core.md` verbatim turns 23 KB of
+/// reviewable prose into one unreadable JSON line and moves the floor text out of
+/// the files `scripts/check_instruction_floor.sh` greps, while resolving the path
+/// on the filesystem at launch would make the delivered system prompt depend on
+/// what happens to be on disk. Resolving through `include_str!` keeps the prose in
+/// markdown, keeps the build hermetic, and makes a renamed section a compile error.
+/// `Text` remains fully expressible, and is how a rule authored *in the manifest*
+/// — rather than in a section file — is carried.
 ///
 /// `deny_unknown_fields` is load-bearing, not decoration. Without it a key
 /// misplaced *inside* `body` — `{"kind":"text","text":"…","join_before":"blank"}`
@@ -316,11 +344,45 @@ pub enum BlockBody {
         /// The markdown body. Trimmed before emission.
         text: String,
     },
+    /// Markdown read from a bundled section source, named by path.
+    File {
+        /// Path relative to `assets/instructions/`, e.g. `sections/core.md`.
+        /// Must be a key of
+        /// [`crate::core::instruction_pipeline::SECTION_SOURCES`]; anything else
+        /// is [`ValidationError::UnknownFileSource`]. Trimmed before emission.
+        path: String,
+    },
     /// Markdown supplied at composition time by a named generator.
     Generated {
         /// Which composition-time input supplies this block.
         generator: Generator,
     },
+}
+
+impl BlockBody {
+    /// The authored markdown this body carries, before trimming.
+    ///
+    /// Why: `Text` and `File` differ only in where the bytes are stored, and
+    /// every caller that cares about authored content — validation, composition,
+    /// [`InstructionPackage::authored_run`], and the `CLAUDE.md` override
+    /// application — must treat them identically. One accessor is what stops the
+    /// v2 addition from having to be remembered at four call sites, which is
+    /// exactly how a `File` block would otherwise become silently
+    /// non-overridable.
+    /// What: `None` for [`BlockBody::Generated`]; `Some(Ok(markdown))` for an
+    /// authored body; `Some(Err(path))` for a `File` body naming a source that is
+    /// not in the bundled table.
+    /// Test: `file_body_resolves_through_the_bundled_table`,
+    /// `unknown_file_source_is_rejected`.
+    pub fn authored(&self) -> Option<Result<&str, &str>> {
+        match self {
+            BlockBody::Text { text } => Some(Ok(text.as_str())),
+            BlockBody::File { path } => {
+                Some(crate::core::instruction_pipeline::section_source(path).ok_or(path.as_str()))
+            }
+            BlockBody::Generated { .. } => None,
+        }
+    }
 }
 
 /// One unit of the ordered composition stream.
@@ -453,21 +515,40 @@ pub enum ValidationError {
     /// The package emits nothing.
     #[error("blocks must not be empty")]
     NoBlocks,
-    /// A `text` block whose content is blank.
-    #[error("block {index} ({section:?}) has empty text; remove it instead")]
-    EmptyText {
+    /// An authored (`text` or `file`) block whose content is blank.
+    #[error("block {index} ({section:?}) has an empty authored body; remove it instead")]
+    EmptyAuthoredBody {
         /// Index into `blocks`.
         index: usize,
         /// The owning section.
         section: SectionId,
     },
-    /// A `text` block marked optional.
-    #[error("block {index} ({section:?}) is a text block and may not be `optional`")]
-    OptionalTextBlock {
+    /// An authored (`text` or `file`) block marked optional.
+    #[error("block {index} ({section:?}) is an authored block and may not be `optional`")]
+    OptionalAuthoredBlock {
         /// Index into `blocks`.
         index: usize,
         /// The owning section.
         section: SectionId,
+    },
+    /// A `file` block naming a source that is not bundled with this build.
+    ///
+    /// Why a hard error and not an empty block: a renamed or mistyped section
+    /// path is the #4196 shape exactly — content that exists, is referenced, and
+    /// never reaches the prompt. The manifest is embedded at compile time, so
+    /// this is caught by `bundled_manifest_parses_and_validates` in CI and can
+    /// never be reached by a shipped build.
+    #[error(
+        "block {index} ({section:?}) references section source `{path}`, which this build \
+         does not bundle"
+    )]
+    UnknownFileSource {
+        /// Index into `blocks`.
+        index: usize,
+        /// The owning section.
+        section: SectionId,
+        /// The unresolvable path as authored.
+        path: String,
     },
     /// No block consumes [`Generator::AgentRoster`].
     #[error(
@@ -523,6 +604,15 @@ pub enum CompositionError {
     /// The package failed [`InstructionPackage::validate`].
     #[error("invalid instruction package: {0}")]
     Invalid(#[from] ValidationError),
+    /// The bundled manifest could not be parsed or validated (#4318).
+    ///
+    /// Distinct from [`Self::Invalid`]: that one carries a typed defect in a
+    /// package the caller already holds, while this one says the JSON artifact
+    /// never became a package at all. Unreachable for the shipped manifest —
+    /// `bundled_manifest_parses_and_validates` gates it in CI — and the caller
+    /// degrades to the legacy assembly rather than emitting a partial prompt.
+    #[error("bundled instruction manifest is unusable: {0}")]
+    Manifest(String),
     /// A non-optional generated block had no content to emit.
     #[error(
         "block {index} requires generator {generator:?} but it supplied no content; \
@@ -650,19 +740,30 @@ impl InstructionPackage {
         }
 
         for (index, block) in self.blocks.iter().enumerate() {
-            if let BlockBody::Text { text } = &block.body {
-                if text.trim().is_empty() {
-                    return Err(ValidationError::EmptyText {
+            let Some(authored) = block.body.authored() else {
+                continue;
+            };
+            let body = match authored {
+                Ok(body) => body,
+                Err(path) => {
+                    return Err(ValidationError::UnknownFileSource {
                         index,
                         section: block.section,
+                        path: path.to_string(),
                     });
                 }
-                if block.optional {
-                    return Err(ValidationError::OptionalTextBlock {
-                        index,
-                        section: block.section,
-                    });
-                }
+            };
+            if body.trim().is_empty() {
+                return Err(ValidationError::EmptyAuthoredBody {
+                    index,
+                    section: block.section,
+                });
+            }
+            if block.optional {
+                return Err(ValidationError::OptionalAuthoredBlock {
+                    index,
+                    section: block.section,
+                });
             }
         }
 
@@ -824,7 +925,11 @@ impl InstructionPackage {
 
         for (index, block) in self.blocks.iter().enumerate() {
             let resolved: Option<&str> = match &block.body {
-                BlockBody::Text { text } => Some(text.as_str()),
+                BlockBody::Text { .. } | BlockBody::File { .. } => match block.body.authored() {
+                    Some(Ok(body)) => Some(body),
+                    // `validate` above rejects an unresolvable `file` path.
+                    _ => unreachable!("validate rejects unknown file sources"),
+                },
                 BlockBody::Generated { generator } => match generator {
                     Generator::AgentRoster => Some(inputs.agent_roster.as_str()),
                     Generator::StackProfile => inputs.stack_profile.as_deref(),
@@ -838,8 +943,8 @@ impl InstructionPackage {
                     continue;
                 }
                 let BlockBody::Generated { generator } = &block.body else {
-                    // Blank text blocks are rejected by `validate`.
-                    unreachable!("validate rejects blank text blocks");
+                    // Blank authored blocks are rejected by `validate`.
+                    unreachable!("validate rejects blank authored blocks");
                 };
                 return Err(CompositionError::MissingGeneratedInput {
                     index,
@@ -858,6 +963,61 @@ impl InstructionPackage {
             out.push('\n');
         }
         Ok(out)
+    }
+
+    /// Concatenate the AUTHORED blocks of `sections`, in block order.
+    ///
+    /// Why: the legacy assembly in
+    /// [`crate::core::instruction_overrides::assemble_sections`] and the
+    /// roster-free [`crate::core::instruction_pipeline::assemble_system_prompt`]
+    /// both need whole multi-section runs as one string, and neither can call
+    /// [`Self::compose`] — one composes a different configuration, the other has
+    /// no agent roster to satisfy the required `agent-roster` generator. Before
+    /// #4318 they rebuilt those runs from the `include_str!` constants directly,
+    /// which was fine only while every byte of prose lived in a section file. Now
+    /// that the manifest may author a rule inline, rebuilding from the constants
+    /// would deliver that rule to package-composed sessions and silently withhold
+    /// it from every other path — a content split-brain. Projecting the manifest
+    /// is what keeps ONE source of truth.
+    ///
+    /// What: walks `blocks` in array order, keeps blocks owned by `sections` whose
+    /// body is authored ([`BlockBody::Text`] or [`BlockBody::File`]), trims each,
+    /// and joins with each block's declared [`Join`] — skipping the join on the
+    /// first emitted block, exactly as [`Self::compose`] does. `generated` blocks
+    /// are skipped: they have no authored bytes, and their host inputs are folded
+    /// in by the callers separately. An unresolvable `file` path is skipped rather
+    /// than panicking, because [`Self::validate`] already rejects it at the one
+    /// place that matters.
+    ///
+    /// Determinism: same guarantees as [`Self::compose`] — array order, declared
+    /// joins, no map iteration, no I/O.
+    ///
+    /// Test: `authored_run_projects_blocks_in_order_with_joins`,
+    /// `authored_run_skips_generated_blocks`,
+    /// `pm_instructions_is_its_three_sections`.
+    pub fn authored_run(&self, sections: &[SectionId]) -> String {
+        let mut out = String::new();
+        let mut emitted = false;
+
+        for block in &self.blocks {
+            if !sections.contains(&block.section) {
+                continue;
+            }
+            let Some(Ok(body)) = block.body.authored() else {
+                continue;
+            };
+            let body = body.trim();
+            if body.is_empty() {
+                continue;
+            }
+            if emitted {
+                out.push_str(block.join_before.as_str());
+            }
+            out.push_str(body);
+            emitted = true;
+        }
+
+        out
     }
 }
 

--- a/crates/trusty-mpm/src/core/instruction_package_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_package_tests.rs
@@ -165,6 +165,158 @@ fn schema_enums_match_rust_enums() {
 }
 
 #[test]
+fn schema_body_kinds_match_rust_variants() {
+    // The v2 drift gate (#4318). `$defs.body` is a `oneOf` of tagged objects
+    // rather than an `enum`, so `schema_enums_match_rust_enums` cannot see it —
+    // and the whole cost of the version bump is that the two spellings of the
+    // body kinds must agree. A `file` variant in Rust with no schema branch, or
+    // the reverse, is a package that validates in one place and fails in the
+    // other.
+    let schema: serde_json::Value = serde_json::from_str(SCHEMA_JSON).expect("schema is JSON");
+    let kinds: Vec<String> = schema["$defs"]["body"]["oneOf"]
+        .as_array()
+        .expect("body is a oneOf")
+        .iter()
+        .map(|branch| {
+            branch["properties"]["kind"]["const"]
+                .as_str()
+                .expect("each branch pins a kind const")
+                .to_string()
+        })
+        .collect();
+
+    let rust: Vec<String> = [
+        BlockBody::Text {
+            text: "x".to_string(),
+        },
+        BlockBody::File {
+            path: "sections/identity.md".to_string(),
+        },
+        BlockBody::Generated {
+            generator: Generator::AgentRoster,
+        },
+    ]
+    .iter()
+    .map(|body| {
+        serde_json::to_value(body).expect("serializes")["kind"]
+            .as_str()
+            .expect("tagged")
+            .to_string()
+    })
+    .collect();
+
+    assert_eq!(
+        kinds, rust,
+        "schema body kinds must match the Rust variants"
+    );
+}
+
+#[test]
+fn file_body_resolves_through_the_bundled_table() {
+    // A `file` body must compose to the referenced source, trimmed — the same
+    // bytes an inline `text` block carrying that file would have produced. That
+    // equivalence is what makes the v2 addition a pure authoring convenience
+    // rather than a second content channel.
+    let source = crate::core::instruction_pipeline::SECTION_IDENTITY;
+    let mut package = fixture();
+    package.blocks[8] = InstructionBlock {
+        section: SectionId::Identity,
+        body: BlockBody::File {
+            path: "sections/identity.md".to_string(),
+        },
+        join_before: Join::Rule,
+        optional: false,
+    };
+
+    assert_eq!(package.validate(), Ok(()));
+    let composed = package.compose(&inputs()).expect("composes");
+    assert!(composed.contains(source.trim()));
+
+    // And the equivalence, stated directly.
+    let mut inline = fixture();
+    inline.blocks[8] = text(SectionId::Identity, source.trim());
+    assert_eq!(composed, inline.compose(&inputs()).expect("composes"));
+}
+
+#[test]
+fn unknown_file_source_is_a_named_validation_error() {
+    // A mistyped path must name the path, not compose to an empty block (#4196's
+    // shape: content referenced but never delivered).
+    let mut package = fixture();
+    package.blocks[8].body = BlockBody::File {
+        path: "sections/nope.md".to_string(),
+    };
+    assert_eq!(
+        package.validate(),
+        Err(ValidationError::UnknownFileSource {
+            index: 8,
+            section: SectionId::Identity,
+            path: "sections/nope.md".to_string(),
+        })
+    );
+}
+
+#[test]
+fn a_file_block_may_not_be_optional() {
+    // Same rule as a text block: only a generator's output may be dropped.
+    let mut package = fixture();
+    package.blocks[8].body = BlockBody::File {
+        path: "sections/identity.md".to_string(),
+    };
+    package.blocks[8].optional = true;
+    assert_eq!(
+        package.validate(),
+        Err(ValidationError::OptionalAuthoredBlock {
+            index: 8,
+            section: SectionId::Identity,
+        })
+    );
+}
+
+#[test]
+fn authored_run_projects_blocks_in_order_with_joins() {
+    // `authored_run` is what keeps the legacy assembly and the roster-free
+    // installer prompt on the SAME content as the packaged composer (#4318). It
+    // must reproduce `compose`'s ordering and whitespace rules exactly: array
+    // order, declared joins, no join before the first emitted block.
+    let mut package = fixture();
+    package.blocks[2].join_before = Join::Blank;
+
+    assert_eq!(
+        package.authored_run(&[SectionId::Core]),
+        format!("CORE-A{}CORE-B", Join::Blank.as_str()),
+        "blocks join with their own declared separator, first one bare"
+    );
+    assert_eq!(
+        package.authored_run(&[SectionId::Core, SectionId::Memory]),
+        format!(
+            "CORE-A{SECTION_SEPARATOR}MEMORY{}CORE-B",
+            Join::Blank.as_str()
+        ),
+        "block order, not the order of the requested sections"
+    );
+    assert_eq!(package.authored_run(&[]), "");
+}
+
+#[test]
+fn authored_run_skips_generated_blocks() {
+    // A generated block has no authored bytes; its host input is folded in by the
+    // caller. Emitting a placeholder here would put unresolved content into the
+    // legacy prompt.
+    let package = fixture();
+    assert_eq!(
+        package.authored_run(&[SectionId::AgentDelegation]),
+        "",
+        "the delegation section is roster-only in this fixture"
+    );
+    assert_eq!(
+        package.authored_run(&[SectionId::Core]),
+        format!("CORE-A{SECTION_SEPARATOR}CORE-B"),
+        "the stack-profile and addendum generators contribute nothing"
+    );
+}
+
+#[test]
 fn schema_example_deserializes_validates_and_round_trips() {
     // Why (acceptance criterion of #4184): the Rust types must deserialize the
     // committed schema, and the round trip must be lossless — tooling that
@@ -507,7 +659,7 @@ fn rejects_blank_text_block() {
     pkg.blocks[0] = text(SectionId::Core, "   \n\t ");
     assert_eq!(
         pkg.validate().unwrap_err(),
-        ValidationError::EmptyText {
+        ValidationError::EmptyAuthoredBody {
             index: 0,
             section: SectionId::Core,
         }
@@ -523,7 +675,7 @@ fn rejects_optional_text_block() {
     pkg.blocks[0].optional = true;
     assert_eq!(
         pkg.validate().unwrap_err(),
-        ValidationError::OptionalTextBlock {
+        ValidationError::OptionalAuthoredBlock {
             index: 0,
             section: SectionId::Core,
         }

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -25,6 +25,7 @@ use std::fmt;
 use std::path::PathBuf;
 
 use crate::core::delegation_authority::{generate_authority, scan_agents};
+use crate::core::instruction_package::SectionId;
 
 /// Separator placed between merged instruction sections.
 ///
@@ -83,6 +84,53 @@ pub(crate) const SECTION_NON_OVERRIDABLE_RULES: &str =
 pub(crate) const SECTION_FRAMEWORK_CONVENTIONS: &str =
     include_str!("../assets/instructions/sections/framework-guaranteed-conventions.md");
 
+/// The compile-time table a schema-v2 `file` body resolves through.
+///
+/// Why: the instruction manifest (#4318) names its prose by path
+/// (`{"kind":"file","path":"sections/core.md"}`) so the bulk of the instructions
+/// keeps living in reviewable markdown rather than becoming one 23 KB JSON line
+/// — but a path resolved at *runtime* would put the delivered system prompt at
+/// the mercy of the filesystem and would let a renamed section ship as a silent
+/// content drop. Every entry here is an `include_str!` of a constant declared
+/// above, so the build stays hermetic and a missing section file is a compile
+/// error rather than a launch-time surprise.
+/// What: the eight canonical section sources, keyed by the path form the manifest
+/// uses — relative to `assets/instructions/`. Table order is irrelevant; the
+/// manifest's `blocks` array alone decides emission order.
+/// Test: `every_section_source_resolves`, `unknown_file_source_is_rejected`.
+pub(crate) const SECTION_SOURCES: [(&str, &str); 8] = [
+    ("sections/identity.md", SECTION_IDENTITY),
+    ("sections/core.md", SECTION_CORE),
+    ("sections/memory.md", SECTION_MEMORY),
+    ("sections/search.md", SECTION_SEARCH),
+    ("sections/workflow.md", WORKFLOW),
+    ("sections/agent-delegation.md", AGENT_DELEGATION),
+    (
+        "sections/non-overridable-rules.md",
+        SECTION_NON_OVERRIDABLE_RULES,
+    ),
+    (
+        "sections/framework-guaranteed-conventions.md",
+        SECTION_FRAMEWORK_CONVENTIONS,
+    ),
+];
+
+/// Resolve a manifest `file` body path to its embedded source.
+///
+/// Why: one lookup point means a path typo in the manifest becomes a named
+/// [`crate::core::instruction_package::ValidationError::UnknownFileSource`]
+/// instead of an empty block.
+/// What: a linear scan of [`SECTION_SOURCES`] — eight entries, called a handful
+/// of times per process, so a map would buy nothing and would reintroduce the
+/// iteration-order hazard the package format exists to avoid.
+/// Test: `every_section_source_resolves`, `unknown_file_source_is_rejected`.
+pub(crate) fn section_source(path: &str) -> Option<&'static str> {
+    SECTION_SOURCES
+        .iter()
+        .find(|(key, _)| *key == path)
+        .map(|(_, body)| *body)
+}
+
 /// The former `PM_INSTRUCTIONS.md` body, rebuilt from its three sections.
 ///
 /// Why: the legacy override assembly
@@ -101,12 +149,66 @@ pub(crate) const SECTION_FRAMEWORK_CONVENTIONS: &str =
 /// `composed_package_is_byte_identical_to_the_legacy_bundled_fallback`.
 pub(crate) fn pm_instructions() -> &'static str {
     static JOINED: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
-        format!(
-            "{}\n\n{}\n\n{}\n",
-            SECTION_CORE.trim(),
-            SECTION_MEMORY.trim(),
-            SECTION_SEARCH.trim()
-        )
+        let run = manifest_run(&[SectionId::Core, SectionId::Memory, SectionId::Search])
+            .unwrap_or_else(|| {
+                format!(
+                    "{}\n\n{}\n\n{}",
+                    SECTION_CORE.trim(),
+                    SECTION_MEMORY.trim(),
+                    SECTION_SEARCH.trim()
+                )
+            });
+        format!("{run}\n")
+    });
+    &JOINED
+}
+
+/// Project a run of sections out of the bundled manifest.
+///
+/// Why: since #4318 the manifest may author a rule inline rather than in a
+/// section file, so rebuilding these strings from the `include_str!` constants
+/// would deliver that rule to package-composed sessions and silently withhold it
+/// from the legacy assembly and from [`assemble_system_prompt`]. Projecting the
+/// manifest keeps one source of truth for the *content*, while the constants stay
+/// as the retained fallback for the case where the manifest itself is unreadable.
+/// What: [`crate::core::bundled_pm_package::authored_run`], or `None` when the
+/// manifest failed to parse or validate.
+/// Test: `pm_instructions_is_its_three_sections`, `base_pm_is_its_three_sections`.
+fn manifest_run(sections: &[SectionId]) -> Option<String> {
+    crate::core::bundled_pm_package::authored_run(sections).filter(|run| !run.trim().is_empty())
+}
+
+/// The bundled workflow section, as authored in the manifest.
+///
+/// Why: the workflow section is no longer only `sections/workflow.md` — the
+/// manifest appends the opportunistic-fix rule as its own block. Every consumer
+/// must therefore ask the manifest, not the constant, or a project with a
+/// `WORKFLOW.md` override would be the only one to notice the difference.
+/// What: the authored workflow blocks joined as declared, trimmed; the raw
+/// `WORKFLOW` constant when the manifest is unreadable.
+/// Test: `workflow_section_carries_the_opportunistic_fix_rule`,
+/// `assemble_system_prompt_contains_all_sections`.
+pub(crate) fn workflow_section() -> &'static str {
+    static JOINED: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        manifest_run(&[SectionId::Workflow]).unwrap_or_else(|| WORKFLOW.trim().to_string())
+    });
+    &JOINED
+}
+
+/// The bundled delegation doctrine plus the roster-precedence note.
+///
+/// Why: #4318 moved the note's prose out of a Rust constant and into the manifest,
+/// where its position between the doctrine and the live roster is declared rather
+/// than formatted in by hand at two call sites.
+/// What: the authored `agent-delegation` blocks joined as declared — the section
+/// source followed by the note — trimmed. Falls back to the doctrine alone if the
+/// manifest is unreadable, which is the pre-#4069 shape.
+/// Test: `bundled_delegation_appends_deployed_roster`,
+/// `composed_prompt_carries_the_live_roster_and_the_precedence_note`.
+pub(crate) fn delegation_doctrine() -> &'static str {
+    static JOINED: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
+        manifest_run(&[SectionId::AgentDelegation])
+            .unwrap_or_else(|| AGENT_DELEGATION.trim().to_string())
     });
     &JOINED
 }
@@ -129,12 +231,20 @@ pub(crate) fn pm_instructions() -> &'static str {
 /// Test: `base_pm_is_its_three_sections`, `floor_carries_the_tool_priority_mandate`.
 pub(crate) fn base_pm() -> &'static str {
     static JOINED: std::sync::LazyLock<String> = std::sync::LazyLock::new(|| {
-        format!(
-            "{}\n\n{}\n\n{}\n",
-            SECTION_IDENTITY.trim(),
-            SECTION_NON_OVERRIDABLE_RULES.trim(),
-            SECTION_FRAMEWORK_CONVENTIONS.trim()
-        )
+        let run = manifest_run(&[
+            SectionId::Identity,
+            SectionId::NonOverridableRules,
+            SectionId::FrameworkGuaranteedConventions,
+        ])
+        .unwrap_or_else(|| {
+            format!(
+                "{}\n\n{}\n\n{}",
+                SECTION_IDENTITY.trim(),
+                SECTION_NON_OVERRIDABLE_RULES.trim(),
+                SECTION_FRAMEWORK_CONVENTIONS.trim()
+            )
+        });
+        format!("{run}\n")
     });
     &JOINED
 }
@@ -150,7 +260,13 @@ pub(crate) fn base_pm() -> &'static str {
 /// Trusty MCP tool-priority block.
 /// Test: `assemble_system_prompt_contains_all_sections`.
 pub fn assemble_system_prompt() -> String {
-    [pm_instructions(), WORKFLOW, AGENT_DELEGATION, base_pm()].join("\n\n---\n\n")
+    [
+        pm_instructions(),
+        workflow_section(),
+        AGENT_DELEGATION,
+        base_pm(),
+    ]
+    .join(SECTION_SEPARATOR)
 }
 
 /// Write the assembled system prompt to an explicit path.
@@ -494,426 +610,5 @@ fn merge_sections(framework: &str, authority: &str) -> String {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    /// Write `<name>.md` into `dir` with the given raw content.
-    fn write_file(path: &PathBuf, content: &str) {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent).expect("create parent");
-        }
-        fs::write(path, content).expect("write file");
-    }
-
-    /// Build a `PipelineInput` rooted at `tmp` with optional INSTRUCTIONS.md.
-    fn input_in(tmp: &TempDir) -> PipelineInput {
-        PipelineInput {
-            framework_instructions_path: tmp.path().join("INSTRUCTIONS.md"),
-            agents_dir: tmp.path().join("agents"),
-            claude_md_path: tmp.path().join("project").join("CLAUDE.md"),
-        }
-    }
-
-    #[test]
-    fn pipeline_full() {
-        // All inputs present → merged output contains the two framework
-        // sections in the documented 3 → 4 order. The project CLAUDE.md is
-        // deliberately NOT folded into `merged` (dead code removed — Claude
-        // Code loads CLAUDE.md natively and the real launch prompt never
-        // read this field for that content).
-        let tmp = TempDir::new().unwrap();
-        let input = input_in(&tmp);
-
-        write_file(
-            &input.framework_instructions_path,
-            "# Framework\n\nFRAMEWORK SECTION\n",
-        );
-        fs::create_dir_all(&input.agents_dir).unwrap();
-        write_file(
-            &input.agents_dir.join("engineer.md"),
-            "---\nname: engineer\nrole: engineer\ndescription: Builds things.\n---\n\n# Engineer\n",
-        );
-        write_file(&input.claude_md_path, "# Project\n\nPROJECT SECTION\n");
-
-        let out = build_instructions(&input).unwrap();
-        assert!(out.instructions_loaded);
-        assert_eq!(out.agent_count, 1);
-        assert!(
-            !out.claude_md_created,
-            "existing CLAUDE.md is not recreated"
-        );
-
-        let fw = out.merged.find("FRAMEWORK SECTION").expect("framework");
-        let auth = out
-            .merged
-            .find("## Delegation Authority")
-            .expect("authority");
-        assert!(fw < auth, "framework precedes delegation authority");
-        assert!(out.merged.contains("### engineer"));
-        assert!(
-            !out.merged.contains("PROJECT SECTION"),
-            "project CLAUDE.md content must not be folded into merged: {}",
-            out.merged
-        );
-    }
-
-    #[test]
-    fn pipeline_missing_instructions() {
-        // INSTRUCTIONS.md absent → pipeline still succeeds, instructions_loaded
-        // is false, and section 4 is still present.
-        let tmp = TempDir::new().unwrap();
-        let input = input_in(&tmp);
-        // No INSTRUCTIONS.md written.
-        fs::create_dir_all(&input.agents_dir).unwrap();
-        write_file(
-            &input.agents_dir.join("qa.md"),
-            "---\nname: qa\nrole: qa\ndescription: Tests things.\n---\n\n# QA\n",
-        );
-        write_file(&input.claude_md_path, "# Project\n\nPROJECT NOTES\n");
-
-        let out = build_instructions(&input).unwrap();
-        assert!(!out.instructions_loaded);
-        assert!(out.merged.contains("## Delegation Authority"));
-        assert!(!out.merged.contains("PROJECT NOTES"));
-        // No dangling separator at the very start.
-        assert!(!out.merged.starts_with("---"));
-    }
-
-    #[test]
-    fn pipeline_creates_claude_md() {
-        // CLAUDE.md absent → it is created as a side effect, claude_md_created
-        // is true, and the file on disk contains the stub — but the stub text
-        // is NOT folded into `merged` (dead code removed).
-        let tmp = TempDir::new().unwrap();
-        let input = input_in(&tmp);
-        write_file(&input.framework_instructions_path, "# Framework\n");
-        fs::create_dir_all(&input.agents_dir).unwrap();
-
-        assert!(!input.claude_md_path.exists());
-        let out = build_instructions(&input).unwrap();
-        assert!(out.claude_md_created);
-        assert!(input.claude_md_path.exists());
-
-        let on_disk = fs::read_to_string(&input.claude_md_path).unwrap();
-        assert!(on_disk.contains("# Project Instructions"));
-        assert!(on_disk.contains("trusty-mpm will never modify this file again"));
-        // The seeded stub carries the attribution convention so every new
-        // trusty-mpm project inherits the footer override at the framework
-        // level (issue #2876) rather than relying on a per-project hand-edit.
-        assert!(
-            on_disk.contains("🤖🤖🤖 Generated with trusty-mpm"),
-            "seeded stub must carry the attribution footer: {on_disk}"
-        );
-        assert!(
-            !out.merged.contains("# Project Instructions"),
-            "stub content must not be folded into merged: {}",
-            out.merged
-        );
-    }
-
-    #[test]
-    fn pipeline_claude_md_left_byte_identical() {
-        // Why (#2170): trusty-mpm must NEVER modify a target project's
-        // CLAUDE.md. An existing file — including one that happens to
-        // contain the literal delegation-block markers as ordinary operator
-        // text — must come back out of `build_instructions` completely
-        // untouched on disk, and its content must not leak into `merged`
-        // (dead code removed).
-        let tmp = TempDir::new().unwrap();
-        let input = input_in(&tmp);
-        write_file(&input.framework_instructions_path, "# Framework\n");
-        fs::create_dir_all(&input.agents_dir).unwrap();
-        let custom = "# My Project\n\nCUSTOM HAND-WRITTEN CONTENT\n";
-        write_file(&input.claude_md_path, custom);
-
-        let out = build_instructions(&input).unwrap();
-        assert!(!out.claude_md_created);
-        let on_disk = fs::read_to_string(&input.claude_md_path).unwrap();
-        assert_eq!(
-            on_disk, custom,
-            "pre-existing CLAUDE.md must be left byte-identical: {on_disk}"
-        );
-        assert!(
-            !on_disk.contains(DELEGATION_BLOCK_BEGIN),
-            "no delegation-directive block may be injected: {on_disk}"
-        );
-        assert!(
-            !out.merged.contains("CUSTOM HAND-WRITTEN CONTENT"),
-            "project CLAUDE.md content must not be folded into merged: {}",
-            out.merged
-        );
-    }
-
-    #[test]
-    fn strip_delegation_block_removes_legacy_block() {
-        // Why (#2170 cleanup helper): a workspace polluted by the old #2125
-        // injection must have the fenced block removed, leaving the
-        // operator's own content untouched.
-        let polluted = format!(
-            "{DELEGATION_BLOCK_BEGIN}\n\nSome injected directive text.\n\n{DELEGATION_BLOCK_END}\n\n# My Project\n\nOperator notes.\n"
-        );
-        let cleaned = strip_delegation_block(&polluted);
-        assert!(!cleaned.contains(DELEGATION_BLOCK_BEGIN));
-        assert!(!cleaned.contains(DELEGATION_BLOCK_END));
-        assert!(!cleaned.contains("Some injected directive text."));
-        assert_eq!(cleaned, "# My Project\n\nOperator notes.\n");
-    }
-
-    #[test]
-    fn strip_delegation_block_noop_when_absent() {
-        // Why: a clean CLAUDE.md (the common case post-#2170) must be
-        // returned byte-identical.
-        let clean = "# My Project\n\nOperator notes.\n";
-        assert_eq!(strip_delegation_block(clean), clean);
-    }
-
-    #[test]
-    fn pm_instructions_is_its_three_sections() {
-        // #4183: the legacy PM body is RECONSTITUTED from the authored sections,
-        // never kept as a fourth copy on disk. If it ever became a copy again,
-        // an edit to `core.md` would reach the packaged composer and not the
-        // legacy override assembly — the split-brain this asserts against.
-        let body = pm_instructions();
-        assert_eq!(
-            body,
-            format!(
-                "{}\n\n{}\n\n{}\n",
-                SECTION_CORE.trim(),
-                SECTION_MEMORY.trim(),
-                SECTION_SEARCH.trim()
-            )
-        );
-        // The paragraph break is `Join::Blank`'s literal, which is what makes
-        // this string byte-identical to what the packaged composer emits.
-        assert!(body.contains("## Memory Protocol (Context-First)"));
-        assert!(body.contains("## Code Search Protocol (Context-First)"));
-        assert!(
-            !body.contains("## Context-First Protocol\n"),
-            "the merged Memory+Search block must not survive as a fourth copy"
-        );
-    }
-
-    #[test]
-    fn base_pm_is_its_three_sections() {
-        // Same no-second-copy property for the non-overridable floor, plus the
-        // one reordering #4183 makes: the tool-priority mandate travels with the
-        // other non-overridable rules and so now precedes the conventions.
-        let floor = base_pm();
-        assert_eq!(
-            floor,
-            format!(
-                "{}\n\n{}\n\n{}\n",
-                SECTION_IDENTITY.trim(),
-                SECTION_NON_OVERRIDABLE_RULES.trim(),
-                SECTION_FRAMEWORK_CONVENTIONS.trim()
-            )
-        );
-
-        let tool = floor
-            .find("## Trusty Tool Priority (Non-Overridable)")
-            .expect("the tool-priority mandate stays in the floor");
-        let conventions = floor
-            .find("## Framework-Guaranteed Conventions (Non-Overridable)")
-            .expect("the guaranteed conventions stay in the floor");
-        assert!(
-            tool < conventions,
-            "tool priority now rides with the non-overridable rules it belongs to"
-        );
-    }
-
-    #[test]
-    fn assemble_system_prompt_contains_all_sections() {
-        // Why: the assembled prompt is the contract `claude` receives; every
-        // bundled section must be present and joined with the `---` rule.
-        let prompt = assemble_system_prompt();
-        assert!(prompt.contains("# PM Agent -- Trusty MPM"));
-        assert!(prompt.contains("# BASE_PM Framework Floor"));
-        assert!(prompt.contains("# PM Workflow Configuration"));
-        assert!(prompt.contains("# Agent Delegation Routing"));
-        // The Trusty tool-priority block now lives inside the BASE_PM floor.
-        assert!(prompt.contains("## Trusty Tool Priority (Non-Overridable)"));
-        assert!(prompt.contains("\n\n---\n\n"));
-        // BASE_PM is the non-overridable floor: it must come last.
-        let base = prompt.find("# BASE_PM Framework Floor").expect("base_pm");
-        let delegation = prompt
-            .find("# Agent Delegation Routing")
-            .expect("delegation");
-        assert!(base > delegation, "BASE_PM floor must be appended last");
-        // Ticketing-specific content was stripped from the bundled assets.
-        assert!(!prompt.contains("mcp__mcp-ticketer__"));
-        assert!(!prompt.contains("ticketing_agent"));
-    }
-
-    // Why serial + fake-HOME (extra sweep hit — review-gate report on top of
-    // #2459/#2460/#2461): `install_system_prompt()` resolves `dirs::home_dir()`
-    // internally and previously wrote straight into the REAL
-    // `$HOME/.trusty-mpm/framework/instructions/` — both polluting the
-    // developer's real home directory on every test run AND racing with any
-    // other test in this binary that redirects `HOME` to a temp dir
-    // concurrently (same class as `manifest_expands_tilde`, #2459). Redirect
-    // `HOME` to an isolated temp dir for the duration of the test and join
-    // the crate's shared `#[serial_test::serial]` lock so no other
-    // HOME-mutating test can interleave.
-    #[serial_test::serial]
-    #[test]
-    fn install_system_prompt_writes_file() {
-        // Why: `tm launch` depends on `install_system_prompt` regenerating
-        // INSTRUCTIONS.md; this asserts it writes a non-empty file under the
-        // expected `~/.trusty-mpm/framework/instructions/` path.
-        let fake_home = TempDir::new().expect("create fake home");
-        let prev_home = std::env::var("HOME").ok();
-        // SAFETY: serialized via `#[serial_test::serial]`, so no other test
-        // thread observes or mutates HOME concurrently. Restored below
-        // regardless of panics via the `HomeGuard` drop impl.
-        unsafe { std::env::set_var("HOME", fake_home.path()) };
-        struct HomeGuard(Option<String>);
-        impl Drop for HomeGuard {
-            fn drop(&mut self) {
-                match &self.0 {
-                    Some(p) => unsafe { std::env::set_var("HOME", p) },
-                    None => unsafe { std::env::remove_var("HOME") },
-                }
-            }
-        }
-        let _guard = HomeGuard(prev_home);
-
-        let out = install_system_prompt().expect("install succeeds");
-        assert!(out.starts_with(fake_home.path()));
-        assert!(out.ends_with("INSTRUCTIONS.md"));
-        assert!(out.exists());
-        let on_disk = fs::read_to_string(&out).unwrap();
-        assert_eq!(on_disk, assemble_system_prompt());
-        assert!(!on_disk.is_empty());
-    }
-
-    #[test]
-    fn install_system_prompt_to_writes_assembled() {
-        // Why: `tm install` calls `install_system_prompt_to` pointing at the
-        // framework path so the assembled prompt (not the 4-line stub) is on
-        // disk immediately after install — regression for issue #383.
-        // What: asserts the file written by the path-parameterised helper
-        // equals `assemble_system_prompt()` and contains key PM headings.
-        // Test: call the helper against a temp path; read back and verify content.
-        let tmp = TempDir::new().unwrap();
-        let dest = tmp.path().join("instructions").join("INSTRUCTIONS.md");
-        install_system_prompt_to(&dest).expect("write succeeds");
-        assert!(
-            dest.exists(),
-            "INSTRUCTIONS.md must exist after install_system_prompt_to"
-        );
-        let on_disk = fs::read_to_string(&dest).unwrap();
-        assert_eq!(
-            on_disk,
-            assemble_system_prompt(),
-            "content must equal assembled prompt"
-        );
-        // The 4-line stub must NOT be present (regression guard for issue #383).
-        assert!(
-            !on_disk.trim().eq("# trusty-mpm Framework Instructions\n\nThis Claude Code instance is managed by trusty-mpm.\nDaemon endpoint: ${TRUSTY_MPM_URL:-http://localhost:7799}"),
-            "stub content must not be written — full assembled prompt required"
-        );
-        // Real PM sections must be present.
-        assert!(
-            on_disk.contains("# PM Agent -- Trusty MPM"),
-            "PM_INSTRUCTIONS section must be present"
-        );
-        assert!(
-            on_disk.contains("# BASE_PM Framework Floor"),
-            "BASE_PM floor must be present"
-        );
-    }
-
-    #[test]
-    fn primary_directive_mandate_not_duplicated_across_channels() {
-        // Issue #2647 (R2): the FULL mandate table (Prohibitions, Circuit
-        // Breakers, Delegation Map, PM Allowlist) must live in exactly ONE
-        // channel — the appended system prompt (`assemble_system_prompt`,
-        // always injected via `--append-system-prompt-file` on tm-driven
-        // spawns). Before this fix, every bundled output-style file (loaded
-        // independently via the Claude Code `outputStyle` settings key) ALSO
-        // carried a full, near-identical restatement of that table —
-        // duplicated tokens every session.
-        //
-        // Code-critic follow-up: `outputStyle` is deployed to
-        // `<project>/.claude/output-styles/*.md` + `settings.json`
-        // (`settings.rs`) and therefore applies to ANY `claude` launched in
-        // that directory — including a manual `claude` invocation that never
-        // receives `--append-system-prompt-file` at all
-        // (`runtime/claude_code.rs`). A style with NOTHING but a pointer to
-        // the appended prompt would leave such a launch with zero
-        // enforcement. So each style keeps a short, SELF-CONTAINED minimal
-        // mandate (PRIMARY DIRECTIVE statement, override-phrase list, a
-        // prohibition summary) alongside the pointer to the full table —
-        // this test asserts that block survived the dedup, not just that the
-        // heading sentinel is de-duplicated.
-        const SENTINEL: &str = "PRIMARY DIRECTIVE";
-        let assembled = assemble_system_prompt();
-        assert_eq!(
-            assembled.matches(SENTINEL).count(),
-            0,
-            "the appended system prompt must not carry a literal PRIMARY \
-             DIRECTIVE banner — the mandate lives there as Identity + \
-             Prohibitions content"
-        );
-
-        // The appended prompt must still carry the substantive, canonical
-        // mandate content — so the mandate can never silently vanish from
-        // BOTH channels at once just because the banner text moved.
-        assert!(
-            assembled.contains("## Prohibitions"),
-            "the appended prompt must carry the canonical Prohibitions table"
-        );
-        assert!(
-            assembled.contains("## Circuit Breakers"),
-            "the appended prompt must carry the canonical Circuit Breakers table"
-        );
-        assert!(
-            assembled.contains("don't delegate"),
-            "the appended prompt must carry at least one override phrase"
-        );
-
-        for style in crate::core::bundle::OUTPUT_STYLES {
-            let combined =
-                assembled.matches(SENTINEL).count() + style.content.matches(SENTINEL).count();
-            assert_eq!(
-                combined, 1,
-                "{}: PRIMARY DIRECTIVE sentinel must appear exactly once across \
-                 the appended prompt + this output style (one heading, never a \
-                 full restatement of the mandate TABLE) — got {combined}",
-                style.id
-            );
-
-            // Each style must still carry its OWN self-contained minimal
-            // mandate — the override-phrase list and a prohibition summary —
-            // so a manual `claude` launch (no --append-system-prompt-file)
-            // in a tm-provisioned workspace is never left with zero
-            // enforcement.
-            assert!(
-                style.content.contains("do this yourself"),
-                "{}: must carry its own self-contained override-phrase list",
-                style.id
-            );
-            assert!(
-                style.content.contains("Minimum prohibitions"),
-                "{}: must carry its own self-contained prohibition summary",
-                style.id
-            );
-        }
-    }
-
-    #[test]
-    fn pipeline_no_agents_still_succeeds() {
-        // An empty agents dir yields a zero agent_count and the "no agents"
-        // delegation section, but the pipeline still produces merged output.
-        let tmp = TempDir::new().unwrap();
-        let input = input_in(&tmp);
-        write_file(&input.framework_instructions_path, "# Framework\n");
-        fs::create_dir_all(&input.agents_dir).unwrap();
-
-        let out = build_instructions(&input).unwrap();
-        assert_eq!(out.agent_count, 0);
-        assert!(out.merged.to_lowercase().contains("no delegatable agents"));
-    }
-}
+#[path = "instruction_pipeline_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -1,0 +1,492 @@
+//! Tests for the instruction merge pipeline and bundled prompt assembly.
+//!
+//! Split out of `instruction_pipeline.rs` (#4318) so the production file stays
+//! under the 500-SLOC cap enforced by `scripts/check_line_cap.sh`. The module is
+//! included with `#[path]`, so `use super::*` still reaches the pipeline's items
+//! exactly as it did inline; nothing about the assertions changed in the move.
+
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Write `<name>.md` into `dir` with the given raw content.
+fn write_file(path: &PathBuf, content: &str) {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create parent");
+    }
+    fs::write(path, content).expect("write file");
+}
+
+/// Build a `PipelineInput` rooted at `tmp` with optional INSTRUCTIONS.md.
+fn input_in(tmp: &TempDir) -> PipelineInput {
+    PipelineInput {
+        framework_instructions_path: tmp.path().join("INSTRUCTIONS.md"),
+        agents_dir: tmp.path().join("agents"),
+        claude_md_path: tmp.path().join("project").join("CLAUDE.md"),
+    }
+}
+
+#[test]
+fn pipeline_full() {
+    // All inputs present → merged output contains the two framework
+    // sections in the documented 3 → 4 order. The project CLAUDE.md is
+    // deliberately NOT folded into `merged` (dead code removed — Claude
+    // Code loads CLAUDE.md natively and the real launch prompt never
+    // read this field for that content).
+    let tmp = TempDir::new().unwrap();
+    let input = input_in(&tmp);
+
+    write_file(
+        &input.framework_instructions_path,
+        "# Framework\n\nFRAMEWORK SECTION\n",
+    );
+    fs::create_dir_all(&input.agents_dir).unwrap();
+    write_file(
+        &input.agents_dir.join("engineer.md"),
+        "---\nname: engineer\nrole: engineer\ndescription: Builds things.\n---\n\n# Engineer\n",
+    );
+    write_file(&input.claude_md_path, "# Project\n\nPROJECT SECTION\n");
+
+    let out = build_instructions(&input).unwrap();
+    assert!(out.instructions_loaded);
+    assert_eq!(out.agent_count, 1);
+    assert!(
+        !out.claude_md_created,
+        "existing CLAUDE.md is not recreated"
+    );
+
+    let fw = out.merged.find("FRAMEWORK SECTION").expect("framework");
+    let auth = out
+        .merged
+        .find("## Delegation Authority")
+        .expect("authority");
+    assert!(fw < auth, "framework precedes delegation authority");
+    assert!(out.merged.contains("### engineer"));
+    assert!(
+        !out.merged.contains("PROJECT SECTION"),
+        "project CLAUDE.md content must not be folded into merged: {}",
+        out.merged
+    );
+}
+
+#[test]
+fn pipeline_missing_instructions() {
+    // INSTRUCTIONS.md absent → pipeline still succeeds, instructions_loaded
+    // is false, and section 4 is still present.
+    let tmp = TempDir::new().unwrap();
+    let input = input_in(&tmp);
+    // No INSTRUCTIONS.md written.
+    fs::create_dir_all(&input.agents_dir).unwrap();
+    write_file(
+        &input.agents_dir.join("qa.md"),
+        "---\nname: qa\nrole: qa\ndescription: Tests things.\n---\n\n# QA\n",
+    );
+    write_file(&input.claude_md_path, "# Project\n\nPROJECT NOTES\n");
+
+    let out = build_instructions(&input).unwrap();
+    assert!(!out.instructions_loaded);
+    assert!(out.merged.contains("## Delegation Authority"));
+    assert!(!out.merged.contains("PROJECT NOTES"));
+    // No dangling separator at the very start.
+    assert!(!out.merged.starts_with("---"));
+}
+
+#[test]
+fn pipeline_creates_claude_md() {
+    // CLAUDE.md absent → it is created as a side effect, claude_md_created
+    // is true, and the file on disk contains the stub — but the stub text
+    // is NOT folded into `merged` (dead code removed).
+    let tmp = TempDir::new().unwrap();
+    let input = input_in(&tmp);
+    write_file(&input.framework_instructions_path, "# Framework\n");
+    fs::create_dir_all(&input.agents_dir).unwrap();
+
+    assert!(!input.claude_md_path.exists());
+    let out = build_instructions(&input).unwrap();
+    assert!(out.claude_md_created);
+    assert!(input.claude_md_path.exists());
+
+    let on_disk = fs::read_to_string(&input.claude_md_path).unwrap();
+    assert!(on_disk.contains("# Project Instructions"));
+    assert!(on_disk.contains("trusty-mpm will never modify this file again"));
+    // The seeded stub carries the attribution convention so every new
+    // trusty-mpm project inherits the footer override at the framework
+    // level (issue #2876) rather than relying on a per-project hand-edit.
+    assert!(
+        on_disk.contains("🤖🤖🤖 Generated with trusty-mpm"),
+        "seeded stub must carry the attribution footer: {on_disk}"
+    );
+    assert!(
+        !out.merged.contains("# Project Instructions"),
+        "stub content must not be folded into merged: {}",
+        out.merged
+    );
+}
+
+#[test]
+fn pipeline_claude_md_left_byte_identical() {
+    // Why (#2170): trusty-mpm must NEVER modify a target project's
+    // CLAUDE.md. An existing file — including one that happens to
+    // contain the literal delegation-block markers as ordinary operator
+    // text — must come back out of `build_instructions` completely
+    // untouched on disk, and its content must not leak into `merged`
+    // (dead code removed).
+    let tmp = TempDir::new().unwrap();
+    let input = input_in(&tmp);
+    write_file(&input.framework_instructions_path, "# Framework\n");
+    fs::create_dir_all(&input.agents_dir).unwrap();
+    let custom = "# My Project\n\nCUSTOM HAND-WRITTEN CONTENT\n";
+    write_file(&input.claude_md_path, custom);
+
+    let out = build_instructions(&input).unwrap();
+    assert!(!out.claude_md_created);
+    let on_disk = fs::read_to_string(&input.claude_md_path).unwrap();
+    assert_eq!(
+        on_disk, custom,
+        "pre-existing CLAUDE.md must be left byte-identical: {on_disk}"
+    );
+    assert!(
+        !on_disk.contains(DELEGATION_BLOCK_BEGIN),
+        "no delegation-directive block may be injected: {on_disk}"
+    );
+    assert!(
+        !out.merged.contains("CUSTOM HAND-WRITTEN CONTENT"),
+        "project CLAUDE.md content must not be folded into merged: {}",
+        out.merged
+    );
+}
+
+#[test]
+fn strip_delegation_block_removes_legacy_block() {
+    // Why (#2170 cleanup helper): a workspace polluted by the old #2125
+    // injection must have the fenced block removed, leaving the
+    // operator's own content untouched.
+    let polluted = format!(
+        "{DELEGATION_BLOCK_BEGIN}\n\nSome injected directive text.\n\n{DELEGATION_BLOCK_END}\n\n# My Project\n\nOperator notes.\n"
+    );
+    let cleaned = strip_delegation_block(&polluted);
+    assert!(!cleaned.contains(DELEGATION_BLOCK_BEGIN));
+    assert!(!cleaned.contains(DELEGATION_BLOCK_END));
+    assert!(!cleaned.contains("Some injected directive text."));
+    assert_eq!(cleaned, "# My Project\n\nOperator notes.\n");
+}
+
+#[test]
+fn strip_delegation_block_noop_when_absent() {
+    // Why: a clean CLAUDE.md (the common case post-#2170) must be
+    // returned byte-identical.
+    let clean = "# My Project\n\nOperator notes.\n";
+    assert_eq!(strip_delegation_block(clean), clean);
+}
+
+#[test]
+fn pm_instructions_is_its_three_sections() {
+    // #4183: the legacy PM body is RECONSTITUTED, never kept as a fourth copy
+    // on disk. #4318 moved the source of that reconstitution from the
+    // `include_str!` constants to the MANIFEST, because the manifest may now
+    // author a rule inline — rebuilding from the constants would deliver such a
+    // rule to the packaged composer and not to the legacy override assembly,
+    // which is the split-brain this asserts against.
+    let body = pm_instructions();
+    let projected = crate::core::bundled_pm_package::authored_run(&[
+        SectionId::Core,
+        SectionId::Memory,
+        SectionId::Search,
+    ])
+    .expect("the manifest is readable");
+    assert_eq!(body, format!("{projected}\n"));
+
+    // Every section source is still delivered in full, in order, and the
+    // manifest-authored rules ride along.
+    for expected in [
+        SECTION_CORE.trim(),
+        SECTION_MEMORY.trim(),
+        SECTION_SEARCH.trim(),
+    ] {
+        assert!(body.contains(expected), "a section source went missing");
+    }
+    assert!(body.contains("### Clickable References"));
+    assert!(body.contains("### Banned Word"));
+
+    // The paragraph break is `Join::Blank`'s literal, which is what makes
+    // this string byte-identical to what the packaged composer emits.
+    assert!(body.contains("## Memory Protocol (Context-First)"));
+    assert!(body.contains("## Code Search Protocol (Context-First)"));
+    assert!(
+        !body.contains("## Context-First Protocol\n"),
+        "the merged Memory+Search block must not survive as a fourth copy"
+    );
+}
+
+#[test]
+fn base_pm_is_its_three_sections() {
+    // Same no-second-copy property for the non-overridable floor, plus the
+    // one reordering #4183 makes: the tool-priority mandate travels with the
+    // other non-overridable rules and so now precedes the conventions.
+    let floor = base_pm();
+    assert_eq!(
+        floor,
+        format!(
+            "{}\n\n{}\n\n{}\n",
+            SECTION_IDENTITY.trim(),
+            SECTION_NON_OVERRIDABLE_RULES.trim(),
+            SECTION_FRAMEWORK_CONVENTIONS.trim()
+        )
+    );
+
+    let tool = floor
+        .find("## Trusty Tool Priority (Non-Overridable)")
+        .expect("the tool-priority mandate stays in the floor");
+    let conventions = floor
+        .find("## Framework-Guaranteed Conventions (Non-Overridable)")
+        .expect("the guaranteed conventions stay in the floor");
+    assert!(
+        tool < conventions,
+        "tool priority now rides with the non-overridable rules it belongs to"
+    );
+}
+
+#[test]
+fn workflow_section_carries_the_opportunistic_fix_rule() {
+    // The opportunistic-fix rule (owner amendment on #4183) is authored in the
+    // manifest, not in `workflow.md`, so the constant alone does not carry it.
+    // Every consumer must therefore read the section through the manifest —
+    // otherwise a project with no override and a project on the legacy path
+    // would receive different workflows.
+    let section = workflow_section();
+    assert!(section.starts_with(WORKFLOW.trim()));
+    assert!(section.contains("## Opportunistic Fixes"));
+    assert!(section.contains("noted on the CURRENT issue"));
+    assert!(
+        !WORKFLOW.contains("## Opportunistic Fixes"),
+        "the rule is manifest-authored; finding it in workflow.md means it was \
+         duplicated"
+    );
+}
+
+#[test]
+fn delegation_doctrine_carries_the_precedence_note() {
+    // #4318 moved the roster-precedence note out of a Rust literal and into the
+    // manifest. The doctrine string every composer uses must still be the asset
+    // followed by that note, in that order.
+    let doctrine = delegation_doctrine();
+    assert!(doctrine.starts_with(AGENT_DELEGATION.trim()));
+    assert!(doctrine.ends_with("do not retry the same agent."));
+    assert!(doctrine.contains("trust the roster"));
+}
+
+#[test]
+fn the_installed_prompt_carries_the_manifest_authored_rules() {
+    // `assemble_system_prompt` writes
+    // `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`, which `tm install`
+    // and `tm launch` hand to `claude --append-system-prompt-file`. It has no
+    // agent roster, so it cannot use the package composer — which is exactly why
+    // it has to project the manifest rather than concatenate the constants. A
+    // manifest-authored rule missing here is a rule half the launch paths never
+    // see.
+    let prompt = assemble_system_prompt();
+    for marker in [
+        "### Clickable References",
+        "### Banned Word",
+        "## Opportunistic Fixes",
+    ] {
+        assert!(
+            prompt.contains(marker),
+            "the installed prompt must carry {marker:?}"
+        );
+    }
+}
+
+#[test]
+fn assemble_system_prompt_contains_all_sections() {
+    // Why: the assembled prompt is the contract `claude` receives; every
+    // bundled section must be present and joined with the `---` rule.
+    let prompt = assemble_system_prompt();
+    assert!(prompt.contains("# PM Agent -- Trusty MPM"));
+    assert!(prompt.contains("# BASE_PM Framework Floor"));
+    assert!(prompt.contains("# PM Workflow Configuration"));
+    assert!(prompt.contains("# Agent Delegation Routing"));
+    // The Trusty tool-priority block now lives inside the BASE_PM floor.
+    assert!(prompt.contains("## Trusty Tool Priority (Non-Overridable)"));
+    assert!(prompt.contains("\n\n---\n\n"));
+    // BASE_PM is the non-overridable floor: it must come last.
+    let base = prompt.find("# BASE_PM Framework Floor").expect("base_pm");
+    let delegation = prompt
+        .find("# Agent Delegation Routing")
+        .expect("delegation");
+    assert!(base > delegation, "BASE_PM floor must be appended last");
+    // Ticketing-specific content was stripped from the bundled assets.
+    assert!(!prompt.contains("mcp__mcp-ticketer__"));
+    assert!(!prompt.contains("ticketing_agent"));
+}
+
+// Why serial + fake-HOME (extra sweep hit — review-gate report on top of
+// #2459/#2460/#2461): `install_system_prompt()` resolves `dirs::home_dir()`
+// internally and previously wrote straight into the REAL
+// `$HOME/.trusty-mpm/framework/instructions/` — both polluting the
+// developer's real home directory on every test run AND racing with any
+// other test in this binary that redirects `HOME` to a temp dir
+// concurrently (same class as `manifest_expands_tilde`, #2459). Redirect
+// `HOME` to an isolated temp dir for the duration of the test and join
+// the crate's shared `#[serial_test::serial]` lock so no other
+// HOME-mutating test can interleave.
+#[serial_test::serial]
+#[test]
+fn install_system_prompt_writes_file() {
+    // Why: `tm launch` depends on `install_system_prompt` regenerating
+    // INSTRUCTIONS.md; this asserts it writes a non-empty file under the
+    // expected `~/.trusty-mpm/framework/instructions/` path.
+    let fake_home = TempDir::new().expect("create fake home");
+    let prev_home = std::env::var("HOME").ok();
+    // SAFETY: serialized via `#[serial_test::serial]`, so no other test
+    // thread observes or mutates HOME concurrently. Restored below
+    // regardless of panics via the `HomeGuard` drop impl.
+    unsafe { std::env::set_var("HOME", fake_home.path()) };
+    struct HomeGuard(Option<String>);
+    impl Drop for HomeGuard {
+        fn drop(&mut self) {
+            match &self.0 {
+                Some(p) => unsafe { std::env::set_var("HOME", p) },
+                None => unsafe { std::env::remove_var("HOME") },
+            }
+        }
+    }
+    let _guard = HomeGuard(prev_home);
+
+    let out = install_system_prompt().expect("install succeeds");
+    assert!(out.starts_with(fake_home.path()));
+    assert!(out.ends_with("INSTRUCTIONS.md"));
+    assert!(out.exists());
+    let on_disk = fs::read_to_string(&out).unwrap();
+    assert_eq!(on_disk, assemble_system_prompt());
+    assert!(!on_disk.is_empty());
+}
+
+#[test]
+fn install_system_prompt_to_writes_assembled() {
+    // Why: `tm install` calls `install_system_prompt_to` pointing at the
+    // framework path so the assembled prompt (not the 4-line stub) is on
+    // disk immediately after install — regression for issue #383.
+    // What: asserts the file written by the path-parameterised helper
+    // equals `assemble_system_prompt()` and contains key PM headings.
+    // Test: call the helper against a temp path; read back and verify content.
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("instructions").join("INSTRUCTIONS.md");
+    install_system_prompt_to(&dest).expect("write succeeds");
+    assert!(
+        dest.exists(),
+        "INSTRUCTIONS.md must exist after install_system_prompt_to"
+    );
+    let on_disk = fs::read_to_string(&dest).unwrap();
+    assert_eq!(
+        on_disk,
+        assemble_system_prompt(),
+        "content must equal assembled prompt"
+    );
+    // The 4-line stub must NOT be present (regression guard for issue #383).
+    assert!(
+        !on_disk.trim().eq("# trusty-mpm Framework Instructions\n\nThis Claude Code instance is managed by trusty-mpm.\nDaemon endpoint: ${TRUSTY_MPM_URL:-http://localhost:7799}"),
+        "stub content must not be written — full assembled prompt required"
+    );
+    // Real PM sections must be present.
+    assert!(
+        on_disk.contains("# PM Agent -- Trusty MPM"),
+        "PM_INSTRUCTIONS section must be present"
+    );
+    assert!(
+        on_disk.contains("# BASE_PM Framework Floor"),
+        "BASE_PM floor must be present"
+    );
+}
+
+#[test]
+fn primary_directive_mandate_not_duplicated_across_channels() {
+    // Issue #2647 (R2): the FULL mandate table (Prohibitions, Circuit
+    // Breakers, Delegation Map, PM Allowlist) must live in exactly ONE
+    // channel — the appended system prompt (`assemble_system_prompt`,
+    // always injected via `--append-system-prompt-file` on tm-driven
+    // spawns). Before this fix, every bundled output-style file (loaded
+    // independently via the Claude Code `outputStyle` settings key) ALSO
+    // carried a full, near-identical restatement of that table —
+    // duplicated tokens every session.
+    //
+    // Code-critic follow-up: `outputStyle` is deployed to
+    // `<project>/.claude/output-styles/*.md` + `settings.json`
+    // (`settings.rs`) and therefore applies to ANY `claude` launched in
+    // that directory — including a manual `claude` invocation that never
+    // receives `--append-system-prompt-file` at all
+    // (`runtime/claude_code.rs`). A style with NOTHING but a pointer to
+    // the appended prompt would leave such a launch with zero
+    // enforcement. So each style keeps a short, SELF-CONTAINED minimal
+    // mandate (PRIMARY DIRECTIVE statement, override-phrase list, a
+    // prohibition summary) alongside the pointer to the full table —
+    // this test asserts that block survived the dedup, not just that the
+    // heading sentinel is de-duplicated.
+    const SENTINEL: &str = "PRIMARY DIRECTIVE";
+    let assembled = assemble_system_prompt();
+    assert_eq!(
+        assembled.matches(SENTINEL).count(),
+        0,
+        "the appended system prompt must not carry a literal PRIMARY \
+         DIRECTIVE banner — the mandate lives there as Identity + \
+         Prohibitions content"
+    );
+
+    // The appended prompt must still carry the substantive, canonical
+    // mandate content — so the mandate can never silently vanish from
+    // BOTH channels at once just because the banner text moved.
+    assert!(
+        assembled.contains("## Prohibitions"),
+        "the appended prompt must carry the canonical Prohibitions table"
+    );
+    assert!(
+        assembled.contains("## Circuit Breakers"),
+        "the appended prompt must carry the canonical Circuit Breakers table"
+    );
+    assert!(
+        assembled.contains("don't delegate"),
+        "the appended prompt must carry at least one override phrase"
+    );
+
+    for style in crate::core::bundle::OUTPUT_STYLES {
+        let combined =
+            assembled.matches(SENTINEL).count() + style.content.matches(SENTINEL).count();
+        assert_eq!(
+            combined, 1,
+            "{}: PRIMARY DIRECTIVE sentinel must appear exactly once across \
+             the appended prompt + this output style (one heading, never a \
+             full restatement of the mandate TABLE) — got {combined}",
+            style.id
+        );
+
+        // Each style must still carry its OWN self-contained minimal
+        // mandate — the override-phrase list and a prohibition summary —
+        // so a manual `claude` launch (no --append-system-prompt-file)
+        // in a tm-provisioned workspace is never left with zero
+        // enforcement.
+        assert!(
+            style.content.contains("do this yourself"),
+            "{}: must carry its own self-contained override-phrase list",
+            style.id
+        );
+        assert!(
+            style.content.contains("Minimum prohibitions"),
+            "{}: must carry its own self-contained prohibition summary",
+            style.id
+        );
+    }
+}
+
+#[test]
+fn pipeline_no_agents_still_succeeds() {
+    // An empty agents dir yields a zero agent_count and the "no agents"
+    // delegation section, but the pipeline still produces merged output.
+    let tmp = TempDir::new().unwrap();
+    let input = input_in(&tmp);
+    write_file(&input.framework_instructions_path, "# Framework\n");
+    fs::create_dir_all(&input.agents_dir).unwrap();
+
+    let out = build_instructions(&input).unwrap();
+    assert_eq!(out.agent_count, 0);
+    assert!(out.merged.to_lowercase().contains("no delegatable agents"));
+}

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -454,6 +454,25 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
+### Clickable References
+
+Every reference to an issue, PR, ticket, or commit renders as a clickable markdown link — never a bare number.
+
+- Issues and PRs: `[#4318](https://github.com/<owner>/<repo>/issues/4318)`. GitHub resolves the `/issues/` form to a PR, so one shape covers both.
+- Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
+- Tickets in another tracker: link to that tracker's issue URL.
+
+This applies to every PM response and report, not only formal ones. "Fixed in #4318" with no link is a defect.
+
+### Banned Word — "honest"
+
+"Honest" and every variation of it — honestly, honesty, dishonest, "to be honest", "the honest answer" — is banned from PM responses, delegation briefs, and review instructions.
+
+A report states facts. Labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel. State the fact.
+
+- Wrong: "The honest answer is that the merge didn't happen."
+- Right: "The merge didn't happen."
+
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook (`trusty-memory prompt-context`) already injects a
@@ -667,6 +686,12 @@ User can explicitly state:
 - "Go directly to [phase]" - jump to phase
 - "No QA needed" - skip QA (not recommended)
 - "Emergency fix" - bypass research
+
+## Opportunistic Fixes
+
+An easy fix discovered while working on a file is noted on the CURRENT issue and made in the same work. Never file a new issue for it.
+
+New issues are reserved for genuinely separable work someone would schedule on its own. Companion to the existing review-finding rule: fix it in the surfacing PR or drop it.
 
 ---
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -454,6 +454,25 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
+### Clickable References
+
+Every reference to an issue, PR, ticket, or commit renders as a clickable markdown link — never a bare number.
+
+- Issues and PRs: `[#4318](https://github.com/<owner>/<repo>/issues/4318)`. GitHub resolves the `/issues/` form to a PR, so one shape covers both.
+- Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
+- Tickets in another tracker: link to that tracker's issue URL.
+
+This applies to every PM response and report, not only formal ones. "Fixed in #4318" with no link is a defect.
+
+### Banned Word — "honest"
+
+"Honest" and every variation of it — honestly, honesty, dishonest, "to be honest", "the honest answer" — is banned from PM responses, delegation briefs, and review instructions.
+
+A report states facts. Labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel. State the fact.
+
+- Wrong: "The honest answer is that the merge didn't happen."
+- Right: "The merge didn't happen."
+
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook (`trusty-memory prompt-context`) already injects a

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-legacy-delegation-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-legacy-delegation-override.md
@@ -454,6 +454,25 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
+### Clickable References
+
+Every reference to an issue, PR, ticket, or commit renders as a clickable markdown link — never a bare number.
+
+- Issues and PRs: `[#4318](https://github.com/<owner>/<repo>/issues/4318)`. GitHub resolves the `/issues/` form to a PR, so one shape covers both.
+- Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
+- Tickets in another tracker: link to that tracker's issue URL.
+
+This applies to every PM response and report, not only formal ones. "Fixed in #4318" with no link is a defect.
+
+### Banned Word — "honest"
+
+"Honest" and every variation of it — honestly, honesty, dishonest, "to be honest", "the honest answer" — is banned from PM responses, delegation briefs, and review instructions.
+
+A report states facts. Labelling them honest implies the alternative was considered, which is the doubt the word was reached for to dispel. State the fact.
+
+- Wrong: "The honest answer is that the merge didn't happen."
+- Right: "The merge didn't happen."
+
 ## Memory Protocol (Context-First)
 
 The `UserPromptSubmit` hook (`trusty-memory prompt-context`) already injects a
@@ -667,6 +686,12 @@ User can explicitly state:
 - "Go directly to [phase]" - jump to phase
 - "No QA needed" - skip QA (not recommended)
 - "Emergency fix" - bypass research
+
+## Opportunistic Fixes
+
+An easy fix discovered while working on a file is noted on the CURRENT issue and made in the same work. Never file a new issue for it.
+
+New issues are reserved for genuinely separable work someone would schedule on its own. Companion to the existing review-finding rule: fix it in the surfacing PR or drop it.
 
 ---
 


### PR DESCRIPTION
Part of [#4183](https://github.com/bobmatnyc/trusty-tools/issues/4183). Closes [#4318](https://github.com/bobmatnyc/trusty-tools/issues/4318).

Pulled forward in the 1.3.0 sequence by owner order: the 1.3 rules belong in JSON, not markdown. So the conversion lands first, and the three new rules land *in the converted artifact*.

## What changed

The bundled PM instruction package was a Rust literal. `InstructionPackage::from_json` had zero non-test call sites and the shipped JSON Schema had no instance under it, while other tickets already recorded "the composed instructions payload is generated from the instruction package JSON" as settled fact. It now is: `assets/instructions/pm-instruction-package.json` is the authored manifest, and `bundled_pm_package.rs` only parses and composes it.

**Schema v2** adds a `{"kind":"file","path":"…"}` body variant. Prose keeps living in reviewable markdown under `sections/`; the manifest names it by path and resolves through a compile-time `include_str!` table (`instruction_pipeline::SECTION_SOURCES`). Inlining the prose instead would have turned `core.md` into one 23 KB JSON line and moved the floor text out of the files `check_instruction_floor.sh` greps; resolving on the filesystem at launch would make the delivered prompt depend on what happens to be on disk. This way the build stays hermetic and a renamed section is a compile error. The bump is required by the format's own evolution policy — a v1 build reading a v2 manifest rejects it loudly rather than composing a prompt missing the new field's effect.

## The mechanism moves nothing

All three composed-prompt goldens passed **byte-unchanged** with the manifest wired in and the content below absent. The golden diff in this PR is content only:

```
 pm-prompt-bundled-fallback.md          | 25 ++++++++++++++++++++++
 pm-prompt-claude-md-override.md        | 19 ++++++++++++++++
 pm-prompt-legacy-delegation-override.md| 25 ++++++++++++++++++++++
 3 files changed, 69 insertions(+)
```

Zero deletions. Nothing moved.

## The three owner rules

Authored as inline `text` blocks in the manifest, not in markdown. Same family as the plain-prose rule from [#4316](https://github.com/bobmatnyc/trusty-tools/pull/4316).

| rule | section | substance |
|---|---|---|
| `### Clickable References` | `core` | issue/PR/ticket/commit references always render as clickable markdown links, never bare numbers |
| `### Banned Word — "honest"` | `core` | banned from PM responses, delegation briefs and review instructions; a report states facts, and labelling them honest implies the alternative was considered |
| `## Opportunistic Fixes` | `workflow` | an easy fix found while working on a file is noted on the CURRENT issue and made in the same work — never a new issue; new issues are for genuinely separable schedulable work |

## Provenance

Raised in review: the banned-word rule and the rules-in-JSON ruling arrived without a citation. The owner declined issue comments for them ("don't ticket it, just do it"), so the record lives here. Two of the four items *do* have posted owner comments, and those are cited rather than restated as verbal — the distinction is the point, since it marks exactly which items rest on relayed authority.

| item | date | source |
|---|---|---|
| Opportunistic-fix rule | 2026-07-29 | posted owner comment — [#4183 comment-5123027792](https://github.com/bobmatnyc/trusty-tools/issues/4183#issuecomment-5123027792) |
| Clickable-links rule | 2026-07-29 | posted owner comment — [#4183 comment-5124050901](https://github.com/bobmatnyc/trusty-tools/issues/4183#issuecomment-5124050901) |
| Banned word "honest" | 2026-07-29 | verbal owner order, session `tm-dogfood-relaunch-01`, relayed via the PM. No issue comment by owner instruction. |
| Rules-in-JSON-not-MD ruling (why [#4318](https://github.com/bobmatnyc/trusty-tools/issues/4318) was pulled forward ahead of the 1.3.0 sequence, and why the three rules are inline `text` blocks rather than new markdown files) | 2026-07-30 | verbal owner order, session `tm-dogfood-relaunch-01`, relayed via the PM. No issue comment by owner instruction. |

## No split-brain

Once a rule may be authored in the manifest, rebuilding the legacy multi-section strings from the `include_str!` constants would deliver it to the packaged composer and silently withhold it from the `.trusty-mpm/` override assembly and from `assemble_system_prompt()` — the roster-free prompt `tm install` writes and `tm launch` hands to `--append-system-prompt-file`, which has no agent roster and so cannot use the package composer at all.

So `pm_instructions()`, `base_pm()` and the new `workflow_section()` / `delegation_doctrine()` project the same manifest through `InstructionPackage::authored_run`. The goldens are the evidence:

| golden | delta | why |
|---|---|---|
| bundled-fallback | +1402 bytes, all 3 rules | the packaged composer |
| legacy-delegation-override | +1402 bytes, all 3 rules | the legacy assembly agrees — no split-brain |
| claude-md-override | +1067 bytes, 2 rules | correct: the `CLAUDE.md` WORKFLOW override replaces that section wholesale, so the workflow rule is *supposed* to be gone |

## Also in scope

- `ROSTER_PRECEDENCE_NOTE` moves out of Rust into the manifest, where its position between the doctrine and the live roster is declared rather than formatted in by hand at two call sites.
- `with_overrides` now matches authored bodies rather than `Text` alone. Without it, every bundled section becoming a `file` body would have made the whole taxonomy silently non-overridable — an advertised-but-unread override, [#381](https://github.com/bobmatnyc/trusty-tools/issues/381) verbatim. Pinned by an added assertion in `content_sections_accept_a_project_override`.
- `bundled_fallback_package()` returns `Result`. On a manifest failure `resolve_pm_prompt` logs loudly and degrades to the legacy assembly built from the retained constants, so the worst case is a prompt missing the inline rules rather than a truncated one. `bundled_manifest_parses_and_validates` makes that unreachable for a shipped build.
- `instruction_pipeline.rs` tests move to a sibling `instruction_pipeline_tests.rs` to stay under the 500-SLOC production cap.

New tests: `bundled_manifest_parses_and_validates`, `manifest_prose_lives_in_markdown_not_in_the_json`, `every_section_source_resolves`, `unknown_file_source_is_rejected`, `schema_body_kinds_match_rust_variants` (the v2 schema↔Rust drift gate), `file_body_resolves_through_the_bundled_table`, `a_file_block_may_not_be_optional`, `authored_run_projects_blocks_in_order_with_joins`, `authored_run_skips_generated_blocks`, `workflow_section_carries_the_opportunistic_fix_rule`, `delegation_doctrine_carries_the_precedence_note`, `the_installed_prompt_carries_the_manifest_authored_rules`.

## Coexistence with #4316 — merged and verified

[#4316](https://github.com/bobmatnyc/trusty-tools/pull/4316) merged at 2026-07-30T05:38Z and is folded into this branch (`cc4dd070`). The merge precondition is satisfied:

- **Golden diff vs the pre-fold commit: +20 / −0 on each of the three goldens. Zero deletions.** The 20 lines are exactly #4316's `### Prose Style — Write Plainly` section.
- Ordering is correct: the prose section lands immediately before `### Clickable References`, both under `## Response Format` — this PR's rules are manifest blocks joined after the whole of `core.md`, so they compose after it automatically.
- `sections/core.md` needed no source resolution; only the generated goldens and `CHANGELOG.md` overlapped. Both CHANGELOG entries are kept.
- Rule coverage in the delivered prompt:

  | golden | rules | reading |
  |---|---|---|
  | bundled-fallback | 4/4 | packaged composer |
  | legacy-delegation-override | 4/4 | legacy assembly agrees — no split-brain |
  | claude-md-override | 3/4 | workflow rule correctly absent; that configuration replaces the WORKFLOW section wholesale |

Re-verified on the folded head: golden test `4 passed; 0 failed`, `cargo test -p trusty-mpm --lib` `3985 passed; 0 failed`, `cargo clippy … -D warnings` exit 0, `cargo fmt --all --check` exit 0, line-cap OK, instruction floor PASS.

## Gates

| gate | result |
|---|---|
| `cargo fmt --all --check` | exit 0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | exit 0, 0 errors |
| `cargo test -p trusty-mpm` | exit 0 — `3985 passed; 0 failed; 6 ignored` (lib) plus 43 further targets, 0 `FAILED` |
| `scripts/check_line_cap.sh` | `7 allowlisted, 0 violations — OK` |
| `scripts/check_instruction_floor.sh` | `PASS: instruction floor is intact` |
| `scripts/check_test_pointers.sh` | `0 dangling pointers — OK` |

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
