### PR TITLE
feat(trusty-agents): bundle the cto-assistant OKG docstore grant

### DIFF
--- a/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
+++ b/crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml
@@ -120,6 +120,27 @@ allow = [
     # (search_gmail_messages/get_gmail_message_content/modify_gmail_messages
     # are already granted by the base's Gmail surface).
     "create_draft",
+    # OKG docstore reach — a SHIPPED grant (owner decision, 2026-07-31), not a
+    # hand edit. It was one in the DEPLOYED copy from 2026-07-29 (there is
+    # still no API to grant a tool, #3890) until a bundled-agent reprovision
+    # overwrote that file and destroyed it with no `.stale.bak` (#4461).
+    # Declaring it here is what survives the next reprovision.
+    #
+    # NARROW ON PURPOSE: the two read/ingest DOCSTORE tools only. This overlay
+    # deliberately does NOT name `okg_ingest_gmail`/`okg_ingest_drive` —
+    # widening it is a decision about what this persona may ingest, never a
+    # cleanup to "match the base".
+    #
+    # Not a FILTER, though, and the difference matters: the base `assistant`
+    # has granted all four OKG tools since #3883, and `extends` unions
+    # base-first, so the RESOLVED persona reaches the Gmail/Drive ingest tools
+    # today regardless of this list. These two lines are an independence
+    # guarantee — they pin the docstore reach this persona actually depends on
+    # so a future narrowing of the base cannot silently take it away. Same
+    # reasoning as the `scopes` line below and the git carve-out above. Pinned
+    # by `bundled_cto_assistant_pins_okg_docstore_reach` (agents/tests/loading.rs).
+    "okg_ingest_docstore",
+    "okg_sources",
 ]
 # #3938: OpenRPC scopes (#3208) for the Gmail/Tasks surface above. These are
 # NOT a delta the base can supply and they are NOT redundant with `allow`:

--- a/crates/trusty-agents/CHANGELOG.md
+++ b/crates/trusty-agents/CHANGELOG.md
@@ -7,6 +7,25 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ---
 ## [Unreleased]
 
+### Changed
+
+- **`cto-assistant` now declares its OKG docstore grant in the bundled
+  persona.** `okg_ingest_docstore` and `okg_sources` are named in the bundled
+  package's `[tools].allow` (owner decision, 2026-07-31) instead of living as
+  a hand edit in the deployed copy, where a bundled-agent reprovision
+  overwrote the file and destroyed the grant with no `.stale.bak` (#4461).
+  There is still no API to grant a tool (#3890), so bundling is what makes it
+  durable — the next reprovision converges on it rather than eating it.
+  Resolved behaviour is unchanged: the base `assistant` has granted the OKG
+  tools since #3883 and `extends` unions `[tools].allow` base-first, so this
+  is an independence guarantee against a future narrowing of the base, not a
+  new capability. Narrow on purpose — the overlay does not name
+  `okg_ingest_gmail`/`okg_ingest_drive`; widening it is a deliberate decision
+  about what the persona may ingest. Pinned by
+  `bundled_cto_assistant_pins_okg_docstore_reach`, which asserts both the
+  resolved reach and the overlay's own declaration, since a resolution-only
+  check would stay green through a full revert.
+
 ### Security
 
 - **`izzie`, `personal-assistant` and the base `assistant` no longer reach

--- a/crates/trusty-agents/src/agents/tests/loading.rs
+++ b/crates/trusty-agents/src/agents/tests/loading.rs
@@ -2143,6 +2143,106 @@ fn bundled_personas_pin_git_reach() {
     }
 }
 
+/// The `cto-assistant` OKG DOCSTORE grant is a shipped, deliberate one, and
+/// this overlay is what owns it.
+///
+/// Why: the grant lived as a hand edit in the DEPLOYED copy only (there is no
+/// API to grant a tool, #3890) until a bundled-agent reprovision overwrote
+/// that file and destroyed it with no `.stale.bak` (#4461). The owner decision
+/// (2026-07-31) was to move it into the bundle so the next reprovision
+/// CONVERGES on it instead of destroying it. Like the git carve-out above it
+/// is a non-obvious re-declaration that reads as redundancy, so a later
+/// tidy-up removes it unless something fails.
+///
+/// The redundancy is real but load-bearing, and that shapes the test: the base
+/// `assistant` has granted all four OKG tools since #3883 and `extends` unions
+/// `[tools].allow` base-first, so the RESOLVED surface keeps both tools even
+/// with this overlay stripped. A resolution-only assertion would therefore stay
+/// green through a full revert of the bundled grant. Both halves are asserted —
+/// resolved reachability (the capability the persona depends on) and the
+/// overlay's own declaration (independence from a base that may narrow later,
+/// exactly as the base narrowing git reach in #4420 already forced once).
+///
+/// Narrowness is pinned on the OVERLAY only, deliberately: this persona does
+/// resolve `okg_ingest_gmail`/`okg_ingest_drive` today, inherited from the
+/// base, so asserting non-reachability would assert a falsehood. What is true
+/// and worth pinning is that this overlay never adds them itself — widening it
+/// has to be a decision taken here, not a side effect of matching the base.
+/// What: resolves the persona through `AgentConfig::by_name` for reachability,
+/// then parses the package TOML directly for what the overlay itself declares.
+/// Test: This function IS the test.
+#[test]
+fn bundled_cto_assistant_pins_okg_docstore_reach() {
+    const GRANTED: [&str; 2] = ["okg_ingest_docstore", "okg_sources"];
+    const NOT_GRANTED_HERE: [&str; 2] = ["okg_ingest_gmail", "okg_ingest_drive"];
+
+    let _guard = ENV_LOCK.blocking_lock();
+    clear_model_env("cto-assistant");
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::set_var("TAGENT_CONFIG_DIR", bundled_agents_dir());
+    }
+    let cfg = AgentConfig::by_name("cto-assistant");
+    // SAFETY: guarded by ENV_LOCK.
+    unsafe {
+        std::env::remove_var("TAGENT_CONFIG_DIR");
+    }
+    let cfg = cfg.unwrap_or_else(|e| panic!("'cto-assistant' must resolve: {e}"));
+    let resolved = cfg.tools.allow.as_deref().unwrap_or_else(|| {
+        panic!("'cto-assistant' must ship a restricted [tools].allow, not an absent one")
+    });
+
+    for tool in GRANTED {
+        assert!(
+            crate::ctrl::pm_task::match_any_glob(tool, resolved),
+            "'cto-assistant' must reach '{tool}' — the OKG docstore grant is a \
+             shipped owner decision (2026-07-31), bundled after #4461 destroyed \
+             the deployed hand edit. Resolved allow-list: {resolved:?}"
+        );
+    }
+
+    // The overlay's OWN declaration, pre-union. This is the half that fails if
+    // the bundled grant is reverted; the resolved half above would not, because
+    // the base re-supplies both tools through `extends`. Read as a raw
+    // `toml::Value` rather than an `AgentConfig` because this is an MD package:
+    // `[system_prompt].content` lives in `persona.md`, so a whole-config
+    // deserialize of the TOML alone fails on the missing field.
+    let raw = std::fs::read_to_string(
+        bundled_agents_dir()
+            .join("cto-assistant")
+            .join("agent.toml"),
+    )
+    .expect("the bundled cto-assistant package must exist");
+    let doc: toml::Value = toml::from_str(&raw).expect("the package must parse");
+    let declared: Vec<&str> = doc
+        .get("tools")
+        .and_then(|t| t.get("allow"))
+        .and_then(|a| a.as_array())
+        .expect("the cto-assistant package must declare its own [tools].allow")
+        .iter()
+        .filter_map(|v| v.as_str())
+        .collect();
+
+    for tool in GRANTED {
+        assert!(
+            declared.contains(&tool),
+            "the cto-assistant package must DECLARE '{tool}' itself rather than \
+             lean on the base's union — that independence is the whole point of \
+             bundling the grant (#3890: no API can re-add it, #4461: a \
+             reprovision eats any out-of-bundle edit). Declared: {declared:?}"
+        );
+    }
+    for tool in NOT_GRANTED_HERE {
+        assert!(
+            !declared.contains(&tool),
+            "the cto-assistant package must NOT declare '{tool}': this grant is \
+             narrow on purpose — docstore ingest only. Widening it is a decision \
+             about what this persona may ingest, not a cleanup to match the base \
+             (which does grant it, and whose union this overlay cannot filter)."
+        );
+    }
+}
+
 /// ADR-0024 decision 4 sub-answer (a), the MIGRATION half: every bundled
 /// assistant persona ships a seeded `[subagents].delegate_allowed`.
 ///


### PR DESCRIPTION
## What

`okg_ingest_docstore` and `okg_sources` are now named in the bundled
`cto-assistant` package's `[tools].allow` (owner decision, 2026-07-31,
"add it to the bundled source") instead of living as a hand edit in the
deployed copy at `~/.trusty-agents/`.

Files changed:
- `crates/trusty-agents/.trusty-agents/agents/cto-assistant/agent.toml` — the grant + its rationale comment
- `crates/trusty-agents/src/agents/tests/loading.rs` — `bundled_cto_assistant_pins_okg_docstore_reach`
- `crates/trusty-agents/CHANGELOG.md`

## Why

The hand edit existed because there is still no API to grant a tool
(#3890). A `tagent` rebuild's bundled-agent reprovision then overwrote
the deployed file and destroyed the grant with no `.stale.bak` (#4461),
so restoring it by hand only reset the same timer. Bundling is what makes
it durable — the next reprovision converges on this content instead of
eating it.

## Reviewer note — this is a no-op on resolved behaviour, and deliberately so

Worth stating plainly, because it changes how to read the diff. The base
`assistant` has granted **all four** OKG tools since #3883 (2026-07-25),
and `extends` unions `[tools].allow` base-first, so `cto-assistant`
already resolved `okg_ingest_docstore` and `okg_sources` before this PR.
Verified against `origin/main` by resolving the persona through
`AgentConfig::by_name`:

```
resolved okg tools: ["okg_ingest_docstore", "okg_ingest_gmail",
                     "okg_ingest_drive", "okg_sources"]
```

Two consequences:

1. **The grant is an independence guarantee, not a new capability.** It
   pins the docstore reach this persona depends on so a future narrowing
   of the base cannot silently remove it — exactly what #4420 just did to
   `git_log`/`git_status`, and the same reasoning this file already
   applies to its `scopes` line and its git carve-out.
2. **The old annotation's safety claim was already false.** The deployed
   comment said `okg_ingest_gmail`/`okg_ingest_drive` "are deliberately
   NOT granted, so this cannot touch a real inbox or Drive". The persona
   reaches both today, via the base. The new comment does not repeat that
   claim; it states the true and enforceable version — *this overlay*
   never adds them, and widening it is a deliberate decision about what
   the persona may ingest, not a cleanup to match the base. Whether the
   base should hand Gmail/Drive ingest to every assistant overlay is a
   separate call, out of scope here.

## Scope

`cto-assistant` package only. The base `assistant`, `izzie`, and every
other persona are untouched, as is the existing four-tool git carve-out.
The flat shadow `cto-assistant.toml` is deliberately **not** edited: the
loader prefers the package, so the flat file is not the resolved persona
— it only loads if the `extends` chain fails, and in that already-degraded
path a narrower surface is the safe direction. No `scopes` change is
needed either; the OKG tools return `None` from `ToolExecutor::scope()`.

## Test

`bundled_cto_assistant_pins_okg_docstore_reach` asserts both halves:

- the **resolved** reach (`AgentConfig::by_name` + `match_any_glob`) — the
  capability the persona depends on;
- the **overlay's own declaration** (raw TOML parse) — independence from a
  base that may narrow later, plus the narrowness constraint.

The second half is load-bearing: a resolution-only assertion stays green
through a full revert of this grant, because the base re-supplies both
tools. Both halves were verified by mutation:

- removing the two lines → `the cto-assistant package must DECLARE 'okg_ingest_docstore' itself rather than lean on the base's union` (FAILED)
- adding `okg_ingest_gmail` → `the cto-assistant package must NOT declare 'okg_ingest_gmail': this grant is narrow on purpose` (FAILED)

Narrowness is pinned on the overlay only, deliberately — asserting the
persona does *not resolve* the Gmail/Drive ingest tools would be asserting
a falsehood.

## Gates

`cargo check`, `cargo test -p trusty-agents` (3111 passed / 0 failed),
`cargo clippy -p trusty-agents --all-targets -- -D warnings`,
`cargo fmt --check`, `check_line_cap.sh` (0 violations),
`check_test_pointers.sh` (exit 0) — all green.

One suite run hit `execute_dispatches_to_python_and_parses_json`, which is
the known pre-existing parallel-load flake tracked as #4414 (uv reads
`$HOME` while other tests mutate it); it passes in isolation and on rerun,
and is untouched by this diff.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools