### PR TITLE
fix(trusty-common): reject system temp roots in the ephemeral-binary guard

### DIFF
--- a/crates/trusty-common/changelog.d/4485-ephemeral-temp-guard.md
+++ b/crates/trusty-common/changelog.d/4485-ephemeral-temp-guard.md
@@ -1,0 +1,3 @@
+Fixed
+
+- `bin_resolve::is_ephemeral_build_path` now also rejects any path under a system temp root (`/tmp`, `/private/tmp`, `/var/tmp`, macOS `/var/folders`, and the live `std::env::temp_dir()`), matched as component-wise path prefixes rather than substrings. Previously the guard enumerated only `target/debug`, `target/release` and the two worktree layouts, so a scratch binary under an agent harness's temp scratchpad read as an ordinary installed path and was accepted as stable (#4485).

--- a/crates/trusty-common/src/bin_resolve.rs
+++ b/crates/trusty-common/src/bin_resolve.rs
@@ -330,10 +330,13 @@ mod tests {
     /// scratchpad path, a plain `/tmp` path, the macOS `/var/folders` per-user
     /// temp root, and a path derived from the live [`std::env::temp_dir`] (so
     /// the check holds on a machine whose `TMPDIR` is none of the literals).
+    /// Every shape is checked before the assertion fires, so reverting the
+    /// guard reports ALL the paths it stops rejecting rather than aborting on
+    /// the first — the difference between "the fix is gone" and "one case is".
     #[test]
     fn is_ephemeral_build_path_flags_system_temp_paths() {
         let temp_derived = std::env::temp_dir().join("claude-4485/scratchpad/base-bins/tm");
-        for p in [
+        let missed: Vec<String> = [
             PathBuf::from(
                 "/private/tmp/claude-502/-Users-x-proj/9f1c/scratchpad/base-bins/trusty-mpm",
             ),
@@ -342,13 +345,16 @@ mod tests {
             PathBuf::from("/var/tmp/tm"),
             PathBuf::from("/var/folders/qz/9x_2/T/cargo-install-abc/tm"),
             temp_derived,
-        ] {
-            assert!(
-                is_ephemeral_build_path(&p),
-                "{} must be flagged: a system temp root is never an installed location (#4485)",
-                p.display()
-            );
-        }
+        ]
+        .into_iter()
+        .filter(|p| !is_ephemeral_build_path(p))
+        .map(|p| p.display().to_string())
+        .collect();
+        assert!(
+            missed.is_empty(),
+            "a system temp root is never an installed location (#4485), but these were \
+             accepted as stable: {missed:#?}"
+        );
     }
 
     /// Why (#4485): the temp check must be a component-wise PREFIX match, not a

--- a/crates/trusty-common/src/bin_resolve.rs
+++ b/crates/trusty-common/src/bin_resolve.rs
@@ -184,7 +184,10 @@ fn candidate(dir: &Path, name: &str) -> Option<PathBuf> {
 /// What: the worktree layout markers this workspace uses
 /// (`.claude/worktrees/`, `.base/.worktrees/`) plus the two Cargo build
 /// profiles. Matched as substrings so `deps/`-nested and profile-suffixed
-/// variants are all covered.
+/// variants are all covered. This list is only ONE of the two rejection rules
+/// [`is_ephemeral_build_path`] applies — see [`SYSTEM_TEMP_ROOTS`] for the
+/// other, and that constant's doc for why a substring list alone was not
+/// enough.
 const EPHEMERAL_PATH_SEGMENTS: &[&str] = &[
     "target/debug",
     "target/release",
@@ -192,21 +195,106 @@ const EPHEMERAL_PATH_SEGMENTS: &[&str] = &[
     ".base/.worktrees/",
 ];
 
-/// Whether `path` points inside an ephemeral build/worktree location that will
-/// not survive a rebuild or worktree cleanup.
+/// Well-known absolute system temp roots, matched as component-wise path
+/// PREFIXES (never substrings).
+///
+/// Why (#4485): [`EPHEMERAL_PATH_SEGMENTS`] enumerated build and worktree
+/// layouts only, so a scratch binary living under a system temp root read as an
+/// ordinary installed path and passed the guard. The Claude Code agent harness
+/// puts per-session scratch space at
+/// `/private/tmp/claude-<uid>/<session>/<uuid>/scratchpad/…`; a
+/// `cargo test --no-run` artifact copied there was accepted as "stable" and
+/// persisted into project `settings.json`, which then EXECUTED a dead libtest
+/// harness on every hook event across ten unrelated projects (#4485, and via
+/// `statusLine.command`, #4492). A temp root is by definition not a place an
+/// installed binary lives, so nothing under one may ever be baked into a
+/// persisted config.
+///
+/// What: the Unix temp roots in both of their macOS spellings. `/tmp` is a
+/// symlink to `/private/tmp` and `/var` one to `/private/var`, so the SAME
+/// directory reaches this guard under either name; both spellings are listed
+/// rather than canonicalized because an ephemeral path routinely no longer
+/// exists on disk and [`Path::canonicalize`] fails on exactly the paths this
+/// guard most needs to reject. `/var/folders` is macOS's per-user temp root
+/// (`confstr(_CS_DARWIN_USER_TEMP_DIR)`), where [`std::env::temp_dir`] lands by
+/// default. The list is deliberately a set of ROOTS, not segments: matching is
+/// done with [`Path::starts_with`], which compares whole path components, so
+/// `/tmpfoo/bin/tm` and `/Users/x/tmp/bin/tm` are correctly NOT flagged —
+/// the false-positive class a `contains("/tmp")` test would have introduced.
+///
+/// This is checked IN ADDITION to the live [`std::env::temp_dir`], not instead
+/// of it: `temp_dir()` reflects the `TMPDIR` of the process asking the
+/// question, which need not be the `TMPDIR` that produced the path being
+/// judged — #4485 is precisely that case.
+const SYSTEM_TEMP_ROOTS: &[&str] = &[
+    "/tmp",
+    "/private/tmp",
+    "/var/tmp",
+    "/private/var/tmp",
+    "/var/folders",
+    "/private/var/folders",
+];
+
+/// Whether `path` lives under a system temp root.
+///
+/// Why (#4485): see [`SYSTEM_TEMP_ROOTS`]. Split out of
+/// [`is_ephemeral_build_path`] so the "is this a temp location" question has
+/// one implementation and one place to document the prefix-vs-substring and
+/// symlink-alias decisions.
+/// What: returns `true` when `path` has any [`SYSTEM_TEMP_ROOTS`] entry as a
+/// component-wise prefix, or is under [`std::env::temp_dir`] (also tried in its
+/// canonicalized form, which resolves the macOS `/tmp` -> `/private/tmp`
+/// symlink when `TMPDIR` points through it). A degenerate temp dir with no
+/// parent (`/`) is ignored rather than allowed to reject every absolute path.
+/// Deliberately free of `#[cfg(target_os)]`: the extra Unix roots simply never
+/// match on Windows, where `temp_dir()` supplies the real answer.
+/// Test: `is_ephemeral_build_path_flags_system_temp_paths`,
+/// `is_ephemeral_build_path_ignores_temp_lookalike_paths`.
+fn is_under_system_temp(path: &Path) -> bool {
+    if SYSTEM_TEMP_ROOTS.iter().any(|root| path.starts_with(root)) {
+        return true;
+    }
+    let tmp = std::env::temp_dir();
+    // `TMPDIR=/` would otherwise make every absolute path "ephemeral".
+    if tmp.parent().is_none() {
+        return false;
+    }
+    if path.starts_with(&tmp) {
+        return true;
+    }
+    tmp.canonicalize()
+        .is_ok_and(|real| real.parent().is_some() && path.starts_with(real))
+}
+
+/// Whether `path` points inside an ephemeral build/worktree/temp location that
+/// will not survive a rebuild, a worktree cleanup, or a temp sweep.
 ///
 /// Why: `std::env::current_exe()` returns a `target/debug/deps/...` path when
-/// `tm`/`trusty-mpm` runs from a worktree or a debug build. Persisting that
-/// path into the SHARED global `settings.json` (hook commands, statusline)
-/// breaks every managed session once the artifact is rebuilt away (#2229).
-/// Callers use this to reject `current_exe()` and fall back to a stable,
-/// PATH-resolved installed binary instead.
-/// What: returns `true` when the path's string form contains any of
-/// [`EPHEMERAL_PATH_SEGMENTS`]. Uses a lossy string comparison so non-UTF-8
-/// path components degrade to "not ephemeral" rather than panicking.
+/// `tm`/`trusty-mpm` runs from a worktree or a debug build, and a
+/// `/private/tmp/claude-<uid>/…/scratchpad/…` path when it runs from an agent
+/// harness's scratch space (#4485). Persisting either into a SHARED
+/// `settings.json` (hook commands, statusline) breaks every managed session
+/// once the artifact is gone (#2229) — and worse, leaves config that keeps
+/// EXECUTING whatever now sits at that path (#4485, #4492). Callers use this to
+/// reject `current_exe()` and fall back to a stable, PATH-resolved installed
+/// binary instead.
+/// What: returns `true` when `path` is under a system temp root
+/// ([`is_under_system_temp`]) OR its string form contains any of
+/// [`EPHEMERAL_PATH_SEGMENTS`]. The segment check uses a lossy string
+/// comparison so non-UTF-8 path components degrade to "not ephemeral" rather
+/// than panicking; the temp check operates on components and is unaffected by
+/// encoding.
 /// Test: `is_ephemeral_build_path_flags_build_and_worktree_paths`,
+/// `is_ephemeral_build_path_flags_system_temp_paths`,
+/// `is_ephemeral_build_path_ignores_temp_lookalike_paths`,
 /// `is_ephemeral_build_path_accepts_installed_paths`.
 pub fn is_ephemeral_build_path(path: &Path) -> bool {
+    // #4485: a system temp root is every bit as ephemeral as `target/debug` —
+    // and, unlike a build dir, an attacker-or-accident-writable location whose
+    // contents a persisted hook command would go on executing.
+    if is_under_system_temp(path) {
+        return true;
+    }
     let s = path.to_string_lossy();
     EPHEMERAL_PATH_SEGMENTS.iter().any(|seg| s.contains(seg))
 }
@@ -226,6 +314,60 @@ mod tests {
             assert!(
                 is_ephemeral_build_path(Path::new(p)),
                 "{p} must be flagged as an ephemeral build path"
+            );
+        }
+    }
+
+    /// Why (#4485): the pre-fix guard enumerated build and worktree layouts
+    /// only, so a scratch binary under a system temp root — the shape the
+    /// Claude Code harness produces at
+    /// `/private/tmp/claude-<uid>/<session>/<uuid>/scratchpad/base-bins/<bin>` —
+    /// passed as an ordinary installed path and got persisted into
+    /// `settings.json` as a hook / statusLine command that then ran a dead
+    /// libtest harness on every hook event (#4492 is the same root cause via
+    /// the statusLine path).
+    /// What: asserts every system-temp shape is rejected: the exact harness
+    /// scratchpad path, a plain `/tmp` path, the macOS `/var/folders` per-user
+    /// temp root, and a path derived from the live [`std::env::temp_dir`] (so
+    /// the check holds on a machine whose `TMPDIR` is none of the literals).
+    #[test]
+    fn is_ephemeral_build_path_flags_system_temp_paths() {
+        let temp_derived = std::env::temp_dir().join("claude-4485/scratchpad/base-bins/tm");
+        for p in [
+            PathBuf::from(
+                "/private/tmp/claude-502/-Users-x-proj/9f1c/scratchpad/base-bins/trusty-mpm",
+            ),
+            PathBuf::from("/tmp/claude-502/scratchpad/base-bins/tm"),
+            PathBuf::from("/tmp/tm"),
+            PathBuf::from("/var/tmp/tm"),
+            PathBuf::from("/var/folders/qz/9x_2/T/cargo-install-abc/tm"),
+            temp_derived,
+        ] {
+            assert!(
+                is_ephemeral_build_path(&p),
+                "{} must be flagged: a system temp root is never an installed location (#4485)",
+                p.display()
+            );
+        }
+    }
+
+    /// Why (#4485): the temp check must be a component-wise PREFIX match, not a
+    /// `contains("/tmp")` substring match — substring matching is exactly what
+    /// left the original guard incomplete, and it would newly misfire on any
+    /// ordinary directory whose name merely starts with or contains `tmp`.
+    /// What: asserts three lookalikes stay accepted. This test does NOT flip
+    /// when the #4485 change is reverted (the old guard accepted them too); it
+    /// exists to pin the matching STRATEGY against a future substring rewrite.
+    #[test]
+    fn is_ephemeral_build_path_ignores_temp_lookalike_paths() {
+        for p in [
+            "/Users/x/tmp/bin/tm",
+            "/tmpfoo/bin/tm",
+            "/opt/tmp-tools/bin/trusty-mpm",
+        ] {
+            assert!(
+                !is_ephemeral_build_path(Path::new(p)),
+                "{p} is not under a temp ROOT and must NOT be flagged"
             );
         }
     }

--- a/crates/trusty-mpm/changelog.d/4485-ephemeral-temp-guard.md
+++ b/crates/trusty-mpm/changelog.d/4485-ephemeral-temp-guard.md
@@ -1,0 +1,3 @@
+Fixed
+
+- Managed hook commands and `statusLine.command` can no longer be persisted pointing at a binary in a system temp directory. A `cargo test --no-run` artifact in an agent harness's scratchpad (`/private/tmp/claude-<uid>/…/scratchpad/…`) passed the ephemeral-path guard, so `settings.json` was written with hook and statusline commands that ran a dead libtest harness on every hook event (#4485; #4492 is the same root cause reaching `statusLine.command`).

--- a/crates/trusty-mpm/src/core/session_launch/settings.rs
+++ b/crates/trusty-mpm/src/core/session_launch/settings.rs
@@ -1129,6 +1129,7 @@ fn resolve_statusline_binary() -> String {
 /// behaviour rather than disappearing outright.
 /// Test: `resolve_statusline_binary_with_prefers_current_exe`,
 /// `resolve_statusline_binary_with_rejects_ephemeral_current_exe`,
+/// `resolve_statusline_binary_with_rejects_system_temp_current_exe`,
 /// `resolve_statusline_binary_with_falls_back_to_path_lookup`,
 /// `resolve_statusline_binary_with_falls_back_to_trusty_mpm_name`,
 /// `resolve_statusline_binary_with_falls_back_to_bare_name`.
@@ -1136,6 +1137,10 @@ pub(super) fn resolve_statusline_binary_with(
     current_exe: impl Fn() -> std::io::Result<PathBuf>,
     path_lookup: impl Fn(&str) -> Option<PathBuf>,
 ) -> String {
+    // #4485/#4492: the guard now also rejects system temp roots, so a
+    // `current_exe()` under an agent harness's temp scratchpad no longer gets
+    // persisted into `statusLine.command`. Same guard as the hooks site by
+    // design — do not add a second check here.
     if let Ok(exe) = current_exe()
         && !trusty_common::bin_resolve::is_ephemeral_build_path(&exe)
         && let Some(s) = exe.to_str()

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -2241,6 +2241,37 @@ fn resolve_statusline_binary_with_rejects_ephemeral_current_exe() {
     );
 }
 
+/// Why (#4492, same root cause as #4485): `statusLine.command` is resolved by
+/// this function, and the #2229 ephemeral guard it consults knew only about
+/// build/worktree layouts. A `current_exe()` under the agent harness's temp
+/// scratchpad therefore passed as "stable" and was persisted, leaving
+/// `statusLine.command` pointing at a dead libtest harness. Only the hooks call
+/// site had coverage for this, which is why the statusline path regressed
+/// independently.
+/// What: injects each system-temp `current_exe()` shape and asserts the
+/// PATH-resolved install wins instead.
+#[test]
+fn resolve_statusline_binary_with_rejects_system_temp_current_exe() {
+    for exe in [
+        PathBuf::from("/private/tmp/claude-502/-Users-x-proj/9f1c/scratchpad/base-bins/tm"),
+        PathBuf::from("/tmp/tm"),
+        std::env::temp_dir().join("claude-4485/base-bins/tm"),
+    ] {
+        let expected = exe.clone();
+        let resolved = resolve_statusline_binary_with(
+            move || Ok(expected.clone()),
+            |_name| Some(PathBuf::from("/opt/homebrew/bin/tm")),
+        );
+        assert_eq!(
+            resolved,
+            "/opt/homebrew/bin/tm",
+            "a system temp current_exe ({}) must be rejected in favour of the PATH-resolved \
+             install (#4492)",
+            exe.display()
+        );
+    }
+}
+
 #[test]
 fn resolve_statusline_binary_with_falls_back_to_path_lookup() {
     let resolved = resolve_statusline_binary_with(

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -2252,24 +2252,25 @@ fn resolve_statusline_binary_with_rejects_ephemeral_current_exe() {
 /// PATH-resolved install wins instead.
 #[test]
 fn resolve_statusline_binary_with_rejects_system_temp_current_exe() {
-    for exe in [
+    let leaked: Vec<String> = [
         PathBuf::from("/private/tmp/claude-502/-Users-x-proj/9f1c/scratchpad/base-bins/tm"),
         PathBuf::from("/tmp/tm"),
         std::env::temp_dir().join("claude-4485/base-bins/tm"),
-    ] {
-        let expected = exe.clone();
-        let resolved = resolve_statusline_binary_with(
-            move || Ok(expected.clone()),
+    ]
+    .into_iter()
+    .map(|exe| {
+        resolve_statusline_binary_with(
+            move || Ok(exe.clone()),
             |_name| Some(PathBuf::from("/opt/homebrew/bin/tm")),
-        );
-        assert_eq!(
-            resolved,
-            "/opt/homebrew/bin/tm",
-            "a system temp current_exe ({}) must be rejected in favour of the PATH-resolved \
-             install (#4492)",
-            exe.display()
-        );
-    }
+        )
+    })
+    .filter(|resolved| resolved != "/opt/homebrew/bin/tm")
+    .collect();
+    assert!(
+        leaked.is_empty(),
+        "a system temp current_exe must be rejected in favour of the PATH-resolved install \
+         (#4492), but these were persisted verbatim: {leaked:#?}"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/mod.rs
@@ -88,7 +88,8 @@ pub fn mpm_hook_command(exe_override: Option<&Path>) -> String {
 /// Returns `None` only when no stable absolute path can be found (caller then
 /// uses the bare command name).
 /// Test: covered by `test_hook_command_uses_absolute_path`,
-/// `test_hook_command_rejects_ephemeral_exe_override`.
+/// `test_hook_command_rejects_ephemeral_exe_override`,
+/// `test_hook_command_rejects_system_temp_exe_override`.
 fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Option<PathBuf> {
     let running = exe_override
         .map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()))
@@ -98,6 +99,11 @@ fn resolve_stable_hook_exe(exe_override: Option<&Path>) -> Option<PathBuf> {
                 .and_then(|p| p.canonicalize().ok().or(Some(p)))
         });
 
+    // #4485: `is_ephemeral_build_path` now also rejects anything under a system
+    // temp root, so an agent harness's scratchpad binary
+    // (`/private/tmp/claude-<uid>/…/scratchpad/…`) can no longer be persisted
+    // here as if it were the installed binary. The check stays in the guard —
+    // this site must not grow a second, divergent copy of it.
     if let Some(p) = running
         && p.is_absolute()
         && !trusty_common::bin_resolve::is_ephemeral_build_path(&p)

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -78,23 +78,26 @@ fn test_hook_command_rejects_ephemeral_exe_override() {
 /// PATH-resolved install, or the bare fallback).
 #[test]
 fn test_hook_command_rejects_system_temp_exe_override() {
+    let mut baked: Vec<String> = Vec::new();
     for ephemeral in [
         PathBuf::from("/private/tmp/claude-502/-Users-x-proj/9f1c/scratchpad/base-bins/trusty-mpm"),
         PathBuf::from("/tmp/trusty-mpm"),
         std::env::temp_dir().join("claude-4485/base-bins/trusty-mpm"),
     ] {
         let cmd = mpm_hook_command(Some(&ephemeral));
-        assert!(
-            !cmd.contains(&ephemeral.display().to_string()),
-            "a system temp path must never be baked into the hook command (#4485), \
-             override {} produced: {cmd:?}",
-            ephemeral.display()
-        );
+        if cmd.contains(&ephemeral.display().to_string()) {
+            baked.push(cmd.clone());
+        }
         assert!(
             cmd.ends_with(" hook"),
             "hook command must still end with ' hook', got: {cmd:?}"
         );
     }
+    assert!(
+        baked.is_empty(),
+        "a system temp path must never be baked into the hook command (#4485), but these \
+         commands carry one: {baked:#?}"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
+++ b/crates/trusty-mpm/src/core/standalone/hooks/tests.rs
@@ -67,6 +67,36 @@ fn test_hook_command_rejects_ephemeral_exe_override() {
     );
 }
 
+/// Why (#4485): the #2229 guard listed build/worktree layouts only, so a
+/// binary under a system temp root — the shape the Claude Code agent harness
+/// produces at `/private/tmp/claude-<uid>/<session>/<uuid>/scratchpad/…` —
+/// looked like an ordinary installed path and WAS baked into the hook command.
+/// Sixteen settings files across ten projects ended up running a dead
+/// `cargo test --no-run` libtest harness on every hook event.
+/// What: passes each system-temp shape as `exe_override` and asserts the
+/// resulting command never contains it, while still ending in " hook" (a stable
+/// PATH-resolved install, or the bare fallback).
+#[test]
+fn test_hook_command_rejects_system_temp_exe_override() {
+    for ephemeral in [
+        PathBuf::from("/private/tmp/claude-502/-Users-x-proj/9f1c/scratchpad/base-bins/trusty-mpm"),
+        PathBuf::from("/tmp/trusty-mpm"),
+        std::env::temp_dir().join("claude-4485/base-bins/trusty-mpm"),
+    ] {
+        let cmd = mpm_hook_command(Some(&ephemeral));
+        assert!(
+            !cmd.contains(&ephemeral.display().to_string()),
+            "a system temp path must never be baked into the hook command (#4485), \
+             override {} produced: {cmd:?}",
+            ephemeral.display()
+        );
+        assert!(
+            cmd.ends_with(" hook"),
+            "hook command must still end with ' hook', got: {cmd:?}"
+        );
+    }
+}
+
 #[test]
 fn test_mpm_hook_additions_has_six_events() {
     // #1744: SessionStart/SessionEnd must be present so the daemon receives


### PR DESCRIPTION
## What broke

`bin_resolve::is_ephemeral_build_path` decided whether `current_exe()` was safe to bake into a persisted config. It rejected ephemeral paths with a hardcoded substring list — `target/debug`, `target/release`, `.claude/worktrees/`, `.base/.worktrees/` — with **no entry for a system temp root**.

The Claude Code agent harness places scratch binaries under `/private/tmp/claude-<uid>/<session>/<uuid>/scratchpad/…`. A `cargo test --no-run` artifact there is an ordinary absolute path with none of those four segments, so it passed the guard and was persisted as if it were the stable installed binary.

Observed: 16 settings files across ten unrelated projects carried hook commands — and in two cases `statusLine.command` — pointing at dead libtest harnesses. Every hook event ran a test suite. A path that should have been rejected was accepted and then written into config that later **executes** it, so this is a correctness-and-safety fix, not hygiene.

Closes #4485.

**#4492 is the same root cause**, reaching the same guard through `session_launch::settings::resolve_statusline_binary_with` instead of the hooks path — that is why only `statusLine.command` was affected there. This PR fixes both and adds regression coverage at both sites. Left open rather than auto-closed so the owner can decide whether to close it as folded into #4485.

## The fix

One change, in the shared guard — both persisting call sites already route through it, so neither grows a second, divergent check.

`is_ephemeral_build_path` now also rejects anything under a system temp root:

- the literal Unix roots in both macOS spellings — `/tmp`, `/private/tmp`, `/var/tmp`, `/private/var/tmp`, `/var/folders`, `/private/var/folders`;
- the live `std::env::temp_dir()`, plus its canonicalized form.

### Why prefix matching, not `contains()`

Matching is `Path::starts_with`, which compares whole path **components**. Substring matching is exactly what left the original list incomplete, and a `contains("/tmp")` test would newly misfire on `/Users/x/tmp/bin/tm`, `/tmpfoo/bin/tm`, `/opt/tmp-tools/bin/tm`. A test pins those three as still-accepted so a future rewrite cannot quietly slide back to substrings.

### Why `/tmp` **and** `/private/tmp` are both listed

They are the same directory on macOS (`/tmp` is a symlink into `/private`, as is `/var`), but either spelling can reach the guard verbatim. Canonicalizing the input path was rejected deliberately: `Path::canonicalize` fails when the file does not exist, and a dead build artifact is precisely the input this guard most needs to reject. Listing both spellings costs nothing and never depends on the path still being on disk.

### Why the literals **and** `temp_dir()`

`std::env::temp_dir()` reflects the `TMPDIR` of the process asking the question, which need not be the `TMPDIR` that produced the path being judged — #4485 is exactly that case. The literals cover the cross-`TMPDIR` case; `temp_dir()` covers a machine whose temp root is none of them (and supplies the whole answer on Windows). A degenerate `TMPDIR=/` is ignored rather than allowed to reject every absolute path.

No `#[cfg(target_os = …)]` anywhere: the extra Unix roots simply never match elsewhere.

## Caller audit

`trusty-common` has eight dependents; `is_ephemeral_build_path` has three call sites, all in `trusty-mpm`, and **all three reject on `true`** — none depends on a temp path being accepted:

| Site | Effect of the tightening |
|---|---|
| `standalone::hooks::resolve_stable_hook_exe` | temp exe now falls back to the PATH-resolved install (the #4485 fix) |
| `session_launch::settings::resolve_statusline_binary_with` | same, for `statusLine.command` (the #4492 fix) |
| `session_launch::settings::is_stale_statusline_command` | opposite polarity — a temp-path statusline is now recognised as stale and **healed** rather than treated as an untouchable customization. Strictly desirable. |

No test in the workspace builds or copies a binary into a tempdir and expects it to resolve as stable. `bin_resolve`'s own tempdir fixtures exercise `candidate()` / `resolve_binary(explicit)`, which never consult this guard; every statusline/hook test uses fabricated paths (`/abs/path/to/tm`, `/opt/homebrew/bin/tm`) or `/bin/sh`. No test needed weakening or an override.

## Tests

`test_hook_command_rejects_ephemeral_exe_override` only ever exercised `target/debug/deps/…`, which is why this gap was untested as well as unguarded. Added:

- `is_ephemeral_build_path_flags_system_temp_paths` — harness scratchpad, plain `/tmp`, `/var/tmp`, `/var/folders`, and a `std::env::temp_dir()`-derived path;
- `is_ephemeral_build_path_ignores_temp_lookalike_paths` — the prefix-vs-substring pin;
- `test_hook_command_rejects_system_temp_exe_override` — hooks site;
- `resolve_statusline_binary_with_rejects_system_temp_current_exe` — statusline site, the path #4492 came in through, which previously had no coverage of its own.

Each collects failures and asserts once, so a revert names every shape that regressed instead of aborting on the first.

**Mutation-verified.** With the temp branch disabled (`if false && is_under_system_temp(path)`), all three go red and name every shape:

```
is_ephemeral_build_path_flags_system_temp_paths ... FAILED
  accepted as stable: [
    "/private/tmp/claude-502/-Users-x-proj/9f1c/scratchpad/base-bins/trusty-mpm",
    "/tmp/claude-502/scratchpad/base-bins/tm",
    "/tmp/tm",
    "/var/tmp/tm",
    "/var/folders/qz/9x_2/T/cargo-install-abc/tm",
    "/var/folders/7s/…/T/claude-4485/scratchpad/base-bins/tm",
  ]

test_hook_command_rejects_system_temp_exe_override ... FAILED
  commands carry one: [
    "/private/tmp/claude-502/…/scratchpad/base-bins/trusty-mpm hook",
    "/tmp/trusty-mpm hook",
    "/var/folders/7s/…/T/claude-4485/base-bins/trusty-mpm hook",
  ]

resolve_statusline_binary_with_rejects_system_temp_current_exe ... FAILED
  persisted verbatim: [
    "/private/tmp/claude-502/…/scratchpad/base-bins/tm",
    "/tmp/tm",
    "/var/folders/7s/…/T/claude-4485/base-bins/tm",
  ]
```

Restored afterwards; `git diff` shows zero lines touching `is_under_system_temp`, i.e. the production guard is byte-identical to the committed version.

## Gates (macOS local)

```
cargo fmt --check                                              exit 0
cargo clippy -p trusty-common -p trusty-mpm --all-targets -- -D warnings   exit 0
cargo test -p trusty-common      227 passed; 0 failed; 6 ignored   exit 0
cargo test -p trusty-mpm        4091 passed; 0 failed; 6 ignored (lib)
                                1363 passed; 0 failed; 1 ignored (bin tm)   exit 0
bash scripts/check_line_cap.sh      7 allowlisted, 0 violations — OK
bash scripts/check_test_pointers.sh 0 dangling pointers — OK
bash scripts/check_changelog_fragment.sh  both crates recorded — OK
```

Ignored counts match `origin/main`; nothing was gated off to reach green.

**One unrelated flake seen and chased down, not buried:** the first full `--bin tm` run hit `compose_session_instructions_display_matches_live_prompt`, whose two sides differed only by the injected output-style preamble. That test calls `FrameworkPaths::default()`, so it reads the live `~/.trusty-mpm` assets and races anything rewriting them. Verified environmental: it passes filtered in this branch, the full `--bin tm` suite passes twice here, and the same full suite is green on a clean `origin/main` worktree. Nothing in this diff can affect prompt composition.

## Changelog

Fragments, per the post-#4476 convention — no `## [Unreleased]` heading:

- `crates/trusty-common/changelog.d/4485-ephemeral-temp-guard.md`
- `crates/trusty-mpm/changelog.d/4485-ephemeral-temp-guard.md`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools