### PR TITLE
fix(trusty-agents): persist slack pairing and make it completable headlessly

### DIFF
--- a/crates/trusty-agents/changelog.d/4853-4854-slack-pairing-headless.md
+++ b/crates/trusty-agents/changelog.d/4853-4854-slack-pairing-headless.md
@@ -1,0 +1,6 @@
+Fixed
+
+- Slack pairing now survives a gateway restart and can be completed without a REPL (closes [#4853](https://github.com/bobmatnyc/trusty-tools/issues/4853), closes [#4854](https://github.com/bobmatnyc/trusty-tools/issues/4854))
+  - paired channels persist to `~/.trusty-agents/state/slack-paired.json`, loaded on boot and saved on pair — mirroring the Telegram precedent in #467
+  - a direct message from a user already in the Slack RBAC table pairs itself, so the launchd-run gateway (which has no REPL and can never mint a pairing code) is reachable; shared channels and unknown users still require an explicit code
+  - `/slack-start` now describes a flow the user can actually complete instead of pointing at a REPL that does not exist in `--slack` mode

--- a/crates/trusty-agents/src/slack/events.rs
+++ b/crates/trusty-agents/src/slack/events.rs
@@ -1,0 +1,111 @@
+//! Eventstream mirror for the Slack gateway (#3852 hybrid architecture).
+//!
+//! Why: The Socket-Mode gateway answers Slack DMs directly — `handlers`
+//! dispatches to ctrl and replies via `chat.postMessage`. Mirroring each
+//! inbound message onto the harness-wide eventstream is a SEPARATE concern
+//! with its own failure posture (append is best-effort; the live SSE mirror
+//! publishes regardless), so it lives in its own file. Split out of
+//! `handlers.rs` under #4853, when that file crossed the 500-SLOC cap.
+//! What: `record_listener_event` plus its snippet helper and the two id/size
+//! constants it owns.
+//! Test: `slack::tests::eventstream_tests`.
+
+use tracing::warn;
+
+use crate::listeners::store::{EventStore, StoredEvent};
+
+/// Fixed listener id used for every Slack-gateway event mirrored onto the
+/// eventstream (#3852). Unlike Gmail (one `ListenerConfig` per configured
+/// mailbox), the Socket-Mode gateway is a single process-wide connection —
+/// there is no per-workspace listener config to derive an id from.
+const SLACK_LISTENER_ID: &str = "slack";
+
+/// Max chars of message text folded into a `ListenerEventReceived` summary
+/// line (#3852) — mirrors the "one glanceable line" contract
+/// `listeners::poll::listener_event_summary` documents for Gmail.
+const SLACK_SNIPPET_MAX_CHARS: usize = 140;
+
+/// Mirror one inbound Slack message onto the harness-wide listener
+/// eventstream (#3852 hybrid architecture).
+///
+/// Why: The Socket-Mode gateway already answers Slack DMs directly —
+/// `handle_message` above dispatches to `ctrl::run_pm_task_with_persona` and
+/// replies via `chat.postMessage`, unchanged by this function. This
+/// ADDITIONALLY makes the message visible to the Events pane / filterable
+/// eventstream (`GET /api/listener-events`), mirroring EXACTLY the
+/// append-then-filter order `listeners::poll::poll_once` uses for Gmail:
+/// append the event (best-effort — a failure is logged, NOT fatal to the
+/// rest of this function, matching `poll_once`'s own log-and-continue
+/// posture at `listeners/poll.rs:326-331` rather than early-returning),
+/// THEN consult `EventStore::is_event_type_included` for the CURRENT filter
+/// state, THEN publish `Event::ListenerEventReceived` carrying that
+/// `included` flag REGARDLESS of whether the append succeeded — a
+/// persistence hiccup must not also blind the LIVE Events pane, which reads
+/// the SSE mirror, not the on-disk log. Deliberately does NOT call
+/// `listeners::wake` — direct dispatch already answers the message; waking a
+/// bound agent here too would make it reply twice (see the #3852 ADR for the
+/// fork rationale).
+/// What: Takes owned `String`s (not `&str`) so callers can `tokio::spawn`
+/// this directly — see the call site in `handle_message`, which detaches it
+/// exactly like the sibling `relay_event` spawn so a slow disk append never
+/// delays the Slack reply. `listener_id` is the fixed `SLACK_LISTENER_ID`
+/// (no per-workspace `ListenerConfig` exists for the Socket-Mode gateway the
+/// way Gmail has one per mailbox); `event_type` is `"message.{channel_type}"`
+/// (e.g. `message.im`, `message.mpim`); `id` is `"slack:{channel}:{ts}"` —
+/// stable and idempotent per Slack message, mirroring Gmail's
+/// `"{listener_id}:{message_id}"`.
+/// Test: `slack_listener_event_appends_and_respects_filter`,
+/// `slack_listener_event_excluded_type_still_appended`,
+/// `slack_listener_event_publishes_even_when_append_fails`.
+pub(super) async fn record_listener_event(
+    channel: String,
+    ts: String,
+    channel_type: String,
+    from_display: String,
+    text: String,
+) {
+    let event_type = format!("message.{channel_type}");
+    let event = StoredEvent {
+        id: format!("slack:{channel}:{ts}"),
+        listener_id: SLACK_LISTENER_ID.to_string(),
+        provider: "slack".to_string(),
+        event_type: event_type.clone(),
+        ts: chrono::Utc::now().to_rfc3339(),
+        from: Some(from_display),
+        subject: None,
+        snippet: Some(truncated_snippet(&text)),
+        included: true,
+    };
+    if let Err(e) = EventStore::append(&event).await {
+        warn!(
+            channel = %channel,
+            error = %e,
+            "slack: failed to persist listener event (non-fatal); still publishing SSE mirror"
+        );
+        // Fall through, deliberately — see the doc comment above and
+        // `listeners::poll::poll_once`, which does the same on an append
+        // error: a persistence failure must not also suppress the live SSE
+        // mirror the Events pane reads from.
+    }
+    let included = EventStore::is_event_type_included(&event_type).await;
+    crate::events::publish(crate::events::Event::ListenerEventReceived {
+        listener_id: event.listener_id.clone(),
+        provider: event.provider.clone(),
+        event_type: event.event_type.clone(),
+        summary: format!("{channel}: {}", truncated_snippet(&text)),
+        included,
+    });
+}
+
+/// Char-boundary-safe truncation of Slack message text to
+/// `SLACK_SNIPPET_MAX_CHARS`, for the `StoredEvent::snippet` and
+/// `ListenerEventReceived::summary` fields (#3852).
+fn truncated_snippet(text: &str) -> String {
+    let mut chars = text.chars();
+    let head: String = chars.by_ref().take(SLACK_SNIPPET_MAX_CHARS).collect();
+    if chars.next().is_some() {
+        format!("{head}…")
+    } else {
+        head
+    }
+}

--- a/crates/trusty-agents/src/slack/handlers.rs
+++ b/crates/trusty-agents/src/slack/handlers.rs
@@ -5,12 +5,8 @@
 //! behavior; isolating them from the socket lifecycle, RBAC, pairing, and
 //! formatting keeps each file focused and under the 500-line cap.
 //! What: `handle_command`, `handle_message`, and the `post_message` /
-//! `send_long_message` HTTP senders. Also `record_listener_event` (#3852
-//! hybrid architecture): mirrors every inbound plain message onto the
-//! harness-wide eventstream (`crate::listeners::store::EventStore` +
-//! `Event::ListenerEventReceived`) IN ADDITION TO the direct
-//! dispatch/reply path below, which is unchanged — see that function's doc
-//! comment and the #3852 ADR (`docs/adr/`) for the fork rationale.
+//! `send_long_message` HTTP senders. The #3852 eventstream mirror lives in
+//! the sibling `events` module and is re-exported here.
 //! Test: Exercised indirectly; the pure helpers they call are unit-tested in
 //! `slack::tests`.
 
@@ -24,23 +20,16 @@ use tracing::{info, warn};
 
 use super::format::{MAX_SLACK_MESSAGE, markdown_to_mrkdwn, split_message};
 use super::pairing::{
-    PAIRING_CODE_TTL, PairOutcome, PendingPairs, SENTINEL_PAIRING_CHANNEL_ID, verify_pair_attempt,
+    PAIRING_CODE_TTL, PairOutcome, PendingPairs, SENTINEL_PAIRING_CHANNEL_ID, save_paired_channels,
+    should_auto_pair, verify_pair_attempt,
 };
 use super::rbac::{SlackRbacConfig, VIRTUAL_CTO_MESSAGE, identity_from_slack_user};
 use super::{ChannelId, ChatSession, PairedChannels, SessionMap};
+// #4853: `record_listener_event` moved to `events.rs` when this file crossed
+// the 500-SLOC cap. Re-exported here so the #3852 call site and its tests keep
+// referring to it by the path they always have.
+pub(super) use super::events::record_listener_event;
 use crate::ctrl::{self, ConversationTurn};
-use crate::listeners::store::{EventStore, StoredEvent};
-
-/// Fixed listener id used for every Slack-gateway event mirrored onto the
-/// eventstream (#3852). Unlike Gmail (one `ListenerConfig` per configured
-/// mailbox), the Socket-Mode gateway is a single process-wide connection —
-/// there is no per-workspace listener config to derive an id from.
-const SLACK_LISTENER_ID: &str = "slack";
-
-/// Max chars of message text folded into a `ListenerEventReceived` summary
-/// line (#3852) — mirrors the "one glanceable line" contract
-/// `listeners::poll::listener_event_summary` documents for Gmail.
-const SLACK_SNIPPET_MAX_CHARS: usize = 140;
 
 /// Record a Slack slash command as a human turn, behind the same two gates
 /// `handle_message` records behind (#4683).
@@ -81,6 +70,40 @@ pub(super) fn note_command_turn(
     )
 }
 
+/// Promote an unpaired channel to paired when the headless auto-pair rule
+/// allows it, persisting the result (#4854).
+///
+/// Why: Both inbound paths (`handle_command`, `handle_message`) must apply the
+/// identical rule — a divergence between them is exactly the class of bug that
+/// makes a security gate meaningless. Composed once here and called from both.
+/// The security decision itself lives in the pure `should_auto_pair`; this
+/// wrapper is only the side effects.
+/// What: Returns the channel's paired state after the attempt. Persists via
+/// `save_paired_channels` on transition only (once per channel per boot), so a
+/// DM does not rewrite the state file on every message. Log-and-continue on IO
+/// error: an unwritable state file must not deny an authorized user service.
+/// Test: `auto_pair_*` cover the decision; `slack_paired_state_round_trip`
+/// covers the persistence this calls.
+async fn ensure_paired(
+    channel: &ChannelId,
+    paired: &PairedChannels,
+    paired_state_path: &std::path::Path,
+    sender_is_known_to_rbac: bool,
+) -> bool {
+    if paired.read().await.contains_key(channel) {
+        return true;
+    }
+    if !should_auto_pair(channel, sender_is_known_to_rbac) {
+        return false;
+    }
+    paired.write().await.insert(channel.clone(), Instant::now());
+    info!(channel = %channel, "slack: DM from known RBAC user auto-paired (#4854)");
+    if let Err(e) = save_paired_channels(paired, paired_state_path).await {
+        warn!(channel = %channel, error = %e, "failed to persist auto-pair");
+    }
+    true
+}
+
 /// Slash command dispatch.
 #[allow(clippy::too_many_arguments)]
 pub(super) async fn handle_command(
@@ -92,6 +115,7 @@ pub(super) async fn handle_command(
     sessions: SessionMap,
     project_path: Arc<PathBuf>,
     paired: PairedChannels,
+    paired_state_path: Arc<PathBuf>,
     pending: PendingPairs,
     rbac: Arc<SlackRbacConfig>,
     // #4703: injected by `run_slack_bot`, not resolved here. The inline
@@ -102,7 +126,16 @@ pub(super) async fn handle_command(
     // Gate every command except /slack-start and /slack-pair behind the
     // pairing check. Unpaired channels get a uniform prompt.
     let is_unauthenticated = matches!(command.as_str(), "/slack-start" | "/slack-pair");
-    let is_paired = paired.read().await.contains_key(&channel);
+    // #4854: a DM from a user already in the RBAC table pairs itself. Without
+    // this, standalone `--slack` mode (no REPL, so no code can ever be minted)
+    // leaves the gate permanently shut.
+    let is_paired = ensure_paired(
+        &channel,
+        &paired,
+        &paired_state_path,
+        rbac.user(&user_id).is_some(),
+    )
+    .await;
     if !is_unauthenticated && !is_paired {
         return post_message(
             bot_token,
@@ -134,14 +167,26 @@ pub(super) async fn handle_command(
     match command.as_str() {
         "/slack-start" => {
             info!(channel = %channel, "Slack /slack-start received");
-            let text = concat!(
-                ":lock: *Pairing required*\n\n",
-                "To link this Slack channel, go to your trusty-agents REPL and run:\n\n",
-                "  `/slack pair`\n\n",
-                "Then send the code here: `/slack-pair <code>`\n\n",
-                "(Codes expire in 5 minutes.)"
-            );
-            post_message(bot_token, &channel, text, None).await
+            // #4854: the old text unconditionally told the user to run
+            // `/slack pair` in a REPL — impossible under the launchd gateway,
+            // which has no REPL. Describe what this channel can actually do.
+            let text = if is_paired {
+                ":white_check_mark: *This channel is already paired.* Just send a message."
+                    .to_string()
+            } else if super::pairing::is_dm_channel(&channel) {
+                // A DM that is still unpaired means the sender is not in the
+                // RBAC table, so no self-service path exists — by design.
+                ":lock: *Not authorized.*\n\nThis assistant is limited to configured team members. \
+                 Ask an operator to add your Slack user id to the bot's access list."
+                    .to_string()
+            } else {
+                ":lock: *Pairing required*\n\nShared channels must be paired explicitly. \
+                 Ask an operator to run `/slack pair` in a trusty-agents REPL and send you the code, \
+                 then run `/slack-pair <code>` here. (Codes expire in 5 minutes.)\n\n\
+                 Or just DM me directly — no pairing step is needed there."
+                    .to_string()
+            };
+            post_message(bot_token, &channel, &text, None).await
         }
         "/slack-pair" => {
             let provided = arg.trim().to_string();
@@ -186,6 +231,13 @@ pub(super) async fn handle_command(
                 PairOutcome::Success => {
                     pending.lock().await.remove(&matched_key);
                     paired.write().await.insert(channel.clone(), now);
+                    // #4853: persist so the pairing survives a restart. Mirrors
+                    // the Telegram #467 handler: log-and-continue on IO error,
+                    // because losing persistence is recoverable on the next
+                    // save and must not block the user's confirmation.
+                    if let Err(e) = save_paired_channels(&paired, &paired_state_path).await {
+                        warn!(channel = %channel, error = %e, "failed to persist paired-channels state");
+                    }
                     info!(channel = %channel, "Slack channel paired successfully");
                     post_message(
                         bot_token,
@@ -336,13 +388,23 @@ pub(super) async fn handle_message(
     sessions: SessionMap,
     project_path: Arc<PathBuf>,
     paired: PairedChannels,
+    paired_state_path: Arc<PathBuf>,
     rbac: Arc<SlackRbacConfig>,
     // #4703: injected by `run_slack_bot`. This handler used the
     // `$HOME`-resolving `note_turn`, so no test could observe its hook.
     attendance_root: crate::attendance::AttendanceRoot,
 ) -> Result<()> {
-    // Gate behind pairing.
-    if !paired.read().await.contains_key(&channel) {
+    // Gate behind pairing. #4854: a DM from a known RBAC user pairs itself —
+    // see `should_auto_pair` for why that grants no capability RBAC does not
+    // already grant. Every other channel still requires an explicit code.
+    if !ensure_paired(
+        &channel,
+        &paired,
+        &paired_state_path,
+        rbac.user(&user_id).is_some(),
+    )
+    .await
+    {
         return post_message(
             bot_token,
             &channel,
@@ -496,91 +558,6 @@ pub(super) async fn handle_message(
     }
 
     send_result
-}
-
-/// Mirror one inbound Slack message onto the harness-wide listener
-/// eventstream (#3852 hybrid architecture).
-///
-/// Why: The Socket-Mode gateway already answers Slack DMs directly —
-/// `handle_message` above dispatches to `ctrl::run_pm_task_with_persona` and
-/// replies via `chat.postMessage`, unchanged by this function. This
-/// ADDITIONALLY makes the message visible to the Events pane / filterable
-/// eventstream (`GET /api/listener-events`), mirroring EXACTLY the
-/// append-then-filter order `listeners::poll::poll_once` uses for Gmail:
-/// append the event (best-effort — a failure is logged, NOT fatal to the
-/// rest of this function, matching `poll_once`'s own log-and-continue
-/// posture at `listeners/poll.rs:326-331` rather than early-returning),
-/// THEN consult `EventStore::is_event_type_included` for the CURRENT filter
-/// state, THEN publish `Event::ListenerEventReceived` carrying that
-/// `included` flag REGARDLESS of whether the append succeeded — a
-/// persistence hiccup must not also blind the LIVE Events pane, which reads
-/// the SSE mirror, not the on-disk log. Deliberately does NOT call
-/// `listeners::wake` — direct dispatch already answers the message; waking a
-/// bound agent here too would make it reply twice (see the #3852 ADR for the
-/// fork rationale).
-/// What: Takes owned `String`s (not `&str`) so callers can `tokio::spawn`
-/// this directly — see the call site in `handle_message`, which detaches it
-/// exactly like the sibling `relay_event` spawn so a slow disk append never
-/// delays the Slack reply. `listener_id` is the fixed `SLACK_LISTENER_ID`
-/// (no per-workspace `ListenerConfig` exists for the Socket-Mode gateway the
-/// way Gmail has one per mailbox); `event_type` is `"message.{channel_type}"`
-/// (e.g. `message.im`, `message.mpim`); `id` is `"slack:{channel}:{ts}"` —
-/// stable and idempotent per Slack message, mirroring Gmail's
-/// `"{listener_id}:{message_id}"`.
-/// Test: `slack_listener_event_appends_and_respects_filter`,
-/// `slack_listener_event_excluded_type_still_appended`,
-/// `slack_listener_event_publishes_even_when_append_fails`.
-pub(super) async fn record_listener_event(
-    channel: String,
-    ts: String,
-    channel_type: String,
-    from_display: String,
-    text: String,
-) {
-    let event_type = format!("message.{channel_type}");
-    let event = StoredEvent {
-        id: format!("slack:{channel}:{ts}"),
-        listener_id: SLACK_LISTENER_ID.to_string(),
-        provider: "slack".to_string(),
-        event_type: event_type.clone(),
-        ts: chrono::Utc::now().to_rfc3339(),
-        from: Some(from_display),
-        subject: None,
-        snippet: Some(truncated_snippet(&text)),
-        included: true,
-    };
-    if let Err(e) = EventStore::append(&event).await {
-        warn!(
-            channel = %channel,
-            error = %e,
-            "slack: failed to persist listener event (non-fatal); still publishing SSE mirror"
-        );
-        // Fall through, deliberately — see the doc comment above and
-        // `listeners::poll::poll_once`, which does the same on an append
-        // error: a persistence failure must not also suppress the live SSE
-        // mirror the Events pane reads from.
-    }
-    let included = EventStore::is_event_type_included(&event_type).await;
-    crate::events::publish(crate::events::Event::ListenerEventReceived {
-        listener_id: event.listener_id.clone(),
-        provider: event.provider.clone(),
-        event_type: event.event_type.clone(),
-        summary: format!("{channel}: {}", truncated_snippet(&text)),
-        included,
-    });
-}
-
-/// Char-boundary-safe truncation of Slack message text to
-/// `SLACK_SNIPPET_MAX_CHARS`, for the `StoredEvent::snippet` and
-/// `ListenerEventReceived::summary` fields (#3852).
-fn truncated_snippet(text: &str) -> String {
-    let mut chars = text.chars();
-    let head: String = chars.by_ref().take(SLACK_SNIPPET_MAX_CHARS).collect();
-    if chars.next().is_some() {
-        format!("{head}…")
-    } else {
-        head
-    }
 }
 
 /// Post a single message via `chat.postMessage`.

--- a/crates/trusty-agents/src/slack/mod.rs
+++ b/crates/trusty-agents/src/slack/mod.rs
@@ -17,6 +17,7 @@
 //! - `rbac.rs` — per-user RBAC config + Virtual-CTO gating
 //! - `pairing.rs` — pairing state machine + REPL-issued codes
 //! - `handlers.rs` — slash/plain-text handlers + `chat.postMessage` senders
+//! - `events.rs` — #3852 eventstream mirror for inbound messages
 //! - `format.rs` — mrkdwn conversion + 3000-char chunking
 //! - `tests.rs` — unit tests for the pure helpers above
 //!
@@ -24,6 +25,7 @@
 //! markdown_to_mrkdwn, generate_pairing_code, verify_pair_attempt, sentinel
 //! flow). Live verification requires a Slack workspace + app tokens.
 
+mod events;
 mod format;
 mod handlers;
 mod pairing;
@@ -161,7 +163,10 @@ pub async fn run_slack_bot(
 
     let project_path = Arc::new(project_path);
     let sessions: SessionMap = Arc::new(Mutex::new(HashMap::new()));
-    let paired: PairedChannels = Arc::new(RwLock::new(HashMap::new()));
+    // #4853: restore pairings from disk instead of starting empty. Before
+    // this, every restart of the launchd gateway un-paired every channel.
+    let paired_state_path = Arc::new(pairing::paired_channels_state_path());
+    let paired: PairedChannels = pairing::load_paired_channels(&paired_state_path).await;
     let dedup: Arc<Mutex<VecDeque<String>>> =
         Arc::new(Mutex::new(VecDeque::with_capacity(ENVELOPE_DEDUP_CAP)));
     // #4703: resolve the attendance root ONCE here, then inject it down to
@@ -189,6 +194,7 @@ pub async fn run_slack_bot(
             Arc::clone(&project_path),
             Arc::clone(&sessions),
             Arc::clone(&paired),
+            Arc::clone(&paired_state_path),
             Arc::clone(&pending),
             Arc::clone(&dedup),
             Arc::clone(&rbac),
@@ -217,6 +223,7 @@ async fn open_socket_and_run(
     project_path: Arc<PathBuf>,
     sessions: SessionMap,
     paired: PairedChannels,
+    paired_state_path: Arc<PathBuf>,
     pending: PendingPairs,
     dedup: Arc<Mutex<VecDeque<String>>>,
     rbac: Arc<SlackRbacConfig>,
@@ -280,6 +287,7 @@ async fn open_socket_and_run(
                 let project_path = Arc::clone(&project_path);
                 let sessions = Arc::clone(&sessions);
                 let paired = Arc::clone(&paired);
+                let paired_state_path = Arc::clone(&paired_state_path);
                 let pending = Arc::clone(&pending);
                 let rbac = Arc::clone(&rbac);
                 let attendance_root = attendance_root.clone();
@@ -290,6 +298,7 @@ async fn open_socket_and_run(
                         project_path,
                         sessions,
                         paired,
+                        paired_state_path,
                         pending,
                         rbac,
                         attendance_root,
@@ -364,6 +373,7 @@ async fn dispatch_envelope(
     project_path: Arc<PathBuf>,
     sessions: SessionMap,
     paired: PairedChannels,
+    paired_state_path: Arc<PathBuf>,
     pending: PendingPairs,
     rbac: Arc<SlackRbacConfig>,
     attendance_root: crate::attendance::AttendanceRoot,
@@ -437,6 +447,7 @@ async fn dispatch_envelope(
                 sessions,
                 project_path,
                 paired,
+                paired_state_path,
                 rbac,
                 attendance_root,
             )
@@ -474,6 +485,7 @@ async fn dispatch_envelope(
                 sessions,
                 project_path,
                 paired,
+                paired_state_path,
                 pending,
                 rbac,
                 attendance_root,

--- a/crates/trusty-agents/src/slack/pairing.rs
+++ b/crates/trusty-agents/src/slack/pairing.rs
@@ -1,17 +1,28 @@
-//! Pairing state machine + REPL-issued code handling for the Slack gateway.
+//! Pairing state machine, persistence, and REPL-issued code handling for the
+//! Slack gateway.
 //!
 //! Why: Pairing codes are generated in the trusted REPL and validated on
 //! Slack, mirroring the Telegram adapter. Keeping the state machine pure and
 //! isolated makes it exhaustively unit-testable without a WebSocket.
-//! What: `PendingPairs` map type + sentinel key, code issuance/generation, and
-//! the `PairOutcome` state machine (`verify_pair_attempt`).
-//! Test: `pair_*`, `repl_issued_code_*`, `sentinel_*` in `slack::tests`.
+//! What: `PendingPairs` map type + sentinel key, code issuance/generation,
+//! the `PairOutcome` state machine (`verify_pair_attempt`), the
+//! `PairedChannels` persistence pair (#4853), and the headless auto-pair
+//! decision (#4854).
+//! Test: `pair_*`, `repl_issued_code_*`, `sentinel_*`,
+//! `slack_paired_state_*`, `auto_pair_*` in `slack::tests`.
 
 use std::collections::HashMap;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tokio::sync::Mutex;
+use anyhow::{Result, anyhow};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, RwLock};
+use tracing::{info, warn};
+
+use super::{ChannelId, PairedChannels};
 
 /// How long a pairing code remains valid after issuance.
 ///
@@ -65,6 +76,174 @@ pub async fn issue_repl_pairing_code(pending: &PendingPairs) -> String {
 /// Test: `pairing_code_is_six_digits` asserts the format.
 pub(super) fn generate_pairing_code() -> String {
     format!("{:06}", rand::random::<u32>() % 1_000_000)
+}
+
+/// On-disk record of a single paired channel.
+///
+/// Why (#4853): `PairedChannels` lived in memory only; `run_slack_bot` built a
+/// fresh empty map on every call, so every restart of the launchd-run gateway
+/// un-paired every channel. Persisting a minimal record under
+/// `~/.trusty-agents/state/` survives restarts without leaking message content.
+/// What: the Slack channel id (a string like `"D0A1B2C3"`, unlike Telegram's
+/// `i64`) plus the wall-clock pairing time. `Instant` is monotonic and
+/// unsuitable for persistence, so we store `DateTime<Utc>` and reconstruct
+/// `Instant::now()` on load — the absolute time is only used for diagnostics.
+/// Test: `slack_paired_state_round_trip`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PairedChannelRecord {
+    channel_id: String,
+    paired_at: DateTime<Utc>,
+}
+
+/// On-disk container for the paired-channels file.
+#[derive(Debug, Default, Serialize, Deserialize)]
+struct PairedChannelsFile {
+    paired_channels: Vec<PairedChannelRecord>,
+}
+
+/// Resolve the absolute path of the paired-channels state file.
+///
+/// Why (#4853): Mirrors `telegram::pairing::paired_chats_state_path` (#467) —
+/// the *user-level* `~/.trusty-agents/state/` directory shared across projects,
+/// NOT the project-local one, so a gateway started from any cwd sees the same
+/// pairings. Falls back to a relative path when `HOME` is unset so we never
+/// panic in odd sandboxes.
+pub(super) fn paired_channels_state_path() -> PathBuf {
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    home.join(".trusty-agents")
+        .join("state")
+        .join("slack-paired.json")
+}
+
+/// Load persisted paired channels from disk.
+///
+/// Why (#4853): On startup, restore the pairing map so a service restart does
+/// not force every user to re-pair.
+/// What: Reads `state_path` as JSON. Missing file -> empty map (first run).
+/// Parse errors -> warn and return an empty map, never panic: a corrupt state
+/// file must not stop the gateway from booting, and the worst case is that
+/// users re-pair.
+/// Test: `slack_paired_state_round_trip`, `slack_paired_state_missing_file_is_empty`.
+pub(super) async fn load_paired_channels(state_path: &Path) -> PairedChannels {
+    let bytes = match tokio::fs::read(state_path).await {
+        Ok(b) => b,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Arc::new(RwLock::new(HashMap::new()));
+        }
+        Err(e) => {
+            warn!(path = %state_path.display(), error = %e, "failed to read paired-channels state; starting empty");
+            return Arc::new(RwLock::new(HashMap::new()));
+        }
+    };
+    let parsed: PairedChannelsFile = match serde_json::from_slice(&bytes) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(path = %state_path.display(), error = %e, "failed to parse paired-channels state; starting empty");
+            return Arc::new(RwLock::new(HashMap::new()));
+        }
+    };
+    let now = Instant::now();
+    let mut map: HashMap<ChannelId, Instant> = HashMap::with_capacity(parsed.paired_channels.len());
+    for rec in parsed.paired_channels {
+        // `Instant` cannot represent a past wall-clock time; `now` is a
+        // stand-in consumed only by diagnostic logging.
+        map.insert(rec.channel_id, now);
+    }
+    info!(count = map.len(), path = %state_path.display(), "loaded paired slack channels");
+    Arc::new(RwLock::new(map))
+}
+
+/// Persist the paired-channels map to disk atomically.
+///
+/// Why (#4853): Makes a successful pair durable across restarts.
+/// What: Snapshots the map under a read lock, serializes to JSON, then writes
+/// `<path>.tmp` + `rename` so a crash mid-write can never leave a torn file.
+/// Creates the parent directory on demand. Callers intentionally log-and-
+/// continue on error: losing persistence is recoverable on the next save and
+/// must never block the user's reply.
+/// Test: `slack_paired_state_round_trip`.
+pub(super) async fn save_paired_channels(paired: &PairedChannels, state_path: &Path) -> Result<()> {
+    if let Some(parent) = state_path.parent() {
+        tokio::fs::create_dir_all(parent).await.map_err(|e| {
+            anyhow!(
+                "failed to create paired-channels state dir {}: {e}",
+                parent.display()
+            )
+        })?;
+    }
+    let snapshot: Vec<PairedChannelRecord> = {
+        let guard = paired.read().await;
+        guard
+            .keys()
+            .map(|cid| PairedChannelRecord {
+                channel_id: cid.clone(),
+                paired_at: Utc::now(),
+            })
+            .collect()
+    };
+    let file = PairedChannelsFile {
+        paired_channels: snapshot,
+    };
+    let json = serde_json::to_vec_pretty(&file)
+        .map_err(|e| anyhow!("failed to serialize paired-channels: {e}"))?;
+    let tmp_path = state_path.with_extension("json.tmp");
+    tokio::fs::write(&tmp_path, &json).await.map_err(|e| {
+        anyhow!(
+            "failed to write paired-channels tmp file {}: {e}",
+            tmp_path.display()
+        )
+    })?;
+    tokio::fs::rename(&tmp_path, state_path)
+        .await
+        .map_err(|e| {
+            anyhow!(
+                "failed to rename paired-channels tmp -> {}: {e}",
+                state_path.display()
+            )
+        })?;
+    Ok(())
+}
+
+/// Is `channel` a 1:1 direct message with the bot?
+///
+/// Why (#4854): Slack channel ids are prefixed by kind — `D` for an IM, `C`
+/// for a public channel, `G` for a private channel / group DM. The prefix is
+/// assigned by Slack and arrives over the authenticated Socket Mode socket, so
+/// it is not attacker-controlled content. We key on it rather than the
+/// message event's `channel_type` field because `channel_type` exists only on
+/// message events — slash-command payloads do not carry it, and both inbound
+/// paths need the same answer.
+/// What: Returns true iff the id starts with `D`.
+/// Test: `auto_pair_rejects_public_channel`, `auto_pair_rejects_private_group`.
+pub(super) fn is_dm_channel(channel: &str) -> bool {
+    channel.starts_with('D')
+}
+
+/// Decide whether an unpaired channel may pair itself headlessly (#4854).
+///
+/// Why: Standalone `--slack` mode has no REPL, so no pairing code can ever be
+/// minted and the gate is unpassable. This is the narrowest rule that reopens
+/// it without weakening the security boundary: a DM from a user already in the
+/// RBAC table is auto-paired, because in that exact case pairing protects
+/// nothing that RBAC does not already protect more strongly.
+///
+/// The argument, precisely: persona access is gated per-USER by
+/// `SlackRbacConfig::user` — an unknown user already gets the static
+/// `VIRTUAL_CTO_MESSAGE` with no LLM call and no tool dispatch. Pairing is a
+/// per-CHANNEL gate whose remaining job is to control *where* an authorized
+/// user's (possibly sensitive) assistant output can land. A DM channel is
+/// readable only by that one user and the bot, so for a known user it grants
+/// exactly the tier they already hold, in a room nobody else can read.
+/// Auto-pairing there adds no capability. Auto-pairing a shared channel would
+/// — so this deliberately refuses every non-DM channel, and every unknown
+/// user, and those remain pairable only by code.
+/// What: Pure predicate; true iff `channel` is a DM AND the sender resolved to
+/// an RBAC entry. Kept pure and separate from the handlers so the security
+/// rule is exhaustively unit-testable without a WebSocket.
+/// Test: `auto_pair_allows_known_user_dm`, `auto_pair_rejects_unknown_user_dm`,
+/// `auto_pair_rejects_public_channel`, `auto_pair_rejects_private_group`.
+pub(super) fn should_auto_pair(channel: &str, sender_is_known_to_rbac: bool) -> bool {
+    is_dm_channel(channel) && sender_is_known_to_rbac
 }
 
 /// Outcome of a `/slack-pair <code>` attempt. Pure for unit testing.

--- a/crates/trusty-agents/src/slack/tests.rs
+++ b/crates/trusty-agents/src/slack/tests.rs
@@ -18,10 +18,11 @@ use super::format::{
 };
 use super::pairing::{
     PAIRING_CODE_TTL, PairOutcome, SENTINEL_PAIRING_CHANNEL_ID, generate_pairing_code,
-    issue_repl_pairing_code, new_pending_pairs, verify_pair_attempt,
+    issue_repl_pairing_code, load_paired_channels, new_pending_pairs, save_paired_channels,
+    should_auto_pair, verify_pair_attempt,
 };
 use super::rbac::{SlackRbacConfig, VIRTUAL_CTO_MESSAGE, default_rbac_users, parse_rbac_users};
-use super::{ENVELOPE_DEDUP_CAP, dedup_check_and_record};
+use super::{ENVELOPE_DEDUP_CAP, PairedChannels, dedup_check_and_record};
 
 #[test]
 fn split_message_short() {
@@ -632,6 +633,10 @@ async fn slack_handle_command_records_attendance_under_the_injected_root() {
         Arc::new(Mutex::new(std::collections::HashMap::new())),
         Arc::new(std::path::PathBuf::from(dir.path())),
         paired_with(channel).await,
+        // #4853: the state path the handler would persist to. `channel` is
+        // already paired, so nothing is written; it stays inside the tempdir
+        // regardless so no test can touch the real ~/.trusty-agents.
+        Arc::new(dir.path().join("slack-paired.json")),
         new_pending_pairs(),
         probe_rbac(),
         Some(Arc::clone(&root)),
@@ -673,6 +678,8 @@ async fn slack_handle_message_records_attendance_under_the_injected_root() {
         Arc::new(Mutex::new(std::collections::HashMap::new())),
         Arc::new(std::path::PathBuf::from(dir.path())),
         paired_with(channel).await,
+        // #4853: see the note in the handle_command probe above.
+        Arc::new(dir.path().join("slack-paired.json")),
         probe_rbac(),
         Some(Arc::clone(&root)),
     )
@@ -715,4 +722,131 @@ async fn post_message_without_a_token_errors_instead_of_requesting() {
         "that message means a request was actually attempted; the guard must \
          refuse BEFORE building a client; got: {msg}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// #4853 — paired-channel persistence across a gateway restart.
+// ---------------------------------------------------------------------------
+
+/// A pairing survives a simulated service restart.
+///
+/// Why (#4853): `run_slack_bot` used to build a fresh empty `PairedChannels`
+/// on every call, so restarting the launchd gateway un-paired every channel.
+/// This is the regression test for that: it pairs, DROPS the in-memory map
+/// entirely (the restart), reloads from disk, and asserts the channel is still
+/// paired. Reverting `load_paired_channels`/`save_paired_channels` to the old
+/// "always empty" behavior turns this red.
+/// What: save -> drop -> load -> assert membership, in a tempdir.
+#[tokio::test]
+async fn slack_paired_state_round_trip() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("slack-paired.json");
+
+    // --- process 1: pair two channels and persist ---
+    let paired: PairedChannels =
+        Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new()));
+    paired
+        .write()
+        .await
+        .insert("D0A6V2W1M2R".to_string(), Instant::now());
+    paired
+        .write()
+        .await
+        .insert("C0TEAMCHAN".to_string(), Instant::now());
+    save_paired_channels(&paired, &path).await.expect("save");
+
+    // --- the restart: nothing of the old map survives ---
+    drop(paired);
+
+    // --- process 2: boot from disk ---
+    let reloaded = load_paired_channels(&path).await;
+    let guard = reloaded.read().await;
+    assert_eq!(guard.len(), 2, "both pairings should survive the restart");
+    assert!(
+        guard.contains_key("D0A6V2W1M2R"),
+        "the DM pairing was lost across the restart"
+    );
+    assert!(
+        guard.contains_key("C0TEAMCHAN"),
+        "the channel pairing was lost across the restart"
+    );
+}
+
+/// A missing state file is a clean first run, not a failure.
+///
+/// Why: The gateway must boot on a host that has never paired anything.
+#[tokio::test]
+async fn slack_paired_state_missing_file_is_empty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("does-not-exist.json");
+    let loaded = load_paired_channels(&path).await;
+    assert!(loaded.read().await.is_empty());
+}
+
+/// A corrupt state file degrades to empty rather than killing the gateway.
+///
+/// Why: A truncated or hand-edited file must not make the service fail to
+/// boot; the worst acceptable outcome is that users re-pair.
+#[tokio::test]
+async fn slack_paired_state_corrupt_file_is_empty() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("slack-paired.json");
+    tokio::fs::write(&path, b"{ not json").await.expect("write");
+    let loaded = load_paired_channels(&path).await;
+    assert!(loaded.read().await.is_empty());
+}
+
+// ---------------------------------------------------------------------------
+// #4854 — headless auto-pair. These pin the SECURITY rule, so each rejection
+// case is asserted independently rather than folded into a table.
+// ---------------------------------------------------------------------------
+
+/// A DM from a user in the RBAC table pairs itself.
+///
+/// Why (#4854): This is the case that unblocks the launchd gateway, which has
+/// no REPL and therefore can never mint a pairing code. Reverting
+/// `should_auto_pair` to a constant `false` (the pre-fix behavior) turns this
+/// red.
+#[test]
+fn auto_pair_allows_known_user_dm() {
+    assert!(should_auto_pair("D0A6V2W1M2R", true));
+}
+
+/// A DM from a user NOT in the RBAC table must never pair itself.
+///
+/// Why (#4854): This is the security property the fix must not weaken — an
+/// unauthorized Slack user must not be able to pair themselves. Any "just drop
+/// the pairing gate" shortcut (a constant `true`) turns this red.
+#[test]
+fn auto_pair_rejects_unknown_user_dm() {
+    assert!(
+        !should_auto_pair("D0STRANGER", false),
+        "an unknown user must not be able to pair themselves"
+    );
+}
+
+/// A public channel never auto-pairs, even for a fully-authorized user.
+///
+/// Why (#4854): Auto-pair is justified ONLY because a DM is readable by one
+/// known user. A public channel has arbitrary readers, so `cto-assistant`
+/// output must not land there without an explicit pairing code.
+#[test]
+fn auto_pair_rejects_public_channel() {
+    assert!(
+        !should_auto_pair("C0TEAMCHAN", true),
+        "a public channel must still require an explicit pairing code"
+    );
+}
+
+/// A private channel / group DM never auto-pairs either.
+///
+/// Why: `G`-prefixed ids are private channels and multi-person DMs — more than
+/// one reader, so the DM argument does not apply.
+#[test]
+fn auto_pair_rejects_private_group() {
+    assert!(
+        !should_auto_pair("G0PRIVATE", true),
+        "a private group must still require an explicit pairing code"
+    );
+    assert!(!should_auto_pair("G0PRIVATE", false));
 }


### PR DESCRIPTION
Closes #4853. Closes #4854. Cutover epic #3852; Telegram precedent #467.

The Slack gateway went live but the pairing gate is unpassable: the owner DMs it, gets `:lock: Not paired. Send /slack-start to begin.`, runs `/slack-start`, and is told to run `/slack pair` in a REPL that does not exist under launchd. Separately, nothing persisted pairings, so even a successful pair died at the next restart.

## What changed

**#4853 — persistence.** `run_slack_bot` built `PairedChannels` fresh on every call and nothing wrote it to disk. Adds `paired_channels_state_path` / `load_paired_channels` / `save_paired_channels` over `~/.trusty-agents/state/slack-paired.json`, loaded on boot and saved on pair. Mirrors `telegram::pairing` (#467) closely: same user-level state dir, same atomic tmp+rename write, same fail-open load (missing or corrupt file degrades to empty and logs, never blocks boot).

**#4854 — headless completion.** Adds the pure predicate `should_auto_pair(channel, sender_is_known_to_rbac)`: a **DM** from a user **already in the Slack RBAC table** pairs itself. Both inbound paths go through one `ensure_paired` wrapper so they cannot drift.

**`/slack-start`** now branches on real state — already paired, unauthorized DM, or shared channel — instead of unconditionally describing the impossible REPL flow.

`record_listener_event` and its helpers moved to a new `slack/events.rs` because `handlers.rs` crossed the 500-SLOC cap. It is re-exported from `handlers`, so the #3852 call site and its tests are untouched.

## Trust model after this change

Unchanged where it matters, and stated plainly:

- **Persona access is gated per-USER by RBAC, not by pairing, and that is untouched.** `handle_message` already returns the static `VIRTUAL_CTO_MESSAGE` — no LLM call, no tool dispatch — for any user absent from `SlackRbacConfig`. RBAC is strictly stronger than pairing and remains the real boundary.
- **Pairing is a per-CHANNEL gate whose remaining job is controlling *where* an authorized user's output can land.** That job is fully preserved: every non-DM channel still requires an explicit code, so `cto-assistant` output cannot be steered into a room with arbitrary readers.
- **Auto-pair grants no new capability.** A DM channel is readable only by that one user and the bot. Auto-pairing it for a user who already holds an RBAC tier gives them exactly the persona they were already entitled to, in a room nobody else can read. An unauthorized user still cannot pair themselves — they are not in the table, so the predicate is false, and even if a channel were paired for them RBAC would still refuse them.
- DM detection uses the Slack channel-id kind prefix (`D` = IM, `C` = public, `G` = private/group), which Slack assigns and delivers over the authenticated Socket Mode socket — not attacker-controlled content. The prefix is used rather than the message event's `channel_type` because slash-command payloads do not carry `channel_type`, and both inbound paths must reach the same answer.

## Alternatives rejected

- **`tagent slack pair` CLI writing the persisted store.** The most general option, and the trust model would have been clean (shell access on the host, exactly what the REPL path assumes). Rejected because the running daemon holds the map in memory and must not be restarted — the CLI would not take effect without either a restart or adding a disk-re-read on every unpaired message. That is extra machinery on the hot rejection path to serve a case nobody is blocked on. The persistence added here is the foundation if we later want it.
- **Env allowlist of pre-approved channel/user ids.** Duplicates `SLACK_RBAC_USERS`, which already carries the authorization data, and would create a second source of truth for "who may talk to the bot" that can silently disagree with the first.
- **Dual-REPL / second Socket Mode connection.** Slack fans events across all open connections for an app, so routing becomes nondeterministic. Not attempted.

## Tests — and proof they bite

Seven new tests. Each was proven to catch the defect by reverting the fix and observing red, then restoring.

**Revert A — `load_paired_channels` forced to always return empty (the pre-fix behavior):**
```
test slack::tests::slack_paired_state_round_trip ... FAILED
assertion `left == right` failed: both pairings should survive the restart
  left: 0
 right: 2
```

**Revert B — `should_auto_pair` forced to `false` (pre-fix: no headless path):**
```
test slack::tests::auto_pair_allows_known_user_dm ... FAILED
assertion failed: should_auto_pair("D0A6V2W1M2R", true)
test result: FAILED. 3 passed; 1 failed
```

**Revert C — `should_auto_pair` forced to `true` (the naive "just drop the gate" shortcut this PR must not ship):**
```
test slack::tests::auto_pair_rejects_unknown_user_dm  ... FAILED
  an unknown user must not be able to pair themselves
test slack::tests::auto_pair_rejects_public_channel   ... FAILED
  a public channel must still require an explicit pairing code
test slack::tests::auto_pair_rejects_private_group    ... FAILED
  a private group must still require an explicit pairing code
test result: FAILED. 1 passed; 3 failed
```

The restart test is a genuine simulated restart: pair two channels, save, **drop the in-memory map entirely**, reload from disk, assert both survive.

## Gates — rung 5 (persistence + security boundary), crate-scoped, exit codes checked

```
GATE cargo test -p trusty-agents                          = 0
GATE cargo clippy -p trusty-agents --all-targets -Dwarnings= 0
GATE cargo fmt --check                                    = 0
GATE bash scripts/check_line_cap.sh                       = 0
GATE bash scripts/check_changelog_fragment.sh             = 0
GATE bash scripts/check_sld.sh                            = 0
```

```
test result: ok. 3341 passed; 0 failed; 11 ignored; 0 measured
line-cap: measured 3646 tracked .rs file(s); 7 allowlisted, 0 violations — OK.
changelog-fragment gate: scanned 6 changed path(s); all 1 crate(s) with source changes are recorded.
sld-lint: scanned 55 spec doc(s) + 3062 code file(s); 0 error(s), 0 warning(s)
```

The running `com.trusty.agents.slack` service was not stopped, restarted, or touched.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools