### PR TITLE
fix(trusty-search): stop the embedder silently downgrading MPS/Python to CPU/ort (#4125)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11535,7 +11535,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-embedderd-py"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "fs4 0.8.4",
@@ -11799,7 +11799,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-common/changelog.d/4125-resolve-binary-fallback-test-seam.md
+++ b/crates/trusty-common/changelog.d/4125-resolve-binary-fallback-test-seam.md
@@ -1,0 +1,8 @@
+Changed
+
+- `bin_resolve::resolve_binary` now delegates to an internal
+  `resolve_binary_in`, which takes the well-known-directory fallback list as a
+  parameter. Behaviour is identical; the seam exists so the fallback branch —
+  "find a binary the process `PATH` does not list", the branch a launchd-spawned
+  daemon depends on — can be tested without mutating the process-global `PATH`
+  (#4125)

--- a/crates/trusty-common/src/bin_resolve.rs
+++ b/crates/trusty-common/src/bin_resolve.rs
@@ -111,9 +111,30 @@ pub fn daemon_path_env() -> String {
 /// an existing `dir/name`; the first hit is returned. Returns `None` if nothing
 /// matches.
 /// Test: `resolve_binary_finds_in_well_known_dir`,
+/// `resolve_binary_finds_a_binary_outside_the_process_path`,
 /// `resolve_binary_returns_none_for_missing`,
 /// `resolve_binary_accepts_absolute_path`.
 pub fn resolve_binary(name: &str) -> Option<PathBuf> {
+    resolve_binary_in(name, &daemon_path_dirs())
+}
+
+/// [`resolve_binary`] with the fallback directory list supplied by the caller.
+///
+/// Why (#4125): the fallback half of [`resolve_binary`] — the half that makes a
+/// launchd-spawned daemon able to find a Homebrew binary its minimal `PATH`
+/// omits — had no test that actually exercised it. The existing
+/// `resolve_binary_finds_in_well_known_dir` deliberately avoids mutating the
+/// process-global `PATH` (that races the parallel harness), so it could only
+/// test [`candidate`] and the explicit-path branch; the real
+/// "found somewhere the process `PATH` does not list" behaviour went unproven,
+/// which is exactly the behaviour `locate_uv` was missing when it hard-failed
+/// the py-embedder bootstrap on a daemon whose `PATH` lacked
+/// `/opt/homebrew/bin`. Parameterizing the fallback list makes that branch
+/// directly testable against a temp dir with no `PATH` mutation at all.
+/// What: identical to [`resolve_binary`] except `fallback_dirs` replaces
+/// [`daemon_path_dirs`] as step 2's search list.
+/// Test: `resolve_binary_finds_a_binary_outside_the_process_path`.
+fn resolve_binary_in(name: &str, fallback_dirs: &[PathBuf]) -> Option<PathBuf> {
     // An explicit path (absolute or relative with a separator) is used verbatim.
     if name.contains(std::path::MAIN_SEPARATOR) {
         let p = PathBuf::from(name);
@@ -130,8 +151,8 @@ pub fn resolve_binary(name: &str) -> Option<PathBuf> {
     }
 
     // 2) Fall back to the well-known daemon dirs (covers launchd's minimal PATH).
-    for dir in daemon_path_dirs() {
-        if let Some(hit) = candidate(&dir, name) {
+    for dir in fallback_dirs {
+        if let Some(hit) = candidate(dir, name) {
             return Some(hit);
         }
     }
@@ -549,6 +570,39 @@ mod tests {
         // mutation required.
         let explicit = bin.to_str().expect("utf8 temp path");
         assert_eq!(resolve_binary(explicit).as_deref(), Some(bin.as_path()));
+
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    /// Why (#4125): this is the branch that makes a launchd-spawned daemon
+    /// able to run a binary its inherited `PATH` never mentions —
+    /// `/opt/homebrew/bin/uv` being the case that broke the py-embedder
+    /// bootstrap, because `locate_uv` used a bare `which::which("uv")` with no
+    /// fallback at all. Nothing previously asserted that fallback works:
+    /// `resolve_binary_finds_in_well_known_dir` avoids `PATH` mutation and so
+    /// only reaches [`candidate`] and the explicit-path branch.
+    /// What: plants an executable in a temp dir that is NOT on the process
+    /// `PATH`, confirms a plain [`resolve_binary`] therefore misses it (the
+    /// `which`-equivalent answer), then confirms [`resolve_binary_in`] finds it
+    /// once that dir is in the fallback list. Against a PATH-only resolver the
+    /// second assertion fails.
+    /// Test: this test.
+    #[test]
+    fn resolve_binary_finds_a_binary_outside_the_process_path() {
+        let tmp = make_temp_dir("outside_path");
+        let name = "trusty-fake-uv-4125";
+        let bin = tmp.join(name);
+        write_executable(&bin);
+
+        assert!(
+            resolve_binary(name).is_none(),
+            "fixture dir must not be on the process PATH for this test to mean anything"
+        );
+        assert_eq!(
+            resolve_binary_in(name, std::slice::from_ref(&tmp)).as_deref(),
+            Some(bin.as_path()),
+            "a binary outside the process PATH must still resolve from the fallback dirs"
+        );
 
         std::fs::remove_dir_all(&tmp).ok();
     }

--- a/crates/trusty-embedderd-py/Cargo.toml
+++ b/crates/trusty-embedderd-py/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-embedderd-py"
-version = "0.1.1"
+version = "0.1.2"
 publish = true
 edition = "2021"
 license.workspace = true

--- a/crates/trusty-embedderd-py/changelog.d/4125-timeout-is-not-a-broken-venv.md
+++ b/crates/trusty-embedderd-py/changelog.d/4125-timeout-is-not-a-broken-venv.md
@@ -1,0 +1,15 @@
+Fixed
+
+- A `.ready` venv recheck that runs out of time is no longer treated as proof
+  the venv is broken. The eager, once-per-daemon-start `import
+  sentence_transformers` recheck ran under a flat 10 s budget while the daemon
+  warm-booted hundreds of indexes, so torch's import routinely exceeded it and
+  an intact venv was condemned to a full rebuild. A timeout is now a distinct
+  outcome (retried once with a much larger budget, then reported as
+  indeterminate and the venv reused) rather than a verification failure (#4125)
+- `uv` discovery no longer looks only at the live `PATH`. `uv` lives in
+  `/opt/homebrew/bin`, which launchd's minimal daemon `PATH` omits, so every
+  needless rebuild hard-failed with "`uv` not found on PATH" and pinned
+  trusty-search on the Rust ort embedder for the rest of the daemon's lifetime.
+  Discovery now goes through `trusty_common::bin_resolve::resolve_binary`, the
+  shared resolver added for the same bug class in #1298 (#4125)

--- a/crates/trusty-embedderd-py/src/bootstrap.rs
+++ b/crates/trusty-embedderd-py/src/bootstrap.rs
@@ -140,9 +140,74 @@ fn bootstrap_timeout() -> Duration {
     Duration::from_secs(secs)
 }
 
-/// Bound on the FULL import recheck (see [`verify_full_import_smoke`]) — the
-/// eager, once-per-daemon-start path only.
+/// FIRST-attempt bound on the FULL import recheck (see
+/// [`verify_full_import_smoke`]) — the eager, once-per-daemon-start path only.
+/// A recheck that outlives this is retried once with
+/// [`FULL_RECHECK_RETRY_TIMEOUT`], never failed outright (#4125).
 const FULL_RECHECK_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Bound on the ONE retry of the full import recheck (#4125).
+///
+/// Why: the eager recheck runs while trusty-search's daemon is simultaneously
+/// warm-booting hundreds of indexes, so torch's import routinely outlives the
+/// first, deliberately-short budget under purely self-inflicted startup
+/// contention. Retrying with a budget several times larger — rather than
+/// raising the first one, which would just move the same fixed-budget cliff —
+/// lets an intact-but-starved venv finish and prove itself, and it costs the
+/// extra wait only on the rare boot that needs it. The killed first attempt
+/// also leaves the interpreter and torch's shared objects warm in the page
+/// cache, so the retry is typically far faster than the attempt it follows.
+const FULL_RECHECK_RETRY_TIMEOUT: Duration = Duration::from_secs(60);
+
+/// What a bounded venv recheck actually established (#4125).
+///
+/// Why: the recheck helpers used to return a bare `bool`, which forced a
+/// timeout to be reported as `false` — i.e. as PROOF the venv is broken. It is
+/// not proof of anything: it means the check ran out of time. Under the
+/// daemon's own warm-boot contention that misreading fired on nearly every
+/// start, condemning a perfectly intact venv to a full rebuild (which then hard
+/// -failed on `uv` discovery and pinned the daemon on ort for its lifetime).
+/// This is the same "slow is not broken" conflation #4333 fixed for a corpus
+/// open timeout being reported as a corrupt corpus; the fix is the same shape —
+/// make the transient outcome a distinct, named third state that callers must
+/// handle deliberately.
+/// What: [`Passed`](Self::Passed) and [`Failed`](Self::Failed) are real
+/// evidence (the check ran to completion); [`Indeterminate`](Self::Indeterminate)
+/// is the absence of evidence and is produced only by a timeout.
+/// Test: `bounded_python_check_classifies_timeout_apart_from_failure`,
+/// `ensure_venv_does_not_rebuild_on_an_indeterminate_recheck`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum RecheckOutcome {
+    /// The check completed and the venv proved itself.
+    Passed,
+    /// The check completed and the venv failed it — a spawn error, a poll
+    /// error, or a non-zero exit. Real evidence of a broken venv.
+    Failed,
+    /// The check did not complete within its budget. Evidence of nothing: the
+    /// venv may be perfectly intact and merely starved of CPU/IO.
+    Indeterminate,
+}
+
+impl RecheckOutcome {
+    /// May the already-`.ready` venv be reused on this outcome?
+    ///
+    /// Why (#4125): only [`Failed`](Self::Failed) is evidence against the venv.
+    /// An [`Indeterminate`](Self::Indeterminate) result must NOT trigger a
+    /// rebuild — the `.ready` sentinel was written only after a real
+    /// import+embed smoke test passed, and a timed-out recheck adds no
+    /// information that contradicts it. The residual risk (trusting a venv that
+    /// is genuinely broken AND slow) is already covered downstream and
+    /// unchanged: the caller's readiness probe forces a real embed through the
+    /// supervisor before anything hot-swaps to python, and a failure there
+    /// leaves search on ort exactly as a failed rebuild would — but without
+    /// destroying a working venv on the way.
+    /// What: `true` for `Passed` and `Indeterminate`, `false` for `Failed`.
+    /// Test: `ensure_venv_does_not_rebuild_on_an_indeterminate_recheck`,
+    /// `ensure_venv_eager_rebuilds_when_full_recheck_fails`.
+    fn trusts_venv(self) -> bool {
+        !matches!(self, RecheckOutcome::Failed)
+    }
+}
 
 /// Bound on the cheap, torch-free liveness recheck (see [`verify_venv_alive`])
 /// — the per-respawn hot-path check. Shorter than [`FULL_RECHECK_TIMEOUT`]
@@ -194,7 +259,7 @@ enum RecheckDepth {
 }
 
 impl RecheckDepth {
-    fn verify(self, layout: &VenvLayout) -> bool {
+    fn verify(self, layout: &VenvLayout) -> RecheckOutcome {
         match self {
             RecheckDepth::Liveness => verify_venv_alive(layout),
             RecheckDepth::FullImport => verify_full_import_smoke(layout),
@@ -203,6 +268,19 @@ impl RecheckDepth {
 }
 
 fn ensure_venv_checked(depth: RecheckDepth) -> Result<VenvLayout> {
+    ensure_venv_verified(&|layout| depth.verify(layout))
+}
+
+/// [`ensure_venv_checked`] with the recheck itself injected (#4125).
+///
+/// Why: the behaviour that matters — an [`RecheckOutcome::Indeterminate`]
+/// recheck must NOT trigger a rebuild — is otherwise only reachable by actually
+/// exhausting the production budgets (70 s of real waiting). The seam lets a
+/// test assert the decision directly, in milliseconds, for every outcome.
+/// What: identical to [`ensure_venv_checked`]; `verify` replaces
+/// `depth.verify`.
+/// Test: `ensure_venv_does_not_rebuild_on_an_indeterminate_recheck`.
+fn ensure_venv_verified(verify: &dyn Fn(&VenvLayout) -> RecheckOutcome) -> Result<VenvLayout> {
     let layout = resolve_layout()?;
 
     // Fast path — already built for this lock.
@@ -215,15 +293,28 @@ fn ensure_venv_checked(depth: RecheckDepth) -> Result<VenvLayout> {
     // of falling back to the Rust ort path. `depth` controls how thoroughly
     // that recheck looks (see `RecheckDepth`).
     if is_ready(&layout) {
-        if depth.verify(&layout) {
-            tracing::debug!(venv = %layout.venv_dir.display(), "py-embedder venv already ready");
-            return Ok(layout);
+        match verify(&layout) {
+            RecheckOutcome::Passed => {
+                tracing::debug!(venv = %layout.venv_dir.display(), "py-embedder venv already ready");
+                return Ok(layout);
+            }
+            // #4125: a recheck that ran out of time is not evidence the venv is
+            // broken — reuse it instead of rebuilding on a timeout.
+            RecheckOutcome::Indeterminate => {
+                tracing::warn!(
+                    venv = %layout.venv_dir.display(),
+                    "py-embedder: `.ready` recheck did not finish in time (startup \
+                     contention, not a failed import) — reusing the venv; a genuinely \
+                     broken venv is still caught by the caller's readiness probe (#4125)"
+                );
+                return Ok(layout);
+            }
+            RecheckOutcome::Failed => tracing::warn!(
+                venv = %layout.venv_dir.display(),
+                "py-embedder: `.ready` sentinel present but the venv failed its \
+                 recheck (possibly corrupted) — rebuilding"
+            ),
         }
-        tracing::warn!(
-            venv = %layout.venv_dir.display(),
-            "py-embedder: `.ready` sentinel present but the venv failed its \
-             recheck (possibly corrupted) — rebuilding"
-        );
     }
 
     fs::create_dir_all(&layout.base)
@@ -243,7 +334,10 @@ fn ensure_venv_checked(depth: RecheckDepth) -> Result<VenvLayout> {
 
     // Double-checked: another process may have finished while we waited.
     let result = (|| {
-        if is_ready(&layout) && depth.verify(&layout) {
+        // #4125: `trusts_venv()` (not a bare bool) so a timed-out re-verify of a
+        // venv another process just finished building reuses it rather than
+        // starting a second, redundant rebuild.
+        if is_ready(&layout) && verify(&layout).trusts_venv() {
             tracing::info!("py-embedder: venv became ready while awaiting lock — reusing");
             return Ok(());
         }
@@ -299,15 +393,16 @@ fn site_packages_dir(layout: &VenvLayout) -> PathBuf {
 /// exist as a directory (a cheap `Path::is_dir`, no process spawn); (2)
 /// `<venv>/bin/python -c "import sys; sys.exit(0)"` must exit 0 within
 /// [`LIVENESS_CHECK_TIMEOUT`] — proves the interpreter starts and runs
-/// without touching torch.
+/// without touching torch. A timeout yields
+/// [`RecheckOutcome::Indeterminate`], never `Failed` (#4125).
 /// Test: `verify_venv_alive_*` in `bootstrap_tests.rs`.
-fn verify_venv_alive(layout: &VenvLayout) -> bool {
+fn verify_venv_alive(layout: &VenvLayout) -> RecheckOutcome {
     if !site_packages_dir(layout)
         .join("sentence_transformers")
         .is_dir()
     {
         tracing::warn!("py-embedder: liveness-recheck: sentence_transformers marker missing from site-packages");
-        return false;
+        return RecheckOutcome::Failed;
     }
     run_bounded_python_check(
         &layout.venv_python,
@@ -322,32 +417,80 @@ fn verify_venv_alive(layout: &VenvLayout) -> bool {
 ///
 /// What: runs `<venv>/bin/python -c "import sentence_transformers"` — an
 /// import only, NOT a full embed (no model download/load, no torch device
-/// init) — bounded by [`FULL_RECHECK_TIMEOUT`]. Returns `true` only on a
-/// clean, successful exit; any spawn failure, non-zero exit, or timeout
-/// returns `false` so the caller treats the venv as not-ready and rebuilds
-/// (and if the rebuild itself fails, that error propagates so
-/// `commands/start/embedder.rs`'s fall-back-to-ort path fires — the venv is
-/// never trusted on a failed recheck).
+/// init) — bounded by [`FULL_RECHECK_TIMEOUT`]. A spawn failure or non-zero
+/// exit is [`RecheckOutcome::Failed`] (the caller rebuilds; if the rebuild
+/// itself fails that error propagates so `commands/start/embedder.rs`'s
+/// fall-back-to-ort path fires — the venv is never trusted on a failed
+/// recheck).
+///
+/// #4125: a timeout is NOT such a failure. This check runs while
+/// trusty-search's daemon warm-boots hundreds of indexes, and torch's import
+/// routinely outlives a short fixed budget under that self-inflicted
+/// contention. So an over-budget first attempt is retried ONCE with
+/// [`FULL_RECHECK_RETRY_TIMEOUT`], and a second over-budget attempt reports
+/// [`RecheckOutcome::Indeterminate`] rather than `Failed` — see
+/// [`RecheckOutcome::trusts_venv`] for what the caller then does and why that
+/// is safe.
 ///
 /// Deliberately does NOT set `current_dir`/`PYTHONPATH` to `project_dir` (unlike
 /// [`smoke_test`], which imports our own bundled `trusty_embed_sidecar`
 /// package): this only imports the venv's own installed `sentence_transformers`
 /// from site-packages, so it stays correct even if `project_dir` were ever
 /// missing (e.g. manually deleted) while the venv itself is intact.
-fn verify_full_import_smoke(layout: &VenvLayout) -> bool {
-    run_bounded_python_check(
-        &layout.venv_python,
-        &["-c", "import sentence_transformers"],
-        FULL_RECHECK_TIMEOUT,
-        "full-import-recheck",
-    )
+/// Test: `verify_full_import_smoke_false_when_stub_exits_nonzero`,
+/// `full_import_recheck_retries_once_before_reporting_indeterminate`,
+/// `full_import_recheck_retry_lets_a_starved_venv_prove_itself`.
+fn verify_full_import_smoke(layout: &VenvLayout) -> RecheckOutcome {
+    verify_full_import_smoke_bounded(layout, FULL_RECHECK_TIMEOUT, FULL_RECHECK_RETRY_TIMEOUT)
+}
+
+/// [`verify_full_import_smoke`] with both budgets supplied by the caller, so
+/// tests can drive the timeout/retry path in milliseconds instead of the 70 s
+/// the production budgets would take (#4125).
+fn verify_full_import_smoke_bounded(
+    layout: &VenvLayout,
+    first: Duration,
+    retry: Duration,
+) -> RecheckOutcome {
+    let args = ["-c", "import sentence_transformers"];
+    match run_bounded_python_check(&layout.venv_python, &args, first, "full-import-recheck") {
+        // #4125: over budget once means "slow", not "broken" — give it a
+        // materially larger budget before drawing any conclusion at all.
+        RecheckOutcome::Indeterminate => {
+            tracing::info!(
+                "py-embedder: full-import-recheck exceeded {:?} (daemon startup \
+                 contention) — retrying once with {:?} before concluding anything",
+                first,
+                retry
+            );
+            run_bounded_python_check(
+                &layout.venv_python,
+                &args,
+                retry,
+                "full-import-recheck (retry)",
+            )
+        }
+        decided => decided,
+    }
 }
 
 /// Shared bounded spawn-and-poll helper for [`verify_venv_alive`] and
 /// [`verify_full_import_smoke`]: run `python <args>` to completion, killing it
-/// (and returning `false`) if it outlives `timeout`. `label` only tags the
-/// warn-log lines so the two call sites stay distinguishable in output.
-fn run_bounded_python_check(python: &Path, args: &[&str], timeout: Duration, label: &str) -> bool {
+/// if it outlives `timeout`. `label` only tags the log lines so the call sites
+/// stay distinguishable in output.
+///
+/// #4125: returns a three-state [`RecheckOutcome`] rather than a bool. A
+/// completed run maps to `Passed`/`Failed` by exit status; a spawn or poll
+/// error is `Failed` (the venv genuinely could not be exercised); running out
+/// of budget is `Indeterminate` and is deliberately NOT reported as a failed
+/// check — it says nothing about the venv, only about how much time it was
+/// given.
+fn run_bounded_python_check(
+    python: &Path,
+    args: &[&str],
+    timeout: Duration,
+    label: &str,
+) -> RecheckOutcome {
     let mut cmd = Command::new(python);
     cmd.args(args)
         .stdout(std::process::Stdio::null())
@@ -357,29 +500,36 @@ fn run_bounded_python_check(python: &Path, args: &[&str], timeout: Duration, lab
         Ok(c) => c,
         Err(e) => {
             tracing::warn!("py-embedder: {label} failed to spawn venv python: {e}");
-            return false;
+            return RecheckOutcome::Failed;
         }
     };
 
     let start = Instant::now();
     loop {
         match child.try_wait() {
-            Ok(Some(status)) => return status.success(),
+            Ok(Some(status)) => {
+                return if status.success() {
+                    RecheckOutcome::Passed
+                } else {
+                    RecheckOutcome::Failed
+                }
+            }
             Ok(None) => {
                 if start.elapsed() >= timeout {
                     let _ = child.kill();
                     let _ = child.wait();
-                    tracing::warn!(
-                        "py-embedder: {label} timed out after {}s",
+                    tracing::debug!(
+                        "py-embedder: {label} did not finish within {}s — indeterminate, \
+                         not a failed check (#4125)",
                         timeout.as_secs()
                     );
-                    return false;
+                    return RecheckOutcome::Indeterminate;
                 }
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(e) => {
                 tracing::warn!("py-embedder: {label} poll failed: {e}");
-                return false;
+                return RecheckOutcome::Failed;
             }
         }
     }
@@ -497,9 +647,26 @@ fn human_bytes(n: u64) -> String {
     format!("{:.1} GB", n as f64 / (1024.0 * 1024.0 * 1024.0))
 }
 
-/// Locate `uv`: `TRUSTY_UV_BIN` → PATH. (Vendored/download-with-SHA256 is a
-/// slice-5/6 follow-up; until then a missing uv is an actionable bootstrap
-/// error that triggers the ort fallback.)
+/// Locate `uv`: `TRUSTY_UV_BIN` → live `PATH` → the well-known daemon bin dirs.
+/// (Vendored/download-with-SHA256 is a slice-5/6 follow-up; until then a
+/// missing uv is an actionable bootstrap error that triggers the ort fallback.)
+///
+/// Why (#4125): this used to be a bare `which::which("uv")`, i.e. live-`PATH`
+/// only. trusty-search's daemon runs under launchd, whose plist sets no `PATH`
+/// and whose default omits `/opt/homebrew/bin` — where `uv` is installed. So on
+/// the daemon (and ONLY on the daemon; an interactive `trusty-search start`
+/// inherits a login shell's `PATH` and works fine) every bootstrap that reached
+/// this function hard-failed with "`uv` not found on PATH", and the daemon
+/// stayed on ort for the rest of its lifetime. This is the exact bug class
+/// #1298 already fixed for `tmux`/`claude` lookups — which is what
+/// [`trusty_common::bin_resolve::resolve_binary`] exists for, complete with the
+/// `/opt/homebrew/bin` fallback. It was simply never wired up here.
+/// What: delegates to that shared resolver, which tries the live `PATH` first
+/// and then the well-known daemon bin dirs (Homebrew, `~/.local/bin`,
+/// `~/.cargo/bin`, the system dirs).
+/// Test: `locate_uv_rejects_bad_explicit_override` (env-override arm). The
+/// fallback this now depends on is covered by trusty-common's own
+/// resolve_binary_finds_a_binary_outside_the_process_path.
 pub fn locate_uv() -> Result<PathBuf> {
     if let Ok(explicit) = std::env::var("TRUSTY_UV_BIN") {
         let p = PathBuf::from(&explicit);
@@ -508,11 +675,14 @@ pub fn locate_uv() -> Result<PathBuf> {
         }
         bail!("TRUSTY_UV_BIN={explicit:?} does not point to an existing file");
     }
-    which::which("uv").map_err(|_| {
+    // #4125: PATH-only lookup misses Homebrew under launchd's minimal PATH.
+    trusty_common::bin_resolve::resolve_binary("uv").ok_or_else(|| {
         anyhow!(
-            "`uv` not found on PATH and TRUSTY_UV_BIN is unset. Install uv \
-             (https://docs.astral.sh/uv/) or set TRUSTY_UV_BIN=/path/to/uv. \
-             Until then trusty-search falls back to the Rust ort embedder."
+            "`uv` not found on PATH or in the well-known install dirs \
+             (/opt/homebrew/bin, /usr/local/bin, ~/.local/bin, ~/.cargo/bin) and \
+             TRUSTY_UV_BIN is unset. Install uv (https://docs.astral.sh/uv/) or set \
+             TRUSTY_UV_BIN=/path/to/uv. Until then trusty-search falls back to the \
+             Rust ort embedder."
         )
     })
 }

--- a/crates/trusty-embedderd-py/src/bootstrap_tests.rs
+++ b/crates/trusty-embedderd-py/src/bootstrap_tests.rs
@@ -119,7 +119,7 @@ fn verify_venv_alive_false_when_venv_python_missing() {
         let layout = resolve_layout().unwrap();
         write_site_packages_marker(&layout);
         // Nothing written at `layout.venv_python` at all.
-        assert!(!super::verify_venv_alive(&layout));
+        assert_eq!(super::verify_venv_alive(&layout), RecheckOutcome::Failed);
     });
 }
 
@@ -132,7 +132,7 @@ fn verify_venv_alive_false_when_site_packages_marker_missing() {
         // (simulates a half-deleted venv) — must fail WITHOUT ever spawning
         // python, since the marker check runs first.
         write_fake_venv_python(&layout.venv_python, "#!/bin/sh\nexit 0\n");
-        assert!(!super::verify_venv_alive(&layout));
+        assert_eq!(super::verify_venv_alive(&layout), RecheckOutcome::Failed);
     });
 }
 
@@ -144,7 +144,7 @@ fn verify_venv_alive_false_when_interpreter_exits_nonzero() {
         write_site_packages_marker(&layout);
         // Simulates a broken interpreter binary / missing shared library.
         write_fake_venv_python(&layout.venv_python, "#!/bin/sh\nexit 1\n");
-        assert!(!super::verify_venv_alive(&layout));
+        assert_eq!(super::verify_venv_alive(&layout), RecheckOutcome::Failed);
     });
 }
 
@@ -155,7 +155,7 @@ fn verify_venv_alive_true_when_marker_present_and_interpreter_ok() {
         let layout = resolve_layout().unwrap();
         write_site_packages_marker(&layout);
         write_fake_venv_python(&layout.venv_python, "#!/bin/sh\nexit 0\n");
-        assert!(super::verify_venv_alive(&layout));
+        assert_eq!(super::verify_venv_alive(&layout), RecheckOutcome::Passed);
     });
 }
 
@@ -167,7 +167,10 @@ fn verify_full_import_smoke_false_when_venv_python_missing() {
     with_data_override(tmp.path(), || {
         let layout = resolve_layout().unwrap();
         // Nothing written at `layout.venv_python` at all.
-        assert!(!super::verify_full_import_smoke(&layout));
+        assert_eq!(
+            super::verify_full_import_smoke(&layout),
+            RecheckOutcome::Failed
+        );
     });
 }
 
@@ -179,7 +182,10 @@ fn verify_full_import_smoke_false_when_stub_exits_nonzero() {
         // Simulates a corrupted venv (e.g. a broken native `.so`): the
         // interpreter itself runs but the import fails.
         write_fake_venv_python(&layout.venv_python, "#!/bin/sh\nexit 1\n");
-        assert!(!super::verify_full_import_smoke(&layout));
+        assert_eq!(
+            super::verify_full_import_smoke(&layout),
+            RecheckOutcome::Failed
+        );
     });
 }
 
@@ -189,7 +195,10 @@ fn verify_full_import_smoke_true_when_stub_exits_zero() {
     with_data_override(tmp.path(), || {
         let layout = resolve_layout().unwrap();
         write_fake_venv_python(&layout.venv_python, "#!/bin/sh\nexit 0\n");
-        assert!(super::verify_full_import_smoke(&layout));
+        assert_eq!(
+            super::verify_full_import_smoke(&layout),
+            RecheckOutcome::Passed
+        );
     });
 }
 
@@ -294,4 +303,190 @@ fn materialize_project_writes_package_and_lock_skips_tests() {
         !dest.join("tests").exists(),
         "tests fixture dir must be skipped"
     );
+}
+
+// ── #4125: a timeout is a distinct outcome, never a verification failure ──
+
+/// Write a fake venv python that records each invocation as one line in
+/// `counter` and then behaves per `body`.
+///
+/// Why (#4125): the retry tests must prove HOW MANY times the recheck ran,
+/// which a plain exit-status stub cannot express.
+/// What: a `/bin/sh` script that appends a line to `counter` before running
+/// `body`.
+/// Test: `full_import_recheck_retries_once_before_reporting_indeterminate`,
+/// `full_import_recheck_retry_lets_a_starved_venv_prove_itself`.
+fn write_counting_venv_python(path: &Path, counter: &Path, body: &str) {
+    write_fake_venv_python(
+        path,
+        &format!(
+            "#!/bin/sh\nprintf 'x\\n' >> {}\n{}\n",
+            counter.display(),
+            body
+        ),
+    );
+}
+
+/// How many times [`write_counting_venv_python`]'s stub has run.
+fn invocation_count(counter: &Path) -> usize {
+    fs::read_to_string(counter)
+        .map(|s| s.lines().count())
+        .unwrap_or(0)
+}
+
+/// Why (#4125): `run_bounded_python_check` returned a bare `bool`, so "the
+/// check ran out of time" and "the check ran and the venv failed it" were the
+/// SAME value — the conflation that made a slow-but-intact venv look broken.
+/// What: pins all three classifications at the one site that produces them —
+/// a clean exit is `Passed`, a non-zero exit is `Failed`, and outliving the
+/// budget is `Indeterminate`. Against the pre-fix code the last case was
+/// indistinguishable from the middle one.
+/// Test: this test.
+#[test]
+fn bounded_python_check_classifies_timeout_apart_from_failure() {
+    let tmp = tempfile::tempdir().unwrap();
+    let ok = tmp.path().join("ok");
+    let bad = tmp.path().join("bad");
+    let slow = tmp.path().join("slow");
+    write_fake_venv_python(&ok, "#!/bin/sh\nexit 0\n");
+    write_fake_venv_python(&bad, "#!/bin/sh\nexit 3\n");
+    write_fake_venv_python(&slow, "#!/bin/sh\nsleep 30\n");
+
+    // Asymmetric budgets on purpose: the two decided outcomes get a budget no
+    // realistic scheduler delay can eat (a loaded CI box can take a surprising
+    // while just to fork /bin/sh, and a flaky `Passed` here would be exactly
+    // the "slow read as broken" mistake this test exists to forbid), while the
+    // `sleep 30` stub is small enough to keep the test fast.
+    let generous = Duration::from_secs(30);
+    let tight = Duration::from_millis(300);
+    assert_eq!(
+        super::run_bounded_python_check(&ok, &["-c", "pass"], generous, "t"),
+        RecheckOutcome::Passed
+    );
+    assert_eq!(
+        super::run_bounded_python_check(&bad, &["-c", "pass"], generous, "t"),
+        RecheckOutcome::Failed
+    );
+    assert_eq!(
+        super::run_bounded_python_check(&slow, &["-c", "pass"], tight, "t"),
+        RecheckOutcome::Indeterminate,
+        "running out of time says nothing about the venv and must not be reported \
+         as a failed check (#4125)"
+    );
+}
+
+/// Why (#4125): a single fixed budget under variable startup load is wrong
+/// again the moment the load changes, so an over-budget first attempt must buy
+/// a second, larger one rather than a verdict.
+/// What: a stub that outlives BOTH budgets is invoked twice and still reports
+/// `Indeterminate`, never `Failed`.
+/// Test: this test.
+#[test]
+fn full_import_recheck_retries_once_before_reporting_indeterminate() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_data_override(tmp.path(), || {
+        let layout = resolve_layout().unwrap();
+        let counter = tmp.path().join("invocations");
+        write_counting_venv_python(&layout.venv_python, &counter, "sleep 30");
+
+        // The first budget must comfortably outlast the stub's own startup
+        // (fork + `printf`) or the invocation would go unrecorded on a loaded
+        // box; only the `sleep` needs to outlast the budget, and it does by
+        // an order of magnitude.
+        let outcome = super::verify_full_import_smoke_bounded(
+            &layout,
+            Duration::from_millis(1500),
+            Duration::from_millis(1500),
+        );
+        assert_eq!(
+            outcome,
+            RecheckOutcome::Indeterminate,
+            "two exhausted budgets still prove nothing about the venv"
+        );
+        assert_eq!(
+            invocation_count(&counter),
+            2,
+            "an over-budget first attempt must be retried with the larger budget"
+        );
+    });
+}
+
+/// Why (#4125): this is the real production shape — torch's import is starved
+/// past the first budget by the daemon's own warm-boot, then completes fine
+/// once given room. That venv must come back `Passed`, not be condemned.
+/// What: a stub that outlives the first budget and exits 0 immediately on its
+/// second invocation reports `Passed`.
+/// Test: this test.
+#[test]
+fn full_import_recheck_retry_lets_a_starved_venv_prove_itself() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_data_override(tmp.path(), || {
+        let layout = resolve_layout().unwrap();
+        let counter = tmp.path().join("invocations");
+        // First run: the counter holds one line (this run's own) -> sleep past
+        // the budget. Second run: two lines -> exit 0 at once.
+        let body = format!(
+            "if [ \"$(wc -l < {})\" -gt 1 ]; then exit 0; fi\nsleep 30",
+            counter.display()
+        );
+        write_counting_venv_python(&layout.venv_python, &counter, &body);
+
+        // First budget generous enough that the stub always gets to record its
+        // invocation before being killed (see the sibling test), retry budget
+        // generous enough that the immediate `exit 0` always lands.
+        assert_eq!(
+            super::verify_full_import_smoke_bounded(
+                &layout,
+                Duration::from_millis(1500),
+                Duration::from_secs(30),
+            ),
+            RecheckOutcome::Passed,
+            "a venv that merely needed more time must pass, not be rebuilt"
+        );
+        assert_eq!(invocation_count(&counter), 2);
+    });
+}
+
+/// Why (#4125): THE defect. `ensure_venv_checked` treated a timed-out recheck
+/// as proof of a broken venv and tore down a perfectly intact one; the
+/// resulting needless rebuild then hard-failed on `uv` discovery and pinned the
+/// daemon on the ort backend for its whole lifetime. Against the pre-fix code
+/// the `Indeterminate` arm below collapses to `false`, the rebuild runs, and
+/// the call returns the uv error instead of the layout.
+/// What: with a `.ready` venv in place and any rebuild guaranteed to fail
+/// (`TRUSTY_UV_BIN` points at nothing), asserts `Indeterminate` returns the
+/// existing layout untouched while `Failed` — the outcome that IS evidence —
+/// still rebuilds. Both arms are asserted so the fix cannot be "kept" by
+/// trusting every outcome either.
+/// Test: this test.
+#[test]
+fn ensure_venv_does_not_rebuild_on_an_indeterminate_recheck() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_data_override(tmp.path(), || {
+        let layout = resolve_layout().unwrap();
+        write_fake_venv_python(&layout.venv_python, "#!/bin/sh\nexit 0\n");
+        write_site_packages_marker(&layout);
+        std::fs::write(layout.base.join(".ready"), lockfile_hash()).unwrap();
+
+        // Any rebuild attempt must fail loudly rather than start a real ~3 GB
+        // torch download. `with_data_override` already holds `ENV_LOCK`.
+        unsafe { std::env::set_var("TRUSTY_UV_BIN", "/nonexistent/uv/binary") };
+
+        let indeterminate =
+            super::ensure_venv_verified(&|_| RecheckOutcome::Indeterminate).map(|l| l.venv_python);
+        let failed = super::ensure_venv_verified(&|_| RecheckOutcome::Failed);
+
+        unsafe { std::env::remove_var("TRUSTY_UV_BIN") };
+
+        assert_eq!(
+            indeterminate.as_deref().ok(),
+            Some(layout.venv_python.as_path()),
+            "a timed-out recheck must reuse the `.ready` venv, not rebuild it (#4125)"
+        );
+        let err = failed.expect_err("a FAILED recheck is real evidence and must still rebuild");
+        assert!(
+            format!("{err:#}").contains("does not point to an existing file"),
+            "expected the rebuild attempt to surface the uv-missing error, got: {err:#}"
+        );
+    });
 }

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.42.0"
+version = "0.42.1"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"
@@ -85,7 +85,7 @@ trusty-embedderd = { path = "../trusty-embedderd", version = "0.3.10", default-f
 # in NO torch/ORT — it is a lightweight uv/venv bootstrapper + launcher used
 # only when `TRUSTY_EMBEDDER=python` selects it (DEFAULT-OFF). Building it does
 # not require a venv; that is all runtime.
-trusty-embedderd-py = { path = "../trusty-embedderd-py", version = "0.1.1" }
+trusty-embedderd-py = { path = "../trusty-embedderd-py", version = "0.1.2" }
 # Why (issue #1318): the `trusty-console` dependency was REMOVED. The console
 # is no longer bundled into trusty-search (single-owner-per-binary); the
 # standalone `trusty-console` crate is its sole producer.

--- a/crates/trusty-search/changelog.d/4125-embedder-silent-cpu-fallback.md
+++ b/crates/trusty-search/changelog.d/4125-embedder-silent-cpu-fallback.md
@@ -1,0 +1,14 @@
+Fixed
+
+- `/health` now reports `status: "degraded"` when the embedder permanently
+  failed to reach its configured backend — `embedder_bootstrap: "failed"` (the
+  graceful Python/MPS bootstrap gave up for this daemon's lifetime) or
+  `"fell_back_to_ort"` (the swap-back watchdog abandoned a dead sidecar). Both
+  previously sat next to `status: "ok"` forever, so a silent MPS → CPU
+  performance regression was invisible to every monitor. `embedder: "ready"` is
+  unchanged and still describes the currently-active backend (#4125)
+- The graceful Python bootstrap's readiness probe now gets a larger budget on
+  each retry instead of the same flat `TRUSTY_EMBEDDERD_STARTUP_TIMEOUT_SECS`
+  twice. A cold torch import + model load, racing the daemon's own warm-boot,
+  could exceed the flat 30 s on both attempts and permanently abandon a healthy
+  sidecar (#4125)

--- a/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
+++ b/crates/trusty-search/src/commands/start/graceful_bootstrap.rs
@@ -264,7 +264,9 @@ pub(super) async fn drive_bootstrap(
     let mut last_err = None;
 
     for attempt in 1..=retries {
-        match try_bootstrap_once(&switchable, &state, &ops).await {
+        // #4125: each retry gets a proportionally larger probe budget — see
+        // `try_bootstrap_once`.
+        match try_bootstrap_once(&switchable, &state, &ops, attempt).await {
             Ok(python_teardown) => {
                 tracing::info!("embedder hot-swapped ort -> python/MPS (sidecar ready)");
                 return Some(python_teardown);
@@ -299,10 +301,22 @@ pub(super) async fn drive_bootstrap(
 /// through the teardown trait so the swap-back watchdog can shut it down
 /// later without needing to downcast the trait object `switchable` now
 /// holds.
+///
+/// #4125: `attempt` (1-based) scales the readiness-probe budget. The probe
+/// forces a cold python spawn — torch import, model load, one real embed —
+/// while the daemon is simultaneously warm-booting its indexes, and the flat
+/// `TRUSTY_EMBEDDERD_STARTUP_TIMEOUT_SECS` budget is measurably too tight under
+/// that self-inflicted load (both attempts of the 2026-08-04T12:19:28 boot
+/// died at exactly 30 s with no child output, and the next daemon start
+/// succeeded unchanged). Unlike the venv recheck this timeout is NOT a
+/// misclassification — a sidecar that will not answer genuinely cannot serve
+/// this attempt — so the fix is not a new outcome but a budget that grows with
+/// the retry instead of failing the same way twice.
 async fn try_bootstrap_once(
     switchable: &SwitchableEmbedder,
     state: &SearchAppState,
     ops: &Arc<dyn PythonBootstrap>,
+    attempt: u32,
 ) -> Result<Arc<dyn PythonAdapterTeardown>> {
     // Step a: blocking venv bootstrap off the async runtime — mirrors the
     // eager `TRUSTY_EMBEDDER=python` arm's `ensure_venv_eager` off-thread call.
@@ -321,7 +335,9 @@ async fn try_bootstrap_once(
     // awaited teardown is required on every failure path below rather than
     // relying on `Drop`.
     let (adapter, pid_slot, teardown) = ops.build_adapter(launcher);
-    let probe_timeout = ops.probe_timeout();
+    // #4125: a fixed budget under variable startup load is wrong again as soon
+    // as the load changes — give attempt N N x the base budget.
+    let probe_timeout = ops.probe_timeout() * attempt.max(1);
 
     // Step d: readiness probe — force the lazy spawn + torch import + model
     // load + one real embed THROUGH the supervisor, bounded by a timeout.

--- a/crates/trusty-search/src/service/server/health.rs
+++ b/crates/trusty-search/src/service/server/health.rs
@@ -175,7 +175,13 @@ pub(super) struct HealthResponse {
     /// no [`SwitchableEmbedder`] handle is installed yet (the same
     /// deferred-init gap `embedder_info` falls back for — see
     /// `current_switchable_embedder`'s ordering note).
-    /// Test: `health_reports_embedder_bootstrap_state`.
+    ///
+    /// #4125: `"failed"` and `"fell_back_to_ort"` also force the top-level
+    /// `status` to `"degraded"` — both are permanent for this daemon's
+    /// lifetime, so search runs on a backend the operator did not configure
+    /// until someone restarts it.
+    /// Test: `health_reports_embedder_bootstrap_state`,
+    /// `health_is_degraded_when_the_embedder_backend_permanently_downgraded`.
     pub(super) embedder_bootstrap: &'static str,
 }
 
@@ -416,6 +422,28 @@ pub(super) async fn health_handler(
         .as_ref()
         .map(|sw| bootstrap_state_str(sw.active().bootstrap))
         .unwrap_or("n/a");
+    // #4125: a permanent embedder capability downgrade must reach `status`.
+    //
+    // Why: `embedder_bootstrap` was reported and then aggregated nowhere, so
+    // `BootstrapState::Failed` (the graceful python bootstrap gave up for this
+    // daemon's lifetime) and `FellBackToOrt` (the swap-back watchdog abandoned a
+    // dead python/MPS sidecar) sat next to `status: "ok"` forever. Note that
+    // `embedder: "ready"` alongside them is not wrong — it reports the
+    // CURRENTLY-ACTIVE backend, which genuinely is ready. What nothing reported
+    // was "we did not get the backend we asked for": search silently runs on
+    // CPU/ort instead of MPS/python, a real and permanent performance
+    // regression, on the one field monitors gate on.
+    // What: `Failed` and `FellBackToOrt` are terminal for this daemon (neither
+    // path ever re-attempts), so both are degraded. `Bootstrapping` is
+    // transient and deliberately excluded — flagging it would make every
+    // Apple-Silicon boot report degraded for its first few seconds.
+    // `NotApplicable`/`Ready` are the healthy states.
+    let embedder_capability_degraded = switchable.as_ref().is_some_and(|sw| {
+        matches!(
+            sw.active().bootstrap,
+            BootstrapState::Failed | BootstrapState::FellBackToOrt
+        )
+    });
     // Issue #282: sample the sidecar's current RSS (None when not running).
     let embedderd_rss_mb = state
         .current_embedderd_pid()
@@ -615,9 +643,13 @@ pub(super) async fn health_handler(
     // walked is not healthy — that is a silent, total search outage for every
     // such index and it was previously invisible on every field of this
     // response. Same `status != "ok"` channel as #1870 / #3408.
+    // #4125: an embedder that permanently failed to reach the backend it was
+    // configured for (or fell back off it) is the same class of capability gap
+    // as #3408's refused watcher — see `embedder_capability_degraded` above.
     let overall_status = if warmboot_summary.warm_boot_degraded
         || indexes_watcher_network_degraded > 0
         || indexes_stuck_empty > 0
+        || embedder_capability_degraded
     {
         "degraded"
     } else {

--- a/crates/trusty-search/src/service/server/tests_health_switchable.rs
+++ b/crates/trusty-search/src/service/server/tests_health_switchable.rs
@@ -135,3 +135,57 @@ async fn health_reports_embedder_bootstrap_state() {
         );
     }
 }
+
+/// Why (#4125): a permanent embedder capability downgrade reached NO field a
+/// monitor gates on. `embedder_bootstrap: "failed"` (the graceful python
+/// bootstrap gave up for this daemon's lifetime) and `"fell_back_to_ort"` (the
+/// swap-back watchdog abandoned a dead python/MPS sidecar) both sat next to
+/// `status: "ok"` forever, so a silent MPS -> CPU regression was
+/// indistinguishable from a healthy daemon. `embedder: "ready"` is not the
+/// misreport — it describes the currently-active backend, which really is
+/// ready; nothing aggregated "we did not get the backend we asked for".
+/// What: drives every `BootstrapState` through `/health` and asserts the exact
+/// degraded/ok partition — the two terminal downgrades degrade, while
+/// `Bootstrapping` (transient, every Apple-Silicon boot passes through it),
+/// `Ready`, and `NotApplicable` stay `"ok"`. Against the pre-fix aggregation
+/// the first two assertions fail; the last three pin the fix against
+/// over-flagging. A daemon with no switchable handle installed yet is checked
+/// too, since that path reports `"n/a"` through a different branch.
+/// Test: this test.
+#[tokio::test]
+async fn health_is_degraded_when_the_embedder_backend_permanently_downgraded() {
+    for (bootstrap, expected_status) in [
+        (BootstrapState::Failed, "degraded"),
+        (BootstrapState::FellBackToOrt, "degraded"),
+        (BootstrapState::Bootstrapping, "ok"),
+        (BootstrapState::Ready, "ok"),
+        (BootstrapState::NotApplicable, "ok"),
+    ] {
+        let state = SearchAppState::new(IndexRegistry::new());
+        let inner: Arc<dyn Embedder> = Arc::new(MockEmbedder::new(384));
+        let active = ActiveBackend {
+            kind: BackendKind::Ort,
+            provider: trusty_common::embedder::ExecutionProvider::Cpu,
+            model: "all-MiniLM-L6-v2".to_string(),
+            quantized: false,
+            bootstrap,
+        };
+        let switchable = Arc::new(SwitchableEmbedder::new(inner, active));
+        state.install_switchable_embedder(Arc::clone(&switchable));
+
+        let state_arc = Arc::new(state);
+        let Json(resp) = health_handler(State(state_arc)).await;
+        assert_eq!(
+            resp.status, expected_status,
+            "BootstrapState::{bootstrap:?} must drive status {expected_status:?}, \
+             got {:?} (embedder_bootstrap={:?})",
+            resp.status, resp.embedder_bootstrap
+        );
+    }
+
+    // No switchable handle installed at all — the `"n/a"` branch must stay ok.
+    let state = Arc::new(SearchAppState::new(IndexRegistry::new()));
+    let Json(resp) = health_handler(State(state)).await;
+    assert_eq!(resp.embedder_bootstrap, "n/a");
+    assert_eq!(resp.status, "ok");
+}


### PR DESCRIPTION
Closes #4125

The owner confirmed the MPS/Python → CPU/ort fallback is **not** intended. Three
independent defects, all pre-dating 0.42.0, chained to produce it — and a fourth
signal gap kept it invisible. Root-caused from this machine's own
`~/Library/Logs/trusty-search/stderr.log` plus the source; every claim below is
backed by a log line I re-verified rather than inferred.

## Defect 1 — a timeout was treated as proof the venv is broken

`verify_full_import_smoke()` runs `<venv>/bin/python -c "import
sentence_transformers"` under a hardcoded 10 s budget. The daemon runs that
recheck while simultaneously warm-booting hundreds of indexes, so torch's import
routinely exceeds 10 s under purely self-inflicted startup contention. The check
returned a bare `bool`, so "ran out of time" and "the venv failed the check" were
the same value, and `ensure_venv_checked` condemned a perfectly intact venv to a
full rebuild.

The log shows this firing on nearly every daemon start from 2026-07-26 onward —
90 occurrences of `py-embedder: full-import-recheck timed out after 10s`, the
most recent at `2026-08-04T13:39:23`.

This is the same conflation of *slow* with *broken* that #4333 fixed for a corpus
open timeout being reported as "corrupted format", and it is fixed the same way:
a timeout is now a distinct, named outcome, never a verification failure.

- Rechecks return `RecheckOutcome { Passed, Failed, Indeterminate }`. Only a
  completed run produces evidence; a timeout produces `Indeterminate`.
- The constant was deliberately **not** just raised — a fixed budget under
  variable startup load is wrong again the moment the load changes. An
  over-budget first attempt buys a second attempt with a materially larger
  budget (10 s → 60 s) instead of a verdict. The killed first attempt also
  leaves the interpreter and torch's shared objects warm, so the retry is
  typically much faster than the attempt it follows.
- `Indeterminate` reuses the `.ready` venv rather than rebuilding. That sentinel
  is written only after a real import+embed smoke test passed, and a timed-out
  recheck adds nothing that contradicts it. The residual risk (a venv that is
  both broken *and* slow) is unchanged and already covered downstream: the
  caller's readiness probe forces a real embed through the supervisor before
  anything hot-swaps to python, and a failure there leaves search on ort exactly
  as a failed rebuild would — but without destroying a working venv on the way.

## Defect 2 — `uv` was looked up on PATH only, and the daemon's PATH lacks Homebrew

`locate_uv()` resolved via `TRUSTY_UV_BIN` or a bare `which::which("uv")`, with no
fallback. `uv` lives at `/opt/homebrew/bin/uv`; the launchd plist sets no `PATH`
and the daemon's inherited `PATH` omits `/opt/homebrew/bin`. So once defect 1
triggered a needless rebuild, it hard-failed:

```
graceful python bootstrap attempt 1/2 failed (py-embedder venv bootstrap: `uv` not found
on PATH and TRUSTY_UV_BIN is unset. …) — staying on the ort sidecar
graceful python bootstrap exhausted 2 attempt(s) — staying permanently on the ort sidecar
for this daemon's lifetime
```

This bug class was already fixed once — #1298, for `tmux`/`claude` lookups —
producing `trusty_common::bin_resolve::resolve_binary()`, which falls back to
well-known dirs including `/opt/homebrew/bin`. `locate_uv` was simply never wired
to it. It is now, rather than growing a second fallback list.

Note this only ever bit the daemon: an interactive `trusty-search start` inherits
a login shell's `PATH` and finds `uv` fine, which is why it survived so long.

## Defect 3 — a permanent capability downgrade never reached `overall_status`

`overall_status` was computed from `warm_boot_degraded ||
indexes_watcher_network_degraded > 0 || indexes_stuck_empty > 0`.
`embedder_bootstrap` was populated and then aggregated nowhere, so
`BootstrapState::Failed` and `FellBackToOrt` (from the swap-back watchdog) sat
next to `status: "ok"` forever.

`embedder: "ready"` is not the misreport — it describes the currently-active
backend, which genuinely is ready. What nothing aggregated was *"we did not get
the backend we asked for"*: search silently runs on CPU/ort instead of MPS, a
real and permanent performance regression, on the one field monitors gate on.

Both terminal states now fold into the existing degraded condition, using the
idiom the file already establishes (#1870 / #3408 / #3706 extended the same `||`
chain; #4718 applied the same pattern to #4087). `Bootstrapping` is deliberately
excluded — it is transient, and flagging it would make every Apple-Silicon boot
report degraded for its first few seconds.

## The 30 s startup probe — same class, different remedy

Asked to judge whether `TRUSTY_EMBEDDERD_STARTUP_TIMEOUT_SECS`'s 30 s sidecar
spawn probe shares the fixed-budget-under-contention problem. **It does**, and
the log confirms it independently of defects 1–2: on the
`2026-08-04T12:19:28` boot both bootstrap attempts died at exactly 30 s with no
child output, and the next daemon start succeeded unchanged.

But the correct remedy differs, so I did not reclassify it. A *verification*
check's timeout is a misreading — it says something about the artifact that the
timeout cannot support. A *readiness probe's* timeout is not: a sidecar that will
not answer genuinely cannot serve that attempt. What was wrong was retrying with
the identical budget and then abandoning python permanently. So the probe budget
now scales with the attempt (attempt N gets N× the base) instead of failing the
same way twice. The budget also remains operator-tunable, which the recheck's
hardcoded 10 s never was.

## Tests

Each fix has a regression test that fails against the current behavior;
verified by reverting each fix and observing the failure.

| Fix | Test | Failure when reverted |
|---|---|---|
| 1 (classification) | `bounded_python_check_classifies_timeout_apart_from_failure` | timeout indistinguishable from `Failed` |
| 1 (retry) | `full_import_recheck_retries_once_before_reporting_indeterminate` | `left: 1, right: 2` — no retry |
| 1 (starved venv) | `full_import_recheck_retry_lets_a_starved_venv_prove_itself` | `left: Indeterminate, right: Passed` |
| 1 (no rebuild) | `ensure_venv_does_not_rebuild_on_an_indeterminate_recheck` | rebuild runs, returns the uv error |
| 2 (resolver) | `resolve_binary_finds_a_binary_outside_the_process_path` | PATH-only lookup misses it |
| 3 (aggregation) | `health_is_degraded_when_the_embedder_backend_permanently_downgraded` | `Failed`/`FellBackToOrt` still report `"ok"` |

The health test drives all five `BootstrapState` variants plus the
no-switchable-handle branch, so it pins the fix against over-flagging
(`Bootstrapping`/`Ready`/`NotApplicable`/`n/a` must stay `"ok"`) as well as
under-flagging. The `ensure_venv` test asserts both arms — `Indeterminate`
reuses, `Failed` still rebuilds — so the fix cannot be "kept" by trusting every
outcome.

No coverage was weakened: no `#[ignore]`, no cfg-gating, no narrowing. The
existing recheck tests were updated from `bool` to the three-state outcome, which
tightens them (they now assert *which* outcome, not merely "not passed").

## Verification

```
cargo test -p trusty-embedderd-py
  test result: ok. 20 passed; 0 failed; 0 ignored
  (+ 1 pre-existing #[ignore] e2e test requiring a real torch venv, untouched)

cargo test -p trusty-common --lib bin_resolve
  test result: ok. 14 passed; 0 failed; 0 ignored

cargo test -p trusty-search
  test result: FAILED. 1443 passed; 6 failed; 1 ignored

cargo clippy -p trusty-embedderd-py -p trusty-common -p trusty-search --all-targets -- -D warnings
  Finished — 0 warnings

cargo fmt --check   → clean
scripts/check_line_cap.sh          → 0 violations
scripts/check_test_pointers.sh     → 0 dangling pointers (20761 citations)
scripts/check_changelog_fragment.sh → all 3 crates with source changes recorded
scripts/check_sld.sh               → 0 errors, 0 warnings
```

The 6 `trusty-search` failures are the macOS FSEvents watcher set tracked as
**#4731** — identical names and count before and after this change, and untouched
by it. All change-specific gates pass.

Crate-scoped rather than `--workspace` deliberately: a workspace run exceeds the
tool timeout. Blast radius is the three crates above, all fully gated.

## Not in scope

- **No PyO3 / no change to the process boundary.** The sidecar stays
  out-of-process, per the owner's decision that this is a separate question.
- **`launcher.rs` still uses `which::which`** for the launcher binary. It has a
  sibling-of-`current_exe()` fallback ahead of the PATH lookup, which covers the
  daemon case, so it is not the same live failure — noting it rather than
  silently leaving it, and rather than widening this PR.
- The live daemon was **not** restarted, reconfigured, or `launchctl`-touched.
  Logs and code were read only, so the daemon on this machine is still on ort
  and will pick these fixes up on its next ordinary restart after release.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
