### PR TITLE
fix(trusty-mpm): never delete a worktree git refused to delete (#4732)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4732-locked-worktree-deletion.md
+++ b/crates/trusty-mpm/changelog.d/4732-locked-worktree-deletion.md
@@ -1,0 +1,6 @@
+Fixed
+
+- Worktree teardown no longer deletes worktrees git refused to delete (closes [#4732](https://github.com/bobmatnyc/trusty-tools/issues/4732))
+  - `remove_session_worktree` fell through to `std::fs::remove_dir_all` on ANY non-zero `git worktree remove --force` exit. Git exits 128 for every fatal condition, so `git worktree lock` — the operator's only "do not remove this" — was exactly what caused deletion. A stale worktree pointer, an unreadable `.git`, and a repository git merely declined to read all produced the same outcome, with uncommitted work in the worktree.
+  - Every git failure is now classified into three states — git holds state here / git positively holds nothing here / git could not be asked — and only the middle one permits a raw removal. Locked, stale-pointer, broken-`.git`, and unrecognized-message cases are refused. Reachable from `tm session decommission`, `tm sessions prune --state stopped`, the age-based reaper, `prune_orphaned_worktrees`, and the `--merged-prs` reclaim pass.
+  - The refusal reason is now returned to the caller instead of buried in a log line: `tm session prune-worktrees --merged-prs` reports `removal_failed` entries as `"<path>: <reason>"`.

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -22,6 +22,7 @@ use super::manager::{ManagedError, SessionManager};
 use super::record::{ManagedSessionId, ManagedSessionState, SessionRecord};
 use super::search_gc;
 use super::workspace_guard::is_safe_to_remove;
+use super::worktree_protection;
 use super::worktree_safety::{DirtyWorktree, inspect_dirt};
 
 /// Sentinel file written by [`create_session_worktree`] into every SM-created
@@ -98,6 +99,42 @@ pub(crate) fn is_session_worktree(path: &Path) -> bool {
         .unwrap_or(false)
 }
 
+/// What happened to a worktree the removal path was asked to delete (#4732).
+///
+/// Why: the caller has to be able to tell "gone" from "still on disk, and here
+/// is why" — and it has to be told the reason, not left to find it in a `warn!`
+/// nobody reads. The previous `bool` could express neither: `false` conflated a
+/// deliberate refusal, an I/O error, and a timeout, and the reason existed only
+/// as a log line inside the function.
+/// What: [`Removed`](Self::Removed) — the directory is gone;
+/// [`Kept`](Self::Kept) — it is still on disk, carrying an operator-facing
+/// reason.
+/// Test: `remove_session_worktree_refuses_a_git_locked_worktree`,
+/// `remove_cleans_up_a_directory_no_repository_claims`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum WorktreeRemoval {
+    /// The directory is gone — git removed it, it was already absent, or an
+    /// unclaimed trusty-mpm-owned directory was removed directly.
+    Removed,
+    /// The directory is still on disk. The string says why, for the operator.
+    Kept(String),
+}
+
+impl WorktreeRemoval {
+    /// `true` only when the directory is gone.
+    pub(super) fn removed(&self) -> bool {
+        matches!(self, Self::Removed)
+    }
+
+    /// The operator-facing reason the directory was kept, if it was.
+    pub(super) fn reason(&self) -> Option<&str> {
+        match self {
+            Self::Removed => None,
+            Self::Kept(reason) => Some(reason),
+        }
+    }
+}
+
 /// Remove an in-project per-session git worktree via `git worktree remove --force`.
 ///
 /// Why (#1840): `remove_dir_all` alone leaves the git ref (`session/<id>`) and
@@ -120,17 +157,49 @@ pub(crate) fn is_session_worktree(path: &Path) -> bool {
 /// convention. Branch deletion is best-effort — "not found" is silently
 /// ignored since older sessions may not have a branch. OsStr-safe path args
 /// avoid lossy UTF-8 coercion (#1840).
-/// Idempotent: if `path` is already absent, returns `true` (already removed).
-/// On git failure, best-effort falls back to `remove_dir_all` and logs WARN.
-/// Returns `true` when the workspace was removed (either via git or fallback)
-/// or was already absent; `false` only when all removal attempts failed.
-/// Test: `is_session_worktree_absent_path_is_noop`; integration coverage via
-/// the decommission round-trip tests that set up real git worktrees.
-pub(super) fn remove_session_worktree(path: &Path) -> bool {
+/// Idempotent: if `path` is already absent, returns
+/// [`Removed`](WorktreeRemoval::Removed).
+///
+/// # 🔴 Git declining is a REFUSAL, not a failure (#4732)
+///
+/// This function used to fall through to `std::fs::remove_dir_all` on ANY
+/// non-zero exit, and on any failure to resolve the owning checkout. Git exits
+/// 128 for every fatal condition, so that fall-through deleted the exact things
+/// git was protecting — most sharply, `git worktree lock`, whose only mechanism
+/// for saying "leave this alone" is a 128 exit. Locking a worktree to protect
+/// it was what got it deleted. A stale worktree pointer and an unreadable
+/// `.git` produced the same outcome while their working trees, uncommitted work
+/// included, were entirely intact.
+///
+/// Every git failure is now classified by
+/// [`super::worktree_protection`], which answers three states and refuses on
+/// two of them. The `remove_dir_all` fallback survives for EXACTLY ONE case:
+///
+/// > `path` has passed the trusty-mpm ownership gate above, and git has
+/// > POSITIVELY established that it holds no state there — the path carries no
+/// > `.git` entry, and either no repository exists above it at all, or the
+/// > owning repository's `git worktree list` does not name it.
+///
+/// That is a leftover directory: a worktree git already pruned, or one whose
+/// creation never completed registration. There is no ref to prune and nothing
+/// for git to protect, so a direct removal is the only way to clean it up.
+/// Every other outcome — including "git could not be asked" — keeps the
+/// directory and returns [`Kept`](WorktreeRemoval::Kept) with the reason.
+///
+/// Test: `is_session_worktree_absent_path_is_noop`,
+/// `remove_session_worktree_refuses_a_git_locked_worktree`,
+/// `remove_refuses_a_stale_worktree_pointer`,
+/// `remove_refuses_an_unreadable_git_entry`,
+/// `remove_refuses_a_worktree_with_a_broken_git_file`,
+/// `remove_cleans_up_a_directory_no_repository_claims`,
+/// `remove_cleans_up_an_unregistered_leftover_inside_a_repo`,
+/// `remove_still_removes_a_healthy_worktree`; integration coverage via the
+/// decommission round-trip tests that set up real git worktrees.
+pub(super) fn remove_session_worktree(path: &Path) -> WorktreeRemoval {
     if !path.exists() {
         // Already gone — either removed by a concurrent decommission or by a
         // previous partial run. Treat as success (idempotent removal).
-        return true;
+        return WorktreeRemoval::Removed;
     }
 
     // Data-safety gate (#1845 item 5): prefer the SM ownership sentinel over the
@@ -150,7 +219,10 @@ pub(super) fn remove_session_worktree(path: &Path) -> bool {
                 "decommission: refusing worktree removal — no SM ownership sentinel \
                  and path is not under .worktrees/; skipping conservatively"
             );
-            return false;
+            return WorktreeRemoval::Kept(format!(
+                "no trusty-mpm ownership sentinel ({WORKTREE_SENTINEL_FILE}) and the path \
+                 is not under {WORKTREES_DIRNAME}/"
+            ));
         }
         warn!(
             path = %path.display(),
@@ -168,19 +240,26 @@ pub(super) fn remove_session_worktree(path: &Path) -> bool {
     let repo_root = match super::worktree_registry::registry_root_for(path) {
         Some(r) => r,
         None => {
-            // No git registry claims this path — it is a plain directory, not a
-            // worktree. The sentinel gate above already established trusty-mpm
-            // owns it, so remove the directory directly rather than refusing.
+            // #4732: a `None` here is NOT "no git repository owns this path".
+            // `registry_root_for` also returns `None` when git could not
+            // resolve one — which is exactly what a worktree with a stale or
+            // unreadable `.git` pointer answers, while its working tree and
+            // uncommitted work are entirely intact. Classify before deleting.
+            let verdict = worktree_protection::protection_without_registry_root(path);
+            if let Some(reason) = verdict.refusal() {
+                warn!(
+                    path = %path.display(),
+                    "decommission: refusing worktree removal — {reason} (#4732)"
+                );
+                return WorktreeRemoval::Kept(reason.to_string());
+            }
+            // The one surviving fallback case — see this function's doc.
             warn!(
                 path = %path.display(),
-                "decommission: no git repository owns this path — removing the \
+                "decommission: no git repository claims this path — removing the \
                  directory directly (no worktree ref to prune)"
             );
-            if let Err(e) = std::fs::remove_dir_all(path) {
-                warn!(path = %path.display(), "decommission: remove_dir_all failed: {e}");
-                return false;
-            }
-            return true;
+            return remove_unclaimed_directory(path);
         }
     };
     let repo_root = repo_root.as_path();
@@ -192,39 +271,84 @@ pub(super) fn remove_session_worktree(path: &Path) -> bool {
         .args(["worktree", "remove", "--force"])
         .arg(path)
         .output();
-    let git_success = match out {
+    match out {
         Ok(o) if o.status.success() => {
             info!(path = %path.display(), "decommission: git worktree removed (incl. ref)");
-            true
+            prune_refs_after_removal(repo_root, path);
+            WorktreeRemoval::Removed
         }
         Ok(o) => {
+            // #4732: git exits 128 for every fatal condition, and `git worktree
+            // lock` uses that exit to REFUSE. Classify the reason instead of
+            // reading every non-zero exit as permission to delete by hand.
             let stderr = String::from_utf8_lossy(&o.stderr);
+            let verdict =
+                worktree_protection::protection_after_failed_removal(path, repo_root, &stderr);
+            if let Some(reason) = verdict.refusal() {
+                warn!(
+                    path = %path.display(),
+                    "decommission: git worktree remove --force declined ({}) and the \
+                     directory must be preserved — {reason} (#4732)",
+                    o.status
+                );
+                return WorktreeRemoval::Kept(reason.to_string());
+            }
+            // The one surviving fallback case — see this function's doc.
             warn!(
                 path = %path.display(),
-                "decommission: git worktree remove --force failed ({}): {stderr}; \
-                 falling back to remove_dir_all",
+                "decommission: git holds no worktree state at this path ({}: {stderr}); \
+                 removing the leftover directory directly",
                 o.status
             );
-            if let Err(e) = std::fs::remove_dir_all(path) {
-                warn!(path = %path.display(), "decommission: fallback remove_dir_all failed: {e}");
-                return false;
-            }
-            false // git remove failed, but dir removal succeeded
+            remove_unclaimed_directory(path)
         }
         Err(e) => {
+            // #4732: git could not be run at all, so nothing is known about
+            // what it may be protecting. An unanswerable probe is never a
+            // licence to delete.
+            let reason = format!("git could not be run to remove the worktree: {e}");
             warn!(
                 path = %path.display(),
-                "decommission: failed to spawn git for worktree removal: {e}; \
-                 falling back to remove_dir_all"
+                "decommission: refusing worktree removal — {reason} (#4732)"
             );
-            if let Err(e2) = std::fs::remove_dir_all(path) {
-                warn!(path = %path.display(), "decommission: fallback remove_dir_all also failed: {e2}");
-                return false;
-            }
-            false
+            WorktreeRemoval::Kept(reason)
         }
-    };
-    if git_success {
+    }
+}
+
+/// Remove a directory git has POSITIVELY disclaimed (#4732).
+///
+/// Why: named so the one legitimate `remove_dir_all` in this module has exactly
+/// one call shape and is greppable. Reaching it requires a
+/// [`worktree_protection`] verdict of "no git state at or claiming this path" —
+/// never a bare non-zero exit, and never an unanswerable probe. See
+/// [`remove_session_worktree`]'s doc for the full statement of that case.
+/// What: `std::fs::remove_dir_all`, mapped onto [`WorktreeRemoval`].
+/// Test: `remove_cleans_up_a_directory_no_repository_claims`,
+/// `remove_cleans_up_an_unregistered_leftover_inside_a_repo`.
+fn remove_unclaimed_directory(path: &Path) -> WorktreeRemoval {
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => WorktreeRemoval::Removed,
+        Err(e) => {
+            warn!(path = %path.display(), "decommission: remove_dir_all failed: {e}");
+            WorktreeRemoval::Kept(format!("removing the directory failed: {e}"))
+        }
+    }
+}
+
+/// Clear the git refs a successful `git worktree remove` leaves behind (#1840,
+/// #2032).
+///
+/// Why: split out of [`remove_session_worktree`] when #4732 turned that
+/// function's tail into a three-way classification — the ref cleanup is
+/// best-effort bookkeeping that runs only after git itself removed the
+/// worktree, and interleaving it with the safety classification made both
+/// harder to read.
+/// What: `git worktree prune`, then `git branch -D session/<leaf>`. Both are
+/// best-effort; a failure leaves a stale ref in git's output, never data loss.
+/// Test: `manager_decommission_removes_real_git_worktree` asserts both effects.
+fn prune_refs_after_removal(repo_root: &Path, path: &Path) {
+    {
         // Step 2: git worktree prune to clear any stale git worktree refs.
         // Best-effort: a failure here is a minor annoyance (stale ref in git output),
         // not a correctness failure.
@@ -286,7 +410,6 @@ pub(super) fn remove_session_worktree(path: &Path) -> bool {
             }
         }
     }
-    true // workspace was removed (either via git or fallback)
 }
 
 impl SessionManager {
@@ -577,28 +700,28 @@ impl SessionManager {
                         let ws_clone = ws.clone();
                         let join =
                             tokio::task::spawn_blocking(move || remove_session_worktree(&ws_clone));
-                        workspace_removed =
+                        let outcome =
                             match tokio::time::timeout(GIT_WORKTREE_REMOVE_TIMEOUT, join).await {
-                                Ok(Ok(removed)) => removed,
+                                Ok(Ok(outcome)) => outcome,
                                 Ok(Err(e)) => {
-                                    warn!(
-                                        id = %id,
-                                        workspace = %ws.display(),
-                                        "decommission: remove_session_worktree task panicked: {e}"
-                                    );
-                                    false
+                                    WorktreeRemoval::Kept(format!("the removal task panicked: {e}"))
                                 }
-                                Err(_elapsed) => {
-                                    warn!(
-                                        id = %id,
-                                        workspace = %ws.display(),
-                                        timeout_secs = GIT_WORKTREE_REMOVE_TIMEOUT.as_secs(),
-                                        "decommission: git worktree remove timed out; \
-                                         worktree may require manual cleanup"
-                                    );
-                                    false
-                                }
+                                Err(_elapsed) => WorktreeRemoval::Kept(format!(
+                                    "git worktree remove did not finish within {}s; the \
+                                     worktree may require manual cleanup",
+                                    GIT_WORKTREE_REMOVE_TIMEOUT.as_secs()
+                                )),
                             };
+                        // #4732: the reason now comes back FROM the remover
+                        // rather than being buried in a log line inside it.
+                        workspace_removed = outcome.removed();
+                        if let Some(reason) = outcome.reason() {
+                            warn!(
+                                id = %id,
+                                workspace = %ws.display(),
+                                "decommission: worktree left on disk — {reason}"
+                            );
+                        }
                     }
                 } else {
                     warn!(

--- a/crates/trusty-mpm/src/session_manager/decommission_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_tests.rs
@@ -54,11 +54,11 @@ fn is_session_worktree_absent_path_is_noop() {
     let absent = std::path::Path::new("/nonexistent/.worktrees/session-abc");
     // is_session_worktree: true (immediate parent is `.worktrees`)
     assert!(is_session_worktree(absent));
-    // remove_session_worktree: returns true idempotently (path already absent)
+    // remove_session_worktree: reports Removed idempotently (path already absent)
     let result = remove_session_worktree(absent);
     assert!(
-        result,
-        "absent path should return true (idempotently removed)"
+        result.removed(),
+        "absent path should report Removed (idempotently removed)"
     );
 }
 
@@ -82,8 +82,12 @@ fn sentinel_gates_worktree_removal_refuses_non_worktrees_dir_without_sentinel() 
     );
     let result = remove_session_worktree(&wt_path);
     assert!(
-        !result,
-        "remove_session_worktree must return false for non-worktrees dir without sentinel"
+        !result.removed(),
+        "remove_session_worktree must refuse a non-worktrees dir without a sentinel"
+    );
+    assert!(
+        result.reason().is_some_and(|r| r.contains("sentinel")),
+        "#4732: and must say WHY, so the caller can report it: {result:?}"
     );
     // The directory must NOT have been deleted.
     assert!(

--- a/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission_worktree_tests.rs
@@ -409,3 +409,150 @@ async fn prune_reports_dirty_worktree_retained() {
         "the uncommitted file must survive a prune sweep"
     );
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// #4732: git declining is a REFUSAL, not a failure to work around.
+//
+// Every test below fails against the pre-#4732 remover, which fell through to
+// `std::fs::remove_dir_all` on ANY non-zero git exit and on any failure to
+// resolve the owning checkout. The two "cleans up" tests are the other half of
+// the contract: the one legitimate fallback case must still work, or this fix
+// would have traded a data-loss bug for a leak.
+// ─────────────────────────────────────────────────────────────────────────
+
+use super::decommission::remove_session_worktree;
+use super::worktree_git_fixture::{GitWorktreeFixture, deny_all};
+
+/// A worktree whose admin directory was removed out of band must be preserved
+/// (#4732).
+///
+/// Why: `git rev-parse` from inside it answers `not a git repository: (null)`,
+/// which `registry_root_for` reports as `None` — and the remover read that
+/// `None` as "a plain directory nothing claims". The working tree, including
+/// work that was never committed anywhere, is entirely intact. This is the
+/// state ~70 worktrees on this machine were left in on 2026-07-21.
+#[test]
+fn remove_refuses_a_stale_worktree_pointer() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("stale-pointer-e2e-4732");
+    std::fs::write(wt.join("precious.txt"), "never committed\n").expect("write precious file");
+    std::fs::remove_dir_all(fx.repo.join(".git").join("worktrees")).expect("drop admin dir");
+
+    let outcome = remove_session_worktree(&wt);
+    assert!(
+        wt.join("precious.txt").exists(),
+        "a stale pointer must not cost the working tree: {outcome:?}"
+    );
+    assert!(
+        !outcome.removed(),
+        "and must report NOT removed: {outcome:?}"
+    );
+}
+
+/// A `.git` git cannot read is a worktree, not an absent one (#4732).
+#[test]
+fn remove_refuses_an_unreadable_git_entry() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("unreadable-git-e2e-4732");
+    std::fs::write(wt.join("precious.txt"), "never committed\n").expect("write precious file");
+    let _restore = deny_all(&wt.join(".git"));
+
+    let outcome = remove_session_worktree(&wt);
+    assert!(
+        wt.join("precious.txt").exists(),
+        "an unreadable .git must not cost the working tree: {outcome:?}"
+    );
+    assert!(
+        !outcome.removed(),
+        "and must report NOT removed: {outcome:?}"
+    );
+}
+
+/// `is not a .git file` is git validating and declining, not git reporting an
+/// empty directory (#4732).
+#[test]
+fn remove_refuses_a_worktree_with_a_broken_git_file() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("broken-git-e2e-4732");
+    std::fs::write(wt.join("precious.txt"), "never committed\n").expect("write precious file");
+    std::fs::write(wt.join(".git"), "gitdir: /nonexistent/xyz\n").expect("corrupt .git");
+
+    let outcome = remove_session_worktree(&wt);
+    assert!(
+        wt.join("precious.txt").exists(),
+        "a broken .git must not cost the working tree: {outcome:?}"
+    );
+    assert!(
+        !outcome.removed(),
+        "and must report NOT removed: {outcome:?}"
+    );
+}
+
+/// The surviving fallback, half one: a trusty-mpm-owned directory with no
+/// repository above it at all (#4732).
+///
+/// Why: pinning this is what keeps the fix from silently becoming "never clean
+/// anything up". Nothing can be claiming a directory outside every repository,
+/// so there is no git state to protect and a direct removal is the only way to
+/// reclaim it.
+#[test]
+fn remove_cleans_up_a_directory_no_repository_claims() {
+    let tmp = crate::test_support::hermetic_temp_dir();
+    let leftover = tmp.path().join("leftover-4732");
+    std::fs::create_dir_all(&leftover).expect("mkdir");
+    std::fs::write(leftover.join(WORKTREE_SENTINEL_FILE), b"").expect("write sentinel");
+
+    let outcome = remove_session_worktree(&leftover);
+    assert!(outcome.removed(), "{outcome:?}");
+    assert!(!leftover.exists(), "the leftover directory must be gone");
+}
+
+/// The surviving fallback, half two: a leftover inside a real repository whose
+/// registry positively does not name it (#4732).
+///
+/// Why: this is the ordinary shape — a worktree git already pruned, or one
+/// whose creation never completed registration. Git holds nothing, so the
+/// directory is the only thing to clean up.
+#[test]
+fn remove_cleans_up_an_unregistered_leftover_inside_a_repo() {
+    let fx = GitWorktreeFixture::new();
+    let leftover = fx.repo.join(".worktrees").join("unregistered-e2e-4732");
+    std::fs::create_dir_all(&leftover).expect("mkdir");
+
+    let outcome = remove_session_worktree(&leftover);
+    assert!(outcome.removed(), "{outcome:?}");
+    assert!(!leftover.exists(), "the leftover directory must be gone");
+}
+
+/// The happy path is unchanged: git removes a healthy worktree, and the ref
+/// cleanup still runs behind it (#4732 regression guard).
+#[test]
+fn remove_still_removes_a_healthy_worktree() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("healthy-4732");
+
+    let outcome = remove_session_worktree(&wt);
+    assert!(outcome.removed(), "{outcome:?}");
+    assert!(!wt.exists(), "the worktree directory must be gone");
+
+    let listed = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&fx.repo)
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .expect("git worktree list");
+    assert!(
+        !String::from_utf8_lossy(&listed.stdout).contains("healthy-4732"),
+        "the registry entry must be pruned too"
+    );
+    let branches = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&fx.repo)
+        .args(["branch", "--list", "session/healthy-4732"])
+        .output()
+        .expect("git branch --list");
+    assert!(
+        String::from_utf8_lossy(&branches.stdout).trim().is_empty(),
+        "the session branch must be deleted too"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -37,6 +37,9 @@ mod worktree_nested;
 pub(crate) mod worktree_ownership;
 // #2919: merged-PR reclamation + the disk accounting `tm doctor` reports.
 pub(crate) mod worktree_reclaim;
+// #4732: the tri-state "does git still hold state here?" classifier that gates
+// every raw directory removal on the worktree teardown path.
+mod worktree_protection;
 // #2919: the survey and the fresh-recheck delete loop that acts on it.
 pub(crate) mod worktree_reclaim_sweep;
 pub(crate) mod worktree_reconcile;

--- a/crates/trusty-mpm/src/session_manager/prune.rs
+++ b/crates/trusty-mpm/src/session_manager/prune.rs
@@ -773,7 +773,7 @@ impl SessionManager {
         dry_run: bool,
         policy: DirtyWorktreePolicy,
     ) -> Result<OrphanSweepOutcome, anyhow::Error> {
-        use super::decommission::remove_session_worktree;
+        use super::decommission::{WorktreeRemoval, remove_session_worktree};
         use super::worktree_ownership::SentinelOwner;
         use std::collections::HashSet;
 
@@ -966,16 +966,25 @@ impl SessionManager {
 
             info!(path = %candidate.display(), "prune-worktrees: removing orphaned worktree");
             let candidate_clone = candidate.clone();
-            let removed_ok =
+            let outcome =
                 tokio::task::spawn_blocking(move || remove_session_worktree(&candidate_clone))
                     .await
                     .unwrap_or_else(|e| {
                         tracing::error!(
                             "prune-worktrees: spawn_blocking panicked during removal: {e}"
                         );
-                        false
+                        WorktreeRemoval::Kept(format!("the removal task panicked: {e}"))
                     });
-            if removed_ok {
+            // #4732: the remover now reports WHY it kept a worktree — most
+            // often a deliberate refusal (a `git worktree lock`, a stale
+            // pointer), which used to be indistinguishable from a silent no-op.
+            if let Some(reason) = outcome.reason() {
+                warn!(
+                    path = %candidate.display(),
+                    "prune-worktrees: worktree kept — {reason}"
+                );
+            }
+            if outcome.removed() {
                 removed.push(candidate);
             }
         }

--- a/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_git_fixture.rs
@@ -65,6 +65,42 @@ fn git_ok(dir: &Path, args: &[&str]) {
     );
 }
 
+/// Restores a path's permission bits when it drops, pass or panic (#4732).
+///
+/// Why: the "git cannot read this" tests work by `chmod 000`-ing a real `.git`
+/// entry. A mode left behind survives the assertion that unwinds past it and
+/// can defeat `TempDir`'s own cleanup, so the restore has to be a `Drop`, not a
+/// line at the end of the test.
+/// What: captures the current mode on construction and re-applies it on drop.
+/// Test: `an_unreadable_git_entry_is_protected`,
+/// `remove_refuses_an_unreadable_git_entry`.
+pub(crate) struct RestoreMode {
+    path: PathBuf,
+    mode: u32,
+}
+
+impl Drop for RestoreMode {
+    fn drop(&mut self) {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(self.mode));
+    }
+}
+
+/// `chmod 000 <path>`, restored when the returned guard drops (#4732).
+pub(crate) fn deny_all(path: &Path) -> RestoreMode {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = std::fs::symlink_metadata(path)
+        .expect("fixture: stat before chmod")
+        .permissions()
+        .mode();
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o000))
+        .expect("fixture: chmod 000");
+    RestoreMode {
+        path: path.to_path_buf(),
+        mode,
+    }
+}
+
 impl GitWorktreeFixture {
     /// Build a checkout on `main`, pushed to a bare remote in the same temp dir.
     ///
@@ -179,14 +215,16 @@ impl GitWorktreeFixture {
     /// this" (#4224 review).
     ///
     /// Why: git itself honours the lock — `git worktree remove --force` exits
-    /// 128 rather than removing it. But `decommission::remove_session_worktree`
-    /// treats that non-zero exit as a git failure and falls back to
-    /// `std::fs::remove_dir_all`, which deletes the directory regardless, so the
-    /// lock can only be honoured by never enumerating the worktree in the first
-    /// place. Proving that requires a really-locked worktree; setting the flag
-    /// on a parsed record instead would test the parser, not the filter.
+    /// 128 rather than removing it. Until #4732
+    /// `decommission::remove_session_worktree` treated that non-zero exit as a
+    /// git failure and fell back to `std::fs::remove_dir_all`, deleting the
+    /// directory regardless; both the enumeration filter and the remover now
+    /// honour it. Proving either requires a really-locked worktree; setting the
+    /// flag on a parsed record instead would test the parser, not the gate.
     /// What: `git -C <repo> worktree lock <wt>`.
-    /// Test: `enumerate_excludes_a_locked_worktree`.
+    /// Test: `enumerate_excludes_a_locked_worktree`,
+    /// `remove_session_worktree_refuses_a_git_locked_worktree`,
+    /// `a_locked_worktree_is_protected`.
     pub(crate) fn lock_worktree(&self, wt: &Path) {
         git_ok(
             &self.repo,

--- a/crates/trusty-mpm/src/session_manager/worktree_protection.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_protection.rs
@@ -1,0 +1,270 @@
+//! Does git still hold state at this directory? (issue #4732)
+//!
+//! Why: `decommission::remove_session_worktree` used to read ANY non-zero
+//! `git worktree remove --force` exit as "git could not do it, so do it
+//! ourselves" and fall through to `std::fs::remove_dir_all`. Git exits 128 for
+//! every fatal condition, and the worst of them is deliberate: `git worktree
+//! lock` is an operator's explicit "do not remove this", and git honours it by
+//! exiting 128. Locking a worktree to protect it was therefore exactly what
+//! caused it to be deleted. The same fall-through swallowed a stale worktree
+//! pointer, an unreadable `.git`, and a repository git merely declined to read.
+//!
+//! What: [`GitProtection`] — three states, never a bool. "git holds state here"
+//! and "git could not be asked" are different facts, but they have the SAME
+//! safe answer (refuse), while "git positively holds nothing here" is the only
+//! state that may proceed to a raw directory removal. Two entry points classify
+//! the two ways the removal path can fail to get an answer from git:
+//! [`protection_after_failed_removal`] (git ran and declined) and
+//! [`protection_without_registry_root`] (git would not even name the checkout
+//! that owns the path).
+//!
+//! This module NEVER writes and NEVER removes. Every git invocation here is a
+//! read-only query.
+//!
+//! Scope note: #4735 will lift this into a shared `GitProbe<T>` alongside
+//! `trusty-agents-common`'s `agents::vcs_claim`, whose three-state shape,
+//! narrow stderr matching, and filesystem corroboration this module
+//! deliberately mirrors. It is one self-contained file so that extraction is a
+//! move rather than a rewrite.
+//!
+//! Test: `worktree_protection_tests`.
+
+use std::path::Path;
+
+use super::worktree_registry::{list_registered_worktrees, registry_root_for};
+
+/// The only `git worktree remove` stderr CONSISTENT with "git has nothing
+/// registered at this path".
+///
+/// Why: the exit code cannot distinguish the cases — git exits 128 for all of
+/// them. Measured against git 2.54.0, the three failures this path actually
+/// meets are:
+///
+/// | condition | stderr | exit |
+/// |---|---|---|
+/// | operator-locked worktree | `cannot remove a locked working tree; use 'remove -f -f' …` | 128 |
+/// | worktree with a broken `.git` file | `validation failed, cannot remove working tree: '…/.git' is not a .git file, error code 7` | 128 |
+/// | plain directory / already-pruned worktree | `'<path>' is not a working tree` | 128 |
+///
+/// Only the third means git is holding nothing. Note how close the second one
+/// reads — `is not a .git file` — while meaning the opposite; matching on the
+/// looser `not a working tree` fragment or on `128` alone deletes a live
+/// worktree. Anything that is not this exact phrase is treated as a REFUSAL,
+/// so an unrecognized or reworded message fails closed.
+///
+/// Consistent with, NOT proof of: git emits this same text for a worktree
+/// whose admin directory (`.git/worktrees/<name>`) was removed out of band,
+/// where the working tree and its uncommitted content are entirely intact —
+/// the state ~70 worktrees on this machine were left in on 2026-07-21.
+/// [`protection_after_failed_removal`] therefore corroborates it against a
+/// filesystem witness and git's own registry before concluding anything.
+/// What: verified byte-identical against git 2.54.0.
+/// Test: `a_locked_worktree_is_protected`,
+/// `a_broken_git_file_is_protected`,
+/// `an_unregistered_directory_inside_a_repo_is_unclaimed`.
+const NOT_A_WORKING_TREE: &str = "is not a working tree";
+
+/// What git says about a directory the removal path is about to delete (#4732).
+///
+/// Why: [`Undetermined`](Self::Undetermined) is not a synonym for
+/// [`Unclaimed`](Self::Unclaimed). If git could not be consulted, the honest
+/// answer is that protected state cannot be ruled out, and the caller must
+/// refuse rather than guess. Folding the two together is the fail-open shape
+/// that made this function delete locked worktrees.
+/// What: [`Protected`](Self::Protected) — git holds state here, or declined to
+/// give it up; [`Unclaimed`](Self::Unclaimed) — positively established that no
+/// git state exists at or claiming this path; [`Undetermined`](Self::Undetermined)
+/// — no conclusion is available. Both non-`Unclaimed` variants carry an
+/// operator-facing reason and are reported identically by
+/// [`Self::refusal`], so a caller cannot accidentally handle only one of them.
+/// Test: `worktree_protection_tests`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum GitProtection {
+    /// Git holds state here, or declined to remove it. NEVER delete.
+    Protected(String),
+    /// No git state exists at or claiming this path. A raw removal is safe.
+    Unclaimed,
+    /// Git could not be consulted, or gave an answer this code cannot read.
+    Undetermined(String),
+}
+
+impl GitProtection {
+    /// `Some(reason)` when the caller must NOT remove the directory.
+    ///
+    /// Why: the whole point of the three states is that two of them refuse.
+    /// Exposing the refusal as one accessor means a caller cannot match on
+    /// `Protected` alone and silently let `Undetermined` through — the exact
+    /// collapse this enum exists to prevent.
+    /// What: `None` only for [`Unclaimed`](Self::Unclaimed).
+    /// Test: `refusal_covers_both_non_unclaimed_states`.
+    pub(super) fn refusal(&self) -> Option<&str> {
+        match self {
+            Self::Unclaimed => None,
+            Self::Protected(reason) | Self::Undetermined(reason) => Some(reason),
+        }
+    }
+}
+
+/// Does `path` itself carry a `.git` entry?
+///
+/// Why: this is a witness git does not consult once its own discovery has
+/// failed. `symlink_metadata` needs only the PARENT directory's search bit,
+/// which is necessarily present — the caller already stat'd `path`. So a
+/// worktree whose `.git` file dangles, is unreadable (mode 000), or names a
+/// gitdir that no longer exists still answers `true` here, even though every
+/// `git` invocation against it reports "not a git repository".
+/// What: `symlink_metadata` on `<path>/.git`, which does not follow the link
+/// and does not read the entry's contents.
+/// Test: `a_stale_worktree_pointer_is_protected`,
+/// `an_unreadable_git_entry_is_protected`.
+fn carries_git_entry(path: &Path) -> bool {
+    path.join(".git").symlink_metadata().is_ok()
+}
+
+/// Does the repository rooted at `root` still register `path` as a worktree?
+///
+/// Why: `git worktree list --porcelain` is the registry itself — a structured
+/// answer, not a message to be pattern-matched. When it disagrees with the
+/// removal command's stderr, the registry wins and the path is protected.
+/// What: `None` from [`list_registered_worktrees`] is an unanswerable probe,
+/// never an empty registry, so it yields
+/// [`Undetermined`](GitProtection::Undetermined). Paths are compared
+/// canonicalised on both sides because git records resolved paths (`/private/var`
+/// on macOS) while callers hold the unresolved spelling; a `path` that cannot be
+/// canonicalised is itself [`Undetermined`](GitProtection::Undetermined) rather
+/// than compared as a raw string that could never match.
+/// Test: `a_locked_worktree_is_protected`,
+/// `a_registered_worktree_is_protected_even_when_git_says_otherwise`,
+/// `an_unregistered_directory_inside_a_repo_is_unclaimed`.
+fn registry_verdict(root: &Path, path: &Path) -> GitProtection {
+    let Some(registered) = list_registered_worktrees(root) else {
+        return GitProtection::Undetermined(
+            "git's worktree registry could not be read for the owning checkout".into(),
+        );
+    };
+    let Ok(canonical) = path.canonicalize() else {
+        return GitProtection::Undetermined(
+            "the path could not be canonicalised, so git's registry cannot be compared \
+             against it"
+                .into(),
+        );
+    };
+    let found = registered
+        .into_iter()
+        .find(|w| w.path.canonicalize().unwrap_or_else(|_| w.path.clone()) == canonical);
+    match found {
+        Some(w) if w.locked => GitProtection::Protected(
+            "the worktree is git-locked — an explicit operator 'do not remove this'".into(),
+        ),
+        Some(_) => {
+            GitProtection::Protected("git still registers this path as one of its worktrees".into())
+        }
+        None => GitProtection::Unclaimed,
+    }
+}
+
+/// Classify a NON-ZERO `git worktree remove --force` exit (#4732).
+///
+/// Why: this decides whether the raw `remove_dir_all` fallback may run at all.
+/// Before #4732 it always ran, so `git worktree lock` — the one mechanism an
+/// operator has to say "leave this alone" — caused deletion instead of
+/// preventing it.
+/// What: three gates, each fail-closed.
+///   1. stderr is not [`NOT_A_WORKING_TREE`] → git declined for a reason this
+///      code does not recognize as "nothing here". Refuse, quoting git.
+///   2. `path` carries a `.git` entry → git's message is describing its own
+///      failed discovery, not an empty directory. Refuse.
+///   3. otherwise the owning repository's registry decides, via
+///      [`registry_verdict`].
+///
+/// Only gate 3 returning [`Unclaimed`](GitProtection::Unclaimed) permits the
+/// fallback.
+///
+/// Test: `a_locked_worktree_is_protected`, `a_broken_git_file_is_protected`,
+/// `a_registered_worktree_is_protected_even_when_git_says_otherwise`,
+/// `an_unregistered_directory_inside_a_repo_is_unclaimed`,
+/// `an_unreadable_registry_is_undetermined`.
+pub(super) fn protection_after_failed_removal(
+    path: &Path,
+    repo_root: &Path,
+    stderr: &str,
+) -> GitProtection {
+    if !stderr.contains(NOT_A_WORKING_TREE) {
+        return GitProtection::Protected(format!(
+            "git declined to remove it: {}",
+            stderr.split_whitespace().collect::<Vec<_>>().join(" ")
+        ));
+    }
+    if carries_git_entry(path) {
+        return GitProtection::Protected(
+            "the directory carries a .git entry — a worktree git could not read, \
+             not an unmanaged directory"
+                .into(),
+        );
+    }
+    registry_verdict(repo_root, path)
+}
+
+/// Classify the case where git would not name a registry root for `path` (#4732).
+///
+/// Why: `registry_root_for` returns `None` both when there is genuinely no
+/// repository and when git could not resolve one — and the removal path read
+/// that `None` as "a plain directory, remove it directly". A worktree whose
+/// admin directory was deleted out of band answers exactly that way
+/// (`fatal: not a git repository: (null)`) while its working tree, including
+/// uncommitted work, is fully intact. That is the state the 2026-07-21 incident
+/// left ~70 worktrees in.
+/// What: three gates, each fail-closed.
+///   1. `path` carries a `.git` entry → it IS a checkout or worktree, however
+///      broken. Refuse.
+///   2. no ancestor carries a `.git` entry → positively outside any repository,
+///      so nothing can be claiming it. [`Unclaimed`](GitProtection::Unclaimed).
+///      The path is canonicalised first: a relative path would otherwise walk a
+///      truncated ancestor chain, miss the project's `.git`, and land back on
+///      the permissive answer.
+///   3. an ancestor IS a repository → that repository's registry decides, via
+///      [`registry_verdict`] against the root git names for the PARENT
+///      directory (asking from `path` itself is what failed).
+///
+/// Test: `a_stale_worktree_pointer_is_protected`,
+/// `an_unreadable_git_entry_is_protected`,
+/// `a_directory_no_repository_claims_is_unclaimed`,
+/// `an_unregistered_leftover_under_a_repo_is_unclaimed`.
+pub(super) fn protection_without_registry_root(path: &Path) -> GitProtection {
+    if carries_git_entry(path) {
+        return GitProtection::Protected(
+            "the directory carries a .git entry that git cannot resolve — a stale or \
+             broken worktree pointer, not an unmanaged directory"
+                .into(),
+        );
+    }
+    let Ok(canonical) = path.canonicalize() else {
+        return GitProtection::Undetermined(
+            "the path could not be canonicalised, so its ancestors cannot be inspected".into(),
+        );
+    };
+    let ancestor_repo = canonical
+        .ancestors()
+        .skip(1)
+        .any(|a| a.join(".git").symlink_metadata().is_ok());
+    if !ancestor_repo {
+        return GitProtection::Unclaimed;
+    }
+    let Some(parent) = canonical.parent() else {
+        return GitProtection::Undetermined(
+            "an ancestor carries a .git entry but the path has no parent to ask about".into(),
+        );
+    };
+    let Some(root) = registry_root_for(parent) else {
+        return GitProtection::Undetermined(
+            "an ancestor carries a .git entry but git would not name the checkout that \
+             owns it"
+                .into(),
+        );
+    };
+    registry_verdict(&root, &canonical)
+}
+
+#[cfg(test)]
+#[path = "worktree_protection_tests.rs"]
+mod worktree_protection_tests;

--- a/crates/trusty-mpm/src/session_manager/worktree_protection_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_protection_tests.rs
@@ -1,0 +1,339 @@
+//! Tests for the "does git still hold state here?" classifier (#4732).
+//!
+//! Why: this module is the only thing standing between a non-zero `git`
+//! exit and `std::fs::remove_dir_all`, so every gate is driven against REAL
+//! git — a mocked git would test the mock, and the whole defect was a
+//! misreading of what real git actually says. Each fixture is built inside a
+//! `tempfile::TempDir`; nothing here ever touches a real worktree.
+//! What: one test per gate, plus the near-miss cases where git's message means
+//! the opposite of what it reads like.
+//! Test: this file IS the test module.
+
+use std::path::Path;
+
+use super::*;
+
+use crate::session_manager::worktree_git_fixture::{GitWorktreeFixture, deny_all};
+
+/// The stderr git really prints when it has nothing registered at a path.
+///
+/// Why: the constant under test is a substring match, so the tests must feed it
+/// git's real sentence rather than the fragment — otherwise the test passes for
+/// a match the production path would never see.
+fn not_a_working_tree_stderr(path: &Path) -> String {
+    format!("fatal: '{}' is not a working tree\n", path.display())
+}
+
+/// Run `git -C <dir> worktree remove --force <path>` and hand back its stderr.
+///
+/// Why: every "git declined" test must classify what git ACTUALLY said, not a
+/// remembered paraphrase of it.
+fn real_removal_stderr(repo: &Path, path: &Path) -> String {
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["worktree", "remove", "--force"])
+        .arg(path)
+        .output()
+        .expect("spawn git worktree remove");
+    assert!(
+        !out.status.success(),
+        "precondition: git must have DECLINED to remove {}",
+        path.display()
+    );
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+// ── gate 1: the message ──────────────────────────────────────────────────
+
+/// A `git worktree lock` is the operator saying "leave this alone", and git
+/// enforces it with the same exit code it uses for everything else (#4732).
+#[test]
+fn a_locked_worktree_is_protected() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("locked-4732");
+    fx.lock_worktree(&wt);
+
+    let stderr = real_removal_stderr(&fx.repo, &wt);
+    assert!(
+        stderr.contains("locked working tree"),
+        "precondition: git must have refused for the LOCK reason: {stderr}"
+    );
+    let verdict = protection_after_failed_removal(&wt, &fx.repo, &stderr);
+    assert!(
+        matches!(verdict, GitProtection::Protected(_)),
+        "a locked worktree must never be deletable: {verdict:?}"
+    );
+    assert!(wt.exists(), "and the directory must still be there");
+}
+
+/// `is not a .git file` reads a hair away from `is not a working tree` and
+/// means the opposite — the worktree is real and git is protecting it (#4732).
+#[test]
+fn a_broken_git_file_is_protected() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("broken-git-file-4732");
+    std::fs::write(wt.join("precious.txt"), "work\n").expect("write precious file");
+    std::fs::write(wt.join(".git"), "gitdir: /nonexistent/xyz\n").expect("corrupt .git");
+
+    let stderr = real_removal_stderr(&fx.repo, &wt);
+    let verdict = protection_after_failed_removal(&wt, &fx.repo, &stderr);
+    assert!(
+        matches!(verdict, GitProtection::Protected(_)),
+        "git validated and declined; the near-miss message must not read as \
+         'nothing here': {stderr} -> {verdict:?}"
+    );
+}
+
+/// Any wording this code does not recognize refuses. A reworded git, a `git`
+/// shim on `PATH`, a locale change — all fail closed (#4732).
+///
+/// Mutation note: the subject is a path gates 2 and 3 would both PERMIT — no
+/// `.git` entry, not in the registry — so the message gate is the only thing
+/// that can refuse it. Run against a real worktree instead, this test passes
+/// with the message gate deleted, because the later gates cover for it (caught
+/// by mutating gate 1 during #4732).
+#[test]
+fn an_unrecognized_git_message_is_protected() {
+    let fx = GitWorktreeFixture::new();
+    let plain = fx.repo.join(".worktrees").join("unrecognized-4732");
+    std::fs::create_dir_all(&plain).expect("mkdir");
+    assert_eq!(
+        registry_verdict(&fx.repo, &plain),
+        GitProtection::Unclaimed,
+        "precondition: every OTHER gate permits this path"
+    );
+
+    let verdict =
+        protection_after_failed_removal(&plain, &fx.repo, "fatal: something entirely new\n");
+    assert!(
+        matches!(verdict, GitProtection::Protected(_)),
+        "an unrecognized refusal must fail closed: {verdict:?}"
+    );
+}
+
+// ── gate 2: the filesystem witness ───────────────────────────────────────
+
+/// The worktree's admin directory is gone, so every `git` call from inside it
+/// reports `not a git repository: (null)` — while the working tree, and the
+/// uncommitted work in it, is entirely intact. This is the state ~70 worktrees
+/// were left in on 2026-07-21 (#4732).
+#[test]
+fn a_stale_worktree_pointer_is_protected() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("stale-pointer-4732");
+    std::fs::write(wt.join("precious.txt"), "uncommitted work\n").expect("write precious file");
+    std::fs::remove_dir_all(fx.repo.join(".git").join("worktrees")).expect("drop admin dir");
+
+    assert!(
+        super::registry_root_for(&wt).is_none(),
+        "precondition: git must be unable to name the owning checkout"
+    );
+    let verdict = protection_without_registry_root(&wt);
+    assert!(
+        matches!(verdict, GitProtection::Protected(_)),
+        "a stale worktree pointer is a broken worktree, not an unmanaged \
+         directory: {verdict:?}"
+    );
+}
+
+/// An unreadable `.git` answers exactly like an absent one to git, and not at
+/// all like one to `symlink_metadata` (#4732).
+#[test]
+fn an_unreadable_git_entry_is_protected() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("unreadable-git-4732");
+    let _restore = deny_all(&wt.join(".git"));
+
+    let verdict = protection_without_registry_root(&wt);
+    assert!(
+        matches!(verdict, GitProtection::Protected(_)),
+        "an unreadable .git is a worktree git could not read, not an absent \
+         one: {verdict:?}"
+    );
+}
+
+/// Gate 2 also guards the post-removal path: git's `not a working tree`
+/// message must not override a `.git` sitting right there (#4732).
+///
+/// Mutation note: the subject is a stale-pointer worktree, so gate 1 sees the
+/// permissive message and gate 3's registry no longer names the path — the
+/// filesystem witness is the ONLY thing that still knows this is a worktree.
+/// Against a healthy worktree the registry covers for it and the test passes
+/// with gate 2 deleted (caught by mutating gate 2 during #4732).
+#[test]
+fn a_dot_git_entry_overrides_gits_not_a_working_tree_message() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("witness-beats-message-4732");
+    std::fs::remove_dir_all(fx.repo.join(".git").join("worktrees")).expect("drop admin dir");
+    assert_eq!(
+        registry_verdict(&fx.repo, &wt),
+        GitProtection::Unclaimed,
+        "precondition: git's registry no longer names this path"
+    );
+
+    let verdict = protection_after_failed_removal(&wt, &fx.repo, &not_a_working_tree_stderr(&wt));
+    assert!(
+        matches!(verdict, GitProtection::Protected(_)),
+        "the filesystem witness must win over the message: {verdict:?}"
+    );
+}
+
+// ── gate 3: git's own registry ───────────────────────────────────────────
+
+/// If the registry still names the path, it is protected no matter how the
+/// removal command phrased its refusal (#4732).
+#[test]
+fn a_registered_worktree_is_protected_even_when_git_says_otherwise() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("registered-4732");
+    // Drop the pointer file so gate 2 cannot answer, leaving the registry as
+    // the only thing that knows this is a worktree.
+    std::fs::remove_file(wt.join(".git")).expect("remove .git pointer");
+
+    let verdict = protection_after_failed_removal(&wt, &fx.repo, &not_a_working_tree_stderr(&wt));
+    assert!(
+        matches!(verdict, GitProtection::Protected(_)),
+        "git's registry outranks git's message: {verdict:?}"
+    );
+}
+
+/// The lock is reported as a lock, so the operator is told to unlock rather
+/// than left guessing (#4732).
+#[test]
+fn the_registry_reports_a_lock_as_a_lock() {
+    let fx = GitWorktreeFixture::new();
+    let wt = fx.add_worktree("registry-lock-4732");
+    fx.lock_worktree(&wt);
+
+    let verdict = registry_verdict(&fx.repo, &wt);
+    match verdict {
+        GitProtection::Protected(reason) => assert!(
+            reason.contains("git-locked"),
+            "the reason must name the lock: {reason}"
+        ),
+        other => panic!("a locked worktree must be Protected: {other:?}"),
+    }
+}
+
+/// An unreadable registry is a question that was not answered, not a "no"
+/// (#4732).
+#[test]
+fn an_unreadable_registry_is_undetermined() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let outside = tmp.path().join("not-a-repo");
+    std::fs::create_dir_all(&outside).expect("mkdir");
+
+    let verdict = registry_verdict(&outside, &outside);
+    assert!(
+        matches!(verdict, GitProtection::Undetermined(_)),
+        "a registry that could not be read must refuse, not permit: {verdict:?}"
+    );
+}
+
+/// A path that cannot be canonicalised can never match git's own canonical
+/// registry entries, so comparing it would silently answer "not registered"
+/// (#4732).
+#[test]
+fn an_uncanonicalisable_path_is_undetermined() {
+    let fx = GitWorktreeFixture::new();
+    let absent = fx.repo.join(".worktrees").join("never-existed-4732");
+
+    let verdict = registry_verdict(&fx.repo, &absent);
+    assert!(
+        matches!(verdict, GitProtection::Undetermined(_)),
+        "an uncanonicalisable path must refuse: {verdict:?}"
+    );
+}
+
+/// An ancestor carrying a `.git` git itself will not resolve is the documented
+/// over-refusal: it fails closed rather than falling back to permissive
+/// (#4732).
+#[test]
+fn an_unresolvable_ancestor_repo_is_undetermined() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let fake_repo = tmp.path().join("fake-repo");
+    let leftover = fake_repo.join("leftover");
+    std::fs::create_dir_all(&leftover).expect("mkdir");
+    std::fs::write(fake_repo.join(".git"), "not a gitfile at all\n").expect("write bogus .git");
+
+    let verdict = protection_without_registry_root(&leftover);
+    assert!(
+        matches!(verdict, GitProtection::Undetermined(_)),
+        "an ancestor .git git will not resolve must refuse: {verdict:?}"
+    );
+}
+
+// ── the only permitted outcome ───────────────────────────────────────────
+
+/// The surviving `remove_dir_all` case, half one: no repository exists above
+/// the path at all, so nothing can be claiming it (#4732).
+#[test]
+fn a_directory_no_repository_claims_is_unclaimed() {
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let leftover = tmp.path().join("leftover-4732");
+    std::fs::create_dir_all(&leftover).expect("mkdir");
+
+    assert_eq!(
+        protection_without_registry_root(&leftover),
+        GitProtection::Unclaimed,
+        "a plain directory outside every repository holds no git state"
+    );
+}
+
+/// The surviving `remove_dir_all` case, half two: a repository DOES own the
+/// enclosing tree, and its registry positively does not name this path — a
+/// worktree git already pruned, or one whose creation never registered (#4732).
+#[test]
+fn an_unregistered_leftover_under_a_repo_is_unclaimed() {
+    let fx = GitWorktreeFixture::new();
+    let leftover = fx.repo.join(".worktrees").join("leftover-4732");
+    std::fs::create_dir_all(&leftover).expect("mkdir");
+
+    assert_eq!(
+        protection_without_registry_root(&leftover),
+        GitProtection::Unclaimed,
+        "a directory the owning repository does not register holds no git state"
+    );
+}
+
+/// The same case reached through the post-removal classifier, with git's real
+/// message (#4732).
+#[test]
+fn an_unregistered_directory_inside_a_repo_is_unclaimed() {
+    let fx = GitWorktreeFixture::new();
+    let leftover = fx.repo.join(".worktrees").join("unregistered-4732");
+    std::fs::create_dir_all(&leftover).expect("mkdir");
+
+    let stderr = real_removal_stderr(&fx.repo, &leftover);
+    assert!(
+        stderr.contains(NOT_A_WORKING_TREE),
+        "precondition: git's real message for a plain directory: {stderr}"
+    );
+    assert_eq!(
+        protection_after_failed_removal(&leftover, &fx.repo, &stderr),
+        GitProtection::Unclaimed
+    );
+}
+
+// ── the enum's own contract ──────────────────────────────────────────────
+
+/// Both non-`Unclaimed` states refuse. A caller that matched only `Protected`
+/// would reopen the exact fail-open this enum exists to close (#4732).
+#[test]
+fn refusal_covers_both_non_unclaimed_states() {
+    assert!(
+        GitProtection::Protected("held".into()).refusal().is_some(),
+        "Protected must refuse"
+    );
+    assert!(
+        GitProtection::Undetermined("unknown".into())
+            .refusal()
+            .is_some(),
+        "Undetermined must refuse — an unanswerable probe is never a verdict"
+    );
+    assert!(
+        GitProtection::Unclaimed.refusal().is_none(),
+        "Unclaimed is the only state that permits removal"
+    );
+}

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim.rs
@@ -861,8 +861,10 @@ pub(crate) struct ReclaimOutcome {
     pub removed_bytes: u64,
     /// Candidates the survey approved but the FRESH re-check refused.
     pub refused_at_recheck: Vec<String>,
-    /// Candidates the re-check approved but whose deletion failed.
-    pub removal_failed: Vec<PathBuf>,
+    /// Candidates the re-check approved but which are still on disk, each as
+    /// `"<path>: <reason>"` (#4732 — the reason used to be dropped, and a
+    /// deliberate `git worktree lock` refusal read as a transient error).
+    pub removal_failed: Vec<String>,
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep.rs
@@ -15,11 +15,12 @@
 //! captured `in_use` slice is therefore asking a question that was answered
 //! more than ten minutes ago — a session that attached in the meantime is
 //! invisible, and a `git worktree lock` applied in the meantime is ignored
-//! (`Admission` was evaluated at survey time, and
-//! `remove_session_worktree`'s `remove_dir_all` fallback deletes a locked
-//! worktree regardless). The first cut of this feature made exactly that
-//! mistake, and its three "re-checks" all survived mutation testing because
-//! they re-asked stale inputs.
+//! (`Admission` was evaluated at survey time). The first cut of this feature
+//! made exactly that mistake, and its three "re-checks" all survived mutation
+//! testing because they re-asked stale inputs. Until #4732,
+//! `remove_session_worktree`'s `remove_dir_all` fallback then deleted the
+//! locked worktree regardless, so this re-check was the ONLY thing honouring
+//! the lock; it now refuses too, and this pass is the outer of two defences.
 //!
 //! So: [`reclaim_with_probes`] re-reads the live session set, git's own
 //! worktree registry, the ownership marker, the pull-request state, and the
@@ -223,11 +224,12 @@ pub(crate) fn survey(
 ///
 /// Why: `Admission` was decided during the survey. Ten minutes later the
 /// operator may have run `git worktree lock` — an explicit "do not remove
-/// this" — and the survey's verdict knows nothing about it. This matters more
-/// than it looks: git itself honours the lock (`git worktree remove --force`
-/// exits 128), but `remove_session_worktree` treats that as a git failure and
-/// falls back to `remove_dir_all`, which deletes the directory anyway. The lock
-/// can therefore only be honoured by re-checking it here.
+/// this" — and the survey's verdict knows nothing about it. Git itself honours
+/// the lock (`git worktree remove --force` exits 128); until #4732
+/// `remove_session_worktree` read that as a git failure and fell back to
+/// `remove_dir_all`, so this re-check was the only thing honouring it. The
+/// remover now refuses as well — this stays the OUTER defence, because a
+/// candidate proposed here and refused there is a reported near-miss.
 /// What: one `git -C <candidate> worktree list --porcelain`, resolved against
 /// the candidate's own repository. Refuses when git cannot be asked, when git
 /// no longer lists the path, and when the record is the main checkout, bare,
@@ -412,7 +414,8 @@ pub(crate) fn reclaim_with_probes(
                 .push(format!("{}: {reason}", path.display()));
             continue;
         }
-        if super::decommission::remove_session_worktree(&path) && !path.exists() {
+        let outcome = super::decommission::remove_session_worktree(&path);
+        if outcome.removed() && !path.exists() {
             tracing::info!(
                 path = %path.display(),
                 "worktree-reclaim: reclaimed a merged-PR worktree (#2919)"
@@ -422,7 +425,19 @@ pub(crate) fn reclaim_with_probes(
                 .saturating_add(candidate.bytes.unwrap_or(0));
             out.removed.push(path);
         } else {
-            out.removal_failed.push(path);
+            // #4732: report WHY it is still on disk. "removal failed" with no
+            // reason reads as a transient error, but the commonest reason is
+            // now a deliberate refusal — a `git worktree lock` the operator set
+            // precisely so this pass would leave the worktree alone.
+            let reason = outcome
+                .reason()
+                .unwrap_or("the directory is still present after a reported removal");
+            tracing::warn!(
+                path = %path.display(),
+                "worktree-reclaim: worktree kept — {reason}"
+            );
+            out.removal_failed
+                .push(format!("{}: {reason}", path.display()));
         }
     }
     out

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_sweep_tests.rs
@@ -79,12 +79,11 @@ fn recheck_refuses_a_worktree_a_session_claims_now() {
 
 #[test]
 fn recheck_refuses_a_worktree_locked_after_the_survey() {
-    // `git worktree lock` is the operator's explicit "do not remove this". git
-    // honours it (`worktree remove --force` exits 128) but
-    // `remove_session_worktree` treats that as a git failure and falls back to
-    // `remove_dir_all`, which deletes the directory anyway — so the lock can
-    // ONLY be honoured by this re-check. The survey's `Admission` was computed
-    // before the lock existed.
+    // `git worktree lock` is the operator's explicit "do not remove this". The
+    // survey's `Admission` was computed before the lock existed, so this
+    // re-check is what notices it. Since #4732 the remover ALSO refuses a
+    // locked worktree, but that is a second line of defence: this pass must
+    // never propose the candidate in the first place.
     let fx = GitWorktreeFixture::new();
     let path = fx.add_worktree("locked-2919");
     land(&path);
@@ -374,9 +373,9 @@ fn reclaim_remove_mode_refuses_a_worktree_dirtied_after_the_survey() {
 #[test]
 fn reclaim_remove_mode_refuses_a_worktree_locked_after_the_survey() {
     // The operator runs `git worktree lock` mid-sweep. This fails if the git
-    // re-check is removed — and note `remove_session_worktree` would delete it
-    // regardless via its `remove_dir_all` fallback, so this re-check is the
-    // ONLY thing honouring the lock.
+    // re-check is removed. Since #4732 the remover would also refuse, but the
+    // sweep must not get that far — a candidate it proposes and then cannot
+    // remove is a reported near-miss, not a clean pass.
     let fx = GitWorktreeFixture::new();
     let path = fx.add_worktree("lock-race-2919");
     land(&path);
@@ -670,34 +669,42 @@ fn survey_discloses_a_partially_measured_reclaimable_set() {
     );
 }
 
-/// Pins what `remove_session_worktree` ACTUALLY returns when git's own removal
-/// fails and the `remove_dir_all` fallback succeeds (#2919).
+/// `remove_session_worktree` must REFUSE a git-locked worktree, not delete it
+/// (#4732 — this test asserted the opposite until #4732 fixed the remover).
 ///
-/// Why: round-3 review read `decommission.rs` as returning `false` on that
-/// path, which would route a genuinely-deleted worktree into `removal_failed`.
-/// It does not — those `false` values bind `git_success` for the prune/branch-D
-/// step and the function still falls through to its final `true`. Rather than
-/// argue from a reading, this test forces the exact condition with a REAL
-/// git-locked worktree (`git worktree remove --force` exits 128) and asserts
-/// both the return value and that the directory is gone, so the `&&` in the
-/// reclaim loop is pinned against either reading drifting.
+/// Why: `git worktree lock` is the only mechanism an operator has to say "leave
+/// this alone", and git enforces it by exiting 128. The remover read every
+/// non-zero exit as licence to run `std::fs::remove_dir_all` by hand, so
+/// locking a worktree to protect it was precisely what got it deleted. That
+/// behaviour was pinned HERE, by a #2919 test written to settle a different
+/// question (what the return value means when the fallback succeeds) — which is
+/// why the defect survived a round of review that read this file.
+///
+/// The return-value question that test was settling still matters, so it is
+/// kept: a refusal must report NOT-removed, or the reclaim loop's
+/// `outcome.removed() && !path.exists()` would count a surviving worktree as
+/// reclaimed.
 #[test]
-fn remove_session_worktree_reports_success_when_the_fallback_removes_it() {
+fn remove_session_worktree_refuses_a_git_locked_worktree() {
     let fx = GitWorktreeFixture::new();
-    let path = fx.add_worktree("fallback-removal-2919");
+    let path = fx.add_worktree("locked-refusal-4732");
     land(&path);
+    std::fs::write(path.join("precious.txt"), "operator work\n").expect("write precious file");
     fx.lock_worktree(&path);
 
-    let reported = crate::session_manager::decommission::remove_session_worktree(&path);
+    let outcome = crate::session_manager::decommission::remove_session_worktree(&path);
     assert!(
-        !path.exists(),
-        "precondition: the fallback really did remove the directory"
+        path.exists() && path.join("precious.txt").exists(),
+        "a locked worktree must survive — git declined, and declining is a \
+         refusal, not a failure to work around"
     );
     assert!(
-        reported,
-        "a worktree that is genuinely gone must be reported as removed, not as \
-         `removal_failed` — the reclaim loop's `remove_session_worktree(..) && \
-         !path.exists()` depends on this"
+        !outcome.removed(),
+        "and the refusal must be reported as NOT removed: {outcome:?}"
+    );
+    assert!(
+        outcome.reason().is_some(),
+        "with a reason the caller can surface: {outcome:?}"
     );
 }
 

--- a/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_reclaim_tests.rs
@@ -453,7 +453,7 @@ fn the_remover_really_refuses_what_tm_provisioned_rejects() {
         "precondition: the classifier rejects this shape"
     );
     let removed = crate::session_manager::decommission::remove_session_worktree(&path);
-    assert!(!removed, "the remover must refuse it too");
+    assert!(!removed.removed(), "the remover must refuse it too");
     assert!(
         path.exists(),
         "and must leave the directory on disk — which is exactly why \

--- a/crates/trusty-mpm/src/session_manager/worktree_registry.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry.rs
@@ -579,13 +579,14 @@ fn admission_for(
         // remove a locked working tree; use 'remove -f -f' to override or
         // unlock first", leaving the directory intact. Git respects the lock.
         //
-        // The danger is what `decommission::remove_session_worktree` does with
-        // that refusal: it treats ANY non-zero git exit as "git failed" and
-        // falls back to `std::fs::remove_dir_all`, which deletes the directory
-        // regardless — defeating the lock via the error path rather than the
-        // force flag, AND leaving git's now-dangling registry entry behind.
-        // Never enumerating a locked worktree is therefore the only place the
-        // operator's veto actually survives.
+        // The danger was what `decommission::remove_session_worktree` did with
+        // that refusal: until #4732 it treated ANY non-zero git exit as "git
+        // failed" and fell back to `std::fs::remove_dir_all`, deleting the
+        // directory regardless — defeating the lock via the error path rather
+        // than the force flag, AND leaving git's now-dangling registry entry
+        // behind. The remover refuses now, so this filter is no longer the ONLY
+        // place the veto survives; it is the first, and it is what keeps a
+        // locked worktree out of every candidate list an operator is shown.
         if wt.bare {
             return Admission::Bare;
         }

--- a/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/worktree_registry_tests.rs
@@ -414,12 +414,12 @@ fn scan_from_anchor_never_admits_the_containment_boundary_itself() {
 ///
 /// Why: NOT because `--force` overrides the lock — it does not. Git refuses a
 /// single `--force` on a locked worktree (exit 128, "use 'remove -f -f' to
-/// override or unlock first") and leaves the directory intact. The problem is
-/// that `decommission::remove_session_worktree` reads that refusal as a generic
-/// git failure and falls back to `std::fs::remove_dir_all`, deleting the
-/// directory anyway and orphaning git's registry entry. So the veto is defeated
-/// through the error path, and never enumerating a locked worktree is the only
-/// place it survives.
+/// override or unlock first") and leaves the directory intact. The problem was
+/// that `decommission::remove_session_worktree` read that refusal as a generic
+/// git failure and fell back to `std::fs::remove_dir_all`, deleting the
+/// directory anyway and orphaning git's registry entry — the veto defeated
+/// through the error path (#4732, since fixed). Keeping a locked worktree out
+/// of the candidate list is the first of the two defences.
 #[test]
 fn enumerate_excludes_a_locked_worktree() {
     let fixture = GitWorktreeFixture::new();


### PR DESCRIPTION
Closes #4732

## The defect

`session_manager::decommission::remove_session_worktree` fell through to `std::fs::remove_dir_all` on **any** non-zero `git worktree remove --force` exit. Git exits 128 for every fatal condition, and the worst one is deliberate: `git worktree lock` is the operator's only mechanism for saying "leave this alone", and git enforces it by exiting 128. **Locking a worktree to protect it was exactly what caused it to be deleted.**

Reachable from `tm session decommission`, `tm sessions prune --state stopped`, the age-based reaper, `prune_orphaned_worktrees()`, and the `--merged-prs` reclaim pass.

### It was wider than the reported case — two fail-open sites, not one

The second one was never reported and deletes uncommitted work without ever reaching the `git worktree remove` call:

`registry_root_for(path) == None` was read as "no git repository owns this path — removing the directory directly". That `None` is **also** what a stale worktree pointer answers. Reproduced against git 2.54.0: with `.git/worktrees/<name>` removed out of band, `git -C <wt> rev-parse --git-common-dir` says `fatal: not a git repository: (null)` while the working tree and its uncommitted files are entirely intact. That is the state ~70 worktrees on this machine were left in on 2026-07-21.

### The pre-fix behaviour was pinned by a test

`worktree_reclaim_sweep_tests::remove_session_worktree_reports_success_when_the_fallback_removes_it` locked a real worktree and asserted the fallback had deleted it. It was written for #2919 to settle a different question (what the return value means when the fallback succeeds), which is why this defect survived a review round that read that file. It is inverted here, with the return-value question it was actually settling preserved.

## The fix

New `session_manager::worktree_protection` — a tri-state classifier, never a bool:

| state | meaning | action |
|---|---|---|
| `Protected(reason)` | git holds state here, or declined to give it up | refuse |
| `Unclaimed` | positively established: no git state at or claiming this path | permit |
| `Undetermined(reason)` | git could not be consulted, or answered unreadably | refuse |

`GitProtection::refusal()` collapses both refusing states into one accessor, so a caller cannot match `Protected` alone and silently let `Undetermined` through.

**Exit code alone never decides, and neither does the message alone.** Measured against git 2.54.0 — all three exit 128:

| condition | stderr |
|---|---|
| operator-locked worktree | `cannot remove a locked working tree; use 'remove -f -f' to override or unlock first` |
| broken `.git` file | `validation failed, cannot remove working tree: '…/.git' is not a .git file, error code 7` |
| plain dir / already-pruned worktree | `'<path>' is not a working tree` |

Only the third means git holds nothing, and the second reads a hair away from it while meaning the opposite. So the match is narrow (`is not a working tree`, anything else refuses) and then **corroborated**: a `symlink_metadata` witness on `<path>/.git` — which needs only the parent's search bit, so it answers for a dangling, unreadable, or mode-000 pointer where every `git` call reports "not a repository" — and then git's own `worktree list --porcelain` registry, canonicalised on both sides. This is deliberately the shape `trusty-agents-common`'s `agents::vcs_claim` landed on in #4727.

### The surviving fallback, stated exactly

`remove_dir_all` now runs for **one** case, in a function named for it (`remove_unclaimed_directory`):

> `path` has passed the trusty-mpm ownership gate, and git has POSITIVELY established that it holds no state there — the path carries no `.git` entry, and either no repository exists above it at all, or the owning repository's `git worktree list` does not name it.

That is a leftover directory: a worktree git already pruned, or one whose creation never completed registration. There is no ref to prune and nothing for git to protect. Both halves have a passing test, so this fix cannot silently become "never clean anything up".

### The reason reaches the caller

`remove_session_worktree` now returns `WorktreeRemoval::{Removed, Kept(reason)}`. `ReclaimOutcome::removal_failed` becomes `Vec<String>` of `"<path>: <reason>"` (same JSON shape — an array of strings — so `tm session prune-worktrees --merged-prs` output is enriched, not broken). "removal failed" with no reason read as a transient error; the commonest reason is now a deliberate refusal.

### Scope

#4735's shared `GitProbe<T>` is **not** built here. `worktree_protection.rs` is one self-contained file with no trusty-mpm-specific types in its signatures, so that extraction is a move rather than a rewrite.

## Tests

Every test below fails against the pre-fix remover.

| test | shape |
|---|---|
| `remove_session_worktree_refuses_a_git_locked_worktree` | real `git worktree lock`; asserts the dir AND a file inside it survive |
| `remove_refuses_a_stale_worktree_pointer` | admin dir removed out of band; uncommitted file must survive |
| `remove_refuses_an_unreadable_git_entry` | `chmod 000` on `.git`, restored by a `Drop` guard |
| `remove_refuses_a_worktree_with_a_broken_git_file` | `.git` naming a nonexistent gitdir |
| `remove_cleans_up_a_directory_no_repository_claims` | the surviving fallback, half one |
| `remove_cleans_up_an_unregistered_leftover_inside_a_repo` | the surviving fallback, half two |
| `remove_still_removes_a_healthy_worktree` | happy path incl. registry prune + `branch -D` |

Plus 15 classifier unit tests, all driven against **real git** in a `TempDir` — a mocked git would test the mock, and this defect was a misreading of what real git actually says.

### Mutation testing — and what it caught

Each new guard was mutated in turn and the suite re-run. **Two of the twelve initially SURVIVED**: gates 1 (message) and 2 (`.git` witness) in `protection_after_failed_removal` were masking each other, because both tests used a healthy registered worktree that a later gate could also refuse. Each was rewritten to target a path every *other* gate permits — an unregistered plain directory for gate 1, a stale-pointer worktree for gate 2 — with the precondition asserted in the test body and a mutation note in its doc. After that, all twelve are killed:

```
KILLED  M1  gate1: accept any stderr as 'nothing here'      by an_unrecognized_git_message_is_protected
KILLED  M2  gate2 (post-removal): ignore the .git witness   by a_dot_git_entry_overrides_gits_not_a_working_tree_message
KILLED  M3  registry unreadable reads as 'not registered'   by an_unreadable_registry_is_undetermined
KILLED  M4  uncanonicalisable path reads as 'not registered' by an_uncanonicalisable_path_is_undetermined
KILLED  M5  a registered worktree reads as unclaimed        by a_registered_worktree_is_protected_even_when_git_says_otherwise
KILLED  M6  the lock is not named in the reason             by the_registry_reports_a_lock_as_a_lock
KILLED  M7  gate1 (no-root): ignore the .git witness        by remove_refuses_a_stale_worktree_pointer, a_stale_worktree_pointer_is_protected
KILLED  M8  ancestor witness always says 'no repository'    by an_unresolvable_ancestor_repo_is_undetermined
KILLED  M9  unresolvable ancestor repo reads as unclaimed   by an_unresolvable_ancestor_repo_is_undetermined
KILLED  M10 refusal() lets Undetermined through             by refusal_covers_both_non_unclaimed_states
KILLED  M11 remover ignores the no-root verdict             by remove_refuses_a_stale_worktree_pointer, remove_refuses_an_unreadable_git_entry, remove_refuses_a_worktree_with_a_broken_git_file
KILLED  M12 remover ignores the failed-removal verdict      by remove_session_worktree_refuses_a_git_locked_worktree
```

One branch has no test and is called out here rather than hidden: the `Err` arm where `git` cannot be spawned at all. It now refuses instead of falling back, but forcing it needs a `PATH` shim.

## Gates — Rust Test Ladder rung 5

```
cargo fmt --check                                      exit 0
cargo check -p trusty-mpm                              exit 0
cargo clippy -p trusty-mpm --all-targets -- -D warnings exit 0
cargo test -p trusty-mpm                               4332 passed, 0 failed, 7 ignored (lib)
                                                       + all integration suites green, exit 0
bash scripts/check_line_cap.sh        3621 files, 0 violations — OK
bash scripts/check_sld.sh             0 errors, 0 warnings
bash scripts/check_test_pointers.sh   20687 citations, 0 dangling — OK
bash scripts/check_changelog_fragment.sh  OK trusty-mpm: fragment present and valid
```

`cargo test -p trusty-mpm -- --include-ignored`: **4338 passed, 1 failed** — `daemon::managed_routes::staleness_bench_tests::bench_stale_assets_for_many`, an `#[ignore]`d benchmark panicking on `deploy_all_skill_tiers(...).unwrap()` with `Io(NotFound)`.

Not this branch. Proven, not asserted:
- `git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/daemon/ crates/trusty-mpm/src/core/` → **0 files**; the diff is confined to `session_manager/`.
- The same run at origin/main state (this branch's `session_manager/` reverted to `origin/main`, new files removed) fails **identically**, same test, same panic site `staleness_bench_tests.rs:115`, `4317 passed; 1 failed`.
- The test passes in isolation at both origin/main and HEAD, so it is a full-run isolation flake, not a regression.

No canonical issue exists for it (`gh issue list --state all --search bench_stale_assets_for_many` and `--search staleness_bench_tests` both return empty). Change-specific gates pass; this one is a pre-existing full-run flake.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools