### PR TITLE
docs(specs): record 2026-08-03 owner decisions on DOC-62 and DOC-63

### DIFF
--- a/docs/specs/DOC-62-style-modes-coding-delegation.md
+++ b/docs/specs/DOC-62-style-modes-coding-delegation.md
@@ -15,7 +15,8 @@ spec_refs:
 
 # DOC-62 — Style Modes for Coding Delegation: `hack` / `vibe` / `engineer`
 
-**Status:** Draft
+**Status:** Accepted — all six §9 open questions resolved by owner decision
+2026-08-03 (see §9); landed 2026-08-01 (#4529).
 **Spec ID:** `SPEC-STYLE-01~draft` … `SPEC-STYLE-10~draft`
 **Subsystem:** cross-crate — trusty-agents (delegation surface, `HandoffContext`, preamble carriage); trusty-code (style parameter, internal pipeline selection); trusty-mpm/GUI (style selector, downstream)
 **Owner:** Architecture / Technical Leadership
@@ -710,7 +711,8 @@ Testable, and mapped to the implementing issues.
 ## 9. Open Questions for the Owner {#SPEC-STYLE-09~draft}
 
 **ID:** SPEC-STYLE-09~draft
-**Status:** Draft
+**Status:** Draft — all six questions below RESOLVED by owner decision
+2026-08-03; recorded inline, not deleted, so the reasoning trail survives.
 
 Only genuine remaining forks are listed. Epic #4345's questions 4 and 5 are
 **not** here: they are decided in §6 and §3 with evidence. Questions 1–3 are
@@ -722,6 +724,8 @@ consumes them.
   pane. Recommendation: **both, per-assistant wins**, because the style that
   suits `izzie` is not the style that suits a CTO assistant. Low reversibility
   cost either way.
+  **RESOLVED (owner decision, 2026-08-03):** both, with per-assistant winning
+  over global — the recommendation is adopted as-is. Unblocks #4353.
 
 - **OQ-2 — Does `hack` belong on the delegation surface at all?** §4.1 argues
   `hack` is the absence of a code change; a coding delegation that resolves to
@@ -732,6 +736,8 @@ consumes them.
   across the three surfaces (config, delegation, GUI) for no safety gain —
   §4.1's escalation rule already closes the hole. Flagged because it is a
   product-vocabulary call, not a technical one.
+  **RESOLVED (owner decision, 2026-08-03):** yes — `hack` stays on the
+  delegation surface; accept and escalate per §4.1's existing position.
 
 - **OQ-3 — The `engineer` name collides with the tcode `engineer` sub-agent
   role** (`crates/trusty-code/src/assets/agents/engineer.md`), noted in
@@ -741,6 +747,8 @@ consumes them.
   `engineer` (decision 1 fixed it) and disambiguate in the **GUI label and
   preamble wording** rather than the wire value. Owner confirmation wanted
   because the mitigation is presentational and therefore easy to lose.
+  **RESOLVED (owner decision, 2026-08-03):** keep the wire value `engineer`;
+  disambiguate in the GUI label and preamble only, per the recommendation.
 
 - **OQ-4 — Should the gate ledger (§3.4) be structured or prose?** Structured
   is enforceable by AC-7 and consumable by the GUI; prose is cheaper and
@@ -748,6 +756,8 @@ consumes them.
   prints only the final `Session` snapshot). Recommendation: **structured**,
   because SM-4 is the rule most likely to erode silently, and a prose summary
   is exactly where "not run" quietly becomes "fine".
+  **RESOLVED (owner decision, 2026-08-03):** structured, enforceable by AC-7
+  and GUI-consumable, per the recommendation.
 
 - **OQ-5 — Which product's circuit breakers does #2596's question 2 refer
   to?** The audit (§3.3, §7.1) found trusty-code has **no circuit breaker**;
@@ -757,6 +767,9 @@ consumes them.
   VIBE get them". No recommendation offered — this is #2596's call, and it is
   flagged here only because #4345 inherited the question in a form that
   presumes a construct that does not exist.
+  **RESOLVED (owner decision, 2026-08-03) on fact, not preference:**
+  trusty-mpm's circuit breakers — trusty-code has none at all, per the code
+  audit already recorded in DOC-62 §3.3.
 
 - **OQ-6 — Should a per-delegation style override be exposed in the GUI at
   all, given §5.4?** #4353 lists a delegation-level override as a "product
@@ -766,6 +779,9 @@ consumes them.
   effective style and its resolution path (§3.4) in the result**, so the
   override is honest rather than decorative. Owner call because it is a
   product-trust decision, not a technical one.
+  **RESOLVED (owner decision, 2026-08-03):** expose it, and always render the
+  effective style plus its resolution path so an overruled request is
+  visible rather than silently ignored, per the recommendation.
 
 ---
 

--- a/docs/specs/DOC-63-okg-sources.md
+++ b/docs/specs/DOC-63-okg-sources.md
@@ -13,7 +13,8 @@ spec_refs:
 
 # DOC-63 — OKG Sources: Per-Assistant Knowledge Sources, Scheduled Refresh, and the Untrusted-Content Boundary
 
-**Status:** Draft
+**Status:** Accepted — all three §14 open questions resolved by owner decision
+2026-08-03 (see §14); landed 2026-08-01 (#4530).
 **Spec ID:** `SPEC-OKGSRC-01~draft` … `SPEC-OKGSRC-14~draft` (DOC-63)
 **Subsystem:** trusty-agents — assistant home / OKG store, source catalog, scheduled refresh, credentials consumption, Knowledge config pane; trusty-kb — `okg` engine (ledger, registry, entity tree); trusty-search — index over the store
 **Owner:** Engineering (trusty-agents) / Bob Matsuoka
@@ -1554,6 +1555,10 @@ construction; each still a capability grant.
 
 ## 14. Open Questions for the Owner
 
+**All three forks below (Q1–Q3) RESOLVED by owner decision 2026-08-03 —
+recorded inline against each question, not deleted, so the reasoning trail
+survives.**
+
 Genuine forks only. Each states what stays blocked until answered.
 
 **Resolved since the first draft, recorded so they are not re-opened:** the
@@ -1598,6 +1603,13 @@ an issue-level decision (as #4406 itself suggests).
 **Blocked until answered:** nothing in this epic — every ticket here names the OKF
 store. What stays blocked is #4406's own closure, and any work bridging the two.
 
+**RESOLVED (owner decision, 2026-08-03):** keep both, separate jobs. The OKF
+store is knowledge built from sources; trusty-memory's KG is structured
+recall. They remain independent with no bridge. This is the status quo made
+deliberate: no feed direction is defined, and any future feature must state
+explicitly which of the two it writes to. The accepted consequence: the KG
+stays underused.
+
 ### Q2 — Do you accept the residual prompt-injection risk in §6.5?
 
 With the §5 boundary implemented, an assistant may still be influenced by
@@ -1615,6 +1627,12 @@ answered:** Phase D in its entirety. This is flagged for explicit sign-off rathe
 than absorbed as a design assumption, because it is a security acceptance and
 those belong to you.
 
+**RESOLVED (owner decision, 2026-08-03):** accepted, on the stated condition —
+Phase A lands before Phase D, and every new source type is reviewed as a
+capability grant. This condition is **binding, not advisory**: Phase D
+(slack-sent, slack-channel, notion, granola) does not start until Phase A has
+landed.
+
 ### Q3 — Should scheduled refresh be a listener, or its own runner?
 
 §8.3 recommends **its own runner**, reusing `listeners::poll`'s *pattern*
@@ -1628,6 +1646,10 @@ wakes nobody.
 **Blocked until answered:** Phase B's runner ticket. Lower stakes than Q1–Q2 —
 recorded because it is a structural choice a reviewer could reasonably reverse,
 not because the recommendation is weak.
+
+**RESOLVED (owner decision, 2026-08-03):** its own runner, reusing the
+`listeners::poll` pattern but not its module, per the recommendation. Unblocks
+Phase B's runner ticket.
 
 ---
 


### PR DESCRIPTION
## Summary

Records nine owner decisions (2026-08-03) into the open-questions sections of
two already-landed specs. Decisions are recorded inline as RESOLVED annotations
— nothing is deleted, so the reasoning trail survives.

**DOC-62 §9 (Style Modes for Coding Delegation) — six resolutions:**
- OQ-1 (config default scope): both, per-assistant wins over global.
- OQ-2 (`hack` on the delegation surface): yes — accept and escalate per §4.1.
- OQ-3 (`engineer` name collision with tcode's `engineer` sub-agent): keep the
  wire value `engineer`; disambiguate in GUI label/preamble only.
- OQ-4 (gate ledger shape): structured, enforceable by AC-7, GUI-consumable.
- OQ-5 (whose circuit breakers #2596 refers to): trusty-mpm's — trusty-code
  has none, per the DOC-62 §3.3 code audit.
- OQ-6 (per-delegation style override in the GUI): expose it, always render
  the effective style plus resolution path.

**DOC-63 §14 (OKG Sources) — three resolutions:**
- Q1 (trusty-memory KG vs. canonical OKG): keep both, separate jobs, no
  bridge, no feed direction defined — deliberate status quo; KG stays
  underused.
- Q2 (residual prompt-injection risk, §6.5): accepted, conditional on Phase A
  landing before Phase D (binding, not advisory) and capability-grant review
  of every new source type.
- Q3 (scheduled refresh mechanism): its own runner, reusing `listeners::poll`'s
  pattern but not its module.

Both documents' **Status** lines move from `Draft` to `Accepted`, matching the
`Draft → Accepted → Superseded` lifecycle vocabulary this repo's SLD standard
defines (`docs/specs/README.md`, `spec-linked-documentation.md` §4.4) — both
specs' content already landed 2026-08-01 (#4529, #4530), so `Draft` no longer
described their state.

Unblocks #4350, #4348, #4349, #4353, DOC-63 Phase B's runner ticket, and
DOC-63 Phase D.

Refs #4040, #4406.

## Test plan
- [x] `scripts/check_doc_numbers.sh` — OK (0 violations)
- [x] `scripts/check_sld.sh` — OK (0 errors, 0 warnings)
- [x] `scripts/check_line_cap.sh` — OK (0 violations)
- [x] `scripts/check_changelog_fragment.sh` — OK (docs-only, no crate source changed)

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools