### PR TITLE
fix(trusty-agents-common): redeploy corrupted bundled assets instead of freezing them as user-modified

### DIFF
--- a/crates/trusty-agents-common/CHANGELOG.md
+++ b/crates/trusty-agents-common/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes are documented in this file.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
+## [Unreleased]
+
+### Fixed
+
+- `agents::deployer` now re-deploys a corrupted bundled agent instead of freezing it as user-modified (closes [#4408](https://github.com/bobmatnyc/trusty-tools/issues/4408)). A manifest entry whose origin is framework-owned (`Origin::Bundled`, the `InstallPolicy::Overwrite` tier) is refreshed from the bundle whenever its on-disk checksum drifts — a mismatch there means corruption or drift, never user ownership. Previously ANY checksum mismatch was read as "the user edited this file", which is unrecoverable for a bundled asset: corrupt content can never checksum-match again, so a 32-byte `v1` stub that replaced the real 25KB `rust-engineer.md` was permanently misclassified as a user edit and skipped by every subsequent deploy and by `tm validate --repair`, dropping the agent from the session roster for the life of the workspace. The user-owned tier is unchanged — an untracked file, and a tracked entry with `Origin::User`/`Origin::Registry`, are still preserved byte-for-byte. Each overwrite-on-mismatch repair logs the file, the expected and found checksums, and the on-disk byte count.
+
+### Added
+
+- `agents::manifest::Origin::is_framework_owned` — names the two install-ownership tiers so the deployer branches on declared ownership rather than on checksum mismatch alone (#4408).
+
 ## [0.3.0] — 2026-07-21
 
 ### Fixed

--- a/crates/trusty-agents-common/src/agents/deployer.rs
+++ b/crates/trusty-agents-common/src/agents/deployer.rs
@@ -20,10 +20,17 @@
 //! manifest. Corrupt manifests are detected and surfaced as errors rather
 //! than silently reset to empty. Returns a [`DeployResult`] summarising what
 //! happened.
+//! Ownership follows the two-variant install policy (#4408): a manifest entry
+//! whose origin is FRAMEWORK-owned (bundled, the `Overwrite` tier) is
+//! re-deployed whenever its on-disk checksum drifts — a mismatch there means
+//! corruption, not user ownership — while a user-owned entry (the `SeedOnce`
+//! tier) and any untracked file keep the preserve-on-mismatch behavior.
 //! Test: `cargo test -p trusty-agents-common agents::deployer` covers a new
-//! deploy, a skipped user-modified file, an unchanged file, a user-owned file,
-//! atomic writes, corrupt manifest detection, and (#3556) a stale-broken-copy
-//! refresh plus a strict-YAML-invalid composition being isolated and skipped.
+//! deploy, a preserved user-owned file, an unchanged file, atomic writes,
+//! corrupt manifest detection, (#3556) a stale-broken-copy refresh plus a
+//! strict-YAML-invalid composition being isolated and skipped, and (#4408) a
+//! corrupted bundled file being re-deployed while a modified user-owned entry
+//! survives byte-identical.
 
 use std::collections::HashMap;
 use std::path::Path;
@@ -50,8 +57,10 @@ use crate::agents::metadata::agent_metadata_from_str;
 pub struct DeployResult {
     /// Filenames successfully (re)written this run.
     pub deployed: Vec<String>,
-    /// Filenames skipped because the user modified them, or because they were
-    /// untracked and differ from the fresh composition.
+    /// Filenames skipped because they are user-owned — either untracked by the
+    /// manifest and differing from the fresh composition, or tracked with a
+    /// user-owned origin (the seed-once tier) and edited. A tracked
+    /// FRAMEWORK-owned file that differs is re-deployed, not skipped (#4408).
     pub skipped: Vec<String>,
     /// Filenames left untouched because their checksum already matched.
     pub unchanged: Vec<String>,
@@ -114,7 +123,11 @@ pub fn is_agent_file(name: &str) -> bool {
 /// Rules:
 ///   - Not in manifest → user-owned → skip silently
 ///   - In manifest, checksum matches → overwrite (safe)
-///   - In manifest, checksum differs → user-modified → warn + skip
+///   - In manifest, checksum differs, entry is framework-owned
+///     ([`Origin::is_framework_owned`], the Overwrite tier) → drift or
+///     corruption → warn + re-deploy the bundled composition (issue #4408)
+///   - In manifest, checksum differs, entry is user-owned (the seed-once
+///     tier) → user-modified → skip, preserving their content byte-for-byte
 ///   - New trusty-mpm agent → compose + write (atomic) + add to manifest
 ///   - Corrupt manifest → error (never silently reset, which would reclassify
 ///     managed files as user-owned and skip re-deploying them)
@@ -274,6 +287,13 @@ pub fn deploy_agents_filtered(
                 continue;
             }
             let current = std::fs::read_to_string(&target_path)?;
+            // #4408: snapshot the recorded checksum + ownership tier before the
+            // branches below take a mutable borrow of `manifest` to re-register
+            // the file.
+            let recorded_owner = manifest
+                .managed
+                .get(&filename)
+                .map(|e| (e.checksum.clone(), e.origin.is_framework_owned()));
             if manifest.checksum_matches(&filename, &current) {
                 if checksum(&composed) == checksum(&current) {
                     // Deployed copy is already the latest composition.
@@ -281,8 +301,26 @@ pub fn deploy_agents_filtered(
                     continue;
                 }
                 // Managed and unmodified by the user → safe to refresh.
+            } else if let Some((expected, true)) = recorded_owner {
+                // #4408: a framework-owned (bundled / Overwrite-tier) file that
+                // no longer matches its recorded checksum is DRIFT or
+                // CORRUPTION, not user ownership — freezing it left a corrupted
+                // agent (a 32-byte `v1` stub in the reported incident)
+                // unrecoverable forever, because corrupt content can never
+                // checksum-match again. Re-deploy it, loudly, so the corruption
+                // event is visible instead of silently skipped.
+                tracing::warn!(
+                    file = %filename,
+                    expected_checksum = %expected,
+                    found_checksum = %checksum(&current),
+                    found_bytes = current.len(),
+                    "bundled agent file drifted from its manifest checksum — \
+                     re-deploying the bundled composition over it (framework-owned \
+                     files are refreshed, not preserved; issue #4408)"
+                );
             } else {
-                // Managed but the user edited it → preserve their changes.
+                // Managed but user-owned (Origin::User / Registry — the
+                // seed-once tier) and edited → preserve their changes.
                 result.skipped.push(filename);
                 continue;
             }

--- a/crates/trusty-agents-common/src/agents/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/agents/deployer_tests.rs
@@ -4,8 +4,9 @@
 //! Why: moved verbatim from `trusty-mpm::core::agent_deployer`'s inline
 //! `#[cfg(test)] mod tests` (#2892) — behavior-preserving extraction, not a
 //! rewrite.
-//! What: covers a new deploy, a skipped user-modified file, an unchanged
-//! file, a user-owned file, atomic writes, corrupt-manifest detection, the
+//! What: covers a new deploy, a preserved user-owned file, an unchanged
+//! file, the #4408 corrupted-bundled-file repair and its user-owned guard,
+//! atomic writes, corrupt-manifest detection, the
 //! HR-1 enrichment deploy path, the HR-2 filtered-select predicate, the
 //! DOC-42 `declared_skills` population, and per-agent compose-failure
 //! isolation.
@@ -58,30 +59,104 @@ fn deploy_new_agent() {
     );
 }
 
+/// The literal degenerate stub from the #4408 incident: a `name:`-only
+/// frontmatter with a body of `v1`, no `description:` — 32 bytes that Claude
+/// Code still counts as a deployed agent while the roster reports
+/// "Agent type not found".
+const CORRUPT_STUB: &str = "---\nname: engineer\n---\n\nv1\n";
+
 #[test]
-fn deploy_skips_user_modified() {
-    // A managed file the user edited must be skipped, not overwritten.
+fn deploy_redeploys_corrupted_bundled_file() {
+    // #4408 regression: a manifest entry with a FRAMEWORK-owned origin
+    // (bundled = the Overwrite tier) whose on-disk content has been replaced
+    // by a degenerate stub must be re-deployed from the bundle, not frozen as
+    // "user-modified". Before this fix the checksum mismatch was read as a
+    // user edit, so the corrupted agent could never be repaired — not by a
+    // redeploy, not by `tm validate --repair` — for the life of the workspace.
     let src = TempDir::new().unwrap();
     let tgt = TempDir::new().unwrap();
     write_sources(src.path());
 
-    // First deploy establishes the manifest.
+    // First deploy establishes the manifest with origin = Bundled.
     deploy_agents(src.path(), tgt.path()).unwrap();
+    let good = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
+    assert!(good.contains("Engineer content."));
+    assert_eq!(
+        AgentManifest::load(tgt.path()).managed["engineer.md"].origin,
+        Origin::Bundled
+    );
 
-    // User edits the deployed engineer file.
-    fs::write(
-        tgt.path().join("engineer.md"),
-        "---\nname: engineer\n---\n\nUSER HAND-EDIT\n",
-    )
-    .unwrap();
+    // Corruption: the deployed copy is replaced by the 32-byte stub while the
+    // manifest still records the checksum of the real content.
+    fs::write(tgt.path().join("engineer.md"), CORRUPT_STUB).unwrap();
 
-    // Second deploy must preserve the user's edit.
     let result = deploy_agents(src.path(), tgt.path()).unwrap();
-    assert!(result.skipped.contains(&"engineer.md".to_string()));
-    assert!(!result.deployed.contains(&"engineer.md".to_string()));
+    assert!(
+        result.deployed.contains(&"engineer.md".to_string()),
+        "a corrupted bundled agent must be re-deployed, got: {result:?}"
+    );
+    assert!(!result.skipped.contains(&"engineer.md".to_string()));
 
-    let still = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
-    assert!(still.contains("USER HAND-EDIT"));
+    // The real content is back, byte-for-byte, and the manifest agrees with it.
+    let repaired = fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
+    assert_eq!(repaired, good, "bundled content must be restored exactly");
+    assert!(
+        AgentManifest::load(tgt.path()).checksum_matches("engineer.md", &repaired),
+        "manifest checksum must match the repaired file"
+    );
+
+    // Idempotent: a third deploy sees a matching checksum and does nothing.
+    let third = deploy_agents(src.path(), tgt.path()).unwrap();
+    assert!(third.unchanged.contains(&"engineer.md".to_string()));
+    assert!(third.deployed.is_empty());
+}
+
+#[test]
+fn deploy_preserves_modified_user_owned_entry() {
+    // #4408 guard: the user-protection carve-out is intentional for the
+    // user-owned (seed-once) tier and must survive the fix — a manifest entry
+    // with `Origin::User` whose content was modified is preserved
+    // byte-identical across deploy, and reported as skipped.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_sources(src.path());
+
+    // Seed a user-owned manifest entry whose on-disk content diverges from
+    // both the recorded checksum and the fresh composition.
+    let user_content = "---\nname: engineer\n---\n\nUSER HAND-EDIT — KEEP ME\n";
+    fs::write(tgt.path().join("engineer.md"), user_content).unwrap();
+    let mut manifest = AgentManifest::default();
+    manifest.managed.insert(
+        "engineer.md".to_string(),
+        ManifestEntry {
+            source_chain: vec!["engineer".to_string()],
+            checksum: checksum("something else entirely"),
+            deployed_at: "2026-01-01T00:00:00Z".to_string(),
+            origin: Origin::User,
+        },
+    );
+    manifest.save(tgt.path()).unwrap();
+
+    // Two deploys, to prove the preservation is stable and not one-shot.
+    for _ in 0..2 {
+        let result = deploy_agents(src.path(), tgt.path()).unwrap();
+        assert!(
+            result.skipped.contains(&"engineer.md".to_string()),
+            "user-owned entry must be skipped, got: {result:?}"
+        );
+        assert!(!result.deployed.contains(&"engineer.md".to_string()));
+        assert_eq!(
+            fs::read_to_string(tgt.path().join("engineer.md")).unwrap(),
+            user_content,
+            "user-owned content must survive byte-identical"
+        );
+    }
+
+    // Its origin is untouched — the deploy never re-registers a skipped file.
+    assert_eq!(
+        AgentManifest::load(tgt.path()).managed["engineer.md"].origin,
+        Origin::User
+    );
 }
 
 #[test]
@@ -356,7 +431,7 @@ fn declared_skills_empty_when_agent_declares_none() {
 #[test]
 fn declared_skills_populated_even_when_deploy_is_skipped() {
     // The declaration is a property of the SOURCE composition, not of
-    // this run's write outcome — even a user-modified (skipped) agent's
+    // this run's write outcome — even a user-owned (skipped) agent's
     // declared skills must still surface for co-deployment purposes.
     let src = TempDir::new().unwrap();
     let tgt = TempDir::new().unwrap();
@@ -365,10 +440,10 @@ fn declared_skills_populated_even_when_deploy_is_skipped() {
         "---\nname: code-critic\nrole: qa\nskills: [code-review-standards]\n---\n\n# Critic\n",
     )
     .unwrap();
-    deploy_agents(src.path(), tgt.path()).unwrap();
+    // A user-owned file (untracked by the manifest) sharing the agent's name.
     fs::write(
         tgt.path().join("code-critic.md"),
-        "---\nname: code-critic\n---\n\nUSER HAND-EDIT\n",
+        "---\nname: code-critic\n---\n\nUSER OWNED\n",
     )
     .unwrap();
 

--- a/crates/trusty-agents-common/src/agents/manifest.rs
+++ b/crates/trusty-agents-common/src/agents/manifest.rs
@@ -121,6 +121,28 @@ pub enum Origin {
     User,
 }
 
+impl Origin {
+    /// Whether this origin marks a FRAMEWORK-owned file (the `Overwrite`
+    /// install tier) rather than a user-owned one (the `SeedOnce` tier).
+    ///
+    /// Why: issue #4408. The two-variant install policy says framework-owned
+    /// bundled assets are refreshed from the bundle on every deploy, while
+    /// user-owned assets are seeded once and never clobbered. Without this
+    /// distinction the deployer read ANY checksum mismatch as "the user edited
+    /// this file", which is fatal for a bundled asset: once its content
+    /// corrupts it can never checksum-match again, so the corruption is
+    /// permanently misclassified as a user edit and the file is frozen —
+    /// unrecoverable by redeploy or `tm validate --repair`.
+    /// What: `true` only for [`Origin::Bundled`]. [`Origin::User`] is
+    /// user-authored by definition, and [`Origin::Registry`] is treated
+    /// conservatively as user-owned (the operator pulled it deliberately), so
+    /// both keep the preserve-on-mismatch behavior.
+    /// Test: `origin_framework_ownership_tiers`.
+    pub fn is_framework_owned(self) -> bool {
+        matches!(self, Origin::Bundled)
+    }
+}
+
 /// One managed agent file's deployment record.
 ///
 /// Why: deploy decisions ("safe to overwrite?", "user-modified?") need the
@@ -424,6 +446,15 @@ mod tests {
             .insert("engineer.md".into(), sample_entry());
         assert!(manifest.is_managed("engineer.md"));
         assert!(!manifest.is_managed("user-agent.md"));
+    }
+
+    #[test]
+    fn origin_framework_ownership_tiers() {
+        // #4408: only `Bundled` is the framework-owned (Overwrite) tier; the
+        // user-owned tiers keep the preserve-on-mismatch behavior.
+        assert!(Origin::Bundled.is_framework_owned());
+        assert!(!Origin::User.is_framework_owned());
+        assert!(!Origin::Registry.is_framework_owned());
     }
 
     #[test]

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -91,6 +91,15 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **A corrupted bundled agent is re-deployed instead of frozen forever (closes
+  [#4408](https://github.com/bobmatnyc/trusty-tools/issues/4408)).** When the
+  deployed copy of a bundled agent drifts from the checksum the deploy manifest
+  recorded, the file is now refreshed from the bundle rather than classified as
+  a user edit and skipped. Previously a degenerate 32-byte stub that replaced
+  `rust-engineer.md` in a workspace's `.claude/agents/` was unrecoverable —
+  neither a redeploy nor `tm validate --repair` could reach it — so every
+  session in that workspace lost the agent from its roster ("Agent type not
+  found") permanently. Hand-placed and user-owned agent files are untouched.
 - **`tm doctor` no longer reports a serving daemon as unreachable (issue
   #4005).** On 2026-07-26 it printed "trusty-memory unreachable at
   127.0.0.1:7070" while MCP `memory_recall` / `memory_remember` succeeded

--- a/crates/trusty-mpm/src/core/session_launch/sync_assets.rs
+++ b/crates/trusty-mpm/src/core/session_launch/sync_assets.rs
@@ -100,7 +100,8 @@ pub struct SyncAssetsReport {
 /// framework install regardless.
 /// Test: `sync_assets_redeploys_new_agent`, `sync_assets_refreshes_stale_skill`,
 /// `sync_assets_refreshes_project_output_style`,
-/// `sync_assets_skips_user_modified_agent`.
+/// `sync_assets_never_touches_hand_placed_agent`,
+/// `sync_assets_repairs_drifted_bundled_agent`.
 pub fn sync_session_assets(
     fw: &FrameworkPaths,
     project_dir: &Path,
@@ -227,9 +228,51 @@ mod tests {
     }
 
     #[test]
-    fn sync_assets_skips_user_modified_agent() {
-        // A user-modified managed agent must be left alone, matching the
-        // deployer's own ownership rule (never silently clobber a hand-edit).
+    fn sync_assets_never_touches_hand_placed_agent() {
+        // A hand-placed agent — a file the operator dropped into
+        // `.claude/agents/` that trusty-mpm never deployed, so it is absent
+        // from the deploy manifest — must survive session-asset sync
+        // byte-identical, even when it shares a bundled agent's filename.
+        let tmp = tempfile::tempdir().unwrap();
+        let mut fw = FrameworkPaths::under(tmp.path().join("home"));
+        fw.trusty_mpm_root = None;
+        let bundled = fw.agent_source_dir();
+        std::fs::create_dir_all(&bundled).unwrap();
+        std::fs::write(
+            bundled.join("rust-engineer.md"),
+            "---\nname: rust-engineer\n---\nv1",
+        )
+        .unwrap();
+
+        let project_dir = tmp.path().join("workspace");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let mut ws_fw = fw.clone();
+        ws_fw.claude_agents = project_dir.join(".claude").join("agents");
+        ws_fw.claude_skills = project_dir.join(".claude").join("skills");
+
+        // The operator's own file lands first — never deployed by trusty-mpm.
+        std::fs::create_dir_all(ws_fw.claude_agents_dir()).unwrap();
+        let hand_placed = ws_fw.claude_agents_dir().join("rust-engineer.md");
+        let content = "---\nname: rust-engineer\n---\noperator's own agent";
+        std::fs::write(&hand_placed, content).unwrap();
+
+        let report = sync_session_assets(&ws_fw, &project_dir).unwrap();
+        assert!(
+            report
+                .agents_skipped
+                .contains(&"rust-engineer.md".to_string())
+        );
+        assert_eq!(std::fs::read_to_string(&hand_placed).unwrap(), content);
+    }
+
+    #[test]
+    fn sync_assets_repairs_drifted_bundled_agent() {
+        // Issue #4408: a BUNDLED agent this deployer wrote is framework-owned
+        // (the `InstallPolicy::Overwrite` tier), so a deployed copy that
+        // drifted from its manifest checksum — here the degenerate stub from
+        // the incident — is refreshed from the bundle rather than frozen as a
+        // user edit. Freezing it made the agent unrecoverable in that
+        // workspace forever.
         let tmp = tempfile::tempdir().unwrap();
         let mut fw = FrameworkPaths::under(tmp.path().join("home"));
         fw.trusty_mpm_root = None;
@@ -249,7 +292,7 @@ mod tests {
 
         sync_session_assets(&ws_fw, &project_dir).unwrap();
         let deployed = ws_fw.claude_agents_dir().join("rust-engineer.md");
-        std::fs::write(&deployed, "operator hand-edited this").unwrap();
+        std::fs::write(&deployed, "---\nname: rust-engineer\n---\n\nv1\n").unwrap();
 
         std::fs::write(
             bundled.join("rust-engineer.md"),
@@ -259,12 +302,18 @@ mod tests {
         let report = sync_session_assets(&ws_fw, &project_dir).unwrap();
         assert!(
             report
+                .agents_deployed
+                .contains(&"rust-engineer.md".to_string()),
+            "drifted bundled agent must be repaired, got: {report:?}"
+        );
+        assert!(
+            !report
                 .agents_skipped
                 .contains(&"rust-engineer.md".to_string())
         );
-        assert_eq!(
-            std::fs::read_to_string(&deployed).unwrap(),
-            "operator hand-edited this"
+        assert!(
+            std::fs::read_to_string(&deployed).unwrap().contains("v2"),
+            "the current bundled composition must be restored"
         );
     }
 }

--- a/crates/trusty-mpm/tests/e2e/test_agent_deploy.rs
+++ b/crates/trusty-mpm/tests/e2e/test_agent_deploy.rs
@@ -69,26 +69,36 @@ fn deploy_skips_user_file() {
     assert_eq!(after, user_content, "user file untouched");
 }
 
-/// A managed file the user later hand-edited is preserved (and reported as
-/// skipped) on the next deploy.
+/// A managed BUNDLED file whose deployed copy drifted from the manifest
+/// checksum is re-deployed from the bundle on the next deploy (issue #4408).
+///
+/// Bundled files are framework-owned (the `Overwrite` install tier), so a
+/// checksum mismatch there means drift or corruption, never user ownership.
+/// The user-owned tier is covered by `deploy_skips_user_file` above, which
+/// still passes untouched.
 #[test]
-fn deploy_skips_user_modified() {
+fn deploy_repairs_drifted_bundled_file() {
     let src = TempDir::new().unwrap();
     let tgt = TempDir::new().unwrap();
     write_agent_sources(src.path());
 
     deploy_agents(src.path(), tgt.path()).expect("first deploy");
+    let bundled = std::fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
 
-    // User edits the deployed (managed) file.
-    let edited = "---\nname: engineer\n---\n\nHAND-EDITED BY USER\n";
-    std::fs::write(tgt.path().join("engineer.md"), edited).unwrap();
+    // The deployed copy corrupts into the degenerate `v1` stub from the
+    // incident, while the manifest still records the real content's checksum.
+    std::fs::write(
+        tgt.path().join("engineer.md"),
+        "---\nname: engineer\n---\n\nv1\n",
+    )
+    .unwrap();
 
     let result = deploy_agents(src.path(), tgt.path()).expect("second deploy");
-    assert!(result.skipped.contains(&"engineer.md".to_string()));
-    assert!(!result.deployed.contains(&"engineer.md".to_string()));
+    assert!(result.deployed.contains(&"engineer.md".to_string()));
+    assert!(!result.skipped.contains(&"engineer.md".to_string()));
 
     let after = std::fs::read_to_string(tgt.path().join("engineer.md")).unwrap();
-    assert!(after.contains("HAND-EDITED BY USER"), "user edit preserved");
+    assert_eq!(after, bundled, "bundled composition restored");
 }
 
 /// Composing an agent resolves the full inheritance chain in base-first order.


### PR DESCRIPTION
## Root cause

`AgentManifest::checksum_matches` mismatch was mapped straight to "the user
edited this file — preserve it" in `agents::deployer::deploy_agents_filtered`,
with no reference to the manifest entry's declared ownership.

That is correct for the user-owned (`InstallPolicy::SeedOnce`) tier and fatal
for the framework-owned (`Origin::Bundled` + `InstallPolicy::Overwrite`) tier.
Corrupt content can never checksum-match again, so once a bundled agent's
deployed copy corrupts, the corruption is permanently misclassified as a user
edit: every subsequent deploy skips it, and `tm validate --repair` skips it too.
In the reported incident a 32-byte stub (`name:` frontmatter, body `v1`, no
`description:`) replaced the real 25KB `rust-engineer.md` while the manifest
still recorded the real content's checksum. Result: "Agent type not found" for
every session in that workspace, permanently, while `tm doctor` (which counts
files, not content) reported the roster healthy.

## Fix seam

The bug was in the caller, not `checksum_matches`. The mismatch branch now
consults the entry's declared origin:

- `crates/trusty-agents-common/src/agents/manifest.rs` — new
  `Origin::is_framework_owned()`: `true` only for `Bundled`. `User` and
  `Registry` stay in the preserve-on-mismatch tier.
- `crates/trusty-agents-common/src/agents/deployer.rs` — a managed file whose
  checksum mismatches is re-deployed when its entry is framework-owned, and
  still skipped when it is user-owned. Untracked files (nothing in the manifest)
  are untouched exactly as before — that is the hand-placed-agent path.
- Every overwrite-on-mismatch repair emits a `warn!` with the filename, the
  expected and found checksums, and the on-disk byte count, so a corruption
  event is visible instead of silent.

Scoping notes:

- **Tier-independent.** This is manifest ownership semantics, so it protects
  bundled entries at whatever tier they are deployed to — including the user
  tier (`$CLAUDE_CONFIG_DIR`) where bundled agents are to live. The
  deploy-target architecture change is tracked separately in
  [#4409](https://github.com/bobmatnyc/trusty-tools/issues/4409); nothing in
  `paths.rs` or any deploy-target selection is touched here.
- **Skills are unaffected.** The skill deployer
  (`trusty-agents-common/src/skills/deployer.rs`) is a separate code path whose
  manifest entries carry no origin at all; its user-edit freeze is untouched.
- **Workspace-local blast radius.** Per-workspace deployment meant the
  corruption was confined to one workspace — the tm-agents workstream in the
  same repo was unaffected. But any workspace that corrupts stays broken forever
  without this fix, because no repair path could ever reach the file.

### Deliberate behavior change

A managed **bundled** agent that was hand-edited in place is now refreshed
rather than preserved. That is the settled two-variant install policy:
framework-owned assets overwrite, user-owned assets seed once. Three tests that
encoded the old semantic were rewritten to assert the new one; the user-owned
guards were kept and strengthened. Hand-placed agents (files trusty-mpm never
deployed, so absent from the manifest) are still never touched, and
`tm install --reset-agents` remains the backup-preserving reconciliation path.

## Test evidence

New / changed tests, both directions:

| Test | Asserts |
|---|---|
| `agents::deployer::tests::deploy_redeploys_corrupted_bundled_file` | bundled entry + the literal `v1` stub on disk → re-deployed, content byte-identical to the bundle, manifest checksum matches after, third run is `unchanged` |
| `agents::deployer::tests::deploy_preserves_modified_user_owned_entry` | `Origin::User` entry with modified content → skipped and byte-identical across two deploys, origin unchanged |
| `agents::manifest::tests::origin_framework_ownership_tiers` | only `Bundled` is framework-owned |
| `core::session_launch::sync_assets::tests::sync_assets_repairs_drifted_bundled_agent` | same repair at the session-launch tier |
| `core::session_launch::sync_assets::tests::sync_assets_never_touches_hand_placed_agent` | a hand-placed (untracked) `.claude/agents/` file survives sync byte-identical |
| `e2e::test_agent_deploy::deploy_repairs_drifted_bundled_file` | end-to-end repair through the `trusty-mpm` re-export |

The regression test was confirmed to FAIL against pre-fix behavior (with
`is_framework_owned` forced to `false`):

```
---- agents::deployer::tests::deploy_redeploys_corrupted_bundled_file stdout ----
panicked at deployer_tests.rs:94:5:
a corrupted bundled agent must be re-deployed, got: DeployResult { deployed: [],
skipped: ["engineer.md"], unchanged: ["base-agent.md"], ... }
```

Gates (all green, crate-scoped):

```
cargo test -p trusty-agents-common
test result: ok. 329 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

cargo test -p trusty-mpm
test result: ok. 4009 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out
(+ 29 further green test binaries, 0 failures)

cargo clippy -p trusty-mpm -p trusty-agents-common --all-targets -- -D warnings   EXIT=0
cargo fmt --check                                                                 clean
bash scripts/check_line_cap.sh    line-cap: 7 allowlisted, 0 violations — OK.
```

Closes #4408

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
