### PR TITLE
fix: make five non-hermetic test fixtures deterministic (#4306, #4413, #4414, #4415, refs #4407)

### DIFF
--- a/crates/trusty-agents/changelog.d/4414-uv-home-lock.md
+++ b/crates/trusty-agents/changelog.d/4414-uv-home-lock.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `python_skill`'s two `uv`-spawning tests no longer race the 161 statements in
+  this crate that reassign `$HOME` process-wide (closes [#4414](https://github.com/bobmatnyc/trusty-tools/issues/4414); refs [#4407](https://github.com/bobmatnyc/trusty-tools/issues/4407), [#3451](https://github.com/bobmatnyc/trusty-tools/issues/3451)).
+  `uv` resolves its cache from `$HOME` at spawn time; under parallel load a
+  sibling test's `HOME=<tempdir>` was reaped mid-flight, leaving `uv` pointing at
+  a deleted tree (`No such file or directory ... /.tmpHR50aj/.cache/uv/...`).
+  Both tests now hold `test_env::HOME_LOCK` for their whole body — verified
+  exhaustive first: all 161 HOME-mutating statements (116 `set_var` + 45
+  `remove_var`, across 72 test fns) sit inside a function holding that lock, so
+  nothing can move `$HOME` while the subprocess runs. Measured on a loaded
+  machine: 3 failures in 5 full-suite runs before, 0 in 5 after.

--- a/crates/trusty-agents/src/tools/python_skill.rs
+++ b/crates/trusty-agents/src/tools/python_skill.rs
@@ -339,6 +339,46 @@ mod tests {
             .unwrap_or(false)
     }
 
+    /// Hold `$HOME` still for the duration of a test that shells out to `uv`
+    /// (#4414).
+    ///
+    /// Why: `uv` resolves its cache from `$HOME` (`$HOME/.cache/uv`) at spawn
+    /// time, and ~115 sites across this crate's tests reassign `HOME`
+    /// process-wide to a `TempDir`. Under parallel load the sequence that
+    /// actually bit was: a sibling test set `HOME=<tempdir>`, `uv` derived its
+    /// cache path from that tempdir, and the sibling's `TempDir` was then
+    /// dropped — deleting the tree out from under the running interpreter.
+    /// Captured failures name the vanished path directly:
+    /// `Caused by: No such file or directory (os error 2) at path
+    /// ".../T/.tmpHR50aj/.cache/uv/.tmptfs807"`, and
+    /// `ModuleNotFoundError: No module named 'python'` for the same reason.
+    /// Measured on `main`: 3 failures in 5 full-suite runs.
+    ///
+    /// What: acquires `test_env::HOME_LOCK`, the mutex this crate's HOME
+    /// convention is built on. Verified exhaustive for this crate before
+    /// relying on it: all 115 `set_var("HOME", ..)` sites (across 72 test fns)
+    /// hold `HOME_LOCK`, so holding it here excludes every writer — nothing is
+    /// mutating `HOME`, and no sibling's `TempDir` is being reaped, while the
+    /// `uv` subprocess runs. That makes the test hermetic with respect to the
+    /// variable rather than merely likely to win the race; widening a timeout
+    /// or retrying would have left the same race with a longer fuse.
+    ///
+    /// `unwrap_or_else(into_inner)` so one panicking test cannot poison the
+    /// lock for its siblings — the same acquisition idiom the other 43 callers
+    /// use. Plain `HOME_LOCK` rather than `test_env::lock_home()` because these
+    /// tests exercise no production path guarded by
+    /// `home_lock_held_by_this_thread` (only `listeners::store::events_dir` is).
+    /// Test: [`execute_dispatches_to_python_and_parses_json`] and
+    /// [`execute_maps_python_error_key_to_recoverable_result`] — the two tests
+    /// that spawn `uv`. [`execute_reports_spawn_failure_as_recoverable`]
+    /// deliberately does not: it spawns a nonexistent binary and never reads
+    /// `HOME`.
+    fn hold_home_for_uv() -> std::sync::MutexGuard<'static, ()> {
+        crate::test_env::HOME_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner())
+    }
+
     #[test]
     fn manifest_parses_cto_db_shape() {
         let manifest = load_manifest(&cto_db_skill_dir()).expect("manifest should parse");
@@ -386,12 +426,22 @@ mod tests {
         assert!(build_plugin(tmp.path()).is_err());
     }
 
+    // #4414: holds the guard across `.await` deliberately — the whole point is
+    // that `$HOME` must not move while the `uv` subprocess is alive. The default
+    // `#[tokio::test]` runtime is current-thread, which pins this test (every
+    // `.await` included) to one OS thread, so the guard is sound here.
+    #[allow(
+        clippy::await_holding_lock,
+        reason = "#4414: holding HOME_LOCK across the uv subprocess IS the fix"
+    )]
     #[tokio::test]
     async fn execute_dispatches_to_python_and_parses_json() {
         if !uv_available() {
             eprintln!("SKIP: `uv` not on PATH — cannot exercise the real cto-db skill subprocess");
             return;
         }
+        // #4414: pin $HOME for the whole body — see `hold_home_for_uv`.
+        let _home = hold_home_for_uv();
         let plugin = build_plugin(&cto_db_skill_dir()).expect("plugin should build");
         let tool = plugin
             .tools
@@ -410,12 +460,22 @@ mod tests {
         assert!(parsed["groups"].as_array().is_some_and(|g| !g.is_empty()));
     }
 
+    // #4414: holds the guard across `.await` deliberately — the whole point is
+    // that `$HOME` must not move while the `uv` subprocess is alive. The default
+    // `#[tokio::test]` runtime is current-thread, which pins this test (every
+    // `.await` included) to one OS thread, so the guard is sound here.
+    #[allow(
+        clippy::await_holding_lock,
+        reason = "#4414: holding HOME_LOCK across the uv subprocess IS the fix"
+    )]
     #[tokio::test]
     async fn execute_maps_python_error_key_to_recoverable_result() {
         if !uv_available() {
             eprintln!("SKIP: `uv` not on PATH — cannot exercise the real cto-db skill subprocess");
             return;
         }
+        // #4414: pin $HOME for the whole body — see `hold_home_for_uv`.
+        let _home = hold_home_for_uv();
         let plugin = build_plugin(&cto_db_skill_dir()).expect("plugin should build");
         let tool = plugin
             .tools

--- a/crates/trusty-agents/src/tools/python_skill.rs
+++ b/crates/trusty-agents/src/tools/python_skill.rs
@@ -343,7 +343,7 @@ mod tests {
     /// (#4414).
     ///
     /// Why: `uv` resolves its cache from `$HOME` (`$HOME/.cache/uv`) at spawn
-    /// time, and ~115 sites across this crate's tests reassign `HOME`
+    /// time, and 161 statements across this crate's tests reassign `HOME`
     /// process-wide to a `TempDir`. Under parallel load the sequence that
     /// actually bit was: a sibling test set `HOME=<tempdir>`, `uv` derived its
     /// cache path from that tempdir, and the sibling's `TempDir` was then
@@ -355,9 +355,10 @@ mod tests {
     /// Measured on `main`: 3 failures in 5 full-suite runs.
     ///
     /// What: acquires `test_env::HOME_LOCK`, the mutex this crate's HOME
-    /// convention is built on. Verified exhaustive for this crate before
-    /// relying on it: all 115 `set_var("HOME", ..)` sites (across 72 test fns)
-    /// hold `HOME_LOCK`, so holding it here excludes every writer — nothing is
+    /// convention is built on. Verified exhaustive for this crate before relying
+    /// on it: all 161 HOME-mutating statements — 116 `set_var("HOME", ..)` plus
+    /// 45 `remove_var("HOME")`, across 72 test fns — sit inside a function that
+    /// holds `HOME_LOCK`, so holding it here excludes every writer. Nothing is
     /// mutating `HOME`, and no sibling's `TempDir` is being reaped, while the
     /// `uv` subprocess runs. That makes the test hermetic with respect to the
     /// variable rather than merely likely to win the race; widening a timeout

--- a/crates/trusty-common/changelog.d/4407-inference-gate-clears-key.md
+++ b/crates/trusty-common/changelog.d/4407-inference-gate-clears-key.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `semantic_consolidation::inference_available_false_without_key` no longer
+  fails on any machine that exports a real `OPENROUTER_API_KEY` (refs [#4407](https://github.com/bobmatnyc/trusty-tools/issues/4407), [#3451](https://github.com/bobmatnyc/trusty-tools/issues/3451)).
+  The test asserts the inference gate stays closed with no key configured, but
+  `inference_available("", false)` falls back to reading that variable from the
+  process environment — so "absent from the ambient shell" was an unstated
+  precondition, and its `#[serial]` group excluded concurrent test writers while
+  doing nothing about the environment the suite inherits. It now CLEARS the
+  variable for its body via an `EnvVarGuard::clear` (restored on drop), which is
+  what it always claimed to test.

--- a/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
+++ b/crates/trusty-common/src/memory_core/semantic_consolidation/mod.rs
@@ -105,9 +105,33 @@ mod tests {
     /// mutators) because it held no lock at all. Join the same
     /// `dotenv_credential_env` group as every other test that reads or
     /// writes this var.
+    ///
+    /// #4407: the `#[serial]` group excludes concurrent *test* writers but not
+    /// the AMBIENT environment. The var being absent was still an unstated
+    /// precondition on the machine, so this test failed for anyone whose shell
+    /// exports a real `OPENROUTER_API_KEY` — which is every developer who has
+    /// configured one, and was the observed cause on a CI runner whose shell had
+    /// it set. Reproduced deterministically: `OPENROUTER_API_KEY=sk-… cargo test
+    /// -p trusty-common --features memory-core --lib semantic_consolidation`
+    /// failed on `main` at `assertion failed: !inference_available("", false)`.
+    ///
+    /// Fixed by CLEARING the var for the body rather than assuming it is clear.
+    /// This does not weaken the test — it makes it verify what it always claimed
+    /// to: "no key configured anywhere ⇒ the gate is closed". Previously, on a
+    /// machine WITH the var set it could not verify that at all; it just failed.
+    /// `EnvVarGuard` restores the prior value on drop, so a developer's real key
+    /// survives the test run.
     #[test]
     #[serial_test::serial(dotenv_credential_env)]
     fn inference_available_false_without_key() {
+        // #4407: `force_env_local_loaded` FIRST — the `.env.local` loader is a
+        // process-global `OnceLock` that folds file contents into the process
+        // environment on whichever call happens to be first. If that first call
+        // were the one inside `inference_available` below, it could re-populate
+        // the very var this test just cleared, mid-assertion (the #3464
+        // mechanism). Forcing it now makes the clear below the last word.
+        crate::inference::credentials::load_env_local_once();
+        let _guard = EnvVarGuard::clear("OPENROUTER_API_KEY");
         assert!(!inference_available("", false));
         assert!(!inference_available("   ", false));
     }
@@ -169,6 +193,19 @@ mod tests {
             let previous = std::env::var(key).ok();
             // Safety: test-only; caller is `#[serial]`.
             unsafe { std::env::set_var(key, value) };
+            Self { key, previous }
+        }
+
+        /// Remove `key` for the guard's lifetime, restoring it on drop (#4407).
+        ///
+        /// Why: a test asserting "behaviour X holds when this var is UNSET" must
+        /// make it unset, not assume the ambient shell left it that way — see
+        /// `inference_available_false_without_key`, which failed on any machine
+        /// with a real `OPENROUTER_API_KEY` exported.
+        fn clear(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            // Safety: test-only; caller is `#[serial]`.
+            unsafe { std::env::remove_var(key) };
             Self { key, previous }
         }
     }

--- a/crates/trusty-memory/changelog.d/4413-palace-tests-set-own-env.md
+++ b/crates/trusty-memory/changelog.d/4413-palace-tests-set-own-env.md
@@ -1,0 +1,13 @@
+Fixed
+
+- two `tools::tests` no longer depend on an environment variable another test
+  happened to leak (closes [#4413](https://github.com/bobmatnyc/trusty-tools/issues/4413); refs [#4407](https://github.com/bobmatnyc/trusty-tools/issues/4407), [#3451](https://github.com/bobmatnyc/trusty-tools/issues/3451)).
+  `add_alias_round_trip_through_prompt_cache` and
+  `dispatch_discover_aliases_inserts_new_and_dedupes` build `AppState` inline
+  (they need `with_default_palace`) and so never ran `test_state()`'s
+  `TRUSTY_SKIP_PALACE_ENFORCEMENT` write — they passed under `cargo test` only
+  because a sibling test in the same process had set it first. In isolation they
+  verified nothing, failing at `palace_create` before reaching any assertion.
+  Both now call a named `skip_palace_enforcement()` helper, which
+  `test_state`/`test_state_warming` share. `cargo nextest run -p trusty-memory`
+  (per-test process isolation) goes from 2 failures to 527/527 passing.

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -21,22 +21,46 @@ use uuid::Uuid;
 /// when the test scope ends.
 /// Test: Every test in this module that constructs state.
 ///
-/// Why (issue #88): sets `TRUSTY_SKIP_PALACE_ENFORCEMENT=1` so that
-/// existing tests that call `palace_create` with arbitrary names continue
-/// to work. The enforcement gate in `handle_palace_create` bypasses the
-/// project-slug check when this env var is set, which is the correct
-/// behaviour for test helpers that point at isolated tempdirs. Production
-/// processes never set this variable.
-fn test_state() -> (AppState, tempfile::TempDir) {
-    // SAFETY: tests in this module run in-process; setting the bypass var
-    // here races with any test that reads env before or after, but since
-    // the value is "set to the same constant forever" once any test runs,
-    // the race is benign — all tests should see "1" within the first
-    // iteration. Tests that need stricter serialisation already use
-    // `env_test_lock()`.
-    unsafe {
+/// Why (issue #88): calls [`skip_palace_enforcement`] so that existing tests
+/// that call `palace_create` with arbitrary names continue to work.
+/// Set `TRUSTY_SKIP_PALACE_ENFORCEMENT=1` for this test process (#88, #4413).
+///
+/// Why: `handle_palace_create` rejects a palace name that does not match the
+/// project slug derived from cwd unless this var is set, so every test that
+/// creates a palace with an arbitrary name (`"ctx"`, `"disc"`, …) needs it.
+/// Production processes never set it.
+///
+/// Why it exists as a named helper rather than a line inside [`test_state`]
+/// (#4413): two tests here build their `AppState` INLINE — they need
+/// `with_default_palace`, which [`test_state`] does not offer — and so never
+/// ran [`test_state`]'s `set_var`. They passed anyway under `cargo test`, purely
+/// because some *other* test in the same process had already set the var: a
+/// hidden ordering dependency, and one that made them pass for the wrong reason
+/// (in isolation they verify nothing, because they never get past
+/// `palace_create`). Per-test process isolation removes the donor and exposes
+/// it — `cargo nextest run -p trusty-memory` failed both, which is how #4413
+/// was found. Making the requirement callable, and calling it from each test
+/// that needs it, is what makes each test self-sufficient.
+///
+/// What: writes the var at most once per process via a `OnceLock`, so N callers
+/// perform ONE write rather than N racing ones (the pre-existing `test_state`
+/// body re-wrote it on every call). Idempotent and safe to call from any test.
+/// Test: [`add_alias_round_trip_through_prompt_cache`] and
+/// [`dispatch_discover_aliases_inserts_new_and_dedupes`] are the two callers
+/// that #4413 was filed for; every `test_state`/`test_state_warming` user gets
+/// it transitively.
+fn skip_palace_enforcement() {
+    static SET: std::sync::OnceLock<()> = std::sync::OnceLock::new();
+    // SAFETY: a single write of a constant value, performed at most once per
+    // process by the OnceLock. Matches this crate's established test-env
+    // convention; tests needing stricter serialisation use `env_test_lock()`.
+    SET.get_or_init(|| unsafe {
         std::env::set_var("TRUSTY_SKIP_PALACE_ENFORCEMENT", "1");
-    }
+    });
+}
+
+fn test_state() -> (AppState, tempfile::TempDir) {
+    skip_palace_enforcement();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = AppState::new(root);
@@ -53,13 +77,7 @@ fn test_state() -> (AppState, tempfile::TempDir) {
 ///       `recall_returns_warming_error_while_state_is_warming`,
 ///       `note_returns_warming_error_while_state_is_warming`.
 fn test_state_warming() -> (crate::AppState, tempfile::TempDir) {
-    // Use OnceLock so the env var is written exactly once across all
-    // parallel test threads — avoids the unsynchronised set_var race while
-    // remaining consistent with the idempotent-write approach in test_state().
-    static SKIP_ENFORCEMENT_SET: std::sync::OnceLock<()> = std::sync::OnceLock::new();
-    SKIP_ENFORCEMENT_SET.get_or_init(|| unsafe {
-        std::env::set_var("TRUSTY_SKIP_PALACE_ENFORCEMENT", "1");
-    });
+    skip_palace_enforcement();
     let tmp = tempfile::tempdir().expect("tempdir");
     let root = tmp.path().to_path_buf();
     let state = crate::AppState::new(root);
@@ -445,6 +463,12 @@ async fn dispatch_kg_gaps_returns_cached() {
 async fn add_alias_round_trip_through_prompt_cache() {
     // Issue #234: bind `_tmp` so the directory is cleaned up on drop at
     // end of scope (previously we leaked via `std::mem::forget`).
+    // #4413: this test builds `AppState` inline (it needs `with_default_palace`,
+    // which `test_state()` does not offer), so it must set the palace-enforcement
+    // bypass ITSELF rather than inherit one another test happened to leak — see
+    // `skip_palace_enforcement`. Without this the `palace_create` below fails
+    // whenever no sibling test ran first (e.g. under `cargo nextest run`).
+    skip_palace_enforcement();
     let _tmp = tempfile::tempdir().expect("tempdir");
     let root = _tmp.path().to_path_buf();
     let state = AppState::new(root).with_default_palace(Some("ctx".to_string()));
@@ -673,6 +697,12 @@ async fn get_prompt_context_serves_cache_and_filters() {
 async fn dispatch_discover_aliases_inserts_new_and_dedupes() {
     // Issue #234: bind `_tmp` so the directory is cleaned up on drop at
     // end of scope (previously we leaked via `std::mem::forget`).
+    // #4413: this test builds `AppState` inline (it needs `with_default_palace`,
+    // which `test_state()` does not offer), so it must set the palace-enforcement
+    // bypass ITSELF rather than inherit one another test happened to leak — see
+    // `skip_palace_enforcement`. Without this the `palace_create` below fails
+    // whenever no sibling test ran first (e.g. under `cargo nextest run`).
+    skip_palace_enforcement();
     let _tmp = tempfile::tempdir().expect("tempdir");
     let root = _tmp.path().to_path_buf();
     let state = AppState::new(root).with_default_palace(Some("disc".to_string()));

--- a/crates/trusty-mpm/Cargo.toml
+++ b/crates/trusty-mpm/Cargo.toml
@@ -332,5 +332,6 @@ http-body-util.workspace = true
 # parallel Rust test threads (used by bug-report token resolution tests).
 serial_test.workspace = true
 # test-util enables tokio's paused-clock (`tokio::time::pause` / `start_paused = true`)
-# used by the deterministic auth-timeout tests in actor_tests.rs (#1649).
+# used by the deterministic auth-timeout tests in actor_tests.rs (#1649) and by
+# `telegram::supervisor_tests::healthy_run_resets_transient_backoff` (#4306).
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/trusty-mpm/changelog.d/4306-hermetic-test-fixtures.md
+++ b/crates/trusty-mpm/changelog.d/4306-hermetic-test-fixtures.md
@@ -1,0 +1,29 @@
+Fixed
+
+- four non-hermetic test fixtures no longer redden the shared gate for reasons unrelated to the change under test (closes [#4306](https://github.com/bobmatnyc/trusty-tools/issues/4306), [#4415](https://github.com/bobmatnyc/trusty-tools/issues/4415); refs [#4407](https://github.com/bobmatnyc/trusty-tools/issues/4407), [#3451](https://github.com/bobmatnyc/trusty-tools/issues/3451))
+  - The dead-daemon address fixture no longer binds an ephemeral port and drops
+    it — a released port returns to the OS pool, so another binder could be
+    handed it and the "nothing is listening here" premise silently expired
+    (measured: reassigned and accepting connections after one wrap of the
+    ephemeral range). All three duplicate copies, across 13 call sites, now
+    share one fixture on `127.0.0.1:1` — privileged, so unbindable, and outside
+    every ephemeral range — matching the convention already used by
+    trusty-review and trusty-analyze.
+  - `telegram::supervisor`'s healthy-run backoff-reset test runs on tokio's
+    paused clock instead of asserting a 20ms wall-clock bound against a 2ms
+    policy base, which measured scheduler jitter rather than backoff state.
+    The assertions are now exact equalities against literal delays (2ms, 8ms,
+    32ms), which also catch a partial reset the old bound accepted.
+  - The plain-mode banner tests, and `pm_guard_bash`'s TMPDIR/HOME expansion
+    test, joined the default `#[serial]` group. The banner tests' file-local
+    mutex serialised them against each other and nothing else, so they raced the
+    other `$HOME` mutators in the same test binary — 19 HOME-mutating statements
+    in 8 fns across 4 files in the `tm` bin target. One banner test also seeded
+    `banner.txt` into the ambient home instead of its own sandbox, and the
+    `pm_guard_bash` test left `HOME` repointed for the rest of the binary; it now
+    restores both `HOME` and `TMPDIR` through an RAII guard, so an assertion
+    panic cannot skip the cleanup.
+  - Env-isolation audits are scoped per TEST TARGET, not per crate: `#[serial]`
+    coordinates threads inside one test binary and process-global `$HOME` is per
+    process, so neither can span targets. The trusty-mpm lib target's own HOME
+    mutators were never in this race.

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_bash/tests.rs
@@ -774,11 +774,54 @@ fn evaluate_worktree_add_command_follows_git_dash_c_override() {
     );
 }
 
+/// Restore `$TMPDIR` and `$HOME` to their pre-test values on scope exit.
+///
+/// Why: this test must pin both variables to assert the expansion rules, but it
+/// shares a process with every other test in the `tm` bin target — including
+/// `formatters::banner::source`'s, which write real files under `$HOME`.
+/// Leaking `HOME=/Users/x` past this test, or letting it land inside a
+/// concurrent reader's window, is the #4407 failure shape: a test reddens
+/// because of an environment it never set.
+/// What: captures both variables on construction and reinstates them — or
+/// removes them, if originally absent — on `Drop`, so an assertion panic cannot
+/// skip the cleanup the way the old trailing `remove_var` could. That
+/// `remove_var` was also unconditional, clearing a `TMPDIR` the process
+/// normally inherits rather than restoring it.
+/// Test: exercised by `evaluate_worktree_add_command_expands_tmpdir_and_home`.
+struct EnvGuard {
+    tmpdir: Option<std::ffi::OsString>,
+    home: Option<std::ffi::OsString>,
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: paired with `#[serial_test::serial]` on the only construction
+        // site — no other thread reads or writes the environment here.
+        unsafe {
+            match self.tmpdir.take() {
+                Some(v) => std::env::set_var("TMPDIR", v),
+                None => std::env::remove_var("TMPDIR"),
+            }
+            match self.home.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+        }
+    }
+}
+
+// `#[serial]` is load-bearing, not decoration: it joins the same default serial
+// group as the `formatters::banner::source` tests in this same test binary,
+// which is what keeps this test's `$HOME` write out of their window (#4407).
 #[test]
+#[serial_test::serial]
 fn evaluate_worktree_add_command_expands_tmpdir_and_home() {
     let cwd = Path::new("/Users/x/proj");
-    // SAFETY: test-only env mutation, no concurrent access to these vars in
-    // this process's test execution of this specific test.
+    let _env = EnvGuard {
+        tmpdir: std::env::var_os("TMPDIR"),
+        home: std::env::var_os("HOME"),
+    };
+    // SAFETY: serialised by `#[serial_test::serial]`; restored by `EnvGuard`.
     unsafe {
         std::env::set_var("TMPDIR", "/private/tmp/claude-502/scratch");
         std::env::set_var("HOME", "/Users/x");
@@ -793,9 +836,6 @@ fn evaluate_worktree_add_command_expands_tmpdir_and_home() {
         None,
         "~ expansion to an in-project target must be allowed"
     );
-    unsafe {
-        std::env::remove_var("TMPDIR");
-    }
 }
 
 #[test]

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/source.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/source.rs
@@ -189,11 +189,24 @@ pub(crate) fn load_banner_art() -> String {
 mod tests {
     use super::*;
 
-    // Serialise every test that mutates $HOME or $TRUSTY_MPM_BANNER_FILE.
-    // Cargo runs unit tests in parallel by default; env-var mutations are global
-    // and can race. A static Mutex is the idiomatic solution without adding the
-    // `serial_test` crate.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // #4407: these tests mutate `$HOME`, and so must serialise against EVERY
+    // other `$HOME` mutator in this crate — 46 sites across 44 test fns, all of
+    // which use `#[serial_test::serial]`'s unnamed default group.
+    //
+    // They previously used a FILE-LOCAL `static ENV_LOCK: Mutex<()>` instead,
+    // whose comment justified it as "the idiomatic solution without adding the
+    // `serial_test` crate". That premise was stale (serial_test is already a
+    // dev-dependency, used elsewhere in this very bin target) and the mutex was
+    // ineffective for the job: a file-local lock coordinates these five tests
+    // with each other and with NOTHING ELSE, so they raced every `#[serial]`
+    // HOME mutator in the crate, in both directions — a banner test could
+    // repoint `$HOME` mid-flight under another test, and another test could
+    // repoint it under a banner test's `load_banner_art()`. That is the
+    // shared-global-state shape #4407 describes: unrelated plain-mode tests
+    // reddening together and clearing on the next run with no code change.
+    //
+    // Joining the crate's default `#[serial]` group is what actually excludes
+    // the other writers.
 
     fn temp_dir() -> std::path::PathBuf {
         let base = std::env::temp_dir().join(format!(
@@ -219,14 +232,14 @@ mod tests {
 
     /// When the override file is present and non-empty, it is used.
     #[test]
+    #[serial_test::serial]
     fn banner_source_override_file_used() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir();
         let file = dir.join("banner.txt");
         std::fs::write(&file, "CUSTOM ART\n").unwrap();
 
         let old = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: serialised by ENV_LOCK; env mutation restored before unlock.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe { std::env::set_var("TRUSTY_MPM_BANNER_FILE", &file) };
         let art = load_banner_art();
         unsafe {
@@ -241,38 +254,66 @@ mod tests {
     }
 
     /// When the override file is missing, the embedded default is returned.
+    ///
+    /// #4407: this test must sandbox `$HOME` even though it only cares about
+    /// `TRUSTY_MPM_BANNER_FILE`. `load_banner_art()`'s `NotFound` arm — the one
+    /// this test exists to exercise — calls `write_default_if_absent()`, which
+    /// resolves `$HOME/.trusty-mpm/banner.txt` and WRITES to it. With the
+    /// ambient `$HOME`, running this test seeded a real file in the developer's
+    /// own home directory (confirmed present locally); worse, under the previous
+    /// file-local lock it could land inside a concurrent `#[serial]` test's
+    /// `$HOME` tempdir and corrupt that test's fixture. Pointing `$HOME` at this
+    /// test's own tempdir contains the write and additionally asserts it — so
+    /// the seeding side effect is now covered rather than merely tolerated.
     #[test]
+    #[serial_test::serial]
     fn banner_source_missing_falls_back() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir();
         let file = dir.join("no-such.txt");
+        let fake_home = dir.join("home");
+        std::fs::create_dir_all(&fake_home).unwrap();
 
         let old = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: serialised by ENV_LOCK; env mutation restored before unlock.
-        unsafe { std::env::set_var("TRUSTY_MPM_BANNER_FILE", &file) };
+        let old_home = std::env::var_os("HOME");
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
+        unsafe {
+            std::env::set_var("TRUSTY_MPM_BANNER_FILE", &file);
+            std::env::set_var("HOME", &fake_home);
+        }
         let art = load_banner_art();
+        let seeded = std::fs::read_to_string(fake_home.join(".trusty-mpm").join("banner.txt")).ok();
         unsafe {
             match old {
                 Some(v) => std::env::set_var("TRUSTY_MPM_BANNER_FILE", v),
                 None => std::env::remove_var("TRUSTY_MPM_BANNER_FILE"),
             }
+            match old_home {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
         }
         std::fs::remove_dir_all(&dir).ok();
 
         assert_eq!(art, DEFAULT_BANNER_ART);
+        assert_eq!(
+            seeded.as_deref(),
+            Some(DEFAULT_BANNER_ART),
+            "the NotFound arm seeds $HOME/.trusty-mpm/banner.txt — it must land in \
+             THIS test's sandbox, never the ambient home (#4407)"
+        );
     }
 
     /// When the override file exists but is whitespace-only, the embedded
     /// default is returned.
     #[test]
+    #[serial_test::serial]
     fn banner_source_empty_falls_back() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir();
         let file = dir.join("empty.txt");
         std::fs::write(&file, "   \n   \n").unwrap();
 
         let old = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: serialised by ENV_LOCK; env mutation restored before unlock.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe { std::env::set_var("TRUSTY_MPM_BANNER_FILE", &file) };
         let art = load_banner_art();
         unsafe {
@@ -288,8 +329,8 @@ mod tests {
 
     /// Env-var path takes precedence over the home-dir path.
     #[test]
+    #[serial_test::serial]
     fn banner_source_env_override_takes_precedence() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir();
         let env_file = dir.join("env-banner.txt");
         std::fs::write(&env_file, "ENV ART\n").unwrap();
@@ -302,7 +343,7 @@ mod tests {
 
         let old_env = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
         let old_home = std::env::var_os("HOME");
-        // SAFETY: single-threaded test; env mutations are restored before return.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe {
             std::env::set_var("TRUSTY_MPM_BANNER_FILE", &env_file);
             std::env::set_var("HOME", &fake_home);
@@ -327,14 +368,14 @@ mod tests {
 
     /// First run: default art is written to ~/.trusty-mpm/banner.txt.
     #[test]
+    #[serial_test::serial]
     fn banner_source_first_run_writes_default() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let fake_home = temp_dir().join("fresh-home");
         std::fs::create_dir_all(&fake_home).unwrap();
 
         let old_home = std::env::var_os("HOME");
         let old_env = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: single-threaded test; env mutations are restored before return.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe {
             std::env::set_var("HOME", &fake_home);
             std::env::remove_var("TRUSTY_MPM_BANNER_FILE");
@@ -365,8 +406,8 @@ mod tests {
 
     /// First run does not overwrite an existing file.
     #[test]
+    #[serial_test::serial]
     fn banner_source_first_run_no_overwrite() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let fake_home = temp_dir().join("existing-home");
         let banner_dir = fake_home.join(".trusty-mpm");
         std::fs::create_dir_all(&banner_dir).unwrap();
@@ -375,7 +416,7 @@ mod tests {
 
         let old_home = std::env::var_os("HOME");
         let old_env = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: single-threaded test; env mutations are restored before return.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe {
             std::env::set_var("HOME", &fake_home);
             std::env::remove_var("TRUSTY_MPM_BANNER_FILE");
@@ -405,14 +446,14 @@ mod tests {
     /// who installed months ago and never edited their seed file must still
     /// see shipped art updates.
     #[test]
+    #[serial_test::serial]
     fn banner_source_refresh_on_legacy_match() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir();
         let file = dir.join("banner.txt");
         std::fs::write(&file, super::super::legacy::LEGACY_PRE_1907).unwrap();
 
         let old = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: serialised by ENV_LOCK; env mutation restored before unlock.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe { std::env::set_var("TRUSTY_MPM_BANNER_FILE", &file) };
         let art = load_banner_art();
         let on_disk_after = std::fs::read_to_string(&file).unwrap();
@@ -437,14 +478,14 @@ mod tests {
     /// A banner file whose content does not match any known legacy default
     /// (i.e. the user customised it) must never be touched.
     #[test]
+    #[serial_test::serial]
     fn banner_source_refresh_does_not_touch_custom_content() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir();
         let file = dir.join("banner.txt");
         std::fs::write(&file, "MY CUSTOM ROBOT ART\n").unwrap();
 
         let old = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: serialised by ENV_LOCK; env mutation restored before unlock.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe { std::env::set_var("TRUSTY_MPM_BANNER_FILE", &file) };
         let art = load_banner_art();
         let on_disk_after = std::fs::read_to_string(&file).unwrap();
@@ -471,14 +512,14 @@ mod tests {
     /// (not a known *previous* legacy default, so no rewrite happens — and
     /// none is needed since it already matches).
     #[test]
+    #[serial_test::serial]
     fn banner_source_refresh_is_noop_on_current_default() {
-        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = temp_dir();
         let file = dir.join("banner.txt");
         std::fs::write(&file, DEFAULT_BANNER_ART).unwrap();
 
         let old = std::env::var_os("TRUSTY_MPM_BANNER_FILE");
-        // SAFETY: serialised by ENV_LOCK; env mutation restored before unlock.
+        // SAFETY: serialised by `#[serial_test::serial]`; restored before return.
         unsafe { std::env::set_var("TRUSTY_MPM_BANNER_FILE", &file) };
         let art = load_banner_art();
         unsafe {

--- a/crates/trusty-mpm/src/bin/tm/formatters/banner/source.rs
+++ b/crates/trusty-mpm/src/bin/tm/formatters/banner/source.rs
@@ -189,24 +189,36 @@ pub(crate) fn load_banner_art() -> String {
 mod tests {
     use super::*;
 
-    // #4407: these tests mutate `$HOME`, and so must serialise against EVERY
-    // other `$HOME` mutator in this crate — 46 sites across 44 test fns, all of
-    // which use `#[serial_test::serial]`'s unnamed default group.
+    // #4407: these tests mutate `$HOME`, so they must serialise against every
+    // other `$HOME` mutator IN THIS TEST BINARY — the `tm` bin target. That is
+    // 19 HOME-mutating statements in 8 fns across 4 files: these four banner
+    // tests, `commands::pm_guard_bash::tests`'s TMPDIR/HOME expansion test, and
+    // the `set_home` / `with_fake_home` helpers in `commands::session::
+    // start_tests` and `tests_project_trust_tests` (whose single callers are
+    // each `#[serial]`). All are now in `serial_test`'s unnamed default group.
     //
-    // They previously used a FILE-LOCAL `static ENV_LOCK: Mutex<()>` instead,
+    // The scope that matters is the TEST TARGET, not the crate. `#[serial]`
+    // coordinates threads within one test binary and process-global `$HOME` is
+    // per process, so neither can span targets: the trusty-mpm LIB test binary
+    // has its own, larger population of HOME mutators that these tests never
+    // raced, because it is a different process. An env-isolation audit scoped
+    // per crate over-counts by exactly that much.
+    //
+    // These tests previously used a FILE-LOCAL `static ENV_LOCK: Mutex<()>`,
     // whose comment justified it as "the idiomatic solution without adding the
     // `serial_test` crate". That premise was stale (serial_test is already a
     // dev-dependency, used elsewhere in this very bin target) and the mutex was
-    // ineffective for the job: a file-local lock coordinates these five tests
-    // with each other and with NOTHING ELSE, so they raced every `#[serial]`
-    // HOME mutator in the crate, in both directions — a banner test could
-    // repoint `$HOME` mid-flight under another test, and another test could
-    // repoint it under a banner test's `load_banner_art()`. That is the
-    // shared-global-state shape #4407 describes: unrelated plain-mode tests
-    // reddening together and clearing on the next run with no code change.
+    // ineffective for the job: a file-local lock coordinates these tests with
+    // each other and with NOTHING ELSE, so they raced the same-target writers
+    // above in both directions — a banner test could repoint `$HOME` mid-flight
+    // under another test, and another test could repoint it under a banner
+    // test's `load_banner_art()`. That is the shared-global-state shape #4407
+    // describes: unrelated plain-mode tests reddening together and clearing on
+    // the next run with no code change.
     //
-    // Joining the crate's default `#[serial]` group is what actually excludes
-    // the other writers.
+    // Joining the default `#[serial]` group is what actually excludes the other
+    // writers. Verified by reproducing the race against `pm_guard_bash`'s test
+    // with a widened window and confirming it no longer reproduces.
 
     fn temp_dir() -> std::path::PathBuf {
         let base = std::env::temp_dir().join(format!(

--- a/crates/trusty-mpm/src/telegram/supervisor_tests.rs
+++ b/crates/trusty-mpm/src/telegram/supervisor_tests.rs
@@ -4,10 +4,14 @@
 //! under the 500-SLOC production cap while sharing its private items via
 //! `use super::*`. The tests inject a counting factory so restart, backoff, and
 //! give-up behaviour are verified deterministically with no real Telegram
-//! network. Backoff delays use a millisecond-scale `fast_policy` so the real
-//! sleeps complete near-instantly (no `tokio` `test-util` paused-time feature
-//! is required), and the cancellation test fires shutdown before its long
-//! backoff can elapse.
+//! network. Most backoff delays use a millisecond-scale `fast_policy` so the
+//! real sleeps complete near-instantly, and the cancellation test fires shutdown
+//! before its long backoff can elapse.
+//!
+//! `healthy_run_resets_transient_backoff` is the exception: it asserts an exact
+//! backoff *duration*, which no wall-clock bound can do reliably under load, so
+//! it runs on tokio's paused clock via `start_paused = true`. That is why this
+//! crate's `tokio` dev-dependency enables the `test-util` feature (#4306).
 //! Test: this *is* the test module.
 
 use super::*;
@@ -126,11 +130,11 @@ fn healthy_run_resets_transient_count() {
 /// so under `start_paused` the runtime auto-advances virtual time to each
 /// timer deadline while idle and every gap below is exact and reproducible.
 ///
-/// That exactness lets the assertions get STRICTER, not looser: they now pin
-/// the precise delays (`== delay_for(3)` and `== healthy run + base`) instead
-/// of bounding them. The old `< 20ms` upper bound would have accepted a
-/// regression that reset the counter to `delay_for(2) = 8ms` rather than to
-/// `base = 2ms`; the equality will not.
+/// That exactness lets the assertions get STRICTER, not looser: they now pin the
+/// precise delays against literals (2ms, 8ms, 32ms, and a post-reset 2ms)
+/// instead of bounding them. The old `< 20ms` upper bound would have accepted a
+/// regression that reset the counter to 8ms rather than to base = 2ms; the
+/// equality will not.
 #[tokio::test(start_paused = true)]
 async fn healthy_run_resets_transient_backoff() {
     let policy = BackoffPolicy {
@@ -182,24 +186,27 @@ async fn healthy_run_resets_transient_backoff() {
 
     // Attempts 0-2 exit without awaiting anything, so on the paused clock they
     // consume zero virtual time and each gap is purely the backoff that preceded
-    // it. Pinning all three proves the escalation SCHEDULE, not just that the
-    // last delay was "big" — the previous `>= 25ms` bound could not tell
-    // delay_for(3) from the 400ms cap.
+    // it. The expected delays are LITERALS, not `policy.delay_for(n)` calls: this
+    // test's job is to pin what the supervisor actually waited, and comparing
+    // against the same function that computed the wait would make the assertion
+    // self-referential — a change to `delay_for`'s curve would move the expected
+    // value in lockstep and survive. With base=2ms and factor=4 the schedule is
+    // 2ms, 8ms, 32ms. (`backoff_grows_and_caps` covers the curve itself.)
     assert_eq!(
         starts[1].duration_since(starts[0]),
-        policy.delay_for(1),
-        "first restart must wait exactly base"
+        Duration::from_millis(2),
+        "first restart must wait exactly base = 2ms"
     );
     assert_eq!(
         starts[2].duration_since(starts[1]),
-        policy.delay_for(2),
-        "second restart must wait exactly base*factor"
+        Duration::from_millis(8),
+        "second restart must wait exactly base*factor = 8ms"
     );
     let escalated_gap = starts[3].duration_since(starts[2]);
     assert_eq!(
         escalated_gap,
-        policy.delay_for(3),
-        "pre-reset backoff must be fully escalated to delay_for(3) = base*factor^2"
+        Duration::from_millis(32),
+        "pre-reset backoff must be fully escalated to base*factor^2 = 32ms"
     );
 
     // THE assertion this test exists for. Gap before attempt 4 = the healthy run
@@ -210,11 +217,11 @@ async fn healthy_run_resets_transient_backoff() {
     let post_healthy_total = starts[4].duration_since(starts[3]);
     let backoff_component = post_healthy_total.saturating_sub(healthy_run_duration);
     assert_eq!(
-        backoff_component, policy.base,
-        "post-healthy backoff must reset to exactly base ({:?}); isolated backoff was \
+        backoff_component,
+        Duration::from_millis(2),
+        "post-healthy backoff must reset to exactly base = 2ms; isolated backoff was \
          {backoff_component:?} (total {post_healthy_total:?}, healthy run \
-         {healthy_run_duration:?})",
-        policy.base
+         {healthy_run_duration:?})"
     );
 }
 

--- a/crates/trusty-mpm/src/telegram/supervisor_tests.rs
+++ b/crates/trusty-mpm/src/telegram/supervisor_tests.rs
@@ -104,14 +104,35 @@ fn healthy_run_resets_transient_count() {
     );
 }
 
-#[tokio::test]
+/// End-to-end proof through `supervise`: the bot flaps transiently several
+/// times with near-instant runs (escalating backoff), then runs "healthily"
+/// (longer than `healthy_run`) before exiting transiently once more, then stops
+/// gracefully. We assert on the gap between the start of the post-healthy
+/// restart and its predecessor: after the reset it must be EXACTLY `base`, not
+/// the escalated delay the prior flaps had built up to.
+///
+/// #4306: runs on tokio's PAUSED clock (`start_paused = true`). Previously this
+/// ran on the real clock and asserted `backoff_component < 20ms` against a
+/// policy `base` of 2ms — an 18ms margin that existed purely to absorb
+/// scheduler jitter, so what the assertion actually measured under a loaded
+/// machine was wakeup latency, not backoff state. It reddened the shared gate
+/// three times in one session at 34.4ms and 21.79ms observed, in PRs touching
+/// zero files under `telegram/`.
+///
+/// A paused clock removes the measurement rather than widening the bound (a
+/// wider wall-clock bound is the same defect with a longer fuse). `supervise`
+/// takes every timing decision through `tokio::time` — `Instant::now()` /
+/// `elapsed()` for the run duration and `tokio::time::sleep` for the backoff —
+/// so under `start_paused` the runtime auto-advances virtual time to each
+/// timer deadline while idle and every gap below is exact and reproducible.
+///
+/// That exactness lets the assertions get STRICTER, not looser: they now pin
+/// the precise delays (`== delay_for(3)` and `== healthy run + base`) instead
+/// of bounding them. The old `< 20ms` upper bound would have accepted a
+/// regression that reset the counter to `delay_for(2) = 8ms` rather than to
+/// `base = 2ms`; the equality will not.
+#[tokio::test(start_paused = true)]
 async fn healthy_run_resets_transient_backoff() {
-    // End-to-end proof through `supervise`: the bot flaps transiently several
-    // times with near-instant runs (escalating backoff), then runs "healthily"
-    // (longer than `healthy_run`) before exiting transiently once more, then
-    // stops gracefully. We assert on the OBSERVED gap between the start of the
-    // post-healthy restart and its predecessor: after the reset it must be ~base,
-    // not the escalated/capped delay the prior flaps had built up to.
     let policy = BackoffPolicy {
         base: Duration::from_millis(2),
         factor: 4,
@@ -129,7 +150,12 @@ async fn healthy_run_resets_transient_backoff() {
     let attempts = Arc::new(AtomicUsize::new(0));
     let a = Arc::clone(&attempts);
     let s = Arc::clone(&starts);
-    let healthy_for = policy.healthy_run;
+    // How long attempt 3 runs before exiting transiently: over `healthy_run`, so
+    // it trips the reset. Named (rather than reconstructed at the assertion) so
+    // the exact-equality assertion below subtracts the duration the run ACTUALLY
+    // had. The old code subtracted `policy.healthy_run` instead — 5ms short of
+    // the real run — which the loose `< 20ms` bound hid.
+    let healthy_run_duration = policy.healthy_run + Duration::from_millis(5);
     let factory = move || {
         let a = Arc::clone(&a);
         let s = Arc::clone(&s);
@@ -138,7 +164,7 @@ async fn healthy_run_resets_transient_backoff() {
             s.lock().unwrap().push(tokio::time::Instant::now());
             if n == 3 {
                 // Run long enough to count as healthy, then exit transiently.
-                tokio::time::sleep(healthy_for + Duration::from_millis(5)).await;
+                tokio::time::sleep(healthy_run_duration).await;
                 BotExit::Transient
             } else if n < 3 {
                 BotExit::Transient
@@ -154,24 +180,41 @@ async fn healthy_run_resets_transient_backoff() {
     let starts = starts.lock().unwrap();
     assert_eq!(starts.len(), 5);
 
-    // Gap before attempt 3 (the healthy run's restart) reflects the ESCALATED
-    // backoff after three flaps: delay_for(3) = base*factor^2 = 2ms*16 = 32ms.
+    // Attempts 0-2 exit without awaiting anything, so on the paused clock they
+    // consume zero virtual time and each gap is purely the backoff that preceded
+    // it. Pinning all three proves the escalation SCHEDULE, not just that the
+    // last delay was "big" — the previous `>= 25ms` bound could not tell
+    // delay_for(3) from the 400ms cap.
+    assert_eq!(
+        starts[1].duration_since(starts[0]),
+        policy.delay_for(1),
+        "first restart must wait exactly base"
+    );
+    assert_eq!(
+        starts[2].duration_since(starts[1]),
+        policy.delay_for(2),
+        "second restart must wait exactly base*factor"
+    );
     let escalated_gap = starts[3].duration_since(starts[2]);
-    assert!(
-        escalated_gap >= Duration::from_millis(25),
-        "pre-reset backoff should be escalated (>=~32ms), saw {escalated_gap:?}"
+    assert_eq!(
+        escalated_gap,
+        policy.delay_for(3),
+        "pre-reset backoff must be fully escalated to delay_for(3) = base*factor^2"
     );
 
-    // Gap before attempt 4 = (healthy run duration ~25ms) + (post-reset backoff).
-    // The backoff component must be back at base (~2ms), NOT the prior escalated
-    // delay_for(4)=128ms. We subtract the known healthy run to isolate the backoff
-    // and assert it is small — proving the counter reset to the floor.
+    // THE assertion this test exists for. Gap before attempt 4 = the healthy run
+    // itself + the post-reset backoff. Subtracting the run duration isolates the
+    // backoff, which must be back at EXACTLY `base` — not the escalated
+    // delay_for(4) = 128ms the counter would have reached without a reset, and
+    // not delay_for(2) = 8ms a partial reset would give.
     let post_healthy_total = starts[4].duration_since(starts[3]);
-    let backoff_component = post_healthy_total.saturating_sub(healthy_for);
-    assert!(
-        backoff_component < Duration::from_millis(20),
-        "post-healthy backoff must reset to ~base, isolated backoff was {backoff_component:?} \
-         (total {post_healthy_total:?})"
+    let backoff_component = post_healthy_total.saturating_sub(healthy_run_duration);
+    assert_eq!(
+        backoff_component, policy.base,
+        "post-healthy backoff must reset to exactly base ({:?}); isolated backoff was \
+         {backoff_component:?} (total {post_healthy_total:?}, healthy run \
+         {healthy_run_duration:?})",
+        policy.base
     );
 }
 

--- a/crates/trusty-mpm/src/test_support.rs
+++ b/crates/trusty-mpm/src/test_support.rs
@@ -1,6 +1,13 @@
-//! Hermetic test temp-directory helper (#3382).
+//! Shared hermetic test fixtures: temp directories (#3382) and a
+//! guaranteed-dead loopback address (#4306/#4415).
 //!
-//! Why: bare `tempfile::TempDir::new()` resolves via `std::env::temp_dir()`,
+//! Why (dead loopback): see [`dead_loopback_url`] and [`DEAD_LOOPBACK_PORT`].
+//! It lives here, beside `hermetic_temp_dir`, because it is the same kind of
+//! thing — a fixture whose whole job is to remove an ambient dependency from
+//! the tests that use it — and because three separate copies of it had already
+//! drifted across the `tui` test modules.
+//!
+//! Why (temp dirs): bare `tempfile::TempDir::new()` resolves via `std::env::temp_dir()`,
 //! which honors an inherited `$TMPDIR`. A test-invoking harness/sandbox set
 //! `TMPDIR` to a real project directory (observed: `~/trusty-mpm-projects`),
 //! so every bare `TempDir::new()` call in the suite deposited its mktemp
@@ -31,6 +38,101 @@ use std::sync::Once;
 use std::time::{Duration, SystemTime};
 
 use tempfile::TempDir;
+
+/// The loopback port every dead-daemon test points at (#4306, #4415).
+///
+/// Why this specific port, rather than one the fixture binds for itself: the
+/// fixture needs an address that (a) refuses connections deterministically and
+/// (b) cannot be taken over by any other binder. A privileged loopback port
+/// satisfies both by construction, and — measured on this suite's two targets —
+/// is the only shape that satisfies (a):
+///
+/// * **Refuses, immediately.** Nothing listens, so the kernel answers `RST` →
+///   `ECONNREFUSED`. Measured on macOS: 30/30 connects refused, worst case
+///   132µs. Contrast the obvious-looking alternative of binding a port and
+///   deliberately NOT calling `listen(2)`: that reserves the port, but macOS
+///   silently DROPS the `SYN` instead of resetting it, so the connect times out
+///   (measured: `TimedOut` after a full 10s) rather than being refused — which
+///   would convert every daemon-down test here into a slow one and hand the
+///   error-classification tests a timeout where they assert on a connect error.
+/// * **Unavailable to any other binder.** It is below 1024, so binding it needs
+///   root / `CAP_NET_BIND_SERVICE` (measured: `PermissionDenied` for an
+///   unprivileged bind of both `:1` and `:1023`), and it sits outside every
+///   ephemeral range the OS allocates from (macOS 49152–65535, Linux
+///   `ip_local_port_range` default 32768–60999), so it can never be handed out
+///   as an ephemeral. Port 1 is IANA `tcpmux`, which has no modern
+///   implementation.
+///
+/// What it replaces: three copies of a `dead_loopback_url()` helper
+/// (`tui::project_ctl::poll::tests`, `tui::coordinator::tests`,
+/// `tui::project_ctl::tests`) feeding 13 call sites, each of which obtained a
+/// "known dead" address by binding an ephemeral port and then DROPPING the
+/// listener. Dropping it returns the port to the OS ephemeral pool, so the
+/// premise — "nothing can be listening here" — held only until some other
+/// binder was handed that same port; then the connect SUCCEEDS and the test
+/// asserts against a live socket (`classify_connect_error_is_transport`'s
+/// `expect_err` panics, or the request fails at the HTTP layer and
+/// misclassifies as `NonTransport`). #4415 observed exactly that failure.
+/// Measured on macOS: a bind-and-drop port was reassigned to a competing
+/// binder — and accepted a connection — after 16,103 ephemeral binds, i.e. one
+/// wrap of the 49152–65535 range, which a full suite's port churn reaches.
+const DEAD_LOOPBACK_PORT: u16 = 1;
+
+/// Pin "privileged" at COMPILE time — it is a property of the constant, not of
+/// any particular run, so a future edit that moves the port above 1024 (into
+/// bindable, and eventually ephemeral, territory) must fail the build rather
+/// than wait for a test to notice. Also what keeps
+/// [`tests::dead_loopback_port_is_not_bindable_or_ephemeral`] free of a
+/// `clippy::assertions_on_constants` lint.
+const _: () = assert!(
+    DEAD_LOOPBACK_PORT < 1024,
+    "DEAD_LOOPBACK_PORT must stay below 1024 so binding it requires root and the \
+     OS never hands it out as an ephemeral port (#4306/#4415)"
+);
+
+/// Verifies [`DEAD_LOOPBACK_PORT`]'s premise once per test process.
+static DEAD_PORT_VERIFIED: Once = Once::new();
+
+/// A `127.0.0.1` URL guaranteed to refuse every connection — the ONE
+/// dead-address fixture for this crate (#4306, #4415).
+///
+/// Why: see [`DEAD_LOOPBACK_PORT`] for the full argument and the measurements.
+/// What: returns `http://127.0.0.1:1`, having first confirmed (once per test
+/// process) that the address really does refuse. That check turns the fixture's
+/// one environmental assumption — "no process on this machine listens on
+/// loopback port 1" — into an immediate, named failure instead of a confusing
+/// downstream one: a `expect_err` panic or a `Transport`/`NonTransport`
+/// misclassification several frames away, which is precisely the debugging
+/// experience #4415 describes as training people to re-run rather than
+/// investigate.
+/// Test: [`tests::dead_loopback_url_refuses_every_connect`] and
+/// [`tests::dead_loopback_port_is_not_bindable_or_ephemeral`] pin the two
+/// properties, so the guarantee is verified rather than merely documented.
+pub(crate) fn dead_loopback_url() -> String {
+    DEAD_PORT_VERIFIED.call_once(|| {
+        let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, DEAD_LOOPBACK_PORT));
+        // A generous timeout: it bounds a pathological environment, it does not
+        // define the expectation. The assertion is on the error KIND, so a
+        // machine that refuses slowly still passes and one that accepts (or
+        // silently drops) fails loudly, naming the remedy.
+        match std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(10)) {
+            Ok(_) => panic!(
+                "test_support::dead_loopback_url(): something is LISTENING on {addr}, so the \
+                 dead-address fixture's premise is void (#4306/#4415). Stop that listener, or \
+                 pick another privileged, non-ephemeral loopback port for DEAD_LOOPBACK_PORT."
+            ),
+            Err(e) if e.kind() == std::io::ErrorKind::ConnectionRefused => {}
+            Err(e) => panic!(
+                "test_support::dead_loopback_url(): {addr} neither accepted nor REFUSED the \
+                 connect — it failed with {:?} ({e}) (#4306/#4415). The fixture requires a \
+                 prompt ECONNREFUSED; a dropped SYN (TimedOut) would make every daemon-down \
+                 test slow and would hand the error-classification tests the wrong error kind.",
+                e.kind()
+            ),
+        }
+    });
+    format!("http://127.0.0.1:{DEAD_LOOPBACK_PORT}")
+}
 
 /// Prefix every hermetic test temp directory carries.
 ///
@@ -353,6 +455,70 @@ mod tests {
         let _ = std::fs::remove_dir_all(&fresh);
         let _ = std::fs::remove_dir_all(&unrelated);
         let _ = std::fs::remove_dir_all(&stale);
+    }
+
+    /// #4306/#4415 property 1 of 2: the address must answer `ECONNREFUSED`,
+    /// and must do so on EVERY attempt.
+    ///
+    /// Deliberately asserts the error KIND, not merely that the connect failed.
+    /// That distinction is load-bearing and was not academic: the first attempt
+    /// at this fixture reserved a port by binding it without `listen(2)`, which
+    /// looked correct and which a "did it fail?" assertion would have passed —
+    /// macOS silently drops the `SYN` there, so connects TIME OUT rather than
+    /// being refused. `classify_connect_error_is_transport` would still have
+    /// gone green (reqwest maps both to `Transport`) while every daemon-down
+    /// test quietly became a multi-second one. Asserting the kind is what
+    /// caught it.
+    #[test]
+    fn dead_loopback_url_refuses_every_connect() {
+        let addr: std::net::SocketAddr = dead_loopback_url()
+            .trim_start_matches("http://")
+            .parse()
+            .expect("the fixture's url must be host:port after the scheme");
+
+        for attempt in 0..50 {
+            let err = std::net::TcpStream::connect_timeout(&addr, Duration::from_secs(10))
+                .expect_err("nothing may be listening on the dead-address port");
+            assert_eq!(
+                err.kind(),
+                std::io::ErrorKind::ConnectionRefused,
+                "attempt {attempt} to {addr} must be REFUSED (RST), not dropped: {err:?}"
+            );
+        }
+    }
+
+    /// #4306/#4415 property 2 of 2: the port must be unavailable to any other
+    /// binder. This is the half the old bind-and-drop fixture lacked, and the
+    /// direct cause of the observed flake — so it is asserted, not assumed.
+    ///
+    /// Two independent guarantees, checked separately because either one alone
+    /// would be enough to break if a future edit moved `DEAD_LOOPBACK_PORT`
+    /// into the ephemeral range or above 1024.
+    #[test]
+    fn dead_loopback_port_is_not_bindable_or_ephemeral() {
+        // (a) Privileged: an unprivileged bind must be refused outright, so no
+        //     test — nor any other unprivileged process — can start listening.
+        // "privileged" itself is pinned at compile time next to the constant.
+        let addr = std::net::SocketAddr::from((std::net::Ipv4Addr::LOCALHOST, DEAD_LOOPBACK_PORT));
+        assert!(
+            std::net::TcpListener::bind(addr).is_err(),
+            "an unprivileged bind of {addr} must fail — a bindable dead-address port is \
+             exactly the invalidated premise #4306 describes"
+        );
+
+        // (b) Never ephemeral: the OS must not hand this port to a competing
+        //     binder. 2,000 binds is a cheap sanity sweep rather than a proof
+        //     (the proof is that the port is below every ephemeral range); it
+        //     exists to catch a future edit that moves the constant.
+        for _ in 0..2_000 {
+            if let Ok(other) = std::net::TcpListener::bind("127.0.0.1:0") {
+                assert_ne!(
+                    other.local_addr().expect("local addr").port(),
+                    DEAD_LOOPBACK_PORT,
+                    "the OS handed a competing binder the dead-address port"
+                );
+            }
+        }
     }
 
     /// Guards against `UNIX_EPOCH` underflow bugs in age math (belt-and-braces).

--- a/crates/trusty-mpm/src/tui/coordinator/tests.rs
+++ b/crates/trusty-mpm/src/tui/coordinator/tests.rs
@@ -798,23 +798,12 @@ fn catalog_indicator_reflects_staleness() {
 
 // ---- Child #2: live polling — daemon-down branch (async) ------------------
 
-/// Reserve, then immediately release, a loopback port so a client pointed at it
-/// is guaranteed to be refused (nothing is listening).
-///
-/// Why: the daemon-down test needs a `DaemonClient` whose probe deterministically
-/// fails. Binding `127.0.0.1:0` lets the OS hand us a free port; dropping the
-/// listener frees it again, so a connect to it is refused rather than hanging on
-/// an open-but-silent socket.
-/// What: binds an ephemeral TCP listener, reads its local addr, drops it, and
-/// returns `http://127.0.0.1:<port>`.
-/// Test: consumed by `poll_marks_unreachable_clears_sessions`.
-fn dead_loopback_url() -> String {
-    let listener =
-        std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
-    let port = listener.local_addr().expect("read bound local addr").port();
-    drop(listener); // release the port so a later connect is refused
-    format!("http://127.0.0.1:{port}")
-}
+// #4306/#4415: the dead-address fixture used to be a local bind-an-ephemeral-
+// port-then-drop-it helper, whose "nothing can be listening here" premise
+// expired the moment the OS re-handed that port to another binder. All three
+// former copies now share ONE fixture whose guarantee does not depend on
+// winning a port race — see `crate::test_support::dead_loopback_url`.
+use crate::test_support::dead_loopback_url;
 
 #[tokio::test]
 async fn poll_marks_unreachable_clears_sessions() {

--- a/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/poll/tests.rs
@@ -49,16 +49,12 @@ fn summary(id: &str, state: &str) -> ManagedSessionSummary {
 
 // ---- daemon-down branches (guaranteed-dead client, no live daemon needed) ---
 
-/// A `127.0.0.1` URL bound to an ephemeral port, then immediately dropped
-/// so a later connect is refused — mirrors
-/// `tui::coordinator::tests::dead_loopback_url`.
-fn dead_loopback_url() -> String {
-    let listener =
-        std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
-    let port = listener.local_addr().expect("read bound local addr").port();
-    drop(listener);
-    format!("http://127.0.0.1:{port}")
-}
+// #4306/#4415: the dead-address fixture used to be a local bind-an-ephemeral-
+// port-then-drop-it helper, whose "nothing can be listening here" premise
+// expired the moment the OS re-handed that port to another binder. All three
+// former copies now share ONE fixture whose guarantee does not depend on
+// winning a port race — see `crate::test_support::dead_loopback_url`.
+use crate::test_support::dead_loopback_url;
 
 #[tokio::test]
 async fn poll_marks_unreachable_clears_state() {

--- a/crates/trusty-mpm/src/tui/project_ctl/tests.rs
+++ b/crates/trusty-mpm/src/tui/project_ctl/tests.rs
@@ -174,16 +174,12 @@ fn action_bar_reflects_daemon_reachability_by_default() {
     assert!(actions_bar::bar_text(&state).contains(actions_bar::DAEMON_UNREACHABLE));
 }
 
-/// A `127.0.0.1` URL bound to an ephemeral port, then immediately dropped so
-/// a later connect is refused — mirrors
-/// `tui::coordinator::tests::dead_loopback_url` / `poll::tests::dead_loopback_url`.
-fn dead_loopback_url() -> String {
-    let listener =
-        std::net::TcpListener::bind("127.0.0.1:0").expect("bind ephemeral loopback port");
-    let port = listener.local_addr().expect("read bound local addr").port();
-    drop(listener);
-    format!("http://127.0.0.1:{port}")
-}
+// #4306/#4415: the dead-address fixture used to be a local bind-an-ephemeral-
+// port-then-drop-it helper, whose "nothing can be listening here" premise
+// expired the moment the OS re-handed that port to another binder. All three
+// former copies now share ONE fixture whose guarantee does not depend on
+// winning a port race — see `crate::test_support::dead_loopback_url`.
+use crate::test_support::dead_loopback_url;
 
 /// A daemon poll racing with an open confirmation gate must never reassign or
 /// clear it (DOC-35 §5.2) — the gate pins its target session id at the moment

--- a/scripts/assemble-changelog.sh
+++ b/scripts/assemble-changelog.sh
@@ -138,7 +138,15 @@ parse_fragment() {
   fi
 
   body="$(fragment_body "${path}")"
-  if ! printf '%s\n' "${body}" | grep -qE '^-[[:space:]]'; then
+  # Herestring, NOT `printf ... | grep -q`. Under `set -o pipefail` that pipeline
+  # is a SIGPIPE race: `grep -q` exits the instant it matches, and when the body
+  # is larger than the pipe buffer the still-writing `printf` takes EPIPE. With
+  # pipefail the pipeline then reports that failure, so a fragment whose FIRST
+  # body line is a bullet — the common shape — is rejected as having none. It
+  # bit `trusty-agents/changelog.d/4476-migrated-added.md` (60 KB, bullet on
+  # line 1) on Linux CI while passing on macOS, which is exactly the
+  # platform-dependent flake this gate exists to prevent.
+  if ! grep -qE '^-[[:space:]]' <<<"${body}"; then
     echo "ERROR: ${base} has a category but no bullet — expected at least one" >&2
     echo "       line starting with '- ' after the category line." >&2
     return 1


### PR DESCRIPTION
Five filed flakes in the hermetic-test-isolation family (#3451), plus one
unfiled instance of the same class found while investigating #4407. Every fix
removes a dependence on shared state or wall-clock timing. None removes
coverage: no `#[ignore]`, no cfg-gate, no deleted test, no loosened bound —
trusty-mpm's lib suite goes from 4033 to **4035** passing tests, and two
assertions got strictly stricter.

## Per test: root cause, fix, A/B

### #4306(2) + #4415 — `dead_loopback_url` raced ephemeral-port reuse

Three copies of the fixture (`tui::project_ctl::poll::tests`,
`tui::coordinator::tests`, `tui::project_ctl::tests`) feeding **13 call sites**
obtained a "dead" address by binding an ephemeral port and dropping the
listener. That returns the port to the OS pool, so the premise held only until
another binder got it — then the connect succeeds and
`classify_connect_error_is_transport`'s `expect_err` panics, or the request
fails at the HTTP layer and misclassifies as `NonTransport`.

**A/B — the premise, measured directly** rather than waiting for the ~1-in-many
failure:

| fixture | port reassigned to a competing binder? |
|---|---|
| old (bind-and-drop) | **yes — accepted a connection after 16,103 ephemeral binds** (one wrap of macOS 49152–65535) |
| new (`127.0.0.1:1`) | no; explicit rebind rejected `EADDRINUSE`-style, 0/30,000 churned binds |

All three copies now share one fixture on `127.0.0.1:1` — privileged (measured:
unprivileged bind → `PermissionDenied`) and outside every ephemeral range, so it
cannot be handed out. This is **already the workspace convention**: trusty-review
says verbatim *"127.0.0.1:1 is always refused (port 1 is reserved/privileged)"*,
and trusty-analyze uses it too.

**A rejected design worth recording.** The obvious fix — bind a port and
deliberately skip `listen(2)`, so you both reserve it and get an RST — is
wrong on macOS: the kernel silently **drops** the SYN instead of resetting it,
so connects time out (measured: `TimedOut` after a full 10s). That would have
gone green (reqwest maps both refusal and timeout to `Transport`) while making
13 tests multi-second and handing the classification tests the wrong error kind.
It was caught only because the new self-test asserts the error **kind**, not
merely that the connect failed. Both properties are now pinned by tests, and a
`const` assertion stops a future edit moving the port above 1024.

### #4306(1) — telegram backoff reset asserted on wall-clock time

`healthy_run_resets_transient_backoff` asserted `backoff_component < 20ms`
against a policy `base` of **2ms**. The 18ms of headroom existed purely to
absorb scheduler jitter, so on a loaded machine the assertion measured wakeup
latency, not backoff state — reddening the gate three times in one session at
34.4ms and 21.79ms, in PRs touching zero files under `telegram/`.

Now runs on tokio's paused clock. `supervise` routes all timing through
`tokio::time`, so virtual time advances to each deadline and every gap is exact.
Widening the bound was rejected: same defect, longer fuse.

**The assertions got stricter, not looser** — two bounds became equalities
(`== delay_for(3)`, `== base`) and two new assertions pin the earlier escalation
steps. Verified by mutation, since a paused clock can make a test vacuous:

| mutation to `next_transient_count` | new assertion | old `< 20ms` bound |
|---|---|---|
| reset removed entirely | **FAILS** (128ms vs 2ms) | would fail |
| reset to `1` instead of `0` → `delay_for(2)` = 8ms | **FAILS** (8ms vs 2ms) | **would PASS** — regression missed |

Also fixed arithmetic the loose bound hid: it subtracted `policy.healthy_run`
where the run actually lasted `healthy_run + 5ms`.

**#4306 acceptance — 20 consecutive full-parallelism runs** of the whole lib
suite (4035 tests), on a machine under 12–86 load average from concurrent
agents. Both target tests: **20/20**.

### #4414 — `uv` read `$HOME` while 161 statements reassigned it

`uv` resolves its cache from `$HOME` at spawn. Captured output shows the real
sequence: a sibling test set `HOME=<tempdir>`, uv derived its cache path from
it, and the sibling's `TempDir` was **dropped mid-flight**:

```
Caused by: No such file or directory (os error 2) at path
  ".../T/.tmpHR50aj/.cache/uv/.tmptfs807"
ModuleNotFoundError: No module named 'python'
```

Both uv-spawning tests now hold `test_env::HOME_LOCK`. Verified exhaustive
before relying on it: **all 161** HOME-mutating statements in the crate — 116
`set_var` + 45 `remove_var`, across 72 test fns — sit inside a function holding
that lock, so holding it excludes every writer.

| | failures |
|---|---|
| `main`, 5 full-suite runs (load 34–72) | **3 / 5** |
| branch, 5 full-suite runs (load 12–20) | **0 / 5** |
| controlled interleaved, identical synthetic load (19–50) | base **1 / 5** → branch **0 / 5** |

The interleaved run exists because the ambient load dropped between the two
uncontrolled measurements, which would otherwise confound them. Combined:
**4/10 → 0/10**.

### #4413 — trusty-memory tests inherited another test's env var

`add_alias_round_trip_through_prompt_cache` and
`dispatch_discover_aliases_inserts_new_and_dedupes` build `AppState` inline
(they need `with_default_palace`, which `test_state()` does not offer) and so
never ran its `TRUSTY_SKIP_PALACE_ENFORCEMENT` write. They passed under
`cargo test` only because a sibling had set it first — and **in isolation they
verified nothing**, panicking at `palace_create` before any assertion.

Both now call a named `skip_palace_enforcement()` helper, which
`test_state`/`test_state_warming` share (replacing three copies of the same
`unsafe { set_var }` with one `OnceLock`-guarded write).

`cargo nextest run -p trusty-memory --no-fail-fast`: **2 failures → 527/527
passing** (2 failures reproduced twice before the fix).

### #4407 — `inference_available_false_without_key` read the ambient shell

The test asserts the gate stays closed with nothing configured, but
`inference_available("", false)` falls back to `OPENROUTER_API_KEY` in the
process env. Its `#[serial]` group excluded concurrent *test* writers while
doing nothing about the environment the suite inherits, so it failed for anyone
with a real key exported. Reproduced deterministically on `main`:

```
OPENROUTER_API_KEY=sk-... cargo test -p trusty-common --features memory-core \
  --lib semantic_consolidation
---- inference_available_false_without_key ----
assertion failed: !inference_available("", false)
```

Now **clears** the variable for its body (`EnvVarGuard::clear`, restored on
drop). Not a weakening — it makes the test verify what it always claimed, which
on a machine with the key set it could not verify at all. Also forces the
`.env.local` loader first so that process-global `OnceLock` cannot repopulate
the variable mid-assertion (the #3464 mechanism). Verified passing **both** with
and without the variable set.

### #4407 (new, unfiled) — banner tests used a lock that coordinated with nothing

Found while auditing for shared global state. The plain-mode banner tests
serialised themselves with a **file-local** `static ENV_LOCK: Mutex<()>`,
justified as *"the idiomatic solution without adding the serial_test crate"* —
a stale premise (serial_test is already a dev-dependency, used in this same bin
target) and ineffective for the job: a file-local mutex coordinates those tests
with each other and nothing else, while the other `$HOME` mutators **in the same
test binary** ran free against them — 19 HOME-mutating statements in 8 fns across
4 files in the `tm` bin target. They raced those, both directions. That is the shape #4407 describes — unrelated plain-mode tests
reddening together and clearing with no code change.

All nine env-mutating tests now use `#[serial_test::serial]`; the local mutex is
gone. Also fixes a hermeticity bug it hid: `banner_source_missing_falls_back`
exercises the `NotFound` arm, which **writes** `$HOME/.trusty-mpm/banner.txt` —
with the ambient `$HOME` that seeded a real file in the developer's home
(confirmed present locally) and could land in a concurrent test's tempdir. It
now sandboxes `$HOME` and asserts the seeded content, so the side effect is
covered rather than tolerated.

## What is NOT resolved — #4407's 7-test cluster

**The specific run #4407 cites is not in the retrievable Actions history**, so I
could not root-cause that cluster and am deliberately not claiming it. The only
two `CI`/`Test` failures on `main` across 2026-07-24…29 were run `30214415477`
(07-26) and `30177354047` (07-25) — both **single**-test failures, both of
`core::session_launch::…::prepare_session_excludes_spoofed_trusty_search_when_injector_disabled`,
not a 7-test cluster. Either the cited run was a PR run rather than `main`, or
the date/time in the issue is imprecise.

What I did instead was attack the *class*: audit `$HOME` mutators for
serialization gaps (found the banner defect above), run trusty-memory under
per-test process isolation, and fix the one named ambient-env test. `Refs`, not
`Closes`, for #4407.

## Two further load-sensitive flakes found, not fixed here

Both are genuinely separable — different crates, different mechanism from the
five filed issues, and each needs its own fix. Recommend filing:

1. **`connectors::tm::tests::create_session_full_lifecycle`** (trusty-mpm).
   Clean in acceptance runs 1–16 (load ≤ 50), failed runs 17–20 at load 74–86.
   Zero diff lines in `crates/trusty-mpm/src/connectors/`, and it does not use
   the fixture this PR changed.
2. **`trusty-agents/tests/api_e2e.rs`** — `support/api_server.rs:94` waits
   `Duration::from_secs(5)` for a freshly spawned binary to become healthy. Red
   3/3 in isolation at load 22–38 on this machine; CI (idle runner) is green.
   Same anti-pattern as the telegram bound: a wall-clock budget sized for an
   idle machine. My trusty-agents change is entirely inside `#[cfg(test)] mod
   tests` in the library and is not compiled into that binary.

## Gates

| gate | result |
|---|---|
| `cargo test -p trusty-mpm` (full, not `--lib`) | **exit 0** |
| `cargo test -p trusty-memory` | **exit 0** — 527 passed, 0 failed |
| `cargo test -p trusty-common --features memory-core` | **exit 0** — 656 passed, 0 failed |
| `cargo test -p trusty-agents --lib` | **exit 0** — 3110 passed, 0 failed |
| `cargo nextest run -p trusty-memory --no-fail-fast` | 527/527 |
| `cargo clippy --workspace --all-targets` (CI's exclusions) | **exit 0** |
| `cargo fmt --check` | **exit 0** |
| `check_line_cap.sh` / `check_sld.sh` / `check_test_pointers.sh` / `check_doc_numbers.sh` | **exit 0** |

`cargo test -p trusty-agents` (full) is red on my machine **only** via the
pre-existing `api_e2e` 5s budget above; `--lib`, which contains every line I
changed, is green.

Closes #4413
Closes #4414
Closes #4415
Closes #4306
Refs #4407
Refs #3451


---

## Round 2 — code-critic WARN addressed (1 HIGH, 2 MEDIUM, 2 LOW)

Verdict: https://github.com/bobmatnyc/trusty-tools/pull/4482#issuecomment-5146724603

**HIGH — my banner fix did not close the race it claimed to.** `pm_guard_bash`'s
`evaluate_worktree_add_command_expands_tmpdir_and_home` sets `HOME`/`TMPDIR` in
the same `tm` bin test binary with no `#[serial]` and no lock, so moving the
banner tests into the serial group never excluded it. Worse, my new assertion is
what made it bite: the old test used the ambient `$HOME` and asserted nothing
about the seeded file, so a concurrent `HOME=/Users/x` was invisible.

Reproduced first, window widened with sleeps, then re-run under the *same*
widened window after the fix. Because two things changed, an isolation matrix:

| `#[serial]` | `EnvGuard` | result (widened window, 2 threads) |
|---|---|---|
| absent | absent | **FAILED** — `left: None` |
| absent | present | **FAILED** — `left: None` |
| present | present | **5/5 ok** |

So `#[serial]` closes the race; the `EnvGuard` fixes a *separate* defect — the
test leaked `HOME=/Users/x` into the rest of the binary, and its trailing
`remove_var("TMPDIR")` cleared an inherited variable rather than restoring it,
and was skipped outright on an assertion panic.

**MEDIUM 1 — my scope claim was wrong and had shipped in the CHANGELOG.** "46
other `$HOME` mutators in the crate" counted the trusty-mpm **lib** test binary,
a different process. Neither `#[serial]` (threads within one binary) nor
process-global `$HOME` can span test targets. Re-audited per target: **19
HOME-mutating statements in 8 fns across 4 files** in the `tm` bin target — the
four banner tests, the `pm_guard_bash` test above, and the `set_home` /
`with_fake_home` helpers, whose single callers are each already `#[serial]`.
Corrected in `source.rs` and the CHANGELOG. The generalizable rule, now written
into both: **env-isolation audits are scoped per TEST TARGET, not per crate.**

**MEDIUM 2** — the `supervisor_tests.rs` module header still claimed no `tokio`
`test-util` paused-time feature was required, the opposite of what this PR does.
Reconciled with the Cargo.toml comment.

**LOW 1 — my three new equalities were self-referential.** They compared the
observed gap to `policy.delay_for(n)`, the same function that computed the wait,
so the critic's mutation sweep found two survivors. Now pinned to literals
(2ms, 8ms, 32ms, post-reset 2ms). Both survivors now die:

| mutation | before | after |
|---|---|---|
| `delay_for` multiplier `factor` → `factor + 1` | survives | **FAILED** |
| `delay_for` collapsed to `self.base` | survives | **FAILED** |

That takes this test from **5 of 8** enumerated mutations killed to **7 of 8**
(the last is a healthy-run threshold boundary a sibling test owns by design).

**LOW 2 — site count.** I wrote 115; the critic corrected to 159; both are wrong.
Re-measured two independent ways, agreeing exactly: 116 `set_var("HOME")` + 45
`remove_var("HOME")` = **161** statements across 72 fns, no overlap. 116+45 is
161, not 159. Only the number was wrong — the coverage claim it supports still
holds.

### Round-2 gates (rebased onto current `main`, was BEHIND)

| gate | result |
|---|---|
| `cargo test -p trusty-mpm` (full) | exit 0 |
| — lib target | 4043 passed, 0 failed |
| — `tm` bin target | 1319 passed, 0 failed |
| `cargo test -p trusty-memory` | exit 0 |
| `cargo test -p trusty-common --features memory-core` | exit 0 — 635 passed |
| `cargo test -p trusty-agents --lib` | exit 0 — 3111 passed |
| `cargo clippy --workspace --all-targets` (CI's 3 GUI exclusions) | exit 0 |
| `cargo fmt --all --check` | exit 0 |
| `check_line_cap` / `check_sld` / `check_test_pointers` / `check_doc_numbers` | all 0 |

Not touched, per the verdict: the paused-clock conversion (independently
verified), and everything in the critic's Verified-CLEAN list.


---

## Round 3 — rebased onto the per-PR changelog-fragment convention (#4476)

[#4477](https://github.com/bobmatnyc/trusty-tools/pull/4477) landed while this
PR was open. It replaced the shared `## [Unreleased]` section with per-PR
fragment files and migrated all 25 crates, so the headings my changelog edits
targeted no longer exist on `main`.

Each of the four bullets moved verbatim into its own crate's `changelog.d/`:

| crate | fragment |
|---|---|
| trusty-mpm | `changelog.d/4306-hermetic-test-fixtures.md` |
| trusty-memory | `changelog.d/4413-palace-tests-set-own-env.md` |
| trusty-agents | `changelog.d/4414-uv-home-lock.md` |
| trusty-common | `changelog.d/4407-inference-gate-clears-key.md` |

No `## [Unreleased]` heading is reintroduced anywhere — the assembler hard-fails
on a leftover one, which would break that crate's release path. All four
`CHANGELOG.md` files are byte-identical to `main`.

Two corrections carried in while moving the text: the trusty-mpm entry's "46
other `$HOME` mutators in the crate" became the correct same-target figure (19
statements, 8 fns, 4 files in the `tm` bin target) plus the general rule, and its
lead line said "three" fixtures when it is four.

Verified with the gate CI actually runs and with the real assembler:

```
$ CHANGELOG_GATE_BASE=$(git rev-parse origin/main) bash scripts/check_changelog_fragment.sh
OK   trusty-agents: changelog.d fragment present and valid
OK   trusty-common: changelog.d fragment present and valid
OK   trusty-mpm: changelog.d fragment present and valid
changelog-fragment gate: all crates with source changes are recorded.
exit 0
```

(`trusty-memory` is not listed because its only change is `src/tools/tests.rs`,
which the gate exempts as test-only; its fragment is recorded anyway.)

`assemble-changelog.sh <crate> 9.9.9 --check` and `<crate> --stdout` both exit 0
for all four crates, and each preview contains that crate's new bullet.


### One extra fix, forced by the migration: the assembler rejected a large fragment

Adding the fragments turned the `Per-PR changelog fragment` job red — against a
fragment **this PR did not write**. `parse_fragment` validated "does this contain
a bullet" with `printf '%s\n' "$body" | grep -qE '^-[[:space:]]'` under
`set -o pipefail`. That is a SIGPIPE race: `grep -q` exits the instant it
matches, and when the body exceeds the pipe buffer the still-writing `printf`
takes EPIPE, which `pipefail` promotes to a pipeline failure — so a fragment
whose *first* body line is a bullet is reported as having none.

```
scripts/assemble-changelog.sh: line 141: printf: write error: Broken pipe
ERROR: 4476-migrated-added.md has a category but no bullet
```

Size- and platform-dependent, which is why it survived review:
`trusty-agents/changelog.d/4476-migrated-added.md` is 60 KB with the bullet on
line 1 — it passes on macOS and fails on Linux CI. Fixed with a herestring (no
second process, so no pipe to break). The old construct false-negatives on a
200 KB body; the new one finds the bullet 10/10. All 25 crates' fragment
directories are accepted, and the gate reports OK for every crate.

### Other hermeticity litter observed, not fixed

`cargo test -p trusty-mpm` scaffolds `crates/trusty-mpm/{.claude/,.trusty-mpm/,CLAUDE.md}`
into the working tree — untracked, not gitignored. Same family as the
`crates/trusty-memory/.trusty-tools/` file the critic noted, and same family as
#3451. My diff touches no session-scaffolding code, so this is not from this PR;
I have not A/B-verified it against `main`. Worth its own ticket.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools



