### PR TITLE
feat(trusty-mpm): deny subagent fan-out via PreToolUse guard

### DIFF
--- a/crates/trusty-mpm/changelog.d/4784-deny-subagent-fanout.md
+++ b/crates/trusty-mpm/changelog.d/4784-deny-subagent-fanout.md
@@ -1,0 +1,6 @@
+Added
+
+- `tm hook --pm-guard` now denies `Task`/`Agent` dispatch when the calling session is itself a subagent (closes [#4784](https://github.com/bobmatnyc/trusty-tools/issues/4784))
+  - the PM keeps dispatching; only fan-out from within a subagent is blocked
+  - `SendMessage` is never denied, so a blocked agent can always report back
+  - fails OPEN — an indeterminate caller context allows the dispatch rather than risking a false deny against the PM

--- a/crates/trusty-mpm/src/bin/tm/commands/mod.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/mod.rs
@@ -58,6 +58,7 @@ pub(crate) mod pm_guard;
 pub(crate) mod pm_guard_bash;
 pub(crate) mod pm_guard_budget;
 pub(crate) mod pm_guard_deny_by_default;
+pub(crate) mod pm_guard_fanout;
 pub(crate) mod pm_guard_routing;
 pub(crate) mod project;
 pub(crate) mod projects;

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard.rs
@@ -78,6 +78,14 @@
 //! in the file that pierces an automatic-marker exemption; see that call
 //! site's comment for why it must never be routed through [`evaluate_tool`]
 //! instead.
+//! **Subagent fan-out denial (issue #4784):** [`pm_guard`] calls
+//! [`crate::commands::pm_guard_fanout::evaluate_subagent_fanout`] DIRECTLY,
+//! before Guards 1 and 4, denying `Task`/`Agent` when the calling session is
+//! itself a subagent — the PM keeps dispatching, `SendMessage` is never
+//! denied, and an indeterminate caller context fails OPEN. It sits ahead of
+//! both exemptions for the same reason the worktree guard does: both return
+//! ALLOW exactly when the caller IS a subagent, the only case the rule fires
+//! on. See that module's doc for the two markers it trusts and why.
 //! Test: `evaluate_tool_*`, `payload_is_subagent_dispatch_*`, and
 //! `build_pretooluse_deny_response_*` below cover the tool policy, sub-agent
 //! exemption, and JSON shape; the Bash-command classifier (composition and
@@ -96,6 +104,7 @@ use crate::commands::pm_guard_bash::{
 };
 use crate::commands::pm_guard_budget::{self, BudgetDecision, DEFAULT_FILE_CHANGE_BUDGET};
 use crate::commands::pm_guard_deny_by_default::{self, PERSONA_DENY_REASON};
+use crate::commands::pm_guard_fanout;
 use crate::commands::pm_guard_routing::{GENERIC_ENGINEER_HINT, delegation_hint_for_path};
 
 /// Escape-hatch env var: `TRUSTY_MPM_PM_UNRESTRICTED=1` disables all PM
@@ -271,6 +280,25 @@ pub(crate) async fn pm_guard(url: &str) -> anyhow::Result<()> {
         }
     }
 
+    // #4784: a subagent must never dispatch further subagents. Placed here,
+    // before Guards 1 and 4, for the same structural reason as the worktree
+    // guard above: both exemptions early-return ALLOW precisely when the
+    // caller IS a subagent, which is the only case this rule fires on — so a
+    // fan-out check placed after either one, or folded into `evaluate_tool`,
+    // would be a guaranteed no-op. Guards 2/3 stay ahead of it (they are
+    // human escape hatches, not automatic markers — see their comments).
+    // It fails OPEN: `caller_is_subagent` reports false whenever neither the
+    // payload's `agent_id` nor `CLAUDE_MPM_SUB_AGENT` is present, so an
+    // unrecognised context allows the dispatch rather than blocking the PM.
+    if let Some(reason) = pm_guard_fanout::evaluate_subagent_fanout(
+        tool_name,
+        pm_guard_fanout::caller_is_subagent(&payload),
+    ) {
+        audit_denied_tool(url, session_id, tool_name, reason).await;
+        println!("{}", build_pretooluse_deny_response(reason));
+        return Ok(());
+    }
+
     // Guard 1: never block a nested MPM sub-agent for anything else — it is
     // doing the delegated work the PM is being steered toward. Moved here
     // (originally the first line of this function, short-circuiting before
@@ -402,7 +430,7 @@ fn pm_unrestricted() -> bool {
 /// `payload_is_subagent_dispatch_false_when_absent_or_empty`; exercised end to
 /// end via `pm_guard_native_subagent_dispatch_allows_edit` in
 /// `tests/tm_hook_pm_guard.rs`.
-fn payload_is_subagent_dispatch(payload: &serde_json::Value) -> bool {
+pub(crate) fn payload_is_subagent_dispatch(payload: &serde_json::Value) -> bool {
     payload
         .get("agent_id")
         .and_then(|v| v.as_str())

--- a/crates/trusty-mpm/src/bin/tm/commands/pm_guard_fanout.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/pm_guard_fanout.rs
@@ -1,0 +1,220 @@
+//! `tm hook --pm-guard` — subagent fan-out denial (issue #4784).
+//!
+//! Why: the orchestration model is one level deep. The PM dispatches
+//! specialists; a specialist does its own work and reports back. A subagent
+//! that dispatches *further* subagents multiplies context cost, hides the
+//! resulting work from the PM's tracking (the PM sees one delegation, not the
+//! tree beneath it), and produces exactly the un-owned fan-out ADR-0024 calls
+//! a single-edge leaf violation. Agent prose alone does not stop it: a model
+//! holding the `Agent`/`Task` tool will use it. The `tools:` frontmatter route
+//! cannot express the rule either — it is an ALLOW-list with no "everything
+//! except X" grammar, and it gates MCP tools through the same list, so
+//! enumerating ~40 agents' tool sets to omit two names would silently break
+//! real MCP access. `PreToolUse` is the one seam that can deny a single named
+//! tool without touching anything else.
+//!
+//! What: [`evaluate_subagent_fanout`] denies [`SUBAGENT_DISPATCH_TOOLS`]
+//! (`Task` and `Agent` — both, since Claude Code renamed the tool between
+//! releases) when, and only when, the calling session is itself a subagent.
+//! [`caller_is_subagent`] answers that from two automatic, spawner/harness-set
+//! markers, never from prose or heuristics:
+//!
+//! 1. `agent_id` in the `PreToolUse` payload — documented by Claude Code as
+//!    present "only when the hook fires inside a subagent call", the same
+//!    signal [`super::pm_guard::payload_is_subagent_dispatch`] has used since
+//!    issue #2014. Reused, not re-derived, so the two can never disagree.
+//! 2. `CLAUDE_MPM_SUB_AGENT` in the environment — stamped by trusty-agents on
+//!    every subagent process it spawns out-of-band
+//!    (`subprocess/spawn.rs`, `agents/claude_code_runner/run.rs`), whose own
+//!    Claude Code session is top-level and therefore carries no `agent_id`.
+//!    Without this arm the guard would be a no-op for that whole class.
+//!
+//! **This guard FAILS OPEN, deliberately.** Neither marker present means
+//! ALLOW, and every upstream degradation ([`super::pm_guard`]'s missing-stdin
+//! and missing-`tool_name` paths) reaches ALLOW before this module is called
+//! at all. The asymmetry is intentional: a false DENY lands on the PM and
+//! halts every dispatch in the system, while a false ALLOW merely reproduces
+//! the behaviour that existed before this guard. Indeterminate is treated as
+//! "not a subagent" for that reason, and no future signal may invert it.
+//!
+//! `SendMessage` is never denied under any circumstance — it is not a member
+//! of [`SUBAGENT_DISPATCH_TOOLS`], and it is how a blocked agent reports back
+//! to the PM and gets resumed. Denying it would strand the very agent this
+//! guard redirects.
+//!
+//! Test: `denies_dispatch_tools_from_a_subagent`,
+//! `allows_dispatch_tools_from_the_pm`, `never_denies_send_message`,
+//! `allows_every_non_dispatch_tool`, and
+//! `fails_open_when_caller_context_is_indeterminate` below; the
+//! payload/env marker resolution and the stdin→decision→stdout path run end to
+//! end through the real binary in `tests/tm_hook_pm_guard.rs`
+//! (`pm_guard_denies_agent_dispatch_from_native_subagent`,
+//! `pm_guard_denies_task_dispatch_from_mpm_subagent_env`,
+//! `pm_guard_allows_agent_dispatch_from_pm`,
+//! `pm_guard_never_denies_send_message`).
+
+use trusty_mpm::core::agent::is_subagent_dispatch_tool;
+
+use crate::commands::misc::SUB_AGENT_ENV;
+use crate::commands::pm_guard::payload_is_subagent_dispatch;
+
+/// Deny reason for a subagent attempting to dispatch another subagent.
+///
+/// Why (#4784): a bare "denied" leaves the model guessing and it retries. The
+/// text names both legitimate continuations — do the work directly, or hand
+/// the parallelisable units back to the PM, which is the only session
+/// authorised to fan out — and states explicitly that `SendMessage` still
+/// works, so reporting back is never mistaken for a second blocked path.
+/// What: the `permissionDecisionReason` string emitted on a fan-out deny.
+/// Test: `denies_dispatch_tools_from_a_subagent`.
+pub(crate) const FANOUT_DENY_REASON: &str = "Subagent fan-out denied (#4784): this session is itself a subagent, and a subagent must \
+     never dispatch further subagents — orchestration is one level deep, and work dispatched \
+     from here is invisible to the PM that owns it. Do this work yourself, or stop and report \
+     back to the PM naming the units that should run in parallel and let the PM dispatch them. \
+     SendMessage is never blocked — use it to report back or to ask for scope.";
+
+/// Classify a `PreToolUse` call for subagent fan-out: `Some(reason)` denies,
+/// `None` allows.
+///
+/// Why: kept pure — it takes the already-resolved caller context as a `bool`
+/// rather than reading the environment itself — so the policy is exhaustively
+/// unit-testable without env mutation, which races across test threads. The
+/// marker resolution lives next door in [`caller_is_subagent`].
+/// What: `Some(`[`FANOUT_DENY_REASON`]`)` when `tool_name` is a
+/// [`SUBAGENT_DISPATCH_TOOLS`] member AND `caller_is_subagent` is true;
+/// `None` (ALLOW) otherwise — which covers the PM's own dispatch, every
+/// non-dispatch tool including `SendMessage`, and the indeterminate case.
+/// Test: `denies_dispatch_tools_from_a_subagent`,
+/// `allows_dispatch_tools_from_the_pm`, `never_denies_send_message`,
+/// `allows_every_non_dispatch_tool`,
+/// `fails_open_when_caller_context_is_indeterminate`.
+pub(crate) fn evaluate_subagent_fanout(
+    tool_name: &str,
+    caller_is_subagent: bool,
+) -> Option<&'static str> {
+    if !caller_is_subagent {
+        return None;
+    }
+    is_subagent_dispatch_tool(tool_name).then_some(FANOUT_DENY_REASON)
+}
+
+/// Whether the session issuing this `PreToolUse` call is itself a subagent.
+///
+/// Why: this is the whole difficulty of #4784 — the PM must keep dispatching,
+/// so the guard is only as safe as this predicate. Both signals below are
+/// AUTOMATIC markers (a harness or a spawn helper sets them; no per-call human
+/// or model decision is involved), which is what makes them trustworthy here.
+/// No prose, transcript-path shape, or agent-name heuristic is consulted.
+/// What: `true` when the payload carries a non-empty `agent_id` (native
+/// `Task`/`Agent` dispatch — delegated to
+/// [`payload_is_subagent_dispatch`] so the `agent_id` rule has one definition
+/// in this crate) OR when [`SUB_AGENT_ENV`] is present (trusty-agents'
+/// out-of-band subagent processes). Absent both, `false` — the FAIL-OPEN
+/// answer, per this module's doc.
+/// Test: the payload arm is pinned by
+/// `pm_guard::payload_is_subagent_dispatch_*`; both arms and their `false`
+/// case run through the real binary in `tests/tm_hook_pm_guard.rs`
+/// (`pm_guard_denies_agent_dispatch_from_native_subagent`,
+/// `pm_guard_denies_task_dispatch_from_mpm_subagent_env`,
+/// `pm_guard_allows_agent_dispatch_from_pm`), where env is controlled
+/// per-process instead of raced across threads.
+pub(crate) fn caller_is_subagent(payload: &serde_json::Value) -> bool {
+    payload_is_subagent_dispatch(payload) || std::env::var_os(SUB_AGENT_ENV).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use trusty_mpm::core::agent::SUBAGENT_DISPATCH_TOOLS;
+
+    #[test]
+    fn denies_dispatch_tools_from_a_subagent() {
+        // Both names must be denied: Claude Code called this tool `Task` in
+        // earlier releases and `Agent` in current ones (see
+        // `core::agent::SUBAGENT_DISPATCH_TOOLS`).
+        for tool in SUBAGENT_DISPATCH_TOOLS {
+            assert_eq!(
+                evaluate_subagent_fanout(tool, true),
+                Some(FANOUT_DENY_REASON),
+                "expected a subagent's {tool} dispatch to be denied"
+            );
+        }
+        // The reason must actually tell the agent what to do instead.
+        assert!(FANOUT_DENY_REASON.contains("report back to the PM"));
+        assert!(FANOUT_DENY_REASON.contains("SendMessage is never blocked"));
+    }
+
+    #[test]
+    fn allows_dispatch_tools_from_the_pm() {
+        // The entire orchestration model depends on this arm: the PM is not a
+        // subagent, so its dispatches must pass untouched.
+        for tool in SUBAGENT_DISPATCH_TOOLS {
+            assert_eq!(
+                evaluate_subagent_fanout(tool, false),
+                None,
+                "the PM's own {tool} dispatch must never be denied"
+            );
+        }
+    }
+
+    #[test]
+    fn never_denies_send_message() {
+        // SendMessage is how a denied agent reports back and gets resumed —
+        // denying it would strand the agent this guard redirects. Asserted in
+        // BOTH caller contexts, because "never" is the contract.
+        for caller_is_subagent in [true, false] {
+            assert_eq!(
+                evaluate_subagent_fanout("SendMessage", caller_is_subagent),
+                None,
+                "SendMessage must never be denied (caller_is_subagent={caller_is_subagent})"
+            );
+        }
+    }
+
+    #[test]
+    fn allows_every_non_dispatch_tool() {
+        // A subagent keeps its full working tool surface; only fan-out is cut.
+        for tool in [
+            "Read",
+            "Edit",
+            "Write",
+            "Bash",
+            "Grep",
+            "Glob",
+            "TodoWrite",
+            "WebFetch",
+            "mcp__trusty-search__search",
+            // Case-sensitive: an unrelated user tool named `agent`/`task`
+            // must not be swept up.
+            "agent",
+            "task",
+        ] {
+            assert_eq!(
+                evaluate_subagent_fanout(tool, true),
+                None,
+                "expected {tool} to be allowed inside a subagent"
+            );
+        }
+    }
+
+    #[test]
+    fn fails_open_when_caller_context_is_indeterminate() {
+        // #4784: a payload carrying neither marker is INDETERMINATE, and
+        // indeterminate must resolve to ALLOW — a false deny against the PM
+        // halts all orchestration, a false allow merely reproduces the
+        // pre-guard behaviour. `caller_is_subagent` reports false for such a
+        // payload (env arm is exercised in the integration test).
+        let indeterminate = serde_json::json!({"tool_name": "Agent"});
+        assert_eq!(
+            evaluate_subagent_fanout("Agent", payload_is_subagent_dispatch(&indeterminate)),
+            None,
+            "an indeterminate caller context must fail OPEN"
+        );
+        // An empty-string agent_id is equally indeterminate, not a subagent.
+        let empty_id = serde_json::json!({"agent_id": "", "tool_name": "Agent"});
+        assert_eq!(
+            evaluate_subagent_fanout("Agent", payload_is_subagent_dispatch(&empty_id)),
+            None
+        );
+    }
+}

--- a/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
+++ b/crates/trusty-mpm/tests/tm_hook_pm_guard.rs
@@ -699,3 +699,133 @@ fn pm_guard_allows_benign_pipes_and_dev_null() {
     );
     assert_eq!(dev_null.trim(), "", "2>/dev/null discard must be allowed");
 }
+
+// ---------------------------------------------------------------------------
+// Subagent fan-out denial (issue #4784) — `commands::pm_guard_fanout`.
+//
+// The pure policy is unit-tested in that module; these cases prove the two
+// caller-context markers actually resolve through the real binary (env is
+// controlled per-process here, which a threaded unit test cannot do safely)
+// and that the decision reaches stdout in the documented deny shape.
+// ---------------------------------------------------------------------------
+
+/// Assert the printed deny names the fan-out rule and its remedy, not just
+/// "denied" — the message is the whole point of the guard for the agent that
+/// hits it.
+fn assert_fanout_denied(stdout: &str) {
+    assert_denied(stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(stdout.trim()).expect("deny stdout must be valid JSON");
+    let reason = parsed["hookSpecificOutput"]["permissionDecisionReason"]
+        .as_str()
+        .expect("reason is a string");
+    assert!(
+        reason.contains("#4784") && reason.contains("report back to the PM"),
+        "the fan-out deny must name the rule and the remedy, got: {reason}"
+    );
+}
+
+#[test]
+fn pm_guard_denies_agent_dispatch_from_native_subagent() {
+    // A native Task/Agent-dispatched subagent (agent_id present) trying to
+    // dispatch again. This is the case #4784 exists for, and it must fire
+    // AHEAD of Guard 4, which would otherwise exempt this exact payload.
+    for tool in ["Agent", "Task"] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","agent_type":"rust-engineer","tool_name":"{tool}","tool_input":{{"subagent_type":"qa","prompt":"go"}}}}"#
+        );
+        assert_fanout_denied(&run_pm_guard(&payload, &[]));
+    }
+}
+
+#[test]
+fn pm_guard_denies_task_dispatch_from_mpm_subagent_env() {
+    // trusty-agents spawns subagents as their own top-level Claude Code
+    // sessions, which carry no `agent_id` — `CLAUDE_MPM_SUB_AGENT` is the only
+    // marker available there. Without this arm the guard is a no-op for that
+    // whole class. It must also fire ahead of Guard 1, which exempts this
+    // process for everything else.
+    for tool in ["Agent", "Task"] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"{tool}","tool_input":{{"subagent_type":"qa","prompt":"go"}}}}"#
+        );
+        assert_fanout_denied(&run_pm_guard(&payload, &[("CLAUDE_MPM_SUB_AGENT", "1")]));
+    }
+}
+
+#[test]
+fn pm_guard_allows_agent_dispatch_from_pm() {
+    // The load-bearing arm: the PM carries neither marker, so its dispatches
+    // must pass silently. A regression here halts every delegation in the
+    // system, which is strictly worse than the fan-out this guard prevents.
+    for tool in ["Agent", "Task"] {
+        let payload = format!(
+            r#"{{"hook_event_name":"PreToolUse","tool_name":"{tool}","tool_input":{{"subagent_type":"rust-engineer","prompt":"go"}}}}"#
+        );
+        assert_eq!(
+            run_pm_guard(&payload, &[]).trim(),
+            "",
+            "the PM's own {tool} dispatch must be allowed"
+        );
+    }
+}
+
+#[test]
+fn pm_guard_fanout_fails_open_on_indeterminate_caller() {
+    // An empty-string `agent_id` and a payload with no marker at all are both
+    // INDETERMINATE. Indeterminate must ALLOW (#4784): a false deny against
+    // the PM halts orchestration; a false allow reproduces prior behaviour.
+    for payload in [
+        r#"{"hook_event_name":"PreToolUse","agent_id":"","tool_name":"Agent","tool_input":{"prompt":"go"}}"#,
+        r#"{"hook_event_name":"PreToolUse","agent_type":"rust-engineer","tool_name":"Agent","tool_input":{"prompt":"go"}}"#,
+    ] {
+        assert_eq!(
+            run_pm_guard(payload, &[]).trim(),
+            "",
+            "an indeterminate caller context must fail OPEN: {payload}"
+        );
+    }
+}
+
+#[test]
+fn pm_guard_never_denies_send_message() {
+    // SendMessage is how a fan-out-denied agent reports back and gets resumed.
+    // Denying it would strand the agent this guard redirects, so it is asserted
+    // in every caller context — including both subagent markers.
+    let payload = r#"{"hook_event_name":"PreToolUse","tool_name":"SendMessage","tool_input":{"agent_id":"x","message":"done"}}"#;
+    let sub_payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","tool_name":"SendMessage","tool_input":{"agent_id":"x","message":"done"}}"#;
+    assert_eq!(run_pm_guard(payload, &[]).trim(), "");
+    assert_eq!(run_pm_guard(sub_payload, &[]).trim(), "");
+    assert_eq!(
+        run_pm_guard(payload, &[("CLAUDE_MPM_SUB_AGENT", "1")]).trim(),
+        "",
+        "SendMessage must never be denied, in any caller context"
+    );
+}
+
+#[test]
+fn pm_guard_fanout_yields_to_operator_escape_hatches() {
+    // Guards 2/3 are human escape hatches and stay ahead of every rule in the
+    // file, this one included — an operator who explicitly lifts enforcement
+    // gets exactly that. Pinned so a future reordering is a deliberate choice.
+    let payload = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","tool_name":"Agent","tool_input":{"prompt":"go"}}"#;
+    assert_eq!(
+        run_pm_guard(payload, &[("TRUSTY_MPM_DISABLE_HOOKS", "1")]).trim(),
+        ""
+    );
+    assert_eq!(
+        run_pm_guard(payload, &[("TRUSTY_MPM_PM_UNRESTRICTED", "1")]).trim(),
+        ""
+    );
+}
+
+#[test]
+fn pm_guard_subagent_keeps_its_working_tool_surface() {
+    // Only fan-out is cut. A subagent's ordinary work — the Edit/Write calls
+    // Guard 4 exists to exempt (#2014) — must still be allowed, proving the
+    // new guard narrowed nothing else.
+    let edit = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","tool_name":"Edit","tool_input":{"file_path":"/x/a.rs","old_string":"a","new_string":"b"}}"#;
+    assert_eq!(run_pm_guard(edit, &[]).trim(), "");
+    let read = r#"{"hook_event_name":"PreToolUse","agent_id":"agent-abc123","tool_name":"Read","tool_input":{"file_path":"/x/a.rs"}}"#;
+    assert_eq!(run_pm_guard(read, &[]).trim(), "");
+}


### PR DESCRIPTION
Closes #4784

## What

`tm hook --pm-guard` now denies `Task`/`Agent` when the session issuing the call is itself a subagent. The PM keeps dispatching — that is the entire orchestration model and nothing about it changes.

## The detection mechanism (the hard part)

Subagent-ness is resolved from two **automatic markers** — a harness or a spawn helper sets them, no per-call model or human decision is involved. No prose, transcript-path shape, or agent-name heuristic is consulted.

| Signal | Source | Covers |
|---|---|---|
| `agent_id` in the `PreToolUse` payload | Claude Code, documented as present "only when the hook fires inside a subagent call" | native `Task`/`Agent` dispatch |
| `CLAUDE_MPM_SUB_AGENT` in the environment | trusty-agents (`subprocess/spawn.rs`, `agents/claude_code_runner/run.rs`) | out-of-band subagent processes, whose own Claude Code session is top-level and carries no `agent_id` |

`agent_id` is **not newly derived** — it is the same signal `pm_guard::payload_is_subagent_dispatch` has used since #2014, reused rather than re-implemented so the two can never disagree. Captured real-world evidence of the field is already in-tree at `tests/tm_hook_delegation_payload.rs:185`.

## Fail-open, stated explicitly

Neither marker present means **ALLOW**. The asymmetry is deliberate and documented in the code: a false DENY lands on the PM and halts every dispatch in the system; a false ALLOW merely reproduces the behaviour that existed before this guard.

`SendMessage` is **never** denied, in any caller context. It is how a blocked agent reports back and gets resumed — denying it would strand the very agent the guard redirects.

## Placement

The check sits ahead of Guard 1 (`CLAUDE_MPM_SUB_AGENT`) and Guard 4 (`agent_id`), for the same structural reason the #3977 worktree guard does: both exemptions early-return ALLOW *precisely* when the caller is a subagent, which is the only case this rule fires on. Placed after either, it would be a guaranteed no-op. Guards 2/3 (`TRUSTY_MPM_DISABLE_HOOKS`, `TRUSTY_MPM_PM_UNRESTRICTED`) stay ahead of it — they are human escape hatches, not automatic markers — and that ordering is pinned by a test.

## Why a hook and not `tools:` frontmatter

Re-verified against the code, all three claims from the prior investigation hold:

1. `tools:` **is** mechanically enforced — `trusty-agents-common/src/agents/builder.rs` parses, merges across the `extends` chain, and re-emits it.
2. It is **allow-list only**. `builder.rs:790-801` treats a present key as a wholesale replacement and `Some(vec![])` as deny-all; there is no exclusion grammar anywhere in the parser.
3. **MCP tools are gated by the same list** — they are ordinary `mcp__server__tool` names that must appear in it, so an enumerated allow-list across ~40 agents would silently break real, often-deferred MCP access.

