### PR TITLE
feat(trusty-memory): quarterly re-affirmation for Tier S facts + doctor check (#4890)

### DIFF
--- a/crates/trusty-memory/changelog.d/4890-tier-s-reaffirmation.md
+++ b/crates/trusty-memory/changelog.d/4890-tier-s-reaffirmation.md
@@ -1,0 +1,29 @@
+Added
+
+- **Quarterly re-affirmation for Tier S standing rules, and a `trusty-memory
+  doctor` check that reports overdue ones (issue #4890, ADR-0028 D8 point 4).**
+  The write-time cap of 20 landed in #4895 and stops the always-injected surface
+  from *growing*; it does nothing about a rule that was true when written and
+  quietly stopped being true. Such a rule keeps its slot forever and is
+  re-transmitted on every turn of every agent session.
+  - Every Tier S fact now carries `affirmed_at`, surfaced on both read paths:
+    the `list_prompt_facts` MCP tool and `GET /api/v1/kg/prompt-facts`. The
+    field is additive — pre-#4890 clients decode both responses unchanged.
+  - `affirmed_at` is **derived** from the active KG row's `valid_from` rather
+    than stored as a second column. `assert` already rewrites `valid_from` on
+    every assertion, so the value is correct by construction on all 93 existing
+    palaces with no migration, and no write path can forget to set it.
+    Re-asserting a rule **verbatim counts as re-affirmation** — that is the
+    deliberate choice, since retyping a rule is exactly the human review the ADR
+    asks for.
+  - `trusty-memory doctor` gains a fifth check, "Tier S re-affirmation". It
+    names every rule unaffirmed for more than 90 days, its age in days, and both
+    the re-affirmation path (`kg_assert`) and the retirement path
+    (`remove_prompt_fact` with the row's `subject` and `predicate`) — the same
+    way the cap's refusal message names the current 20.
+  - **The check never retires anything, and never returns `Fail`.** Promotion
+    and retirement of a standing rule are deliberate human acts (D8 point 3); a
+    `Fail` would flip `doctor`'s exit code and let a stale rule break a scripted
+    health gate, pressuring someone into deleting it unreviewed. A stale rule is
+    unreviewed, not broken, so the strongest verdict is `Warn`. When the daemon
+    is unreachable the check reports `Unknown`, never `Pass`.

--- a/crates/trusty-memory/src/commands/doctor/mod.rs
+++ b/crates/trusty-memory/src/commands/doctor/mod.rs
@@ -6,12 +6,13 @@
 //! `~/Library/LaunchAgents`, `~/.cache/fastembed`, and the lock file by hand
 //! to figure out what's wrong. `doctor` runs the same checks in one shot and
 //! prints a human-readable pass/fail report so the user can act immediately.
-//! What: a one-shot CLI command that runs four checks:
+//! What: a one-shot CLI command that runs five checks:
 //!   1. fastembed cache directory exists and is readable
 //!   2. launchd plist exists at `~/Library/LaunchAgents/com.trusty.memory.plist`
 //!      and contains the `FASTEMBED_CACHE_PATH` env var (macOS only)
 //!   3. The HTTP daemon responds to `GET /health` on its configured port
 //!   4. No obvious stale palace lock sidecar files (`*.lock`) under the data dir
+//!   5. No Tier S standing rule is overdue for re-affirmation (#4890, `tier_s`)
 //!
 //! Each check prints a ✅ or ❌ line. The command exits 0 if all critical
 //! checks pass, 1 otherwise.
@@ -23,12 +24,14 @@
 
 mod audit;
 mod checks;
+mod tier_s;
 
 use audit::audit_palaces;
 pub use audit::{PalaceAuditEntry, PalaceAuditStatus};
 #[cfg(target_os = "macos")]
 use checks::check_launchd_plist;
 use checks::{check_daemon_health, check_fastembed_cache, check_stale_palace_locks};
+use tier_s::check_tier_s_reaffirmation;
 
 use anyhow::Result;
 use colored::Colorize;
@@ -273,6 +276,9 @@ pub async fn handle_doctor() -> Result<()> {
 
     // Check 4: stale palace locks.
     results.push(check_stale_palace_locks());
+
+    // Check 5 (#4890): Tier S facts overdue for re-affirmation. Report only.
+    results.push(check_tier_s_reaffirmation().await);
 
     for r in &results {
         r.print();

--- a/crates/trusty-memory/src/commands/doctor/tier_s.rs
+++ b/crates/trusty-memory/src/commands/doctor/tier_s.rs
@@ -1,0 +1,180 @@
+//! Tier S re-affirmation check for `trusty-memory doctor` (#4890).
+//!
+//! Why: ADR-0028 D8 caps Tier S at 20 facts, which stops the always-injected
+//! surface from *growing*. It does nothing about a rule that was true when
+//! written and quietly stopped being true — that rule keeps its slot forever,
+//! is re-transmitted on every turn of every agent session, and nothing in the
+//! system can tell it has gone stale, because only its author can. D8 point 4's
+//! answer is a cadence: surface anything unaffirmed for a quarter and let a
+//! human decide. This module is that surface.
+//!
+//! What: fetches the live Tier S surface from the daemon's
+//! `GET /api/v1/kg/prompt-facts`, partitions it with
+//! [`crate::prompt_facts::stale_tier_s_facts`], and renders a `CheckResult`.
+//!
+//! **It never retires anything.** Promotion and retirement of a standing rule
+//! are deliberate human acts (D8 point 3); a diagnostic that silently evicted
+//! them would break the exact guarantee the write-time cap exists to protect.
+//! The strongest verdict this check can return is `Warn`, and even that is a
+//! deliberate choice: a stale rule is *unreviewed*, not broken, so it must not
+//! flip `doctor`'s exit code and turn a judgment call into a red build.
+//!
+//! Test: `no_facts_is_pass`, `fresh_facts_are_pass`,
+//! `stale_facts_warn_and_name_the_retirement_path`, `stale_facts_never_fail`
+//! (in the sibling `tier_s_tests.rs`) cover the interpreter fully; the thin
+//! HTTP fetch below is not unit-tested for the same reason
+//! `check_daemon_health`'s transport is not — it needs a live listener.
+
+use std::time::Duration;
+
+use super::CheckResult;
+use crate::prompt_facts::{
+    render_stale_tier_s_report, stale_tier_s_facts, TierSFact, TIER_S_MAX_FACTS,
+    TIER_S_REAFFIRM_DAYS,
+};
+
+/// Budget for the prompt-facts fetch.
+///
+/// Why: this is a read of at most [`TIER_S_MAX_FACTS`] rows out of an in-memory
+/// registry walk — nothing like the process-introspection work `/health` does,
+/// so it does not need `/health`'s 10 s allowance. 5 s is generous for the work
+/// and short enough that a wedged daemon cannot stall the whole `doctor` run.
+/// Test: not directly — exhausting it lands in the fetch's error branch, which
+/// returns `Unknown`; that branch needs a real listener and is exercised by
+/// running `trusty-memory doctor` against a live daemon.
+const FETCH_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// HTTP path serving the Tier S surface with `affirmed_at` per row.
+pub(super) const PROMPT_FACTS_PATH: &str = "/api/v1/kg/prompt-facts";
+
+/// Report Tier S facts overdue for re-affirmation.
+///
+/// Why: see the module docs — this is ADR-0028 D8 point 4.
+/// What: resolves the daemon address, fetches [`PROMPT_FACTS_PATH`], and hands
+/// the rows to [`interpret_tier_s_facts`]. Every failure to reach or decode the
+/// daemon yields `Unknown`, never `Pass`: not knowing whether standing rules
+/// are stale is not the same as knowing they are fresh.
+/// Test: `no_facts_is_pass`, `fresh_facts_are_pass`,
+/// `stale_facts_warn_and_name_the_retirement_path`, `stale_facts_never_fail`
+/// cover the interpreter; the transport is exercised end-to-end by running
+/// `trusty-memory doctor` against a live daemon.
+pub async fn check_tier_s_reaffirmation() -> CheckResult {
+    let label = "Tier S re-affirmation".to_string();
+
+    let addr = match trusty_common::read_daemon_addr("trusty-memory") {
+        Ok(Some(a)) => a,
+        Ok(None) => {
+            return CheckResult::unknown(
+                label,
+                "no daemon address recorded — the Tier S surface lives in the daemon's palace \
+                 registry, so its freshness is UNKNOWN while the daemon is down. Start it with \
+                 `trusty-memory service start` and re-run."
+                    .to_string(),
+            );
+        }
+        Err(e) => {
+            return CheckResult::unknown(
+                label,
+                format!("could not read the daemon address file: {e:#} — freshness is UNKNOWN"),
+            );
+        }
+    };
+    let base = if addr.starts_with("http://") || addr.starts_with("https://") {
+        addr
+    } else {
+        format!("http://{addr}")
+    };
+    let url = format!("{base}{PROMPT_FACTS_PATH}");
+
+    let client = match reqwest::Client::builder().timeout(FETCH_TIMEOUT).build() {
+        Ok(c) => c,
+        Err(e) => {
+            return CheckResult::unknown(label, format!("could not build HTTP client: {e}"));
+        }
+    };
+
+    let facts: Vec<TierSFact> = match client.get(&url).send().await {
+        Ok(resp) if resp.status().is_success() => match resp.json().await {
+            Ok(f) => f,
+            Err(e) => {
+                return CheckResult::unknown(
+                    label,
+                    format!(
+                        "{url} answered, but the body could not be decoded as Tier S facts: {e}. \
+                         A daemon predating #4890 does not report `affirmed_at`; upgrade it to \
+                         get a real answer."
+                    ),
+                );
+            }
+        },
+        Ok(resp) => {
+            return CheckResult::unknown(label, format!("{url} → {}", resp.status()));
+        }
+        Err(e) => {
+            return CheckResult::unknown(
+                label,
+                format!("{url} did not answer ({e}) — Tier S freshness is UNKNOWN"),
+            );
+        }
+    };
+
+    interpret_tier_s_facts(label, &facts, chrono::Utc::now())
+}
+
+/// Turn a Tier S snapshot into a verdict.
+///
+/// Why: split from the fetch so the judgment — which is the whole check — is
+/// testable against a fixed clock and a fixed surface, with no daemon, no
+/// network, and no dependence on whatever happens to be listening on 7070-7079
+/// while the suite runs (#4897).
+/// What: `Pass` when every fact was affirmed within [`TIER_S_REAFFIRM_DAYS`]
+/// (including the empty surface, which is trivially fresh), `Warn` otherwise —
+/// naming each stale rule, its age, and `remove_prompt_fact` as the retirement
+/// path, exactly as the cap's refusal message names the current 20. Never
+/// `Fail`: see the module docs.
+/// Test: `no_facts_is_pass`, `fresh_facts_are_pass`,
+/// `stale_facts_warn_and_name_the_retirement_path`,
+/// `stale_facts_never_fail`.
+pub(super) fn interpret_tier_s_facts(
+    label: String,
+    facts: &[TierSFact],
+    now: chrono::DateTime<chrono::Utc>,
+) -> CheckResult {
+    let stale = stale_tier_s_facts(facts, now);
+    if stale.is_empty() {
+        return CheckResult::pass(
+            label,
+            format!(
+                "{} of {TIER_S_MAX_FACTS} standing facts active, all affirmed within \
+                 {TIER_S_REAFFIRM_DAYS} days",
+                facts.len()
+            ),
+        );
+    }
+    CheckResult::warn(
+        label,
+        format!(
+            "{} of {} active standing fact(s) have not been re-affirmed in {TIER_S_REAFFIRM_DAYS} \
+             days (ADR-0028 D8). Tier S is injected into every turn of every session, so a rule \
+             that stopped being true is paid for on every turn until someone notices. Nothing was \
+             removed — retirement is a deliberate human act. Re-affirm a rule by asserting it \
+             again with `kg_assert` (re-asserting it verbatim counts), or retire it with \
+             `remove_prompt_fact` passing its `subject` and `predicate`. Overdue:{}",
+            stale.len(),
+            facts.len(),
+            render_stale_tier_s_report(&stale),
+        ),
+    )
+}
+
+/// Unit tests live in a sibling file so this module stays under the 500-SLOC
+/// production cap (the test file is classified as a test target).
+///
+/// Why: `doctor/mod.rs` is already at 472 SLOC against a 500 cap, so the suite
+/// could not go there either; a sibling `*_tests.rs` is this repo's established
+/// answer (see `memory_core/filter.rs`).
+/// What: pulls in `tier_s_tests.rs` as the `tests` module under `cfg(test)`.
+/// Test: the referenced file is itself the test suite.
+#[cfg(test)]
+#[path = "tier_s_tests.rs"]
+mod tests;

--- a/crates/trusty-memory/src/commands/doctor/tier_s_tests.rs
+++ b/crates/trusty-memory/src/commands/doctor/tier_s_tests.rs
@@ -1,0 +1,126 @@
+//! Unit tests for the Tier S re-affirmation doctor check (#4890).
+//!
+//! Why: the check's judgment must be provable without a daemon. Two
+//! `check_daemon_health_*` tests in this same module already fail whenever a
+//! live trusty-memory daemon happens to be listening on 7070-7079 (#4897) —
+//! that is exactly the coupling these tests must not repeat, so every case here
+//! drives [`super::interpret_tier_s_facts`] with a fixed clock and a literal
+//! fact list.
+//! What: covers the empty surface, the all-fresh surface, the stale surface's
+//! wording, and the invariant that a stale surface never escalates past `Warn`.
+//! Test: this file is the suite.
+
+use super::super::CheckStatus;
+use super::interpret_tier_s_facts;
+use crate::prompt_facts::{TierSFact, TIER_S_REAFFIRM_DAYS};
+use chrono::{DateTime, Duration, Utc};
+
+/// A fixed clock so no test depends on wall time.
+fn now() -> DateTime<Utc> {
+    DateTime::from_timestamp(1_800_000_000, 0).expect("fixed now")
+}
+
+fn fact(subject: &str, object: &str, days_ago: i64) -> TierSFact {
+    TierSFact {
+        subject: subject.into(),
+        predicate: "has_convention".into(),
+        object: object.into(),
+        affirmed_at: now() - Duration::days(days_ago),
+    }
+}
+
+/// Why: an empty Tier S surface is the state ADR-0028 §C3 says the estate
+/// starts from. Reporting "nothing to re-affirm" as anything but a pass would
+/// make `doctor` yellow on a correct, brand-new install.
+/// What: asserts `Pass` for an empty fact list.
+/// Test: itself.
+#[test]
+fn no_facts_is_pass() {
+    let r = interpret_tier_s_facts("Tier S".into(), &[], now());
+    assert_eq!(r.status, CheckStatus::Pass);
+}
+
+/// Why: the check must not nag about rules that were reviewed this quarter, or
+/// operators will learn to ignore it — which is the failure mode that made
+/// every soft mechanism before the cap useless (D8).
+/// What: two facts inside the window, including one sitting exactly on the
+/// threshold day, assert `Pass`.
+/// Test: itself.
+#[test]
+fn fresh_facts_are_pass() {
+    let facts = vec![
+        fact("conv-1", "Write plainly", 3),
+        fact("conv-2", "Never merge red CI", TIER_S_REAFFIRM_DAYS),
+    ];
+    let r = interpret_tier_s_facts("Tier S".into(), &facts, now());
+    assert_eq!(r.status, CheckStatus::Pass, "detail: {:?}", r.detail);
+}
+
+/// Why: the deliverable of a report-only check is the report. An operator who
+/// reads it must be able to act without a second lookup, so the message has to
+/// carry the rule text, its age, and the `remove_prompt_fact` retirement path
+/// — the same standard the cap's refusal message meets. It must also say
+/// plainly that nothing was removed, because "doctor flagged my standing rules"
+/// otherwise reads as "doctor deleted my standing rules".
+/// What: one stale and one fresh fact; asserts `Warn`, asserts the stale rule
+/// and its age appear, asserts the fresh one does not, and asserts both the
+/// re-affirmation and retirement paths are named.
+/// Test: itself.
+#[test]
+fn stale_facts_warn_and_name_the_retirement_path() {
+    let facts = vec![
+        fact("conv-old", "Clickable links always", 200),
+        fact("conv-new", "Write plainly", 1),
+    ];
+    let r = interpret_tier_s_facts("Tier S".into(), &facts, now());
+    assert_eq!(r.status, CheckStatus::Warn);
+    let d = r.detail.as_deref().unwrap_or("");
+    assert!(d.contains("conv-old"), "must name the stale subject: {d}");
+    assert!(
+        d.contains("Clickable links always"),
+        "must show the rule text: {d}"
+    );
+    assert!(d.contains("200d ago"), "must show the age: {d}");
+    assert!(
+        !d.contains("conv-new"),
+        "must not list a fact affirmed 1 day ago: {d}"
+    );
+    assert!(
+        d.contains("remove_prompt_fact"),
+        "must name the retirement path: {d}"
+    );
+    assert!(
+        d.contains("kg_assert"),
+        "must name the re-affirmation path: {d}"
+    );
+    assert!(
+        d.contains("Nothing was removed"),
+        "must state that it did not retire anything: {d}"
+    );
+    assert!(
+        d.contains("1 of 2"),
+        "must report stale-of-total so the scale is legible: {d}"
+    );
+}
+
+/// Why: this is the ticket's hard constraint, not a nicety. Promotion and
+/// retirement of a standing rule are deliberate human acts (ADR-0028 D8 point
+/// 3). `Fail` flips `doctor`'s exit code, so a `Fail` here would let a stale
+/// rule break a scripted health gate and pressure someone into deleting it
+/// without review — a slower path to the same silent eviction the check exists
+/// to avoid.
+/// What: a surface that is entirely, extremely stale still yields `Warn`.
+/// Test: itself.
+#[test]
+fn stale_facts_never_fail() {
+    let facts: Vec<TierSFact> = (0..20)
+        .map(|i| fact(&format!("conv-{i}"), "an ancient rule", 5_000))
+        .collect();
+    let r = interpret_tier_s_facts("Tier S".into(), &facts, now());
+    assert_eq!(
+        r.status,
+        CheckStatus::Warn,
+        "a report-only check must never escalate to Fail"
+    );
+    assert_ne!(r.status, CheckStatus::Fail);
+}

--- a/crates/trusty-memory/src/prompt_facts.rs
+++ b/crates/trusty-memory/src/prompt_facts.rs
@@ -15,16 +15,20 @@
 //! Tier S injection budget (#4888) — `TIER_S_MAX_FACTS`,
 //! `TIER_S_MAX_OBJECT_CHARS`, and the `check_tier_s_admission` write gate that
 //! enforces both, since this surface is injected on every turn of every
-//! session and its size is therefore a hard budget (ADR-0028 D2/D8).
+//! session and its size is therefore a hard budget (ADR-0028 D2/D8). Owns the
+//! re-affirmation vocabulary too (#4890) — [`TierSFact`],
+//! [`TIER_S_REAFFIRM_DAYS`], and [`stale_tier_s_facts`] — so the write gate and
+//! the `doctor` staleness report read the same primitives.
 //! Test: see the `tests` module — covers `is_hot_predicate`, the formatter
-//! grouping/sections, and the empty-input shortcut. The admission gate is
-//! proven at the handler surface instead: `dispatch_kg_assert_*`,
-//! `dispatch_add_alias_*`, `dispatch_discover_aliases_stops_at_tier_s_cap` in
-//! `tools::tests`, and `*_endpoint_enforces_tier_s_*` in
-//! `web::tests::prompt_tests`.
+//! grouping/sections, the empty-input shortcut, and the staleness partition.
+//! The admission gate is proven at the handler surface instead:
+//! `dispatch_kg_assert_*`, `dispatch_add_alias_*`,
+//! `dispatch_discover_aliases_stops_at_tier_s_cap` in `tools::tests`, and
+//! `*_endpoint_enforces_tier_s_*` in `web::tests::prompt_tests`.
 
 use crate::AppState;
 use anyhow::{anyhow, Context, Result};
+use chrono::{DateTime, Utc};
 
 /// Cached prompt-facts surface: raw triples and a pre-formatted Markdown block.
 ///
@@ -97,6 +101,47 @@ pub const TIER_S_MAX_FACTS: usize = 20;
 /// Test: `dispatch_kg_assert_rejects_object_over_char_limit`,
 /// `dispatch_kg_assert_accepts_object_at_char_limit`.
 pub const TIER_S_MAX_OBJECT_CHARS: usize = 80;
+
+/// Age at which a Tier S fact is reported as needing re-affirmation.
+///
+/// Why (#4890): the cap stops the surface growing; it does nothing about a
+/// rule that was true when written and quietly stopped being true. Nothing in
+/// the system can detect that — only the author can — so the mechanism has to
+/// be a prompt to a human on a cadence, not an inference. 90 days is ADR-0028
+/// D8 point 4's "quarterly": long enough that a genuinely standing rule is not
+/// nagged about (months is the tier's stated cadence, D3 table), short enough
+/// that a rule survives at most one quarter after it stops being true.
+/// What: 90, in days. Compared against [`TierSFact::affirmed_at`] by
+/// [`stale_tier_s_facts`]. It is a *reporting* threshold only — nothing in the
+/// codebase retires or down-ranks a fact for crossing it, because promotion and
+/// retirement are deliberate human acts (D8 point 3) and a surface that
+/// silently evicted standing rules would break the same guarantee the cap
+/// protects.
+/// Test: `stale_tier_s_facts_partitions_at_the_threshold`.
+pub const TIER_S_REAFFIRM_DAYS: i64 = 90;
+
+/// One active Tier S fact, with the moment it was last affirmed.
+///
+/// Why (#4890): ADR-0028 D8 point 4 requires each Tier S fact to carry an
+/// `affirmed_at`. It is **derived, not stored** — see [`gather_hot_facts`] for
+/// why that is the stronger design rather than a shortcut. Bundling it with the
+/// triple in one struct means every read surface (MCP `list_prompt_facts`, the
+/// HTTP endpoint, `doctor`) reports the same value from the same source instead
+/// of three call sites each deciding what "last affirmed" means.
+/// What: the `(subject, predicate, object)` trio plus `affirmed_at`. Serde
+/// derives are present because this struct *is* the wire shape of both read
+/// surfaces; `affirmed_at` serialises as RFC 3339.
+/// Test: `stale_tier_s_facts_partitions_at_the_threshold`,
+/// `list_prompt_facts_endpoint_returns_hot_triples`.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TierSFact {
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    /// When this fact was last written or re-asserted. See
+    /// [`gather_hot_facts`] for the derivation and its consequences.
+    pub affirmed_at: DateTime<Utc>,
+}
 
 /// Check whether `p` is one of the hot predicates surfaced via the prompt.
 ///
@@ -208,6 +253,61 @@ pub fn build_prompt_context(triples: &[(String, String, String)]) -> String {
 /// and skipped — one bad palace must not blank the prompt context.
 /// Test: `gather_hot_triples_skips_non_hot` (integration in `tools::tests`).
 pub async fn gather_hot_triples(state: &AppState) -> Result<Vec<(String, String, String)>> {
+    Ok(gather_hot_facts(state)
+        .await?
+        .into_iter()
+        .map(|f| (f.subject, f.predicate, f.object))
+        .collect())
+}
+
+/// Fetch every active hot-predicate fact across every palace, each carrying
+/// the moment it was last affirmed.
+///
+/// Why (#4890): ADR-0028 D8 point 4 says each Tier S fact "carries"
+/// `affirmed_at`. It is **derived from the active row's `valid_from`** rather
+/// than stored as its own column, and that is the stronger design here, not a
+/// shortcut:
+///
+/// - It is already exactly right. `KnowledgeGraph::assert` closes the prior
+///   interval and writes a fresh `valid_from` on **every** assert, including
+///   one whose object is byte-identical to what is already there. So the active
+///   row's `valid_from` is, by construction, "when a writer last asserted this
+///   fact" — which is the definition of re-affirmation this ticket wants.
+/// - **Re-asserting an identical fact counts as re-affirmation.** That is the
+///   deliberate choice (#4890): retyping a rule verbatim is precisely the human
+///   act D8 asks for, and demanding an edit to prove it would push authors to
+///   make a cosmetic change instead of a considered one. Deriving from
+///   `valid_from` makes that behaviour automatic instead of a rule six write
+///   paths must each remember to honour.
+/// - A stored column could only ever diverge by bug. Every hot-predicate write
+///   path already stamps `valid_from: Utc::now()`, so a parallel `affirmed_at`
+///   would carry the same value on every correct write and a wrong value on any
+///   path that forgot it. #4895 shipped a gate with a hole for exactly that
+///   reason — a write path nobody enumerated. Deriving removes the class: there
+///   is no path that can forget.
+/// - It costs no migration. The 93 live palaces already hold a correct value,
+///   so the check is meaningful on day one instead of reporting "unknown" for
+///   every pre-existing fact until it is next touched.
+///
+/// The cost, stated plainly: the active row cannot distinguish "the rule
+/// changed" from "the same rule was re-affirmed", and the original creation
+/// time moves out of the active row into history on the first re-assert. Both
+/// were already true before this change — `assert` has always overwritten
+/// `valid_from` — so nothing is lost that the KG still had.
+///
+/// A fact promoted by `discover_aliases` rather than by a person gets an
+/// `affirmed_at` that no human ever set. That is a real limitation and it is
+/// tracked as #4896 (whether auto-discovery should reach Tier S at all), not
+/// papered over here.
+///
+/// What: iterates every registered palace, reads `list_active`, keeps the hot
+/// predicates, and pairs each with its `valid_from`. A palace whose KG fails to
+/// read is logged at `warn` and skipped — one bad palace must not blank the
+/// prompt context.
+/// Test: `gather_hot_triples_skips_non_hot` (integration in `tools::tests`);
+/// the `affirmed_at` value round-trips through
+/// `list_prompt_facts_endpoint_returns_hot_triples`.
+pub async fn gather_hot_facts(state: &AppState) -> Result<Vec<TierSFact>> {
     // Why: `list_active` requires a finite limit; HOT_PREDICATES facts are
     // small in count by design (aliases / conventions, not free-form
     // memory), so 1024 is generous without risking unbounded reads on a
@@ -224,7 +324,15 @@ pub async fn gather_hot_triples(state: &AppState) -> Result<Vec<(String, String,
             Ok(triples) => {
                 for t in triples {
                     if is_hot_predicate(&t.predicate) {
-                        out.push((t.subject, t.predicate, t.object));
+                        out.push(TierSFact {
+                            subject: t.subject,
+                            predicate: t.predicate,
+                            object: t.object,
+                            // #4890: the active row's `valid_from` IS the last
+                            // affirmation — `assert` rewrites it on every
+                            // (re-)assertion. See this function's docs.
+                            affirmed_at: t.valid_from,
+                        });
                     }
                 }
             }
@@ -237,6 +345,55 @@ pub async fn gather_hot_triples(state: &AppState) -> Result<Vec<(String, String,
         }
     }
     Ok(out)
+}
+
+/// Partition the Tier S surface into the facts overdue for re-affirmation.
+///
+/// Why (#4890): the doctor check and its tests need the same answer, and the
+/// answer must be computable without a daemon, a registry, or a clock the test
+/// cannot control — hence `now` as a parameter rather than an internal
+/// `Utc::now()`. Sorting stalest-first is not cosmetic: when the surface is at
+/// its cap of 20 the operator's next action is "retire one", and the oldest
+/// unreviewed rule is the one to look at first.
+/// What: returns `(fact, age_in_days)` for every fact whose `affirmed_at` is
+/// more than [`TIER_S_REAFFIRM_DAYS`] days before `now`, stalest first. A fact
+/// affirmed exactly [`TIER_S_REAFFIRM_DAYS`] days ago is **not** stale — the
+/// threshold is "unaffirmed for longer than a quarter", so the boundary day
+/// itself still counts as affirmed. A fact with a future `affirmed_at` (clock
+/// skew, a hand-edited row) yields a negative age and is never reported.
+/// Test: `stale_tier_s_facts_partitions_at_the_threshold`.
+pub fn stale_tier_s_facts(facts: &[TierSFact], now: DateTime<Utc>) -> Vec<(&TierSFact, i64)> {
+    let mut stale: Vec<(&TierSFact, i64)> = facts
+        .iter()
+        .map(|f| (f, (now - f.affirmed_at).num_days()))
+        .filter(|(_, days)| *days > TIER_S_REAFFIRM_DAYS)
+        .collect();
+    stale.sort_by_key(|(_, days)| std::cmp::Reverse(*days));
+    stale
+}
+
+/// Render the stale-fact list as a numbered, retirement-ready block.
+///
+/// Why (#4890): "3 facts are stale" is a fact the operator cannot act on. To
+/// re-affirm a rule they need its text; to retire it they need its
+/// `(subject, predicate)` pair, because that pair — not a row id — is what
+/// `remove_prompt_fact` takes. This mirrors [`render_tier_s_inventory`], which
+/// makes the cap's refusal actionable for the same reason.
+/// What: one `N. subject predicate → object (last affirmed <D>d ago)` line per
+/// fact, 1-indexed, in the order given (stalest first).
+/// Test: `render_stale_tier_s_report_names_pair_and_age`.
+pub fn render_stale_tier_s_report(stale: &[(&TierSFact, i64)]) -> String {
+    let mut out = String::new();
+    for (i, (fact, days)) in stale.iter().enumerate() {
+        out.push_str(&format!(
+            "\n  {}. {} {} → {} (last affirmed {days}d ago)",
+            i + 1,
+            fact.subject,
+            fact.predicate,
+            fact.object,
+        ));
+    }
+    out
 }
 
 /// Render the active Tier S facts as a numbered, retirement-ready list.
@@ -481,5 +638,70 @@ mod tests {
         let facts_idx = out.find("### Facts").unwrap();
         assert!(aliases_idx < conventions_idx);
         assert!(conventions_idx < facts_idx);
+    }
+
+    /// Build a `TierSFact` affirmed `days_ago` days before `now`.
+    fn aged(subject: &str, days_ago: i64, now: DateTime<Utc>) -> TierSFact {
+        TierSFact {
+            subject: subject.into(),
+            predicate: "has_convention".into(),
+            object: format!("rule for {subject}"),
+            affirmed_at: now - chrono::Duration::days(days_ago),
+        }
+    }
+
+    /// Why (#4890): the whole check hinges on where the boundary sits, and an
+    /// off-by-one here either nags about a rule affirmed this quarter or lets
+    /// one slide a day past its review. It also has to survive the two inputs
+    /// that are not "some number of days ago": a fact affirmed in the future
+    /// (clock skew) must not be reported, and the order must be stalest-first
+    /// so the operator's first line is the rule most overdue.
+    /// What: five facts spanning both sides of the threshold plus a
+    /// future-dated one; asserts exactly which are returned and in what order.
+    /// Test: itself.
+    #[test]
+    fn stale_tier_s_facts_partitions_at_the_threshold() {
+        let now = DateTime::from_timestamp(1_800_000_000, 0).expect("fixed now");
+        let facts = vec![
+            aged("fresh", 1, now),
+            aged("ancient", 400, now),
+            // Exactly at the threshold — affirmed, NOT stale.
+            aged("boundary", TIER_S_REAFFIRM_DAYS, now),
+            // One day past — the first stale value.
+            aged("just-over", TIER_S_REAFFIRM_DAYS + 1, now),
+            aged("skewed", -30, now),
+        ];
+
+        let stale = stale_tier_s_facts(&facts, now);
+        let subjects: Vec<&str> = stale.iter().map(|(f, _)| f.subject.as_str()).collect();
+        assert_eq!(
+            subjects,
+            vec!["ancient", "just-over"],
+            "only facts strictly older than the threshold, stalest first"
+        );
+        assert_eq!(stale[0].1, 400, "age is reported in whole days");
+        assert_eq!(stale[1].1, TIER_S_REAFFIRM_DAYS + 1);
+    }
+
+    /// Why (#4890): the report is the entire deliverable of a report-only
+    /// check. If it names a fact without the `(subject, predicate)` pair the
+    /// operator has no way to reach `remove_prompt_fact`, which is what the
+    /// cap's own refusal message got right and what this must match.
+    /// What: asserts the rendered line carries the subject, the predicate, the
+    /// object, and the age.
+    /// Test: itself.
+    #[test]
+    fn render_stale_tier_s_report_names_pair_and_age() {
+        let now = DateTime::from_timestamp(1_800_000_000, 0).expect("fixed now");
+        let facts = vec![aged("conv-1", 200, now)];
+        let stale = stale_tier_s_facts(&facts, now);
+        let out = render_stale_tier_s_report(&stale);
+        assert!(out.contains("conv-1"), "must name the subject: {out}");
+        assert!(
+            out.contains("has_convention"),
+            "must name the predicate: {out}"
+        );
+        assert!(out.contains("rule for conv-1"), "must show the rule: {out}");
+        assert!(out.contains("200d ago"), "must show the age: {out}");
     }
 }

--- a/crates/trusty-memory/src/tools/kg_ops.rs
+++ b/crates/trusty-memory/src/tools/kg_ops.rs
@@ -139,11 +139,18 @@ pub(crate) async fn handle_add_alias(state: &AppState, args: Value) -> Result<Va
 }
 
 pub(crate) async fn handle_list_prompt_facts(state: &AppState, _args: Value) -> Result<Value> {
-    let triples = crate::prompt_facts::gather_hot_triples(state).await?;
-    let payload: Vec<Value> = triples
+    // #4890: each row carries `affirmed_at` so a caller reviewing the surface
+    // can see which rules are overdue without shelling out to `doctor`.
+    let facts = crate::prompt_facts::gather_hot_facts(state).await?;
+    let payload: Vec<Value> = facts
         .into_iter()
-        .map(|(subject, predicate, object)| {
-            json!({ "subject": subject, "predicate": predicate, "object": object })
+        .map(|f| {
+            json!({
+                "subject": f.subject,
+                "predicate": f.predicate,
+                "object": f.object,
+                "affirmed_at": f.affirmed_at.to_rfc3339(),
+            })
         })
         .collect();
     Ok(json!({ "facts": payload }))

--- a/crates/trusty-memory/src/tools/tests.rs
+++ b/crates/trusty-memory/src/tools/tests.rs
@@ -2716,6 +2716,92 @@ async fn dispatch_kg_assert_retracted_fact_frees_a_slot() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// #4890 — Tier S re-affirmation (ADR-0028 D8 point 4)
+// ---------------------------------------------------------------------------
+
+/// Why (#4890): this is the ticket's central semantic decision and the only
+/// place it can be proven. `affirmed_at` is derived from the active row's
+/// `valid_from` rather than stored, and the decision that re-asserting a rule
+/// **verbatim** counts as re-affirmation depends entirely on `assert`
+/// rewriting `valid_from` even when the object is byte-identical. Nothing in
+/// this crate owns that behaviour — it is `KgStoreRedb::assert`'s — so a change
+/// there (an "identical write is a no-op" optimisation, say) would silently
+/// turn the doctor check into a nag that no amount of re-affirmation could
+/// clear. This test is the tripwire for that.
+/// What: asserts a fact, records its `affirmed_at`, sleeps past the storage
+/// layer's millisecond resolution, re-asserts the SAME subject/predicate/object,
+/// and asserts the surface still holds one fact whose `affirmed_at` moved
+/// strictly forward.
+#[tokio::test]
+async fn reasserting_an_identical_fact_refreshes_affirmed_at() {
+    let (state, _tmp) = test_state();
+    dispatch_tool(&state, "palace_create", json!({"name": "affirm"}))
+        .await
+        .expect("palace_create");
+
+    let write = json!({
+        "palace": "affirm",
+        "subject": "conv-1",
+        "predicate": "has_convention",
+        "object": "Write plainly",
+    });
+
+    dispatch_tool(&state, "kg_assert", write.clone())
+        .await
+        .expect("first assert");
+    let first = affirmed_at_of(&state, "conv-1").await;
+
+    // Timestamps persist at millisecond resolution, so two asserts inside the
+    // same millisecond would be indistinguishable and the comparison below
+    // would be measuring the clock rather than the behaviour.
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    dispatch_tool(&state, "kg_assert", write)
+        .await
+        .expect("re-asserting the identical fact must be admitted");
+    let second = affirmed_at_of(&state, "conv-1").await;
+
+    assert!(
+        second > first,
+        "re-asserting a verbatim-identical rule must refresh affirmed_at \
+         (first={first}, second={second})",
+    );
+
+    let listed = dispatch_tool(&state, "list_prompt_facts", json!({}))
+        .await
+        .expect("list_prompt_facts");
+    assert_eq!(
+        listed["facts"].as_array().expect("facts array").len(),
+        1,
+        "a re-affirmation supersedes rather than adds: {listed}",
+    );
+}
+
+/// Read the `affirmed_at` of the single Tier S fact with the given subject.
+///
+/// Parses rather than string-compares: `to_rfc3339` emits 0, 3, 6, or 9
+/// fractional digits depending on the value, so two RFC 3339 strings do not
+/// order lexicographically (a whole-second timestamp emits no fraction at all,
+/// and `+` sorts before `.`).
+async fn affirmed_at_of(state: &AppState, subject: &str) -> chrono::DateTime<chrono::Utc> {
+    let listed = dispatch_tool(state, "list_prompt_facts", json!({}))
+        .await
+        .expect("list_prompt_facts");
+    let facts = listed["facts"].as_array().expect("facts array").clone();
+    let row = facts
+        .iter()
+        .find(|f| f["subject"] == subject)
+        .unwrap_or_else(|| panic!("no Tier S fact for {subject}: {listed}"))
+        .clone();
+    let raw = row["affirmed_at"]
+        .as_str()
+        .unwrap_or_else(|| panic!("affirmed_at missing or not a string: {row}"));
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .unwrap_or_else(|e| panic!("affirmed_at {raw:?} is not RFC 3339: {e}"))
+        .with_timezone(&chrono::Utc)
+}
+
 /// Why (#4888): 80 characters is the boundary and must be inclusive — a rule
 /// of exactly 80 chars is legal (ADR-0028 D2).
 #[tokio::test]

--- a/crates/trusty-memory/src/web/prompt_context.rs
+++ b/crates/trusty-memory/src/web/prompt_context.rs
@@ -149,13 +149,17 @@ pub(super) struct AddAliasRequest {
 /// Why: `list_prompt_facts` returns a structured array rather than the
 /// pre-formatted Markdown so dashboards and tooling can render their own
 /// views over the raw data.
-/// What: subject/predicate/object string trio matching the underlying KG row.
+/// What: subject/predicate/object string trio matching the underlying KG row,
+/// plus the RFC 3339 `affirmed_at` (#4890) that `trusty-memory doctor` reads to
+/// find rules overdue for re-affirmation. The field is purely additive — every
+/// pre-#4890 client keeps decoding the response unchanged.
 /// Test: `list_prompt_facts_endpoint_returns_hot_triples`.
 #[derive(Serialize)]
 pub(super) struct PromptFactRow {
     subject: String,
     predicate: String,
     object: String,
+    affirmed_at: String,
 }
 
 /// Query parameters for `DELETE /api/v1/kg/prompt-facts`.
@@ -275,22 +279,26 @@ pub(super) async fn add_alias_handler(
 /// Why: Mirrors the `list_prompt_facts` MCP tool. Returning the raw triples
 /// (rather than the formatted block) lets dashboards group, search, and
 /// edit them with their own UI.
-/// What: Calls `gather_hot_triples` over the live registry and serialises
-/// each row as `{subject, predicate, object}`.
+/// What: Calls `gather_hot_facts` over the live registry and serialises each
+/// row as `{subject, predicate, object, affirmed_at}`. This is the endpoint
+/// `trusty-memory doctor`'s Tier S re-affirmation check reads (#4890) — it goes
+/// through the daemon rather than opening 93 palace files directly, so a
+/// diagnostic never contends with the daemon's write lock.
 /// Test: `list_prompt_facts_endpoint_returns_hot_triples`.
 pub(super) async fn list_prompt_facts_handler(
     State(state): State<AppState>,
     Query(_q): Query<PromptFactsQuery>,
 ) -> Result<Json<Vec<PromptFactRow>>, ApiError> {
-    let triples = crate::prompt_facts::gather_hot_triples(&state)
+    let facts = crate::prompt_facts::gather_hot_facts(&state)
         .await
-        .map_err(|e| ApiError::internal(format!("gather_hot_triples: {e:#}")))?;
-    let rows: Vec<PromptFactRow> = triples
+        .map_err(|e| ApiError::internal(format!("gather_hot_facts: {e:#}")))?;
+    let rows: Vec<PromptFactRow> = facts
         .into_iter()
-        .map(|(subject, predicate, object)| PromptFactRow {
-            subject,
-            predicate,
-            object,
+        .map(|f| PromptFactRow {
+            subject: f.subject,
+            predicate: f.predicate,
+            object: f.object,
+            affirmed_at: f.affirmed_at.to_rfc3339(),
         })
         .collect();
     Ok(Json(rows))

--- a/crates/trusty-memory/src/web/tests/prompt_tests.rs
+++ b/crates/trusty-memory/src/web/tests/prompt_tests.rs
@@ -184,6 +184,25 @@ async fn list_prompt_facts_endpoint_returns_hot_triples() {
         !arr.iter().any(|r| r["predicate"] == "works_at"),
         "non-hot triple leaked into prompt facts: {arr:?}"
     );
+
+    // #4890: this endpoint is what `trusty-memory doctor`'s Tier S
+    // re-affirmation check reads, and it decodes the body straight into
+    // `Vec<TierSFact>`. Decoding it the same way here pins the wire contract the
+    // check depends on — a dropped or renamed `affirmed_at` would leave the
+    // check permanently reporting "could not determine" against a healthy
+    // daemon, which is exactly the kind of silent degradation nothing else
+    // would catch.
+    let facts: Vec<crate::prompt_facts::TierSFact> =
+        serde_json::from_slice(&bytes).expect("body must decode as the doctor decodes it");
+    let alias = facts
+        .iter()
+        .find(|f| f.subject == "ts")
+        .expect("ts alias present");
+    assert!(
+        (chrono::Utc::now() - alias.affirmed_at).num_seconds() < 60,
+        "affirmed_at must be the write time, got {}",
+        alias.affirmed_at,
+    );
 }
 
 /// Why (issue #42): `DELETE /api/v1/kg/prompt-facts` must retract the


### PR DESCRIPTION
Closes #4890. Implements ADR-0028 D8 point 4.

## Defect

The write-time cap of 20 (#4895) stops the always-injected Tier S surface from *growing*. It does nothing about a rule that was true when written and quietly stopped being true. Such a rule keeps its slot forever, is re-transmitted on every turn of every agent session, and nothing in the system can detect it — only its author can.

## Resolution

**`affirmed_at` on every Tier S fact**, exposed on both read surfaces: the `list_prompt_facts` MCP tool and `GET /api/v1/kg/prompt-facts`. The field is additive; pre-#4890 clients decode both responses unchanged.

**It is derived from the active KG row's `valid_from`, not stored as a second column.** `KgStoreRedb::assert` / `batch_assert` already rewrite `valid_from` on every assertion — including one whose object is byte-identical — so the value is correct by construction on all 93 existing palaces with no migration, and there is no write path that can forget to set it. A parallel stored column could only ever diverge from `valid_from` by bug; #4895 shipped a gate with a hole for exactly that reason.

**Re-asserting a rule verbatim counts as re-affirmation.** Retyping a rule is precisely the human act D8 asks for; demanding an edit to prove it would push authors toward a cosmetic change instead of a considered one.

**A fifth `trusty-memory doctor` check** naming every rule unaffirmed for more than 90 days, its age in days, and both the re-affirmation path (`kg_assert`) and the retirement path (`remove_prompt_fact` with the row's `subject` and `predicate`) — the same way the cap's refusal message names the current 20.

**It never retires anything, and never returns `Fail`.** Promotion and retirement of a standing rule are deliberate human acts (D8 point 3). `Fail` flips doctor's exit code, so a stale rule could break a scripted health gate and pressure someone into deleting it unreviewed — a slower path to the same silent eviction the check exists to avoid. A stale rule is unreviewed, not broken, so `Warn` is the honest ceiling. An unreachable or pre-#4890 daemon reports `Unknown`, never `Pass`.

## Write-path audit

Every production `kg.assert` call site was enumerated and read in full (no truncated grep). Only six can create a hot-predicate triple, and all six already route through `check_tier_s_admission`, whose `Triple` carries `valid_from: Utc::now()` — so all six set `affirmed_at` with no change needed. The remaining production asserters emit fixed non-hot predicates (`bootstrap`: `has_language`/`has_version`/…; `kg_extract` via `tools::helpers` and `commands::kg_rebuild`: `tags`/`contains`/`is-a`/…; `dream::cycle`: `superseded_by`/`alias_of` — note `alias_of` is not the hot `is_alias_for`), and `kuzu_migrate` explicitly refuses hot predicates.

## Evidence

Each new test was proven to fail without the behaviour it claims to cover, by mutating the production code and observing the failure:

| Mutation | Test that caught it |
|---|---|
| `> TIER_S_REAFFIRM_DAYS` → `>=` | `stale_tier_s_facts_partitions_at_the_threshold`, `fresh_facts_are_pass` |
| sort ascending instead of stalest-first | `stale_tier_s_facts_partitions_at_the_threshold` |
| `CheckResult::warn` → `fail` | `stale_facts_never_fail`, `stale_facts_warn_and_name_the_retirement_path` |
| `batch_assert` treats an identical re-assert as a no-op | `reasserting_an_identical_fact_refreshes_affirmed_at` |
| `affirmed_at` dropped from the wire shape | `list_prompt_facts_endpoint_returns_hot_triples` |

The fourth is the important one: it is the tripwire for the derivation. If `assert` ever gained an "identical write is a no-op" optimisation, the doctor check would become a nag no amount of re-affirmation could clear.

Live run against the running daemon:

```
✅ Tier S re-affirmation — 0 of 20 standing facts active, all affirmed within 90 days
```

Zero active facts matches ADR-0028 §C3 — the surface starts empty.

## Gates

```
cargo test -p trusty-memory     → 524 passed; 2 failed; 4 ignored
cargo clippy -p trusty-memory --all-targets -- -D warnings → EXIT=0
cargo fmt --check               → EXIT=0
check_line_cap.sh               → 3690 files, 7 allowlisted, 0 violations — OK
check_test_pointers.sh          → 21551 citations, 0 dangling pointers — OK
```

The 2 failures are `commands::doctor::tests::check_daemon_health_*`, pre-existing and tracked as #4897 (they fail whenever a live daemon is listening on 7070-7079). Confirmed rather than assumed: stashing this branch's changes and running `cargo test -p trusty-memory commands::doctor` on pristine `origin/main` produced the same two failures, `13 passed; 2 failed`. Neither test, nor `check_daemon_health` itself, is touched by this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
