### PR TITLE
fix(trusty-mpm): stop legacy .trusty-mpm/ files from shadowing unrelated CLAUDE.md overrides

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -119,6 +119,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   additionally filters the surfaced list to non-terminal states as defense in
   depth; and the boot-time reconcile sweep backfills (clears) the stale field
   on any terminal record persisted before this fix.
+- **An unrelated legacy `.trusty-mpm/` override file no longer shadows every
+  CLAUDE.md named-section override (closes
+  [#4399](https://github.com/bobmatnyc/trusty-tools/issues/4399)).**
+  Previously, if ANY ONE of the four replace-semantics legacy files
+  (`PM_INSTRUCTIONS_DEPLOYED.md`, `AGENT_DELEGATION.md`, `WORKFLOW.md`,
+  `MEMORY.md`) was present, the whole prompt fell back to the sectionless
+  legacy assembly, and every CLAUDE.md named-section override was reported
+  "not applied" — including sections the legacy file had nothing to do with
+  (an `AGENT_DELEGATION.md` file silently dropped a `WORKFLOW` override
+  authored in `CLAUDE.md`). `WORKFLOW`, `MEMORY` and `AGENT-DELEGATION` are
+  now independently addressable on that legacy path too: a named override for
+  one of those sections lands unless the project's own same-section legacy
+  file is what forced the branch, in which case that file still wins,
+  unchanged. `IDENTITY`/`CORE`/`SEARCH` have no independent slot in the legacy
+  string assembly and remain reported as unapplied, never silently dropped.
 - **A corrupted bundled agent is re-deployed instead of frozen forever (closes
   [#4408](https://github.com/bobmatnyc/trusty-tools/issues/4408)).** When the
   deployed copy of a bundled agent drifts from the checksum the deploy manifest

--- a/crates/trusty-mpm/src/core/claude_md_sections.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections.rs
@@ -501,8 +501,21 @@ pub fn strip_marker_blocks(text: &str) -> String {
 /// Quietly is the part that is unacceptable — that is #381 again. The removal of
 /// the legacy files is a later step of #4183; until then this says so, loudly,
 /// once per override.
+///
+/// #4399: the legacy string assembly is NOT entirely sectionless — `WORKFLOW`,
+/// `MEMORY` and `AGENT-DELEGATION` are independently addressable there too, so
+/// the caller ([`crate::core::instruction_overrides::resolve_pm_prompt_with_roster`])
+/// applies a named override for any of those three sections that has no
+/// same-section legacy file shadowing it, and passes THIS function only the
+/// overrides that genuinely could not land — a same-section legacy-file
+/// collision, or `IDENTITY`/`CORE`/`SEARCH`, which have no slot at all on this
+/// path. This function itself is unchanged: it still warns, unconditionally,
+/// about every override in the slice it is given.
+///
 /// What: one `warn!` per accepted override, naming the file and the section.
-/// Test: `named_sections_are_reported_unapplied_on_the_legacy_path`.
+/// Test: `an_unrelated_legacy_file_does_not_shadow_a_named_section_override`,
+/// `a_same_section_legacy_file_still_wins_over_a_named_override_and_is_reported`,
+/// `identity_core_and_search_stay_reported_unapplied_on_the_legacy_path`.
 pub fn warn_unapplied(scanned: &ProjectOverrides) {
     for applied in &scanned.overrides {
         tracing::warn!(

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -836,6 +836,23 @@ fn a_same_section_legacy_file_still_wins_over_a_named_override_and_is_reported()
         !prompt.contains("NAMED_WORKFLOW"),
         "the named override cannot also apply once its own section has a legacy file"
     );
+    // Not just "one override was scanned" — the SPECIFIC section that lost to
+    // the legacy file, so a miscounted or wrong-section regression cannot pass
+    // this test by accident. `warn_unapplied` is only ever handed the entries
+    // `resolve_pm_prompt_with_roster` still considers unapplied, and this is
+    // that entry: same section (`Workflow`), same host (`CLAUDE.md`).
+    let scanned = scan_project(tmp.path());
+    assert_eq!(scanned.overrides.len(), 1, "the named override was scanned");
+    assert_eq!(
+        scanned.overrides[0].section,
+        SectionId::Workflow,
+        "the reported override is the WORKFLOW one the legacy file shadowed"
+    );
+    assert_eq!(
+        scanned.overrides[0].host,
+        tmp.path().join("CLAUDE.md"),
+        "the reported override was authored in CLAUDE.md, not a legacy file"
+    );
 }
 
 #[test]
@@ -912,10 +929,19 @@ fn identity_core_and_search_stay_reported_unapplied_on_the_legacy_path() {
     let (prompt, source) = resolve(tmp.path());
     assert_eq!(source, PromptSource::Legacy);
     assert!(!prompt.contains("NAMED_CORE"));
+    // Not just "one override was scanned" — the SPECIFIC section that has no
+    // slot on this path, so a miscounted or wrong-section regression cannot
+    // pass this test by accident.
+    let scanned = scan_project(tmp.path());
     assert_eq!(
-        scan_project(tmp.path()).overrides.len(),
+        scanned.overrides.len(),
         1,
         "and it is still reported, never silently"
+    );
+    assert_eq!(
+        scanned.overrides[0].section,
+        SectionId::Core,
+        "the reported override is the CORE one this legacy path cannot honour"
     );
 }
 

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -15,7 +15,7 @@
 use super::*;
 use crate::core::bundled_pm_package::bundled_fallback_package;
 use crate::core::instruction_overrides::{
-    FILE_AGENT_DELEGATION, FILE_INSTRUCTIONS, OVERRIDE_DIR_NAME, PromptSource,
+    FILE_AGENT_DELEGATION, FILE_INSTRUCTIONS, FILE_WORKFLOW, OVERRIDE_DIR_NAME, PromptSource,
     resolve_pm_prompt_with_roster,
 };
 use crate::core::instruction_package::{Generator, InstructionBlock, Join};
@@ -777,24 +777,145 @@ fn tm_never_writes_claude_md() {
 }
 
 #[test]
-fn named_sections_are_reported_unapplied_on_the_legacy_path() {
-    // A project still carrying a legacy `.trusty-mpm/` override file composes
-    // through the sectionless legacy assembly, so its named sections cannot
-    // land. That must be loud (`warn_unapplied`) and must not corrupt the
-    // prompt — never silent, which is the #381 failure.
+fn an_unrelated_legacy_file_does_not_shadow_a_named_section_override() {
+    // #4399 REGRESSION GATE (this test previously pinned the bug it now
+    // guards against). A project carrying a legacy `.trusty-mpm/` override
+    // file composes through the sectionless legacy assembly — but an
+    // unrelated legacy file (here `AGENT_DELEGATION.md`) must not shadow a
+    // CLAUDE.md named override for a DIFFERENT section (here `WORKFLOW`):
+    // that override has nothing to do with the file that forced this branch,
+    // so it must still land.
     let tmp = TempDir::new().unwrap();
     write_claude_md(tmp.path(), &block(SectionId::Workflow, "NAMED_WORKFLOW"));
     write_trusty_file(tmp.path(), FILE_AGENT_DELEGATION, "# Custom Routing\n\nX\n");
 
     let (prompt, source) = resolve(tmp.path());
     assert_eq!(source, PromptSource::Legacy);
-    assert!(!prompt.contains("NAMED_WORKFLOW"));
-    assert!(prompt.contains("# PM Workflow Configuration"));
+    assert!(
+        prompt.contains("NAMED_WORKFLOW"),
+        "an unrelated legacy file must not drop this override: {prompt}"
+    );
+    assert!(
+        !prompt.contains("# PM Workflow Configuration"),
+        "the bundled workflow must be replaced by the named override"
+    );
+    assert!(
+        prompt.contains("X"),
+        "the unrelated legacy file still applies to ITS OWN section"
+    );
     assert!(prompt.contains("# BASE_PM Framework Floor"));
     assert_eq!(
         scan_project(tmp.path()).overrides.len(),
         1,
-        "and it is reported"
+        "the named override was scanned"
+    );
+}
+
+#[test]
+fn a_same_section_legacy_file_still_wins_over_a_named_override_and_is_reported() {
+    // The flip side of #4399: a legacy file for the SAME section a CLAUDE.md
+    // marker names is a genuine, deliberate collision — the legacy file (the
+    // more specific, project-authored mechanism for that exact section) still
+    // wins, unchanged from before. The named override is correctly declined,
+    // and that decline is still reported — never silently.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(tmp.path(), &block(SectionId::Workflow, "NAMED_WORKFLOW"));
+    write_trusty_file(
+        tmp.path(),
+        FILE_WORKFLOW,
+        "# Legacy Workflow\n\nLEGACY_WORKFLOW\n",
+    );
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(
+        prompt.contains("LEGACY_WORKFLOW"),
+        "the same-section legacy file wins"
+    );
+    assert!(
+        !prompt.contains("NAMED_WORKFLOW"),
+        "the named override cannot also apply once its own section has a legacy file"
+    );
+}
+
+#[test]
+fn an_unrelated_legacy_file_does_not_shadow_a_named_memory_override() {
+    // #4399: same guarantee for MEMORY as for WORKFLOW.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &block(SectionId::Memory, "Recall from the `team` palace first."),
+    );
+    write_trusty_file(
+        tmp.path(),
+        FILE_WORKFLOW,
+        "# Custom Workflow\n\nTWO_PHASE_ONLY\n",
+    );
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(
+        prompt.contains("Recall from the `team` palace first."),
+        "an unrelated WORKFLOW.md must not drop the named MEMORY override: {prompt}"
+    );
+    assert!(prompt.contains("## Memory Behavior (project override)"));
+}
+
+#[test]
+fn an_unrelated_legacy_file_does_not_shadow_a_named_delegation_override() {
+    // #4399: same guarantee for AGENT-DELEGATION, including the roster
+    // survival rule (#4196) — the named override replaces the bundled
+    // doctrine, but the LIVE roster (host-computed, not authored) still
+    // follows, exactly as it does on the packaged path.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(
+        tmp.path(),
+        &block(SectionId::AgentDelegation, "# Custom Routing\n\nROUTE_ALL"),
+    );
+    write_trusty_file(
+        tmp.path(),
+        FILE_WORKFLOW,
+        "# Custom Workflow\n\nTWO_PHASE_ONLY\n",
+    );
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(
+        prompt.contains("ROUTE_ALL"),
+        "the named override lands: {prompt}"
+    );
+    assert!(
+        !prompt.contains("## Make / Mise Command Routing"),
+        "the bundled doctrine is replaced"
+    );
+    assert!(
+        prompt.contains("## Delegation Authority") && prompt.contains("### ticketing"),
+        "the LIVE roster must still be emitted: {prompt}"
+    );
+    assert!(
+        prompt.contains("TWO_PHASE_ONLY"),
+        "the unrelated legacy file still applies to ITS OWN section"
+    );
+}
+
+#[test]
+fn identity_core_and_search_stay_reported_unapplied_on_the_legacy_path() {
+    // Unlike WORKFLOW/MEMORY/AGENT-DELEGATION, these sections have no
+    // independent slot in the string-assembled legacy assembly — they live
+    // inside the single opaque `pm_instructions()` blob. A legacy file
+    // forcing that assembly genuinely cannot honour them, and that must stay
+    // loud (`warn_unapplied`), never silently dropped without a trace.
+    let tmp = TempDir::new().unwrap();
+    write_claude_md(tmp.path(), &block(SectionId::Core, "NAMED_CORE"));
+    write_trusty_file(tmp.path(), FILE_AGENT_DELEGATION, "# Custom Routing\n\nX\n");
+
+    let (prompt, source) = resolve(tmp.path());
+    assert_eq!(source, PromptSource::Legacy);
+    assert!(!prompt.contains("NAMED_CORE"));
+    assert_eq!(
+        scan_project(tmp.path()).overrides.len(),
+        1,
+        "and it is still reported, never silently"
     );
 }
 

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -14,17 +14,27 @@
 //! the defaults for any section that has no override.
 //! Named sections (#4183 / #4286): a project may instead mark out an override
 //! inside its `CLAUDE.md`, read by [`crate::core::claude_md_sections`]. Those
-//! apply on the packaged composition path only — the legacy string assembly has
-//! no sections to replace — so an override that cannot be honoured is reported
+//! compose cleanly on the packaged path; on the legacy string assembly (forced
+//! by the presence of any of the five files below) `WORKFLOW`, `MEMORY` and
+//! `AGENT-DELEGATION` are still individually addressable slots, so a named
+//! override for one of THOSE sections lands there too, UNLESS the project's own
+//! same-section legacy file is what forced the branch — that file still wins
+//! (#4399: an unrelated legacy file must never shadow an unrelated named
+//! override). `IDENTITY`/`CORE`/`SEARCH` have no such slot — they live inside
+//! the single opaque `pm_instructions()` blob — so those genuinely cannot be
+//! honoured on this path, and, like a same-section collision, that is reported
 //! by `warn_unapplied` rather than dropped in silence. The five override file
 //! constants below are unchanged and keep working.
 //!
 //! Test: the `tests` module exercises every documented file, the BASE_PM floor
 //! invariant, and the robustness fallbacks (missing/empty/unreadable files);
-//! `claude_md_sections_tests.rs` covers the named-section wiring end to end.
+//! `claude_md_sections_tests.rs` covers the named-section wiring end to end,
+//! including the #4399 non-shadowing guarantee.
 
 use std::path::Path;
 
+use crate::core::claude_md_sections::ProjectOverrides;
+use crate::core::instruction_package::SectionId;
 use crate::core::instruction_pipeline::{
     AGENT_DELEGATION, SECTION_SEPARATOR, base_pm, pm_instructions,
 };
@@ -124,6 +134,14 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 /// replaceable, preserving the framework-floor guarantee `BASE_PM.md` itself
 /// states. Sections are joined with [`SECTION_SEPARATOR`].
 ///
+/// #4399: within branch (2), "WORKFLOW (override or bundled)" and its two
+/// siblings each additionally fall back to a CLAUDE.md named-section override
+/// for that SAME section before reaching the bundled default — so a legacy
+/// file that forces this branch for one section (say `AGENT_DELEGATION.md`)
+/// can no longer shadow a CLAUDE.md override authored for a DIFFERENT,
+/// unrelated section (say `WORKFLOW`). A legacy file still wins over a named
+/// override for its OWN section — that collision is deliberate and unchanged.
+///
 /// Per-project stack profile: in **both** branches an auto-derived
 /// [`crate::core::stack_profile::stack_profile_section`] block is folded in right
 /// after the PM body. It states the project's detected stack (or a neutral
@@ -159,7 +177,12 @@ fn read_override(dir: &Path, name: &str) -> Option<String> {
 /// `pm_deployed_replaces_body_but_keeps_base_floor`,
 /// `memory_override_is_slotted_after_pm_instructions`,
 /// `stack_profile_present_when_detected`, `stack_profile_neutral_when_undetected`,
-/// and the robustness tests.
+/// the robustness tests, and (#4399, in `claude_md_sections_tests.rs`)
+/// `an_unrelated_legacy_file_does_not_shadow_a_named_section_override`,
+/// `a_same_section_legacy_file_still_wins_over_a_named_override_and_is_reported`,
+/// `an_unrelated_legacy_file_does_not_shadow_a_named_memory_override`,
+/// `an_unrelated_legacy_file_does_not_shadow_a_named_delegation_override`,
+/// `identity_core_and_search_stay_reported_unapplied_on_the_legacy_path`.
 pub fn resolve_pm_prompt(project_dir: &Path) -> String {
     let (prompt, source) = resolve_pm_prompt_with_source(project_dir);
     // `info!`, deliberately: this is the operator-visible record of WHICH
@@ -282,11 +305,43 @@ pub(crate) fn resolve_pm_prompt_with_roster(
         .map(|body| crate::core::claude_md_sections::strip_marker_blocks(&body))
         .filter(|body| !body.is_empty());
 
+    // #4399: which legacy file, if any, forced this branch is tracked per
+    // section BEFORE any of the three `Option`s below are consumed, so the
+    // final `warn_unapplied` report can tell "shadowed by this project's own
+    // same-section legacy file" (unavoidable — the file IS the override) apart
+    // from "shadowed only because an UNRELATED legacy file forced this whole
+    // branch" (the #4399 bug: that must not happen any more).
+    let workflow_has_legacy_file = workflow_override.is_some();
+    let memory_has_legacy_file = memory_override.is_some();
+    let delegation_has_legacy_file = delegation_override.is_some();
+
+    // A CLAUDE.md named-section override for a section with NO active
+    // same-section legacy file must still land, even though an unrelated
+    // legacy file forced this string-assembled branch (#4399) — otherwise, for
+    // example, an `AGENT_DELEGATION.md` file silently drops a `WORKFLOW` named
+    // override that has nothing to do with it. Only the three sections this
+    // legacy assembly can independently address (`Workflow`, `Memory`,
+    // `AgentDelegation`) are representable here; `Identity`/`Core`/`Search`
+    // stay inside the opaque `pm_instructions()` blob and remain reported as
+    // unapplied on this path, exactly as before.
+    let named_section = |id: SectionId| {
+        named
+            .overrides
+            .iter()
+            .find(|o| o.section == id)
+            .map(|o| o.body.clone())
+    };
+    let named_workflow = named_section(SectionId::Workflow);
+    let named_memory = named_section(SectionId::Memory);
+    let named_delegation = named_section(SectionId::AgentDelegation);
+
     let delegation = match delegation_override {
         // See #4183 — configuration 2 is deliberately still on the legacy path:
         // an `AGENT_DELEGATION.md` override replaces the whole section and so
         // never consumes the computed roster, which `RosterNotConsumed` exists
-        // to forbid. Follow-up on the epic, not a check to relax.
+        // to forbid. Follow-up on the epic, not a check to relax. It also wins
+        // over a same-section CLAUDE.md override — one file, one winner, same
+        // as before #4399.
         Some(body) => body,
         None => {
             let roster = roster_source();
@@ -340,18 +395,45 @@ pub(crate) fn resolve_pm_prompt_with_roster(
                 }
             }
 
-            delegation_with_roster(roster.as_deref())
+            // #4399: no legacy `AGENT_DELEGATION.md` claimed this section, so a
+            // CLAUDE.md `AGENT-DELEGATION` named override (if any) must still
+            // apply here — an unrelated `WORKFLOW.md`/`MEMORY.md` legacy file
+            // forcing this branch is not a reason to fall back to the bundled
+            // doctrine.
+            delegation_with_named_override(named_delegation.as_deref(), roster.as_deref())
         }
     };
 
     // The bundled workflow comes from the manifest, not the raw section constant:
     // the manifest appends the opportunistic-fix rule as its own block, and a
     // project that overrides nothing must receive the identical bytes here and on
-    // the packaged path (#4318).
+    // the packaged path (#4318). #4399: a same-section `WORKFLOW.md` still wins;
+    // otherwise an unrelated legacy file must not drop a named `WORKFLOW` override.
     let workflow = workflow_override
+        .or(named_workflow)
         .unwrap_or_else(|| crate::core::instruction_pipeline::workflow_section().to_string());
+    // #4399: same rule for `MEMORY.md` versus a named `MEMORY` override.
+    let memory_override = memory_override.or(named_memory);
 
-    crate::core::claude_md_sections::warn_unapplied(&named);
+    // Only report a named override as genuinely unapplied: a same-section
+    // legacy file legitimately wins (that section IS what the file replaces),
+    // and `Identity`/`Core`/`Search` have no slot in this string assembly. Any
+    // OTHER section landed above and must not be reported as dropped.
+    let unapplied = ProjectOverrides {
+        overrides: named
+            .overrides
+            .iter()
+            .filter(|o| match o.section {
+                SectionId::Workflow => workflow_has_legacy_file,
+                SectionId::Memory => memory_has_legacy_file,
+                SectionId::AgentDelegation => delegation_has_legacy_file,
+                _ => true,
+            })
+            .cloned()
+            .collect(),
+        diagnostics: Vec::new(),
+    };
+    crate::core::claude_md_sections::warn_unapplied(&unapplied);
     (
         assemble_sections(stack, memory_override, workflow, delegation, addendum),
         PromptSource::Legacy,
@@ -464,6 +546,35 @@ pub(crate) fn delegation_with_roster(roster: Option<&str>) -> String {
             roster.trim()
         ),
         None => AGENT_DELEGATION.trim().to_string(),
+    }
+}
+
+/// The AGENT-DELEGATION section body when no legacy `AGENT_DELEGATION.md` file
+/// forced full replacement, honoring a CLAUDE.md named-section override if the
+/// project authored one (#4399).
+///
+/// Why: an unrelated legacy file (`WORKFLOW.md`/`MEMORY.md`) can force
+/// [`resolve_pm_prompt_with_roster`] onto this string-assembled branch even
+/// though the project never touched `AGENT_DELEGATION.md`. Before #4399 that
+/// meant a CLAUDE.md `AGENT-DELEGATION` override was silently dropped in favor
+/// of [`delegation_with_roster`]'s bundled doctrine — the project's override
+/// was declined for a reason that has nothing to do with delegation. This
+/// mirrors [`crate::core::instruction_package::InstructionPackage::with_overrides`]'s
+/// authored/generated split for the SAME section on the packaged path: the
+/// override replaces the bundled doctrine (and its roster-precedence note),
+/// while the live roster — host-computed, never authored by a project — still
+/// follows when any agent is deployed.
+///
+/// What: `Some(body)` returns `body` (trimmed), followed by the roster when
+/// `roster` is `Some`; `None` defers to [`delegation_with_roster`] unchanged.
+/// Test: `named_agent_delegation_override_applies_when_an_unrelated_legacy_file_forces_the_legacy_path`.
+fn delegation_with_named_override(named_override: Option<&str>, roster: Option<&str>) -> String {
+    match named_override {
+        Some(body) => match roster {
+            Some(roster) => format!("{}\n\n{}", body.trim(), roster.trim()),
+            None => body.trim().to_string(),
+        },
+        None => delegation_with_roster(roster),
     }
 }
 

--- a/crates/trusty-mpm/src/core/instruction_overrides.rs
+++ b/crates/trusty-mpm/src/core/instruction_overrides.rs
@@ -567,7 +567,8 @@ pub(crate) fn delegation_with_roster(roster: Option<&str>) -> String {
 ///
 /// What: `Some(body)` returns `body` (trimmed), followed by the roster when
 /// `roster` is `Some`; `None` defers to [`delegation_with_roster`] unchanged.
-/// Test: `named_agent_delegation_override_applies_when_an_unrelated_legacy_file_forces_the_legacy_path`.
+/// Test: `an_unrelated_legacy_file_does_not_shadow_a_named_delegation_override`
+/// (`claude_md_sections_tests.rs`).
 fn delegation_with_named_override(named_override: Option<&str>, roster: Option<&str>) -> String {
     match named_override {
         Some(body) => match roster {


### PR DESCRIPTION
## Summary

- Any one of the four replace-semantics legacy files (`PM_INSTRUCTIONS_DEPLOYED.md`, `AGENT_DELEGATION.md`, `WORKFLOW.md`, `MEMORY.md`) forced `resolve_pm_prompt_with_roster` onto the sectionless legacy string assembly, which dropped **every** CLAUDE.md named-section override project-wide — including sections the legacy file had nothing to do with. An `AGENT_DELEGATION.md` file could silently kill a `WORKFLOW` override authored in `CLAUDE.md`.
- `WORKFLOW`, `MEMORY` and `AGENT-DELEGATION` are now independently addressable on the legacy assembly too: a CLAUDE.md named override for one of those sections lands unless the project's own same-section legacy file is what forced the branch — that file still wins, unchanged (one file, one winner, same as before).
- `IDENTITY`/`CORE`/`SEARCH` have no independent slot in the opaque `pm_instructions()` blob on this path and remain reported as unapplied via `warn_unapplied` — never silently dropped, consistent with the module's "never fail closed" doctrine.
- The delegation section reuses the same authored/generated split `InstructionPackage::with_overrides` already uses on the packaged path: a named `AGENT-DELEGATION` override replaces the bundled doctrine, but the live agent roster (host-computed, not authored) still follows when any agent is deployed (#4196).

Scope note: retiring the legacy files outright, or deciding the fate of `.trusty-mpm/INSTRUCTIONS.md` as a second customization surface, is explicitly left to a separate decision per the issue — this PR only fixes the silent cross-section shadowing.

## Test plan

- [x] `cargo fmt --check -p trusty-mpm`
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- [x] `cargo test -p trusty-mpm` (full suite, fresh build) — 4013 lib tests + all integration test binaries, 0 failed
- [x] Rewrote the pinned regression test that previously asserted the bug (`named_sections_are_reported_unapplied_on_the_legacy_path` → `an_unrelated_legacy_file_does_not_shadow_a_named_section_override`) plus 4 new tests covering: same-section collision still wins, MEMORY override, AGENT-DELEGATION override with roster preserved, and IDENTITY/CORE/SEARCH staying reported-unapplied.

Closes #4399

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools