### PR TITLE
fix(trusty-agents): install the rustls CryptoProvider and let TAGENT_PROJECT_DIR beat exe inference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11159,6 +11159,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.28",
  "rust-embed",
+ "rustls",
  "scraper",
  "secrecy",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,12 @@ teloxide = { version = "0.17", default-features = false, features = ["rustls", "
 # Slack Socket-Mode WebSocket client (trusty-mpm `slack` feature, DOC-20 #1294).
 # Same pin/features trusty-agents already uses, so the lockfile is unchanged.
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
+# #4825: direct rustls handle so a binary can install the process-level
+# CryptoProvider explicitly. One rustls 0.23 instance in this graph carries
+# BOTH provider features — `ring` (reqwest's `rustls-tls`, `ureq`) and
+# `aws-lc-rs` (the aws-smithy client stack) — so rustls cannot auto-select one
+# and panics on the first handshake that goes through `ClientConfig::builder()`.
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
 # Progress bars / spinners. Shared rustup/cargo-style progress display lives in
 # the `trusty-progress` crate (#1315). Pinned to 0.17 to match the existing
 # local pins in trusty-search and tga; migrating those two crates to this

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -159,6 +159,8 @@ aws-smithy-types = "1"
 git2 = { version = "0.20", features = ["vendored-libgit2"] }
 teloxide = { version = "0.17", features = ["macros"] }
 tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
+# #4825: needed by `tls::install_crypto_provider` — see the workspace entry.
+rustls = { workspace = true }
 flate2 = "1"
 rand = "0.8"
 similar = { version = "2", features = ["text"] }
@@ -207,6 +209,11 @@ serial_test = "3"
 # tests so credential-resolution tests can assert on the actual value that
 # reaches the request builder, not just "no panic" (see #3431 follow-up).
 secrecy = "0.10"
+# #4825: `tests/slack_wss_crypto_provider.rs` drives the real Socket Mode
+# connector and inspects the installed provider, so both must be reachable
+# from an integration-test binary.
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
+rustls = { workspace = true }
 
 [lints.clippy]
 doc_lazy_continuation = "allow"

--- a/crates/trusty-agents/Cargo.toml
+++ b/crates/trusty-agents/Cargo.toml
@@ -209,11 +209,6 @@ serial_test = "3"
 # tests so credential-resolution tests can assert on the actual value that
 # reaches the request builder, not just "no panic" (see #3431 follow-up).
 secrecy = "0.10"
-# #4825: `tests/slack_wss_crypto_provider.rs` drives the real Socket Mode
-# connector and inspects the installed provider, so both must be reachable
-# from an integration-test binary.
-tokio-tungstenite = { version = "0.24", features = ["rustls-tls-native-roots"] }
-rustls = { workspace = true }
 
 [lints.clippy]
 doc_lazy_continuation = "allow"

--- a/crates/trusty-agents/changelog.d/4825-4826-slack-gateway-startup.md
+++ b/crates/trusty-agents/changelog.d/4825-4826-slack-gateway-startup.md
@@ -1,0 +1,18 @@
+Fixed
+
+- `tagent --slack` no longer panics on its first WebSocket handshake
+  (closes [#4825](https://github.com/bobmatnyc/trusty-tools/issues/4825)).
+  A single `rustls 0.23` instance in the dependency graph carries both the
+  `ring` and `aws-lc-rs` provider features, so rustls could not auto-select one
+  and aborted the process the moment the Socket Mode connector built a
+  `ClientConfig` — right after logging "Slack Socket Mode connected". `run()`
+  now installs the `aws-lc-rs` provider explicitly before any TLS-capable code
+  path, and fails loudly at startup if no provider ends up installed.
+- The Slack gateway resolves the project it was actually pointed at
+  (closes [#4826](https://github.com/bobmatnyc/trusty-tools/issues/4826)).
+  An explicitly-set `TAGENT_PROJECT_DIR` now outranks the `current_exe()`
+  walk-up in self-project detection; previously a hint without a
+  `.trusty-agents/agents/pm.toml` marker was dropped silently and the walk-up
+  from `~/.cargo/bin/tagent` resolved `$HOME`, so a deployed gateway answered
+  users against the wrong project instead of failing. Marker-based inference
+  remains the fallback for when no hint is given.

--- a/crates/trusty-agents/src/ctrl/tests/tools_tests.rs
+++ b/crates/trusty-agents/src/ctrl/tests/tools_tests.rs
@@ -34,12 +34,50 @@ fn detect_self_project_finds_via_env_var() {
     assert!(detected.is_some(), "expected detection via env var");
 }
 
-/// (#3398) See `detect_self_project_finds_via_env_var`'s doc comment.
+/// (#4826) An explicit hint outranks the `current_exe()` walk-up, even when
+/// the hint directory carries no `.trusty-agents/agents/pm.toml` marker.
+///
+/// Why: This is the exact shape of the Slack-gateway defect — the launchd job
+/// set the hint to a markerless project directory, the hint was dropped, and
+/// the exe walk-up resolved `$HOME` (which does carry the marker) instead. The
+/// assertion is on the returned path, not merely on `is_some`, because "some
+/// ancestor of the test binary" is precisely the wrong answer that shipped.
+/// Asserting equality fails whether the old code returned an inferred ancestor
+/// or `None`, so it is machine-independent.
 #[test]
-fn detect_self_project_returns_none_when_no_marker() {
+fn detect_self_project_hint_beats_exe_inference() {
     let tmp = tempfile::tempdir().unwrap();
-    let detected = detect_self_project_with_hint(Some(&tmp.path().to_string_lossy()));
-    let _ = detected;
+    let markerless = tmp.path().join("cto");
+    std::fs::create_dir(&markerless).unwrap();
+    assert!(
+        !markerless.join(".trusty-agents").join("agents").exists(),
+        "fixture must carry no self-project marker"
+    );
+
+    let detected = detect_self_project_with_hint(Some(&markerless.to_string_lossy()));
+
+    assert_eq!(
+        detected,
+        Some(markerless.canonicalize().unwrap()),
+        "an explicitly-set project-dir hint must win over exe-path inference"
+    );
+}
+
+/// (#4826) A hint naming nothing on disk is not a usable declaration, so
+/// detection still falls back to marker-based inference rather than returning
+/// a path that does not exist.
+#[test]
+fn detect_self_project_ignores_unresolvable_hint() {
+    let tmp = tempfile::tempdir().unwrap();
+    let missing = tmp.path().join("does-not-exist");
+
+    let detected = detect_self_project_with_hint(Some(&missing.to_string_lossy()));
+
+    assert_ne!(
+        detected,
+        Some(missing),
+        "a hint that does not resolve must not be returned verbatim"
+    );
 }
 
 #[tokio::test]

--- a/crates/trusty-agents/src/ctrl/util.rs
+++ b/crates/trusty-agents/src/ctrl/util.rs
@@ -71,13 +71,18 @@ pub fn detect_self_project() -> Option<PathBuf> {
 /// `checkpoint_resume.rs` again, regardless of which file adds a new
 /// env-mutating test in the future.
 /// What: Tries three strategies in order:
-///   1. `hint`, if `Some` and it canonicalizes to a path carrying the
-///      `.trusty-agents/agents/pm.toml` self-project marker.
-///   2. Walk up from `current_exe()` looking for the same marker.
-///   3. Use `current_dir()` if it contains the same marker.
-/// Returns the first match, or `None` when no strategy succeeds.
+///   1. `hint`, if `Some` and it canonicalizes to an existing directory. An
+///      explicitly-set hint is an operator declaration, so it wins outright —
+///      the `.trusty-agents/agents/pm.toml` marker is NOT required of it
+///      (#4826).
+///   2. Walk up from `current_exe()` looking for the marker.
+///   3. Use `current_dir()` if it contains the marker.
+/// Returns the first match, or `None` when no strategy succeeds. The marker is
+/// only ever a heuristic for strategies 2 and 3, which run when nobody told us
+/// where the project is.
 /// Test: `detect_self_project_finds_via_env_var`,
-/// `detect_self_project_returns_none_when_no_marker`.
+/// `detect_self_project_hint_beats_exe_inference`,
+/// `detect_self_project_ignores_unresolvable_hint`.
 pub fn detect_self_project_with_hint(hint: Option<&str>) -> Option<PathBuf> {
     fn looks_like_self(p: &Path) -> bool {
         p.join(".trusty-agents")
@@ -96,11 +101,19 @@ pub fn detect_self_project_with_hint(hint: Option<&str>) -> Option<PathBuf> {
         None
     }
 
-    if let Some(p) = hint
-        && let Ok(canon) = PathBuf::from(p).canonicalize()
-        && looks_like_self(&canon)
-    {
-        return Some(canon);
+    // #4826: an explicit hint outranks exe-path inference. It used to be
+    // dropped silently unless it carried the marker, so under launchd the
+    // walk-up from `~/.cargo/bin/tagent` found `~/.trusty-agents/agents/pm.toml`
+    // and resolved $HOME as the project — the Slack gateway then answered users
+    // against the wrong corpus instead of failing.
+    if let Some(p) = hint {
+        match PathBuf::from(p).canonicalize() {
+            Ok(canon) if canon.is_dir() => return Some(canon),
+            _ => tracing::warn!(
+                hint = %p,
+                "project-dir hint does not resolve to a directory; falling back to inference"
+            ),
+        }
     }
     if let Ok(exe) = std::env::current_exe()
         && let Some(parent) = exe.parent()

--- a/crates/trusty-agents/src/lib.rs
+++ b/crates/trusty-agents/src/lib.rs
@@ -136,6 +136,7 @@ pub mod subprocess;
 pub mod system_status;
 pub mod telegram;
 pub mod ticketing;
+pub mod tls;
 pub mod tm;
 pub mod tmux;
 pub mod tools;

--- a/crates/trusty-agents/src/runtime/mod.rs
+++ b/crates/trusty-agents/src/runtime/mod.rs
@@ -120,6 +120,13 @@ use cli_def::{Cli, HELP, argv_as_task_text};
 /// Test: Indirectly via `cargo run -p trusty-agents`/`trusty-agents-local` and the
 ///       crate's integration tests.
 pub async fn run() -> Result<()> {
+    // #4825: install the process-level rustls CryptoProvider before ANY code
+    // path can reach a TLS handshake. Lives here rather than in `main.rs` so
+    // every launcher that calls `run()` — `tagent` and `trusty-agents-local`
+    // alike — is covered, and ahead of the `config` / `mcp-serve` early
+    // dispatches below because those make HTTPS calls too.
+    crate::tls::install_crypto_provider()?;
+
     let args: Vec<String> = std::env::args().collect();
 
     // #2405: the universal `config` credential CLI is a lightweight, daemon-less

--- a/crates/trusty-agents/src/runtime/mode_dispatch.rs
+++ b/crates/trusty-agents/src/runtime/mode_dispatch.rs
@@ -319,6 +319,9 @@ pub(super) async fn dispatch_cli_mode(
     // Why: Same shape as --telegram — each channel gets its own ChatSession +
     // ConversationTurn history, dispatched through ctrl::run_pm_task_with_history.
     if cli.slack {
+        // #4826: this is the gateway's project root — `TAGENT_PROJECT_DIR` now
+        // outranks exe-path inference, so a deployed gateway answers against
+        // the project it was pointed at rather than $HOME.
         let project_path = ctrl::detect_self_project()
             .or_else(|| std::env::current_dir().ok())
             .unwrap_or_else(|| PathBuf::from("."));

--- a/crates/trusty-agents/src/tls.rs
+++ b/crates/trusty-agents/src/tls.rs
@@ -1,0 +1,57 @@
+//! Process-level rustls `CryptoProvider` installation (#4825).
+//!
+//! Why: `tagent --slack` reached its first WSS handshake and aborted the whole
+//! process inside rustls 0.23 — "Could not automatically determine the
+//! process-level CryptoProvider from Rustls crate features". A single
+//! `rustls 0.23` instance in this workspace's graph has BOTH provider features
+//! enabled (`ring`, pulled by reqwest's `rustls-tls` and `ureq`; `aws-lc-rs`,
+//! pulled by the `aws-smithy-http-client` stack behind `aws-sdk-bedrockruntime`),
+//! so rustls refuses to guess and panics. Dependencies that configure their own
+//! provider (reqwest, aws-smithy) are unaffected, which is why the Slack gateway
+//! could log "Socket Mode connected" and only then die: `tokio-tungstenite`'s
+//! connector builds a `ClientConfig` from the process default.
+//!
+//! Deduplicating the providers instead was rejected: `ring` and `aws-lc-rs`
+//! arrive from independent subtrees (HTTP client vs. AWS SDK), so removing
+//! either means changing reqwest's TLS backend workspace-wide or dropping the
+//! Bedrock SDK. An explicit install is one call, is immune to a future
+//! dependency re-enabling the other feature, and makes the choice auditable.
+//!
+//! What: `install_crypto_provider`, called once at the top of
+//! `runtime::run()` before any TLS-capable code path.
+//! Test: `tests/slack_wss_crypto_provider.rs`.
+
+use anyhow::{Result, bail};
+
+/// Install the process-level rustls `CryptoProvider` if none is installed yet.
+///
+/// Why: See the module docs — without this, the first `rustls::ClientConfig`
+/// built from the process default (the Socket Mode WebSocket connector)
+/// panics and takes the gateway down.
+/// What: Installs the `aws-lc-rs` provider, then asserts the postcondition
+/// that the process now HAS a default provider. `install_default` returns
+/// `Err` for exactly one reason — a provider was already installed, by a
+/// launcher or an earlier call — which is benign and why the error value
+/// itself is discarded rather than propagated. The postcondition check is
+/// what makes that discard safe: a swallowed failure that left the process
+/// without a provider would re-hide the original panic until the first
+/// handshake, so it is turned into a loud startup error instead.
+///
+/// Idempotent; safe to call from every launcher.
+/// Test: `wss_handshake_survives_after_install`,
+/// `install_is_idempotent_and_leaves_a_default_provider`.
+pub fn install_crypto_provider() -> Result<()> {
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        // Err here means "someone else installed one first" — a race we are
+        // happy to lose. The check below is the real gate.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+    if rustls::crypto::CryptoProvider::get_default().is_none() {
+        bail!(
+            "failed to install a process-level rustls CryptoProvider; \
+             TLS connections (Slack Socket Mode, HTTPS) would panic at the \
+             first handshake"
+        );
+    }
+    Ok(())
+}

--- a/crates/trusty-agents/tests/config_mount.rs
+++ b/crates/trusty-agents/tests/config_mount.rs
@@ -16,9 +16,27 @@ use std::process::Command;
 /// tests). Using it guarantees we exercise the real mounted CLI, not a stub.
 const BIN: &str = env!("CARGO_BIN_EXE_tagent");
 
+/// Spawn the built binary with the ambient project-dir hint cleared (#4826).
+///
+/// Why: `Command` inherits the parent's environment, so a `TAGENT_PROJECT_DIR`
+/// exported in the shell that ran `cargo test` reaches the child. Since that
+/// hint now outranks exe-path inference, it would steer the child's project
+/// root — and every write under it — out of this test's tempdir and into a real
+/// directory, silently, with the test still green. Constructing every spawn
+/// through here rather than clearing the vars at each call site means a future
+/// spawn added to this file cannot forget it.
+/// Test: `config_help_advertises_keys_feature`, `config_keys_list_runs_offline`,
+/// `profile_show_then_set_round_trips`.
+fn tagent() -> Command {
+    let mut cmd = Command::new(BIN);
+    cmd.env_remove("TAGENT_PROJECT_DIR")
+        .env_remove("OPEN_MPM_PROJECT_DIR");
+    cmd
+}
+
 #[test]
 fn config_help_advertises_keys_feature() {
-    let out = Command::new(BIN)
+    let out = tagent()
         .args(["config", "--help"])
         .output()
         .expect("spawn `config --help`");
@@ -36,7 +54,7 @@ fn config_help_advertises_keys_feature() {
 
 #[test]
 fn config_keys_list_runs_offline() {
-    let out = Command::new(BIN)
+    let out = tagent()
         .args(["config", "keys", "list"])
         .output()
         .expect("spawn `config keys list`");
@@ -64,7 +82,7 @@ fn config_keys_list_runs_offline() {
 fn profile_show_then_set_round_trips() {
     let home = tempfile::tempdir().expect("tempdir for isolated HOME");
 
-    let before = Command::new(BIN)
+    let before = tagent()
         .args(["config", "profile", "show"])
         .env("HOME", home.path())
         .output()
@@ -76,7 +94,7 @@ fn profile_show_then_set_round_trips() {
         "expected 'not set' before any profile exists; got:\n{before_stdout}"
     );
 
-    let set = Command::new(BIN)
+    let set = tagent()
         .args([
             "config",
             "profile",
@@ -99,7 +117,7 @@ fn profile_show_then_set_round_trips() {
         String::from_utf8_lossy(&set.stderr)
     );
 
-    let after = Command::new(BIN)
+    let after = tagent()
         .args(["config", "profile", "show"])
         .env("HOME", home.path())
         .output()

--- a/crates/trusty-agents/tests/plain_cli_repl.rs
+++ b/crates/trusty-agents/tests/plain_cli_repl.rs
@@ -99,6 +99,13 @@ fn run_piped_with_setup(
         // which would otherwise consume lines meant for the REPL loop.
         .env("TAGENT_NONINTERACTIVE", "1")
         .env("HOME", default_isolated_home.path())
+        // #4826: the child inherits the parent's env, and an explicit
+        // project-dir hint now outranks exe-path inference — so an ambient
+        // `TAGENT_PROJECT_DIR` would override the isolated cwd below and send
+        // this process's state writes into a real directory, with the test
+        // still passing. Clearing it is what makes the isolation above real.
+        .env_remove("TAGENT_PROJECT_DIR")
+        .env_remove("OPEN_MPM_PROJECT_DIR")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -264,6 +271,10 @@ fn run_piped_no_forced_noninteractive(
     cmd.args(extra_args)
         .current_dir(isolated_cwd.path())
         .env("HOME", default_isolated_home.path())
+        // #4826: see `run_piped_with_setup` — an inherited project-dir hint
+        // would defeat the cwd isolation above without failing anything.
+        .env_remove("TAGENT_PROJECT_DIR")
+        .env_remove("OPEN_MPM_PROJECT_DIR")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());

--- a/crates/trusty-agents/tests/slack_wss_crypto_provider.rs
+++ b/crates/trusty-agents/tests/slack_wss_crypto_provider.rs
@@ -7,35 +7,46 @@
 //! `tokio_tungstenite::connect_async` does for a `wss://` URL.
 //!
 //! What: Drives the real `tokio-tungstenite` connector — the same one
-//! `slack::run_slack_bot` uses — against a local throwaway TCP listener, so
-//! the TLS setup path is exercised with no network, no Slack tokens, and no
-//! contact with the production Slack app. The handshake is expected to FAIL
-//! (the listener speaks no TLS); the assertion is that it fails as an `Err`
-//! rather than aborting the process.
+//! `slack::run_slack_bot` uses — against a local throwaway TCP listener, with
+//! no network, no Slack tokens, and no contact with the production Slack app.
+//! The listener captures what the client actually puts on the wire and the
+//! test asserts it is a well-formed TLS ClientHello, which can only exist if
+//! the process-level provider supplied the cipher suites and key share. The
+//! connection itself is then expected to fail (the listener speaks no TLS) —
+//! as an `Err`, not as a process abort.
 //!
 //! Verified to fail without the fix: with `install_crypto_provider` absent,
 //! this test panics at `rustls-0.23.40/src/crypto/mod.rs:249:14` with the exact
-//! message from the owner's production log.
+//! message from the owner's production log, and no bytes ever reach the
+//! listener.
 
+use tokio::io::AsyncReadExt;
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 
-/// The connector must return a transport error, not abort the process.
+/// The connector must emit a real TLS ClientHello and return a transport
+/// error, rather than aborting the process.
 ///
 /// Test: this is the test.
 #[tokio::test]
 async fn wss_handshake_survives_after_install() {
     trusty_agents::tls::install_crypto_provider().expect("crypto provider must install");
 
-    // A listener that accepts and then says nothing. TCP connect succeeds, so
-    // `connect_async` proceeds into TLS setup — where the missing provider used
-    // to panic — and then fails on the handshake itself.
+    // A listener that accepts, records the client's first flight, and never
+    // replies. TCP connect succeeds, so `connect_async` proceeds into TLS setup
+    // — where the missing provider used to panic — writes its ClientHello, and
+    // then fails on the handshake itself.
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let port = listener.local_addr().unwrap().port();
+    let (tx, rx) = oneshot::channel();
     tokio::spawn(async move {
-        if let Ok((stream, _)) = listener.accept().await {
-            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-            drop(stream);
-        }
+        let mut buf = vec![0u8; 2048];
+        let n = match listener.accept().await {
+            Ok((mut stream, _)) => stream.read(&mut buf).await.unwrap_or(0),
+            Err(_) => 0,
+        };
+        buf.truncate(n);
+        let _ = tx.send(buf);
     });
 
     let result = tokio_tungstenite::connect_async(format!("wss://127.0.0.1:{port}/")).await;
@@ -43,6 +54,26 @@ async fn wss_handshake_survives_after_install() {
         result.is_err(),
         "a bare TCP listener cannot complete a TLS handshake; reaching Ok would mean \
          this test stopped exercising the TLS path"
+    );
+
+    let first_flight = rx.await.expect("listener task must report");
+    // TLS record header: content type 0x16 (handshake), legacy version 0x0301,
+    // then handshake type 0x01 (ClientHello) at offset 5. The body carries the
+    // provider-supplied cipher-suite list and key share, so a well-formed
+    // ClientHello of real size is proof the provider was resolved and used.
+    assert!(
+        first_flight.len() > 100,
+        "expected a full ClientHello, got {} byte(s): {first_flight:02x?}",
+        first_flight.len()
+    );
+    assert_eq!(
+        &first_flight[..3],
+        &[0x16, 0x03, 0x01],
+        "expected a TLS handshake record header"
+    );
+    assert_eq!(
+        first_flight[5], 0x01,
+        "expected the handshake message to be a ClientHello"
     );
 }
 

--- a/crates/trusty-agents/tests/slack_wss_crypto_provider.rs
+++ b/crates/trusty-agents/tests/slack_wss_crypto_provider.rs
@@ -1,0 +1,60 @@
+//! Regression coverage for the `tagent --slack` startup panic (#4825).
+//!
+//! Why: The Slack gateway died on its first WSS handshake because no
+//! process-level rustls `CryptoProvider` was ever installed. A green build
+//! proves nothing here — the panic only surfaces when a `rustls::ClientConfig`
+//! is actually constructed from the process default, which is what
+//! `tokio_tungstenite::connect_async` does for a `wss://` URL.
+//!
+//! What: Drives the real `tokio-tungstenite` connector — the same one
+//! `slack::run_slack_bot` uses — against a local throwaway TCP listener, so
+//! the TLS setup path is exercised with no network, no Slack tokens, and no
+//! contact with the production Slack app. The handshake is expected to FAIL
+//! (the listener speaks no TLS); the assertion is that it fails as an `Err`
+//! rather than aborting the process.
+//!
+//! Verified to fail without the fix: with `install_crypto_provider` absent,
+//! this test panics at `rustls-0.23.40/src/crypto/mod.rs:249:14` with the exact
+//! message from the owner's production log.
+
+use tokio::net::TcpListener;
+
+/// The connector must return a transport error, not abort the process.
+///
+/// Test: this is the test.
+#[tokio::test]
+async fn wss_handshake_survives_after_install() {
+    trusty_agents::tls::install_crypto_provider().expect("crypto provider must install");
+
+    // A listener that accepts and then says nothing. TCP connect succeeds, so
+    // `connect_async` proceeds into TLS setup — where the missing provider used
+    // to panic — and then fails on the handshake itself.
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await {
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+            drop(stream);
+        }
+    });
+
+    let result = tokio_tungstenite::connect_async(format!("wss://127.0.0.1:{port}/")).await;
+    assert!(
+        result.is_err(),
+        "a bare TCP listener cannot complete a TLS handshake; reaching Ok would mean \
+         this test stopped exercising the TLS path"
+    );
+}
+
+/// Calling the installer twice must stay `Ok`, because both `tagent` and
+/// `trusty-agents-local` route through `run()` and a launcher may have
+/// installed a provider first.
+#[test]
+fn install_is_idempotent_and_leaves_a_default_provider() {
+    trusty_agents::tls::install_crypto_provider().expect("first install");
+    trusty_agents::tls::install_crypto_provider().expect("second install must be a no-op");
+    assert!(
+        rustls::crypto::CryptoProvider::get_default().is_some(),
+        "a process-level provider must be installed once this returns Ok"
+    );
+}

--- a/crates/trusty-agents/tests/support/project.rs
+++ b/crates/trusty-agents/tests/support/project.rs
@@ -93,6 +93,11 @@ impl Project {
         let mut child = Command::new(&self.binary)
             .current_dir(self.root.path())
             .env("HOME", self.home.path())
+            // #4826: an inherited `TAGENT_PROJECT_DIR` now outranks exe-path
+            // inference, so without clearing it the child would resolve a real
+            // directory instead of this fixture's tempdir — silently.
+            .env_remove("TAGENT_PROJECT_DIR")
+            .env_remove("OPEN_MPM_PROJECT_DIR")
             .arg("--workflow")
             .arg(workflow)
             .arg("--task")
@@ -140,6 +145,10 @@ impl Project {
         let output = Command::new(&self.binary)
             .current_dir(self.root.path())
             .env("HOME", self.home.path())
+            // #4826: see `run_task` — clear the inherited project-dir hint so
+            // the fixture tempdir stays the resolved project.
+            .env_remove("TAGENT_PROJECT_DIR")
+            .env_remove("OPEN_MPM_PROJECT_DIR")
             .arg("inspect")
             .arg("--task")
             .arg(task)

--- a/crates/trusty-agents/tests/system_status_cli.rs
+++ b/crates/trusty-agents/tests/system_status_cli.rs
@@ -18,13 +18,29 @@ use std::process::Command;
 
 const BIN: &str = env!("CARGO_BIN_EXE_tagent");
 
+/// Spawn the built binary with the ambient project-dir hint cleared (#4826).
+///
+/// Why: `Command` inherits the parent environment, so a `TAGENT_PROJECT_DIR`
+/// exported in the shell running `cargo test` reaches the child and — now that
+/// an explicit hint outranks exe-path inference — overrides the isolated
+/// `$HOME`/cwd this file relies on, writing state into a real directory while
+/// the assertions still pass. Routing every spawn through here keeps a future
+/// spawn in this file from reintroducing the gap.
+/// Test: `system_status_json_has_expected_top_level_keys`.
+fn tagent() -> Command {
+    let mut cmd = Command::new(BIN);
+    cmd.env_remove("TAGENT_PROJECT_DIR")
+        .env_remove("OPEN_MPM_PROJECT_DIR");
+    cmd
+}
+
 /// Why: `--json` must emit parseable JSON carrying every top-level key the
 /// tool/CLI contract promises, even when every daemon is unreachable.
 /// Test: itself.
 #[test]
 fn system_status_json_has_expected_top_level_keys() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let out = Command::new(BIN)
+    let out = tagent()
         .args(["system", "status", "--json"])
         .current_dir(tmp.path())
         .env("HOME", tmp.path())
@@ -78,7 +94,7 @@ fn system_status_json_has_expected_top_level_keys() {
 #[test]
 fn system_status_text_mode_prints_every_section() {
     let tmp = tempfile::TempDir::new().unwrap();
-    let out = Command::new(BIN)
+    let out = tagent()
         .args(["system", "status"])
         .current_dir(tmp.path())
         .env("HOME", tmp.path())


### PR DESCRIPTION
Closes #4825
Closes #4826

Two defects that together made the Slack gateway unusable for the CTO Assistant cutover: it could not start, and had it started it would have answered against the wrong project.

## #4825 — startup panic on the first WSS handshake

A single `rustls 0.23.40` instance in the graph carries BOTH provider features — `ring` (reqwest's `rustls-tls` → `__rustls-ring`, `tokio-rustls`, `ureq`) and `aws-lc-rs` (the `aws-smithy-http-client` stack) — so rustls cannot auto-select and panics the moment `tokio-tungstenite` builds a `ClientConfig` from the process default. Nothing in the workspace called `install_default()`.

**Chosen fix: install the provider explicitly, not deduplicate the graph.** The two providers arrive from independent subtrees (HTTP client vs. AWS SDK), so dropping either means changing reqwest's TLS backend workspace-wide or dropping the Bedrock SDK — a far larger blast radius, and one a future dependency bump could silently undo. An explicit install is one call, immune to that, and auditable.

**Placement:** `runtime::run()`, not `main.rs` — `trusty-agents-local` also calls `run()`, and `main.rs` would have covered only the `tagent` binary. It sits ahead of the `config` / `mcp-serve` early dispatches because those make HTTPS calls too.

**Error handling: not `.ok()`.** `install_default` returns `Err` for exactly one reason — a provider was already installed — which is benign, so that value is discarded. What makes the discard safe is the postcondition check that follows: if the process still has no default provider, `install_crypto_provider` returns a startup error rather than letting the process reach a handshake and abort. A silently swallowed failure would have re-hidden this exact bug.

## #4826 — gateway resolved $HOME as the project

`detect_self_project_with_hint` honoured its env hint only if the hinted directory itself carried `.trusty-agents/agents/pm.toml`; otherwise it dropped the hint silently and walked up from `current_exe()`. Under launchd that walk reached `~/.trusty-agents/agents/pm.toml` and returned `/Users/masa`, beating both `TAGENT_PROJECT_DIR` and `WorkingDirectory`. An explicit hint is now honoured whenever it resolves to a real directory; marker-based inference remains the fallback for when no hint is given. An unresolvable hint still falls through to inference, with a warning.

## Tests

Both were confirmed to fail against the unfixed code before the fix landed.

`tests/slack_wss_crypto_provider.rs` drives the real Socket Mode connector against a local throwaway listener, captures the client's first flight, and asserts it is a well-formed TLS ClientHello — an invariant that only holds if the provider was resolved and used. Against the unfixed tree the same test panicked at `rustls-0.23.40/src/crypto/mod.rs:249:14` with the identical message from the production log, and no bytes reached the listener.

`detect_self_project_hint_beats_exe_inference` asserts the returned path equals the hint, not merely `is_some`. Against the unfixed tree:

```
assertion `left == right` failed: an explicitly-set project-dir hint must win over exe-path inference
  left: Some("/Users/masa")
 right: Some("/private/var/folders/…/cto")
```

## Live verification

**A green build proves nothing here, so the handshake was exercised for real.** A completed TLS + WebSocket handshake through the exact `tokio-tungstenite` connector the gateway uses:

```
LIVE WSS HANDSHAKE OK  url=wss://echo.websocket.org/  upgrade_status=101 Switching Protocols
```

The built binary was then run as `tagent --slack` with deliberately invalid tokens, under `env -i HOME=/Users/masa` so the `~/.trusty-agents/agents/pm.toml` marker that caused #4826 was present:

```
INFO trusty_agents::runtime::startup: trusty-agents v0.38.6 build #1
INFO trusty_agents::slack: Starting Slack bot in Socket Mode project=/private/tmp/…/fakecto
ERROR trusty_agents::slack: Slack socket error; reconnecting in 5s error=apps.connections.open failed: invalid_auth (status 200 OK)
```

No panic; startup completed; `project=` is the directory `TAGENT_PROJECT_DIR` named, not `$HOME` — #4826 reproduced-and-fixed live under the production condition.

**What is NOT verified, and what the owner must do.** The production Slack app A0AMPRM4W0J was deliberately not touched, so no real Socket Mode session was established. The invalid-token run reaches `apps.connections.open` (plain HTTPS via reqwest, which carries its own provider) and stops there — it never opens the `wss-primary.slack.com` socket. The Slack-specific leg therefore rests on the public-endpoint handshake above, which uses identical TLS mechanics and differs only in endpoint and auth.

The owner should confirm on the real deployment: install the binary, `launchctl kickstart -k gui/$UID/com.trusty.agents.slack`, and check `~/Library/Logs/trusty-agents/slack-stderr.log` shows `Slack Socket Mode connected` followed by a held connection with no panic, and a `project=` line naming the CTO directory rather than `/Users/masa`.

## Gates

Rung 3 (localized behavior in one crate), all crate-scoped, exit codes checked explicitly:

| Gate | Exit | Result |
|---|---|---|
| `cargo test -p trusty-agents` | 0 | 3334 passed, 0 failed, 11 ignored (+ 27 across integration binaries) |
| `cargo clippy -p trusty-agents --all-targets -- -D warnings` | 0 | clean |
| `cargo fmt --check` | 0 | clean |
| `bash scripts/check_line_cap.sh` | 0 | clean |
| `bash scripts/check_changelog_fragment.sh` | 0 | fragment present and valid |
| `bash scripts/check_sld.sh` | 0 | clean |

Blocks lifted for #4821.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools