### PR TITLE
fix(trusty-review): SubprocessAnalyzeClient health check ignores degraded-but-serving, permanently blocking the gate

### DIFF
--- a/crates/trusty-review/CHANGELOG.md
+++ b/crates/trusty-review/CHANGELOG.md
@@ -7,6 +7,39 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- **`SubprocessAnalyzeClient`'s health check ignored degraded-but-serving,
+  permanently blocking the review gate** (closes
+  [#4440](https://github.com/bobmatnyc/trusty-tools/issues/4440)).
+  - The MCP `review_pr` / `serve` path uses `SubprocessAnalyzeClient`, whose
+    `health()` probed trusty-search's `/health` and tested `status == "ok"` as a
+    literal string. trusty-search latches `status: "degraded"` for its entire
+    process lifetime once warm boot skips any index (the underlying
+    `degraded_by_timeout` / `degraded_by_tcc` counters are never decremented), so
+    `has_analysis()` returned `false` forever and `pipeline::context_gate` skipped
+    every review with "trusty-analyze unreachable/not-ready" — against a daemon
+    that was up, embedder-ready and answering queries normally.
+  - This was a duplicated health check that missed a fix applied to its twin:
+    `HealthResponse::serving_state()` already distinguishes "degraded but
+    serving" from "not serving" and was applied to the search-side gate under
+    #4079. `SubprocessAnalyzeClient` now **consumes** `serving_state()` /
+    `is_serving()` instead of re-deriving its own verdict, so one place decides
+    what a trusty-search health payload means.
+  - The gate is narrowed, not weakened: a genuinely not-serving trusty-search
+    (embedder down, or a status that is neither `ok` nor `degraded`) still fails
+    the probe as `Unavailable`. trusty-search's own status string is passed
+    through verbatim rather than laundered into `"ok"`.
+
+### Changed
+
+- The `require_analyze` skip message no longer tells every operator to run
+  `trusty-analyze serve`. That advice was irrelevant in the default subprocess
+  mode, where no analyze daemon exists at all; the message now names the real
+  preconditions (a serving trusty-search and a runnable `trusty-analyze` binary
+  on PATH) and scopes the daemon advice to daemon-backed deployments
+  ([#4440](https://github.com/bobmatnyc/trusty-tools/issues/4440)).
+
 ---
 ## [0.11.0] — 2026-07-27
 

--- a/crates/trusty-review/src/integrations/subprocess_analyze_client/client.rs
+++ b/crates/trusty-review/src/integrations/subprocess_analyze_client/client.rs
@@ -12,6 +12,9 @@ use std::process::{Command, Stdio};
 use crate::integrations::analyze_client::{
     AnalyzeClient, AnalyzeClientError, AnalyzeHealthResponse, ComplexityHotspot, Smell,
 };
+// #4440: the single, shared interpretation of a trusty-search /health payload.
+// This module must CONSUME it rather than re-deriving its own — see `health`.
+use crate::integrations::health::{HealthResponse, ServingState};
 
 use super::{DEFAULT_ANALYZE_BIN, ENV_ANALYZE_BIN, SubprocessReviewReport, map_report};
 
@@ -181,12 +184,36 @@ impl AnalyzeClient for SubprocessAnalyzeClient {
     /// Liveness: probe trusty-search health AND verify the binary is resolvable.
     ///
     /// Why: no analyze daemon exists in the subprocess model; liveness means
-    /// "can we run an analysis?" which requires both trusty-search AND the binary.
-    /// What: GETs `<search_url>/health`, checks `status == "ok"` AND
-    /// `search_reachable` (reusing the same probe URL pattern as the HTTP path
-    /// since trusty-analyze itself calls trusty-search); then verifies the binary
-    /// executes with `--version`.
-    /// Test: `subprocess_client_health_check_fails_gracefully`.
+    /// "can we run an analysis?", which requires both trusty-search (the data
+    /// source `trusty-analyze` itself queries) AND a runnable binary.
+    ///
+    /// Issue #4440: this probe used to deserialise the search payload into a
+    /// private one-field struct and test `status == "ok"` as a literal string —
+    /// a second, cruder copy of the decision
+    /// [`HealthResponse::serving_state`] already makes. trusty-search latches
+    /// `status: "degraded"` for its ENTIRE process lifetime once warm boot skips
+    /// any index (`degraded_by_timeout` / `degraded_by_tcc` are boot-time
+    /// counters that are never decremented), so on a daemon that was up,
+    /// embedder-ready and answering queries normally, the string test pinned
+    /// `has_analysis` at `false` and `context_gate` skipped every single review
+    /// with "trusty-analyze unreachable/not-ready". The search-side gate in
+    /// `pipeline::context_gate` received exactly this fix under #4079; this
+    /// duplicated twin did not. It now CONSUMES `serving_state` so there is one
+    /// place — and only one — that decides what a trusty-search health payload
+    /// means.
+    ///
+    /// What: GETs `<search_url>/health`, deserialises the full
+    /// [`HealthResponse`], and refuses ONLY on [`ServingState::NotServing`]
+    /// (embedder down, or a status that is neither `"ok"` nor `"degraded"`).
+    /// A `Degraded` daemon is answering queries and so passes, carrying
+    /// trusty-search's own status string through verbatim. Then verifies the
+    /// binary executes with `--version`. A genuinely dead dependency — either
+    /// half — still fails: this narrows the false-positive, it does not turn the
+    /// probe into an always-pass.
+    /// Test: `subprocess_client_health_check_fails_gracefully`,
+    /// `subprocess_client_degraded_search_still_has_analysis`,
+    /// `subprocess_client_not_serving_search_has_no_analysis`,
+    /// `subprocess_client_health_preserves_degraded_status_string`.
     async fn health(&self) -> Result<AnalyzeHealthResponse, AnalyzeClientError> {
         // Probe trusty-search /health directly.
         let url = format!("{}/health", self.search_url.trim_end_matches('/'));
@@ -209,14 +236,22 @@ impl AnalyzeClient for SubprocessAnalyzeClient {
             )));
         }
 
-        // Parse the trusty-search health response (same shape the HTTP path uses
-        // via the analyze daemon).
-        #[derive(serde::Deserialize)]
-        struct SearchHealth {
-            status: String,
-        }
-        let sh: SearchHealth = serde_json::from_str(&body)
+        // #4440: parse the FULL trusty-search health payload and delegate the
+        // verdict to the shared `serving_state()`, instead of re-testing
+        // `status == "ok"` on a locally-declared one-field struct. The old
+        // private struct is gone deliberately: keeping it is what let this copy
+        // drift out of sync with the #4079 fix in the first place.
+        let sh: HealthResponse = serde_json::from_str(&body)
             .map_err(|e| AnalyzeClientError::Parse(format!("search health parse: {e}")))?;
+
+        // Refuse ONLY when trusty-search genuinely cannot answer queries.
+        // `Degraded` means "serving, with a named capability gap" — a review can
+        // still be produced against it, and blocking on it is the #4440 bug.
+        if let ServingState::NotServing(reason) = sh.serving_state() {
+            return Err(AnalyzeClientError::Unavailable(format!(
+                "trusty-search at {url} is not serving: {reason}"
+            )));
+        }
 
         // Verify the binary is runnable.
         let binary_ok = {
@@ -240,11 +275,15 @@ impl AnalyzeClient for SubprocessAnalyzeClient {
             )));
         }
 
-        // Express result as AnalyzeHealthResponse: search_reachable = true when
-        // trusty-search reported ok; this mirrors the daemon's own health response.
+        // #4440: `search_reachable` is `is_serving()`, NOT `status == "ok"`.
+        // The `NotServing` case already returned `Err` above, so reaching here
+        // means trusty-search is answering queries — possibly degraded, which is
+        // still analysable. `status` carries trusty-search's own verdict through
+        // verbatim so anything that displays it is never told a degraded daemon
+        // said "ok".
         Ok(AnalyzeHealthResponse {
             status: sh.status.clone(),
-            search_reachable: sh.status == "ok",
+            search_reachable: sh.is_serving(),
         })
     }
 