## Tests

Pure policy (`pm_guard_fanout`, 5 unit tests) plus 7 end-to-end tests through the real binary in `tests/tm_hook_pm_guard.rs`: deny from a native subagent, deny from an MPM-env subagent, **allow from the PM**, `SendMessage` never denied, fail-open on indeterminate context, escape hatches still win, and a subagent's ordinary Edit/Read surface unchanged.

**Fail-before / pass-after**, with the guard neutralized to `caller_is_subagent = false`:

```
failures:
    pm_guard_denies_agent_dispatch_from_native_subagent
    pm_guard_denies_task_dispatch_from_mpm_subagent_env

test result: FAILED. 38 passed; 2 failed; 0 ignored
```

Exactly the two deny arms fail; every ALLOW arm passes both ways, proving those pin non-regression rather than the new behaviour. Restored:

```
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

## Gates — rung 5

```
cargo fmt --check                                    → clean
cargo clippy -p trusty-mpm --all-targets -D warnings → exit 0
cargo test -p trusty-mpm                             → 4371 passed; 1 failed (baseline, below)
cargo check --workspace                              → 2 failed (baseline, below)
bash scripts/check_line_cap.sh    → 3629 files, 0 violations — OK
bash scripts/check_sld.sh         → 55 specs + 3046 files, 0 errors, 0 warnings
bash scripts/check_changelog_fragment.sh → OK, scanned 5 paths
```

### Baseline failures — non-involvement proven, not asserted

`execute_doctor_against_test_daemon` — the documented environmental flake. `git diff --name-only origin/main...HEAD -- crates/trusty-mpm/src/client/` returns **0 files**, and it passes in isolation:

```
test client::executor::tests::execute_doctor_against_test_daemon ... ok
test result: ok. 1 passed; 0 failed; 4378 filtered out
```

`cargo check --workspace` — exactly 2 crates fail, both on the missing pnpm build artifact:

```
error: could not compile `trusty-code-gui` (lib) due to 1 previous error
error: could not compile `trusty-mpm-gui` (lib) due to 1 previous error
  = help: message: The `frontendDist` configuration is set to `"ui/dist"` but this path doesn't exist
```

`git diff --name-only origin/main...HEAD -- crates/trusty-code-gui/ crates/trusty-mpm-gui/` returns **0 files**. Every other workspace crate compiled.

No coverage was deleted, `#[ignore]`-d, `cfg`-gated, or `--exclude`-d anywhere in this change.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools