### PR TITLE
fix(trusty-mpm): compiled PM prompt gets its own path, written before launch (#4752)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,24 @@
 .trusty-mpm/*
 !.trusty-mpm/INSTRUCTIONS.md
 
+# Harness-generated project tier under a CRATE directory is machine-local and
+# never a deliverable (#4752). Running `tm` inside `crates/<name>/` seeds a full
+# project tier there: a `.claude/settings.json` carrying absolute
+# `/Users/<me>/.cargo/bin/...` hook commands, a `.claude/skills/` roster that
+# SHADOWS the bundled one (the #4448/#4526 hazard, same shape as `agents/`
+# above), and a `.trusty-mpm/` session stash.
+#
+# The root-level rules above do NOT reach these, for two different reasons:
+#   * `!.claude/` (above) has no leading or middle slash, so it un-ignores
+#     `.claude` at EVERY level — including every crate's.
+#   * `.trusty-mpm/*` (below) has a middle slash, so it anchors to the repo
+#     root only.
+# 140 such files reached PR #4759 before this rule existed. Scoped to
+# `crates/*/` rather than `**/` on purpose: a bare `**/.claude/` would re-ignore
+# the root `.claude/settings.json` that the re-includes above deliberately keep.
+crates/*/.claude/
+crates/*/.trusty-mpm/
+
 # Re-include tracked files from .claude-mpm/
 !.claude-mpm/INSTRUCTIONS.md
 !.claude-mpm/AGENT_DELEGATION.md

--- a/.line-cap-allowlist.tsv
+++ b/.line-cap-allowlist.tsv
@@ -11,6 +11,6 @@ crates/trusty-common/src/embedder/mod.rs	535
 crates/trusty-git-analytics/src/collect/collector.rs	766
 crates/trusty-mpm/src/daemon/api.rs	1272
 crates/trusty-mpm/src/daemon/api/control_routes.rs	543
-crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	845
+crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs	818
 crates/trusty-search/src/main.rs	658
 crates/trusty-search/src/service/walker.rs	1167

--- a/.test-pointer-allowlist.tsv
+++ b/.test-pointer-allowlist.tsv
@@ -432,7 +432,6 @@ crates/trusty-mpm/src/core/auto_resume.rs	effective_from_env_parses_truthy
 crates/trusty-mpm/src/core/compress.rs	caveman_summary_contains_tool_and_size
 crates/trusty-mpm/src/core/compress.rs	strip_ansi_leaves_plain_text
 crates/trusty-mpm/src/core/deploy_validate/mod.rs	repair_reports_error_when_prepare_session_fails
-crates/trusty-mpm/src/core/instruction_pipeline.rs	install_writes_assembled_prompt
 crates/trusty-mpm/src/core/manifest/schema.rs	instruction_layers_roundtrip
 crates/trusty-mpm/src/core/manifest/schema.rs	mcp_servers_roundtrip
 crates/trusty-mpm/src/core/manifest/schema.rs	model_tiers_roundtrip

--- a/crates/trusty-mpm/changelog.d/4752-compiled-prompt-launch-coverage.md
+++ b/crates/trusty-mpm/changelog.d/4752-compiled-prompt-launch-coverage.md
@@ -1,0 +1,4 @@
+Fixed
+
+- the compiled PM prompt is now refreshed at the spawn seam, so resume, guided-resume and crash-recovery launches no longer run a prompt that never reached `INSTRUCTIONS-COMPILED.md` (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - the compiled write is the last step of session preparation, so a failure can no longer skip the MCP content-pinning injectors that defend against the #3918/#3950 name-squatting class

--- a/crates/trusty-mpm/changelog.d/4752-compiled-prompt-project-local-fatal.md
+++ b/crates/trusty-mpm/changelog.d/4752-compiled-prompt-project-local-fatal.md
@@ -1,0 +1,7 @@
+Changed
+
+- the compiled PM prompt is now written per project, to `<project>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`, and a failure to write it refuses the launch (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - removes the cross-project collision by construction: concurrent sessions no longer share one global file
+  - the resume path writes it too, so resumed sessions can no longer run against a prompt that was never recorded
+  - `tm install` no longer writes a compiled prompt — install has no project, so it has nothing to compile
+  - a refused launch names the path and the remedy instead of surfacing a bare I/O error

--- a/crates/trusty-mpm/changelog.d/4752-instructions-compiled-path.md
+++ b/crates/trusty-mpm/changelog.d/4752-instructions-compiled-path.md
@@ -1,5 +1,5 @@
 Fixed
 
-- compiled PM system prompt now writes to a distinct `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` instead of colliding with the bundled stub (closes [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+- compiled PM system prompt now writes to its own `INSTRUCTIONS-COMPILED.md` instead of colliding with the bundled `instructions/INSTRUCTIONS.md` stub that the pipeline reads as input (closes [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
   - the compiled prompt is refreshed at every session launch, before `claude` is spawned; a failed write now aborts the launch rather than leaving a stale prompt on disk
   - `tm install` removes a stale pre-#4752 `framework/instructions/INSTRUCTIONS.md`, which no writer could refresh but the pipeline still read

--- a/crates/trusty-mpm/changelog.d/4752-instructions-compiled-path.md
+++ b/crates/trusty-mpm/changelog.d/4752-instructions-compiled-path.md
@@ -1,0 +1,5 @@
+Fixed
+
+- compiled PM system prompt now writes to a distinct `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` instead of colliding with the bundled stub (closes [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - the compiled prompt is refreshed at every session launch, before `claude` is spawned; a failed write now aborts the launch rather than leaving a stale prompt on disk
+  - `tm install` removes a stale pre-#4752 `framework/instructions/INSTRUCTIONS.md`, which no writer could refresh but the pipeline still read

--- a/crates/trusty-mpm/changelog.d/4753-retired-override-files-instruction.md
+++ b/crates/trusty-mpm/changelog.d/4753-retired-override-files-instruction.md
@@ -1,0 +1,3 @@
+Fixed
+
+- PM instruction section `non-overridable-rules.md` no longer describes section overrides as "override files" — the live mechanism is marked blocks in the project's `CLAUDE.md`, and the section now points at the spec of record (refs [#4753](https://github.com/bobmatnyc/trusty-tools/issues/4753))

--- a/crates/trusty-mpm/changelog.d/4759-inplace-relaunch-compiled-prompt.md
+++ b/crates/trusty-mpm/changelog.d/4759-inplace-relaunch-compiled-prompt.md
@@ -1,0 +1,8 @@
+Fixed
+
+- bare `tm` in a managed pane now refreshes the project's compiled prompt before relaunching, and refuses the relaunch if that write fails (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - this path calls neither session preparation nor the daemon resume route, so it was the one way to start a session on a stale or missing compiled prompt where a fresh launch would have refused
+  - all three pre-spawn paths now route through a single `refresh_compiled_prompt` entry point so they cannot drift apart
+- an unwritable `.trusty-mpm/` no longer skips the MCP injectors (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - the `last-instructions.md` stash write degraded the whole preparation to an early non-fatal error, so callers launched the session anyway with the `trusty-mpm`/`trusty-review` content-pinning defense against the #3918/#3950 name-squatting class never applied
+  - the stash is an inspection artifact; it now logs and continues instead of short-circuiting

--- a/crates/trusty-mpm/changelog.d/4759-inplace-relaunch-compiled-prompt.md
+++ b/crates/trusty-mpm/changelog.d/4759-inplace-relaunch-compiled-prompt.md
@@ -1,8 +1,13 @@
 Fixed
 
+- a session whose instructions cannot be written no longer starts (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - `build_instructions` returned a non-fatal error, so every launch path logged it and started the session anyway — with no instructions established and no `.mcp.json` written. Reachable whenever the project's `CLAUDE.md` or the framework instructions path cannot be read, for example when something has left a directory at `CLAUDE.md`
+  - it is now the same fatal condition as the compiled-prompt write, reported as one error rather than two classes
 - bare `tm` in a managed pane now refreshes the project's compiled prompt before relaunching, and refuses the relaunch if that write fails (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
   - this path calls neither session preparation nor the daemon resume route, so it was the one way to start a session on a stale or missing compiled prompt where a fresh launch would have refused
-  - all three pre-spawn paths now route through a single `refresh_compiled_prompt` entry point so they cannot drift apart
-- an unwritable `.trusty-mpm/` no longer skips the MCP injectors (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
-  - the `last-instructions.md` stash write degraded the whole preparation to an early non-fatal error, so callers launched the session anyway with the `trusty-mpm`/`trusty-review` content-pinning defense against the #3918/#3950 name-squatting class never applied
-  - the stash is an inspection artifact; it now logs and continues instead of short-circuiting
+  - the two resume-shaped paths now share one `refresh_compiled_prompt` entry point; session preparation keeps its own composition because it must apply the operator's resolved output style
+- an unwritable `.trusty-mpm/` no longer causes a session to start without its instructions recorded (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - the `last-instructions.md` stash write degraded the whole preparation to an early non-fatal error, so callers launched the session having skipped the fatal write below it
+  - the stash is an inspection copy; it now logs and continues instead of short-circuiting
+- the `CLAUDE.md` compiled-instructions pointer no longer names the retired global path (refs [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752))
+  - it pointed at `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`, which nothing writes since the compiled prompt became project-local; it is now the project-relative path, pinned against the pipeline that writes the file

--- a/crates/trusty-mpm/src/assets/instructions/sections/README.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/README.md
@@ -192,7 +192,12 @@ than smoothed over.
   `FRAMEWORK_INSTRUCTIONS` constant, so by the time this finding was acted on
   only one writer remained. The surviving half — the compiled OUTPUT sharing a
   path with the pipeline INPUT `build_instructions` reads — was fixed by giving
-  the compiled prompt its own file, `framework/INSTRUCTIONS-COMPILED.md`
-  (`FrameworkPaths::instructions_compiled`), which nothing else writes. `tm
-  install` now also deletes a stale pre-#4752 `instructions/INSTRUCTIONS.md`,
-  since no writer could refresh it but the pipeline still read it.
+  the compiled prompt its own file, written PER PROJECT to
+  `<project>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
+  (`instruction_pipeline::compiled_prompt_path`), which nothing else writes.
+  Project-local rather than global: one shared file under `~/.trusty-mpm/` would
+  simply have moved the collision from two writers on one path to every project
+  overwriting the same copy. `tm install` no longer writes a compiled prompt at
+  all — install has no project, so it has nothing to compile — and it now
+  deletes a stale pre-#4752 `instructions/INSTRUCTIONS.md`, since no writer
+  could refresh it but the pipeline still read it.

--- a/crates/trusty-mpm/src/assets/instructions/sections/README.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/README.md
@@ -172,7 +172,7 @@ than smoothed over.
    name describes nothing true. Renaming it is mechanical and was left out of
    #4286 to keep that change reviewable.
 
-3. **The `project-addendum` generator is declared but unfeedable.** Its only
+2. **The `project-addendum` generator is declared but unfeedable.** Its only
    production input was the retired `.trusty-mpm/INSTRUCTIONS.md`. The block
    stays declared in the manifest (marked `optional`, so it emits nothing) and
    the composer always passes `None`.
@@ -183,3 +183,16 @@ than smoothed over.
   Resolved by the ruling, not by a fix: **nothing** outside `core` is protected
   now, so this stopped being an anomaly and became the documented model. See
   "Why there is no framework floor" above.
+
+- *"Two writers target one path."* — `bundle_all.rs` wrote a 4-line stub to
+  `instructions/INSTRUCTIONS.md` while `install_system_prompt` wrote the full
+  composed prompt to the same path, last writer winning. Resolved by #4752, in
+  two parts. The stub half was already gone: #4286 split A removed the
+  `instructions/INSTRUCTIONS.md` entry from `bundle::ALL` and deleted the
+  `FRAMEWORK_INSTRUCTIONS` constant, so by the time this finding was acted on
+  only one writer remained. The surviving half — the compiled OUTPUT sharing a
+  path with the pipeline INPUT `build_instructions` reads — was fixed by giving
+  the compiled prompt its own file, `framework/INSTRUCTIONS-COMPILED.md`
+  (`FrameworkPaths::instructions_compiled`), which nothing else writes. `tm
+  install` now also deletes a stale pre-#4752 `instructions/INSTRUCTIONS.md`,
+  since no writer could refresh it but the pipeline still read it.

--- a/crates/trusty-mpm/src/assets/instructions/sections/README.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/README.md
@@ -165,14 +165,7 @@ the findings below.
 Written against the actual code, these do not explain cleanly. Recorded rather
 than smoothed over.
 
-1. **Two writers target one path.** `bundle_all.rs` writes a 4-line stub to
-   `instructions/INSTRUCTIONS.md`, and `instruction_pipeline.rs`'s
-   `install_system_prompt` writes the *full composed prompt* to the same
-   `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`. Whichever runs last
-   wins. Neither is read by the launch path, which composes in memory. The
-   bundled-asset retirement is still open.
-
-2. **`base_pm()` is now a misnomer twice over.** It refers to a file that does
+1. **`base_pm()` is now a misnomer twice over.** It refers to a file that does
    not exist, and it hardcodes four section ids in one order to reconstitute a
    "floor" that no longer exists as a concept. It is still live — the
    roster-absent string assembly appends it — so it is a real function whose

--- a/crates/trusty-mpm/src/assets/instructions/sections/non-overridable-rules.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/non-overridable-rules.md
@@ -63,8 +63,9 @@ delete the file. `tm doctor` fails with `legacy_overrides` until it is gone.
 replaced by a named section in the project's `CLAUDE.md`. There is no framework
 floor: a project owns its own `CLAUDE.md`, so a floor would have been the
 appearance of a control rather than a control.
-Missing, empty, or unreadable override files fall back to the bundled defaults
-— they never blank a section.
+A missing, empty, unclosed, or unreadable marker block falls back to the bundled
+default — an override never blanks a section. Spec of record:
+`docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md`.
 
 ## Trusty Tool Priority (Non-Overridable)
 

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -557,6 +557,23 @@ pub(crate) async fn run_inplace_relaunch(
         return InPlaceOutcome::FallThrough;
     }
 
+    // #4752: refresh the project's compiled prompt BEFORE building the resume
+    // command, and treat a failure as FATAL — the same policy `prepare_session`
+    // and `resume_managed` apply.
+    //
+    // This path is the THIRD entry point that hands a runtime a prompt, and it
+    // calls neither of those two: its only daemon call is `reactivate` below,
+    // which does no prompt work. Until this call existed, the sole compiled write
+    // here was `build_prompt_file`'s best-effort refresh, so a bare-`tm` relaunch
+    // in a managed pane was the one way to start a session on a stale or missing
+    // compiled prompt where a fresh launch would have refused.
+    //
+    // Ordered BEFORE `build_inplace_resume_command` so a refusal costs nothing
+    // and, like the other two sites, cannot half-provision the pane.
+    if let Err(msg) = trusty_mpm::core::instruction_pipeline::refresh_compiled_prompt(&cwd) {
+        return InPlaceOutcome::Result(Err(anyhow::anyhow!("{msg}")));
+    }
+
     let resume = match trusty_mpm::runtime::build_inplace_resume_command(
         &cwd,
         record.claude_session_id.as_deref(),

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -1,8 +1,9 @@
 //! `install` command handler and framework-artifact helpers.
 //!
 //! Why: the install handler is self-contained — it writes bundled artifacts,
-//! assembles the PM prompt, deploys agents and skills, and wires Claude Code
-//! hooks — and benefits from its own file so it stays reviewable.
+//! deploys agents and skills, and wires Claude Code hooks — and benefits from
+//! its own file so it stays reviewable. (#4752: it no longer assembles a PM
+//! prompt; that is per-project and written at launch.)
 //! What: `install`, `install_claude_hooks` / `install_claude_hooks_at`,
 //! `mpm_hook_additions`, `install_to`, `install_one`, `deploy_report_lines`,
 //! `reset_report_lines`, `skill_report_lines`, `remove_global_trusty_mpm_hooks`,
@@ -22,10 +23,10 @@
 /// Why: a fresh machine has no `~/.trusty-mpm/framework/`; `trusty-mpm install`
 /// writes the compile-time-embedded artifacts (optimizer policy, framework
 /// instructions, placeholder agent/skill) so the daemon has a working policy
-/// and launchers have instructions to point sessions at. It also assembles
-/// the full PM system prompt (overwriting the bundle stub — fixes #383),
-/// deploys composed agents and skills, and wires MPM lifecycle hooks into
-/// every Claude Code settings file. All edits are idempotent.
+/// and launchers have a working framework tree. It deploys composed agents and
+/// skills and wires MPM lifecycle hooks into every Claude Code settings file.
+/// All edits are idempotent. #4752: it no longer assembles a PM system prompt —
+/// the compiled prompt is per-project and written by the launch path.
 ///
 /// `reset_agents` (issue #2504) is the explicit reconciliation path for
 /// composed agent files a normal deploy conservatively skips because they
@@ -50,17 +51,18 @@
 /// reset, each gated by that workspace's OWN resolved harness plan (so an
 /// agent one project's manifest excludes is never resurrected there — the
 /// #2462 cross-warning). Only takes effect when `reset_agents` is `Some`.
-/// What: resolves [`FrameworkPaths::default`], calls [`install_to`] then
-/// [`install_system_prompt_to`] to write the real assembled PM prompt,
-/// deploys agents and skills, optionally resets the requested agent scope
-/// (user-level, then every intact session workspace when requested), then
-/// calls [`install_claude_hooks`].
+/// What: resolves [`FrameworkPaths::default`], calls [`install_to`], removes a
+/// stale pre-#4752 `instructions/INSTRUCTIONS.md`, deploys agents and skills,
+/// optionally resets the requested agent scope (user-level, then every intact
+/// session workspace when requested), then calls [`install_claude_hooks`].
+/// #4752: it no longer writes a compiled PM prompt — that is per-project and
+/// written at launch (`instruction_pipeline::compiled_prompt_path`).
 /// Test: `install_writes_all_artifacts`,
 /// `overwrite_artifact_refreshes_modified_file_without_force`,
 /// `seed_once_artifact_is_not_clobbered_without_force`,
 /// `seed_once_artifact_force_resets_to_shipped_default`,
 /// `install_claude_hooks_is_idempotent`,
-/// `instruction_pipeline::install_system_prompt_to_writes_assembled`.
+/// `remove_stale_bundled_instructions_deletes_a_leftover`.
 pub(crate) async fn install(
     force: bool,
     reset_agents: Option<Vec<String>>,

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -77,19 +77,12 @@ pub(crate) async fn install(
         println!("  {line}");
     }
 
-    // #4752: the assembled PM prompt lands on its OWN path — nothing else
-    // writes `framework/INSTRUCTIONS-COMPILED.md`. It used to overwrite
-    // `instructions/INSTRUCTIONS.md`, which a bundled stub also targeted (#383)
-    // and which `build_instructions` reads back as a pipeline INPUT. A session
-    // launch rewrites this same file with the project-RESOLVED prompt before
-    // spawning `claude` (see `session_launch::prepare_session`); this install
-    // write is the bundled compilation, current until the next launch.
-    match trusty_mpm::core::instruction_pipeline::install_system_prompt_to(
-        &paths.instructions_compiled(),
-    ) {
-        Ok(()) => println!("  \u{2713} INSTRUCTIONS-COMPILED.md (assembled)"),
-        Err(e) => eprintln!("warning: failed to assemble system prompt: {e:#}"),
-    }
+    // #4752: `tm install` no longer writes a compiled PM prompt at all. The
+    // compiled prompt is the text ONE project's session runs with, and install
+    // has no project — writing the bundled assembly to a global path is exactly
+    // the "wrong content kind on a shared path" collision this issue closes.
+    // Each launch writes its own project's copy (see
+    // `instruction_pipeline::compiled_prompt_path`).
 
     // #4752: a pre-#4752 install left the compiled prompt at
     // `instructions/INSTRUCTIONS.md`. Nothing writes that path now, but

--- a/crates/trusty-mpm/src/bin/tm/commands/install.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/install.rs
@@ -77,12 +77,31 @@ pub(crate) async fn install(
         println!("  {line}");
     }
 
-    // Overwrite the bundle stub with the fully assembled PM prompt (#383).
+    // #4752: the assembled PM prompt lands on its OWN path — nothing else
+    // writes `framework/INSTRUCTIONS-COMPILED.md`. It used to overwrite
+    // `instructions/INSTRUCTIONS.md`, which a bundled stub also targeted (#383)
+    // and which `build_instructions` reads back as a pipeline INPUT. A session
+    // launch rewrites this same file with the project-RESOLVED prompt before
+    // spawning `claude` (see `session_launch::prepare_session`); this install
+    // write is the bundled compilation, current until the next launch.
     match trusty_mpm::core::instruction_pipeline::install_system_prompt_to(
+        &paths.instructions_compiled(),
+    ) {
+        Ok(()) => println!("  \u{2713} INSTRUCTIONS-COMPILED.md (assembled)"),
+        Err(e) => eprintln!("warning: failed to assemble system prompt: {e:#}"),
+    }
+
+    // #4752: a pre-#4752 install left the compiled prompt at
+    // `instructions/INSTRUCTIONS.md`. Nothing writes that path now, but
+    // `build_instructions` still READS it — so an upgraded machine would fold a
+    // frozen copy of an old prompt into the pipeline forever. Remove it here
+    // rather than leaving a stale input no writer can refresh.
+    match trusty_mpm::core::instruction_pipeline::remove_stale_bundled_instructions(
         &paths.framework_instructions_path(),
     ) {
-        Ok(()) => println!("  \u{2713} instructions/INSTRUCTIONS.md (assembled)"),
-        Err(e) => eprintln!("warning: failed to assemble system prompt: {e:#}"),
+        Ok(true) => println!("  \u{2717} instructions/INSTRUCTIONS.md (stale, removed)"),
+        Ok(false) => {}
+        Err(e) => eprintln!("warning: failed to remove stale instructions/INSTRUCTIONS.md: {e:#}"),
     }
 
     // #4409: bundled agents deploy ONLY into the tm-managed config-dir tier.

--- a/crates/trusty-mpm/src/bin/tm/commands/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/launch.rs
@@ -207,6 +207,12 @@ pub(crate) async fn launch(
                     );
                 }
             }
+            // #4752: a compiled-prompt write failure is FATAL — refuse the
+            // launch rather than start a session whose instructions cannot be
+            // inspected. Every other prep failure stays non-fatal (#2149).
+            Err(e) if e.is_fatal() => {
+                anyhow::bail!("{e}");
+            }
             Err(e) => {
                 tracing::warn!(
                     "session prep failed for worktree {} (non-fatal): {e}",
@@ -275,16 +281,13 @@ pub(crate) async fn launch(
         }
     };
 
-    // 10. Regenerate `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md` from
-    //     the bundled assets so the on-disk system prompt always reflects the
-    //     current trusty-mpm build.
-    let instructions_path = match trusty_mpm::core::instruction_pipeline::install_system_prompt() {
-        Ok(path) => Some(path),
-        Err(err) => {
-            eprintln!("warning: failed to install system prompt: {err}");
-            None
-        }
-    };
+    // 10. (#4752) The former regeneration of
+    //     `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md` is gone. Its
+    //     result was assigned and then immediately discarded (`let _ =
+    //     instructions_path`), so it only ever wrote a file no launch read —
+    //     and that path is now retired: `tm install` deletes a stale copy and
+    //     the compiled prompt is per-project. The prompt this session actually
+    //     receives is built below and written by `prepare_isolated_session`.
 
     // Resolve the PM model (config > frontmatter > default).
     let mpm_cfg = trusty_mpm::core::config::MpmConfig::load_default();
@@ -320,7 +323,6 @@ pub(crate) async fn launch(
         prompt_path.as_deref(),
         Some(&managed_path),
     );
-    let _ = instructions_path;
 
     // 12. Create a detached tmux session rooted at the MANAGED clone directory.
     //     #2398: routes through `core::tmux::create_managed_session`, the
@@ -462,6 +464,11 @@ pub(crate) async fn connect(
             for err in &report.roster_errors {
                 tracing::error!("roster provisioning gap for {}: {err}", path.display());
             }
+        }
+        // #4752: fatal — refuse the connect rather than attach to a session
+        // whose compiled instructions could not be written.
+        Err(err) if err.is_fatal() => {
+            anyhow::bail!("{err}");
         }
         Err(err) => {
             tracing::warn!(

--- a/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/meta/launch.rs
@@ -189,6 +189,9 @@ pub(crate) async fn launch_and_wait(
             project = %project_dir.display(),
             "meta run: prepared session (agents/skills/CLAUDE.md/MCP deployed)"
         ),
+        // #4752: a compiled-prompt write failure refuses the launch; every
+        // other prep failure stays non-fatal (#2149).
+        Err(e) if e.is_fatal() => anyhow::bail!("{e}"),
         Err(e) => warn!(
             project = %project_dir.display(),
             "meta run: session preparation failed (continuing): {e}"

--- a/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session/start.rs
@@ -160,6 +160,10 @@ async fn start_session_in_place(
                 eprintln!("error: roster provisioning gap: {err}");
             }
         }
+        // #4752: fatal — refuse to start rather than run a session whose
+        // compiled instructions could not be written. Other prep failures stay
+        // non-fatal (#2149).
+        Err(err) if err.is_fatal() => anyhow::bail!("{err}"),
         Err(err) => eprintln!("warning: session preparation failed: {err}"),
     }
 

--- a/crates/trusty-mpm/src/bin/tm/install_policy_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/install_policy_tests.rs
@@ -85,3 +85,39 @@ fn seed_once_artifact_force_resets_to_shipped_default() {
         "shipped default content"
     );
 }
+
+#[test]
+fn bundle_install_pass_never_touches_the_compiled_prompt() {
+    // Why (#4752): the defect was two writers on one path — a bundled stub and
+    // the compiled prompt. This pins that the bundle-artifact pass (`install_to`,
+    // which walks `bundle::ALL`) cannot write the compiled prompt's file, so the
+    // only thing that ever puts bytes there is an explicit compiled write.
+    //
+    // FIXTURE NOTE: the compiled path is pre-seeded with a sentinel. Asserting
+    // the sentinel SURVIVES `install_to` is what exercises the guard — an
+    // absence check would pass trivially on a fresh temp dir even if a bundled
+    // artifact did target that name.
+    let dir = tempfile::tempdir().unwrap();
+    let paths = trusty_mpm::core::paths::FrameworkPaths::under(dir.path());
+    let compiled = paths.instructions_compiled();
+    std::fs::create_dir_all(compiled.parent().unwrap()).unwrap();
+    const SENTINEL: &str = "SENTINEL-NOT-WRITTEN-BY-THE-BUNDLE-PASS";
+    std::fs::write(&compiled, SENTINEL).unwrap();
+
+    install_to(&paths, true).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&compiled).unwrap(),
+        SENTINEL,
+        "no bundled artifact may write {}",
+        compiled.display()
+    );
+
+    // And the explicit compiled write — the ONE writer — replaces it with the
+    // full assembled prompt, never a stub (regression guard for #383).
+    trusty_mpm::core::instruction_pipeline::install_system_prompt_to(&compiled).unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&compiled).unwrap(),
+        trusty_mpm::core::instruction_pipeline::assemble_system_prompt()
+    );
+}

--- a/crates/trusty-mpm/src/bin/tm/install_policy_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/install_policy_tests.rs
@@ -99,7 +99,7 @@ fn bundle_install_pass_never_touches_the_compiled_prompt() {
     // artifact did target that name.
     let dir = tempfile::tempdir().unwrap();
     let paths = trusty_mpm::core::paths::FrameworkPaths::under(dir.path());
-    let compiled = paths.instructions_compiled();
+    let compiled = trusty_mpm::core::instruction_pipeline::compiled_prompt_path(dir.path());
     std::fs::create_dir_all(compiled.parent().unwrap()).unwrap();
     const SENTINEL: &str = "SENTINEL-NOT-WRITTEN-BY-THE-BUNDLE-PASS";
     std::fs::write(&compiled, SENTINEL).unwrap();
@@ -115,7 +115,11 @@ fn bundle_install_pass_never_touches_the_compiled_prompt() {
 
     // And the explicit compiled write — the ONE writer — replaces it with the
     // full assembled prompt, never a stub (regression guard for #383).
-    trusty_mpm::core::instruction_pipeline::install_system_prompt_to(&compiled).unwrap();
+    trusty_mpm::core::instruction_pipeline::write_compiled_prompt_to(
+        &compiled,
+        &trusty_mpm::core::instruction_pipeline::assemble_system_prompt(),
+    )
+    .unwrap();
     assert_eq!(
         std::fs::read_to_string(&compiled).unwrap(),
         trusty_mpm::core::instruction_pipeline::assemble_system_prompt()

--- a/crates/trusty-mpm/src/client/http_client/session_connect.rs
+++ b/crates/trusty-mpm/src/client/http_client/session_connect.rs
@@ -34,8 +34,9 @@ impl DaemonClient {
     pub async fn launch_session(&self, workdir: &str) -> anyhow::Result<String> {
         // Prepare the custom instructions Claude Code reads at startup: deploy
         // composed agents to `~/.claude/agents/` and merge the project
-        // `CLAUDE.md`. A prep failure is logged but not fatal — the session can
-        // still launch with whatever instructions already exist on disk.
+        // `CLAUDE.md`. Most prep failures are logged but not fatal (#2149) —
+        // the session can still launch with whatever instructions already exist
+        // on disk. The exception is #4752's compiled-prompt write.
         let fw = crate::core::paths::FrameworkPaths::default();
         match crate::core::session_launch::prepare_session(&fw, std::path::Path::new(workdir)) {
             Ok(report) => {
@@ -44,6 +45,11 @@ impl DaemonClient {
                 for err in &report.roster_errors {
                     tracing::error!(%err, "roster provisioning gap (non-fatal)");
                 }
+            }
+            // #4752: fatal — refuse the launch rather than start a session
+            // whose compiled instructions could not be written.
+            Err(err) if err.is_fatal() => {
+                anyhow::bail!("{err}");
             }
             Err(err) => {
                 tracing::warn!(%err, "session pre-launch preparation failed");

--- a/crates/trusty-mpm/src/core/claude_md_writer.rs
+++ b/crates/trusty-mpm/src/core/claude_md_writer.rs
@@ -67,10 +67,21 @@ use crate::core::instruction_package::{CustomizationTier, OverrideTier, SectionI
 /// `CLAUDE.md` could see marker blocks with no way to find what they compile
 /// into. The pointer runs one way only — `CLAUDE.md` → compiled file — so this
 /// module records the path without owning, creating, or reading it.
-/// What: the tilde-form path, written verbatim into the pointer block. Producing
-/// the file at this path belongs to the instruction pipeline, not here.
-/// Test: `pointer_block_names_the_compiled_instructions_path`.
-pub const COMPILED_INSTRUCTIONS_PATH: &str = "~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md";
+/// What: the path RELATIVE TO THE PROJECT ROOT — which is where the `CLAUDE.md`
+/// holding the pointer lives, so a reader can follow it directly. Written
+/// verbatim into the pointer block. Producing the file at this path belongs to
+/// the instruction pipeline, not here.
+///
+/// #4752: this was the global `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
+/// until the compiled prompt became project-local. Nothing writes the global
+/// path any more, so a pointer naming it would have sent every reader to a file
+/// that never exists. Kept in step with
+/// [`crate::core::instruction_pipeline::compiled_prompt_path`] by
+/// `pointer_path_matches_the_instruction_pipeline`, which fails if either side
+/// moves.
+/// Test: `pointer_block_names_the_compiled_instructions_path`,
+/// `pointer_path_matches_the_instruction_pipeline`.
+pub const COMPILED_INSTRUCTIONS_PATH: &str = ".trusty-mpm/framework/INSTRUCTIONS-COMPILED.md";
 
 /// First line of the managed compiled-instructions pointer block.
 ///

--- a/crates/trusty-mpm/src/core/claude_md_writer_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_writer_tests.rs
@@ -532,6 +532,28 @@ fn refusals_leave_the_file_byte_identical() {
 // Behaviour 6 — the compiled-instructions pointer
 // ---------------------------------------------------------------------------
 
+/// The pointer path must stay in step with the pipeline that writes the file.
+#[test]
+fn pointer_path_matches_the_instruction_pipeline() {
+    // Why (#4752): this constant is a SECOND spelling of a path only
+    // `instruction_pipeline::compiled_prompt_path` actually produces. It already
+    // went stale once — it named the global `~/.trusty-mpm/framework/...` after
+    // the compiled prompt went project-local, so the pointer spliced into a
+    // project's CLAUDE.md would have sent readers to a file nothing writes.
+    // Nothing else fails when these two drift, because `ensure_compiled_pointer`
+    // has no production caller yet (spec §10.5 defers wiring it).
+    let project = std::path::Path::new("/some/project");
+    let produced = crate::core::instruction_pipeline::compiled_prompt_path(project);
+    let relative = produced
+        .strip_prefix(project)
+        .expect("compiled_prompt_path must be project-local");
+    assert_eq!(
+        relative.to_string_lossy(),
+        COMPILED_INSTRUCTIONS_PATH,
+        "the pointer path and the pipeline that writes the file have drifted"
+    );
+}
+
 /// The pointer names the compiled prompt path, visibly.
 #[test]
 fn pointer_block_names_the_compiled_instructions_path() {

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -285,38 +285,98 @@ pub fn assemble_system_prompt() -> String {
     .join(SECTION_SEPARATOR)
 }
 
+/// Filename of the compiled PM system prompt.
+///
+/// Why (#4752): the compiled prompt needs a path NO other writer targets. It
+/// previously shared `instructions/INSTRUCTIONS.md` with a bundled 4-line stub
+/// and with the pipeline's own input file, so the on-disk answer to "what
+/// instructions is my session running?" depended on which writer ran last —
+/// the regression #383 already fixed once and #4752 closes structurally.
+/// What: `INSTRUCTIONS-COMPILED.md`, resolved directly under the framework root
+/// by [`crate::core::paths::FrameworkPaths::instructions_compiled`] — NOT under
+/// `framework/instructions/`.
+/// Test: `compiled_prompt_file_is_not_the_bundled_instructions_name`,
+/// `no_other_writer_targets_the_compiled_prompt_path`.
+pub const COMPILED_PROMPT_FILE: &str = "INSTRUCTIONS-COMPILED.md";
+
+/// Write an already-composed prompt to the compiled-prompt path.
+///
+/// Why (#4752): both writers of `INSTRUCTIONS-COMPILED.md` — `tm install`
+/// (bundled compilation) and the launch path (the project-resolved prompt the
+/// session actually receives) — must go through one function so the file can
+/// never hold anything but a full compiled prompt. This is also the seam that
+/// keeps the launch write cheap: it takes the prompt the composer ALREADY built
+/// for `--append-system-prompt-file` rather than recomposing it, so the launch
+/// cost is one `write`, not a second composition pass.
+/// What: creates `dest`'s parent directory if absent, then writes `prompt`
+/// verbatim. Returns the underlying IO error unchanged — callers decide whether
+/// a failure is fatal (at launch it is; see
+/// `crate::core::session_launch::prepare_session`).
+/// Test: `write_compiled_prompt_to_creates_parent_dirs`,
+/// `install_system_prompt_to_writes_assembled`.
+pub fn write_compiled_prompt_to(dest: &std::path::Path, prompt: &str) -> std::io::Result<()> {
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(dest, prompt)
+}
+
 /// Write the assembled system prompt to an explicit path.
 ///
 /// Why: `tm install` must be testable against a temp directory rather than the
 /// real `~/.trusty-mpm`; extracting the path-parameterised write here lets both
 /// the production path ([`install_system_prompt`]) and the install handler use
 /// the same assembly logic without touching the real home during unit tests.
-/// What: creates parent directories if absent, then writes
-/// [`assemble_system_prompt`] to `dest`.
+/// What: composes [`assemble_system_prompt`] and hands it to
+/// [`write_compiled_prompt_to`]. Callers pass
+/// [`crate::core::paths::FrameworkPaths::instructions_compiled`].
 /// Test: `install_system_prompt_to_writes_assembled`, `install_writes_assembled_prompt`.
 pub fn install_system_prompt_to(dest: &std::path::Path) -> std::io::Result<()> {
-    if let Some(parent) = dest.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(dest, assemble_system_prompt())
+    write_compiled_prompt_to(dest, &assemble_system_prompt())
 }
 
 /// Write the assembled system prompt to the trusty-mpm framework directory.
 ///
-/// Why: `tm launch` passes `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`
-/// to `claude --append-system-prompt-file`; this regenerates that file from the
-/// bundled assets so it always reflects the current trusty-mpm build.
-/// What: creates `~/.trusty-mpm/framework/instructions/` if needed and writes
-/// the output of [`assemble_system_prompt`] to `INSTRUCTIONS.md`, returning the
-/// path it wrote. Delegates the write to [`install_system_prompt_to`].
+/// Why: an operator inspecting `~/.trusty-mpm/framework/` must find the
+/// compiled prompt at one predictable place. #4752 moved that place off
+/// `instructions/INSTRUCTIONS.md` (shared with a bundled stub and with the
+/// pipeline's own input) and onto [`COMPILED_PROMPT_FILE`].
+/// What: creates `~/.trusty-mpm/framework/` if needed and writes the output of
+/// [`assemble_system_prompt`] to `INSTRUCTIONS-COMPILED.md`, returning the path
+/// it wrote. Delegates the write to [`install_system_prompt_to`].
 /// Test: `install_system_prompt_writes_file`.
 pub fn install_system_prompt() -> std::io::Result<std::path::PathBuf> {
     let home = dirs::home_dir()
         .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no home dir"))?;
-    let out_dir = home.join(".trusty-mpm/framework/instructions");
-    let out_path = out_dir.join("INSTRUCTIONS.md");
+    let out_path = home
+        .join(".trusty-mpm/framework")
+        .join(COMPILED_PROMPT_FILE);
     install_system_prompt_to(&out_path)?;
     Ok(out_path)
+}
+
+/// Delete a stale `instructions/INSTRUCTIONS.md` left by a pre-#4752 install.
+///
+/// Why: until #4752, `tm install` wrote the compiled prompt to
+/// `framework/instructions/INSTRUCTIONS.md`. Nothing writes that path anymore —
+/// but [`build_instructions`] still READS it as an optional framework section,
+/// so an upgraded machine would keep folding a frozen copy of an OLD compiled
+/// prompt into [`PipelineOutput::merged`] forever, with no writer left to
+/// refresh it. A stale input nothing can update is worse than an absent one, and
+/// the pipeline already treats absence as normal (`instructions_loaded: false`).
+/// The file is framework-owned — trusty-mpm has always overwritten it on every
+/// install — so removing it takes nothing from the operator.
+/// What: removes `dest` if it exists; returns whether a file was removed. A
+/// `NotFound` race is reported as "nothing removed", not an error, so a
+/// concurrent install cannot fail this one.
+/// Test: `remove_stale_bundled_instructions_deletes_a_leftover`,
+/// `remove_stale_bundled_instructions_is_a_noop_when_absent`.
+pub fn remove_stale_bundled_instructions(dest: &std::path::Path) -> std::io::Result<bool> {
+    match std::fs::remove_file(dest) {
+        Ok(()) => Ok(true),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
 }
 
 /// The CLAUDE.md stub seeded into a project on first session start.

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -292,67 +292,72 @@ pub fn assemble_system_prompt() -> String {
 /// and with the pipeline's own input file, so the on-disk answer to "what
 /// instructions is my session running?" depended on which writer ran last —
 /// the regression #383 already fixed once and #4752 closes structurally.
-/// What: `INSTRUCTIONS-COMPILED.md`, resolved directly under the framework root
-/// by [`crate::core::paths::FrameworkPaths::instructions_compiled`] — NOT under
-/// `framework/instructions/`.
-/// Test: `compiled_prompt_path_is_distinct_from_the_bundled_instructions_path`,
-/// `no_bundled_artifact_targets_the_compiled_prompt_path`.
+/// What: `INSTRUCTIONS-COMPILED.md`, resolved per PROJECT by
+/// [`compiled_prompt_path`] — never under the global framework root.
+/// Test: `compiled_prompt_path_is_project_local`,
+/// `compiled_prompt_path_is_not_the_bundled_instructions_path`.
 pub const COMPILED_PROMPT_FILE: &str = "INSTRUCTIONS-COMPILED.md";
 
-/// Write an already-composed prompt to the compiled-prompt path.
+/// Resolve a project's compiled-prompt path.
 ///
-/// Why (#4752): both writers of `INSTRUCTIONS-COMPILED.md` — `tm install`
-/// (bundled compilation) and the launch path (the project-resolved prompt the
-/// session actually receives) — must go through one function so the file can
-/// never hold anything but a full compiled prompt. This is also the seam that
-/// keeps the launch write cheap: it takes the prompt the composer ALREADY built
-/// for `--append-system-prompt-file` rather than recomposing it, so the launch
-/// cost is one `write`, not a second composition pass.
+/// Why (#4752, owner ruling 2026-08-04): the compiled prompt is the text ONE
+/// project's session runs with, so it belongs to that project. A single global
+/// file could not answer "what is MY session running" — `FrameworkPaths`
+/// deliberately keeps `framework` at the shared managed root
+/// (`for_managed_project_keeps_framework_source_at_managed_root`) and
+/// `for_managed_workspace` resolves it from the real `$HOME`, so concurrent
+/// sessions across projects overwrote each other. Project-local scoping removes
+/// that collision by construction rather than by slug disambiguation — there is
+/// no shared root to race on and no slug to collide.
+///
+/// This is why the accessor does NOT live on `FrameworkPaths`: that type models
+/// the global framework INSTALL layout, and this file is per-project session
+/// state. It sits beside `last-instructions.md` and `sessions/`, in the
+/// `.trusty-mpm/` directory `tm` already writes on every launch.
+/// What: `<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`.
+/// Test: `compiled_prompt_path_is_project_local`,
+/// `compiled_prompt_path_is_beside_the_session_stash`.
+pub fn compiled_prompt_path(project_dir: &std::path::Path) -> std::path::PathBuf {
+    project_dir
+        .join(".trusty-mpm")
+        .join("framework")
+        .join(COMPILED_PROMPT_FILE)
+}
+
+/// The operator-facing explanation for a failed compiled-prompt write.
+///
+/// Why (#4752): the write is fatal — it refuses a launch — so the operator must
+/// be told what was refused, where, and why, not handed a bare `io::Error`. One
+/// formatter keeps that message identical whether the refusal surfaces from the
+/// CLI (`tm session start`), the daemon resume path, or the HTTP client.
+/// What: names the path, the underlying cause, and the remedy.
+/// Test: `compiled_prompt_failure_message_names_the_path_and_a_remedy`.
+pub fn compiled_prompt_failure_message(path: &std::path::Path, source: &std::io::Error) -> String {
+    format!(
+        "could not write the compiled PM prompt to {}: {source}\n\
+         The session was NOT started: it would have run against instructions that \
+         cannot be inspected, and a directory `tm` writes on every launch is \
+         unwritable. Check permissions and free space on that path, then retry.",
+        path.display()
+    )
+}
+
+/// Write an already-composed prompt to a project's compiled-prompt path.
+///
+/// Why (#4752): every writer of `INSTRUCTIONS-COMPILED.md` goes through one
+/// function so the file can never hold anything but a full compiled prompt. It
+/// takes the prompt the composer ALREADY built for
+/// `--append-system-prompt-file` rather than recomposing it, so the launch cost
+/// is one `write`, not a second composition pass.
 /// What: creates `dest`'s parent directory if absent, then writes `prompt`
-/// verbatim. Returns the underlying IO error unchanged — callers decide whether
-/// a failure is fatal (at launch it is; see
-/// `crate::core::session_launch::prepare_session`).
-/// Test: `write_compiled_prompt_to_creates_parent_dirs`,
-/// `install_system_prompt_to_writes_assembled`.
+/// verbatim. Returns the underlying IO error unchanged; pair it with
+/// [`compiled_prompt_failure_message`] when surfacing to an operator.
+/// Test: `write_compiled_prompt_to_creates_parent_dirs`.
 pub fn write_compiled_prompt_to(dest: &std::path::Path, prompt: &str) -> std::io::Result<()> {
     if let Some(parent) = dest.parent() {
         std::fs::create_dir_all(parent)?;
     }
     std::fs::write(dest, prompt)
-}
-
-/// Write the assembled system prompt to an explicit path.
-///
-/// Why: `tm install` must be testable against a temp directory rather than the
-/// real `~/.trusty-mpm`; extracting the path-parameterised write here lets both
-/// the production path ([`install_system_prompt`]) and the install handler use
-/// the same assembly logic without touching the real home during unit tests.
-/// What: composes [`assemble_system_prompt`] and hands it to
-/// [`write_compiled_prompt_to`]. Callers pass
-/// [`crate::core::paths::FrameworkPaths::instructions_compiled`].
-/// Test: `install_system_prompt_to_writes_assembled`, `install_writes_assembled_prompt`.
-pub fn install_system_prompt_to(dest: &std::path::Path) -> std::io::Result<()> {
-    write_compiled_prompt_to(dest, &assemble_system_prompt())
-}
-
-/// Write the assembled system prompt to the trusty-mpm framework directory.
-///
-/// Why: an operator inspecting `~/.trusty-mpm/framework/` must find the
-/// compiled prompt at one predictable place. #4752 moved that place off
-/// `instructions/INSTRUCTIONS.md` (shared with a bundled stub and with the
-/// pipeline's own input) and onto [`COMPILED_PROMPT_FILE`].
-/// What: creates `~/.trusty-mpm/framework/` if needed and writes the output of
-/// [`assemble_system_prompt`] to `INSTRUCTIONS-COMPILED.md`, returning the path
-/// it wrote. Delegates the write to [`install_system_prompt_to`].
-/// Test: `install_system_prompt_writes_file`.
-pub fn install_system_prompt() -> std::io::Result<std::path::PathBuf> {
-    let home = dirs::home_dir()
-        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "no home dir"))?;
-    let out_path = home
-        .join(".trusty-mpm/framework")
-        .join(COMPILED_PROMPT_FILE);
-    install_system_prompt_to(&out_path)?;
-    Ok(out_path)
 }
 
 /// Delete a stale `instructions/INSTRUCTIONS.md` left by a pre-#4752 install.

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -360,6 +360,36 @@ pub fn write_compiled_prompt_to(dest: &std::path::Path, prompt: &str) -> std::io
     std::fs::write(dest, prompt)
 }
 
+/// Compose a project's prompt and refresh its compiled prompt on disk — fatally.
+///
+/// Why (#4752): THREE entry points hand a runtime a prompt, and each must
+/// guarantee the compiled copy is current first — fresh start
+/// ([`crate::core::session_launch::prepare_session`]), daemon resume
+/// (`managed_routes::lifecycle::resume_managed`), and the bare-`tm` in-place
+/// relaunch (`tm::commands::guided_inplace::run_inplace_relaunch`). Round 3 of
+/// this issue missed the third: it calls neither of the other two, so its only
+/// compiled write was `build_prompt_file`'s best-effort refresh. A resumed
+/// session could therefore run on a stale or missing compiled prompt exactly
+/// where a fresh launch would have refused. Consolidating the compose+write+
+/// message triple here keeps the three call sites from drifting apart.
+/// What: composes the project-resolved prompt through the same seam the launcher
+/// uses, writes it to [`compiled_prompt_path`], and on failure returns the
+/// operator-facing string from [`compiled_prompt_failure_message`] — callers
+/// refuse the launch with it.
+/// Test: `refresh_compiled_prompt_writes_the_project_local_file`,
+/// `refresh_compiled_prompt_reports_an_actionable_failure`.
+pub fn refresh_compiled_prompt(project_dir: &std::path::Path) -> Result<(), String> {
+    let native = crate::core::output_style::claude_supports_native_output_style();
+    let prompt = crate::core::session_launch::build_system_prompt_for_with_style_and_native(
+        project_dir,
+        None,
+        native,
+    );
+    let dest = compiled_prompt_path(project_dir);
+    write_compiled_prompt_to(&dest, &prompt)
+        .map_err(|source| compiled_prompt_failure_message(&dest, &source))
+}
+
 /// Delete a stale `instructions/INSTRUCTIONS.md` left by a pre-#4752 install.
 ///
 /// Why: until #4752, `tm install` wrote the compiled prompt to

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -295,8 +295,8 @@ pub fn assemble_system_prompt() -> String {
 /// What: `INSTRUCTIONS-COMPILED.md`, resolved directly under the framework root
 /// by [`crate::core::paths::FrameworkPaths::instructions_compiled`] — NOT under
 /// `framework/instructions/`.
-/// Test: `compiled_prompt_file_is_not_the_bundled_instructions_name`,
-/// `no_other_writer_targets_the_compiled_prompt_path`.
+/// Test: `compiled_prompt_path_is_distinct_from_the_bundled_instructions_path`,
+/// `no_bundled_artifact_targets_the_compiled_prompt_path`.
 pub const COMPILED_PROMPT_FILE: &str = "INSTRUCTIONS-COMPILED.md";
 
 /// Write an already-composed prompt to the compiled-prompt path.

--- a/crates/trusty-mpm/src/core/instruction_pipeline.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline.rs
@@ -324,20 +324,25 @@ pub fn compiled_prompt_path(project_dir: &std::path::Path) -> std::path::PathBuf
         .join(COMPILED_PROMPT_FILE)
 }
 
-/// The operator-facing explanation for a failed compiled-prompt write.
+/// The operator-facing explanation for a failed instruction write.
 ///
-/// Why (#4752): the write is fatal — it refuses a launch — so the operator must
-/// be told what was refused, where, and why, not handed a bare `io::Error`. One
-/// formatter keeps that message identical whether the refusal surfaces from the
-/// CLI (`tm session start`), the daemon resume path, or the HTTP client.
+/// Why (#4752): establishing a session's instructions is fatal — it refuses a
+/// launch — so the operator must be told what was refused, where, and why, not
+/// handed a bare `io::Error`. One formatter keeps that message identical
+/// wherever the refusal surfaces: the CLI (`tm session start`), the daemon
+/// resume path, the bare-`tm` in-place relaunch, or the HTTP client.
+///
+/// Renamed from `instructions_failure_message` (round 4): it now also covers
+/// a [`build_instructions`] failure, so wording specific to the compiled prompt
+/// would have been wrong at half its call sites.
 /// What: names the path, the underlying cause, and the remedy.
-/// Test: `compiled_prompt_failure_message_names_the_path_and_a_remedy`.
-pub fn compiled_prompt_failure_message(path: &std::path::Path, source: &std::io::Error) -> String {
+/// Test: `instructions_failure_message_names_the_path_and_a_remedy`.
+pub fn instructions_failure_message(path: &std::path::Path, source: &std::io::Error) -> String {
     format!(
-        "could not write the compiled PM prompt to {}: {source}\n\
-         The session was NOT started: it would have run against instructions that \
-         cannot be inspected, and a directory `tm` writes on every launch is \
-         unwritable. Check permissions and free space on that path, then retry.",
+        "could not write the session instructions to {}: {source}\n\
+         The session was NOT started: it depends on those instructions, and a \
+         path `tm` must write on every launch is unavailable. Check permissions \
+         and free space on that path, then retry.",
         path.display()
     )
 }
@@ -351,7 +356,7 @@ pub fn compiled_prompt_failure_message(path: &std::path::Path, source: &std::io:
 /// is one `write`, not a second composition pass.
 /// What: creates `dest`'s parent directory if absent, then writes `prompt`
 /// verbatim. Returns the underlying IO error unchanged; pair it with
-/// [`compiled_prompt_failure_message`] when surfacing to an operator.
+/// [`instructions_failure_message`] when surfacing to an operator.
 /// Test: `write_compiled_prompt_to_creates_parent_dirs`.
 pub fn write_compiled_prompt_to(dest: &std::path::Path, prompt: &str) -> std::io::Result<()> {
     if let Some(parent) = dest.parent() {
@@ -370,12 +375,21 @@ pub fn write_compiled_prompt_to(dest: &std::path::Path, prompt: &str) -> std::io
 /// this issue missed the third: it calls neither of the other two, so its only
 /// compiled write was `build_prompt_file`'s best-effort refresh. A resumed
 /// session could therefore run on a stale or missing compiled prompt exactly
-/// where a fresh launch would have refused. Consolidating the compose+write+
-/// message triple here keeps the three call sites from drifting apart.
+/// where a fresh launch would have refused.
+///
+/// SCOPE — this helper serves TWO of those three, not all three. The two
+/// resume-shaped paths (daemon resume, in-place relaunch) share it because
+/// neither has an explicit style to apply, so composing with `None` is right for
+/// both. `prepare_session` deliberately does NOT call it: it must compose with
+/// the `effective_style` it just resolved (flag > config > manifest), which this
+/// helper hardcodes to `None`, and routing it through here would silently drop
+/// the operator's chosen output style from the compiled copy. All three still
+/// share the actual write via [`write_compiled_prompt_to`] and the same fatal
+/// policy; what differs is only which text they compose.
 /// What: composes the project-resolved prompt through the same seam the launcher
-/// uses, writes it to [`compiled_prompt_path`], and on failure returns the
-/// operator-facing string from [`compiled_prompt_failure_message`] — callers
-/// refuse the launch with it.
+/// uses, with no explicit output style, writes it to [`compiled_prompt_path`],
+/// and on failure returns the operator-facing string from
+/// [`instructions_failure_message`] — callers refuse the launch with it.
 /// Test: `refresh_compiled_prompt_writes_the_project_local_file`,
 /// `refresh_compiled_prompt_reports_an_actionable_failure`.
 pub fn refresh_compiled_prompt(project_dir: &std::path::Path) -> Result<(), String> {
@@ -387,7 +401,7 @@ pub fn refresh_compiled_prompt(project_dir: &std::path::Path) -> Result<(), Stri
     );
     let dest = compiled_prompt_path(project_dir);
     write_compiled_prompt_to(&dest, &prompt)
-        .map_err(|source| compiled_prompt_failure_message(&dest, &source))
+        .map_err(|source| instructions_failure_message(&dest, &source))
 }
 
 /// Delete a stale `instructions/INSTRUCTIONS.md` left by a pre-#4752 install.

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -478,12 +478,12 @@ fn compiled_prompt_path_is_not_the_bundled_instructions_path() {
 }
 
 #[test]
-fn compiled_prompt_failure_message_names_the_path_and_a_remedy() {
+fn instructions_failure_message_names_the_path_and_a_remedy() {
     // Why (#4752 ruling follow-up 1): the write is fatal, so a refused launch
     // must tell the operator what was refused, where, and what to do — not
     // surface a bare io error.
     let err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
-    let msg = compiled_prompt_failure_message(Path::new("/p/.trusty-mpm/framework/X.md"), &err);
+    let msg = instructions_failure_message(Path::new("/p/.trusty-mpm/framework/X.md"), &err);
     assert!(
         msg.contains("/p/.trusty-mpm/framework/X.md"),
         "must name the path: {msg}"

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -420,6 +420,107 @@ fn assemble_system_prompt_contains_all_sections() {
     assert!(!prompt.contains("ticketing_agent"));
 }
 
+// ── #4752: the compiled prompt owns a path nothing else writes ─────────────
+
+#[test]
+fn compiled_prompt_path_is_distinct_from_the_bundled_instructions_path() {
+    // Why (#4752): the compiled prompt used to be written to
+    // `framework/instructions/INSTRUCTIONS.md` — the SAME path a bundled stub
+    // targeted (#383) and that `build_instructions` reads back as a pipeline
+    // INPUT. FAILS BEFORE THIS CHANGE: `instructions_compiled()` did not exist,
+    // and the compiled write landed on `framework_instructions_path()`.
+    // What: pins the compiled path to `framework/INSTRUCTIONS-COMPILED.md`,
+    // directly under the framework root and NOT under `instructions/`, and
+    // asserts it is a different path from the bundled-input file.
+    let tmp = TempDir::new().unwrap();
+    let paths = crate::core::paths::FrameworkPaths::under(tmp.path());
+
+    let compiled = paths.instructions_compiled();
+    let bundled = paths.framework_instructions_path();
+
+    assert_ne!(
+        compiled, bundled,
+        "the compiled prompt must not share a path with the bundled instructions input"
+    );
+    assert_eq!(
+        compiled,
+        paths.framework.join("INSTRUCTIONS-COMPILED.md"),
+        "the compiled prompt sits directly under framework/, not framework/instructions/"
+    );
+    assert_eq!(
+        compiled.parent(),
+        Some(paths.framework.as_path()),
+        "framework/ is the compiled prompt's parent — `instructions/` is not"
+    );
+}
+
+#[test]
+fn no_bundled_artifact_targets_the_compiled_prompt_path() {
+    // Why (#4752): the defect was two writers on one path. This pins the
+    // bundle-installer half — no entry in the canonical artifact table may
+    // resolve to the compiled prompt's filename, at any depth, so the
+    // `install_to` pass can never write there. A future artifact re-adding a
+    // stub under that name turns this red instead of silently reintroducing
+    // last-writer-wins.
+    // What: scans `bundle::ALL` for any `rel_path` whose file name is
+    // `COMPILED_PROMPT_FILE`.
+    let clashing: Vec<&str> = crate::core::bundle::ALL
+        .iter()
+        .map(|a| a.rel_path)
+        .filter(|p| Path::new(p).file_name().and_then(|n| n.to_str()) == Some(COMPILED_PROMPT_FILE))
+        .collect();
+    assert!(
+        clashing.is_empty(),
+        "no bundled artifact may target {COMPILED_PROMPT_FILE}; found {clashing:?}"
+    );
+}
+
+#[test]
+fn remove_stale_bundled_instructions_deletes_a_leftover() {
+    // Why (#4752): a pre-#4752 install left the compiled prompt at
+    // `instructions/INSTRUCTIONS.md`. Nothing writes it now but
+    // `build_instructions` still reads it, so an upgraded machine would fold a
+    // frozen old prompt into the pipeline forever. `tm install` removes it.
+    let tmp = TempDir::new().unwrap();
+    let paths = crate::core::paths::FrameworkPaths::under(tmp.path());
+    let stale = paths.framework_instructions_path();
+    write_file(&stale, "# an old compiled prompt\n");
+
+    assert!(
+        remove_stale_bundled_instructions(&stale).expect("removal succeeds"),
+        "an existing leftover must be reported as removed"
+    );
+    assert!(!stale.exists(), "the stale leftover must be gone");
+    // The compiled prompt is a DIFFERENT file and must be untouched by this.
+    assert_ne!(stale, paths.instructions_compiled());
+}
+
+#[test]
+fn remove_stale_bundled_instructions_is_a_noop_when_absent() {
+    // Why: the common case is a fresh machine that never had the file. That
+    // must not be an error, and must not report a removal.
+    let tmp = TempDir::new().unwrap();
+    let paths = crate::core::paths::FrameworkPaths::under(tmp.path());
+    assert!(
+        !remove_stale_bundled_instructions(&paths.framework_instructions_path())
+            .expect("absence is not an error"),
+        "nothing was removed, so the call must report false"
+    );
+}
+
+#[test]
+fn write_compiled_prompt_to_creates_parent_dirs() {
+    // Why: the launch path calls this against a framework root that may not
+    // exist yet on a machine that never ran `tm install`; a missing parent must
+    // not fail the launch.
+    // What: writes into a two-deep absent directory and reads the bytes back
+    // verbatim.
+    let tmp = TempDir::new().unwrap();
+    let dest = tmp.path().join("a").join("b").join(COMPILED_PROMPT_FILE);
+    write_compiled_prompt_to(&dest, "COMPILED-BODY").expect("write succeeds");
+    assert_eq!(fs::read_to_string(&dest).unwrap(), "COMPILED-BODY");
+}
+
 // Why serial + fake-HOME (extra sweep hit — review-gate report on top of
 // #2459/#2460/#2461): `install_system_prompt()` resolves `dirs::home_dir()`
 // internally and previously wrote straight into the REAL
@@ -433,9 +534,10 @@ fn assemble_system_prompt_contains_all_sections() {
 #[serial_test::serial]
 #[test]
 fn install_system_prompt_writes_file() {
-    // Why: `tm launch` depends on `install_system_prompt` regenerating
-    // INSTRUCTIONS.md; this asserts it writes a non-empty file under the
-    // expected `~/.trusty-mpm/framework/instructions/` path.
+    // Why: `install_system_prompt` must regenerate the compiled prompt under
+    // the expected `~/.trusty-mpm/framework/` path. #4752 moved that target off
+    // `instructions/INSTRUCTIONS.md` — the shared, last-writer-wins path — onto
+    // `INSTRUCTIONS-COMPILED.md`, which nothing else writes.
     let fake_home = TempDir::new().expect("create fake home");
     let prev_home = std::env::var("HOME").ok();
     // SAFETY: serialized via `#[serial_test::serial]`, so no other test
@@ -455,7 +557,14 @@ fn install_system_prompt_writes_file() {
 
     let out = install_system_prompt().expect("install succeeds");
     assert!(out.starts_with(fake_home.path()));
-    assert!(out.ends_with("INSTRUCTIONS.md"));
+    assert_eq!(
+        out,
+        fake_home
+            .path()
+            .join(".trusty-mpm/framework")
+            .join(COMPILED_PROMPT_FILE),
+        "#4752: the compiled prompt lands directly under framework/, on its own path"
+    );
     assert!(out.exists());
     let on_disk = fs::read_to_string(&out).unwrap();
     assert_eq!(on_disk, assemble_system_prompt());
@@ -471,11 +580,11 @@ fn install_system_prompt_to_writes_assembled() {
     // equals `assemble_system_prompt()` and contains key PM headings.
     // Test: call the helper against a temp path; read back and verify content.
     let tmp = TempDir::new().unwrap();
-    let dest = tmp.path().join("instructions").join("INSTRUCTIONS.md");
+    let dest = tmp.path().join("framework").join(COMPILED_PROMPT_FILE);
     install_system_prompt_to(&dest).expect("write succeeds");
     assert!(
         dest.exists(),
-        "INSTRUCTIONS.md must exist after install_system_prompt_to"
+        "{COMPILED_PROMPT_FILE} must exist after install_system_prompt_to"
     );
     let on_disk = fs::read_to_string(&dest).unwrap();
     assert_eq!(

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -423,35 +423,77 @@ fn assemble_system_prompt_contains_all_sections() {
 // ── #4752: the compiled prompt owns a path nothing else writes ─────────────
 
 #[test]
-fn compiled_prompt_path_is_distinct_from_the_bundled_instructions_path() {
-    // Why (#4752): the compiled prompt used to be written to
-    // `framework/instructions/INSTRUCTIONS.md` — the SAME path a bundled stub
-    // targeted (#383) and that `build_instructions` reads back as a pipeline
-    // INPUT. FAILS BEFORE THIS CHANGE: `instructions_compiled()` did not exist,
-    // and the compiled write landed on `framework_instructions_path()`.
-    // What: pins the compiled path to `framework/INSTRUCTIONS-COMPILED.md`,
-    // directly under the framework root and NOT under `instructions/`, and
-    // asserts it is a different path from the bundled-input file.
+fn compiled_prompt_path_is_project_local() {
+    // Why (#4752, owner ruling 2026-08-04): the compiled prompt belongs to the
+    // PROJECT whose session runs it. FAILS BEFORE THIS CHANGE — the path was
+    // `FrameworkPaths::instructions_compiled()`, one global file under
+    // `~/.trusty-mpm/framework/`.
+    // What: pins `<project>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`.
+    let project = Path::new("/some/project");
+    assert_eq!(
+        compiled_prompt_path(project),
+        Path::new("/some/project/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md")
+    );
+}
+
+#[test]
+fn compiled_prompt_path_is_beside_the_session_stash() {
+    // Why: the ruling put the file in the project's own `.trusty-mpm/` — the
+    // directory that already holds `last-instructions.md` and `sessions/` and
+    // that `tm` writes on every launch. That co-location is the whole basis for
+    // making the write fatal, so pin it.
+    let project = Path::new("/some/project");
+    let stash_dir = project.join(".trusty-mpm");
+    assert!(
+        compiled_prompt_path(project).starts_with(&stash_dir),
+        "the compiled prompt must live under the project's own .trusty-mpm/"
+    );
+}
+
+#[test]
+fn compiled_prompt_path_never_collides_across_projects() {
+    // Why (#4752 review, MEDIUM 4): the defect was that ONE global file served
+    // every project, so concurrent sessions overwrote each other. FAILS BEFORE
+    // THIS CHANGE — `FrameworkPaths::instructions_compiled()` returned the same
+    // path for both projects (it resolved from the shared managed root, and
+    // `for_managed_workspace` from the real `$HOME`).
+    let a = compiled_prompt_path(Path::new("/projects/alpha"));
+    let b = compiled_prompt_path(Path::new("/projects/beta"));
+    assert_ne!(
+        a, b,
+        "two projects must not share one compiled-prompt file — that was the collision"
+    );
+}
+
+#[test]
+fn compiled_prompt_path_is_not_the_bundled_instructions_path() {
+    // The original #4752 defect: the compiled OUTPUT must not share a path with
+    // the bundled INPUT `build_instructions` reads.
     let tmp = TempDir::new().unwrap();
     let paths = crate::core::paths::FrameworkPaths::under(tmp.path());
-
-    let compiled = paths.instructions_compiled();
-    let bundled = paths.framework_instructions_path();
-
     assert_ne!(
-        compiled, bundled,
-        "the compiled prompt must not share a path with the bundled instructions input"
+        compiled_prompt_path(tmp.path()),
+        paths.framework_instructions_path()
     );
-    assert_eq!(
-        compiled,
-        paths.framework.join("INSTRUCTIONS-COMPILED.md"),
-        "the compiled prompt sits directly under framework/, not framework/instructions/"
+}
+
+#[test]
+fn compiled_prompt_failure_message_names_the_path_and_a_remedy() {
+    // Why (#4752 ruling follow-up 1): the write is fatal, so a refused launch
+    // must tell the operator what was refused, where, and what to do — not
+    // surface a bare io error.
+    let err = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "denied");
+    let msg = compiled_prompt_failure_message(Path::new("/p/.trusty-mpm/framework/X.md"), &err);
+    assert!(
+        msg.contains("/p/.trusty-mpm/framework/X.md"),
+        "must name the path: {msg}"
     );
-    assert_eq!(
-        compiled.parent(),
-        Some(paths.framework.as_path()),
-        "framework/ is the compiled prompt's parent — `instructions/` is not"
+    assert!(msg.contains("denied"), "must carry the cause: {msg}");
+    assert!(
+        msg.contains("was NOT started"),
+        "must say the session did not start: {msg}"
     );
+    assert!(msg.contains("permissions"), "must point at a remedy: {msg}");
 }
 
 #[test]
@@ -491,8 +533,8 @@ fn remove_stale_bundled_instructions_deletes_a_leftover() {
         "an existing leftover must be reported as removed"
     );
     assert!(!stale.exists(), "the stale leftover must be gone");
-    // The compiled prompt is a DIFFERENT file and must be untouched by this.
-    assert_ne!(stale, paths.instructions_compiled());
+    // The compiled prompt is a DIFFERENT, project-local file.
+    assert_ne!(stale, compiled_prompt_path(tmp.path()));
 }
 
 #[test]
@@ -521,90 +563,25 @@ fn write_compiled_prompt_to_creates_parent_dirs() {
     assert_eq!(fs::read_to_string(&dest).unwrap(), "COMPILED-BODY");
 }
 
-// Why serial + fake-HOME (extra sweep hit — review-gate report on top of
-// #2459/#2460/#2461): `install_system_prompt()` resolves `dirs::home_dir()`
-// internally and previously wrote straight into the REAL
-// `$HOME/.trusty-mpm/framework/instructions/` — both polluting the
-// developer's real home directory on every test run AND racing with any
-// other test in this binary that redirects `HOME` to a temp dir
-// concurrently (same class as `manifest_expands_tilde`, #2459). Redirect
-// `HOME` to an isolated temp dir for the duration of the test and join
-// the crate's shared `#[serial_test::serial]` lock so no other
-// HOME-mutating test can interleave.
-#[serial_test::serial]
 #[test]
-fn install_system_prompt_writes_file() {
-    // Why: `install_system_prompt` must regenerate the compiled prompt under
-    // the expected `~/.trusty-mpm/framework/` path. #4752 moved that target off
-    // `instructions/INSTRUCTIONS.md` — the shared, last-writer-wins path — onto
-    // `INSTRUCTIONS-COMPILED.md`, which nothing else writes.
-    let fake_home = TempDir::new().expect("create fake home");
-    let prev_home = std::env::var("HOME").ok();
-    // SAFETY: serialized via `#[serial_test::serial]`, so no other test
-    // thread observes or mutates HOME concurrently. Restored below
-    // regardless of panics via the `HomeGuard` drop impl.
-    unsafe { std::env::set_var("HOME", fake_home.path()) };
-    struct HomeGuard(Option<String>);
-    impl Drop for HomeGuard {
-        fn drop(&mut self) {
-            match &self.0 {
-                Some(p) => unsafe { std::env::set_var("HOME", p) },
-                None => unsafe { std::env::remove_var("HOME") },
-            }
-        }
-    }
-    let _guard = HomeGuard(prev_home);
-
-    let out = install_system_prompt().expect("install succeeds");
-    assert!(out.starts_with(fake_home.path()));
-    assert_eq!(
-        out,
-        fake_home
-            .path()
-            .join(".trusty-mpm/framework")
-            .join(COMPILED_PROMPT_FILE),
-        "#4752: the compiled prompt lands directly under framework/, on its own path"
-    );
-    assert!(out.exists());
-    let on_disk = fs::read_to_string(&out).unwrap();
-    assert_eq!(on_disk, assemble_system_prompt());
-    assert!(!on_disk.is_empty());
-}
-
-#[test]
-fn install_system_prompt_to_writes_assembled() {
-    // Why: `tm install` calls `install_system_prompt_to` pointing at the
-    // framework path so the assembled prompt (not the 4-line stub) is on
-    // disk immediately after install — regression for issue #383.
-    // What: asserts the file written by the path-parameterised helper
-    // equals `assemble_system_prompt()` and contains key PM headings.
-    // Test: call the helper against a temp path; read back and verify content.
+fn compiled_prompt_write_is_the_full_assembled_prompt_never_a_stub() {
+    // Why (#383 regression guard, retained through #4752's path move): the
+    // compiled file must only ever hold a FULL composed prompt. #383 was a
+    // 4-line stub winning a last-writer race on the shared path; the path is
+    // now project-local and single-writer, but the content contract still
+    // needs pinning.
+    // What: writes the bundled assembly to a project's compiled path and
+    // asserts it is neither empty nor the historical stub.
     let tmp = TempDir::new().unwrap();
-    let dest = tmp.path().join("framework").join(COMPILED_PROMPT_FILE);
-    install_system_prompt_to(&dest).expect("write succeeds");
-    assert!(
-        dest.exists(),
-        "{COMPILED_PROMPT_FILE} must exist after install_system_prompt_to"
-    );
+    let dest = compiled_prompt_path(tmp.path());
+    write_compiled_prompt_to(&dest, &assemble_system_prompt()).expect("write succeeds");
+
     let on_disk = fs::read_to_string(&dest).unwrap();
-    assert_eq!(
-        on_disk,
-        assemble_system_prompt(),
-        "content must equal assembled prompt"
-    );
-    // The 4-line stub must NOT be present (regression guard for issue #383).
+    assert_eq!(on_disk, assemble_system_prompt());
+    assert!(!on_disk.trim().is_empty());
     assert!(
         !on_disk.trim().eq("# trusty-mpm Framework Instructions\n\nThis Claude Code instance is managed by trusty-mpm.\nDaemon endpoint: ${TRUSTY_MPM_URL:-http://localhost:7799}"),
-        "stub content must not be written — full assembled prompt required"
-    );
-    // Real PM sections must be present.
-    assert!(
-        on_disk.contains("# PM Agent -- Trusty MPM"),
-        "PM_INSTRUCTIONS section must be present"
-    );
-    assert!(
-        on_disk.contains("# Framework Instructions"),
-        "BASE_PM floor must be present"
+        "stub content must never be written — full assembled prompt required"
     );
 }
 

--- a/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
+++ b/crates/trusty-mpm/src/core/instruction_pipeline_tests.rs
@@ -723,3 +723,64 @@ fn session_start_count_matches_the_delivered_delegation_roster() {
         "engineer + qa + writer + ticketing, with the cross-tier `qa` counted once"
     );
 }
+
+// ── #4752 round 4: the shared fatal compiled-prompt refresh ─────────────────
+
+#[test]
+fn refresh_compiled_prompt_writes_the_project_local_file() {
+    // Why (#4752 round 4): this is the single entry point all THREE pre-spawn
+    // paths now route through — fresh start, daemon resume, and the bare-`tm`
+    // in-place relaunch that round 3 missed entirely. Pinning it directly means
+    // the guarantee is asserted on the implementation, not only through the
+    // daemon's thin `refresh_compiled_prompt_for_resume` delegate.
+    //
+    // FIXTURE: a stale sentinel is pre-seeded so "the file exists" cannot pass;
+    // only a real refresh overwrites it.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest = compiled_prompt_path(tmp.path());
+    fs::create_dir_all(dest.parent().expect("has a parent")).expect("create parent");
+    const STALE: &str = "STALE-FROM-A-PREVIOUS-LAUNCH";
+    fs::write(&dest, STALE).expect("seed stale");
+
+    refresh_compiled_prompt(tmp.path()).expect("refresh must succeed");
+
+    let on_disk = fs::read_to_string(&dest).expect("readable");
+    assert_ne!(
+        on_disk, STALE,
+        "a stale compiled prompt must be overwritten"
+    );
+    assert!(
+        on_disk.contains("# PM Agent -- Trusty MPM"),
+        "must hold the resolved PM prompt, not a fragment: {on_disk}"
+    );
+    assert!(
+        dest.starts_with(tmp.path()),
+        "the compiled prompt is PROJECT-LOCAL; a global path would restore the \
+         cross-project collision #4752 removed"
+    );
+}
+
+#[test]
+fn refresh_compiled_prompt_reports_an_actionable_failure() {
+    // Why (#4752): the write is fatal at all three call sites, so a refusal is
+    // operator-facing — it must name the path and say the session did not
+    // start, never surface a bare io error.
+    //
+    // FIXTURE: a directory planted at the exact destination, so only this write
+    // fails and nothing else in the compose path does.
+    let tmp = TempDir::new().expect("tempdir");
+    let dest = compiled_prompt_path(tmp.path());
+    fs::create_dir_all(&dest).expect("plant a directory at the compiled path");
+
+    let msg = refresh_compiled_prompt(tmp.path())
+        .expect_err("a failed compiled write must be reported as an error");
+    assert!(
+        msg.contains(&dest.display().to_string()),
+        "must name the path: {msg}"
+    );
+    assert!(
+        msg.contains("was NOT started"),
+        "must say the session did not start: {msg}"
+    );
+    assert!(msg.contains("permissions"), "must point at a remedy: {msg}");
+}

--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -322,24 +322,13 @@ impl FrameworkPaths {
         self.instructions.join("INSTRUCTIONS.md")
     }
 
-    /// Path of the COMPILED PM system prompt (`INSTRUCTIONS-COMPILED.md`).
-    ///
-    /// Why (#4752): the compiled prompt used to be written to
-    /// [`framework_instructions`](Self::framework_instructions) — the same
-    /// `instructions/INSTRUCTIONS.md` path a bundled stub also targeted and that
-    /// [`crate::core::instruction_pipeline::build_instructions`] reads back as a
-    /// pipeline INPUT. One path with two writers and a reader is
-    /// non-deterministic by construction (#383 regressed on exactly this), so
-    /// the compiled output gets a path of its own that nothing else writes.
-    /// What: `INSTRUCTIONS-COMPILED.md` directly under the framework root —
-    /// deliberately NOT under `framework/instructions/`, which stays the
-    /// bundled-input directory.
-    /// Test: `instructions_compiled_is_directly_under_framework`,
-    /// `instructions_compiled_is_not_the_framework_instructions_path`.
-    pub fn instructions_compiled(&self) -> PathBuf {
-        self.framework
-            .join(crate::core::instruction_pipeline::COMPILED_PROMPT_FILE)
-    }
+    // #4752: there is deliberately NO `instructions_compiled()` accessor here.
+    // The compiled PM prompt is PER-PROJECT session state, not part of the
+    // global framework install this type models, so it is resolved by
+    // `instruction_pipeline::compiled_prompt_path(project_dir)` instead. An
+    // accessor on this type would have to pick between the shared managed root
+    // and the real `$HOME` — the ambiguity that made the file collide across
+    // concurrent sessions in the first place.
 
     /// Path of the framework launch instructions — explicit-name alias.
     ///
@@ -885,29 +874,6 @@ mod tests {
         assert_eq!(
             paths.framework_instructions(),
             PathBuf::from("/base/.trusty-mpm/framework/instructions/INSTRUCTIONS.md")
-        );
-    }
-
-    #[test]
-    fn instructions_compiled_is_directly_under_framework() {
-        // #4752: `framework/INSTRUCTIONS-COMPILED.md`, NOT
-        // `framework/instructions/…`. FAILS BEFORE THIS CHANGE — the accessor
-        // did not exist and the compiled prompt shared the bundled path.
-        let paths = FrameworkPaths::under("/base");
-        assert_eq!(
-            paths.instructions_compiled(),
-            PathBuf::from("/base/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md")
-        );
-    }
-
-    #[test]
-    fn instructions_compiled_is_not_the_framework_instructions_path() {
-        // The whole point of #4752: the compiled OUTPUT and the bundled INPUT
-        // are different files, so neither can clobber the other.
-        let paths = FrameworkPaths::under("/base");
-        assert_ne!(
-            paths.instructions_compiled(),
-            paths.framework_instructions_path()
         );
     }
 

--- a/crates/trusty-mpm/src/core/paths.rs
+++ b/crates/trusty-mpm/src/core/paths.rs
@@ -322,6 +322,25 @@ impl FrameworkPaths {
         self.instructions.join("INSTRUCTIONS.md")
     }
 
+    /// Path of the COMPILED PM system prompt (`INSTRUCTIONS-COMPILED.md`).
+    ///
+    /// Why (#4752): the compiled prompt used to be written to
+    /// [`framework_instructions`](Self::framework_instructions) — the same
+    /// `instructions/INSTRUCTIONS.md` path a bundled stub also targeted and that
+    /// [`crate::core::instruction_pipeline::build_instructions`] reads back as a
+    /// pipeline INPUT. One path with two writers and a reader is
+    /// non-deterministic by construction (#383 regressed on exactly this), so
+    /// the compiled output gets a path of its own that nothing else writes.
+    /// What: `INSTRUCTIONS-COMPILED.md` directly under the framework root —
+    /// deliberately NOT under `framework/instructions/`, which stays the
+    /// bundled-input directory.
+    /// Test: `instructions_compiled_is_directly_under_framework`,
+    /// `instructions_compiled_is_not_the_framework_instructions_path`.
+    pub fn instructions_compiled(&self) -> PathBuf {
+        self.framework
+            .join(crate::core::instruction_pipeline::COMPILED_PROMPT_FILE)
+    }
+
     /// Path of the framework launch instructions — explicit-name alias.
     ///
     /// Why: the instruction merge pipeline refers to this file as
@@ -866,6 +885,29 @@ mod tests {
         assert_eq!(
             paths.framework_instructions(),
             PathBuf::from("/base/.trusty-mpm/framework/instructions/INSTRUCTIONS.md")
+        );
+    }
+
+    #[test]
+    fn instructions_compiled_is_directly_under_framework() {
+        // #4752: `framework/INSTRUCTIONS-COMPILED.md`, NOT
+        // `framework/instructions/…`. FAILS BEFORE THIS CHANGE — the accessor
+        // did not exist and the compiled prompt shared the bundled path.
+        let paths = FrameworkPaths::under("/base");
+        assert_eq!(
+            paths.instructions_compiled(),
+            PathBuf::from("/base/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md")
+        );
+    }
+
+    #[test]
+    fn instructions_compiled_is_not_the_framework_instructions_path() {
+        // The whole point of #4752: the compiled OUTPUT and the bundled INPUT
+        // are different files, so neither can clobber the other.
+        let paths = FrameworkPaths::under("/base");
+        assert_ne!(
+            paths.instructions_compiled(),
+            paths.framework_instructions_path()
         );
     }
 

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -224,14 +224,17 @@ pub struct PrepReport {
     pub instructions: PipelineOutput,
     /// Path the merged instructions were stashed to for inspection.
     pub stash: PathBuf,
-    /// Path the framework-level compiled prompt was written to (#4752).
+    /// Path the PROJECT-LOCAL compiled prompt was written to (#4752).
     ///
     /// Why: exposing it makes the launch-ordering guarantee assertable — a
     /// returned `PrepReport` means this file exists and holds the exact text
     /// the session is about to receive, because the write is fatal and happens
     /// before this value is constructed.
-    /// What: `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` (or the `fw`
-    /// root a test supplies), byte-identical to [`Self::stash`].
+    /// What: `<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`, as
+    /// resolved by [`crate::core::instruction_pipeline::compiled_prompt_path`],
+    /// byte-identical to [`Self::stash`]. NOT the global
+    /// `~/.trusty-mpm/framework/` path — that shared location was the collision
+    /// #4752 removed, since every project would have overwritten the same file.
     /// Test: `prepare_session_writes_the_compiled_prompt_before_returning`,
     /// `prepare_session_fails_when_the_compiled_prompt_cannot_be_written`.
     pub compiled_prompt: PathBuf,
@@ -386,9 +389,7 @@ impl PrepError {
 /// written to `<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
 /// ([`crate::core::instruction_pipeline::compiled_prompt_path`]) as this
 /// function's LAST step, and a failure returns [`PrepError::CompiledPrompt`],
-/// which every spawning caller treats as FATAL — the launch is refused. So a
-/// session that starts always has a compiled prompt on disk matching the text
-/// it received.
+/// which every spawning caller treats as FATAL — the launch is refused.
 ///
 /// This is the ONE preparation failure that blocks a launch. #2149's
 /// non-fatal-preparation design still governs every other variant (a roster or
@@ -399,9 +400,22 @@ impl PrepError {
 /// injectors or the trust pre-seed — see the inline comment at the call and
 /// `compiled_write_failure_does_not_skip_the_mcp_injectors`.
 ///
-/// The resume path never calls this function; it is covered by an equivalent
-/// fatal write in `daemon::managed_routes::lifecycle::resume_managed`. See
-/// spec §10.3.
+/// WHAT THE CONTRACT DOES **NOT** SAY: it is not "every started session has a
+/// compiled prompt". Making the compiled write fatal while a neighbouring write
+/// under the same `.trusty-mpm/` stayed a short-circuiting non-fatal error would
+/// be incoherent, so the stash write above it now degrades to a warning instead
+/// of returning early — an unwritable `.trusty-mpm/` can no longer skip the
+/// injectors or this write. One early exit remains BEFORE it: a
+/// [`build_instructions`] failure, which returns a non-fatal error, so the
+/// caller still launches and no compiled prompt is refreshed. That is a
+/// different condition (the instruction pipeline itself, not a `.trusty-mpm/`
+/// write) and it predates this issue; it is left to #2149's policy rather than
+/// silently promoted to fatal here.
+///
+/// The resume path never calls this function. Both other entry points carry the
+/// same fatal write: `daemon::managed_routes::lifecycle::resume_managed` (daemon
+/// resume) and `runtime::refresh_compiled_prompt` as called from the bare-`tm`
+/// in-place relaunch in `tm::commands::guided_inplace`. See spec §10.3.
 /// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
 /// `prepare_session_stash_reflects_override`,
 /// `prepare_session_writes_the_compiled_prompt_before_returning`,
@@ -867,16 +881,27 @@ fn prepare_session_inner(
         effective_style.as_deref(),
         native_supported,
     );
+    // #4752: these two writes DEGRADE TO A WARNING; they must never short-circuit
+    // this function. An unwritable `.trusty-mpm/` (disk full, bad perms) used to
+    // return `PrepError::Io` HERE — before the MCP injectors below — and because
+    // `Io` is non-fatal every caller then launched the session anyway, with the
+    // injectors skipped. That is the same security shape as the round-1 regression
+    // this issue already fixed for the compiled write, reached by a second route.
+    // The stash is an inspection artifact (`tm session instructions`); losing it
+    // is not worth skipping the MCP trust boundary or the compiled write.
+    // See the ordering contract on `prepare_session`.
+    // Test: `stash_write_failure_does_not_skip_the_mcp_injectors`.
     let stash_dir = project_dir.join(".trusty-mpm");
-    std::fs::create_dir_all(&stash_dir).map_err(|source| PrepError::Io {
-        path: stash_dir.clone(),
-        source,
-    })?;
     let stash = stash_dir.join("last-instructions.md");
-    std::fs::write(&stash, &resolved_prompt).map_err(|source| PrepError::Io {
-        path: stash.clone(),
-        source,
-    })?;
+    match std::fs::create_dir_all(&stash_dir)
+        .and_then(|()| std::fs::write(&stash, &resolved_prompt))
+    {
+        Ok(()) => {}
+        Err(e) => tracing::warn!(
+            "could not refresh the instruction stash at {} (non-fatal): {e}",
+            stash.display()
+        ),
+    }
 
     // Resolve the active output style for settings.json using the same
     // EFFECTIVE style computed above (HR-4 sources + the HR-2 manifest default).
@@ -1186,9 +1211,10 @@ fn prepare_session_inner(
         None
     };
 
-    // #4752: refresh the framework-level compiled prompt with the text this
-    // session will actually receive (`resolved_prompt`, the same string stashed
-    // to `.trusty-mpm/last-instructions.md` above).
+    // #4752: refresh the PROJECT-LOCAL compiled prompt
+    // (`<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`) with the
+    // text this session will actually receive (`resolved_prompt`, the same
+    // string stashed to `.trusty-mpm/last-instructions.md` above).
     //
     // POSITION IS LOAD-BEARING, and it is deliberately the LAST step. An earlier
     // revision of this change put the write immediately after the stash, where

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -325,6 +325,45 @@ pub enum PrepError {
         /// The underlying IO error.
         source: std::io::Error,
     },
+    /// Writing the project's compiled PM prompt failed — the ONE fatal
+    /// preparation error (#4752, owner ruling 2026-08-04).
+    ///
+    /// Why it is its own variant rather than another [`Self::Io`]: #2149
+    /// deliberately made preparation failures non-fatal so a roster- or
+    /// skill-deploy hiccup could not stop a session launching, and every
+    /// production caller still logs-and-continues on those. This one is ruled
+    /// fatal — "if we can't write a simple file to this directory, we have a
+    /// bigger issue" — so callers need to tell it apart from the failures
+    /// #2149 was aimed at. [`PrepError::is_fatal`] is that discriminator; a
+    /// blanket "all prep errors are fatal" would have reversed #2149 wholesale
+    /// and regressed exactly what it protected.
+    /// Test: `compiled_prompt_failure_is_fatal`,
+    /// `deploy_and_io_failures_stay_non_fatal`.
+    #[error(
+        "{}",
+        crate::core::instruction_pipeline::compiled_prompt_failure_message(path, source)
+    )]
+    CompiledPrompt {
+        /// The compiled-prompt path the write targeted.
+        path: PathBuf,
+        /// The underlying IO error.
+        source: std::io::Error,
+    },
+}
+
+impl PrepError {
+    /// Whether this failure must abort the launch rather than be logged.
+    ///
+    /// Why (#4752): the seven spawning call sites treat preparation as
+    /// best-effort (#2149). Exactly one failure is ruled fatal, and this is the
+    /// single place that decides which — so a future variant does not silently
+    /// inherit either policy.
+    /// What: `true` only for [`Self::CompiledPrompt`].
+    /// Test: `compiled_prompt_failure_is_fatal`,
+    /// `deploy_and_io_failures_stay_non_fatal`.
+    pub fn is_fatal(&self) -> bool {
+        matches!(self, Self::CompiledPrompt { .. })
+    }
 }
 
 /// Prepare a project directory for a fresh Claude Code session launch.
@@ -343,27 +382,26 @@ pub enum PrepError {
 /// matches the live launch prompt byte-for-byte (issue #1409), and returns a
 /// [`PrepReport`].
 ///
-/// COMPILED PROMPT (#4752): the same prompt is ALSO written to
-/// `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
-/// ([`crate::core::paths::FrameworkPaths::instructions_compiled`]) as this
-/// function's LAST step, and a failed write returns `Err`.
+/// ORDERING CONTRACT (#4752, owner ruling 2026-08-04): the same prompt is ALSO
+/// written to `<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
+/// ([`crate::core::instruction_pipeline::compiled_prompt_path`]) as this
+/// function's LAST step, and a failure returns [`PrepError::CompiledPrompt`],
+/// which every spawning caller treats as FATAL — the launch is refused. So a
+/// session that starts always has a compiled prompt on disk matching the text
+/// it received.
 ///
-/// That `Err` does NOT block any launch, and this doc deliberately does not
-/// claim otherwise. Since #2149 every production caller treats a prep failure
-/// as non-fatal and spawns anyway — `commands/launch.rs::connect`, the
-/// managed-clone block in `commands/launch.rs`, `commands/meta/launch.rs`,
-/// `commands/session/start.rs::start_session_in_place`,
-/// `client/http_client/session_connect.rs`,
-/// `daemon/managed_routes/lifecycle.rs::prepare_inproject_session`, and
-/// `provisioner/workspace.rs` all log and continue. The only caller that
-/// propagates, `core/standalone/load.rs::run_prepare_session`, spawns no
-/// `claude` at all, so the fatality's sole live effect is hard-failing
-/// `tm load <alias>`.
+/// This is the ONE preparation failure that blocks a launch. #2149's
+/// non-fatal-preparation design still governs every other variant (a roster or
+/// skill deploy failure is surfaced via [`PrepReport::roster_errors`] and the
+/// session still starts); [`PrepError::is_fatal`] is the discriminator.
 ///
-/// What actually keeps the artifact current at every launch is
-/// `runtime::claude_code::build_prompt_file`, which rewrites it from the exact
-/// bytes it hands to `--append-system-prompt-file` — including on the resume
-/// path, which never calls this function. See #4752 and spec §10.3.
+/// POSITION: the write is deliberately LAST, so a refusal cannot skip the MCP
+/// injectors or the trust pre-seed — see the inline comment at the call and
+/// `compiled_write_failure_does_not_skip_the_mcp_injectors`.
+///
+/// The resume path never calls this function; it is covered by an equivalent
+/// fatal write in `daemon::managed_routes::lifecycle::resume_managed`. See
+/// spec §10.3.
 /// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
 /// `prepare_session_stash_reflects_override`,
 /// `prepare_session_writes_the_compiled_prompt_before_returning`,
@@ -1162,9 +1200,9 @@ fn prepare_session_inner(
     // function's doc comment), a failed compiled write would have SKIPPED those
     // injectors and let the session launch anyway. Nothing below this line may
     // depend on the write succeeding — keep it last.
-    let compiled = fw.instructions_compiled();
+    let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project_dir);
     crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &resolved_prompt)
-        .map_err(|source| PrepError::Io {
+        .map_err(|source| PrepError::CompiledPrompt {
             path: compiled.clone(),
             source,
         })?;
@@ -1194,33 +1232,19 @@ fn prepare_session_inner(
 /// and passed to `claude --append-system-prompt-file`. This variant is kept for
 /// callers that do not know the project directory (e.g. tests); prefer
 /// [`build_system_prompt_for`] at launch sites so project-level overrides apply.
-/// What: reads `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`; if it is
-/// missing or empty (first run) it calls
-/// [`crate::core::instruction_pipeline::install_system_prompt`] to generate it from
-/// the bundled assets, then reads it back. Returns `None` only when the home
-/// directory cannot be resolved or the file cannot be written/read.
+/// What: returns [`crate::core::instruction_pipeline::assemble_system_prompt`],
+/// trimmed. `Option` is retained for API compatibility and is always `Some`.
+///
+/// #4752: this used to read `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`
+/// and regenerate it on disk when missing. That file is retired — nothing writes
+/// it, `tm install` deletes a stale copy, and the compiled prompt is now
+/// per-project — so the round-trip could only ever have returned either bundled
+/// content it already had in memory, or a stale leftover. Composing directly
+/// removes the last dependency on the retired path and the home directory.
 /// Test: `build_system_prompt_includes_trusty_block`.
 pub fn build_system_prompt() -> Option<String> {
-    let home = dirs::home_dir()?;
-    let path = home
-        .join(".trusty-mpm")
-        .join("framework")
-        .join("instructions")
-        .join("INSTRUCTIONS.md");
-
-    // Use the on-disk file when it is present and non-empty.
-    if let Ok(contents) = std::fs::read_to_string(&path) {
-        let trimmed = contents.trim_end();
-        if !trimmed.is_empty() {
-            return Some(trimmed.to_string());
-        }
-    }
-
-    // First run (or empty file): generate it from the bundled assets, then
-    // read it back so the launch path always uses the same source of truth.
-    let generated = crate::core::instruction_pipeline::install_system_prompt().ok()?;
-    let contents = std::fs::read_to_string(&generated).ok()?;
-    let trimmed = contents.trim_end();
+    let composed = crate::core::instruction_pipeline::assemble_system_prompt();
+    let trimmed = composed.trim_end();
     if trimmed.is_empty() {
         None
     } else {

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -224,6 +224,17 @@ pub struct PrepReport {
     pub instructions: PipelineOutput,
     /// Path the merged instructions were stashed to for inspection.
     pub stash: PathBuf,
+    /// Path the framework-level compiled prompt was written to (#4752).
+    ///
+    /// Why: exposing it makes the launch-ordering guarantee assertable — a
+    /// returned `PrepReport` means this file exists and holds the exact text
+    /// the session is about to receive, because the write is fatal and happens
+    /// before this value is constructed.
+    /// What: `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` (or the `fw`
+    /// root a test supplies), byte-identical to [`Self::stash`].
+    /// Test: `prepare_session_writes_the_compiled_prompt_before_returning`,
+    /// `prepare_session_fails_when_the_compiled_prompt_cannot_be_written`.
+    pub compiled_prompt: PathBuf,
     /// Path the `trusty-mpm` output style was deployed to, if it succeeded.
     ///
     /// `None` when the deploy write failed; the session still launches in
@@ -331,8 +342,17 @@ pub enum PrepError {
 /// `<project_dir>/.trusty-mpm/last-instructions.md` so the inspectable stash
 /// matches the live launch prompt byte-for-byte (issue #1409), and returns a
 /// [`PrepReport`].
+///
+/// ORDERING CONTRACT (#4752): the same prompt is ALSO written to
+/// `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
+/// ([`crate::core::paths::FrameworkPaths::instructions_compiled`]) before this
+/// function returns, and a failed write aborts the preparation. Every caller
+/// spawns `claude` only after `Ok`, so "prepare returned" is exactly "the
+/// compiled prompt on disk is the prompt this session is about to run with".
 /// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
-/// `prepare_session_stash_reflects_override`.
+/// `prepare_session_stash_reflects_override`,
+/// `prepare_session_writes_the_compiled_prompt_before_returning`,
+/// `prepare_session_fails_when_the_compiled_prompt_cannot_be_written`.
 pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepReport, PrepError> {
     prepare_session_with_style(fw, project_dir, None)
 }
@@ -804,6 +824,25 @@ fn prepare_session_inner(
         source,
     })?;
 
+    // #4752: the framework-level compiled prompt must be on disk and CURRENT
+    // before `claude` is spawned — every caller of `prepare_session` starts the
+    // process only after this function returns `Ok`, so a blocking write here IS
+    // the ordering guarantee. Deliberately fatal (`?`), not best-effort: a
+    // launch that proceeds past a failed write would leave the operator reading
+    // a stale prompt while the session runs a different one, which is the exact
+    // class of defect #4752 closes.
+    //
+    // Cost is one `write` of a string already in memory — `resolved_prompt` is
+    // the SAME text just stashed above and about to be passed to
+    // `claude --append-system-prompt-file`. No second composition pass; adding
+    // one here would be the thing to eliminate, not to accept.
+    let compiled = fw.instructions_compiled();
+    crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &resolved_prompt)
+        .map_err(|source| PrepError::Io {
+            path: compiled.clone(),
+            source,
+        })?;
+
     // Resolve the active output style for settings.json using the same
     // EFFECTIVE style computed above (HR-4 sources + the HR-2 manifest default).
     // An unknown id is logged and falls back to the professional default rather
@@ -1117,6 +1156,7 @@ fn prepare_session_inner(
         skill_deploy,
         instructions,
         stash,
+        compiled_prompt: compiled,
         output_style,
         hooks_written,
         trusty_mpm_injected,

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -231,10 +231,18 @@ pub struct PrepReport {
     /// the session is about to receive, because the write is fatal and happens
     /// before this value is constructed.
     /// What: `<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`, as
-    /// resolved by [`crate::core::instruction_pipeline::compiled_prompt_path`],
-    /// byte-identical to [`Self::stash`]. NOT the global
-    /// `~/.trusty-mpm/framework/` path — that shared location was the collision
-    /// #4752 removed, since every project would have overwritten the same file.
+    /// resolved by [`crate::core::instruction_pipeline::compiled_prompt_path`].
+    /// NOT the global `~/.trusty-mpm/framework/` path — that shared location was
+    /// the collision #4752 removed, since every project would have overwritten
+    /// the same file.
+    ///
+    /// It holds the same text as [`Self::stash`] AT RETURN, but is not
+    /// permanently byte-identical to it, so do not treat the two as
+    /// interchangeable: the stash write degrades to a warning (so `stash` may be
+    /// absent or stale), and for managed spawns
+    /// `runtime::claude_code::build_prompt_file` later refreshes this file with a
+    /// `None`-style composition that can differ from the `effective_style` text
+    /// written here.
     /// Test: `prepare_session_writes_the_compiled_prompt_before_returning`,
     /// `prepare_session_fails_when_the_compiled_prompt_cannot_be_written`.
     pub compiled_prompt: PathBuf,
@@ -317,9 +325,6 @@ pub enum PrepError {
     /// Deploying skill files to `~/.claude/skills/` failed.
     #[error("skill deploy failed: {0}")]
     SkillDeploy(String),
-    /// Composing or stashing the launch instructions failed.
-    #[error("instruction pipeline failed: {0}")]
-    Instructions(#[from] crate::core::instruction_pipeline::PipelineError),
     /// A filesystem operation on the inspection stash failed.
     #[error("io error for {path}: {source}")]
     Io {
@@ -328,26 +333,35 @@ pub enum PrepError {
         /// The underlying IO error.
         source: std::io::Error,
     },
-    /// Writing the project's compiled PM prompt failed — the ONE fatal
-    /// preparation error (#4752, owner ruling 2026-08-04).
+    /// The session's instructions could not be established — the ONE fatal
+    /// preparation condition (#4752, owner ruling 2026-08-04).
+    ///
+    /// Covers BOTH instruction failures, because they are the same condition
+    /// reaching two sites, not two error classes:
+    ///   * [`build_instructions`] failing to compose or write the merged
+    ///     instructions, and
+    ///   * the compiled prompt write failing.
     ///
     /// Why it is its own variant rather than another [`Self::Io`]: #2149
     /// deliberately made preparation failures non-fatal so a roster- or
     /// skill-deploy hiccup could not stop a session launching, and every
     /// production caller still logs-and-continues on those. This one is ruled
-    /// fatal — "if we can't write a simple file to this directory, we have a
-    /// bigger issue" — so callers need to tell it apart from the failures
-    /// #2149 was aimed at. [`PrepError::is_fatal`] is that discriminator; a
-    /// blanket "all prep errors are fatal" would have reversed #2149 wholesale
-    /// and regressed exactly what it protected.
-    /// Test: `compiled_prompt_failure_is_fatal`,
-    /// `deploy_and_io_failures_stay_non_fatal`.
+    /// fatal — the session depends on its instructions, so a session that
+    /// cannot get them must not start. [`PrepError::is_fatal`] is that
+    /// discriminator; a blanket "all prep errors are fatal" would have reversed
+    /// #2149 wholesale and regressed exactly what it protected.
+    ///
+    /// Renamed from `CompiledPrompt` (round 4): the variant no longer describes
+    /// only the compiled-prompt write.
+    /// Test: `instruction_failure_is_fatal`,
+    /// `deploy_and_io_failures_stay_non_fatal`,
+    /// `prepare_session_refuses_when_the_instructions_cannot_be_built`.
     #[error(
         "{}",
-        crate::core::instruction_pipeline::compiled_prompt_failure_message(path, source)
+        crate::core::instruction_pipeline::instructions_failure_message(path, source)
     )]
-    CompiledPrompt {
-        /// The compiled-prompt path the write targeted.
+    Instructions {
+        /// The instruction path the failed operation targeted.
         path: PathBuf,
         /// The underlying IO error.
         source: std::io::Error,
@@ -358,14 +372,15 @@ impl PrepError {
     /// Whether this failure must abort the launch rather than be logged.
     ///
     /// Why (#4752): the seven spawning call sites treat preparation as
-    /// best-effort (#2149). Exactly one failure is ruled fatal, and this is the
-    /// single place that decides which — so a future variant does not silently
-    /// inherit either policy.
-    /// What: `true` only for [`Self::CompiledPrompt`].
-    /// Test: `compiled_prompt_failure_is_fatal`,
+    /// best-effort (#2149). Exactly one CONDITION is ruled fatal — the session's
+    /// instructions could not be established — and this is the single place that
+    /// decides it, so a future variant does not silently inherit either policy.
+    /// What: `true` only for [`Self::Instructions`], whichever of the two
+    /// instruction sites raised it.
+    /// Test: `instruction_failure_is_fatal`,
     /// `deploy_and_io_failures_stay_non_fatal`.
     pub fn is_fatal(&self) -> bool {
-        matches!(self, Self::CompiledPrompt { .. })
+        matches!(self, Self::Instructions { .. })
     }
 }
 
@@ -385,41 +400,46 @@ impl PrepError {
 /// matches the live launch prompt byte-for-byte (issue #1409), and returns a
 /// [`PrepReport`].
 ///
-/// ORDERING CONTRACT (#4752, owner ruling 2026-08-04): the same prompt is ALSO
-/// written to `<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
-/// ([`crate::core::instruction_pipeline::compiled_prompt_path`]) as this
-/// function's LAST step, and a failure returns [`PrepError::CompiledPrompt`],
-/// which every spawning caller treats as FATAL — the launch is refused.
+/// ORDERING CONTRACT (#4752, owner ruling 2026-08-04): **a session that starts
+/// always has its instructions on disk, matching the text it received.** A
+/// session depends on its instructions, so one that cannot get them must not
+/// start.
 ///
-/// This is the ONE preparation failure that blocks a launch. #2149's
-/// non-fatal-preparation design still governs every other variant (a roster or
-/// skill deploy failure is surfaced via [`PrepReport::roster_errors`] and the
-/// session still starts); [`PrepError::is_fatal`] is the discriminator.
+/// Two steps establish them, and BOTH are fatal — the same condition reaching
+/// two sites, reported as [`PrepError::Instructions`], which every spawning
+/// caller refuses to launch on:
+///   * [`build_instructions`] composes the merged instructions; and
+///   * the same resolved prompt is written to
+///     `<project_dir>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
+///     ([`crate::core::instruction_pipeline::compiled_prompt_path`]) as this
+///     function's LAST step.
 ///
-/// POSITION: the write is deliberately LAST, so a refusal cannot skip the MCP
-/// injectors or the trust pre-seed — see the inline comment at the call and
-/// `compiled_write_failure_does_not_skip_the_mcp_injectors`.
+/// There is no exception between them: nothing that can fail in between returns
+/// early. The `.trusty-mpm/last-instructions.md` stash is the one write that
+/// still degrades to a warning — it is an inspection copy, and letting it
+/// short-circuit would have skipped the fatal write below it and started a
+/// session whose instructions were never recorded, which is precisely what this
+/// contract forbids.
 ///
-/// WHAT THE CONTRACT DOES **NOT** SAY: it is not "every started session has a
-/// compiled prompt". Making the compiled write fatal while a neighbouring write
-/// under the same `.trusty-mpm/` stayed a short-circuiting non-fatal error would
-/// be incoherent, so the stash write above it now degrades to a warning instead
-/// of returning early — an unwritable `.trusty-mpm/` can no longer skip the
-/// injectors or this write. One early exit remains BEFORE it: a
-/// [`build_instructions`] failure, which returns a non-fatal error, so the
-/// caller still launches and no compiled prompt is refreshed. That is a
-/// different condition (the instruction pipeline itself, not a `.trusty-mpm/`
-/// write) and it predates this issue; it is left to #2149's policy rather than
-/// silently promoted to fatal here.
+/// This is the ONE preparation CONDITION that blocks a launch — one condition,
+/// two sites, not two error classes. #2149's non-fatal-preparation design still
+/// governs every other variant (a roster or skill deploy failure is surfaced via
+/// [`PrepReport::roster_errors`] and the session still starts);
+/// [`PrepError::is_fatal`] is the discriminator.
+///
+/// POSITION: the compiled write is deliberately LAST, so a refusal is not also a
+/// half-provisioned workspace — see the inline comment at the call.
 ///
 /// The resume path never calls this function. Both other entry points carry the
 /// same fatal write: `daemon::managed_routes::lifecycle::resume_managed` (daemon
-/// resume) and `runtime::refresh_compiled_prompt` as called from the bare-`tm`
-/// in-place relaunch in `tm::commands::guided_inplace`. See spec §10.3.
+/// resume) and `instruction_pipeline::refresh_compiled_prompt` as called from
+/// the bare-`tm` in-place relaunch in `tm::commands::guided_inplace`. See spec
+/// §10.3.
 /// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
 /// `prepare_session_stash_reflects_override`,
 /// `prepare_session_writes_the_compiled_prompt_before_returning`,
 /// `prepare_session_fails_when_the_compiled_prompt_cannot_be_written`,
+/// `prepare_session_refuses_when_the_instructions_cannot_be_built`,
 /// `compiled_write_failure_does_not_skip_the_mcp_injectors`.
 pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepReport, PrepError> {
     prepare_session_with_style(fw, project_dir, None)
@@ -846,7 +866,18 @@ fn prepare_session_inner(
         project_dir: project_dir.to_path_buf(),
         claude_md_path: project_dir.join("CLAUDE.md"),
     };
-    let instructions = build_instructions(&input)?;
+    // #4752 (owner ruling, round 4): a session DEPENDS on its instructions, so
+    // failing to build them refuses the launch. This used to return the
+    // non-fatal `PrepError::Instructions(PipelineError)`, which every caller
+    // logged-and-continued past — starting a session whose instructions were
+    // never established, the one case the ordering contract could not promise.
+    // It is the SAME fatal condition as the compiled write below, not a second
+    // error class, so it maps onto the same variant.
+    let instructions = build_instructions(&input).map_err(|e| match e {
+        crate::core::instruction_pipeline::PipelineError::Io { path, source } => {
+            PrepError::Instructions { path, source }
+        }
+    })?;
 
     // Resolve the EFFECTIVE output style, folding the manifest's default in as
     // the lowest precedence below the existing HR-4 sources. Precedence:
@@ -883,14 +914,16 @@ fn prepare_session_inner(
     );
     // #4752: these two writes DEGRADE TO A WARNING; they must never short-circuit
     // this function. An unwritable `.trusty-mpm/` (disk full, bad perms) used to
-    // return `PrepError::Io` HERE — before the MCP injectors below — and because
-    // `Io` is non-fatal every caller then launched the session anyway, with the
-    // injectors skipped. That is the same security shape as the round-1 regression
-    // this issue already fixed for the compiled write, reached by a second route.
-    // The stash is an inspection artifact (`tm session instructions`); losing it
-    // is not worth skipping the MCP trust boundary or the compiled write.
+    // return `PrepError::Io` HERE, and because `Io` is non-fatal every caller
+    // launched the session anyway — having skipped the fatal compiled write
+    // below, so the session ran with instructions that were never recorded. That
+    // is exactly what the ordering contract forbids.
+    //
+    // The stash is an inspection copy (`tm session instructions`), not the text
+    // the session runs on, so losing it is not itself a reason to refuse a
+    // launch. What matters is that it cannot take the fatal write down with it.
     // See the ordering contract on `prepare_session`.
-    // Test: `stash_write_failure_does_not_skip_the_mcp_injectors`.
+    // Test: `stash_write_failure_does_not_skip_the_fatal_instruction_write`.
     let stash_dir = project_dir.join(".trusty-mpm");
     let stash = stash_dir.join("last-instructions.md");
     match std::fs::create_dir_all(&stash_dir)
@@ -1216,19 +1249,13 @@ fn prepare_session_inner(
     // text this session will actually receive (`resolved_prompt`, the same
     // string stashed to `.trusty-mpm/last-instructions.md` above).
     //
-    // POSITION IS LOAD-BEARING, and it is deliberately the LAST step. An earlier
-    // revision of this change put the write immediately after the stash, where
-    // its `?` sat upstream of `write_output_style`, `write_project_hooks`, the
-    // workspace trust pre-seed, and all four MCP injectors — including
-    // `inject_trusty_mpm_mcp`/`inject_trusty_review_mcp`, the content-pinning
-    // defense against the #3918/#3950 MCP name-squatting class. Because every
-    // production caller treats a prep failure as non-fatal (#2149, see this
-    // function's doc comment), a failed compiled write would have SKIPPED those
-    // injectors and let the session launch anyway. Nothing below this line may
-    // depend on the write succeeding — keep it last.
+    // It is deliberately the LAST step, so a refusal is not also a
+    // half-provisioned workspace: everything the session needs is already on
+    // disk by the time this can fail. Nothing below this line may depend on the
+    // write succeeding — keep it last.
     let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project_dir);
     crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &resolved_prompt)
-        .map_err(|source| PrepError::CompiledPrompt {
+        .map_err(|source| PrepError::Instructions {
             path: compiled.clone(),
             source,
         })?;
@@ -1253,11 +1280,13 @@ fn prepare_session_inner(
 /// Build the project-agnostic `--append-system-prompt` text (no overrides).
 ///
 /// Why: every `claude` session launched by trusty-mpm must be a configured PM
-/// instance. trusty-mpm owns its PM instructions: they are assembled from
-/// bundled assets into `~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md`
-/// and passed to `claude --append-system-prompt-file`. This variant is kept for
-/// callers that do not know the project directory (e.g. tests); prefer
-/// [`build_system_prompt_for`] at launch sites so project-level overrides apply.
+/// instance. trusty-mpm owns its PM instructions: they are assembled IN MEMORY
+/// from the compile-time bundled sections and passed to
+/// `claude --append-system-prompt-file`. Nothing is read back from an installed
+/// `INSTRUCTIONS.md` to produce them (#4752 retired that path — see the note
+/// below). This variant is kept for callers that do not know the project
+/// directory (e.g. tests); prefer [`build_system_prompt_for`] at launch sites so
+/// project-level overrides apply.
 /// What: returns [`crate::core::instruction_pipeline::assemble_system_prompt`],
 /// trimmed. `Option` is retained for API compatibility and is always `Some`.
 ///

--- a/crates/trusty-mpm/src/core/session_launch/mod.rs
+++ b/crates/trusty-mpm/src/core/session_launch/mod.rs
@@ -343,16 +343,32 @@ pub enum PrepError {
 /// matches the live launch prompt byte-for-byte (issue #1409), and returns a
 /// [`PrepReport`].
 ///
-/// ORDERING CONTRACT (#4752): the same prompt is ALSO written to
+/// COMPILED PROMPT (#4752): the same prompt is ALSO written to
 /// `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`
-/// ([`crate::core::paths::FrameworkPaths::instructions_compiled`]) before this
-/// function returns, and a failed write aborts the preparation. Every caller
-/// spawns `claude` only after `Ok`, so "prepare returned" is exactly "the
-/// compiled prompt on disk is the prompt this session is about to run with".
+/// ([`crate::core::paths::FrameworkPaths::instructions_compiled`]) as this
+/// function's LAST step, and a failed write returns `Err`.
+///
+/// That `Err` does NOT block any launch, and this doc deliberately does not
+/// claim otherwise. Since #2149 every production caller treats a prep failure
+/// as non-fatal and spawns anyway — `commands/launch.rs::connect`, the
+/// managed-clone block in `commands/launch.rs`, `commands/meta/launch.rs`,
+/// `commands/session/start.rs::start_session_in_place`,
+/// `client/http_client/session_connect.rs`,
+/// `daemon/managed_routes/lifecycle.rs::prepare_inproject_session`, and
+/// `provisioner/workspace.rs` all log and continue. The only caller that
+/// propagates, `core/standalone/load.rs::run_prepare_session`, spawns no
+/// `claude` at all, so the fatality's sole live effect is hard-failing
+/// `tm load <alias>`.
+///
+/// What actually keeps the artifact current at every launch is
+/// `runtime::claude_code::build_prompt_file`, which rewrites it from the exact
+/// bytes it hands to `--append-system-prompt-file` — including on the resume
+/// path, which never calls this function. See #4752 and spec §10.3.
 /// Test: `prepare_session_writes_claude_md_and_stash`, `prepare_session_is_idempotent`,
 /// `prepare_session_stash_reflects_override`,
 /// `prepare_session_writes_the_compiled_prompt_before_returning`,
-/// `prepare_session_fails_when_the_compiled_prompt_cannot_be_written`.
+/// `prepare_session_fails_when_the_compiled_prompt_cannot_be_written`,
+/// `compiled_write_failure_does_not_skip_the_mcp_injectors`.
 pub fn prepare_session(fw: &FrameworkPaths, project_dir: &Path) -> Result<PrepReport, PrepError> {
     prepare_session_with_style(fw, project_dir, None)
 }
@@ -824,25 +840,6 @@ fn prepare_session_inner(
         source,
     })?;
 
-    // #4752: the framework-level compiled prompt must be on disk and CURRENT
-    // before `claude` is spawned — every caller of `prepare_session` starts the
-    // process only after this function returns `Ok`, so a blocking write here IS
-    // the ordering guarantee. Deliberately fatal (`?`), not best-effort: a
-    // launch that proceeds past a failed write would leave the operator reading
-    // a stale prompt while the session runs a different one, which is the exact
-    // class of defect #4752 closes.
-    //
-    // Cost is one `write` of a string already in memory — `resolved_prompt` is
-    // the SAME text just stashed above and about to be passed to
-    // `claude --append-system-prompt-file`. No second composition pass; adding
-    // one here would be the thing to eliminate, not to accept.
-    let compiled = fw.instructions_compiled();
-    crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &resolved_prompt)
-        .map_err(|source| PrepError::Io {
-            path: compiled.clone(),
-            source,
-        })?;
-
     // Resolve the active output style for settings.json using the same
     // EFFECTIVE style computed above (HR-4 sources + the HR-2 manifest default).
     // An unknown id is logged and falls back to the professional default rather
@@ -1150,6 +1147,27 @@ fn prepare_session_inner(
     } else {
         None
     };
+
+    // #4752: refresh the framework-level compiled prompt with the text this
+    // session will actually receive (`resolved_prompt`, the same string stashed
+    // to `.trusty-mpm/last-instructions.md` above).
+    //
+    // POSITION IS LOAD-BEARING, and it is deliberately the LAST step. An earlier
+    // revision of this change put the write immediately after the stash, where
+    // its `?` sat upstream of `write_output_style`, `write_project_hooks`, the
+    // workspace trust pre-seed, and all four MCP injectors — including
+    // `inject_trusty_mpm_mcp`/`inject_trusty_review_mcp`, the content-pinning
+    // defense against the #3918/#3950 MCP name-squatting class. Because every
+    // production caller treats a prep failure as non-fatal (#2149, see this
+    // function's doc comment), a failed compiled write would have SKIPPED those
+    // injectors and let the session launch anyway. Nothing below this line may
+    // depend on the write succeeding — keep it last.
+    let compiled = fw.instructions_compiled();
+    crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &resolved_prompt)
+        .map_err(|source| PrepError::Io {
+            path: compiled.clone(),
+            source,
+        })?;
 
     Ok(PrepReport {
         deploy,

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -465,6 +465,62 @@ fn compiled_write_failure_does_not_skip_the_mcp_injectors() {
 
 #[test]
 #[serial_test::serial]
+fn stash_write_failure_does_not_skip_the_mcp_injectors() {
+    // Why (#4752 round 4, HIGH 3): making the compiled write fatal while the
+    // `last-instructions.md` stash — one directory up in the SAME
+    // `.trusty-mpm/` tree — stayed a short-circuiting non-fatal `PrepError::Io`
+    // was incoherent, and it left the round-1 security regression live by a
+    // second route. An unwritable `.trusty-mpm/` returned FIRST, upstream of
+    // `write_output_style`, `write_project_hooks`, the trust pre-seed and all
+    // four MCP injectors; because `Io` is non-fatal, every caller then launched
+    // the session anyway with the #3918/#3950 content-pinning defense skipped.
+    //
+    // FIXTURE: a directory planted at `.trusty-mpm/last-instructions.md`, so
+    // `create_dir_all` on the parent succeeds and only the stash WRITE fails.
+    // The compiled write below it is untouched and must still succeed, so
+    // preparation reports Ok. This test fails if the stash write is ever
+    // restored to a `?`.
+    let tmp_home = tempdir().unwrap();
+    let _home = EnvVarGuard::set("HOME", tmp_home.path());
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    std::fs::create_dir_all(project.join(".trusty-mpm/last-instructions.md"))
+        .expect("plant a directory where the stash file goes");
+
+    let report = prepare_session(&fw, project)
+        .expect("a failed stash write must NOT refuse the launch (#2149) nor abort preparation");
+
+    // The compiled write still ran and is still the fatal one …
+    assert!(
+        report.compiled_prompt.exists(),
+        "the compiled prompt must still be written when only the stash fails"
+    );
+
+    // … and every security-relevant side effect downstream of the stash ran.
+    let mcp_json = project.join(".mcp.json");
+    assert!(
+        mcp_json.exists(),
+        ".mcp.json must be written even when the stash write fails — the MCP \
+         injectors must not sit downstream of a short-circuiting stash error"
+    );
+    let mcp = std::fs::read_to_string(&mcp_json).expect("read .mcp.json");
+    for server in ["trusty-mpm", "trusty-review"] {
+        assert!(
+            mcp.contains(server),
+            "`{server}` MCP entry missing from .mcp.json — the #3918/#3950 \
+             content-pinning injector was skipped by the stash-write failure"
+        );
+    }
+    assert!(
+        project.join(".claude/settings.json").exists(),
+        "project settings/hooks must still be written"
+    );
+}
+
+#[test]
+#[serial_test::serial]
 fn prepare_session_deploys_project_tier_output_style() {
     // Why (#2125 item 2): the daemon managed-spawn path launches `claude`
     // with `--setting-sources project,local`, excluding the `user` tier the

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -263,6 +263,91 @@ fn prepare_session_writes_claude_md_and_stash() {
     );
 }
 
+// ── #4752: INSTRUCTIONS-COMPILED.md must be current BEFORE the spawn ────────
+
+#[test]
+#[serial_test::serial]
+fn prepare_session_writes_the_compiled_prompt_before_returning() {
+    // Why (#4752, owner ruling 2026-08-04): the framework-level compiled prompt
+    // must reflect the prompt the session is ABOUT TO RUN WITH, not the one the
+    // last `tm install` produced. Every caller spawns `claude` only after
+    // `prepare_session` returns `Ok`, so "current at return" IS "current at
+    // launch".
+    //
+    // FIXTURE NOTE — this is deliberately not an existence check. The compiled
+    // path is PRE-SEEDED with stale sentinel content, so a test that only
+    // asserted "the file exists" would pass against a broken implementation
+    // that never writes at launch. Only an actual launch-time write of the
+    // resolved prompt can turn the assertions below green.
+    // #3965: `#[serial]` + `$HOME` override — see
+    // `prepare_session_writes_claude_md_and_stash` for why.
+    let tmp_home = tempdir().unwrap();
+    let _home = EnvVarGuard::set("HOME", tmp_home.path());
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    const STALE: &str = "STALE-FROM-A-PREVIOUS-INSTALL";
+    let compiled = fw.instructions_compiled();
+    std::fs::create_dir_all(compiled.parent().unwrap()).unwrap();
+    std::fs::write(&compiled, STALE).unwrap();
+
+    let report = prepare_session(&fw, project).expect("prep succeeds");
+
+    assert_eq!(
+        report.compiled_prompt, compiled,
+        "the report must name the compiled path the launch actually wrote"
+    );
+    let on_disk = std::fs::read_to_string(&compiled).expect("compiled prompt must be readable");
+    assert_ne!(
+        on_disk, STALE,
+        "the launch must overwrite a stale compiled prompt, not leave it in place"
+    );
+    // The stash is the byte-exact text handed to
+    // `claude --append-system-prompt-file` (issue #1409). Equality here is what
+    // makes the compiled file "the prompt this session runs with" rather than
+    // merely "some compiled prompt".
+    let launch_prompt = std::fs::read_to_string(&report.stash).expect("stash must be readable");
+    assert_eq!(
+        on_disk, launch_prompt,
+        "the compiled prompt must be byte-identical to the text passed to claude"
+    );
+    assert!(!on_disk.is_empty(), "the compiled prompt must not be empty");
+}
+
+#[test]
+#[serial_test::serial]
+fn prepare_session_fails_when_the_compiled_prompt_cannot_be_written() {
+    // Why (#4752): the ordering requirement is that the write BLOCKS the
+    // launch — not that it happens eventually and not that it is best-effort.
+    // This is the test that distinguishes those: if the write were a
+    // `let _ = …`, a warn-and-continue, or deferred to a background task,
+    // `prepare_session` would return `Ok` here and the assertion below fails.
+    //
+    // FIXTURE: a DIRECTORY is planted at the compiled prompt's exact path.
+    // `create_dir_all(parent)` still succeeds, so the failure is isolated to
+    // the compiled write itself — no other step of the preparation is
+    // sabotaged, which is what keeps this test about the guard it names.
+    let tmp_home = tempdir().unwrap();
+    let _home = EnvVarGuard::set("HOME", tmp_home.path());
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    std::fs::create_dir_all(fw.instructions_compiled()).unwrap();
+
+    let err = prepare_session(&fw, project)
+        .expect_err("a failed compiled-prompt write must abort the launch preparation");
+    match err {
+        PrepError::Io { path, .. } => assert_eq!(
+            path,
+            fw.instructions_compiled(),
+            "the error must name the compiled prompt path"
+        ),
+        other => panic!("expected PrepError::Io for the compiled prompt, got {other:?}"),
+    }
+}
+
 #[test]
 #[serial_test::serial]
 fn prepare_session_deploys_project_tier_output_style() {

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -350,6 +350,58 @@ fn prepare_session_fails_when_the_compiled_prompt_cannot_be_written() {
 
 #[test]
 #[serial_test::serial]
+fn compiled_write_failure_does_not_skip_the_mcp_injectors() {
+    // Why (#4752 review, HIGH 1): an earlier revision put the compiled write —
+    // and its fatal `?` — immediately after the `last-instructions.md` stash,
+    // UPSTREAM of `write_output_style`, `write_project_hooks`, the workspace
+    // trust pre-seed, and all four MCP injectors. Because every production
+    // caller treats a prep failure as non-fatal (#2149) and spawns anyway, a
+    // failed compiled write would have launched a session with NO
+    // `inject_trusty_mpm_mcp` / `inject_trusty_review_mcp` content pinning —
+    // silently removing the #3918/#3950 MCP name-squatting defense.
+    //
+    // FIXTURE: the compiled write is forced to fail (directory planted at its
+    // path) and we assert the security-relevant side effects STILL happened.
+    // This fails if the write is ever moved back above them.
+    let tmp_home = tempdir().unwrap();
+    let _home = EnvVarGuard::set("HOME", tmp_home.path());
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    std::fs::create_dir_all(fw.instructions_compiled()).unwrap();
+
+    // The compiled write fails, so preparation reports Err …
+    prepare_session(&fw, project).expect_err("compiled write is expected to fail here");
+
+    // … but everything a launching caller depends on must already be on disk,
+    // because the failing step is last and nothing below it is skipped.
+    let mcp_json = project.join(".mcp.json");
+    assert!(
+        mcp_json.exists(),
+        ".mcp.json must be written even when the compiled prompt write fails — \
+         the MCP injectors must not sit downstream of it"
+    );
+    let mcp = std::fs::read_to_string(&mcp_json).expect("read .mcp.json");
+    for server in ["trusty-mpm", "trusty-review"] {
+        assert!(
+            mcp.contains(server),
+            "`{server}` MCP entry missing from .mcp.json — the #3918/#3950 \
+             content-pinning injector was skipped by the compiled-write failure"
+        );
+    }
+    assert!(
+        project.join(".claude/output-styles/trusty-mpm.md").exists(),
+        "the output style must still be deployed"
+    );
+    assert!(
+        project.join(".claude/settings.json").exists(),
+        "project settings/hooks must still be written"
+    );
+}
+
+#[test]
+#[serial_test::serial]
 fn prepare_session_deploys_project_tier_output_style() {
     // Why (#2125 item 2): the daemon managed-spawn path launches `claude`
     // with `--setting-sources project,local`, excluding the `user` tier the

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -266,6 +266,40 @@ fn prepare_session_writes_claude_md_and_stash() {
 // ── #4752: INSTRUCTIONS-COMPILED.md must be current BEFORE the spawn ────────
 
 #[test]
+fn compiled_prompt_failure_is_fatal() {
+    // Why (#4752 ruling 2026-08-04): exactly one preparation failure refuses a
+    // launch. `is_fatal` is the single discriminator the seven spawning call
+    // sites consult, so it is pinned directly.
+    let err = PrepError::CompiledPrompt {
+        path: PathBuf::from("/p/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md"),
+        source: std::io::Error::other("boom"),
+    };
+    assert!(err.is_fatal());
+    // The Display must be the operator-facing message, not a bare io error.
+    let shown = err.to_string();
+    assert!(shown.contains("/p/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md"));
+    assert!(shown.contains("was NOT started"));
+}
+
+#[test]
+fn deploy_and_io_failures_stay_non_fatal() {
+    // Why (#4752): #2149 deliberately made preparation non-fatal so a roster or
+    // skill deploy hiccup could not stop a session launching. Only the compiled
+    // write was ruled fatal — a blanket "all prep errors abort" would have
+    // reversed #2149 wholesale. This pins that the other variants did NOT
+    // silently inherit the new policy.
+    assert!(!PrepError::Deploy("agents".into()).is_fatal());
+    assert!(!PrepError::SkillDeploy("skills".into()).is_fatal());
+    assert!(
+        !PrepError::Io {
+            path: PathBuf::from("/p/.trusty-mpm/last-instructions.md"),
+            source: std::io::Error::other("boom"),
+        }
+        .is_fatal()
+    );
+}
+
+#[test]
 #[serial_test::serial]
 fn prepare_session_writes_the_compiled_prompt_before_returning() {
     // Why (#4752, owner ruling 2026-08-04): the framework-level compiled prompt
@@ -288,7 +322,7 @@ fn prepare_session_writes_the_compiled_prompt_before_returning() {
     let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
 
     const STALE: &str = "STALE-FROM-A-PREVIOUS-INSTALL";
-    let compiled = fw.instructions_compiled();
+    let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project);
     std::fs::create_dir_all(compiled.parent().unwrap()).unwrap();
     std::fs::write(&compiled, STALE).unwrap();
 
@@ -334,18 +368,44 @@ fn prepare_session_fails_when_the_compiled_prompt_cannot_be_written() {
     let project = tmp.path();
     let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
 
-    std::fs::create_dir_all(fw.instructions_compiled()).unwrap();
+    std::fs::create_dir_all(crate::core::instruction_pipeline::compiled_prompt_path(
+        project,
+    ))
+    .unwrap();
 
     let err = prepare_session(&fw, project)
         .expect_err("a failed compiled-prompt write must abort the launch preparation");
-    match err {
-        PrepError::Io { path, .. } => assert_eq!(
-            path,
-            fw.instructions_compiled(),
+    // #4752 ruling: this is the ONE fatal preparation error — the seven
+    // spawning call sites refuse to launch on it.
+    assert!(
+        err.is_fatal(),
+        "a compiled-prompt write failure must be classified fatal, got {err:?}"
+    );
+    match &err {
+        PrepError::CompiledPrompt { path, .. } => assert_eq!(
+            *path,
+            crate::core::instruction_pipeline::compiled_prompt_path(project),
             "the error must name the compiled prompt path"
         ),
-        other => panic!("expected PrepError::Io for the compiled prompt, got {other:?}"),
+        other => panic!("expected PrepError::CompiledPrompt, got {other:?}"),
     }
+    // Ruling follow-up 1: the operator must see why, and where.
+    let shown = err.to_string();
+    assert!(
+        shown.contains("was NOT started"),
+        "must tell the operator the session did not start: {shown}"
+    );
+    assert!(
+        shown.contains(&compiled_display(project)),
+        "must name the path: {shown}"
+    );
+}
+
+/// The compiled-prompt path as it appears in an operator-facing message.
+fn compiled_display(project: &std::path::Path) -> String {
+    crate::core::instruction_pipeline::compiled_prompt_path(project)
+        .display()
+        .to_string()
 }
 
 #[test]
@@ -369,7 +429,10 @@ fn compiled_write_failure_does_not_skip_the_mcp_injectors() {
     let project = tmp.path();
     let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
 
-    std::fs::create_dir_all(fw.instructions_compiled()).unwrap();
+    std::fs::create_dir_all(crate::core::instruction_pipeline::compiled_prompt_path(
+        project,
+    ))
+    .unwrap();
 
     // The compiled write fails, so preparation reports Err …
     prepare_session(&fw, project).expect_err("compiled write is expected to fail here");

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -266,11 +266,11 @@ fn prepare_session_writes_claude_md_and_stash() {
 // ── #4752: INSTRUCTIONS-COMPILED.md must be current BEFORE the spawn ────────
 
 #[test]
-fn compiled_prompt_failure_is_fatal() {
+fn instruction_failure_is_fatal() {
     // Why (#4752 ruling 2026-08-04): exactly one preparation failure refuses a
     // launch. `is_fatal` is the single discriminator the seven spawning call
     // sites consult, so it is pinned directly.
-    let err = PrepError::CompiledPrompt {
+    let err = PrepError::Instructions {
         path: PathBuf::from("/p/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md"),
         source: std::io::Error::other("boom"),
     };
@@ -284,10 +284,10 @@ fn compiled_prompt_failure_is_fatal() {
 #[test]
 fn deploy_and_io_failures_stay_non_fatal() {
     // Why (#4752): #2149 deliberately made preparation non-fatal so a roster or
-    // skill deploy hiccup could not stop a session launching. Only the compiled
-    // write was ruled fatal — a blanket "all prep errors abort" would have
-    // reversed #2149 wholesale. This pins that the other variants did NOT
-    // silently inherit the new policy.
+    // skill deploy hiccup could not stop a session launching. Only the
+    // instruction condition is ruled fatal — a blanket "all prep errors abort"
+    // would have reversed #2149 wholesale. This pins that the other variants
+    // did NOT silently inherit the new policy.
     assert!(!PrepError::Deploy("agents".into()).is_fatal());
     assert!(!PrepError::SkillDeploy("skills".into()).is_fatal());
     assert!(
@@ -382,12 +382,12 @@ fn prepare_session_fails_when_the_compiled_prompt_cannot_be_written() {
         "a compiled-prompt write failure must be classified fatal, got {err:?}"
     );
     match &err {
-        PrepError::CompiledPrompt { path, .. } => assert_eq!(
+        PrepError::Instructions { path, .. } => assert_eq!(
             *path,
             crate::core::instruction_pipeline::compiled_prompt_path(project),
             "the error must name the compiled prompt path"
         ),
-        other => panic!("expected PrepError::CompiledPrompt, got {other:?}"),
+        other => panic!("expected PrepError::Instructions, got {other:?}"),
     }
     // Ruling follow-up 1: the operator must see why, and where.
     let shown = err.to_string();
@@ -465,15 +465,64 @@ fn compiled_write_failure_does_not_skip_the_mcp_injectors() {
 
 #[test]
 #[serial_test::serial]
-fn stash_write_failure_does_not_skip_the_mcp_injectors() {
-    // Why (#4752 round 4, HIGH 3): making the compiled write fatal while the
-    // `last-instructions.md` stash — one directory up in the SAME
-    // `.trusty-mpm/` tree — stayed a short-circuiting non-fatal `PrepError::Io`
-    // was incoherent, and it left the round-1 security regression live by a
-    // second route. An unwritable `.trusty-mpm/` returned FIRST, upstream of
-    // `write_output_style`, `write_project_hooks`, the trust pre-seed and all
-    // four MCP injectors; because `Io` is non-fatal, every caller then launched
-    // the session anyway with the #3918/#3950 content-pinning defense skipped.
+fn prepare_session_refuses_when_the_instructions_cannot_be_built() {
+    // Why (#4752, owner ruling round 4): "If writing the instruction fails, we
+    // shouldn't start ... we depend on those instructions." `build_instructions`
+    // used to return the NON-fatal `PrepError::Instructions(PipelineError)`,
+    // which every spawning caller logged and continued past — starting a session
+    // whose instructions were never established. It is now the same fatal
+    // condition as the compiled write, so the launch is refused.
+    //
+    // FIXTURE: a directory planted at `<project>/CLAUDE.md`, so the pipeline's
+    // load-or-create step fails. This is the ONLY early exit upstream of the
+    // compiled write; if it ever returns non-fatally again, the ordering
+    // contract's promise stops being true and this test fails.
+    let tmp_home = tempdir().unwrap();
+    let _home = EnvVarGuard::set("HOME", tmp_home.path());
+    let tmp = tempdir().unwrap();
+    let project = tmp.path();
+    let fw = crate::core::paths::FrameworkPaths::under(tmp_home.path());
+
+    std::fs::create_dir_all(project.join("CLAUDE.md"))
+        .expect("plant a directory where CLAUDE.md goes");
+
+    let err = prepare_session(&fw, project)
+        .expect_err("a session whose instructions cannot be built must NOT start");
+
+    assert!(
+        err.is_fatal(),
+        "an instruction-build failure must be classified fatal, got {err:?}"
+    );
+    match &err {
+        PrepError::Instructions { path, .. } => assert!(
+            path.starts_with(project),
+            "the error must name the offending project path, got {}",
+            path.display()
+        ),
+        other => panic!("expected PrepError::Instructions, got {other:?}"),
+    }
+    // Operator-facing, not a bare io error.
+    let shown = err.to_string();
+    assert!(
+        shown.contains("was NOT started"),
+        "must say the session did not start: {shown}"
+    );
+}
+
+#[test]
+#[serial_test::serial]
+fn stash_write_failure_does_not_skip_the_fatal_instruction_write() {
+    // Why (#4752 round 4): the ordering contract promises that a session which
+    // starts has its instructions on disk. An unwritable `.trusty-mpm/` used to
+    // return a short-circuiting non-fatal `PrepError::Io` from the
+    // `last-instructions.md` stash, which sits ABOVE the fatal compiled write.
+    // Because `Io` is non-fatal, every caller launched the session anyway —
+    // having skipped the write that records its instructions. That is the exact
+    // case the contract forbids.
+    //
+    // The stash is an inspection copy, so losing it is not itself grounds to
+    // refuse a launch; what matters is that it cannot take the fatal write down
+    // with it.
     //
     // FIXTURE: a directory planted at `.trusty-mpm/last-instructions.md`, so
     // `create_dir_all` on the parent succeeds and only the stash WRITE fails.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -1012,8 +1012,9 @@ delete the file. `tm doctor` fails with `legacy_overrides` until it is gone.
 replaced by a named section in the project's `CLAUDE.md`. There is no framework
 floor: a project owns its own `CLAUDE.md`, so a floor would have been the
 appearance of a control rather than a control.
-Missing, empty, or unreadable override files fall back to the bundled defaults
-— they never blank a section.
+A missing, empty, unclosed, or unreadable marker block falls back to the bundled
+default — an override never blanks a section. Spec of record:
+`docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md`.
 
 ## Trusty Tool Priority (Non-Overridable)
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -709,8 +709,9 @@ delete the file. `tm doctor` fails with `legacy_overrides` until it is gone.
 replaced by a named section in the project's `CLAUDE.md`. There is no framework
 floor: a project owns its own `CLAUDE.md`, so a floor would have been the
 appearance of a control rather than a control.
-Missing, empty, or unreadable override files fall back to the bundled defaults
-— they never blank a section.
+A missing, empty, unclosed, or unreadable marker block falls back to the bundled
+default — an override never blanks a section. Spec of record:
+`docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md`.
 
 ## Trusty Tool Priority (Non-Overridable)
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -998,8 +998,9 @@ delete the file. `tm doctor` fails with `legacy_overrides` until it is gone.
 replaced by a named section in the project's `CLAUDE.md`. There is no framework
 floor: a project owns its own `CLAUDE.md`, so a floor would have been the
 appearance of a control rather than a control.
-Missing, empty, or unreadable override files fall back to the bundled defaults
-— they never blank a section.
+A missing, empty, unclosed, or unreadable marker block falls back to the bundled
+default — an override never blanks a section. Spec of record:
+`docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md`.
 
 ## Trusty Tool Priority (Non-Overridable)
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/launch_on_main.rs
@@ -136,7 +136,7 @@ pub(super) async fn spawn_managed_on_main(
 
     let synthetic_repo_url = format!("https://github.com/{owner}/{repo}");
     let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(local_path);
-    prepare_inproject_session(&fw, session_id, local_path, &synthetic_repo_url);
+    prepare_inproject_session(&fw, session_id, local_path, &synthetic_repo_url)?;
 
     emit(ProvisioningStage::CreatingTmuxSession);
     let record = mgr

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -18,6 +18,8 @@
 
 use std::sync::Arc;
 
+pub(super) use super::session_prep::prepare_inproject_session;
+
 use tracing::{info, warn};
 
 use super::deployment_check::ensure_deployment_complete;
@@ -972,7 +974,7 @@ async fn spawn_managed_inproject(
     // must land in `<worktree>/.claude/{agents,skills}` (where Claude Code's
     // project-skill discovery looks), not the real `$HOME/.claude`.
     let fw = crate::core::paths::FrameworkPaths::for_managed_workspace(&worktree);
-    prepare_inproject_session(&fw, session_id, &worktree, &synthetic_repo_url);
+    prepare_inproject_session(&fw, session_id, &worktree, &synthetic_repo_url)?;
 
     // #1919: mirrors `spawn_managed_cloned`'s placement — announce the tmux
     // stage right before the record (and its tmux session name) is created.
@@ -1076,62 +1078,6 @@ async fn spawn_managed_inproject(
 
     emit(ProvisioningStage::Complete);
     Ok(mgr.get(&record.id).await.unwrap_or(record))
-}
-
-/// Run the session-preparation pipeline for an in-project worktree, logging
-/// (never propagating) any failure.
-///
-/// Why (#1913): [`spawn_managed_inproject`] has no clone step to wrap this call
-/// in — unlike `spawn_managed`'s clone branch and `spawn_managed_local`, which
-/// both get preparation "for free" as part of `WorkspaceProvisioner::provision_in`
-/// — so it must invoke [`crate::core::session_launch::prepare_session_with_repo_url`]
-/// directly. Extracted to a named, `fw`-parameterised function (rather than
-/// inlined) so it is unit-testable against a hermetic [`crate::core::paths::FrameworkPaths::under`]
-/// tempdir without touching the operator's real `~/.trusty-mpm`/`~/.claude`.
-/// What: calls `prepare_session_with_repo_url(fw, worktree, Some(repo_url))`.
-/// On success, logs the deployed-agent count AND the deployed-skill count
-/// (`report.skill_deploy.deployed.len()` — #1917; previously only the agent
-/// count was logged, so a skill-deploy no-op was invisible here too). On
-/// failure, logs a `tracing::warn!` and returns — mirroring
-/// `WorkspaceProvisioner::provision_in`'s non-fatal handling of the identical
-/// call, so a prep failure never blocks the session from spawning.
-/// Test: `prepare_inproject_session_writes_statusline` in this module's `tests`
-/// submodule.
-pub(super) fn prepare_inproject_session(
-    fw: &crate::core::paths::FrameworkPaths,
-    session_id: &ManagedSessionId,
-    worktree: &std::path::Path,
-    repo_url: &str,
-) {
-    match crate::core::session_launch::prepare_session_with_repo_url(fw, worktree, Some(repo_url)) {
-        Ok(report) => {
-            info!(
-                id = %session_id,
-                deployed = report.deploy.deployed.len(),
-                skills_deployed = report.skill_deploy.deployed.len(),
-                worktree = %worktree.display(),
-                "spawn_managed (inproject): session prepared"
-            );
-            // Issue #2149: a roster-deploy failure no longer aborts
-            // preparation, so surface it loudly here rather than letting it
-            // hide behind a low `deployed`/`skills_deployed` count.
-            for err in &report.roster_errors {
-                tracing::error!(
-                    id = %session_id,
-                    worktree = %worktree.display(),
-                    "spawn_managed (inproject): roster provisioning gap (session \
-                     still launches with its trusty-mpm identity): {err}"
-                );
-            }
-        }
-        Err(e) => {
-            warn!(
-                id = %session_id,
-                worktree = %worktree.display(),
-                "spawn_managed (inproject): session prep failed (non-fatal): {e}"
-            );
-        }
-    }
 }
 
 /// Spawn a managed session rooted at a local directory, redirecting to a managed
@@ -1553,6 +1499,15 @@ pub async fn resume_managed(
         ensure_deployment_complete(&fw, &workspace, record.repo_url.as_deref(), &record.id)
     {
         warn!(id = %record.id, "resume_managed: deployment incomplete after auto-repair (non-blocking, launch proceeds): {reason}");
+    }
+
+    // #4752: the resume path never runs `prepare_session*`, so the compiled PM
+    // prompt is refreshed here — fatal, exactly as on the start path. See
+    // `session_prep::refresh_compiled_prompt_for_resume`.
+    if let Err(msg) = super::session_prep::refresh_compiled_prompt_for_resume(&workspace) {
+        warn!(id = %record.id, "resume_managed: refusing to resume: {msg}");
+        let _ = mgr.mark_errored(&record.id, &msg).await;
+        return Err(ResumeManagedError::Other(msg));
     }
 
     let tmux_arc = mgr.tmux_driver();

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle_tests.rs
@@ -270,7 +270,8 @@ fn prepare_inproject_session_writes_statusline() {
         &session_id,
         worktree.path(),
         "https://github.com/owner/repo",
-    );
+    )
+    .expect("prep succeeds (#4752: only a compiled-prompt write failure is fatal)");
 
     let settings_path = worktree.path().join(".claude").join("settings.json");
     let content = std::fs::read_to_string(&settings_path).unwrap_or_else(|e| {
@@ -334,7 +335,8 @@ async fn prepare_inproject_session_emits_stage_events_in_order() {
             &session_id,
             worktree.path(),
             "https://github.com/owner/repo",
-        );
+        )
+        .expect("prep succeeds (#4752: only a compiled-prompt write failure is fatal)");
     })
     .await;
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/mod.rs
@@ -45,6 +45,7 @@ mod reactivate;
 pub mod reconcile;
 pub mod rename;
 mod resume_error;
+mod session_prep;
 mod session_summary;
 mod summary;
 pub mod sync_assets;

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
@@ -103,14 +103,9 @@ pub(super) fn prepare_inproject_session(
 pub(super) fn refresh_compiled_prompt_for_resume(
     workspace: &std::path::Path,
 ) -> Result<(), String> {
-    let native = crate::core::output_style::claude_supports_native_output_style();
-    let prompt = crate::core::session_launch::build_system_prompt_for_with_style_and_native(
-        workspace, None, native,
-    );
-    let dest = crate::core::instruction_pipeline::compiled_prompt_path(workspace);
-    crate::core::instruction_pipeline::write_compiled_prompt_to(&dest, &prompt).map_err(|source| {
-        crate::core::instruction_pipeline::compiled_prompt_failure_message(&dest, &source)
-    })
+    // #4752: delegates to the shared entry point so the daemon-resume,
+    // fresh-start, and bare-`tm` in-place relaunch paths cannot drift apart.
+    crate::core::instruction_pipeline::refresh_compiled_prompt(workspace)
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
@@ -1,0 +1,118 @@
+//! In-project session preparation and the resume-path compiled-prompt refresh.
+//!
+//! Why: split out of `lifecycle.rs` (#4752), which sits at its frozen SLOC
+//! budget. Both items here answer one question — "what must be on disk before
+//! this session's process starts?" — so they belong together rather than
+//! padding the lifecycle state machine.
+//! What: [`prepare_inproject_session`] (the #1913 preparation call the
+//! in-project spawn paths make directly) and
+//! [`refresh_compiled_prompt_for_resume`] (the #4752 fatal compiled-prompt
+//! write the resume path needs because it never runs `prepare_session*`).
+//! Test: `prepare_inproject_session_writes_statusline`,
+//! `prepare_inproject_session_emits_stage_events_in_order`,
+//! `refresh_compiled_prompt_for_resume_writes_the_project_local_file`,
+//! `refresh_compiled_prompt_for_resume_reports_an_actionable_failure`.
+
+use tracing::{info, warn};
+
+use crate::session_manager::ManagedSessionId;
+
+/// Run the session-preparation pipeline for an in-project worktree, logging
+/// (never propagating) any failure.
+///
+/// Why (#1913): [`spawn_managed_inproject`] has no clone step to wrap this call
+/// in — unlike `spawn_managed`'s clone branch and `spawn_managed_local`, which
+/// both get preparation "for free" as part of `WorkspaceProvisioner::provision_in`
+/// — so it must invoke [`crate::core::session_launch::prepare_session_with_repo_url`]
+/// directly. Extracted to a named, `fw`-parameterised function (rather than
+/// inlined) so it is unit-testable against a hermetic [`crate::core::paths::FrameworkPaths::under`]
+/// tempdir without touching the operator's real `~/.trusty-mpm`/`~/.claude`.
+/// What: calls `prepare_session_with_repo_url(fw, worktree, Some(repo_url))`.
+/// On success, logs the deployed-agent count AND the deployed-skill count
+/// (`report.skill_deploy.deployed.len()` — #1917; previously only the agent
+/// count was logged, so a skill-deploy no-op was invisible here too). On
+/// failure, logs a `tracing::warn!` and returns — mirroring
+/// `WorkspaceProvisioner::provision_in`'s non-fatal handling of the identical
+/// call, so a prep failure never blocks the session from spawning.
+/// Test: `prepare_inproject_session_writes_statusline` in this module's `tests`
+/// submodule.
+pub(super) fn prepare_inproject_session(
+    fw: &crate::core::paths::FrameworkPaths,
+    session_id: &ManagedSessionId,
+    worktree: &std::path::Path,
+    repo_url: &str,
+) -> Result<(), String> {
+    match crate::core::session_launch::prepare_session_with_repo_url(fw, worktree, Some(repo_url)) {
+        Ok(report) => {
+            info!(
+                id = %session_id,
+                deployed = report.deploy.deployed.len(),
+                skills_deployed = report.skill_deploy.deployed.len(),
+                worktree = %worktree.display(),
+                "spawn_managed (inproject): session prepared"
+            );
+            // Issue #2149: a roster-deploy failure no longer aborts
+            // preparation, so surface it loudly here rather than letting it
+            // hide behind a low `deployed`/`skills_deployed` count.
+            for err in &report.roster_errors {
+                tracing::error!(
+                    id = %session_id,
+                    worktree = %worktree.display(),
+                    "spawn_managed (inproject): roster provisioning gap (session \
+                     still launches with its trusty-mpm identity): {err}"
+                );
+            }
+        }
+        // #4752: a compiled-prompt write failure refuses the spawn — the caller
+        // propagates this string. Every other prep failure stays non-fatal
+        // (#2149) and only warns.
+        Err(e) if e.is_fatal() => {
+            warn!(
+                id = %session_id,
+                worktree = %worktree.display(),
+                "spawn_managed (inproject): refusing to spawn: {e}"
+            );
+            return Err(e.to_string());
+        }
+        Err(e) => {
+            warn!(
+                id = %session_id,
+                worktree = %worktree.display(),
+                "spawn_managed (inproject): session prep failed (non-fatal): {e}"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// Refresh the project's compiled PM prompt on the RESUME path.
+///
+/// Why (#4752): `resume_managed` never calls `prepare_session*` on its healthy
+/// path (`resume_self_heal` → `ensure_status_line` → `ensure_deployment_complete`
+/// → `spawn_resume`), so without this a resumed session would run against
+/// whatever the last start wrote — or nothing at all. Composing through the
+/// SAME seam the spawn uses means the bytes written here are the bytes
+/// `spawn_resume` is about to pass to `--append-system-prompt-file`.
+/// What: composes the project-resolved prompt, writes it to
+/// [`crate::core::instruction_pipeline::compiled_prompt_path`], and on failure
+/// returns the operator-facing message from
+/// [`crate::core::instruction_pipeline::compiled_prompt_failure_message`] —
+/// the caller refuses the resume with it.
+/// Test: `refresh_compiled_prompt_for_resume_writes_the_project_local_file`,
+/// `refresh_compiled_prompt_for_resume_reports_an_actionable_failure`.
+pub(super) fn refresh_compiled_prompt_for_resume(
+    workspace: &std::path::Path,
+) -> Result<(), String> {
+    let native = crate::core::output_style::claude_supports_native_output_style();
+    let prompt = crate::core::session_launch::build_system_prompt_for_with_style_and_native(
+        workspace, None, native,
+    );
+    let dest = crate::core::instruction_pipeline::compiled_prompt_path(workspace);
+    crate::core::instruction_pipeline::write_compiled_prompt_to(&dest, &prompt).map_err(|source| {
+        crate::core::instruction_pipeline::compiled_prompt_failure_message(&dest, &source)
+    })
+}
+
+#[cfg(test)]
+#[path = "session_prep_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_prep.rs
@@ -96,7 +96,7 @@ pub(super) fn prepare_inproject_session(
 /// What: composes the project-resolved prompt, writes it to
 /// [`crate::core::instruction_pipeline::compiled_prompt_path`], and on failure
 /// returns the operator-facing message from
-/// [`crate::core::instruction_pipeline::compiled_prompt_failure_message`] —
+/// [`crate::core::instruction_pipeline::instructions_failure_message`] —
 /// the caller refuses the resume with it.
 /// Test: `refresh_compiled_prompt_for_resume_writes_the_project_local_file`,
 /// `refresh_compiled_prompt_for_resume_reports_an_actionable_failure`.

--- a/crates/trusty-mpm/src/daemon/managed_routes/session_prep_tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/session_prep_tests.rs
@@ -1,0 +1,59 @@
+//! Tests for [`super::refresh_compiled_prompt_for_resume`] (#4752).
+//!
+//! Why: the resume path never runs `prepare_session*`, so this helper is the
+//! ONLY thing standing between a resumed session and a stale (or absent)
+//! compiled prompt. It is also fatal, so its failure message is operator-facing
+//! and must be assertable.
+//! What: covers the success write and the actionable-failure message.
+//! Test: this file IS the test suite.
+
+use super::*;
+
+#[test]
+fn refresh_compiled_prompt_for_resume_writes_the_project_local_file() {
+    // Why (#4752 review, HIGH 3): before this helper existed, resume ran a
+    // prompt that never reached the compiled path. FIXTURE: pre-seed a stale
+    // sentinel so "the file exists" cannot pass — only a real refresh can.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = crate::core::instruction_pipeline::compiled_prompt_path(tmp.path());
+    std::fs::create_dir_all(dest.parent().unwrap()).expect("create parent");
+    const STALE: &str = "STALE-FROM-A-PREVIOUS-START";
+    std::fs::write(&dest, STALE).expect("seed stale");
+
+    refresh_compiled_prompt_for_resume(tmp.path()).expect("refresh succeeds");
+
+    let on_disk = std::fs::read_to_string(&dest).expect("readable");
+    assert_ne!(
+        on_disk, STALE,
+        "resume must overwrite a stale compiled prompt"
+    );
+    assert!(
+        on_disk.contains("# PM Agent -- Trusty MPM"),
+        "must hold the resolved PM prompt, not a fragment: {on_disk}"
+    );
+    // Project-local, never global.
+    assert!(dest.starts_with(tmp.path()));
+}
+
+#[test]
+fn refresh_compiled_prompt_for_resume_reports_an_actionable_failure() {
+    // Why (#4752 ruling follow-up 1): the write is fatal, so a refused resume
+    // must name the path and say the session did not start — not surface a bare
+    // io error. FIXTURE: a directory planted at the exact path so only this
+    // write fails.
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let dest = crate::core::instruction_pipeline::compiled_prompt_path(tmp.path());
+    std::fs::create_dir_all(&dest).expect("plant a directory at the compiled path");
+
+    let msg = refresh_compiled_prompt_for_resume(tmp.path())
+        .expect_err("a failed compiled write must refuse the resume");
+    assert!(
+        msg.contains(&dest.display().to_string()),
+        "must name the path: {msg}"
+    );
+    assert!(
+        msg.contains("was NOT started"),
+        "must say it did not start: {msg}"
+    );
+    assert!(msg.contains("permissions"), "must point at a remedy: {msg}");
+}

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -935,6 +935,13 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
                     );
                 }
             }
+            // #4752: a compiled-prompt write failure fails the provision — a
+            // workspace whose session cannot record its own instructions is not
+            // successfully provisioned. Other prep failures stay best-effort
+            // (#2149).
+            Err(e) if e.is_fatal() => {
+                return Err(ProvisionError::PrepareSession(e.to_string()));
+            }
             Err(e) => {
                 tracing::warn!(
                     session = %session_id,

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -345,7 +345,19 @@ fn spawn_command(
 /// "trusty-mpm must never modify the target project's CLAUDE.md" a hard
 /// constraint, so a write failure here means the session runs without the
 /// injected PM system prompt rather than falling back to a different carrier.
-/// Test: `build_prompt_file_writes_resolved_prompt_for_project`.
+///
+/// #4752: this is also where the framework-level compiled prompt
+/// (`INSTRUCTIONS-COMPILED.md`) is refreshed. This function is the ONE seam all
+/// three spawn paths share — `spawn`, the isolated-spawn variant, and
+/// `spawn_resume` — and it materializes the exact bytes handed to
+/// `--append-system-prompt-file`. `resume_managed` never calls
+/// `prepare_session*` on its healthy path, so writing the compiled file here is
+/// what covers resume, guided-resume and crash-recovery launches; writing it
+/// from `prompt` (rather than recomposing) is what makes the on-disk artifact
+/// the SAME text as the running session's prompt by construction.
+/// Test: `build_prompt_file_writes_resolved_prompt_for_project`,
+/// `build_prompt_file_refreshes_the_compiled_prompt`,
+/// `build_prompt_file_compiled_write_failure_does_not_block_the_spawn`.
 fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
     let native = crate::core::output_style::claude_supports_native_output_style();
     let prompt = crate::core::session_launch::build_system_prompt_for_with_style_and_native(
@@ -353,6 +365,27 @@ fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
         None,
         native,
     );
+
+    // #4752: refresh `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` from the
+    // very string about to be passed to `--append-system-prompt-file`.
+    //
+    // Best-effort ON PURPOSE, matching this function's existing contract: the
+    // spawn must not be blocked by an inspection-artifact write. Making it fatal
+    // here would trade a stale debugging aid for a session that fails to launch
+    // — the same inverted priority that put an earlier revision's `?` upstream
+    // of the MCP injectors in `prepare_session_inner`.
+    let compiled = crate::core::paths::FrameworkPaths::default().instructions_compiled();
+    if let Err(err) =
+        crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &prompt)
+    {
+        tracing::warn!(
+            project = %project_dir.display(),
+            path = %compiled.display(),
+            "failed to refresh the compiled PM prompt (non-fatal; the session still \
+             launches with the prompt file below): {err}"
+        );
+    }
+
     let file = crate::core::model_inject::write_prompt_file(&prompt);
     if file.is_none() {
         tracing::warn!(

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -350,14 +350,24 @@ fn spawn_command(
 /// (`<project>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`) is refreshed
 /// from the exact bytes handed to `--append-system-prompt-file`.
 ///
-/// WHY THIS ONE IS BEST-EFFORT while the same write is FATAL in
-/// `prepare_session_inner` and `resume_managed` — the asymmetry is deliberate:
-/// those two are PROVISIONING steps, whose job is to establish the session's
-/// on-disk state before anything spawns; refusing there is coherent and is what
-/// the owner ruled. This call sits INSIDE the spawn, past that gate, and every
-/// path that reaches it has already had a fatal compiled write succeed
-/// (start → `prepare_session_inner`; resume → `resume_managed`). So it is a
-/// belt-and-braces refresh, never the sole guarantee.
+/// WHY THIS ONE IS BEST-EFFORT while the same write is FATAL in the
+/// provisioning paths — the asymmetry is deliberate: those are PROVISIONING
+/// steps, whose job is to establish the session's on-disk state before anything
+/// spawns; refusing there is coherent and is what the owner ruled. This call
+/// sits INSIDE the spawn, past that gate.
+///
+/// That holds only because ALL THREE entry points that reach this function have
+/// already had a fatal compiled write succeed:
+///   * fresh start → `session_launch::prepare_session_inner`
+///   * daemon resume → `managed_routes::lifecycle::resume_managed`
+///   * bare-`tm` in-place relaunch → `guided_inplace::run_inplace_relaunch`,
+///     via `instruction_pipeline::refresh_compiled_prompt`
+///
+/// The third was missing until round 4 of #4752, which made the earlier version
+/// of this comment false: `run_inplace_relaunch` calls neither of the other two,
+/// so this best-effort write was its ONLY compiled write. Adding a call here
+/// without that fatal upstream write would resurrect the same hole — check the
+/// list above before adding a fourth spawn path.
 ///
 /// Making it fatal here would also invert this function's own priority: a
 /// failure of the strictly MORE important write below (the actual system-prompt

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -346,15 +346,24 @@ fn spawn_command(
 /// constraint, so a write failure here means the session runs without the
 /// injected PM system prompt rather than falling back to a different carrier.
 ///
-/// #4752: this is also where the framework-level compiled prompt
-/// (`INSTRUCTIONS-COMPILED.md`) is refreshed. This function is the ONE seam all
-/// three spawn paths share — `spawn`, the isolated-spawn variant, and
-/// `spawn_resume` — and it materializes the exact bytes handed to
-/// `--append-system-prompt-file`. `resume_managed` never calls
-/// `prepare_session*` on its healthy path, so writing the compiled file here is
-/// what covers resume, guided-resume and crash-recovery launches; writing it
-/// from `prompt` (rather than recomposing) is what makes the on-disk artifact
-/// the SAME text as the running session's prompt by construction.
+/// #4752: this is also where the project's compiled prompt
+/// (`<project>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`) is refreshed
+/// from the exact bytes handed to `--append-system-prompt-file`.
+///
+/// WHY THIS ONE IS BEST-EFFORT while the same write is FATAL in
+/// `prepare_session_inner` and `resume_managed` — the asymmetry is deliberate:
+/// those two are PROVISIONING steps, whose job is to establish the session's
+/// on-disk state before anything spawns; refusing there is coherent and is what
+/// the owner ruled. This call sits INSIDE the spawn, past that gate, and every
+/// path that reaches it has already had a fatal compiled write succeed
+/// (start → `prepare_session_inner`; resume → `resume_managed`). So it is a
+/// belt-and-braces refresh, never the sole guarantee.
+///
+/// Making it fatal here would also invert this function's own priority: a
+/// failure of the strictly MORE important write below (the actual system-prompt
+/// file) already degrades to spawning without it (#2173). Refusing to launch
+/// over the inspection copy while shrugging at the real prompt would be exactly
+/// backwards.
 /// Test: `build_prompt_file_writes_resolved_prompt_for_project`,
 /// `build_prompt_file_refreshes_the_compiled_prompt`,
 /// `build_prompt_file_compiled_write_failure_does_not_block_the_spawn`.
@@ -366,15 +375,11 @@ fn build_prompt_file(project_dir: &Path) -> Option<std::path::PathBuf> {
         native,
     );
 
-    // #4752: refresh `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` from the
-    // very string about to be passed to `--append-system-prompt-file`.
-    //
-    // Best-effort ON PURPOSE, matching this function's existing contract: the
-    // spawn must not be blocked by an inspection-artifact write. Making it fatal
-    // here would trade a stale debugging aid for a session that fails to launch
-    // — the same inverted priority that put an earlier revision's `?` upstream
-    // of the MCP injectors in `prepare_session_inner`.
-    let compiled = crate::core::paths::FrameworkPaths::default().instructions_compiled();
+    // #4752: refresh this PROJECT's compiled prompt from the very string about
+    // to be passed to `--append-system-prompt-file`. Best-effort by design —
+    // see this function's doc comment for why the same write is fatal in the
+    // two provisioning steps and not here.
+    let compiled = crate::core::instruction_pipeline::compiled_prompt_path(project_dir);
     if let Err(err) =
         crate::core::instruction_pipeline::write_compiled_prompt_to(&compiled, &prompt)
     {

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -915,12 +915,12 @@ fn build_prompt_file_refreshes_the_compiled_prompt() {
     // can. Equality with the prompt file is what makes the artifact the same
     // text the session runs with.
     let _home = HomeGuard::set();
-    let compiled = crate::core::paths::FrameworkPaths::default().instructions_compiled();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let compiled = crate::core::instruction_pipeline::compiled_prompt_path(tmp.path());
     std::fs::create_dir_all(compiled.parent().unwrap()).expect("create framework dir");
     const STALE: &str = "STALE-FROM-A-PREVIOUS-LAUNCH";
     std::fs::write(&compiled, STALE).expect("seed stale compiled prompt");
 
-    let tmp = tempfile::tempdir().expect("tempdir");
     let path = build_prompt_file(tmp.path()).expect("prompt file written");
 
     let on_disk = std::fs::read_to_string(&compiled).expect("compiled prompt readable");
@@ -951,10 +951,10 @@ fn build_prompt_file_compiled_write_failure_does_not_block_the_spawn() {
     // fails; the prompt file itself must still be produced and still carry the
     // real PM prompt.
     let _home = HomeGuard::set();
-    let compiled = crate::core::paths::FrameworkPaths::default().instructions_compiled();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let compiled = crate::core::instruction_pipeline::compiled_prompt_path(tmp.path());
     std::fs::create_dir_all(&compiled).expect("plant a directory at the compiled path");
 
-    let tmp = tempfile::tempdir().expect("tempdir");
     let path =
         build_prompt_file(tmp.path()).expect("spawn must still get its prompt file (non-fatal)");
     let content = std::fs::read_to_string(&path).expect("prompt file readable");

--- a/crates/trusty-mpm/src/runtime/claude_code_tests.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code_tests.rs
@@ -878,18 +878,89 @@ fn spawn_command_without_prompt_file_omits_flag() {
 }
 
 #[test]
+#[serial_test::serial]
 fn build_prompt_file_writes_resolved_prompt_for_project() {
     // #2125 item 3: build_prompt_file must reuse the SAME
     // build_system_prompt_for_with_style_and_native seam the CLI/client
     // launch paths use, so the daemon adapter's injected prompt is never a
     // divergent copy — proven here by asserting the written file carries
     // the bundled PM_INSTRUCTIONS heading.
+    //
+    // #4752 added a compiled-prompt refresh resolved from `$HOME`, so this test
+    // now needs the HomeGuard + `#[serial]` pairing to keep that write off the
+    // developer's real `~/.trusty-mpm` (the #2459/#2460/#2461 hazard class).
+    let _home = HomeGuard::set();
     let tmp = tempfile::tempdir().expect("tempdir");
     let path = build_prompt_file(tmp.path()).expect("prompt file written");
     let content = std::fs::read_to_string(&path).expect("prompt file readable");
     assert!(
         content.contains("# PM Agent -- Trusty MPM"),
         "prompt file must contain the resolved PM system prompt: {content}"
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn build_prompt_file_refreshes_the_compiled_prompt() {
+    // Why (#4752 review, HIGH 3): `resume_managed` never calls `prepare_session*`
+    // on its healthy path — it goes `resume_self_heal` → `ensure_status_line` →
+    // `ensure_deployment_complete` → `spawn_resume`, and `spawn_resume` builds
+    // its prompt here. Before this fix, every resume, guided-resume and
+    // crash-recovery launch ran a prompt that never reached the compiled path.
+    //
+    // This is the seam ALL THREE spawn paths share, so covering it covers
+    // resume. FIXTURE: the compiled file is pre-seeded with stale sentinel
+    // content, so "the file exists" cannot pass this — only an actual refresh
+    // can. Equality with the prompt file is what makes the artifact the same
+    // text the session runs with.
+    let _home = HomeGuard::set();
+    let compiled = crate::core::paths::FrameworkPaths::default().instructions_compiled();
+    std::fs::create_dir_all(compiled.parent().unwrap()).expect("create framework dir");
+    const STALE: &str = "STALE-FROM-A-PREVIOUS-LAUNCH";
+    std::fs::write(&compiled, STALE).expect("seed stale compiled prompt");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path = build_prompt_file(tmp.path()).expect("prompt file written");
+
+    let on_disk = std::fs::read_to_string(&compiled).expect("compiled prompt readable");
+    assert_ne!(
+        on_disk, STALE,
+        "the spawn seam must refresh a stale compiled prompt — resume paths \
+         depend on this, since they never run prepare_session"
+    );
+    let launch_prompt = std::fs::read_to_string(&path).expect("prompt file readable");
+    assert_eq!(
+        on_disk, launch_prompt,
+        "the compiled prompt must be byte-identical to the file passed to \
+         --append-system-prompt-file"
+    );
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+#[serial_test::serial]
+fn build_prompt_file_compiled_write_failure_does_not_block_the_spawn() {
+    // Why (#4752 review, HIGH 1's lesson applied here): the compiled file is an
+    // INSPECTION artifact. A failure writing it must never cost the session its
+    // actual system prompt — that would trade a stale debugging aid for a
+    // broken launch, the same inverted priority the review flagged in
+    // `prepare_session_inner`.
+    //
+    // FIXTURE: a directory is planted at the compiled path so only that write
+    // fails; the prompt file itself must still be produced and still carry the
+    // real PM prompt.
+    let _home = HomeGuard::set();
+    let compiled = crate::core::paths::FrameworkPaths::default().instructions_compiled();
+    std::fs::create_dir_all(&compiled).expect("plant a directory at the compiled path");
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let path =
+        build_prompt_file(tmp.path()).expect("spawn must still get its prompt file (non-fatal)");
+    let content = std::fs::read_to_string(&path).expect("prompt file readable");
+    assert!(
+        content.contains("# PM Agent -- Trusty MPM"),
+        "the session must still receive the real PM prompt: {content}"
     );
     std::fs::remove_file(&path).ok();
 }

--- a/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
+++ b/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
@@ -1168,29 +1168,63 @@ problem is that two roles share one name.
   can refresh it, yet `build_instructions` would keep reading it. `tm install`
   removes it (`remove_stale_bundled_instructions`).
 
-### 10.3 Ordering: current before launch, and blocking
+### 10.3 Ordering: what is actually guaranteed
 
 **Ruling (2026-08-04):** `INSTRUCTIONS-COMPILED.md` must be fully written and
 current **before** Claude Code launches — not concurrently, not best-effort, not
 eventually consistent with the next `tm install`.
 
-Before this change, the compiled artifact was written at **install time only**
-(`commands/install.rs::install`). The launch path never refreshed it, so it went
-stale the moment a project's `CLAUDE.md` overrides changed.
+Before this change the artifact was written at **install time only**
+(`commands/install.rs::install`), so it went stale the moment a project's
+`CLAUDE.md` overrides changed.
 
-After: `session_launch::prepare_session_inner` writes the prompt to
-`fw.instructions_compiled()` immediately after stashing
-`.trusty-mpm/last-instructions.md` and before returning. The write is **fatal**,
-not best-effort — a failure aborts the preparation with `PrepError::Io`. Every
-caller spawns `claude` only after `prepare_session` returns `Ok`, so "prepare
-returned" **is** "the compiled prompt on disk is the prompt this session will
-run with".
+**What the code now does, stated precisely** (an earlier revision of this
+section claimed a guarantee the code does not make; that claim is retracted):
 
-**Cost.** The launch write reuses the `resolved_prompt` string the composer has
-already built for `--append-system-prompt-file` — the same text just written to
-the project stash. It is one additional `fs::write`, with **no second
-composition pass**. If a future change introduces one, eliminate the extra
-composition; do not relax the ordering.
+1. `session_launch::prepare_session_inner` writes the prompt to
+   `fw.instructions_compiled()` as its **last** step and returns `Err` on
+   failure.
+2. `runtime::claude_code::build_prompt_file` writes it again, from the exact
+   bytes it hands to `--append-system-prompt-file`, immediately before the spawn
+   command is built.
+
+**(2) is what actually makes the guarantee hold**, for two reasons. First,
+`prepare_session`'s `Err` does **not** block any launch: since #2149 every
+production caller treats a prep failure as non-fatal and spawns anyway —
+`commands/launch.rs::connect`, the managed-clone block in `commands/launch.rs`,
+`commands/meta/launch.rs`,
+`commands/session/start.rs::start_session_in_place`,
+`client/http_client/session_connect.rs`,
+`daemon/managed_routes/lifecycle.rs::prepare_inproject_session`, and
+`provisioner/workspace.rs`. The only caller that propagates,
+`core/standalone/load.rs::run_prepare_session`, spawns no `claude` at all, so
+the fatality's sole live effect is hard-failing `tm load <alias>`. Second,
+`resume_managed` never calls `prepare_session*` on its healthy path
+(`resume_self_heal` → `ensure_status_line` → `ensure_deployment_complete` →
+`spawn_resume`), so resume, guided-resume and crash-recovery launches are
+reached only by (2).
+
+Because (2) writes from the same string it passes to the spawn, the artifact is
+current **by construction** rather than by policy. The compiled write there is
+deliberately **best-effort**: it is an inspection artifact, and a failure must
+not cost the session its actual system prompt.
+
+**Position of (1) is load-bearing and must stay last.** An earlier revision
+placed it immediately after the `last-instructions.md` stash, where its `?` sat
+upstream of `write_output_style`, `write_project_hooks`, the workspace trust
+pre-seed, and all four MCP injectors — including `inject_trusty_mpm_mcp` /
+`inject_trusty_review_mcp`, the content-pinning defense against the
+#3918/#3950 MCP name-squatting class. Combined with the non-fatal callers above,
+a failed compiled write would have skipped those injectors **and still
+launched** — a security regression introduced by the fix itself. Pinned by
+`compiled_write_failure_does_not_skip_the_mcp_injectors`.
+
+**Cost.** Both writes reuse an already-composed string; neither adds a
+composition pass. Not benchmarked — no no-regression claim is made.
+
+**Open:** making the spawn genuinely conditional on the write would mean
+reversing #2149's deliberate non-fatal design at seven call sites. Not done
+here; see §10.6.
 
 ### 10.4 Corrections to earlier characterizations of #4752
 
@@ -1228,3 +1262,36 @@ The scaffolding path itself is the `tm-init` skill, which is agent-driven prose
 `<!-- TRUSTY-MPM: <TOKEN> START v=1 -->` marked-block format. Teaching it to
 author marked section-override blocks is unbuilt capability, and where the
 pointer lives is an open owner decision.
+
+### 10.6 Open for owner ruling: launch-blocking, and the global-path collision
+
+Two questions raised by the #4759 review are deliberately **not** answered by
+this change. Both alter a contract the owner should rule on.
+
+**(a) Should a failed compiled write block the spawn?** The owner's requirement
+said the write "blocks" the launch. It does not, and cannot without reversing
+#2149, which made prep failure non-fatal at seven call sites on purpose. Making
+it fatal would mean a transient disk error prevents sessions from launching at
+all — a worse failure than a stale inspection file. §10.3 documents the actual
+guarantee instead: the artifact is current by construction because the spawn
+seam writes it from the string it is passing. Recommendation: accept the
+by-construction guarantee; do not reverse #2149.
+
+**(b) Should the artifact be per-project or per-session?** `INSTRUCTIONS-COMPILED.md`
+is one global file. `FrameworkPaths::for_managed_project` deliberately keeps
+`framework` at the shared managed root (`for_managed_project_keeps_framework_source_at_managed_root`),
+and `for_managed_workspace` resolves it from the real `$HOME`. So `tm install`
+writes the BUNDLED assembly and every launch writes that project's RESOLVED
+prompt to the same path, and concurrent sessions across projects overwrite each
+other. The file answers "the most recent prepare or install on this machine",
+not "what is MY session running" — the question it exists to answer. #383's
+collision was narrowed, not eliminated: the writers now agree on content *kind*
+but still race.
+
+The project-local `.trusty-mpm/last-instructions.md` already answers the
+per-session question correctly and is written on the same paths. Options:
+scope the compiled file per project (e.g. `framework/compiled/<slug>.md`),
+scope it per session, or keep it global and document it explicitly as
+"most recent launch" while pointing at `last-instructions.md` for the
+per-session answer. Recommendation: per-project scoping, since the artifact's
+stated purpose is the per-session question. Not built pending the ruling.

--- a/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
+++ b/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
@@ -1156,75 +1156,88 @@ problem is that two roles share one name.
 
 ### 10.2 The ruling
 
-- The compiled prompt is written to **`~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`**
-  — directly under `framework/`, **not** under `framework/instructions/`, which
-  stays the bundled-input directory. Resolved by
-  `FrameworkPaths::instructions_compiled`; the filename constant is
-  `instruction_pipeline::COMPILED_PROMPT_FILE`.
-- **Nothing else writes that path.** Both writers go through one function,
+- The compiled prompt is written **per project**, to
+  `<project>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` (§10.6(b)).
+  Resolved by `instruction_pipeline::compiled_prompt_path(project_dir)`; the
+  filename constant is `instruction_pipeline::COMPILED_PROMPT_FILE`.
+  `framework/instructions/` stays the bundled-input directory.
+- **Nothing else writes that path.** Every writer goes through one function,
   `write_compiled_prompt_to`, so the file can only ever hold a full compiled
-  prompt — never a stub.
+  prompt — never a stub. `tm install` writes no compiled prompt at all
+  (§10.6(b)).
 - A pre-#4752 `instructions/INSTRUCTIONS.md` is a **stale leftover**: no writer
   can refresh it, yet `build_instructions` would keep reading it. `tm install`
   removes it (`remove_stale_bundled_instructions`).
 
-### 10.3 Ordering: what is actually guaranteed
+### 10.3 Ordering: the write is fatal, and it blocks the spawn
 
-**Ruling (2026-08-04):** `INSTRUCTIONS-COMPILED.md` must be fully written and
-current **before** Claude Code launches — not concurrently, not best-effort, not
-eventually consistent with the next `tm install`.
+**Ruling (2026-08-04, revised after the #4759 review):** the compiled prompt is
+**per project**, at `<project>/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`,
+and a failure to write it **refuses the launch**.
 
-Before this change the artifact was written at **install time only**
-(`commands/install.rs::install`), so it went stale the moment a project's
-`CLAUDE.md` overrides changed.
+Owner's reasoning, verbatim: *"If we can't write a simple file to this
+directory, we have a bigger issue."* That holds because `.trusty-mpm/` is a
+directory `tm` already writes on every launch (it holds `last-instructions.md`
+and `sessions/`), and because the prompt file `--append-system-prompt-file`
+points at is already a mandatory write — a session that cannot write its own
+prompt cannot launch. The compiled file is a second copy alongside a write that
+is fatal by necessity, so a loud, diagnosable refusal beats a session running
+against a silently stale artifact.
 
-**What the code now does, stated precisely** (an earlier revision of this
-section claimed a guarantee the code does not make; that claim is retracted):
+**Where the fatal write happens — both pre-spawn provisioning steps:**
 
-1. `session_launch::prepare_session_inner` writes the prompt to
-   `fw.instructions_compiled()` as its **last** step and returns `Err` on
-   failure.
-2. `runtime::claude_code::build_prompt_file` writes it again, from the exact
-   bytes it hands to `--append-system-prompt-file`, immediately before the spawn
-   command is built.
+| Path | Fatal write | Error |
+|---|---|---|
+| start / connect / in-project / cloned | `session_launch::prepare_session_inner`, as its LAST step | `PrepError::CompiledPrompt` |
+| resume / guided-resume / crash recovery | `daemon::managed_routes::lifecycle::resume_managed`, immediately before `spawn_resume` | `ResumeManagedError::Other` |
 
-**(2) is what actually makes the guarantee hold**, for two reasons. First,
-`prepare_session`'s `Err` does **not** block any launch: since #2149 every
-production caller treats a prep failure as non-fatal and spawns anyway —
-`commands/launch.rs::connect`, the managed-clone block in `commands/launch.rs`,
-`commands/meta/launch.rs`,
+`resume_managed` needs its own write because it never calls `prepare_session*`
+on its healthy path (`resume_self_heal` → `ensure_status_line` →
+`ensure_deployment_complete` → `spawn_resume`).
+
+**Only this one preparation failure is fatal.** #2149 deliberately made
+preparation non-fatal so a roster or skill deploy hiccup could not stop a
+session launching, and that still holds: `PrepError::is_fatal()` returns `true`
+for `CompiledPrompt` and nothing else. All seven spawning call sites consult it
+— `commands/launch.rs::connect`, the managed-clone block in
+`commands/launch.rs`, `commands/meta/launch.rs`,
 `commands/session/start.rs::start_session_in_place`,
 `client/http_client/session_connect.rs`,
-`daemon/managed_routes/lifecycle.rs::prepare_inproject_session`, and
-`provisioner/workspace.rs`. The only caller that propagates,
-`core/standalone/load.rs::run_prepare_session`, spawns no `claude` at all, so
-the fatality's sole live effect is hard-failing `tm load <alias>`. Second,
-`resume_managed` never calls `prepare_session*` on its healthy path
-(`resume_self_heal` → `ensure_status_line` → `ensure_deployment_complete` →
-`spawn_resume`), so resume, guided-resume and crash-recovery launches are
-reached only by (2).
+`daemon/managed_routes/lifecycle.rs::prepare_inproject_session` (now
+`Result`-returning, propagated by both in-project spawns), and
+`provisioner/workspace.rs` (→ `ProvisionError::PrepareSession`). A blanket
+"every prep error aborts" would have reversed #2149 wholesale.
 
-Because (2) writes from the same string it passes to the spawn, the artifact is
-current **by construction** rather than by policy. The compiled write there is
-deliberately **best-effort**: it is an inspection artifact, and a failure must
-not cost the session its actual system prompt.
+**Operator-facing failure.** A refusal never surfaces a bare `io::Error`.
+`instruction_pipeline::compiled_prompt_failure_message` is the single formatter:
+it names the path, carries the cause, states that the session was NOT started,
+and points at permissions/free space. Pinned by
+`compiled_prompt_failure_message_names_the_path_and_a_remedy`.
 
-**Position of (1) is load-bearing and must stay last.** An earlier revision
-placed it immediately after the `last-instructions.md` stash, where its `?` sat
-upstream of `write_output_style`, `write_project_hooks`, the workspace trust
-pre-seed, and all four MCP injectors — including `inject_trusty_mpm_mcp` /
+**Position is load-bearing and must stay last.** An earlier revision placed the
+write immediately after the `last-instructions.md` stash, upstream of
+`write_output_style`, `write_project_hooks`, the workspace trust pre-seed, and
+all four MCP injectors — including `inject_trusty_mpm_mcp` /
 `inject_trusty_review_mcp`, the content-pinning defense against the
-#3918/#3950 MCP name-squatting class. Combined with the non-fatal callers above,
-a failed compiled write would have skipped those injectors **and still
-launched** — a security regression introduced by the fix itself. Pinned by
+#3918/#3950 MCP name-squatting class. That was a security regression: a failed
+write skipped the injectors while the (then non-fatal) callers launched anyway.
+Under a FATAL write the placement matters more, not less — a refusal must not
+also mean provisioning was half-applied. Pinned by
 `compiled_write_failure_does_not_skip_the_mcp_injectors`.
 
-**Cost.** Both writes reuse an already-composed string; neither adds a
-composition pass. Not benchmarked — no no-regression claim is made.
+**One best-effort write remains, deliberately.**
+`runtime::claude_code::build_prompt_file` refreshes the file from the exact
+bytes it hands to `--append-system-prompt-file`. It is NOT fatal, because it
+sits *inside* the spawn, past the provisioning gate — every path reaching it has
+already had a fatal compiled write succeed, so it is a belt-and-braces refresh,
+never the sole guarantee. Making it fatal would also invert that function's own
+priority: a failure of the strictly more important write beside it (the actual
+system-prompt file) already degrades to spawning without it (#2173). Refusing to
+launch over the inspection copy while shrugging at the real prompt would be
+backwards.
 
-**Open:** making the spawn genuinely conditional on the write would mean
-reversing #2149's deliberate non-fatal design at seven call sites. Not done
-here; see §10.6.
+**Cost.** Every write reuses an already-composed string; none adds a composition
+pass. Not benchmarked — no no-regression claim is made.
 
 ### 10.4 Corrections to earlier characterizations of #4752
 
@@ -1263,35 +1276,33 @@ The scaffolding path itself is the `tm-init` skill, which is agent-driven prose
 author marked section-override blocks is unbuilt capability, and where the
 pointer lives is an open owner decision.
 
-### 10.6 Open for owner ruling: launch-blocking, and the global-path collision
+### 10.6 Rulings on the two questions this change raised (2026-08-04)
 
-Two questions raised by the #4759 review are deliberately **not** answered by
-this change. Both alter a contract the owner should rule on.
+Both were referred to the owner during the #4759 review and are now settled.
 
-**(a) Should a failed compiled write block the spawn?** The owner's requirement
-said the write "blocks" the launch. It does not, and cannot without reversing
-#2149, which made prep failure non-fatal at seven call sites on purpose. Making
-it fatal would mean a transient disk error prevents sessions from launching at
-all — a worse failure than a stale inspection file. §10.3 documents the actual
-guarantee instead: the artifact is current by construction because the spawn
-seam writes it from the string it is passing. Recommendation: accept the
-by-construction guarantee; do not reverse #2149.
+**(a) Should a failed compiled write block the spawn? RULED: yes.** The
+implementer's proposal to keep it non-fatal was overruled. That proposal reasoned
+about the OLD global path; under project-local scoping it does not hold — see
+§10.3 for the reasoning and the implementation.
 
-**(b) Should the artifact be per-project or per-session?** `INSTRUCTIONS-COMPILED.md`
-is one global file. `FrameworkPaths::for_managed_project` deliberately keeps
-`framework` at the shared managed root (`for_managed_project_keeps_framework_source_at_managed_root`),
-and `for_managed_workspace` resolves it from the real `$HOME`. So `tm install`
-writes the BUNDLED assembly and every launch writes that project's RESOLVED
-prompt to the same path, and concurrent sessions across projects overwrite each
-other. The file answers "the most recent prepare or install on this machine",
-not "what is MY session running" — the question it exists to answer. #383's
-collision was narrowed, not eliminated: the writers now agree on content *kind*
-but still race.
+**(b) Per-project or per-session? RULED: per project, project-local.** Not
+`framework/compiled/<slug>.md` under the global framework dir, which was the
+implementer's proposal. The file lives inside the project's own `.trusty-mpm/`,
+beside `last-instructions.md` and `sessions/`. That removes the collision **by
+construction** rather than by slug disambiguation: no shared root, no `$HOME`
+special case for managed workspaces, no slugs to collide. Owner: *"it's only
+used on startup, shouldn't be an issue to update it on startup."*
 
-The project-local `.trusty-mpm/last-instructions.md` already answers the
-per-session question correctly and is written on the same paths. Options:
-scope the compiled file per project (e.g. `framework/compiled/<slug>.md`),
-scope it per session, or keep it global and document it explicitly as
-"most recent launch" while pointing at `last-instructions.md` for the
-per-session answer. Recommendation: per-project scoping, since the artifact's
-stated purpose is the per-session question. Not built pending the ruling.
+Two consequences worth recording:
+
+- **The accessor moved off `FrameworkPaths`.** That type models the global
+  framework INSTALL layout; an accessor there would have to choose between the
+  shared managed root and the real `$HOME` — the very ambiguity that caused the
+  collision. The compiled prompt is now resolved by
+  `instruction_pipeline::compiled_prompt_path(project_dir)`.
+- **`tm install` no longer writes a compiled prompt at all.** Install has no
+  project, so it has nothing meaningful to compile; writing the bundled assembly
+  to a shared path was exactly the "wrong content kind on a shared path"
+  collision this issue closes. This eliminates the second writer rather than
+  relocating it. `tm install` still deletes a stale pre-#4752
+  `instructions/INSTRUCTIONS.md`.

--- a/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
+++ b/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
@@ -1188,9 +1188,9 @@ against a silently stale artifact.
 
 | Path | Fatal write | Error |
 |---|---|---|
-| start / connect / in-project / cloned | `session_launch::prepare_session_inner`, as its LAST step | `PrepError::CompiledPrompt` |
+| start / connect / in-project / cloned | `session_launch::prepare_session_inner` — at BOTH `build_instructions` and, as its LAST step, the compiled write | `PrepError::Instructions` |
 | resume / guided-resume / crash recovery | `daemon::managed_routes::lifecycle::resume_managed`, immediately before `spawn_resume` | `ResumeManagedError::Other` |
-| bare `tm` in a managed pane (in-place relaunch) | `tm::commands::guided_inplace::run_inplace_relaunch`, before it builds the resume command | `anyhow::Error` from `compiled_prompt_failure_message` |
+| bare `tm` in a managed pane (in-place relaunch) | `tm::commands::guided_inplace::run_inplace_relaunch`, before it builds the resume command | `anyhow::Error` from `instructions_failure_message` |
 
 `resume_managed` needs its own write because it never calls `prepare_session*`
 on its healthy path (`resume_self_heal` → `ensure_status_line` →
@@ -1202,14 +1202,24 @@ round 4** of this issue: it calls neither `prepare_session*` nor
 no prompt work. Its sole compiled write was therefore
 `build_prompt_file`'s best-effort refresh — so a bare-`tm` relaunch could start
 a session on a stale or missing compiled prompt exactly where a fresh launch
-would have refused. All three now route through the single entry point
+would have refused.
+
+**Two of the three share one helper — not all three.** The two resume-shaped
+paths (daemon resume, in-place relaunch) route through
 `instruction_pipeline::refresh_compiled_prompt`, which composes, writes, and
-formats the failure message, so the three sites cannot drift apart.
+formats the failure message. `prepare_session` deliberately does NOT: it must
+compose with the `effective_style` it has just resolved (flag > config >
+manifest), and `refresh_compiled_prompt` hardcodes the style to `None`, so
+routing preparation through it would silently drop the operator's chosen output
+style from the compiled copy. All three still share the actual write —
+`write_compiled_prompt_to` — and the same fatal policy; only the composed text
+differs. An earlier draft of this section claimed all three routed through the
+helper, which was false.
 
 **Only this one preparation failure is fatal.** #2149 deliberately made
 preparation non-fatal so a roster or skill deploy hiccup could not stop a
 session launching, and that still holds: `PrepError::is_fatal()` returns `true`
-for `CompiledPrompt` and nothing else. All seven spawning call sites consult it
+for `Instructions` and nothing else. All seven spawning call sites consult it
 — `commands/launch.rs::connect`, the managed-clone block in
 `commands/launch.rs`, `commands/meta/launch.rs`,
 `commands/session/start.rs::start_session_in_place`,
@@ -1223,7 +1233,7 @@ for `CompiledPrompt` and nothing else. All seven spawning call sites consult it
 `instruction_pipeline::compiled_prompt_failure_message` is the single formatter:
 it names the path, carries the cause, states that the session was NOT started,
 and points at permissions/free space. Pinned by
-`compiled_prompt_failure_message_names_the_path_and_a_remedy`.
+`instructions_failure_message_names_the_path_and_a_remedy`.
 
 **Position is load-bearing and must stay last.** An earlier revision placed the
 write immediately after the `last-instructions.md` stash, upstream of
@@ -1236,36 +1246,53 @@ Under a FATAL write the placement matters more, not less — a refusal must not
 also mean provisioning was half-applied. Pinned by
 `compiled_write_failure_does_not_skip_the_mcp_injectors`.
 
-**The `.trusty-mpm/` stash write degrades to a warning.** Making the compiled
-write fatal while `last-instructions.md`, one directory up in the same tree,
-stayed a short-circuiting non-fatal `PrepError::Io` was incoherent — and worse,
-it left the round-1 security regression live by a second route: an unwritable
-`.trusty-mpm/` (disk full, bad perms) returned FIRST, upstream of the MCP
-injectors, and because `Io` is non-fatal every caller launched the session
-anyway with the injectors skipped. The stash write now logs and continues, so no
-`.trusty-mpm/` write failure can skip the injectors or the compiled write.
-Pinned by `stash_write_failure_does_not_skip_the_mcp_injectors`.
+**THE CONTRACT: a session that starts always has its instructions on disk.**
+Owner ruling, round 4, verbatim: *"If writing the instruction fails, we
+shouldn't start. But that should be a protected path, we depend on those
+instructions."* Two steps in `prepare_session_inner` establish them and BOTH are
+fatal:
 
-**The contract is not "every started session has a compiled prompt."** One
-early exit remains upstream of the write: a `build_instructions` failure returns
-a non-fatal error, so the caller still launches and no compiled prompt is
-refreshed. That is a different condition — the instruction pipeline itself, not
-a `.trusty-mpm/` write — and it predates this issue. It is left to #2149's
-policy rather than silently promoted to a second fatal error, which would
-contradict the "exactly one fatal preparation failure" ruling above.
+1. `build_instructions` composes the merged instructions. This used to return a
+   NON-fatal error, which every spawning call site logged and continued past —
+   so a session could start with no instructions established at all. Reproduced
+   during round-4 review by planting a directory at `<project>/CLAUDE.md`, which
+   makes `load_or_create_claude_md` fail `IsADirectory` rather than `NotFound`:
+   `is_fatal = false`, no compiled prompt on disk, and the session launched.
+   Pre-existing, not introduced by this issue. Now fatal. Pinned by
+   `prepare_session_refuses_when_the_instructions_cannot_be_built`.
+2. The compiled write, as the function's LAST step.
+
+**One CONDITION, two sites — not two error classes.** Both report
+`PrepError::Instructions`, and `PrepError::is_fatal()` is `true` for that variant
+and nothing else. The "exactly one fatal preparation failure" ruling is about
+there being one fatal *condition*; enforcing it at a second site is the same
+error class reaching another site. The variant was renamed from `CompiledPrompt`
+in round 4 because it no longer describes only the compiled write, and
+`compiled_prompt_failure_message` became `instructions_failure_message` for the
+same reason — its wording would have been wrong at half its call sites.
+
+**The `.trusty-mpm/` stash write is the one write that stays a warning.** It is
+an inspection copy (`tm session instructions`), not the text the session runs
+on, so losing it is not itself grounds to refuse a launch. What it must never do
+is take the fatal write down with it: an unwritable `.trusty-mpm/` used to
+return a short-circuiting non-fatal `PrepError::Io` from the stash, which sits
+ABOVE the compiled write, so every caller launched the session having skipped
+the write that records its instructions — exactly what the contract forbids. It
+now logs and continues. Pinned by
+`stash_write_failure_does_not_skip_the_fatal_instruction_write`.
 
 **One best-effort write remains, deliberately.**
 `runtime::claude_code::build_prompt_file` refreshes the file from the exact
 bytes it hands to `--append-system-prompt-file`. It is NOT fatal, because it
 sits *inside* the spawn, past the provisioning gate — and, now that the in-place
 relaunch carries its own fatal write, every one of the three paths reaching it
-has already had a fatal compiled write succeed, so it is a belt-and-braces
-refresh rather than the sole guarantee. That claim was false until round 4; a
-fourth spawn path must add its own fatal write before relying on it. Making it
-fatal would also invert that function's own priority: a failure of the strictly
-more important write beside it (the actual system-prompt file) already degrades
-to spawning without it (#2173). Refusing to launch over the inspection copy
-while shrugging at the real prompt would be backwards.
+has already had a fatal write succeed, so it is a belt-and-braces refresh rather
+than the sole guarantee. That claim was false until round 4; a fourth spawn path
+must add its own fatal write before relying on it. Making it fatal would also
+invert that function's own priority: a failure of the strictly more important
+write beside it (the actual system-prompt file) already degrades to spawning
+without it (#2173). Refusing to launch over the inspection copy while shrugging
+at the real prompt would be backwards.
 
 **Cost.** Every write reuses an already-composed string; none adds a composition
 pass. Not benchmarked — no no-regression claim is made.

--- a/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
+++ b/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
@@ -1184,16 +1184,27 @@ prompt cannot launch. The compiled file is a second copy alongside a write that
 is fatal by necessity, so a loud, diagnosable refusal beats a session running
 against a silently stale artifact.
 
-**Where the fatal write happens — both pre-spawn provisioning steps:**
+**Where the fatal write happens — all THREE pre-spawn paths:**
 
 | Path | Fatal write | Error |
 |---|---|---|
 | start / connect / in-project / cloned | `session_launch::prepare_session_inner`, as its LAST step | `PrepError::CompiledPrompt` |
 | resume / guided-resume / crash recovery | `daemon::managed_routes::lifecycle::resume_managed`, immediately before `spawn_resume` | `ResumeManagedError::Other` |
+| bare `tm` in a managed pane (in-place relaunch) | `tm::commands::guided_inplace::run_inplace_relaunch`, before it builds the resume command | `anyhow::Error` from `compiled_prompt_failure_message` |
 
 `resume_managed` needs its own write because it never calls `prepare_session*`
 on its healthy path (`resume_self_heal` → `ensure_status_line` →
 `ensure_deployment_complete` → `spawn_resume`).
+
+`run_inplace_relaunch` needs one for the same reason and was **missed until
+round 4** of this issue: it calls neither `prepare_session*` nor
+`resume_managed`, and its only daemon call is the `reactivate` route, which does
+no prompt work. Its sole compiled write was therefore
+`build_prompt_file`'s best-effort refresh — so a bare-`tm` relaunch could start
+a session on a stale or missing compiled prompt exactly where a fresh launch
+would have refused. All three now route through the single entry point
+`instruction_pipeline::refresh_compiled_prompt`, which composes, writes, and
+formats the failure message, so the three sites cannot drift apart.
 
 **Only this one preparation failure is fatal.** #2149 deliberately made
 preparation non-fatal so a roster or skill deploy hiccup could not stop a
@@ -1225,16 +1236,36 @@ Under a FATAL write the placement matters more, not less — a refusal must not
 also mean provisioning was half-applied. Pinned by
 `compiled_write_failure_does_not_skip_the_mcp_injectors`.
 
+**The `.trusty-mpm/` stash write degrades to a warning.** Making the compiled
+write fatal while `last-instructions.md`, one directory up in the same tree,
+stayed a short-circuiting non-fatal `PrepError::Io` was incoherent — and worse,
+it left the round-1 security regression live by a second route: an unwritable
+`.trusty-mpm/` (disk full, bad perms) returned FIRST, upstream of the MCP
+injectors, and because `Io` is non-fatal every caller launched the session
+anyway with the injectors skipped. The stash write now logs and continues, so no
+`.trusty-mpm/` write failure can skip the injectors or the compiled write.
+Pinned by `stash_write_failure_does_not_skip_the_mcp_injectors`.
+
+**The contract is not "every started session has a compiled prompt."** One
+early exit remains upstream of the write: a `build_instructions` failure returns
+a non-fatal error, so the caller still launches and no compiled prompt is
+refreshed. That is a different condition — the instruction pipeline itself, not
+a `.trusty-mpm/` write — and it predates this issue. It is left to #2149's
+policy rather than silently promoted to a second fatal error, which would
+contradict the "exactly one fatal preparation failure" ruling above.
+
 **One best-effort write remains, deliberately.**
 `runtime::claude_code::build_prompt_file` refreshes the file from the exact
 bytes it hands to `--append-system-prompt-file`. It is NOT fatal, because it
-sits *inside* the spawn, past the provisioning gate — every path reaching it has
-already had a fatal compiled write succeed, so it is a belt-and-braces refresh,
-never the sole guarantee. Making it fatal would also invert that function's own
-priority: a failure of the strictly more important write beside it (the actual
-system-prompt file) already degrades to spawning without it (#2173). Refusing to
-launch over the inspection copy while shrugging at the real prompt would be
-backwards.
+sits *inside* the spawn, past the provisioning gate — and, now that the in-place
+relaunch carries its own fatal write, every one of the three paths reaching it
+has already had a fatal compiled write succeed, so it is a belt-and-braces
+refresh rather than the sole guarantee. That claim was false until round 4; a
+fourth spawn path must add its own fatal write before relying on it. Making it
+fatal would also invert that function's own priority: a failure of the strictly
+more important write beside it (the actual system-prompt file) already degrades
+to spawning without it (#2173). Refusing to launch over the inspection copy
+while shrugging at the real prompt would be backwards.
 
 **Cost.** Every write reuses an already-composed string; none adds a composition
 pass. Not benchmarked — no no-regression claim is made.

--- a/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
+++ b/docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md
@@ -1129,3 +1129,102 @@ renaming `base_pm()`, and updating the ~30 test assertions that pin the
 literal string is a **code change**. Per this ruling's own scope note, it
 lands in the #4286 core PR, not this docs-only one. This section records
 the target model and the current gap; it does not perform the rename.
+
+## 10. Owner Ruling (2026-08-04): the Compiled Prompt Owns a Distinct Path, Written Before Launch {#SPEC-PMINSTR-10~draft}
+
+Issue [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752). This
+section supersedes any earlier text in this document that treats
+`~/.trusty-mpm/framework/instructions/INSTRUCTIONS.md` as the home of the
+compiled PM system prompt.
+
+### 10.1 The defect
+
+One path carried three roles at once:
+
+- `instruction_pipeline.rs`'s `install_system_prompt` / `install_system_prompt_to`
+  wrote the **full compiled prompt** to `framework/instructions/INSTRUCTIONS.md`.
+- `bundle_all.rs` used to write a **4-line stub** to that same path. (Already
+  removed by #4286 split A — see §10.4; the `ALL` table and the
+  `FRAMEWORK_INSTRUCTIONS` constant no longer carry the entry.)
+- `build_instructions` **reads** that path as an optional framework section —
+  i.e. the compiled output was simultaneously a pipeline input.
+
+Last writer won, so the artifact an operator inspects to answer "what
+instructions is my session actually running?" was non-deterministic. #383 fixed
+one instance of this by ordering the writes; ordering is not a fix when the real
+problem is that two roles share one name.
+
+### 10.2 The ruling
+
+- The compiled prompt is written to **`~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`**
+  — directly under `framework/`, **not** under `framework/instructions/`, which
+  stays the bundled-input directory. Resolved by
+  `FrameworkPaths::instructions_compiled`; the filename constant is
+  `instruction_pipeline::COMPILED_PROMPT_FILE`.
+- **Nothing else writes that path.** Both writers go through one function,
+  `write_compiled_prompt_to`, so the file can only ever hold a full compiled
+  prompt — never a stub.
+- A pre-#4752 `instructions/INSTRUCTIONS.md` is a **stale leftover**: no writer
+  can refresh it, yet `build_instructions` would keep reading it. `tm install`
+  removes it (`remove_stale_bundled_instructions`).
+
+### 10.3 Ordering: current before launch, and blocking
+
+**Ruling (2026-08-04):** `INSTRUCTIONS-COMPILED.md` must be fully written and
+current **before** Claude Code launches — not concurrently, not best-effort, not
+eventually consistent with the next `tm install`.
+
+Before this change, the compiled artifact was written at **install time only**
+(`commands/install.rs::install`). The launch path never refreshed it, so it went
+stale the moment a project's `CLAUDE.md` overrides changed.
+
+After: `session_launch::prepare_session_inner` writes the prompt to
+`fw.instructions_compiled()` immediately after stashing
+`.trusty-mpm/last-instructions.md` and before returning. The write is **fatal**,
+not best-effort — a failure aborts the preparation with `PrepError::Io`. Every
+caller spawns `claude` only after `prepare_session` returns `Ok`, so "prepare
+returned" **is** "the compiled prompt on disk is the prompt this session will
+run with".
+
+**Cost.** The launch write reuses the `resolved_prompt` string the composer has
+already built for `--append-system-prompt-file` — the same text just written to
+the project stash. It is one additional `fs::write`, with **no second
+composition pass**. If a future change introduces one, eliminate the extra
+composition; do not relax the ordering.
+
+### 10.4 Corrections to earlier characterizations of #4752
+
+Recorded because the issue text and this document previously said otherwise, and
+both were checked directly against the code rather than taken from the report:
+
+- **The `bundle_all.rs` stub was already gone.** #4286 split A removed the
+  `instructions/INSTRUCTIONS.md` entry from `bundle::ALL` and deleted the
+  `FRAMEWORK_INSTRUCTIONS` constant it backed (`bundle_tests.rs`,
+  `bundle_table_is_complete`, pins `ALL.len() == 178`). Finding #1 in
+  `sections/README.md` described a two-writer collision whose first writer no
+  longer existed. The surviving half of the collision — compiled output sharing
+  a path with a pipeline input — is real, and is what §10.2 fixes.
+- **`FrameworkPaths::framework_instructions` / `framework_instructions_path`
+  are NOT dead** and were retained: `session_launch::prepare_session_inner` and
+  `commands/session.rs` both still construct a `PipelineInput` from them.
+
+### 10.5 CLAUDE.md pointer — deferred, not delivered
+
+The ruling that a project's `CLAUDE.md` should point at
+`INSTRUCTIONS-COMPILED.md` is **not implemented here**, superseded mid-flight by
+a second ruling: **all `CLAUDE.md` modification is reserved to the scaffolding
+agent**, which owns that file exclusively.
+
+Two code paths mutate a project `CLAUDE.md` today, neither of which is that
+agent — recorded as a defect to resolve separately, not fixed here:
+
+- `instruction_pipeline::load_or_create_claude_md` seeds `CLAUDE_MD_STUB` on
+  first session start (reached via `build_instructions`).
+- `session_launch::worktree_sync::self_heal_claude_md` strips the legacy #2170
+  delegation block on every session resume, via `strip_delegation_block`.
+
+The scaffolding path itself is the `tm-init` skill, which is agent-driven prose
+— it has no code component and no knowledge of the
+`<!-- TRUSTY-MPM: <TOKEN> START v=1 -->` marked-block format. Teaching it to
+author marked section-override blocks is unbuilt capability, and where the
+pointer lives is an open owner decision.


### PR DESCRIPTION
Closes #4752

**Test ladder rung: 3** (localized behavior inside one crate) — `trusty-mpm` only.

## The defect

One path carried three roles:

| Role | Symbol |
|---|---|
| compiled prompt **output** | `instruction_pipeline.rs` — `install_system_prompt` / `install_system_prompt_to` |
| bundled 4-line **stub** | `bundle_all.rs` — `ALL` (already removed, see below) |
| pipeline **input** | `instruction_pipeline.rs` — `build_instructions` reads `PipelineInput::framework_instructions_path` |

Last writer won, so the artifact an operator inspects to answer "what instructions is my session running?" was non-deterministic. #383 fixed one instance by ordering the writes — ordering is not a fix when two roles share one name.

## What changed

- **Distinct path.** `FrameworkPaths::instructions_compiled()` → `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md`, directly under `framework/`, **not** under `framework/instructions/`. Filename constant: `instruction_pipeline::COMPILED_PROMPT_FILE`.
- **One writer function.** Both call sites go through `write_compiled_prompt_to`, so the file can only ever hold a full compiled prompt, never a stub.
- **Stale leftover removed.** `tm install` deletes a pre-#4752 `instructions/INSTRUCTIONS.md` via `remove_stale_bundled_instructions` — see "Stale leftover" below.
- **`non-overridable-rules.md`** no longer calls section overrides "override files"; the live mechanism is marked blocks in the project's `CLAUDE.md`, now pointing at the spec of record. Golden prompts regenerated with the harness's own `UPDATE_GOLDEN=1`; the diff is exactly those three lines in three files, nothing else.
- **Spec §10** added to `docs/specs/SPEC-PMINSTR-01-p1-p2-instruction-restructure.md`; **Finding #1 retired** from `sections/README.md`.

## Ordering — before, after, and cost

**Today (before this PR):** `install_system_prompt_to` was called from exactly one production site, `commands/install.rs::install` — **install time only**. `install_system_prompt()` (the home-resolving variant) had **zero** production callers. The launch path (`session_launch::prepare_session_inner` → `build_system_prompt_for_with_style_and_native`) never refreshed the framework-level artifact, so it went stale the moment a project's `CLAUDE.md` overrides changed.

**After:** `prepare_session_inner` writes the prompt to `fw.instructions_compiled()` immediately after the `.trusty-mpm/last-instructions.md` stash and before returning. The write is **fatal** (`?` → `PrepError::Io`), not best-effort. Every caller spawns `claude` only after `prepare_session` returns `Ok`, so *"prepare returned"* **is** *"the compiled prompt on disk is the prompt this session will run with."*

**Cost — measured? No.** I did not benchmark, and I am not claiming "no regression". The structural argument: the launch write reuses the `resolved_prompt` string the composer already built for `--append-system-prompt-file` — the same text just written to the project stash — so it is one additional `fs::write` with **no second composition pass**.

## Tests — 9 new, and they fail before the change

The two ordering tests were verified fail-before by temporarily removing the launch-time write:

```
test core::session_launch::tests::prepare_session_writes_the_compiled_prompt_before_returning ... FAILED
test core::session_launch::tests::prepare_session_fails_when_the_compiled_prompt_cannot_be_written ... FAILED

panicked at tests.rs:302: assertion `left != right` failed:
  the launch must overwrite a stale compiled prompt, not leave it in place
panicked at tests.rs:340:
  a failed compiled-prompt write must abort the launch preparation: PrepReport { … }
```

Fixtures are built so only the named guard can make them pass:

- `prepare_session_writes_the_compiled_prompt_before_returning` — the compiled path is **pre-seeded with stale sentinel content**, so a mere "the file exists" check would pass against a broken implementation. It asserts the content is not the sentinel *and* is byte-identical to the stash (the exact `--append-system-prompt-file` payload).
- `prepare_session_fails_when_the_compiled_prompt_cannot_be_written` — this is the one that pins **blocking**, not just eventual: a directory is planted at the compiled path so only that write fails. If the write were best-effort or deferred, `prepare_session` returns `Ok` and the test fails (as shown above).
- `bundle_install_pass_never_touches_the_compiled_prompt` — pre-seeds a sentinel and asserts it **survives** `install_to`; an absence check would pass trivially on a fresh temp dir.

No coverage was deleted, `#[ignore]`d, `cfg`-gated, `--exclude`d, or `--lib`-narrowed.

## Findings you should read before merging

**1. The `bundle_all.rs` stub was already gone — I deleted nothing.** #4286 split A had already removed the `instructions/INSTRUCTIONS.md` entry from `bundle::ALL` and deleted the `FRAMEWORK_INSTRUCTIONS` constant. Verified:

```
$ git grep -n 'FRAMEWORK_INSTRUCTIONS' -- crates/
crates/trusty-mpm/src/core/bundle.rs:11:  (doc comment only)
crates/trusty-mpm/src/core/bundle_tests.rs:406:  (comment: "the constant it backed is gone too. 179 - 1 = 178")
```

`bundle_table_is_complete` pins `ALL.len() == 178`. Finding #1 in `sections/README.md` described a collision whose first writer no longer existed. The surviving half — compiled output sharing a path with a pipeline input — is real, and is what this PR fixes.

**2. Nothing else was dead.** Per the "verify each removal with a `git grep`" instruction: `FrameworkPaths::framework_instructions` / `framework_instructions_path` and the `instructions` field **retain live readers** — `session_launch::prepare_session_inner` and `commands/session.rs` both still build a `PipelineInput` from them. They were kept.

**3. Stale leftover — handled, not ignored.** After this change nothing writes `instructions/INSTRUCTIONS.md`, but `build_instructions` still *reads* it. An upgraded machine would fold a frozen copy of an old compiled prompt into `PipelineOutput::merged` forever, with no writer left to refresh it. `tm install` now removes it. Safe: the file is framework-owned (trusty-mpm has always overwritten it on every install), `build_instructions` already treats absence as normal (`instructions_loaded: false`), and `merged` has no production reader.

**4. No test enshrined the defect.** Two existing tests pinned the old path (`install_system_prompt_writes_file`, `install_system_prompt_to_writes_assembled`); both were **rewritten to assert the new behavior**, with the first strengthened from `ends_with("INSTRUCTIONS.md")` to a full path equality. Neither was ignored or weakened.

**5. `#4753`'s described defect does not exist — marked `Refs`, not `Closes`.** #4753 states `non-overridable-rules.md` tells the PM to create the five retired `.trusty-mpm/` override files on trigger phrases. That is **not** true of current `main`. The shipped file already reads:

> Trigger phrases -> act immediately, always in `CLAUDE.md`
> …
> The `.trusty-mpm/` override files … are RETIRED and are no longer read (#4286). **Never create one.**

Every trigger maps to `CLAUDE.md` prose or a marker block. This matches spec §9.7, which records that commit `0aec8866` (#4592) already rewrote that table. A full sweep of all nine shipped section files found **no** other place describing the retired files as live — the only other `.trusty-mpm/` mentions (`core.md`, `enforcement.md`) refer to orchestration state and config, which is correct.

What I *did* fix in that file is the one genuine residue: line 66 said "Missing, empty, or unreadable override **files**", leftover wording from the file-based era. **I did not write `Closes #4753`**, because closing it on the strength of a one-line wording change would misrepresent what was fixed. Recommend closing #4753 as already-resolved-by-#4592, or reopening it with an accurate description — owner's call.

**6. CLAUDE.md pointer — deliberately not delivered.** Superseded mid-flight by the ruling that all `CLAUDE.md` modification is reserved to the scaffolding agent. I had written the pointer into `CLAUDE_MD_STUB` and the `tm-init` skill; **both were backed out** — `tm-init.md` is untouched in this diff. Reported for a separate decision:

- **Two code paths mutate a project `CLAUDE.md` today, neither of which is the scaffolding agent** — this plurality is itself the defect the ruling names:
  - `instruction_pipeline::load_or_create_claude_md` seeds `CLAUDE_MD_STUB` on first session start (reached via `build_instructions`).
  - `session_launch::worktree_sync::self_heal_claude_md` strips the legacy #2170 block on **every session resume**, via `strip_delegation_block`.
- **The scaffolding path is the `tm-init` skill** — agent-driven prose with no code component; it delegates the file write to the PM or an engineer agent.
- **It cannot currently write a marked section-override block.** `grep 'TRUSTY-MPM:' tm-init.md` returns nothing; the skill has no knowledge of the `<!-- TRUSTY-MPM: <TOKEN> START v=1 -->` format. That capability is **unbuilt**, so where the pointer lives is an open decision, not something I assumed either way.

Recorded in spec §10.5.

## Gates — rung 3, raw output

```
$ cargo fmt --check
fmt exit=0

$ cargo check -p trusty-mpm
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 15.24s
check exit=0

$ cargo clippy -p trusty-mpm --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.81s
clippy exit=0

$ cargo test -p trusty-mpm
TEST_EXIT=0
45 result lines, all ok
TOTAL passed=7410 failed=0 ignored=17

$ bash scripts/check_line_cap.sh
line-cap: measured 3622 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.

$ bash scripts/check_sld.sh
sld-lint: scanned 54 spec doc(s) + 3042 code file(s); 0 error(s), 0 warning(s)

$ bash scripts/check_changelog_fragment.sh
OK   trusty-mpm: changelog.d fragment present and valid
changelog-fragment gate: scanned 15 changed path(s); all 1 crate(s) with source changes are recorded.
```

The 9 new tests, run by exact name:

```
running 9 tests
test core::paths::tests::instructions_compiled_is_directly_under_framework ... ok
test core::paths::tests::instructions_compiled_is_not_the_framework_instructions_path ... ok
test core::instruction_pipeline::tests::no_bundled_artifact_targets_the_compiled_prompt_path ... ok
test core::instruction_pipeline::tests::remove_stale_bundled_instructions_is_a_noop_when_absent ... ok
test core::instruction_pipeline::tests::compiled_prompt_path_is_distinct_from_the_bundled_instructions_path ... ok
test core::instruction_pipeline::tests::remove_stale_bundled_instructions_deletes_a_leftover ... ok
test core::instruction_pipeline::tests::write_compiled_prompt_to_creates_parent_dirs ... ok
test core::session_launch::tests::prepare_session_fails_when_the_compiled_prompt_cannot_be_written ... ok
test core::session_launch::tests::prepare_session_writes_the_compiled_prompt_before_returning ... ok

test result: ok. 9 passed; 0 failed; 0 ignored; 0 measured; 4346 filtered out; finished in 0.44s
```

**No pre-existing failures encountered.** The three `pm_prompt_golden_*` tests went red mid-run from my own `non-overridable-rules.md` edit and were resolved by regenerating the goldens through the sanctioned `UPDATE_GOLDEN=1` path, with the diff reviewed line-by-line — not by weakening the assertion.

**Line-cap note:** the new bundle-writer test initially pushed `tests_behavior_a.rs` to 510 SLOC. That basename does not match the `_tests.rs` pattern, so it carries the 500 **production** cap. Per that file's own comment, the test was moved to its `install_policy_tests.rs` sibling — the same remedy #3381 used. No file was allowlisted and the gate was not weakened.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
