### PR TITLE
fix(ci): blame the right diff, and re-check main on the registry's clock (#4688)

### DIFF
--- a/.github/workflows/version-parity.yml
+++ b/.github/workflows/version-parity.yml
@@ -21,16 +21,37 @@
 #    scripts/check-pr-version-bump.sh's header for why this option was chosen
 #    over running the full parity check on PRs.
 #
-# 2. `version-parity` (PUSH TO MAIN) — unchanged, and still the authority. It
-#    diffs the real published tarball against the real merged tree and fails
-#    CLOSED, including when the registry is unreachable. The PR-time guard is
-#    an early warning, not a replacement: it warns rather than fails on a
-#    registry outage precisely because this job is still behind it.
+# 2. `version-parity` (PUSH TO MAIN **AND ON A SCHEDULE**, #4688) — still the
+#    authority. It diffs the real published tarball against the real merged
+#    tree and fails CLOSED, including when the registry is unreachable. The
+#    PR-time guard is an early warning, not a replacement: it warns rather than
+#    fails on a registry outage precisely because this job is still behind it.
+#
+#    WHY IT ALSO RUNS ON A SCHEDULE (#4688). This job answers a question about
+#    TWO moving parts — main's tree and crates.io — but only ever fired when
+#    ONE of them moved. `cargo publish` happens out of band from a maintainer's
+#    machine, so a green main can go drifted with no commit to trigger anything.
+#    That is exactly the 2026-08-03 sequence: the run at 1ec38321 passed at
+#    17:13Z, `trusty-common 0.27.0` went live at 17:21:48Z, and main was not
+#    re-evaluated until the next unrelated push. A cron re-asks the question on
+#    the registry's clock instead of the repo's, so a publish cannot open a
+#    silent window.
+#
+# 3. `notify-main-drift` (#4688) — files/refreshes a tracking issue when the
+#    main-side job does not come out green, mirroring ci.yml's
+#    `notify-main-failure` (#4179). Drift on main is everyone's problem the
+#    moment it exists; a red square on a scheduled run nobody is watching is
+#    not "loudly".
 name: Version parity
 
 on:
   push:
     branches: [main]
+  # Every three hours. Fine-grained enough that a publish is caught in one
+  # working session, coarse enough to stay well inside crates.io's API-usage
+  # policy (~21 sparse-index GETs + a tarball per published crate, per run).
+  schedule:
+    - cron: "17 */3 * * *"
   pull_request:
     # Explicit activity types (#4179). `edited` is NOT in GitHub's default set
     # (opened/synchronize/reopened) and is the event a base-branch RETARGET
@@ -75,9 +96,23 @@ jobs:
       - name: Scan-floor selftest (must refuse an empty scan)
         run: bash scripts/check_scan_floor_selftest.sh pr_version_bump
 
+      # #4688: diff against the base branch AS IT IS NOW, not the frozen
+      # `base.sha` snapshot. checkout leaves refs/remotes/origin/<base> at
+      # whatever it fetched; re-fetching pins it to the live tip so the merge
+      # base cannot lag behind the merge ref's own first parent. See the
+      # ATTRIBUTION note in scripts/check-pr-version-bump.sh for the failure
+      # this removes (PR #4666 / run 30839255128).
+      - name: Refresh the base branch ref
+        run: |
+          git fetch --no-tags --quiet origin \
+            "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          git rev-parse --verify "refs/remotes/origin/${BASE_REF}"
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+
       - name: Check PR version bumps against crates.io
         env:
-          PR_VERSION_BUMP_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_VERSION_BUMP_BASE: origin/${{ github.event.pull_request.base.ref }}
         run: bash scripts/check-pr-version-bump.sh
 
   # Post-merge authority (#3366). Quoted `name:` — an unquoted ` #` opens a
@@ -102,3 +137,69 @@ jobs:
 
       - name: Run version-parity guard
         run: bash scripts/check-version-parity.sh
+
+  # Loudness (#4688). Without this, drift discovered by a SCHEDULED run is a red
+  # square on a workflow nobody opened — the exact failure mode #4179 fixed for
+  # ci.yml. `always()` so the job still reports when `version-parity` fails,
+  # is cancelled, or is skipped; a non-green verdict is never silence.
+  notify-main-drift:
+    name: Notify on version drift on main
+    if: always() && github.event_name != 'pull_request'
+    needs: [version-parity]
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      issues: write
+    steps:
+      - name: File or update tracking issue
+        if: needs.version-parity.result != 'success'
+        uses: actions/github-script@v7
+        env:
+          PARITY_RESULT: ${{ needs.version-parity.result }}
+        with:
+          script: |
+            const label = 'version-drift-main';
+            const title = 'Version-parity drift on main';
+            const result = process.env.PARITY_RESULT;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const body = [
+              result === 'failure'
+                ? `Version-parity FAILED on \`main\` at ${context.sha} (trigger: ${context.eventName}).`
+                : `Version parity did NOT conclude on \`main\` at ${context.sha} (result: ${result}, trigger: ${context.eventName}).`,
+              '',
+              'A publishable crate\'s `src/**` no longer matches the crates.io tarball for the',
+              'version its own Cargo.toml declares, or the check could not verify that it does.',
+              'Bump the affected crate before the next release; `cargo publish` will otherwise',
+              'fail, or ship source nobody reviewed under a version number that is already out.',
+              '',
+              'This can appear with NO new commit: publishing to crates.io moves the other half',
+              'of the comparison (issue #4688).',
+              '',
+              `Run: ${runUrl}`,
+            ].join('\n');
+
+            const existing = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: label,
+            });
+
+            if (existing.data.length > 0) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: existing.data[0].number,
+                body,
+              });
+              core.notice(`Updated existing tracking issue #${existing.data[0].number}`);
+            } else {
+              const created = await github.rest.issues.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title,
+                body,
+                labels: [label],
+              });
+              core.notice(`Filed tracking issue #${created.data.number}`);
+            }

--- a/scripts/check-ci-helpers-selftest.sh
+++ b/scripts/check-ci-helpers-selftest.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # check-ci-helpers-selftest.sh — regression fixtures for the CI helper scripts
-# (issues #4179, #4468, #4421).
+# (issues #4179, #4468, #4421, #4688).
 #
 # Why: the three helpers this covers each encode a decision that is invisible
 #   until it is WRONG in production — a cancelled run reported as green, a
@@ -14,7 +14,11 @@
 # What: asserts the exact mapping each helper produces:
 #   classify-ci-results: every conclusion value, alone and in precedence pairs
 #   detect-docs-only:    docs-only / code-only / mixed / embedded-asset / empty
-#   check-pr-version-bump: registry-decision branches, via the stub oracle
+#   check-pr-version-bump: registry-decision branches, via the stub oracle, plus
+#                        the #4688 attribution pair — one tree run twice, once
+#                        from a frozen stale base (misattributes) and once from
+#                        the live base branch (does not) — and the workflow
+#                        wiring that decides which of the two CI gets.
 #
 # Usage: bash scripts/check-ci-helpers-selftest.sh
 # Exit: 0 when every case matches; 1 on the first mismatch, printing both sides.
@@ -164,13 +168,14 @@ EOF
   git -C "${dir}" commit -qm head
 }
 
+# run_gate <dir> <stub> [base-ref]  — base defaults to the `base-ref` branch.
 run_gate() {
-  local dir="$1" stub="$2"
+  local dir="$1" stub="$2" base="${3:-base-ref}"
   mkdir -p "${dir}/scripts"
   cp scripts/check-pr-version-bump.sh "${dir}/scripts/check-pr-version-bump.sh"
   (
     cd "${dir}" &&
-      PR_VERSION_BUMP_BASE=base-ref \
+      PR_VERSION_BUMP_BASE="${base}" \
         PR_VERSION_BUMP_REGISTRY_STUB="${stub}" \
         bash scripts/check-pr-version-bump.sh >/dev/null 2>&1
     echo "$?"
@@ -196,6 +201,70 @@ assert_eq "publish = false -> skipped, pass" "0" \
 make_fixture_repo "${STUB_DIR}/offline" "1.0.0" ""
 assert_eq "registry unreachable -> warn, pass" "0" \
   "$(run_gate "${STUB_DIR}/offline" "${STUB_DIR}/unreachable.sh")"
+
+# --- Attribution (#4688) ------------------------------------------------------
+# The shape that failed docs-only PR #4666: the base branch itself changes a
+# published crate's src, and an unrelated branch is checked out as a MERGE REF
+# (`refs/pull/N/merge`) whose first parent is that same base tip. The PR's own
+# diff contains no crate source at all, so the gate must clear it. It used to
+# fail, because the base it diffed from was a frozen `base.sha` predating the
+# base branch's own commits rather than the branch tip.
+make_misattribution_repo() {
+  local dir="$1"
+  rm -rf "${dir}"
+  mkdir -p "${dir}/crates/pinned-crate/src" "${dir}/docs"
+  git -C "${dir}" init -q -b base-ref
+  git -C "${dir}" config user.email ci@example.com
+  git -C "${dir}" config user.name ci
+  cat >"${dir}/crates/pinned-crate/Cargo.toml" <<'EOF'
+[package]
+name = "pinned-crate"
+version = "1.0.0"
+EOF
+  echo "// base" >"${dir}/crates/pinned-crate/src/lib.rs"
+  echo "docs" >"${dir}/docs/readme.md"
+  git -C "${dir}" add -A
+  git -C "${dir}" commit -qm "shared ancestor"
+  # An unrelated branch forks HERE, touching documentation only...
+  git -C "${dir}" branch -q pr-branch
+  # ...and this is the base tip a `base.sha` snapshot would have frozen.
+  git -C "${dir}" branch -q shared-ancestor
+  # ...then the base branch drifts pinned-crate's src with no version bump.
+  echo "// changed on the base branch" >>"${dir}/crates/pinned-crate/src/lib.rs"
+  git -C "${dir}" add -A
+  git -C "${dir}" commit -qm "base branch changes pinned-crate/src"
+  git -C "${dir}" checkout -q pr-branch
+  echo "more docs" >>"${dir}/docs/readme.md"
+  git -C "${dir}" add -A
+  git -C "${dir}" commit -qm "docs only"
+  # What actions/checkout hands the job on a pull_request event.
+  git -C "${dir}" checkout -q --detach base-ref
+  git -C "${dir}" merge -q --no-ff --no-edit pr-branch
+}
+
+make_misattribution_repo "${STUB_DIR}/misattributed"
+# The two halves of #4688, on ONE tree, so the difference is the base ref alone.
+# `shared-ancestor` stands in for a frozen `github.event.pull_request.base.sha`
+# that the base branch has since moved past: the gate then sweeps the base
+# branch's own commit into the PR's diff and blames it. Asserted as a FAILURE on
+# purpose — it is the defect, and it is why the workflow must never pass a
+# frozen SHA (guarded below by `workflow passes a base BRANCH, not base.sha`).
+assert_eq "frozen stale base -> misattributes (the #4688 defect)" "1" \
+  "$(run_gate "${STUB_DIR}/misattributed" "${STUB_DIR}/published.sh" shared-ancestor)"
+assert_eq "live base branch -> docs-only PR not blamed" "0" \
+  "$(run_gate "${STUB_DIR}/misattributed" "${STUB_DIR}/published.sh" base-ref)"
+
+# Wiring guard: the behavioural fix above is only delivered if the workflow
+# actually hands the gate a branch. Assert the wiring, not just the script.
+version_parity_wf=".github/workflows/version-parity.yml"
+assert_eq "workflow passes a base BRANCH, not base.sha" "1" \
+  "$(grep -c 'PR_VERSION_BUMP_BASE: origin/\${{ github.event.pull_request.base.ref }}' \
+    "${version_parity_wf}" || true)"
+assert_eq "workflow no longer passes the frozen base.sha" "0" \
+  "$(grep -c 'PR_VERSION_BUMP_BASE: \${{ github.event.pull_request.base.sha }}' \
+    "${version_parity_wf}" || true)"
+assert_eq "main-side parity also runs on a schedule (#4688)" "1" \
+  "$(grep -c '^  schedule:' "${version_parity_wf}" || true)"
 
 echo
 if [ "${FAILURES}" -gt 0 ]; then

--- a/scripts/check-pr-version-bump.sh
+++ b/scripts/check-pr-version-bump.sh
@@ -44,8 +44,32 @@
 #   fail-closed authority, so a registry outage costs late detection (today's
 #   status quo) instead of blocking every PR in the repo.
 #
+# ATTRIBUTION (issue #4688). `PR_VERSION_BUMP_BASE` must name the base BRANCH
+#   as it exists NOW (`origin/main`), never a frozen commit SHA. The gate blames
+#   whatever `git merge-base BASE HEAD`..HEAD contains, so the base ref decides
+#   which commits are "the PR's". `github.event.pull_request.base.sha` — what
+#   this gate originally used — is the base tip recorded when the PR was last
+#   opened/synchronized, and it goes stale the moment anything else merges.
+#   Meanwhile `actions/checkout` resolves a `pull_request` event to
+#   `refs/pull/N/merge`, whose first parent is CURRENT main. Pair a stale base
+#   with a current merge ref and the diff spans every commit main took in
+#   between, so the gate reports another author's crate as this PR's drift.
+#
+#   That is not hypothetical: run 30839255128 failed PR #4666 — a docs-only
+#   change to two files under docs/specs/ — with
+#   `[FAIL] trusty-common 0.27.0`, because its merge base resolved to
+#   4e7d7073, ~20 commits behind main. Rebasing "fixed" it only by moving the
+#   base past the innocent commits. Against the live branch tip the merge base
+#   IS main's tip (the merge ref's own first parent), so the diff is exactly
+#   what the PR contributes to the merged result — no more, no less.
+#
+#   Keeping the MERGE REF as HEAD is deliberate and separate from the base
+#   question: it evaluates the post-merge tree, so a PR that touches
+#   `crates/X/src/**` while main independently bumps X reads the bumped version
+#   and passes, which checking the raw PR head would get wrong.
+#
 # Usage:
-#   PR_VERSION_BUMP_BASE=<ref> bash scripts/check-pr-version-bump.sh
+#   PR_VERSION_BUMP_BASE=<base-branch-ref> bash scripts/check-pr-version-bump.sh
 #
 # Exit: 0 when every touched crate is clear (or only warnings were raised);
 #   1 when at least one crate changed source under an already-published version,
@@ -212,6 +236,14 @@ main() {
         echo "       published on crates.io, and Cargo.toml was not bumped. Merging this"
         echo "       turns main's 'Version parity' workflow red (issues #4421, #3366)."
         echo "       Fix: bump ${manifest}'s version (patch/minor/major per the change)."
+        # Name the commits instead of asserting the PR owns them (#4688). A
+        # blamed author previously had no way to tell "my change" from "main's
+        # change swept in by a stale base" without bisecting by hand; #4666 cost
+        # exactly that. If these subjects are not yours, the base ref is wrong —
+        # see the ATTRIBUTION note in this file's header.
+        echo "       Commits in ${merge_base:0:10}..HEAD touching crates/${crate}/src/:"
+        git log --no-merges --format='         %h %s' \
+          "${merge_base}..HEAD" -- "crates/${crate}/src/" || true
         failures=$((failures + 1))
         ;;
       *)


### PR DESCRIPTION
Closes #4688.

## Part A — no bump is warranted, and no drift ever existed

The issue's premise ("main currently carries trusty-common src changes at published 0.27.0") does not survive checking. Evidence:

```
$ diff -r <published trusty-common-0.27.0 tarball>/src  <main@745abaea>/crates/trusty-common/src
IDENTICAL — no real drift ever existed at 0.27.0
```

`0.27.0` was bumped at `eb7175ec` but **published at 17:21:48Z on 2026-08-03**, from a main that already contained `16f27faf`, `0c0de180`, `94a4fdf2`, and `1ec38321`. The tarball therefore *includes* the "culprit" commits. That is why every post-merge `Publish-version parity` run on main stayed green throughout — correctly.

Current state, from the fail-closed authority:

```
$ bash scripts/check-version-parity.sh
[ OK ] trusty-common 0.28.1 — not yet published, nothing to compare
publish-guard: checked 21 publishable crate(s) (floor 10) — 0 drifted, 0 unverifiable.
publish-guard: OK — no version-parity drift detected.
```

`trusty-common` is at **0.28.1**, unpublished (highest live is 0.28.0). `5f7f1b0e` and `9cdc0c48` bumped it in the interim. **No `Cargo.toml` bump, no `Cargo.lock` change, no CHANGELOG entry** — inventing a 0.28.2 would stack a bump on an already-unpublished version for a drift that was never real.

## Part B(a) — misattribution

The gate diffed from `github.event.pull_request.base.sha`: the base tip frozen when the PR was last opened/synchronized. `actions/checkout` resolves a `pull_request` to `refs/pull/N/merge`, whose **first parent is current main**. The two diverge the moment anything else merges, and the diff then spans every commit main took in between.

Run `30839255128` failed PR #4666 — two files under `docs/specs/` — with `[FAIL] trusty-common 0.27.0`, from a merge base ~20 commits stale. Rebasing "fixed" it only by moving the base past the innocent commits.

**Fix:** diff from the base **branch as it is now** (`origin/<base.ref>`, re-fetched). The merge base is then the merge ref's own first parent, so the range is exactly what the PR contributes. HEAD stays the merge ref deliberately — it evaluates the *post-merge* tree, so a PR touching `crates/X/src/**` while main independently bumps X reads the bumped version and passes; checking the raw PR head would get that wrong.

The gate also now **names the commits** that touched the crate's src on failure. #4666's author had no way to separate "my change" from "main's change" without bisecting.

## Part B(b) — main-side visibility

The post-merge authority compares **two** moving parts (main's tree, crates.io) but only ever fired when **one** moved. `cargo publish` happens out of band, so a green main can go drifted with no commit to trigger anything — exactly the 2026-08-03 sequence: parity passed at `1ec38321` 17:13Z, `trusty-common 0.27.0` went live at 17:21:48Z, nothing re-asked until an unrelated push.

- **`schedule:` (3-hourly)** on `version-parity.yml` — re-asks on the registry's clock, not the repo's.
- **`notify-main-drift`** — files/refreshes a `version-drift-main` tracking issue when the main-side job is not green, mirroring `ci.yml`'s `notify-main-failure` (#4179). A red square on a scheduled run nobody opened is not "loudly".

I deliberately did **not** add a second, git-history-based main gate. It would duplicate an authority that already runs on push and fails closed, and would false-positive on exactly the pattern above (src landing under a version whose publish lags the bump commit) — the same heuristic error that produced this issue.

## Validation — raw before/after

Faithful reconstruction of run `30839255128`: docs-only branch off `4e7d7073` (the base.sha that run used), merged into main tip `9e025f0d` to reproduce `refs/pull/N/merge`.

**BEFORE** — frozen `base.sha`, byte-identical to the real failure:

```
Merge base: 4e7d70733fdf84aff884de29cddac36efd734e7d
[ OK ] trusty-code 0.3.0 — src changed, version not yet published
[FAIL] trusty-common 0.27.0 — src/** changed under a version that is ALREADY
       published on crates.io, and Cargo.toml was not bumped.
[ OK ] trusty-memory 0.22.0 — src changed, version not yet published
[ OK ] trusty-mpm — version bumped 1.3.2 -> 1.3.4
check-pr-version-bump: 1 crate(s) would drift on merge.
exit=1
```

**AFTER** — same tree, base = live base branch:

```
Merge base: 9e025f0d4ec1313820b8ce3903b6c884e9115f60
[ OK ] 1 changed path(s) examined; none under crates/<crate>/src/**
exit=0
```

**Regression guard** — the gate must still catch real drift. Branch off `745abaea` (trusty-common at published 0.27.0), touch `src/lib.rs`, no bump:

```
[FAIL] trusty-common 0.27.0 — src/** changed under a version that is ALREADY
       published on crates.io, and Cargo.toml was not bumped.
       Commits in 745abaea6b..HEAD touching crates/trusty-common/src/:
         3b530834 feat(trusty-common): touch src without bumping the version
check-pr-version-bump: 1 crate(s) would drift on merge.
exit=1
```

Both halves are now locked into `scripts/check-ci-helpers-selftest.sh` as one tree run twice, so the difference is the base ref alone — plus wiring assertions so the workflow cannot regress to `base.sha` or lose the schedule:

```
  ok   frozen stale base -> misattributes (the #4688 defect)      -> 1
  ok   live base branch -> docs-only PR not blamed                -> 0
  ok   workflow passes a base BRANCH, not base.sha                -> 1
  ok   workflow no longer passes the frozen base.sha              -> 0
  ok   main-side parity also runs on a schedule (#4688)           -> 1
check-ci-helpers-selftest: all 47 cases passed
```

## Gates

```
cargo fmt --check                                    exit 0
cargo check --workspace                              Finished dev profile in 2m 19s
cargo clippy -p trusty-common --all-targets -D warn  Finished in 12.74s
cargo test -p trusty-common                          241 passed; 0 failed; 6 ignored
bash scripts/check_line_cap.sh                       3603 files, 0 violations — OK
bash scripts/check_scan_floor_selftest.sh            1 gate correctly refuses a vacuous scan
bash scripts/check_changelog_fragment.sh             no crate source changed (CI-only) — OK
actionlint .github/workflows/version-parity.yml      OK
```

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools