### PR TITLE
fix(trusty-mpm): stop bare tm daemon bypassing the #2486 unsupervised-spawn guard

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -91,6 +91,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- **Bare `tm daemon` bypassed the #2486 unsupervised-spawn guard (closes
+  [#4397](https://github.com/bobmatnyc/trusty-tools/issues/4397)).** The
+  guard against a launchd-managed daemon being duplicated by an unsupervised
+  spawn previously existed only on the MCP-bridge path
+  (`serve_stdio.rs`'s `no_spawn`); `run_daemon` (the bare-CLI path, invoked
+  directly or by a launchd plist) never consulted it, so `tm daemon` run by
+  hand walked straight past the same hazard — observed live as PID 35895
+  serving a stale 1.2.3 image since 2026-07-29 while the on-disk binary was
+  1.3.0. `run_daemon` now refuses to start when a trusty-mpm launchd unit is
+  registered but this process is not launchd-supervised, unless the operator
+  passes the new `tm daemon --force` opt-in.
 - **A corrupted bundled agent is re-deployed instead of frozen forever (closes
   [#4408](https://github.com/bobmatnyc/trusty-tools/issues/4408)).** When the
   deployed copy of a bundled agent drifts from the checksum the deploy manifest

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -487,6 +487,14 @@ pub(crate) enum Command {
         /// Run as an MCP server over stdio instead of the HTTP daemon.
         #[arg(long)]
         mcp: bool,
+        /// Start even when a trusty-mpm launchd unit is registered but this
+        /// process is NOT launchd-supervised (issue #4397, the bare-CLI
+        /// counterpart of #2486's MCP-bridge `no_spawn` guard). Without this,
+        /// `run_daemon` refuses to start in that hazardous state — it means a
+        /// launchd unit exists and `launchctl kickstart`/`bootstrap` is the
+        /// correct way to bring the daemon back, not a bare `tm daemon`.
+        #[arg(long)]
+        force: bool,
     },
     /// Run the unattended fleet supervisor (24/7 observer + auto-resumer, #1206).
     ///

--- a/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs
@@ -6,8 +6,12 @@
 //! while co-locating the helpers that are only meaningful together.
 //! What: `run_daemon` (the `daemon` subcommand handler) plus private helpers.
 //! Test: `cli_parses_daemon_*` parse tests; `run_daemon_rejects_tailscale_flag`
-//! covers the deprecation error; the bind/serve path is exercised by the
-//! daemon e2e suite.
+//! covers the deprecation error; the #4397 bare-CLI guard's decision table is
+//! covered hermetically by `commands::launchd_probe::tests::
+//! compute_daemon_refuse_*` (`apply_supervision_signal` itself probes real
+//! launchd/filesystem state, so it is not hermetically fakeable here — see
+//! the daemon e2e suite for the wired-up behaviour); the bind/serve path is
+//! likewise exercised by the daemon e2e suite.
 
 use std::net::SocketAddr;
 
@@ -21,14 +25,24 @@ use std::net::SocketAddr;
 /// listener — `trusty-console` is the sole HTTP surface reachable off-host,
 /// via its own `--tailscale`/Funnel modes.
 /// What: rejects `--tailscale` up front with an actionable error (see
-/// [`tailscale_deprecated_error`]); in MCP mode delegates straight to
+/// [`tailscale_deprecated_error`]); refuses to start when a launchd unit is
+/// registered but this process isn't launchd-supervised and `--force` was
+/// not passed (issue #4397, see [`apply_supervision_signal`] and
+/// [`unsupervised_daemon_error`]); in MCP mode delegates straight to
 /// `run_mcp`; otherwise binds `addr` (falling back to `127.0.0.1:0` on
 /// `AddrInUse`), writes the lock file, registers a Ctrl-C handler that
 /// removes the lock, then serves the API on the primary (loopback) listener.
 /// Test: `cli_parses_daemon_*` cover flag parsing; `run_daemon_rejects_
-/// tailscale_flag` covers the deprecation error; the bind/serve path is
-/// exercised by the daemon e2e suite.
-pub(crate) async fn run_daemon(addr: SocketAddr, tailscale: bool, mcp: bool) -> anyhow::Result<()> {
+/// tailscale_flag` covers the deprecation error; the #4397 guard's decision
+/// table is covered hermetically by `commands::launchd_probe::tests::
+/// compute_daemon_refuse_*`; the bind/serve path is exercised by the daemon
+/// e2e suite.
+pub(crate) async fn run_daemon(
+    addr: SocketAddr,
+    tailscale: bool,
+    mcp: bool,
+    force: bool,
+) -> anyhow::Result<()> {
     use std::io::ErrorKind;
 
     // ADR-0011 loopback-only doctrine (#3330): the secondary Tailscale
@@ -60,7 +74,15 @@ pub(crate) async fn run_daemon(addr: SocketAddr, tailscale: bool, mcp: bool) -> 
     // the MCP-mode early return and the HTTP-serving path below carry it on
     // `GET /health`. See `crate::commands::launchd_probe` for the full
     // restart-race rationale and the pure decision table.
-    apply_supervision_signal(&state);
+    let supervised = apply_supervision_signal(&state);
+
+    // #4397: the #2486 guard previously existed only on the MCP-bridge's
+    // `no_spawn` path (`serve_stdio.rs`) — a bare `tm daemon` invocation
+    // walked straight past the same hazard. Refuse here too unless the
+    // operator explicitly opts in with `--force`.
+    if crate::commands::launchd_probe::compute_daemon_refuse(supervised, force) {
+        return Err(unsupervised_daemon_error());
+    }
 
     if mcp {
         return trusty_mpm::daemon::run_mcp(state).await;
@@ -188,13 +210,15 @@ async fn wait_for_shutdown_signal() {
 /// all" into the single safe/hazardous signal `GET /health` exposes.
 /// What: probes for a trusty-mpm launchd plist, combines it with
 /// `trusty_common::update::is_launchd_supervised()`, stores the result on
-/// `state` via [`trusty_mpm::daemon::DaemonState::set_supervised`], and logs a
-/// `tracing::warn!` exactly once at startup when the result is hazardous.
+/// `state` via [`trusty_mpm::daemon::DaemonState::set_supervised`], logs a
+/// `tracing::warn!` exactly once at startup when the result is hazardous, and
+/// returns the `supervised` bool so the caller can also gate startup on it
+/// (issue #4397).
 /// Test: the pure decision table is covered by
 /// `crate::commands::launchd_probe::tests`; this wrapper is side-effect-only
 /// (env/filesystem probes + a state mutation) and is exercised via the daemon
 /// e2e suite's boot path.
-fn apply_supervision_signal(state: &trusty_mpm::daemon::DaemonState) {
+fn apply_supervision_signal(state: &trusty_mpm::daemon::DaemonState) -> bool {
     let plist_exists = crate::commands::launchd_probe::mpm_launchd_plist_exists();
     let is_launchd = trusty_common::update::is_launchd_supervised();
     let supervised = crate::commands::launchd_probe::compute_supervised(is_launchd, plist_exists);
@@ -207,6 +231,36 @@ fn apply_supervision_signal(state: &trusty_mpm::daemon::DaemonState) {
              (or `com.trusty.mpm`) to let launchd own the daemon."
         );
     }
+    supervised
+}
+
+/// Build the error returned when `run_daemon` refuses to start on the
+/// bare-CLI path because a launchd unit is registered but this process is not
+/// launchd-supervised (issue #4397, the bare-CLI counterpart of #2486's
+/// MCP-bridge `no_spawn` guard).
+///
+/// Why: silently starting anyway (the pre-#4397 behaviour) creates exactly
+/// the orphan-daemon hazard #2486 was meant to prevent — a duplicate,
+/// unsupervised daemon that can hold a stale binary indefinitely (observed:
+/// PID 35895 serving a stale 1.2.3 image since 2026-07-29 while the on-disk
+/// binary was 1.3.0). The error names both remedies: let launchd own the
+/// daemon via `launchctl kickstart`/`bootstrap`, or explicitly opt in with
+/// `--force` when the operator really does want an unsupervised run (e.g.
+/// local dev alongside a supervised instance on a different port).
+/// What: returns an `anyhow::Error` with the actionable message; kept as a
+/// separate function so the message text has exactly one source of truth for
+/// both the runtime call site and any future caller.
+/// Test: `unsupervised_daemon_error_names_remedies` below.
+fn unsupervised_daemon_error() -> anyhow::Error {
+    anyhow::anyhow!(
+        "refusing to start: a trusty-mpm launchd unit is registered but this \
+         process was not started by launchd (issue #2486/#4397) — starting \
+         anyway would create a duplicate, unsupervised daemon that can hold a \
+         stale binary indefinitely. Use \
+         `launchctl kickstart -k gui/$(id -u)/com.trusty.mpm.supervisor` (or \
+         `com.trusty.mpm`) to let launchd own the daemon, or pass \
+         `tm daemon --force` to start unsupervised anyway."
+    )
 }
 
 /// Spawn the SUPERVISED Telegram bot as a background task when a token is
@@ -286,12 +340,25 @@ mod tests {
     #[tokio::test]
     async fn run_daemon_rejects_tailscale_flag() {
         let addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let err = run_daemon(addr, true, false)
+        let err = run_daemon(addr, true, false, false)
             .await
             .expect_err("--tailscale must be rejected");
         let msg = err.to_string();
         assert!(msg.contains("trusty-console"), "message was: {msg}");
         assert!(msg.contains("ADR-0011"), "message was: {msg}");
         assert!(msg.contains("#3330"), "message was: {msg}");
+    }
+
+    /// Issue #4397: the bare-CLI refusal message must name both remedies —
+    /// the `launchctl kickstart` recipe and the `--force` opt-in — so an
+    /// operator hitting it has an immediate next step either way.
+    #[test]
+    fn unsupervised_daemon_error_names_remedies() {
+        let msg = unsupervised_daemon_error().to_string();
+        assert!(msg.contains("launchctl kickstart"), "message was: {msg}");
+        assert!(msg.contains("com.trusty.mpm"), "message was: {msg}");
+        assert!(msg.contains("--force"), "message was: {msg}");
+        assert!(msg.contains("#2486"), "message was: {msg}");
+        assert!(msg.contains("#4397"), "message was: {msg}");
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs
@@ -88,6 +88,29 @@ pub(crate) fn compute_no_spawn(plist_exists: bool) -> bool {
     plist_exists
 }
 
+/// Pure decision: should the bare `tm daemon` CLI path refuse to start?
+///
+/// Why (issue #4397): the #2486 guard was wired only into the MCP-bridge's
+/// `no_spawn` path (`compute_no_spawn`, consulted from `serve_stdio.rs`).
+/// `run_daemon` (the bare-CLI path, invoked directly or by a launchd plist)
+/// never consulted any guard, so `tm daemon` run by hand walked straight past
+/// the same hazard: a launchd unit is registered, but THIS process was not
+/// started by launchd — the orphan-daemon signature `compute_supervised`
+/// already detects. `compute_no_spawn` itself is unsuitable here because it
+/// only takes `plist_exists` — applied directly to `run_daemon` it would also
+/// refuse the legitimate case where launchd itself is the one invoking
+/// `tm daemon`. This function instead keys off `supervised` (which already
+/// folds in `is_launchd_supervised`), plus an explicit opt-in.
+/// What: `true` (refuse) exactly when `!supervised && !force` — i.e. a
+/// launchd unit exists, this process isn't the one launchd started, and the
+/// operator did not pass `--force`.
+/// Test: `compute_daemon_refuse_true_when_unsupervised_and_not_forced`,
+/// `compute_daemon_refuse_false_when_supervised`,
+/// `compute_daemon_refuse_false_when_forced`.
+pub(crate) fn compute_daemon_refuse(supervised: bool, force: bool) -> bool {
+    !supervised && !force
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -125,5 +148,24 @@ mod tests {
     #[test]
     fn compute_no_spawn_false_when_no_plist() {
         assert!(!compute_no_spawn(false));
+    }
+
+    #[test]
+    fn compute_daemon_refuse_true_when_unsupervised_and_not_forced() {
+        assert!(compute_daemon_refuse(false, false));
+    }
+
+    #[test]
+    fn compute_daemon_refuse_false_when_supervised() {
+        // Supervised (either no plist, or launchd-supervised) always proceeds,
+        // regardless of `force`.
+        assert!(!compute_daemon_refuse(true, false));
+        assert!(!compute_daemon_refuse(true, true));
+    }
+
+    #[test]
+    fn compute_daemon_refuse_false_when_forced() {
+        // The hazardous state, but the operator explicitly opted in.
+        assert!(!compute_daemon_refuse(false, true));
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -452,7 +452,8 @@ async fn main() -> anyhow::Result<()> {
             addr,
             tailscale,
             mcp,
-        }) => run_daemon(addr, tailscale, mcp).await,
+            force,
+        }) => run_daemon(addr, tailscale, mcp, force).await,
         Some(Command::Supervisor {
             addr,
             interval,

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1072,10 +1072,12 @@ fn cli_parses_daemon_defaults() {
             addr,
             tailscale,
             mcp,
+            force,
         } => {
             assert_eq!(addr.to_string(), "127.0.0.1:7880");
             assert!(!tailscale);
             assert!(!mcp);
+            assert!(!force);
         }
         other => panic!("expected Daemon, got {other:?}"),
     }
@@ -1086,6 +1088,17 @@ fn cli_parses_daemon_tailscale() {
     let cli = Cli::try_parse_from(["trusty-mpm", "daemon", "--tailscale"]).unwrap();
     match cli.command.unwrap() {
         Command::Daemon { tailscale, .. } => assert!(tailscale),
+        other => panic!("expected Daemon, got {other:?}"),
+    }
+}
+
+/// Issue #4397: `tm daemon --force` must parse — the bare-CLI opt-in past the
+/// #2486 unsupervised-launchd guard.
+#[test]
+fn cli_parses_daemon_force() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "daemon", "--force"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Daemon { force, .. } => assert!(force),
         other => panic!("expected Daemon, got {other:?}"),
     }
 }


### PR DESCRIPTION
## Summary

- The #2486 guard against an unsupervised daemon duplicating a launchd-managed one existed only on the MCP-bridge path (`serve_stdio.rs`'s `no_spawn`, keyed off `compute_no_spawn`). `run_daemon` (the bare-CLI path — `tm daemon` invoked directly, or by the launchd plist itself) never consulted any guard, so it walked straight past the same hazard.
- Observed live: PID 35895 serving a stale 1.2.3 image since 2026-07-29 while the on-disk binary was already 1.3.0, because the daemon detected the hazardous state, logged a warning, and proceeded anyway.
- Adds `compute_daemon_refuse(supervised, force)` in `launchd_probe.rs` — a new pure decision distinct from `compute_no_spawn` (which only takes `plist_exists` and would wrongly refuse the legitimate launchd-invoked case). `apply_supervision_signal` now returns the `supervised` bool it already computes; `run_daemon` calls the new guard right after and refuses with an actionable error unless `--force` is passed.
- New `tm daemon --force` flag lets an operator explicitly opt into an unsupervised run.

## Changes

- `crates/trusty-mpm/src/bin/tm/commands/launchd_probe.rs`: `compute_daemon_refuse` + 3 unit tests.
- `crates/trusty-mpm/src/bin/tm/commands/daemon_run.rs`: `apply_supervision_signal` now returns `bool`; new guard check + `unsupervised_daemon_error()`; `run_daemon` takes a `force: bool` param; updated/added tests.
- `crates/trusty-mpm/src/bin/tm/cli/mod.rs`: `Command::Daemon` gains `force: bool` (`--force`).
- `crates/trusty-mpm/src/bin/tm/main.rs`: threads `force` through to `run_daemon`.
- `crates/trusty-mpm/src/bin/tm/tests.rs`: updated `cli_parses_daemon_defaults`, added `cli_parses_daemon_force`.
- `crates/trusty-mpm/CHANGELOG.md`: Unreleased/Fixed entry.

## Test plan

- [x] `cargo fmt --check -p trusty-mpm`
- [x] `cargo clippy -p trusty-mpm --bin tm --all-targets -- -D warnings`
- [x] `cargo test -p trusty-mpm --bin tm` — 1308 passed, 0 failed, 1 pre-existing ignored

Note: the bare-CLI refusal branch itself (`apply_supervision_signal` probing real launchd/filesystem state) isn't hermetically unit-testable without env mocking that doesn't exist elsewhere in this codebase — same convention as the existing `compute_supervised`/`compute_no_spawn` pure-decision-table tests. The wiring is exercised via the daemon e2e suite; the decision table itself (`compute_daemon_refuse`) is fully covered hermetically.

Closes #4397

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools