### PR TITLE
fix(trusty-mpm): retire the bundled instructions/INSTRUCTIONS.md stub asset

### DIFF
--- a/crates/trusty-mpm/changelog.d/4286-retire-bundled-instructions-asset.md
+++ b/crates/trusty-mpm/changelog.d/4286-retire-bundled-instructions-asset.md
@@ -1,0 +1,12 @@
+Removed
+
+- The bundled `crates/trusty-mpm/src/assets/instructions/INSTRUCTIONS.md`
+  stub and the `FRAMEWORK_INSTRUCTIONS` constant/bundle-table entry that
+  embedded it. This is the framework-owned launch-artifact stub, distinct
+  from (and unrelated to) the project-level `.trusty-mpm/INSTRUCTIONS.md`
+  override file retired by #4665. Its content never reached a live session:
+  `tm install`/`tm launch` always overwrite the same on-disk path
+  (`instructions/INSTRUCTIONS.md`) with the fully assembled system prompt in
+  the same call, and the one legacy reader that treats it as optional
+  (`build_instructions`) already discards its result for anything but a
+  side-effect (#4286 split A).

--- a/crates/trusty-mpm/src/assets/instructions/INSTRUCTIONS.md
+++ b/crates/trusty-mpm/src/assets/instructions/INSTRUCTIONS.md
@@ -1,4 +1,0 @@
-# trusty-mpm Framework Instructions
-
-This Claude Code instance is managed by trusty-mpm.
-Daemon endpoint: ${TRUSTY_MPM_URL:-http://localhost:7799}

--- a/crates/trusty-mpm/src/core/bundle.rs
+++ b/crates/trusty-mpm/src/core/bundle.rs
@@ -1,13 +1,19 @@
 //! Compile-time embedded framework artifacts.
 //!
 //! Why: `trusty-mpm install` must deploy a working set of default artifacts
-//! (optimizer policy, framework instructions, placeholder agent/skill)
+//! (optimizer/overseer policy, agent/skill catalog)
 //! without depending on files shipped alongside the binary — embedding them
 //! at compile time keeps the installer a single self-contained executable.
 //! (Issue #3374: the former `CLAUDE_STUB` user-instruction-stub artifact was
 //! removed — it was never read back by any consumer; the project `CLAUDE.md`
 //! actually delivered to users is [`crate::core::instruction_pipeline`]'s
-//! `CLAUDE_MD_STUB`.)
+//! `CLAUDE_MD_STUB`. #4286 split A likewise removed the bundled
+//! `FRAMEWORK_INSTRUCTIONS`/`instructions/INSTRUCTIONS.md` artifact — its
+//! content never reached the compiled prompt: `tm install`/`tm launch` always
+//! overwrite that same on-disk path with
+//! [`crate::core::instruction_pipeline::assemble_system_prompt`]'s output in
+//! the same call, and [`crate::core::instruction_pipeline::build_instructions`]
+//! already treats the file as optional.)
 //! What: exposes each default artifact under `crates/trusty-mpm-core/assets/`
 //! as a `pub const &str` via `include_str!`, plus a [`BundledArtifact`] table
 //! describing the relative install path of each one.
@@ -22,12 +28,6 @@ pub const OPTIMIZER_TOML: &str = include_str!("../assets/hooks/optimizer.toml");
 /// Overseer oversight is opt-in: the shipped policy has `enabled = false`, so
 /// installing it is inert until an operator flips the flag.
 pub const OVERSEER_TOML: &str = include_str!("../assets/hooks/overseer.toml");
-
-/// Framework launch instructions installed to `instructions/INSTRUCTIONS.md`.
-///
-/// This is the framework-owned artifact: `trusty-mpm install` overwrites it on
-/// every run so framework upgrades take effect.
-pub const FRAMEWORK_INSTRUCTIONS: &str = include_str!("../assets/instructions/INSTRUCTIONS.md");
 
 /// Base agent — the root of every trusty-mpm inheritance chain.
 pub const BASE_AGENT: &str = include_str!("../assets/agents/BASE-AGENT.md");

--- a/crates/trusty-mpm/src/core/bundle_all.rs
+++ b/crates/trusty-mpm/src/core/bundle_all.rs
@@ -37,8 +37,7 @@ pub struct BundledArtifact {
 /// again the moment any bundled artifact is meant to be user-owned.
 /// What: [`Overwrite`](InstallPolicy::Overwrite) always writes the embedded
 /// contents; [`SeedOnce`](InstallPolicy::SeedOnce) writes only when absent.
-/// Test: `framework_instructions_overwrites`,
-/// `seed_once_artifact_is_not_clobbered_without_force`,
+/// Test: `seed_once_artifact_is_not_clobbered_without_force`,
 /// `seed_once_artifact_force_resets_to_shipped_default`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InstallPolicy {
@@ -94,14 +93,17 @@ pub(super) const fn seed_once(rel_path: &'static str, contents: &'static str) ->
 
 /// Every bundled framework artifact, in install order.
 ///
-/// Why: gives the installer (and tests) one canonical list to walk.
-/// What: optimizer policy, framework instructions, agent catalog, placeholder
+/// Why: gives the installer (and tests) one canonical list to walk. (#4286
+/// split A removed the `instructions/INSTRUCTIONS.md` stub entry: `tm
+/// install`/`tm launch` always overwrite that same path with the assembled
+/// system prompt in the same call, so the bundled stub's content never
+/// reached a live session.)
+/// What: optimizer/overseer policy, agent catalog, placeholder
 /// skill, and Phase 1 (#770) mpm-* guidance skills.
 /// Test: `bundle_table_is_complete`.
 pub const ALL: &[BundledArtifact] = &[
     overwrite("hooks/optimizer.toml", OPTIMIZER_TOML),
     overwrite("hooks/overseer.toml", OVERSEER_TOML),
-    overwrite("instructions/INSTRUCTIONS.md", FRAMEWORK_INSTRUCTIONS),
     overwrite("agents/BASE-AGENT.md", BASE_AGENT),
     overwrite("agents/BASE-ENGINEER.md", BASE_ENGINEER),
     overwrite("agents/BASE-RESEARCH.md", BASE_RESEARCH),

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -14,7 +14,6 @@ fn constants_are_non_empty() {
     // `include_str!` target would mean a missing or truncated asset file.
     assert!(!OPTIMIZER_TOML.trim().is_empty());
     assert!(!OVERSEER_TOML.trim().is_empty());
-    assert!(!FRAMEWORK_INSTRUCTIONS.trim().is_empty());
     assert!(!BASE_AGENT.trim().is_empty());
     assert!(!BASE_ENGINEER.trim().is_empty());
     assert!(!BASE_RESEARCH.trim().is_empty());
@@ -314,16 +313,6 @@ fn output_style_registry_default_resolves() {
 }
 
 #[test]
-fn framework_instructions_overwrites() {
-    // The framework instructions must be refreshed on every install.
-    let instr = ALL
-        .iter()
-        .find(|a| a.rel_path == "instructions/INSTRUCTIONS.md")
-        .expect("INSTRUCTIONS.md present in bundle");
-    assert_eq!(instr.install, InstallPolicy::Overwrite);
-}
-
-#[test]
 fn seed_once_constructor_builds_the_expected_artifact() {
     // Issue #3381: no shipped artifact currently uses `SeedOnce`, so the
     // `seed_once()` constructor (the counterpart to `overwrite()`) is only
@@ -410,11 +399,16 @@ fn bundle_table_is_complete() {
     // Issue #4447 (1): tm-slack-canvas-delivery — a single flat-file bundled
     //   skill (no references/), the same shape as rust-build-performance.
     //   178 + 1 = 179.
-    assert_eq!(ALL.len(), 179);
+    // Issue #4286 split A (-1): the `instructions/INSTRUCTIONS.md` bundled
+    //   stub artifact was removed — `tm install`/`tm launch` always overwrite
+    //   that same on-disk path with the assembled system prompt in the same
+    //   call, so the stub's content never reached a live session; the
+    //   `FRAMEWORK_INSTRUCTIONS` constant it backed is gone too. 179 - 1 = 178.
+    assert_eq!(ALL.len(), 178);
     let mut paths: Vec<&str> = ALL.iter().map(|a| a.rel_path).collect();
     paths.sort_unstable();
     paths.dedup();
-    assert_eq!(paths.len(), 179, "artifact paths must be unique");
+    assert_eq!(paths.len(), 178, "artifact paths must be unique");
     for artifact in ALL {
         assert!(!artifact.rel_path.is_empty());
         assert!(!artifact.contents.trim().is_empty());


### PR DESCRIPTION
## Summary

Split A of the #4286 retirement (owner-authorized, 2026-08-03). Splits B (tm-workflow skill / output styles) and C (`.trusty-mpm/INSTRUCTIONS.md` in this repo) run in parallel — this PR touches neither.

Removes the **bundled** `crates/trusty-mpm/src/assets/instructions/INSTRUCTIONS.md` stub — the framework-owned launch artifact embedded as `FRAMEWORK_INSTRUCTIONS` and installed to `instructions/INSTRUCTIONS.md` under `~/.trusty-mpm/framework/`. This is distinct from the **project-level** `.trusty-mpm/INSTRUCTIONS.md` override file already retired by #4665 (merged as `7d4a8599`) — that work is not touched or duplicated here.

## What referenced the file

Grepped every `include_str!`/path reference before deleting (#4660 discipline). Exactly three live references, all in `bundle.rs`/`bundle_all.rs`/`bundle_tests.rs`:

- `bundle.rs`: `pub const FRAMEWORK_INSTRUCTIONS = include_str!(...)`
- `bundle_all.rs`: `overwrite("instructions/INSTRUCTIONS.md", FRAMEWORK_INSTRUCTIONS)` in the `ALL` table
- `bundle_tests.rs`: a non-empty assertion + a dedicated `framework_instructions_overwrites` test asserting the table entry's `InstallPolicy::Overwrite`

The prior engineer's scoping (bundle.rs/bundle_all.rs, independent of the composer) held up under verification.

## Does its content still reach the compiled prompt? No — traced the full path

`FRAMEWORK_INSTRUCTIONS` is installed to `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`, but that exact path is **unconditionally overwritten in the same call** with the real assembled system prompt:

- `tm install`: `install_to()` writes the stub, then the very next step calls `install_system_prompt_to()`, which writes `assemble_system_prompt()`'s output to the identical path.
- `tm launch`: unconditionally calls `install_system_prompt()` to regenerate the same path before spawning `claude`.

`assemble_system_prompt()` (and the per-project `InstructionPackage`/`resolve_pm_prompt` composer that actually builds `--append-system-prompt-file` content) is built entirely from `sections/*.md` + generated blocks (roster, stack-profile, project-addendum) — none of it reads `FRAMEWORK_INSTRUCTIONS`. The one remaining reader, `build_instructions()` (used by `session_launch::prepare_session` for its `CLAUDE.md`-seeding side effect), reads the file but its `merged`/`instructions_loaded` output is never consumed by anything else — confirmed by grep; `tm session instructions`'s own doc comment says the display/stash must come from `resolve_pm_prompt`, not this pipeline's `merged`.

Conclusion: the content had no path to a live session even before this PR. Nothing needed a new home in `sections/`.

## Compiled-prompt diff: zero bytes

Built old (`7d4a8599`, pre-change) and new (this branch) `tm` binaries, ran `tm install` into isolated `$HOME`s, then `tm session instructions` in a fresh scratch git repo for each:

- `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md` (the file this PR stops seeding) — **byte-identical**, `diff` exit 0.
- `<project>/.trusty-mpm/last-instructions.md` (the actual composed PM prompt) — **byte-identical**, `diff` exit 0, 1233 lines both sides.

## Live-instance verification

Ran the branch's own `target/debug/tm` (not the installed 1.3.2) against a scratch git project with an isolated `$HOME`:

- Canonical stash path `.trusty-mpm/last-instructions.md`: present.
- 9 canonical sections (identity, core, memory, search, workflow, agent-delegation, enforcement, non-overridable-rules, framework-guaranteed-conventions), each exactly once per the manifest's `sections`/`blocks` arrays — untouched by this PR, still passing the byte-for-byte golden test (`pm_prompt_golden_tests`).
- Dynamic roster present and non-empty: **37 agents** in a clean bundled-only install (verified against `bundle_all.rs`'s 37 `agents/*.md` entries). Note: the brief cited 43 from a prior run — that count likely reflects extra operator/project-tier agents layered on top in that environment; the bundled-catalog count on `7d4a8599` is 37, reproduced identically before and after this change.
- `CLAUDE.md` reference present in the composed prompt.

Scratch dirs cleaned up after verification.

## Gates (raw output)

- `cargo test -p trusty-mpm` (whole crate, not just `bundle`): all suites green, 0 failed anywhere (checked via `grep -c "FAILED"` = 0 across the full run).
- `cargo clippy -p trusty-mpm --all-targets -- -D warnings`: clean.
- `cargo fmt --check`: clean.
- `bash scripts/check_line_cap.sh`: `3596 tracked .rs file(s) ... 0 violations — OK.`
- `bash scripts/check_sld.sh`: `0 error(s), 0 warning(s)`.
- `bash scripts/check_capabilities.sh`: `up to date`.
- `bash scripts/check_test_pointers.sh` (run alone): `0 dangling pointers — OK.`

No coverage was deleted to make a red gate green: the removed `framework_instructions_overwrites` test asserted a property of the artifact being intentionally deleted in this same PR, not a live behavior losing its only test.

## Changelog

`crates/trusty-mpm/changelog.d/4286-retire-bundled-instructions-asset.md`

Refs #4286

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools