### PR TITLE
feat(trusty-mpm): infer abbreviated tm subcommands via clap

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -11,6 +11,10 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - `tm` CLI accepts unambiguous abbreviated subcommands, e.g. `tm doc` for `tm doctor` ([#4398](https://github.com/bobmatnyc/trusty-tools/issues/4398))
   - Turns on clap's `infer_subcommands` for the top-level `Cli`, propagating to every nested action enum. Exact matches still win over prefix inference, so ambiguous-prefix pairs (`hook`/`hooks`, `project`/`projects`, `session`/`sessions`, `status`/`statusline`) keep resolving to their own exact command.
+
+### Fixed
+
+- Abbreviated-subcommand inference (#4398) made the hidden `internal-spawn-disclaimed` shim reachable via any unambiguous prefix (`tm int`, `tm inte`, `tm internal`), which would `posix_spawn` an arbitrary program with macOS TCC responsibility disclaimed. `main` now rejects any invocation whose raw first argv token isn't the exact, full subcommand name before the shim ever runs, while the daemon's own literal self-invocation keeps working unchanged.
 - JSON instruction manifest (schema v2) with owner language rules ([#4386](https://github.com/bobmatnyc/trusty-tools/pull/4386)) ([`838d001`](https://github.com/bobmatnyc/trusty-tools/commit/838d00150e4ac1d2f31e5748bf8a85c05b4e78e7))
   - Adds three owner language rules as inline `text` blocks: **Clickable
     References** (`core` — issue/PR/ticket/commit references always render as

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- `tm` CLI accepts unambiguous abbreviated subcommands, e.g. `tm doc` for `tm doctor` ([#4398](https://github.com/bobmatnyc/trusty-tools/issues/4398))
+  - Turns on clap's `infer_subcommands` for the top-level `Cli`, propagating to every nested action enum. Exact matches still win over prefix inference, so ambiguous-prefix pairs (`hook`/`hooks`, `project`/`projects`, `session`/`sessions`, `status`/`statusline`) keep resolving to their own exact command.
 - JSON instruction manifest (schema v2) with owner language rules ([#4386](https://github.com/bobmatnyc/trusty-tools/pull/4386)) ([`838d001`](https://github.com/bobmatnyc/trusty-tools/commit/838d00150e4ac1d2f31e5748bf8a85c05b4e78e7))
   - Adds three owner language rules as inline `text` blocks: **Clickable
     References** (`core` — issue/PR/ticket/commit references always render as

--- a/crates/trusty-mpm/src/bin/tm/cli/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/cli/mod.rs
@@ -59,13 +59,29 @@ pub(crate) const DEFAULT_ADDR: &str = trusty_mpm::core::DEFAULT_DAEMON_ADDR;
 /// When invoked without a subcommand (#1708) the guided default fires:
 /// the daemon's in-project spawn path is called for the current directory,
 /// reconnecting to an existing session or provisioning a new worktree.
+///
+/// Why (#4398): `infer_subcommands` lets users type any unambiguous prefix of
+/// a subcommand name (`tm sta` for `status`, `tm proj list` for `project
+/// list`) instead of the full spelling. clap applies this at all 3 nesting
+/// levels (top-level `Command`, and every nested action enum under
+/// `cli::actions`) from this single global setting. It is a separate matching
+/// path from the 5 existing `#[arg(short)]` option-short attributes, so there
+/// is zero collision risk with those. Exact matches always win over inferred
+/// prefixes, so the `hook`/`hooks`, `project`/`projects`, `session`/
+/// `sessions`, and `status`/`statusline` pairs keep resolving to their exact
+/// name rather than erroring as ambiguous. `-v` for `--version` and an
+/// explicit `sess` alias are deliberately out of scope here — see #4398.
+/// What: enables clap's automatic subcommand-prefix inference across the
+/// whole `tm` CLI surface.
+/// Test: `cli_infers_abbreviated_subcommands`, `cli_exact_match_wins_over_prefix_ambiguity`.
 #[derive(Debug, Parser)]
 #[command(
     name = "trusty-mpm",
     version,
     about = "trusty-mpm — unified binary",
     subcommand_required = false,
-    arg_required_else_help = false
+    arg_required_else_help = false,
+    infer_subcommands = true
 )]
 pub(crate) struct Cli {
     /// Base URL of the trusty-mpm daemon (used by the thin CLI subcommands).

--- a/crates/trusty-mpm/src/bin/tm/commands/spawn_disclaimed.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/spawn_disclaimed.rs
@@ -23,6 +23,34 @@
 
 use anyhow::Context as _;
 
+/// Whether the raw process argv shows this shim was invoked by its EXACT,
+/// full subcommand name — not an abbreviated prefix clap's
+/// `infer_subcommands` (#4398) resolved to it.
+///
+/// Why (#4431 critic review, HIGH): `infer_subcommands` makes clap resolve
+/// any unambiguous prefix of a subcommand name to that command, and it walks
+/// HIDDEN subcommands too — `#[command(hide = true)]` on
+/// `Command::InternalSpawnDisclaimed` only suppresses the name from
+/// `--help`, it does not exempt it from prefix matching. Since [`run`]
+/// unconditionally `posix_spawn`s `argv[0]` with macOS TCC responsibility
+/// disclaimed (#2997), letting an abbreviation (`tm int <program>`, `tm
+/// inte`, `tm internal`) reach it would spawn an arbitrary process through
+/// this internal, hidden escape hatch. `main` calls this BEFORE dispatching
+/// to [`run`], using the raw `std::env::args()` captured before clap ever
+/// ran inference — `argv[1]` is the first token the operator actually typed,
+/// at the position clap resolved to this variant.
+/// What: `true` only when `argv.get(1)` is exactly
+/// [`trusty_mpm::core::spawn_disclaim::PANE_DISCLAIM_SUBCOMMAND`].
+/// `disclaim_pane_command`'s own self-invocation always emits the full
+/// spelling, so this keeps that literal path working unchanged.
+/// Test: `invoked_literally_accepts_exact_name`,
+/// `invoked_literally_rejects_abbreviated_prefixes`,
+/// `invoked_literally_rejects_missing_token`.
+pub(crate) fn invoked_literally(argv: &[String]) -> bool {
+    argv.get(1).map(String::as_str)
+        == Some(trusty_mpm::core::spawn_disclaim::PANE_DISCLAIM_SUBCOMMAND)
+}
+
 /// Spawn `argv[0]` with `argv[1..]` disclaimed and exit with its status code.
 ///
 /// Why: this is the leaf of the #2997 fix — the one process that actually sets
@@ -85,5 +113,42 @@ mod tests {
             err.to_string().contains("requires a program"),
             "unexpected error: {err}"
         );
+    }
+
+    /// #4431 critic HIGH fix: the exact, full subcommand name — the only form
+    /// `disclaim_pane_command`'s own self-invocation ever emits — must keep
+    /// passing the guard.
+    #[test]
+    fn invoked_literally_accepts_exact_name() {
+        let argv = vec![
+            "tm".to_string(),
+            "internal-spawn-disclaimed".to_string(),
+            "claude".to_string(),
+            "-p".to_string(),
+        ];
+        assert!(invoked_literally(&argv));
+    }
+
+    /// #4431 critic HIGH fix: `infer_subcommands` (#4398) makes clap resolve
+    /// any of these abbreviated prefixes to `Command::InternalSpawnDisclaimed`
+    /// (hidden subcommands are inferred too) — the guard must reject every
+    /// one of them so none can reach the disclaimed-spawn leaf.
+    #[test]
+    fn invoked_literally_rejects_abbreviated_prefixes() {
+        for prefix in ["int", "inte", "internal"] {
+            let argv = vec!["tm".to_string(), prefix.to_string(), "claude".to_string()];
+            assert!(
+                !invoked_literally(&argv),
+                "abbreviated prefix {prefix:?} must not pass the literal-invocation guard"
+            );
+        }
+    }
+
+    /// A bare `tm` (no subcommand token at all) must not panic or vacuously
+    /// pass — `argv.get(1)` is `None`, which never equals the literal name.
+    #[test]
+    fn invoked_literally_rejects_missing_token() {
+        let argv = vec!["tm".to_string()];
+        assert!(!invoked_literally(&argv));
     }
 }

--- a/crates/trusty-mpm/src/bin/tm/main.rs
+++ b/crates/trusty-mpm/src/bin/tm/main.rs
@@ -208,8 +208,21 @@ async fn main() -> anyhow::Result<()> {
     // `posix_spawn` + wait that exits with the child's code and never talks to
     // the daemon. (Emitted into the pane command by
     // `trusty_mpm::core::spawn_disclaim::disclaim_pane_command`.)
-    if let Some(Command::InternalSpawnDisclaimed { argv }) = cli.command {
-        return commands::spawn_disclaimed::run(argv);
+    if let Some(Command::InternalSpawnDisclaimed { argv: spawn_argv }) = cli.command {
+        // #4398 HIGH (critic review on PR #4431): `infer_subcommands` makes
+        // clap resolve ANY unambiguous prefix of "internal-spawn-disclaimed"
+        // to this hidden variant — see `commands::spawn_disclaimed::
+        // invoked_literally`'s doc for the full rationale. Reject anything
+        // that didn't arrive via the exact, full spelling before ever
+        // reaching the disclaimed-spawn leaf.
+        if !commands::spawn_disclaimed::invoked_literally(&argv) {
+            eprintln!(
+                "error: '{}' must be invoked by its exact name, not an abbreviation",
+                trusty_mpm::core::spawn_disclaim::PANE_DISCLAIM_SUBCOMMAND
+            );
+            std::process::exit(2);
+        }
+        return commands::spawn_disclaimed::run(spawn_argv);
     }
 
     // Long-running daemon mode: init file-rotating tracing + bug-capture layer

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1103,6 +1103,83 @@ fn cli_parses_daemon_force() {
     }
 }
 
+/// Issue #4398: `infer_subcommands` lets an unambiguous prefix of a
+/// subcommand name stand in for the full spelling, at every nesting level.
+#[test]
+fn cli_infers_abbreviated_subcommands() {
+    // Top level, no nested action: "doc" only ever prefixes "doctor".
+    let cli = Cli::try_parse_from(["trusty-mpm", "doc"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Doctor {
+            prune_stale_skills: false
+        }
+    ));
+
+    // Top level, no other command starts with "heal".
+    let cli = Cli::try_parse_from(["trusty-mpm", "heal"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Health));
+
+    // Top level, no other command starts with "rest" ("register" is "reg").
+    let cli = Cli::try_parse_from(["trusty-mpm", "rest"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Restart));
+
+    // Inference also propagates into a nested action subcommand.
+    let cli = Cli::try_parse_from(["trusty-mpm", "gen", "cap"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Generate { .. }));
+
+    // Inference applies at the nested-action level too: "project ini" for
+    // "project init".
+    let cli = Cli::try_parse_from(["trusty-mpm", "project", "ini"]).unwrap();
+    match cli.command.unwrap() {
+        Command::Project {
+            action: ProjectAction::Init { dir },
+        } => assert_eq!(dir, None),
+        other => panic!("expected Command::Project(Init), got {other:?}"),
+    }
+}
+
+/// Issue #4398: `infer_subcommands` must never break an EXACT match, even
+/// when that exact name is also a valid prefix of a sibling command name
+/// (`hook`/`hooks`, `project`/`projects`, `session`/`sessions`,
+/// `status`/`statusline`). clap resolves exact matches before falling back
+/// to prefix inference, so all 8 of these keep resolving to their own
+/// command rather than erroring out as an ambiguous prefix.
+#[test]
+fn cli_exact_match_wins_over_prefix_ambiguity() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "status"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Status));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "statusline"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Statusline));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "hook"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Hook { pm_guard: false }
+    ));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "hooks", "clean"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Hooks { .. }));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "project", "list"]).unwrap();
+    assert!(matches!(
+        cli.command.unwrap(),
+        Command::Project {
+            action: ProjectAction::List
+        }
+    ));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "projects", "list"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Projects { .. }));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "session", "start"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Session { .. }));
+
+    let cli = Cli::try_parse_from(["trusty-mpm", "sessions", "start"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Sessions { .. }));
+}
+
 #[test]
 fn cli_parses_supervisor() {
     let cli = Cli::try_parse_from(["trusty-mpm", "supervisor"]).unwrap();

--- a/crates/trusty-mpm/src/bin/tm/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests.rs
@@ -1180,6 +1180,57 @@ fn cli_exact_match_wins_over_prefix_ambiguity() {
     assert!(matches!(cli.command.unwrap(), Command::Sessions { .. }));
 }
 
+/// #4431 critic HIGH fix: proves the vulnerability precondition AND the
+/// runtime guard together close the gap. clap's `infer_subcommands` still
+/// resolves every one of these abbreviated prefixes to the HIDDEN
+/// `Command::InternalSpawnDisclaimed` variant (`hide = true` only suppresses
+/// `--help`, it does not exempt a subcommand from prefix inference) — but
+/// `commands::spawn_disclaimed::invoked_literally`, which `main` calls on the
+/// RAW argv before ever reaching the disclaimed-spawn leaf, rejects every one
+/// of them because the operator did not type the exact, full subcommand
+/// name. The exact spelling still parses AND passes the guard, so
+/// `disclaim_pane_command`'s own literal self-invocation keeps working.
+#[test]
+fn cli_infers_internal_spawn_disclaimed_but_runtime_guard_rejects_abbreviations() {
+    for prefix in ["int", "inte", "internal"] {
+        let raw_argv: Vec<String> = vec!["trusty-mpm".into(), prefix.into(), "claude".into()];
+        let cli = Cli::try_parse_from(raw_argv.clone()).unwrap();
+        assert!(
+            matches!(cli.command, Some(Command::InternalSpawnDisclaimed { .. })),
+            "expected clap to still infer {prefix:?} to InternalSpawnDisclaimed"
+        );
+        assert!(
+            !crate::commands::spawn_disclaimed::invoked_literally(&raw_argv),
+            "the runtime guard must reject the abbreviated prefix {prefix:?}"
+        );
+    }
+
+    let raw_argv: Vec<String> = vec![
+        "trusty-mpm".into(),
+        "internal-spawn-disclaimed".into(),
+        "claude".into(),
+    ];
+    let cli = Cli::try_parse_from(raw_argv.clone()).unwrap();
+    assert!(matches!(
+        cli.command,
+        Some(Command::InternalSpawnDisclaimed { .. })
+    ));
+    assert!(crate::commands::spawn_disclaimed::invoked_literally(
+        &raw_argv
+    ));
+}
+
+/// #4431 critic MEDIUM: `tm ins` (an unambiguous prefix of `install` only —
+/// no other top-level command starts with "ins") must keep resolving to
+/// `Command::Install`, confirming the new disclaim-shim guard is scoped to
+/// that one hidden variant and does not collaterally affect ordinary
+/// abbreviation elsewhere on the CLI surface.
+#[test]
+fn cli_infers_ins_to_install_unaffected_by_disclaim_guard() {
+    let cli = Cli::try_parse_from(["trusty-mpm", "ins"]).unwrap();
+    assert!(matches!(cli.command.unwrap(), Command::Install { .. }));
+}
+
 #[test]
 fn cli_parses_supervisor() {
     let cli = Cli::try_parse_from(["trusty-mpm", "supervisor"]).unwrap();


### PR DESCRIPTION
## Summary
- Enables clap's `infer_subcommands` on the top-level `Cli` struct (`crates/trusty-mpm/src/bin/tm/cli/mod.rs`) so any unambiguous prefix of a subcommand name resolves (e.g. `tm doc` for `tm doctor`, `tm gen cap` for `tm generate capabilities`). This propagates automatically to every nested action enum (`ProjectAction`, `SessionAction`, etc).
- Exact matches still win over prefix inference, so the ambiguous-prefix pairs called out in the issue (`hook`/`hooks`, `project`/`projects`, `session`/`sessions`, `status`/`statusline`) keep resolving to their own exact command rather than erroring as ambiguous.
- Scope is deliberately limited to piece (1) from the issue. `-v` for `--version` and an explicit `sess` alias are called out in #4398 as separate one-way-door decisions and are NOT part of this PR.

Closes #4398

## Stacking note
This PR was originally stacked on #4422 (`fix/4397-daemon-guard-bare-invocation`) because both touched the `tm` clap command tree. #4422 has since squash-merged to `main` as `46e080ed` — this PR has been rebased onto `main` and retargeted; the diff now shows only this PR's change (96+/1-).

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo test -p trusty-mpm` (full surface, no `--lib`) — 4009 lib tests + all integration test binaries, 0 failed
- [x] New tests: `cli_infers_abbreviated_subcommands`, `cli_exact_match_wins_over_prefix_ambiguity`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
