### PR TITLE
feat(trusty-code): wire the `tcode tui` subcommand (DOC-50 AC-2.4)

### DIFF
--- a/crates/trusty-code/CHANGELOG.md
+++ b/crates/trusty-code/CHANGELOG.md
@@ -25,6 +25,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`tcode tui` — the TUI REPL is reachable from the CLI (#4424, DOC-50 §4.1 /
+  AC-2.4).** Every DOC-50 MVP slice was merged, but `CodeEngine` had zero
+  production call sites: the whole TUI existed only under `cargo test`. The new
+  subcommand discovers a running `tcode serve --http` daemon (`TCODE_DAEMON_URL`
+  -> `http_addr` file -> `/health` liveness ping), then hands `CodeEngine` to
+  `trusty_tui::run::run`. `--project` is optional (omit for a projectless
+  session) and is canonicalized at the CLI boundary. Discovery runs BEFORE the
+  alternate screen is entered, so a missing daemon prints an actionable
+  `tcode tui: no tcode daemon found — start one with \`tcode serve --http\` …`
+  and exits nonzero rather than flashing a TUI. This MVP does not auto-spawn a
+  daemon (deliberately deferred, DOC-50 §4.1).
+
 - **`Event::AgentMessageDelta` now has a producer (streaming epic #3696,
   Gap A / Slice 1).** The event contract landed in #3701, but no production
   code ever constructed it — `AgentMessageDelta` existed only in `events.rs`

--- a/crates/trusty-code/src/cli/mod.rs
+++ b/crates/trusty-code/src/cli/mod.rs
@@ -17,6 +17,11 @@
 //! [`cancel::run`], [`transcript::run`], and (#3296)
 //! [`workstream::list`]/[`workstream::get`]/[`workstream::create`]/
 //! [`workstream::activate`]/[`workstream::deactivate`]/[`workstream::close`].
+//! (#4424) [`tui::run`] is the one member that is NOT a JSON-RPC-over-stdio
+//! translator: it is the launch point for the interactive TUI REPL, which
+//! talks to a long-lived `tcode serve --http` daemon instead. It lives here
+//! anyway because it is the same KIND of thing — argument-shaped setup plus
+//! a handoff, with every decision made elsewhere (see its module docs).
 //! Test: each submodule's own doc comments note its coverage; the full
 //! spawn+wire behaviour is covered end-to-end by `tests/cli_e2e.rs` against
 //! the real `tcode` binary — these handlers are too thin to usefully unit
@@ -29,4 +34,5 @@ pub mod run_task;
 pub mod session;
 pub mod tcode_exe;
 pub mod transcript;
+pub mod tui;
 pub mod workstream;

--- a/crates/trusty-code/src/cli/tui.rs
+++ b/crates/trusty-code/src/cli/tui.rs
@@ -1,0 +1,136 @@
+//! `tcode tui` — launch the interactive TUI REPL against a running
+//! `tcode serve --http` daemon (issue #4424; DOC-50 §4.1, AC-2.4).
+//!
+//! Why: every DOC-50 MVP slice landed — the shared `trusty-tui` framework
+//! (event loop, generalized `ReplApp`, widgets) and
+//! `trusty_code::tui_client::CodeEngine` (the `TuiEngine` impl) — but
+//! nothing ever CONSTRUCTED a `CodeEngine` outside tests, so the REPL was
+//! unreachable from a user's shell. This module is that missing integration
+//! point and nothing more: it owns no REPL behaviour, no rendering, and no
+//! daemon logic, matching `crate::cli`'s "translate CLI args into a call,
+//! decisions belong elsewhere" contract.
+//! What: [`run`] resolves the optional project path, discovers a LIVE daemon
+//! through `tui_client::discovery` (`TCODE_DAEMON_URL` -> the `http_addr`
+//! discovery file -> a `GET /health` liveness ping), and hands the resulting
+//! `CodeEngine` to `trusty_tui::run::run` together with the shared
+//! `ReplApp` model, its reducer (`trusty_tui::app::apply`), and its renderer
+//! (`trusty_tui::layout::draw`). MVP assumes an ALREADY-RUNNING
+//! `tcode serve --http`: auto-spawning one is explicitly deferred (DOC-50
+//! §4.1 MVP scope), so a missing daemon surfaces `DiscoveryError`'s
+//! actionable message and exits rather than starting anything. Discovery
+//! deliberately runs BEFORE `trusty_tui::run::run` enters the alternate
+//! screen, so that message lands on a normal terminal instead of flashing
+//! behind a TUI that is about to tear itself down.
+//! Test: `tui_tests::*` covers the pure project-resolution helper;
+//! `tests/cli_e2e.rs::{tui_subcommand_is_listed_in_help,
+//! tui_without_a_reachable_daemon_errors_cleanly}` cover the CLI surface and
+//! the no-daemon path against the REAL binary. The launch path past
+//! discovery needs a real TTY (`trusty_tui::TerminalGuard::enter`) plus a
+//! live daemon, so it is verified by running `tcode tui` by hand; the engine
+//! half is already covered end-to-end by `tests/tui_client_engine.rs`.
+
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use trusty_code::tui_client::CodeEngine;
+use trusty_tui::ReplApp;
+
+/// Product label for the banner identity line and the `[tcode] ` status
+/// prefix `ReplApp::new` derives from it.
+const PRODUCT_LABEL: &str = "tcode";
+
+/// Launch the TUI REPL, returning once the user quits (or immediately with
+/// an actionable error if no live daemon can be found).
+///
+/// Why/What/Test: see the module docs — this function IS the module.
+/// `project` is `Option` because a projectless session is a first-class
+/// state (`session.create` without a `project`), not a degraded one.
+pub async fn run(project: Option<PathBuf>) -> Result<()> {
+    let project = resolve_project(project)?;
+    // #4424: the first production construction of `CodeEngine` — before this
+    // line the whole TUI stack was reachable only from tests.
+    let engine = CodeEngine::discover(project).await?;
+    let app = ReplApp::new(PRODUCT_LABEL, user_label());
+    trusty_tui::run::run(
+        Arc::new(engine),
+        app,
+        trusty_tui::app::apply,
+        trusty_tui::layout::draw,
+    )
+    .await
+}
+
+/// Canonicalize `--project` when given, so the daemon receives an absolute
+/// path and an unusable one fails HERE (with the flag's name in the
+/// message) rather than as a confusing `-32003 invalid_argument` from
+/// `session.create` after the TUI has already started.
+fn resolve_project(project: Option<PathBuf>) -> Result<Option<PathBuf>> {
+    project
+        .map(|p| {
+            p.canonicalize()
+                .with_context(|| format!("invalid --project path '{}'", p.display()))
+        })
+        .transpose()
+}
+
+/// Name shown on the banner's `{user} · tcode` identity line — `$USER`, or a
+/// generic fallback. Mirrors tagent's `repl::run` derivation so both REPLs
+/// label the human the same way.
+fn user_label() -> String {
+    label_or_default(std::env::var("USER").ok())
+}
+
+/// The `$USER`-to-label rule, split out from [`user_label`] so it is
+/// testable without mutating process-global environment state.
+fn label_or_default(raw: Option<String>) -> String {
+    raw.filter(|u| !u.trim().is_empty())
+        .unwrap_or_else(|| "user".to_string())
+}
+
+#[cfg(test)]
+mod tui_tests {
+    use super::*;
+
+    /// Omitting `--project` stays projectless — never silently defaults to
+    /// the current directory (which would bind a session to whatever
+    /// directory the operator happened to launch from).
+    #[test]
+    fn resolve_project_none_stays_projectless() {
+        assert!(resolve_project(None).expect("resolve").is_none());
+    }
+
+    /// A real directory is canonicalized to an absolute path.
+    #[test]
+    fn resolve_project_canonicalizes_a_real_directory() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let resolved = resolve_project(Some(dir.path().to_path_buf()))
+            .expect("resolve")
+            .expect("some");
+        assert!(resolved.is_absolute());
+        assert_eq!(resolved, dir.path().canonicalize().expect("canonicalize"));
+    }
+
+    /// A path that does not exist is rejected with a message naming the
+    /// flag and the offending path.
+    #[test]
+    fn resolve_project_rejects_a_missing_path() {
+        let missing = std::env::temp_dir().join("tcode-tui-4424-does-not-exist");
+        let err = resolve_project(Some(missing.clone())).expect_err("must reject");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("invalid --project path"), "{rendered}");
+        assert!(
+            rendered.contains(&missing.display().to_string()),
+            "{rendered}"
+        );
+    }
+
+    /// The banner identity label is never empty, even with `$USER` unset or
+    /// blank (the banner would otherwise render a bare `· tcode`).
+    #[test]
+    fn label_or_default_falls_back_when_unset_or_blank() {
+        assert_eq!(label_or_default(None), "user");
+        assert_eq!(label_or_default(Some("   ".to_string())), "user");
+        assert_eq!(label_or_default(Some("masa".to_string())), "masa");
+    }
+}

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -17,7 +17,11 @@
 //! `trusty_code::serve::{run_stdio, run_http}` for its two transports.
 //! `run-workflow` remains a stub. `workstream` (`ws` alias, #3296, DOC-48
 //! §5.4) is the same thin-client shape over `workstream.*` — see
-//! [`WorkstreamCommand`] and `crate::cli::workstream`.
+//! [`WorkstreamCommand`] and `crate::cli::workstream`. `tui` (#4424, DOC-50
+//! §4.1/AC-2.4) is the odd one out: instead of spawning its own ephemeral
+//! `--stdio` child, it attaches to an ALREADY-RUNNING `tcode serve --http`
+//! daemon and hands `trusty_code::tui_client::CodeEngine` to
+//! `trusty_tui::run::run` — see `crate::cli::tui`.
 //!
 //! Test: `cargo run -p trusty-code -- --version` must exit 0 and print the
 //! crate version. The thin-client subcommands are covered end-to-end by
@@ -105,6 +109,25 @@ enum Command {
         /// the port discarded.
         #[arg(long, value_name = "PORT", requires = "http", conflicts_with = "stdio")]
         port: Option<u16>,
+    },
+
+    /// Launch the interactive TUI REPL against a running `tcode serve --http`
+    /// daemon (#4424; DOC-50 §4.1, AC-2.4).
+    ///
+    /// The daemon is located by `TCODE_DAEMON_URL`, else the `http_addr`
+    /// discovery file, and is liveness-pinged before use. This MVP does NOT
+    /// auto-spawn one (deliberately deferred, DOC-50 §4.1): start
+    /// `tcode serve --http` first, or the command exits with an actionable
+    /// message. See `crate::cli::tui` for the wiring.
+    Tui {
+        /// Path to the project root the REPL's session binds to.
+        ///
+        /// OPTIONAL: omit it for a PROJECTLESS session — the same
+        /// first-class state `serve` without `--project` and `session.create`
+        /// without a `project` already support. Must name an existing
+        /// directory when given.
+        #[arg(long, short, value_name = "PATH")]
+        project: Option<PathBuf>,
     },
 
     /// Create (or target) a session, run a task through it via the daemon's
@@ -355,6 +378,11 @@ async fn main() -> Result<()> {
             http,
             port,
         } => run_serve(project, stdio, http, port).await,
+
+        // #4424: the launch point for the TUI REPL — reuses `run_thin_client`
+        // so a discovery failure prints `tcode tui: <actionable message>` and
+        // exits nonzero, exactly like every other subcommand's failure.
+        Command::Tui { project } => run_thin_client(cli::tui::run(project), "tui").await,
 
         Command::RunTask {
             agent,

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -583,3 +583,51 @@ fn workstream_close_hides_from_default_list_but_include_closed_shows_it() {
         "include-closed list must show the closed workstream: {include_closed_stdout}"
     );
 }
