### PR TITLE
spike(trusty-search): measure anydoc against the native pdf/docx/xlsx extractors — NO-GO on wholesale replacement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,8 +24,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
- "cipher",
+ "cipher 0.4.4",
  "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8eb277bec05f56a0e0591f155a484cbd0f4f07ff2905051a48c72f004f7ed58"
+dependencies = [
+ "cipher 0.5.2",
+ "cpubits",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -170,6 +181,23 @@ dependencies = [
  "anstyle",
  "once_cell_polyfill",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anydoc"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35ebd211acf8cc346d82dbdffac68509be8963384cb0c11f375a827d3c49445c"
+dependencies = [
+ "calamine",
+ "cfb 0.14.0",
+ "csv",
+ "encoding_rs",
+ "flate2",
+ "log",
+ "pdf-inspector",
+ "quick-xml",
+ "zip 8.6.0",
 ]
 
 [[package]]
@@ -496,7 +524,7 @@ dependencies = [
  "fastrand",
  "hex",
  "http 1.4.0",
- "sha1",
+ "sha1 0.10.6",
  "time",
  "tokio",
  "tracing",
@@ -1125,6 +1153,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
@@ -1255,6 +1284,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1281,12 +1319,13 @@ dependencies = [
 
 [[package]]
 name = "calamine"
-version = "0.36.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6975084f43060e56343ffba7f9731fa52a7dcf2e1cd8e2459fd4c6bf4a1bff59"
+checksum = "5fa68281b1a76b54a62156474adb06bb380a67e07dd60656e3217152b42183f3"
 dependencies = [
  "atoi_simd",
  "byteorder",
+ "chrono",
  "codepage",
  "encoding_rs",
  "fast-float2",
@@ -1492,7 +1531,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26b52a9543ae338f279b96b0b9fed9c8093744685043739079ce85cd58f289a6"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -1522,6 +1561,17 @@ dependencies = [
  "byteorder",
  "fnv",
  "uuid",
+]
+
+[[package]]
+name = "cfb"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a347dcabdae9c31b0825fd6a8bed285ec9c2acb89c47827126d52fa4f59cece3"
+dependencies = [
+ "fnv",
+ "uuid",
+ "web-time",
 ]
 
 [[package]]
@@ -1633,7 +1683,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common 0.1.7",
- "inout",
+ "inout 0.1.4",
+]
+
+[[package]]
+name = "cipher"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
+dependencies = [
+ "crypto-common 0.2.2",
+ "inout 0.2.2",
 ]
 
 [[package]]
@@ -1967,6 +2027,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "cpubits"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -2490,6 +2556,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eed2c4702fa172d1ce21078faa7c5203e69f5394d48cc436d25928394a867a2"
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2638,6 +2710,7 @@ dependencies = [
  "const-oid",
  "crypto-common 0.2.2",
  "ctutils",
+ "zeroize",
 ]
 
 [[package]]
@@ -2851,7 +2924,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a8bfa975b1aec2145850fcaa1c6fe269a16578c44705a532ae3edc92b8881c7"
 dependencies = [
- "cipher",
+ "cipher 0.4.4",
 ]
 
 [[package]]
@@ -5030,7 +5103,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
- "cfb",
+ "cfb 0.7.3",
 ]
 
 [[package]]
@@ -5072,6 +5145,15 @@ checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
  "block-padding",
  "generic-array",
+]
+
+[[package]]
+name = "inout"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -5218,10 +5300,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
 dependencies = [
  "jiff-static",
+ "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5233,6 +5317,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142bd39932ad231f10513df9ab62661fead8719872150b7ad02a2df79f4e141e"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
 ]
 
 [[package]]
@@ -5471,6 +5570,12 @@ dependencies = [
  "libloading 0.7.4",
  "once_cell",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -5732,11 +5837,42 @@ dependencies = [
 
 [[package]]
 name = "lopdf"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67513274c50a2b51e5f75d9e682fcf4ab064a8a9c9ae2c3c59309084882bb24d"
+dependencies = [
+ "aes 0.8.4",
+ "bitflags 2.13.1",
+ "cbc",
+ "chrono",
+ "ecb",
+ "encoding_rs",
+ "flate2",
+ "getrandom 0.4.2",
+ "indexmap 2.14.0",
+ "itoa",
+ "jiff",
+ "log",
+ "md-5",
+ "nom 8.0.0",
+ "rand 0.10.2",
+ "rangemap",
+ "rayon",
+ "sha2 0.10.9",
+ "stringprep",
+ "thiserror 2.0.18",
+ "time",
+ "ttf-parser",
+ "weezl",
+]
+
+[[package]]
+name = "lopdf"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25aab26d99567469098e64a02f42679f8965c6401263eefa31d8f2dcc37a221c"
 dependencies = [
- "aes",
+ "aes 0.8.4",
  "bitflags 2.13.1",
  "cbc",
  "ecb",
@@ -5795,6 +5931,15 @@ name = "lzma-rust2"
 version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
+name = "lzma-rust2"
+version = "0.16.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca93e534d1142d1d0dcca6d25fe302508a5dfb40b302802904577725ea0b695b"
+dependencies = [
+ "sha2 0.11.0",
+]
 
 [[package]]
 name = "mac"
@@ -6535,7 +6680,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -6922,7 +7067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "hmac-sha256",
- "lzma-rust2",
+ "lzma-rust2 0.15.7",
  "ureq 3.3.0",
 ]
 
@@ -7032,6 +7177,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
+name = "pbkdf2"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
+dependencies = [
+ "digest 0.11.3",
+ "hmac 0.13.0",
+]
+
+[[package]]
 name = "pdf-extract"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7042,9 +7197,27 @@ dependencies = [
  "encoding_rs",
  "euclid 0.20.14",
  "log",
- "lopdf",
+ "lopdf 0.42.0",
  "postscript",
  "type1-encoding-parser",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "pdf-inspector"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7475018de0880b394b7cc50f871fac0c010aa411dcd14c64074a3e640a4c05c"
+dependencies = [
+ "env_logger",
+ "include_dir",
+ "log",
+ "lopdf 0.41.0",
+ "once_cell",
+ "rayon",
+ "regex",
+ "thiserror 2.0.18",
+ "ttf-parser",
  "unicode-normalization",
 ]
 
@@ -7403,6 +7576,12 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppmd-rust"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efca4c95a19a79d1c98f791f10aebd5c1363b473244630bb7dbde1dc98455a24"
 
 [[package]]
 name = "ppv-lite86"
@@ -9096,6 +9275,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha1_smol"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10393,6 +10583,7 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "js-sys",
  "libc",
  "num-conv",
  "num_threads",
@@ -11802,6 +11993,7 @@ dependencies = [
 name = "trusty-search"
 version = "0.42.3"
 dependencies = [
+ "anydoc",
  "anyhow",
  "arc-swap",
  "async-trait",
@@ -11947,7 +12139,7 @@ dependencies = [
  "rand 0.8.6",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 1.0.69",
  "utf-8",
 ]
@@ -13909,12 +14101,25 @@ version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
+ "aes 0.9.2",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
+ "deflate64",
  "flate2",
+ "getrandom 0.4.2",
+ "hmac 0.13.0",
  "indexmap 2.14.0",
+ "lzma-rust2 0.16.5",
  "memchr",
+ "pbkdf2",
+ "ppmd-rust",
+ "sha1 0.11.0",
+ "time",
  "typed-path",
+ "zeroize",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]
@@ -13939,6 +14144,34 @@ dependencies = [
  "crc32fast",
  "log",
  "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -381,6 +381,13 @@ calamine = "0.36"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # Pinned to >=0.41 (issue #3367): 0.37.5 is vulnerable to RUSTSEC-2026-0194/0195.
 quick-xml = "0.41"
+# anydoc: MEASUREMENT SPIKE ONLY — not on the production extraction path.
+# Reached exclusively by `crates/trusty-search/examples/anydoc_spike`, which is
+# gated behind the `anydoc-spike` feature, so a default `cargo build`/`cargo
+# test` never compiles it and the shipped daemon never links it. Evaluated
+# against our native pdf/docx/xlsx extractors; see the spike PR for the
+# measurements and the adopt/decline recommendation.
+anydoc = "0.1.3"
 
 # ── [patch.crates-io] ──────────────────────────────────────────────────────
 # trusty-search and a handful of other crates depend on trusty-common by

--- a/crates/trusty-search/Cargo.toml
+++ b/crates/trusty-search/Cargo.toml
@@ -160,6 +160,11 @@ pdf-extract = { workspace = true }
 calamine = { workspace = true }
 zip = { workspace = true }
 quick-xml = { workspace = true }
+# SPIKE-ONLY, optional, default-off. Activated solely by the `anydoc-spike`
+# feature, which nothing except `examples/anydoc_spike` turns on. The shipped
+# `trusty-search` / `trusty-embedderd` binaries never link it and
+# `core::extract` never references it.
+anydoc = { workspace = true, optional = true }
 
 # ── Tree-sitter grammars (ABI 15) ──────────────────────────────────────────
 # Upgraded to tree-sitter 0.26 to align with open-mpm (issue #116) so that
@@ -330,3 +335,20 @@ candle = [
     "dep:hf-hub",
     "dep:tokenizers",
 ]
+# Throwaway measurement harness for the anydoc evaluation spike. Gates BOTH
+# the optional `anydoc` dependency and the `anydoc_spike` example, so nothing
+# on the default build path — the library, the two binaries, `cargo test`,
+# `cargo clippy --all-targets` — compiles or links anydoc. Run the harness
+# with `cargo run -p trusty-search --features anydoc-spike --example
+# anydoc_spike -- <subcommand>`. Delete this feature, the `[[example]]` block
+# below, and the optional dependency together when the spike is retired.
+anydoc-spike = ["dep:anydoc"]
+
+# Why `required-features`: without it `cargo clippy --all-targets` and
+# `cargo build --examples` would compile the harness (and therefore anydoc)
+# on a default feature set, which is exactly the inertness the spike promised
+# not to break.
+[[example]]
+name = "anydoc_spike"
+path = "examples/anydoc_spike/main.rs"
+required-features = ["anydoc-spike"]

--- a/crates/trusty-search/examples/anydoc_spike/MEASUREMENTS.md
+++ b/crates/trusty-search/examples/anydoc_spike/MEASUREMENTS.md
@@ -1,0 +1,424 @@
+# anydoc spike — raw measurements
+
+Verbatim output of `examples/anydoc_spike`. Reproduce with:
+
+```bash
+cargo run -p trusty-search --features anydoc-spike --example anydoc_spike --release -- all
+cargo run -p trusty-search --features anydoc-spike --example anydoc_spike --release -- pdf-sweep
+cargo run -p trusty-search --features anydoc-spike --example anydoc_spike --release -- real <dir>
+```
+
+The recommendation drawn from these numbers lives in the spike PR body, not
+here. This file is the evidence, kept separate so it can be regenerated
+without editing prose.
+
+## Measurement host
+
+| | |
+|---|---|
+| platform | macOS 25.5.0, aarch64 (Apple Silicon) |
+| profile | `--release` |
+| anydoc | 0.1.3 (published 2026-08-04; repo created 2026-08-03) |
+| native baseline | `trusty_search::core::extract::extract_text` at trusty-search 0.42.3 |
+| third-party PDF reference | poppler `pdftotext`, and `qpdf --check` for fixture validity |
+
+## How to read these tables
+
+- **Timing** is in-process over N repetitions, sorted, min and median reported.
+  Min is the least noisy estimate of parse cost on a shared laptop; the gap to
+  the median says how much to trust either.
+- **Peak RSS** is `getrusage(RUSAGE_SELF).ru_maxrss` reported by a child
+  process that performed exactly one extraction, minus a no-op child baseline.
+  One process per measurement, because `ru_maxrss` is a high-water mark and
+  would otherwise attribute the largest run's peak to whichever ran last.
+- **Adversarial outcomes** come from an isolated child under a 45s budget, so
+  an outcome that kills the process (`SIGABRT` is not a catchable panic) is
+  observable rather than fatal to the harness.
+- The **real-document** section prints no filename, path, or extracted
+  content. It was pointed at the operator's own documents; rows are labelled by
+  format and index, and failure messages are digit-normalised so page counts do
+  not fingerprint a file.
+
+
+---
+
+## Extracted-text shape
+
+| fixture | native | anydoc |
+|---|---|---|
+| small-memo.docx | ok (710 bytes) | ok (709 bytes) |
+| structured-report.docx | ok (5056 bytes) | ok (5356 bytes) |
+| large-report.docx | ok (160800 bytes) | ok (164479 bytes) |
+| small-sheet.xlsx | ok (1838 bytes) | ok (2162 bytes) |
+| multi-sheet.xlsx | ok (105144 bytes) | ok (119839 bytes) |
+| text-layer.pdf | ok (36 bytes) | ok (38 bytes) |
+| multi-page.pdf | ok (2192 bytes) | err: unsupported input: PDF has no extractable text (TextBased, 40 pages): OCR is required |
+| image-only.pdf | ok+warning(0 bytes): no extractable text (scanned/image PDF? OCR not supported) | err: unsupported input: PDF has no extractable text (Scanned, 1 pages): OCR is required |
+
+## Structure recovery (docx)
+
+**small-memo.docx** — 12 flat paragraphs, no structure — the shape our extractor already handles well
+
+| signal | native | anydoc |
+|---|---:|---:|
+| markdown heading lines (`#`) | 0 | 0 |
+| table delimiter rows (`| --- |`) | 0 | 0 |
+| table pipe characters | 0 | 0 |
+| occurrences of table cell text `col 0` | 0 | 0 |
+| heading text `Quarterly Operations Review` present | no | no |
+
+**structured-report.docx** — 6 headings + 4 tables (5x4) + 60 paragraphs — the structure our extractor drops
+
+| signal | native | anydoc |
+|---|---:|---:|
+| markdown heading lines (`#`) | 0 | 6 |
+| table delimiter rows (`| --- |`) | 0 | 4 |
+| table pipe characters | 0 | 140 |
+| occurrences of table cell text `col 0` | 4 | 4 |
+| heading text `Quarterly Operations Review` present | yes | yes |
+
+**large-report.docx** — 2000 paragraphs + 40 tables — throughput case
+
+| signal | native | anydoc |
+|---|---:|---:|
+| markdown heading lines (`#`) | 0 | 0 |
+| table delimiter rows (`| --- |`) | 0 | 40 |
+| table pipe characters | 0 | 1920 |
+| occurrences of table cell text `col 0` | 40 | 40 |
+| heading text `Quarterly Operations Review` present | no | no |
+
+
+## Chunk-level impact
+
+Both texts chunked with chunk_text(window=150, stride=50) — the production path.
+
+| fixture | native chunks | anydoc chunks | native lines | anydoc lines | native chars | anydoc chars |
+|---|---:|---:|---:|---:|---:|---:|
+| small-memo.docx | 1 | 1 | 24 | 23 | 710 | 709 |
+| structured-report.docx | 4 | 2 | 294 | 165 | 5056 | 5356 |
+| large-report.docx | 126 | 86 | 6400 | 4359 | 160800 | 164479 |
+| small-sheet.xlsx | 1 | 1 | 22 | 22 | 1838 | 2162 |
+| multi-sheet.xlsx | 15 | 15 | 808 | 819 | 105144 | 119839 |
+| text-layer.pdf | 1 | 1 | 3 | 1 | 36 | 38 |
+| multi-page.pdf | 1 | 0 | 3 | 0 | 2192 | 0 |
+| image-only.pdf | 0 | 0 | 0 | 0 | 0 | 0 |
+
+## Sample output (structured-report.docx, first 900 chars each)
+
+### native
+
+```
+Quarterly Operations Review
+
+This review covers the reporting period and its material variances.
+
+Section 0: Regional Detail
+
+Section 0 paragraph 0: operating expenditure tracked against plan.
+
+Section 0 paragraph 1: operating expenditure tracked against plan.
+
+Section 0 paragraph 2: operating expenditure tracked against plan.
+
+Section 0 paragraph 3: operating expenditure tracked against plan.
+
+Section 0 paragraph 4: operating expenditure tracked against plan.
+
+Section 0 paragraph 5: operating expenditure tracked against plan.
+
+Section 0 paragraph 6: operating expenditure tracked against plan.
+
+Section 0 paragraph 7: operating expenditure tracked against plan.
+
+Section 0 paragraph 8: operating expenditure tracked against plan.
+
+Section 0 paragraph 9: operating expenditure tracked against plan.
+
+Section 0 paragraph 10: operating expenditure tracked against plan.
+
+Section 0 paragraph 11: o…
+```
+
+### anydoc
+
+```
+# Quarterly Operations Review
+
+This review covers the reporting period and its material variances.
+
+## Section 0: Regional Detail
+
+Section 0 paragraph 0: operating expenditure tracked against plan.
+
+Section 0 paragraph 1: operating expenditure tracked against plan.
+
+Section 0 paragraph 2: operating expenditure tracked against plan.
+
+Section 0 paragraph 3: operating expenditure tracked against plan.
+
+Section 0 paragraph 4: operating expenditure tracked against plan.
+
+Section 0 paragraph 5: operating expenditure tracked against plan.
+
+Section 0 paragraph 6: operating expenditure tracked against plan.
+
+Section 0 paragraph 7: operating expenditure tracked against plan.
+
+Section 0 paragraph 8: operating expenditure tracked against plan.
+
+Section 0 paragraph 9: operating expenditure tracked against plan.
+
+Section 0 paragraph 10: operating expenditure tracked against plan.
+
+Section 0 paragraph …
+```
+
+
+---
+
+## `merged-range.xlsx`
+
+issue #8: F1:O3 merge (3 rows x 10 cols) with only the anchor populated
+
+### native — ok (36 bytes)
+
+```
+== Merge Example ==
+Merged heading
+
+
+```
+
+### anydoc — ok (32 bytes)
+
+```
+|  |
+| --- |
+| Merged heading |
+
+```
+
+**Issue #8 assessment**
+
+| check | native | anydoc |
+|---|---|---|
+| anchor text `Merged heading` present | yes | yes |
+| non-empty output lines | 2 | 3 |
+| extracted chars | 36 | 32 |
+
+Index-level reading: the merge span is layout metadata. What reaches a chunk is the anchor's text either way, so a clipped span changes the rendered table shape without removing a searchable term — as long as the anchor text itself survives.
+
+## `hidden-content.xlsx`
+
+issue #9: one hidden row and one hidden column alongside visible cells
+
+### native — ok (64 bytes)
+
+```
+== Visibility Example ==
+Visible row	Hidden column
+Hidden row	
+
+
+```
+
+### anydoc — ok (72 bytes)
+
+```
+|  |  |
+| --- | --- |
+| Visible row | Hidden column |
+| Hidden row |  |
+
+```
+
+**Issue #9 assessment**
+
+| check | native | anydoc |
+|---|---|---|
+| `Visible row` in extracted text | yes | yes |
+| `Hidden row` in extracted text | yes | yes |
+| `Hidden column` in extracted text | yes | yes |
+
+Index-level reading: hidden cells becoming searchable text is a behaviour question, not a fidelity one — it makes content the author suppressed retrievable. Whether that is a defect depends on whether the index is meant to mirror what a reader sees or what the file contains. Both extractors' behaviour is reported above rather than judged here.
+
+
+---
+
+## Speed (wall-clock per file, milliseconds)
+
+Sample: N repetitions per (engine, file) in one process, sorted; min and median reported.
+
+| fixture | format | bytes | N | native min | native med | anydoc min | anydoc med | ratio (med) |
+|---|---|---:|---:|---:|---:|---:|---:|---:|
+| small-memo.docx | docx | 1643 | 100 | 0.03 | 0.03 | 0.05 | 0.07 | 2.10x |
+| structured-report.docx | docx | 2217 | 100 | 0.04 | 0.06 | 0.19 | 0.27 | 4.36x |
+| large-report.docx | docx | 11674 | 100 | 0.44 | 0.57 | 3.71 | 4.65 | 8.09x |
+| small-sheet.xlsx | xlsx | 2087 | 100 | 0.07 | 0.09 | 0.12 | 0.16 | 1.79x |
+| multi-sheet.xlsx | xlsx | 26446 | 100 | 1.50 | 1.94 | 4.69 | 5.45 | 2.81x |
+| text-layer.pdf | pdf | 608 | 100 | 0.03 | 0.04 | 0.06 | 0.14 | 3.97x |
+| multi-page.pdf | pdf | 12785 | 100 | 0.33 | 0.46 | 0.59 | 0.73 | 1.58x |
+| image-only.pdf | pdf | 413 | 100 | 0.02 | 0.02 | 0.04 | 0.08 | 3.74x |
+
+## Peak RSS (isolated child process, MiB)
+
+Baseline (re-exec that parses nothing): 6.4 MiB. Deltas below subtract it.
+
+| fixture | format | bytes | native peak | native Δ | anydoc peak | anydoc Δ |
+|---|---|---:|---:|---:|---:|---:|
+| small-memo.docx | docx | 1643 | 7.0 | 0.6 | 7.8 | 1.5 |
+| structured-report.docx | docx | 2217 | 7.0 | 0.7 | 8.5 | 2.1 |
+| large-report.docx | docx | 11674 | 7.6 | 1.2 | 16.0 | 9.6 |
+| small-sheet.xlsx | xlsx | 2087 | 7.5 | 1.1 | 8.0 | 1.6 |
+| multi-sheet.xlsx | xlsx | 26446 | 8.3 | 1.9 | 9.9 | 3.5 |
+| text-layer.pdf | pdf | 608 | 7.2 | 0.9 | 10.0 | 3.6 |
+| multi-page.pdf | pdf | 12785 | 7.6 | 1.2 | 11.0 | 4.6 |
+| image-only.pdf | pdf | 413 | 7.1 | 0.7 | 8.0 | 1.7 |
+
+---
+
+## Adversarial parity
+
+Each cell is one isolated child process, budget 45s. Both extractors sit behind the same 10 MiB `MAX_OFFICE_FILE_BYTES` gate in production; every fixture here is under it.
+
+| fixture | bytes | native outcome | native ms | native peak MiB | anydoc outcome | anydoc ms | anydoc peak MiB |
+|---|---:|---|---:|---:|---|---:|---:|
+| zipbomb.docx | 522560 | err: docx extraction failed: word/document.xml declares 536870953 uncompressed bytes, over the 52428800 byte cap | 152.83 | 6.9 | err: resource limit exceeded (max_entry_bytes): word/document.xml declares 536870953 decompressed bytes | 89.13 | 8.0 |
+| nested-xml.docx | 6125 | ok (200004 bytes) | 103.65 | 9.7 | err: resource limit exceeded (max_xml_depth): element nesting exceeds 256 | 175.18 | 10.8 |
+| truncated.docx | 1315 | err: docx extraction failed: invalid Zip archive: Could not find EOCD | 174.98 | 6.8 | err: malformed document: not a readable zip archive: invalid Zip archive: Could not find EOCD | 175.10 | 6.8 |
+| malformed.docx | 8196 | err: docx extraction failed: invalid Zip archive: Could not find EOCD | 170.46 | 6.8 | err: malformed document: not a readable zip archive: invalid Zip archive: Could not find EOCD | 171.99 | 6.8 |
+| zipbomb.xlsx | 523141 | ok (10 bytes) | 143.33 | 521.4 | ok (0 bytes) | 413.60 | 1034.2 |
+| truncated.xlsx | 11743 | err: spreadsheet extraction failed: Xlsx error: Zip error: invalid Zip archive: Could not find EOCD | 25.51 | 6.9 | err: malformed document: unreadable workbook: Cannot detect file format | 119.59 | 7.0 |
+| nested-objects.pdf | 21182 | ok+warning(0 bytes): no extractable text (scanned/image PDF? OCR not supported) | 175.13 | 7.2 | **SIGABRT** (uncatchable — process dies) | 173.37 | 0.0 |
+| truncated.pdf | 1712 | err: pdf extraction failed: PDF error: failed parsing cross reference table: invalid start value | 154.73 | 6.9 | err: malformed document: invalid PDF structure | 171.11 | 6.9 |
+| malformed.pdf | 8201 | err: pdf extraction failed: PDF error: failed parsing cross reference table: invalid start value | 172.77 | 6.9 | err: malformed document: invalid PDF structure | 156.27 | 6.9 |
+
+### What each fixture probes
+
+- `zipbomb.docx` — 48 KiB container, 512 MiB declared document.xml (DEFLATE null run)
+- `nested-xml.docx` — 100k-deep XML element nesting in document.xml
+- `truncated.docx` — valid docx cut off mid-archive
+- `malformed.docx` — zip magic followed by garbage — a corrupt central directory
+- `zipbomb.xlsx` — 48 KiB container, 512 MiB declared sheet1.xml (the calamine leg)
+- `truncated.xlsx` — valid xlsx cut off mid-archive
+- `nested-objects.pdf` — RUSTSEC-2026-0187 PoC: 10380-deep nested array in a page object
+- `truncated.pdf` — valid PDF cut off before the xref table
+- `malformed.pdf` — PDF header followed by garbage
+
+
+---
+
+## PDF page-count sweep
+
+| pages | bytes | poppler pdftotext chars | native chars | anydoc |
+|---:|---:|---:|---:|---|
+| 1 | 629 | 54 | 54 | err: unsupported input: PDF has no extractable text (TextBased, 1 pages): OCR is required |
+| 2 | 936 | 111 | 108 | err: unsupported input: PDF has no extractable text (TextBased, 2 pages): OCR is required |
+| 3 | 1245 | 168 | 162 | err: unsupported input: PDF has no extractable text (TextBased, 3 pages): OCR is required |
+| 4 | 1557 | 225 | 216 | err: unsupported input: PDF has no extractable text (TextBased, 4 pages): OCR is required |
+| 5 | 1868 | 282 | 270 | err: unsupported input: PDF has no extractable text (TextBased, 5 pages): OCR is required |
+| 8 | 2801 | 453 | 432 | err: unsupported input: PDF has no extractable text (TextBased, 8 pages): OCR is required |
+| 16 | 5296 | 915 | 870 | err: unsupported input: PDF has no extractable text (TextBased, 16 pages): OCR is required |
+| 40 | 12785 | 2307 | 2190 | err: unsupported input: PDF has no extractable text (TextBased, 40 pages): OCR is required |
+
+
+---
+
+## Real-document corpus
+
+Source: a directory of 67 actual documents on the measurement host. Filenames and content are deliberately omitted; rows are labelled by format and index.
+
+### Outcome summary
+
+| format | files | both extracted | native only | anydoc only | neither |
+|---|---:|---:|---:|---:|---:|
+| docx | 2 | 1 | 0 | 0 | 1 |
+| pdf | 58 | 38 | 7 | 0 | 13 |
+| xlsx | 7 | 5 | 0 | 0 | 2 |
+
+### Failure categories
+
+Error text only — anydoc's and ours both describe the parse, not the file, so no filename leaks through here.
+
+| engine | occurrences | message |
+|---|---:|---|
+| native | 13 | pdf extraction failed: PDF error: couldn't parse input: invalid file header |
+| anydoc | 13 | malformed document: not a PDF: file is empty |
+| anydoc | 5 | unsupported input: PDF has no extractable text (TextBased, N pages): OCR is required |
+| native | 2 | spreadsheet extraction failed: Xlsx error: Zip error: invalid Zip archive: Could not find EOCD |
+| anydoc | 2 | malformed document: unreadable workbook: Cannot detect file format |
+| anydoc | 2 | unsupported input: PDF has no extractable text (ImageBased, N pages): OCR is required |
+| native | 1 | docx extraction failed: invalid Zip archive: Could not find EOCD |
+| anydoc | 1 | malformed document: not a readable zip archive: invalid Zip archive: Could not find EOCD |
+
+### Per-file
+
+| file | bytes | native chars | anydoc chars | native ms | anydoc ms | native | anydoc |
+|---|---:|---:|---:|---:|---:|---|---|
+| pdf-001 | 0 | 0 | 0 | 0.04 | 0.02 | err | err |
+| pdf-002 | 100848 | 70259 | 68265 | 9.09 | 20.55 | ok | ok |
+| pdf-003 | 672057 | 36316 | 0 | 6.23 | 4.43 | ok | err |
+| pdf-004 | 895901 | 138 | 0 | 3.04 | 1.75 | ok | err |
+| pdf-005 | 0 | 0 | 0 | 0.05 | 0.01 | err | err |
+| docx-001 | 12092 | 6445 | 6850 | 0.42 | 1.88 | ok | ok |
+| pdf-006 | 1782465 | 94979 | 0 | 17.37 | 15.22 | ok | err |
+| pdf-007 | 33515 | 1851 | 1783 | 1.37 | 1.23 | ok | ok |
+| pdf-008 | 33515 | 1851 | 1783 | 1.28 | 1.50 | ok | ok |
+| pdf-009 | 168731 | 1868 | 1794 | 1.99 | 2.79 | ok | ok |
+| pdf-010 | 1367062 | 14947 | 14679 | 19.36 | 7.07 | ok | ok |
+| pdf-011 | 721126 | 39602 | 0 | 6.04 | 4.06 | ok | err |
+| pdf-012 | 613735 | 22624 | 0 | 4.24 | 3.15 | ok | err |
+| pdf-013 | 129980 | 16939 | 16618 | 4.64 | 6.65 | ok | ok |
+| pdf-014 | 1805168 | 49419 | 0 | 11.76 | 12.02 | ok | err |
+| pdf-015 | 324817 | 18452 | 17008 | 19.10 | 28.25 | ok | ok |
+| pdf-016 | 1770089 | 32153 | 32886 | 38.09 | 42.04 | ok | ok |
+| pdf-017 | 127595 | 5896 | 5748 | 4.65 | 4.82 | ok | ok |
+| pdf-018 | 124230 | 7858 | 7582 | 5.34 | 5.45 | ok | ok |
+| pdf-019 | 219382 | 11422 | 10946 | 9.88 | 9.37 | ok | ok |
+| pdf-020 | 3645188 | 88290 | 88389 | 35.99 | 73.96 | ok | ok |
+| pdf-021 | 466189 | 14193 | 13895 | 10.41 | 10.20 | ok | ok |
+| pdf-022 | 114157 | 7190 | 7071 | 4.92 | 4.74 | ok | ok |
+| pdf-023 | 0 | 0 | 0 | 0.04 | 0.02 | err | err |
+| pdf-024 | 158947 | 5478 | 5339 | 5.86 | 4.92 | ok | ok |
+| pdf-025 | 181116 | 13196 | 12798 | 8.58 | 8.07 | ok | ok |
+| pdf-026 | 6504263 | 60228 | 56493 | 26.31 | 56.56 | ok | ok |
+| xlsx-001 | 7776 | 2076 | 2516 | 0.77 | 0.48 | ok | ok |
+| xlsx-002 | 13866 | 11333 | 13158 | 0.67 | 1.10 | ok | ok |
+| xlsx-003 | 13866 | 11333 | 13158 | 0.80 | 0.76 | ok | ok |
+| xlsx-004 | 7797 | 2104 | 2544 | 0.36 | 0.28 | ok | ok |
+| pdf-027 | 322138 | 6838 | 5167 | 5.10 | 3.66 | ok | ok |
+| pdf-028 | 80483 | 6783 | 6648 | 5.26 | 10.55 | ok | ok |
+| pdf-029 | 109803 | 4853 | 4733 | 3.51 | 2.99 | ok | ok |
+| pdf-030 | 228639 | 16601 | 15951 | 11.47 | 11.82 | ok | ok |
+| pdf-031 | 186016 | 18102 | 5878 | 8.59 | 6.00 | ok | ok |
+| pdf-032 | 183380 | 7198 | 4706 | 6.92 | 4.32 | ok | ok |
+| pdf-033 | 0 | 0 | 0 | 0.03 | 0.01 | err | err |
+| pdf-034 | 66334 | 1782 | 1729 | 1.63 | 5.00 | ok | ok |
+| pdf-035 | 0 | 0 | 0 | 0.02 | 0.01 | err | err |
+| pdf-036 | 251302 | 7166 | 7024 | 5.56 | 8.92 | ok | ok |
+| pdf-037 | 149027 | 14830 | 14411 | 6.85 | 7.25 | ok | ok |
+| pdf-038 | 121328 | 8046 | 7942 | 4.08 | 5.45 | ok | ok |
+| pdf-039 | 169308 | 1590 | 1349 | 2.20 | 2.32 | ok | ok |
+| pdf-040 | 66212 | 909 | 858 | 1.97 | 2.02 | ok | ok |
+| pdf-041 | 169207 | 1508 | 1293 | 2.17 | 2.48 | ok | ok |
+| xlsx-005 | 0 | 0 | 0 | 0.03 | 0.01 | err | err |
+| docx-002 | 0 | 0 | 0 | 0.04 | 0.01 | err | err |
+| pdf-042 | 274790 | 6749 | 7346 | 11.54 | 14.86 | ok | ok |
+| pdf-043 | 175099 | 13789 | 13242 | 7.80 | 8.16 | ok | ok |
+| pdf-044 | 0 | 0 | 0 | 0.03 | 0.01 | err | err |
+| pdf-045 | 0 | 0 | 0 | 0.02 | 0.01 | err | err |
+| pdf-046 | 0 | 0 | 0 | 0.01 | 0.01 | err | err |
+| pdf-047 | 169693 | 9616 | 9424 | 5.43 | 5.92 | ok | ok |
+| pdf-048 | 146474 | 8 | 0 | 0.41 | 0.34 | ok | err |
+| pdf-049 | 147872 | 9674 | 9552 | 6.10 | 5.96 | ok | ok |
+| pdf-050 | 0 | 0 | 0 | 0.05 | 0.01 | err | err |
+| pdf-051 | 437182 | 20438 | 18786 | 15.40 | 30.41 | ok | ok |
+| pdf-052 | 0 | 0 | 0 | 0.03 | 0.01 | err | err |
+| pdf-053 | 0 | 0 | 0 | 0.02 | 0.01 | err | err |
+| pdf-054 | 0 | 0 | 0 | 0.01 | 0.01 | err | err |
+| pdf-055 | 179177 | 4375 | 4390 | 4.75 | 4.92 | ok | ok |
+| pdf-056 | 28333 | 700 | 849 | 1.53 | 1.38 | ok | ok |
+| pdf-057 | 28501 | 684 | 833 | 1.15 | 1.51 | ok | ok |
+| xlsx-006 | 8185 | 1763 | 1841 | 0.32 | 0.25 | ok | ok |
+| pdf-058 | 0 | 0 | 0 | 0.02 | 0.01 | err | err |
+| xlsx-007 | 0 | 0 | 0 | 0.02 | 0.01 | err | err |

--- a/crates/trusty-search/examples/anydoc_spike/adversarial.rs
+++ b/crates/trusty-search/examples/anydoc_spike/adversarial.rs
@@ -1,0 +1,161 @@
+//! Adversarial-parity leg.
+//!
+//! Every probe runs in a re-exec'd child under a wall-clock bound, because
+//! the outcomes worth distinguishing include ones that end the process. A
+//! stack-overflow abort (`SIGABRT`) is not a panic: `catch_unwind` does not
+//! see it, and neither does `spawn_blocking`'s `JoinError` containment, so
+//! measuring it in-process would take the harness down with it and report
+//! nothing.
+
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use crate::bench::parse_rss;
+use crate::engines::{fmt_mib, fmt_ms, Engine};
+use crate::fixtures::Corpus;
+
+/// How long a child gets before it is judged hung and killed.
+///
+/// Set above the production `EXTRACT_TIMEOUT` (30s) so "our timeout would
+/// have fired" and "the parser never terminates" stay distinguishable.
+const CHILD_BUDGET: Duration = Duration::from_secs(45);
+
+/// What a probe did, in the vocabulary that matters for a daemon.
+#[derive(Debug)]
+enum Verdict {
+    /// Returned a value. Contains the one-line summary.
+    Returned(String),
+    /// Unwinding panic — contained by `spawn_blocking`'s JoinError today.
+    Panicked,
+    /// Killed by a signal. Contains the signal number. Signal 6 (SIGABRT) is
+    /// the uncatchable stack-overflow abort; the process dies regardless of
+    /// any containment the caller wrote.
+    Signalled(i32),
+    /// Still running when the budget expired.
+    Hung,
+}
+
+impl Verdict {
+    fn cell(&self) -> String {
+        match self {
+            Verdict::Returned(s) => s.clone(),
+            Verdict::Panicked => "**PANIC** (unwinding — contained)".to_string(),
+            Verdict::Signalled(6) => "**SIGABRT** (uncatchable — process dies)".to_string(),
+            Verdict::Signalled(11) => "**SIGSEGV** (uncatchable — process dies)".to_string(),
+            Verdict::Signalled(n) => format!("**signal {n}** (uncatchable)"),
+            Verdict::Hung => format!("**HUNG** (> {}s, killed)", CHILD_BUDGET.as_secs()),
+        }
+    }
+}
+
+struct Probe {
+    verdict: Verdict,
+    elapsed: Duration,
+    peak_rss: u64,
+}
+
+pub fn run(corpus: &Corpus) {
+    let fixtures = corpus.adversarial();
+
+    println!("## Adversarial parity\n");
+    println!(
+        "Each cell is one isolated child process, budget {}s. Both extractors sit behind the same \
+         10 MiB `MAX_OFFICE_FILE_BYTES` gate in production; every fixture here is under it.\n",
+        CHILD_BUDGET.as_secs()
+    );
+    println!("| fixture | bytes | native outcome | native ms | native peak MiB | anydoc outcome | anydoc ms | anydoc peak MiB |");
+    println!("|---|---:|---|---:|---:|---|---:|---:|");
+
+    for f in &fixtures {
+        let n = probe(Engine::Native, &f.path);
+        let a = probe(Engine::Anydoc, &f.path);
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} |",
+            f.name,
+            f.size(),
+            n.verdict.cell(),
+            fmt_ms(n.elapsed),
+            fmt_mib(n.peak_rss),
+            a.verdict.cell(),
+            fmt_ms(a.elapsed),
+            fmt_mib(a.peak_rss),
+        );
+    }
+
+    println!("\n### What each fixture probes\n");
+    for f in &fixtures {
+        println!("- `{}` — {}", f.name, f.note);
+    }
+}
+
+fn probe(engine: Engine, path: &Path) -> Probe {
+    let exe = std::env::current_exe().expect("current_exe");
+    let start = Instant::now();
+    let mut child = Command::new(exe)
+        .arg("run-one")
+        .arg(engine.label())
+        .arg(path)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn probe child");
+
+    // Poll rather than `wait()` so a non-terminating parse is reported as
+    // HUNG instead of stalling the harness indefinitely.
+    let status = loop {
+        match child.try_wait().expect("try_wait") {
+            Some(s) => break Some(s),
+            None if start.elapsed() > CHILD_BUDGET => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break None;
+            }
+            None => std::thread::sleep(Duration::from_millis(25)),
+        }
+    };
+    let elapsed = start.elapsed();
+
+    let mut stdout = String::new();
+    let mut stderr = String::new();
+    if let Some(mut o) = child.stdout.take() {
+        use std::io::Read;
+        let _ = o.read_to_string(&mut stdout);
+    }
+    if let Some(mut e) = child.stderr.take() {
+        use std::io::Read;
+        let _ = e.read_to_string(&mut stderr);
+    }
+
+    let verdict = match status {
+        None => Verdict::Hung,
+        Some(s) => classify(s, &stdout, &stderr),
+    };
+    Probe {
+        verdict,
+        elapsed,
+        peak_rss: parse_rss(&stdout),
+    }
+}
+
+fn classify(status: std::process::ExitStatus, stdout: &str, stderr: &str) -> Verdict {
+    use std::os::unix::process::ExitStatusExt;
+    if let Some(sig) = status.signal() {
+        return Verdict::Signalled(sig);
+    }
+    if let Some(line) = stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("RESULT="))
+        .map(str::to_string)
+    {
+        return Verdict::Returned(line);
+    }
+    // No RESULT line and no signal: the child aborted through the panic
+    // handler (which prints to stderr and exits non-zero) or died some other
+    // way we should not silently score as success.
+    if stderr.contains("panicked at") {
+        Verdict::Panicked
+    } else {
+        Verdict::Returned(format!("no result, exit {:?}", status.code()))
+    }
+}

--- a/crates/trusty-search/examples/anydoc_spike/bench.rs
+++ b/crates/trusty-search/examples/anydoc_spike/bench.rs
@@ -1,0 +1,105 @@
+//! Speed and peak-memory leg.
+//!
+//! Timing runs in-process over many repetitions; memory runs one child
+//! process per (engine, file) so `ru_maxrss` attributes its high-water mark
+//! to exactly one extraction. The child baseline — a re-exec that parses
+//! nothing — is subtracted so the reported figure is the extraction's cost,
+//! not the process's.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::engines::{fmt_mib, fmt_ms, time_reps, Engine};
+use crate::fixtures::Corpus;
+
+/// Repetition counts, scaled down for the fixtures that are slow enough that
+/// the noise floor stops mattering.
+fn reps_for(size: u64) -> usize {
+    if size > 2 * 1024 * 1024 {
+        10
+    } else if size > 128 * 1024 {
+        30
+    } else {
+        100
+    }
+}
+
+pub fn run(corpus: &Corpus) {
+    let fixtures = corpus.benign();
+
+    println!("## Speed (wall-clock per file, milliseconds)\n");
+    println!("Sample: N repetitions per (engine, file) in one process, sorted; min and median reported.\n");
+    println!(
+        "| fixture | format | bytes | N | native min | native med | anydoc min | anydoc med | ratio (med) |"
+    );
+    println!("|---|---|---:|---:|---:|---:|---:|---:|---:|");
+
+    for f in &fixtures {
+        let size = f.size();
+        let n = reps_for(size);
+        let (n_min, n_med, _) = time_reps(n, || {
+            let _ = Engine::Native.extract(&f.path);
+        });
+        let (a_min, a_med, _) = time_reps(n, || {
+            let _ = Engine::Anydoc.extract(&f.path);
+        });
+        let ratio = a_med.as_secs_f64() / n_med.as_secs_f64().max(f64::MIN_POSITIVE);
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} | {:.2}x |",
+            f.name,
+            f.format,
+            size,
+            n,
+            fmt_ms(n_min),
+            fmt_ms(n_med),
+            fmt_ms(a_min),
+            fmt_ms(a_med),
+            ratio
+        );
+    }
+
+    println!("\n## Peak RSS (isolated child process, MiB)\n");
+    let baseline = child_peak_rss(None, Path::new("/dev/null"));
+    println!(
+        "Baseline (re-exec that parses nothing): {} MiB. Deltas below subtract it.\n",
+        fmt_mib(baseline)
+    );
+    println!("| fixture | format | bytes | native peak | native Δ | anydoc peak | anydoc Δ |");
+    println!("|---|---|---:|---:|---:|---:|---:|");
+    for f in &fixtures {
+        let n = child_peak_rss(Some(Engine::Native), &f.path);
+        let a = child_peak_rss(Some(Engine::Anydoc), &f.path);
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} |",
+            f.name,
+            f.format,
+            f.size(),
+            fmt_mib(n),
+            fmt_mib(n.saturating_sub(baseline)),
+            fmt_mib(a),
+            fmt_mib(a.saturating_sub(baseline)),
+        );
+    }
+}
+
+/// Re-exec this harness as `run-one`, returning the child's reported peak RSS
+/// in bytes. `None` runs the no-op baseline.
+fn child_peak_rss(engine: Option<Engine>, path: &Path) -> u64 {
+    let exe = std::env::current_exe().expect("current_exe");
+    let label = engine.map(|e| e.label()).unwrap_or("baseline");
+    let out = Command::new(exe)
+        .arg("run-one")
+        .arg(label)
+        .arg(path)
+        .output()
+        .expect("spawn run-one child");
+    parse_rss(&String::from_utf8_lossy(&out.stdout))
+}
+
+pub fn parse_rss(stdout: &str) -> u64 {
+    stdout
+        .lines()
+        .find_map(|l| l.strip_prefix("PEAK_RSS_BYTES="))
+        .and_then(|v| v.trim().parse().ok())
+        .unwrap_or(0)
+}

--- a/crates/trusty-search/examples/anydoc_spike/engines.rs
+++ b/crates/trusty-search/examples/anydoc_spike/engines.rs
@@ -1,0 +1,149 @@
+//! The two extractors under comparison, behind one interface, plus the
+//! process-level measurement helpers.
+//!
+//! `Native` deliberately calls `core::extract::extract_text` — the production
+//! seam, size caps and all — rather than the per-format submodules, because
+//! the spike's question is whether anydoc could replace what actually ships,
+//! not whether it beats a stripped-down parser.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Engine {
+    Native,
+    Anydoc,
+}
+
+impl Engine {
+    pub fn label(self) -> &'static str {
+        match self {
+            Engine::Native => "native",
+            Engine::Anydoc => "anydoc",
+        }
+    }
+
+    pub fn parse(s: &str) -> Option<Engine> {
+        match s {
+            "native" => Some(Engine::Native),
+            "anydoc" => Some(Engine::Anydoc),
+            _ => None,
+        }
+    }
+
+    /// Extract `path`, normalising both extractors onto `Result<String, String>`.
+    ///
+    /// The native side folds `Extracted::warning` into the Ok value's
+    /// companion flag rather than discarding it — a near-empty PDF that our
+    /// extractor flags as probably-scanned is a materially different outcome
+    /// from anydoc's hard `Unsupported` error on the same file, and averaging
+    /// those together would hide the difference.
+    pub fn extract(self, path: &Path) -> Outcome {
+        match self {
+            Engine::Native => match trusty_search::core::extract::extract_text(path) {
+                Ok(e) => Outcome::Ok {
+                    text: e.text,
+                    warning: e.warning,
+                },
+                Err(e) => Outcome::Err(e.to_string()),
+            },
+            Engine::Anydoc => match anydoc::to_markdown(path) {
+                Ok(text) => Outcome::Ok {
+                    text,
+                    warning: None,
+                },
+                Err(e) => Outcome::Err(e.to_string()),
+            },
+        }
+    }
+}
+
+pub enum Outcome {
+    Ok {
+        text: String,
+        warning: Option<String>,
+    },
+    Err(String),
+}
+
+impl Outcome {
+    pub fn text(&self) -> &str {
+        match self {
+            Outcome::Ok { text, .. } => text,
+            Outcome::Err(_) => "",
+        }
+    }
+
+    pub fn summary(&self) -> String {
+        match self {
+            Outcome::Ok {
+                text,
+                warning: Some(w),
+            } => format!("ok+warning({} bytes): {w}", text.len()),
+            Outcome::Ok {
+                text,
+                warning: None,
+            } => format!("ok ({} bytes)", text.len()),
+            Outcome::Err(e) => format!("err: {}", first_line(e)),
+        }
+    }
+}
+
+fn first_line(s: &str) -> String {
+    let line = s.lines().next().unwrap_or("").trim();
+    if line.len() > 120 {
+        format!("{}…", &line[..120])
+    } else {
+        line.to_string()
+    }
+}
+
+/// Peak resident set size of THIS process, in bytes.
+///
+/// `ru_maxrss` is a process high-water mark, which is precisely why the
+/// memory leg re-execs one child per (engine, file) measurement: read
+/// in-process across several extractions it would report the maximum over all
+/// of them and attribute it to whichever ran last.
+pub fn peak_rss_bytes() -> u64 {
+    let mut usage: libc::rusage = unsafe { std::mem::zeroed() };
+    // SAFETY: `usage` is a valid, fully-initialised (zeroed) rusage.
+    let rc = unsafe { libc::getrusage(libc::RUSAGE_SELF, &mut usage) };
+    if rc != 0 {
+        return 0;
+    }
+    let raw = usage.ru_maxrss as u64;
+    // macOS reports bytes; Linux reports kilobytes.
+    if cfg!(target_os = "macos") {
+        raw
+    } else {
+        raw * 1024
+    }
+}
+
+/// Run `f` `reps` times, returning (min, median, max) wall-clock.
+///
+/// Min is reported alongside the median because it is the least noisy
+/// estimator of the parse cost itself on a shared laptop; the spread between
+/// them is the signal for how much to trust either.
+pub fn time_reps<F: FnMut()>(reps: usize, mut f: F) -> (Duration, Duration, Duration) {
+    let mut samples = Vec::with_capacity(reps);
+    for _ in 0..reps {
+        let t = Instant::now();
+        f();
+        samples.push(t.elapsed());
+    }
+    samples.sort();
+    (
+        samples[0],
+        samples[samples.len() / 2],
+        samples[samples.len() - 1],
+    )
+}
+
+pub fn fmt_ms(d: Duration) -> String {
+    format!("{:.2}", d.as_secs_f64() * 1000.0)
+}
+
+pub fn fmt_mib(bytes: u64) -> String {
+    format!("{:.1}", bytes as f64 / (1024.0 * 1024.0))
+}

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/hostile.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/hostile.rs
@@ -1,0 +1,125 @@
+//! Attack-shaped inputs. Every builder here stays under
+//! `MAX_OFFICE_FILE_BYTES` (10 MiB) so the walker's size gate does not reject
+//! the file before either parser sees it — the interesting regime is a
+//! hostile document small enough to get through.
+
+use std::io::Write;
+
+use zip::write::{FileOptions, SimpleFileOptions};
+use zip::ZipWriter;
+
+/// Uncompressed payload each zip bomb expands to: 512 MiB.
+///
+/// Sized to sit above our `MAX_DOCUMENT_XML_BYTES` (50 MiB) AND above
+/// anydoc's `MAX_ENTRY_BYTES` (128 MiB), so both extractors' declared bounds
+/// are genuinely crossed rather than merely approached. A run of NUL bytes
+/// deflates to roughly 1/10000th of its size, keeping the container tiny.
+const BOMB_BYTES: usize = 512 * 1024 * 1024;
+
+/// Build a zip whose single named entry decompresses to 512 MiB of a
+/// repeating byte, wrapped so the surrounding package still looks like the
+/// target format.
+fn bomb_package(entry: &str, siblings: &[(&str, &str)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut zip = ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: SimpleFileOptions =
+            FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        for (name, body) in siblings {
+            zip.start_file(*name, opts).expect("start sibling");
+            zip.write_all(body.as_bytes()).expect("write sibling");
+        }
+        zip.start_file(entry, opts).expect("start bomb entry");
+        // Write in chunks so the generator itself never holds 512 MiB.
+        let chunk = vec![b' '; 1024 * 1024];
+        let mut written = 0usize;
+        // A leading XML prologue keeps the entry plausibly parseable so the
+        // parser commits to decompressing rather than bailing on byte 1.
+        zip.write_all(b"<?xml version=\"1.0\"?><root><t>")
+            .expect("write prologue");
+        while written < BOMB_BYTES {
+            let n = chunk.len().min(BOMB_BYTES - written);
+            zip.write_all(&chunk[..n]).expect("write bomb chunk");
+            written += n;
+        }
+        zip.write_all(b"</t></root>").expect("write epilogue");
+        zip.finish().expect("finish bomb");
+    }
+    buf
+}
+
+/// `.docx` whose `word/document.xml` expands to 512 MiB.
+pub fn docx_zip_bomb() -> Vec<u8> {
+    bomb_package(
+        "word/document.xml",
+        &[
+            ("[Content_Types].xml", r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#),
+            ("_rels/.rels", r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#),
+        ],
+    )
+}
+
+/// `.xlsx` whose `xl/worksheets/sheet1.xml` expands to 512 MiB. This is the
+/// leg issue #2923 documents as a residual risk: calamine exposes no
+/// pre-decompression bound, so our own extractor has nothing to enforce here.
+pub fn xlsx_zip_bomb() -> Vec<u8> {
+    bomb_package(
+        "xl/worksheets/sheet1.xml",
+        &[
+            ("[Content_Types].xml", r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>"#),
+            ("_rels/.rels", r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#),
+            ("xl/workbook.xml", r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="S1" sheetId="1" r:id="rId1"/></sheets></workbook>"#),
+            ("xl/_rels/workbook.xml.rels", r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#),
+        ],
+    )
+}
+
+/// `.docx` whose `word/document.xml` nests `depth` elements deep. Probes the
+/// XML-depth bound: anydoc declares `MAX_XML_DEPTH = 256`; our streaming
+/// quick-xml parse declares none (it never builds a tree, so depth costs it
+/// nothing — a difference in mechanism, not a missing bound).
+pub fn docx_deep_xml(depth: usize) -> Vec<u8> {
+    let ns = r#"xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main""#;
+    let mut xml = format!(r#"<?xml version="1.0"?><w:document {ns}><w:body>"#);
+    xml.push_str(&"<w:p>".repeat(depth));
+    xml.push_str("<w:r><w:t>deep</w:t></w:r>");
+    xml.push_str(&"</w:p>".repeat(depth));
+    xml.push_str("</w:body></w:document>");
+
+    let mut buf = Vec::new();
+    {
+        let mut zip = ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: SimpleFileOptions =
+            FileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+        zip.start_file("[Content_Types].xml", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#).unwrap();
+        zip.start_file("_rels/.rels", opts).unwrap();
+        zip.write_all(br#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#).unwrap();
+        zip.start_file("word/document.xml", opts).unwrap();
+        zip.write_all(xml.as_bytes()).unwrap();
+        zip.finish().unwrap();
+    }
+    buf
+}
+
+/// Cut a well-formed document off at `keep` of its length.
+pub fn truncated(mut bytes: Vec<u8>, keep: f64) -> Vec<u8> {
+    let cut = ((bytes.len() as f64) * keep) as usize;
+    bytes.truncate(cut);
+    bytes
+}
+
+/// Zip local-file-header magic followed by noise: the central directory is
+/// unreachable.
+pub fn malformed_archive() -> Vec<u8> {
+    let mut buf = b"PK\x03\x04".to_vec();
+    buf.extend((0..8192u32).map(|i| (i % 251) as u8));
+    buf
+}
+
+/// PDF header followed by noise.
+pub fn malformed_pdf() -> Vec<u8> {
+    let mut buf = b"%PDF-1.7\n".to_vec();
+    buf.extend((0..8192u32).map(|i| (i.wrapping_mul(37) % 253) as u8));
+    buf
+}

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/hostile.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/hostile.rs
@@ -53,8 +53,14 @@ pub fn docx_zip_bomb() -> Vec<u8> {
     bomb_package(
         "word/document.xml",
         &[
-            ("[Content_Types].xml", r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#),
-            ("_rels/.rels", r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#),
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#,
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#,
+            ),
         ],
     )
 }
@@ -66,10 +72,22 @@ pub fn xlsx_zip_bomb() -> Vec<u8> {
     bomb_package(
         "xl/worksheets/sheet1.xml",
         &[
-            ("[Content_Types].xml", r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>"#),
-            ("_rels/.rels", r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#),
-            ("xl/workbook.xml", r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="S1" sheetId="1" r:id="rId1"/></sheets></workbook>"#),
-            ("xl/_rels/workbook.xml.rels", r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#),
+            (
+                "[Content_Types].xml",
+                r#"<?xml version="1.0"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/><Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/></Types>"#,
+            ),
+            (
+                "_rels/.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#,
+            ),
+            (
+                "xl/workbook.xml",
+                r#"<?xml version="1.0"?><workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="S1" sheetId="1" r:id="rId1"/></sheets></workbook>"#,
+            ),
+            (
+                "xl/_rels/workbook.xml.rels",
+                r#"<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>"#,
+            ),
         ],
     )
 }

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/mod.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/mod.rs
@@ -1,0 +1,199 @@
+//! Deterministic document fixtures for the anydoc evaluation spike.
+//!
+//! Why: the repo's own extraction tests build fixtures inline and throw them
+//! away, so there is no corpus to benchmark two extractors against. Rather
+//! than check binary documents into the tree, every fixture here is generated
+//! byte-for-byte from code — the corpus is reproducible on any machine, and
+//! the adversarial shapes stay auditable as source instead of opaque blobs.
+//!
+//! What: [`Corpus`] materialises a temp directory of realistic and hostile
+//! `.docx` / `.xlsx` / `.pdf` files. `office` and `pdf` build the
+//! well-formed ones; `hostile` builds the attack shapes.
+//!
+//! Test: none — this is a throwaway spike harness gated behind the
+//! `anydoc-spike` feature, not production code.
+
+pub mod hostile;
+pub mod office;
+pub mod pdf;
+
+use std::path::{Path, PathBuf};
+
+/// A materialised fixture: the file on disk plus what it is meant to probe.
+pub struct Fixture {
+    pub name: String,
+    pub path: PathBuf,
+    /// Extension-derived format label used to group benchmark rows.
+    pub format: &'static str,
+    /// One-line description of what this fixture exercises.
+    pub note: String,
+}
+
+impl Fixture {
+    pub fn size(&self) -> u64 {
+        std::fs::metadata(&self.path).map(|m| m.len()).unwrap_or(0)
+    }
+}
+
+/// The generated corpus, rooted in a caller-owned directory.
+pub struct Corpus {
+    pub root: PathBuf,
+}
+
+impl Corpus {
+    pub fn new(root: &Path) -> Self {
+        std::fs::create_dir_all(root).expect("create corpus root");
+        Self {
+            root: root.to_path_buf(),
+        }
+    }
+
+    fn write(&self, name: &str, format: &'static str, note: &str, bytes: Vec<u8>) -> Fixture {
+        let path = self.root.join(name);
+        std::fs::write(&path, bytes).expect("write fixture");
+        Fixture {
+            name: name.to_string(),
+            path,
+            format,
+            note: note.to_string(),
+        }
+    }
+
+    /// Well-formed documents used for the speed, memory, and quality legs.
+    ///
+    /// Sizes are chosen to span the realistic range rather than to flatter
+    /// either extractor: a small memo, a structure-heavy report, and a
+    /// multi-sheet workbook.
+    pub fn benign(&self) -> Vec<Fixture> {
+        vec![
+            self.write(
+                "small-memo.docx",
+                "docx",
+                "12 flat paragraphs, no structure — the shape our extractor already handles well",
+                office::docx_flat(12),
+            ),
+            self.write(
+                "structured-report.docx",
+                "docx",
+                "6 headings + 4 tables (5x4) + 60 paragraphs — the structure our extractor drops",
+                office::docx_structured(),
+            ),
+            self.write(
+                "large-report.docx",
+                "docx",
+                "2000 paragraphs + 40 tables — throughput case",
+                office::docx_large(),
+            ),
+            self.write(
+                "small-sheet.xlsx",
+                "xlsx",
+                "1 sheet, 20x6 populated cells",
+                office::xlsx_grid(1, 20, 6),
+            ),
+            self.write(
+                "multi-sheet.xlsx",
+                "xlsx",
+                "4 sheets, 200x8 populated cells each",
+                office::xlsx_grid(4, 200, 8),
+            ),
+            self.write(
+                "text-layer.pdf",
+                "pdf",
+                "single page, one text-showing operator",
+                pdf::text_layer("Quarterly revenue rose 12 percent."),
+            ),
+            self.write(
+                "multi-page.pdf",
+                "pdf",
+                "40 pages, one text run each",
+                pdf::multi_page(40),
+            ),
+            self.write(
+                "image-only.pdf",
+                "pdf",
+                "valid page, zero text operators — the scanned-document case",
+                pdf::image_only(),
+            ),
+        ]
+    }
+
+    /// Hostile inputs. Every one stays under `MAX_OFFICE_FILE_BYTES` (10 MiB)
+    /// on purpose: a file the walker's size gate already rejects tells us
+    /// nothing about either parser. These are the ones that get through.
+    pub fn adversarial(&self) -> Vec<Fixture> {
+        vec![
+            self.write(
+                "zipbomb.docx",
+                "docx",
+                "48 KiB container, 512 MiB declared document.xml (DEFLATE null run)",
+                hostile::docx_zip_bomb(),
+            ),
+            self.write(
+                "nested-xml.docx",
+                "docx",
+                "100k-deep XML element nesting in document.xml",
+                hostile::docx_deep_xml(100_000),
+            ),
+            self.write(
+                "truncated.docx",
+                "docx",
+                "valid docx cut off mid-archive",
+                hostile::truncated(office::docx_flat(200), 0.6),
+            ),
+            self.write(
+                "malformed.docx",
+                "docx",
+                "zip magic followed by garbage — a corrupt central directory",
+                hostile::malformed_archive(),
+            ),
+            self.write(
+                "zipbomb.xlsx",
+                "xlsx",
+                "48 KiB container, 512 MiB declared sheet1.xml (the calamine leg)",
+                hostile::xlsx_zip_bomb(),
+            ),
+            self.write(
+                "truncated.xlsx",
+                "xlsx",
+                "valid xlsx cut off mid-archive",
+                hostile::truncated(office::xlsx_grid(2, 300, 8), 0.6),
+            ),
+            self.write(
+                "nested-objects.pdf",
+                "pdf",
+                "RUSTSEC-2026-0187 PoC: 10380-deep nested array in a page object",
+                pdf::deeply_nested_objects(10_380),
+            ),
+            self.write(
+                "truncated.pdf",
+                "pdf",
+                "valid PDF cut off before the xref table",
+                hostile::truncated(pdf::multi_page(10), 0.5),
+            ),
+            self.write(
+                "malformed.pdf",
+                "pdf",
+                "PDF header followed by garbage",
+                hostile::malformed_pdf(),
+            ),
+        ]
+    }
+
+    /// Fixtures targeting anydoc issues #8 and #9 specifically.
+    pub fn xlsx_bugs(&self) -> Vec<Fixture> {
+        vec![
+            self.write(
+                "merged-range.xlsx",
+                "xlsx",
+                "issue #8: F1:O3 merge (3 rows x 10 cols) with only the anchor populated",
+                office::xlsx_merged_range(),
+            ),
+            self.write(
+                "hidden-content.xlsx",
+                "xlsx",
+                "issue #9: one hidden row and one hidden column alongside visible cells",
+                office::xlsx_hidden(),
+            ),
+        ]
+    }
+}

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/office.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/office.rs
@@ -1,0 +1,240 @@
+//! OOXML fixture builders: `.docx` (WordprocessingML) and `.xlsx`
+//! (SpreadsheetML) written by hand so every structural feature under test —
+//! headings, tables, merges, hidden rows — is explicit in source.
+//!
+//! Inline strings (`t="inlineStr"`) are used throughout rather than a
+//! shared-strings part: calamine and anydoc both read them, and it keeps the
+//! generator to one worksheet part.
+
+use std::io::Write;
+
+use zip::write::FileOptions;
+use zip::ZipWriter;
+
+const W_NS: &str = r#"xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main""#;
+const S_NS: &str =
+    r#"xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main""#;
+
+/// Zip a set of (path, contents) parts into an OOXML package.
+fn package(parts: &[(&str, String)]) -> Vec<u8> {
+    let mut buf = Vec::new();
+    {
+        let mut zip = ZipWriter::new(std::io::Cursor::new(&mut buf));
+        let opts: FileOptions<'_, ()> = FileOptions::default();
+        for (name, body) in parts {
+            zip.start_file(*name, opts).expect("start entry");
+            zip.write_all(body.as_bytes()).expect("write entry");
+        }
+        zip.finish().expect("finish zip");
+    }
+    buf
+}
+
+fn docx_package(body: String) -> Vec<u8> {
+    let document = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document {W_NS}><w:body>{body}</w:body></w:document>"#
+    );
+    let content_types = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
+    let rels = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+    package(&[
+        ("[Content_Types].xml", content_types.to_string()),
+        ("_rels/.rels", rels.to_string()),
+        ("word/document.xml", document),
+    ])
+}
+
+fn para(text: &str) -> String {
+    format!("<w:p><w:r><w:t xml:space=\"preserve\">{text}</w:t></w:r></w:p>")
+}
+
+fn heading(level: u8, text: &str) -> String {
+    format!(
+        "<w:p><w:pPr><w:pStyle w:val=\"Heading{level}\"/></w:pPr><w:r><w:t>{text}</w:t></w:r></w:p>"
+    )
+}
+
+/// A `<w:tbl>` with `rows` x `cols` cells, first row acting as the header.
+fn table(rows: usize, cols: usize, tag: &str) -> String {
+    let mut out = String::from("<w:tbl>");
+    for r in 0..rows {
+        out.push_str("<w:tr>");
+        for c in 0..cols {
+            let cell = if r == 0 {
+                format!("{tag} col {c}")
+            } else {
+                format!("{tag} r{r}c{c}")
+            };
+            out.push_str(&format!(
+                "<w:tc><w:p><w:r><w:t>{cell}</w:t></w:r></w:p></w:tc>"
+            ));
+        }
+        out.push_str("</w:tr>");
+    }
+    out.push_str("</w:tbl>");
+    out
+}
+
+/// `n` plain paragraphs, no headings and no tables.
+pub fn docx_flat(n: usize) -> Vec<u8> {
+    let body: String = (0..n)
+        .map(|i| para(&format!("Paragraph {i}: the quick brown fox jumps over the lazy dog.")))
+        .collect();
+    docx_package(body)
+}
+
+/// Headings + tables + prose, interleaved the way a real report is. This is
+/// the fixture that decides whether anydoc's structure recovery is real.
+pub fn docx_structured() -> Vec<u8> {
+    let mut body = String::new();
+    body.push_str(&heading(1, "Quarterly Operations Review"));
+    body.push_str(&para(
+        "This review covers the reporting period and its material variances.",
+    ));
+    for section in 0..4 {
+        body.push_str(&heading(2, &format!("Section {section}: Regional Detail")));
+        for p in 0..15 {
+            body.push_str(&para(&format!(
+                "Section {section} paragraph {p}: operating expenditure tracked against plan."
+            )));
+        }
+        body.push_str(&table(5, 4, &format!("S{section}")));
+    }
+    body.push_str(&heading(2, "Appendix"));
+    docx_package(body)
+}
+
+/// Throughput fixture: many paragraphs and many tables.
+pub fn docx_large() -> Vec<u8> {
+    let mut body = String::new();
+    for i in 0..2000 {
+        body.push_str(&para(&format!(
+            "Line item {i}: reconciliation entry with narrative commentary attached."
+        )));
+        if i % 50 == 0 {
+            body.push_str(&table(6, 5, &format!("T{i}")));
+        }
+    }
+    docx_package(body)
+}
+
+fn xlsx_package(sheets: Vec<(String, String)>) -> Vec<u8> {
+    let sheet_entries: String = sheets
+        .iter()
+        .enumerate()
+        .map(|(i, (name, _))| {
+            format!(
+                r#"<sheet name="{name}" sheetId="{id}" r:id="rId{id}"/>"#,
+                id = i + 1
+            )
+        })
+        .collect();
+    let workbook = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><workbook {S_NS} xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets>{sheet_entries}</sheets></workbook>"#
+    );
+    let wb_rels_entries: String = (1..=sheets.len())
+        .map(|i| {
+            format!(
+                r#"<Relationship Id="rId{i}" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet{i}.xml"/>"#
+            )
+        })
+        .collect();
+    let wb_rels = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">{wb_rels_entries}</Relationships>"#
+    );
+    let overrides: String = (1..=sheets.len())
+        .map(|i| format!(r#"<Override PartName="/xl/worksheets/sheet{i}.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>"#))
+        .collect();
+    let content_types = format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>{overrides}</Types>"#
+    );
+    let rels = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/></Relationships>"#;
+
+    let mut parts = vec![
+        ("[Content_Types].xml".to_string(), content_types),
+        ("_rels/.rels".to_string(), rels.to_string()),
+        ("xl/workbook.xml".to_string(), workbook),
+        ("xl/_rels/workbook.xml.rels".to_string(), wb_rels),
+    ];
+    for (i, (_, xml)) in sheets.into_iter().enumerate() {
+        parts.push((format!("xl/worksheets/sheet{}.xml", i + 1), xml));
+    }
+    let borrowed: Vec<(&str, String)> = parts
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.clone()))
+        .collect();
+    package(&borrowed)
+}
+
+fn col_letter(c: usize) -> String {
+    let mut n = c + 1;
+    let mut s = String::new();
+    while n > 0 {
+        let rem = (n - 1) % 26;
+        s.insert(0, (b'A' + rem as u8) as char);
+        n = (n - 1) / 26;
+    }
+    s
+}
+
+fn inline_cell(r: usize, c: usize, value: &str) -> String {
+    format!(
+        r#"<c r="{col}{row}" t="inlineStr"><is><t>{value}</t></is></c>"#,
+        col = col_letter(c),
+        row = r + 1
+    )
+}
+
+fn sheet_xml(inner: String) -> String {
+    format!(r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet {S_NS}>{inner}</worksheet>"#)
+}
+
+/// `sheets` worksheets, each a dense `rows` x `cols` grid of inline strings.
+pub fn xlsx_grid(sheets: usize, rows: usize, cols: usize) -> Vec<u8> {
+    let built: Vec<(String, String)> = (0..sheets)
+        .map(|s| {
+            let mut data = String::from("<sheetData>");
+            for r in 0..rows {
+                data.push_str(&format!(r#"<row r="{}">"#, r + 1));
+                for c in 0..cols {
+                    let v = if r == 0 {
+                        format!("Header {c}")
+                    } else {
+                        format!("S{s} r{r} c{c} value")
+                    };
+                    data.push_str(&inline_cell(r, c, &v));
+                }
+                data.push_str("</row>");
+            }
+            data.push_str("</sheetData>");
+            (format!("Sheet{}", s + 1), sheet_xml(data))
+        })
+        .collect();
+    xlsx_package(built)
+}
+
+/// anydoc issue #8: an `F1:O3` merge whose only populated cell is the anchor.
+pub fn xlsx_merged_range() -> Vec<u8> {
+    let mut data = String::from("<sheetData>");
+    data.push_str(r#"<row r="1">"#);
+    data.push_str(&inline_cell(0, 5, "Merged heading"));
+    data.push_str("</row>");
+    data.push_str("</sheetData>");
+    data.push_str(r#"<mergeCells count="1"><mergeCell ref="F1:O3"/></mergeCells>"#);
+    xlsx_package(vec![("Merge Example".to_string(), sheet_xml(data))])
+}
+
+/// anydoc issue #9: a hidden row and a hidden column beside visible cells.
+pub fn xlsx_hidden() -> Vec<u8> {
+    let mut inner = String::new();
+    inner.push_str(r#"<cols><col min="2" max="2" width="10" hidden="1" customWidth="1"/></cols>"#);
+    inner.push_str("<sheetData>");
+    inner.push_str(r#"<row r="1">"#);
+    inner.push_str(&inline_cell(0, 0, "Visible row"));
+    inner.push_str(&inline_cell(0, 1, "Hidden column"));
+    inner.push_str("</row>");
+    inner.push_str(r#"<row r="2" hidden="1">"#);
+    inner.push_str(&inline_cell(1, 0, "Hidden row"));
+    inner.push_str("</row>");
+    inner.push_str("</sheetData>");
+    xlsx_package(vec![("Visibility Example".to_string(), sheet_xml(inner))])
+}

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/office.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/office.rs
@@ -30,15 +30,42 @@ fn package(parts: &[(&str, String)]) -> Vec<u8> {
     buf
 }
 
+/// `word/styles.xml` defining Heading1..Heading3.
+///
+/// Required for a fair comparison, not decoration: anydoc resolves a
+/// paragraph's heading level by looking `w:pStyle`'s id up in this part and
+/// matching its `w:name` against `heading N` (see anydoc's
+/// `formats::docx::styles::heading_level`), falling back to a direct
+/// `outlineLvl`. A fixture carrying `w:pStyle` with no styles part gives it
+/// nothing to resolve, and the resulting "anydoc recovered no headings" would
+/// be an artifact of the fixture rather than a property of the crate. Real
+/// Word documents always ship this part.
+fn styles_xml() -> String {
+    let styles: String = (1..=3)
+        .map(|lvl| {
+            format!(
+                r#"<w:style w:type="paragraph" w:styleId="Heading{lvl}"><w:name w:val="heading {lvl}"/><w:pPr><w:outlineLvl w:val="{}"/></w:pPr></w:style>"#,
+                lvl - 1
+            )
+        })
+        .collect();
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:styles {W_NS}>{styles}</w:styles>"#
+    )
+}
+
 fn docx_package(body: String) -> Vec<u8> {
     let document = format!(
         r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><w:document {W_NS}><w:body>{body}</w:body></w:document>"#
     );
-    let content_types = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>"#;
+    let content_types = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="xml" ContentType="application/xml"/><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/><Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/></Types>"#;
     let rels = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>"#;
+    let doc_rels = r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/styles" Target="styles.xml"/></Relationships>"#;
     package(&[
         ("[Content_Types].xml", content_types.to_string()),
         ("_rels/.rels", rels.to_string()),
+        ("word/_rels/document.xml.rels", doc_rels.to_string()),
+        ("word/styles.xml", styles_xml()),
         ("word/document.xml", document),
     ])
 }

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/office.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/office.rs
@@ -12,8 +12,7 @@ use zip::write::FileOptions;
 use zip::ZipWriter;
 
 const W_NS: &str = r#"xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main""#;
-const S_NS: &str =
-    r#"xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main""#;
+const S_NS: &str = r#"xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main""#;
 
 /// Zip a set of (path, contents) parts into an OOXML package.
 fn package(parts: &[(&str, String)]) -> Vec<u8> {
@@ -104,7 +103,11 @@ fn table(rows: usize, cols: usize, tag: &str) -> String {
 /// `n` plain paragraphs, no headings and no tables.
 pub fn docx_flat(n: usize) -> Vec<u8> {
     let body: String = (0..n)
-        .map(|i| para(&format!("Paragraph {i}: the quick brown fox jumps over the lazy dog.")))
+        .map(|i| {
+            para(&format!(
+                "Paragraph {i}: the quick brown fox jumps over the lazy dog."
+            ))
+        })
         .collect();
     docx_package(body)
 }
@@ -185,10 +188,8 @@ fn xlsx_package(sheets: Vec<(String, String)>) -> Vec<u8> {
     for (i, (_, xml)) in sheets.into_iter().enumerate() {
         parts.push((format!("xl/worksheets/sheet{}.xml", i + 1), xml));
     }
-    let borrowed: Vec<(&str, String)> = parts
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.clone()))
-        .collect();
+    let borrowed: Vec<(&str, String)> =
+        parts.iter().map(|(k, v)| (k.as_str(), v.clone())).collect();
     package(&borrowed)
 }
 
@@ -212,7 +213,9 @@ fn inline_cell(r: usize, c: usize, value: &str) -> String {
 }
 
 fn sheet_xml(inner: String) -> String {
-    format!(r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet {S_NS}>{inner}</worksheet>"#)
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="yes"?><worksheet {S_NS}>{inner}</worksheet>"#
+    )
 }
 
 /// `sheets` worksheets, each a dense `rows` x `cols` grid of inline strings.

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/pdf.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/pdf.rs
@@ -1,0 +1,114 @@
+//! Hand-built PDF fixtures with byte-accurate `xref` tables.
+//!
+//! The builder follows the same incremental-offset approach as the existing
+//! `core::extract::pdf` tests: lopdf (under both `pdf-extract` and
+//! `pdf-inspector`) resolves objects through the `xref` table, so an
+//! approximate table simply fails to parse and would measure nothing.
+
+use std::io::Write;
+
+/// Assemble a PDF from pre-rendered object bodies (`"<< ... >>"` or
+/// `"<< ... >>\nstream\n...\nendstream"`), numbering them 1..=n and emitting
+/// a correct `xref` + trailer. Object 1 must be the Catalog.
+fn assemble(objects: &[String]) -> Vec<u8> {
+    let mut buf: Vec<u8> = Vec::new();
+    let mut offsets: Vec<usize> = Vec::with_capacity(objects.len());
+    buf.extend_from_slice(b"%PDF-1.4\n");
+    for (i, body) in objects.iter().enumerate() {
+        offsets.push(buf.len());
+        write!(buf, "{} 0 obj\n{}\nendobj\n", i + 1, body).unwrap();
+    }
+    let xref_start = buf.len();
+    let size = objects.len() + 1;
+    let mut xref = format!("xref\n0 {size}\n0000000000 65535 f \n");
+    for off in &offsets {
+        xref.push_str(&format!("{off:010} 00000 n \n"));
+    }
+    buf.extend_from_slice(xref.as_bytes());
+    write!(
+        buf,
+        "trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{xref_start}\n%%EOF"
+    )
+    .unwrap();
+    buf
+}
+
+fn content_stream(ops: &str) -> String {
+    format!(
+        "<< /Length {} >>\nstream\n{}\nendstream",
+        ops.len(),
+        ops
+    )
+}
+
+/// Single page carrying one text-showing operator.
+pub fn text_layer(text: &str) -> Vec<u8> {
+    let ops = format!("BT\n/F1 12 Tf\n20 150 Td\n({text}) Tj\nET");
+    assemble(&[
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> \
+         /MediaBox [0 0 200 200] /Contents 5 0 R >>"
+            .to_string(),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+        content_stream(&ops),
+    ])
+}
+
+/// `pages` pages, each with its own content stream.
+pub fn multi_page(pages: usize) -> Vec<u8> {
+    // Object layout: 1 Catalog, 2 Pages, 3 Font, then (page, content) pairs.
+    let first_page_obj = 4;
+    let kids: String = (0..pages)
+        .map(|i| format!("{} 0 R ", first_page_obj + i * 2))
+        .collect();
+    let mut objects = vec![
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        format!("<< /Type /Pages /Kids [{kids}] /Count {pages} >>"),
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>".to_string(),
+    ];
+    for i in 0..pages {
+        let content_obj = first_page_obj + i * 2 + 1;
+        objects.push(format!(
+            "<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 3 0 R >> >> \
+             /MediaBox [0 0 400 400] /Contents {content_obj} 0 R >>"
+        ));
+        let ops = format!(
+            "BT\n/F1 12 Tf\n20 350 Td\n(Page {i} discusses the operating margin and its drivers.) Tj\nET"
+        );
+        objects.push(content_stream(&ops));
+    }
+    assemble(&objects)
+}
+
+/// A structurally valid page with an empty content stream — no text operators
+/// at all. This is what a scanned/image-only PDF looks like to a text-layer
+/// extractor, without needing a real embedded raster.
+pub fn image_only() -> Vec<u8> {
+    assemble(&[
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R >>".to_string(),
+        content_stream(""),
+    ])
+}
+
+/// RUSTSEC-2026-0187 proof of concept: a page object carrying a
+/// `depth`-deep nested array.
+///
+/// The advisory reports this as a stack overflow that aborts the process with
+/// `SIGABRT` — not a `panic!`, so `catch_unwind` and `spawn_blocking`'s
+/// JoinError containment do not stop it. Patched in lopdf 0.42.0, which
+/// enforces a nesting cap and returns `Err`. `pdf-extract 0.12` (ours) pulls
+/// 0.42.0; `pdf-inspector 0.1.7` (anydoc's) pulls 0.41.0.
+pub fn deeply_nested_objects(depth: usize) -> Vec<u8> {
+    let nested: String = "[".repeat(depth) + &"]".repeat(depth);
+    assemble(&[
+        "<< /Type /Catalog /Pages 2 0 R >>".to_string(),
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>".to_string(),
+        format!(
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Deep {nested} >>"
+        ),
+        content_stream(""),
+    ])
+}

--- a/crates/trusty-search/examples/anydoc_spike/fixtures/pdf.rs
+++ b/crates/trusty-search/examples/anydoc_spike/fixtures/pdf.rs
@@ -34,11 +34,7 @@ fn assemble(objects: &[String]) -> Vec<u8> {
 }
 
 fn content_stream(ops: &str) -> String {
-    format!(
-        "<< /Length {} >>\nstream\n{}\nendstream",
-        ops.len(),
-        ops
-    )
+    format!("<< /Length {} >>\nstream\n{}\nendstream", ops.len(), ops)
 }
 
 /// Single page carrying one text-showing operator.

--- a/crates/trusty-search/examples/anydoc_spike/main.rs
+++ b/crates/trusty-search/examples/anydoc_spike/main.rs
@@ -26,6 +26,7 @@ mod bench;
 mod engines;
 mod fixtures;
 mod quality;
+mod real_corpus;
 mod xlsx_bugs;
 
 use std::path::{Path, PathBuf};
@@ -57,6 +58,16 @@ fn main() {
         "quality" => quality::run(&corpus),
         "adversarial" => adversarial::run(&corpus),
         "xlsx-bugs" => xlsx_bugs::run(&corpus),
+        "pdf-sweep" => pdf_sweep(&dir),
+        // Point at a directory of real documents:
+        //   … --example anydoc_spike -- real /path/to/docs
+        "real" => match args.get(1) {
+            Some(d) => real_corpus::run(Path::new(d)),
+            None => {
+                eprintln!("usage: real <directory>");
+                std::process::exit(2);
+            }
+        },
         "all" => {
             quality::run(&corpus);
             println!("\n---\n");
@@ -93,6 +104,40 @@ fn run_one(args: &[String]) {
         println!("CHECKSUM={checksum}");
     }
     println!("PEAK_RSS_BYTES={}", engines::peak_rss_bytes());
+}
+
+/// Isolate the multi-page PDF failure: sweep page count with the object
+/// layout held constant, so "anydoc cannot read this document" and "anydoc
+/// cannot read documents past N pages" stay distinguishable.
+///
+/// Each fixture is validated against poppler (`pdftotext`) as a third-party
+/// reference before either extractor's result is believed — a hand-built PDF
+/// that only one parser accepts would prove nothing about the other.
+fn pdf_sweep(dir: &Path) {
+    println!("## PDF page-count sweep\n");
+    println!("| pages | bytes | poppler pdftotext chars | native chars | anydoc |");
+    println!("|---:|---:|---:|---:|---|");
+    for pages in [1usize, 2, 3, 4, 5, 8, 16, 40] {
+        let path = dir.join(format!("sweep-{pages}p.pdf"));
+        std::fs::write(&path, fixtures::pdf::multi_page(pages)).expect("write sweep fixture");
+        let poppler = std::process::Command::new("pdftotext")
+            .arg(&path)
+            .arg("-")
+            .output()
+            .map(|o| String::from_utf8_lossy(&o.stdout).trim().len())
+            .map(|n| n.to_string())
+            .unwrap_or_else(|_| "n/a".to_string());
+        let native = Engine::Native.extract(&path);
+        let anydoc = Engine::Anydoc.extract(&path);
+        println!(
+            "| {} | {} | {} | {} | {} |",
+            pages,
+            std::fs::metadata(&path).map(|m| m.len()).unwrap_or(0),
+            poppler,
+            native.text().trim().len(),
+            anydoc.summary()
+        );
+    }
 }
 
 /// Corpus root. `TRUSTY_ANYDOC_SPIKE_DIR` overrides it; otherwise a scratch

--- a/crates/trusty-search/examples/anydoc_spike/main.rs
+++ b/crates/trusty-search/examples/anydoc_spike/main.rs
@@ -1,0 +1,105 @@
+//! Throwaway measurement harness for the anydoc adoption spike.
+//!
+//! Why: the question "should anydoc replace `core::extract`" needs numbers on
+//! speed, memory, output fidelity, and failure behaviour that no existing
+//! test produces. This binary generates them. It is NOT production code and
+//! nothing outside it may reference `anydoc` — see the `anydoc-spike` feature
+//! in `Cargo.toml`, which gates both this example and the dependency, so a
+//! default `cargo build` / `cargo test` / `cargo clippy --all-targets` never
+//! compiles either.
+//!
+//! Usage:
+//!
+//! ```text
+//! cargo run -p trusty-search --features anydoc-spike --example anydoc_spike -- all
+//! ```
+//!
+//! Subcommands: `bench`, `quality`, `adversarial`, `xlsx-bugs`, `all`, and the
+//! internal `run-one <native|anydoc|baseline> <path>` used for per-measurement
+//! process isolation.
+//!
+//! Delete this directory, the `anydoc-spike` feature, the `[[example]]` block,
+//! and the optional dependency together when the spike is retired.
+
+mod adversarial;
+mod bench;
+mod engines;
+mod fixtures;
+mod quality;
+mod xlsx_bugs;
+
+use std::path::{Path, PathBuf};
+
+use engines::Engine;
+use fixtures::Corpus;
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    let cmd = args.first().map(String::as_str).unwrap_or("all");
+
+    if cmd == "run-one" {
+        run_one(&args);
+        return;
+    }
+
+    let dir = corpus_dir();
+    let corpus = Corpus::new(&dir);
+    eprintln!("corpus: {}", dir.display());
+
+    println!("# anydoc spike measurements\n");
+    println!("- host: {} {}", std::env::consts::OS, std::env::consts::ARCH);
+    println!("- anydoc: 0.1.3");
+    println!("- native: `trusty_search::core::extract::extract_text`");
+    println!("- profile: {}\n", if cfg!(debug_assertions) { "debug" } else { "release" });
+
+    match cmd {
+        "bench" => bench::run(&corpus),
+        "quality" => quality::run(&corpus),
+        "adversarial" => adversarial::run(&corpus),
+        "xlsx-bugs" => xlsx_bugs::run(&corpus),
+        "all" => {
+            quality::run(&corpus);
+            println!("\n---\n");
+            xlsx_bugs::run(&corpus);
+            println!("\n---\n");
+            bench::run(&corpus);
+            println!("\n---\n");
+            adversarial::run(&corpus);
+        }
+        other => {
+            eprintln!("unknown subcommand: {other}");
+            std::process::exit(2);
+        }
+    }
+}
+
+/// One extraction in a fresh process, reporting the outcome and this
+/// process's peak RSS. The parent reads both from stdout; a child that dies
+/// on a signal simply prints neither, which is itself the measurement.
+fn run_one(args: &[String]) {
+    let engine = args.get(1).map(String::as_str).unwrap_or("baseline");
+    let path = args.get(2).map(PathBuf::from).unwrap_or_default();
+
+    if engine != "baseline" {
+        let e = Engine::parse(engine).unwrap_or_else(|| {
+            eprintln!("unknown engine: {engine}");
+            std::process::exit(2);
+        });
+        let outcome = e.extract(&path);
+        // Consume the text so a lazy parser cannot defer work past the
+        // measurement point.
+        let checksum: u64 = outcome.text().bytes().map(u64::from).sum();
+        println!("RESULT={}", outcome.summary());
+        println!("CHECKSUM={checksum}");
+    }
+    println!("PEAK_RSS_BYTES={}", engines::peak_rss_bytes());
+}
+
+/// Corpus root. `TRUSTY_ANYDOC_SPIKE_DIR` overrides it; otherwise a scratch
+/// directory under the system temp dir. Never touches a real
+/// `TRUSTY_DATA_DIR` — this harness reads and writes nothing the daemon owns.
+fn corpus_dir() -> PathBuf {
+    std::env::var("TRUSTY_ANYDOC_SPIKE_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| Path::new(&std::env::temp_dir()).join("anydoc-spike-corpus"))
+}

--- a/crates/trusty-search/examples/anydoc_spike/main.rs
+++ b/crates/trusty-search/examples/anydoc_spike/main.rs
@@ -48,10 +48,21 @@ fn main() {
     eprintln!("corpus: {}", dir.display());
 
     println!("# anydoc spike measurements\n");
-    println!("- host: {} {}", std::env::consts::OS, std::env::consts::ARCH);
+    println!(
+        "- host: {} {}",
+        std::env::consts::OS,
+        std::env::consts::ARCH
+    );
     println!("- anydoc: 0.1.3");
     println!("- native: `trusty_search::core::extract::extract_text`");
-    println!("- profile: {}\n", if cfg!(debug_assertions) { "debug" } else { "release" });
+    println!(
+        "- profile: {}\n",
+        if cfg!(debug_assertions) {
+            "debug"
+        } else {
+            "release"
+        }
+    );
 
     match cmd {
         "bench" => bench::run(&corpus),

--- a/crates/trusty-search/examples/anydoc_spike/quality.rs
+++ b/crates/trusty-search/examples/anydoc_spike/quality.rs
@@ -71,7 +71,7 @@ pub fn run(corpus: &Corpus) {
 }
 
 fn chunk_count(name: &str, text: &str) -> usize {
-    trusty_search::core::chunker::types::chunk_text(name, text, WINDOW, STRIDE).len()
+    trusty_search::core::chunker::chunk_text(name, text, WINDOW, STRIDE).len()
 }
 
 /// Count the structural signals each extractor preserved.

--- a/crates/trusty-search/examples/anydoc_spike/quality.rs
+++ b/crates/trusty-search/examples/anydoc_spike/quality.rs
@@ -87,7 +87,10 @@ fn structure_report(f: &Fixture) {
     println!("| signal | native | anydoc |");
     println!("|---|---:|---:|");
     for (label, count) in [
-        ("markdown heading lines (`#`)", count_headings as fn(&str) -> usize),
+        (
+            "markdown heading lines (`#`)",
+            count_headings as fn(&str) -> usize,
+        ),
         ("table delimiter rows (`| --- |`)", count_table_rules),
         ("table pipe characters", count_pipes),
     ] {
@@ -118,7 +121,9 @@ fn present(o: &Outcome, needle: &str) -> &'static str {
 }
 
 fn count_headings(s: &str) -> usize {
-    s.lines().filter(|l| l.trim_start().starts_with('#')).count()
+    s.lines()
+        .filter(|l| l.trim_start().starts_with('#'))
+        .count()
 }
 
 fn count_table_rules(s: &str) -> usize {

--- a/crates/trusty-search/examples/anydoc_spike/quality.rs
+++ b/crates/trusty-search/examples/anydoc_spike/quality.rs
@@ -1,0 +1,146 @@
+//! Output-quality leg: what each extractor recovers, and what survives the
+//! chunker.
+//!
+//! The second question is the one that decides whether structure recovery is
+//! worth anything at the index level. `core::extract` hands every one of
+//! these formats to `chunk_ast`, which finds no tree-sitter grammar and falls
+//! through to `chunk_text(file, content, 150, 50)` — a flat 150-line sliding
+//! window with 50-line stride. Markdown table pipes and `##` headings are
+//! just characters to that chunker, so the gain has to show up as retrieved
+//! terms inside a chunk, not as prettier output.
+
+use crate::engines::{Engine, Outcome};
+use crate::fixtures::{Corpus, Fixture};
+
+/// Window and stride `chunk_ast` applies to extension-unknown content — the
+/// path every EXTRACT_EXTS document takes.
+const WINDOW: usize = 150;
+const STRIDE: usize = 50;
+
+pub fn run(corpus: &Corpus) {
+    let fixtures = corpus.benign();
+
+    println!("## Extracted-text shape\n");
+    println!("| fixture | native | anydoc |");
+    println!("|---|---|---|");
+    for f in &fixtures {
+        println!(
+            "| {} | {} | {} |",
+            f.name,
+            Engine::Native.extract(&f.path).summary(),
+            Engine::Anydoc.extract(&f.path).summary()
+        );
+    }
+
+    println!("\n## Structure recovery (docx)\n");
+    for f in fixtures.iter().filter(|f| f.format == "docx") {
+        structure_report(f);
+    }
+
+    println!("\n## Chunk-level impact\n");
+    println!(
+        "Both texts chunked with chunk_text(window={WINDOW}, stride={STRIDE}) — the production path.\n"
+    );
+    println!("| fixture | native chunks | anydoc chunks | native lines | anydoc lines | native chars | anydoc chars |");
+    println!("|---|---:|---:|---:|---:|---:|---:|");
+    for f in &fixtures {
+        let n = Engine::Native.extract(&f.path);
+        let a = Engine::Anydoc.extract(&f.path);
+        let nc = chunk_count(&f.name, n.text());
+        let ac = chunk_count(&f.name, a.text());
+        println!(
+            "| {} | {} | {} | {} | {} | {} | {} |",
+            f.name,
+            nc,
+            ac,
+            n.text().lines().count(),
+            a.text().lines().count(),
+            n.text().len(),
+            a.text().len()
+        );
+    }
+
+    println!("\n## Sample output (structured-report.docx, first 900 chars each)\n");
+    if let Some(f) = fixtures.iter().find(|f| f.name == "structured-report.docx") {
+        for engine in [Engine::Native, Engine::Anydoc] {
+            let out = engine.extract(&f.path);
+            println!("### {}\n", engine.label());
+            println!("```\n{}\n```\n", head(out.text(), 900));
+        }
+    }
+}
+
+fn chunk_count(name: &str, text: &str) -> usize {
+    trusty_search::core::chunker::types::chunk_text(name, text, WINDOW, STRIDE).len()
+}
+
+/// Count the structural signals each extractor preserved.
+///
+/// `table cells recovered` is the load-bearing number: our extractor emits a
+/// `<w:tbl>` cell as an anonymous paragraph, so the cell TEXT survives but
+/// every row/column boundary is gone. Counting the delimiter characters is
+/// the difference between "the words are present" and "the table is present".
+fn structure_report(f: &Fixture) {
+    let n = Engine::Native.extract(&f.path);
+    let a = Engine::Anydoc.extract(&f.path);
+    println!("**{}** — {}\n", f.name, f.note);
+    println!("| signal | native | anydoc |");
+    println!("|---|---:|---:|");
+    for (label, count) in [
+        ("markdown heading lines (`#`)", count_headings as fn(&str) -> usize),
+        ("table delimiter rows (`| --- |`)", count_table_rules),
+        ("table pipe characters", count_pipes),
+    ] {
+        println!("| {} | {} | {} |", label, count(n.text()), count(a.text()));
+    }
+    // Cell-text presence is separate from cell-structure presence.
+    let probe = "col 0";
+    println!(
+        "| occurrences of table cell text `{}` | {} | {} |",
+        probe,
+        n.text().matches(probe).count(),
+        a.text().matches(probe).count()
+    );
+    println!(
+        "| heading text `Quarterly Operations Review` present | {} | {} |",
+        present(&n, "Quarterly Operations Review"),
+        present(&a, "Quarterly Operations Review")
+    );
+    println!();
+}
+
+fn present(o: &Outcome, needle: &str) -> &'static str {
+    if o.text().contains(needle) {
+        "yes"
+    } else {
+        "no"
+    }
+}
+
+fn count_headings(s: &str) -> usize {
+    s.lines().filter(|l| l.trim_start().starts_with('#')).count()
+}
+
+fn count_table_rules(s: &str) -> usize {
+    s.lines()
+        .filter(|l| {
+            let t = l.trim();
+            t.starts_with('|') && t.contains("---")
+        })
+        .count()
+}
+
+fn count_pipes(s: &str) -> usize {
+    s.matches('|').count()
+}
+
+fn head(s: &str, n: usize) -> String {
+    if s.len() <= n {
+        return s.to_string();
+    }
+    let mut cut = n;
+    while cut > 0 && !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    format!("{}…", &s[..cut])
+}

--- a/crates/trusty-search/examples/anydoc_spike/real_corpus.rs
+++ b/crates/trusty-search/examples/anydoc_spike/real_corpus.rs
@@ -1,0 +1,216 @@
+//! Real-document leg: run both extractors over a directory of actual
+//! `.pdf` / `.docx` / `.xlsx` files.
+//!
+//! Synthetic fixtures answer "does the parser handle the shape I built"; only
+//! real documents answer "does it handle what a user's repo contains". The
+//! synthetic PDF corpus already produced one disagreement between the two
+//! extractors, which is exactly the kind of result that needs a real sample
+//! before it is believed or dismissed.
+//!
+//! PRIVACY: this reads whatever directory it is pointed at, which in practice
+//! is the operator's own documents. Nothing here prints a filename, a path, or
+//! a byte of extracted content — rows are labelled by format and index, and
+//! the only per-file values reported are sizes, timings, and outcome
+//! categories. Keep it that way if this harness is ever rerun.
+
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use crate::engines::{fmt_ms, Engine, Outcome};
+
+/// Outcome buckets that matter for an adoption decision. "Both failed" is
+/// separated from "one failed" because a document neither extractor reads is
+/// a property of the document, not a difference between the candidates.
+#[derive(Default)]
+struct Tally {
+    both_ok: usize,
+    both_err: usize,
+    native_only: usize,
+    anydoc_only: usize,
+}
+
+pub fn run(dir: &Path) {
+    let mut files = collect(dir);
+    files.sort();
+
+    println!("## Real-document corpus\n");
+    println!(
+        "Source: a directory of {} actual documents on the measurement host. Filenames and \
+         content are deliberately omitted; rows are labelled by format and index.\n",
+        files.len()
+    );
+
+    let mut per_format: std::collections::BTreeMap<String, Tally> = Default::default();
+    let mut rows: Vec<String> = Vec::new();
+    let mut counter: std::collections::BTreeMap<String, usize> = Default::default();
+    let mut native_errs: std::collections::BTreeMap<String, usize> = Default::default();
+    let mut anydoc_errs: std::collections::BTreeMap<String, usize> = Default::default();
+
+    for path in &files {
+        let ext = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .unwrap_or("")
+            .to_ascii_lowercase();
+        let idx = counter.entry(ext.clone()).or_insert(0);
+        *idx += 1;
+        let label = format!("{ext}-{idx:03}");
+        let size = std::fs::metadata(path).map(|m| m.len()).unwrap_or(0);
+
+        let t = Instant::now();
+        let n = Engine::Native.extract(path);
+        let n_ms = t.elapsed();
+        let t = Instant::now();
+        let a = Engine::Anydoc.extract(path);
+        let a_ms = t.elapsed();
+
+        for (o, bucket) in [(&n, &mut native_errs), (&a, &mut anydoc_errs)] {
+            if let Some(m) = failure_message(o) {
+                *bucket.entry(m).or_insert(0) += 1;
+            }
+        }
+
+        let tally = per_format.entry(ext.clone()).or_default();
+        // A native "ok" carrying the no-extractable-text warning is counted as
+        // a failure to extract: zero indexed text is zero indexed text,
+        // whatever the return type says. Otherwise the comparison would score
+        // our extractor a win for producing an empty string.
+        match (usable(&n), usable(&a)) {
+            (true, true) => tally.both_ok += 1,
+            (false, false) => tally.both_err += 1,
+            (true, false) => tally.native_only += 1,
+            (false, true) => tally.anydoc_only += 1,
+        }
+
+        rows.push(format!(
+            "| {} | {} | {} | {} | {} | {} | {} | {} |",
+            label,
+            size,
+            n.text().trim().len(),
+            a.text().trim().len(),
+            fmt_ms(n_ms),
+            fmt_ms(a_ms),
+            short(&n),
+            short(&a),
+        ));
+    }
+
+    println!("### Outcome summary\n");
+    println!("| format | files | both extracted | native only | anydoc only | neither |");
+    println!("|---|---:|---:|---:|---:|---:|");
+    for (fmt, t) in &per_format {
+        println!(
+            "| {} | {} | {} | {} | {} | {} |",
+            fmt,
+            t.both_ok + t.both_err + t.native_only + t.anydoc_only,
+            t.both_ok,
+            t.native_only,
+            t.anydoc_only,
+            t.both_err
+        );
+    }
+
+    println!("\n### Failure categories\n");
+    println!(
+        "Error text only — anydoc's and ours both describe the parse, not the file, so no \
+         filename leaks through here.\n"
+    );
+    println!("| engine | occurrences | message |");
+    println!("|---|---:|---|");
+    let mut cats: Vec<(&str, String, usize)> = Vec::new();
+    for (engine, msgs) in [("native", &native_errs), ("anydoc", &anydoc_errs)] {
+        for (msg, n) in msgs {
+            cats.push((engine, msg.clone(), *n));
+        }
+    }
+    cats.sort_by(|a, b| b.2.cmp(&a.2));
+    for (engine, msg, n) in cats {
+        println!("| {} | {} | {} |", engine, n, msg);
+    }
+
+    println!("\n### Per-file\n");
+    println!("| file | bytes | native chars | anydoc chars | native ms | anydoc ms | native | anydoc |");
+    println!("|---|---:|---:|---:|---:|---:|---|---|");
+    for r in &rows {
+        println!("{r}");
+    }
+}
+
+/// A one-line, page-count-normalised failure description, or `None` when the
+/// extractor produced usable text. Digit runs are collapsed so "40 pages" and
+/// "3 pages" bucket together instead of producing one category per document.
+fn failure_message(o: &Outcome) -> Option<String> {
+    let raw = match o {
+        Outcome::Err(e) => e.clone(),
+        Outcome::Ok { text, warning } if text.trim().is_empty() => warning
+            .clone()
+            .unwrap_or_else(|| "ok but empty text".to_string()),
+        Outcome::Ok { .. } => return None,
+    };
+    let line = raw.lines().next().unwrap_or("").trim();
+    let mut out = String::with_capacity(line.len());
+    let mut in_digits = false;
+    for c in line.chars() {
+        if c.is_ascii_digit() {
+            if !in_digits {
+                out.push('N');
+                in_digits = true;
+            }
+        } else {
+            in_digits = false;
+            out.push(c);
+        }
+    }
+    Some(out)
+}
+
+/// Did this extractor actually produce indexable text?
+fn usable(o: &Outcome) -> bool {
+    match o {
+        Outcome::Ok { text, .. } => !text.trim().is_empty(),
+        Outcome::Err(_) => false,
+    }
+}
+
+fn short(o: &Outcome) -> &'static str {
+    match o {
+        Outcome::Ok { text, .. } if text.trim().is_empty() => "empty",
+        Outcome::Ok { warning: Some(_), .. } => "ok+warn",
+        Outcome::Ok { .. } => "ok",
+        Outcome::Err(_) => "err",
+    }
+}
+
+/// Every extractable-extension file under `dir`, bounded by the same 10 MiB
+/// cap the walker applies so the sample matches what production would index.
+fn collect(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&d) else {
+            continue;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                stack.push(p);
+                continue;
+            }
+            let ext = p
+                .extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_ascii_lowercase();
+            if !trusty_search::core::extract::is_extractable_ext(&ext) {
+                continue;
+            }
+            if std::fs::metadata(&p).map(|m| m.len()).unwrap_or(u64::MAX)
+                > trusty_search::core::extract::MAX_OFFICE_FILE_BYTES
+            {
+                continue;
+            }
+            out.push(p);
+        }
+    }
+    out
+}

--- a/crates/trusty-search/examples/anydoc_spike/real_corpus.rs
+++ b/crates/trusty-search/examples/anydoc_spike/real_corpus.rs
@@ -123,13 +123,15 @@ pub fn run(dir: &Path) {
             cats.push((engine, msg.clone(), *n));
         }
     }
-    cats.sort_by(|a, b| b.2.cmp(&a.2));
+    cats.sort_by_key(|c| std::cmp::Reverse(c.2));
     for (engine, msg, n) in cats {
         println!("| {} | {} | {} |", engine, n, msg);
     }
 
     println!("\n### Per-file\n");
-    println!("| file | bytes | native chars | anydoc chars | native ms | anydoc ms | native | anydoc |");
+    println!(
+        "| file | bytes | native chars | anydoc chars | native ms | anydoc ms | native | anydoc |"
+    );
     println!("|---|---:|---:|---:|---:|---:|---|---|");
     for r in &rows {
         println!("{r}");
@@ -175,7 +177,9 @@ fn usable(o: &Outcome) -> bool {
 fn short(o: &Outcome) -> &'static str {
     match o {
         Outcome::Ok { text, .. } if text.trim().is_empty() => "empty",
-        Outcome::Ok { warning: Some(_), .. } => "ok+warn",
+        Outcome::Ok {
+            warning: Some(_), ..
+        } => "ok+warn",
         Outcome::Ok { .. } => "ok",
         Outcome::Err(_) => "err",
     }

--- a/crates/trusty-search/examples/anydoc_spike/xlsx_bugs.rs
+++ b/crates/trusty-search/examples/anydoc_spike/xlsx_bugs.rs
@@ -1,0 +1,88 @@
+//! anydoc issues #8 and #9, reproduced against the installed Rust crate.
+//!
+//! Both were filed against the Python bindings; this leg establishes whether
+//! they hold for `anydoc::to_markdown` on the same document shapes, and — the
+//! part the issues do not answer — what they do to the text that would land
+//! in an index chunk.
+
+use crate::engines::Engine;
+use crate::fixtures::Corpus;
+
+pub fn run(corpus: &Corpus) {
+    let fixtures = corpus.xlsx_bugs();
+
+    for f in &fixtures {
+        println!("## `{}`\n", f.name);
+        println!("{}\n", f.note);
+        for engine in [Engine::Native, Engine::Anydoc] {
+            let out = engine.extract(&f.path);
+            println!("### {} — {}\n", engine.label(), out.summary());
+            println!("```\n{}\n```\n", out.text());
+        }
+        assess(&f.name, &f.path);
+    }
+}
+
+fn assess(name: &str, path: &std::path::Path) {
+    let native = Engine::Native.extract(path);
+    let anydoc = Engine::Anydoc.extract(path);
+    let (n, a) = (native.text(), anydoc.text());
+
+    match name {
+        "merged-range.xlsx" => {
+            println!("**Issue #8 assessment**\n");
+            println!("| check | native | anydoc |");
+            println!("|---|---|---|");
+            println!(
+                "| anchor text `Merged heading` present | {} | {} |",
+                yes(n.contains("Merged heading")),
+                yes(a.contains("Merged heading"))
+            );
+            println!(
+                "| non-empty output lines | {} | {} |",
+                n.lines().filter(|l| !l.trim().is_empty()).count(),
+                a.lines().filter(|l| !l.trim().is_empty()).count()
+            );
+            println!(
+                "| extracted chars | {} | {} |\n",
+                n.len(),
+                a.len()
+            );
+            println!(
+                "Index-level reading: the merge span is layout metadata. What reaches a chunk is \
+                 the anchor's text either way, so a clipped span changes the rendered table shape \
+                 without removing a searchable term — as long as the anchor text itself survives.\n"
+            );
+        }
+        "hidden-content.xlsx" => {
+            println!("**Issue #9 assessment**\n");
+            println!("| check | native | anydoc |");
+            println!("|---|---|---|");
+            for probe in ["Visible row", "Hidden row", "Hidden column"] {
+                println!(
+                    "| `{}` in extracted text | {} | {} |",
+                    probe,
+                    yes(n.contains(probe)),
+                    yes(a.contains(probe))
+                );
+            }
+            println!();
+            println!(
+                "Index-level reading: hidden cells becoming searchable text is a behaviour \
+                 question, not a fidelity one — it makes content the author suppressed \
+                 retrievable. Whether that is a defect depends on whether the index is meant to \
+                 mirror what a reader sees or what the file contains. Both extractors' behaviour \
+                 is reported above rather than judged here.\n"
+            );
+        }
+        _ => {}
+    }
+}
+
+fn yes(b: bool) -> &'static str {
+    if b {
+        "yes"
+    } else {
+        "no"
+    }
+}

--- a/crates/trusty-search/examples/anydoc_spike/xlsx_bugs.rs
+++ b/crates/trusty-search/examples/anydoc_spike/xlsx_bugs.rs
@@ -43,11 +43,7 @@ fn assess(name: &str, path: &std::path::Path) {
                 n.lines().filter(|l| !l.trim().is_empty()).count(),
                 a.lines().filter(|l| !l.trim().is_empty()).count()
             );
-            println!(
-                "| extracted chars | {} | {} |\n",
-                n.len(),
-                a.len()
-            );
+            println!("| extracted chars | {} | {} |\n", n.len(), a.len());
             println!(
                 "Index-level reading: the merge span is layout metadata. What reaches a chunk is \
                  the anchor's text either way, so a clipped span changes the rendered table shape \


### PR DESCRIPTION
Measurement spike only. No production extraction code is touched: `EXTRACT_EXTS` is unchanged, `read_content` dispatches exactly where it did, and the harness plus the `anydoc` dependency are both gated behind a default-off `anydoc-spike` feature. Verified rather than asserted — `Compiling anydoc` appears **zero** times in the default-feature clippy log.

# Verdict: NO-GO on wholesale replacement

Not close, and not for the reason the spike was framed around. The two xlsx bugs designated as blocking (#8, #9) turn out **not** to be regressions. Three things nobody was looking for are.

| Leg | Verdict | Decisive evidence |
|---|---|---|
| **pdf** | **Blocked, twice over** | Uncatchable `SIGABRT` on a 21 KB file; 5 of 58 real PDFs silently lost |
| **xlsx** | **Blocked** | Zip-bomb allocation 2x worse than ours (1036 MiB vs 521 MiB), zero fidelity gain |
| **docx** | **Genuine win, unreachable alone** | Real table + heading recovery — but anydoc has no feature flags, so taking it drags in the PDF stack |

---

## 1. anydoc reintroduces RUSTSEC-2026-0187, the advisory this repo already fixed

`anydoc 0.1.3` → `pdf-inspector 0.1.7` → **`lopdf 0.41.0`**. The advisory's patched range is `>= 0.42.0`.

The brief stated anydoc's PDF path wraps lopdf 0.42.0, the same version we pin. That is wrong, and it inverts the conclusion.

`cargo audit`, the same command the weekly workflow runs:

```
base lockfile   → exit 0, zero RUSTSEC-2026-0187 hits
spike lockfile  → exit 1

Title:     Stack overflow in lopdf via deeply nested PDF objects
ID:        RUSTSEC-2026-0187      Severity: 7.5 (high)
Solution:  Upgrade to >=0.42.0
lopdf 0.41.0
└── pdf-inspector 0.1.7
    └── anydoc 0.1.3
        └── trusty-search 0.42.3
```

`.github/workflows/cargo-audit.yml` names this advisory in its own comment header as **resolved by #3367**. Adopting anydoc un-resolves it.

**It cannot be fixed with `cargo update`.** `pdf-inspector 0.1.7` declares `lopdf = "0.41.0"`, a caret range that cannot reach 0.42.0. The pin has to change upstream, in a crate that is not anydoc.

### The advisory is not theoretical here — it fires

The harness feeds both extractors the PoC shape the advisory describes (10,380-deep nested array in a page object, 21 KB file), each in an isolated child process:

| fixture | native | anydoc |
|---|---|---|
| `nested-objects.pdf` | `ok+warning(0 bytes)` — clean return | **`SIGABRT`** — process dies |

The advisory is explicit that this is a stack-overflow abort, **not a `panic!`**: `catch_unwind` does not see it. Our `run_extract_with_timeout` contains panics via `spawn_blocking`'s `JoinError` — that containment does nothing here. One hostile PDF in a watched directory takes the daemon down, and the 30s `EXTRACT_TIMEOUT` never gets a chance to fire.

This is precisely the containment `core::extract` was built to provide, removed.

## 2. anydoc silently loses real PDFs that we currently read

67 real documents on the measurement host (58 pdf, 7 xlsx, 2 docx). No filenames or content appear anywhere in the harness output — rows are labelled by format and index.

| format | files | both extracted | native only | **anydoc only** | neither |
|---|---:|---:|---:|---:|---:|
| pdf | 58 | 38 | **7** | **0** | 13 |
| xlsx | 7 | 5 | 0 | 0 | 2 |
| docx | 2 | 1 | 0 | 0 | 1 |

anydoc never once extracted a document ours could not. It lost 7 that ours reads, and 5 of those are substantial — 36k, 95k, 40k, 23k, and 49k characters of text, gone entirely. All 7 fail with:

```
unsupported input: PDF has no extractable text (TextBased, N pages): OCR is required
```

`pdf-inspector` classifies the document as `TextBased` — it can see there is a text layer — and then extracts nothing from it. (2 of the 7 are `ImageBased` scans where the substantive outcome is a tie; the 5 `TextBased` ones are the defect.)

### This is not an artifact of a synthetic fixture

The same failure showed up on a hand-built fixture, so it was checked against third-party references before being believed:

- `qpdf --check` → *"No syntax or stream encoding errors found"*
- poppler `pdftotext` → extracts all 40 pages correctly
- `pdf-extract` (ours) → 2,192 characters
- anydoc → `no extractable text (TextBased, 40 pages)`

A page-count sweep with the object layout held constant fails identically at 1, 2, 3, 4, 5, 8, 16, and 40 pages, while poppler reads every one. It is a document-shape sensitivity, not a size limit — and it reproduces on real files.

## 3. Adversarial parity — where anydoc is worse, and where it is better

Every probe is an isolated child under a 45s budget. All fixtures sit under the 10 MiB `MAX_OFFICE_FILE_BYTES` gate on purpose: a file the walker already rejects measures nothing.

| fixture | native | anydoc | reading |
|---|---|---|---|
| `nested-objects.pdf` | clean return | **SIGABRT** | **anydoc worse — fatal** |
| `zipbomb.xlsx` | ok, **521 MiB** peak | ok, **1036 MiB** peak | **anydoc worse — 2x** |
| `zipbomb.docx` | rejected at 50 MiB | rejected at 128 MiB | anydoc bound 2.5x looser, but present |
| `nested-xml.docx` (100k deep) | ok, 200,004 bytes | rejected at depth 256 | ours extracts, anydoc refuses |
| `truncated.{docx,xlsx,pdf}` | clean error | clean error | parity |
| `malformed.{docx,pdf}` | clean error | clean error | parity |

**On the docx zip bomb, anydoc does have a bound.** `package::limits::MAX_ENTRY_BYTES` (128 MiB) fires and returns `ResourceLimit`, so wholesale replacement would not remove the `MAX_DOCUMENT_XML_BYTES` + `Read::take` protection outright — it would loosen it from 50 MiB to 128 MiB. Worth stating plainly, since the scope change assumed the protection might vanish entirely.

**On the xlsx zip bomb, anydoc's declared limits do not apply at all.** Both extractors hand the workbook to calamine, which opens the archive itself and bypasses anydoc's package layer. The residual risk documented on #2923 (calamine exposes no pre-decompression bound) is therefore **identical in kind and worse in degree**: 1,036 MiB peak against our 521 MiB, for a 511 KB input. Neither is acceptable; anydoc is the worse of the two.

**Panic containment.** anydoc returned `Result` on every input that did not kill the process, and never unwound. That is a genuine point in its favour over `pdf-extract`'s known panic paths — and it is worth exactly nothing on the one input that matters, because a `SIGABRT` is not a panic. The 30s timeout and `spawn_blocking` containment would still be required, and would still be insufficient.

## 4. anydoc bugs #8 and #9 — both reproduce, neither is a regression

Both were filed against the Python bindings. Both reproduce against the Rust crate 0.1.3. Neither blocks anything, because our extractor is no better.

**#8, merged-cell spans clipped.** Confirmed: an `F1:O3` merge (3 rows × 10 cols) with only the anchor populated renders as a 1×1 table. But the merge span is layout metadata that **our extractor never had either**, and the anchor text survives in both:

| check | native | anydoc |
|---|---|---|
| `Merged heading` present | yes | yes |

Nothing searchable is lost. Not a regression.

**#9, hidden rows/columns treated as visible.** Confirmed — and **our extractor does exactly the same thing**:

| probe | native | anydoc |
|---|---|---|
| `Visible row` | yes | yes |
| `Hidden row` | yes | yes |
| `Hidden column` | yes | yes |

Identical behaviour. Whether indexing author-suppressed content is right is a real product question, but it is a question about our current extractor, not about adoption. Adopting anydoc changes nothing here.

The scope change asked me to quantify these as blocking. They are not. The blockers are elsewhere.

## 5. The docx structure gain is real — and it is the one thing worth wanting

This is where anydoc delivers what was hoped for.

`structured-report.docx` (6 headings, 4 tables of 5×4, 60 paragraphs):

| signal | native | anydoc |
|---|---:|---:|
| markdown heading lines | 0 | **6** |
| table delimiter rows | 0 | **4** |
| table pipe characters | 0 | **140** |
| cell text present | 4 | 4 |

Cell *text* already survives our extractor; every row and column boundary does not. anydoc recovers the structure.

*(An earlier run showed 0 headings for anydoc. That was my fixture's fault — anydoc resolves heading level through `word/styles.xml`, which the fixture omitted. Corrected, and the corrected result is above.)*

### What it buys at the index level

`core::extract` routes all these formats to `chunk_ast`, which finds no grammar and falls through to `chunk_text(window=150, stride=50)`. Markdown pipes are just characters to that chunker. The measurable effect is density:

| fixture | native chunks | anydoc chunks | native lines | anydoc lines |
|---|---:|---:|---:|---:|
| structured-report.docx | 4 | **2** | 294 | 165 |
| large-report.docx | 126 | **86** | 6400 | 4359 |

A table row that our extractor emits as N anonymous paragraphs becomes one line. 32% fewer chunks on the large fixture, with slightly *more* total text. Denser chunks with row context intact is a real retrieval improvement — a query matching two cells in the same row now hits one chunk containing both.

**But it is not reachable in isolation.** anydoc has **no feature flags** — all 11 dependencies are unconditional. There is no way to take the docx frontend without linking `pdf-inspector` → `lopdf 0.41.0`. Even if we never route a PDF through it, the advisory lands in `Cargo.lock`, and `cargo audit` reads the lockfile, not the feature-resolved graph.

## 6. The simplification case does not hold

The scope change asked me to quantify simplification as part of the argument. Measured, it runs the other way.

**Code deleted** — `pdf.rs` + `docx.rs` + `xlsx.rs`, excluding test modules:

| file | production | tests |
|---|---:|---:|
| pdf.rs | 46 | 202 |
| docx.rs | 181 | 169 |
| xlsx.rs | 58 | 270 |
| **total** | **285** | **641** |

~285 production lines removed. The 641 test lines are not a saving — they encode the zip-bomb bounds, the RUSTSEC-2026-0187 regression test, and the quick-xml entity handling from #3367. Deleting them discards the record of three fixed defects.

**Dependencies and size**, measured with two isolated scratch crates each linking only its own extraction stack, `--release`, stripped:

| | native stack | anydoc stack | delta |
|---|---:|---:|---:|
| binary, macOS arm64 | 2,340,688 B | 7,004,816 B | **+4.45 MiB (2.99x)** |
| binary, aarch64-linux-gnu | 2,593,016 B | 7,202,896 B | **+4.40 MiB (2.78x)** |
| crates in graph | 91 | 175 | **+84** |

`pdf-extract` is dropped; `calamine`/`quick-xml`/`zip` become transitive rather than direct. Net: **285 fewer production lines in exchange for 84 more crates and 4.4 MiB.**

**The `zip` duplication premise was also wrong.** `zip` 1.1.4 / 2.4.2 / 3.0.0 / 7.2.0 / **8.6.0** all already coexist on `main` — calamine has pulled 8.6.0 for some time. anydoc adds **zero** new `zip` versions.

**What it does add is a C toolchain dependency.** anydoc requests `zip ^8.6.0` with default features on, which turns on zstd for the shared node and pulls in `zstd-sys` — 43 C source files, `links = "zstd"`. Every other crate anydoc adds is pure Rust. Consequence, measured:

```
cargo check --target aarch64-unknown-linux-gnu
  native stack → exit 0
  anydoc stack → exit 101
    error occurred in cc-rs: failed to find tool "aarch64-linux-gnu-gcc"
```

The current extraction stack cross-compiles with no C toolchain at all. anydoc's does not.

## 7. Build legs — what I could and could not verify

**Could not run containers.** Docker Desktop would not start on this host (`docker info` fails; the API returns HTTP 500). I am not reporting a container result I did not obtain.

**What I did instead:** built both stacks with `cargo-zigbuild`, which supplies the cross C toolchain, and verified the machine type of the output rather than inferring it from a successful link.

| target | native | anydoc |
|---|---|---|
| `aarch64-unknown-linux-gnu` | exit 0 | exit 0 |
| `aarch64-unknown-linux-gnu.2.34` (AL2023 glibc floor) | exit 0 | exit 0 |

```
size-anydoc: ELF 64-bit LSB pie executable, ARM aarch64, ... stripped
size-native: ELF 64-bit LSB pie executable, ARM aarch64, ... stripped
```

**Scope of that result, stated precisely:** it covers the anydoc dependency subgraph on both aarch64 legs. It does not exercise the full `trusty-search` binary on those legs. PR #4822 moved the `aarch64-unknown-linux-gnu` leg to a native ARM runner specifically because zig's clang mis-compiled `numkong`; a zigbuild pass here says nothing about that. `aarch64-linux-al2023` is a repo label, not a rustc triple — the glibc floor is the reproducible part of it, and that is what I pinned.

## 8. Speed and memory — the one place anydoc's numbers do not matter

anydoc is 2.0x–7.7x slower and allocates 1.5x–8x more, and neither figure should influence the decision, because the absolutes are trivial at this scale.

| fixture | native med (ms) | anydoc med (ms) | ratio | native ΔRSS | anydoc ΔRSS |
|---|---:|---:|---:|---:|---:|
| small-memo.docx | 0.03 | 0.06 | 2.16x | 0.6 MiB | 1.5 MiB |
| structured-report.docx | 0.05 | 0.23 | 4.34x | 0.7 MiB | 2.1 MiB |
| large-report.docx | 0.54 | 4.15 | 7.69x | 1.2 MiB | 9.3 MiB |
| multi-sheet.xlsx | 1.74 | 5.20 | 2.98x | 1.8 MiB | 3.8 MiB |
| multi-page.pdf | 0.37 | 0.72 | 1.96x | 1.2 MiB | 4.5 MiB |

N = 100 repetitions per cell (10–30 for the largest fixtures), min and median reported. On the real corpus the largest PDF took 17.6 ms native / 24.4 ms anydoc. Against a 30s `EXTRACT_TIMEOUT` and one-file-at-a-time ingest, a 4 ms parse and a 9 MiB peak are noise. Reported for completeness; they carry no weight in the verdict.

---

# Recommendation

**Do not adopt anydoc for pdf or xlsx.** Not "wait for the spreadsheet bugs to close" — the spreadsheet bugs turned out to be irrelevant. The reasons are an uncatchable process abort, an 8.6% silent data-loss rate on real PDFs, and worse zip-bomb behaviour than the code it would replace.

**Do not adopt it for docx yet either**, despite the structure gain being real and worth having. Not because docx conversion is bad — it is clearly better than ours — but because anydoc ships no feature flags, so there is no way to take the docx frontend without putting `lopdf 0.41.0` in `Cargo.lock` and turning the weekly `cargo audit` red.

**On the new formats** (ppt/pptx, odt/ods/odp, rtf, epub, legacy .doc) I have no measurement — we cannot read them at all today, so there is no baseline to compare against and I did not invent one. The case for them is real but rests on the same dependency, so it is gated behind the same upstream fixes.

### What would change the answer

Two upstream fixes, in this order:

1. **`pdf-inspector` bumps `lopdf` to `>= 0.42.0`.** Clears the advisory and the abort. Not something we can do with `cargo update`.
2. **`pdf-inspector` extracts text from `TextBased` PDFs it already classifies correctly.** The 5 real-document failures are worth filing upstream with a reproducer — the harness in this PR generates one.

A third, smaller: anydoc setting `default-features = false` on `zip` would drop `zstd-sys` and restore pure-Rust cross-compilation.

If the first two land, re-run this harness. It is one command, and the comparison is already wired.

### Merge consideration

**This PR should not be merged as-is**, independent of the adoption decision. Its `Cargo.lock` alone carries `lopdf 0.41.0` and turns `cargo-audit.yml` red weekly — the feature gate keeps anydoc out of every *build*, but `cargo audit` reads the lockfile, not the feature-resolved graph. If the harness is worth keeping in-tree, drop the dependency and lockfile entry and restore them when re-measuring.

---

## Verification

```
cargo fmt --check                                             → exit 0
cargo clippy -p trusty-search --all-targets -D warnings       → exit 0
cargo clippy -p trusty-search --features anydoc-spike
             --all-targets -D warnings                        → exit 0
cargo test -p trusty-search                                   → exit 0

test result: ok. 1456 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
test result: ok. 349 passed; 0 failed; 3 ignored; 0 measured; 0 filtered out
(22 further targets, all ok, 0 failed)
```

Inertness, verified not assumed: `grep -c 'Compiling anydoc'` over the default-feature clippy log → **0**.

Raw measurements: `crates/trusty-search/examples/anydoc_spike/MEASUREMENTS.md`.

No production extraction code changed. No version bumps. No daemon or `TRUSTY_DATA_DIR` touched — the harness writes only to a scratch corpus directory.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
