### PR TITLE
fix(trusty-mpm): load the user tier so managed sessions can reach bundled agents (#4451)

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -7,6 +7,36 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Fixed
+
+- managed sessions can reach the bundled agent roster again — every delegation was degrading to `general-purpose` (closes [#4451](https://github.com/bobmatnyc/trusty-tools/issues/4451))
+  - Daemon-managed spawns now launch with `--setting-sources user,project,local`
+    instead of `project,local`. Claude Code discovers subagents per settings
+    tier, and `$CLAUDE_CONFIG_DIR/agents` — where [#4409](https://github.com/bobmatnyc/trusty-tools/issues/4409)
+    moved the bundled roster — IS the `user` tier, the one tier the old flag
+    dropped. A session showed only the five Claude Code built-ins and answered
+    `Agent type 'rust-engineer' not found` while all 42 agent files sat
+    correctly on disk.
+  - Re-admitting the `user` tier does not re-admit the operator's global
+    `~/.claude/settings.json` hooks that [#1269](https://github.com/bobmatnyc/trusty-tools/issues/1269)
+    excluded: managed spawns relocate `CLAUDE_CONFIG_DIR`, so the `user` tier
+    resolves to the tm-owned config home. Launch paths that do NOT inject
+    `CLAUDE_CONFIG_DIR` (`tm launch`, `tm connect`) keep `project,local`
+    unchanged — the flag is now selected from that one fact rather than
+    hard-coded per call site.
+
+### Added
+
+- `tm doctor` gains an `agent_reachability` check that fails when the bundled roster is unreachable ([#4451](https://github.com/bobmatnyc/trusty-tools/issues/4451))
+  - The existing `agents` and `deployment` checks are presence-only — they
+    counted 42 files and diffed them against the canonical roster, and both
+    reported green throughout the outage above. The new check asserts the one
+    thing they cannot: that the settings tier the roster deploys into is a tier
+    the managed spawn's `--setting-sources` flag actually loads. It reads both
+    sides from production code, so moving the deploy destination without
+    updating the flag (what happened here) is a hard `Fail`, not a silent
+    regression.
+
 ### Changed
 
 - bundled agents deploy to the tm-managed user tier, never per-workspace and never to `~/.claude` (closes [#4409](https://github.com/bobmatnyc/trusty-tools/issues/4409))

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
@@ -41,7 +41,7 @@ relevant `references/*.md` file here when you need an exact answer.
 | "What MCP tools exist and what parameters do they take?" | `references/mcp-tools.md` (33 tools, plus sibling-daemon pointers) |
 | "What agents can I delegate to, and what do they declare?" | `references/agents.md` (37 concrete agents) |
 | "What skills exist, and are they user-invocable?" | `references/skills.md` (52 bundled skills) |
-| "What does a `tm doctor` check name actually mean?" | `references/doctor.md` (22 checks) |
+| "What does a `tm doctor` check name actually mean?" | `references/doctor.md` (23 checks) |
 | "How do the pieces fit into an end-to-end flow?" | `references/workflows.md` (hand-authored, not generated) |
 
 ## Relationship to Other Skills

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/doctor.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/doctor.md
@@ -2,29 +2,30 @@
 
 Generated from a maintained literal list cross-checked against `run_doctor`'s actual check names (see this module's `doctor_checks_match_run_doctor_names` test — an added, removed, or renamed check fails the test suite). Source: `crates/trusty-mpm/src/daemon/doctor.rs` and its five sibling `doctor_*.rs` files. Regenerate with `tm generate capabilities`.
 
-22 checks, in execution order.
+23 checks, in execution order.
 
 | # | Check | What it probes |
 |---|---|---|
 | 1 | `instructions` | Framework instructions deployed and non-empty for the target project. |
 | 2 | `agents` | Bundled agent roster deployed under the operator/workspace `.claude/agents/` tier. |
-| 3 | `skills` | Bundled skill catalog deployed under the operator/workspace `.claude/skills/` tier. |
-| 4 | `skill_source` | The framework's own skill source directory is present and readable. |
-| 5 | `output_style` | The `trusty-mpm` Claude Code output style is configured and its file exists (DOC-28 F4). |
-| 6 | `output_style_staleness` | Deployed output-style file content matches the bundled catalog, and no orphaned files linger under `output-styles/` (issue #2333). |
-| 7 | `output_style_legacy_ids` | Warns when a legacy/unresolvable `outputStyle` id lingers in a currently-shadowed settings layer (e.g. `settings.local.json`) even though the effective layer resolves fine (issue #3453). |
-| 8 | `deployment` | Full manifest-completeness diff of the deployed payload against the canonical bundled roster (issue #2158). |
-| 9 | `skill_staleness` | Deployed skill content matches the bundled/embedded source (issue #2876). |
-| 10 | `legacy_sources` | No legacy global instruction sources linger from a pre-migration install (issue #2876). |
-| 11 | `agent_skills` | Every agent's declared `skills:` frontmatter resolves to a real skill — dangling references fail (DOC-42, issue #2889). |
-| 12 | `agent_skills_prose_hints` | Informational: skill names mentioned in agent prose but not declared in `skills:` frontmatter (always `Ok`, issue #2906). |
-| 13 | `memory` | trusty-memory sidecar reachability probe (bounded by `PROBE_TIMEOUT`). |
-| 14 | `search` | trusty-search sidecar reachability + expected-index-present probe (bounded by `PROBE_TIMEOUT`). |
-| 15 | `worktrees` | No orphaned git worktrees under the managed workspace root (Fix 1b, #1840). |
-| 16 | `gh_account` | Active `gh` CLI identity is unambiguous — warns on multi-account ambiguity. |
-| 17 | `oauth_token` | Warns when a managed session risks the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop (issue #2246). |
-| 18 | `hooks_contamination` | Warns when a project's `.claude/settings*.json` still carries tm hook entries from a pre-fix `tm install` — suggests `tm hooks clean` (issue #2940). |
-| 19 | `hooks_foreign_conflict` | Informational: warns when a project's `.claude/settings*.json` carries foreign (claude-mpm) hook entries that would fire inside a tm session — never auto-removed (issue #2940). |
-| 20 | `tcc_taint` | macOS: whether managed panes spawn `claude` with TCC responsibility disclaimed so its data-access prompts aren't attributed to the shared tmux server (issue #2997). |
-| 21 | `scaffold_tracking` | Warns when a harness-scaffolding path (`.claude/agents/`, `.claude/skills/`, `.claude/output-styles/`) is BOTH tracked in git AND regenerated locally by tm — the precondition for a `git merge --ff-only` "would be overwritten" collision; reports the exact true-intersection paths, never auto-modifies the index (issue #3427). |
-| 22 | `push_guard` | Warns when the project's clone carries no trusty-mpm cross-branch `pre-push` guard, or an older revision of it — the guard installs itself only on the clone path, so a base provisioned before it shipped is silently unprotected and a worktree tracking a foreign branch can force-push over that branch's reviewed lineage. Names the `tm repair push-guard` retrofit; doctor never writes into a repository (issue #2867). |
+| 3 | `agent_reachability` | Fails when bundled agents deploy into a settings tier a managed session's `--setting-sources` flag never loads — presence-only checks stay green while every delegation degrades to `general-purpose` (issue #4451). |
+| 4 | `skills` | Bundled skill catalog deployed under the operator/workspace `.claude/skills/` tier. |
+| 5 | `skill_source` | The framework's own skill source directory is present and readable. |
+| 6 | `output_style` | The `trusty-mpm` Claude Code output style is configured and its file exists (DOC-28 F4). |
+| 7 | `output_style_staleness` | Deployed output-style file content matches the bundled catalog, and no orphaned files linger under `output-styles/` (issue #2333). |
+| 8 | `output_style_legacy_ids` | Warns when a legacy/unresolvable `outputStyle` id lingers in a currently-shadowed settings layer (e.g. `settings.local.json`) even though the effective layer resolves fine (issue #3453). |
+| 9 | `deployment` | Full manifest-completeness diff of the deployed payload against the canonical bundled roster (issue #2158). |
+| 10 | `skill_staleness` | Deployed skill content matches the bundled/embedded source (issue #2876). |
+| 11 | `legacy_sources` | No legacy global instruction sources linger from a pre-migration install (issue #2876). |
+| 12 | `agent_skills` | Every agent's declared `skills:` frontmatter resolves to a real skill — dangling references fail (DOC-42, issue #2889). |
+| 13 | `agent_skills_prose_hints` | Informational: skill names mentioned in agent prose but not declared in `skills:` frontmatter (always `Ok`, issue #2906). |
+| 14 | `memory` | trusty-memory sidecar reachability probe (bounded by `PROBE_TIMEOUT`). |
+| 15 | `search` | trusty-search sidecar reachability + expected-index-present probe (bounded by `PROBE_TIMEOUT`). |
+| 16 | `worktrees` | No orphaned git worktrees under the managed workspace root (Fix 1b, #1840). |
+| 17 | `gh_account` | Active `gh` CLI identity is unambiguous — warns on multi-account ambiguity. |
+| 18 | `oauth_token` | Warns when a managed session risks the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop (issue #2246). |
+| 19 | `hooks_contamination` | Warns when a project's `.claude/settings*.json` still carries tm hook entries from a pre-fix `tm install` — suggests `tm hooks clean` (issue #2940). |
+| 20 | `hooks_foreign_conflict` | Informational: warns when a project's `.claude/settings*.json` carries foreign (claude-mpm) hook entries that would fire inside a tm session — never auto-removed (issue #2940). |
+| 21 | `tcc_taint` | macOS: whether managed panes spawn `claude` with TCC responsibility disclaimed so its data-access prompts aren't attributed to the shared tmux server (issue #2997). |
+| 22 | `scaffold_tracking` | Warns when a harness-scaffolding path (`.claude/agents/`, `.claude/skills/`, `.claude/output-styles/`) is BOTH tracked in git AND regenerated locally by tm — the precondition for a `git merge --ff-only` "would be overwritten" collision; reports the exact true-intersection paths, never auto-modifies the index (issue #3427). |
+| 23 | `push_guard` | Warns when the project's clone carries no trusty-mpm cross-branch `pre-push` guard, or an older revision of it — the guard installs itself only on the clone path, so a base provisioned before it shipped is silently unprotected and a worktree tracking a foreign branch can force-push over that branch's reviewed lineage. Names the `tm repair push-guard` retrofit; doctor never writes into a repository (issue #2867). |

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -785,10 +785,14 @@ fn inplace_exec_command_carries_isolation_flags_and_persona_end_to_end() {
         .map(|a| a.to_string_lossy().into_owned())
         .collect();
 
+    // #4451: `build_inplace_resume_command` always resolves a tm-owned
+    // CLAUDE_CONFIG_DIR, so the relocated tier list is the correct expectation
+    // here — `user` names tm's own config home, not the operator's ~/.claude,
+    // so the #1269 isolation this test guards is unchanged.
     assert!(
         args.windows(2)
-            .any(|w| w == ["--setting-sources", "project,local"]),
-        "--setting-sources project,local must survive to exec (#1269): {args:?}"
+            .any(|w| w == ["--setting-sources", "user,project,local"]),
+        "--setting-sources user,project,local must survive to exec (#1269/#4451): {args:?}"
     );
     assert!(
         args.iter().any(|a| a == "--dangerously-skip-permissions"),

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -40,6 +40,10 @@ pub(crate) const DOCTOR_CHECKS: &[(&str, &str)] = &[
         "Bundled agent roster deployed under the operator/workspace `.claude/agents/` tier.",
     ),
     (
+        "agent_reachability",
+        "Fails when bundled agents deploy into a settings tier a managed session's `--setting-sources` flag never loads — presence-only checks stay green while every delegation degrades to `general-purpose` (issue #4451).",
+    ),
+    (
         "skills",
         "Bundled skill catalog deployed under the operator/workspace `.claude/skills/` tier.",
     ),

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -196,7 +196,7 @@ async fn execute_doctor_against_test_daemon() {
     match executor.execute(TrustyCommand::Doctor).await {
         CommandResult::Doctor(report) => {
             // This test owns the EXECUTOR round-trip, not the check roster.
-            // The exact count is pinned by `run_doctor_produces_twenty_two_checks`
+            // The exact count is pinned by `run_doctor_produces_twenty_three_checks`
             // and `doctor_endpoint_returns_report`, both of which derive it from
             // their own name list — duplicating a bare literal here just made it a
             // fourth place to forget (#4090 review LOW-1).

--- a/crates/trusty-mpm/src/core/managed_config.rs
+++ b/crates/trusty-mpm/src/core/managed_config.rs
@@ -22,20 +22,36 @@
 //! whether the binary is a dev checkout (git submodule source) or an installed
 //! binary (`~/.trusty-mpm/framework/*`).
 //!
-//! WHICH LAYER ACTUALLY LOADS THE ROSTER (corrected 2026-07-30, issue #4409):
-//! the AGENTS deployed here ARE read by a daemon-managed session. The earlier
-//! reading of this comment — that `--setting-sources project,local` (see
-//! `runtime::claude_code`) excludes the `user` tier `CLAUDE_CONFIG_DIR`
-//! relocates, so only the PROJECT layer delivered the roster — is refuted by
-//! the maintainer's probe matrix on #4409: a probe agent existing ONLY in
-//! `$CLAUDE_CONFIG_DIR/agents/` resolved and executed both at session start
-//! (fresh headless `claude -p` from a workspace with no `.claude/`) and
-//! mid-session. `~/.claude/agents/` is what goes unread, which is documented
-//! behavior — with `CLAUDE_CONFIG_DIR` set, every `~/.claude` path lives under
-//! that directory instead. So this config dir is the ONE tier bundled agents
-//! deploy into, on both the daemon and the flag-less standalone `tm run` path,
-//! which is why provisioning the complete set here remains mandatory. It also
-//! still carries AUTH + TRUST isolation (keychain / `.credentials.json` /
+//! WHICH LAYER ACTUALLY LOADS THE ROSTER (re-corrected 2026-07-31, issue
+//! #4451 — this note supersedes the 2026-07-30 #4409 correction it replaces):
+//! the AGENTS deployed here are read by a daemon-managed session ONLY because
+//! that session's `--setting-sources` list now names the `user` tier.
+//!
+//! The 07-30 correction concluded from a probe matrix that
+//! `$CLAUDE_CONFIG_DIR/agents/` "is discovered", and on that basis #4437 moved
+//! the roster here while the daemon spawn still carried `--setting-sources
+//! project,local`. That probe matrix ran a fresh headless `claude -p` with NO
+//! `--setting-sources` flag, so it measured Claude Code's DEFAULT tier set (all
+//! tiers, `user` included) — not the managed spawn's. Re-run against `claude`
+//! 2.1.220 from a cwd with no `.claude/`, with the same `CLAUDE_CONFIG_DIR`:
+//!
+//!   no flag                          -> all 42 bundled agents resolve
+//!   --setting-sources project,local  -> 5 built-ins only, zero bundled
+//!   --setting-sources user,project,local -> all 42 bundled agents resolve
+//!
+//! So the ORIGINAL reading — `project,local` excludes the `user` tier
+//! `CLAUDE_CONFIG_DIR` relocates — was right about the mechanism; only its
+//! conclusion (that the project layer must therefore deliver the roster) is
+//! obsolete. The fix keeps the roster here and teaches the spawn to load the
+//! tier: see `core::model_inject::SETTING_SOURCES_FLAG_RELOCATED`.
+//!
+//! `~/.claude/agents/` still goes unread, which is documented behavior — with
+//! `CLAUDE_CONFIG_DIR` set, every `~/.claude` path lives under that directory
+//! instead. That is also why re-admitting `user` does not re-admit the
+//! operator's global hooks (#1269). So this config dir is the ONE tier bundled
+//! agents deploy into, on both the daemon and the flag-less standalone `tm run`
+//! path, which is why provisioning the complete set here remains mandatory. It
+//! also still carries AUTH + TRUST isolation (keychain / `.credentials.json` /
 //! `.claude.json` keyed to this path). SKILLS are unchanged: they continue to
 //! deploy per-workspace via `prepare_session`, and this module's skill deploy
 //! remains belt-and-suspenders for the standalone path.

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -56,7 +56,8 @@ pub fn resolve_pm_model(config: &MpmConfig, explicit: Option<&str>) -> String {
     crate::core::config::resolve_agent_model(config, "pm", None, explicit)
 }
 
-/// The setting-sources flag every trusty-mpm-spawned `claude` carries.
+/// The setting-sources flag a spawn that does NOT relocate `CLAUDE_CONFIG_DIR`
+/// carries.
 ///
 /// Why (issue #1269 / step 4): the operator's global `~/.claude/settings.json`
 /// carries hooks (e.g. claude-mpm's) that bleed into — and interfere with —
@@ -64,26 +65,95 @@ pub fn resolve_pm_model(config: &MpmConfig, explicit: Option<&str>) -> String {
 /// load ONLY the project (tm-owned workspace `.claude/settings.json`) and local
 /// settings sources, excluding `user`. This is the correct isolation lever: it
 /// does NOT touch `~/.claude.json`, so the ambient OAuth login tm relies on is
-/// preserved.
-/// What: the literal flag string appended to every launch command.
+/// preserved. It stays the flag for launch paths that do NOT inject their own
+/// `CLAUDE_CONFIG_DIR` (`tm launch`, `tm connect`), where the `user` tier still
+/// resolves to the operator's real `~/.claude` and must stay excluded.
+/// What: the literal flag string appended to those launch commands.
 /// Test: `claude_command_includes_setting_sources`.
 pub const SETTING_SOURCES_FLAG: &str = "--setting-sources project,local";
 
-/// The settings tiers [`SETTING_SOURCES_FLAG`] actually enumerates.
+/// The setting-sources flag a spawn that DOES relocate `CLAUDE_CONFIG_DIR`
+/// carries.
 ///
-/// Why (issue #4203): a deploy step that writes agents into a tier this list
-/// does NOT name is a silent no-op — Claude Code never loads them, and nothing
-/// reports an error. Parsing the flag instead of hard-coding
-/// `["project", "local"]` keeps that invariant honest if the flag's value ever
-/// changes: the tier check and the spawned command can never drift apart.
-/// What: splits [`SETTING_SOURCES_FLAG`] at its first space and then the
-/// comma-separated tier list, trimming each name.
-/// Test: `setting_source_tiers_parses_the_flag`.
-pub fn setting_source_tiers() -> Vec<&'static str> {
-    SETTING_SOURCES_FLAG
-        .split_once(' ')
+/// Why (issue #4451): Claude Code discovers subagents (`agents/*.md`) per
+/// settings tier, and `$CLAUDE_CONFIG_DIR/agents` IS the `user` tier — the tier
+/// [`SETTING_SOURCES_FLAG`] deliberately drops. Since #4437 moved the bundled
+/// roster into the tm-managed `CLAUDE_CONFIG_DIR`, a managed session carrying
+/// the `project,local` flag saw ZERO bundled specialists: `Agent type
+/// 'rust-engineer' not found`, every delegation degrading to `general-purpose`,
+/// while the 42 files sat correctly on disk. Adding `user` back is safe here
+/// precisely BECAUSE the spawn relocates `CLAUDE_CONFIG_DIR`: the `user` tier
+/// then resolves to the tm-owned config home, not the operator's `~/.claude`,
+/// so the #1269 isolation goal (keep claude-mpm's global hooks out) is still met
+/// — by the relocation rather than by the exclusion.
+///
+/// Verified live against `claude` 2.1.220 with
+/// `CLAUDE_CONFIG_DIR=~/.trusty-tools/trusty-mpm/claude-config` from a cwd with
+/// no `.claude/`: `project,local` resolves 5 built-ins only, while both the
+/// flag-less default and `user,project,local` resolve all 42 bundled agents and
+/// NONE of the operator's own `~/.claude/agents` entries.
+/// What: the literal flag string appended to relocated launch commands.
+/// Test: `relocated_setting_sources_flag_loads_the_user_tier`,
+/// `setting_sources_flag_picks_by_config_dir`.
+pub const SETTING_SOURCES_FLAG_RELOCATED: &str = "--setting-sources user,project,local";
+
+/// Pick the setting-sources flag matching a spawn's `CLAUDE_CONFIG_DIR` posture.
+///
+/// Why (issue #4451): the two flags are not interchangeable, and picking the
+/// wrong one fails silently in opposite directions — `project,local` on a
+/// relocated spawn hides the bundled roster, `user,project,local` on a
+/// non-relocated spawn re-admits the operator's global hooks (#1269). Deriving
+/// the choice from the one input that decides it (does this spawn inject
+/// `CLAUDE_CONFIG_DIR`?) removes the chance of a call site getting it wrong.
+/// What: [`SETTING_SOURCES_FLAG_RELOCATED`] when `config_dir` is `Some`
+/// (the spawn points `CLAUDE_CONFIG_DIR` at a tm-owned home), otherwise
+/// [`SETTING_SOURCES_FLAG`].
+/// Test: `setting_sources_flag_picks_by_config_dir`.
+pub fn setting_sources_flag(config_dir: Option<&Path>) -> &'static str {
+    if config_dir.is_some() {
+        SETTING_SOURCES_FLAG_RELOCATED
+    } else {
+        SETTING_SOURCES_FLAG
+    }
+}
+
+/// The settings tiers a `--setting-sources <list>` flag actually enumerates.
+///
+/// Why (issue #4203): a deploy step that writes agents into a tier the spawn's
+/// flag does NOT name is a silent no-op — Claude Code never loads them, and
+/// nothing reports an error. Parsing the flag instead of hard-coding the tier
+/// names keeps that invariant honest if either flag's value ever changes: the
+/// tier check and the spawned command can never drift apart.
+/// What: splits `flag` at its first space and then the comma-separated tier
+/// list, trimming each name.
+/// Test: `setting_source_tiers_parses_the_flag`,
+/// `relocated_setting_sources_flag_loads_the_user_tier`.
+pub fn setting_source_tiers_of(flag: &'static str) -> Vec<&'static str> {
+    flag.split_once(' ')
         .map(|(_, list)| list.split(',').map(str::trim).collect())
         .unwrap_or_default()
+}
+
+/// The settings tiers [`SETTING_SOURCES_FLAG`] enumerates.
+///
+/// Why/What: see [`setting_source_tiers_of`]; this is the non-relocated
+/// (`tm launch` / `tm connect`) tier list.
+/// Test: `setting_source_tiers_parses_the_flag`.
+pub fn setting_source_tiers() -> Vec<&'static str> {
+    setting_source_tiers_of(SETTING_SOURCES_FLAG)
+}
+
+/// The settings tiers [`SETTING_SOURCES_FLAG_RELOCATED`] enumerates.
+///
+/// Why (issue #4451): `tm doctor` needs this list to assert that the tier the
+/// bundled roster deploys into is one a managed session actually loads. Reading
+/// it from the flag — rather than re-stating `["user", "project", "local"]` —
+/// is what makes the doctor check a real gate instead of a tautology: change
+/// either the flag or the deploy destination alone and the check fails.
+/// What: see [`setting_source_tiers_of`].
+/// Test: `relocated_setting_sources_flag_loads_the_user_tier`.
+pub fn relocated_setting_source_tiers() -> Vec<&'static str> {
+    setting_source_tiers_of(SETTING_SOURCES_FLAG_RELOCATED)
 }
 
 /// Name the Claude Code settings tier a `.claude/` deploy destination lands in,
@@ -300,9 +370,36 @@ mod tests {
         assert_eq!(setting_source_tiers(), vec!["project", "local"]);
         assert!(
             !setting_source_tiers().contains(&"user"),
-            "the `user` tier is deliberately excluded (issue #1269); a deploy \
-             landing there is invisible to the session"
+            "on a spawn that does NOT relocate CLAUDE_CONFIG_DIR the `user` tier \
+             is the operator's real ~/.claude and stays excluded (issue #1269)"
         );
+    }
+
+    #[test]
+    fn relocated_setting_sources_flag_loads_the_user_tier() {
+        // #4451: bundled agents deploy into $CLAUDE_CONFIG_DIR/agents, which IS
+        // the `user` tier. A relocated spawn that does not load `user` cannot
+        // see a single bundled specialist, however complete the deploy is.
+        assert!(
+            relocated_setting_source_tiers().contains(&"user"),
+            "the relocated spawn must load the `user` tier — that is where the \
+             bundled roster lives once CLAUDE_CONFIG_DIR is redirected"
+        );
+        assert_eq!(
+            relocated_setting_source_tiers(),
+            vec!["user", "project", "local"]
+        );
+    }
+
+    #[test]
+    fn setting_sources_flag_picks_by_config_dir() {
+        // #4451: the choice is derived from the one fact that decides it —
+        // whether the spawn injects its own CLAUDE_CONFIG_DIR.
+        assert_eq!(
+            setting_sources_flag(Some(Path::new("/tm/claude-config"))),
+            SETTING_SOURCES_FLAG_RELOCATED
+        );
+        assert_eq!(setting_sources_flag(None), SETTING_SOURCES_FLAG);
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1117,6 +1117,7 @@ async fn doctor_endpoint_returns_report() {
     let expected = [
         "instructions",
         "agents",
+        "agent_reachability",
         "skills",
         "skill_source",
         "output_style",

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -42,6 +42,13 @@ use doctor_fs_checks::{check_agents, check_instructions, check_skill_source, che
 mod doctor_deploy_validate;
 use doctor_deploy_validate::check_deployment_completeness;
 
+// #4451: the resolvability half — `check_agents` and
+// `check_deployment_completeness` above are both presence-only and stayed green
+// while the harness could not reach a single deployed agent.
+#[path = "doctor_agent_reachability.rs"]
+mod doctor_agent_reachability;
+use doctor_agent_reachability::check_agent_reachability;
+
 // Split out to keep this file under the 500-SLOC production cap (issue #2876 —
 // the skill-staleness and legacy-instruction-source probes).
 #[path = "doctor_staleness.rs"]
@@ -191,7 +198,7 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// the one tm-managed `CLAUDE_CONFIG_DIR` tier and nowhere else, so
 /// `check_agents`/`check_agent_skills` probe `paths.agent_deploy_dir()`, which
 /// is the same directory whether or not a `project_dir` was supplied.
-/// Test: `run_doctor_produces_twenty_two_checks`,
+/// Test: `run_doctor_produces_twenty_three_checks`,
 /// `agents_check_probes_the_managed_config_tier_not_the_workspace`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
@@ -216,6 +223,9 @@ pub async fn run_doctor(
     let mut checks = vec![
         check_instructions(project_dir),
         check_agents(&paths),
+        // #4451: `check_agents` proves the files exist; this proves the tier
+        // they land in is one a managed session's harness actually scans.
+        check_agent_reachability(&paths, project_dir),
         check_skills(skills_root),
         check_skill_source(&paths),
         check_output_style(project_dir, &home),

--- a/crates/trusty-mpm/src/daemon/doctor_agent_reachability.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_agent_reachability.rs
@@ -1,0 +1,122 @@
+//! Doctor probe: can a managed session's harness actually REACH the deployed
+//! bundled agents? (issue #4451)
+//!
+//! Why: `check_agents` (`doctor_fs_checks`) and `check_deployment_completeness`
+//! (`doctor_deploy_validate`) are both presence-only — they count `.md` files
+//! and diff the payload against the canonical roster. Neither can fail when the
+//! files are perfectly deployed into a directory the harness never scans, which
+//! is exactly what #4451 was: 42 well-formed agents on disk, both checks green,
+//! and every delegation failing with `Agent type '<name>' not found`. A check
+//! that cannot fail when the thing it checks is broken has no value.
+//!
+//! What this probe asserts is the one invariant those two cannot: the SETTINGS
+//! TIER the roster deploys into must be a tier the managed spawn's
+//! `--setting-sources` flag actually loads. Both sides are read from
+//! production code — the deploy destination from
+//! [`FrameworkPaths::agent_deploy_dir`], the tier list from
+//! [`crate::core::model_inject::relocated_setting_source_tiers`] — so this is
+//! not a restatement of a constant: move the deploy destination without
+//! updating the flag (what #4437 did) or narrow the flag without moving the
+//! roster, and this check fails.
+//!
+//! Deliberately STATIC rather than spawning a probe `claude -p`: a live spawn
+//! costs tens of seconds, needs network and auth, and would make `tm doctor`
+//! flaky and slow on the one code path operators reach for when things are
+//! already broken. The static form catches the entire failure CLASS (#4203 and
+//! #4451 are the same bug at two different deploy destinations) at zero cost.
+//!
+//! Test: `crates/trusty-mpm/src/daemon/doctor_agent_reachability_tests.rs`.
+
+use std::path::Path;
+
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+use crate::core::model_inject::{
+    SETTING_SOURCES_FLAG_RELOCATED, relocated_setting_source_tiers, settings_tier_of,
+};
+use crate::core::paths::FrameworkPaths;
+
+/// Name of this check as it appears in `tm doctor` output.
+const CHECK_NAME: &str = "agent_reachability";
+
+/// Probe whether the bundled-agent deploy tier is one a managed session loads.
+///
+/// Why: see the module doc — this is the resolvability half of #4451, distinct
+/// from the presence-only `agents`/`deployment` checks. It is a hard `Fail`,
+/// not a `Warn`: when it trips, the session has NO specialists at all and every
+/// delegation silently degrades to `general-purpose`, which is a broken stack
+/// rather than a configuration preference.
+/// What: resolves the settings tier the roster deploys into via
+/// [`settings_tier_of`] (`harness_cwd` is the managed session's working
+/// directory — the cwd `claude` is spawned with, which is what makes a
+/// destination "project" rather than "user"), then asserts that tier appears in
+/// [`relocated_setting_source_tiers`]. `Fail` when it does not, naming the
+/// deploy directory, the tier, and the flag so the message is actionable
+/// without reading the source. `Ok` otherwise.
+/// Test: `production_deploy_tier_is_reachable`,
+/// `ok_for_a_project_tier_deploy_destination`.
+pub(super) fn check_agent_reachability(
+    paths: &FrameworkPaths,
+    harness_cwd: Option<&Path>,
+) -> DoctorCheck {
+    let dir = paths.agent_deploy_dir();
+    // The tier is decided by the deploy destination's `.claude`-equivalent
+    // HOME, not by the `agents/` leaf — `settings_tier_of` compares that home
+    // against the harness cwd. For the tm-managed destination the home is
+    // `$CLAUDE_CONFIG_DIR`; falling back to `dir` itself keeps a malformed
+    // (parentless) path from panicking.
+    let deploy_home = dir.parent().unwrap_or(&dir);
+    // With no project directory supplied there is no managed cwd to compare
+    // against; an empty path can never equal a real deploy home, so the tier
+    // resolves to `user` — which is the correct answer for the tm-managed
+    // destination and the conservative one for any other.
+    let cwd = harness_cwd.unwrap_or_else(|| Path::new(""));
+    let tier = settings_tier_of(deploy_home, cwd);
+    verdict(&dir, tier, &relocated_setting_source_tiers())
+}
+
+/// Pure verdict: does `tier` appear in `loaded`? (issue #4451)
+///
+/// Why: separated from [`check_agent_reachability`] so the FAIL branch is
+/// directly testable. The real tier list comes from a compile-time constant, so
+/// a test that could only call the wrapper would be unable to exercise the very
+/// branch this check exists for — it would assert the happy path and silently
+/// lose the regression guard, which is the same shape of blind spot #4451 is
+/// about.
+/// What: `Ok` when `loaded` contains `tier`; `Fail` otherwise, with a message
+/// naming the deploy directory, the tier, the spawn flag, and the tiers that
+/// flag actually loads.
+/// Test: `ok_when_the_deploy_tier_is_loaded`,
+/// `fails_when_the_spawn_flag_drops_the_deploy_tier`,
+/// `failure_names_the_directory_the_tier_and_the_flag`,
+/// `failure_is_a_hard_fail_not_a_warn`.
+fn verdict(dir: &Path, tier: &str, loaded: &[&str]) -> DoctorCheck {
+    if loaded.contains(&tier) {
+        return DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Ok,
+            format!(
+                "bundled agents deploy into the `{tier}` tier ({}), which a managed \
+                 session loads via `{SETTING_SOURCES_FLAG_RELOCATED}`",
+                dir.display()
+            ),
+        );
+    }
+    DoctorCheck::new(
+        CHECK_NAME,
+        CheckStatus::Fail,
+        format!(
+            "bundled agents deploy into the `{tier}` tier ({}) but a managed session \
+             launches with `{SETTING_SOURCES_FLAG_RELOCATED}`, which loads only [{}] — \
+             the harness never scans that directory, so EVERY delegation degrades to \
+             `general-purpose` with `Agent type '<name>' not found`, no matter how \
+             complete the deploy is (issue #4451). Fix the spawn flag or the deploy \
+             destination so the two name the same tier.",
+            dir.display(),
+            loaded.join(", ")
+        ),
+    )
+}
+
+#[cfg(test)]
+#[path = "doctor_agent_reachability_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/doctor_agent_reachability_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_agent_reachability_tests.rs
@@ -1,0 +1,131 @@
+//! Tests for the #4451 agent-reachability doctor probe.
+//!
+//! Why: split out of `doctor_agent_reachability.rs` so that file stays well
+//! under the 500-SLOC production cap, matching the existing
+//! `doctor_push_guard{,_tests}.rs` pattern.
+//! What: covers both branches of the pure [`super::verdict`] decision plus the
+//! two wrapper paths that resolve a real tier from a `FrameworkPaths`.
+//! Test: this file.
+
+use std::path::Path;
+
+use super::{check_agent_reachability, verdict};
+use crate::core::doctor::CheckStatus;
+use crate::core::model_inject::relocated_setting_source_tiers;
+use crate::core::paths::FrameworkPaths;
+
+/// The happy path: the tier the roster deploys into is one the spawn loads.
+#[test]
+fn ok_when_the_deploy_tier_is_loaded() {
+    let check = verdict(
+        Path::new("/tm/claude-config/agents"),
+        "user",
+        &["user", "project", "local"],
+    );
+    assert_eq!(check.status, CheckStatus::Ok);
+    assert_eq!(check.name, "agent_reachability");
+}
+
+/// The regression this check exists for: a perfectly deployed roster in a tier
+/// the spawn flag does not name. This is precisely #4451 — presence-only checks
+/// stayed green here while every delegation failed.
+#[test]
+fn fails_when_the_spawn_flag_drops_the_deploy_tier() {
+    let check = verdict(
+        Path::new("/tm/claude-config/agents"),
+        "user",
+        &["project", "local"],
+    );
+    assert_eq!(
+        check.status,
+        CheckStatus::Fail,
+        "a deploy tier the spawn never loads must FAIL, not warn: {}",
+        check.message
+    );
+}
+
+/// A failure operators cannot act on is worth little — pin the three facts the
+/// message must carry.
+#[test]
+fn failure_names_the_directory_the_tier_and_the_flag() {
+    let check = verdict(
+        Path::new("/tm/claude-config/agents"),
+        "user",
+        &["project", "local"],
+    );
+    assert!(
+        check.message.contains("/tm/claude-config/agents"),
+        "message must name the deploy directory: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("`user` tier"),
+        "message must name the unreachable tier: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("--setting-sources"),
+        "message must name the spawn flag: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("#4451"),
+        "message must cite the issue: {}",
+        check.message
+    );
+}
+
+/// Doctor must not soften this to a `Warn`: when it trips there are zero
+/// specialists in the session, which is a broken stack, not a preference.
+#[test]
+fn failure_is_a_hard_fail_not_a_warn() {
+    let check = verdict(Path::new("/somewhere/agents"), "user", &[]);
+    assert_ne!(check.status, CheckStatus::Warn);
+    assert_eq!(check.status, CheckStatus::Fail);
+}
+
+/// The live coupling: the production deploy destination must land in a tier the
+/// production spawn flag loads. This is the assertion that would have caught
+/// #4437's move — it reads BOTH sides from production code, so changing either
+/// one alone trips it.
+#[test]
+fn production_deploy_tier_is_reachable() {
+    let paths = FrameworkPaths::under("/base");
+    let check = check_agent_reachability(&paths, Some(Path::new("/base/workspace")));
+    assert_eq!(
+        check.status,
+        CheckStatus::Ok,
+        "the bundled roster deploys into a tier managed sessions do not load \
+         (loaded: {:?}): {}",
+        relocated_setting_source_tiers(),
+        check.message
+    );
+}
+
+/// A project-tier deploy destination (deploy home == harness cwd) is also
+/// reachable — the check gates on tier membership, not on one specific
+/// directory, so a future move back to project-local deployment stays green
+/// without editing this probe.
+#[test]
+fn ok_for_a_project_tier_deploy_destination() {
+    let mut paths = FrameworkPaths::under("/base");
+    let workspace = Path::new("/base/workspace");
+    paths.agent_deploy = workspace.join("agents");
+    let check = check_agent_reachability(&paths, Some(workspace));
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+    assert!(
+        check.message.contains("`project` tier"),
+        "expected the project tier to be named: {}",
+        check.message
+    );
+}
+
+/// With no project directory supplied the probe still resolves a tier rather
+/// than panicking or silently passing on an unknown.
+#[test]
+fn resolves_a_tier_without_a_project_directory() {
+    let paths = FrameworkPaths::under("/base");
+    let check = check_agent_reachability(&paths, None);
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+    assert!(check.message.contains("`user` tier"), "{}", check.message);
+}

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -102,7 +102,7 @@ async fn agents_check_probes_the_managed_config_tier_not_the_workspace() {
 }
 
 #[tokio::test]
-async fn run_doctor_produces_twenty_two_checks() {
+async fn run_doctor_produces_twenty_three_checks() {
     // Issue #2158 added the `deployment` probe (nine → ten); issue #2246
     // adds `oauth_token` (ten → eleven); issue #2876 adds `skill_staleness`
     // and `legacy_sources` (eleven → thirteen); DOC-42 / issue #2889 adds
@@ -114,7 +114,8 @@ async fn run_doctor_produces_twenty_two_checks() {
     // nineteen); issue #3453 part 2 adds `output_style_legacy_ids` (nineteen
     // → twenty); issue #3427 adds `scaffold_tracking` (twenty →
     // twenty-one); issue #2867 adds `push_guard` (twenty-one →
-    // twenty-two).
+    // twenty-two); issue #4451 adds `agent_reachability` (twenty-two →
+    // twenty-three).
     // #1905's stale-skill cleanup is deliberately NOT a `run_doctor` probe
     // — see the `run_doctor` doc.
     let report = run_doctor(None, None, &[]).await;
@@ -122,6 +123,7 @@ async fn run_doctor_produces_twenty_two_checks() {
     let expected = [
         "instructions",
         "agents",
+        "agent_reachability",
         "skills",
         "skill_source",
         "output_style",

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -224,16 +224,26 @@ fn prompt_file_flag(prompt_file: Option<&Path>) -> String {
 /// `--setting-sources project,local` is RETAINED and is LOAD-BEARING for where
 /// the roster comes from: it restricts every setting source Claude Code loads —
 /// settings.json, subagents (`agents/*.md`), and skills (`skills/`) — to the
-/// `project` + `local` tiers, EXCLUDING the `user` tier. Because
-/// `CLAUDE_CONFIG_DIR` relocates the `user` tier, the agents/skills/hooks the
-/// daemon provisions INTO that config home are NOT read while this flag is in
-/// force (empirically verified against `claude` 2.1.201, DOC-34 review). The
-/// full framework roster, skills, project hooks (trusty-memory + PM-guard) and
-/// MCP servers are instead delivered by the PROJECT layer — `<workspace>/.claude/
-/// {agents,skills,settings.json,.mcp.json}` — which `session_launch::
-/// prepare_session` (run on every daemon spawn path) deploys and which
-/// `project,local` DOES load. The flag also excludes the operator's global
-/// `~/.claude/settings.json` (#1269). `--dangerously-skip-permissions` keeps the
+/// tiers it names. This spawn ALWAYS injects `CLAUDE_CONFIG_DIR`, so it carries
+/// [`crate::core::model_inject::SETTING_SOURCES_FLAG_RELOCATED`]
+/// (`--setting-sources user,project,local`), selected by
+/// [`crate::core::model_inject::setting_sources_flag`].
+///
+/// Issue #4451 — why `user` is in that list, and why it MUST stay: the earlier
+/// `project,local` value (correct for #1269 when the roster lived in the
+/// project tier) became wrong the moment #4437 moved bundled agents into
+/// `$CLAUDE_CONFIG_DIR/agents`, which IS the `user` tier. A managed session then
+/// resolved zero bundled specialists (`Agent type 'rust-engineer' not found`)
+/// with all 42 files correctly on disk. Re-admitting `user` does NOT re-admit
+/// the operator's global `~/.claude/settings.json` hooks the #1269 exclusion was
+/// protecting against: `CLAUDE_CONFIG_DIR` relocates the whole `user` tier to
+/// the tm-owned config home, so the isolation now comes from the relocation.
+/// Verified live against `claude` 2.1.220 — see the constant's own doc.
+/// Project hooks (trusty-memory + PM-guard), workspace skills and MCP servers
+/// continue to come from the PROJECT layer — `<workspace>/.claude/
+/// {skills,settings.json,.mcp.json}` — which `session_launch::prepare_session`
+/// (run on every daemon spawn path) deploys and which `project,local` loads.
+/// `--dangerously-skip-permissions` keeps the
 /// unattended orchestration session from blocking on per-tool prompts (#1269).
 /// Both flags reuse the shared [`crate::core::model_inject::SETTING_SOURCES_FLAG`]
 /// / [`crate::core::model_inject::PERMISSION_MODE_FLAG`] constants so this spawn
@@ -282,7 +292,9 @@ fn spawn_command(
         claude_code_gh_env::gh_env_source_prefix(gh_env_file),
         env_bin_prefix(claude_bin, config_dir, oauth_token),
         prompt_file_flag(prompt_file),
-        crate::core::model_inject::SETTING_SOURCES_FLAG,
+        // #4451: the relocated spawn must load the `user` tier — that is where
+        // `CLAUDE_CONFIG_DIR/agents` (the bundled roster) lives.
+        crate::core::model_inject::setting_sources_flag(config_dir),
         crate::core::model_inject::PERMISSION_MODE_FLAG,
         on_exit_hint_suffix(),
     );
@@ -392,7 +404,8 @@ fn resume_command(
         claude_code_gh_env::gh_env_source_prefix(gh_env_file),
         env_bin_prefix(claude_bin, config_dir, oauth_token),
         prompt_file_flag(prompt_file),
-        crate::core::model_inject::SETTING_SOURCES_FLAG,
+        // #4451: same relocated-tier contract as `spawn_command`.
+        crate::core::model_inject::setting_sources_flag(config_dir),
         crate::core::model_inject::PERMISSION_MODE_FLAG,
     );
     let cmd = match claude_session_id {
@@ -811,7 +824,8 @@ fn compose_inplace_args(
         args.push(prompt.display().to_string());
     }
     args.extend(
-        crate::core::model_inject::SETTING_SOURCES_FLAG
+        // #4451: in-place relaunch inherits the same relocated-tier contract.
+        crate::core::model_inject::setting_sources_flag(config_dir)
             .split_whitespace()
             .chain(crate::core::model_inject::PERMISSION_MODE_FLAG.split_whitespace())
             .map(str::to_owned),

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -144,9 +144,80 @@ fn spawn_command_sets_claude_config_dir() {
         "spawn command must scrub the key (via -u, BEFORE the NAME=VALUE assignment per \
              POSIX env grammar) then set (single-quoted) CLAUDE_CONFIG_DIR: {cmd}"
     );
+    // #4451: with a config dir the spawn relocates the `user` tier onto tm's
+    // own config home, so the flag MUST name that tier — it is where
+    // `CLAUDE_CONFIG_DIR/agents` (the bundled roster) lives. Carrying
+    // `project,local` here is exactly the regression that left managed
+    // sessions with zero specialists.
     assert!(
-        cmd.contains("--setting-sources project,local"),
-        "isolation flag must still be present with a config dir: {cmd}"
+        cmd.contains("--setting-sources user,project,local"),
+        "a relocated spawn must load the `user` tier: {cmd}"
+    );
+}
+
+#[test]
+fn spawn_command_loads_the_user_tier_only_when_config_dir_is_relocated() {
+    // #4451 both directions in one test, because the two failures are
+    // opposite and each is silent:
+    //   - relocated spawn WITHOUT `user` → no bundled agents resolve
+    //   - non-relocated spawn WITH `user` → the operator's global
+    //     ~/.claude/settings.json hooks bleed back in (#1269)
+    let relocated = spawn_command(
+        Path::new(TEST_CWD),
+        "claude",
+        Some(Path::new(
+            "/home/bob/.trusty-tools/trusty-mpm/claude-config",
+        )),
+        TEST_SESSION_ID,
+        None,
+        None,
+        None,
+    );
+    assert!(
+        relocated.contains("--setting-sources user,project,local"),
+        "relocated spawn must load the tm-owned `user` tier: {relocated}"
+    );
+
+    let ambient = spawn_command(
+        Path::new(TEST_CWD),
+        "claude",
+        None,
+        TEST_SESSION_ID,
+        None,
+        None,
+        None,
+    );
+    assert!(
+        ambient.contains("--setting-sources project,local"),
+        "non-relocated spawn must keep the #1269 exclusion: {ambient}"
+    );
+    assert!(
+        !ambient.contains("user,project,local"),
+        "without CLAUDE_CONFIG_DIR the `user` tier is the operator's real \
+         ~/.claude and must stay excluded (#1269): {ambient}"
+    );
+}
+
+#[test]
+fn resume_command_loads_the_user_tier_when_config_dir_is_relocated() {
+    // #4451: a resumed session is as agent-dependent as a fresh one — the
+    // resume path must not be the one that silently keeps the old flag.
+    let cmd = resume_command(
+        Path::new(TEST_CWD),
+        "claude",
+        Some(Path::new(
+            "/home/bob/.trusty-tools/trusty-mpm/claude-config",
+        )),
+        Some("abc-123"),
+        false,
+        TEST_SESSION_ID,
+        None,
+        None,
+        None,
+    );
+    assert!(
+        cmd.contains("--setting-sources user,project,local"),
+        "relocated resume must load the tm-owned `user` tier: {cmd}"
     );
 }
 
@@ -1592,6 +1663,40 @@ fn compose_inplace_args_omits_prompt_flag_when_absent() {
     assert!(
         args.contains(&"--setting-sources".to_owned()),
         "isolation flags are unconditional: {args:?}"
+    );
+}
+
+#[test]
+fn compose_inplace_args_loads_the_user_tier_when_config_dir_is_relocated() {
+    // #4451: the in-place relaunch (bare `tm` inside a managed pane) is a
+    // third spawn path with its own argv builder — it must pick the same
+    // relocated-tier flag, or a relaunched session silently loses every
+    // bundled specialist the pane had before.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let cwd = tmp.path().join("workspace-inplace-tier");
+    std::fs::create_dir_all(&cwd).unwrap();
+    let config_dir = tmp.path().join("claude-config");
+
+    let relocated = compose_inplace_args(&cwd, Some(&config_dir), None, None);
+    let idx = relocated
+        .iter()
+        .position(|a| a == "--setting-sources")
+        .expect("setting-sources flag must be present");
+    assert_eq!(
+        relocated[idx + 1],
+        "user,project,local",
+        "relocated in-place relaunch must load the tm-owned `user` tier: {relocated:?}"
+    );
+
+    let ambient = compose_inplace_args(&cwd, None, None, None);
+    let idx = ambient
+        .iter()
+        .position(|a| a == "--setting-sources")
+        .expect("setting-sources flag must be present");
+    assert_eq!(
+        ambient[idx + 1],
+        "project,local",
+        "without a relocated config dir the #1269 exclusion stands: {ambient:?}"
     );
 }
 


### PR DESCRIPTION
## The real mechanism

Claude Code discovers subagents (`agents/*.md`) **per settings tier**, and
`$CLAUDE_CONFIG_DIR/agents` — where #4437 moved the bundled roster — **is the
`user` tier**. Every daemon-managed spawn carried
`--setting-sources project,local`, which drops that tier. So the harness never
scanned the directory holding all 42 agents.

Reproduced live against `claude` 2.1.220, from a cwd with no `.claude/`, with
`CLAUDE_CONFIG_DIR=~/.trusty-tools/trusty-mpm/claude-config`:

| flag | agent types the Task tool exposes |
|---|---|
| *(none)* | all 42 bundled + 5 built-ins |
| `--setting-sources project,local` | `claude, Explore, general-purpose, Plan, statusline-setup` |
| `--setting-sources user,project,local` | all 42 bundled + 5 built-ins |

Under the fixed flag, dispatching `rust-engineer` — the agent that could not be
loaded at all in the reporting session — resolves *and executes*.

## How this reconciles with the 2026-07-30 ruling

The #4409 probe matrix concluded `$CLAUDE_CONFIG_DIR/agents` "is discovered",
and #4437 moved the roster on that basis. That probe ran **a fresh headless
`claude -p` with no `--setting-sources` flag**, so it measured Claude Code's
*default* tier set — which includes `user` — not the flag every managed spawn
actually carries. Row 1 of the table above reproduces exactly what that probe
saw. The finding was correct for the conditions it ran under; it simply did not
test the managed-spawn condition.

The **original** reading — the one the 07-30 note overturned, still recorded in
`daemon/managed_routes/deployment_check.rs::warn_if_no_persona_carrier`
(#2231) and in `runtime/claude_code.rs` — was right about the mechanism. Only
its conclusion (that the project tier must therefore deliver the roster) is
obsolete. `core/managed_config.rs`'s note is corrected in this PR rather than
left as two contradicting comments in the tree.

## Fix

- Relocated spawns carry `--setting-sources user,project,local`
  (`SETTING_SOURCES_FLAG_RELOCATED`), selected by
  `model_inject::setting_sources_flag(config_dir)` from the one fact that
  decides it: does this spawn inject its own `CLAUDE_CONFIG_DIR`?
- Applied at all three spawn builders in `runtime/claude_code.rs`:
  `spawn_command`, `resume_command`, `compose_inplace_args` (the bare-`tm`
  in-place relaunch).
- **#1269 is not regressed.** Re-admitting `user` does not re-admit the
  operator's global `~/.claude/settings.json` hooks: the spawn relocates
  `CLAUDE_CONFIG_DIR`, so the `user` tier resolves to the tm-owned config home.
  Proof in the probe above — the five non-tm agents in the operator's real
  `~/.claude/agents` (`base`, `copyeditor`, `proofreader`, `writer`,
  `writing-critic`) appear in **none** of the three runs. Isolation now comes
  from the relocation rather than from the exclusion.
- `tm launch` / `tm connect` (`build_claude_command`) do not inject a config
  dir, so they keep `project,local` unchanged.

## Doctor half

New `agent_reachability` check (`daemon/doctor_agent_reachability.rs`), a hard
`Fail`, not a `Warn`.

`check_agents` counts `.md` files; `check_deployment_completeness` diffs the
payload against the canonical roster. Both are presence-only and both reported
green throughout this outage — a check that cannot fail when the thing it
checks is broken has no value. The new check asserts what neither can: **the
settings tier the roster deploys into must be a tier the managed spawn's
`--setting-sources` flag loads.** It reads the deploy destination from
`FrameworkPaths::agent_deploy_dir()` and the tier list from the spawn flag
itself, so it is a coupling and not a restatement of a constant — move one side
without the other (exactly what #4437 did) and it fails.

Deliberately static rather than spawning a probe `claude -p`: a live spawn costs
tens of seconds and needs network and auth, which would make `tm doctor` slow
and flaky on the one command operators reach for when things are already broken.
The static form catches the whole failure class (#4203 and #4451 are the same
bug at two different deploy destinations) at zero cost.

## Not fixed here — `gh_account` false negative under `GH_TOKEN`

Confirmed and deliberately left out of this PR. `core::gh_account::active_gh_account()`
takes a subprocess-free `hosts.yml` shortcut first, but when `GH_TOKEN` is set
in the environment `gh` uses that token and ignores the `hosts.yml` active
pointer — so doctor can name the wrong active account. On this machine
`gh auth status` reports `bobmatnyc (GH_TOKEN)` active while `hosts.yml` marks a
different account.

Excluded on purpose: it is in a different file, and the obvious fix (skip the
local shortcut when `GH_TOKEN`/`GITHUB_TOKEN` is set) forces a `gh` subprocess
onto `active_gh_account()` — which the statusline calls on its hot render path,
the exact cost that shortcut exists to avoid. It needs its own change with a
render-path-safe design, not a rider on this one.

Closes #4451

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
