### PR TITLE
fix(trusty-code): force the test-harness guard on spawned `tcode` children (follow-on to #4864)

### DIFF
--- a/crates/trusty-code/tests/support/mod.rs
+++ b/crates/trusty-code/tests/support/mod.rs
@@ -223,6 +223,14 @@ impl StdioSession {
     ) -> Self {
         let mut cmd = tokio::process::Command::new(env!("CARGO_BIN_EXE_tcode"));
         cmd.arg("serve");
+        // #4255: the child is `target/<profile>/tcode`, not a `deps/` test
+        // binary, so it cannot detect the harness from its own path — and
+        // `tcode serve` warms its working project into whatever trusty-search
+        // daemon it discovers. Without this the e2e suite registered one
+        // `$TMPDIR/.tmpXXXXXX` fixture root per target in the operator's live
+        // registry. Setting `HOME` is not enough: on macOS `data_local_dir()`
+        // goes through NSFileManager, which ignores `$HOME`.
+        cmd.env(trusty_common::test_harness::FORCE_ENV, "1");
         for (key, value) in extra_envs {
             cmd.env(key, value);
         }
@@ -378,6 +386,10 @@ pub async fn spawn_http_daemon_with_env(
         .arg("--project")
         .arg(project)
         .args(["--http", "--port", "0"]);
+    // #4255: same reason as `spawn_inner` — the spawned `tcode` cannot detect
+    // the test harness from its own path, and would warm `project` (a
+    // `tempfile` fixture) into the operator's live trusty-search registry.
+    cmd.env(trusty_common::test_harness::FORCE_ENV, "1");
     for (key, value) in envs {
         cmd.env(key, value);
     }


### PR DESCRIPTION
Follow-on to #4864 (squash `da1e8dcb`, trusty-search 0.42.3). That PR made the
live index registry unreachable from tests; this one covers the case its own
module doc calls out as out of scope — **spawned child processes**.

## Defect

`trusty_common::test_harness::running_under_test_harness()` decides from the
running executable's path: cargo builds test binaries into
`target/<profile>/deps/<name>-<hash>`, and nothing a user runs sits in `deps/`.
That is per-process. trusty-code's e2e suite spawns the real binary, which
resolves to `target/<profile>/tcode` — outside `deps/` — so the child reports
"not a test" and `tcode serve` warms its `tempfile` fixture project into
whatever trusty-search daemon it discovers. `crates/trusty-common/src/test_harness.rs`
names this boundary and says such a child must be told explicitly.

Setting `HOME` on the child does not cover it: on macOS `data_local_dir()`
resolves through NSFileManager, which ignores `$HOME`.

## Evidence

Measured against merged main at `eb8f855a`, in a clean worktree, with the
operator's real trusty-search daemon live:

| | index entries in `~/Library/Application Support/trusty-search/indexes.toml` |
|---|---|
| before `cargo test -p trusty-code --tests` | 80 |
| after | **88** |

All eight new entries were `$TMPDIR/.tmp*` fixture roots — no real project
paths:

```
root_path = "/private/var/folders/.../T/.tmp06njgq"
root_path = "/private/var/folders/.../T/.tmpHTYdpp"
root_path = "/private/var/folders/.../T/.tmpfOScI6"
root_path = "/private/var/folders/.../T/.tmplwJzOt"
root_path = "/private/var/folders/.../T/.tmpomqXOn"
root_path = "/private/var/folders/.../T/.tmpp19mOV"
root_path = "/private/var/folders/.../T/.tmprI3TuE"
root_path = "/private/var/folders/.../T/.tmpzjfLuv"
```

With this commit applied, the same run on the same machine: 88 → 88, zero new
roots.

## Resolution

Set `TRUSTY_TEST_HARNESS=1` on the child at trusty-code's two shared
`tests/support` spawn points — `StdioSession::spawn_inner` and
`spawn_http_daemon_with_env` — which every `tcode serve` in the e2e suite goes
through. Two lines, not 30 call sites.

Test-only change: no crate `src/**` path is touched, so no changelog fragment
and no version bump are required (`check_changelog_fragment.sh` and
`check-pr-version-bump.sh` both confirm).

## Scope

This branch previously carried a full independent fix for #4255, developed
concurrently with #4864. Everything it duplicated has been dropped; it is now
rebased onto `eb8f855a` and reduced to the one commit main does not already
have.

## Gates

```
cargo test -p trusty-code --tests                                   EXIT=0
cargo clippy --workspace --all-targets (CI exclusions) -D warnings  EXIT=0
cargo fmt --check                                                   EXIT=0
scripts/check_line_cap.sh          3674 files, 0 violations
scripts/check_sld.sh               0 errors, 0 warnings
scripts/check_test_pointers.sh     21388 citations, 0 dangling
scripts/check_changelog_fragment.sh  test-only — OK
scripts/check-pr-version-bump.sh     no crates/<crate>/src/** changed — OK
```

Refs #4255

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
