### PR TITLE
chore(tooling): pin Node 20 / pnpm 9 locally — CI-only pin allows silent toolchain drift

### DIFF
--- a/crates/trusty-agents/ui/package.json
+++ b/crates/trusty-agents/ui/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/crates/trusty-analyze/ui/package.json
+++ b/crates/trusty-analyze/ui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.3.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "description": "Svelte 5 + Vite + D3 dashboard for the trusty-analyzer daemon. Built bundle in dist/ is embedded into the Rust binary via include_dir!.",
   "scripts": {
     "dev": "vite",

--- a/crates/trusty-code-gui/ui/package.json
+++ b/crates/trusty-code-gui/ui/package.json
@@ -2,6 +2,7 @@
   "name": "trusty-code-gui-ui",
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/crates/trusty-console/ui/package.json
+++ b/crates/trusty-console/ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "license": "MIT",
   "type": "module",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/crates/trusty-memory/ui/package.json
+++ b/crates/trusty-memory/ui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/crates/trusty-mpm-gui/ui/package.json
+++ b/crates/trusty-mpm-gui/ui/package.json
@@ -2,6 +2,7 @@
   "name": "trusty-mpm-gui-ui",
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/crates/trusty-search/ui/package.json
+++ b/crates/trusty-search/ui/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531",
   "scripts": {
     "dev": "vite",
     "build": "vite build",

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
 rust = "1.91"
+node = "20"


### PR DESCRIPTION
## Problem

CI pins Node 20 and pnpm 9 (`.github/workflows/ci.yml`, `release.yml`, `token-drift.yml`), but a local build had zero signal if the contributor was on a different Node/pnpm version — the first failure surfaced in CI, not locally.

## What changed

- `mise.toml` — added `node = "20"` to the existing `[tools]` table (alongside `rust = "1.91"`, which landed via #4773 earlier this session).
- All 7 UI `package.json` files get `"packageManager": "pnpm@9.15.9+sha512.68046141893c66fad01c079231128e9afb89ef87e2691d69e4d40eee228988295fd4682181bae55b58418c3a253bde65a505ec7c5f9403ece5cc3cd37dcf2531"` (Corepack-verified pin, via `corepack use pnpm@9.15.9`):
  - `crates/trusty-agents/ui/package.json`
  - `crates/trusty-analyze/ui/package.json`
  - `crates/trusty-code-gui/ui/package.json`
  - `crates/trusty-console/ui/package.json`
  - `crates/trusty-memory/ui/package.json`
  - `crates/trusty-mpm-gui/ui/package.json`
  - `crates/trusty-search/ui/package.json`

## Version verification against CI (not trusted from the issue title)

Read `.github/workflows/*.yml` directly rather than trusting "Node 20 / pnpm 9" from the issue title:

- `node-version: "20"` — `ci.yml:1181`, `release.yml:1288`, `token-drift.yml:49`
- `version: 9` (pnpm major, via `pnpm/action-setup@v4`) — `ci.yml:1175`, `release.yml:1283`

Matched. `mise`'s `node = "20"` pin resolves the same floating-latest-20.x semantics as `actions/setup-node`'s `node-version: "20"`. For the `packageManager` field (which Corepack requires as a full pinned version, not a bare major), I used the latest pnpm 9.x release (`9.15.9`) — the version CI's `version: 9` would install today.

## Issue premise correction

#4770's body asserted `mise.toml` already existed with `rust = "1.91"`, citing a commit `6c7837d3` not present in this repo's history. That was **wrong at the time the issue was filed** — `mise.toml` did not exist on `main` until PR #4773 merged mid-session (see the PM's correction comment on the issue). This PR builds on top of that now-real file.

## Gates (Rust Test Ladder rung 1-2 — tooling config, not crate source)

```
$ cargo fmt --check
Warning: can't set `imports_granularity = Crate`, unstable features are only available in nightly channel.
(no diff — exit 0)

$ cargo check
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 31s
(exit 0)
```

### Proof the pin actually works

```
$ mise install
mise node@20.20.2    [3/3] node -v
mise node@20.20.2    [3/3] v20.20.2
mise rust@1.91.1   ✓ installed
mise node@20.20.2  ✓ installed

$ node --version
v20.20.2

$ cd crates/trusty-search/ui && corepack enable && corepack use pnpm@9.15.9
Installing pnpm@9.15.9 in the project...
Done in 548ms using pnpm v9.15.9

$ pnpm --version
9.15.9

$ pnpm install --frozen-lockfile
Lockfile is up to date, resolution step is skipped
Already up to date
Done in 341ms using pnpm v9.15.9

$ pnpm run build
> vite build
vite v6.4.3 building for production...
✓ 139 modules transformed.
dist/index.html                   1.00 kB │ gzip:  0.53 kB
dist/assets/index-TmlFVyjD.css   23.39 kB │ gzip:  4.77 kB
dist/assets/index-DHZwUpbb.js   106.27 kB │ gzip: 36.59 kB
✓ built in 664ms
```

## Changelog fragment

Skipped. This is CI/tooling-only (`mise.toml` + `packageManager` fields) and touches no crate `src/**` — falls under the #4476 convention's CI-only carve-out.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo check` clean (workspace still resolves)
- [x] `mise install` resolves Node 20.20.2 matching CI's floating pin
- [x] Corepack resolves pnpm 9.15.9 from the `packageManager` field, matching CI's floating `version: 9` pin
- [x] `pnpm install --frozen-lockfile && pnpm run build` succeeds against a real UI package (trusty-search/ui)

Closes #4770

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools