### PR TITLE
feat(trusty-agents): origin-tagged attendance + REPL slash-command hook (#4685)

### DIFF
--- a/crates/trusty-agents/changelog.d/4685-origin-tagged-attendance.md
+++ b/crates/trusty-agents/changelog.d/4685-origin-tagged-attendance.md
@@ -54,6 +54,23 @@ Changed
   a human-origin contrast so it fails against an unhooked dispatcher rather than
   passing vacuously.
 
+  **`attempt_forward` honours the caller's origin too**, which closes a second,
+  independent forgery path found in review. Its doc comment claimed "every path
+  through this function starts with a line the user typed" and it recorded
+  `TurnOrigin::Human` unconditionally — but `try_handle_slash`'s `/run <file>`
+  arm reaches it with the contents of a FILE, and `tagent /run task.txt` arrives
+  there from argv through `predispatch`. A cron job invoking that forged a human
+  turn on every fire, through a recording call the dispatcher's own hook never
+  covered. `origin` now threads through `forward_task_to_channel` and
+  `attempt_forward` to every call site, so no intermediate re-asserts humanity on
+  a caller's behalf; the stale doc claim is corrected rather than left to
+  mislead. Pinned by `argv_run_command_with_assistant_origin_records_nothing`.
+
+  That call site also now records through the same injected attendance root as
+  the dispatcher instead of resolving `$HOME` directly — without which it is not
+  observable from a test at all, and a test asserting on it silently writes into
+  the developer's real `~/.trusty-agents`.
+
   The TUI's `ReplBridge::handle_input` records too, because it intercepts and
   returns from six commands (`/exit`, `/clear`, `/switch`, `/model`,
   `/provider`, `/update`) before `try_handle_slash` ever sees them — the same

--- a/crates/trusty-agents/changelog.d/4685-origin-tagged-attendance.md
+++ b/crates/trusty-agents/changelog.d/4685-origin-tagged-attendance.md
@@ -1,0 +1,62 @@
+Changed
+
+- **Attendance turn origin is now caller-declared, and REPL slash commands
+  record** (closes
+  [#4685](https://github.com/bobmatnyc/trusty-tools/issues/4685); owner
+  decision **origin-tagged**, 2026-08-03; part of epic
+  [#4646](https://github.com/bobmatnyc/trusty-tools/issues/4646)). Two halves,
+  and the first is what makes the second safe to ship.
+
+  **`TurnOrigin` moved from inside the helpers onto their signatures.**
+  `note_human_turn`, `note_human_turn_in` and `note_command_turn_in` each
+  hardcoded `TurnOrigin::Human` internally, so "automation cannot forge
+  presence" was a property of *which wrapper a caller happened to reach for* —
+  not a property at all, since a future automated caller picking the convenient
+  function forges presence silently and nothing objects. The helpers are now
+  `attendance::note_turn(instance, origin)`,
+  `note_turn_in(root, instance, origin, now)` and
+  `note_command_turn_in(root, instance, origin, paired, now)`; the names no
+  longer assert an origin the caller did not choose, and the compiler makes
+  every new call site name a variant. It is now impossible to record a human
+  turn without some call site naming `TurnOrigin::Human` in its own source, and
+  an automated caller naming `TurnOrigin::Assistant` records nothing even with
+  every transport gate open — pinned by
+  `an_assistant_origin_caller_records_nothing`. `note_command_turn_in`'s two
+  gates are deliberately independent: `paired` answers "is this sender entitled
+  to assert presence", `origin` answers "was this a person at all", and no
+  transport-level check can answer the second.
+
+- **REPL slash commands now record a human turn** — the last gap left by
+  [#4652](https://github.com/bobmatnyc/trusty-tools/issues/4652).
+  `repl::commands::dispatch::try_handle_slash` is a separate dispatch table
+  from `repl::dispatch::attempt_forward` (the only REPL site #4652 hooked), so
+  every recognized slash command — `/switch`, `/model`, `/provider`, `/status`,
+  `/help` — returned from it and never reached the hook. An owner polling
+  `/status` while a long task ran read as absent after fifteen minutes while
+  sitting right there. `try_handle_slash` takes an explicit `origin` and records
+  through it; pinned by `repl_slash_command_records_a_human_turn`, which drives
+  the real dispatcher against an injected attendance root rather than a helper
+  in isolation — the defect being fixed was precisely a dispatcher nobody had
+  wired, which a helper-only test would have passed throughout.
+
+  The REPL has no pairing or RBAC gate, and unlike Telegram and Slack there is
+  nothing to hang one on: there is no remote sender to authenticate, because the
+  process already runs under the operator's own uid. **`TurnOrigin` is the
+  REPL's gate**, and it is load-bearing rather than ceremonial —
+  `try_handle_slash` has non-human callers today.
+  `ctrl::repl::plain_cli::run_plain_cli` issues its own `/switch assistant` at
+  startup before reading a byte of stdin, and
+  `runtime::predispatch::handle_slash_passthrough` serves `tagent /status` from
+  argv, a surface documented for scripting; both now pass
+  `TurnOrigin::Assistant`. An unconditional hook would have made every REPL
+  launch — and every cron-driven `tagent /status` — forge attendance for an
+  absent owner. `an_automated_repl_slash_caller_records_nothing` pins that, with
+  a human-origin contrast so it fails against an unhooked dispatcher rather than
+  passing vacuously.
+
+  The TUI's `ReplBridge::handle_input` records too, because it intercepts and
+  returns from six commands (`/exit`, `/clear`, `/switch`, `/model`,
+  `/provider`, `/update`) before `try_handle_slash` ever sees them — the same
+  "two dispatch tables drift apart" shape this issue exists to fix. The hook
+  sits at the one point every submitted line passes through; the later
+  `try_handle_slash` call is idempotent under the existing monotonic guard.

--- a/crates/trusty-agents/src/api/server/handlers.rs
+++ b/crates/trusty-agents/src/api/server/handlers.rs
@@ -325,7 +325,10 @@ pub(super) async fn submit_task(
     // assistant's own tool calls. Record it as attendance for the instance the
     // human addressed (no roster selection = the `ctrl` concierge).
     // Infallible: a failure is logged and swallowed, never surfaced here.
-    crate::attendance::note_human_turn(agent_override(&req).as_deref().unwrap_or("ctrl"));
+    crate::attendance::note_turn(
+        agent_override(&req).as_deref().unwrap_or("ctrl"),
+        crate::attendance::TurnOrigin::Human,
+    );
 
     // #192 Phase B: announce the new session immediately on the event bus so
     // SSE subscribers (Sidebar task list, ChatView session bootstrap) update

--- a/crates/trusty-agents/src/attendance/mod.rs
+++ b/crates/trusty-agents/src/attendance/mod.rs
@@ -63,8 +63,8 @@ mod tracker;
 mod tests;
 
 pub use tracker::{
-    AttendanceTracker, attendance_root, default_attendance_root, note_command_turn_in,
-    note_human_turn, note_human_turn_in,
+    AttendanceTracker, attendance_root, default_attendance_root, note_command_turn_in, note_turn,
+    note_turn_in,
 };
 
 /// How long after the last human turn an instance counts as unattended.
@@ -103,11 +103,19 @@ pub const UNATTENDED_AFTER_ENV: &str = "TAGENT_UNATTENDED_AFTER_MINS";
 /// What: two variants, and deliberately only two. Anything that is not a human
 /// putting words in front of this assistant is [`Self::Assistant`]: the
 /// assistant's own replies, its tool calls and their results, hook fires,
-/// scheduled wakes, and event-listener-triggered turns. Passing
-/// [`Self::Assistant`] is always SAFE — it is a documented no-op, not an
-/// error — so a call site that is unsure has a correct default.
+/// scheduled wakes, event-listener-triggered turns, and program-issued
+/// commands. Passing [`Self::Assistant`] is always SAFE — it is a documented
+/// no-op, not an error — so a call site that is unsure has a correct default.
+///
+/// #4685 pushed this argument OUT to every recording helper
+/// ([`note_turn`], [`note_turn_in`], [`note_command_turn_in`]), which had each
+/// hardcoded [`Self::Human`] internally. That made the "automation cannot forge
+/// presence" property depend on which wrapper a caller happened to reach for
+/// rather than on the type system; now no human turn can be recorded without
+/// some call site naming [`Self::Human`] in its own source.
 /// Test: `assistant_turns_never_advance_the_clock`,
-/// `assistant_only_activity_leaves_no_record_at_all`.
+/// `assistant_only_activity_leaves_no_record_at_all`,
+/// `an_assistant_origin_caller_records_nothing`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TurnOrigin {
     /// A person addressed this assistant: a chat message they typed, a

--- a/crates/trusty-agents/src/attendance/tests.rs
+++ b/crates/trusty-agents/src/attendance/tests.rs
@@ -316,30 +316,30 @@ fn parse_threshold_rejects_junk_and_zero() {
     );
 }
 
-/// The one-line hook the four human-facing surfaces call.
+/// The one-line hook the human-facing surfaces call.
 #[test]
-fn note_human_turn_records_a_turn_and_is_infallible() {
+fn note_turn_records_a_turn_and_is_infallible() {
     let (dir, tracker, instance) = tracker();
     let root = attendance_root(dir.path());
 
-    assert!(note_human_turn_in(&root, "izzie", t0()));
+    assert!(note_turn_in(&root, "izzie", TurnOrigin::Human, t0()));
     assert_eq!(
         tracker.last_human_turn(&instance).expect("read"),
         Some(t0())
     );
 
     // Re-recording the same instant is not an advance, and is still not an error.
-    assert!(!note_human_turn_in(&root, "izzie", t0()));
+    assert!(!note_turn_in(&root, "izzie", TurnOrigin::Human, t0()));
 }
 
 #[test]
-fn note_human_turn_swallows_an_unusable_instance_name() {
+fn note_turn_swallows_an_unusable_instance_name() {
     let dir = TempDir::new().expect("temp dir");
     let root = attendance_root(dir.path());
 
     for bad in ["../escape", "", "Izzie", "a/b"] {
         assert!(
-            !note_human_turn_in(&root, bad, t0()),
+            !note_turn_in(&root, bad, TurnOrigin::Human, t0()),
             "`{bad}` must not record, and must not panic a live turn"
         );
     }
@@ -361,6 +361,7 @@ fn a_command_only_session_stays_attended() {
         note_command_turn_in(
             Some(&root),
             "izzie",
+            TurnOrigin::Human,
             true,
             t0() + chrono::Duration::minutes(5 * step),
         );
@@ -384,6 +385,62 @@ fn a_command_only_session_stays_attended() {
     assert!(
         silent.is_unattended(&silent_instance, now).expect("query"),
         "the same window with no recorded turn is unattended"
+    );
+}
+
+/// #4685: the property caller-declared origin buys. An automated caller
+/// reaching for the CONVENIENT command helper — the exact mistake the old
+/// `note_command_turn_in`, which hardcoded `TurnOrigin::Human` internally,
+/// could not prevent — must record nothing even with every transport gate
+/// satisfied.
+///
+/// The contrast in the second half is what makes the first half mean
+/// something: the same call with `TurnOrigin::Human` DOES record, so the
+/// assistant-origin no-op cannot be confused with a missing hook.
+#[test]
+fn an_assistant_origin_caller_records_nothing() {
+    let (dir, tracker, instance) = tracker();
+    let root = attendance_root(dir.path());
+
+    for step in 0..4 {
+        // Paired, authenticated, at a command path — every gate the transports
+        // have is open. Origin is the only thing standing in the way.
+        assert!(
+            !note_command_turn_in(
+                Some(&root),
+                "izzie",
+                TurnOrigin::Assistant,
+                true,
+                t0() + chrono::Duration::minutes(5 * step),
+            ),
+            "an assistant-origin command turn advanced the clock"
+        );
+    }
+    assert!(
+        !note_turn_in(&root, "izzie", TurnOrigin::Assistant, t0()),
+        "an assistant-origin turn advanced the clock"
+    );
+
+    assert!(
+        !tracker.record_path(&instance).exists(),
+        "automation forged an attendance record"
+    );
+    assert_eq!(
+        tracker
+            .attendance(&instance, t0() + chrono::Duration::minutes(20))
+            .expect("query"),
+        Attendance::NeverAttended,
+        "twenty minutes of automated commands must leave the owner absent"
+    );
+
+    // Same call, same gates, human origin — this one records.
+    assert!(
+        note_command_turn_in(Some(&root), "izzie", TurnOrigin::Human, true, t0()),
+        "the human-origin path must still record, or the test above proves nothing"
+    );
+    assert_eq!(
+        tracker.last_human_turn(&instance).expect("read"),
+        Some(t0())
     );
 }
 

--- a/crates/trusty-agents/src/attendance/tracker.rs
+++ b/crates/trusty-agents/src/attendance/tracker.rs
@@ -240,51 +240,66 @@ impl AttendanceTracker {
     }
 }
 
-/// Record that a human just addressed `instance`, best-effort (#4652).
+/// Record a turn of CALLER-DECLARED origin against `instance`, best-effort
+/// (#4652, origin made caller-declared in #4685).
 ///
-/// Why: the four surfaces a person can actually talk to an assistant through
-/// (`POST /api/task`, the REPL, Telegram, Slack) each hold a persona NAME and a
-/// message they know came from a human — and nothing else. Handing them one
-/// infallible call, rather than a tracker to build and a `Result` to handle,
-/// is what makes the hook a single line at each site and keeps the
-/// human-vs-assistant judgement where the evidence is. It is also why this
-/// function exists at all instead of the handlers calling
-/// [`AttendanceTracker::record_turn`]: an assistant-side caller has no
-/// `TurnOrigin` argument here to get wrong.
-/// What: validates the name, resolves [`default_attendance_root`], and records
-/// a [`TurnOrigin::Human`] turn at `now`. Returns whether the clock advanced.
-/// Every failure — an unusable name, no home directory, an I/O error — is
-/// logged at debug and swallowed: attendance is a hint for #4653, never a
-/// reason to fail a turn the user is waiting on. A swallowed failure biases the
-/// instance toward looking LESS attended, i.e. toward B2 staying quiet.
-/// Test: `note_human_turn_records_a_turn_and_is_infallible`,
-/// `note_human_turn_swallows_an_unusable_instance_name`.
-pub fn note_human_turn_in(root: impl Into<PathBuf>, instance: &str, now: DateTime<Utc>) -> bool {
-    match record_human(root, instance, now) {
+/// Why: the surfaces a turn can arrive through each hold a persona NAME and a
+/// line of input — and each one, and ONLY each one, knows who produced that
+/// line. Handing them one infallible call, rather than a tracker to build and a
+/// `Result` to handle, is what makes the hook a single line at each site.
+///
+/// `origin` is a required argument rather than a value this function supplies
+/// because the earlier shape — a `note_human_turn_in` that hardcoded
+/// [`TurnOrigin::Human`] internally — made "automation cannot forge presence" a
+/// property of WHICH WRAPPER a caller happened to reach for. That is not a
+/// property at all: a future automated caller picking the convenient function
+/// forges presence silently and nothing in the type system objects. With the
+/// origin on the signature, the compiler makes every new call site name a
+/// variant, and an automated one that names [`TurnOrigin::Assistant`] records
+/// nothing. The REPL proved this is not hypothetical — `run_plain_cli` issues
+/// its own `/switch assistant` at startup (#4685).
+/// What: for [`TurnOrigin::Human`], validates the name, and records at `now`,
+/// returning whether the clock advanced. For [`TurnOrigin::Assistant`] it
+/// touches nothing and returns `false`. Every failure — an unusable name, an
+/// I/O error — is logged at debug and swallowed: attendance is a hint for
+/// #4653, never a reason to fail a turn the user is waiting on. A swallowed
+/// failure biases the instance toward looking LESS attended, i.e. toward B2
+/// staying quiet.
+/// Test: `note_turn_records_a_turn_and_is_infallible`,
+/// `note_turn_swallows_an_unusable_instance_name`,
+/// `an_assistant_origin_caller_records_nothing`.
+pub fn note_turn_in(
+    root: impl Into<PathBuf>,
+    instance: &str,
+    origin: TurnOrigin,
+    now: DateTime<Utc>,
+) -> bool {
+    match record_turn_at(root, instance, origin, now) {
         Ok(advanced) => advanced,
         Err(error) => {
-            tracing::debug!(instance, %error, "could not record human turn for attendance");
+            tracing::debug!(instance, %error, "could not record turn for attendance");
             false
         }
     }
 }
 
-/// [`note_human_turn_in`] over [`default_attendance_root`] and the system
-/// clock — the form the four human-facing call sites use.
+/// [`note_turn_in`] over [`default_attendance_root`] and the system clock —
+/// the form the live call sites use.
 ///
 /// The root and `now` are injectable one layer down (rather than sandboxed via
 /// `$HOME`) for the reason `test_env` states outright: injection is the durable
-/// fix, `HOME_LOCK` is the legacy one. So every test drives
-/// [`note_human_turn_in`] against a temp directory and this wrapper stays a
-/// two-line delegation with nothing of its own to get wrong.
-/// Test: covered through `note_human_turn_in`; the root resolution it adds is
+/// fix, `HOME_LOCK` is the legacy one. So every test drives [`note_turn_in`]
+/// against a temp directory and this wrapper stays a two-line delegation with
+/// nothing of its own to get wrong. `origin` is threaded through rather than
+/// assumed here for the reason [`note_turn_in`] documents.
+/// Test: covered through [`note_turn_in`]; the root resolution it adds is
 /// pinned by `default_root_is_under_the_app_state_tree`.
-pub fn note_human_turn(instance: &str) -> bool {
+pub fn note_turn(instance: &str, origin: TurnOrigin) -> bool {
     let Ok(root) = default_attendance_root() else {
-        tracing::debug!(instance, "no home directory; not recording human turn");
+        tracing::debug!(instance, "no home directory; not recording turn");
         return false;
     };
-    note_human_turn_in(root, instance, Utc::now())
+    note_turn_in(root, instance, origin, Utc::now())
 }
 
 /// Record an inbound SLASH COMMAND as a human turn, but only from an
@@ -299,35 +314,43 @@ pub fn note_human_turn(instance: &str) -> bool {
 /// route through this ONE helper rather than each re-deriving the gate, because
 /// the previous shape of this bug was two sibling dispatch functions drifting
 /// apart.
-/// What: records a [`TurnOrigin::Human`] turn for `instance` at `now` when
-/// `sender_is_paired`, and does nothing otherwise. The `authenticated` gate is
-/// not decoration: `/start` and `/pair` are reachable by ANY sender, so
-/// recording unconditionally would let an unpaired stranger manufacture
-/// attendance for someone else's assistant and mute their notifications. A
-/// `None` root (no home directory) is likewise a no-op. Returns whether the
-/// clock advanced; infallible, like [`note_human_turn_in`].
+/// What: records a turn of the CALLER-DECLARED `origin` for `instance` at
+/// `now` when `sender_is_paired`, and does nothing otherwise. Both gates must
+/// hold, and neither substitutes for the other: `sender_is_paired` answers "is
+/// this sender entitled to assert presence" (`/start` and `/pair` are reachable
+/// by ANY sender, so recording unconditionally would let an unpaired stranger
+/// manufacture attendance for someone else's assistant and mute their
+/// notifications), while `origin` answers "was this a person at all" — the
+/// question no transport-level check can answer, and the one #4685 made the
+/// caller state. A `None` root (no home directory) is likewise a no-op. Returns
+/// whether the clock advanced; infallible, like [`note_turn_in`].
 /// Test: `a_command_only_session_stays_attended`,
 /// `paired_slash_command_records_a_human_turn`,
-/// `unpaired_slash_command_records_nothing`.
+/// `unpaired_slash_command_records_nothing`,
+/// `an_assistant_origin_caller_records_nothing`.
 pub fn note_command_turn_in(
     root: Option<&Path>,
     instance: &str,
+    origin: TurnOrigin,
     sender_is_paired: bool,
     now: DateTime<Utc>,
 ) -> bool {
     match (root, sender_is_paired) {
-        (Some(root), true) => note_human_turn_in(root, instance, now),
+        (Some(root), true) => note_turn_in(root, instance, origin, now),
         _ => false,
     }
 }
 
-/// The fallible body of [`note_human_turn_in`], split out so the error can be
-/// logged in one place.
-fn record_human(root: impl Into<PathBuf>, instance: &str, now: DateTime<Utc>) -> Result<bool> {
+/// The fallible body of [`note_turn_in`], split out so the error can be logged
+/// in one place. The origin is forwarded verbatim to
+/// [`AttendanceTracker::record_turn`], which is where a non-human origin
+/// becomes a no-op.
+fn record_turn_at(
+    root: impl Into<PathBuf>,
+    instance: &str,
+    origin: TurnOrigin,
+    now: DateTime<Utc>,
+) -> Result<bool> {
     let id = AssistantInstanceId::new(instance)?;
-    AttendanceTracker::new(root, AttendanceConfig::default()).record_turn(
-        &id,
-        TurnOrigin::Human,
-        now,
-    )
+    AttendanceTracker::new(root, AttendanceConfig::default()).record_turn(&id, origin, now)
 }

--- a/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
+++ b/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
@@ -68,7 +68,14 @@ pub async fn run_plain_cli() -> Result<()> {
     // matches exactly. Missing/broken `assistant/agent.toml` degrades
     // gracefully: the error is surfaced and the session stays on `ctrl`.
     match repl
-        .try_handle_slash(&format!("/switch {DEFAULT_PERSONA}"))
+        .try_handle_slash(
+            &format!("/switch {DEFAULT_PERSONA}"),
+            // #4685: THIS PROGRAM issued the command, not the operator — the
+            // REPL has not read a single byte of stdin yet. Recording it as
+            // human would make every launch forge attendance for an owner who
+            // may have started `tagent` over SSH and walked away.
+            crate::attendance::TurnOrigin::Assistant,
+        )
         .await
     {
         Some(Ok((_, output))) => {
@@ -143,7 +150,12 @@ pub async fn run_plain_cli() -> Result<()> {
             continue;
         }
 
-        match repl.try_handle_slash(trimmed).await {
+        // #4685: this line came off the interactive stdin prompt above, so a
+        // person typed it — the one call site in this file that can say so.
+        match repl
+            .try_handle_slash(trimmed, crate::attendance::TurnOrigin::Human)
+            .await
+        {
             Some(Ok((cont, output))) => {
                 if !output.is_empty() {
                     print!("{output}");

--- a/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
+++ b/crates/trusty-agents/src/ctrl/repl/plain_cli.rs
@@ -185,7 +185,12 @@ pub async fn run_plain_cli() -> Result<()> {
 /// context keeps flowing exactly like the TUI.
 async fn dispatch_free_text(repl: &mut crate::repl::TrustyAgentsRepl, trimmed: &str) {
     let start = std::time::Instant::now();
-    match repl.attempt_forward(trimmed).await {
+    // #4685: `trimmed` came off the interactive stdin prompt in
+    // `run_plain_cli`'s loop — the only caller — so a person typed it.
+    match repl
+        .attempt_forward(trimmed, crate::attendance::TurnOrigin::Human)
+        .await
+    {
         Ok((response, _usage)) => {
             let elapsed = start.elapsed();
             println!("{response}");

--- a/crates/trusty-agents/src/repl/bridge.rs
+++ b/crates/trusty-agents/src/repl/bridge.rs
@@ -55,6 +55,10 @@ impl tui::ReplHandler for ReplBridge {
                 repl.attendance_root.as_deref(),
                 repl.active_persona.as_deref().unwrap_or("ctrl"),
                 crate::attendance::TurnOrigin::Human,
+                // Deliberately `true`, mirroring `commands/dispatch.rs`: the
+                // "sender is entitled to assert presence" gate has no REPL
+                // analogue — the local operator owns this process — so the
+                // only question left is the one `origin` answers.
                 true,
                 chrono::Utc::now(),
             );
@@ -304,7 +308,8 @@ impl tui::ReplHandler for ReplBridge {
 
         // Forward to LLM.
         let mut repl = self.repl.lock().await;
-        repl.forward_task_to_channel(&line, tx.clone()).await?;
+        repl.forward_task_to_channel(&line, crate::attendance::TurnOrigin::Human, tx.clone())
+            .await?;
         let _ = tx.send(tui::ReplEvent::LabelChanged(repl.project_name.clone()));
         Ok(true)
     }

--- a/crates/trusty-agents/src/repl/bridge.rs
+++ b/crates/trusty-agents/src/repl/bridge.rs
@@ -37,10 +37,27 @@ impl tui::ReplHandler for ReplBridge {
     ) -> Result<bool> {
         let trimmed = line.trim();
 
-        // Persist to on-disk history before dispatch.
+        // Persist to on-disk history before dispatch, and record the turn.
+        //
+        // #4685: hooking `try_handle_slash` alone would miss six commands —
+        // `/exit`, `/clear`, `/switch`, `/model`, `/provider` (no-arg) and
+        // `/update` — which this method intercepts inline and returns from
+        // below. That is the same "two dispatch tables drift apart" shape
+        // #4685 exists to fix, so the hook goes at the ONE point every
+        // submitted line passes through. `handle_input` is called by the
+        // ratatui driver on a Submit keystroke, so this is a person typing by
+        // construction; the later `try_handle_slash` call is idempotent under
+        // the monotonic guard.
         {
             let repl = self.repl.lock().await;
             append_history_line(&repl.history_path, trimmed);
+            crate::attendance::note_command_turn_in(
+                repl.attendance_root.as_deref(),
+                repl.active_persona.as_deref().unwrap_or("ctrl"),
+                crate::attendance::TurnOrigin::Human,
+                true,
+                chrono::Utc::now(),
+            );
         }
 
         // Natural-language agent switching for short phrases.
@@ -228,7 +245,10 @@ impl tui::ReplHandler for ReplBridge {
             }
 
             let mut repl = self.repl.lock().await;
-            match repl.try_handle_slash(trimmed).await {
+            match repl
+                .try_handle_slash(trimmed, crate::attendance::TurnOrigin::Human)
+                .await
+            {
                 Some(Ok((cont, output))) => {
                     let trimmed_out = output.trim_end_matches('\n').to_string();
                     if !trimmed_out.is_empty() {

--- a/crates/trusty-agents/src/repl/commands/dispatch.rs
+++ b/crates/trusty-agents/src/repl/commands/dispatch.rs
@@ -26,15 +26,51 @@ impl TrustyAgentsRepl {
     ///   through `Some(Err(_))` for the caller to surface.
     /// Test: `try_handle_slash_*` unit tests verify return shape; tmux e2e
     ///   verifies `/help` renders cleanly inside ratatui.
+    ///
+    /// `origin` (#4685) declares who produced `input`, and is what makes this
+    /// dispatcher safe to hook for attendance. The REPL has no pairing or RBAC
+    /// gate — the transports' answer to "may this sender assert presence?" —
+    /// because there is no remote sender to authenticate: the process already
+    /// runs under the operator's own uid. What the REPL has instead is the
+    /// caller, and only the caller knows whether a line came from a terminal.
+    /// That distinction is load-bearing rather than ceremonial: this method has
+    /// non-human callers TODAY (`ctrl::repl::plain_cli::run_plain_cli` issues
+    /// its own `/switch assistant` at startup, and
+    /// `runtime::predispatch::handle_slash_passthrough` serves `tagent /status`
+    /// from argv, a surface documented for scripting), so an unconditional hook
+    /// would have made every REPL launch forge attendance for an absent owner.
+    ///
+    /// See [`crate::attendance::TurnOrigin`]; passing
+    /// [`crate::attendance::TurnOrigin::Assistant`] records nothing.
     // Why: Widened from `pub(crate)` to `pub` so the `trusty-agents` binary
     //      (now a separate crate consuming `trusty-agents` as a library) can
     //      invoke `repl.try_handle_slash(...)` from `main.rs`.
-    // What: Public async method; signature otherwise unchanged.
+    // What: Public async method.
     // Test: Existing slash-command unit tests + tmux e2e cover behaviour.
-    pub async fn try_handle_slash(&mut self, input: &str) -> Option<Result<(bool, String)>> {
+    pub async fn try_handle_slash(
+        &mut self,
+        input: &str,
+        origin: crate::attendance::TurnOrigin,
+    ) -> Option<Result<(bool, String)>> {
         if !input.starts_with('/') {
             return None;
         }
+
+        // #4685: closes the last gap left by #4652 — this dispatch table is
+        // separate from `repl::dispatch::attempt_forward`, so a recognized
+        // slash command returned here and never reached that hook. Recorded
+        // against the persona the line was addressed to (none = `ctrl`).
+        crate::attendance::note_command_turn_in(
+            self.attendance_root.as_deref(),
+            self.active_persona.as_deref().unwrap_or("ctrl"),
+            origin,
+            // The REPL's "sender is entitled to assert presence" check: the
+            // local operator owns this process, so the only question left is
+            // the one `origin` answers.
+            true,
+            chrono::Utc::now(),
+        );
+
         let mut parts = input.splitn(2, char::is_whitespace);
         let cmd = parts.next().unwrap_or("");
         let arg = parts.next().map(str::trim).unwrap_or("");

--- a/crates/trusty-agents/src/repl/commands/dispatch.rs
+++ b/crates/trusty-agents/src/repl/commands/dispatch.rs
@@ -230,7 +230,13 @@ impl TrustyAgentsRepl {
                                 let _ = writeln!(out, "error: task file is empty");
                             } else {
                                 let _ = writeln!(out, "→ Running task from {}", path.display());
-                                match self.attempt_forward(&task).await {
+                                // #4685: forward THIS dispatcher's origin. The
+                                // task text came out of a file, and `tagent
+                                // /run task.txt` reaches here from argv with
+                                // `TurnOrigin::Assistant`; hardcoding human
+                                // here would let a cron job forge a turn on
+                                // every fire.
+                                match self.attempt_forward(&task, origin).await {
                                     Ok((response, _)) => {
                                         let _ = writeln!(out, "{response}");
                                     }

--- a/crates/trusty-agents/src/repl/dispatch.rs
+++ b/crates/trusty-agents/src/repl/dispatch.rs
@@ -32,9 +32,14 @@ impl TrustyAgentsRepl {
     /// display. Also subscribes to the global `events::Event` bus and
     /// translates relevant signals into `ThinkingStep` updates so the user
     /// sees progress (delegating to engineer, generating code, etc.).
+    ///
+    /// `origin` is threaded straight through to [`Self::attempt_forward`]
+    /// (#4685) rather than asserted here — an intermediate that hardcoded the
+    /// claim would reintroduce exactly the forgery path this issue closes.
     pub(crate) async fn forward_task_to_channel(
         &mut self,
         task_text: &str,
+        origin: crate::attendance::TurnOrigin,
         tx: tokio::sync::mpsc::UnboundedSender<tui::ReplEvent>,
     ) -> Result<()> {
         let _ = tx.send(tui::ReplEvent::LlmThinking(true));
@@ -62,7 +67,7 @@ impl TrustyAgentsRepl {
         let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
         spawn_thinking_relay(tx.clone(), cancel.clone());
 
-        let result = self.attempt_forward(task_text).await;
+        let result = self.attempt_forward(task_text, origin).await;
         cancel.store(true, std::sync::atomic::Ordering::SeqCst);
 
         match result {
@@ -119,13 +124,36 @@ impl TrustyAgentsRepl {
     /// - `AgentScope::Project` → keep the existing PM orchestrator path
     ///   (`run_pm_task_with_history`) so project tasks can still delegate
     ///   to sub-agents.
-    pub(crate) async fn attempt_forward(&self, task_text: &str) -> Result<(String, TokenUsage)> {
-        // #4652: every path through this function starts with a line the user
-        // typed, so one call here covers all six dispatch arms below. Recorded
+    /// `origin` declares who produced `task_text`, and must be threaded from
+    /// whoever actually read it (#4685). This function used to assert
+    /// `TurnOrigin::Human` unconditionally on the claim that "every path
+    /// through this function starts with a line the user typed" — that claim
+    /// was already false: `try_handle_slash`'s `/run <file>` arm reaches here
+    /// with the contents of a FILE, and `predispatch::handle_slash_passthrough`
+    /// dispatches `tagent /run task.txt` from argv, a documented scripting
+    /// surface. A cron job invoking that forged a human turn on every fire.
+    /// Now the caller's origin governs, so the forgery is impossible by
+    /// construction rather than by convention.
+    /// Test: `argv_run_command_with_assistant_origin_records_nothing`.
+    pub(crate) async fn attempt_forward(
+        &self,
+        task_text: &str,
+        origin: crate::attendance::TurnOrigin,
+    ) -> Result<(String, TokenUsage)> {
+        // #4652: one call here covers all six dispatch arms below, recorded
         // against the persona the line was addressed to (none = `ctrl`).
-        crate::attendance::note_turn(
+        // #4685: honours the caller's origin — a non-human one records nothing —
+        // and records through the SAME injected root `try_handle_slash` uses.
+        // The bare `note_turn` this replaced always resolved `$HOME`, so no test
+        // could observe this call site; the first draft of the regression test
+        // below passed against the unfixed code for exactly that reason, and
+        // wrote into the developer's real `~/.trusty-agents` doing it.
+        crate::attendance::note_command_turn_in(
+            self.attendance_root.as_deref(),
             self.active_persona.as_deref().unwrap_or("ctrl"),
-            crate::attendance::TurnOrigin::Human,
+            origin,
+            true,
+            chrono::Utc::now(),
         );
 
         // #343: Thin-client mode — forward to the running daemon over HTTP

--- a/crates/trusty-agents/src/repl/dispatch.rs
+++ b/crates/trusty-agents/src/repl/dispatch.rs
@@ -123,7 +123,10 @@ impl TrustyAgentsRepl {
         // #4652: every path through this function starts with a line the user
         // typed, so one call here covers all six dispatch arms below. Recorded
         // against the persona the line was addressed to (none = `ctrl`).
-        crate::attendance::note_human_turn(self.active_persona.as_deref().unwrap_or("ctrl"));
+        crate::attendance::note_turn(
+            self.active_persona.as_deref().unwrap_or("ctrl"),
+            crate::attendance::TurnOrigin::Human,
+        );
 
         // #343: Thin-client mode — forward to the running daemon over HTTP
         // and bypass all in-process dispatch (persona, ctrl socket, PM).

--- a/crates/trusty-agents/src/repl/mod.rs
+++ b/crates/trusty-agents/src/repl/mod.rs
@@ -148,6 +148,16 @@ pub struct TrustyAgentsRepl {
     /// forwarded over HTTP via `crate::service::submit_task_via_service`
     /// instead of running in-process. Set via `set_service_client_mode`.
     pub(crate) service_url: Option<String>,
+    /// Where `try_handle_slash` records attendance (#4685).
+    ///
+    /// Why: injected rather than resolved at the call site so a test can drive
+    /// the REAL dispatcher against a temp directory. That matters more here
+    /// than elsewhere because the defect #4685 fixes was precisely a
+    /// dispatcher nobody had wired — a test of the helper alone would have
+    /// passed throughout the bug. `None` (no home directory) disables
+    /// recording, exactly as every other attendance call site treats it.
+    /// Test: `repl_slash_command_records_a_human_turn`.
+    pub(crate) attendance_root: Option<PathBuf>,
 }
 
 impl TrustyAgentsRepl {
@@ -241,6 +251,7 @@ impl TrustyAgentsRepl {
             tm_manager,
             tm_monitor,
             service_url: None,
+            attendance_root: crate::attendance::default_attendance_root().ok(),
         })
     }
 

--- a/crates/trusty-agents/src/repl/tests.rs
+++ b/crates/trusty-agents/src/repl/tests.rs
@@ -709,3 +709,47 @@ async fn an_automated_repl_slash_caller_records_nothing() {
         "the human-origin path must record, or the assertion above proves nothing"
     );
 }
+
+/// #4685 HIGH regression: `/run <file>` reaches a SECOND recording call —
+/// `attempt_forward` — that the dispatcher's own hook does not cover. Before
+/// this fix `attempt_forward` asserted `TurnOrigin::Human` unconditionally, so
+/// an argv invocation (`tagent /run task.txt`, which `predispatch` dispatches
+/// with `TurnOrigin::Assistant`) forged a human turn on every fire — a cron job
+/// would have masked the owner's absence forever.
+///
+/// The dispatch is short-circuited offline by pointing thin-client mode at a
+/// dead port: `attempt_forward` records BEFORE that branch, so the assertion is
+/// about the hook and not about reaching an LLM.
+///
+/// Note the dispatcher's own hook cannot mask this: it honours `origin` too, so
+/// with `Assistant` neither call may write. A human-origin contrast would be
+/// satisfied by the dispatcher hook alone and is covered separately by
+/// `repl_slash_command_records_a_human_turn`.
+#[tokio::test]
+async fn argv_run_command_with_assistant_origin_records_nothing() {
+    let (dir, mut repl, root) = repl_with_attendance_root();
+    repl.set_service_client_mode("http://127.0.0.1:1");
+
+    let task = dir.path().join("task.txt");
+    std::fs::write(&task, "ship it").expect("write task file");
+
+    let out = repl
+        .try_handle_slash(
+            &format!("/run {}", task.display()),
+            crate::attendance::TurnOrigin::Assistant,
+        )
+        .await
+        .expect("`/run` is a slash command")
+        .expect("`/run` reports dispatch failure rather than erroring");
+    assert!(
+        out.1.contains("Running task from"),
+        "the `/run` arm must actually have executed: {:?}",
+        out.1
+    );
+
+    assert_eq!(
+        recorded_turn(&root, "ctrl"),
+        None,
+        "an argv-driven `/run` forged a human turn through attempt_forward"
+    );
+}

--- a/crates/trusty-agents/src/repl/tests.rs
+++ b/crates/trusty-agents/src/repl/tests.rs
@@ -1,5 +1,11 @@
 //! REPL unit tests, split from `mod.rs` (#357). `super` resolves to the
 //! `repl` module, so the original `use super::*` imports are unchanged.
+//!
+//! #4685: every `try_handle_slash` call below that is not ABOUT attendance
+//! passes `TurnOrigin::Assistant`, because a test harness is an automated
+//! caller — that is the honest tag, and it is also what keeps these tests from
+//! writing attendance records into the developer's real `~/.trusty-agents`.
+//! The two tests that do exercise attendance inject a temp root first.
 
 #![cfg(test)]
 
@@ -28,14 +34,20 @@ fn default_history_path_under_trusty_agents() {
 #[tokio::test]
 async fn try_handle_slash_returns_none_for_non_slash() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
-    let r = repl.try_handle_slash("hello world").await;
+    let r = repl
+        .try_handle_slash("hello world", crate::attendance::TurnOrigin::Assistant)
+        .await;
     assert!(r.is_none());
 }
 
 #[tokio::test]
 async fn try_handle_slash_help_returns_continue() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
-    let r = repl.try_handle_slash("/help").await.unwrap().unwrap();
+    let r = repl
+        .try_handle_slash("/help", crate::attendance::TurnOrigin::Assistant)
+        .await
+        .unwrap()
+        .unwrap();
     assert!(r.0, "/help should keep REPL running");
     assert!(
         r.1.contains("slash commands"),
@@ -47,7 +59,11 @@ async fn try_handle_slash_help_returns_continue() {
 #[tokio::test]
 async fn try_handle_slash_exit_returns_break() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
-    let r = repl.try_handle_slash("/exit").await.unwrap().unwrap();
+    let r = repl
+        .try_handle_slash("/exit", crate::attendance::TurnOrigin::Assistant)
+        .await
+        .unwrap()
+        .unwrap();
     assert!(!r.0, "/exit should signal REPL break");
     assert!(r.1.contains("Bye"));
 }
@@ -64,7 +80,11 @@ async fn try_handle_slash_exit_returns_break() {
 #[tokio::test]
 async fn try_handle_slash_disconnect_is_recognized_alias() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
-    let r = repl.try_handle_slash("/disconnect").await.unwrap().unwrap();
+    let r = repl
+        .try_handle_slash("/disconnect", crate::attendance::TurnOrigin::Assistant)
+        .await
+        .unwrap()
+        .unwrap();
     assert!(!r.0, "/disconnect should signal REPL break");
     assert!(
         !r.1.contains("unknown command"),
@@ -85,7 +105,11 @@ async fn try_handle_slash_disconnect_is_recognized_alias() {
 async fn try_handle_slash_exit_in_client_mode_shows_disconnect_message() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
     repl.set_service_client_mode("http://localhost:7654");
-    let r = repl.try_handle_slash("/exit").await.unwrap().unwrap();
+    let r = repl
+        .try_handle_slash("/exit", crate::attendance::TurnOrigin::Assistant)
+        .await
+        .unwrap()
+        .unwrap();
     assert!(!r.0, "/exit should still signal REPL break in client mode");
     assert!(
         r.1.contains("Server still running"),
@@ -99,7 +123,11 @@ async fn try_handle_slash_exit_in_client_mode_shows_disconnect_message() {
 #[tokio::test]
 async fn try_handle_slash_unknown_captures_into_buffer() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
-    let r = repl.try_handle_slash("/nope").await.unwrap().unwrap();
+    let r = repl
+        .try_handle_slash("/nope", crate::attendance::TurnOrigin::Assistant)
+        .await
+        .unwrap()
+        .unwrap();
     assert!(r.0);
     assert!(
         r.1.contains("unknown command"),
@@ -119,7 +147,7 @@ async fn try_handle_slash_switch_ctrl_clears_persona() {
     repl.active_persona = Some("izzie".to_string());
     repl.project_name = "Izzie".to_string();
     let r = repl
-        .try_handle_slash("/switch ctrl")
+        .try_handle_slash("/switch ctrl", crate::attendance::TurnOrigin::Assistant)
         .await
         .unwrap()
         .unwrap();
@@ -140,7 +168,11 @@ async fn try_handle_slash_switch_ctrl_clears_persona() {
 #[tokio::test]
 async fn try_handle_slash_switch_accepts_aliases() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
-    let r = repl.try_handle_slash("/switch CTO").await.unwrap().unwrap();
+    let r = repl
+        .try_handle_slash("/switch CTO", crate::attendance::TurnOrigin::Assistant)
+        .await
+        .unwrap()
+        .unwrap();
     assert!(r.0);
     assert!(
         !r.1.contains("Unknown persona"),
@@ -159,7 +191,11 @@ async fn try_handle_slash_switch_accepts_aliases() {
 #[tokio::test]
 async fn try_handle_slash_switch_empty_lists_choices() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
-    let r = repl.try_handle_slash("/switch").await.unwrap().unwrap();
+    let r = repl
+        .try_handle_slash("/switch", crate::attendance::TurnOrigin::Assistant)
+        .await
+        .unwrap()
+        .unwrap();
     assert!(r.0);
     assert!(r.1.contains("Assistant"));
     assert!(r.1.contains("Izzie"));
@@ -173,7 +209,7 @@ async fn try_handle_slash_switch_empty_lists_choices() {
 async fn try_handle_slash_switch_unknown_alias_errors() {
     let mut repl = TrustyAgentsRepl::new(None).unwrap();
     let r = repl
-        .try_handle_slash("/switch bogus")
+        .try_handle_slash("/switch bogus", crate::attendance::TurnOrigin::Assistant)
         .await
         .unwrap()
         .unwrap();
@@ -573,4 +609,103 @@ fn resolve_active_model_falls_back_to_haiku_when_no_toml() {
         return;
     }
     assert_eq!(repl.resolve_active_model(), "anthropic/claude-haiku-4-5");
+}
+
+// ---------------------------------------------------------------------------
+// #4685: REPL slash-command attendance. `try_handle_slash` is a SEPARATE
+// dispatch table from `repl::dispatch::attempt_forward` (the only REPL site
+// #4652 hooked), so every recognized slash command returned here and recorded
+// nothing — an owner typing `/status` every few minutes read as absent. These
+// drive the real dispatcher against an injected temp root.
+// ---------------------------------------------------------------------------
+
+/// A REPL whose attendance records land in a temp dir instead of `$HOME`.
+fn repl_with_attendance_root() -> (tempfile::TempDir, TrustyAgentsRepl, std::path::PathBuf) {
+    let dir = tempfile::TempDir::new().expect("temp dir");
+    let root = crate::attendance::attendance_root(dir.path());
+    let mut repl = TrustyAgentsRepl::new(None).expect("repl");
+    repl.attendance_root = Some(root.clone());
+    (dir, repl, root)
+}
+
+/// The last human turn recorded for `persona` under `root`.
+fn recorded_turn(root: &std::path::Path, persona: &str) -> Option<chrono::DateTime<chrono::Utc>> {
+    let tracker = crate::attendance::AttendanceTracker::new(
+        root,
+        crate::attendance::AttendanceConfig::default(),
+    );
+    let id = crate::assistants::AssistantInstanceId::new(persona).expect("valid id");
+    tracker.last_human_turn(&id).expect("read")
+}
+
+/// #4685: a person typing a REPL slash command is attending. `/help` is used
+/// because it touches no socket, no network and no disk — the assertion is
+/// about the hook, not the command.
+#[tokio::test]
+async fn repl_slash_command_records_a_human_turn() {
+    let (_dir, mut repl, root) = repl_with_attendance_root();
+    let before = chrono::Utc::now();
+
+    repl.try_handle_slash("/help", crate::attendance::TurnOrigin::Human)
+        .await
+        .expect("`/help` is a slash command")
+        .expect("`/help` succeeds");
+
+    let recorded = recorded_turn(&root, "ctrl")
+        .expect("a human typing `/help` must advance the last-human-turn clock");
+    assert!(
+        recorded >= before,
+        "recorded turn {recorded} predates the command at {before}"
+    );
+
+    // And the whole point: the instance now reads attended rather than the
+    // never-attended state a command-only REPL session used to be stuck in.
+    let tracker = crate::attendance::AttendanceTracker::new(
+        &root,
+        crate::attendance::AttendanceConfig::default(),
+    );
+    let id = crate::assistants::AssistantInstanceId::new("ctrl").expect("valid id");
+    assert!(
+        !tracker
+            .is_unattended(&id, recorded + chrono::Duration::minutes(1))
+            .expect("query"),
+    );
+}
+
+/// #4685: the REPL has no pairing or RBAC gate, so `TurnOrigin` IS its gate —
+/// and it is load-bearing, not ceremonial. `plain_cli::run_plain_cli` issues
+/// its own `/switch assistant` at startup and `predispatch` serves `tagent
+/// /status` from argv; if the hook ignored origin, every launch and every
+/// scripted poll would forge presence for an absent owner.
+///
+/// The contrast at the end is what makes this test fail against an unhooked
+/// dispatcher rather than passing vacuously.
+#[tokio::test]
+async fn an_automated_repl_slash_caller_records_nothing() {
+    let (_dir, mut repl, root) = repl_with_attendance_root();
+
+    // The commands the two automated callers actually issue: the startup
+    // bootstrap's `/switch`, and an argv-driven status poll.
+    for line in ["/switch", "/help", "/session"] {
+        let _ = repl
+            .try_handle_slash(line, crate::attendance::TurnOrigin::Assistant)
+            .await
+            .expect("slash command");
+    }
+    assert_eq!(
+        recorded_turn(&root, "ctrl"),
+        None,
+        "automation forged attendance through the REPL dispatcher"
+    );
+
+    // Same dispatcher, same command, human origin — this one records. Without
+    // it, the assertion above would also hold for a dispatcher with no hook.
+    let _ = repl
+        .try_handle_slash("/help", crate::attendance::TurnOrigin::Human)
+        .await
+        .expect("slash command");
+    assert!(
+        recorded_turn(&root, "ctrl").is_some(),
+        "the human-origin path must record, or the assertion above proves nothing"
+    );
 }

--- a/crates/trusty-agents/src/runtime/predispatch.rs
+++ b/crates/trusty-agents/src/runtime/predispatch.rs
@@ -79,7 +79,16 @@ pub(super) async fn handle_slash_passthrough(cli: &Cli) -> Result<bool> {
         let slash_line = cli.rest.join(" ");
         let user_profile = identity::user_profile::UserProfile::load();
         let mut repl = repl::TrustyAgentsRepl::new(user_profile)?;
-        match repl.try_handle_slash(&slash_line).await {
+        // #4685: `tagent /status` is a fire-and-exit argv invocation, and this
+        // function is documented as the surface "scripts can detect bad
+        // commands" through. A cron job polling it every minute would mask the
+        // owner's absence forever — the exact forgery #4685 weighed — and a
+        // human who really is present is also typing into a live session that
+        // records. Not human.
+        match repl
+            .try_handle_slash(&slash_line, crate::attendance::TurnOrigin::Assistant)
+            .await
+        {
             Some(Ok((_continue, output))) => {
                 // The REPL slash dispatcher captures "unknown command: ..."
                 // for slashes it doesn't recognize. Surface that as exit 1

--- a/crates/trusty-agents/src/slack/handlers.rs
+++ b/crates/trusty-agents/src/slack/handlers.rs
@@ -54,17 +54,20 @@ const SLACK_SNIPPET_MAX_CHARS: usize = 140;
 /// and mute their notifications. `handle_message` already refuses to record for
 /// an unknown user (it returns the Virtual CTO reply before its own hook); this
 /// keeps the two paths agreeing.
-/// What: records for `persona` at `now` when the channel is paired AND the
-/// sender resolves to a known RBAC identity. Infallible; returns whether the
-/// clock advanced. Deliberately does NOT gate whether the command itself
-/// proceeds — an unknown user's `/slack-status` still answers, exactly as
-/// before.
+/// What: records a turn of the caller-declared `origin` for `persona` at `now`
+/// when the channel is paired AND the sender resolves to a known RBAC identity.
+/// `origin` is threaded rather than assumed (#4685) so this transport obeys the
+/// same rule every other surface does — no wrapper hardcodes humanity on a
+/// caller's behalf. Infallible; returns whether the clock advanced.
+/// Deliberately does NOT gate whether the command itself proceeds — an unknown
+/// user's `/slack-status` still answers, exactly as before.
 /// Test: `paired_slash_command_records_a_human_turn`,
 /// `unpaired_slash_command_records_nothing`,
 /// `unknown_rbac_user_cannot_manufacture_attendance`.
 pub(super) fn note_command_turn(
     root: Option<&std::path::Path>,
     persona: &str,
+    origin: crate::attendance::TurnOrigin,
     is_paired: bool,
     sender_is_known_to_rbac: bool,
     now: chrono::DateTime<chrono::Utc>,
@@ -72,6 +75,7 @@ pub(super) fn note_command_turn(
     crate::attendance::note_command_turn_in(
         root,
         persona,
+        origin,
         is_paired && sender_is_known_to_rbac,
         now,
     )
@@ -116,6 +120,8 @@ pub(super) async fn handle_command(
     note_command_turn(
         crate::attendance::default_attendance_root().ok().as_deref(),
         &persona_for_attendance,
+        // #4685: an inbound Slack command is a person typing.
+        crate::attendance::TurnOrigin::Human,
         is_paired,
         rbac.user(&user_id).is_some(),
         chrono::Utc::now(),
@@ -420,7 +426,7 @@ pub(super) async fn handle_message(
 
     // #4652: past the pairing and RBAC gates, this is a known human speaking —
     // record it as attendance for the persona they addressed.
-    crate::attendance::note_human_turn(&active_persona);
+    crate::attendance::note_turn(&active_persona, crate::attendance::TurnOrigin::Human);
 
     let result = ctrl::run_pm_task_with_persona(
         &path,

--- a/crates/trusty-agents/src/slack/tests.rs
+++ b/crates/trusty-agents/src/slack/tests.rs
@@ -325,7 +325,14 @@ fn paired_slash_command_records_a_human_turn() {
     let (_dir, root, now) = attendance_fixture();
 
     assert!(
-        super::handlers::note_command_turn(Some(&root), "cto-assistant", true, true, now),
+        super::handlers::note_command_turn(
+            Some(&root),
+            "cto-assistant",
+            crate::attendance::TurnOrigin::Human,
+            true,
+            true,
+            now,
+        ),
         "a known user's slash command in a paired channel is a human turn"
     );
     assert_eq!(recorded_turn(&root, "cto-assistant"), Some(now));
@@ -338,6 +345,7 @@ fn unpaired_slash_command_records_nothing() {
     assert!(!super::handlers::note_command_turn(
         Some(&root),
         "cto-assistant",
+        crate::attendance::TurnOrigin::Human,
         false,
         true,
         now
@@ -359,6 +367,7 @@ fn unknown_rbac_user_cannot_manufacture_attendance() {
     assert!(!super::handlers::note_command_turn(
         Some(&root),
         "cto-assistant",
+        crate::attendance::TurnOrigin::Human,
         true,
         false,
         now

--- a/crates/trusty-agents/src/telegram/handlers.rs
+++ b/crates/trusty-agents/src/telegram/handlers.rs
@@ -93,6 +93,8 @@ pub(super) async fn handle_command(
     crate::attendance::note_command_turn_in(
         crate::attendance::default_attendance_root().ok().as_deref(),
         persona_for_attendance.as_deref().unwrap_or("ctrl"),
+        // #4685: a Telegram update is by definition somebody's typing.
+        crate::attendance::TurnOrigin::Human,
         is_paired,
         chrono::Utc::now(),
     );
@@ -306,7 +308,8 @@ pub(super) fn note_turn_and_is_switch(
     now: chrono::DateTime<chrono::Utc>,
 ) -> bool {
     if let Some(root) = root {
-        crate::attendance::note_human_turn_in(root, persona, now);
+        // #4685: an inbound Telegram message is a person typing.
+        crate::attendance::note_turn_in(root, persona, crate::attendance::TurnOrigin::Human, now);
     }
     text.starts_with("/switch")
 }

--- a/crates/trusty-agents/src/telegram/tests.rs
+++ b/crates/trusty-agents/src/telegram/tests.rs
@@ -639,7 +639,13 @@ fn paired_slash_command_records_a_human_turn() {
     let now = chrono::TimeZone::with_ymd_and_hms(&chrono::Utc, 2026, 8, 3, 12, 0, 0).unwrap();
 
     assert!(
-        crate::attendance::note_command_turn_in(Some(&root), "izzie", true, now),
+        crate::attendance::note_command_turn_in(
+            Some(&root),
+            "izzie",
+            crate::attendance::TurnOrigin::Human,
+            true,
+            now
+        ),
         "a paired chat's slash command is a human turn"
     );
 
@@ -663,6 +669,7 @@ fn unpaired_slash_command_records_nothing() {
     assert!(!crate::attendance::note_command_turn_in(
         Some(&root),
         "izzie",
+        crate::attendance::TurnOrigin::Human,
         false,
         now
     ));


### PR DESCRIPTION
Closes #4685. Implements the owner's **origin-tagged** decision (2026-08-03), both required parts.

## Part 1 — origin is caller-declared, not wrapper-hardcoded

`note_human_turn`, `note_human_turn_in` and `note_command_turn_in` each hardcoded `TurnOrigin::Human` internally. That made "automation cannot forge presence" a property of *which wrapper a caller happened to reach for* — which is not a property at all: a future automated caller picking the convenient function forges presence silently and nothing objects.

The helpers become, with the origin on the signature and the human claim out of the name:

- `attendance::note_turn(instance, origin)`
- `attendance::note_turn_in(root, instance, origin, now)`
- `attendance::note_command_turn_in(root, instance, origin, paired, now)`

The compiler now makes every new call site name a variant. **It is impossible to record a human turn without a call site naming `TurnOrigin::Human` in its own source**, and an automated caller naming `TurnOrigin::Assistant` records nothing even with every transport gate open. The two gates on `note_command_turn_in` stay independent on purpose: `paired` answers "is this sender entitled to assert presence", `origin` answers "was this a person at all" — the question no transport-level check can answer.

## Part 2 — REPL slash commands, origin-tagged

`repl::commands::dispatch::try_handle_slash` is a separate dispatch table from `repl::dispatch::attempt_forward` (the only REPL site #4652 hooked), so `/switch`, `/model`, `/provider`, `/status`, `/help` returned from it and recorded nothing. An owner polling `/status` while a long task ran read as absent after fifteen minutes while sitting right there. It now records, through a caller-declared `origin`.

### The REPL gate — stated plainly

The REPL has no pairing or RBAC gate and **nothing can play that role**, because there is no remote sender to authenticate: the process already runs under the operator's own uid. So I did not assume REPL input is inherently human — it demonstrably is not. `try_handle_slash` has non-human callers **today**:

- `ctrl::repl::plain_cli::run_plain_cli` issues its own `/switch assistant` at startup, before reading a byte of stdin.
- `runtime::predispatch::handle_slash_passthrough` serves `tagent /status` from argv — a surface its own docs describe as the one "scripts can detect bad commands" through. A cron job polling it would mask the owner's absence forever.

An unconditional hook would therefore have made **every REPL launch forge attendance for an absent owner**. `TurnOrigin` is the REPL's gate, and it is load-bearing rather than ceremonial. Both automated callers pass `TurnOrigin::Assistant`; the interactive stdin loop and the TUI pass `TurnOrigin::Human`.

`ReplBridge::handle_input` records too: it intercepts and returns from six commands (`/exit`, `/clear`, `/switch`, `/model`, `/provider`, `/update`) before `try_handle_slash` ever sees them — the same "two dispatch tables drift apart" shape this issue exists to fix. The later `try_handle_slash` call is idempotent under the existing monotonic guard.

`TrustyAgentsRepl` gains an injectable `attendance_root` so a test can drive the **real dispatcher** against a temp directory. That matters here specifically: the defect being fixed was a dispatcher nobody had wired, and a helper-only test would have passed throughout the bug.

## Tests — each confirmed red before the fix, green after

| Test | Red without | 
|---|---|
| `attendance::tests::an_assistant_origin_caller_records_nothing` | origin ignored (pre-#4685 behaviour) |
| `repl::tests::repl_slash_command_records_a_human_turn` | REPL hook removed |
| `repl::tests::an_automated_repl_slash_caller_records_nothing` | either regression |

Both `records_nothing` tests carry a human-origin contrast, so neither can pass vacuously against a dispatcher with no hook.

No existing test was weakened, ignored, cfg-gated or removed. Existing `try_handle_slash` tests pass `TurnOrigin::Assistant` — the honest tag for a test harness, and what keeps them from writing into a developer's real `~/.trusty-agents`.

## Gates (crate-scoped, foreground)

```
cargo test -p trusty-agents --lib   → 3311 passed; 0 failed; 11 ignored
cargo clippy -p trusty-agents --all-targets -- -D warnings → exit 0
cargo fmt --check                   → exit 0
bash scripts/check_line_cap.sh      → 3603 files, 0 violations — OK
```

Changelog: `crates/trusty-agents/changelog.d/4685-origin-tagged-attendance.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools