### PR TITLE
docs: per-workstream worktrees, Rust issue boundaries, and the crate-scoped test ladder

### DIFF
--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -121,7 +121,119 @@ Most match (e.g. `crates/trusty-search/` → `-p trusty-search`) but note these 
 
 Always verify the `name` field in the crate's `Cargo.toml` if you get a "package not found" error.
 
+## Rust Test Ladder — how much testing this change needs
+
+🔴 **This ladder is the authoritative answer to "how much testing does this
+change need" for this repo.** Run the smallest deterministic gate that covers the
+change's blast radius — no less, and no more. The framework's phase-entry table
+labels a change Low / Normal / High risk; those labels map onto the rungs below
+(rungs 1–2 = Low, 3–4 = Normal, 5–6 = High). The framework does not carry a
+competing Rust matrix: when the question is *which command to run*, this table
+decides.
+
+Required tests stay in the implementation PR (`tm-pr-workflow`, "One Outcome,
+One PR"). Name the rung and paste its command in the PR body so a reviewer can
+see which rung was actually run.
+
+| # | Change class | Risk | Development proof | PR gate — the command to run | Hardening / release gate |
+|---|---|---|---|---|---|
+| 1 | Docs, comments, changelog fragments only | Low | Read the rendered file | `bash scripts/check_sld.sh` (plus `check_doc_numbers.sh` / `check_line_cap.sh` if those surfaces were touched). No Cargo test by default. | CI required checks only |
+| 2 | Test-only stabilization — flake fix, fixture, test harness | Low | Fail-before / pass-after, repeated: `cargo test -p <crate> <test> -- --exact --nocapture` run ~10× | `cargo fmt --check` && `cargo test -p <crate>`; add `-- --test-threads=1` when the flake is isolation-shaped | `cargo test --workspace` **only** when shared test infrastructure changed |
+| 3 | Localized behavior inside one crate | Normal | One targeted regression test that provably fails before the change | `cargo fmt --check` && `cargo check -p <crate>` && `cargo clippy -p <crate> -- -D warnings` && `cargo test -p <crate>` | Workspace gate only when release policy requires it |
+| 4 | **Cross-crate change** — public API or shared library (`trusty-common`, `trusty-embedderd`, …) | Normal → High | Targeted regression plus `cargo test -p <lib>` | rung 3 for the library, then `cargo check --workspace` && `cargo test -p <consumer>` for **each direct dependent** | `cargo test --workspace` && `cargo clippy --workspace --all-targets -- -D warnings` at HARDEN/release |
+| 5 | Cross-crate contract, persistence, security, process lifecycle, **release tooling** | High | Targeted plus failure-path and concurrency tests | rung 4, plus `cargo test -p <crate> -- --include-ignored` for gated integration coverage, plus an adversarial review round (`code-critic`) | full workspace, `cargo audit`, and for release tooling `scripts/check-publish-ready.sh <crate>` && `scripts/preflight-publish.sh <crate>` |
+| 6 | **UI / API surface** — Svelte UIs, MCP tool schemas, HTTP routes | High | Rust crate tests **plus** direct UI/API evidence (curl the route, call the MCP tool, load the page) | rung 3 or 4 for the Rust side, plus `pnpm -C crates/<crate>/ui test` (where the package defines one; otherwise `… build`) and one smoke run of the binary | full product/e2e gate plus `cargo test -- --include-ignored` when hardening |
+
+🔴 **`cargo test --workspace` is not the default inner-loop proof for a localized
+change.** It belongs at the hardening boundaries (rungs 4–6). Making every narrow
+PR depend on the whole workspace turns unrelated flakes into an issue factory
+without adding one line of coverage for your change.
+
+🔴 **Scope down, never scope away.** Choosing a lower rung is a statement about
+blast radius, and you must be able to prove it (see the baseline-failure rules
+below). It is never licence to make a red gate green by deleting, `#[ignore]`-ing,
+`cfg`-gating, `--exclude`-ing, or `--lib`-narrowing coverage. That remains the
+hard line it has always been.
+
+**Evidence detail:** a PR body may summarise a **passing** gate as command +
+counts + scope — `cargo test -p trusty-mpm — 214 passed, 0 failed` — because the
+reviewer's question there is which rung ran, not what scrolled past. Raw output
+stays **mandatory** for failures, flakes, performance claims, and disputed
+results, and agent-to-PM reporting keeps raw output in all cases
+(`BASE-AGENT.md`: never summarise test results in your own words).
+
+### Baseline failures — the Rust specifics
+
+The six-step baseline-failure protocol (establish whose red it is, fix if
+branch-caused, append to the canonical issue if tracked, one canonical issue if
+not, and the literal report string) lives in `tm-pr-workflow`. It is **not**
+restated here. What follows is only what that generic version cannot carry.
+
+**Known-environmental on this machine — expect these, do not re-file them:**
+
+| Gate | Where | Why it fails independent of your branch |
+|---|---|---|
+| The `trusty-search` filesystem-watcher tests (~6; the set drifts) | `crates/trusty-search/src/service/watch_loop.rs`, `watcher.rs`, `watcher_manager.rs` | FSEvents delivery on this host is nondeterministic. They fail on any branch, and they still fail under `-- --test-threads=1` — so it is the machine, not parallel-test load |
+| `execute_doctor_against_test_daemon` | `crates/trusty-mpm/src/client/executor/tests.rs` | It takes 9–13 s against a 10 s client timeout, so it loses on timing alone under any load |
+
+🔴 **The correct response is to prove your diff touches zero files in those
+crates — never to `#[ignore]`, `cfg`-gate, or `--exclude` them.** The proof is a
+path list, and empty output is the evidence; paste it in the PR:
+
+```bash
+git diff --name-only origin/main...HEAD -- crates/trusty-search/ \
+                                           crates/trusty-mpm/src/client/
+```
+
+**Telling a pre-existing red from one you caused — crate-scoped confirmation:**
+
+1. **Re-run the failure alone on your branch**, not the whole suite:
+   `cargo test -p <crate> <test> -- --exact --nocapture`. A single named test
+   removes ordering and load from the picture.
+2. **Run the identical command against `origin/main` in a second worktree** —
+   never by mutating the main checkout, and never with `git stash`:
+   ```bash
+   git worktree add .claude/worktrees/baseline-<n> origin/main
+   cd .claude/worktrees/baseline-<n> && cargo test -p <crate> <test> -- --exact
+   ```
+   Failing on both is the evidence that the branch did not cause it.
+3. **Serialize before blaming isolation:** `-- --test-threads=1`. If it still
+   fails serialized, parallel interference is not the explanation and "flaky
+   under load" is the wrong diagnosis.
+4. **Check the path evidence:** `git diff --name-only origin/main...HEAD`. If the
+   failing crate does not appear there, and you did not touch a shared library it
+   depends on, the red is not yours.
+5. 🔴 **The shared-crate caveat:** a green `cargo test -p <your-crate>` does
+   **not** clear you when you changed `trusty-common`, `trusty-embedderd`, or any
+   other shared library. A red in a *dependent* crate is yours until rung 4 of
+   the ladder above says otherwise. This is the one case where scoping down is
+   the wrong instinct.
+
+Report it in the shape `tm-pr-workflow` mandates, naming the crate-scoped gate:
+`change-specific gates pass; cargo test -p trusty-search blocked by canonical
+issue #N`. Never "all tests pass" while a gate is red, whoever caused it.
+
 ## Key Conventions
+
+🔴 **Rust issue boundary — what to search by before filing.** Whether a finding
+earns an issue at all is decided by the **Ticket-Promotion Gate** in the
+framework skill `tm-ticketing` (search first, the five promotion criteria, the
+confidence label, outcome-sized granularity, the six-field schema). That gate is
+not restated here — read it there. What this repo adds is *what to search by*,
+because a Cargo workspace hands you four high-signal keys a generic search
+misses:
+
+| Search key | Example | Why it finds the canonical issue |
+|---|---|---|
+| **Test name** | `execute_doctor_against_test_daemon` | Rust test names are effectively unique and get quoted verbatim in every prior report and CI log |
+| **Panic / error text** | `called Option::unwrap() on a None value`, or a `thiserror` Display string | The literal message is what people paste into issue bodies |
+| **Affected symbol** | `WatcherManager::reconcile` | Survives the file moves and module splits that break any path-based search — and this repo splits modules constantly under the 500-SLOC cap |
+| **Crate** | `-p trusty-search`, `-p tga` | Scopes to the owning workstream; expand abbreviations first (see the table below — `tm` is trusty-memory, not the binary) |
+
+Search **open and recently closed** issues on all four. A repeat failure in the
+same crate is almost always another occurrence of an existing canonical issue:
+append the run URL, SHA, command, and failure signature to that issue rather than
+filing a second one.
 
 🔴 **Why/What/Test doc pattern with proportional depth** — public items carry
 documentation proportional to how surprising the code is. The full three-section
@@ -572,11 +684,38 @@ cd .claude/worktrees/<dirname>
 # … edit, build, test, commit, push from here …
 ```
 
-**End-to-end delivery chain:** spec → issue → worktree branch → PR (linked to issue) → trusty-review gate → squash-merge → worktree cleanup. See `.claude-mpm/INSTRUCTIONS.md` for the full required sequence.
+**End-to-end delivery chain:** accepted outcome → optional issue → worktree
+branch → one cohesive PR → applicable Rust gates → trusty-review gate →
+squash-merge → worktree cleanup. The framework skill `tm-pr-workflow` owns the
+full sequence and the optional-issue rule; this file adds only the Rust-specific
+gates (see the Rust Test Ladder above). *(The pointer here used to name
+`.claude-mpm/INSTRUCTIONS.md`, a path that has never existed in this repo — the
+tracked project-instruction host is this file, `.trusty-mpm/INSTRUCTIONS.md`,
+and the delivery chain itself now lives in `tm-pr-workflow`.)*
 
-Each ticket, refactor, or experiment gets its own worktree. Worktrees are
-disposable — delete them with `git worktree remove --force <path>` once the
-PR has merged.
+🔴 **A worktree is a writer; the branch is the workstream.** The durable unit is
+the **branch** — one branch per workstream, and a session owns exactly one
+workstream. A worktree is only the checkout that lets you write to that branch:
+ephemeral, disposable, and recreatable at any time with `git worktree add`.
+Never treat a worktree as the thing being preserved; losing one loses nothing
+the branch does not still hold.
+
+What follows from that:
+
+- **One branch and worktree per independently reviewable PR outcome** — not per
+  ticket, per refactor step, or per experiment. Several related tickets may
+  share one worktree when a single coherent change satisfies them
+  (`Closes #A`, `Closes #B`).
+- **Everything that outcome owes stays in the same worktree and PR:** the
+  implementation, its regression tests, necessary local refactoring, docs, the
+  changelog fragment, and in-scope review fixes. Do not open a second worktree
+  for the tests you still owe the first one.
+- **Experiments stay session-local.** Promote an experiment to a branch and
+  worktree only once its result is accepted for implementation.
+- **Cleanup:** `git worktree remove --force <path>` once the PR has merged, then
+  `git branch -D <branch>` and `git push origin --delete <branch>` — the branch
+  goes last, because until the squash-merge has landed it is the only durable
+  copy of the workstream.
 
 🟡 **If you absolutely must run a command from the main checkout** — for
 example `cargo install --path crates/<name> --locked` after a merge —


### PR DESCRIPTION
## Outcome

Implements the four Rust/monorepo-specific workflow recommendations as **project instructions**. Milestone **1.3.3**.

🔴 **No code changed.** One `.md` file, zero `.rs` files, zero files under `crates/`.

### Why `.trusty-mpm/INSTRUCTIONS.md` and not a root `CLAUDE.md`

This repo cannot take a tracked root `CLAUDE.md`: `scripts/check_claude_md_not_tracked.sh` and `.github/workflows/claude-md-guard.yml` fail CI if it is tracked (#2299, regression #2647 — duplicate context loading, ~11k tokens/session). `.trusty-mpm/INSTRUCTIONS.md` is the tracked project-instruction host, and this PR is an additive addendum to it. Verified before writing; the guard passes below.

## Change

### P1b — worktree granularity (per WORKSTREAM, not per ticket)

Replaced *"Each ticket, refactor, or experiment gets its own worktree"* with the per-workstream model, consistent with the recorded session=workstream decision:

> **A worktree is a writer; the branch is the workstream.** The durable unit is the branch — one branch per workstream, a session owns exactly one. A worktree is only the checkout that lets you write to it: ephemeral, disposable, recreatable with `git worktree add`. Losing one loses nothing the branch does not still hold.

Consequences spelled out: one branch/worktree per independently reviewable **PR outcome** (not per ticket — several tickets may share one when a single coherent change satisfies them); the implementation, tests, docs, changelog fragment, and review fixes for that outcome stay in the *same* worktree and PR; experiments stay session-local until accepted; the branch is deleted **last**, after the squash-merge.

The delivery chain is rewritten from `spec → issue → …` to `accepted outcome → optional issue → worktree branch → one cohesive PR → applicable Rust gates → trusty-review gate → squash-merge → cleanup`, matching what #4630 landed in `tm-pr-workflow`.

### Stale-path fix (same edit)

The old line pointed at **`.claude-mpm/INSTRUCTIONS.md`** — a path that has never existed in this repo. Fixed and called out inline: the tracked host is `.trusty-mpm/INSTRUCTIONS.md` (this file), and the full delivery sequence now lives in the `tm-pr-workflow` skill. The note is left visible so the next reader does not "restore" the dead path.

### P2 — Rust issue boundary (search keys only)

The generic half — whether a finding earns an issue at all — is the **Ticket-Promotion Gate** that landed in `tm-ticketing` via #4630. This PR **points at it and does not restate it**. What it adds is the Rust-specific half: *what to search by*, as a four-row table — **test name** (effectively unique, quoted verbatim in every prior report), **panic/error text** (the literal string people paste), **affected symbol** (survives the module splits this repo does constantly under the 500-SLOC cap), and **crate** (expand abbreviations first). Search open *and* recently closed; append occurrences to the canonical issue.

### P3b — the six-rung Rust test ladder (AUTHORITATIVE)

Stated as the authoritative answer to "how much testing does this change need" for this repo. The framework's Low/Normal/High risk labels map onto the rungs (1–2 Low, 3–4 Normal, 5–6 High); where they disagree about *which command to run*, this table decides — the framework carries no competing Rust matrix.

Every rung **names its actual command**, so a PR body can show which rung was run. Includes the monorepo-specific rows: **cross-crate change** (rung 4), **release tooling** (rung 5), **UI/API surface** (rung 6).

Plus two hard lines kept explicit: `cargo test --workspace` is *not* the default inner-loop proof (it is a hardening gate; making every narrow PR depend on the whole workspace turns unrelated flakes into an issue factory), and **scope down, never scope away** — choosing a lower rung is a claim about blast radius you must prove, never licence to delete/`#[ignore]`/`cfg`-gate/`--exclude`/`--lib`-narrow coverage.

### P4-rust — the Rust half of the baseline-failure protocol

The generic six-step protocol landed in `tm-pr-workflow` via #4630 and is **cross-referenced, not duplicated**. This adds only what the generic version cannot carry:

- **Known-environmental gates on this machine**, so every agent stops rediscovering them: the ~6 `trusty-search` filesystem-watcher tests (`service/watch_loop.rs`, `watcher.rs`, `watcher_manager.rs`) fail nondeterministically on any branch — and still fail under `-- --test-threads=1`, so it is the machine's FSEvents behaviour, not parallel load; and `execute_doctor_against_test_daemon` (`crates/trusty-mpm/src/client/executor/tests.rs:192`) takes 9–13 s against a 10 s client timeout. Both test paths verified present in-tree.
- 🔴 **The correct response is to prove your diff touches zero files in those crates — never to `#[ignore]`, `cfg`-gate, or `--exclude` them.** The proof is a pasteable `git diff --name-only origin/main...HEAD -- crates/trusty-search/ crates/trusty-mpm/src/client/` whose empty output *is* the evidence.
- **Telling a pre-existing red from one you caused:** run the single named test on your branch, run the identical command against `origin/main` **in a second worktree** (never by mutating the main checkout, never `git stash`), serialize with `--test-threads=1` before blaming isolation, check the path evidence — and the **shared-crate caveat**: a green `cargo test -p <your-crate>` does *not* clear you when you changed `trusty-common` et al.; a red in a dependent is yours until rung 4 says otherwise.
- Reporting uses the literal shape `tm-pr-workflow` mandates, naming the crate-scoped gate.

## Risk / blast radius

Documentation only. No crate source, no scripts, no CI config. Blast radius is what agents read, not what the workspace builds.

## Existing rules — survival checklist

Each verified by grep against the post-edit file; none deleted or weakened.

| # | Rule | Survives | Evidence (line in `.trusty-mpm/INSTRUCTIONS.md`) |
|---|---|---|---|
| 1 | Main checkout is inspection-only | ✅ | L670 `🔴 **The main checkout is inspection-only.**` — untouched |
| 2 | Worktree / squash-merge discipline | ✅ | L689, L717, L756 — squash-merge retained in the chain, in the new cleanup ordering, and in the original cleanup note |
| 3 | Never make a red gate green by deleting coverage | ✅ | **Strengthened**: L154–156 (`never licence to make a red gate green by deleting, #[ignore]-ing, cfg-gating, --exclude-ing, or --lib-narrowing`) and L180 (`never to #[ignore], cfg-gate, or --exclude them`) |
| 4 | 500 / 3000 SLOC caps | ✅ | L284–285, L294 — section untouched |
| 5 | `thiserror` for libraries, `anyhow` for binaries | ✅ | L356 — untouched |
| 6 | Per-PR changelog fragments | ✅ | L453 — section untouched |
| 7 | Stronger gates for shared-crate changes | ✅ | L655, L822 untouched; **strengthened** by ladder rung 4 and the P4-rust shared-crate caveat |
| 8 | Security review for trust boundaries | ✅ | L843 threat-model / ADR-0018 pointer and L857 secret-redaction row untouched; **strengthened** by rung 5 (adversarial review + `cargo audit`) |

Two more constraints honoured explicitly:

- **Raw output not weakened.** The file now states the owner ruling: a PR body may summarise a **passing** gate as command + counts + scope; raw output stays **mandatory** for failures, flakes, performance claims, and disputed results, and agent-to-PM reporting keeps raw output in all cases (`BASE-AGENT.md`).
- **No absolute prohibition on PM direct work** is asserted anywhere — #4594's action budget with mid-flight handoff stays live.

## Test evidence

Documentation change; ladder rung 1. All 13 `scripts/check_*.sh` gates run, all exit 0:

```
check_agent_assets.sh            EXIT=0 | scanned 30 byte-parity file(s) (floor 20), all match — OK.
check_buildrs_sync.sh            EXIT=0 | build.rs canonical blocks are in sync across all 4 crates.
check_capabilities.sh            EXIT=0 | tm-capabilities: up to date (6 generated files).
check_changelog_fragment.sh      EXIT=0 | scanned 1 changed path(s); no crate source changed (docs-only) — OK.
check_claude_md_not_tracked.sh   EXIT=0 | PASS: root CLAUDE.md is not tracked — probed against 5563 tracked file(s).
check_doc_numbers.sh             EXIT=0 | scanned 95 doc(s) / 89 claim(s); 4 grandfathered, 0 violations — OK.
check_generation_artifacts.sh    EXIT=0 | scanned 16 stylesheet(s) + 1122 prose file(s) — 0 leaked artifacts — OK.
check_instruction_floor.sh       EXIT=0 | PASS: instruction floor matches its pinned byte-exact digests.
check_line_cap.sh                EXIT=0 | measured 3589 tracked .rs file(s); 7 allowlisted, 0 violations — OK.
check_line_cap_selftest.sh       EXIT=0 | all SLOC-counter regression cases passed.
check_scan_floor_selftest.sh     EXIT=0 | 11 gate(s) correctly refuse a vacuous scan — OK.
check_sld.sh                     EXIT=0 | scanned 53 spec doc(s) + 3019 code file(s); 0 error(s), 0 warning(s)
check_test_pointers.sh           EXIT=0 | resolved 20224 Test: citation(s) — 0 dangling pointers — OK.
```

Baseline failures: none. No Cargo gate was run, and none is owed — rung 1.

## Confirmation: no code changed

```
$ git diff --name-only origin/main...HEAD
.trusty-mpm/INSTRUCTIONS.md

$ git diff --name-only origin/main...HEAD | grep '\.rs$'
(none)

$ git diff --name-only origin/main...HEAD | grep '^crates/'
(none)
```

## Docs / changelog

**No changelog fragment required — verified, not assumed.** `.trusty-mpm/` is not under `crates/*/src/**`, and the gate says so directly:

```
$ bash scripts/check_changelog_fragment.sh
changelog-fragment gate: scanned 1 changed path(s); no crate source changed (docs-only / CI-only / test-only) — OK.
EXIT=0
```

## Related

- Builds on #4630 (ticket-promotion gate in `tm-ticketing`, baseline-failure protocol in `tm-pr-workflow`) and #4631 (crate-scoped rust-engineer gates, issue/PR templates), both merged.
- Sibling in flight: `feat/133-risk-tiers-and-review-disposition` folds Low/Normal/High risk labels into the framework phase-entry table; those labels map onto this ladder's rungs, and this ladder decides which command runs.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
