### PR TITLE
fix(trusty-code): stop the turn recorder minting one memory palace per session (#4638)

### DIFF
--- a/crates/trusty-code/changelog.d/4638-turn-recorder-palace-leak.md
+++ b/crates/trusty-code/changelog.d/4638-turn-recorder-palace-leak.md
@@ -1,0 +1,37 @@
+Fixed
+
+- **Turn recorder no longer mints one memory palace per session (issue
+  #4638).** `SessionRegistry::memory_sink_for` derives the recorder's palace id
+  from the session's project root, so a session bound to a `tempfile::TempDir`
+  produced a per-RUN-unique id (`t-tmp<random>` on macOS) and the drain task's
+  `ensure_palace` step (#2424) auto-created that palace on the live
+  trusty-memory daemon at the first turn. Nothing could ever read it back — the
+  root it was keyed to is swept when the run ends — so the orphans accumulated
+  at ~250-300/day: 5,667 in three weeks, 97.8% of every palace on the affected
+  machine, which turned trusty-memory's O(n) full-registry HTTP handlers
+  (#4637) into a ~90-minute `GET /api/v1/status`. The sink now carries an
+  explicit `PalaceCreation` entitlement, `Allowed` only for a durable project
+  root and `Forbidden` for one under a system temp root, making `palace_create`
+  structurally unreachable from an ephemeral root rather than merely unlikely.
+  N sessions therefore mint at most ONE palace — the project's — reused by
+  every session on that project and shared with the PM catch-up digest, with
+  sessions distinguished inside it by `chat_turn_append`'s `session_id` and
+  `memory_remember`'s `session:<id>` tag exactly as `recall_session` (#2348)
+  already expects.
+  - Recording itself is unchanged: a `Forbidden` sink is still constructed (so
+    the PM's `recall_session` tool surface does not change for a temp-rooted
+    run) and still dual-writes into a palace that already exists — only
+    bringing a NEW one into being is withheld. When its palace is absent the
+    turn is dropped rather than written, since `memory_remember` against a
+    missing palace fails `-32603` anyway; the probe is re-issued each turn so a
+    palace created out-of-band mid-session is picked up.
+  - The dominant real-world source was the crate's own test suite: dozens of
+    tests across `task::executor_tests`, `task::protocol_tests`, and
+    `tests/*_e2e.rs` drive sessions against `TempDir` project roots while the
+    sink resolves the LIVE daemon URL, so every `cargo test -p trusty-code` on
+    a machine with a running trusty-memory daemon permanently leaked palaces.
+    The fix is inside the daemon rather than in test-harness env isolation, so
+    it also protects an end user who binds a session to a temp directory.
+  - Pre-existing `t-tmp*` palaces are untouched — this change never deletes
+    anything and degrades gracefully if it encounters one (a `Forbidden` sink
+    whose palace happens to exist simply writes into it).

--- a/crates/trusty-code/src/session/memory_sink.rs
+++ b/crates/trusty-code/src/session/memory_sink.rs
@@ -25,6 +25,19 @@
 //! palace and fails `-32603 "palace metadata missing"` against a missing
 //! one, which is exactly how the #2343 soak lost all 50 turns. The ensure
 //! result is cached on success so steady state adds zero extra RPCs.
+//! (#4638) That auto-create is gated on [`PalaceCreation`], decided from the
+//! session's project root by `SessionRegistry::memory_sink_for`. The palace id
+//! is DERIVED from that root, so an ephemeral root (a `tempfile::TempDir`)
+//! yields a per-run-unique id and the ensure minted one permanent, unreadable
+//! palace per run — 5,667 `t-tmp<random>` orphans in three weeks, 97.8% of
+//! every palace on the machine, which made trusty-memory's O(n) full-registry
+//! handlers (#4637) unusable. A palace is an expensive object (usearch index,
+//! KG redb, drawer table, recall log), not a per-session scratch container:
+//! the intended shape is ONE durable palace per PROJECT with each session
+//! distinguished INSIDE it by `chat_turn_append`'s `session_id` and
+//! `memory_remember`'s `session:<id>` tag, and that shape is what
+//! [`PalaceCreation::Forbidden`] restores by making `palace_create`
+//! unreachable from an ephemeral root.
 //! (#2363) `memory_remember`'s dedup gate (jaro_winkler >0.92,
 //! 5-min same-palace window) is documented as hostile to sequential
 //! conversational turns, so every turn-recorder write passes `force: true`
@@ -51,7 +64,7 @@ use std::path::Path;
 
 use serde_json::json;
 use tokio::sync::mpsc;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 use crate::memory_envelope::call_tool_wrapped;
 
@@ -63,6 +76,34 @@ use crate::memory_envelope::call_tool_wrapped;
 /// policy below kicks in.
 /// Test: `memory_sink::tests::enqueue_drops_newest_when_queue_full`.
 pub const QUEUE_CAPACITY: usize = 50;
+
+/// Whether a sink is entitled to bring its target palace into EXISTENCE
+/// (#4638).
+///
+/// Why: the recorder's palace id is derived from the session's project root,
+/// so an EPHEMERAL root yields an id that is unique per run — and `drain`'s
+/// [`ensure_palace`] step then auto-created one permanent, unreadable palace
+/// for every such run. That is how 5,667 `t-tmp<random>` orphans accumulated
+/// in three weeks (97.8% of every palace on the machine), which in turn made
+/// trusty-memory's O(n) full-registry handlers (#4637) unusable. A palace is
+/// an expensive object (usearch vector index, KG redb, drawer table, recall
+/// log), not a cheap per-session namespace, so the entitlement to mint one is
+/// modelled explicitly rather than left implicit in "whoever writes first
+/// wins". Making it a two-variant enum rather than a `bool` parameter means no
+/// call site can pass the dangerous value by accident.
+/// What: [`Self::Allowed`] reproduces the pre-#4638 behavior exactly (probe,
+/// then `palace_create` on a miss — #2424); [`Self::Forbidden`] probes and
+/// writes into a palace that already exists but never creates one, so a sink
+/// carrying it can never increase the palace count.
+/// Test: `memory_sink::tests::forbidden_creation_never_creates_a_palace`,
+/// `memory_sink::tests::ensure_palace_creates_missing_palace_once`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PalaceCreation {
+    /// The project root is durable — auto-create the palace if missing (#2424).
+    Allowed,
+    /// The project root is ephemeral — never auto-create (#4638).
+    Forbidden,
+}
 
 /// One user-prompt/assistant-response turn queued for durable dual-write.
 #[derive(Debug, Clone)]
@@ -89,6 +130,8 @@ pub struct TurnMemorySink {
     base_url: String,
     /// This sink's already-resolved palace id (#2348 reuse).
     palace: String,
+    /// Whether this sink may bring `palace` into existence (#4638).
+    creation: PalaceCreation,
 }
 
 impl TurnMemorySink {
@@ -96,8 +139,8 @@ impl TurnMemorySink {
     /// `base_url`, and spawn its background drain task with the default
     /// [`QUEUE_CAPACITY`].
     /// Test: `memory_sink::tests::enqueue_drain_happy_path`.
-    pub fn new(base_url: String, palace: String) -> Self {
-        Self::with_capacity(base_url, palace, QUEUE_CAPACITY)
+    pub fn new(base_url: String, palace: String, creation: PalaceCreation) -> Self {
+        Self::with_capacity(base_url, palace, QUEUE_CAPACITY, creation)
     }
 
     /// Same as [`Self::new`] with an explicit queue capacity — tests use a
@@ -116,14 +159,30 @@ impl TurnMemorySink {
     /// receiver half of a `capacity`-bounded channel; returns the sink
     /// holding only the sender half.
     /// Test: `memory_sink::tests::enqueue_drops_newest_when_queue_full`.
-    pub fn with_capacity(base_url: String, palace: String, capacity: usize) -> Self {
+    pub fn with_capacity(
+        base_url: String,
+        palace: String,
+        capacity: usize,
+        creation: PalaceCreation,
+    ) -> Self {
         let (tx, rx) = mpsc::channel(capacity);
-        tokio::spawn(drain(base_url.clone(), palace.clone(), rx));
+        tokio::spawn(drain(base_url.clone(), palace.clone(), creation, rx));
         Self {
             tx,
             base_url,
             palace,
+            creation,
         }
+    }
+
+    /// Whether this sink may bring its palace into existence (#4638).
+    ///
+    /// Why: the #4638 bound is a property of the sink, so it must be
+    /// observable to assert on directly rather than inferred from RPC traffic.
+    /// What: returns the [`PalaceCreation`] fixed at construction.
+    /// Test: `registry_tests::memory_sink_for_many_sessions_mint_at_most_one_palace`.
+    pub fn palace_creation(&self) -> PalaceCreation {
+        self.creation
     }
 
     /// This sink's already-resolved trusty-memory base URL.
@@ -197,15 +256,46 @@ impl TurnMemorySink {
 /// and so a failed ensure is naturally retried on the next turn (the flag is
 /// only set on success), covering a daemon that comes up mid-session.
 /// What: on success `palace_ensured` latches true and steady state adds
-/// zero extra RPCs per turn; on failure the turn's writes are still
-/// attempted (fail-open — they carry their own warnings).
+/// zero extra RPCs per turn; on failure under [`PalaceCreation::Allowed`] the
+/// turn's writes are still attempted (fail-open — they carry their own
+/// warnings).
+///
+/// (#4638) Under [`PalaceCreation::Forbidden`] a failed ensure means "this
+/// palace does not exist and I am not entitled to create it", so the turn is
+/// DROPPED instead of written: the two writes could not have landed anyway
+/// (`memory_remember` fails `-32603 "palace metadata missing"` against an
+/// absent palace), and skipping them keeps a temp-rooted session down to one
+/// probe RPC per turn instead of three. The ensure is deliberately re-probed
+/// rather than latched-off, so a Forbidden sink whose palace is created
+/// out-of-band mid-session (or whose daemon was merely down for the first
+/// probe) starts recording normally — "the daemon is unreachable" and "the
+/// palace is absent" are not distinguishable from one failed probe, and only
+/// the latter is permanent.
 /// Test: `memory_sink::tests::ensure_palace_creates_missing_palace_once`,
-/// `memory_sink::tests::ensure_palace_skips_create_when_palace_exists`.
-async fn drain(base_url: String, palace: String, mut rx: mpsc::Receiver<QueuedTurn>) {
+/// `memory_sink::tests::ensure_palace_skips_create_when_palace_exists`,
+/// `memory_sink::tests::forbidden_creation_never_creates_a_palace`,
+/// `memory_sink::tests::forbidden_creation_still_writes_to_an_existing_palace`.
+async fn drain(
+    base_url: String,
+    palace: String,
+    creation: PalaceCreation,
+    mut rx: mpsc::Receiver<QueuedTurn>,
+) {
     let mut palace_ensured = false;
     while let Some(turn) = rx.recv().await {
         if !palace_ensured {
-            palace_ensured = ensure_palace(&base_url, &palace).await;
+            palace_ensured = ensure_palace(&base_url, &palace, creation).await;
+        }
+        // #4638: no palace and no entitlement to make one — the writes below
+        // are guaranteed to fail, so don't issue them.
+        if !palace_ensured && creation == PalaceCreation::Forbidden {
+            debug!(
+                palace = %palace,
+                session_id = %turn.session_id,
+                "turn_recorder: dropping turn — palace absent and auto-create \
+                 withheld for an ephemeral project root (#4638)"
+            );
+            continue;
         }
         write_turn(&base_url, &palace, &turn).await;
     }
@@ -230,14 +320,24 @@ async fn drain(base_url: String, palace: String, mut rx: mpsc::Receiver<QueuedTu
 /// authz gate in default single-tenant mode) via `tools/call`. Never
 /// propagates an error — failure is logged and reported as `false` so the
 /// caller retries on the next turn.
+///
+/// (#4638) `creation` gates the CREATE half only — the probe always runs, so a
+/// [`PalaceCreation::Forbidden`] sink still discovers and uses a palace that
+/// already exists. Returning `false` without attempting a create is what makes
+/// the bound structural: `palace_create` is unreachable from an ephemeral
+/// project root, not merely unlikely.
 /// Test: `memory_sink::tests::ensure_palace_creates_missing_palace_once`,
-/// `memory_sink::tests::ensure_palace_skips_create_when_palace_exists`.
-async fn ensure_palace(base_url: &str, palace: &str) -> bool {
+/// `memory_sink::tests::ensure_palace_skips_create_when_palace_exists`,
+/// `memory_sink::tests::forbidden_creation_never_creates_a_palace`.
+async fn ensure_palace(base_url: &str, palace: &str, creation: PalaceCreation) -> bool {
     if call_tool_wrapped(base_url, "palace_info", json!({"palace": palace}))
         .await
         .is_ok()
     {
         return true;
+    }
+    if creation == PalaceCreation::Forbidden {
+        return false;
     }
     let create_params = json!({
         "name": palace,

--- a/crates/trusty-code/src/session/memory_sink_tests.rs
+++ b/crates/trusty-code/src/session/memory_sink_tests.rs
@@ -136,7 +136,7 @@ async fn wait_for_captures(captured: &Captured, n: usize, timeout: Duration) {
 #[tokio::test]
 async fn enqueue_drain_happy_path() {
     let (base_url, captured) = spawn_capturing_mock(PalaceState::Exists).await;
-    let sink = TurnMemorySink::new(base_url, "test-palace".to_string());
+    let sink = TurnMemorySink::new(base_url, "test-palace".to_string(), PalaceCreation::Allowed);
 
     sink.enqueue("sess-1", "what is 2+2?", "4");
     // 3 calls: palace_info (ensure, #2424) + the two dual-write calls.
@@ -194,7 +194,7 @@ async fn enqueue_drain_happy_path() {
 #[tokio::test]
 async fn ensure_palace_creates_missing_palace_once() {
     let (base_url, captured) = spawn_capturing_mock(PalaceState::MissingUntilCreated).await;
-    let sink = TurnMemorySink::new(base_url, "test-palace".to_string());
+    let sink = TurnMemorySink::new(base_url, "test-palace".to_string(), PalaceCreation::Allowed);
 
     sink.enqueue("sess-1", "p1", "r1");
     sink.enqueue("sess-1", "p2", "r2");
@@ -237,7 +237,7 @@ async fn ensure_palace_creates_missing_palace_once() {
 #[tokio::test]
 async fn ensure_palace_skips_create_when_palace_exists() {
     let (base_url, captured) = spawn_capturing_mock(PalaceState::Exists).await;
-    let sink = TurnMemorySink::new(base_url, "test-palace".to_string());
+    let sink = TurnMemorySink::new(base_url, "test-palace".to_string(), PalaceCreation::Allowed);
 
     sink.enqueue("sess-1", "p1", "r1");
     sink.enqueue("sess-1", "p2", "r2");
@@ -254,6 +254,87 @@ async fn ensure_palace_skips_create_when_palace_exists() {
     assert!(
         !names.contains(&"palace_create"),
         "an existing palace must never be re-created (metadata clobber)"
+    );
+}
+
+/// (#4638) THE BOUND, at the RPC layer: a [`PalaceCreation::Forbidden`] sink
+/// must never issue `palace_create`, so it can never increase the palace count
+/// no matter how many turns it drains.
+///
+/// Why: this is the leak itself. The palace id is derived from the session's
+/// project root, so a `tempfile::TempDir` root yields a per-RUN-unique id and
+/// the `Allowed` path auto-created one permanent, unreadable palace for every
+/// such run — 5,667 `t-tmp<random>` orphans, 97.8% of every palace on the
+/// machine. Asserting only that the happy path still works would not have
+/// caught that; the absence of `palace_create` is the whole property.
+/// What: drives the SAME `MissingUntilCreated` mock that
+/// `ensure_palace_creates_missing_palace_once` proves DOES create under
+/// `Allowed`, and asserts the Forbidden sink's entire RPC trace is probes —
+/// no `palace_create`, and no doomed `chat_turn_append`/`memory_remember`
+/// against a palace that does not exist.
+#[tokio::test]
+async fn forbidden_creation_never_creates_a_palace() {
+    let (base_url, captured) = spawn_capturing_mock(PalaceState::MissingUntilCreated).await;
+    let sink = TurnMemorySink::new(
+        base_url,
+        "t-tmpdeadbeef".to_string(),
+        PalaceCreation::Forbidden,
+    );
+
+    for i in 0..5 {
+        sink.enqueue("sess-ephemeral", format!("p{i}"), format!("r{i}"));
+    }
+    // Nothing to wait FOR (the assertion is an absence), so give the drain
+    // task ample time to do the wrong thing if the gate is broken.
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let names: Vec<&str> = calls.iter().map(|(_, p)| tool_name(p)).collect();
+    assert!(
+        !names.contains(&"palace_create"),
+        "a Forbidden sink must never mint a palace, however many turns it \
+         drains (#4638); got {names:?}"
+    );
+    assert!(
+        !names.contains(&"chat_turn_append") && !names.contains(&"memory_remember"),
+        "writes into a palace known not to exist are guaranteed to fail — \
+         they must be skipped, not issued (#4638); got {names:?}"
+    );
+    assert!(
+        names.iter().all(|n| *n == "palace_info"),
+        "the only traffic a homeless Forbidden sink may generate is its \
+         re-probe; got {names:?}"
+    );
+}
+
+/// (#4638) Withholding CREATE must not withhold RECORDING: a Forbidden sink
+/// whose palace already exists must dual-write exactly like an Allowed one.
+///
+/// Why: the fix bounds palace CREATION, not turn recording. If Forbidden also
+/// suppressed writes into an existing palace, a session bound to a durable
+/// project that merely resolved through an unusual root would silently stop
+/// recording — a regression of #2345 dressed up as a fix. This pins the
+/// distinction the design rests on.
+#[tokio::test]
+async fn forbidden_creation_still_writes_to_an_existing_palace() {
+    let (base_url, captured) = spawn_capturing_mock(PalaceState::Exists).await;
+    let sink = TurnMemorySink::new(
+        base_url,
+        "already-there".to_string(),
+        PalaceCreation::Forbidden,
+    );
+
+    sink.enqueue("sess-1", "p1", "r1");
+    // 3 calls: palace_info (probe) + both dual-write calls.
+    wait_for_captures(&captured, 3, Duration::from_secs(2)).await;
+
+    let calls = captured.lock().unwrap_or_else(|e| e.into_inner()).clone();
+    let names: Vec<&str> = calls.iter().map(|(_, p)| tool_name(p)).collect();
+    assert_eq!(
+        names,
+        vec!["palace_info", "chat_turn_append", "memory_remember"],
+        "an existing palace must still receive the full dual-write under \
+         PalaceCreation::Forbidden (#4638)"
     );
 }
 
@@ -290,7 +371,11 @@ async fn write_turn_warns_on_skipped_status() {
         let _ = axum::serve(listener, app).await;
     });
 
-    let sink = TurnMemorySink::new(format!("http://{addr}"), "test-palace".to_string());
+    let sink = TurnMemorySink::new(
+        format!("http://{addr}"),
+        "test-palace".to_string(),
+        PalaceCreation::Allowed,
+    );
     sink.enqueue("sess-skip", "prompt", "response");
     // The assertion is simply that this never panics/hangs; give the drain
     // task a moment to run.
@@ -307,6 +392,7 @@ fn base_url_and_palace_expose_construction_args() {
         tx,
         base_url: "http://example.test:1234".to_string(),
         palace: "a-palace".to_string(),
+        creation: PalaceCreation::Allowed,
     };
     assert_eq!(sink.base_url(), "http://example.test:1234");
     assert_eq!(sink.palace(), "a-palace");
@@ -317,7 +403,11 @@ fn base_url_and_palace_expose_construction_args() {
 /// also covers a failed palace ensure (probe AND create both unreachable).
 #[tokio::test]
 async fn write_turn_is_fail_open_on_unreachable_daemon() {
-    let sink = TurnMemorySink::new("http://127.0.0.1:1".to_string(), "p".to_string());
+    let sink = TurnMemorySink::new(
+        "http://127.0.0.1:1".to_string(),
+        "p".to_string(),
+        PalaceCreation::Allowed,
+    );
     sink.enqueue("sess-2", "prompt", "response");
     // Give the drain task a moment to attempt (and fail) the calls; the test
     // passing at all (no panic, no hang) is the assertion.
@@ -338,6 +428,7 @@ fn enqueue_drops_newest_when_queue_full() {
         tx,
         base_url: String::new(),
         palace: String::new(),
+        creation: PalaceCreation::Allowed,
     };
 
     sink.enqueue("s1", "p1", "r1");

--- a/crates/trusty-code/src/session/mod.rs
+++ b/crates/trusty-code/src/session/mod.rs
@@ -32,7 +32,7 @@ pub mod registry;
 pub mod transcript;
 
 pub use connector::TcodeConnector;
-pub use memory_sink::TurnMemorySink;
+pub use memory_sink::{PalaceCreation, TurnMemorySink};
 pub use model::{Session, SessionStatus};
 pub use registry::SessionRegistry;
 pub use transcript::{GoalSlotRecord, TranscriptRecord};

--- a/crates/trusty-code/src/session/registry_memory_sink.rs
+++ b/crates/trusty-code/src/session/registry_memory_sink.rs
@@ -10,13 +10,20 @@
 //! constructed exactly ONCE per session — see the `memory_sink` module's own
 //! docs — not once per `task.run`; this is the single lazy-init/lookup entry
 //! point `task::executor::run_and_record` calls at each run's turn boundary.
+//! It is therefore also the ONE place that knows the session's project root at
+//! sink-construction time, which makes it the only place that can enforce the
+//! #4638 bound: the recorder may bring a NEW palace into being for a durable
+//! project root and never for an ephemeral one.
 //! What: [`SessionRegistry::memory_sink_for`].
 //! Test: `registry_tests::memory_sink_for_reuses_the_same_sink_across_calls`,
-//! `registry_tests::memory_sink_for_unknown_session_returns_none`.
+//! `registry_tests::memory_sink_for_unknown_session_returns_none`,
+//! `registry_tests::memory_sink_for_many_sessions_mint_at_most_one_palace`.
 
 use std::path::Path;
 
-use crate::session::memory_sink::{TurnMemorySink, derive_palace_id_for_project};
+use tracing::debug;
+
+use crate::session::memory_sink::{PalaceCreation, TurnMemorySink, derive_palace_id_for_project};
 
 use super::*;
 
@@ -56,9 +63,45 @@ impl SessionRegistry {
     /// orphaned palace on every projectless run. The whole sink is already
     /// fail-open and fire-and-forget, so its absence costs a projectless run
     /// nothing but the durable turn record it has no home for anyway.
+    ///
+    /// (#4638) This is also where the sink's [`PalaceCreation`] entitlement is
+    /// decided, and that decision is the fix for the leak the paragraph above
+    /// was written to prevent. The projectless branch guarded only the `None`
+    /// case, so a session BOUND to a `tempfile::TempDir` walked straight
+    /// through it: [`derive_palace_id_for_project`] fell to its
+    /// `parent_dir_slug` level and produced a per-RUN-unique id
+    /// (`t-tmp<random>` on macOS, from `$TMPDIR/.tmpXXXXXX`), and
+    /// [`TurnMemorySink`]'s drain task auto-CREATED that palace on the live
+    /// daemon at the first turn. Every such run minted one palace nothing would
+    /// ever read again: 5,667 orphans in three weeks, 97.8% of every palace on
+    /// the machine, which turned trusty-memory's O(n) full-registry handlers
+    /// (#4637) into a ~90-minute `GET /api/v1/status`. A palace is an expensive
+    /// object (usearch index, KG redb, drawer table, recall log), not a cheap
+    /// namespace, and the trusty-code suite alone drives dozens of temp-rooted
+    /// sessions per `cargo test` run.
+    ///
+    /// The BOUND: [`PalaceCreation::Allowed`] only for a DURABLE project root,
+    /// so the recorder can create at most one palace per real project, reused
+    /// by every session on that project forever — the same palace
+    /// `catchup::pm_catchup_context` reads its digest from. N sessions create
+    /// at most one palace, never N. Sessions stay distinguishable INSIDE it via
+    /// `chat_turn_append`'s `session_id` and `memory_remember`'s
+    /// `session:<id>` tag (exactly how #2348's `recall_session` already scopes
+    /// its query), so no session-level recall is lost.
+    ///
+    /// An ephemeral root still gets a full sink — only the CREATE is withheld.
+    /// That distinction is deliberate: the sink is what registers #2348's
+    /// `recall_session` tool and what `run_and_record` reuses for its
+    /// `base_url`/`palace`, so returning `None` here would silently change the
+    /// PM's tool surface for a temp-rooted run. With
+    /// [`PalaceCreation::Forbidden`] the drain task still writes into a palace
+    /// that ALREADY exists and merely declines to bring a new one into being —
+    /// see `memory_sink::drain`.
     /// Test: `registry_tests::memory_sink_for_reuses_the_same_sink_across_calls`,
     /// `registry_tests::memory_sink_for_unknown_session_returns_none`,
-    /// `registry_tests::memory_sink_for_projectless_session_returns_none`.
+    /// `registry_tests::memory_sink_for_projectless_session_returns_none`,
+    /// `registry_tests::memory_sink_for_temp_rooted_session_forbids_palace_create`,
+    /// `registry_tests::memory_sink_for_many_sessions_mint_at_most_one_palace`.
     pub fn memory_sink_for(
         &self,
         id: &str,
@@ -70,7 +113,20 @@ impl SessionRegistry {
         if entry.memory_sink.is_none() {
             let palace = derive_palace_id_for_project(project_dir);
             let base_url = trusty_common::mcp::memory_rpc::resolve_memory_base_url_or_unreachable();
-            entry.memory_sink = Some(Arc::new(TurnMemorySink::new(base_url, palace)));
+            // #4638: only a durable project root entitles the recorder to bring
+            // a new palace into being — a temp root's id is unique per run.
+            let creation = if trusty_common::bin_resolve::is_under_system_temp(project_dir) {
+                debug!(
+                    project_dir = %project_dir.display(),
+                    palace = %palace,
+                    "turn_recorder: project root is under a system temp root — \
+                     palace auto-create withheld (#4638)"
+                );
+                PalaceCreation::Forbidden
+            } else {
+                PalaceCreation::Allowed
+            };
+            entry.memory_sink = Some(Arc::new(TurnMemorySink::new(base_url, palace, creation)));
         }
         entry.memory_sink.clone()
     }

--- a/crates/trusty-code/src/session/registry_tests.rs
+++ b/crates/trusty-code/src/session/registry_tests.rs
@@ -1039,6 +1039,21 @@ async fn begin_pm_transcript_unknown_session_errors() {
     assert_eq!(err.code, -32007);
 }
 
+/// A DURABLE (non-temp) project root for the `memory_sink_for` tests.
+///
+/// Why (#4638): `memory_sink_for` now refuses any project root under a system
+/// temp root, so these tests can no longer use a `TempDir` — that is the very
+/// input the fix rejects. The path need not exist: `memory_sink_for` does no
+/// filesystem I/O, and `derive_palace_id_for_project`'s `git config` probe on a
+/// missing directory simply fails and falls through to the parent/dir slug,
+/// which is the branch under test. Using a synthetic path rather than a real
+/// on-disk fixture also keeps the suite from writing outside its temp space.
+/// What: a fixed absolute path whose last two components slugify to a stable
+/// palace id (`projects-tcode-fixture`).
+fn durable_project_root() -> &'static std::path::Path {
+    std::path::Path::new("/nonexistent-durable-root/projects/tcode-fixture")
+}
+
 /// `memory_sink_for` (#2345) must construct exactly ONE sink for a session
 /// and return the SAME `Arc` on every subsequent call — proving the sink (and
 /// therefore its background drain task) survives across repeated
@@ -1047,13 +1062,12 @@ async fn begin_pm_transcript_unknown_session_errors() {
 async fn memory_sink_for_reuses_the_same_sink_across_calls() {
     let registry = SessionRegistry::new();
     let session = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
-    let project_dir = tempfile::TempDir::new().unwrap();
 
     let first = registry
-        .memory_sink_for(&session.id, Some(project_dir.path()))
+        .memory_sink_for(&session.id, Some(durable_project_root()))
         .expect("first call constructs a sink");
     let second = registry
-        .memory_sink_for(&session.id, Some(project_dir.path()))
+        .memory_sink_for(&session.id, Some(durable_project_root()))
         .expect("second call reuses the sink");
 
     assert!(
@@ -1067,11 +1081,107 @@ async fn memory_sink_for_reuses_the_same_sink_across_calls() {
 #[tokio::test]
 async fn memory_sink_for_unknown_session_returns_none() {
     let registry = SessionRegistry::new();
-    let project_dir = tempfile::TempDir::new().unwrap();
     assert!(
         registry
-            .memory_sink_for("nope", Some(project_dir.path()))
+            .memory_sink_for("nope", Some(durable_project_root()))
             .is_none()
+    );
+}
+
+/// (#4638) A session bound to a project root under a system temp root must
+/// still get a sink — but one that is FORBIDDEN to bring its palace into
+/// existence.
+///
+/// Why: the palace id is derived from the project root, and every
+/// `tempfile::TempDir` has a fresh random basename, so such a sink's palace id
+/// is unique per run. Letting it auto-create is what minted 5,667 permanent,
+/// unreadable `t-tmp<random>` orphans in three weeks (97.8% of every palace on
+/// the machine). The sink itself must survive, though: it is what registers
+/// #2348's `recall_session` on the PM's tool surface, so suppressing it
+/// entirely would change a temp-rooted run's behavior far beyond storage.
+/// What: asserts `PalaceCreation::Forbidden` for a raw `TempDir` path AND for
+/// the canonicalized form `ProjectBinding::resolve` hands the real
+/// `run_and_record` call path (macOS rewrites `/var/folders/…` to
+/// `/private/var/folders/…`, so the guard must recognise both spellings).
+#[tokio::test]
+async fn memory_sink_for_temp_rooted_session_forbids_palace_create() {
+    let registry = SessionRegistry::new();
+    let project_dir = tempfile::TempDir::new().unwrap();
+
+    let raw = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let sink = registry
+        .memory_sink_for(&raw.id, Some(project_dir.path()))
+        .expect("a temp-rooted session still gets a sink");
+    assert_eq!(
+        sink.palace_creation(),
+        crate::session::PalaceCreation::Forbidden,
+        "a temp-rooted session must never be entitled to mint a palace (#4638)"
+    );
+
+    let binding = crate::binding::ProjectBinding::resolve(Some(project_dir.path().to_path_buf()))
+        .expect("tempdir must bind");
+    let canonical = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+    let sink = registry
+        .memory_sink_for(&canonical.id, binding.root())
+        .expect("a temp-rooted session still gets a sink");
+    assert_eq!(
+        sink.palace_creation(),
+        crate::session::PalaceCreation::Forbidden,
+        "the CANONICALIZED temp root the real run_and_record path passes must \
+         be recognised too (#4638)"
+    );
+}
+
+/// (#4638) THE BOUND: N sessions must not be able to mint N palaces.
+///
+/// Why: a bound is the whole point of the fix, so it is asserted directly
+/// rather than inferred from a happy path. Before #4638 this exact loop would
+/// have yielded 50 distinct create-entitled palace ids — the 1:1
+/// session-to-palace ratio that accumulated 5,667 orphans and pushed
+/// trusty-memory's O(n) full-registry handlers (#4637) to ~90 minutes per
+/// `GET /api/v1/status`.
+/// What: drives 50 distinct sessions — 25 against ONE shared durable project
+/// root, 25 against 25 DISTINCT temp roots — and counts the set of palace ids
+/// that could actually be created, i.e. `palace()` taken only from sinks whose
+/// `palace_creation()` is `Allowed`. That set must have exactly one member.
+/// Counting create-entitled ids rather than sinks is deliberate: it measures
+/// palaces-that-could-be-minted, which is the quantity that leaked.
+#[tokio::test]
+async fn memory_sink_for_many_sessions_mint_at_most_one_palace() {
+    let registry = SessionRegistry::new();
+    let mut creatable: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    let mut temp_rooted = 0usize;
+
+    for _ in 0..25 {
+        let durable = registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        let sink = registry
+            .memory_sink_for(&durable.id, Some(durable_project_root()))
+            .expect("a durable project root must still record turns");
+        if sink.palace_creation() == crate::session::PalaceCreation::Allowed {
+            creatable.insert(sink.palace().to_string());
+        }
+
+        let ephemeral =
+            registry.create("t".to_string(), None, crate::binding::ProjectBinding::None);
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sink = registry
+            .memory_sink_for(&ephemeral.id, Some(tmp.path()))
+            .expect("a temp-rooted session still gets a sink");
+        temp_rooted += 1;
+        if sink.palace_creation() == crate::session::PalaceCreation::Allowed {
+            creatable.insert(sink.palace().to_string());
+        }
+    }
+
+    assert_eq!(
+        temp_rooted, 25,
+        "sanity: every ephemeral session was exercised"
+    );
+    assert_eq!(
+        creatable.len(),
+        1,
+        "50 sessions may mint at most ONE palace — the shared durable \
+         project's; got {creatable:?}"
     );
 }
 

--- a/crates/trusty-common/changelog.d/4638-is-under-system-temp-public.md
+++ b/crates/trusty-common/changelog.d/4638-is-under-system-temp-public.md
@@ -1,0 +1,14 @@
+Changed
+
+- **`bin_resolve::is_under_system_temp` is now public (issue #4638).** Promoted
+  from a private helper of `is_ephemeral_build_path` so trusty-code's turn
+  recorder can ask the one question it needs — "is this project root under a
+  system temp root?" — without duplicating the #4485 temp-root prefix,
+  `TMPDIR`, and macOS symlink-alias logic. Behavior is unchanged; this is a
+  visibility change only.
+  - Callers deciding whether a PROJECT root is durable must use this rather
+    than `is_ephemeral_build_path`, whose `EPHEMERAL_PATH_SEGMENTS` half also
+    flags `.claude/worktrees/` — an ephemeral BINARY location but a durable
+    project checkout that carries the repo's git remote. A new test
+    (`is_under_system_temp_is_true_for_temp_and_false_for_worktrees`) pins that
+    distinction so the two predicates cannot quietly converge.

--- a/crates/trusty-common/src/bin_resolve.rs
+++ b/crates/trusty-common/src/bin_resolve.rs
@@ -248,9 +248,17 @@ const SYSTEM_TEMP_ROOTS: &[&str] = &[
 /// parent (`/`) is ignored rather than allowed to reject every absolute path.
 /// Deliberately free of `#[cfg(target_os)]`: the extra Unix roots simply never
 /// match on Windows, where `temp_dir()` supplies the real answer.
+///
+/// (#4638) Public because a SECOND caller needs exactly this question and
+/// nothing else in [`is_ephemeral_build_path`]: trusty-code's turn recorder
+/// refuses to mint a memory palace for a temp-rooted project. That caller must
+/// NOT use `is_ephemeral_build_path`, whose [`EPHEMERAL_PATH_SEGMENTS`] half
+/// also flags `.claude/worktrees/` — a legitimate, git-remote-carrying project
+/// checkout whose turns belong in the repo's real palace.
 /// Test: `is_ephemeral_build_path_flags_system_temp_paths`,
-/// `is_ephemeral_build_path_ignores_temp_lookalike_paths`.
-fn is_under_system_temp(path: &Path) -> bool {
+/// `is_ephemeral_build_path_ignores_temp_lookalike_paths`,
+/// `is_under_system_temp_is_true_for_temp_and_false_for_worktrees`.
+pub fn is_under_system_temp(path: &Path) -> bool {
     if SYSTEM_TEMP_ROOTS.iter().any(|root| path.starts_with(root)) {
         return true;
     }
@@ -376,6 +384,41 @@ mod tests {
                 "{p} is not under a temp ROOT and must NOT be flagged"
             );
         }
+    }
+
+    /// Why (#4638): trusty-code's turn recorder asks THIS predicate — not
+    /// [`is_ephemeral_build_path`] — whether a session's project root is
+    /// durable enough to justify minting a memory palace for it. The two must
+    /// stay distinguishable: a `.claude/worktrees/` checkout is an ephemeral
+    /// BINARY location but a perfectly durable PROJECT (it carries the repo's
+    /// git remote, so its turns belong in the repo's real palace), and
+    /// conflating the two would silently stop recording every agent session.
+    /// What: pins that `is_under_system_temp` flags real temp roots in both
+    /// macOS spellings while accepting a worktree path that
+    /// `is_ephemeral_build_path` deliberately rejects.
+    #[test]
+    fn is_under_system_temp_is_true_for_temp_and_false_for_worktrees() {
+        for p in [
+            "/private/var/folders/xx/T/.tmpAbC123/project",
+            "/tmp/claude-502/session/scratchpad",
+        ] {
+            assert!(
+                is_under_system_temp(Path::new(p)),
+                "{p} is under a system temp root and must be flagged"
+            );
+        }
+
+        let worktree = Path::new("/Users/x/repo/.claude/worktrees/eng-1");
+        assert!(
+            !is_under_system_temp(worktree),
+            "a worktree checkout is a durable PROJECT root — it must not be \
+             flagged as temp (#4638)"
+        );
+        assert!(
+            is_ephemeral_build_path(worktree),
+            "sanity: the same path IS an ephemeral BINARY location, which is \
+             exactly why the turn recorder must not use that predicate"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #4638

## The defect

`SessionRegistry::memory_sink_for` derives the turn recorder's palace id from the session's **project root**. A session bound to a `tempfile::TempDir` therefore produced a per-RUN-unique id — `t-tmp<random>` on macOS, from `$TMPDIR/.tmpXXXXXX` via `parent_dir_slug` — and the drain task's `ensure_palace` step (#2424) **auto-created that palace on the live daemon** at the first turn.

Nothing could ever read it back: the root the id is keyed to is swept when the run ends. So the orphans accumulated at ~250-300/day — **5,667 in three weeks, 97.8% of every palace on the affected machine** — which turned trusty-memory's O(n) full-registry handlers (#4637) into a ~90-minute `GET /api/v1/status`.

The design error is treating a palace as a per-session scratch container. It is an expensive object: usearch vector index, KG redb, drawer table, recall log.

**The dominant real-world source was this crate's own test suite.** Dozens of tests across `task::executor_tests`, `task::protocol_tests`, and `tests/*_e2e.rs` drive real sessions against `TempDir` project roots while the sink resolves the **live** daemon URL (`resolve_memory_base_url_or_unreachable`, no injection seam at that call site). Every `cargo test -p trusty-code` on a machine with a running trusty-memory daemon permanently leaked palaces.

## The fix

The sink now carries an explicit `PalaceCreation` entitlement, decided from the project root at construction:

| Project root | Entitlement | `palace_create` reachable? |
|---|---|---|
| Durable (a real repo/dir) | `Allowed` | yes — once, then reused forever (#2424 behavior, unchanged) |
| Under a system temp root | `Forbidden` | **no — structurally unreachable** |

This makes the bound structural rather than probabilistic. It is a two-variant enum, not a `bool` parameter, so no call site can pass the dangerous value by accident.

### The bound

**N sessions mint at most ONE palace** — the project's — reused by every session on that project and shared with the PM catch-up digest. Sessions stay distinguishable *inside* it via `chat_turn_append`'s `session_id` and `memory_remember`'s `session:<id>` tag, which is exactly how `recall_session` (#2348) already scopes its query. This is the "one durable palace per project, sessions as records inside it" shape the rest of the system already models; the leak was that shape breaking down when project identity resolved to a throwaway path.

### What is deliberately *not* changed

A `Forbidden` sink is **still constructed** and still dual-writes into a palace that already exists. Only bringing a *new* one into being is withheld. That distinction matters: the sink is what registers `recall_session` on the PM's tool surface and what `run_and_record` reuses for its `base_url`/`palace`, so returning `None` would have silently changed a temp-rooted run's tool surface — a regression of #2345 dressed up as a fix.

When the palace is absent, the turn is dropped rather than written (`memory_remember` against a missing palace fails `-32603` regardless), which also drops a doomed session from 3 RPCs/turn to 1. The probe is re-issued each turn rather than latched off, so a palace created out-of-band mid-session — or a daemon that was merely down for the first probe — starts recording normally; one failed probe cannot distinguish "unreachable" from "absent", and only the latter is permanent.

### Why `is_under_system_temp` and not `is_ephemeral_build_path`

The guard reuses the existing, already-tested #4485 predicate (promoted from private to `pub`, no behavior change) rather than duplicating temp-root/symlink/`TMPDIR` logic. It deliberately does **not** use `is_ephemeral_build_path`, whose `EPHEMERAL_PATH_SEGMENTS` half also flags `.claude/worktrees/` — an ephemeral *binary* location but a perfectly durable *project* root that carries the repo's git remote. Conflating the two would have silently stopped recording every agent session. A new test pins that distinction.

This is the only change outside `crates/trusty-code`.

## Verification

**Live demo** against a scratch palace-counting stand-in on a temp data root (the real trusty-memory daemon was never touched, restarted, or pointed at):

| | palaces created by one full `cargo test -p trusty-code` |
|---|---|
| before | **12** (`t-tmp4bdyp7`, `t-tmpaiajwz`, `t-tmpas6ddk`, …) |
| after | **0** |

Suite green in both runs. The 12 names match the shape of the real orphans on disk exactly.

**Mutation-tested** — reverting the two guard lines makes all three new bound tests fail, and the failure output reproduces the leak verbatim: 26 distinct palace ids for 50 sessions.

New tests:
- `forbidden_creation_never_creates_a_palace` — RPC-level: a Forbidden sink's entire trace is probes; no `palace_create`, no doomed writes.
- `forbidden_creation_still_writes_to_an_existing_palace` — withholding CREATE must not withhold RECORDING.
- `memory_sink_for_temp_rooted_session_forbids_palace_create` — covers both the raw and the `ProjectBinding::resolve`-canonicalized macOS spelling.
- `memory_sink_for_many_sessions_mint_at_most_one_palace` — **the bound**: 50 sessions, 25 durable + 25 distinct temp roots, exactly one create-entitled palace id.
- `is_under_system_temp_is_true_for_temp_and_false_for_worktrees` — pins the worktree-vs-temp distinction.

Gates (raw exit codes): `cargo check -p trusty-code` ok · `cargo test -p trusty-code` 1600 passed, 0 failed · `cargo clippy -p trusty-code -p trusty-common --all-targets -- -D warnings` exit 0 · `cargo fmt --check` exit 0 · `check_line_cap.sh` 0 violations · `cargo check --workspace --all-targets` exit 0 excluding the three Tauri GUI crates, which fail on a pre-existing missing `ui/dist` frontend build unrelated to this change.

## Migration

None needed. Existing `t-tmp*` palaces are untouched — this change never deletes anything, and it degrades gracefully on encountering one (a Forbidden sink whose palace happens to exist simply writes into it). Filesystem cleanup of the existing backlog is being handled out-of-band.

## Out of scope

- The O(n) full-registry handler hang itself (#4637) — this PR removes the input that made it fatal, not the quadratic behavior.
- Test-harness env isolation. `run_task/tests.rs::isolate_ambient_daemons` exists but is scoped to that one module. Hoisting it would also help, but the fix belongs in the daemon: it must protect a real user who binds a session to a temp directory, not just the test suite.
- `derive_palace_id_for_project`'s slug-length/validity issue (#2443).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools