### PR TITLE
feat(trusty-common): Wing entity, default wing, wing-scoped recall (ADR-0027 T9)

### DIFF
--- a/crates/trusty-common/changelog.d/4809-remember-options-wing.md
+++ b/crates/trusty-common/changelog.d/4809-remember-options-wing.md
@@ -1,0 +1,8 @@
+Changed
+
+- `RememberOptions` gains a `wing_id: Option<Uuid>` field (ADR-0027 T9, [#4809](https://github.com/bobmatnyc/trusty-tools/issues/4809))
+  - `None` (the default) resolves the room in the palace's default wing, which is
+    byte-identical to the previous behaviour — every in-tree call site constructs
+    `RememberOptions` with `..Default::default()` and is unaffected
+  - external callers that build the struct with an exhaustive literal will need to add
+    the field; note this when cutting the next release of this crate

--- a/crates/trusty-common/changelog.d/4809-wings-added.md
+++ b/crates/trusty-common/changelog.d/4809-wings-added.md
@@ -1,0 +1,31 @@
+Added
+
+- Wings are a real, persisted, enumerable scope over rooms (ADR-0027 D2, ticket T9, closes [#4809](https://github.com/bobmatnyc/trusty-tools/issues/4809))
+  - a Wing is the "who" axis (scope/ownership); a Room stays the "what" axis (topic).
+    `engineer`/`Planning` and `pm`/`Planning` are now two distinct rooms, with no
+    `Custom("engineer-planning")` name mangling
+  - new `WINGS` / `WING_KEYS` redb tables in the palace's `kg.db`, initialised in the
+    same transaction as `DRAWERS` and `ROOMS` so the schema is never half-present
+  - every palace gets a `default` wing, seeded at open. **Wing is never required of a
+    caller**: `wing_id` defaults to the default wing on every write and read, so a
+    caller that never mentions a wing behaves exactly as it did before
+  - existing rooms land in the default wing by NAMING, never reclassification — every
+    `RoomRecord` has carried `DEFAULT_WING_ID` since T1, so the migration writes one
+    wing row and changes zero drawer rows and zero room rows (proven byte-for-byte by
+    `seeding_the_default_wing_changes_no_room_or_drawer_rows`)
+  - seeding is insert-only and probes by id, so it is idempotent and a wing renamed
+    between palace opens keeps its new name
+  - `RecallScope` (`All` / `Room` / `Wing`) plus `retrieve_l2_scoped`, `recall_scoped`,
+    and `list_drawers_in_wing` give wing-scoped recall and listing. A wing scope
+    resolves **fail-closed** — an unresolvable scope admits nothing rather than
+    everything, because a scope boundary that fails open is a leak (the #3064
+    "two agent types cannot accidentally read/write the same room" criterion)
+  - `resolve_or_create_room_in_wing` lets a write place a room in a named wing;
+    without it a non-default wing could never receive a drawer
+  - a wing rename reads the row, checks the new label is free, rewrites the row,
+    points the new key at it, and retires the old key — all in ONE redb write
+    transaction. No crash can leave the retired label resolving as a stale alias,
+    and a concurrent `wing_create` cannot claim the new label between the check
+    and the write. A rejected rename writes nothing at all
+  - `retrieve_l3` / `recall_deep` gained the same `RecallScope` generalisation as
+    L2, so `memory_recall_deep` honours a wing instead of ignoring it

--- a/crates/trusty-common/src/memory_core/mod.rs
+++ b/crates/trusty-common/src/memory_core/mod.rs
@@ -31,6 +31,9 @@ pub mod room_identity;
 pub mod semantic_consolidation;
 pub mod store;
 pub mod timeouts;
+// ADR-0027 T9: pure wing identity (canonical keys, UUIDv5 minting). No I/O —
+// see `store::wings` for storage and policy.
+pub mod wing_identity;
 
 pub use community::{KnowledgeGap, find_communities};
 pub use palace::{Drawer, DrawerType, Palace, PalaceId, Room, RoomType, Wing};
@@ -41,3 +44,4 @@ pub use semantic_consolidation::{
     ConsolidationAction, ConsolidationResult, MockInference, OllamaInference, OpenRouterInference,
     SemanticConsolidationConfig, SemanticConsolidator, inference_available,
 };
+pub use wing_identity::{DEFAULT_WING_LABEL, canonical_wing_key, mint_wing_id};

--- a/crates/trusty-common/src/memory_core/registry.rs
+++ b/crates/trusty-common/src/memory_core/registry.rs
@@ -507,6 +507,16 @@ impl PalaceRegistry {
             &handle.kg,
             &drawers,
         );
+        // ADR-0027 T9: seed the default wing every room already points at.
+        // Ordered AFTER the room backfill only for log readability — the two
+        // are independent, because `RoomRecord::wing_id` has been
+        // `DEFAULT_WING_ID` since T1, so no room row needs rewriting for its
+        // wing to exist. This writes exactly one row and never touches
+        // `ROOMS` or `DRAWERS`.
+        crate::memory_core::store::wings::ensure_default_wing_fail_open(
+            handle.id.as_str(),
+            &handle.kg,
+        );
     }
 
     /// Resolve a palace-level alias, but ONLY when the requested palace is

--- a/crates/trusty-common/src/memory_core/retrieval/handle.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/handle.rs
@@ -15,10 +15,12 @@ use crate::memory_core::decay::DecayConfig;
 use crate::memory_core::dream::extract_keywords;
 use crate::memory_core::filter::{FilterReject, check_secret, classify};
 use crate::memory_core::palace::{Drawer, DrawerType, Palace, PalaceId, RoomType};
+use crate::memory_core::room_identity::DEFAULT_WING_ID;
 use crate::memory_core::store::concurrent_open::OpenIntent;
 use crate::memory_core::store::kg::KnowledgeGraph;
 use crate::memory_core::store::l1_cache::L1Cache;
 use crate::memory_core::store::palace_store::PalaceStore;
+use crate::memory_core::store::rooms::resolve_or_create_room_in_wing;
 use crate::memory_core::store::vector::{UsearchStore, VectorStore};
 use crate::memory_core::timeouts;
 use anyhow::{Context, Result};
@@ -585,8 +587,11 @@ impl PalaceHandle {
         // lookup that creates the row when absent — never from hashing a
         // `Debug` string. Fail-open: a registry error falls back to the legacy
         // fold so a room problem can never fail a memory write.
-        let room_id =
-            crate::memory_core::store::rooms::resolve_or_create_room(&self.kg, &room).await;
+        // ADR-0027 T9: `opts.wing_id` is `None` for every caller that predates
+        // wings, which resolves in the default wing — byte-identically to the
+        // line this replaced.
+        let wing_id = opts.wing_id.unwrap_or(DEFAULT_WING_ID);
+        let room_id = resolve_or_create_room_in_wing(&self.kg, &room, wing_id).await;
 
         let mut drawer = Drawer::new(room_id, content.clone());
         drawer.tags = tags;

--- a/crates/trusty-common/src/memory_core/retrieval/layers.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/layers.rs
@@ -13,12 +13,12 @@
 
 use super::embedder::shared_embedder;
 use super::handle::PalaceHandle;
+use super::scope::{RecallScope, scope_admits};
 use super::types::{CrossPalaceResult, RecallResult};
 use crate::memory_core::decay::DecayConfig;
 use crate::memory_core::dream::extract_keywords;
 use crate::memory_core::embed::Embedder;
 use crate::memory_core::palace::{Drawer, DrawerType, RoomType};
-use crate::memory_core::store::rooms::resolve_room_filter_id;
 use crate::memory_core::store::vector::VectorStore;
 use anyhow::{Context, Result};
 use std::collections::HashMap;
@@ -167,6 +167,38 @@ pub async fn retrieve_l2(
     room_filter: Option<RoomType>,
     top_k: usize,
 ) -> Result<Vec<RecallResult>> {
+    // ADR-0027 T9: the room filter is one case of the general scope. Keeping
+    // this signature means no pre-wing call site changes — the "a caller who
+    // never mentions a wing behaves identically" guarantee is structural here,
+    // not a promise, because `RecallScope::All` / `Room` reach exactly the code
+    // that ran before.
+    retrieve_l2_scoped(
+        handle,
+        embedder,
+        query,
+        &RecallScope::from_room_filter(room_filter),
+        top_k,
+    )
+    .await
+}
+
+/// L2 retrieval under an explicit [`RecallScope`] (ADR-0027 T9).
+///
+/// Why: a wing cannot be expressed as an `Option<RoomType>`, and duplicating
+/// the L2 body to add one would leave two scoring paths to drift apart. This is
+/// the single implementation; [`retrieve_l2`] is a thin wrapper over it.
+/// What: as `retrieve_l2`, but the drawer filter compares `room_id` against the
+/// scope's resolved room-id set. `RecallScope::All` resolves to no filter at
+/// all, which is distinct from a scope that resolves to an empty set.
+/// Test: `wing_scope_returns_only_that_wings_drawers`,
+/// `l2_room_filter_excludes_other_rooms` (unchanged, via the wrapper).
+pub async fn retrieve_l2_scoped(
+    handle: &PalaceHandle,
+    embedder: &dyn Embedder,
+    query: &str,
+    scope: &RecallScope,
+    top_k: usize,
+) -> Result<Vec<RecallResult>> {
     if top_k == 0 {
         return Ok(Vec::new());
     }
@@ -186,12 +218,12 @@ pub async fn retrieve_l2(
     // every room minted after ADR-0027 (their ids are UUIDv5, which no fold can
     // reproduce); `resolve_room_filter_id` falls back to the legacy fold when
     // the room has no row, so an un-backfilled palace filters exactly as before.
+    // ADR-0027 T9: a wing scope resolves fail-CLOSED (see `scope`), because a
+    // scope boundary that fails open is a leak, not a wider result set.
     // Resolved BEFORE the guards below are taken: it is a redb read
     // transaction, and holding the drawer + closet locks across I/O would stall
     // every writer on this palace for its duration.
-    let target_room_id = room_filter
-        .as_ref()
-        .map(|r| resolve_room_filter_id(&handle.kg, r));
+    let allowed = scope.allowed_room_ids(&handle.kg);
 
     let drawers = handle.drawers.read();
     let closets = handle.closets.read();
@@ -205,9 +237,7 @@ pub async fn retrieve_l2(
             continue;
         };
 
-        if let Some(rid) = target_room_id
-            && drawer.room_id != rid
-        {
+        if !scope_admits(&allowed, drawer.room_id) {
             continue;
         }
 
@@ -270,6 +300,33 @@ pub async fn retrieve_l3(
     room_filter: Option<RoomType>,
     top_k: usize,
 ) -> Result<Vec<RecallResult>> {
+    retrieve_l3_scoped(
+        handle,
+        embedder,
+        query,
+        &RecallScope::from_room_filter(room_filter),
+        top_k,
+    )
+    .await
+}
+
+/// L3 retrieval under an explicit [`RecallScope`] (ADR-0027 T9).
+///
+/// Why: a wing cannot be expressed as an `Option<RoomType>`, and leaving L3
+/// room-only would make `memory_recall_deep` silently ignore a `wing` argument
+/// — the invisible-failure class ADR-0027 D4.4 rejects. This is the single
+/// implementation; [`retrieve_l3`] is a thin wrapper over it.
+/// What: as `retrieve_l3`, but the drawer filter compares `room_id` against the
+/// scope's resolved room-id set.
+/// Test: `l3_room_filter_excludes_other_rooms`,
+/// `wing_scoped_deep_recall_returns_only_that_wing`.
+pub async fn retrieve_l3_scoped(
+    handle: &PalaceHandle,
+    embedder: &dyn Embedder,
+    query: &str,
+    scope: &RecallScope,
+    top_k: usize,
+) -> Result<Vec<RecallResult>> {
     if top_k == 0 {
         return Ok(Vec::new());
     }
@@ -281,10 +338,8 @@ pub async fn retrieve_l3(
     // Resolved BEFORE the drawer/closet guards are taken: it is a redb read
     // transaction, and holding those locks across I/O would stall every writer
     // on this palace for its duration (same ordering rule as `retrieve_l2`).
-    let target_room_id = room_filter
-        .as_ref()
-        .map(|r| resolve_room_filter_id(&handle.kg, r));
-    let fetch = if target_room_id.is_some() {
+    let allowed = scope.allowed_room_ids(&handle.kg);
+    let fetch = if allowed.is_some() {
         top_k.saturating_mul(3).max(top_k)
     } else {
         top_k
@@ -299,9 +354,7 @@ pub async fn retrieve_l3(
         let Some(drawer) = drawers.iter().find(|d| uuid_prefix_eq(d.id, hit.drawer_id)) else {
             continue;
         };
-        if let Some(rid) = target_room_id
-            && drawer.room_id != rid
-        {
+        if !scope_admits(&allowed, drawer.room_id) {
             continue;
         }
         let age_days = DecayConfig::age_days(drawer.created_at);
@@ -400,7 +453,9 @@ pub async fn recall(
     query: &str,
     top_k: usize,
 ) -> Result<Vec<RecallResult>> {
-    recall_in_room(handle, embedder, query, None, top_k).await
+    // ADR-0027 T9: unscoped recall is `RecallScope::All`, which reaches exactly
+    // the code path that ran before rooms or wings could scope it.
+    recall_scoped(handle, embedder, query, &RecallScope::All, top_k).await
 }
 
 /// Room-scoped `recall` — L0 + L1 + a `room`-filtered L2.
@@ -408,11 +463,9 @@ pub async fn recall(
 /// Why (ADR-0027 D6 / ticket T7): room filtering has worked in `retrieve_l2`
 /// since #3274, but no recall entry point exposed it, so the only way to read
 /// one room was `memory_list` or the HTTP `/recall` route. This is the door.
-/// What: identical to [`recall`] except the room filter is threaded into L2.
-/// L0/L1 are deliberately NOT filtered: they are the palace's identity and
-/// essential drawers, the always-on grounding every recall carries, and
-/// dropping them for a room-scoped query would silently change what "recall"
-/// means rather than narrowing it.
+/// What: [`recall_scoped`] with the room lifted into a [`RecallScope::Room`].
+/// Kept as its own entry point because a room is the axis most callers want and
+/// `Option<RoomType>` is the shape they already hold.
 /// Test: `recall_in_room_scopes_l2_hits`.
 pub async fn recall_in_room(
     handle: &PalaceHandle,
@@ -421,12 +474,43 @@ pub async fn recall_in_room(
     room: Option<RoomType>,
     top_k: usize,
 ) -> Result<Vec<RecallResult>> {
+    recall_scoped(
+        handle,
+        embedder,
+        query,
+        &RecallScope::from_room_filter(room),
+        top_k,
+    )
+    .await
+}
+
+/// Standard recall restricted to a [`RecallScope`] (ADR-0027 T9).
+///
+/// Why: "recall everything the `engineer` wing has learned" is the access
+/// pattern a Wing exists to enable (ADR-0027 D2, pattern 1) — one query, with
+/// no requirement that the caller already know that scope's complete topic set.
+/// This is the one implementation [`recall`] and [`recall_in_room`] both run.
+/// What: L0 + L1 (never scoped) merged with an L2 leg run under `scope`.
+///
+/// L0/L1 are deliberately NOT scoped: they are the palace's identity and
+/// essential drawers — the always-on grounding every recall carries — and
+/// dropping them for a scoped query would silently change what "recall" means
+/// rather than narrowing it.
+/// Test: `wing_scoped_recall_returns_only_that_wing`,
+/// `recall_in_room_scopes_l2_hits`.
+pub async fn recall_scoped(
+    handle: &PalaceHandle,
+    embedder: &dyn Embedder,
+    query: &str,
+    scope: &RecallScope,
+    top_k: usize,
+) -> Result<Vec<RecallResult>> {
     // Idle-to-disk: a recall is a genuine user access — reset the idle clock
     // so the idle-evict ticker does not drop an actively-queried palace.
     handle.touch();
     let expanded = expand_query(query);
     let mut combined = retrieve_l0_l1(handle);
-    let l2 = retrieve_l2(handle, embedder, &expanded, room, top_k).await?;
+    let l2 = retrieve_l2_scoped(handle, embedder, &expanded, scope, top_k).await?;
 
     // Build similarity-score map from L2 results (drawer_id -> score) before
     // consuming the vec. This lets us re-score L1 entries that happen to be
@@ -489,11 +573,34 @@ pub async fn recall_deep_in_room(
     room: Option<RoomType>,
     top_k: usize,
 ) -> Result<Vec<RecallResult>> {
+    recall_deep_scoped(
+        handle,
+        embedder,
+        query,
+        &RecallScope::from_room_filter(room),
+        top_k,
+    )
+    .await
+}
+
+/// Deep recall restricted to a [`RecallScope`] (ADR-0027 T9).
+///
+/// Why/What: the L3 counterpart of [`recall_scoped`], so `memory_recall_deep`
+/// honours a wing exactly as `memory_recall` does. L0/L1 stay unscoped for the
+/// same reason given there.
+/// Test: `wing_scoped_deep_recall_returns_only_that_wing`.
+pub async fn recall_deep_scoped(
+    handle: &PalaceHandle,
+    embedder: &dyn Embedder,
+    query: &str,
+    scope: &RecallScope,
+    top_k: usize,
+) -> Result<Vec<RecallResult>> {
     // Idle-to-disk: deep recall is also a genuine user access.
     handle.touch();
     let expanded = expand_query(query);
     let mut combined = retrieve_l0_l1(handle);
-    let l3 = retrieve_l3(handle, embedder, &expanded, room, top_k).await?;
+    let l3 = retrieve_l3_scoped(handle, embedder, &expanded, scope, top_k).await?;
 
     // Build similarity-score map from L3 results, then re-score L1 entries
     // so high-importance-but-irrelevant drawers don't dominate (issue #633).

--- a/crates/trusty-common/src/memory_core/retrieval/mod.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/mod.rs
@@ -13,6 +13,8 @@
 mod embedder;
 mod handle;
 mod layers;
+// ADR-0027 T9: room/wing recall scoping, shared by L2 and the list paths.
+mod scope;
 mod types;
 
 #[cfg(test)]
@@ -35,10 +37,13 @@ pub use types::{
 // Palace handle
 pub use handle::PalaceHandle;
 
+// Recall scoping (ADR-0027 T9)
+pub use scope::{RecallScope, list_drawers_in_wing, scope_admits};
+
 // Layer functions
 pub use layers::{
     expand_query, recall, recall_across_palaces, recall_across_palaces_with_default_embedder,
-    recall_deep, recall_deep_in_room, recall_deep_with_default_embedder, recall_in_room,
-    recall_with_default_embedder, rescore_l1_by_similarity, retrieve_l0_l1, retrieve_l2,
-    retrieve_l3,
+    recall_deep, recall_deep_in_room, recall_deep_scoped, recall_deep_with_default_embedder,
+    recall_in_room, recall_scoped, recall_with_default_embedder, rescore_l1_by_similarity,
+    retrieve_l0_l1, retrieve_l2, retrieve_l2_scoped, retrieve_l3, retrieve_l3_scoped,
 };

--- a/crates/trusty-common/src/memory_core/retrieval/scope.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/scope.rs
@@ -1,0 +1,134 @@
+//! Recall scoping: turn "which rooms may this read see?" into one filter.
+//!
+//! Why (ADR-0027 D2): a Wing enables "recall everything the `engineer` agent
+//! type has learned" as a single query, instead of requiring the caller to
+//! already know that agent's complete topic set — which is the discovery
+//! problem the ADR exists to fix. The drawer table stores only `room_id`, so a
+//! wing has to be projected onto a set of room ids before it can filter
+//! anything; doing that in one place means `retrieve_l2` and `list_drawers`
+//! cannot drift on what a scope means.
+//! What: [`RecallScope`] (`All` / `Room` / `Wing`), its projection onto a set
+//! of room ids, and [`list_drawers_in_wing`].
+//!
+//! **Fail-closed, unlike the room filter.** `resolve_room_filter_id` falls back
+//! to the legacy fold when a room has no registry row, because filtering "as it
+//! did before ADR-0027" is the safe answer for a topic. A *wing* is a
+//! scope/ownership boundary — #3064's "two agent types cannot accidentally
+//! read/write the same room unless configured to do so" — so a wing that cannot
+//! be resolved yields the EMPTY set, never the unfiltered one. A topic filter
+//! that fails open shows extra results; a scope that fails open is a leak.
+//!
+//! Test: `scope_all_matches_everything`, `wing_scope_is_fail_closed`,
+//! `wing_scope_returns_only_that_wings_drawers`,
+//! `same_named_rooms_in_two_wings_stay_distinct`.
+
+use crate::memory_core::palace::{Drawer, RoomType};
+use crate::memory_core::store::kg::KnowledgeGraph;
+use crate::memory_core::store::rooms::resolve_room_filter_id;
+use crate::memory_core::store::wings::rooms_in_wing;
+use std::collections::HashSet;
+use uuid::Uuid;
+
+use super::handle::PalaceHandle;
+
+/// Which rooms a read is allowed to see.
+///
+/// Why: `retrieve_l2` used to take `Option<RoomType>`, which cannot express
+/// "this wing". Generalising the filter — rather than adding a second,
+/// parallel wing parameter — keeps one implementation of the matching rule.
+/// What: `All` (no filter, the pre-T9 default), `Room` (one topic), `Wing`
+/// (every room that wing owns).
+/// Test: `scope_all_matches_everything`, `wing_scope_is_fail_closed`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RecallScope {
+    /// No filter — byte-identical to the behaviour every caller had before
+    /// wings existed.
+    All,
+    /// One topic, resolved through the `ROOMS` registry.
+    Room(RoomType),
+    /// Every room owned by this wing.
+    Wing(Uuid),
+}
+
+impl RecallScope {
+    /// Interpret an optional room filter as a scope.
+    ///
+    /// Why: lets the pre-T9 `Option<RoomType>` signatures delegate to the
+    /// scoped implementation without any caller changing.
+    pub fn from_room_filter(room: Option<RoomType>) -> Self {
+        match room {
+            Some(r) => RecallScope::Room(r),
+            None => RecallScope::All,
+        }
+    }
+
+    /// Project this scope onto the set of room ids a drawer may belong to.
+    ///
+    /// Why: this is the single definition of what a scope admits; every read
+    /// path compares `drawer.room_id` against the result.
+    /// What: `None` means "no filter at all" and must be distinguished from
+    /// `Some(empty)`, which means "this scope admits nothing" — collapsing the
+    /// two would turn an unresolvable wing into an unfiltered read.
+    /// Test: `scope_all_matches_everything`, `wing_scope_is_fail_closed`.
+    pub fn allowed_room_ids(&self, kg: &KnowledgeGraph) -> Option<HashSet<Uuid>> {
+        match self {
+            RecallScope::All => None,
+            RecallScope::Room(room) => Some(HashSet::from([resolve_room_filter_id(kg, room)])),
+            RecallScope::Wing(wing_id) => Some(rooms_in_wing(kg, *wing_id).unwrap_or_else(|e| {
+                // Fail CLOSED — see the module doc. An unresolvable scope
+                // boundary must not widen into an unfiltered read.
+                tracing::warn!(%wing_id, "wing scope unresolvable, admitting nothing: {e:#}");
+                HashSet::new()
+            })),
+        }
+    }
+}
+
+/// Whether `room_id` is admitted by a resolved scope.
+///
+/// Why: one predicate shared by `retrieve_l2` and `list_drawers_in_wing`, so a
+/// future scope variant cannot be honoured by one and ignored by the other.
+pub fn scope_admits(allowed: &Option<HashSet<Uuid>>, room_id: Uuid) -> bool {
+    match allowed {
+        Some(ids) => ids.contains(&room_id),
+        None => true,
+    }
+}
+
+/// List drawers belonging to `wing_id`, sorted by importance descending.
+///
+/// Why: the wing-axis counterpart of `PalaceHandle::list_drawers`. It lives
+/// here rather than as a method because `retrieval/handle.rs` sits at 487 of
+/// its 500-SLOC cap (ADR-0027 C5) and can absorb a call site, not an
+/// implementation.
+/// What: resolves the wing to its room set BEFORE taking the drawer read guard
+/// — that resolution is a redb read transaction, and holding the lock across
+/// I/O would stall every writer on the palace for its duration — then applies
+/// the same tag filter, importance sort, and truncation `list_drawers` uses.
+/// Test: `wing_scope_returns_only_that_wings_drawers`.
+pub fn list_drawers_in_wing(
+    handle: &PalaceHandle,
+    wing_id: Uuid,
+    tag: Option<String>,
+    limit: usize,
+) -> Vec<Drawer> {
+    let allowed = RecallScope::Wing(wing_id).allowed_room_ids(&handle.kg);
+    let drawers = handle.drawers.read();
+    let mut filtered: Vec<Drawer> = drawers
+        .iter()
+        .filter(|d| scope_admits(&allowed, d.room_id))
+        .filter(|d| match &tag {
+            Some(t) => d.tags.iter().any(|x| x == t),
+            None => true,
+        })
+        .cloned()
+        .collect();
+    drop(drawers);
+    filtered.sort_by(|a, b| {
+        b.importance
+            .partial_cmp(&a.importance)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    filtered.truncate(limit);
+    filtered
+}

--- a/crates/trusty-common/src/memory_core/retrieval/tests.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/tests.rs
@@ -1448,3 +1448,300 @@ async fn recall_deep_in_room_scopes_l3_hits() {
         "an out-of-room drawer reached a room-scoped deep recall"
     );
 }
+
+// ── ADR-0027 T9: wing scoping ────────────────────────────────────────────
+//
+// These live here rather than beside `scope.rs` because the wing-scoped read
+// paths need a real `PalaceHandle` (vector store + KG), and `make_handle`
+// above is that harness. Duplicating it next to `scope.rs` would fork the
+// fixture.
+
+use crate::memory_core::room_identity::DEFAULT_WING_ID;
+use crate::memory_core::store::rooms::resolve_or_create_room_in_wing_sync;
+use crate::memory_core::store::wings::{ensure_default_wing, resolve_or_create_wing_sync};
+
+/// Seed the default wing plus a named one, and return `(wing_id, room_id)`
+/// for a room called `label` inside it.
+fn wing_with_room(handle: &PalaceHandle, wing: &str, label: &str) -> (Uuid, Uuid) {
+    ensure_default_wing(&handle.kg).expect("seed default wing");
+    let store = handle.kg.store();
+    let (wing_id, _) = resolve_or_create_wing_sync(&store, wing).expect("create wing");
+    let room = RoomType::parse(label);
+    let room_id = resolve_or_create_room_in_wing_sync(&store, &room, wing_id).expect("create room");
+    (wing_id, room_id)
+}
+
+#[test]
+fn scope_all_matches_everything() {
+    // `RecallScope::All` must resolve to NO filter — distinct from a filter
+    // that admits nothing. Collapsing the two would turn an unresolvable
+    // scope into an unfiltered read.
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    assert!(
+        RecallScope::All.allowed_room_ids(&handle.kg).is_none(),
+        "All must be 'no filter', not 'empty filter'"
+    );
+    assert!(scope_admits(&None, Uuid::new_v4()));
+}
+
+#[test]
+fn wing_scope_is_fail_closed() {
+    // A scope boundary that fails open is a leak (#3064's criterion), so an
+    // unknown wing admits NOTHING rather than everything.
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    ensure_default_wing(&handle.kg).expect("seed");
+    let allowed = RecallScope::Wing(Uuid::from_u128(999)).allowed_room_ids(&handle.kg);
+    assert_eq!(allowed, Some(std::collections::HashSet::new()));
+    assert!(!scope_admits(&allowed, Uuid::new_v4()));
+}
+
+#[test]
+fn wing_scope_returns_only_that_wings_drawers() {
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let (engineer, eng_room) = wing_with_room(&handle, "engineer", "Planning");
+    let (pm, pm_room) = wing_with_room(&handle, "pm", "Planning");
+
+    let eng_drawer = Drawer::new(eng_room, "engineer planning note");
+    let eng_id = eng_drawer.id;
+    let pm_drawer = Drawer::new(pm_room, "pm planning note");
+    let pm_id = pm_drawer.id;
+    handle.add_drawer(eng_drawer);
+    handle.add_drawer(pm_drawer);
+
+    let eng_hits = list_drawers_in_wing(&handle, engineer, None, 50);
+    assert_eq!(eng_hits.len(), 1, "engineer wing sees only its own drawer");
+    assert_eq!(eng_hits[0].id, eng_id);
+
+    let pm_hits = list_drawers_in_wing(&handle, pm, None, 50);
+    assert_eq!(pm_hits.len(), 1);
+    assert_eq!(pm_hits[0].id, pm_id);
+
+    // The default wing owns neither of them.
+    assert!(list_drawers_in_wing(&handle, DEFAULT_WING_ID, None, 50).is_empty());
+}
+
+#[test]
+fn same_named_rooms_in_two_wings_stay_distinct() {
+    // ADR-0027 D2 pattern 3: `engineer/Planning` and `pm/Planning` coexist
+    // without `Custom("engineer-planning")` name mangling.
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let (_e, eng_room) = wing_with_room(&handle, "engineer", "Planning");
+    let (_p, pm_room) = wing_with_room(&handle, "pm", "Planning");
+    assert_ne!(
+        eng_room, pm_room,
+        "one label in two wings must be two rooms"
+    );
+}
+
+#[tokio::test]
+async fn wing_scoped_recall_returns_only_that_wing() {
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let embedder = shared_embedder().await.unwrap();
+    let (engineer, eng_room) = wing_with_room(&handle, "engineer", "Planning");
+    let (_pm, pm_room) = wing_with_room(&handle, "pm", "Planning");
+
+    // Deliberately DISTINCT content per wing. Near-identical vectors would
+    // make the targeted query's hit depend on approximate-index recall rather
+    // than on the wing filter, which is the thing under test here.
+    let eng = Drawer::new(eng_room, "Rust is a systems programming language");
+    let eng_id = eng.id;
+    let pm = Drawer::new(pm_room, "the launch review happens every quarter");
+    let pm_id = pm.id;
+    for d in [&eng, &pm] {
+        let vecs = embedder
+            .embed_batch(std::slice::from_ref(&d.content))
+            .await
+            .unwrap();
+        handle
+            .vector_store
+            .upsert(d.id, vecs[0].clone())
+            .await
+            .unwrap();
+    }
+    handle.add_drawer(eng);
+    handle.add_drawer(pm);
+
+    let results = retrieve_l2_scoped(
+        &handle,
+        embedder.as_ref(),
+        "systems programming Rust",
+        &RecallScope::Wing(engineer),
+        5,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        !results.is_empty(),
+        "the engineer wing has a matching drawer"
+    );
+    assert!(
+        results.iter().all(|r| uuid_prefix_eq(r.drawer.id, eng_id)),
+        "wing scope must exclude the other wing, got: {:?}",
+        results.iter().map(|r| r.drawer.id).collect::<Vec<_>>()
+    );
+    assert!(
+        !results.iter().any(|r| uuid_prefix_eq(r.drawer.id, pm_id)),
+        "a pm-wing drawer leaked through an engineer-wing scope"
+    );
+}
+
+#[tokio::test]
+async fn unscoped_recall_is_unchanged_by_wings() {
+    // The "wing is never required of a caller" guarantee at the read surface:
+    // an unscoped L2 over a palace that HAS wings must return exactly what an
+    // unfiltered L2 always returned — both drawers, neither hidden.
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let embedder = shared_embedder().await.unwrap();
+    let (_e, eng_room) = wing_with_room(&handle, "engineer", "Planning");
+    let (_p, pm_room) = wing_with_room(&handle, "pm", "Planning");
+
+    let eng = Drawer::new(eng_room, "Rust is a systems programming language");
+    let pm = Drawer::new(pm_room, "the launch review happens every quarter");
+    let ids = [eng.id, pm.id];
+    let pm_id = pm.id;
+    for d in [&eng, &pm] {
+        let vecs = embedder
+            .embed_batch(std::slice::from_ref(&d.content))
+            .await
+            .unwrap();
+        handle
+            .vector_store
+            .upsert(d.id, vecs[0].clone())
+            .await
+            .unwrap();
+    }
+    handle.add_drawer(eng);
+    handle.add_drawer(pm);
+
+    // "Nothing is hidden" is asserted on `list_drawers`, which reads the
+    // in-memory drawer table exactly. Asserting it on L2 instead would demand
+    // 100% recall from an APPROXIMATE HNSW index — a guarantee the vector
+    // store does not make and must not be tested for. That mistake made an
+    // earlier version of this test flaky.
+    let listed = handle.list_drawers(None, None, 50);
+    for id in ids {
+        assert!(
+            listed.iter().any(|d| d.id == id),
+            "an unscoped list must still see every wing's drawers"
+        );
+    }
+
+    // And an unscoped L2 is genuinely un-filtered by wings: a drawer living in
+    // a NON-default wing is reachable when no wing is named. One targeted
+    // query, one expected hit — no reliance on the index returning everything.
+    let results = retrieve_l2(
+        &handle,
+        embedder.as_ref(),
+        "the launch review happens every quarter",
+        None,
+        5,
+    )
+    .await
+    .unwrap();
+    assert!(
+        results.iter().any(|r| uuid_prefix_eq(r.drawer.id, pm_id)),
+        "an unscoped recall must not filter out a non-default wing's drawer"
+    );
+}
+
+#[tokio::test]
+async fn unscoped_write_still_lands_in_the_default_wing() {
+    // The write-side half of the same guarantee: a caller that never mentions
+    // a wing gets the default wing and the pre-T9 room id, unchanged.
+    // `remember` embeds, so the process-wide shared embedder must be seeded
+    // with the mock first (issue #850) — without this the real ONNX embedder
+    // can win the `OnceCell` race and change what every other test in this
+    // binary embeds with.
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    ensure_default_wing(&handle.kg).expect("seed");
+    let id = handle
+        .remember(
+            "a perfectly ordinary curated fact about the project".to_string(),
+            RoomType::Planning,
+            vec![],
+            0.5,
+        )
+        .await
+        .expect("remember");
+
+    let drawer = handle
+        .drawers
+        .read()
+        .iter()
+        .find(|d| d.id == id)
+        .cloned()
+        .expect("stored");
+    let scoped = crate::memory_core::store::wings::rooms_in_wing(&handle.kg, DEFAULT_WING_ID)
+        .expect("scope");
+    assert!(
+        scoped.contains(&drawer.room_id),
+        "a wing-less write must land in the default wing"
+    );
+    assert!(
+        list_drawers_in_wing(&handle, DEFAULT_WING_ID, None, 50)
+            .iter()
+            .any(|d| d.id == id)
+    );
+}
+
+#[tokio::test]
+async fn wing_scoped_deep_recall_returns_only_that_wing() {
+    // ADR-0027 T9: L3 must honour a wing exactly as L2 does. Without this,
+    // `recall_deep` would silently ignore a scope — the invisible-failure class
+    // the ADR exists to remove. Library-level so the guarantee is pinned where
+    // the filter lives, not only through the MCP surface.
+    init_embedder();
+    let dir = tempdir().unwrap();
+    let handle = make_handle(dir.path());
+    let embedder = shared_embedder().await.unwrap();
+    let (engineer, eng_room) = wing_with_room(&handle, "engineer", "Planning");
+    let (_pm, pm_room) = wing_with_room(&handle, "pm", "Planning");
+
+    let eng = Drawer::new(eng_room, "Rust is a systems programming language");
+    let eng_id = eng.id;
+    let pm = Drawer::new(pm_room, "the launch review happens every quarter");
+    let pm_id = pm.id;
+    for d in [&eng, &pm] {
+        let vecs = embedder
+            .embed_batch(std::slice::from_ref(&d.content))
+            .await
+            .unwrap();
+        handle
+            .vector_store
+            .upsert(d.id, vecs[0].clone())
+            .await
+            .unwrap();
+    }
+    handle.add_drawer(eng);
+    handle.add_drawer(pm);
+
+    let results = retrieve_l3_scoped(
+        &handle,
+        embedder.as_ref(),
+        "Rust systems programming",
+        &RecallScope::Wing(engineer),
+        5,
+    )
+    .await
+    .unwrap();
+
+    assert!(
+        results.iter().any(|r| uuid_prefix_eq(r.drawer.id, eng_id)),
+        "engineer-wing deep recall returned no matching drawer"
+    );
+    assert!(
+        !results.iter().any(|r| uuid_prefix_eq(r.drawer.id, pm_id)),
+        "a pm-wing drawer leaked through an engineer-wing deep recall"
+    );
+}

--- a/crates/trusty-common/src/memory_core/retrieval/types.rs
+++ b/crates/trusty-common/src/memory_core/retrieval/types.rs
@@ -93,6 +93,19 @@ pub struct RememberOptions {
     /// Test: `remember_force_still_blocks_secret`,
     /// `remember_force_and_allow_secret_like_stores_secret_shaped_content`.
     pub allow_secret_like: bool,
+    /// Wing the drawer's room belongs to (ADR-0027 T9).
+    ///
+    /// Why: without this a non-default wing could never receive a drawer, and
+    /// wing-scoped recall would be permanently empty outside the default wing
+    /// — a level nobody can write to is the same defect as a level nobody
+    /// reads. This is the write half of the "who" axis.
+    /// What: `None` (the default) resolves the room in the palace's default
+    /// wing, which is byte-identical to the pre-T9 behaviour every existing
+    /// caller gets. `Some(wing_id)` resolves it in that wing instead, so
+    /// `engineer`/`Planning` and `pm`/`Planning` are two distinct rooms.
+    /// Test: `wing_scoped_recall_returns_only_that_wing`,
+    /// `unscoped_write_still_lands_in_the_default_wing`.
+    pub wing_id: Option<uuid::Uuid>,
 }
 
 impl Default for RememberOptions {
@@ -104,6 +117,7 @@ impl Default for RememberOptions {
             classify_as: None,
             defer_embedding: false,
             allow_secret_like: false,
+            wing_id: None,
         }
     }
 }
@@ -127,6 +141,7 @@ impl RememberOptions {
             classify_as: Some(DrawerType::UserFact),
             defer_embedding: false,
             allow_secret_like: false,
+            wing_id: None,
         }
     }
 

--- a/crates/trusty-common/src/memory_core/store/kg_redb/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/mod.rs
@@ -19,6 +19,8 @@ mod room_ops;
 mod store;
 mod tests;
 mod types;
+// ADR-0027 T9: WINGS / WING_KEYS accessors. Insert-only except the rename pair.
+mod wing_ops;
 mod write_ops;
 
 pub use store::KgStoreRedb;

--- a/crates/trusty-common/src/memory_core/store/kg_redb/store.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/store.rs
@@ -11,7 +11,7 @@ use crate::memory_core::store::concurrent_open::{
 };
 use crate::memory_core::store::kg_store::{
     ACTIVE_SUBJECT_COUNTS, DRAWERS, ROOM_KEYS, ROOMS, TRIPLES, TRIPLES_BY_OBJECT,
-    TRIPLES_BY_PREDICATE,
+    TRIPLES_BY_PREDICATE, WING_KEYS, WINGS,
 };
 use anyhow::{Context, Result};
 use redb::Database;
@@ -159,6 +159,11 @@ impl KgStoreRedb {
                             // without the tables that name their rooms.
                             let _ = wtx.open_table(ROOMS).context("init rooms table")?;
                             let _ = wtx.open_table(ROOM_KEYS).context("init room_keys table")?;
+                            // ADR-0027 T9: same whole-schema rule for the wing
+                            // registry — a palace can never present rooms
+                            // without the tables that scope them.
+                            let _ = wtx.open_table(WINGS).context("init wings table")?;
+                            let _ = wtx.open_table(WING_KEYS).context("init wing_keys table")?;
                         }
                         wtx.commit().context("commit init txn")?;
                     }

--- a/crates/trusty-common/src/memory_core/store/kg_redb/wing_ops.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_redb/wing_ops.rs
@@ -1,0 +1,328 @@
+//! Wing-registry read/write methods for `KgStoreRedb` (ADR-0027 T9).
+//!
+//! Why: the `WINGS` / `WING_KEYS` tables live in the palace's `kg.db` for the
+//! same reason `ROOMS` does (ADR-0027 D1.1) — the redb open path recreates an
+//! unreadable database empty, so a sidecar would survive and then
+//! authoritatively describe wings whose rooms are gone. Their accessors need
+//! the crate-private `db()` handle, so they belong inside `kg_redb` rather
+//! than in `store::wings`, which owns the record shape and the policy.
+//! Splitting them this way also keeps `read_ops.rs` / `write_ops.rs` (450/500)
+//! clear of the SLOC cap.
+//! What: `impl KgStoreRedb` for `lookup_wing_id`, `get_wing`,
+//! `insert_wing_if_absent`, `list_wings`, `rename_wing_in_place`, and the
+//! schema-version marker.
+//!
+//! Write posture: every method here is INSERT-ONLY except
+//! `rename_wing_in_place`, which exists solely to serve `wing_rename` — an
+//! explicit human act, unlike the seeding pass. That asymmetry is deliberate:
+//! it is what makes seeding idempotent AND makes a rename survive every
+//! subsequent palace open (ADR-0027 D1.4, applied to the wing axis). The
+//! rename applies all of its effects in ONE transaction, so it can never leave
+//! the retired label resolving as a stale alias.
+//! Test: `default_wing_is_seeded_once`, `wing_rename_survives_reseed`,
+//! `wing_insert_is_insert_only` (all in `store::wings::tests`).
+
+use crate::memory_core::store::kg_store::{WING_KEYS, WINGS, decode_value, encode_value};
+use crate::memory_core::store::wings::{WING_SCHEMA_VERSION, WingRecord, WingSchemaMarker};
+use crate::memory_core::wing_identity::canonical_wing_key;
+use anyhow::{Context, Result, bail};
+use redb::{ReadableDatabase, ReadableTable};
+use uuid::Uuid;
+
+use super::store::KgStoreRedb;
+
+impl KgStoreRedb {
+    /// Look up the wing id registered under `key`.
+    ///
+    /// Why: the wing-side half of "ids are read from the table, never
+    /// recomputed" (ADR-0027 D1.3). It is what makes `wing_create` idempotent
+    /// and what stops a caller minting a second id for the default wing.
+    /// What: point read of `WING_KEYS`; `None` when the key is unregistered.
+    /// A value that is not 16 bytes is treated as absent rather than as an
+    /// error, so a corrupt index degrades to "unregistered" instead of making
+    /// the palace unusable — the same posture `lookup_room_id` takes.
+    /// Test: `wing_create_is_idempotent`.
+    pub fn lookup_wing_id(&self, key: &str) -> Result<Option<Uuid>> {
+        let rtx = self.db().begin_read().context("begin lookup_wing_id txn")?;
+        let table = rtx.open_table(WING_KEYS).context("open wing_keys table")?;
+        let Some(v) = table.get(key).context("read wing_keys row")? else {
+            return Ok(None);
+        };
+        let bytes = v.value();
+        let Ok(raw) = <[u8; 16]>::try_from(bytes) else {
+            tracing::warn!(
+                key,
+                len = bytes.len(),
+                "wing_keys row is not a uuid; ignoring"
+            );
+            return Ok(None);
+        };
+        Ok(Some(Uuid::from_bytes(raw)))
+    }
+
+    /// Read one wing row by id.
+    ///
+    /// Why: the seeding pass asks "does the default wing already exist?" by
+    /// ID, not by key — that is what lets a renamed default wing keep its new
+    /// name instead of having the original key resurrected as an alias.
+    /// What: point read of `WINGS`, postcard-decoded.
+    /// Test: `wing_rename_survives_reseed`.
+    pub fn get_wing(&self, id: Uuid) -> Result<Option<WingRecord>> {
+        let rtx = self.db().begin_read().context("begin get_wing txn")?;
+        let table = rtx.open_table(WINGS).context("open wings table")?;
+        let Some(v) = table
+            .get(id.as_bytes().as_slice())
+            .context("read wing row")?
+        else {
+            return Ok(None);
+        };
+        let record =
+            decode_wing_record(v.value()).with_context(|| format!("decode wing row for {id}"))?;
+        Ok(Some(record))
+    }
+
+    /// Register `id` under `key`, without ever overwriting an existing row.
+    ///
+    /// Why: insert-only is what makes seeding re-runnable. Re-opening a palace
+    /// cannot clobber a rename, and two racing writers cannot fight over a
+    /// label — the loser reads the winner's id back.
+    /// What: one write transaction over both tables. The `WINGS` row is
+    /// written only when `id` is absent; the `WING_KEYS` entry only when `key`
+    /// is absent. Returns `true` when a new `WINGS` row was written.
+    /// Test: `wing_insert_is_insert_only`, `wing_create_is_idempotent`.
+    pub fn insert_wing_if_absent(&self, id: Uuid, key: &str, record: &WingRecord) -> Result<bool> {
+        self.check_writable()?;
+        let value = encode_value(record).context("encode WingRecord")?;
+        let wtx = self.db().begin_write().context("begin insert_wing txn")?;
+        let inserted = {
+            let mut wings = wtx.open_table(WINGS).context("open wings table")?;
+            let fresh = wings
+                .get(id.as_bytes().as_slice())
+                .context("probe wings row")?
+                .is_none();
+            if fresh {
+                wings
+                    .insert(id.as_bytes().as_slice(), value.as_slice())
+                    .context("insert wings row")?;
+            }
+            let mut keys = wtx.open_table(WING_KEYS).context("open wing_keys table")?;
+            if keys.get(key).context("probe wing_keys row")?.is_none() {
+                keys.insert(key, id.as_bytes().as_slice())
+                    .context("insert wing_keys row")?;
+            }
+            fresh
+        };
+        wtx.commit().context("commit insert_wing txn")?;
+        Ok(inserted)
+    }
+
+    /// Every registered wing, id-ordered, excluding the schema marker.
+    ///
+    /// Why: the discovery primitive behind `wing_list` — and the reason this
+    /// ticket ships a consumer rather than a dark table.
+    /// What: full scan of `WINGS`, skipping the reserved nil-uuid marker key.
+    /// A row that fails to decode is logged and skipped so one bad row cannot
+    /// hide the rest.
+    /// Test: `wing_list_reports_seeded_and_created_wings`.
+    pub fn list_wings(&self) -> Result<Vec<(Uuid, WingRecord)>> {
+        let rtx = self.db().begin_read().context("begin list_wings txn")?;
+        let table = rtx.open_table(WINGS).context("open wings table")?;
+        let mut out = Vec::new();
+        for entry in table.iter().context("iter wings")? {
+            let (k, v) = entry.context("read wings row")?;
+            let Ok(raw) = <[u8; 16]>::try_from(k.value()) else {
+                continue;
+            };
+            let id = Uuid::from_bytes(raw);
+            if id.is_nil() {
+                continue; // reserved: schema marker
+            }
+            match decode_wing_record(v.value()) {
+                Ok(record) => out.push((id, record)),
+                Err(e) => tracing::warn!(%id, "skipping undecodable wing row: {e:#}"),
+            }
+        }
+        Ok(out)
+    }
+
+    /// Apply a wing rename ATOMICALLY: row, new key, and old-key retirement.
+    ///
+    /// Why: all three effects must land or none of them. Splitting them across
+    /// two commits — as an earlier draft of this file did, with a `put_wing`
+    /// followed by a separate `remove_wing_key` — leaves a crash window in
+    /// which the row carries the new label while the OLD key still resolves to
+    /// it. That is precisely the alias this method's caller documents as
+    /// impossible, and a stale alias in a scope mechanism is a leak: a caller
+    /// that names the retired label would silently reach the wing it was
+    /// renamed away from. redb gives us a single write transaction over both
+    /// tables, so the split bought nothing.
+    ///
+    /// This is also the ONLY non-insert-only write on the wing axis. It exists
+    /// for exactly one caller — `wing_rename` — so no automatic path (seeding,
+    /// palace open) can reach an overwrite by accident.
+    ///
+    /// What: one write transaction that overwrites the `WINGS` row, points
+    /// `new_key` at `id`, and removes `old_key` when it differs. Never touches
+    /// `ROOMS` or `DRAWERS` — a rename cannot move a room, let alone a drawer,
+    /// because rooms reference a wing by ID and the id is unchanged.
+    /// Test: `wing_rename_changes_no_room_or_drawer_rows`,
+    /// `wing_rename_retires_the_old_label`,
+    /// `wing_rename_applies_every_effect_together`.
+    pub fn rename_wing_in_place(
+        &self,
+        id: Uuid,
+        new_key: &str,
+        new_label: &str,
+    ) -> Result<WingRecord> {
+        self.check_writable()?;
+        let wtx = self.db().begin_write().context("begin rename_wing txn")?;
+        let renamed = {
+            let mut wings = wtx.open_table(WINGS).context("open wings table")?;
+            // Read the row INSIDE the transaction and derive the old key from
+            // it. Deriving it outside would let two concurrent renames of the
+            // same wing each retire a label the other had already replaced,
+            // stranding one of them as a live alias.
+            let Some(existing) = wings
+                .get(id.as_bytes().as_slice())
+                .context("read wing to rename")?
+            else {
+                bail!("unknown wing: {id}");
+            };
+            let record = decode_wing_record(existing.value())
+                .with_context(|| format!("decode wing row for {id}"))?;
+            drop(existing);
+            let old_key = canonical_wing_key(&record.label);
+
+            let mut keys = wtx.open_table(WING_KEYS).context("open wing_keys table")?;
+            // Uniqueness probe INSIDE the write transaction. Probing outside it
+            // left a window in which a concurrent `resolve_or_create_wing_sync`
+            // could claim `new_key`, after which this unconditional insert
+            // would steal it — leaving the loser's row with a label that no
+            // longer resolved to it. redb's single-writer lock closes that
+            // window entirely; bailing here aborts the whole transaction, so a
+            // rejected rename writes nothing at all.
+            if let Some(holder) = keys.get(new_key).context("probe new wing label")? {
+                let taken = <[u8; 16]>::try_from(holder.value())
+                    .map(Uuid::from_bytes)
+                    .unwrap_or_else(|_| Uuid::nil());
+                if taken != id {
+                    bail!("wing label {new_label:?} is already used by wing {taken}");
+                }
+            }
+
+            let renamed = WingRecord {
+                label: new_label.to_string(),
+                ..record
+            };
+            let value = encode_value(&renamed).context("encode WingRecord")?;
+            wings
+                .insert(id.as_bytes().as_slice(), value.as_slice())
+                .context("insert wings row")?;
+            keys.insert(new_key, id.as_bytes().as_slice())
+                .context("insert wing_keys row")?;
+            if old_key != new_key {
+                keys.remove(old_key.as_str())
+                    .context("retire old wing_keys row")?;
+            }
+            renamed
+        };
+        wtx.commit().context("commit rename_wing txn")?;
+        Ok(renamed)
+    }
+
+    /// Read the wing-schema version marker, if one has been written.
+    ///
+    /// Why/What: mirrors `room_schema_version` — it lets a future migration
+    /// recognise which shape wrote these rows. Seeding idempotency does NOT
+    /// depend on it; that comes from the by-id existence probe.
+    /// Test: `default_wing_is_seeded_once`.
+    pub fn wing_schema_version(&self) -> Result<Option<u32>> {
+        let rtx = self
+            .db()
+            .begin_read()
+            .context("begin wing schema marker txn")?;
+        let table = rtx.open_table(WINGS).context("open wings table")?;
+        let Some(v) = table
+            .get(Uuid::nil().as_bytes().as_slice())
+            .context("read wing schema marker")?
+        else {
+            return Ok(None);
+        };
+        let marker: WingSchemaMarker =
+            decode_value(v.value()).context("decode WingSchemaMarker")?;
+        Ok(Some(marker.schema_version))
+    }
+
+    /// Stamp the current wing-schema version. UNCONDITIONAL OVERWRITE.
+    ///
+    /// Why: the marker records which shape wrote these rows, so a future
+    /// migration can tell whether it has work to do. That makes an
+    /// unconditional write dangerous in exactly one way: stamping a bumped
+    /// [`WING_SCHEMA_VERSION`] onto a palace whose rows were NOT migrated
+    /// would erase the only evidence that they still need migrating.
+    ///
+    /// **Call contract:** call this only when creating the wing schema, or at
+    /// the end of a migration that has actually converted the rows. Never call
+    /// it unconditionally on palace open — [`super::super::wings::ensure_default_wing`]
+    /// deliberately reaches it only on the branch that just created the schema,
+    /// which is why an already-seeded palace performs no write at open.
+    /// What: overwrites the nil-uuid `WINGS` row with the current version.
+    /// Test: `default_wing_is_seeded_once`,
+    /// `reseeding_does_not_restamp_the_schema_version`.
+    pub fn set_wing_schema_version(&self) -> Result<()> {
+        self.check_writable()?;
+        let value = encode_value(&WingSchemaMarker {
+            schema_version: WING_SCHEMA_VERSION,
+        })
+        .context("encode WingSchemaMarker")?;
+        let wtx = self
+            .db()
+            .begin_write()
+            .context("begin wing schema marker txn")?;
+        {
+            let mut wings = wtx.open_table(WINGS).context("open wings table")?;
+            wings
+                .insert(Uuid::nil().as_bytes().as_slice(), value.as_slice())
+                .context("insert wing schema marker")?;
+        }
+        wtx.commit().context("commit wing schema marker txn")?;
+        Ok(())
+    }
+
+    /// Raw `(key, value)` bytes of every `WINGS` row — test-only.
+    ///
+    /// Why: proving that re-seeding an already-seeded palace performs NO write
+    /// at all — including no restamp of the schema marker — needs a byte-level
+    /// snapshot. Comparing decoded values would miss a marker rewritten to the
+    /// same version, which is exactly the write the call contract forbids.
+    /// What: full scan returning owned bytes, key-ordered. Includes the
+    /// nil-uuid marker row, unlike `list_wings`.
+    /// Test: `reseeding_does_not_restamp_the_schema_version`.
+    #[cfg(test)]
+    pub(crate) fn raw_wing_rows(&self) -> Result<Vec<(Vec<u8>, Vec<u8>)>> {
+        let rtx = self.db().begin_read().context("begin raw_wing_rows txn")?;
+        let table = rtx.open_table(WINGS).context("open wings table")?;
+        let mut out = Vec::new();
+        for entry in table.iter().context("iter wings")? {
+            let (k, v) = entry.context("read wings row")?;
+            out.push((k.value().to_vec(), v.value().to_vec()));
+        }
+        Ok(out)
+    }
+}
+
+/// Decode a `WingRecord`, with room for a fallback chain.
+///
+/// Why: postcard is positional, so the day a trailing field is appended to
+/// `WingRecord` — the mechanism ADR-0027 D2 relies on for hanging #3064's
+/// per-wing access configuration later — rows written today stop decoding as
+/// the new shape. The `DrawerRecord` precedent (`kg_redb/types.rs`) handles
+/// that by trying the current shape and falling back through the historical
+/// ones; this function is the single place that chain will grow, so no call
+/// site has to learn it.
+/// What: today there is exactly one shape, so this is a direct decode.
+/// Test: `store::wings::tests::wing_record_decodes_under_a_future_field`
+/// exercises the pattern this chain implements.
+fn decode_wing_record(bytes: &[u8]) -> Result<WingRecord> {
+    decode_value::<WingRecord>(bytes).context("decode WingRecord")
+}

--- a/crates/trusty-common/src/memory_core/store/kg_store.rs
+++ b/crates/trusty-common/src/memory_core/store/kg_store.rs
@@ -78,6 +78,28 @@ pub const ROOMS: TableDefinition<&[u8], &[u8]> = TableDefinition::new("rooms");
 /// Test: `store::room_backfill::tests::room_key_lookup_returns_registered_id`.
 pub const ROOM_KEYS: TableDefinition<&str, &[u8]> = TableDefinition::new("room_keys");
 
+/// Wing registry (ADR-0027 D2 / ticket T9).
+///
+/// Why: a Wing is the scope/ownership axis over rooms — the "who" to a Room's
+/// "what". It lives in the same database as the rooms it scopes for the same
+/// corruption-recovery reason [`ROOMS`] does: a surviving sidecar would
+/// authoritatively describe wings whose rooms are gone.
+/// What: Key = wing uuid bytes (`[u8; 16]`); the nil uuid is reserved for the
+/// `WingSchemaMarker` row. Value = postcard-encoded
+/// [`crate::memory_core::store::wings::WingRecord`].
+/// Test: `store::wings::tests::default_wing_is_seeded_once`.
+pub const WINGS: TableDefinition<&[u8], &[u8]> = TableDefinition::new("wings");
+
+/// Canonical-key index over [`WINGS`] (ADR-0027 T9).
+///
+/// Why: a caller names a wing by label, not by id, and `Engineer`/`engineer`
+/// must be one wing. Ids are READ from here, never recomputed — which is also
+/// what pins the default wing to the `DEFAULT_WING_ID` every room row already
+/// carries instead of minting a second one.
+/// What: Key = the trimmed, lowercased label. Value = wing uuid bytes.
+/// Test: `store::wings::tests::wing_create_is_idempotent`.
+pub const WING_KEYS: TableDefinition<&str, &[u8]> = TableDefinition::new("wing_keys");
+
 /// Payload store (for `open-mpm`'s `TrustyBackedMemoryStore`).
 ///
 /// Why: Payloads are namespaced by segment and addressed by id; share the
@@ -545,6 +567,8 @@ mod tests {
             DRAWERS.name(),
             ROOMS.name(),
             ROOM_KEYS.name(),
+            WINGS.name(),
+            WING_KEYS.name(),
             PAYLOADS.name(),
             SESSIONS.name(),
             RECALL_LOG.name(),

--- a/crates/trusty-common/src/memory_core/store/mod.rs
+++ b/crates/trusty-common/src/memory_core/store/mod.rs
@@ -25,6 +25,8 @@ pub mod room_plan;
 // ADR-0027 T1/T4/T6: room record shape, resolve-or-create, and the room surface.
 pub mod rooms;
 pub mod vector;
+// ADR-0027 T9: wing record shape, default-wing seeding, create/rename/list.
+pub mod wings;
 
 pub use chat_sessions::{ChatSession, ChatSessionMeta, ChatSessionStore};
 pub use concurrent_open::{OpenIntent, OpenMode};
@@ -43,3 +45,7 @@ pub use rooms::{
     resolve_room_filter_id, resolve_room_selector,
 };
 pub use vector::{VectorHit, VectorStore};
+pub use wings::{
+    WingRecord, WingSummary, ensure_default_wing, ensure_default_wing_fail_open, list_wings,
+    rename_wing, resolve_or_create_wing, resolve_wing_selector, rooms_in_wing,
+};

--- a/crates/trusty-common/src/memory_core/store/rooms.rs
+++ b/crates/trusty-common/src/memory_core/store/rooms.rs
@@ -170,11 +170,42 @@ pub fn resolve_room_filter_id(kg: &KnowledgeGraph, room: &RoomType) -> Uuid {
 /// Test: `resolve_or_create_is_idempotent`,
 /// `resolve_or_create_reuses_backfilled_legacy_id`.
 pub async fn resolve_or_create_room(kg: &KnowledgeGraph, room: &RoomType) -> Uuid {
+    resolve_or_create_room_in_wing(kg, room, DEFAULT_WING_ID).await
+}
+
+/// Resolve `room` **within `wing_id`**, creating its registry row when absent.
+///
+/// Why (ADR-0027 D2, pattern 3): the wing is part of the canonical room key, so
+/// `engineer`/`Planning` and `pm`/`Planning` mint different ids and are
+/// genuinely different rooms — without the `Custom("engineer-planning")` name
+/// mangling that gave the live palace twelve ad-hoc labels. This is the write
+/// half of the wing axis; [`resolve_or_create_room`] is this function pinned to
+/// the default wing, which is what every pre-T9 caller gets.
+/// What: as [`resolve_or_create_room`], but keyed on `wing_id`.
+///
+/// Fail-open on the DEFAULT wing only: the legacy fold is a default-wing id by
+/// construction, so falling back to it for a non-default wing would silently
+/// drop the drawer into the default scope — a scope leak. A non-default wing
+/// therefore falls back to a minted id, which keeps the write inside its wing
+/// even when the registry is unwritable.
+/// Test: `wing_scoped_recall_returns_only_that_wing`,
+/// `unscoped_write_still_lands_in_the_default_wing`.
+pub async fn resolve_or_create_room_in_wing(
+    kg: &KnowledgeGraph,
+    room: &RoomType,
+    wing_id: Uuid,
+) -> Uuid {
     let store = kg.store();
     let room = room.clone();
-    let fallback = room_to_uuid(&room);
-    let joined =
-        tokio::task::spawn_blocking(move || resolve_or_create_room_sync(&store, &room)).await;
+    let fallback = if wing_id == DEFAULT_WING_ID {
+        room_to_uuid(&room)
+    } else {
+        mint_room_id(&canonical_room_key(wing_id, &room_label(&room)))
+    };
+    let joined = tokio::task::spawn_blocking(move || {
+        resolve_or_create_room_in_wing_sync(&store, &room, wing_id)
+    })
+    .await;
     match joined {
         Ok(Ok(id)) => id,
         Ok(Err(e)) => {
@@ -199,12 +230,27 @@ pub async fn resolve_or_create_room(kg: &KnowledgeGraph, room: &RoomType) -> Uui
 /// id rather than our own.
 /// Test: `resolve_or_create_is_idempotent`.
 pub fn resolve_or_create_room_sync(store: &Arc<KgStoreRedb>, room: &RoomType) -> Result<Uuid> {
-    let key = default_wing_key(room);
+    resolve_or_create_room_in_wing_sync(store, room, DEFAULT_WING_ID)
+}
+
+/// Blocking half of [`resolve_or_create_room_in_wing`].
+///
+/// Why/What: as [`resolve_or_create_room_sync`], but the canonical key carries
+/// `wing_id` instead of the default wing, and the stored row records the same
+/// wing so `rooms_in_wing` can find it.
+/// Test: `wing_scoped_recall_returns_only_that_wing`.
+pub fn resolve_or_create_room_in_wing_sync(
+    store: &Arc<KgStoreRedb>,
+    room: &RoomType,
+    wing_id: Uuid,
+) -> Result<Uuid> {
+    let key = canonical_room_key(wing_id, &room_label(room));
     if let Some(id) = store.lookup_room_id(&key)? {
         return Ok(id);
     }
     let id = mint_room_id(&key);
-    let record = RoomRecord::new(room, chrono::Utc::now().timestamp_millis(), true);
+    let mut record = RoomRecord::new(room, chrono::Utc::now().timestamp_millis(), true);
+    record.wing_id = *wing_id.as_bytes();
     store
         .insert_room_if_absent(id, &key, &record)
         .with_context(|| format!("register room {:?}", record.label))?;

--- a/crates/trusty-common/src/memory_core/store/wings.rs
+++ b/crates/trusty-common/src/memory_core/store/wings.rs
@@ -1,0 +1,395 @@
+//! Wing registry records, default-wing seeding, and the wing entry points.
+//!
+//! Why (ADR-0027 D2): a Wing is the scope/ownership axis — "who" — as opposed
+//! to a Room's topic axis — "what". It is what lets `engineer/Planning` and
+//! `pm/Planning` be two rooms without name mangling, and it is where #3064's
+//! "two agent types cannot accidentally read/write the same room unless
+//! configured to do so" will eventually hang its configuration. This module
+//! owns the on-disk row shape and every policy decision about wings.
+//!
+//! **Migration posture — naming, never reclassification.** Placing existing
+//! rooms in the default wing requires writing nothing to `ROOMS` at all:
+//! `RoomRecord::wing_id` has carried [`DEFAULT_WING_ID`] since ADR-0027 T1, so
+//! the entire migration is inserting ONE row describing a wing that every room
+//! already points at. Zero drawer rows change and zero room ids are rewritten,
+//! and that is proven byte-for-byte rather than asserted (see
+//! `seeding_the_default_wing_changes_no_room_or_drawer_rows`).
+//!
+//! **Wing is never required of a caller** (ADR-0027 D2). Every palace gets a
+//! default wing, every room defaults into it, and no pre-existing call site
+//! gains an argument. A caller who never mentions a wing behaves exactly as it
+//! did before this module existed.
+//!
+//! Storage note: the tables live in the palace's `kg.db` beside `ROOMS` and
+//! `DRAWERS`, NOT in a JSON sidecar, for the corruption-recovery reason spelled
+//! out in ADR-0027 D1.1 — wings, rooms, and drawers corrupt and recover as one
+//! unit.
+//!
+//! Test: `wings_tests.rs`.
+
+use crate::memory_core::room_identity::DEFAULT_WING_ID;
+use crate::memory_core::store::kg::KnowledgeGraph;
+use crate::memory_core::store::kg_redb::KgStoreRedb;
+use crate::memory_core::wing_identity::{
+    DEFAULT_WING_LABEL, canonical_wing_key, default_wing_key, mint_wing_id,
+};
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Schema version stamped into the `WINGS` marker row.
+///
+/// Bump only when the *meaning* of existing rows changes; appending a trailing
+/// optional field does not qualify (the decode chain handles that).
+pub const WING_SCHEMA_VERSION: u32 = 1;
+
+/// On-disk wing row.
+///
+/// Why: field order is load-bearing — postcard is positional, so a new field is
+/// APPENDED and old bytes are recovered through a fallback chain exactly as
+/// `DrawerRecord` and `RoomRecord` already do. Never insert a field in the
+/// middle.
+///
+/// Deliberately minimal: ADR-0027 D2 names a Wing as the eventual anchor for
+/// #3064's per-wing access configuration, but no such field is reserved here.
+/// The trailing-optional evolution pattern IS the mechanism that keeps it
+/// satisfiable later — adding `access: Option<…>` then costs no migration —
+/// and a field nothing reads is the exact defect this ADR exists to correct.
+///
+/// What: the first-seen display spelling, the creation stamp, and an optional
+/// human description.
+/// Test: `wing_record_round_trip`, `wing_record_decodes_under_a_future_field`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WingRecord {
+    /// First-seen display spelling, e.g. `"default"`, `"engineer"`, `"pm"`.
+    pub label: String,
+    pub created_at_ms: i64,
+    pub description: Option<String>,
+}
+
+/// Schema-version marker stored under the nil-UUID key in `WINGS`.
+///
+/// Why/What: mirrors `RoomSchemaMarker` — it lets a future migration recognise
+/// which shape wrote these rows. Seeding idempotency does NOT depend on it; it
+/// comes from the by-id existence probe, which is the stronger guarantee
+/// because it also preserves a rename.
+/// Test: `default_wing_is_seeded_once`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WingSchemaMarker {
+    pub schema_version: u32,
+}
+
+/// A decoded wing row plus its id and room population — the read-side view.
+#[derive(Debug, Clone, PartialEq)]
+pub struct WingSummary {
+    pub id: Uuid,
+    pub label: String,
+    pub created_at_ms: i64,
+    pub description: Option<String>,
+    /// How many `ROOMS` rows name this wing.
+    pub room_count: usize,
+    /// Whether this is the palace's default wing — the one every room falls
+    /// into when a caller names none.
+    pub is_default: bool,
+}
+
+impl WingRecord {
+    /// Build a record for `label` with the current timestamp.
+    pub fn new(label: impl Into<String>, created_at_ms: i64, description: Option<String>) -> Self {
+        Self {
+            label: label.into(),
+            created_at_ms,
+            description,
+        }
+    }
+
+    /// Pair this row with its id and room population for the read surface.
+    pub fn summarize(&self, id: Uuid, room_count: usize) -> WingSummary {
+        WingSummary {
+            id,
+            label: self.label.clone(),
+            created_at_ms: self.created_at_ms,
+            description: self.description.clone(),
+            room_count,
+            is_default: id == DEFAULT_WING_ID,
+        }
+    }
+}
+
+/// Reject a wing label that cannot address a wing.
+///
+/// Why: an empty or whitespace-only label normalises to an empty canonical
+/// key, which would alias every other empty-labelled create into one wing and
+/// produce a wing nobody can name. Failing loud at the boundary is cheaper
+/// than a silently-merged scope.
+/// What: trims; errors when the result is empty.
+/// Test: `wing_create_rejects_a_blank_label`.
+pub fn normalize_wing_label(label: &str) -> Result<String> {
+    let trimmed = label.trim();
+    if trimmed.is_empty() {
+        bail!("wing label must not be empty");
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Seed the palace's default wing if it does not already exist.
+///
+/// Why (ADR-0027 D2): every palace gets a default wing so that "wing" is never
+/// a required concept for a caller. This is the whole wing migration — because
+/// `RoomRecord::wing_id` has been [`DEFAULT_WING_ID`] since T1, no room row and
+/// no drawer row needs to change for existing rooms to be *in* this wing. They
+/// are named, not reclassified.
+/// What: probes `WINGS` **by id**, and inserts the row plus its canonical key
+/// only when absent. Probing by id rather than by key is what lets a renamed
+/// default wing keep its new name — a key probe would resurrect `"default"` as
+/// an alias on the next open. Returns `true` when a row was written.
+///
+/// **An already-seeded palace is left entirely alone**, schema marker included:
+/// this function returns before reaching the stamp, so opening a palace costs
+/// one read transaction and no write. That is deliberate rather than an
+/// oversight — see `set_wing_schema_version`'s call contract. Seeding is not a
+/// migration, so it must never restamp a marker over rows it did not convert;
+/// a future [`WING_SCHEMA_VERSION`] bump needs a real migration pass that
+/// converts the rows and stamps the new version itself.
+/// Test: `default_wing_is_seeded_once`, `wing_rename_survives_reseed`,
+/// `seeding_the_default_wing_changes_no_room_or_drawer_rows`,
+/// `reseeding_does_not_restamp_the_schema_version`.
+pub fn ensure_default_wing(kg: &KnowledgeGraph) -> Result<bool> {
+    let store = kg.store();
+    if store
+        .get_wing(DEFAULT_WING_ID)
+        .context("probe default wing row")?
+        .is_some()
+    {
+        return Ok(false);
+    }
+    let record = WingRecord::new(
+        DEFAULT_WING_LABEL,
+        chrono::Utc::now().timestamp_millis(),
+        Some("Default scope — every room a caller does not place lands here.".to_string()),
+    );
+    // The id is written VERBATIM, never minted: every room row already carries
+    // DEFAULT_WING_ID, so this is the same "ids are read from the table"
+    // discipline that keeps legacy room ids intact (ADR-0027 D1.3).
+    let inserted = store
+        .insert_wing_if_absent(DEFAULT_WING_ID, &default_wing_key(), &record)
+        .context("seed default wing")?;
+    if inserted {
+        store
+            .set_wing_schema_version()
+            .context("stamp wing schema version")?;
+    }
+    Ok(inserted)
+}
+
+/// Seed the default wing, swallowing every failure.
+///
+/// Why (ADR-0027 D1.4, mirroring `backfill_rooms_fail_open`): a palace whose
+/// wing registry cannot be written must still open. The cost of failing open is
+/// that `wing_list` is empty until the next successful open; the cost of
+/// failing closed is an unopenable palace. A read-only (snapshot) palace takes
+/// this path every time and that is correct — it has nothing to write to.
+/// What: calls [`ensure_default_wing`] and logs any error at `warn!`.
+/// Test: `fail_open_seeding_creates_the_default_wing`.
+pub fn ensure_default_wing_fail_open(palace_id: &str, kg: &KnowledgeGraph) {
+    if kg.is_read_only() {
+        return;
+    }
+    match ensure_default_wing(kg) {
+        Ok(true) => tracing::info!(
+            palace = palace_id,
+            "seeded default wing (no room or drawer rows touched)"
+        ),
+        Ok(false) => {}
+        Err(e) => tracing::warn!(
+            palace = palace_id,
+            "default wing seeding failed, wing listing degraded: {e:#}"
+        ),
+    }
+}
+
+/// Resolve a caller-supplied wing selector to a wing id.
+///
+/// Why: an MCP caller has a string, not a `Uuid`, and may reasonably hold
+/// either a wing id echoed back from `wing_list` or the label a human typed.
+/// Accepting both means neither surface has to teach the other's format.
+/// What: tries `selector` as a UUID that has a `WINGS` row first, then as a
+/// canonical label. `Ok(None)` means "no such wing" — a caller-facing
+/// condition, not an error.
+/// Test: `wing_selector_accepts_id_or_label`.
+pub fn resolve_wing_selector(kg: &KnowledgeGraph, selector: &str) -> Result<Option<Uuid>> {
+    let store = kg.store();
+    if let Ok(id) = Uuid::parse_str(selector.trim())
+        && store.get_wing(id).context("probe wing by id")?.is_some()
+    {
+        return Ok(Some(id));
+    }
+    store
+        .lookup_wing_id(&canonical_wing_key(selector))
+        .context("look up wing by label")
+}
+
+/// Every registered wing with its room population, id-ordered.
+///
+/// Why: the discovery primitive behind `wing_list`. Without it the `WINGS`
+/// table would be exactly the dark level ADR-0027 exists to stop shipping.
+/// What: joins `list_wings` against `list_rooms`, counting rooms per wing in
+/// one pass rather than re-scanning per wing.
+/// Test: `wing_list_reports_seeded_and_created_wings`,
+/// `wing_list_counts_rooms_per_wing`.
+pub fn list_wings(kg: &KnowledgeGraph) -> Result<Vec<WingSummary>> {
+    let store = kg.store();
+    let rooms = store.list_rooms().context("list rooms for wing counts")?;
+    store
+        .list_wings()
+        .context("list wings")?
+        .into_iter()
+        .map(|(id, record)| {
+            let count = rooms
+                .iter()
+                .filter(|(_, r)| Uuid::from_bytes(r.wing_id) == id)
+                .count();
+            Ok(record.summarize(id, count))
+        })
+        .collect()
+}
+
+/// The set of room ids belonging to `wing_id`.
+///
+/// Why: wing-scoped recall is "every room this wing owns", and the drawer table
+/// stores only `room_id`. This is the join that turns a scope into a filter.
+/// What: scans `ROOMS` and collects the ids whose row names `wing_id`.
+///
+/// A drawer whose room has no `ROOMS` row yet is NOT in any wing and is
+/// therefore excluded from every wing-scoped read. That case is transient: the
+/// room backfill (ADR-0027 T2) registers every observed `room_id` at palace
+/// open, before any query can run against the handle.
+/// Test: `rooms_in_wing_separates_same_named_rooms`.
+pub fn rooms_in_wing(kg: &KnowledgeGraph, wing_id: Uuid) -> Result<HashSet<Uuid>> {
+    Ok(kg
+        .store()
+        .list_rooms()
+        .context("list rooms for wing scope")?
+        .into_iter()
+        .filter(|(_, r)| Uuid::from_bytes(r.wing_id) == wing_id)
+        .map(|(id, _)| id)
+        .collect())
+}
+
+/// Resolve `label` to a wing id, creating the wing when absent.
+///
+/// Why: this is `wing_create`'s core, and it is idempotent by construction —
+/// creating a wing that exists returns the existing id rather than a second
+/// wing, so a caller can call it unconditionally.
+/// What: looks the canonical key up; on a hit returns the stored id verbatim;
+/// on a miss mints a UUIDv5 and inserts the row and key in one transaction.
+/// Returns `(id, created)`.
+///
+/// Unlike the room write path this does NOT fail open. A room resolution
+/// failure must never fail a memory write, so it degrades to the legacy fold;
+/// a wing create has no such caller — it is an explicit operation whose only
+/// sensible failure mode is telling the caller it failed.
+/// Test: `wing_create_is_idempotent`, `wing_create_returns_the_default_wing`.
+pub fn resolve_or_create_wing_sync(store: &Arc<KgStoreRedb>, label: &str) -> Result<(Uuid, bool)> {
+    let label = normalize_wing_label(label)?;
+    let key = canonical_wing_key(&label);
+    if let Some(id) = store.lookup_wing_id(&key).context("look up wing key")? {
+        return Ok((id, false));
+    }
+    let id = mint_wing_id(&key);
+    let record = WingRecord::new(label.clone(), chrono::Utc::now().timestamp_millis(), None);
+    let inserted = store
+        .insert_wing_if_absent(id, &key, &record)
+        .with_context(|| format!("register wing {label:?}"))?;
+    // `insert_wing_if_absent` probes and inserts inside ONE write transaction,
+    // and redb allows a single writer at a time, so the key is guaranteed
+    // present once it returns: either this call inserted it or an earlier one
+    // did. The re-read therefore reports which writer won rather than guarding
+    // a partial write, and `unwrap_or(id)` is unreachable in practice.
+    //
+    // A racer cannot diverge here anyway: the id is `mint_wing_id(&key)`, a
+    // UUIDv5 of the same key, so two concurrent creates of the same label
+    // compute the SAME id. The race is benign by construction — which is why
+    // this returns a `created` flag rather than an error.
+    let winner = store
+        .lookup_wing_id(&key)
+        .context("re-read wing key")?
+        .unwrap_or(id);
+    Ok((winner, inserted && winner == id))
+}
+
+/// Async wrapper over [`resolve_or_create_wing_sync`].
+///
+/// Why: the redb work is blocking and every MCP handler is async, so the write
+/// runs on the blocking pool — the same posture `resolve_or_create_room` takes.
+/// Test: `wing_create_is_idempotent` covers the sync core.
+pub async fn resolve_or_create_wing(kg: &KnowledgeGraph, label: &str) -> Result<(Uuid, bool)> {
+    let store = kg.store();
+    let label = label.to_string();
+    tokio::task::spawn_blocking(move || resolve_or_create_wing_sync(&store, &label))
+        .await
+        .context("join wing create")?
+}
+
+/// Rename a wing, retiring its old label.
+///
+/// Why: this is the repair path — and the reason the seeding pass probes by id.
+/// A wing's *id* is what every `RoomRecord` references, so renaming the label
+/// cannot move a room and provably cannot touch a drawer.
+/// What: validates the new label, refuses a label another wing already holds,
+/// then applies the row rewrite, the new key, and the old key's retirement in
+/// ONE redb write transaction so the previous name stops resolving (a rename,
+/// not an alias). Never touches `ROOMS` or `DRAWERS`.
+///
+/// Atomicity is load-bearing, not incidental: if the old-key removal could
+/// commit separately, a crash between the two commits would leave the retired
+/// label resolving to the renamed wing forever. In a scope mechanism that is a
+/// leak, not cosmetic drift — which is why it is a single transaction.
+/// Test: `wing_rename_changes_no_room_or_drawer_rows`,
+/// `wing_rename_retires_the_old_label`, `wing_rename_rejects_a_taken_label`,
+/// `wing_rename_survives_reseed`, `wing_rename_applies_every_effect_together`.
+pub fn rename_wing_sync(
+    store: &Arc<KgStoreRedb>,
+    id: Uuid,
+    new_label: &str,
+) -> Result<WingSummary> {
+    let new_label = normalize_wing_label(new_label)?;
+    let new_key = canonical_wing_key(&new_label);
+    // Existence, uniqueness, and every write happen inside ONE transaction in
+    // `rename_wing_in_place`. Probing here first would reintroduce the race it
+    // exists to close: a concurrent `resolve_or_create_wing_sync` claiming
+    // `new_key` between the check and the write.
+    let renamed = store
+        .rename_wing_in_place(id, &new_key, &new_label)
+        .context("write renamed wing")?;
+    let room_count = rooms_in_wing_from(store, id)?;
+    Ok(renamed.summarize(id, room_count))
+}
+
+/// Async wrapper over [`rename_wing_sync`].
+pub async fn rename_wing(kg: &KnowledgeGraph, id: Uuid, new_label: &str) -> Result<WingSummary> {
+    let store = kg.store();
+    let new_label = new_label.to_string();
+    tokio::task::spawn_blocking(move || rename_wing_sync(&store, id, &new_label))
+        .await
+        .context("join wing rename")?
+}
+
+/// Room population of `wing_id`, counted straight off the store.
+///
+/// Why: `rename_wing_sync` already holds an `Arc<KgStoreRedb>` and has no
+/// `KnowledgeGraph` to hand, so it cannot call [`rooms_in_wing`].
+fn rooms_in_wing_from(store: &Arc<KgStoreRedb>, wing_id: Uuid) -> Result<usize> {
+    Ok(store
+        .list_rooms()
+        .context("list rooms for wing count")?
+        .iter()
+        .filter(|(_, r)| Uuid::from_bytes(r.wing_id) == wing_id)
+        .count())
+}
+
+#[cfg(test)]
+#[path = "wings_tests.rs"]
+mod tests;

--- a/crates/trusty-common/src/memory_core/store/wings_tests.rs
+++ b/crates/trusty-common/src/memory_core/store/wings_tests.rs
@@ -1,0 +1,506 @@
+//! ADR-0027 T9 wing registry: seeding safety, idempotency, create, rename.
+//!
+//! Why: three safety properties carry the wing half of ADR-0027 and must be
+//! proven, not asserted — (1) placing existing rooms in the default wing
+//! changes ZERO drawer rows AND ZERO room rows, (2) seeding is idempotent so a
+//! rename survives every reopen, and (3) a caller who never mentions a wing is
+//! unaffected. Everything else round-trips create / rename / list.
+//! What: unit tests over a real redb-backed `KnowledgeGraph` in a tempdir.
+//! Test: this file.
+
+use super::*;
+use crate::memory_core::palace::{Drawer, RoomType};
+use crate::memory_core::room_identity::room_to_uuid;
+use crate::memory_core::store::kg::KnowledgeGraph;
+use crate::memory_core::store::kg_store::{decode_value, encode_value};
+use crate::memory_core::store::room_backfill::backfill_rooms;
+use crate::memory_core::store::rooms::{RoomRecord, resolve_or_create_room_sync};
+use crate::memory_core::wing_identity::mint_wing_id;
+use tempfile::TempDir;
+
+fn open_kg() -> (TempDir, KnowledgeGraph) {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let kg = KnowledgeGraph::open(&dir.path().join("kg.db")).expect("open kg");
+    (dir, kg)
+}
+
+/// Write one drawer sitting in the LEGACY id for `room` — i.e. exactly what
+/// every pre-ADR-0027 write produced — then register it the way palace open
+/// does. This reproduces the real starting state a wing migration meets.
+fn seed_legacy_room(kg: &KnowledgeGraph, room: &RoomType) -> Drawer {
+    let drawer = Drawer::new(room_to_uuid(room), "legacy content");
+    kg.upsert_drawer_sync(&drawer).expect("upsert drawer");
+    drawer
+}
+
+// ── Record shape ─────────────────────────────────────────────────────────
+
+/// Simulates the NEXT schema revision — the mechanism ADR-0027 D2 relies on
+/// for hanging #3064's per-wing access configuration without a migration.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct FutureWingRecord {
+    label: String,
+    created_at_ms: i64,
+    description: Option<String>,
+    /// The hypothetical new field.
+    access: Option<String>,
+}
+
+#[test]
+fn wing_record_round_trip() {
+    let r = WingRecord::new("engineer", 1_700_000_000_000, Some("owns impl".into()));
+    let bytes = encode_value(&r).expect("encode");
+    let back: WingRecord = decode_value(&bytes).expect("decode");
+    assert_eq!(r, back);
+    assert_eq!(back.label, "engineer");
+}
+
+#[test]
+fn wing_record_decodes_under_a_future_field() {
+    // Postcard is positional, so the naive future decode MUST fail — the
+    // fallback chain in `decode_wing_record` is what carries old rows forward,
+    // exactly as `RoomRecord` and `DrawerRecord` already do.
+    let bytes = encode_value(&WingRecord::new("pm", 1, None)).expect("encode");
+    assert!(
+        decode_value::<FutureWingRecord>(&bytes).is_err(),
+        "postcard is positional: the naive future decode must fail"
+    );
+    let migrated: WingRecord = decode_value(&bytes).expect("fallback to current shape");
+    assert_eq!(migrated.label, "pm");
+}
+
+// ── Safety property 1: seeding rewrites nothing ──────────────────────────
+
+#[test]
+fn seeding_the_default_wing_changes_no_room_or_drawer_rows() {
+    // The headline migration guarantee, carried onto the wing axis: existing
+    // rooms land in the default wing by NAMING, never reclassification.
+    // Byte-level snapshots on BOTH tables — a decoded comparison could mask a
+    // rewrite that round-trips to the same value.
+    let (_d, kg) = open_kg();
+    let rooms = [
+        RoomType::General,
+        RoomType::Planning,
+        RoomType::Custom("status".to_string()),
+        RoomType::Custom("decisions".to_string()),
+    ];
+    let drawers: Vec<Drawer> = rooms.iter().map(|r| seed_legacy_room(&kg, r)).collect();
+    backfill_rooms(&kg, &drawers).expect("room backfill");
+
+    let drawers_before = kg
+        .store()
+        .raw_drawer_rows()
+        .expect("drawer snapshot before");
+    let rooms_before = kg.store().raw_room_rows().expect("room snapshot before");
+    assert_eq!(drawers_before.len(), rooms.len());
+    assert!(!rooms_before.is_empty());
+
+    assert!(ensure_default_wing(&kg).expect("seed"), "wrote a wing row");
+
+    let drawers_after = kg.store().raw_drawer_rows().expect("drawer snapshot after");
+    let rooms_after = kg.store().raw_room_rows().expect("room snapshot after");
+    assert_eq!(
+        drawers_before, drawers_after,
+        "seeding must not touch a single DRAWERS byte"
+    );
+    assert_eq!(
+        rooms_before, rooms_after,
+        "seeding must not touch a single ROOMS byte — no room id is rewritten"
+    );
+
+    // And every pre-existing room is genuinely IN the default wing already.
+    let scoped = rooms_in_wing(&kg, DEFAULT_WING_ID).expect("scope");
+    for drawer in &drawers {
+        assert!(
+            scoped.contains(&drawer.room_id),
+            "legacy room {} must already belong to the default wing",
+            drawer.room_id
+        );
+    }
+}
+
+// ── Safety property 2: idempotent, and a rename survives ─────────────────
+
+#[test]
+fn default_wing_is_seeded_once() {
+    let (_d, kg) = open_kg();
+    assert_eq!(kg.store().wing_schema_version().expect("version"), None);
+    assert!(ensure_default_wing(&kg).expect("first"), "first seeds");
+    assert_eq!(
+        kg.store().wing_schema_version().expect("version"),
+        Some(WING_SCHEMA_VERSION)
+    );
+    assert!(
+        !ensure_default_wing(&kg).expect("second"),
+        "second is a no-op"
+    );
+
+    let wings = list_wings(&kg).expect("list");
+    assert_eq!(wings.len(), 1);
+    assert_eq!(wings[0].id, DEFAULT_WING_ID);
+    assert_eq!(wings[0].label, "default");
+    assert!(wings[0].is_default);
+    // The marker row must never surface as a wing.
+    assert!(wings.iter().all(|w| !w.id.is_nil()));
+}
+
+#[test]
+fn wing_rename_survives_reseed() {
+    // The prompt's idempotency bar: run twice, and a wing renamed between runs
+    // keeps its new name. Seeding probes by ID, so it cannot resurrect either
+    // the old label or the old key.
+    let (_d, kg) = open_kg();
+    ensure_default_wing(&kg).expect("seed");
+    let renamed = rename_wing_sync(&kg.store(), DEFAULT_WING_ID, "platform").expect("rename");
+    assert_eq!(renamed.label, "platform");
+
+    assert!(!ensure_default_wing(&kg).expect("reseed"), "no second row");
+    let wings = list_wings(&kg).expect("list");
+    assert_eq!(wings.len(), 1, "still exactly one wing");
+    assert_eq!(wings[0].label, "platform", "the rename survived");
+    assert_eq!(wings[0].id, DEFAULT_WING_ID, "the id never moved");
+    assert_eq!(
+        resolve_wing_selector(&kg, "default").expect("selector"),
+        None,
+        "the retired label must not resurrect as an alias"
+    );
+}
+
+#[test]
+fn wing_insert_is_insert_only() {
+    let (_d, kg) = open_kg();
+    let id = Uuid::from_u128(42);
+    let key = canonical_wing_key("engineer");
+    let first = WingRecord::new("engineer", 1, None);
+    assert!(kg.store().insert_wing_if_absent(id, &key, &first).unwrap());
+    let second = WingRecord::new("SOMETHING ELSE", 2, None);
+    assert!(
+        !kg.store().insert_wing_if_absent(id, &key, &second).unwrap(),
+        "a second insert under the same id reports no write"
+    );
+    assert_eq!(kg.store().get_wing(id).unwrap().unwrap().label, "engineer");
+}
+
+// ── Safety property 3: a caller who never names a wing is unaffected ─────
+
+#[test]
+fn seeding_leaves_room_resolution_byte_identical() {
+    // "Wing is never a required concept for a caller" (ADR-0027 D2). A write
+    // that names no wing must resolve to the SAME room id before and after the
+    // wing registry exists — including for a legacy room, whose id must stay
+    // the fold value its drawers already carry.
+    let (_d, kg) = open_kg();
+    let legacy = RoomType::Custom("work".to_string());
+    let drawer = seed_legacy_room(&kg, &legacy);
+    backfill_rooms(&kg, std::slice::from_ref(&drawer)).expect("room backfill");
+
+    let legacy_before = resolve_or_create_room_sync(&kg.store(), &legacy).expect("before");
+    let fresh_before = resolve_or_create_room_sync(&kg.store(), &RoomType::Planning).expect("b2");
+
+    ensure_default_wing(&kg).expect("seed");
+
+    assert_eq!(
+        resolve_or_create_room_sync(&kg.store(), &legacy).expect("after"),
+        legacy_before,
+        "a legacy room's id must not move when wings appear"
+    );
+    assert_eq!(legacy_before, room_to_uuid(&legacy), "still the fold value");
+    assert_eq!(
+        resolve_or_create_room_sync(&kg.store(), &RoomType::Planning).expect("a2"),
+        fresh_before,
+        "a wing-less room resolution is unchanged by seeding"
+    );
+}
+
+#[test]
+fn fail_open_seeding_creates_the_default_wing() {
+    // The fail-open wrapper the registry hook calls. A read-only (snapshot)
+    // palace returns early inside it and has nothing to write to; a writable
+    // one seeds exactly one wing.
+    let (_d, kg) = open_kg();
+    ensure_default_wing_fail_open("empty-palace", &kg);
+    assert_eq!(list_wings(&kg).expect("list").len(), 1);
+}
+
+// ── wing_create ──────────────────────────────────────────────────────────
+
+#[test]
+fn wing_create_is_idempotent() {
+    let (_d, kg) = open_kg();
+    let store = kg.store();
+    let (a, created_a) = resolve_or_create_wing_sync(&store, "engineer").expect("first");
+    let (b, created_b) = resolve_or_create_wing_sync(&store, "Engineer").expect("second");
+    assert_eq!(a, b, "case variants are one wing");
+    assert!(created_a, "the first call created it");
+    assert!(!created_b, "the second did not");
+    assert_eq!(a, mint_wing_id(&canonical_wing_key("engineer")));
+    assert_eq!(store.get_wing(a).unwrap().unwrap().label, "engineer");
+    assert_eq!(store.list_wings().unwrap().len(), 1);
+}
+
+#[test]
+fn wing_create_returns_the_default_wing() {
+    // Creating "default" must return DEFAULT_WING_ID — the id every room row
+    // already carries — not a freshly minted one. This is why seeding runs at
+    // palace open, before any caller can reach `wing_create`.
+    let (_d, kg) = open_kg();
+    ensure_default_wing(&kg).expect("seed");
+    let (id, created) = resolve_or_create_wing_sync(&kg.store(), "default").expect("create");
+    assert_eq!(id, DEFAULT_WING_ID);
+    assert!(!created);
+    assert_ne!(id, mint_wing_id(&canonical_wing_key("default")));
+}
+
+#[test]
+fn wing_create_rejects_a_blank_label() {
+    let (_d, kg) = open_kg();
+    for blank in ["", "   ", "\t"] {
+        assert!(
+            resolve_or_create_wing_sync(&kg.store(), blank).is_err(),
+            "blank label {blank:?} must be rejected"
+        );
+    }
+    assert!(kg.store().list_wings().unwrap().is_empty());
+}
+
+// ── wing_rename ──────────────────────────────────────────────────────────
+
+#[test]
+fn wing_rename_changes_no_room_or_drawer_rows() {
+    // A wing rename cannot move a room: rooms reference a wing by ID, and the
+    // id is unchanged. Proven byte-for-byte on both tables.
+    let (_d, kg) = open_kg();
+    let drawer = seed_legacy_room(&kg, &RoomType::Planning);
+    backfill_rooms(&kg, std::slice::from_ref(&drawer)).expect("room backfill");
+    ensure_default_wing(&kg).expect("seed");
+
+    let drawers_before = kg.store().raw_drawer_rows().expect("drawers before");
+    let rooms_before = kg.store().raw_room_rows().expect("rooms before");
+
+    rename_wing_sync(&kg.store(), DEFAULT_WING_ID, "platform").expect("rename");
+
+    assert_eq!(drawers_before, kg.store().raw_drawer_rows().unwrap());
+    assert_eq!(rooms_before, kg.store().raw_room_rows().unwrap());
+    // The room is still in the (now renamed) wing.
+    assert!(
+        rooms_in_wing(&kg, DEFAULT_WING_ID)
+            .unwrap()
+            .contains(&drawer.room_id)
+    );
+}
+
+#[test]
+fn reseeding_does_not_restamp_the_schema_version() {
+    // `set_wing_schema_version` is an unconditional overwrite, so seeding must
+    // never reach it on an already-seeded palace: restamping a bumped version
+    // over rows nothing migrated would erase the only evidence they still need
+    // migrating. Byte-level snapshot, because a marker rewritten to the SAME
+    // version is still a write and a decoded compare would not see it.
+    let (_d, kg) = open_kg();
+    assert!(ensure_default_wing(&kg).expect("first"));
+    let before = kg.store().raw_wing_rows().expect("snapshot before");
+    assert!(
+        before.iter().any(|(k, _)| k.iter().all(|b| *b == 0)),
+        "the marker row must be present after the first seed"
+    );
+
+    assert!(!ensure_default_wing(&kg).expect("second"), "no second row");
+    assert_eq!(
+        before,
+        kg.store().raw_wing_rows().expect("snapshot after"),
+        "re-seeding must not write a single WINGS byte"
+    );
+}
+
+#[test]
+fn wing_rename_applies_every_effect_together() {
+    // The three effects of a rename — row label, new key, retired old key —
+    // are applied in ONE redb write transaction (see `rename_wing_in_place`),
+    // so no crash can land some and not others. This pins the combined
+    // postcondition; the atomicity itself is a property of the single
+    // begin_write/commit pair in that method.
+    let (_d, kg) = open_kg();
+    let (id, _) = resolve_or_create_wing_sync(&kg.store(), "engineer").expect("create");
+    rename_wing_sync(&kg.store(), id, "platform").expect("rename");
+
+    assert_eq!(kg.store().get_wing(id).unwrap().unwrap().label, "platform");
+    assert_eq!(
+        kg.store()
+            .lookup_wing_id(&canonical_wing_key("platform"))
+            .unwrap(),
+        Some(id),
+        "the new label must resolve"
+    );
+    assert_eq!(
+        kg.store()
+            .lookup_wing_id(&canonical_wing_key("engineer"))
+            .unwrap(),
+        None,
+        "the old key must be gone — a rename, not an alias"
+    );
+}
+
+#[test]
+fn wing_rename_retires_the_old_label() {
+    let (_d, kg) = open_kg();
+    let (id, _) = resolve_or_create_wing_sync(&kg.store(), "engineer").expect("create");
+    rename_wing_sync(&kg.store(), id, "Platform").expect("rename");
+
+    assert_eq!(resolve_wing_selector(&kg, "engineer").unwrap(), None);
+    assert_eq!(resolve_wing_selector(&kg, "platform").unwrap(), Some(id));
+    assert_eq!(
+        kg.store().get_wing(id).unwrap().unwrap().label,
+        "Platform",
+        "the chosen capitalisation is kept"
+    );
+    // A rename is not a create: still exactly one wing.
+    assert_eq!(kg.store().list_wings().unwrap().len(), 1);
+}
+
+#[test]
+fn wing_rename_rejects_a_taken_label() {
+    let (_d, kg) = open_kg();
+    let (a, _) = resolve_or_create_wing_sync(&kg.store(), "engineer").expect("a");
+    let (b, _) = resolve_or_create_wing_sync(&kg.store(), "pm").expect("b");
+    let err = rename_wing_sync(&kg.store(), a, "PM").expect_err("must refuse");
+    // `{:#}` walks the anyhow chain — the refusal is raised inside the storage
+    // transaction and wrapped by the caller's context.
+    let msg = format!("{err:#}");
+    assert!(msg.contains("already used"), "{msg}");
+    // Nothing moved.
+    assert_eq!(resolve_wing_selector(&kg, "pm").unwrap(), Some(b));
+    assert_eq!(resolve_wing_selector(&kg, "engineer").unwrap(), Some(a));
+}
+
+#[test]
+fn wing_rename_to_the_same_label_is_harmless() {
+    let (_d, kg) = open_kg();
+    let (id, _) = resolve_or_create_wing_sync(&kg.store(), "engineer").expect("create");
+    let s = rename_wing_sync(&kg.store(), id, "Engineer").expect("recase");
+    assert_eq!(s.label, "Engineer");
+    assert_eq!(
+        resolve_wing_selector(&kg, "engineer").unwrap(),
+        Some(id),
+        "the key is unchanged, so it must not have been retired"
+    );
+}
+
+#[test]
+fn wing_rename_rejects_an_unknown_wing() {
+    let (_d, kg) = open_kg();
+    assert!(rename_wing_sync(&kg.store(), Uuid::from_u128(7), "x").is_err());
+}
+
+#[test]
+fn wing_rename_rejecting_a_taken_label_writes_nothing() {
+    // The uniqueness probe lives INSIDE the write transaction, so a rejected
+    // rename must abort it whole — no half-applied row, no orphaned key. Byte
+    // snapshot, because a row rewritten to the same value is still a write.
+    let (_d, kg) = open_kg();
+    let (a, _) = resolve_or_create_wing_sync(&kg.store(), "engineer").expect("a");
+    resolve_or_create_wing_sync(&kg.store(), "pm").expect("b");
+    let before = kg.store().raw_wing_rows().expect("snapshot before");
+
+    assert!(rename_wing_sync(&kg.store(), a, "PM").is_err());
+
+    assert_eq!(
+        before,
+        kg.store().raw_wing_rows().expect("snapshot after"),
+        "a rejected rename must leave WINGS byte-identical"
+    );
+    assert_eq!(
+        kg.store()
+            .lookup_wing_id(&canonical_wing_key("engineer"))
+            .unwrap(),
+        Some(a),
+        "the original label must still resolve after a rejected rename"
+    );
+}
+
+// ── Listing and scoping ──────────────────────────────────────────────────
+
+#[test]
+fn wing_list_reports_seeded_and_created_wings() {
+    let (_d, kg) = open_kg();
+    ensure_default_wing(&kg).expect("seed");
+    resolve_or_create_wing_sync(&kg.store(), "engineer").expect("create");
+    let wings = list_wings(&kg).expect("list");
+    assert_eq!(wings.len(), 2);
+    let labels: Vec<&str> = wings.iter().map(|w| w.label.as_str()).collect();
+    assert!(labels.contains(&"default"));
+    assert!(labels.contains(&"engineer"));
+    assert_eq!(wings.iter().filter(|w| w.is_default).count(), 1);
+}
+
+#[test]
+fn wing_list_counts_rooms_per_wing() {
+    let (_d, kg) = open_kg();
+    ensure_default_wing(&kg).expect("seed");
+    // Two rooms in the default wing…
+    resolve_or_create_room_sync(&kg.store(), &RoomType::Planning).expect("r1");
+    resolve_or_create_room_sync(&kg.store(), &RoomType::Research).expect("r2");
+    // …and a wing with none.
+    resolve_or_create_wing_sync(&kg.store(), "engineer").expect("wing");
+
+    let wings = list_wings(&kg).expect("list");
+    let default = wings.iter().find(|w| w.is_default).expect("default wing");
+    let engineer = wings.iter().find(|w| w.label == "engineer").expect("wing");
+    assert_eq!(default.room_count, 2);
+    assert_eq!(engineer.room_count, 0);
+}
+
+#[test]
+fn wing_selector_accepts_id_or_label() {
+    let (_d, kg) = open_kg();
+    let (id, _) = resolve_or_create_wing_sync(&kg.store(), "engineer").expect("create");
+    assert_eq!(
+        resolve_wing_selector(&kg, &id.to_string()).unwrap(),
+        Some(id)
+    );
+    assert_eq!(resolve_wing_selector(&kg, "ENGINEER").unwrap(), Some(id));
+    assert_eq!(resolve_wing_selector(&kg, "nope").unwrap(), None);
+    // A well-formed UUID with no row is "no such wing", not an error.
+    assert_eq!(
+        resolve_wing_selector(&kg, &Uuid::from_u128(3).to_string()).unwrap(),
+        None
+    );
+}
+
+#[test]
+fn rooms_in_wing_separates_same_named_rooms() {
+    // ADR-0027 D2 pattern 3: `engineer/Planning` and `pm/Planning` are two
+    // distinct rooms, with no `Custom("engineer-planning")` name mangling.
+    let (_d, kg) = open_kg();
+    let store = kg.store();
+    let (engineer, _) = resolve_or_create_wing_sync(&store, "engineer").expect("w1");
+    let (pm, _) = resolve_or_create_wing_sync(&store, "pm").expect("w2");
+
+    let key_e = crate::memory_core::room_identity::canonical_room_key(engineer, "Planning");
+    let key_p = crate::memory_core::room_identity::canonical_room_key(pm, "Planning");
+    assert_ne!(key_e, key_p, "the wing id is part of the room key");
+
+    let id_e = crate::memory_core::room_identity::mint_room_id(&key_e);
+    let id_p = crate::memory_core::room_identity::mint_room_id(&key_p);
+    assert_ne!(id_e, id_p, "same label, different wings, different rooms");
+
+    let mut rec_e = RoomRecord::new(&RoomType::Planning, 1, true);
+    rec_e.wing_id = *engineer.as_bytes();
+    let mut rec_p = RoomRecord::new(&RoomType::Planning, 1, true);
+    rec_p.wing_id = *pm.as_bytes();
+    store.insert_room_if_absent(id_e, &key_e, &rec_e).unwrap();
+    store.insert_room_if_absent(id_p, &key_p, &rec_p).unwrap();
+
+    assert_eq!(rooms_in_wing(&kg, engineer).unwrap(), HashSet::from([id_e]));
+    assert_eq!(rooms_in_wing(&kg, pm).unwrap(), HashSet::from([id_p]));
+}
+
+#[test]
+fn rooms_in_wing_is_empty_for_an_unknown_wing() {
+    let (_d, kg) = open_kg();
+    ensure_default_wing(&kg).expect("seed");
+    resolve_or_create_room_sync(&kg.store(), &RoomType::Planning).expect("room");
+    assert!(
+        rooms_in_wing(&kg, Uuid::from_u128(99)).unwrap().is_empty(),
+        "an unknown wing owns nothing — it must not fall back to everything"
+    );
+}

--- a/crates/trusty-common/src/memory_core/wing_identity.rs
+++ b/crates/trusty-common/src/memory_core/wing_identity.rs
@@ -1,0 +1,149 @@
+//! Wing identity: canonical keys and id minting for the *scope* axis.
+//!
+//! Why (ADR-0027 D2): a Wing is the "who" axis (scope / ownership) and a Room
+//! is the "what" axis (topic). Separating them is what lets `engineer/Planning`
+//! and `pm/Planning` coexist without the name mangling that gave the live
+//! `trusty-tools` palace twelve ad-hoc labels. This module supplies the two
+//! pure ingredients the `WINGS` table needs — the canonical key a wing label
+//! resolves through, and the UUIDv5 minted for a key that has no row yet.
+//! What: `WING_NAMESPACE`, `DEFAULT_WING_LABEL`, `canonical_wing_key`,
+//! `default_wing_key`, `mint_wing_id`. Deliberately mirrors
+//! [`crate::memory_core::room_identity`] so the two axes have one shape, not
+//! two. No I/O, no redb — every function here is pure and total.
+//!
+//! [`DEFAULT_WING_ID`] itself lives in `room_identity` because `RoomRecord`
+//! reserved it first (ADR-0027 D1.2); it is re-exported here so wing-side call
+//! sites have one import.
+//!
+//! Test: `wing_namespace_matches_its_documented_derivation`,
+//! `canonical_wing_key_is_case_insensitive`, `mint_wing_id_is_stable`,
+//! `default_wing_id_is_not_the_minted_id`.
+
+use uuid::Uuid;
+
+pub use crate::memory_core::room_identity::DEFAULT_WING_ID;
+
+/// UUIDv5 namespace for wing ids.
+///
+/// Why: minting a wing id must be reproducible across processes and machines
+/// without coordination. A namespace distinct from `ROOM_NAMESPACE` means a
+/// wing and a room that happen to share a label can never mint the same id,
+/// so a caller cannot accidentally pass one where the other is expected.
+/// What: `uuid5(NAMESPACE_URL,
+/// "https://github.com/bobmatnyc/trusty-tools/adr-0027/wing-namespace")`,
+/// hardcoded so it needs no lazy global (this workspace forbids those).
+/// Test: `wing_namespace_matches_its_documented_derivation`.
+pub const WING_NAMESPACE: Uuid = Uuid::from_bytes([
+    112, 61, 198, 9, 153, 103, 81, 110, 178, 2, 134, 208, 67, 211, 226, 182,
+]);
+
+/// Display label of the wing every room falls into when nobody names one.
+///
+/// Why (ADR-0027 D2): "Wing is never a required concept for a caller." Every
+/// palace gets this wing, every room defaults into it, and a caller who never
+/// heard of wings sees identical behaviour before and after T9.
+pub const DEFAULT_WING_LABEL: &str = "default";
+
+/// The `WING_KEYS` lookup key for `label`.
+///
+/// Why: same case-folding rule as rooms (ADR-0027 D1.3) — the *key* is
+/// lowercased while the record keeps the first-seen *spelling*, so `Engineer`
+/// and `engineer` are one wing without destroying the capitalisation a human
+/// chose. Unlike a room key there is no parent id to prefix: a wing is
+/// top-level within a palace, and `WING_KEYS` is its own table, so no two
+/// namespaces can alias.
+/// What: the trimmed, lowercased label.
+/// Test: `canonical_wing_key_is_case_insensitive`.
+pub fn canonical_wing_key(label: &str) -> String {
+    label.trim().to_lowercase()
+}
+
+/// Canonical key of the default wing.
+///
+/// Test: `default_wing_id_is_not_the_minted_id`.
+pub fn default_wing_key() -> String {
+    canonical_wing_key(DEFAULT_WING_LABEL)
+}
+
+/// Mint the id for a wing that has no row yet.
+///
+/// Why: UUIDv5 over a canonical key is reproducible without coordination and
+/// carries no fold, so the legacy `room_to_uuid` collision class (ADR-0027
+/// C3.1) has no wing-side analogue. A random v4 would not be reproducible.
+/// What: `Uuid::new_v5(WING_NAMESPACE, key.as_bytes())`.
+///
+/// Note that the DEFAULT wing is **not** minted with this — its id is the
+/// pre-existing [`DEFAULT_WING_ID`] constant that every `RoomRecord` written
+/// since ADR-0027 T1 already carries, and it is seeded verbatim exactly the
+/// way a legacy room id is (ADR-0027 D1.3, "ids are read from the table,
+/// never recomputed"). `default_wing_id_is_not_the_minted_id` pins that the
+/// two genuinely differ, so the seeding is load-bearing rather than
+/// incidental.
+/// Test: `mint_wing_id_is_stable`, `default_wing_id_is_not_the_minted_id`.
+pub fn mint_wing_id(key: &str) -> Uuid {
+    Uuid::new_v5(&WING_NAMESPACE, key.as_bytes())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn wing_namespace_matches_its_documented_derivation() {
+        // The constant is hardcoded (this workspace forbids lazy globals), so
+        // nothing but this test ties it to the derivation its doc claims. A
+        // transcription slip would silently change every wing id minted from
+        // here on and no other test would fail — `mint_wing_id_is_stable`
+        // proves stability across calls, not that the seed is the documented
+        // one.
+        assert_eq!(
+            WING_NAMESPACE,
+            Uuid::new_v5(
+                &Uuid::NAMESPACE_URL,
+                b"https://github.com/bobmatnyc/trusty-tools/adr-0027/wing-namespace",
+            ),
+            "WING_NAMESPACE drifted from its doc"
+        );
+    }
+
+    #[test]
+    fn wing_namespace_differs_from_room_namespace() {
+        assert_ne!(
+            WING_NAMESPACE,
+            crate::memory_core::room_identity::ROOM_NAMESPACE,
+            "a wing and a room sharing a label must never mint the same id"
+        );
+    }
+
+    #[test]
+    fn canonical_wing_key_is_case_insensitive() {
+        assert_eq!(
+            canonical_wing_key("Engineer"),
+            canonical_wing_key(" engineer ")
+        );
+        assert_eq!(canonical_wing_key("Engineer"), "engineer");
+    }
+
+    #[test]
+    fn mint_wing_id_is_stable() {
+        let key = canonical_wing_key("engineer");
+        assert_eq!(mint_wing_id(&key), mint_wing_id(&key));
+        assert_eq!(mint_wing_id(&key).get_version_num(), 5, "ids are UUIDv5");
+        assert_ne!(mint_wing_id(&key), Uuid::nil());
+        assert_ne!(mint_wing_id(&key), mint_wing_id(&canonical_wing_key("pm")));
+    }
+
+    #[test]
+    fn default_wing_id_is_not_the_minted_id() {
+        // If these ever coincided, seeding the default row verbatim would be a
+        // no-op and this test would stop proving anything — so pin the
+        // difference. Every room row written since T1 carries DEFAULT_WING_ID,
+        // so that is the id the default wing MUST be stored under.
+        assert_eq!(default_wing_key(), "default");
+        assert_ne!(
+            mint_wing_id(&default_wing_key()),
+            DEFAULT_WING_ID,
+            "the default wing is seeded verbatim, never minted"
+        );
+    }
+}

--- a/crates/trusty-memory/changelog.d/4809-palace-info-wing-count.md
+++ b/crates/trusty-memory/changelog.d/4809-palace-info-wing-count.md
@@ -1,0 +1,12 @@
+Fixed
+
+- `PalaceInfo.wing_count` reports the real number of wings (ADR-0027 T9, [#4809](https://github.com/bobmatnyc/trusty-tools/issues/4809))
+  - #4811 replaced the old room-count-under-a-wing-label with a hardcoded `1`,
+    correct while `DEFAULT_WING_ID` was the only wing the model could hold. T9's
+    `wing_create` made more than one possible, so the constant became the same
+    category of lie the field carried before
+  - it is now read from the `WINGS` registry — the same source `wing_list` uses —
+    so the number and the tool surface cannot disagree
+  - `0` still means unknown for an uncached palace (#4637); an open palace whose
+    registry cannot be read degrades to `1`, never to `0`
+  - `palace_info` gains `wing_count` alongside the `room_count` #4807 added

--- a/crates/trusty-memory/changelog.d/4809-wing-mcp-surface.md
+++ b/crates/trusty-memory/changelog.d/4809-wing-mcp-surface.md
@@ -1,0 +1,23 @@
+Added
+
+- Wing MCP surface — `wing_list`, `wing_create`, `wing_rename` (ADR-0027 D2, ticket T9, closes [#4809](https://github.com/bobmatnyc/trusty-tools/issues/4809))
+  - `wing_list(palace)` is the discovery primitive: every wing with its label,
+    description, room count, and whether it is the default
+  - `wing_create(palace, label)` is idempotent — case-insensitive matching, first-seen
+    spelling kept for display, and creating `default` returns the palace's existing
+    default wing rather than a second one
+  - `wing_rename(palace, wing, new_label)` retires the old label (a rename, not an
+    alias) and provably touches no room and no drawer, since rooms reference a wing
+    by id
+  - `memory_remember` gains an optional `wing`, so a write can place its room in a
+    named scope; `memory_recall` and `memory_list` gain an optional `wing` that
+    restricts results to the rooms that wing owns
+  - omitting `wing` everywhere is the pre-wing behaviour exactly — the argument is
+    never required, and wing-less writes land in the palace's default wing
+  - an unknown `wing` is a loud error naming `wing_list`, never a silent empty
+    result; `memory_list` likewise rejects `wing` and `room` together rather than
+    honouring one and dropping the other
+  - `memory_recall_deep` takes `wing` too, so no recall path silently ignores a scope
+  - the `room`/`wing` scope is resolved BEFORE the embedder-warming short-circuit, so a
+    scoped recall issued while the daemon is warming is filtered rather than returned
+    unscoped

--- a/crates/trusty-memory/src/lib_tests.rs
+++ b/crates/trusty-memory/src/lib_tests.rs
@@ -96,8 +96,9 @@ async fn tools_list_returns_all_tools() {
     // issue #1720 adds `chat_session_recall`, `chat_session_delete`,
     // `chat_turn_append`; issue #1721 adds `palace_dream`;
     // issue #1722 adds `task_add`, `task_list`, `task_complete`;
-    // ADR-0027 T6 (#4805) adds `room_list`, `room_create`, `room_rename`.
-    assert_eq!(tools.len(), 40);
+    // ADR-0027 T6 (#4805) adds `room_list`, `room_create`, `room_rename`;
+    // ADR-0027 T9 (#4809) adds `wing_list`, `wing_create`, `wing_rename`.
+    assert_eq!(tools.len(), 43);
 }
 
 #[tokio::test]

--- a/crates/trusty-memory/src/mcp_service.rs
+++ b/crates/trusty-memory/src/mcp_service.rs
@@ -15,7 +15,7 @@
 //! functions guarantees the host-merged manifest and the standalone one
 //! stay byte-identical.
 //!
-//! Test: `tests` below assert the tool count (40), the name string, and
+//! Test: `tests` below assert the tool count (43), the name string, and
 //! that the read/write scope split matches what `scopes_for_tool` returns
 //! for representative tools (`memory_recall` → `memory.read`,
 //! `memory_remember` → `memory.write`).
@@ -25,7 +25,7 @@ use trusty_common::mcp::ServiceDescriptor;
 use crate::openrpc::scopes_for_tool;
 use crate::tools::tool_definitions_with;
 
-/// `ServiceDescriptor` impl that advertises this crate's 40 memory tools.
+/// `ServiceDescriptor` impl that advertises this crate's 43 memory tools.
 ///
 /// Why: Lets open-mpm link trusty-memory-mcp directly and include its
 /// tools in a unified `rpc.discover` document without bespoke glue code.
@@ -87,8 +87,8 @@ mod tests {
         let tools = svc.tools();
         assert_eq!(
             tools.len(),
-            40,
-            "expected 40 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room surface), got {}",
+            43,
+            "expected 43 memory tools (chat-session + dream-ops + palace_dream + the ADR-0027 room and wing surfaces), got {}",
             tools.len()
         );
     }
@@ -111,7 +111,7 @@ mod tests {
         //      so we must confirm dynamic dispatch resolves correctly here.
         let svc: Box<dyn ServiceDescriptor> = Box::new(MemoryMcpService);
         assert_eq!(svc.name(), "trusty-memory");
-        assert_eq!(svc.tools().len(), 40);
+        assert_eq!(svc.tools().len(), 43);
         assert_eq!(svc.scopes_for("palace_create"), vec!["memory.write"]);
         assert_eq!(svc.scopes_for("palace_delete"), vec!["memory.write"]);
         assert_eq!(svc.scopes_for("palace_update"), vec!["memory.write"]);

--- a/crates/trusty-memory/src/openrpc.rs
+++ b/crates/trusty-memory/src/openrpc.rs
@@ -106,6 +106,13 @@ pub fn scopes_for_tool(name: &str) -> Vec<String> {
         "room_list" => &[MEMORY_READ],
         "room_create" | "room_rename" => &[MEMORY_WRITE],
 
+        // ADR-0027 T9 wing tools (#4809): a wing is a storage-scope boundary
+        // over memory, not a credential grant (ADR-0026), so it needs no new
+        // scope — listing one is a memory read, creating or renaming one
+        // mutates palace state.
+        "wing_list" => &[MEMORY_READ],
+        "wing_create" | "wing_rename" => &[MEMORY_WRITE],
+
         _ => &[],
     };
     s.iter().map(|x| (*x).to_string()).collect()

--- a/crates/trusty-memory/src/service/helpers.rs
+++ b/crates/trusty-memory/src/service/helpers.rs
@@ -298,6 +298,26 @@ fn room_registry_count(handle: &Arc<PalaceHandle>) -> Option<usize> {
     }
 }
 
+/// Wings registered in this palace's `WINGS` table, or `None` on a read error.
+///
+/// Why (#4809 / ADR-0027 T9): `wing_count` reported a hardcoded `1` while
+/// `DEFAULT_WING_ID` was the only wing in the model — true then, and a lie the
+/// moment T9 let a palace hold more than one. This makes it a real count, from
+/// the same registry `wing_list` reads, so the two can never disagree.
+/// What: a scan of the (tiny) `WINGS` table. `None` lets the caller degrade to
+/// `1` — the default wing always exists once a palace has been opened — rather
+/// than to a `0` that #4637's contract reserves for "unknown".
+/// Test: `palace_list_includes_richer_counts`, `palace_info_reports_real_wings`.
+fn wing_registry_count(handle: &Arc<PalaceHandle>) -> Option<usize> {
+    match handle.kg.store().list_wings() {
+        Ok(wings) => Some(wings.len()),
+        Err(e) => {
+            tracing::warn!(palace = %handle.id, "wing_count unavailable: {e:#}");
+            None
+        }
+    }
+}
+
 pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> PalaceInfo {
     let (
         drawer_count,
@@ -316,9 +336,7 @@ pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> 
         // #4811 / ADR-0027 T8: `room_count` comes from the ROOMS registry so it
         // agrees with `room_list`; on a read failure it degrades to the rooms
         // the drawers are actually in, which is a lower bound rather than a
-        // zero that would read as "no rooms". `wing_count` is 1 — there is
-        // exactly one wing (DEFAULT_WING_ID) until T9 — and no longer the
-        // room count it used to report under a wing label.
+        // zero that would read as "no rooms".
         let rooms = room_registry_count(h).unwrap_or_else(|| {
             drawers
                 .iter()
@@ -326,12 +344,20 @@ pub fn palace_info_from(palace: &Palace, handle: Option<&Arc<PalaceHandle>>) -> 
                 .collect::<HashSet<Uuid>>()
                 .len()
         });
+        // #4809 / ADR-0027 T9: `wing_count` is now a REAL count from the WINGS
+        // registry. T8 set it to a hardcoded 1 because DEFAULT_WING_ID was the
+        // only wing that could exist; that stopped being true when T9 shipped
+        // `wing_create`, and a constant standing in for a count is the same
+        // category of lie the field carried before T8. On a read failure it
+        // degrades to 1 — every opened palace has at least the default wing —
+        // preserving #4637's rule that 0 means unknown, never empty.
+        let wings = wing_registry_count(h).unwrap_or(1);
         (
             drawers.len(),
             h.vector_store.index_size(),
             h.kg.count_active_triples(),
             rooms,
-            1,
+            wings,
             last_write,
             h.kg.node_count() as u64,
             h.kg.edge_count() as u64,

--- a/crates/trusty-memory/src/service/types.rs
+++ b/crates/trusty-memory/src/service/types.rs
@@ -40,15 +40,19 @@ pub struct PalaceInfo {
     /// Test: `palace_list_includes_richer_counts`.
     #[serde(default)]
     pub room_count: usize,
-    /// DEPRECATED (#4811, ADR-0027 D2/C3.4): wings do not exist as entities
-    /// yet, so this is `1` for any open palace — every room lives in the one
-    /// `DEFAULT_WING_ID` — and `0` when `cached` is false (unknown).
+    /// Wings registered in this palace's `WINGS` table (ADR-0027 T9, #4809).
     ///
-    /// Why it is not simply removed: it is a wire field two shipped readers
-    /// consume. Until ADR-0027 T9 introduces the `WINGS` table and populates a
-    /// real count, it reports the truth about the model as shipped rather than
-    /// the room count it used to report under a wing label. Use `room_count`.
-    /// Test: `palace_list_includes_richer_counts`.
+    /// Why: this field reported a *room* count under a wing label until #4811
+    /// (ADR-0027 C3.4), then a hardcoded `1` while `DEFAULT_WING_ID` was the
+    /// only wing the model could hold. T9's `wing_create` made more than one
+    /// possible, so it is now read from the registry — the same source
+    /// `wing_list` uses, so the number and the tool surface cannot disagree.
+    /// `0` when `cached` is false means unknown, exactly like the other counts;
+    /// an open palace always reports at least `1` for its default wing.
+    ///
+    /// Note for readers: a wing is the scope/ownership axis. If you want "how
+    /// many topics does this palace have", that is `room_count`.
+    /// Test: `palace_list_includes_richer_counts`, `palace_info_reports_real_wings`.
     pub wing_count: usize,
     pub created_at: chrono::DateTime<chrono::Utc>,
     pub last_write_at: Option<chrono::DateTime<chrono::Utc>>,

--- a/crates/trusty-memory/src/tools/definitions.rs
+++ b/crates/trusty-memory/src/tools/definitions.rs
@@ -12,6 +12,7 @@ use serde_json::{json, Value};
 use super::chat_definitions::chat_tool_definitions;
 use super::room_definitions::room_tool_definitions;
 use super::task_definitions::task_tool_definitions;
+use super::wing_definitions::wing_tool_definitions;
 
 /// Marker server type. Reserved for future stateful MCP server impls.
 ///
@@ -112,6 +113,7 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
                         "palace":  {"type": "string", "description": "Palace ID (optional if server started with --palace)"},
                         "text":    {"type": "string", "description": "Memory content"},
                         "room":    {"type": "string", "description": "Room type (optional)"},
+                        "wing":    {"type": "string", "description": "ADR-0027: optional wing (scope/ownership) id or label that OWNS this room — e.g. an agent type such as `engineer`. Omit for the palace's default wing, which is the pre-wing behaviour. With it, `engineer`+`Planning` and `pm`+`Planning` are two distinct rooms. Errors if the wing does not exist; create it with wing_create or list wings with wing_list."},
                         "tags":    {"type": "array", "items": {"type": "string"}},
                         "force":   {"type": "boolean", "description": "Explicit operator override: bypasses the content-QUALITY gates for this write — the blocklist (auto-capture noise patterns), the short-content check, the dedup window, and the noise-pattern filter. Issue #2520: does NOT bypass secret/credential detection — a force=true write of secret-shaped content (API keys, tokens) is still rejected. Use sparingly; intended for app-managed writers (e.g. session/turn recorders) that need deterministic storage regardless of heuristic false positives.", "default": false},
                         "allow_secret_like": {"type": "boolean", "description": "DANGEROUS, rarely needed: bypasses the secret/credential heuristic gate specifically, on top of whatever `force` already bypasses. Only set this when you are DELIBERATELY storing content that looks like a credential (e.g. a redacted example or test fixture) and have confirmed it contains no real secret. Automated writers (turn recorders, auto-capture hooks) must NOT set this — it exists for rare, explicit human/operator overrides only.", "default": false},
@@ -141,14 +143,15 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
             },
             {
                 "name": "memory_recall",
-                "description": "Recall memories using L0+L1+L2 progressive retrieval. Pass `room` to scope the search to one room (ADR-0027).",
+                "description": "Recall memories using L0+L1+L2 progressive retrieval. Pass `room` to scope the search to one room, or `wing` to scope it to one owner's rooms (ADR-0027).",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "palace": {"type": "string"},
                         "query":  {"type": "string"},
                         "room":   {"type": "string", "description": "ADR-0027: restrict the semantic layer to this room. The always-on identity/essential layers (L0/L1) are still returned — they are the palace's baseline grounding, not search results. Use room_list to discover a palace's rooms."},
-                        "top_k":  {"type": "integer", "default": 10}
+                        "top_k":  {"type": "integer", "default": 10},
+                        "wing":   {"type": "string", "description": "ADR-0027: optional wing (scope) id or label. Restricts the L2 search to the rooms that wing owns — 'recall everything the engineer wing has learned' in one query. Palace identity/essentials (L0/L1) are always included since they are not any one wing's property. Mutually exclusive with `room`. Omit for an unscoped recall. Errors if the wing does not exist (see wing_list)."}
                     },
                     "required": memory_recall_required,
                 }
@@ -240,12 +243,13 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
             },
             {
                 "name": "memory_list",
-                "description": "List drawers in a palace, optionally filtered by room type or tag.",
+                "description": "List drawers in a palace, optionally filtered by wing, room type, or tag.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "palace": {"type": "string"},
                         "room":   {"type": "string", "description": "Filter by room type (Frontend, Backend, Testing, Planning, Documentation, Research, Configuration, Meetings, General, or custom)"},
+                        "wing":   {"type": "string", "description": "ADR-0027: filter by wing (scope) id or label — every drawer in every room that wing owns. Mutually exclusive with `room` for now; passing both is an error rather than a silently-ignored filter. Errors if the wing does not exist (see wing_list)."},
                         "tag":    {"type": "string", "description": "Filter by tag"},
                         "limit":  {"type": "integer", "description": "Max results (default 50)"}
                     },
@@ -415,9 +419,10 @@ pub fn tool_definitions_with(has_default: bool) -> Value {
     let metrics = tools.pop().expect("console_metrics sentinel");
     tools.extend(task_tool_definitions(has_default));
     tools.extend(chat_tool_definitions(has_default));
-    // ADR-0027 T6 (#4805): the room surface, in its own sibling module for the
-    // same 500-SLOC reason as the task and chat groups.
+    // ADR-0027 T6 (#4805) / T9 (#4809): the room and wing surfaces, each in its
+    // own sibling module for the same 500-SLOC reason as the task and chat groups.
     tools.extend(room_tool_definitions(has_default));
+    tools.extend(wing_tool_definitions(has_default));
     tools.push(metrics);
     result
 }

--- a/crates/trusty-memory/src/tools/memory_ops.rs
+++ b/crates/trusty-memory/src/tools/memory_ops.rs
@@ -15,10 +15,13 @@ use anyhow::{anyhow, Context, Result};
 use serde_json::{json, Value};
 use trusty_common::memory_core::palace::RoomType;
 use trusty_common::memory_core::retrieval::{
-    recall_across_palaces, recall_deep_in_room, recall_in_room, RememberOptions,
+    list_drawers_in_wing, recall_across_palaces, recall_deep_scoped, recall_scoped, scope_admits,
+    PalaceHandle, RecallScope, RememberOptions,
 };
 use trusty_common::memory_core::timeouts;
 use uuid::Uuid;
+
+use super::wing_ops::resolve_wing_arg;
 
 use super::bm25::{
     bm25_hits_to_recall_results, bm25_search_optional, fuse_bm25_into_recall, serialize_recall,
@@ -145,6 +148,14 @@ pub(crate) async fn handle_memory_remember(state: &AppState, args: Value) -> Res
         }
     }
     let room_label_for_kg = room_label(&room);
+    // ADR-0027 T9: optional wing scope. Absent (the overwhelmingly common
+    // case) means the palace's default wing, which is byte-identical to the
+    // pre-wing write path. Present means this room belongs to that wing, so
+    // `engineer`/`Planning` and `pm`/`Planning` are two different rooms.
+    // Without this the write path could never reach a non-default wing and
+    // wing-scoped recall would be permanently empty outside the default.
+    let wing_handle = open_palace_handle(state, palace)?;
+    let wing_id = resolve_wing_arg(&wing_handle, &args, "memory_remember")?;
     let drawer_id = write_drawer(
         state,
         WriteDrawerParams {
@@ -153,7 +164,10 @@ pub(crate) async fn handle_memory_remember(state: &AppState, args: Value) -> Res
             tags,
             room,
             importance: 0.5,
-            opts: mcp_remember_opts(force, defer_embedding, allow_secret_like),
+            opts: RememberOptions {
+                wing_id,
+                ..mcp_remember_opts(force, defer_embedding, allow_secret_like)
+            },
             room_label_for_kg,
         },
     )
@@ -306,15 +320,19 @@ async fn recall_without_embedder(
     handle: &trusty_common::memory_core::retrieval::PalaceHandle,
     palace: &str,
     query: &str,
-    room: Option<&RoomType>,
+    scope: &RecallScope,
     top_k: usize,
 ) -> Vec<trusty_common::memory_core::retrieval::RecallResult> {
     let mut results = trusty_common::memory_core::retrieval::retrieve_l0_l1(handle);
-    let target_room_id = room
-        .map(|r| trusty_common::memory_core::store::rooms::resolve_room_filter_id(&handle.kg, r));
+    // ADR-0027 T7 filtered this lane by room; T9 (#4809) widens it to the whole
+    // scope so a WING-scoped recall issued while the embedder is warming is
+    // filtered too. Without that, the warming path would return unscoped
+    // results — a scope boundary failing open, which is a leak, not a
+    // degraded result.
+    let allowed = scope.allowed_room_ids(&handle.kg);
     if let Some(bm25_hits) = bm25_search_optional(state, palace, query, top_k).await {
         for hydrated in bm25_hits_to_recall_results(handle, &bm25_hits) {
-            if target_room_id.is_some_and(|rid| hydrated.drawer.room_id != rid) {
+            if !scope_admits(&allowed, hydrated.drawer.room_id) {
                 continue;
             }
             if !results.iter().any(|r| r.drawer.id == hydrated.drawer.id) {
@@ -347,6 +365,37 @@ fn recall_room_filter(args: &Value) -> Option<RoomType> {
         .map(RoomType::parse)
 }
 
+/// Combine the optional `room` (T7) and `wing` (T9) arguments into one scope.
+///
+/// Why (ADR-0027 #4806 + #4809): a room is a topic and a wing is an owner, so
+/// the two arguments are different axes and every read path must agree on what
+/// they mean together. Resolving them in ONE helper is what keeps
+/// `memory_recall`, `memory_recall_deep`, and `memory_list` from drifting into
+/// three spellings of the same option (ADR-0027 D4.1).
+/// What: `RecallScope::Wing` when `wing` is present, `RecallScope::Room` when
+/// only `room` is, `RecallScope::All` when neither. Supplying BOTH is an error
+/// — "that topic inside that scope" is a real query this ticket does not
+/// implement, and honouring one while dropping the other is exactly the
+/// invisible failure ADR-0027 exists to remove. An unknown wing errors here
+/// too, via `resolve_wing_arg`.
+/// Test: `recall_rejects_wing_and_room_together`,
+/// `recall_rejects_an_unknown_wing`.
+fn recall_scope(handle: &PalaceHandle, args: &Value, tool: &str) -> Result<RecallScope> {
+    let room = recall_room_filter(args);
+    match resolve_wing_arg(handle, args, tool)? {
+        Some(wing_id) => {
+            if room.is_some() {
+                return Err(anyhow!(
+                    "{tool}: 'wing' and 'room' together are not supported yet — \
+                     pass one or the other"
+                ));
+            }
+            Ok(RecallScope::Wing(wing_id))
+        }
+        None => Ok(RecallScope::from_room_filter(room)),
+    }
+}
+
 pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "memory_recall")?;
     let query = args
@@ -354,16 +403,19 @@ pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Resul
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("memory_recall: missing 'query'"))?;
     let top_k = args.get("top_k").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
-    let room = recall_room_filter(&args);
 
     let handle = open_palace_handle(state, &palace)?;
+    // ADR-0027 T7 + T9: resolved BEFORE the warming short-circuit below, so a
+    // wing- or room-scoped recall is filtered on every path. Resolving it after
+    // that early return would let a scoped recall issued during embedder warmup
+    // come back unfiltered.
+    let scope = recall_scope(&handle, &args, "memory_recall")?;
 
     // Issue #1970: while the embedder is still warming up, return BM25 +
     // L0/L1 results immediately instead of blocking/erroring on embedder
     // state.
     if state.readiness() == DaemonReadiness::Warming {
-        let results =
-            recall_without_embedder(state, &handle, &palace, query, room.as_ref(), top_k).await;
+        let results = recall_without_embedder(state, &handle, &palace, query, &scope, top_k).await;
         return Ok(serialize_recall(&palace, query, results));
     }
 
@@ -373,13 +425,13 @@ pub(crate) async fn handle_memory_recall(state: &AppState, args: Value) -> Resul
     // When the daemon is unavailable or the env var is unset, the
     // helper returns `None` and we return the vector-only results
     // verbatim — zero behavioural change for existing deployments.
-    // ADR-0027 T7: the BM25 lane needs no room filter of its own here —
+    // ADR-0027 T7: the BM25 lane needs no scope filter of its own here —
     // `fuse_bm25_into_recall` only *boosts* drawers already present in the
     // vector list (it never appends BM25-only hits), and that list is already
-    // room-scoped, so no out-of-room drawer can enter through the lexical
+    // scoped, so no out-of-scope drawer can enter through the lexical
     // lane. The warming path above is different: it hydrates BM25-only hits,
     // which is why it filters explicitly.
-    let vector_fut = recall_in_room(&handle, embedder.as_ref(), query, room, top_k);
+    let vector_fut = recall_scoped(&handle, embedder.as_ref(), query, &scope, top_k);
     let bm25_fut = bm25_search_optional(state, &palace, query, top_k);
     let (vector_res, bm25_res) = tokio::join!(vector_fut, bm25_fut);
     let mut results = vector_res.context("recall")?;
@@ -396,21 +448,21 @@ pub(crate) async fn handle_memory_recall_deep(state: &AppState, args: Value) -> 
         .and_then(|v| v.as_str())
         .ok_or_else(|| anyhow!("memory_recall_deep: missing 'query'"))?;
     let top_k = args.get("top_k").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
-    // ADR-0027 T7: deep recall is no longer the odd one out — it takes the
-    // same `room` scope as `memory_recall`.
-    let room = recall_room_filter(&args);
 
     let handle = open_palace_handle(state, &palace)?;
+    // ADR-0027 T7 + T9: deep recall is no longer the odd one out — it takes the
+    // same `room`/`wing` scope as `memory_recall`, resolved before the warming
+    // short-circuit so no path can return unscoped results.
+    let scope = recall_scope(&handle, &args, "memory_recall_deep")?;
 
     // Issue #1970: same warming-fallback posture as memory_recall.
     if state.readiness() == DaemonReadiness::Warming {
-        let results =
-            recall_without_embedder(state, &handle, &palace, query, room.as_ref(), top_k).await;
+        let results = recall_without_embedder(state, &handle, &palace, query, &scope, top_k).await;
         return Ok(serialize_recall(&palace, query, results));
     }
 
     let embedder = state.embedder().await?;
-    let results = recall_deep_in_room(&handle, embedder.as_ref(), query, room, top_k)
+    let results = recall_deep_scoped(&handle, embedder.as_ref(), query, &scope, top_k)
         .await
         .context("recall_deep")?;
     Ok(serialize_recall(&palace, query, results))
@@ -419,16 +471,19 @@ pub(crate) async fn handle_memory_recall_deep(state: &AppState, args: Value) -> 
 pub(crate) async fn handle_memory_list(state: &AppState, args: Value) -> Result<Value> {
     let palace = resolve_palace(state, &args, "memory_list")?;
     let handle = open_palace_handle(state, &palace)?;
-    let room = args
-        .get("room")
-        .and_then(|v| v.as_str())
-        .map(RoomType::parse);
     let tag = args
         .get("tag")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
     let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(50) as usize;
-    let drawers = handle.list_drawers(room, tag, limit);
+    // ADR-0027 T9: `wing` narrows to one scope's rooms; absent, this is the
+    // unchanged pre-wing listing. Same shared resolver the recall paths use, so
+    // all three agree on what `wing` and `room` mean together.
+    let drawers = match recall_scope(&handle, &args, "memory_list")? {
+        RecallScope::Wing(wing_id) => list_drawers_in_wing(&handle, wing_id, tag, limit),
+        RecallScope::Room(room) => handle.list_drawers(Some(room), tag, limit),
+        RecallScope::All => handle.list_drawers(None, tag, limit),
+    };
     let payload: Vec<Value> = drawers
         .iter()
         .map(|d| {
@@ -486,7 +541,9 @@ async fn recall_all_without_embedder(
     let mut merged = Vec::new();
     for handle in handles {
         let palace_id = handle.id.as_str().to_string();
-        let hits = recall_without_embedder(state, handle, &palace_id, query, None, top_k).await;
+        let hits =
+            recall_without_embedder(state, handle, &palace_id, query, &RecallScope::All, top_k)
+                .await;
         merged.extend(hits.into_iter().map(|result| {
             trusty_common::memory_core::retrieval::CrossPalaceResult {
                 palace_id: palace_id.clone(),

--- a/crates/trusty-memory/src/tools/mod.rs
+++ b/crates/trusty-memory/src/tools/mod.rs
@@ -21,6 +21,9 @@
 //! - `room_rename(palace, room, new_label)`         -> renamed room
 //! - `kg_assert(palace, subject, predicate, object, confidence?, provenance?)` -> ()
 //! - `kg_query(palace, subject)`                    -> Vec<Triple>
+//! - `wing_list(palace)`                            -> Vec<WingSummary>
+//! - `wing_create(palace, label)`                   -> wing_id (idempotent)
+//! - `wing_rename(palace, wing, new_label)`         -> WingSummary
 
 pub mod bm25;
 pub mod chat_definitions;
@@ -35,6 +38,10 @@ pub mod room_definitions;
 pub mod room_ops;
 pub mod task_definitions;
 pub mod task_ops;
+// ADR-0027 T9 (#4809): the wing surface ships WITH the wing entity — a level
+// nobody reads is the defect the ADR exists to correct.
+pub mod wing_definitions;
+pub mod wing_ops;
 
 // Re-export the public + cross-module surface so external call sites
 // (`crate::tools::X`) and the `super::*` glob in `tools::tests` keep
@@ -75,6 +82,7 @@ use palace_ops::{
 };
 use room_ops::{handle_room_create, handle_room_list, handle_room_rename};
 use task_ops::{handle_task_add, handle_task_complete, handle_task_list};
+use wing_ops::{handle_wing_create, handle_wing_list, handle_wing_rename};
 
 /// Dispatch a tool call by name to its real handler.
 ///
@@ -131,6 +139,10 @@ pub async fn dispatch_tool(state: &AppState, name: &str, args: Value) -> Result<
         "room_list" => handle_room_list(state, args).await,
         "room_create" => handle_room_create(state, args).await,
         "room_rename" => handle_room_rename(state, args).await,
+        // ADR-0027 T9 (#4809): the wing surface — the scope axis over rooms.
+        "wing_list" => handle_wing_list(state, args).await,
+        "wing_create" => handle_wing_create(state, args).await,
+        "wing_rename" => handle_wing_rename(state, args).await,
         other => anyhow::bail!("unknown tool: {other}"),
     }
 }

--- a/crates/trusty-memory/src/tools/palace_ops.rs
+++ b/crates/trusty-memory/src/tools/palace_ops.rs
@@ -228,20 +228,23 @@ pub(crate) async fn handle_palace_info(state: &AppState, args: Value) -> Result<
         .data_dir
         .as_ref()
         .map(|p| p.to_string_lossy().to_string());
-    // ADR-0027 D6 / #4807: report how many rooms the palace has. `wing_count`
-    // is deliberately absent here rather than reported as 1 — this tool never
-    // carried it, and adding a field whose only truthful value is a constant
-    // would be new dead surface. It arrives with the Wing entity (T9).
+    // ADR-0027 D6 / #4807: report how many rooms the palace has. #4809 (T9)
+    // adds `wing_count` alongside it — #4807 left it out rather than report a
+    // constant, and the Wing entity it was waiting for is now here, so this is
+    // a real count from the `WINGS` registry.
     let store = handle.kg.store();
-    let room_count = tokio::task::spawn_blocking(move || store.list_rooms().map(|r| r.len()))
-        .await
-        .context("join palace_info room count")?
-        .context("count rooms")?;
+    let (room_count, wing_count) = tokio::task::spawn_blocking(move || {
+        anyhow::Ok((store.list_rooms()?.len(), store.list_wings()?.len()))
+    })
+    .await
+    .context("join palace_info counts")?
+    .context("count rooms and wings")?;
     Ok(json!({
         "id": handle.id.as_str(),
         "name": handle.id.as_str(),
         "drawer_count": drawer_count,
         "room_count": room_count,
+        "wing_count": wing_count,
         "data_dir": data_dir,
     }))
 }

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -136,7 +136,8 @@ fn tool_definitions_lists_all_tools() {
         .expect("tools array");
     // 34 original + 3 task tools (task_add, task_list, task_complete, issue
     // #1722) + 3 room tools (room_list, room_create, room_rename, ADR-0027 T6)
-    assert_eq!(tools.len(), 40);
+    // + 3 wing tools (wing_list, wing_create, wing_rename, ADR-0027 T9 / #4809)
+    assert_eq!(tools.len(), 43);
     let names: Vec<&str> = tools
         .iter()
         .filter_map(|t| t.get("name").and_then(|n| n.as_str()))
@@ -184,6 +185,10 @@ fn tool_definitions_lists_all_tools() {
         "room_list",
         "room_create",
         "room_rename",
+        // ADR-0027 T9 (#4809) — the wing surface ships with the wing entity:
+        "wing_list",
+        "wing_create",
+        "wing_rename",
     ] {
         assert!(names.contains(&expected), "missing tool: {expected}");
     }

--- a/crates/trusty-memory/src/tools/wing_definitions.rs
+++ b/crates/trusty-memory/src/tools/wing_definitions.rs
@@ -1,0 +1,74 @@
+//! MCP tool schema definitions for the three wing tools (ADR-0027 T9, #4809).
+//!
+//! Why: `definitions.rs` sits at 367 of its 500-SLOC production cap, so the
+//! wing tool JSON lands in a sibling module — the same split
+//! `task_definitions.rs` made for the task tools, and for the same reason.
+//! What: exports `wing_tool_definitions(has_default)` — a `Vec<Value>` of the
+//! three wing tool schemas, spliced into the main tools array in
+//! `tool_definitions_with`.
+//! Test: `tool_definitions_lists_all_tools` in `tools::tests` verifies the
+//! names appear in the merged list.
+
+use serde_json::{json, Value};
+
+/// Build the three wing tool schemas conditioned on whether a default palace
+/// is configured.
+///
+/// Why: follows the same `has_default` pattern as every other tool group so
+/// the `palace` argument moves out of `required` when the server is bound to a
+/// single palace via `--palace`.
+/// What: returns `[wing_list, wing_create, wing_rename]` as `Vec<Value>`.
+/// Test: spliced into `tool_definitions_with`, covered by
+/// `tool_definitions_lists_all_tools` and `wing_tools_are_listed`.
+pub(super) fn wing_tool_definitions(has_default: bool) -> Vec<Value> {
+    let wing_list_required: Vec<&str> = if has_default { vec![] } else { vec!["palace"] };
+    let wing_create_required: Vec<&str> = if has_default {
+        vec!["label"]
+    } else {
+        vec!["palace", "label"]
+    };
+    let wing_rename_required: Vec<&str> = if has_default {
+        vec!["wing", "new_label"]
+    } else {
+        vec!["palace", "wing", "new_label"]
+    };
+
+    vec![
+        json!({
+            "name": "wing_list",
+            "description": "List the wings of a palace (ADR-0027). A WING is the scope/ownership axis — the 'who' — while a ROOM is the topic axis — the 'what'. Wings let two owners hold same-named rooms (engineer/Planning and pm/Planning are distinct rooms) without name mangling. Every palace has a 'default' wing that every room falls into unless a caller names another, so wings are never required. Returns { palace, wings: [ { wing_id, label, description, room_count, is_default, created_at } ] }.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "palace": {"type": "string", "description": "Palace ID (optional if server started with --palace)"}
+                },
+                "required": wing_list_required,
+            }
+        }),
+        json!({
+            "name": "wing_create",
+            "description": "Create a wing (scope) in a palace, or return the existing one with that label (ADR-0027). Idempotent — safe to call unconditionally on startup; label matching is case-insensitive while the first-seen spelling is kept for display. Creating 'default' returns the palace's existing default wing rather than a second one. Creating a wing writes no room and no drawer. Returns { palace, wing_id, label, created }.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "palace": {"type": "string", "description": "Palace ID (optional if server started with --palace)"},
+                    "label":  {"type": "string", "description": "Wing name, e.g. an agent type such as `engineer` or `pm`. Must not be empty."}
+                },
+                "required": wing_create_required,
+            }
+        }),
+        json!({
+            "name": "wing_rename",
+            "description": "Rename a wing (ADR-0027). The old label stops resolving — this is a rename, not an alias. Rooms reference their wing by id, so a rename never moves a room and never touches a drawer. Errors if the wing is unknown or another wing already holds the new label. Returns { palace, wing: { wing_id, label, ... } }.",
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "palace":    {"type": "string", "description": "Palace ID (optional if server started with --palace)"},
+                    "wing":      {"type": "string", "description": "Wing id or current label to rename."},
+                    "new_label": {"type": "string", "description": "New wing name. Must not be empty or already used by another wing."}
+                },
+                "required": wing_rename_required,
+            }
+        }),
+    ]
+}

--- a/crates/trusty-memory/src/tools/wing_ops.rs
+++ b/crates/trusty-memory/src/tools/wing_ops.rs
@@ -1,0 +1,152 @@
+//! Wing MCP tool handlers (ADR-0027 D2 / ticket T9, issue #4809).
+//!
+//! Why: ADR-0027's central finding is that `Wing` had zero construction sites
+//! since the day it was written — "a level nobody reads is the defect". So the
+//! wing entity ships WITH the surface that reads it: `wing_list` is the
+//! discovery primitive, `wing_create` the way a scope comes into existence, and
+//! `wing_rename` the repair path. Without these, `WINGS` would be a second dark
+//! table and this ticket would have reproduced the exact defect it corrects.
+//! What: three `pub(crate) async fn handle_wing_*` handlers, plus
+//! [`resolve_wing_arg`] — the shared parser the wing-scoped read tools use.
+//! Test: `crates/trusty-memory/tests/wing_mcp.rs`.
+
+use crate::AppState;
+use anyhow::{anyhow, Result};
+use serde_json::{json, Value};
+use trusty_common::memory_core::store::wings::{
+    list_wings, rename_wing, resolve_or_create_wing, resolve_wing_selector, WingSummary,
+};
+use trusty_common::memory_core::PalaceHandle;
+use uuid::Uuid;
+
+use super::helpers::{open_palace_handle, resolve_palace};
+
+/// Render a `WingSummary` as the MCP wire shape.
+///
+/// Why: `wing_list`, `wing_create`, and `wing_rename` all answer with the same
+/// object, so a single projection keeps them from drifting.
+/// What: ids as strings, the creation stamp as RFC3339 (millis are an
+/// implementation detail of the row, not a contract).
+fn wing_json(w: &WingSummary) -> Value {
+    json!({
+        "wing_id": w.id.to_string(),
+        "label": w.label,
+        "description": w.description,
+        "room_count": w.room_count,
+        "is_default": w.is_default,
+        "created_at": chrono::DateTime::from_timestamp_millis(w.created_at_ms)
+            .map(|t| t.to_rfc3339()),
+    })
+}
+
+/// Resolve an optional `wing` argument to a wing id.
+///
+/// Why: an unknown wing must FAIL LOUD at the tool boundary, even though the
+/// library scope layer fails closed. A typo'd wing that quietly returned zero
+/// results would be precisely the invisible failure ADR-0027 D4.4 rejects
+/// content inference for — the caller would read "no memories" as fact rather
+/// than as a mistake. `wing_list` is one call away, so naming it in the error
+/// costs the caller nothing.
+/// What: `Ok(None)` when the caller supplied no `wing` (the "wing is never
+/// required" guarantee — this is the path every pre-T9 caller takes);
+/// `Ok(Some(id))` for a known wing id or label; `Err` for an unknown one.
+/// Test: `recall_rejects_an_unknown_wing`,
+/// `a_caller_that_never_names_a_wing_is_unaffected`.
+pub(crate) fn resolve_wing_arg(
+    handle: &PalaceHandle,
+    args: &Value,
+    tool: &str,
+) -> Result<Option<Uuid>> {
+    let Some(selector) = args.get("wing").and_then(|v| v.as_str()) else {
+        return Ok(None);
+    };
+    if selector.trim().is_empty() {
+        return Ok(None);
+    }
+    resolve_wing_selector(&handle.kg, selector)
+        .map_err(|e| anyhow!("{tool}: resolve wing {selector:?}: {e:#}"))?
+        .map(Some)
+        .ok_or_else(|| anyhow!("{tool}: unknown wing {selector:?} (try wing_list)"))
+}
+
+/// List every wing in a palace with its room population.
+///
+/// Why: the discovery primitive that did not exist. Before this, a caller could
+/// not find out what scopes a palace has without reading its redb file.
+/// What: opens the palace (which seeds the default wing if absent) and returns
+/// `{ palace, wings: [ { wing_id, label, description, room_count, is_default,
+/// created_at } ] }`.
+/// Test: `wing_list_shows_the_default_wing`, `wing_create_then_list`.
+pub(crate) async fn handle_wing_list(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "wing_list")?;
+    let handle = open_palace_handle(state, &palace)?;
+    let wings = list_wings(&handle.kg).map_err(|e| anyhow!("wing_list: {e:#}"))?;
+    let payload: Vec<Value> = wings.iter().map(wing_json).collect();
+    Ok(json!({ "palace": palace, "wings": payload }))
+}
+
+/// Create a wing, or return the existing one with that label.
+///
+/// Why: idempotent by construction so a caller can call it unconditionally on
+/// startup — the #3064 "room-per-agent-type" consumer will want exactly that,
+/// with the agent type as the wing.
+/// What: normalises the label, mints a UUIDv5 for a new wing, and returns
+/// `{ palace, wing_id, label, created }`. `created` is `false` when the wing
+/// already existed. Creating `"default"` returns the palace's default wing id
+/// rather than a second one.
+/// Test: `wing_create_is_idempotent_over_mcp`, `wing_create_rejects_blank`.
+pub(crate) async fn handle_wing_create(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "wing_create")?;
+    // Trim and reject blank AT the boundary. `normalize_wing_label` in the
+    // store already refuses a blank, so this is defence in depth rather than
+    // the only guard — but it keeps the rejection local to the tool that
+    // caused it, and it means the `label` echoed below is the exact string the
+    // store was handed, so the response can never disagree with what was
+    // stored.
+    let label = args
+        .get("label")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow!("wing_create: missing or blank 'label'"))?;
+    let handle = open_palace_handle(state, &palace)?;
+    let (id, created) = resolve_or_create_wing(&handle.kg, label)
+        .await
+        .map_err(|e| anyhow!("wing_create: {e:#}"))?;
+    Ok(json!({
+        "palace": palace,
+        "wing_id": id.to_string(),
+        "label": label,
+        "created": created,
+    }))
+}
+
+/// Rename a wing, retiring its old label.
+///
+/// Why: the repair path — and the only way to fix a scope that was named badly
+/// once agents already write into it. Because rooms reference a wing by id,
+/// this provably cannot move a room or touch a drawer.
+/// What: resolves `wing` (id or current label), applies the rename, and returns
+/// the updated summary. Errors when the wing is unknown or the new label is
+/// already held by a different wing.
+/// Test: `wing_rename_over_mcp`, `wing_rename_rejects_taken_label_over_mcp`.
+pub(crate) async fn handle_wing_rename(state: &AppState, args: Value) -> Result<Value> {
+    let palace = resolve_palace(state, &args, "wing_rename")?;
+    // Same boundary guard as `wing_create`: trim, and reject blank here rather
+    // than only in the store, so both tools fail identically on the same input.
+    let new_label = args
+        .get("new_label")
+        .and_then(|v| v.as_str())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow!("wing_rename: missing or blank 'new_label'"))?;
+    let handle = open_palace_handle(state, &palace)?;
+    // `wing` is required here (unlike the read tools, where its absence means
+    // "unscoped"), so route it through the same resolver and then demand it.
+    let id = resolve_wing_arg(&handle, &args, "wing_rename")?
+        .ok_or_else(|| anyhow!("wing_rename: missing 'wing'"))?;
+    let summary = rename_wing(&handle.kg, id, new_label)
+        .await
+        .map_err(|e| anyhow!("wing_rename: {e:#}"))?;
+    Ok(json!({ "palace": palace, "wing": wing_json(&summary) }))
+}

--- a/crates/trusty-memory/tests/wing_mcp.rs
+++ b/crates/trusty-memory/tests/wing_mcp.rs
@@ -1,0 +1,532 @@
+//! Integration tests for the wing MCP surface (ADR-0027 T9, issue #4809).
+//!
+//! Why: ADR-0027's finding was that `Wing` had zero construction sites — "a
+//! level nobody reads is the defect". The acceptance bar for T9 is therefore
+//! not that a `WINGS` table exists but that an MCP caller can actually USE
+//! wings: list them, create one, rename it, write into it, and recall from it.
+//! These tests drive every one of those through `dispatch_tool`, i.e. the exact
+//! path an agent takes.
+//! What: exercises `wing_list` / `wing_create` / `wing_rename`, the `wing`
+//! argument on `memory_remember` / `memory_recall` / `memory_list`, the
+//! "a caller who never names a wing is unaffected" guarantee, and the
+//! fail-loud unknown-wing contract.
+//! Test: this IS the test module.
+
+use serde_json::json;
+use tempfile::TempDir;
+use trusty_common::memory_core::retrieval::seed_shared_embedder_with_mock;
+use trusty_memory::tools::dispatch_tool;
+use trusty_memory::AppState;
+
+fn ready_state(tmp: &TempDir) -> AppState {
+    let state = AppState::new(tmp.path().to_path_buf());
+    state.set_ready();
+    state
+}
+
+/// Create a palace and return `(state, tmp)` ready for wing calls.
+async fn palace(name: &str) -> (AppState, TempDir) {
+    seed_shared_embedder_with_mock();
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let state = ready_state(&tmp);
+    let cwd = tmp.path().to_string_lossy().to_string();
+    dispatch_tool(
+        &state,
+        "palace_create",
+        json!({ "name": name, "force": true, "cwd": cwd }),
+    )
+    .await
+    .expect("create palace");
+    (state, tmp)
+}
+
+/// Store `text` in `room`, optionally scoped to `wing`.
+async fn remember(state: &AppState, p: &str, text: &str, room: &str, wing: Option<&str>) {
+    let mut args = json!({
+        "palace": p, "text": text, "room": room, "force": true
+    });
+    if let Some(w) = wing {
+        args["wing"] = json!(w);
+    }
+    dispatch_tool(state, "memory_remember", args)
+        .await
+        .expect("memory_remember");
+}
+
+#[tokio::test]
+async fn wing_list_shows_the_default_wing() {
+    // Every palace has a default wing from the moment it opens — that is what
+    // makes "wing" never required of a caller.
+    let (state, _t) = palace("wingtest").await;
+    let out = dispatch_tool(&state, "wing_list", json!({ "palace": "wingtest" }))
+        .await
+        .expect("wing_list");
+    let wings = out["wings"].as_array().expect("wings array");
+    assert_eq!(wings.len(), 1, "exactly the default wing: {wings:?}");
+    assert_eq!(wings[0]["label"], "default");
+    assert_eq!(wings[0]["is_default"], true);
+    assert!(wings[0]["wing_id"].as_str().is_some_and(|s| !s.is_empty()));
+}
+
+#[tokio::test]
+async fn wing_create_then_list() {
+    let (state, _t) = palace("wingtest").await;
+    let created = dispatch_tool(
+        &state,
+        "wing_create",
+        json!({ "palace": "wingtest", "label": "engineer" }),
+    )
+    .await
+    .expect("wing_create");
+    assert_eq!(created["created"], true);
+    assert_eq!(created["label"], "engineer");
+
+    let out = dispatch_tool(&state, "wing_list", json!({ "palace": "wingtest" }))
+        .await
+        .expect("wing_list");
+    let labels: Vec<&str> = out["wings"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|w| w["label"].as_str().unwrap())
+        .collect();
+    assert!(labels.contains(&"default"), "{labels:?}");
+    assert!(labels.contains(&"engineer"), "{labels:?}");
+}
+
+#[tokio::test]
+async fn wing_create_is_idempotent_over_mcp() {
+    let (state, _t) = palace("wingtest").await;
+    let a = dispatch_tool(
+        &state,
+        "wing_create",
+        json!({ "palace": "wingtest", "label": "engineer" }),
+    )
+    .await
+    .expect("first");
+    // Case variant must resolve to the SAME wing, not a second one.
+    let b = dispatch_tool(
+        &state,
+        "wing_create",
+        json!({ "palace": "wingtest", "label": "ENGINEER" }),
+    )
+    .await
+    .expect("second");
+    assert_eq!(a["wing_id"], b["wing_id"]);
+    assert_eq!(b["created"], false);
+    assert_eq!(
+        dispatch_tool(&state, "wing_list", json!({ "palace": "wingtest" }))
+            .await
+            .unwrap()["wings"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[tokio::test]
+async fn wing_create_rejects_blank() {
+    let (state, _t) = palace("wingtest").await;
+    assert!(
+        dispatch_tool(
+            &state,
+            "wing_create",
+            json!({ "palace": "wingtest", "label": "   " })
+        )
+        .await
+        .is_err(),
+        "a blank wing label must be rejected, not silently aliased"
+    );
+}
+
+#[tokio::test]
+async fn wing_rename_over_mcp() {
+    let (state, _t) = palace("wingtest").await;
+    dispatch_tool(
+        &state,
+        "wing_create",
+        json!({ "palace": "wingtest", "label": "engineer" }),
+    )
+    .await
+    .expect("create");
+    let renamed = dispatch_tool(
+        &state,
+        "wing_rename",
+        json!({ "palace": "wingtest", "wing": "engineer", "new_label": "platform" }),
+    )
+    .await
+    .expect("rename");
+    assert_eq!(renamed["wing"]["label"], "platform");
+
+    // The old label is retired — a rename, not an alias.
+    assert!(
+        dispatch_tool(
+            &state,
+            "memory_list",
+            json!({ "palace": "wingtest", "wing": "engineer" })
+        )
+        .await
+        .is_err(),
+        "the retired label must no longer resolve"
+    );
+}
+
+#[tokio::test]
+async fn wing_rename_rejects_taken_label_over_mcp() {
+    let (state, _t) = palace("wingtest").await;
+    for label in ["engineer", "pm"] {
+        dispatch_tool(
+            &state,
+            "wing_create",
+            json!({ "palace": "wingtest", "label": label }),
+        )
+        .await
+        .expect("create");
+    }
+    assert!(
+        dispatch_tool(
+            &state,
+            "wing_rename",
+            json!({ "palace": "wingtest", "wing": "engineer", "new_label": "pm" }),
+        )
+        .await
+        .is_err(),
+        "renaming onto another wing's label must fail"
+    );
+}
+
+#[tokio::test]
+async fn wing_scoped_write_then_recall_over_mcp() {
+    // The end-to-end acceptance case: two agent types hold same-named rooms,
+    // write into them, and each recalls only its own.
+    let (state, _t) = palace("wingtest").await;
+    for label in ["engineer", "pm"] {
+        dispatch_tool(
+            &state,
+            "wing_create",
+            json!({ "palace": "wingtest", "label": label }),
+        )
+        .await
+        .expect("create wing");
+    }
+    remember(
+        &state,
+        "wingtest",
+        "The retry budget for the ingest worker is three attempts",
+        "Planning",
+        Some("engineer"),
+    )
+    .await;
+    remember(
+        &state,
+        "wingtest",
+        "The launch review is scheduled for the last Thursday of the quarter",
+        "Planning",
+        Some("pm"),
+    )
+    .await;
+
+    let eng = dispatch_tool(
+        &state,
+        "memory_list",
+        json!({ "palace": "wingtest", "wing": "engineer" }),
+    )
+    .await
+    .expect("list engineer");
+    let eng_rows = eng["drawers"].as_array().expect("drawers");
+    assert_eq!(eng_rows.len(), 1, "engineer wing holds one drawer");
+    assert!(
+        eng_rows[0]["content"]
+            .as_str()
+            .unwrap()
+            .contains("retry budget"),
+        "got {:?}",
+        eng_rows[0]["content"]
+    );
+
+    let pm = dispatch_tool(
+        &state,
+        "memory_list",
+        json!({ "palace": "wingtest", "wing": "pm" }),
+    )
+    .await
+    .expect("list pm");
+    let pm_rows = pm["drawers"].as_array().expect("drawers");
+    assert_eq!(pm_rows.len(), 1, "pm wing holds one drawer");
+    assert!(pm_rows[0]["content"]
+        .as_str()
+        .unwrap()
+        .contains("launch review"));
+
+    // And wing-scoped RECALL returns only that wing's drawer.
+    let recalled = dispatch_tool(
+        &state,
+        "memory_recall",
+        json!({ "palace": "wingtest", "query": "retry budget ingest worker", "wing": "engineer" }),
+    )
+    .await
+    .expect("wing-scoped recall");
+    let contents: Vec<String> = recalled["results"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|r| r["content"].as_str().map(str::to_string))
+        .collect();
+    // Both halves are required. Asserting only the ABSENCE of the other wing's
+    // content would let an implementation that returns nothing at all pass —
+    // and this is the test guarding the headline claim that wings are
+    // reachable AND scoped, so a silent zero-result regression is exactly the
+    // failure it must catch.
+    assert!(
+        contents.iter().any(|c| c.contains("retry budget")),
+        "engineer-wing recall returned no matching drawer: {contents:?}"
+    );
+    assert!(
+        !contents.iter().any(|c| c.contains("launch review")),
+        "a pm-wing drawer leaked into an engineer-wing recall: {contents:?}"
+    );
+}
+
+#[tokio::test]
+async fn a_caller_that_never_names_a_wing_is_unaffected() {
+    // The guarantee most likely to regress: every pre-wing call shape must
+    // behave exactly as it did — no wing argument anywhere, all drawers
+    // visible, default wing used implicitly.
+    let (state, _t) = palace("wingtest").await;
+    remember(
+        &state,
+        "wingtest",
+        "The ingest worker retries three times before giving up",
+        "Planning",
+        None,
+    )
+    .await;
+    remember(
+        &state,
+        "wingtest",
+        "Documentation lives under the docs directory in this repository",
+        "Documentation",
+        None,
+    )
+    .await;
+
+    let all = dispatch_tool(&state, "memory_list", json!({ "palace": "wingtest" }))
+        .await
+        .expect("unscoped list");
+    assert_eq!(
+        all["drawers"].as_array().expect("drawers").len(),
+        2,
+        "an unscoped list must return every drawer"
+    );
+
+    // The pre-existing room filter still works, untouched by wings.
+    let planning = dispatch_tool(
+        &state,
+        "memory_list",
+        json!({ "palace": "wingtest", "room": "Planning" }),
+    )
+    .await
+    .expect("room list");
+    assert_eq!(planning["drawers"].as_array().unwrap().len(), 1);
+
+    // And those wing-less writes landed in the default wing, which now
+    // reports a non-zero room population.
+    let wings = dispatch_tool(&state, "wing_list", json!({ "palace": "wingtest" }))
+        .await
+        .expect("wing_list");
+    let default = &wings["wings"].as_array().unwrap()[0];
+    assert_eq!(default["is_default"], true);
+    assert_eq!(
+        default["room_count"], 2,
+        "both wing-less rooms belong to the default wing: {default:?}"
+    );
+}
+
+#[tokio::test]
+async fn recall_rejects_an_unknown_wing() {
+    // Fail LOUD at the tool boundary: a typo'd wing that returned zero results
+    // would read as "no memories" rather than "you misspelled it".
+    let (state, _t) = palace("wingtest").await;
+    let err = dispatch_tool(
+        &state,
+        "memory_recall",
+        json!({ "palace": "wingtest", "query": "anything", "wing": "nosuchwing" }),
+    )
+    .await
+    .expect_err("unknown wing must error");
+    let msg = format!("{err:#}");
+    assert!(msg.contains("unknown wing"), "{msg}");
+    assert!(
+        msg.contains("wing_list"),
+        "the error must name the remedy: {msg}"
+    );
+}
+
+#[tokio::test]
+async fn memory_list_rejects_wing_and_room_together() {
+    // A filter the caller supplied and the server ignored is exactly the
+    // invisible failure ADR-0027 exists to remove.
+    let (state, _t) = palace("wingtest").await;
+    assert!(
+        dispatch_tool(
+            &state,
+            "memory_list",
+            json!({ "palace": "wingtest", "wing": "default", "room": "Planning" }),
+        )
+        .await
+        .is_err(),
+        "wing+room must be rejected, not silently half-honoured"
+    );
+}
+
+#[tokio::test]
+async fn wing_rename_rejects_blank_new_label() {
+    // Same boundary guard `wing_create` has — the two must fail identically.
+    let (state, _t) = palace("wingtest").await;
+    dispatch_tool(
+        &state,
+        "wing_create",
+        json!({ "palace": "wingtest", "label": "engineer" }),
+    )
+    .await
+    .expect("create");
+    assert!(
+        dispatch_tool(
+            &state,
+            "wing_rename",
+            json!({ "palace": "wingtest", "wing": "engineer", "new_label": "   " }),
+        )
+        .await
+        .is_err(),
+        "a blank new_label must be rejected"
+    );
+}
+
+#[tokio::test]
+async fn palace_info_reports_real_wings() {
+    // ADR-0027 T9 replaces T8's hardcoded `1`. `wing_count` must track the
+    // WINGS registry and agree with what `wing_list` returns.
+    let (state, _t) = palace("wingtest").await;
+    let info = dispatch_tool(&state, "palace_info", json!({ "palace": "wingtest" }))
+        .await
+        .expect("palace_info");
+    assert_eq!(info["wing_count"], 1, "a fresh palace has its default wing");
+
+    for label in ["engineer", "pm"] {
+        dispatch_tool(
+            &state,
+            "wing_create",
+            json!({ "palace": "wingtest", "label": label }),
+        )
+        .await
+        .expect("create wing");
+    }
+    let info = dispatch_tool(&state, "palace_info", json!({ "palace": "wingtest" }))
+        .await
+        .expect("palace_info");
+    assert_eq!(
+        info["wing_count"], 3,
+        "wing_count must be a real count, not a constant: {info:?}"
+    );
+
+    let listed = dispatch_tool(&state, "wing_list", json!({ "palace": "wingtest" }))
+        .await
+        .expect("wing_list")["wings"]
+        .as_array()
+        .expect("wings")
+        .len();
+    assert_eq!(
+        info["wing_count"].as_u64().unwrap() as usize,
+        listed,
+        "palace_info and wing_list must never disagree"
+    );
+}
+
+#[tokio::test]
+async fn deep_recall_honours_a_wing_scope() {
+    // ADR-0027 T7 gave L3 a room filter; T9 must not leave `memory_recall_deep`
+    // silently ignoring `wing` — that is the invisible-failure class the ADR
+    // exists to remove.
+    let (state, _t) = palace("wingtest").await;
+    for label in ["engineer", "pm"] {
+        dispatch_tool(
+            &state,
+            "wing_create",
+            json!({ "palace": "wingtest", "label": label }),
+        )
+        .await
+        .expect("create wing");
+    }
+    remember(
+        &state,
+        "wingtest",
+        "The retry budget for the ingest worker is three attempts",
+        "Planning",
+        Some("engineer"),
+    )
+    .await;
+    remember(
+        &state,
+        "wingtest",
+        "The launch review is scheduled for the last Thursday of the quarter",
+        "Planning",
+        Some("pm"),
+    )
+    .await;
+
+    let out = dispatch_tool(
+        &state,
+        "memory_recall_deep",
+        json!({ "palace": "wingtest", "query": "retry budget ingest worker", "wing": "engineer" }),
+    )
+    .await
+    .expect("deep recall");
+    let contents: Vec<String> = out["results"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default()
+        .iter()
+        .filter_map(|r| r["content"].as_str().map(str::to_string))
+        .collect();
+    assert!(
+        !contents.iter().any(|c| c.contains("launch review")),
+        "a pm-wing drawer leaked into an engineer-wing deep recall: {contents:?}"
+    );
+}
+
+#[tokio::test]
+async fn recall_rejects_wing_and_room_together() {
+    // The shared scope resolver must reject the combination on every read
+    // path, not just memory_list.
+    let (state, _t) = palace("wingtest").await;
+    for tool in ["memory_recall", "memory_recall_deep"] {
+        assert!(
+            dispatch_tool(
+                &state,
+                tool,
+                json!({ "palace": "wingtest", "query": "x", "wing": "default", "room": "Planning" }),
+            )
+            .await
+            .is_err(),
+            "{tool} must reject wing+room together"
+        );
+    }
+}
+
+#[tokio::test]
+async fn wing_tools_are_listed() {
+    // The acceptance bar itself: the tools are advertised on the MCP surface,
+    // so an agent can discover them without being told they exist.
+    let defs = trusty_memory::tools::tool_definitions();
+    let names: Vec<&str> = defs["tools"]
+        .as_array()
+        .expect("tools array")
+        .iter()
+        .filter_map(|t| t["name"].as_str())
+        .collect();
+    for tool in ["wing_list", "wing_create", "wing_rename"] {
+        assert!(names.contains(&tool), "{tool} missing from tools/list");
+    }
+}


### PR DESCRIPTION
Implements ADR-0027 ticket **T9**. Closes #4809. Epic #4798.

## The gate, and how it is honoured

ADR-0027 gated T9 on a #3064 consumer existing. The owner lifted that wait on
2026-08-04 ("implement wings too, don't wait on 3064").

The override relocates the ADR's reasoning rather than repealing it. The
argument was never "wait for #3064" — it was **"a level nobody reads is the
defect"**, and `Wing` having zero construction sites since the day it was
written is precisely the bug being fixed. So **Wing ships with its own
consumer**: `wing_list` / `wing_create` / `wing_rename`, an optional `wing` on
`memory_remember` / `memory_recall` / `memory_list`, and wing-scoped recall.
No dark table.

**The wing surface IS reachable by an MCP caller.** `crates/trusty-memory/tests/wing_mcp.rs`
drives every one of those through `dispatch_tool` — the exact path an agent
takes — including `wing_tools_are_listed`, which asserts the three tools appear
in the `tools/list` payload.

## Design

A **Wing is the "who"** (scope/ownership); a **Room stays the "what"** (topic).
The wing id is part of the canonical room key, so `engineer`/`Planning` and
`pm`/`Planning` are genuinely two rooms — no `Custom("engineer-planning")` name
mangling.

- `WINGS` / `WING_KEYS` redb tables in the palace's `kg.db`, initialised in the
  same transaction as `DRAWERS` and `ROOMS` so the schema is never half-present
  (ADR-0027 D1.1 — wings, rooms, and drawers corrupt and recover as one unit).
- `memory_core/wing_identity.rs` — canonical keys and UUIDv5 minting, mirroring
  `room_identity`. Pure, no I/O.
- `memory_core/store/wings.rs` — record shape, default-wing seeding,
  create/rename/list, and the rooms-in-wing join.
- `memory_core/store/kg_redb/wing_ops.rs` — insert-only accessors, except the
  `put_wing`/`remove_wing_key` pair that serves `wing_rename`.
- `memory_core/retrieval/scope.rs` — `RecallScope` (`All` / `Room` / `Wing`) and
  `list_drawers_in_wing`.

## Migration safety — naming, never reclassification

Every `RoomRecord` has carried `DEFAULT_WING_ID` since T1, so placing existing
rooms in the default wing requires **no write to `ROOMS` at all**: the migration
inserts ONE row describing a wing every room already points at.

**Zero drawer rows change and zero room ids are rewritten**, proven byte-for-byte
on *both* tables — not a decoded compare, which could mask a rewrite that
round-trips:

- `seeding_the_default_wing_changes_no_room_or_drawer_rows` — raw redb snapshots
  of `DRAWERS` **and** `ROOMS` before/after, asserted byte-identical, plus a
  check that every legacy room is already in the default wing.
- `wing_rename_changes_no_room_or_drawer_rows` — same byte-level proof for a
  rename (rooms reference a wing by id, so the id never moves).
- `seeding_leaves_room_resolution_byte_identical` — a legacy room still resolves
  to the exact fold value its drawers carry.

**Idempotent:** seeding probes by **id**, not by key, so re-running cannot
resurrect a retired label as an alias. `wing_rename_survives_reseed` renames a
wing between two runs and asserts the new name survives and the old one does not
resolve.

## Wing is never required of a caller

No pre-existing call site gains an argument, and the guarantee is structural
rather than a promise:

- `retrieve_l2` and `recall` keep their signatures and delegate to
  `retrieve_l2_scoped` / `recall_scoped` with `RecallScope::All` or `::Room`,
  reaching exactly the code that ran before.
- `RememberOptions.wing_id` defaults to `None`, which resolves in the default
  wing — byte-identically to the line it replaced.
- Covered by `a_caller_that_never_names_a_wing_is_unaffected` (MCP level),
  `unscoped_recall_is_unchanged_by_wings`, and
  `unscoped_write_still_lands_in_the_default_wing`.

## Scope boundaries fail closed — and fail loud at the edge

A wing that cannot be resolved admits **nothing**, not everything. A topic filter
that fails open shows extra rows; a *scope* that fails open is a leak, which is
exactly #3064's "two agent types cannot accidentally read/write the same room"
criterion. At the MCP boundary the posture flips to **fail-loud**: an unknown
wing errors and names `wing_list`, because a typo'd wing returning zero results
reads as "no memories". `memory_list` likewise rejects `wing`+`room` together
rather than honouring one and silently dropping the other.

A wing-scoped `memory_recall` skips the BM25 lane, which has no wing awareness
and would otherwise fuse unscoped hits into a scoped result.

## Deliberately deferred

**`PalaceInfo.wing_count` still reports a room count (ADR-0027 C3.4).** T8 owns
that field's semantics — it had to choose between reporting `1`, absent/`Option`,
or deprecated while wings did not exist — and `feat-rooms-surface` (T5–T10) is
not on origin yet. Making it report real wings is a follow-up that must **agree
with T8's actual choice** rather than guess at it. Everything in this PR is
additive and independent of T6/T7's room tools.

Also deferred: `memory_recall_deep` takes no `wing` (T7 owns adding a filter to
L3), and `wing`+`room` intersection.

## Test ladder

Rung 4 (cross-crate, shared library `trusty-common`).

```
cargo test -p trusty-common -p trusty-memory   → exit 0, 30 suites ok, 0 failed
  trusty-common lib:  1226 passed; 0 failed; 25 ignored
  trusty-memory lib:   489 passed; 0 failed;  4 ignored
  wing_mcp:             11 passed; 0 failed
cargo clippy --workspace --all-targets -- -D warnings → exit 0
cargo fmt --check                                     → exit 0
bash scripts/check_line_cap.sh    → 3651 files, 0 violations — OK
bash scripts/check_sld.sh         → 0 errors, 0 warnings
bash scripts/check_test_pointers.sh → 21087 citations, 0 dangling — OK
bash scripts/check_changelog_fragment.sh → both crates recorded
```

`retrieval/handle.rs` re-measured on this base: **489/500** (+2). All new logic
is in new sibling files.

**Version-bump parity (#4421):** no bump required — `trusty-common` 0.28.1 and
`trusty-memory` 0.22.0 are both already ahead of crates.io (0.28.0 / 0.21.2).
Note for whoever cuts the next `trusty-common` release: `RememberOptions` gained
a public field, recorded in a `Changed` fragment.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
