### PR TITLE
fix(trusty-mpm): bridge managed id to Claude session UUID in session_status

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -20,6 +20,21 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `usable_agent_id` (non-null, non-empty string), so the presence-check and
     the consumers are structurally incapable of disagreeing again.
 
+- `session_status` MCP tool no longer reports `delegation_count: 0` for a managed session with subagents genuinely in flight (closes [#4141](https://github.com/bobmatnyc/trusty-tools/issues/4141))
+  - The handler resolved a `ManagedSessionId` and passed it straight into
+    `delegations_for`, but hook-observed delegations are keyed by the Claude
+    session UUID — a different identifier space bridged only via
+    `SessionRecord::claude_session_id` /
+    `session_start_correlation::correlate_session_start`. The mismatch made
+    the surface that answers "what is in flight right now" structurally
+    blind to its own feature.
+  - The managed branch now bridges through `record.claude_session_id` before
+    querying. When the bridge itself is missing (no correlated Claude session
+    id yet), `delegation_count` reports an explicit `null` with
+    `delegation_lookup: "unbridged"` rather than a confident-looking `0` —
+    an unbridgeable lookup must never be indistinguishable from "genuinely
+    none in flight".
+
 - managed sessions can reach the bundled agent roster again — every delegation was degrading to `general-purpose` (closes [#4451](https://github.com/bobmatnyc/trusty-tools/issues/4451))
   - Daemon-managed spawns now launch with `--setting-sources user,project,local`
     instead of `project,local`. Claude Code discovers subagents per settings

--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -28,12 +28,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     `session_start_correlation::correlate_session_start`. The mismatch made
     the surface that answers "what is in flight right now" structurally
     blind to its own feature.
-  - The managed branch now bridges through `record.claude_session_id` before
-    querying. When the bridge itself is missing (no correlated Claude session
-    id yet), `delegation_count` reports an explicit `null` with
-    `delegation_lookup: "unbridged"` rather than a confident-looking `0` —
-    an unbridgeable lookup must never be indistinguishable from "genuinely
-    none in flight".
+  - The managed branch now reads BOTH key spaces — the managed id
+    `agent_delegate` (#1976) writes under, and the bridged Claude UUID
+    hook-observed delegations use — and unions them, deduplicated. When the
+    bridge itself is missing (no correlated Claude session id yet),
+    `delegation_count` and `delegations` both report an explicit `null` with
+    `delegation_lookup: "unbridged"` rather than a confident-looking
+    `0`/`[]` — an unbridgeable lookup must never be indistinguishable from
+    "genuinely none in flight".
 
 - managed sessions can reach the bundled agent roster again — every delegation was degrading to `general-purpose` (closes [#4451](https://github.com/bobmatnyc/trusty-tools/issues/4451))
   - Daemon-managed spawns now launch with `--setting-sources user,project,local`

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -100,24 +100,38 @@ impl OrchestratorBackend for StateBackend {
     /// serialized via the shared `record_to_json` (matching `session_list`) and
     /// carry no memory snapshot.
     ///
-    /// #4141: the legacy registry's `SessionId` IS the Claude session UUID
-    /// (hook auto-registration uses it directly), so `delegations_for(id)`
-    /// resolves correctly for that branch with no bridging. The MANAGED
-    /// branch is different: `id` here is a `ManagedSessionId`, but
-    /// hook-observed delegations are keyed by the Claude session UUID that
-    /// `session_start_correlation::correlate_session_start` stores on the
-    /// record as `claude_session_id` — a distinct identifier space (that's
-    /// the whole reason `SessionRecord` carries both fields separately).
-    /// Passing the managed id straight into `delegations_for` silently
-    /// matched nothing and reported `delegation_count: 0` even while
-    /// subagents were actively running — a false all-clear indistinguishable
-    /// from "genuinely none in flight". The fix bridges through
-    /// `record.claude_session_id` before querying, exactly as
-    /// `correlate_session_start` intends; when the bridge itself is missing
-    /// (no correlated Claude session id yet, e.g. the session hasn't started
-    /// or no `SessionStart` hook has landed), `delegation_count` is reported
-    /// as an explicit `null` with `delegation_lookup: "unbridged"` — never a
-    /// confident-looking zero.
+    /// # Delegation lookup (#4141)
+    ///
+    /// Delegations live in up to TWO key spaces. `agent_delegate` (#1976) keys
+    /// a delegation by whatever session id the CALLER passed — for a managed
+    /// session that is the MANAGED id itself (exercised over `/rpc` by
+    /// `connectors::tm::WorkstreamConnector::delegate`, certified by
+    /// `agent_delegate_accepts_managed_session` in `mcp_backend_tests.rs`).
+    /// Hook-observed delegations (`delegation_tracker::observe`) are instead
+    /// keyed by the Claude session UUID, reachable from a managed record only
+    /// by bridging through `record.claude_session_id` (populated by
+    /// `session_start_correlation::correlate_session_start`). Replacing the
+    /// managed-id read with the bridged one — instead of unioning both —
+    /// silently drops every `agent_delegate`-keyed record: the exact
+    /// false-all-clear #4141 exists to eliminate, just relocated to the other
+    /// key. The managed branch below reads BOTH spaces and de-duplicates by
+    /// delegation id.
+    ///
+    /// The legacy branch's `id` equals the Claude session UUID only on the
+    /// `SessionStart`-hook-auto-registered path; a tmux-pane-discovered,
+    /// native-process-discovered, or `POST /sessions`-registered legacy
+    /// session instead gets a freshly minted `SessionId` never correlated to
+    /// anything, so `delegations_for(id)` can under-report there too. No
+    /// marker distinguishes those three registration paths at this call site,
+    /// so the legacy branch omits `delegation_lookup` rather than assert an
+    /// `"ok"` it cannot establish for every path (that pre-existing gap is
+    /// tracked separately from this fix).
+    ///
+    /// When the managed bridge itself is missing (no correlated Claude
+    /// session id yet), `delegation_count` AND `delegations` are both an
+    /// explicit `null` with `delegation_lookup: "unbridged"` — the managed-id
+    /// half alone would be a floor masquerading as a total, so neither field
+    /// may be read as a confident (even if empty) answer.
     async fn session_status(&self, session_id: &str) -> Result<Value, String> {
         let id = parse_session_id(session_id)?;
         // Legacy in-process registry first.
@@ -130,32 +144,43 @@ impl OrchestratorBackend for StateBackend {
                 "memory": memory,
                 "delegation_count": delegations.len(),
                 "delegations": delegations,
-                "delegation_lookup": "ok",
             }));
         }
         // Managed store fallback (#1976): the `tmpm-` sessions `session_list`
         // surfaces and `session_stop`/`session_resume` already target by id.
         let manager = self.state.session_manager().await;
         if let Ok(record) = manager.get(&ManagedSessionId(id.0)).await {
-            // #4141: bridge the managed id to the Claude session UUID before
-            // querying delegations — they live in a different key space.
+            // #4141: read the managed-id key space unconditionally — this is
+            // what `agent_delegate` (#1976) writes under for a managed
+            // session — then union in the Claude-UUID key space when the
+            // bridge resolves, de-duplicating by delegation id.
+            let mut delegations = self.state.delegations_for(id);
             let claude_uuid = record
                 .claude_session_id
                 .as_deref()
                 .and_then(|s| Uuid::parse_str(s).ok());
-            let (delegation_count, delegations, lookup) = match claude_uuid {
+            let (delegation_count, delegations_value, lookup) = match claude_uuid {
                 Some(uuid) => {
-                    let delegations = self.state.delegations_for(SessionId(uuid));
+                    for d in self.state.delegations_for(SessionId(uuid)) {
+                        if !delegations.iter().any(|existing| existing.id == d.id) {
+                            delegations.push(d);
+                        }
+                    }
                     (json!(delegations.len()), json!(delegations), "ok")
                 }
-                None => (Value::Null, Value::Array(Vec::new()), "unbridged"),
+                // The hook-observed half is unreachable without the bridge,
+                // so the managed-id half alone cannot stand in for the
+                // total — report the explicit unknown for BOTH fields
+                // rather than let a caller reading only `delegations` see a
+                // confident empty list.
+                None => (Value::Null, Value::Null, "unbridged"),
             };
             return Ok(json!({
                 "session": crate::daemon::managed_routes::record_to_json(&record),
                 "kind": SessionRecordKind::Managed.as_str(),
                 "memory": Value::Null,
                 "delegation_count": delegation_count,
-                "delegations": delegations,
+                "delegations": delegations_value,
                 "delegation_lookup": lookup,
             }));
         }

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -115,7 +115,17 @@ impl OrchestratorBackend for StateBackend {
     /// silently drops every `agent_delegate`-keyed record: the exact
     /// false-all-clear #4141 exists to eliminate, just relocated to the other
     /// key. The managed branch below reads BOTH spaces and de-duplicates by
-    /// delegation id.
+    /// delegation id — but that only removes an exact record appearing
+    /// twice, e.g. the same `Delegation` reachable under both the managed id
+    /// and the Claude UUID. It does NOT merge a PM's `agent_delegate` call
+    /// (managed-id record) with the hook-observed dispatch of the SAME
+    /// logical subagent (Claude-UUID record): those are two distinct
+    /// `Delegation`s with different ids and `delegation_tracker::dedup` only
+    /// matches within one session/agent pairing, so it cannot span the
+    /// bridge. `delegation_count` can therefore overcount one in-flight
+    /// subagent as two — this is the existing, deliberate tracker trade-off
+    /// (favouring overcount over a false merge, per `dedup`'s own doc
+    /// comment), not new behaviour this fix introduces or is meant to close.
     ///
     /// The legacy branch's `id` equals the Claude session UUID only on the
     /// `SessionStart`-hook-auto-registered path; a tmux-pane-discovered,
@@ -153,7 +163,11 @@ impl OrchestratorBackend for StateBackend {
             // #4141: read the managed-id key space unconditionally — this is
             // what `agent_delegate` (#1976) writes under for a managed
             // session — then union in the Claude-UUID key space when the
-            // bridge resolves, de-duplicating by delegation id.
+            // bridge resolves, de-duplicating by delegation id (removes an
+            // exact record reachable under both keys; does NOT merge a
+            // managed-id `agent_delegate` record with a separate
+            // Claude-UUID hook-observed record for the same logical
+            // subagent — see the doc comment above).
             let mut delegations = self.state.delegations_for(id);
             let claude_uuid = record
                 .claude_session_id

--- a/crates/trusty-mpm/src/daemon/mcp_backend.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend.rs
@@ -98,8 +98,26 @@ impl OrchestratorBackend for StateBackend {
     /// reported "no such session" for the `tmpm-` sessions trusty-mpm itself
     /// spawns, even though `session_list` surfaces them. Managed records are
     /// serialized via the shared `record_to_json` (matching `session_list`) and
-    /// carry no memory snapshot; delegations are keyed by UUID so they resolve
-    /// for either family.
+    /// carry no memory snapshot.
+    ///
+    /// #4141: the legacy registry's `SessionId` IS the Claude session UUID
+    /// (hook auto-registration uses it directly), so `delegations_for(id)`
+    /// resolves correctly for that branch with no bridging. The MANAGED
+    /// branch is different: `id` here is a `ManagedSessionId`, but
+    /// hook-observed delegations are keyed by the Claude session UUID that
+    /// `session_start_correlation::correlate_session_start` stores on the
+    /// record as `claude_session_id` — a distinct identifier space (that's
+    /// the whole reason `SessionRecord` carries both fields separately).
+    /// Passing the managed id straight into `delegations_for` silently
+    /// matched nothing and reported `delegation_count: 0` even while
+    /// subagents were actively running — a false all-clear indistinguishable
+    /// from "genuinely none in flight". The fix bridges through
+    /// `record.claude_session_id` before querying, exactly as
+    /// `correlate_session_start` intends; when the bridge itself is missing
+    /// (no correlated Claude session id yet, e.g. the session hasn't started
+    /// or no `SessionStart` hook has landed), `delegation_count` is reported
+    /// as an explicit `null` with `delegation_lookup: "unbridged"` — never a
+    /// confident-looking zero.
     async fn session_status(&self, session_id: &str) -> Result<Value, String> {
         let id = parse_session_id(session_id)?;
         // Legacy in-process registry first.
@@ -112,19 +130,33 @@ impl OrchestratorBackend for StateBackend {
                 "memory": memory,
                 "delegation_count": delegations.len(),
                 "delegations": delegations,
+                "delegation_lookup": "ok",
             }));
         }
         // Managed store fallback (#1976): the `tmpm-` sessions `session_list`
         // surfaces and `session_stop`/`session_resume` already target by id.
         let manager = self.state.session_manager().await;
         if let Ok(record) = manager.get(&ManagedSessionId(id.0)).await {
-            let delegations = self.state.delegations_for(id);
+            // #4141: bridge the managed id to the Claude session UUID before
+            // querying delegations — they live in a different key space.
+            let claude_uuid = record
+                .claude_session_id
+                .as_deref()
+                .and_then(|s| Uuid::parse_str(s).ok());
+            let (delegation_count, delegations, lookup) = match claude_uuid {
+                Some(uuid) => {
+                    let delegations = self.state.delegations_for(SessionId(uuid));
+                    (json!(delegations.len()), json!(delegations), "ok")
+                }
+                None => (Value::Null, Value::Array(Vec::new()), "unbridged"),
+            };
             return Ok(json!({
                 "session": crate::daemon::managed_routes::record_to_json(&record),
                 "kind": SessionRecordKind::Managed.as_str(),
                 "memory": Value::Null,
-                "delegation_count": delegations.len(),
+                "delegation_count": delegation_count,
                 "delegations": delegations,
+                "delegation_lookup": lookup,
             }));
         }
         Err(format!("no such session: {session_id}"))

--- a/crates/trusty-mpm/src/daemon/mcp_backend_tests.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend_tests.rs
@@ -119,13 +119,19 @@ async fn session_status_resolves_managed_session() {
     assert_eq!(status["session"]["id"], record.id.to_string());
     // #4141 negative case: this record has never been correlated to a Claude
     // session UUID (no `SessionStart` hook has landed), so the delegation
-    // lookup cannot be bridged. It must report an explicit unknown — `null`,
-    // never `0` — so an unbridgeable lookup is distinguishable from
-    // "genuinely none in flight".
+    // lookup cannot be bridged. Both `delegation_count` AND `delegations`
+    // must report an explicit unknown — `null`, never `0`/`[]` — so an
+    // unbridgeable lookup is distinguishable from "genuinely none in
+    // flight" no matter which field a caller reads.
     assert_eq!(
         status["delegation_count"],
         Value::Null,
         "unbridged managed session must report delegation_count: null, not 0 (#4141)"
+    );
+    assert_eq!(
+        status["delegations"],
+        Value::Null,
+        "unbridged managed session must report delegations: null, not [] (#4141)"
     );
     assert_eq!(status["delegation_lookup"], "unbridged");
 }
@@ -183,6 +189,63 @@ async fn session_status_bridges_managed_id_to_hook_observed_delegation() {
         status["delegation_count"], 1,
         "delegation observed under the bridged Claude session UUID must be \
          visible via the managed id (#4141), got: {status}"
+    );
+    assert_eq!(status["delegation_lookup"], "ok");
+}
+
+#[tokio::test]
+async fn session_status_union_keeps_managed_id_keyed_delegation_visible() {
+    // Regression for the #4141 fix-round finding: the first version of this
+    // fix REPLACED the managed-id lookup with the bridged Claude-UUID one
+    // instead of unioning them, so an `agent_delegate`-keyed delegation (the
+    // key `agent_delegate` uses for a managed session, certified by
+    // `agent_delegate_accepts_managed_session` above and exercised for real
+    // by `connectors::tm::WorkstreamConnector::delegate`) went invisible —
+    // reported as `delegation_count: 0` under an affirmative
+    // `delegation_lookup: "ok"`, even though the bridge itself was intact.
+    // This test fails against that (reverted) shape and must pass here.
+    let root = tempfile::TempDir::new().expect("root tempdir");
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create(
+            "fix the bug".to_string(),
+            Some(root.path().to_path_buf()),
+            None,
+            Some(root.path().to_path_buf()),
+            None,
+            None,
+        )
+        .await
+        .expect("managed create");
+
+    // Bridge succeeds (mirrors the critic's probe: correlate BEFORE the
+    // managed-id delegation is registered).
+    let claude_session_id = SessionId::new();
+    mgr.set_claude_session_id(&record.id, &claude_session_id.0.to_string())
+        .await
+        .expect("set_claude_session_id");
+
+    // Register a delegation keyed by the MANAGED id — exactly what
+    // `agent_delegate` does for a managed session (see
+    // `agent_delegate_accepts_managed_session`), NOT the Claude UUID.
+    state.upsert_delegation(Delegation::new(
+        SessionId(record.id.0),
+        None,
+        "rust-engineer",
+        ModelTier::Sonnet,
+        "wire up the fix",
+    ));
+
+    let backend = StateBackend::new(state);
+    let status = backend
+        .session_status(&record.id.to_string())
+        .await
+        .expect("managed session must resolve");
+    assert_eq!(
+        status["delegation_count"], 1,
+        "an agent_delegate-keyed (managed-id) delegation must remain visible \
+         after the bridge fix, not be dropped by it (#4141), got: {status}"
     );
     assert_eq!(status["delegation_lookup"], "ok");
 }

--- a/crates/trusty-mpm/src/daemon/mcp_backend_tests.rs
+++ b/crates/trusty-mpm/src/daemon/mcp_backend_tests.rs
@@ -117,6 +117,74 @@ async fn session_status_resolves_managed_session() {
         .expect("managed session must resolve via the #1976 fallback");
     assert_eq!(status["kind"], "managed");
     assert_eq!(status["session"]["id"], record.id.to_string());
+    // #4141 negative case: this record has never been correlated to a Claude
+    // session UUID (no `SessionStart` hook has landed), so the delegation
+    // lookup cannot be bridged. It must report an explicit unknown — `null`,
+    // never `0` — so an unbridgeable lookup is distinguishable from
+    // "genuinely none in flight".
+    assert_eq!(
+        status["delegation_count"],
+        Value::Null,
+        "unbridged managed session must report delegation_count: null, not 0 (#4141)"
+    );
+    assert_eq!(status["delegation_lookup"], "unbridged");
+}
+
+#[tokio::test]
+async fn session_status_bridges_managed_id_to_hook_observed_delegation() {
+    // Regression for #4141: `session_status` resolved a `ManagedSessionId`
+    // and passed it straight into `delegations_for`, but hook-observed
+    // delegations are keyed by the Claude session UUID — a different
+    // identifier space bridged only via `correlate_session_start` /
+    // `SessionRecord::claude_session_id`. Without that bridge, this test's
+    // delegation (registered under the Claude UUID, exactly as the real hook
+    // pipeline in `daemon::api::observe` does) was invisible and
+    // `delegation_count` silently reported 0 while a subagent was genuinely
+    // in flight.
+    let root = tempfile::TempDir::new().expect("root tempdir");
+    let state = Arc::new(DaemonState::with_root_isolated_managed(root.path().to_path_buf()).await);
+    let mgr = state.session_manager().await;
+    let record = mgr
+        .create(
+            "fix the bug".to_string(),
+            Some(root.path().to_path_buf()),
+            None,
+            Some(root.path().to_path_buf()),
+            None,
+            None,
+        )
+        .await
+        .expect("managed create");
+
+    // Correlate the managed record to a Claude session UUID, exactly as
+    // `correlate_session_start` does when the `SessionStart` hook fires.
+    let claude_session_id = SessionId::new();
+    mgr.set_claude_session_id(&record.id, &claude_session_id.0.to_string())
+        .await
+        .expect("set_claude_session_id");
+
+    // Observe a delegation under the CLAUDE session UUID — the same key the
+    // hook-observed tracker uses (see `daemon::api::observe`).
+    state.upsert_delegation(Delegation::new(
+        claude_session_id,
+        None,
+        "rust-engineer",
+        ModelTier::Sonnet,
+        "wire up the fix",
+    ));
+
+    let backend = StateBackend::new(state);
+    let status = backend
+        .session_status(&record.id.to_string())
+        .await
+        .expect("managed session must resolve");
+    assert_eq!(status["kind"], "managed");
+    assert_eq!(
+        status["delegation_count"], 1,
+        "delegation observed under the bridged Claude session UUID must be \
+         visible via the managed id (#4141), got: {status}"
+    );
+    assert_eq!(status["delegation_lookup"], "ok");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

`session_status` resolved a `ManagedSessionId` and passed it straight into `delegations_for(id)` (crates/trusty-mpm/src/daemon/mcp_backend.rs:121). That missed a key space: hook-observed delegations (`delegation_tracker::observe`) are keyed by the Claude session UUID, bridged from a managed record only via `SessionRecord::claude_session_id` / `session_start_correlation::correlate_session_start`. So `delegation_count` silently reported `0` for a managed session with subagents genuinely in flight — a false all-clear for anything (e.g. `/tm-session-pause`) that trusts this surface.

## What the code does now

Delegations for a managed session live in up to TWO key spaces:

- **Managed-id space** — `agent_delegate` (#1976) keys a delegation by whatever session id the caller passed, which for a managed session is the managed id itself (exercised over `/rpc` by `connectors::tm::WorkstreamConnector::delegate`, certified by `agent_delegate_accepts_managed_session`).
- **Claude-UUID space** — hook-observed delegations, reachable only by bridging through `record.claude_session_id`.

The managed branch of `session_status` reads BOTH spaces unconditionally-for-managed-id / bridge-gated-for-Claude-UUID, and unions them, de-duplicating by delegation id. An earlier version of this fix replaced the managed-id read with the bridged one instead of unioning — that dropped every `agent_delegate`-keyed record and was caught and fixed in review.

De-duplication is by delegation id only: it removes an exact record reachable under both keys, but does **not** merge a managed-id `agent_delegate` record with a separate Claude-UUID hook-observed record for the same logical subagent — those remain two distinct `Delegation`s (`delegation_tracker::dedup` only matches within one session/agent pairing and cannot span the bridge). `delegation_count` can therefore overcount one in-flight subagent as two; that is the tracker's existing, deliberate trade-off (overcount over false-merge) and unrelated to this fix.

When the bridge itself is missing (no correlated Claude session id yet), `delegation_count` **and** `delegations` are both reported as an explicit `null` with `delegation_lookup: "unbridged"` — the managed-id half alone would be a floor masquerading as a total, so neither field may be read as a confident (even if empty) answer.

The legacy branch's `id` equals the Claude session UUID only on the `SessionStart`-hook-auto-registered path; the tmux-pane-discovery, native-process-discovery, and `POST /sessions` paths instead mint a fresh `SessionId` never correlated to anything. Since no marker distinguishes those three paths at this call site, the legacy branch no longer asserts `delegation_lookup: "ok"` (a soundness claim it could not establish for all three) — it omits the field entirely.

## Files changed

- `crates/trusty-mpm/src/daemon/mcp_backend.rs` — the union fix + `// #4141` markers
- `crates/trusty-mpm/src/daemon/mcp_backend_tests.rs` — regression test for the original bug (hook-observed delegation invisible via the managed id), the inverse regression test (managed-id-keyed delegation must stay visible after the bridge fix), and a negative test asserting an unbridged lookup reports `null`/`null`, not `0`/`[]`
- `crates/trusty-mpm/CHANGELOG.md` — `[Unreleased]` entry

## Verification

- `cargo test -p trusty-mpm --lib mcp_backend` — 17/17 passed
- `cargo test -p trusty-mpm` (full crate) — full lib suite green, no failures
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean
- `bash scripts/check_line_cap.sh` — `7 allowlisted, 0 violations — OK`

Closes #4141

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools