### PR TITLE
fix(trusty-common): stop hiding cold palaces from the memory TUI (#4690)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6535,7 +6535,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.0",
+ "proc-macro-crate 1.3.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -11398,7 +11398,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-common"
-version = "0.28.0"
+version = "0.28.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/trusty-common/Cargo.toml
+++ b/crates/trusty-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-common"
-version = "0.28.0"
+version = "0.28.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/trusty-common/changelog.d/4690-cold-palace-visibility.md
+++ b/crates/trusty-common/changelog.d/4690-cold-palace-visibility.md
@@ -1,0 +1,3 @@
+Fixed
+
+- memory TUI no longer hides palaces whose counts the daemon never measured — `palace_has_content()` now reads the `Option<u64>` accessors instead of the raw zeroed fields, so *unknown* counts keep a palace visible (rendered as `—`) while a measured-empty palace stays filtered out (closes [#4690](https://github.com/bobmatnyc/trusty-tools/issues/4690))

--- a/crates/trusty-common/src/monitor/memory_tui/tests.rs
+++ b/crates/trusty-common/src/monitor/memory_tui/tests.rs
@@ -844,6 +844,148 @@ fn test_filter_empty_palaces() {
     assert!(rows.iter().any(|r| r.text.contains("drawer-o")));
 }
 
+/// A never-opened palace: the daemon returned placeholder zeros it never
+/// measured, flagged by `counts_unknown`.
+fn cold_palace(id: &str) -> PalaceRow {
+    PalaceRow {
+        id: id.into(),
+        name: id.into(),
+        counts_unknown: true,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn test_palace_has_content_semantics() {
+    // Unknown counts are NOT empty — the palace stays visible so the renderer
+    // gets a chance to print `—` (#4690).
+    assert!(
+        view::palace_has_content(&cold_palace("cold")),
+        "unknown counts must not hide a palace"
+    );
+
+    // Measured and all zero — genuinely empty, still hidden.
+    assert!(
+        !view::palace_has_content(&PalaceRow {
+            id: "measured-empty".into(),
+            name: "measured-empty".into(),
+            ..Default::default()
+        }),
+        "a measured-empty palace stays hidden"
+    );
+
+    // Measured and non-zero — visible, unchanged.
+    for probe in [
+        PalaceRow {
+            vector_count: 1,
+            ..Default::default()
+        },
+        PalaceRow {
+            kg_triple_count: 1,
+            ..Default::default()
+        },
+        PalaceRow {
+            drawer_count: 1,
+            ..Default::default()
+        },
+    ] {
+        assert!(
+            view::palace_has_content(&probe),
+            "a measured non-zero palace stays visible: {probe:?}"
+        );
+    }
+}
+
+#[test]
+fn test_cold_palace_visible() {
+    let mut state = MemoryTuiState::new("http://x");
+    state.palaces = vec![
+        cold_palace("cold"),
+        PalaceRow {
+            id: "measured-empty".into(),
+            name: "measured-empty".into(),
+            ..Default::default()
+        },
+        PalaceRow {
+            id: "warm".into(),
+            name: "warm".into(),
+            vector_count: 7,
+            ..Default::default()
+        },
+    ];
+
+    let visible = filtered_sorted_palaces(&state);
+    let ids: Vec<&str> = visible.iter().map(|p| p.id.as_str()).collect();
+    assert!(ids.contains(&"cold"), "cold palace must survive the filter");
+    assert!(ids.contains(&"warm"));
+    assert!(
+        !ids.contains(&"measured-empty"),
+        "measured-empty palace stays filtered out"
+    );
+
+    // The em-dash path #4684 added is now actually reachable in the TUI.
+    let rows = palace_lines(&state);
+    let cold_row = rows
+        .iter()
+        .find(|r| r.text.contains("cold"))
+        .expect("cold palace must be rendered as a row");
+    assert!(
+        cold_row
+            .text
+            .contains(crate::monitor::dashboard::UNKNOWN_COUNT),
+        "unknown counts render as `—`, got {:?}",
+        cold_row.text
+    );
+    assert!(!rows.iter().any(|r| r.text.contains("measured-e")));
+}
+
+#[test]
+fn test_cold_palace_navigable() {
+    let mut state = MemoryTuiState::new("http://x");
+    state.sort_key = PalaceSortKey::Name;
+    state.palaces = vec![
+        PalaceRow {
+            id: "aaa-warm".into(),
+            name: "aaa-warm".into(),
+            vector_count: 3,
+            ..Default::default()
+        },
+        cold_palace("bbb-cold"),
+        PalaceRow {
+            id: "ccc-empty".into(),
+            name: "ccc-empty".into(),
+            ..Default::default()
+        },
+    ];
+
+    assert_eq!(
+        visible_palace_ids(&state),
+        vec![
+            tui_common::ALL_SENTINEL.to_string(),
+            "aaa-warm".to_string(),
+            "bbb-cold".to_string(),
+        ],
+        "the cold palace is addressable by the cursor; the measured-empty one is not"
+    );
+
+    navigate_down_visible(&mut state);
+    assert_eq!(state.selected_id(), Some("aaa-warm"));
+    navigate_down_visible(&mut state);
+    assert_eq!(
+        state.selected_id(),
+        Some("bbb-cold"),
+        "arrow keys must be able to land on a cold palace"
+    );
+    navigate_down_visible(&mut state);
+    assert_eq!(
+        state.selected_id(),
+        Some("bbb-cold"),
+        "the measured-empty palace is still skipped past the end"
+    );
+    navigate_up_visible(&mut state);
+    assert_eq!(state.selected_id(), Some("aaa-warm"));
+}
+
 #[test]
 fn test_palace_row_with_activity() {
     let p = PalaceRow {

--- a/crates/trusty-common/src/monitor/memory_tui/view.rs
+++ b/crates/trusty-common/src/monitor/memory_tui/view.rs
@@ -46,23 +46,29 @@ pub fn sort_label(key: ThreeWaySortKey) -> &'static str {
 
 /// Whether to keep a palace in the visible list.
 ///
-/// Why: palaces with no vectors, no KG triples, AND no drawers carry no
-/// user-visible content and would only clutter the list. A palace with drawers
-/// but no vectors is one whose memories have been stored but not yet embedded
-/// (e.g. the embedding model has not run yet); hiding it causes confusion
-/// because the palace clearly exists and has written content. Including
-/// `drawer_count > 0` in the gate keeps such palaces visible in the TUI.
-/// What: returns `true` when any of `vector_count`, `kg_triple_count`, or
-/// `drawer_count` is non-zero; returns `false` only when all three are zero.
-/// Test: `test_filter_empty_palaces`.
+/// Why: a palace measured to hold no vectors, no KG triples, AND no drawers
+/// carries no user-visible content and would only clutter the list. A palace
+/// with drawers but no vectors is one whose memories have been stored but not
+/// yet embedded (e.g. the embedding model has not run yet); hiding it causes
+/// confusion because the palace clearly exists and has written content, so
+/// drawers count toward the gate too. A palace whose counts the daemon never
+/// measured is a third case entirely: unknown is not empty, and hiding it would
+/// erase a palace that may well be full.
+/// What: reads the counts through the `Option<u64>` accessors so the three
+/// cases stay distinguishable. Returns `true` when the counts are unknown, or
+/// when any measured count is non-zero; returns `false` only when every count
+/// was measured and every one of them is zero.
+/// Test: `test_filter_empty_palaces`, `test_cold_palace_visible`,
+/// `test_cold_palace_navigable`.
 //
-// #4682: this reads the raw fields on purpose. Since #4640 an unloaded palace
-// reports zeros that mean *unknown*, so this gate now also hides cold palaces —
-// the same "unknown treated as empty" class as #68. Changing it would make
-// every one of ~2,180 cold palaces appear, which is a visibility decision this
-// change deliberately does not take. Tracked in #4682 as a known adjacent gap.
+// #4690: this reads the accessors, not the raw fields. Since #4640 an unloaded
+// palace reports zeros that mean *unknown*, and reading the raw fields hid every
+// cold palace before any renderer could print the `—` that #4684 added — the
+// same "unknown treated as empty" class as #68.
 pub fn palace_has_content(palace: &PalaceRow) -> bool {
-    palace.vector_count > 0 || palace.kg_triple_count > 0 || palace.drawer_count > 0
+    // `None` (unknown) keeps the palace; `Some(0)` (measured empty) does not.
+    let keeps = |count: Option<u64>| count.is_none_or(|n| n > 0);
+    keeps(palace.vectors()) || keeps(palace.kg_triples()) || keeps(palace.drawers())
 }
 
 /// Maximum characters retained for the trailing snippet column.
@@ -89,10 +95,10 @@ const DRAWER_CREATOR_WIDTH: usize = 24;
 /// state's palaces, returning the visible subset in display order.
 ///
 /// Why: delegates to the shared [`tui_common::filtered_sorted`] so memory and
-/// search apply identical filter / sort rules. Empty palaces (zero vectors and
-/// zero KG triples) are dropped first — they carry no recallable or graph
-/// content and would only clutter the list. Kept as a memory-named wrapper for
-/// the existing tests and callers.
+/// search apply identical filter / sort rules. Measured-empty palaces are
+/// dropped first — they carry no recallable or graph content and would only
+/// clutter the list — while palaces whose counts are unknown are kept (#4690).
+/// Kept as a memory-named wrapper for the existing tests and callers.
 /// What: filters out empty palaces via [`palace_has_content`], then delegates
 /// to [`tui_common::filtered_sorted`].
 /// Test: `test_apply_filter`, `test_apply_sort_*`, `test_filter_empty_palaces`.


### PR DESCRIPTION
## Summary

`palace_has_content()` read `PalaceRow`'s **raw** count fields. Since #4640 a
never-opened ("cold") palace carries zeroed placeholder counts, so the gate
returned `false` for every one of them and the palace was dropped by
`filtered_sorted_palaces` (`view.rs:105`), `visible_palace_ids` (`view.rs:120`),
and both navigation helpers — **before any renderer ever saw it**.

That made the `—` rendering PR #4684 added structurally unreachable in the
interactive TUI: `counts_unknown == true` and `palace_has_content() == false`
were equivalent, so the `format_opt_count(None)` call sites could only ever fire
on the dashboard/CLI paths.

Closes #4690.

## Mechanism — the accessors, as proposed

I kept the mechanism the issue proposed (read through `vectors()` /
`kg_triples()` / `drawers()`) rather than removing the filter or pushing the
decision to the call sites. Reasons:

- The filter has a real, still-valid job: a *measured*-empty palace is noise.
  Removing it entirely would regress `test_filter_empty_palaces` semantics that
  nothing in #4690 asks to change.
- Four call sites (`filtered_sorted_palaces`, `visible_palace_ids`,
  `navigate_up_visible`, `navigate_down_visible`) share the predicate. Pushing
  the unknown-vs-empty decision out to each of them multiplies the rule by four
  and invites exactly the drift that produced this bug.

`crates/trusty-common/src/monitor/memory_tui/view.rs:68`:

```rust
pub fn palace_has_content(palace: &PalaceRow) -> bool {
    // `None` (unknown) keeps the palace; `Some(0)` (measured empty) does not.
    let keeps = |count: Option<u64>| count.is_none_or(|n| n > 0);
    keeps(palace.vectors()) || keeps(palace.kg_triples()) || keeps(palace.drawers())
}
```

Resulting semantics:

| Counts | Before | After |
|---|---|---|
| UNKNOWN (`counts_unknown`) | hidden | **visible**, rendered `—` |
| KNOWN, all zero | hidden | hidden (unchanged) |
| KNOWN, any non-zero | visible | visible (unchanged) |

## Blast radius — the ~2,180-palace flood no longer applies

Issue #4690 warns this "will surface ~2,180 previously-hidden palaces and needs
live verification that the list stays usable at that size." **That is no longer
true.** Those palaces were purged earlier today; the corpus went from 2,183 to
**126** palaces. A reviewer reading #4690 will expect the old blast radius —
it is now a small, eyeball-verifiable visibility change.

## Known adjacent gap (not fixed here)

`PalaceRow`'s `ListItem::count()` still returns the raw `vector_count`, so sorting
by Vectors treats a cold palace as `0` and clusters cold palaces with the
measured-empty ones. That is a sort-ordering nit, not a visibility bug, and it is
out of scope for #4690.

## Tests

Three new tests in `crates/trusty-common/src/monitor/memory_tui/tests.rs`:

- `test_palace_has_content_semantics` — all three cases against the predicate
  directly, including the kg-only and drawer-only measured-non-zero legs.
- `test_cold_palace_visible` — the cold palace survives `filtered_sorted_palaces`,
  the measured-empty one does not, and the rendered row actually contains
  `UNKNOWN_COUNT` (`—`) — i.e. the #4684 path is reachable now.
- `test_cold_palace_navigable` — `visible_palace_ids` lists the cold palace and
  `navigate_down_visible` / `navigate_up_visible` can land the cursor on it,
  while the measured-empty palace stays unaddressable.

### Mutation check

Each mutation was applied to `view.rs`, the suite run, then the file restored
from a scratchpad backup (verified by `shasum`, not `git checkout`).

| Mutation | Tests that went red |
|---|---|
| **A** — revert to the raw fields (`vector_count > 0 \|\| …`), i.e. the pre-fix bug | `test_palace_has_content_semantics`, `test_cold_palace_visible`, `test_cold_palace_navigable` |
| **B** — drop the gate entirely (`true`) | the three above **+** `test_filter_empty_palaces` |
| **C** — vectors-only gate (drop the kg-triple and drawer legs) | `test_palace_has_content_semantics`, `test_filter_empty_palaces`, `test_all_selector`, `test_palace_lines` |

Mutation A is the important one: it is exactly the code this PR replaces, and all
three new tests catch it.

## Gates — Test Ladder rung 3 (localized behavior inside one crate)

```
$ cargo check -p trusty-common
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.94s

$ cargo test -p trusty-common
test result: ok. 241 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.71s

$ cargo test -p trusty-common --features monitor-tui
test result: ok. 404 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.72s

$ cargo clippy -p trusty-common --features monitor-tui --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.82s

$ cargo fmt --check
(clean — exit 0)

$ bash scripts/check_line_cap.sh
line-cap: measured 3603 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_changelog_fragment.sh
OK   trusty-common: changelog.d fragment present and valid
changelog-fragment gate: scanned 3 changed path(s); all 1 crate(s) with source changes are recorded.

$ bash scripts/check_sld.sh
sld-lint: scanned 54 spec doc(s) + 3029 code file(s); 0 error(s), 0 warning(s)
```

## Not verified

I did **not** run the TUI against the live daemon — this is a headless
environment. The em-dash rendering is asserted in `test_cold_palace_visible`
against `palace_lines()`, which is the same content the renderer draws, but
on-screen confirmation against the 126-palace corpus is still worth an eyeball
before this is considered fully closed.

## Changelog

`crates/trusty-common/changelog.d/4690-cold-palace-visibility.md` — single
`Fixed` category, per the one-category-per-fragment rule.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
