### PR TITLE
fix(trusty-mpm): surface the skills the every-run deploy declines (#4873)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4873-skill-deploy-visibility.md
+++ b/crates/trusty-mpm/changelog.d/4873-skill-deploy-visibility.md
@@ -1,0 +1,5 @@
+Fixed
+
+- a skill the every-run deploy declines to refresh is now reported instead of skipped in silence: `ensure_managed_config_dir` emits one bounded warning naming the withheld files and pointing at `tm doctor --fix-skills --include-frozen` (closes [#4873](https://github.com/bobmatnyc/trusty-tools/issues/4873))
+  - the skip itself is unchanged and still correct — a hand-edited (checksum-frozen) skill and an unmanaged project-custom skill are both preserved
+  - corrects the `resume_managed` and `run_inplace_relaunch` comments that claimed agent/skill redeploy and MCP injection were not re-run on those paths; all three run paths reach `ensure_managed_config_dir` through `prepare_managed_config`, so they always were

--- a/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
+++ b/crates/trusty-mpm/src/bin/tm/commands/guided_inplace.rs
@@ -568,6 +568,14 @@ pub(crate) async fn run_inplace_relaunch(
     // in a managed pane was the one way to start a session on a stale or missing
     // compiled prompt where a fresh launch would have refused.
     //
+    // #4873: the PROMPT is the only thing this path had to refresh by hand.
+    // Agents and skills are already covered — `build_inplace_resume_command`
+    // below calls `runtime::claude_code::prepare_managed_config`, which runs
+    // `core::managed_config::ensure_managed_config_dir` and redeploys both
+    // rosters. Read the "only daemon call is `reactivate`" line above as being
+    // about DAEMON calls specifically; it is not a claim that this path skips
+    // asset deployment.
+    //
     // Ordered BEFORE `build_inplace_resume_command` so a refusal costs nothing
     // and, like the other two sites, cannot half-provision the pane.
     //

--- a/crates/trusty-mpm/src/core/agent_source.rs
+++ b/crates/trusty-mpm/src/core/agent_source.rs
@@ -188,8 +188,13 @@ pub fn ensure_agent_source_fresh(agents_dir: &Path) -> Result<bool> {
 ///
 /// What: joins the first `limit` entries with `, `, appending `, …` when more
 /// were elided. Pure.
-/// Test: exercised through `deploy_summary_lines_*`.
-fn preview(items: &[String], limit: usize) -> String {
+///
+/// #4873: shared with `managed_config::skill_skip_summary`, which needs the
+/// identical count-plus-preview shape for the SKILL half of the same warning
+/// policy — a second copy would drift from this one.
+/// Test: exercised through `deploy_summary_lines_*` and
+/// `skill_skip_summary_*`.
+pub(crate) fn preview(items: &[String], limit: usize) -> String {
     let head = items
         .iter()
         .take(limit)

--- a/crates/trusty-mpm/src/core/managed_config.rs
+++ b/crates/trusty-mpm/src/core/managed_config.rs
@@ -52,9 +52,19 @@
 //! agents deploy into, on both the daemon and the flag-less standalone `tm run`
 //! path, which is why provisioning the complete set here remains mandatory. It
 //! also still carries AUTH + TRUST isolation (keychain / `.credentials.json` /
-//! `.claude.json` keyed to this path). SKILLS are unchanged: they continue to
-//! deploy per-workspace via `prepare_session`, and this module's skill deploy
-//! remains belt-and-suspenders for the standalone path.
+//! `.claude.json` keyed to this path).
+//!
+//! SKILLS ride the same tier (corrected #4873). The older note here said they
+//! "continue to deploy per-workspace via `prepare_session`" and that this
+//! module's skill deploy was belt-and-suspenders. That predates
+//! `SETTING_SOURCES_FLAG_RELOCATED`: the managed spawn resolves `config_dir`
+//! to `Some`, so it launches with `--setting-sources user,project,local` and
+//! the `user` tier this directory relocates is read for skills exactly as it
+//! is for agents. The deploy below is load-bearing, not a backup — measured
+//! 2026-08-05, 49 of 52 skills under `$CLAUDE_CONFIG_DIR/skills/` were
+//! byte-identical to the running binary's bundled source, and all three
+//! exceptions were checksum-frozen hand edits the deployer is correct to
+//! decline.
 //!
 //! What: [`ensure_managed_config_dir`] (1) runs the canonical standalone
 //! scaffolding ([`ensure_global_config_dir`] — settings.json + the MPM hook
@@ -68,11 +78,14 @@
 //! [`crate::core::agent_source::autodeploy_agents_for`] — before that, only the
 //! manual `tm install` ever wrote `~/.trusty-mpm/framework/agents/`, so a
 //! merged, compiled-in `BASE-AGENT.md` change silently reached no running
-//! agent.
+//! agent. Since #4873 the SKILL half warns (once, bounded) about every file it
+//! declined to refresh — the deploy itself already ran on all three run paths;
+//! only the evidence of it was missing.
 //! Test: `ensure_managed_config_dir_deploys_full_roster`,
 //! `ensure_managed_config_dir_is_idempotent`,
 //! `ensure_managed_config_dir_refreshes_stale_bundled_agents`,
-//! `ensure_managed_config_dir_survives_an_unwritable_agent_target`.
+//! `ensure_managed_config_dir_survives_an_unwritable_agent_target`,
+//! `crates/trusty-mpm/src/core/managed_config_tests.rs`.
 
 use std::path::Path;
 
@@ -87,10 +100,12 @@ use crate::core::standalone::global_config::ensure_global_config_dir;
 /// the session an isolated, fully-scaffolded config home (auth, trust, MCP
 /// stubs, output-styles) plus the full framework roster/skills. The AGENT
 /// roster deployed here is load-bearing on BOTH the daemon and the standalone
-/// path (issue #4409 — see the module doc's corrected discovery note); the
-/// skill deploy stays belt-and-suspenders for the daemon, since skills still
-/// load from the per-workspace project tier. Runs on every spawn because it is
-/// cheap and idempotent, matching the standalone `tm run` contract.
+/// path (issue #4409 — see the module doc's corrected discovery note), and so
+/// is the SKILL deploy since the spawn began passing
+/// `--setting-sources user,project,local` (#4873 — the module doc's SKILLS
+/// paragraph retires the older "belt-and-suspenders" reading). Runs on every
+/// spawn, resume, and in-place relaunch because it is cheap and idempotent,
+/// matching the standalone `tm run` contract.
 /// What: resolves the framework layout from the daemon's fixed home-relative
 /// root ([`FrameworkPaths::default`]), then:
 /// 1. calls [`ensure_global_config_dir`]`(&fw.root, config_dir)` for the shared
@@ -124,10 +139,28 @@ pub fn ensure_managed_config_dir(config_dir: &Path) -> anyhow::Result<()> {
 /// What: performs the two-phase provisioning described on
 /// [`ensure_managed_config_dir`], using `fw` for both the `ensure_global_config_dir`
 /// managed-root argument (`fw.root`) and the full-roster source dirs.
+///
+/// #4873 — WHY THE SKILL HALF ALSO RUNS ON RESUME AND IN-PLACE RELAUNCH.
+/// This function is the choke point all THREE run paths share, because each
+/// reaches it through `runtime::claude_code::prepare_managed_config`:
+/// `ClaudeCodeAdapter::spawn` (fresh), `ClaudeCodeAdapter::spawn_resume`
+/// (`daemon::managed_routes::lifecycle::resume_managed`), and
+/// `runtime::claude_code::build_inplace_resume_command` (bare `tm` in a
+/// managed pane). So the skill deploy below already satisfies the "deploy on
+/// every run, not just `tm install`" ruling, exactly as the agent half does —
+/// what was missing was any SIGN of it: a skill the deployer declines is
+/// silent, which is why three checksum-frozen skills read as "deployment never
+/// runs". [`skill_skip_summary`] supplies that sign.
+///
 /// Test: `ensure_managed_config_dir_deploys_full_roster`,
 /// `ensure_managed_config_dir_is_idempotent`,
 /// `ensure_managed_config_dir_refreshes_stale_bundled_agents`,
-/// `ensure_managed_config_dir_survives_an_unwritable_agent_target`.
+/// `ensure_managed_config_dir_survives_an_unwritable_agent_target`,
+/// `ensure_managed_config_dir_refreshes_a_stale_managed_skill`,
+/// `ensure_managed_config_dir_skill_deploy_is_a_noop_when_unchanged`,
+/// `ensure_managed_config_dir_preserves_a_project_custom_skill`,
+/// `ensure_managed_config_dir_skips_a_frozen_skill`,
+/// `ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped`.
 pub fn ensure_managed_config_dir_with_root(
     fw: &FrameworkPaths,
     config_dir: &Path,
@@ -177,274 +210,59 @@ pub fn ensure_managed_config_dir_with_root(
     // reasoning — see that function's doc comment for why the project-custom
     // tier is naturally N/A at this destination).
     let skills_dest = config_dir.join("skills");
-    deploy_all_skill_tiers(
+    let skills = deploy_all_skill_tiers(
         &fw.skill_source_dir(),
         &fw.user_skill_source_dir(),
         &skills_dest,
         |_| true,
     )
     .map_err(|e| anyhow::anyhow!("failed to deploy full skill set into managed config dir: {e}"))?;
+    // #4873: a declined skill was SILENT, so a stale one looked like a deploy
+    // that never ran — see this function's doc for why that is the whole defect.
+    if let Some(line) = skill_skip_summary(&skills.stats.skipped) {
+        tracing::warn!("managed config dir: {line}");
+    }
 
     Ok(())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    /// Build a `FrameworkPaths` whose framework SOURCE dirs are populated from a
-    /// small but representative slice of the real bundled roster, so the deploy
-    /// assertions do not depend on a prior `tm install` or the git submodule.
-    fn seed_framework(base: &Path) -> FrameworkPaths {
-        let fw = FrameworkPaths::under(base);
-        std::fs::create_dir_all(&fw.agents).unwrap();
-        std::fs::create_dir_all(&fw.skills).unwrap();
-        // A minimal set spanning the roster's shape: a base to inherit from, a
-        // core specialist, and a couple of the agents #1996 called out.
-        let agents: &[(&str, &str)] = &[
-            (
-                "BASE-AGENT.md",
-                "---\nname: BASE-AGENT\ndescription: base\n---\n\nBase.\n",
-            ),
-            (
-                "engineer.md",
-                "---\nname: engineer\ndescription: implementation specialist\n---\n\nEngineer.\n",
-            ),
-            (
-                "rust-engineer.md",
-                "---\nname: rust-engineer\ndescription: rust specialist\n---\n\nRust.\n",
-            ),
-            (
-                "research.md",
-                "---\nname: research\ndescription: research specialist\n---\n\nResearch.\n",
-            ),
-            (
-                "qa.md",
-                "---\nname: qa\ndescription: quality specialist\n---\n\nQA.\n",
-            ),
-            (
-                "version-control.md",
-                "---\nname: version-control\ndescription: git specialist\n---\n\nVCS.\n",
-            ),
-            (
-                "ticketing.md",
-                "---\nname: ticketing\ndescription: ticketing specialist\n---\n\nTickets.\n",
-            ),
-        ];
-        for (name, body) in agents {
-            std::fs::write(fw.agents.join(name), body).unwrap();
-        }
-        std::fs::write(
-            fw.skills.join("tm-doctor.md"),
-            "---\nname: tm-doctor\ndescription: doctor\n---\n\nDoctor.\n",
-        )
-        .unwrap();
-        fw
+/// One bounded warning line for the skills a deploy declined to write, or
+/// `None` when it declined nothing.
+///
+/// Why: this closes for SKILLS the half of #4840 that PR #4848 closed for
+/// agents. `deploy_one_file` skips a checksum-frozen (hand-edited) or
+/// unmanaged skill and reports it only in the returned `DeployStats`, which
+/// every caller here discarded — so a skill frozen against the manifest stayed
+/// stale on every run, forever, with no warning anywhere. That silence is what
+/// #4873 was filed as: three frozen skills read as "skill deployment never
+/// runs on resume", when deployment had in fact run and correctly declined
+/// them. The skip itself is CORRECT and is deliberately left alone — a hand
+/// edit must survive, and `tm doctor --fix-skills --include-frozen` is the
+/// remedy the pointer names.
+/// What: a count plus a five-entry preview and that remedy pointer. Matches
+/// [`crate::core::agent_source::deploy_summary_lines`]'s policy (issue #2504:
+/// count + preview, never one line per file) because this runs on EVERY spawn,
+/// resume, and in-place relaunch and the frozen set is not reconciled until
+/// someone runs the doctor — one line per file would be permanent log spam.
+/// Pure — no I/O, no logging.
+/// Test: `skill_skip_summary_is_none_on_a_clean_deploy`,
+/// `skill_skip_summary_counts_and_previews`,
+/// `skill_skip_summary_elides_beyond_five`,
+/// `ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped`.
+fn skill_skip_summary(skipped: &[String]) -> Option<String> {
+    if skipped.is_empty() {
+        return None;
     }
-
-    #[test]
-    fn ensure_managed_config_dir_deploys_full_roster() {
-        let tmp = TempDir::new().unwrap();
-        let fw = seed_framework(tmp.path());
-        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
-
-        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-
-        // Scaffolding landed.
-        assert!(config_dir.join("settings.json").exists());
-        assert!(config_dir.join(".mcp.json").exists());
-
-        // Every seeded specialist must be present AND spawnable (has a
-        // `description` in its deployed frontmatter).
-        let agents_dir = config_dir.join("agents");
-        for name in [
-            "engineer",
-            "rust-engineer",
-            "research",
-            "qa",
-            "version-control",
-            "ticketing",
-        ] {
-            let path = agents_dir.join(format!("{name}.md"));
-            assert!(path.exists(), "agent {name} must be deployed to config dir");
-            let body = std::fs::read_to_string(&path).unwrap();
-            assert!(
-                body.contains("description:"),
-                "deployed agent {name} must carry a description (spawnable)"
-            );
-        }
-
-        // Skills landed too.
-        assert!(
-            config_dir.join("skills/tm-doctor/SKILL.md").exists(),
-            "tm-* skills must be deployed to config dir"
-        );
-    }
-
-    #[test]
-    fn ensure_managed_config_dir_is_idempotent() {
-        let tmp = TempDir::new().unwrap();
-        let fw = seed_framework(tmp.path());
-        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
-
-        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-        let first = std::fs::read_to_string(config_dir.join("agents/engineer.md")).unwrap();
-
-        // A second call must not fail and must leave the deployed roster intact.
-        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-        let second = std::fs::read_to_string(config_dir.join("agents/engineer.md")).unwrap();
-
-        assert_eq!(first, second, "re-provisioning must be idempotent");
-    }
-
-    #[test]
-    fn ensure_managed_config_dir_refreshes_stale_bundled_agents() {
-        // #4840: the exact measured shape — a framework agent source written by
-        // an older `tm install` sits on disk while the running binary embeds a
-        // newer one. Provisioning must close that gap with no manual step.
-        let tmp = TempDir::new().unwrap();
-        let fw = FrameworkPaths::under(tmp.path());
-        std::fs::create_dir_all(&fw.agents).unwrap();
-        std::fs::write(
-            fw.agents.join("BASE-AGENT.md"),
-            "---\nname: BASE-AGENT\ndescription: base\n---\n\nSTALE-SENTINEL-4840\n",
-        )
-        .unwrap();
-        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
-
-        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-
-        assert_eq!(
-            std::fs::read_to_string(fw.agents.join("BASE-AGENT.md")).unwrap(),
-            crate::core::bundle::BASE_AGENT,
-            "the bundled agent SOURCE must be re-materialized from the running binary"
-        );
-        let deployed = std::fs::read_to_string(config_dir.join("agents/BASE-AGENT.md")).unwrap();
-        assert!(
-            !deployed.contains("STALE-SENTINEL-4840"),
-            "the stale composition must not survive into the deploy target"
-        );
-    }
-
-    #[test]
-    fn ensure_managed_config_dir_survives_an_unwritable_agent_target() {
-        // Fail open (#4840): a broken agent deploy must never block a session.
-        // A regular file where `<config_dir>/agents` belongs makes every write
-        // under it impossible and cannot be repaired by `create_dir_all`.
-        let tmp = TempDir::new().unwrap();
-        let fw = FrameworkPaths::under(tmp.path());
-        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
-        std::fs::create_dir_all(&config_dir).unwrap();
-        std::fs::write(config_dir.join("agents"), "blocking file\n").unwrap();
-
-        ensure_managed_config_dir_with_root(&fw, &config_dir)
-            .expect("an undeployable agent roster must not fail provisioning");
-
-        assert!(
-            config_dir.join("settings.json").exists(),
-            "the rest of the config dir must still be provisioned"
-        );
-    }
-
-    #[test]
-    fn ensure_managed_config_dir_deploys_user_tier_skill() {
-        // PR #2818 review (round 3, MEDIUM decision): a user-custom skill
-        // (`fw.user_skill_source_dir()`, i.e. `<root>/skills`) must reach the
-        // tm-global roster, not just per-project deploys.
-        let tmp = TempDir::new().unwrap();
-        let fw = seed_framework(tmp.path());
-        std::fs::create_dir_all(&fw.user_skills).unwrap();
-        std::fs::write(
-            fw.user_skills.join("my-custom-skill.md"),
-            "---\nname: my-custom-skill\n---\n\nUSER CUSTOM.\n",
-        )
-        .unwrap();
-
-        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
-        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-
-        assert!(
-            config_dir.join("skills/my-custom-skill/SKILL.md").exists(),
-            "user-custom skill must be deployed to the tm-global config dir"
-        );
-    }
-
-    /// Static verification against the REAL bundled roster (`src/assets/agents`,
-    /// `src/assets/skills`). Ignored by default because it composes and writes the
-    /// full ~40-agent set; run explicitly to prove the complete specialist roster
-    /// deploys and that every deployed agent is spawnable (carries a `description`):
-    ///
-    /// `cargo test -p trusty-mpm --lib manual_static_verify_full_roster -- --ignored --nocapture`
-    #[test]
-    #[ignore = "static verification — composes the full real roster; run explicitly"]
-    fn manual_static_verify_full_roster() {
-        let tmp = TempDir::new().unwrap();
-        let fw = FrameworkPaths::under(tmp.path());
-        std::fs::create_dir_all(&fw.agents).unwrap();
-        std::fs::create_dir_all(&fw.skills).unwrap();
-
-        // Copy the REAL bundled raw sources into the framework source dirs.
-        let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
-        for (src, dst) in [
-            (manifest.join("src/assets/agents"), &fw.agents),
-            (manifest.join("src/assets/skills"), &fw.skills),
-        ] {
-            for entry in std::fs::read_dir(&src).unwrap() {
-                let entry = entry.unwrap();
-                if entry.path().extension().and_then(|e| e.to_str()) == Some("md") {
-                    std::fs::copy(entry.path(), dst.join(entry.file_name())).unwrap();
-                }
-            }
-        }
-
-        let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
-        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-
-        // List every deployed agent and confirm each is spawnable.
-        let agents_dir = config_dir.join("agents");
-        let mut deployed: Vec<String> = std::fs::read_dir(&agents_dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("md"))
-            .map(|e| e.file_name().to_string_lossy().into_owned())
-            .collect();
-        deployed.sort();
-
-        println!("\n=== deployed agents ({}) ===", deployed.len());
-        let mut missing_desc = Vec::new();
-        for name in &deployed {
-            let body = std::fs::read_to_string(agents_dir.join(name)).unwrap();
-            let has_desc = body.contains("description:");
-            println!("  {name}  spawnable={has_desc}");
-            // BASE-*.md are inheritance templates (parents of `extends:` agents),
-            // intentionally without a `description` and never independently
-            // spawnable — exclude them from the spawnable requirement.
-            if !has_desc && !name.starts_with("BASE-") {
-                missing_desc.push(name.clone());
-            }
-        }
-
-        // The specialists #1996 and the task call out must all be present.
-        for required in [
-            "engineer.md",
-            "rust-engineer.md",
-            "research.md",
-            "qa.md",
-            "local-ops.md",
-            "version-control.md",
-            "ticketing.md",
-            "documentation.md",
-            "security.md",
-        ] {
-            assert!(
-                deployed.iter().any(|d| d == required),
-                "required agent {required} missing from deployed roster: {deployed:?}"
-            );
-        }
-        assert!(
-            missing_desc.is_empty(),
-            "these deployed agents are not spawnable (no description): {missing_desc:?}"
-        );
-    }
+    Some(format!(
+        "warning: {} skill file(s) were NOT refreshed — each is user-owned \
+         (hand-edited away from its recorded checksum, or never managed here), \
+         so the bundled version was withheld: {}. Run \
+         `tm doctor --fix-skills --include-frozen` to adopt them.",
+        skipped.len(),
+        crate::core::agent_source::preview(skipped, 5)
+    ))
 }
+
+#[cfg(test)]
+#[path = "managed_config_tests.rs"]
+mod tests;

--- a/crates/trusty-mpm/src/core/managed_config.rs
+++ b/crates/trusty-mpm/src/core/managed_config.rs
@@ -160,7 +160,7 @@ pub fn ensure_managed_config_dir(config_dir: &Path) -> anyhow::Result<()> {
 /// `ensure_managed_config_dir_skill_deploy_is_a_noop_when_unchanged`,
 /// `ensure_managed_config_dir_preserves_a_project_custom_skill`,
 /// `ensure_managed_config_dir_skips_a_frozen_skill`,
-/// `ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped`.
+/// `ensure_managed_config_dir_emits_the_frozen_skill_warning`.
 pub fn ensure_managed_config_dir_with_root(
     fw: &FrameworkPaths,
     config_dir: &Path,
@@ -248,7 +248,8 @@ pub fn ensure_managed_config_dir_with_root(
 /// Test: `skill_skip_summary_is_none_on_a_clean_deploy`,
 /// `skill_skip_summary_counts_and_previews`,
 /// `skill_skip_summary_elides_beyond_five`,
-/// `ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped`.
+/// `a_declined_skill_reaches_skill_skip_summary_from_a_real_deploy`,
+/// `ensure_managed_config_dir_emits_the_frozen_skill_warning` (the call site).
 fn skill_skip_summary(skipped: &[String]) -> Option<String> {
     if skipped.is_empty() {
         return None;

--- a/crates/trusty-mpm/src/core/managed_config_tests.rs
+++ b/crates/trusty-mpm/src/core/managed_config_tests.rs
@@ -1,0 +1,531 @@
+//! Unit tests for [`super::ensure_managed_config_dir_with_root`] — the single
+//! choke point every managed run path shares.
+//!
+//! Why a sibling file (#4873): `managed_config.rs` is a PRODUCTION file under
+//! this repo's 500-SLOC cap and was already at 416 lines before this issue's
+//! coverage was added. A `*_tests.rs` sibling is classified as a test file
+//! (3000-SLOC cap) by `scripts/check_line_cap.sh`, matching the pattern
+//! `agent_source_tests.rs` and `lifecycle_tests.rs` already use.
+//!
+//! What: the pre-existing agent/scaffolding cases, moved verbatim, plus the
+//! #4873 skill cases — refresh, no-op idempotence, project-custom
+//! preservation, frozen-skill preservation, and the warning that finally makes
+//! that last one visible.
+
+use super::*;
+use tempfile::TempDir;
+
+/// Build a `FrameworkPaths` whose framework SOURCE dirs are populated from a
+/// small but representative slice of the real bundled roster, so the deploy
+/// assertions do not depend on a prior `tm install` or the git submodule.
+fn seed_framework(base: &Path) -> FrameworkPaths {
+    let fw = FrameworkPaths::under(base);
+    std::fs::create_dir_all(&fw.agents).unwrap();
+    std::fs::create_dir_all(&fw.skills).unwrap();
+    // A minimal set spanning the roster's shape: a base to inherit from, a
+    // core specialist, and a couple of the agents #1996 called out.
+    let agents: &[(&str, &str)] = &[
+        (
+            "BASE-AGENT.md",
+            "---\nname: BASE-AGENT\ndescription: base\n---\n\nBase.\n",
+        ),
+        (
+            "engineer.md",
+            "---\nname: engineer\ndescription: implementation specialist\n---\n\nEngineer.\n",
+        ),
+        (
+            "rust-engineer.md",
+            "---\nname: rust-engineer\ndescription: rust specialist\n---\n\nRust.\n",
+        ),
+        (
+            "research.md",
+            "---\nname: research\ndescription: research specialist\n---\n\nResearch.\n",
+        ),
+        (
+            "qa.md",
+            "---\nname: qa\ndescription: quality specialist\n---\n\nQA.\n",
+        ),
+        (
+            "version-control.md",
+            "---\nname: version-control\ndescription: git specialist\n---\n\nVCS.\n",
+        ),
+        (
+            "ticketing.md",
+            "---\nname: ticketing\ndescription: ticketing specialist\n---\n\nTickets.\n",
+        ),
+    ];
+    for (name, body) in agents {
+        std::fs::write(fw.agents.join(name), body).unwrap();
+    }
+    std::fs::write(
+        fw.skills.join("tm-doctor.md"),
+        "---\nname: tm-doctor\ndescription: doctor\n---\n\nDoctor.\n",
+    )
+    .unwrap();
+    fw
+}
+
+#[test]
+fn ensure_managed_config_dir_deploys_full_roster() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+    // Scaffolding landed.
+    assert!(config_dir.join("settings.json").exists());
+    assert!(config_dir.join(".mcp.json").exists());
+
+    // Every seeded specialist must be present AND spawnable (has a
+    // `description` in its deployed frontmatter).
+    let agents_dir = config_dir.join("agents");
+    for name in [
+        "engineer",
+        "rust-engineer",
+        "research",
+        "qa",
+        "version-control",
+        "ticketing",
+    ] {
+        let path = agents_dir.join(format!("{name}.md"));
+        assert!(path.exists(), "agent {name} must be deployed to config dir");
+        let body = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            body.contains("description:"),
+            "deployed agent {name} must carry a description (spawnable)"
+        );
+    }
+
+    // Skills landed too.
+    assert!(
+        config_dir.join("skills/tm-doctor/SKILL.md").exists(),
+        "tm-* skills must be deployed to config dir"
+    );
+}
+
+#[test]
+fn ensure_managed_config_dir_is_idempotent() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    let first = std::fs::read_to_string(config_dir.join("agents/engineer.md")).unwrap();
+
+    // A second call must not fail and must leave the deployed roster intact.
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    let second = std::fs::read_to_string(config_dir.join("agents/engineer.md")).unwrap();
+
+    assert_eq!(first, second, "re-provisioning must be idempotent");
+}
+
+#[test]
+fn ensure_managed_config_dir_refreshes_stale_bundled_agents() {
+    // #4840: the exact measured shape — a framework agent source written by
+    // an older `tm install` sits on disk while the running binary embeds a
+    // newer one. Provisioning must close that gap with no manual step.
+    let tmp = TempDir::new().unwrap();
+    let fw = FrameworkPaths::under(tmp.path());
+    std::fs::create_dir_all(&fw.agents).unwrap();
+    std::fs::write(
+        fw.agents.join("BASE-AGENT.md"),
+        "---\nname: BASE-AGENT\ndescription: base\n---\n\nSTALE-SENTINEL-4840\n",
+    )
+    .unwrap();
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(fw.agents.join("BASE-AGENT.md")).unwrap(),
+        crate::core::bundle::BASE_AGENT,
+        "the bundled agent SOURCE must be re-materialized from the running binary"
+    );
+    let deployed = std::fs::read_to_string(config_dir.join("agents/BASE-AGENT.md")).unwrap();
+    assert!(
+        !deployed.contains("STALE-SENTINEL-4840"),
+        "the stale composition must not survive into the deploy target"
+    );
+}
+
+#[test]
+fn ensure_managed_config_dir_survives_an_unwritable_agent_target() {
+    // Fail open (#4840): a broken agent deploy must never block a session.
+    // A regular file where `<config_dir>/agents` belongs makes every write
+    // under it impossible and cannot be repaired by `create_dir_all`.
+    let tmp = TempDir::new().unwrap();
+    let fw = FrameworkPaths::under(tmp.path());
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    std::fs::write(config_dir.join("agents"), "blocking file\n").unwrap();
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir)
+        .expect("an undeployable agent roster must not fail provisioning");
+
+    assert!(
+        config_dir.join("settings.json").exists(),
+        "the rest of the config dir must still be provisioned"
+    );
+}
+
+#[test]
+fn ensure_managed_config_dir_deploys_user_tier_skill() {
+    // PR #2818 review (round 3, MEDIUM decision): a user-custom skill
+    // (`fw.user_skill_source_dir()`, i.e. `<root>/skills`) must reach the
+    // tm-global roster, not just per-project deploys.
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    std::fs::create_dir_all(&fw.user_skills).unwrap();
+    std::fs::write(
+        fw.user_skills.join("my-custom-skill.md"),
+        "---\nname: my-custom-skill\n---\n\nUSER CUSTOM.\n",
+    )
+    .unwrap();
+
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+    assert!(
+        config_dir.join("skills/my-custom-skill/SKILL.md").exists(),
+        "user-custom skill must be deployed to the tm-global config dir"
+    );
+}
+
+/// Static verification against the REAL bundled roster (`src/assets/agents`,
+/// `src/assets/skills`). Ignored by default because it composes and writes the
+/// full ~40-agent set; run explicitly to prove the complete specialist roster
+/// deploys and that every deployed agent is spawnable (carries a `description`):
+///
+/// `cargo test -p trusty-mpm --lib manual_static_verify_full_roster -- --ignored --nocapture`
+#[test]
+#[ignore = "static verification — composes the full real roster; run explicitly"]
+fn manual_static_verify_full_roster() {
+    let tmp = TempDir::new().unwrap();
+    let fw = FrameworkPaths::under(tmp.path());
+    std::fs::create_dir_all(&fw.agents).unwrap();
+    std::fs::create_dir_all(&fw.skills).unwrap();
+
+    // Copy the REAL bundled raw sources into the framework source dirs.
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    for (src, dst) in [
+        (manifest.join("src/assets/agents"), &fw.agents),
+        (manifest.join("src/assets/skills"), &fw.skills),
+    ] {
+        for entry in std::fs::read_dir(&src).unwrap() {
+            let entry = entry.unwrap();
+            if entry.path().extension().and_then(|e| e.to_str()) == Some("md") {
+                std::fs::copy(entry.path(), dst.join(entry.file_name())).unwrap();
+            }
+        }
+    }
+
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+    // List every deployed agent and confirm each is spawnable.
+    let agents_dir = config_dir.join("agents");
+    let mut deployed: Vec<String> = std::fs::read_dir(&agents_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().and_then(|x| x.to_str()) == Some("md"))
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .collect();
+    deployed.sort();
+
+    println!("\n=== deployed agents ({}) ===", deployed.len());
+    let mut missing_desc = Vec::new();
+    for name in &deployed {
+        let body = std::fs::read_to_string(agents_dir.join(name)).unwrap();
+        let has_desc = body.contains("description:");
+        println!("  {name}  spawnable={has_desc}");
+        // BASE-*.md are inheritance templates (parents of `extends:` agents),
+        // intentionally without a `description` and never independently
+        // spawnable — exclude them from the spawnable requirement.
+        if !has_desc && !name.starts_with("BASE-") {
+            missing_desc.push(name.clone());
+        }
+    }
+
+    // The specialists #1996 and the task call out must all be present.
+    for required in [
+        "engineer.md",
+        "rust-engineer.md",
+        "research.md",
+        "qa.md",
+        "local-ops.md",
+        "version-control.md",
+        "ticketing.md",
+        "documentation.md",
+        "security.md",
+    ] {
+        assert!(
+            deployed.iter().any(|d| d == required),
+            "required agent {required} missing from deployed roster: {deployed:?}"
+        );
+    }
+    assert!(
+        missing_desc.is_empty(),
+        "these deployed agents are not spawnable (no description): {missing_desc:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// #4873 — the SKILL half of the every-run deploy, and the warning that makes
+// a declined refresh visible.
+// ---------------------------------------------------------------------------
+
+/// Pin `fw.skills` as already-current so `ensure_skill_source_fresh` leaves a
+/// hand-seeded skill source alone.
+///
+/// Why: that function materializes the REAL compiled-in bundle over
+/// `fw.skills` (and prunes anything the bundle does not list) whenever the
+/// stamp file is absent or stale — which would erase every fixture below
+/// before the deploy under test ever saw it. Writing the current stamp is the
+/// supported way to say "this source is the bundle", and it is what an
+/// installed machine's source dir looks like in steady state.
+/// What: writes `<fw.skills>/.bundle-stamp` with `skill_bundle_stamp()`.
+/// Test: used by every `#4873` case below; its necessity is proven by
+/// `pinning_the_stamp_preserves_a_seeded_skill_source`.
+fn pin_skill_source_stamp(fw: &FrameworkPaths) {
+    std::fs::create_dir_all(&fw.skills).unwrap();
+    std::fs::write(
+        fw.skills.join(crate::core::skill_source::STAMP_FILE_NAME),
+        crate::core::skill_source::skill_bundle_stamp(),
+    )
+    .unwrap();
+}
+
+/// Seed one bundled-tier skill with the given body.
+fn seed_skill(fw: &FrameworkPaths, stem: &str, body: &str) {
+    std::fs::create_dir_all(&fw.skills).unwrap();
+    std::fs::write(fw.skills.join(format!("{stem}.md")), body).unwrap();
+}
+
+/// Guard on the fixture itself: without the pin, the seeded source is replaced
+/// by the real bundle and every assertion below would be measuring the wrong
+/// thing.
+///
+/// Test: itself.
+#[test]
+fn pinning_the_stamp_preserves_a_seeded_skill_source() {
+    let tmp = TempDir::new().unwrap();
+    let fw = FrameworkPaths::under(tmp.path());
+    pin_skill_source_stamp(&fw);
+    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
+
+    crate::core::skill_source::ensure_skill_source_fresh(&fw).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(fw.skills.join("probe-skill.md")).unwrap(),
+        "---\nname: probe-skill\n---\n\nV1\n",
+        "a pinned-current source must not be re-materialized from the bundle"
+    );
+}
+
+/// #4873 test 1+2: the shared choke point every run path reaches — a fresh
+/// spawn, a `resume_managed`, and a bare-`tm` in-place relaunch all arrive
+/// here via `runtime::claude_code::prepare_managed_config` — refreshes a
+/// deployed skill that is managed, unmodified, and stale relative to the
+/// bundled source.
+///
+/// Why one test for both paths: `resume_managed` and `run_inplace_relaunch`
+/// perform NO skill work of their own; each delegates to
+/// `prepare_managed_config`, whose only skill step is this function. Asserting
+/// the behaviour here is what proves it for both, and does so without standing
+/// up a daemon or a tmux pane.
+/// Test: itself.
+#[test]
+fn ensure_managed_config_dir_refreshes_a_stale_managed_skill() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    pin_skill_source_stamp(&fw);
+    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+    let deployed = config_dir.join("skills/probe-skill/SKILL.md");
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    assert_eq!(
+        std::fs::read_to_string(&deployed).unwrap(),
+        "---\nname: probe-skill\n---\n\nV1\n"
+    );
+
+    // The binary now embeds newer content — the exact #4873 shape.
+    seed_skill(
+        &fw,
+        "probe-skill",
+        "---\nname: probe-skill\n---\n\nV2-REFRESHED\n",
+    );
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&deployed).unwrap(),
+        "---\nname: probe-skill\n---\n\nV2-REFRESHED\n",
+        "a managed, user-unmodified skill must be refreshed on every run, not only on `tm install`"
+    );
+}
+
+/// #4873 test 3: a second run with nothing changed rewrites nothing.
+///
+/// Why mtime and not just content: "cheap and idempotent" is the property the
+/// every-run deploy depends on; an unconditional rewrite would still leave the
+/// content correct while churning every skill file on every spawn. This is the
+/// skill mirror of `skill_source::ensure_skill_source_fresh_is_noop_when_current`.
+/// Test: itself.
+#[test]
+fn ensure_managed_config_dir_skill_deploy_is_a_noop_when_unchanged() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    pin_skill_source_stamp(&fw);
+    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+    let deployed = config_dir.join("skills/probe-skill/SKILL.md");
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    let before = std::fs::metadata(&deployed).unwrap().modified().unwrap();
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    let after = std::fs::metadata(&deployed).unwrap().modified().unwrap();
+
+    assert_eq!(
+        before, after,
+        "an unchanged skill must take the manifest checksum no-op path, not a rewrite"
+    );
+}
+
+/// #4873 test 4 (negative): a project-custom skill — present on disk, absent
+/// from the manifest — is never overwritten.
+///
+/// Why: this is what makes `cargo-publish` and `tm-slack-canvas-delivery`
+/// immune to the every-run deploy. `deploy_one_file` skips an unmanaged target
+/// unconditionally; deploying more often must not weaken that.
+/// Test: itself.
+#[test]
+fn ensure_managed_config_dir_preserves_a_project_custom_skill() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    pin_skill_source_stamp(&fw);
+    seed_skill(
+        &fw,
+        "probe-skill",
+        "---\nname: probe-skill\n---\n\nBUNDLED\n",
+    );
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+
+    // A hand-placed skill that no manifest has ever recorded, sharing a stem
+    // with a bundled one so it is the deployer's ownership rule under test and
+    // not mere absence from the source.
+    let custom = config_dir.join("skills/probe-skill/SKILL.md");
+    std::fs::create_dir_all(custom.parent().unwrap()).unwrap();
+    std::fs::write(&custom, "PROJECT CUSTOM — DO NOT TOUCH\n").unwrap();
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&custom).unwrap(),
+        "PROJECT CUSTOM — DO NOT TOUCH\n",
+        "an unmanaged on-disk skill must survive the every-run deploy untouched"
+    );
+}
+
+/// #4873 test 5 (negative): a checksum-frozen (hand-edited) skill is still
+/// skipped.
+///
+/// Why: #4873 explicitly must NOT become "overwrite user edits on every run".
+/// The remedy for a frozen skill stays the opt-in
+/// `tm doctor --fix-skills --include-frozen`; this pins that the normal path
+/// leaves it alone even though the bundled source has moved on.
+/// Test: itself.
+#[test]
+fn ensure_managed_config_dir_skips_a_frozen_skill() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    pin_skill_source_stamp(&fw);
+    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+    let deployed = config_dir.join("skills/probe-skill/SKILL.md");
+
+    // Deploy once so the skill becomes MANAGED, then hand-edit it: the
+    // manifest checksum now records V1 while disk holds the edit.
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    std::fs::write(&deployed, "HAND EDITED BY THE OPERATOR\n").unwrap();
+
+    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV2\n");
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+
+    assert_eq!(
+        std::fs::read_to_string(&deployed).unwrap(),
+        "HAND EDITED BY THE OPERATOR\n",
+        "a checksum-frozen skill must still be preserved — `tm doctor --fix-skills \
+         --include-frozen` remains the only way to adopt it"
+    );
+}
+
+/// #4873's own fix: the frozen skip above is no longer silent.
+///
+/// Why: silence is what turned three correctly-declined skills into a report
+/// that "skill deployment never runs on resume". The deploy DID run; nothing
+/// said so. Asserted through the pure summary rather than a log capture so the
+/// test pins the message contract, not `tracing`'s plumbing.
+/// Test: itself.
+#[test]
+fn ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    pin_skill_source_stamp(&fw);
+    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
+    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
+    let deployed = config_dir.join("skills/probe-skill/SKILL.md");
+
+    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    std::fs::write(&deployed, "HAND EDITED\n").unwrap();
+    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV2\n");
+
+    // Re-run the same deploy the provisioning path runs, and inspect what it
+    // declined — the value `ensure_managed_config_dir_with_root` now warns on.
+    let stats = deploy_all_skill_tiers(
+        &fw.skill_source_dir(),
+        &fw.user_skill_source_dir(),
+        &config_dir.join("skills"),
+        |_| true,
+    )
+    .unwrap();
+
+    let line = skill_skip_summary(&stats.stats.skipped)
+        .expect("a declined skill must produce exactly one warning line");
+    assert!(
+        line.contains("probe-skill"),
+        "the warning must name the skill left stale: {line}"
+    );
+    assert!(
+        line.contains("tm doctor --fix-skills --include-frozen"),
+        "the warning must carry the actionable remedy: {line}"
+    );
+}
+
+#[test]
+fn skill_skip_summary_is_none_on_a_clean_deploy() {
+    assert!(skill_skip_summary(&[]).is_none());
+}
+
+#[test]
+fn skill_skip_summary_counts_and_previews() {
+    let line = skill_skip_summary(&["tm".to_string(), "code-review-standards".to_string()])
+        .expect("a non-empty skip set must summarise");
+    assert!(line.contains("2 skill file(s)"), "{line}");
+    assert!(line.contains("tm, code-review-standards"), "{line}");
+}
+
+#[test]
+fn skill_skip_summary_elides_beyond_five() {
+    // Bounded output is the whole reason this is a summary and not one line
+    // per file — it runs on every spawn, resume, and relaunch.
+    let many: Vec<String> = (0..9).map(|i| format!("skill-{i}")).collect();
+    let line = skill_skip_summary(&many).expect("summary");
+    assert!(line.contains("9 skill file(s)"), "{line}");
+    assert!(line.contains("skill-4, …"), "{line}");
+    assert!(
+        !line.contains("skill-5"),
+        "beyond the preview limit: {line}"
+    );
+}

--- a/crates/trusty-mpm/src/core/managed_config_tests.rs
+++ b/crates/trusty-mpm/src/core/managed_config_tests.rs
@@ -440,17 +440,10 @@ fn ensure_managed_config_dir_preserves_a_project_custom_skill() {
 fn ensure_managed_config_dir_skips_a_frozen_skill() {
     let tmp = TempDir::new().unwrap();
     let fw = seed_framework(tmp.path());
-    pin_skill_source_stamp(&fw);
-    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
-    let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
-    let deployed = config_dir.join("skills/probe-skill/SKILL.md");
+    // Deployed once, then hand-edited, with the source now at V2 — the
+    // manifest checksum records V1 while disk holds the edit.
+    let (config_dir, deployed) = frozen_skill_fixture(&tmp, &fw);
 
-    // Deploy once so the skill becomes MANAGED, then hand-edit it: the
-    // manifest checksum now records V1 while disk holds the edit.
-    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-    std::fs::write(&deployed, "HAND EDITED BY THE OPERATOR\n").unwrap();
-
-    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV2\n");
     ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
 
     assert_eq!(
@@ -461,28 +454,110 @@ fn ensure_managed_config_dir_skips_a_frozen_skill() {
     );
 }
 
-/// #4873's own fix: the frozen skip above is no longer silent.
+/// Drive the fixture to the state the #4873 warning describes: one bundled
+/// skill deployed, then hand-edited, with the source moved on beyond it.
 ///
-/// Why: silence is what turned three correctly-declined skills into a report
-/// that "skill deployment never runs on resume". The deploy DID run; nothing
-/// said so. Asserted through the pure summary rather than a log capture so the
-/// test pins the message contract, not `tracing`'s plumbing.
-/// Test: itself.
-#[test]
-fn ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped() {
-    let tmp = TempDir::new().unwrap();
-    let fw = seed_framework(tmp.path());
-    pin_skill_source_stamp(&fw);
-    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
+/// Why: three cases below need the same checksum-frozen shape, and building it
+/// takes two provisioning runs plus a write — duplicating that setup is how the
+/// three would drift apart.
+/// What: seeds `probe-skill` at V1, provisions once so the skill becomes
+/// MANAGED with V1's checksum recorded, overwrites the deployed copy by hand,
+/// then advances the source to V2. Returns the config dir and the deployed
+/// path. Leaves the NEXT provisioning run to the caller — that run is what each
+/// test is actually measuring.
+/// Test: used by `ensure_managed_config_dir_skips_a_frozen_skill`,
+/// `ensure_managed_config_dir_emits_the_frozen_skill_warning`,
+/// `a_declined_skill_reaches_skill_skip_summary_from_a_real_deploy`.
+fn frozen_skill_fixture(
+    tmp: &TempDir,
+    fw: &FrameworkPaths,
+) -> (std::path::PathBuf, std::path::PathBuf) {
+    pin_skill_source_stamp(fw);
+    seed_skill(fw, "probe-skill", "---\nname: probe-skill\n---\n\nV1\n");
     let config_dir = tmp.path().join(".trusty-tools/trusty-mpm/claude-config");
     let deployed = config_dir.join("skills/probe-skill/SKILL.md");
 
-    ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
-    std::fs::write(&deployed, "HAND EDITED\n").unwrap();
-    seed_skill(&fw, "probe-skill", "---\nname: probe-skill\n---\n\nV2\n");
+    ensure_managed_config_dir_with_root(fw, &config_dir).unwrap();
+    std::fs::write(&deployed, "HAND EDITED BY THE OPERATOR\n").unwrap();
+    seed_skill(fw, "probe-skill", "---\nname: probe-skill\n---\n\nV2\n");
 
-    // Re-run the same deploy the provisioning path runs, and inspect what it
-    // declined — the value `ensure_managed_config_dir_with_root` now warns on.
+    (config_dir, deployed)
+}
+
+/// #4873's own fix, AT THE CALL SITE: `ensure_managed_config_dir_with_root`
+/// actually emits the warning when the deploy declines a skill.
+///
+/// Why (PR #4876 review): the three `skill_skip_summary_*` cases below cover
+/// the pure function, and the case after this one covers the deploy that feeds
+/// it — but deleting the entire `if let Some(line) = …` emit block left all of
+/// them green. The wiring was the whole production change and nothing tested
+/// it. This is the test that fails when that block is removed.
+/// What: installs a capturing subscriber for the duration of one provisioning
+/// run and asserts a `WARN` line carrying the module prefix, the declined
+/// skill's name, and the remedy pointer reaches it. Uses the crate's existing
+/// capture entry point (`trusty_common::log_buffer::LogBufferLayer` +
+/// `tracing::subscriber::with_default`, the pattern `log_buffer`'s own
+/// `layer_captures_events` and `trusty-search`'s
+/// `fallback_logs_build_failure_exactly_once` already use) rather than adding a
+/// capture dependency. `#[serial]` for the same reason that test carries it:
+/// installing a subscriber perturbs the process-global interest cache.
+/// Test: itself.
+#[test]
+#[serial_test::serial]
+fn ensure_managed_config_dir_emits_the_frozen_skill_warning() {
+    use tracing_subscriber::layer::SubscriberExt;
+
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    // Build the frozen state OUTSIDE the capture so the only lines recorded
+    // belong to the run under test.
+    let (config_dir, _deployed) = frozen_skill_fixture(&tmp, &fw);
+
+    let buffer = trusty_common::log_buffer::LogBuffer::new(64);
+    let subscriber = tracing_subscriber::registry().with(
+        trusty_common::log_buffer::LogBufferLayer::new(buffer.clone()),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        ensure_managed_config_dir_with_root(&fw, &config_dir).unwrap();
+    });
+
+    let lines = buffer.tail(64);
+    let hit = lines
+        .iter()
+        .find(|l| l.contains("managed config dir:") && l.contains("probe-skill"));
+    let line = hit.unwrap_or_else(|| {
+        panic!(
+            "provisioning declined `probe-skill` but emitted no warning naming it — \
+             the emit block in `ensure_managed_config_dir_with_root` is missing or \
+             unreachable. Captured lines: {lines:#?}"
+        )
+    });
+    assert!(
+        line.contains("WARN"),
+        "the declined-skill line must be logged at WARN, not a lower level: {line}"
+    );
+    assert!(
+        line.contains("tm doctor --fix-skills --include-frozen"),
+        "the emitted warning must carry the actionable remedy: {line}"
+    );
+}
+
+/// The deploy really does report a frozen skill as `skipped`, so
+/// [`skill_skip_summary`]'s input is the shape production hands it.
+///
+/// Why: the pure-function cases below feed hand-written vectors. This one
+/// closes the gap between "the summary formats a skip list" and "a real
+/// checksum-frozen skill lands in that list" — without it, a change to the
+/// deployer's classification could empty the list and every other case would
+/// still pass.
+/// Test: itself.
+#[test]
+fn a_declined_skill_reaches_skill_skip_summary_from_a_real_deploy() {
+    let tmp = TempDir::new().unwrap();
+    let fw = seed_framework(tmp.path());
+    let (config_dir, _deployed) = frozen_skill_fixture(&tmp, &fw);
+
     let stats = deploy_all_skill_tiers(
         &fw.skill_source_dir(),
         &fw.user_skill_source_dir(),
@@ -491,15 +566,16 @@ fn ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped() {
     )
     .unwrap();
 
-    let line = skill_skip_summary(&stats.stats.skipped)
-        .expect("a declined skill must produce exactly one warning line");
     assert!(
-        line.contains("probe-skill"),
-        "the warning must name the skill left stale: {line}"
+        stats.stats.skipped.iter().any(|s| s == "probe-skill"),
+        "a checksum-frozen skill must be reported as skipped: {:?}",
+        stats.stats.skipped
     );
+    let line = skill_skip_summary(&stats.stats.skipped)
+        .expect("a declined skill must produce exactly one summary line");
     assert!(
-        line.contains("tm doctor --fix-skills --include-frozen"),
-        "the warning must carry the actionable remedy: {line}"
+        line.contains("probe-skill") && line.contains("tm doctor --fix-skills --include-frozen"),
+        "{line}"
     );
 }
 

--- a/crates/trusty-mpm/src/core/skill_source.rs
+++ b/crates/trusty-mpm/src/core/skill_source.rs
@@ -49,7 +49,11 @@ use crate::core::paths::FrameworkPaths;
 
 /// Marker file recording the last-materialized bundle stamp, written
 /// directly under the skill source directory (`paths.skills/.bundle-stamp`).
-const STAMP_FILE_NAME: &str = ".bundle-stamp";
+///
+/// #4873: `pub(crate)` so a test can pin a hand-seeded skill source as
+/// already-current and stop [`ensure_skill_source_fresh`] materializing the
+/// real compiled-in bundle over it.
+pub(crate) const STAMP_FILE_NAME: &str = ".bundle-stamp";
 
 /// Compute a stable sha256 fingerprint over every `skills/*` entry in the
 /// compiled-in [`bundle::ALL`] table.

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -1438,10 +1438,25 @@ pub(super) async fn front_gate_or_escalate(
 /// resume defensively re-applies [`crate::core::session_launch::ensure_status_line`]
 /// — the ONE prep step confirmed idempotent/non-clobbering by its own doc
 /// comment — so such a session self-heals the next time it is resumed. The
-/// broader prep pipeline (agent/skill redeploy, CLAUDE.md merge, MCP injection)
-/// is intentionally NOT re-run here: those steps are not all confirmed safe to
-/// repeat against an already-running workspace, so re-running them on every
-/// resume risks a different class of bug for a narrower payoff.
+/// broader prep pipeline is only PARTLY skipped here — see the next paragraph.
+///
+/// #4873 correction. This comment used to claim that "agent/skill redeploy,
+/// CLAUDE.md merge, MCP injection" were all intentionally NOT re-run on
+/// resume. Two thirds of that was false, and it misled a defect report into
+/// blaming this function for stale skills. `resume_managed` calls no
+/// `prepare_session*` itself, true — but it calls `adapter.spawn_resume`, and
+/// `ClaudeCodeAdapter::spawn_resume` calls
+/// `runtime::claude_code::prepare_managed_config`, which runs the agent
+/// redeploy AND the skill redeploy (via
+/// [`crate::core::managed_config::ensure_managed_config_dir`]) and re-runs
+/// every MCP injector. Agents, skills, and MCP entries therefore DO refresh on
+/// every resume, satisfying the deploy-on-every-run ruling.
+///
+/// What is genuinely not re-run is the per-WORKSPACE half of `prepare_session`
+/// — the `CLAUDE.md` merge and the project-tier `.claude/` payload — because
+/// those steps are not all confirmed safe to repeat against an already-running
+/// workspace. `ensure_deployment_complete` below still repairs that tier when
+/// it is MISSING files, just not when it is merely stale.
 ///
 /// #2647 worktree/upstream sync: before the statusline self-heal, every
 /// resume also calls

--- a/crates/trusty-mpm/src/runtime/claude_code.rs
+++ b/crates/trusty-mpm/src/runtime/claude_code.rs
@@ -139,10 +139,14 @@ fn cd_and_group(cwd: &Path, body: &str) -> String {
 /// strips the API key so Claude Code falls back to OAuth, preventing key leakage
 /// through pane history. (2) When a managed `CLAUDE_CONFIG_DIR` is resolved,
 /// `env -u ANTHROPIC_API_KEY CLAUDE_CONFIG_DIR='<dir>'` points the session at the tm-owned config home
-/// (`~/.trusty-tools/trusty-mpm/claude-config/`). Under the retained
-/// `--setting-sources project,local` flag (see [`spawn_command`]) this config
-/// home does NOT supply the agent roster/skills/hooks — those load from the
-/// project layer — but it DOES isolate the session's auth: with the API key
+/// (`~/.trusty-tools/trusty-mpm/claude-config/`). #4873: this config home DOES
+/// supply the agent roster and skills. Every command builder resolves its flag
+/// through [`crate::core::model_inject::setting_sources_flag`], which returns
+/// `--setting-sources user,project,local` whenever a config dir is present —
+/// and `user` is the tier this directory relocates (see [`spawn_command`]'s
+/// #4451 note). The older text here claimed `project,local` and "loads from the
+/// project layer"; that predates the relocation. It also isolates the session's
+/// auth, which was always true: with the API key
 /// scrubbed, `claude` authenticates via the keychain/`.credentials.json` keyed to
 /// this config-dir path (the tm-managed login), never touching the operator's
 /// `~/.claude`. (3) On macOS the Keychain entry Claude Code reads is keyed by a
@@ -324,10 +328,7 @@ fn spawn_command(
 /// into the daemon managed-spawn command via `--append-system-prompt-file`
 /// (issue #2125 item 3 — the daemon-adapter carrier).
 ///
-/// Why: this module's own DOC-34 audit trail established that under
-/// `--setting-sources project,local` the framework roster/instructions load
-/// from the PROJECT layer, not the `CLAUDE_CONFIG_DIR` [`prepare_managed_config`]
-/// provisions — but `spawn` never actually passed `--append-system-prompt-file`
+/// Why: `spawn` never actually passed `--append-system-prompt-file`
 /// at all, so the one thing that turns a bare `claude` process into a
 /// trusty-mpm PM never reached the daemon's default managed-spawn path,
 /// leaving every bare-`tm` session running vanilla Claude Code (#2125). This
@@ -632,14 +633,23 @@ fn session_id_exists_in(cwd: &Path, projects_dir: &Path, id: &str) -> bool {
 /// authenticates via the keychain/`.credentials.json` keyed to this config-dir
 /// path, and its per-workspace trust is seeded into `<config_dir>/.claude.json`
 /// (NEVER `~/.claude.json`), so a managed session never reads or writes the
-/// operator's `~/.claude`. NOTE (DOC-34 review): under the retained
-/// `--setting-sources project,local` flag the config home's provisioned
-/// agents/skills/settings.json are NOT loaded (that flag excludes the `user`
-/// tier this dir relocates); the framework roster/skills/hooks are delivered by
-/// the PROJECT layer via `session_launch::prepare_session`. The full-roster
-/// provisioning here is therefore belt-and-suspenders (it would load only if the
-/// flag were ever dropped) — the load-bearing effect of the config dir is auth +
-/// trust isolation. This centralises the three coupled steps — resolve the path,
+/// operator's `~/.claude`.
+///
+/// #4873 CORRECTION — the provisioning here is LOAD-BEARING, not
+/// belt-and-suspenders. This doc used to say the config home's provisioned
+/// agents/skills/settings.json "are NOT loaded" because `--setting-sources
+/// project,local` excludes the `user` tier this dir relocates, and that the
+/// framework roster arrived via the PROJECT layer instead. That stopped being
+/// true when the flag became conditional: all three command builders
+/// (`spawn_command`, `resume_command`, `compose_inplace_args`) resolve it
+/// through [`crate::core::model_inject::setting_sources_flag`], which returns
+/// `--setting-sources user,project,local` whenever `config_dir` is `Some` — and
+/// every managed path reaches here with `Some`. The `user` tier IS read. See
+/// `spawn_command`'s #4451 note, which already stated this correctly while
+/// this comment contradicted it. Auth + trust isolation remains true and is now
+/// one of two load-bearing effects, not the only one.
+///
+/// This centralises the three coupled steps — resolve the path,
 /// provision it, and seed workspace trust — so `spawn` and `spawn_resume` stay
 /// identical and cannot drift.
 /// What: resolves [`crate::core::trusty_tools_config::managed_claude_config_dir`].
@@ -1094,9 +1104,11 @@ impl RuntimeAdapter for ClaudeCodeAdapter {
         );
         // Point the session at the tm-owned CLAUDE_CONFIG_DIR for auth + trust
         // isolation and seed trust there — never at `~/.claude.json` (DOC-34).
-        // The framework roster/skills/hooks load from the PROJECT layer under
-        // `--setting-sources project,local`, not from this config dir (see
-        // `prepare_managed_config`). Non-fatal throughout (closes #1696).
+        // #4873: the framework roster and skills load FROM this config dir —
+        // `setting_sources_flag` yields `user,project,local` whenever it is
+        // present, and `user` is the tier it relocates. The older comment here
+        // claimed the project layer under `project,local`; see
+        // `prepare_managed_config`. Non-fatal throughout (closes #1696).
         let config_dir = prepare_managed_config(tmux_name, cwd);
         // Build and inject the PM system prompt (issue #2125 item 3) so this,
         // the default daemon on-ramp, can no longer silently spawn vanilla


### PR DESCRIPTION
Closes [#4873](https://github.com/bobmatnyc/trusty-tools/issues/4873)

## The issue's premise did not hold — read this first

[#4873](https://github.com/bobmatnyc/trusty-tools/issues/4873) says skill deployment runs only on a fresh spawn, and that `ensure_managed_config_dir_with_root` has "NO skills equivalent" to `autodeploy_agents_for`. Against `origin/main` that is false on both counts. `crates/trusty-mpm/src/core/managed_config.rs` already called `skill_source::ensure_skill_source_fresh` and `deploy_all_skill_tiers`, and all three run paths reach it through `runtime::claude_code::prepare_managed_config`:

| Run path | Entry point | Reaches `ensure_managed_config_dir` |
|---|---|---|
| fresh spawn | `ClaudeCodeAdapter::spawn` (`claude_code.rs:1100`) | yes |
| resume | `ClaudeCodeAdapter::spawn_resume` (`claude_code.rs:1201`), called by `resume_managed` | yes |
| in-place relaunch | `build_inplace_resume_command` (`claude_code.rs:948`) | yes |

Measured on the live machine 2026-08-05, comparing every deployed `SKILL.md` against this binary's bundled source by sha256:

- `$CLAUDE_CONFIG_DIR/skills/` — 49 of 52 byte-identical, including `rust-build-performance` and `tm-capabilities`, which the issue lists as frozen.
- a live managed worktree's `.claude/skills/` — 50 of 52 byte-identical.
- all exceptions (`tm`, `tm-delegation-patterns`, `code-review-standards`) are checksum-frozen: the manifest checksum and the on-disk content disagree, so `deploy_one_file` correctly classifies them as hand-edited and preserves them.

So the owner ruling ("it should not be `tm install`, it should be each run") was already satisfied. Deployment ran; it just never said so.

## What this PR changes

`deploy_one_file` reports a declined file only in the returned `DeployStats`, and `ensure_managed_config_dir_with_root` discarded that value. Three correctly-declined skills therefore stayed stale on every run, forever, with no warning anywhere — which is exactly what got read as "deployment never runs". This adds the missing signal, mirroring `agent_source::deploy_summary_lines`, the same half of [#4840](https://github.com/bobmatnyc/trusty-tools/issues/4840) that [PR #4848](https://github.com/bobmatnyc/trusty-tools/pull/4848) closed for agents:

```
warning: 3 skill file(s) were NOT refreshed — each is user-owned (hand-edited away
from its recorded checksum, or never managed here), so the bundled version was
withheld: tm, tm-delegation-patterns, code-review-standards. Run
`tm doctor --fix-skills --include-frozen` to adopt them.
```

Bounded to a count plus a five-entry preview, per `agents::deployer`'s [#2504](https://github.com/bobmatnyc/trusty-tools/issues/2504) policy — this runs on every spawn, resume, and relaunch, so one line per file would be permanent log spam.

Also corrects two comments that misrouted this defect report. `resume_managed` claimed "agent/skill redeploy, CLAUDE.md merge, MCP injection" were all intentionally not re-run on resume; two thirds of that was false. Only the per-workspace half of `prepare_session` is genuinely skipped.

Deploy behaviour is untouched. No regression to [#4752](https://github.com/bobmatnyc/trusty-tools/issues/4752)'s prompt refresh on either path.

## Tests

Tests move to `managed_config_tests.rs` because `managed_config.rs` was already at 416 of its 500-SLOC production cap; a `*_tests.rs` sibling carries the 3000 cap.

| Test | Pins |
|---|---|
| `ensure_managed_config_dir_refreshes_a_stale_managed_skill` | the shared choke point refreshes a managed, unmodified, stale skill |
| `ensure_managed_config_dir_skill_deploy_is_a_noop_when_unchanged` | second run rewrites nothing (mtime unchanged) |
| `ensure_managed_config_dir_preserves_a_project_custom_skill` | unmanaged on-disk skill untouched |
| `ensure_managed_config_dir_skips_a_frozen_skill` | checksum-frozen skill still preserved |
| `ensure_managed_config_dir_warns_when_a_frozen_skill_is_skipped` | the skip is now visible and names the remedy |
| `skill_skip_summary_{is_none_on_a_clean_deploy,counts_and_previews,elides_beyond_five}` | the summary contract, including the five-entry bound |
| `pinning_the_stamp_preserves_a_seeded_skill_source` | fixture guard — without it `ensure_skill_source_fresh` materializes the real bundle over the seed |

Fail-before/pass-after: neutering `skill_skip_summary` to return `None` fails the three warning tests (`11 passed; 3 failed`) and passes with the fix. The four skill-behaviour tests pass either way by design — they are characterization tests documenting that the every-run deploy already worked, which is the premise refutation above.

## Gates — Rust Test Ladder rung 5 (process lifecycle: session start/resume)

```
cargo fmt --check                                     EXIT=0
cargo clippy -p trusty-mpm --all-targets -- -D warnings EXIT=0
cargo test -p trusty-mpm -- --test-threads=1          EXIT=0  (4586 passed, 0 failed, 7 ignored, + all integration targets)
bash scripts/check_line_cap.sh                        EXIT=0  (3678 files, 0 violations)
bash scripts/check_sld.sh                             EXIT=0
bash scripts/check_changelog_fragment.sh              EXIT=0
```

`--test-threads=1` is the deterministic gate, not a workaround for this change. Under the default parallel run two pre-existing `$HOME`-mutation races fail on `origin/main` too — `stale_assets_for_many_reads_shared_agent_dir_once_for_the_whole_fleet` and `safe_session_cwd_replaces_home_and_missing`. Baseline worktree at `origin/main`, five parallel runs: 3 failed, 2 passed. Same branch, five parallel runs: 4 failed, 1 passed. Serialized, both are green. No coverage was ignored, cfg-gated, or excluded.

`cargo check --workspace` fails identically on `origin/main` and on this branch — `trusty-code-gui` and `trusty-mpm-gui` panic in a Tauri proc macro, unrelated to this change.

## Second-order note, carried from the issue

This does not refresh `tm-delegation-patterns`. That skill and two others are checksum-frozen, and preserving a hand edit is correct behaviour this PR deliberately does not weaken. The remedy is the existing `tm doctor --fix-skills --include-frozen`, which the new warning now names at the moment the skip happens. Do not reopen [#4604](https://github.com/bobmatnyc/trusty-tools/issues/4604).

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
