### PR TITLE
docs(specs): drop retired instruction-floor-guard.yml from DOC-62's gate list

### DIFF
--- a/docs/specs/DOC-62-style-modes-coding-delegation.md
+++ b/docs/specs/DOC-62-style-modes-coding-delegation.md
@@ -156,9 +156,8 @@ reviewer, or a human-operated review step. Gates in this repository include —
 non-exhaustively — the workflows in `.github/workflows/` (`ci.yml`,
 `line-cap.yml` (the 500-SLOC cap), `changelog-fragment.yml` (the per-PR
 changelog requirement), `sld-lint.yml`, `doc-numbers.yml`, `test-pointers.yml`,
-`token-drift.yml`, `instruction-floor-guard.yml`,
-`capabilities-drift.yml`, `version-parity.yml`, `cargo-audit.yml`,
-`generation-artifact-lint.yml`, `agent-assets.yml`), GitHub branch protection
+`token-drift.yml`, `capabilities-drift.yml`, `version-parity.yml`,
+`cargo-audit.yml`, `generation-artifact-lint.yml`, `agent-assets.yml`), GitHub branch protection
 and required reviews on `main`, and the trusty-review gate in the delivery
 chain (`CLAUDE.md:493`).
 


### PR DESCRIPTION
## Summary
- Follow-up to the HIGH review finding on #4677 (https://github.com/bobmatnyc/trusty-tools/pull/4677#issuecomment-5170606234): DOC-62's gate list (line 159) still cited `instruction-floor-guard.yml` as a live CI gate. That workflow was deleted by #4665 (framework-floor retirement), so it's a dead reference on a doc now marked Accepted.
- The fix was originally prepared and pushed to #4677's branch (`docs/4040-resolve-open-questions`), but that PR was squash-merged to main (commit 9210981) about 2 minutes after the review comment posted — before the fix landed. This PR carries the same fix forward against current `main`.
- The review's other two flagged citations (lines 163, 805 — the delivery-chain source) were checked directly against the file and are already correct: they point at `CLAUDE.md`, not the retired `.trusty-mpm/INSTRUCTIONS.md`. Commit 2e8a36be (#4676) fixed both, and that commit was already an ancestor of #4677's branch before the review ran. No changes needed there.
- Grepped both DOC-62 and DOC-63 for any other reference to the retired `.trusty-mpm/` override mechanism or the framework floor — none found.

## Test plan
- [x] `bash scripts/check_sld.sh` — passes (54 spec docs, 0 errors/warnings)
- [x] `bash scripts/check_doc_numbers.sh` — passes (96 docs, 0 violations)
- [x] Verified every `.github/workflows/*.yml` name remaining in the gate list still exists on disk
- [x] Verified `CLAUDE.md:493` and the `../../CLAUDE.md` relative link both resolve to the correct delivery-chain content

Docs-only change (rung 1 on the Rust Test Ladder) — no Cargo gates required.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools