### PR TITLE
fix(trusty-agents-common): bump to 0.4.0 to clear version-parity drift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11222,7 +11222,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-agents-common"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ trusty-code = { path = "crates/trusty-code" }
 # shared by trusty-code's `tcode tui` and trusty-agents' tagent REPL (DOC-50,
 # epic #3411). Not yet published (Slice 1, #3425).
 trusty-tui = { path = "crates/trusty-tui", version = "0.1.0" }
-trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.3.0" }
+trusty-agents-common = { path = "crates/trusty-agents-common", version = "0.4.0" }
 trusty-common = { path = "crates/trusty-common", version = "0.27" }
 # trusty-embedderd: embedding daemon — referenced by trusty-search so
 # `cargo install trusty-search` produces both binaries from one command.

--- a/crates/trusty-agents-common/CHANGELOG.md
+++ b/crates/trusty-agents-common/CHANGELOG.md
@@ -9,11 +9,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- `agents::deployer` now re-deploys a corrupted bundled agent instead of freezing it as user-modified (closes [#4408](https://github.com/bobmatnyc/trusty-tools/issues/4408)). A manifest entry whose origin is framework-owned (`Origin::Bundled`, the `InstallPolicy::Overwrite` tier) is refreshed from the bundle whenever its on-disk checksum drifts — a mismatch there means corruption or drift, never user ownership. Previously ANY checksum mismatch was read as "the user edited this file", which is unrecoverable for a bundled asset: corrupt content can never checksum-match again, so a 32-byte `v1` stub that replaced the real 25KB `rust-engineer.md` was permanently misclassified as a user edit and skipped by every subsequent deploy and by `tm validate --repair`, dropping the agent from the session roster for the life of the workspace. The user-owned tier is unchanged — an untracked file, and a tracked entry with `Origin::User`/`Origin::Registry`, are still preserved byte-for-byte. Each overwrite-on-mismatch repair logs the file, the expected and found checksums, and the on-disk byte count.
+- `agents::deployer` now re-deploys a corrupted bundled agent instead of freezing it as user-modified (closes [#4408](https://github.com/bobmatnyc/trusty-tools/issues/4408)). A manifest entry whose origin is framework-owned (`Origin::Bundled`, the `InstallPolicy::Overwrite` tier) is refreshed from the bundle whenever its on-disk checksum drifts — a mismatch there means corruption or drift, never user ownership. Previously ANY checksum mismatch was read as "the user edited this file", which is unrecoverable for a bundled asset: corrupt content can never checksum-match again, so a 32-byte `v1` stub that replaced the real 25KB `rust-engineer.md` was permanently misclassified as a user edit and skipped by every subsequent deploy and by `tm validate --repair`, dropping the agent from the session roster for the life of the workspace. The user-owned tier is unchanged — an untracked file, and a tracked entry with `Origin::User`/`Origin::Registry`, are still preserved byte-for-byte. Each overwrite-on-mismatch repair logs the file, the expected and found checksums, and the on-disk byte count. ([#4419](https://github.com/bobmatnyc/trusty-tools/pull/4419)) ([`e8f30ef`](https://github.com/bobmatnyc/trusty-tools/commit/e8f30ef00bb3c7636c53182e88ee8a569acd6442))
 
 ### Added
 
 - `agents::manifest::Origin::is_framework_owned` — names the two install-ownership tiers so the deployer branches on declared ownership rather than on checksum mismatch alone (#4408).
+
+### Changed
+
+<!--
+  Note: the two entries below predate 0.2.1 (they reference #1959/#1968/#1750,
+  the trusty-agents-common 0.1.3 publish) and were left stranded under a stale
+  duplicate "## [Unreleased]" heading below the 0.2.1 section for several
+  releases (issue #2793 pattern) instead of being folded into whatever version
+  actually shipped them. Merged up into this changelog's single Unreleased
+  section during the 0.4.0 bump rather than deleted, since they are real
+  historical entries, not generator noise.
+-->
+- hoist compress::tool_output from trusty-agents ([#1959](https://github.com/bobmatnyc/trusty-tools/pull/1959)) ([#1968](https://github.com/bobmatnyc/trusty-tools/pull/1968)) ([`7cf93b9`](https://github.com/bobmatnyc/trusty-tools/commit/7cf93b9ab3918aff316238bdfe540a4053aa971d))
+- publish trusty-agents-common 0.1.3 + trusty-mpm 0.11.0 to crates.io ([#1750](https://github.com/bobmatnyc/trusty-tools/pull/1750)) ([`70194ec`](https://github.com/bobmatnyc/trusty-tools/commit/70194ec1788fed2e71016912dae4e062baade139))
 
 ## [0.3.0] — 2026-07-21
 
@@ -50,10 +64,3 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - Add crates.io package metadata (keywords/categories/homepage/readme).
-
-## [Unreleased]
-
-### Changed
-
-- hoist compress::tool_output from trusty-agents ([#1959](https://github.com/bobmatnyc/trusty-tools/pull/1959)) ([#1968](https://github.com/bobmatnyc/trusty-tools/pull/1968)) ([`7cf93b9`](https://github.com/bobmatnyc/trusty-tools/commit/7cf93b9ab3918aff316238bdfe540a4053aa971d))
-- publish trusty-agents-common 0.1.3 + trusty-mpm 0.11.0 to crates.io ([#1750](https://github.com/bobmatnyc/trusty-tools/pull/1750)) ([`70194ec`](https://github.com/bobmatnyc/trusty-tools/commit/70194ec1788fed2e71016912dae4e062baade139))

--- a/crates/trusty-agents-common/Cargo.toml
+++ b/crates/trusty-agents-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-agents-common"
-version = "0.3.0"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -180,7 +180,7 @@ lru = "0.16"
 #      Cargo edge was cut deliberately, ahead of cto-assistant's planned
 #      migration directly into `trusty-agents`. This `install_plugins`
 #      mechanism remains available for any future private launcher.
-trusty-agents-common = { path = "../trusty-agents-common", version = "0.3.0" }
+trusty-agents-common = { path = "../trusty-agents-common", version = "0.4.0" }
 
 # [patch.crates-io] moved to workspace root Cargo.toml (Cargo requires
 # [patch] tables to live in the workspace root; see #460 for context).


### PR DESCRIPTION
## Summary

The "Version parity" workflow went RED on main after PR #4419
("fix(trusty-agents-common): redeploy corrupted bundled assets instead
of freezing them as user-modified") landed Rust source changes under
the already-published `trusty-agents-common` 0.3.0:

- `src/agents/deployer.rs`
- `src/agents/deployer_tests.rs`
- `src/agents/manifest.rs`

`bash scripts/check-version-parity.sh` confirmed: **UNPUBLISHED SOURCE
DRIFT under an already-published version**.

## Why minor, not patch

Despite the commit title, the drift is not asset-only — it's a real
Rust source/behavior change:

- `Origin::is_framework_owned()` is a **new public method** on a
  publicly-reachable enum (`agents::manifest::Origin`, `pub mod
  manifest` under `pub mod agents`).
- `deploy_agents_filtered` behavior changed: a framework-owned
  (`Origin::Bundled`) manifest entry whose checksum drifts is now
  re-deployed instead of frozen as user-modified.

New public API surface → **minor** bump (0.3.0 → 0.4.0), per
`scripts/bump-version.sh crates/trusty-agents-common minor`.

## Sibling pins updated

`trusty-agents-common` is a path+version dependency pinned in two
places; both bumped to `0.4.0` in lockstep so the workspace resolves:

- root `Cargo.toml` (workspace dependency)
- `crates/trusty-agents/Cargo.toml`

(`trusty-code` and `trusty-mpm` use `{ workspace = true }` so they
pick up the bump automatically; `cto-assistant` has no version pin.)
`Cargo.lock` synced via `cargo update -p trusty-agents-common --precise 0.4.0`.

## CHANGELOG

Hit the known #2793 stopgap: `generate-changelog.sh --prepend` doesn't
merge with an existing hand-written `## [Unreleased]` draft. The repo
already had a duplicate — plus a much older, stale `## [Unreleased]`
section stranded below the `## [0.2.1]` heading (pre-existing debt,
same #2793 pattern). Merged all three into a single `## [Unreleased]`
section by hand, preserving every hand-written entry (nothing
deleted).

## Gates (crate-scoped, not --workspace)

- `cargo check -p trusty-agents-common` — clean
- `cargo test -p trusty-agents-common` — 329 passed; 0 failed
- `cargo fmt --check -p trusty-agents-common` — clean
- `bash scripts/check_line_cap.sh` — 0 violations
- `cargo check -p trusty-agents` (dependent crate) — clean
- `bash scripts/check-version-parity.sh` — 0 drifted (was 1)

## Test plan

- [x] Version-parity check passes locally against this branch
- [ ] "Version parity" workflow passes on `main` after merge (this
      workflow runs on `push: [main]` only, never on PRs — will verify
      post-merge)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools