### PR TITLE
fix(trusty-code): actionable MissingConfig for an absent OPENROUTER_API_KEY, and make the missing-key tests hermetic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11367,6 +11367,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2 0.10.9",
  "tempfile",
  "thiserror 1.0.69",

--- a/crates/trusty-code/Cargo.toml
+++ b/crates/trusty-code/Cargo.toml
@@ -153,3 +153,8 @@ tower = { workspace = true }
 # a real bound socket so `reqwest` (SSE included) drives it exactly like a
 # real `tcode serve --http` daemon, without spawning the real binary.
 wiremock = { workspace = true }
+# `llm::client::tests` (#4614): the missing-credential tests clear a provider's
+# API-key env var so they assert unconditionally instead of skipping on a
+# developer machine that has one. `#[serial]` joins the workspace-wide
+# exclusion group so that mutation cannot race a parallel test thread.
+serial_test = { workspace = true }

--- a/crates/trusty-code/changelog.d/4614-openrouter-missing-key-actionable.md
+++ b/crates/trusty-code/changelog.d/4614-openrouter-missing-key-actionable.md
@@ -1,0 +1,21 @@
+Fixed
+
+- **A missing `OPENROUTER_API_KEY` again reports an actionable error (issue
+  #4614).** OpenRouter is tcode's default route, so it is the first credential
+  a new operator has to set — yet since #4436 deleted the `convert::map_error`
+  bridge, an absent key surfaced as the shared resolver's bare
+  `MissingCredential { provider: OpenRouter }` ("no credential resolved for
+  provider openrouter"), which names nothing the operator can act on.
+  `build_adapter` now guards the OpenRouter route explicitly, exactly as it
+  already did for Fireworks, Together, and AtlasCloud, and returns
+  `MissingConfig` naming the env var and the three ways to set it. This is the
+  contract both `llm::client::build_adapter` and `llm::dispatch::chat` have
+  documented throughout; only the code had drifted.
+- **The missing-credential tests no longer pass without asserting anything
+  (issue #4614).** All four `missing_*_key_errors_*` tests returned early
+  whenever the corresponding API key was present in the ambient environment, so
+  on any developer machine holding a real key they reported `ok` having
+  executed zero assertions — which is why the regression above went unseen
+  locally and was visible only in CI. Each test now clears its own key for the
+  duration of the test body (`#[serial]`, restored on drop) so the assertions
+  run unconditionally, and no live API call is reachable.

--- a/crates/trusty-code/src/llm/client.rs
+++ b/crates/trusty-code/src/llm/client.rs
@@ -267,11 +267,15 @@ impl OpenAiCompatClient {
     /// only once the key is confirmed does it resolve + build the Fireworks
     /// adapter. Together (#2494) and AtlasCloud (#2536) follow the identical
     /// contract against `TOGETHER_API_KEY` / `ATLASCLOUD_API_KEY` respectively.
-    /// For OpenRouter, resolves on an `openrouter/` routing
-    /// slug (a missing key surfaces as the resolver's own `MissingCredential`,
-    /// mapped to `MissingConfig`). The resolved model slug is irrelevant to the
-    /// built adapter (it sends the per-request wire model), so a fixed routing
-    /// slug is used.
+    /// OpenRouter — the default route, and so the first one a new operator hits
+    /// — follows the SAME contract against `OPENROUTER_API_KEY` (#4614). Until
+    /// #4436 deleted the `convert::map_error` bridge this was achieved by
+    /// mapping the resolver's own `MissingCredential`; the explicit guard now
+    /// states it directly, and carries the actionable message
+    /// `MissingCredential` structurally cannot. Only once the key is confirmed
+    /// does it resolve on an `openrouter/` routing slug — the resolved model
+    /// slug is irrelevant to the built adapter (it sends the per-request wire
+    /// model), so a fixed routing slug is used.
     /// Test: `client::tests::missing_openrouter_key_errors_at_chat_time`,
     /// `client::tests::missing_fireworks_key_errors_not_falls_back`,
     /// `client::tests::missing_together_key_errors_not_falls_back`,
@@ -321,6 +325,15 @@ impl OpenAiCompatClient {
                 atlascloud::build(&resolved, &self.atlascloud_base)
             }
             _ => {
+                // #4614: restores the mapping #4436 dropped with `convert::map_error`.
+                if resolve_key_with("openrouter", self.store.as_ref()).is_none() {
+                    return Err(InferenceError::MissingConfig(
+                        "OPENROUTER_API_KEY is required to reach an openrouter model. Export it \
+                         (e.g. `export OPENROUTER_API_KEY=sk-or-...`), add it to .env.local, or \
+                         set it via `tcode config keys set openrouter`."
+                            .to_string(),
+                    ));
+                }
                 let resolved = provider_for("openrouter/route", self.store.as_ref())?;
                 openrouter::build(&resolved, &self.openrouter_base)
             }
@@ -438,7 +451,53 @@ impl InferenceAdapter for OpenAiCompatClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use trusty_common::inference::credentials::MemoryKeyStore;
+
+    /// RAII guard clearing one credential env var for the duration of a test.
+    ///
+    /// Why (#4614): the missing-credential tests below used to SKIP whenever the
+    /// ambient environment carried a real key — so on any developer machine that
+    /// has one they reported `ok` without executing a single assertion, and the
+    /// contract they pin was only ever checked hermetically in CI. That is what
+    /// let a real regression (the dropped `MissingConfig` mapping) sit
+    /// undetected. The skip existed for a sound reason — with a real key present
+    /// `chat()` would issue a LIVE API call — so the fix is not to delete the
+    /// guard but to remove its cause: clear the var, and no live call is
+    /// reachable by construction.
+    /// What: saves the previous value, removes the var, and restores the exact
+    /// prior state on drop (including "was unset"). The value is never read,
+    /// logged, or asserted on — only moved.
+    /// Test: `missing_openrouter_key_errors_at_chat_time`,
+    /// `missing_fireworks_key_errors_not_falls_back`,
+    /// `missing_together_key_errors_not_falls_back`,
+    /// `missing_atlascloud_key_errors_not_falls_back`.
+    struct ClearedKey {
+        key: &'static str,
+        prev: Option<String>,
+    }
+
+    impl ClearedKey {
+        fn new(key: &'static str) -> Self {
+            let prev = std::env::var(key).ok();
+            // SAFETY: serialized against every other env-mutating test by
+            // `#[serial]`, matching the workspace-wide convention.
+            unsafe { std::env::remove_var(key) };
+            Self { key, prev }
+        }
+    }
+
+    impl Drop for ClearedKey {
+        fn drop(&mut self) {
+            // SAFETY: as above.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(self.key, v),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
 
     /// A plain (non-fireworks) slug selects OpenRouter.
     ///
@@ -571,21 +630,25 @@ mod tests {
         );
     }
 
-    /// With an empty store and (assumed) no `OPENROUTER_API_KEY` env, an
-    /// OpenRouter chat fails at `chat()` time with a `MissingConfig` — never at
-    /// construction (#2245 deferred-failure contract).
+    /// With an empty store and no `OPENROUTER_API_KEY` env, an OpenRouter chat
+    /// fails at `chat()` time with an actionable `MissingConfig` naming the env
+    /// var — never at construction (#2245 deferred-failure contract), and never
+    /// as the bare `MissingCredential` the shared resolver raises (#4614).
     ///
     /// Why: pins that construction is credential-free and that the missing-key
-    /// error is actionable and surfaces only when a request needs it.
-    /// What: build with an empty `MemoryKeyStore`; if the ambient env happens to
-    /// carry a real key (dev machines), skip the assertion rather than make a
-    /// live call — the hermetic case (no env key) is what CI exercises.
+    /// error is actionable and surfaces only when a request needs it. OpenRouter
+    /// is the default route, so this is the error a new operator sees first —
+    /// "no credential resolved for provider openrouter" tells them nothing they
+    /// can act on, which is exactly what the three sibling providers below
+    /// already refuse to emit.
+    /// What: clear the env var for the test body and build with an empty
+    /// `MemoryKeyStore`, so NOTHING can resolve a credential and no live call is
+    /// reachable; assert the variant AND that the message names the env var.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn missing_openrouter_key_errors_at_chat_time() {
-        if std::env::var("OPENROUTER_API_KEY").is_ok_and(|v| !v.is_empty()) {
-            return; // real key present locally — don't issue a live call
-        }
+        let _cleared = ClearedKey::new("OPENROUTER_API_KEY");
         let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new())); // empty store
         let req = ChatRequest {
             model: "openai/gpt-4o-mini".into(),
@@ -601,10 +664,15 @@ mod tests {
             .chat(&req)
             .await
             .expect_err("must fail without a key");
-        assert!(
-            matches!(err, InferenceError::MissingConfig(_)),
-            "expected MissingConfig, got: {err:?}"
-        );
+        match err {
+            InferenceError::MissingConfig(msg) => {
+                assert!(
+                    msg.contains("OPENROUTER_API_KEY"),
+                    "unhelpful message: {msg}"
+                )
+            }
+            other => panic!("expected MissingConfig naming OPENROUTER_API_KEY, got: {other:?}"),
+        }
     }
 
     /// A `fireworks/*` request with no `FIREWORKS_API_KEY` fails with an
@@ -613,15 +681,14 @@ mod tests {
     /// Why: the shared resolver's stage-1 falls through to OpenRouter when a
     /// family key is absent; for an explicit tcode fireworks route that would be
     /// a wrong-provider misroute, so `build_adapter` turns it into a clear error.
-    /// What: with an empty store (and, when present locally, a real
-    /// `FIREWORKS_API_KEY` shadowing it, in which case skip), assert
-    /// `MissingConfig`.
+    /// What: with the env var cleared for the test body (#4614 — the former
+    /// skip-when-set guard meant this asserted nothing on a machine that has a
+    /// real key) and an empty store, assert `MissingConfig`.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn missing_fireworks_key_errors_not_falls_back() {
-        if std::env::var("FIREWORKS_API_KEY").is_ok_and(|v| !v.is_empty()) {
-            return; // real key present locally — the fall-back guard isn't exercised
-        }
+        let _cleared = ClearedKey::new("FIREWORKS_API_KEY");
         let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new()));
         let req = ChatRequest {
             model: "fireworks/accounts/fireworks/models/llama-v3p1-8b-instruct".into(),
@@ -655,15 +722,13 @@ mod tests {
     /// family key is absent; for an explicit tcode together route that would be a
     /// wrong-provider misroute, so `build_adapter` turns it into a clear error —
     /// the same contract as Fireworks.
-    /// What: with an empty store (and, when present locally, a real
-    /// `TOGETHER_API_KEY` shadowing it, in which case skip), assert
-    /// `MissingConfig` naming `TOGETHER_API_KEY`.
+    /// What: with the env var cleared for the test body (#4614) and an empty
+    /// store, assert `MissingConfig` naming `TOGETHER_API_KEY`.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn missing_together_key_errors_not_falls_back() {
-        if std::env::var("TOGETHER_API_KEY").is_ok_and(|v| !v.is_empty()) {
-            return; // real key present locally — the fall-back guard isn't exercised
-        }
+        let _cleared = ClearedKey::new("TOGETHER_API_KEY");
         let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new()));
         let req = ChatRequest {
             model: "together/meta-llama/Llama-3.3-70B-Instruct-Turbo".into(),
@@ -695,15 +760,13 @@ mod tests {
     /// family key is absent; for an explicit tcode atlascloud route that would be
     /// a wrong-provider misroute, so `build_adapter` turns it into a clear error —
     /// the same contract as Fireworks and Together.
-    /// What: with an empty store (and, when present locally, a real
-    /// `ATLASCLOUD_API_KEY` shadowing it, in which case skip), assert
-    /// `MissingConfig` naming `ATLASCLOUD_API_KEY`.
+    /// What: with the env var cleared for the test body (#4614) and an empty
+    /// store, assert `MissingConfig` naming `ATLASCLOUD_API_KEY`.
     /// Test: this test.
     #[tokio::test]
+    #[serial]
     async fn missing_atlascloud_key_errors_not_falls_back() {
-        if std::env::var("ATLASCLOUD_API_KEY").is_ok_and(|v| !v.is_empty()) {
-            return; // real key present locally — the fall-back guard isn't exercised
-        }
+        let _cleared = ClearedKey::new("ATLASCLOUD_API_KEY");
         let client = OpenAiCompatClient::with_store(Box::new(MemoryKeyStore::new()));
         let req = ChatRequest {
             model: "atlascloud/openai/gpt-5.6-sol".into(),


### PR DESCRIPTION
## Why

`crates/trusty-code/src/llm/client.rs` carries **two distinct defects**. They were invisible together: defect 2 is the one CI sees, and defect 1 is why nobody saw it locally — and #4614's broken `Test` gate is why CI seeing it didn't matter.

Prerequisite for #4614 (step 2 of its sequencing). This must land before `set -o pipefail` does, or pipefail turns `main` red on merge.

## Defect 1 — the test false-passes

`missing_openrouter_key_errors_at_chat_time` opened with an early return taken whenever `OPENROUTER_API_KEY` was non-empty. On any machine with a real key it reported `ok` **without executing a single assertion**. The same guard sits on its three sibling tests, so all four are fixed here.

The guard existed for a sound reason — with a real key present, `chat()` would build the adapter and issue a **live API call**. So this does not delete the guard, it removes its cause: each test now clears its own key for the test body (`#[serial]`, exact prior state restored on drop). The assertions become unconditional, and a live call becomes unreachable by construction rather than by skipping. `serial_test` joins the workspace-wide exclusion group already used by every env-mutating test.

## Defect 2 — which side was wrong

Hermetically the test failed at `client.rs:604`: `expected MissingConfig, got: MissingCredential { provider: OpenRouter }`.

**The code regressed. The test was right.** Evidence:

- **Git history.** `git log -S'MissingConfig' -- crates/trusty-code/src/llm/client.rs` shows the OpenRouter path has asserted `MissingConfig` since `e831a00b` (#1043). The migration `d8b216e8` (#2492) kept it via `provider_for(...).map_err(convert::map_error)?`, and `convert::map_error` explicitly mapped `MissingCredential { provider }` → `MissingConfig(...)` with a resolver hint — under its own test, doc'd "preserves the actionable 'set this key' operator guidance". `5cd6be33` (#4436) deleted `convert.rs` wholesale. The mapping went with it; the doc comments and the test did not.
- **Two live doc contracts still state it.** `build_adapter`: "a missing key surfaces as the resolver's own `MissingCredential`, **mapped to `MissingConfig`**". `dispatch.rs::chat`: "surfaces a missing credential as `InferenceError::MissingConfig` at this point." Neither was touched by #4436.
- **The contract, on its own merits.** Three sibling arms of the *same* `match` — Fireworks, Together, AtlasCloud — deliberately construct `MissingConfig` naming their env var and the three ways to set it. OpenRouter is the `_` default arm, i.e. the first credential a new operator must set, and was the only one emitting the bare `MissingCredential`. What a caller can distinguish is the point: `MissingCredential` can only carry a `ProviderId` — it is *structurally* incapable of the actionable message. `error.rs` says so in as many words: `MissingConfig` exists because `MissingCredential` "cannot carry an operator-actionable message". Operator-facing, this is `no credential resolved for provider openrouter` vs `OPENROUTER_API_KEY is required to reach an openrouter model. Export it (…), add it to .env.local, or set it via 'tcode config keys set openrouter'.`
- **Nothing else breaks.** Both variants are `is_alarm() == true` and `is_retryable() == false`, so classification is unchanged. `trusty-agents` asserts `MissingCredential{OpenRouter}` for *its* client, which has no actionable-message convention — a different consumer with a different contract, not a conflict.

Fixed as an explicit guard mirroring the three siblings rather than by re-adding a mapping layer: `convert.rs` was deleted for good reasons, and the guard states the contract at the site that owns it.

## Verification

Run on a machine where `OPENROUTER_API_KEY` **is** set (73 chars) — i.e. the exact condition that used to hide all of this.

```
cargo test -p trusty-code --lib
test result: ok. 1596 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 3.09s
```
(baseline on `origin/main`: `1595 passed; 1 failed`)

Full crate incl. integration targets: every binary `ok`, `tests/inference_shared_adapter_e2e.rs` 4 passed.

**Hermeticity** — the four tests, three environments:

| env condition | result |
|---|---|
| `env -u OPENROUTER_API_KEY` | `4 passed; 0 failed` |
| `OPENROUTER_API_KEY=<dummy>` | `4 passed; 0 failed` |
| ambient real key inherited | `4 passed; 0 failed` |

**Mutation** — remove the new guard, restoring the regressed code:

```
thread '…missing_openrouter_key_errors_at_chat_time' panicked at crates/trusty-code/src/llm/client.rs:663:22:
expected MissingConfig naming OPENROUTER_API_KEY, got: MissingCredential { provider: OpenRouter }
test result: FAILED. 0 passed; 1 failed
```

It fails identically under **all three** env conditions — including the ambient-real-key case, where the old test returned `ok` having asserted nothing. One mutation, both defects proven. Guard restored, suite green again.

Gates: `cargo clippy -p trusty-code --all-targets -- -D warnings` clean · `cargo fmt --check` clean · `check_line_cap.sh` 0 violations · `check_test_pointers.sh` 0 dangling pointers · changelog fragment at `crates/trusty-code/changelog.d/4614-openrouter-missing-key-actionable.md`.

No `#[ignore]`, no cfg-gating, no narrowing — the OpenRouter test's assertion was *strengthened* (it now also pins the message names the env var, matching its siblings).

Refs #4614

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
