### PR TITLE
fix(trusty-mpm): regenerate stale bundled-fallback golden — main is red after #4593

### DIFF
--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -711,10 +711,20 @@ New issues are reserved for genuinely separable work someone would schedule on i
 
 # Agent Delegation Routing
 
-> This file defines the agent routing table and delegation logic for the PM.
-> Override at project level: .trusty-mpm/AGENT_DELEGATION.md
-> Override at user level:    ~/.trusty-mpm/AGENT_DELEGATION.md
-> System default:            crates/trusty-mpm/src/assets/instructions/AGENT_DELEGATION.md (this file)
+> STATIC: the routing doctrine below is hand-authored, for the universal
+> system agents. It does not change per project.
+>
+> ENRICHED: at composition time, trusty-mpm appends a generated roster built
+> by scanning deployed agents — project `.claude/agents`, the managed
+> `CLAUDE_CONFIG_DIR/agents`, and the framework agents dir, project tier
+> winning on a name collision. The scan reads every `.md` file on disk, so it
+> picks up manifest-declared AND user-installed agents. That roster is
+> required; composition fails without it. Exception: agents whose frontmatter
+> carries `role: base` are filtered out as foundation templates, which
+> currently hides `memory-manager`, `mpm-agent-manager`, and
+> `mpm-skills-manager` (#4589).
+>
+> This file: crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md
 
 ## When to Delegate to Each Agent
 


### PR DESCRIPTION
## main is currently RED — this restores it

`cargo test -p trusty-mpm --lib -- golden_bundled_fallback_prompt` fails on current `origin/main`:

```
DELIVERED PM PROMPT CHANGED — pm-prompt-bundled-fallback.md
first difference at byte offset 33531 (golden 45111 bytes, composed 45630 bytes)
```

**First-bad commit: `42c7774e` ([#4593](https://github.com/bobmatnyc/trusty-tools/pull/4593)).** It rewrote the header of `crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md` — replacing the four `Override at project level` / `System default` lines with the STATIC/ENRICHED description — and touched zero files under `crates/trusty-mpm/src/core/testdata/`. The golden fixture was never regenerated, so every run since has carried an uncommitted 519-byte diff.

`0aec8866` ([#4592](https://github.com/bobmatnyc/trusty-tools/pull/4592)) later ran a golden regeneration, but against a branch state that predated #4593's merge — a no-op for this file, so the mismatch survived.

The test is not machine-dependent: `pm_prompt_golden_tests.rs:46` uses a hardcoded `FIXED_ROSTER` precisely to avoid that. This is a genuine content mismatch.

## The diff was enumerated before regenerating

[#4268](https://github.com/bobmatnyc/trusty-tools/issues/4268) is the known hazard that a blind `UPDATE_GOLDEN=1` silently deletes instruction prose. It does **not** apply here, and that was verified rather than assumed:

- The regenerated diff is **4 lines removed, 14 added** — element-for-element **identical** to #4593's own source hunk (compared programmatically, not by eye). Zero unexplained lines in either direction.
- Independent corroboration: the old→new header is exactly **+519 bytes**, matching the composed/golden size gap (45630 − 45111) precisely.

Every removed line:

```
> This file defines the agent routing table and delegation logic for the PM.
> Override at project level: .trusty-mpm/AGENT_DELEGATION.md
> Override at user level:    ~/.trusty-mpm/AGENT_DELEGATION.md
> System default:            crates/trusty-mpm/src/assets/instructions/AGENT_DELEGATION.md (this file)
```

Every added line is the 14-line STATIC/ENRICHED block introduced by #4593. No other prose moved.

## All three fixtures were checked — only one was stale

| fixture | status |
|---|---|
| `pm-prompt-bundled-fallback.md` | **was stale** — regenerated here |
| `pm-prompt-claude-md-override.md` | already current; byte-for-byte unchanged by regeneration |
| `pm-prompt-legacy-delegation-override.md` | already current; byte-for-byte unchanged by regeneration |

The other two override the AGENT-DELEGATION section wholesale, so #4593's header never reaches them. Confirmed two ways: they passed before this change, and their SHA-256 is identical before and after `UPDATE_GOLDEN=1`.

## Gates

| gate | result |
|---|---|
| `cargo test -p trusty-mpm --lib` | `4199 passed; 0 failed; 6 ignored` |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | exit 0 |
| `cargo fmt --check` | exit 0 |
| `bash scripts/check_instruction_floor.sh` | `PASS: instruction floor matches its pinned byte-exact digests` |
| `bash scripts/check_changelog_fragment.sh` | exit 0 |

No changelog fragment: the gate exempts `*/testdata/*` by design, and its own header comment (lines 66–70) names this exact scenario — regenerating `crates/trusty-mpm/src/core/testdata/pm-prompt-*.md` is test input, not a user-visible change.

## Separately: a second test is also red on main (NOT fixed here)

`trusty-code`'s `llm::client::tests::missing_openrouter_key_errors_at_chat_time` **does fail on current `origin/main`**, and needs its own change:

```
panicked at crates/trusty-code/src/llm/client.rs:604:9:
expected MissingConfig, got: MissingCredential { provider: OpenRouter }
```

It went unnoticed because the test **self-skips on any dev machine with a real key**: `client.rs:586` early-returns when `OPENROUTER_API_KEY` is non-empty, reporting `ok` without executing a single assertion. It only fails hermetically — which is what CI runs. Left untouched deliberately; it gates a separate sequencing decision.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools