### PR TITLE
fix(trusty-mpm): scrub inherited CLAUDE_CODE_CHILD_SESSION so managed sessions keep transcripts

### DIFF
--- a/crates/trusty-mpm/changelog.d/4467-doctor-transcript-check.md
+++ b/crates/trusty-mpm/changelog.d/4467-doctor-transcript-check.md
@@ -1,0 +1,10 @@
+Added
+
+- `tm doctor` gained a `transcript_saving` check (24 checks, was 23) that fails
+  when any `tm` launch line would leave transcript saving disabled — the defect
+  it guards was silent until Claude Code began warning about it. It reads the
+  scrub set out of the real launch commands rather than restating a constant,
+  names the offending builder on failure, and fails in both directions:
+  under-scrub costs the session its transcripts, over-scrub costs it the agent
+  roster ([#4451](https://github.com/bobmatnyc/trusty-tools/issues/4451)) or the
+  OAuth token ([#2246](https://github.com/bobmatnyc/trusty-tools/issues/2246)).

--- a/crates/trusty-mpm/changelog.d/4467-transcript-saving.md
+++ b/crates/trusty-mpm/changelog.d/4467-transcript-saving.md
@@ -18,9 +18,16 @@ Fixed
   - Applied to every launch line, not just the default one: `spawn_command` and
     `resume_command` (a spawn-only fix would leave every resumed session broken),
     the in-place bare-`tm` relaunch, the headless stream-JSON backend, the
-    `tm launch` / `tm connect` / agent-delegation launch line, the pane-relaunch
-    line, and `tm run`.
-  - `tm run` mattered most and was fixed last: it spawns `claude` with no tmux, so
-    Claude Code's `tmux show-environment -g` escape hatch returns false
-    immediately and the suppression fired there every time rather than depending
-    on the tmux server's environment.
+    `tm launch` / `tm connect` launch line, the pane-relaunch line, `tm run`,
+    `tm session start`'s in-place pane, and the `DaemonClient` launch/connect
+    line behind the TUI and bot surfaces.
+  - `tm run` mattered most: it spawns `claude` with no tmux, so Claude Code's
+    `tmux show-environment -g` escape hatch returns false immediately and the
+    suppression fired there every time rather than depending on the tmux
+    server's environment.
+  - Every launch line is now built in one place. Three call sites had each
+    hand-written their own `claude …` string, and all three silently saved no
+    transcript — a hand-built line is invisible to the `transcript_saving`
+    check, which can only read builders. A new test walks the crate's source
+    and fails when a `claude` launch site appears that is not accounted for,
+    so the next one is a build failure rather than a silent gap.

--- a/crates/trusty-mpm/changelog.d/4467-transcript-saving.md
+++ b/crates/trusty-mpm/changelog.d/4467-transcript-saving.md
@@ -1,0 +1,26 @@
+Fixed
+
+- managed sessions no longer silently lose their Claude Code transcripts (closes [#4467](https://github.com/bobmatnyc/trusty-tools/issues/4467))
+  - Every managed spawn now scrubs the process-local session markers Claude Code
+    injects into its child processes. When `tm` was invoked from inside a Claude
+    Code session it inherited `CLAUDE_CODE_CHILD_SESSION` and passed it through,
+    which made the spawned `claude` turn session persistence OFF: no native
+    `--resume`, no `--continue`, no `/rewind`, and the session never appeared in
+    `--resume` listings. Since tm's own pause/resume writes only a condensed
+    summary, a session that died lost everything since its last snapshot.
+  - Scrubbed: `CLAUDE_CODE_CHILD_SESSION` (the sole transcript-saving trigger),
+    `CLAUDE_CODE_SESSION_ID`, `CLAUDECODE`, `CLAUDE_PID`, `CLAUDE_EFFORT`,
+    `CLAUDE_CODE_EXECPATH`. Deliberately NOT scrubbed: `CLAUDE_CONFIG_DIR` (tm
+    relocates it on purpose — [#4455](https://github.com/bobmatnyc/trusty-tools/issues/4455)
+    depends on it to keep the bundled roster in a settings tier managed sessions
+    load), `CLAUDE_CODE_OAUTH_TOKEN`, `CLAUDE_CODE_MAX_OUTPUT_TOKENS` (an
+    operator-facing knob) and `CLAUDE_CODE_ENTRYPOINT`.
+  - Applied to every launch line, not just the default one: `spawn_command` and
+    `resume_command` (a spawn-only fix would leave every resumed session broken),
+    the in-place bare-`tm` relaunch, the headless stream-JSON backend, the
+    `tm launch` / `tm connect` / agent-delegation launch line, the pane-relaunch
+    line, and `tm run`.
+  - `tm run` mattered most and was fixed last: it spawns `claude` with no tmux, so
+    Claude Code's `tmux show-environment -g` escape hatch returns false
+    immediately and the suppression fired there every time rather than depending
+    on the tmux server's environment.

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities.md
@@ -41,7 +41,7 @@ relevant `references/*.md` file here when you need an exact answer.
 | "What MCP tools exist and what parameters do they take?" | `references/mcp-tools.md` (33 tools, plus sibling-daemon pointers) |
 | "What agents can I delegate to, and what do they declare?" | `references/agents.md` (37 concrete agents) |
 | "What skills exist, and are they user-invocable?" | `references/skills.md` (52 bundled skills) |
-| "What does a `tm doctor` check name actually mean?" | `references/doctor.md` (23 checks) |
+| "What does a `tm doctor` check name actually mean?" | `references/doctor.md` (24 checks) |
 | "How do the pieces fit into an end-to-end flow?" | `references/workflows.md` (hand-authored, not generated) |
 
 ## Relationship to Other Skills

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/doctor.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/doctor.md
@@ -2,30 +2,31 @@
 
 Generated from a maintained literal list cross-checked against `run_doctor`'s actual check names (see this module's `doctor_checks_match_run_doctor_names` test — an added, removed, or renamed check fails the test suite). Source: `crates/trusty-mpm/src/daemon/doctor.rs` and its five sibling `doctor_*.rs` files. Regenerate with `tm generate capabilities`.
 
-23 checks, in execution order.
+24 checks, in execution order.
 
 | # | Check | What it probes |
 |---|---|---|
 | 1 | `instructions` | Framework instructions deployed and non-empty for the target project. |
 | 2 | `agents` | Bundled agent roster deployed under the operator/workspace `.claude/agents/` tier. |
 | 3 | `agent_reachability` | Fails when bundled agents deploy into a settings tier a managed session's `--setting-sources` flag never loads — presence-only checks stay green while every delegation degrades to `general-purpose` (issue #4451). |
-| 4 | `skills` | Bundled skill catalog deployed under the operator/workspace `.claude/skills/` tier. |
-| 5 | `skill_source` | The framework's own skill source directory is present and readable. |
-| 6 | `output_style` | The `trusty-mpm` Claude Code output style is configured and its file exists (DOC-28 F4). |
-| 7 | `output_style_staleness` | Deployed output-style file content matches the bundled catalog, and no orphaned files linger under `output-styles/` (issue #2333). |
-| 8 | `output_style_legacy_ids` | Warns when a legacy/unresolvable `outputStyle` id lingers in a currently-shadowed settings layer (e.g. `settings.local.json`) even though the effective layer resolves fine (issue #3453). |
-| 9 | `deployment` | Full manifest-completeness diff of the deployed payload against the canonical bundled roster (issue #2158). |
-| 10 | `skill_staleness` | Deployed skill content matches the bundled/embedded source (issue #2876). |
-| 11 | `legacy_sources` | No legacy global instruction sources linger from a pre-migration install (issue #2876). |
-| 12 | `agent_skills` | Every agent's declared `skills:` frontmatter resolves to a real skill — dangling references fail (DOC-42, issue #2889). |
-| 13 | `agent_skills_prose_hints` | Informational: skill names mentioned in agent prose but not declared in `skills:` frontmatter (always `Ok`, issue #2906). |
-| 14 | `memory` | trusty-memory sidecar reachability probe (bounded by `PROBE_TIMEOUT`). |
-| 15 | `search` | trusty-search sidecar reachability + expected-index-present probe (bounded by `PROBE_TIMEOUT`). |
-| 16 | `worktrees` | No orphaned git worktrees under the managed workspace root (Fix 1b, #1840). |
-| 17 | `gh_account` | Active `gh` CLI identity is unambiguous — warns on multi-account ambiguity. |
-| 18 | `oauth_token` | Warns when a managed session risks the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop (issue #2246). |
-| 19 | `hooks_contamination` | Warns when a project's `.claude/settings*.json` still carries tm hook entries from a pre-fix `tm install` — suggests `tm hooks clean` (issue #2940). |
-| 20 | `hooks_foreign_conflict` | Informational: warns when a project's `.claude/settings*.json` carries foreign (claude-mpm) hook entries that would fire inside a tm session — never auto-removed (issue #2940). |
-| 21 | `tcc_taint` | macOS: whether managed panes spawn `claude` with TCC responsibility disclaimed so its data-access prompts aren't attributed to the shared tmux server (issue #2997). |
-| 22 | `scaffold_tracking` | Warns when a harness-scaffolding path (`.claude/agents/`, `.claude/skills/`, `.claude/output-styles/`) is BOTH tracked in git AND regenerated locally by tm — the precondition for a `git merge --ff-only` "would be overwritten" collision; reports the exact true-intersection paths, never auto-modifies the index (issue #3427). |
-| 23 | `push_guard` | Warns when the project's clone carries no trusty-mpm cross-branch `pre-push` guard, or an older revision of it — the guard installs itself only on the clone path, so a base provisioned before it shipped is silently unprotected and a worktree tracking a foreign branch can force-push over that branch's reviewed lineage. Names the `tm repair push-guard` retrofit; doctor never writes into a repository (issue #2867). |
+| 4 | `transcript_saving` | Fails when a managed spawn would leave Claude Code transcript saving disabled — an inherited `CLAUDE_CODE_CHILD_SESSION` marker costs the session all native `--resume`/`--continue`/`/rewind` recovery, and also fails if the scrub would wrongly take `CLAUDE_CONFIG_DIR` (issue #4467). |
+| 5 | `skills` | Bundled skill catalog deployed under the operator/workspace `.claude/skills/` tier. |
+| 6 | `skill_source` | The framework's own skill source directory is present and readable. |
+| 7 | `output_style` | The `trusty-mpm` Claude Code output style is configured and its file exists (DOC-28 F4). |
+| 8 | `output_style_staleness` | Deployed output-style file content matches the bundled catalog, and no orphaned files linger under `output-styles/` (issue #2333). |
+| 9 | `output_style_legacy_ids` | Warns when a legacy/unresolvable `outputStyle` id lingers in a currently-shadowed settings layer (e.g. `settings.local.json`) even though the effective layer resolves fine (issue #3453). |
+| 10 | `deployment` | Full manifest-completeness diff of the deployed payload against the canonical bundled roster (issue #2158). |
+| 11 | `skill_staleness` | Deployed skill content matches the bundled/embedded source (issue #2876). |
+| 12 | `legacy_sources` | No legacy global instruction sources linger from a pre-migration install (issue #2876). |
+| 13 | `agent_skills` | Every agent's declared `skills:` frontmatter resolves to a real skill — dangling references fail (DOC-42, issue #2889). |
+| 14 | `agent_skills_prose_hints` | Informational: skill names mentioned in agent prose but not declared in `skills:` frontmatter (always `Ok`, issue #2906). |
+| 15 | `memory` | trusty-memory sidecar reachability probe (bounded by `PROBE_TIMEOUT`). |
+| 16 | `search` | trusty-search sidecar reachability + expected-index-present probe (bounded by `PROBE_TIMEOUT`). |
+| 17 | `worktrees` | No orphaned git worktrees under the managed workspace root (Fix 1b, #1840). |
+| 18 | `gh_account` | Active `gh` CLI identity is unambiguous — warns on multi-account ambiguity. |
+| 19 | `oauth_token` | Warns when a managed session risks the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop (issue #2246). |
+| 20 | `hooks_contamination` | Warns when a project's `.claude/settings*.json` still carries tm hook entries from a pre-fix `tm install` — suggests `tm hooks clean` (issue #2940). |
+| 21 | `hooks_foreign_conflict` | Informational: warns when a project's `.claude/settings*.json` carries foreign (claude-mpm) hook entries that would fire inside a tm session — never auto-removed (issue #2940). |
+| 22 | `tcc_taint` | macOS: whether managed panes spawn `claude` with TCC responsibility disclaimed so its data-access prompts aren't attributed to the shared tmux server (issue #2997). |
+| 23 | `scaffold_tracking` | Warns when a harness-scaffolding path (`.claude/agents/`, `.claude/skills/`, `.claude/output-styles/`) is BOTH tracked in git AND regenerated locally by tm — the precondition for a `git merge --ff-only` "would be overwritten" collision; reports the exact true-intersection paths, never auto-modifies the index (issue #3427). |
+| 24 | `push_guard` | Warns when the project's clone carries no trusty-mpm cross-branch `pre-push` guard, or an older revision of it — the guard installs itself only on the clone path, so a base provisioned before it shipped is silently unprotected and a worktree tracking a foreign branch can force-push over that branch's reviewed lineage. Names the `tm repair push-guard` retrofit; doctor never writes into a repository (issue #2867). |

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -605,8 +605,18 @@ pub(crate) async fn run_inplace_relaunch(
 /// the tmux-pane spawn/resume paths so an in-place relaunch does not silently
 /// drop back into the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop the token
 /// exists to bypass. Pure — builds and returns, never spawns.
+///
+/// Issue #4467: the inherited Claude Code session markers are scrubbed here too,
+/// via [`trusty_mpm::core::claude_env_scrub::scrub_command`]. This path execs
+/// `claude` through a `Command` with no shell in between, so the `env -u` prefix
+/// the tmux-pane paths use does not apply to it — but a bare `tm` relaunch run
+/// from inside a Claude Code session leaks exactly the same
+/// `CLAUDE_CODE_CHILD_SESSION` marker and would silently lose its transcript.
+/// The scrub runs BEFORE the deliberate assignments below so it can never
+/// clobber `CLAUDE_CONFIG_DIR` (#4455) even if the marker list grew wrongly.
 /// Test: `inplace_exec_command_forwards_every_arg_in_order`,
 /// `inplace_exec_command_scrubs_api_key_and_sets_auth_env`,
+/// `inplace_exec_command_scrubs_inherited_session_markers`,
 /// `inplace_exec_command_carries_isolation_flags_and_persona_end_to_end`.
 pub(crate) fn build_inplace_exec_command(
     resume: &trusty_mpm::runtime::InPlaceResumeCommand,
@@ -616,6 +626,9 @@ pub(crate) fn build_inplace_exec_command(
     cmd.args(&resume.args)
         .current_dir(cwd)
         .env_remove("ANTHROPIC_API_KEY");
+    // #4467: strip Claude Code's inherited process-local session markers so the
+    // relaunched session keeps native --resume/--continue/rewind recovery.
+    trusty_mpm::core::claude_env_scrub::scrub_command(&mut cmd);
     if let Some(dir) = &resume.config_dir {
         cmd.env("CLAUDE_CONFIG_DIR", dir);
     }

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace/tests.rs
@@ -766,6 +766,45 @@ fn inplace_exec_command_scrubs_api_key_and_sets_auth_env() {
     );
 }
 
+#[test]
+fn inplace_exec_command_scrubs_inherited_session_markers() {
+    // #4467: a bare `tm` relaunch run from inside a Claude Code session inherits
+    // CLAUDE_CODE_CHILD_SESSION and, without this scrub, the relaunched session
+    // saves no transcript — no --resume, no --continue, no /rewind. The marker
+    // name is hard-coded so this cannot pass vacuously if the shared marker list
+    // is emptied.
+    let resume = synthetic_resume(&["--dangerously-skip-permissions"]);
+    let cmd = build_inplace_exec_command(&resume, std::path::Path::new("/fake/cwd"));
+
+    let envs: Vec<(String, Option<String>)> = cmd
+        .get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().into_owned(),
+                v.map(|v| v.to_string_lossy().into_owned()),
+            )
+        })
+        .collect();
+
+    assert!(
+        envs.contains(&("CLAUDE_CODE_CHILD_SESSION".to_owned(), None)),
+        "the transcript-suppressing marker must be REMOVED (None): {envs:?}"
+    );
+    assert!(
+        envs.contains(&("CLAUDE_CODE_SESSION_ID".to_owned(), None)),
+        "the parent's session id must be REMOVED (None): {envs:?}"
+    );
+    // Over-scrub guard: the scrub runs BEFORE the deliberate assignments, so
+    // CLAUDE_CONFIG_DIR must survive it as a SET value (#4455 / #4451).
+    assert!(
+        envs.contains(&(
+            "CLAUDE_CONFIG_DIR".to_owned(),
+            Some("/fake/config".to_owned())
+        )),
+        "CLAUDE_CONFIG_DIR must survive the scrub as a set value: {envs:?}"
+    );
+}
+
 #[serial_test::serial]
 #[test]
 fn inplace_exec_command_carries_isolation_flags_and_persona_end_to_end() {

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
@@ -205,10 +205,15 @@ async fn start_session_in_place(
             // #2997: disclaim the pane's `claude` off the shared tmux server
             // (same wrapper the daemon + `tm launch`/`connect` paths use).
             // No-op off macOS / under TM_DISABLE_SPAWN_DISCLAIM.
-            let claude_cmd = trusty_mpm::core::spawn_disclaim::disclaim_pane_command(&format!(
-                "claude {}",
-                trusty_mpm::core::model_inject::PERMISSION_MODE_FLAG
-            ));
+            // #4467: the launch line itself is built in the LIBRARY
+            // (`model_inject::build_inplace_session_command`) so it carries the
+            // shared inherited-marker scrub and is readable by the
+            // `transcript_saving` doctor check. It used to be hand-built here as
+            // `format!("claude {PERMISSION_MODE_FLAG}")` — a sixth interactive
+            // launch line that silently saved no transcript.
+            let claude_cmd = trusty_mpm::core::spawn_disclaim::disclaim_pane_command(
+                &trusty_mpm::core::model_inject::build_inplace_session_command(),
+            );
             let send = trusty_mpm::core::tmux::send_line(
                 None,
                 &trusty_mpm::core::tmux::TmuxTarget::session(&body.name),

--- a/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
+++ b/crates/trusty-mpm/src/bin/tm/generate/doctor.rs
@@ -44,6 +44,10 @@ pub(crate) const DOCTOR_CHECKS: &[(&str, &str)] = &[
         "Fails when bundled agents deploy into a settings tier a managed session's `--setting-sources` flag never loads — presence-only checks stay green while every delegation degrades to `general-purpose` (issue #4451).",
     ),
     (
+        "transcript_saving",
+        "Fails when a managed spawn would leave Claude Code transcript saving disabled — an inherited `CLAUDE_CODE_CHILD_SESSION` marker costs the session all native `--resume`/`--continue`/`/rewind` recovery, and also fails if the scrub would wrongly take `CLAUDE_CONFIG_DIR` (issue #4467).",
+    ),
+    (
         "skills",
         "Bundled skill catalog deployed under the operator/workspace `.claude/skills/` tier.",
     ),

--- a/crates/trusty-mpm/src/client/executor/tests.rs
+++ b/crates/trusty-mpm/src/client/executor/tests.rs
@@ -196,7 +196,7 @@ async fn execute_doctor_against_test_daemon() {
     match executor.execute(TrustyCommand::Doctor).await {
         CommandResult::Doctor(report) => {
             // This test owns the EXECUTOR round-trip, not the check roster.
-            // The exact count is pinned by `run_doctor_produces_twenty_three_checks`
+            // The exact count is pinned by `run_doctor_produces_twenty_four_checks`
             // and `doctor_endpoint_returns_report`, both of which derive it from
             // their own name list — duplicating a bare literal here just made it a
             // fourth place to forget (#4090 review LOW-1).

--- a/crates/trusty-mpm/src/client/http_client/session_connect.rs
+++ b/crates/trusty-mpm/src/client/http_client/session_connect.rs
@@ -85,11 +85,15 @@ impl DaemonClient {
                 "trusty-mpm-system-prompt-{}.txt",
                 uuid::Uuid::new_v4()
             ));
+            // #4467: the line is built in `core::model_inject` so it carries the
+            // shared inherited-marker scrub and the `transcript_saving` doctor
+            // check can read it. Hand-building it here is what left this launch
+            // path silently saving no transcript.
             match std::fs::write(&path, &prompt) {
-                Ok(()) => format!("claude --append-system-prompt-file {}", path.display()),
+                Ok(()) => crate::core::model_inject::build_client_session_command(Some(&path)),
                 Err(err) => {
                     tracing::warn!(%err, "failed to write system prompt file; launching bare claude");
-                    "claude".to_string()
+                    crate::core::model_inject::build_client_session_command(None)
                 }
             }
         };
@@ -183,11 +187,15 @@ impl DaemonClient {
                 "trusty-mpm-system-prompt-{}.txt",
                 uuid::Uuid::new_v4()
             ));
+            // #4467: the line is built in `core::model_inject` so it carries the
+            // shared inherited-marker scrub and the `transcript_saving` doctor
+            // check can read it. Hand-building it here is what left this launch
+            // path silently saving no transcript.
             match std::fs::write(&path, &prompt) {
-                Ok(()) => format!("claude --append-system-prompt-file {}", path.display()),
+                Ok(()) => crate::core::model_inject::build_client_session_command(Some(&path)),
                 Err(err) => {
                     tracing::warn!(%err, "failed to write system prompt file; launching bare claude");
-                    "claude".to_string()
+                    crate::core::model_inject::build_client_session_command(None)
                 }
             }
         };

--- a/crates/trusty-mpm/src/control/backend/stream_json.rs
+++ b/crates/trusty-mpm/src/control/backend/stream_json.rs
@@ -69,7 +69,15 @@ pub const ANTHROPIC_API_KEY_VAR: &str = "ANTHROPIC_API_KEY";
 /// --workdir <dir>` with `ANTHROPIC_API_KEY` removed from the child env,
 /// stdin/stdout piped, stderr captured, and the working directory set. The
 /// caller converts it to a `tokio::process::Command` to spawn.
-/// Test: `build_command_removes_api_key`, `build_command_has_stream_json_args`.
+///
+/// Issue #4467: the same `env_remove` seam also strips Claude Code's inherited
+/// process-local session markers via
+/// [`crate::core::claude_env_scrub::scrub_command`]. This backend inherits the
+/// daemon's environment, so when the daemon was itself started from inside a
+/// Claude Code session the leaked `CLAUDE_CODE_CHILD_SESSION` reached every
+/// headless `claude` it spawned and disabled transcript saving.
+/// Test: `build_command_removes_api_key`, `build_command_has_stream_json_args`,
+/// `build_command_scrubs_inherited_session_markers`.
 pub fn build_claude_command(workdir: &Path, prompt_file: Option<&Path>) -> std::process::Command {
     // Invoke `claude` directly (not via the `env -u` shell wrapper). Using
     // Command::env_remove makes the key-removal an explicit, inspectable part
@@ -79,6 +87,8 @@ pub fn build_claude_command(workdir: &Path, prompt_file: Option<&Path>) -> std::
     let mut cmd = std::process::Command::new("claude");
     // §9.1 LOCKED: strip the metered key so claude uses ~/.claude Max OAuth.
     cmd.env_remove(ANTHROPIC_API_KEY_VAR);
+    // #4467: strip the inherited Claude Code session markers for the same reason.
+    crate::core::claude_env_scrub::scrub_command(&mut cmd);
     cmd.arg("-p");
     cmd.arg("--output-format").arg("stream-json");
     if let Some(pf) = prompt_file {
@@ -306,6 +316,29 @@ mod tests {
         assert_eq!(
             removed.1, None,
             "ANTHROPIC_API_KEY must be REMOVED (None), never set, in the child env"
+        );
+    }
+
+    #[test]
+    fn build_command_scrubs_inherited_session_markers() {
+        // #4467: the daemon may itself have been started from inside a Claude
+        // Code session, in which case every headless `claude` it spawned
+        // inherited CLAUDE_CODE_CHILD_SESSION and saved no transcript. The
+        // marker name is hard-coded so the assertion cannot go vacuous if the
+        // shared constant is emptied.
+        let cmd = build_claude_command(Path::new("/tmp/wd"), None);
+        let muts = env_mutations(&cmd);
+        let removed = muts
+            .iter()
+            .find(|(k, _)| k == "CLAUDE_CODE_CHILD_SESSION")
+            .expect("CLAUDE_CODE_CHILD_SESSION must appear as an explicit env mutation");
+        assert_eq!(
+            removed.1, None,
+            "CLAUDE_CODE_CHILD_SESSION must be REMOVED (None) from the child env"
+        );
+        assert!(
+            !muts.iter().any(|(k, _)| k == "CLAUDE_CONFIG_DIR"),
+            "CLAUDE_CONFIG_DIR must not be touched by the scrub (#4455): {muts:?}"
         );
     }
 

--- a/crates/trusty-mpm/src/core/claude_env_scrub.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub.rs
@@ -203,34 +203,54 @@ pub fn scrub_command(cmd: &mut std::process::Command) {
 /// [`INHERITED_SESSION_MARKERS`] against itself would be a tautology and would
 /// stay green if someone dropped the flags from the spawn builder — the exact
 /// shape of blind spot issue #4467 is about.
-/// What: whitespace-splits `prefix` and collects the token following each
-/// standalone `-u`, STOPPING at the first `NAME=VALUE` token. A trailing `-u`
-/// with no operand yields nothing.
+/// What: whitespace-splits `prefix`, skips the leading `env` word, and collects
+/// the token following each standalone `-u`. Parsing STOPS at the first token
+/// that ends `env`'s own argument list — a `NAME=VALUE` assignment or the
+/// COMMAND word. A trailing `-u` with no operand yields nothing.
 ///
-/// The early stop models POSIX `env` option termination rather than merely
-/// scanning for `-u`. Without it this function would report a variable as unset
-/// on a prefix that `env` would actually reject: `env CLAUDE_CODE_CHILD_SESSION=1
-/// -u FOO claude` makes `env` stop parsing options at the assignment and try to
-/// exec `-u` as a command (`env: -u: No such file or directory`, exit 127). A
-/// parser that reported `FOO` unset there would let the `tm doctor` probe pass on
-/// an ordering that kills every spawn.
+/// Both stops model POSIX `env [OPTION]... [NAME=VALUE]... [COMMAND] [ARG]...`
+/// rather than merely scanning the whole string for `-u`.
+///
+/// The assignment stop keeps this from reporting a variable as unset on a prefix
+/// that `env` would actually reject: `env CLAUDE_CODE_CHILD_SESSION=1 -u FOO
+/// claude` makes `env` stop parsing options at the assignment and try to exec
+/// `-u` as a command (`env: -u: No such file or directory`, exit 127). A parser
+/// that reported `FOO` unset there would let the `tm doctor` probe pass on an
+/// ordering that kills every spawn.
+///
+/// The COMMAND stop (review round 2) matters because
+/// [`crate::core::model_inject::build_claude_command`] emits NO assignments at
+/// all, so the assignment stop never fires on its output and the scan would
+/// otherwise run to the end of the line. A future `claude` flag pair spelled
+/// `-u <value>` would then be miscounted as an unset variable. Not reachable
+/// today — this closes the hole before a flag makes it reachable.
 /// Test: `parse_env_unset_vars_reads_the_real_spawn_prefix`,
 /// `parse_env_unset_vars_stops_at_the_first_assignment`,
+/// `parse_env_unset_vars_stops_at_the_command_word`,
 /// `parse_env_unset_vars_tolerates_trailing_flag`.
 pub fn parse_env_unset_vars(prefix: &str) -> Vec<&str> {
-    let mut tokens = prefix.split_whitespace();
+    let mut tokens = prefix.split_whitespace().peekable();
+    // The leading `env` word is the program, not an operand — step over it so
+    // the COMMAND stop below does not fire on the very first token.
+    if tokens.peek() == Some(&"env") {
+        tokens.next();
+    }
     let mut found = Vec::new();
     while let Some(token) = tokens.next() {
-        // POSIX: `env [OPTION]... [NAME=VALUE]... [COMMAND]...` — the first
-        // assignment ends option parsing, so no later `-u` is an option.
+        // POSIX: the first assignment ends option parsing, so no later `-u` is
+        // an option.
         if token.contains('=') {
             break;
         }
-        if token == "-u"
-            && let Some(name) = tokens.next()
-        {
-            found.push(name);
+        if token == "-u" {
+            if let Some(name) = tokens.next() {
+                found.push(name);
+            }
+            continue;
         }
+        // Anything else is the COMMAND word: `env`'s own arguments are over, and
+        // every token after it belongs to the command, not to `env`.
+        break;
     }
     found
 }

--- a/crates/trusty-mpm/src/core/claude_env_scrub.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub.rs
@@ -1,0 +1,235 @@
+//! Scrub Claude Code's process-local session markers from a managed spawn's
+//! environment (issue #4467).
+//!
+//! Why: when `tm` is invoked from inside a Claude Code session — the PM
+//! delegating, the daemon having been started from a session, or an operator
+//! simply running `tm` in a `claude` pane — it inherits the markers Claude Code
+//! injects into every child process it spawns. `tm` then passed that whole
+//! environment through to the `claude` it spawns, and the inherited
+//! [`TRANSCRIPT_SUPPRESSING_MARKER`] made Claude Code turn session persistence
+//! OFF for the managed session:
+//!
+//! > Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker
+//!
+//! The consequence was silent: managed sessions got no native `--resume` /
+//! `--continue` / `/rewind` recovery and never appeared in `--resume`, so a
+//! session that died lost everything since tm's last (summary-only) snapshot.
+//!
+//! The marker set below is not guesswork. It is exactly what Claude Code's own
+//! child-process env injector sets, read out of the `claude` 2.1.220 bundle:
+//!
+//! ```text
+//! function KDt(e){ let t={CLAUDECODE:"1", CLAUDE_CODE_SESSION_ID:e.sessionId,
+//!   CLAUDE_CODE_CHILD_SESSION:"1", CLAUDE_PID:String(process.pid)};
+//!   if(e.effortLevel!==void 0) t.CLAUDE_EFFORT=e.effortLevel; ... }
+//! ```
+//!
+//! plus `CLAUDE_CODE_EXECPATH` (the parent interpreter's path), which appears on
+//! that same bundle's own list of variables it refuses to propagate into a
+//! shell snapshot. Every entry names the PARENT process — its session id, its
+//! pid, its binary, its current turn's effort level — so none of them can be
+//! correct for a fresh managed session.
+//!
+//! What this module deliberately does NOT scrub is as load-bearing as what it
+//! does: see [`DELIBERATE_SPAWN_ENV`]. A blanket scrub of `CLAUDE_*` would take
+//! `CLAUDE_CONFIG_DIR` with it and instantly re-break issue #4451 — #4455
+//! depends on that relocation to put the bundled agent roster in a settings
+//! tier a managed session actually loads.
+//!
+//! Test: `crates/trusty-mpm/src/core/claude_env_scrub_tests.rs`.
+
+/// The marker whose INHERITED presence disables Claude Code transcript saving.
+///
+/// Why: this is the single trigger, not one of several. The gate in the `claude`
+/// 2.1.220 bundle reads:
+///
+/// ```text
+/// function Zkt(){
+///   if (Z.CLAUDE_CODE_FORCE_SESSION_PERSISTENCE) return false;
+///   if (!(Z.CLAUDE_CODE_CHILD_SESSION && PN() && !o_())) return false;
+///   return !Tsg();   // Tsg(): tmux show-environment -g CLAUDE_CODE_CHILD_SESSION
+/// }
+/// ```
+///
+/// Named separately from the rest of [`INHERITED_SESSION_MARKERS`] because the
+/// `tm doctor` probe asserts specifically on THIS variable: the others are
+/// correctness hygiene, this one is the difference between a recoverable
+/// managed session and an unrecoverable one.
+///
+/// Note the upstream escape hatch `Tsg()`: a marker present in the tmux SERVER's
+/// global environment suppresses the heuristic. That is why the defect looked
+/// intermittent rather than universal — a tmux server started from inside a
+/// Claude Code session carries the marker globally and masks the leak. Relying
+/// on that mask is not an option: it depends on how the tmux server happened to
+/// be started, so scrubbing the variable is what makes the outcome
+/// deterministic.
+/// What: the literal variable name.
+/// Test: `suppressing_marker_is_scrubbed`.
+pub const TRANSCRIPT_SUPPRESSING_MARKER: &str = "CLAUDE_CODE_CHILD_SESSION";
+
+/// Claude Code's process-local markers, which a managed spawn must not inherit.
+///
+/// Why: see the module doc — every entry is set by Claude Code's own
+/// child-process env injector and describes the PARENT process, so inheriting
+/// any of them mis-attributes the new session. `CLAUDE_CODE_CHILD_SESSION`
+/// additionally disables transcript saving outright (issue #4467).
+/// What: the marker names, in the order they appear on the spawn's `env -u`
+/// prefix. [`TRANSCRIPT_SUPPRESSING_MARKER`] leads so the most consequential
+/// entry is the first one a reader (or a pane's shell history) sees.
+/// Test: `marker_list_is_free_of_deliberate_spawn_env`,
+/// `marker_list_has_no_duplicates`.
+pub const INHERITED_SESSION_MARKERS: &[&str] = &[
+    TRANSCRIPT_SUPPRESSING_MARKER,
+    // The parent's session UUID. Inheriting it makes hooks and the statusline
+    // attribute the child's events to the parent conversation.
+    "CLAUDE_CODE_SESSION_ID",
+    // "you are running inside Claude Code" marker. The spawned `claude` sets it
+    // for its OWN children; inheriting it is the generic leak upstream 2.1.170
+    // called out for the VS Code integrated terminal.
+    "CLAUDECODE",
+    // The parent interpreter's pid — stale by definition, and consulted by
+    // shell-snapshot probes (`/proc/$CLAUDE_PID/comm`).
+    "CLAUDE_PID",
+    // A snapshot of the parent's CURRENT TURN effort level. It is derived
+    // output exposed for hooks, not a user configuration knob, so a fresh
+    // session must recompute it rather than adopt a stale turn's value.
+    "CLAUDE_EFFORT",
+    // Path to the parent's `claude` binary. tm always passes an absolute
+    // resolved binary explicitly, so nothing in tm reads this.
+    "CLAUDE_CODE_EXECPATH",
+];
+
+/// Environment variables a managed spawn sets DELIBERATELY — never scrub these.
+///
+/// Why (issue #4451 / #4455): this list exists to make over-scrubbing a
+/// mechanical failure instead of a judgement call. `CLAUDE_CONFIG_DIR` is
+/// relocated on purpose — it isolates the managed session's auth AND, since
+/// #4455, is what puts the bundled agent roster in the `user` settings tier the
+/// spawn's `--setting-sources user,project,local` flag loads. Scrub it and every
+/// delegation silently degrades to `general-purpose` again. `CLAUDE_CODE_OAUTH_TOKEN`
+/// is injected by #2246 to bypass the `CLAUDE_CONFIG_DIR`-keyed Keychain
+/// divergence that otherwise produces a login loop.
+///
+/// Two further inherited variables are deliberately absent from
+/// [`INHERITED_SESSION_MARKERS`] and are NOT scrubbed, because neither is
+/// process-local state and neither affects transcript saving:
+/// `CLAUDE_CODE_MAX_OUTPUT_TOKENS` is an operator-facing configuration knob
+/// (scrubbing it would silently override the operator's intent), and
+/// `CLAUDE_CODE_ENTRYPOINT` already carries the value a fresh CLI spawn would
+/// compute for itself (`cli`).
+/// What: the variable names a managed spawn assigns rather than unsets.
+/// Test: `marker_list_is_free_of_deliberate_spawn_env`,
+/// `config_dir_is_never_scrubbed`.
+pub const DELIBERATE_SPAWN_ENV: &[&str] = &[
+    "CLAUDE_CONFIG_DIR",
+    crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR,
+];
+
+/// The POSIX `env` unset flags that scrub every [`INHERITED_SESSION_MARKERS`]
+/// entry.
+///
+/// Why: the tmux-pane spawn paths build a shell command STRING, so the scrub has
+/// to be expressed as `env` flags rather than a `Command` mutation. Generating
+/// them from the shared list keeps the string-command paths
+/// (`spawn_command` / `resume_command`) and the `Command`-based paths
+/// ([`scrub_command`]) from ever scrubbing different sets.
+/// What: `" -u NAME"` per marker, each with a LEADING space so the result
+/// concatenates directly onto an existing `env -u …` prefix. Marker names are
+/// compile-time constants containing no shell metacharacters, so they need no
+/// quoting. Every flag precedes any `NAME=VALUE` assignment, as POSIX `env`
+/// grammar requires — an assignment before a `-u` makes `env` stop parsing
+/// options and try to exec `-u` as a command.
+/// Test: `env_unset_flags_covers_every_marker`,
+/// `env_unset_flags_are_space_prefixed`.
+pub fn env_unset_flags() -> String {
+    INHERITED_SESSION_MARKERS
+        .iter()
+        .map(|name| format!(" -u {name}"))
+        .collect()
+}
+
+/// Remove every [`INHERITED_SESSION_MARKERS`] entry from a [`std::process::Command`].
+///
+/// Why: the in-place relaunch (`build_inplace_exec_command`) and the
+/// stream-json backend (`control::backend::stream_json`) exec `claude` through a
+/// `Command` with no shell in between, so [`env_unset_flags`] does not apply to
+/// them — but they leak exactly the same markers and need exactly the same
+/// scrub. Using `env_remove` (rather than filtering an env map) keeps the
+/// removal an explicit, inspectable part of the command that `get_envs()`
+/// surfaces as `(key, None)`, which is what the tests assert on.
+/// What: calls [`std::process::Command::env_remove`] once per marker.
+/// Test: `scrub_command_removes_every_marker`,
+/// `scrub_command_leaves_deliberate_env_intact`.
+pub fn scrub_command(cmd: &mut std::process::Command) {
+    for name in INHERITED_SESSION_MARKERS {
+        cmd.env_remove(name);
+    }
+}
+
+/// Parse the variable names an `env …` prefix string unsets via `-u NAME`.
+///
+/// Why: this is what lets the `tm doctor` probe read the scrub set out of the
+/// REAL spawn command instead of restating the constant. A check that compared
+/// [`INHERITED_SESSION_MARKERS`] against itself would be a tautology and would
+/// stay green if someone dropped the flags from the spawn builder — the exact
+/// shape of blind spot issue #4467 is about.
+/// What: whitespace-splits `prefix` and collects the token following each
+/// standalone `-u`. A trailing `-u` with no operand yields nothing.
+/// Test: `parse_env_unset_vars_reads_the_real_spawn_prefix`,
+/// `parse_env_unset_vars_ignores_assignments`,
+/// `parse_env_unset_vars_tolerates_trailing_flag`.
+pub fn parse_env_unset_vars(prefix: &str) -> Vec<&str> {
+    let mut tokens = prefix.split_whitespace();
+    let mut found = Vec::new();
+    while let Some(token) = tokens.next() {
+        if token == "-u"
+            && let Some(name) = tokens.next()
+        {
+            found.push(name);
+        }
+    }
+    found
+}
+
+/// Which [`INHERITED_SESSION_MARKERS`] are live in the CURRENT process env.
+///
+/// Why: `tm doctor` reports these so an operator can see whether this
+/// invocation is itself running with the leak present — the difference between
+/// "the scrub is configured correctly" (always checkable) and "the leak is
+/// actually reaching me right now" (situational). Reported as context, never as
+/// the pass/fail condition, because `tm doctor` run from a plain shell has no
+/// markers set and the check must still be meaningful there.
+/// What: delegates to [`markers_present_in`] with a real-environment lookup.
+/// Test: covered via [`markers_present_in`].
+pub fn markers_present_in_env() -> Vec<&'static str> {
+    markers_present_in(|name| std::env::var_os(name).is_some())
+}
+
+/// Pure core of [`markers_present_in_env`]: which markers does `is_set` report?
+///
+/// Why: taking the lookup as a parameter keeps this testable without mutating
+/// the process environment. `std::env::set_var` is `unsafe` in edition 2024 and
+/// mutates state shared by every test in the binary, so a test that set a real
+/// marker could flip the result of any concurrently-running test that reads the
+/// environment. Injecting the lookup removes the shared mutable state instead of
+/// trying to synchronise around it.
+/// What: the subset of [`INHERITED_SESSION_MARKERS`] for which `is_set` returns
+/// true. Presence is what matters, not value — Claude Code sets these to `"1"`
+/// or an id, and an empty value would still have been inherited.
+/// Test: `markers_present_in_detects_a_set_marker`,
+/// `markers_present_in_is_empty_for_a_clean_env`,
+/// `markers_present_in_reports_every_marker_when_all_are_set`.
+fn markers_present_in<F>(is_set: F) -> Vec<&'static str>
+where
+    F: Fn(&str) -> bool,
+{
+    INHERITED_SESSION_MARKERS
+        .iter()
+        .copied()
+        .filter(|name| is_set(name))
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "claude_env_scrub_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/claude_env_scrub.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub.rs
@@ -57,12 +57,20 @@
 /// managed session and an unrecoverable one.
 ///
 /// Note the upstream escape hatch `Tsg()`: a marker present in the tmux SERVER's
-/// global environment suppresses the heuristic. That is why the defect looked
-/// intermittent rather than universal — a tmux server started from inside a
-/// Claude Code session carries the marker globally and masks the leak. Relying
-/// on that mask is not an option: it depends on how the tmux server happened to
-/// be started, so scrubbing the variable is what makes the outcome
-/// deterministic.
+/// global environment suppresses the heuristic. For a tmux PANE the marker's
+/// presence and the escape hatch are coupled — tmux's `update-environment` does
+/// not carry `CLAUDE_*`, so a marker only reaches a pane when the server's global
+/// env has it, which is exactly the condition that trips the hatch.
+///
+/// Two things make the hatch unreliable anyway, and both argue for scrubbing:
+/// `Esg()` runs `spawnSync("tmux", …)` by BARE NAME with a 250 ms timeout and
+/// returns false on throw or non-zero status — so it FAILS OPEN INTO SUPPRESSION.
+/// A pane running on the daemon's minimal launchd `PATH` (the #1298 hazard) or a
+/// machine loaded enough to blow 250 ms both flip a masked session to
+/// not-saving. And `tm run` has no tmux at all, so `Esg()` returns false on its
+/// first line (`if(!Z.TMUX) return false`) and the suppression fires every time.
+/// Scrubbing the variable is what makes the outcome deterministic instead of
+/// dependent on a probe that can fail open.
 /// What: the literal variable name.
 /// Test: `suppressing_marker_is_scrubbed`.
 pub const TRANSCRIPT_SUPPRESSING_MARKER: &str = "CLAUDE_CODE_CHILD_SESSION";
@@ -116,7 +124,29 @@ pub const INHERITED_SESSION_MARKERS: &[&str] = &[
 /// `CLAUDE_CODE_MAX_OUTPUT_TOKENS` is an operator-facing configuration knob
 /// (scrubbing it would silently override the operator's intent), and
 /// `CLAUDE_CODE_ENTRYPOINT` already carries the value a fresh CLI spawn would
-/// compute for itself (`cli`).
+/// compute for itself (`cli`). On `CLAUDE_CODE_ENTRYPOINT` specifically: unset is
+/// NOT universally equivalent to `"cli"` — the bundle gates one code path on
+/// `e === "cli" || e === "remote"`, so scrubbing it would silently disable that
+/// path, which is why keeping it is the safer choice at the observed value. The
+/// keep is value-dependent rather than proven-safe for every value: an inherited
+/// `sdk-ts`/`sdk-py`/`sdk-cli` drops one built-in agent from the roster and
+/// `claude-vscode` changes `clientType`. Neither is reachable from a `tm` spawn,
+/// whose parent is always a `cli` session.
+///
+/// `AI_AGENT` and `TRACEPARENT` are set by the same upstream injector but are
+/// also left alone. `AI_AGENT` self-heals: the bundle overwrites any inherited
+/// value beginning `claude-code_`/`claude-code/` with its own at startup, so a
+/// leaked value cannot reach the session stale. `TRACEPARENT` is only set when
+/// tracing is on and its sole effect is span parenting. Both are generically
+/// named, so a third party could legitimately set them.
+///
+/// `CLAUDE_CODE_INVOKED_SKILLS` appears on the same upstream non-propagation
+/// list that justifies including `CLAUDE_CODE_EXECPATH`, and is deliberately NOT
+/// scrubbed: it was not in the observed leak set, nothing in this workspace reads
+/// it, and it carries no session identity — it records which skills the parent
+/// turn invoked. Unlike the entries above, a stale value cannot mis-attribute a
+/// session or suppress a transcript, so scrubbing it would be unjustified churn
+/// on a list whose whole value is that every entry has a stated reason.
 /// What: the variable names a managed spawn assigns rather than unsets.
 /// Test: `marker_list_is_free_of_deliberate_spawn_env`,
 /// `config_dir_is_never_scrubbed`.
@@ -174,14 +204,28 @@ pub fn scrub_command(cmd: &mut std::process::Command) {
 /// stay green if someone dropped the flags from the spawn builder — the exact
 /// shape of blind spot issue #4467 is about.
 /// What: whitespace-splits `prefix` and collects the token following each
-/// standalone `-u`. A trailing `-u` with no operand yields nothing.
+/// standalone `-u`, STOPPING at the first `NAME=VALUE` token. A trailing `-u`
+/// with no operand yields nothing.
+///
+/// The early stop models POSIX `env` option termination rather than merely
+/// scanning for `-u`. Without it this function would report a variable as unset
+/// on a prefix that `env` would actually reject: `env CLAUDE_CODE_CHILD_SESSION=1
+/// -u FOO claude` makes `env` stop parsing options at the assignment and try to
+/// exec `-u` as a command (`env: -u: No such file or directory`, exit 127). A
+/// parser that reported `FOO` unset there would let the `tm doctor` probe pass on
+/// an ordering that kills every spawn.
 /// Test: `parse_env_unset_vars_reads_the_real_spawn_prefix`,
-/// `parse_env_unset_vars_ignores_assignments`,
+/// `parse_env_unset_vars_stops_at_the_first_assignment`,
 /// `parse_env_unset_vars_tolerates_trailing_flag`.
 pub fn parse_env_unset_vars(prefix: &str) -> Vec<&str> {
     let mut tokens = prefix.split_whitespace();
     let mut found = Vec::new();
     while let Some(token) = tokens.next() {
+        // POSIX: `env [OPTION]... [NAME=VALUE]... [COMMAND]...` — the first
+        // assignment ends option parsing, so no later `-u` is an option.
+        if token.contains('=') {
+            break;
+        }
         if token == "-u"
             && let Some(name) = tokens.next()
         {

--- a/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
@@ -9,14 +9,50 @@
 
 use super::*;
 
+/// Every marker, by LITERAL name.
+///
+/// Why (review follow-up on #4467): every other test in this file iterates
+/// `INHERITED_SESSION_MARKERS`, so deleting an entry made them all pass
+/// vacuously — `CLAUDE_PID` and `CLAUDE_EFFORT` in particular were pinned by
+/// nothing, and removing either kept the whole suite green. Restating the names
+/// here is the point: this list and the production constant must be edited
+/// together, deliberately.
+const EXPECTED_MARKERS: &[&str] = &[
+    "CLAUDE_CODE_CHILD_SESSION",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDECODE",
+    "CLAUDE_PID",
+    "CLAUDE_EFFORT",
+    "CLAUDE_CODE_EXECPATH",
+];
+
 /// The single most important assertion in this file: the variable that
 /// disables transcript saving is actually on the scrub list (issue #4467).
 #[test]
 fn suppressing_marker_is_scrubbed() {
+    assert_eq!(
+        TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CODE_CHILD_SESSION",
+        "the suppressing marker's identity is load-bearing; it is the sole trigger \
+         in Claude Code's persistence gate"
+    );
     assert!(
         INHERITED_SESSION_MARKERS.contains(&TRANSCRIPT_SUPPRESSING_MARKER),
         "the marker that disables transcript saving must be scrubbed; \
          without it managed sessions get no --resume/--continue/rewind recovery"
+    );
+}
+
+/// Pins the full marker set by literal name, in order, so deleting ANY entry
+/// fails — including `CLAUDE_PID` and `CLAUDE_EFFORT`, which previously had no
+/// literal assertion anywhere in the suite.
+#[test]
+fn every_marker_is_pinned_by_literal_name() {
+    assert_eq!(
+        INHERITED_SESSION_MARKERS,
+        EXPECTED_MARKERS,
+        "the scrub list changed. If that is intentional, update EXPECTED_MARKERS in \
+         this file too — and re-check the kept/scrubbed rationale in the module doc, \
+         since every entry there has a stated reason"
     );
 }
 
@@ -170,15 +206,27 @@ fn parse_env_unset_vars_reads_the_real_spawn_prefix() {
     );
 }
 
-/// `NAME=VALUE` assignments are not unsets; conflating them would let the
-/// doctor probe pass on a prefix that SET the marker instead of clearing it.
+/// POSIX option termination: the first `NAME=VALUE` ends option parsing, so a
+/// later `-u` is NOT an unset — `env` would try to exec `-u` as a command.
+///
+/// Why this matters (review follow-up on #4467): the earlier parser reported
+/// `FOO` unset here, which meant the doctor probe would have passed on an
+/// ordering that kills every spawn with `env: -u: No such file or directory`
+/// (exit 127). Reporting nothing is the correct answer — the prefix is broken.
 #[test]
-fn parse_env_unset_vars_ignores_assignments() {
+fn parse_env_unset_vars_stops_at_the_first_assignment() {
     let unset = parse_env_unset_vars("env CLAUDE_CODE_CHILD_SESSION=1 -u FOO /abs/claude");
     assert_eq!(
         unset,
+        Vec::<&str>::new(),
+        "an assignment ends option parsing, so no later -u counts as an unset: {unset:?}"
+    );
+    // A well-formed prefix — flags BEFORE the assignment — still parses fully.
+    let good = parse_env_unset_vars("env -u FOO CLAUDE_CONFIG_DIR=/tmp/x /abs/claude");
+    assert_eq!(
+        good,
         vec!["FOO"],
-        "only `-u NAME` operands are unsets: {unset:?}"
+        "flags preceding the assignment must still be collected: {good:?}"
     );
 }
 

--- a/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
@@ -48,8 +48,7 @@ fn suppressing_marker_is_scrubbed() {
 #[test]
 fn every_marker_is_pinned_by_literal_name() {
     assert_eq!(
-        INHERITED_SESSION_MARKERS,
-        EXPECTED_MARKERS,
+        INHERITED_SESSION_MARKERS, EXPECTED_MARKERS,
         "the scrub list changed. If that is intentional, update EXPECTED_MARKERS in \
          this file too — and re-check the kept/scrubbed rationale in the module doc, \
          since every entry there has a stated reason"

--- a/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
@@ -229,6 +229,34 @@ fn parse_env_unset_vars_stops_at_the_first_assignment() {
     );
 }
 
+/// The COMMAND word ends `env`'s argument list, so flags belonging to the
+/// command are never mistaken for `env -u` operands.
+///
+/// Why this matters (review round 2 LOW): `model_inject::build_claude_command`
+/// emits NO `NAME=VALUE` assignments, so the assignment stop never fires on its
+/// output. Without a COMMAND stop the scan runs to the end of the line, and a
+/// future `claude` flag pair spelled `-u <value>` would be counted as an unset
+/// variable — inflating what the `tm doctor` probe believes is scrubbed.
+#[test]
+fn parse_env_unset_vars_stops_at_the_command_word() {
+    let unset = parse_env_unset_vars("env -u REAL claude --some-flag -u NOT_AN_UNSET");
+    assert_eq!(
+        unset,
+        vec!["REAL"],
+        "only operands before the command word are unsets: {unset:?}"
+    );
+
+    // The daemon shape: the command word can be an absolute path, and the
+    // disclaim wrapper puts a quoted tm path there. Neither may be scanned past.
+    let wrapped =
+        parse_env_unset_vars("env -u REAL '/w/tm' internal-spawn-disclaimed /abs/claude -u NOPE");
+    assert_eq!(
+        wrapped,
+        vec!["REAL"],
+        "the wrapper path is a command word, not an operand: {wrapped:?}"
+    );
+}
+
 /// A malformed trailing `-u` must not panic.
 #[test]
 fn parse_env_unset_vars_tolerates_trailing_flag() {

--- a/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_env_scrub_tests.rs
@@ -1,0 +1,208 @@
+//! Tests for [`super`] — the managed-spawn env scrub (issue #4467).
+//!
+//! Why: the scrub is a silent-failure guard, so its own tests have to be able to
+//! fail. The two directions that matter are asserted independently: the
+//! transcript-suppressing marker must be scrubbed (under-scrub → managed
+//! sessions lose transcripts), and `CLAUDE_CONFIG_DIR` must NOT be scrubbed
+//! (over-scrub → issue #4451 returns and every delegation degrades to
+//! `general-purpose`).
+
+use super::*;
+
+/// The single most important assertion in this file: the variable that
+/// disables transcript saving is actually on the scrub list (issue #4467).
+#[test]
+fn suppressing_marker_is_scrubbed() {
+    assert!(
+        INHERITED_SESSION_MARKERS.contains(&TRANSCRIPT_SUPPRESSING_MARKER),
+        "the marker that disables transcript saving must be scrubbed; \
+         without it managed sessions get no --resume/--continue/rewind recovery"
+    );
+}
+
+/// Over-scrub guard: the deliberate spawn env and the scrub list must be
+/// disjoint. Scrubbing `CLAUDE_CONFIG_DIR` re-breaks #4451 (#4455 relies on it).
+#[test]
+fn marker_list_is_free_of_deliberate_spawn_env() {
+    for deliberate in DELIBERATE_SPAWN_ENV {
+        assert!(
+            !INHERITED_SESSION_MARKERS.contains(deliberate),
+            "{deliberate} is set deliberately by a managed spawn and must never \
+             be scrubbed — scrubbing CLAUDE_CONFIG_DIR re-breaks #4451"
+        );
+    }
+}
+
+/// `CLAUDE_CONFIG_DIR` named explicitly, not just via the loop above, so the
+/// guard survives someone emptying `DELIBERATE_SPAWN_ENV` (which would make
+/// `marker_list_is_free_of_deliberate_spawn_env` pass vacuously).
+#[test]
+fn config_dir_is_never_scrubbed() {
+    assert!(
+        !INHERITED_SESSION_MARKERS.contains(&"CLAUDE_CONFIG_DIR"),
+        "CLAUDE_CONFIG_DIR relocation is what puts the bundled roster in the \
+         `user` settings tier a managed session loads (#4455); scrubbing it \
+         silently restores the #4451 zero-specialists failure"
+    );
+    assert!(
+        DELIBERATE_SPAWN_ENV.contains(&"CLAUDE_CONFIG_DIR"),
+        "CLAUDE_CONFIG_DIR must stay listed as deliberate spawn env"
+    );
+}
+
+/// A duplicate would emit a redundant `-u` flag on every managed pane command.
+#[test]
+fn marker_list_has_no_duplicates() {
+    let mut seen: Vec<&str> = Vec::new();
+    for name in INHERITED_SESSION_MARKERS {
+        assert!(
+            !seen.contains(name),
+            "{name} appears twice in INHERITED_SESSION_MARKERS"
+        );
+        seen.push(name);
+    }
+}
+
+/// Every marker must reach the `env` prefix — a marker on the list but missing
+/// from the flags would be scrubbed on the `Command` paths only.
+#[test]
+fn env_unset_flags_covers_every_marker() {
+    let flags = env_unset_flags();
+    for name in INHERITED_SESSION_MARKERS {
+        assert!(
+            flags.contains(&format!(" -u {name}")),
+            "env_unset_flags() must unset {name}; got {flags:?}"
+        );
+    }
+    assert_eq!(
+        parse_env_unset_vars(&flags),
+        INHERITED_SESSION_MARKERS.to_vec(),
+        "the flags must round-trip back to exactly the marker list"
+    );
+}
+
+/// The flags concatenate onto an existing `env -u ANTHROPIC_API_KEY` prefix, so
+/// each needs a LEADING space; a missing one would fuse two tokens together and
+/// break every managed spawn.
+#[test]
+fn env_unset_flags_are_space_prefixed() {
+    let flags = env_unset_flags();
+    assert!(
+        flags.starts_with(" -u "),
+        "flags must start with a leading space: {flags:?}"
+    );
+    assert!(
+        !flags.contains("  "),
+        "no double spaces (would survive but signals a formatting bug): {flags:?}"
+    );
+}
+
+/// `scrub_command` must surface every marker as an explicit removal, which
+/// `get_envs()` reports as `(key, None)`.
+#[test]
+fn scrub_command_removes_every_marker() {
+    let mut cmd = std::process::Command::new("claude");
+    scrub_command(&mut cmd);
+    let removed: Vec<String> = cmd
+        .get_envs()
+        .filter(|(_, v)| v.is_none())
+        .map(|(k, _)| k.to_string_lossy().into_owned())
+        .collect();
+    for name in INHERITED_SESSION_MARKERS {
+        assert!(
+            removed.contains(&(*name).to_owned()),
+            "scrub_command must env_remove({name}); removed={removed:?}"
+        );
+    }
+}
+
+/// Over-scrub guard on the `Command` path: an explicit assignment made before
+/// the scrub must survive it, because `build_inplace_exec_command` sets
+/// `CLAUDE_CONFIG_DIR` and the OAuth token on the same command.
+#[test]
+fn scrub_command_leaves_deliberate_env_intact() {
+    let mut cmd = std::process::Command::new("claude");
+    cmd.env("CLAUDE_CONFIG_DIR", "/tm/config");
+    cmd.env(crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR, "tok");
+    scrub_command(&mut cmd);
+    let kept: Vec<(String, Option<String>)> = cmd
+        .get_envs()
+        .map(|(k, v)| {
+            (
+                k.to_string_lossy().into_owned(),
+                v.map(|v| v.to_string_lossy().into_owned()),
+            )
+        })
+        .collect();
+    assert!(
+        kept.contains(&(
+            "CLAUDE_CONFIG_DIR".to_owned(),
+            Some("/tm/config".to_owned())
+        )),
+        "the deliberate CLAUDE_CONFIG_DIR assignment must survive the scrub: {kept:?}"
+    );
+    assert!(
+        kept.contains(&(
+            crate::core::oauth_token::OAUTH_TOKEN_ENV_VAR.to_owned(),
+            Some("tok".to_owned())
+        )),
+        "the deliberate OAuth token assignment must survive the scrub: {kept:?}"
+    );
+}
+
+/// The parser is what makes the doctor probe non-tautological, so it is tested
+/// against a realistic prefix shape rather than only its own output.
+#[test]
+fn parse_env_unset_vars_reads_the_real_spawn_prefix() {
+    let prefix = format!(
+        "env -u ANTHROPIC_API_KEY{} CLAUDE_CONFIG_DIR='/tm/config' /abs/claude",
+        env_unset_flags()
+    );
+    let unset = parse_env_unset_vars(&prefix);
+    assert_eq!(
+        unset.first(),
+        Some(&"ANTHROPIC_API_KEY"),
+        "the pre-existing API-key scrub must still be detected: {unset:?}"
+    );
+    assert!(
+        unset.contains(&TRANSCRIPT_SUPPRESSING_MARKER),
+        "the suppressing marker must be visible in the parsed prefix: {unset:?}"
+    );
+}
+
+/// `NAME=VALUE` assignments are not unsets; conflating them would let the
+/// doctor probe pass on a prefix that SET the marker instead of clearing it.
+#[test]
+fn parse_env_unset_vars_ignores_assignments() {
+    let unset = parse_env_unset_vars("env CLAUDE_CODE_CHILD_SESSION=1 -u FOO /abs/claude");
+    assert_eq!(
+        unset,
+        vec!["FOO"],
+        "only `-u NAME` operands are unsets: {unset:?}"
+    );
+}
+
+/// A malformed trailing `-u` must not panic.
+#[test]
+fn parse_env_unset_vars_tolerates_trailing_flag() {
+    assert_eq!(parse_env_unset_vars("env -u"), Vec::<&str>::new());
+}
+
+#[test]
+fn markers_present_in_detects_a_set_marker() {
+    let present = markers_present_in(|name| name == TRANSCRIPT_SUPPRESSING_MARKER);
+    assert_eq!(present, vec![TRANSCRIPT_SUPPRESSING_MARKER]);
+}
+
+#[test]
+fn markers_present_in_is_empty_for_a_clean_env() {
+    assert!(markers_present_in(|_| false).is_empty());
+}
+
+#[test]
+fn markers_present_in_reports_every_marker_when_all_are_set() {
+    assert_eq!(
+        markers_present_in(|_| true),
+        INHERITED_SESSION_MARKERS.to_vec()
+    );
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -29,6 +29,11 @@ pub mod bundled_pm_package;
 pub mod catchup;
 pub mod circuit;
 pub mod claude_config;
+// Issue #4467: the shared set of Claude Code process-local session markers every
+// managed spawn must scrub. An inherited `CLAUDE_CODE_CHILD_SESSION` makes
+// Claude Code disable transcript saving, costing the session native
+// `--resume`/`--continue`/`/rewind` recovery.
+pub mod claude_env_scrub;
 // Epic #4183 / #4286: the READER for `CLAUDE.md` named-section instruction
 // overrides. Ships before the floor text that advertises the mechanism —
 // advertising an override no code reads is issue #381 verbatim.

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -220,7 +220,10 @@ pub const PERMISSION_MODE_FLAG: &str = "--dangerously-skip-permissions";
 pub fn build_claude_command(model: Option<&str>, prompt_file: Option<&Path>) -> String {
     // #4467: scrub the inherited Claude Code session markers so `tm launch` /
     // `tm connect` / delegations keep native --resume/--continue/rewind.
-    let mut cmd = format!("env{} claude", crate::core::claude_env_scrub::env_unset_flags());
+    let mut cmd = format!(
+        "env{} claude",
+        crate::core::claude_env_scrub::env_unset_flags()
+    );
     if let Some(m) = model {
         cmd.push_str(" --model ");
         cmd.push_str(m);
@@ -276,7 +279,10 @@ mod tests {
     /// POSITION; its CONTENT is pinned by literal name in
     /// `core::claude_env_scrub`'s `every_marker_is_pinned_by_literal_name`.
     fn head() -> String {
-        format!("env{} claude", crate::core::claude_env_scrub::env_unset_flags())
+        format!(
+            "env{} claude",
+            crate::core::claude_env_scrub::env_unset_flags()
+        )
     }
 
     #[test]
@@ -291,10 +297,7 @@ mod tests {
     #[test]
     fn claude_command_with_model() {
         let cmd = build_claude_command(Some("claude-opus-4-5"), None);
-        assert_eq!(
-            cmd,
-            format!("{} --model claude-opus-4-5 {FLAGS}", head())
-        );
+        assert_eq!(cmd, format!("{} --model claude-opus-4-5 {FLAGS}", head()));
     }
 
     /// #4467: this builder is the launch line for `tm launch`, `tm connect` and
@@ -432,10 +435,7 @@ mod tests {
         // same `env <-u marker…>` head — an agent session that saved no
         // transcript was the same defect as a PM session that saved none.
         let cmd = build_agent_command(&cfg, &agent, None, None);
-        assert_eq!(
-            cmd,
-            format!("{} --model claude-haiku-4-5 {FLAGS}", head())
-        );
+        assert_eq!(cmd, format!("{} --model claude-haiku-4-5 {FLAGS}", head()));
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -10,9 +10,22 @@
 //! `tmux send-keys`; it optionally appends `--model <id>` and
 //! `--append-system-prompt-file <path>` flags. [`write_prompt_file`] handles
 //! the temp-file side of that second flag.
+//!
+//! Issue #4467: this module owns THREE launch-line builders, and every one of
+//! them must be built here rather than hand-written at a call site. That is not
+//! style — `daemon::doctor_transcript_saving`'s `launch_lines()` can only read
+//! builders the library owns, so a hand-built line is structurally invisible to
+//! the check that exists to catch an unscrubbed spawn. Three separate call sites
+//! had hand-built their own and all three silently saved no transcript.
+//! [`build_inplace_session_command`] and [`build_client_session_command`]
+//! deliberately do NOT carry [`SETTING_SOURCES_FLAG`]: their paths do not
+//! relocate `CLAUDE_CONFIG_DIR`, so dropping the `user` tier would change which
+//! of the operator's own settings and agents load.
 //! Test: `claude_command_bare`, `claude_command_with_model`,
 //! `claude_command_with_prompt`, `claude_command_with_both`,
-//! `write_prompt_file_returns_path`.
+//! `write_prompt_file_returns_path`,
+//! `inplace_session_command_scrubs_inherited_session_markers`,
+//! `client_session_command_scrubs_inherited_session_markers`.
 
 use std::path::{Path, PathBuf};
 
@@ -201,9 +214,18 @@ pub const PERMISSION_MODE_FLAG: &str = "--dangerously-skip-permissions";
 /// Issue #4467: the line is prefixed with `env <-u marker…>` from
 /// [`crate::core::claude_env_scrub::env_unset_flags`]. This builder's own doc
 /// claimed to be the place "every spawn path stays unattended and isolated", but
-/// it emitted a BARE `claude` with no `env` prefix at all — so `tm launch`,
-/// `tm connect` and every agent delegation launched with the inherited
-/// `CLAUDE_CODE_CHILD_SESSION` marker intact and silently saved no transcript.
+/// it emitted a BARE `claude` with no `env` prefix at all — so `tm launch` and
+/// `tm connect` launched with the inherited `CLAUDE_CODE_CHILD_SESSION` marker
+/// intact and silently saved no transcript.
+///
+/// Round-2 review correction: earlier wording here (and the doctor's label) also
+/// advertised this as the AGENT-DELEGATION launch line via [`build_agent_command`].
+/// That was wrong and would have sent an operator chasing a `transcript_saving`
+/// failure to a path that does not exist: `build_agent_command` has no production
+/// caller anywhere in the workspace — only its own definition and test. It is
+/// left in place rather than deleted because `trusty-mpm` is a published crate
+/// with no `publish = false`, so removing a `pub fn` is a semver-breaking change
+/// that does not belong in a bug-fix PR; removing it is filed as follow-up.
 /// There are no `NAME=VALUE` assignments on this prefix (unlike
 /// `runtime::claude_code::env_bin_prefix`, this path does not relocate
 /// `CLAUDE_CONFIG_DIR`), so the POSIX ordering constraint is satisfied trivially
@@ -251,6 +273,74 @@ pub fn build_claude_command(model: Option<&str>, prompt_file: Option<&Path>) -> 
     cmd.push_str(SETTING_SOURCES_FLAG);
     cmd.push(' ');
     cmd.push_str(PERMISSION_MODE_FLAG);
+    cmd
+}
+
+/// The `claude` launch line for an in-place `tm session start` pane.
+///
+/// Why (issue #4467, review round 2 HIGH): `bin/tm`'s `start_session_in_place`
+/// hand-built `format!("claude {PERMISSION_MODE_FLAG}")` and sent it straight to
+/// a fresh tmux pane — a SIXTH interactive launch line with no marker scrub, no
+/// test, and no doctor coverage. It is reachable on the documented "just run
+/// claude here" case (`tm session start` outside a GitHub-backed git repo), so
+/// those sessions silently saved no transcript. Living in the library rather
+/// than the binary is the point: `daemon::doctor_transcript_saving`'s
+/// `launch_lines()` can only read builders the library owns, so a binary-crate
+/// builder is structurally invisible to the check that exists to catch exactly
+/// this.
+///
+/// Deliberately NOT routed through [`build_claude_command`]: that would also add
+/// [`SETTING_SOURCES_FLAG`], and `--setting-sources project,local` DROPS the
+/// `user` tier. On this path `CLAUDE_CONFIG_DIR` is not relocated, so the user
+/// tier is the operator's own `~/.claude` — dropping it would change which
+/// settings and agents an in-place session loads. This fix scrubs the markers
+/// and changes nothing else.
+/// What: `env <-u marker…> claude --dangerously-skip-permissions`. The scrub
+/// flags lead the line and there are no `NAME=VALUE` assignments, so POSIX
+/// option termination is satisfied trivially.
+/// Test: `inplace_session_command_scrubs_inherited_session_markers`,
+/// `inplace_session_command_keeps_the_permission_flag_and_nothing_else`.
+pub fn build_inplace_session_command() -> String {
+    // #4467: same shared scrub every other launch line uses — never a second
+    // mechanism.
+    format!(
+        "env{} claude {}",
+        crate::core::claude_env_scrub::env_unset_flags(),
+        PERMISSION_MODE_FLAG
+    )
+}
+
+/// The `claude` launch line the daemon CLIENT sends to a fresh tmux pane.
+///
+/// Why (issue #4467, found by the round-2 anti-drift scan): `DaemonClient`'s
+/// `launch_session` and `connect_session` — the TUI/bot surface behind
+/// `/connect <dir>` — each hand-built `format!("claude --append-system-prompt-file
+/// {}", …)` with no marker scrub. Two more interactive launch lines that saved no
+/// transcript, neither of them named in the review that found the sixth. Sharing
+/// one builder is what stops the seventh: a hand-built line in a caller is
+/// invisible to `daemon::doctor_transcript_saving`'s `launch_lines()`, which can
+/// only read builders.
+///
+/// Deliberately NOT routed through [`build_claude_command`], for the same reason
+/// as [`build_inplace_session_command`]: that would add [`SETTING_SOURCES_FLAG`]
+/// and drop the `user` settings tier on a path that does not relocate
+/// `CLAUDE_CONFIG_DIR`. This scrubs the markers and changes nothing else.
+/// What: `env <-u marker…> claude` plus `--append-system-prompt-file <path>` when
+/// `prompt_file` is `Some`. The caller falls back to `None` when writing the
+/// prompt file failed, which is why the argument is optional.
+/// Test: `client_session_command_scrubs_inherited_session_markers`,
+/// `client_session_command_appends_the_prompt_file`.
+pub fn build_client_session_command(prompt_file: Option<&Path>) -> String {
+    // #4467: same shared scrub every other launch line uses — never a second
+    // mechanism.
+    let mut cmd = format!(
+        "env{} claude",
+        crate::core::claude_env_scrub::env_unset_flags()
+    );
+    if let Some(p) = prompt_file {
+        cmd.push_str(" --append-system-prompt-file ");
+        cmd.push_str(&p.display().to_string());
+    }
     cmd
 }
 
@@ -347,6 +437,86 @@ mod tests {
         assert!(
             !cmd.contains("-u CLAUDE_CODE_OAUTH_TOKEN"),
             "must never unset the OAuth token (#2246): {cmd}"
+        );
+    }
+
+    /// Assert one launch line carries the full scrub and over-scrubs nothing.
+    /// Marker names are hard-coded so an emptied shared list cannot make any
+    /// caller of this helper pass vacuously.
+    fn assert_scrubbed_launch_line(cmd: &str) {
+        assert!(
+            cmd.starts_with("env -u "),
+            "the launch line must carry an env scrub prefix: {cmd}"
+        );
+        for marker in [
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_SESSION_ID",
+            "CLAUDECODE",
+            "CLAUDE_PID",
+            "CLAUDE_EFFORT",
+            "CLAUDE_CODE_EXECPATH",
+        ] {
+            assert!(
+                cmd.contains(&format!("-u {marker}")),
+                "the launch line must unset {marker}: {cmd}"
+            );
+        }
+        assert!(
+            !cmd.contains("CLAUDE_CONFIG_DIR"),
+            "this builder must not touch CLAUDE_CONFIG_DIR at all: {cmd}"
+        );
+        assert!(
+            !cmd.contains("-u CLAUDE_CODE_OAUTH_TOKEN"),
+            "must never unset the OAuth token (#2246): {cmd}"
+        );
+    }
+
+    /// #4467 round 2 HIGH: `tm session start`'s in-place pane line was
+    /// hand-built in the `tm` binary with no scrub — a sixth interactive launch
+    /// line that silently saved no transcript.
+    #[test]
+    fn inplace_session_command_scrubs_inherited_session_markers() {
+        assert_scrubbed_launch_line(&build_inplace_session_command());
+    }
+
+    /// The scrub must be the ONLY change: adding `--setting-sources
+    /// project,local` here would drop the `user` tier, and this path does not
+    /// relocate `CLAUDE_CONFIG_DIR`, so that tier is the operator's own
+    /// `~/.claude`. Pinned as a full string so a flag cannot creep in.
+    #[test]
+    fn inplace_session_command_keeps_the_permission_flag_and_nothing_else() {
+        assert_eq!(
+            build_inplace_session_command(),
+            format!(
+                "env{} claude {PERMISSION_MODE_FLAG}",
+                crate::core::claude_env_scrub::env_unset_flags()
+            )
+        );
+        assert!(
+            !build_inplace_session_command().contains(SETTING_SOURCES_FLAG),
+            "must not add --setting-sources: that would drop the user settings tier"
+        );
+    }
+
+    /// #4467 round 2: `DaemonClient::launch_session` / `connect_session` (the
+    /// TUI/bot surface) hand-built their line too. Found by the anti-drift scan,
+    /// not by review.
+    #[test]
+    fn client_session_command_scrubs_inherited_session_markers() {
+        assert_scrubbed_launch_line(&build_client_session_command(None));
+        assert_scrubbed_launch_line(&build_client_session_command(Some(Path::new("/tmp/p.txt"))));
+    }
+
+    #[test]
+    fn client_session_command_appends_the_prompt_file() {
+        let head = format!(
+            "env{} claude",
+            crate::core::claude_env_scrub::env_unset_flags()
+        );
+        assert_eq!(build_client_session_command(None), head);
+        assert_eq!(
+            build_client_session_command(Some(Path::new("/tmp/p.txt"))),
+            format!("{head} --append-system-prompt-file /tmp/p.txt")
         );
     }
 

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -208,6 +208,20 @@ pub const PERMISSION_MODE_FLAG: &str = "--dangerously-skip-permissions";
 /// `runtime::claude_code::env_bin_prefix`, this path does not relocate
 /// `CLAUDE_CONFIG_DIR`), so the POSIX ordering constraint is satisfied trivially
 /// — but the flags still lead the line for consistency with that builder.
+///
+/// The `env` token becoming the line's PROGRAM is deliberate and safe on the two
+/// CLI callers, both of which wrap this output in
+/// [`crate::core::spawn_disclaim::disclaim_pane_command`] (#2997). That yields
+/// `<tm> internal-spawn-disclaimed env -u … claude …`, so the shim
+/// `posix_spawn`s `env` disclaimed and `env` then EXECs `claude` in that same
+/// process — the disclaim is a process attribute and survives the exec, and
+/// because `env` exec's rather than forks, the process tree
+/// `crate::core::process` walks (`pane sh → tm shim → claude`) is unchanged.
+/// The daemon path composes the two the other way round (`env … <tm>
+/// internal-spawn-disclaimed <abs claude>`); both shapes end with `claude`
+/// running as its own responsible process. Note also that the shim resolves its
+/// program through `PATH`, and `env` is no less resolvable than the bare
+/// `claude` this line used to emit — so this is not a new `PATH` dependency.
 /// What: always starts with `env <-u marker…> claude`; appends `--model <model>`
 /// when `model` is `Some`; appends `--append-system-prompt-file <path>` when
 /// `prompt_file` is `Some`; then ALWAYS appends [`SETTING_SOURCES_FLAG`] and

--- a/crates/trusty-mpm/src/core/model_inject.rs
+++ b/crates/trusty-mpm/src/core/model_inject.rs
@@ -197,16 +197,30 @@ pub const PERMISSION_MODE_FLAG: &str = "--dangerously-skip-permissions";
 /// the session-isolation flag ([`SETTING_SOURCES_FLAG`]) and the
 /// unattended-permission flag ([`PERMISSION_MODE_FLAG`]) are applied so every
 /// spawn path stays unattended and isolated (issue #1269).
-/// What: always starts with `"claude"`; appends `--model <model>` when `model`
-/// is `Some`; appends `--append-system-prompt-file <path>` when `prompt_file` is
-/// `Some`; then ALWAYS appends [`SETTING_SOURCES_FLAG`] and
+///
+/// Issue #4467: the line is prefixed with `env <-u marker…>` from
+/// [`crate::core::claude_env_scrub::env_unset_flags`]. This builder's own doc
+/// claimed to be the place "every spawn path stays unattended and isolated", but
+/// it emitted a BARE `claude` with no `env` prefix at all — so `tm launch`,
+/// `tm connect` and every agent delegation launched with the inherited
+/// `CLAUDE_CODE_CHILD_SESSION` marker intact and silently saved no transcript.
+/// There are no `NAME=VALUE` assignments on this prefix (unlike
+/// `runtime::claude_code::env_bin_prefix`, this path does not relocate
+/// `CLAUDE_CONFIG_DIR`), so the POSIX ordering constraint is satisfied trivially
+/// — but the flags still lead the line for consistency with that builder.
+/// What: always starts with `env <-u marker…> claude`; appends `--model <model>`
+/// when `model` is `Some`; appends `--append-system-prompt-file <path>` when
+/// `prompt_file` is `Some`; then ALWAYS appends [`SETTING_SOURCES_FLAG`] and
 /// [`PERMISSION_MODE_FLAG`]. Returns the composed string.
 /// Test: `claude_command_bare`, `claude_command_with_model`,
 /// `claude_command_with_prompt`, `claude_command_with_both`,
 /// `claude_command_includes_setting_sources`,
-/// `claude_command_includes_permission_mode`.
+/// `claude_command_includes_permission_mode`,
+/// `claude_command_scrubs_inherited_session_markers`.
 pub fn build_claude_command(model: Option<&str>, prompt_file: Option<&Path>) -> String {
-    let mut cmd = "claude".to_string();
+    // #4467: scrub the inherited Claude Code session markers so `tm launch` /
+    // `tm connect` / delegations keep native --resume/--continue/rewind.
+    let mut cmd = format!("env{} claude", crate::core::claude_env_scrub::env_unset_flags());
     if let Some(m) = model {
         cmd.push_str(" --model ");
         cmd.push_str(m);
@@ -256,16 +270,67 @@ mod tests {
     /// The isolation + unattended suffix every command now carries (#1269).
     const FLAGS: &str = "--setting-sources project,local --dangerously-skip-permissions";
 
+    /// The `env <-u marker…> claude` head every command now carries (#4467).
+    ///
+    /// Interpolated from production so these pins assert the marker segment's
+    /// POSITION; its CONTENT is pinned by literal name in
+    /// `core::claude_env_scrub`'s `every_marker_is_pinned_by_literal_name`.
+    fn head() -> String {
+        format!("env{} claude", crate::core::claude_env_scrub::env_unset_flags())
+    }
+
     #[test]
     fn claude_command_bare() {
-        // No model, no prompt file → "claude" + the always-on isolation flags.
-        assert_eq!(build_claude_command(None, None), format!("claude {FLAGS}"));
+        // No model, no prompt file → the env-scrub head + the isolation flags.
+        assert_eq!(
+            build_claude_command(None, None),
+            format!("{} {FLAGS}", head())
+        );
     }
 
     #[test]
     fn claude_command_with_model() {
         let cmd = build_claude_command(Some("claude-opus-4-5"), None);
-        assert_eq!(cmd, format!("claude --model claude-opus-4-5 {FLAGS}"));
+        assert_eq!(
+            cmd,
+            format!("{} --model claude-opus-4-5 {FLAGS}", head())
+        );
+    }
+
+    /// #4467: this builder is the launch line for `tm launch`, `tm connect` and
+    /// every agent delegation, and it previously emitted a BARE `claude` — so all
+    /// three silently saved no transcript. Marker names are hard-coded so this
+    /// cannot go vacuous if the shared list is emptied.
+    #[test]
+    fn claude_command_scrubs_inherited_session_markers() {
+        let cmd = build_claude_command(None, None);
+        assert!(
+            cmd.starts_with("env -u "),
+            "the launch line must carry an env scrub prefix: {cmd}"
+        );
+        for marker in [
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_SESSION_ID",
+            "CLAUDECODE",
+            "CLAUDE_PID",
+            "CLAUDE_EFFORT",
+            "CLAUDE_CODE_EXECPATH",
+        ] {
+            assert!(
+                cmd.contains(&format!("-u {marker}")),
+                "the launch line must unset {marker}: {cmd}"
+            );
+        }
+        // Over-scrub guard: this path does not relocate the config dir, so it
+        // must neither set nor unset it (#4455).
+        assert!(
+            !cmd.contains("CLAUDE_CONFIG_DIR"),
+            "this builder must not touch CLAUDE_CONFIG_DIR at all: {cmd}"
+        );
+        assert!(
+            !cmd.contains("-u CLAUDE_CODE_OAUTH_TOKEN"),
+            "must never unset the OAuth token (#2246): {cmd}"
+        );
     }
 
     #[test]
@@ -274,7 +339,10 @@ mod tests {
         let cmd = build_claude_command(None, Some(path));
         assert_eq!(
             cmd,
-            format!("claude --append-system-prompt-file /tmp/prompt.txt {FLAGS}")
+            format!(
+                "{} --append-system-prompt-file /tmp/prompt.txt {FLAGS}",
+                head()
+            )
         );
     }
 
@@ -285,7 +353,8 @@ mod tests {
         assert_eq!(
             cmd,
             format!(
-                "claude --model claude-haiku-4-5 --append-system-prompt-file /tmp/sys.txt {FLAGS}"
+                "{} --model claude-haiku-4-5 --append-system-prompt-file /tmp/sys.txt {FLAGS}",
+                head()
             )
         );
     }
@@ -359,8 +428,14 @@ mod tests {
         };
 
         // Config per-agent override (haiku) wins over frontmatter (sonnet).
+        // #4467: delegations go through `build_claude_command`, so they carry the
+        // same `env <-u marker…>` head — an agent session that saved no
+        // transcript was the same defect as a PM session that saved none.
         let cmd = build_agent_command(&cfg, &agent, None, None);
-        assert_eq!(cmd, format!("claude --model claude-haiku-4-5 {FLAGS}"));
+        assert_eq!(
+            cmd,
+            format!("{} --model claude-haiku-4-5 {FLAGS}", head())
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/spawn_disclaim/pane.rs
+++ b/crates/trusty-mpm/src/core/spawn_disclaim/pane.rs
@@ -22,7 +22,9 @@
 //! [`super::DISABLE_ENV`] is set, the invocation is returned unchanged.
 //! Test: `wraps_invocation_when_wrapper_present`,
 //! `passes_through_when_no_wrapper`, `single_quotes_wrapper_with_space`,
-//! `preserves_flags_after_program` (all cross-platform, pure).
+//! `preserves_flags_after_program`,
+//! `wraps_the_scrubbed_launch_line_with_env_as_the_program` (all
+//! cross-platform, pure).
 
 /// The hidden `tm`/`trusty-mpm` subcommand a managed pane invokes to launch
 /// its `claude` disclaimed (issue #2997).
@@ -63,7 +65,8 @@ fn shell_single_quote(s: &str) -> String {
 /// existing flags follow the program token as separate shell words). `None`
 /// → `claude_invocation` unchanged.
 /// Test: `wraps_invocation_when_wrapper_present`,
-/// `passes_through_when_no_wrapper`, `preserves_flags_after_program`.
+/// `passes_through_when_no_wrapper`, `preserves_flags_after_program`,
+/// `wraps_the_scrubbed_launch_line_with_env_as_the_program`.
 fn disclaim_pane_command_with(wrapper_bin: Option<&str>, claude_invocation: &str) -> String {
     match wrapper_bin {
         Some(bin) => format!(
@@ -112,8 +115,10 @@ fn current_wrapper_bin() -> Option<String> {
 /// `claude_invocation` with `<current_exe> <PANE_DISCLAIM_SUBCOMMAND>`; on any
 /// other platform, or with the escape hatch set, returns it unchanged.
 /// `claude_invocation` may be a bare program token (the daemon's resolved
-/// `claude_bin`, with its flags appended downstream) or a full `claude …`
-/// command string (the CLI paths) — prefixing works identically for both.
+/// `claude_bin`, with its flags appended downstream) or a full command string
+/// (the CLI paths, which since #4467 lead with `env -u <marker…> claude …`) —
+/// prefixing works identically for both, and in the `env` case the shim spawns
+/// `env` disclaimed and `env` execs `claude` in that same process.
 /// Test: the pure shape is covered by [`disclaim_pane_command_with`]'s tests;
 /// the resolution is exercised by the live managed-session launch path.
 pub fn disclaim_pane_command(claude_invocation: &str) -> String {
@@ -164,6 +169,34 @@ mod tests {
             out,
             "'/w/tm' internal-spawn-disclaimed /abs/claude \
              --setting-sources project,local --dangerously-skip-permissions"
+        );
+    }
+
+    /// #4467: `model_inject::build_claude_command` (the `tm launch` / `tm
+    /// connect` line, the only two callers of [`disclaim_pane_command`] on the
+    /// CLI side) now leads with `env -u <marker…>`, so the token the shim
+    /// `posix_spawn`s is `env` rather than `claude`. Pin that composition: the
+    /// shim must receive `env` as its program with the markers and `claude`
+    /// following as plain trailing argv, which is what makes `env` exec `claude`
+    /// in the disclaimed process instead of the shim spawning `claude` directly.
+    #[test]
+    fn wraps_the_scrubbed_launch_line_with_env_as_the_program() {
+        let line = crate::core::model_inject::build_claude_command(None, None);
+        let out = disclaim_pane_command_with(Some("/w/tm"), &line);
+
+        assert!(
+            out.starts_with("'/w/tm' internal-spawn-disclaimed env -u "),
+            "the shim's program token must be `env`, with the scrub flags as \
+             trailing argv: {out}"
+        );
+        assert!(
+            out.contains("-u CLAUDE_CODE_CHILD_SESSION"),
+            "the suppressing marker must survive the wrapping: {out}"
+        );
+        assert!(
+            out.contains(" claude --"),
+            "`claude` must follow the scrub flags, still carrying its own \
+             flags: {out}"
         );
     }
 

--- a/crates/trusty-mpm/src/core/standalone/run.rs
+++ b/crates/trusty-mpm/src/core/standalone/run.rs
@@ -44,10 +44,18 @@ use super::registry::ManagedRegistry;
 /// env `CLAUDE_CONFIG_DIR=<claude_config_dir>`, stdin/stdout/stderr set to
 /// `Stdio::inherit()`, `--dangerously-skip-permissions`, and (when `api_key` is
 /// `Some(s)` with a non-empty `s`) the `--bare` arg. Does NOT spawn.
+///
+/// Issue #4467: also scrubs Claude Code's inherited process-local session
+/// markers via [`crate::core::claude_env_scrub::scrub_command`]. This is the one
+/// `tm` launch path where the transcript-saving suppression fires deterministically
+/// — there is no tmux here, so upstream's `tmux show-environment -g` escape hatch
+/// returns false immediately and an inherited `CLAUDE_CODE_CHILD_SESSION` always
+/// wins.
 /// Test: `test_build_launch_command_sets_env_and_cwd`,
 /// `test_build_launch_command_adds_bare_with_api_key`,
 /// `test_build_launch_command_no_bare_without_api_key`,
-/// `test_build_launch_command_includes_bypass_permissions`.
+/// `test_build_launch_command_includes_bypass_permissions`,
+/// `test_build_launch_command_scrubs_inherited_session_markers`.
 pub fn build_launch_command(
     repo_path: &Path,
     claude_config_dir: &Path,
@@ -55,6 +63,14 @@ pub fn build_launch_command(
 ) -> Command {
     let mut cmd = Command::new("claude");
     cmd.current_dir(repo_path);
+    // #4467: strip Claude Code's inherited process-local session markers. This
+    // path matters MORE than the tmux ones, not less: `tm run` spawns `claude`
+    // directly with no tmux, and upstream's escape hatch bails on its first line
+    // (`if(!Z.TMUX) return false`), so an inherited `CLAUDE_CODE_CHILD_SESSION`
+    // suppresses transcript saving DETERMINISTICALLY here rather than depending
+    // on the tmux server's global env. Runs before the `CLAUDE_CONFIG_DIR`
+    // assignment below so the deliberate value always wins (#4455).
+    crate::core::claude_env_scrub::scrub_command(&mut cmd);
     cmd.env("CLAUDE_CONFIG_DIR", claude_config_dir);
     cmd.stdin(Stdio::inherit())
         .stdout(Stdio::inherit())
@@ -345,6 +361,53 @@ mod tests {
         assert!(
             args2.iter().any(|a| *a == std::ffi::OsStr::new("--bare")),
             "expected --bare to co-exist with bypass flag; got {args2:?}"
+        );
+    }
+
+    // #4467: `tm run` is the ONE tm launch path with no tmux, so upstream's
+    // `tmux show-environment -g` escape hatch returns false at its first line and
+    // an inherited CLAUDE_CODE_CHILD_SESSION suppresses transcript saving every
+    // time — deterministically, not probe-dependently. Marker names are
+    // hard-coded so this cannot go vacuous if the shared list is emptied.
+    #[test]
+    fn test_build_launch_command_scrubs_inherited_session_markers() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        let cfg = tmp.path().join("claude-config");
+        let cmd = build_launch_command(&repo, &cfg, None);
+
+        let envs: Vec<(String, Option<String>)> = cmd
+            .get_envs()
+            .map(|(k, v)| {
+                (
+                    k.to_string_lossy().into_owned(),
+                    v.map(|v| v.to_string_lossy().into_owned()),
+                )
+            })
+            .collect();
+
+        for marker in [
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_SESSION_ID",
+            "CLAUDECODE",
+            "CLAUDE_PID",
+            "CLAUDE_EFFORT",
+            "CLAUDE_CODE_EXECPATH",
+        ] {
+            assert!(
+                envs.contains(&(marker.to_owned(), None)),
+                "{marker} must be REMOVED (None) for the `tm run` session: {envs:?}"
+            );
+        }
+
+        // Over-scrub guard: the scrub runs BEFORE the deliberate assignment, so
+        // CLAUDE_CONFIG_DIR must survive it as a SET value (#4455 / #4451).
+        assert!(
+            envs.contains(&(
+                "CLAUDE_CONFIG_DIR".to_owned(),
+                Some(cfg.display().to_string())
+            )),
+            "CLAUDE_CONFIG_DIR must survive the scrub as a set value: {envs:?}"
         );
     }
 

--- a/crates/trusty-mpm/src/daemon/api_tests.rs
+++ b/crates/trusty-mpm/src/daemon/api_tests.rs
@@ -1118,6 +1118,7 @@ async fn doctor_endpoint_returns_report() {
         "instructions",
         "agents",
         "agent_reachability",
+        "transcript_saving",
         "skills",
         "skill_source",
         "output_style",

--- a/crates/trusty-mpm/src/daemon/claude_config/restarter.rs
+++ b/crates/trusty-mpm/src/daemon/claude_config/restarter.rs
@@ -84,7 +84,7 @@ impl ClaudeCodeRestarter {
         driver.send_interrupt(&target)?;
         std::thread::sleep(std::time::Duration::from_millis(500));
         // Relaunch Claude Code.
-        driver.send_line(&target, crate::daemon::spawn_command::relaunch_command())?;
+        driver.send_line(&target, &crate::daemon::spawn_command::relaunch_command())?;
         Ok(())
     }
 }

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -49,6 +49,13 @@ use doctor_deploy_validate::check_deployment_completeness;
 mod doctor_agent_reachability;
 use doctor_agent_reachability::check_agent_reachability;
 
+// #4467: the same silent-failure shape as #4451, one layer down — a managed
+// spawn that inherits `CLAUDE_CODE_CHILD_SESSION` has transcript saving turned
+// off, so the session is unrecoverable and nothing reported it.
+#[path = "doctor_transcript_saving.rs"]
+mod doctor_transcript_saving;
+use doctor_transcript_saving::check_transcript_saving;
+
 // Split out to keep this file under the 500-SLOC production cap (issue #2876 —
 // the skill-staleness and legacy-instruction-source probes).
 #[path = "doctor_staleness.rs"]
@@ -198,7 +205,7 @@ const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
 /// the one tm-managed `CLAUDE_CONFIG_DIR` tier and nowhere else, so
 /// `check_agents`/`check_agent_skills` probe `paths.agent_deploy_dir()`, which
 /// is the same directory whether or not a `project_dir` was supplied.
-/// Test: `run_doctor_produces_twenty_three_checks`,
+/// Test: `run_doctor_produces_twenty_four_checks`,
 /// `agents_check_probes_the_managed_config_tier_not_the_workspace`.
 pub async fn run_doctor(
     project_dir: Option<&Path>,
@@ -226,6 +233,11 @@ pub async fn run_doctor(
         // #4451: `check_agents` proves the files exist; this proves the tier
         // they land in is one a managed session's harness actually scans.
         check_agent_reachability(&paths, project_dir),
+        // #4467: and this proves the spawn does not silently lose the session's
+        // own transcript, which costs it all native --resume/--continue/rewind
+        // recovery. No `project_dir`/`paths` input — the invariant is a property
+        // of the spawn command itself, identical for every project.
+        check_transcript_saving(),
         check_skills(skills_root),
         check_skill_source(&paths),
         check_output_style(project_dir, &home),

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -102,7 +102,7 @@ async fn agents_check_probes_the_managed_config_tier_not_the_workspace() {
 }
 
 #[tokio::test]
-async fn run_doctor_produces_twenty_three_checks() {
+async fn run_doctor_produces_twenty_four_checks() {
     // Issue #2158 added the `deployment` probe (nine → ten); issue #2246
     // adds `oauth_token` (ten → eleven); issue #2876 adds `skill_staleness`
     // and `legacy_sources` (eleven → thirteen); DOC-42 / issue #2889 adds
@@ -115,7 +115,8 @@ async fn run_doctor_produces_twenty_three_checks() {
     // → twenty); issue #3427 adds `scaffold_tracking` (twenty →
     // twenty-one); issue #2867 adds `push_guard` (twenty-one →
     // twenty-two); issue #4451 adds `agent_reachability` (twenty-two →
-    // twenty-three).
+    // twenty-three); issue #4467 adds `transcript_saving` (twenty-three →
+    // twenty-four).
     // #1905's stale-skill cleanup is deliberately NOT a `run_doctor` probe
     // — see the `run_doctor` doc.
     let report = run_doctor(None, None, &[]).await;
@@ -124,6 +125,7 @@ async fn run_doctor_produces_twenty_three_checks() {
         "instructions",
         "agents",
         "agent_reachability",
+        "transcript_saving",
         "skills",
         "skill_source",
         "output_style",

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
@@ -1,0 +1,131 @@
+//! Doctor probe: would a managed spawn have Claude Code transcript saving
+//! DISABLED? (issue #4467)
+//!
+//! Why: this defect went unnoticed until Claude Code started printing a warning
+//! about it. Nothing in tm reported it, and the symptom — "the session had no
+//! history to resume from" — only surfaces after the session is already gone.
+//! That is the same shape as #4451: a silent failure with no check capable of
+//! failing, which `agent_reachability` was added for. This probe is that check.
+//!
+//! What it asserts is the invariant the spawn builders encode: the managed
+//! spawn's `env` prefix must UNSET
+//! [`crate::core::claude_env_scrub::TRANSCRIPT_SUPPRESSING_MARKER`], and must
+//! NOT unset `CLAUDE_CONFIG_DIR`. Both directions matter and they fail in
+//! opposite ways — under-scrub costs the session its transcripts (#4467),
+//! over-scrub costs it the entire bundled agent roster (#4451, via #4455).
+//!
+//! Both sides are read from PRODUCTION code, not restated: the scrub set is
+//! parsed out of the real [`crate::runtime::claude_code::env_bin_prefix`] output
+//! by [`crate::core::claude_env_scrub::parse_env_unset_vars`]. Drop the flags
+//! from the spawn builder and this check fails — which a check that compared the
+//! marker constant against itself could never do.
+//!
+//! Deliberately STATIC rather than spawning a probe `claude -p` and inspecting
+//! the transcript directory afterwards: a live spawn costs tens of seconds,
+//! needs network and auth, and would make `tm doctor` slow and flaky on the one
+//! command operators reach for when things are already broken. The static form
+//! catches the whole failure class at zero cost. The set of markers live in the
+//! current environment is reported as CONTEXT in the message, never as the
+//! pass/fail condition — `tm doctor` run from a plain shell has no markers set,
+//! and the check must still be meaningful there.
+//!
+//! Test: `crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs`.
+
+use crate::core::claude_env_scrub::{
+    TRANSCRIPT_SUPPRESSING_MARKER, markers_present_in_env, parse_env_unset_vars,
+};
+use crate::core::doctor::{CheckStatus, DoctorCheck};
+
+/// Name of this check as it appears in `tm doctor` output.
+const CHECK_NAME: &str = "transcript_saving";
+
+/// Probe whether a managed spawn preserves Claude Code transcript saving.
+///
+/// Why: see the module doc. Hard `Fail`, not `Warn`: when it trips, every
+/// managed session is unrecoverable — no native `--resume`, no `--continue`, no
+/// `/rewind`, and absent from `--resume` listings — so a session that dies loses
+/// everything since tm's last summary-only snapshot. That is data loss, not a
+/// configuration preference.
+/// What: builds the REAL managed-spawn env prefix (with a representative config
+/// dir, so the `CLAUDE_CONFIG_DIR` over-scrub branch is exercised too), parses
+/// the variables it unsets, and delegates to [`verdict`].
+/// Test: `production_spawn_preserves_transcript_saving`.
+pub(super) fn check_transcript_saving() -> DoctorCheck {
+    // A representative config dir: `env_bin_prefix` emits CLAUDE_CONFIG_DIR as
+    // an ASSIGNMENT, so passing one is what lets the over-scrub check see
+    // whether the variable was (wrongly) added to the unset list instead.
+    let config_dir = std::path::PathBuf::from("/managed/claude-config");
+    let prefix = crate::runtime::env_bin_prefix("claude", Some(&config_dir), None);
+    verdict(&parse_env_unset_vars(&prefix), &markers_present_in_env())
+}
+
+/// Pure verdict over the spawn prefix's unset list.
+///
+/// Why: separated from [`check_transcript_saving`] so BOTH failure branches are
+/// directly testable. The real prefix comes from production code, so a test that
+/// could only call the wrapper would exercise the happy path and silently lose
+/// the regression guard — the same blind spot #4467 itself is.
+/// What: `Fail` when `unset` omits [`TRANSCRIPT_SUPPRESSING_MARKER`] (transcripts
+/// would be lost) or when it contains `CLAUDE_CONFIG_DIR` (the roster would be
+/// lost). `Ok` otherwise, naming the marker count and any markers live in the
+/// current environment. `present` is context for the message only.
+/// Test: `ok_when_the_marker_is_scrubbed`,
+/// `fails_when_the_suppressing_marker_is_not_scrubbed`,
+/// `fails_when_the_scrub_would_take_the_config_dir`,
+/// `failure_is_a_hard_fail_not_a_warn`,
+/// `ok_message_reports_markers_live_in_the_environment`,
+/// `config_dir_over_scrub_takes_precedence_in_the_message`.
+fn verdict(unset: &[&str], present: &[&'static str]) -> DoctorCheck {
+    if unset.contains(&"CLAUDE_CONFIG_DIR") {
+        return DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Fail,
+            "a managed spawn would UNSET `CLAUDE_CONFIG_DIR`. That relocation is \
+             what puts the bundled agent roster in the `user` settings tier the \
+             spawn's `--setting-sources` flag loads (#4455), so unsetting it \
+             restores issue #4451: every delegation degrades to `general-purpose` \
+             with `Agent type '<name>' not found`. Remove CLAUDE_CONFIG_DIR from \
+             `core::claude_env_scrub::INHERITED_SESSION_MARKERS`."
+                .to_owned(),
+        );
+    }
+    if !unset.contains(&TRANSCRIPT_SUPPRESSING_MARKER) {
+        return DoctorCheck::new(
+            CHECK_NAME,
+            CheckStatus::Fail,
+            format!(
+                "a managed spawn does NOT unset `{TRANSCRIPT_SUPPRESSING_MARKER}`, so when \
+                 `tm` is invoked from inside a Claude Code session the spawned `claude` \
+                 inherits it and turns session persistence OFF (\"Transcript saving is off \
+                 — inherited {TRANSCRIPT_SUPPRESSING_MARKER} marker\"). The managed session \
+                 then has no native --resume/--continue/rewind recovery and never appears \
+                 in `--resume`, so if it dies everything since tm's last snapshot is lost \
+                 (issue #4467). Add it back to \
+                 `core::claude_env_scrub::INHERITED_SESSION_MARKERS`. Currently unsets: [{}].",
+                unset.join(", ")
+            ),
+        );
+    }
+    let context = if present.is_empty() {
+        "no inherited markers in this environment".to_owned()
+    } else {
+        format!(
+            "inherited here and scrubbed: {} — this `tm` is itself running with the leak \
+             present",
+            present.join(", ")
+        )
+    };
+    DoctorCheck::new(
+        CHECK_NAME,
+        CheckStatus::Ok,
+        format!(
+            "a managed spawn unsets [{}] while keeping `CLAUDE_CONFIG_DIR`, so transcript \
+             saving and native --resume stay available; {context}",
+            unset.join(", ")
+        ),
+    )
+}
+
+#[cfg(test)]
+#[path = "doctor_transcript_saving_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
@@ -7,18 +7,25 @@
 //! That is the same shape as #4451: a silent failure with no check capable of
 //! failing, which `agent_reachability` was added for. This probe is that check.
 //!
-//! What it asserts is the invariant the spawn builders encode: the managed
-//! spawn's `env` prefix must UNSET
-//! [`crate::core::claude_env_scrub::TRANSCRIPT_SUPPRESSING_MARKER`], and must
-//! NOT unset `CLAUDE_CONFIG_DIR`. Both directions matter and they fail in
-//! opposite ways — under-scrub costs the session its transcripts (#4467),
-//! over-scrub costs it the entire bundled agent roster (#4451, via #4455).
+//! What it asserts is the invariant every launch-line builder encodes: each one
+//! must UNSET [`crate::core::claude_env_scrub::TRANSCRIPT_SUPPRESSING_MARKER`],
+//! and none may unset a
+//! [`crate::core::claude_env_scrub::DELIBERATE_SPAWN_ENV`] member. Both
+//! directions matter and they fail in opposite ways — under-scrub costs the
+//! session its transcripts (#4467), over-scrub costs it the entire bundled agent
+//! roster (#4451, via #4455) or the #2246 OAuth token.
 //!
-//! Both sides are read from PRODUCTION code, not restated: the scrub set is
-//! parsed out of the real [`crate::runtime::claude_code::env_bin_prefix`] output
-//! by [`crate::core::claude_env_scrub::parse_env_unset_vars`]. Drop the flags
-//! from the spawn builder and this check fails — which a check that compared the
-//! marker constant against itself could never do.
+//! It covers EVERY launch line the library owns, not just the daemon one — see
+//! [`launch_lines`]. The first version of this check parsed only
+//! `env_bin_prefix` and therefore reported `Ok` while three other builders still
+//! leaked; a check that returns `Ok` for a leaking path is worse than no check,
+//! because it actively certifies the broken state.
+//!
+//! Both sides are read from PRODUCTION code, not restated: shell-string builders
+//! are parsed with [`crate::core::claude_env_scrub::parse_env_unset_vars`], and
+//! `Command` builders are read through `get_envs()`. Drop the scrub from any
+//! builder and this check fails — which a check that compared the marker constant
+//! against itself could never do.
 //!
 //! Deliberately STATIC rather than spawning a probe `claude -p` and inspecting
 //! the transcript directory afterwards: a live spawn costs tens of seconds,
@@ -32,61 +39,209 @@
 //! Test: `crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs`.
 
 use crate::core::claude_env_scrub::{
-    TRANSCRIPT_SUPPRESSING_MARKER, markers_present_in_env, parse_env_unset_vars,
+    DELIBERATE_SPAWN_ENV, TRANSCRIPT_SUPPRESSING_MARKER, markers_present_in_env,
+    parse_env_unset_vars,
 };
 use crate::core::doctor::{CheckStatus, DoctorCheck};
 
 /// Name of this check as it appears in `tm doctor` output.
 const CHECK_NAME: &str = "transcript_saving";
 
-/// Probe whether a managed spawn preserves Claude Code transcript saving.
+/// A representative config dir for the probe.
 ///
-/// Why: see the module doc. Hard `Fail`, not `Warn`: when it trips, every
-/// managed session is unrecoverable — no native `--resume`, no `--continue`, no
-/// `/rewind`, and absent from `--resume` listings — so a session that dies loses
-/// everything since tm's last summary-only snapshot. That is data loss, not a
-/// configuration preference.
-/// What: builds the REAL managed-spawn env prefix (with a representative config
-/// dir, so the `CLAUDE_CONFIG_DIR` over-scrub branch is exercised too), parses
-/// the variables it unsets, and delegates to [`verdict`].
-/// Test: `production_spawn_preserves_transcript_saving`.
-pub(super) fn check_transcript_saving() -> DoctorCheck {
-    // A representative config dir: `env_bin_prefix` emits CLAUDE_CONFIG_DIR as
-    // an ASSIGNMENT, so passing one is what lets the over-scrub check see
-    // whether the variable was (wrongly) added to the unset list instead.
-    let config_dir = std::path::PathBuf::from("/managed/claude-config");
-    let prefix = crate::runtime::env_bin_prefix("claude", Some(&config_dir), None);
-    verdict(&parse_env_unset_vars(&prefix), &markers_present_in_env())
+/// Why: `env_bin_prefix` emits `CLAUDE_CONFIG_DIR` as an ASSIGNMENT, so passing
+/// one is what lets the over-scrub branch see whether the variable was (wrongly)
+/// added to the UNSET list instead. A bare `None` would make that branch
+/// unreachable.
+/// What: a fixed non-existent path — nothing is read from disk.
+/// Test: exercised via [`launch_lines`].
+const PROBE_CONFIG_DIR: &str = "/managed/claude-config";
+
+/// A representative OAuth token for the probe.
+///
+/// Why: `CLAUDE_CODE_OAUTH_TOKEN` is the other [`DELIBERATE_SPAWN_ENV`] member,
+/// and it only appears on the emitted prefix when a token is supplied. Passing
+/// `None` would make an over-scrub of it invisible to this check.
+/// What: an obvious non-credential placeholder.
+/// Test: `over_scrub_of_the_oauth_token_is_detected`.
+const PROBE_TOKEN: &str = "probe-token-not-a-credential";
+
+/// Every launch-line builder that spawns a `claude`, paired with the variables it
+/// unsets.
+///
+/// Why (review follow-up on #4467): the first version of this check parsed only
+/// `runtime::claude_code::env_bin_prefix`, so it reported `Ok` while
+/// `model_inject::build_claude_command` (`tm launch` / `tm connect` /
+/// delegations), `standalone::run::build_launch_command` (`tm run`) and
+/// `daemon::spawn_command::relaunch_command` all still leaked. A check that
+/// returns `Ok` for a leaking path is worse than no check: it actively certifies
+/// the broken state. Enumerating the builders here — and reading each one's real
+/// output — is what makes the verdict cover what its message claims.
+/// What: `(label, unset-variable-names)` per builder. Shell-string builders are
+/// parsed with [`parse_env_unset_vars`]; `Command` builders report their
+/// `env_remove`d keys, which `get_envs()` surfaces as `(key, None)`.
+///
+/// `bin/tm`'s `build_inplace_exec_command` is deliberately absent: it lives in
+/// the `tm` BINARY crate, which this library cannot reference. It is covered by
+/// its own `inplace_exec_command_scrubs_inherited_session_markers` test, and the
+/// message below names the gap rather than implying coverage.
+/// Test: `every_production_launch_line_preserves_transcript_saving`,
+/// `launch_lines_covers_every_builder`.
+fn launch_lines() -> Vec<(&'static str, Vec<String>)> {
+    let config_dir = std::path::PathBuf::from(PROBE_CONFIG_DIR);
+
+    // Shell-string builders: parse the `-u` operands out of the `env` prefix.
+    let prefix =
+        crate::runtime::env_bin_prefix("claude", Some(&config_dir), Some(PROBE_TOKEN));
+    let launch_line = crate::core::model_inject::build_claude_command(None, None);
+    let relaunch_line = crate::daemon::spawn_command::relaunch_command();
+
+    // `Command` builders: an `env_remove` shows up as a `None` value.
+    let run_cmd = crate::core::standalone::run::build_launch_command(
+        std::path::Path::new("/probe/repo"),
+        &config_dir,
+        None,
+    );
+    let stream_cmd =
+        crate::control::backend::stream_json::build_claude_command(std::path::Path::new("/probe"), None);
+
+    vec![
+        (
+            "runtime::claude_code::env_bin_prefix (daemon spawn + resume)",
+            owned(parse_env_unset_vars(&prefix)),
+        ),
+        (
+            "core::model_inject::build_claude_command (tm launch / connect / delegate)",
+            owned(parse_env_unset_vars(&launch_line)),
+        ),
+        (
+            "daemon::spawn_command::relaunch_command (pane relaunch)",
+            owned(parse_env_unset_vars(&relaunch_line)),
+        ),
+        (
+            "core::standalone::run::build_launch_command (tm run)",
+            removed_env_keys(&run_cmd),
+        ),
+        (
+            "control::backend::stream_json::build_claude_command (headless)",
+            removed_env_keys(&stream_cmd),
+        ),
+    ]
 }
 
-/// Pure verdict over the spawn prefix's unset list.
+/// Borrow-to-owned helper so both builder shapes share one verdict type.
+///
+/// Why: [`parse_env_unset_vars`] borrows from a local `String`, which cannot
+/// escape [`launch_lines`]; owning the names keeps the two shapes uniform without
+/// leaking lifetimes into the verdict signature.
+/// What: copies each `&str` into a `String`.
+/// Test: exercised via [`launch_lines`].
+fn owned(names: Vec<&str>) -> Vec<String> {
+    names.into_iter().map(str::to_owned).collect()
+}
+
+/// The variables a [`std::process::Command`] explicitly REMOVES from its child env.
+///
+/// Why: the `Command`-based launch paths express the scrub as `env_remove` rather
+/// than an `env -u` flag, so the check needs the equivalent view of them. Reading
+/// `get_envs()` — rather than trusting that `scrub_command` was called — is what
+/// keeps this probe reading production behaviour.
+/// What: keys whose value is `None` (an `env_remove`), lossily stringified.
+/// Test: exercised via [`launch_lines`]; `tm run` coverage is asserted by
+/// `every_production_launch_line_preserves_transcript_saving`.
+fn removed_env_keys(cmd: &std::process::Command) -> Vec<String> {
+    cmd.get_envs()
+        .filter(|(_, value)| value.is_none())
+        .map(|(key, _)| key.to_string_lossy().into_owned())
+        .collect()
+}
+
+/// Probe whether EVERY `tm` launch line preserves Claude Code transcript saving.
+///
+/// Why: see the module doc. Hard `Fail`, not `Warn`: when it trips, sessions on
+/// the offending path are unrecoverable — no native `--resume`, no `--continue`,
+/// no `/rewind`, and absent from `--resume` listings — so a session that dies
+/// loses everything since tm's last summary-only snapshot. That is data loss, not
+/// a configuration preference.
+/// What: runs [`verdict`] over every [`launch_lines`] entry and returns the FIRST
+/// failure, so one leaking builder cannot be averaged away by four correct ones.
+/// Test: `every_production_launch_line_preserves_transcript_saving`.
+pub(super) fn check_transcript_saving() -> DoctorCheck {
+    let present = markers_present_in_env();
+    let lines = launch_lines();
+    let covered = lines.len();
+    for (label, unset) in &lines {
+        let names: Vec<&str> = unset.iter().map(String::as_str).collect();
+        let check = verdict(label, &names, &present);
+        if check.status != CheckStatus::Ok {
+            return check;
+        }
+    }
+    let context = if present.is_empty() {
+        "no inherited markers in this environment".to_owned()
+    } else {
+        format!(
+            "inherited here and scrubbed: {} — this `tm` is itself running with the leak \
+             present",
+            present.join(", ")
+        )
+    };
+    DoctorCheck::new(
+        CHECK_NAME,
+        CheckStatus::Ok,
+        format!(
+            "all {covered} library launch line(s) unset `{TRANSCRIPT_SUPPRESSING_MARKER}` while \
+             keeping [{}], so transcript saving and native --resume stay available; {context} \
+             (the bare-`tm` in-place relaunch lives in the `tm` binary and is covered by its \
+             own test, not by this check)",
+            DELIBERATE_SPAWN_ENV.join(", ")
+        ),
+    )
+}
+
+/// Pure verdict over ONE launch line's unset list.
 ///
 /// Why: separated from [`check_transcript_saving`] so BOTH failure branches are
-/// directly testable. The real prefix comes from production code, so a test that
-/// could only call the wrapper would exercise the happy path and silently lose
-/// the regression guard — the same blind spot #4467 itself is.
-/// What: `Fail` when `unset` omits [`TRANSCRIPT_SUPPRESSING_MARKER`] (transcripts
-/// would be lost) or when it contains `CLAUDE_CONFIG_DIR` (the roster would be
-/// lost). `Ok` otherwise, naming the marker count and any markers live in the
-/// current environment. `present` is context for the message only.
+/// directly testable. The real launch lines come from production code, so a test
+/// that could only call the wrapper would exercise the happy path and silently
+/// lose the regression guard — the same blind spot #4467 itself is. `path` is
+/// threaded through so a failure names WHICH builder leaks; a message that said
+/// only "a managed spawn" would leave an operator grepping five call sites.
+/// What: `Fail` when `unset` contains ANY [`DELIBERATE_SPAWN_ENV`] member (that
+/// variable is set on purpose — unsetting `CLAUDE_CONFIG_DIR` restores #4451),
+/// then `Fail` when it omits [`TRANSCRIPT_SUPPRESSING_MARKER`] (transcripts would
+/// be lost). `Ok` otherwise. `present` is context for the message only.
+///
+/// Iterating `DELIBERATE_SPAWN_ENV` rather than testing the literal
+/// `"CLAUDE_CONFIG_DIR"` is what makes an over-scrub of the OTHER member
+/// (`CLAUDE_CODE_OAUTH_TOKEN`) visible too — the earlier literal form could not
+/// see it.
 /// Test: `ok_when_the_marker_is_scrubbed`,
 /// `fails_when_the_suppressing_marker_is_not_scrubbed`,
 /// `fails_when_the_scrub_would_take_the_config_dir`,
+/// `over_scrub_of_the_oauth_token_is_detected`,
 /// `failure_is_a_hard_fail_not_a_warn`,
+/// `failure_names_the_leaking_path`,
 /// `ok_message_reports_markers_live_in_the_environment`,
 /// `config_dir_over_scrub_takes_precedence_in_the_message`.
-fn verdict(unset: &[&str], present: &[&'static str]) -> DoctorCheck {
-    if unset.contains(&"CLAUDE_CONFIG_DIR") {
+fn verdict(path: &str, unset: &[&str], present: &[&'static str]) -> DoctorCheck {
+    if let Some(deliberate) = DELIBERATE_SPAWN_ENV
+        .iter()
+        .find(|name| unset.contains(*name))
+    {
         return DoctorCheck::new(
             CHECK_NAME,
             CheckStatus::Fail,
-            "a managed spawn would UNSET `CLAUDE_CONFIG_DIR`. That relocation is \
-             what puts the bundled agent roster in the `user` settings tier the \
-             spawn's `--setting-sources` flag loads (#4455), so unsetting it \
-             restores issue #4451: every delegation degrades to `general-purpose` \
-             with `Agent type '<name>' not found`. Remove CLAUDE_CONFIG_DIR from \
-             `core::claude_env_scrub::INHERITED_SESSION_MARKERS`."
-                .to_owned(),
+            format!(
+                "`{path}` would UNSET `{deliberate}`, which a managed spawn sets on \
+                 PURPOSE. For CLAUDE_CONFIG_DIR that relocation is what puts the bundled \
+                 agent roster in the `user` settings tier the spawn's `--setting-sources` \
+                 flag loads (#4455), so unsetting it restores issue #4451: every \
+                 delegation degrades to `general-purpose` with `Agent type '<name>' not \
+                 found`. For CLAUDE_CODE_OAUTH_TOKEN it restores the #2246 Keychain login \
+                 loop. Remove `{deliberate}` from \
+                 `core::claude_env_scrub::INHERITED_SESSION_MARKERS`."
+            ),
         );
     }
     if !unset.contains(&TRANSCRIPT_SUPPRESSING_MARKER) {
@@ -94,14 +249,14 @@ fn verdict(unset: &[&str], present: &[&'static str]) -> DoctorCheck {
             CHECK_NAME,
             CheckStatus::Fail,
             format!(
-                "a managed spawn does NOT unset `{TRANSCRIPT_SUPPRESSING_MARKER}`, so when \
-                 `tm` is invoked from inside a Claude Code session the spawned `claude` \
-                 inherits it and turns session persistence OFF (\"Transcript saving is off \
-                 — inherited {TRANSCRIPT_SUPPRESSING_MARKER} marker\"). The managed session \
-                 then has no native --resume/--continue/rewind recovery and never appears \
-                 in `--resume`, so if it dies everything since tm's last snapshot is lost \
-                 (issue #4467). Add it back to \
-                 `core::claude_env_scrub::INHERITED_SESSION_MARKERS`. Currently unsets: [{}].",
+                "`{path}` does NOT unset `{TRANSCRIPT_SUPPRESSING_MARKER}`, so when `tm` is \
+                 invoked from inside a Claude Code session the `claude` it spawns inherits \
+                 it and turns session persistence OFF (\"Transcript saving is off — \
+                 inherited {TRANSCRIPT_SUPPRESSING_MARKER} marker\"). Sessions on that path \
+                 then have no native --resume/--continue/rewind recovery and never appear \
+                 in `--resume`, so if one dies everything since tm's last snapshot is lost \
+                 (issue #4467). Scrub it via `core::claude_env_scrub`. Currently unsets: \
+                 [{}].",
                 unset.join(", ")
             ),
         );
@@ -119,9 +274,10 @@ fn verdict(unset: &[&str], present: &[&'static str]) -> DoctorCheck {
         CHECK_NAME,
         CheckStatus::Ok,
         format!(
-            "a managed spawn unsets [{}] while keeping `CLAUDE_CONFIG_DIR`, so transcript \
-             saving and native --resume stay available; {context}",
-            unset.join(", ")
+            "`{path}` unsets [{}] while keeping [{}], so transcript saving and native \
+             --resume stay available; {context}",
+            unset.join(", "),
+            DELIBERATE_SPAWN_ENV.join(", ")
         ),
     )
 }

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
@@ -47,6 +47,23 @@ use crate::core::doctor::{CheckStatus, DoctorCheck};
 /// Name of this check as it appears in `tm doctor` output.
 const CHECK_NAME: &str = "transcript_saving";
 
+/// Launch-line builders that live in the `tm` BINARY crate.
+///
+/// Why (review round 2 MEDIUM): the Ok message used to describe exactly one
+/// binary-crate gap in prose ("the bare-`tm` in-place relaunch … is covered by
+/// its own test"), which reads as THE gap rather than A gap — and a sixth
+/// uncovered launch line (`tm session start`, in place) sat outside the check
+/// while that sentence implied completeness. Naming them from a list makes the
+/// disclosure countable and forces an edit here when the set changes.
+/// What: one human-readable entry per binary-crate builder, each naming the test
+/// that covers it. A library check cannot reference the binary crate, so these
+/// can never be read by [`launch_lines`] — the honest disclosure is the fix.
+/// Test: `ok_message_names_every_binary_crate_gap`.
+const BINARY_CRATE_BUILDERS: &[&str] = &[
+    "`bin/tm/commands/guided_inplace.rs::build_inplace_exec_command` (the bare-`tm` in-place \
+     relaunch; covered by `inplace_exec_command_scrubs_inherited_session_markers`)",
+];
+
 /// A representative config dir for the probe.
 ///
 /// Why: `env_bin_prefix` emits `CLAUDE_CONFIG_DIR` as an ASSIGNMENT, so passing
@@ -94,6 +111,11 @@ fn launch_lines() -> Vec<(&'static str, Vec<String>)> {
     let prefix = crate::runtime::env_bin_prefix("claude", Some(&config_dir), Some(PROBE_TOKEN));
     let launch_line = crate::core::model_inject::build_claude_command(None, None);
     let relaunch_line = crate::daemon::spawn_command::relaunch_command();
+    // #4467 round 2: the two launch lines the anti-drift scan found uncovered.
+    let inplace_line = crate::core::model_inject::build_inplace_session_command();
+    let client_line = crate::core::model_inject::build_client_session_command(Some(
+        std::path::Path::new("/probe/prompt.txt"),
+    ));
 
     // `Command` builders: an `env_remove` shows up as a `None` value.
     let run_cmd = crate::core::standalone::run::build_launch_command(
@@ -112,8 +134,16 @@ fn launch_lines() -> Vec<(&'static str, Vec<String>)> {
             owned(parse_env_unset_vars(&prefix)),
         ),
         (
-            "core::model_inject::build_claude_command (tm launch / connect / delegate)",
+            "core::model_inject::build_claude_command (tm launch / tm connect)",
             owned(parse_env_unset_vars(&launch_line)),
+        ),
+        (
+            "core::model_inject::build_inplace_session_command (tm session start, in place)",
+            owned(parse_env_unset_vars(&inplace_line)),
+        ),
+        (
+            "core::model_inject::build_client_session_command (DaemonClient launch/connect)",
+            owned(parse_env_unset_vars(&client_line)),
         ),
         (
             "daemon::spawn_command::relaunch_command (pane relaunch)",
@@ -192,10 +222,14 @@ pub(super) fn check_transcript_saving() -> DoctorCheck {
         CheckStatus::Ok,
         format!(
             "all {covered} library launch line(s) unset `{TRANSCRIPT_SUPPRESSING_MARKER}` while \
-             keeping [{}], so transcript saving and native --resume stay available; {context} \
-             (the bare-`tm` in-place relaunch lives in the `tm` binary and is covered by its \
-             own test, not by this check)",
-            DELIBERATE_SPAWN_ENV.join(", ")
+             keeping [{}], so transcript saving and native --resume stay available; {context}. \
+             NOT covered by this check: {} launch line(s) in the `tm` BINARY crate, which a \
+             library check cannot reference — {}. Each is covered by its own test; \
+             `every_claude_launch_site_in_the_crate_is_allowlisted` is what fails when a new \
+             `claude` launch site appears anywhere in the crate.",
+            DELIBERATE_SPAWN_ENV.join(", "),
+            BINARY_CRATE_BUILDERS.len(),
+            BINARY_CRATE_BUILDERS.join("; ")
         ),
     )
 }

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving.rs
@@ -91,8 +91,7 @@ fn launch_lines() -> Vec<(&'static str, Vec<String>)> {
     let config_dir = std::path::PathBuf::from(PROBE_CONFIG_DIR);
 
     // Shell-string builders: parse the `-u` operands out of the `env` prefix.
-    let prefix =
-        crate::runtime::env_bin_prefix("claude", Some(&config_dir), Some(PROBE_TOKEN));
+    let prefix = crate::runtime::env_bin_prefix("claude", Some(&config_dir), Some(PROBE_TOKEN));
     let launch_line = crate::core::model_inject::build_claude_command(None, None);
     let relaunch_line = crate::daemon::spawn_command::relaunch_command();
 
@@ -102,8 +101,10 @@ fn launch_lines() -> Vec<(&'static str, Vec<String>)> {
         &config_dir,
         None,
     );
-    let stream_cmd =
-        crate::control::backend::stream_json::build_claude_command(std::path::Path::new("/probe"), None);
+    let stream_cmd = crate::control::backend::stream_json::build_claude_command(
+        std::path::Path::new("/probe"),
+        None,
+    );
 
     vec![
         (

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
@@ -1,0 +1,140 @@
+//! Tests for [`super`] — the `transcript_saving` doctor probe (issue #4467).
+//!
+//! Why: this check exists because the defect was silent, so its own tests have
+//! to prove it can FAIL — in both directions. `verdict` is exercised directly
+//! for the failure branches (the production prefix is correct, so the wrapper
+//! can only ever show the happy path), and the wrapper is exercised once against
+//! the real spawn builder so the two can never drift apart.
+
+use super::*;
+
+/// The gate that matters: the REAL production spawn prefix must preserve
+/// transcript saving. Fails if anyone drops the scrub from `env_bin_prefix`.
+#[test]
+fn production_spawn_preserves_transcript_saving() {
+    let check = check_transcript_saving();
+    assert_eq!(
+        check.status,
+        CheckStatus::Ok,
+        "the production managed spawn must preserve transcript saving; got: {}",
+        check.message
+    );
+    assert_eq!(check.name, CHECK_NAME);
+}
+
+#[test]
+fn ok_when_the_marker_is_scrubbed() {
+    let check = verdict(&["ANTHROPIC_API_KEY", TRANSCRIPT_SUPPRESSING_MARKER], &[]);
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+}
+
+/// Under-scrub: the whole point of the check.
+#[test]
+fn fails_when_the_suppressing_marker_is_not_scrubbed() {
+    let check = verdict(&["ANTHROPIC_API_KEY"], &[]);
+    assert_eq!(
+        check.status,
+        CheckStatus::Fail,
+        "omitting the suppressing marker must FAIL: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains(TRANSCRIPT_SUPPRESSING_MARKER),
+        "the message must name the marker: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("4467"),
+        "the message must cite the issue: {}",
+        check.message
+    );
+}
+
+/// Over-scrub: the opposite failure, which would silently restore #4451.
+#[test]
+fn fails_when_the_scrub_would_take_the_config_dir() {
+    let check = verdict(
+        &[
+            "ANTHROPIC_API_KEY",
+            TRANSCRIPT_SUPPRESSING_MARKER,
+            "CLAUDE_CONFIG_DIR",
+        ],
+        &[],
+    );
+    assert_eq!(
+        check.status,
+        CheckStatus::Fail,
+        "unsetting CLAUDE_CONFIG_DIR must FAIL: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("CLAUDE_CONFIG_DIR"),
+        "the message must name the variable: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("4451"),
+        "the message must cite the roster regression it prevents: {}",
+        check.message
+    );
+}
+
+/// An over-scrub is reported even though the transcript marker IS present, so
+/// the two branches cannot mask each other.
+#[test]
+fn config_dir_over_scrub_takes_precedence_in_the_message() {
+    let check = verdict(&[TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CONFIG_DIR"], &[]);
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(
+        check.message.contains("4455"),
+        "the config-dir branch must be the one reported: {}",
+        check.message
+    );
+}
+
+/// Data loss is not a preference — both failures must be hard.
+#[test]
+fn failure_is_a_hard_fail_not_a_warn() {
+    for unset in [
+        vec!["ANTHROPIC_API_KEY"],
+        vec![TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CONFIG_DIR"],
+    ] {
+        let check = verdict(&unset, &[]);
+        assert_ne!(
+            check.status,
+            CheckStatus::Warn,
+            "must never be a Warn for {unset:?}: {}",
+            check.message
+        );
+        assert_eq!(check.status, CheckStatus::Fail);
+    }
+}
+
+/// The live-marker set is context in the message, never the pass/fail
+/// condition — a clean environment must still produce a meaningful Ok.
+#[test]
+fn ok_message_reports_markers_live_in_the_environment() {
+    let clean = verdict(&[TRANSCRIPT_SUPPRESSING_MARKER], &[]);
+    assert_eq!(clean.status, CheckStatus::Ok);
+    assert!(
+        clean.message.contains("no inherited markers"),
+        "a clean env must say so: {}",
+        clean.message
+    );
+
+    let leaking = verdict(
+        &[TRANSCRIPT_SUPPRESSING_MARKER],
+        &[TRANSCRIPT_SUPPRESSING_MARKER],
+    );
+    assert_eq!(
+        leaking.status,
+        CheckStatus::Ok,
+        "a live marker is context, not a failure: {}",
+        leaking.message
+    );
+    assert!(
+        leaking.message.contains("running with the leak present"),
+        "a leaking env must be reported as context: {}",
+        leaking.message
+    );
+}

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
@@ -37,6 +37,8 @@ fn launch_lines_covers_every_builder() {
     for expected in [
         "runtime::claude_code::env_bin_prefix",
         "core::model_inject::build_claude_command",
+        "core::model_inject::build_inplace_session_command",
+        "core::model_inject::build_client_session_command",
         "daemon::spawn_command::relaunch_command",
         "core::standalone::run::build_launch_command",
         "control::backend::stream_json::build_claude_command",
@@ -63,6 +65,163 @@ fn launch_lines_covers_every_builder() {
             "{label} must NOT unset CLAUDE_CODE_OAUTH_TOKEN (#2246); unsets: {unset:?}"
         );
     }
+}
+
+/// Every source site that names `claude` as a command word, with the number of
+/// non-comment occurrences expected in that file and why they are acceptable.
+///
+/// Why (review round 2 MEDIUM): `launch_lines()` is hand-maintained and
+/// `launch_lines_covers_every_builder` only asserts the listed labels are
+/// PRESENT — nothing failed when a launch line existed that was not on the list.
+/// That is how `tm session start`'s in-place line stayed uncovered through two
+/// review rounds, and it is an anti-drift helper that reintroduces drift one
+/// level down. This allowlist inverts the direction: the test enumerates what is
+/// actually IN THE SOURCE and fails on anything unaccounted for, so a new spawn
+/// site is a build failure rather than a silent gap.
+const ALLOWLISTED_CLAUDE_SITES: &[(&str, usize, &str)] = &[
+    (
+        "core/model_inject.rs",
+        4,
+        "the three shared launch-line builders (build_claude_command, \
+         build_inplace_session_command, build_client_session_command — all three in \
+         launch_lines()) plus the `head()` test helper that reconstructs their prefix",
+    ),
+    (
+        "core/standalone/run.rs",
+        2,
+        "build_launch_command (tm run, in launch_lines()) and build_login_command \
+         (`claude auth login` — an auth subcommand, not an interactive session, so it \
+         creates no transcript to suppress)",
+    ),
+    (
+        "daemon/spawn_command.rs",
+        1,
+        "relaunch_command; in launch_lines()",
+    ),
+    (
+        "control/backend/stream_json.rs",
+        1,
+        "build_claude_command (headless); in launch_lines()",
+    ),
+    (
+        "core/claude_env_scrub_tests.rs",
+        2,
+        "test fixtures for scrub_command — not launch lines",
+    ),
+    (
+        "core/spawn_disclaim/pane.rs",
+        3,
+        "test fixtures for the disclaim wrapper — not launch lines",
+    ),
+    (
+        "daemon/discovery.rs",
+        1,
+        "a test fixture pane-line string parsed by discovery — not a launch line",
+    ),
+];
+
+/// Fails when a `claude` launch site appears anywhere in the crate that is not
+/// accounted for above.
+///
+/// Honest about its reach, because a coverage test that overstates itself is the
+/// defect it is guarding against: it matches only sites that name `claude`
+/// LITERALLY. Builders that spawn a RESOLVED binary path held in a variable
+/// (`runtime::claude_code`, `bin/tm/commands/guided_inplace.rs`) carry no literal
+/// and are invisible here — they are covered by `launch_lines()` and by their own
+/// tests respectively. What this catches is the shape that actually went wrong
+/// twice: someone hand-writing `format!("claude …")` or `Command::new("claude")`
+/// at a new call site.
+#[test]
+fn every_claude_launch_site_in_the_crate_is_allowlisted() {
+    let src = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut found: std::collections::BTreeMap<String, usize> = std::collections::BTreeMap::new();
+    let mut stack = vec![src.clone()];
+
+    while let Some(dir) = stack.pop() {
+        for entry in std::fs::read_dir(&dir).expect("src must be readable") {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                stack.push(path);
+                continue;
+            }
+            if path.extension().and_then(|e| e.to_str()) != Some("rs") {
+                continue;
+            }
+            // This file necessarily contains every pattern it searches for — in
+            // the allowlist's own reason strings and in the failure message. It
+            // is the one self-exclusion, and it is a test file, so it can hold
+            // no production launch line.
+            if path.file_name().and_then(|n| n.to_str())
+                == Some("doctor_transcript_saving_tests.rs")
+            {
+                continue;
+            }
+            let text = std::fs::read_to_string(&path).expect("source must be readable");
+            let hits = text
+                .lines()
+                // Prose in a doc comment is not a spawn site. Filtering comments
+                // is what keeps this test from failing on its own explanations.
+                .filter(|line| {
+                    let t = line.trim_start();
+                    !(t.starts_with("//") || t.starts_with("*"))
+                })
+                .filter(|line| {
+                    line.contains(r#"Command::new("claude")"#)
+                        || line.contains(r#""claude ""#)
+                        || line.contains(r#""claude {"#)
+                        || line.contains(r#""claude --"#)
+                        || line.contains(r#"} claude""#)
+                })
+                .count();
+            if hits > 0 {
+                let rel = path
+                    .strip_prefix(&src)
+                    .expect("under src")
+                    .to_string_lossy()
+                    .replace('\\', "/");
+                found.insert(rel, hits);
+            }
+        }
+    }
+
+    let expected: std::collections::BTreeMap<String, usize> = ALLOWLISTED_CLAUDE_SITES
+        .iter()
+        .map(|(f, n, _)| ((*f).to_owned(), *n))
+        .collect();
+
+    assert_eq!(
+        found, expected,
+        "\nA `claude` launch site changed.\n\
+         If you ADDED a launch line: route it through `core::claude_env_scrub` (never a second \
+         mechanism), register it in `daemon::doctor_transcript_saving::launch_lines()` so the \
+         `transcript_saving` check covers it, and then update ALLOWLISTED_CLAUDE_SITES.\n\
+         If it is not a launch line, add it with a reason saying why.\n\
+         found:    {found:#?}\n\
+         expected: {expected:#?}"
+    );
+}
+
+/// The Ok message must enumerate the binary-crate gaps, not describe one of
+/// them — the prose that made a sixth uncovered launch line read as covered.
+#[test]
+fn ok_message_names_every_binary_crate_gap() {
+    let check = check_transcript_saving();
+    assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
+    for gap in BINARY_CRATE_BUILDERS {
+        assert!(
+            check.message.contains(gap),
+            "the Ok message must name the binary-crate gap {gap}: {}",
+            check.message
+        );
+    }
+    assert!(
+        check.message.contains(&format!(
+            "{} launch line(s) in the `tm` BINARY",
+            BINARY_CRATE_BUILDERS.len()
+        )),
+        "the message must COUNT the gaps rather than implying one: {}",
+        check.message
+    );
 }
 
 /// The probe must supply an OAuth token, or an over-scrub of it stays invisible.

--- a/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_transcript_saving_tests.rs
@@ -1,37 +1,99 @@
 //! Tests for [`super`] — the `transcript_saving` doctor probe (issue #4467).
 //!
 //! Why: this check exists because the defect was silent, so its own tests have
-//! to prove it can FAIL — in both directions. `verdict` is exercised directly
-//! for the failure branches (the production prefix is correct, so the wrapper
-//! can only ever show the happy path), and the wrapper is exercised once against
-//! the real spawn builder so the two can never drift apart.
+//! to prove it can FAIL — in both directions, and for every launch line it
+//! claims to cover. `verdict` is exercised directly for the failure branches (the
+//! production builders are correct, so the wrapper can only ever show the happy
+//! path), and the wrapper is exercised against every real builder so the two can
+//! never drift apart.
 
 use super::*;
 
-/// The gate that matters: the REAL production spawn prefix must preserve
-/// transcript saving. Fails if anyone drops the scrub from `env_bin_prefix`.
+/// A representative path label for direct `verdict` calls.
+const PATH: &str = "probe::builder";
+
+/// The gate that matters: EVERY real launch line must preserve transcript
+/// saving. Fails if anyone drops the scrub from any builder.
 #[test]
-fn production_spawn_preserves_transcript_saving() {
+fn every_production_launch_line_preserves_transcript_saving() {
     let check = check_transcript_saving();
     assert_eq!(
         check.status,
         CheckStatus::Ok,
-        "the production managed spawn must preserve transcript saving; got: {}",
+        "every production launch line must preserve transcript saving; got: {}",
         check.message
     );
     assert_eq!(check.name, CHECK_NAME);
 }
 
+/// Per-builder assertion, so a failure names the offender instead of only
+/// reporting that "something" leaks. Marker names are hard-coded: deriving them
+/// from the constant would let an emptied list pass.
+#[test]
+fn launch_lines_covers_every_builder() {
+    let lines = super::launch_lines();
+    let labels: Vec<&str> = lines.iter().map(|(label, _)| *label).collect();
+
+    for expected in [
+        "runtime::claude_code::env_bin_prefix",
+        "core::model_inject::build_claude_command",
+        "daemon::spawn_command::relaunch_command",
+        "core::standalone::run::build_launch_command",
+        "control::backend::stream_json::build_claude_command",
+    ] {
+        assert!(
+            labels.iter().any(|l| l.contains(expected)),
+            "the check must cover {expected}; covered: {labels:?}"
+        );
+    }
+
+    // Every covered builder must actually unset the suppressing marker, and none
+    // may unset a deliberate variable.
+    for (label, unset) in &lines {
+        assert!(
+            unset.iter().any(|n| n == "CLAUDE_CODE_CHILD_SESSION"),
+            "{label} must unset CLAUDE_CODE_CHILD_SESSION; unsets: {unset:?}"
+        );
+        assert!(
+            !unset.iter().any(|n| n == "CLAUDE_CONFIG_DIR"),
+            "{label} must NOT unset CLAUDE_CONFIG_DIR (#4455); unsets: {unset:?}"
+        );
+        assert!(
+            !unset.iter().any(|n| n == "CLAUDE_CODE_OAUTH_TOKEN"),
+            "{label} must NOT unset CLAUDE_CODE_OAUTH_TOKEN (#2246); unsets: {unset:?}"
+        );
+    }
+}
+
+/// The probe must supply an OAuth token, or an over-scrub of it stays invisible.
+#[test]
+fn probe_supplies_an_oauth_token_so_over_scrub_is_visible() {
+    let config_dir = std::path::PathBuf::from(PROBE_CONFIG_DIR);
+    let prefix = crate::runtime::env_bin_prefix("claude", Some(&config_dir), Some(PROBE_TOKEN));
+    assert!(
+        prefix.contains("CLAUDE_CODE_OAUTH_TOKEN="),
+        "the probe prefix must carry the token assignment: {prefix}"
+    );
+    assert!(
+        prefix.contains("CLAUDE_CONFIG_DIR="),
+        "the probe prefix must carry the config-dir assignment: {prefix}"
+    );
+}
+
 #[test]
 fn ok_when_the_marker_is_scrubbed() {
-    let check = verdict(&["ANTHROPIC_API_KEY", TRANSCRIPT_SUPPRESSING_MARKER], &[]);
+    let check = verdict(
+        PATH,
+        &["ANTHROPIC_API_KEY", TRANSCRIPT_SUPPRESSING_MARKER],
+        &[],
+    );
     assert_eq!(check.status, CheckStatus::Ok, "{}", check.message);
 }
 
 /// Under-scrub: the whole point of the check.
 #[test]
 fn fails_when_the_suppressing_marker_is_not_scrubbed() {
-    let check = verdict(&["ANTHROPIC_API_KEY"], &[]);
+    let check = verdict(PATH, &["ANTHROPIC_API_KEY"], &[]);
     assert_eq!(
         check.status,
         CheckStatus::Fail,
@@ -50,10 +112,23 @@ fn fails_when_the_suppressing_marker_is_not_scrubbed() {
     );
 }
 
+/// A failure has to say WHICH builder leaks.
+#[test]
+fn failure_names_the_leaking_path() {
+    let check = verdict("core::some::builder", &["ANTHROPIC_API_KEY"], &[]);
+    assert_eq!(check.status, CheckStatus::Fail);
+    assert!(
+        check.message.contains("core::some::builder"),
+        "the message must name the offending builder: {}",
+        check.message
+    );
+}
+
 /// Over-scrub: the opposite failure, which would silently restore #4451.
 #[test]
 fn fails_when_the_scrub_would_take_the_config_dir() {
     let check = verdict(
+        PATH,
         &[
             "ANTHROPIC_API_KEY",
             TRANSCRIPT_SUPPRESSING_MARKER,
@@ -79,15 +154,45 @@ fn fails_when_the_scrub_would_take_the_config_dir() {
     );
 }
 
+/// The OTHER deliberate variable: invisible to the earlier literal-only form.
+#[test]
+fn over_scrub_of_the_oauth_token_is_detected() {
+    let check = verdict(
+        PATH,
+        &[TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CODE_OAUTH_TOKEN"],
+        &[],
+    );
+    assert_eq!(
+        check.status,
+        CheckStatus::Fail,
+        "unsetting the OAuth token must FAIL: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("CLAUDE_CODE_OAUTH_TOKEN"),
+        "the message must name the token: {}",
+        check.message
+    );
+    assert!(
+        check.message.contains("2246"),
+        "the message must cite the login-loop regression: {}",
+        check.message
+    );
+}
+
 /// An over-scrub is reported even though the transcript marker IS present, so
 /// the two branches cannot mask each other.
 #[test]
 fn config_dir_over_scrub_takes_precedence_in_the_message() {
-    let check = verdict(&[TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CONFIG_DIR"], &[]);
+    let check = verdict(
+        PATH,
+        &[TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CONFIG_DIR"],
+        &[],
+    );
     assert_eq!(check.status, CheckStatus::Fail);
     assert!(
         check.message.contains("4455"),
-        "the config-dir branch must be the one reported: {}",
+        "the deliberate-env branch must be the one reported: {}",
         check.message
     );
 }
@@ -98,8 +203,9 @@ fn failure_is_a_hard_fail_not_a_warn() {
     for unset in [
         vec!["ANTHROPIC_API_KEY"],
         vec![TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CONFIG_DIR"],
+        vec![TRANSCRIPT_SUPPRESSING_MARKER, "CLAUDE_CODE_OAUTH_TOKEN"],
     ] {
-        let check = verdict(&unset, &[]);
+        let check = verdict(PATH, &unset, &[]);
         assert_ne!(
             check.status,
             CheckStatus::Warn,
@@ -114,7 +220,7 @@ fn failure_is_a_hard_fail_not_a_warn() {
 /// condition — a clean environment must still produce a meaningful Ok.
 #[test]
 fn ok_message_reports_markers_live_in_the_environment() {
-    let clean = verdict(&[TRANSCRIPT_SUPPRESSING_MARKER], &[]);
+    let clean = verdict(PATH, &[TRANSCRIPT_SUPPRESSING_MARKER], &[]);
     assert_eq!(clean.status, CheckStatus::Ok);
     assert!(
         clean.message.contains("no inherited markers"),
@@ -123,6 +229,7 @@ fn ok_message_reports_markers_live_in_the_environment() {
     );
 
     let leaking = verdict(
+        PATH,
         &[TRANSCRIPT_SUPPRESSING_MARKER],
         &[TRANSCRIPT_SUPPRESSING_MARKER],
     );

--- a/crates/trusty-mpm/src/daemon/services/tmux_service.rs
+++ b/crates/trusty-mpm/src/daemon/services/tmux_service.rs
@@ -209,7 +209,7 @@ impl TmuxService {
         // may already be gone); the original `send_line` error still propagates
         // to the caller — the rollback never masks it.
         let target = TmuxTarget::session(tmux_name);
-        if let Err(e) = driver.send_line(&target, crate::daemon::spawn_command::relaunch_command())
+        if let Err(e) = driver.send_line(&target, &crate::daemon::spawn_command::relaunch_command())
         {
             Self::kill_best_effort(tmux_name);
             return Err(DaemonError::Internal(format!(

--- a/crates/trusty-mpm/src/daemon/spawn_command.rs
+++ b/crates/trusty-mpm/src/daemon/spawn_command.rs
@@ -49,26 +49,64 @@
 /// (#2010). Named distinctly from `runtime::claude_code::spawn_command` (which
 /// builds the full env/flags managed-session command) so the two are never
 /// confused for one another.
-/// What: returns the literal `"claude"` command. This intentionally carries
-/// none of the managed-session isolation in
+/// What: returns `env <-u marker…> claude`. This still intentionally carries
+/// none of the managed-session AUTH isolation in
 /// [`crate::runtime::claude_code`] (no absolute-path resolution, no
 /// `ANTHROPIC_API_KEY` scrub, no `CLAUDE_CONFIG_DIR`) — see the module doc's
 /// KNOWN LIMITATION note for why that is currently unverified rather than
-/// deliberately safe for every caller of `restart_in_session`.
-/// Test: `relaunch_command_returns_bare_claude`.
-pub(crate) fn relaunch_command() -> &'static str {
-    "claude"
+/// deliberately safe for every caller of `restart_in_session`. That half remains
+/// #2020's.
+///
+/// Issue #4467 adds ONLY the inherited-session-marker scrub, which is orthogonal
+/// to #2020's auth question: a relaunch into an already-configured pane still
+/// inherits `CLAUDE_CODE_CHILD_SESSION` from the pane's environment and would
+/// silently save no transcript. Scrubbing it here is what lets the
+/// `transcript_saving` doctor check cover this launch line instead of returning
+/// `Ok` while it leaks.
+/// Test: `relaunch_command_scrubs_inherited_session_markers`.
+pub(crate) fn relaunch_command() -> String {
+    // #4467: strip the inherited Claude Code session markers. No `NAME=VALUE`
+    // assignments follow, so the POSIX "-u before assignments" rule is trivially
+    // satisfied.
+    format!("env{} claude", crate::core::claude_env_scrub::env_unset_flags())
 }
 
 #[cfg(test)]
 mod tests {
     use super::relaunch_command;
 
-    /// The shared builder must keep returning the bare `claude` literal that
-    /// both call sites relied on before this consolidation (#2010) — this
-    /// change removes the drift risk, not the behavior.
+    /// #4467: the relaunch line must scrub the inherited session markers, or a
+    /// config-restart silently loses the pane's transcript. Marker names are
+    /// hard-coded so this cannot go vacuous if the shared list is emptied. The
+    /// `claude` program itself must still terminate the line (#2010 — no
+    /// absolute-path resolution here; that stays #2020's).
     #[test]
-    fn relaunch_command_returns_bare_claude() {
-        assert_eq!(relaunch_command(), "claude");
+    fn relaunch_command_scrubs_inherited_session_markers() {
+        let cmd = relaunch_command();
+        assert!(
+            cmd.starts_with("env -u "),
+            "the relaunch line must carry an env scrub prefix: {cmd}"
+        );
+        for marker in [
+            "CLAUDE_CODE_CHILD_SESSION",
+            "CLAUDE_CODE_SESSION_ID",
+            "CLAUDECODE",
+            "CLAUDE_PID",
+            "CLAUDE_EFFORT",
+            "CLAUDE_CODE_EXECPATH",
+        ] {
+            assert!(
+                cmd.contains(&format!("-u {marker}")),
+                "relaunch must unset {marker}: {cmd}"
+            );
+        }
+        assert!(
+            cmd.ends_with(" claude"),
+            "the line must still invoke `claude` (#2010): {cmd}"
+        );
+        assert!(
+            !cmd.contains("-u CLAUDE_CONFIG_DIR"),
+            "must never unset CLAUDE_CONFIG_DIR (#4455): {cmd}"
+        );
     }
 }

--- a/crates/trusty-mpm/src/daemon/spawn_command.rs
+++ b/crates/trusty-mpm/src/daemon/spawn_command.rs
@@ -34,9 +34,9 @@
 //! silently drop that session's auth/roster isolation and unattended-permission
 //! mode. Adding registry-aware validation is out of scope for this
 //! consolidation (#2010) and is tracked separately in #2020.
-//! What: [`relaunch_command`] returns the literal shell command sent to the
-//! pane.
-//! Test: `relaunch_command_returns_bare_claude`.
+//! What: [`relaunch_command`] returns the shell command sent to the pane —
+//! `claude` behind the #4467 inherited-session-marker `env` scrub.
+//! Test: `relaunch_command_scrubs_inherited_session_markers`.
 
 /// The shell command used to (re)launch `claude` inside an already-running,
 /// already-configured tmux pane.

--- a/crates/trusty-mpm/src/daemon/spawn_command.rs
+++ b/crates/trusty-mpm/src/daemon/spawn_command.rs
@@ -68,7 +68,10 @@ pub(crate) fn relaunch_command() -> String {
     // #4467: strip the inherited Claude Code session markers. No `NAME=VALUE`
     // assignments follow, so the POSIX "-u before assignments" rule is trivially
     // satisfied.
-    format!("env{} claude", crate::core::claude_env_scrub::env_unset_flags())
+    format!(
+        "env{} claude",
+        crate::core::claude_env_scrub::env_unset_flags()
+    )
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -155,10 +155,19 @@ fn cd_and_group(cwd: &Path, body: &str) -> String {
 /// token, though tokens do not contain shell metacharacters in practice) with a
 /// space does not word-split and break the pane. All settings are applied via a
 /// single `env` prefix, consistent with the scrub-only prefix.
-/// What: `env -u ANTHROPIC_API_KEY [CLAUDE_CONFIG_DIR='<dir>'] [CLAUDE_CODE_OAUTH_TOKEN='<token>'] <claude_bin>`
-/// — each bracketed assignment appears only when its value is `Some`; with
-/// neither, the legacy `env -u ANTHROPIC_API_KEY <claude_bin>` (byte-identical
-/// to the pre-#2246 command). The `-u NAME` option MUST precede any
+/// (4) Issue #4467: Claude Code's own process-local session markers — chiefly
+/// `CLAUDE_CODE_CHILD_SESSION` — are unset via
+/// [`crate::core::claude_env_scrub::env_unset_flags`]. When `tm` is invoked from
+/// inside a Claude Code session it inherits them and passed them straight
+/// through, and an inherited `CLAUDE_CODE_CHILD_SESSION` makes the spawned
+/// `claude` turn session persistence OFF ("Transcript saving is off — inherited
+/// CLAUDE_CODE_CHILD_SESSION marker"), costing the managed session its native
+/// `--resume` / `--continue` / `/rewind` recovery. The scrub list deliberately
+/// EXCLUDES `CLAUDE_CONFIG_DIR` — see that module's `DELIBERATE_SPAWN_ENV`, and
+/// #4455/#4451 for why removing it would re-break the bundled agent roster.
+/// What: `env -u ANTHROPIC_API_KEY <-u marker…> [CLAUDE_CONFIG_DIR='<dir>'] [CLAUDE_CODE_OAUTH_TOKEN='<token>'] <claude_bin>`
+/// — each bracketed assignment appears only when its value is `Some`. The
+/// `-u NAME` option MUST precede any
 /// `NAME=VALUE` assignment per POSIX `env` grammar (`env [OPTION]...
 /// [NAME=VALUE]... [COMMAND]...`); putting an assignment before `-u` makes
 /// `env` stop parsing options at the first `NAME=VALUE` and try to exec `-u`
@@ -170,7 +179,10 @@ fn cd_and_group(cwd: &Path, body: &str) -> String {
 /// `env_bin_prefix_orders_unset_flag_before_config_dir_assignment`,
 /// `spawn_command_sets_oauth_token_when_available`,
 /// `spawn_command_omits_oauth_token_when_absent`,
-/// `spawn_command_without_token_is_byte_identical_to_pre_2246`.
+/// `spawn_command_without_token_pins_the_exact_command`,
+/// `spawn_command_scrubs_inherited_session_markers`,
+/// `spawn_command_keeps_config_dir_out_of_the_scrub`,
+/// `env_bin_prefix_orders_scrub_flags_before_assignments`.
 ///
 /// `GH_TOKEN`/`GH_USER` (issue #3025) are deliberately NOT assignments on
 /// this prefix — see [`claude_code_gh_env::gh_env_source_prefix`], applied
@@ -178,7 +190,7 @@ fn cd_and_group(cwd: &Path, body: &str) -> String {
 /// (review follow-up: embedding a token literally in this `env` command line
 /// would land it in the pane shell's history file and be transiently visible
 /// in `ps` output for the `env` process itself).
-fn env_bin_prefix(
+pub(crate) fn env_bin_prefix(
     claude_bin: &str,
     config_dir: Option<&Path>,
     oauth_token: Option<&str>,
@@ -192,7 +204,14 @@ fn env_bin_prefix(
         let quoted = shell_single_quote(token);
         assignments.push_str(&format!(" {OAUTH_TOKEN_ENV_VAR}={quoted}"));
     }
-    format!("env -u ANTHROPIC_API_KEY{assignments} {claude_bin}")
+    // #4467: strip Claude Code's inherited process-local session markers. An
+    // inherited `CLAUDE_CODE_CHILD_SESSION` makes the spawned `claude` disable
+    // transcript saving, so the managed session gets no native `--resume` /
+    // `--continue` / `/rewind` recovery and never appears in `--resume`. These
+    // flags MUST precede `assignments` — POSIX `env` stops parsing options at
+    // the first `NAME=VALUE`, so a `-u` after one is exec'd as a command.
+    let scrub = crate::core::claude_env_scrub::env_unset_flags();
+    format!("env -u ANTHROPIC_API_KEY{scrub}{assignments} {claude_bin}")
 }
 
 /// Build the `--append-system-prompt-file <path>` flag fragment for a spawn

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -136,11 +136,16 @@ fn spawn_command_sets_claude_config_dir() {
         None,
         None,
     );
+    // #4467 inserted the inherited-marker `-u` flags between the API-key scrub
+    // and the assignment; both must still precede the first NAME=VALUE per POSIX
+    // env grammar, which `env_bin_prefix_orders_scrub_flags_before_assignments`
+    // asserts positionally.
     assert!(
-        cmd.contains(
-            "env -u ANTHROPIC_API_KEY \
-                 CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' claude"
-        ),
+        cmd.contains("env -u ANTHROPIC_API_KEY -u "),
+        "the API-key scrub must still lead the env prefix: {cmd}"
+    );
+    assert!(
+        cmd.contains("CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' claude"),
         "spawn command must scrub the key (via -u, BEFORE the NAME=VALUE assignment per \
              POSIX env grammar) then set (single-quoted) CLAUDE_CONFIG_DIR: {cmd}"
     );
@@ -315,10 +320,15 @@ fn spawn_command_omits_oauth_token_when_absent() {
 }
 
 #[test]
-fn spawn_command_without_token_is_byte_identical_to_pre_2246() {
-    // Zero-regression guard: a caller with no config dir, no prompt file,
-    // and no token must get EXACTLY the same command string this crate
-    // produced before #2246 introduced the extra parameter.
+fn spawn_command_without_token_pins_the_exact_command() {
+    // Full-string pin for the minimal argument set (no config dir, no prompt
+    // file, no token). Supersedes the former
+    // `spawn_command_without_token_is_byte_identical_to_pre_2246` guard: #4467
+    // intentionally changed this string by adding the inherited-marker scrub, so
+    // byte-identity with the pre-#2246 command is no longer the invariant. The
+    // scrub segment is interpolated from production code rather than restated —
+    // its CONTENT is pinned by `core::claude_env_scrub` tests, while this test
+    // pins its POSITION in the assembled command.
     let cmd = spawn_command(
         Path::new(TEST_CWD),
         "claude",
@@ -328,15 +338,123 @@ fn spawn_command_without_token_is_byte_identical_to_pre_2246() {
         None,
         None,
     );
+    let scrub = crate::core::claude_env_scrub::env_unset_flags();
     let expected = format!(
         "cd '/tmp/ws' && {{ export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; \
-             env -u ANTHROPIC_API_KEY claude \
+             env -u ANTHROPIC_API_KEY{scrub} claude \
              --setting-sources project,local --dangerously-skip-permissions; \
              echo 'tm: run `tm` to relaunch this session'; }}"
     );
-    assert_eq!(
-        cmd, expected,
-        "no-token command must be byte-identical to pre-#2246"
+    assert_eq!(cmd, expected, "no-token command shape must stay pinned");
+}
+
+#[test]
+fn spawn_command_scrubs_inherited_session_markers() {
+    // #4467: the marker name is HARD-CODED here on purpose. Deriving it from
+    // the constant would make this test pass even if the constant were emptied,
+    // which is the silent failure the issue is about — a managed session that
+    // saves no transcript and reports nothing.
+    let cmd = spawn_command(
+        Path::new(TEST_CWD),
+        "claude",
+        None,
+        TEST_SESSION_ID,
+        None,
+        None,
+        None,
+    );
+    assert!(
+        cmd.contains("-u CLAUDE_CODE_CHILD_SESSION"),
+        "spawn must unset the marker that disables transcript saving: {cmd}"
+    );
+    assert!(
+        cmd.contains("-u CLAUDE_CODE_SESSION_ID"),
+        "spawn must unset the parent's session id: {cmd}"
+    );
+    assert!(
+        cmd.contains("-u CLAUDECODE"),
+        "spawn must unset the inherited in-Claude-Code marker: {cmd}"
+    );
+}
+
+#[test]
+fn resume_command_scrubs_inherited_session_markers() {
+    // #4467: a fix covering `spawn_command` alone would leave every RESUMED
+    // session still unable to save transcripts, so the resume path is asserted
+    // independently rather than trusted to share `env_bin_prefix`.
+    let cmd = resume_command(
+        Path::new(TEST_CWD),
+        "claude",
+        None,
+        Some("abc-123"),
+        false,
+        TEST_SESSION_ID,
+        None,
+        None,
+        None,
+    );
+    assert!(
+        cmd.contains("-u CLAUDE_CODE_CHILD_SESSION"),
+        "resume must unset the marker that disables transcript saving: {cmd}"
+    );
+    assert!(
+        cmd.contains("--resume abc-123"),
+        "the resume selection must survive the scrub: {cmd}"
+    );
+}
+
+#[test]
+fn spawn_command_keeps_config_dir_out_of_the_scrub() {
+    // #4467 over-scrub guard, at the command-string level: `CLAUDE_CONFIG_DIR`
+    // must appear as an ASSIGNMENT and never as a `-u` unset. Scrubbing it would
+    // move the bundled roster out of the `user` settings tier a managed session
+    // loads and silently restore #4451 (every delegation → `general-purpose`).
+    let dir = Path::new("/home/bob/.trusty-tools/trusty-mpm/claude-config");
+    let cmd = spawn_command(
+        Path::new(TEST_CWD),
+        "claude",
+        Some(dir),
+        TEST_SESSION_ID,
+        None,
+        None,
+        None,
+    );
+    assert!(
+        !cmd.contains("-u CLAUDE_CONFIG_DIR"),
+        "CLAUDE_CONFIG_DIR must never be unset (#4455 depends on it): {cmd}"
+    );
+    assert!(
+        cmd.contains("CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' claude"),
+        "CLAUDE_CONFIG_DIR must still be assigned right before the binary: {cmd}"
+    );
+}
+
+#[test]
+fn env_bin_prefix_orders_scrub_flags_before_assignments() {
+    // POSIX `env` stops parsing options at the first `NAME=VALUE`, so a `-u`
+    // appearing after an assignment is exec'd as a command
+    // (`env: -u: No such file or directory`) and kills every managed spawn.
+    let dir = Path::new("/tm/config");
+    let prefix = env_bin_prefix("/abs/claude", Some(dir), Some("tok"));
+    let last_unset = prefix
+        .rfind("-u ")
+        .expect("prefix must contain at least one -u flag");
+    let first_assignment = prefix
+        .find("CLAUDE_CONFIG_DIR=")
+        .expect("prefix must contain the config-dir assignment");
+    assert!(
+        last_unset < first_assignment,
+        "every -u flag must precede the first NAME=VALUE assignment: {prefix}"
+    );
+    // And the parser the doctor probe relies on must see the marker here.
+    let unset = crate::core::claude_env_scrub::parse_env_unset_vars(&prefix);
+    assert!(
+        unset.contains(&"CLAUDE_CODE_CHILD_SESSION"),
+        "the real spawn prefix must unset the suppressing marker: {unset:?}"
+    );
+    assert!(
+        !unset.contains(&"CLAUDE_CONFIG_DIR"),
+        "the real spawn prefix must NOT unset CLAUDE_CONFIG_DIR: {unset:?}"
     );
 }
 
@@ -354,13 +472,18 @@ fn spawn_command_sets_both_config_dir_and_oauth_token() {
         Some("sk-ant-oat01-fake-token"),
         None,
     );
+    // #4467 inserted the inherited-marker `-u` flags between the API-key scrub
+    // and the assignments, so the assignment run is matched on its own.
     assert!(
         cmd.contains(
-            "env -u ANTHROPIC_API_KEY \
-                 CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' \
+            "CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' \
                  CLAUDE_CODE_OAUTH_TOKEN='sk-ant-oat01-fake-token' claude"
         ),
         "both assignments must coexist, config dir before the token: {cmd}"
+    );
+    assert!(
+        cmd.contains("env -u ANTHROPIC_API_KEY -u "),
+        "the API-key scrub must still lead the env prefix: {cmd}"
     );
 }
 
@@ -407,9 +530,10 @@ fn resume_command_omits_oauth_token_when_absent() {
 }
 
 #[test]
-fn resume_command_without_token_is_byte_identical_to_pre_2246() {
-    // Zero-regression guard, resume-path counterpart to
-    // spawn_command_without_token_is_byte_identical_to_pre_2246.
+fn resume_command_without_token_pins_the_exact_command() {
+    // Full-string pin, resume-path counterpart to
+    // spawn_command_without_token_pins_the_exact_command (see its note on why
+    // #4467 replaced the former pre-#2246 byte-identity guard).
     let cmd = resume_command(
         Path::new(TEST_CWD),
         "claude",
@@ -421,15 +545,16 @@ fn resume_command_without_token_is_byte_identical_to_pre_2246() {
         None,
         None,
     );
+    let scrub = crate::core::claude_env_scrub::env_unset_flags();
     let expected = format!(
         "cd '/tmp/ws' && {{ export TM_MANAGED_SESSION_ID='{TEST_SESSION_ID}'; \
-             env -u ANTHROPIC_API_KEY claude \
+             env -u ANTHROPIC_API_KEY{scrub} claude \
              --setting-sources project,local --dangerously-skip-permissions --resume abc-123; \
              echo 'tm: run `tm` to relaunch this session'; }}"
     );
     assert_eq!(
         cmd, expected,
-        "no-token resume command must be byte-identical to pre-#2246"
+        "no-token resume command shape must stay pinned"
     );
 }
 
@@ -450,8 +575,7 @@ fn env_bin_prefix_quotes_config_dir_with_space() {
     );
     assert!(
         cmd.contains(
-            "env -u ANTHROPIC_API_KEY \
-                 CLAUDE_CONFIG_DIR='/Users/John Doe/.trusty-tools/trusty-mpm/claude-config' claude"
+            "CLAUDE_CONFIG_DIR='/Users/John Doe/.trusty-tools/trusty-mpm/claude-config' claude"
         ),
         "config dir with a space must be single-quoted and intact: {cmd}"
     );
@@ -534,9 +658,16 @@ fn spawn_command_uses_resolved_binary() {
         None,
         None,
     );
+    // The binary follows the `env` prefix, which since #4467 also carries the
+    // inherited-marker `-u` flags — so match on the LAST flag before the binary
+    // rather than assuming the API-key scrub is adjacent to it.
     assert!(
-        cmd.contains("env -u ANTHROPIC_API_KEY /Users/me/.local/bin/claude "),
+        cmd.contains("-u CLAUDE_CODE_EXECPATH /Users/me/.local/bin/claude "),
         "spawn command must invoke the resolved absolute claude path: {cmd}"
+    );
+    assert!(
+        cmd.contains("env -u ANTHROPIC_API_KEY -u "),
+        "the API-key scrub must still lead the env prefix: {cmd}"
     );
 }
 
@@ -846,11 +977,13 @@ fn resume_command_sets_claude_config_dir() {
         None,
         None,
     );
+    // #4467 inserted the inherited-marker `-u` flags before the assignment.
     assert!(
-        cmd.contains(
-            "env -u ANTHROPIC_API_KEY \
-                 CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' claude"
-        ),
+        cmd.contains("env -u ANTHROPIC_API_KEY -u "),
+        "the API-key scrub must still lead the env prefix: {cmd}"
+    );
+    assert!(
+        cmd.contains("CLAUDE_CONFIG_DIR='/home/bob/.trusty-tools/trusty-mpm/claude-config' claude"),
         "resume command must export (single-quoted) CLAUDE_CONFIG_DIR after the -u option: {cmd}"
     );
     assert!(

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -658,16 +658,14 @@ fn spawn_command_uses_resolved_binary() {
         None,
         None,
     );
-    // The binary follows the `env` prefix, which since #4467 also carries the
-    // inherited-marker `-u` flags — so match on the LAST flag before the binary
-    // rather than assuming the API-key scrub is adjacent to it.
+    // This test owns BINARY RESOLUTION, so it must not couple to the marker
+    // list's contents or order. Matching the bare path (space-delimited on both
+    // sides, so a bare `claude` cannot satisfy it) keeps a marker-list reorder
+    // from failing here with an unrelated message — the scrub itself is asserted
+    // by `spawn_command_scrubs_inherited_session_markers`.
     assert!(
-        cmd.contains("-u CLAUDE_CODE_EXECPATH /Users/me/.local/bin/claude "),
+        cmd.contains(" /Users/me/.local/bin/claude "),
         "spawn command must invoke the resolved absolute claude path: {cmd}"
-    );
-    assert!(
-        cmd.contains("env -u ANTHROPIC_API_KEY -u "),
-        "the API-key scrub must still lead the env prefix: {cmd}"
     );
 }
 

--- a/crates/trusty-mpm/src/runtime/mod.rs
+++ b/crates/trusty-mpm/src/runtime/mod.rs
@@ -20,6 +20,10 @@ mod tcode;
 pub(crate) mod test_helpers;
 
 pub(crate) use claude_code::session_id_exists;
+// #4467: re-exported so the `transcript_saving` doctor check can read the scrub
+// set out of the REAL managed-spawn env prefix rather than restating the marker
+// constant — a check that compared the constant against itself could not fail.
+pub(crate) use claude_code::env_bin_prefix;
 pub use claude_code::{ClaudeCodeAdapter, InPlaceResumeCommand, build_inplace_resume_command};
 pub use tcode::TcodeAdapter;
 


### PR DESCRIPTION
## The defect

`tm` never scrubbed Claude Code's process-local session markers when spawning a managed `claude`. When `tm` runs from inside a Claude Code session — the PM delegating, the daemon having been started from a session, an operator running `tm` in a `claude` pane — it inherits them and passed the whole environment through. An inherited `CLAUDE_CODE_CHILD_SESSION` makes Claude Code disable session persistence:

> Transcript saving is off — inherited CLAUDE_CODE_CHILD_SESSION marker
> · restart with CLAUDE_CODE_FORCE_SESSION_PERSISTENCE=1 to keep future transcripts

Managed sessions therefore had no native `--resume` / `--continue` / `/rewind` recovery and never appeared in `--resume`. tm's own pause/resume writes only a condensed summary, so a session that died lost everything since its last snapshot.

The gate, read out of the `claude` 2.1.220 bundle:

```js
function Zkt(){                                              // "disable session persistence?"
  if (Z.CLAUDE_CODE_FORCE_SESSION_PERSISTENCE) return false;
  if (!(Z.CLAUDE_CODE_CHILD_SESSION && PN() && !o_())) return false;
  return !Tsg();                                             // Tsg(): tmux show-environment -g CLAUDE_CODE_CHILD_SESSION
}
```

`CLAUDE_CODE_CHILD_SESSION` is the sole trigger. Removing it short-circuits the gate at the second condition, independent of everything else.

## Where the residual risk actually is

**Correction (this replaces an earlier claim in this body that had it backwards).** The earlier version said "a tmux server restarted from a clean shell would silently stop saving". That is the wrong way round. For a tmux **pane**, the marker's presence and the escape hatch are *coupled*: tmux's `update-environment` does not carry `CLAUDE_*`, so a marker only reaches a pane when the tmux **server's** global env carries it — which is exactly the condition that trips `Tsg()`. A clean server means the panes never inherit the marker in the first place. Tested directly on an isolated socket, both directions.

The defect is still real on the fixed paths, for two reasons the original body did not name — and both argue *for* the scrub:

1. **The escape hatch fails OPEN into suppression.** `Esg()` runs `spawnSync("tmux", …)` **by bare name** with a **250 ms timeout** and returns `false` on throw or non-zero status. A pane on the daemon's minimal launchd `PATH` (the documented #1298 hazard, `spawn_disclaim/pane.rs:83`) or a machine loaded enough to blow 250 ms both flip a masked session to not-saving. That is a better account of "it looked intermittent" than the tmux-server story.
2. **`tm run` has no tmux at all**, so `Esg()` returns `false` on its first line (`if(!Z.TMUX) return false`) and the suppression fires **every time** — deterministic, not probe-dependent.

Scrubbing the variable is what makes the outcome deterministic instead of dependent on a probe that can fail open.

## Per-variable decisions

The scrub list is not guesswork. It is what Claude Code's own child-process env injector sets (`KDt` in the same bundle), plus `CLAUDE_CODE_EXECPATH` which appears on upstream's own list of variables it refuses to propagate into a shell snapshot.

| Variable | Decision | Why |
|---|---|---|
| `CLAUDE_CODE_CHILD_SESSION` | **scrub** | The sole transcript-saving trigger. Upstream strips it when spawning MCP servers too. |
| `CLAUDE_CODE_SESSION_ID` | **scrub** | The parent's session UUID; inheriting it mis-attributes the child's hook/statusline events to the parent conversation. |
| `CLAUDECODE` | **scrub** | The "inside Claude Code" marker for child processes. The spawned `claude` sets it for its own children; inheriting it is the leak upstream 2.1.170 called out for the VS Code terminal. |
| `CLAUDE_PID` | **scrub** | The parent interpreter's pid — stale by definition, and consulted by shell-snapshot probes (`/proc/$CLAUDE_PID/comm`). |
| `CLAUDE_EFFORT` | **scrub** | A snapshot of the parent's *current turn* effort level. Derived output exposed for hooks, not a config knob, so a fresh session must recompute it. |
| `CLAUDE_CODE_EXECPATH` | **scrub** | Path to the parent's `claude` binary. tm always passes a resolved absolute binary, so nothing reads it. |
| `CLAUDE_CONFIG_DIR` | **KEEP** | Set deliberately by tm. #4455 depends on the relocation to put the bundled agent roster in the `user` settings tier a managed session loads — scrubbing it immediately re-breaks #4451 (every delegation degrading to `general-purpose`). Guarded by two tests and a doctor branch, not just a comment. |
| `CLAUDE_CODE_OAUTH_TOKEN` | **KEEP** | Injected by #2246 to bypass the `CLAUDE_CONFIG_DIR`-keyed Keychain login loop. |
| `CLAUDE_CODE_MAX_OUTPUT_TOKENS` | **KEEP** | An operator-facing configuration knob, not process-local state, and not on upstream's own exclusion list. Scrubbing it would silently override the operator's intent. |
| `CLAUDE_CODE_ENTRYPOINT` | **KEEP** | Its inherited value from a `tm` parent (`cli`) is what a fresh CLI spawn computes anyway. Note the keep is *value*-dependent, not proven-safe for every value: unset is not universally equivalent to `"cli"` (the bundle gates one path on `e === "cli" \|\| e === "remote"`, so scrubbing would silently disable it), while an inherited `sdk-ts`/`sdk-py`/`sdk-cli` drops one built-in agent from the roster and `claude-vscode` changes `clientType`. Neither is reachable from a `tm` spawn, whose parent is always a `cli` session. Recorded in the module doc. |
| `CLAUDE_CODE_INVOKED_SKILLS` | **KEEP** | On the same upstream non-propagation list that justifies `CLAUDE_CODE_EXECPATH`, so the decision is stated rather than left implicit: it was not in the observed leak set, nothing in this workspace reads it, and it carries no session identity — a stale value cannot mis-attribute a session or suppress a transcript. |

`AI_AGENT` and `TRACEPARENT` are in the same upstream injector but were left alone deliberately. `AI_AGENT` self-heals: the bundle overwrites any inherited value beginning `claude-code_`/`claude-code/` with its own at startup. `TRACEPARENT` is only set when tracing is on and its sole effect is span parenting. Both are generically named, so a third party could legitimately set them.

## Launch lines fixed

Every launch line that spawns a `claude` — a fix covering only the default spawn would leave every *resumed* session broken, and the first round of this PR left three builders leaking:

- `spawn_command` and `resume_command` (`runtime/claude_code.rs`) — share `env_bin_prefix`, which now emits `env -u ANTHROPIC_API_KEY -u <markers…> [assignments] <bin>`. The `-u` flags must precede any `NAME=VALUE`; POSIX `env` stops parsing options at the first assignment and would exec `-u` as a command.
- `compose_inplace_args` / `build_inplace_exec_command` (`bin/tm/commands/guided_inplace.rs`) — execs through a `Command` with no shell, so it uses `env_remove`. The scrub runs *before* the deliberate assignments so it can never clobber `CLAUDE_CONFIG_DIR`.
- `build_claude_command` (`control/backend/stream_json.rs`) — same `env_remove` seam that already strips `ANTHROPIC_API_KEY`.
- **`build_launch_command` (`core/standalone/run.rs`) — `tm run`.** Added in the review round. The one `tm` path with no tmux, so the suppression fired here deterministically. One line: `scrub_command(&mut cmd)` before the `CLAUDE_CONFIG_DIR` assignment, so the deliberate value still wins.
- **`build_claude_command` (`core/model_inject.rs`) — the `tm launch` (`launch.rs:308`) and `tm connect` (`launch.rs:563` via `connect_claude_cmd`) launch line.** Added in review round 1. It emitted a bare `claude` with **no `env` prefix at all**, while its own doc claimed to be where "every spawn path stays unattended and isolated". Now leads with `env -u <markers…>`.
- **`relaunch_command` (`daemon/spawn_command.rs`) — the pane relaunch.** Added in review round 1. Only the marker scrub; #2020's auth/absolute-path half stays open and is still documented as such.
- **`build_inplace_session_command` (`core/model_inject.rs`) — `tm session start`, in place.** Added in **review round 2** (HIGH). `bin/tm`'s `start_session_in_place` hand-built `format!("claude {PERMISSION_MODE_FLAG}")` and sent it to a fresh pane: no scrub, no test, and the doctor named only one binary-crate gap so it read as covered. Reachable on the documented "just run claude here" case — `tm session start` outside a GitHub-backed git repo.
- **`build_client_session_command` (`core/model_inject.rs`) — `DaemonClient::launch_session` / `connect_session`, the TUI and bot surface behind `/connect <dir>`.** Found in round 2 **by the new anti-drift scan, not by review**: both hand-built `format!("claude --append-system-prompt-file …")`. Two further launch lines nobody had named.

**Why the last two moved into the library rather than being patched in place.** `daemon::doctor_transcript_saving`'s `launch_lines()` can only read builders the *library* owns, so a hand-built line at a call site is structurally invisible to the check that exists to catch exactly this. Three separate call sites had each hand-written their own `claude …` string and all three silently saved no transcript.

**Neither new builder carries `SETTING_SOURCES_FLAG`, deliberately.** Routing them through `build_claude_command` (the critic's first option) would also add `--setting-sources project,local`, which **drops the `user` tier** — and neither path relocates `CLAUDE_CONFIG_DIR`, so on them the `user` tier *is* the operator's own `~/.claude`. That would change which settings and agents an in-place session loads. The scrub is the only behaviour change; pinned by `inplace_session_command_keeps_the_permission_flag_and_nothing_else`.

**Interaction with the #2997 pane disclaim, since the CLI paths changed shape.** `tm launch`/`tm connect` wrap the line in `disclaim_pane_command`, so the pane now runs `<tm> internal-spawn-disclaimed env -u … claude …`: the shim `posix_spawn`s `env` disclaimed and `env` **execs** `claude` in that same process. The disclaim is a process attribute and survives the exec, and because `env` execs rather than forks, the `pane sh → tm shim → claude` tree `core::process` walks is unchanged. The daemon composes the two the other way round (`env … <tm> internal-spawn-disclaimed <abs claude>`); both shapes end with `claude` running as its own responsible process. The shim's `argv` already carries `trailing_var_arg` + `allow_hyphen_values`, so the `-u` tokens parse, and `env` is no less `PATH`-resolvable than the bare `claude` this line used to emit — no new `PATH` dependency. Pinned by `wraps_the_scrubbed_launch_line_with_env_as_the_program`.

## Doctor check

New `transcript_saving` check (24 checks, was 23), modelled on `agent_reachability` (#4455): a silent failure needs a check capable of failing. Static, not a live `claude -p` spawn.

The first version parsed only `env_bin_prefix`, so it returned `Ok` while the three builders above leaked — a check that certifies a broken state is worse than no check. It now **enumerates every launch-line builder the library owns** and reads each one's real output: `parse_env_unset_vars` for shell-string builders, `get_envs()` for `Command` builders. It returns the **first** failure and **names the offending builder**, so one leaking path cannot be averaged away by four correct ones. `bin/tm`'s `build_inplace_exec_command` lives in the binary crate the library cannot reference; the Ok message names that gap rather than implying coverage, and it has its own test.

It fails in **both** directions. Over-scrub detection now iterates `DELIBERATE_SPAWN_ENV` and the probe supplies a token, so an over-scrub of `CLAUDE_CODE_OAUTH_TOKEN` (#2246) is visible too — the earlier literal `"CLAUDE_CONFIG_DIR"` comparison could not see it.

**Verified non-tautological by mutation, on the final tree.** Each mutation applied alone, tests run, file byte-restored (`cmp -s`) afterwards:

| # | Mutation | Result |
|---|---|---|
| M2 | drop `scrub_command` from `standalone::run::build_launch_command` | FAIL, names `(tm run)`, `Currently unsets: []` |
| M1 | `model_inject::build_claude_command` → bare `"claude"` | FAIL, names `(tm launch / tm connect)` |
| **M7** | `build_inplace_session_command` → `format!("claude {PERMISSION_MODE_FLAG}")` | FAIL on 4 tests, names `` `core::model_inject::build_inplace_session_command (tm session start, in place)` ``, `Currently unsets: []` |
| **M8** | `build_client_session_command` → bare `"claude"` | FAIL on 4 tests, names `` `core::model_inject::build_client_session_command (DaemonClient launch/connect)` ``, `Currently unsets: []` |

M7 and M8 cover the two paths added in round 2. The critic independently ran M1–M6 including a partial scrub and a correctly-listed-but-wrongly-positioned scrub; both were caught.

## Anti-drift: new spawn sites now fail the build (round 2 MEDIUM)

`launch_lines()` is hand-maintained, and `launch_lines_covers_every_builder` only asserted the listed labels were **present** — nothing failed when a launch line existed that was *not* on the list. That is an anti-drift helper reintroducing drift one level down, and it is precisely how the round-2 HIGH survived two review rounds and a widening pass.

`every_claude_launch_site_in_the_crate_is_allowlisted` inverts the direction: it walks `crates/trusty-mpm/src`, counts non-comment sites naming `claude` as a command word, and asserts the result equals an explicit allowlist carrying a stated reason per entry. A new spawn site is now a failing test, not a silent gap. **It earned its keep immediately** — it is what found the two `DaemonClient` launch lines.

Honest about its reach, since a coverage test that overstates itself is the defect it guards against: it matches **literal** `claude` only. Builders that spawn a resolved binary path held in a variable (`runtime::claude_code`, `guided_inplace`) carry no literal and are invisible to it; those are covered by `launch_lines()` and their own tests. What it catches is the shape that actually went wrong three times — someone hand-writing `format!("claude …")` or `Command::new("claude")` at a new call site.

The doctor's `Ok` message now **counts and names** the binary-crate gaps from a `BINARY_CRATE_BUILDERS` constant, instead of describing one in prose (which read as *the* gap rather than *a* gap), and points at the test above. Pinned by `ok_message_names_every_binary_crate_gap`.

## Test-pinning hardening (review round)

- All six markers are now pinned by **literal name** (`every_marker_is_pinned_by_literal_name`). Every prior test iterated `INHERITED_SESSION_MARKERS`, so `CLAUDE_PID` and `CLAUDE_EFFORT` were pinned by nothing — deleting either kept the whole suite green.
- `parse_env_unset_vars` now models POSIX option termination and stops at the first `NAME=VALUE`. It previously reported `FOO` unset from `env CLAUDE_CODE_CHILD_SESSION=1 -u FOO claude`, an ordering `env` rejects with `env: -u: No such file or directory` (exit 127) — so the doctor probe could have passed on a prefix that kills every spawn.
- **Round 2 (LOW):** it now also stops at the **command word**. `build_claude_command` emits no assignments at all, so the assignment stop never fired on its output and the scan ran to end of line; a future `claude` flag pair spelled `-u <x>` would have been miscounted as an unset variable. Not reachable today — closed before a flag makes it reachable. Pinned by `parse_env_unset_vars_stops_at_the_command_word`.
- **Round 2 (LOW):** dropped `delegate` from `build_claude_command`'s doc and the doctor's label. `build_agent_command` has **no production caller anywhere in the workspace** — only its definition and its own test — so a `transcript_saving` failure labelled `(… / delegate)` would have sent an operator chasing a path that does not exist. *Declining the delete half:* `trusty-mpm` carries no `publish = false` and eight sibling crates depend on it, so removing a `pub fn` is a semver-breaking change that does not belong in a bug-fix PR. The dead function stays; removing it is follow-up.
- `spawn_command_uses_resolved_binary` no longer matches `-u CLAUDE_CODE_EXECPATH /Users/me/.local/bin/claude `, which coupled a binary-resolution test to `CLAUDE_CODE_EXECPATH` being *last* in the marker list.

## Retention finding — no pruner added

**Relocation does not defeat native retention, and I found no evidence that it does.** The mechanism that decides whether the sweep runs is the `--setting-sources` flag, not the config-dir path:

> Skipping retention cleanup: userSettings source is disabled (--setting-sources) and no enabled source provides cleanupPeriodDays.

Relocated managed spawns carry `--setting-sources user,project,local` (since #4455), so `userSettings` is enabled and `cleanupPeriodDays` is readable — the native sweep applies to the relocated dir.

Evidence gathered:

- Relocated dir: 6.2 GB, 103 project dirs, 10430 `.jsonl`. **0 files older than 30 days** — but the directory was created Jul 4 (27 days ago), so that observation carries little information and I am not claiming it as proof.
- Default `~/.claude/projects` (relocation not in play): 3412 `.jsonl`, of which **1396 are older than 30 days**, oldest 47 days. 1340 of those 1396 sit under `subagents/`.

So the accurate reading is that the native sweep is weak on `subagents/` transcripts **in both directories alike** — that is upstream behaviour, not a tm relocation bug, and nothing tm can fix by relocating differently.

**Call: build no pruning code.** A parallel pruner would be a redundant second mechanism (its own liability, per the brief) aimed at an upstream gap. I also did not add a footprint doctor warning: any threshold would be arbitrary, and a warning would not address the actual gap. The footprint numbers are recorded on #4467 as an open item instead.

Scope note on growth: subagent transcripts already save today (9931 files, 4.46 GB of the 6.2 GB). What was missing is the top-level managed-session transcript (0.82 GB across 499 files), so enabling saving grows the *smaller* bucket.

## Verification

Branch head `66f3d8da`, on `origin/main` at `a226bad6`.

**Changelog migrated to fragments (#4477).** That PR replaced the shared-`CHANGELOG.md` `## [Unreleased]` convention with per-PR fragment files and removed the heading from all 25 crates, so this PR's bullet moved out of `CHANGELOG.md` into two fragments:

- `crates/trusty-mpm/changelog.d/4467-transcript-saving.md` — `Fixed`
- `crates/trusty-mpm/changelog.d/4467-doctor-transcript-check.md` — `Added` (the new doctor check is an addition, not a fix)

`crates/trusty-mpm/CHANGELOG.md` is now byte-identical to main (`git diff origin/main -- crates/trusty-mpm/CHANGELOG.md` is empty) and carries no `## [Unreleased]` heading — `assemble-changelog.sh:265` hard-fails on a leftover one, which would break the release path for the crate.

Validated through the consumer, not just the gate: `scripts/assemble-changelog.sh trusty-mpm --stdout` renders both bullets under the correct `### Added` / `### Fixed` headings, and `scripts/assemble-changelog.sh trusty-mpm 1.3.1 --check` reports `OK: 9 fragment(s) … valid; crates/trusty-mpm/CHANGELOG.md is ready for a [1.3.1] section.` Neither mode wrote anything (tree stayed clean).

- `cargo test -p trusty-mpm` — **exit 0**, 44 targets, **6995 passed; 0 failed; 16 ignored** (pre-existing). Lib target: `test result: ok. 4082 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 55.37s`.
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — exit 0.
- `cargo fmt --check` — exit 0.
- `bash scripts/check_line_cap.sh` — `line-cap: 7 allowlisted, 0 violations — OK`.
- `bash scripts/check_test_pointers.sh` — `test-pointers: 0 dangling pointers — OK`. **This check was RED on `a06cfb8a`** (`spawn_command.rs:39` cited the renamed `relaunch_command_returns_bare_claude`); it was the only failing check on the PR and is fixed here.
- `bash scripts/check_changelog_fragment.sh` — `OK   trusty-mpm: changelog.d fragment present and valid`.
- `bash scripts/check_sld.sh`, `check_doc_numbers.sh`, `check_capabilities.sh` — all exit 0 (`up to date (6 generated files)`).
- Mutation probes on the doctor check — see above.

No `#[ignore]`, no cfg-gating, no `--exclude`, no narrowed scope, no deleted coverage.

**One flake, named rather than buried.** One earlier full run failed `connectors::tm::tests::create_session_full_lifecycle` with `Transport("error sending request for url (http://127.0.0.1:56178/api/v1/sessions/managed)")` — an ephemeral-port transport failure, the same shape as the `execute_doctor_against_test_daemon` flake noted in review. It passes in isolation (`1 passed`) and every subsequent full run is green. Unrelated to this diff: no scrubbed variable is involved in a local HTTP request.

**Not verified end-to-end interactively.** An A/B live probe (marker set vs scrubbed, PTY allocated, tmux escape hatch neutralized) wrote a transcript in *both* arms, because `claude -p` print mode never enters the suppression branch (`PN()` is false there). The suppression only fires for interactive sessions, which is where the warning was originally observed and which I could not drive non-interactively. The fix therefore rests on the decompiled gate above, the verbatim warning string naming the marker, unit tests proving every emitted launch line unsets it, and the two mutation probes on the doctor check.

Closes #4467

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
