### PR TITLE
fix(trusty-search): recover an empty-warm-booted vector layer and stop reporting it ready (#4707)

### DIFF
--- a/crates/trusty-search/changelog.d/4707-vector-warmboot-recovery.md
+++ b/crates/trusty-search/changelog.d/4707-vector-warmboot-recovery.md
@@ -1,0 +1,29 @@
+Fixed
+
+- An index whose vector layer warm-booted empty is no longer left permanently
+  broken while still self-reporting `ready`. Two defects combined: the vector
+  layer never recovered, and the status surface never admitted it
+  ([#4707](https://github.com/bobmatnyc/trusty-tools/issues/4707)).
+  - **Recovery.** When warm-boot's `UsearchStore::load_from` discards a snapshot
+    (the `#2922` size floor, a corrupt sidecar, the `#3970` torn-pairing guard)
+    the store falls back to a fresh empty one. Every later save of that empty
+    store was then correctly refused by the `#1711` data-loss guard — and
+    nothing further happened, so the index served zero vectors forever with an
+    intact snapshot sitting on disk. After refusing the write, `save()` now
+    adopts that on-disk snapshot, so the vector lane recovers without a reindex.
+    The `#1711` guard is unchanged and nothing is ever written on that path;
+    adoption only moves in-memory state towards what is already durable, and
+    reuses `load_from`, so a truncated or torn snapshot is rejected by exactly
+    the code that rejects it at warm-boot. The `#1717` shrink refusal
+    deliberately does not recover this way — a partial in-memory index may hold
+    vectors disk does not.
+  - **Honest health.** The semantic stage is no longer published as `ready`
+    when the live vector store holds zero vectors, a corpus exists, and an
+    embedder is wired. An all-hash-skipped incremental reindex legitimately
+    embeds nothing (`#868`), and both the fast pass and the deferred-embed pass
+    marked `ready` on that basis without ever consulting the store they were
+    vouching for. The stage now reports `failed` with an actionable reason, so
+    `search_capabilities` stops advertising `vector` and the search handler
+    keeps down-shifting queries to the working lexical lane instead of routing
+    them through a query-embed step whose failure surfaced as
+    `500 internal search error` on every query.

--- a/crates/trusty-search/src/core/indexer/persist_hnsw.rs
+++ b/crates/trusty-search/src/core/indexer/persist_hnsw.rs
@@ -83,9 +83,10 @@ impl CodeIndexer {
     /// incremental reindex was marked `semantic: ready` while holding zero
     /// vectors. This accessor is the ground truth those markers must check.
     /// What: one read-lock + `Index::size()` on the wired store.
-    /// Test: `service::reindex::stages::tests::semantic_health_reason_*` drive
-    /// the predicate this feeds; the accessor itself is exercised by every
-    /// reindex integration test.
+    /// Test: `semantic_stage_reports_failed_when_live_store_is_empty` and
+    /// `semantic_stage_still_ready_when_store_is_populated` (in
+    /// `service::reindex::stages::tests`) drive the gate this feeds; the
+    /// accessor itself is exercised by every reindex integration test.
     pub async fn vector_count(&self) -> Option<usize> {
         let store = self.store.as_ref()?;
         store.len().await.ok()

--- a/crates/trusty-search/src/core/indexer/persist_hnsw.rs
+++ b/crates/trusty-search/src/core/indexer/persist_hnsw.rs
@@ -72,6 +72,25 @@ impl CodeIndexer {
         self.store = Some(store);
     }
 
+    /// Number of vectors the LIVE vector store currently holds, or `None` when
+    /// no store is wired (BM25-only / test indexer).
+    ///
+    /// Why (issue #4707): every existing semantic-readiness signal is
+    /// bookkeeping — a stage counter written at warm-boot or at the end of a
+    /// reindex — and none of them is ever reconciled against the store that
+    /// actually answers queries. An index whose warm-boot fell back to an
+    /// empty store (`hnsw_load_failed`) and then saw an all-hash-skipped
+    /// incremental reindex was marked `semantic: ready` while holding zero
+    /// vectors. This accessor is the ground truth those markers must check.
+    /// What: one read-lock + `Index::size()` on the wired store.
+    /// Test: `service::reindex::stages::tests::semantic_health_reason_*` drive
+    /// the predicate this feeds; the accessor itself is exercised by every
+    /// reindex integration test.
+    pub async fn vector_count(&self) -> Option<usize> {
+        let store = self.store.as_ref()?;
+        store.len().await.ok()
+    }
+
     /// Compose the BM25 document text for a chunk: body + virtual_terms,
     /// matching the layout the per-query rebuild used to construct.
     pub(crate) fn bm25_doc_text(chunk: &RawChunk) -> String {

--- a/crates/trusty-search/src/core/store/mod.rs
+++ b/crates/trusty-search/src/core/store/mod.rs
@@ -12,6 +12,9 @@ pub(crate) mod path_match;
 mod tests;
 mod types;
 mod usearch_impl;
+// Issue #4707: snapshot-adoption recovery for the #1711 guard. Kept in its own
+// file so `usearch_store.rs` stays under the 500-SLOC production cap.
+mod usearch_recover;
 mod usearch_store;
 
 pub use self::types::{VectorHit, VectorStore};

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -1173,3 +1173,159 @@ async fn test_filtered_search_excludes_non_matching_keys() {
         "no repoB chunk may leak through the filter: {hits:?}"
     );
 }
+
+/// Build a REAL populated snapshot on disk whose `.usearch` binary exceeds
+/// `POPULATED_SNAPSHOT_THRESHOLD_BYTES`, so the #1711 guard will fire against
+/// it. Returns `(path, chunk_ids, query_vector)`.
+///
+/// Why (issue #4707): the pre-existing #1711 test writes a byte-filler file,
+/// which is enough to prove the guard REFUSES but can never prove recovery —
+/// there is no loadable snapshot to recover from. Reproducing the reported
+/// state needs the real thing: a valid, populated binary + sidecar pair that
+/// `UsearchStore::load_from` accepts, paired with a live store holding zero
+/// vectors. That is exactly the partial warm-boot in the incident.
+/// What: upserts `n` distinct dim-4 vectors and saves. Asserts the resulting
+/// file really is over the guard threshold, so a future change to usearch's
+/// on-disk layout makes this fixture fail loudly instead of silently
+/// producing a sub-threshold file that never trips the guard under test.
+async fn populated_snapshot_over_guard_threshold(
+    dir: &std::path::Path,
+    n: usize,
+) -> (std::path::PathBuf, Vec<String>, Vec<f32>) {
+    let path = dir.join("hnsw.usearch");
+    let store = UsearchStore::new(4).expect("store init");
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let id = format!("src/file{i}.rs:1:9");
+        let f = i as f32;
+        store
+            .upsert(&id, vec![1.0 + f, 0.5 - f, 0.25, 2.0 + f])
+            .await
+            .expect("upsert");
+        ids.push(id);
+    }
+    store.save(&path).await.expect("save populated snapshot");
+
+    let size = std::fs::metadata(&path).expect("stat snapshot").len();
+    assert!(
+        size > POPULATED_SNAPSHOT_THRESHOLD_BYTES,
+        "fixture precondition: the snapshot must exceed the #1711 guard \
+         threshold ({POPULATED_SNAPSHOT_THRESHOLD_BYTES} bytes) or the guard \
+         under test never fires; got {size} bytes for {n} vectors"
+    );
+    assert!(
+        path.with_extension("keys.json").exists(),
+        "fixture precondition: sidecar must exist"
+    );
+    (path, ids, vec![1.0, 0.5, 0.25, 2.0])
+}
+
+/// Why (issue #4707): THE regression test. An index whose vector layer
+/// warm-boots empty while a populated snapshot sits on disk must recover from
+/// that snapshot rather than stay permanently vectorless. Before this fix the
+/// #1711 guard refused the overwrite (correctly, preserving the data) and then
+/// nothing else happened — the empty store kept serving zero vectors forever.
+/// What: builds a real populated snapshot, then simulates the partial warm-boot
+/// by pointing a FRESH EMPTY store at that same path and saving. Asserts three
+/// things at once: the guard still preserved the on-disk bytes (the #1711
+/// contract is NOT weakened), the live store recovered its vectors, and a real
+/// search against the recovered store returns the original chunk ids.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_save_refusal_adopts_populated_snapshot() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, ids, query) = populated_snapshot_over_guard_threshold(dir.path(), 900).await;
+    let before = std::fs::read(&path).expect("read snapshot");
+
+    // The partial warm-boot: a fresh EMPTY store bound to a populated path.
+    let empty = UsearchStore::new(4).expect("store init");
+    assert_eq!(
+        empty.len().await.unwrap(),
+        0,
+        "precondition: the store must start empty (this is the warm-boot fallback state)"
+    );
+
+    empty.save(&path).await.expect("save must return Ok(())");
+
+    // 1. The #1711 contract is intact: nothing was written over the snapshot.
+    assert_eq!(
+        std::fs::read(&path).expect("re-read snapshot"),
+        before,
+        "the #1711 guard must still preserve the on-disk snapshot byte-for-byte — \
+         recovery must never come at the cost of the data-loss guard"
+    );
+
+    // 2. The store recovered rather than staying empty.
+    assert_eq!(
+        empty.len().await.unwrap(),
+        ids.len(),
+        "the store must have adopted the on-disk snapshot's vectors (issue #4707); \
+         0 here means the pre-fix behaviour — refused, then permanently vectorless"
+    );
+
+    // 3. The recovered store actually answers queries with the real chunk ids.
+    let hits = empty
+        .search(&query, 5)
+        .await
+        .expect("search recovered store");
+    assert!(
+        !hits.is_empty(),
+        "a recovered store must return hits, not an empty result set"
+    );
+    assert!(
+        hits.iter().all(|h| ids.contains(&h.chunk_id)),
+        "recovered hits must resolve to the original chunk ids (the key sidecar \
+         must have been rehydrated too, not just the vector graph): {hits:?}"
+    );
+}
+
+/// Why (issue #4707): recovery must be honest about its own failure. When the
+/// on-disk snapshot is NOT adoptable — here, its sidecar is gone, so
+/// `load_from` discards it — the store must stay empty and report so, never
+/// claim a recovery it did not perform. A silent false-positive here would be
+/// worse than the original bug: it would mark the semantic lane healthy.
+/// What: builds a real populated snapshot, deletes the sidecar, then saves an
+/// empty store over it. Asserts the guard preserved the binary AND the store
+/// is still empty.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_adopt_declines_when_snapshot_is_unrecoverable() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, _ids, _query) = populated_snapshot_over_guard_threshold(dir.path(), 900).await;
+    std::fs::remove_file(path.with_extension("keys.json")).expect("remove sidecar");
+    let before = std::fs::read(&path).expect("read snapshot");
+
+    let empty = UsearchStore::new(4).expect("store init");
+    empty.save(&path).await.expect("save must return Ok(())");
+
+    assert_eq!(
+        std::fs::read(&path).expect("re-read snapshot"),
+        before,
+        "the on-disk binary must still be preserved when recovery declines"
+    );
+    assert_eq!(
+        empty.len().await.unwrap(),
+        0,
+        "an unrecoverable snapshot must leave the store empty — never a phantom recovery"
+    );
+}
+
+/// Why (issue #4707): adopting a snapshot built for a different embedding
+/// dimension would wire vectors the query path cannot search. Recovery must
+/// decline rather than corrupt the store.
+/// What: builds a dim-4 snapshot, then attempts recovery into a dim-8 store.
+/// Test: this IS the test.
+#[tokio::test]
+async fn test_adopt_declines_on_dim_mismatch() {
+    let dir = tempfile::tempdir().unwrap();
+    let (path, _ids, _query) = populated_snapshot_over_guard_threshold(dir.path(), 900).await;
+
+    let empty = UsearchStore::new(8).expect("store init");
+    empty.save(&path).await.expect("save must return Ok(())");
+
+    assert_eq!(
+        empty.len().await.unwrap(),
+        0,
+        "a dim-mismatched snapshot must never be adopted"
+    );
+}

--- a/crates/trusty-search/src/core/store/usearch_recover.rs
+++ b/crates/trusty-search/src/core/store/usearch_recover.rs
@@ -1,0 +1,156 @@
+//! Snapshot-adoption recovery for [`UsearchStore`] (issue #4707).
+//!
+//! Why: the #1711 data-loss guard in [`UsearchStore::save`] correctly refuses
+//! to overwrite a populated on-disk snapshot with an empty in-memory index —
+//! but before this module that refusal was the END of the story. The store
+//! stayed empty, every later save was refused for the same reason, and the
+//! index served zero vectors forever while a perfectly good snapshot sat on
+//! disk. Refusing the write protects the DATA; adopting the snapshot restores
+//! the SERVICE. Both are required.
+//! What: [`UsearchStore::adopt_on_disk_snapshot`] re-reads the on-disk
+//! snapshot through the ordinary [`UsearchStore::load_from`] path (so every
+//! existing discard guard — the #2922 size floor, the zero-vector-vs-populated
+//! sidecar check, the #3970 torn-pairing check — applies unchanged) and, only
+//! on a clean load, transplants that state into the live store.
+//! Test: `super::tests::test_save_refusal_adopts_populated_snapshot`,
+//! `super::tests::test_adopt_declines_when_snapshot_is_unrecoverable`,
+//! `super::tests::test_adopt_declines_on_dim_mismatch`.
+
+use std::path::Path;
+use std::sync::atomic::Ordering;
+
+use anyhow::{anyhow, Result};
+
+use super::super::store_config::MmapServeMode;
+use super::usearch_store::UsearchStore;
+
+/// Outcome of the guarded write inside [`UsearchStore::save`].
+///
+/// Why (issue #4707): `save` previously reported "did we write?" as a bare
+/// `bool`, which collapsed two very different refusals into one value. Only
+/// the #1711 empty-over-populated refusal is RECOVERABLE — it is precisely
+/// the case where the on-disk snapshot is known-good and strictly better than
+/// what is in memory, so adopting it is safe and correct. The #1717 shrink
+/// refusal is NOT: a partially-populated in-memory index may hold vectors the
+/// on-disk snapshot does not, so blindly adopting disk there would discard
+/// live state. Naming the two refusals apart is what lets `save` recover from
+/// exactly one of them.
+/// Test: exercised through `save` by the tests named in the module doc.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SaveVerdict {
+    /// The snapshot was written; the caller must finish the rename + sidecar.
+    Saved,
+    /// #1711: in-memory index is empty and the on-disk snapshot is populated.
+    /// Recoverable — the caller should adopt the on-disk snapshot.
+    RefusedEmptyOverPopulated,
+    /// #1717: in-memory index shrank catastrophically without explanation.
+    /// NOT recoverable by adoption — see the enum doc.
+    RefusedShrink,
+}
+
+impl UsearchStore {
+    /// Replace this store's in-memory HNSW state with the snapshot on disk at
+    /// `hnsw_path`, when that snapshot passes every ordinary load guard.
+    ///
+    /// Why (issue #4707): see the module doc. This is the recovery half of the
+    /// #1711 guard — the guard keeps the bytes, this restores the service.
+    ///
+    /// CRITICAL correctness: this method NEVER writes to disk and never
+    /// weakens the #1711 guard. It only ever moves in-memory state in one
+    /// direction — towards whatever is already durably on disk — so the worst
+    /// case is that it declines to act (`Ok(false)`) and the store is left
+    /// exactly as it was. Validation is not reimplemented here: the candidate
+    /// is loaded through [`UsearchStore::load_from`], so a truncated (#2922),
+    /// empty-versus-populated, or torn binary/sidecar pairing (#3970) snapshot
+    /// is rejected by the same code that rejects it at warm-boot, and can
+    /// never be adopted.
+    ///
+    /// What: loads the on-disk snapshot into a throwaway probe store; refuses
+    /// (`Ok(false)`) when the probe is absent/discarded by a guard, when its
+    /// dimensionality disagrees with this store's, or when it carries no
+    /// vectors at all (adopting an empty snapshot would be a no-op that
+    /// falsely reports recovery). Otherwise takes the probe's validated key
+    /// maps, drops the probe, and re-opens the same file on this store's own
+    /// `Index` handle — mirroring [`UsearchStore::try_demote_to_view`]'s
+    /// in-place `Index::view` — then publishes the maps and marks the store
+    /// clean (the in-memory graph now IS the on-disk snapshot). Honours
+    /// `TRUSTY_HNSW_MMAP_SERVE` exactly as `load_from` does.
+    ///
+    /// Test: see the module doc.
+    pub(super) async fn adopt_on_disk_snapshot(&self, hnsw_path: &Path) -> Result<bool> {
+        let path_str = hnsw_path
+            .to_str()
+            .ok_or_else(|| anyhow!("non-utf8 hnsw path: {}", hnsw_path.display()))?
+            .to_string();
+
+        // Load through the ordinary path so every discard guard applies.
+        let probe = match Self::load_from(hnsw_path).await {
+            Ok(Some(p)) => p,
+            Ok(None) => return Ok(false),
+            Err(e) => {
+                tracing::warn!(
+                    "usearch: cannot adopt snapshot {} — load failed ({e}) (issue #4707)",
+                    hnsw_path.display()
+                );
+                return Ok(false);
+            }
+        };
+        if probe.dim() != self.dim {
+            tracing::warn!(
+                "usearch: refusing to adopt snapshot {} — its dim is {} but this store is {} \
+                 (issue #4707)",
+                hnsw_path.display(),
+                probe.dim(),
+                self.dim
+            );
+            return Ok(false);
+        }
+
+        // Take the probe's validated maps rather than re-parsing the sidecar.
+        let new_id_to_key = std::mem::take(&mut *probe.id_to_key.write().await);
+        let new_key_to_id = std::mem::take(&mut *probe.key_to_id.write().await);
+        let new_next_key = probe.next_key.load(Ordering::Relaxed);
+        let restored = new_id_to_key.len();
+        // Release the probe (and its mmap) before re-opening the same file.
+        drop(probe);
+
+        if restored == 0 {
+            // Nothing to adopt. Reporting `true` here would claim a recovery
+            // that left the store just as empty as it started.
+            return Ok(false);
+        }
+
+        {
+            let index = self.index.write().await;
+            if let Err(e) = index.view(&path_str) {
+                tracing::warn!(
+                    "usearch: cannot adopt snapshot {} — view() failed ({e}); leaving the \
+                     store as it was (issue #4707)",
+                    hnsw_path.display()
+                );
+                return Ok(false);
+            }
+            let mut id_map = self.id_to_key.write().await;
+            let mut key_map = self.key_to_id.write().await;
+            *id_map = new_id_to_key;
+            *key_map = new_key_to_id;
+        }
+        self.next_key.store(new_next_key.max(1), Ordering::Relaxed);
+        self.is_view.store(true, Ordering::Release);
+        // The in-memory graph is now byte-for-byte the on-disk snapshot.
+        self.dirty.store(false, Ordering::Release);
+        *self.hnsw_path.write().await = Some(hnsw_path.to_path_buf());
+
+        if MmapServeMode::from_env().promote_on_load() {
+            self.promote_view_to_mutable().await?;
+        }
+
+        tracing::warn!(
+            "usearch: RECOVERED index from its on-disk snapshot {} ({restored} vectors) after \
+             an empty in-memory index was refused by the #1711 data-loss guard — the vector \
+             lane is queryable again without a reindex (issue #4707)",
+            hnsw_path.display(),
+        );
+        Ok(true)
+    }
+}

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -19,6 +19,7 @@ use usearch::{Index, IndexOptions, MetricKind};
 
 use super::super::store_config::{MmapServeMode, VectorQuant};
 use super::types::StoreKeyMap;
+use super::usearch_recover::SaveVerdict;
 
 /// Initial reserved capacity for a new HNSW index. Grows geometrically on demand.
 ///
@@ -438,6 +439,16 @@ impl UsearchStore {
     /// close the full window; the shutdown path's exact protection is
     /// `service::shutdown_flush::flush_one_index_on_shutdown`'s
     /// `ReindexStatus::Running` check.
+    ///
+    /// Recovery (issue #4707): the #1711 refusal above is not the end of the
+    /// story. An empty in-memory index paired with a populated on-disk
+    /// snapshot means the snapshot is strictly authoritative, so after
+    /// refusing the write this method adopts it via
+    /// [`Self::adopt_on_disk_snapshot`] — the vector lane recovers without a
+    /// reindex instead of serving zero vectors forever. The guard itself is
+    /// unchanged and nothing is ever written on that path. The #1717 shrink
+    /// refusal deliberately does NOT recover this way: a partial in-memory
+    /// index may hold vectors disk does not.
     /// Test: `tests::test_save_load_roundtrip` saves then loads into a fresh
     /// store and asserts a search still returns the original chunk_ids;
     /// `tests::test_save_refuses_to_overwrite_populated_snapshot_with_empty_index`
@@ -538,7 +549,7 @@ impl UsearchStore {
             let index_guard = self.index.clone().write_owned().await;
             let hnsw_path_owned = hnsw_path.to_path_buf();
             let removed_since_save = self.removed_since_save.clone();
-            let saved = tokio::task::spawn_blocking(move || -> Result<bool> {
+            let saved = tokio::task::spawn_blocking(move || -> Result<SaveVerdict> {
                 // Guard: check size under the write lock so there is no
                 // window between the check and the save call.
                 if index_guard.size() == 0 {
@@ -552,7 +563,7 @@ impl UsearchStore {
                                 hnsw_path_owned.display(),
                                 meta.len()
                             );
-                            return Ok(false);
+                            return Ok(SaveVerdict::RefusedEmptyOverPopulated);
                         }
                     }
                 }
@@ -587,7 +598,7 @@ impl UsearchStore {
                                 removed,
                                 explained_floor,
                             );
-                            return Ok(false);
+                            return Ok(SaveVerdict::RefusedShrink);
                         }
                     }
                 }
@@ -599,12 +610,39 @@ impl UsearchStore {
                 // clear the counter so future shrink checks only weigh
                 // removals that happen after this save.
                 removed_since_save.store(0, Ordering::Release);
-                Ok(true)
+                Ok(SaveVerdict::Saved)
             })
             .await
             .map_err(|e| anyhow!("usearch save task panicked: {e}"))??;
-            if !saved {
-                return Ok(());
+            match saved {
+                SaveVerdict::Saved => {}
+                // #1717: a partial in-memory index may hold vectors the
+                // on-disk snapshot lacks — adopting disk here could discard
+                // live state, so this refusal stays terminal.
+                SaveVerdict::RefusedShrink => return Ok(()),
+                // #4707: the empty-over-populated refusal above proves the
+                // on-disk snapshot is strictly better than what we hold. Take
+                // it, so the vector lane recovers without a reindex instead of
+                // serving zero vectors forever. The refusal itself stands —
+                // nothing was written — and adoption only ever moves in-memory
+                // state towards disk (see `adopt_on_disk_snapshot`).
+                SaveVerdict::RefusedEmptyOverPopulated => {
+                    match self.adopt_on_disk_snapshot(hnsw_path).await {
+                        Ok(true) => {}
+                        Ok(false) => tracing::error!(
+                            "usearch: index at {} is EMPTY in memory and its on-disk snapshot \
+                             could not be adopted — the vector lane is unrecoverable without a \
+                             reindex (issue #4707). Run `trusty-search index <path> --force`.",
+                            hnsw_path.display()
+                        ),
+                        Err(e) => tracing::error!(
+                            "usearch: recovery from on-disk snapshot {} failed ({e}) — the \
+                             vector lane is unrecoverable without a reindex (issue #4707)",
+                            hnsw_path.display()
+                        ),
+                    }
+                    return Ok(());
+                }
             }
         }
         std::fs::rename(&tmp_hnsw, hnsw_path).map_err(|e| anyhow!("rename hnsw snapshot: {e}"))?;

--- a/crates/trusty-search/src/service/reindex/defer_embed.rs
+++ b/crates/trusty-search/src/service/reindex/defer_embed.rs
@@ -165,6 +165,11 @@ pub(crate) async fn run_embed_catch_up(handle: Arc<IndexHandle>, progress: Arc<R
             // replaced) across every rebuild. Checking `stages.semantic.status`
             // under the SAME write lock the `Ready` write uses makes
             // disable-wins-over-a-racing-embed-pass airtight.
+            // Issue #4707: same honesty gate the fast pass applies — a pass
+            // that finishes with the live store still empty must publish
+            // `Failed`, not `Ready`. Gathered before the stages write lock so
+            // the indexer lock is never nested inside it.
+            let broken = super::stages::semantic_health_reason(&handle).await;
             {
                 let mut stages = handle.stages.write().await;
                 if stages.semantic.status == StageStatus::Skipped {
@@ -174,6 +179,9 @@ pub(crate) async fn run_embed_catch_up(handle: Arc<IndexHandle>, progress: Arc<R
                          Ready, issue #2984 Phase 1 finding 4)",
                         index_id.0,
                     );
+                } else if let Some(reason) = broken {
+                    tracing::error!("deferred_embed[{}]: {reason}", index_id.0);
+                    stages.semantic = StageState::failed(&reason);
                 } else {
                     stages.semantic.status = StageStatus::Ready;
                     stages.semantic.completed_at = Some(now_rfc3339());

--- a/crates/trusty-search/src/service/reindex/stages.rs
+++ b/crates/trusty-search/src/service/reindex/stages.rs
@@ -10,6 +10,8 @@
 //! - `now_rfc3339` — RFC-3339 timestamp helper.
 //! - `reset_stages_for_reindex` — wipe stages at reindex start.
 //! - `mark_lexical_ready_semantic_in_progress` — after the BM25 phase drains.
+//! - `semantic_health_reason` — live-store honesty gate for the two places
+//!   that publish `semantic: Ready` (#4707).
 //! - `mark_semantic_ready_graph_in_progress` — after embed phase completes.
 //! - `mark_reindex_failed` — on zero-vector embed failure (#601).
 //! - `mark_graph_ready` — after KG rebuild.
@@ -17,7 +19,7 @@
 //! - `refresh_context_embedding` — refresh per-index routing embedding (#112).
 //!
 //! Test: covered indirectly by the reindex integration tests; direct unit
-//! coverage in the validate module tests.
+//! coverage in the validate module tests and in `tests` below (#4707).
 
 use crate::core::registry::{IndexHandle, IndexId, IndexStages, StageState, StageStatus};
 use dashmap::DashMap;
@@ -143,6 +145,36 @@ pub(crate) async fn mark_lexical_ready_semantic_in_progress(
     }
 }
 
+/// Read the live signals that decide whether the semantic stage may honestly
+/// be marked `Ready`, and apply
+/// [`super::validate::semantic_stage_broken_reason`] to them (issue #4707).
+///
+/// Why: both places that publish `semantic: Ready` — the fast pass's
+/// [`mark_semantic_ready_graph_in_progress`] and the deferred-embed pass in
+/// `super::defer_embed` — need the same check against the same ground truth,
+/// and neither may hold the `stages` write lock while acquiring the indexer
+/// lock. Centralising the gather here keeps the lock ordering (indexer read,
+/// then stages write) identical at both call sites.
+/// What: takes ONE indexer read lock, reads `has_embedder`, the durable corpus
+/// chunk count (falling back to the in-memory count when no corpus is wired),
+/// and the live vector count; returns the predicate's verdict.
+/// Test: `tests::semantic_health_reason_*` below.
+pub(super) async fn semantic_health_reason(handle: &Arc<IndexHandle>) -> Option<String> {
+    let indexer = handle.indexer.read().await;
+    let embedder_present = indexer.has_embedder();
+    let corpus_chunks = indexer
+        .corpus_arc()
+        .and_then(|c| c.chunk_count().ok())
+        .unwrap_or_else(|| indexer.chunk_count());
+    let live_vector_count = indexer.vector_count().await;
+    drop(indexer);
+    super::validate::semantic_stage_broken_reason(
+        embedder_present,
+        corpus_chunks,
+        live_vector_count,
+    )
+}
+
 /// Flip the semantic stage to `Ready` and stamp `embedded` counter. Stage
 /// 3 (graph) is set to `InProgress` since the post-batch KG rebuild always
 /// follows immediately.
@@ -159,6 +191,9 @@ pub(crate) async fn mark_semantic_ready_graph_in_progress(
     embedded: usize,
     total: usize,
 ) {
+    // Issue #4707: gather the live-store signals BEFORE taking the stages
+    // write lock — never nest an indexer lock inside it.
+    let broken = semantic_health_reason(handle).await;
     let mut stages = handle.stages.write().await;
     if handle.lexical_only {
         // No work for semantic / graph on a lexical-only index. Leave the
@@ -169,10 +204,16 @@ pub(crate) async fn mark_semantic_ready_graph_in_progress(
     // in its pre-marked Skipped state (set by `reset_stages_for_reindex`)
     // rather than flipping it Ready. Orthogonal to the graph transition below.
     if !handle.skip_vector {
-        stages.semantic.status = StageStatus::Ready;
-        stages.semantic.completed_at = Some(now_rfc3339());
-        stages.semantic.embedded = Some(embedded);
-        stages.semantic.total = Some(total);
+        // Issue #4707: never publish `Ready` for a lane that holds no vectors.
+        if let Some(reason) = broken {
+            tracing::error!("reindex[{}]: {reason}", handle.id.0);
+            stages.semantic = StageState::failed(&reason);
+        } else {
+            stages.semantic.status = StageStatus::Ready;
+            stages.semantic.completed_at = Some(now_rfc3339());
+            stages.semantic.embedded = Some(embedded);
+            stages.semantic.total = Some(total);
+        }
     }
     // Issue #313: skip_kg holds graph in Skipped — do not flip to InProgress.
     if !handle.skip_kg && stages.graph.status == StageStatus::Pending {
@@ -300,5 +341,146 @@ pub(super) async fn refresh_context_embedding(handle: &Arc<IndexHandle>) {
             *handle.context_embedding.write().await = None;
             *handle.context_summary.write().await = Some(display);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::chunker::{ChunkType, RawChunk};
+    use crate::core::embed::Embedder;
+    use crate::core::indexer::{CodeIndexer, ParsedBatch};
+    use crate::core::store::{UsearchStore, VectorStore};
+
+    /// A test-only embedder that works. Its presence is what makes a
+    /// zero-vector store a REAL failure rather than the BM25-only steady state.
+    struct WorkingEmbedder;
+
+    #[async_trait::async_trait]
+    impl Embedder for WorkingEmbedder {
+        async fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            Ok(vec![0.5; 8])
+        }
+        async fn embed_batch(&self, texts: &[&str]) -> anyhow::Result<Vec<Vec<f32>>> {
+            Ok(texts.iter().map(|_| vec![0.5; 8]).collect())
+        }
+        fn dimension(&self) -> usize {
+            8
+        }
+    }
+
+    fn synthetic_chunk(id: &str) -> RawChunk {
+        RawChunk {
+            id: id.into(),
+            file: "test.rs".into(),
+            start_line: 1,
+            end_line: 1,
+            content: "fn test_fn() {}".into(),
+            function_name: None,
+            language: Some("rust".into()),
+            chunk_type: ChunkType::Code,
+            calls: vec![],
+            inherits_from: vec![],
+            chunk_depth: 0,
+            parent_chunk_id: None,
+            child_chunk_ids: vec![],
+            nlp_keywords: vec![],
+            nlp_code_refs: vec![],
+            virtual_terms: vec![],
+        }
+    }
+
+    /// Build a handle whose corpus holds one chunk and whose vector store is
+    /// wired with a working embedder. When `populate_store` is false the store
+    /// is left EMPTY — reproducing the reported partial warm-boot, where the
+    /// HNSW snapshot was discarded and replaced by a fresh empty store while
+    /// the corpus (and therefore the lexical lane) restored fine.
+    async fn handle_with(populate_store: bool) -> Arc<IndexHandle> {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let root = tmp.path().to_path_buf();
+        let store: Arc<dyn VectorStore> = Arc::new(UsearchStore::new(8).expect("usearch new"));
+        let store_handle = Arc::clone(&store);
+        let indexer = CodeIndexer::new("stage-health-test", root.clone())
+            .with_components(Arc::new(WorkingEmbedder), store);
+        // Commit the chunk WITHOUT an embedding so the corpus is populated
+        // independently of the vector store — exactly the split the incident
+        // produced (lexical ready, vector empty).
+        let parsed = ParsedBatch {
+            chunks: vec![synthetic_chunk("test:1:1")],
+            embeddings: vec![None],
+            entities_by_file: vec![],
+            parse_ms: 0,
+            embed_ms: 0,
+            vector_count: 0,
+        };
+        indexer.commit_parsed_batch(parsed, false).await.ok();
+        // Seed the vector AFTER the commit: `commit_parsed_batch` replaces the
+        // committed file's vectors, so a pre-seeded one would be dropped and
+        // the "healthy" fixture would silently be the broken one.
+        if populate_store {
+            store_handle
+                .upsert("test:1:1", vec![0.5; 8])
+                .await
+                .expect("upsert");
+        }
+        assert_eq!(
+            store_handle.len().await.expect("len"),
+            usize::from(populate_store),
+            "fixture precondition: the store must be in the intended state"
+        );
+        Arc::new(IndexHandle::bare(
+            IndexId::new("stage-health-test"),
+            Arc::new(tokio::sync::RwLock::new(indexer)),
+            root,
+        ))
+    }
+
+    /// Why (issue #4707): THE honesty regression test. An all-hash-skipped
+    /// incremental reindex reaches `mark_semantic_ready_graph_in_progress` with
+    /// `embedded = 0`, which is legitimate (#868) — but when the live store is
+    /// ALSO empty the lane is not usable, and publishing `Ready` is what makes
+    /// `search_capabilities` advertise `"vector"`, stops the search handler
+    /// down-shifting to the lexical lane, and turns every query into a
+    /// query-embed call that can hard-fail with `500 internal search error`.
+    /// The stage must report `Failed` instead.
+    /// Test: this IS the test.
+    #[tokio::test]
+    async fn semantic_stage_reports_failed_when_live_store_is_empty() {
+        let handle = handle_with(false).await;
+        mark_semantic_ready_graph_in_progress(&handle, 0, 0).await;
+        let stages = handle.stages.read().await;
+        assert_eq!(
+            stages.semantic.status,
+            StageStatus::Failed,
+            "a semantic lane backed by an EMPTY vector store must never be published \
+             as ready (issue #4707)"
+        );
+        let reason = stages
+            .semantic
+            .failure
+            .as_ref()
+            .expect("Failed stage must carry an actionable reason");
+        assert!(reason.contains("0 vectors"), "reason: {reason}");
+        assert!(
+            !stages.search_capabilities().contains(&"vector"),
+            "the vector lane must not be advertised as queryable"
+        );
+    }
+
+    /// Why (issue #4707): the honesty gate must not regress the healthy path —
+    /// a populated store with zero NEWLY embedded chunks (the ordinary
+    /// no-change incremental reindex, #868) must still be `Ready`.
+    /// Test: this IS the test.
+    #[tokio::test]
+    async fn semantic_stage_still_ready_when_store_is_populated() {
+        let handle = handle_with(true).await;
+        mark_semantic_ready_graph_in_progress(&handle, 0, 0).await;
+        let stages = handle.stages.read().await;
+        assert_eq!(
+            stages.semantic.status,
+            StageStatus::Ready,
+            "an all-hash-skipped reindex over a populated store must stay Ready (#868)"
+        );
+        assert!(stages.search_capabilities().contains(&"vector"));
     }
 }

--- a/crates/trusty-search/src/service/reindex/stages.rs
+++ b/crates/trusty-search/src/service/reindex/stages.rs
@@ -158,7 +158,8 @@ pub(crate) async fn mark_lexical_ready_semantic_in_progress(
 /// What: takes ONE indexer read lock, reads `has_embedder`, the durable corpus
 /// chunk count (falling back to the in-memory count when no corpus is wired),
 /// and the live vector count; returns the predicate's verdict.
-/// Test: `tests::semantic_health_reason_*` below.
+/// Test: `tests::semantic_stage_reports_failed_when_live_store_is_empty` and
+/// `tests::semantic_stage_still_ready_when_store_is_populated` below.
 pub(super) async fn semantic_health_reason(handle: &Arc<IndexHandle>) -> Option<String> {
     let indexer = handle.indexer.read().await;
     let embedder_present = indexer.has_embedder();

--- a/crates/trusty-search/src/service/reindex/validate.rs
+++ b/crates/trusty-search/src/service/reindex/validate.rs
@@ -10,9 +10,12 @@
 //! counters and paths. Extracting them here makes each decision independently
 //! testable and keeps the monolith from growing.
 //!
-//! What: four pure helpers —
+//! What: five pure helpers —
 //! - [`reindex_outcome`] decides Ready vs. Failed from the vector/file counters
 //!   (the #601 non-empty gate), honouring the lexical-only exception.
+//! - [`semantic_stage_broken_reason`] decides whether the semantic stage may
+//!   honestly be published as Ready, judged against the LIVE vector store
+//!   rather than the reindex's own counters (#4707).
 //! - [`canonical_walk_root`] canonicalizes a root exactly as the walker does so
 //!   `strip_prefix` reliably yields root-relative (portable) chunk paths (#602).
 //! - [`needs_path_relativization`] decides whether a root change between reindex
@@ -20,7 +23,7 @@
 //! - [`root_move_is_trusted`] decides whether a detected root move is backed by
 //!   durable, persisted config before the caller may walk/prune against it (#2178).
 //!
-//! Test: `super::validate::tests` covers every branch of all four.
+//! Test: `super::validate::tests` covers every branch of all five.
 
 use std::path::{Path, PathBuf};
 
@@ -172,6 +175,57 @@ pub(crate) fn reindex_outcome(
 /// Test: `semantic_ready_now_*` below.
 pub(crate) fn semantic_ready_now(defer_embed: bool, embedder_present: bool) -> bool {
     !(defer_embed && embedder_present)
+}
+
+/// Decide whether the semantic stage may honestly be marked `Ready`, given the
+/// LIVE vector store rather than the reindex's own bookkeeping (issue #4707).
+///
+/// Why: [`reindex_outcome`]'s `newly_submitted == 0` branch (issue #868) and
+/// the deferred-embed pass both legitimately finish with zero NEW vectors on an
+/// all-hash-skipped incremental run — and both then mark semantic `Ready`
+/// without ever asking whether the store they are vouching for holds any
+/// vectors at all. That is fine when the store was warm-booted populated. It is
+/// a lie when warm-boot fell back to an EMPTY store (a discarded snapshot: the
+/// #2922 size floor, a corrupt sidecar, the #3970 torn-pairing guard), because
+/// then nothing in the pass ever adds a vector and nothing ever notices. The
+/// observed consequence is worse than a missing lane: `search_capabilities`
+/// gains `"vector"`, so `service::server::search` stops down-shifting the query
+/// to the lexical lane, every query therefore calls `embed_query`, and a
+/// failing embedder turns that into a hard `Err` — `500 internal search error`
+/// on every query, forever, from an index reporting `status: ready`. Reported
+/// as an empty warm-boot whose save was (correctly) refused by the #1711 guard.
+///
+/// What: returns `Some(reason)` — mark the stage `Failed`, not `Ready` — only
+/// when all three hold: an embedder is wired (an index that cannot embed is
+/// legitimately vectorless), the corpus holds at least one chunk (an empty
+/// corpus has nothing to embed), and the live store reports zero vectors.
+/// `live_vector_count == None` means no store is wired at all, which is the
+/// BM25-only steady state and never a failure. Deliberately narrow: a
+/// PARTIALLY-populated store is not flagged here — partial embeds are surfaced
+/// via `embed_failure_count`, and widening this to a ratio would re-introduce
+/// exactly the heuristic-threshold problem documented on
+/// `SHRINK_GUARD_RATIO_DIVISOR`.
+/// Test: `semantic_stage_broken_reason_*` below.
+pub(crate) fn semantic_stage_broken_reason(
+    embedder_present: bool,
+    corpus_chunks: usize,
+    live_vector_count: Option<usize>,
+) -> Option<String> {
+    if !embedder_present {
+        return None;
+    }
+    let live = live_vector_count?;
+    if corpus_chunks == 0 || live > 0 {
+        return None;
+    }
+    Some(format!(
+        "semantic lane is not usable: the corpus holds {corpus_chunks} chunk(s) and an \
+         embedder is wired, but the live vector store holds 0 vectors — the HNSW snapshot \
+         was discarded at warm-boot and no vector has been added since. Reporting this as \
+         `failed` rather than `ready` keeps searches on the working lexical lane instead of \
+         routing them through a query-embed step that has nothing to search (issue #4707). \
+         Run `trusty-search index <path> --force` to rebuild."
+    ))
 }
 
 /// Canonicalize `root` exactly as the walker does (#602).
@@ -434,6 +488,61 @@ mod tests {
             semantic_ready_now(true, false),
             "defer_embed without an embedder has no background pass to wait for"
         );
+    }
+
+    /// Why (issue #4707): the reported failure — corpus has chunks, an
+    /// embedder is wired, live store holds zero vectors. Must NOT be Ready.
+    /// Test: this test.
+    #[test]
+    fn semantic_stage_broken_reason_flags_empty_store_with_populated_corpus() {
+        let reason = semantic_stage_broken_reason(true, 1732, Some(0))
+            .expect("an empty store over a populated corpus must be flagged");
+        assert!(reason.contains("0 vectors"), "reason: {reason}");
+        assert!(
+            reason.contains("1732"),
+            "reason must cite corpus size: {reason}"
+        );
+        assert!(
+            reason.contains("--force"),
+            "reason must be actionable: {reason}"
+        );
+    }
+
+    /// Why (issue #4707): the healthy steady state — a populated store — must
+    /// never be flagged, or every reindex would report failed.
+    /// Test: this test.
+    #[test]
+    fn semantic_stage_broken_reason_ignores_populated_store() {
+        assert!(semantic_stage_broken_reason(true, 1732, Some(1732)).is_none());
+        assert!(
+            semantic_stage_broken_reason(true, 1732, Some(1)).is_none(),
+            "a partial store is not this gate's business — see the doc comment"
+        );
+    }
+
+    /// Why (issue #4707): a BM25-only / test indexer with no embedder is
+    /// legitimately vectorless; flagging it would break every such deployment
+    /// (the same exemption `reindex_outcome` makes).
+    /// Test: this test.
+    #[test]
+    fn semantic_stage_broken_reason_ignores_index_without_embedder() {
+        assert!(semantic_stage_broken_reason(false, 1732, Some(0)).is_none());
+    }
+
+    /// Why (issue #4707): an empty corpus has nothing to embed, so zero
+    /// vectors is correct — a brand-new index must not report failed.
+    /// Test: this test.
+    #[test]
+    fn semantic_stage_broken_reason_ignores_empty_corpus() {
+        assert!(semantic_stage_broken_reason(true, 0, Some(0)).is_none());
+    }
+
+    /// Why (issue #4707): `None` means no vector store is wired at all — the
+    /// BM25-only steady state, not a broken semantic lane.
+    /// Test: this test.
+    #[test]
+    fn semantic_stage_broken_reason_ignores_unwired_store() {
+        assert!(semantic_stage_broken_reason(true, 1732, None).is_none());
     }
 
     /// Why: confirms the strip-prefix root resolves a real symlinked directory


### PR DESCRIPTION
## Summary

Fixes #4707 — an index whose vector layer warm-boots empty is left permanently broken (search 500s on every query) while still self-reporting `ready`.

**This is two fixes, not one.** They are independent defects that compose into the reported outcome, and either alone leaves a real hole: fixing only recovery still lets a genuinely unrecoverable index advertise a dead lane; fixing only reporting leaves a recoverable index degraded to BM25 forever. They ship together because they share one root cause — *the semantic lane's readiness is pure bookkeeping that is never reconciled against the live vector store.*

## Root cause (investigated, not assumed)

1. **No recovery path.** When `UsearchStore::load_from` discards a snapshot — the #2922 size floor, a corrupt sidecar, the #3970 torn-pairing guard — `build_store_for_entry` installs a fresh **empty** store and sets `hnsw_load_failed = true`. Warm-boot classifies semantic as `Pending`, which is correct. But the intact on-disk snapshot is never revisited: nothing retries the load, and every later `save()` from that empty store is refused by the #1711 guard. The index is permanently vectorless while a perfectly good snapshot sits on disk.

2. **Dishonest health.** A subsequent *incremental* reindex flips `semantic` to `Ready` without the store ever gaining a vector. `validate::reindex_outcome`'s `newly_submitted == 0` branch returns `Ready` for an all-hash-skipped pass **by design** (#868), and `defer_embed::run_embed_catch_up` marks `Ready` on `Ok((0, N))`. Neither consults `store.len()`. `search_capabilities` then contains `"vector"`, so `service/server/search.rs` stops down-shifting the query to the lexical lane — and every query reaches `embed_query`, whose failure is a hard `?` at `core/indexer/search/mod.rs:194` → `500 internal search error`.

### Correction to the issue's implicit assumption

**An empty HNSW index does not itself error.** I verified this before writing any fix: `usearch::Index::search` over 0 vectors returns `Ok([])`, not `Err`. The 500 does **not** come from searching the empty index — it comes from the query-embed step that honest readiness reporting would have skipped entirely. That is why the honesty half is load-bearing rather than cosmetic: with the stage reporting truthfully, the same broken index serves BM25 results (degraded but working) instead of 500ing.

## The #1711 guard

**Not weakened, and not made permissive.** The guard still refuses the overwrite; the on-disk bytes are never written on this path. What changes is what happens *after* the refusal:

- Refusing the write protects the **data**. Adopting the snapshot restores the **service**. Both are required, and they are not in tension — an empty in-memory index has nothing to contribute, so the on-disk snapshot is strictly authoritative.
- `adopt_on_disk_snapshot` **never writes to disk**. It only moves in-memory state in one direction: towards what is already durable. Worst case it declines (`Ok(false)`) and the store is left exactly as it was.
- Validation is **not reimplemented**. The candidate is loaded through `UsearchStore::load_from`, so a truncated (#2922), zero-vector-vs-populated, or torn binary/sidecar (#3970) snapshot is rejected by exactly the code that rejects it at warm-boot.
- The **#1717 shrink refusal deliberately does not recover this way.** A partially-populated in-memory index may hold vectors the on-disk snapshot lacks, so adopting disk there would *cause* data loss. Distinguishing the two refusals is why `save()`'s internal `bool` became `SaveVerdict`.

## Changes

| File | Change |
|---|---|
| `core/store/usearch_recover.rs` *(new)* | `SaveVerdict` + `adopt_on_disk_snapshot`. New file so `usearch_store.rs` stays under the 500-SLOC cap. |
| `core/store/usearch_store.rs` | `save()` returns `SaveVerdict`; adopts the snapshot on the #1711 refusal. |
| `core/indexer/persist_hnsw.rs` | `vector_count()` — live-store ground truth. |
| `service/reindex/validate.rs` | `semantic_stage_broken_reason` — pure predicate. |
| `service/reindex/stages.rs` | `semantic_health_reason` gatherer; gate applied in `mark_semantic_ready_graph_in_progress`. |
| `service/reindex/defer_embed.rs` | Same gate in the deferred-embed Ready branch. |

The honesty gate is deliberately narrow: it fires only when an embedder is wired **and** the corpus is non-empty **and** the live store reports exactly zero. A *partially* populated store is not flagged — widening it to a ratio would re-introduce the heuristic-threshold problem already documented on `SHRINK_GUARD_RATIO_DIVISOR`.

## Could the failure path be genuinely tested?

**Yes — both halves, with the real broken state constructed, not mocked.**

- `test_save_refusal_adopts_populated_snapshot` builds a **real** populated snapshot (900 vectors, verified over the 100 KB guard threshold by an explicit fixture precondition), then points a fresh **empty** store at that path and saves — the exact partial warm-boot. It asserts all three of: the on-disk bytes are byte-identical (the #1711 contract holds), the store recovered its vectors, and a real search returns the original chunk ids (proving the key sidecar was rehydrated, not just the graph).
- `semantic_stage_reports_failed_when_live_store_is_empty` builds a handle with a working embedder, a populated corpus, and an empty vector store, then drives the real `mark_semantic_ready_graph_in_progress` and asserts `Failed` + that `search_capabilities` no longer advertises `vector`.
- Unrecoverable and healthy paths are covered too: `test_adopt_declines_when_snapshot_is_unrecoverable`, `test_adopt_declines_on_dim_mismatch`, `semantic_stage_still_ready_when_store_is_populated` (the #868 no-change reindex must stay `Ready`).

Note the pre-existing #1711 test writes a byte-*filler* file, which can prove refusal but never recovery — there is no loadable snapshot to recover from. It still passes unchanged.

## Mutation table

Every mutation was reverted from a file backup (`/tmp/4707-backup`), md5-verified — never `git checkout <file>`.

| # | Mutation | Expected red | Result |
|---|---|---|---|
| M1 | `save()`'s #1711 arm never calls `adopt_on_disk_snapshot` (pre-fix behaviour) | `test_save_refusal_adopts_populated_snapshot` | **RED** — and both `test_adopt_declines_*` stayed green, proving they don't depend on recovery succeeding |
| M2 | Fast-pass honesty gate bypassed (`if let Some(reason) = None`) | `semantic_stage_reports_failed_when_live_store_is_empty` | **RED**; `..._still_ready_when_store_is_populated` green |
| M3 | `semantic_stage_broken_reason` always returns `None` | predicate test + stage test | **RED** (2 failed); the four "must not fire" tests stayed green |
| M4 | `adopt_on_disk_snapshot` dim-mismatch guard removed | `test_adopt_declines_on_dim_mismatch` | **RED**; adoption + unrecoverable tests green |

Two fixture preconditions also fired for real during development rather than passing silently: the snapshot-size floor (600 vectors → 96,112 bytes, under the 100 KB guard threshold — bumped to 900) and the store-state assertion that caught `commit_parsed_batch` clearing a pre-seeded vector, which would have made the "healthy" fixture silently identical to the broken one.

## Gates (crate-scoped, raw)

```
$ cargo check -p trusty-search
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 16.09s

$ cargo clippy -p trusty-search --all-targets -- -D warnings
CLIPPY_EXIT=0

$ cargo fmt --check
cargo fmt --check EXIT=0

$ bash scripts/check_line_cap.sh
line-cap: measured 3604 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_changelog_fragment.sh
OK   trusty-search: changelog.d fragment present and valid
changelog-fragment gate: scanned 9 changed path(s); all 1 crate(s) with source changes are recorded.

$ cargo test -p trusty-search --lib
test result: FAILED. 1375 passed; 6 failed; 1 ignored; 0 measured; 0 filtered out; finished in 66.66s

failures:
    service::watch_loop::tests::cdk_out_file_is_not_indexed
    service::watch_loop::tests::modified_docx_file_triggers_indexing_via_extractor
    service::watch_loop::tests::modified_file_triggers_indexing
    service::watcher::tests::modified_event_emitted_within_one_second
    service::watcher::tests::removed_event_emitted_on_delete
    service::watcher_manager::tests::save_triggers_incremental_index_via_manager
```

Those 6 are the **known-environmental filesystem-watcher flakes named in `CLAUDE.md`** — not caused by this branch. Evidence: `git diff --name-only origin/main...HEAD | grep watch` returns nothing (the diff touches zero watcher files), and they fail identically in isolation under `--test-threads=1`, i.e. FSEvents is not delivering on this host. Change-specific gates pass.

Every other test target is green:

```
     Running unittests src/main.rs
test result: ok. 325 passed; 0 failed; 3 ignored
     Running tests/integration_tests.rs
test result: ok. 7 passed; 0 failed; 0 ignored
     Running tests/ooc_quick_wins.rs
test result: ok. 6 passed; 0 failed; 0 ignored
     Running tests/warm_boot_corpus_open_failure.rs
test result: ok. 2 passed; 0 failed; 0 ignored
     Running tests/corpus_open_quarantine_4122.rs
test result: ok. 3 passed; 0 failed; 0 ignored
     Running tests/residency_cold_park.rs
test result: ok. 2 passed; 0 failed; 0 ignored
     Running tests/typeahead.rs
test result: ok. 7 passed; 0 failed; 1 ignored
```

## Not done, deliberately

- **Nothing was installed, and no daemon was restarted** — per the task constraint. This PR is not deployed anywhere.
- **The live reproduction index `tm-duetto-agents-skills-01` was not modified.** It was read only (status endpoint, `errors.jsonl`, on-disk file sizes). No reindex, no repair, no write. Note it was independently reindexed at `2026-08-04T03:15Z` by something outside this session, so the live 500 no longer reproduces; the diagnosis rests on the `errors.jsonl` records and the code paths, not on live re-observation. Its `index_status` still shows the honesty defect verbatim: `semantic: { embedded: 0, total: 1732, status: "ready" }`.
- **Version bump** left alone pending CI's `check-pr-version-bump.sh` verdict.

Closes #4707

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
