### PR TITLE
feat(trusty-mpm): single-owner writer for CLAUDE.md section overrides (refs #4754)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4754-claude-md-writer.md
+++ b/crates/trusty-mpm/changelog.d/4754-claude-md-writer.md
@@ -1,0 +1,16 @@
+Added
+
+- `core::claude_md_writer` — the single owner of `CLAUDE.md` section-override
+  writes, the write-side counterpart to the reader-only
+  `core::claude_md_sections` (refs [#4754](https://github.com/bobmatnyc/trusty-tools/issues/4754))
+  - `write_section_override` is idempotent by construction: a repeat write
+    replaces its block in place and collapses any pre-existing duplicate, so a
+    section can never accumulate a stacked second copy
+  - `core` is refused because the shipped package declares it `fixed` — the
+    writer asks `CustomizationTier::permits`, it does not carry its own list
+  - every refusal (protected section, empty body, a marker line inside the body,
+    an unpaired marker in the host, an unreadable host) leaves the file
+    byte-identical and the bundled section in force
+  - `ensure_compiled_pointer` records where the composed PM prompt lands, using
+    delimiters deliberately outside the `TRUSTY-MPM:` grammar so the reader sees
+    no override and raises no diagnostic

--- a/crates/trusty-mpm/changelog.d/4754-claude-md-writer.md
+++ b/crates/trusty-mpm/changelog.d/4754-claude-md-writer.md
@@ -11,6 +11,9 @@ Added
   - every refusal (protected section, empty body, a marker line inside the body,
     an unpaired marker in the host, an unreadable host) leaves the file
     byte-identical and the bundled section in force
+  - written blocks adopt the host's dominant line ending, so splicing into a
+    CRLF `CLAUDE.md` does not leave a mixed-ending file
   - `ensure_compiled_pointer` records where the composed PM prompt lands, using
     delimiters deliberately outside the `TRUSTY-MPM:` grammar so the reader sees
-    no override and raises no diagnostic
+    no override and raises no diagnostic; it collapses duplicate pointer blocks
+    the same way section writes do

--- a/crates/trusty-mpm/src/core/claude_md_sections.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections.rs
@@ -82,7 +82,15 @@ use crate::core::instruction_package::{
 pub const HOST_FILES: [&str; 1] = ["CLAUDE.md"];
 
 /// The only marker version this build understands.
-const SUPPORTED_VERSION: u32 = 1;
+///
+/// Why: [`crate::core::claude_md_writer`] stamps this exact number into every
+/// block it emits rather than hardcoding its own `1`. A writer that spelled the
+/// version independently could drift past the reader on the next bump and emit
+/// blocks its own reader would decline as [`REASON_UNSUPPORTED_VERSION`] — the
+/// writer/reader drift this pairing exists to make impossible.
+/// What: the `v=` value written, and the only one accepted.
+/// Test: `written_block_declares_the_readers_supported_version`.
+pub(crate) const SUPPORTED_VERSION: u32 = 1;
 
 /// Literal opening a marker line.
 const MARKER_OPEN: &str = "<!--";
@@ -371,6 +379,64 @@ fn parse_blocks(text: &str, host: &Path) -> (Vec<ParsedBlock>, Vec<ScanDiagnosti
         diagnostics.push(diagnostic(host, start_line, REASON_UNCLOSED));
     }
     (blocks, diagnostics)
+}
+
+/// Whether any line of `text` would be recognised as a framework marker.
+///
+/// Why: [`crate::core::claude_md_writer`] must refuse a body that itself
+/// contains a marker line. Emitting one would nest a `START` inside the block
+/// being written, and [`parse_blocks`] resolves nesting by DISCARDING the outer
+/// block ([`REASON_UNCLOSED`]) — so an override body carrying a stray marker
+/// would silently delete the very section the author was trying to set. The
+/// check has to use the reader's own recogniser, not a substring search for
+/// `TRUSTY-MPM:`, because prose mentioning the marker inline is legal content
+/// and must stay writable.
+/// What: `true` when [`parse_marker`] accepts any line of `text`.
+/// Test: `body_containing_a_marker_line_is_refused`,
+/// `body_mentioning_the_marker_in_prose_is_written`.
+pub(crate) fn contains_marker_line(text: &str) -> bool {
+    text.lines().any(|line| parse_marker(line).is_some())
+}
+
+/// Where a section's well-formed blocks sit in a host, and whether the host's
+/// marker structure is intact.
+///
+/// Why: the writer needs exactly two facts before it edits a file — which line
+/// ranges belong to the section it is replacing, and whether any marker in the
+/// file is unpaired. It must not re-derive either from its own parser.
+/// What: `spans` holds `(start_line, end_line)` 0-based inclusive line indices
+/// of every well-formed block claiming the section, in file order; `unclosed`
+/// is true when any `START` in the host lacked a matching `END`.
+/// Test: `locate_blocks_finds_one_span_per_block`,
+/// `locate_blocks_flags_an_unclosed_marker`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct HostBlocks {
+    /// 0-based inclusive `(start_line, end_line)` of each matching block.
+    pub(crate) spans: Vec<(usize, usize)>,
+    /// Whether the host contains an unpaired `START` marker.
+    pub(crate) unclosed: bool,
+}
+
+/// Locate every well-formed block in `text` that claims `section`.
+///
+/// Why: one grammar, one pairing pass. The writer splices by line index, and
+/// deriving those indices from [`parse_blocks`] — the same function the reader
+/// uses — is what guarantees the writer can never target a region the reader
+/// would parse differently.
+/// What: runs [`parse_blocks`] and projects the blocks whose token resolved to
+/// `section`, plus whether any [`REASON_UNCLOSED`] diagnostic was raised.
+/// Test: `locate_blocks_finds_one_span_per_block`,
+/// `locate_blocks_flags_an_unclosed_marker`, `locate_blocks_ignores_other_sections`.
+pub(crate) fn locate_blocks(text: &str, section: SectionId) -> HostBlocks {
+    let (blocks, diagnostics) = parse_blocks(text, Path::new("<in-memory>"));
+    HostBlocks {
+        spans: blocks
+            .iter()
+            .filter(|b| b.section == Some(section))
+            .map(|b| (b.start_line, b.end_line))
+            .collect(),
+        unclosed: diagnostics.iter().any(|d| d.reason == REASON_UNCLOSED),
+    }
 }
 
 /// Decide whether a parsed pair may become an override.

--- a/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_sections_tests.rs
@@ -1274,3 +1274,58 @@ fn seeded_claude_md_declares_no_overrides() {
         "the bundled workflow section must survive a freshly seeded CLAUDE.md"
     );
 }
+
+// --- LOCATOR: the projection the writer splices against (#4754) -------------
+
+/// One span per well-formed block, in file order, with the inclusive line
+/// indices the writer needs.
+#[test]
+fn locate_blocks_finds_one_span_per_block() {
+    let token = section_token(SectionId::Workflow);
+    let text = format!(
+        "intro\n\
+         <!-- TRUSTY-MPM: {token} START v=1 -->\nfirst\n<!-- TRUSTY-MPM: {token} END -->\n\
+         middle\n\
+         <!-- TRUSTY-MPM: {token} START v=1 -->\nsecond\n<!-- TRUSTY-MPM: {token} END -->\n"
+    );
+
+    let located = locate_blocks(&text, SectionId::Workflow);
+
+    assert_eq!(located.spans, vec![(1, 3), (5, 7)]);
+    assert!(!located.unclosed);
+    // The spans must really delimit the blocks: the named lines are the markers.
+    let lines: Vec<&str> = text.lines().collect();
+    assert!(lines[1].contains("START") && lines[3].contains("END"));
+}
+
+/// An unpaired `START` is surfaced, because it means the file's block extents
+/// are unknown and the writer must decline to splice.
+#[test]
+fn locate_blocks_flags_an_unclosed_marker() {
+    let token = section_token(SectionId::Memory);
+    let text = format!("<!-- TRUSTY-MPM: {token} START v=1 -->\nno end marker\n");
+
+    let located = locate_blocks(&text, SectionId::Memory);
+
+    assert!(located.unclosed, "an unpaired START must be reported");
+    assert!(located.spans.is_empty(), "and yield no span to splice over");
+}
+
+/// Blocks belonging to other sections are not returned — a writer targeting one
+/// section must never splice over another's block.
+#[test]
+fn locate_blocks_ignores_other_sections() {
+    let text = format!(
+        "{}{}",
+        block(SectionId::Memory, "memory body"),
+        block(SectionId::Workflow, "workflow body")
+    );
+
+    let located = locate_blocks(&text, SectionId::Workflow);
+
+    assert_eq!(located.spans.len(), 1, "only the WORKFLOW block");
+    let lines: Vec<&str> = text.lines().collect();
+    let (start, end) = located.spans[0];
+    assert!(lines[start].contains(section_token(SectionId::Workflow)));
+    assert!(lines[end].contains(section_token(SectionId::Workflow)));
+}

--- a/crates/trusty-mpm/src/core/claude_md_writer.rs
+++ b/crates/trusty-mpm/src/core/claude_md_writer.rs
@@ -196,12 +196,46 @@ fn section_is_writable(section: SectionId) -> Result<(), WriteRejection> {
     Ok(())
 }
 
+/// The line ending the host predominantly uses.
+///
+/// Why: a rendered block always spells `\n` internally, so splicing one into a
+/// CRLF host would leave a file with mixed endings — a user-visible defect in a
+/// file the project owns, and the kind of diff noise that makes a `CLAUDE.md`
+/// change unreviewable. Matching the host's dominant ending keeps the writer
+/// invisible in the diff.
+/// What: `"\r\n"` when more than half the newlines in `text` are CRLF, else
+/// `"\n"`. An empty or newline-free host yields `"\n"`.
+/// Test: `matches_the_hosts_crlf_line_endings`,
+/// `a_mixed_ending_host_takes_the_dominant_ending`.
+fn dominant_eol(text: &str) -> &'static str {
+    let crlf = text.matches("\r\n").count();
+    let newlines = text.matches('\n').count();
+    if crlf * 2 > newlines { "\r\n" } else { "\n" }
+}
+
+/// Re-spell a rendered block's `\n` endings as `eol`.
+///
+/// Why: rendering stays single-spelling (`\n`) so the templates remain readable;
+/// the host-specific ending is applied once, at the boundary.
+/// What: identity for `"\n"`; otherwise every `\n` becomes `\r\n`. Safe against
+/// double-conversion because rendered blocks never contain a `\r`.
+/// Test: `matches_the_hosts_crlf_line_endings`.
+fn normalize_eol(rendered: &str, eol: &str) -> String {
+    debug_assert!(!rendered.contains('\r'), "rendered blocks are LF-only");
+    if eol == "\r\n" {
+        rendered.replace('\n', "\r\n")
+    } else {
+        rendered.to_string()
+    }
+}
+
 /// Render one section override block, terminator included.
 ///
 /// Why: the emitted text has to be something the reader accepts unchanged, so
 /// every variable part comes from the reader — the token from
 /// [`section_token`], the version from [`SUPPORTED_VERSION`].
-/// What: `START` line, trimmed body, `END` line, each newline-terminated.
+/// What: `START` line, trimmed body, `END` line, each `\n`-terminated; the
+/// caller re-spells the endings via [`normalize_eol`] to match the host.
 /// Test: `written_block_declares_the_readers_supported_version`,
 /// `round_trips_through_the_reader`.
 fn render_block(section: SectionId, body: &str) -> String {
@@ -279,19 +313,21 @@ fn splice(text: &str, spans: &[(usize, usize)], replacement: &str) -> String {
 /// and an existing file that lacks a final newline would otherwise have its last
 /// line swallowed into the marker line.
 /// What: returns `block` alone for empty input; otherwise `text`, a normalising
-/// newline when absent, a blank line, then `block`.
+/// line ending when absent, a blank line, then `block` — both separators spelled
+/// with the host's own `eol`.
 /// Test: `appends_after_existing_prose`,
-/// `appends_newline_when_existing_file_lacks_trailing_newline`.
-fn append_block(text: &str, block: &str) -> String {
+/// `appends_newline_when_existing_file_lacks_trailing_newline`,
+/// `matches_the_hosts_crlf_line_endings`.
+fn append_block(text: &str, block: &str, eol: &str) -> String {
     if text.is_empty() {
         return block.to_string();
     }
-    let mut out = String::with_capacity(text.len() + block.len() + 2);
+    let mut out = String::with_capacity(text.len() + block.len() + 2 * eol.len());
     out.push_str(text);
     if !out.ends_with('\n') {
-        out.push('\n');
+        out.push_str(eol);
     }
-    out.push('\n');
+    out.push_str(eol);
     out.push_str(block);
     out
 }
@@ -378,9 +414,10 @@ pub fn write_section_override(
         return Err(WriteRejection::HostMalformed { host: path });
     }
 
-    let block = render_block(section, body);
+    let eol = dominant_eol(&text);
+    let block = normalize_eol(&render_block(section, body), eol);
     let next = if located.spans.is_empty() {
-        append_block(&text, &block)
+        append_block(&text, &block, eol)
     } else {
         splice(&text, &located.spans, &block)
     };
@@ -411,11 +448,12 @@ pub fn write_section_override(
 pub fn ensure_compiled_pointer(project_dir: &Path) -> Result<WriteOutcome, WriteRejection> {
     let path = host_path(project_dir);
     let (text, existed) = read_host(&path)?;
-    let block = render_pointer();
+    let eol = dominant_eol(&text);
+    let block = normalize_eol(&render_pointer(), eol);
 
     let spans = pointer_spans(&text);
     let next = if spans.is_empty() {
-        append_block(&text, &block)
+        append_block(&text, &block, eol)
     } else {
         splice(&text, &spans, &block)
     };
@@ -438,22 +476,30 @@ pub fn ensure_compiled_pointer(project_dir: &Path) -> Result<WriteOutcome, Write
 /// stays conservative in the same direction as the reader: an unpaired begin
 /// marker yields no span, so the block is appended rather than the file being
 /// rewritten around a delimiter whose extent is unknown.
-/// What: at most one `(start, end)` span, matching trimmed delimiter lines.
+/// It also returns EVERY paired block, not just the first, so [`splice`]
+/// collapses duplicates here exactly as it does for sections. The argument is
+/// the same one that justified collapsing there: a caller must be able to read
+/// back what it wrote, and a second pointer block left behind is a stale copy a
+/// reader can find first.
+/// What: one `(start, end)` span per paired delimiter, in file order, matching
+/// trimmed delimiter lines.
 /// Test: `pointer_write_is_idempotent`,
-/// `an_unpaired_pointer_marker_does_not_consume_the_file`.
+/// `an_unpaired_pointer_marker_does_not_consume_the_file`,
+/// `pointer_write_collapses_duplicate_pointer_blocks`.
 fn pointer_spans(text: &str) -> Vec<(usize, usize)> {
+    let mut spans = Vec::new();
     let mut start = None;
     for (index, line) in text.lines().enumerate() {
         let trimmed = line.trim();
         if trimmed == POINTER_BEGIN {
             start = Some(index);
         } else if trimmed == POINTER_END
-            && let Some(open) = start
+            && let Some(open) = start.take()
         {
-            return vec![(open, index)];
+            spans.push((open, index));
         }
     }
-    Vec::new()
+    spans
 }
 
 // A `remove_section_override` counterpart is deliberately absent. Removing a

--- a/crates/trusty-mpm/src/core/claude_md_writer.rs
+++ b/crates/trusty-mpm/src/core/claude_md_writer.rs
@@ -1,0 +1,467 @@
+//! Write-side owner of a project's `CLAUDE.md` — named-section override blocks
+//! and the compiled-instructions pointer (issue #4754).
+//!
+//! Why: [`crate::core::claude_md_sections`] is explicitly reader-only ("Scope:
+//! reader only"), so every write to `CLAUDE.md` has so far been performed by
+//! hand — by an LLM following prose in the `tm-init` skill — against a grammar
+//! only the reader actually knows. That is the pairing that fails: prose cannot
+//! be idempotent, and the repeat-application bug it invites is not hypothetical
+//! in this repo. The shared `## [Unreleased]` changelog section was edited the
+//! same hand-merged way and five concurrent PRs stacked five copies into it
+//! (#4463–#4475, #4399 burned three rebase rounds), which is exactly why
+//! changelog entries moved to per-PR fragment files. A section override stacked
+//! twice is worse than a changelog stacked twice: the reader's block parser keeps the
+//! FIRST well-formed block and reports the rest as
+//! [`crate::core::claude_md_sections::REASON_DUPLICATE`], so the second copy is the one the
+//! author just wrote and the one silently ignored.
+//!
+//! What: [`write_section_override`] — the single entry point that creates,
+//! replaces, or leaves alone one section's marker block — and
+//! [`ensure_compiled_pointer`], which records where the composed system prompt
+//! actually lands. Both are idempotent by construction and both preserve every
+//! byte outside the region they own.
+//!
+//! THE GRAMMAR LIVES IN THE READER, NOT HERE. This module never parses a marker
+//! itself: it locates existing blocks with
+//! [`locate_blocks`], screens bodies with
+//! [`contains_marker_line`], stamps
+//! [`SUPPORTED_VERSION`], and spells the token with
+//! [`section_token`]. A second grammar here would drift, and
+//! the first divergence would be a block this crate writes and this crate then
+//! declines to read — an override that is advertised and unread, issue #381
+//! verbatim.
+//!
+//! WHO DECIDES WHAT MAY BE WRITTEN — the package, and only the package, exactly
+//! as on the read side. [`section_is_writable`] asks
+//! [`CustomizationTier::permits`] for the section as the shipped package
+//! declares it. `core` is refused because the package declares it `fixed`, not
+//! because this module carries a list naming it; a hardcoded list here would be
+//! a second source of truth, and the first time the two disagreed the protected
+//! section would become writable in the one surface that must never write it.
+//!
+//! NEVER FAIL OPEN. Every refusal in this module leaves MORE framework
+//! instruction in force, never less, and never a damaged file: a protected
+//! section, an empty body, a body carrying its own marker line, a host whose
+//! markers are unpaired, and an unavailable package all decline the write and
+//! leave `CLAUDE.md` byte-identical. A customization mistake must never be able
+//! to delete the PM's instructions — the writer's version of the reader's
+//! standing rule.
+//!
+//! Test: `claude_md_writer_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+use crate::core::agent_manifest::atomic_write;
+use crate::core::bundled_pm_package::bundled_fallback_package;
+use crate::core::claude_md_sections::{
+    HOST_FILES, SUPPORTED_VERSION, contains_marker_line, locate_blocks, section_token,
+};
+use crate::core::instruction_package::{CustomizationTier, OverrideTier, SectionId};
+
+/// Where the composed PM system prompt is written, as named in a project's
+/// `CLAUDE.md`.
+///
+/// Why: `CLAUDE.md` and the compiled prompt are read by two different readers
+/// (the reader-side module's "CLAUDE.md is read twice" section), and nothing in
+/// the project's own file says where the composed half ends up. A reader of
+/// `CLAUDE.md` could see marker blocks with no way to find what they compile
+/// into. The pointer runs one way only — `CLAUDE.md` → compiled file — so this
+/// module records the path without owning, creating, or reading it.
+/// What: the tilde-form path, written verbatim into the pointer block. Producing
+/// the file at this path belongs to the instruction pipeline, not here.
+/// Test: `pointer_block_names_the_compiled_instructions_path`.
+pub const COMPILED_INSTRUCTIONS_PATH: &str = "~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md";
+
+/// First line of the managed compiled-instructions pointer block.
+///
+/// Why: the pointer is NOT a section override and must never be parsed as one.
+/// These delimiters deliberately fail [`crate::core::claude_md_sections`]'s namespace test —
+/// `trusty-mpm ` is not `TRUSTY-MPM:` — so the reader treats the whole block as
+/// ordinary prose and raises no `unknown section token` diagnostic for it.
+/// What: the begin marker; its presence is how a repeat call finds the block.
+/// Test: `pointer_block_is_invisible_to_the_section_reader`.
+pub const POINTER_BEGIN: &str = "<!-- trusty-mpm compiled-instructions pointer >>> -->";
+
+/// Last line of the managed compiled-instructions pointer block.
+///
+/// Test: `pointer_block_is_invisible_to_the_section_reader`.
+pub const POINTER_END: &str = "<!-- <<< trusty-mpm compiled-instructions pointer -->";
+
+/// What a write did to the host file.
+///
+/// Why: `Unchanged` is reported separately from `Replaced` so idempotency is an
+/// observable outcome rather than an inference from an unchanged mtime — a
+/// second identical call is provably a no-op, not merely a rewrite that
+/// happened to produce the same bytes.
+/// What: one variant per terminal state of a write.
+/// Test: `applying_the_same_override_twice_reports_unchanged`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WriteOutcome {
+    /// The host did not exist and was created holding just this block.
+    Created,
+    /// The host existed and the block was appended to it.
+    Inserted,
+    /// An existing block for this section was replaced in place.
+    Replaced,
+    /// The host already held exactly this block; nothing was written.
+    Unchanged,
+}
+
+/// Why a write was declined, leaving the host untouched.
+///
+/// Why: every variant is a case where the bundled section stays in force and
+/// `CLAUDE.md` keeps its exact prior bytes. Returning them as data rather than
+/// only logging keeps "the writer refused" an assertable fact, matching the
+/// reader's [`crate::core::claude_md_sections::Rejection`] treatment.
+/// What: one variant per rule in the write contract.
+/// Test: one test per variant in `claude_md_writer_tests.rs`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum WriteRejection {
+    /// The section's declared tier admits no project-tier override.
+    #[error("section {section:?} is tier {tier:?} and may not be written from CLAUDE.md")]
+    Protected {
+        /// The section the write aimed at.
+        section: SectionId,
+        /// The tier the package declares for it.
+        tier: CustomizationTier,
+    },
+    /// The package declares no such section.
+    #[error("section {section:?} is not declared by this package")]
+    UnknownSection {
+        /// The section the write aimed at.
+        section: SectionId,
+    },
+    /// The body was empty once trimmed — never write a section-blanking block.
+    #[error("override body for section {section:?} is empty; nothing written")]
+    EmptyBody {
+        /// The section the write aimed at.
+        section: SectionId,
+    },
+    /// The body carried a marker line, which would nest and destroy the block.
+    #[error("override body for section {section:?} contains a TRUSTY-MPM marker line")]
+    BodyContainsMarker {
+        /// The section the write aimed at.
+        section: SectionId,
+    },
+    /// The host has an unpaired `START`; its structure is not safe to edit.
+    #[error("{host} contains an unclosed TRUSTY-MPM marker; refusing to edit it")]
+    HostMalformed {
+        /// The host file that failed the structural check.
+        host: PathBuf,
+    },
+    /// The bundled package could not be loaded, so no tier could be consulted.
+    #[error("bundled instruction package unavailable ({0}); refusing to write")]
+    PackageUnavailable(&'static str),
+    /// Reading or writing the host failed.
+    #[error("{0}")]
+    Io(String),
+}
+
+/// The project-relative host every write targets.
+///
+/// Why: taken from the reader's [`HOST_FILES`] rather than spelled again here,
+/// so the writer cannot target a file the reader does not scan.
+/// What: the sole host path, joined onto a project root by [`host_path`].
+/// Test: `writes_target_the_readers_only_host`.
+fn host_path(project_dir: &Path) -> PathBuf {
+    project_dir.join(HOST_FILES[0])
+}
+
+/// Confirm the shipped package permits a project-tier write of `section`.
+///
+/// Why: the single decision point for "may this be written?", asking the package
+/// exactly as `InstructionPackage::with_overrides` does on
+/// the read side. Keeping both sides on one authority is what makes the
+/// protected section unwritable rather than merely undocumented.
+/// What: `Ok(())` when the declared tier admits [`OverrideTier::Project`];
+/// otherwise a rejection, logged at `warn` because a declined customization the
+/// author never hears about is the #381 failure mode.
+/// Test: `core_is_declined_and_logged`, `every_other_section_is_writable`.
+fn section_is_writable(section: SectionId) -> Result<(), WriteRejection> {
+    let package = bundled_fallback_package().map_err(WriteRejection::PackageUnavailable)?;
+    let declared = package
+        .section(section)
+        .ok_or(WriteRejection::UnknownSection { section })?;
+    if !declared.customization_tier.permits(OverrideTier::Project) {
+        tracing::warn!(
+            section = ?section,
+            tier = ?declared.customization_tier,
+            "declining CLAUDE.md write: section is protected; the bundled section stays in force"
+        );
+        return Err(WriteRejection::Protected {
+            section,
+            tier: declared.customization_tier,
+        });
+    }
+    Ok(())
+}
+
+/// Render one section override block, terminator included.
+///
+/// Why: the emitted text has to be something the reader accepts unchanged, so
+/// every variable part comes from the reader — the token from
+/// [`section_token`], the version from [`SUPPORTED_VERSION`].
+/// What: `START` line, trimmed body, `END` line, each newline-terminated.
+/// Test: `written_block_declares_the_readers_supported_version`,
+/// `round_trips_through_the_reader`.
+fn render_block(section: SectionId, body: &str) -> String {
+    let token = section_token(section);
+    format!(
+        "<!-- TRUSTY-MPM: {token} START v={SUPPORTED_VERSION} -->\n{}\n<!-- TRUSTY-MPM: {token} END -->\n",
+        body.trim()
+    )
+}
+
+/// Render the managed compiled-instructions pointer block, terminator included.
+///
+/// Why: the body is visible Markdown rather than an HTML comment, because the
+/// point is that a HUMAN reading `CLAUDE.md` can find the compiled prompt. Only
+/// the delimiters are comments.
+/// What: begin marker, a blockquote naming [`COMPILED_INSTRUCTIONS_PATH`], end
+/// marker.
+/// Test: `pointer_block_names_the_compiled_instructions_path`.
+fn render_pointer() -> String {
+    format!(
+        "{POINTER_BEGIN}\n\
+         > The PM system prompt in force for this project is composed at session\n\
+         > launch and written to `{COMPILED_INSTRUCTIONS_PATH}`.\n\
+         > Marked `TRUSTY-MPM:` blocks in this file are inputs to it; all other\n\
+         > prose here is loaded directly by Claude Code and is not copied into it.\n\
+         {POINTER_END}\n"
+    )
+}
+
+/// Splice `replacement` over the line spans `spans`, keeping the first and
+/// dropping the rest.
+///
+/// Why: replacing the first span and DELETING any later duplicate is what makes
+/// the post-condition "exactly one block for this section" hold. It is also
+/// semantically free: the reader already keeps the first block and reports the
+/// others as [`crate::core::claude_md_sections::REASON_DUPLICATE`], so removing them changes
+/// which bytes are on disk but not which override is in force. Leaving them
+/// would mean a caller could read back its own freshly written value and get a
+/// stale one — the stacking failure this module exists to prevent.
+///
+/// Line indices come from the reader's parse of the same string, and
+/// `split_inclusive` yields one segment per `lines()` item while retaining each
+/// terminator, so untouched regions survive byte-for-byte including `\r\n` and
+/// trailing whitespace.
+/// What: concatenates the segments outside every span, emitting `replacement` at
+/// the first. Restores a missing final newline when the original lacked one and
+/// the last span reached end-of-file.
+/// Test: `preserves_surrounding_content_byte_for_byte`,
+/// `replacing_collapses_duplicate_blocks_to_one`,
+/// `preserves_crlf_line_endings`.
+fn splice(text: &str, spans: &[(usize, usize)], replacement: &str) -> String {
+    let segments: Vec<&str> = text.split_inclusive('\n').collect();
+    let mut out = String::with_capacity(text.len() + replacement.len());
+    let mut cursor = 0usize;
+
+    for (index, (start, end)) in spans.iter().enumerate() {
+        out.push_str(&segments[cursor..*start].concat());
+        if index == 0 {
+            out.push_str(replacement);
+        }
+        cursor = end + 1;
+    }
+    let consumed_to_eof = cursor >= segments.len();
+    out.push_str(&segments[cursor..].concat());
+
+    if consumed_to_eof && !text.ends_with('\n') && out.ends_with('\n') {
+        out.pop();
+    }
+    out
+}
+
+/// Append `block` to `text`, separated by one blank line.
+///
+/// Why: a project's own prose and a managed block must stay visually distinct,
+/// and an existing file that lacks a final newline would otherwise have its last
+/// line swallowed into the marker line.
+/// What: returns `block` alone for empty input; otherwise `text`, a normalising
+/// newline when absent, a blank line, then `block`.
+/// Test: `appends_after_existing_prose`,
+/// `appends_newline_when_existing_file_lacks_trailing_newline`.
+fn append_block(text: &str, block: &str) -> String {
+    if text.is_empty() {
+        return block.to_string();
+    }
+    let mut out = String::with_capacity(text.len() + block.len() + 2);
+    out.push_str(text);
+    if !out.ends_with('\n') {
+        out.push('\n');
+    }
+    out.push('\n');
+    out.push_str(block);
+    out
+}
+
+/// Read the host, treating absence as empty content.
+///
+/// Why: "no `CLAUDE.md` yet" is the ordinary first-write case, not an error, and
+/// must not be distinguishable from an empty one by anything but the outcome.
+/// What: `Ok((contents, existed))`; a genuine IO error is surfaced rather than
+/// swallowed, because writing over a file that could not be read risks
+/// destroying content this module promised to preserve.
+/// Test: `creates_the_host_when_absent`, `unreadable_host_is_reported_not_clobbered`.
+fn read_host(path: &Path) -> Result<(String, bool), WriteRejection> {
+    match std::fs::read_to_string(path) {
+        Ok(text) => Ok((text, true)),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok((String::new(), false)),
+        Err(err) => Err(WriteRejection::Io(format!("{}: {err}", path.display()))),
+    }
+}
+
+/// Persist `contents` to `path` unless it already matches.
+///
+/// Why: routed through the shared [`atomic_write`] entry point (the common
+/// entry-point rule) so a crash mid-write cannot leave a half-written
+/// `CLAUDE.md` — the file whose corruption would cost a project its
+/// instructions.
+/// What: writes via temp-file rename; returns `chosen` unchanged for the caller
+/// to report.
+/// Test: covered by every write test's on-disk assertion.
+fn persist(
+    path: &Path,
+    contents: &str,
+    chosen: WriteOutcome,
+) -> Result<WriteOutcome, WriteRejection> {
+    atomic_write(path, contents).map_err(|err| WriteRejection::Io(err.to_string()))?;
+    Ok(chosen)
+}
+
+/// Create, replace, or confirm one named-section override block in a project's
+/// `CLAUDE.md`.
+///
+/// Why: the single owner of section-override writes. Every caller routes here so
+/// that idempotency, the protected-section refusal, and byte preservation are
+/// properties of the system rather than of whoever wrote the calling prose.
+///
+/// What, in order: the package must permit the section; the body must be
+/// non-empty once trimmed and must not contain a marker line; the host's markers
+/// must all be paired. Only then does it splice. An existing block for the
+/// section is replaced in place and any duplicate of it removed, so exactly one
+/// block for that section survives; with no existing block, one is appended.
+/// Re-running with an identical body writes nothing and reports
+/// [`WriteOutcome::Unchanged`].
+///
+/// Every refusal leaves the file byte-identical and the bundled section in
+/// force.
+///
+/// Test: `writes_a_new_block_a_reader_accepts`,
+/// `applying_the_same_override_twice_reports_unchanged`,
+/// `applying_twice_leaves_exactly_one_block`, `core_is_declined_and_logged`,
+/// `preserves_surrounding_content_byte_for_byte`,
+/// `an_unclosed_marker_blocks_the_write`.
+pub fn write_section_override(
+    project_dir: &Path,
+    section: SectionId,
+    body: &str,
+) -> Result<WriteOutcome, WriteRejection> {
+    section_is_writable(section)?;
+    if body.trim().is_empty() {
+        return Err(WriteRejection::EmptyBody { section });
+    }
+    if contains_marker_line(body) {
+        return Err(WriteRejection::BodyContainsMarker { section });
+    }
+
+    let path = host_path(project_dir);
+    let (text, existed) = read_host(&path)?;
+
+    let located = locate_blocks(&text, section);
+    if located.unclosed {
+        tracing::warn!(
+            path = %path.display(),
+            "declining CLAUDE.md write: host has an unclosed TRUSTY-MPM marker"
+        );
+        return Err(WriteRejection::HostMalformed { host: path });
+    }
+
+    let block = render_block(section, body);
+    let next = if located.spans.is_empty() {
+        append_block(&text, &block)
+    } else {
+        splice(&text, &located.spans, &block)
+    };
+
+    if existed && next == text {
+        return Ok(WriteOutcome::Unchanged);
+    }
+    let outcome = match (existed, located.spans.is_empty()) {
+        (false, _) => WriteOutcome::Created,
+        (true, true) => WriteOutcome::Inserted,
+        (true, false) => WriteOutcome::Replaced,
+    };
+    persist(&path, &next, outcome)
+}
+
+/// Ensure the project's `CLAUDE.md` names where its compiled prompt lands.
+///
+/// Why: behaviour 6 of #4754 — a reader of `CLAUDE.md` should be able to find
+/// the composed system prompt actually in force. The pointer is one-directional
+/// and inert: this module writes the path and never reads, creates, or validates
+/// the file it names, which stays the instruction pipeline's to produce.
+/// What: appends the managed pointer block, or replaces it when its content has
+/// changed; reports [`WriteOutcome::Unchanged`] when already correct. The block
+/// is delimited by comments the section reader does not recognise, so it
+/// contributes no override and no diagnostic.
+/// Test: `pointer_block_names_the_compiled_instructions_path`,
+/// `pointer_write_is_idempotent`, `pointer_block_is_invisible_to_the_section_reader`.
+pub fn ensure_compiled_pointer(project_dir: &Path) -> Result<WriteOutcome, WriteRejection> {
+    let path = host_path(project_dir);
+    let (text, existed) = read_host(&path)?;
+    let block = render_pointer();
+
+    let spans = pointer_spans(&text);
+    let next = if spans.is_empty() {
+        append_block(&text, &block)
+    } else {
+        splice(&text, &spans, &block)
+    };
+
+    if existed && next == text {
+        return Ok(WriteOutcome::Unchanged);
+    }
+    let outcome = match (existed, spans.is_empty()) {
+        (false, _) => WriteOutcome::Created,
+        (true, true) => WriteOutcome::Inserted,
+        (true, false) => WriteOutcome::Replaced,
+    };
+    persist(&path, &next, outcome)
+}
+
+/// Locate the managed pointer block's line span, if present.
+///
+/// Why: the pointer is deliberately outside the marker grammar, so
+/// [`locate_blocks`] cannot find it and this small paired scan is required. It
+/// stays conservative in the same direction as the reader: an unpaired begin
+/// marker yields no span, so the block is appended rather than the file being
+/// rewritten around a delimiter whose extent is unknown.
+/// What: at most one `(start, end)` span, matching trimmed delimiter lines.
+/// Test: `pointer_write_is_idempotent`,
+/// `an_unpaired_pointer_marker_does_not_consume_the_file`.
+fn pointer_spans(text: &str) -> Vec<(usize, usize)> {
+    let mut start = None;
+    for (index, line) in text.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed == POINTER_BEGIN {
+            start = Some(index);
+        } else if trimmed == POINTER_END
+            && let Some(open) = start
+        {
+            return vec![(open, index)];
+        }
+    }
+    Vec::new()
+}
+
+// A `remove_section_override` counterpart is deliberately absent. Removing a
+// block means reverting to the bundled section, which the reader already does
+// for an ABSENT block — so deletion has a safe spelling a caller can reach
+// without a code path whose bug mode is "deleted more of CLAUDE.md than asked".
+// Add it only with a caller that needs it, per issue #4754's minimalism note.
+
+#[cfg(test)]
+#[path = "claude_md_writer_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/claude_md_writer_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_writer_tests.rs
@@ -620,3 +620,119 @@ fn pointer_and_section_block_coexist() {
         "the pointer must survive a later section rewrite"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Review follow-ups (#4762): line endings, the EOF replace path, pointer
+// duplicate collapse.
+// ---------------------------------------------------------------------------
+
+/// A block spliced into a CRLF host must be CRLF too. Without this the writer
+/// leaves a mixed-ending file — a user-visible defect in a file the project
+/// owns. The assertion is that NO bare LF survives anywhere.
+#[test]
+fn matches_the_hosts_crlf_line_endings() {
+    let dir = project();
+    seed(dir.path(), "# Project\r\n\r\nExisting prose.\r\n");
+
+    write_section_override(dir.path(), SectionId::Workflow, "line one\nline two")
+        .expect("write accepted");
+
+    let text = read(dir.path());
+    assert!(
+        !text.replace("\r\n", "").contains('\n'),
+        "no bare LF may survive in a CRLF host:\n{text:?}"
+    );
+    assert!(text.contains("\r\n"), "the file is still CRLF");
+    // And the reader still resolves the multi-line body correctly.
+    assert_eq!(
+        scan_project(dir.path()).overrides[0].body,
+        "line one\nline two"
+    );
+}
+
+/// The dominant ending wins in a mixed host, rather than the first one seen.
+#[test]
+fn a_mixed_ending_host_takes_the_dominant_ending() {
+    let dir = project();
+    // One LF line, three CRLF lines: CRLF dominates.
+    seed(dir.path(), "lf-line\r\na\r\nb\r\nc\n");
+
+    write_section_override(dir.path(), SectionId::Memory, "BODY").expect("write accepted");
+
+    let text = read(dir.path());
+    let appended = &text[text.find("TRUSTY-MPM").expect("marker present")..];
+    assert!(
+        !appended.replace("\r\n", "").contains('\n'),
+        "the appended block must use the dominant CRLF ending:\n{appended:?}"
+    );
+}
+
+/// Replacing a block that sits at end-of-file in a host with NO trailing
+/// newline must not invent one. This is the `splice` EOF branch, which was
+/// previously reachable only by inspection.
+#[test]
+fn replacing_a_trailing_block_preserves_a_missing_final_newline() {
+    let dir = project();
+    let token = section_token(SectionId::Workflow);
+    // No trailing newline after the END marker — the block ends the file.
+    seed(
+        dir.path(),
+        &format!(
+            "intro\n<!-- TRUSTY-MPM: {token} START v=1 -->\nOLD\n<!-- TRUSTY-MPM: {token} END -->"
+        ),
+    );
+    assert!(
+        !read(dir.path()).ends_with('\n'),
+        "premise: the fixture has no final newline"
+    );
+
+    write_section_override(dir.path(), SectionId::Workflow, "NEW").expect("write accepted");
+
+    let text = read(dir.path());
+    assert!(
+        !text.ends_with('\n'),
+        "the missing final newline must be preserved, got:\n{text:?}"
+    );
+    assert!(text.starts_with("intro\n"), "prefix preserved");
+    let scanned = scan_project(dir.path());
+    assert_eq!(scanned.overrides.len(), 1, "{:?}", scanned.diagnostics);
+    assert_eq!(scanned.overrides[0].body, "NEW");
+}
+
+/// A host that already carries two pointer blocks is collapsed to one, matching
+/// the section-override rule. The fixture seeds genuine duplicates, so the test
+/// cannot pass unless the collapse actually happens.
+#[test]
+fn pointer_write_collapses_duplicate_pointer_blocks() {
+    let dir = project();
+    seed(
+        dir.path(),
+        &format!(
+            "intro\n\
+             {POINTER_BEGIN}\n> stale first copy\n{POINTER_END}\n\
+             middle\n\
+             {POINTER_BEGIN}\n> stale second copy\n{POINTER_END}\n\
+             outro\n"
+        ),
+    );
+    assert_eq!(
+        read(dir.path()).matches(POINTER_BEGIN).count(),
+        2,
+        "premise: two pointer blocks"
+    );
+
+    ensure_compiled_pointer(dir.path()).expect("write accepted");
+
+    let text = read(dir.path());
+    assert_eq!(
+        text.matches(POINTER_BEGIN).count(),
+        1,
+        "duplicates must be collapsed:\n{text}"
+    );
+    assert!(!text.contains("stale first copy"));
+    assert!(!text.contains("stale second copy"));
+    assert!(text.contains(COMPILED_INSTRUCTIONS_PATH));
+    for kept in ["intro", "middle", "outro"] {
+        assert!(text.contains(kept), "unrelated prose `{kept}` must survive");
+    }
+}

--- a/crates/trusty-mpm/src/core/claude_md_writer_tests.rs
+++ b/crates/trusty-mpm/src/core/claude_md_writer_tests.rs
@@ -1,0 +1,622 @@
+//! Tests for the `CLAUDE.md` writer (issue #4754).
+//!
+//! Every test here asserts against the READER (`claude_md_sections::scan_project`)
+//! rather than against a string the writer also produced. A writer test that
+//! only checked the writer's own output would pass happily while emitting blocks
+//! the reader declines — the advertised-but-unread failure (#381) this pairing
+//! exists to prevent. Where a test does inspect raw bytes it is because the
+//! property under test IS a byte property (preservation, line endings).
+
+use std::path::{Path, PathBuf};
+
+use tempfile::TempDir;
+
+use super::*;
+use crate::core::claude_md_sections::{REASON_DUPLICATE, scan_project};
+
+/// A project root with no `CLAUDE.md` yet.
+fn project() -> TempDir {
+    TempDir::new().expect("temp project dir")
+}
+
+/// The host path inside a scratch project.
+fn host(dir: &Path) -> PathBuf {
+    dir.join("CLAUDE.md")
+}
+
+/// Read the host, or empty string when absent.
+fn read(dir: &Path) -> String {
+    std::fs::read_to_string(host(dir)).unwrap_or_default()
+}
+
+/// Seed the host with exact bytes.
+fn seed(dir: &Path, text: &str) {
+    std::fs::write(host(dir), text).expect("seed CLAUDE.md");
+}
+
+/// Count `START` marker lines for one section in the host.
+fn start_marker_count(dir: &Path, section: SectionId) -> usize {
+    let needle = format!("TRUSTY-MPM: {} START", section_token(section));
+    read(dir).lines().filter(|l| l.contains(&needle)).count()
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour 1 — write a named section-override block
+// ---------------------------------------------------------------------------
+
+/// The written block must be one the READER accepts, with the body intact.
+#[test]
+fn writes_a_new_block_a_reader_accepts() {
+    let dir = project();
+    let outcome = write_section_override(dir.path(), SectionId::Workflow, "CUSTOM WORKFLOW")
+        .expect("write accepted");
+    assert_eq!(outcome, WriteOutcome::Created);
+
+    let scanned = scan_project(dir.path());
+    assert_eq!(
+        scanned.overrides.len(),
+        1,
+        "reader must see exactly one override"
+    );
+    assert_eq!(scanned.overrides[0].section, SectionId::Workflow);
+    assert_eq!(scanned.overrides[0].body, "CUSTOM WORKFLOW");
+    assert!(
+        scanned.diagnostics.is_empty(),
+        "a freshly written block must raise no diagnostics: {:?}",
+        scanned.diagnostics
+    );
+}
+
+/// The emitted `v=` must be the version the reader implements. Hardcoding `1`
+/// in the writer would pass a round-trip test today and silently emit
+/// unsupported blocks after the next bump; asserting the constant is what makes
+/// that drift impossible.
+#[test]
+fn written_block_declares_the_readers_supported_version() {
+    let dir = project();
+    write_section_override(dir.path(), SectionId::Memory, "BODY").expect("write accepted");
+
+    let text = read(dir.path());
+    assert!(
+        text.contains(&format!("START v={SUPPORTED_VERSION} -->")),
+        "block must stamp the reader's supported version, got:\n{text}"
+    );
+    assert_eq!(
+        scan_project(dir.path()).overrides.len(),
+        1,
+        "and the reader must accept that version"
+    );
+}
+
+/// The writer must target the reader's declared host, not a path of its own.
+#[test]
+fn writes_target_the_readers_only_host() {
+    let dir = project();
+    write_section_override(dir.path(), SectionId::Search, "BODY").expect("write accepted");
+
+    assert!(host(dir.path()).is_file(), "CLAUDE.md must exist");
+    assert_eq!(
+        HOST_FILES[0], "CLAUDE.md",
+        "writer follows the reader's host list"
+    );
+}
+
+/// A body is preserved exactly as authored through a full write/read round trip,
+/// including interior blank lines and markdown structure.
+#[test]
+fn round_trips_through_the_reader() {
+    let dir = project();
+    let body = "# Heading\n\n- bullet one\n- bullet two\n\nTrailing paragraph.";
+    write_section_override(dir.path(), SectionId::Enforcement, body).expect("write accepted");
+
+    let scanned = scan_project(dir.path());
+    assert_eq!(scanned.overrides[0].body, body);
+}
+
+/// The host is created when absent — the ordinary first-write case.
+#[test]
+fn creates_the_host_when_absent() {
+    let dir = project();
+    assert!(!host(dir.path()).exists(), "premise: no CLAUDE.md yet");
+
+    let outcome =
+        write_section_override(dir.path(), SectionId::Identity, "ID").expect("write accepted");
+    assert_eq!(outcome, WriteOutcome::Created);
+    assert!(host(dir.path()).is_file());
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour 2 — idempotent update, never a stacked second copy
+// ---------------------------------------------------------------------------
+
+/// The stacking regression in one assertion: apply twice, exactly one block.
+#[test]
+fn applying_twice_leaves_exactly_one_block() {
+    let dir = project();
+    write_section_override(dir.path(), SectionId::Workflow, "ONCE").expect("first write");
+    write_section_override(dir.path(), SectionId::Workflow, "ONCE").expect("second write");
+
+    assert_eq!(
+        start_marker_count(dir.path(), SectionId::Workflow),
+        1,
+        "a repeat write must never stack a second block:\n{}",
+        read(dir.path())
+    );
+    let scanned = scan_project(dir.path());
+    assert_eq!(scanned.overrides.len(), 1);
+    assert!(
+        !scanned
+            .diagnostics
+            .iter()
+            .any(|d| d.reason == REASON_DUPLICATE),
+        "no duplicate diagnostic may be raised: {:?}",
+        scanned.diagnostics
+    );
+}
+
+/// An identical repeat write is a reported no-op, not a silent rewrite.
+#[test]
+fn applying_the_same_override_twice_reports_unchanged() {
+    let dir = project();
+    write_section_override(dir.path(), SectionId::Memory, "SAME").expect("first write");
+    let after_first = read(dir.path());
+
+    let outcome =
+        write_section_override(dir.path(), SectionId::Memory, "SAME").expect("second write");
+    assert_eq!(outcome, WriteOutcome::Unchanged);
+    assert_eq!(read(dir.path()), after_first, "bytes must not move");
+}
+
+/// A changed body replaces the old one in place — the reader must see only the
+/// new value, never the stale first-wins copy.
+#[test]
+fn replacing_updates_the_body_in_place() {
+    let dir = project();
+    write_section_override(dir.path(), SectionId::Workflow, "OLD VALUE").expect("first write");
+    let outcome =
+        write_section_override(dir.path(), SectionId::Workflow, "NEW VALUE").expect("second write");
+    assert_eq!(outcome, WriteOutcome::Replaced);
+
+    let scanned = scan_project(dir.path());
+    assert_eq!(scanned.overrides.len(), 1);
+    assert_eq!(
+        scanned.overrides[0].body, "NEW VALUE",
+        "the reader must resolve to the value just written"
+    );
+    assert!(
+        !read(dir.path()).contains("OLD VALUE"),
+        "the superseded body must be gone from the file"
+    );
+}
+
+/// A host that ALREADY carries two blocks for one section (the pre-existing
+/// stacked state) is collapsed to one by a write. The fixture seeds genuine
+/// duplicates, so the test cannot pass unless the writer actually removes the
+/// shadowed copy.
+#[test]
+fn replacing_collapses_duplicate_blocks_to_one() {
+    let dir = project();
+    let token = section_token(SectionId::Workflow);
+    seed(
+        dir.path(),
+        &format!(
+            "intro\n\n\
+             <!-- TRUSTY-MPM: {token} START v=1 -->\nFIRST\n<!-- TRUSTY-MPM: {token} END -->\n\n\
+             middle prose\n\n\
+             <!-- TRUSTY-MPM: {token} START v=1 -->\nSECOND\n<!-- TRUSTY-MPM: {token} END -->\n\n\
+             outro\n"
+        ),
+    );
+    // Premise: the reader really does see a duplicate before the write.
+    let before = scan_project(dir.path());
+    assert!(
+        before
+            .diagnostics
+            .iter()
+            .any(|d| d.reason == REASON_DUPLICATE),
+        "fixture must actually contain a duplicate the reader reports"
+    );
+
+    write_section_override(dir.path(), SectionId::Workflow, "MERGED").expect("write accepted");
+
+    assert_eq!(
+        start_marker_count(dir.path(), SectionId::Workflow),
+        1,
+        "duplicates must be collapsed:\n{}",
+        read(dir.path())
+    );
+    let after = scan_project(dir.path());
+    assert_eq!(after.overrides[0].body, "MERGED");
+    assert!(
+        after.diagnostics.is_empty(),
+        "no diagnostics should survive the collapse: {:?}",
+        after.diagnostics
+    );
+    let text = read(dir.path());
+    for kept in ["intro", "middle prose", "outro"] {
+        assert!(text.contains(kept), "unrelated prose `{kept}` must survive");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour 3 — decline CORE, and only CORE
+// ---------------------------------------------------------------------------
+
+/// `CORE` is refused and the host is left exactly as it was.
+#[test]
+fn core_is_declined_and_logged() {
+    let dir = project();
+    seed(dir.path(), "project prose\n");
+    let before = read(dir.path());
+
+    let err = write_section_override(dir.path(), SectionId::Core, "TAKE OVER")
+        .expect_err("CORE must be refused");
+    assert!(
+        matches!(
+            err,
+            WriteRejection::Protected {
+                section: SectionId::Core,
+                tier: CustomizationTier::Fixed
+            }
+        ),
+        "unexpected rejection: {err:?}"
+    );
+    assert_eq!(
+        read(dir.path()),
+        before,
+        "a refusal must not touch the file"
+    );
+}
+
+/// CORE is the ONLY protected section. Without this, `core_is_declined_and_logged`
+/// would still pass if the writer refused everything — the guard would be named
+/// but never exercised.
+#[test]
+fn every_other_section_is_writable() {
+    let dir = project();
+    let mut written = 0usize;
+
+    for section in SectionId::CANONICAL {
+        let result = write_section_override(dir.path(), section, &format!("BODY {section:?}"));
+        if section == SectionId::Core {
+            assert!(result.is_err(), "CORE must be refused");
+            continue;
+        }
+        result.unwrap_or_else(|e| panic!("{section:?} must be writable, got {e:?}"));
+        written += 1;
+    }
+
+    assert!(
+        written >= 8,
+        "expected the full non-core taxonomy, wrote {written}"
+    );
+    let scanned = scan_project(dir.path());
+    assert_eq!(
+        scanned.overrides.len(),
+        written,
+        "the reader must accept every block written: {:?}",
+        scanned.diagnostics
+    );
+    assert!(
+        !scanned
+            .overrides
+            .iter()
+            .any(|o| o.section == SectionId::Core),
+        "no CORE override may exist"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour 4 — preserve everything outside the markers verbatim
+// ---------------------------------------------------------------------------
+
+/// Prose around the block — including trailing whitespace the author chose —
+/// survives a replace byte for byte.
+#[test]
+fn preserves_surrounding_content_byte_for_byte() {
+    let dir = project();
+    let token = section_token(SectionId::Workflow);
+    let prefix = "# Project   \n\nLine with trailing spaces   \n\n";
+    let suffix = "\n\n## After\n\ttab-indented\t\n";
+    seed(
+        dir.path(),
+        &format!(
+            "{prefix}<!-- TRUSTY-MPM: {token} START v=1 -->\nOLD\n<!-- TRUSTY-MPM: {token} END -->\n{suffix}"
+        ),
+    );
+
+    write_section_override(dir.path(), SectionId::Workflow, "NEW").expect("write accepted");
+
+    let text = read(dir.path());
+    assert!(
+        text.starts_with(prefix),
+        "prefix must be byte-identical, got:\n{text:?}"
+    );
+    assert!(
+        text.ends_with(suffix),
+        "suffix must be byte-identical, got:\n{text:?}"
+    );
+}
+
+/// `\r\n` endings outside the block are not normalised away.
+#[test]
+fn preserves_crlf_line_endings() {
+    let dir = project();
+    let token = section_token(SectionId::Memory);
+    seed(
+        dir.path(),
+        &format!(
+            "alpha\r\nbeta\r\n<!-- TRUSTY-MPM: {token} START v=1 -->\r\nOLD\r\n<!-- TRUSTY-MPM: {token} END -->\r\nomega\r\n"
+        ),
+    );
+
+    write_section_override(dir.path(), SectionId::Memory, "NEW").expect("write accepted");
+
+    let text = read(dir.path());
+    assert!(text.starts_with("alpha\r\nbeta\r\n"), "got:\n{text:?}");
+    assert!(text.ends_with("omega\r\n"), "got:\n{text:?}");
+    assert_eq!(scan_project(dir.path()).overrides[0].body, "NEW");
+}
+
+/// Appending to existing prose keeps that prose and separates the block.
+#[test]
+fn appends_after_existing_prose() {
+    let dir = project();
+    seed(dir.path(), "# Existing\n\nSome rules.\n");
+
+    let outcome =
+        write_section_override(dir.path(), SectionId::Search, "SEARCH RULES").expect("write");
+    assert_eq!(outcome, WriteOutcome::Inserted);
+
+    let text = read(dir.path());
+    assert!(text.starts_with("# Existing\n\nSome rules.\n"));
+    assert_eq!(scan_project(dir.path()).overrides[0].body, "SEARCH RULES");
+}
+
+/// A file with no final newline must not have its last line swallowed into the
+/// marker line.
+#[test]
+fn appends_newline_when_existing_file_lacks_trailing_newline() {
+    let dir = project();
+    seed(dir.path(), "no trailing newline");
+
+    write_section_override(dir.path(), SectionId::Search, "BODY").expect("write accepted");
+
+    let text = read(dir.path());
+    assert!(
+        text.starts_with("no trailing newline\n"),
+        "last line must stay its own line, got:\n{text:?}"
+    );
+    let scanned = scan_project(dir.path());
+    assert_eq!(scanned.overrides.len(), 1, "{:?}", scanned.diagnostics);
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour 5 — fail toward more framework instruction, never a corrupt file
+// ---------------------------------------------------------------------------
+
+/// An empty or whitespace-only body never blanks a section.
+#[test]
+fn empty_body_is_refused() {
+    let dir = project();
+    for body in ["", "   ", "\n\t\n"] {
+        let err = write_section_override(dir.path(), SectionId::Workflow, body)
+            .expect_err("empty body must be refused");
+        assert!(matches!(err, WriteRejection::EmptyBody { .. }), "{err:?}");
+    }
+    assert!(
+        !host(dir.path()).exists(),
+        "a refused write must not even create the host"
+    );
+}
+
+/// A body carrying its own marker line is refused. Were it written, the nested
+/// `START` would make the reader DISCARD the outer block — deleting the very
+/// section the author was setting.
+#[test]
+fn body_containing_a_marker_line_is_refused() {
+    let dir = project();
+    seed(dir.path(), "untouched\n");
+    let before = read(dir.path());
+
+    let hostile = "legit line\n<!-- TRUSTY-MPM: MEMORY START v=1 -->\nsmuggled\n";
+    let err = write_section_override(dir.path(), SectionId::Workflow, hostile)
+        .expect_err("a marker line in the body must be refused");
+    assert!(
+        matches!(err, WriteRejection::BodyContainsMarker { .. }),
+        "{err:?}"
+    );
+    assert_eq!(read(dir.path()), before, "file must be untouched");
+}
+
+/// The marker screen uses the reader's recogniser, not a substring search:
+/// prose that MENTIONS the marker inline is legal content and must still be
+/// writable. Without this, the guard above could be satisfied by a blunt
+/// `contains("TRUSTY-MPM:")` that silently blocks legitimate documentation.
+#[test]
+fn body_mentioning_the_marker_in_prose_is_written() {
+    let dir = project();
+    let body = "Use `<!-- TRUSTY-MPM: WORKFLOW START v=1 -->` to open a block.";
+
+    write_section_override(dir.path(), SectionId::Workflow, body)
+        .expect("prose mentioning a marker must be writable");
+
+    let scanned = scan_project(dir.path());
+    assert_eq!(scanned.overrides.len(), 1, "{:?}", scanned.diagnostics);
+    assert_eq!(scanned.overrides[0].body, body);
+}
+
+/// A host whose markers are unpaired is not edited at all. Splicing into a file
+/// whose block extents are unknown is how a writer destroys content.
+#[test]
+fn an_unclosed_marker_blocks_the_write() {
+    let dir = project();
+    let token = section_token(SectionId::Workflow);
+    seed(
+        dir.path(),
+        &format!("prose\n<!-- TRUSTY-MPM: {token} START v=1 -->\ndangling body\n"),
+    );
+    let before = read(dir.path());
+
+    let err = write_section_override(dir.path(), SectionId::Workflow, "NEW")
+        .expect_err("an unclosed marker must block the write");
+    assert!(
+        matches!(err, WriteRejection::HostMalformed { .. }),
+        "{err:?}"
+    );
+    assert_eq!(read(dir.path()), before, "file must be byte-identical");
+}
+
+/// A host that cannot be read is reported, never overwritten. A directory at the
+/// host path reproduces an unreadable host on every platform without depending
+/// on file permissions.
+#[test]
+fn unreadable_host_is_reported_not_clobbered() {
+    let dir = project();
+    std::fs::create_dir(host(dir.path())).expect("directory at the host path");
+
+    let err = write_section_override(dir.path(), SectionId::Workflow, "BODY")
+        .expect_err("an unreadable host must be reported");
+    assert!(matches!(err, WriteRejection::Io(_)), "{err:?}");
+    assert!(
+        host(dir.path()).is_dir(),
+        "the writer must not have replaced it"
+    );
+}
+
+/// Every refusal path leaves the host byte-identical — stated once, over all of
+/// them, so a new rejection variant cannot quietly skip the guarantee.
+#[test]
+fn refusals_leave_the_file_byte_identical() {
+    let token = section_token(SectionId::Workflow);
+    let cases: Vec<(&str, String, SectionId, String)> = vec![
+        (
+            "protected section",
+            "prose\n".to_string(),
+            SectionId::Core,
+            "BODY".to_string(),
+        ),
+        (
+            "empty body",
+            "prose\n".to_string(),
+            SectionId::Workflow,
+            "  ".to_string(),
+        ),
+        (
+            "marker in body",
+            "prose\n".to_string(),
+            SectionId::Workflow,
+            format!("<!-- TRUSTY-MPM: {token} END -->"),
+        ),
+        (
+            "unclosed host",
+            format!("<!-- TRUSTY-MPM: {token} START v=1 -->\nx\n"),
+            SectionId::Workflow,
+            "BODY".to_string(),
+        ),
+    ];
+
+    for (label, seeded, section, body) in cases {
+        let dir = project();
+        seed(dir.path(), &seeded);
+        let before = read(dir.path());
+
+        write_section_override(dir.path(), section, &body)
+            .expect_err(&format!("{label} must be refused"));
+
+        assert_eq!(read(dir.path()), before, "{label} must not alter the file");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Behaviour 6 — the compiled-instructions pointer
+// ---------------------------------------------------------------------------
+
+/// The pointer names the compiled prompt path, visibly.
+#[test]
+fn pointer_block_names_the_compiled_instructions_path() {
+    let dir = project();
+    ensure_compiled_pointer(dir.path()).expect("pointer written");
+
+    let text = read(dir.path());
+    assert!(
+        text.contains(COMPILED_INSTRUCTIONS_PATH),
+        "pointer must name the compiled path, got:\n{text}"
+    );
+    assert!(text.contains(POINTER_BEGIN) && text.contains(POINTER_END));
+}
+
+/// The pointer must be inert to the section reader: no override, and — the part
+/// that actually matters — no `unknown section token` diagnostic. A delimiter
+/// spelled inside the `TRUSTY-MPM:` namespace would trip that, so this test is
+/// what keeps the pointer out of the marker grammar.
+#[test]
+fn pointer_block_is_invisible_to_the_section_reader() {
+    let dir = project();
+    ensure_compiled_pointer(dir.path()).expect("pointer written");
+
+    let scanned = scan_project(dir.path());
+    assert!(
+        scanned.overrides.is_empty(),
+        "pointer must contribute no override: {:?}",
+        scanned.overrides
+    );
+    assert!(
+        scanned.diagnostics.is_empty(),
+        "pointer must raise no diagnostic: {:?}",
+        scanned.diagnostics
+    );
+}
+
+/// Writing the pointer twice leaves exactly one.
+#[test]
+fn pointer_write_is_idempotent() {
+    let dir = project();
+    ensure_compiled_pointer(dir.path()).expect("first");
+    let after_first = read(dir.path());
+
+    let outcome = ensure_compiled_pointer(dir.path()).expect("second");
+    assert_eq!(outcome, WriteOutcome::Unchanged);
+    assert_eq!(read(dir.path()), after_first);
+    assert_eq!(
+        read(dir.path()).matches(POINTER_BEGIN).count(),
+        1,
+        "exactly one pointer block"
+    );
+}
+
+/// An unpaired pointer begin marker must not make the writer treat the rest of
+/// the file as the block's body.
+#[test]
+fn an_unpaired_pointer_marker_does_not_consume_the_file() {
+    let dir = project();
+    seed(dir.path(), &format!("{POINTER_BEGIN}\nstranded prose\n"));
+
+    ensure_compiled_pointer(dir.path()).expect("write accepted");
+
+    let text = read(dir.path());
+    assert!(
+        text.contains("stranded prose"),
+        "content after an unpaired marker must survive, got:\n{text}"
+    );
+    assert!(text.contains(COMPILED_INSTRUCTIONS_PATH));
+}
+
+/// A section override and the pointer occupy independent regions.
+#[test]
+fn pointer_and_section_block_coexist() {
+    let dir = project();
+    write_section_override(dir.path(), SectionId::Workflow, "WF").expect("section write");
+    ensure_compiled_pointer(dir.path()).expect("pointer write");
+    write_section_override(dir.path(), SectionId::Workflow, "WF2").expect("section rewrite");
+
+    let scanned = scan_project(dir.path());
+    assert_eq!(scanned.overrides.len(), 1, "{:?}", scanned.diagnostics);
+    assert_eq!(scanned.overrides[0].body, "WF2");
+    assert!(scanned.diagnostics.is_empty(), "{:?}", scanned.diagnostics);
+    assert_eq!(
+        read(dir.path()).matches(POINTER_BEGIN).count(),
+        1,
+        "the pointer must survive a later section rewrite"
+    );
+}

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -42,6 +42,10 @@ pub mod claude_env_scrub;
 // overrides. Ships before the floor text that advertises the mechanism —
 // advertising an override no code reads is issue #381 verbatim.
 pub mod claude_md_sections;
+// Issue #4754: the WRITER counterpart to `claude_md_sections` — the single
+// owner of `CLAUDE.md` section-override edits. Idempotent by construction, and
+// it borrows the reader's grammar rather than spelling a second one.
+pub mod claude_md_writer;
 // Issue #4072: one process-wide lock every `~/.claude.json` read-modify-write
 // seeder holds, so concurrent daemon provisioning cannot lose a trust entry.
 pub mod claude_json_guard;


### PR DESCRIPTION
PR1 of the #4754 split. The `tm-scaffold` skill itself (PR2) waits for the
`bundle_all.rs` fence to clear; orphan handling is PR3. This PR touches no
fenced file.

## Why

`core::claude_md_sections` is explicitly reader-only ("Scope: reader only"), so
every write to a project's `CLAUDE.md` has so far been done by hand — by an LLM
following prose in `tm-init` — against a grammar only the reader knows.

Prose cannot be idempotent. The same hand-merged pattern stacked five copies
into the shared `## [Unreleased]` changelog section (#4463–#4475; #4399 burned
three rebase rounds), which is why changelog entries moved to per-PR fragments.
A stacked *section override* is worse than a stacked changelog entry: the reader
keeps the FIRST well-formed block and reports the rest as `REASON_DUPLICATE`, so
the copy the author just wrote is the one silently ignored.

## What

`core::claude_md_writer` — the write-side counterpart.

| Behaviour | How it holds |
|---|---|
| Write a named block | `write_section_override`, emitting the reader's grammar |
| Idempotent | Replaces in place and collapses pre-existing duplicates: exactly one block per section survives |
| Decline `CORE` | Asks `CustomizationTier::permits`; refused because the package declares it `fixed`, with a logged warning |
| Preserve outside verbatim | Splices by line span over `split_inclusive('\n')`, so `\r\n` and trailing whitespace survive byte-for-byte |
| Fail toward more instruction | Protected section, empty body, marker line in the body, unpaired marker in the host, unreadable host → file byte-identical, bundled section in force |
| Pointer to the compiled prompt | `ensure_compiled_pointer` names `~/.trusty-mpm/framework/INSTRUCTIONS-COMPILED.md` — referenced, not implemented |

**The grammar is not duplicated.** The writer borrows the reader's recogniser
through three new `pub(crate)` accessors — `SUPPORTED_VERSION`,
`contains_marker_line`, `locate_blocks` — so a writer/reader divergence cannot
be expressed. Every writer test asserts through `scan_project`, not against a
string the writer also produced.

Two design points worth a reviewer's attention:

- **The pointer is deliberately outside the marker grammar.** Its delimiters
  (`<!-- trusty-mpm compiled-instructions pointer >>> -->`) fail the
  `TRUSTY-MPM:` namespace test, so the reader treats the block as ordinary prose
  and raises no `unknown section token` diagnostic. `pointer_block_is_invisible_to_the_section_reader` pins that.
- **A body containing a marker line is refused.** Writing one would nest a
  `START`, and the reader resolves nesting by discarding the *outer* block —
  deleting the very section being set. The screen uses the reader's recogniser,
  not a substring match, so prose *mentioning* a marker stays writable
  (`body_mentioning_the_marker_in_prose_is_written`).

No `remove_section_override` is included: deleting a block already has a safe
spelling (an absent block reverts to bundled), so a delete path whose bug mode
is "removed more of CLAUDE.md than asked" is not worth adding without a caller.

## Test ladder

Rung 3 — localized behavior inside one crate.

Each guard was **mutation-tested**: disabling the span reuse, the tier check,
the marker screen, and the unclosed-host guard each fails its own named test, so
no fixture names a guard it does not exercise.

`every_other_section_is_writable` exists specifically so `core_is_declined_and_logged`
cannot pass by refusing everything.

```
cargo fmt --check                        exit 0
cargo check -p trusty-mpm                Finished
cargo clippy -p trusty-mpm --all-targets -- -D warnings   Finished
cargo test -p trusty-mpm                 exit 0 — lib: 4368 passed; 0 failed; 7 ignored
bash scripts/check_line_cap.sh           3625 files, 0 violations — OK
bash scripts/check_sld.sh                0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh OK
```

New coverage: 23 writer tests + 3 locator tests, all in temp dirs. This diff
changes no root `CLAUDE.md` (`git diff --name-only origin/main...HEAD` lists
only the six files above).

> **Correction to the brief I was given.** It stated the root `CLAUDE.md` is not
> tracked on main and that `claude-md-guard` forbids tracking it (#2299). Both
> are stale: `CLAUDE.md` has been tracked on main deliberately since #4286 split
> C (`2e8a36be`, "migrate to tracked root CLAUDE.md"), and no `claude-md-guard`
> workflow or script exists in the tree any more. Nothing here depended on that
> premise — the tests use temp dirs because that is correct for a filesystem
> writer, not to dodge a guard — but the constraint should not be re-issued to
> the next agent as written.

Refs #4754

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
