### PR TITLE
fix(ci): stop the doc-pointer lint racing its own CI timeout

### DIFF
--- a/.github/workflows/test-pointers.yml
+++ b/.github/workflows/test-pointers.yml
@@ -34,7 +34,16 @@ jobs:
   test-pointers:
     name: "Test: doc-comment pointer lint"
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # #4882: was 5. Measured 2026-08-05: the lint itself legitimately took
+    # 352s locally (close to CI's observed 303s the run that got cancelled),
+    # dominated by tens of thousands of subprocess forks in
+    # scripts/check_test_pointers.sh (dirname/tr/mktemp/grep per file, per
+    # Test: annotation, per citation — see that script's #4882 comments).
+    # Fixing those forks cut local wall time to ~201s (43% faster), but that
+    # still leaves under 2x headroom against a 5-minute cap on a runner that
+    # was already this close to timing out under normal load — not a safe
+    # margin. 10 minutes gives ~3x headroom over the post-fix measurement.
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v5
 

--- a/scripts/check_test_pointers.sh
+++ b/scripts/check_test_pointers.sh
@@ -326,7 +326,12 @@ function emit(nm,    parts, k, final) {
 '
 
 candidate_names() {
-  printf '%s\n' "$1" | awk "$CANDIDATES_AWK"
+  # #4882: a here-string feeds awk's stdin without forking a separate
+  # `printf` process the way `printf ... | awk ...` did — same trailing
+  # newline, same $0 content, one less fork per call. This function is
+  # invoked once per Test: annotation (tens of thousands workspace-wide), so
+  # the extra fork was a measurable share of total runtime.
+  awk "$CANDIDATES_AWK" <<< "$1"
 }
 
 # ---------------------------------------------------------------------------
@@ -335,14 +340,27 @@ candidate_names() {
 # Falls back to "." (workspace root) if none is found above it.
 # ---------------------------------------------------------------------------
 crate_root_for() {
+  # #4882: bash-builtin parameter expansion instead of external `dirname` —
+  # called once per file plus once per ancestor directory walked (thousands
+  # of forks workspace-wide; ~24s of a ~350s run measured locally). Mimics
+  # dirname's behavior for the repo-relative, slash-separated paths
+  # `git ls-files` emits (no trailing slashes, no leading "/").
   local f="$1" dir
-  dir="$(dirname "$f")"
+  case "$f" in
+    */*) dir="${f%/*}" ;;
+    *) dir="." ;;
+  esac
+  [ -z "$dir" ] && dir="/"
   while [ "$dir" != "." ] && [ "$dir" != "/" ]; do
     if [ -f "$dir/Cargo.toml" ]; then
       printf '%s\n' "$dir"
       return 0
     fi
-    dir="$(dirname "$dir")"
+    case "$dir" in
+      */*) dir="${dir%/*}" ;;
+      *) dir="." ;;
+    esac
+    [ -z "$dir" ] && dir="/"
   done
   printf '%s\n' "."
 }
@@ -358,8 +376,12 @@ crate_root_for() {
 CRATE_FN_CACHE_DIR=""
 
 crate_cache_file() {
+  # #4882: this runs once per CITATION (~21k times workspace-wide), not once
+  # per crate — only the git-grep build below is crate-scoped. `tr` forked a
+  # process on every call; bash's own `//` pattern substitution does the
+  # same character-class replacement without a fork.
   local crate="$1" key
-  key="$(printf '%s' "$crate" | tr -c 'A-Za-z0-9' '_')"
+  key="${crate//[^A-Za-z0-9]/_}"
   printf '%s/%s.fns\n' "$CRATE_FN_CACHE_DIR" "$key"
 }
 
@@ -484,17 +506,29 @@ scan() {
     exit 1
   fi
 
+  # #4882: both nested loops below used to read from a `cmd | while ...`
+  # pipe, which forces bash to fork a subshell to run the loop body on the
+  # PRODUCER side of every pipe (once per file for the block loop, once per
+  # Test: annotation — ~25k times workspace-wide — for the candidate loop).
+  # Everything the loop bodies do is written straight to the *_out files
+  # rather than to shell variables, so nothing here actually depends on
+  # subshell isolation; switching to `< <(cmd)` process substitution runs
+  # both loops in the *current* shell and removes that fork entirely, on
+  # top of removing the awk-script/`dirname`/`tr` forks fixed above. This
+  # was the single largest contributor to the ~350s measured runtime.
   while IFS= read -r f; do
     [ -n "$f" ] || continue
     [ -f "$f" ] || continue
     is_excluded_path "$f" && continue
     local crate
     crate="$(crate_root_for "$f")"
-    extract_test_blocks "$f" | while IFS=$'\t' read -r line blob; do
+    while IFS=$'\t' read -r line blob; do
       [ -n "${line:-}" ] || continue
-      local seen_file
-      seen_file="$(mktemp "${TMPDIR:-/tmp}/tpseen.XXXXXX")"
-      candidate_names "$blob" | while IFS=$'\t' read -r kind name; do
+      # #4882: in-shell dedup (newline-delimited string + `case`) instead of
+      # a per-block `mktemp` file plus a `grep -qxF` fork per candidate —
+      # same whole-entry exact-match semantics, zero forks.
+      local seen=$'\n'
+      while IFS=$'\t' read -r kind name; do
         [ -n "$kind" ] || continue
         case "$kind" in
           ERR)
@@ -504,8 +538,10 @@ scan() {
         esac
         [ -n "$name" ] || continue
         # De-dupe within a single annotation (same name cited twice in one blob).
-        if grep -qxF "${kind}:${name}" "$seen_file" 2>/dev/null; then continue; fi
-        printf '%s\n' "${kind}:${name}" >> "$seen_file"
+        case "$seen" in
+          *$'\n'"${kind}:${name}"$'\n'*) continue ;;
+        esac
+        seen="${seen}${kind}:${name}"$'\n'
         # #4618: one row per citation this gate actually resolved. "0 dangling
         # pointers" over 0 resolved citations is a broken scan, not a clean tree.
         printf '%s\t%s\t%s\t%s\n' "$f" "$line" "$kind" "$name" >> "$checked_out"
@@ -518,9 +554,8 @@ scan() {
             printf '%s\t%s\t%s\t%s\n' "$f" "$line" "$name" "$crate" >> "$raw"
           fi
         fi
-      done
-      rm -f "$seen_file"
-    done
+      done < <(candidate_names "$blob")
+    done < <(extract_test_blocks "$f")
   done < "$rslist"
   rm -f "$rslist"
 


### PR DESCRIPTION
## Summary

The `Test: doc-comment pointer lint` job (`test-pointers.yml`) was getting
CANCELLED by its own `timeout-minutes: 5`, even when the lint passed clean.

Evidence, measured 2026-08-05 on [PR #4882](https://github.com/bobmatnyc/trusty-tools/issues/4882), run `31003954565`, job `92300184046`:
`scripts/check_test_pointers.sh` printed its own success line
`0 dangling pointers — OK` at `12:12:27.188`, and GitHub cancelled the job
at `12:12:27.200` — **120ms later**, 5:03 against a 5-minute cap. No
`FAIL:` lines — this was never a lint defect, only a timing race.

## What was actually slow

Ran the unmodified script locally: **352s** wall time (`/usr/bin/time -p`),
consistent with CI's observed 303s. It scans 3686 tracked `.rs` files for
~25k `Test:` doc-comment annotations and ~21.5k backtick-quoted citations.
The slowness wasn't algorithmic — it was subprocess-spawn overhead:
`dirname` and `tr` forked once per file / per citation, a `mktemp` +
`grep -qxF` file pair built and torn down per annotation for in-block
de-duplication, a redundant `printf | awk` pipe per annotation, and two
nested `cmd | while read` loops that each force bash to fork a subshell
per file / per annotation just to run the loop body.

## Fix

`scripts/check_test_pointers.sh`:
- `crate_root_for`: bash parameter expansion instead of external `dirname`.
- `crate_cache_file`: bash `${var//pattern/repl}` instead of external `tr`.
- `candidate_names`: a here-string (`awk ... <<< "$1"`) instead of
  `printf | awk`, dropping one fork per annotation.
- Per-block de-dup: an in-shell newline-delimited string + `case` match
  instead of a `mktemp` file + `grep -qxF` per candidate.
- Both nested `cmd | while read` loops switched to `< <(cmd)` process
  substitution, removing a subshell fork per file and per annotation.
  Nothing in either loop body depends on subshell variable isolation —
  everything is written straight to the `*_out` files scan() already uses.

None of the actual parsing logic (the two AWK programs, the citation
classification, the allowlist ratchet) changed.

**Result:** 352s -> 201s locally, 43% faster, identical output
(21475 citations checked, 0 dangling pointers both before and after).

`timeout-minutes: 5 -> 10` on top of the speedup: 201s still leaves under
2x headroom against a cap the job had already blown past by 3s under
normal load — not a safe margin against CI-runner variance even after a
real fix to the underlying slowness.

## Verification

- `bash scripts/check_test_pointers.sh --self-test` — all fixtures
  (dangling fn/mod citations, globs, parenthetical asides, unterminated
  backticks, allowlist ratchet suppress/prune) pass unchanged.
- Manually injected a dangling `Test:` pointer into a scratch copy of
  `crates/trusty-common/src/lib.rs`, confirmed the script correctly FAILs
  citing it (`FAIL: crates/trusty-common/src/lib.rs:788: Test: pointer
  cites `this_test_definitely_does_not_exist_anywhere_zzz` — ...`), then
  reverted (`git checkout --`) before committing.
- `bash scripts/check_test_pointers.sh` — 21475 citations, 0 dangling, exit 0.
- `bash scripts/check_sld.sh` — 55 spec docs + 3085 code files, 0 errors.
- `bash scripts/check_line_cap.sh` — 3686 files, 0 violations.

No `.rs` files touched — CI/script-only change, no changelog fragment
required.

## Test plan

- [x] `check_test_pointers.sh --self-test` passes
- [x] Manual dangling-pointer injection still fails the gate
- [x] Full `check_test_pointers.sh` run: same citation count and result
      before/after, 43% faster
- [x] `check_sld.sh` and `check_line_cap.sh` pass
- [ ] CI: `Test: doc-comment pointer lint` completes without hitting its
      own timeout

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools