### PR TITLE
fix(trusty-mpm): unify agentId usability check across delegation tracker

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -9,6 +9,17 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- delegation-tracker `agentId` presence-check no longer accepts `null`/`""` (closes [#4163](https://github.com/bobmatnyc/trusty-tools/issues/4163))
+  - `classify_dispatch` decided "we have an agent id" with key-presence alone
+    (`r.get("agentId").is_some()`), while `on_launched`'s consumer rejected a
+    non-string value and `on_subagent_stop`'s consumer rejected an empty
+    string. A `{"agentId": null}` or `{"agentId": ""}` dispatch response took
+    the `Launched` branch and pinned the delegation `Running` with a handle no
+    `SubagentStop` can ever quote back, burning the full 6h staleness window as
+    a phantom in-flight entry. Both call sites now share one extraction,
+    `usable_agent_id` (non-null, non-empty string), so the presence-check and
+    the consumers are structurally incapable of disagreeing again.
+
 - managed sessions can reach the bundled agent roster again — every delegation was degrading to `general-purpose` (closes [#4451](https://github.com/bobmatnyc/trusty-tools/issues/4451))
   - Daemon-managed spawns now launch with `--setting-sources user,project,local`
     instead of `project,local`. Claude Code discovers subagents per settings

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -172,6 +172,28 @@ fn field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
         .filter(|s| !s.is_empty())
 }
 
+/// The `agentId` a `tool_response` actually offers as a usable correlation
+/// handle: present, a string, and non-empty.
+///
+/// Why (#4163): [`classify_dispatch`]'s presence-check and [`on_launched`]'s
+/// consumption used to ask different questions —
+/// `r.get("agentId").is_some()` treats `null` and `""` as "we have an id",
+/// while the consumer's `.and_then(Value::as_str)` (for `null`) or
+/// [`on_subagent_stop`]'s `field` (for `""`) both reject them. A response
+/// carrying either shape took the `Launched` branch, pinning the delegation
+/// `Running` with an `agent_id` no `SubagentStop` can ever quote back —
+/// burning the full 6 h staleness window as a phantom in-flight entry. One
+/// extraction used by every site that asks "do we have an agent id" makes
+/// them structurally incapable of disagreeing again.
+/// Test: `null_agent_id_does_not_launch_a_phantom_delegation`,
+/// `empty_string_agent_id_does_not_launch_a_phantom_delegation`.
+fn usable_agent_id(response: &Value) -> Option<&str> {
+    response
+        .get("agentId")
+        .and_then(Value::as_str)
+        .filter(|s| !s.is_empty())
+}
+
 /// `PreToolUse` on a dispatch tool: a subagent is starting now.
 ///
 /// Why: this is the moment tracking must record a *live* child, so a PM with
@@ -316,7 +338,9 @@ fn tasks_match(declared: &str, dispatched: &str) -> bool {
 /// `post_tool_use_without_tool_response_stays_running`,
 /// `post_tool_use_with_unrecognized_response_stays_running`,
 /// `post_tool_use_with_only_an_agent_id_stays_running`,
-/// `changed_async_status_value_with_an_agent_id_stays_running`.
+/// `changed_async_status_value_with_an_agent_id_stays_running`,
+/// `null_agent_id_does_not_launch_a_phantom_delegation`,
+/// `empty_string_agent_id_does_not_launch_a_phantom_delegation`.
 fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: HookEvent) {
     let Some(tool_use_id) = field(payload, "tool_use_id") else {
         return;
@@ -331,10 +355,10 @@ fn on_launched(state: &DaemonState, session: SessionId, payload: &Value, event: 
     let response = payload
         .get("tool_response")
         .filter(|r| recognized_response(r));
-    let agent_id = response
-        .and_then(|r| r.get("agentId"))
-        .and_then(Value::as_str)
-        .map(str::to_string);
+    // #4163: use the same extraction `classify_dispatch` uses for its
+    // presence-check, so a null/empty `agentId` is never stored as a handle
+    // nothing can ever resolve.
+    let agent_id = response.and_then(usable_agent_id).map(str::to_string);
     let tier = response
         .and_then(|r| r.get("resolvedModel"))
         .and_then(Value::as_str)
@@ -414,11 +438,14 @@ enum DispatchOutcome {
 ///
 /// What, in order:
 ///
-/// - `Launched` — `isAsync == true`, `status == "async_launched"`, or an
-///   `agentId` is present. An `agentId` is by design the *async* correlation
-///   key; handing one back is evidence of a launch, never of a return. Testing
-///   it first is also what makes a `status` whose **value** drifted (rather than
-///   its key) safe, since such a response still carries its `agentId`.
+/// - `Launched` — `isAsync == true`, `status == "async_launched"`, or a
+///   *usable* `agentId` ([`usable_agent_id`]: non-null, non-empty) is present.
+///   An `agentId` is by design the *async* correlation key; handing one back
+///   is evidence of a launch, never of a return. Testing it first is also
+///   what makes a `status` whose **value** drifted (rather than its key)
+///   safe, since such a response still carries its `agentId`. A `null` or
+///   `""` `agentId` is not a usable handle (#4163) — nothing downstream could
+///   ever resolve it — so it does not take this branch.
 /// - `Returned` — any other recognized response.
 /// - `Unknown` — absent, not an object, or carrying no [`TOOL_RESPONSE_KEYS`]
 ///   member.
@@ -453,14 +480,20 @@ enum DispatchOutcome {
 /// `post_tool_use_with_only_an_agent_id_stays_running`,
 /// `changed_async_status_value_with_an_agent_id_stays_running`,
 /// `synchronous_post_tool_use_completes_delegation`,
-/// `liveness_silent_response_is_read_as_a_return_known_gap`.
+/// `liveness_silent_response_is_read_as_a_return_known_gap`,
+/// `null_agent_id_does_not_launch_a_phantom_delegation`,
+/// `empty_string_agent_id_does_not_launch_a_phantom_delegation`.
 fn classify_dispatch(response: Option<&Value>) -> DispatchOutcome {
     let Some(r) = response else {
         return DispatchOutcome::Unknown;
     };
     if r.get("isAsync").and_then(Value::as_bool) == Some(true)
         || r.get("status").and_then(Value::as_str) == Some("async_launched")
-        || r.get("agentId").is_some()
+        // #4163: was `r.get("agentId").is_some()` — key presence only, so a
+        // `null` or `""` agentId took this branch even though nothing
+        // downstream could ever resolve it. Use the same extraction the
+        // consumer in `on_launched` uses.
+        || usable_agent_id(r).is_some()
     {
         return DispatchOutcome::Launched;
     }

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker.rs
@@ -177,21 +177,20 @@ fn field<'a>(payload: &'a Value, key: &str) -> Option<&'a str> {
 ///
 /// Why (#4163): [`classify_dispatch`]'s presence-check and [`on_launched`]'s
 /// consumption used to ask different questions —
-/// `r.get("agentId").is_some()` treats `null` and `""` as "we have an id",
+/// `r.get("agentId").is_some()` treated `null` and `""` as "we have an id",
 /// while the consumer's `.and_then(Value::as_str)` (for `null`) or
 /// [`on_subagent_stop`]'s `field` (for `""`) both reject them. A response
 /// carrying either shape took the `Launched` branch, pinning the delegation
 /// `Running` with an `agent_id` no `SubagentStop` can ever quote back —
-/// burning the full 6 h staleness window as a phantom in-flight entry. One
-/// extraction used by every site that asks "do we have an agent id" makes
-/// them structurally incapable of disagreeing again.
+/// burning the full 6 h staleness window as a phantom in-flight entry. This
+/// is a thin wrapper around [`field`] — the exact same extraction
+/// [`on_subagent_stop`] already uses for `agent_id` — rather than an
+/// independent body, so all three sites route through one implementation and
+/// are structurally incapable of disagreeing again.
 /// Test: `null_agent_id_does_not_launch_a_phantom_delegation`,
 /// `empty_string_agent_id_does_not_launch_a_phantom_delegation`.
 fn usable_agent_id(response: &Value) -> Option<&str> {
-    response
-        .get("agentId")
-        .and_then(Value::as_str)
-        .filter(|s| !s.is_empty())
+    field(response, "agentId")
 }
 
 /// `PreToolUse` on a dispatch tool: a subagent is starting now.
@@ -450,7 +449,7 @@ enum DispatchOutcome {
 /// - `Unknown` — absent, not an object, or carrying no [`TOOL_RESPONSE_KEYS`]
 ///   member.
 ///
-/// # KNOWN LIMITATION — an `agentId`-less response is read as a return
+/// # KNOWN LIMITATION — a response with no usable `agentId` is read as a return
 ///
 /// `Returned` is deliberately still *residual* rather than affirmative
 /// (`isAsync == false` or a non-launch `status`), so a recognized response that
@@ -460,7 +459,8 @@ enum DispatchOutcome {
 /// today, not better:
 ///
 /// [`on_subagent_stop`] resolves a delegation *only* by `agent_id`, and
-/// `agent_id` is taught *only* by this function. A response with no `agentId`
+/// `agent_id` is taught *only* by this function. A response with no *usable*
+/// `agentId` — absent, `null`, `""`, or any non-string ([`usable_agent_id`])
 /// therefore has **no** route to termination other than this branch — nothing
 /// can ever quote it back to us. Compounding that, `PostToolUse` is installed
 /// `async: true` while `SubagentStop` is synchronous

--- a/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
+++ b/crates/trusty-mpm/src/daemon/services/delegation_tracker_tests.rs
@@ -603,6 +603,72 @@ fn changed_async_status_value_with_an_agent_id_stays_running() {
 }
 
 #[test]
+fn null_agent_id_does_not_launch_a_phantom_delegation() {
+    // #4163: `classify_dispatch`'s old presence-check (`.is_some()`) read a
+    // `null` agentId as evidence of a launch, storing `agent_id = None` while
+    // staying `Running` — a delegation `SubagentStop` can never resolve
+    // (it matches only a stored `agent_id`), so it would burn the full 6h
+    // staleness window as a phantom in-flight entry. With no other launch
+    // marker present, this must terminalize as an ordinary synchronous
+    // return instead.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "tool_response": { "agentId": null }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+
+    let d = only(&state, sid);
+    assert_eq!(
+        d.status,
+        DelegationStatus::Completed,
+        "a null agentId is not a usable handle and carries no other launch \
+         marker, so it must not pin the delegation Running with nothing left \
+         to resolve it"
+    );
+    assert_eq!(d.agent_id, None);
+}
+
+#[test]
+fn empty_string_agent_id_does_not_launch_a_phantom_delegation() {
+    // #4163: an empty-string agentId passed the old presence-check too
+    // (`.is_some()` is true for `Some("")`), storing `agent_id = Some("")` —
+    // a value `on_subagent_stop`'s `field()` (which rejects empty strings)
+    // can never match. Same phantom-Running failure as the null case, via a
+    // different payload shape.
+    let (state, sid) = state_with_session();
+    observe(
+        &state,
+        sid,
+        HookEvent::PreToolUse,
+        &pre("Agent", "engineer", "t", "toolu_1"),
+    );
+    let payload = serde_json::json!({
+        "tool": "Agent",
+        "tool_use_id": "toolu_1",
+        "tool_response": { "agentId": "" }
+    });
+    observe(&state, sid, HookEvent::PostToolUse, &payload);
+
+    let d = only(&state, sid);
+    assert_eq!(
+        d.status,
+        DelegationStatus::Completed,
+        "an empty-string agentId is not a usable handle and carries no other \
+         launch marker, so it must not pin the delegation Running with \
+         nothing left to resolve it"
+    );
+    assert_eq!(d.agent_id, None);
+}
+
+#[test]
 fn renamed_async_marker_does_not_terminalize() {
     // The specific drift scenario: `isAsync`/`status` renamed but `agentId`
     // kept. We still recognise the response, so we would infer a synchronous


### PR DESCRIPTION
## Problem

`delegation_tracker.rs:463`'s `classify_dispatch` decided "we have an agent id" with key-presence alone: `r.get("agentId").is_some()`. Two other sites in the same file disagreed about what a usable id is — `on_launched` consumes via `as_str` (a non-string value yields nothing), and `on_subagent_stop` explicitly rejects an empty string via `field()`.

Probed against the merged head:

| Payload | Result |
|---|---|
| `{"agentId": null}` | delegation transitions to `Running` with `agent_id = None` |
| `{"agentId": ""}` | delegation transitions to `Running` with `agent_id = Some("")`, which a `SubagentStop` can never match |

Either way, the delegation records "expect a stop for this agent" while holding no handle a stop can ever quote — burning the full 6h staleness window as a phantom in-flight entry, the exact cost a prior fix round (PR #4096) explicitly refused to trade for.

## Fix

Added `usable_agent_id(&Value) -> Option<&str>` (non-null, non-empty string) and used it at both:
- `classify_dispatch`'s presence-check (was `r.get("agentId").is_some()`)
- `on_launched`'s consumption (was `.and_then(Value::as_str)` without the empty-string filter)

Both call sites now share one extraction, so the presence-check and the consumers are structurally incapable of disagreeing again.

## Tests

Added `null_agent_id_does_not_launch_a_phantom_delegation` and `empty_string_agent_id_does_not_launch_a_phantom_delegation`, covering both probed payloads from the issue. Both assert the delegation terminalizes as `Completed` (an ordinary synchronous return, since neither payload carries any other launch marker) rather than lingering `Running` with an unresolvable `agent_id`.

Closes #4163

## Gates (raw output)

- `cargo test -p trusty-mpm` (full crate, not `--lib`): all 13 suites `ok`, 0 failed
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: clean
- `cargo fmt --check`: clean
- `bash scripts/check_line_cap.sh`: `7 allowlisted, 0 violations — OK.`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools