### PR TITLE
fix(trusty-common): capitalised identifier segments are not credentials

### DIFF
--- a/crates/trusty-common/changelog.d/4739-mixed-case-branch.md
+++ b/crates/trusty-common/changelog.d/4739-mixed-case-branch.md
@@ -1,0 +1,7 @@
+Fixed
+
+- Secret detector no longer flags dotted or underscored filenames that carry a capital letter (closes [#4739](https://github.com/bobmatnyc/trusty-tools/issues/4739))
+  - `Agents.app.bak-20260729-000028` and shapes like it reached the mixed-case branch, which #4723's base64-branch narrowing never covered
+  - `is_structural_token`'s segmented-identifier branch now splits on `.` and `_` as well as `-`, and accepts a `Capitalized` segment alongside `lowercase` and `UPPERCASE`
+  - Measured over a 36-shape prose battery and a 30-shape credential battery: prose false positives 17 → 2, credential misses 0 → 0
+  - CamelCase segments (`TrustyMemory.app.bak-…`) are a stated known bound, not fixed: admitting them would lose delimiter-segmented mixed-case credentials

--- a/crates/trusty-common/src/memory_core/filter.rs
+++ b/crates/trusty-common/src/memory_core/filter.rs
@@ -559,11 +559,36 @@ const IDENTIFIER_DELIMITERS: [char; 3] = ['-', '_', '.'];
 /// measurement disproved: a segment that is not uniformly uppercase admits **at
 /// most one uppercase letter, and only as its first letter**. That is what
 /// keeps the run-of-two case alternation of an encoded blob (`AbCd`, `EfGh`)
-/// out — two uppercase letters in a non-uppercase segment is disqualifying. It
-/// is NOT a claim that no credential can be built from capitalized segments:
-/// `Abcd-1234-Efgh-5678` satisfies it. That shape is a product key, already
-/// exempt in its conventional ALL-CAPS form, and carries no case entropy to
-/// lose.
+/// out — two uppercase letters in a non-uppercase segment is disqualifying.
+///
+/// The ACCEPTED side of that bound, stated because the rejected side alone
+/// would read as a stronger guarantee than this predicate gives: what
+/// [`is_segmented_identifier`] admits is a token whose **every segment is
+/// independently case-uniform**. At short segment lengths that includes shapes
+/// which are not human words at all —
+/// `Xy7-Kp2-Qm9-Rt4-Vw8-Nz3-Bc6-Fj0` and `A1b2-C3d4-E5f6-G7h8-I9j0-K1l2` are
+/// both admitted, and neither is a filename. They are a real, measured miss,
+/// not a hypothetical.
+///
+/// Why that is an acceptable price rather than a hole: a *generated* credential
+/// essentially never satisfies per-segment case uniformity, because it is not
+/// segmented into short groups in the first place, and if it is, every group
+/// must independently land in one of three case shapes. Treating a short
+/// alphanumeric segment as case-uniform with probability roughly ¼ (an
+/// estimate, assuming uniform draws from a mixed alphabet — not a measured
+/// constant), an eight-segment token clears the bar about `(1/4)^8` of the
+/// time, order 1 in 10^4–10^5. Everything **generated** rather than
+/// **composed** — bare blobs, base64, base64url, JWTs, provider-prefixed keys —
+/// carries no such segmentation and still flags. The exposure is to a
+/// credential a human deliberately composed to look like an identifier, which
+/// is the accidental-storage hygiene threat model this module has always had,
+/// not an adversarial one.
+///
+/// The earlier revision of this doc illustrated the accepted side with
+/// `Abcd-1234-Efgh-5678`. That example was wrong: at 19 characters it is below
+/// `looks_like_secret`'s own 20-char floor, so it never reaches this branch and
+/// could not demonstrate anything about it. `Abcd-1234-Efgh-5678-Ijkl` (24) is
+/// the corrected form and is genuinely admitted here.
 ///
 /// Known bound, deliberately not fixed: CamelCase (`TrustyMemory`,
 /// `MyDocument`) has two capitalized runs and is still not a word here, so
@@ -578,7 +603,8 @@ const IDENTIFIER_DELIMITERS: [char; 3] = ['-', '_', '.'];
 /// predicate constrains case, not charset.
 /// Test: `structural_tokens_are_not_flagged`,
 /// `dotted_capitalised_filenames_are_not_flagged`,
-/// `real_secrets_still_blocked_after_4739_capitalised_segments`.
+/// `real_secrets_still_blocked_after_4739_capitalised_segments`,
+/// `per_segment_case_uniformity_is_a_known_accepted_bound`.
 fn is_human_word_segment(seg: &str) -> bool {
     let s = seg.trim_matches(|c: char| !c.is_ascii_alphanumeric());
     if s.is_empty() {

--- a/crates/trusty-common/src/memory_core/filter.rs
+++ b/crates/trusty-common/src/memory_core/filter.rs
@@ -521,55 +521,115 @@ const SECRET_PREFIXES: &[&str] = &[
     "asia",
 ];
 
-/// True when `seg` is a "uniform-case word segment": non-empty, consists only
-/// of ASCII alphanumeric chars (no punctuation), and every alphabetic char is
-/// either all-lowercase or all-uppercase (no internal mixed case within the
-/// segment). Digits count as case-neutral.
+/// Characters that separate the words of a human-readable compound identifier.
+///
+/// Why (issue #4739): [`is_segmented_identifier`] split on `-` alone, so an
+/// ordinary dotted filename (`Agents.app.bak-20260729-000028`) was segmented
+/// into `["Agents.app.bak", "20260729", "000028"]` — and the first segment,
+/// carrying two case runs across its dots, could not be a word. `.` and `_`
+/// delimit identifier words exactly as `-` does; treating them as delimiters is
+/// what lets the per-segment predicate see words instead of a blob.
+///
+/// Why this does not widen the base64 branch: [`is_structural_token`] returns
+/// before reaching its segmented-identifier branch whenever the token contains
+/// `+`, `=`, or `/` — which is precisely the `has_b64_sym` set. The segmented
+/// branch is therefore reachable only for tokens the base64 branch can never
+/// fire on, so this delimiter set is confined to the mixed-case branch.
+/// What: the delimiter set `-`, `_`, `.` used by both `contains` and `split`.
+/// Test: `dotted_capitalised_filenames_are_not_flagged`.
+const IDENTIFIER_DELIMITERS: [char; 3] = ['-', '_', '.'];
+
+/// True when `seg` reads as a single human-readable word: all-lowercase,
+/// ALL-UPPERCASE, or Capitalized. Digits are case-neutral, so a digit-only
+/// segment (`20260729`) qualifies.
 ///
 /// Why: this is the per-segment predicate used by [`is_segmented_identifier`]
-/// to determine whether a hyphen-delimited token reads like a compound
-/// human-readable identifier (`2-medium->REQUEST_CHANGES`) vs. a random
-/// mixed-case credential blob (`AbCd1234-EfGh5678`).
-/// What: strips leading/trailing non-alnum chars (from arrow punctuation like
-/// `>`, `<`), then checks all-lowercase-or-digit or all-uppercase-or-digit.
-/// Test: `structural_tokens_are_not_flagged`.
-fn is_uniform_word_segment(seg: &str) -> bool {
+/// to tell a compound human-readable identifier (`2-medium->REQUEST_CHANGES`,
+/// `Agents.app.bak-20260729-000028`) from a random mixed-case credential blob
+/// (`AbCd1234-EfGh5678`).
+///
+/// Why Capitalized was added (issue #4739, the FIFTH recurrence in this
+/// detector after #1667, #2800, #4216 and #4312): admitting only all-lower and
+/// all-upper meant a leading capital — the single most ordinary thing about an
+/// English word or a macOS app bundle name — read as internal mixed case, so
+/// `Agents.app.bak-20260729-000028` fell through to the credential heuristic.
+///
+/// The bound this predicate actually holds, stated exactly because a reader
+/// will rely on it and because #4723 shipped an absolute here that a
+/// measurement disproved: a segment that is not uniformly uppercase admits **at
+/// most one uppercase letter, and only as its first letter**. That is what
+/// keeps the run-of-two case alternation of an encoded blob (`AbCd`, `EfGh`)
+/// out — two uppercase letters in a non-uppercase segment is disqualifying. It
+/// is NOT a claim that no credential can be built from capitalized segments:
+/// `Abcd-1234-Efgh-5678` satisfies it. That shape is a product key, already
+/// exempt in its conventional ALL-CAPS form, and carries no case entropy to
+/// lose.
+///
+/// Known bound, deliberately not fixed: CamelCase (`TrustyMemory`,
+/// `MyDocument`) has two capitalized runs and is still not a word here, so
+/// `TrustyMemory.app.bak-20260801-120000` remains a false positive. Admitting
+/// it would require accepting multi-uppercase segments, which is the exact
+/// signature of `AbCdEfGhIjKlMnOpQrSt-1234` — a credential miss. Measured, not
+/// assumed; see the residue assertion in the test below.
+/// What: strips leading/trailing non-alnum chars (arrow punctuation like `>`,
+/// `<`), then accepts when the alphabetic characters are all-lowercase,
+/// all-uppercase, or a single leading uppercase followed by lowercase. Interior
+/// non-alphanumeric characters are ignored rather than rejected — this
+/// predicate constrains case, not charset.
+/// Test: `structural_tokens_are_not_flagged`,
+/// `dotted_capitalised_filenames_are_not_flagged`,
+/// `real_secrets_still_blocked_after_4739_capitalised_segments`.
+fn is_human_word_segment(seg: &str) -> bool {
     let s = seg.trim_matches(|c: char| !c.is_ascii_alphanumeric());
     if s.is_empty() {
         return false;
     }
-    // All alphabetic chars in segment must share a single case.
-    let all_lower = s
-        .chars()
-        .all(|c| !c.is_ascii_alphabetic() || c.is_ascii_lowercase());
-    let all_upper = s
-        .chars()
-        .all(|c| !c.is_ascii_alphabetic() || c.is_ascii_uppercase());
-    all_lower || all_upper
+    let alphas: Vec<char> = s.chars().filter(|c| c.is_ascii_alphabetic()).collect();
+    // Digit-only segments are case-neutral (`20260729`, `000028`).
+    let Some((first, rest)) = alphas.split_first() else {
+        return true;
+    };
+    let rest_all_lower = rest.iter().all(|c| c.is_ascii_lowercase());
+    let rest_all_upper = rest.iter().all(|c| c.is_ascii_uppercase());
+    // #4739: `lowercase` | `UPPERCASE` | `Capitalized`. A leading uppercase may
+    // be followed by either case run (Capitalized or ALL-UPPERCASE); a leading
+    // lowercase may only be followed by lowercase.
+    if first.is_ascii_uppercase() {
+        rest_all_lower || rest_all_upper
+    } else {
+        rest_all_lower
+    }
 }
 
-/// True when `token` looks like a compound identifier whose hyphen-separated
-/// segments are each uniform-case words (e.g. `2-medium->REQUEST_CHANGES`,
-/// `trusty-review-v0.6.0`, `snake-case-value`).
+/// True when `token` looks like a compound identifier whose delimiter-separated
+/// segments are each human-readable words (e.g. `2-medium->REQUEST_CHANGES`,
+/// `trusty-review-v0.6.0`, `Agents.app.bak-20260729-000028`).
 ///
 /// Why (issue #1667): the mixed-case-plus-digit heuristic in
 /// [`looks_like_secret`] fires on `2-medium->REQUEST_CHANGES` because the
 /// compound token contains lower (`medium`), upper (`REQUEST_CHANGES`), and
-/// digit (`2`) when considered as a whole. But each segment is internally
-/// uniform-case, which is the hallmark of a human-readable compound
-/// identifier, not a random credential blob.
-/// What: requires at least two non-empty segments after splitting on `-`,
-/// with each segment passing [`is_uniform_word_segment`].
-/// Test: `structural_tokens_are_not_flagged`.
+/// digit (`2`) when considered as a whole. But each segment is internally a
+/// single word, which is the hallmark of a human-readable compound identifier,
+/// not a random credential blob.
+///
+/// Why the delimiter set widened (issue #4739): splitting on `-` alone left
+/// every dot- and underscore-joined filename as one unsplittable segment. See
+/// [`IDENTIFIER_DELIMITERS`] for why that widening cannot reach the base64
+/// branch.
+/// What: requires at least two segments after splitting on
+/// [`IDENTIFIER_DELIMITERS`], each passing [`is_human_word_segment`] (which
+/// rejects the empty segment a trailing delimiter produces).
+/// Test: `structural_tokens_are_not_flagged`,
+/// `dotted_capitalised_filenames_are_not_flagged`.
 fn is_segmented_identifier(token: &str) -> bool {
-    if !token.contains('-') {
+    if !token.contains(IDENTIFIER_DELIMITERS) {
         return false;
     }
-    let segments: Vec<&str> = token.split('-').collect();
+    let segments: Vec<&str> = token.split(IDENTIFIER_DELIMITERS).collect();
     if segments.len() < 2 {
         return false;
     }
-    segments.iter().all(|s| is_uniform_word_segment(s))
+    segments.iter().all(|s| is_human_word_segment(s))
 }
 
 /// True when `token` is a structured path/slug/key=value/compound-identifier
@@ -585,15 +645,24 @@ fn is_segmented_identifier(token: &str) -> bool {
 /// causing a false positive (#1676).
 /// This function recognises those structural shapes and short-circuits the
 /// two dangerous branches in `looks_like_secret`.
+///
+/// How the three branches divide the work (issue #4739): branches (a) and (b)
+/// fire only on tokens carrying `=` or `/`, and branch (a)'s `+` guard returns
+/// first — so (a) and (b) are the ones that can rescue a token from the base64
+/// branch. Branch (c) is reachable only after all of `+`, `=` and `/` are ruled
+/// out, i.e. only for tokens on which `has_b64_sym` is false, so it serves the
+/// mixed-case branch exclusively. That partition is why a fix to (c) cannot
+/// loosen base64 detection.
 /// What: returns `true` for (a) `=`-containing tokens where the LHS is a
 /// word segment and the RHS is itself structural (a word segment OR a
 /// slash-path), checked before the slash-path branch so that tokens like
 /// `key=path/to/value` are decomposed at `=` first; (b) slash-path tokens
-/// where every `/`-segment is word-like; or (c) hyphen-segmented compound
-/// identifiers where each segment is uniform-case. A token with `+` is
-/// never structural (`+` never appears in identifiers).
+/// where every `/`-segment is word-like; or (c) `-`/`_`/`.`-segmented compound
+/// identifiers where each segment is a single human-readable word. A token with
+/// `+` is never structural (`+` never appears in identifiers).
 /// Test: `structural_tokens_are_not_flagged`, `base64_blob_is_blocked`,
-/// `key_equals_slashpath_not_flagged` (issue #1676 regression tests).
+/// `key_equals_slashpath_not_flagged` (issue #1676 regression tests),
+/// `dotted_capitalised_filenames_are_not_flagged` (issue #4739).
 fn is_structural_token(token: &str) -> bool {
     // `+` is unambiguously base64 — no structural pattern uses it.
     if token.contains('+') {
@@ -756,6 +825,12 @@ fn looks_like_secret(token: &str) -> bool {
     // Gate the fallback on [`is_plausible_credential_charset`] so it only
     // fires for tokens shaped like an actual bare credential (alphanumeric
     // plus the `-`/`_`/`.` separators used by JWTs and slug-style API keys).
+    //
+    // #4739: that charset gate is necessary but not sufficient — an ordinary
+    // dotted filename is built from exactly this charset. The shape gate is
+    // `is_structural_token` branch (c), widened there rather than here so the
+    // two branches keep sharing one notion of "human-readable token" instead of
+    // each growing its own allowlist for the fifth time.
     has_lower && has_upper && has_digit && is_plausible_credential_charset(token)
 }
 

--- a/crates/trusty-common/src/memory_core/filter_tests.rs
+++ b/crates/trusty-common/src/memory_core/filter_tests.rs
@@ -1607,3 +1607,50 @@ fn real_secrets_still_blocked_after_4739_capitalised_segments() {
         );
     }
 }
+
+/// Why (issue #4739, review round 1): the battery above probes the REJECTED
+/// side of `is_human_word_segment`'s bound — shapes that must stay flagged.
+/// Nothing probed the ACCEPTED side at token scale, which left the widening
+/// reading as a stronger guarantee than it gives. What `is_segmented_identifier`
+/// actually admits is a token whose every segment is independently case-uniform,
+/// and at short segment lengths that includes shapes which are not human words
+/// at all. These moved FLAG -> pass in this PR; they are neither prose nor
+/// credentials the module is expected to catch, and they are accepted (see the
+/// bound stated on `is_human_word_segment`) rather than fixed.
+///
+/// This block is modelled on the #4312 known-miss pin it sits beside: that one
+/// is the reason the URL-path misses stayed visible across two PRs instead of
+/// being rediscovered. The accepted side of this bound gets the same treatment,
+/// so any future movement — in either direction — is caught rather than found.
+/// What: pins two of the admitted shapes, plus the corrected doc example.
+/// Test: itself.
+#[test]
+fn per_segment_case_uniformity_is_a_known_accepted_bound() {
+    for (label, tok) in [
+        (
+            "capitalised 3-char groups",
+            "Xy7-Kp2-Qm9-Rt4-Vw8-Nz3-Bc6-Fj0",
+        ),
+        ("capitalised 4-char groups", "A1b2-C3d4-E5f6-G7h8-I9j0-K1l2"),
+        // The corrected doc example. The earlier revision cited
+        // `Abcd-1234-Efgh-5678`, which at 19 chars is below the 20-char floor in
+        // `looks_like_secret` and so never reaches this branch at all — it could
+        // not illustrate the bound it was cited for. This form does.
+        ("corrected doc example", "Abcd-1234-Efgh-5678-Ijkl"),
+    ] {
+        assert!(
+            tok.len() >= 20,
+            "{label}: this pin is meaningless below the 20-char secret floor — \
+             the token would never reach the segmented-identifier branch. \
+             Token: {tok} ({} chars)",
+            tok.len()
+        );
+        assert!(
+            find_secret_token(tok).is_none(),
+            "KNOWN ACCEPTED BOUND (#4739, {label}): every segment is \
+             independently case-uniform, so this is admitted even though it is \
+             not a human-readable identifier. If it now FLAGS, the bound \
+             tightened — update the doc on `is_human_word_segment`. Token: {tok}"
+        );
+    }
+}

--- a/crates/trusty-common/src/memory_core/filter_tests.rs
+++ b/crates/trusty-common/src/memory_core/filter_tests.rs
@@ -1457,3 +1457,153 @@ fn real_secrets_still_blocked_after_4312_charset_gate() {
         );
     }
 }
+
+// ---- Issue #4739: the mixed-case branch, capitalised identifier segments ----
+
+/// Why (issue #4739, the FIFTH recurrence in this detector after #1667, #2800,
+/// #4216 and #4312): `Agents.app.bak-20260729-000028` — an ordinary macOS app
+/// bundle backup — was rejected as `Agen…(30 chars)`. It carries no `+`, `/` or
+/// `=`, so the base64 branch #4312 narrowed never runs; it reaches the mixed-case
+/// branch and `is_structural_token`'s segmented-identifier branch declines to
+/// rescue it, because that branch split on `-` alone and admitted only
+/// all-lowercase and ALL-UPPERCASE segments. A leading capital — the single most
+/// ordinary thing about an English word or an app bundle name — read as internal
+/// mixed case.
+///
+/// What this pins: the reproduction verbatim, plus fourteen further shapes of the
+/// same class (release artifacts, screenshots, plist backups, snapshots, branch
+/// and milestone labels) that reproduce the identical defect with different
+/// delimiters. Each is asserted at BOTH levels — the token predicate and the full
+/// `FilterConfig::apply` gate — because the gate is what a memory write actually
+/// hits.
+/// Test: itself.
+#[test]
+fn dotted_capitalised_filenames_are_not_flagged() {
+    let cfg = FilterConfig::default();
+    for (label, tok) in [
+        // The #4739 reproduction, verbatim from the issue body.
+        ("4739 repro", "Agents.app.bak-20260729-000028"),
+        (
+            "4739 repro, full line",
+            "/Applications/Trusty Agents.app.bak-20260729-000028",
+        ),
+        ("release artifact", "Trusty-Agents-v1.3.5-darwin-arm64"),
+        ("macOS screenshot", "Screenshot-2026-08-04-at-10.31.22.png"),
+        ("lockfile backup", "Cargo.lock-backup-20260803-091500"),
+        ("draft doc", "README-Draft-20260804-final.md"),
+        ("instructions backup", "INSTRUCTIONS.md.bak-20260731-000028"),
+        ("session snapshot", "Session-Snapshot-20260804-093000.json"),
+        (
+            "reverse-dns plist backup",
+            "com.apple.Finder.plist.bak-20260101",
+        ),
+        ("app with build number", "Xcode.app-15.4.0-build-2026"),
+        (
+            "double-extension backup",
+            "Agents.app.bak-20260729-000028.zip",
+        ),
+        ("milestone label", "Milestone-1.3.5-Release-Candidate"),
+        ("person-dated note", "Bob.Matsuoka-20260804-notes.md"),
+        // Underscore is an identifier delimiter too (#4739): these were false
+        // positives on origin/main for the same reason, one delimiter over.
+        ("snake_case capitalised", "Trusty_Agents_20260804"),
+        ("dotted snake backup", "Session_Log.2026.08.04.txt"),
+    ] {
+        assert!(
+            find_secret_token(tok).is_none(),
+            "#4739 ({label}): a capitalised, delimiter-segmented filename must \
+             NOT be flagged: {tok}; got {:?}",
+            find_secret_token(tok)
+        );
+        let prose = format!("Checkpoint: rolled back to {tok} after the bounce");
+        assert!(
+            cfg.apply(&prose, true).is_ok(),
+            "#4739 ({label}): the gate must ACCEPT prose carrying {tok}; got {:?}",
+            cfg.apply(&prose, true)
+        );
+    }
+}
+
+/// Why (issue #4739): widening `is_human_word_segment` widens
+/// `is_structural_token`, and `is_structural_token` returning `true` makes
+/// `looks_like_secret` return `false` — so this change NARROWS flagging and can
+/// only lose detection, never add it. #4723 shipped a doc claiming the opposite
+/// direction for a neighbouring predicate and a measurement disproved it, so the
+/// narrowing is pinned here against every credential family the mixed-case branch
+/// is responsible for.
+///
+/// The load-bearing cases are the delimiter-segmented MIXED-CASE blobs. A
+/// careless widening — anything that admits a segment with two uppercase letters
+/// — loses every one of them, because run-of-two case alternation (`AbCd`,
+/// `EfGh`) is exactly the signature of an encoded blob. The predicate admits at
+/// most ONE uppercase letter in a non-uppercase segment, and only as its first
+/// letter, which is what keeps these caught.
+/// What: asserts the mixed-case credential families stay flagged, then pins the
+/// CamelCase residue that this change deliberately did NOT fix.
+/// Test: itself.
+#[test]
+fn real_secrets_still_blocked_after_4739_capitalised_segments() {
+    for (label, tok) in [
+        // LOAD-BEARING: delimiter-segmented mixed-case blobs. If the segment
+        // predicate ever admits two uppercase letters, every one of these is lost.
+        ("hyphenated mixed-case cred", "AbCd1234-EfGh5678-IjKl9012"), // pragma: allowlist secret
+        ("dotted mixed-case cred", "AbCd1234.EfGh5678.IjKl9012"),     // pragma: allowlist secret
+        ("underscored mixed-case cred", "AbCd1234_EfGh5678_IjKl9012"), // pragma: allowlist secret
+        ("camelCase blob segments", "xYzAbc123-qRsTuv456-mNoPqr789"), // pragma: allowlist secret
+        ("slug-prefixed api key", "apikey-Xy7Kp2Qm9Rt4Vw8Nz3Bc6Fj"),  // pragma: allowlist secret
+        ("capitalised head, blob tail", "Prod-AbCd1234EfGh5678IjKl"), // pragma: allowlist secret
+        (
+            "dotted capitalised head, blob tail",
+            "Prod.Key.AbCd1234EfGh5678",
+        ), // pragma: allowlist secret
+        // Unchanged families, re-asserted because the widened predicate sits on
+        // the path every one of them takes.
+        ("bare mixed-case blob", "AbCd1234EfGh5678IjKl9012"), // pragma: allowlist secret
+        ("base64url token", "AbCd1234EfGh5678IjKl9012_MnOp-QrSt="), // pragma: allowlist secret
+        ("colon-bearing credential", "token:aBc123XyZ987uvW456QrS"), // pragma: allowlist secret
+        (
+            "JWT",
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk",
+        ), // pragma: allowlist secret
+        ("GitHub PAT", "ghp_abcdefghijklmnopqrstuvwxyz0123456789"), // pragma: allowlist secret
+        ("AWS key id", "AKIAIOSFODNN7EXAMPLE"),               // pragma: allowlist secret
+        (
+            "padded base64",
+            "dGhpcyBpcyBhIHZlcnkgbG9uZyBzZWNyZXQgdG9rZW4=",
+        ), // pragma: allowlist secret
+        (
+            "basic-auth URL",
+            "https://admin:Sup3rS3cret@internal.example.com/api",
+        ), // pragma: allowlist secret
+        (
+            "lowercase postgres conn",
+            "postgres://user:password@host/database",
+        ), // pragma: allowlist secret
+    ] {
+        assert!(
+            find_secret_token(tok).is_some(),
+            "{label} must STILL be flagged after the #4739 widening: {tok}"
+        );
+    }
+
+    // KNOWN RESIDUE, deliberately not fixed by #4739, asserted rather than left
+    // implicit. A CamelCase segment has TWO capitalised runs, so it is not a word
+    // under `is_human_word_segment` and these stay flagged. Admitting CamelCase
+    // would mean admitting multi-uppercase segments, which is the exact signature
+    // of `AbCdEfGhIjKlMnOpQrSt-1234` — i.e. it would buy two prose cases at the
+    // cost of a credential miss. Measured at both revisions: 17 -> 2 prose false
+    // positives with 0 -> 0 credential misses. If these start passing, the
+    // follow-up landed — move them into
+    // `dotted_capitalised_filenames_are_not_flagged`.
+    for residue in [
+        "TrustyMemory.app.bak-20260801-120000",
+        "MyDocument.Backup.2026.tar.gz",
+    ] {
+        assert!(
+            find_secret_token(residue).is_some(),
+            "KNOWN RESIDUE (#4739): CamelCase segments are still not words, so \
+             this is still flagged. If it now passes, update the bound stated on \
+             `is_human_word_segment`. Token: {residue}"
+        );
+    }
+}


### PR DESCRIPTION
Closes #4739

## The defect

`Agents.app.bak-20260729-000028` — an ordinary macOS app bundle backup — was rejected as `Agen…(30 chars)`. The reproduction from #4312's issue body, Case 1, still live on `fd9d913c`.

It carries no `+`, `/` or `=`, so `has_b64_sym` is false and the base64 branch that PR #4723 narrowed **never runs**. It reaches the mixed-case branch instead, and `is_structural_token`'s segmented-identifier branch declines to rescue it:

```
Agents.app.bak-20260729-000028
  split('-')  ->  ["Agents.app.bak", "20260729", "000028"]
  is_uniform_word_segment("Agents.app.bak")  ->  false   (leading capital A)
```

The predicate admitted only all-lowercase and ALL-UPPERCASE segments, so a leading capital — the single most ordinary thing about an English word or an app bundle name — read as internal mixed case.

## The scoping question the issue asks, answered

> should the mixed-case branch get the same credential-plausibility treatment #2442 gave it and PR #4723 gave the base64 branch, or should the branches share one predicate rather than drifting independently?

**Neither, exactly — because the branches already share a predicate, and this defect is in it.** `is_structural_token` is checked once, before both branches. What I found tracing it is that its three internal branches partition cleanly by delimiter:

| Branch | Fires on | Serves |
|---|---|---|
| (a) `key=value` | token contains `=` | base64 branch |
| (b) slash-path | token contains `/` | base64 branch |
| (c) segmented identifier | reached only after `+`, `=`, `/` are **all** ruled out | mixed-case branch, **exclusively** |

Branch (c) is reachable only when `has_b64_sym` is false by construction. So the shared predicate already has a part dedicated to each branch, and the fix belongs in part (c) — where it fixes the class without any possibility of loosening base64 detection.

Giving the mixed-case branch a second branch-local charset gate would have been recurrence #6 waiting to happen. It already has one (`is_plausible_credential_charset`, #2442), and that gate is *passing* here — a dotted filename is built from exactly the credential charset. Charset was never the discriminator; **word structure** is.

## The fix — two changes, both in the shared predicate

1. **`IDENTIFIER_DELIMITERS = ['-', '_', '.']`.** `is_segmented_identifier` split on `-` alone, so every dot- and underscore-joined name arrived as one unsplittable segment. `.` and `_` delimit identifier words exactly as `-` does.
2. **`is_uniform_word_segment` → `is_human_word_segment`**, accepting `Capitalized` alongside `lowercase` and `UPPERCASE`.

## Direction of the trade, and why the bound is stated as a bound

`is_structural_token` returning `true` makes `looks_like_secret` return `false`. **Widening it narrows flagging and can only lose detection, never add it.** PR #4723 shipped a doc asserting the opposite direction for a neighbouring predicate and a measurement disproved it, so this is measured rather than argued.

The real bound `is_human_word_segment` holds, stated as what it is: **a segment that is not uniformly uppercase admits at most ONE uppercase letter, and only as its first letter.** That is what keeps run-of-two case alternation — `AbCd`, `EfGh`, the signature of an encoded blob — out. It is *not* a claim that no credential can be built from capitalized segments: `Abcd-1234-Efgh-5678` satisfies it. That shape is a product key, already exempt today in its conventional ALL-CAPS form, and carries no case entropy to lose.

## Measured, not asserted

Same 36-shape prose battery and 30-shape credential battery, run at both revisions in this worktree (`filter.rs` reverted to `origin/main` for the baseline so the batteries are identical):

| Corpus | `origin/main` | this PR |
|---|---|---|
| Prose false positives | **17 / 36** | **2 / 36** |
| Credential misses | **0 / 30** | **0 / 30** |

**15 of 17 false positives fixed, zero new credential misses.** Every one of the eight pins PR #4723 left behind is unmoved — the AWS secret-key baseline miss, the two lowercase URL-path known misses, and the four URL prose residue cases all read identically at both revisions.

The credential battery is not just the inherited one. It adds six shapes that specifically probe this widening — `AbCd1234-EfGh5678-IjKl9012`, its `.` and `_` variants, `xYzAbc123-qRsTuv456-mNoPqr789`, `Prod-AbCd1234EfGh5678IjKl`, `Prod.Key.AbCd1234EfGh5678` — because a careless version of this change loses exactly those and nothing else would have noticed.

## What I did NOT fix, and why

CamelCase segments (`TrustyMemory`, `MyDocument`) have two capitalised runs, so they are still not words and these two stay flagged:

```
TrustyMemory.app.bak-20260801-120000
MyDocument.Backup.2026.tar.gz
```

Fixing them means admitting multi-uppercase segments, which is the exact signature of `AbCdEfGhIjKlMnOpQrSt-1234`. That trades a credential miss for two prose cases. 15-of-17 with zero misses is the better deal, so the residue is pinned as an explicit change-detector assertion in `real_secrets_still_blocked_after_4739_capitalised_segments` and stated as a known bound on `is_human_word_segment` rather than left to be rediscovered.

## Guard mutation

Each new guard was mutated and the intended test confirmed failing:

| Mutation | Test that caught it |
|---|---|
| Drop the `Capitalized` acceptance | `dotted_capitalised_filenames_are_not_flagged` — `Agents.app.bak-20260729-000028` |
| Narrow `IDENTIFIER_DELIMITERS` back to `['-']` | `dotted_capitalised_filenames_are_not_flagged` — `INSTRUCTIONS.md.bak-20260731-000028` |
| Over-widen: accept any segment | `real_secrets_still_blocked_after_4739_capitalised_segments` (+ 2 inherited batteries) |

## Gates — Rust Test Ladder **rung 4**

```
$ cargo fmt --check
exit=0

$ cargo check -p trusty-common --features memory-core
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 7.30s

$ cargo clippy -p trusty-common --features memory-core --all-targets -- -D warnings
exit=0

$ cargo test -p trusty-common --features memory-core
running 713 tests
test result: ok. 700 passed; 0 failed; 13 ignored; 0 measured; 0 filtered out; finished in 11.49s
test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out

$ cargo test -p trusty-common --features memory-core --lib -- memory_core::filter
test result: ok. 52 passed; 0 failed; 0 ignored; 0 measured; 661 filtered out
```

> `--features memory-core` is mandatory: `trusty-common`'s default feature set is empty, so a bare `cargo test -p trusty-common` filters out all ~700 memory-core tests and exits 0 while proving nothing.

**Workspace:**

```
$ cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui --exclude trusty-agents-ui
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 38.01s   (exit=0)
```

The three excluded crates fail on the pre-existing environmental Tauri gap (`frontendDist` → `ui/dist` missing). `git status --porcelain` shows zero files touched in them, and CI excludes the same three (`ci.yml:302,308`).

**Direct dependents:**

```
$ cargo test -p trusty-memory
test result: FAILED. 486 passed; 2 failed; 4 ignored; 0 measured; 0 filtered out
    commands::doctor::tests::check_daemon_health_fails_cleanly_with_stale_addr_and_no_listener
    commands::doctor::tests::check_daemon_health_fails_when_no_addr_file_and_no_listener
```

The two known environment-dependent doctor failures (they depend on whether a live memory daemon is listening). `git status --porcelain -- crates/trusty-memory/` is empty — zero files touched in that crate.

```
$ cargo test -p trusty-agents
test result: FAILED. 3311 passed; 1 failed; 11 ignored; 0 measured; 0 filtered out
    assistants::tests::home_tests::for_instance_validates_the_id
```

**Pre-existing flake, proven by repetition rather than asserted.** Zero files touched in that crate. It passes in isolation and fails intermittently under parallel execution, at *both* revisions — `home_tests` run 10× each:

```
my HEAD              : 9 of 10 runs FAILED
pristine origin/main : 5 of 10 runs FAILED   (filter.rs + filter_tests.rs reverted)
```

Root cause is visible and unrelated to this diff: `for_instance_validates_the_id` (`home_tests.rs:106`) mutates the process-global `ASSISTANTS_DIR_ENV` via `EnvVarGuard::set` **without** `#[serial]`, while three sibling tests in the same file (lines 116, 135, 160) are `#[serial]` and one of them sets the same variable. The observed failure is another test's temp root leaking in:

```
left:  ".../trusty-agents-knowledge-e868720e-.../trusty-agents/izzie"
right: ".../.tmpuxe4m1/izzie"
```

Reporting it rather than touching it — it belongs to `trusty-agents`, not to this PR's blast radius, and a sibling engineer is active in that crate.

**Repo gates:**

```
bash scripts/check_line_cap.sh           → 3619 files; 7 allowlisted, 0 violations — OK
bash scripts/check_sld.sh                → 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh → OK trusty-common: fragment present and valid
bash scripts/check-pr-version-bump.sh    → OK trusty-common 0.28.1 — src changed, version not yet published
```

**Version parity:** in-tree `0.28.1`, latest published `0.28.0`. No bump needed, verified against the registry rather than assumed.

Nothing was `#[ignore]`d, `cfg`-gated, `--exclude`d from a crate suite, or `--lib`-narrowed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