@@ -253,14 +292,32 @@ impl AnalyzeClient for SubprocessAnalyzeClient {
     /// Why: spec REV-441 applies to the subprocess model too — both the data
     /// source (trusty-search) and the analysis runtime (the binary) must be
     /// confirmed before the pipeline marks analyze available.
-    /// What: calls `health()` and returns `true` only if no error and is_healthy.
+    /// What: calls `health()` — which already enforces BOTH preconditions
+    /// (trusty-search serving, binary runnable) — and gates on
+    /// `search_reachable`.
+    ///
+    /// Issue #4440: this gated on `AnalyzeHealthResponse::is_healthy()`, i.e.
+    /// `status == "ok" && search_reachable`. `is_healthy` is the strict
+    /// "fully nominal" gate, and trusty-search latches `"degraded"` for its whole
+    /// process lifetime after any warm-boot skip, so this returned `false`
+    /// forever on a perfectly serving daemon and `context_gate` skipped every
+    /// review. `search_reachable` is now derived from
+    /// [`HealthResponse::is_serving`], the same three-state classification the
+    /// search-side gate uses, so degraded-but-serving proceeds while a daemon
+    /// that genuinely cannot answer still returns `false`.
+    ///
     /// The `index_id` argument is accepted for trait compatibility but the
     /// subprocess model does not pre-check index existence (the review subcommand
-    /// will surface a missing index as an exit-1 error at call time).
-    /// Test: `subprocess_client_has_analysis_returns_false_on_error`.
+    /// will surface a missing index as an exit-1 error at call time). It is
+    /// effectively dead weight here; removing it would change the shared
+    /// `AnalyzeClient` trait signature and every implementor, so it is left
+    /// alone deliberately — out of scope for a gate-unblocking fix.
+    /// Test: `subprocess_client_has_analysis_returns_false_on_error`,
+    /// `subprocess_client_degraded_search_still_has_analysis`,
+    /// `subprocess_client_not_serving_search_has_no_analysis`.
     async fn has_analysis(&self, _index_id: &str) -> bool {
         match self.health().await {
-            Ok(h) => h.is_healthy(),
+            Ok(h) => h.search_reachable,
             Err(e) => {
                 tracing::debug!("trusty-analyze subprocess health check failed (optional): {e}");
                 false

--- a/crates/trusty-review/src/integrations/subprocess_analyze_client/tests.rs
+++ b/crates/trusty-review/src/integrations/subprocess_analyze_client/tests.rs
@@ -94,6 +94,184 @@ async fn subprocess_client_binary_not_found() {
     );
 }
 
+// ─── Degraded-but-serving health (#4440) ───────────────────────────────────────
+
+/// The VERBATIM `/health` payload from the live trusty-search 0.39.1 daemon that
+/// permanently blocked the review gate in #4440.
+///
+/// Why: `status` is `"degraded"` solely because four UNRELATED indexes timed out
+/// at warm boot. trusty-search derives that flag from boot-time counters that are
+/// never decremented, so it stays `"degraded"` for the daemon's whole process
+/// lifetime no matter how healthy it becomes. The daemon is embedder-ready,
+/// 12 indexes loaded, zero failures, and answering queries normally.
+/// What: a `const` so the fixture is byte-identical to what the real daemon sent.
+/// Test: used by `subprocess_client_degraded_search_still_has_analysis` and
+/// `subprocess_client_health_preserves_degraded_status_string`.
+const LIVE_DEGRADED_HEALTH: &str = r#"{"status":"degraded","version":"0.39.1","indexes":7,
+    "uptime_secs":18279,"embedder":"ready","embedder_last_ok_secs_ago":11909,
+    "embedder_recent_timeout_count":0,"rss_mb":247,
+    "embedder_info":{"dimension":384,"provider":"MPS","quantized":false,
+        "model":"all-MiniLM-L6-v2","backend":"python"},
+    "warmboot_summary":{"indexes_loaded":12,"indexes_skipped_tcc":0,
+        "indexes_skipped_timeout":4,"warm_boot_degraded":true,"indexes_lazy":0,
+        "indexes_failed":0,"indexes_corpus_failed":0,"indexes_health_scan_skipped":0},
+    "embedder_bootstrap":"ready"}"#;
+
+/// A daemon that is genuinely NOT serving: `status` is neither `"ok"` nor
+/// `"degraded"`, so no query can succeed against it.
+///
+/// Why: the #4440 fix must narrow the false-positive WITHOUT turning the gate
+/// into an always-pass. This is the control payload that must still fail.
+/// What: `status: "starting"` with a ready embedder and a spotless warm boot —
+/// so the ONLY thing distinguishing it from the passing case is the status.
+/// Test: `subprocess_client_not_serving_search_has_no_analysis`.
+const NOT_SERVING_HEALTH: &str = r#"{"status":"starting","version":"0.39.1","embedder":"ready",
+    "warmboot_summary":{"indexes_loaded":12,"indexes_skipped_tcc":0,
+        "indexes_skipped_timeout":0,"warm_boot_degraded":false,
+        "indexes_failed":0,"indexes_corpus_failed":0}}"#;
+
+/// Bind a one-shot stub HTTP server that answers the next request with `body`.
+///
+/// Why: the #4440 regression is entirely about how a specific `/health` JSON
+/// document is interpreted, so the test must drive the REAL `health()` code path
+/// — HTTP fetch, deserialise, classify — rather than assert on a hand-built
+/// struct. The crate has no mock-server dev-dependency, and this mirrors the
+/// raw-`TcpListener` stub already used by `llm/openrouter_tests.rs`.
+/// What: binds an ephemeral loopback port, spawns a task that accepts exactly one
+/// connection, drains the request, and writes `body` as a 200 JSON response.
+/// Returns the base URL plus the task handle so the test can join it.
+/// Test: used by the three `#4440` tests below.
+async fn stub_health_server(body: &'static str) -> (String, tokio::task::JoinHandle<()>) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind ephemeral loopback port");
+    let addr = listener.local_addr().expect("stub server local_addr");
+    let handle = tokio::spawn(async move {
+        if let Ok((mut sock, _)) = listener.accept().await {
+            let mut buf = vec![0u8; 4096];
+            let _ = sock.read(&mut buf).await;
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\
+                 Connection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.shutdown().await;
+        }
+    });
+    (format!("http://{addr}"), handle)
+}
+
+/// REGRESSION (#4440): a `"degraded"`-but-serving trusty-search must NOT block
+/// the review gate.
+///
+/// Why: `health()` tested `status == "ok"` as a literal string, so this exact
+/// payload made `has_analysis` return `false` — permanently, because
+/// trusty-search never clears the flag within a process lifetime — and
+/// `context_gate` skipped EVERY review with "trusty-analyze unreachable/not-ready"
+/// against a daemon that was up and answering queries. This is the assertion that
+/// would have caught it.
+/// What: serves the verbatim live payload and asserts `has_analysis()` is `true`.
+/// The binary is `echo` (always present, exits 0 on `--version`) so the probe's
+/// binary half is satisfied and the payload is the only variable under test.
+/// Test: this test.
+#[tokio::test]
+async fn subprocess_client_degraded_search_still_has_analysis() {
+    let (base_url, server) = stub_health_server(LIVE_DEGRADED_HEALTH).await;
+    let client = SubprocessAnalyzeClient::new("echo", base_url).expect("TLS init should succeed");
+
+    assert!(
+        client.has_analysis("any-index").await,
+        "a trusty-search reporting status=\"degraded\" purely because 4 UNRELATED indexes timed \
+         out at warm boot is still SERVING — it must not block the review gate (#4440)"
+    );
+
+    server.await.expect("stub server task must not panic");
+}
+
+/// The degraded status string must survive the probe unaltered.
+///
+/// Why: the fix must not "solve" the block by laundering `"degraded"` into
+/// `"ok"`. Anything that displays the analyze health must still see what
+/// trusty-search actually said; only the PASS/FAIL decision changed.
+/// What: asserts `status` is still `"degraded"` while `search_reachable` is
+/// `true` — the two facts that used to be forced to agree.
+/// Test: this test.
+#[tokio::test]
+async fn subprocess_client_health_preserves_degraded_status_string() {
+    let (base_url, server) = stub_health_server(LIVE_DEGRADED_HEALTH).await;
+    let client = SubprocessAnalyzeClient::new("echo", base_url).expect("TLS init should succeed");
+
+    let health = client
+        .health()
+        .await
+        .expect("degraded-but-serving must not error");
+    assert_eq!(
+        health.status, "degraded",
+        "trusty-search's own status string must pass through verbatim, never be rewritten to \"ok\""
+    );
+    assert!(
+        health.search_reachable,
+        "search_reachable must reflect is_serving(), not status == \"ok\" (#4440)"
+    );
+
+    server.await.expect("stub server task must not panic");
+}
+
+/// NEGATIVE (#4440): a trusty-search that genuinely is not serving must STILL
+/// fail the gate.
+///
+/// Why: the whole risk of this fix is over-correcting into an always-pass gate
+/// that lets reviews run with no static-analysis context at all. This payload
+/// differs from the passing one ONLY in its status (`"starting"`, with a ready
+/// embedder and a clean warm boot), so a `false` here proves the probe still
+/// discriminates rather than having been blanket-disabled.
+/// What: asserts `has_analysis()` is `false` and `health()` reports `Unavailable`.
+/// Test: this test.
+#[tokio::test]
+async fn subprocess_client_not_serving_search_has_no_analysis() {
+    let (base_url, server) = stub_health_server(NOT_SERVING_HEALTH).await;
+    let client = SubprocessAnalyzeClient::new("echo", base_url).expect("TLS init should succeed");
+
+    assert!(
+        !client.has_analysis("any-index").await,
+        "a trusty-search that is not serving must still block the gate — the #4440 fix narrows \
+         the false-positive, it must not weaken the gate into always-pass"
+    );
+
+    server.await.expect("stub server task must not panic");
+}
+
+/// A not-serving daemon must surface as `Unavailable`, not `Parse` or `Ok`.
+///
+/// Why: `context_gate` and `probe_deps` branch on the error variant; a wrong
+/// variant would misreport a live-but-broken daemon.
+/// What: asserts the `NOT_SERVING_HEALTH` payload yields
+/// `AnalyzeClientError::Unavailable` whose text names the real reason.
+/// Test: this test.
+#[tokio::test]
+async fn subprocess_client_not_serving_search_reports_unavailable() {
+    let (base_url, server) = stub_health_server(NOT_SERVING_HEALTH).await;
+    let client = SubprocessAnalyzeClient::new("echo", base_url).expect("TLS init should succeed");
+
+    let err = client
+        .health()
+        .await
+        .expect_err("a not-serving trusty-search must error");
+    match err {
+        AnalyzeClientError::Unavailable(msg) => assert!(
+            msg.contains("not serving"),
+            "message must name the real reason; got: {msg}"
+        ),
+        other => panic!("expected Unavailable, got {other:?}"),
+    }
+
+    server.await.expect("stub server task must not panic");
+}
+
 // ─── Map report tests ──────────────────────────────────────────────────────────
 
 /// Core mapping logic: a `ReviewReport`-shaped JSON is correctly projected

--- a/crates/trusty-review/src/pipeline/context_gate.rs
+++ b/crates/trusty-review/src/pipeline/context_gate.rs
@@ -197,11 +197,22 @@ pub async fn preflight_context(
     // ── trusty-analyze gate ────────────────────────────────────────────────
     if !analyze_ready {
         if config.context.require_analyze {
+            // #4440: the old text told every operator to `trusty-analyze serve`.
+            // That advice is irrelevant in the DEFAULT subprocess mode used by
+            // `serve`/MCP and `run`, where no analyze daemon exists at all and
+            // `analyzer_url` is never contacted — it sent people hunting for a
+            // daemon they were never supposed to be running. Name the actual
+            // preconditions of each mode instead.
             return GateOutcome::Skip(format!(
-                "trusty-analyze unreachable/not-ready at {analyzer_url} — start it \
-                 (`trusty-analyze serve`) and index `{index}`; refusing to review without \
-                 static-analysis context (set TRUSTY_REVIEW_REQUIRE_ANALYZE=false or \
-                 [context] require_analyze=false to opt into a degraded, non-authoritative review)"
+                "trusty-analyze static-analysis context is unavailable for index `{index}` — \
+                 refusing to review without it. In the default subprocess mode (`serve`/MCP and \
+                 `run`) no analyze daemon is used: the preconditions are a trusty-search at \
+                 {search_url} that is SERVING (a `degraded` warm boot still counts as serving) \
+                 and a runnable `trusty-analyze` binary on PATH (override with \
+                 TRUSTY_ANALYZE_BIN). Only when trusty-review is wired to an analyze daemon do \
+                 you need to start `trusty-analyze serve` at {analyzer_url}. (Set \
+                 TRUSTY_REVIEW_REQUIRE_ANALYZE=false or [context] require_analyze=false to opt \
+                 into a degraded, non-authoritative review.)"
             ));
         }
         info!(


### PR DESCRIPTION
## Problem

In the default subprocess mode (`serve`/MCP `review_pr` and `run`),
`serve.rs:172` builds a `SubprocessAnalyzeClient`. Its `health()` probed
**trusty-search**'s `/health`, deserialised it into a private one-field struct,
and tested `status == "ok"` as a literal string:

```rust
struct SearchHealth { status: String }
...
search_reachable: sh.status == "ok",   // <-- the bug
```

`has_analysis()` gated on `is_healthy()` (`status == "ok" && search_reachable`),
so both halves were `false`. `context_gate.rs:199` then tripped `require_analyze`
and **skipped the review**.

trusty-search latches `status: "degraded"` for its **entire process lifetime**:
`recompute_warm_boot_degraded()` re-derives some flags live, but
`degraded_by_tcc` / `degraded_by_timeout` come from boot-time counters that are
never decremented. So once warm boot skips any index, the gate is shut until the
daemon restarts — and restarting trusty-search is itself hazardous.

## The real defect class

`integrations/health.rs` **already models this correctly**.
`HealthResponse::serving_state()` / `is_serving()` classify the same JSON into
`Serving` / `Degraded(reason)` / `NotServing(reason)` by reading the individual
`warmboot_summary` counters instead of guessing from the status string. The
**search-side** gate consumes it and correctly proceeds on degraded-but-serving.

`SubprocessAnalyzeClient::health()` reimplemented its own cruder check against
the very same document and never received the #4079 fix. This is a duplicated
health check that missed a fix applied to its twin — the same
**common-entry-point defect class CLAUDE.md warns about**.

## Fix

`SubprocessAnalyzeClient::health()` now parses the full `HealthResponse` and
**consumes** `serving_state()` / `is_serving()`. The private one-field struct is
deleted deliberately — keeping it is what let this copy drift in the first place.
No third copy of the logic was added; that is the entire point.

## Judgment calls (explicitly owned)

**1. A daemon that is genuinely NOT serving still fails the gate.**
`health()` returns `Err(Unavailable)` on `ServingState::NotServing` — embedder
down, or a status that is neither `ok` nor `degraded`. Only the
degraded-but-serving false-positive was removed. This is a narrowing, not a
weakening into always-pass, and `subprocess_client_not_serving_search_has_no_analysis`
pins it with a payload that differs from the passing one **only** in its status.

**2. `has_analysis()`'s ignored `index_id` IS dead weight — deliberately left alone.**
It is documented as ignored and the subprocess model never pre-checks index
existence. Removing it would change the shared `AnalyzeClient` trait signature
and every implementor (HTTP client, null client, and 6+ test fakes) — not
trivially safe, and out of scope for a gate-unblocking fix. Recorded in the
doc comment instead.

**3. `status` is passed through verbatim, never laundered.**
The fix does not "solve" the block by rewriting `"degraded"` into `"ok"`. Only
the pass/fail decision changed; anything displaying analyze health still sees
what trusty-search actually said. Pinned by
`subprocess_client_health_preserves_degraded_status_string`.

**4. The skip message named the wrong precondition.**
It told every operator to `start it (trusty-analyze serve)`. In the default
subprocess mode **no analyze daemon exists at all** and `analyzer_url` is never
contacted — that advice sent people hunting for a daemon they were never
supposed to run. The message now names the real preconditions (a *serving*
trusty-search, and a runnable `trusty-analyze` binary on PATH / `TRUSTY_ANALYZE_BIN`)
and scopes the daemon advice to daemon-backed deployments.

## Tests

Four new tests in `subprocess_analyze_client/tests.rs`, driving the **real**
`health()` code path (HTTP fetch → deserialise → classify) via a raw
`TcpListener` stub, mirroring the existing pattern in `llm/openrouter_tests.rs`.
The binary is `echo` (always present, exits 0) so the payload is the only
variable under test.

- `subprocess_client_degraded_search_still_has_analysis` — **the exact
  regression**: the verbatim live payload (`status: "degraded"`,
  `indexes_skipped_timeout: 4`, embedder ready) must yield `has_analysis() == true`.
- `subprocess_client_not_serving_search_has_no_analysis` — **negative case**:
  genuinely not serving → `false`.
- `subprocess_client_not_serving_search_reports_unavailable` — correct error
  variant, since `context_gate` and `probe_deps` branch on it.
- `subprocess_client_health_preserves_degraded_status_string` — status not
  laundered.

**Verified the tests would have caught this**: temporarily restoring the old
`status == "ok"` / `is_healthy()` logic fails exactly 3 of them:

```
test ...subprocess_client_health_preserves_degraded_status_string ... FAILED
test ...subprocess_client_not_serving_search_reports_unavailable ... FAILED
test ...subprocess_client_degraded_search_still_has_analysis ... FAILED
test result: FAILED. 8 passed; 3 failed
```

## Live proof against the CURRENT trusty-search daemon

A unit test alone does not prove the gate unblocks, so the real client was run
against the live daemon on :7878 (no daemon was restarted or disturbed):

```
=== LIVE /health payload ===
{"status":"degraded","version":"0.39.1","indexes":7,"uptime_secs":18848,
 "embedder":"ready",...,"warmboot_summary":{"indexes_loaded":12,
 "indexes_skipped_tcc":0,"indexes_skipped_timeout":4,"warm_boot_degraded":true,
 "indexes_lazy":0,"indexes_failed":0,"indexes_corpus_failed":0,...}}

status string            = "degraded"
warmboot skipped_timeout = Some(4)
--- OLD logic (pre-#4440) ---
  status == "ok"        => false
--- NEW logic (#4440) ---
  serving_state()      => Degraded(serving but degraded (12 of 16 index(es) loaded):
                          4 index(es) were skipped on a warm-boot scan timeout
                          and are absent from the registry)
  is_serving()         => true

=== SubprocessAnalyzeClient against the LIVE daemon ===
  health()      => Ok(status="degraded", search_reachable=true)
  is_healthy() [old gate] => false
  has_analysis() => true   <-- the value context_gate.rs:199 branches on
```

`has_analysis()` flips `false` → `true` against the real, unmodified daemon
state: the gate is unblocked, while `status` still reports `"degraded"` and the
warm-boot gap is still named. (The harness used to capture this was temporary and
is not part of the diff.)

## Gates

```
cargo test -p trusty-review
  test result: ok. 1560 passed; 0 failed; 5 ignored
  test result: ok. 68 passed; 0 failed
  test result: ok. 3 passed; 0 failed
  test result: ok. 3 passed; 0 failed
  test result: ok. 2 passed; 0 failed
  test result: ok. 5 passed; 0 failed
  test result: ok. 2 passed; 0 failed
  test result: ok. 3 passed; 0 failed
  test result: ok. 3 passed; 0 failed
  test result: ok. 0 passed; 0 failed   (doc-tests)

cargo clippy -p trusty-review --all-targets -- -D warnings
  Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.91s

cargo fmt --check
  exit 0

bash scripts/check_line_cap.sh
  line-cap: 7 allowlisted, 0 violations — OK.
```

Closes #4440

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
