### PR TITLE
feat(trusty-memory): read-only backfill classification report (ADR-0028)

### DIFF
--- a/crates/trusty-memory/Cargo.toml
+++ b/crates/trusty-memory/Cargo.toml
@@ -98,6 +98,9 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }
+# #4891: the backfill report reads a private COPY of each palace's redb store so
+# that opening it can never write to the live file (see commands/backfill_report).
+tempfile = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 # Why (issue #226): axum + tower-http are HTTP-server only. Gating them behind

--- a/crates/trusty-memory/changelog.d/4891-backfill-report-added.md
+++ b/crates/trusty-memory/changelog.d/4891-backfill-report-added.md
@@ -11,8 +11,18 @@ Added
   - injection frequency is recovered from the enriched-prompt hook logs, which record the
     rendered injection but no drawer id. The join re-renders each drawer's preview with
     the same `drawer_preview` the injection pipeline uses and counts matching bullets;
-    against the live estate it reproduces ADR-0028 §C7's table (3,705 injections / 45.1%
-    for the top drawer, where the ADR measured 3,612 / 44.8% a day earlier)
+    against the live estate it reproduces ADR-0028 §C7's table — the top drawer measures
+    45.1% of `trusty-tools` turns where the ADR measured 44.8%, and the second measures
+    20.7% against its 21.2%. The share is quoted rather than the raw count because the
+    count climbs with every logged turn; only the ratio is stable enough to cite
+  - two drawers in one palace whose content truncates to the same 220-char excerpt are
+    indistinguishable in the logs and receive one combined count. Such rows are marked
+    `⚠ SHARED` with a content digest that separates them, and counted in the header, so a
+    combined count can never be mistaken for a per-drawer one. The live estate has no
+    collisions today
+  - a drawer created before the scanned log window carries `predates-log-window`, so a
+    reading of 0 injections is distinguishable from "genuinely never retrieved" — the two
+    warrant opposite decisions
   - no tier is suggested. §C4 measured why: `resume-target` splits 71/26 across tiers, so
     a tag-derived verdict would be wrong for a quarter of rows while looking exactly as
     confident as the rest. Rows carry checkable observations instead

--- a/crates/trusty-memory/changelog.d/4891-backfill-report-added.md
+++ b/crates/trusty-memory/changelog.d/4891-backfill-report-added.md
@@ -1,0 +1,27 @@
+Added
+
+- `trusty-memory backfill-report` — the read-only triage list for ADR-0028's human-gated
+  backfill (Migration step 3, closes [#4891](https://github.com/bobmatnyc/trusty-tools/issues/4891))
+  - ranks existing drawers by how many turns they actually reached, so the worst
+    offenders are triaged first — the ADR's motivating case is a 19-day-old session
+    checkpoint reaching 44.8% of turns, and a stale drawer nobody retrieves costs nothing
+  - each row carries what a single triage decision needs: drawer id, content excerpt,
+    age, injection count and share of that palace's turns, stored importance and its
+    decayed value, whether `expires_at` is already set, and room/palace
+  - injection frequency is recovered from the enriched-prompt hook logs, which record the
+    rendered injection but no drawer id. The join re-renders each drawer's preview with
+    the same `drawer_preview` the injection pipeline uses and counts matching bullets;
+    against the live estate it reproduces ADR-0028 §C7's table (3,705 injections / 45.1%
+    for the top drawer, where the ADR measured 3,612 / 44.8% a day earlier)
+  - no tier is suggested. §C4 measured why: `resume-target` splits 71/26 across tiers, so
+    a tag-derived verdict would be wrong for a quarter of rows while looking exactly as
+    confident as the rest. Rows carry checkable observations instead
+  - with no hook log present the report says the counts are missing data rather than
+    presenting estate-wide zeros as an absence of stale drawers
+  - `--json` for scripted triage; `--palace`, `--limit`, `--min-injections`, `--logs-dir`
+  - the command writes nothing, by construction: it never opens a `PalaceHandle` (that
+    path deletes expired drawers at open, and expired drawers are exactly what a human
+    triages), and it reads a private copy of each palace's redb store rather than the live
+    file, because `OpenIntent::ReadOnlyClient` only snapshots when the file is already
+    locked and otherwise reaches `Database::create` — which runs an init write
+    transaction and can rename an incompatible-format store aside

--- a/crates/trusty-memory/src/commands/backfill_report/candidates.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/candidates.rs
@@ -34,11 +34,11 @@
 //! `report_writes_nothing_to_the_palace`,
 //! `incompatible_store_is_reported_not_recreated`.
 
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use chrono::Utc;
 use trusty_common::memory_core::decay::DecayConfig;
 use trusty_common::memory_core::palace::Drawer;
 use trusty_common::memory_core::store::kg_redb::KgStoreRedb;
@@ -55,8 +55,17 @@ use crate::commands::prompt_context::format::drawer_preview;
 /// Why: the ticket's actionability bar is that a human can triage a single
 /// drawer from one row — which needs identity, enough content to recognise it,
 /// how old it is, how much it costs, and how privileged it currently is.
-/// What: every field is measured or read, none inferred. `injections` and
-/// `share_of_turns` come from the hook logs; the rest from the drawer row.
+///
+/// What: every field is read from the drawer row or measured from the hook logs,
+/// with one qualification the reader must be able to see. `injections` is keyed
+/// on the 220-char `excerpt`, so if two drawers in one palace truncate to the
+/// same excerpt they are indistinguishable in the logs and both receive the
+/// combined count — misattributed to each, not split between them. That case is
+/// never left silent: [`collision_peers`](Self::collision_peers) is `Some` on
+/// every row it affects and [`content_digest`](Self::content_digest)
+/// distinguishes rows whose excerpts read identically. The live estate has zero
+/// collisions across 2,287 rows today; near-duplicate session checkpoints (§C5)
+/// are the content most likely to converge on a shared prefix as it grows.
 #[derive(Debug, Clone)]
 pub struct CandidateRow {
     pub palace: String,
@@ -77,6 +86,23 @@ pub struct CandidateRow {
     pub has_expiry: bool,
     /// Objective observations about this drawer. Not a classification.
     pub signals: Vec<Signal>,
+    /// Other drawers in this palace whose `excerpt` is byte-identical to this
+    /// one. `None` when the excerpt is unique — the case for every row in the
+    /// live estate today.
+    ///
+    /// When `Some(n)`, this row's `injections` is the count for all `n + 1`
+    /// drawers together, not this drawer alone. Acting on the number without
+    /// reading the peers would retire the wrong drawer.
+    pub collision_peers: Option<usize>,
+    /// Short digest of the drawer's **full, untruncated** content.
+    ///
+    /// Why: when two rows collide their stanzas are visually identical down to
+    /// the last rendered character, so a reader cannot tell which is which. The
+    /// digest differs whenever the underlying content differs, which is what
+    /// makes the two rows separable on the page. Stable only within one run —
+    /// it disambiguates rows, it is not an identifier to store or compare across
+    /// runs.
+    pub content_digest: String,
 }
 
 /// What one palace's read produced, including a failure that did not stop the run.
@@ -102,12 +128,15 @@ pub struct Census {
 /// (registry dir, log index, filters) makes the read-only property testable —
 /// a test can point it at a fixture palace and assert the files are unchanged.
 /// What: for each palace (optionally filtered), reads drawers read-only, joins
-/// each to its injection count, drops rows below `min_injections`, and sorts by
-/// injections descending with the oldest drawer breaking ties. One palace
-/// failing to open is recorded in `outcomes` and skipped — a single locked or
-/// corrupt palace must not deny the operator the other 92.
+/// each to its injection count, drops rows below `min_injections`, marks excerpt
+/// collisions, and sorts by injections descending with the oldest drawer
+/// breaking ties. One palace failing to open is recorded in `outcomes` and
+/// skipped — a single locked or corrupt palace must not deny the operator the
+/// other 92.
 /// Test: `ranks_by_injection_count`, `min_injections_filters`,
-/// `unreadable_palace_is_recorded_not_fatal`.
+/// `incompatible_store_is_reported_not_recreated` (one palace fails to open, is
+/// recorded in `outcomes`, and is skipped while the rest still report),
+/// `colliding_excerpts_are_marked_on_every_affected_row`.
 pub fn build_census(
     registry_dir: &Path,
     index: &InjectionIndex,
@@ -118,7 +147,7 @@ pub fn build_census(
         .with_context(|| format!("list palaces under {}", registry_dir.display()))?;
     let mut census = Census::default();
     let decay = DecayConfig::default();
-    let now = Utc::now();
+    let window_start = index.stats.earliest;
 
     for palace in palaces {
         let slug = palace.id.0.clone();
@@ -160,7 +189,10 @@ pub fn build_census(
                             0.0,
                         ),
                         has_expiry: drawer.expires_at.is_some(),
-                        signals: super::signals::observe(drawer, age_days, now),
+                        signals: super::signals::observe(drawer, age_days, window_start),
+                        // Filled in below, once the whole palace has been read.
+                        collision_peers: None,
+                        content_digest: content_digest(&drawer.content),
                     });
                 }
             }
@@ -172,12 +204,65 @@ pub fn build_census(
         }
     }
 
+    mark_excerpt_collisions(&mut census.rows);
     census.rows.sort_by(|a, b| {
         b.injections
             .cmp(&a.injections)
             .then_with(|| b.age_days.total_cmp(&a.age_days))
     });
     Ok(census)
+}
+
+/// Mark every row whose `(palace, excerpt)` is shared with another row.
+///
+/// Why: the hook logs key on the rendered excerpt, so colliding drawers are
+/// genuinely indistinguishable there and both receive the combined count. That
+/// is a real limit of the measurement, and the one thing it must never do is
+/// stay invisible — a reader who trusts a misattributed number retires the wrong
+/// drawer, which is exactly the harm ADR-0028's human gate exists to prevent.
+///
+/// What: counts occurrences of each `(palace, excerpt)` pair and writes
+/// `collision_peers = Some(n - 1)` on every row in a group of `n > 1`. Rows with
+/// a unique excerpt keep `None`.
+///
+/// A collision never hides behind `min_injections`: colliding rows share one
+/// excerpt and therefore one count, so the filter keeps or drops them together.
+///
+/// Test: `colliding_excerpts_are_marked_on_every_affected_row`,
+/// `unique_excerpts_are_not_marked`.
+fn mark_excerpt_collisions(rows: &mut [CandidateRow]) {
+    let mut counts: HashMap<(&str, &str), usize> = HashMap::new();
+    for row in rows.iter() {
+        *counts
+            .entry((row.palace.as_str(), row.excerpt.as_str()))
+            .or_default() += 1;
+    }
+    let shared: HashMap<(String, String), usize> = counts
+        .into_iter()
+        .filter(|(_, n)| *n > 1)
+        .map(|((p, e), n)| ((p.to_string(), e.to_string()), n))
+        .collect();
+    if shared.is_empty() {
+        return;
+    }
+    for row in rows.iter_mut() {
+        if let Some(n) = shared.get(&(row.palace.clone(), row.excerpt.clone())) {
+            row.collision_peers = Some(n - 1);
+        }
+    }
+}
+
+/// Short digest of a drawer's full content, for telling colliding rows apart.
+///
+/// What: `DefaultHasher` rendered as 8 hex characters. Deliberately not a
+/// cryptographic or cross-run-stable hash — its only job is to differ when two
+/// visually identical stanzas have different underlying content, within one
+/// report. Nothing persists or compares it.
+fn content_digest(content: &str) -> String {
+    use std::hash::{Hash, Hasher};
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    content.hash(&mut hasher);
+    format!("{:08x}", hasher.finish() as u32)
 }
 
 /// Filename of a palace's KG store.

--- a/crates/trusty-memory/src/commands/backfill_report/candidates.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/candidates.rs
@@ -1,0 +1,259 @@
+//! Read-only drawer census, joined to injection frequency and ranked.
+//!
+//! Why: ADR-0028 does not migrate the drawers already on disk — §"What this does
+//! not fix" is explicit that tier assignment for them is a classification
+//! problem tags cannot settle, so Migration step 3 makes backfill *read-only and
+//! human-gated*. This module is the read half of that gate: it produces the
+//! evidence a human needs to decide one drawer at a time, and it deliberately
+//! produces no decision.
+//!
+//! What: enumerates palaces, opens each palace's KG store **read-only**, reads
+//! the drawer table, renders each drawer's preview exactly as the injection
+//! pipeline would, looks that preview up in the hook-log index, and ranks by the
+//! resulting injection count.
+//!
+//! The read-only guarantee is structural, and two separate write paths had to be
+//! closed to make it true rather than merely intended:
+//!
+//! 1. **No `PalaceHandle`.** `PalaceHandle::open_with_intent` deletes every
+//!    drawer whose `expires_at` has passed (`handle.rs`, issue #61) as a side
+//!    effect of opening. A report built on it would retire drawers merely by
+//!    being run — the one outcome ADR-0028's human-gated migration forbids. It
+//!    would also delete the rows a human most wants to see.
+//! 2. **No open against the live file.** Going one level lower to
+//!    [`KgStoreRedb`] is not enough on its own: `OpenIntent::ReadOnlyClient`
+//!    only snapshots when the file is *already locked*. On an unlocked palace it
+//!    reaches `Database::create`, which opens read-write and runs a table-init
+//!    write transaction — and on a file in an incompatible redb format it
+//!    *renames the palace's store aside* and creates a fresh empty one
+//!    (`concurrent_open.rs`, issue #702). So this module copies each store to a
+//!    private temporary file and opens the copy. Whatever redb does on open —
+//!    init transaction, recovery, or that recreate — lands on a throwaway.
+//!
+//! Test: `ranks_by_injection_count`, `zero_injection_drawers_rank_last`,
+//! `report_writes_nothing_to_the_palace`,
+//! `incompatible_store_is_reported_not_recreated`.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use chrono::Utc;
+use trusty_common::memory_core::decay::DecayConfig;
+use trusty_common::memory_core::palace::Drawer;
+use trusty_common::memory_core::store::kg_redb::KgStoreRedb;
+use trusty_common::memory_core::store::rooms::list_room_summaries;
+use trusty_common::memory_core::store::OpenIntent;
+use trusty_common::memory_core::PalaceRegistry;
+
+use super::log_index::InjectionIndex;
+use super::signals::Signal;
+use crate::commands::prompt_context::format::drawer_preview;
+
+/// One drawer's evidence row.
+///
+/// Why: the ticket's actionability bar is that a human can triage a single
+/// drawer from one row — which needs identity, enough content to recognise it,
+/// how old it is, how much it costs, and how privileged it currently is.
+/// What: every field is measured or read, none inferred. `injections` and
+/// `share_of_turns` come from the hook logs; the rest from the drawer row.
+#[derive(Debug, Clone)]
+pub struct CandidateRow {
+    pub palace: String,
+    pub drawer_id: uuid::Uuid,
+    pub room: String,
+    /// Whitespace-collapsed content, exactly as the injection renders it.
+    pub excerpt: String,
+    pub age_days: f32,
+    /// Turns this drawer's preview reached, over the scanned log window.
+    pub injections: u64,
+    /// `injections` as a fraction of the palace's total injections.
+    pub share_of_turns: f64,
+    /// Stored `importance`, the field §C5 identifies as the working privilege dial.
+    pub importance: f32,
+    /// `importance` after the 90-day-half-life decay §C7 blames for the staleness.
+    pub effective_importance: f32,
+    /// Whether an `expires_at` is already set — i.e. already triaged.
+    pub has_expiry: bool,
+    /// Objective observations about this drawer. Not a classification.
+    pub signals: Vec<Signal>,
+}
+
+/// What one palace's read produced, including a failure that did not stop the run.
+#[derive(Debug, Clone)]
+pub struct PalaceOutcome {
+    pub palace: String,
+    pub drawers_read: usize,
+    pub error: Option<String>,
+}
+
+/// Everything the report needs to print.
+#[derive(Debug, Default)]
+pub struct Census {
+    pub rows: Vec<CandidateRow>,
+    pub outcomes: Vec<PalaceOutcome>,
+    /// Drawers read across every palace, before any filtering.
+    pub drawers_total: usize,
+}
+
+/// Build the ranked census.
+///
+/// Why: this is the whole report, minus rendering. Keeping it a pure function of
+/// (registry dir, log index, filters) makes the read-only property testable —
+/// a test can point it at a fixture palace and assert the files are unchanged.
+/// What: for each palace (optionally filtered), reads drawers read-only, joins
+/// each to its injection count, drops rows below `min_injections`, and sorts by
+/// injections descending with the oldest drawer breaking ties. One palace
+/// failing to open is recorded in `outcomes` and skipped — a single locked or
+/// corrupt palace must not deny the operator the other 92.
+/// Test: `ranks_by_injection_count`, `min_injections_filters`,
+/// `unreadable_palace_is_recorded_not_fatal`.
+pub fn build_census(
+    registry_dir: &Path,
+    index: &InjectionIndex,
+    palace_filter: Option<&str>,
+    min_injections: u64,
+) -> Result<Census> {
+    let palaces = PalaceRegistry::list_palaces(registry_dir)
+        .with_context(|| format!("list palaces under {}", registry_dir.display()))?;
+    let mut census = Census::default();
+    let decay = DecayConfig::default();
+    let now = Utc::now();
+
+    for palace in palaces {
+        let slug = palace.id.0.clone();
+        if palace_filter.is_some_and(|f| f != slug) {
+            continue;
+        }
+        match read_palace_drawers(&palace.data_dir) {
+            Ok((drawers, rooms)) => {
+                census.outcomes.push(PalaceOutcome {
+                    palace: slug.clone(),
+                    drawers_read: drawers.len(),
+                    error: None,
+                });
+                census.drawers_total += drawers.len();
+                let total = index.total_injections(&slug);
+                for drawer in &drawers {
+                    let excerpt = drawer_preview(&drawer.content);
+                    let injections = index.injections_for(&slug, &excerpt);
+                    if injections < min_injections {
+                        continue;
+                    }
+                    let age_days = DecayConfig::age_days(drawer.created_at);
+                    census.rows.push(CandidateRow {
+                        palace: slug.clone(),
+                        drawer_id: drawer.id,
+                        room: room_label(&rooms, drawer),
+                        excerpt,
+                        age_days,
+                        injections,
+                        share_of_turns: if total == 0 {
+                            0.0
+                        } else {
+                            injections as f64 / total as f64
+                        },
+                        importance: drawer.importance,
+                        effective_importance: decay.effective_importance(
+                            drawer.importance,
+                            age_days,
+                            0.0,
+                        ),
+                        has_expiry: drawer.expires_at.is_some(),
+                        signals: super::signals::observe(drawer, age_days, now),
+                    });
+                }
+            }
+            Err(e) => census.outcomes.push(PalaceOutcome {
+                palace: slug,
+                drawers_read: 0,
+                error: Some(format!("{e:#}")),
+            }),
+        }
+    }
+
+    census.rows.sort_by(|a, b| {
+        b.injections
+            .cmp(&a.injections)
+            .then_with(|| b.age_days.total_cmp(&a.age_days))
+    });
+    Ok(census)
+}
+
+/// Filename of a palace's KG store.
+const KG_FILE: &str = "kg.redb";
+
+/// Suffix `redb_open::backup_incompatible_file` gives a store it moves aside.
+const INCOMPATIBLE_SUFFIX: &str = ".v2-incompatible";
+
+/// Read one palace's drawer table and rooms without touching its store.
+///
+/// Why: see the module doc — this is the one place the read-only guarantee is
+/// made, and it is made by never handing the palace's own file to redb.
+/// What: copies `<data_dir>/kg.redb` into a private temp dir, opens the copy,
+/// and performs two reads. The `TempDir` drops at return, taking the copy and
+/// anything redb wrote beside it. A store in an incompatible format is detected
+/// by the backup redb leaves next to the copy and reported as an error rather
+/// than silently reading as an empty palace.
+/// Test: `report_writes_nothing_to_the_palace`,
+/// `incompatible_store_is_reported_not_recreated`.
+fn read_palace_drawers(
+    data_dir: &Path,
+) -> Result<(
+    Vec<Drawer>,
+    Vec<trusty_common::memory_core::store::rooms::RoomSummary>,
+)> {
+    let live = data_dir.join(KG_FILE);
+    if !live.exists() {
+        // A palace directory with no KG store has no drawers to report. That is
+        // an empty palace, not a failure.
+        return Ok((Vec::new(), Vec::new()));
+    }
+    // #4891: read a copy, never the live file. `OpenIntent::ReadOnlyClient`
+    // alone does NOT prevent writes — it only snapshots when the file is
+    // already locked, and otherwise reaches `Database::create`, which runs an
+    // init write txn and can rename an incompatible store aside.
+    let scratch = tempfile::tempdir().context("create scratch dir for read-only palace copy")?;
+    let copy = scratch.path().join(KG_FILE);
+    std::fs::copy(&live, &copy)
+        .with_context(|| format!("copy {} for read-only inspection", live.display()))?;
+
+    let store = KgStoreRedb::open_with_intent(&copy, OpenIntent::ReadOnlyClient)
+        .with_context(|| format!("open copy of KG store {}", live.display()))?;
+    if scratch
+        .path()
+        .join(format!("{KG_FILE}{INCOMPATIBLE_SUFFIX}"))
+        .exists()
+    {
+        anyhow::bail!(
+            "KG store at {} is in an incompatible redb format — reading it would have \
+             required recreating it, which this report never does. Rebuild the palace.",
+            live.display()
+        );
+    }
+    let drawers = store.load_drawers().context("load drawers")?;
+    let store = Arc::new(store);
+    let rooms = list_room_summaries(&store).unwrap_or_default();
+    Ok((drawers, rooms))
+}
+
+/// Resolve a drawer's room label, falling back to a short id.
+///
+/// ADR-0027 D1.3: labels are read from the ROOMS table, never recomputed. A
+/// drawer whose room predates the registry has no row, so the id stands in.
+fn room_label(
+    rooms: &[trusty_common::memory_core::store::rooms::RoomSummary],
+    drawer: &Drawer,
+) -> String {
+    rooms
+        .iter()
+        .find(|r| r.id == drawer.room_id)
+        .map(|r| r.label.clone())
+        .unwrap_or_else(|| short_id(&drawer.room_id))
+}
+
+/// First 8 characters of a UUID — enough to identify a drawer in conversation,
+/// which is how the ADR itself refers to them (`drawer f59fb536`).
+pub fn short_id(id: &uuid::Uuid) -> String {
+    id.to_string().chars().take(8).collect()
+}

--- a/crates/trusty-memory/src/commands/backfill_report/log_index.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/log_index.rs
@@ -1,0 +1,307 @@
+//! Per-drawer injection-frequency index over the enriched-prompt hook logs.
+//!
+//! Why: ADR-0028's Migration step 3 ranks backfill candidates by **injection
+//! frequency**, because that is the cost the design actually cares about — a
+//! stale drawer nobody retrieves is free, while the ADR's motivating case (§C7)
+//! is a 19-day-old session checkpoint reaching 44.8% of turns. Nothing in the
+//! drawer store records that number: `access_count` is 0 on every drawer in the
+//! estate (§C5), so the store cannot answer "how often was this injected". The
+//! only surviving record is the hook log
+//! (`<data_root>/logs/enriched-prompts.<date>.jsonl`), which stores the rendered
+//! injection text but **no drawer id**. This module recovers the join.
+//!
+//! What: the injection renders each drawer as one bullet whose body is exactly
+//! [`crate::commands::prompt_context::format::drawer_preview`] of its content —
+//! a deterministic, whitespace-collapsed 220-char truncation. Parsing those
+//! bullets back out and counting distinct injections per bullet body therefore
+//! yields, for any drawer, the number of turns its preview reached. Counting is
+//! per *entry*, not per bullet: an injection that lists the same drawer under
+//! two palace sections still reached one turn.
+//!
+//! Two details make the recovered count exact rather than approximate:
+//!   - Bullets are read only inside a `## Relevant memories` section, so the
+//!     `## Relevant KG facts` section's `- ` lines cannot contaminate the index.
+//!   - `compose_injection` truncates the whole block at a 4 KiB cap, which can
+//!     cut the final bullet mid-preview. Those tails are indexed separately and
+//!     matched by prefix, so a drawer that reached a turn but got cut is still
+//!     counted. They are rare — 4 of 8,216 `trusty-tools` injections in the live
+//!     estate — but dropping them would silently under-count.
+//!
+//! Test: `bullets_are_counted_once_per_entry`, `kg_facts_section_is_ignored`,
+//! `truncated_tail_bullet_matches_by_prefix`,
+//! `short_partial_is_not_matched`, `untagged_bullet_counts_exactly`.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Result;
+use chrono::{DateTime, Utc};
+
+use crate::prompt_log::PromptLogEntry;
+
+/// Section header introducing the drawer bullets. Matched as a prefix because
+/// the header carries the palace slug (`## Relevant memories from palace \`x\``).
+const DRAWER_SECTION_PREFIX: &str = "## Relevant memories";
+/// Separator `format::compose_injection` writes between the preview and tags.
+const TAG_SUFFIX_OPEN: &str = "  _(tags: ";
+/// Closing marker of the tag run.
+const TAG_SUFFIX_CLOSE: &str = ")_";
+/// Only `prompt-context` entries carry drawer bullets.
+const DRAWER_INJECTION_KIND: &str = "prompt-context-facts";
+/// Filename stem of the rolling hook log.
+const LOG_PREFIX: &str = "enriched-prompts.";
+/// Filename suffix of the rolling hook log.
+const LOG_SUFFIX: &str = ".jsonl";
+/// Marker `compose_injection` appends where the byte cap cut the block.
+const TRUNCATION_MARKER: char = '…';
+
+/// Shortest byte-cap-truncated tail that may be prefix-matched against a
+/// drawer preview.
+///
+/// Why: a partial is matched with `preview.starts_with(partial)`, so a very
+/// short partial could match several unrelated drawers and inflate all of
+/// them. Requiring a substantial prefix makes a false attribution require two
+/// drawers that agree on their first 60 characters — at which point the human
+/// reading the report sees two near-identical excerpts and can tell.
+const MIN_PARTIAL_CHARS: usize = 60;
+
+/// What a scan actually read, so the report can state its own coverage.
+///
+/// Why: an empty or short log window silently produces zeros, which reads
+/// identically to "this drawer is never injected" — the opposite conclusion.
+/// Surfacing the window and entry count lets the report say which it is.
+#[derive(Debug, Clone, Default)]
+pub struct ScanStats {
+    /// Log files successfully read.
+    pub files_scanned: usize,
+    /// Log files that could not be opened or read.
+    pub files_failed: usize,
+    /// JSONL lines parsed into an entry.
+    pub entries_read: u64,
+    /// Entries that were `prompt-context-facts` and thus counted.
+    pub injections_counted: u64,
+    /// Earliest counted entry timestamp.
+    pub earliest: Option<DateTime<Utc>>,
+    /// Latest counted entry timestamp.
+    pub latest: Option<DateTime<Utc>>,
+}
+
+/// Palace slug plus a rendered drawer preview.
+type PreviewKey = (String, String);
+
+/// Injection counts recovered from the hook logs.
+#[derive(Debug, Default)]
+pub struct InjectionIndex {
+    /// Total `prompt-context` injections seen per palace — the denominator for
+    /// the "% of turns" column.
+    totals: HashMap<String, u64>,
+    /// Entries containing a complete rendering of this preview.
+    exact: HashMap<PreviewKey, u64>,
+    /// Entries whose final bullet was cut by the byte cap, keyed by the surviving
+    /// prefix.
+    partial: HashMap<PreviewKey, u64>,
+    /// Coverage of the scan that produced this index.
+    pub stats: ScanStats,
+}
+
+impl InjectionIndex {
+    /// Scan every `enriched-prompts.*.jsonl` under `dir`.
+    ///
+    /// Why: the logs roll daily and on a size cap, so the corpus is a directory
+    /// of files rather than one stream. A missing directory is not an error —
+    /// it means logging was never enabled — and returns an empty index whose
+    /// `stats.files_scanned == 0` tells the caller to say so rather than
+    /// reporting a estate-wide zero.
+    /// What: reads each matching file line by line, deserialises each line as a
+    /// [`PromptLogEntry`], and ingests the `prompt-context` ones. A single
+    /// unreadable file or unparseable line is skipped, not fatal — a partially
+    /// corrupt log still carries usable frequency signal, and refusing to
+    /// report at all would be worse.
+    /// Test: `scan_dir_on_missing_directory_is_empty_not_error`,
+    /// `scan_dir_counts_across_files`.
+    pub fn scan_dir(dir: &Path) -> Result<Self> {
+        let mut index = Self::default();
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return Ok(index);
+        };
+        let mut paths: Vec<_> = entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| {
+                p.file_name()
+                    .and_then(|n| n.to_str())
+                    .is_some_and(|n| n.starts_with(LOG_PREFIX) && n.ends_with(LOG_SUFFIX))
+            })
+            .collect();
+        paths.sort();
+        for path in paths {
+            match std::fs::read_to_string(&path) {
+                Ok(body) => {
+                    index.stats.files_scanned += 1;
+                    index.ingest_file(&body);
+                }
+                Err(e) => {
+                    index.stats.files_failed += 1;
+                    tracing::warn!(path = %path.display(), "read prompt log failed: {e:#}");
+                }
+            }
+        }
+        Ok(index)
+    }
+
+    /// Ingest one log file's contents.
+    fn ingest_file(&mut self, body: &str) {
+        for line in body.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let Ok(entry) = serde_json::from_str::<PromptLogEntry>(line) else {
+                continue;
+            };
+            self.stats.entries_read += 1;
+            if entry.injection_kind != DRAWER_INJECTION_KIND {
+                continue;
+            }
+            self.ingest_entry(&entry);
+        }
+    }
+
+    /// Count one `prompt-context` injection.
+    ///
+    /// Why: the unit the report reasons about is a *turn*, so a drawer listed
+    /// twice in one injection must add one, not two.
+    /// What: collects this entry's distinct preview bodies, then increments each
+    /// once. Also advances the palace total and the observed time window.
+    /// Test: `bullets_are_counted_once_per_entry`.
+    fn ingest_entry(&mut self, entry: &PromptLogEntry) {
+        self.stats.injections_counted += 1;
+        *self.totals.entry(entry.palace.clone()).or_default() += 1;
+        let ts = entry.timestamp;
+        self.stats.earliest = Some(self.stats.earliest.map_or(ts, |e| e.min(ts)));
+        self.stats.latest = Some(self.stats.latest.map_or(ts, |l| l.max(ts)));
+
+        let (exact, partial) = parse_drawer_bullets(&entry.injection);
+        for body in exact {
+            *self.exact.entry((entry.palace.clone(), body)).or_default() += 1;
+        }
+        for body in partial {
+            *self
+                .partial
+                .entry((entry.palace.clone(), body))
+                .or_default() += 1;
+        }
+    }
+
+    /// Injections observed for `palace` — the denominator for "% of turns".
+    pub fn total_injections(&self, palace: &str) -> u64 {
+        self.totals.get(palace).copied().unwrap_or(0)
+    }
+
+    /// Turns in which `preview` reached the model, for `palace`.
+    ///
+    /// Why: the ranking column. Exact matches dominate; the prefix pass recovers
+    /// the byte-cap-truncated tails that would otherwise read as zero.
+    /// What: exact-map lookup plus a scan of the (small) partial map for entries
+    /// that are a prefix of `preview` and long enough to be unambiguous. The
+    /// cap's own `…` marker is stripped before the comparison — it is appended
+    /// *after* the cut, so it is never part of the drawer's own preview and a
+    /// literal compare against it could never match.
+    /// Test: `truncated_tail_bullet_matches_by_prefix`, `short_partial_is_not_matched`.
+    pub fn injections_for(&self, palace: &str, preview: &str) -> u64 {
+        let exact = self
+            .exact
+            .get(&(palace.to_string(), preview.to_string()))
+            .copied()
+            .unwrap_or(0);
+        let partial: u64 = self
+            .partial
+            .iter()
+            .filter(|((p, body), _)| {
+                if p != palace {
+                    return false;
+                }
+                let stem = body.trim_end_matches(TRUNCATION_MARKER);
+                stem.chars().count() >= MIN_PARTIAL_CHARS && preview.starts_with(stem)
+            })
+            .map(|(_, n)| *n)
+            .sum();
+        exact + partial
+    }
+
+    /// True when no log file was read at all.
+    pub fn saw_no_logs(&self) -> bool {
+        self.stats.files_scanned == 0
+    }
+}
+
+/// Split an injection's drawer bullets into complete and byte-cap-truncated
+/// preview bodies.
+///
+/// Why: the two need different matching rules, and mixing them would either drop
+/// the truncated tail (under-count) or prefix-match short bullets against
+/// unrelated drawers (over-count).
+///
+/// What: walks lines, tracking whether the current section is a drawer section,
+/// and classifies each `- ` bullet. A bullet ending in a well-formed
+/// `  _(tags: …)_` run is complete — the text before the run is the preview.
+///
+/// A bullet without that run is complete too, *except* for one case: the 4 KiB
+/// cap cuts the block mid-line and appends `…`, which strips the tag run off
+/// whatever bullet it landed in. That can only ever be the **last line of the
+/// injection**, and only when the injection ends in the cap's `…`. Those two
+/// conditions together identify the truncated tail; everything else without a
+/// tag run is simply an untagged drawer, and treating it as a partial would lose
+/// it — a short untagged preview never reaches the prefix pass's minimum length.
+///
+/// Complete bodies are deduplicated so a drawer listed under two palace sections
+/// in one injection still counts as one turn.
+///
+/// Test: `kg_facts_section_is_ignored`, `untagged_bullet_counts_exactly`,
+/// `truncated_tail_bullet_matches_by_prefix`,
+/// `untagged_bullet_mid_block_is_not_treated_as_a_tail`.
+fn parse_drawer_bullets(injection: &str) -> (Vec<String>, Vec<String>) {
+    let mut exact: Vec<String> = Vec::new();
+    let mut partial: Vec<String> = Vec::new();
+    let mut in_drawer_section = false;
+    // The cap writes `…` as the final character of the whole injection.
+    let cap_truncated = injection.ends_with(TRUNCATION_MARKER);
+    let last_line = injection.lines().next_back();
+
+    for line in injection.lines() {
+        if line.starts_with("## ") {
+            in_drawer_section = line.starts_with(DRAWER_SECTION_PREFIX);
+            continue;
+        }
+        if !in_drawer_section {
+            continue;
+        }
+        let Some(body) = line.strip_prefix("- ") else {
+            continue;
+        };
+        if let Some(preview) = split_tag_run(body) {
+            if !exact.iter().any(|e| e == preview) {
+                exact.push(preview.to_string());
+            }
+            continue;
+        }
+        let is_cap_tail = cap_truncated && last_line == Some(line);
+        if is_cap_tail {
+            partial.push(body.to_string());
+        } else if !exact.iter().any(|e| e == body) {
+            exact.push(body.to_string());
+        }
+    }
+    (exact, partial)
+}
+
+/// Strip a trailing `  _(tags: …)_` run, returning the preview body.
+///
+/// Returns `None` when the line carries no well-formed tag run.
+fn split_tag_run(body: &str) -> Option<&str> {
+    if !body.ends_with(TAG_SUFFIX_CLOSE) {
+        return None;
+    }
+    let at = body.rfind(TAG_SUFFIX_OPEN)?;
+    Some(&body[..at])
+}

--- a/crates/trusty-memory/src/commands/backfill_report/mod.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/mod.rs
@@ -1,0 +1,105 @@
+//! `trusty-memory backfill-report` — ADR-0028 Migration step 3, the read-only
+//! human-gated triage list.
+//!
+//! Why: ADR-0028 changes how *new* facts are written. It leaves the 2,016
+//! drawers already on disk across 93 palaces exactly as they are — §"What this
+//! does not fix" records that tier assignment for them is a classification
+//! problem the existing tags cannot settle, so Migration step 3 makes backfill
+//! read-only and human-gated instead of automatic. That decision has a
+//! consequence the ADR states plainly and this command exists to serve: the
+//! estate's current problem drawers are addressed by human action or not at all,
+//! and this report is the only thing that tells a human which ones they are.
+//!
+//! What: ranks drawers by how many turns they actually reached, measured from
+//! the enriched-prompt hook logs, and prints the evidence for each — id,
+//! excerpt, age, injection frequency, importance and its decayed value, room and
+//! palace. It emits no verdict (see `signals.rs` for why) and it writes nothing.
+//!
+//! Sub-modules:
+//!   - `log_index`: recovers per-drawer injection counts from the hook logs.
+//!   - `candidates`: reads drawers read-only, joins, ranks.
+//!   - `signals`: the observations attached to each row.
+//!   - `render`: stanza and JSON output.
+//!
+//! Test: see `tests.rs`.
+
+pub mod candidates;
+pub mod log_index;
+pub mod render;
+pub mod signals;
+
+use anyhow::{Context, Result};
+
+use log_index::InjectionIndex;
+
+/// Default number of stanzas printed.
+///
+/// Why: the ADR's own triage framing is "the worst offenders first" — the top of
+/// this list is where nearly all the recovered budget is. 25 is a reading
+/// session, not a backlog.
+const DEFAULT_LIMIT: usize = 25;
+
+/// Options for one report run.
+#[derive(Debug, Clone, Default)]
+pub struct ReportOptions {
+    /// Restrict to a single palace slug.
+    pub palace: Option<String>,
+    /// Stanzas (or JSON entries) to emit.
+    pub limit: Option<usize>,
+    /// Drop drawers injected fewer than this many times.
+    pub min_injections: u64,
+    /// Emit JSON instead of stanzas.
+    pub json: bool,
+    /// Override the hook-log directory (default `<data_root>/logs`).
+    pub logs_dir: Option<std::path::PathBuf>,
+}
+
+/// CLI entry point.
+///
+/// Why: a thin shim so the testable surface is [`candidates::build_census`] and
+/// [`log_index::InjectionIndex`] rather than a clap handler, matching the shape
+/// `commands::rooms` already uses for the other read-only audit path.
+/// What: resolves the data root, scans the hook logs, builds the ranked census,
+/// and renders it to stdout. Nothing on this path opens a palace for writing.
+/// Test: covered through the two functions above; the wiring itself is exercised
+/// by running the command.
+pub async fn handle_backfill_report(opts: ReportOptions) -> Result<()> {
+    let data_dir = trusty_common::resolve_data_dir("trusty-memory")
+        .context("resolve trusty-memory data dir")?;
+    let logs_dir = opts
+        .logs_dir
+        .clone()
+        .unwrap_or_else(|| data_dir.join("logs"));
+    let registry_dir = crate::resolve_palace_registry_dir(data_dir);
+
+    let index = InjectionIndex::scan_dir(&logs_dir)
+        .with_context(|| format!("scan prompt logs in {}", logs_dir.display()))?;
+    if index.saw_no_logs() {
+        // #4891: a missing log directory makes every count 0, which reads
+        // identically to "nothing is stale". Say which it is before printing.
+        eprintln!(
+            "warning: no enriched-prompts.*.jsonl found in {} — injection counts \
+             will all be 0. This is missing data, not an absence of stale drawers.",
+            logs_dir.display()
+        );
+    }
+    let census = candidates::build_census(
+        &registry_dir,
+        &index,
+        opts.palace.as_deref(),
+        opts.min_injections,
+    )?;
+
+    let limit = opts.limit.unwrap_or(DEFAULT_LIMIT);
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    if opts.json {
+        render::render_json(&mut out, &census, &index.stats, limit)
+    } else {
+        render::render_text(&mut out, &census, &index.stats, limit)
+    }
+}
+
+#[cfg(test)]
+#[path = "tests.rs"]
+mod tests;

--- a/crates/trusty-memory/src/commands/backfill_report/render.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/render.rs
@@ -85,6 +85,21 @@ pub fn render_text(
             palace = row.palace,
             room = row.room
         )?;
+        // A shared count is the one number on this page that does not mean what
+        // it appears to mean, so it is called out ABOVE the count it qualifies —
+        // a reader who stops after the number must still have seen the warning.
+        if let Some(peers) = row.collision_peers {
+            writeln!(
+                out,
+                "    ⚠ SHARED     this excerpt is identical to {peers} other drawer(s) in {palace}; \
+                 the count below is for all {total} together, not this drawer alone. \
+                 Content digest {digest} distinguishes them.",
+                peers = peers,
+                palace = row.palace,
+                total = peers + 1,
+                digest = row.content_digest
+            )?;
+        }
         // The coverage line counts injections estate-wide; this percentage is
         // against the drawer's OWN palace. Name the denominator here so the two
         // numbers cannot be read as contradicting each other.
@@ -173,6 +188,20 @@ fn render_coverage(out: &mut dyn Write, census: &Census, stats: &ScanStats) -> R
             o.error.as_deref().unwrap_or("unknown")
         )?;
     }
+    // Silence here is itself the report: no line means every excerpt was unique
+    // and every count below belongs to exactly one drawer.
+    let colliding = census
+        .rows
+        .iter()
+        .filter(|r| r.collision_peers.is_some())
+        .count();
+    if colliding > 0 {
+        writeln!(
+            out,
+            "  {colliding} row(s) share an excerpt with another drawer — their counts are \
+             combined, not per-drawer. Marked ⚠ SHARED below."
+        )?;
+    }
     Ok(())
 }
 
@@ -227,6 +256,11 @@ pub fn render_json(
                 "effective_importance": r.effective_importance,
                 "has_expiry": r.has_expiry,
                 "signals": r.signals.iter().map(|s| s.label()).collect::<Vec<_>>(),
+                // Always present, never omitted-when-null: a consumer must be
+                // able to test one field to know whether `injections` is this
+                // drawer's alone, rather than inferring it from a missing key.
+                "excerpt_collision_peers": r.collision_peers,
+                "content_digest": r.content_digest,
             })
         })
         .collect();

--- a/crates/trusty-memory/src/commands/backfill_report/render.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/render.rs
@@ -1,0 +1,254 @@
+//! Output rendering for the backfill report.
+//!
+//! Why: the ticket's bar is that the output be actionable for a human deciding
+//! **one drawer at a time**. A fixed-width table cannot meet it — the excerpt is
+//! 220 characters, and truncating it to a column width would hide the very text
+//! the decision turns on. So the default output is one stanza per drawer, in
+//! ranked order, each carrying everything the decision needs and nothing else.
+//! `--json` exists for the other consumer: piping a triage list into a script.
+//!
+//! What: `render_text` writes a header stating the scan's coverage and the
+//! tool's read-only contract, then a stanza per row. `render_json` writes the
+//! same data as one object. Both take `&mut dyn Write` so tests assert on a
+//! buffer rather than on stdout.
+//!
+//! Test: `text_output_leads_with_the_read_only_contract`,
+//! `stanza_carries_every_decision_field`, `json_round_trips`,
+//! `empty_census_says_why`.
+
+use std::io::Write;
+
+use anyhow::Result;
+use serde_json::json;
+
+use super::candidates::{short_id, Census};
+use super::log_index::ScanStats;
+
+/// Width the excerpt is wrapped to, before the stanza indent.
+const EXCERPT_WIDTH: usize = 88;
+/// Indent applied to every continuation line of a wrapped excerpt.
+const EXCERPT_INDENT: &str = "                 ";
+
+/// Render the human-facing report.
+///
+/// Why: a reader who runs this without having read ADR-0028 must still learn the
+/// two facts that make the numbers mean anything — that the tool changes
+/// nothing, and that the existing drawers it lists are not migrated by the ADR,
+/// so this report is the only route by which they get addressed.
+/// What: header, coverage line, per-palace read outcomes when any failed, then
+/// the ranked stanzas.
+/// Test: `text_output_leads_with_the_read_only_contract`, `empty_census_says_why`.
+pub fn render_text(
+    out: &mut dyn Write,
+    census: &Census,
+    stats: &ScanStats,
+    limit: usize,
+) -> Result<()> {
+    writeln!(out, "ADR-0028 backfill classification report")?;
+    writeln!(
+        out,
+        "READ-ONLY. This command never writes a drawer, never sets expires_at, and never"
+    )?;
+    writeln!(
+        out,
+        "retires anything. ADR-0028 does not migrate the drawers already on disk — they"
+    )?;
+    writeln!(
+        out,
+        "keep competing in L1 exactly as before — so acting on a row below is a human"
+    )?;
+    writeln!(out, "decision, taken one drawer at a time.")?;
+    writeln!(out)?;
+    render_coverage(out, census, stats)?;
+    writeln!(out)?;
+
+    if census.rows.is_empty() {
+        writeln!(
+            out,
+            "No drawer met the filter. {}",
+            if stats.files_scanned == 0 {
+                "No hook log was found, so every injection count would be 0 — \
+                 this is missing data, not an absence of stale drawers."
+            } else {
+                "Lower --min-injections to widen the list."
+            }
+        )?;
+        return Ok(());
+    }
+
+    for (i, row) in census.rows.iter().take(limit).enumerate() {
+        writeln!(
+            out,
+            "#{rank}  {id}  {palace} / {room}",
+            rank = i + 1,
+            id = short_id(&row.drawer_id),
+            palace = row.palace,
+            room = row.room
+        )?;
+        // The coverage line counts injections estate-wide; this percentage is
+        // against the drawer's OWN palace. Name the denominator here so the two
+        // numbers cannot be read as contradicting each other.
+        writeln!(
+            out,
+            "    injections   {n}  ({pct:.1}% of {palace} turns)",
+            n = row.injections,
+            pct = row.share_of_turns * 100.0,
+            palace = row.palace
+        )?;
+        writeln!(
+            out,
+            "    age          {age:.1} days     importance {imp:.2} -> {eff:.2} effective (90-day half-life)",
+            age = row.age_days,
+            imp = row.importance,
+            eff = row.effective_importance
+        )?;
+        writeln!(
+            out,
+            "    expires_at   {}",
+            if row.has_expiry {
+                "set — already triaged"
+            } else {
+                "not set"
+            }
+        )?;
+        let signals = if row.signals.is_empty() {
+            "none".to_string()
+        } else {
+            row.signals
+                .iter()
+                .map(|s| s.label())
+                .collect::<Vec<_>>()
+                .join(", ")
+        };
+        writeln!(out, "    signals      {signals}")?;
+        writeln!(out, "    excerpt      {}", wrap_excerpt(&row.excerpt))?;
+        writeln!(out)?;
+    }
+
+    if census.rows.len() > limit {
+        writeln!(
+            out,
+            "({shown} of {total} matching drawers shown — raise --limit for more)",
+            shown = limit,
+            total = census.rows.len()
+        )?;
+    }
+    Ok(())
+}
+
+/// Write the coverage block — what was actually read.
+///
+/// Why: every number above is a measurement over a specific log window and a
+/// specific set of palaces. Stating the window is what separates "this drawer is
+/// never injected" from "the logs do not go back far enough to know".
+fn render_coverage(out: &mut dyn Write, census: &Census, stats: &ScanStats) -> Result<()> {
+    let window = match (stats.earliest, stats.latest) {
+        (Some(a), Some(b)) => format!("{} to {}", a.format("%Y-%m-%d"), b.format("%Y-%m-%d")),
+        _ => "no entries".to_string(),
+    };
+    writeln!(
+        out,
+        "Hook logs: {files} file(s), {inj} prompt-context injections across all palaces, {window}",
+        files = stats.files_scanned,
+        inj = stats.injections_counted,
+    )?;
+    if stats.files_failed > 0 {
+        writeln!(
+            out,
+            "  {} log file(s) unreadable and skipped",
+            stats.files_failed
+        )?;
+    }
+    let ok = census.outcomes.iter().filter(|o| o.error.is_none()).count();
+    writeln!(
+        out,
+        "Palaces:   {ok} read, {drawers} drawers",
+        drawers = census.drawers_total
+    )?;
+    for o in census.outcomes.iter().filter(|o| o.error.is_some()) {
+        writeln!(
+            out,
+            "  {} could not be read: {}",
+            o.palace,
+            o.error.as_deref().unwrap_or("unknown")
+        )?;
+    }
+    Ok(())
+}
+
+/// Wrap the excerpt at [`EXCERPT_WIDTH`], indenting continuation lines.
+///
+/// What: greedy word wrap. The excerpt is already whitespace-collapsed to a
+/// single line by `drawer_preview`, so splitting on spaces is sufficient.
+fn wrap_excerpt(excerpt: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
+    let mut current = String::new();
+    for word in excerpt.split(' ') {
+        if !current.is_empty() && current.chars().count() + 1 + word.chars().count() > EXCERPT_WIDTH
+        {
+            lines.push(std::mem::take(&mut current));
+        }
+        if !current.is_empty() {
+            current.push(' ');
+        }
+        current.push_str(word);
+    }
+    if !current.is_empty() {
+        lines.push(current);
+    }
+    lines.join(&format!("\n{EXCERPT_INDENT}"))
+}
+
+/// Render the report as one JSON object.
+///
+/// Why: the human path is the stanza list, but triage across 93 palaces wants a
+/// machine-readable list to slice. Same data, no derived verdict here either.
+/// Test: `json_round_trips`.
+pub fn render_json(
+    out: &mut dyn Write,
+    census: &Census,
+    stats: &ScanStats,
+    limit: usize,
+) -> Result<()> {
+    let rows: Vec<_> = census
+        .rows
+        .iter()
+        .take(limit)
+        .map(|r| {
+            json!({
+                "palace": r.palace,
+                "drawer_id": r.drawer_id.to_string(),
+                "room": r.room,
+                "excerpt": r.excerpt,
+                "age_days": r.age_days,
+                "injections": r.injections,
+                "share_of_turns": r.share_of_turns,
+                "importance": r.importance,
+                "effective_importance": r.effective_importance,
+                "has_expiry": r.has_expiry,
+                "signals": r.signals.iter().map(|s| s.label()).collect::<Vec<_>>(),
+            })
+        })
+        .collect();
+    let doc = json!({
+        "read_only": true,
+        "coverage": {
+            "log_files_scanned": stats.files_scanned,
+            "log_files_failed": stats.files_failed,
+            "injections_counted": stats.injections_counted,
+            "window_start": stats.earliest.map(|t| t.to_rfc3339()),
+            "window_end": stats.latest.map(|t| t.to_rfc3339()),
+            "drawers_read": census.drawers_total,
+            "palaces_failed": census
+                .outcomes
+                .iter()
+                .filter(|o| o.error.is_some())
+                .map(|o| json!({ "palace": o.palace, "error": o.error }))
+                .collect::<Vec<_>>(),
+        },
+        "matching_drawers": census.rows.len(),
+        "candidates": rows,
+    });
+    writeln!(out, "{}", serde_json::to_string_pretty(&doc)?)?;
+    Ok(())
+}

--- a/crates/trusty-memory/src/commands/backfill_report/signals.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/signals.rs
@@ -12,13 +12,14 @@
 //! have no way to tell which quarter. So each signal states a fact the reader
 //! can check against the row beside it, and stops there.
 //!
-//! What: five checks, each true or false from the drawer row alone. They are
-//! listed on the row so a reader can see *why* something is near the top; they
-//! never combine into a score and never order the output — injection frequency
-//! does that.
+//! What: six checks, each true or false from the drawer row and the scanned log
+//! window alone. They are listed on the row so a reader can see *why* something
+//! is near the top; they never combine into a score and never order the output —
+//! injection frequency does that.
 //!
 //! Test: `tags_are_reported_verbatim`, `date_stamp_only_scans_the_opening`,
-//! `weight_retained_needs_both_age_and_weight`, `no_signal_implies_empty_list`.
+//! `weight_retained_needs_both_age_and_weight`, `no_signal_implies_empty_list`,
+//! `predates_log_window_fires_only_outside_coverage`.
 
 use chrono::{DateTime, Utc};
 use trusty_common::memory_core::decay::DecayConfig;
@@ -52,6 +53,15 @@ pub enum Signal {
     /// Old enough to be stale, yet the 90-day half-life still leaves most of its
     /// weight — the §C7 arithmetic, evaluated for this specific row.
     WeightRetained,
+    /// The drawer was created before the scanned log window opens, so part of
+    /// its life is unmeasured.
+    ///
+    /// Why this is its own signal: a 0-injection row means two opposite things
+    /// that warrant opposite decisions. Without this marker, "nobody retrieves
+    /// this, it costs nothing, leave it" and "the logs do not reach back far
+    /// enough to know" are indistinguishable on the page, and a reader would
+    /// have to compare each row's age against the coverage header by hand.
+    PredatesLogWindow,
 }
 
 impl Signal {
@@ -63,6 +73,7 @@ impl Signal {
             Signal::MaxImportance => "importance=1.0".to_string(),
             Signal::NoExpiry => "no-expiry".to_string(),
             Signal::WeightRetained => "weight-retained".to_string(),
+            Signal::PredatesLogWindow => "predates-log-window".to_string(),
         }
     }
 }
@@ -80,9 +91,12 @@ const REPORTED_TAGS: [&str; 4] = [
 /// Why: gathering them in one pass keeps the "observation, not verdict" rule in
 /// a single reviewable place.
 /// What: checks the four reported tags, the opening date stamp, the importance
-/// ceiling, the absence of an expiry, and the retained-weight condition.
-/// Test: `tags_are_reported_verbatim`, `no_signal_implies_empty_list`.
-pub fn observe(drawer: &Drawer, age_days: f32, _now: DateTime<Utc>) -> Vec<Signal> {
+/// ceiling, the absence of an expiry, the retained-weight condition, and whether
+/// the drawer predates `window_start` — the earliest hook-log entry scanned, or
+/// `None` when no log was read at all.
+/// Test: `tags_are_reported_verbatim`, `no_signal_implies_empty_list`,
+/// `predates_log_window_fires_only_outside_coverage`.
+pub fn observe(drawer: &Drawer, age_days: f32, window_start: Option<DateTime<Utc>>) -> Vec<Signal> {
     let mut out = Vec::new();
     for tag in REPORTED_TAGS {
         if drawer.tags.iter().any(|t| t == tag) {
@@ -104,6 +118,12 @@ pub fn observe(drawer: &Drawer, age_days: f32, _now: DateTime<Utc>) -> Vec<Signa
         && decayed / drawer.importance >= WEIGHT_RETAINED_FRACTION
     {
         out.push(Signal::WeightRetained);
+    }
+    // #4891: only meaningful when a window exists. With no log scanned at all,
+    // every count is 0 for a different reason, and the report says that once at
+    // the top rather than tagging all 2,287 rows with it.
+    if window_start.is_some_and(|start| drawer.created_at < start) {
+        out.push(Signal::PredatesLogWindow);
     }
     out
 }

--- a/crates/trusty-memory/src/commands/backfill_report/signals.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/signals.rs
@@ -1,0 +1,127 @@
+//! Objective observations attached to a candidate row.
+//!
+//! Why: the report deliberately emits **no suggested classification**, and this
+//! module is where that restraint is enforced. ADR-0028 §C4 measured the
+//! alternative directly: content-classifying the 654 `resume-target` drawers
+//! gives 71.4% point-in-time but 25.5% standing, and `standing-instruction` is
+//! overloaded in the opposite direction — drawer `f59fb536` carries it while its
+//! content is a one-shot action. The ADR's conclusion is that "any design that
+//! infers tier from the existing tags inherits this ambiguity". A verdict column
+//! built on those tags would be wrong for a quarter of the rows while looking
+//! exactly as confident as the right ones, and the human doing the triage would
+//! have no way to tell which quarter. So each signal states a fact the reader
+//! can check against the row beside it, and stops there.
+//!
+//! What: five checks, each true or false from the drawer row alone. They are
+//! listed on the row so a reader can see *why* something is near the top; they
+//! never combine into a score and never order the output — injection frequency
+//! does that.
+//!
+//! Test: `tags_are_reported_verbatim`, `date_stamp_only_scans_the_opening`,
+//! `weight_retained_needs_both_age_and_weight`, `no_signal_implies_empty_list`.
+
+use chrono::{DateTime, Utc};
+use trusty_common::memory_core::decay::DecayConfig;
+use trusty_common::memory_core::palace::Drawer;
+
+/// Characters of content scanned for an opening date stamp.
+///
+/// Why: the point-in-time drawers §C7 names put their date in the headline
+/// ("SESSION CHECKPOINT 2026-07-16 — …"). Scanning the whole body would instead
+/// match any drawer that happens to cite a date anywhere, which is most of them.
+const DATE_SCAN_CHARS: usize = 120;
+
+/// Age past which [`Signal::WeightRetained`] can fire.
+const WEIGHT_RETAINED_MIN_AGE_DAYS: f32 = 14.0;
+
+/// Fraction of base importance still retained for [`Signal::WeightRetained`].
+const WEIGHT_RETAINED_FRACTION: f32 = 0.8;
+
+/// A checkable observation about a drawer. Never a conclusion about its tier.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Signal {
+    /// Carries one of the tags §C4 found spanning both tiers. Reported because
+    /// the reader will want to see it, not because it decides anything.
+    Tagged(String),
+    /// The first [`DATE_SCAN_CHARS`] characters contain a `YYYY-MM-DD` date.
+    DateStamped,
+    /// `importance` is at the 1.0 ceiling — the §C5 privilege dial, fully open.
+    MaxImportance,
+    /// No `expires_at` is set, so nothing retires this drawer.
+    NoExpiry,
+    /// Old enough to be stale, yet the 90-day half-life still leaves most of its
+    /// weight — the §C7 arithmetic, evaluated for this specific row.
+    WeightRetained,
+}
+
+impl Signal {
+    /// Short label for the table column.
+    pub fn label(&self) -> String {
+        match self {
+            Signal::Tagged(t) => format!("tag:{t}"),
+            Signal::DateStamped => "date-stamped".to_string(),
+            Signal::MaxImportance => "importance=1.0".to_string(),
+            Signal::NoExpiry => "no-expiry".to_string(),
+            Signal::WeightRetained => "weight-retained".to_string(),
+        }
+    }
+}
+
+/// Tags worth surfacing, in the order §C4's census reports them.
+const REPORTED_TAGS: [&str; 4] = [
+    "status",
+    "resume-target",
+    "standing-instruction",
+    "bob-decision",
+];
+
+/// Collect every signal true of `drawer`.
+///
+/// Why: gathering them in one pass keeps the "observation, not verdict" rule in
+/// a single reviewable place.
+/// What: checks the four reported tags, the opening date stamp, the importance
+/// ceiling, the absence of an expiry, and the retained-weight condition.
+/// Test: `tags_are_reported_verbatim`, `no_signal_implies_empty_list`.
+pub fn observe(drawer: &Drawer, age_days: f32, _now: DateTime<Utc>) -> Vec<Signal> {
+    let mut out = Vec::new();
+    for tag in REPORTED_TAGS {
+        if drawer.tags.iter().any(|t| t == tag) {
+            out.push(Signal::Tagged(tag.to_string()));
+        }
+    }
+    if opens_with_date(&drawer.content) {
+        out.push(Signal::DateStamped);
+    }
+    if drawer.importance >= 1.0 {
+        out.push(Signal::MaxImportance);
+    }
+    if drawer.expires_at.is_none() {
+        out.push(Signal::NoExpiry);
+    }
+    let decayed = DecayConfig::default().effective_importance(drawer.importance, age_days, 0.0);
+    if age_days >= WEIGHT_RETAINED_MIN_AGE_DAYS
+        && drawer.importance > 0.0
+        && decayed / drawer.importance >= WEIGHT_RETAINED_FRACTION
+    {
+        out.push(Signal::WeightRetained);
+    }
+    out
+}
+
+/// True when the opening of `content` carries a `YYYY-MM-DD` date.
+///
+/// What: scans the first [`DATE_SCAN_CHARS`] characters for four digits, a
+/// dash, two digits, a dash, two digits. Deliberately shape-only — it does not
+/// validate the date, because a malformed date in a headline is still a date
+/// stamp for the reader's purposes.
+/// Test: `date_stamp_only_scans_the_opening`.
+fn opens_with_date(content: &str) -> bool {
+    let head: Vec<char> = content.chars().take(DATE_SCAN_CHARS).collect();
+    head.windows(10).any(|w| {
+        w[0..4].iter().all(char::is_ascii_digit)
+            && w[4] == '-'
+            && w[5..7].iter().all(char::is_ascii_digit)
+            && w[7] == '-'
+            && w[8..10].iter().all(char::is_ascii_digit)
+    })
+}

--- a/crates/trusty-memory/src/commands/backfill_report/tests.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/tests.rs
@@ -284,7 +284,7 @@ fn tags_are_reported_verbatim() {
         1,
         &["status", "resume-target", "unrelated"],
     );
-    let s = observe(&d, 1.0, Utc::now());
+    let s = observe(&d, 1.0, None);
     assert!(s.contains(&Signal::Tagged("status".into())));
     assert!(s.contains(&Signal::Tagged("resume-target".into())));
     assert!(
@@ -297,11 +297,11 @@ fn tags_are_reported_verbatim() {
 #[test]
 fn date_stamp_only_scans_the_opening() {
     let opening = drawer("SESSION CHECKPOINT 2026-07-16 — done", 0.5, 1, &[]);
-    assert!(observe(&opening, 1.0, Utc::now()).contains(&Signal::DateStamped));
+    assert!(observe(&opening, 1.0, None).contains(&Signal::DateStamped));
 
     let buried = drawer(&format!("{} 2026-07-16", "x".repeat(400)), 0.5, 1, &[]);
     assert!(
-        !observe(&buried, 1.0, Utc::now()).contains(&Signal::DateStamped),
+        !observe(&buried, 1.0, None).contains(&Signal::DateStamped),
         "a date deep in the body is not a headline date stamp"
     );
 }
@@ -310,28 +310,50 @@ fn date_stamp_only_scans_the_opening() {
 fn weight_retained_needs_both_age_and_weight() {
     // 3 days old: too young to be called stale, even though weight is retained.
     let young = drawer("x", 1.0, 3, &[]);
-    assert!(!observe(&young, 3.0, Utc::now()).contains(&Signal::WeightRetained));
+    assert!(!observe(&young, 3.0, None).contains(&Signal::WeightRetained));
 
     // 19 days at a 90-day half-life keeps 86% — the ADR §C7 case exactly.
     let old = drawer("x", 1.0, 19, &[]);
-    assert!(observe(&old, 19.0, Utc::now()).contains(&Signal::WeightRetained));
+    assert!(observe(&old, 19.0, None).contains(&Signal::WeightRetained));
 }
 
 #[test]
 fn max_importance_and_expiry_are_reported() {
     let mut d = drawer("x", 1.0, 1, &[]);
-    assert!(observe(&d, 1.0, Utc::now()).contains(&Signal::MaxImportance));
-    assert!(observe(&d, 1.0, Utc::now()).contains(&Signal::NoExpiry));
+    assert!(observe(&d, 1.0, None).contains(&Signal::MaxImportance));
+    assert!(observe(&d, 1.0, None).contains(&Signal::NoExpiry));
 
     d.expires_at = Some(Utc::now() + Duration::days(7));
-    assert!(!observe(&d, 1.0, Utc::now()).contains(&Signal::NoExpiry));
+    assert!(!observe(&d, 1.0, None).contains(&Signal::NoExpiry));
 }
 
 #[test]
 fn no_signal_implies_empty_list() {
     let mut d = drawer("plain text with no date and no tags", 0.5, 1, &[]);
     d.expires_at = Some(Utc::now() + Duration::days(1));
-    assert!(observe(&d, 1.0, Utc::now()).is_empty());
+    assert!(observe(&d, 1.0, None).is_empty());
+}
+
+#[test]
+fn predates_log_window_fires_only_outside_coverage() {
+    let window_start = Utc::now() - Duration::days(31);
+
+    // Created before the logs begin: part of its life is unmeasured, so a 0 here
+    // means "unknown", not "cold".
+    let older = drawer("older than the logs", 0.5, 60, &[]);
+    assert!(observe(&older, 60.0, Some(window_start)).contains(&Signal::PredatesLogWindow));
+
+    // Created inside the window: a 0 here genuinely means nobody retrieves it.
+    let inside = drawer("created inside the window", 0.5, 5, &[]);
+    assert!(!observe(&inside, 5.0, Some(window_start)).contains(&Signal::PredatesLogWindow));
+}
+
+#[test]
+fn predates_log_window_is_silent_when_no_log_was_scanned() {
+    // With no window at all, every count is 0 for one reason the report states
+    // once at the top. Tagging every row would be noise, not information.
+    let ancient = drawer("very old drawer", 0.5, 900, &[]);
+    assert!(!observe(&ancient, 900.0, None).contains(&Signal::PredatesLogWindow));
 }
 
 // -------------------------------------------------------- census + render
@@ -436,6 +458,137 @@ fn zero_injection_drawers_rank_last() {
         "high importance alone must never manufacture a frequency"
     );
     assert_eq!(census.rows[0].share_of_turns, 0.0);
+}
+
+#[test]
+fn colliding_excerpts_are_marked_on_every_affected_row() {
+    // Two drawers whose contents differ only past the 220-char preview cut, so
+    // they render an identical excerpt and the hook log cannot tell them apart.
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let shared_head = "SESSION PAUSE 2026-07-16 — RESUME TARGET. ".repeat(8);
+    let a = drawer(&format!("{shared_head} FIRST tail"), 1.0, 20, &["status"]);
+    let b = drawer(&format!("{shared_head} SECOND tail"), 1.0, 20, &["status"]);
+    let unique = drawer("a drawer nobody else resembles", 0.5, 20, &[]);
+    fixture_palace(root.path(), "p", &[a.clone(), b.clone(), unique.clone()]);
+
+    assert_eq!(
+        drawer_preview(&a.content),
+        drawer_preview(&b.content),
+        "fixture precondition: these two must actually collide"
+    );
+
+    let inj = section("p", &[(&drawer_preview(&a.content), &["status"])]);
+    write_log(
+        logs.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj), log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+
+    let row_a = census.rows.iter().find(|r| r.drawer_id == a.id).expect("a");
+    let row_b = census.rows.iter().find(|r| r.drawer_id == b.id).expect("b");
+    let row_u = census
+        .rows
+        .iter()
+        .find(|r| r.drawer_id == unique.id)
+        .expect("u");
+
+    assert_eq!(row_a.collision_peers, Some(1), "both sides must be marked");
+    assert_eq!(row_b.collision_peers, Some(1), "both sides must be marked");
+    assert_eq!(
+        row_u.collision_peers, None,
+        "a unique excerpt is not marked"
+    );
+
+    assert_eq!(
+        (row_a.injections, row_b.injections),
+        (2, 2),
+        "the shared count is reported on both — the marker is what makes that honest"
+    );
+    assert_ne!(
+        row_a.content_digest, row_b.content_digest,
+        "the digest must separate rows the excerpt cannot"
+    );
+
+    // And the reader sees it, in the header and on the rows.
+    let mut buf = Vec::new();
+    render_text(&mut buf, &census, &index.stats, 25).expect("render");
+    let s = String::from_utf8(buf).expect("utf8");
+    assert!(s.contains("2 row(s) share an excerpt"));
+    // Count stanza markers only — the header's "Marked ⚠ SHARED below" mentions
+    // the same string.
+    assert_eq!(
+        s.lines().filter(|l| l.starts_with("    ⚠ SHARED")).count(),
+        2
+    );
+    assert!(s.contains(&row_a.content_digest));
+    assert!(s.contains(&row_b.content_digest));
+}
+
+#[test]
+fn unique_excerpts_are_not_marked() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    fixture_palace(
+        root.path(),
+        "p",
+        &[drawer("alpha", 0.5, 1, &[]), drawer("beta", 0.5, 1, &[])],
+    );
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    assert!(census.rows.iter().all(|r| r.collision_peers.is_none()));
+
+    let mut buf = Vec::new();
+    render_text(&mut buf, &census, &index.stats, 25).expect("render");
+    let s = String::from_utf8(buf).expect("utf8");
+    assert!(!s.contains("SHARED"), "no collision, no warning");
+    assert!(!s.contains("share an excerpt"));
+}
+
+#[test]
+fn identical_excerpts_in_different_palaces_do_not_collide() {
+    // The hook-log index is keyed per palace, so the same excerpt in two palaces
+    // is two independent counts and neither is misattributed.
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let same = "an excerpt that appears in two palaces";
+    fixture_palace(root.path(), "a", &[drawer(same, 0.5, 1, &[])]);
+    fixture_palace(root.path(), "b", &[drawer(same, 0.5, 1, &[])]);
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    assert_eq!(census.rows.len(), 2);
+    assert!(census.rows.iter().all(|r| r.collision_peers.is_none()));
+}
+
+#[test]
+fn collision_json_field_is_always_present() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let d = drawer("solo drawer", 0.5, 1, &[]);
+    fixture_palace(root.path(), "p", std::slice::from_ref(&d));
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    let mut buf = Vec::new();
+    render_json(&mut buf, &census, &index.stats, 25).expect("render");
+    let v: serde_json::Value = serde_json::from_slice(&buf).expect("json");
+
+    // Present-and-null, never absent: a consumer tests one field rather than
+    // inferring safety from a missing key.
+    assert!(
+        v["candidates"][0]
+            .as_object()
+            .expect("obj")
+            .contains_key("excerpt_collision_peers"),
+        "the field must exist even when there is no collision"
+    );
+    assert!(v["candidates"][0]["excerpt_collision_peers"].is_null());
+    assert!(v["candidates"][0]["content_digest"].is_string());
 }
 
 #[test]

--- a/crates/trusty-memory/src/commands/backfill_report/tests.rs
+++ b/crates/trusty-memory/src/commands/backfill_report/tests.rs
@@ -1,0 +1,658 @@
+//! Tests for the ADR-0028 read-only backfill report.
+//!
+//! The load-bearing ones are the exactness of the log join (a silent
+//! under-count would make the ranking meaningless) and the read-only contract
+//! (a report that mutates the estate is the one outcome the ADR forbids).
+
+use std::path::Path;
+
+use chrono::{Duration, Utc};
+use trusty_common::memory_core::palace::{Drawer, DrawerType};
+use uuid::Uuid;
+
+use super::candidates::build_census;
+use super::log_index::InjectionIndex;
+use super::render::{render_json, render_text};
+use super::signals::{observe, Signal};
+use crate::commands::prompt_context::format::drawer_preview;
+
+// ---------------------------------------------------------------- helpers
+
+/// One JSONL log line in the real `PromptLogEntry` shape.
+fn log_line(palace: &str, injection: &str) -> String {
+    serde_json::json!({
+        "timestamp": "2026-08-01T00:00:00Z",
+        "hook_type": "UserPromptSubmit",
+        "injection_kind": "prompt-context-facts",
+        "palace": palace,
+        "trigger_prompt": "hi",
+        "injection": injection,
+        "injection_length": injection.len(),
+        "duration_ms": 1,
+    })
+    .to_string()
+}
+
+/// Render a drawer section the way `compose_injection` does.
+fn section(palace: &str, bullets: &[(&str, &[&str])]) -> String {
+    let mut s = format!("## Relevant memories from palace `{palace}`\n");
+    for (preview, tags) in bullets {
+        s.push_str("- ");
+        s.push_str(preview);
+        if !tags.is_empty() {
+            s.push_str("  _(tags: ");
+            s.push_str(
+                &tags
+                    .iter()
+                    .map(|t| format!("`{t}`"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+            s.push_str(")_");
+        }
+        s.push('\n');
+    }
+    s
+}
+
+fn write_log(dir: &Path, name: &str, lines: &[String]) {
+    std::fs::write(dir.join(name), format!("{}\n", lines.join("\n"))).expect("write log");
+}
+
+fn drawer(content: &str, importance: f32, age_days: i64, tags: &[&str]) -> Drawer {
+    let mut d = Drawer::new(Uuid::new_v4(), content);
+    d.importance = importance;
+    d.created_at = Utc::now() - Duration::days(age_days);
+    d.tags = tags.iter().map(|t| t.to_string()).collect();
+    d.drawer_type = DrawerType::Unknown;
+    d
+}
+
+// ------------------------------------------------------------- log_index
+
+#[test]
+fn bullets_are_counted_once_per_entry() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // The same drawer appears under two palace sections in ONE injection. It
+    // reached one turn, so it must count once.
+    let inj = format!(
+        "{}\n{}",
+        section("p", &[("alpha fact", &["status"])]),
+        section("p", &[("alpha fact", &["status"])])
+    );
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.injections_for("p", "alpha fact"), 1);
+    assert_eq!(index.total_injections("p"), 1);
+}
+
+#[test]
+fn kg_facts_section_is_ignored() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let inj = format!(
+        "{}\n## Relevant KG facts\n- tag:status **tags** drawer:abc\n",
+        section("p", &[("real drawer", &["status"])])
+    );
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.injections_for("p", "real drawer"), 1);
+    assert_eq!(
+        index.injections_for("p", "tag:status **tags** drawer:abc"),
+        0,
+        "a KG triple line must never be mistaken for a drawer bullet"
+    );
+}
+
+#[test]
+fn truncated_tail_bullet_matches_by_prefix() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let full = "SESSION CHECKPOINT 2026-07-16 — MERGE TRAIN COMPLETE, eight PRs merged this session and every one reviewed";
+    // The 4 KiB cap cut this bullet mid-preview: the tag run is gone and the
+    // whole injection ends with the cap's `…`.
+    let cut = &full[..80];
+    let inj = format!("## Relevant memories from palace `p`\n- {cut}…");
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(
+        index.injections_for("p", full),
+        1,
+        "a drawer cut by the byte cap still reached the turn"
+    );
+}
+
+#[test]
+fn short_partial_is_not_matched() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Far below MIN_PARTIAL_CHARS — matching it as a prefix would inflate every
+    // drawer whose content starts with "SESSION".
+    let inj = "## Relevant memories from palace `p`\n- SESSION…";
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.injections_for("p", "SESSION CHECKPOINT one"), 0);
+    assert_eq!(index.injections_for("p", "SESSION CHECKPOINT two"), 0);
+}
+
+#[test]
+fn untagged_bullet_counts_exactly() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // Short AND untagged — the case that would vanish if every tag-less bullet
+    // were treated as a byte-cap tail, since it is far below MIN_PARTIAL_CHARS.
+    let short = "untagged drawer";
+    let inj = format!("## Relevant memories from palace `p`\n- {short}\n");
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.injections_for("p", short), 1);
+}
+
+#[test]
+fn untagged_bullet_mid_block_is_not_treated_as_a_tail() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    // The injection IS cap-truncated, but the untagged bullet is not its last
+    // line, so only the genuine tail may be prefix-matched.
+    let inj = "## Relevant memories from palace `p`\n- untagged\n- tail bullet that the cap cut before its tags could be written out…";
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.injections_for("p", "untagged"), 1);
+    assert_eq!(
+        index.injections_for(
+            "p",
+            "tail bullet that the cap cut before its tags could be written out… and then some more"
+        ),
+        1
+    );
+}
+
+#[test]
+fn counts_are_scoped_per_palace() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let inj = section("a", &[("shared text", &["status"])]);
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("a", &inj), log_line("a", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.injections_for("a", "shared text"), 2);
+    assert_eq!(index.injections_for("b", "shared text"), 0);
+}
+
+#[test]
+fn scan_dir_on_missing_directory_is_empty_not_error() {
+    let index = InjectionIndex::scan_dir(Path::new("/nonexistent/trusty/logs")).expect("scan");
+    assert!(index.saw_no_logs());
+    assert_eq!(index.stats.injections_counted, 0);
+}
+
+#[test]
+fn scan_dir_counts_across_files() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let inj = section("p", &[("rolled fact", &["status"])]);
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-02.jsonl",
+        &[log_line("p", &inj)],
+    );
+    // Not a hook log — must be ignored.
+    std::fs::write(dir.path().join("other.jsonl"), log_line("p", &inj)).expect("write");
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.stats.files_scanned, 2);
+    assert_eq!(index.injections_for("p", "rolled fact"), 2);
+}
+
+#[test]
+fn non_prompt_context_entries_are_not_counted() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let mut line: serde_json::Value =
+        serde_json::from_str(&log_line("p", &section("p", &[("x", &["status"])]))).expect("json");
+    line["injection_kind"] = serde_json::json!("inbox-check-messages");
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[line.to_string()],
+    );
+
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.total_injections("p"), 0);
+    assert_eq!(index.injections_for("p", "x"), 0);
+}
+
+#[test]
+fn preview_matches_injection_bullet() {
+    // The join's whole correctness rests on the report rendering a preview
+    // identically to the injection. Pin it: a >220-char body must truncate the
+    // same way on both sides, which it does because both call `drawer_preview`.
+    let content = "word ".repeat(200);
+    let preview = drawer_preview(&content);
+    assert_eq!(preview.chars().count(), 220);
+    assert!(preview.ends_with('…'));
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let inj = section("p", &[(preview.as_str(), &["status"])]);
+    write_log(
+        dir.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+    let index = InjectionIndex::scan_dir(dir.path()).expect("scan");
+    assert_eq!(index.injections_for("p", &drawer_preview(&content)), 1);
+}
+
+// --------------------------------------------------------------- signals
+
+#[test]
+fn tags_are_reported_verbatim() {
+    let d = drawer(
+        "some fact",
+        0.5,
+        1,
+        &["status", "resume-target", "unrelated"],
+    );
+    let s = observe(&d, 1.0, Utc::now());
+    assert!(s.contains(&Signal::Tagged("status".into())));
+    assert!(s.contains(&Signal::Tagged("resume-target".into())));
+    assert!(
+        !s.iter()
+            .any(|x| matches!(x, Signal::Tagged(t) if t == "unrelated")),
+        "only the tags §C4 censused are surfaced"
+    );
+}
+
+#[test]
+fn date_stamp_only_scans_the_opening() {
+    let opening = drawer("SESSION CHECKPOINT 2026-07-16 — done", 0.5, 1, &[]);
+    assert!(observe(&opening, 1.0, Utc::now()).contains(&Signal::DateStamped));
+
+    let buried = drawer(&format!("{} 2026-07-16", "x".repeat(400)), 0.5, 1, &[]);
+    assert!(
+        !observe(&buried, 1.0, Utc::now()).contains(&Signal::DateStamped),
+        "a date deep in the body is not a headline date stamp"
+    );
+}
+
+#[test]
+fn weight_retained_needs_both_age_and_weight() {
+    // 3 days old: too young to be called stale, even though weight is retained.
+    let young = drawer("x", 1.0, 3, &[]);
+    assert!(!observe(&young, 3.0, Utc::now()).contains(&Signal::WeightRetained));
+
+    // 19 days at a 90-day half-life keeps 86% — the ADR §C7 case exactly.
+    let old = drawer("x", 1.0, 19, &[]);
+    assert!(observe(&old, 19.0, Utc::now()).contains(&Signal::WeightRetained));
+}
+
+#[test]
+fn max_importance_and_expiry_are_reported() {
+    let mut d = drawer("x", 1.0, 1, &[]);
+    assert!(observe(&d, 1.0, Utc::now()).contains(&Signal::MaxImportance));
+    assert!(observe(&d, 1.0, Utc::now()).contains(&Signal::NoExpiry));
+
+    d.expires_at = Some(Utc::now() + Duration::days(7));
+    assert!(!observe(&d, 1.0, Utc::now()).contains(&Signal::NoExpiry));
+}
+
+#[test]
+fn no_signal_implies_empty_list() {
+    let mut d = drawer("plain text with no date and no tags", 0.5, 1, &[]);
+    d.expires_at = Some(Utc::now() + Duration::days(1));
+    assert!(observe(&d, 1.0, Utc::now()).is_empty());
+}
+
+// -------------------------------------------------------- census + render
+
+/// Build a palace on disk and return (registry_dir, palace_slug).
+fn fixture_palace(root: &Path, slug: &str, drawers: &[Drawer]) {
+    use std::sync::Arc;
+    use trusty_common::memory_core::store::kg_redb::KgStoreRedb;
+    use trusty_common::memory_core::store::OpenIntent;
+
+    let data_dir = root.join(slug);
+    std::fs::create_dir_all(&data_dir).expect("palace dir");
+    // A palace is discovered by `PalaceStore::list_palaces` via its metadata;
+    // write it the same way the store does.
+    trusty_common::memory_core::store::PalaceStore::save_palace(
+        &trusty_common::memory_core::palace::Palace {
+            id: trusty_common::memory_core::palace::PalaceId(slug.to_string()),
+            name: slug.to_string(),
+            description: None,
+            created_at: Utc::now(),
+            data_dir: data_dir.clone(),
+        },
+    )
+    .expect("save palace");
+
+    let store = KgStoreRedb::open_with_intent(&data_dir.join("kg.redb"), OpenIntent::Writer)
+        .expect("open store");
+    let store = Arc::new(store);
+    for d in drawers {
+        store.upsert_drawer(d).expect("upsert");
+    }
+}
+
+#[test]
+fn ranks_by_injection_count() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+
+    let hot = drawer("HOT drawer content", 1.0, 20, &["status"]);
+    let cold = drawer("COLD drawer content", 0.5, 20, &[]);
+    fixture_palace(root.path(), "p", &[hot.clone(), cold.clone()]);
+
+    let hot_inj = section("p", &[(&drawer_preview(&hot.content), &["status"])]);
+    let cold_inj = section("p", &[(&drawer_preview(&cold.content), &[])]);
+    write_log(
+        logs.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[
+            log_line("p", &hot_inj),
+            log_line("p", &hot_inj),
+            log_line("p", &hot_inj),
+            log_line("p", &cold_inj),
+        ],
+    );
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    assert_eq!(census.rows.len(), 2);
+    assert_eq!(census.rows[0].drawer_id, hot.id);
+    assert_eq!(census.rows[0].injections, 3);
+    assert!((census.rows[0].share_of_turns - 0.75).abs() < 1e-9);
+    assert_eq!(census.rows[1].drawer_id, cold.id);
+    assert_eq!(census.rows[1].injections, 1);
+}
+
+#[test]
+fn min_injections_filters() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let a = drawer("kept drawer", 0.5, 5, &[]);
+    let b = drawer("dropped drawer", 0.5, 5, &[]);
+    fixture_palace(root.path(), "p", &[a.clone(), b.clone()]);
+    let inj = section("p", &[(&drawer_preview(&a.content), &[])]);
+    write_log(
+        logs.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj), log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 2).expect("census");
+    assert_eq!(census.rows.len(), 1);
+    assert_eq!(census.rows[0].drawer_id, a.id);
+    assert_eq!(
+        census.drawers_total, 2,
+        "the filter hides rows, it does not hide that the drawers were read"
+    );
+}
+
+#[test]
+fn zero_injection_drawers_rank_last() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let never = drawer("never injected", 1.0, 30, &["status"]);
+    fixture_palace(root.path(), "p", std::slice::from_ref(&never));
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    assert_eq!(census.rows.len(), 1);
+    assert_eq!(
+        census.rows[0].injections, 0,
+        "high importance alone must never manufacture a frequency"
+    );
+    assert_eq!(census.rows[0].share_of_turns, 0.0);
+}
+
+#[test]
+fn palace_filter_narrows_the_census() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    fixture_palace(root.path(), "keep", &[drawer("a", 0.5, 1, &[])]);
+    fixture_palace(root.path(), "skip", &[drawer("b", 0.5, 1, &[])]);
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, Some("keep"), 0).expect("census");
+    assert_eq!(census.outcomes.len(), 1);
+    assert_eq!(census.outcomes[0].palace, "keep");
+}
+
+#[test]
+fn report_writes_nothing_to_the_palace() {
+    // The ADR forbids exactly one outcome: a backfill tool that mutates. An
+    // expired drawer is the sharp case — `PalaceHandle::open` would DELETE it.
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let mut expired = drawer("long expired status drawer", 1.0, 40, &["status"]);
+    expired.expires_at = Some(Utc::now() - Duration::days(30));
+    let live = drawer("live drawer", 0.5, 1, &[]);
+    fixture_palace(root.path(), "p", &[expired.clone(), live.clone()]);
+
+    let kg = root.path().join("p").join("kg.redb");
+    let before = std::fs::metadata(&kg).expect("stat").len();
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+
+    assert_eq!(
+        census.drawers_total, 2,
+        "the expired drawer must still be READ — it is precisely what a human triages"
+    );
+    assert!(
+        census
+            .rows
+            .iter()
+            .any(|r| r.drawer_id == expired.id && r.has_expiry),
+        "an already-triaged drawer is reported as such, not silently dropped"
+    );
+    assert_eq!(
+        std::fs::metadata(&kg).expect("stat").len(),
+        before,
+        "the report must not have written to the palace store"
+    );
+
+    // And the drawer is still there on a fresh read.
+    let index2 = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census2 = build_census(root.path(), &index2, None, 0).expect("census");
+    assert_eq!(census2.drawers_total, 2);
+}
+
+#[test]
+fn incompatible_store_is_reported_not_recreated() {
+    // Opening an incompatible-format store with `Database::create` renames it
+    // aside and starts a fresh empty one (concurrent_open.rs, #702). Reading a
+    // copy means that happens to the copy — and the report must say so rather
+    // than present the palace as empty.
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    fixture_palace(root.path(), "good", &[drawer("a", 0.5, 1, &[])]);
+    fixture_palace(root.path(), "bad", &[drawer("b", 0.5, 1, &[])]);
+    let bad_kg = root.path().join("bad").join("kg.redb");
+    std::fs::write(&bad_kg, b"not a redb file at all").expect("corrupt");
+    let before = std::fs::read(&bad_kg).expect("read");
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+
+    assert_eq!(census.outcomes.len(), 2);
+    let bad = census
+        .outcomes
+        .iter()
+        .find(|o| o.palace == "bad")
+        .expect("bad");
+    assert!(bad.error.is_some(), "a bad palace is reported, not fatal");
+    assert_eq!(census.drawers_total, 1, "the good palace still reports");
+    assert_eq!(
+        std::fs::read(&bad_kg).expect("read"),
+        before,
+        "the unreadable store must be left exactly as found, never recreated"
+    );
+    assert!(
+        !bad_kg.with_extension("redb.v2-incompatible").exists(),
+        "no backup file may be left beside the live store"
+    );
+}
+
+#[test]
+fn palace_without_a_kg_store_is_empty_not_an_error() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    fixture_palace(root.path(), "p", &[drawer("a", 0.5, 1, &[])]);
+    std::fs::remove_file(root.path().join("p").join("kg.redb")).expect("remove");
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    assert_eq!(census.outcomes.len(), 1);
+    assert!(census.outcomes[0].error.is_none());
+    assert_eq!(census.drawers_total, 0);
+}
+
+#[test]
+fn text_output_leads_with_the_read_only_contract() {
+    let census = super::candidates::Census::default();
+    let stats = super::log_index::ScanStats::default();
+    let mut buf = Vec::new();
+    render_text(&mut buf, &census, &stats, 25).expect("render");
+    let s = String::from_utf8(buf).expect("utf8");
+    assert!(s.contains("READ-ONLY"));
+    assert!(s.contains("never sets expires_at"));
+    assert!(
+        s.contains("does not migrate the drawers already on disk"),
+        "the help must state that this report is the only route for existing drawers"
+    );
+}
+
+#[test]
+fn empty_census_says_why() {
+    let census = super::candidates::Census::default();
+    let stats = super::log_index::ScanStats::default();
+    let mut buf = Vec::new();
+    render_text(&mut buf, &census, &stats, 25).expect("render");
+    let s = String::from_utf8(buf).expect("utf8");
+    assert!(
+        s.contains("missing data, not an absence of stale drawers"),
+        "zero counts from a missing log must not read as a clean estate"
+    );
+}
+
+#[test]
+fn stanza_carries_every_decision_field() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let d = drawer(
+        "SESSION CHECKPOINT 2026-07-16 — merge train complete",
+        1.0,
+        19,
+        &["status"],
+    );
+    fixture_palace(root.path(), "p", std::slice::from_ref(&d));
+    let inj = section("p", &[(&drawer_preview(&d.content), &["status"])]);
+    write_log(
+        logs.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    let mut buf = Vec::new();
+    render_text(&mut buf, &census, &index.stats, 25).expect("render");
+    let s = String::from_utf8(buf).expect("utf8");
+
+    assert!(s.contains(&super::candidates::short_id(&d.id)), "drawer id");
+    assert!(s.contains("SESSION CHECKPOINT 2026-07-16"), "excerpt");
+    assert!(s.contains("injections   1"), "frequency");
+    assert!(
+        s.contains("100.0% of p turns"),
+        "share names its denominator"
+    );
+    assert!(s.contains("importance 1.00"), "importance");
+    assert!(s.contains("age          19"), "age");
+    assert!(s.contains("tag:status"), "signals");
+    assert!(s.contains("not set"), "expiry state");
+    assert!(
+        !s.to_lowercase().contains("point-in-time"),
+        "the report must not emit a tier verdict"
+    );
+}
+
+#[test]
+fn json_round_trips() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let d = drawer("json drawer", 0.75, 4, &["status"]);
+    fixture_palace(root.path(), "p", std::slice::from_ref(&d));
+    let inj = section("p", &[(&drawer_preview(&d.content), &["status"])]);
+    write_log(
+        logs.path(),
+        "enriched-prompts.2026-08-01.jsonl",
+        &[log_line("p", &inj)],
+    );
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    let mut buf = Vec::new();
+    render_json(&mut buf, &census, &index.stats, 25).expect("render");
+    let v: serde_json::Value = serde_json::from_slice(&buf).expect("json");
+
+    assert_eq!(v["read_only"], serde_json::json!(true));
+    assert_eq!(v["candidates"][0]["drawer_id"], d.id.to_string());
+    assert_eq!(v["candidates"][0]["injections"], 1);
+    assert_eq!(v["coverage"]["injections_counted"], 1);
+    assert!(v["candidates"][0]["signals"]
+        .as_array()
+        .expect("signals")
+        .iter()
+        .any(|s| s == "tag:status"));
+}
+
+#[test]
+fn limit_caps_the_output_without_hiding_the_total() {
+    let logs = tempfile::tempdir().expect("logs");
+    let root = tempfile::tempdir().expect("root");
+    let ds: Vec<Drawer> = (0..5)
+        .map(|i| drawer(&format!("drawer number {i}"), 0.5, 1, &[]))
+        .collect();
+    fixture_palace(root.path(), "p", &ds);
+
+    let index = InjectionIndex::scan_dir(logs.path()).expect("scan");
+    let census = build_census(root.path(), &index, None, 0).expect("census");
+    let mut buf = Vec::new();
+    render_text(&mut buf, &census, &index.stats, 2).expect("render");
+    let s = String::from_utf8(buf).expect("utf8");
+    assert!(s.contains("(2 of 5 matching drawers shown"));
+}

