### PR TITLE
test(trusty-agents): pause the clock on discover_one_returns_none_on_timeout

### DIFF
--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **`discover_one_returns_none_on_timeout` now runs on Tokio's paused clock
+  instead of sleeping out the real 15s `DISCOVERY_TIMEOUT`** — 15.015s to
+  0.00s, removing what was the single slowest test in the workspace (of
+  20,317). `#[tokio::test(start_paused = true)]` still spawns the real
+  unresponsive `sleep 3600` server and still fires the real, unmodified
+  15s constant; the runtime just auto-advances to the deadline rather than
+  waiting for it. Coverage is verified preserved, not assumed: with the
+  `tokio::time::timeout` removed from `discover_one` the test fails, and a
+  new elapsed-time assertion additionally fails if `None` ever comes back
+  from an early spawn failure rather than from the deadline expiring — a
+  paused-clock test that no longer exercises the timeout would otherwise
+  pass green.
+
 ### Fixed
 
 - **The daemon now writes a real, best-effort log file, scoped per project

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -194,6 +194,11 @@ name = "tagent"
 path = "src/main.rs"
 
 [dev-dependencies]
+# test-util enables Tokio's paused clock (`#[tokio::test(start_paused = true)]`)
+# used by `discover_one_returns_none_on_timeout` to exercise the real 15s
+# `DISCOVERY_TIMEOUT` on the virtual clock. Declared explicitly rather than
+# relying on `tokio-test` happening to pull the same feature in.
+tokio = { version = "1", features = ["full", "test-util"] }
 tokio-test = "0.4"
 tempfile = "3"
 tower = { version = "0.5", features = ["util"] }

--- a/crates/trusty-agents/src/tools/mcp_live/cache.rs
+++ b/crates/trusty-agents/src/tools/mcp_live/cache.rs
@@ -210,12 +210,22 @@ done"#,
     /// block discovery indefinitely (or for the full chained-60s worst
     /// case) — `DISCOVERY_TIMEOUT` must actually fire.
     /// What: Point a spec at `sleep 3600` (never speaks the MCP protocol);
-    /// assert `discover_one` returns `None` well before the OS would kill
-    /// the process on its own. Uses a shortened effective wait by relying on
-    /// `DISCOVERY_TIMEOUT`'s real value — this test's own timeout wrapper
-    /// only guards against the assertion itself hanging in CI.
+    /// assert `discover_one` returns `None`, and that it did so by exhausting
+    /// `DISCOVERY_TIMEOUT` rather than by some unrelated early failure (a
+    /// spawn error would also produce `None`, but at ~zero elapsed time).
+    /// This test's own outer timeout wrapper only guards against the
+    /// assertion itself hanging.
+    ///
+    /// `start_paused = true` runs this on Tokio's virtual clock: the real
+    /// `sleep 3600` child still never speaks, so the runtime goes idle and
+    /// Tokio auto-advances straight to the next timer deadline —
+    /// `DISCOVERY_TIMEOUT` fires against the real, unmodified 15s constant
+    /// but costs no wall-clock (was the workspace's slowest test at 15.0s).
+    /// Removing the `tokio::time::timeout` from `discover_one` still fails
+    /// this test: the discovery future would stay pending forever, the outer
+    /// wrapper below would fire instead, and `expect` would panic.
     /// Test: This test.
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     #[cfg(unix)]
     async fn discover_one_returns_none_on_timeout() {
         let spec = McpServerSpec {
@@ -226,15 +236,22 @@ done"#,
             source: SpecSource::ConfigService,
         };
 
+        let started = tokio::time::Instant::now();
         let result = tokio::time::timeout(DISCOVERY_TIMEOUT + Duration::from_secs(10), async {
             discover_one(&spec).await
         })
         .await
         .expect("discover_one must respect DISCOVERY_TIMEOUT, not hang indefinitely");
+        let elapsed = started.elapsed();
 
         assert!(
             result.is_none(),
             "a server that never speaks MCP must be skipped, not treated as discovered"
+        );
+        assert!(
+            elapsed >= DISCOVERY_TIMEOUT,
+            "`None` must come from `DISCOVERY_TIMEOUT` expiring, but discovery gave up after \
+             only {elapsed:?} — the timeout path was not the one exercised"
         );
     }
 }

--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -8,6 +8,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **`events_connect_hang_is_bounded_by_connect_timeout_not_infinite` waits out
+  `CONNECT_TIMEOUT` on Tokio's virtual clock** — 10.01s to 0.01s. The pause is
+  taken only AFTER the listener confirms it accepted the pump's connection, so
+  the #3494 "TCP accepted, headers never sent" precondition is established for
+  real before time is faked. A blanket `#[tokio::test(start_paused = true)]`
+  here is NOT equivalent and was rejected on measurement: it lost the accept on
+  6 of 10 runs (Tokio auto-advances while the handshake is still in flight),
+  quietly downgrading this to a plain connect-timeout test while still passing,
+  because both failure modes produce a "connection failed" reason. With the
+  ordering above the emitted reason string is byte-identical to the real-clock
+  run, and removing `.timeout(CONNECT_TIMEOUT)` from `pump_session_events`
+  still fails the test.
+
 ### Added
 
 - **`Event::AgentMessageDelta` now has a producer (streaming epic #3696,

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -140,8 +140,11 @@ tempfile = { workspace = true }
 # `bedrock-client`.
 
 [dev-dependencies]
-# Async test runtime (events, build_info, perf async tests, tools tests)
-tokio = { workspace = true }
+# Async test runtime (events, build_info, perf async tests, tools tests).
+# test-util enables Tokio's paused clock (`tokio::time::pause`) used by
+# `events_connect_hang_is_bounded_by_connect_timeout_not_infinite` to wait out
+# `CONNECT_TIMEOUT` on the virtual clock instead of 10s of real time.
+tokio = { workspace = true, features = ["test-util"] }
 # HTTP router test-only helper (`tower::util::ServiceExt::oneshot`) for
 # driving the `tcode serve --http` axum router without a real socket (#2053).
 tower = { workspace = true }

--- a/crates/trusty-code/src/tui_client/engine_tests.rs
+++ b/crates/trusty-code/src/tui_client/engine_tests.rs
@@ -433,6 +433,11 @@ fn statusline_segments_reflect_active_workstream_and_clear_on_none() {
 /// `SESSION_STREAM_MAX_RECONNECTS` (every attempt would hang the same way,
 /// ~1 minute total) — observing the FIRST `ConnectionLost` is sufficient
 /// proof the connect attempt is bounded by `CONNECT_TIMEOUT`, not infinite.
+///
+/// The `CONNECT_TIMEOUT` wait itself runs on Tokio's virtual clock, but only
+/// after the accept is confirmed on the real one — see the `tokio::time::pause()`
+/// call below for why the ordering is load-bearing and a blanket
+/// `start_paused = true` is not a valid substitute here.
 #[tokio::test]
 async fn events_connect_hang_is_bounded_by_connect_timeout_not_infinite() {
     let std_listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
@@ -440,12 +445,14 @@ async fn events_connect_hang_is_bounded_by_connect_timeout_not_infinite() {
     let listener = tokio::net::TcpListener::from_std(std_listener).expect("tokio listener");
     let addr = listener.local_addr().expect("local_addr");
 
+    let (accepted_tx, mut accepted_rx) = unbounded_channel();
     // Accept connections forever, never writing/closing — `mem::forget`
     // keeps each accepted socket's fd open (dropping it would close the
     // connection, which reqwest would see as a fast, distinct failure mode,
     // not the hang this test targets).
     let accept_task = tokio::spawn(async move {
         while let Ok((stream, _)) = listener.accept().await {
+            let _ = accepted_tx.send(());
             std::mem::forget(stream);
         }
     });
@@ -457,6 +464,25 @@ async fn events_connect_hang_is_bounded_by_connect_timeout_not_infinite() {
     let (tx, mut rx) = unbounded_channel();
 
     let pump_task = tokio::spawn(async move { state.pump_session_events("s-1", &tx).await });
+
+    // Wait — on the REAL clock — until the listener has actually accepted the
+    // connection. This is what makes the pause below safe: the "TCP accepted,
+    // headers never sent" precondition is established for real, not assumed.
+    // A blind `#[tokio::test(start_paused = true)]` here is NOT equivalent —
+    // measured, it lost the accept on 6 of 10 runs (Tokio auto-advances the
+    // clock while the handshake is still in flight), silently downgrading
+    // this from the #3494 shape to a plain connect timeout while still
+    // passing, since both produce a "connection failed" reason.
+    accepted_rx
+        .recv()
+        .await
+        .expect("listener must accept the pump's connection");
+
+    // Only now switch to the virtual clock: the connection is up and the
+    // daemon will never send headers, so the runtime goes idle and Tokio
+    // auto-advances straight to `CONNECT_TIMEOUT` at no wall-clock cost
+    // (this test was 10.0s of pure waiting).
+    tokio::time::pause();
 
     // CONNECT_TIMEOUT (10s) plus slack — comfortably short of the ~1 minute
     // a full 5-reconnect exhaustion would take, but generous enough that

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -18,8 +18,6 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ([`bd28002`](https://github.com/bobmatnyc/trusty-tools/commit/bd2800216c2999bbcfb72373a2f81e837b2ab93a), [`6078b21`](https://github.com/bobmatnyc/trusty-tools/commit/6078b21c091b7d4b1ea7d5d05eb96cd49801cfec))
 
-## [Unreleased]
-
 ### Changed
 
 - **`detect_does_not_hang_on_an_unresponsive_shadowing_binary` now runs on

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -18,6 +18,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ([`bd28002`](https://github.com/bobmatnyc/trusty-tools/commit/bd2800216c2999bbcfb72373a2f81e837b2ab93a), [`6078b21`](https://github.com/bobmatnyc/trusty-tools/commit/6078b21c091b7d4b1ea7d5d05eb96cd49801cfec))
 
+## [Unreleased]
+
+### Changed
+
+- **`detect_does_not_hang_on_an_unresponsive_shadowing_binary` now runs on
+  Tokio's paused clock** — 10.01s to 0.00s. The hanging `sleep 30` shadowing
+  binary is still really spawned and still really never answers; only the
+  health gate's 10s probe timeout moves to the virtual clock. That the child
+  is genuinely spawned under a paused clock was verified by measurement (a
+  spawn marker written by the fake binary was present on 3 of 3 runs), and a
+  new elapsed-time assertion keeps it honest: if `shadowing_version: None`
+  ever came from an early probe failure instead of the timeout expiring, the
+  test fails rather than passing green on deleted coverage. Reverting the
+  probe to the un-timed-out `installed_version` call still fails the test.
+
+---
+
 ## [0.4.10] — 2026-07-26
 
 ### Fixed

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -79,3 +79,7 @@ trusty-progress = { workspace = true }
 tempfile = { workspace = true }
 
 [dev-dependencies]
+# test-util enables Tokio's paused clock (`#[tokio::test(start_paused = true)]`)
+# used by `detect_does_not_hang_on_an_unresponsive_shadowing_binary` so the
+# health gate's 10s probe timeout is exercised on the virtual clock.
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/trusty-installer/src/commands/shadow_check.rs
+++ b/crates/trusty-installer/src/commands/shadow_check.rs
@@ -317,8 +317,16 @@ mod tests {
     /// i.e. forever, for a shell shim blocked on stdin or any other hung
     /// `--version` invocation, on the very step meant to make failure loud
     /// right after the health gate passed.
+    ///
+    /// `start_paused = true` puts the TIMEOUTS on Tokio's virtual clock while
+    /// the `sleep 30` child still runs on the real one — the child is really
+    /// spawned and really never answers, so the runtime goes idle and Tokio
+    /// auto-advances to the probe's 10s deadline at no wall-clock cost (was
+    /// 10.0s). The `elapsed` assertion below is what keeps that honest: it
+    /// proves `None` came from the probe timing out after a full 10s, not
+    /// from an early spawn failure that never exercised the hang at all.
     #[cfg(unix)]
-    #[tokio::test]
+    #[tokio::test(start_paused = true)]
     async fn detect_does_not_hang_on_an_unresponsive_shadowing_binary() {
         let tmp = tempfile::tempdir().expect("tempdir");
 
@@ -350,6 +358,7 @@ mod tests {
         // Bound the WHOLE test well under what an indefinite hang would look
         // like (the pre-fix behaviour), but comfortably above the 10s
         // internal health-gate timeout `detect` now goes through.
+        let started = tokio::time::Instant::now();
         let result = tokio::time::timeout(
             std::time::Duration::from_secs(20),
             detect(
@@ -361,12 +370,20 @@ mod tests {
         )
         .await
         .expect("detect must return within 20s, never hang on an unresponsive shadowing binary");
+        let elapsed = started.elapsed();
 
         let report = result.expect("the shadow itself must still be reported");
         assert_eq!(report.shadowing_path, early_dir.join("tm"));
         assert_eq!(
             report.shadowing_version, None,
             "an unprobeable (timed-out) shadowing binary must degrade to None, not block"
+        );
+        assert!(
+            elapsed >= std::time::Duration::from_secs(10),
+            "`shadowing_version: None` must come from the health gate's 10s probe timeout \
+             expiring, but `detect` gave up after only {elapsed:?} — the probe never ran \
+             against the hanging binary at all, so this test would no longer catch the \
+             un-timed-out `installed_version` regression"
         );
     }
 


### PR DESCRIPTION
## What

The workspace's slowest test — `discover_one_returns_none_on_timeout`, measured
at 15.015s of the 20,317 in the workspace — spent all of it asleep waiting out
the real `DISCOVERY_TIMEOUT`. It now runs on Tokio's virtual clock. Two of the
three slow siblings were converted as well; one was left alone and one blind
approach was rejected on measurement rather than on theory.

## Before / after

| Test | Crate | Before | After |
|---|---|---|---|
| `discover_one_returns_none_on_timeout` | trusty-agents | 15.015s | 0.00s |
| `detect_does_not_hang_on_an_unresponsive_shadowing_binary` | trusty-installer | 10.01s | 0.00s |
| `events_connect_hang_is_bounded_by_connect_timeout_not_infinite` | trusty-code | 10.01s | 0.01s |

~35s of pure wall-clock sleeping removed from every test run. No production
timeout constant was changed — all three still fire their real values.

## The one that could not be converted blindly

`events_connect_hang_is_bounded_by_connect_timeout_not_infinite` pins #3494:
a daemon that accepts the TCP connection but never sends response headers must
not hang `.send()` forever.

A blanket `#[tokio::test(start_paused = true)]` **passes** here, and is wrong.
Tokio auto-advances the clock while the TCP handshake is still in flight, so
the request times out before the listener ever accepts. Instrumented with an
accept counter, that happened on **6 of 10 runs** — the test would still have
gone green every time, because a premature connect timeout and the real
headers-never-sent case both produce a `"connection failed"` reason. That is
exactly a deleted-coverage-with-a-green-badge outcome.

Fixed by ordering instead: wait for the accept on the **real** clock, then call
`tokio::time::pause()`. The emitted reason string is then byte-identical to the
real-clock run:

```
REASON-PROBE: connection failed: error sending request for url (http://127.0.0.1:57166/sessions/s-1/events); reconnecting…   [paused,   0.01s]
REASON-PROBE: connection failed: error sending request for url (http://127.0.0.1:57191/sessions/s-1/events); reconnecting…   [real,    10.01s]
```

10/10 stable at 0.00–0.01s afterwards.

## The subprocess one

`detect_does_not_hang_on_an_unresponsive_shadowing_binary` spawns a real
`sleep 30` shell script, and `start_paused` does not control a child's wall
clock — so this was checked, not assumed. A spawn marker written by the fake
binary was present on **3 of 3 runs**, confirming the child really is spawned
and really does hang; only the health gate's 10s timeout moves to the virtual
clock. The marker scaffolding was removed after the check; the permanent
guard is the elapsed assertion below.

## Deliberately untouched

`crates/trusty-mpm/src/client/http_client/tests.rs` —
`top_level_default_client_is_bounded_against_a_stalled_daemon` (~10.3s). Its own
comment explains it uses a real timeout on purpose to pin incident #2517, where
an "unbounded" client hung 55s instead of respecting its 10s bound. Faking the
clock there would let precisely that regression hide. That 10.3s is bought.

## Coverage-survival evidence

Every conversion also gained an elapsed-time assertion, because a paused-clock
test can return early for an unrelated reason and still look correct. Each test
was verified by breaking the timeout under test, watching it fail, and
restoring.

**`discover_one_returns_none_on_timeout`**

Break 1 — remove `tokio::time::timeout` from `discover_one` (the DoS bug it pins):
```
panicked at crates/trusty-agents/src/tools/mcp_live/cache.rs:244:10:
discover_one must respect DISCOVERY_TIMEOUT, not hang indefinitely: Elapsed(())
test result: FAILED. 0 passed; 1 failed
```
Break 2 — shrink the deadline to 1ms, so `None` comes back for the wrong reason:
```
panicked at crates/trusty-agents/src/tools/mcp_live/cache.rs:251:9:
`None` must come from `DISCOVERY_TIMEOUT` expiring, but discovery gave up after
only 1ms — the timeout path was not the one exercised
test result: FAILED. 0 passed; 1 failed
```

**`detect_does_not_hang_on_an_unresponsive_shadowing_binary`**

Break 1 — revert the probe to the pre-fix un-timed-out `Command::output()`:
```
panicked at crates/trusty-installer/src/commands/shadow_check.rs:374:10:
detect must return within 20s, never hang on an unresponsive shadowing binary: Elapsed(())
test result: FAILED. 0 passed; 1 failed
```
Break 2 — probe a path that fails instantly instead of hanging:
```
panicked at crates/trusty-installer/src/commands/shadow_check.rs:381:9:
`shadowing_version: None` must come from the health gate's 10s probe timeout
expiring, but `detect` gave up after only 0ns — the probe never ran against the
hanging binary at all
test result: FAILED. 0 passed; 1 failed
```

**`events_connect_hang_is_bounded_by_connect_timeout_not_infinite`**

Break — remove `.timeout(CONNECT_TIMEOUT)` from `pump_session_events` (the #3494 regression):
```
panicked at crates/trusty-code/src/tui_client/engine_tests.rs:495:19:
no ConnectionLost observed within CONNECT_TIMEOUT + slack — the initial connect
attempt hung past CONNECT_TIMEOUT (issue #3494 regression)
test result: FAILED. 0 passed; 1 failed
```

## Gates

```
$ cargo test -p trusty-agents
test result: ok. 3013 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 31.61s
  (+ 9 further test binaries, all ok)                                        exit=0

$ cargo test -p trusty-installer
test result: ok. 507 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 2.05s
  (+ 5 further test binaries, all ok)                                        exit=0

$ cargo test -p trusty-code
test result: ok. 1609 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 2.28s
  (+ 16 further test binaries, all ok)                                       exit=0

$ cargo clippy -p trusty-agents -p trusty-installer -p trusty-code --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 41.37s     exit=0

$ cargo fmt --check                                                          exit=0

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.                                  exit=0
```

No `#[ignore]`, no `--exclude`, no narrowing to `--lib`.

## Pre-existing flake found (not from this PR)

`tools::python_skill::tests::execute_dispatches_to_python_and_parses_json`
fails intermittently under parallel load: it shells out to `uv`, which reads
`$HOME` for its cache, while ~20 other tests in the crate mutate the
process-wide `HOME`. When one of those tempdir `HOME`s is torn down mid-probe,
uv dies with `No such file or directory ... /.cache/uv/.tmpXXXX`.

Since this change alters suite scheduling (a worker thread frees 15s earlier),
it was A/B'd rather than waved off — 5 full `cargo test -p trusty-agents --lib`
runs each way:

| Tree | Failures |
|---|---|
| `main`'s `cache.rs` (unmodified) | **2 of 5** |
| this PR | 0 of 5 |

Pre-existing, and not made worse. Worth a separate ticket to serialize that
test; out of scope here.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
