### PR TITLE
test(trusty-mpm): pin MPM_BIN_NAMES's PATH-preference ORDER, not just its set

### DIFF
--- a/crates/trusty-mpm/CHANGELOG.md
+++ b/crates/trusty-mpm/CHANGELOG.md
@@ -21,6 +21,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     one canonical `core::own_binary_names::OWN_BINARY_NAMES` constant; hooks'
     list keeps its own array (its PATH-lookup order differs) pinned to the
     same set by a test.
+
 - delegation-tracker `agentId` presence-check no longer accepts `null`/`""` (closes [#4163](https://github.com/bobmatnyc/trusty-tools/issues/4163))
   - `classify_dispatch` decided "we have an agent id" with key-presence alone
     (`r.get("agentId").is_some()`), while `on_launched`'s consumer rejected a
@@ -31,6 +32,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
     a phantom in-flight entry. Both call sites now share one extraction,
     `usable_agent_id` (non-null, non-empty string), so the presence-check and
     the consumers are structurally incapable of disagreeing again.
+
 - `session_status` MCP tool no longer reports `delegation_count: 0` for a managed session with subagents genuinely in flight (closes [#4141](https://github.com/bobmatnyc/trusty-tools/issues/4141))
   - The handler resolved a `ManagedSessionId` and passed it straight into
     `delegations_for`, but hook-observed delegations are keyed by the Claude

--- a/crates/trusty-mpm/src/core/own_binary_names.rs
+++ b/crates/trusty-mpm/src/core/own_binary_names.rs
@@ -24,9 +24,11 @@
 //! first-PATH-hit-wins lookup. `core::standalone::hooks::MPM_BIN_NAMES` needs
 //! the OPPOSITE preference for its own first-hit-wins lookup, so it keeps a
 //! separate literal array with the same two-name SET rather than aliasing
-//! this constant — see that module's doc comment, and
-//! `hooks::tests::test_mpm_bin_names_matches_own_binary_names_set`, which pins
-//! the two to the same set. `daemon::discovery::is_claude_command` and
+//! this constant — see that module's doc comment,
+//! `hooks::tests::test_mpm_bin_names_matches_own_binary_names_set` (pins the
+//! two to the same set) and
+//! `hooks::tests::test_mpm_bin_names_prefers_full_name_over_short_alias`
+//! (pins that array's opposite order). `daemon::discovery::is_claude_command` and
 //! `bin::tm::commands::daemon::find_daemon_pids` compare by exact equality, so
 //! order is immaterial to them.
 //! Test: `own_binary_names_is_tm_then_trusty_mpm` (below) pins the exact

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -219,9 +219,18 @@ pub fn mpm_hook_additions() -> serde_json::Value {
 /// before the #4058 consolidation. `OWN_BINARY_NAMES` is ordered `tm` first
 /// instead, because ITS order-sensitive consumer
 /// (`session_launch::settings::STATUSLINE_BIN_NAMES`) needs the opposite
-/// preference. `test_mpm_bin_names_matches_own_binary_names_set` pins the two
-/// arrays to the same SET so a future third `[[bin]]` target can't drift
-/// between them unnoticed.
+/// preference. `"trusty-mpm"` is first on purpose: it is the unambiguous full
+/// binary name, while `"tm"` is a short alias a user may have shadowed on
+/// `PATH`, and the resolved exe is persisted into `settings.json` where a
+/// wrong resolution survives across sessions.
+///
+/// Test: `test_mpm_bin_names_prefers_full_name_over_short_alias` pins this
+/// array's exact ORDER (the only mechanical guard — `resolve_stable_hook_exe`
+/// calls the real `resolve_binary` and is not injectable, so no behavioural
+/// test can observe the preference), and
+/// `test_mpm_bin_names_matches_own_binary_names_set` pins the two arrays to
+/// the same SET so a future third `[[bin]]` target can't drift between them
+/// unnoticed.
 const MPM_BIN_NAMES: &[&str] = &["trusty-mpm", "tm"];
 
 /// File-name STEMS that identify an mpm-owned binary once any Cargo

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -446,6 +446,27 @@ fn test_mpm_bin_names_matches_own_binary_names_set() {
     );
 }
 
+/// Why (#4058 review round 1 MEDIUM finding 2): the SET test above cannot see
+/// an order flip, and an order flip at this site is exactly what shipped
+/// unnoticed in round 1 — [`resolve_stable_hook_exe`] consumes `MPM_BIN_NAMES`
+/// via `.find_map(resolve_binary)`, so the FIRST entry that resolves on `PATH`
+/// becomes the hook exe. `resolve_stable_hook_exe` calls the real
+/// `resolve_binary` and is not injectable, so no behavioural test can observe
+/// that preference; pinning the array's order is the only mechanical guard.
+/// The order is `"trusty-mpm"` first deliberately: it is the unambiguous full
+/// crate/binary name, whereas `"tm"` is a short alias a user may well have
+/// shadowed on `PATH` with an unrelated tool, and a hook command is persisted
+/// into `settings.json` where a wrong resolution survives across sessions.
+/// What: asserts `MPM_BIN_NAMES` is exactly `["trusty-mpm", "tm"]`, in order.
+#[test]
+fn test_mpm_bin_names_prefers_full_name_over_short_alias() {
+    assert_eq!(
+        MPM_BIN_NAMES,
+        &["trusty-mpm", "tm"],
+        "resolve_stable_hook_exe takes the first PATH hit — 'trusty-mpm' must stay first"
+    );
+}
+
 /// Why (#2235): dedup that keyed identity on the exact file name ∈
 /// {`trusty-mpm`,`tm`} could never strip a stale entry whose command carried a
 /// Cargo build-artifact path (`.../deps/trusty_mpm-<hash> hook`,


### PR DESCRIPTION
Follow-up to #4465 (issue #4058), which squash-merged as `da6ca5e1` while this round's gates were still running. One code-critic finding was left half-closed by that merge; this PR finishes it.

## What was left open

Critic round-1 finding 2 (MEDIUM) was that `hooks::MPM_BIN_NAMES` had silently flipped from `["trusty-mpm", "tm"]` to `["tm", "trusty-mpm"]`, changing which binary `resolve_stable_hook_exe` prefers on `PATH`. #4465 restored the original literal and added `test_mpm_bin_names_matches_own_binary_names_set` — but that test pins the two-name **SET** against `OWN_BINARY_NAMES`, and a set assertion cannot see an order flip. The exact failure mode that shipped unnoticed in round 1 was still unguarded.

## Fix

- `test_mpm_bin_names_prefers_full_name_over_short_alias` asserts the array is exactly `["trusty-mpm", "tm"]`, **in order**. `resolve_stable_hook_exe` calls the real `resolve_binary` and is not injectable, so no behavioural test can observe the preference — pinning the array order is the only mechanical guard available.
- Recorded the rationale on `MPM_BIN_NAMES`'s doc comment (`Test:` axis now cites both tests) and cross-referenced the new test from `own_binary_names.rs`'s module doc.

## Why `trusty-mpm` first, deliberately

`resolve_stable_hook_exe` consumes `MPM_BIN_NAMES` via `.find_map(resolve_binary)` — first PATH hit wins. `trusty-mpm` is the unambiguous full binary name; `tm` is a two-letter alias a user may well have shadowed on `PATH` with an unrelated tool, and the resolved exe is persisted into `settings.json`, where a wrong resolution survives across sessions. `OWN_BINARY_NAMES` keeps the opposite order (`tm` first) because *its* order-sensitive consumer, `session_launch::settings::STATUSLINE_BIN_NAMES`, needs that preference. Both orders are load-bearing; both are now pinned.

## Also

CHANGELOG: restored two blank separator lines between the `#4163` / `#4141` / `#4058` `[Unreleased]` entries. #4465's merge of `origin/main` dropped them, so `da6ca5e1` landed a cosmetic regression in entries it didn't otherwise touch.

## Gates (raw output)

Run on a tree byte-identical to `main` + this commit (`tree(da6ca5e1) == tree(4af4a1e6)`, verified).

- `cargo test -p trusty-mpm --no-fail-fast` → exit 0; lib `test result: ok. 4041 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out`, plus both feature-variant targets `1319 passed; 0 failed` and all integration targets `0 failed`
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings` → exit 0, no crate warnings
- `cargo fmt --check` → exit 0
- `bash scripts/check_line_cap.sh` → `line-cap: 7 allowlisted, 0 violations — OK.`
- `bash scripts/check_claude_md_not_tracked.sh` → `PASS: root CLAUDE.md is not tracked (see #2299).`

An earlier full-surface run showed 2 failures — `client::executor::tests::execute_doctor_against_test_daemon` and `connectors::tm::tests::create_session_full_lifecycle`, both `daemon unreachable` / transport errors against ephemeral localhost test daemons under parallel load (the known #4407/#4306 shape). Neither test references any symbol this PR or #4465 touches; both pass in isolation and both passed in the clean full run above. No coverage was disabled to get there — the total test count is identical (4039 passed + 2 failed = 4041 → 4041 passed).

Refs #4058, #4465.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools