### PR TITLE
feat(trusty-agents): unattended detection via last-human-turn timeout (#4652)

### DIFF
--- a/crates/trusty-agents/changelog.d/4652-unattended-detection.md
+++ b/crates/trusty-agents/changelog.d/4652-unattended-detection.md
@@ -37,12 +37,17 @@ Added
   `~/.trusty-agents/attendance/`, written through the existing lock+tmp+rename
   `state_writer` so a GUI, an `--api` sidecar and a REPL sharing that tree
   cannot tear each other's records. Recording is monotonic — an out-of-order
-  turn never rewinds the clock.
+  turn never rewinds the clock — and the guard is evaluated under the SAME held
+  lock as the write (`state_writer::atomic_update`, new in this change), so two
+  processes recording near-simultaneous turns cannot both read the old value and
+  let the loser's older write land last. Pinned by
+  `concurrent_writers_never_rewind_the_clock`, which fails against a
+  read-then-write guard.
 
-  Recorded at the four surfaces a person can actually address an assistant
-  through, each against the persona the message named: `POST /api/task`, the
-  REPL's `attempt_forward` (one call covering all six of its dispatch arms),
-  Telegram past the pairing gate, and Slack past the pairing and RBAC gates. The
+  Recorded at every surface a person can actually address an assistant through,
+  each against the persona the message named: `POST /api/task`, the REPL's
+  `attempt_forward` (one call covering all six of its dispatch arms), and BOTH
+  inbound paths on Telegram and Slack — free text and slash commands alike. The
   hook is infallible by construction — an unusable instance name, a missing home
   directory or an I/O error is logged at debug and swallowed, because attendance
   is a hint for #4653 and never a reason to fail a turn a user is waiting on.
@@ -50,9 +55,27 @@ Added
   Signal only: nothing here sends or queues, and `trusty-agents` gains no
   dependency on `trusty-mpm`.
 
-  Telegram's `/switch <persona>` intercept returns early from `handle_message`,
-  so a paired human switching persona was never recorded as a turn (caught in
-  review of [#4683](https://github.com/bobmatnyc/trusty-tools/pull/4683)). The
-  hook now runs before the intercept, fused with the routing decision so the two
-  cannot drift apart again — pinned by
-  `switch_command_still_records_a_human_turn`.
+  Three attendance gaps were caught in review of
+  [#4683](https://github.com/bobmatnyc/trusty-tools/pull/4683), all the same
+  shape — a live entry point that never advanced the clock, so a human who was
+  demonstrably present read as unattended after fifteen minutes:
+
+  - Telegram's `/switch <persona>` intercept returns early from
+    `handle_message`, so a paired human switching persona was never recorded.
+    The hook now runs before the intercept, fused with the routing decision so
+    the two cannot drift apart again — pinned by
+    `switch_command_still_records_a_human_turn`.
+  - Telegram's `handle_command` (`/start`, `/pair`, `/help`, `/connect`,
+    `/clear`, `/status`) and Slack's (`/slack-start`, `/slack-pair`,
+    `/slack-connect`, `/slack-clear`, `/slack-switch`, `/slack-status`)
+    recorded nothing at all, so a human polling `/status` every few minutes
+    while a long task ran was invisible. Both now record through one shared
+    `attendance::note_command_turn_in`, behind the same authentication each
+    transport's message path already records behind: paired on Telegram, paired
+    AND a known RBAC identity on Slack — so an unpaired chat, or an unknown
+    Slack user posting in a paired channel, still cannot manufacture attendance
+    for someone else's assistant. Pinned by
+    `paired_slash_command_records_a_human_turn`,
+    `unpaired_slash_command_records_nothing`,
+    `unknown_rbac_user_cannot_manufacture_attendance` and, end to end,
+    `a_command_only_session_stays_attended`.

--- a/crates/trusty-agents/changelog.d/4652-unattended-detection.md
+++ b/crates/trusty-agents/changelog.d/4652-unattended-detection.md
@@ -1,0 +1,51 @@
+Added
+
+- **`attendance` — "is a human currently attending this assistant instance?"**
+  (closes [#4652](https://github.com/bobmatnyc/trusty-tools/issues/4652); part
+  of epic [#4646](https://github.com/bobmatnyc/trusty-tools/issues/4646), owner
+  decision **D3**). Nothing could answer that question, and the `notify_owner`
+  tool ([#4653](https://github.com/bobmatnyc/trusty-tools/issues/4653)) cannot
+  exist without an answer. The new module exposes `AttendanceTracker`,
+  `Attendance` and `is_unattended()` for #4653 to gate on. Per D3 the mechanism
+  is a last-human-turn timeout with one tunable threshold — explicitly not SSE
+  connection counting and not a manual do-not-disturb toggle.
+
+  This is new work rather than a reuse of `SessionRecord.last_activity_at`
+  because that field advances on the assistant's own tool and hook activity
+  exactly as it does on a human typing, so an assistant grinding through a long
+  solo task reads as attended forever. Here the origin of a turn is an explicit
+  `TurnOrigin` argument and only `TurnOrigin::Human` advances the clock;
+  assistant activity writes nothing at all, which
+  `assistant_turns_never_advance_the_clock` and
+  `assistant_only_activity_leaves_no_record_at_all` pin. `Attendance` carries a
+  distinct `NeverAttended` state — no human turn has ever been recorded — which
+  counts as unattended, and the threshold boundary is inclusive on the
+  unattended side, so "N minutes" means N minutes of silence is enough. A
+  timestamp in the future (clock skew) reads as attended, biasing toward silence
+  rather than toward interrupting someone who is present.
+
+  **The threshold defaults to 15 minutes**, overridable with
+  `TAGENT_UNATTENDED_AFTER_MINS` (whole minutes; blank, non-numeric or zero
+  input keeps the default rather than failing a boot). Long enough to clear an
+  ordinary interruption, short enough that a real walk-away is noticed inside
+  one break.
+
+  **Durable**, and that is correctness rather than tidiness: an in-memory
+  tracker would report a fresh process as never-attended, so restarting the API
+  server mid-conversation would hand #4653 a licence to notify a human who is
+  demonstrably present. State is one small JSON record per instance under
+  `~/.trusty-agents/attendance/`, written through the existing lock+tmp+rename
+  `state_writer` so a GUI, an `--api` sidecar and a REPL sharing that tree
+  cannot tear each other's records. Recording is monotonic — an out-of-order
+  turn never rewinds the clock.
+
+  Recorded at the four surfaces a person can actually address an assistant
+  through, each against the persona the message named: `POST /api/task`, the
+  REPL's `attempt_forward` (one call covering all six of its dispatch arms),
+  Telegram past the pairing gate, and Slack past the pairing and RBAC gates. The
+  hook is infallible by construction — an unusable instance name, a missing home
+  directory or an I/O error is logged at debug and swallowed, because attendance
+  is a hint for #4653 and never a reason to fail a turn a user is waiting on.
+
+  Signal only: nothing here sends or queues, and `trusty-agents` gains no
+  dependency on `trusty-mpm`.

--- a/crates/trusty-agents/changelog.d/4652-unattended-detection.md
+++ b/crates/trusty-agents/changelog.d/4652-unattended-detection.md
@@ -49,3 +49,10 @@ Added
 
   Signal only: nothing here sends or queues, and `trusty-agents` gains no
   dependency on `trusty-mpm`.
+
+  Telegram's `/switch <persona>` intercept returns early from `handle_message`,
+  so a paired human switching persona was never recorded as a turn (caught in
+  review of [#4683](https://github.com/bobmatnyc/trusty-tools/pull/4683)). The
+  hook now runs before the intercept, fused with the routing decision so the two
+  cannot drift apart again — pinned by
+  `switch_command_still_records_a_human_turn`.

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -320,6 +320,13 @@ pub(super) async fn submit_task(
     let placeholder = PmResponse::running(&id);
     state.upsert(id.clone(), placeholder).await;
 
+    // #4652: this request is a person typing in the GUI/WebUI, which is the
+    // one thing `SessionRecord.last_activity_at` cannot distinguish from the
+    // assistant's own tool calls. Record it as attendance for the instance the
+    // human addressed (no roster selection = the `ctrl` concierge).
+    // Infallible: a failure is logged and swallowed, never surfaced here.
+    crate::attendance::note_human_turn(agent_override(&req).as_deref().unwrap_or("ctrl"));
+
     // #192 Phase B: announce the new session immediately on the event bus so
     // SSE subscribers (Sidebar task list, ChatView session bootstrap) update
     // before the child subprocess has even spawned.

--- a/crates/trusty-agents/src/attendance/mod.rs
+++ b/crates/trusty-agents/src/attendance/mod.rs
@@ -63,8 +63,8 @@ mod tracker;
 mod tests;
 
 pub use tracker::{
-    AttendanceTracker, attendance_root, default_attendance_root, note_human_turn,
-    note_human_turn_in,
+    AttendanceTracker, attendance_root, default_attendance_root, note_command_turn_in,
+    note_human_turn, note_human_turn_in,
 };
 
 /// How long after the last human turn an instance counts as unattended.

--- a/crates/trusty-agents/src/attendance/mod.rs
+++ b/crates/trusty-agents/src/attendance/mod.rs
@@ -1,0 +1,245 @@
+//! Is a human currently attending this assistant instance? (#4652, epic #4646)
+//!
+//! Why: nothing in the codebase could answer that question, and B2's
+//! `notify_owner` tool (#4653) cannot exist without an answer — an assistant
+//! that speaks unprompted while the owner is sitting right there is noise, and
+//! one that stays silent while the owner is away is useless. The three signals
+//! that look like they might serve were each verified NOT to (epic #4646,
+//! 2026-08-03 research pass):
+//!
+//! - `SessionRecord.last_activity_at` (`trusty-mpm`,
+//!   `session_manager/record.rs:204`) advances on TOOL and HOOK activity. An
+//!   assistant grinding through a long solo task advances it exactly as a human
+//!   typing does, so it answers "is something happening?", never "is someone
+//!   here?".
+//! - Telegram/Slack `focus` (`trusty-mpm/src/telegram/focus.rs`) is a
+//!   per-conversation routing `HashMap` with no lease and no heartbeat. It
+//!   answers "where do inbound messages go", which survives the human walking
+//!   away unchanged.
+//! - SSE (`api/server/events_sse.rs`) tracks no connection count at all.
+//!
+//! So this is a NEW signal, built to the owner's binding decision **D3**
+//! (2026-08-03): unattended is a LAST-HUMAN-TURN TIMEOUT with one tunable
+//! threshold. Explicitly not SSE connection counting, and not a manual
+//! do-not-disturb toggle.
+//!
+//! What:
+//! - [`TurnOrigin`] — the crux of the whole module. A turn is either
+//!   [`TurnOrigin::Human`] or [`TurnOrigin::Assistant`], and ONLY the former
+//!   advances the clock. Every other kind of activity an instance produces
+//!   (its own replies, tool calls, tool results, hook fires, background wakes)
+//!   is [`TurnOrigin::Assistant`] and is inert here by construction — that is
+//!   precisely the distinction `last_activity_at` cannot make.
+//! - [`AttendanceTracker`] — records human turns and answers
+//!   [`AttendanceTracker::is_unattended`] for one instance.
+//! - [`Attendance`] — the three-way answer, including the "no human has ever
+//!   spoken to this instance" case that a bare timestamp cannot express.
+//! - [`AttendanceConfig`] — the single tunable threshold, defaulting to
+//!   [`DEFAULT_UNATTENDED_AFTER`] and overridable via
+//!   [`UNATTENDED_AFTER_ENV`].
+//!
+//! DURABLE. State is one small JSON file per instance under
+//! `~/.trusty-agents/attendance/<instance>.json`, written through
+//! [`crate::state_writer::atomic_write`] (the same lock+tmp+rename path every
+//! other trusty-agents state file uses), so the answer survives a restart. That
+//! matters for correctness, not just tidiness: an in-memory tracker would
+//! report a fresh process as never-attended, and a never-attended instance is
+//! unattended (see [`Attendance::NeverAttended`]) — so restarting the API
+//! server while the owner was mid-conversation would hand B2 a licence to
+//! notify a human who is demonstrably right there.
+//!
+//! Scope: this module delivers the SIGNAL only. It sends nothing, queues
+//! nothing, and knows nothing about Telegram, Slack or the `notify_owner` tool
+//! — those are #4653/#4654/#4655/#4657.
+//!
+//! Test: `tests` — the whole module.
+
+use std::time::Duration;
+
+mod tracker;
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;
+
+pub use tracker::{
+    AttendanceTracker, attendance_root, default_attendance_root, note_human_turn,
+    note_human_turn_in,
+};
+
+/// How long after the last human turn an instance counts as unattended.
+///
+/// Why: the threshold has to clear an ordinary interruption — reading a
+/// message, taking a call, refilling a coffee — because notifying a human who
+/// is about to look back at the screen is the failure mode D3 exists to avoid.
+/// It also has to be short enough that a genuine walk-away is noticed inside
+/// one break rather than one workday. Fifteen minutes is the shortest span that
+/// comfortably clears the first without approaching the second, and it matches
+/// the idle convention users already expect from chat clients.
+/// What: 15 minutes, as a [`Duration`]. Tunable per [`AttendanceConfig`].
+/// Test: `default_threshold_is_fifteen_minutes`.
+pub const DEFAULT_UNATTENDED_AFTER: Duration = Duration::from_secs(15 * 60);
+
+/// Environment override for the unattended threshold, in whole minutes.
+///
+/// Why: D3 requires the threshold be tunable, and an env var is the override
+/// mechanism the rest of this crate already uses for operator-facing paths
+/// (`TAGENT_ASSISTANTS_DIR`).
+/// What: `TAGENT_UNATTENDED_AFTER_MINS`. Parsed by
+/// [`AttendanceConfig::from_env`]; see [`parse_threshold_minutes`] for the
+/// rejection rules.
+/// Test: `parse_threshold_accepts_whole_minutes`.
+pub const UNATTENDED_AFTER_ENV: &str = "TAGENT_UNATTENDED_AFTER_MINS";
+
+/// Who produced a turn — the distinction this whole module exists to make.
+///
+/// Why: `SessionRecord.last_activity_at` cannot tell an assistant's own tool
+/// call from a human typing, which is why it cannot answer "is someone here?".
+/// Making the origin an explicit, exhaustive parameter of
+/// [`AttendanceTracker::record_turn`] moves that decision to the ONE place that
+/// knows the answer — the entry point the turn arrived through — and makes
+/// "assistant activity must not count as attendance" a property the type system
+/// carries rather than a convention a future call site can forget.
+/// What: two variants, and deliberately only two. Anything that is not a human
+/// putting words in front of this assistant is [`Self::Assistant`]: the
+/// assistant's own replies, its tool calls and their results, hook fires,
+/// scheduled wakes, and event-listener-triggered turns. Passing
+/// [`Self::Assistant`] is always SAFE — it is a documented no-op, not an
+/// error — so a call site that is unsure has a correct default.
+/// Test: `assistant_turns_never_advance_the_clock`,
+/// `assistant_only_activity_leaves_no_record_at_all`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TurnOrigin {
+    /// A person addressed this assistant: a chat message they typed, a
+    /// Telegram/Slack message they sent, a REPL prompt they submitted.
+    Human,
+    /// Anything the assistant itself produced or was driven by: its own
+    /// replies, tool calls, tool results, hooks, timers, event wakes.
+    Assistant,
+}
+
+impl TurnOrigin {
+    /// Whether a turn of this origin advances the last-human-turn clock.
+    ///
+    /// Test: `assistant_turns_never_advance_the_clock`.
+    pub fn is_human(self) -> bool {
+        matches!(self, Self::Human)
+    }
+}
+
+/// Whether a human is attending an instance, and for how long they have not
+/// spoken.
+///
+/// Why: a bare `Option<DateTime>` forces every caller to re-derive the
+/// threshold comparison, and re-derivation is where two callers disagree.
+/// Returning the verdict WITH the idle duration also lets a caller log why it
+/// decided what it decided without a second query.
+/// What: three states. [`Self::NeverAttended`] is not a degenerate
+/// [`Self::Unattended`] — it means no human turn has EVER been recorded for
+/// this instance, which a duration cannot express. Both it and
+/// [`Self::Unattended`] answer `true` to [`Self::is_unattended`]: the question
+/// is "is a human attending", and no evidence of a human is not evidence of a
+/// human.
+/// Test: `fresh_human_turn_is_attended`, `past_threshold_is_unattended`,
+/// `never_attended_counts_as_unattended`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Attendance {
+    /// A human turn landed less than the threshold ago.
+    Attended {
+        /// Time since that turn.
+        idle_for: Duration,
+    },
+    /// A human turn was recorded, but at least the threshold ago.
+    Unattended {
+        /// Time since that turn.
+        idle_for: Duration,
+    },
+    /// No human turn has ever been recorded for this instance.
+    NeverAttended,
+}
+
+impl Attendance {
+    /// Whether B2 may treat the owner as away.
+    ///
+    /// Why: the one predicate `notify_owner` (#4653) gates on, so the
+    /// never-attended policy lives here rather than being re-decided per
+    /// caller.
+    /// What: `true` for [`Self::Unattended`] and [`Self::NeverAttended`],
+    /// `false` for [`Self::Attended`].
+    /// Test: `never_attended_counts_as_unattended`,
+    /// `threshold_boundary_is_unattended_at_exactly_the_threshold`.
+    pub fn is_unattended(self) -> bool {
+        !matches!(self, Self::Attended { .. })
+    }
+
+    /// Time since the last human turn, when there has been one.
+    ///
+    /// Test: `fresh_human_turn_is_attended`.
+    pub fn idle_for(self) -> Option<Duration> {
+        match self {
+            Self::Attended { idle_for } | Self::Unattended { idle_for } => Some(idle_for),
+            Self::NeverAttended => None,
+        }
+    }
+}
+
+/// The single tunable this module exposes (D3).
+///
+/// Why: D3 specifies "one tunable threshold". Keeping it a struct rather than a
+/// loose `Duration` argument means adding a second knob later does not change
+/// every [`AttendanceTracker`] construction site.
+/// What: one field. [`Default`] is [`DEFAULT_UNATTENDED_AFTER`] and reads no
+/// environment; [`Self::from_env`] is the only environment-reading
+/// constructor, so tests configure a tracker directly and never race on a
+/// process-global variable.
+/// Test: `default_threshold_is_fifteen_minutes`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AttendanceConfig {
+    /// Idle time at or beyond which an instance counts as unattended.
+    pub unattended_after: Duration,
+}
+
+impl Default for AttendanceConfig {
+    fn default() -> Self {
+        Self {
+            unattended_after: DEFAULT_UNATTENDED_AFTER,
+        }
+    }
+}
+
+impl AttendanceConfig {
+    /// The configuration with [`UNATTENDED_AFTER_ENV`] applied, if it is set.
+    ///
+    /// Why: an operator tuning the threshold must not have to edit a file the
+    /// app also writes.
+    /// What: delegates to [`parse_threshold_minutes`]; an unset, blank or
+    /// unparseable value leaves the default in place rather than failing —
+    /// a typo in an env var must not stop an assistant from running.
+    /// Test: `parse_threshold_accepts_whole_minutes`,
+    /// `parse_threshold_rejects_junk_and_zero`.
+    pub fn from_env() -> Self {
+        let raw = std::env::var(UNATTENDED_AFTER_ENV).ok();
+        Self {
+            unattended_after: parse_threshold_minutes(raw.as_deref())
+                .unwrap_or(DEFAULT_UNATTENDED_AFTER),
+        }
+    }
+}
+
+/// Parse an [`UNATTENDED_AFTER_ENV`] value into a threshold.
+///
+/// Why: a free function taking the raw value (rather than reading the variable
+/// itself) is what makes the parsing rules testable without mutating
+/// process-global state — the exact race that makes
+/// `assistants::tests::home_tests::for_instance_validates_the_id` flaky
+/// (#4611).
+/// What: `Some(duration)` for a positive whole number of minutes; `None` for
+/// absent, blank, non-numeric, negative or zero input. Zero is rejected rather
+/// than honoured because a zero threshold makes every instance permanently
+/// unattended, which is a footgun disguised as a setting.
+/// Test: `parse_threshold_accepts_whole_minutes`,
+/// `parse_threshold_rejects_junk_and_zero`.
+pub fn parse_threshold_minutes(raw: Option<&str>) -> Option<Duration> {
+    let mins: u64 = raw?.trim().parse().ok()?;
+    (mins > 0).then(|| Duration::from_secs(mins * 60))
+}

--- a/crates/trusty-agents/src/attendance/tests.rs
+++ b/crates/trusty-agents/src/attendance/tests.rs
@@ -346,6 +346,99 @@ fn note_human_turn_swallows_an_unusable_instance_name() {
     assert!(!root.exists(), "a rejected name created state anyway");
 }
 
+/// #4683 regression: the outcome the two `handle_command` gaps produced. A
+/// human who drives a chat bot with NOTHING but slash commands is present, so
+/// the instance must read attended — before the fix `handle_command` recorded
+/// nothing, and the same traffic aged past the threshold into `Unattended`.
+#[test]
+fn a_command_only_session_stays_attended() {
+    let (dir, recorded, instance) = tracker();
+    let root = attendance_root(dir.path());
+
+    // Four slash commands, five minutes apart — e.g. `/status` polled while a
+    // long task runs. Every one of them is a person typing.
+    for step in 0..4 {
+        note_command_turn_in(
+            Some(&root),
+            "izzie",
+            true,
+            t0() + chrono::Duration::minutes(5 * step),
+        );
+    }
+
+    // Twenty minutes after the FIRST command — well past the 15-minute
+    // threshold — but only five after the last one.
+    let now = t0() + chrono::Duration::minutes(20);
+    assert_eq!(
+        recorded.attendance(&instance, now).expect("query"),
+        Attendance::Attended {
+            idle_for: Duration::from_secs(5 * 60)
+        },
+        "slash commands are human turns; a command-only session is attended"
+    );
+
+    // The contrast that makes the assertion mean something: with the commands
+    // NOT recorded (the pre-fix behaviour), the same twenty minutes reads as
+    // never-attended, which `is_unattended` answers true to.
+    let (_dir2, silent, silent_instance) = tracker();
+    assert!(
+        silent.is_unattended(&silent_instance, now).expect("query"),
+        "the same window with no recorded turn is unattended"
+    );
+}
+
+/// #4683 regression for the monotonic guard. Two processes recording human
+/// turns for one instance interleave; the guard must be evaluated under the
+/// same held lock as the write, or a stale reader's older timestamp lands last
+/// and REWINDS the clock.
+///
+/// Fails against a read-then-write guard: the newest turn is written first and
+/// every later writer carries an older instant, so any writer that read before
+/// that write and published after it clobbers the newest value.
+#[test]
+fn concurrent_writers_never_rewind_the_clock() {
+    let dir = TempDir::new().expect("temp dir");
+    let root = attendance_root(dir.path());
+    let instance = AssistantInstanceId::new("izzie").expect("valid id");
+    let newest = t0() + chrono::Duration::hours(1);
+
+    let barrier = std::sync::Arc::new(std::sync::Barrier::new(8));
+    let mut handles = Vec::new();
+    for worker in 0..8 {
+        let root = root.clone();
+        let instance = instance.clone();
+        let barrier = std::sync::Arc::clone(&barrier);
+        handles.push(std::thread::spawn(move || {
+            let tracker = AttendanceTracker::new(root, AttendanceConfig::default());
+            barrier.wait();
+            for round in 0..25 {
+                // Worker 0 publishes the newest instant immediately; everyone
+                // else only ever offers strictly older ones, which the guard
+                // must reject for the rest of the run.
+                let at = if worker == 0 && round == 0 {
+                    newest
+                } else {
+                    t0() + chrono::Duration::seconds(worker * 25 + round)
+                };
+                tracker
+                    .record_turn(&instance, TurnOrigin::Human, at)
+                    .expect("record");
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().expect("worker panicked");
+    }
+
+    let tracker = AttendanceTracker::new(root, AttendanceConfig::default());
+    assert_eq!(
+        tracker.last_human_turn(&instance).expect("read"),
+        Some(newest),
+        "a concurrent older turn rewound the clock — the monotonic guard is not \
+         atomic with the write"
+    );
+}
+
 #[test]
 fn default_root_is_under_the_app_state_tree() {
     let root = default_attendance_root().expect("home dir");

--- a/crates/trusty-agents/src/attendance/tests.rs
+++ b/crates/trusty-agents/src/attendance/tests.rs
@@ -1,0 +1,357 @@
+//! Tests for unattended detection (#4652, epic #4646).
+//!
+//! Every test drives `now` explicitly and points the tracker at a temp
+//! directory, so none of them sleeps and none of them reads a process-global
+//! (the flakiness class of #4611).
+
+use std::time::Duration;
+
+use chrono::{TimeZone, Utc};
+use tempfile::TempDir;
+
+use super::*;
+use crate::assistants::AssistantInstanceId;
+
+/// A tracker over a fresh temp dir with the default threshold.
+fn tracker() -> (TempDir, AttendanceTracker, AssistantInstanceId) {
+    tracker_with(AttendanceConfig::default())
+}
+
+/// A tracker over a fresh temp dir with an explicit threshold.
+fn tracker_with(config: AttendanceConfig) -> (TempDir, AttendanceTracker, AssistantInstanceId) {
+    let dir = TempDir::new().expect("temp dir");
+    let tracker = AttendanceTracker::new(attendance_root(dir.path()), config);
+    let instance = AssistantInstanceId::new("izzie").expect("valid id");
+    (dir, tracker, instance)
+}
+
+/// A fixed base instant, so every assertion reads as an offset from one point.
+fn t0() -> chrono::DateTime<Utc> {
+    Utc.with_ymd_and_hms(2026, 8, 3, 12, 0, 0).unwrap()
+}
+
+#[test]
+fn default_threshold_is_fifteen_minutes() {
+    assert_eq!(DEFAULT_UNATTENDED_AFTER, Duration::from_secs(15 * 60));
+    assert_eq!(
+        AttendanceConfig::default().unattended_after,
+        DEFAULT_UNATTENDED_AFTER
+    );
+    let (_dir, tracker, _instance) = tracker();
+    assert_eq!(tracker.config().unattended_after, DEFAULT_UNATTENDED_AFTER);
+}
+
+#[test]
+fn fresh_human_turn_is_attended() {
+    let (_dir, tracker, instance) = tracker();
+
+    assert!(
+        tracker
+            .record_turn(&instance, TurnOrigin::Human, t0())
+            .expect("record"),
+        "a first human turn advances the clock"
+    );
+
+    assert_eq!(
+        tracker.last_human_turn(&instance).expect("read"),
+        Some(t0())
+    );
+
+    let now = t0() + chrono::Duration::minutes(1);
+    let attendance = tracker.attendance(&instance, now).expect("query");
+    assert_eq!(
+        attendance,
+        Attendance::Attended {
+            idle_for: Duration::from_secs(60)
+        }
+    );
+    assert!(!attendance.is_unattended());
+    assert_eq!(attendance.idle_for(), Some(Duration::from_secs(60)));
+    assert!(!tracker.is_unattended(&instance, now).expect("query"));
+}
+
+#[test]
+fn past_threshold_is_unattended() {
+    let (_dir, tracker, instance) = tracker();
+    tracker
+        .record_turn(&instance, TurnOrigin::Human, t0())
+        .expect("record");
+
+    let now = t0() + chrono::Duration::minutes(16);
+    let attendance = tracker.attendance(&instance, now).expect("query");
+    assert_eq!(
+        attendance,
+        Attendance::Unattended {
+            idle_for: Duration::from_secs(16 * 60)
+        }
+    );
+    assert!(tracker.is_unattended(&instance, now).expect("query"));
+}
+
+/// The distinction the whole issue turns on: the assistant working alone must
+/// never look like a human being present.
+#[test]
+fn assistant_turns_never_advance_the_clock() {
+    let (_dir, tracker, instance) = tracker();
+    tracker
+        .record_turn(&instance, TurnOrigin::Human, t0())
+        .expect("record");
+
+    // Sixty minutes of the assistant's own work: replies, tool calls, hooks.
+    // `last_activity_at` would advance on every one of these.
+    for minute in 1..=60 {
+        let advanced = tracker
+            .record_turn(
+                &instance,
+                TurnOrigin::Assistant,
+                t0() + chrono::Duration::minutes(minute),
+            )
+            .expect("record");
+        assert!(!advanced, "assistant turn at +{minute}m advanced the clock");
+    }
+
+    assert_eq!(
+        tracker.last_human_turn(&instance).expect("read"),
+        Some(t0()),
+        "the clock still points at the human's turn"
+    );
+    let now = t0() + chrono::Duration::minutes(60);
+    assert!(
+        tracker.is_unattended(&instance, now).expect("query"),
+        "an hour of assistant-only activity leaves the instance unattended"
+    );
+    assert!(!TurnOrigin::Assistant.is_human());
+    assert!(TurnOrigin::Human.is_human());
+}
+
+/// Stronger than "does not advance": assistant activity does not write at all,
+/// so an instance that has only ever worked alone has no attendance record.
+#[test]
+fn assistant_only_activity_leaves_no_record_at_all() {
+    let (_dir, tracker, instance) = tracker();
+
+    for minute in 0..30 {
+        tracker
+            .record_turn(
+                &instance,
+                TurnOrigin::Assistant,
+                t0() + chrono::Duration::minutes(minute),
+            )
+            .expect("record");
+    }
+
+    assert!(
+        !tracker.record_path(&instance).exists(),
+        "assistant activity created an attendance record"
+    );
+    assert_eq!(tracker.last_human_turn(&instance).expect("read"), None);
+    assert_eq!(
+        tracker.attendance(&instance, t0()).expect("query"),
+        Attendance::NeverAttended
+    );
+}
+
+#[test]
+fn threshold_boundary_is_unattended_at_exactly_the_threshold() {
+    let (_dir, tracker, instance) = tracker_with(AttendanceConfig {
+        unattended_after: Duration::from_secs(10 * 60),
+    });
+    tracker
+        .record_turn(&instance, TurnOrigin::Human, t0())
+        .expect("record");
+
+    let one_second_short = t0() + chrono::Duration::seconds(10 * 60 - 1);
+    assert!(
+        !tracker
+            .is_unattended(&instance, one_second_short)
+            .expect("query"),
+        "one second short of the threshold is still attended"
+    );
+
+    let exactly = t0() + chrono::Duration::seconds(10 * 60);
+    assert!(
+        tracker.is_unattended(&instance, exactly).expect("query"),
+        "the boundary is inclusive: N minutes of silence is unattended"
+    );
+}
+
+#[test]
+fn never_attended_counts_as_unattended() {
+    let (_dir, tracker, instance) = tracker();
+    let attendance = tracker.attendance(&instance, t0()).expect("query");
+    assert_eq!(attendance, Attendance::NeverAttended);
+    assert_eq!(attendance.idle_for(), None);
+    assert!(attendance.is_unattended());
+    assert!(tracker.is_unattended(&instance, t0()).expect("query"));
+}
+
+#[test]
+fn an_older_human_turn_never_rewinds_the_clock() {
+    let (_dir, tracker, instance) = tracker();
+    let latest = t0() + chrono::Duration::minutes(5);
+    tracker
+        .record_turn(&instance, TurnOrigin::Human, latest)
+        .expect("record");
+
+    assert!(
+        !tracker
+            .record_turn(&instance, TurnOrigin::Human, t0())
+            .expect("record"),
+        "an out-of-order turn must not be persisted"
+    );
+    assert_eq!(
+        tracker.last_human_turn(&instance).expect("read"),
+        Some(latest)
+    );
+}
+
+#[test]
+fn a_future_timestamp_reads_as_attended() {
+    let (_dir, tracker, instance) = tracker();
+    tracker
+        .record_turn(
+            &instance,
+            TurnOrigin::Human,
+            t0() + chrono::Duration::hours(1),
+        )
+        .expect("record");
+
+    let attendance = tracker.attendance(&instance, t0()).expect("query");
+    assert_eq!(
+        attendance,
+        Attendance::Attended {
+            idle_for: Duration::ZERO
+        },
+        "clock skew biases toward silence, not toward interrupting a human"
+    );
+}
+
+#[test]
+fn record_path_is_one_file_per_instance() {
+    let (dir, tracker, izzie) = tracker();
+    let cto = AssistantInstanceId::new("cto-assistant").expect("valid id");
+
+    assert_eq!(
+        tracker.record_path(&izzie),
+        attendance_root(dir.path()).join("izzie.json")
+    );
+    assert_ne!(tracker.record_path(&izzie), tracker.record_path(&cto));
+
+    tracker
+        .record_turn(&izzie, TurnOrigin::Human, t0())
+        .expect("record");
+    assert_eq!(
+        tracker.last_human_turn(&cto).expect("read"),
+        None,
+        "one instance's human turn must not attend another's"
+    );
+}
+
+#[test]
+fn unreadable_record_is_an_error_not_a_silent_never() {
+    let (_dir, tracker, instance) = tracker();
+    let path = tracker.record_path(&instance);
+    std::fs::create_dir_all(path.parent().expect("parent")).expect("mkdir");
+    std::fs::write(&path, b"{ not json").expect("write");
+
+    assert!(
+        tracker.last_human_turn(&instance).is_err(),
+        "corruption must surface, not read as never-attended"
+    );
+    assert!(tracker.attendance(&instance, t0()).is_err());
+}
+
+#[test]
+fn a_recorded_turn_survives_a_new_tracker() {
+    let dir = TempDir::new().expect("temp dir");
+    let instance = AssistantInstanceId::new("izzie").expect("valid id");
+    let config = AttendanceConfig::default();
+
+    AttendanceTracker::new(attendance_root(dir.path()), config)
+        .record_turn(&instance, TurnOrigin::Human, t0())
+        .expect("record");
+
+    // A different process would resolve the same root and read the same value:
+    // the signal is durable, so a restart cannot fabricate "nobody is here".
+    let reopened = AttendanceTracker::new(attendance_root(dir.path()), config);
+    assert_eq!(
+        reopened.last_human_turn(&instance).expect("read"),
+        Some(t0())
+    );
+    assert!(
+        !reopened
+            .is_unattended(&instance, t0() + chrono::Duration::minutes(1))
+            .expect("query")
+    );
+}
+
+#[test]
+fn parse_threshold_accepts_whole_minutes() {
+    assert_eq!(
+        parse_threshold_minutes(Some("5")),
+        Some(Duration::from_secs(300))
+    );
+    assert_eq!(
+        parse_threshold_minutes(Some("  45 ")),
+        Some(Duration::from_secs(45 * 60))
+    );
+}
+
+#[test]
+fn parse_threshold_rejects_junk_and_zero() {
+    for raw in [
+        None,
+        Some(""),
+        Some("   "),
+        Some("abc"),
+        Some("-3"),
+        Some("1.5"),
+    ] {
+        assert_eq!(parse_threshold_minutes(raw), None, "accepted {raw:?}");
+    }
+    assert_eq!(
+        parse_threshold_minutes(Some("0")),
+        None,
+        "a zero threshold would make every instance permanently unattended"
+    );
+}
+
+/// The one-line hook the four human-facing surfaces call.
+#[test]
+fn note_human_turn_records_a_turn_and_is_infallible() {
+    let (dir, tracker, instance) = tracker();
+    let root = attendance_root(dir.path());
+
+    assert!(note_human_turn_in(&root, "izzie", t0()));
+    assert_eq!(
+        tracker.last_human_turn(&instance).expect("read"),
+        Some(t0())
+    );
+
+    // Re-recording the same instant is not an advance, and is still not an error.
+    assert!(!note_human_turn_in(&root, "izzie", t0()));
+}
+
+#[test]
+fn note_human_turn_swallows_an_unusable_instance_name() {
+    let dir = TempDir::new().expect("temp dir");
+    let root = attendance_root(dir.path());
+
+    for bad in ["../escape", "", "Izzie", "a/b"] {
+        assert!(
+            !note_human_turn_in(&root, bad, t0()),
+            "`{bad}` must not record, and must not panic a live turn"
+        );
+    }
+    assert!(!root.exists(), "a rejected name created state anyway");
+}
+
+#[test]
+fn default_root_is_under_the_app_state_tree() {
+    let root = default_attendance_root().expect("home dir");
+    assert!(root.ends_with("attendance"));
+    assert!(
+        root.parent().expect("parent").ends_with(".trusty-agents"),
+        "attendance is app-private machine state, not the user-browsable home"
+    );
+}

--- a/crates/trusty-agents/src/attendance/tracker.rs
+++ b/crates/trusty-agents/src/attendance/tracker.rs
@@ -1,0 +1,288 @@
+//! Durable last-human-turn state, and the attended/unattended query (#4652).
+//!
+//! Why: see the module doc on [`super`] for why this signal is new work. This
+//! file holds the half that touches disk, kept apart from the vocabulary
+//! ([`TurnOrigin`], [`Attendance`], [`AttendanceConfig`]) so the types a caller
+//! reasons about are readable without the I/O.
+//! What: [`AttendanceTracker`] over a directory of one JSON record per
+//! instance. Writes go through [`crate::state_writer::atomic_write`], so a GUI,
+//! an `--api` sidecar and a REPL sharing `~/.trusty-agents/` cannot tear each
+//! other's records.
+//! Test: `super::tests` — the whole module.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+use super::{Attendance, AttendanceConfig, TurnOrigin};
+use crate::assistants::AssistantInstanceId;
+use crate::state_writer;
+
+/// Directory name holding one attendance record per instance.
+const ATTENDANCE_DIR: &str = "attendance";
+
+/// The attendance directory under an explicit app-state root.
+///
+/// Why: the injectable form. Tests point it at a temp dir and never touch
+/// `$HOME`, so nothing here can race a concurrently-running test on a
+/// process-global (#4611).
+/// What: `<base>/attendance`. Touches no filesystem.
+/// Test: `default_root_is_under_the_app_state_tree`.
+pub fn attendance_root(base: impl AsRef<Path>) -> PathBuf {
+    base.as_ref().join(ATTENDANCE_DIR)
+}
+
+/// The attendance directory under `~/.trusty-agents`.
+///
+/// Why: one definition, so a writer and a reader in different processes cannot
+/// disagree about where the signal lives.
+/// What: `~/.trusty-agents/attendance`. The DOTTED, app-private tree — this is
+/// machine state, not the user-browsable `~/trusty-agents/<instance>/` home
+/// that `assistants::home` deliberately hands to the user.
+/// Test: `default_root_is_under_the_app_state_tree`.
+pub fn default_attendance_root() -> Result<PathBuf> {
+    let home = dirs::home_dir().context("no home directory; cannot locate attendance state")?;
+    Ok(attendance_root(home.join(".trusty-agents")))
+}
+
+/// One instance's persisted last-human-turn timestamp.
+///
+/// What: `instance` is carried for legibility when a human opens the file;
+/// `last_human_turn_at` is the value. Unknown keys are ignored so a later
+/// field addition cannot make an existing record unreadable.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AttendanceRecord {
+    /// The instance this record belongs to.
+    instance: String,
+    /// RFC3339 instant of the most recent [`TurnOrigin::Human`] turn.
+    last_human_turn_at: DateTime<Utc>,
+}
+
+/// Records human turns and answers whether an instance is unattended (D3).
+///
+/// Why: the consumable seam #4652 owes B2 (#4653). Holding the threshold on the
+/// tracker (rather than passing it per query) means every caller in a process
+/// answers the question the same way.
+/// What: a root directory plus one [`AttendanceConfig`]. Construction touches
+/// no filesystem; the directory is created lazily on the first recorded human
+/// turn, so an instance nobody has ever spoken to leaves no trace on disk.
+///
+/// `now` is a PARAMETER on every query rather than read from the system clock
+/// inside, which is what lets the tests drive the threshold boundary exactly
+/// instead of sleeping.
+/// Test: `super::tests` — the whole module.
+#[derive(Debug, Clone)]
+pub struct AttendanceTracker {
+    root: PathBuf,
+    config: AttendanceConfig,
+}
+
+impl AttendanceTracker {
+    /// A tracker over an explicit attendance directory.
+    ///
+    /// Test: `fresh_human_turn_is_attended`.
+    pub fn new(root: impl Into<PathBuf>, config: AttendanceConfig) -> Self {
+        Self {
+            root: root.into(),
+            config,
+        }
+    }
+
+    /// A tracker over [`default_attendance_root`].
+    ///
+    /// Test: `default_root_is_under_the_app_state_tree`.
+    pub fn with_default_root(config: AttendanceConfig) -> Result<Self> {
+        Ok(Self::new(default_attendance_root()?, config))
+    }
+
+    /// The threshold this tracker applies. Test: `default_threshold_is_fifteen_minutes`.
+    pub fn config(&self) -> AttendanceConfig {
+        self.config
+    }
+
+    /// Where `instance`'s record lives.
+    ///
+    /// Why: exposed so an operator-facing diagnostic can name the file. Safe as
+    /// a path segment because [`AssistantInstanceId`] is validated at
+    /// construction — it cannot contain a separator, `.` or `..`.
+    /// Test: `record_path_is_one_file_per_instance`.
+    pub fn record_path(&self, instance: &AssistantInstanceId) -> PathBuf {
+        self.root.join(format!("{instance}.json"))
+    }
+
+    /// Record a turn, advancing the last-human-turn clock only if it was a
+    /// human's (#4652).
+    ///
+    /// Why: THE distinction the whole issue turns on. `last_activity_at` is
+    /// unusable precisely because every write to it looks alike; here the
+    /// origin is an explicit argument, so a call site that hands over the
+    /// assistant's own work cannot silently manufacture attendance. Making the
+    /// [`TurnOrigin::Assistant`] case a no-op rather than an error means the
+    /// safe choice is also the easy one for an unsure caller.
+    /// What: for [`TurnOrigin::Human`], persists `at` and returns `Ok(true)` —
+    /// unless the stored timestamp is already at or after `at`, in which case
+    /// nothing is written and it returns `Ok(false)`. That monotonic guard
+    /// stops an out-of-order or replayed turn from REWINDING attendance, which
+    /// would make an absent owner look present. For [`TurnOrigin::Assistant`]
+    /// it touches no file and returns `Ok(false)`.
+    ///
+    /// Errors are I/O only. A caller should log and continue: failing to record
+    /// attendance degrades the signal (the instance looks less attended than it
+    /// is, which biases toward silence), it does not break the turn.
+    /// Test: `fresh_human_turn_is_attended`,
+    /// `assistant_turns_never_advance_the_clock`,
+    /// `assistant_only_activity_leaves_no_record_at_all`,
+    /// `an_older_human_turn_never_rewinds_the_clock`.
+    pub fn record_turn(
+        &self,
+        instance: &AssistantInstanceId,
+        origin: TurnOrigin,
+        at: DateTime<Utc>,
+    ) -> Result<bool> {
+        if !origin.is_human() {
+            return Ok(false);
+        }
+        if self
+            .last_human_turn(instance)?
+            .is_some_and(|stored| stored >= at)
+        {
+            return Ok(false);
+        }
+        let record = AttendanceRecord {
+            instance: instance.as_str().to_string(),
+            last_human_turn_at: at,
+        };
+        let body = serde_json::to_vec_pretty(&record).context("serializing attendance record")?;
+        let path = self.record_path(instance);
+        state_writer::atomic_write(&path, &body)
+            .with_context(|| format!("writing attendance record {}", path.display()))?;
+        Ok(true)
+    }
+
+    /// When a human last addressed `instance`, if ever.
+    ///
+    /// Why: the raw value, for callers that want to render "last seen 4 minutes
+    /// ago" rather than a verdict.
+    /// What: `Ok(None)` when no record exists — an instance nobody has spoken
+    /// to is a normal state, not a fault. A record that exists but cannot be
+    /// read or parsed IS an error: silently treating corruption as "never
+    /// attended" would hand B2 a licence to notify on a bad file.
+    /// Test: `fresh_human_turn_is_attended`,
+    /// `unreadable_record_is_an_error_not_a_silent_never`.
+    pub fn last_human_turn(&self, instance: &AssistantInstanceId) -> Result<Option<DateTime<Utc>>> {
+        let path = self.record_path(instance);
+        if !path.exists() {
+            return Ok(None);
+        }
+        let raw = std::fs::read_to_string(&path)
+            .with_context(|| format!("reading attendance record {}", path.display()))?;
+        let record: AttendanceRecord = serde_json::from_str(&raw)
+            .with_context(|| format!("attendance record {} is not valid JSON", path.display()))?;
+        Ok(Some(record.last_human_turn_at))
+    }
+
+    /// Whether a human is attending `instance` as of `now`.
+    ///
+    /// Why: the query D3 asks for, with the threshold comparison in ONE place.
+    /// What: [`Attendance::NeverAttended`] with no record;
+    /// [`Attendance::Unattended`] when `now - last >= unattended_after`;
+    /// [`Attendance::Attended`] otherwise. The boundary is inclusive on the
+    /// unattended side so a threshold of N minutes means "N minutes of silence
+    /// is enough", which is how an operator reads the setting.
+    ///
+    /// A stored timestamp in the FUTURE (clock skew, an edited file) yields an
+    /// idle time of zero — i.e. attended. Biasing skew toward silence is the
+    /// safe direction: the cost of a missed notification is a delay, the cost
+    /// of a wrong one is interrupting a human who is present.
+    /// Test: `fresh_human_turn_is_attended`, `past_threshold_is_unattended`,
+    /// `threshold_boundary_is_unattended_at_exactly_the_threshold`,
+    /// `never_attended_counts_as_unattended`,
+    /// `a_future_timestamp_reads_as_attended`.
+    pub fn attendance(
+        &self,
+        instance: &AssistantInstanceId,
+        now: DateTime<Utc>,
+    ) -> Result<Attendance> {
+        let Some(last) = self.last_human_turn(instance)? else {
+            return Ok(Attendance::NeverAttended);
+        };
+        let idle_for = (now - last).to_std().unwrap_or(Duration::ZERO);
+        Ok(if idle_for >= self.config.unattended_after {
+            Attendance::Unattended { idle_for }
+        } else {
+            Attendance::Attended { idle_for }
+        })
+    }
+
+    /// The one-line form of [`Self::attendance`] for callers that only gate.
+    ///
+    /// Test: `past_threshold_is_unattended`, `never_attended_counts_as_unattended`.
+    pub fn is_unattended(
+        &self,
+        instance: &AssistantInstanceId,
+        now: DateTime<Utc>,
+    ) -> Result<bool> {
+        Ok(self.attendance(instance, now)?.is_unattended())
+    }
+}
+
+/// Record that a human just addressed `instance`, best-effort (#4652).
+///
+/// Why: the four surfaces a person can actually talk to an assistant through
+/// (`POST /api/task`, the REPL, Telegram, Slack) each hold a persona NAME and a
+/// message they know came from a human — and nothing else. Handing them one
+/// infallible call, rather than a tracker to build and a `Result` to handle,
+/// is what makes the hook a single line at each site and keeps the
+/// human-vs-assistant judgement where the evidence is. It is also why this
+/// function exists at all instead of the handlers calling
+/// [`AttendanceTracker::record_turn`]: an assistant-side caller has no
+/// `TurnOrigin` argument here to get wrong.
+/// What: validates the name, resolves [`default_attendance_root`], and records
+/// a [`TurnOrigin::Human`] turn at `now`. Returns whether the clock advanced.
+/// Every failure — an unusable name, no home directory, an I/O error — is
+/// logged at debug and swallowed: attendance is a hint for #4653, never a
+/// reason to fail a turn the user is waiting on. A swallowed failure biases the
+/// instance toward looking LESS attended, i.e. toward B2 staying quiet.
+/// Test: `note_human_turn_records_a_turn_and_is_infallible`,
+/// `note_human_turn_swallows_an_unusable_instance_name`.
+pub fn note_human_turn_in(root: impl Into<PathBuf>, instance: &str, now: DateTime<Utc>) -> bool {
+    match record_human(root, instance, now) {
+        Ok(advanced) => advanced,
+        Err(error) => {
+            tracing::debug!(instance, %error, "could not record human turn for attendance");
+            false
+        }
+    }
+}
+
+/// [`note_human_turn_in`] over [`default_attendance_root`] and the system
+/// clock — the form the four human-facing call sites use.
+///
+/// The root and `now` are injectable one layer down (rather than sandboxed via
+/// `$HOME`) for the reason `test_env` states outright: injection is the durable
+/// fix, `HOME_LOCK` is the legacy one. So every test drives
+/// [`note_human_turn_in`] against a temp directory and this wrapper stays a
+/// two-line delegation with nothing of its own to get wrong.
+/// Test: covered through `note_human_turn_in`; the root resolution it adds is
+/// pinned by `default_root_is_under_the_app_state_tree`.
+pub fn note_human_turn(instance: &str) -> bool {
+    let Ok(root) = default_attendance_root() else {
+        tracing::debug!(instance, "no home directory; not recording human turn");
+        return false;
+    };
+    note_human_turn_in(root, instance, Utc::now())
+}
+
+/// The fallible body of [`note_human_turn_in`], split out so the error can be
+/// logged in one place.
+fn record_human(root: impl Into<PathBuf>, instance: &str, now: DateTime<Utc>) -> Result<bool> {
+    let id = AssistantInstanceId::new(instance)?;
+    AttendanceTracker::new(root, AttendanceConfig::default()).record_turn(
+        &id,
+        TurnOrigin::Human,
+        now,
+    )
+}

--- a/crates/trusty-agents/src/attendance/tracker.rs
+++ b/crates/trusty-agents/src/attendance/tracker.rs
@@ -129,13 +129,20 @@ impl AttendanceTracker {
     /// would make an absent owner look present. For [`TurnOrigin::Assistant`]
     /// it touches no file and returns `Ok(false)`.
     ///
+    /// The compare and the write happen under ONE held lock
+    /// ([`state_writer::atomic_update`], #4683). Reading the stored value
+    /// outside the lock and writing after would let two processes both observe
+    /// the old timestamp and let the loser's older write land last — silently
+    /// rewinding the clock the guard exists to protect.
+    ///
     /// Errors are I/O only. A caller should log and continue: failing to record
     /// attendance degrades the signal (the instance looks less attended than it
     /// is, which biases toward silence), it does not break the turn.
     /// Test: `fresh_human_turn_is_attended`,
     /// `assistant_turns_never_advance_the_clock`,
     /// `assistant_only_activity_leaves_no_record_at_all`,
-    /// `an_older_human_turn_never_rewinds_the_clock`.
+    /// `an_older_human_turn_never_rewinds_the_clock`,
+    /// `concurrent_writers_never_rewind_the_clock`.
     pub fn record_turn(
         &self,
         instance: &AssistantInstanceId,
@@ -145,21 +152,25 @@ impl AttendanceTracker {
         if !origin.is_human() {
             return Ok(false);
         }
-        if self
-            .last_human_turn(instance)?
-            .is_some_and(|stored| stored >= at)
-        {
-            return Ok(false);
-        }
-        let record = AttendanceRecord {
-            instance: instance.as_str().to_string(),
-            last_human_turn_at: at,
-        };
-        let body = serde_json::to_vec_pretty(&record).context("serializing attendance record")?;
         let path = self.record_path(instance);
-        state_writer::atomic_write(&path, &body)
-            .with_context(|| format!("writing attendance record {}", path.display()))?;
-        Ok(true)
+        state_writer::atomic_update(&path, |existing| {
+            if let Some(raw) = existing {
+                let stored: AttendanceRecord = serde_json::from_slice(raw).with_context(|| {
+                    format!("attendance record {} is not valid JSON", path.display())
+                })?;
+                if stored.last_human_turn_at >= at {
+                    return Ok(None);
+                }
+            }
+            let record = AttendanceRecord {
+                instance: instance.as_str().to_string(),
+                last_human_turn_at: at,
+            };
+            Ok(Some(
+                serde_json::to_vec_pretty(&record).context("serializing attendance record")?,
+            ))
+        })
+        .with_context(|| format!("writing attendance record {}", path.display()))
     }
 
     /// When a human last addressed `instance`, if ever.
@@ -274,6 +285,40 @@ pub fn note_human_turn(instance: &str) -> bool {
         return false;
     };
     note_human_turn_in(root, instance, Utc::now())
+}
+
+/// Record an inbound SLASH COMMAND as a human turn, but only from an
+/// authenticated sender (#4683).
+///
+/// Why: a paired human who drives a chat bot purely through slash commands —
+/// polling `/status` every few minutes while a long task runs, clearing
+/// history, reconnecting a project — is demonstrably present, yet the first cut
+/// of this feature only hooked the free-text handler. That reads as unattended
+/// after the threshold while the owner is sitting right there, which is exactly
+/// the false positive #4652 exists to prevent. Both transports' `handle_command`
+/// route through this ONE helper rather than each re-deriving the gate, because
+/// the previous shape of this bug was two sibling dispatch functions drifting
+/// apart.
+/// What: records a [`TurnOrigin::Human`] turn for `instance` at `now` when
+/// `sender_is_paired`, and does nothing otherwise. The `authenticated` gate is
+/// not decoration: `/start` and `/pair` are reachable by ANY sender, so
+/// recording unconditionally would let an unpaired stranger manufacture
+/// attendance for someone else's assistant and mute their notifications. A
+/// `None` root (no home directory) is likewise a no-op. Returns whether the
+/// clock advanced; infallible, like [`note_human_turn_in`].
+/// Test: `a_command_only_session_stays_attended`,
+/// `paired_slash_command_records_a_human_turn`,
+/// `unpaired_slash_command_records_nothing`.
+pub fn note_command_turn_in(
+    root: Option<&Path>,
+    instance: &str,
+    sender_is_paired: bool,
+    now: DateTime<Utc>,
+) -> bool {
+    match (root, sender_is_paired) {
+        (Some(root), true) => note_human_turn_in(root, instance, now),
+        _ => false,
+    }
 }
 
 /// The fallible body of [`note_human_turn_in`], split out so the error can be

--- a/crates/trusty-agents/src/lib.rs
+++ b/crates/trusty-agents/src/lib.rs
@@ -72,6 +72,9 @@ pub mod api;
 // TYPE, `izzie`/`cto-assistant` are INSTANCES of it, each with its own home.
 pub mod assistants;
 pub mod ast;
+// #4652: last-human-turn timeout — the only signal that can tell a human
+// attending an instance from the assistant's own activity (owner decision D3).
+pub mod attendance;
 pub mod build_info;
 pub mod bus;
 pub mod cli;

--- a/crates/trusty-agents/src/repl/dispatch.rs
+++ b/crates/trusty-agents/src/repl/dispatch.rs
@@ -120,6 +120,11 @@ impl TrustyAgentsRepl {
     ///   (`run_pm_task_with_history`) so project tasks can still delegate
     ///   to sub-agents.
     pub(crate) async fn attempt_forward(&self, task_text: &str) -> Result<(String, TokenUsage)> {
+        // #4652: every path through this function starts with a line the user
+        // typed, so one call here covers all six dispatch arms below. Recorded
+        // against the persona the line was addressed to (none = `ctrl`).
+        crate::attendance::note_human_turn(self.active_persona.as_deref().unwrap_or("ctrl"));
+
         // #343: Thin-client mode — forward to the running daemon over HTTP
         // and bypass all in-process dispatch (persona, ctrl socket, PM).
         // Token usage isn't reported by the HTTP API today, so we return

--- a/crates/trusty-agents/src/slack/handlers.rs
+++ b/crates/trusty-agents/src/slack/handlers.rs
@@ -42,6 +42,41 @@ const SLACK_LISTENER_ID: &str = "slack";
 /// `listeners::poll::listener_event_summary` documents for Gmail.
 const SLACK_SNIPPET_MAX_CHARS: usize = 140;
 
+/// Record a Slack slash command as a human turn, behind the same two gates
+/// `handle_message` records behind (#4683).
+///
+/// Why: `handle_command` is the second of this transport's two inbound paths,
+/// and it recorded nothing — so a human polling `/slack-status` while a long
+/// task ran read as unattended after the threshold. The gate is composed here
+/// rather than inline because it is a SECURITY decision, not plumbing: pairing
+/// alone is a per-channel check, so an unknown Slack user posting in a paired
+/// channel could otherwise manufacture attendance for someone else's assistant
+/// and mute their notifications. `handle_message` already refuses to record for
+/// an unknown user (it returns the Virtual CTO reply before its own hook); this
+/// keeps the two paths agreeing.
+/// What: records for `persona` at `now` when the channel is paired AND the
+/// sender resolves to a known RBAC identity. Infallible; returns whether the
+/// clock advanced. Deliberately does NOT gate whether the command itself
+/// proceeds — an unknown user's `/slack-status` still answers, exactly as
+/// before.
+/// Test: `paired_slash_command_records_a_human_turn`,
+/// `unpaired_slash_command_records_nothing`,
+/// `unknown_rbac_user_cannot_manufacture_attendance`.
+pub(super) fn note_command_turn(
+    root: Option<&std::path::Path>,
+    persona: &str,
+    is_paired: bool,
+    sender_is_known_to_rbac: bool,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    crate::attendance::note_command_turn_in(
+        root,
+        persona,
+        is_paired && sender_is_known_to_rbac,
+        now,
+    )
+}
+
 /// Slash command dispatch.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_command(
@@ -59,18 +94,32 @@ pub(super) async fn handle_command(
     // Gate every command except /slack-start and /slack-pair behind the
     // pairing check. Unpaired channels get a uniform prompt.
     let is_unauthenticated = matches!(command.as_str(), "/slack-start" | "/slack-pair");
-    if !is_unauthenticated {
-        let is_paired = paired.read().await.contains_key(&channel);
-        if !is_paired {
-            return post_message(
-                bot_token,
-                &channel,
-                ":lock: Not paired. Send `/slack-start` to begin.",
-                None,
-            )
-            .await;
-        }
+    let is_paired = paired.read().await.contains_key(&channel);
+    if !is_unauthenticated && !is_paired {
+        return post_message(
+            bot_token,
+            &channel,
+            ":lock: Not paired. Send `/slack-start` to begin.",
+            None,
+        )
+        .await;
     }
+
+    // #4683: mirrors the Telegram fix — a paired human polling `/slack-status`
+    // is attending, but only `handle_message` recorded it.
+    let persona_for_attendance = {
+        let map = sessions.lock().await;
+        map.get(&channel)
+            .map(|s| s.active_persona.clone())
+            .unwrap_or_else(|| rbac.default_persona.clone())
+    };
+    note_command_turn(
+        crate::attendance::default_attendance_root().ok().as_deref(),
+        &persona_for_attendance,
+        is_paired,
+        rbac.user(&user_id).is_some(),
+        chrono::Utc::now(),
+    );
 
     match command.as_str() {
         "/slack-start" => {

--- a/crates/trusty-agents/src/slack/handlers.rs
+++ b/crates/trusty-agents/src/slack/handlers.rs
@@ -369,6 +369,10 @@ pub(super) async fn handle_message(
         },
     ));
 
+    // #4652: past the pairing and RBAC gates, this is a known human speaking —
+    // record it as attendance for the persona they addressed.
+    crate::attendance::note_human_turn(&active_persona);
+
     let result = ctrl::run_pm_task_with_persona(
         &path,
         &active_persona,

--- a/crates/trusty-agents/src/slack/tests.rs
+++ b/crates/trusty-agents/src/slack/tests.rs
@@ -290,6 +290,83 @@ fn default_rbac_users_includes_kartik_parity() {
 }
 
 // ---------------------------------------------------------------------------
+// #4683: `handle_command` — the dispatch path for `/slack-status`,
+// `/slack-switch`, `/slack-connect`, `/slack-clear` — recorded no attendance,
+// so a human polling `/slack-status` while a long task ran read as unattended
+// after the threshold. These pin the gate `handlers::note_command_turn` now
+// applies on that path.
+// ---------------------------------------------------------------------------
+
+/// A temp attendance root plus a fixed instant, so nothing here reads `$HOME`
+/// or the wall clock.
+fn attendance_fixture() -> (
+    tempfile::TempDir,
+    std::path::PathBuf,
+    chrono::DateTime<chrono::Utc>,
+) {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = crate::attendance::attendance_root(dir.path());
+    let now = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 8, 3, 12, 0, 0).unwrap();
+    (dir, root, now)
+}
+
+/// The last human turn recorded for `persona` under `root`.
+fn recorded_turn(root: &std::path::Path, persona: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    let tracker = crate::attendance::AttendanceTracker::new(
+        root,
+        crate::attendance::AttendanceConfig::default(),
+    );
+    let id = crate::assistants::AssistantInstanceId::new(persona).expect("valid id");
+    tracker.last_human_turn(&id).expect("read")
+}
+
+#[test]
+fn paired_slash_command_records_a_human_turn() {
+    let (_dir, root, now) = attendance_fixture();
+
+    assert!(
+        super::handlers::note_command_turn(Some(&root), "cto-assistant", true, true, now),
+        "a known user's slash command in a paired channel is a human turn"
+    );
+    assert_eq!(recorded_turn(&root, "cto-assistant"), Some(now));
+}
+
+#[test]
+fn unpaired_slash_command_records_nothing() {
+    let (_dir, root, now) = attendance_fixture();
+
+    assert!(!super::handlers::note_command_turn(
+        Some(&root),
+        "cto-assistant",
+        false,
+        true,
+        now
+    ));
+    assert_eq!(
+        recorded_turn(&root, "cto-assistant"),
+        None,
+        "an unpaired sender must not manufacture attendance"
+    );
+}
+
+/// Pairing is per-CHANNEL, so it alone is not proof of who typed. An unknown
+/// Slack user posting in a paired channel gets the Virtual CTO reply from
+/// `handle_message` and records nothing there; the command path must agree.
+#[test]
+fn unknown_rbac_user_cannot_manufacture_attendance() {
+    let (_dir, root, now) = attendance_fixture();
+
+    assert!(!super::handlers::note_command_turn(
+        Some(&root),
+        "cto-assistant",
+        true,
+        false,
+        now
+    ));
+    assert_eq!(recorded_turn(&root, "cto-assistant"), None);
+}
+
+// ---------------------------------------------------------------------------
 // #3852 hybrid architecture: `handlers::record_listener_event` mirrors
 // inbound Slack messages onto the harness eventstream. These tests exercise
 // it directly against a temp `$HOME` (same `HOME_LOCK` pattern as

--- a/crates/trusty-agents/src/state_writer.rs
+++ b/crates/trusty-agents/src/state_writer.rs
@@ -8,15 +8,17 @@
 //! already use `fs4` advisory locks for the code memory store
 //! (`memory::code_store`); this module extends the same pattern to all
 //! state files (sessions, skill index, interaction log, perf, processes).
-//! What: Two helpers — `atomic_write` (lock + tmp + rename, suitable for whole
-//! files like `skill_index.json`) and `atomic_append_line` (lock + append,
-//! suitable for NDJSON logs). Both use a sibling `<path>.lock` file as the
-//! advisory-lock target so the data file itself is never opened just to take
-//! a lock; this avoids the "open exclusively-locked-by-other-process file"
-//! failure mode on Windows and keeps the lock semantics symmetric across
-//! readers/writers.
+//! What: Three helpers — `atomic_write` (lock + tmp + rename, suitable for
+//! whole files like `skill_index.json`), `atomic_update` (lock + read + decide
+//! + write, for a state file whose new value DEPENDS on its old one), and
+//! `atomic_append_line` (lock + append, suitable for NDJSON logs). All three
+//! use a sibling `<path>.lock` file as the advisory-lock target so the data
+//! file itself is never opened just to take a lock; this avoids the "open
+//! exclusively-locked-by-other-process file" failure mode on Windows and keeps
+//! the lock semantics symmetric across readers/writers.
 //! Test: `atomic_write_is_crash_safe`, `concurrent_writes_no_corruption`,
-//! `atomic_append_line_multiple_writers`.
+//! `atomic_append_line_multiple_writers`,
+//! `atomic_update_serializes_read_modify_write`.
 
 use std::fs::{File, OpenOptions};
 use std::io::Write;
@@ -82,34 +84,90 @@ pub fn atomic_write(path: &Path, contents: &[u8]) -> Result<()> {
     FileExt::lock(&lock_file).map_err(|e| anyhow!("acquiring exclusive write lock: {e}"))?;
 
     // Inner block so we always unlock even on early return.
-    let result = (|| -> Result<()> {
-        // Ensure the parent directory exists for the data file too (it's the
-        // same dir as the lock, but be explicit).
-        if let Some(parent) = path.parent() {
-            std::fs::create_dir_all(parent)
-                .with_context(|| format!("creating parent dir {}", parent.display()))?;
-        }
-        let tmp = {
-            let mut s = path.as_os_str().to_owned();
-            s.push(".tmp");
-            PathBuf::from(s)
+    let result = write_tmp_and_rename(path, contents);
+
+    let _ = FileExt::unlock(&lock_file);
+    result
+}
+
+/// The tmp-write + rename half of [`atomic_write`], with NO locking.
+///
+/// Why: [`atomic_update`] needs the same publish step while already holding the
+/// lock, and taking the lock twice would deadlock. Splitting it out is what
+/// lets both entry points share one definition of "publish these bytes".
+/// What: writes `contents` to `<path>.tmp`, fsyncs best-effort, renames onto
+/// `path`. The caller MUST hold the advisory lock.
+fn write_tmp_and_rename(path: &Path, contents: &[u8]) -> Result<()> {
+    // Ensure the parent directory exists for the data file too (it's the
+    // same dir as the lock, but be explicit).
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating parent dir {}", parent.display()))?;
+    }
+    let tmp = {
+        let mut s = path.as_os_str().to_owned();
+        s.push(".tmp");
+        PathBuf::from(s)
+    };
+    {
+        let mut f = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(&tmp)
+            .with_context(|| format!("opening tmp file {}", tmp.display()))?;
+        f.write_all(contents)
+            .with_context(|| format!("writing tmp file {}", tmp.display()))?;
+        // Best-effort fsync so the rename can't expose an empty file on
+        // crash; ignore platform errors.
+        let _ = f.sync_all();
+    }
+    std::fs::rename(&tmp, path)
+        .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
+    Ok(())
+}
+
+/// Read `path`, decide the new contents from the old, and write — all under a
+/// SINGLE held exclusive lock (#4683).
+///
+/// Why: [`atomic_write`] makes each individual write atomic, but a caller whose
+/// new value depends on the current one (a counter, a high-water mark, a
+/// monotonic timestamp) has to read first — and a read outside the lock is a
+/// lost update waiting to happen. Two processes can both read the old value,
+/// both decide they may write, and the later write clobbers the earlier one's
+/// effect. Holding the lock across read + decide + write closes that window,
+/// which is the only way a "never goes backwards" invariant can actually hold
+/// across the GUI / `--api` sidecar / REPL processes that share
+/// `~/.trusty-agents/`.
+/// What: acquires the exclusive lock on `<path>.lock`, reads `path` (`None`
+/// when it does not exist), hands the bytes to `update`, and publishes the
+/// returned bytes via tmp + rename. `update` returning `Ok(None)` means "leave
+/// the file alone" and the whole call is a no-op; the return value says whether
+/// a write happened. An `Err` from `update` propagates and writes nothing.
+///
+/// `update` runs with the lock HELD, so it must be short and must not itself
+/// call back into this module for the same path.
+/// Test: `atomic_update_serializes_read_modify_write`,
+/// `atomic_update_skips_the_write_when_the_closure_declines`.
+pub fn atomic_update<F>(path: &Path, update: F) -> Result<bool>
+where
+    F: FnOnce(Option<&[u8]>) -> Result<Option<Vec<u8>>>,
+{
+    let lock_file = open_lock_file(path)?;
+    FileExt::lock(&lock_file).map_err(|e| anyhow!("acquiring exclusive update lock: {e}"))?;
+
+    let result = (|| -> Result<bool> {
+        let existing = match std::fs::read(path) {
+            Ok(bytes) => Some(bytes),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => None,
+            Err(e) => {
+                return Err(e).with_context(|| format!("reading {} for update", path.display()));
+            }
         };
-        {
-            let mut f = OpenOptions::new()
-                .create(true)
-                .write(true)
-                .truncate(true)
-                .open(&tmp)
-                .with_context(|| format!("opening tmp file {}", tmp.display()))?;
-            f.write_all(contents)
-                .with_context(|| format!("writing tmp file {}", tmp.display()))?;
-            // Best-effort fsync so the rename can't expose an empty file on
-            // crash; ignore platform errors.
-            let _ = f.sync_all();
+        match update(existing.as_deref())? {
+            Some(contents) => write_tmp_and_rename(path, &contents).map(|()| true),
+            None => Ok(false),
         }
-        std::fs::rename(&tmp, path)
-            .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))?;
-        Ok(())
     })();
 
     let _ = FileExt::unlock(&lock_file);
@@ -259,6 +317,78 @@ mod tests {
             assert!(seen.insert((w, i)), "duplicate row ({w},{i})");
         }
         assert_eq!(seen.len(), 200);
+    }
+
+    /// Why: `atomic_update` exists to make a read-modify-write sequence safe
+    /// across concurrent writers (#4683). A lost update — two writers both
+    /// reading the same old value and both incrementing it — is exactly what
+    /// `atomic_write` plus a separate read cannot prevent. Counting to 400
+    /// from 8 threads is the cheapest way to detect one.
+    /// What: 8 threads × 50 increments of a counter stored in the file. With
+    /// the read held under the lock the final value must be exactly 400; a
+    /// lost update shows up as any smaller number.
+    #[test]
+    fn atomic_update_serializes_read_modify_write() {
+        let tmp = TempDir::new().unwrap();
+        let path = Arc::new(tmp.path().join("counter.txt"));
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let p = Arc::clone(&path);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..50 {
+                    atomic_update(&p, |existing| {
+                        let current: u64 = match existing {
+                            Some(bytes) => std::str::from_utf8(bytes)?.trim().parse()?,
+                            None => 0,
+                        };
+                        Ok(Some((current + 1).to_string().into_bytes()))
+                    })
+                    .unwrap();
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let final_value: u64 = std::fs::read_to_string(&*path)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        assert_eq!(
+            final_value, 400,
+            "lost update: increments were not serialized under the lock"
+        );
+    }
+
+    /// Why: "leave the file alone" has to be a first-class outcome — a
+    /// monotonic guard that rejects an out-of-order value must not rewrite the
+    /// file with what is already there, and must report that it did nothing.
+    /// What: an update returning `Ok(None)` leaves the existing bytes untouched
+    /// and returns `Ok(false)`; on a missing file it creates nothing.
+    #[test]
+    fn atomic_update_skips_the_write_when_the_closure_declines() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("state.json");
+
+        assert!(!atomic_update(&path, |_| Ok(None)).unwrap());
+        assert!(!path.exists(), "a declined update created the file anyway");
+
+        assert!(
+            atomic_update(&path, |existing| {
+                assert!(existing.is_none());
+                Ok(Some(b"first".to_vec()))
+            })
+            .unwrap()
+        );
+        assert!(
+            !atomic_update(&path, |existing| {
+                assert_eq!(existing, Some(&b"first"[..]));
+                Ok(None)
+            })
+            .unwrap()
+        );
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "first");
     }
 
     /// Why: An exclusive lock must NOT prevent the same process from later

--- a/crates/trusty-agents/src/telegram/handlers.rs
+++ b/crates/trusty-agents/src/telegram/handlers.rs
@@ -339,6 +339,9 @@ pub(super) async fn handle_message(
     // mirror that pattern here so Telegram and REPL agree on which agent
     // config wins by default.
     let persona_name = active_persona.as_deref().unwrap_or("ctrl");
+    // #4652: a paired Telegram chat message is a human turn — record it as
+    // attendance for the persona it addressed, before the multi-second LLM call.
+    crate::attendance::note_human_turn(persona_name);
     let result = ctrl::run_pm_task_with_persona(
         &path,
         persona_name,

--- a/crates/trusty-agents/src/telegram/handlers.rs
+++ b/crates/trusty-agents/src/telegram/handlers.rs
@@ -271,6 +271,33 @@ pub(super) async fn handle_command(
     Ok(())
 }
 
+/// Record a paired inbound message as a human turn, then report whether it is
+/// the `/switch` intercept (#4652).
+///
+/// Why: `/switch` returns early from [`handle_message`], so the attendance hook
+/// has to run BEFORE the routing decision. Wiring it after the intercept
+/// silently dropped every persona-switch turn — a paired human typing
+/// `/switch` is attending exactly as much as one typing a task, and dropping
+/// those turns biases an active chat toward looking unattended. Fusing the
+/// record and the decision into one call is what keeps the two from drifting
+/// apart again: there is no order left for a caller to get wrong.
+/// What: records a human turn for `persona` at `now` under `root` — always,
+/// and first — then returns `true` for a `/switch` command. A `None` root
+/// (no home directory) skips the record and still routes correctly.
+/// Test: `switch_command_still_records_a_human_turn`,
+/// `plain_message_records_a_human_turn_and_is_not_a_switch`.
+pub(super) fn note_turn_and_is_switch(
+    root: Option<&std::path::Path>,
+    persona: &str,
+    text: &str,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if let Some(root) = root {
+        crate::attendance::note_human_turn_in(root, persona, now);
+    }
+    text.starts_with("/switch")
+}
+
 /// Forward a plain-text message to ctrl and reply with the result.
 pub(super) async fn handle_message(
     bot: Bot,
@@ -295,12 +322,25 @@ pub(super) async fn handle_message(
         return Ok(());
     }
 
+    // #4652: record attendance BEFORE the `/switch` intercept below, which
+    // returns early. Hooking after it dropped every persona-switch turn.
+    let persona_for_attendance = {
+        let map = sessions.lock().await;
+        map.get(&chat_id).and_then(|s| s.active_persona.clone())
+    };
+    let is_switch = note_turn_and_is_switch(
+        crate::attendance::default_attendance_root().ok().as_deref(),
+        persona_for_attendance.as_deref().unwrap_or("ctrl"),
+        &text,
+        chrono::Utc::now(),
+    );
+
     // #457: Intercept `/switch <persona>` BEFORE ctrl dispatch. ctrl's
     // text path passes the message verbatim to the LLM — it has no slash
     // command awareness. We must handle persona switching ourselves and
     // store the choice on the session so subsequent turns route through
     // `run_pm_task_with_persona`.
-    if text.starts_with("/switch") {
+    if is_switch {
         return handle_switch(&bot, chat_id, &sessions, &project_path, &text).await;
     }
 
@@ -339,9 +379,6 @@ pub(super) async fn handle_message(
     // mirror that pattern here so Telegram and REPL agree on which agent
     // config wins by default.
     let persona_name = active_persona.as_deref().unwrap_or("ctrl");
-    // #4652: a paired Telegram chat message is a human turn — record it as
-    // attendance for the persona it addressed, before the multi-second LLM call.
-    crate::attendance::note_human_turn(persona_name);
     let result = ctrl::run_pm_task_with_persona(
         &path,
         persona_name,

--- a/crates/trusty-agents/src/telegram/handlers.rs
+++ b/crates/trusty-agents/src/telegram/handlers.rs
@@ -74,15 +74,28 @@ pub(super) async fn handle_command(
     // check. Unpaired chats get a uniform "send /start" prompt instead of
     // partial information about the bot.
     let is_unauthenticated_cmd = matches!(cmd, Command::Start | Command::Pair(_));
-    if !is_unauthenticated_cmd {
-        let is_paired = paired.read().await.contains_key(&chat_id);
-        if !is_paired {
-            bot.send_message(chat_id, "🔒 Not paired. Send /start to begin.")
-                .parse_mode(ParseMode::Html)
-                .await?;
-            return Ok(());
-        }
+    let is_paired = paired.read().await.contains_key(&chat_id);
+    if !is_unauthenticated_cmd && !is_paired {
+        bot.send_message(chat_id, "🔒 Not paired. Send /start to begin.")
+            .parse_mode(ParseMode::Html)
+            .await?;
+        return Ok(());
     }
+
+    // #4683: a paired human polling `/status` (or running any other slash
+    // command) is attending exactly as much as one typing a task. Only
+    // `handle_message` recorded attendance, so a command-only session read as
+    // unattended after the threshold while the owner was right there.
+    let persona_for_attendance = {
+        let map = sessions.lock().await;
+        map.get(&chat_id).and_then(|s| s.active_persona.clone())
+    };
+    crate::attendance::note_command_turn_in(
+        crate::attendance::default_attendance_root().ok().as_deref(),
+        persona_for_attendance.as_deref().unwrap_or("ctrl"),
+        is_paired,
+        chrono::Utc::now(),
+    );
 
     match cmd {
         Command::Start => {

--- a/crates/trusty-agents/src/telegram/tests.rs
+++ b/crates/trusty-agents/src/telegram/tests.rs
@@ -627,6 +627,58 @@ fn switch_command_still_records_a_human_turn() {
     );
 }
 
+/// #4683 regression: `handle_command` — the dispatch path for `/start`,
+/// `/pair`, `/help`, `/connect`, `/clear`, `/status` — recorded no attendance.
+/// A paired human polling `/status` every few minutes while a long task ran was
+/// invisible to the clock and read as unattended after fifteen minutes, which
+/// is the exact false positive this feature exists to prevent.
+#[test]
+fn paired_slash_command_records_a_human_turn() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = crate::attendance::attendance_root(dir.path());
+    let now = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 8, 3, 12, 0, 0).unwrap();
+
+    assert!(
+        crate::attendance::note_command_turn_in(Some(&root), "izzie", true, now),
+        "a paired chat's slash command is a human turn"
+    );
+
+    let tracker = crate::attendance::AttendanceTracker::new(
+        &root,
+        crate::attendance::AttendanceConfig::default(),
+    );
+    let id = crate::assistants::AssistantInstanceId::new("izzie").expect("valid id");
+    assert_eq!(tracker.last_human_turn(&id).expect("read"), Some(now));
+}
+
+/// `/start` and `/pair` are reachable by ANY chat, so the record has to stay
+/// behind the pairing gate — otherwise a stranger could attend someone else's
+/// assistant and mute their notifications.
+#[test]
+fn unpaired_slash_command_records_nothing() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = crate::attendance::attendance_root(dir.path());
+    let now = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 8, 3, 12, 0, 0).unwrap();
+
+    assert!(!crate::attendance::note_command_turn_in(
+        Some(&root),
+        "izzie",
+        false,
+        now
+    ));
+
+    let tracker = crate::attendance::AttendanceTracker::new(
+        &root,
+        crate::attendance::AttendanceConfig::default(),
+    );
+    let id = crate::assistants::AssistantInstanceId::new("izzie").expect("valid id");
+    assert_eq!(
+        tracker.last_human_turn(&id).expect("read"),
+        None,
+        "an unpaired sender must not manufacture attendance"
+    );
+}
+
 /// The ordinary path still records, and is not misread as a switch.
 #[test]
 fn plain_message_records_a_human_turn_and_is_not_a_switch() {

--- a/crates/trusty-agents/src/telegram/tests.rs
+++ b/crates/trusty-agents/src/telegram/tests.rs
@@ -595,3 +595,56 @@ fn project_persona_exists_rejects_unknown_name() {
     let project = tempdir_for_test();
     assert!(!super::project_persona_exists(&project, "nope"));
 }
+
+/// #4652 regression: the `/switch` intercept returns early from
+/// `handle_message`, so a persona switch used to be dropped from the
+/// last-human-turn clock. A paired human typing `/switch` is attending.
+#[test]
+fn switch_command_still_records_a_human_turn() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = crate::attendance::attendance_root(dir.path());
+    let now = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 8, 3, 12, 0, 0).unwrap();
+
+    assert!(
+        super::handlers::note_turn_and_is_switch(
+            Some(&root),
+            "izzie",
+            "/switch cto-assistant",
+            now
+        ),
+        "`/switch` must still route to the switch handler"
+    );
+
+    let tracker = crate::attendance::AttendanceTracker::new(
+        &root,
+        crate::attendance::AttendanceConfig::default(),
+    );
+    let id = crate::assistants::AssistantInstanceId::new("izzie").expect("valid id");
+    assert_eq!(
+        tracker.last_human_turn(&id).expect("read"),
+        Some(now),
+        "a human typing `/switch` is attending; the turn must be recorded"
+    );
+}
+
+/// The ordinary path still records, and is not misread as a switch.
+#[test]
+fn plain_message_records_a_human_turn_and_is_not_a_switch() {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = crate::attendance::attendance_root(dir.path());
+    let now = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 8, 3, 12, 0, 0).unwrap();
+
+    assert!(!super::handlers::note_turn_and_is_switch(
+        Some(&root),
+        "izzie",
+        "what is the status of #4652?",
+        now
+    ));
+
+    let tracker = crate::attendance::AttendanceTracker::new(
+        &root,
+        crate::attendance::AttendanceConfig::default(),
+    );
+    let id = crate::assistants::AssistantInstanceId::new("izzie").expect("valid id");
+    assert_eq!(tracker.last_human_turn(&id).expect("read"), Some(now));
+}


### PR DESCRIPTION
Closes #4652. Part of epic #4646 (unsolicited assistant-to-owner notifications), owner decision **D3**.

## What this delivers

Code can now answer "is a human currently attending this assistant instance?" Nothing could before.

The three signals that looked adaptable were each verified unusable, which is why this is new work:

- `SessionRecord.last_activity_at` (`crates/trusty-mpm/src/session_manager/record.rs:204`) advances on TOOL and HOOK activity — an assistant grinding through a long solo task advances it identically to a human typing.
- Telegram/Slack `focus` is a per-conversation routing `HashMap` with no lease and no heartbeat. It survives the human walking away unchanged.
- `crates/trusty-agents/src/api/server/events_sse.rs` tracks no connection count at all.

Per **D3** the mechanism is a **last-human-turn timeout with one tunable threshold** — explicitly not SSE connection counting, and not a manual do-not-disturb toggle.

## The crux: human turn vs. assistant activity

`TurnOrigin` is an explicit, exhaustive argument to `AttendanceTracker::record_turn`, and only `TurnOrigin::Human` advances the clock. Everything an instance produces on its own — replies, tool calls, tool results, hook fires, scheduled wakes — is `TurnOrigin::Assistant` and is a documented **no-op that writes nothing at all**. Passing `Assistant` is always safe, so a call site that is unsure has a correct default and cannot manufacture attendance.

That is what `last_activity_at` structurally cannot do, and it is what the two load-bearing tests pin:

- `assistant_turns_never_advance_the_clock` — 60 minutes of `Assistant` turns after one human turn; the clock still points at the human's turn and the instance is unattended.
- `assistant_only_activity_leaves_no_record_at_all` — an instance that has only ever worked alone has **no attendance record on disk**, so it reads `NeverAttended`.

## Threshold default: 15 minutes

`DEFAULT_UNATTENDED_AFTER = 15 min`, overridable with `TAGENT_UNATTENDED_AFTER_MINS` (whole minutes; blank, non-numeric, negative or zero input keeps the default rather than failing a boot — a zero threshold would make every instance permanently unattended, a footgun disguised as a setting).

**Why 15:** the threshold has to clear an ordinary interruption — reading a message, taking a call, refilling a coffee — because notifying a human who is about to look back at the screen is exactly the failure D3 exists to avoid. It also has to be short enough that a genuine walk-away is noticed inside one break rather than one workday. Fifteen minutes is the shortest span that comfortably clears the first without approaching the second, and it matches the idle convention users already expect from chat clients.

## Durability: durable, and that is correctness

State is **one small JSON record per instance** at `~/.trusty-agents/attendance/<instance>.json`, written through the existing `state_writer::atomic_write` (lock + tmp + rename), so a GUI, an `--api` sidecar and a REPL sharing that tree cannot tear each other's records.

The natural home was already durable, and durability here is not tidiness. An in-memory tracker would report a fresh process as never-attended — and never-attended counts as unattended — so restarting the API server while the owner was mid-conversation would hand #4653 a licence to notify a human who is demonstrably right there. `a_recorded_turn_survives_a_new_tracker` pins the restart case.

It lives in the **dotted, app-private** `~/.trusty-agents/` tree (alongside `sessions/`, `state/`), not the dotless user-browsable `~/trusty-agents/<instance>/` home that `assistants::home` deliberately hands to the user. This is machine state.

Recording is monotonic: an out-of-order or replayed turn never *rewinds* the clock, which would make an absent owner look present.

## Design decisions worth reviewing

- **`NeverAttended` counts as unattended.** The question is "is a human attending", and no evidence of a human is not evidence of a human. It is a distinct third state rather than a degenerate `Unattended` because a duration cannot express "never".
- **The threshold boundary is inclusive on the unattended side.** `idle >= threshold` is unattended, so "N minutes" reads the way an operator expects: N minutes of silence is enough.
- **A future timestamp (clock skew, an edited file) reads as attended.** Biasing skew toward silence is the safe direction — a missed notification costs a delay, a wrong one interrupts a human who is present.
- **A corrupt record is an error, not a silent `None`.** Treating corruption as never-attended would hand #4653 a licence to notify on a bad file.
- **`now` is a parameter on every query**, not a system-clock read. That is the injectable-clock seam this crate lacks, and it lets the boundary tests be exact instead of sleeping. Same reasoning for the injectable root (`attendance_root(base)`): `test_env` states outright that injection is the durable fix and `HOME_LOCK` is the legacy one, so no test here mutates `$HOME`.

## Wiring

The signal is fed at the four surfaces a person can actually address an assistant through, each recording the persona the message named (no selection = the `ctrl` concierge):

| Surface | Site |
|---|---|
| GUI / WebUI | `api/server/handlers.rs::submit_task` |
| REPL | `repl/dispatch.rs::attempt_forward` — one call covering all six dispatch arms |
| Telegram | `telegram/handlers.rs::handle_message`, past the pairing gate |
| Slack | `slack/handlers.rs::handle_message`, past the pairing and RBAC gates |

`run_pm_task_with_persona` was rejected as a single hook despite being the narrowest waist: delegation reaches it too, so hooking there would have counted an assistant's own delegated work as a human turn — the exact bug this issue exists to avoid.

The hook (`attendance::note_human_turn`) is **infallible by construction**: an unusable instance name, a missing home directory or an I/O error is logged at debug and swallowed. Attendance is a hint for #4653, never a reason to fail a turn a user is waiting on — and a swallowed failure biases the instance toward looking *less* attended, i.e. toward B2 staying quiet.

## Scope

Signal only. No `notify_owner` tool (#4653), no Telegram/Slack egress binding (#4654/#4655), no queueing (#4657). **`trusty-agents` gains no dependency on `trusty-mpm`** — the constraint documented at `crates/trusty-agents/src/tools/session_state/store.rs:1-12` holds; nothing here reaches into that crate.

## Gates

Crate-scoped, foreground, raw output in the PR thread. `cargo test -p trusty-agents --lib`: **3297 passed, 0 failed, 11 ignored** — including all 17 `attendance::tests::*`, verified by name in the output (the module is behind no feature flag, so no extra `--features` was needed). `cargo clippy -p trusty-agents --all-targets -- -D warnings`, `cargo fmt --check` and `bash scripts/check_line_cap.sh` all exit 0.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
