### PR TITLE
fix(trusty-search,trusty-common): make the live index registry unreachable from tests (#4255)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11800,7 +11800,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-search"
-version = "0.42.2"
+version = "0.42.3"
 dependencies = [
  "anyhow",
  "arc-swap",

--- a/crates/trusty-common/changelog.d/4255-test-harness-daemon-guard.md
+++ b/crates/trusty-common/changelog.d/4255-test-harness-daemon-guard.md
@@ -1,0 +1,6 @@
+Fixed
+
+- `search_index`'s two mutating entry points (`ensure_project_indexed`, `index_files_best_effort`) no longer reach a live trusty-search daemon from a `cargo test` process, so a `tempfile` fixture root can no longer be registered in the operator's `indexes.toml` (closes [#4255](https://github.com/bobmatnyc/trusty-tools/issues/4255))
+  - new `test_harness::running_under_test_harness()` detects a cargo test binary at runtime, which — unlike `cfg(test)` — also covers `tests/` and `[[bin]]` targets and the cross-process case where the write lands in a different process
+  - `TRUSTY_ALLOW_PRODUCTION_STATE=1` is the explicit opt-in for a test that deliberately drives a real daemon; `TRUSTY_TEST_HARNESS=1` forces detection on for a child process a test spawns
+  - reads are unaffected — only the writes are gated

--- a/crates/trusty-common/src/lib.rs
+++ b/crates/trusty-common/src/lib.rs
@@ -641,6 +641,23 @@ pub mod slack_format;
 /// Test: `cargo test -p trusty-common -- data_dir::tests`.
 pub mod data_dir;
 
+/// Runtime "am I a `cargo test` process?" detection (issue #4255).
+///
+/// Why: every existing guard against a test run mutating the operator's live
+/// state was either compile-time (`cfg(test)`, which does not reach a crate's
+/// `tests/` or `[[bin]]` targets) or a per-test convention someone had to
+/// remember. Both were forgotten, and the live `indexes.toml` accumulated
+/// throwaway fixture roots as a result. A runtime check is the only one that
+/// also covers the cross-process case, where a test POSTs to a REAL daemon.
+/// Unconditional (not feature-gated) because trusty-search consumes it from a
+/// path that no feature flag governs.
+/// What: exposes [`test_harness::running_under_test_harness`] plus the
+/// [`test_harness::FORCE_ENV`] / [`test_harness::ALLOW_PRODUCTION_ENV`]
+/// override names.
+/// Test: `cargo test -p trusty-common -- test_harness::tests`.
+pub mod test_harness;
+pub use test_harness::running_under_test_harness;
+
 /// Cross-process locked read-modify-write for whole-file JSON documents.
 ///
 /// Why: `trusty-mpm`'s `projects.json`, `trusty-gworkspace`'s `tokens.json`

--- a/crates/trusty-common/src/search_index.rs
+++ b/crates/trusty-common/src/search_index.rs
@@ -114,6 +114,11 @@ pub fn ensure_project_indexed(project_root: &Path, allow_sensitive_path: bool) -
         return None;
     }
 
+    // #4255: never register a fixture root against the operator's real daemon.
+    if refuse_daemon_write_under_test("registration", &index_id) {
+        return Some(index_id);
+    }
+
     // Discover the running daemon's address (issue #2033: via the shared
     // `resolve_daemon_base_url` helper — never a hardcoded port). Absent /
     // unreadable file ⇒ daemon not started: skip registration (best-effort) but
@@ -133,6 +138,39 @@ pub fn ensure_project_indexed(project_root: &Path, allow_sensitive_path: bool) -
     }
 
     Some(index_id)
+}
+
+/// Should this process refuse to mutate a real trusty-search daemon?
+///
+/// Why (issue #4255): both mutating entry points in this module talk to
+/// whatever daemon is discoverable on the machine. Under `cargo test` that is
+/// the OPERATOR's daemon, so a test exercising a session launch or a task run
+/// against a `tempfile` fixture registered that throwaway directory in the
+/// live `indexes.toml` — the dead roots then stall warm boot for the timeout,
+/// once per entry. Issue #2914 narrowed this by making the temp-dir denylist
+/// bypass opt-in, and trusty-code's tests added a per-test
+/// `isolate_ambient_daemons()` call, but both leave the safety to whoever
+/// writes the next test. The live registry carried five `.tmpXXXXXX` roots
+/// proving that was forgotten. Deciding it here, in the shared helper, is the
+/// version nobody can forget.
+/// What: returns `true` — and logs why — when
+/// [`crate::running_under_test_harness`] says this is a test process. A test
+/// that genuinely wants the real daemon sets `TRUSTY_ALLOW_PRODUCTION_STATE=1`
+/// (see [`crate::test_harness::ALLOW_PRODUCTION_ENV`]). Reads are untouched:
+/// this gates only the writes.
+/// Test: `ensure_project_indexed_never_writes_to_a_daemon_under_test`,
+/// `index_files_inner_never_writes_to_a_daemon_under_test`.
+fn refuse_daemon_write_under_test(operation: &str, index_id: &str) -> bool {
+    if !crate::running_under_test_harness() {
+        return false;
+    }
+    tracing::debug!(
+        "test harness detected (issue #4255): skipping trusty-search {operation} for \
+         '{index_id}' so a fixture root can never reach the operator's live registry. \
+         Set {}=1 to opt in to real daemon writes.",
+        crate::test_harness::ALLOW_PRODUCTION_ENV
+    );
+    true
 }
 
 /// Best-effort, non-blocking incremental re-index of specific files into an
@@ -206,6 +244,10 @@ fn index_files_inner(project_root: &Path, paths: &[std::path::PathBuf]) {
             "skipping incremental trusty-search index update: empty index id for {}",
             root.display()
         );
+        return;
+    }
+    // #4255: never push fixture file content into the operator's real indexes.
+    if refuse_daemon_write_under_test("incremental index update", &index_id) {
         return;
     }
     let Some(base) = crate::resolve_daemon_base_url("trusty-search") else {

--- a/crates/trusty-common/src/search_index_tests.rs
+++ b/crates/trusty-common/src/search_index_tests.rs
@@ -286,6 +286,13 @@ fn ensure_project_indexed_sends_allow_sensitive_path_through_to_create_body() {
         // SAFETY: guarded by ENV_LOCK; removed below before returning.
         unsafe {
             std::env::set_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV, &data_dir);
+            // #4255: this is the ONE test that genuinely needs the daemon-write
+            // path — asserting on the wire body requires the POST to actually
+            // happen. Opting in explicitly is safe here because the "daemon"
+            // is this test's own loopback socket, not the operator's: the
+            // override above points discovery at it. Every other caller stays
+            // guarded.
+            std::env::set_var(crate::test_harness::ALLOW_PRODUCTION_ENV, "1");
         }
 
         // Fake daemon: accept one connection, capture the request body,
@@ -335,6 +342,7 @@ fn ensure_project_indexed_sends_allow_sensitive_path_through_to_create_body() {
 
         unsafe {
             std::env::remove_var(crate::data_dir::DATA_DIR_OVERRIDE_ENV);
+            std::env::remove_var(crate::test_harness::ALLOW_PRODUCTION_ENV);
         }
         let _ = fs::remove_dir_all(&project);
         let _ = fs::remove_dir_all(&data_dir);
@@ -532,4 +540,125 @@ fn post_index_file_exhausts_retries_and_returns_send_failed() {
     // attempts — no more, no less.
     assert_eq!(outcome, IndexOutcome::SendFailed);
     assert_eq!(accepted, MAX_INDEX_ATTEMPTS as usize);
+}
+
+/// Offer the code under test a REAL, discoverable trusty-search daemon, run
+/// `body`, and report whether anything connected to it (issue #4255).
+///
+/// Why: "no write reached the operator's daemon" cannot be proved by pointing
+/// discovery at a dead port — the fail-open path and the guarded path both
+/// look identical then. Standing up a socket that WOULD accept the write is
+/// the only arrangement where the guard is the thing making the difference.
+/// What: binds `127.0.0.1:0`, publishes that address where
+/// `resolve_daemon_base_url("trusty-search")` reads it (via an isolated
+/// `DATA_DIR_OVERRIDE_ENV` data dir, serialised on `ENV_LOCK` like every other
+/// env-mutating test here), asserts discovery actually finds it, runs `body`,
+/// restores the env, and returns `true` if a connection arrived.
+/// Test: used by the two `never_writes_to_a_daemon_under_test` tests below.
+fn daemon_was_contacted_during(body: impl FnOnce()) -> bool {
+    use crate::data_dir::{DATA_DIR_OVERRIDE_ENV, ENV_LOCK};
+
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind stand-in daemon");
+    let addr = listener.local_addr().expect("stand-in daemon local_addr");
+    listener
+        .set_nonblocking(true)
+        .expect("stand-in daemon set_nonblocking");
+
+    let guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let data_dir = scratch_dir("4255-daemon");
+    fs::create_dir_all(&data_dir).expect("create isolated data dir");
+    let previous = std::env::var(DATA_DIR_OVERRIDE_ENV).ok();
+    unsafe { std::env::set_var(DATA_DIR_OVERRIDE_ENV, &data_dir) };
+    crate::write_daemon_addr("trusty-search", &addr.to_string()).expect("publish daemon addr");
+    assert_eq!(
+        crate::resolve_daemon_base_url("trusty-search"),
+        Some(format!("http://{addr}")),
+        "the stand-in daemon must be discoverable, or this test proves nothing"
+    );
+
+    body();
+
+    match previous {
+        Some(p) => unsafe { std::env::set_var(DATA_DIR_OVERRIDE_ENV, p) },
+        None => unsafe { std::env::remove_var(DATA_DIR_OVERRIDE_ENV) },
+    }
+    drop(guard);
+    let _ = fs::remove_dir_all(&data_dir);
+
+    // A connection the code opened just before returning may still be in the
+    // accept queue; give it a moment rather than racing it.
+    std::thread::sleep(std::time::Duration::from_millis(250));
+    !matches!(
+        listener.accept(),
+        Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock
+    )
+}
+
+/// Issue #4255: registering a project must not reach a live daemon from a test
+/// process — and must still return the derived id.
+///
+/// Why: this is the defect the ticket reports, in the form it actually
+/// occurred: trusty-code's and trusty-mpm's tests call this helper with a
+/// `tempfile` fixture root, and every such call registered that throwaway path
+/// in whatever real `indexes.toml` the discoverable daemon owned. The dead
+/// roots then stalled warm boot. `allow_sensitive_path: true` is passed
+/// deliberately — that is tcode's real caller, and the temp-dir denylist (the
+/// only prior guard) is switched off on that path, so nothing else stands
+/// between the fixture and the operator's registry.
+/// What: with a discoverable stand-in daemon, calls `ensure_project_indexed`
+/// on a temp fixture root; asserts no connection was made and the id still
+/// came back (the fail-open contract is unchanged).
+/// Test: this test.
+#[test]
+fn ensure_project_indexed_never_writes_to_a_daemon_under_test() {
+    let root = scratch_dir("4255-ensure");
+    fs::create_dir_all(&root).expect("create fixture root");
+    let mut id = None;
+
+    let contacted = daemon_was_contacted_during(|| {
+        id = ensure_project_indexed(&root, true);
+    });
+
+    assert!(
+        !contacted,
+        "ensure_project_indexed contacted a live trusty-search daemon from a test \
+         process — that is the issue #4255 registry leak"
+    );
+    assert!(
+        id.is_some(),
+        "the derived index id must still be returned; the guard suppresses the \
+         daemon write, not the caller's contract"
+    );
+    let _ = fs::remove_dir_all(&root);
+}
+
+/// Issue #4255: incremental per-file indexing must not reach a live daemon
+/// from a test process either.
+///
+/// Why: `index_files_best_effort` is the other mutating entry point in this
+/// module. It does not create registry entries, but it POSTs fixture file
+/// content into a real index — corrupting the operator's search results rather
+/// than their registry. Guarding only the registration half would leave that
+/// open.
+/// What: with a discoverable stand-in daemon, calls `index_files_inner`
+/// (the synchronous body, so there is no detached thread to race) with one
+/// real file; asserts no connection was made.
+/// Test: this test.
+#[test]
+fn index_files_inner_never_writes_to_a_daemon_under_test() {
+    let root = scratch_dir("4255-incremental");
+    fs::create_dir_all(&root).expect("create fixture root");
+    let file = root.join("fixture.rs");
+    fs::write(&file, "fn fixture() {}\n").expect("write fixture file");
+
+    let contacted = daemon_was_contacted_during(|| {
+        index_files_inner(&root, std::slice::from_ref(&file));
+    });
+
+    assert!(
+        !contacted,
+        "index_files_inner pushed fixture content to a live trusty-search daemon \
+         from a test process (issue #4255)"
+    );
+    let _ = fs::remove_dir_all(&root);
 }

--- a/crates/trusty-common/src/test_harness.rs
+++ b/crates/trusty-common/src/test_harness.rs
@@ -1,0 +1,228 @@
+//! Runtime detection of a `cargo test` harness process, so shared code can
+//! refuse to mutate the operator's production state from a test run (#4255).
+//!
+//! Why: trusty-search already had a compile-time guard for this
+//! (`persistence::default_data_dir`'s `#[cfg(test)]` arm, issue #4094), but
+//! `cfg(test)` is set per *compilation unit*, not per *process*. A crate's
+//! `tests/` integration tests and its `[[bin]]` unit tests link the library
+//! built WITHOUT `cfg(test)`, so the guard silently did not apply to them —
+//! its own doc comment said so. Worse, the pollution that reached the live
+//! `indexes.toml` most recently did not come from trusty-search's tests at
+//! all: trusty-code's and trusty-mpm's tests call
+//! [`crate::search_index::ensure_project_indexed`], which POSTs to whatever
+//! real trusty-search daemon is discoverable. That write happens in a
+//! DIFFERENT process, so no compile-time guard anywhere in trusty-search can
+//! ever prevent it. A runtime check is the only mechanism that covers both.
+//!
+//! What: [`running_under_test_harness`] answers "is this process a cargo test
+//! binary?" from the running executable's own path, with two env-var
+//! overrides. Cargo compiles every test target to
+//! `target/<profile>/deps/<name>-<metadata-hash>`; a `cargo run` binary
+//! (`target/<profile>/<name>`) and an installed one (`~/.cargo/bin/<name>`)
+//! never sit in a `deps/` directory, so the check is true for every test
+//! target — lib unit tests, bin unit tests, integration tests, benches — and
+//! false for every way a user actually runs the software.
+//!
+//! Scope boundary: this reads THIS process's path. A test that spawns the
+//! real binary (`env!("CARGO_BIN_EXE_…")` resolves to `target/<profile>/<name>`,
+//! outside `deps/`) produces a child that is not detected. Such a test must
+//! set [`FORCE_ENV`] or `TRUSTY_DATA_DIR` on the child explicitly.
+//!
+//! Test: `detect_*` and `is_cargo_test_binary_*` in this module's `tests`.
+
+use std::path::Path;
+
+/// Forces [`running_under_test_harness`] to report `true`.
+///
+/// Set this on a child process a test spawns, so the child inherits the
+/// parent's test-isolation even though its own path is outside `deps/`.
+pub const FORCE_ENV: &str = "TRUSTY_TEST_HARNESS";
+
+/// Opt-in escape hatch: forces [`running_under_test_harness`] to report
+/// `false`, letting a test deliberately exercise real production state.
+///
+/// Outranks everything else, including [`FORCE_ENV`] and `cfg!(test)`. This
+/// exists so "a test needs the real registry" stays an explicit, greppable
+/// decision rather than a hole every accident falls through.
+pub const ALLOW_PRODUCTION_ENV: &str = "TRUSTY_ALLOW_PRODUCTION_STATE";
+
+/// Is this process a `cargo test` binary?
+///
+/// Why: production-state mutations (registering an index in the operator's
+/// `indexes.toml`, POSTing to the live daemon) must never happen from a test
+/// run. Callers gate those mutations on this (#4255).
+/// What: [`ALLOW_PRODUCTION_ENV`] wins first (→ `false`), then [`FORCE_ENV`]
+/// (→ `true`), then this crate's own `cfg!(test)`, then the executable-path
+/// check described in the module doc.
+/// Test: `running_under_test_harness_is_true_in_this_test_binary` — this
+/// module's tests run in exactly the harness the function must detect.
+pub fn running_under_test_harness() -> bool {
+    detect(
+        std::env::var(ALLOW_PRODUCTION_ENV).ok().as_deref(),
+        std::env::var(FORCE_ENV).ok().as_deref(),
+        cfg!(test),
+        std::env::current_exe().ok().as_deref(),
+    )
+}
+
+/// Pure decision table behind [`running_under_test_harness`], with every
+/// input injected so the precedence is testable without touching process
+/// state (env vars are process-global and race concurrent tests).
+///
+/// Test: the `detect_*` tests in this module cover each precedence rung.
+fn detect(
+    allow_production: Option<&str>,
+    force: Option<&str>,
+    compiled_as_test: bool,
+    current_exe: Option<&Path>,
+) -> bool {
+    if is_truthy(allow_production) {
+        return false;
+    }
+    if is_truthy(force) || compiled_as_test {
+        return true;
+    }
+    current_exe.is_some_and(is_cargo_test_binary)
+}
+
+/// Shared truthiness parse for both override vars: `1`/`true`/`yes`/`on`,
+/// case-insensitive. Anything else (including unset) is false.
+fn is_truthy(value: Option<&str>) -> bool {
+    value.is_some_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// Does `exe` look like a cargo-compiled test binary?
+///
+/// Why: this is the load-bearing signal — it must be true for every test
+/// target and false for every real invocation. Cargo puts test binaries in
+/// `deps/` and appends a metadata hash to the file stem; neither is true of
+/// `cargo run`'s `target/<profile>/<name>` or an installed `~/.cargo/bin/<name>`.
+/// Requiring BOTH keeps a user who happens to have a `deps` directory on their
+/// PATH from being misdetected as a test.
+/// What: parent directory is named `deps` AND the file stem ends in
+/// `-<hex>` with at least 8 hex digits.
+/// Test: `is_cargo_test_binary_*`.
+fn is_cargo_test_binary(exe: &Path) -> bool {
+    if exe.parent().and_then(Path::file_name) != Some(std::ffi::OsStr::new("deps")) {
+        return false;
+    }
+    let Some(stem) = exe.file_stem().and_then(|s| s.to_str()) else {
+        return false;
+    };
+    stem.rsplit_once('-').is_some_and(|(name, hash)| {
+        !name.is_empty() && hash.len() >= 8 && hash.chars().all(|c| c.is_ascii_hexdigit())
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn test_exe() -> PathBuf {
+        PathBuf::from("/repo/target/debug/deps/integration_tests-f54141ba75b48011")
+    }
+
+    /// The whole point of the module: the real running test process must be
+    /// detected, through the real public entry point, with no injection.
+    ///
+    /// Takes `ENV_LOCK` because this is the only test here that reads the
+    /// process-global override vars, and a sibling test sets
+    /// [`ALLOW_PRODUCTION_ENV`] for its own duration
+    /// (`search_index_tests`' wire-body test). Without the lock the two race
+    /// and this one fails for a reason that has nothing to do with detection.
+    #[test]
+    fn running_under_test_harness_is_true_in_this_test_binary() {
+        let _guard = crate::data_dir::ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        assert!(
+            running_under_test_harness(),
+            "a cargo test process must be detected as a test harness"
+        );
+    }
+
+    #[test]
+    fn detect_allow_production_outranks_everything() {
+        assert!(
+            !detect(Some("1"), Some("1"), true, Some(&test_exe())),
+            "TRUSTY_ALLOW_PRODUCTION_STATE must win over force, cfg(test) and the path check"
+        );
+    }
+
+    #[test]
+    fn detect_force_env_wins_over_path_check() {
+        let installed = PathBuf::from("/Users/me/.cargo/bin/trusty-search");
+        assert!(detect(None, Some("true"), false, Some(&installed)));
+    }
+
+    #[test]
+    fn detect_falls_back_to_exe_path() {
+        assert!(detect(None, None, false, Some(&test_exe())));
+    }
+
+    #[test]
+    fn detect_is_false_for_a_real_invocation() {
+        for exe in [
+            "/Users/me/.cargo/bin/trusty-search",
+            "/opt/homebrew/bin/trusty-search",
+            "/repo/target/debug/trusty-search",
+            "/repo/target/release/trusty-search",
+        ] {
+            assert!(
+                !detect(None, None, false, Some(Path::new(exe))),
+                "{exe} must not be mistaken for a test binary"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_is_false_when_exe_is_unresolvable() {
+        assert!(!detect(None, None, false, None));
+    }
+
+    #[test]
+    fn is_cargo_test_binary_accepts_every_target_kind() {
+        for exe in [
+            // lib + bin unit tests, integration tests, benches
+            "/repo/target/debug/deps/trusty_search-88c47ed536c1e550",
+            "/repo/target/debug/deps/integration_tests-f54141ba75b48011",
+            "/repo/target/release/deps/registry_isolation-0802fde7a9957161",
+        ] {
+            assert!(
+                is_cargo_test_binary(Path::new(exe)),
+                "{exe} is a cargo test binary"
+            );
+        }
+    }
+
+    #[test]
+    fn is_cargo_test_binary_requires_the_metadata_hash() {
+        // A `deps/` directory alone is not enough — a plain name with no
+        // `-<hex>` suffix is not something cargo's test harness produces.
+        assert!(!is_cargo_test_binary(Path::new("/repo/deps/trusty-search")));
+        assert!(!is_cargo_test_binary(Path::new(
+            "/repo/target/debug/deps/trusty-search-notahash"
+        )));
+        // Too short to be cargo's 16-hex metadata hash.
+        assert!(!is_cargo_test_binary(Path::new(
+            "/repo/target/debug/deps/thing-abc"
+        )));
+    }
+
+    #[test]
+    fn is_truthy_accepts_the_documented_spellings_only() {
+        for yes in ["1", "true", "TRUE", "Yes", " on "] {
+            assert!(is_truthy(Some(yes)), "{yes:?} must be truthy");
+        }
+        for no in ["0", "false", "", "no", "off", "maybe"] {
+            assert!(!is_truthy(Some(no)), "{no:?} must not be truthy");
+        }
+        assert!(!is_truthy(None));
+    }
+}

--- a/crates/trusty-mpm/changelog.d/4255-daemon-write-opt-in.md
+++ b/crates/trusty-mpm/changelog.d/4255-daemon-write-opt-in.md
@@ -1,0 +1,4 @@
+Fixed
+
+- `register_project_index_never_bypasses_sensitive_path_denylist` opts into real daemon writes with `TRUSTY_ALLOW_PRODUCTION_STATE=1`, so it keeps receiving the `POST /indexes` body it asserts on now that test processes are barred from writing to a live trusty-search daemon (refs [#4255](https://github.com/bobmatnyc/trusty-tools/issues/4255))
+  - the override is scoped to the test and points at its own loopback socket, never the operator's daemon

--- a/crates/trusty-mpm/src/core/session_launch/tests.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests.rs
@@ -48,7 +48,9 @@ impl EnvVarGuard {
     /// `PathBuf` unnecessarily.
     /// What: snapshots the prior value and sets `key=value`; restored in `Drop`.
     /// Test: used by `inject_trusty_memory_mcp_override_env_wins`.
-    fn set_str(key: &'static str, value: &str) -> Self {
+    // #4255: `pub(super)` so the sibling `tests_search_index` module can opt
+    // into real daemon writes via `TRUSTY_ALLOW_PRODUCTION_STATE`.
+    pub(super) fn set_str(key: &'static str, value: &str) -> Self {
         let prev = std::env::var(key).ok();
         // SAFETY: serialized by `#[serial]`; restored in `Drop`.
         unsafe {

--- a/crates/trusty-mpm/src/core/session_launch/tests_search_index.rs
+++ b/crates/trusty-mpm/src/core/session_launch/tests_search_index.rs
@@ -54,6 +54,13 @@ fn register_project_index_never_bypasses_sensitive_path_denylist() {
         trusty_common::data_dir::DATA_DIR_OVERRIDE_ENV,
         data_dir.path(),
     );
+    // #4255: this test asserts on the wire body, so the POST must actually
+    // happen — the guard that otherwise suppresses daemon writes under a test
+    // harness has to be opted out of. Safe here because the override above
+    // points discovery at this test's OWN loopback socket, never the
+    // operator's daemon. Restored by the guard's `Drop`.
+    let _allow_production =
+        EnvVarGuard::set_str(trusty_common::test_harness::ALLOW_PRODUCTION_ENV, "1");
 
     // Fake daemon: accept one connection, capture the request body, answer
     // 200, then close the listener so the follow-up reindex calls fail fast

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-search"
-version = "0.42.2"
+version = "0.42.3"
 edition = "2021"
 description = "Machine-wide hybrid code search service: BM25 + vector + KG, zero cold-start, MCP server"
 readme = "README.md"

--- a/crates/trusty-search/changelog.d/4255-registry-isolation.md
+++ b/crates/trusty-search/changelog.d/4255-registry-isolation.md
@@ -1,0 +1,6 @@
+Fixed
+
+- No test process can resolve the operator's live data directory any more, so the test suite can no longer register fixture roots in `indexes.toml` (closes [#4255](https://github.com/bobmatnyc/trusty-tools/issues/4255))
+  - issue #4094 guarded this with `#[cfg(test)]`, which is set per compilation unit: the `tests/` integration targets and the `[[bin]]` unit tests link the library built without it and kept resolving the real location. `default_data_dir` now branches on the runtime check `trusty_common::running_under_test_harness()` instead
+  - `tests/registry_isolation.rs` proves it from the non-`cfg(test)` linkage the old guard missed: it performs a real `upsert_index_registry_entry` and asserts the operator's `indexes.toml` is byte-identical afterwards
+  - `TRUSTY_DATA_DIR` still wins over both branches, so tests that set it are unchanged

--- a/crates/trusty-search/src/service/data_dir.rs
+++ b/crates/trusty-search/src/service/data_dir.rs
@@ -33,10 +33,9 @@ use std::path::PathBuf;
 /// creates the directory, and returns it. Emits `tracing::error!` when HOME
 /// is also absent.
 /// Test: `data_dir_home_fallback_path_is_absolute` in this module.
-// #4094: in test builds `persistence::default_data_dir` resolves to the
-// isolated per-process directory instead, so this production-only fallback has
-// no caller there. It is fully live in every non-test build.
-#[cfg_attr(test, allow(dead_code))]
+// #4255: reached from `persistence::production_data_dir`, which a test process
+// no longer routes to — but the routing is now a runtime branch, so the
+// function is live in every build and needs no `dead_code` exemption.
 pub(super) fn data_dir_home_fallback() -> Result<PathBuf> {
     tracing::warn!(
         "data_dir: dirs::data_local_dir() returned None (launchd / supervised spawn?); \
@@ -170,25 +169,27 @@ fn passwd_home_dir() -> Option<PathBuf> {
     }
 }
 
-/// Issue #4094: the data directory this crate's UNIT TESTS resolve to when
-/// they have not set `TRUSTY_DATA_DIR` — never the developer's live data dir.
+/// The data directory a TEST PROCESS resolves to when it has not set
+/// `TRUSTY_DATA_DIR` — never the operator's live data dir (issues #4094, #4255).
 ///
 /// Why: `persistence::data_dir`'s production fallback is the real, well-known
-/// user data location, so any unit test that exercised a persisting handler
-/// without setting `TRUSTY_DATA_DIR` registered its throwaway fixture index in
-/// the developer's live `indexes.toml`. Those entries outlive the test's
-/// `TempDir` and kept `search_health` reporting `degraded`. This function is
-/// what `persistence::default_data_dir` resolves to under `cfg(test)`, so the
-/// real location is unreachable from the unit-test binary by construction —
-/// no per-test discipline to forget, and no process-global env var for a
-/// concurrently-running sibling test to race (issue #4213's failure mode).
+/// user data location, so any test that exercised a persisting handler without
+/// setting `TRUSTY_DATA_DIR` registered its throwaway fixture index in the
+/// operator's live `indexes.toml`. Those entries outlive the test's `TempDir`
+/// and kept `search_health` reporting `degraded`. Issue #4094 made the real
+/// location unreachable under `cfg(test)`; #4255 widened the guard to a
+/// RUNTIME check, because `cfg(test)` is per compilation unit — this crate's
+/// `tests/` integration targets and its `[[bin]]` unit tests link the library
+/// built without it, so they kept resolving to the real location. Neither form
+/// needs per-test discipline, and neither uses a process-global env var a
+/// concurrently-running sibling test could race (issue #4213's failure mode).
 /// What: `<temp_dir>/trusty-search-unit-test-data/pid-<pid>`, resolved once
 /// per process and created on demand. Directories from previous runs older
 /// than [`TEST_DATA_STALE_AFTER`] are opportunistically swept, since a process
 /// that is SIGKILLed cannot clean up after itself.
-/// Test: `unit_test_data_dir_is_isolated_from_real_user_data_dir`.
-#[cfg(test)]
-pub(super) fn unit_test_data_dir() -> Result<PathBuf> {
+/// Test: `test_harness_data_dir_is_isolated_from_real_user_data_dir`, and the
+/// `registry_isolation` integration test for the non-`cfg(test)` linkage.
+pub(super) fn test_harness_data_dir() -> Result<PathBuf> {
     static DIR: std::sync::OnceLock<PathBuf> = std::sync::OnceLock::new();
     let dir = DIR.get_or_init(|| {
         let base = std::env::temp_dir().join("trusty-search-unit-test-data");
@@ -196,19 +197,17 @@ pub(super) fn unit_test_data_dir() -> Result<PathBuf> {
         sweep_stale_test_data_dirs(&base);
         base.join(format!("pid-{}", std::process::id()))
     });
-    std::fs::create_dir_all(dir).context("create isolated unit-test data dir (issue #4094)")?;
+    std::fs::create_dir_all(dir).context("create isolated test-harness data dir (issue #4094)")?;
     Ok(dir.clone())
 }
 
-/// How long an abandoned per-process unit-test data dir survives before the
-/// next test process sweeps it.
-#[cfg(test)]
+/// How long an abandoned per-process test data dir survives before the next
+/// test process sweeps it.
 const TEST_DATA_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(24 * 60 * 60);
 
-/// Best-effort removal of unit-test data dirs left behind by earlier runs.
+/// Best-effort removal of test data dirs left behind by earlier runs.
 /// Failures (a concurrent test process removing the same entry, permissions)
 /// are swallowed — this is tidiness, never correctness.
-#[cfg(test)]
 fn sweep_stale_test_data_dirs(base: &std::path::Path) {
     let Ok(entries) = std::fs::read_dir(base) else {
         return;
@@ -232,22 +231,25 @@ mod tests {
     use super::*;
     use serial_test::serial;
 
-    /// Issue #4094: the un-overridden data-dir fallback must, in test builds,
-    /// resolve somewhere isolated — never the developer's live data dir.
+    /// Issues #4094 / #4255: the un-overridden data-dir fallback must, in a
+    /// test process, resolve somewhere isolated — never the operator's live
+    /// data dir.
     ///
-    /// Why: this is the guard that keeps unit tests from registering fixture
+    /// Why: this is the guard that keeps tests from registering fixture
     /// indexes in the real `indexes.toml`. It asserts the *routing*
-    /// (`persistence::default_data_dir` resolving to [`unit_test_data_dir`]),
-    /// not just the helper in isolation, so reverting the `cfg(test)` arm in
-    /// `persistence.rs` fails here.
+    /// (`persistence::default_data_dir` resolving to
+    /// [`test_harness_data_dir`]), not just the helper in isolation, so
+    /// reverting the test-harness branch in `persistence.rs` fails here. The
+    /// `tests/registry_isolation.rs` integration test covers the same routing
+    /// from the non-`cfg(test)` linkage this one cannot reach.
     /// What: calls `persistence::default_data_dir()` directly — no
     /// `TRUSTY_DATA_DIR` read, no env mutation, therefore nothing a
     /// concurrently-running sibling test can perturb — and asserts the result
-    /// is absolute, exists, lives under the per-process unit-test base, and is
+    /// is absolute, exists, lives under the per-process test base, and is
     /// not the real user data location on either supported platform.
     /// Test: this test.
     #[test]
-    fn unit_test_data_dir_is_isolated_from_real_user_data_dir() {
+    fn test_harness_data_dir_is_isolated_from_real_user_data_dir() {
         let dir = crate::service::persistence::default_data_dir()
             .expect("test-build data dir must resolve");
         assert!(

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -386,14 +386,15 @@ pub struct IndexRegistryFile {
 /// `dirs::data_local_dir()` (NSFileManager-backed) can return None on macOS 26:
 /// (1) `TRUSTY_DATA_DIR` env var, (2) `dirs::data_local_dir()`,
 /// (3) `$HOME`-relative path via `service::data_dir::data_dir_home_fallback`.
-/// Issue #4094: in test builds the un-overridden fallback resolves to an
-/// isolated per-process directory instead of the developer's live data dir,
-/// so a test that never sets `TRUSTY_DATA_DIR` cannot register indexes in the
-/// real `indexes.toml` (see [`default_data_dir`]).
+/// Issues #4094 / #4255: in a TEST PROCESS the un-overridden fallback
+/// resolves to an isolated per-process directory instead of the operator's
+/// live data dir, so a test that never sets `TRUSTY_DATA_DIR` cannot register
+/// indexes in the real `indexes.toml` (see [`default_data_dir`]).
 /// What: returns an absolute path, creating the directory if missing.
 /// Test: `data_dir_respects_trusty_data_dir_env_var`, `data_dir_override_yields_absolute_path`,
 /// `data_dir_home_fallback_path_is_absolute`,
-/// `unit_test_data_dir_is_isolated_from_real_user_data_dir`.
+/// `test_harness_data_dir_is_isolated_from_real_user_data_dir`,
+/// `production_data_dir_is_the_real_user_location`.
 pub fn data_dir() -> Result<PathBuf> {
     if let Ok(override_dir) = std::env::var("TRUSTY_DATA_DIR") {
         let dir = PathBuf::from(&override_dir);

--- a/crates/trusty-search/src/service/persistence.rs
+++ b/crates/trusty-search/src/service/persistence.rs
@@ -420,10 +420,28 @@ pub fn data_dir() -> Result<PathBuf> {
 /// What: `dirs::data_local_dir()/trusty-search`, or the `$HOME`-relative
 /// fallback when `NSFileManager` is unavailable (issue #718: launchd
 /// posix_spawn, macOS 26).
-/// Test: exercised by every production caller; not reachable from the crate's
-/// own unit tests by construction (see the `cfg(test)` sibling below).
-#[cfg(not(test))]
+/// Test: exercised by every production caller; not reachable from ANY test
+/// process by construction (see the test-harness branch below).
 pub(super) fn default_data_dir() -> Result<PathBuf> {
+    // #4255: a test process gets an isolated dir instead of the operator's.
+    if trusty_common::running_under_test_harness() {
+        return super::data_dir::test_harness_data_dir();
+    }
+    production_data_dir()
+}
+
+/// The real, operator-facing data location — reached only when this process
+/// is not a test binary.
+///
+/// Why: split from [`default_data_dir`] so the test-harness branch above is a
+/// single guarded call rather than a `cfg` fork of the whole resolver, and so
+/// the production path stays independently readable.
+/// What: `dirs::data_local_dir()/trusty-search`, falling back to the
+/// `$HOME`-relative path when `NSFileManager` is unavailable (issue #718).
+/// Test: `production_data_dir_is_the_real_user_location` pins the location;
+/// `test_harness_data_dir_is_isolated_from_real_user_data_dir` proves tests
+/// never reach it.
+fn production_data_dir() -> Result<PathBuf> {
     if let Some(base) = dirs::data_local_dir() {
         let dir = base.join("trusty-search");
         std::fs::create_dir_all(&dir).context("create trusty-search data dir")?;
@@ -432,32 +450,6 @@ pub(super) fn default_data_dir() -> Result<PathBuf> {
     }
     // Issue #718: NSFileManager unavailable (launchd posix_spawn, macOS 26).
     super::data_dir::data_dir_home_fallback()
-}
-
-/// Test-build replacement for the un-overridden data-dir fallback.
-///
-/// Why (issue #4094): server handler tests drive `create_index` /
-/// `relocate_index` end to end, and those handlers persist through
-/// [`indexes_toml_path`] → [`data_dir`]. A test that does not set
-/// `TRUSTY_DATA_DIR` therefore wrote real entries into the developer's live
-/// `~/Library/Application Support/trusty-search/indexes.toml`, pointing at
-/// `~/.trusty-search-test-roots/…` fixtures that vanish when the test's
-/// `TempDir` drops. A live machine was found carrying 11 such stale entries,
-/// which kept `search_health` reporting `degraded` indefinitely. Remembering
-/// to set the env var in each test is exactly the discipline that failed;
-/// making the fallback unreachable at compile time in test builds cannot be
-/// forgotten, and — unlike a process-global env var — cannot be raced by a
-/// concurrently-running sibling test (the failure mode of issue #4213).
-/// What: a per-process directory under the system temp dir. Tests that DO set
-/// `TRUSTY_DATA_DIR` are unaffected — that branch still wins in [`data_dir`].
-/// Test: `unit_test_data_dir_is_isolated_from_real_user_data_dir`.
-///
-/// Scope note: `cfg(test)` covers this crate's unit tests (the whole of the
-/// documented pollution). Integration tests under `tests/` link the library
-/// built WITHOUT `cfg(test)` and must still set `TRUSTY_DATA_DIR` themselves.
-#[cfg(test)]
-pub(super) fn default_data_dir() -> Result<PathBuf> {
-    super::data_dir::unit_test_data_dir()
 }
 
 /// Path to the registry TOML file.

--- a/crates/trusty-search/src/service/persistence_tests.rs
+++ b/crates/trusty-search/src/service/persistence_tests.rs
@@ -726,3 +726,26 @@ fn data_dir_respects_trusty_data_dir_env_var() {
         "data_dir() should ensure the directory exists"
     );
 }
+
+/// Issue #4255: isolating tests must not have moved production too.
+///
+/// Why: `default_data_dir` now branches on a runtime test-harness check. The
+/// isolation tests prove the test branch is taken; nothing proved the OTHER
+/// branch still points where the daemon's data actually lives. A silent
+/// regression there would strand every existing index on the next release.
+/// What: calls the production resolver directly (bypassing the branch) and
+/// asserts it equals the well-known user location.
+/// Test: this test.
+#[test]
+fn production_data_dir_is_the_real_user_location() {
+    let Some(expected) = dirs::data_local_dir().map(|b| b.join("trusty-search")) else {
+        // `dirs::data_local_dir()` unavailable — that is the issue #718
+        // fallback path, covered by `data_dir_home_fallback_path_is_absolute`.
+        return;
+    };
+    let dir = production_data_dir().expect("production data dir must resolve");
+    assert_eq!(
+        dir, expected,
+        "the production data dir must stay the operator's real location"
+    );
+}

--- a/crates/trusty-search/tests/registry_isolation.rs
+++ b/crates/trusty-search/tests/registry_isolation.rs
@@ -1,0 +1,118 @@
+//! The operator's live `indexes.toml` must be unreachable from a test process
+//! (issue #4255).
+//!
+//! Why: this file lives in `tests/`, so it links the library built WITHOUT
+//! `cfg(test)` — exactly the linkage issue #4094's compile-time guard did not
+//! cover, and exactly the linkage that let a test register a throwaway fixture
+//! root in the operator's registry. A unit test in `src/` cannot prove this,
+//! because there `cfg(test)` is set and the old guard already applied. Placing
+//! the proof here is the point of the file.
+//!
+//! Why these assertions and not a mock: the failure being guarded against is
+//! "a real write reached a real path". Asserting against an injected path
+//! would pass even with the guard removed, so every assertion below resolves
+//! the operator's real location independently of the code under test.
+//!
+//! Test: the three tests in this file.
+
+use std::path::PathBuf;
+use trusty_search::service::persistence::{
+    indexes_toml_path, load_index_registry_at, upsert_index_registry_entry, PersistedIndex,
+};
+
+/// The operator's real `indexes.toml`, resolved WITHOUT going through the code
+/// under test.
+///
+/// Why: if this called `indexes_toml_path()` the comparison would be a
+/// tautology. Duplicating the well-known layout here is deliberate — it is the
+/// independent oracle the isolation is measured against.
+/// What: `dirs::data_local_dir()/trusty-search/indexes.toml`, falling back to
+/// the `$HOME`-relative platform path (mirrors `service::data_dir`'s issue
+/// #718 fallback).
+/// Test: used by every test below.
+fn production_indexes_toml() -> PathBuf {
+    let base = dirs::data_local_dir().unwrap_or_else(|| {
+        let home = dirs::home_dir().expect("HOME must be set to run these tests");
+        if cfg!(target_os = "macos") {
+            home.join("Library").join("Application Support")
+        } else {
+            home.join(".local").join("share")
+        }
+    });
+    base.join("trusty-search").join("indexes.toml")
+}
+
+/// The detector must fire in this binary — the linkage that used to slip
+/// through.
+///
+/// Why: everything else here depends on it. If this fails, the isolation is
+/// not merely weakened, it is absent, and the more specific failures below
+/// would be confusing to diagnose.
+/// What: asserts `running_under_test_harness()` is true from an integration
+/// test process, where `cfg!(test)` is false for the library.
+/// Test: this test.
+#[test]
+fn integration_test_process_is_detected_as_a_test_harness() {
+    assert!(
+        trusty_common::running_under_test_harness(),
+        "an integration test binary must be detected as a test harness; \
+         without this every other guard in issue #4255 is inert"
+    );
+}
+
+/// The registry path a test resolves must not be the operator's.
+#[test]
+fn registry_path_is_not_the_production_registry() {
+    let resolved = indexes_toml_path().expect("indexes_toml_path must resolve");
+    assert_ne!(
+        resolved,
+        production_indexes_toml(),
+        "a test process resolved the operator's live registry (issue #4255)"
+    );
+}
+
+/// A test that actually registers an index must leave the operator's registry
+/// byte-for-byte untouched.
+///
+/// Why: this is the regression itself, not a proxy for it. It performs the
+/// exact misbehaviour issue #4255 reports — a real `upsert_index_registry_entry`
+/// with a fixture root — and pins the consequence. With the runtime guard in
+/// `persistence::default_data_dir` removed, the write lands in the operator's
+/// `indexes.toml` and this test fails.
+/// What: snapshots the production file's bytes, upserts a fixture entry,
+/// asserts the production bytes are unchanged (or that the file still does not
+/// exist), and asserts the entry did land in the isolated registry — so the
+/// test cannot pass by the write silently failing.
+/// Test: this test.
+#[test]
+fn registering_an_index_never_writes_to_the_production_registry() {
+    let production = production_indexes_toml();
+    let before = std::fs::read(&production).ok();
+
+    let id = format!("ts-4255-isolation-{}", std::process::id());
+    let entry = PersistedIndex {
+        id: id.clone(),
+        root_path: PathBuf::from("/nonexistent/ts-4255-fixture-root"),
+        ..Default::default()
+    };
+    upsert_index_registry_entry(entry).expect("upsert must succeed against the isolated registry");
+
+    let after = std::fs::read(&production).ok();
+    assert_eq!(
+        before,
+        after,
+        "registering an index from a test mutated the operator's live registry at {} \
+         (issue #4255)",
+        production.display()
+    );
+
+    // The write must have actually happened somewhere — otherwise this test
+    // would also pass if `upsert` had become a no-op.
+    let isolated = indexes_toml_path().expect("indexes_toml_path must resolve");
+    let registry = load_index_registry_at(&isolated).expect("isolated registry must load");
+    assert!(
+        registry.iter().any(|i| i.id == id),
+        "the fixture entry must land in the isolated registry at {}",
+        isolated.display()
+    );
+}


### PR DESCRIPTION
## Defect

The test suite wrote fixture roots into the operator's live
`~/Library/Application Support/trusty-search/indexes.toml` and never removed
them. Warm boot then walks each dead root and stalls on it. The live registry
reached 396 entries against ~19 real projects; a manual prune to 41 was back at
43 within an hour.

Two paths reached production state, and neither existing guard closed them:

- `cfg(test)` (the issue #4094 guard) is set per *compilation unit*. A crate's
  `tests/` integration targets and its `[[bin]]` unit tests link the library
  built WITHOUT it, so `persistence::default_data_dir` kept resolving the
  operator's real data dir for them. The guard's own doc comment said so.
- `trusty_common::search_index`'s two mutating entry points POST to whatever
  trusty-search daemon is discoverable. Under `cargo test` that is the
  operator's, and the write lands in a DIFFERENT process — no compile-time
  guard anywhere in trusty-search can prevent it. The live registry carried
  five `.tmpXXXXXX` roots from this path.

## Resolution

Both paths now gate on one runtime check,
`trusty_common::running_under_test_harness()`, which reads the running
executable's own path: cargo compiles every test target into
`target/<profile>/deps/<name>-<hash>`, and no real invocation sits in a
`deps/` directory. This covers lib unit tests, bin unit tests, integration
tests and benches, and — because it is a runtime check — also the
cross-process case.

- `persistence::default_data_dir` branches to an isolated per-process temp dir
  for any test process; the real resolver moves to `production_data_dir()` and
  is pinned by `production_data_dir_is_the_real_user_location`.
- `search_index`'s `ensure_project_indexed` and `index_files_inner` refuse the
  daemon write under a test harness. Reads are untouched.
- `TRUSTY_ALLOW_PRODUCTION_STATE=1` is the explicit opt-in for a test that
  deliberately drives a real daemon. The one such test
  (`ensure_project_indexed_sends_allow_sensitive_path_through_to_create_body`,
  which asserts on the wire body against its own loopback socket) now states
  that intent instead of inheriting it.
- `TRUSTY_DATA_DIR` still wins over both branches, so tests that already set it
  are unchanged.

## Evidence

`crates/trusty-search/tests/registry_isolation.rs` is the enforcement guard,
and it lives in `tests/` on purpose — that is the linkage the old guard missed.
It performs a real `upsert_index_registry_entry` with a fixture root, resolves
the operator's `indexes.toml` independently of the code under test, and asserts
the file is byte-identical afterwards, then asserts the entry did land in the
isolated registry so it cannot pass by the write becoming a no-op. Removing the
runtime branch fails it.

`ensure_project_indexed_never_writes_to_a_daemon_under_test` and
`index_files_inner_never_writes_to_a_daemon_under_test` stand up a real,
discoverable loopback daemon that WOULD accept the write, then assert nothing
connected — a dead port would let the guarded and fail-open paths look
identical.

Empirical: the live registry measured before and after a full
`cargo test -p trusty-search -p trusty-common` run — line count and byte
content unchanged. Numbers in the PR thread.

Closes #4255

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
