### PR TITLE
feat(trusty-agents): read trusty-mpm's .claude/agents artifacts with the SHARED frontmatter parser (#4495)

### DIFF
--- a/crates/trusty-agents/changelog.d/4495-mpm-shared-frontmatter-bridge.md
+++ b/crates/trusty-agents/changelog.d/4495-mpm-shared-frontmatter-bridge.md
@@ -1,0 +1,21 @@
+Added
+
+- **`agents::mpm_bridge` — read trusty-mpm's deployed `.claude/agents/*.md`
+  artifacts with the SHARED frontmatter parser** (#4495). The crate already
+  depended on `trusty_agents_common::agents::metadata::agent_metadata_from_str`
+  — the product-agnostic reader wrapping the same `split_frontmatter` grammar
+  `compose_agent` emits with — but used it only for compress/adapters/rbac/perf;
+  no agent-loading code touched it. This module projects one already-flattened
+  deploy artifact onto trusty-agents' own `AgentConfig`, mirroring trusty-code's
+  `plugins::agents::load_plugin_agent` (#3539) so all three products read one
+  grammar. Leaf-only by decision: a residual `extends:` is warned about and
+  ignored (deploy artifacts are pre-flattened) and is not propagated to
+  `AgentInfo::extends`. Two same-name/different-semantics traps are refused
+  rather than mapped, each pinned by its own test: trusty-mpm's `skills:` is a
+  co-deployment DEPENDENCY list and never becomes trusty-agents' `[skills].allow`
+  PERMISSION GATE, and `tier` is never populated because it is derived
+  (`AgentTier::for_kind`). `tools:` maps to `ToolsConfig.allowed` (exact-name)
+  rather than `.allow` (globs, where a trailing `*` widens) — where the two
+  readings differ the restrictive one wins. Every other frontmatter key is
+  dropped with one aggregated warning naming it. Additive: nothing calls the
+  module yet, and no agent's reachability changes.

--- a/crates/trusty-agents/src/agents/mod.rs
+++ b/crates/trusty-agents/src/agents/mod.rs
@@ -26,6 +26,9 @@ pub mod harness_protocol;
 pub mod in_process_runner;
 mod loader;
 mod model;
+// The shared-frontmatter bridge for trusty-mpm's deployed `.claude/agents`
+// artifacts. `pub(crate)` — an internal parser selection, not public surface.
+pub(crate) mod mpm_bridge;
 mod params;
 pub mod permissions;
 pub mod persona;

--- a/crates/trusty-agents/src/agents/mpm_bridge.rs
+++ b/crates/trusty-agents/src/agents/mpm_bridge.rs
@@ -1,0 +1,365 @@
+//! Read a trusty-mpm-deployed `.claude/agents/*.md` artifact with the SHARED
+//! frontmatter reader and project it onto trusty-agents' `AgentConfig`.
+//!
+//! Why: the owner's directive is "the same agents across the system — mpm,
+//! code, agents" with as little rewriting as feasible. trusty-mpm composes its
+//! agents and DEPLOYS them, already flattened, to `~/.claude/agents/*.md` and
+//! `<project>/.claude/agents/*.md`. `AgentRegistry::load` already scans both
+//! of those directories as a first-class roster tier, but it parses them with
+//! `registry::md_agent::parse_md_agent` — a hand-rolled `serde_yaml` reader
+//! shaped for trusty-agents' OWN `.md` overlay schema, not for trusty-mpm's.
+//! The two schemas disagree (mpm's `tools:` is a flat name list; the overlay's
+//! is a nested `ToolsConfig` map — feeding the former to the latter is a hard
+//! `serde_yaml` error that silently drops the whole agent), so the tier that
+//! reads mpm's artifacts should use mpm's own reader. That reader already
+//! exists and is already a dependency of this crate:
+//! `trusty_agents_common::agents::metadata::agent_metadata_from_str`, which
+//! wraps the identical `split_frontmatter` grammar `compose_agent` emits with.
+//! trusty-code adopted exactly this reader for exactly this artifact class in
+//! #3539 (`plugins::agents::load_plugin_agent`); this module mirrors that
+//! precedent so all three products read one grammar.
+//!
+//! LEAF-ONLY, by decision: this consumes the already-flattened DEPLOY artifact,
+//! never trusty-mpm's pre-compose source tree. `compose_agent` resolves and
+//! strips `extends:` before deploy, so there is nothing left to resolve —
+//! a residual `extends:` is warned about and ignored, and `AgentInfo::extends`
+//! is left `None` so `registry::resolve_extends_in_map` never chases an mpm
+//! base name that does not exist in this registry.
+//!
+//! What: [`load_mpm_agent`] (read one file, warn about every field this crate
+//! has no home for, project the rest) and [`is_claude_agents_dir`] (the
+//! predicate that selects the `.claude/agents` tier).
+//! Test: `tests::*` in `mpm_bridge_tests.rs` — scalar projection, `extends:`
+//! ignored, `skills:` never becoming a permission grant, `tier` never
+//! populated, `tools:` mapped to the exact-name allowlist, the aggregated
+//! drop warning, and the directory predicate.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::Context;
+use trusty_agents_common::agents::frontmatter::parse_kv_line;
+use trusty_agents_common::agents::metadata::{AgentMetadata, agent_metadata_from_str};
+
+use crate::agents::{
+    AgentCompressConfig, AgentConfig, AgentInfo, LlmParams, RunnerKind, SystemPrompt, ToolChoice,
+    ToolsConfig,
+};
+use crate::llm::adapter::adapter_for_model;
+
+/// The frontmatter keys this projection actually consumes.
+///
+/// Why: the drop warning is computed as "every key present minus these"
+/// rather than from a hardcoded list of known-unsupported mpm keys. A
+/// deny-list would go stale the moment trusty-mpm's schema grows a key; an
+/// allow-list cannot, because a new key is unmapped by construction and shows
+/// up in the warning on its first appearance.
+/// What: lowercase keys, matching [`parse_kv_line`]'s case-folded output.
+/// `extends` is listed here because it is deliberately consumed (to warn) —
+/// it gets its own, more specific message rather than the aggregated one.
+/// Test: `tests::drop_warning_lists_only_unmapped_keys`.
+const CONSUMED_KEYS: &[&str] = &[
+    "name",
+    "role",
+    "description",
+    "model",
+    "max_tokens",
+    "tools",
+    "extends",
+];
+
+/// Is `dir` a `.claude/agents` directory — the tier that holds trusty-mpm's
+/// deployed artifacts?
+///
+/// Why: `AgentRegistry::load` walks a mixed list of search paths
+/// (`agent_search_paths`): `.trusty-agents/agents` holds trusty-agents' OWN
+/// `.md` overlay schema and must keep using `parse_md_agent`, while
+/// `.claude/agents` holds trusty-mpm's deploy artifacts and must use this
+/// module. The loader needs one predicate to tell the two apart, and matching
+/// on the directory SHAPE (rather than on a string equal to a hardcoded path)
+/// is what makes it work identically for the project-local
+/// `.claude/agents` and the `$HOME/.claude/agents` entries.
+/// What: `true` when `dir`'s final component is `agents` and its parent's
+/// final component is `.claude`. Purely lexical — no IO, no canonicalization,
+/// so a caller that already knows the directory exists pays nothing.
+/// Test: `tests::claude_agents_dir_predicate_matches_both_tiers`,
+/// `tests::claude_agents_dir_predicate_rejects_trusty_agents_dir`.
+#[allow(dead_code)] // Wired into `AgentRegistry::load`'s tier selection in the follow-up PR.
+pub(crate) fn is_claude_agents_dir(dir: &Path) -> bool {
+    dir.file_name().is_some_and(|n| n == "agents")
+        && dir
+            .parent()
+            .and_then(Path::file_name)
+            .is_some_and(|n| n == ".claude")
+}
+
+/// Read one trusty-mpm-deployed agent file and project it onto `AgentConfig`.
+///
+/// Why: the single entry point `AgentRegistry::load` calls for the
+/// `.claude/agents` tier, so the read/warn/project contract is written once.
+/// What: reads `path`, parses its frontmatter with the SHARED
+/// [`agent_metadata_from_str`] (never `compose_agent` — the artifact is
+/// already flattened), emits the two warnings described on
+/// [`warn_dropped_fields`] and below, then projects via
+/// [`project_mpm_agent`]. An unreadable file is the only error path; a
+/// malformed frontmatter block degrades to empty metadata (the shared
+/// reader's own documented behavior) and the file-stem name, rather than
+/// dropping the agent.
+/// Test: `tests::projects_clean_scalars`, `tests::missing_file_errors`,
+/// `tests::malformed_frontmatter_falls_back_to_file_stem`.
+#[allow(dead_code)] // Wired into `AgentRegistry::load`'s tier selection in the follow-up PR.
+pub(crate) fn load_mpm_agent(path: &Path) -> anyhow::Result<AgentConfig> {
+    let raw = std::fs::read_to_string(path)
+        .with_context(|| format!("failed to read trusty-mpm agent md {}", path.display()))?;
+
+    let default_name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown");
+
+    let meta = agent_metadata_from_str(&raw);
+    let agent_name = meta.name.as_deref().unwrap_or(default_name);
+
+    if let Some(parent) = &meta.extends {
+        tracing::warn!(
+            agent = %agent_name,
+            path = %path.display(),
+            extends = %parent,
+            "trusty-mpm agent declares `extends:` — .claude/agents holds already-flattened \
+             DEPLOY artifacts, so this tier is leaf-only and the parent is NOT resolved; \
+             loading this file's own frontmatter and body only"
+        );
+    }
+    warn_dropped_fields(agent_name, path, &raw);
+
+    Ok(project_mpm_agent(default_name, meta, extract_body(&raw)))
+}
+
+/// Warn ONCE, naming every frontmatter key this projection has no home for.
+///
+/// Why: trusty-mpm's schema is richer than trusty-agents' `.md` surface
+/// (`skills:`, `initialPrompt:`, `agent_type:`, `version:`, `effort:`, …).
+/// Silently discarding them is how a user ends up believing a declaration
+/// took effect when it did not, so every drop is reported — but as ONE
+/// aggregated line per agent rather than one line per key, mirroring
+/// trusty-code's `plugins::agents::warn_unsupported_fields` (#3539).
+/// What: scans the frontmatter block's top-level keys with the SHARED
+/// [`parse_kv_line`] (presence detection only — the values that ARE mapped
+/// were already parsed by `agent_metadata_from_str`), subtracts
+/// [`CONSUMED_KEYS`], and logs the remainder. No-op when nothing is dropped.
+/// Test: `tests::drop_warning_lists_only_unmapped_keys`,
+/// `tests::no_drop_warning_when_every_key_is_mapped`.
+fn warn_dropped_fields(agent_name: &str, path: &Path, raw: &str) {
+    let dropped = unmapped_keys(raw);
+    if dropped.is_empty() {
+        return;
+    }
+    tracing::warn!(
+        agent = %agent_name,
+        path = %path.display(),
+        dropped = %dropped.join(", "),
+        "trusty-mpm agent declares frontmatter key(s) trusty-agents has no slot for — dropped; \
+         note `skills:` in particular is a trusty-mpm CO-DEPLOYMENT DEPENDENCY list and is NOT \
+         mapped onto trusty-agents' `[skills].allow`, which is a permission GATE"
+    );
+}
+
+/// The top-level frontmatter keys in `raw` that [`project_mpm_agent`] does not
+/// consume, in first-seen order, de-duplicated.
+///
+/// Why: split out from [`warn_dropped_fields`] so the key-set logic is
+/// directly assertable in a test without capturing a `tracing` subscriber.
+/// What: walks only the block between the opening `---` and the next `---`,
+/// and only lines with no leading indentation (a nested map's or block
+/// sequence's members are part of their parent key, not keys in their own
+/// right). Returns empty for a document with no frontmatter fence.
+/// Test: `tests::drop_warning_lists_only_unmapped_keys`,
+/// `tests::unmapped_keys_ignores_nested_and_body_lines`.
+fn unmapped_keys(raw: &str) -> Vec<String> {
+    let mut lines = raw.trim_start_matches('\u{feff}').lines();
+    match lines.next() {
+        Some(first) if first.trim() == "---" => {}
+        _ => return Vec::new(),
+    }
+    let mut out: Vec<String> = Vec::new();
+    for line in lines {
+        if line.trim() == "---" {
+            break;
+        }
+        // Indented lines belong to the preceding key (nested map entries,
+        // block-sequence items); they are never keys themselves.
+        if line.starts_with([' ', '\t', '-']) {
+            continue;
+        }
+        let Some((key, _)) = parse_kv_line(line) else {
+            continue;
+        };
+        if !CONSUMED_KEYS.contains(&key.as_str()) && !out.contains(&key) {
+            out.push(key);
+        }
+    }
+    out
+}
+
+/// The prose body of a composed agent document — everything after the closing
+/// frontmatter fence.
+///
+/// Why: this becomes `system_prompt.content` verbatim. It is located
+/// STRUCTURALLY (scan to the closing fence) rather than by re-reading parsed
+/// frontmatter, which is the same guarantee trusty-code's
+/// `md_loader::extract_body` documents: trusty-mpm's compose step can enrich
+/// a role-derived `initialPrompt:` INTO the frontmatter, and that value must
+/// never leak into a trusty-agents system prompt. Never inspecting the block's
+/// contents makes the leak unrepresentable rather than merely unimplemented.
+/// What: skips the opening `---` line and everything through the next `---`
+/// line, returns the trimmed remainder. A document with no opening fence
+/// returns the whole input trimmed (a body-only file is still a usable
+/// prompt). An interior `---` horizontal rule in the prose survives, because
+/// the scan stops at the FIRST closing fence.
+/// Test: `tests::body_excludes_frontmatter`,
+/// `tests::body_keeps_interior_horizontal_rule`,
+/// `tests::body_of_frontmatter_only_document_is_empty`.
+fn extract_body(raw: &str) -> String {
+    let mut lines = raw.trim_start_matches('\u{feff}').lines();
+    match lines.next() {
+        Some(first) if first.trim() == "---" => {}
+        _ => return raw.trim().to_string(),
+    }
+    let mut in_frontmatter = true;
+    let mut body: Vec<&str> = Vec::new();
+    for line in lines {
+        if in_frontmatter {
+            if line.trim() == "---" {
+                in_frontmatter = false;
+            }
+            continue;
+        }
+        body.push(line);
+    }
+    body.join("\n").trim().to_string()
+}
+
+/// Project parsed trusty-mpm metadata + body onto trusty-agents'
+/// `AgentConfig`.
+///
+/// Why: centralises the field-by-field mapping so [`load_mpm_agent`] stays a
+/// thin IO wrapper, and so every deliberate NON-mapping below has one place to
+/// be read and tested.
+/// What, field by field:
+/// - `name` -> `agent.name`, falling back to `default_name` (the file stem),
+///   exactly as `parse_md_agent` identifies an unnamed file.
+/// - `role` -> `agent.role`, defaulting to `"agent"` — byte-identical to
+///   `parse_md_agent`'s default, so switching this tier's parser changes no
+///   agent's role and therefore no agent's derived tier (see below).
+/// - `description` -> `agent.description`; `model` -> `agent.model` after
+///   `resolve_model` (the same `TAGENT_MODEL_*` / default env resolution
+///   `parse_md_agent` applies on its non-`extends` path — this tier is always
+///   that path, since it is leaf-only).
+/// - `max_tokens` -> `llm.max_tokens`, defaulting to `parse_md_agent`'s
+///   historical `8192` when the artifact declares none (which is the norm —
+///   trusty-mpm agents do not set this key).
+/// - `tools: Option<Vec<String>>` -> `tools.allowed`, a DIRECT map. Both sides
+///   are an EXACT-NAME allowlist with identical three-way semantics: `None` =
+///   no restriction, `Some(vec![])` = deny-all, `Some(list)` = exactly those
+///   names (see `ToolsConfig::allowed` and
+///   `agents_common::builder::Frontmatter::tools`). The alternative slot,
+///   `tools.allow`, is a GLOB list where a trailing `*` is a suffix wildcard —
+///   routing exact names through it would let a literal tool name containing
+///   `*` widen into a pattern, which is strictly MORE permissive than what the
+///   artifact declared. Where the two readings differ, the restrictive one
+///   wins, so: `allowed`, and `allow` stays `None`. This is also the exact
+///   mapping trusty-code made for the same artifact class (`md_loader`'s
+///   `ToolsConfig { allowed: meta.tools }`). Note trusty-mpm OVERRIDE-merges
+///   `tools:` across an `extends` chain while trusty-agents UNIONs it; the
+///   difference is unreachable here because this tier resolves no chain at all.
+/// - `skills` -> DROPPED, deliberately. trusty-mpm's `skills:` is a
+///   co-deployment DEPENDENCY list ("ship these skill files alongside me");
+///   trusty-agents' `[skills].allow` is a PERMISSION GATE whose `None` means
+///   "this agent does not use skill grants" and whose `Some([])` means "grants
+///   none". Mapping one to the other would silently convert a dependency
+///   declaration into a grant, so `skills` is left at `SkillsConfig::default()`
+///   and reported in the drop warning.
+/// - `extends` -> NOT propagated to `agent.extends`. Deploy artifacts are
+///   pre-flattened; leaving the field `Some` would make
+///   `resolve_extends_in_map` chase an mpm base name absent from this registry
+///   and log a resolution failure for an agent that has nothing to resolve.
+/// - `tier` -> NOT populated. It is DERIVED (`AgentInfo::tier()` ->
+///   `AgentTier::for_kind(role)`); an mpm-sourced sub-agent is L1 by
+///   construction, and declaring a tier here would either restate that or
+///   forge an escalation.
+/// - `subagents`/`permissions`/`rbac`/`listeners`/`stores` -> defaults. In
+///   particular `SubagentsConfig::default()` grants NO delegation targets, so
+///   nothing loaded through this path becomes reachable from any assistant.
+/// Test: `tests::projects_clean_scalars`, `tests::tools_map_to_exact_allowlist`,
+/// `tests::skills_never_become_a_permission_grant`,
+/// `tests::tier_is_never_populated`, `tests::extends_is_not_propagated`,
+/// `tests::projected_agent_grants_no_subagents`.
+fn project_mpm_agent(default_name: &str, meta: AgentMetadata, body: String) -> AgentConfig {
+    let name = meta.name.unwrap_or_else(|| default_name.to_string());
+    let model = crate::agents::resolve_model(&name, &meta.model.unwrap_or_default(), None).0;
+    let adapter: Arc<dyn crate::llm::adapter::ModelAdapter> = Arc::from(adapter_for_model(&model));
+
+    AgentConfig {
+        agent: AgentInfo {
+            name,
+            role: meta.role.unwrap_or_else(|| "agent".to_string()),
+            model,
+            description: meta.description.unwrap_or_default(),
+            persistent_session: false,
+            runner: RunnerKind::Subprocess,
+            capabilities: None,
+            display_name: None,
+            hidden: false,
+            kind: "assistant".to_string(),
+            prompt_label: None,
+            // Leaf-only: see this function's doc comment.
+            extends: None,
+            // Derived, never declared: see this function's doc comment.
+            tier: None,
+        },
+        llm: LlmParams {
+            temperature: 0.2,
+            max_tokens: meta.max_tokens.unwrap_or(8192),
+            model_override: None,
+            enable_prompt_caching: true,
+            max_turns: 20,
+            persona_max_turns: None,
+            tool_choice: ToolChoice::Auto,
+            use_finish_task: false,
+            use_anthropic_direct: false,
+            claude_allowed_tools: Vec::new(),
+            aws_profile: None,
+            aws_region: None,
+            elevation_threshold: None,
+            elevation_model: None,
+            stop_sequences: Vec::new(),
+            routing_model: None,
+            thinking_enabled: None,
+        },
+        system_prompt: SystemPrompt {
+            content: body,
+            skills: None,
+        },
+        tools: ToolsConfig {
+            allowed: meta.tools,
+            ..ToolsConfig::default()
+        },
+        compress: AgentCompressConfig::default(),
+        runner_config: crate::agents::RunnerConfig::default(),
+        session: crate::agents::SessionCompressionConfig::default(),
+        plugins: crate::agents::AgentPluginsConfig::default(),
+        rbac: crate::agents::RbacConfig::default(),
+        workstreams: crate::agents::WorkstreamContextConfig::default(),
+        adapter,
+        listeners: Vec::new(),
+        stores: crate::stores::StoresConfig::default(),
+        // Dependency list, NOT a permission grant: see this function's doc.
+        skills: crate::agents::SkillsConfig::default(),
+        permissions: crate::agents::PermissionsConfig::default(),
+        subagents: crate::agents::SubagentsConfig::default(),
+    }
+}
+
+#[cfg(test)]
+#[path = "mpm_bridge_tests.rs"]
+mod tests;

--- a/crates/trusty-agents/src/agents/mpm_bridge_tests.rs
+++ b/crates/trusty-agents/src/agents/mpm_bridge_tests.rs
@@ -1,0 +1,250 @@
+//! Unit tests for the trusty-mpm `.claude/agents` frontmatter bridge.
+//!
+//! Why: the correctness-critical part of this adapter is not what it maps but
+//! what it deliberately REFUSES to map — `skills:` must never become a
+//! permission grant, `tier` must never be declared, `extends:` must never be
+//! propagated, and `tools:` must land in the exact-name slot rather than the
+//! glob slot. Each of those is pinned by its own test so a future "helpful"
+//! widening fails loudly.
+//! What: covers scalar projection, body extraction, the unmapped-key set, the
+//! four refusals above, and the `.claude/agents` directory predicate.
+//! Test: this file.
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use super::*;
+
+/// Write `content` to `<dir>/<name>.md` and return its path.
+fn write_agent(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(format!("{name}.md"));
+    std::fs::write(&path, content).expect("write agent md");
+    path
+}
+
+/// A realistic trusty-mpm deploy artifact: the flattened shape
+/// `compose_agent` emits, block-style `skills:` and all.
+const MPM_ARTIFACT: &str = "---\n\
+name: rust-engineer\n\
+role: engineer\n\
+description: Rust 2024 specialist\n\
+model: sonnet\n\
+effort: balanced\n\
+agent_type: engineer\n\
+version: \"2.0.1\"\n\
+skills:\n\
+- toolchains-rust-core\n\
+- git-workflow\n\
+---\n\
+\n\
+# Rust Engineer\n\
+\n\
+Body prose.\n";
+
+#[test]
+fn projects_clean_scalars() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_agent(tmp.path(), "rust-engineer", MPM_ARTIFACT);
+
+    let cfg = load_mpm_agent(&path).expect("mpm artifact loads");
+
+    assert_eq!(cfg.agent.name, "rust-engineer");
+    assert_eq!(cfg.agent.role, "engineer");
+    assert_eq!(cfg.agent.description, "Rust 2024 specialist");
+    assert!(
+        cfg.agent.model.contains("sonnet"),
+        "declared model should survive resolve_model, got {}",
+        cfg.agent.model
+    );
+    assert!(cfg.system_prompt.content.starts_with("# Rust Engineer"));
+    assert!(cfg.system_prompt.content.ends_with("Body prose."));
+}
+
+/// `skills:` is a trusty-mpm CO-DEPLOYMENT DEPENDENCY list. trusty-agents'
+/// `[skills].allow` is a PERMISSION GATE where `None` means "does not use
+/// skill grants". Mapping one onto the other would silently turn a dependency
+/// declaration into a grant — the single most dangerous same-name/
+/// different-semantics collision between the two schemas.
+#[test]
+fn skills_never_become_a_permission_grant() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_agent(tmp.path(), "rust-engineer", MPM_ARTIFACT);
+
+    let cfg = load_mpm_agent(&path).expect("mpm artifact loads");
+
+    assert!(
+        cfg.skills.allow.is_none(),
+        "[skills].allow must stay at its default `None` (does not use skill grants); \
+         mapping trusty-mpm's dependency list here would forge a permission grant"
+    );
+    // The body-side prompt-skills slot must be untouched too.
+    assert!(cfg.system_prompt.skills.is_none());
+}
+
+/// `tier` is DERIVED (`AgentInfo::tier()` -> `AgentTier::for_kind(role)`), so
+/// an mpm-sourced sub-agent is L1 by construction. Declaring one here would be
+/// meaningless at best and an escalation at worst.
+#[test]
+fn tier_is_never_populated() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_agent(
+        tmp.path(),
+        "sneaky",
+        "---\nname: sneaky\nrole: engineer\ntier: l0\n---\n\nBody.\n",
+    );
+
+    let cfg = load_mpm_agent(&path).expect("loads");
+
+    assert!(
+        cfg.agent.tier.is_none(),
+        "a declared `tier:` in an mpm artifact must be dropped, not honoured"
+    );
+    assert_eq!(cfg.agent.tier(), crate::agents::AgentTier::L1Standard);
+}
+
+/// `.claude/agents` holds already-flattened DEPLOY artifacts, so this tier is
+/// leaf-only: a residual `extends:` is warned about and ignored, and the field
+/// is NOT propagated (propagating it would make `resolve_extends_in_map` chase
+/// an mpm base name that is absent from this registry).
+#[test]
+fn extends_is_not_propagated() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_agent(
+        tmp.path(),
+        "child",
+        "---\nname: child\nrole: engineer\nextends: base-engineer\n---\n\nBody.\n",
+    );
+
+    let cfg = load_mpm_agent(&path).expect("loads despite extends");
+
+    assert!(cfg.agent.extends.is_none());
+    assert_eq!(cfg.agent.name, "child");
+    assert_eq!(cfg.system_prompt.content, "Body.");
+}
+
+/// trusty-mpm's `tools:` is a flat list of EXACT tool names, so it maps to
+/// `ToolsConfig::allowed` (exact-name allowlist) and never to
+/// `ToolsConfig::allow` (glob patterns, where a trailing `*` widens).
+#[test]
+fn tools_map_to_exact_allowlist() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_agent(
+        tmp.path(),
+        "narrow",
+        "---\nname: narrow\nrole: qa\ntools: [Read, Grep]\n---\n\nBody.\n",
+    );
+
+    let cfg = load_mpm_agent(&path).expect("loads");
+
+    assert_eq!(
+        cfg.tools.allowed.as_deref(),
+        Some(["Read".to_string(), "Grep".to_string()].as_slice())
+    );
+    assert!(
+        cfg.tools.allow.is_none(),
+        "the glob slot must stay unset — exact names routed through it could widen"
+    );
+}
+
+/// `tools: []` is a deliberate deny-all on BOTH sides and must survive as
+/// `Some(vec![])`, never collapse to the `None` that means "no restriction".
+#[test]
+fn empty_tools_list_stays_deny_all() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_agent(
+        tmp.path(),
+        "denied",
+        "---\nname: denied\nrole: qa\ntools: []\n---\n\nBody.\n",
+    );
+
+    let cfg = load_mpm_agent(&path).expect("loads");
+
+    assert_eq!(cfg.tools.allowed, Some(Vec::new()));
+}
+
+/// Nothing loaded through this path grants a delegation target — catalog
+/// population must never change reachability.
+#[test]
+fn projected_agent_grants_no_subagents() {
+    let tmp = TempDir::new().unwrap();
+    let path = write_agent(tmp.path(), "rust-engineer", MPM_ARTIFACT);
+
+    let cfg = load_mpm_agent(&path).expect("loads");
+
+    assert!(cfg.subagents.delegate_allowed.is_none());
+}
+
+#[test]
+fn drop_warning_lists_only_unmapped_keys() {
+    let dropped = unmapped_keys(MPM_ARTIFACT);
+    assert_eq!(dropped, vec!["effort", "agent_type", "version", "skills"]);
+}
+
+#[test]
+fn no_drop_warning_when_every_key_is_mapped() {
+    let doc =
+        "---\nname: plain\nrole: qa\ndescription: d\nmodel: sonnet\ntools: [Read]\n---\n\nB.\n";
+    assert!(unmapped_keys(doc).is_empty());
+}
+
+#[test]
+fn unmapped_keys_ignores_nested_and_body_lines() {
+    let doc = "---\nname: n\nnested:\n  inner: v\n---\n\nbody_key: not a frontmatter key\n";
+    assert_eq!(unmapped_keys(doc), vec!["nested"]);
+}
+
+#[test]
+fn body_excludes_frontmatter() {
+    assert_eq!(
+        extract_body("---\nname: x\nskills:\n- a\n---\n\nPrompt text.\n"),
+        "Prompt text."
+    );
+}
+
+#[test]
+fn body_keeps_interior_horizontal_rule() {
+    let body = extract_body("---\nname: x\n---\n\nOne\n\n---\n\nTwo\n");
+    assert!(body.contains("---"), "interior rule survived: {body}");
+    assert!(body.starts_with("One") && body.ends_with("Two"));
+}
+
+#[test]
+fn body_of_frontmatter_only_document_is_empty() {
+    assert_eq!(extract_body("---\nname: x\n---\n"), "");
+}
+
+#[test]
+fn malformed_frontmatter_falls_back_to_file_stem() {
+    let tmp = TempDir::new().unwrap();
+    // No opening fence at all: the shared reader yields default metadata and
+    // the whole document becomes the prompt body.
+    let path = write_agent(tmp.path(), "bodyonly", "Just a prompt, no frontmatter.\n");
+
+    let cfg = load_mpm_agent(&path).expect("degrades rather than dropping the agent");
+
+    assert_eq!(cfg.agent.name, "bodyonly");
+    assert_eq!(cfg.agent.role, "agent");
+    assert_eq!(cfg.system_prompt.content, "Just a prompt, no frontmatter.");
+}
+
+#[test]
+fn missing_file_errors() {
+    assert!(load_mpm_agent(Path::new("/nonexistent/agent.md")).is_err());
+}
+
+#[test]
+fn claude_agents_dir_predicate_matches_both_tiers() {
+    assert!(is_claude_agents_dir(Path::new(".claude/agents")));
+    assert!(is_claude_agents_dir(Path::new("/home/user/.claude/agents")));
+}
+
+#[test]
+fn claude_agents_dir_predicate_rejects_trusty_agents_dir() {
+    assert!(!is_claude_agents_dir(Path::new(".trusty-agents/agents")));
+    assert!(!is_claude_agents_dir(Path::new(
+        "/home/u/.trusty-agents/agents"
+    )));
+    assert!(!is_claude_agents_dir(Path::new(".claude/skills")));
+    assert!(!is_claude_agents_dir(Path::new("agents")));
+}


### PR DESCRIPTION
## What

Adds `agents::mpm_bridge` — a small adapter that reads a trusty-mpm-deployed `.claude/agents/*.md` artifact with the **shared** frontmatter reader (`trusty_agents_common::agents::metadata::agent_metadata_from_str`) and projects it onto trusty-agents' own `AgentConfig`.

Purely additive: nothing calls it yet. #4496 wires it into `AgentRegistry::load`'s `.claude/agents` tier.

## Why

Owner directive (2026-07-31): *"I want to use the same agents across the system. mpm, code, agents. … We're trying to rewrite as little as feasible."*

trusty-agents hand-rolls **two** frontmatter parsers (`claude_mpm_loader::ClaudeMpmFrontmatter`, `registry::md_agent::MdAgentFrontmatter`) while the shared, product-agnostic reader — which wraps the very `split_frontmatter` grammar `compose_agent` *emits* with — is already a live dependency of this crate (`Cargo.toml:183`), used only for compress/adapters/rbac/perf. Zero agent-loading code touches it.

trusty-code adopted that reader for exactly this artifact class in #3539 (`plugins::agents::load_plugin_agent`). This mirrors that precedent so all three products read one grammar.

## Design decision (settled, not re-litigated here)

Consume the **already-flattened deploy artifacts**, leaf-only — exactly trusty-code's posture. Not trusty-mpm's pre-compose source tree, and no `extends:` resolution: trusty-mpm flattens `extends` before deploy, so there is nothing to resolve. This is the minimal-rewrite path.