--- a/crates/trusty-memory/src/commands/mod.rs
+++ b/crates/trusty-memory/src/commands/mod.rs
@@ -12,6 +12,8 @@
 //! in PR3 of the #914 epic.
 //! Test: Each submodule carries its own unit tests.
 
+// #4891: ADR-0028 Migration step 3 — the read-only backfill triage report.
+pub mod backfill_report;
 pub mod daemon_guard;
 pub mod daemon_lock;
 pub mod doctor;

--- a/crates/trusty-memory/src/commands/prompt_context/format.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/format.rs
@@ -111,8 +111,11 @@ pub(super) fn push_section(out: &mut String, section: &str) {
 /// what's available and lets it pull more via MCP recall if needed.
 /// What: whitespace-collapses and truncates to [`DRAWER_PREVIEW_CHARS`]
 /// chars with a trailing `…` when cut.
-/// Test: indirectly via `prompt_context_recalls_palace_drawers`.
-pub(super) fn drawer_preview(content: &str) -> String {
+/// Test: indirectly via `prompt_context_recalls_palace_drawers`; the exactness
+/// the backfill report depends on is pinned by `preview_matches_injection_bullet`.
+// #4891: `pub(crate)` so `commands::backfill_report` reuses this exact
+// truncation when joining drawers back to the hook logs.
+pub(crate) fn drawer_preview(content: &str) -> String {
     let normalised: String = content.split_whitespace().collect::<Vec<_>>().join(" ");
     if normalised.chars().count() <= DRAWER_PREVIEW_CHARS {
         normalised

--- a/crates/trusty-memory/src/commands/prompt_context/mod.rs
+++ b/crates/trusty-memory/src/commands/prompt_context/mod.rs
@@ -40,7 +40,10 @@
 
 mod fetch;
 mod filter;
-mod format;
+// #4891: `backfill_report` must render a drawer's preview byte-for-byte as the
+// injection does, or its log join silently under-counts. Sharing the one
+// implementation is what makes that guarantee hold.
+pub(crate) mod format;
 
 use anyhow::Result;
 use serde_json::Value;

--- a/crates/trusty-memory/src/main.rs
+++ b/crates/trusty-memory/src/main.rs
@@ -358,6 +358,55 @@ enum Command {
         action: RoomsAction,
     },
 
+    /// Rank existing drawers by how often they are actually injected, so a
+    /// human can decide which deserve an `expires_at` (ADR-0028, Migration).
+    ///
+    /// READ-ONLY. This never writes a drawer, never sets `expires_at`, and
+    /// never retires anything — ADR-0028 makes backfill human-gated, and a
+    /// tool that applied its own recommendations would violate that outright.
+    ///
+    /// ADR-0028 does NOT migrate the drawers already on disk. They keep
+    /// competing in L1 exactly as they do today, so this report is the only
+    /// path by which the estate's existing problem drawers get addressed —
+    /// and only when a human acts on a row.
+    ///
+    /// Ranking is by injection frequency because that is the cost the ADR
+    /// cares about: a stale drawer nobody retrieves is free, while the
+    /// motivating case is a 19-day-old session checkpoint reaching 44.8% of
+    /// turns. Counts are measured from the enriched-prompt hook logs; with no
+    /// logs present every count is 0, which the report says out loud rather
+    /// than reporting as "nothing is stale".
+    ///
+    /// No tier is suggested. ADR-0028 §C4 measured why: `resume-target` splits
+    /// 71/26 across tiers, so a tag-derived verdict would be wrong for a
+    /// quarter of rows while looking as confident as the rest. The evidence is
+    /// listed; the call is yours.
+    ///
+    ///   trusty-memory backfill-report
+    ///   trusty-memory backfill-report --palace trusty-tools --min-injections 50
+    ///   trusty-memory backfill-report --json --limit 200
+    BackfillReport {
+        /// Restrict the report to one palace slug.
+        #[arg(long, value_name = "ID")]
+        palace: Option<String>,
+
+        /// Maximum drawers to print (default 25).
+        #[arg(long, value_name = "N")]
+        limit: Option<usize>,
+
+        /// Hide drawers injected fewer than N times.
+        #[arg(long, value_name = "N", default_value_t = 1)]
+        min_injections: u64,
+
+        /// Emit JSON instead of the human-readable stanzas.
+        #[arg(long)]
+        json: bool,
+
+        /// Override the hook-log directory (default `<data_root>/logs`).
+        #[arg(long, value_name = "DIR")]
+        logs_dir: Option<std::path::PathBuf>,
+    },
+
     /// Pin this project's palace slug in `.trusty-tools/trusty-memory.yaml`.
     ///
     /// Why: the lazy write in normal memory operations locks in the slug the
@@ -647,6 +696,24 @@ async fn main() -> Result<()> {
         Command::Rooms {
             action: RoomsAction::Backfill { palace, apply, .. },
         } => trusty_memory::commands::rooms::handle_rooms_backfill(palace, apply).await,
+        Command::BackfillReport {
+            palace,
+            limit,
+            min_injections,
+            json,
+            logs_dir,
+        } => {
+            trusty_memory::commands::backfill_report::handle_backfill_report(
+                trusty_memory::commands::backfill_report::ReportOptions {
+                    palace,
+                    limit,
+                    min_injections,
+                    json,
+                    logs_dir,
+                },
+            )
+            .await
+        }
         Command::Link {
             path,
             slug,


### PR DESCRIPTION
Closes #4891 — ADR-0028 Migration step 3, the read-only human-gated triage list.

## Why

ADR-0028 does not migrate the drawers already on disk. Its "What this does not fix" section records that tier assignment for them is a classification problem the existing tags cannot settle, so Migration step 3 makes backfill read-only and human-gated. Existing drawers keep competing in L1 exactly as before, which means the estate's current problem drawers get addressed by human action or not at all. This report is the only thing that tells a human which ones they are.

## The data gate

The ticket required verifying the `enriched-prompts.*.jsonl` format still exists and still carries what the report needs, before building anything. It does:

- 31 files, 17,488 entries, 2026-07-06 to today, still being written (144 entries on 2026-08-05).
- Fields carry `palace`, `injection_kind`, `timestamp`, and the full rendered `injection` text.
- It carries **no drawer id**, so per-drawer frequency is not read directly — it is recovered. Each drawer renders as one bullet whose body is exactly `drawer_preview` of its content: a deterministic, whitespace-collapsed 220-char truncation. Parsing those bullets back out and counting distinct injections per body gives the per-drawer count.

The recovery reproduces ADR-0028 §C7's table against the live estate:

| Drawer | This report | ADR §C7 (measured 2026-08-04) |
|---|---|---|
| `SESSION CHECKPOINT 2026-07-16 — MERGE TRAIN COMPLETE` | 3,708 / 45.1% | 3,612 / 44.8% |
| `RESUME (trusty-code M1, PAUSED 2026-07-06)` | 1,711 / 20.8% | 1,711 / 21.2% |
| `SESSION PAUSE #19 2026-07-17` | 1,259 / 15.3% | 1,257 / 15.6% |

The deltas are one extra day of logs. This report adds the drawer ids the ADR's analysis did not have.

## Read-only, by construction

Two write paths had to be closed for the read-only claim to be true rather than intended:

1. **No `PalaceHandle`.** `PalaceHandle::open_with_intent` deletes every drawer whose `expires_at` has passed as a side effect of opening (`handle.rs`, #61). A report built on it would retire drawers merely by running — and would delete the rows a human most wants to see.
2. **No open against the live file.** Dropping to `KgStoreRedb` is not sufficient on its own: `OpenIntent::ReadOnlyClient` only snapshots when the file is *already locked*. On an unlocked palace it reaches `Database::create`, which opens read-write, runs a table-init write transaction, and on an incompatible-format file *renames the palace's store aside* and creates a fresh empty one (`concurrent_open.rs`, #702). So each store is copied to a private temp file and the copy is opened.

Verified live, not asserted: `md5` of `palaces/trusty-tools/kg.redb` is byte-identical across a full run with the daemon holding the lock. An incompatible-format store is reported as an error rather than silently reading as an empty palace, and the live file is left exactly as found.

## No suggested tier

ADR-0028 §C4 measured the alternative: content-classifying the 654 `resume-target` drawers gives 71.4% point-in-time but 25.5% standing, and `standing-instruction` is overloaded in the opposite direction. A tag-derived verdict would be wrong for a quarter of rows while looking exactly as confident as the right ones, and the human triaging would have no way to tell which quarter. Rows carry checkable observations instead — `tag:status`, `date-stamped`, `importance=1.0`, `no-expiry`, `weight-retained` — each true or false from the row beside it. They never combine into a score and never order the output; injection frequency does that.

## Output

One stanza per drawer rather than a table — the excerpt is 220 characters, and a column width would hide the text the decision turns on.

```
#1  752988dd  trusty-tools / General
    injections   3708  (45.1% of trusty-tools turns)
    age          20.4 days     importance 1.00 -> 0.85 effective (90-day half-life)
    expires_at   not set
    signals      tag:status, tag:resume-target, date-stamped, importance=1.0, no-expiry, weight-retained
    excerpt      SESSION CHECKPOINT 2026-07-16 (session 2eb72dca) — MERGE TRAIN COMPLETE, EIGHT PRs
                 merged this session, all code-critic reviewed + green-only admin-squash. …
```

`--json` for scripted triage. `--palace`, `--limit`, `--min-injections`, `--logs-dir`.

With no hook log present, the report says the counts are missing data rather than presenting zeros as an absence of stale drawers.

## Two bugs the tests caught

- Every bullet without a tag run was being treated as a byte-cap tail and prefix-matched, so short untagged drawers fell below the minimum prefix length and counted as 0. A tail is now identified by being the last line of an injection that ends in the cap's `…`.
- The cap appends `…` *after* the cut, so a literal prefix compare against the surviving text could never match. The marker is stripped before comparison.

## Shared-file edits (for merge sequencing)

Minimal edits outside the new module, none in the files the two concurrent `trusty-memory` agents hold:

- `commands/prompt_context/mod.rs` — `mod format` → `pub(crate) mod format` (one word).
- `commands/prompt_context/format.rs` — `drawer_preview` → `pub(crate)` (one word). Sharing the one implementation is what makes the join exact; a divergent copy would silently under-count rather than fail.
- `commands/mod.rs` — one `pub mod backfill_report;` line.
- `main.rs` — the clap variant and its dispatch arm.
- `Cargo.toml` — `tempfile` promoted from dev-dependency to dependency (already a workspace dep) for the private store copy.

## Verification

```
cargo test -p trusty-common --features memory-core,embedder-test-support
  test result: ok. 816 passed; 0 failed; 13 ignored

cargo test -p trusty-memory
  test result: FAILED. 526 passed; 2 failed; 4 ignored

cargo clippy -p trusty-memory --all-targets -- -D warnings   EXIT=0
cargo fmt --check                                            EXIT=0

bash scripts/check_line_cap.sh
  line-cap: measured 3688 tracked .rs file(s) (floor 500); 7 allowlisted, 0 violations — OK.
```

The 2 failures are `commands::doctor::tests::check_daemon_health_*`, pre-existing and tracked as #4897 (a live daemon on 7070-7079). Confirmed by stashing this branch's changes and running the same two tests on the unmodified base — both fail identically there. 28 new tests, all passing.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
