### PR TITLE
feat(trusty-common): port Bedrock ConverseStream into inference::bedrock (#4426)

### DIFF
--- a/crates/trusty-code/src/llm/bedrock.rs
+++ b/crates/trusty-code/src/llm/bedrock.rs
@@ -22,12 +22,11 @@
 //! removal would otherwise be undocumented/silent).
 //!
 //! Streaming (#4425/#4426): [`Self::chat_stream`] forwards to the shared
-//! adapter's, which today is the trait's buffered fallback — a Bedrock turn
-//! therefore arrives as one delta plus the terminal event, exactly as it did
-//! before streaming existed. Giving it a real `ConverseStream` transport is
-//! #4426, and because this wrapper delegates rather than reimplements, that
-//! change lands entirely inside `trusty_common::inference::bedrock` with no
-//! edit here.
+//! adapter's, which since #4426 is a NATIVE `ConverseStream` transport — a
+//! Bedrock turn arrives token-by-token, not as one buffered delta. This
+//! wrapper needed no edit for that (only this doc line): because it delegates
+//! rather than reimplements, the whole change landed inside
+//! `trusty_common::inference::bedrock`.
 //! Test: `bedrock::tests::*` (offline construction) plus the shared adapter's own
 //! conversion + `#[ignore]`-gated live coverage in
 //! `trusty_common::inference::bedrock`.

--- a/crates/trusty-common/CHANGELOG.md
+++ b/crates/trusty-common/CHANGELOG.md
@@ -9,6 +9,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- **`inference::bedrock` streams natively via `ConverseStream` (issue #4426).**
+  `BedrockAdapter` now overrides `InferenceAdapter::chat_stream` with AWS's
+  real streaming operation instead of inheriting the trait's buffered fallback,
+  so a `bedrock/*` turn arrives token-by-token rather than as one delta emitted
+  after the model already finished. The event handling is ported from the
+  implementation proven in production on `chat::bedrock_impl` (#3767) and
+  extended: `ContentBlockDelta::Text` → `ChatStreamEvent::Delta`, tool-use
+  block starts and partial-JSON argument fragments → `ChatStreamEvent::ToolCall`
+  (which the `chat::ChatProvider` path never supported), `MessageStop` +
+  `Metadata` folded into the single terminal `Done` carrying the finish reason
+  and token tally, and a mid-stream failure surfacing as a terminal `Err` and
+  never as a `Done`. Both transports build their request from ONE shared
+  conversion (`build_converse_parts`), so streamed and buffered turns cannot
+  disagree about messages, sampling, tool config, or the reported
+  `finish_reason`. Consumers that delegate `chat_stream` to the shared adapter —
+  trusty-code's `BedrockChatClient` — get this with no change of their own.
 - **`inference::streaming::StreamAssembly` — rebuild a `ChatResponse` from
   streamed events (issue #4425).** The inverse of the existing
   `buffered_stream`: push `ChatStreamEvent`s in arrival order, then

--- a/crates/trusty-common/src/inference/bedrock/mod.rs
+++ b/crates/trusty-common/src/inference/bedrock/mod.rs
@@ -13,28 +13,37 @@
 //! What: [`BedrockAdapter`] wraps a lazily-constructed
 //! `aws_sdk_bedrockruntime::Client` (so a `Configurator` that merely registers
 //! the factory never touches AWS credentials — #2245) and implements
-//! [`InferenceAdapter`]: `chat` converts the request via
-//! [`convert::build_converse_messages`]/[`convert::build_tool_config`], calls
-//! `Converse` (non-streaming), maps SDK errors to [`InferenceError::Provider`],
-//! and converts the response back via [`convert::converse_output_to_chat_response`];
-//! `map_tool_choice` emits Converse's own tool-choice JSON shape. Region resolves
-//! `TRUSTY_AWS_REGION` > `AWS_REGION` > `us-east-1`; credentials come from the
-//! standard AWS credential chain (env, `~/.aws/credentials`, IMDS, SSO — so
-//! `AWS_PROFILE=cto` works with zero code changes). [`register_bedrock_factory`]
-//! wires the adapter into a [`Configurator`] under [`ProviderId::Bedrock`].
+//! [`InferenceAdapter`]: `chat` converts the request via [`build_converse_parts`]
+//! (which funnels [`convert::build_converse_messages`]/
+//! [`convert::build_tool_config`]), calls the unary `Converse` operation, maps
+//! SDK errors to [`InferenceError::Provider`], and converts the response back via
+//! [`convert::converse_output_to_chat_response`]; `chat_stream` (#4426) sends the
+//! SAME converted request to `ConverseStream` instead and maps its binary
+//! event-stream framing into the neutral [`ChatStream`] via [`stream`], so a
+//! `bedrock/*` turn streams token-by-token rather than falling back to the
+//! trait's buffered default; `map_tool_choice` emits Converse's own tool-choice
+//! JSON shape. Region resolves `TRUSTY_AWS_REGION` > `AWS_REGION` > `us-east-1`;
+//! credentials come from the standard AWS credential chain (env,
+//! `~/.aws/credentials`, IMDS, SSO — so `AWS_PROFILE=cto` works with zero code
+//! changes). [`register_bedrock_factory`] wires the adapter into a
+//! [`Configurator`] under [`ProviderId::Bedrock`].
 //! Test: `super::tests::*` (region resolution, message/tool-choice/response
-//! conversion — all offline, no real AWS) plus an `#[ignore]`-gated live
-//! Converse call; the configurator wiring is covered by
-//! `crates/trusty-common/tests/inference_bedrock.rs`.
+//! conversion, and the `stream_*` suite driving the real streaming path against
+//! a scripted `ConverseStream` event sequence — all offline, no real AWS) plus
+//! `#[ignore]`-gated live `Converse` and `ConverseStream` calls; the configurator
+//! wiring is covered by `crates/trusty-common/tests/inference_bedrock.rs`.
 
 pub(crate) mod cache;
 pub(crate) mod convert;
+pub(crate) mod stream;
 
 use async_trait::async_trait;
 use aws_config::BehaviorVersion;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_bedrockruntime::Client as BedrockRuntimeClient;
-use aws_sdk_bedrockruntime::types::InferenceConfiguration;
+use aws_sdk_bedrockruntime::types::{
+    InferenceConfiguration, Message, SystemContentBlock, ToolConfiguration,
+};
 use aws_smithy_types::error::display::DisplayErrorContext;
 use aws_types::region::Region;
 use serde_json::{Value, json};
@@ -44,6 +53,7 @@ use crate::inference::adapter::InferenceAdapter;
 use crate::inference::configurator::{Configurator, ResolvedProvider};
 use crate::inference::error::InferenceError;
 use crate::inference::registry::{ProviderCapabilities, ProviderId, capabilities};
+use crate::inference::streaming::ChatStream;
 use crate::inference::types::{ChatRequest, ChatResponse, ToolChoice};
 
 /// Region env var: trusty-specific override (checked before the standard
@@ -180,28 +190,19 @@ impl InferenceAdapter for BedrockAdapter {
     /// `#[ignore]`-gated `live_bedrock_call` exercises this end-to-end.
     async fn chat(&self, request: &ChatRequest) -> Result<ChatResponse, InferenceError> {
         let client = self.client().await?;
-        let (system_blocks, messages) = convert::build_converse_messages(request)?;
-
-        let inference = InferenceConfiguration::builder()
-            .set_max_tokens(request.max_tokens.map(|v| v as i32))
-            .set_temperature(request.temperature)
-            .build();
+        let parts = build_converse_parts(request)?;
 
         let mut sdk_req = client
             .converse()
             .model_id(bedrock_model_id(&request.model))
-            .inference_config(inference)
-            .set_messages(Some(messages));
+            .inference_config(parts.inference)
+            .set_messages(Some(parts.messages));
 
-        if !system_blocks.is_empty() {
-            sdk_req = sdk_req.set_system(Some(system_blocks));
+        if !parts.system.is_empty() {
+            sdk_req = sdk_req.set_system(Some(parts.system));
         }
-
-        if let Some(tools) = &request.tools {
-            let tool_config = convert::build_tool_config(tools, request.tool_choice.as_ref())?;
-            if let Some(tool_config) = tool_config {
-                sdk_req = sdk_req.tool_config(tool_config);
-            }
+        if let Some(tool_config) = parts.tool_config {
+            sdk_req = sdk_req.tool_config(tool_config);
         }
 
         let resp = sdk_req.send().await.map_err(|e| {
@@ -217,6 +218,63 @@ impl InferenceAdapter for BedrockAdapter {
             &resp,
             &request.model,
         ))
+    }
+
+    /// Execute one `ConverseStream` call and yield its events incrementally
+    /// (#4426).
+    ///
+    /// Why: without this override a `bedrock/*` turn used the trait's buffered
+    /// default — the caller waited for the whole answer and then received it as
+    /// a single delta, which is indistinguishable from not streaming at all.
+    /// Bedrock's own streaming operation has been proven in this workspace since
+    /// #3767 (`crate::chat::bedrock_impl`, live on trusty-agents' chat path);
+    /// this is that capability moved onto [`InferenceAdapter`], the surface epic
+    /// #4429 is converging on. Every consumer of the shared adapter — trusty-code
+    /// foremost, which delegates `chat_stream` straight through — gets real token
+    /// streaming with no change of its own.
+    /// What: converts `request` with the SAME [`build_converse_parts`] the unary
+    /// [`Self::chat`] uses (so the two transports can never disagree about
+    /// messages, sampling, or tool config), sends `ConverseStream`, and returns
+    /// the SDK's event receiver wrapped as a [`ChatStream`] via
+    /// [`stream::drive`]. A failed `stream=true` handshake surfaces
+    /// SYNCHRONOUSLY as `Err` (per the trait contract, so the caller may choose
+    /// to retry non-streaming); a mid-stream failure surfaces as a terminal `Err`
+    /// item and never as a `Done`. Dropping the returned stream drops the
+    /// receiver, cancelling the AWS request.
+    /// Test: `super::tests::stream_*` drive [`stream::drive`] over a scripted
+    /// event sequence; `super::tests::live_bedrock_converse_stream` (`#[ignore]`)
+    /// covers this method end to end against the real service.
+    async fn chat_stream(&self, request: &ChatRequest) -> Result<ChatStream, InferenceError> {
+        let client = self.client().await?;
+        let parts = build_converse_parts(request)?;
+
+        let mut sdk_req = client
+            .converse_stream()
+            .model_id(bedrock_model_id(&request.model))
+            .inference_config(parts.inference)
+            .set_messages(Some(parts.messages));
+
+        if !parts.system.is_empty() {
+            sdk_req = sdk_req.set_system(Some(parts.system));
+        }
+        if let Some(tool_config) = parts.tool_config {
+            sdk_req = sdk_req.tool_config(tool_config);
+        }
+
+        let output = sdk_req.send().await.map_err(|e| {
+            InferenceError::Provider(format!(
+                "ConverseStream call failed (model={}, region={}): {}",
+                request.model,
+                self.region,
+                DisplayErrorContext(&e)
+            ))
+        })?;
+
+        Ok(stream::drive(stream::SdkEventSource::new(
+            output,
+            &request.model,
+            &self.region,
+        )))
     }
 
     /// Translate a neutral [`ToolChoice`] into Converse's own tool-choice JSON
@@ -241,6 +299,69 @@ impl InferenceAdapter for BedrockAdapter {
             ToolChoice::Function(name) => json!({"tool": {"name": name}}),
         }
     }
+}
+
+/// One [`ChatRequest`] converted into the four pieces both Converse operations
+/// take (#4426).
+///
+/// Why: `Converse` and `ConverseStream` have DIFFERENT fluent-builder types, so
+/// the request assembly cannot be shared by passing a builder around — but the
+/// conversion itself must be shared, or the streaming and buffered transports
+/// silently drift (a `cache_control` marker, a tool-pairing repair, or a
+/// sampling knob honoured on one path and not the other is exactly the class of
+/// bug that makes "streaming broke tool calls" reports). Producing the pieces
+/// once and letting each caller mount them on its own builder keeps a single
+/// conversion with two call sites.
+/// What: `system` is Converse's system-prompt array (empty when the transcript
+/// has no system content); `messages` is the alternation-safe, tool-pairing-
+/// repaired conversation; `inference` carries `max_tokens`/`temperature`;
+/// `tool_config` is `None` when the request declares no tools (or when the
+/// tool-choice mapping says to omit it entirely).
+/// Test: covered through both call sites — `super::tests::*` conversion tests
+/// for the pieces and `super::tests::stream_*` for the streaming mount.
+pub(crate) struct ConverseParts {
+    /// Converse's top-level system-prompt blocks.
+    pub(crate) system: Vec<SystemContentBlock>,
+    /// The user/assistant conversation, role-merged and tool-pairing-repaired.
+    pub(crate) messages: Vec<Message>,
+    /// Sampling configuration (`max_tokens`, `temperature`).
+    pub(crate) inference: InferenceConfiguration,
+    /// Tool definitions + tool choice, when the request declares any.
+    pub(crate) tool_config: Option<ToolConfiguration>,
+}
+
+/// Convert a [`ChatRequest`] into the shared Converse request pieces.
+///
+/// Why: see [`ConverseParts`] — this is the ONE conversion both
+/// [`BedrockAdapter::chat`] and [`BedrockAdapter::chat_stream`] run, so the two
+/// transports are guaranteed to send the same thing.
+/// What: delegates messages/system to [`convert::build_converse_messages`] and
+/// tools to [`convert::build_tool_config`] (only when `request.tools` is set),
+/// and builds the [`InferenceConfiguration`] from `max_tokens`/`temperature`
+/// via `set_*` so an absent knob omits the field rather than sending a default.
+/// Errors propagate from the converters (an unrepresentable message or an
+/// invalid tool schema).
+/// Test: `super::tests::*` (message/tool conversion) and
+/// `super::tests::stream_*`.
+pub(crate) fn build_converse_parts(request: &ChatRequest) -> Result<ConverseParts, InferenceError> {
+    let (system, messages) = convert::build_converse_messages(request)?;
+
+    let inference = InferenceConfiguration::builder()
+        .set_max_tokens(request.max_tokens.map(|v| v as i32))
+        .set_temperature(request.temperature)
+        .build();
+
+    let tool_config = match &request.tools {
+        Some(tools) => convert::build_tool_config(tools, request.tool_choice.as_ref())?,
+        None => None,
+    };
+
+    Ok(ConverseParts {
+        system,
+        messages,
+        inference,
+        tool_config,
+    })
 }
 
 /// Strip the `bedrock/` dispatch-routing prefix from a model slug, yielding the

--- a/crates/trusty-common/src/inference/bedrock/stream.rs
+++ b/crates/trusty-common/src/inference/bedrock/stream.rs
@@ -1,0 +1,329 @@
+//! Native `ConverseStream` transport for the shared Bedrock adapter (#4426).
+//!
+//! Why: [`InferenceAdapter::chat_stream`](crate::inference::InferenceAdapter::chat_stream)
+//! had no Bedrock override, so every `bedrock/*` turn fell back to the trait's
+//! buffered default — the whole answer arrived as ONE delta after the model had
+//! already finished. Real token streaming for Bedrock is not new work in this
+//! workspace: `crate::chat::bedrock_impl::BedrockProvider::chat_stream` has
+//! driven `ConverseStream` in production (trusty-agents' chat path) since #3767.
+//! This module ports that proven event handling onto the `inference` side, which
+//! is the convergence target (`chat::ChatProvider` is being retired — epic
+//! #4429). It deliberately does NOT reuse
+//! [`crate::inference::streaming::SseDecoder`]: `ConverseStream` is a BINARY AWS
+//! event-stream framed and demultiplexed by the SDK's `EventReceiver`, not the
+//! `data:`-line SSE grammar that decoder speaks, and its token accounting
+//! arrives exactly once in a terminal `Metadata` event rather than in a
+//! usage-only final chunk.
+//! What: [`ConverseStreamDecoder`] — the pure, synchronous
+//! `ConverseStreamOutput` → [`ChatStreamEvent`] fold (text deltas, tool-use
+//! start/argument fragments, the `MessageStop` stop reason, and the `Metadata`
+//! usage tally); [`ConverseEventSource`] — a one-method seam over the SDK's
+//! `EventReceiver` so [`drive`] (which produces the real [`ChatStream`] the
+//! adapter returns) is unit-testable against a scripted event sequence, since
+//! `EventReceiver` has no public constructor outside a live HTTP response; and
+//! [`SdkEventSource`], the live implementation of that seam.
+//! Test: `super::tests::stream_*` — delta ordering, structural-event skipping,
+//! tool-call fragment mapping, terminal usage/stop-reason carry-over, the
+//! mid-stream-error contract, and a `StreamAssembly` round-trip proving a
+//! streamed turn rebuilds into the same `ChatResponse` the buffered `chat()`
+//! path returns; plus the `#[ignore]`-gated `live_bedrock_converse_stream`.
+
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use aws_sdk_bedrockruntime::operation::converse_stream::ConverseStreamOutput as ConverseStreamResponse;
+use aws_sdk_bedrockruntime::types::{
+    ContentBlockDelta, ContentBlockStart, ConverseStreamOutput as ConverseEvent,
+};
+use aws_smithy_types::error::display::DisplayErrorContext;
+use futures_util::stream;
+
+use crate::inference::error::InferenceError;
+use crate::inference::streaming::{ChatStream, ChatStreamEvent, StreamCompletion, ToolCallDelta};
+use crate::inference::types::{StopReason, Usage};
+
+/// A pull source of decoded `ConverseStream` events.
+///
+/// Why (#4426): the AWS SDK hands the streamed turn back as an
+/// `EventReceiver<ConverseStreamOutput, _>`, which has NO public constructor —
+/// it can only be obtained from a live HTTP response. Testing [`drive`] (the
+/// function that turns those events into the [`ChatStream`] the adapter
+/// actually returns) therefore requires a seam; without one the only coverage
+/// possible would be of the decoder in isolation, leaving the stream plumbing —
+/// event ordering, terminal emission, error termination — unproven. One
+/// `recv`-shaped method is enough because that is the entire surface [`drive`]
+/// consumes.
+/// What: `recv` yields the next event, `Ok(None)` at a clean end of stream, or
+/// an [`InferenceError`] for a mid-stream failure (a modeled exception such as
+/// throttling, or a transport fault). `Send + 'static` so the produced stream
+/// satisfies [`ChatStream`]'s bounds.
+/// Test: [`SdkEventSource`] is the live impl; `super::tests::ScriptedEvents` is
+/// the test impl driving every `stream_*` test.
+#[async_trait]
+pub(super) trait ConverseEventSource: Send + 'static {
+    /// Receive the next event, `None` at clean end of stream.
+    async fn recv(&mut self) -> Result<Option<ConverseEvent>, InferenceError>;
+}
+
+/// The live [`ConverseEventSource`]: the AWS SDK's `ConverseStream` response.
+///
+/// Why: wraps the SDK response so the SDK error type is mapped to
+/// [`InferenceError`] in ONE place, and so [`drive`] never names an AWS type.
+/// It holds the whole operation OUTPUT rather than just its `stream` field
+/// because the field's `EventReceiver<..>` type is not publicly nameable from
+/// outside the SDK crate (`aws_sdk_bedrockruntime::event_receiver` is private) —
+/// keeping the public wrapper is the only way to store it without a generic
+/// escape hatch. The model/region are carried purely to make a mid-stream
+/// failure message actionable (which model, which region) — the same context
+/// [`super::BedrockAdapter::chat`] puts on its non-streaming errors.
+/// What: `recv` delegates to the receiver's `recv`, mapping any `SdkError` to
+/// [`InferenceError::Provider`] with the full source chain via
+/// `DisplayErrorContext` (an `SdkError`'s own `Display` omits its cause, which
+/// is where the real reason lives).
+/// Test: exercised by the `#[ignore]`-gated `live_bedrock_converse_stream`; the
+/// offline `stream_*` tests use the scripted source instead.
+pub(super) struct SdkEventSource {
+    response: ConverseStreamResponse,
+    model: String,
+    region: String,
+}
+
+impl SdkEventSource {
+    /// Wrap a `ConverseStream` response with the context a failure message needs.
+    ///
+    /// Why: the adapter hands the operation output straight over; the
+    /// model/region are captured here rather than at each error site.
+    /// What: stores the response plus owned copies of the requested model slug
+    /// and resolved region.
+    /// Test: `live_bedrock_converse_stream` (`#[ignore]`).
+    pub(super) fn new(response: ConverseStreamResponse, model: &str, region: &str) -> Self {
+        Self {
+            response,
+            model: model.to_string(),
+            region: region.to_string(),
+        }
+    }
+}
+
+#[async_trait]
+impl ConverseEventSource for SdkEventSource {
+    async fn recv(&mut self) -> Result<Option<ConverseEvent>, InferenceError> {
+        self.response.stream.recv().await.map_err(|e| {
+            InferenceError::Provider(format!(
+                "ConverseStream failed mid-stream (model={}, region={}): {}",
+                self.model,
+                self.region,
+                DisplayErrorContext(&e)
+            ))
+        })
+    }
+}
+
+/// Folds `ConverseStream` events into the neutral streaming event model.
+///
+/// Why: this is the part of the port with real branching logic, so it is a
+/// plain synchronous struct rather than being inlined into the async stream —
+/// it can then be driven by a scripted event list in a unit test, exactly as
+/// `chat::bedrock_impl::handle_stream_event` is. Converse spreads the terminal
+/// summary across TWO events (`MessageStop` carries the stop reason,
+/// `Metadata` carries usage) and neither is the last thing the receiver yields,
+/// so the decoder must accumulate both and emit the single terminal
+/// [`ChatStreamEvent::Done`] only at end of stream — the neutral contract's
+/// "exactly one `Done`, always last".
+/// What: [`Self::push`] maps one event to at most one [`ChatStreamEvent`] while
+/// recording stop reason / usage / tool-call slots; [`Self::finish`] builds the
+/// terminal event. Tool calls are re-indexed into DENSE slots (0, 1, 2 …) keyed
+/// by Converse's `contentBlockIndex`, because that index counts every content
+/// block (a leading text block makes the first tool block index 1) while
+/// [`ToolCallDelta::index`] is the OpenAI-dialect call ordinal every consumer —
+/// [`crate::inference::StreamAssembly`] included — accumulates by.
+/// Test: `super::tests::stream_*`.
+#[derive(Debug, Default)]
+pub(super) struct ConverseStreamDecoder {
+    /// The stop reason from `MessageStop`, carried into the terminal event.
+    finish_reason: Option<StopReason>,
+    /// The token tally from `Metadata`, carried into the terminal event.
+    usage: Usage,
+    /// Converse `contentBlockIndex` → dense tool-call slot.
+    slots: HashMap<i32, usize>,
+    /// Next dense slot to hand out.
+    next_slot: usize,
+}
+
+impl ConverseStreamDecoder {
+    /// Start an empty decoder.
+    ///
+    /// Why: one is built per streamed request.
+    /// What: no stop reason, zeroed usage, no tool slots.
+    /// Test: `super::tests::stream_forwards_text_deltas_in_order`.
+    pub(super) fn new() -> Self {
+        Self::default()
+    }
+
+    /// Fold one `ConverseStream` event in, returning what to emit for it.
+    ///
+    /// Why: keeps the whole Converse→neutral mapping in one readable match so a
+    /// new SDK event variant is a visible, single-place decision rather than a
+    /// silent behaviour change spread across the stream driver.
+    /// What: a `ContentBlockDelta::Text` becomes [`ChatStreamEvent::Delta`]
+    /// (empty fragments are dropped — a keep-alive-shaped empty delta must not
+    /// reach the consumer as a token); a `ContentBlockStart::ToolUse` becomes
+    /// the introducing [`ChatStreamEvent::ToolCall`] carrying `id` + `name`;
+    /// a `ContentBlockDelta::ToolUse` becomes a continuation `ToolCall` carrying
+    /// only the partial-JSON `arguments` fragment; `MessageStop` records the
+    /// stop reason (lowercased and parsed exactly as the non-streaming path
+    /// does, so `chat` and `chat_stream` report the SAME `finish_reason`
+    /// string); `Metadata` records usage when present (and fabricates nothing
+    /// when absent — Bedrock omits it on some guardrail paths). Every other
+    /// variant (`MessageStart`, `ContentBlockStop`, image/citation/reasoning
+    /// deltas, and any SDK `Unknown` future variant) is a structural marker
+    /// with nothing to forward and yields `None`.
+    /// Test: `super::tests::stream_forwards_text_deltas_in_order`,
+    /// `super::tests::stream_ignores_structural_events`,
+    /// `super::tests::stream_maps_tool_use_fragments`,
+    /// `super::tests::stream_carries_usage_and_stop_reason_in_terminal`.
+    pub(super) fn push(&mut self, event: ConverseEvent) -> Option<ChatStreamEvent> {
+        match event {
+            ConverseEvent::ContentBlockStart(ev) => match ev.start() {
+                Some(ContentBlockStart::ToolUse(tool)) => {
+                    let index = self.slot_for(ev.content_block_index());
+                    Some(ChatStreamEvent::ToolCall(ToolCallDelta {
+                        index,
+                        id: Some(tool.tool_use_id().to_string()),
+                        name: Some(tool.name().to_string()),
+                        arguments: String::new(),
+                    }))
+                }
+                _ => None,
+            },
+            ConverseEvent::ContentBlockDelta(ev) => match ev.delta() {
+                Some(ContentBlockDelta::Text(text)) if !text.is_empty() => {
+                    Some(ChatStreamEvent::Delta(text.clone()))
+                }
+                Some(ContentBlockDelta::ToolUse(delta)) => {
+                    let index = self.slot_for(ev.content_block_index());
+                    Some(ChatStreamEvent::ToolCall(ToolCallDelta {
+                        index,
+                        id: None,
+                        name: None,
+                        arguments: delta.input().to_string(),
+                    }))
+                }
+                _ => None,
+            },
+            ConverseEvent::MessageStop(ev) => {
+                // #4426: mirror `convert::converse_output_to_chat_response`'s
+                // `stop_reason().as_str().to_ascii_lowercase()` so a streamed
+                // turn and a buffered one report an IDENTICAL finish reason
+                // (`"end_turn"`, `"tool_use"`, `"max_tokens"` …) — a consumer
+                // must never be able to tell which transport ran from it.
+                self.finish_reason = Some(StopReason::from_wire(
+                    &ev.stop_reason().as_str().to_ascii_lowercase(),
+                ));
+                None
+            }
+            ConverseEvent::Metadata(meta) => {
+                if let Some(usage) = meta.usage() {
+                    self.usage = Usage::new(
+                        usage.input_tokens().max(0) as u32,
+                        usage.output_tokens().max(0) as u32,
+                        usage.cache_read_input_tokens().unwrap_or(0).max(0) as u32,
+                        usage.cache_write_input_tokens().unwrap_or(0).max(0) as u32,
+                    );
+                }
+                None
+            }
+            _ => None,
+        }
+    }
+
+    /// The terminal [`ChatStreamEvent::Done`] for this stream.
+    ///
+    /// Why: the stop reason and usage arrive in earlier events than the end of
+    /// stream, so the terminal summary can only be built once the receiver is
+    /// exhausted.
+    /// What: a `Done` carrying the recorded finish reason (`None` if Bedrock
+    /// never sent `MessageStop`) and usage (zeroed if no `Metadata` arrived).
+    /// Test: `super::tests::stream_carries_usage_and_stop_reason_in_terminal`.
+    pub(super) fn finish(&self) -> ChatStreamEvent {
+        ChatStreamEvent::Done(StreamCompletion {
+            finish_reason: self.finish_reason.clone(),
+            usage: self.usage,
+        })
+    }
+
+    /// Resolve (or allocate) the dense tool-call slot for a Converse content
+    /// block index.
+    ///
+    /// Why: see the struct doc — Converse's `contentBlockIndex` is a
+    /// content-block ordinal, not a tool-call ordinal, and a consumer keyed on
+    /// the raw value would number a turn's first tool call `1` whenever the
+    /// model emitted any text first.
+    /// What: returns the slot already assigned to `block_index`, else assigns
+    /// the next slot (0, 1, 2 …) in first-seen order.
+    /// Test: `super::tests::stream_tool_slots_are_dense_from_zero`.
+    fn slot_for(&mut self, block_index: i32) -> usize {
+        if let Some(slot) = self.slots.get(&block_index) {
+            return *slot;
+        }
+        let slot = self.next_slot;
+        self.next_slot += 1;
+        self.slots.insert(block_index, slot);
+        slot
+    }
+}
+
+/// Drive a [`ConverseEventSource`] into the neutral [`ChatStream`].
+///
+/// Why: the adapter's `chat_stream` must return a pollable, `Send`, boxed
+/// stream — not an ad-hoc loop — so the caller keeps back-pressure and
+/// cancellation (dropping the returned stream drops the source, which aborts
+/// the underlying AWS request). Generic over the source so the entire
+/// production path is exercised offline by the scripted tests.
+/// What: pulls events, forwards whatever [`ConverseStreamDecoder::push`]
+/// produces, and terminates on either a clean end of stream (emitting exactly
+/// one [`ChatStreamEvent::Done`]) or a mid-stream error (emitting a terminal
+/// `Err` and NO `Done` — a failed stream must never be mistakable for a
+/// complete short answer, the same contract
+/// [`crate::inference::streaming::decode_event_stream`] holds for the SSE lane).
+/// Test: `super::tests::stream_forwards_text_deltas_in_order`,
+/// `super::tests::stream_surfaces_mid_stream_error`,
+/// `super::tests::stream_assembles_into_buffered_shaped_response`.
+pub(super) fn drive<S: ConverseEventSource>(source: S) -> ChatStream {
+    struct State<S> {
+        source: S,
+        decoder: ConverseStreamDecoder,
+        done: bool,
+    }
+
+    let init = State {
+        source,
+        decoder: ConverseStreamDecoder::new(),
+        done: false,
+    };
+
+    let s = stream::unfold(init, |mut st| async move {
+        loop {
+            if st.done {
+                return None;
+            }
+            match st.source.recv().await {
+                Ok(Some(event)) => {
+                    if let Some(out) = st.decoder.push(event) {
+                        return Some((Ok(out), st));
+                    }
+                }
+                Ok(None) => {
+                    st.done = true;
+                    return Some((Ok(st.decoder.finish()), st));
+                }
+                Err(e) => {
+                    st.done = true;
+                    return Some((Err(e), st));
+                }
+            }
+        }
+    });
+
+    Box::pin(s)
+}

--- a/crates/trusty-common/src/inference/bedrock/tests.rs
+++ b/crates/trusty-common/src/inference/bedrock/tests.rs
@@ -5,15 +5,23 @@
 //! conversion logic keeps full coverage.
 //! What: region resolution, message/tool-choice/response conversion, the
 //! cachePoint translation, and the adapter surface (`name`, `map_tool_choice`,
-//! lazy construction) — all offline, no real AWS — plus one `#[ignore]`-gated
-//! live Converse call.
+//! lazy construction) — all offline, no real AWS — plus, since #4426, the
+//! `stream_*` suite that drives the REAL `ConverseStream` decode/stream path
+//! against a scripted event sequence, and two `#[ignore]`-gated live calls
+//! (`Converse` and `ConverseStream`).
+
+use std::collections::VecDeque;
 
 use aws_sdk_bedrockruntime::operation::converse::ConverseOutput as ConverseOutputResponse;
 use aws_sdk_bedrockruntime::types::{
-    CachePointType, ContentBlock, ConverseOutput as ConverseOutputKind, Message as SdkMessage,
-    StopReason, SystemContentBlock, TokenUsage as SdkTokenUsage, Tool as SdkTool,
-    ToolChoice as SdkToolChoice, ToolResultStatus,
+    CachePointType, ContentBlock, ContentBlockDelta as SdkContentBlockDelta,
+    ContentBlockDeltaEvent, ContentBlockStart as SdkContentBlockStart, ContentBlockStartEvent,
+    ContentBlockStopEvent, ConverseOutput as ConverseOutputKind, ConverseStreamMetadataEvent,
+    ConverseStreamOutput as ConverseEvent, Message as SdkMessage, MessageStartEvent,
+    MessageStopEvent, StopReason, SystemContentBlock, TokenUsage as SdkTokenUsage, Tool as SdkTool,
+    ToolChoice as SdkToolChoice, ToolResultStatus, ToolUseBlockDelta, ToolUseBlockStart,
 };
+use futures_util::StreamExt;
 use serde_json::json;
 
 use super::cache::{MIN_CACHEABLE_TOKENS, cache_point_block, system_cacheable, tools_cacheable};
@@ -21,8 +29,11 @@ use super::convert::{
     build_converse_messages, build_tool_config, converse_output_to_chat_response,
     document_to_json_string, json_to_document,
 };
-use super::{BedrockAdapter, bedrock_model_id, resolve_bedrock_region};
+use super::stream::{ConverseEventSource, drive};
+use super::{BedrockAdapter, bedrock_model_id, build_converse_parts, resolve_bedrock_region};
 use crate::inference::adapter::InferenceAdapter;
+use crate::inference::error::InferenceError;
+use crate::inference::streaming::{ChatStreamEvent, StreamAssembly, ToolCallDelta};
 use crate::inference::types::{
     CacheControl, ChatMessage, ChatRequest, FunctionCall, FunctionDefinition, ToolCall, ToolChoice,
     ToolDefinition,
@@ -852,6 +863,514 @@ fn json_to_document_rejects_non_object_top_level() {
     assert!(json_to_document(&json!("just a string")).is_none());
 }
 
+// ─── ConverseStream (#4426) ─────────────────────────────────────────────────
+
+/// A scripted [`ConverseEventSource`] standing in for a live `ConverseStream`
+/// response.
+///
+/// Why: the SDK's `EventReceiver` cannot be constructed outside a real HTTP
+/// response, so without this double the streaming path could only ever be
+/// verified live (i.e. never in CI). Every event TYPE it yields DOES have a
+/// public builder, so a scripted sequence of already-decoded events drives the
+/// exact production `drive`/`ConverseStreamDecoder` code — only the socket is
+/// replaced.
+/// What: pops the next scripted `recv` result; an exhausted script reports a
+/// clean end of stream (`Ok(None)`), which is what a healthy Bedrock response
+/// does after its `Metadata` event.
+struct ScriptedEvents {
+    script: VecDeque<Result<Option<ConverseEvent>, InferenceError>>,
+}
+
+impl ScriptedEvents {
+    /// Build a source that yields each event in order, then ends cleanly.
+    fn events(events: Vec<ConverseEvent>) -> Self {
+        Self {
+            script: events.into_iter().map(|e| Ok(Some(e))).collect(),
+        }
+    }
+
+    /// Build a source that yields each event in order, then FAILS mid-stream.
+    fn events_then_error(events: Vec<ConverseEvent>, error: &str) -> Self {
+        let mut script: VecDeque<_> = events.into_iter().map(|e| Ok(Some(e))).collect();
+        script.push_back(Err(InferenceError::Provider(error.to_string())));
+        Self { script }
+    }
+}
+
+#[async_trait::async_trait]
+impl ConverseEventSource for ScriptedEvents {
+    async fn recv(&mut self) -> Result<Option<ConverseEvent>, InferenceError> {
+        self.script.pop_front().unwrap_or(Ok(None))
+    }
+}
+
+/// Helper: a `ContentBlockDelta::Text` event on content block 0.
+fn text_delta(text: &str) -> ConverseEvent {
+    text_delta_at(0, text)
+}
+
+/// Helper: a `ContentBlockDelta::Text` event on an explicit content block.
+fn text_delta_at(block: i32, text: &str) -> ConverseEvent {
+    ConverseEvent::ContentBlockDelta(
+        ContentBlockDeltaEvent::builder()
+            .delta(SdkContentBlockDelta::Text(text.to_string()))
+            .content_block_index(block)
+            .build()
+            .expect("build ContentBlockDeltaEvent"),
+    )
+}
+
+/// Helper: the `ContentBlockStart` that introduces a tool call.
+fn tool_use_start(block: i32, id: &str, name: &str) -> ConverseEvent {
+    ConverseEvent::ContentBlockStart(
+        ContentBlockStartEvent::builder()
+            .start(SdkContentBlockStart::ToolUse(
+                ToolUseBlockStart::builder()
+                    .tool_use_id(id)
+                    .name(name)
+                    .build()
+                    .expect("build ToolUseBlockStart"),
+            ))
+            .content_block_index(block)
+            .build()
+            .expect("build ContentBlockStartEvent"),
+    )
+}
+
+/// Helper: a partial-JSON tool-argument fragment for a tool block.
+fn tool_use_delta(block: i32, fragment: &str) -> ConverseEvent {
+    ConverseEvent::ContentBlockDelta(
+        ContentBlockDeltaEvent::builder()
+            .delta(SdkContentBlockDelta::ToolUse(
+                ToolUseBlockDelta::builder()
+                    .input(fragment)
+                    .build()
+                    .expect("build ToolUseBlockDelta"),
+            ))
+            .content_block_index(block)
+            .build()
+            .expect("build ContentBlockDeltaEvent"),
+    )
+}
+
+/// Helper: the `MessageStop` event carrying a Bedrock stop reason.
+fn message_stop(reason: StopReason) -> ConverseEvent {
+    ConverseEvent::MessageStop(
+        MessageStopEvent::builder()
+            .stop_reason(reason)
+            .build()
+            .expect("build MessageStopEvent"),
+    )
+}
+
+/// Helper: the terminal `Metadata` event carrying a full token tally.
+fn metadata_with_usage(
+    input: i32,
+    output: i32,
+    cache_read: i32,
+    cache_write: i32,
+) -> ConverseEvent {
+    let usage = SdkTokenUsage::builder()
+        .input_tokens(input)
+        .output_tokens(output)
+        .total_tokens(input + output)
+        .cache_read_input_tokens(cache_read)
+        .cache_write_input_tokens(cache_write)
+        .build()
+        .expect("build TokenUsage");
+    ConverseEvent::Metadata(ConverseStreamMetadataEvent::builder().usage(usage).build())
+}
+
+/// Helper: collect a whole [`ChatStream`] into a vector.
+async fn collect_stream(
+    mut stream: crate::inference::streaming::ChatStream,
+) -> Vec<Result<ChatStreamEvent, InferenceError>> {
+    let mut out = Vec::new();
+    while let Some(item) = stream.next().await {
+        out.push(item);
+    }
+    out
+}
+
+/// Text deltas reach the consumer in arrival order, followed by exactly one
+/// terminal `Done`.
+///
+/// Why (#4426): out-of-order or dropped concatenation is the most visible
+/// streaming defect — the user reads scrambled prose — and a missing terminal
+/// event strands any consumer waiting for usage.
+/// What: script two text deltas plus a clean end; assert `Delta`, `Delta`,
+/// `Done` and nothing else.
+/// Test: this test.
+#[tokio::test]
+async fn stream_forwards_text_deltas_in_order() {
+    let events = collect_stream(drive(ScriptedEvents::events(vec![
+        text_delta("He"),
+        text_delta("llo"),
+    ])))
+    .await;
+
+    assert_eq!(events.len(), 3, "expected two deltas + Done: {events:?}");
+    assert_eq!(
+        events[0].as_ref().expect("delta"),
+        &ChatStreamEvent::Delta("He".to_string())
+    );
+    assert_eq!(
+        events[1].as_ref().expect("delta"),
+        &ChatStreamEvent::Delta("llo".to_string())
+    );
+    assert!(matches!(
+        events[2].as_ref().expect("done"),
+        ChatStreamEvent::Done(_)
+    ));
+}
+
+/// Structural framing events forward nothing.
+///
+/// Why: `MessageStart`/`ContentBlockStop` (and any future SDK `Unknown`
+/// variant) carry no assistant content; emitting anything for them would inject
+/// phantom deltas into the rendered turn.
+/// What: script a `MessageStart` and a `ContentBlockStop` around one real
+/// delta; assert only that delta plus `Done` come out. An EMPTY text delta is
+/// included too — Bedrock can frame one, and it must not surface as a token.
+/// Test: this test.
+#[tokio::test]
+async fn stream_ignores_structural_events() {
+    let events = collect_stream(drive(ScriptedEvents::events(vec![
+        ConverseEvent::MessageStart(
+            MessageStartEvent::builder()
+                .role(aws_sdk_bedrockruntime::types::ConversationRole::Assistant)
+                .build()
+                .expect("build MessageStartEvent"),
+        ),
+        text_delta(""),
+        text_delta("hi"),
+        ConverseEvent::ContentBlockStop(
+            ContentBlockStopEvent::builder()
+                .content_block_index(0)
+                .build()
+                .expect("build ContentBlockStopEvent"),
+        ),
+    ])))
+    .await;
+
+    assert_eq!(
+        events.len(),
+        2,
+        "only the non-empty delta + Done: {events:?}"
+    );
+    assert_eq!(
+        events[0].as_ref().expect("delta"),
+        &ChatStreamEvent::Delta("hi".to_string())
+    );
+    assert!(matches!(
+        events[1].as_ref().expect("done"),
+        ChatStreamEvent::Done(_)
+    ));
+}
+
+/// `MessageStop`'s stop reason and `Metadata`'s token tally both land in the
+/// single terminal `Done`.
+///
+/// Why (#4426): Bedrock splits the terminal summary across two events, neither
+/// of which is last, while the neutral contract promises ONE `Done` carrying
+/// both. Dropping the `Metadata` tally would silently zero every streamed
+/// Bedrock turn for cost/telemetry consumers — the same defect #3767 fixed on
+/// the `chat::bedrock_impl` path.
+/// What: script a delta, a `MessageStop(EndTurn)`, and a `Metadata` with all
+/// four token buckets; assert the terminal event carries the lowercased stop
+/// reason and every bucket.
+/// Test: this test.
+#[tokio::test]
+async fn stream_carries_usage_and_stop_reason_in_terminal() {
+    let events = collect_stream(drive(ScriptedEvents::events(vec![
+        text_delta("ok"),
+        message_stop(StopReason::EndTurn),
+        metadata_with_usage(100, 20, 30, 10),
+    ])))
+    .await;
+
+    let ChatStreamEvent::Done(completion) = events.last().expect("terminal").as_ref().expect("ok")
+    else {
+        panic!("last event must be Done: {events:?}");
+    };
+    assert_eq!(
+        completion.finish_reason,
+        Some(crate::inference::types::StopReason::Other(
+            "end_turn".into()
+        )),
+        "Bedrock's stopReason must be lowercased, exactly as the buffered path does"
+    );
+    assert_eq!(completion.usage.prompt_tokens, 100);
+    assert_eq!(completion.usage.completion_tokens, 20);
+    assert_eq!(completion.usage.cache_read_tokens, 30);
+    assert_eq!(completion.usage.cache_creation_tokens, 10);
+}
+
+/// A `Metadata` event with no `usage` must not fabricate a zeroed tally over a
+/// real one.
+///
+/// Why: Bedrock omits `usage` on some guardrail/error paths; treating an absent
+/// tally as "all zeros" is fine only because the decoder starts zeroed — the
+/// bug to guard against is a later empty `Metadata` ERASING a tally already
+/// reported.
+/// What: script a usage-bearing `Metadata` followed by an empty one; assert the
+/// terminal event still carries the real numbers.
+/// Test: this test.
+#[tokio::test]
+async fn stream_metadata_without_usage_does_not_clobber() {
+    let events = collect_stream(drive(ScriptedEvents::events(vec![
+        metadata_with_usage(7, 3, 0, 0),
+        ConverseEvent::Metadata(ConverseStreamMetadataEvent::builder().build()),
+    ])))
+    .await;
+
+    let ChatStreamEvent::Done(completion) = events.last().expect("terminal").as_ref().expect("ok")
+    else {
+        panic!("last event must be Done: {events:?}");
+    };
+    assert_eq!(completion.usage.prompt_tokens, 7);
+    assert_eq!(completion.usage.completion_tokens, 3);
+}
+
+/// A streamed tool call maps to an introducing `ToolCall` (id + name) followed
+/// by argument-fragment `ToolCall`s.
+///
+/// Why (#4426): the reference `chat::bedrock_impl` path IGNORES tool use
+/// entirely — porting that gap would have left the shared adapter unable to
+/// stream an agent turn, which is trusty-code's whole use case. Converse
+/// introduces the call in `ContentBlockStart` and streams its arguments as
+/// partial JSON in later deltas, so both must be forwarded.
+/// What: script a tool-use start plus two argument fragments; assert the
+/// introducing event carries id/name with empty arguments and the continuations
+/// carry only the fragments, all on the same slot index.
+/// Test: this test.
+#[tokio::test]
+async fn stream_maps_tool_use_fragments() {
+    let events = collect_stream(drive(ScriptedEvents::events(vec![
+        tool_use_start(0, "call_1", "get_weather"),
+        tool_use_delta(0, "{\"location\":"),
+        tool_use_delta(0, "\"Seattle\"}"),
+        message_stop(StopReason::ToolUse),
+    ])))
+    .await;
+
+    assert_eq!(events.len(), 4, "3 tool events + Done: {events:?}");
+    assert_eq!(
+        events[0].as_ref().expect("start"),
+        &ChatStreamEvent::ToolCall(ToolCallDelta {
+            index: 0,
+            id: Some("call_1".into()),
+            name: Some("get_weather".into()),
+            arguments: String::new(),
+        })
+    );
+    assert_eq!(
+        events[1].as_ref().expect("fragment"),
+        &ChatStreamEvent::ToolCall(ToolCallDelta {
+            index: 0,
+            id: None,
+            name: None,
+            arguments: "{\"location\":".into(),
+        })
+    );
+    assert_eq!(
+        events[2].as_ref().expect("fragment"),
+        &ChatStreamEvent::ToolCall(ToolCallDelta {
+            index: 0,
+            id: None,
+            name: None,
+            arguments: "\"Seattle\"}".into(),
+        })
+    );
+}
+
+/// Tool-call slots are dense from zero even when text precedes the tool block.
+///
+/// Why: Converse's `contentBlockIndex` counts EVERY content block, so a turn
+/// that says something before calling a tool puts the tool on block 1. Passing
+/// that raw index through as the tool-call ordinal would number the turn's only
+/// call `1` — an OpenAI-dialect consumer indexing calls densely from 0 would
+/// then see a phantom empty call at slot 0.
+/// What: script a text block (index 0) then two tool blocks (indices 1 and 2);
+/// assert the tool slots are 0 and 1.
+/// Test: this test.
+#[tokio::test]
+async fn stream_tool_slots_are_dense_from_zero() {
+    let events = collect_stream(drive(ScriptedEvents::events(vec![
+        text_delta_at(0, "let me check"),
+        tool_use_start(1, "call_a", "alpha"),
+        tool_use_start(2, "call_b", "beta"),
+        tool_use_delta(1, "{}"),
+    ])))
+    .await;
+
+    let slots: Vec<(usize, Option<String>)> = events
+        .iter()
+        .filter_map(|e| match e.as_ref().expect("ok") {
+            ChatStreamEvent::ToolCall(d) => Some((d.index, d.id.clone())),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        slots,
+        vec![
+            (0, Some("call_a".to_string())),
+            (1, Some("call_b".to_string())),
+            (0, None),
+        ],
+        "tool slots must be dense from 0 and stable per content block"
+    );
+}
+
+/// A mid-stream failure ends the stream with `Err` and NEVER a `Done`.
+///
+/// Why: a truncated stream that terminates with a clean `Done` is
+/// indistinguishable from a complete short answer — the caller would record a
+/// partial turn as successful. This is the same dual-channel failure contract
+/// the SSE lane (`decode_event_stream`) and `chat::bedrock_impl` both hold.
+/// What: script one delta then a provider error; assert the delta arrives, the
+/// next item is `Err`, and the stream ends there.
+/// Test: this test.
+#[tokio::test]
+async fn stream_surfaces_mid_stream_error() {
+    let events = collect_stream(drive(ScriptedEvents::events_then_error(
+        vec![text_delta("partial ")],
+        "ConverseStream failed mid-stream: throttled",
+    )))
+    .await;
+
+    assert_eq!(events.len(), 2, "delta + terminal Err: {events:?}");
+    assert_eq!(
+        events[0].as_ref().expect("delta"),
+        &ChatStreamEvent::Delta("partial ".to_string())
+    );
+    let err = events[1].as_ref().expect_err("must be an error");
+    assert!(
+        err.to_string().contains("throttled"),
+        "error must carry the provider reason: {err}"
+    );
+    assert!(
+        !events
+            .iter()
+            .any(|e| matches!(e, Ok(ChatStreamEvent::Done(_)))),
+        "a failed stream must not also emit Done: {events:?}"
+    );
+}
+
+/// A streamed turn rebuilds into the SAME `ChatResponse` the buffered
+/// `Converse` path returns for the equivalent output.
+///
+/// Why (#4426): this is the property that makes streaming a transport detail.
+/// If the streamed finish reason, text, or usage differed from the buffered
+/// one, every downstream consumer (transcript recording, cost accrual, the tool
+/// loop) would need to branch on which transport ran. Asserting against the
+/// REAL `converse_output_to_chat_response` output — not a hand-written expected
+/// value — means a future change to either side that breaks the equivalence
+/// fails here.
+/// What: stream `"hello world"` with `EndTurn` and a token tally, assemble via
+/// [`StreamAssembly`], and compare against the buffered conversion of a
+/// `ConverseOutput` carrying the same content.
+/// Test: this test.
+#[tokio::test]
+async fn stream_assembles_into_buffered_shaped_response() {
+    let usage = SdkTokenUsage::builder()
+        .input_tokens(100)
+        .output_tokens(20)
+        .total_tokens(120)
+        .cache_read_input_tokens(30)
+        .cache_write_input_tokens(10)
+        .build()
+        .expect("build usage");
+    let buffered = converse_output_to_chat_response(
+        &output_with_text("hello world", StopReason::EndTurn, Some(usage)),
+        "bedrock/us.anthropic.claude-sonnet-4-6",
+    );
+
+    let mut assembly = StreamAssembly::new();
+    let mut stream = drive(ScriptedEvents::events(vec![
+        text_delta("hello"),
+        text_delta(" world"),
+        message_stop(StopReason::EndTurn),
+        metadata_with_usage(100, 20, 30, 10),
+    ]));
+    while let Some(item) = stream.next().await {
+        assembly.push(item.expect("no stream error"));
+    }
+    let streamed = assembly.into_response(
+        buffered.id.clone(),
+        "bedrock/us.anthropic.claude-sonnet-4-6",
+    );
+
+    // `ChatResponse` has no `PartialEq` (it is a wire type, not a value type),
+    // so compare the serialised forms — which is a STRICTER check than a
+    // field-by-field assertion: a new field added to either path shows up here.
+    assert_eq!(
+        serde_json::to_value(&streamed).expect("serialise streamed"),
+        serde_json::to_value(&buffered).expect("serialise buffered"),
+        "a streamed turn must rebuild into exactly the buffered response"
+    );
+}
+
+/// Both Converse transports build their request from ONE conversion.
+///
+/// Why (#4426): `Converse` and `ConverseStream` have different fluent builders,
+/// so the shared conversion is the only thing preventing the two paths from
+/// drifting (a sampling knob, a cachePoint, or a tool config honoured on one
+/// and not the other). This pins the shared builder directly, so a regression
+/// in it fails a test rather than only showing up as a live behaviour
+/// difference.
+/// What: build parts from a request carrying a system prompt, sampling knobs,
+/// and a tool; assert every piece is populated.
+/// Test: this test.
+#[test]
+fn build_converse_parts_carries_system_sampling_and_tools() {
+    let req = ChatRequest {
+        model: "bedrock/us.anthropic.claude-sonnet-4-6".into(),
+        messages: vec![
+            ChatMessage::system("be brief"),
+            ChatMessage::user("what is the weather?"),
+        ],
+        temperature: Some(0.25),
+        max_tokens: Some(512),
+        tools: Some(vec![sample_tool()]),
+        tool_choice: Some(json!({"auto": {}})),
+        stop: None,
+        usage: None,
+    };
+
+    let parts = build_converse_parts(&req).expect("parts must build");
+    assert_eq!(parts.system.len(), 1, "system prompt must be diverted");
+    assert_eq!(parts.messages.len(), 1, "one user message");
+    assert_eq!(parts.inference.max_tokens(), Some(512));
+    assert_eq!(parts.inference.temperature(), Some(0.25));
+    let tool_config = parts.tool_config.expect("tool config must be built");
+    assert_eq!(tool_config.tools().len(), 1);
+}
+
+/// A request with no tools omits `toolConfig` entirely.
+///
+/// Why: Converse rejects an empty `toolConfig`, so "no tools" must mean the
+/// field is absent, not present-and-empty.
+/// What: build parts from a tool-free request; assert `tool_config` is `None`.
+/// Test: this test.
+#[test]
+fn build_converse_parts_omits_tool_config_without_tools() {
+    let req = ChatRequest {
+        model: "bedrock/us.anthropic.claude-sonnet-4-6".into(),
+        messages: vec![ChatMessage::user("hi")],
+        temperature: None,
+        max_tokens: None,
+        tools: None,
+        tool_choice: None,
+        stop: None,
+        usage: None,
+    };
+    let parts = build_converse_parts(&req).expect("parts must build");
+    assert!(parts.tool_config.is_none());
+    assert!(parts.system.is_empty());
+    assert_eq!(parts.inference.max_tokens(), None);
+}
+
 // ─── Live integration test ──────────────────────────────────────────────────
 
 /// Live integration test: send a trivial prompt to Bedrock via Converse.
@@ -893,4 +1412,74 @@ async fn live_bedrock_call() {
             eprintln!("skipping live_bedrock_call: call failed: {e}");
         }
     }
+}
+
+/// Live integration test: stream a trivial prompt from Bedrock via
+/// `ConverseStream` (#4426).
+///
+/// Why: the offline `stream_*` tests inject already-decoded events, so they
+/// cannot exercise credential resolution, the `ConverseStream` handshake, or
+/// the SDK's binary event-stream wire decoding — the three things that can only
+/// fail against the real service. This is the end-to-end proof that
+/// [`BedrockAdapter::chat_stream`] streams; unlike the offline suite it FAILS
+/// (rather than skips) on a mid-stream error, since a caller who opts into this
+/// test has credentials and wants a real verdict.
+/// What: requires AWS credentials resolvable by the default chain (e.g.
+/// `AWS_PROFILE=cto`) and a reachable `us.anthropic.claude-*` inference profile.
+/// Asserts MORE THAN ONE event carrying text arrived (one delta would mean the
+/// buffered fallback was still in play), that the concatenated text is
+/// non-empty, and that the terminal `Done` reports non-zero usage.
+/// Test: run with `cargo test -p trusty-common --features bedrock-client -- \
+///        --include-ignored live_bedrock_converse_stream --nocapture`.
+#[tokio::test]
+#[ignore = "requires AWS credentials; skipped in CI"]
+async fn live_bedrock_converse_stream() {
+    let adapter = BedrockAdapter::new(None);
+    let req = ChatRequest {
+        model: "bedrock/us.anthropic.claude-sonnet-4-6".into(),
+        messages: vec![
+            ChatMessage::system("You are a concise assistant."),
+            ChatMessage::user("Count from one to ten in words, separated by commas."),
+        ],
+        temperature: Some(0.0),
+        max_tokens: Some(128),
+        tools: None,
+        tool_choice: None,
+        stop: None,
+        usage: None,
+    };
+
+    let mut stream = adapter
+        .chat_stream(&req)
+        .await
+        .expect("ConverseStream handshake must succeed");
+
+    let mut deltas = 0usize;
+    let mut text = String::new();
+    let mut completion = None;
+    while let Some(item) = stream.next().await {
+        match item.expect("no mid-stream error") {
+            ChatStreamEvent::Delta(chunk) => {
+                deltas += 1;
+                eprintln!("delta {deltas}: {chunk:?}");
+                text.push_str(&chunk);
+            }
+            ChatStreamEvent::ToolCall(call) => eprintln!("tool call: {call:?}"),
+            ChatStreamEvent::Done(done) => completion = Some(done),
+        }
+    }
+
+    let done = completion.expect("stream must end with a terminal Done");
+    eprintln!("live_bedrock_converse_stream — {deltas} deltas, done: {done:?}");
+    assert!(!text.trim().is_empty(), "streamed text must be non-empty");
+    assert!(
+        deltas > 1,
+        "a real ConverseStream turn arrives in MANY deltas; {deltas} would mean \
+         the buffered fallback is still in play"
+    );
+    assert!(
+        done.usage.prompt_tokens > 0 && done.usage.completion_tokens > 0,
+        "the terminal Metadata tally must survive: {:?}",
+        done.usage
+    );
 }


### PR DESCRIPTION
## Why

`InferenceAdapter::chat_stream` had no Bedrock override, so every `bedrock/*` turn fell back to the trait's buffered default — the whole answer arrived as ONE delta after the model had already finished.

Bedrock streaming is **not new work** in this workspace: `chat::bedrock_impl::BedrockProvider::chat_stream` has driven `ConverseStream` in production (trusty-agents' chat path) since #3767. This PR ports that proven event handling onto `inference::InferenceAdapter` — the surface epic #4429 is converging on — so the *winning* adapter is the one that can stream.

`chat::bedrock_impl` is deliberately **UNTOUCHED**: trusty-agents runs on it in production, and retiring it is #4427, sequenced after this. Two implementations coexisting is intentional here.

## What

**New `crates/trusty-common/src/inference/bedrock/stream.rs`**

- `ConverseStreamDecoder` — the pure, synchronous `ConverseStreamOutput` → `ChatStreamEvent` fold.
- `drive()` — turns an event source into the boxed `ChatStream` the adapter returns (dropping it cancels the AWS request).
- `ConverseEventSource` / `SdkEventSource` — a one-method seam over the SDK's `EventReceiver`, which has no public constructor outside a live HTTP response. This is what makes the production streaming path unit-testable offline.

Event mapping:

| ConverseStream event | Neutral event |
|---|---|
| `ContentBlockDelta::Text` | `Delta` (empty fragments dropped) |
| `ContentBlockStart::ToolUse` | introducing `ToolCall` (id + name) |
| `ContentBlockDelta::ToolUse` | continuation `ToolCall` (partial-JSON args) |
| `MessageStop` | recorded → terminal `Done` |
| `Metadata` | usage recorded → terminal `Done` |
| `MessageStart` / `ContentBlockStop` / `Unknown` | ignored (structural) |

Three decisions worth review attention:

1. **Tool use is supported, unlike the reference impl.** `chat::bedrock_impl` ignores `tools` entirely. Porting that gap would have left the shared adapter unable to stream an *agent* turn — trusty-code's whole use case — so tool-use starts and argument fragments are forwarded.
2. **Tool slots are re-indexed dense from 0.** Converse's `contentBlockIndex` counts *every* content block, so a turn that says something before calling a tool puts the tool on block 1. `ToolCallDelta::index` is the OpenAI-dialect *call ordinal* consumers (incl. `StreamAssembly`) accumulate by; passing the raw index through would fabricate a phantom empty call at slot 0.
3. **A mid-stream failure yields a terminal `Err` and never a `Done`.** A truncated stream that ends cleanly is indistinguishable from a complete short answer — same contract `decode_event_stream` holds for the SSE lane.

**Shared request conversion.** `Converse` and `ConverseStream` have *different* fluent-builder types, so the conversion cannot be shared by passing a builder around — but it must be shared, or the two transports silently drift (a `cache_control` marker, a tool-pairing repair, or a sampling knob honoured on one path and not the other). Both now go through one `build_converse_parts`. Stop reasons are lowercased and parsed exactly as the buffered path does, so `chat` and `chat_stream` report an **identical** `finish_reason`.

The module doc no longer claims "`Converse` (non-streaming)".

## Zero trusty-code code changes

`BedrockChatClient` already delegates every trait method — including `chat_stream` — to the shared `BedrockAdapter` (#4436). Its **only** edit in this PR is a 6-line doc comment that described the buffered fallback as current behaviour and is now false. No code, no signatures, no tests.

## Test

Offline (`stream_*`, in `inference/bedrock/tests.rs`) — these drive the **real** `drive()`/decoder code over a scripted `ConverseStream` event sequence, not a reimplementation:

- `stream_forwards_text_deltas_in_order`
- `stream_ignores_structural_events`
- `stream_carries_usage_and_stop_reason_in_terminal`
- `stream_metadata_without_usage_does_not_clobber`
- `stream_maps_tool_use_fragments`
- `stream_tool_slots_are_dense_from_zero`
- `stream_surfaces_mid_stream_error`
- `stream_assembles_into_buffered_shaped_response` — asserts a streamed turn rebuilds (via `StreamAssembly`) into the **same** response `converse_output_to_chat_response` produces, compared against real production output rather than a hand-written expectation
- `build_converse_parts_carries_system_sampling_and_tools`, `build_converse_parts_omits_tool_config_without_tools`

### Live Bedrock: VERIFIED (not just mocked)

Run against real AWS Bedrock, `us.anthropic.claude-sonnet-4-6` in `us-east-1`:

```
running 1 test
delta 1: "One"
delta 2: ", two, three, four, five"
delta 3: ", six, seven, eight, nine"
delta 4: ", ten."
live_bedrock_converse_stream — 4 deltas, done: StreamCompletion { finish_reason: Some(Other("end_turn")), usage: Usage { prompt_tokens: 28, completion_tokens: 23, cache_read_tokens: 0, cache_creation_tokens: 0, cost_usd: None } }
test inference::bedrock::tests::live_bedrock_converse_stream ... ok
```

Four **incremental** deltas (not one buffered blob), correct stop reason, and the terminal `Metadata` token tally surviving. The non-streaming `Converse` path was re-verified live in the same session (returned `"pong"`).

## Gates

| Gate | Result |
|---|---|
| `cargo test -p trusty-common --features inference-client` | 393 passed, 0 failed |
| `cargo test -p trusty-common --features bedrock-client` | 444 passed, 0 failed (incl. all 8 `stream_*`) |
| `cargo test -p trusty-code` | 1590 passed, 0 failed |
| `cargo check -p trusty-agents` | Finished, exit 0 — still builds on untouched `chat::bedrock_impl` |
| `cargo clippy -p trusty-common -p trusty-code --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --check` | exit 0 |
| `bash scripts/check_line_cap.sh` | 7 allowlisted, 0 violations |

Two notes for the reviewer:

- **`--features inference-client` does not compile `src/inference/bedrock/**`** — that module sits behind `bedrock-client` (which implies `inference-client`). Grepping the `inference-client` run for `inference::bedrock` returns **0** tests. Both feature runs are reported above so the coverage claim is honest; this is the trap tracked as #4474.
- `cargo test -p trusty-code` flaked once on `run_task::tests::exit_code_reflects_deadline_exceeded_distinct_from_run_failure` (a wall-clock assertion: `elapsed=5.05s` against a 1s deadline) under parallel build load. It passes in isolation and on rerun, and is unreachable from this diff — the entire trusty-code change is a doc comment.

Closes #4426

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