## Projection mapping

| trusty-mpm frontmatter | trusty-agents `AgentConfig` | Notes |
|---|---|---|
| `name` | `agent.name` | falls back to file stem |
| `role` | `agent.role` | defaults `"agent"` — byte-identical to `parse_md_agent` |
| `description` | `agent.description` | direct |
| `model` | `agent.model` | via `resolve_model` (same env resolution as today) |
| `max_tokens` | `llm.max_tokens` | defaults to the historical `8192` |
| `tools` | `tools.allowed` | **exact-name**, see below |
| `extends` | *(dropped, warned)* | leaf-only; not propagated to `agent.extends` |
| `skills` | *(dropped, warned)* | **must not** become a permission grant |
| `tier` | *(never populated)* | derived, not declared |
| everything else | *(dropped, one aggregated warning)* | |

### Why `tools:` → `allowed`, not `allow`

trusty-mpm's `tools:` is a **flat list of exact tool names** (`Option<Vec<String>>`, `agents_common::builder::Frontmatter::tools`). trusty-agents offers two slots:

- `ToolsConfig::allowed` — exact-name allowlist. `None` = no restriction, `Some([])` = deny-all, `Some(list)` = exactly those names. **Identical three-way semantics to mpm's field.**
- `ToolsConfig::allow` — glob patterns, where a trailing `*` is a suffix wildcard.

