### PR TITLE
feat(trusty-agents): persist selected assistant across launches (#4281)

### DIFF
--- a/crates/trusty-agents/changelog.d/4281-persist-selected-assistant.md
+++ b/crates/trusty-agents/changelog.d/4281-persist-selected-assistant.md
@@ -1,0 +1,26 @@
+Added
+
+- The selected assistant now survives an app relaunch (closes [#4281](https://github.com/bobmatnyc/trusty-tools/issues/4281)).
+  `activeAgentId` was the last significant piece of desktop-client state that
+  did not persist — a plain in-memory `writable<string | null>(null)` that reset
+  to Concierge on every reload, while the API token and the theme already
+  round-tripped through `localStorage`. Since "Assistant" is a TYPE and `izzie`
+  / `cto-assistant` are INSTANCES of it, which instance is selected is
+  user-meaningful state. The store now seeds from `localStorage` at import time
+  and writes back through a subscription, so every selection site — the chat
+  header switcher, the sidebar's workstream resume, and the assistant picker
+  coming in [#4404](https://github.com/bobmatnyc/trusty-tools/issues/4404) —
+  sticks by simply setting the store; there is no separate save call to forget.
+  Per the owner decision of 2026-07-28 the stickiness is per-app-launch
+  (last-used), NOT per-workstream: filtering to a workstream does not re-select
+  an assistant, which would cut against DOC-54 §9.2's "workstreams are filters,
+  not containers".
+  - Degrades on every axis a hand-editable file can fail: a missing key, a
+    corrupt value (evicted so it is never re-parsed), an explicit Concierge
+    selection, and a `localStorage` that is absent or throws all resolve to the
+    pre-existing Concierge default without throwing or blocking startup.
+  - A stale selection naming an assistant that no longer exists is demoted to
+    Concierge as soon as a POPULATED roster contradicts it. An empty roster is
+    deliberately not treated as stale — the cold-start catalog fetch races the
+    sidecar and fails outright when the API is unreachable, so "no entries"
+    means "not loaded", never "your assistant is gone".

--- a/crates/trusty-agents/ui/src/lib/selectedAssistant.test.ts
+++ b/crates/trusty-agents/ui/src/lib/selectedAssistant.test.ts
@@ -7,7 +7,7 @@
 // `SelectionStorage` (no jsdom `localStorage` dependency), including a
 // storage that throws on every operation.
 // Test: this file.
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import {
   SELECTED_ASSISTANT_KEY,
   defaultSelectionStorage,
@@ -102,12 +102,24 @@ describe('selected-assistant codec (#4281)', () => {
   });
 
   it('defaultSelectionStorage_returns_null_when_unavailable', () => {
-    // No stub is installed here, and this environment genuinely has no
-    // `localStorage` (Node 26's own global shadows jsdom's) — so this is the
-    // real absent-storage path, not a simulation of it.
+    // Both branches are FORCED rather than inherited from the runtime: CI runs
+    // Node 20, where jsdom's `localStorage` is present, while Node 22+ defines
+    // its own `localStorage` global (undefined unless `--localstorage-file` is
+    // passed) that shadows jsdom's. Asserting whichever the host happens to
+    // provide would make this test pass on one and fail on the other.
+    vi.stubGlobal('localStorage', undefined);
     expect(defaultSelectionStorage()).toBeNull();
     expect(readSelectedAssistant()).toBeNull();
     expect(() => persistSelectedAssistant('izzie')).not.toThrow();
+    vi.unstubAllGlobals();
+  });
+
+  it('defaultSelectionStorage_resolves_the_global_when_present', () => {
+    const storage = fakeStorage('izzie');
+    vi.stubGlobal('localStorage', storage);
+    expect(defaultSelectionStorage()).toBe(storage);
+    expect(readSelectedAssistant()).toBe('izzie');
+    vi.unstubAllGlobals();
   });
 });
 

--- a/crates/trusty-agents/ui/src/lib/selectedAssistant.test.ts
+++ b/crates/trusty-agents/ui/src/lib/selectedAssistant.test.ts
@@ -1,0 +1,136 @@
+// Why (#4281): the persisted selection is a file the user can edit, delete,
+// or point at an assistant that no longer exists — and startup must survive
+// all three without panicking or blocking. These tests pin the degradation
+// contract for the codec itself; `stores/selectedAssistant.store.test.ts`
+// pins the store wiring on top of it.
+// What: unit tests over `lib/selectedAssistant.ts` with an injected
+// `SelectionStorage` (no jsdom `localStorage` dependency), including a
+// storage that throws on every operation.
+// Test: this file.
+import { describe, expect, it } from 'vitest';
+import {
+  SELECTED_ASSISTANT_KEY,
+  defaultSelectionStorage,
+  persistSelectedAssistant,
+  readSelectedAssistant,
+  reconcileSelectedAssistant,
+  type SelectionStorage,
+} from './selectedAssistant';
+import type { RosterEntry } from './roster';
+
+/** In-memory `SelectionStorage`, optionally pre-seeded. */
+function fakeStorage(seed?: string): SelectionStorage & { map: Map<string, string> } {
+  const map = new Map<string, string>();
+  if (seed !== undefined) map.set(SELECTED_ASSISTANT_KEY, seed);
+  return {
+    map,
+    getItem: (k) => map.get(k) ?? null,
+    setItem: (k, v) => {
+      map.set(k, v);
+    },
+    removeItem: (k) => {
+      map.delete(k);
+    },
+  };
+}
+
+/** Storage that throws on every operation (Safari private mode, quota). */
+const throwingStorage: SelectionStorage = {
+  getItem() {
+    throw new Error('SecurityError');
+  },
+  setItem() {
+    throw new Error('QuotaExceededError');
+  },
+  removeItem() {
+    throw new Error('SecurityError');
+  },
+};
+
+function entry(id: string): RosterEntry {
+  return { id, label: id, source: 'catalog', kind: 'assistant' };
+}
+
+describe('selected-assistant codec (#4281)', () => {
+  it('readSelectedAssistant_absent_key_is_concierge', () => {
+    expect(readSelectedAssistant(fakeStorage())).toBeNull();
+  });
+
+  it('readSelectedAssistant_returns_a_persisted_instance_id', () => {
+    expect(readSelectedAssistant(fakeStorage('cto-assistant'))).toBe('cto-assistant');
+  });
+
+  it('readSelectedAssistant_ctrl_sentinel_is_concierge', () => {
+    // Concierge is `activeAgentId === null`; dispatching it BY NAME would
+    // route through the tools-OFF persona path, so the sentinel must decode
+    // back to null rather than to the string 'ctrl'.
+    expect(readSelectedAssistant(fakeStorage('ctrl'))).toBeNull();
+  });
+
+  it('readSelectedAssistant_corrupt_value_is_concierge_and_evicted', () => {
+    for (const corrupt of ['', '   ', '{"id":"izzie"}', 'izzie izzie', '../../etc/passwd', 'x'.repeat(65)]) {
+      const storage = fakeStorage(corrupt);
+      expect(readSelectedAssistant(storage)).toBeNull();
+      // Self-heals: the unreadable value is not left to be re-parsed forever.
+      expect(storage.map.has(SELECTED_ASSISTANT_KEY)).toBe(false);
+    }
+  });
+
+  it('readSelectedAssistant_survives_throwing_storage', () => {
+    expect(() => readSelectedAssistant(throwingStorage)).not.toThrow();
+    expect(readSelectedAssistant(throwingStorage)).toBeNull();
+    expect(readSelectedAssistant(null)).toBeNull();
+  });
+
+  it('persistSelectedAssistant_round_trips_an_instance_id', () => {
+    const storage = fakeStorage();
+    persistSelectedAssistant('izzie', storage);
+    expect(storage.map.get(SELECTED_ASSISTANT_KEY)).toBe('izzie');
+    expect(readSelectedAssistant(storage)).toBe('izzie');
+  });
+
+  it('persistSelectedAssistant_encodes_concierge_as_the_ctrl_sentinel', () => {
+    const storage = fakeStorage('izzie');
+    persistSelectedAssistant(null, storage);
+    expect(storage.map.get(SELECTED_ASSISTANT_KEY)).toBe('ctrl');
+    expect(readSelectedAssistant(storage)).toBeNull();
+  });
+
+  it('persistSelectedAssistant_survives_throwing_storage', () => {
+    expect(() => persistSelectedAssistant('izzie', throwingStorage)).not.toThrow();
+    expect(() => persistSelectedAssistant(null, null)).not.toThrow();
+  });
+
+  it('defaultSelectionStorage_returns_null_when_unavailable', () => {
+    // No stub is installed here, and this environment genuinely has no
+    // `localStorage` (Node 26's own global shadows jsdom's) — so this is the
+    // real absent-storage path, not a simulation of it.
+    expect(defaultSelectionStorage()).toBeNull();
+    expect(readSelectedAssistant()).toBeNull();
+    expect(() => persistSelectedAssistant('izzie')).not.toThrow();
+  });
+});
+
+describe('stale-selection reconciliation (#4281)', () => {
+  const roster = [entry('izzie'), entry('cto-assistant')];
+
+  it('reconcileSelectedAssistant_keeps_a_live_selection', () => {
+    expect(reconcileSelectedAssistant('izzie', roster)).toBe('izzie');
+  });
+
+  it('reconcileSelectedAssistant_drops_a_stale_selection_to_concierge', () => {
+    expect(reconcileSelectedAssistant('deleted-assistant', roster)).toBeNull();
+  });
+
+  it('reconcileSelectedAssistant_keeps_selection_while_roster_is_empty', () => {
+    // Empty means "catalog not loaded / API unreachable", never "gone" — the
+    // cold-start fetch race in App.svelte would otherwise discard a valid
+    // selection on every launch.
+    expect(reconcileSelectedAssistant('izzie', [])).toBe('izzie');
+  });
+
+  it('reconcileSelectedAssistant_passes_concierge_through', () => {
+    expect(reconcileSelectedAssistant(null, roster)).toBeNull();
+    expect(reconcileSelectedAssistant(null, [])).toBeNull();
+  });
+});

--- a/crates/trusty-agents/ui/src/lib/selectedAssistant.ts
+++ b/crates/trusty-agents/ui/src/lib/selectedAssistant.ts
@@ -1,0 +1,176 @@
+// Selected-assistant persistence (#4281 — persist the selected assistant
+// across app launches; milestone M2, pillar (b) instance isolation).
+//
+// Why: "Assistant" is a TYPE and `izzie` / `cto-assistant` are INSTANCES of
+// it, each with its own home, OKG and persona — so WHICH instance is selected
+// is user-meaningful state, not an incidental UI toggle. It was nonetheless
+// the only significant piece of client state that did not survive a reload:
+// `activeAgentId` (`stores/app.ts`) was a plain in-memory
+// `writable<string | null>(null)`, so every relaunch silently dropped the
+// user back to Concierge, while the API token (`stores/app.ts`) and the theme
+// (`stores/theme.ts`) already round-tripped through localStorage. Per the
+// owner decision of 2026-07-28 the stickiness is PER-APP-LAUNCH (last-used,
+// persisted client-side), NOT per-workstream — a per-workstream binding would
+// cut against DOC-54 §9.2's "workstreams are filters, not containers", since
+// filtering to a workstream would re-select a different assistant and
+// reintroduce the context boundary DOC-54 rejects. Keeping the codec here as
+// pure functions over an injectable `SelectionStorage` (rather than inline in
+// the store) is what makes the failure modes — absent, corrupt, stale, or
+// outright throwing storage — testable without a browser.
+//
+// What: the on-disk encoding of one assistant selection plus the three
+// operations over it — `readSelectedAssistant`, `persistSelectedAssistant`,
+// and `reconcileSelectedAssistant`. `stores/app.ts` wires them to
+// `activeAgentId`; nothing else needs to call them (writing `activeAgentId`
+// persists automatically).
+//
+// Test: `selectedAssistant.test.ts` (codec + degradation) and
+// `stores/selectedAssistant.store.test.ts` (the store wiring).
+
+import { CONCIERGE_AGENT_ID, type RosterEntry } from './roster';
+
+/**
+ * Why: the `activeAgentId` axis encodes Concierge as `null`, but localStorage
+ * only stores strings — and `null` must be distinguishable from "the key was
+ * never written". Reusing `CONCIERGE_AGENT_ID` ('ctrl') as the on-disk
+ * sentinel keeps the persisted vocabulary identical to the one the config
+ * surface already addresses agents by (`configAgentName` in `roster.ts`), so
+ * a picker (#4404) can persist a card's id verbatim without a second mapping
+ * table. Reading `'ctrl'` back as `null` is also a correctness guard: `ctrl`
+ * does legitimately appear in `$agentRoster`, and dispatching it BY NAME
+ * routes through the tools-OFF persona path (`handlers.rs::
+ * resolve_agent_for_chat`), silently stripping Concierge's delegation
+ * capability — see `components/ChatHeader.svelte`'s header comment.
+ */
+export const SELECTED_ASSISTANT_KEY = 'tagent.selectedAssistant';
+
+/**
+ * Why: agent ids are filesystem-addressable slugs — the Rust side enforces
+ * `[a-zA-Z0-9_-]+` (`is_valid_agent_slug`) and `slugify` in `roster.ts`
+ * produces exactly that charset. Anything else in storage was not written by
+ * this app (hand-edited, truncated, or a foreign key collision) and must be
+ * treated as absent rather than forwarded into a dispatch payload. The length
+ * bound stops a corrupt multi-megabyte value from ever reaching the wire.
+ */
+const SELECTION_PATTERN = /^[A-Za-z0-9_-]{1,64}$/;
+
+/** The slice of the `Storage` API this module needs; injectable for tests. */
+export interface SelectionStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * Why: this module runs in three environments — the Tauri webview, a plain
+ * browser tab, and jsdom/SSR where `localStorage` may be undefined or (Safari
+ * private mode, hardened enterprise policies) throw `SecurityError` on mere
+ * access. Resolving it through a guarded helper means every caller degrades to
+ * "no persistence" instead of throwing during module initialization, which
+ * would take the whole app down before first paint.
+ * What: returns `globalThis.localStorage`, or `null` when it is unavailable.
+ * Test: `defaultSelectionStorage_returns_null_when_unavailable`.
+ */
+export function defaultSelectionStorage(): SelectionStorage | null {
+  try {
+    return typeof localStorage !== 'undefined' ? localStorage : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Why: startup must never block or panic on state the user can edit by hand.
+ * A missing key (first launch), a corrupt value (hand-edited storage), or a
+ * storage object that throws all mean the same thing to the app — no
+ * remembered selection — and all resolve to Concierge, the pre-#4281 default.
+ * Corrupt values are additionally EVICTED so the app self-heals rather than
+ * re-parsing the same garbage on every launch.
+ * What: reads the persisted selection and returns it in `activeAgentId`'s own
+ * vocabulary — `null` for Concierge (absent, corrupt, or the explicit `ctrl`
+ * sentinel), otherwise the assistant instance's id.
+ * Test: `readSelectedAssistant_absent_key_is_concierge`,
+ * `readSelectedAssistant_returns_a_persisted_instance_id`,
+ * `readSelectedAssistant_ctrl_sentinel_is_concierge`,
+ * `readSelectedAssistant_corrupt_value_is_concierge_and_evicted`,
+ * `readSelectedAssistant_survives_throwing_storage`.
+ */
+export function readSelectedAssistant(
+  storage: SelectionStorage | null = defaultSelectionStorage(),
+): string | null {
+  if (!storage) return null;
+  let raw: string | null;
+  try {
+    raw = storage.getItem(SELECTED_ASSISTANT_KEY);
+  } catch {
+    return null;
+  }
+  if (raw === null) return null;
+  const value = raw.trim();
+  if (!SELECTION_PATTERN.test(value)) {
+    // Self-heal: a value this app could not have written is never re-read.
+    try {
+      storage.removeItem(SELECTED_ASSISTANT_KEY);
+    } catch {
+      /* storage is read-only or unavailable — nothing further to do */
+    }
+    return null;
+  }
+  return value === CONCIERGE_AGENT_ID ? null : value;
+}
+
+/**
+ * Why: the write half of the same contract — and the reason it is total
+ * (Concierge included, via the sentinel) rather than "clear the key for
+ * `null`": deliberately switching BACK to Concierge is a selection the user
+ * expects to stick just as much as switching to Izzie, and clearing the key
+ * would make it indistinguishable from a fresh install only by luck of the
+ * default agreeing.
+ * What: writes `id`, encoding Concierge (`null`) as the `ctrl` sentinel.
+ * Silently no-ops when storage is unavailable or rejects the write (quota
+ * exhausted, private mode) — persistence is a convenience, never a
+ * precondition for using the app.
+ * Test: `persistSelectedAssistant_round_trips_an_instance_id`,
+ * `persistSelectedAssistant_encodes_concierge_as_the_ctrl_sentinel`,
+ * `persistSelectedAssistant_survives_throwing_storage`.
+ */
+export function persistSelectedAssistant(
+  id: string | null,
+  storage: SelectionStorage | null = defaultSelectionStorage(),
+): void {
+  if (!storage) return;
+  try {
+    storage.setItem(SELECTED_ASSISTANT_KEY, id ?? CONCIERGE_AGENT_ID);
+  } catch {
+    /* quota exceeded / private mode — the in-memory selection still works */
+  }
+}
+
+/**
+ * Why: a persisted selection is a POINTER into a roster the user can change
+ * between launches — deleting `izzie`'s overlay, or opening the app against a
+ * different project whose catalog never contained it. Left unchecked, that
+ * stale pointer would ride into `TaskRequest.agent` and fail server-side on
+ * the user's first message. The one case that must NOT be treated as stale is
+ * an EMPTY roster: the catalog fetch races the cold-start sidecar (see
+ * `App.svelte`'s `refetchPickerCatalogsOnReady`) and fails outright when the
+ * API is unreachable, so "no entries" means "not loaded", never "your
+ * assistant is gone". Erring that way costs a stale label until the roster
+ * arrives; erring the other way would silently discard a valid selection on
+ * every cold start — exactly the bug #4281 exists to fix.
+ * What: returns `id` when it still names a roster entry (or when the roster is
+ * empty/unloaded), and `null` — Concierge — when the roster is populated and
+ * has no such entry. Pure; the caller decides when to apply it.
+ * Test: `reconcileSelectedAssistant_keeps_a_live_selection`,
+ * `reconcileSelectedAssistant_drops_a_stale_selection_to_concierge`,
+ * `reconcileSelectedAssistant_keeps_selection_while_roster_is_empty`,
+ * `reconcileSelectedAssistant_passes_concierge_through`.
+ */
+export function reconcileSelectedAssistant(
+  id: string | null,
+  roster: RosterEntry[],
+): string | null {
+  if (id === null) return null;
+  if (roster.length === 0) return id;
+  return roster.some((entry) => entry.id === id) ? id : null;
+}

--- a/crates/trusty-agents/ui/src/stores/app.ts
+++ b/crates/trusty-agents/ui/src/stores/app.ts
@@ -10,6 +10,12 @@ import {
 } from '../lib/roster';
 import type { ModelsCatalogResponse, PickerEntry } from '../lib/models';
 import { fillDeltaIntoList } from '../lib/chatStream';
+// #4281: selected-assistant persistence — see `lib/selectedAssistant.ts`.
+import {
+  persistSelectedAssistant,
+  readSelectedAssistant,
+  reconcileSelectedAssistant,
+} from '../lib/selectedAssistant';
 
 /**
  * Why: The sidebar needs a single source of truth for the list of chat
@@ -141,8 +147,21 @@ export const activeProjectId = writable<string>('ctrl');
  * this is `null`, rather than forwarding it.
  * Test: `AgentSwitcher.svelte` sets this on row click; `InputArea.svelte`
  * reads it into the submission payload (only when non-null).
+ *
+ * #4281: the selection now SURVIVES RELAUNCH. This store is the persistence
+ * surface — seeded from localStorage at import time and written back on every
+ * change by the subscription below, so any selection site (the header
+ * switcher, the sidebar's workstream resume, and #4404's assistant picker)
+ * sticks by simply calling `activeAgentId.set(id)`; there is no separate
+ * "save" call to forget. `null` remains Concierge on both sides of the codec.
  */
-export const activeAgentId = writable<string | null>(null);
+export const activeAgentId = writable<string | null>(readSelectedAssistant());
+
+// #4281: write-through, so no current or future selection site can forget to
+// persist. Subscribing (rather than wrapping every `.set`) makes the store
+// itself the single choke point; the first, synchronous invocation just
+// re-writes the value we seeded from.
+activeAgentId.subscribe((id) => persistSelectedAssistant(id));
 
 /** `GET /api/agents` catalog (`.trusty-agents/agents/*.toml`), #407. */
 export const catalogAgents = writable<CatalogAgent[]>([]);
@@ -167,6 +186,30 @@ export const agentRoster = derived(
   [catalogAgents, overlayAgents],
   ([$catalogAgents, $overlayAgents]) => buildRoster($catalogAgents, $overlayAgents),
 );
+
+/**
+ * Why (#4281): a persisted selection is a pointer into a roster the user can
+ * change between launches, so it has to be re-validated once the real roster
+ * lands — otherwise a deleted assistant would ride into `TaskRequest.agent`
+ * and fail on the user's first message. Reconciling HERE (a subscription on
+ * the merged roster) rather than in a component keeps the guarantee
+ * independent of which surface happens to be mounted: the picker (#4404), the
+ * header switcher, and a headless boot all get the same behaviour. An empty
+ * roster is deliberately NOT treated as stale — see
+ * `reconcileSelectedAssistant`'s doc comment for why "not loaded" must never
+ * be mistaken for "gone".
+ * What: demotes a stale selection to Concierge (`null`) as soon as a
+ * populated roster contradicts it; a no-op in every other case (the
+ * conditional `set` also keeps this from re-notifying on unrelated catalog
+ * refreshes).
+ * Test: `stores/selectedAssistant.store.test.ts` — the stale/empty-roster
+ * cases.
+ */
+agentRoster.subscribe((roster) => {
+  const current = get(activeAgentId);
+  const reconciled = reconcileSelectedAssistant(current, roster);
+  if (reconciled !== current) activeAgentId.set(reconciled);
+});
 
 /**
  * Why: `GET /api/agents` is a plain REST endpoint (unlike the overlay tier),

--- a/crates/trusty-agents/ui/src/stores/selectedAssistant.store.test.ts
+++ b/crates/trusty-agents/ui/src/stores/selectedAssistant.store.test.ts
@@ -7,12 +7,13 @@
 // `lib/selectedAssistant.test.ts`; this file pins the wiring — seed,
 // write-through, and stale-pointer reconciliation against the live roster.
 // What: store-level tests over `activeAgentId` against a stubbed
-// `globalThis.localStorage`. The stub is not a convenience — under Node 26 the
-// runtime defines its own `localStorage` global (undefined unless
-// `--localstorage-file` is passed), which shadows jsdom's, so `localStorage`
-// is genuinely absent in this environment. That is itself worth knowing: the
-// production code's "no storage ⇒ no persistence, never a throw" guard is
-// exercised by every OTHER test file in this suite for free.
+// `globalThis.localStorage`. The stub is not a convenience — whether a real
+// one exists at all depends on the host: CI runs Node 20, where jsdom supplies
+// it, while Node 22+ defines its own `localStorage` global (undefined unless
+// `--localstorage-file` is passed) that shadows jsdom's. Stubbing makes these
+// tests assert the same thing on both, and incidentally means the production
+// "no storage ⇒ no persistence, never a throw" guard is exercised for free by
+// every other test file in this suite on the newer runtime.
 // Test: this file.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { get } from 'svelte/store';

--- a/crates/trusty-agents/ui/src/stores/selectedAssistant.store.test.ts
+++ b/crates/trusty-agents/ui/src/stores/selectedAssistant.store.test.ts
@@ -1,0 +1,134 @@
+// Why (#4281): the acceptance criterion is a LAUNCH-boundary property —
+// "relaunching the app restores the previously selected assistant" — and the
+// seed happens at MODULE-IMPORT time, which no in-module `.set()` can
+// simulate. Each test here therefore writes localStorage, resets the module
+// registry, and re-imports `stores/app.ts`: that re-import IS the app launch.
+// The codec's own degradation contract is covered by
+// `lib/selectedAssistant.test.ts`; this file pins the wiring — seed,
+// write-through, and stale-pointer reconciliation against the live roster.
+// What: store-level tests over `activeAgentId` against a stubbed
+// `globalThis.localStorage`. The stub is not a convenience — under Node 26 the
+// runtime defines its own `localStorage` global (undefined unless
+// `--localstorage-file` is passed), which shadows jsdom's, so `localStorage`
+// is genuinely absent in this environment. That is itself worth knowing: the
+// production code's "no storage ⇒ no persistence, never a throw" guard is
+// exercised by every OTHER test file in this suite for free.
+// Test: this file.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { get } from 'svelte/store';
+import { SELECTED_ASSISTANT_KEY } from '../lib/selectedAssistant';
+
+/** Minimal in-memory `Storage` stand-in for `globalThis.localStorage`. */
+function installFakeLocalStorage(): Map<string, string> {
+  const map = new Map<string, string>();
+  vi.stubGlobal('localStorage', {
+    getItem: (k: string) => map.get(k) ?? null,
+    setItem: (k: string, v: string) => {
+      map.set(k, String(v));
+    },
+    removeItem: (k: string) => {
+      map.delete(k);
+    },
+    clear: () => map.clear(),
+  });
+  return map;
+}
+
+let store: Map<string, string>;
+
+/** Re-imports `stores/app.ts` with a fresh module registry — one app launch. */
+async function relaunch() {
+  vi.resetModules();
+  return await import('./app');
+}
+
+beforeEach(() => {
+  store = installFakeLocalStorage();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.resetModules();
+});
+
+describe('activeAgentId persistence across launches (#4281)', () => {
+  it('defaults to Concierge on a first launch with no persisted selection', async () => {
+    const app = await relaunch();
+    expect(get(app.activeAgentId)).toBeNull();
+  });
+
+  it('restores the previously selected assistant instance on relaunch', async () => {
+    const first = await relaunch();
+    first.activeAgentId.set('cto-assistant');
+    expect(store.get(SELECTED_ASSISTANT_KEY) ?? null).toBe('cto-assistant');
+
+    const second = await relaunch();
+    expect(get(second.activeAgentId)).toBe('cto-assistant');
+  });
+
+  it('restores an explicit Concierge selection on relaunch', async () => {
+    const first = await relaunch();
+    first.activeAgentId.set('izzie');
+    first.activeAgentId.set(null);
+    expect(store.get(SELECTED_ASSISTANT_KEY) ?? null).toBe('ctrl');
+
+    const second = await relaunch();
+    expect(get(second.activeAgentId)).toBeNull();
+  });
+
+  it('falls back to Concierge when the persisted selection is corrupt', async () => {
+    store.set(SELECTED_ASSISTANT_KEY, '{"agent":"izzie"}');
+    const app = await relaunch();
+    expect(get(app.activeAgentId)).toBeNull();
+  });
+
+  it('demotes a stale selection to Concierge once a populated roster contradicts it', async () => {
+    store.set(SELECTED_ASSISTANT_KEY, 'deleted-assistant');
+    const app = await relaunch();
+    // Survives until the roster actually arrives — nothing has contradicted it yet.
+    expect(get(app.activeAgentId)).toBe('deleted-assistant');
+
+    app.catalogAgents.set([{ name: 'izzie' }]);
+    expect(get(app.activeAgentId)).toBeNull();
+    expect(store.get(SELECTED_ASSISTANT_KEY) ?? null).toBe('ctrl');
+  });
+
+  it('keeps a selection the roster confirms', async () => {
+    store.set(SELECTED_ASSISTANT_KEY, 'izzie');
+    const app = await relaunch();
+    app.catalogAgents.set([{ name: 'izzie' }, { name: 'cto-assistant' }]);
+    expect(get(app.activeAgentId)).toBe('izzie');
+  });
+
+  it('never discards a selection when the catalog fetch yields nothing', async () => {
+    // The cold-start race (App.svelte's `refetchPickerCatalogsOnReady`): the
+    // first `/api/agents` call can fail outright, leaving the roster empty.
+    // That must not read as "your assistant is gone".
+    store.set(SELECTED_ASSISTANT_KEY, 'izzie');
+    const app = await relaunch();
+    app.catalogAgents.set([]);
+    app.overlayAgents.set([]);
+    expect(get(app.activeAgentId)).toBe('izzie');
+  });
+
+  it('persists a selection made through an overlay entry', async () => {
+    const app = await relaunch();
+    app.overlayAgents.set([{ slug: 'my-cto', name: 'My CTO' }]);
+    app.activeAgentId.set('my-cto');
+    expect(store.get(SELECTED_ASSISTANT_KEY) ?? null).toBe('my-cto');
+    expect(get(app.activeAgentId)).toBe('my-cto');
+  });
+
+  it('does not re-scope the selection when a workstream filter changes', async () => {
+    // Owner decision 2026-07-28 / DOC-54 §9.2: workstreams are FILTERS, not
+    // containers — filtering must never re-select a different assistant.
+    // `activeProjectId` is the only workstream-ish axis in this store and is
+    // deliberately independent of `activeAgentId`.
+    store.set(SELECTED_ASSISTANT_KEY, 'izzie');
+    const app = await relaunch();
+    app.catalogAgents.set([{ name: 'izzie' }]);
+    app.activeProjectId.set('some-other-project');
+    expect(get(app.activeAgentId)).toBe('izzie');
+    expect(store.get(SELECTED_ASSISTANT_KEY) ?? null).toBe('izzie');
+  });
+});


### PR DESCRIPTION
## What changed

`activeAgentId` (`crates/trusty-agents/ui/src/stores/app.ts:145`) was the last
significant piece of desktop-client state that did not survive a reload — a
plain in-memory `writable<string | null>(null)` that reset to Concierge on
every launch, while the API token and the theme already round-tripped through
`localStorage`. Per the product model, "Assistant" is a TYPE and `izzie` /
`cto-assistant` are INSTANCES of it, each with its own home/OKG/persona — so
which instance is selected is user-meaningful state, not an incidental UI
toggle.

- **New** `crates/trusty-agents/ui/src/lib/selectedAssistant.ts` (169 lines) —
  the codec, as pure functions over an injectable `SelectionStorage`:
  `readSelectedAssistant`, `persistSelectedAssistant`,
  `reconcileSelectedAssistant`, plus `SELECTED_ASSISTANT_KEY` and
  `defaultSelectionStorage`.
- **Modified** `crates/trusty-agents/ui/src/stores/app.ts` (+35 lines) — seeds
  `activeAgentId` from storage at import time, writes back through a
  subscription, and reconciles against `agentRoster`.
- **New** two test files (23 tests).

Per the owner decision of 2026-07-28, stickiness is **per-app-launch**
(last-used, persisted client-side), **not per-workstream** — a per-workstream
binding would cut against DOC-54 §9.2's "workstreams are filters, not
containers". The second acceptance criterion ("filtering to a workstream must
not change `activeAgentId`") is pinned by a test rather than assumed.

## The persistence surface, and how #4404's picker consumes it

**The store IS the surface.** `activeAgentId` is seeded from `localStorage` at
module-import time and written back by a subscription on the store itself, so
persistence is not a separate call any site can forget:

```ts
export const activeAgentId = writable<string | null>(readSelectedAssistant());
activeAgentId.subscribe((id) => persistSelectedAssistant(id));
```

For the picker in #4404 this means one line — `activeAgentId.set(entry.id)` —
and the selection sticks. No `saveSelection()`, no picker-owned storage key,
and the three existing selection sites (`ChatHeader.svelte`,
`AgentSwitcher.svelte`, `Sidebar.svelte`'s workstream resume) inherit the
behaviour without being touched. Subscribing rather than wrapping every `.set`
was deliberate: it makes the store the single choke point, so a future
selection surface cannot regress persistence by construction.

Two details that matter for a card-based picker:

- **Concierge encodes as the `ctrl` sentinel**, not as a cleared key. The
  persisted vocabulary is therefore identical to the one the config surface
  already addresses agents by (`configAgentName` in `lib/roster.ts`), so a card
  list containing Concierge + instances can persist a card's id verbatim with
  no second mapping table. Reading `'ctrl'` back as `null` is also a
  correctness guard: `ctrl` legitimately appears in `$agentRoster`, and
  dispatching it *by name* routes through the tools-OFF persona path
  (`handlers.rs::resolve_agent_for_chat`), silently stripping Concierge's
  delegation capability.
- **Storage key** is `tagent.selectedAssistant`, matching the existing
  `tagent.apiToken` namespace.

Scope held to persistence: no picker UI, no OKG/store work, no boot-path
directory creation. `crates/trusty-agents/src/assistants/` and
`stores/config.rs` (#4325 / PR #4523) were read for the instance-identity shape
and **not modified** — the persisted value is the instance id (a
`[a-zA-Z0-9_-]` slug, the same charset the Rust `is_valid_agent_slug` enforces
and `slugify` produces), so it refers to instances the same way that model does.

## Degradation behaviour, with test evidence

Persisted state is a hand-editable file, so every failure axis resolves to the
pre-existing Concierge default — never a throw, never a blocked startup.

| Failure | Behaviour | Test |
|---|---|---|
| Key absent (first launch) | Concierge | `readSelectedAssistant_absent_key_is_concierge`; store: `defaults to Concierge on a first launch…` |
| Corrupt value (JSON blob, spaces, path traversal, >64 chars, empty) | Concierge, **and the value is evicted** so it is never re-parsed | `readSelectedAssistant_corrupt_value_is_concierge_and_evicted`; store: `falls back to Concierge when the persisted selection is corrupt` |
| `localStorage` absent | Concierge, no throw | `defaultSelectionStorage_returns_null_when_unavailable` |
| `localStorage` throws (`SecurityError` / `QuotaExceededError`) on get/set/remove | Concierge, no throw | `readSelectedAssistant_survives_throwing_storage`, `persistSelectedAssistant_survives_throwing_storage` |
| **Stale** — names an assistant that no longer exists | Demoted to Concierge once a **populated** roster contradicts it | `reconcileSelectedAssistant_drops_a_stale_selection_to_concierge`; store: `demotes a stale selection to Concierge once a populated roster contradicts it` |
| Roster empty (catalog fetch failed / cold-start race) | Selection **kept** | `reconcileSelectedAssistant_keeps_selection_while_roster_is_empty`; store: `never discards a selection when the catalog fetch yields nothing` |

That last row is the one deliberate asymmetry. `App.svelte`'s
`refetchPickerCatalogsOnReady` exists because the first `/api/agents` call
races the cold-start sidecar and fails outright; an empty roster therefore
means "not loaded", never "your assistant is gone". Treating it as stale would
discard a valid selection on every cold start — exactly the bug this issue
exists to fix. The cost is a stale label until the roster arrives.

**Environment note (worth knowing, not a workaround):** whether a real
`localStorage` exists in this vitest suite at all depends on the host. CI runs
Node 20, where jsdom supplies one; Node 22+ defines its own `localStorage`
global — `undefined` unless `--localstorage-file` is passed — which shadows
jsdom's. The first push caught this the hard way: one test asserted whichever
the host provided and so passed locally and failed in CI. Every test that
touches the global now forces the branch it means with `vi.stubGlobal`, so both
runtimes assert the same thing. A side benefit on the newer runtime: every
*other* test file in the suite exercises the absent-storage guard for free.

No existing test was weakened, deleted, or `#[ignore]`d; no
`ASSISTANT_REACHABLE_SUBAGENTS` / `delegate_allowed` / delegate allow-set
change. LOC: added 516, removed 1, net +515 (169 production, 313 test, 34
changelog/docs).

## Raw gate output

```
$ cargo fmt --check
(exit 0 — only the usual nightly-only rustfmt option warnings)

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 37s
(exit 0)

$ cargo test -p trusty-agents
test result: ok. 3148 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 27.62s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 3.75s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.51s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.12s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.10s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.39s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
(exit 0)

$ cargo test -p trusty-agents -- --test-threads=1
test result: ok. 3148 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 77.20s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 4.67s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.96s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.07s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.17s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.13s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.75s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.52s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
(exit 0)

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 50 spec doc(s) + 2987 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_changelog_fragment.sh
changelog-fragment gate: no crate source changed (docs-only / CI-only / test-only) — OK.
(fragment added anyway: crates/trusty-agents/changelog.d/4281-persist-selected-assistant.md)
```

### Frontend gates (`crates/trusty-agents/ui/`, pnpm)

```
$ pnpm test:unit          # vitest run
 Test Files  32 passed (32)
      Tests  358 passed (358)

$ npx vitest run src/lib/selectedAssistant.test.ts src/stores/selectedAssistant.store.test.ts --reporter=verbose
 ✓ selected-assistant codec (#4281) > readSelectedAssistant_absent_key_is_concierge
 ✓ selected-assistant codec (#4281) > readSelectedAssistant_returns_a_persisted_instance_id
 ✓ selected-assistant codec (#4281) > readSelectedAssistant_ctrl_sentinel_is_concierge
 ✓ selected-assistant codec (#4281) > readSelectedAssistant_corrupt_value_is_concierge_and_evicted
 ✓ selected-assistant codec (#4281) > readSelectedAssistant_survives_throwing_storage
 ✓ selected-assistant codec (#4281) > persistSelectedAssistant_round_trips_an_instance_id
 ✓ selected-assistant codec (#4281) > persistSelectedAssistant_encodes_concierge_as_the_ctrl_sentinel
 ✓ selected-assistant codec (#4281) > persistSelectedAssistant_survives_throwing_storage
 ✓ selected-assistant codec (#4281) > defaultSelectionStorage_returns_null_when_unavailable
 ✓ selected-assistant codec (#4281) > defaultSelectionStorage_resolves_the_global_when_present
 ✓ stale-selection reconciliation (#4281) > reconcileSelectedAssistant_keeps_a_live_selection
 ✓ stale-selection reconciliation (#4281) > reconcileSelectedAssistant_drops_a_stale_selection_to_concierge
 ✓ stale-selection reconciliation (#4281) > reconcileSelectedAssistant_keeps_selection_while_roster_is_empty
 ✓ stale-selection reconciliation (#4281) > reconcileSelectedAssistant_passes_concierge_through
 ✓ activeAgentId persistence across launches (#4281) > defaults to Concierge on a first launch with no persisted selection
 ✓ activeAgentId persistence across launches (#4281) > restores the previously selected assistant instance on relaunch
 ✓ activeAgentId persistence across launches (#4281) > restores an explicit Concierge selection on relaunch
 ✓ activeAgentId persistence across launches (#4281) > falls back to Concierge when the persisted selection is corrupt
 ✓ activeAgentId persistence across launches (#4281) > demotes a stale selection to Concierge once a populated roster contradicts it
 ✓ activeAgentId persistence across launches (#4281) > keeps a selection the roster confirms
 ✓ activeAgentId persistence across launches (#4281) > never discards a selection when the catalog fetch yields nothing
 ✓ activeAgentId persistence across launches (#4281) > persists a selection made through an overlay entry
 ✓ activeAgentId persistence across launches (#4281) > does not re-scope the selection when a workstream filter changes

 Test Files  2 passed (2)
      Tests  23 passed (23)

$ pnpm check              # svelte-check
COMPLETED 1751 FILES 0 ERRORS 3 WARNINGS 2 FILES_WITH_PROBLEMS
(the 3 warnings are pre-existing a11y warnings in KnowledgeGraphBrowser.svelte
 and ProjectsView.svelte — untouched by this PR)

$ pnpm build
✓ built in 3.11s
```

All 25 required checks are green on `f14d797a` (run
[30695472918](https://github.com/bobmatnyc/trusty-tools/actions/runs/30695472918)),
including `UI checks (trusty-agents)`, `Test`, `Clippy`, `MSRV check (1.91)`,
`500-line file-size cap`, `SLD (DOC-38) reference + spec-doc lint`, `Test:
doc-comment pointer lint`, and `Per-PR changelog fragment`.

Each store test re-imports `stores/app.ts` under `vi.resetModules()` — that
re-import *is* the app launch, which is the only way to exercise a
module-import-time seed.

Closes #4281

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
