### PR TITLE
fix(trusty-search): make the shutdown window achievable and stop the reaper killing by name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11578,7 +11578,7 @@ dependencies = [
 
 [[package]]
 name = "trusty-installer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/crates/trusty-common/changelog.d/4393-launchd-exit-timeout.md
+++ b/crates/trusty-common/changelog.d/4393-launchd-exit-timeout.md
@@ -1,0 +1,12 @@
+Fixed
+
+- Generated LaunchAgent plists now declare `ExitTimeOut`. Without the key
+  launchd applies its "system-defined" default, which measures 5 s on macOS —
+  SIGTERM, then SIGKILL 5 s later on every `launchctl bootout`, `kickstart -k`,
+  logout and reboot. That is shorter than the shutdown work several trusty-*
+  daemons do; trusty-search's index flush alone floors at 30 s per index, so it
+  was cut off mid-write every time. The rendered window comes from the new
+  `shutdown::TERMINATION_GRACE_SECS` (60 s), which `trusty-search stop` and its
+  orphan reaper now wait as well, so the window a daemon plans for and the
+  window its terminator grants cannot drift apart. **Already-installed agents
+  keep launchd's 5 s default until their plist is regenerated** (#4393)

--- a/crates/trusty-common/src/launchd.rs
+++ b/crates/trusty-common/src/launchd.rs
@@ -570,10 +570,15 @@ mod tests {
             )),
             "ExitTimeOut must carry the shared termination grace, got:\n{xml}"
         );
-        assert!(
-            crate::shutdown::TERMINATION_GRACE_SECS > 5,
-            "rendering the measured system default would leave #4393 unfixed"
-        );
+        // `const` block: the operands are compile-time constants, so a later
+        // edit that shortens the window back toward launchd's default fails the
+        // build rather than a test run.
+        const {
+            assert!(
+                crate::shutdown::TERMINATION_GRACE_SECS > 5,
+                "rendering the measured system default would leave #4393 unfixed"
+            );
+        }
     }
 
     #[test]

--- a/crates/trusty-common/src/launchd.rs
+++ b/crates/trusty-common/src/launchd.rs
@@ -130,10 +130,13 @@ impl LaunchdConfig {
     /// (exe + args), `KeepAlive` (per [`KeepAlive`]), `ThrottleInterval`,
     /// `RunAtLoad`, `StandardOutPath`/`StandardErrorPath` under `log_dir`,
     /// `SoftResourceLimits` + `HardResourceLimits` dicts (when `fd_limit` is
-    /// `Some`), and an `EnvironmentVariables` dictionary when `env_vars` is
-    /// non-empty. All string values are XML-escaped.
+    /// `Some`), `ExitTimeOut` (#4393, from
+    /// [`crate::shutdown::TERMINATION_GRACE_SECS`]), and an
+    /// `EnvironmentVariables` dictionary when `env_vars` is non-empty. All
+    /// string values are XML-escaped.
     /// Test: `render_plist_contains_core_keys`, `render_plist_keepalive_*`,
-    /// `render_plist_escapes_xml`, `render_plist_includes_resource_limits`.
+    /// `render_plist_escapes_xml`, `render_plist_includes_resource_limits`,
+    /// `render_plist_declares_exit_timeout`.
     pub fn render_plist(&self) -> Result<String> {
         let exe = self
             .exe_path
@@ -186,6 +189,21 @@ impl LaunchdConfig {
         s.push_str(&format!(
             "  <integer>{}</integer>\n",
             self.throttle_interval
+        ));
+
+        // #4393: without this key launchd applies its "system-defined" default,
+        // measured at 5 s on macOS — SIGTERM, then SIGKILL 5 s later. Every
+        // termination path routes through it: `launchctl bootout`, `launchctl
+        // kickstart -k` (measured: SIGTERM first, SIGKILL at exactly the
+        // ExitTimeOut boundary), and logout/reboot. trusty-search's shutdown
+        // flush floors each index at 30 s, so it was cut off mid-write on all of
+        // them. Rendered from the shared constant rather than a per-agent field
+        // so the window a daemon PLANS for and the window launchd GRANTS cannot
+        // disagree.
+        s.push_str("  <key>ExitTimeOut</key>\n");
+        s.push_str(&format!(
+            "  <integer>{}</integer>\n",
+            crate::shutdown::TERMINATION_GRACE_SECS
         ));
 
         s.push_str("  <key>StandardOutPath</key>\n");
@@ -526,6 +544,35 @@ mod tests {
         assert!(
             !xml_no_limits.contains("HardResourceLimits"),
             "fd_limit=None must suppress HardResourceLimits"
+        );
+    }
+
+    /// Why (#4393 — the regression this test exists for): the renderer emitted
+    /// no `ExitTimeOut` key at all, so launchd applied its "system-defined"
+    /// default, measured at 5 s on this host. A daemon whose shutdown flush
+    /// floors at 30 s per index was therefore SIGKILLed mid-write on every
+    /// launchd-mediated termination — `bootout`, `kickstart -k`, logout.
+    /// What: asserts the key is present, carries
+    /// [`crate::shutdown::TERMINATION_GRACE_SECS`], and that the rendered
+    /// window clears the measured 5 s default it replaces.
+    /// Test: itself.
+    #[test]
+    fn render_plist_declares_exit_timeout() {
+        let xml = sample(KeepAlive::Always).render_plist().unwrap();
+        assert!(
+            xml.contains("<key>ExitTimeOut</key>"),
+            "plist must declare ExitTimeOut or launchd applies its 5 s default (#4393)"
+        );
+        assert!(
+            xml.contains(&format!(
+                "<key>ExitTimeOut</key>\n  <integer>{}</integer>",
+                crate::shutdown::TERMINATION_GRACE_SECS
+            )),
+            "ExitTimeOut must carry the shared termination grace, got:\n{xml}"
+        );
+        assert!(
+            crate::shutdown::TERMINATION_GRACE_SECS > 5,
+            "rendering the measured system default would leave #4393 unfixed"
         );
     }
 

--- a/crates/trusty-common/src/shutdown.rs
+++ b/crates/trusty-common/src/shutdown.rs
@@ -155,14 +155,20 @@ mod tests {
     /// Test: itself.
     #[test]
     fn termination_grace_clears_the_measured_launchd_default() {
-        assert!(
-            super::TERMINATION_GRACE_SECS > 5,
-            "the grace window must exceed launchd's measured 5 s ExitTimeOut default"
-        );
-        assert!(
-            super::TERMINATION_GRACE_SECS >= 30,
-            "the grace window must cover trusty-search's 30 s per-index flush floor"
-        );
+        // `const` blocks: both operands are compile-time constants, so the
+        // check fires at build time rather than waiting for the test binary.
+        const {
+            assert!(
+                super::TERMINATION_GRACE_SECS > 5,
+                "the grace window must exceed launchd's measured 5 s ExitTimeOut default"
+            );
+        }
+        const {
+            assert!(
+                super::TERMINATION_GRACE_SECS >= 30,
+                "the grace window must cover trusty-search's 30 s per-index flush floor"
+            );
+        }
     }
 
     /// Why (#4393): a host that cannot raise its supervisor's real window has

--- a/crates/trusty-common/src/shutdown.rs
+++ b/crates/trusty-common/src/shutdown.rs
@@ -15,6 +15,71 @@
 //! `raise(SIGTERM)`, which is unsafe; the integration tests in trusty-search
 //! exercise the full axum `with_graceful_shutdown` path.
 
+/// Seconds a trusty-* daemon is granted between SIGTERM and SIGKILL (#4393).
+///
+/// Why: this is the ONE number every terminator and every terminated daemon has
+/// to agree on, and before #4393 nobody stated it. launchd's `ExitTimeOut`
+/// default is documented only as "system-defined" and measures **5 s** on
+/// macOS; `trusty-search stop` allowed 5 s; its orphan reaper allowed 3 s.
+/// Meanwhile trusty-search's shutdown flush floors each index's budget at 30 s
+/// (`service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS`), so no flush that had
+/// real work to do could ever run to completion — it was SIGKILLed mid-write on
+/// every path. Publishing the window as a shared constant is what lets the
+/// plist renderer, the CLI stop path, the reaper, and the daemon's own flush
+/// planner be checked against each other instead of drifting silently.
+///
+/// What: 60 s. Deliberately modest — long enough to clear the 30 s per-index
+/// floor, short enough that a wedged daemon does not stall reboot or
+/// `launchctl bootout` for minutes. Not derived from the flush budget's
+/// 20-minute ceiling: a multi-minute `ExitTimeOut` in a static plist trades one
+/// operator-visible failure for a worse one.
+///
+/// Test: `termination_grace_clears_the_measured_launchd_default`,
+/// `launchd::tests::render_plist_declares_exit_timeout`, and (in trusty-search)
+/// `shutdown_budget_tests::flush_floor_fits_the_termination_window`.
+pub const TERMINATION_GRACE_SECS: u64 = 60;
+
+/// Operator override for [`TERMINATION_GRACE_SECS`].
+///
+/// Why: a host whose launchd `ExitTimeOut` cannot be raised (a stale installed
+/// plist, a container supervisor with its own `TimeoutStopSec`) needs to tell
+/// the daemon the truth about its window, or the daemon plans a 55 s flush
+/// inside a 5 s life and loses more than it would have with an accurate,
+/// smaller budget. The env var is how the terminator declares the real number.
+/// What: `TRUSTY_TERMINATION_GRACE_SECS`, a positive integer count of seconds.
+/// Test: `termination_grace_honours_a_valid_override`,
+/// `termination_grace_ignores_junk_overrides`.
+pub const TERMINATION_GRACE_ENV: &str = "TRUSTY_TERMINATION_GRACE_SECS";
+
+/// The termination window this process should plan for.
+///
+/// Why: reads the override at the one place that owns the policy so no caller
+/// re-implements the parse. See [`TERMINATION_GRACE_SECS`] for why the number
+/// exists at all.
+/// What: [`termination_grace_from`] applied to [`TERMINATION_GRACE_ENV`].
+/// Test: covered through `termination_grace_from`'s tests; this wrapper only
+/// supplies the env read.
+pub fn termination_grace() -> std::time::Duration {
+    termination_grace_from(std::env::var(TERMINATION_GRACE_ENV).ok().as_deref())
+}
+
+/// Pure half of [`termination_grace`], over an already-read env value.
+///
+/// Why: pure so the parse and its fallbacks are testable without mutating the
+/// process environment (which races every other test in the binary).
+/// What: a trimmed, positive integer wins; unset, empty, `0`, and unparseable
+/// all fall back to [`TERMINATION_GRACE_SECS`]. A junk value must never shorten
+/// the window to zero — a zero-length grace makes every flush a no-op.
+/// Test: `termination_grace_honours_a_valid_override`,
+/// `termination_grace_ignores_junk_overrides`.
+pub fn termination_grace_from(value: Option<&str>) -> std::time::Duration {
+    let secs = value
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&s| s > 0)
+        .unwrap_or(TERMINATION_GRACE_SECS);
+    std::time::Duration::from_secs(secs)
+}
+
 /// Await SIGTERM (unix) or SIGINT/Ctrl-C (all platforms), whichever fires first.
 ///
 /// Why: axum's `with_graceful_shutdown` takes an `async fn()` — it polls the
@@ -78,5 +143,54 @@ mod tests {
         // compiles and has the expected signature: `async fn() -> ()`.
         let _fut = super::shutdown_signal();
         // The future is dropped here without being polled — no signal is sent.
+    }
+
+    /// Why (#4393): the measured launchd `ExitTimeOut` default on macOS is 5 s,
+    /// and trusty-search's shutdown flush floors each index at 30 s. A grace
+    /// constant at or below either number reproduces the defect this issue
+    /// reports — the flush cannot finish before SIGKILL. Pinning the floor here
+    /// means a later "let's shorten it a bit" edit fails loudly.
+    /// What: asserts the constant clears both the measured 5 s system default
+    /// and trusty-search's 30 s per-index floor.
+    /// Test: itself.
+    #[test]
+    fn termination_grace_clears_the_measured_launchd_default() {
+        assert!(
+            super::TERMINATION_GRACE_SECS > 5,
+            "the grace window must exceed launchd's measured 5 s ExitTimeOut default"
+        );
+        assert!(
+            super::TERMINATION_GRACE_SECS >= 30,
+            "the grace window must cover trusty-search's 30 s per-index flush floor"
+        );
+    }
+
+    /// Why (#4393): a host that cannot raise its supervisor's real window has
+    /// to be able to tell the daemon the truth, or the daemon over-plans.
+    /// What: a valid positive override wins over the constant.
+    /// Test: itself.
+    #[test]
+    fn termination_grace_honours_a_valid_override() {
+        assert_eq!(
+            super::termination_grace_from(Some(" 12 ")),
+            std::time::Duration::from_secs(12)
+        );
+    }
+
+    /// Why (#4393): a zero or unparseable override must never collapse the
+    /// window to nothing — a zero grace turns every shutdown flush into a no-op,
+    /// which is the data loss this issue exists to stop, self-inflicted.
+    /// What: unset, empty, `0`, and junk all fall back to the constant.
+    /// Test: itself.
+    #[test]
+    fn termination_grace_ignores_junk_overrides() {
+        let default = std::time::Duration::from_secs(super::TERMINATION_GRACE_SECS);
+        for value in [None, Some(""), Some("0"), Some("soon"), Some("-5")] {
+            assert_eq!(
+                super::termination_grace_from(value),
+                default,
+                "junk override {value:?} must fall back to the constant"
+            );
+        }
     }
 }

--- a/crates/trusty-common/src/shutdown.rs
+++ b/crates/trusty-common/src/shutdown.rs
@@ -35,8 +35,10 @@
 /// operator-visible failure for a worse one.
 ///
 /// Test: `termination_grace_clears_the_measured_launchd_default`,
-/// `launchd::tests::render_plist_declares_exit_timeout`, and (in trusty-search)
-/// `shutdown_budget_tests::flush_floor_fits_the_termination_window`.
+/// `render_plist_declares_exit_timeout`. trusty-search additionally asserts
+/// this window covers its own per-index flush floor, in
+/// `service::shutdown_budget`, `commands::stop`, and
+/// `commands::start::reap_orphans`.
 pub const TERMINATION_GRACE_SECS: u64 = 60;
 
 /// Operator override for [`TERMINATION_GRACE_SECS`].

--- a/crates/trusty-installer/Cargo.toml
+++ b/crates/trusty-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "trusty-installer"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Thin control plane for the claude-mpm stack: install, upgrade, restart, health, and config coordination across all trusty-* tools."
 readme = "README.md"

--- a/crates/trusty-installer/changelog.d/4393-exit-timeout-doc-correction.md
+++ b/crates/trusty-installer/changelog.d/4393-exit-timeout-doc-correction.md
@@ -1,0 +1,7 @@
+Documentation
+
+- The `kickstart -k` hazard notes on `probe_http` and `verify_tail::needs_kickstart`
+  described the shared plist renderer as emitting no `ExitTimeOut` and launchd
+  as SIGKILLing 20 s after SIGTERM. The renderer now declares the key (#4393),
+  and the pre-fix default measured 5 s, not 20 s. No behaviour change — the
+  confirmed-down gate is unaffected (#4393)

--- a/crates/trusty-installer/src/commands/probe_http.rs
+++ b/crates/trusty-installer/src/commands/probe_http.rs
@@ -8,9 +8,10 @@
 //! reported six healthy daemons as `down`. That false `down` then drove
 //! `verify_tail::needs_kickstart` into `launchctl kickstart -k`, meaning **every
 //! `tctl install` hard-restarted a fully healthy stack** — the real harm behind
-//! #4246, up to and including a SIGKILL of trusty-search mid-index-flush (the
-//! shared plist renderer emits no `ExitTimeOut`, so launchd's default 20s bound
-//! fires well inside search's ≥30s-per-index flush budget).
+//! #4246, up to and including a SIGKILL of trusty-search mid-index-flush (at
+//! the time the shared plist renderer emitted no `ExitTimeOut` at all, so
+//! launchd applied its measured 5s default, well inside search's 30s-per-index
+//! flush floor — #4393 has since made the renderer declare the window).
 //!
 //! Every one of those daemons *does* answer `GET /health` over loopback today,
 //! so this module replaces the subprocess contract with the transport that
@@ -242,11 +243,12 @@ impl ProbeOutcome {
     /// that may authorise a destructive repair (#4246).
     ///
     /// Why: this is the gate that stops `tctl install` hard-restarting healthy
-    /// daemons. `launchctl kickstart -k` is not a polite restart — the shared
-    /// plist renderer emits no `ExitTimeOut`, so launchd SIGKILLs 20s after
-    /// SIGTERM, while trusty-search's graceful index flush budgets ≥30s per
-    /// index. A restart triggered by a schema mismatch or a squatter on a
-    /// default port therefore costs unflushed HNSW vectors. Only an observation
+    /// daemons. `launchctl kickstart -k` SIGTERMs and SIGKILLs at the
+    /// `ExitTimeOut` boundary; before #4393 the shared plist renderer emitted no
+    /// such key, so launchd applied its measured 5s default while
+    /// trusty-search's graceful index flush floors at 30s per index. A restart
+    /// triggered by a schema mismatch or a squatter on a default port therefore
+    /// cost unflushed HNSW vectors. Only an observation
     /// at the TRANSPORT layer — nothing accepted the connection, or nothing
     /// answered in time — is evidence a process is actually not serving. Every
     /// other failure means *something* answered, so restarting is at best a

--- a/crates/trusty-installer/src/commands/verify_tail.rs
+++ b/crates/trusty-installer/src/commands/verify_tail.rs
@@ -224,9 +224,13 @@ impl VerifyTailReport {
 /// TRANSPORT-level observation that nothing accepted the connection or nothing
 /// answered in time. A schema mismatch, an unusable body, or a squatter on a
 /// documented port all mean *something* answered, so restarting is a guess — and
-/// `kickstart -k` is not a polite restart (no `ExitTimeOut` in the shared plist
-/// renderer, so launchd SIGKILLs 20s after SIGTERM, inside trusty-search's
-/// ≥30s-per-index flush budget). That gate is only expressible now that the
+/// `kickstart -k` is not a polite restart: it SIGTERMs and SIGKILLs at the
+/// `ExitTimeOut` boundary. #4393 raised that boundary — the shared plist
+/// renderer now declares 60s where it previously emitted no key at all and
+/// launchd applied its measured 5s default — so a restart no longer lands
+/// inside trusty-search's 30s-per-index flush floor. The gate stands anyway: a
+/// restart nobody asked for still costs a warm-boot. It is only expressible now
+/// that the
 /// transport is HTTP: a subprocess probe cannot produce a `Refused`.
 ///
 /// The mirror property matters just as much: a genuinely dead daemon still

--- a/crates/trusty-search/changelog.d/4393-shutdown-window-and-orphan-reaper.md
+++ b/crates/trusty-search/changelog.d/4393-shutdown-window-and-orphan-reaper.md
@@ -1,0 +1,33 @@
+Fixed
+
+- The shutdown flush can now actually finish. Its per-index budget floors at
+  30 s and ceilings at 20 min, while every window that terminates the daemon
+  granted 3–5 s: launchd's `ExitTimeOut` default (measured 5 s on macOS, not
+  the documented "system-defined" anything), `trusty-search stop`, and the
+  orphan reaper. A flush with real work to do was SIGKILLed mid-sweep on every
+  path, losing HNSW vectors committed since the last checkpoint. Two changes:
+  every generated LaunchAgent plist now declares `ExitTimeOut`, and `stop` and
+  the reaper wait the same window. **An already-installed LaunchAgent keeps
+  launchd's 5 s default until its plist is regenerated** — re-run the
+  installer's service setup to pick it up (#4393)
+- A per-index flush deadline can no longer outlive the process that granted it.
+  Deadlines are now minted by a `ShutdownBudget` counting down from the instant
+  SIGTERM landed, so a sweep that runs out of window stops cleanly at an index
+  boundary — logging how many indexes kept their last incremental checkpoint —
+  instead of being cut off partway through a write (#4393)
+- `trusty-search start` no longer SIGKILLs healthy daemons that merely share
+  its executable name. Its orphan reaper matched on process name plus `start`
+  in argv, so any lock-visibility asymmetry — a second instance under
+  `--data-dir`/`TRUSTY_DATA_DIR`, a daemon restarted without the override it
+  started with, a deleted lockfile — turned a routine `start` into the
+  destruction of a live production daemon, with 3 s to shut down. The reaper
+  now reaps only processes it has positively identified as sharing its own data
+  directory, read from the candidate's own `--data-dir` argument or
+  `TRUSTY_DATA_DIR`; a process whose argv or environment cannot be read is
+  spared and reported, never killed. `trusty-search stop` keeps its explicit
+  stop-everything contract (#4395)
+- Two daemons indexing the same repository can no longer splice each other's
+  HNSW snapshot. Both staged through the same `hnsw.usearch.tmp` before
+  renaming, and colocated indexes keep that file in the project root — outside
+  every data directory, so even fully data-dir-isolated daemons collided there.
+  The staging name is now scoped to the writing process (#4395)

--- a/crates/trusty-search/src/commands/start/daemon.rs
+++ b/crates/trusty-search/src/commands/start/daemon.rs
@@ -258,57 +258,15 @@ pub async fn handle_start(
     // Issue #81: detect orphan daemons whose PIDs are NOT recorded in the
     // lockfile. Reap them now so we don't end up with two daemons fighting
     // over `bind_with_auto_port`.
-    let orphans = crate::commands::stop::find_daemon_pids();
-    if !orphans.is_empty() {
-        tracing::warn!(
-            "found {} existing trusty-search daemon process(es) not tracked by lockfile: {:?} — terminating before start",
-            orphans.len(),
-            orphans
-        );
-        eprintln!(
-            "{} found {} existing trusty-search daemon process(es) not tracked by lockfile — stopping them first",
-            "⚠".yellow(),
-            orphans.len()
-        );
-        #[cfg(unix)]
-        for pid in &orphans {
-            let _ = nix::sys::signal::kill(
-                nix::unistd::Pid::from_raw(*pid as i32),
-                nix::sys::signal::Signal::SIGTERM,
-            );
-        }
-        // Give them 3 s to exit cleanly, then SIGKILL stragglers.
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
-        loop {
-            std::thread::sleep(std::time::Duration::from_millis(100));
-            #[cfg(unix)]
-            let any_alive = orphans.iter().any(|p| {
-                nix::sys::signal::kill(nix::unistd::Pid::from_raw(*p as i32), None).is_ok()
-            });
-            #[cfg(not(unix))]
-            let any_alive = false;
-            if !any_alive || std::time::Instant::now() >= deadline {
-                break;
-            }
-        }
-        #[cfg(unix)]
-        for pid in &orphans {
-            if nix::sys::signal::kill(nix::unistd::Pid::from_raw(*pid as i32), None).is_ok() {
-                tracing::warn!("orphan pid {pid} ignored SIGTERM — sending SIGKILL");
-                let _ = nix::sys::signal::kill(
-                    nix::unistd::Pid::from_raw(*pid as i32),
-                    nix::sys::signal::Signal::SIGKILL,
-                );
-            }
-        }
-        // Clear stale lock/port files left behind by the killed orphans.
-        if let Ok(lock) = crate::service::daemon_lock_path() {
-            let _ = std::fs::remove_file(&lock);
-        }
-        if let Some(port) = super::super::daemon_utils::daemon_port_path() {
-            let _ = std::fs::remove_file(&port);
-        }
-    }
+    //
+    // #4395: this used to SIGTERM every process on the machine named
+    // `trusty-search` with `start` in argv and SIGKILL the survivors 3 s later,
+    // so a `start` in an isolated data dir destroyed the healthy production
+    // daemon. It now reaps only processes positively identified as sharing our
+    // own data directory, and allows them the same termination window every
+    // other path grants (#4393). See `reap_orphans`'s module doc for why the
+    // data directory is the identity signal and process name never was.
+    super::reap_orphans::reap_orphans_before_start();
 
     // Construct `SearchAppState` immediately; kick off model loading on
     // a background task, and let `run_daemon` bind the HTTP port right away.

--- a/crates/trusty-search/src/commands/start/mod.rs
+++ b/crates/trusty-search/src/commands/start/mod.rs
@@ -24,6 +24,9 @@ mod daemon;
 mod embedder;
 mod embedder_fallback;
 mod graceful_bootstrap;
+// #4395: ownership-aware orphan reaping — the reaper `daemon` calls before it
+// starts, which used to match by process name alone.
+mod reap_orphans;
 mod restore;
 mod swap_back_watchdog;
 

--- a/crates/trusty-search/src/commands/start/reap_orphans.rs
+++ b/crates/trusty-search/src/commands/start/reap_orphans.rs
@@ -129,7 +129,12 @@ pub struct ReapPlan {
 /// What: `Ok(Some(dir))` for an explicit declaration, `Ok(None)` for "positively
 /// declares nothing, so it uses the platform default", `Err(why)` when neither
 /// argv nor environ could be read.
-/// Test: `declared_data_dir_*`.
+/// Test: reached through [`identify`] —
+/// `identify_spares_a_daemon_whose_environment_is_unreadable`,
+/// `identify_spares_a_daemon_whose_argv_is_unreadable`,
+/// `identify_prefers_the_flag_over_the_environment`,
+/// `identify_reads_the_equals_form_of_the_flag`,
+/// `identify_falls_back_to_the_platform_default`.
 fn declared_data_dir(argv: &[String], environ: &[String]) -> Result<Option<PathBuf>, String> {
     if argv.is_empty() {
         return Err("process argv is unreadable".to_string());

--- a/crates/trusty-search/src/commands/start/reap_orphans.rs
+++ b/crates/trusty-search/src/commands/start/reap_orphans.rs
@@ -1,0 +1,431 @@
+//! Ownership-aware orphan reaping for `trusty-search start` (#4395).
+//!
+//! Why: the reaper this replaces SIGTERMed **every process on the machine named
+//! `trusty-search` with `start` in its argv**, SIGKILLed the survivors 3 seconds
+//! later, and deleted their lock and port files. Process name is not an identity
+//! — it says nothing about whose data a daemon is serving. Any asymmetry between
+//! the starter's lock path and a running daemon's (a second instance under
+//! `--data-dir` / `TRUSTY_DATA_DIR`, a daemon started with the override and
+//! restarted without it, a deleted lockfile) turned a routine `start` into the
+//! destruction of a healthy production daemon — with one tenth of that daemon's
+//! own flush budget to shut down. The lockfile fast-path that would have caught
+//! it (`service::running_daemon_pid`) is data-dir-local while the reaper was
+//! machine-global, so the guard and the hazard never met.
+//!
+//! Which identity signal, and why this one. A pid file only names the daemon we
+//! already track, which is by definition not the orphan we are hunting. A
+//! launchd label does not exist for the CLI-detached daemons this reaper
+//! actually finds (`PPID 1`, no plist). A port-ownership probe (the #4470 shape,
+//! `trusty-installer::commands::port_guard`) answers "is someone on my port?",
+//! which is the right question for a bootstrap and the wrong one here — the
+//! daemon walks its port on collision, so a foreign holder is a condition it
+//! survives, and a *different* port proves nothing about whose data dir a
+//! process has open. A `/health` handshake would identify a daemon that is
+//! *answering*, which excludes exactly the wedged instance the reaper exists to
+//! clear.
+//!
+//! The signal that matches the actual hazard is the **data directory**: a
+//! trusty-search daemon fights us for precisely one thing, the lock and index
+//! data under its data dir, and it declares that directory in its own argv
+//! (`--data-dir`, always passed explicitly by the self-spawn — issue #1182) or
+//! its own environment (`TRUSTY_DATA_DIR`), falling back to the platform default
+//! when it declares neither. Two daemons on disjoint data dirs are not in
+//! conflict and never were.
+//!
+//! FAIL CLOSED, structurally. [`ConfirmedOrphan`] wraps a pid behind a private
+//! field with no constructor from a bare `u32`, and [`reap`] accepts nothing
+//! else. There is no way to write "signal this pid" for a pid that did not come
+//! out of [`plan`] having been positively matched to our own data dir — a
+//! process whose argv or environment could not be read is
+//! [`DaemonIdentity::Unidentified`] and is spared, not reaped. "I could not tell"
+//! is never "kill it".
+//!
+//! Scope: this is the IMPLICIT reaper that runs inside `start`. `trusty-search
+//! stop` deliberately still terminates every daemon it can find (issue #81) —
+//! that is an explicit operator command whose documented contract is "stop
+//! everything", and narrowing it is a separate decision.
+//!
+//! Test: `reap_orphans_tests.rs`.
+
+use std::path::{Path, PathBuf};
+
+/// What we could establish about one candidate `trusty-search` process (#4395).
+///
+/// Why: three genuinely different answers, and the third is the one a `bool`
+/// silently folds into "kill it" — which is how a name match became a death
+/// sentence. Making "could not tell" its own variant is what forces the caller
+/// to spare it.
+/// What: `OwnInstance` — the candidate resolves to the same data directory we
+/// do, so it is contending for our lock and our index files. `ForeignInstance`
+/// — it resolves to a different one, carrying that directory for the log.
+/// `Unidentified` — its argv or environment could not be read, carrying why.
+/// Test: the `identify_*` tests.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum DaemonIdentity {
+    /// Shares our data directory: our orphan, safe to reap.
+    OwnInstance,
+    /// Serves a different data directory: never ours to kill.
+    ForeignInstance(PathBuf),
+    /// Could not be established; the payload says why.
+    Unidentified(String),
+}
+
+/// A pid the reaper has POSITIVELY identified as its own orphan (#4395).
+///
+/// Why: the invariant "we only ever signal a process we identified" is enforced
+/// by the type system rather than by remembering to check. The field is private
+/// and this module exposes no way to build one from a `u32`, so [`reap`] cannot
+/// be handed an unvetted pid even by a future call site that has forgotten the
+/// rule. The pre-#4395 reaper's whole defect was a `Vec<u32>` that carried no
+/// evidence at all.
+/// What: a newtype over the pid, minted only inside [`plan`].
+/// Test: `plan_confirms_only_our_own_data_dir`; the unforgeability itself is a
+/// compile-time property, not a runtime assertion.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConfirmedOrphan(u32);
+
+impl ConfirmedOrphan {
+    /// The identified pid.
+    pub fn pid(&self) -> u32 {
+        self.0
+    }
+}
+
+/// One live `trusty-search` process as observed from the process table.
+///
+/// Why: separating the observation from the decision is what makes the decision
+/// testable without spawning daemons — the same seam
+/// `trusty-installer::commands::port_guard` uses for its `lsof` probe.
+/// What: the pid plus the two things identity is read from. Both are `Vec<String>`
+/// in the process table's own form: argv words, and `KEY=VALUE` environment
+/// entries.
+#[derive(Clone, Debug)]
+pub struct Candidate {
+    pub pid: u32,
+    pub argv: Vec<String>,
+    pub environ: Vec<String>,
+}
+
+/// The reaper's decision over a whole candidate set (#4395).
+///
+/// Why: the spared processes are as load-bearing as the doomed ones — an
+/// operator who runs `start` against a machine with a production daemon needs to
+/// see that it was recognised and left alone, not silent success. Carrying both
+/// lists is what lets the caller say so.
+/// What: `orphans` are the only pids [`reap`] will signal; `spared` pairs each
+/// untouched pid with the reason.
+pub struct ReapPlan {
+    pub orphans: Vec<ConfirmedOrphan>,
+    pub spared: Vec<(u32, String)>,
+}
+
+/// Which data directory a candidate declares, or why we cannot tell (#4395).
+///
+/// Why: the fallback to "platform default" is only sound when we have positively
+/// read an environment that does NOT set `TRUSTY_DATA_DIR`. An UNREADABLE
+/// environment looks identical to an empty one, and treating the two the same
+/// would classify every process we cannot inspect as sharing our default data
+/// dir — a name match by another route, and the same fatal outcome.
+/// What: `Ok(Some(dir))` for an explicit declaration, `Ok(None)` for "positively
+/// declares nothing, so it uses the platform default", `Err(why)` when neither
+/// argv nor environ could be read.
+/// Test: `declared_data_dir_*`.
+fn declared_data_dir(argv: &[String], environ: &[String]) -> Result<Option<PathBuf>, String> {
+    if argv.is_empty() {
+        return Err("process argv is unreadable".to_string());
+    }
+    // `--data-dir` wins over the environment, matching issue #1182: the
+    // self-spawn passes the flag explicitly precisely so it beats a stale
+    // inherited `TRUSTY_DATA_DIR`.
+    let mut words = argv.iter();
+    while let Some(word) = words.next() {
+        if let Some(value) = word.strip_prefix("--data-dir=") {
+            return Ok(Some(PathBuf::from(value)));
+        }
+        if word == "--data-dir" {
+            return match words.next() {
+                Some(value) => Ok(Some(PathBuf::from(value))),
+                None => Err("`--data-dir` present in argv with no value".to_string()),
+            };
+        }
+    }
+    for entry in environ {
+        if let Some(value) = entry.strip_prefix("TRUSTY_DATA_DIR=") {
+            return Ok(Some(PathBuf::from(value)));
+        }
+    }
+    if environ.is_empty() {
+        // Cannot distinguish "does not set the var" from "we may not read this
+        // process's environment". Both look like an empty slice, so neither may
+        // be treated as the default data dir.
+        return Err("process environment is unreadable".to_string());
+    }
+    Ok(None)
+}
+
+/// Normalise a data-dir path for comparison.
+///
+/// Why: `/tmp/ts` and `/tmp/ts/` and a symlinked `/var/…` vs `/private/var/…`
+/// (macOS) are the same directory, and a spurious mismatch here is the SAFE
+/// direction (spare a process that was ours) while a spurious match is the fatal
+/// one (kill a stranger). Canonicalising when the path exists gets both right.
+/// What: `canonicalize` when it succeeds, otherwise the lexically re-joined
+/// components, which drops trailing separators and `.` segments.
+/// Test: exercised through `identify_treats_a_trailing_slash_as_the_same_dir`.
+fn normalise(dir: &Path) -> PathBuf {
+    std::fs::canonicalize(dir).unwrap_or_else(|_| dir.components().collect())
+}
+
+/// Decide whether one candidate is our orphan (#4395).
+///
+/// Why: the whole policy, pure, so the truth table is testable without a live
+/// process table or a real daemon. `platform_default` is a parameter rather than
+/// a call to `dirs::data_local_dir()` for the same reason.
+/// What: resolves the candidate's data dir per [`declared_data_dir`] (falling
+/// back to `platform_default` when it positively declares none), and compares it
+/// with `our_data_dir` under [`normalise`]. An unreadable observation is
+/// [`DaemonIdentity::Unidentified`] and never a match.
+/// Test: `identify_claims_a_daemon_sharing_our_data_dir`,
+/// `identify_spares_a_daemon_with_a_different_data_dir`,
+/// `identify_spares_a_daemon_whose_environment_is_unreadable`,
+/// `identify_prefers_the_flag_over_the_environment`,
+/// `identify_reads_the_equals_form_of_the_flag`,
+/// `identify_falls_back_to_the_platform_default`,
+/// `identify_treats_a_trailing_slash_as_the_same_dir`.
+pub fn identify(
+    argv: &[String],
+    environ: &[String],
+    our_data_dir: &Path,
+    platform_default: &Path,
+) -> DaemonIdentity {
+    let theirs = match declared_data_dir(argv, environ) {
+        Ok(Some(dir)) => dir,
+        Ok(None) => platform_default.to_path_buf(),
+        Err(why) => return DaemonIdentity::Unidentified(why),
+    };
+    if normalise(&theirs) == normalise(our_data_dir) {
+        DaemonIdentity::OwnInstance
+    } else {
+        DaemonIdentity::ForeignInstance(theirs)
+    }
+}
+
+/// Turn observed candidates into a reap plan (#4395).
+///
+/// Why: the only place a [`ConfirmedOrphan`] comes into existence, so every pid
+/// the reaper can signal has passed [`identify`] on its way here. A candidate
+/// list is data; a `ConfirmedOrphan` list is a conclusion.
+/// What: applies [`identify`] to each candidate; `OwnInstance` becomes a
+/// confirmed orphan, everything else is spared with its reason recorded.
+/// Test: `plan_confirms_only_our_own_data_dir`,
+/// `plan_spares_an_unidentifiable_candidate`.
+pub fn plan(candidates: &[Candidate], our_data_dir: &Path, platform_default: &Path) -> ReapPlan {
+    let mut orphans = Vec::new();
+    let mut spared = Vec::new();
+    for candidate in candidates {
+        match identify(
+            &candidate.argv,
+            &candidate.environ,
+            our_data_dir,
+            platform_default,
+        ) {
+            DaemonIdentity::OwnInstance => orphans.push(ConfirmedOrphan(candidate.pid)),
+            DaemonIdentity::ForeignInstance(dir) => spared.push((
+                candidate.pid,
+                format!("serves a different data dir ({})", dir.display()),
+            )),
+            DaemonIdentity::Unidentified(why) => spared.push((
+                candidate.pid,
+                format!("could not be identified as ours ({why})"),
+            )),
+        }
+    }
+    ReapPlan { orphans, spared }
+}
+
+/// Snapshot every live `trusty-search` daemon process with its argv and environ.
+///
+/// Why: `commands::stop::find_daemon_pids` finds the candidates but returns bare
+/// pids, which is exactly the evidence-free list #4395 is about. This gathers the
+/// two fields identity is read from at the same time, from the same snapshot, so
+/// a process cannot change identity between being listed and being judged.
+/// What: one `sysinfo` refresh with `cmd` and `environ` requested, filtered the
+/// same way `find_daemon_pids` filters — executable basename `trusty-search`,
+/// `start` in argv, never our own pid.
+/// Test: side-effecting (reads the live process table); the decision it feeds is
+/// covered by the `plan_*` and `identify_*` tests.
+fn observe_candidates() -> Vec<Candidate> {
+    use sysinfo::{ProcessRefreshKind, RefreshKind, System, UpdateKind};
+    let mut sys = System::new_with_specifics(
+        RefreshKind::nothing().with_processes(
+            ProcessRefreshKind::nothing()
+                .with_cmd(UpdateKind::Always)
+                .with_environ(UpdateKind::Always),
+        ),
+    );
+    sys.refresh_processes(sysinfo::ProcessesToUpdate::All, true);
+    let me = std::process::id();
+    let mut out = Vec::new();
+    for (pid, proc_) in sys.processes() {
+        let raw = pid.as_u32();
+        if raw == me || proc_.name().to_string_lossy() != "trusty-search" {
+            continue;
+        }
+        let argv: Vec<String> = proc_
+            .cmd()
+            .iter()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        if !argv.iter().any(|a| a == "start") {
+            continue;
+        }
+        let environ: Vec<String> = proc_
+            .environ()
+            .iter()
+            .map(|e| e.to_string_lossy().into_owned())
+            .collect();
+        out.push(Candidate {
+            pid: raw,
+            argv,
+            environ,
+        });
+    }
+    out
+}
+
+/// SIGTERM the confirmed orphans, then SIGKILL whichever survive the window.
+///
+/// Why: the `&[ConfirmedOrphan]` parameter is the fix. There is no overload
+/// taking pids, so a future edit cannot reintroduce "signal everything that
+/// looked like us" without first inventing a way to mint the token.
+///
+/// The window is [`trusty_common::shutdown::termination_grace`], the same one
+/// launchd's `ExitTimeOut` and `trusty-search stop` now use (#4393). The old 3 s
+/// was a tenth of the flushing daemon's own 30 s per-index floor, so even a
+/// correctly-targeted orphan was SIGKILLed mid-write.
+///
+/// What: SIGTERM all, poll every 100 ms until all are gone or the window
+/// closes, then SIGKILL the remainder. Returns the pids that had to be killed.
+/// Test: side-effecting; the window it uses is pinned by
+/// `reap_window_covers_the_flush_floor`.
+#[cfg(unix)]
+fn reap(orphans: &[ConfirmedOrphan]) -> Vec<u32> {
+    use nix::sys::signal::{kill, Signal};
+    use nix::unistd::Pid;
+
+    let alive = |pid: u32| kill(Pid::from_raw(pid as i32), None).is_ok();
+
+    for orphan in orphans {
+        let _ = kill(Pid::from_raw(orphan.pid() as i32), Signal::SIGTERM);
+    }
+    let deadline = std::time::Instant::now() + trusty_common::shutdown::termination_grace();
+    loop {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        if !orphans.iter().any(|o| alive(o.pid())) || std::time::Instant::now() >= deadline {
+            break;
+        }
+    }
+    let mut killed = Vec::new();
+    for orphan in orphans {
+        if alive(orphan.pid()) {
+            tracing::warn!(
+                "orphan pid {} ignored SIGTERM for {}s — sending SIGKILL",
+                orphan.pid(),
+                trusty_common::shutdown::termination_grace().as_secs(),
+            );
+            let _ = kill(Pid::from_raw(orphan.pid() as i32), Signal::SIGKILL);
+            killed.push(orphan.pid());
+        }
+    }
+    killed
+}
+
+#[cfg(not(unix))]
+fn reap(_orphans: &[ConfirmedOrphan]) -> Vec<u32> {
+    Vec::new()
+}
+
+/// Reap this instance's orphaned daemons before starting (#81, rescoped by #4395).
+///
+/// Why: `start` still has to clear daemons that hold our data dir but are not in
+/// our lockfile, or two of them end up fighting over `bind_with_auto_port` and
+/// the older one keeps consuming memory forever. What it must NOT do is decide
+/// that by name — see the module doc.
+///
+/// What: observes the live candidates, plans against our own resolved data dir,
+/// reports every spared process and why, reaps the confirmed orphans, and clears
+/// the lock and port files only when something was actually reaped. Called from
+/// `handle_start` after the lockfile fast-path has already ruled out a tracked
+/// live daemon.
+///
+/// Test: side-effecting; the policy is `plan_*` / `identify_*`.
+pub fn reap_orphans_before_start() {
+    let Some(our_data_dir) =
+        crate::service::daemon::resolve_daemon_dir(std::env::var_os("TRUSTY_DATA_DIR").as_deref())
+    else {
+        tracing::warn!(
+            "orphan reaper: own data dir is unresolvable — skipping the sweep entirely \
+             (#4395: an unidentifiable owner cannot identify anyone else's)"
+        );
+        return;
+    };
+    let Some(platform_default) = crate::service::daemon::resolve_daemon_dir(None) else {
+        tracing::warn!(
+            "orphan reaper: platform default data dir is unresolvable — skipping the \
+             sweep entirely (#4395)"
+        );
+        return;
+    };
+
+    let candidates = observe_candidates();
+    if candidates.is_empty() {
+        return;
+    }
+    let plan = plan(&candidates, &our_data_dir, &platform_default);
+
+    for (pid, reason) in &plan.spared {
+        tracing::info!("orphan reaper: leaving pid {pid} alone — {reason} (#4395)");
+    }
+    if !plan.spared.is_empty() {
+        eprintln!(
+            "{} {} other trusty-search daemon(s) are running but serve different data — \
+             leaving them alone",
+            "·".dimmed(),
+            plan.spared.len(),
+        );
+    }
+    if plan.orphans.is_empty() {
+        return;
+    }
+
+    let pids: Vec<u32> = plan.orphans.iter().map(ConfirmedOrphan::pid).collect();
+    tracing::warn!(
+        "found {} trusty-search daemon(s) on our own data dir ({}) not tracked by the \
+         lockfile: {pids:?} — terminating before start",
+        pids.len(),
+        our_data_dir.display(),
+    );
+    eprintln!(
+        "{} found {} orphaned trusty-search daemon(s) on this data dir — stopping them first",
+        "⚠".yellow(),
+        pids.len(),
+    );
+
+    reap(&plan.orphans);
+
+    // Clear the lock/port files the reaped orphans left behind. Only reachable
+    // when we actually reaped something on OUR data dir, so this can no longer
+    // delete a foreign daemon's files.
+    if let Ok(lock) = crate::service::daemon_lock_path() {
+        let _ = std::fs::remove_file(&lock);
+    }
+    if let Some(port) = crate::commands::daemon_utils::daemon_port_path() {
+        let _ = std::fs::remove_file(&port);
+    }
+}
+
+use colored::Colorize;
+
+#[cfg(test)]
+#[path = "reap_orphans_tests.rs"]
+mod tests;

--- a/crates/trusty-search/src/commands/start/reap_orphans_tests.rs
+++ b/crates/trusty-search/src/commands/start/reap_orphans_tests.rs
@@ -1,0 +1,288 @@
+//! Regression tests for the #4395 ownership-aware orphan reaper.
+//!
+//! Why: the defect was that a healthy production daemon could be SIGKILLed
+//! because it shared an executable name. Every test here hands the policy a
+//! candidate that a name match would have condemned and asserts it survives.
+//! Reverting [`super::plan`] to "confirm every candidate" — the pre-#4395
+//! behaviour, where `find_daemon_pids()`'s bare pid list WAS the kill list —
+//! fails `plan_confirms_only_our_own_data_dir` and
+//! `plan_spares_an_unidentifiable_candidate`.
+//!
+//! Test: this IS the test module.
+
+use super::*;
+
+fn words(items: &[&str]) -> Vec<String> {
+    items.iter().map(|s| (*s).to_string()).collect()
+}
+
+/// The argv of a daemon started with no explicit `--data-dir`.
+fn plain_argv() -> Vec<String> {
+    words(&["trusty-search", "start", "--foreground", "--port", "7878"])
+}
+
+/// A minimal but non-empty environment, so "declares no data dir" is
+/// distinguishable from "environment unreadable".
+fn plain_environ() -> Vec<String> {
+    words(&["PATH=/usr/bin", "HOME=/Users/test"])
+}
+
+/// Why (#4395): the reaper still has to work — a daemon holding our own data dir
+/// but absent from our lockfile is the orphan issue #81 added it for. Sparing
+/// everything would be as wrong as killing everything.
+/// What: a candidate declaring our exact data dir via `--data-dir` is claimed.
+/// Test: this IS the test.
+#[test]
+fn identify_claims_a_daemon_sharing_our_data_dir() {
+    let argv = words(&["trusty-search", "start", "--data-dir", "/tmp/ts-shared"]);
+    assert_eq!(
+        identify(
+            &argv,
+            &plain_environ(),
+            Path::new("/tmp/ts-shared"),
+            Path::new("/platform/default")
+        ),
+        DaemonIdentity::OwnInstance
+    );
+}
+
+/// Why (#4395 — THE defect): this is the healthy production daemon. It has the
+/// same executable name, the same `start` in argv, and is serving real indexes
+/// out of a different data directory. The pre-fix reaper SIGTERMed it and
+/// SIGKILLed it 3 seconds later.
+/// What: a candidate under a different `--data-dir` is `ForeignInstance`, and the
+/// variant carries that directory so the log can name it.
+/// Test: this IS the test.
+#[test]
+fn identify_spares_a_daemon_with_a_different_data_dir() {
+    let argv = words(&["trusty-search", "start", "--data-dir", "/tmp/ts-theirs"]);
+    assert_eq!(
+        identify(
+            &argv,
+            &plain_environ(),
+            Path::new("/tmp/ts-ours"),
+            Path::new("/platform/default")
+        ),
+        DaemonIdentity::ForeignInstance(PathBuf::from("/tmp/ts-theirs"))
+    );
+}
+
+/// Why (#4395, fail-closed): an unreadable environment is indistinguishable from
+/// an empty one. Folding the two together would make every process we cannot
+/// inspect resolve to the platform default — a name match by another route, with
+/// the same fatal consequence.
+/// What: a candidate with no `--data-dir` and an EMPTY environ slice is
+/// `Unidentified`, never `OwnInstance`, even when our data dir IS the platform
+/// default (the case where the fold would have been invisible).
+/// Test: this IS the test.
+#[test]
+fn identify_spares_a_daemon_whose_environment_is_unreadable() {
+    let identity = identify(
+        &plain_argv(),
+        &[],
+        Path::new("/platform/default"),
+        Path::new("/platform/default"),
+    );
+    assert!(
+        matches!(identity, DaemonIdentity::Unidentified(_)),
+        "an unreadable environment must never resolve to our data dir; got {identity:?}"
+    );
+}
+
+/// Why (#4395, fail-closed): same argument one level up — argv we cannot read
+/// tells us nothing at all.
+/// What: an empty argv is `Unidentified`.
+/// Test: this IS the test.
+#[test]
+fn identify_spares_a_daemon_whose_argv_is_unreadable() {
+    let identity = identify(
+        &[],
+        &plain_environ(),
+        Path::new("/platform/default"),
+        Path::new("/platform/default"),
+    );
+    assert!(
+        matches!(identity, DaemonIdentity::Unidentified(_)),
+        "an unreadable argv must not be resolved to any data dir; got {identity:?}"
+    );
+}
+
+/// Why (#4395, mirroring issue #1182): the self-spawn passes `--data-dir`
+/// explicitly precisely so the flag beats a stale inherited `TRUSTY_DATA_DIR`.
+/// Reading the environment first would identify such a daemon by the directory
+/// it is NOT using.
+/// What: with the flag and the env var disagreeing, the flag decides.
+/// Test: this IS the test.
+#[test]
+fn identify_prefers_the_flag_over_the_environment() {
+    let argv = words(&["trusty-search", "start", "--data-dir", "/tmp/ts-flag"]);
+    let environ = words(&["TRUSTY_DATA_DIR=/tmp/ts-env", "PATH=/usr/bin"]);
+    assert_eq!(
+        identify(
+            &argv,
+            &environ,
+            Path::new("/tmp/ts-flag"),
+            Path::new("/platform/default")
+        ),
+        DaemonIdentity::OwnInstance,
+        "the explicit --data-dir flag must decide (#1182)"
+    );
+}
+
+/// Why: `--data-dir=/path` is as valid as `--data-dir /path` on the command
+/// line, and missing the joined form would leave that daemon `Unidentified` at
+/// best and misattributed at worst.
+/// What: the `=` form resolves identically.
+/// Test: this IS the test.
+#[test]
+fn identify_reads_the_equals_form_of_the_flag() {
+    let argv = words(&["trusty-search", "start", "--data-dir=/tmp/ts-eq"]);
+    assert_eq!(
+        identify(
+            &argv,
+            &plain_environ(),
+            Path::new("/tmp/ts-eq"),
+            Path::new("/platform/default")
+        ),
+        DaemonIdentity::OwnInstance
+    );
+}
+
+/// Why (#4395): the common path — neither side sets an override, both use the
+/// platform default, so they genuinely do contend and the reap is correct.
+/// Sparing here would leave issue #81's orphan accumulation unfixed.
+/// What: with a readable environment declaring nothing, the candidate resolves
+/// to the platform default and matches an owner on the same default.
+/// Test: this IS the test.
+#[test]
+fn identify_falls_back_to_the_platform_default() {
+    assert_eq!(
+        identify(
+            &plain_argv(),
+            &plain_environ(),
+            Path::new("/platform/default"),
+            Path::new("/platform/default")
+        ),
+        DaemonIdentity::OwnInstance
+    );
+    assert_eq!(
+        identify(
+            &plain_argv(),
+            &plain_environ(),
+            Path::new("/tmp/ts-isolated"),
+            Path::new("/platform/default")
+        ),
+        DaemonIdentity::ForeignInstance(PathBuf::from("/platform/default")),
+        "an isolated owner must not claim the default-dir daemon"
+    );
+}
+
+/// Why: a trailing separator is the same directory, and a spurious mismatch
+/// there would leak orphans (the #81 regression) even though it errs safe.
+/// What: `/tmp/ts-x/` and `/tmp/ts-x` compare equal.
+/// Test: this IS the test.
+#[test]
+fn identify_treats_a_trailing_slash_as_the_same_dir() {
+    let argv = words(&["trusty-search", "start", "--data-dir", "/tmp/ts-x/"]);
+    assert_eq!(
+        identify(
+            &argv,
+            &plain_environ(),
+            Path::new("/tmp/ts-x"),
+            Path::new("/platform/default")
+        ),
+        DaemonIdentity::OwnInstance
+    );
+}
+
+/// Why (#4395 — the regression this whole module exists for): the pre-fix reaper
+/// took `find_daemon_pids()`'s bare pid list and signalled all of it. This test
+/// hands `plan` a mixed set — one of ours, one production daemon on another data
+/// dir, one uninspectable — and asserts only ours is confirmed. Reverting `plan`
+/// to confirm every candidate fails it.
+/// What: asserts the confirmed set is exactly `[10]` and both others are spared
+/// with a stated reason.
+/// Test: this IS the test.
+#[test]
+fn plan_confirms_only_our_own_data_dir() {
+    let candidates = vec![
+        Candidate {
+            pid: 10,
+            argv: words(&["trusty-search", "start", "--data-dir", "/tmp/ts-ours"]),
+            environ: plain_environ(),
+        },
+        Candidate {
+            pid: 20,
+            argv: words(&["trusty-search", "start", "--data-dir", "/tmp/ts-production"]),
+            environ: plain_environ(),
+        },
+        Candidate {
+            pid: 30,
+            argv: plain_argv(),
+            environ: vec![],
+        },
+    ];
+    let plan = plan(
+        &candidates,
+        Path::new("/tmp/ts-ours"),
+        Path::new("/platform/default"),
+    );
+
+    let confirmed: Vec<u32> = plan.orphans.iter().map(ConfirmedOrphan::pid).collect();
+    assert_eq!(
+        confirmed,
+        vec![10],
+        "only the daemon on our own data dir may be reaped — pid 20 is a healthy \
+         production daemon and pid 30 could not be identified (#4395)"
+    );
+    let spared: Vec<u32> = plan.spared.iter().map(|(pid, _)| *pid).collect();
+    assert_eq!(spared, vec![20, 30], "both non-matches must be reported");
+    assert!(
+        plan.spared.iter().all(|(_, why)| !why.is_empty()),
+        "every spared process must carry a stated reason for the operator"
+    );
+}
+
+/// Why (#4395, fail-closed): "we could not tell" must never advance to a kill.
+/// This is the branch a `bool`-shaped check silently folds into "proceed" — the
+/// same fail-open shape #4470's port guard was written to avoid.
+/// What: a single uninspectable candidate produces an empty orphan list.
+/// Test: this IS the test.
+#[test]
+fn plan_spares_an_unidentifiable_candidate() {
+    let candidates = vec![Candidate {
+        pid: 99,
+        argv: plain_argv(),
+        environ: vec![],
+    }];
+    let plan = plan(
+        &candidates,
+        Path::new("/platform/default"),
+        Path::new("/platform/default"),
+    );
+    assert!(
+        plan.orphans.is_empty(),
+        "an unidentifiable process must never be confirmed as an orphan"
+    );
+    assert_eq!(plan.spared.len(), 1);
+}
+
+/// Why (#4395 fix 3, the #4393 half of this issue): the reaper allowed 3 s —
+/// roughly a tenth of the 30 s floor the daemon's own shutdown flush applies per
+/// index — so even a correctly-targeted orphan was SIGKILLed mid-write. The
+/// window `reap` uses must cover that floor.
+/// What: asserts the shared termination grace covers
+/// `shutdown_flush::MIN_FLUSH_TIMEOUT_SECS`.
+/// Test: this IS the test.
+#[test]
+fn reap_window_covers_the_flush_floor() {
+    let window = trusty_common::shutdown::termination_grace();
+    let floor = std::time::Duration::from_secs(
+        crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS,
+    );
+    assert!(
+        window >= floor,
+        "the reaper's SIGKILL window ({window:?}) must cover a reaped daemon's own \
+         per-index flush floor ({floor:?}) — 3 s against 30 s is the #4395 defect"
+    );
+}

--- a/crates/trusty-search/src/commands/start/reap_orphans_tests.rs
+++ b/crates/trusty-search/src/commands/start/reap_orphans_tests.rs
@@ -277,9 +277,8 @@ fn plan_spares_an_unidentifiable_candidate() {
 #[test]
 fn reap_window_covers_the_flush_floor() {
     let window = trusty_common::shutdown::termination_grace();
-    let floor = std::time::Duration::from_secs(
-        crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS,
-    );
+    let floor =
+        std::time::Duration::from_secs(crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS);
     assert!(
         window >= floor,
         "the reaper's SIGKILL window ({window:?}) must cover a reaped daemon's own \

--- a/crates/trusty-search/src/commands/stop.rs
+++ b/crates/trusty-search/src/commands/stop.rs
@@ -270,9 +270,8 @@ mod window_tests {
     #[test]
     fn stop_window_covers_the_flush_floor() {
         let window = trusty_common::shutdown::termination_grace();
-        let floor = std::time::Duration::from_secs(
-            crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS,
-        );
+        let floor =
+            std::time::Duration::from_secs(crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS);
         assert!(
             window >= floor,
             "`stop`'s SIGKILL window ({window:?}) must cover the daemon's per-index \

--- a/crates/trusty-search/src/commands/stop.rs
+++ b/crates/trusty-search/src/commands/stop.rs
@@ -8,13 +8,23 @@ use std::time::{Duration, Instant};
 /// Why: extracted from `main()`. Stopping involves PID-file lookup, SIGTERM,
 /// and a poll loop — clearer in its own function.
 /// What: reads `~/.local/share/trusty-search/daemon.lock` for the PID, sends
-/// SIGTERM, then waits up to 5 s for the daemon's port file to disappear.
+/// SIGTERM, then waits up to
+/// [`trusty_common::shutdown::termination_grace`] (#4393) for the daemon's port
+/// file to disappear.
 /// Additionally scans the process table for ANY other live `trusty-search`
 /// daemon processes (closes #81 — orphans left running when the lockfile
 /// went stale could consume unbounded RAM) and terminates them too.
+///
+/// #4395 scope note: `stop` deliberately keeps its stop-everything semantics —
+/// it is an explicit operator command whose documented contract since #81 is
+/// "nothing named trusty-search is left running". The IMPLICIT reaper inside
+/// `start` is the one that had to become ownership-aware, because nobody asked
+/// it to kill anything; see `commands::start::reap_orphans`.
+///
 /// Exits 1 only if NOTHING is killed (no lockfile + no orphans).
-/// Test: with a running daemon → "Daemon stopped" within 5 s. Spawn two
-/// `trusty-search start` instances; stop must reap both.
+/// Test: with a running daemon → "Daemon stopped" within the grace window. Spawn
+/// two `trusty-search start` instances; stop must reap both.
+/// `stop_window_covers_the_flush_floor` pins the window against the flush floor.
 pub async fn handle_stop() -> Result<()> {
     // The daemon writes its PID into the fs4 lockfile at startup
     // (see trusty-search-service/src/daemon.rs). Read the PID, send
@@ -83,9 +93,17 @@ pub async fn handle_stop() -> Result<()> {
         let _ = send_signal(*pid, "TERM");
     }
 
-    // Phase 2: poll up to 5 s for the lockfile-owning daemon to release the
-    // port file AND for every targeted PID to exit.
-    let deadline = Instant::now() + Duration::from_secs(5);
+    // Phase 2: poll for the lockfile-owning daemon to release the port file AND
+    // for every targeted PID to exit.
+    //
+    // #4393: this window was 5 s, against a shutdown flush that floors at 30 s
+    // per index — so `trusty-search stop` SIGKILLed a daemon that was mid-flush
+    // on every stop that had real work to do. It now uses the same termination
+    // grace launchd's `ExitTimeOut` and the orphan reaper use, so the three
+    // paths cannot disagree about how long a daemon has to finish.
+    let grace = trusty_common::shutdown::termination_grace();
+    let deadline = Instant::now() + grace;
+    let mut last_notice = Instant::now();
     loop {
         std::thread::sleep(Duration::from_millis(100));
         let any_alive = targets.iter().any(|p| pid_alive(*p));
@@ -96,6 +114,15 @@ pub async fn handle_stop() -> Result<()> {
         }
         if Instant::now() >= deadline {
             break;
+        }
+        // A 60 s silent wait reads as a hang. Say what is being waited on.
+        if last_notice.elapsed() >= Duration::from_secs(5) {
+            last_notice = Instant::now();
+            println!(
+                "{} still flushing index snapshots… (up to {}s, #4393)",
+                "·".dimmed(),
+                grace.as_secs()
+            );
         }
     }
 
@@ -228,6 +255,30 @@ fn pid_alive(pid: u32) -> bool {
 #[cfg(not(unix))]
 fn pid_alive(_pid: u32) -> bool {
     true
+}
+
+#[cfg(test)]
+mod window_tests {
+    /// Why (#4393 — the mismatch, on the path the original filing missed
+    /// entirely): `stop` allowed 5 s before SIGKILL while the daemon's own
+    /// shutdown flush floors at 30 s per index, so a stop issued while an index
+    /// had real work to flush killed it mid-write. Every termination path has to
+    /// clear that floor or the flush is decorative.
+    /// What: asserts the grace window `handle_stop` waits for covers
+    /// `shutdown_flush::MIN_FLUSH_TIMEOUT_SECS`.
+    /// Test: this IS the test.
+    #[test]
+    fn stop_window_covers_the_flush_floor() {
+        let window = trusty_common::shutdown::termination_grace();
+        let floor = std::time::Duration::from_secs(
+            crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS,
+        );
+        assert!(
+            window >= floor,
+            "`stop`'s SIGKILL window ({window:?}) must cover the daemon's per-index \
+             flush floor ({floor:?}) — 5 s against 30 s is the #4393 defect"
+        );
+    }
 }
 
 #[cfg(all(test, target_os = "macos"))]

--- a/crates/trusty-search/src/core/store/tests.rs
+++ b/crates/trusty-search/src/core/store/tests.rs
@@ -10,7 +10,48 @@ use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use super::types::VectorStore;
-use super::usearch_store::{UsearchStore, POPULATED_SNAPSHOT_THRESHOLD_BYTES};
+use super::usearch_store::{staging_path, UsearchStore, POPULATED_SNAPSHOT_THRESHOLD_BYTES};
+
+/// Why (#4395's second defect): both writers used the same deterministic
+/// `hnsw.usearch.tmp`, and `hnsw.usearch` has no cross-process lock. Colocated
+/// indexes keep their snapshot in the project root, outside every data
+/// directory, so two data-dir-isolated daemons indexing the same repo staged
+/// through the identical file — one could truncate the other's half-written tmp
+/// and rename a spliced snapshot into place. Reverting `staging_path` to
+/// `with_extension("usearch.tmp")` fails this test.
+/// What: asserts the staging name carries this process's pid, is not the bare
+/// shared name, and still sits beside its target with the target's extension
+/// readable in it.
+/// Test: this IS the test.
+#[test]
+fn test_staging_path_is_process_scoped() {
+    let target = std::path::Path::new("/tmp/proj/.trusty-search/hnsw.usearch");
+    let staged = staging_path(target, "usearch");
+    let name = staged.file_name().unwrap().to_string_lossy().into_owned();
+
+    assert!(
+        name.contains(&std::process::id().to_string()),
+        "staging name must be scoped to this process; got {name}"
+    );
+    assert_ne!(
+        name, "hnsw.usearch.tmp",
+        "the shared staging name is the #4395 collision"
+    );
+    assert!(name.starts_with("hnsw.usearch."), "got {name}");
+    assert!(name.ends_with(".tmp"), "got {name}");
+    assert_eq!(
+        staged.parent(),
+        target.parent(),
+        "staging must happen beside the target so the rename stays same-filesystem"
+    );
+
+    // The sidecar uses the same helper and must not collide with the HNSW one.
+    let sidecar = staging_path(
+        std::path::Path::new("/tmp/proj/.trusty-search/hnsw.keys.json"),
+        "json",
+    );
+    assert_ne!(staged, sidecar);
+}
 
 #[tokio::test]
 async fn test_upsert_and_search() {

--- a/crates/trusty-search/src/core/store/usearch_store.rs
+++ b/crates/trusty-search/src/core/store/usearch_store.rs
@@ -21,6 +21,36 @@ use super::super::store_config::{MmapServeMode, VectorQuant};
 use super::types::StoreKeyMap;
 use super::usearch_recover::SaveVerdict;
 
+/// Derive the staging path a snapshot is written to before it is renamed into
+/// place, scoped to THIS process (#4395).
+///
+/// Why: the staging name used to be deterministic — `hnsw.usearch.tmp` and
+/// `hnsw.keys.json.tmp` — and `hnsw.usearch` has no cross-process lock. The
+/// `save_lock` serialises two savers *inside one daemon*; it says nothing about
+/// two daemons. That case is not hypothetical: colocated indexes keep their
+/// snapshot in the project root (`<repo>/.trusty-search/`), OUTSIDE any data
+/// directory, so even two perfectly data-dir-isolated daemons indexing the same
+/// repo wrote to the identical staging file. One could truncate and rewrite the
+/// other's half-finished tmp and rename a spliced snapshot into place. Putting
+/// the pid in the name removes the collision instead of trying to coordinate
+/// through it — no lock to acquire, nothing to time out, and it holds for
+/// colocated stores where no daemon lock reaches.
+///
+/// What: `<path minus final extension>.<ext>.<pid>.tmp`. Callers pass the
+/// extension the finished file will carry (`usearch`, `json`) so the staging
+/// name still sorts and reads next to its target.
+///
+/// Residual, stated rather than papered over: a process SIGKILLed between the
+/// write and the rename leaves its staging file behind, and a per-pid name means
+/// a later process no longer overwrites it. That is one small file per
+/// (index, killed pid), and #4393's widened termination window is what makes the
+/// kill rare. The alternative — a shared name that IS overwritten — is the bug.
+///
+/// Test: `tests::test_staging_path_is_process_scoped`.
+pub(super) fn staging_path(path: &Path, ext: &str) -> PathBuf {
+    path.with_extension(format!("{ext}.{}.tmp", std::process::id()))
+}
+
 /// Initial reserved capacity for a new HNSW index. Grows geometrically on demand.
 ///
 /// Why (memory fix): we register one HNSW index per project, and the daemon
@@ -524,7 +554,7 @@ impl UsearchStore {
         // [`SHRINK_GUARD_RATIO_DIVISOR`] for the full rationale, including how
         // legitimate shrinkage (document deletion, pruning, a deliberate
         // reindex of a smaller corpus) stays unblocked.
-        let tmp_hnsw = hnsw_path.with_extension("usearch.tmp");
+        let tmp_hnsw = staging_path(hnsw_path, "usearch");
         let tmp_hnsw_str = tmp_hnsw
             .to_str()
             .ok_or_else(|| anyhow!("non-utf8 path: {}", tmp_hnsw.display()))?
@@ -612,8 +642,22 @@ impl UsearchStore {
                 removed_since_save.store(0, Ordering::Release);
                 Ok(SaveVerdict::Saved)
             })
-            .await
-            .map_err(|e| anyhow!("usearch save task panicked: {e}"))??;
+            .await;
+            // #4395: the staging file is now process-scoped, so nothing else
+            // will overwrite ours on the next save — clear it ourselves on
+            // every failure path rather than leaving it to be reclaimed by a
+            // collision that no longer happens.
+            let saved = match saved {
+                Ok(Ok(verdict)) => verdict,
+                Ok(Err(e)) => {
+                    let _ = std::fs::remove_file(&tmp_hnsw);
+                    return Err(e);
+                }
+                Err(e) => {
+                    let _ = std::fs::remove_file(&tmp_hnsw);
+                    return Err(anyhow!("usearch save task panicked: {e}"));
+                }
+            };
             match saved {
                 SaveVerdict::Saved => {}
                 // #1717: a partial in-memory index may hold vectors the
@@ -645,10 +689,14 @@ impl UsearchStore {
                 }
             }
         }
-        std::fs::rename(&tmp_hnsw, hnsw_path).map_err(|e| anyhow!("rename hnsw snapshot: {e}"))?;
+        std::fs::rename(&tmp_hnsw, hnsw_path).map_err(|e| {
+            // #4395: as above — our staging file is ours alone to clean up.
+            let _ = std::fs::remove_file(&tmp_hnsw);
+            anyhow!("rename hnsw snapshot: {e}")
+        })?;
 
         let sidecar = hnsw_path.with_extension("keys.json");
-        let sidecar_tmp = sidecar.with_extension("json.tmp");
+        let sidecar_tmp = staging_path(&sidecar, "json");
         let json =
             serde_json::to_vec(&key_map).map_err(|e| anyhow!("serialize hnsw key map: {e}"))?;
         std::fs::write(&sidecar_tmp, &json)

--- a/crates/trusty-search/src/service/daemon.rs
+++ b/crates/trusty-search/src/service/daemon.rs
@@ -584,7 +584,10 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
     // `serve` returning for a reason other than shutdown (a bind/accept error),
     // where the window has not started ticking against us at all.
     let budget = crate::service::shutdown_budget::ShutdownBudget::started_at(
-        sigterm_at.get().copied().unwrap_or_else(std::time::Instant::now),
+        sigterm_at
+            .get()
+            .copied()
+            .unwrap_or_else(std::time::Instant::now),
     );
     flush_all_indexes_on_shutdown(&flush_state, budget).await;
 

--- a/crates/trusty-search/src/service/daemon.rs
+++ b/crates/trusty-search/src/service/daemon.rs
@@ -523,6 +523,16 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
         );
     }
 
+    // #4393: the termination window starts the moment SIGTERM lands, not when
+    // the flush starts — the axum drain and watcher teardown happen in between
+    // and spend real time out of the same window. Recording the instant here
+    // and building the `ShutdownBudget` from it is what makes the flush charge
+    // that time to itself instead of over-planning by however long the drain
+    // took.
+    let sigterm_at: std::sync::Arc<std::sync::OnceLock<std::time::Instant>> =
+        std::sync::Arc::new(std::sync::OnceLock::new());
+    let sigterm_at_signal = std::sync::Arc::clone(&sigterm_at);
+
     // Issue #829: OS signal OR in-process admin_stop channel.
     let serve_result = axum::serve(listener, router)
         .with_graceful_shutdown(async move {
@@ -532,6 +542,7 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
                     tracing::warn!("daemon: in-process stop via admin_stop");
                 }
             }
+            let _ = sigterm_at_signal.set(std::time::Instant::now());
         })
         .await;
 
@@ -546,7 +557,16 @@ pub async fn run_daemon(state: SearchAppState, requested_port: u16) -> Result<()
     // Issue #85 — flush HNSW + chunk corpus for every registered index so
     // the next daemon boot warm-starts instead of paying a full re-index.
     // Best-effort: log on failure, don't abort cleanup.
-    flush_all_indexes_on_shutdown(&flush_state).await;
+    //
+    // #4393: bounded by the real SIGTERM→SIGKILL window rather than by the sum
+    // of the per-index budgets, which no terminator ever granted. Anchored at
+    // the instant the shutdown future resolved; `unwrap_or_else` covers the
+    // `serve` returning for a reason other than shutdown (a bind/accept error),
+    // where the window has not started ticking against us at all.
+    let budget = crate::service::shutdown_budget::ShutdownBudget::started_at(
+        sigterm_at.get().copied().unwrap_or_else(std::time::Instant::now),
+    );
+    flush_all_indexes_on_shutdown(&flush_state, budget).await;
 
     // Best-effort cleanup; ignore errors so the lockfile drop is what frees
     // the next daemon, not our cleanup.

--- a/crates/trusty-search/src/service/daemon.rs
+++ b/crates/trusty-search/src/service/daemon.rs
@@ -227,25 +227,45 @@ pub fn http_addr_path() -> Option<PathBuf> {
 /// Test: set `TRUSTY_DATA_DIR=/tmp/ts-test` before calling; assert the returned
 /// path equals `/tmp/ts-test` and the directory exists.
 fn daemon_dir() -> Result<PathBuf, DaemonError> {
+    let dir = resolve_daemon_dir(std::env::var_os("TRUSTY_DATA_DIR").as_deref())
+        .ok_or(DaemonError::NoDataDir)?;
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+/// Resolve which data directory a trusty-search daemon uses, given the value of
+/// its `TRUSTY_DATA_DIR` (equivalently, its `--data-dir` flag).
+///
+/// Why (#4395): the orphan reaper has to answer this question about OTHER
+/// processes, not just itself — "is that daemon looking at my data, or someone
+/// else's?" is the only trustworthy basis for deciding whether it is an orphan
+/// of mine or a healthy stranger. Taking the override as a parameter rather than
+/// reading the environment makes the rule one function that the reaper can apply
+/// to a candidate's observed argv/environ and to its own, so the two answers
+/// cannot be computed by different logic.
+///
+/// What: `Some(override)` when one is supplied, otherwise
+/// `<data_local_dir>/trusty-search`. Pure — creates nothing. `None` only when
+/// the platform data-local dir is unresolvable, which [`daemon_dir`] reports as
+/// [`DaemonError::NoDataDir`].
+///
+/// NB: We use `data_local_dir()` (not the shared `trusty_common::resolve_data_dir`
+/// which uses `data_dir()`) because the lockfile path is replicated in `main.rs`
+/// (`Stop`, `daemon_port_path`) against `data_local_dir()`. They must agree;
+/// diverging would break daemon discovery on Windows where the two paths differ
+/// (Roaming vs Local). If/when `trusty-common` grows a `resolve_data_local_dir`
+/// helper, switch both sides at once.
+///
+/// Test: `commands::start::reap_orphans` tests drive it through
+/// `DaemonIdentity`; `daemon_tests` cover the override precedence.
+pub fn resolve_daemon_dir(override_dir: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
     // TRUSTY_DATA_DIR wins over the platform default so callers can run
     // isolated daemons for cert/benchmark work without conflicting with the
     // production lockfile (issue #281).
-    if let Ok(override_dir) = std::env::var("TRUSTY_DATA_DIR") {
-        let dir = PathBuf::from(override_dir);
-        std::fs::create_dir_all(&dir)?;
-        return Ok(dir);
+    if let Some(dir) = override_dir {
+        return Some(PathBuf::from(dir));
     }
-    // NB: We use `data_local_dir()` (not the shared `trusty_common::resolve_data_dir`
-    // which uses `data_dir()`) because the lockfile path is replicated in `main.rs`
-    // (`Stop`, `daemon_port_path`) against `data_local_dir()`. They must agree;
-    // diverging would break daemon discovery on Windows where the two paths differ
-    // (Roaming vs Local). If/when `trusty-common` grows a `resolve_data_local_dir`
-    // helper, switch both sides at once.
-    let dir = dirs::data_local_dir()
-        .ok_or(DaemonError::NoDataDir)?
-        .join("trusty-search");
-    std::fs::create_dir_all(&dir)?;
-    Ok(dir)
+    dirs::data_local_dir().map(|d| d.join("trusty-search"))
 }
 
 /// Handle returned by [`run_daemon`] (mostly for tests).

--- a/crates/trusty-search/src/service/mod.rs
+++ b/crates/trusty-search/src/service/mod.rs
@@ -29,6 +29,7 @@ pub mod reconcile;
 pub mod reindex;
 pub mod roots_registry;
 pub mod server;
+pub mod shutdown_budget;
 pub mod shutdown_flush;
 pub mod stall_tracker;
 pub mod ui;

--- a/crates/trusty-search/src/service/shutdown_budget.rs
+++ b/crates/trusty-search/src/service/shutdown_budget.rs
@@ -1,0 +1,149 @@
+//! The process's real shutdown window, and the per-index flush deadlines it
+//! may mint (#4393).
+//!
+//! Why: `shutdown_flush::shutdown_flush_deadline_for` sizes each index's flush
+//! budget from that index's on-disk snapshot — 30 s floor, 20 min ceiling — and
+//! never once asks how long the process is going to live. It cannot: nothing in
+//! the flush path knew. So the daemon planned a 30-second-per-index sweep inside
+//! a 5-second life, and every terminator in the system SIGKILLed it partway
+//! through: launchd's `ExitTimeOut` default (measured 5 s), `trusty-search
+//! stop`'s wait (5 s), the orphan reaper's wait (3 s). The flush that "has a
+//! generous budget" had, in practice, never run to completion when it had real
+//! work to do.
+//!
+//! Raising the windows is half the fix ([`trusty_common::shutdown::
+//! TERMINATION_GRACE_SECS`], rendered into every plist as `ExitTimeOut`). This
+//! module is the other half, and the durable one: a per-index deadline is now a
+//! [`FlushDeadline`], and the ONLY way to obtain one is to ask a
+//! [`ShutdownBudget`] — which subtracts elapsed time and hands back `None` once
+//! the process is out of window. The flush loop is therefore structurally
+//! incapable of granting an index more time than the process has left, and a
+//! sweep that runs out of window stops cleanly at an index boundary instead of
+//! being cut off mid-write.
+//!
+//! What an interrupted sweep costs, precisely: nothing beyond the last
+//! checkpoint. `UsearchStore::save` writes to a staging file and renames, so a
+//! flush that never starts and a flush that is abandoned leave the same on-disk
+//! state — whatever the incremental persister last published (every
+//! `HNSW_SNAPSHOT_BATCH_INTERVAL` batches). Stopping at an index boundary is
+//! what converts "SIGKILLed at an arbitrary point" into "these N indexes were
+//! flushed, these M kept their last checkpoint", which is a bounded, logged
+//! outcome rather than a silent one.
+//!
+//! What: [`ShutdownBudget`] (the window, counted from SIGTERM) and
+//! [`FlushDeadline`] (an unforgeable per-index grant).
+//!
+//! Test: `shutdown_budget_tests.rs`.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+/// Wall-clock time held back from the flush for post-flush cleanup.
+///
+/// Why: `run_daemon` still has work to do after the sweep returns — remove the
+/// port file, remove `http_addr`, deregister shared discovery, release the
+/// lockfile, exit. Spending the entire window on flushing would hand SIGKILL the
+/// cleanup instead of the flush, trading one truncated step for another.
+/// What: 5 s, subtracted from the grace window when a budget is created.
+/// Test: `budget_reserves_time_for_post_flush_cleanup`.
+pub(crate) const CLEANUP_RESERVE: Duration = Duration::from_secs(5);
+
+/// How much of its life this process has left to spend on the shutdown flush.
+///
+/// Why: see the module doc. The type exists so that "how long may this index
+/// take?" can only be answered by something that knows how long the process has
+/// left — a plain `Duration` parameter is exactly what let a 20-minute deadline
+/// be handed to a 5-second process.
+/// What: an absolute deadline, created from the termination window at the
+/// moment SIGTERM was observed, minus [`CLEANUP_RESERVE`].
+/// Test: `shutdown_budget_tests.rs`.
+#[derive(Debug, Clone, Copy)]
+pub struct ShutdownBudget {
+    deadline: Instant,
+}
+
+/// A per-index flush grant that cannot outlive the process (#4393).
+///
+/// Why: the unforgeable half of the fix. The field is private and this module
+/// exposes no constructor from a bare `Duration`, so `shutdown_flush` — a
+/// different module — literally cannot write `FlushDeadline(Duration::from_secs(
+/// 1200))`. Every deadline that reaches [`crate::service::shutdown_flush`] has
+/// passed through [`ShutdownBudget::flush_deadline_for`] and been clamped there.
+/// What: wraps the granted duration; [`Self::as_duration`] reads it back.
+/// Test: `flush_deadline_is_clamped_to_the_remaining_window`.
+#[derive(Debug, Clone, Copy)]
+pub struct FlushDeadline(Duration);
+
+impl FlushDeadline {
+    /// The granted duration.
+    pub fn as_duration(self) -> Duration {
+        self.0
+    }
+}
+
+impl ShutdownBudget {
+    /// Open a budget for a shutdown that began at `sigterm_at`.
+    ///
+    /// Why: the window starts when SIGTERM lands, not when the flush starts —
+    /// the axum drain and watcher teardown happen in between and spend real
+    /// time. Taking the instant as a parameter is what lets `run_daemon` record
+    /// it in the signal handler and charge that time honestly.
+    /// What: `sigterm_at + termination_grace() - CLEANUP_RESERVE`. A grace
+    /// shorter than the reserve saturates to zero rather than wrapping, so a
+    /// tiny declared window yields a budget that is immediately exhausted (no
+    /// flush) rather than an accidentally enormous one.
+    /// Test: `budget_reserves_time_for_post_flush_cleanup`,
+    /// `budget_shorter_than_the_cleanup_reserve_is_exhausted`.
+    pub fn started_at(sigterm_at: Instant) -> Self {
+        Self::from_window_at(sigterm_at, trusty_common::shutdown::termination_grace())
+    }
+
+    /// [`Self::started_at`] with an explicit window instead of the configured
+    /// one — the seam the tests drive.
+    pub fn from_window_at(sigterm_at: Instant, window: Duration) -> Self {
+        Self {
+            deadline: sigterm_at + window.saturating_sub(CLEANUP_RESERVE),
+        }
+    }
+
+    /// [`Self::from_window_at`] anchored at now.
+    pub fn from_window(window: Duration) -> Self {
+        Self::from_window_at(Instant::now(), window)
+    }
+
+    /// Time left before the process must stop flushing and start cleaning up.
+    pub fn remaining(&self) -> Duration {
+        self.deadline.saturating_duration_since(Instant::now())
+    }
+
+    /// Whether the window is spent.
+    pub fn is_exhausted(&self) -> bool {
+        self.remaining().is_zero()
+    }
+
+    /// Mint the flush grant for one index, or `None` if the window is spent.
+    ///
+    /// Why: THE #4393 fix, in one function. `shutdown_flush_deadline_for` still
+    /// decides how long this index *deserves* from its snapshot size; this
+    /// clamps that to how long the process *has*. Before, only the first half
+    /// existed, so index #1 could be granted 20 minutes of a 5-second life and
+    /// indexes #2..N were never reached at all.
+    /// What: `min(size-scaled deadline, remaining window)`, or `None` when the
+    /// budget is exhausted — which the caller reports as a skip, leaving that
+    /// index on its last incremental checkpoint.
+    /// Test: `flush_deadline_is_clamped_to_the_remaining_window`,
+    /// `exhausted_budget_mints_no_deadline`,
+    /// `flush_deadline_keeps_the_size_scaled_value_when_the_window_is_ample`.
+    pub fn flush_deadline_for(&self, hnsw_path: &Path) -> Option<FlushDeadline> {
+        let remaining = self.remaining();
+        if remaining.is_zero() {
+            return None;
+        }
+        let wanted = crate::service::shutdown_flush::shutdown_flush_deadline_for(hnsw_path);
+        Some(FlushDeadline(wanted.min(remaining)))
+    }
+}
+
+#[cfg(test)]
+#[path = "shutdown_budget_tests.rs"]
+mod tests;

--- a/crates/trusty-search/src/service/shutdown_budget_tests.rs
+++ b/crates/trusty-search/src/service/shutdown_budget_tests.rs
@@ -1,0 +1,162 @@
+//! Regression tests for the #4393 shutdown-window fix.
+//!
+//! Why: the defect was arithmetic — a 30 s-floored, 20 min-ceilinged per-index
+//! flush budget inside a 3–5 s termination window — so the tests are arithmetic
+//! too. Each one fails if the clamp in
+//! [`super::ShutdownBudget::flush_deadline_for`] is removed and the size-scaled
+//! deadline is handed straight through, which is exactly the pre-fix code.
+//!
+//! Test: this IS the test module.
+
+use super::*;
+use crate::service::shutdown_flush::MIN_FLUSH_TIMEOUT_SECS;
+use serial_test::serial;
+
+/// A snapshot path that does not exist, so `shutdown_flush_deadline_for` returns
+/// exactly its floor (`MIN_FLUSH_TIMEOUT_SECS`) with no size scaling.
+fn missing_snapshot() -> &'static Path {
+    Path::new("/nonexistent/hnsw.usearch")
+}
+
+/// Why (#4393 — the core defect): a per-index deadline larger than the process's
+/// remaining life is a promise the process cannot keep. Before the clamp, a
+/// missing snapshot alone bought 30 s inside a window that measured 3–5 s, and a
+/// 200 MB one bought 40 s; the flush was SIGKILLed partway through index #1 and
+/// indexes #2..N were never attempted. Deleting the `.min(remaining)` in
+/// `flush_deadline_for` makes this assertion fail.
+/// What: opens a 10 s window (5 s after the cleanup reserve) and asks for a
+/// deadline against a missing snapshot, whose unclamped value is the 30 s floor.
+/// Asserts the grant is bounded by the window, not by the floor.
+/// Test: this IS the test.
+#[test]
+#[serial]
+fn flush_deadline_is_clamped_to_the_remaining_window() {
+    // SAFETY: `#[serial]` — no other thread reads the environment during this body.
+    unsafe { std::env::remove_var("TRUSTY_SHUTDOWN_FLUSH_TIMEOUT_SECS") };
+
+    let budget = ShutdownBudget::from_window(Duration::from_secs(10));
+    let granted = budget
+        .flush_deadline_for(missing_snapshot())
+        .expect("a 10 s window is not exhausted")
+        .as_duration();
+
+    assert!(
+        granted <= Duration::from_secs(5),
+        "grant must fit the 10 s window minus the 5 s cleanup reserve; got {granted:?}"
+    );
+    assert!(
+        granted < Duration::from_secs(MIN_FLUSH_TIMEOUT_SECS),
+        "grant must be smaller than the {MIN_FLUSH_TIMEOUT_SECS}s size-scaled floor — \
+         handing the floor through unclamped is the #4393 defect; got {granted:?}"
+    );
+}
+
+/// Why (#4393): the clamp must not become a cap. When the process genuinely has
+/// the time, a large index must still get its size-scaled budget — otherwise the
+/// fix for one data-loss mode introduces another (a 500 MB snapshot cut off at an
+/// arbitrary small deadline).
+/// What: opens a window far larger than the floor and asserts the grant equals
+/// the size-scaled value `shutdown_flush_deadline_for` computed.
+/// Test: this IS the test.
+#[test]
+#[serial]
+fn flush_deadline_keeps_the_size_scaled_value_when_the_window_is_ample() {
+    // SAFETY: `#[serial]`.
+    unsafe { std::env::remove_var("TRUSTY_SHUTDOWN_FLUSH_TIMEOUT_SECS") };
+
+    let budget = ShutdownBudget::from_window(Duration::from_secs(3600));
+    let granted = budget
+        .flush_deadline_for(missing_snapshot())
+        .expect("an hour-long window is not exhausted")
+        .as_duration();
+
+    assert_eq!(
+        granted,
+        Duration::from_secs(MIN_FLUSH_TIMEOUT_SECS),
+        "with time to spare the size-scaled deadline must survive intact"
+    );
+}
+
+/// Why (#4393): once the window is spent the sweep must stop at an index
+/// boundary rather than start a flush it cannot finish. `None` is what makes
+/// that structural — there is no deadline to hand out, so `flush_index_bounded`
+/// is never called for that index and its last checkpoint stands.
+/// What: builds a budget whose deadline is already in the past and asserts no
+/// deadline can be minted from it.
+/// Test: this IS the test.
+#[test]
+#[serial]
+fn exhausted_budget_mints_no_deadline() {
+    // SAFETY: `#[serial]`.
+    unsafe { std::env::remove_var("TRUSTY_SHUTDOWN_FLUSH_TIMEOUT_SECS") };
+
+    let long_ago = Instant::now() - Duration::from_secs(600);
+    let budget = ShutdownBudget::from_window_at(long_ago, Duration::from_secs(60));
+
+    assert!(budget.is_exhausted(), "a window opened 10 min ago is spent");
+    assert!(
+        budget.flush_deadline_for(missing_snapshot()).is_none(),
+        "an exhausted budget must refuse to grant a deadline"
+    );
+}
+
+/// Why (#4393): the flush is not the last thing the process does — the port
+/// file, `http_addr`, the discovery registry, and the lockfile all still have to
+/// be cleared. Spending the whole window flushing hands SIGKILL the cleanup
+/// instead.
+/// What: asserts the usable budget is the window minus [`CLEANUP_RESERVE`].
+/// Test: this IS the test.
+#[test]
+fn budget_reserves_time_for_post_flush_cleanup() {
+    let now = Instant::now();
+    let budget = ShutdownBudget::from_window_at(now, Duration::from_secs(60));
+    let remaining = budget.remaining();
+    assert!(
+        remaining <= Duration::from_secs(55),
+        "budget must hold back the cleanup reserve; got {remaining:?}"
+    );
+    assert!(
+        remaining > Duration::from_secs(50),
+        "budget must not hold back more than the reserve; got {remaining:?}"
+    );
+}
+
+/// Why (#4393): a declared window smaller than the cleanup reserve must
+/// saturate to zero, not wrap. `Instant + Duration` has no wrapping hazard, but
+/// `Duration - Duration` does, and an underflow here would panic or (worse, with
+/// a different formulation) produce an enormous budget inside a tiny window —
+/// the exact bug, restored by accident.
+/// What: declares a 1 s window and asserts the budget is immediately exhausted.
+/// Test: this IS the test.
+#[test]
+fn budget_shorter_than_the_cleanup_reserve_is_exhausted() {
+    let budget = ShutdownBudget::from_window(Duration::from_secs(1));
+    assert!(
+        budget.is_exhausted(),
+        "a window under the cleanup reserve leaves nothing for flushing"
+    );
+}
+
+/// Why (#4393 — the mismatch this issue reports, asserted directly): the per-
+/// index floor is 30 s and the shipped termination window must cover it, or the
+/// very first index of every shutdown is planned to outlive the process. This is
+/// the arithmetic that failed on `main`: floor 30 s, window 3–5 s.
+/// What: asserts the configured termination grace covers the floor plus the
+/// cleanup reserve.
+/// Test: this IS the test.
+#[test]
+#[serial]
+fn flush_floor_fits_the_termination_window() {
+    // SAFETY: `#[serial]`; clear any operator override so the shipped default
+    // is what gets asserted.
+    unsafe { std::env::remove_var(trusty_common::shutdown::TERMINATION_GRACE_ENV) };
+
+    let window = trusty_common::shutdown::termination_grace();
+    let floor = Duration::from_secs(MIN_FLUSH_TIMEOUT_SECS);
+    assert!(
+        window >= floor + CLEANUP_RESERVE,
+        "the termination window ({window:?}) must cover one index's flush floor \
+         ({floor:?}) plus the cleanup reserve ({CLEANUP_RESERVE:?}) — this is the \
+         #4393 mismatch, which measured 5 s against 30 s on main"
+    );
+}

--- a/crates/trusty-search/src/service/shutdown_flush.rs
+++ b/crates/trusty-search/src/service/shutdown_flush.rs
@@ -33,7 +33,13 @@ use std::sync::Arc;
 /// [`crate::service::shutdown_budget`] — deadlines are now clamped to the
 /// remaining window, and the window itself is declared to launchd via
 /// `ExitTimeOut`.
-pub(crate) const MIN_FLUSH_TIMEOUT_SECS: u64 = 30;
+///
+/// `pub` rather than `pub(crate)`: the `trusty-search` BIN re-exports the lib's
+/// modules into its own `crate::` namespace (see `main.rs`), so the CLI-side
+/// gates in `commands::stop` and `commands::start::reap_orphans` that assert
+/// their termination windows cover this floor are, to the compiler, a different
+/// crate.
+pub const MIN_FLUSH_TIMEOUT_SECS: u64 = 30;
 
 /// Conservative disk-write throughput floor (MB/s) used to scale the flush
 /// deadline from the on-disk HNSW snapshot's current size — a cheap proxy for

--- a/crates/trusty-search/src/service/shutdown_flush.rs
+++ b/crates/trusty-search/src/service/shutdown_flush.rs
@@ -649,7 +649,11 @@ mod tests {
             crate::core::registry::IndexRegistry::new(),
         );
         let start = std::time::Instant::now();
-        flush_all_indexes_on_shutdown(&state, ShutdownBudget::from_window(std::time::Duration::from_secs(65))).await;
+        flush_all_indexes_on_shutdown(
+            &state,
+            ShutdownBudget::from_window(std::time::Duration::from_secs(65)),
+        )
+        .await;
         // SAFETY: same serial guarantee as above.
         unsafe { std::env::remove_var("TRUSTY_SHUTDOWN_FLUSH_TIMEOUT_SECS") };
         assert!(
@@ -995,7 +999,8 @@ mod tests {
             std::time::Instant::now() - std::time::Duration::from_secs(600),
             std::time::Duration::from_secs(60),
         );
-        let window_open = flush_one_index_on_shutdown(&registry, &reindex_progress, id, spent).await;
+        let window_open =
+            flush_one_index_on_shutdown(&registry, &reindex_progress, id, spent).await;
 
         assert!(
             !window_open,

--- a/crates/trusty-search/src/service/shutdown_flush.rs
+++ b/crates/trusty-search/src/service/shutdown_flush.rs
@@ -16,6 +16,8 @@
 use crate::core::registry::IndexId;
 use crate::service::reindex::{ReindexProgress, ReindexStatus};
 use crate::service::server::SearchAppState;
+// #4393: the shutdown window and the per-index grants it mints.
+use crate::service::shutdown_budget::{FlushDeadline, ShutdownBudget};
 use dashmap::DashMap;
 use std::sync::Arc;
 
@@ -23,7 +25,15 @@ use std::sync::Arc;
 /// empty snapshot (issue #2922 — the prior flat 10 s default was far too
 /// short for anything beyond a trivial index; filesystem/lock-acquisition
 /// overhead alone can exceed 10 s on a loaded host).
-const MIN_FLUSH_TIMEOUT_SECS: u64 = 30;
+/// #4393: this floor exceeded EVERY termination window in the system (launchd's
+/// measured 5 s `ExitTimeOut` default, `stop`'s 5 s, the reaper's 3 s), so a
+/// flush with real work to do was SIGKILLed before it finished on every path.
+/// The floor itself is right; what was missing was any relationship between it
+/// and how long the process actually lives. See
+/// [`crate::service::shutdown_budget`] — deadlines are now clamped to the
+/// remaining window, and the window itself is declared to launchd via
+/// `ExitTimeOut`.
+pub(crate) const MIN_FLUSH_TIMEOUT_SECS: u64 = 30;
 
 /// Conservative disk-write throughput floor (MB/s) used to scale the flush
 /// deadline from the on-disk HNSW snapshot's current size — a cheap proxy for
@@ -175,21 +185,35 @@ fn shutdown_flush_concurrency() -> usize {
 ///    essentially no protection there either, on any reindex large enough to
 ///    matter).
 ///
-/// What: iterates `state.registry.list()`, applying the above five mitigations
+/// 6. **Bounded by the process's actual remaining life** (#4393): every
+///    per-index deadline is minted by the caller-supplied [`ShutdownBudget`],
+///    which clamps the size-scaled value to the time left before SIGKILL and
+///    refuses to grant anything once the window is spent. Mitigations 1–5 all
+///    assumed the process would still be alive to enforce them; it usually was
+///    not, because the 30 s floor exceeded every termination window in the
+///    system. A sweep that runs out of window now stops at an index boundary,
+///    logging how many indexes kept their last incremental checkpoint, instead
+///    of being cut off mid-write at an arbitrary point.
+///
+/// What: iterates `state.registry.list()`, applying the above six mitigations
 /// per index, running up to `shutdown_flush_concurrency()` flushes at a time.
 /// Test: `shutdown_flush_empty_registry_returns_immediately`,
 /// `shutdown_flush_skips_index_with_reindex_in_progress`,
-/// `shutdown_flush_proceeds_when_reindex_complete` in this module.
-pub async fn flush_all_indexes_on_shutdown(state: &SearchAppState) {
+/// `shutdown_flush_proceeds_when_reindex_complete`,
+/// `shutdown_flush_skips_every_index_when_the_window_is_spent` in this module.
+pub async fn flush_all_indexes_on_shutdown(state: &SearchAppState, budget: ShutdownBudget) {
     let ids = state.registry.list();
     if ids.is_empty() {
         return;
     }
     tracing::info!(
-        "shutdown: flushing {} index snapshot(s) before exit (concurrency={})",
+        "shutdown: flushing {} index snapshot(s) before exit (concurrency={}, \
+         window={:?} remaining, #4393)",
         ids.len(),
-        shutdown_flush_concurrency()
+        shutdown_flush_concurrency(),
+        budget.remaining(),
     );
+    let skipped = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
     let semaphore = std::sync::Arc::new(tokio::sync::Semaphore::new(shutdown_flush_concurrency()));
     let tasks: Vec<_> = ids
         .into_iter()
@@ -197,30 +221,56 @@ pub async fn flush_all_indexes_on_shutdown(state: &SearchAppState) {
             let state_registry = state.registry.clone();
             let reindex_progress = state.reindex_progress.clone();
             let semaphore = semaphore.clone();
+            let skipped = skipped.clone();
             async move {
                 // Issue #2922: bound how many indexes flush at once so a
                 // fleet of large indexes can't all saturate disk I/O / the
                 // blocking thread pool simultaneously. `acquire_owned` is
                 // dropped (releasing the permit) when this future completes.
                 let _permit = semaphore.acquire_owned().await;
-                flush_one_index_on_shutdown(&state_registry, &reindex_progress, id).await;
+                // #4393: the budget is re-checked here, after the permit wait,
+                // so indexes queued behind a slow one discover the spent window
+                // immediately rather than each starting a flush they cannot
+                // finish.
+                if !flush_one_index_on_shutdown(&state_registry, &reindex_progress, id, budget)
+                    .await
+                {
+                    skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                }
             }
         })
         .collect();
     futures::future::join_all(tasks).await;
+    let skipped = skipped.load(std::sync::atomic::Ordering::Relaxed);
+    if skipped > 0 {
+        tracing::warn!(
+            "shutdown: {skipped} index(es) were not flushed — the {}s termination window \
+             ran out (#4393). Each keeps its last incremental checkpoint; raise \
+             {} to widen the window.",
+            trusty_common::shutdown::termination_grace().as_secs(),
+            trusty_common::shutdown::TERMINATION_GRACE_ENV,
+        );
+    }
 }
 
 /// Flush a single index's HNSW + chunk corpus to disk during shutdown,
 /// applying the reindex-in-progress skip, the external-volume skip, and the
 /// size-scaled bounded timeout. Extracted from [`flush_all_indexes_on_shutdown`]
 /// so that function can run one of these per index concurrently (issue #2922).
+///
+/// Returns `false` only when `budget` refused to mint a deadline because the
+/// #4393 termination window was already spent — the one skip reason that says
+/// something about the shutdown as a whole rather than about this index. Every
+/// other early return (missing handle, live reindex, external volume,
+/// unresolvable path) is an index-specific decision and reports `true`.
 async fn flush_one_index_on_shutdown(
     registry: &crate::core::registry::IndexRegistry,
     reindex_progress: &Arc<DashMap<IndexId, Arc<ReindexProgress>>>,
     id: crate::core::registry::IndexId,
-) {
+    budget: ShutdownBudget,
+) -> bool {
     let Some(handle) = registry.get(&id) else {
-        return;
+        return true;
     };
 
     // Issue #1717: never publish a shutdown flush while a background reindex
@@ -286,7 +336,7 @@ async fn flush_one_index_on_shutdown(
              persist.",
             id.0,
         );
-        return;
+        return true;
     }
 
     // Fix #874 (3): skip indexes on external volumes to avoid TCC I/O stalls.
@@ -298,7 +348,7 @@ async fn flush_one_index_on_shutdown(
             id.0,
             handle.root_path.display(),
         );
-        return;
+        return true;
     }
 
     // Fix #874 (2): derive paths inside a short read-lock scope, then drop
@@ -319,7 +369,7 @@ async fn flush_one_index_on_shutdown(
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!("shutdown: chunks path unresolvable for '{}': {e}", id.0);
-                return;
+                return true;
             }
         }
     };
@@ -331,7 +381,7 @@ async fn flush_one_index_on_shutdown(
                     "shutdown: colocated hnsw path unresolvable for '{}': {e}",
                     id.0
                 );
-                return;
+                return true;
             }
         }
     } else {
@@ -339,7 +389,7 @@ async fn flush_one_index_on_shutdown(
             Ok(p) => p,
             Err(e) => {
                 tracing::warn!("shutdown: hnsw path unresolvable for '{}': {e}", id.0);
-                return;
+                return true;
             }
         }
     };
@@ -348,7 +398,19 @@ async fn flush_one_index_on_shutdown(
     // rather than a flat constant, so a tiny index isn't held to a needlessly
     // long budget and a huge one isn't cut off before it can finish an atomic
     // write. Computed once per index, before spawning the flush task.
-    let flush_deadline = shutdown_flush_deadline_for(&hnsw_path);
+    //
+    // #4393: and clamped by the budget to what the process actually has left.
+    // `None` means the window is spent: start nothing, so this index keeps the
+    // snapshot its last incremental persist wrote instead of being SIGKILLed
+    // partway through a fresh one.
+    let Some(flush_deadline) = budget.flush_deadline_for(&hnsw_path) else {
+        tracing::warn!(
+            "shutdown: skipping flush for '{}' — the termination window is spent \
+             (#4393). On-disk state is from the last incremental persist.",
+            id.0,
+        );
+        return false;
+    };
 
     // Fix #874 (2): derive paths inside a short read-lock scope above,
     // then hold the indexer read-lock across the flush I/O below.
@@ -398,6 +460,7 @@ async fn flush_one_index_on_shutdown(
     // own consistent rename or block behind — and safely lose to — a fresher
     // save that started after it; it can never interleave with one.
     flush_index_bounded(&id.0, flush_deadline, flush_future).await;
+    true
 }
 
 /// Run a single index's flush future to completion under a hard deadline,
@@ -423,10 +486,16 @@ async fn flush_one_index_on_shutdown(
 /// worker without depending on tokio's runtime teardown.
 /// Test: `flush_bounded_returns_on_blocking_work` and
 /// `flush_bounded_completes_fast_path` in the `tests` submodule.
-async fn flush_index_bounded<F>(index_id: &str, deadline: std::time::Duration, flush: F)
+///
+/// #4393: the deadline is a [`FlushDeadline`], not a bare `Duration`. This
+/// function is the only place a flush is given a wall-clock budget, and
+/// `FlushDeadline` can only be minted by [`ShutdownBudget::flush_deadline_for`],
+/// so no call site can hand it a budget the process will not live to honour.
+async fn flush_index_bounded<F>(index_id: &str, deadline: FlushDeadline, flush: F)
 where
     F: std::future::Future<Output = ()> + Send + 'static,
 {
+    let deadline = deadline.as_duration();
     let task = tokio::spawn(flush);
     let abort = task.abort_handle();
     match tokio::time::timeout(deadline, task).await {
@@ -451,6 +520,18 @@ where
 mod tests {
     use super::*;
     use serial_test::serial;
+
+    /// A [`FlushDeadline`] of roughly `millis`, minted the only way one can be
+    /// (#4393): from a [`ShutdownBudget`] whose window is that long plus the
+    /// cleanup reserve. There is deliberately no constructor from a bare
+    /// `Duration` — that is the whole point of the type.
+    fn deadline_of(millis: u64) -> FlushDeadline {
+        let window = std::time::Duration::from_millis(millis)
+            + crate::service::shutdown_budget::CLEANUP_RESERVE;
+        ShutdownBudget::from_window(window)
+            .flush_deadline_for(std::path::Path::new("/nonexistent/hnsw.usearch"))
+            .expect("a positive window grants a deadline")
+    }
 
     /// Why: `shutdown_flush_timeout_override` must parse the env var and
     /// return `None` when absent, letting size-based scaling take over.
@@ -562,7 +643,7 @@ mod tests {
             crate::core::registry::IndexRegistry::new(),
         );
         let start = std::time::Instant::now();
-        flush_all_indexes_on_shutdown(&state).await;
+        flush_all_indexes_on_shutdown(&state, ShutdownBudget::from_window(std::time::Duration::from_secs(65))).await;
         // SAFETY: same serial guarantee as above.
         unsafe { std::env::remove_var("TRUSTY_SHUTDOWN_FLUSH_TIMEOUT_SECS") };
         assert!(
@@ -592,7 +673,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn flush_bounded_returns_on_blocking_work() {
         let start = std::time::Instant::now();
-        flush_index_bounded("blocking", std::time::Duration::from_millis(200), async {
+        flush_index_bounded("blocking", deadline_of(200), async {
             // Simulate usearch's synchronous save FFI: blocks the worker
             // thread and ignores async cancellation.
             std::thread::sleep(std::time::Duration::from_millis(1500));
@@ -627,7 +708,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
     async fn flush_bounded_survives_single_worker_when_blocking_work_is_offloaded() {
         let start = std::time::Instant::now();
-        flush_index_bounded("offloaded", std::time::Duration::from_millis(200), async {
+        flush_index_bounded("offloaded", deadline_of(200), async {
             // Mirrors `UsearchStore::save`: the actual blocking work runs
             // on the blocking thread pool, not the sole async worker, so
             // that worker stays free to drive the outer timeout's timer.
@@ -653,7 +734,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn flush_bounded_completes_fast_path() {
         let start = std::time::Instant::now();
-        flush_index_bounded("fast", std::time::Duration::from_secs(10), async {}).await;
+        flush_index_bounded("fast", deadline_of(10_000), async {}).await;
         assert!(
             start.elapsed() < std::time::Duration::from_secs(1),
             "a completed flush must return immediately; elapsed: {:?}",
@@ -756,7 +837,13 @@ mod tests {
         // in-flight state this test needs.
         reindex_progress.insert(id.clone(), std::sync::Arc::new(ReindexProgress::new()));
 
-        flush_one_index_on_shutdown(&registry, &reindex_progress, id).await;
+        flush_one_index_on_shutdown(
+            &registry,
+            &reindex_progress,
+            id,
+            ShutdownBudget::from_window(std::time::Duration::from_secs(65)),
+        )
+        .await;
 
         let hnsw_after = std::fs::read(&hnsw_path).expect("read hnsw after guarded flush");
         assert_eq!(
@@ -824,7 +911,13 @@ mod tests {
         progress.status.store(ReindexStatus::Complete);
         reindex_progress.insert(id.clone(), std::sync::Arc::new(progress));
 
-        flush_one_index_on_shutdown(&registry, &reindex_progress, id).await;
+        flush_one_index_on_shutdown(
+            &registry,
+            &reindex_progress,
+            id,
+            ShutdownBudget::from_window(std::time::Duration::from_secs(65)),
+        )
+        .await;
 
         use crate::core::store::VectorStore as _;
         let reloaded = crate::core::store::UsearchStore::load_from(&hnsw_path)
@@ -838,6 +931,79 @@ mod tests {
              (correct, smaller) state — the skip must not be permanent"
         );
 
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+    }
+
+    // ── #4393 regression — the sweep must fit the termination window ────────
+
+    /// Why (#4393 — the reachable damage this issue reports): the flush budget
+    /// floored at 30 s per index while every terminator granted 3–5 s, so the
+    /// sweep was SIGKILLed partway through whichever index it happened to be
+    /// writing. The fix is that a spent window produces a clean skip at an index
+    /// boundary instead: nothing is started that cannot finish, and the on-disk
+    /// snapshot stays at its last incremental checkpoint. Reverting
+    /// `flush_one_index_on_shutdown`'s budget check to the unconditional
+    /// `shutdown_flush_deadline_for` call makes this fail — the flush runs, the
+    /// 500-vector in-memory state is published over the seeded 2,000, and the
+    /// bytes change.
+    /// What: seeds a complete on-disk snapshot, registers a handle holding a
+    /// legitimately different (smaller, fully-explained) state, and flushes with
+    /// a budget whose window closed ten minutes ago. Asserts the on-disk file is
+    /// byte-for-byte unchanged and the call reports the window as spent.
+    /// Test: this IS the test.
+    #[tokio::test]
+    #[serial]
+    async fn shutdown_flush_skips_every_index_when_the_window_is_spent() {
+        // SAFETY: `#[serial]`.
+        unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
+        let data_dir = tempfile::tempdir().expect("tempdir");
+        // SAFETY: `#[serial]`.
+        unsafe { std::env::set_var("TRUSTY_DATA_DIR", data_dir.path()) };
+        let root_dir = tempfile::tempdir().expect("tempdir");
+
+        let hnsw_path =
+            crate::service::persistence::hnsw_path("shutdown-4393-spent").expect("hnsw_path");
+        let seed = store_with_vectors(2000).await;
+        seed.save(&hnsw_path).await.expect("seed save");
+        let hnsw_before = std::fs::read(&hnsw_path).expect("read seeded hnsw");
+
+        // A legitimately shrunk store, so nothing OTHER than the spent window
+        // could be what stops the write (the #1717 shrink guard would otherwise
+        // refuse it and the test would pass for the wrong reason).
+        {
+            use crate::core::store::VectorStore as _;
+            for i in 0..1500 {
+                seed.remove(&format!("chunk:{i}")).await.unwrap();
+            }
+        }
+        let (id, hnsw_path, handle) =
+            build_test_handle("shutdown-4393-spent", root_dir.path(), seed);
+
+        let registry = crate::core::registry::IndexRegistry::new();
+        registry.register(handle);
+        let reindex_progress: std::sync::Arc<
+            dashmap::DashMap<crate::core::registry::IndexId, std::sync::Arc<ReindexProgress>>,
+        > = std::sync::Arc::new(dashmap::DashMap::new());
+
+        let spent = ShutdownBudget::from_window_at(
+            std::time::Instant::now() - std::time::Duration::from_secs(600),
+            std::time::Duration::from_secs(60),
+        );
+        let window_open = flush_one_index_on_shutdown(&registry, &reindex_progress, id, spent).await;
+
+        assert!(
+            !window_open,
+            "a spent window must be reported as such so the sweep can log how \
+             many indexes kept their checkpoint"
+        );
+        let hnsw_after = std::fs::read(&hnsw_path).expect("read hnsw after skipped flush");
+        assert_eq!(
+            hnsw_after, hnsw_before,
+            "with the termination window spent the flush must not start at all — \
+             starting one the process cannot finish is the #4393 defect"
+        );
+
+        // SAFETY: `#[serial]`.
         unsafe { std::env::remove_var("TRUSTY_DATA_DIR") };
     }
 }


### PR DESCRIPTION
## What was broken

One failure story with two halves. trusty-search's shutdown flush budgets **≥30 s per index** and up to 20 min; every window that actually terminates the daemon granted **3–5 s**. So a flush that had real work to do was SIGKILLed before finishing, on every path. And one of those windows — the orphan reaper's 3 s — was being applied to daemons the reaper had no business killing at all, because it matched them by **process name**.

## The termination windows, and where each is written down

| Path | Before | After | Source |
|---|---|---|---|
| launchd `ExitTimeOut` | **5 s** (measured; no key rendered, so launchd's "system-defined" default applied) | 60 s | `trusty-common/src/launchd.rs` `render_plist` |
| `trusty-search stop` | 5 s | `termination_grace()` | `trusty-search/src/commands/stop.rs` |
| orphan reaper inside `start` | 3 s | `termination_grace()` | `trusty-search/src/commands/start/reap_orphans.rs` `reap` |
| flush floor, per index | 30 s | 30 s, clamped to the remaining window | `service/shutdown_flush.rs` `MIN_FLUSH_TIMEOUT_SECS` |

The 5 s launchd figure is #4393's own measurement, reproduced there on a throwaway LaunchAgent (`kickstart -k` → SIGTERM at t+14 ms, new pid at t+5.03 s, the trap's post-handler line never printed). I did not re-measure it and did not touch launchd on this host — see Safety below. No other killer exists in the codebase: the only `SIGKILL` sites in the workspace are these three plus `stop`'s phase-3 escalation, which is the same window now widened.

## Is ≥30 s inherent, or incidental?

Incidental, in the sense that matters. `MIN_FLUSH_TIMEOUT_SECS` is a *ceiling granted*, not a duration *required* — the typical flush is milliseconds (`UsearchStore::save`'s view-mode skip, plus per-batch redb durability). The real defect was not that 30 s is too long; it is that **nothing in the flush path knew how long the process would live**. `shutdown_flush_deadline_for` could return 20 minutes to a process with 5 seconds left, spend all 5 on index #1, and never reach #2..N.

So the durable fix is structural rather than a bigger number, and it is the same shape as the resume-checkpoint work in #4721/#4768:

- `ShutdownBudget` counts down from the instant SIGTERM landed (recorded in the graceful-shutdown future, so the axum drain and watcher teardown are charged against it, not ignored).
- `FlushDeadline` is the only type `flush_index_bounded` accepts. Its field is private and `shutdown_budget` exposes no constructor from a bare `Duration`, so `shutdown_flush` — a different module — **cannot write a deadline the process will not live to honour**. Every grant is `min(size-scaled, remaining)`.
- An exhausted budget mints `None`, so the sweep stops at an **index boundary** rather than being cut off mid-write.

What an interrupted sweep now costs: nothing beyond the last checkpoint. `save` stages and renames, so a flush never started and a flush abandoned leave identical on-disk state — whatever the incremental persister last published. Stopping at a boundary is what turns "SIGKILLed at an arbitrary point" into "N flushed, M kept their checkpoint", logged with the count.

## The reaper's identity signal: the data directory

Process name says nothing about whose data a daemon serves. The candidates I weighed:

- **A pid file** names the daemon we already track — by definition not the orphan we are hunting (`running_daemon_pid()` has already returned `None` by the time the reaper runs).
- **A launchd label** does not exist for the CLI-detached daemons this reaper actually finds (PPID 1, no plist).
- **Port ownership** — the #4470 shape, `trusty-installer::commands::port_guard`, which I read and modelled the fail-closed structure on — answers "is someone on my port?". Right question for a bootstrap; wrong one here. The daemon *walks* its port on collision, so a foreign holder is a condition it is designed to survive, and a different port proves nothing about whose data dir a process has open.
- **A `/health` handshake** identifies a daemon that is *answering* — which excludes exactly the wedged instance the reaper exists to clear.

**The data directory** is what a trusty-search daemon actually contends over: one lock, one set of index files. It declares that directory in its own argv (`--data-dir`, always passed explicitly by the self-spawn per #1182) or its own environment (`TRUSTY_DATA_DIR`), falling back to the platform default when it declares neither. Two daemons on disjoint data dirs were never in conflict.

Structurally, per the #4718/#4835 pattern rather than "check a bit harder":

- `DaemonIdentity` is a three-state enum — `OwnInstance` / `ForeignInstance(dir)` / `Unidentified(why)`. The third state is the one a `bool` folds into "kill it", which is how a name match became a death sentence. An **unreadable** environment is indistinguishable from an empty one, so it is `Unidentified`, never resolved to the default dir.
- `ConfirmedOrphan` wraps a pid behind a private field with no constructor from a `u32`. `reap` accepts nothing else. **There is no way to express "signal this pid" for a pid that did not come out of `plan` positively matched to our own data dir.**

`trusty-search stop` deliberately keeps its stop-everything semantics: it is an explicit operator command whose contract since #81 is "nothing named trusty-search is left running". The *implicit* reaper is the one that had to change, because nobody asked it to kill anything.

Also fixed, #4395's second defect: both writers staged through the same `hnsw.usearch.tmp`, and colocated indexes keep that file in the project root — outside every data dir, so even fully data-dir-isolated daemons collided there. The staging name is now process-scoped.

## Does an installed unit need regeneration?

**Yes.** `ExitTimeOut` lives in the plist, not the binary. An already-installed LaunchAgent keeps launchd's 5 s default until its plist is re-rendered and re-bootstrapped — upgrading the binary alone does not pick it up. Operators re-run the installer's service setup. In the meantime the daemon does not lose more than it did before: with a 5 s real window it flushes fewer indexes than it plans to, which is exactly the pre-fix outcome, minus the mid-write kill. `TRUSTY_TERMINATION_GRACE_SECS` lets a host whose supervisor window cannot be raised declare the true number.

**The owner's live unit was not regenerated and no `launchctl` command was run against it.**

## Safety

No live daemon was touched. Everything here is verified through pure unit tests over seams — `identify`/`plan` take argv/environ/data-dir as parameters, `ShutdownBudget` takes an explicit window, `staging_path` is a pure path function. No daemon was started, no port was bound, no signal was sent, and `launchctl` was never invoked. The owner's trusty-search 0.42.2 was left alone.

## Regression tests, demonstrated by reverting

Each fix was reverted in place, the tests run, and the fix restored.

**#4395 — reverted `plan` to confirm every candidate (the pre-fix "bare pid list IS the kill list"):**
```
test commands::start::reap_orphans::tests::plan_spares_an_unidentifiable_candidate ... FAILED
test commands::start::reap_orphans::tests::plan_confirms_only_our_own_data_dir ... FAILED
assertion `left == right` failed: only the daemon on our own data dir may be reaped — pid 20 is a healthy production daemon and pid 30 could not be identified (#4395)
test result: FAILED. 9 passed; 2 failed; 0 ignored; 0 measured; 353 filtered out
```

**#4393 — reverted `flush_deadline_for` to hand the size-scaled deadline through unclamped:**
```
test service::shutdown_budget::tests::flush_deadline_is_clamped_to_the_remaining_window ... FAILED
test service::shutdown_budget::tests::exhausted_budget_mints_no_deadline ... FAILED
test service::shutdown_flush::tests::shutdown_flush_skips_every_index_when_the_window_is_spent ... FAILED
test service::shutdown_flush::tests::flush_bounded_returns_on_blocking_work ... FAILED
test service::shutdown_flush::tests::flush_bounded_survives_single_worker_when_blocking_work_is_offloaded ... FAILED
test result: FAILED. 11 passed; 5 failed; 0 ignored; 0 measured; 1448 filtered out
```

**#4393 — removed the `ExitTimeOut` key from the renderer:**
```
test launchd::tests::render_plist_declares_exit_timeout ... FAILED
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 256 filtered out
```

**#4395 — reverted the staging name to the shared `hnsw.usearch.tmp`:**
```
test core::store::tests::test_staging_path_is_process_scoped ... FAILED
staging name must be scoped to this process; got hnsw.usearch.tmp
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1463 filtered out
```

No coverage was weakened to reach green: no `#[ignore]`, no `cfg`-gating, no `--exclude`. The one visibility widening (`MIN_FLUSH_TIMEOUT_SECS` from `pub(crate)` to `pub`) exists because the `trusty-search` bin re-exports the lib's modules into its own `crate::` namespace, so the CLI-side window assertions are a different crate to the compiler.

## Gates

```
cargo test -p trusty-search
test result: ok. 1463 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out; finished in 44.05s   (lib)
test result: ok. 361 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out; finished in 0.33s     (bin)
  + 12 integration binaries, all ok, 0 failed

cargo test -p trusty-common
test result: ok. 251 passed; 0 failed; 6 ignored; 0 measured; 0 filtered out; finished in 0.74s

cargo test -p trusty-installer
test result: ok. 551 passed; 0 failed; 4 ignored; 0 measured; 0 filtered out; finished in 2.03s

cargo clippy -p trusty-search -p trusty-common -p trusty-installer --all-targets -- -D warnings   exit 0
cargo fmt --check                                                                                 exit 0
scripts/check_line_cap.sh            3660 files, 7 allowlisted, 0 violations — OK
scripts/check_test_pointers.sh       21198 citations, 0 dangling — OK
scripts/check_sld.sh                 55 specs + 3067 code files, 0 errors, 0 warnings
scripts/check_doc_numbers.sh         98 docs / 92 claims, 0 violations — OK
scripts/check_changelog_fragment.sh  all 3 crates with source changes recorded
```

No version bumps — 0.42.2 is published and no gate asked for one.

Closes #4393
Closes #4395

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