+
+/// `tcode --help` must list the `tui` subcommand (DOC-50 AC-2.4: "the
+/// command exists"). This is the cheapest possible regression guard on the
+/// integration point #4424 added — the whole TUI stack was already merged
+/// and only this CLI surface was missing.
+#[test]
+fn tui_subcommand_is_listed_in_help() {
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .arg("--help")
+        .output()
+        .expect("spawn tcode --help");
+
+    assert!(output.status.success(), "--help must exit 0: {output:?}");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("tui"),
+        "`tcode --help` must list the tui subcommand: {stdout}"
+    );
+}
+
+/// `tcode tui` with no reachable daemon must fail FAST with an actionable
+/// message and a nonzero exit — never hang, never enter the alternate
+/// screen, and never try to auto-spawn a daemon (explicitly deferred,
+/// DOC-50 §4.1 MVP scope).
+///
+/// `TCODE_DAEMON_URL` is pointed at a port nothing listens on, which also
+/// makes the test deterministic on a developer machine that happens to have
+/// a real daemon running (the env var outranks the discovery file).
+#[test]
+fn tui_without_a_reachable_daemon_errors_cleanly() {
+    let home = tempfile::tempdir().expect("home tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .arg("tui")
+        .env("HOME", home.path())
+        .env("TCODE_DAEMON_URL", "http://127.0.0.1:1")
+        .output()
+        .expect("spawn tcode tui");
+
+    assert!(
+        !output.status.success(),
+        "must exit nonzero without a daemon: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("tcode tui:") && stderr.contains("tcode serve --http"),
+        "error must name the command and the fix: {stderr}"
+    );
+}


### PR DESCRIPTION
## What

Wires the `tcode tui` subcommand so the already-built TUI is reachable by a user. Extension only — no new construction.

Before this PR, `crates/trusty-tui` (7.5k SLOC, 162 tests) and `trusty_code::tui_client::CodeEngine` were both complete and merged, but `CodeEngine` had **zero production call sites**: it was constructed only in `engine_tests.rs` and `tests/tui_client_engine.rs`. The entire TUI existed only under `cargo test`.

- `Command::Tui` added to the clap enum in `crates/trusty-code/src/main.rs`, with an optional `--project/-p` (omit it for a **projectless** session — the same first-class state `serve` without `--project` and `session.create` without a `project` already support). The path is canonicalized at the CLI boundary so an unusable one fails with the flag's name in the message rather than as a `-32003 invalid_argument` after the TUI has started.
- `crates/trusty-code/src/cli/tui.rs` (new, 67 SLOC) constructs `CodeEngine` through the **existing** `tui_client::discovery` path (`TCODE_DAEMON_URL` → `http_addr` discovery file → `GET /health` liveness ping) and hands it to `trusty_tui::run::run` with the shared `ReplApp` model, `trusty_tui::app::apply` reducer, and `trusty_tui::layout::draw` renderer.
- **No-daemon case:** discovery deliberately runs *before* `run()` enters the alternate screen, and the match arm reuses the existing `run_thin_client` helper, so the failure prints `tcode tui: no tcode daemon found — start one with \`tcode serve --http\`, or point \`tcode tui\` at a running instance with \`TCODE_DAEMON_URL=http://host:port\`` and exits nonzero — never flashes a TUI. Auto-spawning a daemon stays deferred per DOC-50 §4.1 MVP scope.

Nothing else was touched: no tool-call cards, no permission prompts, no pickers, no streaming-layer changes (#4425/#4426, epic #3421).

## I actually launched it

Not tests-only. Against a real `tcode serve --http --port 17883` (with `TCODE_MOCK_LLM=echo`), driven through a pty with a real window size, `tcode tui` rendered and behaved:

```
╭─── tcode v0.1.0 ─────────────────────────────────────────────╮
 tcode v0.1.0   masa · tcode   Recent activity   Commands
╰──────────────────────────────────────────────────────────────╯
[tcode]  connected to tcode daemon at http://127.0.0.1:17883 (session 69bb8e77-c2ff-43af-93d8-fc2037dafa38)
────────────────────────────────────────────────────────────────
 tcode>  Ask anything, or /help for commands
────────────────────────────────────────────────────────────────
 WS: bobmatnyc/bakeoff-l1 — 2026-07-23 (548f2143-ab36-4b02-8048-1f6ec95747f5)
```

Typing `hello there` + Enter streamed the real turn back:

```
[tcode]  [TOOL] … bash … {"command":"echo hello-from-mock-engineer"}
 tcode>  ↑ to cancel
[tcode]  [RESULT] stdout:hello-from-mock-engineer  exit_code: 0
⏺ tcode  ·  engineer: echoed hello-from-mock-engineer
⏺ tcode  ·  pm: task complete
```

`/quit` exited cleanly (`ESC[?1049l` — alternate screen left, mouse capture released, terminal restored). `session.list` on the daemon confirmed the TUI's own session (`"task": "tcode tui session"`, bound to the ambient active workstream).

## Quality gates

| Gate | Result |
| --- | --- |
| `cargo test -p trusty-code` | 1609 + 11 + 16 + 7 (+ every other suite) passed, 0 failed |
| `cargo test -p trusty-tui` | 162 passed, 0 failed |
| `cargo clippy -p trusty-code -p trusty-tui --all-targets -- -D warnings` | clean |
| `cargo fmt --check` | clean |
| `scripts/check_line_cap.sh` | 7 allowlisted, 0 violations |

New tests: 4 unit tests for the project/label resolution helpers, plus 2 black-box tests in `tests/cli_e2e.rs` (`tui_subcommand_is_listed_in_help` — the literal AC-2.4 "the command exists"; `tui_without_a_reachable_daemon_errors_cleanly` — nonzero exit and an actionable message with `TCODE_DAEMON_URL` pointed at a dead port).

## Reviewer notes / follow-ups (not fixed here, deliberately)

1. **`main.rs` is now 498/500 SLOC** — the variant fits under the cap, but with only 2 SLOC of headroom. The next change to `main.rs` will need a split first (the legacy in-process `run_task` + `validate_agent_name` + `build_llm_client` block is the obvious extraction into `cli/`). Left alone here to keep this PR's diff in its lane and avoid conflicting with the parallel #4425/#4426 work.
2. **`/help` does not list engine-routed commands yet.** `ReplApp::commands` is caller-seeded, but `CodeEngine`'s command cache is only populated inside `setup()` — which runs *after* the model is moved into `run()`. Built-in commands (`/help`, `/clear`, `/quit`) all list correctly; `/workstream` does not appear in `/help` even though it works. Fixing it needs either a `ReplEvent` for command updates or a pre-`setup()` seed, which belongs to the slash-command slice, not here.

Closes #4424

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
