### PR TITLE
chore(trusty-installer): bump past 0.4.10 to clear the version-parity gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11589,7 +11589,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.4.10"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-installer/CHANGELOG.md
+++ b/crates/trusty-installer/CHANGELOG.md
@@ -1,10 +1,22 @@
-# Changelog — trusty-installer
+# Changelog
 
-All notable changes to trusty-installer are documented in this file.
+All notable changes are documented in this file.
 
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Added
+
+- New public `probe_http` module: an HTTP `/health` probe local to trusty-installer, replacing the old CLI-verb probe ([#4246](https://github.com/bobmatnyc/trusty-tools/pull/4246), [#4381](https://github.com/bobmatnyc/trusty-tools/pull/4381)).
+
+### Fixed
+
+- **`tctl install` could SIGKILL-restart healthy daemons mid-flush** ([#4246](https://github.com/bobmatnyc/trusty-tools/issues/4246)). Root cause: the health probe shelled out to `<binary> health --json`, a contract no daemon implements, so healthy daemons falsely reported `down` and drove `needs_kickstart`. Fixed by replacing it with an HTTP `/health` probe local to trusty-installer ([#4381](https://github.com/bobmatnyc/trusty-tools/pull/4381)). Fixes the reported symptom; #4246 stays open pending root-cause confirmation.
+- **Follow-up hardening from code review of the above** ([#4388](https://github.com/bobmatnyc/trusty-tools/pull/4388)): the regression-guard tests used a TOCTOU-racy ephemeral port for their "connection refused" fixture, making them latently flaky — replaced with a fixed privileged loopback port that verifies the refusal before returning; a probe test's timeout bounds were inverted (connect budget longer than the total request budget), leaving the `silent`/read-path-timeout case ambiguous — reordered so connect and read-path timeouts are unambiguously distinct; and the `health_string()` / `is_confirmed_down()` asymmetry — a display-only "down" string must never authorise a kickstart — is now documented on both methods and pinned by a new test asserting the confirmed-down set is a strict, non-empty subset of the down-rendering set.
+
+([`bd28002`](https://github.com/bobmatnyc/trusty-tools/commit/bd2800216c2999bbcfb72373a2f81e837b2ab93a), [`6078b21`](https://github.com/bobmatnyc/trusty-tools/commit/6078b21c091b7d4b1ea7d5d05eb96cd49801cfec))
 
 ## [0.4.10] — 2026-07-26
 

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.4.10"
+version = "0.5.0"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"


### PR DESCRIPTION
## Drift evidence

`crates/trusty-installer/Cargo.toml` still declared `0.4.10` — the version already live on crates.io — while `main` carried 17 changed files under `crates/trusty-installer/src/**` from two already-merged commits:

- `6078b21c` — fix(installer): probe daemon health over HTTP instead of a nonexistent CLI verb (#4246) (#4381)
- `bd280021` — fix(installer): address code-review findings from #4381 (#4246) (#4388)

That's unpublished source drift under an already-published version number — the #3366 defect class. The `Version parity` gate on `main` fails on it.

## Version level: minor (0.4.10 → 0.5.0)

Both merged commits are titled `fix(installer): …`, which argues patch. But `6078b21c` adds a new module, `commands::probe_http`, that is unconditionally compiled (`pub mod probe_http;` in `commands/mod.rs`, not `#[cfg(test)]`) and exposes 11 public items (`ProbeOutcome`, `build_probe_client`, `classify_response`, `reconcile`, `probe_daemon_http`, etc.), all reachable through the crate's public API (`pub mod commands;` in `lib.rs`). That's an additive, backward-compatible change to the public surface — minor under semver, independent of the commit-subject prefix. (The other new file, `test_support.rs`, is `#[cfg(test)]`-gated and not part of the released public surface.)

## Publish-guard now passes

```
$ bash scripts/check-version-parity.sh
...
[ OK ] trusty-installer 0.5.0 — not yet published, nothing to compare
...
publish-guard: checked 21 publishable crate(s) — 0 drifted, 0 unverifiable.
publish-guard: OK — no version-parity drift detected.
```

## Lockfile

`scripts/bump-version.sh trusty-installer minor` ran the targeted `cargo update -p trusty-installer --precise 0.5.0`. `git diff Cargo.lock` shows only the trusty-installer version line changed (no broad refresh):

```diff
 name = "trusty-installer"
-version = "0.4.10"
+version = "0.5.0"
```

## Changelog

No hand-written `[Unreleased]` section existed before this PR, so `generate-changelog.sh` didn't collide with anything — but its git-cliff output only carries squash-commit *subjects*, so I rewrote the generated bullets by hand to restore the root-cause/fix detail from the commit bodies (the SIGKILL-restart symptom, the TOCTOU-racy test port fix, the inverted timeout bounds fix, and the `health_string()`/`is_confirmed_down()` asymmetry doc). I also removed a stale duplicate `# Changelog — trusty-installer` header that the prepend step left directly below the new generic `# Changelog` header (pre-existing formatting debt in this file, not something this PR's diff introduced elsewhere in the repo — other crates' CHANGELOGs already use the single generic header).

## Scope

Bump and changelog only — **no tag, no publish**. A human tags per the repo's manual-tag release convention.

Refs [#4403](https://github.com/bobmatnyc/trusty-tools/issues/4403) — leaving that issue open until the `Version parity` gate is confirmed green on `main`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools