### PR TITLE
fix(trusty-mpm): derive tm doctor's expected search index id from the project

### DIFF
--- a/crates/trusty-mpm/changelog.d/4003-search-index-id.md
+++ b/crates/trusty-mpm/changelog.d/4003-search-index-id.md
@@ -1,0 +1,9 @@
+Fixed
+
+- `tm doctor`'s `search` check no longer hardcodes a literal expected index id
+  (`"trusty-mpm"`, the crate name) — it now derives the expected id from the
+  project itself, the same rule `core::session_launch` and trusty-search's own
+  `detect_project` use, so a repo registered under a different index id (e.g.
+  this repo's `trusty-tools`) no longer permanently warns "index missing"
+  against a healthy, fully-indexed project
+  ([#4003](https://github.com/bobmatnyc/trusty-tools/issues/4003)).

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -126,8 +126,12 @@ const PROBE_ATTEMPTS: usize = 3;
 /// attempts stay well inside an interactive `tm doctor` run.
 const PROBE_RETRY_DELAY: Duration = Duration::from_millis(500);
 
-/// The trusty-search index `tm doctor` expects to exist for this repo.
-const EXPECTED_SEARCH_INDEX: &str = "trusty-mpm";
+// #4003: the search-index doctor probe used to hardcode a literal expected
+// index id ("trusty-mpm" — the crate name, not this repo's registered index
+// id "trusty-tools"), so it permanently warned "index missing" against a
+// healthy, fully-indexed project. `expected_search_index_id` below resolves
+// the id the same way every other launch path does, via
+// `trusty_common::derive_index_id`.
 
 /// Run every diagnostic probe and assemble the report.
 ///
@@ -250,7 +254,7 @@ pub async fn run_doctor(
         agent_skills_prose_hints,
     ];
     checks.push(check_memory(&home).await);
-    checks.push(check_search(&home).await);
+    checks.push(check_search(&home, project_dir).await);
     checks.push(check_worktrees(repos_root, active_workspace_paths).await);
     checks.push(check_gh_account().await);
     checks.push(check_oauth_token_config());
@@ -739,15 +743,16 @@ fn interpret_health(
     )
 }
 
-/// Probe the trusty-search sidecar's health and the `trusty-mpm` index.
+/// Probe the trusty-search sidecar's health and this project's index.
 ///
 /// Why: code search backs the PM's "search before grep" rule; both the service
-/// being up *and* the `trusty-mpm` index existing are required for it to work.
+/// being up *and* this project's index existing are required for it to work.
 /// What: resolves the service address, checks `GET /health` (a non-2xx or
-/// transport error is `Fail`), then checks `GET /indexes` for an index named
-/// [`EXPECTED_SEARCH_INDEX`] — a healthy service missing that index is `Warn`.
+/// transport error is `Fail`), then checks `GET /indexes` for the index id
+/// [`expected_search_index_id`] resolves for `project_dir` — a healthy
+/// service missing that index is `Warn`.
 /// Test: `search_unreachable_is_fail`.
-async fn check_search(home: &Path) -> DoctorCheck {
+async fn check_search(home: &Path, project_dir: Option<&Path>) -> DoctorCheck {
     let dir = home.join(".trusty-search");
     let default = TRUSTY_SEARCH_DEFAULT_ADDR
         .parse()
@@ -773,19 +778,21 @@ async fn check_search(home: &Path) -> DoctorCheck {
         }
     }
 
-    // Service is up — confirm the expected index exists.
+    // Service is up — confirm the expected index exists. #4003: the expected
+    // id is DERIVED from the project (same rule `session_launch` and
+    // `trusty-search`'s own `detect_project` use), not a hardcoded literal —
+    // see `expected_search_index_id`.
+    let expected_index = expected_search_index_id(project_dir);
     match http_get_json(&format!("http://{addr}/indexes")).await {
-        Ok(body) if index_present(&body, EXPECTED_SEARCH_INDEX) => DoctorCheck::new(
+        Ok(body) if index_present(&body, &expected_index) => DoctorCheck::new(
             "search",
             CheckStatus::Ok,
-            format!("trusty-search healthy at {addr}, `{EXPECTED_SEARCH_INDEX}` index present"),
+            format!("trusty-search healthy at {addr}, `{expected_index}` index present"),
         ),
         Ok(_) => DoctorCheck::new(
             "search",
             CheckStatus::Warn,
-            format!(
-                "trusty-search healthy at {addr} but the `{EXPECTED_SEARCH_INDEX}` index is missing"
-            ),
+            format!("trusty-search healthy at {addr} but the `{expected_index}` index is missing"),
         ),
         Err(e) => DoctorCheck::new(
             "search",
@@ -793,6 +800,30 @@ async fn check_search(home: &Path) -> DoctorCheck {
             format!("trusty-search healthy at {addr} but listing indexes failed: {e}"),
         ),
     }
+}
+
+/// Resolve the trusty-search index id `tm doctor` should expect for
+/// `project_dir` (#4003).
+///
+/// Why: the probe previously hardcoded a literal expected index name
+/// (`"trusty-mpm"` — the crate name), which diverges from a repo's actual
+/// registered index id (e.g. this repo registers as `"trusty-tools"`), so a
+/// healthy, fully-indexed project permanently reported "index missing".
+/// What: walks up from `project_dir` (falling back to the process cwd when
+/// `None`, matching the daemon's own `run_doctor` default) to the nearest
+/// git root via [`trusty_common::resolve_project_root`], then derives the id
+/// via [`trusty_common::derive_index_id`] — the exact same rule
+/// `core::session_launch` uses to register-and-pin a session's index and
+/// trusty-search's own `detect_project` uses to resolve a bare `search`
+/// call, so all three agree on one id per project (#1373).
+/// Test: `expected_search_index_id_derives_from_project_dir_not_hardcoded`.
+fn expected_search_index_id(project_dir: Option<&Path>) -> String {
+    let start = match project_dir {
+        Some(dir) => dir.to_path_buf(),
+        None => std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+    };
+    let root = trusty_common::resolve_project_root(&start);
+    trusty_common::derive_index_id(&root)
 }
 
 /// True when `body` mentions an index named `name`.

--- a/crates/trusty-mpm/src/daemon/doctor_tests.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_tests.rs
@@ -41,13 +41,48 @@ async fn memory_unreachable_is_fail() {
     assert_eq!(check.status, CheckStatus::Fail);
 }
 
+#[test]
+fn expected_search_index_id_derives_from_project_dir_not_hardcoded() {
+    // #4003: `tm doctor`'s search check used to hardcode the literal expected
+    // index id "trusty-mpm" (the crate name), which diverges from a repo's
+    // actual registered index id — this repo registers as "trusty-tools" —
+    // so a healthy, fully-indexed project permanently warned "index
+    // missing". Pin that the id is now DERIVED from the project root's
+    // basename (the same rule `trusty_common::derive_index_id` applies
+    // everywhere else an index id is resolved), not a fixed constant: a
+    // project literally named "trusty-mpm" must resolve to "trusty-mpm", and
+    // one named anything else must resolve to ITS OWN name, never the old
+    // hardcoded literal.
+    let tmp = tempfile::tempdir().unwrap();
+
+    let other_repo = tmp.path().join("trusty-tools");
+    std::fs::create_dir_all(other_repo.join(".git")).unwrap();
+    let other_id = expected_search_index_id(Some(&other_repo));
+    assert_eq!(other_id, "trusty-tools");
+    assert_ne!(
+        other_id, "trusty-mpm",
+        "must not fall back to the old hardcoded literal for an unrelated project"
+    );
+
+    let mpm_repo = tmp.path().join("trusty-mpm");
+    std::fs::create_dir_all(mpm_repo.join(".git")).unwrap();
+    let mpm_id = expected_search_index_id(Some(&mpm_repo));
+    assert_eq!(mpm_id, "trusty-mpm");
+
+    // Nested working directory inside the repo still resolves to the git
+    // root's basename, not the nested dir's own name.
+    let nested = other_repo.join("crates").join("trusty-mpm");
+    std::fs::create_dir_all(&nested).unwrap();
+    assert_eq!(expected_search_index_id(Some(&nested)), "trusty-tools");
+}
+
 #[tokio::test]
 async fn search_unreachable_is_fail() {
     unsafe {
         std::env::set_var("TRUSTY_SEARCH_ADDR", "127.0.0.1:0");
     }
     let tmp = tempfile::tempdir().unwrap();
-    let check = check_search(tmp.path()).await;
+    let check = check_search(tmp.path(), None).await;
     unsafe {
         std::env::remove_var("TRUSTY_SEARCH_ADDR");
     }


### PR DESCRIPTION
## Summary

`tm doctor`'s `search` check hardcoded a literal expected index id
(`"trusty-mpm"` — the crate name) instead of resolving it from the project.
This repo's actual registered trusty-search index id is `trusty-tools`, so
`tm doctor` permanently reported "index missing" against a healthy,
fully-indexed project (#4003).

## Fix

`check_search` now derives the expected index id from `project_dir` via
`trusty_common::resolve_project_root` + `trusty_common::derive_index_id` — the
exact same rule `core::session_launch` uses to register-and-pin a session's
index, and trusty-search's own `detect_project` uses to resolve a bare
`search` call (#1373), so all three agree on one id per project. Falls back to
the process cwd when no `project_dir` is supplied, matching the daemon's
existing default elsewhere in `run_doctor`.

## Test plan

- [x] Added `expected_search_index_id_derives_from_project_dir_not_hardcoded`
      (`crates/trusty-mpm/src/daemon/doctor_tests.rs`) — pins the actual
      defect: a repo named `trusty-tools` must resolve to `trusty-tools`, not
      the old hardcoded `"trusty-mpm"` literal, including from a nested
      working directory. The HTTP-branch behavior (`Ok`/`Warn` verdict against
      a live `/indexes` response) is exercised indirectly through
      `search_unreachable_is_fail`, which now passes `project_dir: None`; a
      full `Ok`-path integration test would need a live trusty-search daemon
      or a mock HTTP server, neither of which exists in this test module today
      — flagging that gap rather than expanding scope to add one.
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo test -p trusty-mpm` (full crate surface) — all green
- [x] `bash scripts/check_line_cap.sh` — OK
- [x] `scripts/check_changelog_fragment.sh` — OK, fragment validated by the
      real assembler

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools