### PR TITLE
feat: style-aware coding handoff — HandoffContext style field + addressable tcode PM (#4349, #4350)

### DIFF
--- a/crates/trusty-agents/changelog.d/4349-4350-style-aware-coding-handoff.md
+++ b/crates/trusty-agents/changelog.d/4349-4350-style-aware-coding-handoff.md
@@ -1,0 +1,40 @@
+Added
+
+- **Style-aware coding handoff: `HandoffContext.style` + an addressable coding
+  PM (issues [#4349](https://github.com/bobmatnyc/trusty-tools/issues/4349),
+  [#4350](https://github.com/bobmatnyc/trusty-tools/issues/4350); spec DOC-62
+  §5/§6).** `dispatch_task` gains two things. First, a closed
+  `ExecutionStyle` vocabulary — `hack` / `vibe` / `engineer` — that a caller may
+  attach to a handoff as a *ceremony request*, resolved caller > `[subagents]
+  default_style` > built-in `engineer` and then raised, never lowered, to the
+  target lane's own floor. The resolution travels outbound as a policy block
+  appended to the existing preamble and inbound on the `ProposalEnvelope`, so a
+  caller always learns which style actually ran. Second, `specialist:
+  "coding-pm"` names the external coding project manager the coding lane has
+  always run, making that route selectable and stylable instead of reachable
+  only by accident of task phrasing.
+
+  The style is a request, not a setting: `ResolvedStyle::resolve` is the only
+  constructor, combines every input with `max` over a ceremony-ordered enum, and
+  exposes no mutator — so no code path yields an effective style below the
+  callee's floor. `vibe` is unimplemented ([#2596](https://github.com/bobmatnyc/trusty-tools/issues/2596)),
+  so it runs the `engineer` pipeline today and reports effective style
+  `engineer` with reason `tier-unimplemented` rather than silently accepting a
+  tier that does not exist.
+
+  Nothing about reach changed. `NON_CODING_TARGETS` is untouched and still the
+  code-enforced closed literal behind
+  [#4126](https://github.com/bobmatnyc/trusty-tools/issues/4126); `coding-pm` is
+  deliberately not a member of it and is resolved on its own path, and
+  `DispatchTarget::CodingPm` carries no caller string onward, so the coding
+  leg's argv is byte-identical to an unnamed coding dispatch. Style is an input
+  to advisory preamble text and to nothing else — not the route, the target, the
+  argv, the allow-set, or any tool permission. An absent style is byte-identical
+  to previous behaviour at every level: no wire key, no policy block, no
+  envelope field.
+
+- **`[subagents] default_style` in agent TOML.** The configured middle
+  precedence level for coding-delegation ceremony (`hack` / `vibe` /
+  `engineer`). Absent falls through to the built-in `engineer`, i.e. today's
+  behaviour; an unrecognized value is a config parse error, never a silent
+  default.

--- a/crates/trusty-agents/src/agents/config.rs
+++ b/crates/trusty-agents/src/agents/config.rs
@@ -274,6 +274,25 @@ pub struct SubagentsConfig {
     /// `bundled_assistant_personas_seed_the_reachable_subagent_whitelist`.
     #[serde(default)]
     pub delegate_allowed: Option<Vec<String>>,
+
+    /// The CONFIGURED default execution style for this agent's coding
+    /// delegations (#4350; spec DOC-62 §5.2/§5.3, middle precedence level).
+    ///
+    /// Why: DOC-62 §5.2 records that no style/rigor field exists anywhere today
+    /// and that #4350 introduces one. It lives beside the other cross-product
+    /// keys because it configures the SAME surface — what `dispatch_task` hands
+    /// to an external target — and an additive key avoids reinterpreting either
+    /// existing list. Absent is the safe posture: it falls through to the
+    /// built-in `engineer`, which is exactly today's behaviour, so no agent
+    /// silently loses ceremony by not being updated.
+    /// What: `hack` / `vibe` / `engineer`; anything else is a config parse
+    /// error, never a silent default. A per-delegation value from the caller
+    /// outranks this, and the target lane's own floor outranks both — this key
+    /// can lower ceremony no more than a caller can.
+    /// Test: `subagents_config_parses_default_style`,
+    /// `subagents_config_rejects_an_unknown_default_style`.
+    #[serde(default)]
+    pub default_style: Option<crate::tools::execution_style::ExecutionStyle>,
 }
 
 /// Optional `[skills]` section in agent TOML (#3933).

--- a/crates/trusty-agents/src/agents/tests/mod.rs
+++ b/crates/trusty-agents/src/agents/tests/mod.rs
@@ -714,6 +714,80 @@ delegate_allowed = ["research-agent", "ticketing-agent"]
     );
 }
 
+/// #4350 (DOC-62 §5.2): `[subagents] default_style` parses into the closed
+/// `ExecutionStyle` vocabulary and stays independent of the two name lists.
+///
+/// Why: this is the CONFIG precedence level for coding-delegation ceremony. It
+/// must be a separate, additive key — reinterpreting either name list would
+/// make one config line mean two things — and it must be `None` when absent so
+/// an un-updated agent keeps today's built-in `engineer` behaviour.
+/// What: the key parses; absent leaves it `None`.
+/// Test: this function IS the test.
+#[test]
+fn subagents_config_parses_default_style() {
+    let base = r#"
+[agent]
+name = "seeded"
+role = "assistant"
+model = "m"
+description = "d"
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+"#;
+    let cfg: AgentConfig =
+        toml::from_str(&format!("{base}\n[subagents]\ndefault_style = \"vibe\"\n"))
+            .expect("parses");
+    assert_eq!(
+        cfg.subagents.default_style,
+        Some(crate::tools::execution_style::ExecutionStyle::Vibe)
+    );
+    assert!(cfg.subagents.allowed.is_none());
+    assert!(cfg.subagents.delegate_allowed.is_none());
+
+    let absent: AgentConfig = toml::from_str(base).expect("parses");
+    assert!(
+        absent.subagents.default_style.is_none(),
+        "an absent key must not invent a style"
+    );
+}
+
+/// An unrecognized style in config is a PARSE ERROR, never a silent default
+/// (DOC-62 §5.1) — the same rule the delegation parameter follows.
+///
+/// Why: silently mapping an unknown style onto a default is indistinguishable,
+/// from the operator's side, from the style having been honoured.
+/// What: a bad value fails `toml::from_str`.
+/// Test: this function IS the test.
+#[test]
+fn subagents_config_rejects_an_unknown_default_style() {
+    let toml_str = r#"
+[agent]
+name = "seeded"
+role = "assistant"
+model = "m"
+description = "d"
+
+[llm]
+temperature = 0.2
+max_tokens = 1024
+
+[system_prompt]
+content = "base"
+
+[subagents]
+default_style = "turbo"
+"#;
+    assert!(
+        toml::from_str::<AgentConfig>(toml_str).is_err(),
+        "an unknown style must not parse"
+    );
+}
+
 // --- `AgentInfo::tier` (#4168, epic #4167 — L0/L1 orchestration model) ---
 //
 // Fail-closed contract: absent, blank, or unrecognized `[agent].tier` must

--- a/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
+++ b/crates/trusty-agents/src/ctrl/pm_task/dispatch/history.rs
@@ -456,7 +456,10 @@ pub async fn run_pm_task_with_history(
         // `user_authority` has no `AgentConfig` field yet (#3074/AUTH-1), so
         // the fail-closed `Standard` tier is reported until it lands — never
         // an invented tier.
-        .with_origin(pm_cfg.agent.name.clone(), CallerAuthority::Standard),
+        .with_origin(pm_cfg.agent.name.clone(), CallerAuthority::Standard)
+        // #4350: the middle precedence level (DOC-62 §5.3). Absent =
+        // built-in `engineer` = today's behaviour.
+        .with_default_style(pm_cfg.subagents.default_style),
     ));
     let stop_pending: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
     let active_project_slot: Arc<Mutex<Option<PathBuf>>> = Arc::new(Mutex::new(None));

--- a/crates/trusty-agents/src/runtime/pm_mode.rs
+++ b/crates/trusty-agents/src/runtime/pm_mode.rs
@@ -130,7 +130,10 @@ pub(super) async fn run_pm() -> Result<()> {
                     NON_CODING_TARGETS,
                     pm_cfg.subagents.allowed.as_deref(),
                 ))
-                .with_origin(pm_cfg.agent.name.clone(), CallerAuthority::Standard),
+                .with_origin(pm_cfg.agent.name.clone(), CallerAuthority::Standard)
+                // #4350: configured default style (DOC-62 §5.3); absent =
+                // built-in `engineer` = today's behaviour.
+                .with_default_style(pm_cfg.subagents.default_style),
         ));
     }
     // #304: Coordinator-facing shell executor — see `tools::run_bash`.

--- a/crates/trusty-agents/src/tools/cross_product.rs
+++ b/crates/trusty-agents/src/tools/cross_product.rs
@@ -37,6 +37,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::tools::execution_style::{ExecutionStyle, ResolvedStyle};
+
 /// Maximum serialized size of a [`HandoffContext`], in bytes (#2809 §5.2's
 /// 4 KiB cap, mirrored locally per OQ-6).
 ///
@@ -68,6 +70,129 @@ pub const HANDOFF_MAX_BYTES: usize = 4096;
 /// `allow_set_accepts_a_named_non_coding_target`.
 pub const NON_CODING_TARGETS: &[&str] = &["research", "ticketing"];
 
+/// The ONE addressable name for the external coding project manager (#4350).
+///
+/// Why: the coding route already exists and is already the PM — `run_tcode`
+/// spawns `tcode run-task pm …` whenever `route_task` classifies the caller's
+/// text as coding — but it is UNADDRESSABLE: a caller cannot say which target
+/// it means, so it cannot attach a style to the handoff either. #4350 makes
+/// that existing route nameable. It deliberately does NOT join
+/// [`NON_CODING_TARGETS`]: that floor is the #4126 prompt-injection protection
+/// and epic #4345 decision 2 forbids widening it, so the coding PM is a
+/// SEPARATE, single, closed literal resolved on its own path. The name carries
+/// no product branding, because `dispatch_task`'s black-box contract (epic
+/// #3052 PR B, owner-locked) still holds — `scrub_branding` removes backend
+/// identity from every transcript, and a schema that named the backend would
+/// re-leak from the front what the result path strips from the back.
+/// What: `"coding-pm"`, matched case-insensitively after trimming. It resolves
+/// to [`DispatchTarget::CodingPm`], which carries no caller string onward.
+/// Test: `coding_pm_target_name_is_pinned`,
+/// `coding_pm_is_not_reachable_through_the_non_coding_floor`.
+pub const CODING_PM_TARGET: &str = "coding-pm";
+
+/// The resolved destination of one `dispatch_task` call — a CLOSED two-variant
+/// type, not a string (#4350).
+///
+/// Why: this is where "the tcode PM became addressable" is prevented from also
+/// meaning "an arbitrary caller string became an agent name". Before #4350 the
+/// bridge carried `Option<&str>` all the way into `run_tcode`, where it became
+/// the `<AGENT>` argv slot; the ONLY thing keeping a coding agent out of that
+/// slot was [`NON_CODING_TARGETS`]. Adding a second admissible target as another
+/// string would have made that floor the sole guard for two vocabularies at
+/// once. Instead the coding lane gets a variant that carries NO name:
+/// [`Self::backend_agent`] returns `None` for it, so the backend falls through
+/// to its own hardcoded `DEFAULT_TCODE_AGENT` and the coding leg's argv is
+/// byte-identical to an unnamed dispatch. No caller-supplied string can reach
+/// the coding leg's agent argument by construction — the same "structural
+/// rather than a convention" shape [`ProposalEnvelope::for_cross_product`] uses
+/// for `Disposition`.
+/// What: `CodingPm` (the single coding delegation surface) and `NonCoding(name)`
+/// (a name ALREADY resolved against the [`NON_CODING_TARGETS`] floor by
+/// `subagent_allow::SubagentAllowSet`). This type never decides admissibility;
+/// it records a decision already made.
+/// Test: `coding_pm_carries_no_caller_string_into_the_backend`,
+/// `non_coding_target_still_carries_its_resolved_name`,
+/// `coding_pm_floor_is_at_least_vibe`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DispatchTarget {
+    /// The external coding project manager — epic #4345 decision 2's sole
+    /// coding delegation surface. Carries no caller-supplied name.
+    CodingPm,
+    /// A non-coding specialist, already floor-resolved.
+    NonCoding(String),
+}
+
+impl DispatchTarget {
+    /// Recognise the reserved coding-PM name, or `None` if this is not it.
+    ///
+    /// Why: the recognition MUST happen before the non-coding allow-set is
+    /// consulted, because `coding-pm` is deliberately absent from that floor and
+    /// would otherwise be denied. Keeping the match here — one closed literal,
+    /// trimmed and lowercased exactly like `SubagentAllowSet::resolve` does —
+    /// means the two lanes normalise names identically and neither can be
+    /// reached by a differently-cased spelling of the other's name.
+    /// What: `Some(Self::CodingPm)` iff `requested` equals
+    /// [`CODING_PM_TARGET`] after trim + ASCII-lowercase.
+    /// Test: `coding_pm_target_name_is_pinned`,
+    /// `coding_pm_name_matching_is_case_and_space_insensitive`.
+    pub fn for_reserved_name(requested: &str) -> Option<Self> {
+        (requested.trim().to_ascii_lowercase() == CODING_PM_TARGET).then_some(Self::CodingPm)
+    }
+
+    /// The agent name handed across the process boundary, if any.
+    ///
+    /// Why: see the type docs — `None` for the coding PM is the structural
+    /// guarantee that no caller string becomes the coding leg's `<AGENT>` argv
+    /// slot. This method is the single place that property is expressed, so a
+    /// future edit that wanted to pass a name would have to change a documented
+    /// return value rather than quietly thread a string through.
+    /// What: `None` for [`Self::CodingPm`]; the already-resolved name for
+    /// [`Self::NonCoding`].
+    /// Test: `coding_pm_carries_no_caller_string_into_the_backend`,
+    /// `non_coding_target_still_carries_its_resolved_name`.
+    pub fn backend_agent(&self) -> Option<&str> {
+        match self {
+            Self::CodingPm => None,
+            Self::NonCoding(name) => Some(name),
+        }
+    }
+
+    /// The label recorded as the envelope's `target_agent`.
+    ///
+    /// Why: [`ProposalEnvelope`] must identify what produced a result, and for
+    /// the coding lane there is no wire name to report — the reserved literal is
+    /// the honest answer, and it is the same token the caller used.
+    /// What: [`CODING_PM_TARGET`] or the resolved specialist name.
+    /// Test: `styled_coding_delegation_returns_a_proposal_with_the_resolution`.
+    pub fn label(&self) -> &str {
+        match self {
+            Self::CodingPm => CODING_PM_TARGET,
+            Self::NonCoding(name) => name,
+        }
+    }
+
+    /// The ceremony FLOOR this lane enforces on a resolved style.
+    ///
+    /// Why: DOC-62 §4.1 defines `hack` as the ABSENCE of a code change — "a
+    /// delegation that asks for `hack` and then turns out to require a code
+    /// change MUST escalate, not proceed unchecked. Without this rule `hack`
+    /// becomes the gate-suppression channel SM-2 forbids, wearing a different
+    /// name." A delegation explicitly addressed to the coding PM is by
+    /// definition asking for a code change, so its floor is `vibe`. A non-coding
+    /// specialist produces no code, so it imposes no coding-ceremony floor.
+    /// What: `Vibe` for [`Self::CodingPm`], `Hack` (no floor) otherwise. Note
+    /// that `vibe` itself then degrades UPWARD to `engineer` today (SM-9), so a
+    /// `hack`-styled coding delegation currently runs the full loop and says so.
+    /// Test: `coding_pm_floor_is_at_least_vibe`,
+    /// `a_hack_request_to_the_coding_pm_does_not_lower_ceremony`.
+    pub fn style_floor(&self) -> ExecutionStyle {
+        match self {
+            Self::CodingPm => ExecutionStyle::Vibe,
+            Self::NonCoding(_) => ExecutionStyle::Hack,
+        }
+    }
+}
+
 /// Minimal, #2809-SHAPED outbound handoff payload (#4028, OQ-6).
 ///
 /// Why: the owner's OQ-6 ruling is "minimal HandoffContext-shaped envelope
@@ -80,8 +205,16 @@ pub const NON_CODING_TARGETS: &[&str] = &["research", "ticketing"];
 /// (caller-selected facts), `constraints` (limits the specialist must honour).
 /// All optional; an omitted handoff is byte-identical to pre-#4026 behaviour.
 /// [`HandoffContext::validate`] enforces [`HANDOFF_MAX_BYTES`].
+///
+/// #4349 added `style` — a TYPED field rather than prose the caller writes into
+/// `summary`/`constraints`, per DOC-62 §6.4: only a typed field keeps the wire,
+/// the config default and the GUI (#4353) in agreement, and only a typed field
+/// makes the ceiling property testable. It is a REQUEST, not a setting: what
+/// actually runs is [`crate::tools::execution_style::ResolvedStyle`], resolved
+/// at the bridge against the lane's floor.
 /// Test: `handoff_over_cap_is_rejected`, `handoff_at_cap_is_accepted`,
-/// `handoff_renders_into_the_task_preamble`.
+/// `handoff_renders_into_the_task_preamble`,
+/// `a_styled_handoff_stays_within_the_cap`.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct HandoffContext {
     /// Short statement of the situation the specialist is being handed.
@@ -93,6 +226,18 @@ pub struct HandoffContext {
     /// Limits the specialist must honour (scope, tone, forbidden actions).
     #[serde(default)]
     pub constraints: Vec<String>,
+    /// The ceremony level the caller REQUESTS for a coding handoff (#4349).
+    ///
+    /// Why: DOC-41 §5.5 — "no `HandoffContext` field grants elevated authority
+    /// to a callee". This one is no exception: it selects ceremony and confers
+    /// nothing (DOC-62 SM-6, SM-11). `None` is the pre-#4349 behaviour exactly.
+    /// What: a closed [`ExecutionStyle`]; an unrecognized wire value is a
+    /// deserialization error the bridge returns to the caller, never a silent
+    /// default.
+    /// Test: `a_styled_handoff_stays_within_the_cap`,
+    /// `an_unknown_style_is_a_caller_error_not_a_silent_default`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub style: Option<ExecutionStyle>,
 }
 
 impl HandoffContext {
@@ -118,8 +263,12 @@ impl HandoffContext {
     /// Why: an all-empty handoff must render NOTHING into the task text so the
     /// no-handoff path stays byte-identical to pre-#4026 dispatch.
     /// What: true iff both optional fields are `None`/blank and `constraints`
-    /// is empty.
-    /// Test: `empty_handoff_renders_nothing`.
+    /// is empty. Deliberately says nothing about `style`: this predicate governs
+    /// the CALLER-authored block, and the style-derived policy block is
+    /// governed separately by `ResolvedStyle::is_explicit` (DOC-62 §6.4), so a
+    /// style-only handoff renders the policy block and no caller block.
+    /// Test: `empty_handoff_renders_nothing`,
+    /// `a_style_only_handoff_renders_only_the_policy_block`.
     pub fn is_empty(&self) -> bool {
         self.summary.as_deref().unwrap_or("").trim().is_empty()
             && self
@@ -137,13 +286,28 @@ impl HandoffContext {
     /// a structured handoff must be flattened to cross the process boundary.
     /// Plain text (not JSON) because the receiving side is an LLM persona, not
     /// a parser.
-    /// What: returns `None` when [`Self::is_empty`]; otherwise a labelled
-    /// block naming only the fields that are actually set.
+    /// What: returns `None` when [`Self::is_empty`] AND no explicit style was
+    /// resolved; otherwise a labelled block naming only the fields that are
+    /// actually set, followed by the TA-PM-policy block when `policy` is
+    /// explicit.
+    ///
+    /// #4349: `policy` is the RESOLVED style (never `self.style`, which is only
+    /// the request). Two ordering rules from DOC-62 §6.4 are load-bearing and
+    /// are why the policy block is appended here rather than merged into the
+    /// caller's lines: it comes AFTER the caller's `Constraint` lines, and it
+    /// carries its own heading, so a caller-supplied constraint can never be
+    /// mistaken for the policy block. Note SM-8's limit on what that separation
+    /// buys — a preamble is advisory text read by a model, so this ordering
+    /// makes the policy legible, NOT tamper-proof; every security property it
+    /// mentions is enforced in code elsewhere.
     /// Test: `handoff_renders_into_the_task_preamble`,
-    /// `empty_handoff_renders_nothing`.
-    pub fn render_preamble(&self) -> Option<String> {
+    /// `empty_handoff_renders_nothing`,
+    /// `policy_block_follows_caller_supplied_constraints`,
+    /// `a_style_only_handoff_renders_only_the_policy_block`.
+    pub fn render_preamble(&self, policy: Option<&ResolvedStyle>) -> Option<String> {
+        let policy = policy.filter(|p| p.is_explicit());
         if self.is_empty() {
-            return None;
+            return policy.map(ResolvedStyle::render_policy_block);
         }
         let mut out = String::from("Context handed to you:\n");
         if let Some(s) = self
@@ -169,6 +333,10 @@ impl HandoffContext {
             .filter(|c| !c.is_empty())
         {
             out.push_str(&format!("- Constraint: {c}\n"));
+        }
+        if let Some(policy) = policy {
+            out.push('\n');
+            out.push_str(&policy.render_policy_block());
         }
         Some(out)
     }
@@ -242,6 +410,19 @@ pub struct ProposalEnvelope {
     pub authority: CallerAuthority,
     /// Always [`Disposition::Proposal`] for a cross-product result.
     pub disposition: Disposition,
+    /// The style that was actually applied and how it was arrived at (#4350).
+    ///
+    /// Why: DOC-62 §3.4 makes the resolution path part of the RESULT, not just
+    /// of the outbound preamble — "so a caller can see when its request was
+    /// overridden or degraded". A caller that asked for `vibe` and silently
+    /// received `engineer` would otherwise have no way to tell. Absent (and
+    /// omitted from the JSON) when no style was supplied at any level, keeping
+    /// the envelope byte-identical for every pre-#4350 caller.
+    /// What: the resolved record, never the raw request.
+    /// Test: `styled_coding_delegation_returns_a_proposal_with_the_resolution`,
+    /// `an_unstyled_envelope_is_byte_identical`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub style: Option<ResolvedStyle>,
     /// The specialist's output, already branding-scrubbed by the tool layer.
     pub result: String,
 }
@@ -268,8 +449,26 @@ impl ProposalEnvelope {
             authority,
             // Never `Action` — see the type docs and DOC-41 §5.5 line 1398.
             disposition: Disposition::Proposal,
+            style: None,
             result: result.into(),
         }
+    }
+
+    /// Record the resolved style on an already-built envelope (#4350).
+    ///
+    /// Why: a BUILDER rather than a fifth constructor parameter, deliberately.
+    /// [`Self::for_cross_product`] stays the sole constructor and keeps
+    /// hardcoding `Disposition::Proposal`, so the propose-only invariant is
+    /// untouched by this change — a style can be attached to an envelope but
+    /// there is still no code path through this type that yields
+    /// `Disposition::Action`, with or without one (DOC-62 AC-10, SM-6).
+    /// What: sets [`Self::style`]; `None` leaves the envelope byte-identical to
+    /// a pre-#4350 one.
+    /// Test: `styled_coding_delegation_returns_a_proposal_with_the_resolution`,
+    /// `a_styled_envelope_is_still_only_a_proposal`.
+    pub fn with_style(mut self, style: Option<ResolvedStyle>) -> Self {
+        self.style = style;
+        self
     }
 
     /// Render as the tool-result string handed back to the calling LLM.

--- a/crates/trusty-agents/src/tools/cross_product_tests.rs
+++ b/crates/trusty-agents/src/tools/cross_product_tests.rs
@@ -23,6 +23,7 @@ fn handoff_at_cap_is_accepted() {
         summary: Some("x".repeat(64)),
         relevant_state: None,
         constraints: vec!["stay read-only".to_string()],
+        style: None,
     };
     assert!(handoff.validate().is_ok());
     assert!(serde_json::to_vec(&handoff).unwrap().len() <= HANDOFF_MAX_BYTES);
@@ -35,6 +36,7 @@ fn handoff_over_cap_is_rejected() {
         summary: Some("x".repeat(HANDOFF_MAX_BYTES + 1)),
         relevant_state: None,
         constraints: Vec::new(),
+        style: None,
     };
     let err = handoff.validate().expect_err("over-cap handoff must fail");
     assert!(err > HANDOFF_MAX_BYTES, "reported size {err} not over cap");
@@ -44,7 +46,7 @@ fn handoff_over_cap_is_rejected() {
 #[test]
 fn empty_handoff_renders_nothing() {
     assert!(HandoffContext::default().is_empty());
-    assert!(HandoffContext::default().render_preamble().is_none());
+    assert!(HandoffContext::default().render_preamble(None).is_none());
 }
 
 /// A populated handoff renders a labelled preamble naming only set fields.
@@ -54,9 +56,10 @@ fn handoff_renders_into_the_task_preamble() {
         summary: Some("backlog triage".to_string()),
         relevant_state: None,
         constraints: vec!["do not close anything".to_string()],
+        style: None,
     };
     let rendered = handoff
-        .render_preamble()
+        .render_preamble(None)
         .expect("non-empty handoff renders");
     assert!(rendered.contains("backlog triage"));
     assert!(rendered.contains("do not close anything"));
@@ -119,4 +122,252 @@ fn envelope_json_shape() {
     let rendered = env.render();
     assert!(rendered.contains("PROPOSAL"), "rendered: {rendered}");
     assert!(rendered.contains("\"disposition\": \"proposal\""));
+}
+
+// =====================================================================
+// The #4126 floor and the addressable coding PM (#4350, DOC-62 AC-5)
+// =====================================================================
+
+/// **AC-5.** The floor's exact membership is pinned, so a future widening is a
+/// RED BUILD rather than a review miss. Epic #4345 decision 2 forbids adding,
+/// renaming, or widening this list; #4126's prompt-injection protection is what
+/// it protects.
+#[test]
+fn non_coding_targets_floor_membership_is_pinned() {
+    assert_eq!(
+        NON_CODING_TARGETS,
+        &["research", "ticketing"],
+        "the #4126 floor changed — this is an owner decision, not a refactor"
+    );
+}
+
+/// The coding PM is addressable, but NOT by joining the non-coding floor: a
+/// config that lists it still cannot reach it through the allow-set. The two
+/// vocabularies stay separate, and neither lane can widen the other.
+#[test]
+fn coding_pm_is_not_reachable_through_the_non_coding_floor() {
+    assert!(
+        !NON_CODING_TARGETS.contains(&CODING_PM_TARGET),
+        "the coding PM must never be a member of the non-coding floor"
+    );
+    let permissive = crate::tools::subagent_allow::SubagentAllowSet::over(
+        NON_CODING_TARGETS,
+        Some(&[CODING_PM_TARGET.to_string()]),
+    );
+    assert!(
+        permissive.resolve(CODING_PM_TARGET).is_err(),
+        "a permissive config must not smuggle the coding PM onto the non-coding floor"
+    );
+}
+
+/// The reserved name is a closed literal, matched the same way the allow-set
+/// normalizes names.
+#[test]
+fn coding_pm_target_name_is_pinned() {
+    assert_eq!(CODING_PM_TARGET, "coding-pm");
+    assert_eq!(
+        DispatchTarget::for_reserved_name("coding-pm"),
+        Some(DispatchTarget::CodingPm)
+    );
+    assert_eq!(DispatchTarget::for_reserved_name("research"), None);
+    assert_eq!(DispatchTarget::for_reserved_name("engineer"), None);
+}
+
+/// Trim + case-fold, matching `SubagentAllowSet::resolve`, so neither lane can
+/// be reached by a differently-cased spelling of the other's name.
+#[test]
+fn coding_pm_name_matching_is_case_and_space_insensitive() {
+    for spelling in ["  coding-pm ", "Coding-PM", "CODING-PM"] {
+        assert_eq!(
+            DispatchTarget::for_reserved_name(spelling),
+            Some(DispatchTarget::CodingPm),
+            "spelling {spelling:?} must resolve to the coding PM"
+        );
+    }
+}
+
+/// **The structural half of #4350.** The coding lane receives NO caller string:
+/// `backend_agent()` is `None`, so the backend falls through to its own
+/// hardcoded default agent and the argv is byte-identical to an unnamed coding
+/// dispatch. Naming the PM therefore adds no reach — there is no code path by
+/// which a caller-supplied name becomes the coding leg's agent argument.
+#[test]
+fn coding_pm_carries_no_caller_string_into_the_backend() {
+    assert_eq!(DispatchTarget::CodingPm.backend_agent(), None);
+    assert_eq!(DispatchTarget::CodingPm.label(), CODING_PM_TARGET);
+}
+
+/// A non-coding specialist still carries its already-floor-resolved name.
+#[test]
+fn non_coding_target_still_carries_its_resolved_name() {
+    let target = DispatchTarget::NonCoding("research".to_string());
+    assert_eq!(target.backend_agent(), Some("research"));
+    assert_eq!(target.label(), "research");
+}
+
+/// DOC-62 §4.1: `hack` is the ABSENCE of a code change, so a delegation
+/// explicitly addressed to the coding PM floors at `vibe`. A non-coding
+/// specialist imposes no coding-ceremony floor.
+#[test]
+fn coding_pm_floor_is_at_least_vibe() {
+    assert_eq!(DispatchTarget::CodingPm.style_floor(), ExecutionStyle::Vibe);
+    assert_eq!(
+        DispatchTarget::NonCoding("research".to_string()).style_floor(),
+        ExecutionStyle::Hack
+    );
+}
+
+/// **The ceiling, at the delegation surface.** A caller asking the coding PM
+/// for the cheapest style does NOT get less ceremony than the lane's floor —
+/// and today, because the floor is `vibe` and `vibe` is unimplemented, it gets
+/// the full loop and is told exactly why.
+#[test]
+fn a_hack_request_to_the_coding_pm_does_not_lower_ceremony() {
+    let resolved = ResolvedStyle::resolve(
+        Some(ExecutionStyle::Hack),
+        Some(ExecutionStyle::Hack),
+        DispatchTarget::CodingPm.style_floor(),
+    );
+    assert!(resolved.effective() > ExecutionStyle::Hack);
+    assert_eq!(resolved.effective(), ExecutionStyle::Engineer);
+    let block = resolved.render_policy_block();
+    assert!(block.contains("Requested style was hack"), "{block}");
+}
+
+// =====================================================================
+// Style on the handoff and in the envelope (#4349/#4350)
+// =====================================================================
+
+/// The style field is small and typed, so a handoff that fits today still fits
+/// with a style attached (DOC-62 AC-3).
+#[test]
+fn a_styled_handoff_stays_within_the_cap() {
+    let handoff = HandoffContext {
+        summary: Some("x".repeat(64)),
+        relevant_state: None,
+        constraints: vec!["stay read-only".to_string()],
+        style: Some(ExecutionStyle::Vibe),
+    };
+    assert!(handoff.validate().is_ok());
+    let json = serde_json::to_value(&handoff).expect("styled handoff serializes");
+    assert_eq!(json["style"], "vibe");
+}
+
+/// DOC-62 §5.1: an unrecognized style is a recoverable CALLER ERROR at the
+/// deserialization boundary, never a silent fallback to a default.
+#[test]
+fn an_unknown_style_is_a_caller_error_not_a_silent_default() {
+    let raw = serde_json::json!({ "summary": "s", "style": "turbo" });
+    let parsed = serde_json::from_value::<HandoffContext>(raw);
+    assert!(parsed.is_err(), "unknown style must not parse: {parsed:?}");
+}
+
+/// AC-2: an absent style serializes away entirely, so the no-style handoff is
+/// byte-identical to a pre-#4349 one and the 4 KiB cap measures the same bytes.
+#[test]
+fn an_unstyled_handoff_serializes_without_a_style_key() {
+    let json = serde_json::to_value(HandoffContext {
+        summary: Some("s".to_string()),
+        relevant_state: None,
+        constraints: Vec::new(),
+        style: None,
+    })
+    .expect("handoff serializes");
+    assert!(
+        json.get("style").is_none(),
+        "an absent style must not appear on the wire: {json}"
+    );
+}
+
+/// DOC-62 §6.4: the policy block comes AFTER the caller's own lines and under
+/// its own heading, so caller text cannot be mistaken for policy text.
+#[test]
+fn policy_block_follows_caller_supplied_constraints() {
+    let handoff = HandoffContext {
+        summary: Some("ship the parser fix".to_string()),
+        relevant_state: None,
+        constraints: vec!["touch only the parser".to_string()],
+        style: Some(ExecutionStyle::Engineer),
+    };
+    let style = ResolvedStyle::resolve(handoff.style, None, ExecutionStyle::Hack);
+    let rendered = handoff
+        .render_preamble(Some(&style))
+        .expect("styled handoff renders");
+    let constraint_at = rendered
+        .find("- Constraint: touch only the parser")
+        .expect("caller constraint rendered");
+    let policy_at = rendered
+        .find("Delegation policy (system-supplied, not from the caller):")
+        .expect("policy block rendered");
+    assert!(
+        constraint_at < policy_at,
+        "policy block must follow caller text: {rendered}"
+    );
+}
+
+/// A style-only handoff renders the policy block and no caller block.
+#[test]
+fn a_style_only_handoff_renders_only_the_policy_block() {
+    let handoff = HandoffContext {
+        style: Some(ExecutionStyle::Engineer),
+        ..Default::default()
+    };
+    let style = ResolvedStyle::resolve(handoff.style, None, ExecutionStyle::Hack);
+    let rendered = handoff
+        .render_preamble(Some(&style))
+        .expect("a style alone still renders policy");
+    assert!(!rendered.contains("Context handed to you:"), "{rendered}");
+    assert!(rendered.starts_with("Delegation policy"), "{rendered}");
+}
+
+/// AC-10: attaching a style does NOT change the disposition. A styled envelope
+/// is indistinguishable from an unstyled one in propose-only status.
+#[test]
+fn a_styled_envelope_is_still_only_a_proposal() {
+    let style = ResolvedStyle::resolve(Some(ExecutionStyle::Hack), None, ExecutionStyle::Hack);
+    for authority in [CallerAuthority::Standard, CallerAuthority::UserAuthority] {
+        let env =
+            ProposalEnvelope::for_cross_product("assistant", CODING_PM_TARGET, authority, "diff")
+                .with_style(Some(style.clone()));
+        assert_eq!(env.disposition, Disposition::Proposal);
+        assert_ne!(env.disposition, Disposition::Action);
+    }
+}
+
+/// AC-4: the resolution path is present in the RESULT, not only in the outbound
+/// preamble — a caller can see that its `vibe` request actually ran `engineer`.
+#[test]
+fn styled_coding_delegation_returns_a_proposal_with_the_resolution() {
+    let style = ResolvedStyle::resolve(
+        Some(ExecutionStyle::Vibe),
+        None,
+        DispatchTarget::CodingPm.style_floor(),
+    );
+    let env = ProposalEnvelope::for_cross_product(
+        "assistant",
+        DispatchTarget::CodingPm.label(),
+        CallerAuthority::Standard,
+        "proposed diff",
+    )
+    .with_style(Some(style));
+    let json = serde_json::to_value(&env).expect("envelope serializes");
+    assert_eq!(json["target_agent"], "coding-pm");
+    assert_eq!(json["disposition"], "proposal");
+    assert_eq!(json["style"]["requested"], "vibe");
+    assert_eq!(json["style"]["effective"], "engineer");
+    assert_eq!(json["style"]["escalations"][0], "tier-unimplemented");
+}
+
+/// An unstyled envelope carries no `style` key at all — byte-identical to
+/// pre-#4350 output for every existing caller.
+#[test]
+fn an_unstyled_envelope_is_byte_identical() {
+    let env = ProposalEnvelope::for_cross_product(
+        "assistant",
+        "ticketing",
+        CallerAuthority::Standard,
+        "drafted",
+    );
+    let json = serde_json::to_value(&env).expect("envelope serializes");
+    assert!(json.get("style").is_none(), "unstyled envelope: {json}");
 }

--- a/crates/trusty-agents/src/tools/execution_style.rs
+++ b/crates/trusty-agents/src/tools/execution_style.rs
@@ -1,0 +1,359 @@
+//! `ExecutionStyle` — the ceremony level a caller may attach to a coding
+//! delegation, and the one-way resolution that turns a caller REQUEST into an
+//! effective style (issues #4349/#4350; spec DOC-62 §5, in review as PR #4529).
+//!
+//! Why: a caller-supplied style is an **author tag**, and this repository's own
+//! captured research
+//! (`docs/research/quality-gates-agent-prs-article-2026-04.md:122`) rules that
+//! risk classification "must be automatic … not from author tags, since an
+//! agent has no self-awareness of how risky its own change is". The spec
+//! reconciles that with the owner's decision 3 (callers MAY name a style) by
+//! making the value a **ceiling request the callee may raise but never lower**.
+//! That asymmetry is the whole safety story of the feature, so it is enforced
+//! by CONSTRUCTION here rather than by discipline at the call sites — the same
+//! shape `ProposalEnvelope::for_cross_product`
+//! (`crate::tools::cross_product`) uses to make DOC-41 §5.5's propose-only rule
+//! "structural rather than a convention a future edit could forget".
+//! What: [`ExecutionStyle`] is the closed three-variant vocabulary, declared and
+//! `Ord`-ered by ascending ceremony so `max` IS "raise, never lower".
+//! [`ResolvedStyle`] is the resolution result; its ONLY constructor is
+//! [`ResolvedStyle::resolve`], its fields are private, and it exposes no
+//! mutator — there is no code path through this module that yields an effective
+//! style below the floor it was resolved against. [`StyleSource`] records which
+//! precedence level supplied the value and [`StyleEscalation`] why the effective
+//! value differs from the request, so a caller is never silently overruled.
+//! Style is ceremony ONLY: nothing here reads or writes a tool list, a
+//! permission, or a command line (DOC-62 SM-11).
+//! Test: `execution_style_tests` — the ceiling property over the full
+//! request×floor cross-product, the `vibe` → `engineer` fail-safe, precedence,
+//! and the bounded, task-independent policy block.
+
+use serde::{Deserialize, Serialize};
+
+/// The closed vocabulary of ceremony levels (DOC-62 §5.1, epic #4345 decision
+/// 1).
+///
+/// Why: a closed enum rather than a string is how decision 1's "no new axis is
+/// invented" becomes mechanical — an open field is a place for a fourth,
+/// undocumented tier to appear without a decision. The three names are the
+/// already-ratified Execution Patterns tiers
+/// (`docs/trusty-code/vision-and-architecture-spec.md` §5.10, §10 D3), not a
+/// new taxonomy. An unrecognized wire value is a `serde` error the bridge
+/// returns to the caller, never a silent fallback to a default: silently
+/// mapping an unknown style onto a default is indistinguishable, from the
+/// caller's side, from the style having been honoured.
+/// What: `Hack` (QUICK OPS — no code change at all), `Vibe` (VIBE — a small
+/// change, reduced ceremony), `Engineer` (FULL LOOP — today's behaviour).
+/// **Variant order is load-bearing**: the derived `Ord` is ascending ceremony,
+/// so `a.max(b)` is "the higher ceremony of the two" and every escalation in
+/// this module is a `max`. Reordering these variants silently inverts the
+/// safety property; [`ceremony_order_is_ascending`] fails if anyone does.
+/// Test: `ceremony_order_is_ascending`, `styles_round_trip_lowercase`,
+/// `an_unknown_style_string_is_a_deserialization_error`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ExecutionStyle {
+    /// QUICK OPS — trivial, answerable in a couple of reads. Per DOC-62 §4.1
+    /// this is the ABSENCE of a code change, not a code change with the checks
+    /// removed.
+    Hack,
+    /// VIBE — a small, self-contained change with reduced pre-PR ceremony.
+    /// Unimplemented today (#2596); see [`ExecutionStyle::implemented`].
+    Vibe,
+    /// FULL LOOP — spec → issue → worktree → branch → PR → review → merge → CI.
+    /// The built-in default and the fail-safe direction.
+    Engineer,
+}
+
+impl ExecutionStyle {
+    /// The built-in default when neither the caller nor config supplies one
+    /// (DOC-62 §5.2).
+    ///
+    /// Why: `Engineer` is the most ceremony and matches today's behaviour
+    /// exactly, so an absent style is byte-equivalent in behaviour to
+    /// pre-#4349 dispatch. Defaulting in the other direction would silently
+    /// reduce ceremony for every existing caller.
+    /// What: [`ExecutionStyle::Engineer`].
+    /// Test: `built_in_default_is_engineer`, `precedence_falls_through_to_built_in`.
+    pub const BUILT_IN_DEFAULT: Self = Self::Engineer;
+
+    /// The style whose pipeline actually EXISTS today, and why it differs
+    /// (DOC-62 §7.3, SM-9).
+    ///
+    /// Why: VIBE is unimplemented (#2596 open; vision spec §5.10 marks it "Not
+    /// implemented"). Silently accepting `vibe` and running less would ship the
+    /// reduced tier without the ratification vision spec §10 D3 requires, so
+    /// the fail-safe degrades UPWARD — more ceremony — and says so. When #2596
+    /// lands, this one function changes and nothing else does: no interface
+    /// change, no re-plumbing.
+    /// What: `(Engineer, Some(TierUnimplemented))` for `Vibe`; the style itself
+    /// with `None` otherwise. Never returns a style below its input — the
+    /// ceiling property holds through this step too.
+    /// Test: `vibe_degrades_upward_to_engineer_and_says_why`,
+    /// `implemented_never_lowers_ceremony`.
+    pub fn implemented(self) -> (Self, Option<StyleEscalation>) {
+        match self {
+            Self::Vibe => (Self::Engineer, Some(StyleEscalation::TierUnimplemented)),
+            other => (other, None),
+        }
+    }
+
+    /// The lowercase wire/display name.
+    ///
+    /// Why: the policy preamble is plain text read by an LLM persona, so the
+    /// rendered name must come from one place rather than being re-spelled at
+    /// each format site (where it could drift from the serde representation).
+    /// What: `"hack"` / `"vibe"` / `"engineer"`, matching `rename_all`.
+    /// Test: `styles_round_trip_lowercase`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Hack => "hack",
+            Self::Vibe => "vibe",
+            Self::Engineer => "engineer",
+        }
+    }
+}
+
+/// Which precedence level supplied the style (DOC-62 §5.3).
+///
+/// Why: §3.4's reporting contract entitles a caller to see WHICH level its
+/// effective style came from, so an override that was never read is visible
+/// rather than mysterious.
+/// What: `Caller` (per-delegation parameter) > `Config` (per-agent default) >
+/// `BuiltIn` ([`ExecutionStyle::BUILT_IN_DEFAULT`]), first-match-wins.
+/// Test: `precedence_is_caller_then_config_then_built_in`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StyleSource {
+    /// Supplied on the delegation call itself.
+    Caller,
+    /// Supplied by the calling agent's configuration default.
+    Config,
+    /// Neither of the above — [`ExecutionStyle::BUILT_IN_DEFAULT`].
+    BuiltIn,
+}
+
+/// Why an effective style is HIGHER than the one that was requested.
+///
+/// Why: DOC-62 §3.4 requires "an explicit statement when the effective style
+/// differs from the requested style, with the reason". Without it, a caller
+/// cannot distinguish "you got what you asked for" from "we quietly ran
+/// something else", which is the failure mode SM-4 exists to prevent.
+/// What: the two reasons this module can produce. Both are raises; there is no
+/// variant for a reduction because no code path produces one.
+/// Test: `vibe_degrades_upward_to_engineer_and_says_why`,
+/// `a_floor_above_the_request_is_reported_as_an_escalation`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum StyleEscalation {
+    /// The callee's own lane enforces a higher floor than the request
+    /// (DOC-62 §5.4).
+    CalleeFloor,
+    /// The requested tier has no implementation yet, so the next higher one
+    /// ran (DOC-62 §7.3, SM-9; #2596).
+    TierUnimplemented,
+}
+
+impl StyleEscalation {
+    /// Human-readable tag used in the policy preamble and in reports.
+    ///
+    /// Why: same single-source-of-truth reason as [`ExecutionStyle::as_str`];
+    /// SM-9 names the wire reason `tier-unimplemented` verbatim, so the string
+    /// must not be re-spelled at render sites.
+    /// What: the kebab-case serde name.
+    /// Test: `escalation_tags_match_the_spec_wire_names`.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CalleeFloor => "callee-floor",
+            Self::TierUnimplemented => "tier-unimplemented",
+        }
+    }
+}
+
+/// A resolved style: what was asked for, what will actually run, and why they
+/// differ (DOC-62 §5.3, §5.4, §3.4).
+///
+/// Why: **the ceiling property is structural here, not conventional.** Fields
+/// are private, there is no `Default`, no public constructor other than
+/// [`ResolvedStyle::resolve`], and no mutator; `resolve` computes `effective`
+/// only through `max` and [`ExecutionStyle::implemented`], both of which are
+/// monotonically non-decreasing in ceremony. There is therefore no code path
+/// through this type that yields an effective style below the floor it was
+/// resolved against, regardless of what the caller requested — exactly the
+/// guarantee `ProposalEnvelope::for_cross_product` gives `Disposition`.
+/// Note what this type deliberately does NOT have: any accessor a caller could
+/// use to reach a tool list, a permission, or a command line. Style is a
+/// ceremony record and nothing else (DOC-62 SM-11).
+/// What: `requested` (the value that entered resolution, `None` when nothing
+/// was supplied at any level), `source`, `effective`, and `escalations` (empty
+/// when the request was honoured as-is).
+/// Test: `a_caller_can_never_lower_ceremony_below_the_callee_floor`,
+/// `resolution_is_reported_end_to_end`, `precedence_is_caller_then_config_then_built_in`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ResolvedStyle {
+    /// The style that entered resolution, or `None` when no level supplied one.
+    requested: Option<ExecutionStyle>,
+    /// Which precedence level [`Self::requested`] came from.
+    source: StyleSource,
+    /// The style that will actually be applied — never below the floor.
+    effective: ExecutionStyle,
+    /// Why `effective` differs from `requested`; empty when it does not.
+    escalations: Vec<StyleEscalation>,
+}
+
+impl ResolvedStyle {
+    /// Resolve caller > config > built-in, then raise to the callee's floor and
+    /// to the nearest implemented tier.
+    ///
+    /// Why: the ONLY constructor, deliberately (see the type docs). Every input
+    /// is combined with `max`, so the function is monotonically non-decreasing
+    /// in ceremony: a caller asking for LESS than `callee_floor` moves the
+    /// effective value up to the floor and is told so, and can never move it
+    /// down. That is DOC-62 §5.4 — "the tcode PM MAY apply more ceremony than
+    /// the resolved style requests; it MUST NOT apply less" — made mechanical.
+    /// What: first-match-wins over `caller` then `config` then
+    /// [`ExecutionStyle::BUILT_IN_DEFAULT`]; the result is `max`-ed with
+    /// `callee_floor` (recording [`StyleEscalation::CalleeFloor`] if that
+    /// raised it) and then passed through [`ExecutionStyle::implemented`]
+    /// (recording [`StyleEscalation::TierUnimplemented`] if that raised it
+    /// again). Both escalations can apply to one resolution and both are
+    /// reported, in the order they were applied.
+    /// Test: `a_caller_can_never_lower_ceremony_below_the_callee_floor`,
+    /// `precedence_is_caller_then_config_then_built_in`,
+    /// `vibe_degrades_upward_to_engineer_and_says_why`,
+    /// `both_escalations_are_reported_when_both_apply`.
+    pub fn resolve(
+        caller: Option<ExecutionStyle>,
+        config: Option<ExecutionStyle>,
+        callee_floor: ExecutionStyle,
+    ) -> Self {
+        let (requested, source) = match (caller, config) {
+            (Some(style), _) => (Some(style), StyleSource::Caller),
+            (None, Some(style)) => (Some(style), StyleSource::Config),
+            (None, None) => (None, StyleSource::BuiltIn),
+        };
+        let asked = requested.unwrap_or(ExecutionStyle::BUILT_IN_DEFAULT);
+
+        let mut escalations = Vec::new();
+        // Raise (never lower) to the lane's floor.
+        let floored = asked.max(callee_floor);
+        if floored > asked {
+            escalations.push(StyleEscalation::CalleeFloor);
+        }
+        // Raise (never lower) to the nearest tier that actually exists.
+        let (effective, tier) = floored.implemented();
+        if let Some(reason) = tier {
+            escalations.push(reason);
+        }
+
+        // Postcondition — the ceiling property, asserted at the one site that
+        // can produce a `ResolvedStyle`. Cheap and debug-only; the property is
+        // pinned unconditionally by
+        // `a_caller_can_never_lower_ceremony_below_the_callee_floor`.
+        debug_assert!(effective >= callee_floor, "resolution lowered below floor");
+        debug_assert!(effective >= asked, "resolution lowered below the request");
+
+        Self {
+            requested,
+            source,
+            effective,
+            escalations,
+        }
+    }
+
+    /// The style that will actually be applied.
+    ///
+    /// Why: callers that report or branch on style must read the EFFECTIVE
+    /// value, never the request — reading the request is how "not run" quietly
+    /// becomes "fine" (DOC-62 SM-4).
+    /// What: the resolved value, always `>=` both the request and the floor.
+    /// Test: `resolution_is_reported_end_to_end`.
+    pub fn effective(&self) -> ExecutionStyle {
+        self.effective
+    }
+
+    /// Which precedence level supplied the requested value.
+    ///
+    /// Why: DOC-62 §3.4's reporting contract (AC-4).
+    /// What: see [`StyleSource`].
+    /// Test: `precedence_is_caller_then_config_then_built_in`.
+    pub fn source(&self) -> StyleSource {
+        self.source
+    }
+
+    /// Why the effective style differs from the request; empty when it does not.
+    ///
+    /// Why: DOC-62 §3.4 — a caller that asked for `vibe` is entitled to know
+    /// exactly what it bought.
+    /// What: raises only, in application order.
+    /// Test: `both_escalations_are_reported_when_both_apply`.
+    pub fn escalations(&self) -> &[StyleEscalation] {
+        &self.escalations
+    }
+
+    /// Whether a style was supplied at all, rather than falling through to the
+    /// built-in default.
+    ///
+    /// Why: DOC-62 §6.4 requires that an absent style render NO policy block,
+    /// so the no-style path stays byte-identical to pre-#4349 dispatch. This is
+    /// the predicate that keeps that promise, and it deliberately asks about
+    /// the SOURCE rather than the effective value (which is always populated).
+    /// What: true iff [`Self::source`] is not [`StyleSource::BuiltIn`].
+    /// Test: `an_unrequested_style_renders_no_policy_block`.
+    pub fn is_explicit(&self) -> bool {
+        !matches!(self.source, StyleSource::BuiltIn)
+    }
+
+    /// Render the TA-PM-policy block appended to a cross-product preamble
+    /// (#4349; DOC-62 §6.1, SM-7).
+    ///
+    /// Why: the product boundary is one argv slot — `tcode run-task <agent>
+    /// <task> --project <dir> --json` — so a structured handoff can only cross
+    /// it flattened into the task string (see
+    /// `HandoffContext::render_preamble`'s docs). SM-7 fixes what this text MAY
+    /// carry: the effective style, its meaning, decision 2's PM-only statement
+    /// as INFORMATION, and the §3 gate boundary as INSTRUCTION. SM-8 fixes what
+    /// it may not be: the sole enforcement of any security control. Both rules
+    /// are visible in the text itself — the `NON_CODING_TARGETS` line says out
+    /// loud that it is describing a code-enforced property, so no future reader
+    /// mistakes the paragraph for the mechanism.
+    /// What: a short block whose length is bounded and INDEPENDENT of the task
+    /// text or of any caller-supplied field, so the 4 KiB handoff cap never
+    /// becomes a function of task size (DOC-62 §6.4). Rendered after the
+    /// caller's own lines and under a heading that labels it as not
+    /// caller-supplied.
+    /// Test: `policy_block_states_effective_style_and_the_gate_boundary`,
+    /// `policy_block_is_bounded_and_task_independent`,
+    /// `policy_block_reports_the_tier_unimplemented_fallback`.
+    pub fn render_policy_block(&self) -> String {
+        let mut out = String::from("Delegation policy (system-supplied, not from the caller):\n");
+        out.push_str(&format!(
+            "- Effective execution style: {}.\n",
+            self.effective.as_str()
+        ));
+        if let Some(requested) = self.requested.filter(|r| *r != self.effective) {
+            let reasons: Vec<&str> = self.escalations.iter().map(|e| e.as_str()).collect();
+            out.push_str(&format!(
+                "- Requested style was {}; raised to {} ({}). Ceremony may be raised, never lowered.\n",
+                requested.as_str(),
+                self.effective.as_str(),
+                reasons.join(", ")
+            ));
+        }
+        out.push_str(
+            "- Style selects only your own internal ceremony. It never relaxes a check the \
+             target repository enforces (CI, branch protection, required review), and is never \
+             a reason to skip a review gate.\n\
+             - A check that was not run is reported as not run, never as passed.\n\
+             - Style grants no capability: it does not change which tools you may call or what \
+             they may do.\n\
+             - Coding work is delegated to you as the project manager; no coding sub-agent is \
+             reachable from the caller. That boundary is enforced in code, not by this text.\n",
+        );
+        out
+    }
+}
+
+#[cfg(test)]
+#[path = "execution_style_tests.rs"]
+mod execution_style_tests;

--- a/crates/trusty-agents/src/tools/execution_style_tests.rs
+++ b/crates/trusty-agents/src/tools/execution_style_tests.rs
@@ -1,0 +1,285 @@
+//! Tests for `tools::execution_style` — the ceiling property, the SM-9
+//! fail-safe, precedence, and the policy block (#4349/#4350, spec DOC-62 §5/§7).
+//!
+//! Why: every assertion here pins a rule a future edit could silently relax.
+//! The load-bearing one is the CEILING: a caller-supplied style is an author
+//! tag, and the feature is only safe because the callee may raise ceremony and
+//! never lower it. That is asserted over the FULL request×floor cross-product
+//! rather than on one happy path, because a single example would not catch a
+//! reordered `ExecutionStyle` variant list (which silently inverts `Ord`, and
+//! therefore inverts `max`, and therefore inverts the whole property).
+//! What: pure unit tests, no I/O. The bridge-side wiring (which floor applies
+//! to which lane, and that the backend argv is style-independent) is pinned in
+//! `pm_bridge_tests.rs`, where a recording backend can observe it.
+
+use super::*;
+
+/// Every style, for exhaustive cross-products.
+const ALL: [ExecutionStyle; 3] = [
+    ExecutionStyle::Hack,
+    ExecutionStyle::Vibe,
+    ExecutionStyle::Engineer,
+];
+
+// =====================================================================
+// The vocabulary (DOC-62 §5.1)
+// =====================================================================
+
+/// Variant order IS the ceremony order — `max` means "raise" only while this
+/// holds. Reordering the enum breaks the safety property silently; this fails.
+#[test]
+fn ceremony_order_is_ascending() {
+    assert!(ExecutionStyle::Hack < ExecutionStyle::Vibe);
+    assert!(ExecutionStyle::Vibe < ExecutionStyle::Engineer);
+    assert_eq!(
+        ExecutionStyle::Hack.max(ExecutionStyle::Engineer),
+        ExecutionStyle::Engineer
+    );
+}
+
+/// The wire form is lowercase, and `as_str` matches it exactly.
+#[test]
+fn styles_round_trip_lowercase() {
+    for style in ALL {
+        let json = serde_json::to_string(&style).expect("style serializes");
+        assert_eq!(json, format!("\"{}\"", style.as_str()));
+        let back: ExecutionStyle = serde_json::from_str(&json).expect("style round-trips");
+        assert_eq!(back, style);
+    }
+}
+
+/// DOC-62 §5.1: an unrecognized value is a recoverable ERROR, never a silent
+/// fallback to a default.
+#[test]
+fn an_unknown_style_string_is_a_deserialization_error() {
+    let err = serde_json::from_str::<ExecutionStyle>("\"yolo\"");
+    assert!(err.is_err(), "unknown style must not deserialize: {err:?}");
+}
+
+/// DOC-62 §5.2: the built-in default is the MOST ceremony, matching today.
+#[test]
+fn built_in_default_is_engineer() {
+    assert_eq!(ExecutionStyle::BUILT_IN_DEFAULT, ExecutionStyle::Engineer);
+}
+
+// =====================================================================
+// The ceiling property (DOC-62 §5.4) — the load-bearing invariant
+// =====================================================================
+
+/// **The ceiling.** For EVERY (request, floor) pair the effective style is at
+/// least the floor and at least the request. A caller asking for less ceremony
+/// than the callee's floor does not get less ceremony.
+#[test]
+fn a_caller_can_never_lower_ceremony_below_the_callee_floor() {
+    for requested in ALL {
+        for floor in ALL {
+            let resolved = ResolvedStyle::resolve(Some(requested), None, floor);
+            assert!(
+                resolved.effective() >= floor,
+                "request {requested:?} lowered effective below floor {floor:?}: {:?}",
+                resolved.effective()
+            );
+            assert!(
+                resolved.effective() >= requested,
+                "request {requested:?} at floor {floor:?} lowered below the request: {:?}",
+                resolved.effective()
+            );
+        }
+    }
+}
+
+/// The same property for a CONFIG-supplied style — config is an author tag too.
+#[test]
+fn a_config_default_can_never_lower_ceremony_below_the_callee_floor() {
+    for config in ALL {
+        for floor in ALL {
+            let resolved = ResolvedStyle::resolve(None, Some(config), floor);
+            assert!(resolved.effective() >= floor);
+            assert!(resolved.effective() >= config);
+        }
+    }
+}
+
+/// The tier fail-safe is itself a raise — `implemented()` never lowers.
+#[test]
+fn implemented_never_lowers_ceremony() {
+    for style in ALL {
+        let (effective, _) = style.implemented();
+        assert!(
+            effective >= style,
+            "{style:?} degraded downward to {effective:?}"
+        );
+    }
+}
+
+/// A floor above the request is reported, not applied silently.
+#[test]
+fn a_floor_above_the_request_is_reported_as_an_escalation() {
+    let resolved =
+        ResolvedStyle::resolve(Some(ExecutionStyle::Hack), None, ExecutionStyle::Engineer);
+    assert_eq!(resolved.effective(), ExecutionStyle::Engineer);
+    assert!(
+        resolved
+            .escalations()
+            .contains(&StyleEscalation::CalleeFloor),
+        "floor raise must be reported: {:?}",
+        resolved.escalations()
+    );
+}
+
+// =====================================================================
+// SM-9 — the VIBE fail-safe (DOC-62 §7.3, #2596)
+// =====================================================================
+
+/// SM-9: `vibe` runs the `engineer` pipeline TODAY and reports effective
+/// `engineer` with reason `tier-unimplemented`.
+#[test]
+fn vibe_degrades_upward_to_engineer_and_says_why() {
+    let resolved = ResolvedStyle::resolve(Some(ExecutionStyle::Vibe), None, ExecutionStyle::Hack);
+    assert_eq!(resolved.effective(), ExecutionStyle::Engineer);
+    assert_eq!(
+        resolved.escalations(),
+        &[StyleEscalation::TierUnimplemented],
+        "SM-9 requires the tier-unimplemented reason verbatim"
+    );
+}
+
+/// Both raises can apply to one resolution, and both are reported in order.
+#[test]
+fn both_escalations_are_reported_when_both_apply() {
+    // `hack` requested at a lane whose floor is `vibe`: floor raises it to
+    // `vibe`, then the unimplemented tier raises it again to `engineer`.
+    let resolved = ResolvedStyle::resolve(Some(ExecutionStyle::Hack), None, ExecutionStyle::Vibe);
+    assert_eq!(resolved.effective(), ExecutionStyle::Engineer);
+    assert_eq!(
+        resolved.escalations(),
+        &[
+            StyleEscalation::CalleeFloor,
+            StyleEscalation::TierUnimplemented
+        ]
+    );
+}
+
+/// The wire reason names are exactly the ones DOC-62 SM-9/§3.4 spell.
+#[test]
+fn escalation_tags_match_the_spec_wire_names() {
+    assert_eq!(
+        StyleEscalation::TierUnimplemented.as_str(),
+        "tier-unimplemented"
+    );
+    assert_eq!(StyleEscalation::CalleeFloor.as_str(), "callee-floor");
+    assert_eq!(
+        serde_json::to_string(&StyleEscalation::TierUnimplemented).unwrap(),
+        "\"tier-unimplemented\""
+    );
+}
+
+// =====================================================================
+// Precedence (DOC-62 §5.3)
+// =====================================================================
+
+/// caller > config > built-in, first-match-wins, with the level reported.
+#[test]
+fn precedence_is_caller_then_config_then_built_in() {
+    let caller_wins = ResolvedStyle::resolve(
+        Some(ExecutionStyle::Engineer),
+        Some(ExecutionStyle::Hack),
+        ExecutionStyle::Hack,
+    );
+    assert_eq!(caller_wins.source(), StyleSource::Caller);
+    assert_eq!(caller_wins.effective(), ExecutionStyle::Engineer);
+
+    let config_wins =
+        ResolvedStyle::resolve(None, Some(ExecutionStyle::Hack), ExecutionStyle::Hack);
+    assert_eq!(config_wins.source(), StyleSource::Config);
+    assert_eq!(config_wins.effective(), ExecutionStyle::Hack);
+}
+
+/// Nothing supplied anywhere falls through to the built-in default.
+#[test]
+fn precedence_falls_through_to_built_in() {
+    let resolved = ResolvedStyle::resolve(None, None, ExecutionStyle::Hack);
+    assert_eq!(resolved.source(), StyleSource::BuiltIn);
+    assert_eq!(resolved.effective(), ExecutionStyle::BUILT_IN_DEFAULT);
+    assert!(!resolved.is_explicit());
+}
+
+/// The resolution path is fully reportable (DOC-62 §3.4 / AC-4).
+#[test]
+fn resolution_is_reported_end_to_end() {
+    let resolved = ResolvedStyle::resolve(Some(ExecutionStyle::Vibe), None, ExecutionStyle::Hack);
+    let json = serde_json::to_value(&resolved).expect("resolved style serializes");
+    assert_eq!(json["requested"], "vibe");
+    assert_eq!(json["effective"], "engineer");
+    assert_eq!(json["source"], "caller");
+    assert_eq!(json["escalations"][0], "tier-unimplemented");
+}
+
+// =====================================================================
+// The policy block (#4349; DOC-62 §6.1/§6.4, SM-7/SM-8)
+// =====================================================================
+
+/// SM-7: the block states the effective style and the gate boundary, and SM-8:
+/// it labels the `NON_CODING_TARGETS` boundary as code-enforced rather than
+/// claiming to BE the enforcement.
+#[test]
+fn policy_block_states_effective_style_and_the_gate_boundary() {
+    let block = ResolvedStyle::resolve(Some(ExecutionStyle::Engineer), None, ExecutionStyle::Hack)
+        .render_policy_block();
+    assert!(block.contains("Effective execution style: engineer"));
+    assert!(
+        block.contains("never relaxes"),
+        "gate boundary missing: {block}"
+    );
+    assert!(
+        block.contains("never as passed"),
+        "SM-4 line missing: {block}"
+    );
+    assert!(
+        block.contains("grants no capability"),
+        "SM-11 line missing: {block}"
+    );
+    assert!(
+        block.contains("enforced in code, not by this text"),
+        "SM-8 must not let the preamble pose as the enforcement: {block}"
+    );
+    assert!(
+        block.starts_with("Delegation policy (system-supplied, not from the caller):"),
+        "the block must be distinguishable from caller text: {block}"
+    );
+}
+
+/// SM-9's fallback is visible to the caller in the text it actually reads.
+#[test]
+fn policy_block_reports_the_tier_unimplemented_fallback() {
+    let block = ResolvedStyle::resolve(Some(ExecutionStyle::Vibe), None, ExecutionStyle::Hack)
+        .render_policy_block();
+    assert!(block.contains("Requested style was vibe"), "{block}");
+    assert!(block.contains("tier-unimplemented"), "{block}");
+    assert!(block.contains("raised, never lowered"), "{block}");
+}
+
+/// DOC-62 §6.4: the block is bounded and independent of the task — its size is
+/// not a function of anything the caller supplies, so it can never be what
+/// pushes a handoff over the 4 KiB cap.
+#[test]
+fn policy_block_is_bounded_and_task_independent() {
+    for requested in ALL {
+        for floor in ALL {
+            let block = ResolvedStyle::resolve(Some(requested), None, floor).render_policy_block();
+            assert!(
+                block.len() < 1024,
+                "policy block must stay well under the 4 KiB handoff cap, got {}",
+                block.len()
+            );
+        }
+    }
+}
+
+/// The built-in default is not "explicit", so it renders no block at all —
+/// the pre-#4349 path stays byte-identical.
+#[test]
+fn an_unrequested_style_renders_no_policy_block() {
+    let resolved = ResolvedStyle::resolve(None, None, ExecutionStyle::Engineer);
+    assert!(!resolved.is_explicit());
+}

--- a/crates/trusty-agents/src/tools/mod.rs
+++ b/crates/trusty-agents/src/tools/mod.rs
@@ -17,6 +17,9 @@ pub mod ast_tools;
 // #4026/#4028: cross-product subagent allow-set + propose-only envelope.
 pub mod cross_product;
 pub mod delegate;
+// #4349/#4350 (spec DOC-62): the closed ceremony vocabulary for coding
+// delegation, and the raise-never-lower resolution that applies it.
+pub mod execution_style;
 pub mod file_filter;
 pub mod finish_task;
 pub mod format_translator;

--- a/crates/trusty-agents/src/tools/pm_bridge.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge.rs
@@ -49,6 +49,28 @@
 //!
 //! Omitting `specialist` is byte-identical to pre-#4026 behaviour: same route
 //! derivation, same default target, same bare scrubbed transcript back.
+//!
+//! ## Addressable coding PM + execution style (#4349/#4350, spec DOC-62)
+//!
+//! - **#4350, addressability.** `cross_product::CODING_PM_TARGET`
+//!   (`"coding-pm"`) names the external coding project manager the coding lane
+//!   has ALWAYS run (`DEFAULT_TCODE_AGENT`); naming it makes the existing route
+//!   selectable and stylable instead of only reachable by accident of phrasing.
+//!   It is resolved on its own path and is deliberately NOT a member of
+//!   `NON_CODING_TARGETS`, which stays the closed, code-enforced #4126 floor
+//!   for the non-coding vocabulary and is untouched by this change. The
+//!   resolved `DispatchTarget::CodingPm` carries NO caller string onward
+//!   (`backend_agent()` is `None`), so the coding leg's argv is byte-identical
+//!   to an unnamed coding dispatch — naming the PM adds no reach.
+//! - **#4349, style.** `HandoffContext::style` is the caller's ceremony
+//!   REQUEST. It is resolved here — caller > config default > built-in
+//!   `engineer` — and then raised, never lowered, to the lane's own floor and
+//!   to the nearest implemented tier (`vibe` runs `engineer` today and says so,
+//!   DOC-62 SM-9). The resolved record travels outbound as a policy block in
+//!   the preamble and inbound on the `ProposalEnvelope`, so a caller always
+//!   learns what actually ran. Style is an input to that text and to nothing
+//!   else: not to the route, the target, the argv, the allow-set, or any tool
+//!   permission (DOC-62 SM-11).
 
 use std::sync::{Arc, OnceLock};
 
@@ -59,8 +81,9 @@ use serde_json::{Value, json};
 use crate::intent::route::{BridgeRoute, route_task};
 use crate::rbac::ServiceTier;
 use crate::tools::cross_product::{
-    CallerAuthority, HandoffContext, NON_CODING_TARGETS, ProposalEnvelope,
+    CallerAuthority, DispatchTarget, HandoffContext, NON_CODING_TARGETS, ProposalEnvelope,
 };
+use crate::tools::execution_style::{ExecutionStyle, ResolvedStyle};
 use crate::tools::pm_bridge_backend::PmBridgeBackend;
 use crate::tools::subagent_allow::SubagentAllowSet;
 use crate::tools::traits::{ToolExecutor, ToolResult};
@@ -85,6 +108,10 @@ pub struct PmBridgeTool {
     // #4028: envelope provenance/authority for cross-product results.
     origin_agent: String,
     caller_authority: CallerAuthority,
+    // #4350: the calling agent's CONFIGURED default style — the middle
+    // precedence level (DOC-62 §5.3). `None` means "config supplies nothing",
+    // which falls through to the built-in `engineer`.
+    default_style: Option<ExecutionStyle>,
 }
 
 impl PmBridgeTool {
@@ -106,7 +133,27 @@ impl PmBridgeTool {
             allow_set: SubagentAllowSet::empty_over(NON_CODING_TARGETS),
             origin_agent: DEFAULT_ORIGIN_AGENT.to_string(),
             caller_authority: CallerAuthority::Standard,
+            // #4350: no configured default until a registration site supplies
+            // one — the built-in `engineer` then applies, i.e. today's behaviour.
+            default_style: None,
         }
+    }
+
+    /// Attach the calling agent's configured default execution style (#4350).
+    ///
+    /// Why: DOC-62 §5.3's middle precedence level. Read at REGISTRATION time
+    /// from the agent's own config for the same reason `with_allow_set` is:
+    /// `execute` must never consult anything the LLM can influence mid-turn.
+    /// Note what this dial CANNOT do — it selects ceremony and nothing else; it
+    /// is not an input to the allow-set, the route, the target, the argv, or
+    /// any tool permission (DOC-62 SM-11).
+    /// What: replaces the `None` default. A caller-supplied style still wins
+    /// over it, and the lane's own floor still wins over both (DOC-62 §5.4).
+    /// Test: `config_default_style_is_used_when_the_caller_supplies_none`,
+    /// `a_caller_style_beats_the_config_default`.
+    pub fn with_default_style(mut self, style: Option<ExecutionStyle>) -> Self {
+        self.default_style = style;
+        self
     }
 
     /// Attach the calling agent's cross-product allow-set (#4026).
@@ -188,18 +235,29 @@ impl ToolExecutor for PmBridgeTool {
                         // naming any backend or enumerating the roster (the
                         // #3052 PR A CRITICAL-2 rule) — the caller's own
                         // instructions are the source of legitimate names.
+                        // #4350: the reserved coding-PM name is described here
+                        // — the LLM must be able to NAME its coding target — but
+                        // still without identifying any backend product, since
+                        // the black-box contract (#3052 PR B) is unchanged and
+                        // `scrub_branding` still strips identity from results.
                         "specialist": {
                             "type": "string",
-                            "description": "Optional name of a non-coding specialist to hand this to, when your own instructions name one. Omit to let the system choose how to execute the task."
+                            "description": "Optional name of the specialist to hand this to. Use \"coding-pm\" for the project manager that owns code changes: it plans and implements the change itself and hands back a proposal for you to review. Any other name must be one your own instructions name. Omit to let the system choose how to execute the task.",
                         },
                         // #4028: optional HandoffContext-shaped payload.
+                        // #4349: plus the optional style REQUEST.
                         "handoff": {
                             "type": "object",
                             "description": "Optional context to hand along with the task. Keep it small; it is capped.",
                             "properties": {
                                 "summary": { "type": "string" },
                                 "relevant_state": { "type": "string" },
-                                "constraints": { "type": "array", "items": { "type": "string" } }
+                                "constraints": { "type": "array", "items": { "type": "string" } },
+                                "style": {
+                                    "type": "string",
+                                    "enum": ["hack", "vibe", "engineer"],
+                                    "description": "Optional ceremony level requested for a coding handoff: \"hack\" (trivial, no code change), \"vibe\" (small change, reduced process), \"engineer\" (full lifecycle — spec, branch, tests, review). This is a REQUEST: the receiver may apply more ceremony than you ask for and will tell you what it actually applied, but never less. It changes only how carefully the work is done — never what the receiver is allowed to do, and never which checks the repository itself enforces."
+                                }
                             },
                             "additionalProperties": false
                         }
@@ -243,40 +301,82 @@ impl ToolExecutor for PmBridgeTool {
             .get("specialist")
             .and_then(Value::as_str)
             .filter(|s| !s.trim().is_empty());
+        // #4350: the reserved coding-PM name is recognised FIRST and never
+        // consulted against the non-coding allow-set — `CODING_PM_TARGET` is
+        // deliberately absent from `NON_CODING_TARGETS`, which stays the closed
+        // #4126 floor for the non-coding vocabulary only. The two lanes are
+        // separate resolutions over separate vocabularies; neither can widen
+        // the other.
         let target = match requested {
-            Some(name) => match self.allow_set.resolve(name) {
-                Ok(resolved) => Some(resolved),
-                Err(denied) => return ToolResult::err(format!("dispatch_task: {denied}")),
+            Some(name) => match DispatchTarget::for_reserved_name(name) {
+                Some(coding_pm) => Some(coding_pm),
+                None => match self.allow_set.resolve(name) {
+                    Ok(resolved) => Some(DispatchTarget::NonCoding(resolved)),
+                    Err(denied) => return ToolResult::err(format!("dispatch_task: {denied}")),
+                },
             },
             None => None,
         };
 
-        let body = match handoff.render_preamble() {
-            Some(preamble) => format!("{preamble}\n{task}"),
-            None => task.to_string(),
-        };
         // #4026: a named specialist always takes the external-roster leg —
         // that roster is where the non-coding specialists live (#4027), and
         // re-deriving the route would let an unrelated phrase in `task` send
-        // a named target somewhere it does not exist.
+        // a named target somewhere it does not exist. #4350's coding PM lives
+        // on the same leg (it IS that leg's default agent), so naming it forces
+        // the coding lane rather than re-deriving it from the task text.
         let route = match target {
             Some(_) => BridgeRoute::Tcode,
             None => route_task(task),
         };
 
-        match self.backend.run(route, target.as_deref(), &body).await {
+        // #4349/#4350: resolve the style AFTER the lane is known, because the
+        // lane supplies the floor. Caller > config > built-in `engineer`, then
+        // raised (never lowered) to that floor and to the nearest implemented
+        // tier. The result feeds the preamble and the returned envelope; it is
+        // deliberately NOT an input to `route`, `target`, or anything the
+        // backend is handed beyond advisory text (DOC-62 SM-11).
+        let floor = match &target {
+            Some(t) => t.style_floor(),
+            // An unnamed dispatch that the router sends to the coding lane is
+            // still a coding delegation, so it carries the same floor.
+            None => match route {
+                BridgeRoute::Tcode => DispatchTarget::CodingPm.style_floor(),
+                BridgeRoute::Tm => ExecutionStyle::Hack,
+            },
+        };
+        let style = ResolvedStyle::resolve(handoff.style, self.default_style, floor);
+
+        let body = match handoff.render_preamble(Some(&style)) {
+            Some(preamble) => format!("{preamble}\n{task}"),
+            None => task.to_string(),
+        };
+        let reported_style = style.is_explicit().then_some(style);
+
+        match self
+            .backend
+            .run(
+                route,
+                target.as_ref().and_then(DispatchTarget::backend_agent),
+                &body,
+            )
+            .await
+        {
             Ok(out) => {
                 let scrubbed = scrub_branding(&out);
                 match target {
                     // #4028: a cross-product specialist's result is wrapped in
                     // the propose-only envelope — DOC-41 §5.5 line 1398.
-                    Some(name) => ToolResult::ok(
+                    // #4350: carrying the resolved style so the caller can see
+                    // what actually ran (DOC-62 §3.4). Still a proposal; the
+                    // style rides along, it does not upgrade anything.
+                    Some(named) => ToolResult::ok(
                         ProposalEnvelope::for_cross_product(
                             self.origin_agent.clone(),
-                            name,
+                            named.label(),
                             self.caller_authority,
                             scrubbed,
                         )
+                        .with_style(reported_style)
                         .render(),
                     ),
                     // Unnamed dispatch is the pre-#4026 opaque path, returned

--- a/crates/trusty-agents/src/tools/pm_bridge_tests.rs
+++ b/crates/trusty-agents/src/tools/pm_bridge_tests.rs
@@ -514,3 +514,265 @@ fn widened_schema_names_no_backend_or_roster() {
     }
     assert!(schema.contains("specialist"));
 }
+
+// =====================================================================
+// The addressable coding PM (#4350) and execution style (#4349)
+// =====================================================================
+
+/// The reserved name reaches the coding lane WITHOUT any allow-set grant —
+/// `coding-pm` is not on the non-coding floor and is not resolved through it.
+#[tokio::test]
+async fn coding_pm_is_addressable_without_a_non_coding_grant() {
+    let backend = Arc::new(RecordingBackend::new("proposed diff"));
+    // No `with_allow_set`: named NON-CODING targeting stays fully disabled.
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({
+            "task": "add a null check to the parser",
+            "specialist": "coding-pm",
+        }))
+        .await;
+
+    assert!(!result.is_error(), "expected success: {}", result.content());
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert_eq!(invoked.len(), 1);
+    assert_eq!(invoked[0].0, BridgeRoute::Tcode);
+    // The structural guarantee: no caller string crosses into the agent slot.
+    assert_eq!(
+        invoked[0].1, None,
+        "the coding lane must receive no caller-supplied agent name"
+    );
+}
+
+/// Naming the coding PM adds NO reach: the backend call is identical to the
+/// unnamed coding dispatch the router already produces for the same task.
+#[tokio::test]
+async fn naming_the_coding_pm_matches_the_unnamed_coding_dispatch() {
+    let task = "fix the failing unit test in parser.rs";
+
+    let unnamed_backend = Arc::new(RecordingBackend::new("ok"));
+    PmBridgeTool::new(unnamed_backend.clone())
+        .execute(json!({ "task": task }))
+        .await;
+
+    let named_backend = Arc::new(RecordingBackend::new("ok"));
+    PmBridgeTool::new(named_backend.clone())
+        .execute(json!({ "task": task, "specialist": "coding-pm" }))
+        .await;
+
+    let unnamed = unnamed_backend.invoked_with.lock().unwrap();
+    let named = named_backend.invoked_with.lock().unwrap();
+    assert_eq!(
+        (unnamed[0].0, &unnamed[0].1, &unnamed[0].2),
+        (named[0].0, &named[0].1, &named[0].2),
+        "addressing the coding PM must not change what crosses the boundary"
+    );
+}
+
+/// A coding-PM result is wrapped in the propose-only envelope, same as any
+/// other cross-product target.
+#[tokio::test]
+async fn coding_pm_result_is_wrapped_as_a_proposal() {
+    let backend = Arc::new(RecordingBackend::new("here is a diff"));
+    let tool = PmBridgeTool::new(backend);
+
+    let result = tool
+        .execute(json!({ "task": "rename the field", "specialist": "coding-pm" }))
+        .await;
+
+    assert!(!result.is_error());
+    assert!(
+        result.content().contains("PROPOSAL"),
+        "{}",
+        result.content()
+    );
+    assert!(
+        result.content().contains("\"disposition\": \"proposal\""),
+        "{}",
+        result.content()
+    );
+}
+
+/// A non-coding name is STILL denied when no allow-set is configured — making
+/// the coding PM addressable did not open the named-specialist lane.
+#[tokio::test]
+async fn the_coding_pm_name_does_not_open_the_non_coding_lane() {
+    let backend = Arc::new(RecordingBackend::new("never"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    for name in ["research", "ticketing", "engineer", "coding_pm", "pm"] {
+        let result = tool
+            .execute(json!({ "task": "do the thing", "specialist": name }))
+            .await;
+        assert!(
+            result.is_error(),
+            "{name} must be denied: {}",
+            result.content()
+        );
+    }
+    assert!(
+        backend.invoked_with.lock().unwrap().is_empty(),
+        "a denial must dispatch nothing"
+    );
+}
+
+/// **AC-9 / SM-11.** Style never touches the tool surface: for the SAME task,
+/// all three styles produce the same route, the same target, and the same
+/// RBAC restriction. Only the advisory preamble text differs.
+#[tokio::test]
+async fn style_does_not_change_the_route_target_or_rbac_surface() {
+    let mut observed = Vec::new();
+    for style in ["hack", "vibe", "engineer"] {
+        let backend = Arc::new(RecordingBackend::new("ok"));
+        let tool = PmBridgeTool::new(backend.clone())
+            .with_restricted_tiers(vec![ServiceTier::ReadOnly, ServiceTier::Analytics]);
+        tool.execute(json!({
+            "task": "add a null check to the parser",
+            "specialist": "coding-pm",
+            "handoff": { "style": style },
+        }))
+        .await;
+        assert_eq!(
+            tool.restricted_tiers(),
+            &[ServiceTier::ReadOnly, ServiceTier::Analytics],
+            "style must not change the RBAC surface"
+        );
+        let invoked = backend.invoked_with.lock().unwrap();
+        observed.push((invoked[0].0, invoked[0].1.clone()));
+    }
+    assert!(
+        observed.windows(2).all(|w| w[0] == w[1]),
+        "style changed the dispatch surface: {observed:?}"
+    );
+}
+
+/// The advisory policy block travels with the task, and reports the SM-9
+/// fallback rather than pretending `vibe` ran.
+#[tokio::test]
+async fn a_styled_coding_delegation_carries_the_policy_preamble() {
+    let backend = Arc::new(RecordingBackend::new("ok"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({
+            "task": "add a null check to the parser",
+            "specialist": "coding-pm",
+            "handoff": { "style": "vibe" },
+        }))
+        .await;
+
+    let invoked = backend.invoked_with.lock().unwrap();
+    let body = &invoked[0].2;
+    assert!(body.contains("Delegation policy"), "{body}");
+    assert!(
+        body.contains("Effective execution style: engineer"),
+        "{body}"
+    );
+    assert!(body.contains("tier-unimplemented"), "{body}");
+    assert!(body.ends_with("add a null check to the parser"), "{body}");
+    // …and the caller is told in the RESULT too (DOC-62 §3.4 / AC-4).
+    assert!(
+        result.content().contains("tier-unimplemented"),
+        "{}",
+        result.content()
+    );
+}
+
+/// AC-2: with no style anywhere, the task body is byte-identical to today's.
+#[tokio::test]
+async fn an_unstyled_dispatch_carries_no_policy_block() {
+    let backend = Arc::new(RecordingBackend::new("ok"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({ "task": "fix the failing unit test in parser.rs" }))
+        .await;
+
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert_eq!(invoked[0].2, "fix the failing unit test in parser.rs");
+    assert!(!result.content().contains("Delegation policy"));
+}
+
+/// The configured default is the middle precedence level and is honoured when
+/// the caller supplies nothing.
+#[tokio::test]
+async fn config_default_style_is_used_when_the_caller_supplies_none() {
+    let backend = Arc::new(RecordingBackend::new("ok"));
+    let tool = PmBridgeTool::new(backend.clone()).with_default_style(Some(
+        crate::tools::execution_style::ExecutionStyle::Engineer,
+    ));
+
+    tool.execute(json!({ "task": "fix the failing unit test in parser.rs" }))
+        .await;
+
+    let invoked = backend.invoked_with.lock().unwrap();
+    assert!(
+        invoked[0].2.contains("Effective execution style: engineer"),
+        "{}",
+        invoked[0].2
+    );
+}
+
+/// caller > config: a per-delegation value outranks the configured default —
+/// but still cannot lower ceremony below the lane's floor.
+#[tokio::test]
+async fn a_caller_style_beats_the_config_default() {
+    let backend = Arc::new(RecordingBackend::new("ok"));
+    let tool = PmBridgeTool::new(backend.clone()).with_default_style(Some(
+        crate::tools::execution_style::ExecutionStyle::Engineer,
+    ));
+
+    tool.execute(json!({
+        "task": "add a null check to the parser",
+        "specialist": "coding-pm",
+        "handoff": { "style": "hack" },
+    }))
+    .await;
+
+    let invoked = backend.invoked_with.lock().unwrap();
+    let body = &invoked[0].2;
+    assert!(body.contains("Requested style was hack"), "{body}");
+    // …and the callee floor plus the unimplemented tier still raise it.
+    assert!(
+        body.contains("Effective execution style: engineer"),
+        "{body}"
+    );
+}
+
+/// An unrecognized style is a recoverable caller error and dispatches nothing.
+#[tokio::test]
+async fn an_unknown_style_is_rejected_before_dispatch() {
+    let backend = Arc::new(RecordingBackend::new("never"));
+    let tool = PmBridgeTool::new(backend.clone());
+
+    let result = tool
+        .execute(json!({
+            "task": "add a null check",
+            "handoff": { "style": "turbo" },
+        }))
+        .await;
+
+    assert!(result.is_error(), "{}", result.content());
+    assert!(
+        backend.invoked_with.lock().unwrap().is_empty(),
+        "nothing may be dispatched on an invalid style"
+    );
+}
+
+/// The schema names the coding PM (so the model can address it) and enumerates
+/// the closed style vocabulary, while still naming no backend product.
+#[test]
+fn schema_advertises_the_coding_pm_and_the_closed_style_vocabulary() {
+    let tool = PmBridgeTool::new(Arc::new(RecordingBackend::new("ok")));
+    let schema = serde_json::to_string(&tool.schema()).expect("schema serializes");
+    assert!(schema.contains("coding-pm"), "{schema}");
+    assert!(schema.contains("hack"), "{schema}");
+    assert!(schema.contains("vibe"), "{schema}");
+    for forbidden in ["tcode", "trusty-code", "trusty-mpm"] {
+        assert!(
+            !schema.to_ascii_lowercase().contains(forbidden),
+            "schema leaked backend identity {forbidden}: {schema}"
+        );
+    }
+}


### PR DESCRIPTION
Both halves of the same plumbing, built against **DOC-62 §5/§6** (PR #4529, read from that branch). Milestone 22 (M2), pillar (a) coding delegation.

Closes #4349
Closes #4350

---

## #4349 — `HandoffContext` style field + TA-PM-policy preamble

- `HandoffContext` gains `style: Option<ExecutionStyle>` — a **typed** field, per DOC-62 §6.4's shaping note ("do not have callers hand-write style prose into `summary` or `constraints`"). `ExecutionStyle` is a closed three-variant enum (`hack`/`vibe`/`engineer`, lowercase wire form). An unrecognized value is a `serde` error the bridge returns before anything is dispatched — never a silent default (§5.1).
- `render_preamble` gains the TA-PM-policy block. It carries exactly what SM-7 permits: the effective style, the ceremony/gate boundary (SM-1/SM-5), the honest-reporting rule (SM-4), the no-capability rule (SM-11), and decision 2's PM-only statement **as information**. Per SM-8 the block ends by saying that last boundary is *"enforced in code, not by this text"*, so no future reader mistakes the paragraph for the mechanism.
- Ordering follows §6.4: the policy block renders **after** the caller's `- Constraint:` lines and under its own heading (`Delegation policy (system-supplied, not from the caller):`), so caller text is not confusable with policy text. Pinned by `policy_block_follows_caller_supplied_constraints`.
- **Backward compatibility is literal.** `style` is `skip_serializing_if = "Option::is_none"`, so an unstyled `HandoffContext` serializes to the same bytes as before and the 4 KiB cap measures the same payload. `ResolvedStyle::is_explicit()` gates the block, so a dispatch with no style anywhere renders no block at all — `an_unstyled_dispatch_carries_no_policy_block` asserts the task body is byte-identical.
- The block is **bounded and task-independent** (`policy_block_is_bounded_and_task_independent`, < 1 KiB across the full request×floor cross-product), so the cap can never become a function of task size.

## #4350 — addressable coding PM, `NON_CODING_TARGETS` preserved

- `CODING_PM_TARGET = "coding-pm"` names the external coding project manager the coding lane has always run (`DEFAULT_TCODE_AGENT`). Naming it makes the existing route **selectable and stylable** instead of reachable only by accident of task phrasing.
- Style resolves **caller > `[subagents] default_style` > built-in `engineer`** (§5.3). The config key is new and additive; absent falls through to `engineer`, i.e. today's behaviour, and an unrecognized value is a config parse error.
- The resolution path travels back to the caller on the `ProposalEnvelope` (§3.4 / AC-4), so a `vibe` request that actually ran `engineer` says so in the result, not only in the outbound preamble.

### `NON_CODING_TARGETS` is unchanged and still code-enforced

```rust
pub const NON_CODING_TARGETS: &[&str] = &["research", "ticketing"];
```

Byte-identical on this branch. Three tests pin it:

- `non_coding_targets_floor_membership_is_pinned` asserts exact membership (AC-5), so a future widening is a red build rather than a review miss.
- `coding_pm_is_not_reachable_through_the_non_coding_floor` asserts that a *permissive config* listing `coding-pm` still gets `Err` from `SubagentAllowSet::resolve` — the coding name cannot be smuggled onto the non-coding floor.
- `the_coding_pm_name_does_not_open_the_non_coding_lane` asserts `research` / `ticketing` / `engineer` / `pm` are all still denied with no allow-set configured, and that a denial dispatches nothing.

The reserved name resolves on a **separate path** that never consults the allow-set, precisely so the floor stays a single-vocabulary closed literal. Nothing became data-driven; nothing is enforced by preamble text.

## DOC-62 conformance — §5/§6

| Rule | How |
|---|---|
| §5.1 closed enum, error on unknown | `ExecutionStyle` + `an_unknown_style_is_a_caller_error_not_a_silent_default` |
| §5.2 built-in default `engineer` | `ExecutionStyle::BUILT_IN_DEFAULT` |
| §5.3 caller > config > built-in | `precedence_is_caller_then_config_then_built_in` |
| §5.4 raise, never lower | structural — see below |
| §6.1 preamble, not prompt composition | extends `render_preamble()`; no new mechanism invented |
| §6.3 SM-7 / SM-8 | policy text names its own advisory status |
| §6.4 typed field, block after caller lines, bounded, `None` renders nothing | four tests, listed above |
| §7.3 SM-9 | see below |
| SM-11 style never touches the tool surface | see below |
| AC-10 disposition unchanged | `a_styled_envelope_is_still_only_a_proposal` |

## SM-9 fallback behaviour

`vibe` is unimplemented (#2596), so a resolved `vibe` runs the `engineer` pipeline and **reports** effective style `engineer` with reason `tier-unimplemented`. Implemented as `ExecutionStyle::implemented()` — one function that changes when #2596 lands, with no interface change and no re-plumbing.

The caller sees it in both directions: `Effective execution style: engineer` plus `Requested style was vibe; raised to engineer (tier-unimplemented)` in the outbound preamble, and `"escalations": ["tier-unimplemented"]` in the returned envelope. Asserted end-to-end through the bridge by `a_styled_coding_delegation_carries_the_policy_preamble`, and in isolation by `vibe_degrades_upward_to_engineer_and_says_why`.

## How the style invariant is made structural

Modelled on `ProposalEnvelope::for_cross_product`, whose doc comment calls hardcoding `Disposition::Proposal` in the sole constructor *"structural rather than a convention a future edit could forget"*. Four properties compose:

1. **`ExecutionStyle` variants are declared in ascending ceremony order**, so the derived `Ord` makes `a.max(b)` mean *"the higher ceremony of the two"*. Every escalation in the module is a `max`.
2. **`ResolvedStyle::resolve` is the only constructor.** No `Default`, no `From`, no public field, no mutator. There is no way to obtain a `ResolvedStyle` except by resolving one.
3. **Every input is combined with `max`**, and the tier fail-safe `implemented()` is itself monotonically non-decreasing (`implemented_never_lowers_ceremony`). The composition is therefore monotone: no code path yields an effective style below the floor.
4. A `debug_assert!` postcondition at the single construction site, backed by an unconditional test.

The one thing convention still guards, stated in the type docs: reordering the enum variants would silently invert `Ord` and therefore the whole property. `ceremony_order_is_ascending` fails if anyone does.

## The ceiling test

Asserted over the **full request × floor cross-product**, not one happy path:

```rust
#[test]
fn a_caller_can_never_lower_ceremony_below_the_callee_floor() {
    for requested in ALL {
        for floor in ALL {
            let resolved = ResolvedStyle::resolve(Some(requested), None, floor);
            assert!(resolved.effective() >= floor);
            assert!(resolved.effective() >= requested);
        }
    }
}
```

Plus `a_config_default_can_never_lower_ceremony_below_the_callee_floor` (a config default is an author tag too) and, at the delegation surface, `a_hack_request_to_the_coding_pm_does_not_lower_ceremony` — a caller asking the coding PM for `hack` gets `engineer` and is told both reasons.

## Style never touches the tool surface (SM-11) — structural, with the honest boundary

**Structurally impossible within this diff.** `ResolvedStyle` exposes no accessor that reaches a tool list, a permission, or a command line; the only consumers of the resolved value are `render_policy_block()` (a `String`) and the envelope field. `route`, `target`, the argv, the allow-set, and `restricted_tiers()` are all computed *before* `ResolvedStyle::resolve` is called, from inputs that do not include a style. Asserted by `style_does_not_change_the_route_target_or_rbac_surface`: for the same task, all three styles produce the same route, the same target, and the same RBAC tier list.

**What remains only conventional, stated plainly:** the policy block is *text a model reads*. A model on the far side could disregard it, or be persuaded by it — which is exactly SM-8's point, and why the `NON_CODING_TARGETS` boundary is enforced in code and the preamble says so about itself. This PR does not, and cannot, make a preamble tamper-proof.

## On reach — naming the PM adds none

`DispatchTarget::CodingPm::backend_agent()` returns `None`, so the coding leg falls through to the backend's own hardcoded `DEFAULT_TCODE_AGENT` and **no caller-supplied string can become the coding leg's `<AGENT>` argv slot**. `naming_the_coding_pm_matches_the_unnamed_coding_dispatch` asserts the `(route, target, task)` tuple crossing the boundary is identical to the unnamed coding dispatch the router already produces for the same task.

One behavioural delta, stated rather than glossed: a caller can now *force* the coding lane for text `route_task` would have sent to `Tm`. That is not new reach — `route_task` is a pure function of caller-authored text, so the caller already fully controlled that choice and only had to phrase around it — but it is now explicit instead of implicit, which is the point of the issue. No shell capability is granted, widened, or assumed here.

## Where DOC-62 / the issues did not survive contact with the code

Reported plainly rather than worked around quietly.

1. **#4350's "LLM is told tcode PM exists … (opposite of `scrub_branding`)" is only half-implemented, deliberately.** The black-box contract is owner-locked (#3052 PR B): the schema must not name a backend, and `scrub_branding` strips backend identity from every transcript. DOC-62 never rules on de-branding. I made the target addressable under an **unbranded capability name** (`coding-pm`) and described what it does, so the LLM now knows a coding PM exists and can name it — but it still does not learn the backend is `tcode`. `schema_advertises_the_coding_pm_and_the_closed_style_vocabulary` pins that no branded token leaked. **If the owner intends the branding rule itself to be relaxed, that is a separate decision and this PR did not make it.**
2. **DOC-62 never says what the coding lane's ceremony floor IS.** §5.4 only says the callee MAY raise. To make the ceiling testable at the delegation surface I had to pick one, and derived `vibe` from §4.1 (*"`hack` is not coding with no gates … a delegation that asks for `hack` and then turns out to require a code change MUST escalate"*). That is an **inference from §4.1, not a spec statement.** If the owner wants a coding delegation to be able to resolve to `hack`, one constant changes.
3. **§3.4's gate ledger (`passed`/`failed`/`not-run(style)`) and AC-7 are not in this PR and are not satisfiable from it.** That data does not exist on this side of the boundary — the tcode return payload is a `Session` snapshot with no per-check detail (§6.2 point 6; OQ-4 is still open on structured-vs-prose). This PR delivers the §3.4 half that *does* live here: effective style, resolution path, and escalation reasons.
4. **AC-4's "resolution path present in the returned result" holds only on the named-target path.** An unnamed dispatch returns a bare scrubbed transcript with no envelope — byte-identity that is a pre-#4026 requirement I did not want to break. A styled *unnamed* dispatch therefore carries the policy block outbound but gets no structured resolution back. The remedy is to name the target, which is what #4350 adds.
5. **§6.4 asks for a "fixed-length" policy block; mine is bounded and task-independent but not literally fixed-length** — it grows one line when an escalation occurred. Literal fixed length would mean not reporting the escalation, which SM-4 / §3.4 require. I chose honest reporting over the literal word.
6. **OQ-1 (per-assistant vs global config default) is still unanswered.** I implemented **per-assistant only** (`[subagents] default_style`), matching OQ-1's own recommendation but not ratified. A global level can be added later as a fourth precedence step without touching the resolution shape.
7. **AC-6's recommended repo-wide "no style value reaches a merge/push/gate-skip flag" check is not included.** It was outside the stated scope and its natural home is a workspace-level gate, not a `trusty-agents` unit test. The narrower structural property *is* asserted, and no code in this diff constructs an argv from a style value.

## Not in scope, confirmed untouched

`ASSISTANT_REACHABLE_SUBAGENTS`, `[subagents].delegate_allowed`, and the delegate allow-set are unmodified. No existing test was weakened, deleted, or `#[ignore]`d — `bundled_personas_pin_git_reach` and `agents/tests/loading.rs` are untouched. The only edits to existing tests are mechanical call-site updates for the new struct field and the `render_preamble(None)` argument; every assertion is unchanged. Nothing from #2596 (VIBE tier behaviour) or #4353 (GUI) is implemented, and no shell-permission model is introduced.

## Changelog

`crates/trusty-agents/changelog.d/4349-4350-style-aware-coding-handoff.md`. Only `trusty-agents` is touched, so the `-p` set below is scoped to it.

## Gate output

```
$ cargo fmt --check
(clean — no output)

$ cargo clippy -p trusty-agents --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s)
exit 0

$ cargo test -p trusty-agents
test result: ok. 3195 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 27.88s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 3.96s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.55s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.12s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.13s
exit 0

$ cargo test -p trusty-agents -- --test-threads=1
test result: ok. 3195 passed; 0 failed; 11 ignored; 0 measured; 0 filtered out; finished in 59.18s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
test result: ok. 6 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 4.18s
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.78s
test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.05s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.12s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 7.12s
test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 2.67s
test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.47s
test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
exit 0

$ bash scripts/check_line_cap.sh
line-cap: 7 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 50 spec doc(s) + 2985 code file(s); 0 error(s), 0 warning(s)
exit 0

$ bash scripts/check_test_pointers.sh
test-pointers: 0 dangling pointers — OK.
```

`cargo test -p trusty-code` is omitted deliberately: this PR touches only `trusty-agents` (the tcode-side style parameter is #4348, not this slice).

The 55 new tests, all green in both passes:

```
test agents::tests::loading::assistant_reachable_floor_names_resolve_in_the_bundled_roster ... ok
test agents::tests::loading::bundled_agent_tier_table_is_pinned ... ok
test agents::tests::subagents_config_parses_default_style ... ok
test agents::tests::subagents_config_rejects_an_unknown_default_style ... ok
test tools::cross_product::cross_product_tests::a_hack_request_to_the_coding_pm_does_not_lower_ceremony ... ok
test tools::cross_product::cross_product_tests::a_style_only_handoff_renders_only_the_policy_block ... ok
test tools::cross_product::cross_product_tests::a_styled_envelope_is_still_only_a_proposal ... ok
test tools::cross_product::cross_product_tests::a_styled_handoff_stays_within_the_cap ... ok
test tools::cross_product::cross_product_tests::an_unknown_style_is_a_caller_error_not_a_silent_default ... ok
test tools::cross_product::cross_product_tests::an_unstyled_envelope_is_byte_identical ... ok
test tools::cross_product::cross_product_tests::an_unstyled_handoff_serializes_without_a_style_key ... ok
test tools::cross_product::cross_product_tests::coding_pm_carries_no_caller_string_into_the_backend ... ok
test tools::cross_product::cross_product_tests::coding_pm_floor_is_at_least_vibe ... ok
test tools::cross_product::cross_product_tests::coding_pm_is_not_reachable_through_the_non_coding_floor ... ok
test tools::cross_product::cross_product_tests::coding_pm_name_matching_is_case_and_space_insensitive ... ok
test tools::cross_product::cross_product_tests::coding_pm_target_name_is_pinned ... ok
test tools::cross_product::cross_product_tests::non_coding_targets_floor_membership_is_pinned ... ok
test tools::cross_product::cross_product_tests::policy_block_follows_caller_supplied_constraints ... ok
test tools::cross_product::cross_product_tests::styled_coding_delegation_returns_a_proposal_with_the_resolution ... ok
test tools::execution_style::execution_style_tests::a_caller_can_never_lower_ceremony_below_the_callee_floor ... ok
test tools::execution_style::execution_style_tests::a_config_default_can_never_lower_ceremony_below_the_callee_floor ... ok
test tools::execution_style::execution_style_tests::a_floor_above_the_request_is_reported_as_an_escalation ... ok
test tools::execution_style::execution_style_tests::an_unknown_style_string_is_a_deserialization_error ... ok
test tools::execution_style::execution_style_tests::an_unrequested_style_renders_no_policy_block ... ok
test tools::execution_style::execution_style_tests::both_escalations_are_reported_when_both_apply ... ok
test tools::execution_style::execution_style_tests::built_in_default_is_engineer ... ok
test tools::execution_style::execution_style_tests::ceremony_order_is_ascending ... ok
test tools::execution_style::execution_style_tests::escalation_tags_match_the_spec_wire_names ... ok
test tools::execution_style::execution_style_tests::implemented_never_lowers_ceremony ... ok
test tools::execution_style::execution_style_tests::policy_block_is_bounded_and_task_independent ... ok
test tools::execution_style::execution_style_tests::policy_block_reports_the_tier_unimplemented_fallback ... ok
test tools::execution_style::execution_style_tests::policy_block_states_effective_style_and_the_gate_boundary ... ok
test tools::execution_style::execution_style_tests::precedence_falls_through_to_built_in ... ok
test tools::execution_style::execution_style_tests::precedence_is_caller_then_config_then_built_in ... ok
test tools::execution_style::execution_style_tests::resolution_is_reported_end_to_end ... ok
test tools::execution_style::execution_style_tests::styles_round_trip_lowercase ... ok
test tools::execution_style::execution_style_tests::vibe_degrades_upward_to_engineer_and_says_why ... ok
test tools::pm_bridge::pm_bridge_tests::a_caller_style_beats_the_config_default ... ok
test tools::pm_bridge::pm_bridge_tests::a_styled_coding_delegation_carries_the_policy_preamble ... ok
test tools::pm_bridge::pm_bridge_tests::an_unknown_style_is_rejected_before_dispatch ... ok
test tools::pm_bridge::pm_bridge_tests::an_unstyled_dispatch_carries_no_policy_block ... ok
test tools::pm_bridge::pm_bridge_tests::coding_pm_is_addressable_without_a_non_coding_grant ... ok
test tools::pm_bridge::pm_bridge_tests::coding_pm_result_is_wrapped_as_a_proposal ... ok
test tools::pm_bridge::pm_bridge_tests::config_default_style_is_used_when_the_caller_supplies_none ... ok
test tools::pm_bridge::pm_bridge_tests::naming_the_coding_pm_matches_the_unnamed_coding_dispatch ... ok
test tools::pm_bridge::pm_bridge_tests::schema_advertises_the_coding_pm_and_the_closed_style_vocabulary ... ok
test tools::pm_bridge::pm_bridge_tests::style_does_not_change_the_route_target_or_rbac_surface ... ok
test tools::pm_bridge::pm_bridge_tests::the_coding_pm_name_does_not_open_the_non_coding_lane ... ok
```


🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