Routing exact names through the glob slot would let a literal tool name containing `*` widen into a pattern — strictly *more* permissive than what the artifact declared. Per the "default to the more restrictive interpretation" rule, it maps to `allowed`, and `allow` stays `None`. This is also the exact mapping trusty-code made (`md_loader`'s `ToolsConfig { allowed: meta.tools }`).

(trusty-mpm OVERRIDE-merges `tools:` across an `extends` chain while trusty-agents UNIONs it. That divergence is unreachable here because this tier resolves no chain at all.)

### Why `skills:` is dropped, not mapped

Same name, opposite meaning — the most dangerous collision between the two schemas:

- trusty-mpm's `skills:` is a **co-deployment dependency list** ("ship these skill files alongside me").
- trusty-agents' `[skills].allow` is a **permission gate** (`config.rs:279-292`): `None` = "does not use skill grants", `Some([])` = "grants none".

Mapping one to the other silently converts a dependency declaration into a permission grant. `[skills]` stays at its default and the field is named in the drop warning. Pinned by `skills_never_become_a_permission_grant`.

### Why `tier` is never populated

It is DERIVED — `AgentInfo::tier()` → `AgentTier::for_kind(role)` — and an mpm-sourced sub-agent is L1 by construction. A declared `tier: l0` is dropped, not honoured. Pinned by `tier_is_never_populated`.

### Body extraction

Located **structurally** (scan past the closing fence) rather than from parsed frontmatter. trusty-mpm's compose step can enrich a role-derived `initialPrompt:` into the frontmatter, and that value must never reach a trusty-agents system prompt. Never inspecting the block's contents makes the leak unrepresentable rather than merely unimplemented — the same guarantee trusty-code's `extract_body` documents.

## Security: no reachability change

`ASSISTANT_REACHABLE_SUBAGENTS` (`agents/delegation.rs:78`), every persona's `[subagents].delegate_allowed`, and `SubagentAllowSet` are **untouched**. Every projected agent carries `SubagentsConfig::default()`, which grants no delegation targets — pinned by `projected_agent_grants_no_subagents`. No assistant gains a reachable delegation target from this PR. `bundled_personas_pin_git_reach` is unaffected.

## Tests

17 new unit tests, including one per refusal above plus `tools: []` staying deny-all, the aggregated drop-warning key set, interior-`---` survival in the body, and the `.claude/agents` directory predicate.

## Gates

`cargo check` · `cargo test -p trusty-agents` (3128 lib passed, 0 failed) · `cargo clippy -p trusty-agents --all-targets -- -D warnings` (clean) · `cargo fmt --check` (clean) · `check_line_cap.sh` (0 violations) · `check_test_pointers.sh` (exit 0) · `check_changelog_fragment.sh` (fragment valid).

Closes #4495

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
