### PR TITLE
fix(trusty-memory): probe /health, not the unregistered /api/v1/health

### DIFF
--- a/crates/trusty-memory/changelog.d/4635-daemon-guard-health-path.md
+++ b/crates/trusty-memory/changelog.d/4635-daemon-guard-health-path.md
@@ -1,0 +1,21 @@
+Fixed
+
+- **`trusty-memory monitor web` no longer reports a healthy daemon as down
+  (issue #4635).** `commands::daemon_guard` probed `{base}/api/v1/health` in
+  two places — `probe_health()` and the `health_url` field it handed to
+  `spin_until_ready` — but `web::router` registers only `GET /health`
+  (`src/web/mod.rs:190`). Against a live daemon on :7070, `/health` answers 200
+  and `/api/v1/health` answers 404, so the guard always took the cold path: it
+  printed `◉ Starting trusty-memory daemon…`, spawned a duplicate daemon (which
+  self-exited via `single_instance_check`), then spun on the dead URL for the
+  full 30 s startup budget and errored out, leaving the dashboard unreachable
+  from its documented entry point. Both probe sites now derive the URL from a
+  single `health_url()` helper — the drift between them is what allowed the two
+  to disagree — matching the `/health` path already used by
+  `commands::single_instance`, `commands::start`, and
+  `trusty_common::monitor::memory_client`.
+
+- **`trusty-memory port` help text no longer instructs a 404 route
+  (issue #4635).** The `--help` example and two `commands::port` doc comments
+  told users to `curl http://127.0.0.1:$(trusty-memory port)/api/v1/health`;
+  they now name `/health`.

--- a/crates/trusty-memory/src/commands/daemon_guard.rs
+++ b/crates/trusty-memory/src/commands/daemon_guard.rs
@@ -2,7 +2,7 @@
 //!
 //! Why: `trusty-memory monitor web` and any future human-facing commands
 //! that open the UI silently fail or emit a confusing connection error when
-//! the daemon isn't running. This guard probes `/api/v1/health`; if the
+//! the daemon isn't running. This guard probes `/health`; if the
 //! daemon is down it spawns a detached `<exe> serve --foreground` child and
 //! polls until ready or a 30-second budget is exhausted. Users see a single
 //! informational line and the command Just Works.
@@ -10,7 +10,7 @@
 //! What: thin shim over `trusty_common::daemon_guard` (issue #985).
 //! `ensure_daemon_running` delegates the spinner/probe/timeout loop to the
 //! shared implementation; only the trusty-memory–specific knobs (health path
-//! `/api/v1/health`, spawn args, base-URL resolver) live here.
+//! `/health`, spawn args, base-URL resolver) live here.
 //!
 //! Test: `probe_health_returns_false_on_connection_refused`,
 //! `probe_health_returns_false_on_bad_url`, and
@@ -25,15 +25,29 @@ use anyhow::{anyhow, Result};
 use colored::Colorize;
 use trusty_common::daemon_guard::{probe_once, spin_until_ready, DaemonGuardConfig};
 
-/// Probe `GET {base}/api/v1/health`. Returns `true` on any 2xx response.
+/// Build the daemon's health-probe URL for `base`.
 ///
-/// Why: trusty-memory's health endpoint lives at `/api/v1/health` — callers
-/// must use this helper rather than constructing the URL themselves.
+/// Why: the probe path has to agree with what the router actually registers —
+/// `GET /health` (`web::router`). Deriving it in one place keeps `probe_health`
+/// and `ensure_daemon_running` from drifting apart, which is exactly how #4635
+/// happened.
+/// What: appends the `/health` route to an already-scheme-qualified base URL.
+/// Test: `health_url_targets_the_registered_health_route`.
+// #4635: probe /health — /api/v1/health is not a registered route.
+fn health_url(base: &str) -> String {
+    format!("{base}/health")
+}
+
+/// Probe `GET {base}/health`. Returns `true` on any 2xx response.
+///
+/// Why: trusty-memory's health endpoint lives at `/health` — callers must use
+/// this helper rather than constructing the URL themselves.
 /// What: delegates to `trusty_common::daemon_guard::probe_once`.
-/// Test: `probe_health_returns_false_on_connection_refused`,
+/// Test: `probe_health_succeeds_against_the_registered_health_route`,
+/// `probe_health_returns_false_on_connection_refused`,
 /// `probe_health_returns_false_on_bad_url`.
 pub async fn probe_health(base: &str) -> bool {
-    probe_once(&format!("{base}/api/v1/health")).await
+    probe_once(&health_url(base)).await
 }
 
 /// Spawn `<this exe> serve --foreground` as a detached background process.
@@ -74,7 +88,7 @@ pub fn daemon_base_url() -> String {
 /// Why: `monitor web` should never tell the user "daemon not running — start
 /// it yourself". Auto-starting matches the UX in `trusty-search` and
 /// `trusty-analyze`.
-/// What: fast-path probes `/api/v1/health`; on miss, spawns
+/// What: fast-path probes `/health`; on miss, spawns
 /// `<exe> serve --foreground`, then delegates the spinner/poll/timeout loop
 /// to `trusty_common::daemon_guard::spin_until_ready` (30s budget).
 /// Test: `probe_health_returns_false_on_connection_refused` covers the probe;
@@ -89,7 +103,8 @@ pub async fn ensure_daemon_running(base: &str) -> Result<()> {
     spawn_daemon()?;
 
     let cfg = DaemonGuardConfig {
-        health_url: format!("{base}/api/v1/health"),
+        // #4635: probe /health — /api/v1/health is not a registered route.
+        health_url: health_url(base),
         service_name: "trusty-memory".to_string(),
         startup_timeout: std::time::Duration::from_secs(30),
         poll_interval: std::time::Duration::from_millis(500),
@@ -105,7 +120,7 @@ pub async fn ensure_daemon_running(base: &str) -> Result<()> {
 /// the `monitor web` subcommand, mirroring the UX in `trusty-analyze` and
 /// `trusty-search`.
 /// What: resolves the daemon base URL from the discovery file; calls
-/// `ensure_daemon_running` which probes `/api/v1/health` and auto-spawns as
+/// `ensure_daemon_running` which probes `/health` and auto-spawns as
 /// needed; re-resolves the live URL after boot; opens `http://<addr>/ui`.
 /// Browser-open failure degrades to printing the URL.
 /// Test: `cargo run -p trusty-memory -- monitor web` with no daemon running.
@@ -129,6 +144,62 @@ pub async fn open_web_dashboard() -> Result<()> {
 mod tests {
     use super::*;
     use std::time::{Duration, Instant};
+
+    /// Why: #4635 — the guard probed `/api/v1/health`, which `web::router` never
+    /// registers, so `monitor web` reported a healthy daemon as down. Pin the
+    /// path against the route the router actually serves.
+    /// What: asserts the probe URL is `{base}/health`.
+    /// Test: this test.
+    #[test]
+    fn health_url_targets_the_registered_health_route() {
+        assert_eq!(
+            health_url("http://127.0.0.1:7070"),
+            "http://127.0.0.1:7070/health"
+        );
+    }
+
+    /// Why: the string assertion above cannot catch a router/probe disagreement
+    /// on its own — #4635 needed a wire-level check that the path the guard
+    /// requests is the path a trusty-memory daemon answers.
+    /// What: binds a stub server that mirrors `web::router`'s health surface —
+    /// 200 on `GET /health`, 404 on everything else, including `/api/v1/health`
+    /// — then asserts `probe_health` resolves it as up. Fails against the
+    /// pre-#4635 `/api/v1/health` probe path.
+    /// Test: this test.
+    #[tokio::test]
+    async fn probe_health_succeeds_against_the_registered_health_route() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind stub health server");
+        let addr = listener.local_addr().expect("stub server local addr");
+
+        tokio::spawn(async move {
+            let (mut sock, _) = match listener.accept().await {
+                Ok(pair) => pair,
+                Err(_) => return,
+            };
+            let mut buf = [0u8; 1024];
+            let n = sock.read(&mut buf).await.unwrap_or(0);
+            let req = String::from_utf8_lossy(&buf[..n]);
+            // Only `/health` is a registered route; anything else 404s, exactly
+            // as the live daemon does for `/api/v1/health`.
+            let resp = if req.starts_with("GET /health ") {
+                "HTTP/1.1 200 OK\r\ncontent-length: 2\r\nconnection: close\r\n\r\nok"
+            } else {
+                "HTTP/1.1 404 Not Found\r\ncontent-length: 9\r\nconnection: close\r\n\r\nnot found"
+            };
+            let _ = sock.write_all(resp.as_bytes()).await;
+            let _ = sock.flush().await;
+        });
+
+        let base = format!("http://{addr}");
+        assert!(
+            probe_health(&base).await,
+            "probe_health must resolve a daemon serving GET /health as up"
+        );
+    }
 
     /// Why: `probe_health` against an unbound localhost port must return `false`
     /// (connection refused) within a reasonable wall-clock bound, never panic.

--- a/crates/trusty-memory/src/commands/port.rs
+++ b/crates/trusty-memory/src/commands/port.rs
@@ -80,7 +80,7 @@ pub fn format_output(addr: &str, format: PortFormat) -> Option<String> {
 /// Entry point for `trusty-memory port [--json | --addr]`.
 ///
 /// Why: exposes the daemon's listening port as a first-class CLI command so
-/// shell substitutions like `curl http://127.0.0.1:$(trusty-memory port)/api/v1/health`
+/// shell substitutions like `curl http://127.0.0.1:$(trusty-memory port)/health`
 /// work without guessing. Issue #526.
 /// What: reads the address from the `http_addr` discovery file via
 /// `trusty_common::read_daemon_addr("trusty-memory")`, formats it per the
@@ -141,7 +141,7 @@ mod tests {
 
     /// `--addr` format emits the full `host:port` string unchanged.
     ///
-    /// Why: callers using `curl http://$(trusty-memory port --addr)/api/v1/health`
+    /// Why: callers using `curl http://$(trusty-memory port --addr)/health`
     /// need the host included.
     #[test]
     fn format_port_output_addr() {

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -383,7 +383,7 @@ enum Command {
     ///
     /// Reads the address the running daemon persisted to its `http_addr`
     /// discovery file. Useful for shell substitution:
-    ///   curl http://127.0.0.1:$(trusty-memory port)/api/v1/health
+    ///   curl http://127.0.0.1:$(trusty-memory port)/health
     ///
     /// Exits non-zero (with a message on stderr) when no daemon is running
     /// or the address file is missing, so substitution fails cleanly.


### PR DESCRIPTION
Closes #4635
Refs #4246

## The bug

`crates/trusty-memory/src/commands/daemon_guard.rs` probed `{base}/api/v1/health` in two places:

- `probe_health()` — line 36
- `ensure_daemon_running()`, the `health_url` field handed to `spin_until_ready` — line 92

That route is not registered. `web::router` registers only `GET /health` (`crates/trusty-memory/src/web/mod.rs:190`).

Verified live against the running daemon on :7070:

```
$ curl -s -o /dev/null -w '%{http_code}\n' http://127.0.0.1:7070/health
200

$ curl -s -w '\nHTTP %{http_code}\n' http://127.0.0.1:7070/api/v1/health
not found
HTTP 404
```

Consequence: `trusty-memory monitor web` always believed the daemon was down. It printed `◉ Starting trusty-memory daemon…` against a healthy daemon, spawned a duplicate (which self-exited via `single_instance_check`), then spun on the dead URL for the full 30 s `startup_timeout` and errored — the dashboard was unreachable from its documented entry point.

## The fix

Both probe sites now derive the URL from a single `health_url()` helper. Two independently-formatted path literals drifting apart is the exact shape of this bug, so consolidating them is the fix, not incidental cleanup. The `/health` path matches what already works in `commands::single_instance:83`, `commands::start:54`, and `trusty_common::monitor::memory_client::client:120` — none of which were touched.

No caller depended on the `/api/v1/` form: `probe_health` is used only inside this module and its tests, and `open_web_dashboard` (via `main.rs:646`) is the sole entry point into `ensure_daemon_running`.

### Also fixed — same typo, documentation surface

Three sites in the same crate instructed users to curl the 404 route, including user-facing `--help` text:

- `src/main.rs:386` — `trusty-memory port` `--help` example
- `src/commands/port.rs:83`, `src/commands/port.rs:144`

## Tests

Two new tests, both of which **fail** when the `/api/v1/health` path is reintroduced (mutation-checked, output below):

- `health_url_targets_the_registered_health_route` — pins the probe path string; covers builds without the optional `axum-server` feature.
- `probe_health_succeeds_against_the_registered_health_route` — binds a stub server mirroring the router's health surface (200 on `GET /health`, 404 on everything else, including `/api/v1/health`) and asserts `probe_health` resolves it as up. This is the wire-level check a string assertion alone cannot give.

Mutation check with the bug reintroduced:

```
test commands::daemon_guard::tests::health_url_targets_the_registered_health_route ... FAILED
test commands::daemon_guard::tests::probe_health_succeeds_against_the_registered_health_route ... FAILED
test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 471 filtered out
```

## Gates

```
$ cargo check -p trusty-memory
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 10s

$ cargo test -p trusty-memory
test result: ok. 472 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 25.56s
(+ 18 further suites, all ok; 0 failed across the whole run)

$ cargo clippy -p trusty-memory --all-targets -- -D warnings
exit 0

$ cargo fmt --check
exit 0

$ bash scripts/check_line_cap.sh
line-cap: measured 3589 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.
```

## Live verification

Freshly built `target/debug/trusty-memory` run against the already-running launchd daemon (`com.trusty.memory`, PID 29856, :7070) — **not** installed, and the daemon was not restarted, killed, or booted out:

```
$ ./target/debug/trusty-memory monitor web
◉ Opening http://127.0.0.1:7070/ui …
./target/debug/trusty-memory monitor web  0.04s user 0.02s system 2% cpu 2.228 total
EXIT=0
```

No `Starting trusty-memory daemon…` line, no 30 s spin, exit 0. PID 29856 was still the only `serve --foreground` process afterward — no duplicate spawned.

## Out of scope

`GET /api/v1/status` and `/api/v1/palaces` currently hang on the running daemon (suspected redb lock contention from ~15 concurrent `serve --stdio` sessions), so `monitor status` still fails and `/ui` may render empty. That is a separate defect, untouched here, and it did not affect the check above.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools