### PR TITLE
fix(trusty-agents): read the .claude/agents tier with trusty-mpm's frontmatter grammar (#4496)

### DIFF
--- a/crates/trusty-agents/changelog.d/4496-registry-claude-agents-tier-parser.md
+++ b/crates/trusty-agents/changelog.d/4496-registry-claude-agents-tier-parser.md
@@ -1,0 +1,28 @@
+Fixed
+
+- **`AgentRegistry::load` now reads the `.claude/agents` tier with trusty-mpm's
+  own frontmatter grammar** (#4496). That tier has been a first-class roster
+  source for some time, but its `.md` files were parsed by `parse_md_agent` —
+  trusty-agents' OWN overlay reader — even though they hold trusty-mpm's
+  DEPLOYED artifacts. The two schemas disagree in a way that loses agents
+  silently: trusty-mpm's `tools:` is a flat list of tool names, while
+  `MdAgentFrontmatter::tools` is a nested `ToolsConfig` map, so a `serde_yaml`
+  deserialize of the former into the latter hard-errors and `load` warns and
+  skips the entire file — the agent disappears from the roster with only a log
+  line to show for it. `.claude/agents` (project-local and `$HOME`) now routes
+  through `agents::mpm_bridge` (#4495); `.trusty-agents/agents` and
+  `<config_dir>/agents` keep `parse_md_agent`, which remains the reader for
+  trusty-agents' own overlay schema (`capabilities:`, `runner:`,
+  `display_name:`, live `extends:`). Neither reader is a superset of the other,
+  so this is a per-tier selection rather than a merge.
+- Name-collision precedence is now pinned by tests: a hand-authored or bundled
+  `.trusty-agents/agents/*` agent still wins over a trusty-mpm-sourced agent of
+  the same name. `agent_search_paths` already ordered the tiers that way and
+  `load` is first-occurrence-wins, so this is preserved, not introduced — but
+  now that the two tiers use different parsers, a silent ordering inversion
+  would also silently change which schema an operator's file is read with.
+- No reachability change: `ASSISTANT_REACHABLE_SUBAGENTS`, every persona's
+  `[subagents].delegate_allowed`, and `SubagentAllowSet` are untouched, and
+  every agent projected from this tier carries `SubagentsConfig::default()`
+  (no delegation targets granted). Catalog population cannot make anything
+  reachable from an assistant.

--- a/crates/trusty-agents/src/agents/mpm_bridge.rs
+++ b/crates/trusty-agents/src/agents/mpm_bridge.rs
@@ -84,7 +84,6 @@ const CONSUMED_KEYS: &[&str] = &[
 /// so a caller that already knows the directory exists pays nothing.
 /// Test: `tests::claude_agents_dir_predicate_matches_both_tiers`,
 /// `tests::claude_agents_dir_predicate_rejects_trusty_agents_dir`.
-#[allow(dead_code)] // Wired into `AgentRegistry::load`'s tier selection in the follow-up PR.
 pub(crate) fn is_claude_agents_dir(dir: &Path) -> bool {
     dir.file_name().is_some_and(|n| n == "agents")
         && dir
@@ -107,7 +106,6 @@ pub(crate) fn is_claude_agents_dir(dir: &Path) -> bool {
 /// dropping the agent.
 /// Test: `tests::projects_clean_scalars`, `tests::missing_file_errors`,
 /// `tests::malformed_frontmatter_falls_back_to_file_stem`.
-#[allow(dead_code)] // Wired into `AgentRegistry::load`'s tier selection in the follow-up PR.
 pub(crate) fn load_mpm_agent(path: &Path) -> anyhow::Result<AgentConfig> {
     let raw = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read trusty-mpm agent md {}", path.display()))?;

--- a/crates/trusty-agents/src/agents/registry/mod.rs
+++ b/crates/trusty-agents/src/agents/registry/mod.rs
@@ -31,6 +31,8 @@ mod tests;
 pub(crate) use md_agent::parse_md_agent;
 pub use roster::{build_roster_section, inject_roster_into_prompt};
 
+use crate::agents::mpm_bridge;
+
 /// Discovers and holds the project's agent configs.
 pub struct AgentRegistry {
     /// Ordered map: agent_name → (AgentConfig, source_path).
@@ -78,11 +80,17 @@ impl AgentRegistry {
     /// `.trusty-agents/agents/engineer.toml` in the project overrides a bundled
     /// `config/agents/engineer.toml`. Missing dirs are silently skipped so
     /// operators don't need to pre-create every path.
-    /// What: Walks each directory for `*.toml` files, parses each via
-    /// `AgentConfig::load`, and inserts the first occurrence of each agent
-    /// name. Malformed files log a warn and are skipped.
+    /// What: Walks each directory for `*.toml` and `*.md` files, parses each,
+    /// and inserts the first occurrence of each agent name. Malformed files log
+    /// a warn and are skipped.
+    ///
+    /// `.md` files are parsed by ONE OF TWO readers, selected by which tier the
+    /// containing directory belongs to (#4496) — see the match on
+    /// `mpm_bridge::is_claude_agents_dir` below for the full rationale.
     /// Test: `registry_loads_from_multiple_dirs_with_priority`,
-    /// `registry_skips_missing_dirs_silently`.
+    /// `registry_skips_missing_dirs_silently`,
+    /// `registry_reads_claude_agents_tier_with_the_mpm_parser`,
+    /// `hand_authored_trusty_agents_md_wins_over_a_claude_agents_agent`.
     pub fn load(search_paths: &[PathBuf]) -> Self {
         let mut agents: IndexMap<String, (AgentConfig, PathBuf)> = IndexMap::new();
 
@@ -103,6 +111,23 @@ impl AgentRegistry {
                 let ext = path.extension().and_then(|s| s.to_str());
                 let parsed = match ext {
                     Some("toml") => AgentConfig::load(&path),
+                    // #4496: `.md` means two different schemas depending on the
+                    // tier. `.claude/agents` holds trusty-mpm's DEPLOYED,
+                    // already-flattened artifacts, whose frontmatter follows
+                    // trusty-mpm's grammar — most visibly `tools:` as a FLAT
+                    // NAME LIST, where `parse_md_agent` expects a nested
+                    // `ToolsConfig` map and hard-errors, dropping the whole
+                    // agent with only a warn to show for it. Route that tier
+                    // through the SHARED reader that trusty-mpm itself emits
+                    // with (`mpm_bridge`, leaf-only). Every other tier —
+                    // `.trusty-agents/agents`, `<config_dir>/agents` — is
+                    // trusty-agents' OWN `.md` overlay schema (`capabilities:`,
+                    // `runner:`, `display_name:`, live `extends:`) and keeps
+                    // `parse_md_agent`. Neither reader is a superset of the
+                    // other, which is why this is a selection and not a merge.
+                    Some("md") if mpm_bridge::is_claude_agents_dir(dir) => {
+                        mpm_bridge::load_mpm_agent(&path)
+                    }
                     Some("md") => parse_md_agent(&path),
                     _ => continue,
                 };

--- a/crates/trusty-agents/src/agents/registry/tests.rs
+++ b/crates/trusty-agents/src/agents/registry/tests.rs
@@ -368,11 +368,123 @@ fn registry_md_file_without_frontmatter_is_skipped() {
     let dir = TempDir::new().unwrap();
     // Valid TOML agent stays loadable.
     write_agent(dir.path(), "ok", "engineer", &[], &[], &[]);
-    // MD without frontmatter: skipped with warn.
+    // MD without frontmatter: skipped with warn. This dir is NOT shaped
+    // `.claude/agents`, so it stays on `parse_md_agent`, whose missing-fence
+    // hard error is what drops the file (#4496 changed only the other tier).
     fs::write(dir.path().join("broken.md"), "# not an agent\n").unwrap();
     let reg = AgentRegistry::load(&[dir.path().to_path_buf()]);
     assert_eq!(reg.len(), 1);
     assert!(reg.get("ok").is_some());
+}
+
+/// Create a `<root>/<parent>/agents` directory and return its path.
+fn agents_tier(root: &Path, parent: &str) -> PathBuf {
+    let dir = root.join(parent).join("agents");
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+/// #4496: the `.claude/agents` tier holds trusty-mpm's DEPLOYED artifacts and
+/// must be read with trusty-mpm's own grammar, not with `parse_md_agent`.
+///
+/// `tools:` is the discriminator that proves which reader ran: trusty-mpm
+/// emits a FLAT NAME LIST, which `parse_md_agent`'s `serde_yaml` deserialize
+/// into a nested `ToolsConfig` map rejects outright — under the old routing
+/// this agent did not merely lose its tools, it vanished from the roster
+/// entirely.
+#[test]
+fn registry_reads_claude_agents_tier_with_the_mpm_parser() {
+    let tmp = TempDir::new().unwrap();
+    let claude = agents_tier(tmp.path(), ".claude");
+    fs::write(
+        claude.join("research.md"),
+        "---\nname: research\nrole: researcher\ndescription: mpm research agent\n\
+         tools: [Read, Grep]\nskills:\n- systematic-debugging\n---\n\nBody.\n",
+    )
+    .unwrap();
+
+    let reg = AgentRegistry::load(&[claude]);
+
+    let cfg = reg.get("research").expect("mpm artifact is discovered");
+    assert_eq!(cfg.agent.role, "researcher");
+    assert_eq!(cfg.agent.description, "mpm research agent");
+    assert_eq!(
+        cfg.tools.allowed.as_deref(),
+        Some(["Read".to_string(), "Grep".to_string()].as_slice()),
+        "trusty-mpm's flat `tools:` list must survive as the exact-name allowlist"
+    );
+    assert!(
+        cfg.skills.allow.is_none(),
+        "trusty-mpm's `skills:` dependency list must never become a permission grant"
+    );
+    assert!(cfg.agent.tier.is_none());
+}
+
+/// Hand-authored `.trusty-agents/agents/*` MUST WIN over a trusty-mpm-sourced
+/// agent of the same name.
+///
+/// Why pin it: `agent_search_paths` already orders `.trusty-agents/agents`
+/// ahead of `.claude/agents` and `AgentRegistry::load` is first-occurrence-wins,
+/// so #4496 preserves this rather than introducing it — but nothing previously
+/// asserted it, and now that the two tiers use DIFFERENT parsers a silent
+/// inversion would also silently change which schema an operator's file is read
+/// with. The assertion is on the resulting config, not on the ordering, so it
+/// still holds if the shadowing mechanism is ever reimplemented.
+#[test]
+fn hand_authored_trusty_agents_md_wins_over_a_claude_agents_agent() {
+    let tmp = TempDir::new().unwrap();
+    let trusty = agents_tier(tmp.path(), ".trusty-agents");
+    let claude = agents_tier(tmp.path(), ".claude");
+
+    // Hand-authored overlay, trusty-agents' own schema.
+    fs::write(
+        trusty.join("engineer.md"),
+        "---\nname: engineer\nrole: engineer\ndescription: hand-authored\n\
+         runner: in-process\n---\n\nHand-authored body.\n",
+    )
+    .unwrap();
+    // Same name, trusty-mpm deploy artifact.
+    fs::write(
+        claude.join("engineer.md"),
+        "---\nname: engineer\nrole: qa\ndescription: mpm-deployed\n---\n\nDeployed body.\n",
+    )
+    .unwrap();
+
+    let reg = AgentRegistry::load(&[trusty, claude]);
+
+    assert_eq!(reg.len(), 1, "the shadowed copy must not be added");
+    let cfg = reg.get("engineer").expect("engineer is registered");
+    assert_eq!(cfg.agent.description, "hand-authored");
+    assert_eq!(cfg.agent.role, "engineer");
+    assert_eq!(
+        cfg.agent.runner,
+        RunnerKind::InProcess,
+        "the winning copy must be the one parsed by `parse_md_agent` — `runner:` \
+         is a key only trusty-agents' own overlay schema has"
+    );
+}
+
+/// The bundled `.trusty-agents/agents` roster must keep shadowing a
+/// same-named trusty-mpm artifact even when the mpm tier is listed too —
+/// the real-world shape of the collision, using the actual shipped agents.
+#[test]
+fn bundled_agents_are_not_shadowed_by_a_claude_agents_copy() {
+    let _guard = HOME_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let tmp = TempDir::new().unwrap();
+    let claude = agents_tier(tmp.path(), ".claude");
+    fs::write(
+        claude.join("research-agent.md"),
+        "---\nname: research-agent\nrole: qa\ndescription: impostor\n---\n\nBody.\n",
+    )
+    .unwrap();
+
+    let reg = AgentRegistry::load(&[bundled_agents_dir(), claude]);
+
+    let cfg = reg.get("research-agent").expect("bundled agent present");
+    assert_ne!(
+        cfg.agent.description, "impostor",
+        "a trusty-mpm artifact must never shadow a bundled/hand-authored agent"
+    );
 }
 
 // ── Integration-style tests against bundled config/agents/ ─────────────


### PR DESCRIPTION
> Follow-up to #4498 (merged as `887dfbed`), which added the `agents::mpm_bridge` adapter this PR wires in.
>
> _(Supersedes PR #4500, which GitHub auto-closed when its stacked base branch was deleted on #4498's merge. Same branch, same commit, retargeted to `main`.)_

## What

Switches the `.claude/agents` tier — and **only** that tier — from `parse_md_agent` to the `agents::mpm_bridge` adapter added in #4498.

## Why: this is a real bug, not a tidy-up

`AgentRegistry::load` has scanned `~/.claude/agents` and `<project>/.claude/agents` as a first-class roster tier (`registry/mod.rs:106`, `:429-433`) for some time — but parsed those files with trusty-agents' **own** overlay reader, even though the tier holds trusty-mpm's **deployed** artifacts.

The two schemas disagree in a way that loses agents *silently*:

| | trusty-mpm `tools:` | `MdAgentFrontmatter::tools` |
|---|---|---|
| shape | flat list of names | nested `ToolsConfig` map |

`serde_yaml` deserializing the former into the latter is a **hard error**, and `load` warns and skips the whole file. The agent doesn't lose its tools — it disappears from the roster, leaving only a log line.

The new test pins exactly that failure mode. With the routing disabled it does **not** fail on a wrong field value:

```
panicked at registry/tests.rs:408: mpm artifact is discovered: None
```

i.e. `reg.get("research")` was `None`. Verified by temporarily disabling the match arm and re-running.

## The split

- `.claude/agents` (project-local **and** `$HOME`) → `mpm_bridge::load_mpm_agent` — leaf-only, shared grammar.
- `.trusty-agents/agents`, `<config_dir>/agents` → `parse_md_agent`, unchanged. This stays the reader for trusty-agents' own overlay schema: `capabilities:`, `runner:`, `display_name:`, and a **live** `extends:` that the mpm tier deliberately does not resolve.

Neither reader is a superset of the other, which is why this is a per-tier **selection** rather than a merge. The tier is identified by directory *shape* (`is_claude_agents_dir`), so it works identically for both `.claude/agents` entries without hardcoding either path.

## Name-collision precedence

Hand-authored and bundled `.trusty-agents/agents/*` agents **must win** over a same-named trusty-mpm agent. `agent_search_paths` already orders the tiers that way and `load` is first-occurrence-wins, so this PR **preserves** that rather than introducing it — but nothing previously asserted it, and now that the two tiers use *different parsers*, a silent ordering inversion would also silently change which schema an operator's file is read with.

Two tests pin it:

- `hand_authored_trusty_agents_md_wins_over_a_claude_agents_agent` — asserts on the resulting config (including `runner: in-process`, a key only the overlay schema has, so it also proves *which parser* produced the winner), not on the ordering, so it survives a reimplementation of the shadowing mechanism.
- `bundled_agents_are_not_shadowed_by_a_claude_agents_copy` — uses `research-agent`, which is both a real bundled agent **and** a `ASSISTANT_REACHABLE_SUBAGENTS` floor name, so the collision that would matter most is the one under test.

## Existing tests

`registry_picks_up_md_files_alongside_toml` and `registry_md_file_without_frontmatter_is_skipped` needed **no change and were not weakened**: both use a bare `TempDir`, which is not shaped `.claude/agents`, so they still exercise `parse_md_agent` — including the latter, whose skip still comes from that parser's missing-fence error. A comment now records why, so the next reader doesn't assume the tier changed under them.

## Security: no reachability change

Verified by diff, not by assertion — `git diff origin/main` for this stack touches **6 files**, and none of these appear in it:

- `agents/delegation.rs` (`ASSISTANT_REACHABLE_SUBAGENTS`)
- `tools/subagent_allow.rs` (`SubagentAllowSet`)
- `tools/delegate.rs`, `tools/cross_product.rs`
- any persona `agent.toml` / `[subagents].delegate_allowed`

Every agent projected from this tier carries `SubagentsConfig::default()` — no delegation targets granted. **No assistant gains a reachable delegation target.** `bundled_personas_pin_git_reach` (`agents/tests/loading.rs:2075`) passes unchanged, so the `assistant/agent.toml:79-91` no-git-tools posture that guards izzie's untrusted-Gmail/Drive ingestion is intact.

Note the delegation floor is name-based (`research-agent`, `ticketing-agent`), and the bundled copies of both win the collision — pinned above.

## Gates

`cargo check` · `cargo test -p trusty-agents --lib` (3131 passed, 0 failed) · `--test api_e2e` (4 passed) · `cargo clippy -p trusty-agents --all-targets -- -D warnings` (clean) · `cargo fmt --check` (clean) · `check_line_cap.sh` (0 violations) · `check_test_pointers.sh` (exit 0) · `check_changelog_fragment.sh` (fragment valid).

Closes #4496

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
