### PR TITLE
fix(trusty-code): tcode tui auto-spawns the daemon instead of exiting when none is running

### DIFF
--- a/crates/trusty-code/changelog.d/4476-migrated-added.md
+++ b/crates/trusty-code/changelog.d/4476-migrated-added.md
@@ -7,10 +7,10 @@ Added
   -> `http_addr` file -> `/health` liveness ping), then hands `CodeEngine` to
   `trusty_tui::run::run`. `--project` is optional (omit for a projectless
   session) and is canonicalized at the CLI boundary. Discovery runs BEFORE the
-  alternate screen is entered, so a missing daemon prints an actionable
-  `tcode tui: no tcode daemon found — start one with \`tcode serve --http\` …`
-  and exits nonzero rather than flashing a TUI. This MVP does not auto-spawn a
-  daemon (deliberately deferred, DOC-50 §4.1).
+  alternate screen is entered, so any daemon-resolution failure lands on a
+  normal terminal rather than flashing a TUI. As shipped this MVP did not
+  auto-spawn a daemon; that was reversed in the same release — see the #4512
+  entry below.
 
 - **`Event::AgentMessageDelta` now has a producer (streaming epic #3696,
   Gap A / Slice 1).** The event contract landed in #3701, but no production

--- a/crates/trusty-code/changelog.d/4512-tui-daemon-autospawn.md
+++ b/crates/trusty-code/changelog.d/4512-tui-daemon-autospawn.md
@@ -1,7 +1,8 @@
 Changed
 
 - **`tcode tui` now starts its own daemon instead of exiting when none is
