### PR TITLE
fix(trusty-mpm): sweep shipped asset text advertising retired .trusty-mpm/ overrides

### DIFF
--- a/crates/trusty-mpm/changelog.d/4286-shipped-asset-text-sweep.md
+++ b/crates/trusty-mpm/changelog.d/4286-shipped-asset-text-sweep.md
@@ -1,0 +1,23 @@
+Fixed
+
+- Swept shipped asset text that still advertised the five retired
+  `.trusty-mpm/` per-file PM instruction overrides (#4286): the `tm-workflow`
+  skill described them as the live customization mechanism and told the PM to
+  write to them; three output styles (`trusty-mpm`, `trusty-mpm-research`,
+  `trusty-mpm-teacher`) described the compiled prompt as four monolithic files
+  (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` + `AGENT_DELEGATION.md` +
+  `BASE_PM.md`) that haven't existed since #4183; `tm-delegation-patterns`,
+  `tm-circuit-breaker`, and `tm-pr-workflow` pointed at `AGENT_DELEGATION.md`
+  / `.trusty-mpm/INSTRUCTIONS.md` as if still reachable. All now describe the
+  current model: framework instructions compose from
+  `assets/instructions/sections/*.md`, and the sole project-customization
+  channel is a named-section marker in the project's root `CLAUDE.md` — `core`
+  is the only section such a marker cannot replace.
+- `assets/instructions/sections/workflow.md` pointed the project test-ladder
+  lookup at the retired `.trusty-mpm/INSTRUCTIONS.md`; it now points at
+  `CLAUDE.md`. This is a compiled-prompt change, so the `pm-prompt-bundled-
+  fallback.md` and `pm-prompt-roster-absent.md` golden fixtures were
+  regenerated (`UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden`) to match.
+- Verified no scaffolding path (`tm-init`, `tm project init`) creates any of
+  the five retired override files — the only writers found were the
+  `legacy_overrides` doctor check's own fixtures.

--- a/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/workflow.md
@@ -56,8 +56,8 @@ its review. This is the "spend the budget where blast radius is real" rule
 above, applied at the point of entry.
 
 The labels say nothing about how much testing a change needs. The project's
-test ladder in `.trusty-mpm/INSTRUCTIONS.md` answers that, and it is
-authoritative where the project defines one.
+test ladder in its `CLAUDE.md` answers that, and it is authoritative where the
+project defines one.
 
 ### Phase 1: Research (CONDITIONAL)
 **Agent**: `research`

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-research.md
@@ -34,10 +34,11 @@ without agent-verified evidence.
 
 **🔴 THIS IS ABSOLUTE. NO EXCEPTIONS** beyond the override phrases above. The
 full Prohibitions table, Circuit Breakers, Delegation Map, and PM Allowlist
-live in the appended system prompt (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` +
-`AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md` floor) whenever `tm`
-launches this session; the block above is this style's own self-contained
-floor for when that channel is absent (issue #2647).
+live in the appended system prompt (composed from
+`assets/instructions/sections/*.md` — `core`, `workflow`, `agent-delegation`,
+`enforcement`, and the rest) whenever `tm` launches this session; the block
+above is this style's own self-contained floor for when that channel is
+absent (issue #2647).
 
 ## Research Behavior (what makes this style different)
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm-teacher.md
@@ -33,10 +33,11 @@ claim "done"/"fixed"/"working" without agent-verified evidence.
 **🔴 THIS IS ABSOLUTE. NO EXCEPTIONS** beyond the override phrases above —
 teach the reasoning behind each delegation, but never skip it. The full
 Prohibitions table, Circuit Breakers, Delegation Map, and PM Allowlist live in
-the appended system prompt (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` +
-`AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md` floor) whenever `tm`
-launches this session; the block above is this style's own self-contained
-floor for when that channel is absent (issue #2647).
+the appended system prompt (composed from
+`assets/instructions/sections/*.md` — `core`, `workflow`, `agent-delegation`,
+`enforcement`, and the rest) whenever `tm` launches this session; the block
+above is this style's own self-contained floor for when that channel is
+absent (issue #2647).
 
 ## Teaching Behavior (what makes this style different)
 

--- a/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
+++ b/crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md
@@ -32,10 +32,11 @@ claim "done"/"fixed"/"working" without agent-verified evidence.
 
 **🔴 THIS IS ABSOLUTE. NO EXCEPTIONS** beyond the override phrases above. The
 full Prohibitions table, Circuit Breakers, Delegation Map, and PM Allowlist
-live in the appended system prompt (`PM_INSTRUCTIONS.md` + `WORKFLOW.md` +
-`AGENT_DELEGATION.md` + the non-overridable `BASE_PM.md` floor) whenever `tm`
-launches this session; the block above is this style's own self-contained
-floor for when that channel is absent (issue #2647).
+live in the appended system prompt (composed from
+`assets/instructions/sections/*.md` — `core`, `workflow`, `agent-delegation`,
+`enforcement`, and the rest) whenever `tm` launches this session; the block
+above is this style's own self-contained floor for when that channel is
+absent (issue #2647).
 
 Inspect the exact resolved text a tm-driven launch received: `tm session
 instructions` (or read `.trusty-mpm/last-instructions.md`).

--- a/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/skills.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-capabilities/references/skills.md
@@ -52,7 +52,7 @@ Generated from `bundle::ALL` (filtered to top-level `skills/*.md` entries) + a s
 | `tm-ticketing` | pm-workflow | yes | Ticket-driven development protocol and high-level ticketing orchestration for the trusty-mpm PM |
 | `tm-tool-usage-guide` | pm-reference | no | Detailed tool usage patterns and examples for the trusty-mpm PM agent |
 | `tm-verification-protocols` | pm-workflow | no | QA verification gate and evidence requirements for the trusty-mpm PM |
-| `tm-workflow` | pm-workflow | yes | Manage and customize the trusty-mpm PM workflow via project-level .trusty-mpm/ override files |
+| `tm-workflow` | pm-workflow | yes | Manage and customize the trusty-mpm PM workflow via named-section overrides in the project's CLAUDE.md |
 | `verification-before-completion` | agent-reference | no | Run verification commands and confirm output before claiming success |
 | `web-performance-optimization` | agent-reference | no | Optimize web performance using Core Web Vitals, modern patterns (View Transitions, Speculation Rules), and framework-specific techniques |
 | `webapp-testing` | agent-reference | no | Comprehensive web application testing patterns with Playwright selectors, wait strategies, and best practices |

--- a/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md
@@ -302,5 +302,5 @@ All CBs share one enforcement model:
 
 The PM must proactively check for violations before tool usage and delegate
 to the correct specialist agent — see `tm-delegation-patterns` for the
-agent-selection decision trees and `AGENT_DELEGATION.md` for the routing
-table.
+agent-selection decision trees and the bundled agent-delegation section
+(`assets/instructions/sections/agent-delegation.md`) for the routing table.

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -83,9 +83,9 @@ tell the user no dedicated ops agent exists yet.
 Language-specific Engineer selection follows `Cargo.toml` (rust-engineer),
 `tsconfig.json` (typescript-engineer), `pyproject.toml`/`setup.py`
 (python-engineer), `go.mod` (golang-engineer), `pom.xml`/`build.gradle`
-(java-engineer), `.csproj` — see `AGENT_DELEGATION.md`'s Language Detection
-section for the full table; when unknown, Research is mandatory (never
-default to a guess).
+(java-engineer), `.csproj` — see the bundled agent-delegation section
+(`assets/instructions/sections/agent-delegation.md`) for the full table; when
+unknown, Research is mandatory (never default to a guess).
 
 ## Long-Wait Delegation (chunked-repoll — issue #2833)
 

--- a/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md
@@ -153,10 +153,10 @@ matching the file's existing style.
   Treat it exactly like CB#8 (QA gate): block the merge, delegate back to the
   Engineer to add the entry, don't wave it through as "trivial."
 - If the project also runs automated changelog generation at release time (e.g.
-  a conventional-commits generator), check the project's own instructions (root
-  `CLAUDE.md` / `.trusty-mpm/INSTRUCTIONS.md`) for which mechanism owns
-  `CHANGELOG.md` before assuming they coexist safely. Two writers to one file is
-  a defect; do not invent a precedence rule on the fly.
+  a conventional-commits generator), check the project's own instructions
+  (root `CLAUDE.md`) for which mechanism owns `CHANGELOG.md` before assuming
+  they coexist safely. Two writers to one file is a defect; do not invent a
+  precedence rule on the fly.
 
 ## The trusty-review Gate
 

--- a/crates/trusty-mpm/src/assets/skills/tm-workflow.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-workflow.md
@@ -1,6 +1,6 @@
 ---
 name: tm-workflow
-description: Manage and customize the trusty-mpm PM workflow via project-level .trusty-mpm/ override files
+description: Manage and customize the trusty-mpm PM workflow via named-section overrides in the project's CLAUDE.md
 user-invocable: true
 version: "1.0.0"
 category: pm-workflow
@@ -12,11 +12,16 @@ effort: medium
 
 trusty-mpm has no separate "workflow engine" a project configures at
 runtime — the PM's phase/gate behavior comes from the bundled instruction
-package, and a project customizes it via marker blocks in `CLAUDE.md` or
-override files in `<project>/.trusty-mpm/`. This skill documents that
-mechanism, which is implemented (not aspirational) in
-`core/instruction_overrides.rs`, `core/instruction_pipeline.rs`, and
-`core/claude_md_sections.rs`.
+package, and a project customizes it via named-section marker blocks in its
+root `CLAUDE.md`. This skill documents that mechanism, which is implemented
+(not aspirational) in `core/instruction_overrides.rs`,
+`core/instruction_pipeline.rs`, and `core/claude_md_sections.rs`.
+
+The project-level `.trusty-mpm/{INSTRUCTIONS,AGENT_DELEGATION,WORKFLOW,MEMORY,
+PM_INSTRUCTIONS_DEPLOYED}.md` per-file override system described in older
+docs is RETIRED (#4286) — no code reads those files anymore, and a leftover
+one fails `tm doctor`'s `legacy_overrides` check. `CLAUDE.md` is the sole
+project customization surface.
 
 ## How the PM Prompt Is Assembled
 
@@ -27,35 +32,37 @@ composition; the prose for each section is stored separately in
 `assets/instructions/sections/*.md`, pulled in as `include_str!` constants
 registered in the `SECTION_SOURCES` table (`core/instruction_pipeline.rs`)
 — a missing section file is a compile error, not a launch-time surprise.
-Three sections (identity, non-overridable-rules,
-framework-guaranteed-conventions — the "floor") are tier `fixed` and cannot
-be overridden by any project.
+The nine marker tokens (`core/claude_md_sections.rs::section_token`) are
+`IDENTITY`, `CORE`, `MEMORY`, `SEARCH`, `WORKFLOW`, `AGENT-DELEGATION`,
+`ENFORCEMENT`, `NON-OVERRIDABLE-RULES`, and
+`FRAMEWORK-GUARANTEED-CONVENTIONS`. `CORE` is the only one a project cannot
+replace; every other section, including `NON-OVERRIDABLE-RULES` and
+`FRAMEWORK-GUARANTEED-CONVENTIONS`, can be overridden — there is no separate
+"floor" concept anymore (the `is_floor()`/`instruction_floor.sha256` machinery
+was itself retired by #4286, being the appearance of a control rather than a
+control a project-owned `CLAUDE.md` can actually enforce).
 
 At session start, `core/instruction_overrides.rs::resolve_pm_prompt` (reached
 via `build_system_prompt_for*`) composes the final prompt. It is not a file a
 user edits — it's composed fresh per launch. See "Inspecting the Resolved
 Prompt" below for where that composed prompt is stashed.
 
-A project can customize the non-floor sections two ways:
+A project customizes any non-`CORE` section one way: a named-section marker,
+`<!-- TRUSTY-MPM: <TOKEN> START v=1 -->` … `<!-- TRUSTY-MPM: <TOKEN> END -->`,
+in the project's root `CLAUDE.md` — the sole marker host
+(`core/claude_md_sections.rs::HOST_FILES`). This replaces exactly the
+matching section, nothing else.
 
-| Channel | Where | Effect |
-|---|---|---|
-| Named-section marker | `<!-- TRUSTY-MPM: <TOKEN> START v=1 -->` … `<!-- TRUSTY-MPM: <TOKEN> END -->` in `CLAUDE.md` or `.trusty-mpm/INSTRUCTIONS.md` (first host wins, `core/claude_md_sections.rs`) | Replaces exactly that section |
-| Per-file override | `.trusty-mpm/INSTRUCTIONS.md` (additive) / `AGENT_DELEGATION.md` / `WORKFLOW.md` / `MEMORY.md` / `PM_INSTRUCTIONS_DEPLOYED.md` (full-body replacement) | Replaces the matching section, or the whole body |
+The five legacy per-file overrides
+(`.trusty-mpm/{INSTRUCTIONS,AGENT_DELEGATION,WORKFLOW,MEMORY,
+PM_INSTRUCTIONS_DEPLOYED}.md`) are RETIRED (#4286) and are never read. Never
+create one; if a project still has one, move its contents into `CLAUDE.md`
+(plain prose, or a marker block for a specific section) and delete the file
+— `tm doctor`'s `legacy_overrides` check fails until it is gone.
 
-Both channels are live. `CLAUDE.md` is the surface project customization is
-consolidating onto (#4183/#4286), but the five per-file overrides still work
-exactly as before, and a same-section per-file override always wins over a
-named marker for that section.
-
-**The floor is never overridable.** Even `PM_INSTRUCTIONS_DEPLOYED.md`'s
-full-body replacement still gets the floor appended last — a hard invariant
-enforced by `resolve_pm_prompt`, not a convention.
-
-Robustness: a missing `.trusty-mpm/` directory, a missing override file, an
-empty override file, or an unreadable override file all fall back silently
-to the bundled default (with a `tracing::warn!` for the empty/unreadable
-cases) — a customization attempt never blanks a section or crashes launch.
+Robustness: a missing `CLAUDE.md`, a missing marker block, or an empty marker
+body all fall back silently to the bundled default — a customization attempt
+never blanks a section or crashes launch.
 
 The agent-delegation roster is DYNAMIC, not authored prose: it comes from
 `deployed_roster_section` → `roster_from_dirs`, a union of the project tier,
@@ -65,18 +72,20 @@ package where the roster generator is optional or absent (#4069).
 
 ## Making a Change
 
-Trigger phrases the PM should act on immediately:
+Trigger phrases the PM should act on immediately — all of them land in the
+project's root `CLAUDE.md`:
 
 | User says | PM writes to |
 |---|---|
-| "remember/always/never/for this project" | `.trusty-mpm/INSTRUCTIONS.md` |
-| "use X agent for Y" / "route/change agent" | `.trusty-mpm/AGENT_DELEGATION.md` |
-| "add/change workflow phase" | `.trusty-mpm/WORKFLOW.md` |
-| "memory behavior" | `.trusty-mpm/MEMORY.md` |
+| "remember/always/never/for this project" | Plain prose in `CLAUDE.md` (no marker needed) |
+| "use X agent for Y" / "route/change agent" | `<!-- TRUSTY-MPM: AGENT-DELEGATION START v=1 -->` block in `CLAUDE.md` |
+| "add/change workflow phase" | `<!-- TRUSTY-MPM: WORKFLOW START v=1 -->` block in `CLAUDE.md` |
+| "memory behavior" | `<!-- TRUSTY-MPM: MEMORY START v=1 -->` block in `CLAUDE.md` |
 
-After writing an override: confirm the file path to the user and note it
-"takes effect at next session startup" — the resolved prompt is only
-assembled at session-prepare time, not hot-reloaded mid-session.
+After writing an override: confirm the marker (or the added prose) to the
+user and note it "takes effect at next session startup" — the resolved
+prompt is only assembled at session-prepare time, not hot-reloaded
+mid-session.
 
 ## Inspecting the Resolved Prompt
 
@@ -100,16 +109,17 @@ replaceable via the override above) documents: Research (conditional) →
 Code Analysis review (mandatory gate) → Implementation → QA (mandatory
 gate) → Documentation, with skip conditions. This is genuinely tm's bundled
 default, not a claude-mpm holdover — but a project is free to replace the
-whole section via a `WORKFLOW` override (named marker or
-`.trusty-mpm/WORKFLOW.md`) if its delivery process differs (e.g. no Code
-Analysis gate, an extra Security phase, a different QA routing rule).
+whole section via a `WORKFLOW` named-section marker in `CLAUDE.md` if its
+delivery process differs (e.g. no Code Analysis gate, an extra Security
+phase, a different QA routing rule).
 
 ## Verification Gates
 
 Regardless of which phases are overridden, the verification-gate contract in
 `tm-verification-protocols` is not itself an override target — it is a
-project-independent invariant enforced by CB#8. A custom `WORKFLOW.md` can
-change *when* QA runs but not *whether* a completion claim requires evidence.
+project-independent invariant enforced by CB#8. A custom `WORKFLOW` override
+can change *when* QA runs but not *whether* a completion claim requires
+evidence.
 
 ## Related Skills
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -564,8 +564,8 @@ its review. This is the "spend the budget where blast radius is real" rule
 above, applied at the point of entry.
 
 The labels say nothing about how much testing a change needs. The project's
-test ladder in `.trusty-mpm/INSTRUCTIONS.md` answers that, and it is
-authoritative where the project defines one.
+test ladder in its `CLAUDE.md` answers that, and it is authoritative where the
+project defines one.
 
 ### Phase 1: Research (CONDITIONAL)
 **Agent**: `research`

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -564,8 +564,8 @@ its review. This is the "spend the budget where blast radius is real" rule
 above, applied at the point of entry.
 
 The labels say nothing about how much testing a change needs. The project's
-test ladder in `.trusty-mpm/INSTRUCTIONS.md` answers that, and it is
-authoritative where the project defines one.
+test ladder in its `CLAUDE.md` answers that, and it is authoritative where the
+project defines one.
 
 ### Phase 1: Research (CONDITIONAL)
 **Agent**: `research`


### PR DESCRIPTION
## Summary

Split piece B of the #4286 retirement (Split A retires the bundled
`assets/instructions/INSTRUCTIONS.md`; Split C migrates this repo's own
`.trusty-mpm/INSTRUCTIONS.md` — neither touched here).

PR #4665 retired the five project-level `.trusty-mpm/` PM instruction
override files (`INSTRUCTIONS.md`, `AGENT_DELEGATION.md`, `WORKFLOW.md`,
`MEMORY.md`, `PM_INSTRUCTIONS_DEPLOYED.md`). No code reads them anymore, and
a leftover one now fails `tm doctor`'s `legacy_overrides` check — but shipped
asset text still told users and the PM to create and use them. This PR
sweeps that text to describe the current model: framework instructions
compose from `assets/instructions/sections/*.md`, and a named-section marker
in the project's root `CLAUDE.md` is the sole customization channel (`core`
is the only section such a marker cannot replace).

## Grep hit list and per-hit verdict

`grep -rn "\.trusty-mpm/INSTRUCTIONS\|AGENT_DELEGATION\.md\|PM_INSTRUCTIONS_DEPLOYED\|\.trusty-mpm/WORKFLOW\|\.trusty-mpm/MEMORY" crates/ docs/ .claude/`

**Rewritten:**
| File | Fix |
|---|---|
| `crates/trusty-mpm/src/assets/skills/tm-workflow.md` | Full rewrite — frontmatter description, marker-token list (quoted from `claude_md_sections.rs::section_token`), the "Making a Change" table, robustness section, and the 5-phase-model override mention. Removed every per-file-override reference. |
| `crates/trusty-mpm/src/assets/output-styles/trusty-mpm.md`, `trusty-mpm-research.md`, `trusty-mpm-teacher.md` | Fixed the identical stale claim that the appended system prompt is `PM_INSTRUCTIONS.md + WORKFLOW.md + AGENT_DELEGATION.md + BASE_PM.md` (none of those files have existed since #4183) — now describes composition from `assets/instructions/sections/*.md`. |
| `crates/trusty-mpm/src/assets/instructions/sections/workflow.md:59` | "test ladder in `.trusty-mpm/INSTRUCTIONS.md`" → "test ladder in its `CLAUDE.md`". **This is a compiled-prompt change** — see delta below. |
| `crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md:86` | "`AGENT_DELEGATION.md`'s Language Detection section" (no such section exists) → points at `assets/instructions/sections/agent-delegation.md`. |
| `crates/trusty-mpm/src/assets/skills/tm-circuit-breaker.md:305` | Same `AGENT_DELEGATION.md` pointer fix. |
| `crates/trusty-mpm/src/assets/skills/tm-pr-workflow.md:157` | Dropped the `.trusty-mpm/INSTRUCTIONS.md` half of a "check root `CLAUDE.md` / `.trusty-mpm/INSTRUCTIONS.md`" pointer. |
| `crates/trusty-mpm/src/assets/skills/tm-capabilities/references/skills.md` | Regenerated (`tm generate capabilities`) to pick up the `tm-workflow` description change — auto-generated, no hand edit. |

**Out of scope, with reason:**
| File(s) | Reason |
|---|---|
| `crates/trusty-git-analytics/.claude-mpm/**` (51 tracked files) | A different, pre-existing tool namespace (`.claude-mpm`, hyphenated) — already documented elsewhere as dead/unread by any trusty-mpm code (`docs/research/architecture-review-2026-07-19.md:374`). Not this mechanism; separate cleanup. |
| `crates/trusty-mpm/CHANGELOG.md`, `changelog.d/4286-retire-trusty-mpm-override-files.md` | Historical record — already accurate, describes the retirement itself. |
| `crates/trusty-mpm/src/session_manager/worktree_safety_tests.rs:243` | Uses the path as an arbitrary tracked-file fixture for git-dirt bookkeeping tests; unrelated to instruction composition. |
| `crates/trusty-mpm/src/core/{bundled_pm_package,instruction_pipeline,instruction_overrides,claude_md_sections,delegation_authority}.rs` + their `_tests.rs` + `testdata/pm-prompt-claude-md-override.md` | **The composer** — explicitly out of scope per task constraints. Comments here are accurate implementation history, not shipped user-facing prose. |
| `crates/trusty-mpm/src/core/session_launch/tests.rs`, `src/bin/tm/tests_behavior_b_tests.rs` | Already correct — assert the retirement, not stale. |
| `crates/trusty-mpm/src/assets/instructions/sections/README.md`, `non-overridable-rules.md` | Already accurate — both explicitly state the five files are RETIRED. |
| `docs/research/**`, `docs/trusty-mpm/research/**`, `docs/trusty-agents/research/bake-off-challenges.md` | Dated, point-in-time research snapshots (the bake-off doc describes a *different* competing harness's file layout, not trusty-mpm's). Historical record, not living instructions. |
| `docs/adr/0024-*.md` | ADR — immutable decision record. |
| `docs/specs/SPEC-PMINSTR-01-*.md` | The spec that itself proposed/analyzed this exact retirement — self-referential historical analysis. |
| `docs/specs/session-manager-agent.md`, `docs/specs/mpm-behavior-conformance.md` | Living specs, but already carry a "stale as of 2026-08-01 — corrected below" self-annotation for the *prior* #4183 transition; that correction is now itself out of date re: #4665 (still says "nothing has removed the `.trusty-mpm/` override surface"). Needs another correction layer following the doc's own convention — a deliberate follow-up, not a blind text-sweep edit. |
| `docs/specs/DOC-62-style-modes-coding-delegation.md`, `docs/reference/common-pitfalls.md` | Point at **this repo's own** `.trusty-mpm/INSTRUCTIONS.md` — Split C's migration target. Editing the pointer here before Split C lands either breaks the link or preempts that PR; flagging for Split C to update. |
| `docs/trusty-mpm/spec/PRD.md`, `docs/trusty-mpm/spec/ARCHITECTURE.md` | Labeled "Canonical · Living Document" but pervasively stale since #4183 (four-monolithic-file model, long-resolved defect numbers) — predates this ticket. A proper fix is a full doc refresh well beyond a text sweep; recommend a dedicated ticket. |

## Scaffolding check

Searched for any writer of the five retired filenames outside tests/docs
(`grep -rn "fs::write|write_all|create(" crates/ --include="*.rs"` filtered to
the five names). Only hits are the `legacy_overrides` doctor check's own
detection logic and its test fixtures (which *create* the files to verify the
check flags them). `tm-init.md` explicitly documents that it never writes
`INSTRUCTIONS.md` or trusty config. **No scaffolding defect found.**

## Compiled-prompt delta

`sections/workflow.md` is `include_str!`'d directly into the composed PM
prompt (`SECTION_SOURCES` in `instruction_pipeline.rs`), so its one-line fix
changes the compiled prompt:

```diff
 The labels say nothing about how much testing a change needs. The project's
-test ladder in `.trusty-mpm/INSTRUCTIONS.md` answers that, and it is
-authoritative where the project defines one.
+test ladder in its `CLAUDE.md` answers that, and it is authoritative where the
+project defines one.
```

Regenerated the two affected golden fixtures with the project's own
sanctioned mechanism: `UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden`
(`pm-prompt-bundled-fallback.md`, `pm-prompt-roster-absent.md`;
`pm-prompt-claude-md-override.md` didn't contain this line and was
unaffected). No composer code changed.

The three output-style and four skill edits do **not** touch the compiled PM
system prompt — output styles are a separate Claude Code `--output-style`
mechanism and skills are invoked on demand, neither is part of
`build_instructions`/`resolve_pm_prompt`.

## Verification

```
$ cargo test -p trusty-mpm
test result: ok. 4291 passed; 0 failed; 7 ignored (lib)
... (all other test binaries) 0 failed across the board

$ cargo clippy -p trusty-mpm --all-targets -- -D warnings
Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 26s   (no warnings)

$ cargo fmt --check
(exit 0, no diffs)

$ bash scripts/check_line_cap.sh
line-cap: measured 3596 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 53 spec doc(s) + 3025 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_capabilities.sh
tm-capabilities: up to date (6 generated files).

$ bash scripts/check_test_pointers.sh   # run alone, ~6m17s
test-pointers: resolved 20315 Test: citation(s) (floor 200) — 0 dangling pointers — OK.
```

CI checks will be verified with `gh pr checks --watch --fail-fast` once
opened, per this repo's `never green-off-local-gates-alone` standard.

Refs #4286

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools