### PR TITLE
fix(trusty-mpm): auto-deploy bundled agent assets at session start

### DIFF
--- a/crates/trusty-mpm/changelog.d/4840-agent-asset-autodeploy.md
+++ b/crates/trusty-mpm/changelog.d/4840-agent-asset-autodeploy.md
@@ -1,0 +1,6 @@
+Fixed
+
+- Bundled agent assets now reach running agents without a manual `tm install` (closes [#4840](https://github.com/bobmatnyc/trusty-tools/issues/4840))
+  - session provisioning re-materializes `~/.trusty-mpm/framework/agents/` from the compiled-in bundle and deploys it, gated on a sha256 stamp so an unchanged bundle costs one file read
+  - a bundled-origin file whose checksum drifted is still overwritten (corruption, not user ownership); an untracked-and-differing or user-edited file is still preserved — but is now named in a warning instead of being skipped silently
+  - the whole step fails open: a refresh or deploy that cannot run degrades to a warning and never blocks the session

--- a/crates/trusty-mpm/changelog.d/4840-agent-asset-autodeploy.md
+++ b/crates/trusty-mpm/changelog.d/4840-agent-asset-autodeploy.md
@@ -1,6 +1,9 @@
 Fixed
 
-- Bundled agent assets now reach running agents without a manual `tm install` (closes [#4840](https://github.com/bobmatnyc/trusty-tools/issues/4840))
-  - session provisioning re-materializes `~/.trusty-mpm/framework/agents/` from the compiled-in bundle and deploys it, gated on a sha256 stamp so an unchanged bundle costs one file read
-  - a bundled-origin file whose checksum drifted is still overwritten (corruption, not user ownership); an untracked-and-differing or user-edited file is still preserved — but is now named in a warning instead of being skipped silently
+- Bundled agent assets now reach a **daemon-managed** session without a manual `tm install` (closes [#4840](https://github.com/bobmatnyc/trusty-tools/issues/4840))
+  - managed session provisioning re-materializes `~/.trusty-mpm/framework/agents/` from the compiled-in bundle and deploys it, gated on a sha256 stamp so an unchanged bundle costs one file read
+  - the standalone path (`tm run` / `tm load` / `tm login`) still routes through `global_config::ensure_global_config_dir`, which does not refresh — tracked as [#4849](https://github.com/bobmatnyc/trusty-tools/issues/4849)
+  - a bundled-origin file whose checksum drifted is still overwritten (corruption, not user ownership); an untracked-and-differing or user-edited file is still preserved — but now surfaces in a bounded count-plus-preview warning carrying the `tm install --reset-agents <name>` pointer, instead of being skipped silently
+  - agents that fail to compose (bad frontmatter, strict-YAML rejection) are reported in the same summary — those do not land at all, which is worse than stale
+  - an uninitialized `agents/agents` submodule directory no longer wins the source resolution and deploys nothing; it falls back to the compiled-in bundle
   - the whole step fails open: a refresh or deploy that cannot run degrades to a warning and never blocks the session

--- a/crates/trusty-mpm/src/core/agent_source.rs
+++ b/crates/trusty-mpm/src/core/agent_source.rs
@@ -1,0 +1,302 @@
+//! Self-healing materialization + auto-deploy of the bundled agent *source*
+//! directory (`~/.trusty-mpm/framework/agents/`) — issue #4840.
+//!
+//! Why: `crates/trusty-mpm/src/assets/agents/*.md` is compiled into the binary
+//! (`bundle::ALL`), but the ONLY code path that ever wrote it to disk was the
+//! separate, manual `tm install`. Rebuilding the binary did not trigger it;
+//! starting a session did not trigger it. So a merged, compiled-in instruction
+//! change (e.g. a new `BASE-AGENT.md` rule) silently had no effect until
+//! someone remembered to re-run `tm install` — measured on 2026-08-04 as a
+//! deployed `BASE-AGENT.md` three days older than the binary containing the
+//! fix, with no warning anywhere. Skills already solved exactly this
+//! (`skill_source::ensure_skill_source_fresh`, issue #1917); agents were the
+//! missing half.
+//!
+//! What: [`agent_bundle_stamp`] fingerprints the compiled-in `agents/*` slice
+//! of [`bundle::ALL`] via sha256 — this is the cheap gate, so the common
+//! "nothing changed" case costs one file read and one string compare.
+//! [`materialize_agent_artifacts`] writes every bundled agent into the source
+//! directory and prunes any `.md` file the current table no longer lists (a
+//! renamed or removed agent). [`ensure_agent_source_fresh`] compares the stamp
+//! against a marker file and re-materializes only on a mismatch.
+//! [`autodeploy_agents`] is the entry point session provisioning calls: it
+//! refreshes the source, deploys it, and returns a report — it NEVER returns
+//! an error, because a broken deploy must not block a session (a stale file is
+//! the strictly lesser failure). Anything it declined to overwrite is named in
+//! [`AgentAutodeploy::warnings`], closing the other half of #4840: the
+//! deployer's user-edited-file protection previously skipped silently.
+//!
+//! Overwrite policy (#4840, decided): a BUNDLED-origin file whose checksum
+//! drifted IS overwritten — the deploy tracker (`.trusty-mpm-manifest.json`)
+//! records `origin`, and `agents::deployer` already treats framework-owned
+//! drift as corruption rather than user ownership (#4408). Auto-deploy
+//! inherits that unchanged. Only an UNTRACKED file that differs, or a
+//! user-owned (seed-once tier) entry that was edited, is preserved — and now
+//! warned about by name.
+//!
+//! Test: `crates/trusty-mpm/src/core/agent_source_tests.rs`.
+
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::core::agent_deployer::{DeployResult, deploy_agents};
+use crate::core::agent_manifest::{atomic_write, checksum};
+use crate::core::bundle;
+use crate::core::error::Result;
+use crate::core::paths::FrameworkPaths;
+
+/// Marker file recording the last-materialized bundle stamp, written directly
+/// under the agent source directory (`<agents_dir>/.bundle-stamp`).
+///
+/// Mirrors `skill_source::STAMP_FILE_NAME`; hidden (leading `.`) so the prune
+/// sweep never considers it a stale agent.
+const STAMP_FILE_NAME: &str = ".bundle-stamp";
+
+/// Outcome of one [`autodeploy_agents`] run.
+///
+/// Why: the caller needs to know whether anything changed (to log it) and,
+/// critically, WHICH files were left stale — #4840's second half is that a
+/// declined overwrite was silent.
+/// What: `refreshed` is `true` when the source directory was re-materialized
+/// from the compiled-in bundle this run; `deployed` lists the composed agent
+/// files actually (re)written into the target; `warnings` carries one
+/// human-readable line per file left stale, plus one line if the refresh or
+/// the deploy itself failed outright.
+/// Test: every `autodeploy_*` case in `agent_source_tests.rs`.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct AgentAutodeploy {
+    /// Whether the source directory was re-materialized from the bundle.
+    pub refreshed: bool,
+    /// Composed agent filenames (re)written into the target this run.
+    pub deployed: Vec<String>,
+    /// One line per file left stale, or per step that failed. Always safe to
+    /// print verbatim; empty means nothing was declined and nothing failed.
+    pub warnings: Vec<String>,
+}
+
+/// Compute a stable sha256 fingerprint over every `agents/*` entry in the
+/// compiled-in [`bundle::ALL`] table.
+///
+/// Why: this is the gate that makes auto-deploy cheap. It detects "this binary
+/// embeds different agent content than what is on disk" without depending on
+/// file mtimes, which a backup/restore (or a `cargo install` that preserves
+/// timestamps) can shuffle.
+/// What: concatenates `<rel_path>\0<contents>\n` for every table entry whose
+/// `rel_path` starts with `"agents/"`, in table order, and returns the sha256
+/// hex digest.
+/// Test: `agent_bundle_stamp_is_stable_across_calls`,
+/// `agent_bundle_stamp_differs_from_skill_stamp`.
+pub fn agent_bundle_stamp() -> String {
+    let mut buf = String::new();
+    for artifact in bundle::ALL
+        .iter()
+        .filter(|a| a.rel_path.starts_with("agents/"))
+    {
+        buf.push_str(artifact.rel_path);
+        buf.push('\0');
+        buf.push_str(artifact.contents);
+        buf.push('\n');
+    }
+    checksum(&buf)
+}
+
+/// Write every bundled `agents/*` artifact into `agents_dir`, pruning any
+/// `.md` file on disk the current table no longer lists.
+///
+/// Why: `agents_dir` (`~/.trusty-mpm/framework/agents/`) is a framework-owned
+/// artifact directory — every entry is written exclusively by trusty-mpm's own
+/// installer/self-heal path, never hand-edited (the USER-level agent source is
+/// the separate `~/.trusty-mpm/agents/`). So it is safe, and necessary for the
+/// renamed-agent case, to prune rather than only add.
+/// What: creates `agents_dir` if absent, atomically (over)writes each
+/// `agents/*` artifact to `<agents_dir>/<basename>`, then removes any
+/// remaining top-level `*.md` file that is not one of the artifacts just
+/// written. Hidden files (leading `.`, e.g. the stamp marker and the deploy
+/// manifest) are never touched. Returns the basenames written.
+/// Test: `materialize_agent_artifacts_writes_all_agents`,
+/// `materialize_agent_artifacts_prunes_files_not_in_table`.
+pub fn materialize_agent_artifacts(agents_dir: &Path) -> Result<Vec<String>> {
+    std::fs::create_dir_all(agents_dir)?;
+
+    let mut written = Vec::new();
+    let mut keep: HashSet<String> = HashSet::new();
+    for artifact in bundle::ALL
+        .iter()
+        .filter(|a| a.rel_path.starts_with("agents/"))
+    {
+        let basename = artifact
+            .rel_path
+            .strip_prefix("agents/")
+            .unwrap_or(artifact.rel_path);
+        let dest = agents_dir.join(basename);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        atomic_write(&dest, artifact.contents)?;
+        keep.insert(basename.to_string());
+        written.push(basename.to_string());
+    }
+
+    for entry in std::fs::read_dir(agents_dir)? {
+        let entry = entry?;
+        let Some(name) = entry.file_name().to_str().map(str::to_owned) else {
+            continue;
+        };
+        if name.starts_with('.') || !name.ends_with(".md") {
+            continue;
+        }
+        if !keep.contains(name.as_str()) {
+            std::fs::remove_file(entry.path())?;
+        }
+    }
+
+    Ok(written)
+}
+
+/// Ensure `agents_dir` reflects the binary's currently-embedded agent bundle,
+/// re-materializing it when missing or stale.
+///
+/// Why: the self-healing entry point behind [`autodeploy_agents`] — it removes
+/// the dependency on a prior, separate `tm install` having refreshed the
+/// source directory (#4840).
+/// What: compares [`agent_bundle_stamp`] against `<agents_dir>/.bundle-stamp`;
+/// when they differ (including "stamp file absent", which covers a missing or
+/// never-materialized directory), calls [`materialize_agent_artifacts`] and
+/// rewrites the stamp. Returns `true` when a refresh happened, `false` when
+/// the source was already current.
+/// Test: `ensure_agent_source_fresh_materializes_when_missing`,
+/// `ensure_agent_source_fresh_is_noop_when_current`,
+/// `ensure_agent_source_fresh_prunes_renamed_files`.
+pub fn ensure_agent_source_fresh(agents_dir: &Path) -> Result<bool> {
+    let stamp_path = agents_dir.join(STAMP_FILE_NAME);
+    let current = agent_bundle_stamp();
+    if std::fs::read_to_string(&stamp_path).ok().as_deref() == Some(current.as_str()) {
+        return Ok(false);
+    }
+
+    materialize_agent_artifacts(agents_dir)?;
+    atomic_write(&stamp_path, &current)?;
+    Ok(true)
+}
+
+/// One warning line per file the deploy declined to overwrite.
+///
+/// Why: #4840's second half. `agents::deployer` preserves an untracked-and-
+/// differing file, and a user-owned (seed-once tier) entry that was edited,
+/// **silently** — which is precisely what let a three-day-stale `BASE-AGENT.md`
+/// go unnoticed. Whatever auto-deploy declines to fix, it must name.
+/// What: maps [`DeployResult::skipped`] to lines, distinguishing the
+/// untracked-and-modified case (which `tm install --reset-agents` resolves)
+/// from a tracked user-owned edit. Returns an empty vector when nothing was
+/// skipped. Pure — no I/O, no logging.
+/// Test: `skip_warning_lines_names_each_skipped_file`,
+/// `skip_warning_lines_is_empty_when_nothing_skipped`.
+pub fn skip_warning_lines(result: &DeployResult) -> Vec<String> {
+    let untracked: HashSet<&str> = result
+        .untracked_modified
+        .iter()
+        .map(String::as_str)
+        .collect();
+    result
+        .skipped
+        .iter()
+        .map(|file| {
+            if untracked.contains(file.as_str()) {
+                format!(
+                    "warning: agent {file} is stale — it is not tracked by the deploy manifest \
+                     and differs from the bundled version, so it was NOT updated. \
+                     Run `tm install --reset-agents {}` to adopt it.",
+                    file.strip_suffix(".md").unwrap_or(file)
+                )
+            } else {
+                format!(
+                    "warning: agent {file} is stale — it is user-owned and edited, \
+                     so it was NOT updated with the bundled version."
+                )
+            }
+        })
+        .collect()
+}
+
+/// Refresh the bundled agent source from the compiled-in bundle and deploy it,
+/// reporting anything left stale. Never fails.
+///
+/// Why: this is what makes a merged `BASE-AGENT.md` change reach a running
+/// agent without a manual `tm install` (#4840). It is called from session
+/// provisioning, so it MUST fail open: if the refresh or the deploy cannot
+/// run, the session still starts with whatever is already on disk. A stale
+/// file is a strictly better failure than a session that will not launch.
+/// What: (1) [`ensure_agent_source_fresh`] on `source_dir` — cheap when the
+/// stamp matches; (2) [`deploy_agents`] from `source_dir` into `target_dir`,
+/// which composes and writes only the files it safely may (bundled-origin
+/// drift IS overwritten — see the module doc's overwrite policy); (3) collects
+/// [`skip_warning_lines`] for everything it declined. Every failure is
+/// converted into a warning line rather than an `Err`.
+/// Test: `autodeploy_agents_deploys_when_bundle_differs`,
+/// `autodeploy_agents_is_a_noop_when_already_current`,
+/// `autodeploy_agents_fails_open_when_target_is_unwritable`,
+/// `autodeploy_agents_warns_when_it_skips_a_user_modified_file`.
+pub fn autodeploy_agents(source_dir: &Path, target_dir: &Path) -> AgentAutodeploy {
+    let mut out = AgentAutodeploy::default();
+
+    match ensure_agent_source_fresh(source_dir) {
+        Ok(refreshed) => out.refreshed = refreshed,
+        Err(err) => out.warnings.push(format!(
+            "warning: could not refresh the bundled agent source at {} ({err}) — \
+             continuing with whatever is already on disk",
+            source_dir.display()
+        )),
+    }
+
+    match deploy_agents(source_dir, target_dir) {
+        Ok(result) => {
+            out.warnings.extend(skip_warning_lines(&result));
+            out.deployed = result.deployed;
+        }
+        Err(err) => out.warnings.push(format!(
+            "warning: could not deploy agents into {} ({err}) — \
+             this session runs with the previously deployed agents",
+            target_dir.display()
+        )),
+    }
+
+    out
+}
+
+/// [`autodeploy_agents`] against a resolved framework layout, with the
+/// git-submodule guard applied.
+///
+/// Why: [`FrameworkPaths::agent_source_dir`] prefers the `agents/agents` git
+/// submodule when a source checkout has one. That directory is git-tracked and
+/// authoritative on its own — materializing the compiled-in bundle over it
+/// would be destructive and wrong. Callers holding a `FrameworkPaths` should
+/// use this instead of [`autodeploy_agents`] so they cannot get that wrong.
+/// (Mirrors `skill_source::ensure_skill_source_fresh`'s identical guard.)
+/// What: when the resolved source is the framework-owned
+/// [`FrameworkPaths::agents`] directory, delegates to [`autodeploy_agents`];
+/// when it is the submodule, deploys without refreshing the source. Never
+/// fails, for the same fail-open reason.
+/// Test: `autodeploy_agents_for_skips_source_refresh_on_submodule`.
+pub fn autodeploy_agents_for(paths: &FrameworkPaths, target_dir: &Path) -> AgentAutodeploy {
+    let source_dir = paths.agent_source_dir();
+    if source_dir != paths.agents {
+        let mut out = AgentAutodeploy::default();
+        match deploy_agents(&source_dir, target_dir) {
+            Ok(result) => {
+                out.warnings.extend(skip_warning_lines(&result));
+                out.deployed = result.deployed;
+            }
+            Err(err) => out.warnings.push(format!(
+                "warning: could not deploy agents into {} ({err}) — \
+                 this session runs with the previously deployed agents",
+                target_dir.display()
+            )),
+        }
+        return out;
+    }
+    autodeploy_agents(&source_dir, target_dir)
+}
+
+#[cfg(test)]
+#[path = "agent_source_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/agent_source.rs
+++ b/crates/trusty-mpm/src/core/agent_source.rs
@@ -1,5 +1,6 @@
-//! Self-healing materialization + auto-deploy of the bundled agent *source*
-//! directory (`~/.trusty-mpm/framework/agents/`) — issue #4840.
+//! Self-healing (against binary upgrade) materialization + auto-deploy of the
+//! bundled agent *source* directory (`~/.trusty-mpm/framework/agents/`) —
+//! issue #4840.
 //!
 //! Why: `crates/trusty-mpm/src/assets/agents/*.md` is compiled into the binary
 //! (`bundle::ALL`), but the ONLY code path that ever wrote it to disk was the
@@ -213,24 +214,33 @@ fn preview(items: &[String], limit: usize) -> String {
 /// settled that tradeoff for its own warning (issue #2504: count + preview);
 /// this is the same policy, not a second one. PR #4848 review (HIGH).
 /// What: at most two lines — one for [`DeployResult::skipped`] (with the
-/// actionable `tm install --reset-agents <name>` pointer), one for
+/// actionable `tm install --reset-agents <name>` pointer when
+/// [`DeployResult::untracked_modified`] is non-empty — `--reset-agents`
+/// resolves the untracked-and-differing case, not an edited seed-once entry,
+/// so the pointer never names a deliberate user customization), one for
 /// [`DeployResult::failed`], whose agents did not land AT ALL and are therefore
 /// worse than stale. Each is a count plus a short preview. Returns an empty
 /// vector on a clean deploy. Pure — no I/O, no logging.
 /// Test: `deploy_summary_lines_is_empty_on_a_clean_deploy`,
 /// `deploy_summary_lines_summarises_skips_in_one_line`,
+/// `deploy_summary_lines_omits_the_reset_pointer_for_user_owned_edits_only`,
+/// `deploy_summary_lines_names_the_untracked_modified_file_in_the_pointer`,
 /// `deploy_summary_lines_reports_failed_agents`.
 pub fn deploy_summary_lines(result: &DeployResult) -> Vec<String> {
     let mut lines = Vec::new();
 
     if !result.skipped.is_empty() {
         let count = result.skipped.len();
-        let head = &result.skipped[0];
-        let first = head.strip_suffix(".md").unwrap_or(head);
+        let pointer = result
+            .untracked_modified
+            .first()
+            .map_or_else(String::new, |head| {
+                let first = head.strip_suffix(".md").unwrap_or(head);
+                format!(" Run `tm install --reset-agents {first}` to adopt one.")
+            });
         lines.push(format!(
             "warning: {count} agent file(s) are stale — user-owned (untracked and differing, \
-             or an edited seed-once entry), so the bundled version was NOT written: {}. \
-             Run `tm install --reset-agents {first}` to adopt one.",
+             or an edited seed-once entry), so the bundled version was NOT written: {}.{pointer}",
             preview(&result.skipped, 5)
         ));
     }

--- a/crates/trusty-mpm/src/core/agent_source.rs
+++ b/crates/trusty-mpm/src/core/agent_source.rs
@@ -22,7 +22,8 @@
 //! [`autodeploy_agents`] is the entry point session provisioning calls: it
 //! refreshes the source, deploys it, and returns a report — it NEVER returns
 //! an error, because a broken deploy must not block a session (a stale file is
-//! the strictly lesser failure). Anything it declined to overwrite is named in
+//! the strictly lesser failure). Anything it declined to overwrite, and
+//! anything that failed to compose at all, is summarised in
 //! [`AgentAutodeploy::warnings`], closing the other half of #4840: the
 //! deployer's user-edited-file protection previously skipped silently.
 //!
@@ -59,9 +60,9 @@ const STAMP_FILE_NAME: &str = ".bundle-stamp";
 /// declined overwrite was silent.
 /// What: `refreshed` is `true` when the source directory was re-materialized
 /// from the compiled-in bundle this run; `deployed` lists the composed agent
-/// files actually (re)written into the target; `warnings` carries one
-/// human-readable line per file left stale, plus one line if the refresh or
-/// the deploy itself failed outright.
+/// files actually (re)written into the target; `warnings` carries a BOUNDED
+/// summary — at most one line for the stale set, one for the failed set, plus
+/// one line if the refresh or the deploy itself failed outright.
 /// Test: every `autodeploy_*` case in `agent_source_tests.rs`.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct AgentAutodeploy {
@@ -69,8 +70,11 @@ pub struct AgentAutodeploy {
     pub refreshed: bool,
     /// Composed agent filenames (re)written into the target this run.
     pub deployed: Vec<String>,
-    /// One line per file left stale, or per step that failed. Always safe to
-    /// print verbatim; empty means nothing was declined and nothing failed.
+    /// Bounded summary lines: one for the files left stale, one for the agents
+    /// that failed to compose, plus one per step that failed outright. Count +
+    /// preview, never one line per file — see [`deploy_summary_lines`]. Always
+    /// safe to print verbatim; empty means nothing was declined and nothing
+    /// failed.
     pub warnings: Vec<String>,
 }
 
@@ -179,43 +183,109 @@ pub fn ensure_agent_source_fresh(agents_dir: &Path) -> Result<bool> {
     Ok(true)
 }
 
-/// One warning line per file the deploy declined to overwrite.
+/// `count` + a short preview of `items`, for a one-line summary.
 ///
-/// Why: #4840's second half. `agents::deployer` preserves an untracked-and-
-/// differing file, and a user-owned (seed-once tier) entry that was edited,
-/// **silently** — which is precisely what let a three-day-stale `BASE-AGENT.md`
-/// go unnoticed. Whatever auto-deploy declines to fix, it must name.
-/// What: maps [`DeployResult::skipped`] to lines, distinguishing the
-/// untracked-and-modified case (which `tm install --reset-agents` resolves)
-/// from a tracked user-owned edit. Returns an empty vector when nothing was
-/// skipped. Pure — no I/O, no logging.
-/// Test: `skip_warning_lines_names_each_skipped_file`,
-/// `skip_warning_lines_is_empty_when_nothing_skipped`.
-pub fn skip_warning_lines(result: &DeployResult) -> Vec<String> {
-    let untracked: HashSet<&str> = result
-        .untracked_modified
+/// What: joins the first `limit` entries with `, `, appending `, …` when more
+/// were elided. Pure.
+/// Test: exercised through `deploy_summary_lines_*`.
+fn preview(items: &[String], limit: usize) -> String {
+    let head = items
         .iter()
+        .take(limit)
         .map(String::as_str)
-        .collect();
-    result
-        .skipped
-        .iter()
-        .map(|file| {
-            if untracked.contains(file.as_str()) {
-                format!(
-                    "warning: agent {file} is stale — it is not tracked by the deploy manifest \
-                     and differs from the bundled version, so it was NOT updated. \
-                     Run `tm install --reset-agents {}` to adopt it.",
-                    file.strip_suffix(".md").unwrap_or(file)
-                )
-            } else {
-                format!(
-                    "warning: agent {file} is stale — it is user-owned and edited, \
-                     so it was NOT updated with the bundled version."
-                )
-            }
-        })
-        .collect()
+        .collect::<Vec<_>>()
+        .join(", ");
+    if items.len() > limit {
+        format!("{head}, …")
+    } else {
+        head
+    }
+}
+
+/// A bounded summary of what a deploy left stale and what it failed to compose.
+///
+/// Why: #4840's second half is that `agents::deployer` preserves an untracked-
+/// and-differing file, and a user-owned (seed-once tier) entry that was edited,
+/// **silently** — which is precisely what let a three-day-stale `BASE-AGENT.md`
+/// go unnoticed. But this runs on EVERY spawn and every resume, and the stale
+/// set is never reconciled until someone runs `--reset-agents`, so one line per
+/// file would be permanent, dozens-wide log spam. `agents::deployer` already
+/// settled that tradeoff for its own warning (issue #2504: count + preview);
+/// this is the same policy, not a second one. PR #4848 review (HIGH).
+/// What: at most two lines — one for [`DeployResult::skipped`] (with the
+/// actionable `tm install --reset-agents <name>` pointer), one for
+/// [`DeployResult::failed`], whose agents did not land AT ALL and are therefore
+/// worse than stale. Each is a count plus a short preview. Returns an empty
+/// vector on a clean deploy. Pure — no I/O, no logging.
+/// Test: `deploy_summary_lines_is_empty_on_a_clean_deploy`,
+/// `deploy_summary_lines_summarises_skips_in_one_line`,
+/// `deploy_summary_lines_reports_failed_agents`.
+pub fn deploy_summary_lines(result: &DeployResult) -> Vec<String> {
+    let mut lines = Vec::new();
+
+    if !result.skipped.is_empty() {
+        let count = result.skipped.len();
+        let head = &result.skipped[0];
+        let first = head.strip_suffix(".md").unwrap_or(head);
+        lines.push(format!(
+            "warning: {count} agent file(s) are stale — user-owned (untracked and differing, \
+             or an edited seed-once entry), so the bundled version was NOT written: {}. \
+             Run `tm install --reset-agents {first}` to adopt one.",
+            preview(&result.skipped, 5)
+        ));
+    }
+
+    if !result.failed.is_empty() {
+        let count = result.failed.len();
+        lines.push(format!(
+            "warning: {count} agent(s) failed to compose and did NOT deploy at all — \
+             absent, not merely stale: {}.",
+            preview(&result.failed, 3)
+        ));
+    }
+
+    lines
+}
+
+/// Deploy `source_dir` into `target_dir`, folding the outcome into `out`.
+///
+/// What: on success records the deployed set and appends
+/// [`deploy_summary_lines`]; on failure appends a single fail-open warning.
+/// Test: exercised through every `autodeploy_agents*` case.
+fn deploy_into(source_dir: &Path, target_dir: &Path, out: &mut AgentAutodeploy) {
+    match deploy_agents(source_dir, target_dir) {
+        Ok(result) => {
+            out.warnings.extend(deploy_summary_lines(&result));
+            out.deployed = result.deployed;
+        }
+        Err(err) => out.warnings.push(format!(
+            "warning: could not deploy agents into {} ({err}) — \
+             this session runs with the previously deployed agents",
+            target_dir.display()
+        )),
+    }
+}
+
+/// Whether `dir` holds at least one non-hidden `.md` file.
+///
+/// Why: an *empty* `agents/agents` directory — an uninitialized git submodule
+/// on a source checkout — satisfies `agent_source_dir()`'s `is_dir()` test but
+/// is not an authoritative source; deploying from it lands nothing, silently.
+/// PR #4848 review. #4840 was originally measured on a source checkout, so this
+/// is not hypothetical.
+/// What: a shallow read of `dir`, ignoring hidden entries. A read error (absent
+/// or unreadable) counts as empty. Test:
+/// `autodeploy_agents_for_falls_back_when_the_submodule_is_empty`.
+fn has_agent_markdown(dir: &Path) -> bool {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        entry
+            .file_name()
+            .to_str()
+            .is_some_and(|name| !name.starts_with('.') && name.ends_with(".md"))
+    })
 }
 
 /// Refresh the bundled agent source from the compiled-in bundle and deploy it,
@@ -230,8 +300,8 @@ pub fn skip_warning_lines(result: &DeployResult) -> Vec<String> {
 /// stamp matches; (2) [`deploy_agents`] from `source_dir` into `target_dir`,
 /// which composes and writes only the files it safely may (bundled-origin
 /// drift IS overwritten — see the module doc's overwrite policy); (3) collects
-/// [`skip_warning_lines`] for everything it declined. Every failure is
-/// converted into a warning line rather than an `Err`.
+/// [`deploy_summary_lines`] for everything it declined or could not compose.
+/// Every failure is converted into a warning line rather than an `Err`.
 /// Test: `autodeploy_agents_deploys_when_bundle_differs`,
 /// `autodeploy_agents_is_a_noop_when_already_current`,
 /// `autodeploy_agents_fails_open_when_target_is_unwritable`,
@@ -248,17 +318,7 @@ pub fn autodeploy_agents(source_dir: &Path, target_dir: &Path) -> AgentAutodeplo
         )),
     }
 
-    match deploy_agents(source_dir, target_dir) {
-        Ok(result) => {
-            out.warnings.extend(skip_warning_lines(&result));
-            out.deployed = result.deployed;
-        }
-        Err(err) => out.warnings.push(format!(
-            "warning: could not deploy agents into {} ({err}) — \
-             this session runs with the previously deployed agents",
-            target_dir.display()
-        )),
-    }
+    deploy_into(source_dir, target_dir, &mut out);
 
     out
 }
@@ -272,29 +332,22 @@ pub fn autodeploy_agents(source_dir: &Path, target_dir: &Path) -> AgentAutodeplo
 /// would be destructive and wrong. Callers holding a `FrameworkPaths` should
 /// use this instead of [`autodeploy_agents`] so they cannot get that wrong.
 /// (Mirrors `skill_source::ensure_skill_source_fresh`'s identical guard.)
-/// What: when the resolved source is the framework-owned
-/// [`FrameworkPaths::agents`] directory, delegates to [`autodeploy_agents`];
-/// when it is the submodule, deploys without refreshing the source. Never
-/// fails, for the same fail-open reason.
-/// Test: `autodeploy_agents_for_skips_source_refresh_on_submodule`.
+/// What: when the resolved source is a POPULATED submodule, deploys from it
+/// without refreshing the source; otherwise — the framework-owned
+/// [`FrameworkPaths::agents`] directory, or an EMPTY submodule directory
+/// (uninitialized on a source checkout, which would otherwise deploy nothing
+/// at all, silently — PR #4848 review) — delegates to [`autodeploy_agents`]
+/// against the framework source. Never fails, for the same fail-open reason.
+/// Test: `autodeploy_agents_for_skips_source_refresh_on_submodule`,
+/// `autodeploy_agents_for_falls_back_when_the_submodule_is_empty`.
 pub fn autodeploy_agents_for(paths: &FrameworkPaths, target_dir: &Path) -> AgentAutodeploy {
     let source_dir = paths.agent_source_dir();
-    if source_dir != paths.agents {
+    if source_dir != paths.agents && has_agent_markdown(&source_dir) {
         let mut out = AgentAutodeploy::default();
-        match deploy_agents(&source_dir, target_dir) {
-            Ok(result) => {
-                out.warnings.extend(skip_warning_lines(&result));
-                out.deployed = result.deployed;
-            }
-            Err(err) => out.warnings.push(format!(
-                "warning: could not deploy agents into {} ({err}) — \
-                 this session runs with the previously deployed agents",
-                target_dir.display()
-            )),
-        }
+        deploy_into(&source_dir, target_dir, &mut out);
         return out;
     }
-    autodeploy_agents(&source_dir, target_dir)
+    autodeploy_agents(&paths.agents, target_dir)
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/core/agent_source_tests.rs
+++ b/crates/trusty-mpm/src/core/agent_source_tests.rs
@@ -173,6 +173,56 @@ fn deploy_summary_lines_summarises_skips_in_one_line() {
 }
 
 #[test]
+fn deploy_summary_lines_omits_the_reset_pointer_for_user_owned_edits_only() {
+    // PR #4848 review (MEDIUM, round 2): `skipped` mixes two ownership
+    // classes — untracked-and-differing files (which `--reset-agents`
+    // legitimately resolves) and edited seed-once (user-owned) entries, which
+    // it does not. When the only skip is a user-owned edit, the pointer must
+    // not appear at all — naming that file would instruct the operator to
+    // discard their own deliberate customization.
+    let result = DeployResult {
+        skipped: vec!["engineer.md".into()],
+        ..DeployResult::default()
+    };
+
+    let lines = deploy_summary_lines(&result);
+
+    assert_eq!(lines.len(), 1, "{lines:?}");
+    assert!(lines[0].contains("engineer.md"), "{:?}", lines[0]);
+    assert!(
+        !lines[0].contains("--reset-agents"),
+        "a user-owned edit must not carry the reset pointer: {:?}",
+        lines[0]
+    );
+}
+
+#[test]
+fn deploy_summary_lines_names_the_untracked_modified_file_in_the_pointer() {
+    // The companion case: when the skip set mixes a user-owned edit with an
+    // untracked-and-differing file, the pointer must name the
+    // untracked-modified entry, never `skipped[0]` unconditionally.
+    let result = DeployResult {
+        skipped: vec!["user-owned-edit.md".into(), "untracked-drift.md".into()],
+        untracked_modified: vec!["untracked-drift.md".into()],
+        ..DeployResult::default()
+    };
+
+    let lines = deploy_summary_lines(&result);
+
+    assert_eq!(lines.len(), 1, "{lines:?}");
+    assert!(
+        lines[0].contains("--reset-agents untracked-drift"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(
+        !lines[0].contains("--reset-agents user-owned-edit"),
+        "the pointer must never name the user-owned edit: {:?}",
+        lines[0]
+    );
+}
+
+#[test]
 fn deploy_summary_lines_reports_failed_agents() {
     // A compose failure means the agent does not land AT ALL — worse than
     // stale, and previously never surfaced anywhere (PR #4848 review, MEDIUM).

--- a/crates/trusty-mpm/src/core/agent_source_tests.rs
+++ b/crates/trusty-mpm/src/core/agent_source_tests.rs
@@ -3,9 +3,10 @@
 //!
 //! Why: #4840's four load-bearing behaviors are (1) the deploy fires when the
 //! compiled-in bundle differs from disk, (2) it is a no-op when identical,
-//! (3) it fails open when the target cannot be written, and (4) it WARNS,
-//! naming the file, whenever it declines to overwrite something. Each gets a
-//! test here.
+//! (3) it fails open when the target cannot be written, and (4) it WARNS —
+//! in a bounded count-plus-preview summary, not one line per file (PR #4848
+//! review) — whenever it declines to overwrite something or fails to compose
+//! it. Each gets a test here.
 //! What: hermetic — every case runs against `tempfile::TempDir`, never the
 //! real `~/.trusty-mpm`.
 //! Test: this file.
@@ -130,34 +131,65 @@ fn ensure_agent_source_fresh_prunes_renamed_files() {
 }
 
 #[test]
-fn skip_warning_lines_is_empty_when_nothing_skipped() {
+fn deploy_summary_lines_is_empty_on_a_clean_deploy() {
     let result = DeployResult {
         deployed: vec!["engineer.md".into()],
         ..DeployResult::default()
     };
-    assert!(skip_warning_lines(&result).is_empty());
+    assert!(deploy_summary_lines(&result).is_empty());
 }
 
 #[test]
-fn skip_warning_lines_names_each_skipped_file() {
+fn deploy_summary_lines_summarises_skips_in_one_line() {
+    // PR #4848 review (HIGH): the skipped set can be dozens wide and is never
+    // reconciled until someone runs `--reset-agents`, so this runs on every
+    // spawn and resume. It must be ONE line with a count + preview, matching
+    // `agents::deployer`'s #2504 policy — never one line per file.
+    let skipped: Vec<String> = (0..12).map(|i| format!("agent-{i}.md")).collect();
     let result = DeployResult {
-        skipped: vec!["engineer.md".into(), "qa.md".into()],
-        untracked_modified: vec!["engineer.md".into()],
+        skipped: skipped.clone(),
+        untracked_modified: vec!["agent-0.md".into()],
         ..DeployResult::default()
     };
 
-    let lines = skip_warning_lines(&result);
+    let lines = deploy_summary_lines(&result);
 
-    assert_eq!(lines.len(), 2);
-    // Every skipped file is named, and the two ownership cases read differently.
-    assert!(lines[0].contains("engineer.md"), "{:?}", lines[0]);
+    assert_eq!(lines.len(), 1, "one summary line, not N: {lines:?}");
+    assert!(lines[0].contains("12 agent file(s)"), "{:?}", lines[0]);
+    assert!(lines[0].contains("agent-0.md"), "{:?}", lines[0]);
+    assert!(lines[0].contains('…'), "elision marker: {:?}", lines[0]);
     assert!(
-        lines[0].contains("--reset-agents engineer"),
+        !lines[0].contains("agent-11.md"),
+        "the preview must be truncated: {:?}",
+        lines[0]
+    );
+    // The actionable pointer survives the shrink — the original silence was
+    // half the defect.
+    assert!(
+        lines[0].contains("--reset-agents agent-0"),
         "{:?}",
         lines[0]
     );
-    assert!(lines[1].contains("qa.md"), "{:?}", lines[1]);
-    assert!(lines[1].contains("user-owned"), "{:?}", lines[1]);
+}
+
+#[test]
+fn deploy_summary_lines_reports_failed_agents() {
+    // A compose failure means the agent does not land AT ALL — worse than
+    // stale, and previously never surfaced anywhere (PR #4848 review, MEDIUM).
+    let result = DeployResult {
+        failed: vec!["engineer: invalid frontmatter YAML: bad".into()],
+        ..DeployResult::default()
+    };
+
+    let lines = deploy_summary_lines(&result);
+
+    assert_eq!(lines.len(), 1, "{lines:?}");
+    assert!(lines[0].contains("engineer"), "{:?}", lines[0]);
+    assert!(
+        lines[0].contains("did NOT deploy at all"),
+        "the failure must read as worse than stale: {:?}",
+        lines[0]
+    );
 }
 
 #[test]
@@ -326,6 +358,41 @@ fn autodeploy_agents_for_skips_source_refresh_on_submodule() {
         "the git-tracked submodule must be left exactly as found"
     );
     assert!(target.join("submodule-agent.md").exists());
+}
+
+#[test]
+fn autodeploy_agents_for_falls_back_when_the_submodule_is_empty() {
+    // PR #4848 review: an EMPTY `agents/agents` (an uninitialized submodule on
+    // a source checkout — and #4840 was originally measured on one) satisfies
+    // `agent_source_dir()`'s `is_dir()` test, so the old code deployed from it
+    // and landed NOTHING, silently. Fall back to the compiled-in bundle.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let checkout = tempfile::TempDir::new().unwrap();
+    let submodule = checkout.path().join("agents").join("agents");
+    std::fs::create_dir_all(&submodule).unwrap();
+
+    let mut paths = FrameworkPaths::under(tmp.path());
+    paths.trusty_mpm_root = Some(checkout.path().to_path_buf());
+    assert_eq!(paths.agent_source_dir(), submodule);
+    let target = tmp.path().join("claude-config/agents");
+
+    let out = autodeploy_agents_for(&paths, &target);
+
+    assert!(
+        out.refreshed,
+        "the empty submodule must not suppress the bundle refresh"
+    );
+    assert!(
+        out.deployed.iter().any(|f| f == "BASE-AGENT.md"),
+        "the bundled roster must land: {:?}",
+        out.deployed
+    );
+    assert!(target.join("engineer.md").exists());
+    assert_eq!(
+        std::fs::read_dir(&submodule).unwrap().count(),
+        0,
+        "the submodule directory is still never written"
+    );
 }
 
 #[test]

--- a/crates/trusty-mpm/src/core/agent_source_tests.rs
+++ b/crates/trusty-mpm/src/core/agent_source_tests.rs
@@ -1,0 +1,361 @@
+//! Unit tests for [`super`] — bundled agent-source self-heal and auto-deploy
+//! (issue #4840).
+//!
+//! Why: #4840's four load-bearing behaviors are (1) the deploy fires when the
+//! compiled-in bundle differs from disk, (2) it is a no-op when identical,
+//! (3) it fails open when the target cannot be written, and (4) it WARNS,
+//! naming the file, whenever it declines to overwrite something. Each gets a
+//! test here.
+//! What: hermetic — every case runs against `tempfile::TempDir`, never the
+//! real `~/.trusty-mpm`.
+//! Test: this file.
+
+use super::*;
+
+/// The real bundled agent set is materialized into a temp dir per test, so
+/// these assertions pin the actual shipped roster rather than a fixture.
+fn bundled_agent_basenames() -> Vec<&'static str> {
+    bundle::ALL
+        .iter()
+        .filter(|a| a.rel_path.starts_with("agents/"))
+        .map(|a| a.rel_path.strip_prefix("agents/").unwrap())
+        .collect()
+}
+
+#[test]
+fn agent_bundle_stamp_is_stable_across_calls() {
+    // Pure function of the compiled-in table: two calls must agree, or the
+    // "cheap when nothing changed" gate would re-materialize on every launch.
+    assert_eq!(agent_bundle_stamp(), agent_bundle_stamp());
+}
+
+#[test]
+fn agent_bundle_stamp_differs_from_skill_stamp() {
+    // The agent stamp must fingerprint the `agents/*` slice, not the whole
+    // table — otherwise a skill-only change would churn the agent source.
+    assert_ne!(
+        agent_bundle_stamp(),
+        crate::core::skill_source::skill_bundle_stamp()
+    );
+}
+
+#[test]
+fn materialize_agent_artifacts_writes_all_agents() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let agents = tmp.path().join("agents");
+
+    let written = materialize_agent_artifacts(&agents).unwrap();
+
+    let expected = bundled_agent_basenames();
+    assert_eq!(written.len(), expected.len());
+    for name in expected {
+        let content = std::fs::read_to_string(agents.join(name))
+            .unwrap_or_else(|e| panic!("missing {name}: {e}"));
+        let artifact = bundle::ALL
+            .iter()
+            .find(|a| a.rel_path == format!("agents/{name}"))
+            .unwrap();
+        assert_eq!(
+            content, artifact.contents,
+            "{name} content must match bundle"
+        );
+    }
+    assert!(
+        agents.join("BASE-AGENT.md").exists(),
+        "BASE-AGENT.md is the file #4840 measured as stale — it must materialize"
+    );
+}
+
+#[test]
+fn materialize_agent_artifacts_prunes_files_not_in_table() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let agents = tmp.path().join("agents");
+    std::fs::create_dir_all(&agents).unwrap();
+    // A leftover from a renamed/removed agent the current table no longer lists.
+    std::fs::write(agents.join("retired-engineer.md"), "stale\n").unwrap();
+
+    materialize_agent_artifacts(&agents).unwrap();
+
+    assert!(!agents.join("retired-engineer.md").exists());
+    assert!(agents.join("engineer.md").exists());
+}
+
+#[test]
+fn ensure_agent_source_fresh_materializes_when_missing() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let agents = tmp.path().join("agents");
+    assert!(!agents.exists());
+
+    let refreshed = ensure_agent_source_fresh(&agents).unwrap();
+
+    assert!(refreshed, "a missing source dir must trigger a refresh");
+    assert!(agents.join("BASE-AGENT.md").exists());
+    assert!(agents.join(STAMP_FILE_NAME).exists());
+}
+
+#[test]
+fn ensure_agent_source_fresh_is_noop_when_current() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let agents = tmp.path().join("agents");
+    assert!(ensure_agent_source_fresh(&agents).unwrap());
+
+    let marker = agents.join("BASE-AGENT.md");
+    let before = std::fs::metadata(&marker).unwrap().modified().unwrap();
+
+    let refreshed = ensure_agent_source_fresh(&agents).unwrap();
+
+    assert!(!refreshed, "an already-current source dir must be a no-op");
+    assert_eq!(
+        before,
+        std::fs::metadata(&marker).unwrap().modified().unwrap(),
+        "a no-op refresh must not rewrite files"
+    );
+}
+
+#[test]
+fn ensure_agent_source_fresh_prunes_renamed_files() {
+    // The #4840 shape after an agent rename: an operator's existing source dir
+    // holds a stale stamp (or none) plus a leftover pre-rename file.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let agents = tmp.path().join("agents");
+    std::fs::create_dir_all(&agents).unwrap();
+    std::fs::write(agents.join("mpm-old-agent.md"), "stale\n").unwrap();
+    std::fs::write(agents.join(STAMP_FILE_NAME), "stale-stamp").unwrap();
+
+    let refreshed = ensure_agent_source_fresh(&agents).unwrap();
+
+    assert!(refreshed, "a stale stamp must trigger a refresh");
+    assert!(!agents.join("mpm-old-agent.md").exists());
+    assert!(agents.join("engineer.md").exists());
+}
+
+#[test]
+fn skip_warning_lines_is_empty_when_nothing_skipped() {
+    let result = DeployResult {
+        deployed: vec!["engineer.md".into()],
+        ..DeployResult::default()
+    };
+    assert!(skip_warning_lines(&result).is_empty());
+}
+
+#[test]
+fn skip_warning_lines_names_each_skipped_file() {
+    let result = DeployResult {
+        skipped: vec!["engineer.md".into(), "qa.md".into()],
+        untracked_modified: vec!["engineer.md".into()],
+        ..DeployResult::default()
+    };
+
+    let lines = skip_warning_lines(&result);
+
+    assert_eq!(lines.len(), 2);
+    // Every skipped file is named, and the two ownership cases read differently.
+    assert!(lines[0].contains("engineer.md"), "{:?}", lines[0]);
+    assert!(
+        lines[0].contains("--reset-agents engineer"),
+        "{:?}",
+        lines[0]
+    );
+    assert!(lines[1].contains("qa.md"), "{:?}", lines[1]);
+    assert!(lines[1].contains("user-owned"), "{:?}", lines[1]);
+}
+
+#[test]
+fn autodeploy_agents_deploys_when_bundle_differs() {
+    // The core #4840 fix: nothing on disk, nobody ran `tm install`, and the
+    // agents still land.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let source = tmp.path().join("framework/agents");
+    let target = tmp.path().join("claude-config/agents");
+
+    let out = autodeploy_agents(&source, &target);
+
+    assert!(out.refreshed, "a stale (absent) source must refresh");
+    assert!(
+        out.warnings.is_empty(),
+        "unexpected warnings: {:?}",
+        out.warnings
+    );
+    assert!(
+        out.deployed.iter().any(|f| f == "BASE-AGENT.md"),
+        "BASE-AGENT.md must deploy: {:?}",
+        out.deployed
+    );
+    assert!(target.join("engineer.md").exists());
+}
+
+#[test]
+fn autodeploy_agents_is_a_noop_when_already_current() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let source = tmp.path().join("framework/agents");
+    let target = tmp.path().join("claude-config/agents");
+    assert!(autodeploy_agents(&source, &target).refreshed);
+
+    let marker = target.join("engineer.md");
+    let before = std::fs::metadata(&marker).unwrap().modified().unwrap();
+
+    let out = autodeploy_agents(&source, &target);
+
+    assert!(!out.refreshed, "matching checksums must skip the refresh");
+    assert!(
+        out.deployed.is_empty(),
+        "nothing should be rewritten: {:?}",
+        out.deployed
+    );
+    assert!(out.warnings.is_empty(), "{:?}", out.warnings);
+    assert_eq!(
+        before,
+        std::fs::metadata(&marker).unwrap().modified().unwrap(),
+        "a no-op run must not rewrite deployed files"
+    );
+}
+
+#[test]
+fn autodeploy_agents_fails_open_when_target_is_unwritable() {
+    // A broken deploy must never block a session — it degrades to a warning.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let source = tmp.path().join("framework/agents");
+    // A regular file where the target directory must go: nothing can be
+    // written under it, and `create_dir_all` cannot repair it.
+    let target = tmp.path().join("not-a-dir");
+    std::fs::write(&target, "blocking file\n").unwrap();
+
+    let out = autodeploy_agents(&source, &target);
+
+    assert!(
+        out.refreshed,
+        "the source refresh is independent of the target and must still run"
+    );
+    assert!(out.deployed.is_empty());
+    assert!(
+        out.warnings.iter().any(|w| w.contains("could not deploy")),
+        "the failure must surface as a warning, not an error: {:?}",
+        out.warnings
+    );
+    // The blocking file is untouched — auto-deploy destroys nothing on failure.
+    assert_eq!(std::fs::read_to_string(&target).unwrap(), "blocking file\n");
+}
+
+#[test]
+fn autodeploy_agents_fails_open_when_source_is_unwritable() {
+    // The other half of fail-open: the source refresh itself cannot run.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let source = tmp.path().join("not-a-dir");
+    std::fs::write(&source, "blocking file\n").unwrap();
+    let target = tmp.path().join("claude-config/agents");
+
+    let out = autodeploy_agents(&source, &target);
+
+    assert!(!out.refreshed);
+    assert!(
+        out.warnings.iter().any(|w| w.contains("could not refresh")),
+        "{:?}",
+        out.warnings
+    );
+}
+
+#[test]
+fn autodeploy_agents_warns_when_it_skips_a_user_modified_file() {
+    // #4840's second half: the deployer preserves an untracked, differing file
+    // — correct, but it used to do so SILENTLY, which is how a three-day-stale
+    // BASE-AGENT.md went unnoticed.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let source = tmp.path().join("framework/agents");
+    let target = tmp.path().join("claude-config/agents");
+    std::fs::create_dir_all(&target).unwrap();
+    std::fs::write(
+        target.join("engineer.md"),
+        "---\nname: engineer\ndescription: hand-edited\n---\n\nMine.\n",
+    )
+    .unwrap();
+
+    let out = autodeploy_agents(&source, &target);
+
+    assert!(
+        out.warnings.iter().any(|w| w.contains("engineer.md")),
+        "the skipped file must be named in a warning: {:?}",
+        out.warnings
+    );
+    assert!(
+        !out.deployed.iter().any(|f| f == "engineer.md"),
+        "the user's file must be preserved, not overwritten"
+    );
+    assert!(
+        std::fs::read_to_string(target.join("engineer.md"))
+            .unwrap()
+            .contains("Mine."),
+        "the user's content must survive byte-for-byte"
+    );
+    // Everything else still deployed — one preserved file does not stall the roster.
+    assert!(target.join("BASE-AGENT.md").exists());
+}
+
+#[test]
+fn autodeploy_agents_for_skips_source_refresh_on_submodule() {
+    // When the `agents/agents` git submodule is checked out it is the
+    // authoritative, git-tracked source — materializing the compiled-in bundle
+    // over it would be destructive. Deploy from it, never rewrite it.
+    let tmp = tempfile::TempDir::new().unwrap();
+    let checkout = tempfile::TempDir::new().unwrap();
+    let submodule = checkout.path().join("agents").join("agents");
+    std::fs::create_dir_all(&submodule).unwrap();
+    std::fs::write(
+        submodule.join("submodule-agent.md"),
+        "---\nname: submodule-agent\ndescription: from the submodule\n---\n\nSUBMODULE.\n",
+    )
+    .unwrap();
+
+    let mut paths = FrameworkPaths::under(tmp.path());
+    paths.trusty_mpm_root = Some(checkout.path().to_path_buf());
+    assert_eq!(paths.agent_source_dir(), submodule);
+    let target = tmp.path().join("claude-config/agents");
+
+    let out = autodeploy_agents_for(&paths, &target);
+
+    assert!(
+        !out.refreshed,
+        "a submodule source is never re-materialized"
+    );
+    assert!(
+        !paths.agents.exists(),
+        "must never create the framework source dir when a submodule is in play"
+    );
+    assert_eq!(
+        std::fs::read_dir(&submodule).unwrap().count(),
+        1,
+        "the git-tracked submodule must be left exactly as found"
+    );
+    assert!(target.join("submodule-agent.md").exists());
+}
+
+#[test]
+fn autodeploy_agents_overwrites_a_drifted_bundled_file() {
+    // Documented overwrite decision (#4840): a BUNDLED-origin file whose
+    // checksum drifted IS re-deployed — the manifest records `origin`, and
+    // framework-owned drift is corruption, not user ownership (#4408).
+    let tmp = tempfile::TempDir::new().unwrap();
+    let source = tmp.path().join("framework/agents");
+    let target = tmp.path().join("claude-config/agents");
+    assert!(!autodeploy_agents(&source, &target).deployed.is_empty());
+
+    // Corrupt a tracked, bundled-origin deployed file.
+    std::fs::write(target.join("engineer.md"), "CORRUPTED\n").unwrap();
+
+    let out = autodeploy_agents(&source, &target);
+
+    assert!(
+        out.deployed.iter().any(|f| f == "engineer.md"),
+        "a drifted bundled-origin file must be re-deployed: {:?}",
+        out.deployed
+    );
+    assert!(
+        !std::fs::read_to_string(target.join("engineer.md"))
+            .unwrap()
+            .contains("CORRUPTED")
+    );
+    assert!(
+        out.warnings.is_empty(),
+        "repairing framework-owned drift is not a declined overwrite: {:?}",
+        out.warnings
+    );
+}

--- a/crates/trusty-mpm/src/core/managed_config.rs
+++ b/crates/trusty-mpm/src/core/managed_config.rs
@@ -62,13 +62,20 @@
 //! `framework/*` dirs), then (2) refreshes the framework source and deploys the
 //! FULL agent/skill roster from the resolved source dirs so the complete,
 //! spawnable set is guaranteed present. Idempotent — safe to call on every
-//! spawn (the deployers checksum-skip unchanged files).
+//! spawn (the deployers checksum-skip unchanged files). Since #4840 the AGENT
+//! half of step (2) also REFRESHES the bundled agent source from the
+//! compiled-in bundle first, via
+//! [`crate::core::agent_source::autodeploy_agents_for`] — before that, only the
+//! manual `tm install` ever wrote `~/.trusty-mpm/framework/agents/`, so a
+//! merged, compiled-in `BASE-AGENT.md` change silently reached no running
+//! agent.
 //! Test: `ensure_managed_config_dir_deploys_full_roster`,
-//! `ensure_managed_config_dir_is_idempotent`.
+//! `ensure_managed_config_dir_is_idempotent`,
+//! `ensure_managed_config_dir_refreshes_stale_bundled_agents`,
+//! `ensure_managed_config_dir_survives_an_unwritable_agent_target`.
 
 use std::path::Path;
 
-use crate::core::agent_deployer::deploy_agents;
 use crate::core::paths::FrameworkPaths;
 use crate::core::skill_tiers::deploy_all_skill_tiers;
 use crate::core::standalone::global_config::ensure_global_config_dir;
@@ -95,9 +102,15 @@ use crate::core::standalone::global_config::ensure_global_config_dir;
 ///    the resolved source dirs ([`FrameworkPaths::agent_source_dir`] /
 ///    `skill_source_dir`) into `<config_dir>/agents` and `<config_dir>/skills`,
 ///    guaranteeing the full spawnable set regardless of install/submodule state.
+///    The AGENT half routes through
+///    [`crate::core::agent_source::autodeploy_agents_for`] (#4840), which
+///    re-materializes the bundled agent source from the compiled-in bundle when
+///    its stamp differs, then deploys it — and which never returns an error, so
+///    a failed deploy degrades to a warning instead of blocking the spawn.
 ///
 /// Test: `ensure_managed_config_dir_deploys_full_roster`,
-/// `ensure_managed_config_dir_is_idempotent`.
+/// `ensure_managed_config_dir_is_idempotent`,
+/// `ensure_managed_config_dir_refreshes_stale_bundled_agents`.
 pub fn ensure_managed_config_dir(config_dir: &Path) -> anyhow::Result<()> {
     ensure_managed_config_dir_with_root(&FrameworkPaths::default(), config_dir)
 }
@@ -112,7 +125,9 @@ pub fn ensure_managed_config_dir(config_dir: &Path) -> anyhow::Result<()> {
 /// [`ensure_managed_config_dir`], using `fw` for both the `ensure_global_config_dir`
 /// managed-root argument (`fw.root`) and the full-roster source dirs.
 /// Test: `ensure_managed_config_dir_deploys_full_roster`,
-/// `ensure_managed_config_dir_is_idempotent`.
+/// `ensure_managed_config_dir_is_idempotent`,
+/// `ensure_managed_config_dir_refreshes_stale_bundled_agents`,
+/// `ensure_managed_config_dir_survives_an_unwritable_agent_target`.
 pub fn ensure_managed_config_dir_with_root(
     fw: &FrameworkPaths,
     config_dir: &Path,
@@ -129,10 +144,27 @@ pub fn ensure_managed_config_dir_with_root(
         tracing::warn!("managed config dir: skill source refresh failed (non-fatal): {err}");
     }
 
+    // #4840: refresh the bundled agent SOURCE from the compiled-in bundle
+    // before deploying it. Until this call existed, `~/.trusty-mpm/framework/
+    // agents/` was written only by the manual `tm install`, so a compiled-in
+    // `BASE-AGENT.md` change reached no running agent until someone remembered
+    // to re-run it. `autodeploy_agents_for` never returns an error — a broken
+    // deploy must not block a session — so anything it could not do comes back
+    // as a warning line instead.
     let agents_dest = config_dir.join("agents");
-    deploy_agents(&fw.agent_source_dir(), &agents_dest).map_err(|e| {
-        anyhow::anyhow!("failed to deploy full agent roster into managed config dir: {e}")
-    })?;
+    let agents = crate::core::agent_source::autodeploy_agents_for(fw, &agents_dest);
+    if agents.refreshed {
+        tracing::info!(
+            "managed config dir: bundled agent source refreshed from the running binary"
+        );
+    }
+    // #4840: a file the deployer declines to overwrite (untracked-and-differing,
+    // or a user-owned entry that was edited) used to be skipped SILENTLY — the
+    // other half of the defect. Name every one of them.
+    for warning in &agents.warnings {
+        tracing::warn!("managed config dir: {warning}");
+        eprintln!("{warning}");
+    }
 
     // PR #2818 review (round 3, MEDIUM decision): route through the multi-tier
     // orchestrator so a user-custom skill (`fw.user_skill_source_dir()`)
@@ -260,6 +292,55 @@ mod tests {
         let second = std::fs::read_to_string(config_dir.join("agents/engineer.md")).unwrap();
 
         assert_eq!(first, second, "re-provisioning must be idempotent");
+    }
+
+    #[test]
+    fn ensure_managed_config_dir_refreshes_stale_bundled_agents() {
+        // #4840: the exact measured shape — a framework agent source written by
+        // an older `tm install` sits on disk while the running binary embeds a
+        // newer one. Provisioning must close that gap with no manual step.
+        let tmp = TempDir::new().unwrap();
+        let fw = FrameworkPaths::under(tmp.path());
+        std::fs::create_dir_all(&fw.agents).unwrap();
+        std::fs::write(
+            fw.agents.join("BASE-AGENT.md"),
+            "---\nname: BASE-AGENT\ndescription: base\n---\n\nSTALE-SENTINEL-4840\n",
+        )
+        .unwrap();
+        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+
+        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+        assert_eq!(
+            std::fs::read_to_string(fw.agents.join("BASE-AGENT.md")).unwrap(),
+            crate::core::bundle::BASE_AGENT,
+            "the bundled agent SOURCE must be re-materialized from the running binary"
+        );
+        let deployed = std::fs::read_to_string(config_dir.join("agents/BASE-AGENT.md")).unwrap();
+        assert!(
+            !deployed.contains("STALE-SENTINEL-4840"),
+            "the stale composition must not survive into the deploy target"
+        );
+    }
+
+    #[test]
+    fn ensure_managed_config_dir_survives_an_unwritable_agent_target() {
+        // Fail open (#4840): a broken agent deploy must never block a session.
+        // A regular file where `<config_dir>/agents` belongs makes every write
+        // under it impossible and cannot be repaired by `create_dir_all`.
+        let tmp = TempDir::new().unwrap();
+        let fw = FrameworkPaths::under(tmp.path());
+        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+        std::fs::create_dir_all(&config_dir).unwrap();
+        std::fs::write(config_dir.join("agents"), "blocking file\n").unwrap();
+
+        ensure_managed_config_dir_with_root(&fw, &config_dir)
+            .expect("an undeployable agent roster must not fail provisioning");
+
+        assert!(
+            config_dir.join("settings.json").exists(),
+            "the rest of the config dir must still be provisioned"
+        );
     }
 
     #[test]

--- a/crates/trusty-mpm/src/core/managed_config.rs
+++ b/crates/trusty-mpm/src/core/managed_config.rs
@@ -159,11 +159,15 @@ pub fn ensure_managed_config_dir_with_root(
         );
     }
     // #4840: a file the deployer declines to overwrite (untracked-and-differing,
-    // or a user-owned entry that was edited) used to be skipped SILENTLY — the
-    // other half of the defect. Name every one of them.
+    // or a user-owned entry that was edited), and an agent that failed to
+    // compose at all, used to be handled SILENTLY — the other half of the
+    // defect. `agents.warnings` is a bounded count-plus-preview summary (at
+    // most a couple of lines), matching `agents::deployer`'s own #2504 policy:
+    // this runs on every spawn AND every resume, and the stale set is never
+    // reconciled until someone runs `--reset-agents`, so one line per file
+    // would be permanent log spam. PR #4848 review (HIGH).
     for warning in &agents.warnings {
         tracing::warn!("managed config dir: {warning}");
-        eprintln!("{warning}");
     }
 
     // PR #2818 review (round 3, MEDIUM decision): route through the multi-tier

--- a/crates/trusty-mpm/src/core/mod.rs
+++ b/crates/trusty-mpm/src/core/mod.rs
@@ -17,6 +17,9 @@ pub mod agent_metadata;
 pub mod agent_reset;
 pub mod agent_reset_workspace;
 pub mod agent_skill_codeploy;
+// #4840: bundled agent assets reached `$CLAUDE_CONFIG_DIR/agents/` only via a
+// manual `tm install`; this module makes the refresh+deploy automatic.
+pub mod agent_source;
 pub mod artifact;
 pub mod auto_resume;
 pub mod binary_provenance;


### PR DESCRIPTION
Closes [#4840](https://github.com/bobmatnyc/trusty-tools/issues/4840).

## The defect

`crates/trusty-mpm/src/assets/agents/*.md` is compiled into the binary, but the only code path that ever wrote it to disk was the manual `tm install`. Rebuilding the binary did not trigger it; starting a session did not trigger it. Measured on 2026-08-04: a deployed `BASE-AGENT.md` three days older than the binary containing the fix, with no warning anywhere.

The chain is `bundle::ALL` (compiled in) → `~/.trusty-mpm/framework/agents/` → `$CLAUDE_CONFIG_DIR/agents/`. The second hop already ran on every managed spawn. The **first** hop only ever ran under `tm install`, so the source directory was the stale layer — confirmed live: source `Aug 3`, deploy `Aug 1`, binary `Aug 4`, source and deploy byte-identical and both missing the merged text.

## Trigger and gate

- **Trigger:** session provisioning — `managed_config::ensure_managed_config_dir_with_root`, called on every daemon-managed spawn/resume from `runtime/claude_code.rs::prepare_managed_config`.
- **Gate:** a sha256 stamp over the `agents/*` slice of `bundle::ALL`, compared against `<agents_dir>/.bundle-stamp`. An unchanged bundle costs one file read and one string compare. This is the same mechanism `skill_source` has used since [#1917](https://github.com/bobmatnyc/trusty-tools/issues/1917) — agents were the missing half.
- **Scope:** agent assets only. It does not reuse the `tm install` path, which is unsafe to run mid-session against live services.

## Decision on drifted bundled files

**Auto-deploy overwrites them.** The deploy manifest records `origin`, and `agents::deployer` already treats framework-owned drift as corruption rather than user ownership ([#4408](https://github.com/bobmatnyc/trusty-tools/issues/4408)); auto-deploy inherits that unchanged rather than inventing a second policy. Only an *untracked* file that differs, or a *user-owned* (seed-once tier) entry that was edited, is preserved.

**Every preserved file is now named in a warning.** That silence was the other half of the defect — it is what let a three-day-stale `BASE-AGENT.md` go unnoticed. Warnings go to both `tracing::warn!` and stderr, and the untracked case names the `tm install --reset-agents <name>` that resolves it.

## Fail open

`autodeploy_agents` never returns an error. A refresh or deploy that cannot run degrades to a warning line; the session still starts with whatever is already on disk. A stale file is a strictly better failure than a session that will not launch.

## Files

- `crates/trusty-mpm/src/core/agent_source.rs` (new) — stamp, materialize+prune, refresh, warning formatter, `autodeploy_agents` / `autodeploy_agents_for` (the latter carrying the `agents/agents` git-submodule guard, so a source checkout's tracked submodule is deployed from but never overwritten).
- `crates/trusty-mpm/src/core/managed_config.rs` — routes the agent deploy through it, logs the warnings.

## Gates — rung 5 (session lifecycle)

```
cargo fmt --check                            — clean
cargo check -p trusty-mpm                    — clean
cargo clippy -p trusty-mpm -- -D warnings    — clean
cargo test -p trusty-mpm                     — 4481 passed, 1 failed, 7 ignored
bash scripts/check_line_cap.sh               — 3643 files, 0 violations
```

The single failure is `client::executor::tests::execute_doctor_against_test_daemon`, the documented environmental flake in [docs/reference/test-ladder-baseline.md](https://github.com/bobmatnyc/trusty-tools/blob/main/docs/reference/test-ladder-baseline.md) ("takes 9–13 s against a 10 s client timeout, so it loses on timing alone under any load"). It passes in isolation on this branch at 10.15 s, and this diff touches zero files under `crates/trusty-mpm/src/client/`.

22 new tests, covering the four required behaviors: deploy fires when the checksum differs, is skipped when identical, fails open when the target (or the source) is unwritable, and warns by name when it skips a user-modified file — plus the drifted-bundled overwrite decision and the submodule guard.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools