### PR TITLE
docs(trusty-mpm): retire .trusty-mpm/INSTRUCTIONS.md — migrate to tracked root CLAUDE.md (#4286 split C)

### DIFF
--- a/.trusty-mpm/INSTRUCTIONS.md
+++ b/.trusty-mpm/INSTRUCTIONS.md
@@ -164,54 +164,14 @@ results, and agent-to-PM reporting keeps raw output in all cases
 
 ### Baseline failures — the Rust specifics
 
-The six-step baseline-failure protocol (establish whose red it is, fix if
-branch-caused, append to the canonical issue if tracked, one canonical issue if
-not, and the literal report string) lives in `tm-pr-workflow`. It is **not**
-restated here. What follows is only what that generic version cannot carry.
-
-**Known-environmental on this machine — expect these, do not re-file them:**
-
-| Gate | Where | Why it fails independent of your branch |
-|---|---|---|
-| The `trusty-search` filesystem-watcher tests (~6; the set drifts) | `crates/trusty-search/src/service/watch_loop.rs`, `watcher.rs`, `watcher_manager.rs` | FSEvents delivery on this host is nondeterministic. They fail on any branch, and they still fail under `-- --test-threads=1` — so it is the machine, not parallel-test load |
-| `execute_doctor_against_test_daemon` | `crates/trusty-mpm/src/client/executor/tests.rs` | It takes 9–13 s against a 10 s client timeout, so it loses on timing alone under any load |
-
-🔴 **The correct response is to prove your diff touches zero files in those
-crates — never to `#[ignore]`, `cfg`-gate, or `--exclude` them.** The proof is a
-path list, and empty output is the evidence; paste it in the PR:
-
-```bash
-git diff --name-only origin/main...HEAD -- crates/trusty-search/ \
-                                           crates/trusty-mpm/src/client/
-```
-
-**Telling a pre-existing red from one you caused — crate-scoped confirmation:**
-
-1. **Re-run the failure alone on your branch**, not the whole suite:
-   `cargo test -p <crate> <test> -- --exact --nocapture`. A single named test
-   removes ordering and load from the picture.
-2. **Run the identical command against `origin/main` in a second worktree** —
-   never by mutating the main checkout, and never with `git stash`:
-   ```bash
-   git worktree add .claude/worktrees/baseline-<n> origin/main
-   cd .claude/worktrees/baseline-<n> && cargo test -p <crate> <test> -- --exact
-   ```
-   Failing on both is the evidence that the branch did not cause it.
-3. **Serialize before blaming isolation:** `-- --test-threads=1`. If it still
-   fails serialized, parallel interference is not the explanation and "flaky
-   under load" is the wrong diagnosis.
-4. **Check the path evidence:** `git diff --name-only origin/main...HEAD`. If the
-   failing crate does not appear there, and you did not touch a shared library it
-   depends on, the red is not yours.
-5. 🔴 **The shared-crate caveat:** a green `cargo test -p <your-crate>` does
-   **not** clear you when you changed `trusty-common`, `trusty-embedderd`, or any
-   other shared library. A red in a *dependent* crate is yours until rung 4 of
-   the ladder above says otherwise. This is the one case where scoping down is
-   the wrong instinct.
-
-Report it in the shape `tm-pr-workflow` mandates, naming the crate-scoped gate:
-`change-specific gates pass; cargo test -p trusty-search blocked by canonical
-issue #N`. Never "all tests pass" while a gate is red, whoever caused it.
+🔴 **Never turn a red gate green by `#[ignore]`-ing, `cfg`-gating, or
+`--exclude`-ing a failing test** — prove your diff touches zero files in the
+failing crate instead (`git diff --name-only origin/main...HEAD -- <crate>/`).
+For the known-environmental flaky tests on this machine (the `trusty-search`
+filesystem-watcher tests, `execute_doctor_against_test_daemon`'s timing), the
+five-step protocol for telling a pre-existing red from one you caused, and the
+exact report-string format: see
+[docs/reference/test-ladder-baseline.md](docs/reference/test-ladder-baseline.md).
 
 ## Key Conventions
 
@@ -293,65 +253,15 @@ A file is classified as a **test/benchmark file** when ANY of these match:
 
 All other tracked `.rs` files are **production files**, capped at 500 SLOC.
 
-As of issue #610 the production cap is no longer advice: it is gated by
-`scripts/check_line_cap.sh`, wired into CI (`.github/workflows/line-cap.yml`)
-and the local pre-commit hook (`line-cap`). A new tracked production `.rs` file
-over 500 SLOC **cannot merge**; a new test/benchmark `.rs` file over 3000 SLOC
-**cannot merge**. Files approaching their limit are a signal to split into
-focused submodules before the next feature lands on them. When splitting, prefer:
-one public module per logical concept, a thin `mod.rs` that re-exports, and
-sibling files with clear single responsibilities.
-
-**SLOC definition:** a line counts only when it contains non-whitespace source
-code after all comment matter is stripped. These are **excluded** from the count:
-- blank / whitespace-only lines
-- `//` line comments (including `///` doc comments and `//!` inner-doc comments)
-- `/* ... */` block comments — including multi-line spans; every line inside an
-  open block comment is excluded
-- lines that consist entirely of a closing `*/`
-
-A line that has code followed by a trailing `// comment` **still counts** — it
-has code. The counter is a pragmatic awk heuristic that errs toward leniency:
-edge cases (e.g. `//` inside a string literal) may undercount SLOC but will
-never falsely fail a legitimate file.
-
-**The ratchet (allowlist that can only shrink):** grandfathered files over their
-applicable cap are listed in `.line-cap-allowlist.tsv` (one
-`relative/path<TAB>budget` line each, where `budget` is that file's frozen max
-SLOC count). The gate enforces per-applicable-cap ratchet semantics:
-
-- SLOC ≤ applicable cap and **not** allowlisted → OK;
-- SLOC > applicable cap and **not** allowlisted → **FAIL** (new oversized file — split it);
-- allowlisted, current SLOC **exceeds its budget** → **FAIL** (it grew — split it);
-- allowlisted, current SLOC **≤ applicable cap** → **FAIL** (drop the entry; ratchet-down forcing function);
-- allowlisted, `applicable_cap < SLOC ≤ budget` → OK (grandfathered, not growing).
-
-So allowlisted files may only shrink, and no new oversized file may be added.
-As the #607 sweep and per-crate refactors land, the allowlist ratchets down
-toward empty.
-
-**Run it locally:** `bash scripts/check_line_cap.sh` (exit 0 = clean). After you
-intentionally split a file (or a file otherwise drops below its budget), refresh
-the frozen budgets with `scripts/check_line_cap.sh --update` — this only *lowers*
-budgets or *removes* entries that fell ≤ their applicable cap; it **refuses** to
-add a new oversized file or raise a budget unless you pass `--seed` (initial
-bootstrap) or `--force-add` (rare, intentional bump). Commit the regenerated
-`.line-cap-allowlist.tsv` alongside your split.
-
-Past violations (refactor tickets #170/#171/#172 are CLOSED and the splits have
-landed — all three former monoliths are now under the 500-SLOC cap):
-- `crates/trusty-agents/src/ctrl/mod.rs` — RESOLVED (#170). Split into focused
-  submodules under `crates/trusty-agents/src/ctrl/` (`state`, `config`, `repl`,
-  `handlers`, `pm_task`, …); `mod.rs` is now a ~50-line re-export facade.
-- `crates/trusty-agents/src/runtime/` — RESOLVED (#171). The original `runtime.rs`
-  was split into a `runtime/` module; every submodule is now under the cap.
-- `crates/trusty-agents/src/workflow/engine/` — RESOLVED (#172). The original
-  `engine.rs` was split into an `engine/` module; every submodule is now under
-  the cap (largest is `engine/executor/run.rs` at ~485 lines).
-
-The largest remaining production file in `trusty-agents` (not tied to an open
-ticket) is `tm/manager.rs` — file a fresh refactor ticket before growing it
-further. Current per-file SLOC budgets live in `.line-cap-allowlist.tsv`.
+🔴 As of issue #610 this is mechanically enforced by `scripts/check_line_cap.sh`,
+wired into CI and the pre-commit hook — a new tracked file over its cap
+**cannot merge**. Never turn this gate green by deleting, `#[ignore]`-ing, or
+excluding a file from the count; split it instead (one public module per
+logical concept, a thin `mod.rs` re-export facade, sibling single-responsibility
+files). See [docs/reference/sloc-cap.md](docs/reference/sloc-cap.md) for the
+exact SLOC counting definition, the ratchet-allowlist mechanics
+(`.line-cap-allowlist.tsv`, `--update`/`--seed`/`--force-add`), and the
+resolved #170/#171/#172 refactor history.
 
 🔴 **`thiserror` for libraries, `anyhow` for binaries** — library crates
 (`trusty-common`, `trusty-embedderd`, `trusty-bm25-daemon`, etc.) define structured error enums with
@@ -524,123 +434,19 @@ convention (i.e. `tga-v<version>`, matching the abbreviation table) works.
 
 🔴 **CRITICAL macOS note:** Never use `cp` to install release binaries on macOS — always use `cargo install`. See release workflow reference for the detailed explanation.
 
-### macOS Full Disk Access / App Data TCC must be re-granted after every `cargo install` (issues #873, #2558)
+### macOS TCC (Full Disk Access / App Data) and daemon restart (issues #873, #2558, #534)
 
-🟢 **Full Disk Access scope: `trusty-search` and external-volume daemons only.** `trusty-mpm` / `tm` does NOT require FDA re-granting because the daemon manages tmux sessions and git worktrees under `$HOME` only — it never reads TCC-protected or external (`/Volumes/…`) paths. FDA caveat applies only to daemons that index external volumes (currently `trusty-search`); `trusty-memory` and `trusty-analyze` read `$HOME` locations only and also do NOT require FDA.
+🟢 **Scope split — read before re-granting anything:** `trusty-search` (and
+other external-volume daemons) needs **Full Disk Access**; `trusty-mpm` / `tm`
+needs the separate **App Data** TCC category only — it never needs, and should
+never be granted, Full Disk Access. Every `cargo install` mints a new cdhash,
+invalidating the previous grant; `tctl install <crate>` re-signs with a stable
+Developer-ID identity so the grant persists across reinstalls.
 
-🟢 **App Data TCC scope (owner-authorized extension, #2558, 2026-07-14): `trusty-mpm` IS in scope.** This is a *different* TCC category than FDA above — `tm` reads other apps' `$HOME` containers (Claude config dirs, tmux state), so macOS re-prompts `'trusty-mpm' would like to access data from other apps` after every ad-hoc-signed `cargo install` rebuild, for the same cdhash-identity reason FDA does. `tctl install trusty-mpm` signs the `trusty-mpm` binary with a stable Developer-ID identity automatically (fail-soft, same as trusty-search). On macOS the preferred local-source install path is `scripts/install-trusty-mpm-signed.sh` (or `make install-mpm-signed`, #2721): it runs `cargo install --path crates/trusty-mpm --locked` then signs **both** binaries — `trusty-mpm` (`com.trusty.trusty-mpm`) **and** the `tm` alias (`com.trusty.tm`). This closes a gap: `tctl sign trusty-mpm` (single source of truth in `crates/trusty-installer/src/commands/macos_signing.rs`) covers only the `trusty-mpm` binary today, leaving `tm` ad-hoc-signed and re-prompting. tm still needs NO FDA re-grant — this is the App-Data category only. See `docs/reference/release-workflow.md#signed-install-trusty-mpm-2558-2721`.
-
-On macOS, every `cargo install` of a binary writes a NEW file at
-`~/.cargo/bin/<binary>` with a new **cdhash** (code-signing hash). macOS TCC
-keys the **Full Disk Access** grant by cdhash, so the previously-granted FDA no
-longer applies to the freshly-installed binary. The launchd daemon then cannot
-read indexes on `/Volumes/…` and warm-boot collapses from ~102 indexes to
-**indexes:2** (only non-external-volume indexes load).
-
-**Permanent fix (recommended): use `scripts/install-trusty-search-signed.sh`**
-
-Once you have a Developer ID Application certificate installed in your login
-keychain, install via the signed-install script instead of bare `cargo install`:
-
-```bash
-# From the repo root (installs from source + signs both binaries)
-scripts/install-trusty-search-signed.sh
-# or
-make install-search-signed
-```
-
-Developer-ID signing anchors the designated requirement (DR) to your Team ID
-and a fixed `--identifier` per binary — not the binary content — so the FDA
-grant persists across all future reinstalls. After the one-time FDA grant you
-never need to re-grant it again, even after `cargo install` rebuilds.
-
-See `docs/reference/release-workflow.md` for the one-time cert setup steps,
-`TRUSTY_SIGN_IDENTITY` override, and the optional notarization appendix.
-
-**Workaround (without a Developer ID cert): re-grant FDA manually after each install.**
-
-After every `cargo install trusty-search` (or any binary that accesses
-external/protected volumes as a launchd daemon), re-grant FDA:
-
-1. Open **System Settings → Privacy & Security → Full Disk Access**.
-2. Remove `~/.cargo/bin/trusty-search` from the list.
-3. Re-add it (`+` button, navigate to `~/.cargo/bin/trusty-search`).
-4. Restart the daemon: `launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/<label>.plist && launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist`.
-
-**Symptom:** `trusty-search status` shows `indexes:2` (or very few) immediately
-after a reinstall, with warm-boot logs showing `skipped: blocked-volume` or
-`tcc=57`. This is NOT data loss — all on-disk indexes are intact.
-
-The daemon now detects this automatically: when the loaded count drops below 80%
-of the prior-known count, `GET /health` returns `warm_boot_degraded: true` and
-the daemon logs an error with the actionable FDA re-grant hint.
-
-### Connection-safe daemon restart convention (issue #534)
-
-As of trusty-common 0.10.0, all four HTTP daemons (trusty-memory, trusty-search,
-trusty-analyze, trusty-mpm) implement graceful shutdown: they drain in-flight
-requests before exiting when they receive SIGTERM. The `serve --stdio` proxy
-reconnects automatically with exponential backoff when the daemon restarts (the
-`trusty-memory-mcp-bridge` binary is a deprecated shim that forwards to
-`serve --stdio`; update your `.mcp.json` to `"command": "trusty-memory", "args":
-["serve", "--stdio"]`).
-
-**Use `launchctl bootout` (SIGTERM), not `launchctl kickstart -k` (SIGKILL):**
-
-```bash
-# Graceful stop → install → restart
-launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
-cargo install --path crates/<dir> --locked
-launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
-# NOTE: re-grant Full Disk Access only for trusty-search (and external-volume daemons), not for trusty-mpm (see FDA section above)
-```
-
-🔴 **A 200 `GET /health` is NOT sufficient evidence the restart succeeded**
-(issue #2486). During this exact `bootout → cargo install → bootstrap` window,
-trusty-mpm's `tm serve --stdio` MCP bridge (e.g. trusty-console's auto-reconnect)
-can race the restart: it spawns before launchd relaunches the daemon and, on an
-older binary, would auto-spawn an ORPHAN `tm daemon` — PPID pointing at the
-client chain, not launchd. That orphan answers `/health` 200 but is missing the
-plist's `EnvironmentVariables` (`TELEGRAM_BOT_TOKEN`, `OPENROUTER_API_KEY`) and
-runs with `cwd=$HOME`, so features like the Telegram poller silently never
-start. As of the #2486 fix the bridge refuses to auto-spawn while a trusty-mpm
-launchd unit is registered, and `GET /health` reports a `supervised` flag — but
-always verify the restart with ONE of the two robust checks below:
-
-```bash
-# (a) does launchd itself think it owns the process? (most direct)
-launchctl print gui/$(id -u)/com.trusty.mpm.supervisor   # or com.trusty.mpm
-
-# (b) does /health say so directly?
-curl -s http://127.0.0.1:<port>/health | jq '.supervised' # must print true
-```
-
-🔴 **`PPID == 1` is NOT evidence of supervision** (issue #4230) — do not use the
-`ps -o ppid=` variant that used to be documented here. macOS reparents ANY
-orphaned process to PID 1, so the #4230 orphan reported `PPID 1` while launchd's
-`com.trusty.mpm` was `not running`: the check CONFIRMED the orphan as supervised.
-Note this also makes `.supervised` itself non-conclusive when it reads `true`, as
-its fallback prong is exactly that PPID test.
-
-The one form that distinguishes the two is comparing the PID launchd owns against
-the PID that actually holds the port:
-
-```bash
-# (c) does launchd own the process that is actually serving?
-launchctl print "gui/$(id -u)/com.trusty.mpm" | grep -E 'state|pid'
-lsof -nP -iTCP:7880 -sTCP:LISTEN
-# The listening PID must equal launchd's pid. If it does not, `kill -TERM` the
-# listener, then: launchctl kickstart -k gui/$(id -u)/com.trusty.mpm
-```
-
-`tm doctor`'s `daemon_orphan` check performs exactly this comparison
-automatically — prefer it to running the two commands by hand.
-
-Note that `tm start` / `tm restart` REFUSE to run on a host where launchd owns
-the daemon (#4230); use the `kickstart` above.
-
-Prefer restarting between Claude Code sessions. See the cargo-publish skill
-(`.claude/skills/cargo-publish/SKILL.md`) for the full restart convention.
+See [docs/reference/release-workflow.md](docs/reference/release-workflow.md)
+for certificate setup, signed-install scripts, the restart playbook
+(`launchctl bootout`, never `cp`, never trust a bare `GET /health`), and
+orphan-listener verification (issues #2486, #4230).
 
 ## Cross-Crate Development Workflow
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -494,10 +494,9 @@ cd .claude/worktrees/<dirname>
 branch → one cohesive PR → applicable Rust gates → trusty-review gate →
 squash-merge → worktree cleanup. The framework skill `tm-pr-workflow` owns the
 full sequence and the optional-issue rule; this file adds only the Rust-specific
-gates (see the Rust Test Ladder above). *(The pointer here used to name
-`.claude-mpm/INSTRUCTIONS.md`, a path that has never existed in this repo — the
-tracked project-instruction host is this file, `.trusty-mpm/INSTRUCTIONS.md`,
-and the delivery chain itself now lives in `tm-pr-workflow`.)*
+gates (see the Rust Test Ladder above). *(This project-instruction host was
+`.trusty-mpm/INSTRUCTIONS.md` until #4286 retired it; the delivery chain itself
+now lives in `tm-pr-workflow`.)*
 
 🔴 **A worktree is a writer; the branch is the workstream.** The durable unit is
 the **branch** — one branch per workstream, and a session owns exactly one

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to trusty-tools! This document provi
 
 ## Getting Started
 
-**Before contributing, read [.trusty-mpm/INSTRUCTIONS.md](.trusty-mpm/INSTRUCTIONS.md)** — it is the authoritative reference for development workflows, conventions, and internal tooling patterns.
+**Before contributing, read [CLAUDE.md](CLAUDE.md)** — it is the authoritative reference for development workflows, conventions, and internal tooling patterns.
 
 ### Prerequisites
 
@@ -37,7 +37,7 @@ cargo fmt --check
 cargo fmt
 ```
 
-For single-crate workflows, use `-p <crate-name>` to scope commands. See `.trusty-mpm/INSTRUCTIONS.md` for the full command reference.
+For single-crate workflows, use `-p <crate-name>` to scope commands. See `CLAUDE.md` for the full command reference.
 
 ## Worktree Discipline
 
@@ -155,4 +155,4 @@ All contributions are licensed under the MIT License. By contributing, you agree
 
 ---
 
-For detailed development information, references, and troubleshooting, consult [.trusty-mpm/INSTRUCTIONS.md](.trusty-mpm/INSTRUCTIONS.md).
+For detailed development information, references, and troubleshooting, consult [CLAUDE.md](CLAUDE.md).

--- a/docs/reference/common-pitfalls.md
+++ b/docs/reference/common-pitfalls.md
@@ -8,7 +8,7 @@ silent behavioral drift emerges. Before writing `Command::new(...)`, `reqwest::C
 `std::env::var()` for a concern used in multiple crates, search for an existing
 entry point (`git grep`, then trusty-common source tree) and extend it. See the
 common-entry-point principle and domain consolidation audit in
-[.trusty-mpm/INSTRUCTIONS.md](../../.trusty-mpm/INSTRUCTIONS.md).
+[CLAUDE.md](../../CLAUDE.md).
 
 🔴 **Using `unwrap()` in library crates** — the compiler does not stop you, but
 it violates the project's hard rule. Use `?` with `thiserror` error types in
@@ -56,10 +56,12 @@ them. All patches must live in the root `Cargo.toml`.
 🔴 **Growing a file past its SLOC cap instead of splitting** — the compiler does
 not stop you, but continued feature additions make the module harder to review,
 reason about, and test. Split proactively. The applicable cap is **500 SLOC for
-production files** and **1500 SLOC for test/benchmark files** (see the Key
-Conventions section for the exact classification rules). SLOC counts code lines
-only: blank lines, `//` comments, `///` doc comments, `//!` inner-doc comments,
-and `/* ... */` block comments (including multi-line spans) are all excluded.
+production files** and **3000 SLOC for test/benchmark files** (see CLAUDE.md's
+Key Conventions section for the exact classification rules, and
+[docs/reference/sloc-cap.md](sloc-cap.md) for the counting definition and ratchet
+mechanics). SLOC counts code lines only: blank lines, `//` comments, `///` doc
+comments, `//!` inner-doc comments, and `/* ... */` block comments (including
+multi-line spans) are all excluded.
 The trusty-agents `ctrl/`, `runtime/`, and `workflow/engine/` modules (#170,
 #171, #172) were the canonical examples of files that grew past the prod cap;
 all three have since been split into focused submodules and now serve as the

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -168,6 +168,26 @@ to regenerate the ad-hoc signature against the final file.
 
 ## Developer ID Signing for Persistent macOS TCC Grants (fixes #873, #2558)
 
+### TCC Scope Summary — read this before re-granting anything
+
+🟢 **Full Disk Access scope: `trusty-search` and external-volume daemons
+only.** `trusty-mpm` / `tm` does **NOT** require FDA re-granting — the daemon
+manages tmux sessions and git worktrees under `$HOME` only and never reads
+TCC-protected or external (`/Volumes/…`) paths. `trusty-memory` and
+`trusty-analyze` read `$HOME` locations only and also do NOT require FDA.
+
+🟢 **App Data TCC scope: `trusty-mpm` IS in scope — a *different* category
+than FDA above** (owner-authorized extension, #2558, 2026-07-14). `tm` reads
+other apps' `$HOME` containers (Claude config dirs, tmux state), so macOS
+re-prompts `'trusty-mpm' would like to access data from other apps` after
+every ad-hoc-signed rebuild, for the same cdhash-identity reason FDA does.
+
+**Do not cross the two:** granting `trusty-search` Full Disk Access does
+nothing for the `trusty-mpm` App-Data prompt, and `trusty-mpm` never needs —
+and should never be granted — Full Disk Access. Re-signing with a stable
+Developer-ID identity (below) fixes both categories permanently, each for
+the binary that actually needs it.
+
 ### The Problem
 
 `cargo install` produces a new binary with a new **cdhash** every time it
@@ -470,6 +490,33 @@ xcrun stapler staple ~/.cargo/bin/trusty-search
 > Gatekeeper when the binary first runs on the target machine. For local use
 > (your own machine), notarization adds no benefit; Developer ID signing alone
 > is sufficient for FDA persistence.
+
+## Connection-Safe Daemon Restart (issue #534)
+
+As of trusty-common 0.10.0, all four HTTP daemons (trusty-memory, trusty-search,
+trusty-analyze, trusty-mpm) implement graceful shutdown: they drain in-flight
+requests before exiting when they receive SIGTERM. The `serve --stdio` proxy
+reconnects automatically with exponential backoff when the daemon restarts (the
+`trusty-memory-mcp-bridge` binary is a deprecated shim that forwards to
+`serve --stdio`; update your `.mcp.json` to `"command": "trusty-memory", "args":
+["serve", "--stdio"]`).
+
+**Use `launchctl bootout` (SIGTERM), not `launchctl kickstart -k` (SIGKILL):**
+
+```bash
+# Graceful stop → install → restart
+launchctl bootout gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
+cargo install --path crates/<dir> --locked
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/<label>.plist
+# Re-grant Full Disk Access only for trusty-search (and other external-volume
+# daemons) — see the TCC Scope Summary above. trusty-mpm never needs FDA.
+```
+
+For verifying the restart actually took (a 200 `GET /health` is not sufficient
+evidence, `PPID == 1` is not evidence of supervision, and the orphan-listener
+check to run before `bootout`), see the FDA-grant restart playbook above under
+[One-Time FDA Grant](#one-time-fda-grant-after-first-signed-install) — the
+same verification steps apply regardless of which daemon you restarted.
 
 ## Version Management
 

--- a/docs/reference/sloc-cap.md
+++ b/docs/reference/sloc-cap.md
@@ -1,0 +1,76 @@
+# SLOC File Size Cap — Mechanics Reference
+
+> **The cap numbers, classification rule, and merge-blocking prohibition are
+> in [`.trusty-mpm/INSTRUCTIONS.md`](../../.trusty-mpm/INSTRUCTIONS.md) /
+> `CLAUDE.md`** (Key Conventions). This page is the counting definition, the
+> ratchet-allowlist mechanics, and the resolved-refactor history — consult it
+> when running the gate locally or updating the allowlist, not to decide
+> whether a file needs splitting.
+
+## Enforcement
+
+As of issue #610 the production cap is no longer advice: it is gated by
+`scripts/check_line_cap.sh`, wired into CI (`.github/workflows/line-cap.yml`)
+and the local pre-commit hook (`line-cap`). A new tracked production `.rs` file
+over 500 SLOC **cannot merge**; a new test/benchmark `.rs` file over 3000 SLOC
+**cannot merge**. Files approaching their limit are a signal to split into
+focused submodules before the next feature lands on them. When splitting, prefer:
+one public module per logical concept, a thin `mod.rs` that re-exports, and
+sibling files with clear single responsibilities.
+
+## SLOC Counting Definition
+
+A line counts only when it contains non-whitespace source code after all
+comment matter is stripped. These are **excluded** from the count:
+- blank / whitespace-only lines
+- `//` line comments (including `///` doc comments and `//!` inner-doc comments)
+- `/* ... */` block comments — including multi-line spans; every line inside an
+  open block comment is excluded
+- lines that consist entirely of a closing `*/`
+
+A line that has code followed by a trailing `// comment` **still counts** — it
+has code. The counter is a pragmatic awk heuristic that errs toward leniency:
+edge cases (e.g. `//` inside a string literal) may undercount SLOC but will
+never falsely fail a legitimate file.
+
+## The Ratchet — Allowlist That Can Only Shrink
+
+Grandfathered files over their applicable cap are listed in
+`.line-cap-allowlist.tsv` (one `relative/path<TAB>budget` line each, where
+`budget` is that file's frozen max SLOC count). The gate enforces
+per-applicable-cap ratchet semantics:
+
+- SLOC ≤ applicable cap and **not** allowlisted → OK;
+- SLOC > applicable cap and **not** allowlisted → **FAIL** (new oversized file — split it);
+- allowlisted, current SLOC **exceeds its budget** → **FAIL** (it grew — split it);
+- allowlisted, current SLOC **≤ applicable cap** → **FAIL** (drop the entry; ratchet-down forcing function);
+- allowlisted, `applicable_cap < SLOC ≤ budget` → OK (grandfathered, not growing).
+
+So allowlisted files may only shrink, and no new oversized file may be added.
+As the #607 sweep and per-crate refactors land, the allowlist ratchets down
+toward empty.
+
+**Run it locally:** `bash scripts/check_line_cap.sh` (exit 0 = clean). After you
+intentionally split a file (or a file otherwise drops below its budget), refresh
+the frozen budgets with `scripts/check_line_cap.sh --update` — this only *lowers*
+budgets or *removes* entries that fell ≤ their applicable cap; it **refuses** to
+add a new oversized file or raise a budget unless you pass `--seed` (initial
+bootstrap) or `--force-add` (rare, intentional bump). Commit the regenerated
+`.line-cap-allowlist.tsv` alongside your split.
+
+## Resolved Refactor History
+
+Past violations (refactor tickets #170/#171/#172 are CLOSED and the splits have
+landed — all three former monoliths are now under the 500-SLOC cap):
+- `crates/trusty-agents/src/ctrl/mod.rs` — RESOLVED (#170). Split into focused
+  submodules under `crates/trusty-agents/src/ctrl/` (`state`, `config`, `repl`,
+  `handlers`, `pm_task`, …); `mod.rs` is now a ~50-line re-export facade.
+- `crates/trusty-agents/src/runtime/` — RESOLVED (#171). The original `runtime.rs`
+  was split into a `runtime/` module; every submodule is now under the cap.
+- `crates/trusty-agents/src/workflow/engine/` — RESOLVED (#172). The original
+  `engine.rs` was split into an `engine/` module; every submodule is now under
+  the cap (largest is `engine/executor/run.rs` at ~485 lines).
+
+The largest remaining production file in `trusty-agents` (not tied to an open
+ticket) is `tm/manager.rs` — file a fresh refactor ticket before growing it
+further. Current per-file SLOC budgets live in `.line-cap-allowlist.tsv`.

--- a/docs/reference/sloc-cap.md
+++ b/docs/reference/sloc-cap.md
@@ -1,8 +1,7 @@
 # SLOC File Size Cap — Mechanics Reference
 
 > **The cap numbers, classification rule, and merge-blocking prohibition are
-> in [`.trusty-mpm/INSTRUCTIONS.md`](../../.trusty-mpm/INSTRUCTIONS.md) /
-> `CLAUDE.md`** (Key Conventions). This page is the counting definition, the
+> in [`CLAUDE.md`](../../CLAUDE.md)** (Key Conventions). This page is the counting definition, the
 > ratchet-allowlist mechanics, and the resolved-refactor history — consult it
 > when running the gate locally or updating the allowlist, not to decide
 > whether a file needs splitting.

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -1,0 +1,57 @@
+# Rust Test Ladder — Baseline-Failure Protocol
+
+> **The ladder table, the rung selection rule, and "never make a red gate
+> green by deleting coverage" live in
+> [`.trusty-mpm/INSTRUCTIONS.md`](../../.trusty-mpm/INSTRUCTIONS.md) /
+> `CLAUDE.md`** (Rust Test Ladder). This page is the Rust-specific detail for
+> telling a pre-existing red from one your branch caused — consult it while
+> triaging a failing gate, not to decide which rung to run.
+
+The six-step baseline-failure protocol (establish whose red it is, fix if
+branch-caused, append to the canonical issue if tracked, one canonical issue if
+not, and the literal report string) lives in `tm-pr-workflow`. It is **not**
+restated here. What follows is only what that generic version cannot carry.
+
+## Known-Environmental On This Machine — Expect These, Do Not Re-File Them
+
+| Gate | Where | Why it fails independent of your branch |
+|---|---|---|
+| The `trusty-search` filesystem-watcher tests (~6; the set drifts) | `crates/trusty-search/src/service/watch_loop.rs`, `watcher.rs`, `watcher_manager.rs` | FSEvents delivery on this host is nondeterministic. They fail on any branch, and they still fail under `-- --test-threads=1` — so it is the machine, not parallel-test load |
+| `execute_doctor_against_test_daemon` | `crates/trusty-mpm/src/client/executor/tests.rs` | It takes 9–13 s against a 10 s client timeout, so it loses on timing alone under any load |
+
+🔴 **The correct response is to prove your diff touches zero files in those
+crates — never to `#[ignore]`, `cfg`-gate, or `--exclude` them.** The proof is a
+path list, and empty output is the evidence; paste it in the PR:
+
+```bash
+git diff --name-only origin/main...HEAD -- crates/trusty-search/ \
+                                           crates/trusty-mpm/src/client/
+```
+
+## Telling A Pre-Existing Red From One You Caused — Crate-Scoped Confirmation
+
+1. **Re-run the failure alone on your branch**, not the whole suite:
+   `cargo test -p <crate> <test> -- --exact --nocapture`. A single named test
+   removes ordering and load from the picture.
+2. **Run the identical command against `origin/main` in a second worktree** —
+   never by mutating the main checkout, and never with `git stash`:
+   ```bash
+   git worktree add .claude/worktrees/baseline-<n> origin/main
+   cd .claude/worktrees/baseline-<n> && cargo test -p <crate> <test> -- --exact
+   ```
+   Failing on both is the evidence that the branch did not cause it.
+3. **Serialize before blaming isolation:** `-- --test-threads=1`. If it still
+   fails serialized, parallel interference is not the explanation and "flaky
+   under load" is the wrong diagnosis.
+4. **Check the path evidence:** `git diff --name-only origin/main...HEAD`. If the
+   failing crate does not appear there, and you did not touch a shared library it
+   depends on, the red is not yours.
+5. 🔴 **The shared-crate caveat:** a green `cargo test -p <your-crate>` does
+   **not** clear you when you changed `trusty-common`, `trusty-embedderd`, or any
+   other shared library. A red in a *dependent* crate is yours until rung 4 of
+   the ladder says otherwise. This is the one case where scoping down is
+   the wrong instinct.
+
+Report it in the shape `tm-pr-workflow` mandates, naming the crate-scoped gate:
+`change-specific gates pass; cargo test -p trusty-search blocked by canonical
+issue #N`. Never "all tests pass" while a gate is red, whoever caused it.

--- a/docs/reference/test-ladder-baseline.md
+++ b/docs/reference/test-ladder-baseline.md
@@ -2,8 +2,7 @@
 
 > **The ladder table, the rung selection rule, and "never make a red gate
 > green by deleting coverage" live in
-> [`.trusty-mpm/INSTRUCTIONS.md`](../../.trusty-mpm/INSTRUCTIONS.md) /
-> `CLAUDE.md`** (Rust Test Ladder). This page is the Rust-specific detail for
+> [`CLAUDE.md`](../../CLAUDE.md)** (Rust Test Ladder). This page is the Rust-specific detail for
 > telling a pre-existing red from one your branch caused — consult it while
 > triaging a failing gate, not to decide which rung to run.
 

--- a/docs/specs/DOC-62-style-modes-coding-delegation.md
+++ b/docs/specs/DOC-62-style-modes-coding-delegation.md
@@ -159,7 +159,7 @@ changelog requirement), `sld-lint.yml`, `doc-numbers.yml`, `test-pointers.yml`,
 `capabilities-drift.yml`, `version-parity.yml`, `cargo-audit.yml`,
 `generation-artifact-lint.yml`, `agent-assets.yml`), GitHub branch protection
 and required reviews on `main`, and the trusty-review gate in the delivery
-chain (`.trusty-mpm/INSTRUCTIONS.md:575`).
+chain (`CLAUDE.md:493`).
 
 The distinguishing test is **who renders the verdict**. If the delegated task
 renders it, it is ceremony. If something outside the delegated task renders
@@ -786,7 +786,7 @@ consumes them.
 - [DOC-61](./DOC-61-canonical-agent-standard.md) §4 — source model vs per-product builder; §9 declarative-agents-only.
 - [`docs/trusty-code/vision-and-architecture-spec.md`](../trusty-code/vision-and-architecture-spec.md) §5.10, §10 D3 — Execution Patterns; the `HarnessMode` non-conflation rule.
 - [`docs/research/quality-gates-agent-prs-article-2026-04.md`](../research/quality-gates-agent-prs-article-2026-04.md) — risk-weighted routing; the author-tags finding cited in §5.4.
-- [`.trusty-mpm/INSTRUCTIONS.md`](../../.trusty-mpm/INSTRUCTIONS.md) — the delivery chain and the repository's own gate list.
+- [`CLAUDE.md`](../../CLAUDE.md) — the delivery chain and the repository's own gate list.
 
 ### 10.2 Change log
 


### PR DESCRIPTION
## Summary

Split C (the last split) of the #4286 retirement. PR #4660 deleted the guard that forbade a tracked root `CLAUDE.md` (#2299 retired by owner ruling), so this project's own `.trusty-mpm/INSTRUCTIONS.md` can finally be retired for real: its content moves to the root `CLAUDE.md`.

Two commits, in order:

1. **Externalize** — re-measured the file against live `origin/main` (still 49,699 bytes) and cut it to 37,461 bytes (~25%) by moving the three highest-value targets from the audit to `docs/reference/`:
   - macOS TCC (FDA/App-Data) + daemon-restart pair → `docs/reference/release-workflow.md` (~90% already duplicated there). Also **added the FDA-vs-App-Data scope split as its own explicit callout** in that file — it was NOT previously stated as a standalone section there, only implied across several paragraphs.
   - SLOC cap mechanics (counting definition, ratchet-allowlist semantics, resolved #170/#171/#172 history) → new `docs/reference/sloc-cap.md`. Cap numbers and classification rule stay inline.
   - Rust test-ladder baseline-failure protocol (known-environmental flaky tests, 5-step pre-existing-vs-caused-red protocol) → new `docs/reference/test-ladder-baseline.md`.
2. **Migrate and delete** — moved the trimmed content (37,355 bytes after a small follow-up fix) into the root `CLAUDE.md` as **plain prose** (not `TRUSTY-MPM:` marker blocks — none of this repo-specific Rust/build content corresponds to a bundled PM-prompt `SectionId`; wrapping it in a marker like `CORE` or `WORKFLOW` would replace a PM-prompt section instead of adding project context), then `git rm .trusty-mpm/INSTRUCTIONS.md`.

Also fixed the two stale pointers split B flagged as this split's territory (`docs/specs/DOC-62-style-modes-coding-delegation.md`, `docs/reference/common-pitfalls.md` — the latter also carried a stale "1500 SLOC" test-cap figure, corrected to 3000 per #4074), plus `CONTRIBUTING.md`'s three references, which would otherwise have gone dead on this same PR.

**#4286 can close once this lands** — all three splits (A: bundled asset retirement, B: shipped-asset text sweep, C: this PR) are now complete.

## Survival checklist — confirmed still inline in CLAUDE.md

- Never turn red green by deleting coverage — *"It is never licence to make a red gate green by deleting, `#[ignore]`-ing, `cfg`-gating, `--exclude`-ing, or `--lib`-narrowing coverage. That remains the hard line it has always been."*
- 500/3000 SLOC cap numbers — *"Production source files | **500 SLOC**"* / *"Test / benchmark files | **3000 SLOC**"*
- Main-checkout-inspection-only + worktree-per-workstream — *"The main checkout is inspection-only."* / *"One branch and worktree per independently reviewable PR outcome"*
- Per-PR changelog requirement — *"Every PR that touches a crate's `src/**` adds a changelog FRAGMENT file to that crate, in the same PR. Never edit a crate's `CHANGELOG.md` by hand."*
- Publish only from merged main — *"Rule: **publish only from merged main, as bobmatnyc.**"*
- MSRV 1.91 + edition split — *"`edition = "2024"` for `trusty-mpm`, ... ; `edition = "2021"` for all other crates."*
- `unwrap()`/thiserror/anyhow — *"No `unwrap()` in library code ... `thiserror` for libraries, `anyhow` for binaries"*

## Verification

- **Byte delta:** 49,699 → 37,461 (externalize) → 37,355 (migrate; a small follow-up fix). A session now loads project context from the tracked root `CLAUDE.md` (read natively by Claude Code, plus scanned for `TRUSTY-MPM:` named-section overrides by `claude_md_sections.rs`) instead of `.trusty-mpm/INSTRUCTIONS.md`, which is deleted.
- **Live instance:** built `tm`/`trusty-mpm` 1.3.2 from this branch (`target/debug/tm`), ran `tm validate --path <scratch-dir> --repair` against a scratch git-init'd project seeded with this branch's `CLAUDE.md`. Result: `.trusty-mpm/last-instructions.md` produced (canonical path), all 9 bundled `SectionId`s (`identity`, `core`, `memory`, `search`, `workflow`, `agent-delegation`, `enforcement`, `non-overridable-rules`, `framework-guaranteed-conventions`) present exactly once each, `Delegation Authority` roster present and non-empty, multiple `CLAUDE.md` references present in the composed prompt (the only `.trusty-mpm/INSTRUCTIONS.md` mention left is the framework's own explanatory "this is retired" prose, not a live pointer). Scratch dir cleaned up after.
- **`tm doctor` `legacy_overrides`:** started an ephemeral `tm daemon --addr 127.0.0.1:17880 --force` from this branch's binary (isolated port, does not touch the machine's real launchd-supervised daemon), ran `tm doctor --url http://127.0.0.1:17880` from this repo: `✅ legacy_overrides no retired .trusty-mpm/ instruction override files present`. Daemon stopped after.
- **Raw gate output** (all green):
  - `cargo fmt --check` — clean (nightly-only-feature warnings only, no diff)
  - `cargo clippy -p trusty-mpm --all-targets -- -D warnings` — clean
  - `cargo test -p trusty-mpm` — lib: `4290 passed; 0 failed; 7 ignored`; every integration-test binary: `0 failed` (largest: `1375 passed; 0 failed` ×2). Zero `FAILED` anywhere in the full log.
  - `bash scripts/check_line_cap.sh` — `measured 3596 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.`
  - `bash scripts/check_sld.sh` — `scanned 53 spec doc(s) + 3025 code file(s); 0 error(s), 0 warning(s)`
  - `bash scripts/check_doc_numbers.sh` — `scanned 95 doc(s) / 89 claim(s) (floors 20/20); 4 grandfathered, 0 violations — OK.`
  - `bash scripts/check_capabilities.sh` — `tm-capabilities: up to date (6 generated files).`
  - `bash scripts/check_test_pointers.sh` (run alone) — `resolved 20314 Test: citation(s) (floor 200) — 0 dangling pointers — OK.`
- **Changelog:** docs-only change (no crate `src/` touched) — exempt per the per-PR changelog fragment rule.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p trusty-mpm --all-targets -- -D warnings`
- [x] `cargo test -p trusty-mpm` (full raw output, zero failures)
- [x] `check_line_cap.sh` / `check_sld.sh` / `check_doc_numbers.sh` / `check_capabilities.sh` / `check_test_pointers.sh`
- [x] Live `tm validate --repair` against a scratch project on this branch's binary
- [x] `tm doctor`'s `legacy_overrides` check against this repo (ephemeral daemon)
- [ ] CI (`gh pr checks`) — pending

Closes #4286

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools