### PR TITLE
fix(trusty-mpm): corroborate a removed worktree against its worktree root, not its parent (#4872)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4872-prune-worktree-root-ancestor.md
+++ b/crates/trusty-mpm/changelog.d/4872-prune-worktree-root-ancestor.md
@@ -1,0 +1,5 @@
+Fixed
+
+- `tm ls` auto-prune now clears dead session records whose git worktree was fully removed (closes [#4872](https://github.com/bobmatnyc/trusty-tools/issues/4872))
+  - `git worktree remove` deletes leaf and parent together, so the old immediate-parent probe read the removal as an unmounted volume and the record could never advance — it was never even marked in `auto-prune-seen.json`
+  - absence is now corroborated against the nearest surviving worktree root (`.base/.worktrees`, `.claude/worktrees`); when that root is gone too, the record is still kept, so an unplugged external volume cannot mass-tombstone the sessions on it

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
@@ -395,15 +395,24 @@ async fn workspace_verified_gone(s: &ManagedSessionSummary) -> bool {
 /// What: `(parent-dir-name, container-dir-name)` pairs matched against a
 /// candidate's ancestors — `.base/.worktrees` (session worktrees) and
 /// `.claude/worktrees` (the worktree root `CLAUDE.md` documents).
-const WORKTREE_ROOT_MARKERS: [(&str, &str); 2] =
+const WORKTREE_CONTAINER_MARKERS: [(&str, &str); 2] =
     [(".base", ".worktrees"), (".claude", "worktrees")];
 
-/// Whether `dir` is one of the [`WORKTREE_ROOT_MARKERS`] container directories.
+/// Whether `dir` is a worktree CONTAINER — the directory that HOLDS worktrees,
+/// never an individual worktree itself.
 ///
-/// What: matches on the LAST TWO path components only, so it holds for any
-/// checkout location and for nested worktrees alike.
+/// 🔴 Read the name literally: this is `true` for `.base/.worktrees` and
+/// `.claude/worktrees`, and `false` for every worktree inside them. It is the
+/// exact OPPOSITE of `session_manager::worktree_safety::is_worktree_root`, which
+/// asks whether a path is the root of ONE worktree (`git rev-parse
+/// --show-toplevel`). The two answer contradictory questions about the same
+/// paths, so they must never share a name (PR #4874 review).
+///
+/// What: matches the LAST TWO path components against
+/// [`WORKTREE_CONTAINER_MARKERS`], so it holds for any checkout location and for
+/// nested worktrees alike.
 /// Test: `auto_prune_clears_record_whose_worktree_root_survived_the_removal`.
-fn is_worktree_root(dir: &Path) -> bool {
+fn is_worktree_container(dir: &Path) -> bool {
     let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
         return false;
     };
@@ -414,7 +423,7 @@ fn is_worktree_root(dir: &Path) -> bool {
     else {
         return false;
     };
-    WORKTREE_ROOT_MARKERS
+    WORKTREE_CONTAINER_MARKERS
         .iter()
         .any(|(p, c)| *p == parent && *c == name)
 }
@@ -422,34 +431,34 @@ fn is_worktree_root(dir: &Path) -> bool {
 /// Decide whether an absent `candidate` is absent because something was DELETED
 /// (corroborated) or because its filesystem is unreachable (#4872).
 ///
-/// Why: see [`WORKTREE_ROOT_MARKERS`]. This deliberately does NOT settle for
+/// Why: see [`WORKTREE_CONTAINER_MARKERS`]. This deliberately does NOT settle for
 /// "some ancestor exists" — `/Volumes` survives every unmount, so that weaker
 /// rule would reinstate exactly the mass-tombstone the guard was written to
 /// prevent.
-/// What: walks the ancestors nearest-first. When any [`is_worktree_root`]
+/// What: walks the ancestors nearest-first. When any [`is_worktree_container`]
 /// ancestor still exists, the tree below it was removed — corroborated. When the
 /// path has such an ancestor but NONE of them exist, the whole checkout is
-/// unreachable — not corroborated. A path with no worktree-root ancestor at all
+/// unreachable — not corroborated. A path with no container ancestor at all
 /// falls back to the original immediate-parent rule, unchanged.
 /// Test: `auto_prune_clears_record_whose_worktree_root_survived_the_removal`,
 /// `auto_prune_keeps_record_when_the_worktree_root_itself_is_gone`,
 /// `auto_prune_keeps_record_whose_parent_directory_is_unreachable`.
 async fn absence_corroborated(candidate: &Path) -> bool {
-    let mut saw_worktree_root = false;
+    let mut saw_container = false;
     for ancestor in candidate
         .ancestors()
         .skip(1)
-        .filter(|a| is_worktree_root(a))
+        .filter(|a| is_worktree_container(a))
     {
-        saw_worktree_root = true;
+        saw_container = true;
         if tokio::fs::try_exists(ancestor).await.unwrap_or(false) {
             return true;
         }
     }
-    if saw_worktree_root {
+    if saw_container {
         return false;
     }
-    // No worktree root in this path: fall back to the immediate parent. A path
+    // No worktree container in this path: fall back to the immediate parent. A path
     // with no parent (a bare relative name, or the filesystem root itself) has
     // nothing to corroborate against, so refuse to call it gone.
     match candidate.parent() {

--- a/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/session_picker_prune.rs
@@ -341,25 +341,26 @@ fn workdir_candidates(s: &ManagedSessionSummary) -> [Option<&str>; 2] {
 ///     none is unverifiable, and is kept);
 ///   * every candidate's probe came back a definitive `Ok(false)`. A probe
 ///     `Err` (permission denied, transient I/O) counts as "possibly present";
-///   * every candidate's PARENT DIRECTORY exists — see below.
+///   * every candidate's absence is CORROBORATED by a surviving directory above
+///     it ([`absence_corroborated`]) — see below.
 ///
-/// 🔴 The parent check is not defensive padding, it is the whole point of the
-/// word "verified". `try_exists("/Volumes/Unplugged/work/proj")` returns
+/// 🔴 The reachability check is not defensive padding, it is the whole point of
+/// the word "verified". `try_exists("/Volumes/Unplugged/work/proj")` returns
 /// `Ok(false)`, NOT `Err`, when the volume is not mounted — ENOENT on an
 /// intermediate component is indistinguishable from ENOENT on the leaf. Without
-/// this check, unplugging an external drive reads as "verified gone" for every
-/// session on it, and one `tm ls` tombstones the lot. Requiring the parent to
-/// exist means the only thing we ever call gone is a leaf missing from a
-/// directory we can still see. This errs toward keeping — a workspace whose
-/// whole parent tree was deleted is kept rather than cleared, which costs one
-/// stale row and risks nothing. Measured 2026-08-03: 4 of 5 spot-checked
-/// stopped workspaces still existed on disk.
+/// it, unplugging an external drive reads as "verified gone" for every session
+/// on it, and one `tm ls` tombstones the lot. The only thing we ever call gone
+/// is a leaf missing from a directory we can still see. This errs toward
+/// keeping — costing one stale row and risking nothing. Measured 2026-08-03:
+/// 4 of 5 spot-checked stopped workspaces still existed on disk.
 ///
 /// What: for each of [`workdir_candidates`], `tokio::fs::try_exists` on the path
-/// itself and on `Path::parent()`.
+/// itself, then [`absence_corroborated`] on the surviving tree above it.
 /// Test: `auto_prune_clears_stopped_record_whose_workspace_is_gone`,
 /// `auto_prune_keeps_stopped_record_whose_workspace_still_exists`,
-/// `auto_prune_keeps_record_whose_parent_directory_is_unreachable`.
+/// `auto_prune_keeps_record_whose_parent_directory_is_unreachable`,
+/// `auto_prune_clears_record_whose_worktree_root_survived_the_removal`,
+/// `auto_prune_keeps_record_when_the_worktree_root_itself_is_gone`.
 async fn workspace_verified_gone(s: &ManagedSessionSummary) -> bool {
     let mut probed_any = false;
     for candidate in workdir_candidates(s).into_iter().flatten() {
@@ -370,18 +371,91 @@ async fn workspace_verified_gone(s: &ManagedSessionSummary) -> bool {
             Ok(true) | Err(_) => return false,
             Ok(false) => {}
         }
-        // #4702: the leaf is absent — but is its directory even reachable? An
-        // unmounted volume answers `Ok(false)` for every path under it.
-        let Some(parent) = std::path::Path::new(candidate).parent() else {
-            // No parent (a bare relative name, or the filesystem root itself) —
-            // nothing to corroborate against, so refuse to call it gone.
-            return false;
-        };
-        if !tokio::fs::try_exists(parent).await.unwrap_or(false) {
+        // #4872: the leaf is absent — corroborate against the nearest surviving
+        // worktree root, because `git worktree remove` takes leaf and parent
+        // together and a parent-only probe can never tell that apart.
+        if !absence_corroborated(std::path::Path::new(candidate)).await {
             return false;
         }
     }
     probed_any
+}
+
+/// Directory-name pairs naming a git-worktree CONTAINER — the stable root under
+/// which this project's worktrees are created and removed (#4872).
+///
+/// Why: `git worktree remove` unlinks the whole tree in one operation, so a
+/// removed worktree's leaf, its parent and its grandparent all vanish together.
+/// A parent-only probe therefore cannot distinguish "the worktree was removed"
+/// from "the volume is unmounted", and #4872's four stuck records could never
+/// advance. The container directory is not itself part of any worktree, so it
+/// survives every removal and disappears only when the filesystem holding it is
+/// genuinely unreachable — which is exactly the corroborating anchor the
+/// immediate parent fails to be.
+/// What: `(parent-dir-name, container-dir-name)` pairs matched against a
+/// candidate's ancestors — `.base/.worktrees` (session worktrees) and
+/// `.claude/worktrees` (the worktree root `CLAUDE.md` documents).
+const WORKTREE_ROOT_MARKERS: [(&str, &str); 2] =
+    [(".base", ".worktrees"), (".claude", "worktrees")];
+
+/// Whether `dir` is one of the [`WORKTREE_ROOT_MARKERS`] container directories.
+///
+/// What: matches on the LAST TWO path components only, so it holds for any
+/// checkout location and for nested worktrees alike.
+/// Test: `auto_prune_clears_record_whose_worktree_root_survived_the_removal`.
+fn is_worktree_root(dir: &Path) -> bool {
+    let Some(name) = dir.file_name().and_then(|n| n.to_str()) else {
+        return false;
+    };
+    let Some(parent) = dir
+        .parent()
+        .and_then(Path::file_name)
+        .and_then(|n| n.to_str())
+    else {
+        return false;
+    };
+    WORKTREE_ROOT_MARKERS
+        .iter()
+        .any(|(p, c)| *p == parent && *c == name)
+}
+
+/// Decide whether an absent `candidate` is absent because something was DELETED
+/// (corroborated) or because its filesystem is unreachable (#4872).
+///
+/// Why: see [`WORKTREE_ROOT_MARKERS`]. This deliberately does NOT settle for
+/// "some ancestor exists" — `/Volumes` survives every unmount, so that weaker
+/// rule would reinstate exactly the mass-tombstone the guard was written to
+/// prevent.
+/// What: walks the ancestors nearest-first. When any [`is_worktree_root`]
+/// ancestor still exists, the tree below it was removed — corroborated. When the
+/// path has such an ancestor but NONE of them exist, the whole checkout is
+/// unreachable — not corroborated. A path with no worktree-root ancestor at all
+/// falls back to the original immediate-parent rule, unchanged.
+/// Test: `auto_prune_clears_record_whose_worktree_root_survived_the_removal`,
+/// `auto_prune_keeps_record_when_the_worktree_root_itself_is_gone`,
+/// `auto_prune_keeps_record_whose_parent_directory_is_unreachable`.
+async fn absence_corroborated(candidate: &Path) -> bool {
+    let mut saw_worktree_root = false;
+    for ancestor in candidate
+        .ancestors()
+        .skip(1)
+        .filter(|a| is_worktree_root(a))
+    {
+        saw_worktree_root = true;
+        if tokio::fs::try_exists(ancestor).await.unwrap_or(false) {
+            return true;
+        }
+    }
+    if saw_worktree_root {
+        return false;
+    }
+    // No worktree root in this path: fall back to the immediate parent. A path
+    // with no parent (a bare relative name, or the filesystem root itself) has
+    // nothing to corroborate against, so refuse to call it gone.
+    match candidate.parent() {
+        Some(parent) => tokio::fs::try_exists(parent).await.unwrap_or(false),
+        None => false,
+    }
 }
 
 /// Whether a record's lifecycle state makes it eligible for a record-only

--- a/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
+++ b/crates/trusty-mpm/src/bin/tm/tests_behavior_d_tests.rs
@@ -2728,6 +2728,135 @@ async fn auto_prune_keeps_record_whose_parent_directory_is_unreachable() {
     handle.abort();
 }
 
+/// #4872: `git worktree remove` deletes the leaf, its parent AND its
+/// grandparent in one operation, so the parent-only probe left four dead records
+/// permanently stuck — never pruned, and never even marked in
+/// `auto-prune-seen.json`, so repeated `tm ls` could not advance them.
+///
+/// What: the two shapes actually observed on 2026-08-05 —
+/// `.claude/worktrees/critic-4850/crates/trusty-mpm` and
+/// `.base/.worktrees/qa-4850/crates/trusty-mpm` — with the worktree ROOT
+/// (`.claude/worktrees`, `.base/.worktrees`) still present and everything below
+/// it removed. That root surviving is what proves the removal was a deletion,
+/// not an unmount.
+///
+/// Fails before the fix: `workspace_verified_gone` returned `false` because the
+/// immediate parent (`crates/`) was gone too, so `pruned` stayed 0 forever.
+#[tokio::test]
+async fn auto_prune_clears_record_whose_worktree_root_survived_the_removal() {
+    for (marker_dir, container, worktree) in [
+        (".claude", "worktrees", "critic-4850"),
+        (".base", ".worktrees", "qa-4850"),
+    ] {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        let marker_path = root.path().join("seen.json");
+        let worktree_root = root.path().join(marker_dir).join(container);
+        std::fs::create_dir_all(&worktree_root).expect("create worktree root");
+        // The worktree itself, and every level under it, is gone.
+        let removed = worktree_root
+            .join(worktree)
+            .join("crates")
+            .join("trusty-mpm");
+        let (url, captured, handle) = spawn_recording_decommission_stub().await;
+        let client = reqwest::Client::new();
+
+        let first = auto_prune_dead_records_at(
+            &client,
+            &url,
+            vec![stopped_session_at("tm-deadrt40493-01", &removed)],
+            &marker_path,
+            Some(HashSet::new()),
+        )
+        .await;
+        assert_eq!(first.pruned, 0, "{container}: first sighting never prunes");
+        assert_eq!(
+            first.pending, 1,
+            "{container}: the record must be RECORDED as dead — a record that \
+             never reaches `pending` never gets a marker, which is why #4872's \
+             four records could not advance across repeated `tm ls` calls"
+        );
+
+        backdate_sightings(&marker_path, 11);
+        let second = auto_prune_dead_records_at(
+            &client,
+            &url,
+            vec![stopped_session_at("tm-deadrt40493-01", &removed)],
+            &marker_path,
+            Some(HashSet::new()),
+        )
+        .await;
+        assert_eq!(
+            second.pruned, 1,
+            "{container}: a removed worktree whose ROOT still exists is \
+             verifiably deleted, not unmounted, and must be cleared"
+        );
+        assert!(second.kept.is_empty(), "{container}: nothing left to keep");
+        assert_eq!(
+            captured.lock().expect("capture lock").len(),
+            1,
+            "{container}: exactly one decommission call"
+        );
+
+        handle.abort();
+    }
+}
+
+/// #4872, the safety half: the guard's ORIGINAL purpose must survive the fix. An
+/// unmounted volume answers `Ok(false)` for every path under it, including the
+/// worktree root — so nothing is corroborated and nothing may be cleared.
+///
+/// What: the same two worktree shapes, but the whole checkout sits under a
+/// directory that does not exist. The tempdir ABOVE it does exist, standing in
+/// for `/Volumes` — which survives every unmount. A fix that settled for "some
+/// ancestor exists" would pass the sibling test above and mass-tombstone here;
+/// this test is what rules that implementation out.
+#[tokio::test]
+async fn auto_prune_keeps_record_when_the_worktree_root_itself_is_gone() {
+    for (marker_dir, container, worktree) in [
+        (".claude", "worktrees", "critic-4850"),
+        (".base", ".worktrees", "qa-4850"),
+    ] {
+        let root = tempfile::TempDir::new().expect("tempdir");
+        let marker_path = root.path().join("seen.json");
+        // `root` exists; `unmounted-volume` and everything below it does not.
+        let removed = root
+            .path()
+            .join("unmounted-volume")
+            .join(marker_dir)
+            .join(container)
+            .join(worktree)
+            .join("crates")
+            .join("trusty-mpm");
+        let (url, captured, handle) = spawn_recording_decommission_stub().await;
+        let client = reqwest::Client::new();
+
+        for round in 0..3 {
+            let outcome = auto_prune_dead_records_at(
+                &client,
+                &url,
+                vec![stopped_session_at("on-the-volume", &removed)],
+                &marker_path,
+                Some(HashSet::new()),
+            )
+            .await;
+            assert_eq!(
+                outcome.pruned, 0,
+                "{container} round {round}: an absent worktree ROOT means the \
+                 filesystem is unreachable, not that the worktree was removed"
+            );
+            if marker_path.exists() {
+                backdate_sightings(&marker_path, 11);
+            }
+        }
+        assert!(
+            captured.lock().expect("capture lock").is_empty(),
+            "{container}: no decommission may be issued for an unreachable volume"
+        );
+
+        handle.abort();
+    }
+}
+
 /// Change 3, second half (PR #4725 review): the daemon's `unresumable` verdict
 /// alone must NOT clear a record whose parent is unreachable.
 ///


### PR DESCRIPTION
Closes #4872

## Defect

`workspace_verified_gone` returned `false` unless the workspace path's IMMEDIATE PARENT still existed on disk. `git worktree remove` deletes the whole tree in one operation, so the leaf, its parent and its grandparent vanish together — indistinguishable to a parent-only probe from the unmounted-volume case the guard was written to protect against (`try_exists` answers `Ok(false)`, not `Err`, under a missing mount point).

`is_dead_record` therefore returned `false` forever, the record landed in `kept`, and no marker was ever written to `~/.trusty-mpm/auto-prune-seen.json` — so repeated `tm ls` calls could never advance it. Four records observed stuck on 2026-08-05: `tm-deadrt40493-01`, `tm-deadrt90908-01`, `tm-deadrt7897-01`, `tm-deadrt55373-01`.

## Resolution

Absence is now corroborated against the nearest surviving worktree ROOT — `.base/.worktrees` or `.claude/worktrees` — instead of the immediate parent. That directory is not itself part of any worktree, so it survives every `git worktree remove` and disappears only when the filesystem holding it is genuinely unreachable.

- worktree root still exists → the tree below it was deleted → verified gone, prune it
- the path has such an ancestor but none of them exist → the checkout is unreachable → keep
- the path has no worktree-root ancestor at all → the original immediate-parent rule, unchanged

`tm session prune`'s manual path is untouched.

## The guard's original purpose is preserved, and pinned

`auto_prune_keeps_record_when_the_worktree_root_itself_is_gone` puts the whole checkout under a directory that does not exist, while the tempdir ABOVE it does — standing in for `/Volumes`, which survives every unmount. A "walk up until some ancestor exists" implementation would pass the positive test and mass-tombstone here; this test rules it out. `auto_prune_keeps_record_whose_parent_directory_is_unreachable` and `auto_prune_ignores_daemon_unresumable_when_parent_is_unreachable` still pass unchanged.

## Tests

| Test | Before | After |
|---|---|---|
| `auto_prune_clears_record_whose_worktree_root_survived_the_removal` | FAILED (`pending: 0`, no marker written) | ok |
| `auto_prune_keeps_record_when_the_worktree_root_itself_is_gone` | ok (regression guard) | ok |

Both cover the two observed shapes: `.claude/worktrees/critic-4850/crates/trusty-mpm` and `.base/.worktrees/qa-4850/crates/trusty-mpm`.

Fail-before, on `origin/main`'s `session_picker_prune.rs`:

```
test tests_behavior_d::auto_prune_clears_record_whose_worktree_root_survived_the_removal ... FAILED
assertion `left == right` failed: worktrees: the record must be RECORDED as dead — a record
that never reaches `pending` never gets a marker, which is why #4872's four records could not
advance across repeated `tm ls` calls
  left: 0
 right: 1
test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 1437 filtered out
```

## Gates — Rust Test Ladder rung 5 (process lifecycle)

This predicate gates session decommission, which force-removes worktrees and deletes branches.

| Command | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-mpm` | EXIT=0 — 4572 passed, 0 failed, 7 ignored (lib); 1438 passed ×2 (bin `tm`); all other targets ok |
| `cargo test -p trusty-mpm -- --include-ignored` | 2 pre-existing environmental failures, see below |
| `bash scripts/check_line_cap.sh` | EXIT=0 |
| `bash scripts/check_sld.sh` | EXIT=0 |
| `bash scripts/check_changelog_fragment.sh` | EXIT=0 |

### Pre-existing `--include-ignored` failures — not caused by this branch

The diff touches three files, all under `crates/trusty-mpm/src/bin/tm/` plus a changelog fragment. It touches zero library files, so the `--lib` test binary is byte-identical to `origin/main`.

- `meta_demo_e2e::meta_run_demo_writes_and_verifies_artifact` — reproduced identically on this worktree with the branch's changes stashed: `launch_outcome: "timed-out"` after 187s. It launches a real Claude Code session; it times out on this machine regardless of the diff.
- `daemon::managed_routes::staleness_bench_tests::bench_stale_assets_for_many` — a load-sensitive benchmark. It failed once under a fully loaded run, then passed in isolation on the clean baseline, passed in a full clean-baseline `--lib --include-ignored` run (4579 passed, 0 failed), and passed again on the second run with these changes.

Change-specific gates pass. Neither failing test resides in a file this branch modifies.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools