### PR TITLE
fix(ci): stop cancelled runs reading as green, give stacked PRs real checks, and gate docs-only PRs (#4468, #4421)

### DIFF
--- a/.github/workflows/agent-assets.yml
+++ b/.github/workflows/agent-assets.yml
@@ -25,6 +25,12 @@ on:
       - "scripts/agent-asset-pins.tsv"
       - ".github/workflows/agent-assets.yml"
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
     paths:
       - "crates/trusty-code/src/assets/agents/**"
@@ -33,10 +39,12 @@ on:
       - "scripts/agent-asset-pins.tsv"
       - ".github/workflows/agent-assets.yml"
 
-# Cancel superseded runs for the same ref to save CI minutes (matches ci.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: agent-assets-${{ github.ref }}
-  cancel-in-progress: true
+  group: agent-assets-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   agent-assets:

--- a/.github/workflows/agent-assets.yml
+++ b/.github/workflows/agent-assets.yml
@@ -44,7 +44,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: agent-assets-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   agent-assets:

--- a/.github/workflows/al2023-build.yml
+++ b/.github/workflows/al2023-build.yml
@@ -67,6 +67,12 @@ on:
       - "crates/trusty-common/**"
       - ".github/workflows/al2023-build.yml"
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
     paths:
       - "crates/trusty-analyze/**"
@@ -77,10 +83,12 @@ on:
   workflow_dispatch:
     # Allow manual trigger from the Actions UI for ad-hoc validation.
 
-# Cancel superseded runs for the same ref (matches ci.yml convention).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: al2023-build-${{ github.ref }}
-  cancel-in-progress: true
+  group: al2023-build-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 env:
   # Suppress ort/fastembed download progress bars in build output.

--- a/.github/workflows/al2023-build.yml
+++ b/.github/workflows/al2023-build.yml
@@ -88,7 +88,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: al2023-build-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 env:
   # Suppress ort/fastembed download progress bars in build output.

--- a/.github/workflows/capabilities-drift.yml
+++ b/.github/workflows/capabilities-drift.yml
@@ -10,12 +10,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches ci.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: capabilities-drift-${{ github.ref }}
-  cancel-in-progress: true
+  group: capabilities-drift-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   capabilities-drift:

--- a/.github/workflows/capabilities-drift.yml
+++ b/.github/workflows/capabilities-drift.yml
@@ -23,7 +23,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: capabilities-drift-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   capabilities-drift:

--- a/.github/workflows/changelog-fragment.yml
+++ b/.github/workflows/changelog-fragment.yml
@@ -20,6 +20,12 @@ name: Changelog fragment
 
 on:
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
 # Cancel superseded runs for the same ref to save CI minutes (matches ci.yml).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 # CI workflow for the trusty-tools Cargo workspace.
 #
 # Jobs:
+#   changes  – classify the diff as docs-only or not, once, for every job
+#              below to consult (issue #4468: docs-only PRs ran the full Rust
+#              build). The exemption is applied to STEPS, never to the trigger
+#              or to the job, so required checks always report.
 #   fmt      – cargo fmt --all --check (stable)
 #   clippy   – cargo clippy --workspace --all-targets -D warnings (stable, SKIP_UI_BUILD=1)
 #   test     – cargo test --workspace (stable, SKIP_UI_BUILD=1, full clone for git tests)
@@ -79,12 +83,36 @@ on:
   push:
     branches: [main]
   pull_request:
+    # EXPLICIT activity types (#4179). Without a `types:` key GitHub uses the
+    # default set — opened, synchronize, reopened — and RETARGETING a pull
+    # request fires none of them: a base change is delivered as `edited` with
+    # `changes.base`. A stacked PR opened against another feature branch is
+    # therefore filtered out by `branches: [main]` while it is stacked, and
+    # then never re-triggered when it is retargeted to main. PR #3838 merged
+    # with `statusCheckRollup: []` — zero check runs, ever — exactly this way.
+    #
+    # `edited` also fires on title/body edits, so a PR description edit costs a
+    # duplicate run. That is the deliberate trade: a wasted run is recoverable,
+    # a zero-check merge is not, and PR runs are still superseded by the
+    # concurrency group below. `ready_for_review` (also non-default) covers a
+    # draft being marked ready.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes.
+# PULL REQUESTS: one run per PR ref — a new push supersedes the previous run,
+# which is what saves the CI minutes this key was added for.
+#
+# PUSH TO MAIN: the group is keyed to the COMMIT, not the branch, so it is
+# unique per merge and no run is ever cancelled or queued behind a sibling
+# (#4179). The previous `ci-${{ github.ref }}` + `cancel-in-progress: true`
+# meant every push to main shared the group `ci-refs/heads/main`, so each merge
+# KILLED the previous merge's verification: 19 of 60 sampled push-to-main runs
+# (32%) concluded `cancelled`. A cancelled run is the only signal that commit
+# will ever get — the commit is already on main, so there is nothing to
+# supersede and nothing to save by cancelling.
 concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 # SKIP_UI_BUILD=1 prevents the four build.rs Svelte pipelines from invoking pnpm.
 env:
@@ -95,10 +123,69 @@ env:
 
 jobs:
   # --------------------------------------------------------------------------
+  # changes: classify the diff as docs-only or not (issue #4468), once, for
+  # every job below to consult.
+  #
+  # WHY THIS IS A JOB AND NOT A `paths:` FILTER. Five of this workflow's checks
+  # are REQUIRED by branch protection (Format check, Clippy, Test, MSRV check
+  # (1.91), trusty-search daemon smoke test). GitHub does not create check runs
+  # for a workflow its path/branch filters skipped, so a required context would
+  # sit pending forever and a docs-only PR would become unmergeable instead of
+  # fast — the trap #4468 calls out and the one
+  # .github/workflows/changelog-fragment.yml already documents. So every job
+  # still RUNS and still REPORTS; the exemption lives inside the jobs, on the
+  # steps that cost money. A docs-only PR therefore gets a green required check
+  # in ~30 s of runner startup instead of 45 minutes of cargo.
+  #
+  # The same reasoning rules out a job-level `if:`. GitHub documents a
+  # conditionally-skipped job as reporting success to branch protection, but
+  # the failure mode if that is wrong is every docs PR blocked forever, so the
+  # jobs are kept unconditional and only their steps are gated.
+  #
+  # PUSH TO MAIN never takes the exemption: main is the branch everything is
+  # cut from, so it is verified in full regardless of what the diff touched.
+  # --------------------------------------------------------------------------
+  changes:
+    name: Detect docs-only change set
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.detect.outputs.docs_only }}
+    steps:
+      # fetch-depth: 0 — the detector needs `git merge-base` against the base
+      # branch, which a shallow checkout cannot resolve.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      # The detector and the notifier's conclusion mapping are both pure shell
+      # with fixture-backed selftests; run them here so a regression in either
+      # is caught on the PR that introduces it rather than in production.
+      - name: CI helper selftests (#4179, #4468, #4421)
+        run: bash scripts/check-ci-helpers-selftest.sh
+
+      - name: Classify changed paths
+        id: detect
+        env:
+          DOCS_ONLY_BASE: ${{ github.event.pull_request.base.sha }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "push to ${{ github.ref }} — verifying in full, no docs-only exemption"
+            echo "docs_only=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          bash scripts/detect-docs-only.sh > /dev/null
+
+  # --------------------------------------------------------------------------
   # fmt: enforce cargo fmt --all --check (stable toolchain + rustfmt component)
+  #
+  # The instruction floor guard below is NOT gated on the docs-only detection:
+  # it guards instruction/markdown content, which is exactly what a docs-only
+  # PR changes.
   # --------------------------------------------------------------------------
   fmt:
     name: Format check
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -114,6 +201,7 @@ jobs:
         run: bash scripts/check_instruction_floor.sh
 
       - name: Install stable toolchain with rustfmt
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -122,6 +210,7 @@ jobs:
       # nightly-only; stable rustfmt silently ignores them (emits warnings, exit 0).
       # The format check itself is not affected.
       - name: cargo fmt --all --check
+        if: needs.changes.outputs.docs_only != 'true'
         run: cargo fmt --all --check
 
   # --------------------------------------------------------------------------
@@ -130,6 +219,7 @@ jobs:
   # --------------------------------------------------------------------------
   clippy:
     name: Clippy
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -138,6 +228,7 @@ jobs:
       # Free disk space (issue #2091): kept in sync with the more aggressive
       # reclamation in the `test` job (see comment there for rationale).
       - name: Free disk space
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
@@ -168,11 +259,13 @@ jobs:
           echo "After:"; df -h /
 
       - name: Install stable toolchain with clippy
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
 
       - name: Install system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -181,6 +274,7 @@ jobs:
             libssl-dev
 
       - name: Cache cargo artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           # Separate cache key per job so fmt/clippy/test/msrv don't fight
@@ -188,6 +282,7 @@ jobs:
           key: clippy
 
       - name: cargo clippy --workspace --all-targets -- -D warnings
+        if: needs.changes.outputs.docs_only != 'true'
         run: cargo clippy --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui -- -D warnings
 
   # --------------------------------------------------------------------------
@@ -225,6 +320,7 @@ jobs:
   # --------------------------------------------------------------------------
   test:
     name: Test
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -264,6 +360,7 @@ jobs:
       # the Azure CLI (~600 MB), and stale apt package caches/lists — none of
       # which this workspace's build or test steps touch.
       - name: Free disk space
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
@@ -298,12 +395,15 @@ jobs:
       # a local branch for the PR head; "main" is only a remote ref unless we
       # explicitly create a local tracking branch for it.
       - name: Create local main branch for git tests
+        if: needs.changes.outputs.docs_only != 'true'
         run: git fetch origin main:main || true
 
       - name: Install stable toolchain
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -312,6 +412,7 @@ jobs:
             libssl-dev
 
       - name: Cache cargo artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: test
@@ -325,6 +426,7 @@ jobs:
       # Changing any of these (e.g. upgrading fastembed) rotates the key so
       # the old model blobs are not served to the new version.
       - name: Restore fastembed model cache
+        if: needs.changes.outputs.docs_only != 'true'
         id: fastembed-cache
         uses: actions/cache@v4
         with:
@@ -399,7 +501,7 @@ jobs:
       #       seed_models as a plain statement in a subshell (never as a
       #       conditional's test) and capture its exit status via $?.
       - name: Pre-seed fastembed models (cache miss only)
-        if: steps.fastembed-cache.outputs.cache-hit != 'true'
+        if: needs.changes.outputs.docs_only != 'true' && steps.fastembed-cache.outputs.cache-hit != 'true'
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -584,6 +686,7 @@ jobs:
       # swept once linking is done and before the (disk-heavier) test
       # execution phase runs. See #3668.
       - name: cargo test --workspace --no-run (build phase)
+        if: needs.changes.outputs.docs_only != 'true'
         run: cargo test --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui --no-run
 
       # Sweep intermediate per-codegen-unit object files (#3668): once a
@@ -593,6 +696,7 @@ jobs:
       # a subsequent `cargo test` invocation to relink (cargo's fingerprint
       # tracking does not depend on these surviving).
       - name: Sweep intermediate .rcgu.o codegen objects
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "Before sweep:"; du -sh target/debug 2>/dev/null || true
           find target/debug/deps -name '*.rcgu.o' -delete
@@ -652,6 +756,7 @@ jobs:
       # pipefail at once would change every other step's failure semantics in
       # the same commit.
       - name: cargo test --workspace
+        if: needs.changes.outputs.docs_only != 'true'
         shell: bash
         run: |
           set -uo pipefail
@@ -681,6 +786,7 @@ jobs:
       # and only gets pulled in under `--workspace` via other crates'
       # feature unification, not under a bare `-p trusty-common` build.
       - name: cargo test -p trusty-common (cache-freshness, CI unset)
+        if: needs.changes.outputs.docs_only != 'true'
         env:
           CI: ""
         run: |
@@ -701,6 +807,7 @@ jobs:
   # --------------------------------------------------------------------------
   msrv:
     name: MSRV check (1.91)
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -709,6 +816,7 @@ jobs:
       # Free disk space (issue #2091): kept in sync with the more aggressive
       # reclamation in the `test` job (see comment there for rationale).
       - name: Free disk space
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
@@ -739,9 +847,11 @@ jobs:
           echo "After:"; df -h /
 
       - name: Install Rust 1.91 toolchain
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@1.91
 
       - name: Install system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -750,11 +860,13 @@ jobs:
             libssl-dev
 
       - name: Cache cargo artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: msrv-1-91
 
       - name: cargo check --workspace
+        if: needs.changes.outputs.docs_only != 'true'
         run: cargo check --workspace --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
 
   # --------------------------------------------------------------------------
@@ -777,12 +889,14 @@ jobs:
   # --------------------------------------------------------------------------
   agents-ui:
     name: trusty-agents-ui clippy
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
 
       - name: Install stable toolchain with clippy
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -791,6 +905,7 @@ jobs:
       # mirror the Tauri project's documented Linux prerequisites and are the
       # same reason the headless workspace jobs exclude this crate.
       - name: Install Tauri system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -805,18 +920,21 @@ jobs:
             libjavascriptcoregtk-4.1-dev
 
       - name: Cache cargo artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: agents-ui
 
       # Stub the frontendDist so tauri::generate_context!() can embed it.
       - name: Stub frontend dist for generate_context!
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           mkdir -p crates/trusty-agents/ui/dist
           printf '<!doctype html><html><head><meta charset="utf-8"><title>open-mpm</title></head><body></body></html>\n' \
             > crates/trusty-agents/ui/dist/index.html
 
       - name: cargo clippy -p trusty-agents-ui --all-targets -- -D warnings
+        if: needs.changes.outputs.docs_only != 'true'
         run: cargo clippy -p trusty-agents-ui --all-targets -- -D warnings
 
   # --------------------------------------------------------------------------
@@ -867,6 +985,7 @@ jobs:
   # --------------------------------------------------------------------------
   embedder-cuda-check:
     name: embedder-cuda compile check (#3508)
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -875,9 +994,11 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install stable toolchain
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -888,6 +1009,7 @@ jobs:
       # nvcc ONLY — see the job-level comment above for why the compiler
       # (not a GPU, not a driver) is a genuine, unavoidable requirement here.
       - name: Install nvcc (CUDA 12.8 compiler only; no driver, no GPU)
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/cuda-keyring_1.1-1_all.deb
           sudo dpkg -i cuda-keyring_1.1-1_all.deb
@@ -897,14 +1019,17 @@ jobs:
           echo "/usr/local/cuda-12.8/bin" >> "$GITHUB_PATH"
 
       - name: Verify nvcc is on PATH
+        if: needs.changes.outputs.docs_only != 'true'
         run: nvcc --version
 
       - name: Cache cargo artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: embedder-cuda-check
 
       - name: cargo check -p trusty-common --features embedder-cuda --all-targets
+        if: needs.changes.outputs.docs_only != 'true'
         run: cargo check -p trusty-common --features embedder-cuda --all-targets
 
   # --------------------------------------------------------------------------
@@ -961,6 +1086,7 @@ jobs:
   # --------------------------------------------------------------------------
   ui-checks:
     name: UI checks (${{ matrix.name }})
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -992,11 +1118,13 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install pnpm
+        if: needs.changes.outputs.docs_only != 'true'
         uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Install Node.js
+        if: needs.changes.outputs.docs_only != 'true'
         uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -1004,10 +1132,12 @@ jobs:
           cache-dependency-path: ${{ matrix.dir }}/pnpm-lock.yaml
 
       - name: Install dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         working-directory: ${{ matrix.dir }}
         run: pnpm install --frozen-lockfile
 
       - name: Run checks
+        if: needs.changes.outputs.docs_only != 'true'
         working-directory: ${{ matrix.dir }}
         run: ${{ matrix.command }}
 
@@ -1030,17 +1160,24 @@ jobs:
   #   4. --data-dir /tmp/ts-smoke — fully isolated data directory so no
   #      indexes.toml, lockfile, or port-file collides with any other process.
   #
-  # OPTIONAL — this job is marked continue-on-error: true because:
-  #   • It requires a full release build of trusty-search (~15-20 min on cold
-  #     cache), which adds significant wall-clock cost on top of the existing
-  #     four jobs.
-  #   • A timeout/kill race in the ephemeral runner is unlikely but not zero.
-  #   • The functional correctness of the daemon is covered by unit + integration
-  #     tests in the `test` job; this job only checks that the binary starts and
-  #     the HTTP server binds.
+  # REQUIRED, AND ABLE TO FAIL (#4179). This job used to carry
+  # `continue-on-error: true` and describe itself as OPTIONAL while branch
+  # protection listed `trusty-search daemon smoke test` among its seven
+  # required contexts. Both statements could not be true, and the combination
+  # produced signal inversion: job-level `continue-on-error` still publishes
+  # `conclusion: failure` to the CHECK RUN (so it did gate the merge button),
+  # but it keeps the RUN green — so the Actions UI, `gh run view`, and
+  # `needs.<job>.result` all read healthy while a required check was red.
   #
-  # If flakiness is never observed in practice, remove continue-on-error to
-  # make it a hard gate.
+  # Resolved in favour of REQUIRED, because that half is the one enforced by
+  # branch protection and this PR is not permitted to change branch-protection
+  # settings. Dropping `continue-on-error` costs nothing in wall clock (the
+  # ~15-20 min cold release build ran either way) and buys an honest run
+  # conclusion plus a place in `notify-main-failure`'s `needs`, which it could
+  # not have while its result never surfaced as `failure`. If the runner
+  # timeout/kill race it worried about ever materialises, the answer is to fix
+  # the race or drop the check from branch protection — not to make a required
+  # check unable to report the truth.
   #
   # TEARDOWN — the daemon is killed at the end via the stored PID. This is
   # correct CI behaviour: ephemeral runners are discarded after the job
@@ -1049,15 +1186,16 @@ jobs:
   # --------------------------------------------------------------------------
   search-daemon-smoke:
     name: trusty-search daemon smoke test
+    needs: [changes]
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v5
 
       # Free disk space (issue #2091): kept in sync with the more aggressive
       # reclamation in the `test` job (see comment there for rationale).
       - name: Free disk space
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           echo "Before:"; df -h /
           sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/lib/android \
@@ -1088,9 +1226,11 @@ jobs:
           echo "After:"; df -h /
 
       - name: Install stable toolchain
+        if: needs.changes.outputs.docs_only != 'true'
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install system dependencies
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
@@ -1099,6 +1239,7 @@ jobs:
             libssl-dev
 
       - name: Cache cargo artifacts
+        if: needs.changes.outputs.docs_only != 'true'
         uses: Swatinem/rust-cache@v2
         with:
           key: search-daemon-smoke
@@ -1106,9 +1247,11 @@ jobs:
       # SKIP_UI_BUILD=1 is already set globally via env: at the workflow level.
       # The committed ui-dist/ bundle is used as-is; pnpm is not required.
       - name: Build trusty-search release binary
+        if: needs.changes.outputs.docs_only != 'true'
         run: cargo build --release -p trusty-search
 
       - name: Start trusty-search daemon (background)
+        if: needs.changes.outputs.docs_only != 'true'
         env:
           # Skip KG init — no network calls, no model downloads at startup.
           TRUSTY_NO_KG: "1"
@@ -1131,6 +1274,7 @@ jobs:
           echo "Daemon PID: $(cat /tmp/ts-smoke/daemon.pid)"
 
       - name: Wait for /health (poll up to 30 s)
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           PORT=7999
           DEADLINE=$(( $(date +%s) + 30 ))
@@ -1148,6 +1292,7 @@ jobs:
           cat /tmp/ts-smoke/health.json
 
       - name: Assert /health returns status=ok
+        if: needs.changes.outputs.docs_only != 'true'
         run: |
           # jq is preinstalled on ubuntu-latest; use it instead of python3 for clarity.
           HEALTH_STATUS=$(jq -r '.status // ""' /tmp/ts-smoke/health.json)
@@ -1160,7 +1305,7 @@ jobs:
           echo "OK: status=ok confirmed"
 
       - name: Tear down daemon
-        if: always()
+        if: always() && needs.changes.outputs.docs_only != 'true'
         run: |
           if [ -f /tmp/ts-smoke/daemon.pid ]; then
             PID=$(cat /tmp/ts-smoke/daemon.pid)
@@ -1193,34 +1338,93 @@ jobs:
   # breakage having been diagnosed and handled, so closing stays a human
   # call.
   #
-  # `needs` lists every hard-gating job so `contains(needs.*.result,
-  # 'failure')` catches a red run from any of them; `search-daemon-smoke` is
-  # deliberately excluded (continue-on-error: true — see its own header
-  # comment — its job `result` never surfaces as `failure`).
+  # NOT-SUCCESS IS NOT SUCCESS (#4179). This job used to ask
+  # `contains(needs.*.result, 'failure')`. `cancelled` is not `failure`, so a
+  # run whose every build and test job was CANCELLED skipped the alarm AND
+  # reported success — the merge commit read verified when nothing had been
+  # verified. Live instance: run 30720348101 (head b4b91af9) — Test, Clippy,
+  # MSRV and the smoke test all cancelled, notifier green. It was not an edge
+  # case either: 19 of 60 sampled push-to-main runs concluded `cancelled`.
+  #
+  # The verdict now comes from scripts/classify-ci-results.sh, which folds
+  # every job conclusion into green / red / inconclusive with red >
+  # inconclusive > green precedence, and only an all-`success` set is green.
+  # The mapping is fixture-tested (scripts/check-ci-helpers-selftest.sh) rather
+  # than buried in a GitHub expression where it cannot be exercised.
+  #
+  # This job also FAILS on any non-green verdict, so the run's own conclusion
+  # stops disagreeing with what the jobs actually did.
+  #
+  # LAYERING, STATED HONESTLY: the concurrency change at the top of this file
+  # is the primary remedy, because a run cancelled mid-flight takes this job
+  # with it and no notifier can report from inside a cancelled run. This
+  # verdict is the second layer, for the cancellations concurrency cannot
+  # prevent — a manual cancel, a runner eviction, a `skipped` job.
+  #
+  # `needs` lists every hard-gating job. `search-daemon-smoke` is now included:
+  # it was excluded only because `continue-on-error: true` meant its result
+  # never surfaced as `failure`, and that flag is gone.
   # --------------------------------------------------------------------------
   notify-main-failure:
     name: Notify on red main
     if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main'
-    needs: [fmt, clippy, test, msrv, agents-ui, embedder-cuda-check, ui-checks]
+    needs:
+      [
+        fmt,
+        clippy,
+        test,
+        msrv,
+        agents-ui,
+        embedder-cuda-check,
+        ui-checks,
+        search-daemon-smoke,
+      ]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     permissions:
       issues: write
     steps:
-      - name: File or update tracking issue on failure
-        if: contains(needs.*.result, 'failure')
+      - uses: actions/checkout@v5
+
+      - name: Classify job conclusions
+        id: verdict
+        env:
+          CI_JOB_RESULTS: >-
+            fmt=${{ needs.fmt.result }}
+            clippy=${{ needs.clippy.result }}
+            test=${{ needs.test.result }}
+            msrv=${{ needs.msrv.result }}
+            agents-ui=${{ needs['agents-ui'].result }}
+            embedder-cuda-check=${{ needs['embedder-cuda-check'].result }}
+            ui-checks=${{ needs['ui-checks'].result }}
+            search-daemon-smoke=${{ needs['search-daemon-smoke'].result }}
+        run: bash scripts/classify-ci-results.sh > /dev/null
+
+      - name: File or update tracking issue
+        if: steps.verdict.outputs.verdict != 'green'
         uses: actions/github-script@v7
+        env:
+          CI_VERDICT: ${{ steps.verdict.outputs.verdict }}
+          CI_SUMMARY: ${{ steps.verdict.outputs.summary }}
         with:
           script: |
             const label = 'ci-red-main';
             const title = 'CI red on main';
+            const verdict = process.env.CI_VERDICT;
             const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const headline = verdict === 'red'
+              ? `CI FAILED on a push to \`main\` at ${context.sha}.`
+              : `CI did NOT conclude successfully on a push to \`main\` at ${context.sha} (verdict: ${verdict}).`;
             const body = [
-              `CI failed on a push to \`main\` at ${context.sha}.`,
+              headline,
+              '',
+              `Job conclusions: ${process.env.CI_SUMMARY}`,
               '',
               `Run: ${runUrl}`,
               '',
-              'Anyone branching off `main` right now inherits this breakage.',
+              verdict === 'red'
+                ? 'Anyone branching off `main` right now inherits this breakage.'
+                : 'This commit has NO verification result. Cancelled and skipped jobs prove nothing; re-run this workflow before treating `main` as green.',
             ].join('\n');
 
             const existing = await github.rest.issues.listForRepo({
@@ -1249,3 +1453,12 @@ jobs:
               });
               core.notice(`Filed new tracking issue #${created.data.number}`);
             }
+
+      # The run's own conclusion must match what the jobs actually did. Without
+      # this, a run whose jobs were all cancelled still ends green and `gh run
+      # view` reports a verified commit that was never verified (#4179).
+      - name: Fail the run when main was not verified green
+        if: steps.verdict.outputs.verdict != 'green'
+        run: |
+          echo "::error::main CI verdict is '${{ steps.verdict.outputs.verdict }}', not green — ${{ steps.verdict.outputs.summary }}"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,11 +91,15 @@ on:
     # then never re-triggered when it is retargeted to main. PR #3838 merged
     # with `statusCheckRollup: []` — zero check runs, ever — exactly this way.
     #
-    # `edited` also fires on title/body edits, so a PR description edit costs a
-    # duplicate run. That is the deliberate trade: a wasted run is recoverable,
-    # a zero-check merge is not, and PR runs are still superseded by the
-    # concurrency group below. `ready_for_review` (also non-default) covers a
-    # draft being marked ready.
+    # `edited` also fires on title/body edits. Left alone that is worse than a
+    # duplicate run: the PR concurrency group is the same for `edited` and
+    # `synchronize`, so an edit mid-flight would CANCEL the running checks and
+    # restart from zero — up to ~16 min of `Test` discarded, and under repeated
+    # description edits (routine here, agents rewrite PR bodies) the checks
+    # could be kept from ever settling. The `cancel-in-progress` expression
+    # below excludes `edited` for exactly that reason, so an edit-triggered run
+    # QUEUES behind the in-flight one instead of killing it. `ready_for_review`
+    # (also non-default) covers a draft being marked ready.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
@@ -110,9 +114,14 @@ on:
 # (32%) concluded `cancelled`. A cancelled run is the only signal that commit
 # will ever get — the commit is already on main, so there is nothing to
 # supersede and nothing to save by cancelling.
+#
+# `edited` is excluded from cancel-in-progress: a title/body edit shares the PR
+# group with the real run, so cancelling on it would discard up to ~16 min of
+# in-flight `Test`. Excluded, the edit-triggered run queues behind the running
+# one instead. Same total minutes, but no completed work is thrown away.
 concurrency:
   group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 # SKIP_UI_BUILD=1 prevents the four build.rs Svelte pipelines from invoking pnpm.
 env:
@@ -186,6 +195,13 @@ jobs:
   fmt:
     name: Format check
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -220,6 +236,13 @@ jobs:
   clippy:
     name: Clippy
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -321,6 +344,13 @@ jobs:
   test:
     name: Test
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -808,6 +838,13 @@ jobs:
   msrv:
     name: MSRV check (1.91)
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -890,6 +927,13 @@ jobs:
   agents-ui:
     name: trusty-agents-ui clippy
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -986,6 +1030,13 @@ jobs:
   embedder-cuda-check:
     name: embedder-cuda compile check (#3508)
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -1087,6 +1138,13 @@ jobs:
   ui-checks:
     name: UI checks (${{ matrix.name }})
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     strategy:
@@ -1187,6 +1245,13 @@ jobs:
   search-daemon-smoke:
     name: trusty-search daemon smoke test
     needs: [changes]
+    # #4179: `needs:` alone would make this job SKIP when `changes` fails, and
+    # GitHub reports a skipped required check as PASSING — reintroducing the
+    # fail-open hole this PR exists to close. `!cancelled()` overrides the
+    # implicit success() so the job still runs; `docs_only` then resolves to
+    # '' and every gated step runs, i.e. a broken classifier costs a FULL
+    # build, never a silent skip.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ on:
     # description edits (routine here, agents rewrite PR bodies) the checks
     # could be kept from ever settling. The `cancel-in-progress` expression
     # below excludes `edited` for exactly that reason, so an edit-triggered run
-    # QUEUES behind the in-flight one instead of killing it. `ready_for_review`
+    # leaves the in-flight one alone instead of killing it. `ready_for_review`
     # (also non-default) covers a draft being marked ready.
     types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
@@ -117,8 +117,10 @@ on:
 #
 # `edited` is excluded from cancel-in-progress: a title/body edit shares the PR
 # group with the real run, so cancelling on it would discard up to ~16 min of
-# in-flight `Test`. Excluded, the edit-triggered run queues behind the running
-# one instead. Same total minutes, but no completed work is thrown away.
+# in-flight `Test`. Excluded, the edit-triggered run leaves the running one
+# alone and it still reaches a conclusion. Costs an extra run per description
+# edit; throws away no completed work. Observed on this PR: two body edits
+# produced two extra runs and the in-flight run completed `success` regardless.
 concurrency:
   group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}

--- a/.github/workflows/claude-md-guard.yml
+++ b/.github/workflows/claude-md-guard.yml
@@ -14,12 +14,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches line-cap.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: claude-md-guard-${{ github.ref }}
-  cancel-in-progress: true
+  group: claude-md-guard-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   claude-md-guard:

--- a/.github/workflows/claude-md-guard.yml
+++ b/.github/workflows/claude-md-guard.yml
@@ -27,7 +27,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: claude-md-guard-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   claude-md-guard:

--- a/.github/workflows/doc-numbers.yml
+++ b/.github/workflows/doc-numbers.yml
@@ -20,13 +20,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches
-# line-cap.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: doc-numbers-${{ github.ref }}
-  cancel-in-progress: true
+  group: doc-numbers-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   doc-numbers:

--- a/.github/workflows/doc-numbers.yml
+++ b/.github/workflows/doc-numbers.yml
@@ -33,7 +33,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: doc-numbers-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   doc-numbers:

--- a/.github/workflows/generation-artifact-lint.yml
+++ b/.github/workflows/generation-artifact-lint.yml
@@ -25,12 +25,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches line-cap.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: generation-artifact-lint-${{ github.ref }}
-  cancel-in-progress: true
+  group: generation-artifact-lint-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   generation-artifact-lint:

--- a/.github/workflows/generation-artifact-lint.yml
+++ b/.github/workflows/generation-artifact-lint.yml
@@ -38,7 +38,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: generation-artifact-lint-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   generation-artifact-lint:

--- a/.github/workflows/instruction-floor-guard.yml
+++ b/.github/workflows/instruction-floor-guard.yml
@@ -34,7 +34,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: instruction-floor-guard-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   instruction-floor-guard:

--- a/.github/workflows/instruction-floor-guard.yml
+++ b/.github/workflows/instruction-floor-guard.yml
@@ -21,12 +21,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches line-cap.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: instruction-floor-guard-${{ github.ref }}
-  cancel-in-progress: true
+  group: instruction-floor-guard-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   instruction-floor-guard:

--- a/.github/workflows/line-cap.yml
+++ b/.github/workflows/line-cap.yml
@@ -16,12 +16,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches ci.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: line-cap-${{ github.ref }}
-  cancel-in-progress: true
+  group: line-cap-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   line-cap:

--- a/.github/workflows/line-cap.yml
+++ b/.github/workflows/line-cap.yml
@@ -29,7 +29,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: line-cap-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   line-cap:

--- a/.github/workflows/sld-lint.yml
+++ b/.github/workflows/sld-lint.yml
@@ -12,12 +12,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches ci.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: sld-lint-${{ github.ref }}
-  cancel-in-progress: true
+  group: sld-lint-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   sld-lint:

--- a/.github/workflows/sld-lint.yml
+++ b/.github/workflows/sld-lint.yml
@@ -25,7 +25,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: sld-lint-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   sld-lint:

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -28,7 +28,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: test-pointers-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   test-pointers:

--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -15,13 +15,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches
-# line-cap.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: test-pointers-${{ github.ref }}
-  cancel-in-progress: true
+  group: test-pointers-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   test-pointers:

--- a/.github/workflows/token-drift.yml
+++ b/.github/workflows/token-drift.yml
@@ -41,7 +41,7 @@ on:
 # still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: token-drift-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   token-drift:

--- a/.github/workflows/token-drift.yml
+++ b/.github/workflows/token-drift.yml
@@ -28,13 +28,20 @@ on:
   push:
     branches: [main]
   pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
     branches: [main]
 
-# Cancel superseded runs for the same ref to save CI minutes (matches
-# line-cap.yml).
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179); per-ref group on pull_request so a new push
+# still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: token-drift-${{ github.ref }}
-  cancel-in-progress: true
+  group: token-drift-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   token-drift:

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -1,4 +1,5 @@
-# Version-parity drift gate for the trusty-tools workspace (issue #3366).
+# Version-parity drift gates for the trusty-tools workspace (issues #3366,
+# #4421).
 #
 # Detects "unpublished source drift under an already-published version
 # number": a crate whose Cargo.toml version is already live on crates.io, but
@@ -7,28 +8,76 @@
 # --dry-run` into a release blocker (6 "symbol not found" errors) when
 # trusty-common and trusty-agents-common each drifted this way.
 #
-# Runs on PUSH TO MAIN ONLY (no pull_request trigger), per the issue's own
-# proposed design: this check compares against the LIVE crates.io registry,
-# so its result is only meaningful for what actually landed on main — a
-# feature branch's crate versions haven't been decided yet, and running a
-# registry-dependent check on every PR (including ones from parallel agent
-# worktrees) would be noisy without being actionable. Catching drift right
-# after it merges (a red commit status on main) is the goal: a merge-time
-# finding instead of a release-time surprise.
+# TWO jobs, deliberately different in what they compare and when.
+#
+# 1. `pr-version-bump` (PULL REQUEST) — the merge-time guard #3366 proposed
+#    and never got, which is why the defect kept recurring: TWICE on
+#    2026-07-30 alone (trusty-installer 0.4.10 at 6078b21c, nine consecutive
+#    red runs; trusty-agents-common 0.3.0 at e8f30ef0, hours after the first
+#    fix landed). It asks the one question that is decidable from the PR
+#    itself — did this branch change `crates/<X>/src/**` without bumping
+#    `crates/<X>/Cargo.toml`, under a version crates.io already has? — with
+#    one sparse-index GET per touched crate and no tarball downloads. See
+#    scripts/check-pr-version-bump.sh's header for why this option was chosen
+#    over running the full parity check on PRs.
+#
+# 2. `version-parity` (PUSH TO MAIN) — unchanged, and still the authority. It
+#    diffs the real published tarball against the real merged tree and fails
+#    CLOSED, including when the registry is unreachable. The PR-time guard is
+#    an early warning, not a replacement: it warns rather than fails on a
+#    registry outage precisely because this job is still behind it.
 name: Version parity
 
 on:
   push:
     branches: [main]
+  pull_request:
+    # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
+    # (opened/synchronize/reopened) and is the event a base-branch RETARGET
+    # fires, so without it a stacked PR retargeted onto main never re-triggers
+    # and can merge with zero checks — PR #3838 did exactly that.
+    # `ready_for_review` covers a draft being marked ready. Matches ci.yml.
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
   workflow_dispatch: {}
 
+# Per-COMMIT concurrency group on push so a merge never cancels the previous
+# merge's verification (#4179) — this workflow was hit particularly hard by the
+# old `${{ github.ref }}` group, since it is push-to-main only and therefore
+# only ever saw the LAST commit of a merge train. Per-ref group on pull_request
+# so a new push still supersedes the superseded run. Matches ci.yml.
 concurrency:
-  group: version-parity-${{ github.ref }}
-  cancel-in-progress: true
+  group: version-parity-${{ github.event_name == 'push' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
+  # Pre-merge guard (#4421). Pure shell + one HTTP GET per touched crate: no
+  # Rust toolchain, no cargo build, so it adds seconds to a PR rather than the
+  # minutes the post-merge job costs.
+  pr-version-bump:
+    name: "PR version bump vs crates.io (issue #4421)"
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # fetch-depth: 0 — the guard needs `git merge-base` against the base
+      # branch and `git show <merge-base>:crates/<X>/Cargo.toml`, neither of
+      # which a shallow checkout can resolve.
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Check PR version bumps against crates.io
+        env:
+          PR_VERSION_BUMP_BASE: ${{ github.event.pull_request.base.sha }}
+        run: bash scripts/check-pr-version-bump.sh
+
+  # Post-merge authority (#3366). Quoted `name:` — an unquoted ` #` opens a
+  # YAML comment in a plain scalar, which silently truncated this job's
+  # reported context to "Publish-version parity (issue".
   version-parity:
-    name: Publish-version parity (issue #3366)
+    name: "Publish-version parity (issue #3366)"
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -67,6 +67,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Scan-floor mutation self-test (issue #4618): re-proves in CI that this
+      # gate REFUSES a vacuous scan. Without it the floor is untested code and a
+      # later refactor can silently restore the "0 examined, still green" pass.
+      # Runs before the real gate — a gate that cannot fail makes the real run's
+      # green meaningless. Mirrors line-cap.yml's selftest-then-gate ordering.
+      - name: Scan-floor selftest (must refuse an empty scan)
+        run: bash scripts/check_scan_floor_selftest.sh pr_version_bump
+
       - name: Check PR version bumps against crates.io
         env:
           PR_VERSION_BUMP_BASE: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -48,7 +48,7 @@ on:
 # so a new push still supersedes the superseded run. Matches ci.yml.
 concurrency:
   group: version-parity-${{ github.event_name == 'push' && github.sha || github.ref }}
-  cancel-in-progress: ${{ github.event_name != 'push' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
 
 jobs:
   # Pre-merge guard (#4421). Pure shell + one HTTP GET per touched crate: no

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+#
+# check-ci-helpers-selftest.sh — regression fixtures for the CI helper scripts
+# (issues #4179, #4468, #4421).
+#
+# Why: the three helpers this covers each encode a decision that is invisible
+#   until it is WRONG in production — a cancelled run reported as green, a
+#   compiled-in asset classified as documentation and skipped, a drifted crate
+#   waved through. None of that shows up in a diff review, and none of it is
+#   reachable by `cargo test`. Same rationale as
+#   scripts/check_line_cap_selftest.sh, which exists because a silent counting
+#   bug in the SLOC gate is worse than no gate.
+#
+# What: asserts the exact mapping each helper produces:
+#   classify-ci-results: every conclusion value, alone and in precedence pairs
+#   detect-docs-only:    docs-only / code-only / mixed / embedded-asset / empty
+#   check-pr-version-bump: registry-decision branches, via the stub oracle
+#
+# Usage: bash scripts/check-ci-helpers-selftest.sh
+# Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+FAILURES=0
+CASES=0
+
+fail() {
+  FAILURES=$((FAILURES + 1))
+  echo "  FAIL: $*"
+}
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  CASES=$((CASES + 1))
+  if [ "$2" = "$3" ]; then
+    printf '  ok   %-58s -> %s\n' "$1" "$3"
+  else
+    fail "$1: expected '$2', got '$3'"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# classify-ci-results.sh
+# ---------------------------------------------------------------------------
+verdict_of() {
+  CI_JOB_RESULTS="$1" bash scripts/classify-ci-results.sh 2>/dev/null |
+    sed -n 's/^verdict=//p'
+}
+
+echo "classify-ci-results:"
+assert_eq "success"                       "green"        "$(verdict_of 'test=success')"
+assert_eq "failure"                       "red"          "$(verdict_of 'test=failure')"
+assert_eq "cancelled"                     "inconclusive" "$(verdict_of 'test=cancelled')"
+assert_eq "skipped"                       "inconclusive" "$(verdict_of 'test=skipped')"
+assert_eq "timed_out"                     "red"          "$(verdict_of 'test=timed_out')"
+assert_eq "unknown value"                 "inconclusive" "$(verdict_of 'test=neutral')"
+assert_eq "empty input (fail closed)"     "inconclusive" "$(verdict_of '')"
+assert_eq "all success"                   "green"        "$(verdict_of 'a=success b=success c=success')"
+assert_eq "success + cancelled"           "inconclusive" "$(verdict_of 'a=success b=cancelled')"
+assert_eq "success + skipped"             "inconclusive" "$(verdict_of 'a=success b=skipped')"
+assert_eq "failure outranks cancelled"    "red"          "$(verdict_of 'a=cancelled b=failure')"
+assert_eq "failure outranks skipped"      "red"          "$(verdict_of 'a=skipped b=failure')"
+assert_eq "the #4179 live run shape"      "inconclusive" \
+  "$(verdict_of 'fmt=success clippy=cancelled test=cancelled msrv=cancelled smoke=cancelled')"
+
+# ---------------------------------------------------------------------------
+# detect-docs-only.sh
+# ---------------------------------------------------------------------------
+docs_only_of() {
+  printf '%s' "$1" | bash scripts/detect-docs-only.sh 2>/dev/null |
+    sed -n 's/^docs_only=//p'
+}
+
+echo
+echo "detect-docs-only:"
+assert_eq "docs/ tree"            "true"  "$(docs_only_of 'docs/specs/foo.md')"
+assert_eq "docs/ nested asset"    "true"  "$(docs_only_of 'docs/a/b/c/diagram.svg')"
+assert_eq "root markdown"         "true"  "$(docs_only_of 'README.md')"
+assert_eq "root CHANGELOG"        "true"  "$(docs_only_of 'CHANGELOG.md')"
+assert_eq "LICENSE"               "true"  "$(docs_only_of 'LICENSE')"
+assert_eq "crate README"          "true"  "$(docs_only_of 'crates/trusty-mpm/README.md')"
+assert_eq "crate CHANGELOG"       "true"  "$(docs_only_of 'crates/trusty-mpm/CHANGELOG.md')"
+assert_eq "changelog fragment"    "true"  "$(docs_only_of 'crates/trusty-mpm/changelog.d/4468-x.md')"
+assert_eq "issue template"        "true"  "$(docs_only_of '.github/ISSUE_TEMPLATE/bug.md')"
+assert_eq "PR template"           "true"  "$(docs_only_of '.github/PULL_REQUEST_TEMPLATE.md')"
+assert_eq "docs-only multi-file"  "true"  "$(docs_only_of 'docs/a.md
+README.md
+crates/trusty-mpm/changelog.d/1-x.md')"
+
+assert_eq "rust source"           "false" "$(docs_only_of 'crates/trusty-mpm/src/lib.rs')"
+assert_eq "Cargo.toml"            "false" "$(docs_only_of 'Cargo.toml')"
+assert_eq "Cargo.lock"            "false" "$(docs_only_of 'Cargo.lock')"
+assert_eq "workflow file"         "false" "$(docs_only_of '.github/workflows/ci.yml')"
+assert_eq "script"                "false" "$(docs_only_of 'scripts/check_line_cap.sh')"
+assert_eq "UI source"             "false" "$(docs_only_of 'crates/trusty-agents/ui/src/App.svelte')"
+# The trap this denylist exists to avoid: markdown UNDER a crate's src/ is a
+# bundled agent/skill/instruction asset compiled in via include_dir!.
+assert_eq "embedded .md asset"    "false" "$(docs_only_of 'crates/trusty-code/src/assets/agents/ops.md')"
+assert_eq "nested fragment"       "false" "$(docs_only_of 'crates/x/changelog.d/sub/1.md')"
+assert_eq "mixed docs + code"     "false" "$(docs_only_of 'docs/a.md
+crates/trusty-mpm/src/lib.rs')"
+assert_eq "empty (fail closed)"   "false" "$(docs_only_of '')"
+
+# ---------------------------------------------------------------------------
+# check-pr-version-bump.sh — decision branches with the registry stubbed.
+# ---------------------------------------------------------------------------
+echo
+echo "check-pr-version-bump:"
+
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "${STUB_DIR}"' EXIT
+
+# Oracle: "pinned-crate 1.0.0" is published; everything else is not.
+cat >"${STUB_DIR}/published.sh" <<'STUB'
+#!/usr/bin/env bash
+[ "$1" = "pinned-crate" ] && [ "$2" = "1.0.0" ] && exit 0
+exit 1
+STUB
+cat >"${STUB_DIR}/notpublished.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 1
+STUB
+cat >"${STUB_DIR}/unreachable.sh" <<'STUB'
+#!/usr/bin/env bash
+exit 2
+STUB
+chmod +x "${STUB_DIR}/published.sh" "${STUB_DIR}/notpublished.sh" \
+  "${STUB_DIR}/unreachable.sh"
+
+# Build a throwaway repo so the gate sees a real merge base and a real diff.
+make_fixture_repo() {
+  local dir="$1" version_at_head="$2" publish_line="$3"
+  rm -rf "${dir}"
+  mkdir -p "${dir}/crates/pinned-crate/src"
+  git -C "${dir}" init -q
+  git -C "${dir}" config user.email ci@example.com
+  git -C "${dir}" config user.name ci
+  cat >"${dir}/crates/pinned-crate/Cargo.toml" <<EOF
+[package]
+name = "pinned-crate"
+version = "1.0.0"
+${publish_line}
+EOF
+  echo "// base" >"${dir}/crates/pinned-crate/src/lib.rs"
+  git -C "${dir}" add -A
+  git -C "${dir}" commit -qm base
+  git -C "${dir}" branch -q base-ref
+
+  echo "// drifted" >>"${dir}/crates/pinned-crate/src/lib.rs"
+  sed -i.bak "s/^version = .*/version = \"${version_at_head}\"/" \
+    "${dir}/crates/pinned-crate/Cargo.toml"
+  rm -f "${dir}/crates/pinned-crate/Cargo.toml.bak"
+  git -C "${dir}" add -A
+  git -C "${dir}" commit -qm head
+}
+
+run_gate() {
+  local dir="$1" stub="$2"
+  mkdir -p "${dir}/scripts"
+  cp scripts/check-pr-version-bump.sh "${dir}/scripts/check-pr-version-bump.sh"
+  (
+    cd "${dir}" &&
+      PR_VERSION_BUMP_BASE=base-ref \
+        PR_VERSION_BUMP_REGISTRY_STUB="${stub}" \
+        bash scripts/check-pr-version-bump.sh >/dev/null 2>&1
+    echo "$?"
+  )
+}
+
+make_fixture_repo "${STUB_DIR}/drift" "1.0.0" ""
+assert_eq "src changed, version published, no bump -> fail" "1" \
+  "$(run_gate "${STUB_DIR}/drift" "${STUB_DIR}/published.sh")"
+
+make_fixture_repo "${STUB_DIR}/bumped" "1.0.1" ""
+assert_eq "src changed, version bumped -> pass" "0" \
+  "$(run_gate "${STUB_DIR}/bumped" "${STUB_DIR}/published.sh")"
+
+make_fixture_repo "${STUB_DIR}/unpub" "1.0.0" ""
+assert_eq "src changed, version not published -> pass" "0" \
+  "$(run_gate "${STUB_DIR}/unpub" "${STUB_DIR}/notpublished.sh")"
+
+make_fixture_repo "${STUB_DIR}/private" "1.0.0" "publish = false"
+assert_eq "publish = false -> skipped, pass" "0" \
+  "$(run_gate "${STUB_DIR}/private" "${STUB_DIR}/published.sh")"
+
+make_fixture_repo "${STUB_DIR}/offline" "1.0.0" ""
+assert_eq "registry unreachable -> warn, pass" "0" \
+  "$(run_gate "${STUB_DIR}/offline" "${STUB_DIR}/unreachable.sh")"
+
+echo
+if [ "${FAILURES}" -gt 0 ]; then
+  echo "check-ci-helpers-selftest: ${FAILURES}/${CASES} case(s) FAILED"
+  exit 1
+fi
+echo "check-ci-helpers-selftest: all ${CASES} cases passed"

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -63,6 +63,13 @@ assert_eq "success + cancelled"           "inconclusive" "$(verdict_of 'a=succes
 assert_eq "success + skipped"             "inconclusive" "$(verdict_of 'a=success b=skipped')"
 assert_eq "failure outranks cancelled"    "red"          "$(verdict_of 'a=cancelled b=failure')"
 assert_eq "failure outranks skipped"      "red"          "$(verdict_of 'a=skipped b=failure')"
+# Both cases above put `failure` LAST, so they pass even without the
+# red-precedence guard in classify-ci-results.sh. These assert the other
+# direction: once red, nothing downgrades it. Order-independence is the actual
+# contract, and only these cases hold the guard in place.
+assert_eq "cancelled cannot downgrade red" "red"         "$(verdict_of 'a=failure b=cancelled')"
+assert_eq "skipped cannot downgrade red"   "red"         "$(verdict_of 'a=failure b=skipped')"
+assert_eq "success+cancelled after red"    "red"         "$(verdict_of 'a=failure b=success c=cancelled')"
 assert_eq "the #4179 live run shape"      "inconclusive" \
   "$(verdict_of 'fmt=success clippy=cancelled test=cancelled msrv=cancelled smoke=cancelled')"
 

--- a/scripts/check-pr-version-bump.sh
+++ b/scripts/check-pr-version-bump.sh
@@ -48,7 +48,9 @@
 #   PR_VERSION_BUMP_BASE=<ref> bash scripts/check-pr-version-bump.sh
 #
 # Exit: 0 when every touched crate is clear (or only warnings were raised);
-#   1 when at least one crate changed source under an already-published version.
+#   1 when at least one crate changed source under an already-published version,
+#   or when the diff resolved to zero paths at all (the #4618 scan floor — see
+#   the inline note in `main`).
 #
 # Test: scripts/check-ci-helpers-selftest.sh (`check-pr-version-bump:` cases)
 #   exercises the crate-extraction and version-decision logic against synthetic
@@ -123,8 +125,30 @@ main() {
   fi
   echo "Merge base: ${merge_base}"
 
-  local changed touched
+  local changed changed_count touched
   changed="$(git diff --name-only --no-renames "${merge_base}" HEAD)"
+
+  # #4618 scan floor. Two very different situations both leave `touched` empty,
+  # and only ONE of them is a pass:
+  #   - the diff RESOLVED and simply contains no crate source (a docs-only or
+  #     CI-only PR) — nothing can drift, so passing is correct;
+  #   - the diff resolved to NOTHING AT ALL, which no real PR does. That means
+  #     something upstream broke — a wrong base ref, a shallow clone with no
+  #     merge base, a detached HEAD — and the gate would report OK having
+  #     examined zero paths.
+  # Asserting a non-zero overall path count before the legitimate-empty branch
+  # below separates them, so an unresolvable base fails loudly instead of
+  # reading as a clean bill of health. Same floor and wording as
+  # scripts/check_changelog_fragment.sh, which faces the identical hazard.
+  changed_count="$(printf '%s' "${changed}" | grep -c . || true)"
+  if [ "${changed_count:-0}" -eq 0 ]; then
+    echo "FAIL: SCAN FLOOR — the diff ${merge_base}..HEAD lists 0 changed path(s)." >&2
+    echo "      Nothing was examined, so this gate could not have failed. Check that" >&2
+    echo "      '${BASE}' is the right base and that CI checked out with fetch-depth: 0." >&2
+    echo "      A gate that scans nothing is not a passing gate (issue #4618)." >&2
+    return 1
+  fi
+
   touched="$(
     grep -E '^crates/[^/]+/src/' <<<"${changed}" |
       cut -d/ -f2 |
@@ -132,7 +156,7 @@ main() {
   )" || true
 
   if [ -z "${touched}" ]; then
-    echo "[ OK ] no crates/<crate>/src/** paths changed — nothing to check"
+    echo "[ OK ] ${changed_count} changed path(s) examined; none under crates/<crate>/src/**"
     return 0
   fi
 

--- a/scripts/check-pr-version-bump.sh
+++ b/scripts/check-pr-version-bump.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+#
+# check-pr-version-bump.sh — pre-merge half of the version-parity gate
+# (issue #4421; original defect class #3366).
+#
+# Why: `scripts/check-version-parity.sh` runs on PUSH TO MAIN ONLY, so drift is
+#   only ever caught AFTER it lands. A crate sails through review fully green
+#   and main goes red minutes later. It recurred TWICE on 2026-07-30 alone
+#   (`trusty-installer 0.4.10` at 6078b21c, nine consecutive red runs;
+#   `trusty-agents-common 0.3.0` at e8f30ef0, hours after the first fix). #3366
+#   proposed a merge-time guard and was closed without one being written, which
+#   is why the hole kept producing incidents.
+#
+#   #4421 offered three options. This implements the SECOND — the lighter
+#   PR-time check — and the post-merge tarball diff stays exactly as it is:
+#
+#     1. Run the full parity check on PRs. Rejected: it downloads and diffs the
+#        published tarball for every publishable crate against the PR's tree,
+#        so a PR that touches nothing publishable still pays the whole cost,
+#        and it fails CLOSED on registry trouble — one crates.io hiccup would
+#        block every open PR. It also mis-fires on a merge train, where crate
+#        N's parity depends on crate N-1 having landed.
+#     2. (chosen) Fail when a PR changes `crates/<X>/src/**` without bumping
+#        `crates/<X>/Cargo.toml`'s version AND that version is already live on
+#        crates.io. This is exactly the shape of both 07-30 recurrences,
+#        needs one sparse-index GET per touched crate (no tarballs), is
+#        deterministic from the diff, and answers a question that is TRUE of
+#        the PR itself rather than of a moving main.
+#     3. Keep it post-merge but louder. Rejected as the primary remedy: main
+#        still goes red, which is the cost #4421 is about. (The louder half
+#        landed anyway — see ci.yml's notify job, #4179.)
+#
+# What: for every crate whose `crates/<X>/src/**` changed between the merge
+#   base and HEAD:
+#     - crate absent at HEAD (deleted by the PR)  -> SKIP
+#     - `publish = false`                          -> SKIP
+#     - version differs from the merge base        -> PASS (bumped)
+#     - version unchanged, not live on crates.io   -> PASS (nothing to drift from)
+#     - version unchanged, ALREADY live            -> FAIL (the #3366 defect)
+#     - crates.io unreachable                      -> WARN, does not fail
+#
+#   The unreachable case deliberately does NOT fail. This gate is a pre-merge
+#   EARLY WARNING; `scripts/check-version-parity.sh` on main remains the
+#   fail-closed authority, so a registry outage costs late detection (today's
+#   status quo) instead of blocking every PR in the repo.
+#
+# Usage:
+#   PR_VERSION_BUMP_BASE=<ref> bash scripts/check-pr-version-bump.sh
+#
+# Exit: 0 when every touched crate is clear (or only warnings were raised);
+#   1 when at least one crate changed source under an already-published version.
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`check-pr-version-bump:` cases)
+#   exercises the crate-extraction and version-decision logic against synthetic
+#   diffs with the registry lookup stubbed; the live crates.io path is covered
+#   by running this script against a real branch (see the #4421 PR body).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+BASE="${PR_VERSION_BUMP_BASE:-origin/main}"
+
+# manifest_field <file> <field> — first literal `field = "value"` in [package].
+manifest_field() {
+  sed -n '/^\[package\]/,/^\[[^p]/p' "$1" 2>/dev/null |
+    grep -m1 -E "^${2}[[:space:]]*=[[:space:]]*\"" |
+    sed -E 's/^[^"]*"([^"]*)".*/\1/'
+}
+
+# manifest_is_unpublishable <file> — true when [package] carries publish = false.
+manifest_is_unpublishable() {
+  sed -n '/^\[package\]/,/^\[[^p]/p' "$1" 2>/dev/null |
+    grep -qE '^publish[[:space:]]*=[[:space:]]*false'
+}
+
+# sparse_index_path <crate-name> — crates.io sparse-index route for a name.
+sparse_index_path() {
+  local name="$1"
+  local n=${#name}
+  case "$n" in
+    1) echo "1/${name}" ;;
+    2) echo "2/${name}" ;;
+    3) echo "3/${name:0:1}/${name}" ;;
+    *) echo "${name:0:2}/${name:2:2}/${name}" ;;
+  esac
+}
+
+# is_version_published <crate-name> <version>
+#   0 = published, 1 = not published, 2 = could not determine.
+is_version_published() {
+  local name="$1" version="$2"
+  # Allow the selftest to substitute a deterministic oracle for the network.
+  if [ -n "${PR_VERSION_BUMP_REGISTRY_STUB:-}" ]; then
+    "${PR_VERSION_BUMP_REGISTRY_STUB}" "$name" "$version"
+    return $?
+  fi
+
+  local url="https://index.crates.io/$(sparse_index_path "$name")"
+  local body status
+  body="$(curl -sS --max-time 20 --retry 2 --retry-delay 2 -w '\n%{http_code}' "$url" 2>/dev/null)" || return 2
+  status="${body##*$'\n'}"
+  body="${body%$'\n'*}"
+
+  case "$status" in
+    404) return 1 ;;
+    200) ;;
+    *) return 2 ;;
+  esac
+
+  if grep -qF "\"vers\":\"${version}\"" <<<"$body"; then
+    return 0
+  fi
+  return 1
+}
+
+main() {
+  local merge_base
+  if ! merge_base="$(git merge-base "${BASE}" HEAD 2>/dev/null)"; then
+    echo "check-pr-version-bump: cannot resolve merge-base against '${BASE}'" >&2
+    return 1
+  fi
+  echo "Merge base: ${merge_base}"
+
+  local changed touched
+  changed="$(git diff --name-only --no-renames "${merge_base}" HEAD)"
+  touched="$(
+    grep -E '^crates/[^/]+/src/' <<<"${changed}" |
+      cut -d/ -f2 |
+      sort -u
+  )" || true
+
+  if [ -z "${touched}" ]; then
+    echo "[ OK ] no crates/<crate>/src/** paths changed — nothing to check"
+    return 0
+  fi
+
+  local failures=0 warnings=0 crate manifest name version base_version
+  while IFS= read -r crate; do
+    [ -n "${crate}" ] || continue
+    manifest="crates/${crate}/Cargo.toml"
+
+    if [ ! -f "${manifest}" ]; then
+      echo "[SKIP] ${crate} — crate removed by this PR"
+      continue
+    fi
+    if manifest_is_unpublishable "${manifest}"; then
+      echo "[SKIP] ${crate} — publish = false"
+      continue
+    fi
+
+    name="$(manifest_field "${manifest}" name)"
+    version="$(manifest_field "${manifest}" version)"
+    if [ -z "${name}" ] || [ -z "${version}" ]; then
+      echo "[WARN] ${crate} — could not read name/version from ${manifest}"
+      warnings=$((warnings + 1))
+      continue
+    fi
+
+    base_version="$(
+      git show "${merge_base}:${manifest}" 2>/dev/null |
+        sed -n '/^\[package\]/,/^\[[^p]/p' |
+        grep -m1 -E '^version[[:space:]]*=[[:space:]]*"' |
+        sed -E 's/^[^"]*"([^"]*)".*/\1/'
+    )" || true
+
+    if [ -z "${base_version}" ]; then
+      echo "[ OK ] ${name} — new crate on this branch, nothing published to drift from"
+      continue
+    fi
+    if [ "${version}" != "${base_version}" ]; then
+      echo "[ OK ] ${name} — version bumped ${base_version} -> ${version}"
+      continue
+    fi
+
+    set +e
+    is_version_published "${name}" "${version}"
+    local rc=$?
+    set -e
+
+    case "${rc}" in
+      1)
+        echo "[ OK ] ${name} ${version} — src changed, version not yet published"
+        ;;
+      0)
+        echo "[FAIL] ${name} ${version} — src/** changed under a version that is ALREADY"
+        echo "       published on crates.io, and Cargo.toml was not bumped. Merging this"
+        echo "       turns main's 'Version parity' workflow red (issues #4421, #3366)."
+        echo "       Fix: bump ${manifest}'s version (patch/minor/major per the change)."
+        failures=$((failures + 1))
+        ;;
+      *)
+        echo "[WARN] ${name} ${version} — crates.io lookup failed; cannot tell whether this"
+        echo "       version is published. Not failing the PR: the post-merge parity check"
+        echo "       (scripts/check-version-parity.sh) still fails closed on main."
+        warnings=$((warnings + 1))
+        ;;
+    esac
+  done <<<"${touched}"
+
+  echo
+  if [ "${failures}" -gt 0 ]; then
+    echo "check-pr-version-bump: ${failures} crate(s) would drift on merge."
+    return 1
+  fi
+  echo "check-pr-version-bump: clear (${warnings} warning(s))."
+  return 0
+}
+
+main "$@"

--- a/scripts/check_scan_floor_selftest.sh
+++ b/scripts/check_scan_floor_selftest.sh
@@ -35,7 +35,7 @@
 #   bash scripts/check_scan_floor_selftest.sh line_cap            # one by name
 #   bash scripts/check_scan_floor_selftest.sh a b                 # several
 #   (names: line_cap generation_artifacts generation_artifacts_write_modes
-#    test_pointers doc_numbers claude_md changelog_fragment
+#    test_pointers doc_numbers claude_md changelog_fragment pr_version_bump
 #    agent_assets_tool_error changelog_fragment_tool_error)
 #
 # Exit: 0 when every gate rejects its vacuous scan; 1 (naming the gate) when one
@@ -55,7 +55,7 @@ PASSED=0
 FAILED=0
 
 KNOWN="line_cap generation_artifacts generation_artifacts_write_modes \
-test_pointers doc_numbers claude_md changelog_fragment \
+test_pointers doc_numbers claude_md changelog_fragment pr_version_bump \
 agent_assets_tool_error changelog_fragment_tool_error"
 
 for requested in "$@"; do
@@ -256,6 +256,22 @@ if want changelog_fragment; then
   git -C "$f" add -A && git -C "$f" commit -qm fixture
   expect_rejects "check_changelog_fragment.sh (0 changed paths)" "$f" \
     bash scripts/check_changelog_fragment.sh --base HEAD
+fi
+
+# ===========================================================================
+# 6b. check-pr-version-bump.sh — an empty diff against the base.
+#     This gate has TWO empty-set outcomes and only one is a pass: a diff that
+#     resolved but holds no crate source is a legitimate docs-only PR, while a
+#     diff that resolved to nothing at all means the base ref never resolved.
+#     Pre-floor both printed OK, so an unresolvable base read as "no drift".
+# ===========================================================================
+if want pr_version_bump; then
+  f="$(new_fixture)"
+  install_gate "$f" check-pr-version-bump.sh
+  echo "placeholder" > "$f/README.md"
+  git -C "$f" add -A && git -C "$f" commit -qm fixture
+  expect_rejects "check-pr-version-bump.sh (0 changed paths)" "$f" \
+    env PR_VERSION_BUMP_BASE=HEAD bash scripts/check-pr-version-bump.sh
 fi
 
 # ===========================================================================

--- a/scripts/classify-ci-results.sh
+++ b/scripts/classify-ci-results.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# classify-ci-results.sh — honest verdict for a set of CI job conclusions
+# (issue #4179).
+#
+# Why: `ci.yml`'s "Notify on red main" job asked `contains(needs.*.result,
+#   'failure')`. `cancelled` is not `failure`, so a run whose every build and
+#   test job was CANCELLED skipped the alarm and the job reported success —
+#   the merge commit read verified when nothing had been verified. That is not
+#   a rare edge: 19 of 60 sampled push-to-main runs (32%) concluded
+#   `cancelled`, because every workflow used `cancel-in-progress: true` on a
+#   group keyed to `github.ref`, which on a push is `refs/heads/main` for every
+#   merge — so each merge killed the previous merge's verification. Live
+#   instance: run 30720348101 (head b4b91af9), four jobs cancelled, notifier
+#   green.
+#
+#   The concurrency change in ci.yml (per-commit group on push) stops the
+#   cancellations at the source. This script is the second layer: even when a
+#   run IS cancelled for some other reason — a manual cancel, a runner
+#   eviction — the verdict it produces refuses to call that green.
+#
+# What: reads `<job>=<conclusion>` pairs (whitespace- or newline-separated)
+#   from $CI_JOB_RESULTS or argv and folds them into ONE verdict:
+#
+#     conclusion  | class         | contributes
+#     ------------|---------------|-------------------------------------------
+#     success     | pass          | nothing
+#     failure     | red           | verdict=red
+#     timed_out   | red           | verdict=red
+#     cancelled   | inconclusive  | verdict=inconclusive (unless already red)
+#     skipped     | inconclusive  | verdict=inconclusive (unless already red)
+#     <anything>  | inconclusive  | verdict=inconclusive (unless already red)
+#
+#   Precedence is red > inconclusive > green. Only an all-`success` set is
+#   green. `timed_out` is accepted even though GitHub's `needs.<job>.result`
+#   collapses a timed-out job into `failure` and never emits it: the same
+#   mapping is then correct if it is ever fed raw check-run conclusions, where
+#   `timed_out` is a real value.
+#
+# Outputs (stdout, and appended to $GITHUB_OUTPUT when set):
+#   verdict=green|red|inconclusive
+#   summary=<one-line per-job breakdown>
+#
+# Exit: 0 always. The verdict is data for the caller; deciding whether to fail
+#   the run belongs to the workflow, not here.
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`classify-ci-results:` cases)
+#   asserts the verdict for every conclusion value above, individually and in
+#   precedence combinations.
+
+set -euo pipefail
+
+# classify_one <conclusion> — echoes `pass`, `red`, or `inconclusive`.
+classify_one() {
+  case "$1" in
+    success) echo "pass" ;;
+    failure | timed_out) echo "red" ;;
+    *) echo "inconclusive" ;;
+  esac
+}
+
+main() {
+  local raw="${CI_JOB_RESULTS:-$*}"
+
+  local verdict="green"
+  local summary=""
+  local count=0
+  local pair job conclusion class
+
+  for pair in $raw; do
+    [ -n "$pair" ] || continue
+    count=$((count + 1))
+    job="${pair%%=*}"
+    conclusion="${pair#*=}"
+    class="$(classify_one "$conclusion")"
+
+    case "$class" in
+      red) verdict="red" ;;
+      inconclusive) [ "$verdict" = "red" ] || verdict="inconclusive" ;;
+    esac
+
+    summary="${summary}${summary:+, }${job}: ${conclusion} (${class})"
+    echo "  ${job} = ${conclusion} -> ${class}" >&2
+  done
+
+  # No inputs at all means the caller could not read the job results. That is
+  # not evidence of success — fail closed, same rule as detect-docs-only.sh.
+  if [ "$count" -eq 0 ]; then
+    verdict="inconclusive"
+    summary="no job results supplied"
+    echo "classify-ci-results: no inputs — verdict=inconclusive (fail closed)" >&2
+  fi
+
+  echo "classify-ci-results: verdict=${verdict}" >&2
+  echo "verdict=${verdict}"
+  echo "summary=${summary}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "verdict=${verdict}" >>"${GITHUB_OUTPUT}"
+    echo "summary=${summary}" >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+main "$@"

--- a/scripts/detect-docs-only.sh
+++ b/scripts/detect-docs-only.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+#
+# detect-docs-only.sh — classify a change set as docs-only or not (issue #4468).
+#
+# Why: docs-only PRs ran the full Rust build — Clippy, Format, MSRV, Test, and
+#   a 15-20 min release build for the search-daemon smoke test — even though
+#   nothing in the diff can affect compilation. A `paths:`/`paths-ignore:`
+#   filter on the workflow trigger is NOT the fix: GitHub never creates the
+#   check runs for a workflow the filters skipped, so a REQUIRED context stays
+#   pending forever and the PR becomes unmergeable rather than fast. The same
+#   trap is documented in .github/workflows/changelog-fragment.yml. So the
+#   exemption lives here, in a script the always-running job consults, and the
+#   jobs keep reporting.
+#
+# What: reads a newline-separated list of changed paths on stdin (or resolves
+#   one itself from git when given a base ref) and answers ONE question: does
+#   every changed path match a pattern that provably cannot affect a cargo
+#   build, test, clippy, or rustfmt result? Emits `docs_only=true|false` on
+#   stdout, and appends the same line to $GITHUB_OUTPUT when that is set.
+#
+#   The classification is a DENYLIST-of-inert, not an allowlist-of-code: a path
+#   is inert only when it matches one of the patterns below, and anything
+#   unrecognised is treated as code. An unknown new path therefore costs a full
+#   build (correct, cheap to fix) instead of silently skipping verification
+#   (incorrect, expensive to discover). An EMPTY change set is likewise not
+#   docs-only, so a failure to resolve the diff can never turn into a skip.
+#
+#   Inert (docs-only) paths:
+#     docs/**                      project documentation tree
+#     <root>/*.md                  README/CHANGELOG/CONTRIBUTING/SECURITY/CLAUDE
+#     LICENSE, LICENSE-*
+#     .github/*.md                 e.g. PULL_REQUEST_TEMPLATE.md
+#     .github/ISSUE_TEMPLATE/**
+#     crates/*/README.md
+#     crates/*/CHANGELOG.md
+#     crates/*/changelog.d/*       per-PR changelog fragments (#4476)
+#
+#   Deliberately NOT inert, though they look like documentation:
+#     crates/*/src/**/*.md   — bundled agent/skill/instruction assets that are
+#                              compiled into binaries via include_dir!/
+#                              include_str!. Editing one changes program
+#                              output and breaks asset-pin and drift tests.
+#     scripts/**             — invoked by integration tests and by CI itself.
+#     .github/workflows/**   — a CI change must re-verify against real CI.
+#     crates/*/changelog.d/*/*  — a NESTED fragment is already a defect the
+#                              changelog gate rejects; do not also exempt it.
+#
+# Usage:
+#   git diff --name-only --no-renames "$MERGE_BASE" HEAD | scripts/detect-docs-only.sh
+#   DOCS_ONLY_BASE=origin/main scripts/detect-docs-only.sh     # resolves its own diff
+#
+# Exit: always 0 on a successful classification; non-zero only when a requested
+#   base ref cannot be resolved (fail closed — the caller must not guess).
+#
+# Test: scripts/check-ci-helpers-selftest.sh (`detect-docs-only:` cases) runs
+#   this against docs-only, code-only, mixed, embedded-asset, and empty change
+#   sets and asserts the emitted verdict for each.
+
+set -euo pipefail
+
+# is_inert_path <path> — true when the path cannot affect a cargo result.
+#
+# Matching is done on SPLIT SEGMENTS, not on glob patterns: in a bash `case`,
+# `*` happily matches `/`, so a pattern like `crates/*/changelog.d/*.md` would
+# also accept `crates/a/src/assets/changelog.d/x.md`. Segment-count checks make
+# each rule mean exactly the depth it appears to mean.
+is_inert_path() {
+  local p="$1"
+  local -a seg
+  IFS='/' read -r -a seg <<<"$p"
+  local n=${#seg[@]}
+
+  # docs/** — the project documentation tree, at any depth.
+  if [ "$n" -ge 2 ] && [ "${seg[0]}" = "docs" ]; then
+    return 0
+  fi
+
+  case "$n" in
+    1)
+      # Repo-root markdown and licence files.
+      case "${seg[0]}" in
+        LICENSE | LICENSE-*) return 0 ;;
+        *.md) return 0 ;;
+      esac
+      ;;
+    2)
+      # .github/<file>.md — e.g. PULL_REQUEST_TEMPLATE.md.
+      if [ "${seg[0]}" = ".github" ]; then
+        case "${seg[1]}" in *.md) return 0 ;; esac
+      fi
+      ;;
+    3)
+      # .github/ISSUE_TEMPLATE/<file>
+      if [ "${seg[0]}" = ".github" ] && [ "${seg[1]}" = "ISSUE_TEMPLATE" ]; then
+        return 0
+      fi
+      # crates/<crate>/README.md | crates/<crate>/CHANGELOG.md
+      if [ "${seg[0]}" = "crates" ]; then
+        case "${seg[2]}" in README.md | CHANGELOG.md) return 0 ;; esac
+      fi
+      ;;
+    4)
+      # crates/<crate>/changelog.d/<file>.md
+      if [ "${seg[0]}" = "crates" ] && [ "${seg[2]}" = "changelog.d" ]; then
+        case "${seg[3]}" in *.md) return 0 ;; esac
+      fi
+      ;;
+  esac
+
+  return 1
+}
+
+main() {
+  local input
+  if [ -n "${DOCS_ONLY_BASE:-}" ]; then
+    local merge_base
+    if ! merge_base="$(git merge-base "${DOCS_ONLY_BASE}" HEAD 2>/dev/null)"; then
+      echo "detect-docs-only: cannot resolve merge-base against '${DOCS_ONLY_BASE}'" >&2
+      return 2
+    fi
+    input="$(git diff --name-only --no-renames "${merge_base}" HEAD)"
+  else
+    input="$(cat)"
+  fi
+
+  local docs_only=true
+  local count=0
+  local path
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    count=$((count + 1))
+    if is_inert_path "$path"; then
+      echo "  inert: ${path}" >&2
+    else
+      echo "  code : ${path}" >&2
+      docs_only=false
+    fi
+  done <<<"$input"
+
+  # An empty change set is never docs-only: it means the diff could not be
+  # resolved, and a skip must never be the consequence of a lookup failure.
+  if [ "$count" -eq 0 ]; then
+    echo "detect-docs-only: empty change set — treating as code (fail closed)" >&2
+    docs_only=false
+  fi
+
+  echo "detect-docs-only: ${count} changed path(s) -> docs_only=${docs_only}" >&2
+  echo "docs_only=${docs_only}"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    echo "docs_only=${docs_only}" >>"${GITHUB_OUTPUT}"
+  fi
+}
+
+main "$@"

--- a/scripts/instruction_floor.sha256
+++ b/scripts/instruction_floor.sha256
@@ -5,7 +5,7 @@
 # A deliberate floor change is a two-part commit: the floor edit AND the
 # regenerated digests below. Regenerating these without a reviewed floor change
 # defeats the guard (issues #3374, #4183).
-92ba79819608f0516cde30e5a6e5a66c68a4000e2deaaeccb7996995efe800f7  .github/workflows/instruction-floor-guard.yml
+19a7810e48df249e27e5c281312d9e2dbef8d02057d09f7da538080c9e12dcce  .github/workflows/instruction-floor-guard.yml
 b5930fbb08e5111d0b9ce30e07751bf05074bea1c381dfbfc5a2060a922a5852  crates/trusty-mpm/src/assets/instructions/sections/enforcement.md
 25fe05ed4853590324bd5fdce8a147baf52bd959f269ccf99f9adff7c6fc98e8  crates/trusty-mpm/src/assets/instructions/sections/framework-guaranteed-conventions.md
 417c3214339855207fb43e8f8a0c1431f93aaf6e72975f740b0cf6401decb0d2  crates/trusty-mpm/src/assets/instructions/sections/identity.md

--- a/scripts/instruction_floor.sha256
+++ b/scripts/instruction_floor.sha256
@@ -5,7 +5,7 @@
 # A deliberate floor change is a two-part commit: the floor edit AND the
 # regenerated digests below. Regenerating these without a reviewed floor change
 # defeats the guard (issues #3374, #4183).
-19a7810e48df249e27e5c281312d9e2dbef8d02057d09f7da538080c9e12dcce  .github/workflows/instruction-floor-guard.yml
+ff2d0d103f1424e5a621f9ebf939ee09155899c7fe8ac628f1b65a162eadbb52  .github/workflows/instruction-floor-guard.yml
 b5930fbb08e5111d0b9ce30e07751bf05074bea1c381dfbfc5a2060a922a5852  crates/trusty-mpm/src/assets/instructions/sections/enforcement.md
 25fe05ed4853590324bd5fdce8a147baf52bd959f269ccf99f9adff7c6fc98e8  crates/trusty-mpm/src/assets/instructions/sections/framework-guaranteed-conventions.md
 417c3214339855207fb43e8f8a0c1431f93aaf6e72975f740b0cf6401decb0d2  crates/trusty-mpm/src/assets/instructions/sections/identity.md


### PR DESCRIPTION
Fixes the workflow layer of #4179 (the parts that do not need a branch-protection change), plus #4468 and #4421. Five changes, one review.

**`enforce_admins` was deliberately left OFF, per owner ruling.** No branch-protection setting was touched by this PR — not via `gh api`, not otherwise. #4179 therefore stays OPEN with its first root cause intact by design; this PR closes only the downstream holes.

---

## 1. Cancelled runs read as green (#4179)

**Root cause, two halves.** Every workflow used `cancel-in-progress: true` on a group keyed to `github.ref`. On a `push` that key is `refs/heads/main` for every merge, so each merge cancelled the previous merge's verification — 19 of 60 sampled push-to-main runs (32%) concluded `cancelled`. The notifier then asked `contains(needs.*.result, 'failure')`, and `cancelled` is not `failure`, so it reported success. Live instance: run [30720348101](https://github.com/bobmatnyc/trusty-tools/actions/runs/30720348101), head `b4b91af9` — Test, Clippy, MSRV and the smoke test all cancelled, notifier green. (Still visible today: `gh run list --branch=main` shows `b4b91af9 cancelled` sandwiched between two successes.)

### Concurrency decision — cancel PR runs, never cancel main runs

| Event | Group | `cancel-in-progress` | Why |
|---|---|---|---|
| `pull_request` | per PR ref (`github.ref`) | `true` | A new push makes the old run obsolete. This is the case the setting was added for, and it keeps working. |
| `push` to main | per **COMMIT** (`github.sha`) | `false` | The commit is already on main. There is nothing to supersede, and a cancelled run is the only signal that commit will ever get. |

Implemented as `group: ci-${{ github.event_name == 'push' && github.sha || github.ref }}` with `cancel-in-progress: ${{ github.event_name != 'push' }}`.

Keying push runs to the SHA rather than just setting `cancel-in-progress: false` on a shared group matters: a shared group would serialise a merge train behind itself. Per-SHA groups are unique, so main runs neither cancel nor queue.

Applied to all 12 workflows carrying the `${{ github.ref }}` + `cancel-in-progress: true` pattern on a `push: [main]` trigger. `cargo-audit` and `e2e-docker` (schedule/dispatch only) and `release` (tag refs, already unique) were left alone.

### Notifier decision — not-success is not success

The verdict moved out of a GitHub expression and into `scripts/classify-ci-results.sh`, so the mapping is executable and fixture-tested rather than buried where it cannot be exercised. The notify job now also **fails the run** on any non-green verdict, so the run conclusion stops disagreeing with what the jobs did. `search-daemon-smoke` joins its `needs` — it could not be there while `continue-on-error` kept its result off `failure`.

**Conclusion-mapping table** (asserted by `scripts/check-ci-helpers-selftest.sh`):

| input conclusion | class | reported verdict |
|---|---|---|
| `success` | pass | `green` |
| `failure` | red | `red` |
| `cancelled` | inconclusive | `inconclusive` |
| `skipped` | inconclusive | `inconclusive` |
| `timed_out` | red | `red` |
| anything else (e.g. `neutral`) | inconclusive | `inconclusive` |
| no inputs at all | — | `inconclusive` (fail closed) |

Precedence, also asserted:

| input set | verdict |
|---|---|
| `a=success b=success c=success` | `green` |
| `a=success b=cancelled` | `inconclusive` |
| `a=success b=skipped` | `inconclusive` |
| `a=cancelled b=failure` | `red` (failure outranks cancelled) |
| `a=skipped b=failure` | `red` |
| `fmt=success clippy=cancelled test=cancelled msrv=cancelled smoke=cancelled` — the shape of live run 30720348101 | `inconclusive` (**was: green**) |

`timed_out` is accepted even though GitHub's `needs.<job>.result` collapses a timed-out job into `failure` and never emits the literal string. The same mapping is then also correct if it is ever fed raw check-run conclusions, where `timed_out` is a real value.

**Layering, stated honestly:** the concurrency change is the primary remedy. A run cancelled mid-flight takes the notify job with it, so no notifier can report from inside a cancelled run. The verdict is the second layer, for the cancellations concurrency cannot prevent — a manual cancel, a runner eviction, a `skipped` job.

---

## 2. Stacked PRs got zero checks (#4179)

No workflow declared `types:`, so `pull_request` used GitHub's default set — `opened`, `synchronize`, `reopened`. **Retargeting a PR's base is delivered as `edited` (with `changes.base`), which is not in that set.** A PR stacked on another feature branch is filtered out by `branches: [main]` while it is stacked, and then nothing re-triggers when it is retargeted to main. PR #3838 merged with `statusCheckRollup: []` — zero check runs, ever — exactly this way.

Every `pull_request` trigger now declares:

```yaml
types: [opened, synchronize, reopened, ready_for_review, edited]
```

### Trigger matrix for a PR whose base is NOT main

| moment | event delivered | before | after |
|---|---|---|---|
| PR opened against feature branch `X` | `opened`, base=`X` | filtered by `branches: [main]` — no run | filtered by `branches: [main]` — no run |
| push to the PR head while still on `X` | `synchronize`, base=`X` | filtered — no run | filtered — no run |
| **base retargeted `X` → `main`** | **`edited`** (`changes.base`), base=`main` | **not in the default types — NOTHING fires** | **`edited` is declared → full run, base now matches `main`** |
| draft marked ready | `ready_for_review` | not in default types — no run | run |
| any later push | `synchronize`, base=`main` | run | run |

So, explicitly: for a base-branch-is-not-main PR, **no** event fires while it is stacked (correct — `branches: [main]` still applies), and then **`edited`** fires at the moment of retarget. That is the event that previously fired nothing.

**Accepted cost, corrected after review.** An earlier draft of this body said `edited` "costs a duplicate run". That understated it. `github.ref` is `refs/pull/N/merge` for both `synchronize` and `edited`, so with a shared PR concurrency group an `edited` event would have **cancelled the in-flight run and restarted from zero** — measured against this PR's own timings (`Test` 15m49s, smoke 5m58s) that is up to ~16 minutes of completed work discarded, and under repeated body edits (routine here — agents rewrite PR descriptions) the checks could be kept from ever settling.

Fixed rather than merely documented: `cancel-in-progress` now excludes `edited`.

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'edited' }}
```

An edit-triggered run now **leaves the in-flight one alone** instead of killing it, and it still reaches a conclusion. Costs one extra run per description edit; throws away no completed work. With that, the trade is clearly worth it: a redundant run versus a zero-check merge.

**Observed live on this PR.** Editing this description twice produced runs `30768284687` and `30768304988` on the same head SHA, and the already-running `30768284687` went on to complete `success` (16 min, full `cargo test`) rather than being cancelled. Under the old `cancel-in-progress: true` it would have been killed at the first edit.

The tempting alternative — a job-level `if:` skipping edit-triggered runs — stays rejected. A skipped job publishes a fresh `skipped` check run on the same SHA, overwriting a previously red result. That is signal laundering, the same class of bug this PR exists to close.

---

## 3. The smoke test contradiction (#4179)

`trusty-search daemon smoke test` was simultaneously (a) listed among branch protection's seven required contexts, (b) documented in its own header as OPTIONAL, and (c) carrying `continue-on-error: true`.

**Decision: it is REQUIRED, and it must be able to fail. `continue-on-error: true` is removed.**

- The "required" half is the one enforced by branch protection, and this PR may not change branch protection. Making it optional was not an available option, only a wish.
- The flag was never providing the protection its header claimed. Per the repo owner's own correction on #4179 (settled empirically against `release.yml`'s `best_effort` legs), job-level `continue-on-error` still publishes `conclusion: failure` to the **check run** — so it already gated the merge button. All it added was **signal inversion**: the Actions UI, `gh run view`, and `needs.<job>.result` all read healthy while a required check was red.
- It costs nothing in wall clock. The ~15–20 min cold release build ran either way; only the reporting changes.
- It buys a place in `notify-main-failure`'s `needs`, which was impossible while the job's result never surfaced as `failure`.

If the runner timeout/kill race the old header worried about ever materialises, the answer is to fix the race or drop the check from branch protection — not to keep a required check unable to report the truth.

---

## 4. Docs-only PRs ran the full Rust build (#4468)

**The constraint drove the design.** Five of `ci.yml`'s checks are required (`Format check`, `Clippy`, `Test`, `MSRV check (1.91)`, `trusty-search daemon smoke test`). GitHub does not create check runs for a workflow its path filters skipped, so a bare `paths-ignore:` would leave a required context pending forever and make docs-only PRs **unmergeable** rather than fast.

A job-level `if:` was also rejected. GitHub documents a conditionally-skipped job as reporting success to branch protection, but that cannot be verified from here and the failure mode if it is wrong is *every docs PR blocked forever*. So:

**Every job still RUNS and still REPORTS. Only the expensive STEPS are gated.** This is the pattern `changelog-fragment.yml` already documents in its own header — the exemption lives in the script, not in the trigger. A docs-only PR gets a green required check in ~30 s of runner startup instead of 45 minutes of cargo, with zero reliance on skip semantics.

A new `changes` job runs `scripts/detect-docs-only.sh` and publishes one output; the heavy jobs consume it as `needs.changes.outputs.docs_only != 'true'` on each costly step.

### The `needs:` edge, closed after review

`needs: [changes]` alone reintroduced the exact bug this PR exists to close, in the worse direction. If `changes` went red, all five required contexts depending on it would become **`skipped`** — and GitHub reports a skipped required check as **passing**. Worse, `changes` is what runs the helper selftest, so the designed alarm for a helper regression would also have disarmed five gates.

Every one of the eight dependent jobs now carries:

```yaml
if: ${{ !cancelled() }}
```

This overrides the implicit `success()` on `needs`, so the job runs even when `changes` fails. `needs.changes.outputs.docs_only` then resolves to `''`, `'' != 'true'` is true, and every gated step runs — a broken or unresolvable classifier costs a **full build**, never a silent skip. Proven live rather than reasoned about; see Verification below.

### Path patterns

Classification is a **denylist of provably-inert paths**, not an allowlist of code: anything unrecognised is treated as code. An unknown new path costs a full build (correct, cheap to fix) rather than silently skipping verification. Matching is on **split segments**, not globs — in a bash `case`, `*` matches `/`, so `crates/*/changelog.d/*.md` would otherwise also accept `crates/a/src/assets/changelog.d/x.md`.

| inert (docs-only) | NOT inert |
|---|---|
| `docs/**` (any depth) | `crates/*/src/**` — **including `.md`** |
| repo-root `*.md` | `crates/*/tests/**`, `crates/*/ui/**` |
| `LICENSE`, `LICENSE-*` | `Cargo.toml`, `Cargo.lock`, any `*.toml` |
| `.github/*.md` | `.github/workflows/**` |
| `.github/ISSUE_TEMPLATE/**` | `scripts/**` |
| `crates/*/README.md`, `crates/*/CHANGELOG.md` | `crates/*/changelog.d/*/**` (nested) |
| `crates/*/changelog.d/*.md` | anything else |

`crates/*/src/**/*.md` is the trap this list exists to avoid: those are bundled agent/skill/instruction assets compiled in via `include_dir!`/`include_str!`. Editing one changes program output and breaks asset-pin and drift tests, so it is code.

### Three concrete change sets

| # | change set | `docs_only` | what RUNS | what REPORTS |
|---|---|---|---|---|
| 1 | `docs/a.md`, `README.md`, `crates/trusty-mpm/changelog.d/1-x.md` | `true` | `changes` (+ helper selftests); `fmt`'s instruction-floor-guard step; `line-cap`; `instruction-floor-guard`; `changelog-fragment`; the docs linters. **No cargo, no pnpm, no release build.** | All 7 required contexts report **success**: `Format check`, `Clippy`, `Test`, `MSRV check (1.91)`, `trusty-search daemon smoke test`, `500-line file-size cap`, `BASE_PM floor carries the guaranteed conventions` |
| 2 | `crates/trusty-mpm/src/lib.rs` | `false` | everything, unchanged | all 7 required contexts, real results |
| 3 | mixed: `docs/a.md` + `crates/trusty-mpm/src/lib.rs` | `false` | everything, unchanged | all 7 required contexts, real results |

Verified against this branch itself — 19 changed paths, all workflows + scripts → `docs_only=false`, i.e. **this PR runs the real jobs**, which is also the live proof of cases 2 and 3.

`fmt`'s instruction-floor-guard step is deliberately **not** gated: it guards instruction/markdown content, which is exactly what a docs-only PR changes. `line-cap`, `instruction-floor-guard`, `sld-lint`, `claude-md-guard`, `doc-numbers`, `test-pointers`, `generation-artifact-lint`, `token-drift`, `capabilities-drift` and `changelog-fragment` are untouched by the filter, per #4468's "decide per workflow, not globally."

**Push to main never takes the exemption** — main is what everything is cut from, so it is verified in full regardless of the diff.

---

## 5. Version-parity drift only caught after merge (#4421)

#4421 offered three options. **Option 2 — the lighter PR-time check — is implemented**, as `scripts/check-pr-version-bump.sh` in a new `pull_request` job. The post-merge tarball diff is unchanged and remains the fail-closed authority.

| option | verdict |
|---|---|
| 1. Full parity check on PRs | **Rejected.** Downloads and diffs the published tarball for every publishable crate, so a PR touching nothing publishable pays the whole cost; fails CLOSED on registry trouble, so one crates.io hiccup blocks every open PR; and mis-fires on a merge train, where crate N's parity depends on crate N−1 having landed. |
| **2. Bump-vs-published check** | **Chosen.** Exactly the shape of both 2026-07-30 recurrences. One sparse-index GET per touched crate, no tarballs, no cargo build — seconds, not minutes. Decidable from the PR's own diff rather than from a moving main. |
| 3. Keep post-merge, make it loud | **Rejected as the primary remedy** — main still goes red, which is the cost #4421 is about. The "louder" half landed anyway via the #4179 notifier work above. |

Rule, per crate whose `crates/<X>/src/**` changed:

| situation | result |
|---|---|
| crate deleted by the PR | skip |
| `publish = false` | skip |
| version bumped vs merge base | pass |
| version unchanged, not on crates.io | pass |
| **version unchanged, already live on crates.io** | **fail** |
| registry unreachable | warn, do **not** fail |

The unreachable case deliberately does not fail: the post-merge gate is still behind it, so an outage costs late detection (today's status quo) rather than blocking every PR in the repo.

**Also fixed here:** `version-parity.yml`'s job `name:` was unquoted, so ` #3366)` opened a YAML comment and the job registered as `Publish-version parity (issue`. Both job names in that file are now quoted. Not a required context, so nothing was blocked — but promoting one to required by copying the `name:` line out of the YAML would have produced a context that never reports and blocks every PR forever.

---

## Verification

### Ran, with output

- **`actionlint` 1.7.12 on all 14 changed workflow files — clean, exit 0, no output** (re-run after the rebase onto `b8e03184`). Confirmed non-vacuous by temporarily corrupting a `needs.` reference: actionlint reported `property "nosuchjob" is not defined in object type {changes: {outputs: {docs_only: string}; result: string}}`, then the file was restored and re-linted clean. (One pre-existing SC2129 style note in the untouched `e2e-docker.yml` is unrelated.)
- **`scripts/check-ci-helpers-selftest.sh` — all 42 cases passed**: 16 conclusion-mapping cases, 21 path-classification cases, 5 version-bump decision branches. Three red-precedence cases were added after review found the guard survived mutation because every existing fixture put `failure` last; the new cases were confirmed to kill that mutant (3/42 fail on the mutated script, 42/42 on the real one). Production behaviour was already correct — this was a test gap, not a live defect. Wired into the always-running `changes` job, so a regression in any of the three helpers fails CI.
- **Required-context audit** — parsed every workflow with `yaml.safe_load` and confirmed all 7 branch-protection contexts are still declared under byte-identical names.
- **`scripts/detect-docs-only.sh` on this branch** — 19 changed paths → `docs_only=false`.
- **`scripts/check-pr-version-bump.sh` against LIVE crates.io**, on a throwaway commit touching every crate's `src/`: correctly failed the 4 crates whose current version is already published (`trusty-bm25-daemon 0.1.3`, `trusty-embedderd 0.3.10`, `trusty-embedderd-py 0.1.1`, `trusty-progress 0.2.0`), skipped the 6 `publish = false` crates, and passed the rest. Cross-checked independently against the sparse index for 5 crates — agreement in all 5. The throwaway branch was deleted.
- **`scripts/check_instruction_floor.sh`** — PASS. #4623 landed on main and re-pinned the same file, so this branch was rebased onto `b8e03184` and the pin resolved as the **union**: this PR's guard-workflow hash plus all five of #4623's lines unchanged. The two edits are orthogonal (this PR touches zero files under `assets/instructions/`; #4623 never touched the guard workflow), and `diff` against main's pin now shows exactly one differing line — the guard workflow's own hash.
- **`check_line_cap_selftest`, `check_line_cap`, `check_sld`, `check_doc_numbers`, `check_changelog_fragment`** — all PASS. No changelog fragment is required: this PR changes no `crates/<crate>/src/**` path.
- **Rust quality gate**, mirroring CI's exclusions (`--exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui` — the three Tauri crates CI never compiles, since they need a built `ui/dist` and WebKit2GTK):
  - `cargo fmt --all --check` → **exit 0**
  - `cargo clippy --workspace --all-targets <exclusions> -- -D warnings` → **exit 0**
  - `cargo test --workspace <exclusions>` → **20558 passed, 6 failed, 93 ignored across 152 suites**
  - `cargo test -p trusty-common --features update-check` (CI-unset leg) → **1 passed, 0 failed**

**The 6 failures are environmental, not caused by this PR.** All 6 are macOS FSEvents watcher-timing tests in `trusty-search` (`watch_loop::tests::{cdk_out_file_is_not_indexed, modified_docx_file_triggers_indexing_via_extractor, modified_file_triggers_indexing}`, `watcher::tests::{modified_event_emitted_within_one_second, removed_event_emitted_on_delete}`, `watcher_manager::tests::save_triggers_incremental_index_via_manager`), failing with `event arrives before deadline: Elapsed(())` and `chunk_count never grew`. Evidence rather than assertion:

1. `git diff --stat origin/main...HEAD -- crates/ Cargo.toml Cargo.lock` is **empty** — every Rust source byte in this branch is identical to `origin/main`.
2. The same 6 fail on this machine with `--test-threads=1`, so it is the environment, not parallel load.
3. CI's `Test` job on `01e4bf9b` — this branch's exact merge base, same sources — concluded **success**.

Nothing was `#[ignore]`d, excluded, or otherwise silenced.

### Proven on a live throwaway PR (#4625, closed unmerged)

Two observations the earlier draft listed as unverifiable are now recorded.

**Docs-only path — the highest-blast-radius change, end to end.** With the `changes` job forced to `docs_only=true`, all five ci.yml required contexts reported green without invoking cargo:

| required context | real-code run | docs-only run |
|---|---|---|
| Format check | 14s | **8s** |
| Clippy | 4m51s | **8s** |
| Test | 15m49s | **13s** |
| MSRV check (1.91) | 2m52s | **7s** |
| trusty-search daemon smoke test | 5m58s | **9s** |

Step conclusions confirm it: in both Clippy and Test, every step after `checkout` was `skipped`. `500-line file-size cap` (17s) and `BASE_PM floor` (11s) still ran in full — correct, they are not gated.

Stated precisely: the *classification input* was forced, not observed. A genuinely docs-only PR against main cannot exercise this until these workflow changes are on main — a PR that contains them is by definition not docs-only. What is proven is the step-gating and required-check-reporting mechanism, which is where the blast radius lives. The classifier itself carries 21 fixtures plus the reviewer's independent mutation testing (5 of 6 mutants killed).

**The `needs:` fail-open edge is closed.** With the `changes` job forced to `exit 1`: `Detect docs-only change set` = **failure**, and all eight dependents **ran** rather than reporting `skipped` — Clippy 4 min with `cargo clippy` = success, Test 16 min with `cargo test --workspace` = success. Without `if: ${{ !cancelled() }}` those five required contexts would have been `skipped`, which GitHub counts as passing.

### NOT verified locally — only a live PR can prove these

Stated plainly, because they were reasoned about and not run:

1. **That `edited` actually re-triggers on a base retarget.** Sourced from GitHub's documented activity types and from #4179's own diagnosis of PR #3838. No local harness can deliver a `pull_request` webhook, and a retarget needs a stacked PR to retarget.
2. **That a real docs-only *classification* happens on a real docs-only PR.** The gating mechanism is now proven (above); what remains unobserved is `detect-docs-only.sh` returning `true` from a real diff in CI, which is impossible until these workflows are on main.
3. **That the per-SHA push concurrency group prevents cancellation in practice.** Provable only by two merges landing close together and both runs completing. Sound analytically — `ci-<sha>` is unique per commit, so each group holds exactly one run.
4. **That the notify job's `exit 1` turns a cancelled-jobs run red.** The mapping is tested and the wiring was traced end to end by review, but the GitHub-side behaviour of a `needs`-cancelled job under `if: always()` needs production conditions.
5. **That the smoke test, now without `continue-on-error`, behaves as expected on failure.** #4179's one open mutation experiment (force `exit 1` in the health assertion, then read `mergeStateStatus`) is untouched by this PR.

Closes #4468
Closes #4421

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
