### PR TITLE
fix(trusty-agents): drop cross-project git reach from untrusted-input assistant personas

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/assistant/agent.toml
@@ -76,8 +76,19 @@ allow = [
   # in-process (tagent -> tagent), without exposing internal mechanics to
   # the user. See `delegate_to_agent` (`src/tools/delegate.rs`).
   "delegate_to_agent",
-  # git
-  "git_log", "git_status",
+  # NO git tools on the base (owner, 2026-07-30). `git_log`/`git_status` used
+  # to live here and were UNIONED into every overlay. PR #4222 gave L0-tier
+  # agents cross-project git scoping, and ADR-0024 decision 3 made an
+  # undeclared tier derive from KIND — so assistant-kind personas resolve L0
+  # and these two went from a single-tenant git surface to a cross-project one
+  # bounded only by the operator's `projects.json`. `izzie` ingests UNTRUSTED
+  # content (Gmail/Drive/Calendar), so that put untrusted input one hop from a
+  # cross-project read primitive: a prompt-injection exfiltration shape. Still
+  # read-only and registry-bounded, but the reach was new and unintended.
+  # Personas that genuinely need git RE-DECLARE it themselves — see
+  # `../cto-assistant/agent.toml`, which is a coding assistant, not a
+  # mail-ingesting one. Do not restore a git grant to this base file.
+  # Pinned by `bundled_personas_pin_git_reach` (agents/tests/loading.rs).
   # OKG builder (epic #3052): grow this assistant's own knowledge graph from
   # real sources — a directory of documents, a Gmail query window, a Drive
   # folder — idempotently and additively. Generic capability (every user

--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -63,8 +63,8 @@ palace = "cto"
 
 
 [tools]
-# CTO-specific DELTAS only — the base `assistant` already grants git_log,
-# git_status, granola_*, web_search, delegate_to_agent, and the full
+# CTO-specific DELTAS only — the base `assistant` already grants granola_*,
+# web_search, delegate_to_agent, and the full
 # gworkspace Gmail/Calendar/Drive/Docs/Sheets/Slides/Tasks surface (unioned
 # in automatically). BLACK-BOX POSTURE (PR A): session_list, session_status,
 # session_send, project_list, agent_delegate (trusty-mpm proxied tools),
@@ -72,7 +72,18 @@ palace = "cto"
 # DELIBERATELY EXCLUDED — do not re-add them here (see
 # `../assistant/agent.toml` for the rationale).
 allow = [
-    # #255: branch listing + commit search beyond the base's git_log/git_status.
+    # DELIBERATE CARVE-OUT (owner, 2026-07-30): all four git tools, declared
+    # HERE rather than inherited. The base `assistant` dropped
+    # `git_log`/`git_status` in the same change because they reached every
+    # overlay — including `izzie`, who ingests untrusted Gmail/Drive content
+    # and must not sit one hop from a cross-project read primitive. The CTO
+    # assistant is a CODING assistant, not a mail-ingesting one, so the owner
+    # chose to keep its git surface intact rather than accept a silent
+    # capability regression. Re-declaring here is what makes that choice
+    # explicit and reviewable instead of a side effect of the base edit.
+    # #255: branch listing + commit search, alongside the two the base no
+    # longer supplies.
+    "git_log", "git_status",
     "git_branches", "git_search_commits",
     # ADR-0024 decision 4 (owner, 2026-07-29): the four direct ticket-tool
     # grants (`ticket_search`, `list_tickets`, `get_ticket`, `create_ticket`)

--- a/crates/trusty-agents/.trusty-agents/agents/izzie.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie.toml
@@ -65,8 +65,6 @@ palace = "owner-profile"
 allow = [
   # delegation (PR A, epic #3052)
   "delegate_to_agent",
-  # git
-  "git_log", "git_status",
   # granola
   "granola_*",
   # web search

--- a/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/izzie/agent.toml
@@ -88,8 +88,6 @@ palace = "owner-profile"
 allow = [
   # delegation (PR A, epic #3052)
   "delegate_to_agent",
-  # git
-  "git_log", "git_status",
   # meeting notes
   "granola_*",
   # web search

--- a/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/personal-assistant.toml
@@ -44,7 +44,6 @@ use_anthropic_direct = false
 # (enumerate internal MCP service names) are DELIBERATELY EXCLUDED — this is
 # an assistant-tier persona and must not leak internal system names.
 allow = [
-    "git_log", "git_status",
     "granola_*",
 ]
 # OpenRPC over stdio scopes (#454). Personal assistant taps the gworkspace

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,27 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Security
+
+- **`izzie`, `personal-assistant` and the base `assistant` no longer reach
+  `git_log`/`git_status`.** PR #4222 gave L0-tier agents cross-project git
+  scoping and ADR-0024 decision 3 (PR #4296) made an undeclared `tier =`
+  derive from agent kind, so assistant-kind personas resolve L0 — together
+  moving those two tools from a single-tenant git surface to a cross-project
+  one bounded only by the operator's `projects.json`. `izzie` ingests
+  untrusted content (Gmail, Drive, Calendar), which left untrusted input one
+  hop from a cross-project read primitive: a prompt-injection exfiltration
+  shape. Read-only and registry-bounded throughout, but the reach was new and
+  unintended. Removing the entries from izzie's own two files was NOT
+  sufficient — `izzie/agent.toml` declares `extends = "assistant"` and
+  `merge_extends` UNIONS `[tools].allow` base-first with no subtractive key,
+  so the base kept re-granting them; `assistant/agent.toml` had to drop them
+  too. `cto-assistant` re-declares all four git tools itself as a deliberate
+  carve-out (it is a coding assistant, not a mail-ingesting one) and keeps an
+  unchanged surface. Pinned by `bundled_personas_pin_git_reach`, which
+  resolves personas through the real loader rather than reading TOML — a
+  file-reading test would have gone green while the inherited grant stayed.
+
 ### Changed
 
 - **`discover_one_returns_none_on_timeout` now runs on Tokio's paused clock

--- a/crates/trusty-agents/src/agents/cross_project/tests.rs
+++ b/crates/trusty-agents/src/agents/cross_project/tests.rs
@@ -650,19 +650,30 @@ fn audit_summary_names_tier_and_allowed_roots() {
     );
 }
 
-/// The SHIPPED-PERSONA consequence of this PR landing after ADR-0024
+/// The TIER-DERIVATION consequence of this PR landing after ADR-0024
 /// decision 3 (PR #4296) — recorded as a reviewed fact, not left implicit.
 ///
 /// Why: ADR-0024's "Capability grants: zero observable delta" analysis was
 /// written while #4170/#4172/#4173 were still open, and it holds for the other
 /// two — their tools are gated by NAME, and no bundled assistant's
-/// `[tools].allow` matches one. It does NOT hold for this PR. `git_log` and
-/// `git_status` ARE in the shipped `izzie` / `personal-assistant` allow-lists,
-/// so those personas — assistant-kind, therefore L0 by derivation — go from a
+/// `[tools].allow` matches one. It did NOT hold for this PR: `git_log` and
+/// `git_status` were in the shipped `izzie` / `personal-assistant` allow-lists,
+/// so those personas — assistant-kind, therefore L0 by derivation — went from a
 /// single-tenant git surface to a cross-project one bounded by the operator's
-/// own `projects.json`. That is a real, if bounded, widening of what an
-/// untrusted-content-ingesting persona can read, and it should fail this test
-/// (and be re-reviewed) rather than change silently again.
+/// own `projects.json`. Untrusted-content-ingesting personas sitting one hop
+/// from a cross-project read primitive was not intended, and the owner removed
+/// the grant on 2026-07-30: `izzie`, `personal-assistant` and the base
+/// `assistant` no longer reach either tool, while `cto-assistant` re-declares
+/// all four as a deliberate carve-out. That end state is pinned by
+/// `agents::tests::loading::bundled_personas_pin_git_reach`, NOT here.
+///
+/// This test is about TIER DERIVATION, not about any persona's allow-list: it
+/// asserts that an assistant-kind config with no declared tier resolves L0 and
+/// therefore a bounded cross-project SCOPE. That mechanism is unchanged and
+/// still worth pinning — a future persona granted a git tool would inherit
+/// exactly this scope — which is why the fixture below is synthetic
+/// (`izzie-shaped`) rather than the real `izzie`, and why removing the shipped
+/// grant did not and should not have made this test fail.
 ///
 /// What: an assistant-kind persona with no declared tier, over a registry
 /// holding one active sibling repo, resolves a CROSS-PROJECT scope that

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -2036,6 +2036,113 @@ fn bundled_assistant_personas_resolve_l0_and_gain_nothing() {
     );
 }
 
+/// The owner's 2026-07-30 decision on git reach, pinned against the REAL
+/// bundled roster and the REAL `extends` resolution.
+///
+/// Why: PR #4222 gave L0-tier agents cross-project git scoping, and ADR-0024
+/// decision 3 (PR #4296) made an undeclared `tier =` derive from agent KIND —
+/// so every assistant-kind persona resolves L0. Together those moved
+/// `git_log`/`git_status` from a single-tenant git surface to a CROSS-PROJECT
+/// one bounded only by the operator's `projects.json`. `izzie` ingests
+/// untrusted content (Gmail, Drive, Calendar), which put untrusted input one
+/// hop from a cross-project read primitive — a prompt-injection exfiltration
+/// shape. The grant was removed, and this test is what keeps it removed.
+///
+/// A per-file assertion would NOT be sufficient and this is the whole reason
+/// the test resolves configs instead of reading TOML: `izzie/agent.toml`
+/// declares `extends = "assistant"`, and `merge_extends` UNIONS `[tools].allow`
+/// base-first with no subtractive key anywhere in `ToolsConfig`. Deleting the
+/// two entries from izzie's own files therefore changed NOTHING on its own —
+/// the base kept re-granting them through the union, and only stripping
+/// `assistant/agent.toml` too made izzie's resolved surface actually clean.
+/// Any future test of this property that reads files rather than resolving
+/// them would go green while the hole stayed open.
+///
+/// The `cto-assistant` half is not symmetry, it is the deliberate CARVE-OUT:
+/// the owner chose to keep all four git tools there because it is a coding
+/// assistant, not a mail-ingesting one, so it re-declares them itself now that
+/// the base no longer supplies them. Pinned so a later "cleanup" of that
+/// apparently-redundant re-declaration fails loudly instead of silently
+/// regressing a capability that was explicitly retained.
+///
+/// What: resolves all four personas through `AgentConfig::by_name` (the same
+/// dispatch loader production uses, directory package shadowing flat file) and
+/// asserts reachability per tool via `match_any_glob` — the real matching
+/// semantics, so a persona that re-grants reach by widening a pattern to
+/// `git_*` or `*` fails this test exactly as an explicit re-add would.
+/// Test: This function IS the test.
+#[test]
+fn bundled_personas_pin_git_reach() {
+    let _guard = ENV_LOCK.blocking_lock();
+
+    // (persona, the git tools it is intended to reach — exhaustive)
+    let expected: [(&str, &[&str]); 4] = [
+        ("izzie", &[]),
+        ("personal-assistant", &[]),
+        ("assistant", &[]),
+        (
+            "cto-assistant",
+            &[
+                "git_log",
+                "git_status",
+                "git_branches",
+                "git_search_commits",
+            ],
+        ),
+    ];
+    // Every git tool named anywhere in the roster, so "reaches nothing" is
+    // asserted against the full set rather than only the two that moved.
+    const ALL_GIT_TOOLS: [&str; 4] = [
+        "git_log",
+        "git_status",
+        "git_branches",
+        "git_search_commits",
+    ];
+
+    for (name, intended) in expected {
+        clear_model_env(name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::set_var("TAGENT_CONFIG_DIR", bundled_agents_dir());
+        }
+        let cfg = AgentConfig::by_name(name);
+        // SAFETY: guarded by ENV_LOCK.
+        unsafe {
+            std::env::remove_var("TAGENT_CONFIG_DIR");
+        }
+        let cfg = cfg.unwrap_or_else(|e| panic!("'{name}' must resolve: {e}"));
+
+        // An absent `allow` means UNRESTRICTED, which would make every
+        // assertion below vacuously wrong rather than failing — check it.
+        let allow = cfg.tools.allow.as_deref().unwrap_or_else(|| {
+            panic!("'{name}' must ship a restricted [tools].allow, not an absent one")
+        });
+
+        for tool in ALL_GIT_TOOLS {
+            let reaches = crate::ctrl::pm_task::match_any_glob(tool, allow);
+            if intended.contains(&tool) {
+                assert!(
+                    reaches,
+                    "'{name}' must still reach '{tool}' — this is the deliberate \
+                     carve-out (owner, 2026-07-30), not leftover redundancy. If the \
+                     base stopped supplying it, re-declare it in this persona's own \
+                     [tools].allow rather than deleting the expectation."
+                );
+            } else {
+                assert!(
+                    !reaches,
+                    "'{name}' resolves git tool '{tool}', which it must NOT: as an \
+                     assistant-kind (therefore L0) persona this is CROSS-PROJECT git \
+                     reach bounded only by projects.json, and '{name}' handles \
+                     untrusted content. Resolved allow-list: {allow:?}. Note the \
+                     grant may be INHERITED — `extends` unions base-first, so check \
+                     `assistant/agent.toml` too, not just this persona's file."
+                );
+            }
+        }
+    }
+}
+
 /// ADR-0024 decision 4 sub-answer (a), the MIGRATION half: every bundled
 /// assistant persona ships a seeded `[subagents].delegate_allowed`.
 ///


### PR DESCRIPTION
## What this closes

`izzie` and `personal-assistant` no longer resolve cross-project `git_log`/`git_status`.

PR #4222 (squash 130e7d8b) granted L0-tier assistants cross-project git/search scoping. Separately, ADR-0024 decision 3 (PR #4296, 54bba9f7) made an undeclared `tier =` derive from agent KIND, and assistant-kind resolves L0. Combined, the shipped `izzie` and `personal-assistant` personas — whose `[tools].allow` lists already contained `git_log`/`git_status` — moved from a single-tenant git surface to a **cross-project** one. `izzie` ingests UNTRUSTED content (Gmail, Drive, Calendar), so untrusted input reached a cross-project read primitive. That is a prompt-injection exfiltration shape. It stayed read-only and bounded by `projects.json` throughout, but the reach was new and unintended.

## The finding that changed the shape of this PR

**Deleting the entries from izzie's own two files fixed nothing on its own.** `izzie/agent.toml:42` declares `extends = "assistant"`, and `merge_extends` (`agents/extends/mod.rs:348`) **unions** `[tools].allow` base-first. There is no `deny` or other subtractive key anywhere in `ToolsConfig` (`agents/config.rs:296`). The base `assistant/agent.toml` also listed both tools, so it kept re-granting them and izzie's *resolved* surface was byte-identical before and after those edits.

Measured through the real loader (`AgentConfig::by_name`, directory package shadowing flat file):

| persona | before | after izzie/PA edits only | **after this PR** |
|---|---|---|---|
| `izzie` | `git_log, git_status` | `git_log, git_status` (unchanged) | **`[]`** |
| `personal-assistant` | `git_log, git_status` | `[]` | **`[]`** |
| `assistant` (base) | `git_log, git_status` | `git_log, git_status` | **`[]`** |
| `cto-assistant` | `git_log, git_status, git_branches, git_search_commits` | unchanged | **all four, unchanged** (81 entries, same as baseline) |

So the base had to drop them too — that is why this PR touches `assistant/agent.toml` rather than only the two personas named in the original decision.

## The cto-assistant carve-out, and why

Stripping the base would otherwise have silently de-capability'd `cto-assistant`, which inherited `git_log`/`git_status` from it. Owner decision (2026-07-30): **keep all four** there. It is the *coding* assistant, not a Gmail-ingesting persona, so the injection rationale that motivates this change does not apply to it, and a silent capability regression is not wanted. It now **re-declares** all four in its own `[tools].allow`, which makes the retention explicit and reviewable instead of an accident of inheritance.

Worth stating plainly: stripping the base would *not* have secured `cto-assistant` anyway — it declares `git_branches` and `git_search_commits` itself, so it would have kept cross-project git reach while losing two tools. The carve-out is the honest option.

## What this does NOT close

- **All git calls routing through a Versioning sub-agent.** That is the owner's stated direction and is **separate architectural work, not delivered here.** Two things are worth recording so the follow-up is scoped accurately:
  - A Versioning sub-agent is **not currently in the reachable set**. The floor constant `ASSISTANT_REACHABLE_SUBAGENTS` (`agents/delegation.rs:78`) is `["research-agent", "ticketing-agent"]`, so no such target is reachable today even if it existed.
  - **Routing through a sub-agent does not by itself narrow scope.** The sub-agent would still resolve its own tier and scope; unless it enforces project scoping explicitly, delegation relocates the primitive without bounding it. Indirection is not a boundary.
- This PR changes **no Rust production code** — no tier model, no reachable-set floor, no grant factory. Config plus tests only.

## Correcting the record on the zero-delta guard

`bundled_assistant_personas_resolve_l0_and_gain_nothing` **never covered this and still does not**, and the ADR's zero-delta claim is not retroactively repaired by this PR. The two are on different axes:

- The guard checks whether a persona names an **L0-gated tool** — `is_l0_only_session_state_tool`, the `L0_SHELL_EXEC` glob, `GH_TOOL_NAMES`. That is a **tool-gating** axis: *which tools exist for L0*.
- #4222 widened a **scope** axis: *which repos an already-granted tool may touch*. `git_log`/`git_status` are in none of those gated sets, so the guard was green before #4222, green after it, and green throughout this PR. It could not have caught the widening.

Both tests named in the original brief were verified against the real code rather than assumed:

- `shipped_assistant_kind_gains_bounded_cross_project_git_reach` (`cross_project/tests.rs:674`) **did not break** and was not forced to. It builds a synthetic `izzie-shaped` fixture (line 685), not the real persona — it is a test about **tier derivation** producing a bounded scope, which is unchanged and still worth pinning. Only its **doc comment** was stale (it asserted in prose that the shipped allow-lists contain these tools); the comment is corrected and the logic is untouched.
- `bundled_assistant_personas_resolve_l0_and_gain_nothing` needed no change, per the axis argument above.

Nothing was weakened, deleted, or `#[ignore]`d.

## New test

`bundled_personas_pin_git_reach` (`agents/tests/loading.rs`) pins the end state for all four personas. It **resolves** each through `AgentConfig::by_name` rather than reading TOML — deliberately, because a file-reading test would have gone green while the inherited grant stayed open, which is exactly the trap this PR walked into. Reachability is checked with `match_any_glob`, the real matching semantics, so re-granting by widening a pattern to `git_*` or `*` fails it just as an explicit re-add would.

Both halves are **mutation-verified**, not assumed:

- Restoring `git_log`/`git_status` to the base → fails on `izzie`, with the resolved allow-list dumped and a pointer that the grant may be inherited.
- Dropping cto-assistant's re-declaration → fails on the carve-out, telling the reader to re-declare rather than delete the expectation.

## Gates

All crate-scoped, all green: `cargo check`; `cargo test -p trusty-agents` (**3110 passed, 0 failed**); `cargo clippy -p trusty-agents --all-targets -- -D warnings` (zero warnings); `cargo fmt --check`; `scripts/check_line_cap.sh` (0 violations); `scripts/check_test_pointers.sh` (0 dangling).

One pre-existing local flake was ruled out rather than waved off: `tools::python_skill::tests::execute_dispatches_to_python_and_parses_json` fails on every *second consecutive* run because it self-corrupts its gitignored `skills/cto-db/python/.venv`. Confirmed identical on a clean `origin/main` checkout with none of these changes (run 1 green, run 2 red), so it is unrelated to this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
