### PR TITLE
feat(trusty-common): CredentialRef, Secret, and resolve-at-use-time (#4565)

### DIFF
--- a/crates/trusty-common/changelog.d/4565-credential-ref-secret-resolve-at-use-time.md
+++ b/crates/trusty-common/changelog.d/4565-credential-ref-secret-resolve-at-use-time.md
@@ -1,0 +1,63 @@
+Added
+
+- `credentials::CredentialRef` — the opaque, durable, **non-secret** handle that
+  names a credential without carrying it (closes
+  [#4565](https://github.com/bobmatnyc/trusty-tools/issues/4565), epic
+  [#4040](https://github.com/bobmatnyc/trusty-tools/issues/4040), DOC-45
+  `C-2.1`–`C-2.7`). `credential_ref` had zero hits under `crates/*/src/**`
+  despite being an acceptance bullet of the closed-as-completed #2808, so
+  anything that needed to *refer* to a credential had to *hold* one — which is
+  why `McpService.env` is a map of literal API keys in a hand-editable TOML. A
+  ref is safe in a git-tracked file, a config row, a log line, an audit record,
+  and a model-visible tool result: its grammar is lowercase-kebab segments,
+  ≤ 64 bytes, at most one `/`, which no realistic API key, JWT, OAuth token, or
+  PEM body can satisfy. Pinned by
+  `realistic_credentials_are_rejected_by_the_grammar` against specimens shaped
+  like every credential format the registry names. Stable across rotation, and
+  shape-agnostic: one type, one entry point, and no code path that exists only
+  for OAuth or only for a plain API key.
+- `credentials::Secret<T>` — the wrapper a resolved credential comes back in.
+  Its `Debug`/`Display` render a constant that is not merely redacted but
+  *independent of the value* (the impls carry no `T: Debug` bound, so they
+  cannot read it), and it implements neither `Serialize`, `Deserialize`,
+  `Clone`, `Deref`, nor `PartialEq`. Each omission is a closed leak path; the
+  absent `Serialize` is the load-bearing one, because every config struct in the
+  workspace derives it, so a `Secret` cannot compile inside one. Three
+  compile-time assertions (the `assert_not_impl` coherence trick, inlined rather
+  than adding a dependency) fail the build if any of the three traits is ever
+  added.
+- `credentials::resolve(&CredentialRef, &Principal, &Scope) -> Result<Secret<String>, CredentialError>`
+  — the single resolution entry point, called where the credential is consumed
+  rather than at config load (`C-3.3`, `C-8.4`). `resolve_client` is the same
+  entry point with the value consumed in place, handing back an
+  already-authenticated handle so the caller never sees the string (`C-3.4`,
+  DOC-63 `S-5.1`). A ref naming a provider absent from the registry fails with
+  `Missing` carrying a remediation that names the registry (`C-2.7`).
+- `credentials::CredentialError` — `Missing` / `Denied` / `Expired` /
+  `ZeroScope` / `ScopeUnavailable`. Every variant is recoverable, carries the
+  `CredentialRef` and the `Principal`, renders an actionable remediation, and
+  can hold no secret material by construction. The fifth variant is DOC-45
+  `C-5.5`'s deliberate addition to #4040's stated four, kept distinct from
+  `ZeroScope` by `C-5.6` because "widen the grant" is advice that cannot be
+  followed for a provider that has no such scope.
+- `credentials::Principal`, `ServiceId`, `Scope`, `Access` — the vocabulary
+  `resolve`'s final signature is written in. `Principal` is a closed,
+  `#[non_exhaustive]` enumeration carrying `Operator` and `Service` only:
+  DOC-45 `C-1.3` is PROVISIONAL pending owner question Q-B and says in terms
+  not to implement the `Assistant` variant until it is answered, so #4566 adds
+  `Assistant` and `SubAgent` without a breaking change.
+- `SecretString::into_secret` — the one-line migration from the older inference
+  wrapper to the canonical `Secret<String>`.
+
+Changed
+
+- `inference::types::SecretString` is documented as superseded by
+  `credentials::Secret`. Its behaviour is unchanged; note that its
+  four-character head preview does **not** meet DOC-45 `C-8.2`, and collapsing
+  the two types is left to a follow-up because it requires changing the existing
+  test that pins that preview's shape.
+
+Note: this change adds **no authorization**. `resolve` accepts a `Principal` and
+checks no grant against it — grants, the ACL, default-deny and the code-owned
+floor are [#4566](https://github.com/bobmatnyc/trusty-tools/issues/4566). The
+signature is final so no consumer is migrated twice.

--- a/crates/trusty-common/src/credentials/authority.rs
+++ b/crates/trusty-common/src/credentials/authority.rs
@@ -1,0 +1,427 @@
+//! The single credential-resolution entry point, resolved **at use time**
+//! (issue #4565, DOC-45 `C-3.3`/`C-3.4`/`C-8.4`).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CREDAUTH-03~draft`](docs/specs/DOC-45-credential-authority-model.md#SPEC-CREDAUTH-03~draft)
+//!
+//! Why: `C-3.3` requires exactly one entry point, and `C-8.4` requires
+//! resolution to happen at use time — *"never at config-load time and never at
+//! spawn-list-construction time"* — so the window in which a secret exists in
+//! memory is bounded by the call that needs it. Those two clauses only bite if
+//! the *shape* of the API makes the eager version awkward and the lazy version
+//! natural, which is what this module is for.
+//!
+//! ## How use-time resolution is enforced, not merely enabled
+//!
+//! 1. **A config struct cannot hold the result.** [`Secret`] implements neither
+//!    `Serialize` nor `Deserialize`, and every config type in this workspace
+//!    derives both, so a `Secret` field fails to compile inside one. The only
+//!    credential-shaped thing a config row *can* hold is a
+//!    [`CredentialRef`], which is exactly `C-8.8`. Pinned at compile time in
+//!    `super::secret::not_serialize_not_clone`.
+//! 2. **The result cannot be duplicated into a longer-lived home.** [`Secret`]
+//!    is not `Clone` and [`Secret::expose`] returns a borrow, so caching one is
+//!    a deliberate move, not an accident.
+//! 3. **Resolution needs facts a config loader does not have.** [`resolve`]
+//!    takes a [`Principal`] and a [`Scope`]: *who is acting* and *what for*.
+//!    Neither is answerable at config-load time — a loader has no principal in
+//!    hand and no operation in flight — so the eager call is not merely
+//!    discouraged, it has no arguments.
+//! 4. **The caller can avoid seeing the value at all.** [`resolve_client`]
+//!    hands back an already-authenticated handle built from the secret, so a
+//!    source type receives *"a resolved, scoped client and nothing else"*
+//!    (`C-3.4`, DOC-63 `S-5.1`). A caller that never sees the string cannot
+//!    leak the string.
+//!
+//! ## What this module does NOT do — the honesty clause
+//!
+//! **There is no authorization here.** [`resolve`] takes a `Principal` and
+//! checks no grant against it, because grants, the ACL, default-deny, and the
+//! code-owned floor are #4566 (DOC-45 §5) and #4565 is explicitly scoped to the
+//! reference type and the signature. Today's behaviour is therefore identical
+//! to [`super::resolve_key`]'s: the three storage tiers answer, and any caller
+//! that can reach the function gets the value. `C-3.12` says the same thing
+//! about default-deny at large — it is not airtight until #4571 migrates the 55
+//! raw `std::env::var` reads, and this document does not claim it is.
+//!
+//! What #4565 buys is that the signature will not change when #4566 lands: the
+//! grant check goes *inside* [`resolve`], and no consumer is migrated twice.
+//!
+//! Test: `tests::oauth_and_api_key_shapes_resolve_through_one_entry_point`,
+//! `tests::unregistered_provider_is_missing_and_names_the_registry`,
+//! `tests::absent_credential_is_missing`,
+//! `tests::resolve_client_never_hands_back_the_string`,
+//! `tests::resolved_secret_does_not_render_in_debug_or_display`.
+
+use super::error::CredentialError;
+use super::handle::CredentialRef;
+use super::principal::{Principal, Scope};
+use super::registry::env_var_for;
+use super::secret::Secret;
+use super::{KeyStore, default_store, dotenv, resolve_key_with};
+
+/// Resolve `credential` for `principal` at `scope`, at the point of use.
+///
+/// Why: the one entry point `C-3.3` requires. A second resolution path is a
+/// defect under this repo's common-entry-point rule and under DOC-63 `S-5.2`,
+/// and is rejected at review regardless of expedience.
+///
+/// What: loads `.env.local` once, then delegates to [`resolve_with`] against
+/// [`default_store`]. Returns the value wrapped in a [`Secret`], which cannot
+/// be serialised, cloned, or printed.
+///
+/// **Call this where the credential is consumed** — inside the function that
+/// builds the request, not in the constructor that builds the config. `C-8.4`.
+///
+/// # Errors
+///
+/// [`CredentialError::Missing`] when the reference names an unregistered
+/// provider (`C-2.7`, with a remediation naming the registry) or when no tier
+/// holds a value. The other four variants become reachable when #4566 adds the
+/// grant check; see the module docs.
+///
+/// Test: `tests::oauth_and_api_key_shapes_resolve_through_one_entry_point`
+/// exercises the hermetic core; the `load_env_local_once` + `default_store`
+/// wiring is intentionally not independently unit tested, for the same reason
+/// [`super::resolve_key`]'s is not.
+pub fn resolve(
+    credential: &CredentialRef,
+    principal: &Principal,
+    scope: &Scope,
+) -> Result<Secret<String>, CredentialError> {
+    dotenv::load_env_local_once();
+    resolve_with(credential, principal, scope, default_store().as_ref())
+}
+
+/// Hermetic core of [`resolve`]: same decision, injectable store.
+///
+/// Why: separated so tests can inject a `MemoryKeyStore` and control the
+/// process environment without touching the real filesystem, `$HOME`, or an OS
+/// keychain — the same split [`super::resolve_key`] / [`super::resolve_key_with`]
+/// already uses. It is one entry point with an injectable dependency, not a
+/// second entry point.
+///
+/// What: checks the provider registry (`C-2.7`), then the 3-tier precedence.
+/// `scope` is accepted and carried into the error path but not yet checked
+/// against a grant — see the module's honesty clause.
+///
+/// # Errors
+///
+/// [`CredentialError::Missing`], as [`resolve`].
+///
+/// Test: `tests::oauth_and_api_key_shapes_resolve_through_one_entry_point`,
+/// `tests::unregistered_provider_is_missing_and_names_the_registry`,
+/// `tests::absent_credential_is_missing`.
+pub fn resolve_with(
+    credential: &CredentialRef,
+    principal: &Principal,
+    scope: &Scope,
+    store: &dyn KeyStore,
+) -> Result<Secret<String>, CredentialError> {
+    // C-2.7: a ref, a registry entry, and a storage location are one chain.
+    // A ref naming an unregistered provider fails with `Missing` carrying a
+    // remediation that names the registry — the failure mode that used to hit
+    // silently for 13 of this workspace's 23 credential env vars.
+    if env_var_for(credential.provider()).is_none() {
+        return Err(CredentialError::Missing {
+            credential: credential.clone(),
+            principal: principal.clone(),
+            hint: format!(
+                " — provider `{}` is not in the credential registry \
+                 (`trusty_common::credentials::registry::REGISTRY`, #4564)",
+                credential.provider()
+            ),
+        });
+    }
+
+    // #4566 inserts the grant check here: `effective(principal)` per C-3.7,
+    // then `Scope::covers` per C-3.9, before any secret is materialised.
+    let _ = scope;
+
+    match resolve_key_with(&store_key(credential), store) {
+        Some(value) => Ok(Secret::new(value)),
+        None => Err(CredentialError::Missing {
+            credential: credential.clone(),
+            principal: principal.clone(),
+            hint: String::new(),
+        }),
+    }
+}
+
+/// The key a reference is stored and looked up under.
+///
+/// Why: an unqualified ref must keep hitting exactly the key the pre-#4565
+/// resolver used, or every credential already in a store or an environment
+/// variable becomes unreachable the day this lands. A qualified ref must reach
+/// a *distinct* row, or `github/work` and `github/personal` collapse onto one
+/// credential.
+/// What: renders the whole ref. The consequence for the env tier is deliberate
+/// and worth stating: [`super::registry::env_var_for`] has no entry for
+/// `github/work`, so a qualified ref resolves from the store only — there is
+/// one canonical environment variable per provider, and a second credential of
+/// the same provider has nowhere in the environment to live.
+/// Test: `tests::qualified_refs_reach_distinct_store_rows`.
+fn store_key(credential: &CredentialRef) -> String {
+    credential.to_string()
+}
+
+/// A type that can be built from a resolved credential without the caller ever
+/// holding the value (`C-3.4`).
+///
+/// Why: DOC-63 `S-5.1` requires that a source type receives *"a resolved,
+/// scoped client and nothing else"*. The point is not convenience — a caller
+/// that never sees the string cannot leak the string into a log, a
+/// `ToolResult`, or a delegation payload.
+/// What: implemented by an authenticated client handle. The `Secret` is lent
+/// for the duration of the call and dropped by [`resolve_client`] before it
+/// returns.
+/// Test: `tests::resolve_client_never_hands_back_the_string`.
+pub trait FromCredential: Sized {
+    /// Build `Self` from the resolved credential.
+    ///
+    /// # Errors
+    ///
+    /// A [`CredentialError`] the implementor judges appropriate — typically
+    /// [`CredentialError::Expired`] for a token the provider rejects at
+    /// construction time.
+    fn from_credential(
+        secret: &Secret<String>,
+        credential: &CredentialRef,
+        principal: &Principal,
+    ) -> Result<Self, CredentialError>;
+}
+
+/// Resolve and immediately build an authenticated handle (`C-3.4`).
+///
+/// Why: the shape DOC-63 `S-5.1` asks for. Same entry point, same registry
+/// check, same errors — this is [`resolve`] with the value consumed in place
+/// rather than returned, not a second resolution path.
+/// What: resolves, hands the [`Secret`] to `T::from_credential` by reference,
+/// and drops it. `T` never has to be a secret-bearing type.
+///
+/// # Errors
+///
+/// Whatever [`resolve`] returns, or whatever `T::from_credential` returns.
+///
+/// Test: `tests::resolve_client_never_hands_back_the_string`.
+pub fn resolve_client<T: FromCredential>(
+    credential: &CredentialRef,
+    principal: &Principal,
+    scope: &Scope,
+) -> Result<T, CredentialError> {
+    let secret = resolve(credential, principal, scope)?;
+    T::from_credential(&secret, credential, principal)
+}
+
+/// Store-injectable counterpart of [`resolve_client`], for tests.
+///
+/// Test: `tests::resolve_client_never_hands_back_the_string`.
+///
+/// # Errors
+///
+/// Whatever [`resolve_with`] returns, or whatever `T::from_credential` returns.
+pub fn resolve_client_with<T: FromCredential>(
+    credential: &CredentialRef,
+    principal: &Principal,
+    scope: &Scope,
+    store: &dyn KeyStore,
+) -> Result<T, CredentialError> {
+    let secret = resolve_with(credential, principal, scope, store)?;
+    T::from_credential(&secret, credential, principal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::credentials::MemoryKeyStore;
+    use serial_test::serial;
+
+    /// A stand-in for an authenticated client: it keeps a derived, non-secret
+    /// fact about the credential and drops the value.
+    struct AuthenticatedClient {
+        /// The reference the client was built for — non-secret by `C-2.1`.
+        credential: String,
+        /// Length of the credential, to prove the builder really saw it. A
+        /// length is not a substring, so this leaks nothing.
+        credential_len: usize,
+    }
+
+    impl FromCredential for AuthenticatedClient {
+        fn from_credential(
+            secret: &Secret<String>,
+            credential: &CredentialRef,
+            _principal: &Principal,
+        ) -> Result<Self, CredentialError> {
+            Ok(Self {
+                credential: credential.to_string(),
+                credential_len: secret.expose().len(),
+            })
+        }
+    }
+
+    /// Why: DOC-63 §7.1b item 5 warns that the plain-API-key shape is the one
+    /// most likely to be special-cased, and `C-2.5`/`C-3.3`/`C-8.5` require both
+    /// shapes to traverse the *same* entry point with no type, trait, or code
+    /// path existing for only one of them. This test is that requirement:
+    /// `google-oauth` (OAuth) and `brave` (plain API key) resolve through one
+    /// call with one argument list.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn oauth_and_api_key_shapes_resolve_through_one_entry_point() {
+        let store = MemoryKeyStore::new();
+        // pragma: allowlist secret
+        store
+            .set("google-oauth", "oauth-refresh-token-value")
+            .unwrap();
+        // pragma: allowlist secret
+        store.set("brave", "plain-api-key-value").unwrap();
+        // SAFETY: `#[serial(dotenv_credential_env)]` guarantees no other test in
+        // this crate mutates process env concurrently with this one.
+        unsafe {
+            std::env::remove_var("GOOGLE_OAUTH_CLIENT_SECRET");
+            std::env::remove_var("BRAVE_API_KEY");
+        }
+
+        let principal = Principal::Operator;
+        let scope = Scope::read();
+        for (name, expected) in [
+            ("google-oauth", "oauth-refresh-token-value"),
+            ("brave", "plain-api-key-value"),
+        ] {
+            let cred = CredentialRef::parse(name).unwrap();
+            let secret = resolve_with(&cred, &principal, &scope, &store).unwrap();
+            assert_eq!(secret.expose(), expected, "shape {name} did not resolve");
+        }
+    }
+
+    /// Why: `C-2.7` — a ref naming a provider absent from the registry must
+    /// fail with `Missing` carrying a remediation that names the registry,
+    /// because "silently" is how 13 of 23 credential env vars used to fail.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn unregistered_provider_is_missing_and_names_the_registry() {
+        let store = MemoryKeyStore::new();
+        // pragma: allowlist secret
+        store
+            .set("not-a-provider", "value-that-must-not-be-returned")
+            .unwrap();
+        let cred = CredentialRef::parse("not-a-provider").unwrap();
+        let err = resolve_with(&cred, &Principal::Operator, &Scope::read(), &store).unwrap_err();
+        assert!(matches!(err, CredentialError::Missing { .. }));
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("registry"),
+            "no registry hint: {rendered}"
+        );
+        assert!(rendered.contains("not-a-provider"), "no ref: {rendered}");
+        assert!(
+            !rendered.contains("value-that-must-not-be-returned"),
+            "leaked the stored value: {rendered}"
+        );
+    }
+
+    /// Why: `C-3.11` — a resolution failure is a recoverable `Err`, never a
+    /// silent `None` a caller can mistake for "not configured".
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn absent_credential_is_missing() {
+        // SAFETY: see `oauth_and_api_key_shapes_resolve_through_one_entry_point`.
+        unsafe {
+            std::env::remove_var("LINEAR_API_KEY");
+        }
+        let store = MemoryKeyStore::new();
+        let cred = CredentialRef::parse("linear").unwrap();
+        let err = resolve_with(&cred, &Principal::Operator, &Scope::read(), &store).unwrap_err();
+        assert!(matches!(err, CredentialError::Missing { hint, .. } if hint.is_empty()));
+    }
+
+    /// Why: `C-3.4` / DOC-63 `S-5.1` — the authority must be able to hand back
+    /// an already-authenticated handle so the caller never touches the value.
+    /// The handle here carries only non-secret derived facts, and the assertion
+    /// is that nothing about it renders the credential.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn resolve_client_never_hands_back_the_string() {
+        let store = MemoryKeyStore::new();
+        // pragma: allowlist secret
+        let value = "sk-brave-abcdefghijklmnop";
+        store.set("brave", value).unwrap();
+        // SAFETY: see `oauth_and_api_key_shapes_resolve_through_one_entry_point`.
+        unsafe {
+            std::env::remove_var("BRAVE_API_KEY");
+        }
+        let cred = CredentialRef::parse("brave").unwrap();
+        let client: AuthenticatedClient =
+            resolve_client_with(&cred, &Principal::Operator, &Scope::read(), &store).unwrap();
+        assert_eq!(client.credential, "brave");
+        assert_eq!(client.credential_len, value.len());
+    }
+
+    /// Why: the end-to-end statement of `C-8.2` on the *resolved* value, not
+    /// just on a hand-constructed `Secret` — this is what a caller who logs the
+    /// result of `resolve` would actually get.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn resolved_secret_does_not_render_in_debug_or_display() {
+        let store = MemoryKeyStore::new();
+        // pragma: allowlist secret
+        let value = concat!("xo", "xb", "-2314151234-2321313111-QwErTyUiOpAsDf");
+        store.set("slack", value).unwrap();
+        // SAFETY: see `oauth_and_api_key_shapes_resolve_through_one_entry_point`.
+        unsafe {
+            std::env::remove_var("SLACK_BOT_TOKEN");
+        }
+        let cred = CredentialRef::parse("slack").unwrap();
+        let secret = resolve_with(&cred, &Principal::Operator, &Scope::read(), &store).unwrap();
+        let rendered = format!("{secret} {secret:?} {cred}");
+        assert!(!rendered.contains(value), "leaked: {rendered}");
+        assert!(
+            !rendered.contains(concat!("xo", "xb")),
+            "leaked prefix: {rendered}"
+        );
+        // C-2.6: the *handle* still prints verbatim, which is the whole point.
+        assert!(
+            rendered.contains("slack"),
+            "handle should print: {rendered}"
+        );
+    }
+
+    /// Why: a qualified ref must reach a distinct store row, or `github/work`
+    /// and `github/personal` collapse onto one credential.
+    /// Test: itself.
+    #[test]
+    #[serial(dotenv_credential_env)]
+    fn qualified_refs_reach_distinct_store_rows() {
+        let store = MemoryKeyStore::new();
+        // pragma: allowlist secret
+        store.set("github/work", "work-token").unwrap();
+        // pragma: allowlist secret
+        store.set("github/personal", "personal-token").unwrap();
+        // SAFETY: see `oauth_and_api_key_shapes_resolve_through_one_entry_point`.
+        unsafe {
+            std::env::remove_var("GITHUB_TOKEN");
+        }
+        let principal = Principal::Operator;
+        let scope = Scope::read();
+        let work = CredentialRef::parse("github/work").unwrap();
+        let personal = CredentialRef::parse("github/personal").unwrap();
+        assert_eq!(
+            resolve_with(&work, &principal, &scope, &store)
+                .unwrap()
+                .expose(),
+            "work-token"
+        );
+        assert_eq!(
+            resolve_with(&personal, &principal, &scope, &store)
+                .unwrap()
+                .expose(),
+            "personal-token"
+        );
+    }
+}

--- a/crates/trusty-common/src/credentials/error.rs
+++ b/crates/trusty-common/src/credentials/error.rs
@@ -1,0 +1,259 @@
+//! [`CredentialError`] — the denial taxonomy (issue #4565, DOC-45 §7).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CREDAUTH-05~draft`](docs/specs/DOC-45-credential-authority-model.md#SPEC-CREDAUTH-05~draft)
+//!
+//! Why: `resolve_key` returns `Option<String>`, so today "there is no such
+//! credential", "you may not read it", and "the token expired" are the same
+//! answer: `None`. A caller cannot tell an operator what to do about it, and
+//! a scheduled source silently failing forever on an expired token is the
+//! result. Each variant here exists because it has a *different remediation*.
+//!
+//! What: five variants, each carrying the [`CredentialRef`] and the
+//! [`Principal`] and each rendering an actionable remediation (`C-5.7`). Every
+//! failure is a recoverable `Result::Err` — no panic, no `unwrap`, no
+//! empty-string-as-success, and no silent `None` a caller can mistake for "not
+//! configured" when the real answer was "denied" (`C-3.11`).
+//!
+//! **Five, not four.** #4040's "Done when" names four. DOC-45 `C-5.5`/`C-5.6`
+//! adds [`CredentialError::ScopeUnavailable`] as a fifth and requires it stay
+//! distinct from [`CredentialError::ZeroScope`], because the two have different
+//! remediations: `ZeroScope` says *widen the grant*, which for a provider with
+//! no read-only scope is advice that cannot be followed and will be worked
+//! around by granting write. DOC-45 flags this as a deliberate addition rather
+//! than folding it in silently, and so does this module.
+//!
+//! Test: `tests::every_variant_is_constructible_and_matchable`,
+//! `tests::remediation_names_the_principal_and_the_ref`,
+//! `tests::no_variant_renders_secret_material`.
+
+use super::handle::CredentialRef;
+use super::principal::{Principal, Scope};
+
+/// Why a credential could not be resolved.
+///
+/// Why: see the module docs — one variant per distinct operator action.
+/// What: five variants, all recoverable, all pattern-matchable by a caller
+/// (`C-5.8` — distinguishable by matching, never by string comparison on a
+/// rendered message), and none carrying secret material (`C-5.9`).
+///
+/// **`Missing` vs `Denied` (`C-5.10`).** The two are deliberately distinct so
+/// an *operator* can tell "store the credential" from "issue a grant". Where a
+/// denial is surfaced into model-visible context, the surfaced form must not
+/// reveal whether a credential the principal is not granted actually exists —
+/// the full distinction belongs in the audit record (#4567), which the operator
+/// reads and the model does not. This type does not enforce that; the surfacing
+/// call site does, and #4567 is where it is pinned.
+///
+/// Test: `tests::every_variant_is_constructible_and_matchable`,
+/// `tests::no_variant_renders_secret_material`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[non_exhaustive]
+pub enum CredentialError {
+    /// No credential is stored for this reference at all (`C-5.1`). The grant
+    /// may well exist; there is simply nothing to resolve.
+    ///
+    /// Also the answer when the reference names a provider absent from the
+    /// registry (`C-2.7`) — hence `hint`, which names the registry in that case
+    /// so the failure mode 13 of 23 credential env-vars used to hit silently
+    /// now says what to do.
+    #[error(
+        "no credential stored for `{credential}` (principal `{principal}`); \
+         store it with `config keys set {credential}`{hint}"
+    )]
+    Missing {
+        /// The reference that could not be resolved.
+        credential: CredentialRef,
+        /// The principal that asked.
+        principal: Principal,
+        /// Extra remediation, e.g. naming the provider registry. Empty when
+        /// there is nothing more to say.
+        hint: String,
+    },
+
+    /// The credential exists, but this principal holds no grant covering it
+    /// (`C-5.2`). The default-deny answer (`C-3.2`) and the sub-agent answer
+    /// (`C-4.3`).
+    #[error(
+        "principal `{principal}` is not granted `{credential}`; \
+         issue a grant for that principal, or accept the denial"
+    )]
+    Denied {
+        /// The reference that was denied.
+        credential: CredentialRef,
+        /// The principal that was denied.
+        principal: Principal,
+    },
+
+    /// A grant or credential existed and is no longer valid (`C-5.3`) — the
+    /// grant's expiry passed, or the authority recorded the credential as
+    /// revoked.
+    #[error("`{credential}` is expired or revoked for principal `{principal}`; re-authenticate")]
+    Expired {
+        /// The reference whose credential or grant died.
+        credential: CredentialRef,
+        /// The principal that asked.
+        principal: Principal,
+    },
+
+    /// The grant exists and is live, but its scope does not cover the request
+    /// (`C-5.4`) — the intersection is empty.
+    #[error(
+        "principal `{principal}`'s grant on `{credential}` does not cover scope `{requested}`; \
+         widen the grant's scope"
+    )]
+    ZeroScope {
+        /// The reference whose grant was too narrow.
+        credential: CredentialRef,
+        /// The principal that asked.
+        principal: Principal,
+        /// The scope that was requested.
+        requested: Scope,
+    },
+
+    /// The **provider** cannot issue a credential at the requested scope at all
+    /// (`C-5.5`). Not a property of the grant; a property of the provider.
+    ///
+    /// Kept distinct from [`Self::ZeroScope`] by `C-5.6`: telling an operator
+    /// to "widen the grant" for a provider that has no such scope is advice
+    /// that cannot be followed, and the workaround is to grant write — which is
+    /// the exact dishonesty DOC-63 `S-5.3` exists to prevent.
+    #[error(
+        "provider for `{credential}` cannot issue a credential at scope `{requested}` \
+         (principal `{principal}`); this provider has no such scope"
+    )]
+    ScopeUnavailable {
+        /// The reference whose provider cannot issue the scope.
+        credential: CredentialRef,
+        /// The principal that asked.
+        principal: Principal,
+        /// The scope that is unavailable.
+        requested: Scope,
+    },
+}
+
+impl CredentialError {
+    /// The reference this failure is about.
+    ///
+    /// Why: #4567's audit record needs the ref off any failure without matching
+    /// five variants at every call site.
+    /// Test: `tests::every_variant_is_constructible_and_matchable`.
+    pub fn credential(&self) -> &CredentialRef {
+        match self {
+            Self::Missing { credential, .. }
+            | Self::Denied { credential, .. }
+            | Self::Expired { credential, .. }
+            | Self::ZeroScope { credential, .. }
+            | Self::ScopeUnavailable { credential, .. } => credential,
+        }
+    }
+
+    /// The principal this failure is about.
+    ///
+    /// Test: `tests::every_variant_is_constructible_and_matchable`.
+    pub fn principal(&self) -> &Principal {
+        match self {
+            Self::Missing { principal, .. }
+            | Self::Denied { principal, .. }
+            | Self::Expired { principal, .. }
+            | Self::ZeroScope { principal, .. }
+            | Self::ScopeUnavailable { principal, .. } => principal,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// One of each variant, for the tests below.
+    fn one_of_each() -> Vec<CredentialError> {
+        let credential = CredentialRef::parse("github/work").unwrap();
+        let principal = Principal::Operator;
+        vec![
+            CredentialError::Missing {
+                credential: credential.clone(),
+                principal: principal.clone(),
+                hint: String::new(),
+            },
+            CredentialError::Denied {
+                credential: credential.clone(),
+                principal: principal.clone(),
+            },
+            CredentialError::Expired {
+                credential: credential.clone(),
+                principal: principal.clone(),
+            },
+            CredentialError::ZeroScope {
+                credential: credential.clone(),
+                principal: principal.clone(),
+                requested: Scope::write(),
+            },
+            CredentialError::ScopeUnavailable {
+                credential,
+                principal,
+                requested: Scope::read(),
+            },
+        ]
+    }
+
+    /// Why: `C-5.8` — every variant must be constructible and observable from a
+    /// test, and distinguishable by pattern-matching rather than by string
+    /// comparison on a rendered message. This is #4565's acceptance criterion
+    /// on the error type, and #4040's "four (five) diagnostics" clause.
+    /// Test: itself.
+    #[test]
+    fn every_variant_is_constructible_and_matchable() {
+        let all = one_of_each();
+        assert_eq!(all.len(), 5, "DOC-45 C-5.1–C-5.5 name five variants");
+        for e in &all {
+            // Matched structurally, never by rendered text.
+            let named = match e {
+                CredentialError::Missing { .. } => "missing",
+                CredentialError::Denied { .. } => "denied",
+                CredentialError::Expired { .. } => "expired",
+                CredentialError::ZeroScope { .. } => "zero-scope",
+                CredentialError::ScopeUnavailable { .. } => "scope-unavailable",
+            };
+            assert!(!named.is_empty());
+            assert_eq!(e.credential().provider(), "github");
+            assert_eq!(e.principal(), &Principal::Operator);
+        }
+        // C-5.6: the two scope variants are distinct values, not aliases.
+        assert_ne!(all[3], all[4]);
+    }
+
+    /// Why: `C-5.7` — every variant carries an actionable remediation naming
+    /// the principal and the reference. `Denied` in particular must name both,
+    /// so the first denial a sub-agent hits under §6 tells the operator exactly
+    /// which grant to issue (`C-4.6`) rather than starting a debugging session.
+    /// Test: itself.
+    #[test]
+    fn remediation_names_the_principal_and_the_ref() {
+        for e in one_of_each() {
+            let rendered = e.to_string();
+            assert!(
+                rendered.contains("github/work"),
+                "no credential ref in: {rendered}"
+            );
+            assert!(rendered.contains("operator"), "no principal in: {rendered}");
+        }
+    }
+
+    /// Why: `C-5.9` — no variant may carry secret material, not even a prefix
+    /// "for identification". The type makes this structural: every field is a
+    /// `CredentialRef`, a `Principal`, or a `Scope`, and none of the three can
+    /// hold a value. This test pins the consequence.
+    /// Test: itself.
+    #[test]
+    fn no_variant_renders_secret_material() {
+        // pragma: allowlist secret
+        let secret = "ghp_16C7e42F292c6912E7710c838347Ae178B4a";
+        for e in one_of_each() {
+            let rendered = format!("{e} {e:?}");
+            assert!(!rendered.contains(secret), "leaked: {rendered}");
+            assert!(!rendered.contains("ghp_"), "leaked prefix: {rendered}");
+        }
+    }
+}

--- a/crates/trusty-common/src/credentials/handle.rs
+++ b/crates/trusty-common/src/credentials/handle.rs
@@ -1,0 +1,410 @@
+//! [`CredentialRef`] — the opaque, non-secret handle that *names* a credential
+//! (issue #4565, DOC-45 §4).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CREDAUTH-02~draft`](docs/specs/DOC-45-credential-authority-model.md#SPEC-CREDAUTH-02~draft)
+//!
+//! Why: today a credential's only identity is the value itself, so anything
+//! that needs to *refer* to one has to *hold* one. That is why
+//! `McpService.env` is a `HashMap<String, String>` of literal API keys in a
+//! hand-editable TOML, and why DOC-63 `S-5.6`'s "no secrets in the assistant
+//! home" is a rule people remember rather than a property of the types. A
+//! reference type is the mechanism that inverts that: a config row, a store
+//! row, a log line, an audit record, and a model-visible `ToolResult` can all
+//! carry a `CredentialRef` in plain text because a `CredentialRef` is not a
+//! secret and — by `C-2.4`'s grammar — cannot be made to carry one.
+//!
+//! What: a `provider` key, optionally qualified (`slack/bot`), restricted to
+//! lowercase-kebab segments and 64 bytes. Stable across rotation (`C-2.2`),
+//! shape-agnostic between OAuth and API-key credentials (`C-2.5`), rendered
+//! verbatim by `Display` (`C-2.6`), and resolved through the provider registry
+//! (`C-2.7`).
+//!
+//! Test: `tests::round_trips_through_serde`, `tests::display_is_verbatim`,
+//! `tests::realistic_credentials_are_rejected_by_the_grammar`,
+//! `tests::qualifier_is_optional_and_preserved`,
+//! `tests::rejects_out_of_grammar_text`.
+
+use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Maximum total length of a rendered `CredentialRef`, in bytes.
+///
+/// Why: part of `C-2.4`'s restrictive grammar. Every credential format in this
+/// workspace's census is either longer than this or uses characters the
+/// grammar rejects, so a value cannot be laundered into a ref by accident.
+const MAX_LEN: usize = 64;
+
+/// Maximum length of one `/`-separated segment.
+const MAX_SEGMENT_LEN: usize = 32;
+
+/// Why a piece of text is not a valid [`CredentialRef`].
+///
+/// Why: `C-2.4` requires construction from out-of-grammar text to be a
+/// *recoverable parse error*, not a panic and not a silent acceptance — the
+/// audit stream's "secret material is unrepresentable" guarantee (`C-7.3`) is
+/// worth exactly as much as this type's willingness to say no.
+/// What: one variant per rejection reason, each naming the offending shape
+/// without echoing the input — a rejected input may well *be* a secret, which
+/// is the whole reason it was rejected.
+/// Test: `tests::rejects_out_of_grammar_text`,
+/// `tests::parse_error_never_echoes_the_input`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum CredentialRefError {
+    /// The text was empty.
+    #[error("credential reference is empty")]
+    Empty,
+
+    /// The text exceeded [`MAX_LEN`] bytes, or a segment exceeded
+    /// [`MAX_SEGMENT_LEN`].
+    #[error(
+        "credential reference is too long ({len} bytes; max {MAX_LEN}, max {MAX_SEGMENT_LEN} per segment)"
+    )]
+    TooLong {
+        /// Length of the offending text, in bytes. Never the text itself.
+        len: usize,
+    },
+
+    /// The text used more than one `/`, or had an empty segment.
+    #[error("credential reference must be `provider` or `provider/qualifier`")]
+    Shape,
+
+    /// A segment used a character outside `[a-z0-9-]`, or started/ended with
+    /// `-`.
+    #[error(
+        "credential reference segments must be lowercase kebab-case `[a-z0-9-]`, \
+         not starting or ending with `-` (DOC-45 C-2.4)"
+    )]
+    Charset,
+}
+
+/// An opaque, durable, serialisable, **non-secret** handle naming a credential.
+///
+/// Why: see the module docs. In one line — this is what a config row holds
+/// *instead of* a secret, so "no credential in the assistant home" becomes true
+/// by construction rather than by discipline (`C-8.8`).
+///
+/// What: `provider` plus an optional `qualifier`, rendered `provider` or
+/// `provider/qualifier`. The provider segment is the key looked up in
+/// [`super::registry`] (`C-2.7`); the qualifier distinguishes several
+/// credentials of one provider held by one operator (`github/work` vs
+/// `github/personal`) without needing a registry entry per instance.
+///
+/// Invariants, all enforced by [`CredentialRef::parse`] and by the
+/// `Deserialize` impl, which routes through it:
+/// - every segment matches `[a-z0-9]([a-z0-9-]*[a-z0-9])?`;
+/// - at most one `/`;
+/// - total rendered length ≤ 64 bytes, each segment ≤ 32.
+///
+/// **Stability (`C-2.2`).** A ref does not change when the underlying secret
+/// rotates. A store row written once keeps working across every rotation, and
+/// rotation never becomes a config edit across N files.
+///
+/// **Shape-agnosticism (`C-2.5`).** The same type names an OAuth credential and
+/// a plain API key. There is deliberately no `Kind`, no `is_oauth()`, and no
+/// second constructor — DOC-63 §7.1b item 5 warns that the API-key shape is the
+/// one most likely to be special-cased, and states that it must not be.
+///
+/// Test: `tests::round_trips_through_serde`,
+/// `tests::realistic_credentials_are_rejected_by_the_grammar`,
+/// `tests::qualifier_is_optional_and_preserved`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct CredentialRef {
+    provider: String,
+    qualifier: Option<String>,
+}
+
+impl CredentialRef {
+    /// Parse `text` into a reference, validating the full grammar.
+    ///
+    /// Why: the single door into the type. `C-2.4` requires that a
+    /// `CredentialRef` cannot be built from arbitrary text, because the audit
+    /// record (#4567) accepts a `CredentialRef` precisely so that secret
+    /// material is unrepresentable there — an unvalidated newtype would
+    /// launder any string straight into a retained stream.
+    /// What: splits on `/`, validates each segment, and enforces the length
+    /// caps. Returns [`CredentialRefError`] rather than panicking.
+    /// Test: `tests::rejects_out_of_grammar_text`,
+    /// `tests::realistic_credentials_are_rejected_by_the_grammar`,
+    /// `tests::qualifier_is_optional_and_preserved`.
+    pub fn parse(text: &str) -> Result<Self, CredentialRefError> {
+        if text.is_empty() {
+            return Err(CredentialRefError::Empty);
+        }
+        if text.len() > MAX_LEN {
+            return Err(CredentialRefError::TooLong { len: text.len() });
+        }
+        let mut parts = text.split('/');
+        let provider = parts.next().unwrap_or_default();
+        let qualifier = parts.next();
+        if parts.next().is_some() {
+            return Err(CredentialRefError::Shape);
+        }
+        validate_segment(provider)?;
+        if let Some(q) = qualifier {
+            validate_segment(q)?;
+        }
+        Ok(Self {
+            provider: provider.to_string(),
+            qualifier: qualifier.map(str::to_string),
+        })
+    }
+
+    /// The provider key this reference names.
+    ///
+    /// Why: [`super::registry::env_var_for`] and the store tier both key off
+    /// the provider, never the qualifier — `C-2.7`'s "a ref, a registry entry,
+    /// and a storage location are one chain".
+    /// Test: `tests::qualifier_is_optional_and_preserved`.
+    pub fn provider(&self) -> &str {
+        &self.provider
+    }
+
+    /// The optional qualifier, distinguishing several credentials of one
+    /// provider.
+    ///
+    /// Test: `tests::qualifier_is_optional_and_preserved`.
+    pub fn qualifier(&self) -> Option<&str> {
+        self.qualifier.as_deref()
+    }
+}
+
+/// Reject a segment that is not `[a-z0-9]([a-z0-9-]*[a-z0-9])?` or is too long.
+fn validate_segment(segment: &str) -> Result<(), CredentialRefError> {
+    if segment.is_empty() {
+        return Err(CredentialRefError::Shape);
+    }
+    if segment.len() > MAX_SEGMENT_LEN {
+        return Err(CredentialRefError::TooLong { len: segment.len() });
+    }
+    if segment.starts_with('-') || segment.ends_with('-') {
+        return Err(CredentialRefError::Charset);
+    }
+    if !segment
+        .bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+    {
+        return Err(CredentialRefError::Charset);
+    }
+    Ok(())
+}
+
+impl fmt::Display for CredentialRef {
+    /// Render the reference verbatim.
+    ///
+    /// Why: `C-2.6` — a ref is non-secret by `C-2.1` and `C-2.4`, so masking it
+    /// would only make the audit trail harder to read while buying nothing.
+    /// This is the deliberate opposite of [`super::Secret`], and the contrast
+    /// is the design: the handle prints, the value never does.
+    /// Test: `tests::display_is_verbatim`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.provider)?;
+        if let Some(q) = &self.qualifier {
+            write!(f, "/{q}")?;
+        }
+        Ok(())
+    }
+}
+
+impl FromStr for CredentialRef {
+    type Err = CredentialRefError;
+
+    /// Delegates to [`CredentialRef::parse`] so there is one validation path.
+    /// Test: `tests::round_trips_through_serde`.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl Serialize for CredentialRef {
+    /// Serialise as the rendered string, so a TOML/JSON row reads
+    /// `credential_ref = "slack/bot"` rather than a nested table.
+    /// Test: `tests::round_trips_through_serde`.
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for CredentialRef {
+    /// Deserialise through [`CredentialRef::parse`], so a hand-edited config
+    /// cannot introduce an out-of-grammar ref — the grammar is enforced at the
+    /// boundary, not merely at the constructor.
+    /// Test: `tests::round_trips_through_serde`,
+    /// `tests::deserialize_rejects_out_of_grammar_text`.
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let raw = String::deserialize(deserializer)?;
+        Self::parse(&raw).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `C-2.1` requires a ref to be durable — writable into a config TOML
+    /// and readable back — and the serialised form is what a store row holds.
+    /// Test: itself.
+    #[test]
+    fn round_trips_through_serde() {
+        for text in ["slack", "slack/bot", "github/work", "google-oauth"] {
+            let parsed = CredentialRef::parse(text).unwrap();
+            let json = serde_json::to_string(&parsed).unwrap();
+            assert_eq!(json, format!("\"{text}\""));
+            let back: CredentialRef = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, parsed);
+            assert_eq!(text.parse::<CredentialRef>().unwrap(), parsed);
+        }
+    }
+
+    /// Why: `C-2.6` — the handle prints verbatim, which is what makes an audit
+    /// record readable. Paired with `secret::tests` proving the *value* never
+    /// prints, this is the whole reference-type contract in two tests.
+    /// Test: itself.
+    #[test]
+    fn display_is_verbatim() {
+        assert_eq!(CredentialRef::parse("slack").unwrap().to_string(), "slack");
+        assert_eq!(
+            CredentialRef::parse("github/work").unwrap().to_string(),
+            "github/work"
+        );
+    }
+
+    /// Why: this is `C-2.4`'s actual claim — the grammar is restrictive enough
+    /// that no realistic API key, JWT, OAuth token, or PEM body can satisfy it,
+    /// so a secret cannot be laundered into a ref (and thence into the audit
+    /// stream) by accident. Specimens are shaped like the real formats this
+    /// workspace's registry names, with the values themselves invented.
+    /// Test: itself.
+    #[test]
+    fn realistic_credentials_are_rejected_by_the_grammar() {
+        let specimens: &[(&str, &str)] = &[
+            // pragma: allowlist secret
+            ("GitHub PAT", "ghp_16C7e42F292c6912E7710c838347Ae178B4a"),
+            // pragma: allowlist secret
+            (
+                "GitHub fine-grained",
+                "github_pat_11ABCDE0Y_aBcDeFgHiJkLmNoP",
+            ),
+            // pragma: allowlist secret
+            ("OpenAI", "sk-proj-Ab12Cd34Ef56Gh78Ij90KlMnOpQrSt"),
+            // pragma: allowlist secret
+            (
+                "Slack bot",
+                // Assembled rather than written literally so GitHub push
+                // protection does not flag an invented specimen as a live token.
+                concat!("xo", "xb", "-2314151234-2321313111-QwErTyUiOpAsDf"),
+            ),
+            // pragma: allowlist secret
+            (
+                "Slack app",
+                concat!("xa", "pp", "-1-A012BCDEF-1234567890-abcdefABCDEF0123"),
+            ),
+            // pragma: allowlist secret
+            (
+                "Telegram",
+                "1234567890:AAF-abcDEF1234ghIkl-zyx57W2v1u123ew11",
+            ),
+            // pragma: allowlist secret
+            ("Brave", "BSA_aBcDeFgHiJkLmNoPqRsTuVwXyZ012345"),
+            // pragma: allowlist secret
+            ("JWT", "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CVP"),
+            // pragma: allowlist secret
+            ("PEM body", "-----BEGIN RSA PRIVATE KEY-----\nMIIEow=="),
+            // pragma: allowlist secret
+            ("Google OAuth secret", "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"),
+        ];
+        for (name, specimen) in specimens {
+            assert!(
+                CredentialRef::parse(specimen).is_err(),
+                "{name} specimen parsed as a CredentialRef — the C-2.4 grammar is too permissive"
+            );
+        }
+    }
+
+    /// Why: the qualifier is what lets one operator hold two credentials of one
+    /// provider without a registry entry per instance; dropping it silently
+    /// would collapse `github/work` and `github/personal` onto one row.
+    /// Test: itself.
+    #[test]
+    fn qualifier_is_optional_and_preserved() {
+        let bare = CredentialRef::parse("github").unwrap();
+        assert_eq!(bare.provider(), "github");
+        assert_eq!(bare.qualifier(), None);
+
+        let qualified = CredentialRef::parse("github/work").unwrap();
+        assert_eq!(qualified.provider(), "github");
+        assert_eq!(qualified.qualifier(), Some("work"));
+        assert_ne!(bare, qualified);
+    }
+
+    /// Why: each rejection reason must be reachable, so the grammar is pinned
+    /// rather than merely described.
+    /// Test: itself.
+    #[test]
+    fn rejects_out_of_grammar_text() {
+        use CredentialRefError::*;
+        let cases: &[(&str, CredentialRefError)] = &[
+            ("", Empty),
+            ("a/b/c", Shape),
+            ("slack/", Shape),
+            ("/slack", Shape),
+            ("Slack", Charset),
+            ("slack_bot", Charset),
+            ("slack.bot", Charset),
+            ("slack bot", Charset),
+            ("-slack", Charset),
+            ("slack-", Charset),
+            ("slack\n", Charset),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                CredentialRef::parse(input).unwrap_err(),
+                *expected,
+                "input {input:?}"
+            );
+        }
+        let long = "a".repeat(MAX_LEN + 1);
+        assert_eq!(
+            CredentialRef::parse(&long).unwrap_err(),
+            TooLong { len: MAX_LEN + 1 }
+        );
+        let long_segment = format!("{}/b", "a".repeat(MAX_SEGMENT_LEN + 1));
+        assert_eq!(
+            CredentialRef::parse(&long_segment).unwrap_err(),
+            TooLong {
+                len: MAX_SEGMENT_LEN + 1
+            }
+        );
+    }
+
+    /// Why: a rejected input may itself be a secret — that is precisely why it
+    /// was rejected — so the error must not echo it. `C-5.9` in miniature.
+    /// Test: itself.
+    #[test]
+    fn parse_error_never_echoes_the_input() {
+        // pragma: allowlist secret
+        let secret = "ghp_16C7e42F292c6912E7710c838347Ae178B4a";
+        let rendered = CredentialRef::parse(secret).unwrap_err().to_string();
+        assert!(!rendered.contains(secret), "leaked: {rendered}");
+        assert!(!rendered.contains("ghp_"), "leaked prefix: {rendered}");
+    }
+
+    /// Why: enforcing the grammar only in `parse` would leave a hand-edited
+    /// config TOML as an unchecked door into the type.
+    /// Test: itself.
+    #[test]
+    fn deserialize_rejects_out_of_grammar_text() {
+        // pragma: allowlist secret
+        let json = concat!(
+            "\"",
+            "xo",
+            "xb",
+            "-2314151234-2321313111-QwErTyUiOpAsDf",
+            "\""
+        );
+        assert!(serde_json::from_str::<CredentialRef>(json).is_err());
+    }
+}

--- a/crates/trusty-common/src/credentials/mod.rs
+++ b/crates/trusty-common/src/credentials/mod.rs
@@ -12,43 +12,65 @@
 //! path had become actively misleading, which is why consumers kept adding a
 //! raw `std::env::var` read instead of finding it.
 //!
-//! What: [`KeyStore`] is the storage trait ([`memory_store::MemoryKeyStore`],
-//! [`file_store::FileKeyStore`], and — behind the `keyring-store` feature —
-//! `keyring_store::KeyringStore`). [`registry`] is the
-//! provider→environment-variable table. [`resolver::resolve_key`] applies the
-//! 3-tier precedence (process env var via [`registry::env_var_for`] >
-//! `.env.local` via [`dotenv`] > [`resolver::default_store`]).
-//! [`redact::redact_secret`] is the one credential-masking implementation,
-//! also reused by `memory_core::filter`.
+//! What: two layers.
+//!
+//! **Storage and naming.** [`KeyStore`] is the storage trait
+//! ([`memory_store::MemoryKeyStore`], [`file_store::FileKeyStore`], and —
+//! behind the `keyring-store` feature — `keyring_store::KeyringStore`).
+//! [`registry`] is the provider→environment-variable table.
+//! [`resolver::resolve_key`] applies the 3-tier precedence (process env var via
+//! [`registry::env_var_for`] > `.env.local` via [`dotenv`] >
+//! [`resolver::default_store`]). [`redact::redact_secret`] is the one
+//! credential-masking implementation, also reused by `memory_core::filter`.
+//!
+//! **Reference and use-time resolution** (#4565). [`CredentialRef`] is the
+//! opaque, non-secret handle a config row holds *instead of* a credential;
+//! [`Secret`] is what a resolved credential comes back in, and it cannot be
+//! serialised, cloned, or printed; [`authority::resolve`] is the single entry
+//! point, taking a [`Principal`] and a [`Scope`] so resolution happens where
+//! the credential is consumed rather than at config load;
+//! [`CredentialError`] is the five-variant denial taxonomy.
 //!
 //! This module holds **no** authorization. Which principal may resolve which
 //! credential is DOC-45 §5 and lands with #4566; the storage tiers here
-//! determine *where a value lives*, never *who may read it* (`C-9.8`).
+//! determine *where a value lives*, never *who may read it* (`C-9.8`). The
+//! [`Principal`] argument exists so no consumer is migrated twice when that
+//! check lands — see [`authority`]'s honesty clause.
 //!
 //! Test: `cargo test -p trusty-common --features credentials -- credentials::`
 //! and (KeyringStore compile/probe-failure-path only, never a real keychain)
 //! `cargo test -p trusty-common --features keyring-store -- credentials::`.
 
+pub mod authority;
 mod dotenv;
+mod error;
 mod file_store;
+mod handle;
 #[cfg(feature = "keyring-store")]
 mod keyring_store;
 mod memory_store;
+mod principal;
 mod redact;
 pub mod registry;
 mod resolver;
+mod secret;
 
+pub use authority::{FromCredential, resolve, resolve_client, resolve_client_with, resolve_with};
 pub use dotenv::{
     env_local_value, find_workspace_env_local, load_env_from_path, load_env_local_once,
     read_var_from_env_local, user_env_local_path,
 };
+pub use error::CredentialError;
 pub use file_store::FileKeyStore;
+pub use handle::{CredentialRef, CredentialRefError};
 #[cfg(feature = "keyring-store")]
 pub use keyring_store::KeyringStore;
 pub use memory_store::MemoryKeyStore;
+pub use principal::{Access, Principal, Scope, ServiceId};
 pub use redact::redact_secret;
 pub use registry::{REGISTRY, env_var_for, registered_providers};
 pub use resolver::{default_store, resolve_key, resolve_key_with};
+pub use secret::Secret;
 
 use std::path::PathBuf;
 

--- a/crates/trusty-common/src/credentials/principal.rs
+++ b/crates/trusty-common/src/credentials/principal.rs
@@ -1,0 +1,298 @@
+//! [`Principal`] and [`Scope`] — the two arguments that make resolution a
+//! *decision* rather than a lookup (issue #4565, DOC-45 §3 and §5.4).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CREDAUTH-01~draft`](docs/specs/DOC-45-credential-authority-model.md#SPEC-CREDAUTH-01~draft)
+//!
+//! Why: #4565's job is to fix the *signature* of `resolve` before #4566 fills
+//! in the authorization behind it, so that no consumer has to be migrated twice.
+//! Both types therefore exist here in their final shape and are deliberately
+//! inert: nothing in this module denies anything.
+//!
+//! **Scope boundary, stated plainly.** ACL, grants, default-deny, and the
+//! code-owned floor are #4566 and are **not** implemented here. What is here is
+//! the vocabulary those decisions will be expressed in.
+//!
+//! **What is deliberately missing.** DOC-45 `C-1.3` is PROVISIONAL pending owner
+//! question **Q-B** (do two assistant instances share a credential namespace?)
+//! and says in terms: *"Do not implement `Principal`'s `Assistant` variant until
+//! Q-B is answered."* `C-12.1` repeats it as a delivery rule. So [`Principal`]
+//! ships with `Operator` and `Service` — the two kinds Q-B does not touch — and
+//! is `#[non_exhaustive]` so `Assistant` and `SubAgent` can be added by #4566
+//! without a breaking change.
+//!
+//! Test: `tests::principal_renders_its_full_shape`,
+//! `tests::service_id_rejects_out_of_grammar_text`,
+//! `tests::scope_read_is_covered_by_write`,
+//! `tests::provider_scopes_must_all_be_covered`.
+
+use std::fmt;
+
+use super::handle::CredentialRefError;
+
+/// The thing an authorization decision is made *about* (`C-1.1`).
+///
+/// Why: `resolve_key(provider)` today takes a provider name **and nothing
+/// else**, so any code in any crate that can call it gets any credential the
+/// process can see — that is the entire access-control model as of #4565.
+/// Threading a `Principal` through the entry point is the change that makes an
+/// ACL expressible at all; #4566 is what makes it enforced.
+///
+/// What: a **closed enumeration** (`C-1.7`), never a string — a stringly-typed
+/// principal would let any caller spell one, re-opening `C-1.2`'s
+/// derived-not-declared rule, and would make `C-3.7`'s exhaustive-match floor
+/// impossible to write. `#[non_exhaustive]` because two of the four kinds
+/// DOC-45 names are blocked on owner Q-B; see the module docs.
+///
+/// **Derivation (`C-1.2`).** A `Principal` is derived by the authority from the
+/// executing context, never declared by the thing it names. Nothing in this
+/// module enforces that yet — there is no authorization here to enforce it
+/// *for* — and #4566 owns making it true.
+///
+/// **No secret material (`C-1.8`).** `Principal` renders its full shape in
+/// `Debug`/`Display`, which is what makes it safe to place on every audit
+/// record (#4567) without a redaction pass.
+///
+/// Test: `tests::principal_renders_its_full_shape`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
+pub enum Principal {
+    /// The human at the keyboard — the authenticated owner of the machine.
+    /// The highest authority, and per `C-3.6` the only kind that may issue or
+    /// revoke a grant.
+    Operator,
+
+    /// A daemon or non-assistant process: `trusty-search`, `trusty-memory`,
+    /// the `tm` daemon, a `trusty-code` session. Required by the owner's
+    /// cross-product decision — trusty-code has no assistant in the loop at
+    /// all, so without this kind the model would not apply to half of DOC-45's
+    /// declared scope.
+    Service(ServiceId),
+}
+
+impl fmt::Display for Principal {
+    /// Render the full shape — no redaction, because there is nothing to
+    /// redact (`C-1.8`).
+    /// Test: `tests::principal_renders_its_full_shape`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Operator => f.write_str("operator"),
+            Self::Service(id) => write!(f, "service:{id}"),
+        }
+    }
+}
+
+/// A stable identifier for a [`Principal::Service`].
+///
+/// Why: "stable" is the load-bearing word — a grant is issued against it and
+/// must survive a restart, so it cannot be a PID or a session id.
+/// What: a validated newtype over the same lowercase-kebab grammar
+/// [`super::CredentialRef`] uses, so a service id cannot carry secret material
+/// into an audit record either.
+/// Test: `tests::service_id_rejects_out_of_grammar_text`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct ServiceId(String);
+
+impl ServiceId {
+    /// Validate and wrap a service identifier.
+    ///
+    /// What: accepts `[a-z0-9]([a-z0-9-]*[a-z0-9])?`, at most 32 bytes —
+    /// reusing [`super::CredentialRef`]'s segment grammar so the two cannot
+    /// drift.
+    /// Test: `tests::service_id_rejects_out_of_grammar_text`.
+    pub fn parse(text: &str) -> Result<Self, CredentialRefError> {
+        // A single-segment ref is exactly the grammar a service id needs;
+        // routing through it keeps one validator rather than two.
+        let as_ref = super::CredentialRef::parse(text)?;
+        if as_ref.qualifier().is_some() {
+            return Err(CredentialRefError::Shape);
+        }
+        Ok(Self(text.to_string()))
+    }
+
+    /// The identifier as a string slice.
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for ServiceId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// The read/write dimension of a [`Scope`] (`C-3.8`).
+///
+/// Why: DOC-45 `C-3.10` exists because a false read-only claim has already been
+/// shipped in this repo and caught. Making read-vs-write a required, typed part
+/// of every resolution is the smallest thing that stops the next one.
+/// Test: `tests::scope_read_is_covered_by_write`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Access {
+    /// Read-only use of the credential.
+    Read,
+    /// Read and write.
+    Write,
+}
+
+/// What a resolution asks for, and what a grant permits (`C-3.8`).
+///
+/// Why: `C-3.9` requires scope to be checked **at the point of resolution**,
+/// before any secret is materialised — so the scope has to be an argument to
+/// `resolve`, not something the caller applies afterwards. It is also the
+/// argument that makes eager, config-load-time resolution unnatural: at config
+/// load there is no answer to "what am I about to do with this".
+///
+/// What: an [`Access`] level plus zero or more provider-native scope strings
+/// (OAuth scopes, where the provider expresses them).
+///
+/// Test: `tests::scope_read_is_covered_by_write`,
+/// `tests::provider_scopes_must_all_be_covered`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Scope {
+    access: Access,
+    provider_scopes: Vec<String>,
+}
+
+impl Scope {
+    /// A read-only scope with no provider-native scopes.
+    pub fn read() -> Self {
+        Self {
+            access: Access::Read,
+            provider_scopes: Vec::new(),
+        }
+    }
+
+    /// A read-write scope with no provider-native scopes.
+    pub fn write() -> Self {
+        Self {
+            access: Access::Write,
+            provider_scopes: Vec::new(),
+        }
+    }
+
+    /// Attach provider-native scope strings (OAuth scopes).
+    ///
+    /// Test: `tests::provider_scopes_must_all_be_covered`.
+    pub fn with_provider_scopes<I, S>(mut self, scopes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.provider_scopes = scopes.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// The read/write dimension.
+    pub fn access(&self) -> Access {
+        self.access
+    }
+
+    /// The provider-native scope strings, if any.
+    pub fn provider_scopes(&self) -> &[String] {
+        &self.provider_scopes
+    }
+
+    /// Whether a grant at `self` covers a request for `requested`.
+    ///
+    /// Why: #4566 needs one definition of "covers" or the floor and the grant
+    /// check will disagree. Defining it next to the type, before there is an
+    /// ACL to use it, is what stops a second definition appearing inside the
+    /// ACL later.
+    /// What: `Write` covers `Read`; `Read` does not cover `Write`; and every
+    /// provider-native scope the request names must appear in the grant. An
+    /// empty grant scope list means "no provider-native scopes granted", so it
+    /// covers only a request that names none — the fail-closed reading, matching
+    /// `C-3.2`.
+    /// Test: `tests::scope_read_is_covered_by_write`,
+    /// `tests::provider_scopes_must_all_be_covered`.
+    pub fn covers(&self, requested: &Scope) -> bool {
+        if requested.access == Access::Write && self.access == Access::Read {
+            return false;
+        }
+        requested
+            .provider_scopes
+            .iter()
+            .all(|s| self.provider_scopes.contains(s))
+    }
+}
+
+impl fmt::Display for Scope {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let access = match self.access {
+            Access::Read => "read",
+            Access::Write => "write",
+        };
+        if self.provider_scopes.is_empty() {
+            f.write_str(access)
+        } else {
+            write!(f, "{access}[{}]", self.provider_scopes.join(" "))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Why: `C-1.8` — a `Principal` must render its full shape, because the
+    /// audit record (#4567) places it verbatim and a redacted principal is an
+    /// unattributable record.
+    /// Test: itself.
+    #[test]
+    fn principal_renders_its_full_shape() {
+        assert_eq!(Principal::Operator.to_string(), "operator");
+        let svc = Principal::Service(ServiceId::parse("trusty-search").unwrap());
+        assert_eq!(svc.to_string(), "service:trusty-search");
+        assert!(format!("{svc:?}").contains("trusty-search"));
+    }
+
+    /// Why: a service id lands in the audit stream, so it is held to the same
+    /// grammar as a `CredentialRef` — an unvalidated one would be a second door
+    /// for arbitrary text into a retained stream (`C-7.3`).
+    /// Test: itself.
+    #[test]
+    fn service_id_rejects_out_of_grammar_text() {
+        assert!(ServiceId::parse("trusty-search").is_ok());
+        assert!(ServiceId::parse("Trusty-Search").is_err());
+        assert!(ServiceId::parse("trusty_search").is_err());
+        assert!(ServiceId::parse("").is_err());
+        // A qualified path is a CredentialRef shape, not a service id.
+        assert_eq!(
+            ServiceId::parse("trusty/search").unwrap_err(),
+            CredentialRefError::Shape
+        );
+    }
+
+    /// Why: pins the asymmetry — a write grant satisfies a read request, never
+    /// the reverse. Getting this backwards would silently hand write-capable
+    /// credentials to read-only consumers, the exact defect `C-3.10` names.
+    /// Test: itself.
+    #[test]
+    fn scope_read_is_covered_by_write() {
+        assert!(Scope::write().covers(&Scope::read()));
+        assert!(Scope::write().covers(&Scope::write()));
+        assert!(Scope::read().covers(&Scope::read()));
+        assert!(!Scope::read().covers(&Scope::write()));
+    }
+
+    /// Why: an empty grant scope list must not read as "all scopes" — the
+    /// fail-closed reading, matching `C-3.2`'s default-deny posture.
+    /// Test: itself.
+    #[test]
+    fn provider_scopes_must_all_be_covered() {
+        let granted = Scope::read().with_provider_scopes(["gmail.readonly", "calendar.readonly"]);
+        assert!(granted.covers(&Scope::read().with_provider_scopes(["gmail.readonly"])));
+        assert!(granted.covers(&Scope::read()));
+        assert!(!granted.covers(&Scope::read().with_provider_scopes(["drive.readonly"])));
+        assert!(!Scope::read().covers(&Scope::read().with_provider_scopes(["gmail.readonly"])));
+        assert_eq!(
+            Scope::read()
+                .with_provider_scopes(["gmail.readonly"])
+                .to_string(),
+            "read[gmail.readonly]"
+        );
+    }
+}

--- a/crates/trusty-common/src/credentials/secret.rs
+++ b/crates/trusty-common/src/credentials/secret.rs
@@ -1,0 +1,328 @@
+//! [`Secret`] — the wrapper a resolved credential is returned in, and the
+//! reason a resolved credential cannot be stored, serialised, or printed
+//! (issue #4565, DOC-45 `C-8.2`/`C-8.3`).
+//!
+//! # Spec References
+//!
+//! - [`SPEC-CREDAUTH-08~draft`](docs/specs/DOC-45-credential-authority-model.md#SPEC-CREDAUTH-08~draft)
+//!
+//! Why: redaction that a call site has to remember is redaction that eventually
+//! does not happen. `C-8.2` therefore requires the *type* to be unable to
+//! render its value, and `C-8.3` requires a resolved credential never to be
+//! returned by value from a function whose result is serialised into a
+//! `ToolResult` — "where the type system permits, pinned at compile time
+//! rather than by review". This module is that pin.
+//!
+//! What: [`Secret`] renders a **constant** in `Debug`/`Display` — not a
+//! truncated preview, not a length, nothing derived from the value at all — and
+//! deliberately implements **neither** `Serialize`, `Deserialize`, `Clone`,
+//! `Deref`, `PartialEq`, nor `AsRef`. Each omission is load-bearing; see
+//! [`Secret`]'s own docs. The value is reachable only through the named,
+//! greppable [`Secret::expose`].
+//!
+//! Relationship to [`crate::inference::types::SecretString`]: that type came
+//! first (#2402) and renders a four-character head preview via
+//! [`super::redact_secret`], which does **not** satisfy `C-8.2`'s "contains no
+//! substring of the wrapped value". It also derives `Clone` and `PartialEq`,
+//! which `Secret` deliberately does not, so it cannot simply become an alias.
+//! [`SecretString::into_secret`](crate::inference::types::SecretString::into_secret)
+//! converts one to the other; collapsing the two is deliberately left to a
+//! follow-up because it requires changing an existing test that pins the older
+//! type's leakier `Debug` shape.
+//!
+//! Test: `tests::debug_and_display_are_value_independent`,
+//! `tests::rendering_contains_no_substring_of_the_value`,
+//! `tests::expose_returns_the_raw_value`, and the compile-time assertions in
+//! `not_serialize_not_clone`.
+
+use std::fmt;
+
+/// The exact text [`Secret`] renders in `Debug` and `Display`.
+///
+/// Why: a single constant makes "the rendered form is independent of the value"
+/// checkable by inspection as well as by test.
+const REDACTED: &str = "Secret(<redacted>)";
+
+/// A resolved credential. Never prints, never serialises, never clones.
+///
+/// Why: the resolved value is the one thing in this subsystem whose accidental
+/// disclosure is unrecoverable. Every capability this type *lacks* is a leak
+/// path it closes:
+///
+/// | Not implemented | What it would let you do |
+/// |---|---|
+/// | `Serialize` / `Deserialize` | put a secret in a config row, a store row, or a `ToolResult` — `C-8.1`, `C-8.3` |
+/// | `Clone` | duplicate one into a long-lived struct, defeating `C-8.4`'s bounded window |
+/// | `Deref` / `AsRef` | expose the value implicitly, with no greppable call site |
+/// | `PartialEq` | compare a secret in non-constant time, and encourage secrets as map keys |
+/// | a value-derived `Debug`/`Display` | leak a prefix into a log, which is `SecretString`'s existing shortfall |
+///
+/// The single omission that matters most is `Serialize`: because every config
+/// struct in this workspace derives it, a `Secret` **cannot compile** inside
+/// one. That is what makes "a config row holds a [`super::CredentialRef`], not
+/// a credential" (`C-8.8`) structural rather than aspirational.
+///
+/// What: a transparent wrapper over `T` with hand-written `Debug`/`Display`
+/// that render [`REDACTED`] and read nothing from the value. Constructed by
+/// [`Secret::new`], read by [`Secret::expose`].
+///
+/// Test: `tests::debug_and_display_are_value_independent`,
+/// `tests::rendering_contains_no_substring_of_the_value`,
+/// `tests::expose_returns_the_raw_value`.
+pub struct Secret<T>(T);
+
+impl<T> Secret<T> {
+    /// Wrap a resolved credential value.
+    ///
+    /// Why: one constructor, so every secret enters the type through one door.
+    /// Test: `tests::expose_returns_the_raw_value`.
+    pub fn new(value: T) -> Self {
+        Self(value)
+    }
+
+    /// Borrow the raw value.
+    ///
+    /// Why: authentication needs the actual bytes. The explicit, greppable name
+    /// documents the deliberate exposure at the call site — which is exactly
+    /// what a `Deref` impl would have hidden. Returns a **borrow**, so using a
+    /// secret does not hand the caller an owned copy to stash.
+    /// Test: `tests::expose_returns_the_raw_value`.
+    pub fn expose(&self) -> &T {
+        &self.0
+    }
+
+    /// Consume the wrapper and return the raw value.
+    ///
+    /// Why: an adapter that must own its credential (an HTTP client built once
+    /// per call) would otherwise clone through `expose`, and a clone with no
+    /// wrapper is worse than a move. Consuming `self` keeps the count of live
+    /// copies at one.
+    /// Test: `tests::into_inner_moves_the_value`.
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<T> fmt::Debug for Secret<T> {
+    /// Render [`REDACTED`], reading nothing from the value.
+    ///
+    /// Why: `C-8.2`. Note the absence of a `T: Debug` bound — the impl *cannot*
+    /// consult the value even if it wanted to, which is a stronger statement
+    /// than an impl that chooses not to.
+    /// Test: `tests::debug_and_display_are_value_independent`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+impl<T> fmt::Display for Secret<T> {
+    /// Render [`REDACTED`], reading nothing from the value.
+    ///
+    /// Why: `Display` is the surface most likely to reach a user-facing message
+    /// or a `format!` in a log; it must be as blind as `Debug`.
+    /// Test: `tests::debug_and_display_are_value_independent`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(REDACTED)
+    }
+}
+
+/// Compile-time proof that [`Secret`] implements neither `Serialize` nor
+/// `Clone` (DOC-45 `C-8.3`, #4565 acceptance criterion 3).
+///
+/// Why: "a resolved credential is never returned by value from a function whose
+/// result is `Serialize`" cannot be asserted by a runtime test — by the time a
+/// test could observe the leak, the impl exists. Rust has no `!Trait` bound, so
+/// this uses coherence instead: a blanket impl over every `T: Serialize` plus a
+/// concrete impl for `Secret<String>` can only coexist while `Secret<String>`
+/// does **not** implement `Serialize`. The day someone adds `#[derive(Serialize)]`
+/// the two impls overlap and the crate fails to build with E0119.
+///
+/// What: for each trait, two blanket impls of a private helper — one
+/// unconditional, one bounded by the trait under test. Resolving
+/// `<Secret<String> as AmbiguousIfImpl<_>>` picks the unconditional impl while
+/// `Secret<String>` lacks the trait; the moment it gains the trait both impls
+/// apply, inference becomes ambiguous, and the build fails. (This is the
+/// mechanism behind `static_assertions::assert_not_impl_all!`, inlined rather
+/// than adding a dependency for two assertions.)
+/// Test: compiling this module is the test. `tests::compile_time_assertions_hold`
+/// records that in the test list so a reader learns the assertions exist.
+mod not_serialize_not_clone {
+    use super::Secret;
+
+    /// `C-8.3`: a resolved credential must never be `Serialize`, because every
+    /// config struct and every `ToolResult` in this workspace derives it.
+    const _ASSERT_NOT_SERIALIZE: fn() = || {
+        trait AmbiguousIfImpl<A> {
+            fn some_item() {}
+        }
+        impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+        impl<T: ?Sized + serde::Serialize> AmbiguousIfImpl<u8> for T {}
+        let _ = <Secret<String> as AmbiguousIfImpl<_>>::some_item;
+    };
+
+    /// `C-8.4`: not `Clone`, so a resolved credential cannot be duplicated into
+    /// a longer-lived home than the call that resolved it.
+    const _ASSERT_NOT_CLONE: fn() = || {
+        trait AmbiguousIfImpl<A> {
+            fn some_item() {}
+        }
+        impl<T> AmbiguousIfImpl<()> for T {}
+        impl<T: Clone> AmbiguousIfImpl<u8> for T {}
+        let _ = <Secret<String> as AmbiguousIfImpl<_>>::some_item;
+    };
+
+    /// `C-8.1`: not `Deserialize` either, so a hand-edited config cannot
+    /// construct one — the reverse of the `Serialize` door.
+    const _ASSERT_NOT_DESERIALIZE: fn() = || {
+        trait AmbiguousIfImpl<A> {
+            fn some_item() {}
+        }
+        impl<T: ?Sized> AmbiguousIfImpl<()> for T {}
+        impl<T: serde::de::DeserializeOwned> AmbiguousIfImpl<u8> for T {}
+        let _ = <Secret<String> as AmbiguousIfImpl<_>>::some_item;
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A spread of realistic credential shapes: long, short, high-entropy,
+    /// low-entropy, non-ASCII, and empty. `C-8.2` says "property-tested"; this
+    /// is the input set the two properties below are quantified over.
+    fn specimens() -> Vec<String> {
+        let mut v: Vec<String> = [
+            "",
+            "a",
+            "ab",
+            "secret",
+            // pragma: allowlist secret
+            "ghp_16C7e42F292c6912E7710c838347Ae178B4a",
+            // pragma: allowlist secret
+            concat!("xo", "xb", "-2314151234-2321313111-QwErTyUiOpAsDf"),
+            // pragma: allowlist secret
+            "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.dBjftJeZ4CVP",
+            // pragma: allowlist secret
+            "-----BEGIN RSA PRIVATE KEY-----\nMIIEow==\n",
+            "パスワード",
+            "Secret(<redacted>)",
+        ]
+        .iter()
+        .map(|s| s.to_string())
+        .collect();
+        // Deterministic pseudo-random values, so the property is quantified
+        // over more than a hand-picked table without adding a proptest dep.
+        let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+        for len in 1..=64 {
+            let mut s = String::with_capacity(len);
+            for _ in 0..len {
+                state = state.wrapping_mul(6364136223846793005).wrapping_add(1);
+                let byte = ((state >> 33) % 94) as u8 + 33; // printable ASCII
+                s.push(byte as char);
+            }
+            v.push(s);
+        }
+        v
+    }
+
+    /// Why: the strongest possible statement of `C-8.2` — not "the rendering
+    /// omits the value" but "the rendering does not *depend* on the value at
+    /// all". If two secrets with nothing in common render identically, no
+    /// information about either can have survived.
+    /// Test: itself.
+    #[test]
+    fn debug_and_display_are_value_independent() {
+        let baseline_debug = format!("{:?}", Secret::new(String::new()));
+        let baseline_display = format!("{}", Secret::new(String::new()));
+        for value in specimens() {
+            let s = Secret::new(value.clone());
+            assert_eq!(
+                format!("{s:?}"),
+                baseline_debug,
+                "Debug varied with the value: {value:?}"
+            );
+            assert_eq!(
+                format!("{s}"),
+                baseline_display,
+                "Display varied with the value: {value:?}"
+            );
+        }
+    }
+
+    /// Why: `C-8.2` as literally written — "the rendered form contains no
+    /// substring of it". Quantified over every contiguous substring of length
+    /// ≥ 3 of every credential-shaped specimen.
+    ///
+    /// Two exclusions, both deliberate and both necessary for the property to
+    /// mean anything. Specimens shorter than 8 characters are dropped: they are
+    /// not credential-shaped, and `C-8.2` is about credentials. And a candidate
+    /// that already appears in the rendering of the *empty* secret is exempt:
+    /// the constant `Secret(<redacted>)` contains `ecr`, so an English word
+    /// like `secret` trips a naive version of this assertion without anything
+    /// having leaked. The exemption is what keeps the test measuring
+    /// disclosure rather than coincidence — and
+    /// `debug_and_display_are_value_independent` is the stronger property that
+    /// makes the exemption safe, since a rendering that never varies with the
+    /// value cannot be disclosing it.
+    /// Test: itself.
+    #[test]
+    fn rendering_contains_no_substring_of_the_value() {
+        const MIN_DISCLOSURE_LEN: usize = 3;
+        const MIN_CREDENTIAL_LEN: usize = 8;
+        let baseline = format!("{:?} {}", Secret::new(String::new()), Secret::new(""));
+        for value in specimens() {
+            let chars: Vec<char> = value.chars().collect();
+            if chars.len() < MIN_CREDENTIAL_LEN {
+                continue;
+            }
+            let rendered = format!("{:?} {}", Secret::new(value.clone()), Secret::new(&value));
+            for start in 0..chars.len() {
+                for end in (start + MIN_DISCLOSURE_LEN)..=chars.len() {
+                    let candidate: String = chars[start..end].iter().collect();
+                    if baseline.contains(&candidate) {
+                        continue; // present regardless of the value; not disclosure
+                    }
+                    assert!(
+                        !rendered.contains(&candidate),
+                        "rendering {rendered:?} disclosed {candidate:?} from {value:?}"
+                    );
+                }
+            }
+        }
+    }
+
+    /// Why: `expose` is the one sanctioned path back to the raw value, and it
+    /// must be lossless — a redacting accessor would be worse than none.
+    /// Test: itself.
+    #[test]
+    fn expose_returns_the_raw_value() {
+        // pragma: allowlist secret
+        let s = Secret::new("raw-key".to_string());
+        assert_eq!(s.expose(), "raw-key");
+        let bytes = Secret::new(vec![1u8, 2, 3]);
+        assert_eq!(bytes.expose(), &[1u8, 2, 3]);
+    }
+
+    /// Why: `into_inner` must move rather than copy, keeping the number of live
+    /// copies at one — the point of not deriving `Clone`.
+    /// Test: itself.
+    #[test]
+    fn into_inner_moves_the_value() {
+        // pragma: allowlist secret
+        let s = Secret::new("raw-key".to_string());
+        assert_eq!(s.into_inner(), "raw-key");
+    }
+
+    /// Why: names the compile-time assertions so a reader of the test list
+    /// learns they exist. The assertion itself is structural — if
+    /// `Secret<String>` ever gains `Serialize`, `Deserialize`, or `Clone`,
+    /// `super::not_serialize_not_clone` fails to compile and this test never
+    /// runs at all.
+    /// Test: itself, plus compilation of `super::not_serialize_not_clone`.
+    #[test]
+    fn compile_time_assertions_hold() {
+        // Reaching this line at all means the crate compiled, which means the
+        // three ambiguity assertions in `not_serialize_not_clone` resolved.
+        assert_eq!(REDACTED, "Secret(<redacted>)");
+    }
+}

--- a/crates/trusty-common/src/inference/types/secret.rs
+++ b/crates/trusty-common/src/inference/types/secret.rs
@@ -11,12 +11,23 @@
 //! redacted preview from [`crate::credentials::redact_secret`]. It
 //! does NOT derive `Serialize`, so it can never be written to the wire. The raw
 //! value is reachable only via the explicit [`SecretString::expose`] method.
+//!
+//! **Superseded by [`crate::credentials::Secret`] (#4565).** That type is the
+//! canonical credential wrapper going forward and is strictly stricter: its
+//! `Debug`/`Display` are *value-independent* (this type discloses a
+//! four-character head preview, which does not meet DOC-45 `C-8.2`'s "contains
+//! no substring of the wrapped value"), and it implements neither `Clone` nor
+//! `Deserialize`. `SecretString` cannot simply become an alias for it: the
+//! inference stack relies on `Clone`/`PartialEq`, and the preview shape is
+//! pinned by this module's own `secret_debug_is_redacted`. Collapsing the two
+//! is therefore a deliberate follow-up, not a side effect of #4565.
+//! [`SecretString::into_secret`] is the one-line migration.
 //! Test: inline `tests` — `secret_debug_is_redacted`, `secret_display_is_redacted`,
-//! `secret_expose_returns_raw`.
+//! `secret_expose_returns_raw`, `secret_string_converts_to_the_canonical_secret`.
 
 use std::fmt;
 
-use crate::credentials::redact_secret;
+use crate::credentials::{Secret, redact_secret};
 
 /// A string credential that redacts itself in `Debug`/`Display`.
 ///
@@ -51,6 +62,18 @@ impl SecretString {
     /// Test: `secret_expose_returns_raw`.
     pub fn expose(&self) -> &str {
         &self.0
+    }
+
+    /// Convert into the canonical [`Secret`] wrapper (#4565).
+    ///
+    /// Why: the migration path off this type. `Secret<String>` is strictly
+    /// stricter — value-independent rendering, no `Clone`, no `Deserialize` —
+    /// so this conversion only ever tightens the guarantees; there is
+    /// deliberately no conversion in the other direction.
+    /// What: moves the wrapped string into a `Secret`.
+    /// Test: `secret_string_converts_to_the_canonical_secret`.
+    pub fn into_secret(self) -> Secret<String> {
+        Secret::new(self.0)
     }
 }
 
@@ -110,5 +133,26 @@ mod tests {
     fn secret_expose_returns_raw() {
         let s = SecretString::new("raw-key"); // pragma: allowlist secret
         assert_eq!(s.expose(), "raw-key");
+    }
+
+    /// Why: the migration path off this type must be lossless, and the
+    /// conversion must actually *tighten* the rendering — the head preview this
+    /// type discloses (see `secret_debug_is_redacted` above) must be gone once
+    /// the value is in a `Secret`.
+    /// Test: itself.
+    #[test]
+    fn secret_string_converts_to_the_canonical_secret() {
+        let s = SecretString::new("sk-or-verysecretvalue1234"); // pragma: allowlist secret
+        let leaky = format!("{s:?}");
+        assert!(
+            leaky.contains("sk-o"),
+            "precondition: this type leaks a head"
+        );
+
+        let tightened = s.into_secret();
+        assert_eq!(tightened.expose(), "sk-or-verysecretvalue1234");
+        let rendered = format!("{tightened:?} {tightened}");
+        assert!(!rendered.contains("sk-o"), "head survived: {rendered}");
+        assert!(!rendered.contains("verysecretvalue"), "leaked: {rendered}");
     }
 }


### PR DESCRIPTION
Closes #4565. Parent epic #4040. **Stacked on #4627** (`feat/4564-credentials-module`) — that PR must land first; this one is based on its branch so the diff below is only #4565's work.

Built against **DOC-45** §4 (`CredentialRef`), §7 (denial taxonomy) and §10 (`Secret`, delivery), and **ADR-0026**.

## The gap this closes

`credential_ref` had **zero hits** under `crates/*/src/**` despite being an acceptance bullet of epic #2808, closed `COMPLETED`. Without a reference type, anything that needs to *refer* to a credential has to *hold* one — which is why `McpService.env` is a `HashMap<String, String>` of literal API keys in a hand-editable `~/.trusty-agents/config.toml`, and why DOC-63 `S-5.6`'s "no secrets in the assistant home" is a rule people remember rather than a property of the types.

## What landed

### `CredentialRef` — the handle (`C-2.1`–`C-2.7`)

`provider` or `provider/qualifier`. Lowercase-kebab segments, at most one `/`, ≤ 64 bytes total and ≤ 32 per segment. `Display` renders it **verbatim** (`C-2.6`) — the deliberate opposite of `Secret`, and the contrast is the design: the handle prints, the value never does.

The grammar is `C-2.4`'s "restrictive enough that no realistic API key, JWT, OAuth token, or PEM body can satisfy it". `realistic_credentials_are_rejected_by_the_grammar` pins that against ten specimens shaped like the real formats this registry names — GitHub classic and fine-grained PATs, OpenAI, Slack bot and app, Telegram, Brave, a JWT, a PEM body, a Google OAuth secret. Every one is rejected by uppercase, `_`, `.`, `:`, a newline, or length.

**Stated honestly:** the grammar excludes every credential format in the workspace's census, which is exactly `C-2.4`'s claim. It is not a proof against a *deliberately chosen* lowercase-hex string ≤ 64 chars. The property it buys is that a secret cannot be laundered into a ref — and thence into a retained audit stream (`C-7.3`) — by accident.

Shape-agnostic (`C-2.5`): one type, no `Kind`, no `is_oauth()`, no second constructor. DOC-63 §7.1b item 5 warns the API-key shape is the one likely to be special-cased; `oauth_and_api_key_shapes_resolve_through_one_entry_point` resolves `google-oauth` and `brave` through one call with one argument list.

### `Secret<T>` — the value (`C-8.2`, `C-8.3`)

**Redaction proof.** Two properties, because the literal acceptance criterion is weaker than what is actually true here:

1. `debug_and_display_are_value_independent` — the strongest form. `Debug`/`Display` render a **constant**, and the impls carry **no `T: Debug` bound**, so they *cannot* consult the value even in principle. Quantified over 74 specimens (realistic credential formats, non-ASCII, empty, and 64 deterministic pseudo-random printable-ASCII strings of length 1–64): every one renders byte-identically to the empty secret. A rendering that never varies with the value cannot be disclosing it.
2. `rendering_contains_no_substring_of_the_value` — `C-8.2` as literally written, over every contiguous substring of length ≥ 3 of every credential-shaped (≥ 8 char) specimen. Two documented exclusions: sub-8-char specimens are not credential-shaped, and a candidate already present in the rendering of the *empty* secret is exempt — the constant `Secret(<redacted>)` contains `ecr`, so the English word `secret` trips a naive version of this without anything having leaked. The exemption keeps the test measuring disclosure rather than coincidence, and property 1 is what makes it safe.

`Secret` implements **neither** `Serialize`, `Deserialize`, `Clone`, `Deref`, `AsRef`, nor `PartialEq`. Each omission closes a leak path; the table in its doc comment says which.

**Three compile-time assertions** (`not_serialize_not_clone`) use the `assert_not_impl` coherence trick — inlined rather than adding a dependency for three assertions — so the build fails the day `Secret<String>` gains `Serialize`, `Deserialize`, or `Clone`. That is #4565's acceptance criterion 3 and DOC-45 `C-8.3`'s "pinned at compile time rather than by review". **Verified by perturbation**, not just asserted: adding `impl Clone for Secret<String>` and `impl Serialize for Secret<String>` produces two `E0283 type annotations needed` / `multiple impls satisfying … AmbiguousIfImpl` errors and the crate does not build (output in the first comment).

### How resolve-at-use-time is *enforced*, not merely enabled

This is the question the brief asked to be answered explicitly. Four mechanisms, in descending order of how hard they are to work around:

1. **A config struct cannot hold the result.** `Secret` is not `Serialize`/`Deserialize`, and every config type in this workspace derives both, so a `Secret` field **fails to compile** inside one. The only credential-shaped thing a config row *can* hold is a `CredentialRef` — which is `C-8.8` made structural. Backed by the compile-time assertion above, so this cannot regress silently.
2. **The result cannot be duplicated into a longer-lived home.** Not `Clone`; `expose()` returns a **borrow**, not an owned `String`. Caching a resolved credential is a deliberate `into_inner()` move, not an accidental `.clone()`.
3. **Resolution needs facts a config loader does not have.** `resolve` takes a `Principal` and a `Scope` — *who is acting* and *what for*. Neither is answerable at config-load time: a loader has no principal in hand and no operation in flight. The eager call is not discouraged by convention, it has no arguments.
4. **The caller can avoid seeing the value at all.** `resolve_client::<T: FromCredential>` resolves, lends the `Secret` by reference to the builder, and drops it before returning — so a source type receives *"a resolved, scoped client and nothing else"* (`C-3.4`, DOC-63 `S-5.1`). A caller that never sees the string cannot leak the string.

### `CredentialError` — five variants (`C-5.1`–`C-5.10`)

`Missing` / `Denied` / `Expired` / `ZeroScope` / `ScopeUnavailable`. All recoverable (`C-3.11`), all matchable structurally rather than by string comparison (`C-5.8`), all naming the principal and the ref in an actionable remediation (`C-5.7`), and none able to carry secret material — **by construction**, since every field is a `CredentialRef`, a `Principal`, or a `Scope` and none of the three can hold a value (`C-5.9`).

The fifth variant is DOC-45 `C-5.5`'s deliberate addition to #4040's stated four, kept distinct from `ZeroScope` by `C-5.6` because "widen the grant" is advice that cannot be followed for a provider with no such scope, and the workaround is to grant write.

### `Principal` / `Scope` — the vocabulary, deliberately inert

`Principal` is a closed, `#[non_exhaustive]` enumeration (`C-1.7`) carrying **`Operator` and `Service` only**. DOC-45 `C-1.3` is PROVISIONAL pending owner **Q-B** and says in terms: *"Do not implement `Principal`'s `Assistant` variant until Q-B is answered"*, and `C-12.1` repeats it as a delivery rule. `#[non_exhaustive]` means #4566 adds `Assistant` and `SubAgent` without a breaking change.

`Scope::covers` is defined here, before there is an ACL to use it, specifically so a second definition does not appear inside #4566's grant check. Write covers read; read does not cover write; an empty provider-scope list covers only a request naming none (the fail-closed reading).

## Honesty clause — what this PR does NOT do

**There is no authorization here.** `resolve` accepts a `Principal` and checks **no grant** against it. Grants, the ACL, default-deny, and the code-owned floor are #4566 (DOC-45 §5). Today's behaviour is byte-for-byte what `resolve_key` already does: the three storage tiers answer, and any caller that can reach the function gets the value. `C-3.12` says the same about default-deny at large — it is not airtight until #4571 migrates the 55 raw `std::env::var` reads.

What #4565 buys is that **the signature will not change** when #4566 lands: the grant check goes inside `resolve`, between the registry check and the store lookup, at the marked line. No consumer is migrated twice.

Nothing here touches at-rest storage (#4570), the audit trail (#4567), `McpService.env` (#4568), or consumer migration (#4571).

## `SecretString` — the one thing I did not do, and why

The issue says to *"extend or fold in"* `inference::types::SecretString` rather than write a second wrapper. I extended it (`into_secret()`, superseded-by docs) but did **not** fold it in, and this is a deliberate stop rather than an omission:

- `SecretString`'s `Debug`/`Display` disclose a **four-character head preview** via `redact_secret`. That does not meet `C-8.2`'s "no substring of the wrapped value", so it cannot become a `Secret<String>` alias without changing behaviour.
- That preview shape is pinned by an **existing test**, `secret_debug_is_redacted`, which asserts `dumped.contains("chars")`. Collapsing the types requires changing that test.
- `SecretString` also derives `Clone` and `PartialEq`, which the inference stack relies on across `ResolvedProvider` and every provider adapter, and which `Secret` deliberately does not have.

The brief's standing instruction is to stop and report rather than weaken or rewrite an existing test, so I did. `secret_string_converts_to_the_canonical_secret` documents the divergence executably: it asserts the old type *does* leak a head, then asserts the head is gone once converted. **This is a real pre-existing leak** — every `ResolvedProvider` debug dump prints the first four characters of the live API key — and it wants its own ticket.

## Public API

- **Added:** `credentials::{CredentialRef, CredentialRefError, Secret, CredentialError, Principal, ServiceId, Scope, Access, FromCredential, resolve, resolve_with, resolve_client, resolve_client_with}`; `credentials::authority`; `SecretString::into_secret`.
- **Breaking:** none.

## Gates

All run on the final head. Raw output in the first comment.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
