### PR TITLE
fix(trusty-mpm): resolve the agent roster once so the delegation list and session-start count cannot drift (#4589, #4588)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4589-one-roster-resolver.md
+++ b/crates/trusty-mpm/changelog.d/4589-one-roster-resolver.md
@@ -24,6 +24,11 @@ Fixed
   assets: the roster unions two tiers whose frontmatter tm does not author, so
   the same rule would eat an operator's own agent with no recourse
   ([#4589](https://github.com/bobmatnyc/trusty-tools/issues/4589)).
+- The bundled `agent-delegation` instruction section no longer tells the PM that
+  `memory-manager`, `mpm-agent-manager` and `mpm-skills-manager` are hidden by a
+  `role: base` filter. That paragraph shipped into every PM prompt and, once the
+  filter was removed, contradicted the live roster rendered directly beneath it
+  ([#4589](https://github.com/bobmatnyc/trusty-tools/issues/4589)).
 - `tm doctor`'s `agents` check reports the delegatable roster size alongside the
   deployed file count on every status — including the empty-deploy-tier failure,
   where the roster can still be non-empty because the project and generic

--- a/crates/trusty-mpm/changelog.d/4589-one-roster-resolver.md
+++ b/crates/trusty-mpm/changelog.d/4589-one-roster-resolver.md
@@ -13,7 +13,11 @@ Fixed
   ([#4588](https://github.com/bobmatnyc/trusty-tools/issues/4588)).
 - Agents are no longer excluded from the delegation roster because their
   frontmatter `role:` begins with `base`. Foundation templates are identified by
-  the `BASE-*` file-name convention alone. The frontmatter rule silently deleted
+  a case-insensitive `base-` file-stem prefix — the hyphen is load-bearing, so
+  `baseline-analyzer`, `base64-decoder` and `basecamp-sync` are ordinary
+  delegatable agents rather than templates, and every excluded file is logged at
+  debug level with its directory instead of vanishing silently. The frontmatter
+  rule silently deleted
   three real, deployed, dispatchable agents — `memory-manager`,
   `mpm-agent-manager`, `mpm-skills-manager` — from every roster the PM ever saw
   (34 advertised where 37 were deployed), and it could not be fixed by editing
@@ -21,8 +25,11 @@ Fixed
   the same rule would eat an operator's own agent with no recourse
   ([#4589](https://github.com/bobmatnyc/trusty-tools/issues/4589)).
 - `tm doctor`'s `agents` check reports the delegatable roster size alongside the
-  deployed file count, resolved by that same function, and reports it as
-  `unknown` rather than guessing when no project directory scopes the probe. A
+  deployed file count on every status — including the empty-deploy-tier failure,
+  where the roster can still be non-empty because the project and generic
+  `~/.claude/agents` tiers are independent of the deploy tier — resolved by that
+  same function, and reports it as `unknown` rather than guessing when no project
+  directory scopes the probe. A
   file count is a deploy fact, not a routing fact; reporting only the former is
   how a 42-file, 34-agent install read as healthy
   ([#4589](https://github.com/bobmatnyc/trusty-tools/issues/4589)).

--- a/crates/trusty-mpm/changelog.d/4589-one-roster-resolver.md
+++ b/crates/trusty-mpm/changelog.d/4589-one-roster-resolver.md
@@ -1,0 +1,28 @@
+Fixed
+
+- The agent roster is resolved by exactly one function, so the count `tm session
+  start` prints can no longer disagree with the roster the PM receives. The
+  printed number came from a single-directory scan of the tm-managed deploy tier
+  while the delegation section delivered to the PM was a three-tier union
+  (project `.claude/agents` + `$CLAUDE_CONFIG_DIR/agents` + the operator's
+  `~/.claude/agents`) — two independent implementations of the same question,
+  measured live at 37 printed against 42 delivered. `build_instructions` now
+  takes the project rather than an agents directory and resolves the roster
+  through `delegation_authority::resolve_roster`, which the PM prompt and
+  `tm doctor` also call
+  ([#4588](https://github.com/bobmatnyc/trusty-tools/issues/4588)).
+- Agents are no longer excluded from the delegation roster because their
+  frontmatter `role:` begins with `base`. Foundation templates are identified by
+  the `BASE-*` file-name convention alone. The frontmatter rule silently deleted
+  three real, deployed, dispatchable agents — `memory-manager`,
+  `mpm-agent-manager`, `mpm-skills-manager` — from every roster the PM ever saw
+  (34 advertised where 37 were deployed), and it could not be fixed by editing
+  assets: the roster unions two tiers whose frontmatter tm does not author, so
+  the same rule would eat an operator's own agent with no recourse
+  ([#4589](https://github.com/bobmatnyc/trusty-tools/issues/4589)).
+- `tm doctor`'s `agents` check reports the delegatable roster size alongside the
+  deployed file count, resolved by that same function, and reports it as
+  `unknown` rather than guessing when no project directory scopes the probe. A
+  file count is a deploy fact, not a routing fact; reporting only the former is
+  how a 42-file, 34-agent install read as healthy
+  ([#4589](https://github.com/bobmatnyc/trusty-tools/issues/4589)).

--- a/crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md
@@ -8,10 +8,9 @@
 > `CLAUDE_CONFIG_DIR/agents`, and the framework agents dir, project tier
 > winning on a name collision. The scan reads every `.md` file on disk, so it
 > picks up manifest-declared AND user-installed agents. That roster is
-> required; composition fails without it. Exception: agents whose frontmatter
-> carries `role: base` are filtered out as foundation templates, which
-> currently hides `memory-manager`, `mpm-agent-manager`, and
-> `mpm-skills-manager` (#4589).
+> required; composition fails without it. The ONLY agents filtered out are
+> foundation templates, identified by a `BASE-*` file name (the `base-` prefix
+> is required); frontmatter is never used to hide an agent (#4589).
 >
 > This file: crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md
 

--- a/crates/trusty-mpm/src/bin/tm/commands/session.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session.rs
@@ -617,8 +617,10 @@ pub(crate) fn compose_session_instructions(
     // and populate the metadata flags (agent_count, claude_md_created, …).
     let input = PipelineInput {
         framework_instructions_path: fw.framework_instructions_path(),
-        // #4409: scan the tier bundled agents actually deploy into.
-        agents_dir: fw.agent_deploy_dir(),
+        // #4588: the roster is resolved from the project by the one shared
+        // resolver, not from a directory named here — naming one tier is what
+        // made the printed count disagree with the delivered roster.
+        project_dir: project_dir.to_path_buf(),
         claude_md_path: project_dir.join("CLAUDE.md"),
     };
     let output = build_instructions(&input)?;

--- a/crates/trusty-mpm/src/core/delegation_authority.rs
+++ b/crates/trusty-mpm/src/core/delegation_authority.rs
@@ -102,16 +102,6 @@ fn parse_frontmatter(raw: &str) -> AgentFrontmatter {
     fm
 }
 
-/// Whether a role marks a foundation (non-delegatable) agent.
-///
-/// Why: `base-agent` / `base-engineer` and friends are inheritance foundations,
-/// not work destinations; advertising them would mislead the router.
-/// What: returns true when the role (lower-cased) starts with `base`.
-/// Test: `scan_excludes_base_agents`.
-fn is_base_role(role: &str) -> bool {
-    role.trim().to_ascii_lowercase().starts_with("base")
-}
-
 /// Scan `agents_dir` and return summaries for all non-base agents.
 ///
 /// Why: the orchestrating CC instance needs to know which agents exist
@@ -121,7 +111,20 @@ fn is_base_role(role: &str) -> bool {
 /// role, description, model, extends), excludes BASE-* files and the
 /// manifest file, returns one AgentSummary per deployable agent.
 ///
-/// Test: `scan_finds_agents`, `scan_excludes_base_agents`, `scan_empty_dir`
+/// Foundation templates are identified by the `BASE-*` FILE NAME convention
+/// alone (#4589). An earlier revision also dropped any agent whose frontmatter
+/// `role:` began with `base`, which silently deleted three real, dispatchable
+/// agents — `memory-manager`, `mpm-agent-manager`, `mpm-skills-manager` — from
+/// every roster. `role:` is the wrong signal for the job: the roster is a union
+/// over three tiers (see [`deployed_agent_dirs`]) and tm authors the frontmatter
+/// in exactly one of them, so no asset edit can stop the same rule from eating
+/// an operator's own agent in `<project>/.claude/agents` or `~/.claude/agents`.
+/// The file-name convention is tm's own, applies to the files tm actually
+/// ships, and is checked before the file is even read.
+///
+/// Test: `scan_finds_agents`, `scan_excludes_base_agents`,
+/// `agent_with_a_base_role_but_no_base_filename_stays_in_the_roster`,
+/// `scan_empty_dir`
 pub fn scan_agents(agents_dir: &Path) -> Vec<AgentSummary> {
     // An ABSENT tier is normal (not every launch mode populates every tier) and
     // stays silent. Any OTHER enumeration failure — permissions, a bad mount, an
@@ -172,13 +175,6 @@ pub fn scan_agents(agents_dir: &Path) -> Vec<AgentSummary> {
         let fm = parse_frontmatter(&raw);
         let name = fm.name.clone().unwrap_or_else(|| stem.to_string());
         let role = fm.role.clone().unwrap_or_else(|| name.clone());
-
-        // Also exclude by declared role, catching base agents whose file name
-        // does not follow the `base-` convention.
-        if is_base_role(&role) {
-            continue;
-        }
-
         let extends_chain = build_extends_chain(fm.extends.as_deref(), &name);
 
         summaries.push(AgentSummary {
@@ -330,6 +326,26 @@ pub fn roster_from_dirs(dirs: &[PathBuf]) -> Vec<AgentSummary> {
     by_name.into_values().collect()
 }
 
+/// THE agent roster for `project_dir`. Every consumer calls this one function.
+///
+/// Why (#4588): a roster resolved twice is a roster that drifts. The PM prompt
+/// took the three-tier union while `tm session start` printed a count taken
+/// from a single directory, so the operator was told 34 when the PM had been
+/// given 39 — the two numbers were never wrong in the same way at the same
+/// time, because they were never the same computation. There is now exactly one
+/// implementation, and `tm session start`, the delegation section injected into
+/// the PM prompt, and `tm doctor` all read it.
+/// What: unions [`deployed_agent_dirs`] via [`roster_from_dirs`], name-sorted
+/// and deduplicated with the highest-precedence tier winning.
+/// Test: `session_start_count_matches_the_delivered_delegation_roster`
+/// (instruction_pipeline_tests) is the cross-consumer agreement gate; the
+/// tier-union behaviour itself is covered by the `roster_from_dirs_*` tests.
+/// This function consults machine-global tiers, so it has no hermetic direct
+/// test of its own.
+pub fn resolve_roster(project_dir: &Path) -> Vec<AgentSummary> {
+    roster_from_dirs(&deployed_agent_dirs(project_dir))
+}
+
 /// Render the LIVE deployed roster for a project, or `None` when none is found.
 ///
 /// Why (#4069): `build_instructions` already computed this section via
@@ -343,8 +359,8 @@ pub fn roster_from_dirs(dirs: &[PathBuf]) -> Vec<AgentSummary> {
 /// `tm session instructions`, the tmux connect path, the daemon spawn — receive
 /// a `project_dir` and nothing else, and two of them never run the pipeline at
 /// all, so there is no `PipelineOutput` available to thread.
-/// What: unions [`deployed_agent_dirs`] via [`roster_from_dirs`] and renders it
-/// with [`generate_authority`]. Returns `None` when no agent is deployed
+/// What: resolves the roster via [`resolve_roster`] — the one resolver every
+/// consumer shares — and renders it with [`generate_authority`]. Returns `None` when no agent is deployed
 /// anywhere, so an unprovisioned environment keeps exactly the previous
 /// behaviour (the bundled asset alone) instead of being told it has no agents.
 /// Test: `roster_from_dirs_ignores_missing_dirs` (the `None` branch's input) and
@@ -352,8 +368,7 @@ pub fn roster_from_dirs(dirs: &[PathBuf]) -> Vec<AgentSummary> {
 /// (the rendered output reaching the delivered prompt). This function itself
 /// consults machine-global tiers, so it has no hermetic direct test.
 pub fn deployed_roster_section(project_dir: &Path) -> Option<String> {
-    let dirs = deployed_agent_dirs(project_dir);
-    let agents = roster_from_dirs(&dirs);
+    let agents = resolve_roster(project_dir);
     if agents.is_empty() {
         // Reverting to the bundled asset must be an OBSERVABLE event, not an
         // invisible one — this is the state #4069 describes, and if it recurs
@@ -362,7 +377,7 @@ pub fn deployed_roster_section(project_dir: &Path) -> Option<String> {
         // 8-name prompt that looks healthy.
         tracing::info!(
             project = %project_dir.display(),
-            tiers = dirs.len(),
+            tiers = deployed_agent_dirs(project_dir).len(),
             "no deployed agents found in any tier; delegation section falls back to the \
              bundled asset alone"
         );
@@ -417,8 +432,10 @@ mod tests {
 
     #[test]
     fn scan_excludes_base_agents() {
-        // BASE-* files (by name) and base-role agents (by frontmatter) must
-        // never appear in the scan results.
+        // Foundation templates are excluded by the `BASE-*` FILE NAME
+        // convention, case-insensitively, and never by frontmatter (#4589 —
+        // see `agent_with_a_base_role_but_no_base_filename_stays_in_the_roster`
+        // for why the `role:` half was removed).
         let tmp = TempDir::new().unwrap();
         write_agent(
             tmp.path(),
@@ -430,12 +447,6 @@ mod tests {
             "base-engineer",
             "---\nname: base-engineer\nrole: base-engineer\n---\n\nfoundation\n",
         );
-        // A file not following the `base-` name convention but with a base role.
-        write_agent(
-            tmp.path(),
-            "foundation",
-            "---\nname: foundation\nrole: base-thing\n---\n\nfoundation\n",
-        );
         write_agent(
             tmp.path(),
             "qa",
@@ -445,9 +456,30 @@ mod tests {
         let agents = scan_agents(tmp.path());
         assert_eq!(agents.len(), 1);
         assert_eq!(agents[0].name, "qa");
-        assert!(
-            agents.iter().all(|a| !a.role.starts_with("base")),
-            "no base-role agent should survive the scan"
+    }
+
+    #[test]
+    fn agent_with_a_base_role_but_no_base_filename_stays_in_the_roster() {
+        // #4589 REGRESSION. `memory-manager`, `mpm-agent-manager` and
+        // `mpm-skills-manager` shipped with `role: base` and were therefore
+        // dropped from every tier of the roster — deployed, dispatchable, and
+        // invisible to the PM. The exclusion keys off the `BASE-*` FILE NAME
+        // convention (tm's own, applied to the files tm ships) rather than a
+        // frontmatter value tm does not control in the project and generic
+        // `~/.claude/agents` tiers it also unions.
+        let tmp = TempDir::new().unwrap();
+        write_agent(
+            tmp.path(),
+            "memory-manager",
+            "---\nname: memory-manager\nrole: base\ndescription: Manages memory.\n---\n\n# MM\n",
+        );
+
+        let agents = scan_agents(tmp.path());
+        assert_eq!(
+            agents.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+            vec!["memory-manager"],
+            "a non-`BASE-*` file must never be classified as a foundation \
+             template by its `role:` value alone (#4589)"
         );
     }
 
@@ -589,18 +621,14 @@ mod tests {
 
     #[test]
     fn every_bundled_non_base_agent_reaches_the_roster() {
-        // Issue #4069 REGRESSION GATE (review HIGH-1). `is_base_role` drops any
-        // agent whose `role:` starts with "base" — a deliberate rule that also
-        // catches base agents whose FILE name does not follow the `BASE-`
-        // convention (see `scan_excludes_base_agents`). Three bundled agents
-        // were misfiled with `role: base` despite being ordinary delegatable
-        // agents (`memory-manager`, `mpm-agent-manager`, `mpm-skills-manager`),
-        // so they were silently dropped from EVERY tier they deploy into — the
-        // exact "advertised roster != real roster" defect #4069 exists to fix.
-        //
-        // This asserts the invariant at the ASSET level rather than weakening
-        // the scanner: every bundled `.md` that is not a `BASE-*` foundation
-        // file must survive `scan_agents`.
+        // Issue #4069 / #4589 REGRESSION GATE. The scanner's only exclusion is
+        // the `BASE-*` file-name convention, so this asserts the property that
+        // matters end to end: every bundled `.md` that is not a `BASE-*`
+        // foundation file survives `scan_agents` and can therefore be routed
+        // to. It is the asset-level half of the same invariant
+        // `agent_with_a_base_role_but_no_base_filename_stays_in_the_roster`
+        // asserts at the scanner level — one guards the shipped files, the
+        // other guards the rule, and #4589 needed both.
         let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/assets/agents");
 
         let mut expected: Vec<String> = fs::read_dir(&assets)

--- a/crates/trusty-mpm/src/core/delegation_authority.rs
+++ b/crates/trusty-mpm/src/core/delegation_authority.rs
@@ -8,10 +8,12 @@
 //! its frontmatter, and returns one [`AgentSummary`] per deployable (non-base)
 //! agent; [`generate_authority`] folds those summaries into a Markdown section
 //! injected into the session launch instructions;
-//! [`deployed_roster_section`] resolves the tiers a launched session actually
-//! loads agents from and renders that live roster for the PM prompt (#4069).
-//! Test: `cargo test -p trusty-mpm-core delegation_authority` covers scanning,
-//! base-agent exclusion, the empty directory, and both render branches.
+//! [`resolve_roster`] is THE roster resolver every consumer shares — the PM
+//! prompt's delegation section, the `tm session start` count, and `tm doctor`
+//! (#4588); [`deployed_roster_section`] renders what it returns (#4069).
+//! Test: `delegation_authority_tests.rs` covers scanning, foundation-file
+//! exclusion and its near misses, the empty directory, and both render
+//! branches.
 
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
@@ -102,6 +104,24 @@ fn parse_frontmatter(raw: &str) -> AgentFrontmatter {
     fm
 }
 
+/// Whether a file stem names a foundation (non-delegatable) template.
+///
+/// Why (#4589): this is the ONLY rule that removes an agent from the roster, so
+/// it must be narrow and it must exist in exactly one place. The `-` is the
+/// whole point: `starts_with("base")` silently deletes `baseline-analyzer`,
+/// `base64-decoder`, `basecamp-sync` and `based-reviewer` — ordinary names in
+/// the project and `~/.claude/agents` tiers tm does not author, which is
+/// precisely the failure mode the frontmatter `role:` rule was removed for.
+/// Sharing the predicate with the asset-level gate keeps the shipped files and
+/// the scanner from drifting apart the way the roster and its count did.
+/// What: case-insensitive `base-` prefix on the file stem, so every bundled
+/// `BASE-*.md` matches and nothing else plausibly does.
+/// Test: `scan_excludes_base_agents`,
+/// `near_miss_base_names_are_not_treated_as_foundation_files`.
+fn is_foundation_file(stem: &str) -> bool {
+    stem.to_ascii_lowercase().starts_with("base-")
+}
+
 /// Scan `agents_dir` and return summaries for all non-base agents.
 ///
 /// Why: the orchestrating CC instance needs to know which agents exist
@@ -111,8 +131,9 @@ fn parse_frontmatter(raw: &str) -> AgentFrontmatter {
 /// role, description, model, extends), excludes BASE-* files and the
 /// manifest file, returns one AgentSummary per deployable agent.
 ///
-/// Foundation templates are identified by the `BASE-*` FILE NAME convention
-/// alone (#4589). An earlier revision also dropped any agent whose frontmatter
+/// Foundation templates are identified by [`is_foundation_file`] — the `BASE-*`
+/// FILE NAME convention alone (#4589). An earlier revision also dropped any
+/// agent whose frontmatter
 /// `role:` began with `base`, which silently deleted three real, dispatchable
 /// agents — `memory-manager`, `mpm-agent-manager`, `mpm-skills-manager` — from
 /// every roster. `role:` is the wrong signal for the job: the roster is a union
@@ -162,7 +183,18 @@ pub fn scan_agents(agents_dir: &Path) -> Vec<AgentSummary> {
             continue;
         };
         // Exclude BASE-* source/foundation files by file name, before any read.
-        if stem.to_ascii_lowercase().starts_with("base") {
+        // The trailing `-` is load-bearing (#4589 review): a bare `base` prefix
+        // also eats `baseline-analyzer`, `base64-decoder`, `basecamp-sync` and
+        // `based-reviewer` — plausible agent names in tiers tm does not author,
+        // which is the exact failure this rule replaced, not a fix for it.
+        if is_foundation_file(stem) {
+            // A silent deletion is what made #4589 undiagnosable. An operator
+            // whose `base-…` agent vanished has no other thread to pull.
+            tracing::debug!(
+                file = %file_name,
+                dir = %agents_dir.display(),
+                "excluded from the delegation roster as a BASE-* foundation template"
+            );
             continue;
         }
         if path.extension().and_then(|e| e.to_str()) != Some("md") {
@@ -387,379 +419,5 @@ pub fn deployed_roster_section(project_dir: &Path) -> Option<String> {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::TempDir;
-
-    /// Write `<name>.md` into `dir` with the given raw content.
-    fn write_agent(dir: &Path, name: &str, content: &str) {
-        fs::write(dir.join(format!("{name}.md")), content).expect("write agent");
-    }
-
-    #[test]
-    fn scan_finds_agents() {
-        // A directory with one deployable agent and one base agent must yield
-        // exactly the deployable one, with its frontmatter parsed.
-        let tmp = TempDir::new().unwrap();
-        write_agent(
-            tmp.path(),
-            "engineer",
-            "---\nname: engineer\nrole: engineer\nextends: base-engineer\n\
-             description: Implements features and fixes bugs.\nmodel: sonnet\n---\n\n# Engineer\n",
-        );
-        write_agent(
-            tmp.path(),
-            "BASE-AGENT",
-            "---\nname: base-agent\nrole: base\n---\n\n# Base\n",
-        );
-
-        let agents = scan_agents(tmp.path());
-        assert_eq!(agents.len(), 1, "only the engineer is deployable");
-        let engineer = &agents[0];
-        assert_eq!(engineer.name, "engineer");
-        assert_eq!(engineer.role, "engineer");
-        assert_eq!(
-            engineer.description.as_deref(),
-            Some("Implements features and fixes bugs.")
-        );
-        assert_eq!(engineer.model.as_deref(), Some("sonnet"));
-        assert_eq!(
-            engineer.extends_chain,
-            vec!["base-engineer".to_string(), "engineer".to_string()]
-        );
-    }
-
-    #[test]
-    fn scan_excludes_base_agents() {
-        // Foundation templates are excluded by the `BASE-*` FILE NAME
-        // convention, case-insensitively, and never by frontmatter (#4589 —
-        // see `agent_with_a_base_role_but_no_base_filename_stays_in_the_roster`
-        // for why the `role:` half was removed).
-        let tmp = TempDir::new().unwrap();
-        write_agent(
-            tmp.path(),
-            "BASE-AGENT",
-            "---\nname: base-agent\nrole: base\n---\n\nfoundation\n",
-        );
-        write_agent(
-            tmp.path(),
-            "base-engineer",
-            "---\nname: base-engineer\nrole: base-engineer\n---\n\nfoundation\n",
-        );
-        write_agent(
-            tmp.path(),
-            "qa",
-            "---\nname: qa\nrole: qa\ndescription: Tests things.\n---\n\n# QA\n",
-        );
-
-        let agents = scan_agents(tmp.path());
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "qa");
-    }
-
-    #[test]
-    fn agent_with_a_base_role_but_no_base_filename_stays_in_the_roster() {
-        // #4589 REGRESSION. `memory-manager`, `mpm-agent-manager` and
-        // `mpm-skills-manager` shipped with `role: base` and were therefore
-        // dropped from every tier of the roster — deployed, dispatchable, and
-        // invisible to the PM. The exclusion keys off the `BASE-*` FILE NAME
-        // convention (tm's own, applied to the files tm ships) rather than a
-        // frontmatter value tm does not control in the project and generic
-        // `~/.claude/agents` tiers it also unions.
-        let tmp = TempDir::new().unwrap();
-        write_agent(
-            tmp.path(),
-            "memory-manager",
-            "---\nname: memory-manager\nrole: base\ndescription: Manages memory.\n---\n\n# MM\n",
-        );
-
-        let agents = scan_agents(tmp.path());
-        assert_eq!(
-            agents.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
-            vec!["memory-manager"],
-            "a non-`BASE-*` file must never be classified as a foundation \
-             template by its `role:` value alone (#4589)"
-        );
-    }
-
-    #[test]
-    fn scan_empty_dir() {
-        // An empty directory must yield an empty vec with no error.
-        let tmp = TempDir::new().unwrap();
-        let agents = scan_agents(tmp.path());
-        assert!(agents.is_empty());
-    }
-
-    #[test]
-    fn scan_missing_dir_is_empty() {
-        // A non-existent directory must also yield an empty vec, not panic.
-        let agents = scan_agents(Path::new("/no/such/agents/dir/xyz"));
-        assert!(agents.is_empty());
-    }
-
-    #[test]
-    fn scan_ignores_manifest_and_non_md() {
-        // The deploy manifest and non-Markdown files must be skipped.
-        let tmp = TempDir::new().unwrap();
-        fs::write(tmp.path().join("manifest.json"), "{}").unwrap();
-        fs::write(tmp.path().join("notes.txt"), "hello").unwrap();
-        write_agent(
-            tmp.path(),
-            "writer",
-            "---\nname: writer\nrole: writer\n---\n\n# Writer\n",
-        );
-        let agents = scan_agents(tmp.path());
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "writer");
-    }
-
-    #[test]
-    fn scan_handles_no_frontmatter() {
-        // An agent file with no frontmatter falls back to the file stem.
-        let tmp = TempDir::new().unwrap();
-        write_agent(
-            tmp.path(),
-            "plain",
-            "# Plain agent\n\nNo frontmatter here.\n",
-        );
-        let agents = scan_agents(tmp.path());
-        assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].name, "plain");
-        assert_eq!(agents[0].role, "plain");
-        assert_eq!(agents[0].extends_chain, vec!["plain".to_string()]);
-    }
-
-    #[test]
-    fn generate_authority_nonempty() {
-        // A single agent renders under the heading with its name and details.
-        let agents = vec![AgentSummary {
-            name: "engineer".to_string(),
-            role: "engineer".to_string(),
-            description: Some("Implements features.".to_string()),
-            model: Some("sonnet".to_string()),
-            extends_chain: vec![
-                "base-agent".to_string(),
-                "base-engineer".to_string(),
-                "engineer".to_string(),
-            ],
-        }];
-        let md = generate_authority(&agents);
-        assert!(md.contains("## Delegation Authority"));
-        assert!(md.contains("### engineer"));
-        assert!(md.contains("Implements features."));
-        assert!(md.contains("base-agent → base-engineer → engineer"));
-        assert!(md.contains("**Model:** sonnet"));
-    }
-
-    #[test]
-    fn generate_authority_empty() {
-        // With no agents the heading still renders, plus a "no agents" note.
-        let md = generate_authority(&[]);
-        assert!(md.contains("## Delegation Authority"));
-        assert!(md.to_lowercase().contains("no delegatable agents"));
-    }
-
-    // ── colon-in-value regression tests (issue #389) ─────────────────────────
-
-    #[test]
-    fn scan_preserves_url_in_description() {
-        // A `description:` value that is or contains a URL must not be
-        // silently truncated at the first colon.
-        let tmp = TempDir::new().unwrap();
-        write_agent(
-            tmp.path(),
-            "docs-agent",
-            "---\nname: docs-agent\nrole: docs\ndescription: See https://docs.example.com/guide\n---\n\n# Docs\n",
-        );
-        let agents = scan_agents(tmp.path());
-        assert_eq!(agents.len(), 1);
-        assert_eq!(
-            agents[0].description.as_deref(),
-            Some("See https://docs.example.com/guide"),
-            "URL in description must not be truncated"
-        );
-    }
-
-    #[test]
-    fn scan_preserves_bedrock_model_id() {
-        // A `model:` value containing a bedrock model id (with `/` and `.`)
-        // must survive the scan without truncation.
-        let tmp = TempDir::new().unwrap();
-        write_agent(
-            tmp.path(),
-            "ml-agent",
-            "---\nname: ml-agent\nrole: ml\nmodel: bedrock/us.anthropic.claude-sonnet-4-6\n---\n\n# ML\n",
-        );
-        let agents = scan_agents(tmp.path());
-        assert_eq!(agents.len(), 1);
-        assert_eq!(
-            agents[0].model.as_deref(),
-            Some("bedrock/us.anthropic.claude-sonnet-4-6"),
-            "bedrock model id must be preserved verbatim"
-        );
-    }
-
-    #[test]
-    fn scan_preserves_timestamp_in_description() {
-        // A description that embeds an ISO-8601 timestamp must keep the full
-        // timestamp including the time component (colons after the first).
-        let tmp = TempDir::new().unwrap();
-        write_agent(
-            tmp.path(),
-            "timed-agent",
-            "---\nname: timed-agent\nrole: timer\ndescription: Deployed at 2026-06-05T14:31:34\n---\n\n# Timed\n",
-        );
-        let agents = scan_agents(tmp.path());
-        assert_eq!(agents.len(), 1);
-        assert_eq!(
-            agents[0].description.as_deref(),
-            Some("Deployed at 2026-06-05T14:31:34"),
-            "timestamp in description must not be truncated"
-        );
-    }
-
-    #[test]
-    fn every_bundled_non_base_agent_reaches_the_roster() {
-        // Issue #4069 / #4589 REGRESSION GATE. The scanner's only exclusion is
-        // the `BASE-*` file-name convention, so this asserts the property that
-        // matters end to end: every bundled `.md` that is not a `BASE-*`
-        // foundation file survives `scan_agents` and can therefore be routed
-        // to. It is the asset-level half of the same invariant
-        // `agent_with_a_base_role_but_no_base_filename_stays_in_the_roster`
-        // asserts at the scanner level — one guards the shipped files, the
-        // other guards the rule, and #4589 needed both.
-        let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/assets/agents");
-
-        let mut expected: Vec<String> = fs::read_dir(&assets)
-            .expect("bundled agent assets dir")
-            .flatten()
-            .map(|e| e.path())
-            .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
-            .filter_map(|p| {
-                p.file_stem()
-                    .and_then(|s| s.to_str())
-                    .filter(|stem| !stem.to_ascii_lowercase().starts_with("base"))
-                    .map(str::to_string)
-            })
-            .collect();
-        expected.sort();
-
-        let mut scanned: Vec<String> = scan_agents(&assets).into_iter().map(|a| a.name).collect();
-        scanned.sort();
-
-        let dropped: Vec<&String> = expected.iter().filter(|n| !scanned.contains(n)).collect();
-        assert!(
-            dropped.is_empty(),
-            "bundled agents silently dropped from every roster (check for a stray \
-             `role: base` in their frontmatter): {dropped:?}"
-        );
-        assert_eq!(
-            scanned.len(),
-            expected.len(),
-            "every non-BASE bundled agent must be delegatable"
-        );
-    }
-
-    #[test]
-    fn generate_authority_omits_self_referential_lines() {
-        // Review MEDIUM-3: `Role` that merely repeats the heading and a
-        // single-element `Foundation` chain are pure noise, re-emitted into
-        // every PM session. A real (multi-element) chain still renders.
-        let agents = vec![AgentSummary {
-            name: "ticketing".to_string(),
-            role: "ticketing".to_string(),
-            description: Some("Files tickets.".to_string()),
-            model: None,
-            extends_chain: vec!["ticketing".to_string()],
-        }];
-        let md = generate_authority(&agents);
-
-        assert!(md.contains("### ticketing"));
-        assert!(md.contains("Files tickets."));
-        assert!(
-            !md.contains("**Role:**"),
-            "role duplicating the heading must be omitted"
-        );
-        assert!(
-            !md.contains("**Foundation:**"),
-            "a self-referential single-element chain must be omitted"
-        );
-    }
-
-    #[test]
-    fn roster_from_dirs_dedup_is_case_insensitive() {
-        // Review LOW-1: agent names are case-insensitive to the dispatcher, so
-        // `QA` and `qa` across two tiers are one agent, not two entries.
-        let high = TempDir::new().unwrap();
-        let low = TempDir::new().unwrap();
-        write_agent(
-            high.path(),
-            "QA",
-            "---\nname: QA\nrole: qa\ndescription: PROJECT TIER\n---\n\n# QA\n",
-        );
-        write_agent(
-            low.path(),
-            "qa",
-            "---\nname: qa\nrole: qa\ndescription: USER TIER\n---\n\n# QA\n",
-        );
-
-        let roster = roster_from_dirs(&[high.path().to_path_buf(), low.path().to_path_buf()]);
-
-        assert_eq!(roster.len(), 1, "QA and qa are the same agent");
-        assert_eq!(roster[0].description.as_deref(), Some("PROJECT TIER"));
-    }
-
-    #[test]
-    fn deployed_agent_dirs_puts_project_tier_first() {
-        // Issue #4069: the project tier is the destination the daemon
-        // managed-spawn path deploys into AND the only tier readable under
-        // `--setting-sources project,local`, so it must rank first.
-        let dirs = deployed_agent_dirs(Path::new("/proj"));
-        assert_eq!(dirs[0], PathBuf::from("/proj/.claude/agents"));
-        assert!(
-            dirs.len() >= 2,
-            "the user-level tier(s) must also be consulted"
-        );
-    }
-
-    #[test]
-    fn roster_from_dirs_dedupes_with_first_dir_winning() {
-        // The same agent is normally deployed into more than one tier; the
-        // higher-precedence copy must be the one described, exactly once.
-        let high = TempDir::new().unwrap();
-        let low = TempDir::new().unwrap();
-        write_agent(
-            high.path(),
-            "qa",
-            "---\nname: qa\nrole: qa\ndescription: PROJECT TIER\n---\n\n# QA\n",
-        );
-        write_agent(
-            low.path(),
-            "qa",
-            "---\nname: qa\nrole: qa\ndescription: USER TIER\n---\n\n# QA\n",
-        );
-        write_agent(
-            low.path(),
-            "ops",
-            "---\nname: ops\nrole: ops\ndescription: USER TIER\n---\n\n# Ops\n",
-        );
-
-        let roster = roster_from_dirs(&[high.path().to_path_buf(), low.path().to_path_buf()]);
-
-        assert_eq!(roster.len(), 2, "qa must appear once, plus ops");
-        assert_eq!(roster[0].name, "ops", "roster is name-sorted");
-        assert_eq!(roster[1].name, "qa");
-        assert_eq!(roster[1].description.as_deref(), Some("PROJECT TIER"));
-    }
-
-    #[test]
-    fn roster_from_dirs_ignores_missing_dirs() {
-        // A tier that does not exist is an empty tier, never a failure — this is
-        // the input that makes `deployed_roster_section` return `None`, leaving
-        // an unprovisioned environment with the bundled asset alone.
-        let roster = roster_from_dirs(&[PathBuf::from("/nonexistent/agents")]);
-        assert!(roster.is_empty());
-        assert!(roster_from_dirs(&[]).is_empty());
-    }
-}
+#[path = "delegation_authority_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/delegation_authority_tests.rs
+++ b/crates/trusty-mpm/src/core/delegation_authority_tests.rs
@@ -1,0 +1,440 @@
+//! Tests for the delegation-authority scanner, roster resolver, and renderer.
+//!
+//! Split out of `delegation_authority.rs` (#4589) so the production file stays
+//! under the 500-SLOC cap enforced by `scripts/check_line_cap.sh` — the same
+//! move `instruction_pipeline.rs` made in #4318. The module is included with
+//! `#[path]`, so `use super::*` still reaches every item (including the private
+//! `is_foundation_file`) exactly as it did inline; no assertion changed.
+
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+/// Write `<name>.md` into `dir` with the given raw content.
+fn write_agent(dir: &Path, name: &str, content: &str) {
+    fs::write(dir.join(format!("{name}.md")), content).expect("write agent");
+}
+
+#[test]
+fn scan_finds_agents() {
+    // A directory with one deployable agent and one base agent must yield
+    // exactly the deployable one, with its frontmatter parsed.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "engineer",
+        "---\nname: engineer\nrole: engineer\nextends: base-engineer\n\
+         description: Implements features and fixes bugs.\nmodel: sonnet\n---\n\n# Engineer\n",
+    );
+    write_agent(
+        tmp.path(),
+        "BASE-AGENT",
+        "---\nname: base-agent\nrole: base\n---\n\n# Base\n",
+    );
+
+    let agents = scan_agents(tmp.path());
+    assert_eq!(agents.len(), 1, "only the engineer is deployable");
+    let engineer = &agents[0];
+    assert_eq!(engineer.name, "engineer");
+    assert_eq!(engineer.role, "engineer");
+    assert_eq!(
+        engineer.description.as_deref(),
+        Some("Implements features and fixes bugs.")
+    );
+    assert_eq!(engineer.model.as_deref(), Some("sonnet"));
+    assert_eq!(
+        engineer.extends_chain,
+        vec!["base-engineer".to_string(), "engineer".to_string()]
+    );
+}
+
+#[test]
+fn scan_excludes_base_agents() {
+    // Foundation templates are excluded by the `BASE-*` FILE NAME
+    // convention, case-insensitively, and never by frontmatter (#4589 —
+    // see `agent_with_a_base_role_but_no_base_filename_stays_in_the_roster`
+    // for why the `role:` half was removed).
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "BASE-AGENT",
+        "---\nname: base-agent\nrole: base\n---\n\nfoundation\n",
+    );
+    write_agent(
+        tmp.path(),
+        "base-engineer",
+        "---\nname: base-engineer\nrole: base-engineer\n---\n\nfoundation\n",
+    );
+    write_agent(
+        tmp.path(),
+        "qa",
+        "---\nname: qa\nrole: qa\ndescription: Tests things.\n---\n\n# QA\n",
+    );
+
+    let agents = scan_agents(tmp.path());
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].name, "qa");
+}
+
+#[test]
+fn agent_with_a_base_role_but_no_base_filename_stays_in_the_roster() {
+    // #4589 REGRESSION. `memory-manager`, `mpm-agent-manager` and
+    // `mpm-skills-manager` shipped with `role: base` and were therefore
+    // dropped from every tier of the roster — deployed, dispatchable, and
+    // invisible to the PM. The exclusion keys off the `BASE-*` FILE NAME
+    // convention (tm's own, applied to the files tm ships) rather than a
+    // frontmatter value tm does not control in the project and generic
+    // `~/.claude/agents` tiers it also unions.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "memory-manager",
+        "---\nname: memory-manager\nrole: base\ndescription: Manages memory.\n---\n\n# MM\n",
+    );
+
+    let agents = scan_agents(tmp.path());
+    assert_eq!(
+        agents.iter().map(|a| a.name.as_str()).collect::<Vec<_>>(),
+        vec!["memory-manager"],
+        "a non-`BASE-*` file must never be classified as a foundation \
+         template by its `role:` value alone (#4589)"
+    );
+}
+
+#[test]
+fn near_miss_base_names_are_not_treated_as_foundation_files() {
+    // #4589 REVIEW (HIGH). The first cut of this fix read
+    // `starts_with("base")` with no separator while its docs and its test
+    // name both said "`BASE-*` file name". Under that rule
+    // `baseline-analyzer`, `base64-decoder`, `basecamp-sync` and
+    // `based-reviewer` are all silently deleted from the roster — the same
+    // "a rule tm controls eats an agent tm did not author, and no asset
+    // edit can fix it" failure the frontmatter `role:` rule was removed
+    // for. The failure would have MOVED rather than been removed.
+    //
+    // This pins both directions: the five bundled foundation files stay
+    // out, and every near miss stays in.
+    let tmp = TempDir::new().unwrap();
+    let kept = [
+        "baseline-analyzer",
+        "base64-decoder",
+        "basecamp-sync",
+        "based-reviewer",
+        "database-migrator",
+        "engineer",
+    ];
+    let excluded = [
+        "BASE-AGENT",
+        "BASE-ENGINEER",
+        "BASE-OPS",
+        "BASE-QA",
+        "BASE-RESEARCH",
+        // Lower-case and mixed-case spellings are the same convention.
+        "base-custom",
+        "Base-Custom-Two",
+    ];
+    for name in kept.iter().chain(excluded.iter()) {
+        write_agent(
+            tmp.path(),
+            name,
+            &format!("---\nname: {name}\nrole: {name}\n---\n\n# {name}\n"),
+        );
+    }
+
+    let mut scanned: Vec<String> = scan_agents(tmp.path())
+        .into_iter()
+        .map(|a| a.name)
+        .collect();
+    scanned.sort();
+    let mut want: Vec<String> = kept.iter().map(|s| s.to_string()).collect();
+    want.sort();
+
+    assert_eq!(
+        scanned, want,
+        "only `base-`-prefixed files are foundation templates; a bare \
+         `base` prefix silently deletes real agents (#4589 review)"
+    );
+}
+
+#[test]
+fn scan_empty_dir() {
+    // An empty directory must yield an empty vec with no error.
+    let tmp = TempDir::new().unwrap();
+    let agents = scan_agents(tmp.path());
+    assert!(agents.is_empty());
+}
+
+#[test]
+fn scan_missing_dir_is_empty() {
+    // A non-existent directory must also yield an empty vec, not panic.
+    let agents = scan_agents(Path::new("/no/such/agents/dir/xyz"));
+    assert!(agents.is_empty());
+}
+
+#[test]
+fn scan_ignores_manifest_and_non_md() {
+    // The deploy manifest and non-Markdown files must be skipped.
+    let tmp = TempDir::new().unwrap();
+    fs::write(tmp.path().join("manifest.json"), "{}").unwrap();
+    fs::write(tmp.path().join("notes.txt"), "hello").unwrap();
+    write_agent(
+        tmp.path(),
+        "writer",
+        "---\nname: writer\nrole: writer\n---\n\n# Writer\n",
+    );
+    let agents = scan_agents(tmp.path());
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].name, "writer");
+}
+
+#[test]
+fn scan_handles_no_frontmatter() {
+    // An agent file with no frontmatter falls back to the file stem.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "plain",
+        "# Plain agent\n\nNo frontmatter here.\n",
+    );
+    let agents = scan_agents(tmp.path());
+    assert_eq!(agents.len(), 1);
+    assert_eq!(agents[0].name, "plain");
+    assert_eq!(agents[0].role, "plain");
+    assert_eq!(agents[0].extends_chain, vec!["plain".to_string()]);
+}
+
+#[test]
+fn generate_authority_nonempty() {
+    // A single agent renders under the heading with its name and details.
+    let agents = vec![AgentSummary {
+        name: "engineer".to_string(),
+        role: "engineer".to_string(),
+        description: Some("Implements features.".to_string()),
+        model: Some("sonnet".to_string()),
+        extends_chain: vec![
+            "base-agent".to_string(),
+            "base-engineer".to_string(),
+            "engineer".to_string(),
+        ],
+    }];
+    let md = generate_authority(&agents);
+    assert!(md.contains("## Delegation Authority"));
+    assert!(md.contains("### engineer"));
+    assert!(md.contains("Implements features."));
+    assert!(md.contains("base-agent → base-engineer → engineer"));
+    assert!(md.contains("**Model:** sonnet"));
+}
+
+#[test]
+fn generate_authority_empty() {
+    // With no agents the heading still renders, plus a "no agents" note.
+    let md = generate_authority(&[]);
+    assert!(md.contains("## Delegation Authority"));
+    assert!(md.to_lowercase().contains("no delegatable agents"));
+}
+
+// ── colon-in-value regression tests (issue #389) ─────────────────────────
+
+#[test]
+fn scan_preserves_url_in_description() {
+    // A `description:` value that is or contains a URL must not be
+    // silently truncated at the first colon.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "docs-agent",
+        "---\nname: docs-agent\nrole: docs\ndescription: See https://docs.example.com/guide\n---\n\n# Docs\n",
+    );
+    let agents = scan_agents(tmp.path());
+    assert_eq!(agents.len(), 1);
+    assert_eq!(
+        agents[0].description.as_deref(),
+        Some("See https://docs.example.com/guide"),
+        "URL in description must not be truncated"
+    );
+}
+
+#[test]
+fn scan_preserves_bedrock_model_id() {
+    // A `model:` value containing a bedrock model id (with `/` and `.`)
+    // must survive the scan without truncation.
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "ml-agent",
+        "---\nname: ml-agent\nrole: ml\nmodel: bedrock/us.anthropic.claude-sonnet-4-6\n---\n\n# ML\n",
+    );
+    let agents = scan_agents(tmp.path());
+    assert_eq!(agents.len(), 1);
+    assert_eq!(
+        agents[0].model.as_deref(),
+        Some("bedrock/us.anthropic.claude-sonnet-4-6"),
+        "bedrock model id must be preserved verbatim"
+    );
+}
+
+#[test]
+fn scan_preserves_timestamp_in_description() {
+    // A description that embeds an ISO-8601 timestamp must keep the full
+    // timestamp including the time component (colons after the first).
+    let tmp = TempDir::new().unwrap();
+    write_agent(
+        tmp.path(),
+        "timed-agent",
+        "---\nname: timed-agent\nrole: timer\ndescription: Deployed at 2026-06-05T14:31:34\n---\n\n# Timed\n",
+    );
+    let agents = scan_agents(tmp.path());
+    assert_eq!(agents.len(), 1);
+    assert_eq!(
+        agents[0].description.as_deref(),
+        Some("Deployed at 2026-06-05T14:31:34"),
+        "timestamp in description must not be truncated"
+    );
+}
+
+#[test]
+fn every_bundled_non_base_agent_reaches_the_roster() {
+    // Issue #4069 / #4589 REGRESSION GATE. The scanner's only exclusion is
+    // the `BASE-*` file-name convention, so this asserts the property that
+    // matters end to end: every bundled `.md` that is not a `BASE-*`
+    // foundation file survives `scan_agents` and can therefore be routed
+    // to. It is the asset-level half of the same invariant
+    // `agent_with_a_base_role_but_no_base_filename_stays_in_the_roster`
+    // asserts at the scanner level — one guards the shipped files, the
+    // other guards the rule, and #4589 needed both.
+    let assets = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/assets/agents");
+
+    let mut expected: Vec<String> = fs::read_dir(&assets)
+        .expect("bundled agent assets dir")
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("md"))
+        .filter_map(|p| {
+            p.file_stem()
+                .and_then(|s| s.to_str())
+                // Shares the production predicate deliberately: a private
+                // copy of the rule here would let the gate and the scanner
+                // drift, which is the defect shape this PR removes.
+                .filter(|stem| !is_foundation_file(stem))
+                .map(str::to_string)
+        })
+        .collect();
+    expected.sort();
+
+    let mut scanned: Vec<String> = scan_agents(&assets).into_iter().map(|a| a.name).collect();
+    scanned.sort();
+
+    let dropped: Vec<&String> = expected.iter().filter(|n| !scanned.contains(n)).collect();
+    assert!(
+        dropped.is_empty(),
+        "bundled agents silently dropped from every roster (check for a stray \
+         `role: base` in their frontmatter): {dropped:?}"
+    );
+    assert_eq!(
+        scanned.len(),
+        expected.len(),
+        "every non-BASE bundled agent must be delegatable"
+    );
+}
+
+#[test]
+fn generate_authority_omits_self_referential_lines() {
+    // Review MEDIUM-3: `Role` that merely repeats the heading and a
+    // single-element `Foundation` chain are pure noise, re-emitted into
+    // every PM session. A real (multi-element) chain still renders.
+    let agents = vec![AgentSummary {
+        name: "ticketing".to_string(),
+        role: "ticketing".to_string(),
+        description: Some("Files tickets.".to_string()),
+        model: None,
+        extends_chain: vec!["ticketing".to_string()],
+    }];
+    let md = generate_authority(&agents);
+
+    assert!(md.contains("### ticketing"));
+    assert!(md.contains("Files tickets."));
+    assert!(
+        !md.contains("**Role:**"),
+        "role duplicating the heading must be omitted"
+    );
+    assert!(
+        !md.contains("**Foundation:**"),
+        "a self-referential single-element chain must be omitted"
+    );
+}
+
+#[test]
+fn roster_from_dirs_dedup_is_case_insensitive() {
+    // Review LOW-1: agent names are case-insensitive to the dispatcher, so
+    // `QA` and `qa` across two tiers are one agent, not two entries.
+    let high = TempDir::new().unwrap();
+    let low = TempDir::new().unwrap();
+    write_agent(
+        high.path(),
+        "QA",
+        "---\nname: QA\nrole: qa\ndescription: PROJECT TIER\n---\n\n# QA\n",
+    );
+    write_agent(
+        low.path(),
+        "qa",
+        "---\nname: qa\nrole: qa\ndescription: USER TIER\n---\n\n# QA\n",
+    );
+
+    let roster = roster_from_dirs(&[high.path().to_path_buf(), low.path().to_path_buf()]);
+
+    assert_eq!(roster.len(), 1, "QA and qa are the same agent");
+    assert_eq!(roster[0].description.as_deref(), Some("PROJECT TIER"));
+}
+
+#[test]
+fn deployed_agent_dirs_puts_project_tier_first() {
+    // Issue #4069: the project tier is the destination the daemon
+    // managed-spawn path deploys into AND the only tier readable under
+    // `--setting-sources project,local`, so it must rank first.
+    let dirs = deployed_agent_dirs(Path::new("/proj"));
+    assert_eq!(dirs[0], PathBuf::from("/proj/.claude/agents"));
+    assert!(
+        dirs.len() >= 2,
+        "the user-level tier(s) must also be consulted"
+    );
+}
+
+#[test]
+fn roster_from_dirs_dedupes_with_first_dir_winning() {
+    // The same agent is normally deployed into more than one tier; the
+    // higher-precedence copy must be the one described, exactly once.
+    let high = TempDir::new().unwrap();
+    let low = TempDir::new().unwrap();
+    write_agent(
+        high.path(),
+        "qa",
+        "---\nname: qa\nrole: qa\ndescription: PROJECT TIER\n---\n\n# QA\n",
+    );
+    write_agent(
+        low.path(),
+        "qa",
+        "---\nname: qa\nrole: qa\ndescription: USER TIER\n---\n\n# QA\n",
+    );
+    write_agent(
+        low.path(),
+        "ops",
+        "---\nname: ops\nrole: ops\ndescription: USER TIER\n---\n\n# Ops\n",
+    );
+
+    let roster = roster_from_dirs(&[high.path().to_path_buf(), low.path().to_path_buf()]);
+
+    assert_eq!(roster.len(), 2, "qa must appear once, plus ops");
+    assert_eq!(roster[0].name, "ops", "roster is name-sorted");
+    assert_eq!(roster[1].name, "qa");
+    assert_eq!(roster[1].description.as_deref(), Some("PROJECT TIER"));
+}
+
+#[test]
+fn roster_from_dirs_ignores_missing_dirs() {
+    // A tier that does not exist is an empty tier, never a failure — this is
+    // the input that makes `deployed_roster_section` return `None`, leaving
+    // an unprovisioned environment with the bundled asset alone.
+    let roster = roster_from_dirs(&[PathBuf::from("/nonexistent/agents")]);
+    assert!(roster.is_empty());
+    assert!(roster_from_dirs(&[]).is_empty());
+}

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -24,7 +24,7 @@
 use std::fmt;
 use std::path::PathBuf;
 
-use crate::core::delegation_authority::{generate_authority, scan_agents};
+use crate::core::delegation_authority::{generate_authority, resolve_roster};
 use crate::core::instruction_package::SectionId;
 
 /// Separator placed between merged instruction sections.
@@ -440,15 +440,22 @@ pub fn strip_delegation_block(content: &str) -> String {
 ///
 /// Why: bundles the three source locations so callers pass one value instead
 /// of three loosely-related paths.
-/// What: the framework `INSTRUCTIONS.md`, the deployed agents directory, and
-/// the project `CLAUDE.md`.
+/// What: the framework `INSTRUCTIONS.md`, the project the roster is resolved
+/// for, and the project `CLAUDE.md`.
 /// Test: every `pipeline_*` test constructs one of these.
 #[derive(Debug, Clone)]
 pub struct PipelineInput {
     /// Path to the framework `INSTRUCTIONS.md`.
     pub framework_instructions_path: PathBuf,
-    /// Directory of deployed agents (`~/.claude/agents/`).
-    pub agents_dir: PathBuf,
+    /// The project whose agent roster this session will receive.
+    ///
+    /// #4588: this replaced a single `agents_dir`. Callers used to name one
+    /// directory to scan, which is how the printed count came to describe a
+    /// different set of agents than the PM was given. The roster is resolved
+    /// from the project by
+    /// [`crate::core::delegation_authority::resolve_roster`], so there is no
+    /// longer a directory for a caller to get wrong.
+    pub project_dir: PathBuf,
     /// Path to the project `CLAUDE.md`.
     pub claude_md_path: PathBuf,
 }
@@ -520,13 +527,16 @@ impl std::error::Error for PipelineError {
 /// Code loads it natively), so this still seeds the stub as a side effect.
 ///
 /// What: loads INSTRUCTIONS.md (falls back to empty string if missing),
-/// generates delegation authority from agents_dir, concatenates the two in
-/// order 3→4, and returns the merged string. Separately ensures the project
-/// `CLAUDE.md` exists (creating the stub if absent) purely for its side
-/// effect — its content is intentionally NOT folded into `merged` (dead code
-/// removed; see module docs).
+/// generates delegation authority from the roster
+/// [`crate::core::delegation_authority::resolve_roster`] resolves for
+/// `project_dir`, concatenates the two in order 3→4, and returns the merged
+/// string. Separately ensures the project `CLAUDE.md` exists (creating the stub
+/// if absent) purely for its side effect — its content is intentionally NOT
+/// folded into `merged` (dead code removed; see module docs).
 ///
-/// Test: `pipeline_full`, `pipeline_missing_instructions`, `pipeline_creates_claude_md`
+/// Test: `pipeline_full`, `pipeline_missing_instructions`,
+/// `pipeline_creates_claude_md`,
+/// `session_start_count_matches_the_delivered_delegation_roster`
 pub fn build_instructions(input: &PipelineInput) -> Result<PipelineOutput, PipelineError> {
     // Section 3: framework instructions. A missing file is not fatal — the
     // session can still launch with delegation context.
@@ -543,7 +553,11 @@ pub fn build_instructions(input: &PipelineInput) -> Result<PipelineOutput, Pipel
         };
 
     // Section 4: delegation authority, built fresh from the deployed agents.
-    let agents = scan_agents(&input.agents_dir);
+    // #4588: resolved by `resolve_roster` — the SAME function that renders the
+    // delegation section delivered to the PM — so `agent_count`, which
+    // `tm session start` prints verbatim, cannot describe a different set of
+    // agents than the PM received.
+    let agents = resolve_roster(&input.project_dir);
     let agent_count = agents.len();
     let authority = generate_authority(&agents);
 

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -7,6 +7,7 @@
 
 use super::*;
 use std::fs;
+use std::path::Path;
 use tempfile::TempDir;
 
 /// Write `<name>.md` into `dir` with the given raw content.
@@ -17,15 +18,114 @@ fn write_file(path: &PathBuf, content: &str) {
     fs::write(path, content).expect("write file");
 }
 
-/// Build a `PipelineInput` rooted at `tmp` with optional INSTRUCTIONS.md.
-fn input_in(tmp: &TempDir) -> PipelineInput {
-    PipelineInput {
-        framework_instructions_path: tmp.path().join("INSTRUCTIONS.md"),
-        agents_dir: tmp.path().join("agents"),
-        claude_md_path: tmp.path().join("project").join("CLAUDE.md"),
+// ── #4588 / #4589: one resolution path, two operator-visible numbers ────────
+
+/// RAII override of every environment input
+/// [`crate::core::delegation_authority::deployed_agent_dirs`] consults, so a
+/// roster assertion is a property of the TEST rather than of the developer's
+/// machine.
+///
+/// Why: the roster is a three-tier union and two of those tiers are
+/// machine-global (`$CLAUDE_CONFIG_DIR/agents` and `$HOME/.claude/agents`).
+/// Without this, the exact-count assertions below would read whatever the
+/// developer happens to have deployed — and live `tm` sessions rewrite those
+/// directories mid-run, which is a documented 1-in-4 flake in
+/// `bundled_pm_package_tests`.
+/// What: points `$HOME` and `$CLAUDE_CONFIG_DIR` at a fresh temp root and
+/// restores both on drop (including on a panic-driven unwind).
+/// Test: used by `session_start_count_matches_the_delivered_delegation_roster`.
+struct RosterTiers {
+    tmp: TempDir,
+    prev_home: Option<std::ffi::OsString>,
+    prev_config: Option<std::ffi::OsString>,
+}
+
+impl RosterTiers {
+    /// Callers MUST be tagged `#[serial_test::serial]` — this mutates
+    /// process-global environment state.
+    fn new() -> Self {
+        let tmp = TempDir::new().expect("tempdir");
+        let prev_home = std::env::var_os("HOME");
+        let prev_config = std::env::var_os("CLAUDE_CONFIG_DIR");
+        // SAFETY: every caller is `#[serial]`, so no other test thread races
+        // this set/restore.
+        unsafe {
+            std::env::set_var("HOME", tmp.path().join("home"));
+            std::env::set_var("CLAUDE_CONFIG_DIR", tmp.path().join("claude-config"));
+        }
+        Self {
+            tmp,
+            prev_home,
+            prev_config,
+        }
+    }
+
+    /// The project whose roster is under test.
+    fn project(&self) -> PathBuf {
+        self.tmp.path().join("project")
+    }
+
+    /// Tier 1 — `<project>/.claude/agents`, the operator's hand-placed agents.
+    fn project_tier(&self) -> PathBuf {
+        self.project().join(".claude").join("agents")
+    }
+
+    /// Tier 2 — the tm-managed `$CLAUDE_CONFIG_DIR/agents` bundled agents
+    /// deploy into since #4409. This is the ONE directory the pre-#4588
+    /// session-start count was derived from.
+    fn managed_tier(&self) -> PathBuf {
+        self.tmp.path().join("claude-config").join("agents")
+    }
+
+    /// Tier 3 — the operator's own generic `~/.claude/agents`, which tm never
+    /// writes to but a launched session still resolves agents from. This tier
+    /// held the five agents behind #4588's observed 34-vs-39 delta.
+    fn generic_tier(&self) -> PathBuf {
+        self.tmp.path().join("home").join(".claude").join("agents")
     }
 }
 
+impl Drop for RosterTiers {
+    fn drop(&mut self) {
+        // SAFETY: caller is `#[serial]`.
+        unsafe {
+            match self.prev_home.take() {
+                Some(v) => std::env::set_var("HOME", v),
+                None => std::env::remove_var("HOME"),
+            }
+            match self.prev_config.take() {
+                Some(v) => std::env::set_var("CLAUDE_CONFIG_DIR", v),
+                None => std::env::remove_var("CLAUDE_CONFIG_DIR"),
+            }
+        }
+    }
+}
+
+/// Write a minimal composed agent named `name` into `dir`.
+fn write_roster_agent(dir: &Path, name: &str) {
+    fs::create_dir_all(dir).expect("create tier");
+    fs::write(
+        dir.join(format!("{name}.md")),
+        format!("---\nname: {name}\nrole: {name}\ndescription: Handles {name} work.\n---\n"),
+    )
+    .expect("write agent");
+}
+
+/// Build a `PipelineInput` for the isolated project `tiers` describes.
+///
+/// #4588: the pipeline resolves the roster from the PROJECT, not from a
+/// caller-named directory, so every test that asserts an exact `agent_count`
+/// must pin all three tiers — hence [`RosterTiers`] rather than a bare
+/// `TempDir`.
+fn input_in(tiers: &RosterTiers) -> PipelineInput {
+    PipelineInput {
+        framework_instructions_path: tiers.tmp.path().join("INSTRUCTIONS.md"),
+        project_dir: tiers.project(),
+        claude_md_path: tiers.project().join("CLAUDE.md"),
+    }
+}
+
+#[serial_test::serial]
 #[test]
 fn pipeline_full() {
     // All inputs present → merged output contains the two framework
@@ -33,18 +133,14 @@ fn pipeline_full() {
     // deliberately NOT folded into `merged` (dead code removed — Claude
     // Code loads CLAUDE.md natively and the real launch prompt never
     // read this field for that content).
-    let tmp = TempDir::new().unwrap();
-    let input = input_in(&tmp);
+    let tiers = RosterTiers::new();
+    let input = input_in(&tiers);
 
     write_file(
         &input.framework_instructions_path,
         "# Framework\n\nFRAMEWORK SECTION\n",
     );
-    fs::create_dir_all(&input.agents_dir).unwrap();
-    write_file(
-        &input.agents_dir.join("engineer.md"),
-        "---\nname: engineer\nrole: engineer\ndescription: Builds things.\n---\n\n# Engineer\n",
-    );
+    write_roster_agent(&tiers.project_tier(), "engineer");
     write_file(&input.claude_md_path, "# Project\n\nPROJECT SECTION\n");
 
     let out = build_instructions(&input).unwrap();
@@ -69,18 +165,15 @@ fn pipeline_full() {
     );
 }
 
+#[serial_test::serial]
 #[test]
 fn pipeline_missing_instructions() {
     // INSTRUCTIONS.md absent → pipeline still succeeds, instructions_loaded
     // is false, and section 4 is still present.
-    let tmp = TempDir::new().unwrap();
-    let input = input_in(&tmp);
+    let tiers = RosterTiers::new();
+    let input = input_in(&tiers);
     // No INSTRUCTIONS.md written.
-    fs::create_dir_all(&input.agents_dir).unwrap();
-    write_file(
-        &input.agents_dir.join("qa.md"),
-        "---\nname: qa\nrole: qa\ndescription: Tests things.\n---\n\n# QA\n",
-    );
+    write_roster_agent(&tiers.project_tier(), "qa");
     write_file(&input.claude_md_path, "# Project\n\nPROJECT NOTES\n");
 
     let out = build_instructions(&input).unwrap();
@@ -91,15 +184,15 @@ fn pipeline_missing_instructions() {
     assert!(!out.merged.starts_with("---"));
 }
 
+#[serial_test::serial]
 #[test]
 fn pipeline_creates_claude_md() {
     // CLAUDE.md absent → it is created as a side effect, claude_md_created
     // is true, and the file on disk contains the stub — but the stub text
     // is NOT folded into `merged` (dead code removed).
-    let tmp = TempDir::new().unwrap();
-    let input = input_in(&tmp);
+    let tiers = RosterTiers::new();
+    let input = input_in(&tiers);
     write_file(&input.framework_instructions_path, "# Framework\n");
-    fs::create_dir_all(&input.agents_dir).unwrap();
 
     assert!(!input.claude_md_path.exists());
     let out = build_instructions(&input).unwrap();
@@ -123,6 +216,7 @@ fn pipeline_creates_claude_md() {
     );
 }
 
+#[serial_test::serial]
 #[test]
 fn pipeline_claude_md_left_byte_identical() {
     // Why (#2170): trusty-mpm must NEVER modify a target project's
@@ -131,10 +225,9 @@ fn pipeline_claude_md_left_byte_identical() {
     // text — must come back out of `build_instructions` completely
     // untouched on disk, and its content must not leak into `merged`
     // (dead code removed).
-    let tmp = TempDir::new().unwrap();
-    let input = input_in(&tmp);
+    let tiers = RosterTiers::new();
+    let input = input_in(&tiers);
     write_file(&input.framework_instructions_path, "# Framework\n");
-    fs::create_dir_all(&input.agents_dir).unwrap();
     let custom = "# My Project\n\nCUSTOM HAND-WRITTEN CONTENT\n";
     write_file(&input.claude_md_path, custom);
 
@@ -484,16 +577,63 @@ fn primary_directive_mandate_not_duplicated_across_channels() {
     }
 }
 
+#[serial_test::serial]
 #[test]
 fn pipeline_no_agents_still_succeeds() {
-    // An empty agents dir yields a zero agent_count and the "no agents"
+    // Every tier empty yields a zero agent_count and the "no agents"
     // delegation section, but the pipeline still produces merged output.
-    let tmp = TempDir::new().unwrap();
-    let input = input_in(&tmp);
+    let tiers = RosterTiers::new();
+    let input = input_in(&tiers);
     write_file(&input.framework_instructions_path, "# Framework\n");
-    fs::create_dir_all(&input.agents_dir).unwrap();
 
     let out = build_instructions(&input).unwrap();
     assert_eq!(out.agent_count, 0);
     assert!(out.merged.to_lowercase().contains("no delegatable agents"));
+}
+
+#[serial_test::serial]
+#[test]
+fn session_start_count_matches_the_delivered_delegation_roster() {
+    // THE #4588 GATE. `tm session start` prints
+    // `Instructions: {agent_count} agents in delegation authority` straight
+    // from `PipelineOutput::agent_count`, while the roster the PM actually
+    // receives is rendered by `deployed_roster_section`. Those were two
+    // independent resolutions — a single-directory scan versus a three-tier
+    // union — so the printed number understated the delivered roster (34 vs 39
+    // measured live on tm 1.3.1). Both must now come from ONE resolver, which
+    // is what this asserts: not that the number is plausible, but that it is
+    // the SAME number, computed the same way, over a roster spanning all three
+    // tiers with a deliberate cross-tier duplicate.
+    let tiers = RosterTiers::new();
+
+    write_roster_agent(&tiers.managed_tier(), "engineer");
+    write_roster_agent(&tiers.managed_tier(), "qa");
+    write_roster_agent(&tiers.generic_tier(), "writer");
+    write_roster_agent(&tiers.project_tier(), "ticketing");
+    // Deployed in two tiers at once — the union must advertise it exactly once,
+    // so a naive concatenation cannot pass this test either.
+    write_roster_agent(&tiers.generic_tier(), "qa");
+
+    let input = PipelineInput {
+        framework_instructions_path: tiers.tmp.path().join("INSTRUCTIONS.md"),
+        project_dir: tiers.project(),
+        claude_md_path: tiers.project().join("CLAUDE.md"),
+    };
+    write_file(&input.framework_instructions_path, "# Framework\n");
+
+    let out = build_instructions(&input).expect("pipeline");
+    let delivered = crate::core::delegation_authority::deployed_roster_section(&tiers.project())
+        .expect("a roster is deployed in three tiers, so a section must render");
+    let delivered_entries = delivered.matches("\n### ").count();
+
+    assert_eq!(
+        out.agent_count, delivered_entries,
+        "the count `tm session start` prints must equal the number of agents \
+         the PM was actually given (#4588)\nprinted: {}\ndelivered roster:\n{delivered}",
+        out.agent_count
+    );
+    assert_eq!(
+        out.agent_count, 4,
+        "engineer + qa + writer + ticketing, with the cross-tier `qa` counted once"
+    );
 }

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -708,9 +708,11 @@ fn prepare_session_inner(
     );
     let input = PipelineInput {
         framework_instructions_path: fw.framework_instructions_path(),
-        // #4409: the roster is scanned from the tier the agents actually
-        // deploy into, not the workspace's project tier.
-        agents_dir: fw.agent_deploy_dir(),
+        // #4588: the roster is resolved from the project by the one shared
+        // resolver (project tier + the tm-managed `CLAUDE_CONFIG_DIR` tier
+        // #4409 deploys into + the operator's generic `~/.claude/agents`), so
+        // the count printed at session start is the roster the PM receives.
+        project_dir: project_dir.to_path_buf(),
         claude_md_path: project_dir.join("CLAUDE.md"),
     };
     let instructions = build_instructions(&input)?;

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -661,10 +661,9 @@ New issues are reserved for genuinely separable work someone would schedule on i
 > `CLAUDE_CONFIG_DIR/agents`, and the framework agents dir, project tier
 > winning on a name collision. The scan reads every `.md` file on disk, so it
 > picks up manifest-declared AND user-installed agents. That roster is
-> required; composition fails without it. Exception: agents whose frontmatter
-> carries `role: base` are filtered out as foundation templates, which
-> currently hides `memory-manager`, `mpm-agent-manager`, and
-> `mpm-skills-manager` (#4589).
+> required; composition fails without it. The ONLY agents filtered out are
+> foundation templates, identified by a `BASE-*` file name (the `base-` prefix
+> is required); frontmatter is never used to hide an agent (#4589).
 >
 > This file: crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md
 

--- a/crates/trusty-mpm/src/daemon/doctor.rs
+++ b/crates/trusty-mpm/src/daemon/doctor.rs
@@ -271,7 +271,7 @@ pub async fn run_doctor(
 
     let mut checks = vec![
         check_instructions(project_dir),
-        check_agents(&paths),
+        check_agents(&paths, project_dir),
         // #4451: `check_agents` proves the files exist; this proves the tier
         // they land in is one a managed session's harness actually scans.
         check_agent_reachability(&paths, project_dir),

--- a/crates/trusty-mpm/src/daemon/doctor_fs_checks.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_fs_checks.rs
@@ -68,7 +68,9 @@ pub(super) fn check_instructions(project_dir: Option<&Path>) -> DoctorCheck {
 /// checking the old location would report a healthy install as broken.
 /// What: `Fail` when the directory is absent or holds no `.md` files; `Warn`
 /// when agents are present but the manifest JSON is missing; `Ok` when both
-/// agent files and the manifest are present. Every message also carries the
+/// agent files and the manifest are present. EVERY message — including the
+/// empty-deploy-tier `Fail`, whose roster can still be non-empty because the
+/// project and generic tiers are independent of the deploy tier — carries the
 /// DELEGATABLE roster size, resolved by
 /// [`crate::core::delegation_authority::resolve_roster`] — the same function
 /// that builds the PM's delegation section and the count `tm session start`
@@ -78,22 +80,19 @@ pub(super) fn check_instructions(project_dir: Option<&Path>) -> DoctorCheck {
 /// supplied the roster is genuinely undetermined (its highest-precedence tier
 /// is a project directory), and it is reported as `unknown` rather than as a
 /// plausible-looking number.
-/// Test: `agents_missing_dir_is_fail`, `agents_without_manifest_is_warn`,
-/// `agents_with_manifest_is_ok`, `agents_message_reports_the_delegatable_roster`,
+/// Test: `agents_missing_dir_is_fail`, `agents_fail_path_still_reports_the_roster`,
+/// `agents_without_manifest_is_warn`, `agents_with_manifest_is_ok`,
+/// `agents_message_reports_the_delegatable_roster`,
 /// `agents_roster_is_unknown_without_a_project_dir`.
 pub(super) fn check_agents(paths: &FrameworkPaths, project_dir: Option<&Path>) -> DoctorCheck {
     let dir = paths.agent_deploy_dir();
     let md_count = count_files_with_extension(&dir, "md");
-    if md_count == 0 {
-        return DoctorCheck::new(
-            "agents",
-            CheckStatus::Fail,
-            format!(
-                "no agent files in {} — run `tm install` to deploy agents",
-                dir.display()
-            ),
-        );
-    }
+    // Resolved BEFORE the empty-deploy-tier branch (#4589 review, MEDIUM): an
+    // empty deploy tier does NOT mean an empty roster — the project and generic
+    // `~/.claude/agents` tiers are independent of it, and a probe measured 42
+    // delegatable agents while this branch reported only "no agent files".
+    // Returning early with a deploy fact and no routing fact is the same
+    // conflation this check exists to remove.
     let roster = match project_dir {
         Some(project) => format!(
             "{} delegatable",
@@ -101,6 +100,16 @@ pub(super) fn check_agents(paths: &FrameworkPaths, project_dir: Option<&Path>) -
         ),
         None => "delegatable roster unknown (no project directory)".to_string(),
     };
+    if md_count == 0 {
+        return DoctorCheck::new(
+            "agents",
+            CheckStatus::Fail,
+            format!(
+                "no agent files in {} — run `tm install` to deploy agents; {roster}",
+                dir.display()
+            ),
+        );
+    }
     let manifest = dir.join(MANIFEST_FILE);
     if manifest.exists() {
         DoctorCheck::new(
@@ -320,6 +329,43 @@ mod tests {
         let paths = FrameworkPaths::under(tmp.path());
         let check = check_agents(&paths, None);
         assert_eq!(check.status, CheckStatus::Fail);
+    }
+
+    #[test]
+    fn agents_fail_path_still_reports_the_roster() {
+        // #4589 review (MEDIUM): the empty-deploy-tier `Fail` returned before
+        // the roster was resolved, so it reported a deploy fact and no routing
+        // fact — while the project and generic tiers could still be serving a
+        // full roster. An empty deploy tier is not an empty roster.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+
+        let project = tempfile::tempdir().unwrap();
+        let project_tier = project.path().join(".claude").join("agents");
+        std::fs::create_dir_all(&project_tier).unwrap();
+        std::fs::write(
+            project_tier.join("ticketing.md"),
+            "---\nname: ticketing\nrole: ticketing\n---\n",
+        )
+        .unwrap();
+
+        let check = check_agents(&paths, Some(project.path()));
+        assert_eq!(check.status, CheckStatus::Fail, "no deployed agent files");
+        assert!(
+            check.message.contains("delegatable"),
+            "the Fail path must still report the routing fact: {}",
+            check.message
+        );
+
+        // And with no project to scope it, it must say unknown on this path too
+        // rather than fall silent.
+        let bare = check_agents(&paths, None);
+        assert_eq!(bare.status, CheckStatus::Fail);
+        assert!(
+            bare.message.contains("delegatable roster unknown"),
+            "an undetermined roster must be named, not omitted: {}",
+            bare.message
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/daemon/doctor_fs_checks.rs
+++ b/crates/trusty-mpm/src/daemon/doctor_fs_checks.rs
@@ -68,9 +68,20 @@ pub(super) fn check_instructions(project_dir: Option<&Path>) -> DoctorCheck {
 /// checking the old location would report a healthy install as broken.
 /// What: `Fail` when the directory is absent or holds no `.md` files; `Warn`
 /// when agents are present but the manifest JSON is missing; `Ok` when both
-/// agent files and the manifest are present.
-/// Test: `agents_missing_dir_is_fail`, `agents_without_manifest_is_warn`.
-pub(super) fn check_agents(paths: &FrameworkPaths) -> DoctorCheck {
+/// agent files and the manifest are present. Every message also carries the
+/// DELEGATABLE roster size, resolved by
+/// [`crate::core::delegation_authority::resolve_roster`] — the same function
+/// that builds the PM's delegation section and the count `tm session start`
+/// prints (#4588/#4589). A file count is a deploy fact, not a routing fact: the
+/// two diverged by three agents in #4589 and by five in #4588, and reporting
+/// only the file count made both invisible here. When no `project_dir` is
+/// supplied the roster is genuinely undetermined (its highest-precedence tier
+/// is a project directory), and it is reported as `unknown` rather than as a
+/// plausible-looking number.
+/// Test: `agents_missing_dir_is_fail`, `agents_without_manifest_is_warn`,
+/// `agents_with_manifest_is_ok`, `agents_message_reports_the_delegatable_roster`,
+/// `agents_roster_is_unknown_without_a_project_dir`.
+pub(super) fn check_agents(paths: &FrameworkPaths, project_dir: Option<&Path>) -> DoctorCheck {
     let dir = paths.agent_deploy_dir();
     let md_count = count_files_with_extension(&dir, "md");
     if md_count == 0 {
@@ -83,13 +94,20 @@ pub(super) fn check_agents(paths: &FrameworkPaths) -> DoctorCheck {
             ),
         );
     }
+    let roster = match project_dir {
+        Some(project) => format!(
+            "{} delegatable",
+            crate::core::delegation_authority::resolve_roster(project).len()
+        ),
+        None => "delegatable roster unknown (no project directory)".to_string(),
+    };
     let manifest = dir.join(MANIFEST_FILE);
     if manifest.exists() {
         DoctorCheck::new(
             "agents",
             CheckStatus::Ok,
             format!(
-                "{md_count} agent(s) deployed in {} with manifest",
+                "{md_count} agent file(s) deployed in {} with manifest; {roster}",
                 dir.display()
             ),
         )
@@ -98,7 +116,7 @@ pub(super) fn check_agents(paths: &FrameworkPaths) -> DoctorCheck {
             "agents",
             CheckStatus::Warn,
             format!(
-                "{md_count} agent(s) in {} but {MANIFEST_FILE} is missing",
+                "{md_count} agent file(s) in {} but {MANIFEST_FILE} is missing; {roster}",
                 dir.display()
             ),
         )
@@ -300,7 +318,7 @@ mod tests {
         // `FrameworkPaths::under` derives the managed config-dir agents tier
         // (#4409), which does not exist under a fresh temp dir.
         let paths = FrameworkPaths::under(tmp.path());
-        let check = check_agents(&paths);
+        let check = check_agents(&paths, None);
         assert_eq!(check.status, CheckStatus::Fail);
     }
 
@@ -311,7 +329,7 @@ mod tests {
         let agents = paths.agent_deploy_dir();
         std::fs::create_dir_all(&agents).unwrap();
         std::fs::write(agents.join("engineer.md"), "agent").unwrap();
-        let check = check_agents(&paths);
+        let check = check_agents(&paths, None);
         assert_eq!(check.status, CheckStatus::Warn);
     }
 
@@ -323,8 +341,70 @@ mod tests {
         std::fs::create_dir_all(&agents).unwrap();
         std::fs::write(agents.join("engineer.md"), "agent").unwrap();
         std::fs::write(agents.join(MANIFEST_FILE), "{}").unwrap();
-        let check = check_agents(&paths);
+        let check = check_agents(&paths, None);
         assert_eq!(check.status, CheckStatus::Ok);
+    }
+
+    #[test]
+    fn agents_message_reports_the_delegatable_roster() {
+        // #4588/#4589: the file count is a deploy fact, the roster is the
+        // routing fact, and they diverged by three agents (#4589) and by five
+        // (#4588) while this probe reported only the former. The roster figure
+        // comes from `resolve_roster` — the same function the PM prompt and
+        // `tm session start` use — so a divergence is legible here instead of
+        // being discovered from a live PM that never heard of an agent.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+        let agents = paths.agent_deploy_dir();
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("engineer.md"), "agent").unwrap();
+        std::fs::write(agents.join(MANIFEST_FILE), "{}").unwrap();
+
+        let project = tempfile::tempdir().unwrap();
+        let project_tier = project.path().join(".claude").join("agents");
+        std::fs::create_dir_all(&project_tier).unwrap();
+        std::fs::write(
+            project_tier.join("ticketing.md"),
+            "---\nname: ticketing\nrole: ticketing\n---\n",
+        )
+        .unwrap();
+
+        let check = check_agents(&paths, Some(project.path()));
+        assert!(
+            check.message.contains("1 agent file(s) deployed"),
+            "the deploy-tier file count must still be reported: {}",
+            check.message
+        );
+        assert!(
+            check.message.contains("delegatable"),
+            "the delegatable roster size must be reported: {}",
+            check.message
+        );
+        assert!(
+            !check.message.contains("unknown"),
+            "a project was supplied, so the roster is knowable: {}",
+            check.message
+        );
+    }
+
+    #[test]
+    fn agents_roster_is_unknown_without_a_project_dir() {
+        // The roster's highest-precedence tier IS a project directory, so with
+        // no project there is no roster to report. It must say so rather than
+        // print a plausible-looking number derived from the other tiers.
+        let tmp = tempfile::tempdir().unwrap();
+        let paths = FrameworkPaths::under(tmp.path());
+        let agents = paths.agent_deploy_dir();
+        std::fs::create_dir_all(&agents).unwrap();
+        std::fs::write(agents.join("engineer.md"), "agent").unwrap();
+        std::fs::write(agents.join(MANIFEST_FILE), "{}").unwrap();
+
+        let check = check_agents(&paths, None);
+        assert!(
+            check.message.contains("delegatable roster unknown"),
+            "an undetermined roster must be reported as unknown: {}",
+            check.message
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/tests/e2e/test_instruction_pipeline.rs
+++ b/crates/trusty-mpm/tests/e2e/test_instruction_pipeline.rs
@@ -15,12 +15,22 @@ use trusty_mpm::core::agent_deployer::deploy_agents;
 use trusty_mpm::core::instruction_pipeline::{PipelineInput, build_instructions};
 
 /// Build a `PipelineInput` rooted at `tmp`.
+///
+/// #4588: the pipeline resolves its roster from the PROJECT via the one shared
+/// resolver, so the input names a project directory rather than an agents
+/// directory. Agents for these tests go into that project's own
+/// `.claude/agents` tier — see [`agents_tier`].
 fn input_in(tmp: &TempDir) -> PipelineInput {
     PipelineInput {
         framework_instructions_path: tmp.path().join("INSTRUCTIONS.md"),
-        agents_dir: tmp.path().join("agents"),
+        project_dir: tmp.path().join("project"),
         claude_md_path: tmp.path().join("project").join("CLAUDE.md"),
     }
+}
+
+/// The highest-precedence roster tier for `input`'s project.
+fn agents_tier(input: &PipelineInput) -> PathBuf {
+    input.project_dir.join(".claude").join("agents")
 }
 
 fn write(path: &PathBuf, content: &str) {
@@ -45,9 +55,9 @@ fn pipeline_produces_merged_output() {
         &input.framework_instructions_path,
         "# Framework\n\nFRAMEWORK SECTION\n",
     );
-    std::fs::create_dir_all(&input.agents_dir).unwrap();
+    std::fs::create_dir_all(agents_tier(&input)).unwrap();
     write(
-        &input.agents_dir.join("engineer.md"),
+        &agents_tier(&input).join("engineer.md"),
         "---\nname: engineer\nrole: engineer\ndescription: Builds things.\n---\n\n# Engineer\n",
     );
     // No CLAUDE.md — the pipeline must still seed the stub.
@@ -82,7 +92,7 @@ fn pipeline_preserves_claude_md() {
     let input = input_in(&tmp);
 
     write(&input.framework_instructions_path, "# Framework\n");
-    std::fs::create_dir_all(&input.agents_dir).unwrap();
+    std::fs::create_dir_all(agents_tier(&input)).unwrap();
     let custom = "# My Project\n\nCUSTOM HAND-WRITTEN CONTENT\n";
     write(&input.claude_md_path, custom);
 
@@ -112,7 +122,7 @@ fn pipeline_without_instructions_file() {
     let tmp = TempDir::new().unwrap();
     let input = input_in(&tmp);
     // No INSTRUCTIONS.md written.
-    std::fs::create_dir_all(&input.agents_dir).unwrap();
+    std::fs::create_dir_all(agents_tier(&input)).unwrap();
 
     let out = build_instructions(&input).expect("pipeline succeeds");
     assert!(!out.instructions_loaded);
@@ -130,7 +140,7 @@ fn pipeline_authority_lists_deployed_agents() {
     // Deploy a real composed engineer agent into the pipeline's agents dir.
     let src = TempDir::new().unwrap();
     write_agent_sources(src.path());
-    deploy_agents(src.path(), &input.agents_dir).expect("deploy succeeds");
+    deploy_agents(src.path(), &agents_tier(&input)).expect("deploy succeeds");
 
     let out = build_instructions(&input).expect("pipeline succeeds");
     assert!(out.agent_count >= 1, "deployed agents counted");

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -125,3 +125,16 @@ second, independent Tauri crate (`crates/trusty-code-gui`, for the
 GUI binary (no `install-trusty-code-signed.sh` script or `CODE_SET` exists);
 the Tauri `bundle.macOS.signingIdentity` config is the only signing path for
 `trusty-code-gui` today.
+
+🔴 **Naming an agent file `base…` without a hyphen** — `scan_agents`
+(`crates/trusty-mpm/src/core/delegation_authority.rs`) treats a case-insensitive
+`base-` file-stem prefix as a foundation template and removes it from the
+delegation roster entirely. That is the ONLY rule that hides a deployed agent,
+and it keys on the FILE NAME, never on frontmatter — an agent's `role:` value is
+irrelevant to it (#4589). The hyphen is the whole convention: `base-anything.md`
+is excluded, while `baseline-analyzer.md`, `base64-decoder.md`, and
+`basecamp-sync.md` are ordinary delegatable agents. If an agent you deployed
+never appears in the PM's `## Delegation Authority` section, check the file name
+first, then run `tm doctor` — its `agents` check reports the deployed file count
+and the delegatable roster size side by side, and a gap between them is the
+symptom. `RUST_LOG=debug` logs every file this rule excludes, with its directory.


### PR DESCRIPTION
Two reports, one defect: trusty-mpm advertised an agent roster that did not match what was actually deployed and reachable. Both are consequences of resolving the roster **twice**.

## #4589 — three real agents hidden by the `role: base` filter

`scan_agents` excluded any agent whose frontmatter `role:` began with `base`, on top of the `BASE-*` file-name rule. `memory-manager`, `mpm-agent-manager` and `mpm-skills-manager` shipped that way — deployed, dispatchable, and absent from every roster the PM ever received.

**Chosen resolution: option (b)** — key the exclusion off the `BASE-*` file-name convention alone.

Why (b), not (a):

- **Option (a) is already in the tree and was not enough.** The three bundled assets already carry correct `role:` values on `main`, and `every_bundled_non_base_agent_reaches_the_roster` already gates that. The rule that caused the defect survived, and it is the rule — not the three files — that #4589 is about.
- **The roster is a three-tier union (#4409 direction).** Bundled agents live at the tm-owned `$CLAUDE_CONFIG_DIR` user tier, but `deployed_agent_dirs` also unions `<project>/.claude/agents` and the operator's own `~/.claude/agents`. tm authors the frontmatter in exactly one of those three. A classification rule that reads a value tm does not control will silently delete an operator's agent from the other two, and **no asset edit can fix it**. `BASE-*` is tm's own convention, applies to the files tm actually ships, and `scan_agents` already checks it before the file is even read.

## #4588 — printed count derived from a single directory

`tm session start` printed `Instructions: N agents in delegation authority` from `scan_agents(fw.agent_deploy_dir())` — one directory — while the roster delivered to the PM was the three-tier union computed separately by `deployed_roster_section`.

## The unifying fix: one resolver

`delegation_authority::resolve_roster(project_dir)` is now the only implementation, and every consumer calls it:

| Consumer | Before | After |
|---|---|---|
| Delegation section in the PM prompt | `deployed_agent_dirs` + `roster_from_dirs` (inline) | `resolve_roster` |
| `tm session start` count | `scan_agents(<one dir>)` — **second implementation** | `resolve_roster` |
| `tm doctor` `agents` check | `.md` file count only | `.md` file count **+** `resolve_roster` size |

`PipelineInput.agents_dir` is replaced by `project_dir`: there is no longer a directory for a call site to get wrong. `tm doctor` reports the roster as `unknown` — never a plausible-looking number — when no project directory scopes the probe.

## Measured, from the real code path

Live machine, `resolve_roster` and `scan_agents` called directly:

```
tier 0 : <project>/.claude/agents                          (0 .md files)
tier 1 : ~/.trusty-tools/trusty-mpm/claude-config/agents   (42 .md files)
tier 2 : ~/.claude/agents                                  (6 .md files)

#4588  session-start count BEFORE (single tier, main rule): 37
#4588  roster AFTER (one resolver, three-tier union)      : 42
#4588  delegation roster the PM already received          : 42
```

Printed 37, delivered 42 — the delta of 5 is the generic `~/.claude/agents` tier, exactly the delta #4588 reports. After the fix both numbers are 42, because both are the same call.

For #4589, the deploy tier was reconstructed in the state the issue reports (`role: base` on the three agents) and scanned under both rules:

```
#4589  BEFORE (main rule): 34 agents
#4589  AFTER  (this PR) : 37 agents
#4589  memory-manager       BEFORE: MISSING  AFTER: present
#4589  mpm-agent-manager    BEFORE: MISSING  AFTER: present
#4589  mpm-skills-manager   BEFORE: MISSING  AFTER: present
```

34-vs-37 is the exact gap #4589 measured. All three agents are present in the live roster after the fix.

**Honest caveat:** because option (a) already landed, no *currently deployed* agent on this machine carries `role: base` — so today's live roster count does not change from the #4589 half alone. The 34→37 figures above come from reconstructing the reported state. What changes permanently is the rule.

## Red-then-green

Both regression tests were written and run **before** any production change:

```
running 2 tests

thread '...::agent_with_a_base_role_but_no_base_filename_stays_in_the_roster' panicked:
assertion `left == right` failed: a non-`BASE-*` file must never be classified as a
foundation template by its `role:` value alone (#4589)
  left: []
 right: ["memory-manager"]

thread '...::session_start_count_matches_the_delivered_delegation_roster' panicked:
assertion `left == right` failed: the count `tm session start` prints must equal the
number of agents the PM was actually given (#4588)
printed: 2
delivered roster:
### engineer / ### qa / ### ticketing / ### writer
  left: 2
 right: 4

test result: FAILED. 0 passed; 2 failed; 0 ignored; 4213 filtered out
```

After the fix, the same two tests plus the whole surrounding surface:

```
test core::delegation_authority::tests::agent_with_a_base_role_but_no_base_filename_stays_in_the_roster ... ok
test core::instruction_pipeline::tests::session_start_count_matches_the_delivered_delegation_roster ... ok
test daemon::doctor::doctor_fs_checks::tests::agents_message_reports_the_delegatable_roster ... ok
test daemon::doctor::doctor_fs_checks::tests::agents_roster_is_unknown_without_a_project_dir ... ok

test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 4165 filtered out
```

`session_start_count_matches_the_delivered_delegation_roster` pins all three tiers (`$HOME` + `$CLAUDE_CONFIG_DIR` under a `#[serial]` RAII guard) so the assertion is a property of the test, not of the developer's machine — and it plants a cross-tier duplicate so a naive concatenation cannot pass it either. The five pre-existing `pipeline_*` tests moved onto the same guard, since the pipeline now resolves from the project rather than a caller-named directory.

## Gates

- `cargo fmt --check` — exit 0.
- `cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings` — exit 0 (the three GUI crates are CI's own exclusions; they need a built `ui/dist`).
- `cargo test -p trusty-mpm` — `4211 passed; 0 failed; 6 ignored` plus every integration binary green. This is the only crate the diff touches.
- `cargo test --workspace` (CI's command) — 152 binaries, **20563 passed, 5 failed**. All five are `trusty-search`'s FSEvents watcher tests (`service::watcher::*`, `service::watch_loop::*`, `watcher_manager`), which fail identically on this machine against the completely untouched crate in isolation. The diff contains zero `trusty-search` files.
- One further attribution: `client::executor::tests::execute_doctor_against_test_daemon` timed out once under full-workspace load. It passes 5/5 standalone and takes 9-13 s against this machine's 269-worktree store, right at the client's 10 s request timeout. The work this PR adds to that path was measured at **1.0-1.6 ms warm, 98 ms cold** — 0.01-1 % of that budget, not the cause.

Closes #4589
Closes #4588

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
