### PR TITLE
feat(trusty-agents): per-assistant home dir + OKG store model (#4325)

### DIFF
--- a/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
+++ b/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
@@ -13,9 +13,12 @@ Added
   - `AssistantHome` — the app-generated, DOTLESS, human-browsable home at
     `~/trusty-agents/<instance>/` (override with
     `TAGENT_ASSISTANTS_DIR`), holding `instructions.md`, `config.toml`,
-    `agents/`, `okg/` and `attachments/`. The store path is the owner's,
-    verbatim (2026-08-01): `trusty-agents/<agent>/okg/`, indexed by
-    trusty-search. `ensure()` is additive and idempotent
+    `agents/`, `okg/`, `attachments/` and `stores/`. Both store paths are the
+    owner's, verbatim (2026-08-01): `trusty-agents/<agent>/okg/` (indexed by
+    trusty-search) and `trusty-agents/<agent>/stores/<store-identifier>/` (one
+    subdirectory per remote store). This change creates the `stores/` PARENT
+    only — store-identifier derivation, extraction state and extraction logic
+    belong to a separate spec. `ensure()` is additive and idempotent
     — it creates what is missing and never overwrites what a user edited,
     because #4325 makes external modification expected rather than an error.
   - `AssistantInstanceId` — a validated instance name. It becomes a directory

--- a/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
+++ b/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
@@ -11,9 +11,11 @@ Added
   [#3890](https://github.com/bobmatnyc/trusty-tools/issues/3890)). The new
   module supplies the missing container:
   - `AssistantHome` — the app-generated, DOTLESS, human-browsable home at
-    `~/trusty-agents/assistants/<instance>/` (override with
+    `~/trusty-agents/<instance>/` (override with
     `TAGENT_ASSISTANTS_DIR`), holding `instructions.md`, `config.toml`,
-    `agents/`, `okg/` and `attachments/`. `ensure()` is additive and idempotent
+    `agents/`, `okg/` and `attachments/`. The store path is the owner's,
+    verbatim (2026-08-01): `trusty-agents/<agent>/okg/`, indexed by
+    trusty-search. `ensure()` is additive and idempotent
     — it creates what is missing and never overwrites what a user edited,
     because #4325 makes external modification expected rather than an error.
   - `AssistantInstanceId` — a validated instance name. It becomes a directory

--- a/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
+++ b/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
@@ -1,0 +1,33 @@
+Added
+
+- **`assistants` — per-assistant home directory + OKG store model (issue
+  [#4325](https://github.com/bobmatnyc/trusty-tools/issues/4325)).** "Assistant"
+  is a TYPE (`[agent] role = "assistant"`); `izzie` and `cto-assistant` are
+  INSTANCES of it, not distinct agent types. Until now nothing modelled the
+  instance half: a persona lived in the shared agents directory, the OKG tree in
+  the flat `<knowledge_dir>/<slug(agent)>` pool addressed by naming convention,
+  and `[[stores]]` had no field naming a per-assistant root at all (the
+  data-model gap recorded in
+  [#3890](https://github.com/bobmatnyc/trusty-tools/issues/3890)). The new
+  module supplies the missing container:
+  - `AssistantHome` — the app-generated, DOTLESS, human-browsable home at
+    `~/trusty-agents/assistants/<instance>/` (override with
+    `TAGENT_ASSISTANTS_DIR`), holding `instructions.md`, `config.toml`,
+    `agents/`, `okg/` and `attachments/`. `ensure()` is additive and idempotent
+    — it creates what is missing and never overwrites what a user edited,
+    because #4325 makes external modification expected rather than an error.
+  - `AssistantInstanceId` — a validated instance name. It becomes a directory
+    name, so it is checked (no separators, no `.`/`..`, no uppercase) and
+    rejected rather than silently slugged.
+  - `assistants::inspect()` — the DETECTION half of #4325's resilience
+    requirement: structured findings for missing / wrong-kind / unreadable /
+    malformed entries, each carrying a remedy, plus `HomeHealth::narration()`
+    as the seam the concierge narrates from
+    ([#4320](https://github.com/bobmatnyc/trusty-tools/issues/4320)).
+- **`[[stores]] root` — the per-assistant OKG tree root.** A new optional,
+  relative, traversal-free path on `AgentStoreBinding`, resolved and confined by
+  `AssistantHome::store_root()` and defaulting to the home's `okg/` directory.
+  `AgentStoreBinding::validate()` reports an absolute or `..`-bearing value as a
+  store problem instead of failing the agent's boot, matching the module's
+  existing fail-soft posture. Existing bindings that omit `root` parse and
+  validate exactly as before.

--- a/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
+++ b/crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md
@@ -36,3 +36,29 @@ Added
   store problem instead of failing the agent's boot, matching the module's
   existing fail-soft posture. Existing bindings that omit `root` parse and
   validate exactly as before.
+- **Assistant home directories are now created at app startup (issue
+  [#4325](https://github.com/bobmatnyc/trusty-tools/issues/4325)).**
+  **User-visible on first launch after upgrading:** `tagent` creates
+  `~/trusty-agents/<instance>/` for each Assistant instance it finds — a
+  directory tree that did not exist before. It is dotless and browsable on
+  purpose. Each creation is logged at `info` (`created assistant home
+  directory`); a home that cannot be created is logged at `warn` with its
+  reason and remedy.
+  - Wired at `runtime::startup::run_startup_init`, alongside the existing
+    bundled-agent deploy and before the `--api`/`--serve` early dispatch, so one
+    call covers the API server, the Tauri GUI (which spawns `--api` as a
+    sidecar), the `start` daemon, the REPL/TUI and every one-shot subcommand.
+    `config` and `mcp-serve` return earlier and are not covered; neither touches
+    an assistant home.
+  - **It cannot fail startup.** `provision_startup_homes()` returns a report,
+    never a `Result` — a read-only `$HOME`, a denied permission, a full disk, or
+    a file left where a directory belongs leaves the app running and degraded,
+    with the problem surfaced through `HomeHealth::narration()`.
+  - Creation only: it makes what is missing and never rewrites a file you
+    edited. Nothing is moved, renamed or cleaned up, and the existing dotted
+    `~/.trusty-agents` tree is untouched — relocating a home needs a migration
+    process that remains future work.
+  - `roster::discover_instances()` decides what counts as an instance:
+    `role = "assistant"` AND either being the base `assistant` or declaring
+    `extends = "assistant"`. `ctrl` declares the role but is the concierge, not
+    a selectable instance, and gets no home.

--- a/crates/trusty-agents/src/assistants/error.rs
+++ b/crates/trusty-agents/src/assistants/error.rs
@@ -1,0 +1,52 @@
+//! Typed errors for the per-assistant home model (#4325).
+//!
+//! Why: The home directory is USER-FACING and externally modified by design
+//! (#4325's "Design Rationale: Visibility and Resilience"), so its failures are
+//! things a concierge has to EXPLAIN, not opaque strings a caller can only
+//! bubble. Matchable variants let the narration layer say "your home directory
+//! has no `$HOME` to hang off" differently from "`izzie/..` is not a legal
+//! instance id" without string-sniffing an `anyhow::Error`.
+//! What: [`AssistantError`] — the errors raised while RESOLVING or CREATING a
+//! home. Errors while INSPECTING an existing home are not errors at all: they
+//! are findings, and live in [`super::health`] instead, because a malformed
+//! home must never fail a caller that only wanted to report on it.
+//! Test: `super::tests::instance_tests::rejects_path_separators`,
+//! `super::tests::home_tests::ensure_is_idempotent`.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// A failure resolving or creating an assistant instance's home directory.
+///
+/// Why/What/Test: see this module's doc comment.
+#[derive(Debug, Error)]
+pub enum AssistantError {
+    /// #4325: the instance id would not be safe as a single directory name.
+    #[error("`{raw}` is not a usable assistant instance id: {reason}")]
+    InvalidInstanceId { raw: String, reason: String },
+
+    /// #4325: no `$HOME`/`$USERPROFILE`, so the dotless assistants root under
+    /// the user's home directory cannot be located.
+    #[error(
+        "cannot locate the assistants root: neither $HOME nor $USERPROFILE is set \
+         (set ${env} to choose one explicitly)"
+    )]
+    NoUserHome { env: &'static str },
+
+    /// #4325: a `[[stores]] root` that would escape the assistant's own home.
+    #[error("store `{store}` declares root `{root}`, which {reason}")]
+    UnconfinedStoreRoot {
+        store: String,
+        root: String,
+        reason: String,
+    },
+
+    /// #4325: creating or seeding one entry of the home failed.
+    #[error("could not create `{}`: {source}", path.display())]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+}

--- a/crates/trusty-agents/src/assistants/health.rs
+++ b/crates/trusty-agents/src/assistants/health.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 
 use super::home::{
     AGENTS_DIR, ATTACHMENTS_DIR, AssistantHome, AssistantHomeConfig, CONFIG_FILE,
-    INSTRUCTIONS_FILE, OKG_DIR,
+    INSTRUCTIONS_FILE, OKG_DIR, STORES_DIR,
 };
 
 /// What is wrong with one entry of an assistant's home.
@@ -179,6 +179,9 @@ pub fn inspect(home: &AssistantHome) -> HomeHealth {
         (AGENTS_DIR, home.agents_dir()),
         (OKG_DIR, home.okg_dir()),
         (ATTACHMENTS_DIR, home.attachments_dir()),
+        // #4325: `stores/` gets the same detection as every other layout
+        // directory (owner, 2026-08-01).
+        (STORES_DIR, home.stores_dir()),
     ] {
         check_dir(entry, &path, &mut issues);
     }

--- a/crates/trusty-agents/src/assistants/health.rs
+++ b/crates/trusty-agents/src/assistants/health.rs
@@ -50,6 +50,11 @@ pub enum HomeIssueKind {
     Unreadable,
     /// The entry was read but its content is not what it must be.
     Malformed,
+    /// #4325: the app tried to create the entry at startup and could not
+    /// (read-only filesystem, permission denied, no space, a file sitting where
+    /// a directory belongs). Startup continues regardless — see
+    /// [`super::provision`].
+    NotCreatable,
 }
 
 impl HomeIssueKind {
@@ -64,6 +69,7 @@ impl HomeIssueKind {
             Self::NotAFile => "not a file",
             Self::Unreadable => "unreadable",
             Self::Malformed => "malformed",
+            Self::NotCreatable => "could not be created",
         }
     }
 }

--- a/crates/trusty-agents/src/assistants/health.rs
+++ b/crates/trusty-agents/src/assistants/health.rs
@@ -1,0 +1,298 @@
+//! Detecting a home directory a user changed from outside (#4325).
+//!
+//! Why: #4325's "Design Rationale: Visibility and Resilience" makes external
+//! modification EXPECTED, not an error condition — users will edit, move,
+//! rename and delete inside a home that is deliberately browsable. The system's
+//! two obligations there are asymmetric and this module implements the first:
+//! it is NOT required to auto-migrate or relocate anything, but it IS required
+//! to DETECT missing or malformed files. The second obligation — the concierge
+//! surfacing the problem CONVERSATIONALLY and walking the user through the fix
+//! — needs a narration seam that #4320 owns; what it needs FROM here is a
+//! structured finding with a reason and a remedy, never a raw error dump.
+//!
+//! What: [`inspect`] walks the five entries [`super::home`] defines and returns
+//! a [`HomeHealth`] — zero or more [`HomeIssue`]s, each naming the entry, the
+//! path, WHAT is wrong ([`HomeIssueKind`]) and WHAT WOULD FIX IT. Inspection
+//! never fails and never repairs: an unreadable file is a finding, not an
+//! `Err`, because a caller that only wanted to report must not be blocked by
+//! the very condition it was reporting on. A missing home short-circuits to a
+//! single finding rather than five, since "you have no home directory" and
+//! "your okg directory is missing" are the same fact told once or five times.
+//!
+//! Test: `super::tests::health_tests` — the whole module.
+
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+use super::home::{
+    AGENTS_DIR, ATTACHMENTS_DIR, AssistantHome, AssistantHomeConfig, CONFIG_FILE,
+    INSTRUCTIONS_FILE, OKG_DIR,
+};
+
+/// What is wrong with one entry of an assistant's home.
+///
+/// Why: the concierge phrases "it is gone" differently from "it is there but I
+/// cannot parse it"; a single "broken" verdict would collapse that distinction
+/// and force the narration layer to sniff strings.
+/// What: the five conditions [`inspect`] can distinguish on a user-owned tree.
+/// Test: `super::tests::health_tests` — the whole module.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HomeIssueKind {
+    /// The whole home directory is absent.
+    HomeMissing,
+    /// One expected entry inside an existing home is absent.
+    Missing,
+    /// An entry that must be a directory is something else (usually a file).
+    NotADirectory,
+    /// An entry that must be a file is something else (usually a directory).
+    NotAFile,
+    /// The entry exists but could not be read (permissions, a broken symlink).
+    Unreadable,
+    /// The entry was read but its content is not what it must be.
+    Malformed,
+}
+
+impl HomeIssueKind {
+    /// A short human phrase for this condition.
+    ///
+    /// Test: `super::tests::health_tests::narration_names_every_issue`.
+    pub fn describe(self) -> &'static str {
+        match self {
+            Self::HomeMissing => "the home directory is missing",
+            Self::Missing => "missing",
+            Self::NotADirectory => "not a directory",
+            Self::NotAFile => "not a file",
+            Self::Unreadable => "unreadable",
+            Self::Malformed => "malformed",
+        }
+    }
+}
+
+/// One detected problem with an assistant's home directory.
+///
+/// Why/What/Test: see this module's doc comment. `remedy` is the whole point of
+/// the struct — a finding a user cannot act on is the raw error dump #4325
+/// (via #4320) rules out.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HomeIssue {
+    /// What is wrong.
+    pub kind: HomeIssueKind,
+    /// The layout entry this concerns (`okg`, `config.toml`, …), or `""` for
+    /// the home itself.
+    pub entry: &'static str,
+    /// The path the finding is about.
+    pub path: PathBuf,
+    /// The specific reason, phrased for a person.
+    pub detail: String,
+    /// What would fix it, phrased as an action the user can take.
+    pub remedy: String,
+}
+
+impl fmt::Display for HomeIssue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "{} — {}. {}",
+            self.path.display(),
+            self.detail,
+            self.remedy
+        )
+    }
+}
+
+/// The result of inspecting one assistant's home directory.
+///
+/// Why/What/Test: see this module's doc comment.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HomeHealth {
+    /// The home that was inspected.
+    pub home: PathBuf,
+    /// Every problem found, in layout order. Empty means healthy.
+    pub issues: Vec<HomeIssue>,
+}
+
+impl HomeHealth {
+    /// Whether the home is intact.
+    ///
+    /// Test: `super::tests::health_tests::a_freshly_ensured_home_is_healthy`.
+    pub fn is_healthy(&self) -> bool {
+        self.issues.is_empty()
+    }
+
+    /// The findings as text a concierge can say out loud.
+    ///
+    /// Why: this is the seam #4325 places here — the narration layer (#4320)
+    /// consumes a REASON plus a REMEDY, so it never has to render a stack of
+    /// `Debug` output at a user. It is a plain rendering, not a decision: the
+    /// concierge is free to rephrase it.
+    /// What: `None` when healthy; otherwise one line per finding, each already
+    /// carrying its own remedy.
+    /// Test: `super::tests::health_tests::narration_names_every_issue`,
+    /// `super::tests::health_tests::a_freshly_ensured_home_is_healthy`.
+    pub fn narration(&self) -> Option<String> {
+        if self.is_healthy() {
+            return None;
+        }
+        let mut out = format!(
+            "The assistant home at {} needs attention:",
+            self.home.display()
+        );
+        for issue in &self.issues {
+            out.push_str("\n- ");
+            out.push_str(&issue.to_string());
+        }
+        Some(out)
+    }
+}
+
+/// Inspect an assistant's home for missing or malformed entries.
+///
+/// Why/What/Test: see this module's doc comment.
+pub fn inspect(home: &AssistantHome) -> HomeHealth {
+    let root = home.path().to_path_buf();
+    if !root.is_dir() {
+        let kind = if root.exists() {
+            HomeIssueKind::NotADirectory
+        } else {
+            HomeIssueKind::HomeMissing
+        };
+        return HomeHealth {
+            issues: vec![HomeIssue {
+                kind,
+                entry: "",
+                path: root.clone(),
+                detail: kind.describe().to_string(),
+                remedy: format!(
+                    "recreate it (the app regenerates the standard layout), or move the \
+                     `{}` directory back if you relocated it",
+                    home.id()
+                ),
+            }],
+            home: root,
+        };
+    }
+
+    let mut issues = Vec::new();
+    check_instructions(home, &mut issues);
+    check_config(home, &mut issues);
+    for (entry, path) in [
+        (AGENTS_DIR, home.agents_dir()),
+        (OKG_DIR, home.okg_dir()),
+        (ATTACHMENTS_DIR, home.attachments_dir()),
+    ] {
+        check_dir(entry, &path, &mut issues);
+    }
+    HomeHealth { home: root, issues }
+}
+
+/// `instructions.md` must exist, be a file, and carry something.
+fn check_instructions(home: &AssistantHome, issues: &mut Vec<HomeIssue>) {
+    let path = home.instructions_path();
+    if let Some(issue) = missing_or_wrong_kind(INSTRUCTIONS_FILE, &path, Kind::File) {
+        issues.push(issue);
+        return;
+    }
+    match std::fs::read_to_string(&path) {
+        Err(err) => issues.push(HomeIssue {
+            kind: HomeIssueKind::Unreadable,
+            entry: INSTRUCTIONS_FILE,
+            path,
+            detail: format!("could not be read ({err})"),
+            remedy: "check its permissions, or replace it with a readable text file".to_string(),
+        }),
+        Ok(body) if body.trim().is_empty() => issues.push(HomeIssue {
+            kind: HomeIssueKind::Malformed,
+            entry: INSTRUCTIONS_FILE,
+            path,
+            detail: "is empty, so this assistant has no instructions of its own".to_string(),
+            remedy: "write what you want this assistant to do, or delete the file to have \
+                     the standard one regenerated"
+                .to_string(),
+        }),
+        Ok(_) => {}
+    }
+}
+
+/// `config.toml` must exist, be a file, and parse as TOML.
+fn check_config(home: &AssistantHome, issues: &mut Vec<HomeIssue>) {
+    let path = home.config_path();
+    if let Some(issue) = missing_or_wrong_kind(CONFIG_FILE, &path, Kind::File) {
+        issues.push(issue);
+        return;
+    }
+    let raw = match std::fs::read_to_string(&path) {
+        Ok(raw) => raw,
+        Err(err) => {
+            issues.push(HomeIssue {
+                kind: HomeIssueKind::Unreadable,
+                entry: CONFIG_FILE,
+                path,
+                detail: format!("could not be read ({err})"),
+                remedy: "check its permissions, or replace it with a readable TOML file"
+                    .to_string(),
+            });
+            return;
+        }
+    };
+    if let Err(err) = toml::from_str::<AssistantHomeConfig>(&raw) {
+        issues.push(HomeIssue {
+            kind: HomeIssueKind::Malformed,
+            entry: CONFIG_FILE,
+            path,
+            detail: format!("is not valid TOML ({})", first_line(&err.to_string())),
+            remedy: "fix the line the error names, or delete the file to have the standard \
+                     one regenerated"
+                .to_string(),
+        });
+    }
+}
+
+/// One of the three layout directories must exist and be a directory.
+fn check_dir(entry: &'static str, path: &Path, issues: &mut Vec<HomeIssue>) {
+    if let Some(issue) = missing_or_wrong_kind(entry, path, Kind::Dir) {
+        issues.push(issue);
+    }
+}
+
+/// Whether an entry is expected to be a file or a directory.
+#[derive(Clone, Copy)]
+enum Kind {
+    File,
+    Dir,
+}
+
+/// The shared "absent, or present as the wrong thing" check.
+fn missing_or_wrong_kind(entry: &'static str, path: &Path, kind: Kind) -> Option<HomeIssue> {
+    let (ok, wrong_kind, noun) = match kind {
+        Kind::File => (path.is_file(), HomeIssueKind::NotAFile, "file"),
+        Kind::Dir => (path.is_dir(), HomeIssueKind::NotADirectory, "directory"),
+    };
+    if ok {
+        return None;
+    }
+    if path.exists() {
+        return Some(HomeIssue {
+            kind: wrong_kind,
+            entry,
+            path: path.to_path_buf(),
+            detail: format!("exists but is not a {noun}"),
+            remedy: format!(
+                "move whatever is there aside so a `{entry}` {noun} can take its place"
+            ),
+        });
+    }
+    Some(HomeIssue {
+        kind: HomeIssueKind::Missing,
+        entry,
+        path: path.to_path_buf(),
+        detail: format!("`{entry}` is missing"),
+        remedy: format!(
+            "restore it if you moved it, or let the app regenerate the standard `{entry}` {noun}"
+        ),
+    })
+}
+
+/// The first line of a multi-line parser message, for a one-line finding.
+fn first_line(message: &str) -> &str {
+    message.lines().next().unwrap_or(message).trim()
+}

--- a/crates/trusty-agents/src/assistants/home.rs
+++ b/crates/trusty-agents/src/assistants/home.rs
@@ -16,6 +16,11 @@
 //! system's obligation is to DETECT that and help ([`super::health`]), never to
 //! defend against it or silently rewrite it.
 //!
+//! The path is the owner's, verbatim (2026-08-01): the store is
+//! `trusty-agents/<agent>/okg/`, so a home is `~/trusty-agents/<instance>/` with
+//! no intervening `assistants/` segment, and that `okg/` tree is the store
+//! trusty-search indexes.
+//!
 //! What: [`assistants_root`] resolves the dotless root holding one home per
 //! instance. [`AssistantHome`] is one instance's home — the five entries
 //! #4325 specifies ([`INSTRUCTIONS_FILE`], [`CONFIG_FILE`], [`AGENTS_DIR`],
@@ -57,13 +62,13 @@ pub const ASSISTANTS_DIR_ENV: &str = "TAGENT_ASSISTANTS_DIR";
 /// — a leading dot would hide it from Finder and from a plain `ls`, which is
 /// the opposite of the decision. The existing dotted `~/.trusty-agents` tree is
 /// app-private config and is untouched by this module.
-/// Test: `super::tests::home_tests::default_root_is_dotless_under_the_user_home`.
-pub const ASSISTANTS_DIR_NAME: &str = "trusty-agents";
-
-/// The subdirectory of [`ASSISTANTS_DIR_NAME`] holding one home per instance.
 ///
-/// Test: `super::tests::home_tests::default_root_is_dotless_under_the_user_home`.
-pub const ASSISTANTS_SUBDIR: &str = "assistants";
+/// It holds one home per instance DIRECTLY — the owner specified the store path
+/// as `trusty-agents/<agent>/okg/` (2026-08-01), so there is no intervening
+/// `assistants/` segment.
+/// Test: `super::tests::home_tests::default_root_is_dotless_under_the_user_home`,
+/// `super::tests::home_tests::okg_store_path_matches_the_owners_spelling`.
+pub const ASSISTANTS_DIR_NAME: &str = "trusty-agents";
 
 /// The instance's own instructions (#4325). Test: `super::tests::home_tests::layout_matches_the_ticket`.
 pub const INSTRUCTIONS_FILE: &str = "instructions.md";
@@ -88,9 +93,9 @@ pub const ATTACHMENTS_DIR: &str = "attachments";
 /// the concierge are the same directory. See [`ASSISTANTS_DIR_NAME`] for why it
 /// is dotless.
 /// What: `$TAGENT_ASSISTANTS_DIR` verbatim when set and non-blank, else
-/// `<user home>/trusty-agents/assistants`. `Err(NoUserHome)` when neither
-/// `$HOME` nor `$USERPROFILE` is set — resolving to the process CWD instead
-/// would scatter user-owned homes wherever the binary happened to start.
+/// `<user home>/trusty-agents`. `Err(NoUserHome)` when neither `$HOME` nor
+/// `$USERPROFILE` is set — resolving to the process CWD instead would scatter
+/// user-owned homes wherever the binary happened to start.
 /// Test: `super::tests::home_tests::default_root_is_dotless_under_the_user_home`,
 /// `super::tests::home_tests::env_override_wins_over_the_user_home`.
 pub fn assistants_root() -> Result<PathBuf, AssistantError> {
@@ -105,9 +110,7 @@ pub fn assistants_root() -> Result<PathBuf, AssistantError> {
         .ok_or(AssistantError::NoUserHome {
             env: ASSISTANTS_DIR_ENV,
         })?;
-    Ok(PathBuf::from(home)
-        .join(ASSISTANTS_DIR_NAME)
-        .join(ASSISTANTS_SUBDIR))
+    Ok(PathBuf::from(home).join(ASSISTANTS_DIR_NAME))
 }
 
 /// One Assistant-type INSTANCE's home directory.

--- a/crates/trusty-agents/src/assistants/home.rs
+++ b/crates/trusty-agents/src/assistants/home.rs
@@ -1,0 +1,365 @@
+//! The app-generated per-assistant home directory (#4325).
+//!
+//! Why: An Assistant INSTANCE owns three things the owner named on 2026-07-30 —
+//! a home directory, an OKG store and a persona — and before this module none
+//! of them were per-instance. A persona sat in the shared agents directory, the
+//! OKG tree sat in a flat `<knowledge_dir>/<slug(agent)>` pool addressed by
+//! naming convention, and `[[stores]]` had no field naming a per-assistant root
+//! at all (#3890's data-model gap, restated as requirement 1 of #4325). Adding
+//! an instance therefore meant adding entries to three shared pools, which is
+//! why the current model reads as "more agent types" rather than "more
+//! instances of one type".
+//!
+//! The home is DOTLESS and human-browsable by deliberate decision (#4325's
+//! "Open Questions Resolved" — confirmed, not open). It is the user's, not the
+//! app's private state: users will edit, rename and delete inside it, and the
+//! system's obligation is to DETECT that and help ([`super::health`]), never to
+//! defend against it or silently rewrite it.
+//!
+//! What: [`assistants_root`] resolves the dotless root holding one home per
+//! instance. [`AssistantHome`] is one instance's home — the five entries
+//! #4325 specifies ([`INSTRUCTIONS_FILE`], [`CONFIG_FILE`], [`AGENTS_DIR`],
+//! [`OKG_DIR`], [`ATTACHMENTS_DIR`]) as typed accessors, plus
+//! [`AssistantHome::ensure`], the app-generated creation the ticket's
+//! "AUTO-CREATED, APP-GENERATED" wording names. `ensure` is additive and
+//! idempotent: it creates what is missing and never overwrites what is there,
+//! because overwriting is precisely the external-change intolerance #4325
+//! rules out. [`AssistantHome::store_root`] resolves a `[[stores]]` binding's
+//! new `root` field against the home, confined inside it.
+//!
+//! Scope: this module OWNS the layout and its creation. It deliberately does
+//! NOT migrate anything out of the existing dotted `~/.trusty-agents` tree
+//! (#4325: "The system is NOT required to auto-migrate or auto-relocate"), and
+//! nothing on the boot path calls [`AssistantHome::ensure`] yet — provisioning
+//! is the caller's deliberate act, exactly like OKG extraction (#4283).
+//!
+//! Test: `super::tests::home_tests` — the whole module.
+
+use std::path::{Component, Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+
+use super::error::AssistantError;
+use super::instance::AssistantInstanceId;
+use crate::stores::AgentStoreBinding;
+
+/// Environment override for the assistants root.
+///
+/// Why: tests, and any operator who keeps the tree somewhere other than their
+/// home directory. Named in the `NoUserHome` error so a user with no `$HOME`
+/// is told the way out rather than just the problem.
+/// Test: `super::tests::home_tests::env_override_wins_over_the_user_home`.
+pub const ASSISTANTS_DIR_ENV: &str = "TAGENT_ASSISTANTS_DIR";
+
+/// The DOTLESS product directory under the user's home (#4325).
+///
+/// Why: the home is user-facing and browsable "just like trusty-mpm-projects"
+/// — a leading dot would hide it from Finder and from a plain `ls`, which is
+/// the opposite of the decision. The existing dotted `~/.trusty-agents` tree is
+/// app-private config and is untouched by this module.
+/// Test: `super::tests::home_tests::default_root_is_dotless_under_the_user_home`.
+pub const ASSISTANTS_DIR_NAME: &str = "trusty-agents";
+
+/// The subdirectory of [`ASSISTANTS_DIR_NAME`] holding one home per instance.
+///
+/// Test: `super::tests::home_tests::default_root_is_dotless_under_the_user_home`.
+pub const ASSISTANTS_SUBDIR: &str = "assistants";
+
+/// The instance's own instructions (#4325). Test: `super::tests::home_tests::layout_matches_the_ticket`.
+pub const INSTRUCTIONS_FILE: &str = "instructions.md";
+
+/// The instance's own configuration, TOML (#4325 owner clarification
+/// 2026-07-29: TOML throughout, no format migration).
+/// Test: `super::tests::home_tests::layout_matches_the_ticket`.
+pub const CONFIG_FILE: &str = "config.toml";
+
+/// Custom agents scoped to this instance (#4325). Test: `super::tests::home_tests::layout_matches_the_ticket`.
+pub const AGENTS_DIR: &str = "agents";
+
+/// This instance's knowledge graph (#4325). Test: `super::tests::home_tests::layout_matches_the_ticket`.
+pub const OKG_DIR: &str = "okg";
+
+/// Binary files attached to this instance's chat (#4325). Test: `super::tests::home_tests::layout_matches_the_ticket`.
+pub const ATTACHMENTS_DIR: &str = "attachments";
+
+/// The dotless root holding one home directory per assistant instance.
+///
+/// Why: one resolver, so a home created by provisioning and a home inspected by
+/// the concierge are the same directory. See [`ASSISTANTS_DIR_NAME`] for why it
+/// is dotless.
+/// What: `$TAGENT_ASSISTANTS_DIR` verbatim when set and non-blank, else
+/// `<user home>/trusty-agents/assistants`. `Err(NoUserHome)` when neither
+/// `$HOME` nor `$USERPROFILE` is set — resolving to the process CWD instead
+/// would scatter user-owned homes wherever the binary happened to start.
+/// Test: `super::tests::home_tests::default_root_is_dotless_under_the_user_home`,
+/// `super::tests::home_tests::env_override_wins_over_the_user_home`.
+pub fn assistants_root() -> Result<PathBuf, AssistantError> {
+    if let Some(dir) = std::env::var_os(ASSISTANTS_DIR_ENV)
+        && !dir.is_empty()
+    {
+        return Ok(PathBuf::from(dir));
+    }
+    let home = std::env::var_os("HOME")
+        .or_else(|| std::env::var_os("USERPROFILE"))
+        .filter(|h| !h.is_empty())
+        .ok_or(AssistantError::NoUserHome {
+            env: ASSISTANTS_DIR_ENV,
+        })?;
+    Ok(PathBuf::from(home)
+        .join(ASSISTANTS_DIR_NAME)
+        .join(ASSISTANTS_SUBDIR))
+}
+
+/// One Assistant-type INSTANCE's home directory.
+///
+/// Why/What/Test: see this module's doc comment. The value is pure path
+/// arithmetic — constructing it touches no filesystem, so a caller can describe
+/// a home that does not exist yet (which is the normal state before
+/// [`Self::ensure`], and a reportable state after a user deletes it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssistantHome {
+    id: AssistantInstanceId,
+    path: PathBuf,
+}
+
+impl AssistantHome {
+    /// The home for `id` under an explicit assistants root.
+    ///
+    /// Why: the injectable form — tests and any caller that already resolved a
+    /// root use this, so [`assistants_root`]'s environment read happens exactly
+    /// once per call chain instead of once per accessor.
+    /// What: `<root>/<id>`. Never touches the filesystem.
+    /// Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn under(root: impl Into<PathBuf>, id: AssistantInstanceId) -> Self {
+        let path = root.into().join(id.as_str());
+        Self { id, path }
+    }
+
+    /// The home for `raw_id` under the resolved [`assistants_root`].
+    ///
+    /// Why: the one-call form for callers that have only a name.
+    /// What: validates `raw_id` ([`AssistantInstanceId::new`]), resolves the
+    /// root, and joins. Never touches the filesystem.
+    /// Test: `super::tests::home_tests::for_instance_validates_the_id`.
+    pub fn for_instance(raw_id: &str) -> Result<Self, AssistantError> {
+        let id = AssistantInstanceId::new(raw_id)?;
+        Ok(Self::under(assistants_root()?, id))
+    }
+
+    /// The instance this home belongs to. Test: `super::tests::home_tests::for_instance_validates_the_id`.
+    pub fn id(&self) -> &AssistantInstanceId {
+        &self.id
+    }
+
+    /// The home directory itself. Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// This instance's instructions file. Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn instructions_path(&self) -> PathBuf {
+        self.path.join(INSTRUCTIONS_FILE)
+    }
+
+    /// This instance's configuration file. Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn config_path(&self) -> PathBuf {
+        self.path.join(CONFIG_FILE)
+    }
+
+    /// Custom agents scoped to this instance. Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn agents_dir(&self) -> PathBuf {
+        self.path.join(AGENTS_DIR)
+    }
+
+    /// This instance's OKG store directory. Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn okg_dir(&self) -> PathBuf {
+        self.path.join(OKG_DIR)
+    }
+
+    /// This instance's chat attachments. Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn attachments_dir(&self) -> PathBuf {
+        self.path.join(ATTACHMENTS_DIR)
+    }
+
+    /// Whether the home directory exists on disk.
+    ///
+    /// Test: `super::tests::home_tests::ensure_creates_the_whole_layout`.
+    pub fn exists(&self) -> bool {
+        self.path.is_dir()
+    }
+
+    /// Resolve a store binding's OKG tree root against this home.
+    ///
+    /// Why: this is #4325 requirement 1 — the per-assistant root the binding
+    /// never had. Without it, `okg://<agent>` resolved only into the SHARED
+    /// `<knowledge_dir>/<slug>` pool, so "each instance carries its own OKG
+    /// store" was a naming convention rather than a path. The result is
+    /// CONFINED under the home: a binding that could name an absolute path or
+    /// climb out with `..` would let one instance's extraction write into
+    /// another's store — the same silent-wrong-target failure
+    /// `crate::stores::binding` exists to prevent.
+    /// What: `Ok(<home>/<root>)` for a declared relative, traversal-free
+    /// `root`; `Ok(<home>/okg)` when `root` is absent (the default layout);
+    /// [`AssistantError::UnconfinedStoreRoot`] for anything absolute, empty, or
+    /// containing a `..`/prefix component.
+    /// Test: `super::tests::store_root_tests` — the whole module.
+    pub fn store_root(&self, binding: &AgentStoreBinding) -> Result<PathBuf, AssistantError> {
+        let Some(declared) = binding
+            .root
+            .as_deref()
+            .map(str::trim)
+            .filter(|r| !r.is_empty())
+        else {
+            return Ok(self.okg_dir());
+        };
+        let unconfined = |reason: &str| AssistantError::UnconfinedStoreRoot {
+            store: binding.name.clone(),
+            root: declared.to_string(),
+            reason: reason.to_string(),
+        };
+        let mut out = self.path.clone();
+        for component in Path::new(declared).components() {
+            match component {
+                Component::Normal(part) => out.push(part),
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    return Err(unconfined(
+                        "climbs out of the assistant's home with `..`; a store root must \
+                         stay inside the home it belongs to",
+                    ));
+                }
+                Component::RootDir | Component::Prefix(_) => {
+                    return Err(unconfined(
+                        "is an absolute path; a store root is relative to the assistant's home",
+                    ));
+                }
+            }
+        }
+        if out == self.path {
+            return Err(unconfined(
+                "names the home directory itself, not a store inside it",
+            ));
+        }
+        Ok(out)
+    }
+
+    /// Create any missing part of the home, seeding the two files (#4325).
+    ///
+    /// Why: "AUTO-CREATED, APP-GENERATED" is the ticket's own wording, and
+    /// "app-generated" was clarified by the owner (2026-07-29) to mean
+    /// ownership of ORIGIN — the app creates it — with NO write-enforcement and
+    /// no narrowing semantics. So this call is additive only: every entry that
+    /// already exists is left exactly as the user left it, including a file
+    /// they emptied or rewrote. Overwriting would make the directory
+    /// app-owned in the sense the owner explicitly ruled out.
+    /// What: creates the home, [`AGENTS_DIR`], [`OKG_DIR`] and
+    /// [`ATTACHMENTS_DIR`], and writes [`INSTRUCTIONS_FILE`] /
+    /// [`CONFIG_FILE`] ONLY when absent. Returns the paths it actually
+    /// created, so a caller can report what it generated rather than guess.
+    /// Idempotent: a second call on an intact home creates nothing.
+    /// Test: `super::tests::home_tests::ensure_creates_the_whole_layout`,
+    /// `super::tests::home_tests::ensure_is_idempotent`,
+    /// `super::tests::home_tests::ensure_never_overwrites_user_edits`.
+    pub fn ensure(&self) -> Result<Created, AssistantError> {
+        let mut created = Created::default();
+        for dir in [
+            self.path.clone(),
+            self.agents_dir(),
+            self.okg_dir(),
+            self.attachments_dir(),
+        ] {
+            if !dir.is_dir() {
+                std::fs::create_dir_all(&dir).map_err(|source| AssistantError::Io {
+                    path: dir.clone(),
+                    source,
+                })?;
+                created.paths.push(dir);
+            }
+        }
+        self.seed(
+            self.instructions_path(),
+            seed_instructions(&self.id),
+            &mut created,
+        )?;
+        self.seed(self.config_path(), seed_config(&self.id), &mut created)?;
+        Ok(created)
+    }
+
+    /// Write `body` to `path` only when nothing is there. See [`Self::ensure`].
+    fn seed(
+        &self,
+        path: PathBuf,
+        body: String,
+        created: &mut Created,
+    ) -> Result<(), AssistantError> {
+        if path.exists() {
+            return Ok(());
+        }
+        std::fs::write(&path, body).map_err(|source| AssistantError::Io {
+            path: path.clone(),
+            source,
+        })?;
+        created.paths.push(path);
+        Ok(())
+    }
+}
+
+/// What one [`AssistantHome::ensure`] call actually generated.
+///
+/// Why: the caller reports "created your home directory" honestly, and a second
+/// run reports nothing rather than repeating itself.
+/// What: the paths created by THIS call, in creation order; empty when the home
+/// was already intact.
+/// Test: `super::tests::home_tests::ensure_is_idempotent`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Created {
+    pub paths: Vec<PathBuf>,
+}
+
+impl Created {
+    /// Whether this call generated nothing. Test: `super::tests::home_tests::ensure_is_idempotent`.
+    pub fn is_empty(&self) -> bool {
+        self.paths.is_empty()
+    }
+}
+
+/// The `config.toml` shape at the root of an assistant's home (#4325).
+///
+/// Why: the ticket puts a `config.toml` in the home, and [`super::health`] has
+/// to tell "malformed" from "fine" — which needs a shape to parse against.
+/// Kept DELIBERATELY minimal and non-authoritative: the agent's behaviour still
+/// comes from `agent.toml`, and this file exists so instance-scoped settings
+/// (#4281's persisted selection, #4282's attached-index list) have a home to
+/// land in without another format decision.
+/// What: `id` plus an optional `display_name`. Unknown keys are IGNORED, not
+/// rejected — a user's hand-added key must never make their home "malformed".
+/// Test: `super::tests::health_tests::tolerates_unknown_config_keys`,
+/// `super::tests::health_tests::reports_malformed_config`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize, Serialize)]
+pub struct AssistantHomeConfig {
+    #[serde(default)]
+    pub id: String,
+    #[serde(default)]
+    pub display_name: Option<String>,
+}
+
+/// The seeded `instructions.md` body for a fresh home.
+fn seed_instructions(id: &AssistantInstanceId) -> String {
+    format!(
+        "# {id}\n\n\
+         Instructions for the `{id}` assistant instance.\n\n\
+         This file is yours to edit. It was generated once, when the home\n\
+         directory was created, and is never rewritten — if it goes missing or\n\
+         cannot be read, the assistant tells you and helps you restore it\n\
+         rather than silently replacing what you wrote.\n"
+    )
+}
+
+/// The seeded `config.toml` body for a fresh home.
+fn seed_config(id: &AssistantInstanceId) -> String {
+    format!(
+        "# Configuration for the `{id}` assistant instance (generated by\n\
+         # trusty-agents, issue #4325). Safe to edit by hand.\n\
+         id = \"{id}\"\n"
+    )
+}

--- a/crates/trusty-agents/src/assistants/home.rs
+++ b/crates/trusty-agents/src/assistants/home.rs
@@ -24,7 +24,8 @@
 //! What: [`assistants_root`] resolves the dotless root holding one home per
 //! instance. [`AssistantHome`] is one instance's home — the five entries
 //! #4325 specifies ([`INSTRUCTIONS_FILE`], [`CONFIG_FILE`], [`AGENTS_DIR`],
-//! [`OKG_DIR`], [`ATTACHMENTS_DIR`]) as typed accessors, plus
+//! [`OKG_DIR`], [`ATTACHMENTS_DIR`]) plus [`STORES_DIR`] (owner, 2026-08-01),
+//! as typed accessors, plus
 //! [`AssistantHome::ensure`], the app-generated creation the ticket's
 //! "AUTO-CREATED, APP-GENERATED" wording names. `ensure` is additive and
 //! idempotent: it creates what is missing and never overwrites what is there,
@@ -86,6 +87,21 @@ pub const OKG_DIR: &str = "okg";
 
 /// Binary files attached to this instance's chat (#4325). Test: `super::tests::home_tests::layout_matches_the_ticket`.
 pub const ATTACHMENTS_DIR: &str = "attachments";
+
+/// One subdirectory per remote store this instance pulls from (owner,
+/// 2026-08-01): `<home>/stores/<store-identifier>/`.
+///
+/// Why: the extraction target and extraction state for a remote store (when it
+/// was last pulled, what came back) need somewhere to live that is per-instance
+/// and per-store. Creating the PARENT here means the slice that defines what
+/// goes inside it does not need a PR just to add a `mkdir`.
+/// What: the directory only. Store-identifier derivation, the extraction-state
+/// record, per-store subdirectories and all extraction logic are deliberately
+/// NOT here — a separate spec defines what lives under
+/// `stores/<store-identifier>/`.
+/// Test: `super::tests::home_tests::layout_matches_the_ticket`,
+/// `super::tests::health_tests::reports_a_deleted_stores_directory`.
+pub const STORES_DIR: &str = "stores";
 
 /// The dotless root holding one home directory per assistant instance.
 ///
@@ -184,6 +200,15 @@ impl AssistantHome {
         self.path.join(ATTACHMENTS_DIR)
     }
 
+    /// The parent of this instance's per-remote-store directories.
+    ///
+    /// Why/What: see [`STORES_DIR`] — this PR creates the parent and nothing
+    /// under it.
+    /// Test: `super::tests::home_tests::layout_matches_the_ticket`.
+    pub fn stores_dir(&self) -> PathBuf {
+        self.path.join(STORES_DIR)
+    }
+
     /// Whether the home directory exists on disk.
     ///
     /// Test: `super::tests::home_tests::ensure_creates_the_whole_layout`.
@@ -255,8 +280,8 @@ impl AssistantHome {
     /// already exists is left exactly as the user left it, including a file
     /// they emptied or rewrote. Overwriting would make the directory
     /// app-owned in the sense the owner explicitly ruled out.
-    /// What: creates the home, [`AGENTS_DIR`], [`OKG_DIR`] and
-    /// [`ATTACHMENTS_DIR`], and writes [`INSTRUCTIONS_FILE`] /
+    /// What: creates the home, [`AGENTS_DIR`], [`OKG_DIR`],
+    /// [`ATTACHMENTS_DIR`] and [`STORES_DIR`], and writes [`INSTRUCTIONS_FILE`] /
     /// [`CONFIG_FILE`] ONLY when absent. Returns the paths it actually
     /// created, so a caller can report what it generated rather than guess.
     /// Idempotent: a second call on an intact home creates nothing.
@@ -270,6 +295,7 @@ impl AssistantHome {
             self.agents_dir(),
             self.okg_dir(),
             self.attachments_dir(),
+            self.stores_dir(),
         ] {
             if !dir.is_dir() {
                 std::fs::create_dir_all(&dir).map_err(|source| AssistantError::Io {

--- a/crates/trusty-agents/src/assistants/instance.rs
+++ b/crates/trusty-agents/src/assistants/instance.rs
@@ -1,0 +1,130 @@
+//! Assistant as a TYPE, and the ids that name its INSTANCES (#4325).
+//!
+//! Why: The owner's 2026-07-30 product model is that "Assistant" is a TYPE and
+//! `izzie` / `cto-assistant` are INSTANCES of it — NOT distinct agent types.
+//! The repo already encodes half of that (`[agent] role = "assistant"` on the
+//! base, `extends = "assistant"` on both named personas) but nothing NAMED the
+//! other half, so every surface that wanted "which assistant is this?" reached
+//! for the raw agent name — an unvalidated string that is about to become a
+//! DIRECTORY NAME under the user's home (see [`super::home`]). A raw name is
+//! not safe in that position: `../..` or `a/b` would place an instance's home
+//! outside the assistants root.
+//! What: [`ASSISTANT_ROLE`] is the type discriminator, [`is_assistant_role`]
+//! the one predicate that reads it, and [`AssistantInstanceId`] is a validated
+//! instance name — the only thing [`super::home::AssistantHome`] accepts.
+//! Validation is REJECTION, never silent slugging: an instance whose home
+//! silently landed under a different name than its `agent.toml` says would be
+//! exactly the "naming coincidence" failure `super::super::stores::binding`
+//! was written to eliminate.
+//! Test: `super::tests::instance_tests` — the whole module.
+
+use std::fmt;
+
+use super::error::AssistantError;
+
+/// The `[agent] role` value that marks a config as an Assistant-TYPE instance.
+///
+/// Why: instance isolation is scoped to assistants; an `engineer` or `ctrl`
+/// agent gets no per-assistant home. Pinning the discriminator in one constant
+/// keeps that scope from drifting into a second hardcoded `"assistant"`.
+/// What: the literal role string used by `assistant/agent.toml` and inherited
+/// by every `extends = "assistant"` overlay.
+/// Test: `super::tests::instance_tests::assistant_role_is_the_type_discriminator`.
+pub const ASSISTANT_ROLE: &str = "assistant";
+
+/// Whether an agent's `[agent] role` makes it an instance of the Assistant type.
+///
+/// Why/What: see [`ASSISTANT_ROLE`]. Comparison is exact — a role of
+/// `assistant-ish` is a different type, not a sloppy spelling of this one.
+/// Test: `super::tests::instance_tests::assistant_role_is_the_type_discriminator`.
+pub fn is_assistant_role(role: &str) -> bool {
+    role == ASSISTANT_ROLE
+}
+
+/// A validated name for one INSTANCE of the Assistant type.
+///
+/// Why: this value becomes a single directory name under the assistants root,
+/// so it must be safe in that position before any filesystem call sees it — see
+/// this module's doc comment for why rejection beats slugging here.
+/// What: a newtype over a `String` that is non-blank, contains only
+/// `[a-z0-9._-]` with at least one alphanumeric, is not `.`/`..`, and holds no
+/// path separator. Construct with [`AssistantInstanceId::new`]; there is no
+/// unchecked constructor, which is what makes the invariant hold everywhere.
+/// Test: `super::tests::instance_tests` — the whole module.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct AssistantInstanceId(String);
+
+impl AssistantInstanceId {
+    /// Validate `raw` as an instance id.
+    ///
+    /// Why: see the type's doc comment — this is the single gate every home
+    /// path goes through.
+    /// What: `Ok(id)` for an acceptable name; otherwise
+    /// [`AssistantError::InvalidInstanceId`] carrying the reason verbatim, so
+    /// the concierge can tell the user WHICH rule the name broke rather than
+    /// "invalid name".
+    /// Test: `super::tests::instance_tests::accepts_the_shipped_instance_names`,
+    /// `super::tests::instance_tests::rejects_path_separators`,
+    /// `super::tests::instance_tests::rejects_dot_names`,
+    /// `super::tests::instance_tests::rejects_blank_and_exotic_characters`.
+    pub fn new(raw: impl Into<String>) -> Result<Self, AssistantError> {
+        let raw: String = raw.into();
+        let name = raw.trim();
+        let invalid = |reason: &str| AssistantError::InvalidInstanceId {
+            raw: raw.clone(),
+            reason: reason.to_string(),
+        };
+
+        if name.is_empty() {
+            return Err(invalid("it is blank"));
+        }
+        if name.len() > MAX_ID_LEN {
+            return Err(invalid(&format!(
+                "it is longer than {MAX_ID_LEN} characters"
+            )));
+        }
+        if name == "." || name == ".." {
+            return Err(invalid(
+                "`.` and `..` name a directory's parent or itself, not an instance",
+            ));
+        }
+        if name.contains('/') || name.contains('\\') {
+            return Err(invalid(
+                "an instance id is ONE directory name, so it may not contain a path separator",
+            ));
+        }
+        if let Some(bad) = name.chars().find(|c| !is_allowed(*c)) {
+            return Err(invalid(&format!(
+                "`{bad}` is not allowed; use lowercase letters, digits, `-`, `_` or `.`"
+            )));
+        }
+        if !name.chars().any(|c| c.is_ascii_alphanumeric()) {
+            return Err(invalid("it contains no letter or digit"));
+        }
+        Ok(Self(name.to_string()))
+    }
+
+    /// The id as a string slice. Test: `super::tests::instance_tests::accepts_the_shipped_instance_names`.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for AssistantInstanceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Longest accepted instance id, well under every filesystem's name limit.
+const MAX_ID_LEN: usize = 64;
+
+/// Characters an instance id may contain.
+///
+/// Why: uppercase is excluded because macOS is case-INSENSITIVE while Linux is
+/// not — `Izzie` and `izzie` would be one home on one machine and two on the
+/// other, which is exactly the silent-divergence class this newtype exists to
+/// prevent.
+fn is_allowed(c: char) -> bool {
+    c.is_ascii_lowercase() || c.is_ascii_digit() || matches!(c, '-' | '_' | '.')
+}

--- a/crates/trusty-agents/src/assistants/mod.rs
+++ b/crates/trusty-agents/src/assistants/mod.rs
@@ -1,0 +1,61 @@
+//! Assistant INSTANCES — per-instance home, OKG store and persona (#4325).
+//!
+//! Why: "Assistant" is a TYPE; `izzie` and `cto-assistant` are INSTANCES of
+//! that type, not distinct agent types (owner, 2026-07-30). The repo already
+//! encoded the type half — `assistant/agent.toml` declares
+//! `[agent] role = "assistant"` and both named personas carry
+//! `extends = "assistant"` — but nothing encoded the INSTANCE half. An
+//! instance's three belongings were spread across shared pools with no
+//! per-instance container: the persona in the shared agents directory, the OKG
+//! tree in the flat `<knowledge_dir>/<slug(agent)>` pool addressed by naming
+//! convention, and `[[stores]]` with no field naming a per-assistant root at
+//! all. That is why adding an instance today looks like adding a type. This
+//! module is the container that was missing, and #4325 is the foundation the
+//! rest of milestone 22 pillar (b) builds on (#4281, #4282, #4283).
+//!
+//! What:
+//! - `instance` — [`ASSISTANT_ROLE`], the type discriminator, and
+//!   [`AssistantInstanceId`], a VALIDATED instance name (it becomes a directory
+//!   name, so it is checked, never silently slugged).
+//! - `home` — [`AssistantHome`]: the app-generated, DOTLESS, human-browsable
+//!   per-instance home holding `instructions.md`, `config.toml`, `agents/`,
+//!   `okg/` and `attachments/`, plus [`AssistantHome::store_root`], which
+//!   resolves a `[[stores]]` binding's new `root` field inside that home
+//!   (#4325 requirement 1 — #3890's data-model gap).
+//! - `health` — [`inspect`]: the DETECTION half of #4325's resilience
+//!   requirement. External modification is expected, so the system reports
+//!   missing/malformed entries with a remedy the concierge can narrate; it
+//!   never auto-migrates and never overwrites.
+//! - `error` — [`AssistantError`], for resolving and creating a home.
+//!   Inspecting one yields findings, not errors.
+//!
+//! Deliberately NOT here: the writable store-config path (#3890), index→OKG
+//! entity extraction (#4283), the attached-index cap (#4282), and any migration
+//! of the existing dotted `~/.trusty-agents` tree — #4325 confirms the dotless
+//! decision but does not require auto-relocation.
+//!
+//! Naming caveat (#4406): two unrelated stores are both called "OKG" — the
+//! trusty-kb markdown entity tree and the trusty-memory knowledge graph. #4325
+//! specifies an `okg/` DIRECTORY inside the home, which only the filesystem
+//! tree can be, so [`home::OKG_DIR`] is that tree. The binding's separate
+//! `palace` field is untouched, so whichever store an ADR later makes canonical
+//! can be bound without changing this layout.
+//!
+//! Test: `tests` — the submodules under `assistants/tests/`.
+
+pub mod error;
+pub mod health;
+pub mod home;
+pub mod instance;
+
+#[cfg(test)]
+mod tests;
+
+pub use error::AssistantError;
+pub use health::{HomeHealth, HomeIssue, HomeIssueKind, inspect};
+pub use home::{
+    AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ASSISTANTS_SUBDIR, ATTACHMENTS_DIR,
+    AssistantHome, AssistantHomeConfig, CONFIG_FILE, Created, INSTRUCTIONS_FILE, OKG_DIR,
+    assistants_root,
+};
+pub use instance::{ASSISTANT_ROLE, AssistantInstanceId, is_assistant_role};

--- a/crates/trusty-agents/src/assistants/mod.rs
+++ b/crates/trusty-agents/src/assistants/mod.rs
@@ -19,9 +19,12 @@
 //!   name, so it is checked, never silently slugged).
 //! - `home` — [`AssistantHome`]: the app-generated, DOTLESS, human-browsable
 //!   per-instance home at `~/trusty-agents/<instance>/`, holding
-//!   `instructions.md`, `config.toml`, `agents/`, `okg/` and `attachments/`.
-//!   The store path is the owner's, verbatim (2026-08-01):
-//!   `trusty-agents/<agent>/okg/`. Plus [`AssistantHome::store_root`], which
+//!   `instructions.md`, `config.toml`, `agents/`, `okg/`, `attachments/` and
+//!   `stores/`. Both paths are the owner's, verbatim (2026-08-01):
+//!   `trusty-agents/<agent>/okg/` and
+//!   `trusty-agents/<agent>/stores/<store-identifier>/` — this module creates
+//!   the `stores/` PARENT only; what lives beneath it is a separate spec.
+//!   Plus [`AssistantHome::store_root`], which
 //!   resolves a `[[stores]]` binding's new `root` field inside that home
 //!   (#4325 requirement 1 — #3890's data-model gap).
 //! - `health` — [`inspect`]: the DETECTION half of #4325's resilience
@@ -32,9 +35,19 @@
 //!   Inspecting one yields findings, not errors.
 //!
 //! Deliberately NOT here: the writable store-config path (#3890), index→OKG
-//! entity extraction (#4283), the attached-index cap (#4282), and any migration
-//! of the existing dotted `~/.trusty-agents` tree — #4325 confirms the dotless
-//! decision but does not require auto-relocation.
+//! entity extraction (#4283), the attached-index cap (#4282), everything under
+//! [`home::STORES_DIR`] (store-identifier derivation, extraction state,
+//! per-store subdirectories, extraction logic — a separate spec owns those),
+//! and any migration of the existing dotted `~/.trusty-agents` tree — #4325
+//! confirms the dotless decision but does not require auto-relocation.
+//!
+//! Ownership, not enforcement: "app-generated" was narrowed by the owner
+//! (2026-07-29) to mean the app OWNS THE ORIGIN of the directory. Access control
+//! is explicitly out of scope — there is no write-enforcement, no floor, no
+//! narrow-only semantics. Users may change anything in here; the system's job is
+//! to notice and help, which is what [`inspect`] is for. TOML is likewise
+//! confirmed, not assumed: `config.toml` stays TOML and no format migration is
+//! in scope.
 //!
 //! Naming caveat (#4406): two unrelated stores are both called "OKG" — the
 //! trusty-kb markdown entity tree and the trusty-memory knowledge graph. #4325
@@ -59,6 +72,7 @@ pub use error::AssistantError;
 pub use health::{HomeHealth, HomeIssue, HomeIssueKind, inspect};
 pub use home::{
     AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ATTACHMENTS_DIR, AssistantHome,
-    AssistantHomeConfig, CONFIG_FILE, Created, INSTRUCTIONS_FILE, OKG_DIR, assistants_root,
+    AssistantHomeConfig, CONFIG_FILE, Created, INSTRUCTIONS_FILE, OKG_DIR, STORES_DIR,
+    assistants_root,
 };
 pub use instance::{ASSISTANT_ROLE, AssistantInstanceId, is_assistant_role};

--- a/crates/trusty-agents/src/assistants/mod.rs
+++ b/crates/trusty-agents/src/assistants/mod.rs
@@ -18,8 +18,10 @@
 //!   [`AssistantInstanceId`], a VALIDATED instance name (it becomes a directory
 //!   name, so it is checked, never silently slugged).
 //! - `home` — [`AssistantHome`]: the app-generated, DOTLESS, human-browsable
-//!   per-instance home holding `instructions.md`, `config.toml`, `agents/`,
-//!   `okg/` and `attachments/`, plus [`AssistantHome::store_root`], which
+//!   per-instance home at `~/trusty-agents/<instance>/`, holding
+//!   `instructions.md`, `config.toml`, `agents/`, `okg/` and `attachments/`.
+//!   The store path is the owner's, verbatim (2026-08-01):
+//!   `trusty-agents/<agent>/okg/`. Plus [`AssistantHome::store_root`], which
 //!   resolves a `[[stores]]` binding's new `root` field inside that home
 //!   (#4325 requirement 1 — #3890's data-model gap).
 //! - `health` — [`inspect`]: the DETECTION half of #4325's resilience
@@ -37,9 +39,11 @@
 //! Naming caveat (#4406): two unrelated stores are both called "OKG" — the
 //! trusty-kb markdown entity tree and the trusty-memory knowledge graph. #4325
 //! specifies an `okg/` DIRECTORY inside the home, which only the filesystem
-//! tree can be, so [`home::OKG_DIR`] is that tree. The binding's separate
-//! `palace` field is untouched, so whichever store an ADR later makes canonical
-//! can be bound without changing this layout.
+//! tree can be, so [`home::OKG_DIR`] is that tree. The owner CONFIRMED that
+//! shape on 2026-08-01 — `trusty-agents/<agent>/okg/`, a store indexed by
+//! trusty-search — so this is no longer an inference. The binding's separate
+//! `palace` field stays untouched, which keeps the trusty-memory leg addressable
+//! without changing this layout.
 //!
 //! Test: `tests` — the submodules under `assistants/tests/`.
 
@@ -54,8 +58,7 @@ mod tests;
 pub use error::AssistantError;
 pub use health::{HomeHealth, HomeIssue, HomeIssueKind, inspect};
 pub use home::{
-    AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ASSISTANTS_SUBDIR, ATTACHMENTS_DIR,
-    AssistantHome, AssistantHomeConfig, CONFIG_FILE, Created, INSTRUCTIONS_FILE, OKG_DIR,
-    assistants_root,
+    AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ATTACHMENTS_DIR, AssistantHome,
+    AssistantHomeConfig, CONFIG_FILE, Created, INSTRUCTIONS_FILE, OKG_DIR, assistants_root,
 };
 pub use instance::{ASSISTANT_ROLE, AssistantInstanceId, is_assistant_role};

--- a/crates/trusty-agents/src/assistants/mod.rs
+++ b/crates/trusty-agents/src/assistants/mod.rs
@@ -31,6 +31,13 @@
 //!   requirement. External modification is expected, so the system reports
 //!   missing/malformed entries with a remedy the concierge can narrate; it
 //!   never auto-migrates and never overwrites.
+//! - `roster` — [`discover_instances`]: which configs are instances of the
+//!   type. `role = "assistant"` alone is not the rule — `ctrl` declares it too
+//!   and is the concierge, not a selectable instance.
+//! - `provision` — [`provision_startup_homes`]: the STARTUP call (owner,
+//!   2026-08-01). Runs on every launch, creates what is missing, and CANNOT
+//!   fail — a home the app cannot create becomes a reported issue with a
+//!   remedy, never a failed boot.
 //! - `error` — [`AssistantError`], for resolving and creating a home.
 //!   Inspecting one yields findings, not errors.
 //!
@@ -64,6 +71,8 @@ pub mod error;
 pub mod health;
 pub mod home;
 pub mod instance;
+pub mod provision;
+pub mod roster;
 
 #[cfg(test)]
 mod tests;
@@ -76,3 +85,8 @@ pub use home::{
     assistants_root,
 };
 pub use instance::{ASSISTANT_ROLE, AssistantInstanceId, is_assistant_role};
+pub use provision::{
+    ProvisionedHome, StartupProvisioning, provision, provision_all, provision_startup_homes,
+    provision_startup_homes_in,
+};
+pub use roster::{ASSISTANT_BASE, discover_instances};

--- a/crates/trusty-agents/src/assistants/provision.rs
+++ b/crates/trusty-agents/src/assistants/provision.rs
@@ -1,0 +1,226 @@
+//! Startup provisioning of assistant home directories (#4325).
+//!
+//! Why: the home is only useful if it EXISTS before anything reaches for it, and
+//! the owner's answer (2026-08-01) is to create it at app startup rather than on
+//! first use. That makes provisioning a boot-path concern, which changes its
+//! risk profile completely: a boot-path filesystem call that can fail is a boot
+//! path that can fail. It must not be. A read-only filesystem, a denied
+//! permission, a full disk, or a user who left a FILE where `okg/` belongs are
+//! all states the app has to start in — degraded and able to explain itself, but
+//! started. So nothing in this module returns `Result`: every failure becomes a
+//! [`HomeIssue`] on the report, which is what the [`super::health`] narration
+//! seam was built for.
+//!
+//! What: [`provision`] provisions ONE instance — `ensure()` then `inspect()`,
+//! never failing. [`provision_all`] runs it across a roster and returns a
+//! [`StartupProvisioning`] the caller logs. Running `inspect` even on the
+//! success path is deliberate: `ensure` reports what it CREATED, not whether the
+//! result is sound, and a home containing a user's malformed `config.toml` is
+//! healthy from `ensure`'s point of view and broken from the user's.
+//!
+//! Idempotence is load-bearing here in a way it was not before. This runs on
+//! EVERY launch, so `ensure`'s never-overwrite semantics are now what stands
+//! between a user's edited `instructions.md` and losing it on next boot — see
+//! `super::tests::provision_tests::repeated_startup_never_disturbs_user_edits`.
+//!
+//! Scope: creation only. No migration, no relocation, no cleanup of anything
+//! already on disk — relocating an existing home needs a migration process the
+//! owner has explicitly deferred.
+//!
+//! Test: `super::tests::provision_tests` — the whole module.
+
+use std::path::{Path, PathBuf};
+
+use super::error::AssistantError;
+use super::health::{HomeHealth, HomeIssue, HomeIssueKind, inspect};
+use super::home::AssistantHome;
+use super::instance::AssistantInstanceId;
+use super::roster::discover_instances;
+
+/// The outcome of provisioning ONE assistant instance's home at startup.
+///
+/// Why/What/Test: see this module's doc comment. There is no error variant —
+/// a failed provision is a report with issues, not an absent report.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProvisionedHome {
+    /// The instance this home belongs to.
+    pub id: AssistantInstanceId,
+    /// The home directory.
+    pub home: PathBuf,
+    /// Paths this launch actually created; empty on every launch after the
+    /// first. Also empty when creation FAILED, even if some entries were made
+    /// before the failure — `ensure` discards its progress record on error, so
+    /// `health` (not this field) is the authority on the resulting state.
+    pub created: Vec<PathBuf>,
+    /// The state of the home AFTER provisioning. Healthy on the happy path.
+    pub health: HomeHealth,
+}
+
+impl ProvisionedHome {
+    /// Whether this launch generated anything.
+    ///
+    /// Why: the startup log should say something the first time and nothing on
+    /// every launch after — a line per boot that never changes is noise.
+    /// Test: `super::tests::provision_tests::second_startup_creates_nothing`.
+    pub fn created_anything(&self) -> bool {
+        !self.created.is_empty()
+    }
+
+    /// Whether the home is usable after provisioning.
+    ///
+    /// Test: `super::tests::provision_tests::startup_creates_a_missing_home`.
+    pub fn is_healthy(&self) -> bool {
+        self.health.is_healthy()
+    }
+}
+
+/// The outcome of startup provisioning across every known instance.
+///
+/// Why/What/Test: see this module's doc comment.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct StartupProvisioning {
+    pub homes: Vec<ProvisionedHome>,
+}
+
+impl StartupProvisioning {
+    /// Every home that came out of provisioning with a problem.
+    ///
+    /// Why: the caller logs these at warn level and the concierge narrates them
+    /// on demand; the healthy ones need no attention.
+    /// Test: `super::tests::provision_tests::startup_survives_a_home_it_cannot_create`.
+    pub fn degraded(&self) -> impl Iterator<Item = &ProvisionedHome> {
+        self.homes.iter().filter(|h| !h.is_healthy())
+    }
+
+    /// Every home this launch actually created something for.
+    ///
+    /// Test: `super::tests::provision_tests::second_startup_creates_nothing`.
+    pub fn newly_created(&self) -> impl Iterator<Item = &ProvisionedHome> {
+        self.homes.iter().filter(|h| h.created_anything())
+    }
+}
+
+/// Provision one instance's home. Never fails.
+///
+/// Why: see this module's doc comment — this is the call that must not be able
+/// to take startup down.
+/// What: `ensure()` then `inspect()`. On an `ensure` failure the reason is
+/// preserved as a leading [`HomeIssueKind::NotCreatable`] issue and inspection
+/// still runs, so the report says both WHY creation failed and WHAT state the
+/// home was left in. `AssistantError`'s message is used verbatim — it is
+/// already written for a person.
+/// Test: `super::tests::provision_tests::startup_creates_a_missing_home`,
+/// `super::tests::provision_tests::startup_survives_a_home_it_cannot_create`,
+/// `super::tests::provision_tests::startup_fills_only_the_gaps`.
+pub fn provision(home: &AssistantHome) -> ProvisionedHome {
+    let (created, failure) = match home.ensure() {
+        Ok(created) => (created.paths, None),
+        Err(err) => (Vec::new(), Some(err)),
+    };
+    let mut health = inspect(home);
+    if let Some(err) = failure {
+        health.issues.insert(0, creation_failure(home, &err));
+    }
+    ProvisionedHome {
+        id: home.id().clone(),
+        home: home.path().to_path_buf(),
+        created,
+        health,
+    }
+}
+
+/// Provision every instance in `roster`, in order. Never fails.
+///
+/// Why: startup knows a set of assistant instances, not one — and a single
+/// unwritable home must not stop the others from being provisioned. Each is
+/// independent.
+/// What: [`provision`] per instance, collected. An empty roster yields an empty
+/// report, which is a normal state (no assistants configured yet).
+/// Test: `super::tests::provision_tests::provisions_every_instance_independently`,
+/// `super::tests::provision_tests::an_empty_roster_is_not_an_error`.
+pub fn provision_all(roster: impl IntoIterator<Item = AssistantHome>) -> StartupProvisioning {
+    StartupProvisioning {
+        homes: roster.into_iter().map(|home| provision(&home)).collect(),
+    }
+}
+
+/// Provision every Assistant instance found in `agent_dirs`, under `root`.
+///
+/// Why: the hermetic core, taking both roots explicitly so tests point at a
+/// tempdir instead of a developer's real `$HOME` — the same
+/// `ensure_bundled_agents_deployed_in` shape this crate already uses for
+/// boot-time provisioning.
+/// What: discovers instances ([`super::roster::discover_instances`]) and
+/// provisions each. Never fails; never logs (the caller decides).
+/// Test: `super::tests::provision_tests::startup_provisions_the_discovered_roster`.
+pub fn provision_startup_homes_in(root: &Path, agent_dirs: &[PathBuf]) -> StartupProvisioning {
+    let roster = discover_instances(agent_dirs)
+        .into_iter()
+        .map(|id| AssistantHome::under(root, id));
+    provision_all(roster)
+}
+
+/// The startup call: provision every Assistant instance's home (#4325).
+///
+/// Why: the owner's answer (2026-08-01) — the home layout exists before
+/// anything needs it, created at app startup. This is the ONE function the boot
+/// path calls, and it is infallible by construction so the boot path cannot
+/// acquire a new way to die. A `$HOME` that cannot be resolved is the one case
+/// with no home to even report against, so it degrades to an empty report plus
+/// a warning.
+/// What: resolves [`super::home::assistants_root`] and
+/// `crate::agents::agents_dir_candidates()`, provisions each discovered
+/// instance, and LOGS — `info` naming what this launch created (first launch
+/// only; silent on every launch after), `warn` per degraded home carrying the
+/// reason and the remedy. Never panics, never returns `Err`.
+/// Test: `super::tests::provision_tests::startup_provisions_the_discovered_roster`
+/// (the hermetic core; this wrapper only adds `$HOME` resolution and logging).
+pub fn provision_startup_homes() -> StartupProvisioning {
+    let root = match super::home::assistants_root() {
+        Ok(root) => root,
+        Err(err) => {
+            tracing::warn!(error = %err, "skipped assistant home provisioning");
+            return StartupProvisioning::default();
+        }
+    };
+    let report = provision_startup_homes_in(&root, &crate::agents::agents_dir_candidates());
+
+    for home in report.newly_created() {
+        tracing::info!(
+            assistant = home.id.as_str(),
+            home = %home.home.display(),
+            created = home.created.len(),
+            "created assistant home directory"
+        );
+    }
+    for home in report.degraded() {
+        for issue in &home.health.issues {
+            tracing::warn!(
+                assistant = home.id.as_str(),
+                path = %issue.path.display(),
+                detail = %issue.detail,
+                remedy = %issue.remedy,
+                "assistant home needs attention"
+            );
+        }
+    }
+    report
+}
+
+/// Turn a failed `ensure()` into a reportable finding.
+///
+/// Why: the error carries the only thing the user needs and `inspect` cannot
+/// recover — WHY the write failed. "Your home directory is missing" is much less
+/// useful than "…because the filesystem is read-only".
+fn creation_failure(home: &AssistantHome, err: &AssistantError) -> HomeIssue {
+    HomeIssue {
+        kind: HomeIssueKind::NotCreatable,
+        entry: "",
+        path: home.path().to_path_buf(),
+        detail: err.to_string(),
+        remedy: "the app started without it, so this assistant's own files are unavailable \
+                 until it is fixed — check the permissions and free space on that path, or \
+                 move aside anything sitting where a directory belongs"
+            .to_string(),
+    }
+}

--- a/crates/trusty-agents/src/assistants/roster.rs
+++ b/crates/trusty-agents/src/assistants/roster.rs
@@ -1,0 +1,128 @@
+//! Which configs are INSTANCES of the Assistant type (#4325).
+//!
+//! Why: startup provisioning needs a roster, and `role = "assistant"` alone is
+//! not it. `ctrl` — the orchestrator/concierge — also declares that role, and it
+//! is emphatically not one of the "multiple Assistant instances" milestone 22
+//! pillar (b) is about: the GUI's null `activeAgentId` MEANS ctrl (Concierge),
+//! so giving it a selectable per-instance home would model the one agent that
+//! is not an instance as if it were. Selecting on the role alone would have
+//! silently provisioned it.
+//!
+//! What: [`discover_instances`] returns the instances found in the agent
+//! directories, under a mechanical rule with no name special-casing — a config
+//! is an instance when it declares `role = "assistant"` AND is either the base
+//! `assistant` itself or declares `extends = "assistant"`. That is the same
+//! lineage the shipped personas already use (`izzie` and `cto-assistant` both
+//! extend the base), and it excludes `ctrl`, which declares the role but
+//! descends from nothing.
+//!
+//! Parsing is PARTIAL and forgiving, matching
+//! `super::super::stores::binding::load_stores`: reading through `AgentConfig`
+//! would demand `[llm]`/`[system_prompt]` be present and valid, which a
+//! directory-package `agent.toml` deliberately omits. A malformed file is
+//! skipped, never fatal — startup provisioning must not care.
+//!
+//! Test: `super::tests::roster_tests` — the whole module.
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use super::instance::{ASSISTANT_ROLE, AssistantInstanceId, is_assistant_role};
+
+/// The base agent every Assistant instance descends from.
+///
+/// Why: the base is both the TYPE's template and, per its own `agent.toml`, a
+/// usable default — so it is an instance as well as the thing instances extend.
+/// Test: `super::tests::roster_tests::the_base_assistant_is_itself_an_instance`.
+pub const ASSISTANT_BASE: &str = ASSISTANT_ROLE;
+
+/// Every Assistant-type INSTANCE discoverable in `agent_dirs`.
+///
+/// Why/What: see this module's doc comment. Results are deduplicated and
+/// sorted, so the startup log is stable across launches rather than reordering
+/// with directory iteration.
+/// What: an id per instance. A config whose name is not a usable instance id
+/// (it would become a directory name) is SKIPPED rather than rejected — an
+/// unrelated agent with an odd name must not stop provisioning the rest.
+/// Test: `super::tests::roster_tests::finds_the_shipped_instances`,
+/// `super::tests::roster_tests::excludes_ctrl_and_non_assistants`,
+/// `super::tests::roster_tests::skips_unparseable_and_unusable_entries`.
+pub fn discover_instances(agent_dirs: &[PathBuf]) -> Vec<AssistantInstanceId> {
+    let mut found: Vec<AssistantInstanceId> = Vec::new();
+    for dir in agent_dirs {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let (name, config) = if path.is_dir() {
+                let package = path.join("agent.toml");
+                if !package.is_file() {
+                    continue;
+                }
+                (file_stem(&path), package)
+            } else if path.extension().is_some_and(|e| e == "toml") {
+                (file_stem(&path), path.clone())
+            } else {
+                continue;
+            };
+            let Some(name) = name else { continue };
+            if !is_instance(&config) {
+                continue;
+            }
+            let Ok(id) = AssistantInstanceId::new(&name) else {
+                continue;
+            };
+            if !found.contains(&id) {
+                found.push(id);
+            }
+        }
+    }
+    found.sort();
+    found
+}
+
+/// Whether the config at `path` describes an Assistant-type instance.
+fn is_instance(path: &Path) -> bool {
+    let Ok(raw) = std::fs::read_to_string(path) else {
+        return false;
+    };
+    let Ok(partial) = toml::from_str::<Partial>(&raw) else {
+        return false;
+    };
+    let agent = partial.agent;
+    if !is_assistant_role(&agent.role) {
+        return false;
+    }
+    // Either the base itself, or something that descends from it. `ctrl`
+    // declares the role but neither is nor extends the base.
+    agent.name == ASSISTANT_BASE || agent.extends.as_deref() == Some(ASSISTANT_BASE)
+}
+
+/// The directory or file-stem name of a roster entry.
+fn file_stem(path: &Path) -> Option<String> {
+    let raw = if path.is_dir() {
+        path.file_name()
+    } else {
+        path.file_stem()
+    };
+    raw.map(|n| n.to_string_lossy().to_string())
+}
+
+/// Just the `[agent]` keys the instance rule needs.
+#[derive(Default, Deserialize)]
+struct Partial {
+    #[serde(default)]
+    agent: PartialAgent,
+}
+
+#[derive(Default, Deserialize)]
+struct PartialAgent {
+    #[serde(default)]
+    name: String,
+    #[serde(default)]
+    role: String,
+    #[serde(default)]
+    extends: Option<String>,
+}

--- a/crates/trusty-agents/src/assistants/tests/health_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/health_tests.rs
@@ -1,0 +1,155 @@
+//! Detection of externally-changed assistant homes (#4325).
+//!
+//! Why: #4325 makes external modification EXPECTED and requires DETECTION plus
+//! a remedy the concierge can narrate. Every test here is one thing a user can
+//! actually do to their own directory.
+//! What: healthy baseline, then each condition — home deleted, entry deleted,
+//! entry replaced by the wrong kind, config corrupted, instructions emptied —
+//! and the narration seam that carries them.
+//! Test: this module IS the test surface.
+
+use super::home_tests::temp_home;
+use crate::assistants::{HomeIssueKind, inspect};
+
+#[test]
+fn a_freshly_ensured_home_is_healthy() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    let health = inspect(&home);
+    assert!(health.is_healthy(), "issues: {:?}", health.issues);
+    assert_eq!(health.narration(), None);
+}
+
+/// Why: "you have no home directory" is ONE fact. Reporting it five times (once
+/// per missing entry) is the raw dump #4325 rules out.
+#[test]
+fn a_missing_home_is_one_finding_not_five() {
+    let (_tmp, home) = temp_home();
+    let health = inspect(&home);
+    assert_eq!(health.issues.len(), 1, "issues: {:?}", health.issues);
+    assert_eq!(health.issues[0].kind, HomeIssueKind::HomeMissing);
+    assert!(!health.issues[0].remedy.is_empty());
+}
+
+#[test]
+fn reports_a_deleted_layout_directory() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::remove_dir_all(home.okg_dir()).unwrap();
+
+    let health = inspect(&home);
+    assert_eq!(health.issues.len(), 1, "issues: {:?}", health.issues);
+    let issue = &health.issues[0];
+    assert_eq!(issue.kind, HomeIssueKind::Missing);
+    assert_eq!(issue.entry, "okg");
+    assert_eq!(issue.path, home.okg_dir());
+}
+
+#[test]
+fn reports_a_deleted_instructions_file() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::remove_file(home.instructions_path()).unwrap();
+
+    let health = inspect(&home);
+    assert_eq!(health.issues.len(), 1, "issues: {:?}", health.issues);
+    assert_eq!(health.issues[0].kind, HomeIssueKind::Missing);
+    assert_eq!(health.issues[0].entry, "instructions.md");
+}
+
+/// Why: a user who replaces `okg/` with a note file has not "deleted" it — the
+/// remedy differs, so the finding must too.
+#[test]
+fn reports_an_entry_of_the_wrong_kind() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::remove_dir_all(home.agents_dir()).unwrap();
+    std::fs::write(home.agents_dir(), "not a directory").unwrap();
+
+    let health = inspect(&home);
+    let issue = health
+        .issues
+        .iter()
+        .find(|i| i.entry == "agents")
+        .expect("agents finding");
+    assert_eq!(issue.kind, HomeIssueKind::NotADirectory);
+    assert!(issue.detail.contains("not a directory"), "was: {issue}");
+}
+
+#[test]
+fn reports_malformed_config() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::write(home.config_path(), "id = \"izzie\"\nthis is not toml [[[\n").unwrap();
+
+    let health = inspect(&home);
+    let issue = health
+        .issues
+        .iter()
+        .find(|i| i.entry == "config.toml")
+        .expect("config finding");
+    assert_eq!(issue.kind, HomeIssueKind::Malformed);
+    assert!(issue.detail.contains("not valid TOML"), "was: {issue}");
+    assert!(!issue.remedy.is_empty());
+    // One line, not a multi-line parser dump.
+    assert!(!issue.detail.contains('\n'), "was: {issue}");
+}
+
+/// Why: a hand-added key is a user personalising their own file, not a defect.
+/// Calling it malformed would train users to distrust the detector.
+#[test]
+fn tolerates_unknown_config_keys() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::write(
+        home.config_path(),
+        "id = \"izzie\"\nfavourite_colour = \"green\"\n",
+    )
+    .unwrap();
+    assert!(inspect(&home).is_healthy());
+}
+
+#[test]
+fn reports_emptied_instructions() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::write(home.instructions_path(), "   \n").unwrap();
+
+    let health = inspect(&home);
+    let issue = health
+        .issues
+        .iter()
+        .find(|i| i.entry == "instructions.md")
+        .expect("instructions finding");
+    assert_eq!(issue.kind, HomeIssueKind::Malformed);
+    assert!(issue.detail.contains("empty"), "was: {issue}");
+}
+
+/// Why: the narration seam is what #4320's conversational surface consumes —
+/// every finding must reach it with its remedy attached.
+#[test]
+fn narration_names_every_issue() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::remove_dir_all(home.okg_dir()).unwrap();
+    std::fs::remove_file(home.config_path()).unwrap();
+
+    let health = inspect(&home);
+    let narration = health.narration().expect("unhealthy home narrates");
+    assert!(narration.contains(&home.path().display().to_string()));
+    for issue in &health.issues {
+        assert!(
+            narration.contains(&issue.remedy),
+            "narration dropped a remedy: {narration}"
+        );
+    }
+    assert_eq!(HomeIssueKind::Missing.describe(), "missing");
+    assert_eq!(HomeIssueKind::Unreadable.describe(), "unreadable");
+    assert_eq!(HomeIssueKind::NotAFile.describe(), "not a file");
+    assert_eq!(
+        HomeIssueKind::HomeMissing.describe(),
+        "the home directory is missing"
+    );
+    assert_eq!(HomeIssueKind::Malformed.describe(), "malformed");
+    assert_eq!(HomeIssueKind::NotADirectory.describe(), "not a directory");
+}

--- a/crates/trusty-agents/src/assistants/tests/health_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/health_tests.rs
@@ -45,6 +45,43 @@ fn reports_a_deleted_layout_directory() {
     assert_eq!(issue.path, home.okg_dir());
 }
 
+/// Why: `stores/` (owner, 2026-08-01) gets the SAME detection as every other
+/// layout directory — a user who deletes it must be told, not silently left
+/// with nowhere for a remote store's extraction state to land.
+#[test]
+fn reports_a_deleted_stores_directory() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::remove_dir_all(home.stores_dir()).unwrap();
+
+    let health = inspect(&home);
+    assert_eq!(health.issues.len(), 1, "issues: {:?}", health.issues);
+    let issue = &health.issues[0];
+    assert_eq!(issue.kind, HomeIssueKind::Missing);
+    assert_eq!(issue.entry, "stores");
+    assert_eq!(issue.path, home.stores_dir());
+    assert!(!issue.remedy.is_empty());
+}
+
+/// Why: `stores/` holds one subdirectory per remote store. Whatever a later
+/// spec puts in there is the user's and the extractor's, so inspection must
+/// look at the directory itself and never at its contents.
+#[test]
+fn ignores_whatever_lives_under_stores() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::create_dir_all(home.stores_dir().join("some-remote-store")).unwrap();
+    std::fs::write(
+        home.stores_dir()
+            .join("some-remote-store")
+            .join("state.json"),
+        "{not even valid json",
+    )
+    .unwrap();
+
+    assert!(inspect(&home).is_healthy());
+}
+
 #[test]
 fn reports_a_deleted_instructions_file() {
     let (_tmp, home) = temp_home();

--- a/crates/trusty-agents/src/assistants/tests/home_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/home_tests.rs
@@ -1,7 +1,8 @@
 //! Layout, resolution and app-generated creation of an assistant home (#4325).
 //!
-//! Why: the layout is a product decision the ticket states literally (five
-//! entries, dotless, TOML config), and `ensure` is the "AUTO-CREATED,
+//! Why: the layout is a product decision stated literally — the ticket's five
+//! entries plus `stores/` (owner, 2026-08-01), dotless, TOML config — and
+//! `ensure` is the "AUTO-CREATED,
 //! APP-GENERATED" half — its additive-only behaviour is what makes external
 //! edits safe, so it is pinned rather than assumed.
 //! What: layout accessors, root resolution (default + env override), and the
@@ -15,7 +16,7 @@ use serial_test::serial;
 
 use crate::assistants::{
     AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ATTACHMENTS_DIR, AssistantHome,
-    AssistantHomeConfig, AssistantInstanceId, CONFIG_FILE, INSTRUCTIONS_FILE, OKG_DIR,
+    AssistantHomeConfig, AssistantInstanceId, CONFIG_FILE, INSTRUCTIONS_FILE, OKG_DIR, STORES_DIR,
     assistants_root,
 };
 
@@ -65,8 +66,9 @@ pub(super) fn temp_home() -> (tempfile::TempDir, AssistantHome) {
     (tmp, home)
 }
 
-/// Why: #4325 names the five entries literally; this is the layout contract
-/// every later issue (#4282, #4283) resolves against.
+/// Why: #4325 names its five entries literally and the owner added `stores/`
+/// on 2026-08-01; this is the layout contract every later issue (#4282, #4283,
+/// the OKG Sources spec) resolves against.
 #[test]
 fn layout_matches_the_ticket() {
     let (_tmp, home) = temp_home();
@@ -78,6 +80,9 @@ fn layout_matches_the_ticket() {
     assert_eq!(home.agents_dir(), root.join(AGENTS_DIR));
     assert_eq!(home.okg_dir(), root.join(OKG_DIR));
     assert_eq!(home.attachments_dir(), root.join(ATTACHMENTS_DIR));
+    // #4325 (owner, 2026-08-01): one subdirectory per remote store lives under
+    // `stores/`. This PR creates the parent only.
+    assert_eq!(home.stores_dir(), root.join(STORES_DIR));
     // Constructing a home must not touch the filesystem.
     assert!(!home.exists());
 }
@@ -140,6 +145,15 @@ fn okg_store_path_matches_the_owners_spelling() {
         home.okg_dir(),
         tmp.path().join("trusty-agents").join("izzie").join("okg")
     );
+    // `<trusty-agents home>/<agent>/stores/` — the parent of the per-remote-store
+    // directories, same owner message.
+    assert_eq!(
+        home.stores_dir(),
+        tmp.path()
+            .join("trusty-agents")
+            .join("izzie")
+            .join("stores")
+    );
 }
 
 #[test]
@@ -157,13 +171,25 @@ fn ensure_creates_the_whole_layout() {
     let (_tmp, home) = temp_home();
     let created = home.ensure().expect("ensure");
     assert!(home.exists());
-    for path in [home.agents_dir(), home.okg_dir(), home.attachments_dir()] {
+    for path in [
+        home.agents_dir(),
+        home.okg_dir(),
+        home.attachments_dir(),
+        home.stores_dir(),
+    ] {
         assert!(path.is_dir(), "{} should be a directory", path.display());
     }
+    // The parent only — nothing is created beneath `stores/`; a separate spec
+    // defines what `stores/<store-identifier>/` holds.
+    assert_eq!(
+        std::fs::read_dir(home.stores_dir()).unwrap().count(),
+        0,
+        "stores/ must ship empty"
+    );
     for path in [home.instructions_path(), home.config_path()] {
         assert!(path.is_file(), "{} should be a file", path.display());
     }
-    assert_eq!(created.paths.len(), 6, "created: {:?}", created.paths);
+    assert_eq!(created.paths.len(), 7, "created: {:?}", created.paths);
 
     // The seeded config parses back into the shape health checks against, and
     // carries the instance id.

--- a/crates/trusty-agents/src/assistants/tests/home_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/home_tests.rs
@@ -14,9 +14,9 @@ use std::path::{Path, PathBuf};
 use serial_test::serial;
 
 use crate::assistants::{
-    AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ASSISTANTS_SUBDIR, ATTACHMENTS_DIR,
-    AssistantHome, AssistantHomeConfig, AssistantInstanceId, CONFIG_FILE, INSTRUCTIONS_FILE,
-    OKG_DIR, assistants_root,
+    AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ATTACHMENTS_DIR, AssistantHome,
+    AssistantHomeConfig, AssistantInstanceId, CONFIG_FILE, INSTRUCTIONS_FILE, OKG_DIR,
+    assistants_root,
 };
 
 /// RAII guard setting or clearing a process env var for one test body.
@@ -59,7 +59,9 @@ impl Drop for EnvVarGuard {
 pub(super) fn temp_home() -> (tempfile::TempDir, AssistantHome) {
     let tmp = tempfile::tempdir().expect("tempdir");
     let id = AssistantInstanceId::new("izzie").expect("valid id");
-    let home = AssistantHome::under(tmp.path().join("assistants"), id);
+    // A throwaway root standing in for `~/trusty-agents`; the real spelling is
+    // pinned by `okg_store_path_matches_the_owners_spelling`.
+    let home = AssistantHome::under(tmp.path().join("trusty-agents"), id);
     (tmp, home)
 }
 
@@ -84,7 +86,7 @@ fn layout_matches_the_ticket() {
 /// the whole point of instance isolation.
 #[test]
 fn two_instances_get_separate_homes() {
-    let root = PathBuf::from("/assistants");
+    let root = PathBuf::from("/trusty-agents");
     let izzie = AssistantHome::under(&root, AssistantInstanceId::new("izzie").unwrap());
     let cto = AssistantHome::under(&root, AssistantInstanceId::new("cto-assistant").unwrap());
     assert_ne!(izzie.path(), cto.path());
@@ -112,13 +114,31 @@ fn default_root_is_dotless_under_the_user_home() {
     let _no_override = EnvVarGuard::clear(ASSISTANTS_DIR_ENV);
     let _home = EnvVarGuard::set("HOME", tmp.path());
     let root = assistants_root().expect("HOME is set");
-    assert_eq!(
-        root,
-        tmp.path().join(ASSISTANTS_DIR_NAME).join(ASSISTANTS_SUBDIR)
-    );
+    assert_eq!(root, tmp.path().join(ASSISTANTS_DIR_NAME));
     assert!(
         !ASSISTANTS_DIR_NAME.starts_with('.'),
         "the assistants root must be visible, not hidden"
+    );
+}
+
+/// Why: the owner specified the store path literally on 2026-08-01 —
+/// `trusty-agents/<agent>/okg/`. An intervening `assistants/` segment (the
+/// spelling this PR originally carried) would make every path the OKG Sources
+/// spec is written against wrong, so the full absolute path is pinned here
+/// rather than only the accessors.
+#[test]
+#[serial]
+fn okg_store_path_matches_the_owners_spelling() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _no_override = EnvVarGuard::clear(ASSISTANTS_DIR_ENV);
+    let _home = EnvVarGuard::set("HOME", tmp.path());
+
+    let home = AssistantHome::for_instance("izzie").expect("valid id");
+
+    assert_eq!(home.path(), tmp.path().join("trusty-agents").join("izzie"));
+    assert_eq!(
+        home.okg_dir(),
+        tmp.path().join("trusty-agents").join("izzie").join("okg")
     );
 }
 

--- a/crates/trusty-agents/src/assistants/tests/home_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/home_tests.rs
@@ -1,0 +1,207 @@
+//! Layout, resolution and app-generated creation of an assistant home (#4325).
+//!
+//! Why: the layout is a product decision the ticket states literally (five
+//! entries, dotless, TOML config), and `ensure` is the "AUTO-CREATED,
+//! APP-GENERATED" half — its additive-only behaviour is what makes external
+//! edits safe, so it is pinned rather than assumed.
+//! What: layout accessors, root resolution (default + env override), and the
+//! three `ensure` properties: it creates everything, it repeats nothing, and it
+//! overwrites nothing.
+//! Test: this module IS the test surface.
+
+use std::path::{Path, PathBuf};
+
+use serial_test::serial;
+
+use crate::assistants::{
+    AGENTS_DIR, ASSISTANTS_DIR_ENV, ASSISTANTS_DIR_NAME, ASSISTANTS_SUBDIR, ATTACHMENTS_DIR,
+    AssistantHome, AssistantHomeConfig, AssistantInstanceId, CONFIG_FILE, INSTRUCTIONS_FILE,
+    OKG_DIR, assistants_root,
+};
+
+/// RAII guard setting or clearing a process env var for one test body.
+///
+/// Mirrors the crate's established `#[serial]` + guard convention (see
+/// `workflow::engine::executor::tests::checkpoint_resume`).
+pub(super) struct EnvVarGuard {
+    key: &'static str,
+    prev: Option<String>,
+}
+
+impl EnvVarGuard {
+    pub(super) fn set(key: &'static str, value: &Path) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: serialized against other env-mutating tests by `#[serial]`.
+        unsafe { std::env::set_var(key, value) };
+        Self { key, prev }
+    }
+
+    pub(super) fn clear(key: &'static str) -> Self {
+        let prev = std::env::var(key).ok();
+        // SAFETY: as above.
+        unsafe { std::env::remove_var(key) };
+        Self { key, prev }
+    }
+}
+
+impl Drop for EnvVarGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.prev {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+/// A home for `izzie` under a throwaway root.
+pub(super) fn temp_home() -> (tempfile::TempDir, AssistantHome) {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let id = AssistantInstanceId::new("izzie").expect("valid id");
+    let home = AssistantHome::under(tmp.path().join("assistants"), id);
+    (tmp, home)
+}
+
+/// Why: #4325 names the five entries literally; this is the layout contract
+/// every later issue (#4282, #4283) resolves against.
+#[test]
+fn layout_matches_the_ticket() {
+    let (_tmp, home) = temp_home();
+    let root = home.path().to_path_buf();
+    assert!(root.ends_with("izzie"), "home is <root>/<instance>");
+    assert_eq!(home.id().as_str(), "izzie");
+    assert_eq!(home.instructions_path(), root.join(INSTRUCTIONS_FILE));
+    assert_eq!(home.config_path(), root.join(CONFIG_FILE));
+    assert_eq!(home.agents_dir(), root.join(AGENTS_DIR));
+    assert_eq!(home.okg_dir(), root.join(OKG_DIR));
+    assert_eq!(home.attachments_dir(), root.join(ATTACHMENTS_DIR));
+    // Constructing a home must not touch the filesystem.
+    assert!(!home.exists());
+}
+
+/// Why: two instances of the same TYPE must not share a directory — that is
+/// the whole point of instance isolation.
+#[test]
+fn two_instances_get_separate_homes() {
+    let root = PathBuf::from("/assistants");
+    let izzie = AssistantHome::under(&root, AssistantInstanceId::new("izzie").unwrap());
+    let cto = AssistantHome::under(&root, AssistantInstanceId::new("cto-assistant").unwrap());
+    assert_ne!(izzie.path(), cto.path());
+    assert_ne!(izzie.okg_dir(), cto.okg_dir());
+    assert_eq!(izzie.okg_dir(), root.join("izzie").join(OKG_DIR));
+    assert_eq!(cto.okg_dir(), root.join("cto-assistant").join(OKG_DIR));
+}
+
+#[test]
+fn for_instance_validates_the_id() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _guard = EnvVarGuard::set(ASSISTANTS_DIR_ENV, tmp.path());
+    assert!(AssistantHome::for_instance("../escape").is_err());
+    let home = AssistantHome::for_instance("izzie").expect("valid id");
+    assert_eq!(home.id().as_str(), "izzie");
+    assert_eq!(home.path(), tmp.path().join("izzie"));
+}
+
+/// Why: DOTLESS is a confirmed product decision (#4325 "Open Questions
+/// Resolved"), so a stray leading dot is a regression, not a style change.
+#[test]
+#[serial]
+fn default_root_is_dotless_under_the_user_home() {
+    let tmp = tempfile::tempdir().unwrap();
+    let _no_override = EnvVarGuard::clear(ASSISTANTS_DIR_ENV);
+    let _home = EnvVarGuard::set("HOME", tmp.path());
+    let root = assistants_root().expect("HOME is set");
+    assert_eq!(
+        root,
+        tmp.path().join(ASSISTANTS_DIR_NAME).join(ASSISTANTS_SUBDIR)
+    );
+    assert!(
+        !ASSISTANTS_DIR_NAME.starts_with('.'),
+        "the assistants root must be visible, not hidden"
+    );
+}
+
+#[test]
+#[serial]
+fn env_override_wins_over_the_user_home() {
+    let tmp = tempfile::tempdir().unwrap();
+    let elsewhere = tmp.path().join("elsewhere");
+    let _home = EnvVarGuard::set("HOME", tmp.path());
+    let _override = EnvVarGuard::set(ASSISTANTS_DIR_ENV, &elsewhere);
+    assert_eq!(assistants_root().unwrap(), elsewhere);
+}
+
+#[test]
+fn ensure_creates_the_whole_layout() {
+    let (_tmp, home) = temp_home();
+    let created = home.ensure().expect("ensure");
+    assert!(home.exists());
+    for path in [home.agents_dir(), home.okg_dir(), home.attachments_dir()] {
+        assert!(path.is_dir(), "{} should be a directory", path.display());
+    }
+    for path in [home.instructions_path(), home.config_path()] {
+        assert!(path.is_file(), "{} should be a file", path.display());
+    }
+    assert_eq!(created.paths.len(), 6, "created: {:?}", created.paths);
+
+    // The seeded config parses back into the shape health checks against, and
+    // carries the instance id.
+    let raw = std::fs::read_to_string(home.config_path()).unwrap();
+    let cfg: AssistantHomeConfig = toml::from_str(&raw).expect("seeded config parses");
+    assert_eq!(cfg.id, "izzie");
+}
+
+#[test]
+fn ensure_is_idempotent() {
+    let (_tmp, home) = temp_home();
+    assert!(!home.ensure().unwrap().is_empty());
+    let second = home.ensure().expect("second ensure");
+    assert!(second.is_empty(), "created again: {:?}", second.paths);
+}
+
+/// Why: #4325 makes external modification EXPECTED. A `ensure` that restored
+/// its own seed over a user's edit would be the intolerance the ticket rules
+/// out — and would silently destroy work.
+#[test]
+fn ensure_never_overwrites_user_edits() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::write(home.instructions_path(), "MY OWN INSTRUCTIONS\n").unwrap();
+    std::fs::write(home.config_path(), "id = \"izzie\"\nmine = true\n").unwrap();
+    std::fs::write(home.okg_dir().join("note.md"), "kept").unwrap();
+
+    home.ensure().expect("re-ensure");
+
+    assert_eq!(
+        std::fs::read_to_string(home.instructions_path()).unwrap(),
+        "MY OWN INSTRUCTIONS\n"
+    );
+    assert!(
+        std::fs::read_to_string(home.config_path())
+            .unwrap()
+            .contains("mine = true")
+    );
+    assert_eq!(
+        std::fs::read_to_string(home.okg_dir().join("note.md")).unwrap(),
+        "kept"
+    );
+}
+
+/// Why: a user who deletes just one entry must get it back without the rest
+/// being touched — partial repair, not a wholesale regenerate.
+#[test]
+fn ensure_restores_only_what_is_missing() {
+    let (_tmp, home) = temp_home();
+    home.ensure().unwrap();
+    std::fs::write(home.instructions_path(), "kept\n").unwrap();
+    std::fs::remove_dir_all(home.attachments_dir()).unwrap();
+
+    let created = home.ensure().expect("re-ensure");
+
+    assert_eq!(created.paths, vec![home.attachments_dir()]);
+    assert_eq!(
+        std::fs::read_to_string(home.instructions_path()).unwrap(),
+        "kept\n"
+    );
+}

--- a/crates/trusty-agents/src/assistants/tests/instance_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/instance_tests.rs
@@ -1,0 +1,69 @@
+//! `AssistantInstanceId` validation (#4325).
+//!
+//! Why: the id becomes a single directory name under the user's home, so every
+//! rejection here is a path the home model must never be able to take.
+//! What: the accept cases (today's shipped instance names) and each reject rule.
+//! Test: this module IS the test surface.
+
+use crate::assistants::{ASSISTANT_ROLE, AssistantError, AssistantInstanceId, is_assistant_role};
+
+/// Why: `assistant` is the TYPE and `izzie`/`cto-assistant` are INSTANCES of
+/// it — the discriminator is the role, and it is exact.
+#[test]
+fn assistant_role_is_the_type_discriminator() {
+    assert_eq!(ASSISTANT_ROLE, "assistant");
+    assert!(is_assistant_role("assistant"));
+    assert!(!is_assistant_role("engineer"));
+    assert!(!is_assistant_role("assistant-ish"));
+    assert!(!is_assistant_role("Assistant"));
+}
+
+#[test]
+fn accepts_the_shipped_instance_names() {
+    for name in ["assistant", "izzie", "cto-assistant", "bob_kb2", "a.b"] {
+        let id = AssistantInstanceId::new(name).expect("should accept");
+        assert_eq!(id.as_str(), name);
+        assert_eq!(id.to_string(), name);
+    }
+    // Surrounding whitespace is trimmed, not rejected.
+    assert_eq!(
+        AssistantInstanceId::new("  izzie ").unwrap().as_str(),
+        "izzie"
+    );
+}
+
+/// Why: an id containing a separator would place the home somewhere other than
+/// `<assistants_root>/<id>` — the exact escape the newtype exists to stop.
+#[test]
+fn rejects_path_separators() {
+    for name in ["a/b", "a\\b", "../izzie", "/etc/passwd"] {
+        let err = AssistantInstanceId::new(name).expect_err("should reject");
+        assert!(
+            matches!(err, AssistantError::InvalidInstanceId { .. }),
+            "wrong error for {name}: {err}"
+        );
+    }
+}
+
+#[test]
+fn rejects_dot_names() {
+    for name in [".", ".."] {
+        let err = AssistantInstanceId::new(name).expect_err("should reject");
+        assert!(err.to_string().contains("not an instance"), "was: {err}");
+    }
+}
+
+#[test]
+fn rejects_blank_and_exotic_characters() {
+    assert!(AssistantInstanceId::new("").is_err());
+    assert!(AssistantInstanceId::new("   ").is_err());
+    // Uppercase: case-insensitive macOS vs case-sensitive Linux would disagree
+    // about whether `Izzie` and `izzie` are one home or two.
+    assert!(AssistantInstanceId::new("Izzie").is_err());
+    assert!(AssistantInstanceId::new("izzie!").is_err());
+    assert!(AssistantInstanceId::new("izzie bot").is_err());
+    // Punctuation-only has no letter or digit to identify an instance by.
+    assert!(AssistantInstanceId::new("--").is_err());
+    assert!(AssistantInstanceId::new("x".repeat(65)).is_err());
+    assert!(AssistantInstanceId::new("x".repeat(64)).is_ok());
+}

--- a/crates/trusty-agents/src/assistants/tests/mod.rs
+++ b/crates/trusty-agents/src/assistants/tests/mod.rs
@@ -5,10 +5,14 @@
 //! and what the system says when a user changes it from outside.
 //! What: `instance_tests` (id validation), `home_tests` (layout, resolution,
 //! idempotent creation), `store_root_tests` (the new `[[stores]] root` field's
-//! confinement), `health_tests` (detection of missing/malformed entries).
+//! confinement), `health_tests` (detection of missing/malformed entries),
+//! `provision_tests` (startup provisioning, including the failure modes that
+//! must not take startup down), `roster_tests` (which configs are instances).
 //! Test: this module IS the test surface.
 
 mod health_tests;
 mod home_tests;
 mod instance_tests;
+mod provision_tests;
+mod roster_tests;
 mod store_root_tests;

--- a/crates/trusty-agents/src/assistants/tests/mod.rs
+++ b/crates/trusty-agents/src/assistants/tests/mod.rs
@@ -1,0 +1,14 @@
+//! Tests for the per-assistant home + OKG store model (#4325).
+//!
+//! Why: the home is a USER-OWNED directory the app generates, so the two things
+//! worth pinning are the ones a user can break — the layout contract itself,
+//! and what the system says when a user changes it from outside.
+//! What: `instance_tests` (id validation), `home_tests` (layout, resolution,
+//! idempotent creation), `store_root_tests` (the new `[[stores]] root` field's
+//! confinement), `health_tests` (detection of missing/malformed entries).
+//! Test: this module IS the test surface.
+
+mod health_tests;
+mod home_tests;
+mod instance_tests;
+mod store_root_tests;

--- a/crates/trusty-agents/src/assistants/tests/provision_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/provision_tests.rs
@@ -1,0 +1,216 @@
+//! Startup provisioning, happy path and failure modes (#4325).
+//!
+//! Why: this runs on EVERY app launch, so two properties matter more than the
+//! happy path — it must never be able to fail startup, and it must never
+//! disturb a home the user has edited. Both are covered here rather than
+//! assumed from `ensure`'s own tests, because the boot path is where they
+//! actually bite.
+//! What: no home, complete home, partial home, user-edited home, and a home the
+//! app CANNOT create.
+//! Test: this module IS the test surface.
+
+use super::home_tests::temp_home;
+use crate::assistants::{
+    AssistantHome, AssistantInstanceId, HomeIssueKind, provision, provision_all,
+    provision_startup_homes_in,
+};
+
+#[test]
+fn startup_creates_a_missing_home() {
+    let (_tmp, home) = temp_home();
+    assert!(!home.exists(), "precondition: nothing on disk yet");
+
+    let report = provision(&home);
+
+    assert!(home.exists());
+    assert!(report.is_healthy(), "issues: {:?}", report.health.issues);
+    assert!(report.created_anything());
+    assert_eq!(report.id.as_str(), "izzie");
+    assert_eq!(report.home, home.path());
+    assert!(report.health.narration().is_none());
+}
+
+#[test]
+fn second_startup_creates_nothing() {
+    let (_tmp, home) = temp_home();
+    let first = provision(&home);
+    assert!(first.created_anything());
+
+    let second = provision(&home);
+
+    assert!(!second.created_anything(), "created: {:?}", second.created);
+    assert!(second.is_healthy());
+}
+
+/// Why: a user who deleted one directory gets it back; everything else is left
+/// exactly as they left it.
+#[test]
+fn startup_fills_only_the_gaps() {
+    let (_tmp, home) = temp_home();
+    provision(&home);
+    std::fs::write(home.okg_dir().join("kept.md"), "mine").unwrap();
+    std::fs::remove_dir_all(home.attachments_dir()).unwrap();
+
+    let report = provision(&home);
+
+    assert_eq!(report.created, vec![home.attachments_dir()]);
+    assert!(report.is_healthy());
+    assert_eq!(
+        std::fs::read_to_string(home.okg_dir().join("kept.md")).unwrap(),
+        "mine"
+    );
+}
+
+/// Why: THE regression this module could cause. `ensure`'s never-overwrite
+/// semantics used to guard an occasional explicit call; now they stand between
+/// a user's edited files and every single boot.
+#[test]
+fn repeated_startup_never_disturbs_user_edits() {
+    let (_tmp, home) = temp_home();
+    provision(&home);
+    std::fs::write(home.instructions_path(), "MY OWN INSTRUCTIONS\n").unwrap();
+    std::fs::write(home.config_path(), "id = \"izzie\"\nmine = true\n").unwrap();
+
+    for _ in 0..3 {
+        let report = provision(&home);
+        assert!(!report.created_anything());
+        assert!(report.is_healthy());
+    }
+
+    assert_eq!(
+        std::fs::read_to_string(home.instructions_path()).unwrap(),
+        "MY OWN INSTRUCTIONS\n"
+    );
+    assert!(
+        std::fs::read_to_string(home.config_path())
+            .unwrap()
+            .contains("mine = true")
+    );
+}
+
+/// Why: the failure mode that matters. A file sitting where the home directory
+/// belongs makes `create_dir_all` fail — the portable stand-in for a read-only
+/// filesystem or a denied permission, neither of which can be simulated
+/// reliably in CI. Startup must survive it and must say WHY.
+#[test]
+fn startup_survives_a_home_it_cannot_create() {
+    let (_tmp, home) = temp_home();
+    std::fs::create_dir_all(home.path().parent().unwrap()).unwrap();
+    std::fs::write(home.path(), "a file, not a directory").unwrap();
+
+    // The call itself returns — no panic, no Result to unwrap, no early exit.
+    let report = provision(&home);
+
+    assert!(!report.is_healthy());
+    let issue = &report.health.issues[0];
+    assert_eq!(
+        issue.kind,
+        HomeIssueKind::NotCreatable,
+        "the creation failure must lead the report: {:?}",
+        report.health.issues
+    );
+    assert!(!issue.remedy.is_empty());
+    // The reason survives to the narration seam the concierge reads.
+    let narration = report.health.narration().expect("degraded home narrates");
+    assert!(narration.contains(&issue.remedy), "was: {narration}");
+    assert!(!report.created_anything());
+}
+
+/// Why: a home that cannot be created for one instance must not stop the
+/// others — startup provisions each independently.
+#[test]
+fn provisions_every_instance_independently() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = tmp.path().join("trusty-agents");
+    std::fs::create_dir_all(&root).unwrap();
+    // `broken` cannot be created; the other two can.
+    std::fs::write(root.join("broken"), "in the way").unwrap();
+
+    let roster: Vec<AssistantHome> = ["izzie", "broken", "cto-assistant"]
+        .into_iter()
+        .map(|n| AssistantHome::under(&root, AssistantInstanceId::new(n).unwrap()))
+        .collect();
+
+    let report = provision_all(roster);
+
+    assert_eq!(report.homes.len(), 3);
+    assert!(root.join("izzie").join("okg").is_dir());
+    assert!(root.join("cto-assistant").join("okg").is_dir());
+
+    let degraded: Vec<&str> = report.degraded().map(|h| h.id.as_str()).collect();
+    assert_eq!(degraded, vec!["broken"]);
+    let created: Vec<&str> = report.newly_created().map(|h| h.id.as_str()).collect();
+    assert_eq!(created, vec!["izzie", "cto-assistant"]);
+}
+
+#[test]
+fn an_empty_roster_is_not_an_error() {
+    let report = provision_all(Vec::new());
+    assert!(report.homes.is_empty());
+    assert_eq!(report.degraded().count(), 0);
+    assert_eq!(report.newly_created().count(), 0);
+}
+
+/// Why: provisioning creates the layout; it never repairs a file the user
+/// broke. A malformed `config.toml` is reported, not rewritten — rewriting it
+/// would destroy the user's work on the next boot.
+#[test]
+fn startup_reports_but_never_repairs_a_broken_file() {
+    let (_tmp, home) = temp_home();
+    provision(&home);
+    std::fs::write(home.config_path(), "not [[[ toml").unwrap();
+
+    let report = provision(&home);
+
+    assert!(!report.is_healthy());
+    assert!(
+        report
+            .health
+            .issues
+            .iter()
+            .any(|i| i.kind == HomeIssueKind::Malformed && i.entry == "config.toml")
+    );
+    assert_eq!(
+        std::fs::read_to_string(home.config_path()).unwrap(),
+        "not [[[ toml",
+        "provisioning must not rewrite what the user broke"
+    );
+}
+
+/// Why: the hermetic core of the boot-path call — discovery and provisioning
+/// wired together, pointed at a tempdir instead of a real `$HOME`. The `$HOME`
+/// resolution and logging in `provision_startup_homes()` are the only things
+/// this does not cover, deliberately: exercising them would write into the
+/// developer's actual home directory on every `cargo test`.
+#[test]
+fn startup_provisions_the_discovered_roster() {
+    let tmp = tempfile::tempdir().unwrap();
+    let agents = tmp.path().join("agents");
+    let root = tmp.path().join("trusty-agents");
+    std::fs::create_dir_all(agents.join("izzie")).unwrap();
+    std::fs::write(
+        agents.join("izzie").join("agent.toml"),
+        "[agent]\nname = \"izzie\"\nrole = \"assistant\"\nextends = \"assistant\"\n",
+    )
+    .unwrap();
+    // Declares the role but is not an instance — must get no home.
+    std::fs::create_dir_all(agents.join("ctrl")).unwrap();
+    std::fs::write(
+        agents.join("ctrl").join("agent.toml"),
+        "[agent]\nname = \"ctrl\"\nrole = \"assistant\"\n",
+    )
+    .unwrap();
+
+    let report = provision_startup_homes_in(&root, &[agents]);
+
+    assert_eq!(report.homes.len(), 1);
+    assert_eq!(report.homes[0].id.as_str(), "izzie");
+    assert!(root.join("izzie").join("okg").is_dir());
+    assert!(!root.join("ctrl").exists(), "ctrl is not an instance");
+    assert_eq!(report.degraded().count(), 0);
+
+    // Second launch: idempotent, nothing created, still healthy.
+    let second = provision_startup_homes_in(&root, &[tmp.path().join("agents")]);
+    assert_eq!(second.newly_created().count(), 0);
+    assert_eq!(second.degraded().count(), 0);
+}

--- a/crates/trusty-agents/src/assistants/tests/roster_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/roster_tests.rs
@@ -1,0 +1,154 @@
+//! Which configs count as Assistant INSTANCES (#4325).
+//!
+//! Why: startup provisioning acts on this list, so a wrong answer creates
+//! directories for agents that should not have them — `ctrl` above all, which
+//! declares `role = "assistant"` but is the concierge, not a selectable
+//! instance.
+//! What: the shipped lineage (base + `extends`), the exclusions, and the
+//! forgiving-parse behaviour.
+//! Test: this module IS the test surface.
+
+use std::path::{Path, PathBuf};
+
+use crate::assistants::discover_instances;
+
+/// Write a flat `<name>.toml` agent config.
+fn flat(dir: &Path, name: &str, body: &str) {
+    std::fs::create_dir_all(dir).unwrap();
+    std::fs::write(dir.join(format!("{name}.toml")), body).unwrap();
+}
+
+/// Write a package `<name>/agent.toml` agent config.
+fn package(dir: &Path, name: &str, body: &str) {
+    let pkg = dir.join(name);
+    std::fs::create_dir_all(&pkg).unwrap();
+    std::fs::write(pkg.join("agent.toml"), body).unwrap();
+}
+
+fn ids(dirs: &[PathBuf]) -> Vec<String> {
+    discover_instances(dirs)
+        .into_iter()
+        .map(|id| id.as_str().to_string())
+        .collect()
+}
+
+/// Why: this mirrors the real shipped roster — the base plus the two personas
+/// that extend it, which are exactly milestone 22 pillar (b)'s instances.
+#[test]
+fn finds_the_shipped_instances() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_path_buf();
+    package(
+        &dir,
+        "assistant",
+        "[agent]\nname = \"assistant\"\nrole = \"assistant\"\n",
+    );
+    package(
+        &dir,
+        "izzie",
+        "[agent]\nname = \"izzie\"\nrole = \"assistant\"\nextends = \"assistant\"\n",
+    );
+    package(
+        &dir,
+        "cto-assistant",
+        "[agent]\nname = \"cto-assistant\"\nrole = \"assistant\"\nextends = \"assistant\"\n",
+    );
+
+    assert_eq!(ids(&[dir]), vec!["assistant", "cto-assistant", "izzie"]);
+}
+
+/// Why: THE reason this module exists. `ctrl` declares `role = "assistant"`
+/// but neither is nor extends the base — the GUI's null selection MEANS ctrl,
+/// so provisioning it a selectable instance home would model the one agent
+/// that is not an instance as if it were. Selecting on role alone would have
+/// silently included it.
+#[test]
+fn excludes_ctrl_and_non_assistants() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_path_buf();
+    package(
+        &dir,
+        "assistant",
+        "[agent]\nname = \"assistant\"\nrole = \"assistant\"\n",
+    );
+    // Declares the role, descends from nothing.
+    package(
+        &dir,
+        "ctrl",
+        "[agent]\nname = \"ctrl\"\nrole = \"assistant\"\n",
+    );
+    flat(
+        &dir,
+        "engineer",
+        "[agent]\nname = \"engineer\"\nrole = \"engineer\"\n",
+    );
+    // Extends something else entirely.
+    flat(
+        &dir,
+        "gpt-engineer",
+        "[agent]\nname = \"gpt-engineer\"\nrole = \"engineer\"\nextends = \"engineer\"\n",
+    );
+
+    assert_eq!(ids(&[dir]), vec!["assistant"]);
+}
+
+/// Why: a malformed or oddly-named file in the agents directory is a normal
+/// state on a user's machine. It must be skipped, never fatal — startup
+/// provisioning cannot care.
+#[test]
+fn skips_unparseable_and_unusable_entries() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_path_buf();
+    package(
+        &dir,
+        "izzie",
+        "[agent]\nname = \"izzie\"\nrole = \"assistant\"\nextends = \"assistant\"\n",
+    );
+    flat(&dir, "broken", "this is not [[[ toml");
+    // A name that could never be a directory entry of its own.
+    flat(
+        &dir,
+        "Upper",
+        "[agent]\nname = \"Upper\"\nrole = \"assistant\"\nextends = \"assistant\"\n",
+    );
+    // Not a toml file at all, and a directory with no agent.toml.
+    std::fs::write(dir.join("notes.md"), "hi").unwrap();
+    std::fs::create_dir_all(dir.join("empty-pkg")).unwrap();
+
+    assert_eq!(ids(&[dir]), vec!["izzie"]);
+}
+
+#[test]
+fn the_base_assistant_is_itself_an_instance() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path().to_path_buf();
+    flat(
+        &dir,
+        "assistant",
+        "[agent]\nname = \"assistant\"\nrole = \"assistant\"\n",
+    );
+    assert_eq!(ids(&[dir]), vec!["assistant"]);
+}
+
+/// Why: `agents_dir_candidates()` returns several tiers and the same agent can
+/// appear in more than one. One instance means one home, so the list is
+/// deduplicated.
+#[test]
+fn deduplicates_across_directory_tiers() {
+    let tmp = tempfile::tempdir().unwrap();
+    let a = tmp.path().join("a");
+    let b = tmp.path().join("b");
+    let body = "[agent]\nname = \"izzie\"\nrole = \"assistant\"\nextends = \"assistant\"\n";
+    package(&a, "izzie", body);
+    flat(&b, "izzie", body);
+
+    assert_eq!(ids(&[a, b]), vec!["izzie"]);
+}
+
+/// Why: a missing agents directory is normal on a fresh machine.
+#[test]
+fn a_missing_directory_is_not_an_error() {
+    let tmp = tempfile::tempdir().unwrap();
+    assert!(ids(&[tmp.path().join("does-not-exist")]).is_empty());
+    assert!(ids(&[]).is_empty());
+}

--- a/crates/trusty-agents/src/assistants/tests/store_root_tests.rs
+++ b/crates/trusty-agents/src/assistants/tests/store_root_tests.rs
@@ -1,0 +1,105 @@
+//! The new `[[stores]] root` field and its confinement (#4325).
+//!
+//! Why: this is #4325 requirement 1 — "per-assistant root field on
+//! AgentStoreBinding", the data-model gap #3890 recorded. The field only means
+//! "this instance's own store" if it cannot name someone else's, so the reject
+//! cases matter as much as the accept ones.
+//! What: the derived default, an explicit relative root, and every escape a
+//! hand-edited `agent.toml` could attempt.
+//! Test: this module IS the test surface.
+
+use super::home_tests::temp_home;
+use crate::assistants::{AssistantError, OKG_DIR};
+use crate::stores::AgentStoreBinding;
+
+fn binding(root: Option<&str>) -> AgentStoreBinding {
+    AgentStoreBinding {
+        name: "izzie-kb".to_string(),
+        root: root.map(str::to_string),
+        ..Default::default()
+    }
+}
+
+/// Why: the default is what makes "each instance carries its own OKG store"
+/// true without every `agent.toml` having to say so.
+#[test]
+fn omitted_root_defaults_to_the_home_okg_dir() {
+    let (_tmp, home) = temp_home();
+    assert_eq!(home.store_root(&binding(None)).unwrap(), home.okg_dir());
+    // A blank/whitespace root is the same as omitting it, not an error.
+    assert_eq!(
+        home.store_root(&binding(Some("  "))).unwrap(),
+        home.okg_dir()
+    );
+}
+
+#[test]
+fn declared_relative_root_resolves_inside_the_home() {
+    let (_tmp, home) = temp_home();
+    assert_eq!(
+        home.store_root(&binding(Some("okg/personal"))).unwrap(),
+        home.path().join(OKG_DIR).join("personal")
+    );
+    assert_eq!(
+        home.store_root(&binding(Some("./knowledge"))).unwrap(),
+        home.path().join("knowledge")
+    );
+}
+
+/// Why: an instance's store must not be able to name another instance's — the
+/// same silent-wrong-target hazard `stores::binding` refuses to guess at.
+#[test]
+fn rejects_a_root_that_climbs_out_of_the_home() {
+    let (_tmp, home) = temp_home();
+    let err = home
+        .store_root(&binding(Some("../cto-assistant/okg")))
+        .expect_err("must reject");
+    assert!(
+        matches!(err, AssistantError::UnconfinedStoreRoot { .. }),
+        "wrong error: {err}"
+    );
+    assert!(err.to_string().contains("climbs out"), "was: {err}");
+}
+
+#[test]
+fn rejects_an_absolute_root() {
+    let (_tmp, home) = temp_home();
+    let err = home
+        .store_root(&binding(Some("/tmp/okg")))
+        .expect_err("must reject");
+    assert!(err.to_string().contains("absolute path"), "was: {err}");
+}
+
+#[test]
+fn rejects_a_root_that_is_the_home_itself() {
+    let (_tmp, home) = temp_home();
+    let err = home
+        .store_root(&binding(Some(".")))
+        .expect_err("must reject");
+    assert!(
+        err.to_string().contains("home directory itself"),
+        "was: {err}"
+    );
+}
+
+/// Why: the field is new, so an existing `agent.toml` with no `root` must
+/// parse unchanged and validate exactly as before.
+#[test]
+fn root_is_optional_and_validated_in_the_binding() {
+    let existing: AgentStoreBinding =
+        toml::from_str("name = \"bob-kb\"\ntree = \"okg://izzie\"\nindex = \"bob-kb\"").unwrap();
+    assert_eq!(existing.root, None);
+    assert_eq!(existing.validate(), None);
+
+    let with_root: AgentStoreBinding = toml::from_str("name = \"bob-kb\"\nroot = \"okg\"").unwrap();
+    assert_eq!(with_root.root.as_deref(), Some("okg"));
+    assert_eq!(with_root.validate(), None);
+
+    let escaping: AgentStoreBinding =
+        toml::from_str("name = \"bob-kb\"\nroot = \"../elsewhere\"").unwrap();
+    let reason = escaping.validate().expect("must be flagged");
+    assert!(
+        reason.contains("relative to the assistant"),
+        "was: {reason}"
+    );
+}

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_memory_tests.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/persona_memory_tests.rs
@@ -23,6 +23,9 @@ fn binding(palace: Option<&str>) -> StoresConfig {
             tree: Some("okg://izzie".to_string()),
             index: Some("bob-kb".to_string()),
             palace: palace.map(str::to_string),
+            // #4325: no per-assistant home root — these tests exercise the
+            // palace leg, which the new field does not touch.
+            root: None,
         }],
     }
 }

--- a/crates/trusty-agents/src/lib.rs
+++ b/crates/trusty-agents/src/lib.rs
@@ -66,6 +66,9 @@ pub mod adapters {
 
 pub mod agents;
 pub mod api;
+// #4325: per-assistant home directory + OKG store model — "Assistant" is a
+// TYPE, `izzie`/`cto-assistant` are INSTANCES of it, each with its own home.
+pub mod assistants;
 pub mod ast;
 pub mod build_info;
 pub mod bus;

--- a/crates/trusty-agents/src/runtime/startup.rs
+++ b/crates/trusty-agents/src/runtime/startup.rs
@@ -59,8 +59,8 @@ use anyhow::Result;
 
 use super::cli_def::check_credentials_and_warn;
 use crate::{
-    agents, api, build_info, bus, ctrl, logging, mcp, memory, process_tracker, registry, repl,
-    search, session_registry, tools, workflow,
+    agents, api, assistants, build_info, bus, ctrl, logging, mcp, memory, process_tracker,
+    registry, repl, search, session_registry, tools, workflow,
 };
 
 use build_info::BuildInfo;
@@ -171,6 +171,28 @@ pub(super) async fn run_startup_init(_args: &[String]) -> Result<bool> {
     let bundled_agents_report = agents::bundled::ensure_bundled_agents_deployed()
         .inspect_err(|e| tracing::warn!(error = %e, "failed to deploy bundled agents to $HOME"))
         .unwrap_or_default();
+
+    // #4325: create each Assistant INSTANCE's home directory
+    // (`~/trusty-agents/<instance>/`) so the layout exists before anything
+    // reaches for it. Placed here, immediately after the bundled roster is on
+    // disk, for two reasons: the roster is what this enumerates (an instance
+    // with no `agent.toml` yet is not discoverable), and this line runs BEFORE
+    // the `--api`/`--serve` early dispatch below — so one call covers the API
+    // server, the Tauri GUI (which spawns `--api` as a sidecar), the `start`
+    // daemon, the REPL/TUI, and every one-shot subcommand. It does NOT cover
+    // `config` and `mcp-serve`, which return before `run_startup_init` runs;
+    // both are deliberately daemon-less and neither touches an assistant home.
+    //
+    // Unlike the state-dir `create_dir_all` further down, this CANNOT fail the
+    // boot: `provision_startup_homes` returns a report, never a `Result`. A
+    // read-only `$HOME`, a denied permission, or a file left where a directory
+    // belongs is logged with its remedy and the app starts degraded — the same
+    // best-effort posture as the bundled-agent deploy above, and the reason the
+    // sidecar's `cwd=/` EROFS crash cannot recur here (the root resolves from
+    // `$HOME`/`$USERPROFILE`, never the cwd). It creates only what is missing
+    // and never rewrites a file the user edited; there is no migration of the
+    // existing dotted `~/.trusty-agents` tree.
+    let _assistant_homes = assistants::provision_startup_homes();
 
     // #366: Credential onboarding banner. After env loading is the right time
     // to check — both `.env.local` files and the host environment have been

--- a/crates/trusty-agents/src/stores/config.rs
+++ b/crates/trusty-agents/src/stores/config.rs
@@ -59,6 +59,20 @@ pub struct AgentStoreBinding {
     /// Absent = the agent binds no palace (a document-only store).
     #[serde(default)]
     pub palace: Option<String>,
+    /// #4325: where this store's tree lives INSIDE the owning assistant
+    /// instance's home directory, relative to that home. Absent = the home's
+    /// standard `okg/` directory.
+    ///
+    /// Why: before #4325 a binding could name a tree URI but not a per-assistant
+    /// ROOT, so `okg://<agent>` could only ever resolve into the SHARED
+    /// `<knowledge_dir>/<slug>` pool — the data-model gap #3890 recorded. This
+    /// field is what makes "each instance carries its own OKG store" a path
+    /// rather than a naming convention.
+    /// What: a RELATIVE, traversal-free path. It is resolved (and confined)
+    /// by [`crate::assistants::AssistantHome::store_root`], never here — this
+    /// module stays pure serde data.
+    #[serde(default)]
+    pub root: Option<String>,
 }
 
 impl AgentStoreBinding {
@@ -98,10 +112,11 @@ impl AgentStoreBinding {
     /// (not an error type) keeps the reason renderable straight into the GUI
     /// card without a second mapping layer.
     /// What: `Some(reason)` for the first problem found, `None` when the
-    /// binding is usable. Checks: non-blank `name`, non-blank `index`, and
-    /// an `okg://` scheme on any explicitly declared `tree`.
+    /// binding is usable. Checks: non-blank `name`, non-blank `index`, an
+    /// `okg://` scheme on any explicitly declared `tree`, and (#4325) a
+    /// `root` that stays inside the assistant's own home.
     /// Test: `validate_flags_blank_name`, `validate_flags_bad_tree_scheme`,
-    /// `validate_accepts_good_binding`.
+    /// `validate_accepts_good_binding`, `validate_flags_escaping_root`.
     pub fn validate(&self) -> Option<String> {
         if self.name.trim().is_empty() {
             return Some("store binding has a blank `name`".to_string());
@@ -120,8 +135,45 @@ impl AgentStoreBinding {
                 self.name
             ));
         }
+        // #4325: a root that is absolute or climbs out with `..` would let one
+        // instance's store name another instance's directory.
+        if let Some(root) = self
+            .root
+            .as_deref()
+            .map(str::trim)
+            .filter(|r| !r.is_empty())
+            && !is_confined_relative(root)
+        {
+            return Some(format!(
+                "store `{}` declares root `{root}`, which must be relative to the assistant's \
+                 home directory and may not contain `..`",
+                self.name
+            ));
+        }
         None
     }
+}
+
+/// Whether a declared `[[stores]] root` stays inside the assistant's home.
+///
+/// Why: the same rule [`crate::assistants::AssistantHome::store_root`]
+/// enforces when it RESOLVES the path, stated here so a bad value is REPORTED
+/// as a store problem (the module's fail-soft posture) instead of only failing
+/// at resolution time.
+/// What: `true` for a non-empty relative path made of ordinary components;
+/// `false` for anything absolute, prefixed, or containing `..`.
+/// Test: `validate_flags_escaping_root`.
+fn is_confined_relative(root: &str) -> bool {
+    use std::path::{Component, Path};
+    let mut had_normal = false;
+    for component in Path::new(root).components() {
+        match component {
+            Component::Normal(_) => had_normal = true,
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return false,
+        }
+    }
+    had_normal
 }
 
 /// The `stores` field of `agent.toml`, in either accepted spelling.
@@ -333,6 +385,40 @@ palace = "owner-profile"
         let b: AgentStoreBinding =
             toml::from_str("name = \"kb\"\ntree = \"okg://izzie\"\nindex = \"bob-kb\"").unwrap();
         assert_eq!(b.validate(), None);
+    }
+
+    /// #4325: the per-assistant `root` must stay inside the instance's own
+    /// home — an absolute or `..`-bearing value would name another instance's
+    /// store.
+    #[test]
+    fn validate_flags_escaping_root() {
+        for bad in [
+            "../cto-assistant/okg",
+            "/tmp/okg",
+            "okg/../../elsewhere",
+            ".",
+        ] {
+            let b: AgentStoreBinding =
+                toml::from_str(&format!("name = \"kb\"\nroot = \"{bad}\"")).unwrap();
+            let reason = b
+                .validate()
+                .unwrap_or_else(|| panic!("`{bad}` should be flagged"));
+            assert!(
+                reason.contains("relative to the assistant"),
+                "reason was: {reason}"
+            );
+        }
+        for good in ["okg", "okg/personal", "./okg"] {
+            let b: AgentStoreBinding =
+                toml::from_str(&format!("name = \"kb\"\nroot = \"{good}\"")).unwrap();
+            assert_eq!(b.validate(), None, "`{good}` should be accepted");
+        }
+        // Absent and blank are both "use the default", not a problem.
+        let absent: AgentStoreBinding = toml::from_str("name = \"kb\"").unwrap();
+        assert_eq!(absent.root, None);
+        assert_eq!(absent.validate(), None);
+        let blank: AgentStoreBinding = toml::from_str("name = \"kb\"\nroot = \"  \"").unwrap();
+        assert_eq!(blank.validate(), None);
     }
 
     #[test]


### PR DESCRIPTION
## What changed

Adds `crate::assistants` — the per-instance container that models **instance isolation for the Assistant TYPE**, plus the `[[stores]] root` field #4325 lists as requirement 1.

| File | What |
|---|---|
| `crates/trusty-agents/src/assistants/instance.rs` | `ASSISTANT_ROLE` / `is_assistant_role` (the TYPE discriminator) and `AssistantInstanceId` (a validated INSTANCE name) |
| `crates/trusty-agents/src/assistants/home.rs` | `AssistantHome` — layout, resolution, app-generated `ensure()`, and `store_root()` |
| `crates/trusty-agents/src/assistants/health.rs` | `inspect()` / `HomeHealth` / `HomeIssue` — the detection half of the resilience requirement |
| `crates/trusty-agents/src/assistants/error.rs` | `AssistantError` (`thiserror`) |
| `crates/trusty-agents/src/stores/config.rs` | new `AgentStoreBinding.root` + its `validate()` rule |

Added: 1584 / Removed: 3 / Net: +1581 (of which 546 lines are the four test modules).

## The instance-isolation model

Per the owner's 2026-07-30 wording: **"Assistant" is a TYPE. `izzie` and `cto-assistant` are INSTANCES of that type — they are NOT distinct agent types.** The repo already encoded the type half (`assistant/agent.toml` declares `role = "assistant"`; both named personas carry `extends = "assistant"`). Nothing encoded the instance half — an instance's three belongings were spread across shared pools with no per-instance container:

- persona → the shared agents directory
- OKG tree → the flat `<knowledge_dir>/<slug(agent)>` pool, addressed by naming convention
- store root → did not exist as a field at all (#3890's data-model gap)

That is precisely why adding an instance reads as adding a *type*. This PR adds the container, and nothing else:

```
~/trusty-agents/<instance>/                # DOTLESS, visible, browsable
├── instructions.md
├── config.toml                            # TOML — confirmed, not assumed
├── agents/
├── okg/                                   # indexed by trusty-search
├── attachments/
└── stores/                                # parent only; <store-identifier>/ is a later spec
```

`TAGENT_ASSISTANTS_DIR` overrides the root. Two instances of the same type get two homes, two `okg/` trees, two `agents/` dirs — verified by `two_instances_get_separate_homes`.

**Resilience.** #4325 makes external modification EXPECTED. So:
- `ensure()` is additive and idempotent — it creates only what is missing and never rewrites a file the user edited (`ensure_never_overwrites_user_edits`, `ensure_restores_only_what_is_missing`). Restoring its own seed over a user's work would be exactly the intolerance the ticket rules out.
- `inspect()` never fails and never repairs. It returns structured findings — kind, path, detail, and a **remedy** — and `HomeHealth::narration()` is the seam #4320's concierge renders from. A missing home is one finding, not five.
- No auto-migration and no auto-relocation, per the ticket.

**`[[stores]] root`.** Optional, relative, traversal-free; resolved by `AssistantHome::store_root()` and defaulting to the home's `okg/`. Absolute or `..`-bearing values are refused at resolution AND reported by `AgentStoreBinding::validate()` (fail-soft, matching the module's existing posture — a bad store degrades, it never blocks boot). Bindings that omit `root` parse and validate byte-identically to before.

## Startup wiring (owner answer, 2026-08-01)

`ensure()` now runs on the boot path. **This is user-visible:** the first launch after this lands creates `~/trusty-agents/<instance>/` trees that did not exist before, logged at `info` (`created assistant home directory`) — not silent. A home that cannot be created logs at `warn` with its reason and remedy.

**Call site: `runtime::startup::run_startup_init`**, immediately after `ensure_bundled_agents_deployed()`. Two reasons it is that line and not another:

- It is the single per-launch choke point, and it runs **before** the `--api`/`--serve` early dispatch further down. One call therefore covers the API server, the Tauri GUI, the `start` daemon, the REPL/TUI and every one-shot subcommand.
- The GUI needs no second hook: `ui/src-tauri` spawns `tagent --api` as a sidecar (`sidecar.rs::ensure_api_server`) rather than provisioning anything itself; its `setup()` only builds the tray. Same for the daemon — `service::start_service` is a detached `tagent --serve`, so it re-enters this path.

**Not covered, deliberately:** `config` and `mcp-serve` return before `run_startup_init` runs. Both are intentionally daemon-less and stdout-protocol-sensitive, and neither touches an assistant home. That is the honest full answer to "does more than one entry point need this" — one site covers every launch mode, and the two it misses should miss it.

**It cannot fail startup.** Nothing in the new `provision` module returns `Result`. A read-only `$HOME`, a denied permission, a full disk, or a file left where a directory belongs becomes a `HomeIssueKind::NotCreatable` finding carrying the reason and a remedy, surfaced through the `health::narration()` seam built earlier in this PR. No panic, no `unwrap()`, no propagated error. It also cannot repeat the sidecar's historical `cwd=/` EROFS crash: the root resolves from `$HOME`/`$USERPROFILE`, never the cwd.

**Creation only.** No migration, no relocation, no cleanup; the dotted `~/.trusty-agents` tree is untouched. Relocating a home needs a migration process that stays future work.

### A judgment call worth your eye: which agents get a home

`role = "assistant"` alone is the **wrong** rule. `ctrl` declares it too — and the GUI's null `activeAgentId` *means* ctrl (Concierge), so provisioning it a selectable instance home would model the one agent that is not an instance as if it were. Selecting on role alone would have silently created it.

`roster::discover_instances()` uses role **plus lineage**: be the base `assistant`, or declare `extends = "assistant"`. Mechanical, no name special-casing. On the shipped roster that yields `assistant`, `izzie`, `cto-assistant` and excludes `ctrl`.

**It also excludes `personal-assistant.toml`**, which declares `role = "assistant"` but extends nothing. I judged that correct — it is a standalone persona, not an instance of the base — but it is a genuine call, so flag it if you disagree; it is a one-line rule change.

Note this introduces the **first boot-time agent enumeration** in the codebase (`agent_roster()` is per-request today). It is a partial, forgiving TOML read of `[agent]` only — the same shape `stores::binding::load_stores` already uses — so a malformed file is skipped, never fatal.

### Still no persisted selection

Confirmed by inspection: `activeAgentId` is in-memory only (`ui/src/stores/app.ts:145`), `user.toml` carries no agent field, and the backend documents the null default as deliberate. So "provision the selected assistant" has nothing to select yet — every discovered instance is provisioned, which is what makes #4281's selection land on homes that already exist.

## Owner decisions since the first push

**The store path is the owner's, verbatim (2026-08-01): `trusty-agents/<agent>/okg/`.** My original spelling carried an extra `assistants/` segment — flagged at the time as my own choice, not the ticket's — and has been dropped. Home is now `~/trusty-agents/<instance>/`, `okg/` sits directly under it, and `okg_store_path_matches_the_owners_spelling` pins the full absolute path rather than only the accessors (an accessor-only test would not have caught the extra segment, and the OKG Sources spec is being written against this path).

**`stores/` joins the layout (2026-08-01).** `<trusty-agents home>/<agent>/stores/<store-identifier>/` — one subdirectory per remote store, holding that store's extraction target and extraction state. **This PR creates the parent directory and nothing else.** It gets the same additive/idempotent/never-overwrite `ensure()` semantics and the same health findings as every other layout directory; store-identifier derivation, the extraction-state record, per-store subdirectories and extraction logic are all absent by design, because a separate spec defines them. `ignores_whatever_lives_under_stores` pins that boundary — inspection looks at the directory, never at its contents, so whatever the spec later puts inside cannot make a home report unhealthy. Creating the parent now means that slice needs no PR just to add a `mkdir`.

**TOML is confirmed, not assumed.** The `config.yaml` vs `config.toml` question is closed per the owner's 2026-07-29 correction: TOML stays, no format migration. Same correction confirms the dotless spelling, and narrows "protected"/"app-generated" to **ownership of origin with access control explicitly out of scope** — no write-enforcement, no floor, no narrow-only semantics. The doc comments have been softened accordingly (`assistants/mod.rs`, `AssistantHome::ensure`); nothing in the code ever enforced anything, but two comments read as if it might.

**#4406 is settled for this layout, by the owner rather than by me.** The owner specified `okg/` as a filesystem store indexed by trusty-search — the trusty-kb tree shape — which confirms the minimal read I flagged in the first push. The binding's separate `palace` field correctly stays untouched, so the trusty-memory leg remains addressable without changing this layout. I did not decide this; it was decided for me and matches.

## Remaining assumptions

1. **`attachments/` is created but its lifecycle is undefined.** The owner's comment scopes it to binary chat attachments and records the blocker: no binary→text extraction exists anywhere (`read_text` rejects NUL-bearing files; zero hits for `docx|pptx|xlsx|pdf_extract|lopdf|calamine|zip::`). New capability, not this ticket.
2. **`config.toml` is deliberately minimal** (`id`, optional `display_name`, unknown keys tolerated). Agent behaviour still comes from `agent.toml`; this file exists so instance-scoped settings have a landing place without a second format decision.

## Notes for the OKG Sources spec

Nothing here blocks a pluggable extractor writing into `okg/` on a schedule, but four things in the current shape are worth the spec accounting for:

1. **`StoresConfig::validate()` warns above ONE binding per agent** (`crates/trusty-agents/src/stores/config.rs`, pre-existing since #3816). If each OKG Source became its own `[[stores]]` binding, every multi-source assistant would emit a config warning. Sources should sit *under* the single store — e.g. `[[sources]]` in the home's `config.toml`, which already tolerates unknown keys — not as sibling bindings.
2. **`store_root()` confines the DESTINATION, not the source.** An extractor cannot repoint `okg/` outside the home (deliberate — it is what stops one instance writing into another's store). Reading from an arbitrary directory, Gmail, Drive, Slack, Notion or Granola is entirely unaffected. If a source type ever needs to write outside the home, that is a new decision, not a tweak.
3. **There is no place for per-source refresh state yet.** `health::inspect()` checks that `okg/` exists and is a directory; it knows nothing about last-run time, cursors, or a failing credential. A scheduled refresh needs that state, and `HomeIssue`/`HomeIssueKind` is the natural place to surface a stale or broken source through the same concierge narration seam — but the kinds are filesystem-shaped today and would need extending.
4. **Secrets must not land in the home.** The home is deliberately human-browsable and user-editable; a Granola API key or Slack token in `config.toml` would be sitting in a directory the product invites users to open. The spec should name a separate credential store.

## Out of scope## Out of scope (interfaces left open for them)

#3890 (writable store-config PATCH), #4283 (index→OKG extraction), #4282 (attached-index cap + GUI), #4281 (persisted selection). None are implemented here. `ASSISTANT_REACHABLE_SUBAGENTS`, `[subagents].delegate_allowed` and the delegate allow-set are untouched — this is instance isolation, not capability grants. No existing test was weakened, ignored or deleted.

## Test evidence

47 new tests. `cargo test -p trusty-agents --lib assistants::`:

```
test result: ok. 47 passed; 0 failed; 0 ignored; 0 measured; 3167 filtered out; finished in 0.05s
```

The five startup cases you asked for, plus the ones that turned out to matter:

| Test | Covers |
|---|---|
| `startup_creates_a_missing_home` | no home at all → creates it |
| `second_startup_creates_nothing` | complete home → no-op |
| `startup_fills_only_the_gaps` | partial home → fills only gaps |
| `repeated_startup_never_disturbs_user_edits` | 3 boots over edited files → untouched |
| `startup_survives_a_home_it_cannot_create` | **creation fails → app still starts, reason + remedy reach narration** |
| `provisions_every_instance_independently` | one unwritable home does not stop the others |
| `startup_reports_but_never_repairs_a_broken_file` | broken `config.toml` reported, never rewritten |
| `startup_provisions_the_discovered_roster` | discovery + provisioning wired, `ctrl` gets no home |
| `excludes_ctrl_and_non_assistants` | the lineage rule |

The failure case uses a regular file sitting where the home belongs — the portable stand-in for a read-only filesystem or denied permission, neither of which simulates reliably in CI.

Full crate suite, parallel (exit 0):

```
test result: ok. 3203 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 27.57s
test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 3.73s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.50s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.12s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.12s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.42s
```

Full crate suite, `--test-threads=1` (exit 0):

```
test result: ok. 3203 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 58.73s
test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 4.54s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.82s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.13s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.15s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.55s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.49s
```

No existing test was weakened, ignored or deleted; `bundled_personas_pin_git_reach` and the floor/persona-seed tests pass unchanged. `ASSISTANT_REACHABLE_SUBAGENTS`, `delegate_allowed` and the delegate allow-set are untouched, as are `mpm_bridge.rs` / `claude_mpm_role.rs`.

Gates:

```
$ cargo fmt --check                                          # clean, no diff
$ cargo clippy -p trusty-agents --all-targets -- -D warnings  # clean, 0 warnings
$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.
$ bash scripts/check_sld.sh
sld-lint: scanned 50 spec doc(s) + 2991 code file(s); 0 error(s), 0 warning(s)
$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.
```

No frontend files were touched, so the UI gates are unchanged (CI runs them regardless).

Rebased onto `origin/main` (was 7 behind); 4 commits replay cleanly.

One flake worth recording as PRE-EXISTING and unrelated: an early `--test-threads=1` run failed `api_e2e::test_health_returns_version` with "api server did not become healthy within 5s". It passes alone and in every full serial suite since, and this PR touches no API/server code — a cold-start timing flake in that test's own 5s probe budget.

Changelog: `crates/trusty-agents/changelog.d/4325-assistant-home-store-model.md`, including the user-visible first-launch note.

Closes #4325

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
