### PR TITLE
fix(trusty-agents-common): serialise the skill manifest's read-modify-write (#4881)

### DIFF
--- a/crates/trusty-agents-common/changelog.d/4881-manifest-lock.md
+++ b/crates/trusty-agents-common/changelog.d/4881-manifest-lock.md
@@ -1,0 +1,6 @@
+Fixed
+
+- serialise the skill manifest's read-modify-write so concurrent deploys stop freezing skills nobody edited (closes [#4881](https://github.com/bobmatnyc/trusty-tools/issues/4881))
+  - `deploy_skills_filtered` and the unmanaged-skill adoption now run their whole load-modify-save under a new `with_skill_manifest_lock` sidecar lock, the skill-side counterpart of the agent ledger lock added in #4409
+  - `SkillManifest::save_if_current` refuses a save whose base snapshot has gone stale rather than clobbering a newer record — defence in depth for any writer that bypasses the advisory lock
+  - the `flock` critical section itself is now one implementation (`with_ledger_lock`) shared by the agent and skill ledgers

--- a/crates/trusty-agents-common/changelog.d/4881-manifest-lock.md
+++ b/crates/trusty-agents-common/changelog.d/4881-manifest-lock.md
@@ -3,4 +3,6 @@ Fixed
 - serialise the skill manifest's read-modify-write so concurrent deploys stop freezing skills nobody edited (closes [#4881](https://github.com/bobmatnyc/trusty-tools/issues/4881))
   - `deploy_skills_filtered` and the unmanaged-skill adoption now run their whole load-modify-save under a new `with_skill_manifest_lock` sidecar lock, the skill-side counterpart of the agent ledger lock added in #4409
   - `SkillManifest::save_merging` folds in any entries a writer that bypassed the lock published mid-run, instead of dropping them; it never fails or refuses after skill files are on disk, because bytes newer than their recorded checksum are exactly what the deployer reads as a hand-edit and skips forever
+  - a manifest that exists but does not parse is no longer treated as an empty one — merging from that default would publish only the current run's entries and drop the rest
+  - a mid-loop I/O failure during a deploy no longer skips the manifest save, so a skill written just before the failure stays tm-owned instead of freezing
   - the `flock` critical section is now one implementation (`with_ledger_lock`) shared by the agent and skill ledgers

--- a/crates/trusty-agents-common/changelog.d/4881-manifest-lock.md
+++ b/crates/trusty-agents-common/changelog.d/4881-manifest-lock.md
@@ -2,5 +2,5 @@ Fixed
 
 - serialise the skill manifest's read-modify-write so concurrent deploys stop freezing skills nobody edited (closes [#4881](https://github.com/bobmatnyc/trusty-tools/issues/4881))
   - `deploy_skills_filtered` and the unmanaged-skill adoption now run their whole load-modify-save under a new `with_skill_manifest_lock` sidecar lock, the skill-side counterpart of the agent ledger lock added in #4409
-  - `SkillManifest::save_if_current` refuses a save whose base snapshot has gone stale rather than clobbering a newer record — defence in depth for any writer that bypasses the advisory lock
-  - the `flock` critical section itself is now one implementation (`with_ledger_lock`) shared by the agent and skill ledgers
+  - `SkillManifest::save_merging` folds in any entries a writer that bypassed the lock published mid-run, instead of dropping them; it never fails or refuses after skill files are on disk, because bytes newer than their recorded checksum are exactly what the deployer reads as a hand-edit and skips forever
+  - the `flock` critical section is now one implementation (`with_ledger_lock`) shared by the agent and skill ledgers

--- a/crates/trusty-agents-common/src/agents/manifest.rs
+++ b/crates/trusty-agents-common/src/agents/manifest.rs
@@ -138,6 +138,49 @@ pub fn manifest_lock_path(target_dir: &Path) -> std::path::PathBuf {
     target_dir.join(format!("{MANIFEST_FILE}.lock"))
 }
 
+/// Run `f` holding the exclusive cross-process lock on the sidecar `lock_file`.
+///
+/// Why (#4881): the agent ledger (#4409) and the skill ledger need the IDENTICAL
+/// serialisation, and a `flock` critical section is the last code two copies
+/// should drift on — blocking acquisition, RAII release, and
+/// lock-failure-is-an-error ARE the safety property. One implementation, two
+/// named wrappers ([`with_agent_manifest_lock`] and
+/// [`crate::skills::manifest::with_skill_manifest_lock`]), so a change to the
+/// rule lands once.
+/// What: creates `lock_file`'s parent directory and the file itself if absent,
+/// takes a `flock(2)`-style advisory EXCLUSIVE lock on it (blocking until
+/// available), runs `f`, and releases the lock on every exit path including
+/// panics (RAII).
+///
+/// Advisory, not mandatory: a writer that bypasses this helper is not blocked,
+/// so every load-modify-save of a ledger must go through it. Blocking: callers
+/// on an async runtime must use a blocking-safe thread. Not reentrant — a nested
+/// call on the same lock file self-deadlocks.
+///
+/// Lock acquisition failure is an `Err`, never a silent unlocked fallthrough:
+/// proceeding without the lock reinstates exactly the race this closes.
+/// Test: `manifest_lock_serialises_concurrent_writers`,
+/// `crate::skills::manifest::tests::skill_manifest_lock_serialises_concurrent_writers`.
+pub fn with_ledger_lock<T, E, F>(lock_file: &Path, f: F) -> std::result::Result<T, E>
+where
+    E: From<ManifestError>,
+    F: FnOnce() -> std::result::Result<T, E>,
+{
+    if let Some(parent) = lock_file.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| E::from(ManifestError::Io(e)))?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(false)
+        .open(lock_file)
+        .map_err(|e| E::from(ManifestError::Io(e)))?;
+    let mut lock = fd_lock::RwLock::new(file);
+    let _guard = lock.write().map_err(|e| E::from(ManifestError::Io(e)))?;
+    f()
+}
+
 /// Run `f` holding the exclusive cross-process lock on `target_dir`'s ledger.
 ///
 /// Why (#4409): the deployer's cycle is load manifest → write files → save
@@ -173,17 +216,7 @@ where
     E: From<ManifestError>,
     F: FnOnce() -> std::result::Result<T, E>,
 {
-    std::fs::create_dir_all(target_dir).map_err(|e| E::from(ManifestError::Io(e)))?;
-    let file = std::fs::OpenOptions::new()
-        .read(true)
-        .write(true)
-        .create(true)
-        .truncate(false)
-        .open(manifest_lock_path(target_dir))
-        .map_err(|e| E::from(ManifestError::Io(e)))?;
-    let mut lock = fd_lock::RwLock::new(file);
-    let _guard = lock.write().map_err(|e| E::from(ManifestError::Io(e)))?;
-    f()
+    with_ledger_lock(&manifest_lock_path(target_dir), f)
 }
 
 // `repair_stale_tmp(path)` was removed with #4409. It derived a single scratch

--- a/crates/trusty-agents-common/src/skills/deployer.rs
+++ b/crates/trusty-agents-common/src/skills/deployer.rs
@@ -27,7 +27,7 @@
 
 use std::path::Path;
 
-use crate::agents::manifest::{ManifestError, Result, atomic_write, checksum};
+use crate::agents::manifest::{Result, atomic_write, checksum};
 use crate::skills::manifest::{
     SkillManifest, SkillManifestEntry, SkillManifestSave, with_skill_manifest_lock,
 };
@@ -275,19 +275,17 @@ fn deploy_skills_locked(
         }
     }
 
-    // #4881: refuse rather than clobber if the ledger moved under us. Holding
-    // the lock makes that impossible among writers that take it, so a refusal
-    // here means an UNLOCKED writer exists — a bug to surface, not to paper
-    // over. Deploy is idempotent, so the next run redoes this cycle intact.
-    match manifest.save_if_current(dest, &base)? {
-        SkillManifestSave::Written => {}
-        SkillManifestSave::RefusedStale => {
-            return Err(ManifestError::Io(std::io::Error::other(format!(
-                "the skill manifest at {} changed during this deploy — an unlocked \
-                 writer bypassed `with_skill_manifest_lock`; nothing was written",
-                dest.display()
-            ))));
-        }
+    // #4881: every file above is ALREADY on disk, so this save must publish —
+    // failing or refusing here would leave bytes newer than their recorded
+    // checksums, which is exactly what the classifier above reads as a hand-edit
+    // and skips forever. `save_merging` folds in anything an unlocked writer
+    // published mid-deploy rather than dropping it.
+    if manifest.save_merging(dest, &base)? == SkillManifestSave::Merged {
+        tracing::warn!(
+            dest = %dest.display(),
+            "the skill manifest changed during this deploy — a writer bypassed the \
+             ledger lock; its entries were merged rather than dropped"
+        );
     }
 
     Ok(stats)

--- a/crates/trusty-agents-common/src/skills/deployer.rs
+++ b/crates/trusty-agents-common/src/skills/deployer.rs
@@ -208,8 +208,56 @@ fn deploy_skills_locked(
         );
     }
 
+    // #4881: the write loop's failure sites (an unreadable source file, a failed
+    // `atomic_write`) can return AFTER earlier `SKILL.md` files are already on
+    // disk. Propagating straight out would skip the save below, leaving those
+    // files unrecorded — bytes newer than any recorded checksum, which the
+    // classifier reads as a hand-edit and skips forever. So the loop's error is
+    // held, the ledger is saved either way, and the error propagates after.
+    // Pre-existing (it predates this issue's lock work) but fixed here because
+    // it violates the same invariant.
+    let write_result = deploy_selected(source, dest, &names, &now, &mut manifest, &mut stats);
+
+    let save_result = manifest.save_merging(dest, &base);
+
+    // The write error comes first: it is the more specific failure, and the save
+    // has already run by this point regardless of which one is reported.
+    write_result?;
+    if save_result? == SkillManifestSave::Merged {
+        tracing::warn!(
+            dest = %dest.display(),
+            "the skill manifest changed during this deploy — a writer bypassed the \
+             ledger lock; its entries were merged rather than dropped"
+        );
+    }
+
+    Ok(stats)
+}
+
+/// Write every selected skill and record it, stopping at the first I/O failure.
+///
+/// Why (#4881): split out of [`deploy_skills_locked`] so its `?` sites cannot
+/// bypass the manifest save. Files this function has already written are on disk
+/// whether it returns `Ok` or `Err`, so the caller must save the ledger on BOTH
+/// paths — a shape that is easy to get wrong while the loop and the save share
+/// one function body, and was wrong here before this change.
+/// What: for each name, writes `<dest>/<stem>/SKILL.md` plus any
+/// `references/*.md` siblings through [`deploy_one_file`], recording each in
+/// `manifest` and `stats`. Skills whose stem contains `mcp` are rejected before
+/// any I/O (#2186). Returns the first I/O error; `manifest` and `stats` still
+/// describe everything written up to that point.
+/// Test: `deploy_records_files_written_before_a_mid_loop_failure`, plus every
+/// `deploy_*` test through the public entry point.
+fn deploy_selected(
+    source: &Path,
+    dest: &Path,
+    names: &[String],
+    now: &str,
+    manifest: &mut SkillManifest,
+    stats: &mut DeployStats,
+) -> Result<()> {
     for filename in names {
-        let stem = skill_stem(&filename).to_string();
+        let stem = skill_stem(filename).to_string();
 
         // Claude Code ships a built-in `/mcp` slash command. A deployed skill
         // whose invocable name (the stem, i.e. the directory Claude Code
@@ -225,20 +273,13 @@ fn deploy_skills_locked(
             continue;
         }
 
-        let source_path = source.join(&filename);
+        let source_path = source.join(filename);
         let content = std::fs::read_to_string(&source_path)?;
         // Claude Code discovers skills from <dest>/<name>/SKILL.md.
         let skill_dir = dest.join(&stem);
         let target_path = skill_dir.join("SKILL.md");
 
-        deploy_one_file(
-            &mut manifest,
-            &stem,
-            &target_path,
-            &content,
-            &now,
-            &mut stats,
-        )?;
+        deploy_one_file(manifest, &stem, &target_path, &content, now, stats)?;
 
         // Mirror any reference files a multi-file skill carries alongside its
         // SKILL.md (issue #2903, ported from `trusty-mpm` PR #2915 —
@@ -263,32 +304,12 @@ fn deploy_skills_locked(
                 let ref_content = std::fs::read_to_string(refs_source_dir.join(&ref_name))?;
                 let ref_key = format!("{stem}/references/{ref_name}");
                 let ref_target = skill_dir.join("references").join(&ref_name);
-                deploy_one_file(
-                    &mut manifest,
-                    &ref_key,
-                    &ref_target,
-                    &ref_content,
-                    &now,
-                    &mut stats,
-                )?;
+                deploy_one_file(manifest, &ref_key, &ref_target, &ref_content, now, stats)?;
             }
         }
     }
 
-    // #4881: every file above is ALREADY on disk, so this save must publish —
-    // failing or refusing here would leave bytes newer than their recorded
-    // checksums, which is exactly what the classifier above reads as a hand-edit
-    // and skips forever. `save_merging` folds in anything an unlocked writer
-    // published mid-deploy rather than dropping it.
-    if manifest.save_merging(dest, &base)? == SkillManifestSave::Merged {
-        tracing::warn!(
-            dest = %dest.display(),
-            "the skill manifest changed during this deploy — a writer bypassed the \
-             ledger lock; its entries were merged rather than dropped"
-        );
-    }
-
-    Ok(stats)
+    Ok(())
 }
 
 /// Deploy one managed file (a skill's `SKILL.md` or one of its

--- a/crates/trusty-agents-common/src/skills/deployer.rs
+++ b/crates/trusty-agents-common/src/skills/deployer.rs
@@ -27,8 +27,10 @@
 
 use std::path::Path;
 
-use crate::agents::manifest::{Result, atomic_write, checksum};
-use crate::skills::manifest::{SkillManifest, SkillManifestEntry};
+use crate::agents::manifest::{ManifestError, Result, atomic_write, checksum};
+use crate::skills::manifest::{
+    SkillManifest, SkillManifestEntry, SkillManifestSave, with_skill_manifest_lock,
+};
 
 /// Summary of one [`deploy_skills`] run.
 ///
@@ -124,24 +126,56 @@ pub fn deploy_skills_filtered(
     dest: &Path,
     select: impl Fn(&str) -> bool,
 ) -> Result<DeployStats> {
-    let mut stats = DeployStats::default();
-
     // No source directory means nothing to deploy — an empty result, not an
     // error, so a fresh install with no skills still succeeds. This is a
     // legitimate state for a fresh checkout, but it is also indistinguishable
     // from a misconfigured `skill_source_dir()` (e.g. a submodule that failed
     // to initialise) unless we log it — silently returning an empty
     // `DeployStats` previously left operators with no signal that zero
-    // skills were ever considered (A2, tm-skills-portfolio epic).
+    // skills were ever considered (A2, tm-skills-portfolio epic). Checked
+    // BEFORE taking the ledger lock so a no-op deploy neither blocks on a
+    // concurrent writer nor creates a lock sidecar in a directory it will not
+    // touch.
     if !source.is_dir() {
         tracing::warn!(
             source = %source.display(),
             "skill source directory missing — no skills will be deployed"
         );
-        return Ok(stats);
+        return Ok(DeployStats::default());
     }
 
+    // #4881: the ENTIRE load-modify-save cycle runs under the directory's
+    // exclusive ledger lock. Four writers share this target — a session
+    // launch's deploy, `sync-assets`, `tm catalog apply`, and (since #4882) the
+    // project-tier deploy on a version change — and without the lock two of
+    // them that both load before either saves silently drop each other's
+    // entries, after which the files those entries described read as
+    // user-edited and are skipped forever. See
+    // `manifest::with_skill_manifest_lock`.
+    with_skill_manifest_lock(dest, || deploy_skills_locked(source, dest, select))
+}
+
+/// The body of [`deploy_skills_filtered`], run while holding the ledger lock.
+///
+/// Why (#4881): split out so the critical section is a single expression the
+/// lock helper wraps, and so the lock's scope is impossible to misread — every
+/// manifest load, file write, and manifest save in this function happens with
+/// the lock held. Mirrors `agents::deployer::deploy_agents_locked`.
+/// What: the classify/write/save pipeline documented on
+/// [`deploy_skills_filtered`]. Never call it directly; it is unsafe against
+/// concurrent writers by construction.
+/// Test: covered by every `deploy_*` test through the public wrapper, plus
+/// `deploy_blocks_while_the_skill_ledger_lock_is_held`.
+fn deploy_skills_locked(
+    source: &Path,
+    dest: &Path,
+    select: impl Fn(&str) -> bool,
+) -> Result<DeployStats> {
+    let mut stats = DeployStats::default();
+
     let mut manifest = SkillManifest::load(dest);
+    // #4881: the snapshot the compare-and-swap save is checked against.
+    let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();
 
     // Collect skill filenames deterministically so output and tests are stable.
@@ -241,7 +275,20 @@ pub fn deploy_skills_filtered(
         }
     }
 
-    manifest.save(dest)?;
+    // #4881: refuse rather than clobber if the ledger moved under us. Holding
+    // the lock makes that impossible among writers that take it, so a refusal
+    // here means an UNLOCKED writer exists — a bug to surface, not to paper
+    // over. Deploy is idempotent, so the next run redoes this cycle intact.
+    match manifest.save_if_current(dest, &base)? {
+        SkillManifestSave::Written => {}
+        SkillManifestSave::RefusedStale => {
+            return Err(ManifestError::Io(std::io::Error::other(format!(
+                "the skill manifest at {} changed during this deploy — an unlocked \
+                 writer bypassed `with_skill_manifest_lock`; nothing was written",
+                dest.display()
+            ))));
+        }
+    }
 
     Ok(stats)
 }

--- a/crates/trusty-agents-common/src/skills/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/skills/deployer_tests.rs
@@ -503,3 +503,49 @@ fn a_racing_writer_freezes_nothing_on_either_side() {
     );
     assert!(final_manifest.checksum_matches("racing-writer-skill", "racer content"));
 }
+
+#[test]
+fn deploy_records_files_written_before_a_mid_loop_failure() {
+    // #4881 review (pre-existing, fixed here): the write loop's `?` sites can
+    // return AFTER earlier SKILL.md files are on disk. Propagating straight out
+    // skipped the manifest save, leaving those files unrecorded — and the next
+    // deploy then read them as hand-edits and skipped them forever. The ledger
+    // must be saved on the error path too.
+    //
+    // The failure is deterministic: `aaa-skill` sorts first and deploys, then
+    // `zzz-skill.md` holds invalid UTF-8, so `read_to_string` fails on it every
+    // run. Invalid bytes rather than a chmod, so the test behaves the same when
+    // the suite happens to run as root.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    fs::write(
+        src.path().join("aaa-skill.md"),
+        "---\nname: aaa-skill\n---\n\nfirst\n",
+    )
+    .unwrap();
+    fs::write(src.path().join("zzz-skill.md"), [0xff, 0xfe, 0xff]).unwrap();
+
+    let err = deploy_skills(src.path(), tgt.path());
+    assert!(err.is_err(), "an unreadable source must still fail the run");
+
+    // The file that DID get written is on disk...
+    let written = tgt.path().join("aaa-skill").join("SKILL.md");
+    assert!(written.exists(), "aaa-skill was written before the failure");
+    // ...and the ledger records it, so it is not orphaned.
+    let manifest = SkillManifest::load(tgt.path());
+    assert!(
+        manifest.is_managed("aaa-skill"),
+        "a file written before the failure must still be recorded"
+    );
+
+    // The proof that matters: a later deploy still owns it, rather than reading
+    // it as a hand-edit and skipping it forever.
+    fs::remove_file(src.path().join("zzz-skill.md")).unwrap();
+    let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+    assert!(
+        stats.skipped.is_empty(),
+        "nothing may be frozen by a mid-loop failure: skipped={:?}",
+        stats.skipped
+    );
+    assert!(stats.unchanged.contains(&"aaa-skill".to_string()));
+}

--- a/crates/trusty-agents-common/src/skills/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/skills/deployer_tests.rs
@@ -365,3 +365,62 @@ fn deploy_single_file_skill_has_no_references_dir() {
 
     assert!(!tgt.path().join("tm-doctor").join("references").exists());
 }
+
+#[test]
+fn deploy_blocks_while_the_skill_ledger_lock_is_held() {
+    // #4881: proves the WHOLE load-modify-save cycle is inside the lock, not
+    // just the save. The main thread holds the target's ledger lock; a deploy
+    // running concurrently must not finish, or write anything, until that lock
+    // is released.
+    //
+    // Deterministic in both directions, with no reliance on scheduling luck:
+    // an UNLOCKED deploy of two tiny files completes in well under a
+    // millisecond, so the 2s "still blocked?" probe cannot pass by accident;
+    // and a deploy that IS blocked on `flock` stays blocked for exactly as long
+    // as the lock is held, so the locked version cannot fail by accident.
+    use std::sync::mpsc;
+
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_sources(src.path());
+
+    let (tx, rx) = mpsc::channel();
+    let src_path = src.path().to_path_buf();
+    let deploy_target = tgt.path().to_path_buf();
+    let deployed_marker = tgt.path().join("tm-doctor").join("SKILL.md");
+
+    // The handle leaves the critical section rather than being joined inside
+    // it: the deploy cannot finish until we release, so joining under the lock
+    // would deadlock this test rather than exercise it.
+    let handle = crate::skills::manifest::with_skill_manifest_lock::<_, ManifestError, _>(
+        tgt.path(),
+        || {
+            let handle = std::thread::spawn(move || {
+                tx.send(deploy_skills(&src_path, &deploy_target).unwrap())
+                    .ok();
+            });
+
+            assert!(
+                rx.recv_timeout(std::time::Duration::from_secs(2)).is_err(),
+                "deploy completed while the skill ledger lock was held — its \
+                 load-modify-save is not inside the lock"
+            );
+            assert!(
+                !deployed_marker.exists(),
+                "deploy wrote a skill file while the ledger lock was held"
+            );
+            Ok(handle)
+        },
+    )
+    .unwrap();
+
+    handle.join().unwrap();
+    let stats = rx
+        .recv_timeout(std::time::Duration::from_secs(30))
+        .expect("deploy must complete once the lock is released");
+    assert_eq!(stats.deployed.len(), 2);
+    assert!(
+        SkillManifest::load(tgt.path()).is_managed("tm-doctor"),
+        "the released deploy must have recorded its entries"
+    );
+}

--- a/crates/trusty-agents-common/src/skills/deployer_tests.rs
+++ b/crates/trusty-agents-common/src/skills/deployer_tests.rs
@@ -12,6 +12,7 @@
 //! `cargo test -p trusty-agents-common -- skills::deployer`.
 
 use super::*;
+use crate::agents::manifest::ManifestError;
 use std::fs;
 use tempfile::TempDir;
 
@@ -423,4 +424,82 @@ fn deploy_blocks_while_the_skill_ledger_lock_is_held() {
         SkillManifest::load(tgt.path()).is_managed("tm-doctor"),
         "the released deploy must have recorded its entries"
     );
+}
+
+#[test]
+fn a_racing_writer_freezes_nothing_on_either_side() {
+    // #4881 — the invariant a save must uphold once files are on disk. This is
+    // the regression test for a CAS that returned `Err` after `atomic_write`
+    // had already published every `SKILL.md`: the bytes were newer than their
+    // recorded checksums, so the next deploy read all of them as hand-edits and
+    // skipped the whole tier forever — manufacturing the freeze this issue
+    // exists to prevent.
+    //
+    // The interleaving is CONSTRUCTED, not raced: it replays the deployer's own
+    // ordering (load, write files, save against the base loaded earlier) with a
+    // competing writer publishing in between. The assertion that matters is
+    // made by the REAL deployer afterwards — its classifier is what freezes.
+    let src = TempDir::new().unwrap();
+    let tgt = TempDir::new().unwrap();
+    write_sources(src.path());
+
+    // A first, uncontended deploy. This is the `base` an in-flight deploy loads.
+    deploy_skills(src.path(), tgt.path()).unwrap();
+    let base = SkillManifest::load(tgt.path());
+
+    // A writer that does NOT take the ledger lock — an older installed `tm`
+    // during a rollout — publishes its own entry after our base was loaded.
+    let mut racer = base.clone();
+    racer.managed.insert(
+        "racing-writer-skill".into(),
+        SkillManifestEntry {
+            checksum: checksum("racer content"),
+            deployed_at: "2026-08-05T00:00:00Z".into(),
+        },
+    );
+    let racer_dir = tgt.path().join("racing-writer-skill");
+    fs::create_dir_all(&racer_dir).unwrap();
+    fs::write(racer_dir.join("SKILL.md"), "racer content").unwrap();
+    racer.save(tgt.path()).unwrap();
+
+    // Our in-flight deploy: new content for every source skill is written to
+    // disk FIRST (as `deploy_one_file` does), then the ledger is saved against
+    // the now-stale `base`.
+    let mut ours = base.clone();
+    for stem in ["tm-doctor", "example-skill"] {
+        let content = format!("---\nname: {stem}\n---\n\nv2 content\n");
+        let dir = tgt.path().join(stem);
+        fs::write(dir.join("SKILL.md"), &content).unwrap();
+        fs::write(src.path().join(format!("{stem}.md")), &content).unwrap();
+        ours.managed.insert(
+            stem.to_string(),
+            SkillManifestEntry {
+                checksum: checksum(&content),
+                deployed_at: "2026-08-05T00:00:01Z".into(),
+            },
+        );
+    }
+    assert_eq!(
+        ours.save_merging(tgt.path(), &base).unwrap(),
+        SkillManifestSave::Merged
+    );
+
+    // Nothing is frozen on OUR side: the real deployer sees content it wrote,
+    // matching its recorded checksum — `unchanged`, never `skipped`.
+    let stats = deploy_skills(src.path(), tgt.path()).unwrap();
+    assert!(
+        stats.skipped.is_empty(),
+        "a racing writer must freeze nothing: skipped={:?}",
+        stats.skipped
+    );
+    assert_eq!(stats.unchanged.len(), 2, "both skills must stay writable");
+
+    // Nothing is frozen on the RACER's side either: a blind save would have
+    // dropped its entry, leaving its file untracked and skipped from then on.
+    let final_manifest = SkillManifest::load(tgt.path());
+    assert!(
+        final_manifest.is_managed("racing-writer-skill"),
+        "the racing writer's entry must survive, or ITS file freezes instead"
+    );
+    assert!(final_manifest.checksum_matches("racing-writer-skill", "racer content"));
 }

--- a/crates/trusty-agents-common/src/skills/manifest.rs
+++ b/crates/trusty-agents-common/src/skills/manifest.rs
@@ -24,10 +24,72 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
-use crate::agents::manifest::{Result, atomic_write, checksum};
+use crate::agents::manifest::{ManifestError, Result, atomic_write, checksum, with_ledger_lock};
 
 /// Filename of the skill manifest within a target directory.
 pub const SKILL_MANIFEST_FILE: &str = ".trusty-mpm-skills-manifest.json";
+
+/// Sidecar lock-file path serialising one directory's skill ledger.
+///
+/// Why (#4881): named once so the lock helper and any future repair tooling
+/// cannot disagree about which file serialises a skill deploy directory. Locking
+/// the ledger document itself would not work — the lock would be lost across the
+/// `rename` that publishes each new version, because the renamed-over inode (and
+/// any lock held on it) is discarded. A stable sidecar survives every publish.
+/// Same reasoning and convention as [`crate::agents::manifest::manifest_lock_path`].
+/// What: `<dir>/.trusty-mpm-skills-manifest.json.lock`.
+/// Test: `skill_manifest_lock_path_is_a_sidecar`.
+pub fn skill_manifest_lock_path(target_dir: &Path) -> std::path::PathBuf {
+    target_dir.join(format!("{SKILL_MANIFEST_FILE}.lock"))
+}
+
+/// Run `f` holding the exclusive cross-process lock on `target_dir`'s skill ledger.
+///
+/// Why (#4881): the skill deploy cycle is load manifest → write skill files →
+/// save manifest, and four separate writers run it against the SAME directory —
+/// a session launch's deploy, `sync-assets`, `tm catalog apply`'s deploy+prune,
+/// and (since #4882) the project-tier deploy triggered by a version change. Two
+/// concurrent writers each read the ledger before either writes, so the second
+/// `save` publishes a document missing the first's entries. The file a lost
+/// entry described still holds the newer bytes, so its recorded checksum now
+/// names an OLDER revision than what is on disk, and
+/// [`crate::skills::deployer`]'s `deploy_one_file` reads that mismatch as "the
+/// user hand-edited this" and skips the file from then on — a skill nobody
+/// touched, frozen against every future update. Three such skills were measured
+/// frozen on 2026-08-05 with zero hand-authored content in any of them. An
+/// in-process `Mutex` cannot fix it, because the writers are separate processes.
+///
+/// What: delegates to [`with_ledger_lock`] on [`skill_manifest_lock_path`]. `f`
+/// must perform the WHOLE load-modify-save cycle — the lost-update window opens
+/// at the load, not at the save.
+///
+/// Advisory and not reentrant; see [`with_ledger_lock`] for the full contract.
+/// Test: `skill_manifest_lock_serialises_concurrent_writers`,
+/// `skill_manifest_lock_releases_so_a_second_acquisition_succeeds`.
+pub fn with_skill_manifest_lock<T, E, F>(target_dir: &Path, f: F) -> std::result::Result<T, E>
+where
+    E: From<ManifestError>,
+    F: FnOnce() -> std::result::Result<T, E>,
+{
+    with_ledger_lock(&skill_manifest_lock_path(target_dir), f)
+}
+
+/// Outcome of a compare-and-swap manifest save.
+///
+/// Why (#4881): a refused save is not a failure the caller may ignore — it means
+/// the ledger moved under an unlocked writer, which is the exact condition that
+/// freezes skills. `#[must_use]` makes dropping the answer a compile error.
+/// What: `Written` when the snapshot was still current and the document was
+/// published; `RefusedStale` when it was not and NOTHING was written.
+/// Test: `skill_manifest_save_if_current_refuses_a_stale_snapshot`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[must_use]
+pub enum SkillManifestSave {
+    /// The snapshot was current; the manifest was written.
+    Written,
+    /// On-disk state had moved on since the snapshot; nothing was written.
+    RefusedStale,
+}
 
 /// Current on-disk skill manifest schema version.
 const SKILL_MANIFEST_VERSION: u32 = 1;
@@ -103,6 +165,38 @@ impl SkillManifest {
         Ok(())
     }
 
+    /// Save only if the on-disk manifest is still the one `base` was loaded from.
+    ///
+    /// Why (#4881): defence in depth behind [`with_skill_manifest_lock`]. The
+    /// lock is ADVISORY, so it protects only writers that take it; a future
+    /// caller that reaches for plain [`SkillManifest::save`] silently reinstates
+    /// the lost-update race. Under the owner's lifecycle ruling this ledger is
+    /// the durable record of what the user customized, so a stale write no
+    /// longer merely freezes a file — it corrupts that record. Comparing against
+    /// disk turns the clobber into a refusal the caller must handle.
+    /// What: re-reads the manifest at `target_dir` and writes `self` only when
+    /// it equals `base` (the snapshot this manifest was derived from), returning
+    /// [`SkillManifestSave::Written`]. Otherwise nothing is written and
+    /// [`SkillManifestSave::RefusedStale`] is returned. An absent file loads as
+    /// the empty default, so a first-ever deploy compares equal and proceeds.
+    ///
+    /// This is a CAS, not a merge: it refuses, it never reconciles. Deploy is
+    /// idempotent, so the correct response to a refusal is to surface it and let
+    /// the next run redo the cycle.
+    /// Test: `skill_manifest_save_if_current_refuses_a_stale_snapshot`,
+    /// `skill_manifest_save_if_current_writes_when_unchanged`.
+    pub fn save_if_current(
+        &self,
+        target_dir: &Path,
+        base: &SkillManifest,
+    ) -> Result<SkillManifestSave> {
+        if &Self::load(target_dir) != base {
+            return Ok(SkillManifestSave::RefusedStale);
+        }
+        self.save(target_dir)?;
+        Ok(SkillManifestSave::Written)
+    }
+
     /// Whether `filename` is a trusty-mpm-managed skill file.
     ///
     /// Why: files absent from the manifest are user-owned and must never be
@@ -129,69 +223,5 @@ impl SkillManifest {
 }
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-
-    fn sample_entry() -> SkillManifestEntry {
-        SkillManifestEntry {
-            checksum: checksum("hello world"),
-            deployed_at: "2026-05-19T00:00:00Z".into(),
-        }
-    }
-
-    #[test]
-    fn skill_manifest_load_missing_returns_empty() {
-        // A directory with no manifest file must yield an empty, valid
-        // manifest rather than an error.
-        let tmp = TempDir::new().unwrap();
-        let manifest = SkillManifest::load(tmp.path());
-        assert_eq!(manifest.version, SKILL_MANIFEST_VERSION);
-        assert!(manifest.managed.is_empty());
-    }
-
-    #[test]
-    fn skill_manifest_round_trip() {
-        // A saved manifest must reload identically.
-        let tmp = TempDir::new().unwrap();
-        let mut manifest = SkillManifest::default();
-        manifest
-            .managed
-            .insert("tm-doctor.md".into(), sample_entry());
-        manifest.save(tmp.path()).unwrap();
-
-        let loaded = SkillManifest::load(tmp.path());
-        assert_eq!(loaded, manifest);
-        assert!(tmp.path().join(SKILL_MANIFEST_FILE).exists());
-    }
-
-    #[test]
-    fn skill_manifest_checksum_matches() {
-        // Correct content matches; modified content does not.
-        let mut manifest = SkillManifest::default();
-        manifest
-            .managed
-            .insert("tm-doctor.md".into(), sample_entry());
-        assert!(manifest.checksum_matches("tm-doctor.md", "hello world"));
-        assert!(!manifest.checksum_matches("tm-doctor.md", "hello world!"));
-        // An unmanaged file never matches.
-        assert!(!manifest.checksum_matches("other.md", "hello world"));
-    }
-
-    #[test]
-    fn skill_manifest_is_managed() {
-        let mut manifest = SkillManifest::default();
-        manifest
-            .managed
-            .insert("tm-doctor.md".into(), sample_entry());
-        assert!(manifest.is_managed("tm-doctor.md"));
-        assert!(!manifest.is_managed("user-skill.md"));
-    }
-
-    #[test]
-    fn skill_manifest_file_name_differs_from_agent_manifest() {
-        // The skill manifest must use a distinct filename so it never collides
-        // with the agent manifest if both ever share a directory.
-        assert_ne!(SKILL_MANIFEST_FILE, crate::agents::manifest::MANIFEST_FILE);
-    }
-}
+#[path = "manifest_tests.rs"]
+mod tests;

--- a/crates/trusty-agents-common/src/skills/manifest.rs
+++ b/crates/trusty-agents-common/src/skills/manifest.rs
@@ -76,19 +76,22 @@ where
 
 /// Outcome of a compare-and-swap manifest save.
 ///
-/// Why (#4881): a refused save is not a failure the caller may ignore — it means
-/// the ledger moved under an unlocked writer, which is the exact condition that
-/// freezes skills. `#[must_use]` makes dropping the answer a compile error.
-/// What: `Written` when the snapshot was still current and the document was
-/// published; `RefusedStale` when it was not and NOTHING was written.
-/// Test: `skill_manifest_save_if_current_refuses_a_stale_snapshot`.
+/// Why (#4881): a merge means an UNLOCKED writer published between this
+/// writer's load and its save. The ledger is intact either way, but the
+/// condition is worth a log line — it says the advisory lock was bypassed.
+/// `#[must_use]` keeps that answer from being silently dropped.
+/// What: `Written` when the snapshot was still current; `Merged` when a
+/// concurrent writer's entries were folded in first. Both mean the manifest
+/// WAS published — there is deliberately no variant meaning "nothing written".
+/// Test: `skill_manifest_save_merging_folds_in_a_concurrent_writer`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[must_use]
 pub enum SkillManifestSave {
-    /// The snapshot was current; the manifest was written.
+    /// The snapshot was current; the manifest was written as-is.
     Written,
-    /// On-disk state had moved on since the snapshot; nothing was written.
-    RefusedStale,
+    /// A concurrent writer had published; its entries were folded in and the
+    /// merged document written.
+    Merged,
 }
 
 /// Current on-disk skill manifest schema version.
@@ -165,36 +168,57 @@ impl SkillManifest {
         Ok(())
     }
 
-    /// Save only if the on-disk manifest is still the one `base` was loaded from.
+    /// Publish `self`, folding in anything a concurrent writer added since `base`.
     ///
-    /// Why (#4881): defence in depth behind [`with_skill_manifest_lock`]. The
-    /// lock is ADVISORY, so it protects only writers that take it; a future
-    /// caller that reaches for plain [`SkillManifest::save`] silently reinstates
-    /// the lost-update race. Under the owner's lifecycle ruling this ledger is
-    /// the durable record of what the user customized, so a stale write no
-    /// longer merely freezes a file — it corrupts that record. Comparing against
-    /// disk turns the clobber into a refusal the caller must handle.
-    /// What: re-reads the manifest at `target_dir` and writes `self` only when
-    /// it equals `base` (the snapshot this manifest was derived from), returning
-    /// [`SkillManifestSave::Written`]. Otherwise nothing is written and
-    /// [`SkillManifestSave::RefusedStale`] is returned. An absent file loads as
-    /// the empty default, so a first-ever deploy compares equal and proceeds.
+    /// Why (#4881): defence in depth behind [`with_skill_manifest_lock`], which
+    /// is ADVISORY and so protects only writers that take it — during a rollout
+    /// the older installed `tm` binaries do not. Every caller writes SKILL FILES
+    /// before it saves, which forces one invariant: **a save must never fail, or
+    /// refuse, after files are on disk.** Bytes newer than the recorded checksum
+    /// are precisely what `deployer::deploy_one_file` reads as a hand-edit and
+    /// skips forever, so a refusal here would manufacture the freeze this issue
+    /// exists to prevent — across the whole tier, not one file. Merging is also
+    /// strictly better than a plain [`SkillManifest::save`]: a blind save drops
+    /// the racing writer's entries and freezes ITS files instead.
+    /// What: a three-way merge. When the on-disk manifest still equals `base`,
+    /// writes `self` and returns [`SkillManifestSave::Written`]. Otherwise it
+    /// starts from the CURRENT on-disk document and applies this run's delta
+    /// relative to `base` — every key `self` added or changed is inserted, every
+    /// key `base` had and `self` dropped is removed — then writes that and
+    /// returns [`SkillManifestSave::Merged`]. Both outcomes publish. An absent
+    /// file loads as the empty default, so a first-ever save compares equal.
     ///
-    /// This is a CAS, not a merge: it refuses, it never reconciles. Deploy is
-    /// idempotent, so the correct response to a refusal is to surface it and let
-    /// the next run redo the cycle.
-    /// Test: `skill_manifest_save_if_current_refuses_a_stale_snapshot`,
-    /// `skill_manifest_save_if_current_writes_when_unchanged`.
-    pub fn save_if_current(
+    /// The delta, not `self`, is what gets applied: `self` is `base` plus this
+    /// run's changes, so replaying only the difference is what preserves the
+    /// other writer's work instead of overwriting it.
+    /// Test: `skill_manifest_save_merging_folds_in_a_concurrent_writer`,
+    /// `skill_manifest_save_merging_applies_this_runs_removals`,
+    /// `skill_manifest_save_merging_writes_when_unchanged`.
+    pub fn save_merging(
         &self,
         target_dir: &Path,
         base: &SkillManifest,
     ) -> Result<SkillManifestSave> {
-        if &Self::load(target_dir) != base {
-            return Ok(SkillManifestSave::RefusedStale);
+        let on_disk = Self::load(target_dir);
+        if on_disk == *base {
+            self.save(target_dir)?;
+            return Ok(SkillManifestSave::Written);
         }
-        self.save(target_dir)?;
-        Ok(SkillManifestSave::Written)
+
+        let mut merged = on_disk;
+        merged.version = self.version;
+        for (key, entry) in &self.managed {
+            if base.managed.get(key) != Some(entry) {
+                merged.managed.insert(key.clone(), entry.clone());
+            }
+        }
+        for key in base.managed.keys() {
+            if !self.managed.contains_key(key) {
+                merged.managed.remove(key);
+            }
+        }
+        merged.save(target_dir)?;
+        Ok(SkillManifestSave::Merged)
     }
 
     /// Whether `filename` is a trusty-mpm-managed skill file.

--- a/crates/trusty-agents-common/src/skills/manifest.rs
+++ b/crates/trusty-agents-common/src/skills/manifest.rs
@@ -92,6 +92,9 @@ pub enum SkillManifestSave {
     /// A concurrent writer had published; its entries were folded in and the
     /// merged document written.
     Merged,
+    /// The on-disk manifest existed but did not parse, so nothing could be
+    /// merged from it; the caller's own ledger was published over it.
+    OverwroteUnreadable,
 }
 
 /// Current on-disk skill manifest schema version.
@@ -199,7 +202,23 @@ impl SkillManifest {
         target_dir: &Path,
         base: &SkillManifest,
     ) -> Result<SkillManifestSave> {
-        let on_disk = Self::load(target_dir);
+        // #4881 review: an UNPARSEABLE ledger is not an empty one. `load` maps
+        // both to the default, and merging from that default would publish only
+        // this run's delta — silently dropping every entry `base` holds, which
+        // is the same fail-open shape (unreadable treated as absent) this method
+        // exists to remove. Publishing `self` instead is exactly what a plain
+        // `save` does, so this path is never worse than before the merge landed,
+        // and the entries read at load time survive.
+        let Some(on_disk) = Self::read_parsed(target_dir)? else {
+            tracing::error!(
+                target = %target_dir.display(),
+                file = SKILL_MANIFEST_FILE,
+                "the skill manifest could not be parsed — publishing this run's \
+                 ledger over it; entries it may have held are unrecoverable"
+            );
+            self.save(target_dir)?;
+            return Ok(SkillManifestSave::OverwroteUnreadable);
+        };
         if on_disk == *base {
             self.save(target_dir)?;
             return Ok(SkillManifestSave::Written);
@@ -219,6 +238,26 @@ impl SkillManifest {
         }
         merged.save(target_dir)?;
         Ok(SkillManifestSave::Merged)
+    }
+
+    /// Read the on-disk manifest, distinguishing "absent" from "unparseable".
+    ///
+    /// Why (#4881 review): [`SkillManifest::load`] collapses both into the empty
+    /// default, which is right for a first-ever deploy and wrong for corruption
+    /// — a merge that starts from "empty" because it could not read the file
+    /// publishes a ledger missing everything the file held. Only
+    /// [`SkillManifest::save_merging`] needs the distinction, so this stays
+    /// private rather than adding a second public load API.
+    /// What: `Ok(Some(default))` when the file is absent (nothing was ever
+    /// deployed here), `Ok(Some(parsed))` when it reads, `Ok(None)` when it
+    /// exists but does not parse. A non-`NotFound` I/O error propagates.
+    /// Test: `skill_manifest_save_merging_over_a_corrupt_ledger_keeps_the_base`.
+    fn read_parsed(target_dir: &Path) -> Result<Option<SkillManifest>> {
+        match std::fs::read_to_string(target_dir.join(SKILL_MANIFEST_FILE)) {
+            Ok(raw) => Ok(serde_json::from_str(&raw).ok()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Some(Self::default())),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Whether `filename` is a trusty-mpm-managed skill file.

--- a/crates/trusty-agents-common/src/skills/manifest_tests.rs
+++ b/crates/trusty-agents-common/src/skills/manifest_tests.rs
@@ -145,10 +145,11 @@ fn skill_manifest_lock_releases_so_a_second_acquisition_succeeds() {
 }
 
 #[test]
-fn skill_manifest_save_if_current_refuses_a_stale_snapshot() {
-    // #4881, defence in depth behind the lock: a writer whose snapshot went
-    // stale must be refused, never allowed to clobber the newer record. The
-    // staleness is constructed directly — no scheduling involved.
+fn skill_manifest_save_merging_folds_in_a_concurrent_writer() {
+    // #4881: a writer whose snapshot went stale must publish a document holding
+    // BOTH its own delta and the racing writer's — never one at the other's
+    // expense, and never nothing. Staleness is constructed directly; no
+    // scheduling is involved.
     let tmp = TempDir::new().unwrap();
     let dir = tmp.path();
 
@@ -169,20 +170,58 @@ fn skill_manifest_save_if_current_refuses_a_stale_snapshot() {
     ours.managed.insert("ours".into(), sample_entry());
 
     assert_eq!(
-        ours.save_if_current(dir, &base).unwrap(),
-        SkillManifestSave::RefusedStale
+        ours.save_merging(dir, &base).unwrap(),
+        SkillManifestSave::Merged
     );
 
-    // Nothing was written: the other writer's entry survives and ours is absent.
     let on_disk = SkillManifest::load(dir);
-    assert!(on_disk.is_managed("from-the-other-writer"));
-    assert!(!on_disk.is_managed("ours"));
+    assert!(on_disk.is_managed("ours"), "our own entry must be recorded");
+    assert!(
+        on_disk.is_managed("from-the-other-writer"),
+        "the racing writer's entry must survive"
+    );
+    assert!(on_disk.is_managed("shared"));
 }
 
 #[test]
-fn skill_manifest_save_if_current_writes_when_unchanged() {
-    // The CAS must not be a permanent refusal: an unraced save proceeds, and a
-    // first-ever save (no file on disk, snapshot = empty default) proceeds too.
+fn skill_manifest_save_merging_applies_this_runs_removals() {
+    // The prune path's delta is REMOVALS. Merging must apply them to the
+    // current on-disk document, not silently revert them, and must still leave
+    // a concurrent writer's inserts alone.
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    let mut base = SkillManifest::default();
+    base.managed.insert("keep".into(), sample_entry());
+    base.managed.insert("prune-me".into(), sample_entry());
+    base.save(dir).unwrap();
+
+    let mut newer = base.clone();
+    newer.managed.insert("arrived-later".into(), sample_entry());
+    newer.save(dir).unwrap();
+
+    // Our delta: drop `prune-me`.
+    let mut ours = base.clone();
+    ours.managed.remove("prune-me");
+
+    assert_eq!(
+        ours.save_merging(dir, &base).unwrap(),
+        SkillManifestSave::Merged
+    );
+
+    let on_disk = SkillManifest::load(dir);
+    assert!(!on_disk.is_managed("prune-me"), "our removal must apply");
+    assert!(on_disk.is_managed("keep"));
+    assert!(
+        on_disk.is_managed("arrived-later"),
+        "the racing writer's insert must survive a prune merge"
+    );
+}
+
+#[test]
+fn skill_manifest_save_merging_writes_when_unchanged() {
+    // The uncontended path: an unraced save publishes as-is, and a first-ever
+    // save (no file on disk, snapshot = empty default) publishes too.
     let tmp = TempDir::new().unwrap();
     let dir = tmp.path();
 
@@ -190,7 +229,7 @@ fn skill_manifest_save_if_current_writes_when_unchanged() {
     let mut first = base.clone();
     first.managed.insert("tm-doctor".into(), sample_entry());
     assert_eq!(
-        first.save_if_current(dir, &base).unwrap(),
+        first.save_merging(dir, &base).unwrap(),
         SkillManifestSave::Written
     );
     assert!(SkillManifest::load(dir).is_managed("tm-doctor"));
@@ -199,7 +238,7 @@ fn skill_manifest_save_if_current_writes_when_unchanged() {
     let mut second = base.clone();
     second.managed.insert("tm-workflow".into(), sample_entry());
     assert_eq!(
-        second.save_if_current(dir, &base).unwrap(),
+        second.save_merging(dir, &base).unwrap(),
         SkillManifestSave::Written
     );
     let on_disk = SkillManifest::load(dir);

--- a/crates/trusty-agents-common/src/skills/manifest_tests.rs
+++ b/crates/trusty-agents-common/src/skills/manifest_tests.rs
@@ -5,9 +5,10 @@
 //!
 //! Why: moved verbatim from `manifest.rs`'s inline `#[cfg(test)] mod tests` —
 //! a behavior-preserving extraction, not a rewrite — plus the #4881 lock and
-//! compare-and-swap coverage.
+//! merging-save coverage.
 //! What: covers load-of-missing, round-trip save/load, checksum matching, the
-//! ledger lock's serialisation and release, and the stale-snapshot refusal.
+//! ledger lock's serialisation and release, and the merging save's handling of
+//! a concurrent writer, of this run's removals, and of an unreadable ledger.
 //! Test: this file IS the test module for `manifest`; run with
 //! `cargo test -p trusty-agents-common -- skills::manifest`.
 
@@ -244,4 +245,43 @@ fn skill_manifest_save_merging_writes_when_unchanged() {
     let on_disk = SkillManifest::load(dir);
     assert!(on_disk.is_managed("tm-doctor"));
     assert!(on_disk.is_managed("tm-workflow"));
+}
+
+#[test]
+fn skill_manifest_save_merging_over_a_corrupt_ledger_keeps_the_base() {
+    // #4881 review: `load` maps an UNPARSEABLE ledger to the empty default, so
+    // merging from it would publish only this run's delta and silently drop
+    // everything `base` holds — unreadable treated as absent, the same fail-open
+    // shape the merge exists to remove. The base's entries must survive.
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    let mut base = SkillManifest::default();
+    for i in 0..9 {
+        base.managed.insert(format!("s{i}"), sample_entry());
+    }
+    base.save(dir).unwrap();
+
+    // The ledger becomes unparseable after this run loaded its base.
+    std::fs::write(dir.join(SKILL_MANIFEST_FILE), "{ not json").unwrap();
+
+    let mut ours = base.clone();
+    ours.managed.insert("ours".into(), sample_entry());
+
+    assert_eq!(
+        ours.save_merging(dir, &base).unwrap(),
+        SkillManifestSave::OverwroteUnreadable
+    );
+
+    let on_disk = SkillManifest::load(dir);
+    assert_eq!(
+        on_disk.managed.len(),
+        10,
+        "the base's 9 entries plus ours must survive, not just ours: {:?}",
+        on_disk.managed.keys().collect::<Vec<_>>()
+    );
+    for i in 0..9 {
+        assert!(on_disk.is_managed(&format!("s{i}")));
+    }
+    assert!(on_disk.is_managed("ours"));
 }

--- a/crates/trusty-agents-common/src/skills/manifest_tests.rs
+++ b/crates/trusty-agents-common/src/skills/manifest_tests.rs
@@ -1,0 +1,208 @@
+//! Tests for `skills::manifest` — split out to mirror the
+//! `deployer`/`deployer_tests` pattern the rest of this module already uses,
+//! and to keep `manifest.rs` under the 500-SLOC production cap once the #4881
+//! ledger lock and its concurrency tests landed.
+//!
+//! Why: moved verbatim from `manifest.rs`'s inline `#[cfg(test)] mod tests` —
+//! a behavior-preserving extraction, not a rewrite — plus the #4881 lock and
+//! compare-and-swap coverage.
+//! What: covers load-of-missing, round-trip save/load, checksum matching, the
+//! ledger lock's serialisation and release, and the stale-snapshot refusal.
+//! Test: this file IS the test module for `manifest`; run with
+//! `cargo test -p trusty-agents-common -- skills::manifest`.
+
+use super::*;
+use tempfile::TempDir;
+
+fn sample_entry() -> SkillManifestEntry {
+    SkillManifestEntry {
+        checksum: checksum("hello world"),
+        deployed_at: "2026-05-19T00:00:00Z".into(),
+    }
+}
+
+#[test]
+fn skill_manifest_load_missing_returns_empty() {
+    // A directory with no manifest file must yield an empty, valid
+    // manifest rather than an error.
+    let tmp = TempDir::new().unwrap();
+    let manifest = SkillManifest::load(tmp.path());
+    assert_eq!(manifest.version, SKILL_MANIFEST_VERSION);
+    assert!(manifest.managed.is_empty());
+}
+
+#[test]
+fn skill_manifest_round_trip() {
+    // A saved manifest must reload identically.
+    let tmp = TempDir::new().unwrap();
+    let mut manifest = SkillManifest::default();
+    manifest
+        .managed
+        .insert("tm-doctor.md".into(), sample_entry());
+    manifest.save(tmp.path()).unwrap();
+
+    let loaded = SkillManifest::load(tmp.path());
+    assert_eq!(loaded, manifest);
+    assert!(tmp.path().join(SKILL_MANIFEST_FILE).exists());
+}
+
+#[test]
+fn skill_manifest_checksum_matches() {
+    // Correct content matches; modified content does not.
+    let mut manifest = SkillManifest::default();
+    manifest
+        .managed
+        .insert("tm-doctor.md".into(), sample_entry());
+    assert!(manifest.checksum_matches("tm-doctor.md", "hello world"));
+    assert!(!manifest.checksum_matches("tm-doctor.md", "hello world!"));
+    // An unmanaged file never matches.
+    assert!(!manifest.checksum_matches("other.md", "hello world"));
+}
+
+#[test]
+fn skill_manifest_is_managed() {
+    let mut manifest = SkillManifest::default();
+    manifest
+        .managed
+        .insert("tm-doctor.md".into(), sample_entry());
+    assert!(manifest.is_managed("tm-doctor.md"));
+    assert!(!manifest.is_managed("user-skill.md"));
+}
+
+#[test]
+fn skill_manifest_file_name_differs_from_agent_manifest() {
+    // The skill manifest must use a distinct filename so it never collides
+    // with the agent manifest if both ever share a directory.
+    assert_ne!(SKILL_MANIFEST_FILE, crate::agents::manifest::MANIFEST_FILE);
+}
+
+#[test]
+fn skill_manifest_lock_path_is_a_sidecar() {
+    // #4881: the lock must be a stable sibling, not the ledger itself — a lock
+    // on the document is discarded by the rename that publishes each version.
+    let dir = Path::new("/some/skills");
+    assert_eq!(
+        skill_manifest_lock_path(dir),
+        dir.join(".trusty-mpm-skills-manifest.json.lock")
+    );
+    // And it must not collide with the agent ledger's sidecar if the two ever
+    // share a directory.
+    assert_ne!(
+        skill_manifest_lock_path(dir),
+        crate::agents::manifest::manifest_lock_path(dir)
+    );
+}
+
+#[test]
+fn skill_manifest_lock_serialises_concurrent_writers() {
+    // #4881: the load-modify-save cycle must be serialised, or two writers that
+    // both load before either saves silently drop each other's entries — and a
+    // skill whose entry was lost then reads as hand-edited and freezes.
+    //
+    // The interleaving is FORCED, not hoped for: each thread sleeps 5ms while
+    // holding its loaded snapshot, which is four orders of magnitude longer
+    // than the load itself, so without the lock every thread is guaranteed to
+    // have loaded before any thread saves and exactly one entry survives.
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path().to_path_buf();
+    SkillManifest::default().save(&dir).unwrap();
+
+    let handles: Vec<_> = (0..8)
+        .map(|i| {
+            let dir = dir.clone();
+            std::thread::spawn(move || {
+                with_skill_manifest_lock::<(), ManifestError, _>(&dir, || {
+                    let mut m = SkillManifest::load(&dir);
+                    m.managed.insert(format!("skill-{i}"), sample_entry());
+                    std::thread::sleep(std::time::Duration::from_millis(5));
+                    m.save(&dir)
+                })
+                .unwrap();
+            })
+        })
+        .collect();
+    for h in handles {
+        h.join().unwrap();
+    }
+
+    let final_manifest = SkillManifest::load(&dir);
+    assert_eq!(
+        final_manifest.managed.len(),
+        8,
+        "every writer's entry must survive: {:?}",
+        final_manifest.managed.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn skill_manifest_lock_releases_so_a_second_acquisition_succeeds() {
+    // The lock is RAII: a completed critical section must not leave the
+    // directory locked, or the next deploy in this process deadlocks.
+    let tmp = TempDir::new().unwrap();
+    for _ in 0..3 {
+        with_skill_manifest_lock::<(), ManifestError, _>(tmp.path(), || Ok(())).unwrap();
+    }
+}
+
+#[test]
+fn skill_manifest_save_if_current_refuses_a_stale_snapshot() {
+    // #4881, defence in depth behind the lock: a writer whose snapshot went
+    // stale must be refused, never allowed to clobber the newer record. The
+    // staleness is constructed directly — no scheduling involved.
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    // The snapshot both writers start from.
+    let mut base = SkillManifest::default();
+    base.managed.insert("shared".into(), sample_entry());
+    base.save(dir).unwrap();
+
+    // A concurrent writer publishes an entry our snapshot never saw.
+    let mut newer = base.clone();
+    newer
+        .managed
+        .insert("from-the-other-writer".into(), sample_entry());
+    newer.save(dir).unwrap();
+
+    // Our own edit, computed against the now-stale `base`.
+    let mut ours = base.clone();
+    ours.managed.insert("ours".into(), sample_entry());
+
+    assert_eq!(
+        ours.save_if_current(dir, &base).unwrap(),
+        SkillManifestSave::RefusedStale
+    );
+
+    // Nothing was written: the other writer's entry survives and ours is absent.
+    let on_disk = SkillManifest::load(dir);
+    assert!(on_disk.is_managed("from-the-other-writer"));
+    assert!(!on_disk.is_managed("ours"));
+}
+
+#[test]
+fn skill_manifest_save_if_current_writes_when_unchanged() {
+    // The CAS must not be a permanent refusal: an unraced save proceeds, and a
+    // first-ever save (no file on disk, snapshot = empty default) proceeds too.
+    let tmp = TempDir::new().unwrap();
+    let dir = tmp.path();
+
+    let base = SkillManifest::default();
+    let mut first = base.clone();
+    first.managed.insert("tm-doctor".into(), sample_entry());
+    assert_eq!(
+        first.save_if_current(dir, &base).unwrap(),
+        SkillManifestSave::Written
+    );
+    assert!(SkillManifest::load(dir).is_managed("tm-doctor"));
+
+    let base = SkillManifest::load(dir);
+    let mut second = base.clone();
+    second.managed.insert("tm-workflow".into(), sample_entry());
+    assert_eq!(
+        second.save_if_current(dir, &base).unwrap(),
+        SkillManifestSave::Written
+    );
+    let on_disk = SkillManifest::load(dir);
+    assert!(on_disk.is_managed("tm-doctor"));
+    assert!(on_disk.is_managed("tm-workflow"));
+}

--- a/crates/trusty-agents-common/src/skills/reconcile.rs
+++ b/crates/trusty-agents-common/src/skills/reconcile.rs
@@ -33,7 +33,7 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::agents::manifest::{Result, checksum};
-use crate::skills::manifest::{SkillManifest, SkillManifestEntry};
+use crate::skills::manifest::{SkillManifest, SkillManifestEntry, with_skill_manifest_lock};
 use crate::skills::unmanaged::{UnmanagedBundledSkill, unmanaged_bundled_skills};
 
 /// Filename of the per-backup-root ledger of what was copied where.
@@ -88,6 +88,30 @@ pub struct AdoptedSkill {
 /// `adopt_backs_up_before_recording`, `adopt_leaves_an_operator_skill_alone`,
 /// `adopt_then_deploy_refreshes_a_stale_skill`, `adopt_no_findings_writes_nothing`.
 pub fn adopt_unmanaged_bundled_skills(
+    dest: &Path,
+    bundled: &BTreeSet<String>,
+    backup_root: &Path,
+) -> Result<Vec<AdoptedSkill>> {
+    // #4881: cheap read-only precheck OUTSIDE the lock, so a no-op adoption
+    // neither blocks on a concurrent writer nor leaves a lock sidecar in a
+    // directory it will not touch — `adopt_no_findings_writes_nothing` holds
+    // the target byte-identical. The authoritative scan happens again inside.
+    if unmanaged_bundled_skills(dest, bundled).is_empty() {
+        return Ok(Vec::new());
+    }
+    with_skill_manifest_lock(dest, || adopt_locked(dest, bundled, backup_root))
+}
+
+/// The body of [`adopt_unmanaged_bundled_skills`], run holding the ledger lock.
+///
+/// Why (#4881): adoption is a load-modify-save of the same ledger the deployer
+/// writes; unlocked, it drops whatever a concurrent deploy recorded. Never call
+/// it directly, and never from inside another [`with_skill_manifest_lock`] on
+/// the same directory (`flock` on a second descriptor self-deadlocks).
+/// What: the scan/back-up/record pipeline documented on the public wrapper.
+/// Test: the `adopt_*` tests in `reconcile_tests.rs` exercise it through that
+/// wrapper.
+fn adopt_locked(
     dest: &Path,
     bundled: &BTreeSet<String>,
     backup_root: &Path,

--- a/crates/trusty-agents-common/src/skills/reconcile.rs
+++ b/crates/trusty-agents-common/src/skills/reconcile.rs
@@ -33,7 +33,9 @@ use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use crate::agents::manifest::{Result, checksum};
-use crate::skills::manifest::{SkillManifest, SkillManifestEntry, with_skill_manifest_lock};
+use crate::skills::manifest::{
+    SkillManifest, SkillManifestEntry, SkillManifestSave, with_skill_manifest_lock,
+};
 use crate::skills::unmanaged::{UnmanagedBundledSkill, unmanaged_bundled_skills};
 
 /// Filename of the per-backup-root ledger of what was copied where.
@@ -122,6 +124,8 @@ fn adopt_locked(
     }
 
     let mut manifest = SkillManifest::load(dest);
+    // #4881: the snapshot the merging save replays this run's delta against.
+    let base = manifest.clone();
     let now = chrono::Utc::now().to_rfc3339();
     let mut adopted = Vec::with_capacity(found.len());
 
@@ -150,7 +154,15 @@ fn adopt_locked(
         });
     }
 
-    manifest.save(dest)?;
+    // #4881: backups are already on disk and the whole point of adoption is the
+    // manifest record, so this save must publish — see `save_merging`.
+    if manifest.save_merging(dest, &base)? == SkillManifestSave::Merged {
+        tracing::warn!(
+            dest = %dest.display(),
+            "the skill manifest changed during adoption — a writer bypassed the \
+             ledger lock; its entries were merged rather than dropped"
+        );
+    }
     Ok(adopted)
 }
 

--- a/crates/trusty-mpm/changelog.d/4881-manifest-lock.md
+++ b/crates/trusty-mpm/changelog.d/4881-manifest-lock.md
@@ -1,0 +1,5 @@
+Fixed
+
+- take the skill ledger lock in the two trusty-mpm writers that also read-modify-write it — `tm doctor --fix-skills` repair and `tm catalog apply --prune` (closes [#4881](https://github.com/bobmatnyc/trusty-tools/issues/4881))
+  - a tier directory that does not exist is skipped before the lock, so a repair never creates an empty `skills/` directory in a project it was only inspecting
+  - skill-drift auditing no longer counts the lock sidecar as deployed content when deciding whether a manifest-less tier is populated

--- a/crates/trusty-mpm/src/core/skill_drift.rs
+++ b/crates/trusty-mpm/src/core/skill_drift.rs
@@ -333,8 +333,18 @@ pub fn audit_deployed_skills(reference: &SkillReference, dest_dir: &Path) -> Tie
             // A tier directory that does not exist, or exists and is empty, was
             // simply never deployed to. One that holds entries WITHOUT a ledger
             // cannot be attributed at all.
+            // #4881: "populated" means DEPLOYED SKILLS, not merely non-empty.
+            // The ledger lock's sidecar (`.trusty-mpm-skills-manifest.json.lock`)
+            // is created when the lock is taken, which is before anything is
+            // written — counting it would report a tier that was never deployed
+            // to as unattributable, and `tm doctor` would call it unverifiable.
+            // Every deployed skill is a `<stem>/` directory, so dot-prefixed
+            // entries are bookkeeping by construction.
             let populated = std::fs::read_dir(dest_dir)
-                .map(|mut d| d.next().is_some())
+                .map(|d| {
+                    d.flatten()
+                        .any(|e| !e.file_name().to_string_lossy().starts_with('.'))
+                })
                 .unwrap_or(false);
             if populated {
                 ManifestState::AbsentButPopulated

--- a/crates/trusty-mpm/src/core/skill_drift_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_drift_tests.rs
@@ -454,3 +454,27 @@ fn drift_states_report_not_fresh() {
     assert!(SkillDrift::Missing.is_problem());
     assert!(SkillDrift::Unverifiable("x".into()).is_problem());
 }
+
+/// #4881: the ledger lock's sidecar is bookkeeping, not deployed content.
+///
+/// Why: `with_skill_manifest_lock` creates
+/// `.trusty-mpm-skills-manifest.json.lock` when the lock is TAKEN, which is
+/// before anything is written. Counting it as content would report a tier that
+/// was never deployed to as unattributable, and `tm doctor` renders
+/// `AbsentButPopulated` as unverifiable — a false alarm on an empty tier.
+#[test]
+fn a_lock_sidecar_alone_is_not_a_populated_tier() {
+    let dest = TempDir::new().unwrap();
+    fs::write(
+        crate::core::skill_manifest::skill_manifest_lock_path(dest.path()),
+        "",
+    )
+    .unwrap();
+
+    let audit = audit_deployed_skills(&reference_of(&[("tm-workflow", "v1")]), dest.path());
+    assert_eq!(
+        audit.manifest,
+        ManifestState::AbsentAndEmpty,
+        "a tier holding only the lock sidecar was never deployed to"
+    );
+}

--- a/crates/trusty-mpm/src/core/skill_repair.rs
+++ b/crates/trusty-mpm/src/core/skill_repair.rs
@@ -46,7 +46,9 @@ use crate::core::skill_deploy_tiers::{SkillDeployTier, skill_deploy_tiers};
 use crate::core::skill_drift::{
     ManifestState, SkillDrift, SkillReference, audit_deployed_skills, deployed_path,
 };
-use crate::core::skill_manifest::{SkillManifest, SkillManifestEntry, with_skill_manifest_lock};
+use crate::core::skill_manifest::{
+    SkillManifest, SkillManifestEntry, SkillManifestSave, with_skill_manifest_lock,
+};
 
 /// What the repair did — or deliberately did not do — to one skill.
 ///
@@ -187,6 +189,8 @@ fn repair_tier_locked(
     }
 
     let mut manifest = SkillManifest::load(&tier.dir);
+    // #4881: the snapshot the merging save replays this run's delta against.
+    let base = manifest.clone();
     let mut manifest_dirty = false;
 
     for finding in audit.findings {
@@ -231,12 +235,24 @@ fn repair_tier_locked(
         });
     }
 
-    if manifest_dirty && let Err(e) = manifest.save(&tier.dir) {
-        outcomes.push(RepairOutcome {
-            tier: tier.label,
-            stem: "<manifest>".to_string(),
-            action: RepairAction::Failed(format!("could not save the deploy manifest: {e}")),
-        });
+    // #4881: `rewrite_and_verify` already wrote and re-read every repaired file,
+    // so this save must publish or the repair leaves each one reading as
+    // hand-edited — the exact state it was invoked to clear. `save_merging`
+    // folds in a writer that bypassed the lock rather than dropping it.
+    if manifest_dirty {
+        match manifest.save_merging(&tier.dir, &base) {
+            Ok(SkillManifestSave::Written) => {}
+            Ok(SkillManifestSave::Merged) => tracing::warn!(
+                tier = tier.label,
+                "the skill manifest changed during repair — a writer bypassed the \
+                 ledger lock; its entries were merged rather than dropped"
+            ),
+            Err(e) => outcomes.push(RepairOutcome {
+                tier: tier.label,
+                stem: "<manifest>".to_string(),
+                action: RepairAction::Failed(format!("could not save the deploy manifest: {e}")),
+            }),
+        }
     }
     outcomes
 }

--- a/crates/trusty-mpm/src/core/skill_repair.rs
+++ b/crates/trusty-mpm/src/core/skill_repair.rs
@@ -241,7 +241,10 @@ fn repair_tier_locked(
     // folds in a writer that bypassed the lock rather than dropping it.
     if manifest_dirty {
         match manifest.save_merging(&tier.dir, &base) {
-            Ok(SkillManifestSave::Written) => {}
+            // `OverwroteUnreadable` is already reported by `save_merging` at
+            // error level — louder than this warn would be — so it needs no
+            // second line here. The ledger was published either way.
+            Ok(SkillManifestSave::Written | SkillManifestSave::OverwroteUnreadable) => {}
             Ok(SkillManifestSave::Merged) => tracing::warn!(
                 tier = tier.label,
                 "the skill manifest changed during repair — a writer bypassed the \

--- a/crates/trusty-mpm/src/core/skill_repair.rs
+++ b/crates/trusty-mpm/src/core/skill_repair.rs
@@ -39,13 +39,14 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::core::agent_manifest::ManifestError;
 use crate::core::agent_manifest::{atomic_write, checksum};
 use crate::core::paths::FrameworkPaths;
-use crate::core::skill_deploy_tiers::skill_deploy_tiers;
+use crate::core::skill_deploy_tiers::{SkillDeployTier, skill_deploy_tiers};
 use crate::core::skill_drift::{
     ManifestState, SkillDrift, SkillReference, audit_deployed_skills, deployed_path,
 };
-use crate::core::skill_manifest::{SkillManifest, SkillManifestEntry};
+use crate::core::skill_manifest::{SkillManifest, SkillManifestEntry, with_skill_manifest_lock};
 
 /// What the repair did — or deliberately did not do — to one skill.
 ///
@@ -115,80 +116,127 @@ pub fn repair_skills(
 ) -> Vec<RepairOutcome> {
     let mut outcomes = Vec::new();
     for tier in skill_deploy_tiers(paths, project_dir) {
-        let audit = audit_deployed_skills(reference, &tier.dir);
-        // #4622 review: never write into a tier whose ownership ledger could not
-        // be read. Saving a rebuilt manifest over an unparseable one would
-        // silently reclassify every file there as tm-owned and make the next
-        // deploy overwrite the operator's work — the frozen-skill protection
-        // depends on that ledger being intact.
-        if let ManifestState::Unreadable(why) = &audit.manifest {
-            outcomes.push(RepairOutcome {
-                tier: tier.label,
-                stem: "<manifest>".to_string(),
-                action: RepairAction::SkippedUnverifiable(format!(
-                    "{why} — refusing to touch this tier; repairing it would rewrite an                      ownership ledger that cannot be read"
-                )),
-            });
+        // #4881: a tier directory that does not exist has no ledger and so no
+        // findings — repairing it was already a no-op. Skipped BEFORE the lock
+        // so taking one never creates an empty `skills/` directory and a lock
+        // sidecar in a project `tm doctor` was only inspecting.
+        if !tier.dir.is_dir() {
             continue;
         }
-
-        let mut manifest = SkillManifest::load(&tier.dir);
-        let mut manifest_dirty = false;
-
-        for finding in audit.findings {
-            let action = match finding.state {
-                SkillDrift::Fresh => continue,
-                SkillDrift::Unverifiable(why) => RepairAction::SkippedUnverifiable(why),
-                SkillDrift::DriftedFrozen if !include_frozen => RepairAction::SkippedFrozen,
-                SkillDrift::Drifted | SkillDrift::DriftedFrozen | SkillDrift::Missing => {
-                    let Some(content) = reference.assets.get(&finding.stem) else {
-                        // Unreachable: a non-`Unverifiable` state implies an
-                        // asset exists. Reported rather than unwrapped.
-                        outcomes.push(RepairOutcome {
-                            tier: tier.label,
-                            stem: finding.stem,
-                            action: RepairAction::Failed(
-                                "no bundled asset available to write".to_string(),
-                            ),
-                        });
-                        continue;
-                    };
-                    match rewrite_and_verify(
-                        &tier.dir,
-                        tier.label,
-                        &finding.stem,
-                        content,
-                        backup_root,
-                    ) {
-                        Ok(backup) => {
-                            manifest.managed.insert(
-                                finding.stem.clone(),
-                                SkillManifestEntry {
-                                    checksum: checksum(content),
-                                    deployed_at: chrono::Utc::now().to_rfc3339(),
-                                },
-                            );
-                            manifest_dirty = true;
-                            RepairAction::Repaired { backup }
-                        }
-                        Err(e) => RepairAction::Failed(e),
-                    }
-                }
-            };
-            outcomes.push(RepairOutcome {
-                tier: tier.label,
-                stem: finding.stem,
-                action,
-            });
-        }
-
-        if manifest_dirty && let Err(e) = manifest.save(&tier.dir) {
-            outcomes.push(RepairOutcome {
-                tier: tier.label,
+        // #4881: audit → rewrite → manifest save is a load-modify-save of the
+        // same ledger the deployer writes, so it runs under the tier's ledger
+        // lock. Unlocked, a repair racing a session launch's deploy publishes a
+        // manifest missing the launch's entries, and the skills those entries
+        // described then read as hand-edited and freeze — the very state this
+        // module exists to remedy.
+        let label = tier.label;
+        let locked = with_skill_manifest_lock::<_, ManifestError, _>(&tier.dir, || {
+            Ok(repair_tier_locked(
+                reference,
+                &tier,
+                include_frozen,
+                backup_root,
+            ))
+        });
+        match locked {
+            Ok(tier_outcomes) => outcomes.extend(tier_outcomes),
+            Err(e) => outcomes.push(RepairOutcome {
+                tier: label,
                 stem: "<manifest>".to_string(),
-                action: RepairAction::Failed(format!("could not save the deploy manifest: {e}")),
-            });
+                action: RepairAction::Failed(format!(
+                    "could not lock the deploy manifest: {e} — refusing to repair this tier \
+                     unserialised"
+                )),
+            }),
         }
+    }
+    outcomes
+}
+
+/// Repair one tier, holding that tier's skill ledger lock.
+///
+/// Why (#4881): split out so the locked critical section is one expression and
+/// its scope cannot be misread — every manifest load, file write, and manifest
+/// save for this tier happens with the lock held. Never call it directly, and
+/// never from inside another `with_skill_manifest_lock` on the same directory.
+/// What: the audit/classify/rewrite/save pipeline documented on
+/// [`repair_skills`], for a single tier.
+/// Test: `skill_repair_tests.rs` exercises it through [`repair_skills`].
+fn repair_tier_locked(
+    reference: &SkillReference,
+    tier: &SkillDeployTier,
+    include_frozen: bool,
+    backup_root: &Path,
+) -> Vec<RepairOutcome> {
+    let mut outcomes = Vec::new();
+    let audit = audit_deployed_skills(reference, &tier.dir);
+    // #4622 review: never write into a tier whose ownership ledger could not
+    // be read. Saving a rebuilt manifest over an unparseable one would
+    // silently reclassify every file there as tm-owned and make the next
+    // deploy overwrite the operator's work — the frozen-skill protection
+    // depends on that ledger being intact.
+    if let ManifestState::Unreadable(why) = &audit.manifest {
+        outcomes.push(RepairOutcome {
+            tier: tier.label,
+            stem: "<manifest>".to_string(),
+            action: RepairAction::SkippedUnverifiable(format!(
+                "{why} — refusing to touch this tier; repairing it would rewrite an                      ownership ledger that cannot be read"
+            )),
+        });
+        return outcomes;
+    }
+
+    let mut manifest = SkillManifest::load(&tier.dir);
+    let mut manifest_dirty = false;
+
+    for finding in audit.findings {
+        let action = match finding.state {
+            SkillDrift::Fresh => continue,
+            SkillDrift::Unverifiable(why) => RepairAction::SkippedUnverifiable(why),
+            SkillDrift::DriftedFrozen if !include_frozen => RepairAction::SkippedFrozen,
+            SkillDrift::Drifted | SkillDrift::DriftedFrozen | SkillDrift::Missing => {
+                let Some(content) = reference.assets.get(&finding.stem) else {
+                    // Unreachable: a non-`Unverifiable` state implies an
+                    // asset exists. Reported rather than unwrapped.
+                    outcomes.push(RepairOutcome {
+                        tier: tier.label,
+                        stem: finding.stem,
+                        action: RepairAction::Failed(
+                            "no bundled asset available to write".to_string(),
+                        ),
+                    });
+                    continue;
+                };
+                match rewrite_and_verify(&tier.dir, tier.label, &finding.stem, content, backup_root)
+                {
+                    Ok(backup) => {
+                        manifest.managed.insert(
+                            finding.stem.clone(),
+                            SkillManifestEntry {
+                                checksum: checksum(content),
+                                deployed_at: chrono::Utc::now().to_rfc3339(),
+                            },
+                        );
+                        manifest_dirty = true;
+                        RepairAction::Repaired { backup }
+                    }
+                    Err(e) => RepairAction::Failed(e),
+                }
+            }
+        };
+        outcomes.push(RepairOutcome {
+            tier: tier.label,
+            stem: finding.stem,
+            action,
+        });
+    }
+
+    if manifest_dirty && let Err(e) = manifest.save(&tier.dir) {
+        outcomes.push(RepairOutcome {
+            tier: tier.label,
+            stem: "<manifest>".to_string(),
+            action: RepairAction::Failed(format!("could not save the deploy manifest: {e}")),
+        });
     }
     outcomes
 }

--- a/crates/trusty-mpm/src/core/skill_repair_tests.rs
+++ b/crates/trusty-mpm/src/core/skill_repair_tests.rs
@@ -395,3 +395,35 @@ fn embedded_reference_is_usable_as_a_repair_source() {
     );
     assert!(!reference.assets["tm-workflow"].is_empty());
 }
+
+/// #4881: a tier directory that does not exist must stay non-existent.
+///
+/// Why: taking the ledger lock creates the directory and a lock sidecar. A
+/// repair over a project with no `.claude/skills/` would then leave both behind
+/// in a tree `tm doctor` was only inspecting. Such a tier has no ledger and so
+/// no findings — skipping it before the lock is behaviour-preserving.
+#[test]
+fn repair_leaves_a_missing_tier_directory_alone() {
+    let home = TempDir::new().unwrap();
+    let project = TempDir::new().unwrap();
+    let paths = paths_under(&home);
+    let backups = TempDir::new().unwrap();
+
+    let outcomes = repair_skills(
+        &reference_of(&[("tm-workflow", "v1")]),
+        &paths,
+        Some(project.path()),
+        false,
+        backups.path(),
+    );
+
+    assert!(
+        outcomes.is_empty(),
+        "a tier with no directory has no findings: {outcomes:?}"
+    );
+    let skills_dir = project.path().join(".claude").join("skills");
+    assert!(
+        !skills_dir.exists(),
+        "repair must not create a skills directory it was only inspecting"
+    );
+}

--- a/crates/trusty-mpm/src/core/update_check/apply.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply.rs
@@ -22,7 +22,9 @@ use crate::core::agent_manifest::{
 };
 use crate::core::manifest::HarnessPlan;
 use crate::core::paths::FrameworkPaths;
-use crate::core::skill_manifest::{SKILL_MANIFEST_FILE, SkillManifest, with_skill_manifest_lock};
+use crate::core::skill_manifest::{
+    SKILL_MANIFEST_FILE, SkillManifest, SkillManifestSave, with_skill_manifest_lock,
+};
 use crate::core::skill_tiers::deploy_all_skill_tiers;
 use crate::provisioner::GitBackend;
 
@@ -266,6 +268,10 @@ fn prune_skills(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyE
 /// Test: `apply_prune_removes_deselected`.
 fn prune_skills_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
     let mut manifest = SkillManifest::load(target);
+    // #4881: the snapshot the merging save replays this run's delta against —
+    // here the delta is REMOVALS, which `save_merging` applies to the current
+    // on-disk document rather than reverting a concurrent writer's inserts.
+    let base = manifest.clone();
     let mut pruned: Vec<String> = Vec::new();
 
     let candidates: Vec<String> = manifest.managed.keys().cloned().collect();
@@ -282,9 +288,19 @@ fn prune_skills_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>,
     }
 
     if !pruned.is_empty() {
-        manifest
-            .save(target)
-            .map_err(|e| ApplyError::Prune(e.to_string()))?;
+        // #4881: the skill DIRECTORIES are already removed, so this save must
+        // publish or the manifest keeps listing files that no longer exist.
+        if manifest
+            .save_merging(target, &base)
+            .map_err(|e| ApplyError::Prune(e.to_string()))?
+            == SkillManifestSave::Merged
+        {
+            tracing::warn!(
+                target = %target.display(),
+                "the skill manifest changed during prune — a writer bypassed the \
+                 ledger lock; its entries were merged rather than dropped"
+            );
+        }
         debug_assert!(target.join(SKILL_MANIFEST_FILE).exists());
     }
     pruned.sort_unstable();

--- a/crates/trusty-mpm/src/core/update_check/apply.rs
+++ b/crates/trusty-mpm/src/core/update_check/apply.rs
@@ -22,7 +22,7 @@ use crate::core::agent_manifest::{
 };
 use crate::core::manifest::HarnessPlan;
 use crate::core::paths::FrameworkPaths;
-use crate::core::skill_manifest::{SKILL_MANIFEST_FILE, SkillManifest};
+use crate::core::skill_manifest::{SKILL_MANIFEST_FILE, SkillManifest, with_skill_manifest_lock};
 use crate::core::skill_tiers::deploy_all_skill_tiers;
 use crate::provisioner::GitBackend;
 
@@ -52,10 +52,11 @@ pub enum ApplyError {
 
 /// Lift a ledger failure into [`ApplyError`].
 ///
-/// Why: `with_agent_manifest_lock` reports a lock-acquisition failure as the
-/// caller's own error type (#4409), which requires this conversion. Prune is
-/// the only stage here that takes the lock directly, so a ledger failure on
-/// this path is always a prune-stage failure.
+/// Why: `with_agent_manifest_lock` (#4409) and `with_skill_manifest_lock`
+/// (#4881) report a lock-acquisition failure as the caller's own error type,
+/// which requires this conversion. Prune is the only stage here that takes
+/// either lock directly, so a ledger failure on this path is always a
+/// prune-stage failure.
 /// What: renders the ledger error into the `Prune` variant's message.
 /// Test: exercised by `apply_prune_removes_deselected` (happy path).
 impl From<ManifestError> for ApplyError {
@@ -241,8 +242,29 @@ fn prune_agents_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>,
 /// `<target>/<stem>/` (ignoring absence) and drops the manifest entry; saves the
 /// manifest if anything changed. The [`SkillManifest`] is keyed by stem, matching
 /// the skill deployer. Returns the removed stems, sorted.
+///
+/// CONCURRENCY (#4881): the whole load-modify-save runs under the skill ledger
+/// lock, for the same reason [`prune_agents`] does — an unlocked prune racing a
+/// session launch's skill deploy drops the launch's ledger entries, and the
+/// files those entries described then read as user-edited and are skipped
+/// forever. As with agents, the deploy (step 3) and this prune (step 4) are two
+/// SEPARATE locked sections rather than one span: `flock` is not reentrant, so a
+/// single span would have to call an unlocked inner deploy entry point, which is
+/// a worse hazard than the residual window. A skill deployed between the two
+/// steps that this prune then removes returns on the next deploy — deploy is
+/// idempotent, and no ledger update is ever lost.
 /// Test: `apply_prune_removes_deselected`.
 fn prune_skills(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
+    with_skill_manifest_lock(target, || prune_skills_locked(target, plan))
+}
+
+/// The body of [`prune_skills`], run while holding the skill ledger lock.
+///
+/// Why/What: mirrors [`prune_agents_locked`] — the critical section is one
+/// expression so the lock's scope cannot be misread. Never call it directly, and
+/// never from inside another `with_skill_manifest_lock` on the same directory.
+/// Test: `apply_prune_removes_deselected`.
+fn prune_skills_locked(target: &Path, plan: &HarnessPlan) -> Result<Vec<String>, ApplyError> {
     let mut manifest = SkillManifest::load(target);
     let mut pruned: Vec<String> = Vec::new();
 


### PR DESCRIPTION
Closes #4881

> **Review round 2.** The first version of this PR was BLOCKED for a CRITICAL: its compare-and-swap returned `Err` after every `SKILL.md` was already on disk, freezing the whole tier. That is fixed below, and two claims this body previously made were wrong — both are corrected here rather than quietly dropped.

## Defect

`SkillManifest::load`/`save` took no lock, so overlapping deploy runs raced on load-modify-save. One process wrote a skill and saved its manifest; a slower one then saved a snapshot taken BEFORE that write, dropping the entry. The recorded checksum for that key then named an older revision than the bytes on disk, and `deploy_one_file` read the mismatch as "the user hand-edited this" and skipped the file permanently. A skill nobody touched, frozen against every future update, silently.

Measured, not theoretical: three skills were found frozen on 2026-08-05, each byte-identical to an official historical main commit.

**The race widened.** [#4882](https://github.com/bobmatnyc/trusty-tools/pull/4882) took the manifest writers from two to four. And under the owner's lifecycle ruling the local manifest is now the durable record of what the user customized — a clobbered manifest can corrupt that record, not just freeze a file.

## Mechanism

**The lock is the fix.** `with_skill_manifest_lock` — an advisory `flock` sidecar, the skill-side counterpart of the agent ledger lock from [#4409](https://github.com/bobmatnyc/trusty-tools/issues/4409) — wraps the whole read-modify-write in all four writers: `deploy_skills_filtered`, unmanaged-skill adoption, `tm doctor --fix-skills` repair, and `tm catalog apply --prune`. It is held across the manifest load, the file writes it authorises, and the save; not across tier planning, and nothing slow runs inside it. `flock` blocks rather than spins and no writer holds it across anything unbounded, so there is no starvation path. Each public entry takes it once and every locked body is a `*_locked` function never called from inside another, so nothing self-deadlocks on the non-reentrant lock.

**The save must always publish.** Every writer writes files BEFORE it saves. Bytes newer than their recorded checksum are precisely what the deployer reads as a hand-edit and skips forever — so a save that fails or refuses after files are on disk manufactures the freeze this issue exists to prevent, across the whole tier. `SkillManifest::save_merging` is a three-way merge: when the on-disk document has moved since the caller's base, it starts from what is on disk and replays this run's delta (inserts, updates, and removals) onto it, then publishes. It always publishes.

Merging also beats a plain `save`, which is why it is not just a safety valve: a blind save drops the racing writer's entries and freezes ITS files instead. That matters concretely during rollout, when older installed `tm` binaries do not take the lock at all.

Also consolidated: the `flock` critical section is now one implementation (`with_ledger_lock`) that both ledgers' wrappers delegate to.

## What changed since the BLOCK

| Finding | Resolution |
|---|---|
| **CRITICAL** — `Err` after files written froze the tier | `save_if_current` replaced by `save_merging`; there is no longer any variant meaning "nothing written". Regression test below. |
| **MEDIUM** — CAS on 1 of 4 writers | All four now use `save_merging` against a base snapshot. |
| **MEDIUM** — 3 `trusty-mpm` behaviour changes, 0 tests | Two tests added, each proven to fail on revert. The third change (`prune_skills` locking) is covered by `apply_prune_removes_deselected`. |
| **LOW** — unreproducible fail-before number | Re-derived honestly below. |
| Two false doc claims | Deleted with the code they described. |

## Tests

**The CRITICAL, as a regression test.** `a_racing_writer_freezes_nothing_on_either_side` replays the deployer's own ordering — load, write files, save against a base a competing writer has since superseded — and then lets the REAL deployer classify the result, because its classifier is what freezes. It catches both failure modes, verified by breaking `save_merging` two ways:

```
# refuse-after-write (the blocked version):
  a racing writer must freeze nothing: skipped=["example-skill", "tm-doctor"]
# blind save:
  the racing writer's entry must survive, or ITS file freezes instead
```

The first line is the critic's finding reproduced in-tree: the whole tier skipped.

**Fail-before, re-derived.** My earlier claim that neutering the lock yields `left: 1, right: 8` was wrong as stated — that is one of two failure modes, not the failure mode. Neutered and run 5×: every run fails, but only runs 1 and 3 show lost updates (`every writer's entry must survive: ["skill-6"]`, `left: 1 right: 8`); runs 2, 4 and 5 die earlier inside `atomic_write` with `Io(Os { code: 2, kind: NotFound })` — eight threads racing `temp_path`, whose pid+nanosecond scratch name can collide at that concurrency. The honest statement is that the test fails without the lock every time, by one of two mechanisms. (The scratch-name collision is a pre-existing #4409 sharp edge, not in scope here; the lock makes it unreachable on this path.)

`deploy_blocks_while_the_skill_ledger_lock_is_held` holds the lock and probes a concurrent deploy for 2s — an unlocked deploy of two tiny files finishes in under a millisecond so the probe cannot pass by accident, and a deploy blocked on `flock` stays blocked as long as the lock is held so it cannot fail by accident. The merge tests construct staleness directly, with no scheduling involved.

**The two `trusty-mpm` tests, each failing on revert:**

```
a_lock_sidecar_alone_is_not_a_populated_tier ... FAILED
  left: AbsentButPopulated   right: AbsentAndEmpty
repair_leaves_a_missing_tier_directory_alone ... FAILED
```

Negative regression guards, unchanged and still passing: `deploy_user_owned_skipped`, `deploy_skips_user_modified`. `deploy_one_file`'s skip rules are untouched — no frozen file is unfrozen, no fix-skills command added.

## Side effects of the new sidecar

`skill_drift`'s manifest-less-tier check counted any directory entry as content, so a lone `.lock` would report a never-deployed tier as unverifiable; it now ignores dot-prefixed entries. And `repair_skills` skips a non-existent tier before taking the lock, so a repair never creates an empty `skills/` directory in a project doctor was only inspecting. Checked and safe unchanged: `unmanaged.rs` and `count_skill_entries` (directories only), `stale_skills` (`tm-` prefix), `deploy_validate` (manifest presence).

## Gates — Rust Test Ladder rung 5 (cross-crate, shared library)

Rebased on current main (picks up #4907, which fixes the doc-pointer lint timeout).

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-agents-common --all-targets -- -D warnings` | EXIT=0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-agents-common -- --test-threads=1` | 463 passed, 0 failed |
| `cargo test -p trusty-mpm -- --test-threads=1` | 4604 + 1438 + 1438 passed, 0 failed |
| `cargo test -p trusty-agents --lib -- --test-threads=1` | 3341 passed, 0 failed |
| `cargo test -p trusty-code -- --test-threads=1` | 1600 + 21 passed, 0 failed |
| `bash scripts/check_line_cap.sh` | EXIT=0 |
| `bash scripts/check_sld.sh` | EXIT=0 |
| `bash scripts/check_changelog_fragment.sh` | EXIT=0, both crates recorded |
| `cargo check --workspace --exclude trusty-code-gui --exclude trusty-mpm-gui` | EXIT=0 |

Direct dependents of `trusty-agents-common`, from `crates/*/Cargo.toml`: `trusty-mpm`, `trusty-agents`, `trusty-code` — all three tested. The GUI exclusions are the documented pre-existing Tauri `frontendDist` red; `git diff --name-only origin/main...HEAD -- crates/trusty-code-gui/ crates/trusty-mpm-gui/` returns 0 files.

`manifest.rs`'s inline tests moved to `manifest_tests.rs`, matching the convention every sibling in the module already uses. Behavior-preserving extraction.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools