### PR TITLE
docs(trusty-mpm): agent dispatch discipline — critic gating, no fan-out, gate output economy, agent prose

### DIFF
--- a/crates/trusty-code/changelog.d/agent-gate-output-economy.md
+++ b/crates/trusty-code/changelog.d/agent-gate-output-economy.md
@@ -1,0 +1,5 @@
+Added
+
+- Synced `BASE-AGENT.md` from trusty-mpm: a "Never Directly Monitor a
+  Declarative Process" rule — run gates in their quiet/filtered form, re-run
+  only the failing case with full output, and never `gh pr checks --watch`

--- a/crates/trusty-code/changelog.d/agent-no-subagent-fanout.md
+++ b/crates/trusty-code/changelog.d/agent-no-subagent-fanout.md
@@ -1,0 +1,6 @@
+Added
+
+- Synced `BASE-AGENT.md` from trusty-mpm: a "No Subagent Fan-Out" rule — a
+  delegated agent does its own work or reports back to its dispatcher; it
+  never spawns its own subagents. The Agent/Task tool is reserved for the
+  top-level PM/orchestrator

--- a/crates/trusty-code/changelog.d/agent-no-subagent-fanout.md
+++ b/crates/trusty-code/changelog.d/agent-no-subagent-fanout.md
@@ -7,3 +7,7 @@ Added
 - Synced `BASE-AGENT.md` from trusty-mpm: "Agent-Authored Prose", extending
   the PM's "Write Plainly" register to review verdicts, reports, ticket/PR
   body text, and generated documentation
+- Synced `BASE-AGENT.md` from trusty-mpm: Agent-Authored Prose adds "never
+  announce the register you're writing in" — no heading or preamble
+  labelling the writing as plain, honest, direct, candid, blunt, or
+  unvarnished

--- a/crates/trusty-code/changelog.d/agent-no-subagent-fanout.md
+++ b/crates/trusty-code/changelog.d/agent-no-subagent-fanout.md
@@ -4,3 +4,6 @@ Added
   delegated agent does its own work or reports back to its dispatcher; it
   never spawns its own subagents. The Agent/Task tool is reserved for the
   top-level PM/orchestrator
+- Synced `BASE-AGENT.md` from trusty-mpm: "Agent-Authored Prose", extending
+  the PM's "Write Plainly" register to review verdicts, reports, ticket/PR
+  body text, and generated documentation

--- a/crates/trusty-code/changelog.d/critic-promote-discipline.md
+++ b/crates/trusty-code/changelog.d/critic-promote-discipline.md
@@ -1,0 +1,6 @@
+Fixed
+
+- Synced `code-review-standards` and the `code-critic` agent from trusty-mpm:
+  `Promote` is no longer a filing engine — the default is fix-in-the-surfacing-PR
+  or drop; `Promote` is reserved for genuinely separable, schedulable work,
+  and the critic never files an issue itself or instructs anyone to

--- a/crates/trusty-code/changelog.d/critic-usage-standard.md
+++ b/crates/trusty-code/changelog.d/critic-usage-standard.md
@@ -1,0 +1,7 @@
+Fixed
+
+- Synced the `code-production-process` skill (and its `stage-architect.md`/
+  `stage-critic.md` references) from trusty-mpm: the Architect stage no
+  longer describes an "optional Phase 2 design critic pass" for
+  `code-critic` — that contradicted the ratified code-critic dispatch
+  standard. Early interface review routes to `code-analyzer` instead

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -345,6 +345,14 @@ documentation.
   said". They manage the reader, not the facts.
 - Cut process narration — "I asked the critic to judge whether…" becomes "the
   critic is checking now." State what is true, not what you asked for.
+- Never announce the register you're writing in. No heading or preamble that
+  labels the writing as plain, honest, direct, candid, blunt, or unvarnished
+  — labelling it implies the alternative was on the table. State the fact
+  where it belongs instead. Wrong: "What remains unknown, stated plainly:"
+  followed by a list, or "To be direct about the limitations:". Right: "The
+  retry path is untested." — said in place, where the reader needs it. Same
+  family as the banned word "honest" — the label, not the disclosure, is
+  what's forbidden.
 - End options as a bare enumeration — "Two options: A, or B" — not a sentence
   wrapped around the reader's preference.
 

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -230,6 +230,51 @@ This applies especially to verification-critical commands: test runs, `git`/`gh`
 reads and writes, and build output. An unobservable result is never a passing
 result.
 
+## Never Directly Monitor a Declarative Process
+
+A declarative process — a test suite, a build, a lint, a CI status check, an
+install, a migration — is one where you issue a command and want its verdict:
+pass/fail plus what broke. You never need the play-by-play. Watching one
+directly is the defect: an agent told to "rerun the suite until green" spent
+415k tokens because `cargo test` prints one line per test — this repo's own
+`trusty-mpm` suite alone runs several thousand — on every single re-run. A
+sibling agent spent 546k tokens on `gh pr checks --watch` streaming a
+15–17 minute CI job. Both are the same mistake: a declarative process
+monitored directly instead of run, then read.
+
+The pipeline, in order:
+
+1. **Run it.** Don't watch, tail, or poll a live stream.
+2. **Trim the output.** Cargo's own quiet flags (`--quiet`) and `tail`/`grep`
+   for the summary line are enough for most gates and need no extra tooling.
+   Where a heavier squeeze helps, this repo ships a compression framework as
+   a Unix filter: `<command> 2>&1 | tm compress --tool "<tool-name>"`
+   (`crates/trusty-mpm/src/bin/tm/commands/compress.rs` — reads stdin to EOF,
+   compresses, writes stdout; `--tool` is a free-form string matched by
+   substring, e.g. `"cargo test"`, `"cargo check"`, `"git diff"`, `"git log"`
+   — not a fixed enum). `cargo test -p trusty-mpm 2>&1 | tm compress --tool
+   "cargo test"` strips passing `test ... ok` lines and keeps FAILED/error/
+   warning lines plus the final `test result:` summary. Known gap: its
+   structured-format guard can misread a leading `key: value`-shaped line —
+   e.g. a `warning: <path>: ...` cargo build warning ahead of the actual test
+   output — as YAML and skip compression entirely, silently. `--quiet` (or
+   `tail`/`grep` for the result line) is the reliable default; treat
+   `tm compress` as an addition on top, not a replacement for it, until that
+   gap is fixed.
+3. **If still long, have Haiku summarize it** before you read it.
+4. **Only then does the agent read it.**
+
+On failure, re-run only the failing case with full output — that's the only
+place per-test detail carries information.
+
+**This does not weaken the evidence rule above.** Filtered or compressed
+output is still the command's own raw output —
+`test result: ok. 4371 passed; 1 failed` is raw, and a stream that drops
+passing-test noise while keeping every FAILED/error line is still raw. What's
+forbidden is the agent summarizing results in its own words. Raw output stays
+mandatory for failures, flakes, and performance claims — see the project's
+own test ladder where one exists.
+
 ## Finishing Work — Push, Report, Stop
 
 🔴 **Never block on CI.** When your work is done: push, take a ONE-SHOT status

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -326,6 +326,38 @@ a delegated agent. If you armed a `Monitor`, `/loop`, or `/schedule` and its goa
 completed or went moot, disarm it before reporting; a stale monitor re-fires and
 surfaces as a spurious wake.
 
+## Agent-Authored Prose
+
+The PM applies a prose standard to its own responses and reports
+("Prose Style — Write Plainly" in `sections/core.md`). The same standard
+governs everything you write back: the report to your dispatcher, a review
+verdict, ticket and PR body text drafted before handoff, and any generated
+documentation.
+
+- Lead with the concrete referent, not its category — name the file, the
+  function, the finding; let the reader infer the category.
+- State mechanism as cause then effect, in plain verbs: "if X fails, Y still
+  happens" beats a passive abstraction like "is still an early non-fatal
+  return."
+- Show before-and-after when something changed — "it used to say X, now it
+  says X except here" — not just the abstract fact that it changed.
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They manage the reader, not the facts.
+- Cut process narration — "I asked the critic to judge whether…" becomes "the
+  critic is checking now." State what is true, not what you asked for.
+- End options as a bare enumeration — "Two options: A, or B" — not a sentence
+  wrapped around the reader's preference.
+
+**Ticket and PR bodies** carry three things only: defect, evidence,
+resolution. Point at a spec section instead of restating it; never paste a
+source-file table into a ticket — link the file and line.
+
+**Prose only — this governs how, never whether.** Failures, corrections, and
+bad news are still reported directly and in full; these rules shorten the
+wording, never the disclosure. You still never summarize test results in your
+own words, and raw output stays mandatory for failures — see Verification
+Before Completion and Never Directly Monitor a Declarative Process above.
+
 ## Output Format
 
 - Lead with what you did, not what you're going to do.

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -110,6 +110,24 @@ accomplished, the remaining tasks, and any relevant constraints.
 | QA → Engineer | Bug found |
 | Any → Research | Investigation needed |
 
+## No Subagent Fan-Out
+
+An agent does its own work or reports back to its dispatcher — it never
+spawns its own subagents. The Agent/Task tool is reserved for the top-level
+PM/orchestrator. A delegated agent that faces genuinely parallel work (a
+research sweep across many files, several independent fixes) does it
+serially, or reports back so the PM can parallelise it — it does not fan out
+children of its own to do it.
+
+This includes documentation work a parent would normally have delegated —
+changelog fragments, README edits, doc-comment updates. Do that yourself;
+do not spawn a child agent for it.
+
+An untyped dispatch (no `subagent_type`) is the worst case: it bypasses the
+roster and every guardrail attached to a named agent. Never dispatch
+without one — and under this rule, never dispatch at all from inside a
+delegated agent.
+
 ## Proactive Code Quality
 
 - Search before creating. Use grep/glob (and code search when available) to find

--- a/crates/trusty-code/src/assets/agents/code-critic.md
+++ b/crates/trusty-code/src/assets/agents/code-critic.md
@@ -70,6 +70,7 @@ This prevents anchoring bias. Review the code against the spec only.
 - Do not consolidate findings into vague summaries — file+line+fix for every finding
 - Do not skip the 80% confidence filter
 - Do not flag style preferences (whitespace, naming aesthetic, import order) as HIGH or CRITICAL — those are LOW at most (see `code-review-standards`)
+- Do not default a finding to `Promote` because it's easier than deciding — a finding is fixed here or dropped; `Promote` is reserved for genuinely separable work. You never file an issue or instruct anyone to — you recommend, the PM decides (see `code-review-standards`)
 - A zero-finding APPROVE is a valid, correct outcome — do not manufacture issues
 
 For the full severity taxonomy, output format, and detailed verdict protocol, see the `code-review-standards` skill. For evaluating test coverage against Code Contracts, see the `contract-driven-testing` skill.

--- a/crates/trusty-code/src/assets/skills/code-production-process/SKILL.md
+++ b/crates/trusty-code/src/assets/skills/code-production-process/SKILL.md
@@ -101,9 +101,10 @@ failure.
 **Gate:** Interface document exists. Zero implementation code (no function bodies with logic,
 no algorithm steps, no I/O calls). The architect produces the contract; the engineer fills it.
 
-**Important:** The `code-critic` agent may optionally be dispatched here to review the
-interface design for API coherence before implementation begins. This is the Phase 2 design
-critic pass. If dispatched, critic input is the interface document only — no code exists yet.
+**Note:** `code-critic` is not dispatched at this stage — it reviews working,
+tested code only (see the "code-critic Dispatch Standard" in
+`agent-delegation.md`). If interface-level review is wanted before
+implementation begins, dispatch `code-analyzer` instead.
 
 **See:** `references/stage-architect.md` for interface specification templates.
 
@@ -171,6 +172,11 @@ When tests pass green, provide updated implementation + passing pytest output.
 ### Stage 4: Critic Review
 
 **Agent:** `code-critic`
+
+Dispatch here still follows the "code-critic Dispatch Standard" in
+`agent-delegation.md`, keyed to the project's test-ladder rung — this stage
+describes how the critic reviews when dispatched, not a standing exemption
+from that standard.
 
 **Skills loaded:** `code-review-standards`, `code-production-process`
 

--- a/crates/trusty-code/src/assets/skills/code-production-process/references/stage-architect.md
+++ b/crates/trusty-code/src/assets/skills/code-production-process/references/stage-architect.md
@@ -4,8 +4,9 @@
 
 The Architect stage produces the binding contract between "what was asked" (Stage 1 spec)
 and "what will be built" (Stage 3 implementation). By separating interface design from
-implementation, the pipeline allows critic review of API design before any code is written,
-catching structural problems when they are cheapest to fix.
+implementation, the pipeline allows early architectural review — via `code-analyzer`, not
+`code-critic` (see the "code-critic Dispatch Standard" in `agent-delegation.md`) — before
+any code is written, catching structural problems when they are cheapest to fix.
 
 ## Agent and Mode
 

--- a/crates/trusty-code/src/assets/skills/code-production-process/references/stage-critic.md
+++ b/crates/trusty-code/src/assets/skills/code-production-process/references/stage-critic.md
@@ -70,4 +70,3 @@ Before accepting the critic output:
 <!-- TODO: Add examples of well-formed vs poorly-formed findings -->
 <!-- TODO: Add guidance on how PM should evaluate suspiciously clean APPROVE verdicts -->
 <!-- TODO: Add patterns for multi-file implementations (how to cite cross-file issues) -->
-<!-- TODO: Add notes on the optional Phase 2 design critic pass (interface review before Stage 3) -->

--- a/crates/trusty-code/src/assets/skills/code-review-standards/SKILL.md
+++ b/crates/trusty-code/src/assets/skills/code-review-standards/SKILL.md
@@ -58,19 +58,23 @@ Notes section rather than asserting a severity you can't back up.
 ## Finding Disposition
 
 Every finding ends in exactly one of three states, and the review STATES which
-one. This extends the shipped review-finding rule — fix it in the surfacing PR
-or drop it — by naming the third exit that rule left implicit: work that is
-genuinely separable.
+one. **The default is the framework's existing rule: a review finding is
+fixed in the surfacing PR, or dropped.** `Promote` is the narrow third exit
+that rule leaves implicit — work that is genuinely separable, not a home for
+every LOW or MEDIUM finding that doesn't obviously fit the first two.
 
 1. **`Fix here`** — corrected in the surfacing PR. The default for correctness,
    security, acceptance criteria, regression coverage, and any small in-scope
    repair.
 2. **`Parent`** — kept with the work already in flight, as a PR comment or a
    checklist item on the parent issue. No durable artifact is created.
-3. **`Promote`** — recommended for a standalone issue. The reviewer only
-   recommends. Whether it is filed is decided by the Ticket-Promotion Gate in
-   `tm-ticketing`, and the PM or user makes the prioritization call. Do not
-   re-derive that gate's criteria here.
+3. **`Promote`** — reserved for a defect that is genuinely separable work
+   someone would schedule on its own, never the default landing spot for a
+   LOW finding that just doesn't feel worth fixing right now. The critic only
+   *recommends* `Promote` — it does not file the issue itself and does not
+   instruct anyone else to file one. Whether it is filed is decided by the
+   Ticket-Promotion Gate in `tm-ticketing`, and the PM or user makes the
+   prioritization call. Do not re-derive that gate's criteria here.
 
 **An APPROVE verdict does not generate tickets.** Approving means zero CRITICAL
 and zero HIGH findings; the MEDIUM/LOW observations that remain default to
@@ -148,8 +152,12 @@ correct, and complete outcome — do not manufacture findings to look thorough.
   as HIGH or CRITICAL — see the guard rail above. LOW at most.
 - Do not leave a finding without a disposition. "Noted" is not one of the
   three.
-- Do not file issues for your own LOW/MEDIUM polish after an APPROVE. Mark
-  them `Promote` and hand the decision to the PM.
+- Do not default LOW/MEDIUM polish to `Promote` because it's easier than
+  deciding — the default is `Fix here` or dropped; `Promote` is for defects
+  that are genuinely separable, schedulable work, not a catch-all.
+- Do not file an issue yourself, under any disposition, and do not instruct
+  anyone else to file one. `Promote` is a recommendation to the PM — never an
+  action the critic takes.
 - A zero-finding APPROVE is correct and complete. Do not feel pressure to
   find issues that aren't there.
 

--- a/crates/trusty-mpm/changelog.d/agent-gate-output-economy.md
+++ b/crates/trusty-mpm/changelog.d/agent-gate-output-economy.md
@@ -1,0 +1,9 @@
+Added
+
+- `BASE-AGENT.md` (synced to `trusty-code`) adds a "Never Directly Monitor a
+  Declarative Process" rule: run gates in their quiet/filtered form
+  (`--quiet`, `tail`/`grep` for the summary line, or `tm compress --tool
+  "<tool-name>"`), re-run only the failing case with full output, and never
+  `gh pr checks --watch`. Prompted by two agents burning 415k and 546k tokens
+  streaming per-test and per-check-poll output directly. States explicitly
+  that filtered output is still raw output — the evidence rule is unchanged

--- a/crates/trusty-mpm/changelog.d/agent-no-subagent-fanout.md
+++ b/crates/trusty-mpm/changelog.d/agent-no-subagent-fanout.md
@@ -14,3 +14,9 @@ Added
   then effect, show before-and-after, cut hedges and process narration, end
   options as a bare enumeration. Governs how, never whether: the evidence
   rule is unchanged
+- `BASE-AGENT.md` (synced to `trusty-code`) Agent-Authored Prose adds "never
+  announce the register you're writing in" — no heading or preamble that
+  labels the writing as plain, honest, direct, candid, blunt, or unvarnished
+  (e.g. "What remains unknown, stated plainly:"); state the fact in place
+  instead. Same family as the banned word "honest" — the label is forbidden,
+  not the disclosure

--- a/crates/trusty-mpm/changelog.d/agent-no-subagent-fanout.md
+++ b/crates/trusty-mpm/changelog.d/agent-no-subagent-fanout.md
@@ -6,3 +6,11 @@ Added
   reserved for the top-level PM/orchestrator. Prompted by a `rust-engineer`
   spawning an untyped child agent that bypassed the roster entirely for
   routine documentation work
+- `BASE-AGENT.md` (synced to `trusty-code`) adds "Agent-Authored Prose",
+  extending the PM's "Write Plainly" register (`core.md`,
+  [#4757](https://github.com/bobmatnyc/trusty-tools/issues/4757)) to the
+  agent side: review verdicts, reports back to the PM, ticket/PR body text,
+  and generated documentation — lead with the concrete referent, state cause
+  then effect, show before-and-after, cut hedges and process narration, end
+  options as a bare enumeration. Governs how, never whether: the evidence
+  rule is unchanged

--- a/crates/trusty-mpm/changelog.d/agent-no-subagent-fanout.md
+++ b/crates/trusty-mpm/changelog.d/agent-no-subagent-fanout.md
@@ -1,0 +1,8 @@
+Added
+
+- `BASE-AGENT.md` (synced to `trusty-code`) now states a "No Subagent
+  Fan-Out" rule: a delegated agent does its own work or reports back to its
+  dispatcher — it never spawns its own subagents. The Agent/Task tool is
+  reserved for the top-level PM/orchestrator. Prompted by a `rust-engineer`
+  spawning an untyped child agent that bypassed the roster entirely for
+  routine documentation work

--- a/crates/trusty-mpm/changelog.d/critic-promote-discipline.md
+++ b/crates/trusty-mpm/changelog.d/critic-promote-discipline.md
@@ -1,0 +1,11 @@
+Fixed
+
+- `code-review-standards` and the `code-critic` agent (both synced to
+  `trusty-code`) no longer let `Promote` act as a filing engine. The default
+  is now stated explicitly: a review finding is fixed in the surfacing PR, or
+  dropped. `Promote` is reserved for defects that are genuinely separable,
+  schedulable work — not every LOW/MEDIUM finding — and the critic never
+  files an issue itself or instructs anyone to; it only recommends, and the
+  PM or user decides. Prompted by nine issues filed in a single review leg
+  against one merged PR, several forwarded straight from an unqualified
+  `Promote` disposition

--- a/crates/trusty-mpm/changelog.d/critic-usage-standard.md
+++ b/crates/trusty-mpm/changelog.d/critic-usage-standard.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `agent-delegation.md` no longer claims code-critic is a "universal qa-tier
+  agent" for "any engineer dispatch" or design critique — both were owner
+  rulings against the actual standard. Added a "code-critic Dispatch
+  Standard" keyed to the project's test-ladder rung (never on rungs 1–3,
+  conditional on rung 4, required on rungs 5–6), plus explicit escalations
+  and non-reasons to dispatch
+- `code-production-process` (and its `stage-architect.md`/`stage-critic.md`
+  references, synced to `trusty-code`) no longer describes an "optional
+  Phase 2 design critic pass" at the Architect stage — that contradicted the
+  standard; early interface review routes to `code-analyzer` instead

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -345,6 +345,14 @@ documentation.
   said". They manage the reader, not the facts.
 - Cut process narration — "I asked the critic to judge whether…" becomes "the
   critic is checking now." State what is true, not what you asked for.
+- Never announce the register you're writing in. No heading or preamble that
+  labels the writing as plain, honest, direct, candid, blunt, or unvarnished
+  — labelling it implies the alternative was on the table. State the fact
+  where it belongs instead. Wrong: "What remains unknown, stated plainly:"
+  followed by a list, or "To be direct about the limitations:". Right: "The
+  retry path is untested." — said in place, where the reader needs it. Same
+  family as the banned word "honest" — the label, not the disclosure, is
+  what's forbidden.
 - End options as a bare enumeration — "Two options: A, or B" — not a sentence
   wrapped around the reader's preference.
 

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -230,6 +230,51 @@ This applies especially to verification-critical commands: test runs, `git`/`gh`
 reads and writes, and build output. An unobservable result is never a passing
 result.
 
+## Never Directly Monitor a Declarative Process
+
+A declarative process — a test suite, a build, a lint, a CI status check, an
+install, a migration — is one where you issue a command and want its verdict:
+pass/fail plus what broke. You never need the play-by-play. Watching one
+directly is the defect: an agent told to "rerun the suite until green" spent
+415k tokens because `cargo test` prints one line per test — this repo's own
+`trusty-mpm` suite alone runs several thousand — on every single re-run. A
+sibling agent spent 546k tokens on `gh pr checks --watch` streaming a
+15–17 minute CI job. Both are the same mistake: a declarative process
+monitored directly instead of run, then read.
+
+The pipeline, in order:
+
+1. **Run it.** Don't watch, tail, or poll a live stream.
+2. **Trim the output.** Cargo's own quiet flags (`--quiet`) and `tail`/`grep`
+   for the summary line are enough for most gates and need no extra tooling.
+   Where a heavier squeeze helps, this repo ships a compression framework as
+   a Unix filter: `<command> 2>&1 | tm compress --tool "<tool-name>"`
+   (`crates/trusty-mpm/src/bin/tm/commands/compress.rs` — reads stdin to EOF,
+   compresses, writes stdout; `--tool` is a free-form string matched by
+   substring, e.g. `"cargo test"`, `"cargo check"`, `"git diff"`, `"git log"`
+   — not a fixed enum). `cargo test -p trusty-mpm 2>&1 | tm compress --tool
+   "cargo test"` strips passing `test ... ok` lines and keeps FAILED/error/
+   warning lines plus the final `test result:` summary. Known gap: its
+   structured-format guard can misread a leading `key: value`-shaped line —
+   e.g. a `warning: <path>: ...` cargo build warning ahead of the actual test
+   output — as YAML and skip compression entirely, silently. `--quiet` (or
+   `tail`/`grep` for the result line) is the reliable default; treat
+   `tm compress` as an addition on top, not a replacement for it, until that
+   gap is fixed.
+3. **If still long, have Haiku summarize it** before you read it.
+4. **Only then does the agent read it.**
+
+On failure, re-run only the failing case with full output — that's the only
+place per-test detail carries information.
+
+**This does not weaken the evidence rule above.** Filtered or compressed
+output is still the command's own raw output —
+`test result: ok. 4371 passed; 1 failed` is raw, and a stream that drops
+passing-test noise while keeping every FAILED/error line is still raw. What's
+forbidden is the agent summarizing results in its own words. Raw output stays
+mandatory for failures, flakes, and performance claims — see the project's
+own test ladder where one exists.
+
 ## Finishing Work — Push, Report, Stop
 
 🔴 **Never block on CI.** When your work is done: push, take a ONE-SHOT status

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -326,6 +326,38 @@ a delegated agent. If you armed a `Monitor`, `/loop`, or `/schedule` and its goa
 completed or went moot, disarm it before reporting; a stale monitor re-fires and
 surfaces as a spurious wake.
 
+## Agent-Authored Prose
+
+The PM applies a prose standard to its own responses and reports
+("Prose Style — Write Plainly" in `sections/core.md`). The same standard
+governs everything you write back: the report to your dispatcher, a review
+verdict, ticket and PR body text drafted before handoff, and any generated
+documentation.
+
+- Lead with the concrete referent, not its category — name the file, the
+  function, the finding; let the reader infer the category.
+- State mechanism as cause then effect, in plain verbs: "if X fails, Y still
+  happens" beats a passive abstraction like "is still an early non-fatal
+  return."
+- Show before-and-after when something changed — "it used to say X, now it
+  says X except here" — not just the abstract fact that it changed.
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They manage the reader, not the facts.
+- Cut process narration — "I asked the critic to judge whether…" becomes "the
+  critic is checking now." State what is true, not what you asked for.
+- End options as a bare enumeration — "Two options: A, or B" — not a sentence
+  wrapped around the reader's preference.
+
+**Ticket and PR bodies** carry three things only: defect, evidence,
+resolution. Point at a spec section instead of restating it; never paste a
+source-file table into a ticket — link the file and line.
+
+**Prose only — this governs how, never whether.** Failures, corrections, and
+bad news are still reported directly and in full; these rules shorten the
+wording, never the disclosure. You still never summarize test results in your
+own words, and raw output stays mandatory for failures — see Verification
+Before Completion and Never Directly Monitor a Declarative Process above.
+
 ## Output Format
 
 - Lead with what you did, not what you're going to do.

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -110,6 +110,24 @@ accomplished, the remaining tasks, and any relevant constraints.
 | QA → Engineer | Bug found |
 | Any → Research | Investigation needed |
 
+## No Subagent Fan-Out
+
+An agent does its own work or reports back to its dispatcher — it never
+spawns its own subagents. The Agent/Task tool is reserved for the top-level
+PM/orchestrator. A delegated agent that faces genuinely parallel work (a
+research sweep across many files, several independent fixes) does it
+serially, or reports back so the PM can parallelise it — it does not fan out
+children of its own to do it.
+
+This includes documentation work a parent would normally have delegated —
+changelog fragments, README edits, doc-comment updates. Do that yourself;
+do not spawn a child agent for it.
+
+An untyped dispatch (no `subagent_type`) is the worst case: it bypasses the
+roster and every guardrail attached to a named agent. Never dispatch
+without one — and under this rule, never dispatch at all from inside a
+delegated agent.
+
 ## Proactive Code Quality
 
 - Search before creating. Use grep/glob (and code search when available) to find

--- a/crates/trusty-mpm/src/assets/agents/code-critic.md
+++ b/crates/trusty-mpm/src/assets/agents/code-critic.md
@@ -69,6 +69,7 @@ This prevents anchoring bias. Review the code against the spec only.
 - Do not consolidate findings into vague summaries — file+line+fix for every finding
 - Do not skip the 80% confidence filter
 - Do not flag style preferences (whitespace, naming aesthetic, import order) as HIGH or CRITICAL — those are LOW at most (see `code-review-standards`)
+- Do not default a finding to `Promote` because it's easier than deciding — a finding is fixed here or dropped; `Promote` is reserved for genuinely separable work. You never file an issue or instruct anyone to — you recommend, the PM decides (see `code-review-standards`)
 - A zero-finding APPROVE is a valid, correct outcome — do not manufacture issues
 
 For the full severity taxonomy, output format, and detailed verdict protocol, see the `code-review-standards` skill. For evaluating test coverage against Code Contracts, see the `contract-driven-testing` skill.

--- a/crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/agent-delegation.md
@@ -27,12 +27,38 @@ Agent" or "API QA" is not an agent and fails to dispatch (issue #4594).
 | `local-ops` | Deploying apps, managing infrastructure, starting servers, port/process management | Environment config, deployment procedures | Generic `ops` is DEPRECATED; use `local-ops` for localhost/PM2/docker |
 | `qa`, `web-qa`, `api-qa` | Testing implementations, verifying deployments, regression tests, browser testing | Playwright (web), fetch (APIs), verification protocols | For browser: use `web-qa` (never use chrome-devtools, claude-in-chrome, or playwright directly) |
 | `code-analyzer` | Reviewing a proposed solution before implementation; static analysis, correctness and architectural health | Static analysis, APPROVED/NEEDS_IMPROVEMENT/BLOCKED verdict | This is the phase-2 "Code Analysis" agent. `code-analyzer` and `code-critic` are separate agents, not interchangeable |
-| `code-critic` | Adversarial code review with rubric-based verdict (APPROVE/WARN/BLOCK). Universal qa-tier agent — code review, design critique, adversarial verdict on any engineer dispatch | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | trusty-mpm (universal) |
+| `code-critic` | Adversarial code review with a rubric-based verdict (APPROVE/WARN/BLOCK) on code that already exists and passes its tests. NOT for design critique, NOT for every engineer dispatch — dispatch is gated, see "code-critic Dispatch Standard" below | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | trusty-mpm (universal), dispatch-gated |
 | `documentation` | Creating/updating docs, README, API docs, guides | Style consistency, organization standards | - |
 | `ticketing` | Issue/ticket bookkeeping: create, update, close, label, triage, comment (P6) | `gh issue` surface, scope validation, workflow state | Required by P6 — ticket bookkeeping never goes to `version-control` |
 | `version-control` | Creating PRs, managing branches, complex git ops (P7) | PR workflows, branch management | Check git user for main branch access |
 | `security` | Pre-push credential scan, vulnerability assessment | Secret scanning, attack-vector detection | - |
 | `mpm-skills-manager` | Creating/improving skills, recommending skills, stack detection | manifest.json access, validation tools, GitHub PR integration | Triggers: "skill", "stack", "framework" |
+
+## code-critic Dispatch Standard
+
+The critic tier keys off the project's test-ladder rung (this repo's Rust
+Test Ladder in `CLAUDE.md`) — never a parallel risk axis invented for this
+decision.
+
+| Rung | Change class | Dispatch code-critic? |
+|---|---|---|
+| 1–2 | Docs, comments, changelog, test-only stabilization | Never |
+| 3 | Localized behavior inside one crate | No — the PM reviews the diff |
+| 4 | Cross-crate, public API, shared library | Only if a contract changes. Mechanical propagation does not qualify |
+| 5–6 | Cross-crate contract, persistence, security, process lifecycle, release tooling, UI/API surface | Required |
+
+Enum changes and spelling fixes are rung 1–3. No critic.
+
+**Escalate to required regardless of rung:**
+- the change can start, refuse, or gate a session
+- it touches a trust boundary or an injection defense
+- it rewrites history or force-pushes
+- the PR is already at review round 3+ — evidence something is being missed
+
+**Not a reason to dispatch:**
+- a design question — send it to the owner, or the PM decides
+- the PM is unsure and wants a second opinion
+- confirming green CI
 
 ## Ops Agent Routing
 

--- a/crates/trusty-mpm/src/assets/skills/code-production-process.md
+++ b/crates/trusty-mpm/src/assets/skills/code-production-process.md
@@ -101,9 +101,10 @@ failure.
 **Gate:** Interface document exists. Zero implementation code (no function bodies with logic,
 no algorithm steps, no I/O calls). The architect produces the contract; the engineer fills it.
 
-**Important:** The `code-critic` agent may optionally be dispatched here to review the
-interface design for API coherence before implementation begins. This is the Phase 2 design
-critic pass. If dispatched, critic input is the interface document only — no code exists yet.
+**Note:** `code-critic` is not dispatched at this stage — it reviews working,
+tested code only (see the "code-critic Dispatch Standard" in
+`agent-delegation.md`). If interface-level review is wanted before
+implementation begins, dispatch `code-analyzer` instead.
 
 **See:** `references/stage-architect.md` for interface specification templates.
 
@@ -171,6 +172,11 @@ When tests pass green, provide updated implementation + passing pytest output.
 ### Stage 4: Critic Review
 
 **Agent:** `code-critic`
+
+Dispatch here still follows the "code-critic Dispatch Standard" in
+`agent-delegation.md`, keyed to the project's test-ladder rung — this stage
+describes how the critic reviews when dispatched, not a standing exemption
+from that standard.
 
 **Skills loaded:** `code-review-standards`, `code-production-process`
 

--- a/crates/trusty-mpm/src/assets/skills/code-production-process/references/stage-architect.md
+++ b/crates/trusty-mpm/src/assets/skills/code-production-process/references/stage-architect.md
@@ -4,8 +4,9 @@
 
 The Architect stage produces the binding contract between "what was asked" (Stage 1 spec)
 and "what will be built" (Stage 3 implementation). By separating interface design from
-implementation, the pipeline allows critic review of API design before any code is written,
-catching structural problems when they are cheapest to fix.
+implementation, the pipeline allows early architectural review — via `code-analyzer`, not
+`code-critic` (see the "code-critic Dispatch Standard" in `agent-delegation.md`) — before
+any code is written, catching structural problems when they are cheapest to fix.
 
 ## Agent and Mode
 

--- a/crates/trusty-mpm/src/assets/skills/code-production-process/references/stage-critic.md
+++ b/crates/trusty-mpm/src/assets/skills/code-production-process/references/stage-critic.md
@@ -70,4 +70,3 @@ Before accepting the critic output:
 <!-- TODO: Add examples of well-formed vs poorly-formed findings -->
 <!-- TODO: Add guidance on how PM should evaluate suspiciously clean APPROVE verdicts -->
 <!-- TODO: Add patterns for multi-file implementations (how to cite cross-file issues) -->
-<!-- TODO: Add notes on the optional Phase 2 design critic pass (interface review before Stage 3) -->

--- a/crates/trusty-mpm/src/assets/skills/code-review-standards.md
+++ b/crates/trusty-mpm/src/assets/skills/code-review-standards.md
@@ -58,19 +58,23 @@ Notes section rather than asserting a severity you can't back up.
 ## Finding Disposition
 
 Every finding ends in exactly one of three states, and the review STATES which
-one. This extends the shipped review-finding rule — fix it in the surfacing PR
-or drop it — by naming the third exit that rule left implicit: work that is
-genuinely separable.
+one. **The default is the framework's existing rule: a review finding is
+fixed in the surfacing PR, or dropped.** `Promote` is the narrow third exit
+that rule leaves implicit — work that is genuinely separable, not a home for
+every LOW or MEDIUM finding that doesn't obviously fit the first two.
 
 1. **`Fix here`** — corrected in the surfacing PR. The default for correctness,
    security, acceptance criteria, regression coverage, and any small in-scope
    repair.
 2. **`Parent`** — kept with the work already in flight, as a PR comment or a
    checklist item on the parent issue. No durable artifact is created.
-3. **`Promote`** — recommended for a standalone issue. The reviewer only
-   recommends. Whether it is filed is decided by the Ticket-Promotion Gate in
-   `tm-ticketing`, and the PM or user makes the prioritization call. Do not
-   re-derive that gate's criteria here.
+3. **`Promote`** — reserved for a defect that is genuinely separable work
+   someone would schedule on its own, never the default landing spot for a
+   LOW finding that just doesn't feel worth fixing right now. The critic only
+   *recommends* `Promote` — it does not file the issue itself and does not
+   instruct anyone else to file one. Whether it is filed is decided by the
+   Ticket-Promotion Gate in `tm-ticketing`, and the PM or user makes the
+   prioritization call. Do not re-derive that gate's criteria here.
 
 **An APPROVE verdict does not generate tickets.** Approving means zero CRITICAL
 and zero HIGH findings; the MEDIUM/LOW observations that remain default to
@@ -148,8 +152,12 @@ correct, and complete outcome — do not manufacture findings to look thorough.
   as HIGH or CRITICAL — see the guard rail above. LOW at most.
 - Do not leave a finding without a disposition. "Noted" is not one of the
   three.
-- Do not file issues for your own LOW/MEDIUM polish after an APPROVE. Mark
-  them `Promote` and hand the decision to the PM.
+- Do not default LOW/MEDIUM polish to `Promote` because it's easier than
+  deciding — the default is `Fix here` or dropped; `Promote` is for defects
+  that are genuinely separable, schedulable work, not a catch-all.
+- Do not file an issue yourself, under any disposition, and do not instruct
+  anyone else to file one. `Promote` is a recommendation to the PM — never an
+  action the critic takes.
 - A zero-finding APPROVE is correct and complete. Do not feel pressure to
   find issues that aren't there.
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -783,12 +783,38 @@ Agent" or "API QA" is not an agent and fails to dispatch (issue #4594).
 | `local-ops` | Deploying apps, managing infrastructure, starting servers, port/process management | Environment config, deployment procedures | Generic `ops` is DEPRECATED; use `local-ops` for localhost/PM2/docker |
 | `qa`, `web-qa`, `api-qa` | Testing implementations, verifying deployments, regression tests, browser testing | Playwright (web), fetch (APIs), verification protocols | For browser: use `web-qa` (never use chrome-devtools, claude-in-chrome, or playwright directly) |
 | `code-analyzer` | Reviewing a proposed solution before implementation; static analysis, correctness and architectural health | Static analysis, APPROVED/NEEDS_IMPROVEMENT/BLOCKED verdict | This is the phase-2 "Code Analysis" agent. `code-analyzer` and `code-critic` are separate agents, not interchangeable |
-| `code-critic` | Adversarial code review with rubric-based verdict (APPROVE/WARN/BLOCK). Universal qa-tier agent — code review, design critique, adversarial verdict on any engineer dispatch | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | trusty-mpm (universal) |
+| `code-critic` | Adversarial code review with a rubric-based verdict (APPROVE/WARN/BLOCK) on code that already exists and passes its tests. NOT for design critique, NOT for every engineer dispatch — dispatch is gated, see "code-critic Dispatch Standard" below | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | trusty-mpm (universal), dispatch-gated |
 | `documentation` | Creating/updating docs, README, API docs, guides | Style consistency, organization standards | - |
 | `ticketing` | Issue/ticket bookkeeping: create, update, close, label, triage, comment (P6) | `gh issue` surface, scope validation, workflow state | Required by P6 — ticket bookkeeping never goes to `version-control` |
 | `version-control` | Creating PRs, managing branches, complex git ops (P7) | PR workflows, branch management | Check git user for main branch access |
 | `security` | Pre-push credential scan, vulnerability assessment | Secret scanning, attack-vector detection | - |
 | `mpm-skills-manager` | Creating/improving skills, recommending skills, stack detection | manifest.json access, validation tools, GitHub PR integration | Triggers: "skill", "stack", "framework" |
+
+## code-critic Dispatch Standard
+
+The critic tier keys off the project's test-ladder rung (this repo's Rust
+Test Ladder in `CLAUDE.md`) — never a parallel risk axis invented for this
+decision.
+
+| Rung | Change class | Dispatch code-critic? |
+|---|---|---|
+| 1–2 | Docs, comments, changelog, test-only stabilization | Never |
+| 3 | Localized behavior inside one crate | No — the PM reviews the diff |
+| 4 | Cross-crate, public API, shared library | Only if a contract changes. Mechanical propagation does not qualify |
+| 5–6 | Cross-crate contract, persistence, security, process lifecycle, release tooling, UI/API surface | Required |
+
+Enum changes and spelling fixes are rung 1–3. No critic.
+
+**Escalate to required regardless of rung:**
+- the change can start, refuse, or gate a session
+- it touches a trust boundary or an injection defense
+- it rewrites history or force-pushes
+- the PR is already at review round 3+ — evidence something is being missed
+
+**Not a reason to dispatch:**
+- a design question — send it to the owner, or the PM decides
+- the PM is unsure and wants a second opinion
+- confirming green CI
 
 ## Ops Agent Routing
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -783,12 +783,38 @@ Agent" or "API QA" is not an agent and fails to dispatch (issue #4594).
 | `local-ops` | Deploying apps, managing infrastructure, starting servers, port/process management | Environment config, deployment procedures | Generic `ops` is DEPRECATED; use `local-ops` for localhost/PM2/docker |
 | `qa`, `web-qa`, `api-qa` | Testing implementations, verifying deployments, regression tests, browser testing | Playwright (web), fetch (APIs), verification protocols | For browser: use `web-qa` (never use chrome-devtools, claude-in-chrome, or playwright directly) |
 | `code-analyzer` | Reviewing a proposed solution before implementation; static analysis, correctness and architectural health | Static analysis, APPROVED/NEEDS_IMPROVEMENT/BLOCKED verdict | This is the phase-2 "Code Analysis" agent. `code-analyzer` and `code-critic` are separate agents, not interchangeable |
-| `code-critic` | Adversarial code review with rubric-based verdict (APPROVE/WARN/BLOCK). Universal qa-tier agent — code review, design critique, adversarial verdict on any engineer dispatch | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | trusty-mpm (universal) |
+| `code-critic` | Adversarial code review with a rubric-based verdict (APPROVE/WARN/BLOCK) on code that already exists and passes its tests. NOT for design critique, NOT for every engineer dispatch — dispatch is gated, see "code-critic Dispatch Standard" below | Rubric-based severity scoring (CRITICAL/HIGH/MEDIUM/LOW), APPROVE/WARN/BLOCK protocol, anchoring-bias isolation | trusty-mpm (universal), dispatch-gated |
 | `documentation` | Creating/updating docs, README, API docs, guides | Style consistency, organization standards | - |
 | `ticketing` | Issue/ticket bookkeeping: create, update, close, label, triage, comment (P6) | `gh issue` surface, scope validation, workflow state | Required by P6 — ticket bookkeeping never goes to `version-control` |
 | `version-control` | Creating PRs, managing branches, complex git ops (P7) | PR workflows, branch management | Check git user for main branch access |
 | `security` | Pre-push credential scan, vulnerability assessment | Secret scanning, attack-vector detection | - |
 | `mpm-skills-manager` | Creating/improving skills, recommending skills, stack detection | manifest.json access, validation tools, GitHub PR integration | Triggers: "skill", "stack", "framework" |
+
+## code-critic Dispatch Standard
+
+The critic tier keys off the project's test-ladder rung (this repo's Rust
+Test Ladder in `CLAUDE.md`) — never a parallel risk axis invented for this
+decision.
+
+| Rung | Change class | Dispatch code-critic? |
+|---|---|---|
+| 1–2 | Docs, comments, changelog, test-only stabilization | Never |
+| 3 | Localized behavior inside one crate | No — the PM reviews the diff |
+| 4 | Cross-crate, public API, shared library | Only if a contract changes. Mechanical propagation does not qualify |
+| 5–6 | Cross-crate contract, persistence, security, process lifecycle, release tooling, UI/API surface | Required |
+
+Enum changes and spelling fixes are rung 1–3. No critic.
+
+**Escalate to required regardless of rung:**
+- the change can start, refuse, or gate a session
+- it touches a trust boundary or an injection defense
+- it rewrites history or force-pushes
+- the PR is already at review round 3+ — evidence something is being missed
+
+**Not a reason to dispatch:**
+- a design question — send it to the owner, or the PM decides
+- the PM is unsure and wants a second opinion
+- confirming green CI
 
 ## Ops Agent Routing
 

--- a/scripts/agent-asset-pins.tsv
+++ b/scripts/agent-asset-pins.tsv
@@ -20,6 +20,6 @@
 # Regenerate a pin (only after manually reconciling the tcode copy with the
 # new upstream content) with: scripts/check_agent_assets.sh --update
 crates/trusty-mpm/src/assets/agents/code-analyzer.md	55d810bc4f3524740165aeb75f687bf21c2d07597401e278e8aa17077727bad0
-crates/trusty-mpm/src/assets/agents/code-critic.md	539e7a8d5fa2969dd7a4d29a092d178b84bd98bf965a413d11df13c9625dfaa9
+crates/trusty-mpm/src/assets/agents/code-critic.md	5af5724d50d69273fc4665bcc85a37dcb9611f0ca106f4900f14990a68cd0521
 crates/trusty-mpm/src/assets/agents/qa.md	40d4b79e9ecfd934fd77012a249396a80fefd43a9ccc7f0e347755e922366ca2
 crates/trusty-mpm/src/assets/agents/web-qa.md	339ba6d85e2024ea7b5683249bf5c53feff2d45f610d998cd286b198a638d31a


### PR DESCRIPTION
## Summary

Four related agent-dispatch-and-output-discipline rulings, landed together as one outcome in `BASE-AGENT.md` (synced byte-for-byte to `crates/trusty-code/src/assets/agents/BASE-AGENT.md`) and its dependencies.

### 1. code-critic dispatch standard

`agent-delegation.md` described code-critic as a "universal qa-tier agent" for "any engineer dispatch" including design critique — both ruled wrong. Added a "code-critic Dispatch Standard" keyed to the project's test-ladder rung: never on rungs 1–3 (docs, changelog, test-only stabilization, localized single-crate behavior, enum changes, spelling fixes — PM reviews the diff), conditional on rung 4 (only if a contract changes), required on rungs 5–6. Plus explicit escalations (session gating, trust boundaries, history rewrites/force-pushes, review round 3+) and non-reasons (design questions, PM uncertainty, confirming green CI).

Swept every place the critic's scope is described in both crates' assets. Found and fixed a second contradiction: `code-production-process`'s Stage 2 described an "optional Phase 2 design critic pass" for `code-critic` — removed; early interface review now routes to `code-analyzer`.

### 2. No Subagent Fan-Out

Trigger: a `rust-engineer` spawned an untyped child agent for documentation work, bypassing the 42-agent roster and every guardrail attached to a named agent. Added: a delegated agent does its own work or reports back to its dispatcher; it never spawns its own subagents; the Agent/Task tool is reserved for the top-level PM/orchestrator. Audited every bundled agent for contradicting dispatch guidance — none found.

### 3. Never Directly Monitor a Declarative Process

Two agents burned 415k and 546k tokens streaming per-test and per-CI-check output directly. Added: run it, trim with `--quiet`/`tail`/`grep` or this repo's `tm compress --tool "<name>"`, summarize with Haiku if still long, only then read it. On failure, re-run only the failing case with full output. States explicitly this doesn't weaken the evidence rule — filtered output is still raw output.

**Ground-truth on `tm compress`** (verified directly, not assumed — `crates/trusty-agents-common/src/compress/tool_output/mod.rs`): `--tool` is a free-form string matched by substring, not an enum (`"cargo test"`, `"cargo check"`, `"git diff"`, `"git log"`, …). Confirmed working: `cargo test -p trusty-mpm --quiet 2>&1 | tm compress --tool "cargo test"` reduced 37,616→3,107 bytes (91.7%) on this repo's own suite. Also confirmed two real gaps, documented in the rule rather than papered over: (a) its structured-format guard misreads a leading `warning: <path>: ...` cargo build warning as YAML `key: value` and skips compression entirely — a verbose run led by a fresh build warning compressed 0% (374,305→374,305 bytes); (b) `filter_test_runner` keeps only the *last* `test result:` line when multiple test binaries run in one invocation, silently dropping the `--lib` summary. Given both, the rule recommends `--quiet`/`tail`/`grep` as the reliable default and `tm compress` as an addition on top, not a replacement. Test count corrected from a cited ~7,450: this repo's `cargo test -p trusty-mpm` runs ~4,380–4,400 tests today, verified directly.

### 4. Agent-Authored Prose

Issue #4757 (PR #4812, merged as `2b1ac74d`) widened `core.md`'s "Write Plainly" register to every artifact the *PM* authors. `core.md` only reaches PM-authored text — review verdicts (code-critic) and generated docs (`documentation` agent) are agent-authored and outside its reach. Adds the agent-side half to `BASE-AGENT.md`: the same six rules (lead with the concrete referent, cause-then-effect, before-and-after, cut hedges, cut process narration, bare-enumeration options), scoped to reports back to the PM, review verdicts, ticket/PR body text, and generated documentation. Mirrors PR #4812's landed wording (`git show 2b1ac74d -- .../core.md`) rather than the pre-merge PR diff. Placed as its own section ahead of the existing, test-pinned `## Output Format` heading rather than folding into or renaming it (`bundle_tests.rs` asserts that literal heading and its position). States the same "governs how, never whether" constraint — the evidence rule is unchanged.

### Also fixed: critic Promote discipline

Nine issues filed in a single review leg against one merged PR, several forwarded straight from an unqualified `Promote` disposition. `code-review-standards` and the `code-critic` agent (both crates) now state explicitly: the default is fix-in-the-surfacing-PR or drop; `Promote` is reserved for defects that are genuinely separable, schedulable work, not every LOW/MEDIUM finding; the critic never files an issue itself or instructs anyone to — it recommends, the PM decides. Confirmed no contradiction with the new dispatch standard (code-review-standards has no scope-of-dispatch language at all — it governs review content, not when to dispatch).

## Rebase history

Rebased three times as `origin/main` moved during this PR: `29a90314` → `b60b8136` (clean) → `3c4449fa` (one conflict, `BASE-AGENT.md`, resolved: PR #4795 renamed "Foreground Execution" to "Finishing Work — Push, Report, Stop"; my new section now sits between "Empty-Output Protocol" and that renamed section) → `2b1ac74d` (PR #4812 merged; clean rebase, goldens auto-merged correctly — verified both #4812's prose rules and this PR's code-critic text are present, neither reverted the other).

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -p trusty-mpm --quiet -- -D warnings` — clean
- [x] `cargo test -p trusty-mpm --quiet` — 4393 passed, 1 failed, 7 ignored. The one failure, `client::executor::tests::execute_doctor_against_test_daemon`, is the documented environmental flake (CLAUDE.md test-ladder-baseline: "daemon unreachable" connection errors under concurrent-worktree load on this machine). Diff touches zero files under `crates/trusty-mpm/src/client/` (`git diff --name-only origin/main...HEAD` — 0 `.rs` files touched anywhere in this PR). Two other tests flickered once under heavy concurrent-worktree load earlier in this session (`daemon::managed_routes::tests::stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet`, `tests_behavior_b::compose_session_instructions_display_matches_live_prompt[_with_override]`) and passed clean on every other run, including the final gate run reported here — load-induced, not caused by this diff.
- [x] `bash scripts/check_line_cap.sh` — OK, 0 violations
- [x] `bash scripts/check_sld.sh` — OK, 0 errors/warnings
- [x] `bash scripts/check_changelog_fragment.sh` — OK, both crates recorded
- [x] `bash scripts/check_agent_assets.sh` — OK, 30 byte-parity files match, 4 pinned deviations match upstream (re-pinned `code-critic.md` after editing its Promote-discipline bullet)
- [x] PM-prompt goldens regenerated (`UPDATE_GOLDEN=1 cargo test -p trusty-mpm golden --quiet`) after every rebase; diffs reviewed each time, contain only the intended text

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
