### PR TITLE
perf(trusty-memory): peek() the registry instead of opening every palace in HTTP handlers

### DIFF
--- a/crates/trusty-memory/changelog.d/4637-registry-peek-http-handlers-changed.md
+++ b/crates/trusty-memory/changelog.d/4637-registry-peek-http-handlers-changed.md
@@ -1,0 +1,18 @@
+Changed
+
+- **`/api/v1/status` totals now cover cache-resident palaces only, and say so
+  (issue #4637).** `total_drawers`, `total_vectors` and `total_kg_triples` are
+  summed across the palaces resident in the open-handle cache rather than every
+  palace on disk — that is what makes the endpoint answer at all at 5,794
+  palaces. `palace_count` is unchanged and still reports the true on-disk
+  total; a new `cached_palace_count` reports how many of those the three totals
+  actually cover. The chat-surface `get_status` tool gained the same field.
+
+- **`/api/v1/palaces` rows carry a `cached` flag (issue #4637).** When `cached`
+  is `false` the row's `drawer_count` / `vector_count` / `kg_triple_count` /
+  `wing_count` / `node_count` / `edge_count` / `community_count` are `0` because
+  they are *unknown*, not because they are empty — the list route no longer
+  opens a palace just to count it. Fetch `GET /api/v1/palaces/{id}` for live
+  counts on a specific palace; the single-palace route still opens it and is
+  unaffected. Both new fields are `#[serde(default)]`, so older clients that do
+  not know them are unaffected.

--- a/crates/trusty-memory/changelog.d/4637-registry-peek-http-handlers-performance.md
+++ b/crates/trusty-memory/changelog.d/4637-registry-peek-http-handlers-performance.md
@@ -1,0 +1,31 @@
+Performance
+
+- **`GET /api/v1/status` and `GET /api/v1/palaces` no longer force-open every
+  palace on disk (issue #4637).** Both handlers looped over the whole registry
+  calling `PalaceRegistry::open_palace` — a synchronous, blocking per-palace
+  load (usearch vector index, KG redb, full drawer table, recall-log redb) —
+  inline on the async axum executor, with no `spawn_blocking`, no timeout and
+  no pagination. Against the live daemon's 5,794 palaces and the 64-slot LRU
+  (`DEFAULT_MAX_OPEN_PALACES`), ~98.9% of those were cold opens at ~0.9–1.1 s
+  each: roughly 87–106 minutes of disk I/O per request. Measured before the
+  fix, `/api/v1/status` did not respond within 90 s while `/health` returned in
+  36 ms. Both routes now read counts through `PalaceRegistry::peek` — a
+  cache-only, zero-I/O, non-promoting lookup — carrying the fix from issue
+  #1924 (which fixed the same anti-pattern in the MCP `console_metrics`
+  handler) across to the HTTP handler path, where it had never been applied.
+  The same conversion lands on the chat-surface twins `list_palaces` and
+  `get_status`, and the `PalaceRegistry::list_palaces` directory walk that
+  feeds them now runs on the blocking pool.
+
+- **Cross-palace recall and the dream cycle no longer park a tokio worker
+  thread (issue #4637).** `recall_all` (`GET /api/v1/recall`), its chat and MCP
+  twins, and `dream_run` (`POST /api/v1/dream/run`) genuinely need every palace
+  open — a recall answered from cache-resident palaces only would silently omit
+  ~98.9% of the corpus, and a dream cycle that skipped uncached palaces would
+  silently stop maintaining them — so these are deliberately *not* converted to
+  `peek()`. Their blocking open loops moved to `spawn_blocking` instead, which
+  keeps the semantics intact while taking the multi-minute stall off the async
+  executor. Three byte-identical copies of that loop collapsed into one shared
+  `open_palaces_blocking` helper. These routes are still slow by nature; making
+  them fast needs a cross-palace index or an explicit palace scope, not a
+  cache-only read.

--- a/crates/trusty-memory/src/chat/tools.rs
+++ b/crates/trusty-memory/src/chat/tools.rs
@@ -9,6 +9,7 @@
 //! Test: `all_tools_returns_expected_set`, `execute_tool_dispatches_known_tools`
 //! in `web::tests`.
 
+use crate::service::helpers::{collect_palace_stats, list_palaces_blocking, open_palaces_blocking};
 use crate::web::{load_user_config, palace_info_from, DreamStatusPayload};
 use crate::AppState;
 use serde::Deserialize;
@@ -277,15 +278,25 @@ pub(crate) async fn execute_tool(name: &str, args: &str, state: &AppState) -> Va
     }
 }
 
+/// Chat-surface twin of `MemoryService::list_palaces` (issue #4637).
+///
+/// Why: shares the fix, not just the shape — this path had the identical
+/// force-open-every-palace loop, so it was identically unusable at 5,794
+/// palaces. Rows for uncached palaces carry `cached: false` and zero counts.
+/// What: lists palaces on the blocking pool, enriches each row from the
+/// registry's open-handle cache via `peek`.
+/// Test: `list_palaces_does_not_open_uncached_palaces` covers the shared
+/// `palace_info_from` contract this relies on.
 async fn execute_list_palaces(state: &AppState) -> Value {
-    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
+    let palaces = match list_palaces_blocking(state).await {
         Ok(v) => v,
-        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
+        Err(e) => return json!({ "error": format!("{e:#}") }),
     };
     let out: Vec<Value> = palaces
         .into_iter()
         .map(|p| {
-            let handle = state.registry.open_palace(&state.data_root, &p.id).ok();
+            // #4637: peek() not open_palace() — full-registry open is O(n) cold disk I/O
+            let handle = state.registry.peek(&p.id);
             let info = palace_info_from(&p, handle.as_ref());
             serde_json::to_value(info).unwrap_or(json!({}))
         })
@@ -347,19 +358,13 @@ pub(crate) async fn execute_recall_all(
     top_k: usize,
     deep: bool,
 ) -> Value {
-    let palaces = match PalaceRegistry::list_palaces(&state.data_root) {
+    let palaces = match list_palaces_blocking(state).await {
         Ok(v) => v,
-        Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
+        Err(e) => return json!({ "error": format!("{e:#}") }),
     };
-    let mut handles = Vec::with_capacity(palaces.len());
-    for p in &palaces {
-        match state.registry.open_palace(&state.data_root, &p.id) {
-            Ok(h) => handles.push(h),
-            Err(e) => {
-                tracing::warn!(palace = %p.id, "execute_recall_all: open failed: {e:#}");
-            }
-        }
-    }
+    // #4637: open_palace (not peek) is deliberate — recall must see every
+    // palace; the spawn_blocking hop keeps it off the async executor.
+    let handles = open_palaces_blocking(state, &palaces, "execute_recall_all").await;
     if handles.is_empty() {
         return json!([]);
     }
@@ -420,24 +425,29 @@ fn execute_get_config(state: &AppState) -> Value {
     })
 }
 
+/// Chat-surface twin of `MemoryService::status` (issue #4637).
+///
+/// Why: this had a byte-identical inline copy of the `collect_palace_stats`
+/// loop — including the force-open-every-palace bug. It now delegates to the
+/// shared helper so the fix (and any future one) lands once, and it reports
+/// `cached_palace_count` so the changed meaning of the totals is on the wire
+/// here too.
+/// What: lists palaces on the blocking pool, sums counts across the
+/// cache-resident subset via `collect_palace_stats`.
+/// Test: `status_does_not_open_uncached_palaces` covers the shared helper.
 async fn execute_get_status(state: &AppState) -> Value {
-    let palaces = PalaceRegistry::list_palaces(&state.data_root).unwrap_or_default();
-    let (mut total_drawers, mut total_vectors, mut total_kg_triples) = (0usize, 0usize, 0usize);
-    for p in &palaces {
-        if let Ok(handle) = state.registry.open_palace(&state.data_root, &p.id) {
-            total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
-            total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
-            total_kg_triples = total_kg_triples.saturating_add(handle.kg.count_active_triples());
-        }
-    }
+    let palaces = list_palaces_blocking(state).await.unwrap_or_default();
+    // #4637: peek() not open_palace() — full-registry open is O(n) cold disk I/O
+    let stats = collect_palace_stats(state, palaces.iter().map(|p| &p.id));
     json!({
         "version": state.version,
         "palace_count": palaces.len(),
         "default_palace": state.default_palace,
         "data_root": state.data_root.display().to_string(),
-        "total_drawers": total_drawers,
-        "total_vectors": total_vectors,
-        "total_kg_triples": total_kg_triples,
+        "total_drawers": stats.total_drawers,
+        "total_vectors": stats.total_vectors,
+        "total_kg_triples": stats.total_kg_triples,
+        "cached_palace_count": stats.cached_palace_count,
     })
 }
 

--- a/crates/trusty-memory/src/service/core.rs
+++ b/crates/trusty-memory/src/service/core.rs
@@ -24,7 +24,7 @@ use uuid::Uuid;
 
 use super::helpers::{
     collect_palace_stats, drawer_content_preview, drawer_snippet, is_reserved_system_palace,
-    palace_info_from, recall_entry_json,
+    list_palaces_blocking, open_palaces_blocking, palace_info_from, recall_entry_json,
 };
 use super::types::{
     CreateDrawerBody, CreatePalaceBody, ListDrawersQuery, PalaceInfo, ServiceError, ServiceResult,
@@ -80,16 +80,25 @@ impl MemoryService {
     ///
     /// Why: dashboard widgets and the MCP `get_status` tool need the same
     /// roll-up; centralising avoids drift between the two surfaces.
-    /// What: walks every persisted palace, sums drawer/vector/triple counts,
-    /// and returns the [`StatusPayload`].
-    /// Test: `status_endpoint_returns_payload`.
+    /// What: walks every persisted palace for `palace_count`, then sums
+    /// drawer/vector/triple counts across the cache-resident subset and
+    /// returns the [`StatusPayload`].
+    /// Why (issue #4637): this used to open every persisted palace to sum
+    /// those three counts. With 5,794 palaces on disk against a 64-slot LRU
+    /// that is ~5,730 cold opens of ~1s each — the endpoint measurably never
+    /// responded. `palace_count` still reflects the true on-disk total (the
+    /// directory walk is cheap and now runs on the blocking pool); the totals
+    /// cover only cache-resident palaces and say so via `cached_palace_count`.
+    /// Test: `status_endpoint_returns_payload`,
+    /// `status_does_not_open_uncached_palaces`.
     pub async fn status(&self) -> StatusPayload {
         // The `/status` endpoint is the one place we still want a disk view —
         // an operator hitting this endpoint right after restart (before
         // `load_palaces_from_disk` finishes) should still see every persisted
         // palace counted, even if it isn't in the in-memory registry yet.
-        let palaces = PalaceRegistry::list_palaces(&self.state.data_root).unwrap_or_default();
+        let palaces = list_palaces_blocking(&self.state).await.unwrap_or_default();
         let palace_count = palaces.len();
+        // #4637: peek() not open_palace() — full-registry open is O(n) cold disk I/O
         let stats = collect_palace_stats(&self.state, palaces.iter().map(|p| &p.id));
         StatusPayload {
             version: self.state.version.clone(),
@@ -99,6 +108,7 @@ impl MemoryService {
             total_drawers: stats.total_drawers,
             total_vectors: stats.total_vectors,
             total_kg_triples: stats.total_kg_triples,
+            cached_palace_count: stats.cached_palace_count,
         }
     }
 
@@ -146,21 +156,28 @@ impl MemoryService {
     /// admin UI, TUI, or any user-facing roster.
     /// What: walks the registry, drops any palace whose id starts with the
     /// reserved `__` prefix, and builds a `PalaceInfo` per remaining row.
+    /// Why (issue #4637): this used to call `open_palace` per row purely to
+    /// enrich it with counts. At 5,794 palaces against a 64-slot LRU that is
+    /// ~90 minutes of cold, blocking disk I/O inline on the async executor —
+    /// and it evicted the entire working set on every call. Rows now come
+    /// from `PalaceRegistry::peek` (zero I/O, no LRU promotion, mirroring the
+    /// #1924 fix in `console_metrics.rs`). Uncached rows carry `cached: false`
+    /// and zero counts; a client that needs live counts for one palace should
+    /// fetch `GET /api/v1/palaces/{id}`, which still opens it.
     /// Test: `palace_list_includes_richer_counts`, `palace_list_includes_graph_counts`,
-    /// `health_probe_palace_is_invisible` (in `web::tests`).
+    /// `health_probe_palace_is_invisible` (in `web::tests`),
+    /// `list_palaces_does_not_open_uncached_palaces`.
     pub async fn list_palaces(&self) -> ServiceResult<Vec<PalaceInfo>> {
-        let palaces = PalaceRegistry::list_palaces(&self.state.data_root)
-            .map_err(|e| ServiceError::internal(format!("list palaces: {e:#}")))?;
+        let palaces = list_palaces_blocking(&self.state)
+            .await
+            .map_err(|e| ServiceError::internal(format!("{e:#}")))?;
         let mut out = Vec::with_capacity(palaces.len());
         for p in palaces {
             if is_reserved_system_palace(&p.id) {
                 continue;
             }
-            let handle = self
-                .state
-                .registry
-                .open_palace(&self.state.data_root, &p.id)
-                .ok();
+            // #4637: peek() not open_palace() — full-registry open is O(n) cold disk I/O
+            let handle = self.state.registry.peek(&p.id);
             out.push(palace_info_from(&p, handle.as_ref()));
         }
         Ok(out)
@@ -643,26 +660,25 @@ impl MemoryService {
     /// What: lists every palace, opens handles (skipping failures with a
     /// `tracing::warn!`), delegates to
     /// `recall_across_palaces_with_default_embedder`. Returns a JSON array.
+    /// Why (issue #4637): unlike `list_palaces`/`status`, this route is NOT
+    /// converted to `peek()`. A cross-palace recall that answered from
+    /// cache-resident palaces only would silently omit ~98.9% of the corpus —
+    /// a wrong answer that looks like a right one, which is strictly worse
+    /// than a slow correct one. The open loop keeps opening every palace; it
+    /// just no longer does so inline on a tokio worker thread. Making this
+    /// route actually fast needs a different design (a shared cross-palace
+    /// index, or an explicit palace-scoped query), not a cache-only read.
     /// Test: indirectly via `recall_across_palaces_merges_results` and the
-    /// MCP `memory_recall_all` integration paths.
+    /// MCP `memory_recall_all` integration paths; `recall_all_opens_every_palace`
+    /// pins that uncached palaces are still searched.
     pub async fn recall_all(&self, query: &str, top_k: usize, deep: bool) -> Value {
-        let palaces = match PalaceRegistry::list_palaces(&self.state.data_root) {
+        let palaces = match list_palaces_blocking(&self.state).await {
             Ok(v) => v,
-            Err(e) => return json!({ "error": format!("list palaces: {e:#}") }),
+            Err(e) => return json!({ "error": format!("{e:#}") }),
         };
-        let mut handles = Vec::with_capacity(palaces.len());
-        for p in &palaces {
-            match self
-                .state
-                .registry
-                .open_palace(&self.state.data_root, &p.id)
-            {
-                Ok(h) => handles.push(h),
-                Err(e) => {
-                    tracing::warn!(palace = %p.id, "recall_all: open failed: {e:#}");
-                }
-            }
-        }
+        // #4637: open_palace (not peek) is deliberate — recall must see every
+        // palace; the spawn_blocking hop keeps it off the async executor.
+        let handles = open_palaces_blocking(&self.state, &palaces, "recall_all").await;
         if handles.is_empty() {
             return json!([]);
         }

--- a/crates/trusty-memory/src/service/core.rs
+++ b/crates/trusty-memory/src/service/core.rs
@@ -669,8 +669,9 @@ impl MemoryService {
     /// route actually fast needs a different design (a shared cross-palace
     /// index, or an explicit palace-scoped query), not a cache-only read.
     /// Test: indirectly via `recall_across_palaces_merges_results` and the
-    /// MCP `memory_recall_all` integration paths; `recall_all_opens_every_palace`
-    /// pins that uncached palaces are still searched.
+    /// MCP `memory_recall_all` integration paths;
+    /// `open_palaces_blocking_opens_every_palace` pins that uncached palaces
+    /// are still searched.
     pub async fn recall_all(&self, query: &str, top_k: usize, deep: bool) -> Value {
         let palaces = match list_palaces_blocking(&self.state).await {
             Ok(v) => v,

--- a/crates/trusty-memory/src/service/core_kg.rs
+++ b/crates/trusty-memory/src/service/core_kg.rs
@@ -15,7 +15,7 @@ use trusty_common::memory_core::store::kg::Triple;
 use trusty_common::memory_core::{PalaceHandle, PalaceRegistry};
 
 use super::core::KG_GRAPH_MAX_TRIPLES;
-use super::helpers::refresh_gaps_cache;
+use super::helpers::{list_palaces_blocking, refresh_gaps_cache};
 use super::types::{DreamStatusPayload, KgAssertBody, KgGraphPayload, ServiceError, ServiceResult};
 use super::MemoryService;
 
@@ -181,20 +181,41 @@ impl MemoryService {
     }
 
     /// Run a dream cycle across every palace.
+    ///
+    /// Why (issue #4637): like `recall_all`, this route is deliberately NOT
+    /// converted to `PalaceRegistry::peek`. Dreaming is a maintenance pass —
+    /// consolidating only the 64 palaces that happen to be cache-resident
+    /// would silently stop maintaining the other ~5,730, which is a worse
+    /// failure than a slow run because nothing reports it. Opening every
+    /// palace stays correct; what changes is that the blocking open no longer
+    /// runs inline on a tokio worker thread. A long dream run is expected —
+    /// this is an explicitly-triggered `POST`, not a page load.
+    /// What: lists palaces on the blocking pool, then per palace hops to
+    /// `spawn_blocking` for the open before awaiting the async dream cycle.
+    /// Test: `dream_run_aggregates_stats`.
     pub async fn dream_run(&self) -> ServiceResult<DreamStatusPayload> {
-        let palaces = PalaceRegistry::list_palaces(&self.state.data_root)
-            .map_err(|e| ServiceError::internal(format!("list palaces: {e:#}")))?;
+        let palaces = list_palaces_blocking(&self.state)
+            .await
+            .map_err(|e| ServiceError::internal(format!("{e:#}")))?;
         let dreamer = Dreamer::new(DreamConfig::default());
         let mut out = DreamStatusPayload::default();
         for p in palaces {
-            let handle = match self
-                .state
-                .registry
-                .open_palace(&self.state.data_root, &p.id)
-            {
-                Ok(h) => h,
-                Err(e) => {
+            // #4637: open_palace (not peek) is deliberate — a dream cycle must
+            // maintain every palace; the spawn_blocking hop keeps the cold open
+            // off the async executor.
+            let registry = std::sync::Arc::clone(&self.state.registry);
+            let root = self.state.data_root.clone();
+            let pid = p.id.clone();
+            let opened =
+                tokio::task::spawn_blocking(move || registry.open_palace(&root, &pid)).await;
+            let handle = match opened {
+                Ok(Ok(h)) => h,
+                Ok(Err(e)) => {
                     tracing::warn!(palace = %p.id, "dream_run: open failed: {e:#}");
+                    continue;
+                }
+                Err(e) => {
+                    tracing::warn!(palace = %p.id, "dream_run: join open failed: {e}");
                     continue;
                 }
             };

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -138,47 +138,134 @@ pub(crate) fn is_reserved_system_palace(id: &PalaceId) -> bool {
 /// single helper eliminates the byte-for-byte duplicate and makes future
 /// changes (e.g. adding a `total_vectors_orphaned` field) land in one place.
 /// What: saturating sums of `drawers.read().len()`, `vector_store.index_size()`,
-/// and `kg.count_active_triples()` across the supplied palace ids.
+/// and `kg.count_active_triples()` across the supplied palace ids, plus
+/// `cached_palace_count` — how many of those ids actually contributed (issue
+/// #4637). The three totals are therefore a **cache-resident** roll-up, not a
+/// whole-disk one; `cached_palace_count` is what makes that legible.
 /// Test: indirectly via `status_endpoint_returns_payload` and any SSE test
-/// that observes `StatusChanged`.
+/// that observes `StatusChanged`; cache-only behaviour is pinned by
+/// `status_does_not_open_uncached_palaces`.
 pub(crate) struct PalaceStats {
     pub total_drawers: usize,
     pub total_vectors: usize,
     pub total_kg_triples: usize,
+    /// Number of `ids` that were resident in the registry's LRU cache and so
+    /// contributed real counts to the three totals above (issue #4637).
+    pub cached_palace_count: usize,
 }
 
-/// Sum drawer / vector / KG-triple counts across `ids`, skipping palaces that
-/// cannot be opened.
+/// Sum drawer / vector / KG-triple counts across the `ids` that are already
+/// resident in the registry's open-handle cache.
 ///
 /// Why (issue #228): centralises the previously-duplicated loop from
 /// `status()` and `aggregate_status_event()`. Callers pass an iterator of
 /// `PalaceId` so the helper works for both the on-disk view (used by
 /// `status()`) and the in-memory registry view (used by
 /// `aggregate_status_event()` on the SSE hot path).
-/// What: for each id, calls `registry.open_palace` (cheap when the handle is
-/// already cached, slow only on first-ever open) and accumulates the three
-/// counts via `saturating_add` so overflow is impossible. Palaces that fail
-/// to open are silently skipped — one bad palace must not blank the
-/// dashboard.
-/// Test: indirectly through `status_endpoint_returns_payload`.
+/// Why (issue #4637): this used to call `registry.open_palace` per id. On a
+/// daemon with 5,794 palaces on disk and a 64-slot LRU that is ~5,730 cold
+/// opens of ~1s each — roughly 90 minutes of blocking disk I/O inline on the
+/// async executor, which made `GET /api/v1/status` never respond. Switching
+/// to `PalaceRegistry::peek` (a mutex lock + `Arc` clone, zero I/O, no LRU
+/// promotion) makes the call O(n) in cheap lock acquisitions instead of O(n)
+/// in cold palace opens. This mirrors the fix #1924 already landed in
+/// `console_metrics.rs`.
+/// What: for each id, `peek`s the registry and accumulates the three counts
+/// via `saturating_add` so overflow is impossible. Ids that are not currently
+/// cached contribute nothing and are counted only by the caller's own
+/// `palace_count`. The totals are consequently a cache-resident
+/// approximation — callers must surface `cached_palace_count` alongside them
+/// so the wire shape says so.
+/// Test: `status_does_not_open_uncached_palaces`, and indirectly through
+/// `status_endpoint_returns_payload`.
 pub(crate) fn collect_palace_stats<'a, I>(state: &AppState, ids: I) -> PalaceStats
 where
     I: IntoIterator<Item = &'a PalaceId>,
 {
     let (mut total_drawers, mut total_vectors, mut total_kg_triples): (usize, usize, usize) =
         (0, 0, 0);
+    let mut cached_palace_count: usize = 0;
     for id in ids {
-        if let Ok(handle) = state.registry.open_palace(&state.data_root, id) {
+        // #4637: peek() not open_palace() — full-registry open is O(n) cold disk I/O
+        if let Some(handle) = state.registry.peek(id) {
             total_drawers = total_drawers.saturating_add(handle.drawers.read().len());
             total_vectors = total_vectors.saturating_add(handle.vector_store.index_size());
             total_kg_triples = total_kg_triples.saturating_add(handle.kg.count_active_triples());
+            cached_palace_count += 1;
         }
     }
     PalaceStats {
         total_drawers,
         total_vectors,
         total_kg_triples,
+        cached_palace_count,
     }
+}
+
+/// List every palace on disk without blocking the async executor.
+///
+/// Why (issue #4637): `PalaceRegistry::list_palaces` is a synchronous
+/// directory walk that reads one `palace.json` per palace — at 5,794 palaces
+/// that is thousands of `stat`+read syscalls. Every caller in the service
+/// layer ran it inline on a tokio worker. `console_metrics.rs` already hops
+/// to the blocking pool for exactly this call; this helper makes that the
+/// shared behaviour instead of a one-off.
+/// What: clones `data_root`, runs the walk on `spawn_blocking`, and folds
+/// both the join error and the walk error into `anyhow`.
+/// Test: exercised by every `list_palaces`/`status` service test.
+pub(crate) async fn list_palaces_blocking(state: &AppState) -> Result<Vec<Palace>> {
+    let root = state.data_root.clone();
+    tokio::task::spawn_blocking(move || {
+        trusty_common::memory_core::PalaceRegistry::list_palaces(&root)
+    })
+    .await
+    .map_err(|e| anyhow!("join list_palaces: {e}"))?
+    .map_err(|e| anyhow!("list palaces: {e:#}"))
+}
+
+/// Open a handle for every palace in `palaces`, off the async executor.
+///
+/// Why (issue #4637): the cross-palace recall fan-out genuinely needs every
+/// palace open — answering a recall from cache-resident palaces only would
+/// silently drop ~98.9% of the corpus, which is a correctness regression, not
+/// an optimisation. So `peek()` is the wrong tool here. What *was* wrong is
+/// that the open loop ran inline on a tokio worker thread, parking it for the
+/// full duration. This helper keeps the semantics (every palace is opened)
+/// and moves the blocking work to the blocking pool where it belongs. Three
+/// byte-identical copies of this loop previously existed (`MemoryService::recall_all`,
+/// `chat::tools::execute_recall_all`, `tools::memory_ops::handle_memory_recall_all`).
+/// What: clones the registry `Arc` + `data_root`, opens each palace serially
+/// on `spawn_blocking` (serial on purpose — parallel cold opens would thrash
+/// the 64-slot LRU), and skips failures with a `tracing::warn!` so one bad
+/// palace cannot fail the whole fan-out. `label` names the caller in that
+/// warning.
+/// Test: `recall_all_opens_every_palace` pins that the fan-out still sees
+/// palaces that were never cached.
+pub(crate) async fn open_palaces_blocking(
+    state: &AppState,
+    palaces: &[Palace],
+    label: &'static str,
+) -> Vec<Arc<PalaceHandle>> {
+    let registry = Arc::clone(&state.registry);
+    let root = state.data_root.clone();
+    let ids: Vec<PalaceId> = palaces.iter().map(|p| p.id.clone()).collect();
+    // #4637: open_palace is correct here (recall must see every palace) but must
+    // not run inline on the async executor — hop to the blocking pool.
+    tokio::task::spawn_blocking(move || {
+        let mut handles = Vec::with_capacity(ids.len());
+        for id in &ids {
+            match registry.open_palace(&root, id) {
+                Ok(h) => handles.push(h),
+                Err(e) => tracing::warn!(palace = %id, "{label}: open failed: {e:#}"),
+            }
+        }
+        handles
+    })
+    .await
+    .unwrap_or_else(|e| {
+        tracing::warn!("{label}: join open_palaces failed: {e}");
+        Vec::new()
+    })
 }
 
 /// Build a `PalaceInfo` from a `Palace` row plus an optional opened handle.
@@ -187,7 +274,11 @@ where
 /// the helper avoids field-set drift between them.
 /// What: reads drawer/vector/triple counts, distinct rooms, max
 /// `created_at`, KG node/edge/community counts, and the `is_compacting` flag.
-/// Test: `palace_list_includes_richer_counts`, `palace_list_includes_graph_counts`.
+/// When `handle` is `None` every count is `0` and `cached` is `false` — since
+/// issue #4637 that is the normal case on the full-registry list route, so
+/// `cached` is what tells a client "these zeros mean unknown, not empty".
+/// Test: `palace_list_includes_richer_counts`, `palace_list_includes_graph_counts`,
+/// `list_palaces_does_not_open_uncached_palaces`.
 pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> PalaceInfo {
     let (
         drawer_count,
@@ -231,6 +322,7 @@ pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> 
         edge_count,
         community_count,
         is_compacting,
+        cached: handle.is_some(),
     }
 }
 
@@ -532,5 +624,167 @@ mod tests {
     fn drawer_snippet_handles_empty_content() {
         assert_eq!(drawer_snippet(""), "");
         assert_eq!(drawer_snippet("   \n\t  "), "");
+    }
+
+    /// Build an `AppState` over a temp dir whose registry holds at most two
+    /// open handles, with palaces `a`, `b`, `c` created in that order.
+    ///
+    /// Why: a capacity-2 LRU plus three creations gives a deterministic
+    /// cached/evicted split — `a` is guaranteed evicted, `b` and `c` are
+    /// guaranteed resident — which is exactly the shape the #4637 regression
+    /// guards need. Mirrors the fixture the #1924 guard uses in
+    /// `console_metrics.rs`.
+    /// What: returns the `AppState`; the temp dir is leaked so it outlives the
+    /// test body (same convention as `test_state`).
+    /// Test: used by `list_palaces_does_not_open_uncached_palaces`,
+    /// `status_does_not_open_uncached_palaces`, and
+    /// `open_palaces_blocking_opens_every_palace`.
+    fn state_with_one_evicted_palace() -> AppState {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let data_root = tmp.path().to_path_buf();
+        std::mem::forget(tmp);
+
+        let registry = trusty_common::memory_core::PalaceRegistry::with_max_open(2);
+        for name in ["a", "b", "c"] {
+            let palace = Palace {
+                id: PalaceId::new(name),
+                name: name.to_string(),
+                description: None,
+                created_at: Utc::now(),
+                data_dir: data_root.join(name),
+            };
+            registry
+                .create_palace(&data_root, palace)
+                .unwrap_or_else(|e| panic!("create_palace({name}) failed: {e:#}"));
+        }
+        assert_eq!(registry.len(), 2, "capacity-2 registry holds 2 of 3");
+        assert!(
+            registry.peek(&PalaceId::new("a")).is_none(),
+            "'a' must be evicted before the route under test runs"
+        );
+
+        let mut state = AppState::new(data_root);
+        state.registry = Arc::new(registry);
+        state
+    }
+
+    /// Issue #4637 regression guard — `GET /api/v1/palaces` must never
+    /// force-open a palace that isn't already in the registry's LRU cache.
+    ///
+    /// Why: the previous implementation called `open_palace` per row. On the
+    /// live daemon (5,794 palaces, 64-slot LRU) that is ~5,730 cold opens of
+    /// ~1s each per request — the route was unusable, and it evicted the
+    /// entire working set every time it ran. A test that only checked the row
+    /// count would not have caught that, so this asserts on the *cache*.
+    /// What: builds the capacity-2 / three-palace fixture, calls
+    /// `MemoryService::list_palaces`, and asserts (1) all three palaces are
+    /// listed, (2) the evicted one is flagged `cached: false` with zero counts
+    /// while the resident ones are `cached: true`, and (3) the registry's
+    /// membership and size are byte-for-byte unchanged — nothing was opened,
+    /// nothing was evicted.
+    /// Test: this test.
+    #[tokio::test]
+    async fn list_palaces_does_not_open_uncached_palaces() {
+        let state = state_with_one_evicted_palace();
+        let svc = MemoryService::new(state.clone());
+
+        let rows = svc.list_palaces().await.expect("list_palaces");
+
+        assert_eq!(rows.len(), 3, "every on-disk palace is still listed");
+        let row = |id: &str| {
+            rows.iter()
+                .find(|r| r.id == id)
+                .unwrap_or_else(|| panic!("row for '{id}' present"))
+        };
+        assert!(!row("a").cached, "'a' was evicted, so it is not cached");
+        assert_eq!(
+            row("a").drawer_count,
+            0,
+            "an uncached row reports 0 (unknown), not a live count"
+        );
+        assert!(row("b").cached, "'b' is resident");
+        assert!(row("c").cached, "'c' is resident");
+
+        assert_eq!(
+            state.registry.len(),
+            2,
+            "list_palaces must not grow the LRU cache"
+        );
+        assert!(
+            state.registry.peek(&PalaceId::new("a")).is_none(),
+            "list_palaces must not reopen the evicted palace 'a'"
+        );
+        assert!(state.registry.peek(&PalaceId::new("b")).is_some());
+        assert!(state.registry.peek(&PalaceId::new("c")).is_some());
+    }
+
+    /// Issue #4637 regression guard — `GET /api/v1/status` must never
+    /// force-open a palace that isn't already cached.
+    ///
+    /// Why: `status()` fed every on-disk palace id through
+    /// `collect_palace_stats`, which called `open_palace` per id. Measured
+    /// live, the endpoint did not respond within 90s while `/health` returned
+    /// in 36ms. The totals are now a cache-resident roll-up, which is only
+    /// honest if `cached_palace_count` says so — this pins both halves.
+    /// What: builds the capacity-2 / three-palace fixture, calls
+    /// `MemoryService::status`, and asserts `palace_count` still reports all
+    /// three on-disk palaces while `cached_palace_count` reports only the two
+    /// resident ones, and that the cache is untouched afterwards.
+    /// Test: this test.
+    #[tokio::test]
+    async fn status_does_not_open_uncached_palaces() {
+        let state = state_with_one_evicted_palace();
+        let svc = MemoryService::new(state.clone());
+
+        let payload = svc.status().await;
+
+        assert_eq!(
+            payload.palace_count, 3,
+            "palace_count still reflects every palace on disk"
+        );
+        assert_eq!(
+            payload.cached_palace_count, 2,
+            "the totals cover only the 2 cache-resident palaces"
+        );
+
+        assert_eq!(
+            state.registry.len(),
+            2,
+            "status must not grow the LRU cache"
+        );
+        assert!(
+            state.registry.peek(&PalaceId::new("a")).is_none(),
+            "status must not reopen the evicted palace 'a'"
+        );
+    }
+
+    /// Issue #4637 — the recall fan-out deliberately still opens every palace.
+    ///
+    /// Why: this is the other half of the fix and the more important half to
+    /// pin. `peek()` is the right tool for stat/list routes and the WRONG tool
+    /// here — a cross-palace recall answered from cache-resident palaces only
+    /// would silently omit ~98.9% of the corpus. If someone later "optimises"
+    /// `open_palaces_blocking` into a `peek`, this test fails.
+    /// What: builds the capacity-2 / three-palace fixture (so `a` is evicted)
+    /// and asserts `open_palaces_blocking` still returns three handles,
+    /// including one for the palace that was not cached.
+    /// Test: this test.
+    #[tokio::test]
+    async fn open_palaces_blocking_opens_every_palace() {
+        let state = state_with_one_evicted_palace();
+        let palaces = list_palaces_blocking(&state).await.expect("list palaces");
+        assert_eq!(palaces.len(), 3);
+
+        let handles = open_palaces_blocking(&state, &palaces, "test").await;
+
+        assert_eq!(
+            handles.len(),
+            3,
+            "recall fan-out must open every palace, including uncached ones"
+        );
+        assert!(
+            handles.iter().any(|h| h.id == PalaceId::new("a")),
+            "the evicted palace 'a' must still be opened and searched"
+        );
     }
 }

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -239,8 +239,8 @@ pub(crate) async fn list_palaces_blocking(state: &AppState) -> Result<Vec<Palace
 /// the 64-slot LRU), and skips failures with a `tracing::warn!` so one bad
 /// palace cannot fail the whole fan-out. `label` names the caller in that
 /// warning.
-/// Test: `recall_all_opens_every_palace` pins that the fan-out still sees
-/// palaces that were never cached.
+/// Test: `open_palaces_blocking_opens_every_palace` pins that the fan-out
+/// still sees palaces that were never cached.
 pub(crate) async fn open_palaces_blocking(
     state: &AppState,
     palaces: &[Palace],

--- a/crates/trusty-memory/src/service/types.rs
+++ b/crates/trusty-memory/src/service/types.rs
@@ -41,6 +41,18 @@ pub struct PalaceInfo {
     pub community_count: u64,
     #[serde(default)]
     pub is_compacting: bool,
+    /// Whether the palace's handle was resident in the registry's open-handle
+    /// cache when this row was built (issue #4637).
+    ///
+    /// The full-registry list route no longer force-opens every palace — at
+    /// 5,794 palaces that was ~90 minutes of cold disk I/O per request. When
+    /// this is `false`, `drawer_count` / `vector_count` / `kg_triple_count` /
+    /// `wing_count` / `node_count` / `edge_count` / `community_count` are `0`
+    /// because they are **unknown**, not because they are empty; fetch
+    /// `GET /api/v1/palaces/{id}` for live counts on a specific palace.
+    /// `#[serde(default)]` keeps the field omissible for older clients.
+    #[serde(default)]
+    pub cached: bool,
 }
 
 /// Dream statistics wire shape used by both per-palace and aggregate endpoints.
@@ -198,15 +210,30 @@ pub struct KgGraphPayload {
 }
 
 /// Status payload returned by `GET /api/v1/status`.
+///
+/// Issue #4637 changed the meaning of the three `total_*` fields: they are now
+/// summed over the palaces resident in the registry's open-handle cache, not
+/// over every palace on disk, because summing over disk meant force-opening
+/// ~5,730 cold palaces per request. `palace_count` still reports the true
+/// on-disk total; `cached_palace_count` reports how many of those the totals
+/// actually cover.
 #[derive(Serialize, Clone, Debug)]
 pub struct StatusPayload {
     pub version: String,
+    /// Every palace on disk.
     pub palace_count: usize,
     pub default_palace: Option<String>,
     pub data_root: String,
+    /// Summed over cache-resident palaces only — see the type docs (#4637).
     pub total_drawers: usize,
+    /// Summed over cache-resident palaces only — see the type docs (#4637).
     pub total_vectors: usize,
+    /// Summed over cache-resident palaces only — see the type docs (#4637).
     pub total_kg_triples: usize,
+    /// How many of `palace_count` palaces the three totals above cover
+    /// (issue #4637). `#[serde(default)]` keeps it omissible for older clients.
+    #[serde(default)]
+    pub cached_palace_count: usize,
 }
 
 /// Service-level error type that maps cleanly onto HTTP status codes.

--- a/crates/trusty-memory/src/tools/memory_ops.rs
+++ b/crates/trusty-memory/src/tools/memory_ops.rs
@@ -463,22 +463,12 @@ pub(crate) async fn handle_memory_recall_all(state: &AppState, args: Value) -> R
     // List every palace on disk and open a handle for each. Palaces
     // that fail to open are skipped with a warning so a single bad
     // namespace cannot fail the whole fan-out.
-    let root = state.data_root.clone();
-    let palaces = tokio::task::spawn_blocking(move || {
-        trusty_common::memory_core::PalaceRegistry::list_palaces(&root)
-    })
-    .await
-    .context("join list_palaces")??;
+    let palaces = crate::service::helpers::list_palaces_blocking(state).await?;
 
-    let mut handles = Vec::with_capacity(palaces.len());
-    for p in &palaces {
-        match state.registry.open_palace(&state.data_root, &p.id) {
-            Ok(h) => handles.push(h),
-            Err(e) => {
-                tracing::warn!(palace = %p.id, "memory_recall_all: open failed: {e:#}")
-            }
-        }
-    }
+    // #4637: open_palace (not peek) is deliberate — recall must see every
+    // palace; the shared helper keeps the blocking opens off the async executor.
+    let handles =
+        crate::service::helpers::open_palaces_blocking(state, &palaces, "memory_recall_all").await;
 
     // Issue #1970: BM25 + L0/L1 fallback across every palace while warming.
     let results = if state.readiness() == DaemonReadiness::Warming {


### PR DESCRIPTION
Carries the issue #1924 fix pattern — `PalaceRegistry::peek` instead of `PalaceRegistry::open_palace` — from the MCP `console_metrics` handler across to the HTTP handler path, where it was never applied.

Closes #4637

## The bug

`MemoryService::status`, `MemoryService::list_palaces`, and their chat-surface twins looped over **every** palace on disk calling `PalaceRegistry::open_palace` — a synchronous per-palace load (usearch vector index, KG redb, full drawer-table load + prune, recall-log redb) — inline on the async axum executor, with no `spawn_blocking`, no timeout and no pagination.

The open-handle LRU caps at `DEFAULT_MAX_OPEN_PALACES = 64` (`crates/trusty-common/src/memory_core/registry.rs:70`), so on the live daemon ~97% of palaces are cold opens at ~0.9–1.1 s each.

Routing was traced and confirmed: `GET /api/v1/status` → `palace_routes::status` → `MemoryService::status()`, and `GET /api/v1/palaces` → `palace_routes::list_palaces` → `MemoryService::list_palaces()` — exactly the functions changed here.

## Measured

**Before** — live launchd daemon (`com.trusty.memory`, PID 29856, port 7070, unmodified binary), 2,192 palaces on disk. Not restarted for this measurement:

```
/health              http=200 time_total=0.001404s
/api/v1/status       http=000 time_total=120.066615s   <- timed out
/api/v1/palaces      http=000 time_total=120.136525s   <- timed out
```

**After** — this branch, in-process harness driving `MemoryService::status()` / `::list_palaces()` against the same real data root (`~/Library/Application Support/trusty-memory/palaces`) with a cold, empty registry:

```
data_root = /Users/masa/Library/Application Support/trusty-memory/palaces
status()       : 56.72875ms   palace_count=2184 cached_palace_count=0 total_drawers=0
list_palaces() : 50.806417ms  rows=2183 cached_rows=0
registry open handles after both calls = 0 (0 == no palace was opened)
```

**Two honest caveats on that number:**

1. This is a **harness** measurement, not a second daemon on an alternate port. Standing up a second `trusty-memory serve` against the live data root would run `load_palaces_from_disk` and contend on redb locks with the running daemon, which the task forbade — so I did not. The harness calls the same service methods over the same real data root; it does not exercise the axum/HTTP layer.
2. The `registry open handles = 0` line is the load-bearing assertion, not the millisecond figure: it proves the route completed without opening a single palace, which is the actual behavioural change. The before/after asymmetry (real daemon vs. harness) is why I lean on that rather than on 120 s → 57 ms as a like-for-like ratio.

## What changed

**Converted to `peek()`** — cache-only, zero-I/O, non-promoting:
- `MemoryService::list_palaces` (`service/core.rs`)
- `collect_palace_stats` (`service/helpers.rs`), which backs `MemoryService::status` and the SSE `aggregate_status_event`
- chat twins `execute_list_palaces` and `execute_get_status` (`chat/tools.rs`) — the latter had a byte-identical inline copy of `collect_palace_stats` and now delegates to it

**Deliberately NOT converted** — `peek()` would be a correctness regression here:
- `recall_all` (`GET /api/v1/recall`) + its chat and MCP twins
- `dream_run` (`POST /api/v1/dream/run`)

A cross-palace recall answered from cache-resident palaces only would silently omit ~97% of the corpus — a wrong answer that looks like a right one, which is strictly worse than a slow correct one. A dream cycle that skipped uncached palaces would silently stop maintaining them, with nothing reporting it. These keep opening every palace; what changed is that the blocking opens moved to `spawn_blocking` so they no longer park a tokio worker thread. They are still slow by nature — making them fast needs a cross-palace index or an explicit palace scope, not a cache-only read. Three byte-identical copies of that open loop collapsed into one `open_palaces_blocking` helper.

`PalaceRegistry::list_palaces` (a directory walk reading one `palace.json` per palace) also moved to the blocking pool, via a shared `list_palaces_blocking` helper.

## API shape

Both new fields are `#[serde(default)]`, so clients that do not know them are unaffected.

- `StatusPayload` gains `cached_palace_count`. `palace_count` is unchanged and still reports the true on-disk total; `total_drawers` / `total_vectors` / `total_kg_triples` now cover the cache-resident subset only, and `cached_palace_count` is what makes that legible rather than silent. **This is a real reduction in fidelity** — on the live daemon at most 64 of 2,184 palaces are resident, so the totals will read low. That is the documented tradeoff #1924 already made for the same reason, and the alternative is an endpoint that does not answer.
- `PalaceInfo` gains `cached: bool`. When `false`, the row's counts are `0` because they are *unknown*, not empty. `GET /api/v1/palaces/{id}` still opens the palace and returns live counts; it is unaffected.

## Tests

- `list_palaces_does_not_open_uncached_palaces` / `status_does_not_open_uncached_palaces` — capacity-2 registry with three palaces, so one is deterministically evicted. They assert on the **LRU cache itself**: after the call the evicted palace is still evicted and `registry.len()` is unchanged. A row-count assertion alone would not have caught the original bug.
- `open_palaces_blocking_opens_every_palace` — pins the other direction, so a future "optimisation" of the recall fan-out into a `peek()` fails the suite.

## Related, not addressed here

- A separate unbounded handle leak is confirmed real and tracked on its own issue: `session_stores` (`crates/trusty-memory/src/lib.rs:287`) opens `chat_sessions.redb` per palace with `.insert()` and never `.remove()` — no TTL, no cap, no removal on palace delete; ~844 leaked handles currently point at already-deleted files. Not in this PR's files and not expanded into here. fd exhaustion was investigated and ruled out as the current hang mechanism (1,073 / 8,192 fds, 13%).
- The `trusty-code` turn recorder creates ~250–300 `t-tmp*` palaces/day (`crates/trusty-code/src/session/registry_memory_sink.rs`), which is why the on-disk count got so high. Out of scope — an owner decision. The O(n) fix is correct regardless of how many palaces exist.

## Gates

```
cargo check -p trusty-memory                          Finished, clean
cargo test -p trusty-memory                           473 passed; 0 failed; 4 ignored
cargo test -p trusty-common                           240 passed; 0 failed; 6 ignored
cargo clippy -p trusty-memory --all-targets -D warn   Finished, clean
cargo fmt --check                                     clean (exit 0)
bash scripts/check_line_cap.sh                        3589 files, 0 violations — OK
bash scripts/check_changelog_fragment.sh              OK trusty-memory: fragment present and valid
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