-  running ([#4512](https://github.com/bobmatnyc/trusty-tools/issues/4512)).**
+  running, and never stops it
+  ([#4512](https://github.com/bobmatnyc/trusty-tools/issues/4512)).**
   The subcommand shipped in #4424 (PR #4433) requiring an already-running
   `tcode serve --http`: discovery failed, an actionable "start one first"
   message printed, and the command exited. DOC-50 §4.1 had deferred auto-spawn
@@ -9,8 +10,8 @@ Changed
   the operator hand-start a background service first is not a shippable
   first-run experience.
   - Discovery is UNCHANGED: `TCODE_DAEMON_URL`, then the `http_addr` discovery
-    file, each verified with a `GET /health` liveness ping. A live daemon is
-    attached to exactly as before.
+    file, each verified with a `GET /health` liveness ping. A live daemon
+    serving the same project is attached to exactly as before.
   - A missing or stale discovery file now spawns `tcode serve --http` as a
     child, forwarding `--project <path>` when the TUI has one and omitting it
     for a projectless session so the daemon's binding matches the TUI's. The
@@ -20,13 +21,16 @@ Changed
     `trusty_common::daemon_guard::spin_until_ready` spinner rather than a fourth
     hand-rolled poll loop, raced against the child's exit so a daemon that fails
     to bind is reported immediately instead of spinning out the 20s budget.
-  - **Ownership is tracked and enforced.** A daemon `tcode tui` spawned is owned
-    by it and stopped when the REPL exits — SIGTERM plus a 5s grace period so
-    axum drains in-flight requests (the connection-safe restart convention,
-    #534), escalating to SIGKILL only if it ignores SIGTERM. A pre-existing
-    daemon the TUI merely attached to is NEVER killed on exit. Teardown runs
-    even when the REPL itself failed, so a spawned daemon cannot outlive its
-    TUI.
+  - **Quitting the TUI never stops the daemon — including one the TUI itself
+    started.** The tcode daemon owns PM lifecycle, agent dispatch, and agent
+    communication, and CLIs/TUIs *attach* to it, so a client exiting must not
+    destroy live PM or agent work (owner directive, 2026-08-01). There is no
+    client-side teardown of any kind: no ownership tracking, no SIGTERM, no
+    `kill_on_drop`. A daemon `tcode tui` spawned keeps running afterwards
+    exactly like one started by hand. Quiescence-gated idle exit — a daemon
+    that stops itself once it has no attached clients AND no active PM/agent
+    sessions — is separate follow-up work and is deliberately not implemented
+    here.
   - A `TCODE_DAEMON_URL` that is set but unreachable is still an ERROR, not a
     spawn: starting a daemon at the default port would silently ignore an
     address the operator named explicitly. The message names the dead URL and
@@ -37,6 +41,36 @@ Changed
     make a failed startup undiagnosable); startup errors name that file.
   - New `cli::daemon_autospawn` holds the whole policy, keeping `cli::tui` the
     thin wiring file it was. `tui_client::discovery` gained `lookup_daemon` +
-    `Lookup`/`Source`, the source-aware primitive `discover_daemon_url` is now
-    a wrapper over — needed because auto-spawn must distinguish an explicit
-    instruction it has to obey from a stale file it may replace.
+    `Lookup`/`Source`, and `discover_daemon_url` is now a wrapper over it —
+    needed because auto-spawn must distinguish an explicit instruction it has
+    to obey from a stale file it may replace.
+
+Added
+
+- **`GET /health` (and the `health` JSON-RPC method) now report the daemon's
+  project binding and pid
+  ([#4512](https://github.com/bobmatnyc/trusty-tools/issues/4512)).**
+  Additive only — `server`, `version`, and `status` are unchanged, so existing
+  probes keep working. A daemon binds exactly one `ProjectBinding` at
+  `serve::build_router` time and holds it for its whole life, but published
+  nothing about it, so a client had no way to tell which project a daemon it
+  found was serving. `binding` uses the same `{state, root}` wire shape
+  `Session` already serialises.
+
+Fixed
+
+- **`tcode tui` refuses to attach to a daemon serving a different project
+  ([#4512](https://github.com/bobmatnyc/trusty-tools/issues/4512)).**
+  Auto-attach picks daemons up off a well-known address, so without a check a
+  TUI launched in project B would silently drive project A's daemon and every
+  session, index, and file operation would land in the wrong repository. The
+  client now compares its own project against the binding the daemon reports on
+  `/health` and, on a mismatch, fails with an error naming BOTH projects and
+  the ways forward. It deliberately does NOT fall back to spawning a competing
+  daemon on a port that is already in use. Projectless and project-bound are a
+  mismatch in either direction: attaching a projectless TUI to a bound daemon
+  would grant it a project nobody named, and attaching a bound TUI to a
+  projectless daemon would withdraw the indexing and git affordances the
+  operator asked for. A daemon too old to report a binding is refused as well
+  (fail-closed — "old build" is no evidence the project is right), with a
+  message saying to restart it.

--- a/crates/trusty-code/changelog.d/4512-tui-daemon-autospawn.md
+++ b/crates/trusty-code/changelog.d/4512-tui-daemon-autospawn.md
@@ -1,0 +1,42 @@
+Changed
+
+- **`tcode tui` now starts its own daemon instead of exiting when none is
+  running ([#4512](https://github.com/bobmatnyc/trusty-tools/issues/4512)).**
+  The subcommand shipped in #4424 (PR #4433) requiring an already-running
+  `tcode serve --http`: discovery failed, an actionable "start one first"
+  message printed, and the command exited. DOC-50 §4.1 had deferred auto-spawn
+  to Phase 2; that deferral is reversed — an interactive command that demands
+  the operator hand-start a background service first is not a shippable
+  first-run experience.
+  - Discovery is UNCHANGED: `TCODE_DAEMON_URL`, then the `http_addr` discovery
+    file, each verified with a `GET /health` liveness ping. A live daemon is
+    attached to exactly as before.
+  - A missing or stale discovery file now spawns `tcode serve --http` as a
+    child, forwarding `--project <path>` when the TUI has one and omitting it
+    for a projectless session so the daemon's binding matches the TUI's. The
+    binary is resolved via `std::env::current_exe()` (`cli::tcode_exe::resolve`),
+    so a locally built binary spawns itself rather than a stale `PATH` copy.
+    Readiness reuses the shared
+    `trusty_common::daemon_guard::spin_until_ready` spinner rather than a fourth
+    hand-rolled poll loop, raced against the child's exit so a daemon that fails
+    to bind is reported immediately instead of spinning out the 20s budget.
+  - **Ownership is tracked and enforced.** A daemon `tcode tui` spawned is owned
+    by it and stopped when the REPL exits — SIGTERM plus a 5s grace period so
+    axum drains in-flight requests (the connection-safe restart convention,
+    #534), escalating to SIGKILL only if it ignores SIGTERM. A pre-existing
+    daemon the TUI merely attached to is NEVER killed on exit. Teardown runs
+    even when the REPL itself failed, so a spawned daemon cannot outlive its
+    TUI.
+  - A `TCODE_DAEMON_URL` that is set but unreachable is still an ERROR, not a
+    spawn: starting a daemon at the default port would silently ignore an
+    address the operator named explicitly. The message names the dead URL and
+    both ways forward.
+  - The spawned daemon's stdout/stderr go to
+    `{data_dir}/trusty-code/tui-spawned-daemon.log` rather than being inherited
+    (which would scribble across the alternate screen) or null-ed (which would
+    make a failed startup undiagnosable); startup errors name that file.
+  - New `cli::daemon_autospawn` holds the whole policy, keeping `cli::tui` the
+    thin wiring file it was. `tui_client::discovery` gained `lookup_daemon` +
+    `Lookup`/`Source`, the source-aware primitive `discover_daemon_url` is now
+    a wrapper over — needed because auto-spawn must distinguish an explicit
+    instruction it has to obey from a stale file it may replace.

--- a/crates/trusty-code/src/cli/daemon_autospawn.rs
+++ b/crates/trusty-code/src/cli/daemon_autospawn.rs
@@ -1,0 +1,375 @@
+//! Attach to a running `tcode serve --http` daemon, or START one — with
+//! ownership tracked so only a daemon WE started is ever stopped (#4512).
+//!
+//! Why: `tcode tui` shipped (#4424, PR #4433) refusing to run without a
+//! hand-started daemon: discovery failed, the command printed an "actionable
+//! message" and exited. DOC-50 §4.1 deferred auto-spawn to Phase 2, but an
+//! interactive command that demands the operator go start a background
+//! service first is not a shippable first-run experience — the owner
+//! directive of 2026-07-31 overturns that deferral. This module is the
+//! resulting policy layer, kept OUT of `tui.rs` so the launch path stays a
+//! thin "resolve args -> build engine -> run" wiring file (`crate::cli`'s
+//! contract) and so the lifetime rules below are stated in one place.
+//! What: [`ensure_daemon`] resolves a daemon URL through the UNCHANGED
+//! discovery order (`TCODE_DAEMON_URL`, then the `http_addr` file, each
+//! liveness-pinged — `tui_client::discovery::lookup_daemon`) and returns a
+//! [`DaemonSession`] carrying that URL plus who owns the process:
+//!
+//! * **Live daemon found** -> [`Ownership::Attached`]. Nothing is spawned,
+//!   and [`DaemonSession::shutdown`] is a NO-OP: a daemon we merely attached
+//!   to belongs to whoever started it (possibly another TUI, an IDE, or a
+//!   long-running dev daemon) and must survive our exit.
+//! * **`TCODE_DAEMON_URL` set but unreachable** -> hard error naming that
+//!   URL. Auto-spawn deliberately does NOT apply here: the operator named an
+//!   address, and starting a daemon at a DIFFERENT address (the default
+//!   port) would silently ignore that instruction.
+//! * **Discovery file stale or absent** -> spawn
+//!   `<current_exe> serve --http [--project <path>]` as a child, wait for it
+//!   to answer `GET /health`, and return [`Ownership::Spawned`]. We started
+//!   it, so we stop it: [`DaemonSession::shutdown`] sends SIGTERM and waits
+//!   out a grace period so axum drains in-flight requests (the workspace's
+//!   connection-safe restart convention, #534), escalating to SIGKILL only
+//!   if the daemon ignores SIGTERM.
+//!
+//! The binary is resolved with [`super::tcode_exe::resolve`]
+//! (`std::env::current_exe()`), never a bare `tcode` PATH lookup, so a
+//! locally built binary spawns ITSELF rather than a stale installed copy.
+//! The readiness wait reuses the shared
+//! `trusty_common::daemon_guard::spin_until_ready` spinner (issue #985's
+//! single tested implementation, already used by trusty-search/-memory/
+//! -analyze) instead of a fourth hand-rolled poll loop, raced against
+//! `Child::wait` so a daemon that dies on startup (e.g. its port is taken)
+//! reports THAT immediately instead of spinning out the whole budget.
+//! Test: `daemon_autospawn_tests::*` (sibling file, per the 500-SLOC
+//! production cap) covers all four branches against a `wiremock` health
+//! endpoint and stub child binaries — attach-without-spawning, spawn,
+//! never-kill-what-we-did-not-spawn, and refuse-to-spawn-for-an-explicit-URL.
+
+use std::path::{Path, PathBuf};
+use std::process::Stdio;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use tokio::process::{Child, Command};
+use trusty_code::serve::DEFAULT_HTTP_PORT;
+use trusty_code::tui_client::discovery::{DAEMON_URL_ENV, Lookup, Source, lookup_daemon};
+use trusty_common::daemon_guard::{DaemonGuardConfig, spin_until_ready};
+
+/// How long a daemon WE spawned gets to become healthy before we give up,
+/// stop it, and report the failure.
+///
+/// Shorter than `daemon_guard::DEFAULT_STARTUP_TIMEOUT` (30s) because this
+/// wait sits between the operator pressing Enter and a TUI appearing — 20s
+/// of spinner is already the outer edge of tolerable, and a tcode daemon
+/// that has not bound its port by then is not about to.
+const STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// How long a daemon we own gets to drain and exit after SIGTERM before we
+/// escalate to SIGKILL. Matches the sibling sidecar teardown in
+/// `trusty-agents`' Tauri shell, whose axum drain is the same shape.
+const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
+
+/// Filename (under `resolve_data_dir("trusty-code")`) the spawned daemon's
+/// stdout/stderr are appended to.
+///
+/// Why a file rather than inherited fds: the TUI takes over the terminal
+/// with an alternate screen immediately after this, so an inherited stderr
+/// would scribble daemon log lines across the rendered UI. Null-ing it
+/// instead (as `daemon_guard::spawn_current_exe` does) would make a
+/// failed startup completely undiagnosable, so we keep the output and name
+/// the file in the error message.
+const DAEMON_LOG_FILENAME: &str = "tui-spawned-daemon.log";
+
+/// Who owns the daemon's process lifetime — the distinction the whole
+/// module exists to enforce.
+#[derive(Debug)]
+pub enum Ownership {
+    /// The daemon was already running. We did not start it, so we never
+    /// stop it.
+    Attached,
+    /// We started this daemon, so we are responsible for stopping it.
+    Spawned(Child),
+}
+
+/// A daemon `tcode tui` is about to drive, plus who owns its lifetime.
+#[derive(Debug)]
+pub struct DaemonSession {
+    /// Base URL (no trailing slash) the engine should target.
+    pub url: String,
+    ownership: Ownership,
+}
+
+impl DaemonSession {
+    /// Stop the daemon IF we started it; leave a pre-existing one running.
+    ///
+    /// Why: killing a daemon we merely attached to would tear the rug out
+    /// from under whoever actually started it — another TUI, an editor
+    /// integration, or a dev daemon deliberately left running. Ownership is
+    /// therefore recorded at attach/spawn time, not inferred here.
+    /// What: no-op for [`Ownership::Attached`]; for [`Ownership::Spawned`],
+    /// SIGTERM -> wait up to [`SHUTDOWN_GRACE`] for a graceful axum drain ->
+    /// SIGKILL + reap only if it ignored SIGTERM. Consumes `self` so a
+    /// session cannot be shut down twice.
+    /// Test: `daemon_autospawn_tests::{shutdown_stops_a_daemon_we_spawned,
+    /// shutdown_leaves_a_pre_existing_daemon_running}`.
+    pub async fn shutdown(self) {
+        match self.ownership {
+            Ownership::Attached => {
+                tracing::debug!(
+                    url = %self.url,
+                    "tcode tui: leaving the pre-existing daemon running (we did not start it)"
+                );
+            }
+            Ownership::Spawned(child) => {
+                tracing::debug!(url = %self.url, "tcode tui: stopping the daemon it started");
+                terminate(child, SHUTDOWN_GRACE).await;
+            }
+        }
+    }
+}
+
+/// Resolve a live daemon URL, starting a daemon if none is running.
+///
+/// Why/What/Test: see module docs — this function IS the policy.
+/// `project` mirrors `tcode tui`'s own `--project`: it is forwarded to a
+/// spawned daemon so the daemon's binding matches the TUI's, and OMITTED
+/// when the TUI is projectless (a first-class state, not a degraded one).
+pub async fn ensure_daemon(
+    client: &reqwest::Client,
+    project: Option<&Path>,
+) -> Result<DaemonSession> {
+    let tcode_exe = super::tcode_exe::resolve()?;
+    let health_url = format!("http://127.0.0.1:{DEFAULT_HTTP_PORT}");
+    ensure_daemon_with(client, project, &tcode_exe, &health_url).await
+}
+
+/// [`ensure_daemon`] with the binary and default daemon URL injected.
+///
+/// Why: mirrors `cli_client::StdioRpcClient::spawn`'s established shape —
+/// the library half takes an explicit binary path so it stays testable with
+/// a stub, and the `std::env`/well-known-port policy lives in the one CLI
+/// wrapper above. Tests drive the real spawn/wait/teardown machinery
+/// against a stub child and a `wiremock` health endpoint, with no dependence
+/// on the developer's actual port 7882 or `$HOME`.
+async fn ensure_daemon_with(
+    client: &reqwest::Client,
+    project: Option<&Path>,
+    tcode_exe: &Path,
+    health_base_url: &str,
+) -> Result<DaemonSession> {
+    match lookup_daemon(client).await {
+        Lookup::Live(url) => Ok(DaemonSession {
+            url,
+            ownership: Ownership::Attached,
+        }),
+        // An explicit instruction we must not second-guess — see module docs.
+        Lookup::Dead {
+            url,
+            source: Source::Env,
+        } => Err(explicit_url_unreachable(&url)),
+        Lookup::Dead {
+            source: Source::File,
+            ..
+        }
+        | Lookup::Absent => spawn_and_wait(project, tcode_exe, health_base_url).await,
+    }
+}
+
+/// The error for a `TCODE_DAEMON_URL` that names an unreachable daemon.
+///
+/// Kept verbose on purpose: the operator has to know both that we refused to
+/// spawn and exactly how to change that.
+fn explicit_url_unreachable(url: &str) -> anyhow::Error {
+    anyhow!(
+        "{DAEMON_URL_ENV} is set to {url} but no daemon is responding there. \
+         `tcode tui` will not start one for you while {DAEMON_URL_ENV} names an \
+         address explicitly — spawning at a different address would ignore that \
+         setting. Start `tcode serve --http` at {url}, or unset {DAEMON_URL_ENV} \
+         and let `tcode tui` start a daemon itself."
+    )
+}
+
+/// Spawn a daemon and block until it answers `GET {health_base_url}/health`.
+async fn spawn_and_wait(
+    project: Option<&Path>,
+    tcode_exe: &Path,
+    health_base_url: &str,
+) -> Result<DaemonSession> {
+    let log_path = daemon_log_path();
+    let mut child = spawn_daemon(tcode_exe, project, log_path.as_deref())?;
+    let config = DaemonGuardConfig {
+        startup_timeout: STARTUP_TIMEOUT,
+        ..DaemonGuardConfig::new(
+            format!("{health_base_url}/health"),
+            "the tcode daemon",
+            log_hint(log_path.as_deref()),
+        )
+    };
+
+    // Race readiness against the child dying: a daemon whose port is already
+    // taken exits in milliseconds, and spinning out the full budget to then
+    // report a timeout would hide the real cause. Bound to an `Outcome` so
+    // the `&mut child` borrow the `wait()` future holds ends with the
+    // `select!` expression, leaving `child` movable below.
+    let outcome = tokio::select! {
+        ready = spin_until_ready(&config) => Outcome::Ready(ready),
+        exit = child.wait() => Outcome::Exited(exit.map(|s| s.to_string())),
+    };
+
+    match outcome {
+        Outcome::Ready(Ok(())) => {
+            // Healthy AND still running. `try_wait` closes the race where
+            // the health URL was answered by SOMETHING ELSE while our own
+            // child died (e.g. another daemon already held the port).
+            if matches!(child.try_wait(), Ok(Some(_))) {
+                return Err(exited_early(
+                    "it exited during startup",
+                    log_path.as_deref(),
+                ));
+            }
+            Ok(DaemonSession {
+                url: health_base_url.to_string(),
+                ownership: Ownership::Spawned(child),
+            })
+        }
+        Outcome::Ready(Err(e)) => {
+            // Never leak the child we just gave up on.
+            terminate(child, SHUTDOWN_GRACE).await;
+            Err(e)
+        }
+        Outcome::Exited(status) => {
+            let detail = match status {
+                Ok(s) => format!("it exited during startup ({s})"),
+                Err(e) => format!("its exit status could not be read ({e})"),
+            };
+            Err(exited_early(&detail, log_path.as_deref()))
+        }
+    }
+}
+
+/// Which arm of [`spawn_and_wait`]'s race finished first.
+enum Outcome {
+    Ready(Result<()>),
+    Exited(std::io::Result<String>),
+}
+
+/// Build and spawn `<tcode_exe> serve --http [--project <path>]`.
+///
+/// `kill_on_drop(true)` is a BACKSTOP, not the teardown path: a panic or
+/// early return that drops the session without calling
+/// [`DaemonSession::shutdown`] must not leak a daemon holding the port. The
+/// graceful SIGTERM path in [`terminate`] always runs first on the normal
+/// exit, reaping the child so this drop hook becomes a no-op.
+fn spawn_daemon(
+    tcode_exe: &Path,
+    project: Option<&Path>,
+    log_path: Option<&Path>,
+) -> Result<Child> {
+    let mut cmd = Command::new(tcode_exe);
+    cmd.arg("serve").arg("--http");
+    if let Some(project) = project {
+        cmd.arg("--project").arg(project);
+    }
+    cmd.stdin(Stdio::null());
+    match log_path.and_then(open_log) {
+        Some((out, err)) => {
+            cmd.stdout(out).stderr(err);
+        }
+        None => {
+            cmd.stdout(Stdio::null()).stderr(Stdio::null());
+        }
+    }
+    cmd.kill_on_drop(true).spawn().with_context(|| {
+        format!(
+            "tcode tui: could not start a daemon with `{} serve --http`",
+            tcode_exe.display()
+        )
+    })
+}
+
+/// Open (append, creating as needed) two handles onto the daemon log — one
+/// each for the child's stdout and stderr. `None` on any failure, which
+/// downgrades the spawn to null-ed output rather than failing the launch.
+fn open_log(path: &Path) -> Option<(Stdio, Stdio)> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).ok()?;
+    }
+    let open = || {
+        std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .ok()
+    };
+    Some((Stdio::from(open()?), Stdio::from(open()?)))
+}
+
+/// `{resolve_data_dir("trusty-code")}/tui-spawned-daemon.log`, or `None` if
+/// the data directory cannot be resolved (never fatal — see
+/// [`DAEMON_LOG_FILENAME`]).
+fn daemon_log_path() -> Option<PathBuf> {
+    trusty_common::resolve_data_dir("trusty-code")
+        .ok()
+        .map(|dir| dir.join(DAEMON_LOG_FILENAME))
+}
+
+/// "see <log>" pointer appended to startup failures, or a generic hint when
+/// no log file could be opened.
+fn log_hint(log_path: Option<&Path>) -> String {
+    match log_path {
+        Some(path) => format!("see {} for the daemon's own output", path.display()),
+        None => "run `tcode serve --http` by hand to see why".to_string(),
+    }
+}
+
+/// Error for a spawned daemon that died instead of coming up.
+fn exited_early(detail: &str, log_path: Option<&Path>) -> anyhow::Error {
+    anyhow!(
+        "tcode tui: started a daemon but {detail} — {}. A daemon already \
+         holding port {DEFAULT_HTTP_PORT} is the usual cause.",
+        log_hint(log_path)
+    )
+}
+
+/// SIGTERM -> grace -> SIGKILL, reaping the child either way.
+///
+/// Why: SIGTERM lets `tcode serve --http`'s axum server run its graceful
+/// shutdown (`trusty_common::shutdown_signal`) and drain in-flight requests,
+/// per the workspace's connection-safe restart convention (#534) — a bare
+/// kill would drop live SSE subscribers mid-stream. The SIGKILL escalation
+/// exists so a wedged daemon still cannot outlive the TUI and keep the port.
+/// Mirrors `trusty-agents`' `ui/src-tauri/src/sidecar.rs::terminate_child`
+/// (that one is `pub(crate)` inside a Tauri binary crate, so it cannot be
+/// imported — only its shape reused).
+async fn terminate(mut child: Child, grace: Duration) {
+    // Already gone: reap without signalling.
+    if let Ok(Some(_)) = child.try_wait() {
+        return;
+    }
+
+    #[cfg(unix)]
+    if let Some(pid) = child.id() {
+        // SAFETY: `pid` names a child process we spawned and have not yet
+        // reaped, and `SIGTERM` is a valid signal. `kill` has no
+        // memory-safety effects — a already-exited pid merely returns ESRCH,
+        // which is exactly the case the `try_wait` above handles.
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+        if tokio::time::timeout(grace, child.wait()).await.is_ok() {
+            return;
+        }
+        tracing::warn!(
+            pid,
+            ?grace,
+            "tcode daemon did not exit on SIGTERM within grace; sending SIGKILL"
+        );
+    }
+
+    let _ = child.start_kill();
+    let _ = child.wait().await;
+}
+
+#[cfg(test)]
+#[path = "daemon_autospawn_tests.rs"]
+mod daemon_autospawn_tests;

--- a/crates/trusty-code/src/cli/daemon_autospawn.rs
+++ b/crates/trusty-code/src/cli/daemon_autospawn.rs
@@ -1,5 +1,5 @@
-//! Attach to a running `tcode serve --http` daemon, or START one — with
-//! ownership tracked so only a daemon WE started is ever stopped (#4512).
+//! Attach to a running `tcode serve --http` daemon, or START one — and
+//! then LEAVE IT RUNNING, whoever started it (#4512).
 //!
 //! Why: `tcode tui` shipped (#4424, PR #4433) refusing to run without a
 //! hand-started daemon: discovery failed, the command printed an "actionable
@@ -9,27 +9,41 @@
 //! directive of 2026-07-31 overturns that deferral. This module is the
 //! resulting policy layer, kept OUT of `tui.rs` so the launch path stays a
 //! thin "resolve args -> build engine -> run" wiring file (`crate::cli`'s
-//! contract) and so the lifetime rules below are stated in one place.
+//! contract) and so the lifetime and binding rules below are stated in one
+//! place.
+//!
+//! **The TUI never stops the daemon.** Per the owner directive of
+//! 2026-08-01, the tcode daemon is the process that owns PM lifecycle, agent
+//! dispatch, and inter-agent communication; a TUI is one of possibly several
+//! CLIs/TUIs *attached* to it. Quitting a client must therefore never end
+//! live PM or agent work, so this module signals the daemon on exit under NO
+//! circumstance — not even one it started itself. A daemon `tcode tui`
+//! spawned simply keeps running afterwards, exactly like one started by
+//! hand. Quiescence-gated idle exit (a daemon that stops itself once it has
+//! no attached clients AND no active PM/agent sessions) is separate
+//! follow-up work, deliberately not implemented here: getting it wrong in
+//! either direction destroys work or leaks processes, and it needs its own
+//! lease/refcount design rather than a client-side kill.
+//!
 //! What: [`ensure_daemon`] resolves a daemon URL through the UNCHANGED
 //! discovery order (`TCODE_DAEMON_URL`, then the `http_addr` file, each
-//! liveness-pinged — `tui_client::discovery::lookup_daemon`) and returns a
-//! [`DaemonSession`] carrying that URL plus who owns the process:
+//! liveness-pinged — `tui_client::discovery::lookup_daemon`) and returns the
+//! base URL to drive:
 //!
-//! * **Live daemon found** -> [`Ownership::Attached`]. Nothing is spawned,
-//!   and [`DaemonSession::shutdown`] is a NO-OP: a daemon we merely attached
-//!   to belongs to whoever started it (possibly another TUI, an IDE, or a
-//!   long-running dev daemon) and must survive our exit.
+//! * **Live daemon found, serving the SAME project** -> attach. Nothing is
+//!   spawned and nothing is owned.
+//! * **Live daemon found, serving a DIFFERENT project** -> hard error naming
+//!   both projects (see [`check_binding`]). We neither attach — that would
+//!   silently operate against the wrong repository — nor start a competing
+//!   daemon on a port that is already taken.
 //! * **`TCODE_DAEMON_URL` set but unreachable** -> hard error naming that
 //!   URL. Auto-spawn deliberately does NOT apply here: the operator named an
 //!   address, and starting a daemon at a DIFFERENT address (the default
 //!   port) would silently ignore that instruction.
 //! * **Discovery file stale or absent** -> spawn
-//!   `<current_exe> serve --http [--project <path>]` as a child, wait for it
-//!   to answer `GET /health`, and return [`Ownership::Spawned`]. We started
-//!   it, so we stop it: [`DaemonSession::shutdown`] sends SIGTERM and waits
-//!   out a grace period so axum drains in-flight requests (the workspace's
-//!   connection-safe restart convention, #534), escalating to SIGKILL only
-//!   if the daemon ignores SIGTERM.
+//!   `<current_exe> serve --http [--project <path>]` as a child and wait for
+//!   it to answer `GET /health`. The child handle is dropped once it is
+//!   healthy; the daemon outlives this process.
 //!
 //! The binary is resolved with [`super::tcode_exe::resolve`]
 //! (`std::env::current_exe()`), never a bare `tcode` PATH lookup, so a
@@ -41,9 +55,10 @@
 //! `Child::wait` so a daemon that dies on startup (e.g. its port is taken)
 //! reports THAT immediately instead of spinning out the whole budget.
 //! Test: `daemon_autospawn_tests::*` (sibling file, per the 500-SLOC
-//! production cap) covers all four branches against a `wiremock` health
-//! endpoint and stub child binaries — attach-without-spawning, spawn,
-//! never-kill-what-we-did-not-spawn, and refuse-to-spawn-for-an-explicit-URL.
+//! production cap) covers every branch against a `wiremock` health endpoint
+//! and stub child binaries — attach-without-spawning, spawn, refuse-for-an-
+//! explicit-URL, refuse-on-a-binding-mismatch, and the universal
+//! never-signal-the-daemon-on-exit rule.
 
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -52,22 +67,19 @@ use std::time::Duration;
 use anyhow::{Context, Result, anyhow};
 use tokio::process::{Child, Command};
 use trusty_code::serve::DEFAULT_HTTP_PORT;
-use trusty_code::tui_client::discovery::{DAEMON_URL_ENV, Lookup, Source, lookup_daemon};
+use trusty_code::tui_client::discovery::{
+    DAEMON_URL_ENV, Lookup, ReportedBinding, Source, lookup_daemon,
+};
 use trusty_common::daemon_guard::{DaemonGuardConfig, spin_until_ready};
 
-/// How long a daemon WE spawned gets to become healthy before we give up,
-/// stop it, and report the failure.
+/// How long a daemon WE spawned gets to become healthy before we give up and
+/// report the failure.
 ///
 /// Shorter than `daemon_guard::DEFAULT_STARTUP_TIMEOUT` (30s) because this
 /// wait sits between the operator pressing Enter and a TUI appearing — 20s
 /// of spinner is already the outer edge of tolerable, and a tcode daemon
 /// that has not bound its port by then is not about to.
 const STARTUP_TIMEOUT: Duration = Duration::from_secs(20);
-
-/// How long a daemon we own gets to drain and exit after SIGTERM before we
-/// escalate to SIGKILL. Matches the sibling sidecar teardown in
-/// `trusty-agents`' Tauri shell, whose axum drain is the same shape.
-const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 
 /// Filename (under `resolve_data_dir("trusty-code")`) the spawned daemon's
 /// stdout/stderr are appended to.
@@ -80,64 +92,16 @@ const SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 /// the file in the error message.
 const DAEMON_LOG_FILENAME: &str = "tui-spawned-daemon.log";
 
-/// Who owns the daemon's process lifetime — the distinction the whole
-/// module exists to enforce.
-#[derive(Debug)]
-pub enum Ownership {
-    /// The daemon was already running. We did not start it, so we never
-    /// stop it.
-    Attached,
-    /// We started this daemon, so we are responsible for stopping it.
-    Spawned(Child),
-}
-
-/// A daemon `tcode tui` is about to drive, plus who owns its lifetime.
-#[derive(Debug)]
-pub struct DaemonSession {
-    /// Base URL (no trailing slash) the engine should target.
-    pub url: String,
-    ownership: Ownership,
-}
-
-impl DaemonSession {
-    /// Stop the daemon IF we started it; leave a pre-existing one running.
-    ///
-    /// Why: killing a daemon we merely attached to would tear the rug out
-    /// from under whoever actually started it — another TUI, an editor
-    /// integration, or a dev daemon deliberately left running. Ownership is
-    /// therefore recorded at attach/spawn time, not inferred here.
-    /// What: no-op for [`Ownership::Attached`]; for [`Ownership::Spawned`],
-    /// SIGTERM -> wait up to [`SHUTDOWN_GRACE`] for a graceful axum drain ->
-    /// SIGKILL + reap only if it ignored SIGTERM. Consumes `self` so a
-    /// session cannot be shut down twice.
-    /// Test: `daemon_autospawn_tests::{shutdown_stops_a_daemon_we_spawned,
-    /// shutdown_leaves_a_pre_existing_daemon_running}`.
-    pub async fn shutdown(self) {
-        match self.ownership {
-            Ownership::Attached => {
-                tracing::debug!(
-                    url = %self.url,
-                    "tcode tui: leaving the pre-existing daemon running (we did not start it)"
-                );
-            }
-            Ownership::Spawned(child) => {
-                tracing::debug!(url = %self.url, "tcode tui: stopping the daemon it started");
-                terminate(child, SHUTDOWN_GRACE).await;
-            }
-        }
-    }
-}
-
-/// Resolve a live daemon URL, starting a daemon if none is running.
+/// Resolve a live daemon URL for `project`, starting a daemon if none is
+/// running.
 ///
 /// Why/What/Test: see module docs — this function IS the policy.
-/// `project` mirrors `tcode tui`'s own `--project`: it is forwarded to a
-/// spawned daemon so the daemon's binding matches the TUI's, and OMITTED
-/// when the TUI is projectless (a first-class state, not a degraded one).
-pub async fn ensure_daemon(
-    client: &reqwest::Client,
-    project: Option<&Path>,
-) -> Result<DaemonSession> {
+/// `project` mirrors `tcode tui`'s own `--project` (already canonicalized by
+/// `cli::tui::resolve_project`): it is forwarded to a spawned daemon so the
+/// daemon's binding matches the TUI's, OMITTED when the TUI is projectless (a
+/// first-class state, not a degraded one), and — since #4512 — checked
+/// against the binding an already-running daemon reports.
+pub async fn ensure_daemon(client: &reqwest::Client, project: Option<&Path>) -> Result<String> {
     let tcode_exe = super::tcode_exe::resolve()?;
     let health_url = format!("http://127.0.0.1:{DEFAULT_HTTP_PORT}");
     ensure_daemon_with(client, project, &tcode_exe, &health_url).await
@@ -148,20 +112,19 @@ pub async fn ensure_daemon(
 /// Why: mirrors `cli_client::StdioRpcClient::spawn`'s established shape —
 /// the library half takes an explicit binary path so it stays testable with
 /// a stub, and the `std::env`/well-known-port policy lives in the one CLI
-/// wrapper above. Tests drive the real spawn/wait/teardown machinery
-/// against a stub child and a `wiremock` health endpoint, with no dependence
-/// on the developer's actual port 7882 or `$HOME`.
+/// wrapper above. Tests drive the real spawn/wait machinery against a stub
+/// child and a `wiremock` health endpoint, with no dependence on the
+/// developer's actual port 7882 or `$HOME`.
 async fn ensure_daemon_with(
     client: &reqwest::Client,
     project: Option<&Path>,
     tcode_exe: &Path,
     health_base_url: &str,
-) -> Result<DaemonSession> {
+) -> Result<String> {
     match lookup_daemon(client).await {
-        Lookup::Live(url) => Ok(DaemonSession {
-            url,
-            ownership: Ownership::Attached,
-        }),
+        // #4512: a daemon answering is not the same as a daemon serving the
+        // project we mean to work in.
+        Lookup::Live { url, binding } => check_binding(&url, &binding, project).map(|()| url),
         // An explicit instruction we must not second-guess — see module docs.
         Lookup::Dead {
             url,
@@ -172,6 +135,69 @@ async fn ensure_daemon_with(
             ..
         }
         | Lookup::Absent => spawn_and_wait(project, tcode_exe, health_base_url).await,
+    }
+}
+
+/// Accept a discovered daemon only if it serves the project the client wants.
+///
+/// Why: a daemon binds exactly one `ProjectBinding` for its whole life
+/// (`serve::build_router`), and auto-attach picks daemons up off a
+/// well-known port without the operator choosing one. Before #4512 the
+/// binding was not even on the wire, so a TUI launched in project B would
+/// attach to project A's daemon and every session, index, and file operation
+/// would land in the wrong repository — silently. Mismatch is therefore a
+/// hard error, and it is deliberately NOT an auto-spawn trigger: the port is
+/// already taken, so "just start our own" would either fail to bind or race
+/// the incumbent.
+///
+/// A projectless client meeting a project-bound daemon (and the reverse) is
+/// a MISMATCH, not a compatible pair. Projectless is a deliberate,
+/// first-class state — chat/planning with no index, no diff target and no
+/// project-scoped memory — so attaching a projectless TUI to a bound daemon
+/// would silently grant it a project the operator never named (exactly the
+/// implicit-binding bug `ProjectBinding` exists to prevent), and attaching a
+/// project-bound TUI to a projectless daemon would silently withdraw the
+/// indexing and git affordances the operator explicitly asked for. Neither
+/// side can be repaired after the fact, because the daemon's binding is
+/// fixed at its startup.
+///
+/// A daemon that reports NO binding ([`ReportedBinding::Unreported`], i.e. a
+/// build older than #4512) is refused as well. It fails CLOSED on purpose:
+/// the whole point of the check is that an unverified project is how work
+/// lands in the wrong repository, and "old daemon" is not evidence that its
+/// project is right. The remedy — restart it — is in the message.
+/// What: `Ok(())` when both sides name the same project or both are
+/// projectless; otherwise an error naming `url`, both projects, and the ways
+/// forward.
+/// Test: `daemon_autospawn_tests::{refuses_a_daemon_bound_to_another_project,
+/// refuses_a_project_bound_client_against_a_projectless_daemon,
+/// refuses_a_daemon_that_cannot_report_its_binding,
+/// attaches_to_a_live_daemon_without_spawning}`.
+fn check_binding(url: &str, reported: &ReportedBinding, wanted: Option<&Path>) -> Result<()> {
+    let wanted_label = wanted
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<projectless>".to_string());
+    match (reported, wanted) {
+        (ReportedBinding::Projectless, None) => Ok(()),
+        (ReportedBinding::Bound(root), Some(wanted)) if root == wanted => Ok(()),
+        (ReportedBinding::Unreported, _) => Err(anyhow!(
+            "the tcode daemon at {url} does not report which project it serves, \
+             so `tcode tui` cannot confirm it is bound to {wanted_label} — and \
+             attaching to the wrong project would run every session against the \
+             wrong repository. That daemon predates the binding check (#4512): \
+             stop it and let `tcode tui` start a current one, or restart it from \
+             this build of `tcode serve --http`."
+        )),
+        _ => Err(anyhow!(
+            "the tcode daemon at {url} serves a different project than this TUI: \
+             daemon = {daemon}, requested = {wanted_label}. `tcode tui` will not \
+             attach to it (every session would run against the wrong project) and \
+             will not start a competing daemon on a port that is already in use. \
+             Either relaunch this TUI against {daemon}, or stop that daemon and \
+             let this one start its own, or point `{DAEMON_URL_ENV}` at a daemon \
+             serving {wanted_label}.",
+            daemon = reported.describe(),
+        )),
     }
 }
 
@@ -190,11 +216,17 @@ fn explicit_url_unreachable(url: &str) -> anyhow::Error {
 }
 
 /// Spawn a daemon and block until it answers `GET {health_base_url}/health`.
+///
+/// The `Child` handle is dropped on every path, without a kill: a daemon
+/// this process started is a daemon it must not stop (module docs). Even the
+/// failure paths leave it alone — a half-started daemon may still be binding
+/// its port, and killing it would be the same "client tears down a shared
+/// service" mistake at a worse moment. The error names the log file instead.
 async fn spawn_and_wait(
     project: Option<&Path>,
     tcode_exe: &Path,
     health_base_url: &str,
-) -> Result<DaemonSession> {
+) -> Result<String> {
     let log_path = daemon_log_path();
     let mut child = spawn_daemon(tcode_exe, project, log_path.as_deref())?;
     let config = DaemonGuardConfig {
@@ -210,7 +242,7 @@ async fn spawn_and_wait(
     // taken exits in milliseconds, and spinning out the full budget to then
     // report a timeout would hide the real cause. Bound to an `Outcome` so
     // the `&mut child` borrow the `wait()` future holds ends with the
-    // `select!` expression, leaving `child` movable below.
+    // `select!` expression.
     let outcome = tokio::select! {
         ready = spin_until_ready(&config) => Outcome::Ready(ready),
         exit = child.wait() => Outcome::Exited(exit.map(|s| s.to_string())),
@@ -227,16 +259,9 @@ async fn spawn_and_wait(
                     log_path.as_deref(),
                 ));
             }
-            Ok(DaemonSession {
-                url: health_base_url.to_string(),
-                ownership: Ownership::Spawned(child),
-            })
+            Ok(health_base_url.to_string())
         }
-        Outcome::Ready(Err(e)) => {
-            // Never leak the child we just gave up on.
-            terminate(child, SHUTDOWN_GRACE).await;
-            Err(e)
-        }
+        Outcome::Ready(Err(e)) => Err(e),
         Outcome::Exited(status) => {
             let detail = match status {
                 Ok(s) => format!("it exited during startup ({s})"),
@@ -255,11 +280,10 @@ enum Outcome {
 
 /// Build and spawn `<tcode_exe> serve --http [--project <path>]`.
 ///
-/// `kill_on_drop(true)` is a BACKSTOP, not the teardown path: a panic or
-/// early return that drops the session without calling
-/// [`DaemonSession::shutdown`] must not leak a daemon holding the port. The
-/// graceful SIGTERM path in [`terminate`] always runs first on the normal
-/// exit, reaping the child so this drop hook becomes a no-op.
+/// There is deliberately no `kill_on_drop(true)`: the spawned daemon must
+/// survive this process, so the one thing the `Child` handle must NOT do is
+/// signal it when the TUI's stack unwinds (module docs, owner directive
+/// 2026-08-01).
 fn spawn_daemon(
     tcode_exe: &Path,
     project: Option<&Path>,
@@ -279,7 +303,7 @@ fn spawn_daemon(
             cmd.stdout(Stdio::null()).stderr(Stdio::null());
         }
     }
-    cmd.kill_on_drop(true).spawn().with_context(|| {
+    cmd.spawn().with_context(|| {
         format!(
             "tcode tui: could not start a daemon with `{} serve --http`",
             tcode_exe.display()
@@ -329,45 +353,6 @@ fn exited_early(detail: &str, log_path: Option<&Path>) -> anyhow::Error {
          holding port {DEFAULT_HTTP_PORT} is the usual cause.",
         log_hint(log_path)
     )
-}
-
-/// SIGTERM -> grace -> SIGKILL, reaping the child either way.
-///
-/// Why: SIGTERM lets `tcode serve --http`'s axum server run its graceful
-/// shutdown (`trusty_common::shutdown_signal`) and drain in-flight requests,
-/// per the workspace's connection-safe restart convention (#534) — a bare
-/// kill would drop live SSE subscribers mid-stream. The SIGKILL escalation
-/// exists so a wedged daemon still cannot outlive the TUI and keep the port.
-/// Mirrors `trusty-agents`' `ui/src-tauri/src/sidecar.rs::terminate_child`
-/// (that one is `pub(crate)` inside a Tauri binary crate, so it cannot be
-/// imported — only its shape reused).
-async fn terminate(mut child: Child, grace: Duration) {
-    // Already gone: reap without signalling.
-    if let Ok(Some(_)) = child.try_wait() {
-        return;
-    }
-
-    #[cfg(unix)]
-    if let Some(pid) = child.id() {
-        // SAFETY: `pid` names a child process we spawned and have not yet
-        // reaped, and `SIGTERM` is a valid signal. `kill` has no
-        // memory-safety effects — a already-exited pid merely returns ESRCH,
-        // which is exactly the case the `try_wait` above handles.
-        unsafe {
-            libc::kill(pid as libc::pid_t, libc::SIGTERM);
-        }
-        if tokio::time::timeout(grace, child.wait()).await.is_ok() {
-            return;
-        }
-        tracing::warn!(
-            pid,
-            ?grace,
-            "tcode daemon did not exit on SIGTERM within grace; sending SIGKILL"
-        );
-    }
-
-    let _ = child.start_kill();
-    let _ = child.wait().await;
 }
 
 #[cfg(test)]

--- a/crates/trusty-code/src/cli/daemon_autospawn_tests.rs
+++ b/crates/trusty-code/src/cli/daemon_autospawn_tests.rs
@@ -6,14 +6,13 @@
 //! `tui_client/engine.rs` uses keeps these cases in a test-capped file.
 //! What: every branch of [`super::ensure_daemon_with`] is exercised against
 //! REAL child processes and a real `wiremock` health endpoint — no mocked
-//! internals — so the spawn, the readiness gate, and the SIGTERM teardown
-//! are all genuinely executed. Stub children stand in for the daemon: a
-//! `sh` script that sleeps (a daemon that stays up), one that exits
-//! immediately (a daemon that fails to bind), and one that touches a marker
-//! file (to prove a branch never spawned anything).
+//! internals — so the spawn, the readiness gate, and the binding check are
+//! all genuinely executed. Stub children stand in for the daemon: a `sh`
+//! script that records its pid and argv then sleeps (a daemon that stays
+//! up), one that exits immediately (a daemon that fails to bind), and one
+//! that touches a marker file (to prove a branch never spawned anything).
 
 use std::path::{Path, PathBuf};
-use std::time::Duration;
 
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -66,13 +65,34 @@ impl Drop for EnvGuard {
     }
 }
 
-/// A `wiremock` server answering `GET /health` with 200 — i.e. a daemon that
-/// looks alive to `lookup_daemon` and to `spin_until_ready`.
-async fn healthy_daemon() -> MockServer {
+/// A `wiremock` server whose `GET /health` reports `binding` — i.e. a daemon
+/// that looks alive to `lookup_daemon` and to `spin_until_ready`, and that
+/// answers the #4512 binding question the way a real daemon would.
+async fn healthy_daemon(root: Option<&Path>) -> MockServer {
+    let binding = trusty_code::binding::ProjectBinding::resolve(root.map(Path::to_path_buf))
+        .expect("must bind");
     let server = MockServer::start().await;
     Mock::given(method("GET"))
         .and(path("/health"))
-        .respond_with(ResponseTemplate::new(200))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "server": "tcode",
+            "status": "ok",
+            "binding": binding.to_json(),
+        })))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// A daemon from before #4512: healthy, but reporting no binding at all.
+async fn daemon_without_a_binding_field() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(
+            ResponseTemplate::new(200)
+                .set_body_json(serde_json::json!({"server": "tcode", "status": "ok"})),
+        )
         .mount(&server)
         .await;
     server
@@ -92,13 +112,22 @@ fn stub_binary(dir: &Path, name: &str, body: &str) -> PathBuf {
     script
 }
 
-/// A stub that records the argv it was called with, then sleeps — the
-/// "daemon that comes up and stays up" case.
-fn sleeping_stub(dir: &Path, argv_log: &Path) -> PathBuf {
+/// A stub that records its own pid and the argv it was called with, then
+/// sleeps — the "daemon that comes up and stays up" case.
+///
+/// The pid is written to disk rather than read off a `Child` handle because
+/// `ensure_daemon_with` no longer RETURNS one: it drops the handle without
+/// signalling, which is exactly the behaviour
+/// [`the_tui_never_signals_the_daemon_on_exit`] has to observe from outside.
+fn sleeping_stub(dir: &Path, argv_log: &Path, pid_log: &Path) -> PathBuf {
     stub_binary(
         dir,
         "tcode-sleep",
-        &format!("echo \"$@\" > {}\nsleep 300", argv_log.display()),
+        &format!(
+            "echo \"$@\" > {}\necho $$ > {}\nsleep 300",
+            argv_log.display(),
+            pid_log.display()
+        ),
     )
 }
 
@@ -118,102 +147,211 @@ fn is_alive(pid: u32) -> bool {
     unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
 }
 
-/// A LIVE daemon must be attached to, never re-spawned: the recorded
-/// ownership is `Attached` and the binary is never executed at all.
+#[cfg(unix)]
+fn kill(pid: u32) {
+    // SAFETY: `pid` names a stub process this test spawned; `kill` has no
+    // memory-safety effects.
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGKILL);
+    }
+}
+
+/// Block until `pid_log` exists and holds a pid — the stub writes it a few
+/// milliseconds after `spawn` returns.
+async fn spawned_pid(pid_log: &Path) -> u32 {
+    for _ in 0..200 {
+        if let Ok(raw) = std::fs::read_to_string(pid_log)
+            && let Ok(pid) = raw.trim().parse::<u32>()
+        {
+            return pid;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("the spawned stub never recorded its pid at {pid_log:?}");
+}
+
+/// A LIVE daemon bound to the SAME project must be attached to, never
+/// re-spawned: the binary is never executed at all.
 #[tokio::test]
 async fn attaches_to_a_live_daemon_without_spawning() {
     let _lock = ENV_LOCK.lock().await;
-    let server = healthy_daemon().await;
+    let project = tempfile::tempdir().expect("project");
+    let canonical = project.path().canonicalize().expect("canonicalize");
+    let server = healthy_daemon(Some(&canonical)).await;
     let _env = EnvGuard::isolated(Some(&server.uri()));
 
     let dir = tempfile::tempdir().expect("tempdir");
     let marker = dir.path().join("spawned");
     let stub = marker_stub(dir.path(), &marker);
 
-    let session = ensure_daemon_with(
+    let url = ensure_daemon_with(
         &reqwest::Client::new(),
-        None,
+        Some(&canonical),
         &stub,
         "http://unused.invalid",
     )
     .await
     .expect("must attach to the live daemon");
 
-    assert!(
-        matches!(session.ownership, Ownership::Attached),
-        "a pre-existing daemon must be recorded as Attached, not Spawned"
-    );
-    assert_eq!(session.url, server.uri().trim_end_matches('/'));
+    assert_eq!(url, server.uri().trim_end_matches('/'));
     assert!(
         !marker.exists(),
         "must not have spawned anything: {marker:?}"
     );
 }
 
-/// Shutting down an ATTACHED session must be a no-op — a daemon we did not
-/// start has to survive our exit. Asserted against a real, independently
-/// spawned process that stands in for "somebody else's daemon".
+/// A projectless TUI must attach to a projectless daemon — the other
+/// agreeing pair.
 #[tokio::test]
-async fn shutdown_leaves_a_pre_existing_daemon_running() {
+async fn attaches_to_a_projectless_daemon_when_projectless() {
     let _lock = ENV_LOCK.lock().await;
-    let server = healthy_daemon().await;
+    let server = healthy_daemon(None).await;
     let _env = EnvGuard::isolated(Some(&server.uri()));
 
     let dir = tempfile::tempdir().expect("tempdir");
-    let argv_log = dir.path().join("argv");
-    let stub = sleeping_stub(dir.path(), &argv_log);
-    // Somebody else's daemon: started outside `ensure_daemon_with` entirely.
-    let mut foreign = tokio::process::Command::new(&stub)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn foreign daemon");
-    let foreign_pid = foreign.id().expect("foreign pid");
+    let marker = dir.path().join("spawned");
+    let stub = marker_stub(dir.path(), &marker);
 
-    let session = ensure_daemon_with(
+    let url = ensure_daemon_with(
         &reqwest::Client::new(),
         None,
         &stub,
         "http://unused.invalid",
     )
     .await
-    .expect("must attach");
-    session.shutdown().await;
-
-    assert!(
-        is_alive(foreign_pid),
-        "shutdown must not kill a daemon it did not spawn (pid {foreign_pid})"
-    );
-    foreign.kill().await.expect("clean up foreign daemon");
+    .expect("a projectless TUI must attach to a projectless daemon");
+    assert_eq!(url, server.uri().trim_end_matches('/'));
+    assert!(!marker.exists(), "must not have spawned anything");
 }
 
-/// No candidate daemon at all: a daemon must be SPAWNED, waited for, and
-/// recorded as owned — with `--project` forwarded through to it.
+/// The daemon on the well-known port may be serving a DIFFERENT project.
+/// Attaching would run every session against the wrong repository, so it
+/// must be refused — and refused WITHOUT starting a competing daemon on a
+/// port that is already taken (#4512).
+#[tokio::test]
+async fn refuses_a_daemon_bound_to_another_project() {
+    let _lock = ENV_LOCK.lock().await;
+    let their_project = tempfile::tempdir().expect("their project");
+    let our_project = tempfile::tempdir().expect("our project");
+    let theirs = their_project.path().canonicalize().expect("canonicalize");
+    let ours = our_project.path().canonicalize().expect("canonicalize");
+    let server = healthy_daemon(Some(&theirs)).await;
+    let _env = EnvGuard::isolated(Some(&server.uri()));
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let marker = dir.path().join("spawned");
+    let stub = marker_stub(dir.path(), &marker);
+
+    let err = ensure_daemon_with(&reqwest::Client::new(), Some(&ours), &stub, &server.uri())
+        .await
+        .expect_err("a daemon on another project must not be attached to");
+
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains(&theirs.display().to_string()),
+        "error must name the daemon's project: {rendered}"
+    );
+    assert!(
+        rendered.contains(&ours.display().to_string()),
+        "error must name the requested project: {rendered}"
+    );
+    assert!(
+        !marker.exists(),
+        "must not start a competing daemon on a port already in use: {rendered}"
+    );
+}
+
+/// Projectless and bound are not interchangeable in EITHER direction — a
+/// project-bound TUI must not silently lose its project to a projectless
+/// daemon, and a projectless TUI must not silently inherit a project it
+/// never named.
+#[tokio::test]
+async fn refuses_a_project_bound_client_against_a_projectless_daemon() {
+    let _lock = ENV_LOCK.lock().await;
+    let project = tempfile::tempdir().expect("project");
+    let ours = project.path().canonicalize().expect("canonicalize");
+
+    // Bound client, projectless daemon.
+    {
+        let server = healthy_daemon(None).await;
+        let _env = EnvGuard::isolated(Some(&server.uri()));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let marker = dir.path().join("spawned");
+        let stub = marker_stub(dir.path(), &marker);
+        let err = ensure_daemon_with(&reqwest::Client::new(), Some(&ours), &stub, &server.uri())
+            .await
+            .expect_err("a bound TUI must not attach to a projectless daemon");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains("<projectless>"), "{rendered}");
+        assert!(!marker.exists(), "must not spawn a competing daemon");
+    }
+
+    // Projectless client, bound daemon.
+    {
+        let server = healthy_daemon(Some(&ours)).await;
+        let _env = EnvGuard::isolated(Some(&server.uri()));
+        let dir = tempfile::tempdir().expect("tempdir");
+        let marker = dir.path().join("spawned");
+        let stub = marker_stub(dir.path(), &marker);
+        let err = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
+            .await
+            .expect_err("a projectless TUI must not inherit a daemon's project");
+        let rendered = format!("{err:#}");
+        assert!(rendered.contains(&ours.display().to_string()), "{rendered}");
+        assert!(rendered.contains("<projectless>"), "{rendered}");
+        assert!(!marker.exists(), "must not spawn a competing daemon");
+    }
+}
+
+/// A daemon too old to report its binding cannot be verified, so it is
+/// refused — failing CLOSED, since "old build" is no evidence that its
+/// project is the right one.
+#[tokio::test]
+async fn refuses_a_daemon_that_cannot_report_its_binding() {
+    let _lock = ENV_LOCK.lock().await;
+    let server = daemon_without_a_binding_field().await;
+    let _env = EnvGuard::isolated(Some(&server.uri()));
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let marker = dir.path().join("spawned");
+    let stub = marker_stub(dir.path(), &marker);
+
+    let err = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
+        .await
+        .expect_err("an unverifiable daemon must not be attached to");
+
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("does not report which project"),
+        "error must say the binding could not be confirmed: {rendered}"
+    );
+    assert!(!marker.exists(), "must not spawn a competing daemon");
+}
+
+/// No candidate daemon at all: a daemon must be SPAWNED and waited for, with
+/// `--project` forwarded through to it so its binding matches the TUI's.
 #[tokio::test]
 async fn spawns_a_daemon_when_none_is_running() {
     let _lock = ENV_LOCK.lock().await;
     let _env = EnvGuard::isolated(None);
-    let server = healthy_daemon().await;
+    let project = tempfile::tempdir().expect("project");
+    let canonical = project.path().canonicalize().expect("canonicalize");
+    let server = healthy_daemon(Some(&canonical)).await;
 
     let dir = tempfile::tempdir().expect("tempdir");
     let argv_log = dir.path().join("argv");
-    let stub = sleeping_stub(dir.path(), &argv_log);
-    let project = dir.path().join("proj");
-    std::fs::create_dir(&project).expect("mkdir project");
+    let pid_log = dir.path().join("pid");
+    let stub = sleeping_stub(dir.path(), &argv_log, &pid_log);
 
-    let session = ensure_daemon_with(
+    let url = ensure_daemon_with(
         &reqwest::Client::new(),
-        Some(project.as_path()),
+        Some(&canonical),
         &stub,
         &server.uri(),
     )
     .await
     .expect("must spawn a daemon");
-
-    let Ownership::Spawned(ref child) = session.ownership else {
-        panic!("a daemon we started must be recorded as Spawned");
-    };
-    assert!(child.id().is_some(), "the spawned child must have a pid");
+    assert_eq!(url, server.uri());
 
     let argv = std::fs::read_to_string(&argv_log).expect("stub must have recorded its argv");
     assert!(
@@ -221,10 +359,10 @@ async fn spawns_a_daemon_when_none_is_running() {
         "must spawn `serve --http`: {argv}"
     );
     assert!(
-        argv.contains("--project") && argv.contains(project.to_str().expect("utf8")),
+        argv.contains("--project") && argv.contains(canonical.to_str().expect("utf8")),
         "must forward --project to the daemon: {argv}"
     );
-    session.shutdown().await;
+    kill(spawned_pid(&pid_log).await);
 }
 
 /// A PROJECTLESS TUI must spawn a projectless daemon — `--project` is
@@ -233,13 +371,14 @@ async fn spawns_a_daemon_when_none_is_running() {
 async fn spawns_projectless_when_the_tui_is_projectless() {
     let _lock = ENV_LOCK.lock().await;
     let _env = EnvGuard::isolated(None);
-    let server = healthy_daemon().await;
+    let server = healthy_daemon(None).await;
 
     let dir = tempfile::tempdir().expect("tempdir");
     let argv_log = dir.path().join("argv");
-    let stub = sleeping_stub(dir.path(), &argv_log);
+    let pid_log = dir.path().join("pid");
+    let stub = sleeping_stub(dir.path(), &argv_log, &pid_log);
 
-    let session = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
+    ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
         .await
         .expect("must spawn a daemon");
 
@@ -248,36 +387,74 @@ async fn spawns_projectless_when_the_tui_is_projectless() {
         !argv.contains("--project"),
         "a projectless TUI must not bind the daemon to a project: {argv}"
     );
-    session.shutdown().await;
+    kill(spawned_pid(&pid_log).await);
 }
 
-/// A daemon WE spawned must actually be stopped on shutdown — the other
-/// half of the ownership rule.
+/// **The rule this module exists to guarantee.** The TUI NEVER signals the
+/// daemon on exit, regardless of which process started it (owner directive,
+/// 2026-08-01): the daemon owns PM lifecycle and agent dispatch, so a client
+/// quitting must not destroy live work.
+///
+/// Both cases are asserted against real processes, after everything
+/// `ensure_daemon_with` returned has been dropped — the drop is the moment a
+/// `kill_on_drop` handle or a teardown step would have fired:
+///
+/// 1. a daemon THIS call spawned, and
+/// 2. a pre-existing daemon it merely attached to.
 #[tokio::test]
-async fn shutdown_stops_a_daemon_we_spawned() {
+async fn the_tui_never_signals_the_daemon_on_exit() {
     let _lock = ENV_LOCK.lock().await;
-    let _env = EnvGuard::isolated(None);
-    let server = healthy_daemon().await;
 
+    // 1. A daemon we spawned ourselves.
+    let our_pid = {
+        let _env = EnvGuard::isolated(None);
+        let server = healthy_daemon(None).await;
+        let dir = tempfile::tempdir().expect("tempdir");
+        let argv_log = dir.path().join("argv");
+        let pid_log = dir.path().join("pid");
+        let stub = sleeping_stub(dir.path(), &argv_log, &pid_log);
+
+        let url = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
+            .await
+            .expect("must spawn a daemon");
+        assert_eq!(url, server.uri());
+        spawned_pid(&pid_log).await
+        // Everything `ensure_daemon_with` produced is dropped here.
+    };
+    assert!(
+        is_alive(our_pid),
+        "a daemon the TUI spawned must OUTLIVE it (pid {our_pid} was killed)"
+    );
+    kill(our_pid);
+
+    // 2. Somebody else's daemon, started outside `ensure_daemon_with`.
+    let server = healthy_daemon(None).await;
+    let _env = EnvGuard::isolated(Some(&server.uri()));
     let dir = tempfile::tempdir().expect("tempdir");
     let argv_log = dir.path().join("argv");
-    let stub = sleeping_stub(dir.path(), &argv_log);
+    let pid_log = dir.path().join("pid");
+    let stub = sleeping_stub(dir.path(), &argv_log, &pid_log);
+    let mut foreign = tokio::process::Command::new(&stub)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn foreign daemon");
+    let foreign_pid = foreign.id().expect("foreign pid");
 
-    let session = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
-        .await
-        .expect("must spawn a daemon");
-    let Ownership::Spawned(ref child) = session.ownership else {
-        panic!("must be Spawned");
-    };
-    let pid = child.id().expect("pid");
-    assert!(is_alive(pid), "the spawned daemon must be running first");
-
-    session.shutdown().await;
+    ensure_daemon_with(
+        &reqwest::Client::new(),
+        None,
+        &stub,
+        "http://unused.invalid",
+    )
+    .await
+    .expect("must attach");
 
     assert!(
-        !is_alive(pid),
-        "a daemon we spawned must be stopped on shutdown (pid {pid} still alive)"
+        is_alive(foreign_pid),
+        "a pre-existing daemon must survive the TUI too (pid {foreign_pid})"
     );
+    foreign.kill().await.expect("clean up foreign daemon");
 }
 
 /// A spawned daemon that dies immediately (the port-already-taken case)
@@ -315,7 +492,7 @@ async fn refuses_to_spawn_for_an_unreachable_explicit_url() {
     let _lock = ENV_LOCK.lock().await;
     // Port 1 is reserved and unbound: reachable-looking, never answering.
     let _env = EnvGuard::isolated(Some("http://127.0.0.1:1"));
-    let server = healthy_daemon().await;
+    let server = healthy_daemon(None).await;
 
     let dir = tempfile::tempdir().expect("tempdir");
     let marker = dir.path().join("spawned");
@@ -338,23 +515,4 @@ async fn refuses_to_spawn_for_an_unreachable_explicit_url() {
         rendered.contains(DAEMON_URL_ENV),
         "error must name the env var responsible: {rendered}"
     );
-}
-
-/// `terminate` on an already-exited child must reap it without panicking or
-/// waiting out the grace period.
-#[tokio::test]
-async fn terminate_handles_an_already_exited_child() {
-    let dir = tempfile::tempdir().expect("tempdir");
-    let stub = stub_binary(dir.path(), "tcode-quick", "exit 0");
-    let mut child = tokio::process::Command::new(&stub)
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .expect("spawn");
-    child.wait().await.expect("reap");
-
-    // Must return promptly; a hang here would stall every TUI exit.
-    tokio::time::timeout(Duration::from_secs(2), terminate(child, SHUTDOWN_GRACE))
-        .await
-        .expect("terminate must not hang on an already-exited child");
 }

--- a/crates/trusty-code/src/cli/daemon_autospawn_tests.rs
+++ b/crates/trusty-code/src/cli/daemon_autospawn_tests.rs
@@ -1,0 +1,360 @@
+//! Tests for [`super`] — `tcode tui`'s attach-or-spawn daemon policy
+//! (#4512).
+//!
+//! Why a sibling file: `daemon_autospawn.rs` is a production file under the
+//! 500-SLOC cap (issue #610); the same `#[cfg(test)] #[path = ...]` split
+//! `tui_client/engine.rs` uses keeps these cases in a test-capped file.
+//! What: every branch of [`super::ensure_daemon_with`] is exercised against
+//! REAL child processes and a real `wiremock` health endpoint — no mocked
+//! internals — so the spawn, the readiness gate, and the SIGTERM teardown
+//! are all genuinely executed. Stub children stand in for the daemon: a
+//! `sh` script that sleeps (a daemon that stays up), one that exits
+//! immediately (a daemon that fails to bind), and one that touches a marker
+//! file (to prove a branch never spawned anything).
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use wiremock::matchers::{method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+use super::*;
+
+/// Serializes every case here, since they all mutate the process-global
+/// environment `lookup_daemon` reads. Mirrors the `ENV_LOCK` convention
+/// already used by `tui_client::discovery`'s tests and `crate::task::mock_llm`.
+static ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+/// RAII guard isolating BOTH discovery sources for one test, and restoring
+/// the environment on drop even if the test panics.
+///
+/// `TRUSTY_DATA_DIR_OVERRIDE` (trusty-common's documented test escape hatch)
+/// repoints `resolve_data_dir("trusty-code")` at a fresh temp directory, so
+/// the `http_addr` discovery file and the spawned-daemon log belong to this
+/// test alone — a real daemon running on the developer's machine can never
+/// make a "no daemon running" case attach to it instead.
+struct EnvGuard {
+    _data_dir: tempfile::TempDir,
+}
+
+impl EnvGuard {
+    /// `daemon_url = None` means "TCODE_DAEMON_URL unset", i.e. discovery
+    /// falls through to the (now empty) discovery file.
+    fn isolated(daemon_url: Option<&str>) -> Self {
+        let data_dir = tempfile::tempdir().expect("data dir");
+        // SAFETY: test-only env mutation, serialized by `ENV_LOCK`.
+        unsafe {
+            std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, data_dir.path());
+            match daemon_url {
+                Some(url) => std::env::set_var(DAEMON_URL_ENV, url),
+                None => std::env::remove_var(DAEMON_URL_ENV),
+            }
+        }
+        Self {
+            _data_dir: data_dir,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        // SAFETY: test-only env mutation, serialized by `ENV_LOCK`.
+        unsafe {
+            std::env::remove_var(DAEMON_URL_ENV);
+            std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
+        }
+    }
+}
+
+/// A `wiremock` server answering `GET /health` with 200 — i.e. a daemon that
+/// looks alive to `lookup_daemon` and to `spin_until_ready`.
+async fn healthy_daemon() -> MockServer {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/health"))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+    server
+}
+
+/// Write an executable `sh` stub to `dir` and return its path. The stub
+/// stands in for the `tcode` binary that would be spawned.
+fn stub_binary(dir: &Path, name: &str, body: &str) -> PathBuf {
+    let script = dir.join(name);
+    std::fs::write(&script, format!("#!/bin/sh\n{body}\n")).expect("write stub");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755))
+            .expect("chmod stub");
+    }
+    script
+}
+
+/// A stub that records the argv it was called with, then sleeps — the
+/// "daemon that comes up and stays up" case.
+fn sleeping_stub(dir: &Path, argv_log: &Path) -> PathBuf {
+    stub_binary(
+        dir,
+        "tcode-sleep",
+        &format!("echo \"$@\" > {}\nsleep 300", argv_log.display()),
+    )
+}
+
+/// A stub that touches `marker` — used to PROVE a branch never spawned it.
+fn marker_stub(dir: &Path, marker: &Path) -> PathBuf {
+    stub_binary(
+        dir,
+        "tcode-marker",
+        &format!("touch {}\nsleep 300", marker.display()),
+    )
+}
+
+#[cfg(unix)]
+fn is_alive(pid: u32) -> bool {
+    // SAFETY: signal 0 performs permission/existence checks only and never
+    // delivers a signal; it has no memory-safety effects.
+    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
+}
+
+/// A LIVE daemon must be attached to, never re-spawned: the recorded
+/// ownership is `Attached` and the binary is never executed at all.
+#[tokio::test]
+async fn attaches_to_a_live_daemon_without_spawning() {
+    let _lock = ENV_LOCK.lock().await;
+    let server = healthy_daemon().await;
+    let _env = EnvGuard::isolated(Some(&server.uri()));
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let marker = dir.path().join("spawned");
+    let stub = marker_stub(dir.path(), &marker);
+
+    let session = ensure_daemon_with(
+        &reqwest::Client::new(),
+        None,
+        &stub,
+        "http://unused.invalid",
+    )
+    .await
+    .expect("must attach to the live daemon");
+
+    assert!(
+        matches!(session.ownership, Ownership::Attached),
+        "a pre-existing daemon must be recorded as Attached, not Spawned"
+    );
+    assert_eq!(session.url, server.uri().trim_end_matches('/'));
+    assert!(
+        !marker.exists(),
+        "must not have spawned anything: {marker:?}"
+    );
+}
+
+/// Shutting down an ATTACHED session must be a no-op — a daemon we did not
+/// start has to survive our exit. Asserted against a real, independently
+/// spawned process that stands in for "somebody else's daemon".
+#[tokio::test]
+async fn shutdown_leaves_a_pre_existing_daemon_running() {
+    let _lock = ENV_LOCK.lock().await;
+    let server = healthy_daemon().await;
+    let _env = EnvGuard::isolated(Some(&server.uri()));
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let argv_log = dir.path().join("argv");
+    let stub = sleeping_stub(dir.path(), &argv_log);
+    // Somebody else's daemon: started outside `ensure_daemon_with` entirely.
+    let mut foreign = tokio::process::Command::new(&stub)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn foreign daemon");
+    let foreign_pid = foreign.id().expect("foreign pid");
+
+    let session = ensure_daemon_with(
+        &reqwest::Client::new(),
+        None,
+        &stub,
+        "http://unused.invalid",
+    )
+    .await
+    .expect("must attach");
+    session.shutdown().await;
+
+    assert!(
+        is_alive(foreign_pid),
+        "shutdown must not kill a daemon it did not spawn (pid {foreign_pid})"
+    );
+    foreign.kill().await.expect("clean up foreign daemon");
+}
+
+/// No candidate daemon at all: a daemon must be SPAWNED, waited for, and
+/// recorded as owned — with `--project` forwarded through to it.
+#[tokio::test]
+async fn spawns_a_daemon_when_none_is_running() {
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::isolated(None);
+    let server = healthy_daemon().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let argv_log = dir.path().join("argv");
+    let stub = sleeping_stub(dir.path(), &argv_log);
+    let project = dir.path().join("proj");
+    std::fs::create_dir(&project).expect("mkdir project");
+
+    let session = ensure_daemon_with(
+        &reqwest::Client::new(),
+        Some(project.as_path()),
+        &stub,
+        &server.uri(),
+    )
+    .await
+    .expect("must spawn a daemon");
+
+    let Ownership::Spawned(ref child) = session.ownership else {
+        panic!("a daemon we started must be recorded as Spawned");
+    };
+    assert!(child.id().is_some(), "the spawned child must have a pid");
+
+    let argv = std::fs::read_to_string(&argv_log).expect("stub must have recorded its argv");
+    assert!(
+        argv.contains("serve") && argv.contains("--http"),
+        "must spawn `serve --http`: {argv}"
+    );
+    assert!(
+        argv.contains("--project") && argv.contains(project.to_str().expect("utf8")),
+        "must forward --project to the daemon: {argv}"
+    );
+    session.shutdown().await;
+}
+
+/// A PROJECTLESS TUI must spawn a projectless daemon — `--project` is
+/// omitted entirely rather than defaulting to the launch directory.
+#[tokio::test]
+async fn spawns_projectless_when_the_tui_is_projectless() {
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::isolated(None);
+    let server = healthy_daemon().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let argv_log = dir.path().join("argv");
+    let stub = sleeping_stub(dir.path(), &argv_log);
+
+    let session = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
+        .await
+        .expect("must spawn a daemon");
+
+    let argv = std::fs::read_to_string(&argv_log).expect("stub must have recorded its argv");
+    assert!(
+        !argv.contains("--project"),
+        "a projectless TUI must not bind the daemon to a project: {argv}"
+    );
+    session.shutdown().await;
+}
+
+/// A daemon WE spawned must actually be stopped on shutdown — the other
+/// half of the ownership rule.
+#[tokio::test]
+async fn shutdown_stops_a_daemon_we_spawned() {
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::isolated(None);
+    let server = healthy_daemon().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let argv_log = dir.path().join("argv");
+    let stub = sleeping_stub(dir.path(), &argv_log);
+
+    let session = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
+        .await
+        .expect("must spawn a daemon");
+    let Ownership::Spawned(ref child) = session.ownership else {
+        panic!("must be Spawned");
+    };
+    let pid = child.id().expect("pid");
+    assert!(is_alive(pid), "the spawned daemon must be running first");
+
+    session.shutdown().await;
+
+    assert!(
+        !is_alive(pid),
+        "a daemon we spawned must be stopped on shutdown (pid {pid} still alive)"
+    );
+}
+
+/// A spawned daemon that dies immediately (the port-already-taken case)
+/// must be reported straight away, not spun out to the startup timeout.
+#[tokio::test]
+async fn reports_a_daemon_that_dies_on_startup() {
+    let _lock = ENV_LOCK.lock().await;
+    let _env = EnvGuard::isolated(None);
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stub = stub_binary(dir.path(), "tcode-dies", "exit 3");
+    // Nothing is bound here, so readiness can only ever come from the child
+    // — which exits at once.
+    let started = std::time::Instant::now();
+    let err = ensure_daemon_with(&reqwest::Client::new(), None, &stub, "http://127.0.0.1:1")
+        .await
+        .expect_err("a daemon that exits must surface an error");
+
+    assert!(
+        started.elapsed() < STARTUP_TIMEOUT,
+        "must fail fast rather than spin out the startup budget"
+    );
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("exited during startup"),
+        "error must say the daemon died: {rendered}"
+    );
+}
+
+/// An explicitly-set-but-unreachable `TCODE_DAEMON_URL` must FAIL, never
+/// silently start a daemon somewhere else — the operator named an address
+/// and we obey it.
+#[tokio::test]
+async fn refuses_to_spawn_for_an_unreachable_explicit_url() {
+    let _lock = ENV_LOCK.lock().await;
+    // Port 1 is reserved and unbound: reachable-looking, never answering.
+    let _env = EnvGuard::isolated(Some("http://127.0.0.1:1"));
+    let server = healthy_daemon().await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let marker = dir.path().join("spawned");
+    let stub = marker_stub(dir.path(), &marker);
+
+    let err = ensure_daemon_with(&reqwest::Client::new(), None, &stub, &server.uri())
+        .await
+        .expect_err("an unreachable explicit URL must be an error");
+
+    assert!(
+        !marker.exists(),
+        "must not spawn a daemon when {DAEMON_URL_ENV} names one explicitly"
+    );
+    let rendered = format!("{err:#}");
+    assert!(
+        rendered.contains("http://127.0.0.1:1"),
+        "error must name the unreachable URL: {rendered}"
+    );
+    assert!(
+        rendered.contains(DAEMON_URL_ENV),
+        "error must name the env var responsible: {rendered}"
+    );
+}
+
+/// `terminate` on an already-exited child must reap it without panicking or
+/// waiting out the grace period.
+#[tokio::test]
+async fn terminate_handles_an_already_exited_child() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let stub = stub_binary(dir.path(), "tcode-quick", "exit 0");
+    let mut child = tokio::process::Command::new(&stub)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .expect("spawn");
+    child.wait().await.expect("reap");
+
+    // Must return promptly; a hang here would stall every TUI exit.
+    tokio::time::timeout(Duration::from_secs(2), terminate(child, SHUTDOWN_GRACE))
+        .await
+        .expect("terminate must not hang on an already-exited child");
+}

--- a/crates/trusty-code/src/cli/mod.rs
+++ b/crates/trusty-code/src/cli/mod.rs
@@ -22,7 +22,12 @@
 //! interactive TUI REPL, which talks to a long-lived `tcode serve --http`
 //! daemon instead. It lives here anyway because it is the same KIND of thing
 //! — argument-shaped setup plus a handoff, with every decision made
-//! elsewhere (see its module docs). (#4434) [`legacy_run_task::run`] is the
+//! elsewhere (see its module docs) — with the one exception of
+//! [`daemon_autospawn`] (#4512), the policy module `tui::run` delegates to
+//! for "attach to a running daemon, or start one and own it". That is a
+//! genuine decision rather than glue, which is exactly why it is a separate,
+//! separately-tested file instead of more code inside `tui.rs`.
+//! (#4434) [`legacy_run_task::run`] is the
 //! other: it is `run-task --legacy-in-process`, the pre-#2060 path that runs
 //! the `AgentLoop` in THIS process rather than driving a daemon, so it alone
 //! carries CLI-shaped setup no thin client needs (agent-name validation,
@@ -37,6 +42,7 @@
 
 pub mod attach;
 pub mod cancel;
+pub mod daemon_autospawn;
 pub mod legacy_run_task;
 pub mod run_task;
 pub mod session;

--- a/crates/trusty-code/src/cli/tui.rs
+++ b/crates/trusty-code/src/cli/tui.rs
@@ -9,25 +9,40 @@
 //! point and nothing more: it owns no REPL behaviour, no rendering, and no
 //! daemon logic, matching `crate::cli`'s "translate CLI args into a call,
 //! decisions belong elsewhere" contract.
-//! What: [`run`] resolves the optional project path, discovers a LIVE daemon
-//! through `tui_client::discovery` (`TCODE_DAEMON_URL` -> the `http_addr`
-//! discovery file -> a `GET /health` liveness ping), and hands the resulting
-//! `CodeEngine` to `trusty_tui::run::run` together with the shared
-//! `ReplApp` model, its reducer (`trusty_tui::app::apply`), and its renderer
-//! (`trusty_tui::layout::draw`). MVP assumes an ALREADY-RUNNING
-//! `tcode serve --http`: auto-spawning one is explicitly deferred (DOC-50
-//! §4.1 MVP scope), so a missing daemon surfaces `DiscoveryError`'s
-//! actionable message and exits rather than starting anything. Discovery
-//! deliberately runs BEFORE `trusty_tui::run::run` enters the alternate
-//! screen, so that message lands on a normal terminal instead of flashing
-//! behind a TUI that is about to tear itself down.
+//! What: [`run`] resolves the optional project path, obtains a daemon to
+//! drive from `super::daemon_autospawn`, and hands a `CodeEngine` pointed at
+//! it to `trusty_tui::run::run` together with the shared `ReplApp` model,
+//! its reducer (`trusty_tui::app::apply`), and its renderer
+//! (`trusty_tui::layout::draw`).
+//!
+//! `tcode tui` AUTO-SPAWNS its daemon (#4512, reversing DOC-50 §4.1's
+//! deferral): discovery is unchanged (`TCODE_DAEMON_URL` -> the `http_addr`
+//! discovery file -> a `GET /health` liveness ping), but a missing or stale
+//! discovery file now starts `tcode serve --http` instead of exiting with an
+//! actionable message. Ownership follows who started it — a daemon THIS
+//! command spawned is stopped (SIGTERM, graceful drain) when the REPL exits;
+//! a pre-existing daemon we merely attached to is left running. An
+//! explicitly-set-but-unreachable `TCODE_DAEMON_URL` still errors rather
+//! than spawning, since starting a daemon at a different address would
+//! ignore that instruction. See `super::daemon_autospawn` for the whole
+//! policy — none of it lives here.
+//!
+//! Daemon resolution deliberately runs BEFORE `trusty_tui::run::run` enters
+//! the alternate screen, so the startup spinner and any failure land on a
+//! normal terminal instead of flashing behind a TUI that is about to tear
+//! itself down. Teardown correspondingly runs AFTER it exits, and runs even
+//! when the REPL itself failed, so a spawned daemon can never outlive the
+//! TUI that owns it.
 //! Test: `tui_tests::*` covers the pure project-resolution helper;
+//! `super::daemon_autospawn`'s tests cover every attach/spawn/teardown
+//! branch against real child processes;
 //! `tests/cli_e2e.rs::{tui_subcommand_is_listed_in_help,
-//! tui_without_a_reachable_daemon_errors_cleanly}` cover the CLI surface and
-//! the no-daemon path against the REAL binary. The launch path past
-//! discovery needs a real TTY (`trusty_tui::TerminalGuard::enter`) plus a
-//! live daemon, so it is verified by running `tcode tui` by hand; the engine
-//! half is already covered end-to-end by `tests/tui_client_engine.rs`.
+//! tui_refuses_to_spawn_for_an_unreachable_explicit_daemon_url}` cover the
+//! CLI surface and the no-auto-spawn guard against the REAL binary. The
+//! launch path past daemon resolution needs a real TTY
+//! (`trusty_tui::TerminalGuard::enter`), so it is verified by running
+//! `tcode tui` by hand; the engine half is already covered end-to-end by
+//! `tests/tui_client_engine.rs`.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -36,29 +51,40 @@ use anyhow::{Context, Result};
 use trusty_code::tui_client::CodeEngine;
 use trusty_tui::ReplApp;
 
+use super::daemon_autospawn;
+
 /// Product label for the banner identity line and the `[tcode] ` status
 /// prefix `ReplApp::new` derives from it.
 const PRODUCT_LABEL: &str = "tcode";
 
-/// Launch the TUI REPL, returning once the user quits (or immediately with
-/// an actionable error if no live daemon can be found).
+/// Launch the TUI REPL, returning once the user quits — starting a daemon
+/// first if none is running, and stopping it again on the way out.
 ///
 /// Why/What/Test: see the module docs — this function IS the module.
 /// `project` is `Option` because a projectless session is a first-class
-/// state (`session.create` without a `project`), not a degraded one.
+/// state (`session.create` without a `project`), not a degraded one; it is
+/// forwarded to a spawned daemon so the daemon's binding matches the TUI's.
 pub async fn run(project: Option<PathBuf>) -> Result<()> {
     let project = resolve_project(project)?;
-    // #4424: the first production construction of `CodeEngine` — before this
-    // line the whole TUI stack was reachable only from tests.
-    let engine = CodeEngine::discover(project).await?;
+    let http = trusty_code::tui_client::build_http_client();
+    // #4512: attach to a running daemon, or start one and take ownership of
+    // it — replaces #4424's "exit and tell the user to start one".
+    let daemon = daemon_autospawn::ensure_daemon(&http, project.as_deref()).await?;
+    let engine = CodeEngine::with_daemon_url(http, daemon.url.clone(), project);
     let app = ReplApp::new(PRODUCT_LABEL, user_label());
-    trusty_tui::run::run(
+
+    let outcome = trusty_tui::run::run(
         Arc::new(engine),
         app,
         trusty_tui::app::apply,
         trusty_tui::layout::draw,
     )
-    .await
+    .await;
+
+    // Unconditional: a REPL that failed must still not leak the daemon it
+    // started. A no-op when we only attached to a pre-existing one.
+    daemon.shutdown().await;
+    outcome
 }
 
 /// Canonicalize `--project` when given, so the daemon receives an absolute

--- a/crates/trusty-code/src/cli/tui.rs
+++ b/crates/trusty-code/src/cli/tui.rs
@@ -9,7 +9,7 @@
 //! point and nothing more: it owns no REPL behaviour, no rendering, and no
 //! daemon logic, matching `crate::cli`'s "translate CLI args into a call,
 //! decisions belong elsewhere" contract.
-//! What: [`run`] resolves the optional project path, obtains a daemon to
+//! What: [`run`] resolves the optional project path, obtains a daemon URL to
 //! drive from `super::daemon_autospawn`, and hands a `CodeEngine` pointed at
 //! it to `trusty_tui::run::run` together with the shared `ReplApp` model,
 //! its reducer (`trusty_tui::app::apply`), and its renderer
@@ -19,30 +19,34 @@
 //! deferral): discovery is unchanged (`TCODE_DAEMON_URL` -> the `http_addr`
 //! discovery file -> a `GET /health` liveness ping), but a missing or stale
 //! discovery file now starts `tcode serve --http` instead of exiting with an
-//! actionable message. Ownership follows who started it — a daemon THIS
-//! command spawned is stopped (SIGTERM, graceful drain) when the REPL exits;
-//! a pre-existing daemon we merely attached to is left running. An
+//! actionable message.
+//!
+//! **Quitting the TUI never stops the daemon** — not even one this command
+//! started. The daemon owns PM lifecycle, agent dispatch, and agent
+//! communication, and a TUI is one attached client among possibly several,
+//! so a client exit must not end live work (owner directive, 2026-08-01).
+//! There is correspondingly NO teardown step here. An
 //! explicitly-set-but-unreachable `TCODE_DAEMON_URL` still errors rather
 //! than spawning, since starting a daemon at a different address would
-//! ignore that instruction. See `super::daemon_autospawn` for the whole
-//! policy — none of it lives here.
+//! ignore that instruction, and a daemon bound to a DIFFERENT project than
+//! this TUI is refused rather than attached to. See
+//! `super::daemon_autospawn` for the whole policy — none of it lives here.
 //!
 //! Daemon resolution deliberately runs BEFORE `trusty_tui::run::run` enters
 //! the alternate screen, so the startup spinner and any failure land on a
 //! normal terminal instead of flashing behind a TUI that is about to tear
-//! itself down. Teardown correspondingly runs AFTER it exits, and runs even
-//! when the REPL itself failed, so a spawned daemon can never outlive the
-//! TUI that owns it.
+//! itself down.
 //! Test: `tui_tests::*` covers the pure project-resolution helper;
-//! `super::daemon_autospawn`'s tests cover every attach/spawn/teardown
+//! `super::daemon_autospawn`'s tests cover every attach/spawn/binding-check
 //! branch against real child processes;
 //! `tests/cli_e2e.rs::{tui_subcommand_is_listed_in_help,
-//! tui_refuses_to_spawn_for_an_unreachable_explicit_daemon_url}` cover the
-//! CLI surface and the no-auto-spawn guard against the REAL binary. The
-//! launch path past daemon resolution needs a real TTY
-//! (`trusty_tui::TerminalGuard::enter`), so it is verified by running
-//! `tcode tui` by hand; the engine half is already covered end-to-end by
-//! `tests/tui_client_engine.rs`.
+//! tui_auto_spawns_a_daemon_that_outlives_it,
+//! tui_refuses_to_spawn_for_an_unreachable_explicit_daemon_url,
+//! tui_refuses_a_daemon_bound_to_a_different_project}` cover the CLI surface
+//! against the REAL binary. The launch path past daemon resolution needs a
+//! real TTY (`trusty_tui::TerminalGuard::enter`), so it is verified by
+//! running `tcode tui` by hand; the engine half is already covered
+//! end-to-end by `tests/tui_client_engine.rs`.
 
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -58,33 +62,30 @@ use super::daemon_autospawn;
 const PRODUCT_LABEL: &str = "tcode";
 
 /// Launch the TUI REPL, returning once the user quits — starting a daemon
-/// first if none is running, and stopping it again on the way out.
+/// first if none is running, and leaving it running on the way out.
 ///
 /// Why/What/Test: see the module docs — this function IS the module.
 /// `project` is `Option` because a projectless session is a first-class
 /// state (`session.create` without a `project`), not a degraded one; it is
-/// forwarded to a spawned daemon so the daemon's binding matches the TUI's.
+/// forwarded to a spawned daemon so the daemon's binding matches the TUI's,
+/// and checked against a pre-existing daemon's reported binding.
 pub async fn run(project: Option<PathBuf>) -> Result<()> {
     let project = resolve_project(project)?;
     let http = trusty_code::tui_client::build_http_client();
-    // #4512: attach to a running daemon, or start one and take ownership of
-    // it — replaces #4424's "exit and tell the user to start one".
-    let daemon = daemon_autospawn::ensure_daemon(&http, project.as_deref()).await?;
-    let engine = CodeEngine::with_daemon_url(http, daemon.url.clone(), project);
+    // #4512: attach to a running daemon serving this project, or start one —
+    // replaces #4424's "exit and tell the user to start one". Nothing is
+    // torn down afterwards: the daemon outlives every client (module docs).
+    let daemon_url = daemon_autospawn::ensure_daemon(&http, project.as_deref()).await?;
+    let engine = CodeEngine::with_daemon_url(http, daemon_url, project);
     let app = ReplApp::new(PRODUCT_LABEL, user_label());
 
-    let outcome = trusty_tui::run::run(
+    trusty_tui::run::run(
         Arc::new(engine),
         app,
         trusty_tui::app::apply,
         trusty_tui::layout::draw,
     )
-    .await;
-
-    // Unconditional: a REPL that failed must still not leak the daemon it
-    // started. A no-op when we only attached to a pre-existing one.
-    daemon.shutdown().await;
-    outcome
+    .await
 }
 
 /// Canonicalize `--project` when given, so the daemon receives an absolute

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -113,10 +113,12 @@ enum Command {
     /// The daemon is located by `TCODE_DAEMON_URL`, else the `http_addr`
     /// discovery file, and is liveness-pinged before use. When nothing
     /// answers, one is STARTED automatically (#4512, reversing DOC-50 §4.1's
-    /// deferral) and stopped again when the REPL exits — a pre-existing
-    /// daemon is attached to and left running. A `TCODE_DAEMON_URL` that is
-    /// set but unreachable is an error rather than a spawn, so an explicit
-    /// address is never quietly replaced with a different one. See
+    /// deferral) — and LEFT RUNNING when the REPL exits, since the daemon
+    /// owns PM lifecycle and agent dispatch and this TUI is only one of its
+    /// attached clients. A `TCODE_DAEMON_URL` that is set but unreachable is
+    /// an error rather than a spawn, so an explicit address is never quietly
+    /// replaced with a different one, and a daemon bound to a DIFFERENT
+    /// project than `--project` is refused rather than attached to. See
     /// `crate::cli::tui` for the wiring and `crate::cli::daemon_autospawn`
     /// for the policy.
     Tui {

--- a/crates/trusty-code/src/main.rs
+++ b/crates/trusty-code/src/main.rs
@@ -107,14 +107,18 @@ enum Command {
         port: Option<u16>,
     },
 
-    /// Launch the interactive TUI REPL against a running `tcode serve --http`
-    /// daemon (#4424; DOC-50 §4.1, AC-2.4).
+    /// Launch the interactive TUI REPL, starting a `tcode serve --http`
+    /// daemon if one isn't already running (#4424; auto-spawn #4512).
     ///
     /// The daemon is located by `TCODE_DAEMON_URL`, else the `http_addr`
-    /// discovery file, and is liveness-pinged before use. This MVP does NOT
-    /// auto-spawn one (deliberately deferred, DOC-50 §4.1): start
-    /// `tcode serve --http` first, or the command exits with an actionable
-    /// message. See `crate::cli::tui` for the wiring.
+    /// discovery file, and is liveness-pinged before use. When nothing
+    /// answers, one is STARTED automatically (#4512, reversing DOC-50 §4.1's
+    /// deferral) and stopped again when the REPL exits — a pre-existing
+    /// daemon is attached to and left running. A `TCODE_DAEMON_URL` that is
+    /// set but unreachable is an error rather than a spawn, so an explicit
+    /// address is never quietly replaced with a different one. See
+    /// `crate::cli::tui` for the wiring and `crate::cli::daemon_autospawn`
+    /// for the policy.
     Tui {
         /// Path to the project root the REPL's session binds to.
         ///
@@ -377,8 +381,11 @@ async fn main() -> Result<()> {
         } => run_serve(project, stdio, http, port).await,
 
         // #4424: the launch point for the TUI REPL — reuses `run_thin_client`
-        // so a discovery failure prints `tcode tui: <actionable message>` and
-        // exits nonzero, exactly like every other subcommand's failure.
+        // so a daemon-resolution failure prints `tcode tui: <actionable
+        // message>` and exits nonzero, exactly like every other subcommand's
+        // failure.
+        // #4512: that failure is now rare — a missing daemon is started, not
+        // reported.
         Command::Tui { project } => run_thin_client(cli::tui::run(project), "tui").await,
 
         Command::RunTask {

--- a/crates/trusty-code/src/serve/http.rs
+++ b/crates/trusty-code/src/serve/http.rs
@@ -58,23 +58,27 @@ use tokio_stream::wrappers::BroadcastStream;
 use tracing::info;
 use trusty_common::mcp::Response;
 
+use crate::binding::ProjectBinding;
 use crate::jsonrpc::{ConnectionContext, Router};
 use crate::serve::methods::health_payload;
 use crate::serve::rest;
 use crate::session::SessionRegistry;
 use crate::workstreams::SharedWorkstreamStore;
 
-/// Shared axum state: the JSON-RPC router (for `POST /rpc`) and the session
+/// Shared axum state: the JSON-RPC router (for `POST /rpc`), the session
 /// registry (for the SSE route, which reads it directly rather than going
-/// through the router).
+/// through the router), and the daemon's project binding (for `GET /health`).
 ///
-/// Why: both fields are `Arc` so cloning per-request (axum requires `State`
-/// to be `Clone`) is cheap and every route sees the same daemon-wide
-/// instances.
+/// Why: every field is an `Arc` so cloning per-request (axum requires
+/// `State` to be `Clone`) is cheap and every route sees the same daemon-wide
+/// instances. `binding` is here rather than resolved per request because a
+/// daemon binds exactly ONE project for its whole life — that immutability
+/// is precisely what makes it worth publishing on `/health` (#4512).
 #[derive(Clone)]
 struct HttpState {
     router: Arc<Router>,
     sessions: Arc<SessionRegistry>,
+    binding: Arc<ProjectBinding>,
 }
 
 /// Build the pure axum router (no listener bound) exposing `POST /rpc`,
@@ -125,10 +129,12 @@ pub fn build_axum_router(
     router: Arc<Router>,
     sessions: Arc<SessionRegistry>,
     workstreams: SharedWorkstreamStore,
+    binding: Arc<ProjectBinding>,
 ) -> AxumRouter {
     let state = HttpState {
         router: router.clone(),
         sessions,
+        binding,
     };
     let core = AxumRouter::new()
         .route("/rpc", post(rpc_handler))
@@ -179,10 +185,16 @@ async fn rpc_handler(State(state): State<HttpState>, body: Bytes) -> Json<Respon
 /// confirm a daemon is alive. Reusing [`health_payload`] — the exact
 /// function the `health` JSON-RPC method calls — keeps the two transports
 /// from drifting into two different health shapes.
-/// What: always returns HTTP 200 with `{"server","version","status"}`.
-/// Test: `http_health_matches_jsonrpc_health_payload`.
-async fn health_handler() -> Json<serde_json::Value> {
-    Json(health_payload())
+///
+/// #4512: this is also the route `tcode tui`'s auto-attach reads the
+/// daemon's `binding` from before deciding whether attaching would put it on
+/// the wrong project, which is why the handler now needs `State`.
+/// What: always returns HTTP 200 with
+/// `{"server","version","status","pid","binding"}`.
+/// Test: `http_health_matches_jsonrpc_health_payload`,
+/// `http_health_reports_the_daemons_project_binding`.
+async fn health_handler(State(state): State<HttpState>) -> Json<serde_json::Value> {
+    Json(health_payload(&state.binding))
 }
 
 /// `GET /sessions/{id}/events` — Server-Sent Events stream of a session's
@@ -275,6 +287,9 @@ pub async fn run_http(
     sessions: Arc<SessionRegistry>,
     workstreams: SharedWorkstreamStore,
     port: u16,
+    // #4512: published on `GET /health` so an auto-attaching client can tell
+    // WHICH project this daemon serves before it starts driving it.
+    binding: Arc<ProjectBinding>,
 ) -> Result<()> {
     let addr = SocketAddr::from(([127, 0, 0, 1], port));
     let listener = TcpListener::bind(addr)
@@ -301,7 +316,7 @@ pub async fn run_http(
         );
     }
 
-    let app = build_axum_router(Arc::new(router), sessions, workstreams);
+    let app = build_axum_router(Arc::new(router), sessions, workstreams, binding);
     axum::serve(listener, app)
         .with_graceful_shutdown(trusty_common::shutdown_signal())
         .await

--- a/crates/trusty-code/src/serve/http_tests.rs
+++ b/crates/trusty-code/src/serve/http_tests.rs
@@ -23,7 +23,7 @@ async fn router_and_sessions() -> (Arc<Router>, Arc<SessionRegistry>, SharedWork
     let sessions = Arc::new(SessionRegistry::new());
     let workstreams = test_workstreams_store().await;
     let mut router = Router::new();
-    crate::serve::methods::register(&mut router);
+    crate::serve::methods::register(&mut router, crate::binding::ProjectBinding::None);
     crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     (Arc::new(router), sessions, workstreams)
 }
@@ -43,6 +43,14 @@ async fn test_workstreams_store() -> SharedWorkstreamStore {
     Arc::new(tokio::sync::Mutex::new(store))
 }
 
+/// The projectless binding every route test that doesn't specifically
+/// exercise `GET /health`'s binding field passes to `build_axum_router`
+/// (#4512 made it a required parameter so the daemon can publish which
+/// project it serves).
+fn test_binding() -> Arc<crate::binding::ProjectBinding> {
+    Arc::new(crate::binding::ProjectBinding::None)
+}
+
 async fn body_json(response: axum::response::Response) -> Value {
     let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
     serde_json::from_slice(&bytes).unwrap()
@@ -53,7 +61,7 @@ async fn body_json(response: axum::response::Response) -> Value {
 #[tokio::test]
 async fn http_rpc_ping_returns_pong() {
     let (router, sessions, workstreams) = router_and_sessions().await;
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
     let req_body = json!({"jsonrpc": "2.0", "id": 1, "method": "ping"}).to_string();
 
     let resp = app
@@ -79,7 +87,7 @@ async fn http_rpc_ping_returns_pong() {
 #[tokio::test]
 async fn http_rpc_malformed_json_returns_parse_error() {
     let (router, sessions, workstreams) = router_and_sessions().await;
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -103,7 +111,7 @@ async fn http_rpc_malformed_json_returns_parse_error() {
 #[tokio::test]
 async fn http_health_matches_jsonrpc_health_payload() {
     let (router, sessions, workstreams) = router_and_sessions().await;
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -118,7 +126,36 @@ async fn http_health_matches_jsonrpc_health_payload() {
 
     assert_eq!(resp.status(), StatusCode::OK);
     let v = body_json(resp).await;
-    assert_eq!(v, health_payload());
+    assert_eq!(v, health_payload(&crate::binding::ProjectBinding::None));
+}
+
+/// `GET /health` must publish the daemon's OWN binding, not a placeholder —
+/// this is the field `cli::daemon_autospawn` compares before attaching, so a
+/// daemon that reported the wrong project would defeat the whole check
+/// (#4512).
+#[tokio::test]
+async fn http_health_reports_the_daemons_project_binding() {
+    let project = tempfile::tempdir().expect("project tempdir");
+    let binding = crate::binding::ProjectBinding::resolve(Some(project.path().to_path_buf()))
+        .expect("tempdir must bind");
+    let (router, sessions, workstreams) = router_and_sessions().await;
+    let app = build_axum_router(router, sessions, workstreams, Arc::new(binding.clone()));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri("/health")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let v = body_json(resp).await;
+    assert_eq!(v["binding"], binding.to_json());
+    assert_eq!(v["pid"], std::process::id());
 }
 
 /// `GET /sessions` (the #2983 Slice 2 REST route group, merged in by
@@ -130,7 +167,7 @@ async fn http_health_matches_jsonrpc_health_payload() {
 #[tokio::test]
 async fn http_rest_sessions_route_is_merged_in() {
     let (router, sessions, workstreams) = router_and_sessions().await;
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -167,7 +204,7 @@ async fn http_rest_sessions_route_is_merged_in() {
 async fn http_rest_post_sessions_route_is_merged_in() {
     let (router, sessions, workstreams) = router_and_sessions().await;
     let sessions_for_seeding = sessions.clone();
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let create_resp = app
         .clone()
@@ -253,7 +290,7 @@ async fn http_rest_post_tasks_route_is_merged_in() {
     let project = tempfile::tempdir().expect("project tempdir");
     let workstreams = test_workstreams_store().await;
     let mut router = Router::new();
-    crate::serve::methods::register(&mut router);
+    crate::serve::methods::register(&mut router, crate::binding::ProjectBinding::None);
     crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     crate::task::protocol::register(
         &mut router,
@@ -263,7 +300,7 @@ async fn http_rest_post_tasks_route_is_merged_in() {
         agents.path().to_path_buf(),
         workstreams.clone(),
     );
-    let app = build_axum_router(Arc::new(router), sessions, workstreams);
+    let app = build_axum_router(Arc::new(router), sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -300,14 +337,19 @@ async fn http_rest_get_fs_route_is_merged_in() {
     // has it wired.
     let sessions = Arc::new(SessionRegistry::new());
     let mut router = Router::new();
-    crate::serve::methods::register(&mut router);
+    crate::serve::methods::register(&mut router, crate::binding::ProjectBinding::None);
     crate::session::protocol::register(
         &mut router,
         sessions.clone(),
         test_workstreams_store().await,
     );
     crate::fs_browse::protocol::register(&mut router);
-    let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
+    let app = build_axum_router(
+        Arc::new(router),
+        sessions,
+        test_workstreams_store().await,
+        test_binding(),
+    );
     let tmp = tempfile::tempdir().expect("tempdir");
 
     let resp = app
@@ -339,14 +381,19 @@ async fn http_rest_get_projects_route_is_merged_in() {
     // also has it wired, mirroring `http_rest_get_fs_route_is_merged_in`.
     let sessions = Arc::new(SessionRegistry::new());
     let mut router = Router::new();
-    crate::serve::methods::register(&mut router);
+    crate::serve::methods::register(&mut router, crate::binding::ProjectBinding::None);
     crate::session::protocol::register(
         &mut router,
         sessions.clone(),
         test_workstreams_store().await,
     );
     crate::fs_browse::protocol::register(&mut router);
-    let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
+    let app = build_axum_router(
+        Arc::new(router),
+        sessions,
+        test_workstreams_store().await,
+        test_binding(),
+    );
 
     let resp = app
         .oneshot(
@@ -376,7 +423,7 @@ async fn http_rest_get_agent_and_skill_catalog_routes_are_merged_in() {
     let sessions = Arc::new(SessionRegistry::new());
     let project = tempfile::tempdir().expect("project tempdir");
     let mut router = Router::new();
-    crate::serve::methods::register(&mut router);
+    crate::serve::methods::register(&mut router, crate::binding::ProjectBinding::None);
     crate::session::protocol::register(
         &mut router,
         sessions.clone(),
@@ -390,7 +437,12 @@ async fn http_rest_get_agent_and_skill_catalog_routes_are_merged_in() {
         &mut router,
         crate::skills::protocol::SkillsCatalogState::new(Some(project.path())),
     );
-    let app = build_axum_router(Arc::new(router), sessions, test_workstreams_store().await);
+    let app = build_axum_router(
+        Arc::new(router),
+        sessions,
+        test_workstreams_store().await,
+        test_binding(),
+    );
 
     let agents_resp = app
         .clone()
@@ -431,7 +483,7 @@ async fn http_rest_get_agent_and_skill_catalog_routes_are_merged_in() {
 async fn http_rest_get_session_agents_route_is_merged_in() {
     let (router, sessions, workstreams) = router_and_sessions().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -460,7 +512,7 @@ async fn http_rest_get_session_agents_route_is_merged_in() {
 async fn http_rest_get_session_budget_route_is_merged_in() {
     let (router, sessions, workstreams) = router_and_sessions().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -488,7 +540,7 @@ async fn http_rest_get_session_budget_route_is_merged_in() {
 async fn http_rest_get_session_search_audit_route_is_merged_in() {
     let (router, sessions, workstreams) = router_and_sessions().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -525,11 +577,11 @@ async fn http_rest_get_workstreams_route_is_merged_in() {
         .expect("load");
     let workstreams = Arc::new(tokio::sync::Mutex::new(store));
     let mut router = Router::new();
-    crate::serve::methods::register(&mut router);
+    crate::serve::methods::register(&mut router, crate::binding::ProjectBinding::None);
     crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     crate::workstreams::protocol::register(&mut router, workstreams.clone());
     let id = workstreams.lock().await.create("t").await.expect("create");
-    let app = build_axum_router(Arc::new(router), sessions, workstreams);
+    let app = build_axum_router(Arc::new(router), sessions, workstreams, test_binding());
 
     let resp = app
         .clone()
@@ -564,7 +616,7 @@ async fn http_rest_get_workstreams_route_is_merged_in() {
 #[tokio::test]
 async fn http_session_events_sse_unknown_session_returns_404() {
     let (router, sessions, workstreams) = router_and_sessions().await;
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(
@@ -594,7 +646,7 @@ async fn http_session_events_sse_unknown_session_returns_404() {
 async fn http_session_events_sse_streams_replay() {
     let (router, sessions, workstreams) = router_and_sessions().await;
     let session = sessions.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-    let app = build_axum_router(router, sessions, workstreams);
+    let app = build_axum_router(router, sessions, workstreams, test_binding());
 
     let resp = app
         .oneshot(

--- a/crates/trusty-code/src/serve/methods.rs
+++ b/crates/trusty-code/src/serve/methods.rs
@@ -10,22 +10,38 @@
 //! different shapes.
 //! What: `register` wires both methods into a [`Router`]; `ping` returns
 //! `{"pong": true}`; `health` returns [`health_payload`]'s server name,
-//! crate version, and a static `"ok"` status.
+//! crate version, static `"ok"` status, pid, and the daemon's project
+//! binding.
 //! Test: `methods::tests::*`.
+
+use std::sync::Arc;
 
 use serde_json::{Value, json};
 
+use crate::binding::ProjectBinding;
 use crate::jsonrpc::{ConnectionContext, Router, RpcError};
 
 /// Register every proof-of-life method onto `router`.
 ///
 /// Why: keeps `crate::serve::build_router` a one-line call as more method
 /// groups (session/task/harness) register themselves the same way later.
-/// What: registers `"ping"` and `"health"`.
-/// Test: `methods_register_wires_ping_and_health`.
-pub fn register(router: &mut Router) {
+/// `binding` is taken here — rather than `health` staying a bare `fn` — so
+/// the daemon can REPORT which project it serves (#4512): a daemon binds
+/// exactly one `ProjectBinding` for its whole life, and a client that
+/// auto-attaches to a daemon it did not start has no other way to tell
+/// whether it is about to operate against the wrong project.
+/// What: registers `"ping"` and `"health"`; `binding` is shared into the
+/// `health` closure behind an `Arc` so answering a probe never clones a
+/// `PathBuf`.
+/// Test: `methods_register_wires_ping_and_health`,
+/// `health_reports_the_daemons_project_binding`.
+pub fn register(router: &mut Router, binding: ProjectBinding) {
     router.register("ping", ping);
-    router.register("health", health);
+    let binding = Arc::new(binding);
+    router.register("health", move |params: Value, ctx: ConnectionContext| {
+        let binding = binding.clone();
+        async move { health(&binding, params, ctx).await }
+    });
 }
 
 /// `ping` — returns `{"pong": true}` regardless of `params`.
@@ -38,33 +54,54 @@ async fn ping(_params: Value, _ctx: ConnectionContext) -> Result<Value, RpcError
     Ok(json!({"pong": true}))
 }
 
-/// `health` — returns server identity, crate version, and status.
+/// `health` — returns server identity, crate version, status, and binding.
 ///
 /// Why: a slightly richer proof-of-life than `ping` that a caller can use to
-/// confirm which build of `tcode` it is talking to.
+/// confirm which build of `tcode` — and, since #4512, which PROJECT — it is
+/// talking to.
 /// What: ignores `params` and the connection context, never fails; the
 /// payload is [`health_payload`].
-/// Test: `health_returns_server_identity`.
-async fn health(_params: Value, _ctx: ConnectionContext) -> Result<Value, RpcError> {
-    Ok(health_payload())
+/// Test: `health_returns_server_identity`,
+/// `health_reports_the_daemons_project_binding`.
+async fn health(
+    binding: &ProjectBinding,
+    _params: Value,
+    _ctx: ConnectionContext,
+) -> Result<Value, RpcError> {
+    Ok(health_payload(binding))
 }
 
-/// The shared `health` payload: `{"server","version","status"}`.
+/// The shared `health` payload:
+/// `{"server","version","status","pid","binding"}`.
 ///
 /// Why: pulled out of the `health` JSON-RPC handler so
 /// `crate::serve::http::health_handler` (`GET /health`) can return the
 /// identical shape without duplicating the `json!` literal — one source of
 /// truth for what "healthy" means over either transport.
+///
+/// `pid` and `binding` are ADDITIVE (#4512) — every field that was here
+/// before is unchanged, so an older client that only reads
+/// `server`/`version`/`status` keeps working. They exist because a daemon
+/// binds exactly one `ProjectBinding` at `build_router` time and holds it for
+/// its whole life, while `tcode tui` now AUTO-ATTACHES to whatever daemon
+/// discovery finds. Without the binding on the wire, a TUI launched in
+/// project B silently drives project A's daemon; `pid` is what lets an
+/// operator (or a test) identify and signal the exact process it found.
 /// What: `server = "tcode"`, `version = crate::VERSION`
-/// (`CARGO_PKG_VERSION`), `status = "ok"`. Never fails — there is no
-/// fallible state to check yet; a future ticket that adds real readiness
-/// checks (e.g. project root validity) will extend this function.
-/// Test: `health_payload_has_expected_shape`.
-pub(crate) fn health_payload() -> Value {
+/// (`CARGO_PKG_VERSION`), `status = "ok"`, `pid = std::process::id()`,
+/// `binding = ProjectBinding::to_json()` (the SAME `{state, root}` wire shape
+/// `Session` already serialises, not a second spelling). Never fails — there
+/// is no fallible state to check; a future ticket that adds real readiness
+/// checks will extend this function.
+/// Test: `health_payload_has_expected_shape`,
+/// `health_payload_reports_a_bound_project_root`.
+pub(crate) fn health_payload(binding: &ProjectBinding) -> Value {
     json!({
         "server": "tcode",
         "version": crate::VERSION,
         "status": "ok",
+        "pid": std::process::id(),
+        "binding": binding.to_json(),
     })
 }
 
@@ -90,7 +127,7 @@ mod tests {
     /// `health` must report the server name, version, and "ok" status.
     #[tokio::test]
     async fn health_returns_server_identity() {
-        let result = health(Value::Null, test_ctx())
+        let result = health(&ProjectBinding::None, Value::Null, test_ctx())
             .await
             .expect("health must not fail");
         assert_eq!(result["server"], "tcode");
@@ -98,14 +135,45 @@ mod tests {
         assert_eq!(result["version"], crate::VERSION);
     }
 
-    /// `health_payload` (shared with the HTTP `GET /health` route) must
-    /// carry the same three fields.
+    /// `health_payload` (shared with the HTTP `GET /health` route) must carry
+    /// the original three fields UNCHANGED plus #4512's additive `pid` and
+    /// `binding` — pinned so the backward-compatible promise in this
+    /// function's docs can't be broken by a later edit.
     #[test]
     fn health_payload_has_expected_shape() {
-        let v = health_payload();
+        let v = health_payload(&ProjectBinding::None);
         assert_eq!(v["server"], "tcode");
         assert_eq!(v["status"], "ok");
         assert_eq!(v["version"], crate::VERSION);
+        assert_eq!(v["pid"], std::process::id());
+        assert_eq!(v["binding"]["state"], crate::binding::STATE_PROJECTLESS);
+        assert!(v["binding"]["root"].is_null());
+    }
+
+    /// A BOUND daemon must publish its project root, since that is the field
+    /// `cli::daemon_autospawn` compares against the client's own project
+    /// before attaching (#4512).
+    #[test]
+    fn health_payload_reports_a_bound_project_root() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let binding = ProjectBinding::resolve(Some(dir.path().to_path_buf())).expect("must bind");
+        let v = health_payload(&binding);
+        assert_eq!(
+            v["binding"]["root"],
+            json!(binding.label().expect("a bound binding has a root"))
+        );
+    }
+
+    /// The `health` METHOD (not just the payload helper) must carry the
+    /// daemon's binding, so the STDIO transport reports it too.
+    #[tokio::test]
+    async fn health_reports_the_daemons_project_binding() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let binding = ProjectBinding::resolve(Some(dir.path().to_path_buf())).expect("must bind");
+        let result = health(&binding, Value::Null, test_ctx())
+            .await
+            .expect("health must not fail");
+        assert_eq!(result["binding"], binding.to_json());
     }
 
     /// `register` must wire both methods so the router recognises them
@@ -115,7 +183,7 @@ mod tests {
         use trusty_common::mcp::Request;
 
         let mut router = Router::new();
-        register(&mut router);
+        register(&mut router, ProjectBinding::None);
 
         for method in ["ping", "health"] {
             let req = Request {

--- a/crates/trusty-code/src/serve/mod.rs
+++ b/crates/trusty-code/src/serve/mod.rs
@@ -186,7 +186,9 @@ async fn build_router_at(
     let workstreams = Arc::new(Mutex::new(workstream_store));
 
     let mut router = Router::new();
-    methods::register(&mut router);
+    // #4512: `health` publishes the binding, so a client that auto-attaches
+    // to a daemon it did not start can tell which project it would drive.
+    methods::register(&mut router, binding.clone());
     crate::session::protocol::register(&mut router, sessions.clone(), workstreams.clone());
     crate::fs_browse::protocol::register(&mut router);
     crate::agents::protocol::register(
@@ -251,8 +253,18 @@ pub async fn run_http(binding: ProjectBinding, port: u16) -> Result<()> {
         port,
         "tcode serve --http: starting"
     );
+    // #4512: `GET /health` reports this binding, so keep a handle before
+    // `build_router` consumes it.
+    let published_binding = Arc::new(binding.clone());
     let (router, sessions, workstreams) = build_router(binding).await?;
-    http::run_http(router, sessions.clone(), workstreams, port).await?;
+    http::run_http(
+        router,
+        sessions.clone(),
+        workstreams,
+        port,
+        published_binding,
+    )
+    .await?;
     sessions.shutdown_executions(SHUTDOWN_GRACE).await;
     info!("tcode serve --http: stopped");
     Ok(())

--- a/crates/trusty-code/src/tui_client/discovery.rs
+++ b/crates/trusty-code/src/tui_client/discovery.rs
@@ -23,17 +23,24 @@
 //! discovery file is stale or absent, but must NOT when
 //! [`DAEMON_URL_ENV`] explicitly named an address, since spawning
 //! something at a DIFFERENT address would quietly ignore that instruction
-//! (#4512). [`discover_daemon_url`] is the attach-only wrapper over it,
-//! collapsing the same three outcomes into a [`DiscoveryError`] with an
-//! actionable message — never a silent `None`/default.
+//! (#4512). A live daemon additionally carries the [`ReportedBinding`] it
+//! published, because "a daemon is answering" is NOT the same question as
+//! "that daemon serves the project I mean to work in" — see
+//! [`ReportedBinding`]. [`discover_daemon_url`] is the attach-only wrapper
+//! over it, collapsing the same three outcomes into a [`DiscoveryError`]
+//! with an actionable message — never a silent `None`/default.
 //! Test: `discovery_tests::*` for the pure candidate-selection logic (env
-//! var precedence, file fallback, "neither present" case) and the
-//! [`Lookup`]-to-[`DiscoveryError`] collapse; the liveness-ping
-//! branch is covered end-to-end in `tests/tui_client_engine.rs` against a
-//! mock daemon (a unit test would need a real bound socket to ping, which
-//! belongs in that hermetic integration suite, not here).
+//! var precedence, file fallback, "neither present" case), the
+//! [`Lookup`]-to-[`DiscoveryError`] collapse, and [`ReportedBinding`]
+//! parsing; the liveness-ping branch is covered end-to-end in
+//! `tests/tui_client_engine.rs` against a mock daemon (a unit test would need
+//! a real bound socket to ping, which belongs in that hermetic integration
+//! suite, not here).
 
+use std::path::PathBuf;
 use std::time::Duration;
+
+use crate::binding::ProjectBinding;
 
 /// Environment variable that, when set to a non-empty value, names the
 /// daemon URL directly — highest-priority discovery source (DOC-50 §3.4
@@ -70,6 +77,70 @@ impl Source {
     }
 }
 
+/// The project binding a live daemon published on `GET /health` (#4512).
+///
+/// Why: a `tcode serve --http` daemon binds exactly ONE `ProjectBinding` at
+/// `crate::serve::build_router` time and keeps it for its whole life. Until
+/// #4512 that binding was invisible to clients, which was harmless while
+/// `tcode tui` refused to run without a hand-started daemon — the operator
+/// who started it knew what it was bound to. Auto-attach removes that
+/// guarantee: a TUI launched in project B finds project A's daemon on the
+/// well-known port and would drive it, so every session, index, and file
+/// operation would silently land in the wrong project. Making the binding
+/// part of the lookup result is what lets a caller refuse.
+/// What: the daemon's bound project root, or an explicit projectless state,
+/// or [`Unreported`](ReportedBinding::Unreported) when `/health` answered but
+/// carried no usable `binding` field — a daemon older than #4512, or one
+/// whose payload could not be parsed. Those two are deliberately the same
+/// variant: both mean "this daemon's project CANNOT be verified", and a
+/// caller must treat an unverifiable daemon the same way regardless of why.
+/// Test: `discovery_tests::reported_binding_parses_every_health_shape`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ReportedBinding {
+    /// The daemon reported it serves no project.
+    Projectless,
+    /// The daemon reported this canonical project root.
+    Bound(PathBuf),
+    /// `/health` answered, but with no parseable `binding` field.
+    Unreported,
+}
+
+impl ReportedBinding {
+    /// Read a [`ReportedBinding`] out of a `GET /health` body.
+    ///
+    /// Why/What: reuses `ProjectBinding`'s own `Deserialize` (the
+    /// `{state, root}` wire shape defined once in `crate::binding`) rather
+    /// than re-spelling that shape here, so the reader can never drift from
+    /// the writer. A missing or malformed field is
+    /// [`Unreported`](ReportedBinding::Unreported), never a guess.
+    /// Test: `discovery_tests::reported_binding_parses_every_health_shape`.
+    pub fn from_health(health: &serde_json::Value) -> Self {
+        let Some(raw) = health.get("binding") else {
+            return Self::Unreported;
+        };
+        match serde_json::from_value::<ProjectBinding>(raw.clone()) {
+            Ok(binding) => match binding.root() {
+                Some(root) => Self::Bound(root.to_path_buf()),
+                None => Self::Projectless,
+            },
+            Err(_) => Self::Unreported,
+        }
+    }
+
+    /// How to name this binding in an operator-facing message.
+    ///
+    /// Why: a mismatch error has to print BOTH sides, and "no project" has to
+    /// read as a deliberate state rather than as missing information.
+    /// Test: `discovery_tests::reported_binding_describes_each_state`.
+    pub fn describe(&self) -> String {
+        match self {
+            Self::Projectless => "<projectless>".to_string(),
+            Self::Bound(root) => root.display().to_string(),
+            Self::Unreported => "<unreported — daemon predates #4512>".to_string(),
+        }
+    }
+}
+
 /// The three distinguishable outcomes of one daemon lookup.
 ///
 /// Why: [`DiscoveryError`] collapses "found but dead" and "nothing found"
@@ -77,12 +148,18 @@ impl Source {
 /// an attach-only caller needs. Auto-spawn needs MORE: it must refuse to
 /// spawn when [`Source::Env`] named a dead address (spawning would land at a
 /// different address and ignore the operator's explicit instruction), while
-/// treating a dead or absent discovery file as a green light (#4512).
+/// treating a dead or absent discovery file as a green light (#4512). It
+/// also needs the live daemon's [`ReportedBinding`], since attaching to a
+/// daemon bound to a DIFFERENT project is worse than not attaching at all.
 /// Test: `discovery_tests::lookup_collapses_into_discovery_errors`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Lookup {
-    /// A candidate answered `GET {url}/health` — attach to it.
-    Live(String),
+    /// A candidate answered `GET {url}/health` — attach to it, if `binding`
+    /// is the project the caller wants.
+    Live {
+        url: String,
+        binding: ReportedBinding,
+    },
     /// A candidate URL was named by `source` but is not responding.
     Dead { url: String, source: Source },
     /// Neither source named a candidate URL.
@@ -131,10 +208,12 @@ pub async fn lookup_daemon(client: &reqwest::Client) -> Lookup {
     let Some((url, source)) = candidate_url() else {
         return Lookup::Absent;
     };
-    if ping_alive(client, &url).await {
-        Lookup::Live(url)
-    } else {
-        Lookup::Dead { url, source }
+    match probe_health(client, &url).await {
+        Some(health) => Lookup::Live {
+            url,
+            binding: ReportedBinding::from_health(&health),
+        },
+        None => Lookup::Dead { url, source },
     }
 }
 
@@ -154,7 +233,7 @@ pub async fn discover_daemon_url(client: &reqwest::Client) -> Result<String, Dis
 /// [`discover_daemon_url`] so it is unit testable without a bound socket.
 fn collapse(lookup: Lookup) -> Result<String, DiscoveryError> {
     match lookup {
-        Lookup::Live(url) => Ok(url),
+        Lookup::Live { url, .. } => Ok(url),
         Lookup::Dead { url, source } => Err(DiscoveryError::NotAlive {
             url,
             found_via: source.as_str(),
@@ -178,14 +257,21 @@ fn candidate_url() -> Option<(String, Source)> {
     Some((format!("http://{addr}"), Source::File))
 }
 
-/// `GET {base_url}/health`, bounded by [`PING_TIMEOUT`] — `true` iff it
-/// returns a success (2xx) status.
-async fn ping_alive(client: &reqwest::Client, base_url: &str) -> bool {
+/// `GET {base_url}/health`, bounded by [`PING_TIMEOUT`] — `Some(body)` iff
+/// it returns a success (2xx) status with a JSON body.
+///
+/// #4512: this used to answer a bare `bool`. The BODY is now needed too, for
+/// the `binding` field the caller checks before attaching; a 2xx whose body
+/// will not parse as JSON still counts as alive (the daemon is answering),
+/// and degrades to `Value::Null`, from which
+/// [`ReportedBinding::from_health`] correctly reports `Unreported`.
+async fn probe_health(client: &reqwest::Client, base_url: &str) -> Option<serde_json::Value> {
     let url = format!("{base_url}/health");
-    match client.get(&url).timeout(PING_TIMEOUT).send().await {
-        Ok(resp) => resp.status().is_success(),
-        Err(_) => false,
+    let resp = client.get(&url).timeout(PING_TIMEOUT).send().await.ok()?;
+    if !resp.status().is_success() {
+        return None;
     }
+    Some(resp.json().await.unwrap_or(serde_json::Value::Null))
 }
 
 #[cfg(test)]
@@ -268,7 +354,10 @@ mod discovery_tests {
     #[test]
     fn lookup_collapses_into_discovery_errors() {
         assert_eq!(
-            collapse(Lookup::Live("http://127.0.0.1:7882".to_string())),
+            collapse(Lookup::Live {
+                url: "http://127.0.0.1:7882".to_string(),
+                binding: ReportedBinding::Projectless,
+            }),
             Ok("http://127.0.0.1:7882".to_string())
         );
         assert_eq!(
@@ -282,6 +371,65 @@ mod discovery_tests {
             })
         );
         assert_eq!(collapse(Lookup::Absent), Err(DiscoveryError::NotFound));
+    }
+
+    /// Every shape a real `GET /health` body can take must map to the right
+    /// `ReportedBinding` — including the two "cannot verify" shapes, which
+    /// must NOT be mistaken for a projectless daemon (#4512).
+    #[test]
+    fn reported_binding_parses_every_health_shape() {
+        use serde_json::json;
+
+        let bound = json!({
+            "server": "tcode",
+            "binding": {"state": crate::binding::STATE_GIT_REPO, "root": "/tmp/proj"},
+        });
+        assert_eq!(
+            ReportedBinding::from_health(&bound),
+            ReportedBinding::Bound(PathBuf::from("/tmp/proj"))
+        );
+
+        let projectless = json!({
+            "binding": {"state": crate::binding::STATE_PROJECTLESS, "root": null},
+        });
+        assert_eq!(
+            ReportedBinding::from_health(&projectless),
+            ReportedBinding::Projectless
+        );
+
+        // A pre-#4512 daemon: `/health` answers, but with no binding at all.
+        let old = json!({"server": "tcode", "version": "0.2.0", "status": "ok"});
+        assert_eq!(
+            ReportedBinding::from_health(&old),
+            ReportedBinding::Unreported,
+            "a daemon that reports nothing must never read as projectless"
+        );
+
+        // A malformed payload is equally unverifiable, never a guess.
+        let malformed = json!({"binding": {"state": "who knows"}});
+        assert_eq!(
+            ReportedBinding::from_health(&malformed),
+            ReportedBinding::Unreported
+        );
+        assert_eq!(
+            ReportedBinding::from_health(&serde_json::Value::Null),
+            ReportedBinding::Unreported
+        );
+    }
+
+    /// Each state must render an operator-readable name — the mismatch error
+    /// prints both sides, so "no project" must not come out blank.
+    #[test]
+    fn reported_binding_describes_each_state() {
+        assert_eq!(ReportedBinding::Projectless.describe(), "<projectless>");
+        assert_eq!(
+            ReportedBinding::Bound(PathBuf::from("/tmp/proj")).describe(),
+            "/tmp/proj"
+        );
+        assert!(
+            ReportedBinding::Unreported.describe().contains("4512"),
+            "an unverifiable daemon must say why it cannot be checked"
+        );
     }
 
     /// `DiscoveryError::NotAlive`'s message must name both the dead URL and

--- a/crates/trusty-code/src/tui_client/discovery.rs
+++ b/crates/trusty-code/src/tui_client/discovery.rs
@@ -10,18 +10,25 @@
 //! plain-text `http_addr` file) instead. This module is the READ side of
 //! that convention; `crate::serve::discovery`'s `write_http_addr_file` is
 //! the write side, called from `crate::serve::http::run_http`.
-//! What: [`discover_daemon_url`] tries, in order, [`DAEMON_URL_ENV`] (an
+//! What: [`lookup_daemon`] tries, in order, [`DAEMON_URL_ENV`] (an
 //! explicit override — trusted without a liveness check of its own source,
 //! but still ping-verified before use, same as the file-sourced candidate)
 //! then the `http_addr` discovery file; whichever candidate is found is
 //! verified alive via `GET {url}/health` (the SAME route
 //! `crate::serve::methods::health_payload` answers, already the
-//! ecosystem-standard liveness probe per `crate::serve::http`'s docs) before
-//! being returned. No candidate, or a candidate that fails the liveness
-//! ping, produces a [`DiscoveryError`] with an actionable message — never a
-//! silent `None`/default.
+//! ecosystem-standard liveness probe per `crate::serve::http`'s docs). It
+//! reports the outcome as a three-way [`Lookup`] — live, found-but-dead
+//! (naming its [`Source`]), or no candidate at all — because a CALLER has to
+//! branch on WHICH source failed: `tcode tui` auto-spawns a daemon when the
+//! discovery file is stale or absent, but must NOT when
+//! [`DAEMON_URL_ENV`] explicitly named an address, since spawning
+//! something at a DIFFERENT address would quietly ignore that instruction
+//! (#4512). [`discover_daemon_url`] is the attach-only wrapper over it,
+//! collapsing the same three outcomes into a [`DiscoveryError`] with an
+//! actionable message — never a silent `None`/default.
 //! Test: `discovery_tests::*` for the pure candidate-selection logic (env
-//! var precedence, file fallback, "neither present" case); the liveness-ping
+//! var precedence, file fallback, "neither present" case) and the
+//! [`Lookup`]-to-[`DiscoveryError`] collapse; the liveness-ping
 //! branch is covered end-to-end in `tests/tui_client_engine.rs` against a
 //! mock daemon (a unit test would need a real bound socket to ping, which
 //! belongs in that hermetic integration suite, not here).
@@ -40,21 +47,46 @@ pub const DAEMON_URL_ENV: &str = "TCODE_DAEMON_URL";
 const PING_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// Which discovery source produced a candidate URL — carried into
-/// [`DiscoveryError::NotAlive`] so the error message tells the operator
-/// WHERE the stale/wrong pointer came from.
+/// [`Lookup::Dead`] (and from there into [`DiscoveryError::NotAlive`]) so the
+/// error message tells the operator WHERE the stale/wrong pointer came from,
+/// and so `tcode tui`'s auto-spawn can tell an EXPLICIT instruction it must
+/// obey ([`Source::Env`]) from a stale file it may replace ([`Source::File`]).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum Source {
+pub enum Source {
+    /// [`DAEMON_URL_ENV`] named the URL — an explicit operator instruction.
     Env,
+    /// The `http_addr` discovery file named the URL — a best-effort pointer
+    /// a previous daemon left behind.
     File,
 }
 
 impl Source {
-    fn as_str(self) -> &'static str {
+    /// Human-readable name for error messages ("from {found_via}").
+    pub fn as_str(self) -> &'static str {
         match self {
             Source::Env => "TCODE_DAEMON_URL",
             Source::File => "discovery file",
         }
     }
+}
+
+/// The three distinguishable outcomes of one daemon lookup.
+///
+/// Why: [`DiscoveryError`] collapses "found but dead" and "nothing found"
+/// into two error variants that both mean "you can't attach", which is all
+/// an attach-only caller needs. Auto-spawn needs MORE: it must refuse to
+/// spawn when [`Source::Env`] named a dead address (spawning would land at a
+/// different address and ignore the operator's explicit instruction), while
+/// treating a dead or absent discovery file as a green light (#4512).
+/// Test: `discovery_tests::lookup_collapses_into_discovery_errors`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Lookup {
+    /// A candidate answered `GET {url}/health` — attach to it.
+    Live(String),
+    /// A candidate URL was named by `source` but is not responding.
+    Dead { url: String, source: Source },
+    /// Neither source named a candidate URL.
+    Absent,
 }
 
 /// See module docs.
@@ -81,26 +113,53 @@ pub enum DiscoveryError {
     },
 }
 
-/// Resolve and verify a live daemon URL, per this module's docs.
+/// Resolve a candidate daemon URL and report whether it is live, per this
+/// module's docs.
 ///
-/// Why/What: see module docs. `client` is caller-supplied (rather than built
-/// internally) so `CodeEngine` can reuse the SAME pooled `reqwest::Client`
-/// for both this ping and every later `POST /rpc`/SSE call — one connection
-/// pool for the engine's whole lifetime, not one throwaway client per call.
+/// Why/What: see module docs — this is the source-aware primitive
+/// [`discover_daemon_url`] and `tcode tui`'s auto-spawn (#4512) are both
+/// built on. `client` is caller-supplied (rather than built internally) so
+/// `CodeEngine` can reuse the SAME pooled `reqwest::Client` for both this
+/// ping and every later `POST /rpc`/SSE call — one connection pool for the
+/// engine's whole lifetime, not one throwaway client per call.
 /// Test: `discovery_tests::env_var_wins_over_file`,
 /// `discovery_tests::env_var_trailing_slash_is_stripped`,
-/// `discovery_tests::blank_env_var_is_ignored`; the liveness branch (and the
-/// "neither source present" -> `NotFound` case) is covered by
-/// `tests/tui_client_engine.rs`.
-pub async fn discover_daemon_url(client: &reqwest::Client) -> Result<String, DiscoveryError> {
-    let (url, source) = candidate_url().ok_or(DiscoveryError::NotFound)?;
+/// `discovery_tests::blank_env_var_is_ignored` cover candidate selection;
+/// the liveness branch is covered by `tests/tui_client_engine.rs` and (for
+/// the spawn decision it feeds) `cli::daemon_autospawn`'s tests.
+pub async fn lookup_daemon(client: &reqwest::Client) -> Lookup {
+    let Some((url, source)) = candidate_url() else {
+        return Lookup::Absent;
+    };
     if ping_alive(client, &url).await {
-        Ok(url)
+        Lookup::Live(url)
     } else {
-        Err(DiscoveryError::NotAlive {
+        Lookup::Dead { url, source }
+    }
+}
+
+/// Resolve and verify a live daemon URL, failing when none can be attached
+/// to — the attach-only view of [`lookup_daemon`].
+///
+/// Why: `CodeEngine::discover` (and every non-TUI caller) only ever wants
+/// "give me a live daemon or an actionable error"; the three-way [`Lookup`]
+/// distinction matters solely to the auto-spawn path.
+/// Test: `discovery_tests::lookup_collapses_into_discovery_errors`;
+/// end-to-end in `tests/tui_client_engine.rs`.
+pub async fn discover_daemon_url(client: &reqwest::Client) -> Result<String, DiscoveryError> {
+    collapse(lookup_daemon(client).await)
+}
+
+/// The pure [`Lookup`] -> [`DiscoveryError`] mapping, split out of
+/// [`discover_daemon_url`] so it is unit testable without a bound socket.
+fn collapse(lookup: Lookup) -> Result<String, DiscoveryError> {
+    match lookup {
+        Lookup::Live(url) => Ok(url),
+        Lookup::Dead { url, source } => Err(DiscoveryError::NotAlive {
             url,
             found_via: source.as_str(),
-        })
+        }),
+        Lookup::Absent => Err(DiscoveryError::NotFound),
     }
 }
 
@@ -200,6 +259,29 @@ mod discovery_tests {
         let msg = DiscoveryError::NotFound.to_string();
         assert!(msg.contains("tcode serve --http"));
         assert!(msg.contains(DAEMON_URL_ENV));
+    }
+
+    /// Every `Lookup` outcome must collapse to the matching attach-only
+    /// result — pinned because `tcode tui`'s auto-spawn now branches on the
+    /// SAME three outcomes (#4512), and the two views must stay agreed on
+    /// what each one means.
+    #[test]
+    fn lookup_collapses_into_discovery_errors() {
+        assert_eq!(
+            collapse(Lookup::Live("http://127.0.0.1:7882".to_string())),
+            Ok("http://127.0.0.1:7882".to_string())
+        );
+        assert_eq!(
+            collapse(Lookup::Dead {
+                url: "http://127.0.0.1:7882".to_string(),
+                source: Source::Env,
+            }),
+            Err(DiscoveryError::NotAlive {
+                url: "http://127.0.0.1:7882".to_string(),
+                found_via: "TCODE_DAEMON_URL",
+            })
+        );
+        assert_eq!(collapse(Lookup::Absent), Err(DiscoveryError::NotFound));
     }
 
     /// `DiscoveryError::NotAlive`'s message must name both the dead URL and

--- a/crates/trusty-code/src/tui_client/engine.rs
+++ b/crates/trusty-code/src/tui_client/engine.rs
@@ -112,7 +112,14 @@ fn workstream_subcommand(line: &str) -> Option<&str> {
     None
 }
 
-fn build_http_client() -> reqwest::Client {
+/// The pooled `reqwest::Client` every `CodeEngine` call (discovery ping,
+/// `POST /rpc`, SSE) shares.
+///
+/// Why: `pub` since #4512 so `tcode tui`'s auto-spawn path — which resolves
+/// the daemon URL itself, then hands it to [`CodeEngine::with_daemon_url`] —
+/// builds its liveness-probe client with the SAME pool settings the engine
+/// would have used, rather than a second, divergent client.
+pub fn build_http_client() -> reqwest::Client {
     reqwest::Client::builder()
         .pool_idle_timeout(Duration::from_secs(90))
         .connect_timeout(Duration::from_secs(5))

--- a/crates/trusty-code/src/tui_client/mod.rs
+++ b/crates/trusty-code/src/tui_client/mod.rs
@@ -20,5 +20,5 @@ mod session_events;
 pub mod sse;
 mod workstream_subscription;
 
-pub use engine::CodeEngine;
+pub use engine::{CodeEngine, build_http_client};
 pub use error::EngineError;

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -603,31 +603,75 @@ fn tui_subcommand_is_listed_in_help() {
     );
 }
 
-/// `tcode tui` with no reachable daemon must fail FAST with an actionable
-/// message and a nonzero exit — never hang, never enter the alternate
-/// screen, and never try to auto-spawn a daemon (explicitly deferred,
-/// DOC-50 §4.1 MVP scope).
+/// `tcode tui` auto-spawns a daemon when none is running (#4512, reversing
+/// DOC-50 §4.1's deferral) — it must NEVER exit telling the operator to go
+/// start one by hand.
 ///
-/// `TCODE_DAEMON_URL` is pointed at a port nothing listens on, which also
-/// makes the test deterministic on a developer machine that happens to have
-/// a real daemon running (the env var outranks the discovery file).
+/// `TRUSTY_DATA_DIR_OVERRIDE` isolates the `http_addr` discovery file (and
+/// the spawned daemon's log) into a temp directory, so this stays a genuine
+/// "no daemon known" case on a developer machine that has one running.
+/// Evidence of the spawn is the daemon log file the auto-spawn path opens
+/// for the child: asserting on THAT rather than on a successful launch keeps
+/// the test valid even when the default port is already taken by a foreign
+/// daemon (the child then dies on bind, which is its own reported error).
+/// The launch still fails afterwards, because a test harness has no TTY for
+/// the alternate screen — that is expected and unrelated.
 #[test]
-fn tui_without_a_reachable_daemon_errors_cleanly() {
-    let home = tempfile::tempdir().expect("home tempdir");
+fn tui_auto_spawns_a_daemon_when_none_is_running() {
+    let data_dir = tempfile::tempdir().expect("data dir tempdir");
     let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
         .arg("tui")
-        .env("HOME", home.path())
+        .env("TRUSTY_DATA_DIR_OVERRIDE", data_dir.path())
+        .env_remove("TCODE_DAEMON_URL")
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("spawn tcode tui");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        data_dir
+            .path()
+            .join("trusty-code/tui-spawned-daemon.log")
+            .exists(),
+        "must have started a daemon of its own: {stderr}"
+    );
+    assert!(
+        !stderr.contains("no tcode daemon found"),
+        "must never bail with the old start-one-yourself message: {stderr}"
+    );
+}
+
+/// An explicitly-set `TCODE_DAEMON_URL` that nothing answers must fail with
+/// an actionable message and a nonzero exit — never hang, never enter the
+/// alternate screen, and never auto-spawn a daemon at a DIFFERENT address,
+/// which would silently ignore the operator's explicit instruction (#4512).
+#[test]
+fn tui_refuses_to_spawn_for_an_unreachable_explicit_daemon_url() {
+    let data_dir = tempfile::tempdir().expect("data dir tempdir");
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .arg("tui")
+        .env("TRUSTY_DATA_DIR_OVERRIDE", data_dir.path())
         .env("TCODE_DAEMON_URL", "http://127.0.0.1:1")
+        .stdin(std::process::Stdio::null())
         .output()
         .expect("spawn tcode tui");
 
     assert!(
         !output.status.success(),
-        "must exit nonzero without a daemon: {output:?}"
+        "must exit nonzero for an unreachable explicit URL: {output:?}"
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("tcode tui:") && stderr.contains("tcode serve --http"),
-        "error must name the command and the fix: {stderr}"
+        stderr.contains("tcode tui:")
+            && stderr.contains("TCODE_DAEMON_URL")
+            && stderr.contains("http://127.0.0.1:1"),
+        "error must name the command, the env var, and the dead URL: {stderr}"
+    );
+    assert!(
+        !data_dir
+            .path()
+            .join("trusty-code/tui-spawned-daemon.log")
+            .exists(),
+        "must not have spawned a daemon: {stderr}"
     );
 }

--- a/crates/trusty-code/tests/cli_e2e.rs
+++ b/crates/trusty-code/tests/cli_e2e.rs
@@ -605,19 +605,27 @@ fn tui_subcommand_is_listed_in_help() {
 
 /// `tcode tui` auto-spawns a daemon when none is running (#4512, reversing
 /// DOC-50 §4.1's deferral) — it must NEVER exit telling the operator to go
-/// start one by hand.
+/// start one by hand — and that daemon must OUTLIVE the TUI, because it owns
+/// PM lifecycle and agent dispatch (owner directive, 2026-08-01).
 ///
 /// `TRUSTY_DATA_DIR_OVERRIDE` isolates the `http_addr` discovery file (and
 /// the spawned daemon's log) into a temp directory, so this stays a genuine
 /// "no daemon known" case on a developer machine that has one running.
 /// Evidence of the spawn is the daemon log file the auto-spawn path opens
-/// for the child: asserting on THAT rather than on a successful launch keeps
-/// the test valid even when the default port is already taken by a foreign
-/// daemon (the child then dies on bind, which is its own reported error).
-/// The launch still fails afterwards, because a test harness has no TTY for
-/// the alternate screen — that is expected and unrelated.
-#[test]
-fn tui_auto_spawns_a_daemon_when_none_is_running() {
+/// for the child. The launch itself still fails afterwards, because a test
+/// harness has no TTY for the alternate screen — that is expected and
+/// unrelated, and it is precisely the "the TUI exited" moment a teardown
+/// would have fired at.
+///
+/// The survival half is CONDITIONAL on the child actually binding: the
+/// spawned daemon uses the well-known default port, so a foreign daemon
+/// already holding it makes ours die on bind (its own reported error). The
+/// isolated `http_addr` file is written only by OUR child, so its presence is
+/// the exact "our daemon came up" signal — when it is absent the test still
+/// asserts everything that does not depend on a free port. This test kills
+/// the daemon it caused to start; nothing else will.
+#[tokio::test]
+async fn tui_auto_spawns_a_daemon_that_outlives_it() {
     let data_dir = tempfile::tempdir().expect("data dir tempdir");
     let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
         .arg("tui")
@@ -638,6 +646,112 @@ fn tui_auto_spawns_a_daemon_when_none_is_running() {
     assert!(
         !stderr.contains("no tcode daemon found"),
         "must never bail with the old start-one-yourself message: {stderr}"
+    );
+
+    let Some(addr) = std::fs::read_to_string(data_dir.path().join("trusty-code/http_addr"))
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    else {
+        // The default port was already taken; see this test's docs.
+        return;
+    };
+
+    let health: serde_json::Value = reqwest::get(format!("http://{addr}/health"))
+        .await
+        .expect("the spawned daemon must still be serving /health after the TUI exited")
+        .json()
+        .await
+        .expect("/health must return JSON");
+    assert_eq!(health["status"], "ok");
+    assert_eq!(
+        health["binding"]["state"], "projectless",
+        "a projectless TUI must have spawned a projectless daemon: {health}"
+    );
+
+    let pid = health["pid"].as_u64().expect("/health must report a pid") as libc::pid_t;
+    // SAFETY: `pid` was just reported by a live daemon this test caused to
+    // start; `kill` has no memory-safety effects.
+    unsafe {
+        libc::kill(pid, libc::SIGTERM);
+    }
+}
+
+/// A daemon bound to a DIFFERENT project must be refused, not attached to:
+/// auto-attach picks daemons up off a well-known address, so without this
+/// check a TUI launched in project B drives project A's daemon and every
+/// session lands in the wrong repository (#4512).
+///
+/// Driven end-to-end against the REAL binary on both sides — a genuine
+/// `tcode serve --http --project A` daemon on an OS-assigned port, and a real
+/// `tcode tui --project B` pointed at it.
+#[tokio::test]
+async fn tui_refuses_a_daemon_bound_to_a_different_project() {
+    use std::io::BufRead;
+
+    let their_project = tempfile::tempdir().expect("their project");
+    let our_project = tempfile::tempdir().expect("our project");
+    let daemon_data = tempfile::tempdir().expect("daemon data dir");
+    let tui_data = tempfile::tempdir().expect("tui data dir");
+
+    let mut daemon = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .args(["serve", "--http", "--port", "0", "--project"])
+        .arg(their_project.path())
+        .env("TRUSTY_DATA_DIR_OVERRIDE", daemon_data.path())
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .expect("spawn tcode serve --http");
+
+    // `run_http` prints `listening on http://127.0.0.1:<port>` to stderr as
+    // soon as it binds — the only place the OS-assigned port is reported.
+    let mut reader = std::io::BufReader::new(daemon.stderr.take().expect("daemon stderr"));
+    let url = loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).expect("read daemon stderr") == 0 {
+            panic!("daemon exited before reporting its address");
+        }
+        if let Some(idx) = line.find("http://") {
+            break line[idx..].trim().to_string();
+        }
+    };
+
+    let output = Command::new(env!("CARGO_BIN_EXE_tcode"))
+        .arg("tui")
+        .arg("--project")
+        .arg(our_project.path())
+        .env("TRUSTY_DATA_DIR_OVERRIDE", tui_data.path())
+        .env("TCODE_DAEMON_URL", &url)
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("spawn tcode tui");
+    daemon.kill().expect("stop the test daemon");
+    daemon.wait().expect("reap the test daemon");
+
+    assert!(
+        !output.status.success(),
+        "must exit nonzero on a binding mismatch: {output:?}"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let theirs = their_project
+        .path()
+        .canonicalize()
+        .expect("canonicalize theirs");
+    let ours = our_project
+        .path()
+        .canonicalize()
+        .expect("canonicalize ours");
+    assert!(
+        stderr.contains(&theirs.display().to_string())
+            && stderr.contains(&ours.display().to_string()),
+        "error must name BOTH projects: {stderr}"
+    );
+    assert!(
+        !tui_data
+            .path()
+            .join("trusty-code/tui-spawned-daemon.log")
+            .exists(),
+        "must not start a competing daemon: {stderr}"
     );
 }
 

--- a/docs/specs/DOC-50-tcode-tui-claude-code-clone.md
+++ b/docs/specs/DOC-50-tcode-tui-claude-code-clone.md
@@ -286,6 +286,12 @@ The CodeEngine communicates with a long-lived `tcode serve --http` daemon (defau
    - An unreachable `TCODE_DAEMON_URL` is an ERROR, not a spawn — the operator
      named an address, and starting a daemon at a different one would ignore
      that instruction.
+   - **BINDING CHECK (#4512):** a daemon binds exactly one project for its whole
+     life, and `GET /health` now publishes it. A discovered daemon whose binding
+     differs from the TUI's `--project` (in either direction, including
+     projectless-vs-bound) is REFUSED with an error naming both projects — never
+     attached to, and never replaced by a competing daemon on a port already in
+     use.
 
 3. **CodeEngine struct:**
    ```rust
@@ -358,13 +364,20 @@ belongs to trusty-memory).
     projectless. Readiness is awaited via
     `trusty_common::daemon_guard::spin_until_ready`, raced against the child's
     exit so a daemon that fails to bind reports that immediately.
-  - **Ownership:** a daemon the TUI spawned is OWNED by the TUI and stopped on
-    exit — SIGTERM plus a grace period so axum drains in-flight requests (the
-    connection-safe restart convention, #534), escalating to SIGKILL only if it
-    ignores SIGTERM. A pre-existing daemon the TUI merely attached to is NEVER
-    killed on exit.
+  - **Lifetime: the TUI NEVER stops the daemon** — not even one it started.
+    Per the owner directive of 2026-08-01 the daemon owns PM lifecycle, agent
+    dispatch, and agent communication; CLIs and TUIs *attach* to it, so a
+    client quitting must not destroy live PM or agent work. There is no
+    ownership tracking, no exit-time SIGTERM, and no `kill_on_drop`. A daemon
+    the TUI spawned keeps running afterwards exactly like one started by hand.
+    Quiescence-gated idle exit — a daemon that stops itself once it has no
+    attached clients AND no active PM/agent sessions, allowing safe
+    upgrades/restarts that preserve running sessions — is separate follow-up
+    work and is NOT part of this slice.
   - An unreachable-but-explicitly-set `TCODE_DAEMON_URL` is an error, not a
     spawn.
+  - A daemon whose reported project binding differs from the TUI's is refused
+    (§3.4 binding check).
 
   Implementation: `crates/trusty-code/src/cli/daemon_autospawn.rs`.
 - Streaming chat input/output (assistant responses render in real time).
@@ -387,8 +400,10 @@ belongs to trusty-memory).
 **Acceptance criteria (MVP):**
 - `tcode tui` command exists and launches the REPL.
 - (#4512) `tcode tui` starts a daemon when none is running, attaches to one that
-  is already running, stops only a daemon it started itself, and errors rather
-  than spawning when `TCODE_DAEMON_URL` names an unreachable address.
+  is already running and serving the same project, leaves the daemon running on
+  exit no matter which process started it, and errors rather than spawning when
+  `TCODE_DAEMON_URL` names an unreachable address or when the daemon it found is
+  bound to a different project.
 - User types a prompt, presses Enter, the daemon's response streams to the TUI.
 - `/help` shows a list of slash commands.
 - Scrollback works (Up-arrow, mouse-wheel, Page-up/down).

--- a/docs/specs/DOC-50-tcode-tui-claude-code-clone.md
+++ b/docs/specs/DOC-50-tcode-tui-claude-code-clone.md
@@ -279,9 +279,13 @@ The CodeEngine communicates with a long-lived `tcode serve --http` daemon (defau
 
 2. **Daemon lookup sequence:**
    - Check env var `TCODE_DAEMON_URL` (highest priority).
-   - Read `~/.trusty-code/daemon.json`; validate daemon is alive (http GET /?ping or HEAD / → 200).
-   - If not alive or missing, skip (Phase 2: auto-spawn or fallback).
-   - For MVP: bail with "No daemon found; start one with `tcode daemon --project <path>`" (documented limitation).
+   - Read the discovery file; validate the daemon is alive (`GET /health` → 2xx).
+   - **AUTO-SPAWN (#4512):** if the discovery file is missing or names a dead
+     daemon, start `tcode serve --http` (with `--project <path>` when the TUI
+     has one) and wait for it to answer `/health`. See §4.1.
+   - An unreachable `TCODE_DAEMON_URL` is an ERROR, not a spawn — the operator
+     named an address, and starting a daemon at a different one would ignore
+     that instruction.
 
 3. **CodeEngine struct:**
    ```rust
@@ -306,7 +310,12 @@ The CodeEngine communicates with a long-lived `tcode serve --http` daemon (defau
    - Reconnect on 502/503 (daemon restart) or timeout; user sees "Connection lost" status.
    - No local `--stdio` child spawned (daemon is independent).
 
-**MVP Known Limitation:** "tcode tui assumes a running `tcode serve --http` daemon on localhost:7881; see `tcode daemon --project <path>` to start one." Discovery/auto-spawn is Phase 2.
+**RESOLVED (#4512):** this section previously carried an MVP known limitation —
+"tcode tui assumes a running `tcode serve --http` daemon on localhost:7881" with
+auto-spawn deferred to Phase 2. That limitation is GONE: `tcode tui` starts its
+own daemon when none is running (see §4.1). The port reference above was also
+stale — the implemented default is `serve::DEFAULT_HTTP_PORT` = **7882** (7881
+belongs to trusty-memory).
 
 ### 3.5 Step 5: Add widgets and render layer (trusty-tui)
 
@@ -332,6 +341,32 @@ The CodeEngine communicates with a long-lived `tcode serve --http` daemon (defau
 **Goal:** A working, shippable tcode TUI that does the core loop: user types a prompt, the daemon runs an agent, the TUI streams the output.
 
 **Features:**
+- **Daemon auto-spawn (#4512 — AMENDED after the original MVP cut).** Auto-spawn
+  was listed under "OUT of scope (Phase 2+)" when this section was written, and
+  `tcode tui` shipped (#4424, PR #4433) exiting with an actionable "start
+  `tcode serve --http` first" message when no daemon answered. The owner
+  directive of 2026-07-31 overturned that deferral: requiring a human to
+  hand-start a background service before an interactive command works is not a
+  shippable first-run experience. The behaviour is now:
+  - Discovery order is unchanged: `TCODE_DAEMON_URL`, then the `http_addr`
+    discovery file, each verified with a `GET /health` liveness ping.
+  - A live daemon is ATTACHED to — nothing is spawned.
+  - A missing or stale discovery file causes `tcode serve --http` to be spawned
+    as a child (binary resolved via `std::env::current_exe()`, so a locally
+    built binary spawns itself, never a stale `PATH` copy), with
+    `--project <path>` forwarded when the TUI has one and OMITTED when it is
+    projectless. Readiness is awaited via
+    `trusty_common::daemon_guard::spin_until_ready`, raced against the child's
+    exit so a daemon that fails to bind reports that immediately.
+  - **Ownership:** a daemon the TUI spawned is OWNED by the TUI and stopped on
+    exit — SIGTERM plus a grace period so axum drains in-flight requests (the
+    connection-safe restart convention, #534), escalating to SIGKILL only if it
+    ignores SIGTERM. A pre-existing daemon the TUI merely attached to is NEVER
+    killed on exit.
+  - An unreachable-but-explicitly-set `TCODE_DAEMON_URL` is an error, not a
+    spawn.
+
+  Implementation: `crates/trusty-code/src/cli/daemon_autospawn.rs`.
 - Streaming chat input/output (assistant responses render in real time).
 - Input composer (multi-line, history, line editing).
 - Slash commands: `/clear` (clear scrollback), `/help` (list commands), `/quit` or Ctrl-D (exit), `/workstream list` (list workstreams), `/workstream activate <id>` (switch workstream).
@@ -351,6 +386,9 @@ The CodeEngine communicates with a long-lived `tcode serve --http` daemon (defau
 
 **Acceptance criteria (MVP):**
 - `tcode tui` command exists and launches the REPL.
+- (#4512) `tcode tui` starts a daemon when none is running, attaches to one that
+  is already running, stops only a daemon it started itself, and errors rather
+  than spawning when `TCODE_DAEMON_URL` names an unreachable address.
 - User types a prompt, presses Enter, the daemon's response streams to the TUI.
 - `/help` shows a list of slash commands.
 - Scrollback works (Up-arrow, mouse-wheel, Page-up/down).


### PR DESCRIPTION
Closes #4512

## What changed

`tcode tui` now starts its own daemon when none is running, instead of exiting
with a "start `tcode serve --http` first" message — and it **never stops that
daemon**, no matter which process started it.

Discovery order is **unchanged** — `TCODE_DAEMON_URL`, then the `http_addr`
discovery file, each verified with a `GET /health` ping. What changes is what
happens around it:

| Situation | Behavior |
|---|---|
| Live daemon found, same project | Attach. |
| Live daemon found, **different** project | **Error** naming both projects. No attach, no competing spawn. |
| Live daemon that can't report a binding | **Error** — fail closed; restart it. |
| Discovery file stale or absent | Spawn `tcode serve --http`, wait for `/health`. |
| `TCODE_DAEMON_URL` set but unreachable | **Error** naming the URL. Never spawn. |

`--project` is forwarded to a spawned daemon when the TUI has one, and omitted
for a projectless session, so the daemon's binding matches the TUI's.

## The daemon outlives every client

Per the owner directive of 2026-08-01: the tcode daemon owns PM lifecycle,
agent dispatch, and agent communication; CLIs and TUIs **attach** to it. A
client quitting must therefore never end live PM or agent work.

So the TUI signals the daemon on exit under **no** circumstance — not even one
it started itself. There is no ownership tracking, no exit-time SIGTERM, and no
`kill_on_drop`. A daemon `tcode tui` spawned keeps running afterwards exactly
like one started by hand.

An earlier revision of this PR did the opposite (SIGTERM + 5s grace for a
daemon the TUI had spawned). That is removed, not disabled: `Ownership`,
`Ownership::Spawned(Child)`, the `DaemonSession` wrapper and its `shutdown`,
`terminate()`, `SHUTDOWN_GRACE`, and `kill_on_drop(true)` are all deleted, and
`ensure_daemon` returns a plain URL. The two tests that asserted teardown are
deleted; `shutdown_leaves_a_pre_existing_daemon_running` became
`the_tui_never_signals_the_daemon_on_exit`, which asserts the universal rule
for **both** a daemon we spawned and a pre-existing one, against real
processes, after everything `ensure_daemon_with` returned has been dropped.

**Quiescence-gated idle exit is NOT in this PR.** A daemon that stops itself
once it has no attached clients *and* no active PM/agent sessions — and that
supports safe upgrades/restarts preserving running sessions — is follow-up work
needing its own lease/refcount design. No leases, refcounts, or idle timers are
introduced here. The interim state (a spawned daemon lingers) is strictly safer
than killing one that is mid-dispatch.

## Project binding is now reported and verified

A pre-existing gap that auto-attach makes dangerous: a daemon binds exactly one
`ProjectBinding` at `build_router` time and holds it for its whole life, but
`/health` reported only `{server, version, status}`. Auto-attach picks daemons
up off a well-known address, so a TUI launched in project B would silently
drive project A's daemon — every session, index, and file operation landing in
the wrong repository.

- **Server:** `health_payload` gained `pid` and `binding`, **additive** —
  `server`/`version`/`status` are byte-identical, so existing probes keep
  working. `binding` reuses the `{state, root}` wire shape `Session` already
  serialises rather than inventing a second spelling. It is threaded from
  `build_router`/`run_http` into `HttpState` rather than resolved per request,
  because the binding is immutable for the daemon's lifetime.
- **Client:** `lookup_daemon` parses it into a `ReportedBinding`;
  `ensure_daemon` compares it against the client's own (already-canonicalized)
  project and refuses a mismatch — no attach, and deliberately **no** fallback
  to spawning a competing daemon on a port that is already in use. The error
  names both projects and three ways forward.

**A projectless client against a project-bound daemon (and the reverse) is a
mismatch.** Projectless is a deliberate, first-class state — chat/planning with
no index, no diff target, no project-scoped memory. Attaching a projectless TUI
to a bound daemon would silently grant it a project the operator never named,
which is exactly the implicit-binding bug `ProjectBinding` exists to prevent;
attaching a project-bound TUI to a projectless daemon would silently withdraw
the indexing and git affordances the operator explicitly asked for. Neither is
repairable after the fact, because the daemon's binding is fixed at its
startup. Both are refused.

**A daemon too old to report a binding is refused too — fail closed.** The
whole point of the check is that an unverified project is how work lands in the
wrong repository, and "old build" is no evidence that its project is right. The
remedy (restart it) is in the message.

## Reuse over reimplementation (common-entry-point check)

- `cli::tcode_exe::resolve` — `std::env::current_exe()`, so a locally built
  binary spawns **itself**, never a stale `PATH` copy. Reused as-is.
- `trusty_common::daemon_guard::spin_until_ready` — issue #985's single tested
  readiness spinner. Reused rather than adding a fourth hand-rolled poll loop,
  raced against `Child::wait` so a daemon that fails to bind reports that
  immediately instead of spinning out the 20s budget.
- `tui_client::build_http_client` — promoted to `pub` so the probe client
  shares the engine's pool settings instead of diverging.
- `ProjectBinding`'s own `Serialize`/`Deserialize` — the health payload writes
  it and `ReportedBinding::from_health` reads it, so the reader can never drift
  from the writer.
- `daemon_guard::spawn_current_exe` was deliberately **not** reused: it null-s
  the child's output, which would make a failed daemon startup undiagnosable.

New reusable logic lives in `cli::daemon_autospawn` (a `pub` module), not
inline in `tui.rs`, so `tcode attach`/`run-task` can adopt the same policy
later.

## Verified by running

Real `./target/debug/tcode`, `TRUSTY_DATA_DIR_OVERRIDE` isolating discovery.

**(a) TUI spawns a daemon; TUI exits; daemon still running and still serving.**

```
$ TRUSTY_DATA_DIR_OVERRIDE=$D ./target/debug/tcode tui < /dev/null
✓ the tcode daemon ready (0s)
tcode tui: Device not configured (os error 6)      # no TTY — expected
tui exit=3

$ ps -o pid,ppid,stat,command -p $(lsof -nP -iTCP:7882 -sTCP:LISTEN -t)
  PID  PPID STAT COMMAND
48500     1 S    .../target/debug/tcode serve --http      # PPID 1: reparented, alive

$ curl -s http://127.0.0.1:7882/health
{"binding":{"root":null,"state":"projectless"},"pid":48500,"server":"tcode","status":"ok","version":"0.3.0"}
```

**(b) Pre-existing daemon untouched on exit** (second run, same data dir):

```
tcode tui: Device not configured (os error 6)
tui exit=3
$ ls $D/trusty-code/                 # no tui-spawned-daemon.log => nothing spawned
http_addr
$ ps -o pid,ppid,stat,command -p 48500
48500     1 S    .../tcode serve --http
$ curl -s http://127.0.0.1:7882/health
{"binding":{"root":null,"state":"projectless"},"pid":48500,...,"status":"ok",...}
```

**(c) Binding mismatch refused**, both against the projectless daemon above and
against a real `tcode serve --http --port 0 --project A`:

```
$ TCODE_DAEMON_URL=http://127.0.0.1:54326 ./target/debug/tcode tui --project $PB
tcode tui: the tcode daemon at http://127.0.0.1:54326 serves a different project
than this TUI: daemon = /private/var/.../tmp.jxy3czuUhn, requested =
/private/var/.../tmp.EkASG2VGZe. `tcode tui` will not attach to it (every session
would run against the wrong project) and will not start a competing daemon on a
port that is already in use. Either relaunch this TUI against
/private/var/.../tmp.jxy3czuUhn, or stop that daemon and let this one start its
own, or point `TCODE_DAEMON_URL` at a daemon serving /private/var/.../tmp.EkASG2VGZe.
exit=3
$ ls $D3                             # empty: no competing daemon spawned
```

**What a human still has to check.** The interactive TUI cannot be driven
headlessly — every run above ends at `Device not configured (os error 6)`,
crossterm failing to enter the alternate screen without a TTY. That failure is
*after* daemon resolution, so it does not weaken (a)/(b)/(c): the exit is
exactly the moment a teardown would have fired. Still unverified by machine:
**quitting the REPL from inside a real terminal**. A human should run
`tcode tui` in a real terminal with no daemon running, quit with `/quit`, and
confirm `curl http://127.0.0.1:7882/health` still answers afterwards.

## Tests

10 unit cases in `cli::daemon_autospawn` drive **real child processes** and a
real `wiremock` `/health` endpoint through every branch — attach (bound and
projectless), spawn (with and without `--project`), refuse-for-an-explicit-URL,
refuse-on-a-project-mismatch, refuse-both-projectless-directions,
refuse-an-unreportable-daemon, die-on-startup, and the never-signal rule — plus
`ReportedBinding` parsing/description cases in `discovery`, two `health_payload`
binding cases in `serve::methods`, one in `serve::http_tests`, and three
real-binary e2e cases in `cli_e2e.rs` (including a genuine
`tcode serve --http --project A` vs `tcode tui --project B` mismatch, and an
assertion that a TUI-spawned daemon is still serving `/health` after the TUI
exited). `TRUSTY_DATA_DIR_OVERRIDE` isolates discovery so a developer's running
daemon cannot turn a "nothing running" case into an attach.

```
$ cargo test -p trusty-code
test result: ok. 1596 passed; 0 failed; 4 ignored   (lib)
test result: ok. 21 passed; 0 failed; 0 ignored     (bin tcode)
test result: ok. 18 passed; 0 failed; 0 ignored     (cli_e2e)
... all other suites ok, 0 failed
```

The 4 ignored are pre-existing live-API tests (`requires OPENROUTER_API_KEY`).

```
$ cargo fmt --check                                        -> clean (exit 0)
$ cargo clippy -p trusty-code --all-targets -- -D warnings  -> exit 0
$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.
```

Production files stay under the 500-SLOC cap; tests are split into the sibling
`daemon_autospawn_tests.rs` following the `engine.rs`/`engine_tests.rs` pattern.

## Docs and changelog

- **DOC-50** §3.4's lookup sequence rewritten and given the binding check; its
  "MVP Known Limitation" marked resolved (and its stale `localhost:7881`
  corrected — the implemented default is `DEFAULT_HTTP_PORT` = 7882; 7881 is
  trusty-memory). §4.1 carries the full behavior, the never-stop-the-daemon
  lifetime rule, the explicit note that quiescence-gated idle exit is out of
  scope, and updated acceptance criteria.
- **Doc comments** on `Command::Tui` (`main.rs`), the `cli::tui` module doc, and
  `cli::daemon_autospawn`'s module doc all previously asserted the teardown
  behavior and are rewritten.
- **Changelog** follows this repo's per-PR fragment convention (#4476):
  `changelog.d/4512-tui-daemon-autospawn.md` describes the final behavior —
  auto-spawn, the never-stop rule, the additive `/health` fields, and the
  binding check. `changelog.d/4476-migrated-added.md`'s now-false "this MVP does
  not auto-spawn a daemon" sentence is corrected in place.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
