### PR TITLE
ci(release): build the linux arm64 leg natively and stop reporting partial releases as success

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,9 +34,31 @@
 #   versioned glibc stubs), so it changes nothing about which sources get
 #   compiled or which Cargo features are active — the resulting binary lands
 #   in the SAME `target/<triple>/release/` directory a plain `cargo build`
-#   would use, just linked against an older glibc baseline. This same
-#   mechanism cross-compiles `aarch64-unknown-linux-gnu` from the x86_64
-#   runner with no separate arm64 runner or Docker `cross` toolchain needed.
+#   would use, just linked against an older glibc baseline.
+#
+# 2533: LINUX ARM64 IS BUILT NATIVELY, NOT CROSS-COMPILED.
+#   #2037 originally cross-compiled `aarch64-unknown-linux-gnu` from the
+#   x86_64 runner via zig. That works for pure-Rust crates, but breaks for any
+#   crate whose graph reaches a `-sys` crate that asks pkg-config where a
+#   system library lives: `openssl-sys` (reached via fastembed → hf-hub →
+#   native-tls, and via git2/libgit2-sys) aborts the build with
+#
+#       pkg-config has not been configured to support cross-compilation
+#       Could not find directory of OpenSSL installation
+#
+#   because the x86_64 host's pkg-config cannot answer questions about arm64
+#   target libraries, and there is no arm64 sysroot on the runner. That is why
+#   no `aarch64-unknown-linux-gnu` asset ever shipped for trusty-search (last
+#   confirmed: run 30910233376 / job 91994983751, v0.42.0).
+#
+#   Fix: the leg now runs on GitHub's NATIVE `ubuntu-24.04-arm` runner (public
+#   repositories get these at no cost), so HOST == TARGET and every `-sys`
+#   build script resolves against the runner's own arm64 `libssl-dev` exactly
+#   the way the x86_64 leg resolves against its amd64 one. Cross-compilation —
+#   the actual root difficulty — is removed rather than worked around. zig is
+#   still used on this leg, but ONLY to pin the glibc floor (below), never to
+#   cross-compile. Alternatives considered and rejected are recorded in the PR
+#   for #2533.
 #
 #   CAVEAT — ORT-bundling crates (trusty-search, trusty-analyze), discovered
 #   via a real workflow_dispatch dry-run CI validation while building #2037:
@@ -58,10 +80,23 @@
 #   crates (see the matrix-generation step below) — proven working in CI,
 #   since it never links ONNX Runtime at build time either.
 #
-#   The Linux arm64 leg is marked `best_effort` (continue-on-error, like the
-#   existing AL2023 leg) because it is new and has not yet been validated by
-#   an actual tagged release — see the PR for #2037 for the target-triple /
-#   asset-name coordination with the companion install.sh issue (#2038).
+# 2533: THE ARM64 LINUX LEG IS BLOCKING, AND MISSING ASSETS ARE AUDITED.
+#   The arm64 leg used to be `best_effort` (continue-on-error). Because a
+#   `best_effort` leg's failure does not change the run's conclusion, the
+#   workflow reported `success` for four releases in a row while shipping no
+#   arm64 Linux binary at all — a partial release that looked clean. Two
+#   changes close that:
+#     1. The arm64 Linux leg is no longer `best_effort`. It is a supported
+#        target (Graviton, arm64 containers), so its failure now turns the run
+#        red like any other required leg.
+#     2. The `release-completeness-audit` job below compares the assets that
+#        were actually produced against the build matrix that was requested,
+#        and reports every dropped leg in the run summary — as a hard failure
+#        for required legs, and as a loud `::warning` annotation for the one
+#        remaining `best_effort` leg (AL2023). No matrix leg can now go
+#        missing without saying so somewhere a reader will look.
+#   See also #4087 and #4125 — the same "real failure reported as success"
+#   shape in other subsystems.
 #
 # ASSET NAMING CONVENTION (matches INSTALL-CONVENTION.md / PR #891):
 #   <crate>-<version>-<target>.tar.gz           (standard variants, e.g.
@@ -444,12 +479,12 @@ jobs:
       # linux-zigbuild variants (issue #2037 — portable glibc 2.17 baseline,
       # built via `cargo zigbuild --target <triple>.2.17`; see the file-header
       # comment for the full rationale):
-      #   { runner: ubuntu-latest, target: x86_64-unknown-linux-gnu,  variant: linux-zigbuild, best_effort: false }
-      #   { runner: ubuntu-latest, target: aarch64-unknown-linux-gnu, variant: linux-zigbuild, best_effort: true  }
-      #   (aarch64 is cross-compiled from the x86_64 runner by zig/cargo-zigbuild;
-      #    for ORT-bundling crates it uses the load-dynamic feature set, same as
-      #    the AL2023 variant below, since bundled-ort has no aarch64 build-time
-      #    binary to download)
+      #   { runner: ubuntu-latest,    target: x86_64-unknown-linux-gnu,  variant: linux-zigbuild, best_effort: false }
+      #   { runner: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu, variant: linux-zigbuild, best_effort: false }
+      #   (2533: aarch64 builds NATIVELY on an arm64 runner — it is no longer
+      #    cross-compiled and no longer best-effort; for ORT-bundling crates it
+      #    uses the load-dynamic feature set, same as the AL2023 variant below,
+      #    since bundled-ort has no aarch64 build-time binary to download)
       #
       # AL2023 variant (ORT crates only):
       #   { runner: ubuntu-latest, target: x86_64-unknown-linux-gnu,  variant: al2023   }
@@ -503,6 +538,17 @@ jobs:
           # runs on effectively every glibc Linux distro still in service.
           ZIG_GLIBC = "2.17"
 
+          # 2533: each Linux leg builds on a runner of its OWN architecture —
+          # amd64 targets on `ubuntu-latest`, arm64 targets on
+          # `ubuntu-24.04-arm` — so HOST == TARGET and pkg-config-dependent
+          # `-sys` build scripts (openssl-sys) work. `host_multiarch` is the
+          # runner's Debian multiarch directory name, consumed by HOST_CFLAGS
+          # in the build step; it tracks the RUNNER's arch, not the target's.
+          LINUX_RUNNERS = {
+              "x86_64-unknown-linux-gnu":  ("ubuntu-latest",   "x86_64-linux-gnu"),
+              "aarch64-unknown-linux-gnu": ("ubuntu-24.04-arm", "aarch64-linux-gnu"),
+          }
+
           def linux_zigbuild_entry(target, best_effort, use_al2023_features):
               # For ORT-bundling crates (al2023 True), the aarch64 leg reuses
               # the load-dynamic feature set instead of default bundled-ort:
@@ -512,9 +558,11 @@ jobs:
               # builds regardless of target arch (see file-header comment).
               entry_features = al_feats if use_al2023_features else feats
               entry_no_def   = al_no_def if use_al2023_features else no_def
+              runner, host_multiarch = LINUX_RUNNERS[target]
               return {
                   **common,
-                  "runner": "ubuntu-latest",
+                  "runner": runner,
+                  "host_multiarch": host_multiarch,
                   "target": target,
                   "variant": "linux-zigbuild",
                   "asset_suffix": target,
@@ -535,6 +583,7 @@ jobs:
               return {
                   **common,
                   "runner": "ubuntu-latest",
+                  "host_multiarch": "",
                   "target": target,
                   "variant": "standard",
                   "asset_suffix": target,
@@ -573,6 +622,7 @@ jobs:
           includes = [
               {**common,
                "runner": "macos-14",
+               "host_multiarch": "",
                "target": "aarch64-apple-darwin",
                "variant": "standard",
                "asset_suffix": "aarch64-apple-darwin",
@@ -584,19 +634,21 @@ jobs:
                "al2023_no_default": False,
                "al2023_features": ""},
               x86_64_entry,
-              # aarch64 Linux — NEW (issue #2037), best-effort/non-blocking
-              # until validated by a real tagged-release CI run. For
+              # aarch64 Linux (issue #2037). 2533: built natively on
+              # `ubuntu-24.04-arm` and BLOCKING (best_effort=False) — see the
+              # file-header comment. For
               # ORT-bundling crates this reuses the load-dynamic feature set
               # (see linux_zigbuild_entry) — proven working in CI, since it
               # never links ONNX Runtime at build time and so never hits the
               # libstdc++-ABI problem above.
-              linux_zigbuild_entry("aarch64-unknown-linux-gnu", best_effort=True, use_al2023_features=al2023),
+              linux_zigbuild_entry("aarch64-unknown-linux-gnu", best_effort=False, use_al2023_features=al2023),
           ]
 
           if al2023:
               includes.append({
                   **common,
                   "runner": "ubuntu-latest",
+                  "host_multiarch": "",
                   "target": "x86_64-unknown-linux-gnu",
                   "variant": "al2023",
                   "asset_suffix": "x86_64-linux-al2023",
@@ -773,15 +825,14 @@ jobs:
     if: needs.setup.outputs.bundled != 'true'
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 60
-    # Why: `best_effort` legs (AL2023, and the new Linux aarch64 leg from
-    # issue #2037) are allowed to fail without sinking the whole build matrix.
-    # AL2023 uses GCC 11 which rejects newer SIMD probe flags emitted by
-    # numkind (needs GCC 12+); the aarch64-linux-gnu leg is new/CI-unverified
-    # (cross-compiled via zig — see #2037 PR for what remains to be validated
-    # by a real tagged release). Neither is required for Homebrew (Tier-1:
-    # macOS arm64 + linux x86_64-gnu, unchanged). The release job is
-    # conditioned to run when the Tier-1 legs succeed regardless of a
-    # best_effort leg's outcome.
+    # Why: `best_effort` legs are allowed to fail without sinking the whole
+    # build matrix. 2533: the ONLY remaining `best_effort` leg is AL2023,
+    # whose GCC 11 rejects newer SIMD probe flags emitted by numkind (needs
+    # GCC 12+); the aarch64-linux-gnu leg is now required like every other
+    # target. AL2023 is not required for Homebrew (Tier-1: macOS arm64 + linux
+    # x86_64-gnu, unchanged), and the release job is conditioned to run when
+    # the Tier-1 legs succeed regardless of its outcome — but a dropped leg is
+    # no longer invisible: `release-completeness-audit` below reports it.
     continue-on-error: ${{ matrix.best_effort == true }}
 
     strategy:
@@ -809,7 +860,7 @@ jobs:
         run: |
           dnf install -y --allowerasing \
             gcc gcc-c++ make openssl-devel perl \
-            curl tar gzip pkg-config findutils binutils
+            curl tar gzip pkg-config findutils binutils file
 
       # ── Linux runners (linux-zigbuild): install system deps ─────────────────
       # Same base toolchain as before; zigbuild only replaces the final linker,
@@ -824,15 +875,17 @@ jobs:
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            build-essential pkg-config libssl-dev binutils curl
+            build-essential pkg-config libssl-dev binutils curl file
 
       # ── zig + cargo-zigbuild (issue #2037) ──────────────────────────────────
       # cargo-zigbuild wraps `cargo build`, routing the link step through
       # `zig cc`/`zig c++`/`zig ar` for the target in `matrix.zig_target`
       # (e.g. `x86_64-unknown-linux-gnu.2.17`), which pins the glibc symbol
-      # baseline instead of whatever the build host happens to ship. It also
-      # cross-links `aarch64-unknown-linux-gnu` from this x86_64 runner with
-      # no separate arm64 runner or Docker `cross` toolchain required.
+      # baseline instead of whatever the build host happens to ship.
+      #
+      # 2533: on the aarch64 leg zig is now doing ONLY that glibc pinning —
+      # the leg runs on a native arm64 runner, so nothing is cross-compiled.
+      # Both actions below resolve an arm64 Linux build of their tool.
       - name: Install zig (linux-zigbuild variant)
         if: matrix.variant == 'linux-zigbuild'
         uses: mlugg/setup-zig@v1
@@ -969,7 +1022,12 @@ jobs:
         # no shellcheck warnings, and the value is validated at workflow parse time.
         env:
           SKIP_UI_BUILD: ${{ matrix.skip_ui_build && '1' || '' }}
-          HOST_CFLAGS: ${{ matrix.variant == 'linux-zigbuild' && '-I/usr/include/x86_64-linux-gnu' || '' }}
+          # 2533: the multiarch include dir tracks the RUNNER's architecture,
+          # not the target's — this override exists for HOST-targeted compiles
+          # (see the paragraph above), and the arm64 leg now runs on an arm64
+          # runner where the path is /usr/include/aarch64-linux-gnu. Hardcoding
+          # x86_64 here would silently point at a non-existent directory.
+          HOST_CFLAGS: ${{ matrix.host_multiarch != '' && format('-I/usr/include/{0}', matrix.host_multiarch) || '' }}
           RUSTFLAGS: ${{ matrix.variant == 'linux-zigbuild' && '-C link-arg=-lstdc++' || '' }}
           # numkong (usearch's SIMD backend — a mandatory, non-optional
           # dependency of trusty-search, unrelated to the bundled-ort /
@@ -1045,6 +1103,27 @@ jobs:
               echo "ERROR: expected binary not found: ${BIN_PATH}"
               exit 1
             fi
+            # 2533: an asset named `…-aarch64-unknown-linux-gnu.tar.gz` that
+            # actually contains an x86_64 binary is worse than a missing
+            # asset — it fails at exec time on the user's machine with no
+            # explanation. Assert the ELF/Mach-O machine type matches the
+            # target triple before the binary can be packaged under that name.
+            if command -v file >/dev/null 2>&1; then
+              case "${TARGET}" in
+                aarch64-*) EXPECT_ARCH='aarch64|arm64' ;;
+                x86_64-*)  EXPECT_ARCH='x86-64|x86_64' ;;
+                *)         EXPECT_ARCH='' ;;
+              esac
+              ARCH_DESC="$(file -b "${BIN_PATH}")"
+              if [[ -n "${EXPECT_ARCH}" ]] && ! grep -Eqi "${EXPECT_ARCH}" <<<"${ARCH_DESC}"; then
+                echo "::error::Architecture mismatch for ${BIN}: target is ${TARGET} but the built binary reports '${ARCH_DESC}'. Refusing to package a mislabelled asset."
+                exit 1
+              fi
+              echo "Arch check OK (${TARGET}): ${ARCH_DESC}"
+            else
+              echo "::warning::'file' unavailable — skipping the ${TARGET} architecture assertion for ${BIN}."
+            fi
+
             strip "${BIN_PATH}" || true   # strip may not be available on all hosts; non-fatal
             cp "${BIN_PATH}" "${STAGING_DIR}/"
             echo "Packaged: ${BIN}"
@@ -1122,6 +1201,102 @@ jobs:
             ${{ steps.package.outputs.asset_checksum }}
           retention-days: 7
           if-no-files-found: error
+
+  # ─────────────────────────────────────────────────────────────────────────────
+  # JOB 2a: release-completeness-audit (issue #2533)
+  #
+  # WHY: for four consecutive trusty-search releases this workflow reported
+  #   conclusion `success` while shipping no arm64 Linux binary at all. The
+  #   arm64 leg was `continue-on-error`, so its failure never reached the run
+  #   conclusion, and nothing else compared "assets we asked for" against
+  #   "assets we got". The only way to notice was to open the release page and
+  #   spot an absent file. #2533 makes the arm64 leg blocking; this job closes
+  #   the general case, so no FUTURE leg can be dropped silently either —
+  #   including the AL2023 leg, which stays deliberately non-blocking.
+  #
+  # WHAT: re-derives the expected asset filename for every entry in the build
+  #   matrix, checks it against the artifacts the build job actually produced,
+  #   and writes a per-leg table to the run summary. A missing REQUIRED leg
+  #   fails this job (red run). A missing `best_effort` leg is not a failure —
+  #   it emits a `::warning` annotation and is marked DROPPED in the summary,
+  #   so the release is still visibly partial rather than clean.
+  #
+  # `!cancelled()` (not the implicit `success()`) is required so this job runs
+  #   precisely when it matters — after a build leg has failed. Same mechanism
+  #   as the `release` job's condition; see the #3540 comment there.
+  # ─────────────────────────────────────────────────────────────────────────────
+  release-completeness-audit:
+    name: Release completeness audit (issue #2533)
+    needs: [setup, build]
+    if: >-
+      !cancelled() &&
+      needs.setup.outputs.bundled != 'true' &&
+      needs.build.result != 'skipped'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # continue-on-error: with zero artifacts (every leg failed) the download
+      # action errors out; that is the loudest case of all and must be
+      # REPORTED by the audit step below, not swallowed as an action failure
+      # with no summary.
+      - name: Download all build artifacts
+        uses: actions/download-artifact@v5
+        continue-on-error: true
+        with:
+          path: release-assets
+          merge-multiple: true
+
+      - name: Compare produced assets against the requested build matrix
+        shell: python3 {0}
+        env:
+          MATRIX:       ${{ needs.setup.outputs.matrix }}
+          BUILD_RESULT: ${{ needs.build.result }}
+        run: |
+          import json, os, pathlib, sys
+
+          entries = json.loads(os.environ["MATRIX"])["include"]
+          root = pathlib.Path("release-assets")
+          produced = {p.name for p in root.rglob("*.tar.gz")} if root.is_dir() else set()
+
+          rows, missing_required, dropped_best_effort = [], [], []
+          for e in entries:
+              asset = f"{e['crate']}-{e['version']}-{e['asset_suffix']}.tar.gz"
+              required = not e["best_effort"]
+              if asset in produced:
+                  rows.append(("OK", asset, "required" if required else "best-effort"))
+              elif required:
+                  missing_required.append(asset)
+                  rows.append(("MISSING", asset, "required"))
+              else:
+                  dropped_best_effort.append(asset)
+                  rows.append(("DROPPED", asset, "best-effort"))
+
+          summary = ["## Release completeness audit (issue #2533)", "",
+                     f"`build` job result: **{os.environ['BUILD_RESULT']}**", "",
+                     "| Status | Asset | Leg |", "| --- | --- | --- |"]
+          summary += [f"| {s} | `{a}` | {k} |" for s, a, k in rows]
+          for asset in dropped_best_effort:
+              print(f"::warning::Release is PARTIAL — best-effort leg produced no asset: {asset}. "
+                    "The run is not failed for this, but the release will be missing that platform. "
+                    "Open the corresponding build job log for the real failure.")
+          for asset in missing_required:
+              print(f"::error::Required release asset missing: {asset}. "
+                    "The corresponding build leg failed — see its job log.")
+
+          if dropped_best_effort:
+              summary += ["", "> One or more **best-effort** legs produced no asset. "
+                              "This release is PARTIAL — see the warning annotations."]
+          if missing_required:
+              summary += ["", "> **FAILED** — a required leg produced no asset. "
+                              "A partial release must not report success (issue #2533)."]
+          elif not dropped_best_effort:
+              summary += ["", "All requested assets were produced."]
+
+          with open(os.environ["GITHUB_STEP_SUMMARY"], "a") as fh:
+              fh.write("\n".join(summary) + "\n")
+          print("\n".join(summary))
+
+          sys.exit(1 if missing_required else 0)
 
   # ─────────────────────────────────────────────────────────────────────────────
   # JOB 2b: publish-dry-run (issue #3366)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -575,14 +575,18 @@ jobs:
                   "al2023_features": "",
               }
 
-          def native_linux_entry(target):
-              # Original (pre-#2037) native x86_64 build: plain `cargo build`
-              # on ubuntu-latest, no zig. Reserved for ORT-bundling crates'
-              # x86_64 leg (see comment below) — NOT a regression, this is
-              # exactly what shipped before this issue.
+          def native_linux_entry(target, use_al2023_features=False):
+              # Original (pre-#2037) native build: plain `cargo build` with the
+              # runner's own GCC, no zig. Used by ORT-bundling crates for BOTH
+              # Linux legs (see the comments at each call site) — NOT a
+              # regression on x86_64, this is exactly what shipped before
+              # #2037.
+              entry_features = al_feats if use_al2023_features else feats
+              entry_no_def   = al_no_def if use_al2023_features else no_def
+              runner, _ = LINUX_RUNNERS[target]
               return {
                   **common,
-                  "runner": "ubuntu-latest",
+                  "runner": runner,
                   "host_multiarch": "",
                   "target": target,
                   "variant": "standard",
@@ -590,8 +594,8 @@ jobs:
                   "container": "",
                   "zig_target": "",
                   "best_effort": False,
-                  "cargo_features": feats,
-                  "no_default_features": no_def,
+                  "cargo_features": entry_features,
+                  "no_default_features": entry_no_def,
                   "al2023_no_default": False,
                   "al2023_features": "",
               }
@@ -619,6 +623,42 @@ jobs:
               else linux_zigbuild_entry("x86_64-unknown-linux-gnu", best_effort=False, use_al2023_features=False)
           )
 
+          # 2533: aarch64 Linux mirrors the x86_64 leg's toolchain choice for
+          # the same crate, on a native arm64 runner.
+          #
+          #   ORT-bundling crates (al2023 True) -> plain `cargo build` with the
+          #   runner's GCC. These crates pull in `numkong` (usearch's SIMD
+          #   backend), whose build.rs probes CPU features by compiling C
+          #   probe files with whatever compiler cc-rs is handed. Under zig's
+          #   clang those probes disagree with the sources they gate: clang
+          #   rejects GCC's `__attribute__((target("neon")))` spelling on
+          #   AArch64, so the baseline NEON probe reports NK_TARGET_NEON=0
+          #   while the dependent NK_TARGET_NEONSDOT / NK_TARGET_SVE* probes
+          #   still report 1 — and those code paths need the `arm_neon.h`
+          #   include that only the NEON path pulls in. The build then dies on
+          #   ~20 `call to undeclared function 'vdupq_n_s32'` errors (observed:
+          #   run 30941401868, job 92100578898). This is the same probe/source
+          #   desync already documented for AL2023's GCC 11 below, and the
+          #   available zig workaround — forcing NK_TARGET_*=0 — would compile
+          #   the arm64 binary with the SIMD paths of a vector search engine
+          #   switched off. Using the platform GCC avoids the whole class.
+          #
+          #   All other crates keep the glibc-2.17 zigbuild leg, which is
+          #   unaffected (no numkong in their graph) and is now a NATIVE zig
+          #   build rather than a cross build.
+          #
+          # Consequence, stated plainly: for ORT-bundling crates the
+          # `aarch64-unknown-linux-gnu` asset carries the runner's glibc floor
+          # (Ubuntu 24.04 / 2.39) — the SAME floor its `x86_64-unknown-linux-gnu`
+          # sibling has always carried, not a new class of limitation. An
+          # `aarch64-linux-al2023` counterpart to the existing x86_64 AL2023
+          # asset is the portable-arm64 follow-up; it is deliberately NOT
+          # bundled into this fix.
+          aarch64_entry = (
+              native_linux_entry("aarch64-unknown-linux-gnu", use_al2023_features=True) if al2023
+              else linux_zigbuild_entry("aarch64-unknown-linux-gnu", best_effort=False, use_al2023_features=False)
+          )
+
           includes = [
               {**common,
                "runner": "macos-14",
@@ -636,12 +676,10 @@ jobs:
               x86_64_entry,
               # aarch64 Linux (issue #2037). 2533: built natively on
               # `ubuntu-24.04-arm` and BLOCKING (best_effort=False) — see the
-              # file-header comment. For
-              # ORT-bundling crates this reuses the load-dynamic feature set
-              # (see linux_zigbuild_entry) — proven working in CI, since it
-              # never links ONNX Runtime at build time and so never hits the
-              # libstdc++-ABI problem above.
-              linux_zigbuild_entry("aarch64-unknown-linux-gnu", best_effort=False, use_al2023_features=al2023),
+              # file-header comment and the aarch64_entry comment above. For
+              # ORT-bundling crates it still uses the load-dynamic feature set,
+              # since bundled-ort has no aarch64 build-time binary to download.
+              aarch64_entry,
           ]
 
           if al2023:
@@ -867,11 +905,13 @@ jobs:
       # so build-essential/pkg-config/libssl-dev are still needed for crates
       # whose build.rs shells out to a C compiler or pkg-config directly.
       - name: Install build prerequisites (Ubuntu)
-        # `standard` here means the ORT-bundling-crate native x86_64 leg
-        # (see native_linux_entry in the matrix-generation step) — the only
-        # `standard`-variant entry that runs on ubuntu-latest; the OTHER
-        # `standard` entry is macOS (guarded out by the runner check).
-        if: matrix.variant == 'linux-zigbuild' || (matrix.variant == 'standard' && matrix.runner == 'ubuntu-latest')
+        # `standard` here means an ORT-bundling-crate native Linux leg (see
+        # native_linux_entry in the matrix-generation step); the OTHER
+        # `standard` entry is macOS, which the runner check guards out.
+        # 2533: keyed off the runner PREFIX, not the literal `ubuntu-latest`,
+        # so the arm64 runner (`ubuntu-24.04-arm`) is covered too — matching on
+        # the exact string silently skipped apt on the whole arm64 leg.
+        if: matrix.container == '' && startsWith(matrix.runner, 'ubuntu')
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \


### PR DESCRIPTION
Closes #2533

The `aarch64-unknown-linux-gnu` leg of the binary-release workflow has never
produced an asset for trusty-search, and the workflow reported `success` while
doing so. Both halves are fixed here.

## Where the OpenSSL dependency actually comes from

Established before choosing an approach, because it changes the calculus:

```
cargo tree -p trusty-search -i openssl-sys
openssl-sys v0.9.116
├── native-tls v0.2.18
│   ├── hf-hub v0.5.0  ← fastembed v5.13.4 ← trusty-common (feature "hf-hub-native-tls")
│   ├── hyper-tls ← reqwest (pulled to native-tls by feature unification from hf-hub)
│   └── ureq ← hf-hub
└── openssl v0.10.80
```

It is entirely transitive, and this workspace has already standardised on
rustls everywhere else — `reqwest` is `default-features = false` + `rustls-tls`
at the workspace root, `teloxide` carries a comment saying it was switched to
rustls for exactly this reason, `git2` uses `vendored-openssl`, and
`trusty-analyze` already selects `fastembed/hf-hub-rustls-tls`. The single
holdout is `crates/trusty-common/Cargo.toml`'s `hf-hub-native-tls`.

## Approach chosen: native arm64 runner

The leg now builds on GitHub's `ubuntu-24.04-arm` runner (free for public
repos; this repo is public) instead of cross-compiling from x86_64. HOST ==
TARGET, so every pkg-config-dependent `-sys` build script resolves against the
runner's own arm64 `libssl-dev` exactly as the x86_64 leg does. This removes
cross-compilation — the actual root difficulty — rather than working around it,
and it fixes the whole class, not just OpenSSL: any future native dependency
behaves the same way it does on the x86_64 leg.

### Alternatives rejected

**rustls (option 3)** — technically the most attractive: one line in
`crates/trusty-common/Cargo.toml` (`hf-hub-native-tls` → `hf-hub-rustls-tls`,
matching what trusty-analyze already does) removes `openssl-sys` from the graph
outright and drops a native runtime dependency. Rejected *for this PR*, not on
merit: it changes a shipped crate's dependency graph and TLS trust behaviour
(hf-hub's rustls path uses bundled roots rather than the system trust store, so
a corporate MITM proxy that works today would stop working) while the
trusty-search 0.42.1 release chain is in flight in another worktree, and it
would need a changelog fragment in a file that release chain is actively
assembling. **Recommended as a follow-up** — it is a genuine inconsistency in
`trusty-common`, and it would also let the arm64 leg drop its libssl runtime
dependency.

**Vendored OpenSSL (option 2)** — builds OpenSSL from C source, so it would
still have been compiled by zig's clang under the cross setup, which is exactly
the toolchain that turned out to be the *second* problem (see below). Costs
build time on every leg and pins an OpenSSL version for CVE purposes. Solves
less than the native runner for more cost.

**Cross-compile sysroot (option 4)** — correct, most fragile to maintain, and
the only option that keeps the cross-compilation that caused the bug.

## The second failure the native runner exposed

With OpenSSL resolved, the leg then failed inside `numkong` (usearch's SIMD
backend). Under zig's clang the probe results contradict the sources they gate:
clang rejects GCC's `__attribute__((target("neon")))` spelling on AArch64, so
the baseline probe emits `-DNK_TARGET_NEON=0` while the dependent
`NK_TARGET_NEONSDOT=1` / `NK_TARGET_SVE*=1` stay on — and those paths need the
`arm_neon.h` that only the NEON path includes. Result: ~20 `call to undeclared
function 'vdupq_n_s32'` errors (run 30941401868, job 92100578898).

The available zig workaround — forcing `NK_TARGET_*=0`, as this workflow
already does for AL2023's GCC 11 — would ship the arm64 binary of a vector
search engine with its SIMD paths switched off. Instead, crates that pull in
numkong (the ORT-bundling crates) now build their arm64 leg with the runner's
GCC, which is the same toolchain choice their x86_64 leg already makes for the
same class of problem. Crates without numkong keep the glibc-2.17 zigbuild leg,
now native rather than cross.

## Silent-failure half — both mechanisms

Chosen: **make the leg blocking, and audit every leg**. The arm64 leg is a
supported target (Graviton, arm64 containers), so `best_effort` was the wrong
classification — a leg nobody is willing to fail on is a leg nobody reads. It
is now required, so it turns the run red.

Blocking the one known leg does not stop the *next* one being dropped quietly,
so a new `release-completeness-audit` job re-derives the expected asset name for
every matrix entry and compares it against what the build job actually produced:

- missing **required** asset → job fails, run goes red;
- missing **best-effort** asset (AL2023, still deliberately non-blocking) →
  `::warning` annotation + `DROPPED` row, so a partial release is visibly
  partial;
- either way a per-leg table lands in the run summary.

Also added: before packaging, each binary's ELF/Mach-O machine type is asserted
against its target triple. An asset named `…-aarch64-…` containing an x86_64
binary is worse than a missing asset.

## Verification

Real `workflow_dispatch` dry runs on this branch, not a config diff.

**1. The silent-failure fix, proven on a genuinely broken build**
(run [30941401868](https://github.com/bobmatnyc/trusty-tools/actions/runs/30941401868),
the intermediate commit where arm64 still failed):

```
run conclusion: failure        ← the same shape of failure reported `success` in v0.42.0
| Status  | Asset                                            | Leg         |
| OK      | trusty-search-…-aarch64-apple-darwin.tar.gz      | required    |
| OK      | trusty-search-…-x86_64-unknown-linux-gnu.tar.gz  | required    |
| MISSING | trusty-search-…-aarch64-unknown-linux-gnu.tar.gz | required    |
| OK      | trusty-search-…-x86_64-linux-al2023.tar.gz       | best-effort |
```

The audit job also has local unit coverage over all four states (all present /
best-effort dropped → exit 0 + warning / required missing → exit 1 / no
artifacts at all → exit 1).

**2. trusty-search arm64 builds**
(run [30942504925](https://github.com/bobmatnyc/trusty-tools/actions/runs/30942504925),
conclusion `success`, all four legs green including
`Build trusty-search aarch64-unknown-linux-gnu`).

**3. The artifact is genuinely aarch64** — downloaded and inspected, not assumed:

```
file: ELF 64-bit LSB pie executable, ARM aarch64, version 1 (GNU/Linux),
      dynamically linked, interpreter /lib/ld-linux-aarch64.so.1, stripped
e_machine bytes at 0x12: b7 00   (EM_AARCH64)
sha256 recomputed locally == the .sha256 shipped beside it
```

**4. It actually RUNS** — executed in `linux/arm64` containers, not inferred
from the link succeeding:

```
ubuntu:24.04 (glibc 2.39, aarch64):
  trusty-search --version → "trusty-search 0.42.1"   exit=0
  tm --version            → "trusty-mpm 1.3.5"       exit=0

amazonlinux:2023 (glibc 2.34, aarch64):
  trusty-search → error while loading shared libraries: libmvec.so.1  exit=127
  tm            → "trusty-mpm 1.3.5"                                  exit=0
```

**5. The zigbuild path did not regress** — trusty-mpm (no numkong) dry run
(run [30943136387](https://github.com/bobmatnyc/trusty-tools/actions/runs/30943136387)):
all three build legs green, and its arm64 binary keeps the glibc **2.17** floor
with no libssl dependency at all, confirming the native runner change did not
cost the portable path anything.

## Known limitation, stated plainly

The `trusty-search` arm64 gnu asset carries a **glibc 2.39** floor and needs
OpenSSL 3 (`libssl.so.3`, `libcrypto.so.3`) at runtime. Evidence #4 above shows
it running on Ubuntu 24.04 arm64 and **failing to load on AL2023 arm64**.

This is the same floor its `x86_64-unknown-linux-gnu` sibling has always
carried — the project's answer there is the separate `x86_64-linux-al2023`
load-dynamic asset. The symmetric answer for arm64 is an `aarch64-linux-al2023`
leg; that is an additional asset name with install.sh coordination (#2038)
attached, so it is deliberately **not** bundled into this fix. It is the right
follow-up if AL2023/Graviton is the target deployment, and I would recommend
filing it. Non-ORT crates are unaffected: their arm64 asset runs on AL2023
today (evidence #4).

## Unverified

- No **tagged-release** run was exercised (dry runs skip the `release` and
  `homebrew-bump` jobs by design). The `release` job's asset handling is
  unchanged by this PR and its inputs are the same artifacts verified above.
- The audit's behaviour when a **macOS** leg is the one missing is covered by
  local unit tests, not by a live run.
- `publish-dry-run` failed on the trusty-mpm run — `trusty-agents-common ^0.5.0`
  is not on crates.io yet. Pre-existing, unrelated to this change, and that job
  is deliberately not a dependency of `build`/`release`.

## Scope

`.github/workflows/release.yml` only. No version bumps, no `Cargo.toml`
changes, nothing touched in `crates/trusty-search/`. CI-only, so the changelog
gate exempts it — verified locally:
`changelog-fragment gate: scanned 1 changed path(s); no crate source changed
(docs-only / CI-only / test-only) — OK.`

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
