### PR TITLE
fix(installer): address code-review findings from #4381 (#4246)

### DIFF
--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -272,8 +272,10 @@ pub fn build_probe_client() -> reqwest::Result<reqwest::Client> {
 /// Why: the `Timeout` arm of the failure taxonomy has to be provable, and a test
 /// that waits out the production [`REQUEST_TIMEOUT`] would add 5 seconds to
 /// every run. Parameterising the bounds keeps the production defaults in ONE
-/// place ([`build_probe_client`]) while letting the timeout test drive a
-/// sub-second bound against a deliberately silent peer.
+/// place ([`build_probe_client`]) while letting the timeout test drive much
+/// shorter ones against a deliberately silent peer. The caller is expected to
+/// pass `connect` ≪ `request`, so that a silent peer's verdict is reached on the
+/// READ path rather than on the handshake.
 /// What: same client as [`build_probe_client`] — `.no_proxy()` included, since
 /// the proxy test needs both bounds AND the flag — with `connect`/`request`
 /// substituted.

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -184,7 +184,26 @@ impl ProbeOutcome {
     /// we hold no actual health information. `down` is the honest verdict — and
     /// it is now safe to say, because the kickstart is gated on
     /// [`Self::is_confirmed_down`], not on this string.
-    /// Test: `tests::health_string_maps_every_variant`.
+    ///
+    /// # Invariant — this string is for DISPLAY ONLY
+    /// `health_string() == "down"` does **NOT** imply
+    /// [`Self::is_confirmed_down`], and that gap is deliberate rather than an
+    /// oversight. `NoAddress`, `HttpError`, `BadEnvelope` and `ProbeFailed` all
+    /// render `down` while being explicitly NOT confirmed-down: each means
+    /// "something answered, or we never looked", which is not evidence that a
+    /// process is dead. The two views answer different questions — this one asks
+    /// *what should we report*, [`Self::is_confirmed_down`] asks *may we destroy
+    /// state*.
+    ///
+    /// So this string MUST NOT be used to authorise a destructive action
+    /// (`launchctl kickstart -k`, a restart, a teardown). Gating on
+    /// `health_string() == "down"` would re-merge exactly the causes
+    /// [`ProbeOutcome`] exists to keep apart, restoring the #4246 harm: a
+    /// `NoAddress` member (address never resolved) or a squatter's
+    /// `BadEnvelope` would once again hard-restart a daemon nobody has shown to
+    /// be down. Authorise on the VARIANT, via [`Self::is_confirmed_down`].
+    /// Test: `tests::health_string_maps_every_variant`,
+    /// `tests::down_health_string_is_not_a_kickstart_licence`.
     pub fn health_string(&self) -> &'static str {
         use super::probe::health_str;
         match self {
@@ -238,7 +257,23 @@ impl ProbeOutcome {
     /// never hits the timeout — which is exactly why the gate and the transport
     /// had to land together rather than in sequence.
     /// What: `true` iff `Refused` or `Timeout`.
+    ///
+    /// # Invariant — this is NARROWER than [`Self::health_string`]`() == "down"`
+    /// The two are deliberately NOT equivalent, and callers must not treat them
+    /// as interchangeable. Four variants — `NoAddress`, `HttpError`,
+    /// `BadEnvelope`, `ProbeFailed` — report `down` for display while returning
+    /// `false` here. `NoAddress` is the sharpest example: it reports `down`
+    /// on purpose (mapping it to `unknown` would make
+    /// `VerifyTailReport::build` and `status`'s exit code print `VERIFIED` for a
+    /// member whose address was never resolved), yet it is emphatically not
+    /// grounds for a restart, because nothing was ever observed.
+    ///
+    /// This asymmetry is the whole safety mechanism, so it is pinned by a test
+    /// rather than left to be rediscovered: any future caller reaching for the
+    /// display string to decide whether to repair something is reintroducing
+    /// #4246 and must use this predicate instead.
     /// Test: `tests::only_transport_failures_are_confirmed_down`,
+    /// `tests::down_health_string_is_not_a_kickstart_licence`,
     /// `verify_tail::tests::verify_one_does_not_kickstart_a_healthy_launchd_daemon`.
     pub fn is_confirmed_down(&self) -> bool {
         matches!(self, Self::Refused | Self::Timeout)

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -377,9 +377,21 @@ fn reconcile_all_refused_stays_refused() {
 /// Test: This is the test.
 #[tokio::test]
 async fn probe_distinguishes_failure_causes() {
-    // Sub-second bounds so the Timeout case does not add the production 5s to
-    // every test run; `build_probe_client_with` keeps `.no_proxy()`.
-    let client = build_probe_client_with(Duration::from_millis(500), Duration::from_millis(400))
+    // Bounds well under the production 5s so the Timeout case stays cheap, but
+    // with the CONNECT bound deliberately an order of magnitude SHORTER than the
+    // whole-request bound. That ordering is load-bearing for what the `silent`
+    // case below proves: the peer completes the TCP handshake and then goes
+    // quiet, so the deadline that must fire is the REQUEST one, reached while
+    // waiting to READ. The previous bounds were inverted (connect 500ms >
+    // request 400ms), which made the connect bound unreachable dead config and
+    // left the case unable to distinguish a read timeout from a connect timeout
+    // — the two are indistinguishable downstream, because
+    // `classify_transport_error` tests `is_timeout()` before `is_connect()` and
+    // hyper-util reports a connect timeout as `io::ErrorKind::TimedOut`, so both
+    // land on `Timeout`. A loopback connect completes in microseconds, so 250ms
+    // is ~1000x headroom while 2s leaves the read path an 8x margin over it.
+    // `build_probe_client_with` keeps `.no_proxy()`.
+    let client = build_probe_client_with(Duration::from_millis(250), Duration::from_secs(2))
         .expect("probe client builds");
 
     let refused = dead_addr();

--- a/crates/trusty-installer/src/commands/probe_http_tests.rs
+++ b/crates/trusty-installer/src/commands/probe_http_tests.rs
@@ -695,6 +695,65 @@ fn member_health_maps_every_variant() {
     );
 }
 
+/// Why: pins the deliberate ASYMMETRY between the display vocabulary and the
+/// repair gate, which is otherwise a trap: `health_string()` and
+/// `is_confirmed_down()` disagree by design, and a future caller who conflates
+/// them ("it says `down`, so restart it") reintroduces #4246 in one line.
+/// `NoAddress` is the sharpest case — it reports `down` on purpose, because
+/// mapping it to `unknown` would make `VerifyTailReport::build` and `status`'s
+/// exit code report `VERIFIED` for a member whose address never resolved, yet
+/// nothing was ever observed about it so there is nothing to repair.
+///
+/// Asserting the asymmetry EXISTS (rather than only asserting each view
+/// separately, as the two sibling tests do) is what stops it being quietly
+/// "tidied" into equivalence: if someone makes the sets coincide, this fails.
+/// What: asserts `NoAddress` specifically maps to `down` while not being
+/// confirmed-down; then, over every `down`-rendering variant, that the
+/// confirmed-down set is a STRICT subset — non-empty on both sides.
+/// Test: This is the test.
+#[test]
+fn down_health_string_is_not_a_kickstart_licence() {
+    // The named trap, spelled out: `down` for display, no repair authorisation.
+    assert_eq!(ProbeOutcome::NoAddress.health_string(), "down");
+    assert!(
+        !ProbeOutcome::NoAddress.is_confirmed_down(),
+        "NoAddress reports `down` but observed NOTHING — it must never authorise \
+         a kickstart. If this ever flips, `tctl install` can hard-restart a member \
+         whose address simply failed to resolve."
+    );
+
+    let down_renderers = [
+        ProbeOutcome::NoAddress,
+        ProbeOutcome::Refused,
+        ProbeOutcome::Timeout,
+        ProbeOutcome::HttpError { status: 502 },
+        ProbeOutcome::BadEnvelope {
+            got: "<html>squatter</html>".to_owned(),
+        },
+        ProbeOutcome::ProbeFailed {
+            detail: "no runtime".to_owned(),
+        },
+    ];
+    let (repairable, benign): (Vec<_>, Vec<_>) = down_renderers
+        .iter()
+        .inspect(|o| {
+            assert_eq!(o.health_string(), "down", "{o:?} must render `down`");
+        })
+        .partition(|o| o.is_confirmed_down());
+
+    assert!(
+        !benign.is_empty(),
+        "the invariant under test is that `down` does NOT imply confirmed-down; if \
+         every down-rendering variant is confirmed-down, the display string has \
+         become a repair authorisation and #4246's gate is gone"
+    );
+    assert!(
+        !repairable.is_empty(),
+        "the mirror property: some `down` MUST still authorise repair, or a \
+         genuinely dead daemon is never kickstarted (#2498)"
+    );
+}
+
 /// Why: THE gate. `launchctl kickstart -k` is destructive — no `ExitTimeOut` in
 /// the shared plist renderer means launchd SIGKILLs 20s after SIGTERM, inside
 /// trusty-search's ≥30s-per-index flush budget — so only an observation at the

--- a/crates/trusty-installer/src/commands/test_support.rs
+++ b/crates/trusty-installer/src/commands/test_support.rs
@@ -201,24 +201,79 @@ pub(crate) async fn stub_hang() -> String {
     addr
 }
 
+/// The loopback port [`dead_addr`] hands out — reserved, privileged, and used by
+/// no trusty daemon.
+///
+/// Why: port 1 (`tcpmux`) is in the privileged range, so an unprivileged process
+/// — which is what `cargo test` is, locally and on CI — cannot bind it even by
+/// accident (`bind` fails `EACCES`). No trusty daemon is anywhere near it either:
+/// the stable set lives in `7070..=7891` (`docs/architecture/port-assignments.md`),
+/// so this cannot repeat the collision class that made hardcoding a port
+/// unattractive in the first place. A closed loopback port answers `connect` with
+/// an immediate RST, so the refusal is both certain and sub-millisecond.
+const DEAD_PORT: u16 = 1;
+
+/// How long [`dead_addr`] waits while proving its address really refuses.
+///
+/// Why: a loopback RST arrives in microseconds, so this bound is never reached in
+/// practice — it exists only so that an environment which silently BLACKHOLES the
+/// port (a packet filter dropping SYNs instead of rejecting them) fails fast with
+/// a diagnosis rather than hanging the suite.
+const DEAD_ADDR_PROOF_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(1);
+
 /// A loopback `host:port` guaranteed to REFUSE a connection.
 ///
 /// Why: the confirmed-down half of the probe taxonomy needs a deterministic
-/// "nothing is listening" address. Hardcoding a port risks colliding with a real
-/// daemon on the developer's machine (this workspace has had three port
-/// collisions); binding an ephemeral port and immediately releasing it yields an
-/// address the OS has just confirmed is free. Deliberately sync (`std::net`) so
-/// it is usable from both `#[test]` and `#[tokio::test]`.
-/// What: binds `127.0.0.1:0`, records the address, drops the listener, and
-/// returns the address.
+/// "nothing is listening" address, because `ProbeOutcome::Refused` is what
+/// authorises `launchctl kickstart -k`.
+///
+/// This used to bind an ephemeral port, record the address, drop the listener and
+/// return it — which is a TOCTOU race, not a guarantee: between the drop and the
+/// caller's `connect`, the OS is free to hand that same port to anything asking
+/// for an ephemeral one (including a sibling stub in the same test binary, since
+/// `cargo test` runs tests concurrently). When it did, the expected refusal became
+/// a successful connection and the #4246 regression guards
+/// (`probe_distinguishes_failure_causes`,
+/// `verify_one_kickstarts_a_genuinely_down_launchd_daemon`) failed for a reason
+/// that had nothing to do with the code under test.
+///
+/// Two seemingly-obvious repairs do NOT work, both measured rather than assumed:
+/// - **Holding the listener open but never calling `accept`** does not refuse at
+///   all. The kernel completes the handshake from the listen backlog, so the
+///   connect SUCCEEDS and the probe classifies it `Timeout` — which is what
+///   [`stub_hang`] is for, and the opposite of what this helper must produce.
+/// - **Holding a socket bound but never calling `listen`** drops the SYN on
+///   macOS; the connect hangs to its own deadline rather than being refused, so
+///   again `Timeout`, not `Refused`.
+///
+/// So the address is a fixed port that can never be listening instead of one that
+/// merely happened to be free, and the helper VERIFIES that before returning:
+/// the guarantee in this doc comment is asserted, not asserted-by-comment. A
+/// violated precondition is a loud panic naming the port, rather than a silent
+/// wrong-outcome flake in whichever test happened to draw it. Deliberately sync
+/// (`std::net`) so it is usable from both `#[test]` and `#[tokio::test]`.
+///
+/// # Postconditions
+/// The returned address refused a connection microseconds ago, and — unlike an
+/// ephemeral port — cannot subsequently be claimed by an unprivileged listener.
 /// Test: `probe_http::tests::probe_distinguishes_failure_causes`,
 /// `probe_http::tests::probe_port_walked_daemon_is_healthy`,
 /// `verify_tail::tests::verify_one_kickstarts_a_genuinely_down_launchd_daemon`.
 pub(crate) fn dead_addr() -> String {
-    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
-    let addr = listener.local_addr().unwrap().to_string();
-    drop(listener);
-    addr
+    let sock = std::net::SocketAddr::from(([127, 0, 0, 1], DEAD_PORT));
+    match std::net::TcpStream::connect_timeout(&sock, DEAD_ADDR_PROOF_TIMEOUT) {
+        Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => sock.to_string(),
+        Ok(_) => panic!(
+            "dead_addr's contract is violated: something is LISTENING on {sock}. The \
+             confirmed-down tests cannot be trusted until that listener is gone."
+        ),
+        Err(e) => panic!(
+            "dead_addr expected an immediate connection refusal from {sock}, got {e:?} \
+             ({}). A packet filter that DROPS rather than rejects loopback SYNs would \
+             turn every Refused assertion into a Timeout.",
+            e.kind()
+        ),
+    }
 }
 
 /// Point `resolve_data_dir` at a throwaway directory with NO `http_addr` in it.


### PR DESCRIPTION
Follow-up to #4381 (squash-merged as `6078b21c`), addressing three code-review findings that were raised after that PR landed. No production behaviour change — two test-determinism fixes and one documented invariant.

## Why this is a follow-up rather than part of #4381

The findings came from a review pass that completed after #4381 was merged. `main` currently carries two latent test flakes in the suite that is the regression guard for #4246, which is worse than it sounds: a flaky guard trains people to re-run until green, and the thing it guards is "do not `launchctl kickstart -k` a healthy daemon."

## 1. `dead_addr` was TOCTOU-racy (`test_support.rs`)

It bound an ephemeral port, recorded the address, dropped the listener, then returned the address. Between the drop and the caller's `connect()` the OS could reassign that port, so the expected `ECONNREFUSED` could become a successful connection — silently changing which `ProbeOutcome` the test asserted. Affected `probe_distinguishes_failure_causes` and `verify_one_kickstarts_a_genuinely_down_launchd_daemon`.

Two obvious fixes were measured and **both are wrong**:
- Hold the listener open and never `accept()` → the kernel still completes the handshake from the backlog (connect succeeded in 0.15 ms) → `Timeout`, not `Refused`.
- Bind without listening → macOS drops the SYN → 2 s hang → also `Timeout`.

Now uses a guaranteed-closed privileged port (`127.0.0.1:1` — `ECONNREFUSED` in 0.171 ms, unbindable without root so it cannot be squatted), and the helper **asserts the refusal before returning** so the documented guarantee is enforced rather than commented. No `ProbeOutcome` expectations changed.

## 2. Probe timeout bounds were inverted (`probe_http_tests.rs`)

The `silent` case built the client with `connect_timeout(500ms)` and `timeout(400ms)` — the connect bound was larger than the total request bound, making it dead configuration and leaving the test unable to show *which* deadline it proved.

Worth recording, since the review raised it: the reviewer's stated mechanism — that the connect timeout could fire first and yield `Refused`, inverting the assertion — is **not reachable**. hyper-util constructs the connect timeout as `io::Error::new(io::ErrorKind::TimedOut, _)`, reqwest's `is_timeout()` matches that kind, and `classify_transport_error` tests `is_timeout()` before `is_connect()`, so a connect timeout also classifies as `Timeout`. The assertion could not invert. The inverted bounds were a real defect regardless.

Now `connect 250ms` / `request 2s`. The assertion still requires `Timeout` specifically — it was not loosened to accept either outcome.

## 3. `health_string()` / `is_confirmed_down()` asymmetry is now pinned

`NoAddress` renders as `"down"` but is deliberately **not** `is_confirmed_down` — the display string is for reporting, and only a transport-level observation (`Refused`/`Timeout`) may authorise a destructive `launchctl kickstart -k`. That asymmetry is load-bearing and was undocumented, making it a trap for any caller that conflates `health_string() == "down"` with `is_confirmed_down()`.

Documented on both methods from each side, plus a new test `down_health_string_is_not_a_kickstart_licence` asserting the asymmetry **exists** — over every `down`-rendering variant, the confirmed-down set must be a strict, non-empty subset. It fails if anyone "tidies" the two views into equivalence.

`NoAddress` intentionally keeps `"down"` rather than `"unknown"`: `unknown` is tolerated by both `VerifyTailReport::build` and `status`'s exit code, so remapping it would report VERIFIED for a member whose address never resolved.

## Verification

507 tests pass (506 + the one new invariant test). Both previously-flaky tests run 20/20 deterministically with fully-qualified paths. `cargo clippy -p trusty-installer --all-targets -- -D warnings`, `cargo fmt --check`, and the doc-comment pointer lint are all clean. `tctl status` still reports real health for all five launchd daemons.

## Not addressed

Four findings from the same review were judged cosmetic and skipped: `classify_transport_error` labelling TLS/redirect errors as `BadEnvelope` (semantically loose, but `BadEnvelope` cannot authorise a kickstart so the safety gate is unaffected), the `reconcile` rank-6 bucket ordering among unreachable variants, `stub_seq_blocking`'s error message, and `SAFETY`-comment wording.

One further finding — a possible type mismatch at `stack/doctor.rs:130` — was a false positive: the branch compiles with 507 passing tests and a clean clippy, so a compile error cannot be present.

🤖👥 Generated with [Claude MPM](https://github.com/bobmatnyc/claude-mpm)
