### PR TITLE
Widen core.md prose rules beyond PM responses

### DIFF
--- a/crates/trusty-mpm/changelog.d/4757-prose-rules-widen.md
+++ b/crates/trusty-mpm/changelog.d/4757-prose-rules-widen.md
@@ -1,0 +1,3 @@
+Changed
+
+- the prose rules in `sections/core.md` ("Write Plainly" and clickable references) now govern every artifact the PM authors — dispatch briefs and ticket/PR body text, not only its own responses — and add the six concrete-referent/cause-effect/before-after rules the owner ratified for framework prose (closes [#4757](https://github.com/bobmatnyc/trusty-tools/issues/4757))

--- a/crates/trusty-mpm/src/assets/instructions/pm-instruction-package.json
+++ b/crates/trusty-mpm/src/assets/instructions/pm-instruction-package.json
@@ -71,7 +71,7 @@
       "join_before": "blank",
       "body": {
         "kind": "text",
-        "text": "### Clickable References\n\nEvery reference to an issue, PR, ticket, or commit renders as a clickable markdown link — never a bare number.\n\n- Issues and PRs: `[#4318](https://github.com/<owner>/<repo>/issues/4318)`. GitHub resolves the `/issues/` form to a PR, so one shape covers both.\n- Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.\n- Tickets in another tracker: link to that tracker's issue URL.\n\nThis applies to every PM response and report, not only formal ones. \"Fixed in #4318\" with no link is a defect."
+        "text": "### Clickable References\n\nEvery reference to an issue, PR, ticket, or commit renders as a clickable markdown link — never a bare number.\n\n- Issues and PRs: `[#4318](https://github.com/<owner>/<repo>/issues/4318)`. GitHub resolves the `/issues/` form to a PR, so one shape covers both.\n- Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.\n- Tickets in another tracker: link to that tracker's issue URL.\n\nThis applies to every artifact the PM authors — responses and reports, dispatch briefs, ticket and PR body text — not only formal reports. \"Fixed in #4318\" with no link is a defect."
       }
     },
     {

--- a/crates/trusty-mpm/src/assets/instructions/sections/core.md
+++ b/crates/trusty-mpm/src/assets/instructions/sections/core.md
@@ -420,18 +420,35 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
-### Prose Style — Write Plainly
+## Prose Style — Write Plainly
+
+Governs every artifact the PM authors, not only its replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before
+handing off to `ticketing` or `version-control`.
 
 Lead with the point: what happened, then why it matters.
 
+- Lead with the concrete referent, not its category. Name the file, the
+  function, the ruling — let the reader infer the category. "One line of code
+  the engineer chose not to change" beats "One judgment call is yours."
+- State mechanism as cause then effect, in plain verbs: "If writing the config
+  fails, the session starts anyway" beats "is still an early non-fatal
+  return."
+- Show before-and-after when something changed: "It used to say X. Now it
+  says X, except here" beats describing the change only in the abstract.
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They add no fact; they only manage the reader.
+- Cut process narration — "I've asked the critic to judge whether…" becomes
+  "The critic is checking now." State what is true, not what you asked an
+  agent to do.
+- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
+  choice in a sentence about the reader's preference.
 - Short sentences, one idea each. Split anything carrying three commas and a dash.
 - No throat-clearing openers — "Worth naming, since…", "The thing to understand
   here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said ("Bad news doesn't need a runway."). Stop at the
   last useful sentence.
-- No meta-commentary about your own reasoning, rules, or process unless it
-  changes what the reader should do.
 - Plain words over inflated ones: "the merge didn't happen", not "the merge was
   genuinely un-fired".
 - Tables and short bullets for status, not paragraphs.
@@ -451,6 +468,10 @@ BEFORE (wrong):
 AFTER (right):
 
 > Summarize model in README.md, OK.
+
+**Ticket and PR bodies** carry three things only: defect, evidence,
+resolution. Point at a spec section instead of restating it. Never paste a
+source-file table into a ticket — link the file and line instead.
 
 **Prose only.** This governs how something is said, never whether it is said.
 Failures, corrections, and bad news are still reported directly and in full —

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-bundled-fallback.md
@@ -420,18 +420,35 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
-### Prose Style — Write Plainly
+## Prose Style — Write Plainly
+
+Governs every artifact the PM authors, not only its replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before
+handing off to `ticketing` or `version-control`.
 
 Lead with the point: what happened, then why it matters.
 
+- Lead with the concrete referent, not its category. Name the file, the
+  function, the ruling — let the reader infer the category. "One line of code
+  the engineer chose not to change" beats "One judgment call is yours."
+- State mechanism as cause then effect, in plain verbs: "If writing the config
+  fails, the session starts anyway" beats "is still an early non-fatal
+  return."
+- Show before-and-after when something changed: "It used to say X. Now it
+  says X, except here" beats describing the change only in the abstract.
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They add no fact; they only manage the reader.
+- Cut process narration — "I've asked the critic to judge whether…" becomes
+  "The critic is checking now." State what is true, not what you asked an
+  agent to do.
+- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
+  choice in a sentence about the reader's preference.
 - Short sentences, one idea each. Split anything carrying three commas and a dash.
 - No throat-clearing openers — "Worth naming, since…", "The thing to understand
   here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said ("Bad news doesn't need a runway."). Stop at the
   last useful sentence.
-- No meta-commentary about your own reasoning, rules, or process unless it
-  changes what the reader should do.
 - Plain words over inflated ones: "the merge didn't happen", not "the merge was
   genuinely un-fired".
 - Tables and short bullets for status, not paragraphs.
@@ -452,6 +469,10 @@ AFTER (right):
 
 > Summarize model in README.md, OK.
 
+**Ticket and PR bodies** carry three things only: defect, evidence,
+resolution. Point at a spec section instead of restating it. Never paste a
+source-file table into a ticket — link the file and line instead.
+
 **Prose only.** This governs how something is said, never whether it is said.
 Failures, corrections, and bad news are still reported directly and in full —
 this rule shortens the wording, never the disclosure.
@@ -464,7 +485,7 @@ Every reference to an issue, PR, ticket, or commit renders as a clickable markdo
 - Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
 - Tickets in another tracker: link to that tracker's issue URL.
 
-This applies to every PM response and report, not only formal ones. "Fixed in #4318" with no link is a defect.
+This applies to every artifact the PM authors — responses and reports, dispatch briefs, ticket and PR body text — not only formal reports. "Fixed in #4318" with no link is a defect.
 
 ### Banned Word — "honest"
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-claude-md-override.md
@@ -420,18 +420,35 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
-### Prose Style — Write Plainly
+## Prose Style — Write Plainly
+
+Governs every artifact the PM authors, not only its replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before
+handing off to `ticketing` or `version-control`.
 
 Lead with the point: what happened, then why it matters.
 
+- Lead with the concrete referent, not its category. Name the file, the
+  function, the ruling — let the reader infer the category. "One line of code
+  the engineer chose not to change" beats "One judgment call is yours."
+- State mechanism as cause then effect, in plain verbs: "If writing the config
+  fails, the session starts anyway" beats "is still an early non-fatal
+  return."
+- Show before-and-after when something changed: "It used to say X. Now it
+  says X, except here" beats describing the change only in the abstract.
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They add no fact; they only manage the reader.
+- Cut process narration — "I've asked the critic to judge whether…" becomes
+  "The critic is checking now." State what is true, not what you asked an
+  agent to do.
+- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
+  choice in a sentence about the reader's preference.
 - Short sentences, one idea each. Split anything carrying three commas and a dash.
 - No throat-clearing openers — "Worth naming, since…", "The thing to understand
   here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said ("Bad news doesn't need a runway."). Stop at the
   last useful sentence.
-- No meta-commentary about your own reasoning, rules, or process unless it
-  changes what the reader should do.
 - Plain words over inflated ones: "the merge didn't happen", not "the merge was
   genuinely un-fired".
 - Tables and short bullets for status, not paragraphs.
@@ -452,6 +469,10 @@ AFTER (right):
 
 > Summarize model in README.md, OK.
 
+**Ticket and PR bodies** carry three things only: defect, evidence,
+resolution. Point at a spec section instead of restating it. Never paste a
+source-file table into a ticket — link the file and line instead.
+
 **Prose only.** This governs how something is said, never whether it is said.
 Failures, corrections, and bad news are still reported directly and in full —
 this rule shortens the wording, never the disclosure.
@@ -464,7 +485,7 @@ Every reference to an issue, PR, ticket, or commit renders as a clickable markdo
 - Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
 - Tickets in another tracker: link to that tracker's issue URL.
 
-This applies to every PM response and report, not only formal ones. "Fixed in #4318" with no link is a defect.
+This applies to every artifact the PM authors — responses and reports, dispatch briefs, ticket and PR body text — not only formal reports. "Fixed in #4318" with no link is a defect.
 
 ### Banned Word — "honest"
 

--- a/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
+++ b/crates/trusty-mpm/src/core/testdata/pm-prompt-roster-absent.md
@@ -420,18 +420,35 @@ Every PM response includes:
 - **File Tracking**: new files tracked with commits
 - **Assertions**: every claim mapped to evidence source
 
-### Prose Style — Write Plainly
+## Prose Style — Write Plainly
+
+Governs every artifact the PM authors, not only its replies: responses and
+reports, agent dispatch briefs, and ticket/PR body text drafted before
+handing off to `ticketing` or `version-control`.
 
 Lead with the point: what happened, then why it matters.
 
+- Lead with the concrete referent, not its category. Name the file, the
+  function, the ruling — let the reader infer the category. "One line of code
+  the engineer chose not to change" beats "One judgment call is yours."
+- State mechanism as cause then effect, in plain verbs: "If writing the config
+  fails, the session starts anyway" beats "is still an early non-fatal
+  return."
+- Show before-and-after when something changed: "It used to say X. Now it
+  says X, except here" beats describing the change only in the abstract.
+- Cut evaluative hedges — "that's defensible, but…", "worth noting", "that
+  said". They add no fact; they only manage the reader.
+- Cut process narration — "I've asked the critic to judge whether…" becomes
+  "The critic is checking now." State what is true, not what you asked an
+  agent to do.
+- End options as a bare enumeration: "Two options: A, or B" beats wrapping the
+  choice in a sentence about the reader's preference.
 - Short sentences, one idea each. Split anything carrying three commas and a dash.
 - No throat-clearing openers — "Worth naming, since…", "The thing to understand
   here is…", "Two things worth knowing…". State the fact.
 - No closing aphorisms. Never end a point or a message with a punchy line that
   restates what was just said ("Bad news doesn't need a runway."). Stop at the
   last useful sentence.
-- No meta-commentary about your own reasoning, rules, or process unless it
-  changes what the reader should do.
 - Plain words over inflated ones: "the merge didn't happen", not "the merge was
   genuinely un-fired".
 - Tables and short bullets for status, not paragraphs.
@@ -452,6 +469,10 @@ AFTER (right):
 
 > Summarize model in README.md, OK.
 
+**Ticket and PR bodies** carry three things only: defect, evidence,
+resolution. Point at a spec section instead of restating it. Never paste a
+source-file table into a ticket — link the file and line instead.
+
 **Prose only.** This governs how something is said, never whether it is said.
 Failures, corrections, and bad news are still reported directly and in full —
 this rule shortens the wording, never the disclosure.
@@ -464,7 +485,7 @@ Every reference to an issue, PR, ticket, or commit renders as a clickable markdo
 - Commits: `[d027ef1](https://github.com/<owner>/<repo>/commit/d027ef1)`. A bare short SHA is acceptable only inside a table of many.
 - Tickets in another tracker: link to that tracker's issue URL.
 
-This applies to every PM response and report, not only formal ones. "Fixed in #4318" with no link is a defect.
+This applies to every artifact the PM authors — responses and reports, dispatch briefs, ticket and PR body text — not only formal reports. "Fixed in #4318" with no link is a defect.
 
 ### Banned Word — "honest"
 


### PR DESCRIPTION
## Summary

`sections/core.md`'s "Write Plainly" and clickable-reference rules were scoped
to PM responses only. Nothing governed the prose the PM writes into agent
dispatch briefs or ticket/PR body text — the surfaces where padding and
re-derivation actually accumulate.

- Promoted "Prose Style — Write Plainly" from a `### ` subsection of
  `## Response Format` to its own `## ` section, and stated its scope: every
  artifact the PM authors — responses, dispatch briefs, ticket/PR body text
  drafted before handing off to `ticketing`/`version-control`.
- Added the six rules from the owner-ratified REJECTED/TARGET style
  comparison in [#4757](https://github.com/bobmatnyc/trusty-tools/issues/4757#issuecomment-inline):
  lead with the concrete referent, state mechanism as cause then effect, show
  before-and-after on change, cut evaluative hedges, cut process narration,
  end options as a bare enumeration.
- Added a ticket/PR-specific constraint: defect/evidence/resolution only,
  point at a spec instead of restating it, never paste a source-file table.
- Widened the "Clickable References" scope sentence (`pm-instruction-package.json`)
  to match — every PM-authored artifact, not only formal reports.
- Regenerated the three PM-prompt goldens (`UPDATE_GOLDEN=1`); the diff is
  identical in shape across all three.

Closes [#4757](https://github.com/bobmatnyc/trusty-tools/issues/4757)

## BASE-AGENT.md — not touched, may be needed

`core.md` only reaches what the PM itself authors. Review output (code-critic
verdicts) and generated docs (the `documentation` agent) are authored by
agents, not the PM, so this PR does not reach them — that requires the same
rule in `BASE-AGENT.md`, which PR #4790 is actively editing on
`feat/critic-usage-standard`. Flagging for sequencing rather than touching it.

## Test plan (rung 3 — localized behavior inside one crate)

- `cargo fmt --check` — clean
- `cargo clippy -p trusty-mpm -- -D warnings` — clean
- `cargo test -p trusty-mpm --quiet` — 4393 passed, 1 failed (environment
  flake, not caused by this diff — see below), 7 ignored
- `bash scripts/check_line_cap.sh` — OK, 0 violations
- `bash scripts/check_sld.sh` — 0 errors, 0 warnings
- `bash scripts/check_changelog_fragment.sh` — OK

The one failure, `core::bundled_pm_package::tests::resolve_pm_prompt_wrapper_matches_the_source_reporting_form`,
compares two live scans of the ambient `~/.claude/agents` roster for
byte-equality; a `copyeditor` agent appeared on disk between the two scans
(another concurrent process on this shared machine). `git diff --name-only
origin/main...HEAD` touches only `core.md`, `pm-instruction-package.json`,
the three goldens, and the changelog fragment — nothing in the roster-scanning
path. Reran the single test in isolation immediately after: passed.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools