### PR TITLE
fix(trusty-mpm): gate destructive index DELETEs behind a capability tests cannot hold (#4743)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4743-test-index-delete-guard.md
+++ b/crates/trusty-mpm/changelog.d/4743-test-index-delete-guard.md
@@ -1,0 +1,8 @@
+Fixed
+
+- `cargo test` can no longer destroy a real trusty-search index (closes [#4743](https://github.com/bobmatnyc/trusty-tools/issues/4743))
+  - `session_manager::search_gc` formatted `DELETE /indexes/{id}?delete_data=true` at two sites and sent it to whatever daemon `resolve_daemon_base_url` discovered — under a test run, the operator's live one on port 7878. `?delete_data=true` destroys the index's on-disk data directory
+  - fixture workspaces derive their index id from a bare `file_name()`, so `decommission_full_still_terminates_the_runtime` asked that daemon to destroy an index named `full`; `sess`, `live` and `proj` appear the same way elsewhere in the suite
+  - both sites now go through one `DestructiveIndexDelete` capability that holds the only copy of the `?delete_data=true` literal and exposes no constructor taking a base URL, so a caller cannot build the request without acquiring it — and a `cargo test` process never can
+  - the orphan sweep acquires the capability before listing anything, so a test process makes no request at all instead of enumerating real indexes and stopping at the delete
+  - `TRUSTY_ALLOW_PRODUCTION_STATE=1` remains the explicit opt-in for a test that deliberately drives a real daemon

--- a/crates/trusty-mpm/src/session_manager/decommission.rs
+++ b/crates/trusty-mpm/src/session_manager/decommission.rs
@@ -585,7 +585,7 @@ impl SessionManager {
     /// | 1 | `graceful_terminate_runtime` — SIGTERM + `kill_session` the pane | no |
     /// | 2 | `remove_session_worktree` — `git worktree remove --force`, `fs::remove_dir_all` fallback, `git worktree prune`, `git branch -D` (dirty-gated, #4344) | no |
     /// | 3 | `fs::remove_dir_all` on an SM-owned workspace (containment-gated) | no |
-    /// | 4 | `delete_search_index_best_effort` — cross-daemon `DELETE /indexes/{id}` | no |
+    /// | 4 | `delete_search_index_best_effort` — cross-daemon `DELETE /indexes/{id}` (never from a test process, #4743) | no |
     /// | 5 | clears `workspace_path`/`workspace_owned` when nothing is on disk | store-only |
     /// | 6 | clears `pending_decision`/`proposed_default` (#4400) | store-only |
     /// | 7 | writes state `Decommissioned` | store-only |

--- a/crates/trusty-mpm/src/session_manager/index_delete_guard.rs
+++ b/crates/trusty-mpm/src/session_manager/index_delete_guard.rs
@@ -1,0 +1,246 @@
+//! The one door a destructive trusty-search index DELETE may pass through (#4743).
+//!
+//! Why: `search_gc` had two independent sites that formatted
+//! `DELETE /indexes/{id}?delete_data=true` — the decommission-time removal and
+//! the orphan sweep's delete loop. `?delete_data=true` destroys the index's
+//! on-disk data directory (trusty-search's own
+//! `delete_index_with_delete_data_true_destroys_data` asserts exactly that;
+//! its orphan reaper deliberately passes `delete_data=false`). The daemon those
+//! requests reach is whichever one `resolve_daemon_base_url` discovers, and
+//! under `cargo test` that is the OPERATOR'S live daemon: the address comes from
+//! `~/Library/Application Support/trusty-search/http_addr`, which a test process
+//! reads exactly like production does. Fixture workspaces derive their index id
+//! from a bare `file_name()` — `full`, `sess`, `live` — so a real index sharing
+//! that basename is destroyed by a test run, silently.
+//!
+//! Why a capability type rather than an `if` at each site: two review rounds on
+//! PR #4725 each found a different destructive effect that a caller had failed
+//! to gate, and the response there was the same one taken here — stop relying on
+//! every call site remembering, and make the ungated shape unrepresentable. A
+//! caller cannot build the URL, because [`DestructiveIndexDelete`] holds the
+//! only copy of the `?delete_data=true` literal and exposes no constructor that
+//! takes a base URL. The only way to obtain one is [`DestructiveIndexDelete::acquire`],
+//! which decides for itself whether the process may destroy data. A new
+//! destructive site added later inherits the refusal by construction: it has to
+//! call `acquire` to get anything it can delete with.
+//!
+//! Why the refusal is a RUNTIME check: the delete lands in a DIFFERENT PROCESS.
+//! Issue #4094's `cfg(test)` arm in trusty-search's `default_data_dir` isolates
+//! that daemon's own data-dir resolution, and #4255/PR #4864 extended isolation
+//! to registry writes — but neither can help here. No compile-time guard in
+//! trusty-search governs what a trusty-mpm test binary puts on the wire, and no
+//! data-dir seam moves a request that is already addressed to port 7878.
+//! `trusty_common::running_under_test_harness` is the process-level answer, and
+//! reusing it keeps this crate from growing a second, drifting copy of the same
+//! detection.
+//!
+//! Test: `acquire_is_refused_under_a_test_harness`,
+//! `acquire_succeeds_when_production_state_is_explicitly_allowed`,
+//! `delete_url_opts_into_data_deletion`; end-to-end,
+//! `decommission_issues_no_request_to_a_live_daemon_under_test` in
+//! `search_gc_guard_tests`.
+
+use std::time::Duration;
+
+use tracing::{debug, warn};
+
+/// Per-request timeout for the index DELETE.
+///
+/// Why: the destructive call runs off the interactive request path
+/// (decommission, periodic GC) but must still never hang the daemon
+/// indefinitely if trusty-search is wedged.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Connect timeout, tighter than the overall request timeout so an unreachable
+/// host fails fast.
+const CONNECT_TIMEOUT: Duration = Duration::from_millis(750);
+
+/// What a destructive index DELETE did, for the caller to log in its own voice.
+///
+/// Why: the two call sites want different log messages for the same three
+/// outcomes, and threading `reqwest` types back to them would leak the
+/// transport this module exists to own.
+#[derive(Debug)]
+pub(super) enum DeleteOutcome {
+    /// The daemon reported the index removed.
+    Removed,
+    /// The daemon answered, but not with a 2xx.
+    Rejected(reqwest::StatusCode),
+    /// The request never got an answer.
+    Transport(String),
+}
+
+/// The capability to destroy a trusty-search index's on-disk data (#4743).
+///
+/// Why: see the module doc — holding one of these is the proof that this
+/// process is allowed to delete real data, and it is the only thing in the
+/// crate that can produce a `?delete_data=true` request.
+/// What: an acquired daemon base URL plus the short-timeout client to reach it.
+/// Both fields are private and there is no constructor other than
+/// [`Self::acquire`], so the capability cannot be forged from a base URL a
+/// caller happens to have.
+/// Test: see the module doc.
+pub(super) struct DestructiveIndexDelete {
+    base: String,
+    client: reqwest::Client,
+}
+
+impl DestructiveIndexDelete {
+    /// Acquire the capability, or `None` when this process must not destroy
+    /// index data.
+    ///
+    /// Why: the refusal lives here, at the single point of acquisition, rather
+    /// than at each call site — a guard a caller has to remember is one new
+    /// call site away from being forgotten, which is precisely how the second
+    /// destructive site in `search_gc` came to have no guard at all.
+    /// What: `None` when (a) `trusty_common::running_under_test_harness()` says
+    /// this is a `cargo test` process, (b) no trusty-search daemon is
+    /// discoverable, or (c) the HTTP client cannot be built. `Some` otherwise.
+    /// The test refusal is checked FIRST so a test run never even resolves the
+    /// operator's daemon address.
+    ///
+    /// A test that genuinely needs to drive a real daemon sets
+    /// `TRUSTY_ALLOW_PRODUCTION_STATE=1` (`trusty_common::test_harness::ALLOW_PRODUCTION_ENV`),
+    /// which makes that intent explicit and greppable instead of ambient.
+    /// Test: `acquire_is_refused_under_a_test_harness`,
+    /// `acquire_succeeds_when_production_state_is_explicitly_allowed`.
+    pub(super) fn acquire() -> Option<Self> {
+        // #4743: a `cargo test` process may not destroy index data. Checked
+        // before discovery so a test run does not even look up where the
+        // operator's daemon lives.
+        if trusty_common::running_under_test_harness() {
+            warn!(
+                "refusing a destructive trusty-search index DELETE: this is a test process \
+                 (#4743). Set {} to override.",
+                trusty_common::test_harness::ALLOW_PRODUCTION_ENV
+            );
+            return None;
+        }
+        let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
+            debug!("trusty-search daemon not discoverable; skipping index removal (#2033)");
+            return None;
+        };
+        match reqwest::Client::builder()
+            .timeout(REQUEST_TIMEOUT)
+            .connect_timeout(CONNECT_TIMEOUT)
+            .build()
+        {
+            Ok(client) => Some(Self { base, client }),
+            Err(e) => {
+                warn!("trusty-search index-delete client build failed: {e}");
+                None
+            }
+        }
+    }
+
+    /// The destructive URL for `index_id` — the crate's only `?delete_data=true`.
+    ///
+    /// Why (#4123): trusty-search's `DELETE /indexes/:id` preserves on-disk data
+    /// unless `delete_data=true` is passed. Both callers opt in deliberately:
+    /// the workspace each index describes is a disposable worktree that is
+    /// being (or has been) deleted, so preserved index data would be
+    /// unreachable garbage on disk forever.
+    /// What: `{base}/indexes/{index_id}?delete_data=true`. Private, and
+    /// reachable only through an acquired capability.
+    /// Test: `delete_url_opts_into_data_deletion`.
+    fn delete_url(&self, index_id: &str) -> String {
+        format!("{}/indexes/{index_id}?delete_data=true", self.base)
+    }
+
+    /// Issue the DELETE and classify the result.
+    ///
+    /// What: never returns an error — every failure mode maps to a
+    /// [`DeleteOutcome`] variant so both callers stay fail-soft (an unreachable
+    /// or erroring search daemon must not block session teardown).
+    /// Test: covered end-to-end by
+    /// `decommission_issues_no_request_to_a_live_daemon_under_test`, which
+    /// asserts this never runs under a test harness.
+    pub(super) async fn delete(&self, index_id: &str) -> DeleteOutcome {
+        match self.client.delete(self.delete_url(index_id)).send().await {
+            Ok(resp) if resp.status().is_success() => DeleteOutcome::Removed,
+            Ok(resp) => DeleteOutcome::Rejected(resp.status()),
+            Err(e) => DeleteOutcome::Transport(e.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The load-bearing assertion, made from inside the very thing it detects:
+    /// this test IS a `cargo test` process, so `acquire` must refuse it.
+    ///
+    /// Why no injection: a decision table with fabricated inputs would prove
+    /// the precedence rules (`trusty-common` already tests those) but not the
+    /// only fact that matters here — that a real trusty-mpm test binary is
+    /// classified as one. Reverting the `running_under_test_harness` branch in
+    /// `acquire` fails this on any machine with a running trusty-search daemon.
+    /// Test: this function IS the test.
+    #[test]
+    fn acquire_is_refused_under_a_test_harness() {
+        assert!(
+            DestructiveIndexDelete::acquire().is_none(),
+            "a cargo test process must never acquire the destructive-delete capability (#4743)"
+        );
+    }
+
+    /// The escape hatch works, and the guard is not over-applied into a
+    /// permanent disablement of the orphan GC.
+    ///
+    /// Why: a refusal that could never be lifted would be indistinguishable
+    /// from having deleted the feature, and nothing would notice if `acquire`
+    /// started returning `None` unconditionally.
+    /// What: with `TRUSTY_ALLOW_PRODUCTION_STATE=1` and a discoverable daemon
+    /// address written into an ISOLATED data dir, `acquire` yields a capability
+    /// pointed at that isolated address. Deliberately never calls `delete` — the
+    /// address belongs to nothing, and issuing a request is not what is under
+    /// test.
+    /// Test: this function IS the test.
+    #[serial_test::serial]
+    #[test]
+    fn acquire_succeeds_when_production_state_is_explicitly_allowed() {
+        let dir = crate::test_support::hermetic_temp_dir();
+        std::fs::create_dir_all(dir.path().join("trusty-search")).unwrap();
+        std::fs::write(
+            dir.path().join("trusty-search").join("http_addr"),
+            "127.0.0.1:59999",
+        )
+        .unwrap();
+
+        // SAFETY: `#[serial]` — no other test thread races this set/restore.
+        unsafe {
+            std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, dir.path());
+            std::env::set_var(trusty_common::test_harness::ALLOW_PRODUCTION_ENV, "1");
+        }
+        let acquired = DestructiveIndexDelete::acquire();
+        let url = acquired.as_ref().map(|d| d.delete_url("some-index"));
+        unsafe {
+            std::env::remove_var(trusty_common::test_harness::ALLOW_PRODUCTION_ENV);
+            std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
+        }
+
+        assert_eq!(
+            url.as_deref(),
+            Some("http://127.0.0.1:59999/indexes/some-index?delete_data=true"),
+            "the explicit production opt-in must still yield a working capability"
+        );
+    }
+
+    /// The opt-in that makes the call destructive must survive refactoring —
+    /// a URL that lost `?delete_data=true` would silently leak index data
+    /// forever (#4123), the failure this whole module is downstream of.
+    /// Test: this function IS the test.
+    #[serial_test::serial]
+    #[test]
+    fn delete_url_opts_into_data_deletion() {
+        let cap = DestructiveIndexDelete {
+            base: "http://127.0.0.1:7878".into(),
+            client: reqwest::Client::new(),
+        };
+        assert_eq!(
+            cap.delete_url("my-index"),
+            "http://127.0.0.1:7878/indexes/my-index?delete_data=true"
+        );
+    }
+}

--- a/crates/trusty-mpm/src/session_manager/mod.rs
+++ b/crates/trusty-mpm/src/session_manager/mod.rs
@@ -15,6 +15,8 @@ pub mod dedup;
 pub mod delete;
 pub mod driver;
 pub mod hook_sync;
+// #4743: the single capability every destructive index DELETE must hold.
+mod index_delete_guard;
 pub mod injection_status;
 pub mod manager;
 pub mod naming;
@@ -48,6 +50,11 @@ pub mod worktree_safety;
 
 #[cfg(test)]
 mod tests;
+
+// #4743: the destructive index-DELETE guard, asserted against a live,
+// accepting loopback daemon rather than a dead port.
+#[cfg(test)]
+mod search_gc_guard_tests;
 
 #[cfg(test)]
 mod restart_tests;

--- a/crates/trusty-mpm/src/session_manager/search_gc.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc.rs
@@ -29,13 +29,16 @@ use serde::Deserialize;
 use tracing::{debug, info, warn};
 
 use super::decommission::is_session_worktree;
+use super::index_delete_guard::{DeleteOutcome, DestructiveIndexDelete};
 use super::manager::SessionManager;
 
-/// Per-request timeout for trusty-search index-lifecycle HTTP calls.
+/// Per-request timeout for the READ-ONLY trusty-search calls in this module
+/// (the sweep's index listing and status probes).
 ///
 /// Why: these calls run off the interactive request path (decommission,
 /// periodic GC) but must still never hang the daemon indefinitely if
-/// trusty-search is wedged.
+/// trusty-search is wedged. The destructive DELETE carries its own timeouts
+/// inside [`DestructiveIndexDelete`] (#4743).
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(5);
 /// Connect timeout, tighter than the overall request timeout so an
 /// unreachable host fails fast.
@@ -87,50 +90,34 @@ pub(super) fn disposable_workspace_index_id(
 /// unreachable or erroring search daemon must NEVER block or fail session
 /// teardown, so every outcome is logged and swallowed here — the caller
 /// (`decommission_with_root`) invokes this unconditionally.
-/// What: resolves the daemon's base URL via
-/// `trusty_common::resolve_daemon_base_url`; when discoverable, issues a
-/// short-timeout `DELETE` and logs the outcome (removed / non-2xx / transport
-/// error) at info/warn. A `None` base (daemon never started) is a debug-logged
-/// no-op.
-/// Test: exercised via the live-daemon decommission integration path; the
-/// daemon-unreachable branch mirrors the shared `trusty_common::search_index`
-/// register path's (both skip cleanly on a missing address file).
+/// What: acquires the [`DestructiveIndexDelete`] capability and, when granted,
+/// issues the DELETE and logs the outcome (removed / non-2xx / transport error)
+/// at info/warn. A refused capability — daemon never started, or this is a test
+/// process (#4743) — is a no-op, logged by `acquire` itself.
+/// Test: exercised via the live-daemon decommission integration path;
+/// `decommission_issues_no_request_to_a_live_daemon_under_test` pins that a
+/// test process reaches the daemon zero times.
 pub(super) async fn delete_search_index_best_effort(index_id: &str) {
-    let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
-        debug!(
-            index_id,
-            "trusty-search daemon not discoverable; skipping index removal on decommission (#2033)"
-        );
+    // #4743: no base URL, no client, no `?delete_data=true` without this. A
+    // test process cannot acquire it, so the request is never built at all.
+    let Some(deleter) = DestructiveIndexDelete::acquire() else {
         return;
     };
-    let client = match build_client() {
-        Ok(c) => c,
-        Err(e) => {
-            warn!("trusty-search index-delete client build failed: {e}");
-            return;
-        }
-    };
-    // Issue #4123: trusty-search's `DELETE /indexes/:id` now preserves on-disk
-    // data unless `delete_data=true` is passed. Opt in — the workspace this
-    // index describes is a disposable worktree that decommission is about to
-    // delete, so nothing will ever re-register at that root and preserved
-    // index data would be unreachable garbage on disk forever.
-    let url = format!("{base}/indexes/{index_id}?delete_data=true");
-    match client.delete(&url).send().await {
-        Ok(resp) if resp.status().is_success() => {
+    match deleter.delete(index_id).await {
+        DeleteOutcome::Removed => {
             info!(
                 index_id,
                 "decommission: removed trusty-search index (#2033)"
             );
         }
-        Ok(resp) => {
+        DeleteOutcome::Rejected(status) => {
             warn!(
                 index_id,
-                status = %resp.status(),
+                %status,
                 "decommission: trusty-search index delete returned non-2xx"
             );
         }
-        Err(e) => {
+        DeleteOutcome::Transport(e) => {
             warn!(
                 index_id,
                 "decommission: trusty-search index delete failed: {e}"
@@ -139,8 +126,8 @@ pub(super) async fn delete_search_index_best_effort(index_id: &str) {
     }
 }
 
-/// Build the short-timeout `reqwest::Client` shared by every search-index
-/// lifecycle call in this module.
+/// Build the short-timeout `reqwest::Client` shared by the READ-ONLY
+/// search-index calls in this module.
 fn build_client() -> reqwest::Result<reqwest::Client> {
     reqwest::Client::builder()
         .timeout(REQUEST_TIMEOUT)
@@ -280,17 +267,36 @@ impl SessionManager {
     /// `chunk_count`, and applies [`is_orphan_index`]. Under `dry_run` the
     /// matching ids are logged and returned without deleting anything
     /// (mirrors `PruneWorktreesRequest`'s dry-run-by-default convention);
-    /// otherwise each is removed via `DELETE /indexes/:id`, logged
-    /// individually (no silent truncation), and returned. Returns `Ok(vec![])`
-    /// without error when the daemon is undiscoverable — the sweep is
-    /// best-effort, like the rest of the orphan-GC loop.
+    /// otherwise each is removed via the [`DestructiveIndexDelete`] capability,
+    /// logged individually (no silent truncation), and returned. Returns
+    /// `Ok(vec![])` without error when the daemon is undiscoverable — the sweep
+    /// is best-effort, like the rest of the orphan-GC loop.
+    ///
+    /// #4743: a non-dry-run sweep acquires the destructive capability BEFORE
+    /// listing anything, so a test process returns `Ok(vec![])` having made no
+    /// request at all rather than enumerating the operator's real indexes.
     /// Test: `is_orphan_index_*` cover the pure decision; this async
     /// orchestration is exercised via the daemon-unreachable no-op path in
-    /// `sweep_orphaned_search_indexes_noop_when_daemon_unreachable`.
+    /// `sweep_orphaned_search_indexes_noop_when_daemon_unreachable`, and the
+    /// test-process refusal by `sweep_makes_no_request_under_a_test_harness`.
     pub async fn sweep_orphaned_search_indexes(
         &self,
         dry_run: bool,
     ) -> anyhow::Result<Vec<String>> {
+        // #4743: acquire the destructive capability BEFORE doing any work, not
+        // at the delete. A sweep that lists indexes and probes each one only to
+        // discover at the last step that it may not delete has already spent a
+        // round-trip per index against a daemon it has no business acting on.
+        // `dry_run` needs no capability — it deletes nothing by definition.
+        let deleter = if dry_run {
+            None
+        } else {
+            match DestructiveIndexDelete::acquire() {
+                Some(d) => Some(d),
+                None => return Ok(Vec::new()),
+            }
+        };
+
         let Some(base) = trusty_common::resolve_daemon_base_url("trusty-search") else {
             debug!("trusty-search daemon not discoverable; skipping index orphan sweep (#2033)");
             return Ok(Vec::new());
@@ -318,33 +324,36 @@ impl SessionManager {
             }
         }
 
-        if dry_run {
+        // No capability means `dry_run` — the only other way to get here
+        // without one is the early return above.
+        let Some(deleter) = deleter else {
             for id in &candidates {
                 info!(index_id = %id, "search-index-gc (dry-run): would remove orphaned/0-chunk index");
             }
             return Ok(candidates);
-        }
+        };
 
         let mut removed = Vec::new();
         for id in candidates {
-            // Issue #4123: opt in to data deletion — same rationale as
-            // `delete_search_index_best_effort`. Every candidate here is a
-            // worktree-scoped index with no live session, so its data is
-            // unreachable garbage; a bare DELETE would silently leak it.
-            let url = format!("{base}/indexes/{id}?delete_data=true");
-            match client.delete(&url).send().await {
-                Ok(resp) if resp.status().is_success() => {
+            // #4743: the `?delete_data=true` opt-in that used to be formatted
+            // inline here now lives inside the capability, so this loop and the
+            // decommission-time delete share one destructive door instead of
+            // two independently-guarded ones. Its #4123 rationale is unchanged:
+            // every candidate is a worktree-scoped index with no live session,
+            // so its data is unreachable garbage a bare DELETE would leak.
+            match deleter.delete(&id).await {
+                DeleteOutcome::Removed => {
                     info!(index_id = %id, "search-index-gc: removed orphaned/0-chunk index");
                     removed.push(id);
                 }
-                Ok(resp) => {
+                DeleteOutcome::Rejected(status) => {
                     warn!(
                         index_id = %id,
-                        status = %resp.status(),
+                        %status,
                         "search-index-gc: delete returned non-2xx"
                     );
                 }
-                Err(e) => {
+                DeleteOutcome::Transport(e) => {
                     warn!(index_id = %id, "search-index-gc: delete failed: {e}");
                 }
             }

--- a/crates/trusty-mpm/src/session_manager/search_gc_guard_tests.rs
+++ b/crates/trusty-mpm/src/session_manager/search_gc_guard_tests.rs
@@ -1,0 +1,214 @@
+//! The standing guard on #4743: a test process reaches no trusty-search daemon
+//! on any destructive path.
+//!
+//! Why a real, live, accepting listener rather than a dead port: a dead port
+//! makes the guarded and the unguarded code look identical — both end with "no
+//! index was deleted", one because the request was refused at the source and one
+//! because nothing was there to answer it. The listener here is a daemon that
+//! WOULD have accepted the DELETE and answered 200, so the connection counter
+//! staying at zero is evidence about trusty-mpm's behaviour rather than about
+//! the machine's port allocation. This mirrors the shape PR #4864 used for the
+//! registry-write guard, and the reason is the same.
+//!
+//! Why these fixtures reproduce the reported hazard exactly: the issue names
+//! `decommission_full_still_terminates_the_runtime`, whose workspace basename is
+//! `full`. `disposable_workspace_index_id` derives the index id from a bare
+//! `file_name()`, so that test asks a daemon to destroy an index called `full`.
+//! `sess`, `live` and `proj` appear the same way elsewhere in this suite, and
+//! the operator's daemon carried a real index named `proj` when this was
+//! written. Nothing about the fixture names is fixed here — the point of the fix
+//! is that the id no longer matters, because the request is never issued.
+//!
+//! Test: the two functions below.
+
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use tempfile::TempDir;
+
+use super::record::{ManagedSessionId, ManagedSessionState};
+use super::tests::make_manager;
+
+/// A loopback stand-in for the operator's trusty-search daemon that accepts
+/// every connection, answers a success body, and counts what it saw.
+struct CountingDaemon {
+    connections: Arc<AtomicUsize>,
+    /// Data dir whose `trusty-search/http_addr` points at this listener, for
+    /// `TRUSTY_DATA_DIR_OVERRIDE`.
+    data_dir: TempDir,
+}
+
+impl CountingDaemon {
+    /// Bind, start accepting, and write the discovery file the production
+    /// resolver reads.
+    async fn start() -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let connections = Arc::new(AtomicUsize::new(0));
+
+        let counter = Arc::clone(&connections);
+        tokio::spawn(async move {
+            use tokio::io::{AsyncReadExt, AsyncWriteExt};
+            while let Ok((mut sock, _)) = listener.accept().await {
+                counter.fetch_add(1, Ordering::SeqCst);
+                let mut buf = [0u8; 2048];
+                let _ = sock.read(&mut buf).await;
+                let _ = sock
+                    .write_all(
+                        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n\
+                          Content-Length: 36\r\n\r\n{\"removed\":true,\"data_deleted\":true}",
+                    )
+                    .await;
+                let _ = sock.shutdown().await;
+            }
+        });
+
+        let data_dir = crate::test_support::hermetic_temp_dir();
+        std::fs::create_dir_all(data_dir.path().join("trusty-search")).unwrap();
+        std::fs::write(
+            data_dir.path().join("trusty-search").join("http_addr"),
+            addr.to_string(),
+        )
+        .unwrap();
+
+        Self {
+            connections,
+            data_dir,
+        }
+    }
+
+    /// Confirm the fixture's own premise: this listener really does accept and
+    /// answer. Without it, a zero count could mean the listener was broken.
+    async fn self_check(&self) {
+        let body = reqwest::Client::new()
+            .get(format!(
+                "http://{}/health",
+                std::fs::read_to_string(
+                    self.data_dir.path().join("trusty-search").join("http_addr")
+                )
+                .unwrap()
+            ))
+            .send()
+            .await
+            .expect("the stand-in daemon must answer — the fixture's premise")
+            .text()
+            .await
+            .unwrap();
+        assert!(body.contains("removed"), "unexpected body: {body}");
+        // The self-check's own connection does not count against the assertion.
+        self.connections.store(0, Ordering::SeqCst);
+    }
+
+    fn seen(&self) -> usize {
+        self.connections.load(Ordering::SeqCst)
+    }
+}
+
+/// The regression test for #4743: a full decommission from a test process must
+/// put nothing on the wire, even though a daemon is discoverable and willing.
+///
+/// Why serial: `TRUSTY_DATA_DIR_OVERRIDE` is process-global.
+/// What: reproduces the issue's own fixture — an SM-owned workspace whose
+/// basename is `full`, so `disposable_workspace_index_id` yields the index id
+/// `full` and `decommission_with_root` reaches its effect-4 index delete. Points
+/// daemon discovery at a listener that would accept the DELETE, decommissions
+/// for real, and asserts the listener saw zero connections. Reverting
+/// `DestructiveIndexDelete::acquire`'s `running_under_test_harness` branch makes
+/// this fail with a count of 1.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn decommission_issues_no_request_to_a_live_daemon_under_test() {
+    let daemon = CountingDaemon::start().await;
+    daemon.self_check().await;
+
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    let managed_root = crate::test_support::hermetic_temp_dir();
+    // The issue's own fixture name. A bare `file_name()` becomes the index id.
+    let workspace_path = managed_root.path().join("owner").join("repo").join("full");
+    std::fs::create_dir_all(&workspace_path).unwrap();
+
+    let record = mgr
+        .create_with_id(
+            ManagedSessionId::new(),
+            "task".into(),
+            Some(workspace_path.clone()),
+            None,
+            Some(workspace_path.clone()),
+            None,
+            None,
+            crate::runtime::RuntimeKind::default(),
+            false,
+            true, // owned — reaches the index-delete effect
+        )
+        .await
+        .expect("create");
+
+    // SAFETY: `#[serial]` — no other test thread races this set/restore.
+    unsafe {
+        std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, daemon.data_dir.path());
+    }
+    let outcome = mgr
+        .decommission_with_root(&record.id, managed_root.path(), None)
+        .await;
+    unsafe {
+        std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
+    }
+
+    let (tombstone, _removed) = outcome.expect("full decommission");
+    assert_eq!(
+        tombstone.state,
+        ManagedSessionState::Decommissioned,
+        "the guard must not change what decommission does to the record"
+    );
+    assert_eq!(
+        daemon.seen(),
+        0,
+        "a test process must reach the trusty-search daemon zero times — a DELETE here \
+         carries ?delete_data=true and destroys a real index named `full` (#4743)"
+    );
+}
+
+/// The same guarantee for the second destructive site, which before #4743 had
+/// no guard of its own at all.
+///
+/// Why separate: `sweep_orphaned_search_indexes` formatted its own
+/// `?delete_data=true` URL in a loop rather than calling the decommission-time
+/// helper, so a guard placed only on that helper would have left this path
+/// fully exposed. Asserting on the sweep directly is what keeps the two from
+/// diverging again.
+/// What: with a willing daemon discoverable, a non-dry-run sweep must return
+/// empty having made no request — not even the index listing, which the
+/// capability is acquired ahead of.
+/// Test: this function IS the test.
+#[serial_test::serial]
+#[tokio::test]
+async fn sweep_makes_no_request_under_a_test_harness() {
+    let daemon = CountingDaemon::start().await;
+    daemon.self_check().await;
+
+    let dir = crate::test_support::hermetic_temp_dir();
+    let (mgr, _fake) = make_manager(&dir).await;
+
+    // SAFETY: `#[serial]` — no other test thread races this set/restore.
+    unsafe {
+        std::env::set_var(trusty_common::DATA_DIR_OVERRIDE_ENV, daemon.data_dir.path());
+    }
+    let swept = mgr.sweep_orphaned_search_indexes(false).await;
+    unsafe {
+        std::env::remove_var(trusty_common::DATA_DIR_OVERRIDE_ENV);
+    }
+
+    assert_eq!(
+        swept.expect("sweep must not error").len(),
+        0,
+        "a refused sweep reports nothing removed"
+    );
+    assert_eq!(
+        daemon.seen(),
+        0,
+        "the orphan sweep must not even LIST indexes from a test process (#4743)"
+    );
+}


### PR DESCRIPTION
## Defect

The route is in `trusty-mpm`, not `trusty-search`.

`session_manager/search_gc.rs` formatted `DELETE /indexes/{id}?delete_data=true`
at two sites — `delete_search_index_best_effort:118` (decommission) and the
orphan sweep's own inline loop at `:334` — and sent it to whatever daemon
`trusty_common::resolve_daemon_base_url("trusty-search")` discovered. That
resolver reads `~/Library/Application Support/trusty-search/http_addr`, and a
test process reads it exactly like production does. On this machine that file
contains `127.0.0.1:7878`: the operator's live daemon. `?delete_data=true`
destroys the index's on-disk data directory — trusty-search's own
`delete_index_with_delete_data_true_destroys_data` asserts it, and its orphan
reaper deliberately passes `delete_data=false`.

Fixture workspaces derive their index id from a bare `file_name()`
(`derive_index_id`), so `decommission_full_still_terminates_the_runtime` asked
that daemon to destroy an index named `full`. `sess`, `live` and `proj` reach the
same path elsewhere in the suite; the operator's daemon carried a real index
named `proj` while this was written.

Measured, not inferred. With the guard removed, the regression test's counting
daemon records exactly one connection:

```
assertion `left == right` failed: a test process must reach the trusty-search
daemon zero times — a DELETE here carries ?delete_data=true and destroys a real
index named `full` (#4743)
  left: 1
 right: 0
```

## Why #4094's fix does not cover it

#4094 put a `cfg(test)` arm in trusty-search's `persistence::default_data_dir`,
so that daemon resolves an isolated data dir under test. Neither half of that
helps here:

- The delete lands in a **different process**. No compile-time guard anywhere in
  trusty-search governs what a trusty-mpm test binary puts on the wire.
- A data-dir seam cannot move a request that is already addressed to port 7878.
  Pointing the target elsewhere is the one thing a data-dir fix does not do.

## Resolution

Both destructive sites now go through one capability,
`session_manager::index_delete_guard::DestructiveIndexDelete`.

- It holds the **only** copy of the `?delete_data=true` literal, and exposes no
  constructor taking a base URL. A caller cannot build the request without
  acquiring the capability; the capability decides for itself whether the
  process may destroy data. A destructive site added later inherits the refusal
  by construction — it has to call `acquire` to get anything it can delete with.
- `acquire` refuses a `cargo test` process, checked **before** discovery so a
  test run never even looks up where the operator's daemon lives.
- The orphan sweep acquires the capability **before listing anything**, so a
  test process makes no request at all rather than enumerating the operator's
  real indexes and stopping at the delete. That loop previously had no guard of
  its own — a guard placed only on the decommission helper would have left it
  fully exposed, which is the shape PR #4725's review kept finding.

This is deliberately not a conditional at each call site. Two review rounds on
PR #4725 each found a different destructive effect a caller had failed to gate;
the response there, as here, was to make the ungated shape unrepresentable
rather than rely on every call site remembering.

The refusal itself must be a runtime check, for the cross-process reason above.

## Relationship to PR #4864

This **builds on** #4864 rather than duplicating or fighting it. It was
developed stacked on `fix-4255-registry-pollution`; that PR merged as `da1e8dcb`
partway through, so this now sits directly on main as a single commit.

#4864 establishes `trusty_common::running_under_test_harness()` in a new
`crates/trusty-common/src/test_harness.rs`. That is precisely the process-level
seam this defect needs, so this PR consumes it rather than growing a second,
drifting copy of the same detection in trusty-mpm. `TRUSTY_ALLOW_PRODUCTION_STATE=1`
carries over unchanged as the explicit opt-in.

The two are complementary halves of the same exposure. #4864 closed the
**write** paths — a fixture root registering itself in the operator's
`indexes.toml`, and `ensure_project_indexed` POSTing to the live daemon. This
closes the **destructive** path, which no data-dir or registry seam reaches.
File overlap is zero: #4864 changed `trusty-common` and `trusty-search`; this
changes only `crates/trusty-mpm/src/session_manager/`.

One finding was fed back to #4864 while stacked on it:
`register_project_index_never_bypasses_sensitive_path_denylist`
(`crates/trusty-mpm/src/core/session_launch/tests_search_index.rs`) drives
`ensure_project_indexed` and was failing on that branch, because #4864's guard
suppressed the POST it asserts on. #4864 fixed it in `c68825bc` before merging.

## Evidence

`search_gc_guard_tests.rs` asserts against a **live, accepting** loopback daemon
rather than a dead port. A dead port makes the guarded and unguarded code look
identical — both end with "no index was deleted", one because the request was
refused at the source and one because nothing was there to answer. The listener
here would have accepted the DELETE and answered 200, so a zero count is
evidence about trusty-mpm's behaviour rather than about the machine's port
allocation. The fixture self-checks that it really does answer, so a zero count
cannot come from a broken listener.

Reverting `acquire`'s `running_under_test_harness` branch fails three tests:

```
test session_manager::index_delete_guard::tests::acquire_is_refused_under_a_test_harness ... FAILED
test session_manager::search_gc_guard_tests::decommission_issues_no_request_to_a_live_daemon_under_test ... FAILED
test session_manager::search_gc_guard_tests::sweep_makes_no_request_under_a_test_harness ... FAILED
test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured; 4530 filtered out
```

Restored, the full crate suite is green:

```
test result: ok. 4529 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 129.29s
```

`cargo clippy -p trusty-mpm --all-targets -- -D warnings`, `cargo fmt --check`,
`scripts/check_line_cap.sh` (0 violations) and `scripts/check_sld.sh` (0 errors,
0 warnings) all pass. No version bumps.

Unrelated pre-existing flake, seen across these runs and reported rather than
chased: `daemon::managed_routes::tests::stale_assets_for_many_*` fails
intermittently, a different member each time, and passes when the four are run
in isolation. They share a process-global `$HOME` override (`fake_home()`) and
race other `$HOME`-touching tests under parallel execution. That file contains
zero references to `search_gc`, `index_delete` or `delete_data`, and is not in
this diff.

No destructive path was exercised against the operator's live daemon at any
point: the revert demonstration ran with `TRUSTY_DATA_DIR_OVERRIDE` pointed at
the test's own counting daemon, which is where that one DELETE landed.

Closes #4743

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
