### PR TITLE
docs(instructions): retire the blocking CI wait — agents push, report, stop

### DIFF
--- a/crates/trusty-code/changelog.d/4792-retire-blocking-ci-wait.md
+++ b/crates/trusty-code/changelog.d/4792-retire-blocking-ci-wait.md
@@ -1,0 +1,5 @@
+Changed
+
+- Bundled agent assets no longer prescribe a blocking CI wait: `BASE-AGENT.md`, `BASE-ENGINEER.md`, and `local-ops.md` now direct agents to push, take a ONE-SHOT `gh pr checks` / `gh pr view` status read, report, and end the turn ([#4792](https://github.com/bobmatnyc/trusty-tools/issues/4792))
+  - `gh pr checks --watch` is forbidden — it streams check output into the agent's context. Own-gate commands (builds, test suites) still block in the foreground
+  - Kept byte-identical to the `trusty-mpm` asset originals

--- a/crates/trusty-code/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-code/src/assets/agents/BASE-AGENT.md
@@ -212,96 +212,56 @@ This applies especially to verification-critical commands: test runs, `git`/`gh`
 reads and writes, and build output. An unobservable result is never a passing
 result.
 
-## Foreground Execution — NEVER End Your Turn To Wait
+## Finishing Work — Push, Report, Stop
 
-🔴 **You must NEVER end your turn to "wait" for anything.** Nothing re-invokes a
-stopped agent. The moment you end your turn, you are stopped — no background
-monitor, watcher, poller, timer, or notification you spawned can ever wake you
-back up. It fires into the void and your task strands until a human notices and
-manually resumes you. Waiting is done ONLY by running a blocking command in the
-FOREGROUND and letting it hold your turn until the thing you're waiting for is
-done.
-
-**Background monitors/watchers/pollers are FORBIDDEN as a wake mechanism.** Do
-not spawn a "background polling monitor", "background watcher", or async job and
-then end your turn expecting it to report back. That mechanism does not exist for
-you — it exists only for a top-level human-driven orchestrator, never for a
-delegated agent.
-
-**Ending your turn with any of these — "waiting for…", "monitoring…", "standing
-by…", "will report when…", "I'll report back once…", "checking back later",
-"I'll wait for the notification" — is a PROTOCOL VIOLATION, not a status
-update.** If you catch yourself about to write one of those, you are about to
-strand the task. Instead: run the blocking command now, in this turn.
-
-### Canonical CI-wait pattern (blocking, foreground)
+🔴 **Never block on CI.** When your work is done: push, take a ONE-SHOT status
+read, report what it says, and END YOUR TURN. The PM re-engages when CI settles.
+Anti-parking is enforced by the PM coming back, not by you holding a turn open.
 
 ```bash
-gh pr checks <pr> --watch --fail-fast    # blocks until all checks settle
+gh pr view <pr> --json state,mergeable,statusCheckRollup   # one shot
+gh pr checks <pr>                                          # one shot
 ```
 
-Run it as a plain foreground command and let it hold the turn — even 15+ minutes.
-Do NOT background it (`&` / `run_in_background`). Do NOT end the turn to "monitor
-the checks". When it exits, read the result and act. If it exits nonzero, capture
-the failure evidence and report it — don't retry-by-waiting.
+Two ways that read misleads if you take it flatly:
 
-### Canonical long-command pattern (blocking, foreground)
+- **`bucket` can report a false DONE.** Under GitHub API eventual-consistency
+  lag a check surfaces as bucketed-complete before it has actually settled.
+  Cross-check the `state` field before calling anything green.
+- **Repeated `gh pr update-branch` is a treadmill.** When main drifts faster than
+  CI completes, each update mints a new untested head and restarts the clock.
+  Merge the head that is actually green; BEHIND is not a correctness gate.
 
-Run builds, test suites, and deploy waits as plain foreground commands with a
-long timeout and wait for them to exit. If a command was already backgrounded,
-you MUST poll it to completion with blocking status calls in the SAME turn — you
-may not end the turn while it is still running.
+### Never `gh pr checks --watch`
 
-### When a single invocation times out
+`--watch` streams every check's output into your context for the whole run — one
+engineer burned 546k tokens over 54 minutes on a single PR. That is why blocking
+CI waits are retired: **context cost**, not runnability (`--watch` runs fine; an
+explicit `timeout` raises the 120s bash default toward the 600000ms ceiling). Do
+not reintroduce it, and do not substitute a manual poll loop for it.
 
-The tool layer enforces a hard per-invocation timeout (10 minutes / 600000ms). If
-a blocking command hits that ceiling before finishing — or otherwise legitimately
-outlasts one invocation — immediately RE-ISSUE the same blocking command (or its
-status-check equivalent; e.g. running `gh pr checks <pr> --watch` again resumes
-watching) in the SAME turn, looping re-invocations until it completes. Re-issuing
-is not "checking back later"; the forbidden move is ending the turn to wait, not
-the re-invocation itself.
+### Report, don't promise
 
-This rule exists because merge/CI/release agents repeatedly parked mid-watch
-waiting for a notification that never came (issues #2501, #2610).
+Hand back with an observation: "pushed `<sha>`; 3 checks pending — PM to
+re-engage when they settle." Ending with "I'll report back once CI is green",
+"monitoring the checks", "standing by", or "waiting for the notification" is a
+PROTOCOL VIOLATION, not a status update — nothing re-invokes a stopped agent, so
+a promise to return strands the task.
 
-### Re-issue without spamming — the chunked-repoll pattern (issue #2833)
+### Your own gates DO block, in the foreground
 
-Re-issuing a wait must not degenerate into the OPPOSITE failure: a tight blind
-poll loop that emits a "still pending" line every ~30 seconds for 20+ minutes.
-Parking and spamming are two ends of the same mistake — both come from not
-sizing the wait to its real duration.
+A build, test suite, or lint run is YOUR gate, it terminates, and its output is
+the evidence you owe. Run it as a plain foreground command with an explicit long
+`timeout` and let it hold the turn until it exits. Keep gates crate-scoped
+(`cargo test -p <crate>`) so they finish inside one invocation; re-issue in the
+SAME turn if one legitimately outlasts the ceiling. If a command was already
+backgrounded, poll it to completion in the same turn.
 
-- **Prefer the blocking watch.** `gh pr checks <pr> --watch --fail-fast` blocks
-  silently until checks settle and prints once. It is the correct primitive —
-  it neither parks nor spams. Re-issue it verbatim after a 10-min ceiling.
-- **If you must repoll a status command** (no `--watch` available), use a
-  blocking wait sized to the KNOWN wall-clock, not to impatience — a
-  Monitor/until-loop where the harness provides one, or a minutes-scale sleep
-  where it doesn't (some harnesses block a raw foreground `sleep`; use whatever
-  blocking primitive is actually available). Size it to a 5-minute-plus interval
-  for a ~15-minute CI run, not 30 seconds. A tight loop tells the reader nothing
-  they didn't know 30 seconds ago.
-- **Message only on state change.** Emit a line when the observed state actually
-  changes (pending→running, a check flips, count drops), not on every poll. "No
-  change" is not worth a message.
-- **Diagnose an overrun once.** If a wait runs abnormally long (well past the
-  expected wall-clock), run a ONE-SHOT diagnosis — `gh run view <run-id>` (or
-  `gh pr checks <pr>` without `--watch`) — to see WHY it's stuck, then resume the
-  blocking wait. Do not convert the overrun into faster polling.
-- **Disarm monitors on goal completion.** When your goal completes or becomes
-  moot — a CI run settles, a deployment finishes, a file appears, a condition
-  is satisfied — immediately cancel or disarm any `Monitor` tool call, `/loop`,
-  or `/schedule` routine you started (this cleans up legitimate recurring checks
-  — it does not re-authorize a background watcher to wake your own stopped turn).
-  A stale monitor re-fires after your goal is done, waking the agent again and
-  surfacing as a spurious "Agent finished" event to the user. Disarm first, then
-  report. This applies even if the monitor timeout is "distant" — do not rely on
-  wall-clock limits to clean up your own armed state.
-
-Do not end your turn while an unresolved wait is yours to watch — re-issue the
-blocking wait instead. A quiet foreground block is the goal; a poll-spam stream
-is a smell that you dropped the blocking primitive for a manual loop.
+Never spawn a background monitor, watcher, poller, or timer as a wake mechanism
+and end your turn expecting it to report back — that mechanism does not exist for
+a delegated agent. If you armed a `Monitor`, `/loop`, or `/schedule` and its goal
+completed or went moot, disarm it before reporting; a stale monitor re-fires and
+surfaces as a spurious wake.
 
 ## Output Format
 

--- a/crates/trusty-code/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-code/src/assets/agents/BASE-ENGINEER.md
@@ -196,8 +196,9 @@ Before returning, re-read the prompt for "Deliverables" / "Requirements" /
 Run that verify/quality-gate command as a BLOCKING FOREGROUND call and wait for it
 to exit — even 15+ minutes. NEVER end your turn to "wait for the gate to finish"
 or hand it to a background monitor: nothing wakes a stopped agent, so the run
-strands until a human resumes you. See BASE-AGENT "Foreground Execution — NEVER
-End Your Turn To Wait" (issues #2501, #2610).
+strands until a human resumes you. CI is the opposite case — never block on it;
+push, take a one-shot status read, report, and stop. See BASE-AGENT "Finishing
+Work — Push, Report, Stop".
 
 ## Output Requirements
 

--- a/crates/trusty-code/src/assets/agents/local-ops.md
+++ b/crates/trusty-code/src/assets/agents/local-ops.md
@@ -85,38 +85,33 @@ npm audit / cargo audit / bandit -r src/
 
 Surface failures with the failing command output and remediation steps — do not silently swallow errors.
 
-## Long Waits — Block In The Foreground, NEVER Park (issues #2501, #2610)
+## Long Waits — Block On Your Own Gates, Never On CI
 
-🔴 Release cuts, CI watches, `cargo build --release`, publish waits, and
-`gh pr checks --watch` are where ops/release agents strand tasks. **You must NEVER
-end your turn to "wait" for one — and NEVER spawn a background polling monitor and
-end your turn expecting it to notify you.** Nothing wakes a stopped agent; a
-self-created monitor/watcher fires into the void and the release hangs until a
-human manually resumes you. Ending a turn with "waiting for…", "monitoring in the
-background", "will report back once…", or "standing by" is a PROTOCOL VIOLATION.
-
-Wait ONLY by blocking in the foreground:
+🔴 A release cut, `cargo build --release`, or a publish wait is YOUR command: run
+it in the FOREGROUND with a long timeout and let it hold the turn until it exits.
+Do not background it and end your turn expecting a notification — nothing wakes a
+stopped agent, so a self-spawned monitor fires into the void and the release
+hangs until a human resumes you.
 
 ```bash
-gh pr checks <pr> --watch --fail-fast    # CI: blocks until checks settle
 cargo build --release -p <crate>         # long build: run it, wait for exit
 ```
 
-- Run long commands in the FOREGROUND with a long timeout and wait for them to
-  exit — do NOT background them (`&` / `run_in_background`).
-- If a command was already backgrounded, poll it to completion with blocking
-  status calls in the SAME turn; do not end the turn while it runs.
-- If an invocation hits the 10-min tool ceiling, RE-ISSUE the same blocking
-  command in the SAME turn and loop until it completes.
+**CI is the opposite.** Never wait on it and never use `gh pr checks --watch` —
+`--watch` streams check output into your context for the whole run (546k tokens
+over 54 minutes on one PR). Push, take a ONE-SHOT `gh pr checks <pr>` /
+`gh pr view <pr>` read, report it, and end your turn; the PM re-engages when CI
+settles. Trust `bucket` only after cross-checking `state` — GitHub API
+eventual-consistency lag can surface a check as bucketed-complete before it has
+settled.
+
+- If a foreground invocation hits the 10-min tool ceiling, RE-ISSUE it in the
+  SAME turn and loop until it completes.
 - On failure, capture the output and report it — do not retry-by-waiting.
-- Re-issuing is NOT tight blind polling. Don't loop a status check every ~30s
-  emitting "still building"/"still pending" — that is the opposite failure, spam
-  (#2833). Prefer the blocking form (`--watch`, or the build itself); if you must
-  sleep-poll, size the sleep to the real wall-clock (minutes) and print only when
-  the observed state changes.
-- **When your wait goal completes** (build finishes, publish succeeds, CI goes
-  green), immediately disarm any monitors, polls, or re-issue timers you armed.
-  Stale monitors re-fire after your goal is done, spuriously waking the agent.
+- Ending a turn with "monitoring in the background", "will report back once…",
+  or "standing by" is a PROTOCOL VIOLATION, not a status update.
+- **When your wait goal completes**, immediately disarm any monitors, polls, or
+  re-issue timers you armed. Stale monitors re-fire after the goal is done.
 
 ## GitHub Account Management
 

--- a/crates/trusty-mpm/changelog.d/4792-retire-blocking-ci-wait.md
+++ b/crates/trusty-mpm/changelog.d/4792-retire-blocking-ci-wait.md
@@ -1,0 +1,9 @@
+Changed
+
+- Retired the blocking-CI-wait doctrine across every bundled instruction copy: agents now push, take a ONE-SHOT `gh pr view` / `gh pr checks` status read, report, and end their turn; the PM owns re-engagement when CI settles ([#4792](https://github.com/bobmatnyc/trusty-tools/issues/4792))
+  - `gh pr checks --watch` is now forbidden — it streams check output into the agent's context (546k tokens over 54 minutes on one PR). The retirement is about context cost, not runnability
+  - `BASE-AGENT.md` "Foreground Execution — NEVER End Your Turn To Wait" is replaced by "Finishing Work — Push, Report, Stop"; own-gate commands still block in the foreground
+  - `version-control.md`, `local-ops.md`, `BASE-ENGINEER.md`, `tm-delegation-patterns.md`, and the `trusty-code` asset mirror updated to match
+  - PM instructions section renamed "Parked-Subagent Re-Engagement": a hand-back with CI pending is correct behavior, not a park, and must not be nudged back into a blocking wait
+  - `idle_nudge::DEFAULT_NUDGE_MESSAGE` no longer tells a stalled pane to run `gh pr checks --watch`
+  - The one-shot read now documents two traps: `bucket` can report a false DONE under GitHub API eventual-consistency lag (cross-check `state`), and repeated `gh pr update-branch` is a treadmill that mints a new untested head each time (BEHIND is not a correctness gate)

--- a/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-AGENT.md
@@ -212,96 +212,56 @@ This applies especially to verification-critical commands: test runs, `git`/`gh`
 reads and writes, and build output. An unobservable result is never a passing
 result.
 
-## Foreground Execution — NEVER End Your Turn To Wait
+## Finishing Work — Push, Report, Stop
 
-🔴 **You must NEVER end your turn to "wait" for anything.** Nothing re-invokes a
-stopped agent. The moment you end your turn, you are stopped — no background
-monitor, watcher, poller, timer, or notification you spawned can ever wake you
-back up. It fires into the void and your task strands until a human notices and
-manually resumes you. Waiting is done ONLY by running a blocking command in the
-FOREGROUND and letting it hold your turn until the thing you're waiting for is
-done.
-
-**Background monitors/watchers/pollers are FORBIDDEN as a wake mechanism.** Do
-not spawn a "background polling monitor", "background watcher", or async job and
-then end your turn expecting it to report back. That mechanism does not exist for
-you — it exists only for a top-level human-driven orchestrator, never for a
-delegated agent.
-
-**Ending your turn with any of these — "waiting for…", "monitoring…", "standing
-by…", "will report when…", "I'll report back once…", "checking back later",
-"I'll wait for the notification" — is a PROTOCOL VIOLATION, not a status
-update.** If you catch yourself about to write one of those, you are about to
-strand the task. Instead: run the blocking command now, in this turn.
-
-### Canonical CI-wait pattern (blocking, foreground)
+🔴 **Never block on CI.** When your work is done: push, take a ONE-SHOT status
+read, report what it says, and END YOUR TURN. The PM re-engages when CI settles.
+Anti-parking is enforced by the PM coming back, not by you holding a turn open.
 
 ```bash
-gh pr checks <pr> --watch --fail-fast    # blocks until all checks settle
+gh pr view <pr> --json state,mergeable,statusCheckRollup   # one shot
+gh pr checks <pr>                                          # one shot
 ```
 
-Run it as a plain foreground command and let it hold the turn — even 15+ minutes.
-Do NOT background it (`&` / `run_in_background`). Do NOT end the turn to "monitor
-the checks". When it exits, read the result and act. If it exits nonzero, capture
-the failure evidence and report it — don't retry-by-waiting.
+Two ways that read misleads if you take it flatly:
 
-### Canonical long-command pattern (blocking, foreground)
+- **`bucket` can report a false DONE.** Under GitHub API eventual-consistency
+  lag a check surfaces as bucketed-complete before it has actually settled.
+  Cross-check the `state` field before calling anything green.
+- **Repeated `gh pr update-branch` is a treadmill.** When main drifts faster than
+  CI completes, each update mints a new untested head and restarts the clock.
+  Merge the head that is actually green; BEHIND is not a correctness gate.
 
-Run builds, test suites, and deploy waits as plain foreground commands with a
-long timeout and wait for them to exit. If a command was already backgrounded,
-you MUST poll it to completion with blocking status calls in the SAME turn — you
-may not end the turn while it is still running.
+### Never `gh pr checks --watch`
 
-### When a single invocation times out
+`--watch` streams every check's output into your context for the whole run — one
+engineer burned 546k tokens over 54 minutes on a single PR. That is why blocking
+CI waits are retired: **context cost**, not runnability (`--watch` runs fine; an
+explicit `timeout` raises the 120s bash default toward the 600000ms ceiling). Do
+not reintroduce it, and do not substitute a manual poll loop for it.
 
-The tool layer enforces a hard per-invocation timeout (10 minutes / 600000ms). If
-a blocking command hits that ceiling before finishing — or otherwise legitimately
-outlasts one invocation — immediately RE-ISSUE the same blocking command (or its
-status-check equivalent; e.g. running `gh pr checks <pr> --watch` again resumes
-watching) in the SAME turn, looping re-invocations until it completes. Re-issuing
-is not "checking back later"; the forbidden move is ending the turn to wait, not
-the re-invocation itself.
+### Report, don't promise
 
-This rule exists because merge/CI/release agents repeatedly parked mid-watch
-waiting for a notification that never came (issues #2501, #2610).
+Hand back with an observation: "pushed `<sha>`; 3 checks pending — PM to
+re-engage when they settle." Ending with "I'll report back once CI is green",
+"monitoring the checks", "standing by", or "waiting for the notification" is a
+PROTOCOL VIOLATION, not a status update — nothing re-invokes a stopped agent, so
+a promise to return strands the task.
 
-### Re-issue without spamming — the chunked-repoll pattern (issue #2833)
+### Your own gates DO block, in the foreground
 
-Re-issuing a wait must not degenerate into the OPPOSITE failure: a tight blind
-poll loop that emits a "still pending" line every ~30 seconds for 20+ minutes.
-Parking and spamming are two ends of the same mistake — both come from not
-sizing the wait to its real duration.
+A build, test suite, or lint run is YOUR gate, it terminates, and its output is
+the evidence you owe. Run it as a plain foreground command with an explicit long
+`timeout` and let it hold the turn until it exits. Keep gates crate-scoped
+(`cargo test -p <crate>`) so they finish inside one invocation; re-issue in the
+SAME turn if one legitimately outlasts the ceiling. If a command was already
+backgrounded, poll it to completion in the same turn.
 
-- **Prefer the blocking watch.** `gh pr checks <pr> --watch --fail-fast` blocks
-  silently until checks settle and prints once. It is the correct primitive —
-  it neither parks nor spams. Re-issue it verbatim after a 10-min ceiling.
-- **If you must repoll a status command** (no `--watch` available), use a
-  blocking wait sized to the KNOWN wall-clock, not to impatience — a
-  Monitor/until-loop where the harness provides one, or a minutes-scale sleep
-  where it doesn't (some harnesses block a raw foreground `sleep`; use whatever
-  blocking primitive is actually available). Size it to a 5-minute-plus interval
-  for a ~15-minute CI run, not 30 seconds. A tight loop tells the reader nothing
-  they didn't know 30 seconds ago.
-- **Message only on state change.** Emit a line when the observed state actually
-  changes (pending→running, a check flips, count drops), not on every poll. "No
-  change" is not worth a message.
-- **Diagnose an overrun once.** If a wait runs abnormally long (well past the
-  expected wall-clock), run a ONE-SHOT diagnosis — `gh run view <run-id>` (or
-  `gh pr checks <pr>` without `--watch`) — to see WHY it's stuck, then resume the
-  blocking wait. Do not convert the overrun into faster polling.
-- **Disarm monitors on goal completion.** When your goal completes or becomes
-  moot — a CI run settles, a deployment finishes, a file appears, a condition
-  is satisfied — immediately cancel or disarm any `Monitor` tool call, `/loop`,
-  or `/schedule` routine you started (this cleans up legitimate recurring checks
-  — it does not re-authorize a background watcher to wake your own stopped turn).
-  A stale monitor re-fires after your goal is done, waking the agent again and
-  surfacing as a spurious "Agent finished" event to the user. Disarm first, then
-  report. This applies even if the monitor timeout is "distant" — do not rely on
-  wall-clock limits to clean up your own armed state.
-
-Do not end your turn while an unresolved wait is yours to watch — re-issue the
-blocking wait instead. A quiet foreground block is the goal; a poll-spam stream
-is a smell that you dropped the blocking primitive for a manual loop.
+Never spawn a background monitor, watcher, poller, or timer as a wake mechanism
+and end your turn expecting it to report back — that mechanism does not exist for
+a delegated agent. If you armed a `Monitor`, `/loop`, or `/schedule` and its goal
+completed or went moot, disarm it before reporting; a stale monitor re-fires and
+surfaces as a spurious wake.
 
 ## Output Format
 

--- a/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
+++ b/crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md
@@ -196,8 +196,9 @@ Before returning, re-read the prompt for "Deliverables" / "Requirements" /
 Run that verify/quality-gate command as a BLOCKING FOREGROUND call and wait for it
 to exit — even 15+ minutes. NEVER end your turn to "wait for the gate to finish"
 or hand it to a background monitor: nothing wakes a stopped agent, so the run
-strands until a human resumes you. See BASE-AGENT "Foreground Execution — NEVER
-End Your Turn To Wait" (issues #2501, #2610).
+strands until a human resumes you. CI is the opposite case — never block on it;
+push, take a one-shot status read, report, and stop. See BASE-AGENT "Finishing
+Work — Push, Report, Stop".
 
 ## Output Requirements
 

--- a/crates/trusty-mpm/src/assets/agents/local-ops.md
+++ b/crates/trusty-mpm/src/assets/agents/local-ops.md
@@ -85,38 +85,33 @@ npm audit / cargo audit / bandit -r src/
 
 Surface failures with the failing command output and remediation steps — do not silently swallow errors.
 
-## Long Waits — Block In The Foreground, NEVER Park (issues #2501, #2610)
+## Long Waits — Block On Your Own Gates, Never On CI
 
-🔴 Release cuts, CI watches, `cargo build --release`, publish waits, and
-`gh pr checks --watch` are where ops/release agents strand tasks. **You must NEVER
-end your turn to "wait" for one — and NEVER spawn a background polling monitor and
-end your turn expecting it to notify you.** Nothing wakes a stopped agent; a
-self-created monitor/watcher fires into the void and the release hangs until a
-human manually resumes you. Ending a turn with "waiting for…", "monitoring in the
-background", "will report back once…", or "standing by" is a PROTOCOL VIOLATION.
-
-Wait ONLY by blocking in the foreground:
+🔴 A release cut, `cargo build --release`, or a publish wait is YOUR command: run
+it in the FOREGROUND with a long timeout and let it hold the turn until it exits.
+Do not background it and end your turn expecting a notification — nothing wakes a
+stopped agent, so a self-spawned monitor fires into the void and the release
+hangs until a human resumes you.
 
 ```bash
-gh pr checks <pr> --watch --fail-fast    # CI: blocks until checks settle
 cargo build --release -p <crate>         # long build: run it, wait for exit
 ```
 
-- Run long commands in the FOREGROUND with a long timeout and wait for them to
-  exit — do NOT background them (`&` / `run_in_background`).
-- If a command was already backgrounded, poll it to completion with blocking
-  status calls in the SAME turn; do not end the turn while it runs.
-- If an invocation hits the 10-min tool ceiling, RE-ISSUE the same blocking
-  command in the SAME turn and loop until it completes.
+**CI is the opposite.** Never wait on it and never use `gh pr checks --watch` —
+`--watch` streams check output into your context for the whole run (546k tokens
+over 54 minutes on one PR). Push, take a ONE-SHOT `gh pr checks <pr>` /
+`gh pr view <pr>` read, report it, and end your turn; the PM re-engages when CI
+settles. Trust `bucket` only after cross-checking `state` — GitHub API
+eventual-consistency lag can surface a check as bucketed-complete before it has
+settled.
+
+- If a foreground invocation hits the 10-min tool ceiling, RE-ISSUE it in the
+  SAME turn and loop until it completes.
 - On failure, capture the output and report it — do not retry-by-waiting.
-- Re-issuing is NOT tight blind polling. Don't loop a status check every ~30s
-  emitting "still building"/"still pending" — that is the opposite failure, spam
-  (#2833). Prefer the blocking form (`--watch`, or the build itself); if you must
-  sleep-poll, size the sleep to the real wall-clock (minutes) and print only when
-  the observed state changes.
-- **When your wait goal completes** (build finishes, publish succeeds, CI goes
-  green), immediately disarm any monitors, polls, or re-issue timers you armed.
-  Stale monitors re-fire after your goal is done, spuriously waking the agent.
+- Ending a turn with "monitoring in the background", "will report back once…",
+  or "standing by" is a PROTOCOL VIOLATION, not a status update.
+- **When your wait goal completes**, immediately disarm any monitors, polls, or
+  re-issue timers you armed. Stale monitors re-fire after the goal is done.
 
 ## GitHub Account Management
 

--- a/crates/trusty-mpm/src/assets/agents/version-control.md
+++ b/crates/trusty-mpm/src/assets/agents/version-control.md
@@ -35,35 +35,37 @@ the PM instead of freezing the pipeline.
 
 For most features, use main-based PRs (each PR from `main`). Use stacked PRs only when the user explicitly requests them.
 
-## CI Waits — Block In The Foreground, NEVER Park (issues #2501, #2610)
+## CI Waits — Push, Report, Stop; NEVER Block (issue #4792)
 
-🔴 Waiting on PR checks, a merge queue, or `gh run watch` is where version-control
-agents strand tasks. **You must NEVER end your turn to "monitor" checks or wait
-for a notification** — nothing wakes a stopped agent, so a self-spawned watcher or
-"background monitor" fires into the void and the merge hangs until a human resumes
-you. This is a protocol violation, not a status update.
+🔴 **Never block on CI and never use `gh pr checks --watch`.** `--watch` streams
+every check's output into your context for the whole run — one engineer burned
+546k tokens over 54 minutes on a single PR. Context cost, not runnability, is why
+blocking CI waits are retired; do not reintroduce one and do not substitute a
+manual poll loop.
 
-Wait ONLY by blocking in the foreground:
+When your work is pushed, take a ONE-SHOT status read, report it, and end your
+turn. The PM re-engages when CI settles.
 
 ```bash
-gh pr checks <pr> --watch --fail-fast    # blocks until checks settle; run it and wait
+gh pr view <pr> --json state,mergeable,statusCheckRollup   # one shot
+gh pr checks <pr>                                          # one shot
 ```
 
-- Run it as a plain foreground command — do NOT background it (`&` /
-  `run_in_background`) and do NOT stop to "monitor".
-- If the invocation times out (10-min tool ceiling), RE-ISSUE the same
-  `gh pr checks <pr> --watch` in the SAME turn and keep looping until it exits.
-- On a nonzero exit, capture the failing check output and report it — do not
-  retry-by-waiting.
-- Ending a turn with "monitoring the checks", "waiting for CI", "will report when
-  green", or "standing by" is FORBIDDEN.
-- Do NOT replace the blocking `--watch` with a tight manual poll loop that prints
-  "still N pending" every ~30s — that is the opposite failure (spam) and just as
-  wrong (#2833). `--watch` blocks silently and prints once; keep using it. If you
-  ever must sleep-poll, size the sleep to the CI wall-clock (minutes, not
-  seconds) and only print when a check's state actually changes.
-- **When checks settle**, immediately disarm any monitors or re-issue timers you
-  armed — do not let stale monitors re-fire after your goal is done.
+- **`bucket` can report a false DONE.** Under GitHub API eventual-consistency lag
+  a check surfaces as bucketed-complete before it has settled — cross-check the
+  `state` field before calling anything green, and never merge on a bucket alone.
+- **Repeated `gh pr update-branch` is a treadmill.** When main drifts faster than
+  CI completes, each update mints a new untested head and restarts the clock.
+  Merge the head that is actually green; BEHIND is not a correctness gate.
+- Hand back with an observation — "pushed `<sha>`; 3 checks pending — PM to
+  re-engage". Ending with "monitoring the checks", "waiting for CI", "will report
+  when green", or "standing by" is a PROTOCOL VIOLATION: nothing re-invokes a
+  stopped agent, so the promise strands the merge.
+- Never spawn a background monitor or watcher as a wake mechanism. If you armed
+  one and its goal completed, disarm it before reporting.
+
+Your own commands — a build, a test suite, a `gh pr merge` — still run in the
+FOREGROUND and hold the turn until they exit.
 
 ## Memory Management for Git Operations
 

--- a/crates/trusty-mpm/src/assets/instructions/sections/core.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/core.md
@@ -147,44 +147,42 @@ When delegated work fails (build error, test failure, lint issue):
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
 
-## Parked-Subagent Detection & Nudge (issue #2833)
+## Parked-Subagent Re-Engagement (issues #2833, #4792)
 
-An in-conversation Agent-tool subagent has NO tmux pane, so the daemon-side
-idle-nudge (`#2621`, managed sessions only) cannot reach it. Detecting and
-resuming a parked subagent is YOUR job as PM — it is the only back-stop below
-the managed-session layer.
+Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
+(`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
+that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
+Blocking waits were retired for context cost: `--watch` streams check output for
+the whole run, and one engineer burned 546k tokens over 54 minutes on a single
+PR. Do not nudge an agent back into a blocking wait, and do not restore that
+advice anywhere.
 
-**A parked stop looks like this:** a subagent returns with its stated goal
-still unmet (PR not merged, checks not confirmed green, fix not pushed) AND its
-final message references *backgrounding a wait* — "monitoring … in the
-background", "will report back once …", "standing by", "I'll wait for the
-notification", or a background task id it expects to wake it. Nothing wakes a
-stopped subagent, so that wait strands forever unless you nudge it.
+**When an agent hands back with CI pending**, own the gap yourself: re-read the
+status when the run should have settled and `SendMessage` the SAME agent (never a
+fresh delegation — zero context reload) with the outcome, either the merge
+go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
+API eventual-consistency lag it can report a false DONE, so cross-check `state`
+before telling an agent the PR is green.
 
-**When you see that shape, do NOT accept the turn as complete.** Immediately
-`SendMessage` to the SAME agent (never a fresh delegation — zero context reload):
+If you monitor the gap with a `Monitor`, size the interval to the known CI
+wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
+run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
+never a 30-second blind poll (that is the spam counter-failure, #2833).
+Disarm the monitor the moment checks settle.
 
-> "Your wait is unresolved and nothing will re-wake a stopped agent. Re-issue
-> the blocking wait in the FOREGROUND now — `gh pr checks <pr> --watch
-> --fail-fast` (or the equivalent blocking command) — and do not end your turn
-> until it exits and the goal is met. Do not background it and do not tight-poll
-> it; `--watch` blocks silently and prints once."
+**A genuine park still exists and is still yours to catch:** a subagent returns
+with its goal unmet AND its final message says it backgrounded a wait —
+"monitoring … in the background", "I'll wait for the notification", or a
+background task id it expects to wake it. Nothing wakes a stopped agent, so
+`SendMessage` the SAME agent to resume the unfinished work in this turn. A
+handoff that names pending CI and stops is NOT this; accept it.
 
 Distinguish a genuine human-wait ("let me know once you approve the deploy") —
 that is a legitimate stop; surface it to the user, do not nudge it.
 
-**Prevention beats detection.** Two defaults keep waits under the tool ceiling
-so subagents rarely need to re-issue at all:
-- Tell the engineer/QA to use **crate-scoped gates** (`cargo test -p <crate>`,
-  not `cargo test --workspace`) — the scoped run finishes well under the 10-min
-  ceiling; the workspace run does not.
-- Tell any agent that must wait on CI to use the blocking `--watch` form, never
-  a manual `sleep` poll loop.
-
-**If you monitor a wait yourself** (a Monitor over a long delegation): size the
-interval to the known wait (5-minute-plus for ~15-min CI), message only on
-state change, and run a one-shot `gh run view <run-id>` diagnosis if it overruns
-— never a 30-second blind poll (that is the spam counter-failure, #2833).
+**Prevention.** Tell the engineer/QA to use crate-scoped gates
+(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
+well under the 10-min tool ceiling, so agents rarely re-issue at all.
 
 ## Task Complexity Detection
 

--- a/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
+++ b/crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md
@@ -87,34 +87,32 @@ Language-specific Engineer selection follows `Cargo.toml` (rust-engineer),
 (`assets/instructions/sections/agent-delegation.md`) for the full table; when
 unknown, Research is mandatory (never default to a guess).
 
-## Long-Wait Delegation (chunked-repoll — issue #2833)
+## Long-Wait Delegation (issues #2833, #4792)
 
-Any delegation that ends in a wait longer than the bash tool's 10-minute
-per-invocation ceiling — `gh pr checks` (CI ~10-20 min), a release cut, or
-`cargo test --workspace` (~16 min) — is where subagents strand: they background
-the wait and end their turn (a **park**), or degenerate into a 30-second blind
-poll loop (**spam**). Both come from not sizing the wait to its real duration.
-Make the wait first-class in the delegation prompt instead of hoping the agent
-improvises it:
+A delegated agent's own gate (`cargo test -p <crate>`, a release build) blocks in
+its foreground; **CI does not**. Agents push, take a one-shot status read, report,
+and stop — the PM re-engages when checks settle. Make both halves explicit in the
+delegation prompt instead of hoping the agent improvises:
 
 1. **Keep the gate under the ceiling.** Ask for **crate-scoped** gates
    (`cargo test -p <crate>`, `cargo clippy -p <crate>`), never
-   `cargo test --workspace` — the scoped run finishes inside one invocation.
-2. **Name the blocking primitive.** For CI, instruct: "wait with
-   `gh pr checks <pr> --watch --fail-fast` in the foreground; it blocks silently
-   and prints once. Re-issue it verbatim if the 10-min ceiling cuts it off. Do
-   NOT background it, do NOT sleep-poll it, do NOT end your turn to monitor it."
-3. **Forbid both failure modes explicitly.** "Parking (ending your turn to wait)
-   and spamming (a tight `still pending` poll loop) are both wrong. Block quietly
-   in the foreground; message only when state changes."
-4. **PM back-stop.** If the subagent parks anyway, `SendMessage` the SAME agent a
-   resume nudge (see PM_INSTRUCTIONS "Parked-Subagent Detection & Nudge") — never
-   a fresh delegation.
+   `cargo test --workspace` — the scoped run finishes inside one invocation and
+   its raw output is the evidence you collect.
+2. **Forbid the CI block.** "Do NOT use `gh pr checks --watch` — it streams check
+   output into your context (546k tokens over 54 minutes on one PR). Push, take a
+   one-shot `gh pr checks <pr>` read, report it, and end your turn."
+3. **Forbid parking too.** "Do not background your gate and end the turn
+   expecting a notification, and do not sleep-poll. Block quietly in the
+   foreground on your own commands; hand back an observation, not a promise to
+   report."
+4. **PM re-engagement.** When the agent hands back with CI pending, re-read the
+   status yourself and `SendMessage` the SAME agent the outcome — never a fresh
+   delegation, and never a nudge back into a blocking wait (see PM_INSTRUCTIONS
+   "Parked-Subagent Re-Engagement").
 
-This is prevention (steps 1-3, in the delegation prompt) plus a PM-side
-detect-and-nudge back-stop (step 4). The daemon idle-nudge (#2621) does NOT
-cover in-conversation subagents — they have no tmux pane — so this protocol is
-the only mitigation below the managed-session layer.
+The daemon idle-nudge (#2621) does NOT cover in-conversation subagents — they
+have no tmux pane — so PM-side re-engagement is the only mechanism below the
+managed-session layer.
 
 ## Delegation Best Practices
 

--- a/crates/trusty-mpm/src/core/bundle_tests.rs
+++ b/crates/trusty-mpm/src/core/bundle_tests.rs
@@ -638,13 +638,13 @@ fn new_concrete_agents_deploy_via_real_asset_files() {
 
 #[test]
 fn base_agent_guidance_sections_survive_composition() {
-    // Regression for #2501/#2502/#2610: BASE-AGENT.md's "Foreground Execution"
-    // and "PM Directives Do Not Bind You" sections — plus the version-control
-    // persona's own CI-wait reinforcement — must propagate into the composed
-    // agent via the real bundled asset chain, not just exist in the source
-    // files. Uses version-control (the worst parking offender) composed from
-    // the real assets dir so a future refactor of the compose/extends pipeline
-    // can't silently drop the no-parking guidance.
+    // Regression for #2501/#2502/#2610/#4792: BASE-AGENT.md's "Finishing Work —
+    // Push, Report, Stop" and "PM Directives Do Not Bind You" sections — plus
+    // the version-control persona's own CI reinforcement — must propagate into
+    // the composed agent via the real bundled asset chain, not just exist in the
+    // source files. Uses version-control (the worst parking offender) composed
+    // from the real assets dir so a future refactor of the compose/extends
+    // pipeline can't silently drop the guidance.
     use crate::core::agent_builder::compose_agent;
     use std::path::Path;
 
@@ -657,24 +657,25 @@ fn base_agent_guidance_sections_survive_composition() {
         .expect("compose_agent(version-control) must succeed");
 
     assert!(
-        composed.contains("## Foreground Execution"),
-        "composed version-control is missing the Foreground Execution section"
+        composed.contains("## Finishing Work — Push, Report, Stop"),
+        "composed version-control is missing the Finishing Work section (#4792)"
     );
     assert!(
-        composed.contains("NEVER end your turn to \"wait\""),
-        "composed version-control is missing the BASE-AGENT hard no-parking rule (#2610)"
+        composed.contains("Never block on CI"),
+        "composed version-control is missing the BASE-AGENT no-CI-block rule (#4792)"
     );
     assert!(
         composed.contains("PROTOCOL VIOLATION"),
-        "composed version-control is missing the parking-is-a-protocol-violation rule (#2610)"
+        "composed version-control is missing the promise-instead-of-report rule (#2610)"
+    );
+    // #4792: the retired blocking wait must not come back through ANY layer.
+    assert!(
+        !composed.contains("--watch --fail-fast"),
+        "composed version-control prescribes the retired blocking CI wait (#4792)"
     );
     assert!(
-        composed.contains("gh pr checks <pr> --watch --fail-fast"),
-        "composed version-control is missing the canonical CI-wait blocking pattern (#2610)"
-    );
-    assert!(
-        composed.contains("## CI Waits — Block In The Foreground, NEVER Park"),
-        "composed version-control is missing its persona-level CI-wait section (#2610)"
+        composed.contains("## CI Waits — Push, Report, Stop; NEVER Block"),
+        "composed version-control is missing its persona-level CI section (#4792)"
     );
     assert!(
         composed.contains("## PM Directives Do Not Bind You"),
@@ -700,15 +701,15 @@ fn base_agent_guidance_sections_survive_composition() {
          Git Workflow ({git_workflow_idx})"
     );
 
-    let foreground_execution_idx = composed
-        .find("## Foreground Execution")
-        .expect("Foreground Execution marker must be present");
+    let finishing_work_idx = composed
+        .find("## Finishing Work — Push, Report, Stop")
+        .expect("Finishing Work marker must be present");
     let output_format_idx = composed
         .find("## Output Format")
         .expect("Output Format marker must be present");
     assert!(
-        foreground_execution_idx < output_format_idx,
-        "Foreground Execution ({foreground_execution_idx}) must appear before \
+        finishing_work_idx < output_format_idx,
+        "Finishing Work ({finishing_work_idx}) must appear before \
          Output Format ({output_format_idx})"
     );
 
@@ -717,11 +718,11 @@ fn base_agent_guidance_sections_survive_composition() {
     let local_ops =
         compose_agent("local-ops", &assets_dir).expect("compose_agent(local-ops) must succeed");
     assert!(
-        local_ops.contains("## Long Waits — Block In The Foreground, NEVER Park"),
+        local_ops.contains("## Long Waits — Block On Your Own Gates, Never On CI"),
         "composed local-ops is missing its persona-level long-wait section (#2610)"
     );
     assert!(
-        local_ops.contains("NEVER end your turn to \"wait\""),
+        local_ops.contains("Never spawn a background monitor"),
         "composed local-ops is missing the inherited BASE-AGENT no-parking rule (#2610)"
     );
 }
@@ -944,8 +945,8 @@ fn idle_park_mitigation_2833_guidance_survives_composition() {
     // Regression for #2833's code-critic review (MEDIUM finding): the prior
     // `base_agent_guidance_sections_survive_composition` test only asserted the
     // pre-existing #2501/#2610 strings — none of the #2833 idle-park-mitigation
-    // content (chunked-repoll anti-spam guidance, the PM-side parked-subagent
-    // nudge protocol, the version-control anti-spam bullet) was ever exercised
+    // content (the BASE-AGENT hand-back guidance, the PM-side re-engagement
+    // protocol, the version-control persona bullets) was ever exercised
     // through the REAL bundled asset chain. This test closes that gap using the
     // same real-composition approach as its sibling: `compose_agent` reading
     // the actual `assets/agents` dir for the two agent-tier assertions, and
@@ -961,31 +962,31 @@ fn idle_park_mitigation_2833_guidance_survives_composition() {
         .join("assets")
         .join("agents");
 
-    // (a) BASE-AGENT.md's chunked-repoll subsection must reach a composed
-    // agent that inherits BASE-AGENT (version-control extends it).
+    // (a) BASE-AGENT.md's report-don't-promise subsection (which replaced the
+    // retired chunked-repoll guidance in #4792) must reach a composed agent
+    // that inherits BASE-AGENT (version-control extends it).
     let composed = compose_agent("version-control", &assets_dir)
         .expect("compose_agent(version-control) must succeed");
     assert!(
-        composed
-            .contains("### Re-issue without spamming — the chunked-repoll pattern (issue #2833)"),
-        "composed version-control is missing the BASE-AGENT chunked-repoll subsection (#2833)"
+        composed.contains("### Report, don't promise"),
+        "composed version-control is missing the BASE-AGENT report-don't-promise subsection (#4792)"
     );
 
-    // (c) version-control's own anti-spam bullet (distinct from the inherited
-    // BASE-AGENT section) must also survive composition.
+    // (c) version-control's own merge-decision bullets (distinct from the
+    // inherited BASE-AGENT section) must also survive composition.
     assert!(
-        composed.contains("that is the opposite failure (spam) and just as"),
-        "composed version-control is missing its persona-level anti-spam bullet (#2833)"
+        composed.contains("Repeated `gh pr update-branch` is a treadmill"),
+        "composed version-control is missing its persona-level update-branch bullet (#4792)"
     );
 
-    // (b) PM_INSTRUCTIONS.md's new Parked-Subagent Detection & Nudge section
-    // must survive the real PM system-prompt assembly (not just exist in the
-    // source .md file).
+    // (b) PM_INSTRUCTIONS.md's Parked-Subagent Re-Engagement section must
+    // survive the real PM system-prompt assembly (not just exist in the source
+    // .md file).
     let pm_prompt = assemble_system_prompt();
     assert!(
-        pm_prompt.contains("## Parked-Subagent Detection & Nudge (issue #2833)"),
-        "assembled PM system prompt is missing the Parked-Subagent Detection & \
-         Nudge section (#2833)"
+        pm_prompt.contains("## Parked-Subagent Re-Engagement (issues #2833, #4792)"),
+        "assembled PM system prompt is missing the Parked-Subagent \
+         Re-Engagement section (#2833, #4792)"
     );
     assert!(
         pm_prompt

--- a/crates/trusty-mpm/src/core/idle_nudge.rs
+++ b/crates/trusty-mpm/src/core/idle_nudge.rs
@@ -104,9 +104,11 @@ impl Default for IdleNudgeConfig {
 /// The default text injected into a parked pane, submitted with Enter.
 ///
 /// Why: the nudge must do more than say "you stalled" — it must correct the
-/// exact anti-pattern (#2501/#2610): the agent backgrounded a watch and ended
-/// its turn. The message tells it to block in the FOREGROUND and keep its turn
-/// open, which is the behavior the bundled agent guidance already prescribes.
+/// exact anti-pattern (#2501/#2610): the agent backgrounded a wait and ended its
+/// turn. It tells the agent to resume by blocking in the FOREGROUND on its OWN
+/// commands, which is what the bundled guidance prescribes. #4792: it must NOT
+/// push the agent onto `gh pr checks --watch` — blocking CI waits were retired
+/// for context cost, and the correct CI behavior is a one-shot read then stop.
 /// What: a `'static` instruction string citing #2621 so an operator reading the
 /// pane knows the message was machine-injected, not typed by a human.
 /// Test: `config_idle_nudge_section_parses` (in `core::config`) asserts the
@@ -114,8 +116,9 @@ impl Default for IdleNudgeConfig {
 /// below.
 pub const DEFAULT_NUDGE_MESSAGE: &str = "[trusty-mpm auto-nudge #2621] Your last turn ended with \
 language that parks the task waiting on a background monitor/notification, but a stopped agent \
-cannot be re-woken by the thing it is waiting on. Resume NOW: block in the FOREGROUND (re-run the \
-gate, or `gh pr checks <n> --watch`) and do not end your turn until it actually completes. If you \
+cannot be re-woken by the thing it is waiting on. Resume NOW: finish the work in this turn, \
+blocking in the FOREGROUND on your own commands (re-run the gate, the build). Do NOT block on CI \
+and do NOT use `gh pr checks --watch` — take a one-shot status read, report it, and stop. If you \
 are genuinely blocked on a human decision, say so explicitly instead.";
 
 /// Per-session record of how many nudges were sent and when the last one fired.

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -147,44 +147,42 @@ When delegated work fails (build error, test failure, lint issue):
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
 
-## Parked-Subagent Detection & Nudge (issue #2833)
+## Parked-Subagent Re-Engagement (issues #2833, #4792)
 
-An in-conversation Agent-tool subagent has NO tmux pane, so the daemon-side
-idle-nudge (`#2621`, managed sessions only) cannot reach it. Detecting and
-resuming a parked subagent is YOUR job as PM — it is the only back-stop below
-the managed-session layer.
+Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
+(`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
+that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
+Blocking waits were retired for context cost: `--watch` streams check output for
+the whole run, and one engineer burned 546k tokens over 54 minutes on a single
+PR. Do not nudge an agent back into a blocking wait, and do not restore that
+advice anywhere.
 
-**A parked stop looks like this:** a subagent returns with its stated goal
-still unmet (PR not merged, checks not confirmed green, fix not pushed) AND its
-final message references *backgrounding a wait* — "monitoring … in the
-background", "will report back once …", "standing by", "I'll wait for the
-notification", or a background task id it expects to wake it. Nothing wakes a
-stopped subagent, so that wait strands forever unless you nudge it.
+**When an agent hands back with CI pending**, own the gap yourself: re-read the
+status when the run should have settled and `SendMessage` the SAME agent (never a
+fresh delegation — zero context reload) with the outcome, either the merge
+go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
+API eventual-consistency lag it can report a false DONE, so cross-check `state`
+before telling an agent the PR is green.
 
-**When you see that shape, do NOT accept the turn as complete.** Immediately
-`SendMessage` to the SAME agent (never a fresh delegation — zero context reload):
+If you monitor the gap with a `Monitor`, size the interval to the known CI
+wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
+run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
+never a 30-second blind poll (that is the spam counter-failure, #2833).
+Disarm the monitor the moment checks settle.
 
-> "Your wait is unresolved and nothing will re-wake a stopped agent. Re-issue
-> the blocking wait in the FOREGROUND now — `gh pr checks <pr> --watch
-> --fail-fast` (or the equivalent blocking command) — and do not end your turn
-> until it exits and the goal is met. Do not background it and do not tight-poll
-> it; `--watch` blocks silently and prints once."
+**A genuine park still exists and is still yours to catch:** a subagent returns
+with its goal unmet AND its final message says it backgrounded a wait —
+"monitoring … in the background", "I'll wait for the notification", or a
+background task id it expects to wake it. Nothing wakes a stopped agent, so
+`SendMessage` the SAME agent to resume the unfinished work in this turn. A
+handoff that names pending CI and stops is NOT this; accept it.
 
 Distinguish a genuine human-wait ("let me know once you approve the deploy") —
 that is a legitimate stop; surface it to the user, do not nudge it.
 
-**Prevention beats detection.** Two defaults keep waits under the tool ceiling
-so subagents rarely need to re-issue at all:
-- Tell the engineer/QA to use **crate-scoped gates** (`cargo test -p <crate>`,
-  not `cargo test --workspace`) — the scoped run finishes well under the 10-min
-  ceiling; the workspace run does not.
-- Tell any agent that must wait on CI to use the blocking `--watch` form, never
-  a manual `sleep` poll loop.
-
-**If you monitor a wait yourself** (a Monitor over a long delegation): size the
-interval to the known wait (5-minute-plus for ~15-min CI), message only on
-state change, and run a one-shot `gh run view <run-id>` diagnosis if it overruns
-— never a 30-second blind poll (that is the spam counter-failure, #2833).
+**Prevention.** Tell the engineer/QA to use crate-scoped gates
+(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
+well under the 10-min tool ceiling, so agents rarely re-issue at all.
 
 ## Task Complexity Detection
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -147,44 +147,42 @@ When delegated work fails (build error, test failure, lint issue):
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
 
-## Parked-Subagent Detection & Nudge (issue #2833)
+## Parked-Subagent Re-Engagement (issues #2833, #4792)
 
-An in-conversation Agent-tool subagent has NO tmux pane, so the daemon-side
-idle-nudge (`#2621`, managed sessions only) cannot reach it. Detecting and
-resuming a parked subagent is YOUR job as PM — it is the only back-stop below
-the managed-session layer.
+Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
+(`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
+that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
+Blocking waits were retired for context cost: `--watch` streams check output for
+the whole run, and one engineer burned 546k tokens over 54 minutes on a single
+PR. Do not nudge an agent back into a blocking wait, and do not restore that
+advice anywhere.
 
-**A parked stop looks like this:** a subagent returns with its stated goal
-still unmet (PR not merged, checks not confirmed green, fix not pushed) AND its
-final message references *backgrounding a wait* — "monitoring … in the
-background", "will report back once …", "standing by", "I'll wait for the
-notification", or a background task id it expects to wake it. Nothing wakes a
-stopped subagent, so that wait strands forever unless you nudge it.
+**When an agent hands back with CI pending**, own the gap yourself: re-read the
+status when the run should have settled and `SendMessage` the SAME agent (never a
+fresh delegation — zero context reload) with the outcome, either the merge
+go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
+API eventual-consistency lag it can report a false DONE, so cross-check `state`
+before telling an agent the PR is green.
 
-**When you see that shape, do NOT accept the turn as complete.** Immediately
-`SendMessage` to the SAME agent (never a fresh delegation — zero context reload):
+If you monitor the gap with a `Monitor`, size the interval to the known CI
+wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
+run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
+never a 30-second blind poll (that is the spam counter-failure, #2833).
+Disarm the monitor the moment checks settle.
 
-> "Your wait is unresolved and nothing will re-wake a stopped agent. Re-issue
-> the blocking wait in the FOREGROUND now — `gh pr checks <pr> --watch
-> --fail-fast` (or the equivalent blocking command) — and do not end your turn
-> until it exits and the goal is met. Do not background it and do not tight-poll
-> it; `--watch` blocks silently and prints once."
+**A genuine park still exists and is still yours to catch:** a subagent returns
+with its goal unmet AND its final message says it backgrounded a wait —
+"monitoring … in the background", "I'll wait for the notification", or a
+background task id it expects to wake it. Nothing wakes a stopped agent, so
+`SendMessage` the SAME agent to resume the unfinished work in this turn. A
+handoff that names pending CI and stops is NOT this; accept it.
 
 Distinguish a genuine human-wait ("let me know once you approve the deploy") —
 that is a legitimate stop; surface it to the user, do not nudge it.
 
-**Prevention beats detection.** Two defaults keep waits under the tool ceiling
-so subagents rarely need to re-issue at all:
-- Tell the engineer/QA to use **crate-scoped gates** (`cargo test -p <crate>`,
-  not `cargo test --workspace`) — the scoped run finishes well under the 10-min
-  ceiling; the workspace run does not.
-- Tell any agent that must wait on CI to use the blocking `--watch` form, never
-  a manual `sleep` poll loop.
-
-**If you monitor a wait yourself** (a Monitor over a long delegation): size the
-interval to the known wait (5-minute-plus for ~15-min CI), message only on
-state change, and run a one-shot `gh run view <run-id>` diagnosis if it overruns
-— never a 30-second blind poll (that is the spam counter-failure, #2833).
+**Prevention.** Tell the engineer/QA to use crate-scoped gates
+(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
+well under the 10-min tool ceiling, so agents rarely re-issue at all.
 
 ## Task Complexity Detection
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -147,44 +147,42 @@ When delegated work fails (build error, test failure, lint issue):
 
 **Never spawn a separate docs agent for a per-task README** — include it in the engineer delegation.
 
-## Parked-Subagent Detection & Nudge (issue #2833)
+## Parked-Subagent Re-Engagement (issues #2833, #4792)
 
-An in-conversation Agent-tool subagent has NO tmux pane, so the daemon-side
-idle-nudge (`#2621`, managed sessions only) cannot reach it. Detecting and
-resuming a parked subagent is YOUR job as PM — it is the only back-stop below
-the managed-session layer.
+Agents do NOT block on CI. A delegated agent pushes, takes a one-shot status read
+(`gh pr view` / `gh pr checks`, never `--watch`), reports, and ends its turn —
+that is correct, expected behavior, not a park. **Re-engagement is YOUR job.**
+Blocking waits were retired for context cost: `--watch` streams check output for
+the whole run, and one engineer burned 546k tokens over 54 minutes on a single
+PR. Do not nudge an agent back into a blocking wait, and do not restore that
+advice anywhere.
 
-**A parked stop looks like this:** a subagent returns with its stated goal
-still unmet (PR not merged, checks not confirmed green, fix not pushed) AND its
-final message references *backgrounding a wait* — "monitoring … in the
-background", "will report back once …", "standing by", "I'll wait for the
-notification", or a background task id it expects to wake it. Nothing wakes a
-stopped subagent, so that wait strands forever unless you nudge it.
+**When an agent hands back with CI pending**, own the gap yourself: re-read the
+status when the run should have settled and `SendMessage` the SAME agent (never a
+fresh delegation — zero context reload) with the outcome, either the merge
+go-ahead or the failing check output. Treat `bucket` as advisory — under GitHub
+API eventual-consistency lag it can report a false DONE, so cross-check `state`
+before telling an agent the PR is green.
 
-**When you see that shape, do NOT accept the turn as complete.** Immediately
-`SendMessage` to the SAME agent (never a fresh delegation — zero context reload):
+If you monitor the gap with a `Monitor`, size the interval to the known CI
+wall-clock (5-minute-plus for a ~15-min run), message only on state change, and
+run a one-shot `gh run view <run-id>` if it overruns. Do NOT tight-poll:
+never a 30-second blind poll (that is the spam counter-failure, #2833).
+Disarm the monitor the moment checks settle.
 
-> "Your wait is unresolved and nothing will re-wake a stopped agent. Re-issue
-> the blocking wait in the FOREGROUND now — `gh pr checks <pr> --watch
-> --fail-fast` (or the equivalent blocking command) — and do not end your turn
-> until it exits and the goal is met. Do not background it and do not tight-poll
-> it; `--watch` blocks silently and prints once."
+**A genuine park still exists and is still yours to catch:** a subagent returns
+with its goal unmet AND its final message says it backgrounded a wait —
+"monitoring … in the background", "I'll wait for the notification", or a
+background task id it expects to wake it. Nothing wakes a stopped agent, so
+`SendMessage` the SAME agent to resume the unfinished work in this turn. A
+handoff that names pending CI and stops is NOT this; accept it.
 
 Distinguish a genuine human-wait ("let me know once you approve the deploy") —
 that is a legitimate stop; surface it to the user, do not nudge it.
 
-**Prevention beats detection.** Two defaults keep waits under the tool ceiling
-so subagents rarely need to re-issue at all:
-- Tell the engineer/QA to use **crate-scoped gates** (`cargo test -p <crate>`,
-  not `cargo test --workspace`) — the scoped run finishes well under the 10-min
-  ceiling; the workspace run does not.
-- Tell any agent that must wait on CI to use the blocking `--watch` form, never
-  a manual `sleep` poll loop.
-
-**If you monitor a wait yourself** (a Monitor over a long delegation): size the
-interval to the known wait (5-minute-plus for ~15-min CI), message only on
-state change, and run a one-shot `gh run view <run-id>` diagnosis if it overruns
-— never a 30-second blind poll (that is the spam counter-failure, #2833).
+**Prevention.** Tell the engineer/QA to use crate-scoped gates
+(`cargo test -p <crate>`, not `cargo test --workspace`) — the scoped run finishes
+well under the 10-min tool ceiling, so agents rarely re-issue at all.
 
 ## Task Complexity Detection
 


### PR DESCRIPTION
Closes #4792

## The contradiction

Two shipped rules pointed opposite ways. The bundled instructions told agents to block on `gh pr checks <pr> --watch --fail-fast` in the foreground and never end their turn until CI settled. The standing rule for this repo forbids `--watch` outright, because it streams check output into the agent context — one engineer burned 546k tokens over 54 minutes on PR #4759.

(`--watch` runs fine; an explicit bash `timeout` raises the 120s default toward the 600000ms ceiling. The defect is context cost, not runnability. That distinction is stated inline in the new text so nobody "restores" the old advice on runnability grounds.)

## The ruling, as implemented

**Push, report, stop.** An agent finishing work pushes, takes a ONE-SHOT status read (`gh pr view` / `gh pr checks`, no `--watch`), reports, and ends its turn. It does not block on CI. The PM re-engages when CI settles.

The #2833 parked-subagent concern is still real — the remedy moved to the PM side. The PM instructions section is renamed **"Parked-Subagent Re-Engagement"** and now says plainly that a hand-back naming pending CI is correct behavior, not a park, and must not be nudged back into a blocking wait. A genuine park (goal unmet + a backgrounded wait the agent expects to wake it) is still detected and still nudged.

Own-gate commands are unchanged: builds, test suites, and release cuts still block in the FOREGROUND and hold the turn until they exit.

## Two operational facts folded into the one-shot read

- **`bucket` can report a false DONE.** Under GitHub API eventual-consistency lag a check surfaces as bucketed-complete before it has settled — cross-check `state`.
- **Repeated `gh pr update-branch` is a treadmill.** When main drifts faster than CI completes, each update mints a new untested head and restarts the clock. Merge the head that is actually green; BEHIND is not a correctness gate.

## The sweep

An inconsistent set is what produced the contradiction, so every mirrored copy moved together:

| File | Change |
|---|---|
| `crates/trusty-mpm/src/assets/agents/BASE-AGENT.md` | "Foreground Execution — NEVER End Your Turn To Wait" + "chunked-repoll" replaced by "Finishing Work — Push, Report, Stop" |
| `crates/trusty-mpm/src/assets/agents/BASE-ENGINEER.md` | gate paragraph now points at the new section name and states the CI exception |
| `crates/trusty-mpm/src/assets/agents/version-control.md` | "CI Waits — Push, Report, Stop; NEVER Block" |
| `crates/trusty-mpm/src/assets/agents/local-ops.md` | "Long Waits — Block On Your Own Gates, Never On CI" |
| `crates/trusty-mpm/src/assets/instructions/sections/core.md` | "Parked-Subagent Re-Engagement (issues #2833, #4792)" |
| `crates/trusty-mpm/src/assets/skills/tm-delegation-patterns.md` | "Long-Wait Delegation" rewritten to brief both halves |
| `crates/trusty-code/src/assets/agents/{BASE-AGENT,BASE-ENGINEER,local-ops}.md` | asset mirror, kept byte-identical (verified with `diff`) |
| `crates/trusty-mpm/src/core/testdata/pm-prompt-*.md` | 3 golden snapshots regenerated via `UPDATE_GOLDEN=1` |
| `crates/trusty-mpm/src/core/bundle_tests.rs` | literal-string assertions updated to the new text, plus a new negative assertion that `--watch --fail-fast` cannot come back through any layer |
| `crates/trusty-mpm/src/core/idle_nudge.rs` | `DEFAULT_NUDGE_MESSAGE` no longer tells a stalled pane to run `gh pr checks --watch` |

Not touched, deliberately: `core::idle_parking` phrase detection. It matches parking *idioms* ("standing by", "will report back") which remain wrong under the new doctrine — a push-report-stop hand-back does not trip it.

## Gates — rung 3 (localized behavior, two crates)

```
cargo test -p trusty-mpm                              exit 0 — 4372 passed; 0 failed; 7 ignored
cargo test -p trusty-code                             exit 0 — 1600 passed; 0 failed; 4 ignored (asset mirror)
cargo clippy -p trusty-mpm --all-targets -- -D warnings   exit 0
cargo fmt --check                                     exit 0
bash scripts/check_line_cap.sh                        exit 0 — 3628 files, 0 violations
bash scripts/check_changelog_fragment.sh              exit 0 — both crates recorded
```

Changelog fragments (never a hand-edited `CHANGELOG.md`, per #4476): `crates/trusty-mpm/changelog.d/4792-retire-blocking-ci-wait.md` and `crates/trusty-code/changelog.d/4792-retire-blocking-ci-wait.md`.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools