### PR TITLE
fix(trusty-mpm): default ticketing agent to sonnet, not haiku

### DIFF
--- a/crates/trusty-code/changelog.d/ticketing-agent-default-model-sonnet.md
+++ b/crates/trusty-code/changelog.d/ticketing-agent-default-model-sonnet.md
@@ -1,0 +1,6 @@
+Changed
+
+- `ticketing` agent's default model tier is now `sonnet`, up from `haiku`,
+  matching the trusty-mpm bundled default (kept byte-parity by
+  `scripts/check_agent_assets.sh`). Duplicate-detection and scope-boundary
+  judgement are judgement calls, not clerical ones.

--- a/crates/trusty-code/src/assets/agents/ticketing.md
+++ b/crates/trusty-code/src/assets/agents/ticketing.md
@@ -2,7 +2,7 @@
 name: ticketing
 role: ticketing
 description: Ticket management specialist. Creates, updates, and tracks issues with scope validation, scope-aware linking, and workflow state intelligence.
-model: haiku
+model: sonnet
 extends: base-agent
 skills: [brainstorming, git-workflow, requesting-code-review, writing-plans, json-data-handling, root-cause-tracing, systematic-debugging, verification-before-completion, internal-comms, test-driven-development]
 ---

--- a/crates/trusty-mpm/changelog.d/ticketing-agent-default-model-sonnet.md
+++ b/crates/trusty-mpm/changelog.d/ticketing-agent-default-model-sonnet.md
@@ -1,0 +1,8 @@
+Changed
+
+- `ticketing` agent's default model tier is now `sonnet`, up from `haiku`.
+  Duplicate-detection and scope-boundary judgement (is this issue already
+  filed, is this work in scope for a milestone) are judgement calls, not
+  clerical ones — observed 2026-08-03: a haiku-tier ticketing agent filed a
+  duplicate issue after being told not to, and cleared milestones on a shipped
+  release when asked only to report them.

--- a/crates/trusty-mpm/src/assets/agents/ticketing.md
+++ b/crates/trusty-mpm/src/assets/agents/ticketing.md
@@ -2,7 +2,7 @@
 name: ticketing
 role: ticketing
 description: Ticket management specialist. Creates, updates, and tracks issues with scope validation, scope-aware linking, and workflow state intelligence.
-model: haiku
+model: sonnet
 extends: base-agent
 skills: [brainstorming, git-workflow, requesting-code-review, writing-plans, json-data-handling, root-cause-tracing, systematic-debugging, verification-before-completion, internal-comms, test-driven-development]
 ---


### PR DESCRIPTION
## Summary

- Bump the bundled `ticketing` agent's default model tier from `haiku` to `sonnet` in both embedded copies (`crates/trusty-mpm/src/assets/agents/ticketing.md` and its byte-parity twin `crates/trusty-code/src/assets/agents/ticketing.md`, enforced by `scripts/check_agent_assets.sh`).
- Ticketing performs duplicate detection and scope judgement (does this issue already exist, is this work in scope for a milestone) — judgement calls, not clerical ones. Observed 2026-08-03: a haiku-tier ticketing agent filed a duplicate issue after being explicitly told not to, and cleared milestones on a shipped release when asked only to report them.

## Known follow-up (not fixed here — collision with an in-flight PR)

`crates/trusty-mpm/src/assets/instructions/sections/core.md` line ~57 has an agent-routing table row `| \`ticketing\` | issue create/update/close/label/triage/comment | haiku |` that is now stale. A separate PR is actively rewriting everything under `src/assets/instructions/`, so this PR does not touch it — filing this as an explicit follow-up instead.

## Test plan

- [x] `cargo test -p trusty-mpm` — full crate-scoped suite green
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `bash scripts/check_line_cap.sh` — OK
- [x] `bash scripts/check_agent_assets.sh` — OK (byte-parity maintained)
- [x] `bash scripts/check_instruction_floor.sh` — OK (untouched)
- [x] changelog fragments added: `crates/trusty-mpm/changelog.d/ticketing-agent-default-model-sonnet.md`, `crates/trusty-code/changelog.d/ticketing-agent-default-model-sonnet.md`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
