### PR TITLE
fix(trusty-mpm): provision new worktrees at <project-root>/.worktrees (#4270)

### DIFF
--- a/crates/trusty-mpm/changelog.d/4270-provision-worktrees.md
+++ b/crates/trusty-mpm/changelog.d/4270-provision-worktrees.md
@@ -3,3 +3,4 @@ Changed
 - new sessions provisioned from a repo URL now get their worktree at `<project-root>/.worktrees/<name>`, following the git convention, instead of nesting it inside a `.base` bare clone (closes [#4270](https://github.com/bobmatnyc/trusty-tools/issues/4270))
   - the base checkout is now the project directory's own clone, the same one the in-project spawn path establishes, so both paths share one base clone per project
   - existing `.base` stores are left exactly as they are — still discoverable via `git worktree list`, still working — and provisioning refuses loudly rather than moving or deleting one; retiring `.base` stays a manual operator step
+  - a project directory holding git or trusty-mpm state (`.git`, `.base`, or `.worktrees`) is never offered for `mv`-aside recovery and never renamed by the old-layout migrator; the presence probe treats an unreadable entry as present, so a permissions blip cannot read as "no git dir"

--- a/crates/trusty-mpm/changelog.d/4270-provision-worktrees.md
+++ b/crates/trusty-mpm/changelog.d/4270-provision-worktrees.md
@@ -1,0 +1,5 @@
+Changed
+
+- new sessions provisioned from a repo URL now get their worktree at `<project-root>/.worktrees/<name>`, following the git convention, instead of nesting it inside a `.base` bare clone (closes [#4270](https://github.com/bobmatnyc/trusty-tools/issues/4270))
+  - the base checkout is now the project directory's own clone, the same one the in-project spawn path establishes, so both paths share one base clone per project
+  - existing `.base` stores are left exactly as they are — still discoverable via `git worktree list`, still working — and provisioning refuses loudly rather than moving or deleting one; retiring `.base` stays a manual operator step

--- a/crates/trusty-mpm/changelog.d/4270-provision-worktrees.md
+++ b/crates/trusty-mpm/changelog.d/4270-provision-worktrees.md
@@ -4,3 +4,4 @@ Changed
   - the base checkout is now the project directory's own clone, the same one the in-project spawn path establishes, so both paths share one base clone per project
   - existing `.base` stores are left exactly as they are — still discoverable via `git worktree list`, still working — and provisioning refuses loudly rather than moving or deleting one; retiring `.base` stays a manual operator step
   - a project directory holding git or trusty-mpm state (`.git`, `.base`, or `.worktrees`) is never offered for `mv`-aside recovery and never renamed by the old-layout migrator; the presence probe treats an unreadable entry as present, so a permissions blip cannot read as "no git dir"
+  - the base clone's `.worktrees/` is excluded in `.git/info/exclude`, as the in-project path already does — without it `git clean -ffd` in the base deletes every session worktree including uncommitted work (single-force `clean` skips them; `-ff` does not)

--- a/crates/trusty-mpm/src/core/harness_root.rs
+++ b/crates/trusty-mpm/src/core/harness_root.rs
@@ -65,6 +65,44 @@ pub const SESSIONS_DIR: &str = "sessions";
 /// `provision_in_leaves_an_existing_dot_base_store_untouched`.
 pub(crate) const BASE_CLONE_DIRNAME: &str = ".base";
 
+/// Name the protected state `dir` holds, or `None` when it holds none.
+///
+/// Why (#4270): two call sites decide whether a directory may be renamed aside
+/// — `provisioner::workspace`'s stale-base recovery hint and
+/// `daemon::managed_routes::inproject::migrate_old_layout_aside`. Both used to
+/// ask a narrower question (is there a `.base`? is there a `.git`?) and both
+/// were wrong in the same way: the thing that must never be moved is any
+/// directory git or trusty-mpm keeps real state in. Renaming one orphans every
+/// worktree beneath it, which is the #3605 failure with the project directory
+/// as its target. One predicate means the two guards cannot drift apart.
+///
+/// The probe is deliberately fail-SAFE rather than accurate. `Path::exists`
+/// answers `false` for a directory it lacks permission to stat, so an EACCES
+/// blip on `.git` reads exactly like a project with no git directory at all —
+/// and the caller then renames live work. Anything that is not a definite
+/// `NotFound` therefore counts as present: the cost of a false positive is a
+/// refusal the operator can act on, the cost of a false negative is lost work.
+/// What: returns the first of `.git`, `.base`, or `.worktrees` found under
+/// `dir`, so the caller's message can name what it found; `None` only when all
+/// three are definitely absent.
+/// Test: `protected_state_in_names_each_protected_entry`,
+/// `protected_state_in_is_none_for_a_foreign_directory`,
+/// `protected_state_in_treats_an_unreadable_entry_as_present`.
+pub(crate) fn protected_state_in(dir: &Path) -> Option<&'static str> {
+    [
+        ".git",
+        BASE_CLONE_DIRNAME,
+        crate::session_manager::decommission::WORKTREES_DIRNAME,
+    ]
+    .into_iter()
+    .find(|name| {
+        !matches!(
+            std::fs::symlink_metadata(dir.join(name)),
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound
+        )
+    })
+}
+
 /// Environment variable carrying the managed session id inside a tm pane.
 const MANAGED_SESSION_ID_ENV: &str = "TM_MANAGED_SESSION_ID";
 

--- a/crates/trusty-mpm/src/core/harness_root.rs
+++ b/crates/trusty-mpm/src/core/harness_root.rs
@@ -44,20 +44,26 @@ pub const FRAMEWORK_DIR: &str = "framework";
 /// Test: `session_dir_is_per_session_under_the_harness_root`.
 pub const SESSIONS_DIR: &str = "sessions";
 
-/// The shared bare clone trusty-mpm provisions inside a managed project.
+/// The shared bare clone trusty-mpm provisioned inside a managed project
+/// before #4270.
 ///
-/// Why: `provisioner::workspace` clones the shared base into `<project>/.base`
-/// and adds every managed session's worktree from THERE, so those worktrees'
-/// git common dir is the bare clone — a directory INSIDE the project, not the
-/// project. This is not a path guess: it is the same directory name
-/// `provisioner::workspace::BASE_CHECKOUT_DIRNAME` writes and
-/// `session_manager::worktree_registry` interrogates.
+/// Why: `provisioner::workspace` used to clone the shared base into
+/// `<project>/.base` and add every managed session's worktree from THERE, so
+/// those worktrees' git common dir is the bare clone — a directory INSIDE the
+/// project, not the project. #4270 retired that store: provisioning now clones
+/// the base into `<project>` itself and puts worktrees at
+/// `<project>/.worktrees/<id>`, matching the in-project path. Existing `.base`
+/// stores were deliberately NOT migrated, so this mapping stays load-bearing
+/// for every worktree already under one, and the name is also what
+/// `provisioner::workspace`'s own guard checks before refusing to clone over a
+/// live legacy store.
 /// What: `.base`. The name alone is never sufficient — see
 /// [`map_base_clone_to_project`], which also requires the directory to be a
 /// BARE repository before rewriting it.
 /// Test: `harness_root_maps_a_base_clone_back_to_the_project`,
-/// `harness_root_for_a_non_bare_repo_named_base_is_itself`.
-const BASE_CLONE_DIRNAME: &str = ".base";
+/// `harness_root_for_a_non_bare_repo_named_base_is_itself`,
+/// `provision_in_leaves_an_existing_dot_base_store_untouched`.
+pub(crate) const BASE_CLONE_DIRNAME: &str = ".base";
 
 /// Environment variable carrying the managed session id inside a tm pane.
 const MANAGED_SESSION_ID_ENV: &str = "TM_MANAGED_SESSION_ID";

--- a/crates/trusty-mpm/src/core/harness_root_tests.rs
+++ b/crates/trusty-mpm/src/core/harness_root_tests.rs
@@ -333,3 +333,88 @@ fn session_scope_rejects_a_path_traversal_segment() {
         );
     }
 }
+
+/// #4270: the predicate names each protected entry it finds.
+///
+/// Why: two guards refuse a rename based on this answer, and each wants to say
+/// what it found. A predicate that recognised only one of the three names is
+/// exactly the hole the first round of #4270 shipped — `.base` was guarded and
+/// `.worktrees` was not.
+/// What: asserts each of `.git`, `.base`, `.worktrees` is detected on its own.
+/// Test: this function IS the test.
+#[test]
+fn protected_state_in_names_each_protected_entry() {
+    for name in [".git", ".base", ".worktrees"] {
+        let tmp = crate::test_support::hermetic_temp_dir();
+        let dir = tmp.path().join("owner").join("repo");
+        std::fs::create_dir_all(dir.join(name)).expect("create protected entry");
+        assert_eq!(
+            protected_state_in(&dir),
+            Some(name),
+            "{name} must be recognised as protected state"
+        );
+    }
+}
+
+/// #4270: a directory carrying none of the protected entries is not protected.
+///
+/// Why: the guards must still let genuine foreign debris through to the
+/// quarantine path, or the stale-clone recovery #1937 added stops working.
+/// What: a non-empty directory holding only a stray `HEAD` — the crashed-clone
+/// shape — reads as unprotected.
+/// Test: this function IS the test.
+#[test]
+fn protected_state_in_is_none_for_a_foreign_directory() {
+    let tmp = crate::test_support::hermetic_temp_dir();
+    let dir = tmp.path().join("owner").join("repo");
+    std::fs::create_dir_all(&dir).expect("create dir");
+    std::fs::write(dir.join("HEAD"), "ref: refs/heads/main\n").expect("write HEAD");
+    assert_eq!(protected_state_in(&dir), None);
+}
+
+/// #4270: an entry that cannot be stat'd counts as PRESENT, not absent.
+///
+/// Why: this is the whole reason the probe is not `Path::exists`, which maps
+/// EACCES to `false` — indistinguishable from "no git dir". Under that
+/// spelling a permissions blip on `.git` lets `migrate_old_layout_aside` rename
+/// a live project directory. The failure is silent and the data is gone, so the
+/// fail-safe direction has to be proven, not assumed.
+/// What: chmods the containing directory to 000 so stat'ing a child returns
+/// EACCES, then asserts the probe still reports protected. Skips when running
+/// as root (root bypasses the permission check) or when the platform lets the
+/// stat through anyway.
+/// Test: this function IS the test.
+#[cfg(unix)]
+#[test]
+fn protected_state_in_treats_an_unreadable_entry_as_present() {
+    use std::os::unix::fs::PermissionsExt as _;
+
+    let tmp = crate::test_support::hermetic_temp_dir();
+    let dir = tmp.path().join("owner").join("repo");
+    std::fs::create_dir_all(dir.join(".git")).expect("create .git");
+
+    let restore = std::fs::metadata(&dir).expect("stat dir").permissions();
+    std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o000)).expect("chmod 000");
+
+    let unreadable = std::fs::symlink_metadata(dir.join(".git"))
+        .err()
+        .is_some_and(|e| e.kind() != std::io::ErrorKind::NotFound);
+    let observed = protected_state_in(&dir);
+
+    // Restore before asserting so a failure cannot leave an undeletable tempdir.
+    std::fs::set_permissions(&dir, restore).expect("restore permissions");
+
+    if !unreadable {
+        eprintln!(
+            "protected_state_in_treats_an_unreadable_entry_as_present: stat still \
+             succeeds (running as root?), skipping"
+        );
+        return;
+    }
+    assert_eq!(
+        observed,
+        Some(".git"),
+        "an entry that cannot be stat'd must count as present — Path::exists would \
+         report false here and the caller would rename live work"
+    );
+}

--- a/crates/trusty-mpm/src/core/worktree_naming.rs
+++ b/crates/trusty-mpm/src/core/worktree_naming.rs
@@ -1,20 +1,25 @@
-//! Shared per-session git-worktree branch naming convention (issue #2032).
+//! Shared per-session git-worktree conventions (issue #2032, extended #4270).
 //!
-//! Why: both `daemon::managed_routes::inproject` (feature = `"daemon"`;
-//! creates per-session worktrees/branches) and `session_manager::decommission`
-//! (unconditional — compiled with or without the `daemon` feature; removes
-//! them) must agree on EXACTLY the same `session/<name>` branch convention.
-//! Placing the convention here, in `core` (always compiled, no feature gate),
-//! lets the unconditional `session_manager` module depend on it WITHOUT
-//! pulling in the feature-gated `daemon` module — the reverse dependency
-//! direction is what caused the bug this module fixes: `decommission.rs`
-//! previously hardcoded `git branch -D <leaf>` (missing the `session/` prefix
-//! `create_session_worktree` actually uses), so the branch-delete step always
-//! targeted a nonexistent ref and silently no-opped — every session's branch
-//! leaked forever.
+//! Why: modules on BOTH sides of the `daemon` feature gate create and destroy
+//! per-session worktrees, and every one of them must agree on the same
+//! conventions. `daemon::managed_routes::inproject` (feature = `"daemon"`)
+//! creates them, `session_manager::decommission` (unconditional) removes them,
+//! and since #4270 `provisioner::workspace` (also unconditional) creates the
+//! identical topology from the clone-from-URL path. Placing the conventions
+//! here, in `core` (always compiled, no feature gate), lets the unconditional
+//! modules depend on them WITHOUT pulling in the feature-gated `daemon` module.
+//! The reverse dependency direction is what caused the bug this module was
+//! created to fix: `decommission.rs` hardcoded `git branch -D <leaf>`, missing
+//! the `session/` prefix `create_session_worktree` actually uses, so the
+//! branch-delete step targeted a nonexistent ref and silently no-opped — every
+//! session's branch leaked forever.
 //! What: [`worktree_branch_for`] builds the `session/<name>` branch name for a
-//! given worktree leaf/session name.
-//! Test: `worktree_branch_for_adds_session_prefix`.
+//! given worktree leaf/session name; [`ensure_worktrees_gitignored`] keeps the
+//! `.worktrees/` directory out of the base clone's `git status` and out of
+//! reach of `git clean -ffd`.
+//! Test: `worktree_branch_for_adds_session_prefix`,
+//! `ensure_worktrees_gitignored_idempotent`,
+//! `worktrees_exclude_entry_protects_against_double_force_clean`.
 
 /// Compute the per-session branch name for a worktree leaf/session name.
 ///
@@ -27,6 +32,81 @@
 /// Test: `worktree_branch_for_adds_session_prefix`.
 pub fn worktree_branch_for(name: &str) -> String {
     format!("session/{name}")
+}
+
+/// Add `.worktrees/` to `base_path`'s `.git/info/exclude`, idempotently.
+///
+/// Why: this is a DATA-LOSS guard, not cosmetics. Without the entry the
+/// per-session worktrees are untracked content in the base clone, and
+/// `git clean -ffd` there deletes them outright — uncommitted session work
+/// included. Single-force `clean` is safe (git refuses to descend into a
+/// nested repository, reporting `Skipping repository .worktrees/<id>`), which
+/// is why this reads as harmless until someone force-cleans a dirty base. With
+/// the entry, `.worktrees/` is ignored and `-ffd` removes nothing. Measured
+/// against real git 2.54.0 in a throwaway repo built to the shipping topology:
+///
+/// | command | without entry | with entry |
+/// |---|---|---|
+/// | `git clean -fd` / `-xfd` | `Skipping repository` | untouched |
+/// | `git clean -ffd` | `Removing .worktrees/` | untouched |
+/// | `git clean -xffd` | `Removing .worktrees/` | `Removing .worktrees/` |
+///
+/// `-xffd` defeats it because `-x` discards ignore rules; nothing short of not
+/// running that command protects against it. The secondary benefit is the one
+/// this started as: `git status` in the base stays clean.
+///
+/// Writing to `.git/info/exclude` rather than `.gitignore` keeps the entry
+/// local to the clone and never touches a committed file.
+/// What: creates `<base>/.git/info/` if absent, then appends the entry only
+/// when it is not already present. The read-then-append window means
+/// concurrent callers racing at first launch may each observe an absent entry
+/// and both append, producing a duplicate line; git tolerates duplicate
+/// patterns (the same set is matched), so this is safe, and single-caller
+/// invocations are strictly idempotent. Returns `Ok(())` on success or when
+/// the entry already exists; propagates I/O errors.
+/// Test: `ensure_worktrees_gitignored_idempotent`,
+/// `worktrees_exclude_entry_protects_against_double_force_clean`.
+pub fn ensure_worktrees_gitignored(base_path: &std::path::Path) -> Result<(), String> {
+    // The entry is the shared directory name plus a trailing slash, so the
+    // pattern can never drift from the directory the provisioners create.
+    let entry_pattern = format!(
+        "{}/",
+        crate::session_manager::decommission::WORKTREES_DIRNAME
+    );
+
+    let info_dir = base_path.join(".git").join("info");
+    std::fs::create_dir_all(&info_dir)
+        .map_err(|e| format!("could not create .git/info/ at {}: {e}", info_dir.display()))?;
+
+    let exclude_path = info_dir.join("exclude");
+    let existing = std::fs::read_to_string(&exclude_path).unwrap_or_default();
+
+    // Idempotent: skip if the entry is already present.
+    if existing.lines().any(|line| line.trim() == entry_pattern) {
+        return Ok(());
+    }
+
+    // Append with a leading newline when the file does not already end with one.
+    let entry = if existing.is_empty() || existing.ends_with('\n') {
+        format!("{entry_pattern}\n")
+    } else {
+        format!("\n{entry_pattern}\n")
+    };
+
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&exclude_path)
+        .map_err(|e| format!("could not open .git/info/exclude: {e}"))?;
+    file.write_all(entry.as_bytes())
+        .map_err(|e| format!("could not write .git/info/exclude: {e}"))?;
+
+    tracing::info!(
+        path = %exclude_path.display(),
+        "added {entry_pattern} to .git/info/exclude"
+    );
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -698,60 +698,19 @@ fn configure_session_branch_tracking(base_path: &Path, worktree_path: &Path) {
     }
 }
 
-/// Best-effort-idempotent: add `.worktrees/` to the base clone's `.git/info/exclude`.
+/// Keep the base clone's `.worktrees/` out of `git status` AND out of reach of
+/// `git clean -ffd`.
 ///
-/// Why: per-session worktrees live at `<base>/.worktrees/<session-id>/`; without
-/// a gitignore entry `git status` inside the base clone reports the `.worktrees/`
-/// directory as untracked, polluting the output for every harness that runs there.
-/// Adding to `.git/info/exclude` (not `.gitignore`) keeps the entry local to the
-/// clone and does not affect any committed `.gitignore`.
-/// What: creates `<base>/.git/info/` if absent, then reads the current exclude
-/// file and appends `.worktrees/` only when the entry is absent. The read-then-
-/// append window means concurrent callers racing at first launch may each observe
-/// an absent entry and both append — resulting in a duplicate line. Git tolerates
-/// duplicate patterns (same set is matched), so this is safe; single-caller
-/// invocations are strictly idempotent. Returns `Ok(())` on success or when the
-/// entry already exists; propagates I/O errors.
-/// Test: `ensure_worktrees_gitignored_idempotent`.
-pub fn ensure_worktrees_gitignored(base_path: &Path) -> Result<(), String> {
-    let info_dir = base_path.join(".git").join("info");
-    std::fs::create_dir_all(&info_dir).map_err(|e| {
-        format!(
-            "inproject: could not create .git/info/ at {}: {e}",
-            info_dir.display()
-        )
-    })?;
-
-    let exclude_path = info_dir.join("exclude");
-    let existing = std::fs::read_to_string(&exclude_path).unwrap_or_default();
-
-    // Idempotent: skip if the entry is already present.
-    if existing.lines().any(|line| line.trim() == ".worktrees/") {
-        return Ok(());
-    }
-
-    // Append with a leading newline when the file does not already end with one.
-    let entry = if existing.is_empty() || existing.ends_with('\n') {
-        ".worktrees/\n".to_string()
-    } else {
-        "\n.worktrees/\n".to_string()
-    };
-
-    use std::io::Write as _;
-    let mut file = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&exclude_path)
-        .map_err(|e| format!("inproject: could not open .git/info/exclude: {e}"))?;
-    file.write_all(entry.as_bytes())
-        .map_err(|e| format!("inproject: could not write .git/info/exclude: {e}"))?;
-
-    info!(
-        path = %exclude_path.display(),
-        "inproject: added .worktrees/ to .git/info/exclude"
-    );
-    Ok(())
-}
+/// Why: re-exported here (rather than defined here) so this module's existing
+/// callers keep the short spelling, exactly like [`worktree_branch_for`] above.
+/// The single source of truth moved to [`crate::core::worktree_naming`] in
+/// #4270 because `provisioner::workspace` — which is NOT gated behind the
+/// `daemon` feature — now produces the identical topology and needs the same
+/// entry. See that module for the `git clean` evidence.
+/// What: appends `.worktrees/` to `<base>/.git/info/exclude`, idempotently.
+/// Test: `ensure_worktrees_gitignored_idempotent`,
+/// `worktrees_exclude_entry_protects_against_double_force_clean`.
+pub use crate::core::worktree_naming::ensure_worktrees_gitignored;
 
 /// Read the `remote.origin.url` from a git repository at `path`.
 ///

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -156,15 +156,26 @@ pub const OLD_LAYOUT_BACKUP_SUFFIX: &str = ".old-layout-backup-";
 /// aside (rather than erroring) upholds the project's "operator does nothing"
 /// north-star: the fresh clone proceeds automatically and the old data is preserved
 /// under a clearly-named backup the operator can inspect or delete at leisure.
-/// What: acts ONLY when `base_path` exists, is a directory, is non-empty, and has
-/// NO top-level `.git` (the precise old-layout signature). In that case it renames
-/// `base_path` to a sibling `<repo><OLD_LAYOUT_BACKUP_SUFFIX><unix_nanos>` and
-/// returns `Ok(Some(backup))`. Empty dirs, already-`.git` dirs, and absent paths
-/// are left untouched (`Ok(None)`) — git clone handles an empty/absent dir fine and
-/// the caller handles the `.git` case before ever calling this. Loudly `warn!`s so
-/// the migration is never silent.
+///
+/// #4270 carves out one directory shape from that automatic rename: a project
+/// directory holding a `.base` store. It matches the old-layout signature
+/// exactly (non-empty, no top-level `.git`) but is nothing like it — `.base` is
+/// a real bare repository owning every `.base/.worktrees/<id>` worktree under
+/// it, and renaming the parent orphans all of them at once, possibly while a
+/// session is live. That is the #3605 failure mode with a bigger blast radius,
+/// so this returns `Err` there instead: retiring `.base` is a manual step the
+/// operator takes once nothing needs it.
+/// What: acts ONLY when `base_path` exists, is a directory, is non-empty, has
+/// NO top-level `.git` (the precise old-layout signature), and holds no `.base`
+/// store. In that case it renames `base_path` to a sibling
+/// `<repo><OLD_LAYOUT_BACKUP_SUFFIX><unix_nanos>` and returns `Ok(Some(backup))`.
+/// Empty dirs, already-`.git` dirs, and absent paths are left untouched
+/// (`Ok(None)`) — git clone handles an empty/absent dir fine and the caller
+/// handles the `.git` case before ever calling this. Loudly `warn!`s so the
+/// migration is never silent.
 /// Test: `ensure_base_clone_migrates_old_layout_dir_aside`,
-/// `migrate_old_layout_aside_ignores_empty_and_git_dirs`.
+/// `migrate_old_layout_aside_ignores_empty_and_git_dirs`,
+/// `migrate_old_layout_aside_refuses_a_dir_holding_a_dot_base_store`.
 fn migrate_old_layout_aside(base_path: &Path) -> Result<Option<PathBuf>, String> {
     // Absent path or an existing `.git` dir are both non-old-layout: nothing to do.
     if !base_path.exists() || base_path.join(".git").exists() {
@@ -189,6 +200,20 @@ fn migrate_old_layout_aside(base_path: &Path) -> Result<Option<PathBuf>, String>
         .is_none();
     if is_empty {
         return Ok(None);
+    }
+
+    // #4270: never rename a directory that owns a live `.base` store.
+    let legacy_base = base_path.join(crate::core::harness_root::BASE_CLONE_DIRNAME);
+    if legacy_base.exists() {
+        return Err(format!(
+            "inproject: refusing to migrate {base} aside because it holds the legacy \
+             {legacy} store retired by #4270. That store owns every \
+             {legacy}/.worktrees/<id> worktree under it and a session may be using one \
+             right now, so trusty-mpm will not move, rename, or delete it. Retiring it \
+             is a manual step for once no session needs it.",
+            base = base_path.display(),
+            legacy = crate::core::harness_root::BASE_CLONE_DIRNAME,
+        ));
     }
 
     // Non-empty, no top-level `.git` → this is the pre-#1803 old layout. Move it

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject.rs
@@ -157,17 +157,20 @@ pub const OLD_LAYOUT_BACKUP_SUFFIX: &str = ".old-layout-backup-";
 /// north-star: the fresh clone proceeds automatically and the old data is preserved
 /// under a clearly-named backup the operator can inspect or delete at leisure.
 ///
-/// #4270 carves out one directory shape from that automatic rename: a project
-/// directory holding a `.base` store. It matches the old-layout signature
-/// exactly (non-empty, no top-level `.git`) but is nothing like it — `.base` is
-/// a real bare repository owning every `.base/.worktrees/<id>` worktree under
-/// it, and renaming the parent orphans all of them at once, possibly while a
-/// session is live. That is the #3605 failure mode with a bigger blast radius,
-/// so this returns `Err` there instead: retiring `.base` is a manual step the
-/// operator takes once nothing needs it.
+/// #4270 carves a whole class out of that automatic rename: a directory holding
+/// git or trusty-mpm state. A project directory with `.base` or `.worktrees`
+/// matches the old-layout signature exactly (non-empty, no top-level `.git`)
+/// but is nothing like it — those hold real repositories and checked-out
+/// worktrees, and renaming the parent orphans every one of them at once,
+/// possibly while a session is live. That is the #3605 failure mode with a
+/// bigger blast radius, so this returns `Err` there instead. The `.git`
+/// early-return below does not make `.git` redundant in that check:
+/// `Path::exists` answers `false` for an entry it lacks permission to stat, so
+/// an EACCES blip on `.git` would otherwise fall through to the rename.
 /// What: acts ONLY when `base_path` exists, is a directory, is non-empty, has
-/// NO top-level `.git` (the precise old-layout signature), and holds no `.base`
-/// store. In that case it renames `base_path` to a sibling
+/// NO top-level `.git` (the precise old-layout signature), and holds none of the
+/// protected entries [`crate::core::harness_root::protected_state_in`] names. In
+/// that case it renames `base_path` to a sibling
 /// `<repo><OLD_LAYOUT_BACKUP_SUFFIX><unix_nanos>` and returns `Ok(Some(backup))`.
 /// Empty dirs, already-`.git` dirs, and absent paths are left untouched
 /// (`Ok(None)`) — git clone handles an empty/absent dir fine and the caller
@@ -175,7 +178,8 @@ pub const OLD_LAYOUT_BACKUP_SUFFIX: &str = ".old-layout-backup-";
 /// migration is never silent.
 /// Test: `ensure_base_clone_migrates_old_layout_dir_aside`,
 /// `migrate_old_layout_aside_ignores_empty_and_git_dirs`,
-/// `migrate_old_layout_aside_refuses_a_dir_holding_a_dot_base_store`.
+/// `migrate_old_layout_aside_refuses_a_dir_holding_a_dot_base_store`,
+/// `migrate_old_layout_aside_refuses_a_dir_holding_live_worktrees`.
 fn migrate_old_layout_aside(base_path: &Path) -> Result<Option<PathBuf>, String> {
     // Absent path or an existing `.git` dir are both non-old-layout: nothing to do.
     if !base_path.exists() || base_path.join(".git").exists() {
@@ -202,17 +206,21 @@ fn migrate_old_layout_aside(base_path: &Path) -> Result<Option<PathBuf>, String>
         return Ok(None);
     }
 
-    // #4270: never rename a directory that owns a live `.base` store.
-    let legacy_base = base_path.join(crate::core::harness_root::BASE_CLONE_DIRNAME);
-    if legacy_base.exists() {
+    // #4270: never rename a directory holding git or trusty-mpm state. The
+    // `.git` early-return above cannot cover this on its own — `Path::exists`
+    // answers `false` for an entry it cannot stat, so an EACCES blip reads as
+    // "no git dir" and the rename proceeds over live work.
+    if let Some(found) = crate::core::harness_root::protected_state_in(base_path) {
         return Err(format!(
-            "inproject: refusing to migrate {base} aside because it holds the legacy \
-             {legacy} store retired by #4270. That store owns every \
-             {legacy}/.worktrees/<id> worktree under it and a session may be using one \
-             right now, so trusty-mpm will not move, rename, or delete it. Retiring it \
-             is a manual step for once no session needs it.",
+            "inproject: refusing to migrate {base} aside because it holds {found}, so it \
+             already carries git or trusty-mpm state. A `{worktrees}/<id>` worktree or a \
+             `{legacy}` store under it may belong to a live session, and renaming the \
+             parent orphans every one of them. trusty-mpm will not move, rename, or \
+             delete it; retiring a `{legacy}` store is a manual step for once no session \
+             needs it.",
             base = base_path.display(),
             legacy = crate::core::harness_root::BASE_CLONE_DIRNAME,
+            worktrees = crate::session_manager::decommission::WORKTREES_DIRNAME,
         ));
     }
 

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
@@ -201,6 +201,56 @@ fn migrate_old_layout_aside_ignores_empty_and_git_dirs() {
     );
 }
 
+/// #4270: a project directory holding a legacy `.base` store must be refused,
+/// never renamed aside.
+///
+/// Why: `.base` matches the old-layout signature exactly — non-empty, no
+/// top-level `.git` — but it is a real bare repository owning every
+/// `.base/.worktrees/<id>` worktree beneath it, any of which may belong to a
+/// live session. Renaming the parent orphans all of them at once. This is the
+/// same failure #3605 caused one level down, and the owner ruling makes `.base`
+/// cleanup a manual step, so the correct behaviour is a loud refusal that moves
+/// nothing.
+/// What: pre-seeds `<base>/.base/.worktrees/live/IN-USE.txt`, calls
+/// `migrate_old_layout_aside`, and asserts it returns `Err` naming `.base` while
+/// the marker file survives byte-for-byte and no backup sibling was created.
+/// Test: this function IS the test.
+#[test]
+fn migrate_old_layout_aside_refuses_a_dir_holding_a_dot_base_store() {
+    let tmp = crate::test_support::hermetic_temp_dir();
+    let base = tmp.path().join("owner").join("repo");
+    let live = base.join(".base").join(".worktrees").join("live");
+    std::fs::create_dir_all(&live).expect("create legacy worktree");
+    let marker = live.join("IN-USE.txt");
+    std::fs::write(&marker, b"live session").expect("write marker");
+
+    let err = migrate_old_layout_aside(&base)
+        .expect_err("a dir holding a .base store must be refused, not migrated");
+    assert!(
+        err.contains(".base"),
+        "the refusal must name the legacy store, got: {err}"
+    );
+
+    assert!(
+        base.is_dir(),
+        "the project dir must stay exactly where it is"
+    );
+    assert_eq!(
+        std::fs::read(&marker).expect("the legacy worktree must survive untouched"),
+        b"live session",
+        "#4270: an existing .base worktree must not be disturbed, relocated, or deleted"
+    );
+    let siblings: Vec<_> = std::fs::read_dir(base.parent().unwrap())
+        .expect("read owner dir")
+        .filter_map(|e| e.ok().map(|e| e.file_name()))
+        .collect();
+    assert_eq!(
+        siblings.len(),
+        1,
+        "no backup sibling may be created, got {siblings:?}"
+    );
+}
+
 #[test]
 fn try_inproject_spawn_returns_none_for_non_git_path() {
     // A directory that is not a git repo must return Ok(None), not an error.

--- a/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/inproject/tests.rs
@@ -251,6 +251,54 @@ fn migrate_old_layout_aside_refuses_a_dir_holding_a_dot_base_store() {
     );
 }
 
+/// #4270: a project directory holding live worktrees must be refused too, not
+/// just one holding `.base`.
+///
+/// Why: the first round of this fix guarded `.base` and left `.worktrees`
+/// open — the same hole one name over. A project directory whose `.git` is
+/// absent OR merely unreadable still matches the old-layout signature, so it
+/// gets renamed whole, orphaning every session worktree beneath it. The guard
+/// has to key on the class, not on one member of it.
+/// What: pre-seeds `<base>/.worktrees/sess-1/IN-USE.txt` with no `.git` at all,
+/// calls `migrate_old_layout_aside`, and asserts it returns `Err` naming
+/// `.worktrees` while the marker survives and no backup sibling appears.
+/// Test: this function IS the test.
+#[test]
+fn migrate_old_layout_aside_refuses_a_dir_holding_live_worktrees() {
+    let tmp = crate::test_support::hermetic_temp_dir();
+    let base = tmp.path().join("owner").join("repo");
+    let live = base.join(".worktrees").join("sess-1");
+    std::fs::create_dir_all(&live).expect("create live worktree");
+    let marker = live.join("IN-USE.txt");
+    std::fs::write(&marker, b"live session").expect("write marker");
+
+    let err = migrate_old_layout_aside(&base)
+        .expect_err("a dir holding live worktrees must be refused, not migrated");
+    assert!(
+        err.contains(".worktrees"),
+        "the refusal must name what it found, got: {err}"
+    );
+
+    assert!(
+        base.is_dir(),
+        "the project dir must stay exactly where it is"
+    );
+    assert_eq!(
+        std::fs::read(&marker).expect("the live worktree must survive untouched"),
+        b"live session",
+        "#4270: a live session worktree must not be disturbed, relocated, or deleted"
+    );
+    let siblings: Vec<_> = std::fs::read_dir(base.parent().unwrap())
+        .expect("read owner dir")
+        .filter_map(|e| e.ok().map(|e| e.file_name()))
+        .collect();
+    assert_eq!(
+        siblings.len(),
+        1,
+        "no backup sibling may be created, got {siblings:?}"
+    );
+}
+
 #[test]
 fn try_inproject_spawn_returns_none_for_non_git_path() {
     // A directory that is not a git repo must return Ok(None), not an error.

--- a/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
+++ b/crates/trusty-mpm/src/daemon/managed_routes/lifecycle.rs
@@ -658,8 +658,10 @@ async fn spawn_managed_cloned(
 
     // Step 2: create the tmux session rooted at the provisioned workspace.
     // #1935: `owned=false` — the workspace is now a `git worktree` slice of a
-    // shared, persistent base checkout (`<project_dir>/.base/`), not an
-    // independently-owned full clone. Bulk `remove_dir_all` would leave the
+    // shared, persistent base checkout, not an independently-owned full clone.
+    // #4270: that base checkout is `<project_dir>` itself and the worktree is
+    // `<project_dir>/.worktrees/<id>`, the same shape `spawn_managed_inproject`
+    // produces. Bulk `remove_dir_all` would leave the
     // base checkout's git worktree metadata and session branch ref dangling;
     // `session_manager::decommission` instead detects the `.worktrees/<id>`
     // shape (`is_session_worktree`) and runs `git worktree remove --force` +

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -10,12 +10,16 @@
 //! it). #1935 replaces the per-session clone with ONE persistent, shared base
 //! checkout per project plus a per-session `git worktree add`, mirroring the
 //! same shared-base-plus-worktrees pattern already proven by the in-project
-//! spawn path (`daemon::managed_routes::inproject`).
+//! spawn path (`daemon::managed_routes::inproject`). #4270 finished that
+//! convergence: the base checkout is the project directory itself and
+//! worktrees sit beside it in `.worktrees/`, so a repo spawned from a URL and
+//! the same repo spawned from a local checkout now share ONE base clone
+//! instead of two stores in one project directory.
 //! What: [`WorkspaceProvisioner`] accepts (repo_url, ref, task, session_id),
-//! ensures a persistent bare base checkout exists at
-//! `<project_dir>/.base/` (cloning once via [`GitBackend::ensure_base_checkout`]),
+//! ensures a persistent base checkout exists at `<project_dir>/`
+//! (cloning once via [`GitBackend::ensure_base_checkout`]),
 //! then fetches `git_ref` fresh from `origin` and adds an isolated per-session
-//! `git worktree` at `<project_dir>/.base/.worktrees/<session-id>/` via
+//! `git worktree` at `<project_dir>/.worktrees/<session-id>/` via
 //! [`GitBackend::worktree_add`]. It then calls `prepare_session` to deploy
 //! agents/skills into that worktree, and returns a [`PreparedWorkspace`] with
 //! the worktree path, repo_url, and the REQUESTED branch/ref (not the internal
@@ -50,20 +54,6 @@ pub enum ProvisionError {
     #[error("session preparation failed: {0}")]
     PrepareSession(String),
 }
-
-/// Directory name (relative to a project directory) holding the persistent,
-/// shared base git checkout that every session's worktree branches off of (#1935).
-///
-/// Why: naming this segment `.base` (rather than reusing the project
-/// directory itself as the checkout root) guarantees it is EMPTY the first
-/// time a project is provisioned under the new scheme — even on an existing
-/// installation whose project directory already holds pre-#1935 per-session
-/// full-clone subdirectories — so establishing the base checkout never needs
-/// an old-layout migration step.
-/// What: `".base"`.
-/// Test: `provision_in_uses_explicit_project_dir`,
-/// `provision_reuses_base_checkout_across_sessions`.
-const BASE_CHECKOUT_DIRNAME: &str = ".base";
 
 /// Describes an isolated workspace after provisioning.
 ///
@@ -136,14 +126,15 @@ pub trait GitBackend: Send + Sync {
     /// A single shared base checkout per project lets every session's git
     /// worktree share one object database, cloned only once.
     /// What: no-op (idempotent) when `base_dir` already looks like an
-    /// established git directory; otherwise clones `repo_url` into `base_dir`.
-    /// `RealGitBackend` clones `--bare` (see its impl doc for why); callers
-    /// must not assume a working tree exists at `base_dir` itself — only
-    /// [`worktree_add`](Self::worktree_add) produces checked-out working trees.
-    /// Test: `FakeGitBackend` records the call and writes fake bare-checkout
-    /// markers (`HEAD` + a `bare = true` `config`) so a second call is
-    /// recognised as already-established (no re-clone), while a stale directory
-    /// carrying only a stray `HEAD` is rejected — matching the real backend.
+    /// established git checkout; otherwise clones `repo_url` into `base_dir`.
+    /// Since #4270 `base_dir` is the project directory and the clone is a
+    /// NON-bare one — the same clone `daemon::managed_routes::inproject::
+    /// ensure_base_clone` establishes, so both spawn paths reuse one base per
+    /// project rather than each keeping its own.
+    /// Test: `FakeGitBackend` records the call and writes a fake `.git/config`
+    /// so a second call is recognised as already-established (no re-clone),
+    /// while a stale directory carrying only a stray `HEAD` is rejected —
+    /// matching the real backend.
     fn ensure_base_checkout(&self, repo_url: &str, base_dir: &Path) -> Result<(), ProvisionError>;
 
     /// Fetch `git_ref` fresh from `origin` and add an isolated worktree for it.
@@ -237,8 +228,8 @@ impl RealGitBackend {
 // the 500-SLOC production cap — see that module's doc comment for the full
 // rationale behind each item.
 use base_lock::{
-    acquire_base_checkout_lock, base_checkout_lock_path, fake_is_established_bare_checkout,
-    is_established_bare_checkout, stale_base_dir_error, write_fake_bare_checkout,
+    acquire_base_checkout_lock, base_checkout_lock_path, fake_is_established_checkout,
+    is_established_checkout, stale_base_dir_error, write_fake_checkout,
 };
 
 impl GitBackend for RealGitBackend {
@@ -332,59 +323,38 @@ impl GitBackend for RealGitBackend {
         }
     }
 
-    /// Why: this method used to treat `base_dir.join("HEAD").is_file()` as
-    /// proof of an established bare checkout (trusty-review finding #2 on
-    /// PR #1936 / #1935). A non-bare git repo ALSO has a root-level `HEAD`
-    /// file, so a stale non-bare directory (e.g. left over from a pre-#1935
-    /// full-clone install sharing this path) would be silently accepted as a
-    /// valid base, and a later `git worktree add` against it would then fail
-    /// with `'<branch>' is already checked out`. It also unconditionally
-    /// attempted `git clone --bare` on a cache miss with no protection
-    /// against two sessions provisioning the SAME project for the first time
-    /// concurrently (finding #1): both observe "no base yet" and both start
-    /// cloning into the identical target directory. Note that "recover by
-    /// re-checking after the clone fails" is NOT sufficient here — real `git
-    /// clone --bare` is not safe against a concurrent writer into the exact
-    /// same directory; two interleaved clones can corrupt each other's
-    /// partial checkout (observed empirically: colliding on copying
-    /// `hooks/commit-msg.sample`) rather than cleanly failing with "already
-    /// exists". Only mutual exclusion around the whole check-and-clone window
-    /// avoids that.
-    /// What: replaces the fragile file-existence probe with
-    /// [`is_established_bare_checkout`], which asks git itself via
-    /// `rev-parse --is-bare-repository` (returns `false`, never panics, for a
-    /// non-bare repo or a non-repo directory) — this alone fixes finding #2.
-    /// For finding #1, wraps the clone in [`acquire_base_checkout_lock`]: a
-    /// dependency-free `OpenOptions::create_new` marker-file mutex (no
-    /// file-locking crate such as `fs2`/`fs4` is currently a workspace
-    /// dependency) that serializes concurrent callers for the SAME
-    /// `base_dir`, with stale-lock recovery so a crashed process can never
-    /// permanently deadlock future provisioning. After acquiring the lock,
-    /// re-checks `is_established_bare_checkout` once more (another caller may
-    /// have finished cloning while this one was waiting) before cloning. If the
-    /// path is then found occupied by a non-empty stale/broken (non-bare)
-    /// directory, returns an actionable [`stale_base_dir_error`] naming the
-    /// exact path and a non-destructive `mv`-aside quarantine command — rather
-    /// than a cryptic clone failure, a destructive auto-delete, or a suggested
-    /// recursive delete of this project's SHARED base (issues #1937 item 1,
-    /// #3605).
+    /// Why: this method used to accept a root-level `HEAD` file as proof of an
+    /// established base and to clone on every cache miss with nothing
+    /// serializing two first-time callers. A stray `HEAD` fooled the first
+    /// check; two interleaved clones into one directory corrupt each other
+    /// rather than cleanly failing, so recovering after the fact is not enough
+    /// — only mutual exclusion across the whole check-and-clone window is. See
+    /// trusty-review findings #1 and #2 on PR #1936 / #1935.
+    /// What: asks git itself via [`is_established_checkout`], then wraps the
+    /// clone in [`acquire_base_checkout_lock`] — a dependency-free
+    /// `create_new` marker-file mutex (no file-locking crate is a workspace
+    /// dependency) with stale-lock recovery, so a crashed holder cannot
+    /// deadlock future provisioning — and re-checks once the lock is held,
+    /// since a concurrent caller may have finished while this one waited.
+    /// An occupied path yields an actionable error rather than a cryptic clone
+    /// failure or any auto-delete: [`stale_base_dir_error`], whose recovery
+    /// hint is a non-destructive `mv`-aside quarantine (#1937 item 1, #3605)
+    /// and which answers a live legacy `.base` store with a refusal that moves
+    /// nothing (#4270).
     /// Test: `ensure_base_checkout_recovers_from_concurrent_race` (spawns
     /// real threads racing on the same `base_dir`, asserts every one returns
-    /// `Ok` and exactly one valid bare checkout results),
-    /// `ensure_base_checkout_rejects_stale_non_bare_directory` (pre-seeds a
-    /// non-bare repo at `base_dir` and asserts a loud error, not silent
-    /// reuse), both in `provisioner/workspace/tests.rs`.
+    /// `Ok` and exactly one valid checkout results),
+    /// `ensure_base_checkout_rejects_stale_directory` (pre-seeds a stray
+    /// `HEAD` at `base_dir` and asserts a loud error, not silent reuse),
+    /// `provision_in_leaves_an_existing_dot_base_store_untouched`, all in
+    /// `provisioner/workspace/tests.rs`.
     fn ensure_base_checkout(&self, repo_url: &str, base_dir: &Path) -> Result<(), ProvisionError> {
-        // A bare clone has no working tree of its own, so it can never conflict
-        // with a session worktree checking out the same branch (a non-bare
-        // clone's own checked-out branch would collide with a worktree trying
-        // to check out that same branch elsewhere). Bare-plus-worktrees is the
-        // standard git pattern for exactly this "one shared base, many
-        // isolated worktrees" shape (verified empirically before landing this:
-        // `git clone --bare`, then repeated `git fetch origin +<ref>:refs/heads/<x>`
-        // + `git worktree add` against it, works cleanly for branches, tags,
-        // and SHAs alike).
-        if is_established_bare_checkout(base_dir) {
+        // #4270: the base is the project directory's own non-bare clone, which
+        // is what the in-project spawn path already establishes there. A
+        // session worktree cannot collide with the base's checked-out branch
+        // because `worktree_add` always fetches into a session-unique branch
+        // named after the session id.
+        if is_established_checkout(base_dir) {
             debug!(path = %base_dir.display(), "base checkout already present, reusing");
             return Ok(());
         }
@@ -401,7 +371,7 @@ impl GitBackend for RealGitBackend {
 
         // Re-check now that the lock is held: another caller may have
         // completed the clone while this one was waiting for the lock.
-        if is_established_bare_checkout(base_dir) {
+        if is_established_checkout(base_dir) {
             debug!(
                 path = %base_dir.display(),
                 "base checkout completed by a concurrent caller while waiting for the lock; reusing"
@@ -409,15 +379,14 @@ impl GitBackend for RealGitBackend {
             return Ok(());
         }
 
-        // The path is confirmed NOT a valid bare checkout. If it is a non-empty
-        // stale/broken directory (crashed mid-clone leftover, or a pre-#1935
-        // non-bare clone) a `git clone --bare` here would fail with an opaque
-        // "destination path already exists" message. Surface an actionable
-        // error naming the exact path + a non-destructive `mv`-aside quarantine
-        // command instead (issue #1937 item 1). We neither auto-delete nor
-        // SUGGEST a delete: this base is shared by every worktree of the
-        // project, and the suggested command is executed verbatim by agents
-        // (issue #3605).
+        // The path is confirmed NOT a valid checkout. If it is a non-empty
+        // stale/broken directory (crashed mid-clone leftover) a `git clone`
+        // here would fail with an opaque "destination path already exists"
+        // message. Surface an actionable error naming the exact path + a
+        // non-destructive `mv`-aside quarantine command instead (issue #1937
+        // item 1). We neither auto-delete nor SUGGEST a delete: this base is
+        // shared by every worktree of the project, and the suggested command is
+        // executed verbatim by agents (issue #3605).
         if let Some(err) = stale_base_dir_error(base_dir) {
             return Err(err);
         }
@@ -428,12 +397,15 @@ impl GitBackend for RealGitBackend {
         // `--progress` + `clone_with_progress` streams byte/object percentages
         // as `CloningRepo` stage detail for the (long, on a large repo) base
         // clone — the dominant path for the in-project spawn (#2605).
+        // #4270: `--no-local` mirrors `inproject::ensure_base_clone` so a
+        // `file://`-style origin produces a real, self-contained object store
+        // rather than hardlinks into the source repository.
         let mut cmd = self.command();
-        cmd.args(["clone", "--bare", "--progress", repo_url])
+        cmd.args(["clone", "--no-local", "--progress", repo_url])
             .arg(base_dir)
             .current_dir(cwd);
         let outcome = super::clone_progress::clone_with_progress(cmd)
-            .map_err(|e| ProvisionError::Git(format!("git clone --bare exec failed: {e}")))?;
+            .map_err(|e| ProvisionError::Git(format!("git clone exec failed: {e}")))?;
         if outcome.success {
             info!(url = %repo_url, dest = %base_dir.display(), "base checkout cloned");
             // #2867: install the cross-branch push guard into the FRESHLY
@@ -450,7 +422,7 @@ impl GitBackend for RealGitBackend {
             Ok(())
         } else {
             Err(ProvisionError::Git(format!(
-                "git clone --bare failed: {}",
+                "git clone failed: {}",
                 outcome.stderr
             )))
         }
@@ -636,25 +608,24 @@ impl GitBackend for FakeGitBackend {
             "ensure_base_checkout".to_owned(),
             base_dir.to_owned(),
         ));
-        // Idempotent reuse, mirroring `RealGitBackend`'s
-        // `rev-parse --is-bare-repository` semantics (issue #1937 item 3):
-        // recognise an already-established base ONLY when it looks like a valid
-        // (fake) bare checkout, not merely when a stray `HEAD` file exists.
-        // This is the observable contract
+        // Idempotent reuse, mirroring `RealGitBackend`'s `rev-parse` semantics
+        // (issue #1937 item 3): recognise an already-established base ONLY when
+        // it looks like a valid (fake) checkout, not merely when a stray `HEAD`
+        // file exists. This is the observable contract
         // `provision_reuses_base_checkout_across_sessions` pins down.
-        if fake_is_established_bare_checkout(base_dir) {
+        if fake_is_established_checkout(base_dir) {
             return Ok(());
         }
         // Mirror `RealGitBackend`: a non-empty directory that is NOT a valid
-        // bare checkout is a stale/broken artifact — reject it loudly (with the
+        // checkout is a stale/broken artifact — reject it loudly (with the
         // same actionable message) rather than silently reuse or clobber it, so
         // a fake-backend stale-directory test catches what a real one would.
         if let Some(err) = stale_base_dir_error(base_dir) {
             return Err(err);
         }
-        // Simulate `git clone --bare`: write the structural markers that make
-        // `fake_is_established_bare_checkout` recognise this as a valid base.
-        write_fake_bare_checkout(base_dir)?;
+        // Simulate `git clone`: write the structural markers that make
+        // `fake_is_established_checkout` recognise this as a valid base.
+        write_fake_checkout(base_dir, repo_url)?;
         Ok(())
     }
 
@@ -745,7 +716,7 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
     /// What: derives the project directory
     /// (workspace_root/<project-slug>/), delegates to [`Self::provision_in`]
     /// which ensures a shared base checkout and adds a per-session worktree at
-    /// `<project-slug>/.base/.worktrees/<session-id>/`, runs prepare_session
+    /// `<project-slug>/.worktrees/<session-id>/`, runs prepare_session
     /// inside it, and returns a PreparedWorkspace with path, repo_url, and branch.
     /// Test: provisioner_isolation_path, provisioner_uses_session_id_subdir.
     pub fn provision(
@@ -769,19 +740,18 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
     /// [`Self::provision`] derives a single-segment slug from the URL; this
     /// variant lets the caller supply the pre-resolved two-segment project
     /// directory. #1935: rather than a full clone per session, both variants
-    /// now share ONE persistent base checkout per project
-    /// (`<project_dir>/.base/`, established once via
+    /// share ONE persistent base checkout per project (established once via
     /// [`GitBackend::ensure_base_checkout`]) plus a per-session `git worktree`
-    /// (`<project_dir>/.base/.worktrees/<session-id>/`, added fresh every call
-    /// via [`GitBackend::worktree_add`]) — see the module doc for the full
-    /// rationale. Nesting worktrees under the NEW `.base/` directory (rather
-    /// than reusing `project_dir` as the checkout root directly) means an
-    /// existing installation's pre-#1935 per-session full clones sitting
-    /// directly under `project_dir` can never collide with the fresh base
-    /// checkout: `.base/` is guaranteed empty on first use, so no migration
-    /// step is required.
-    /// What: computes `base_dir = project_dir/.base` and
-    /// `workspace_path = base_dir/.worktrees/<session_id>`; ensures the base
+    /// (added fresh every call via [`GitBackend::worktree_add`]) — see the
+    /// module doc for the full rationale. #4270 moved both: the base checkout
+    /// is `project_dir` itself and the worktree is
+    /// `<project_dir>/.worktrees/<session-id>/`, so this path and the
+    /// in-project path resolve to the SAME base clone for the same repo
+    /// instead of keeping two stores side by side. A project directory that
+    /// still holds the retired `.base` store is refused rather than cloned
+    /// over — see `base_lock::legacy_base_store_error`.
+    /// What: computes `base_dir = project_dir` and
+    /// `workspace_path = project_dir/.worktrees/<session_id>`; ensures the base
     /// checkout exists, fetches `git_ref` fresh from `origin` into an isolated
     /// worktree at `workspace_path`, writes the session-manager worktree
     /// ownership sentinel (so `session_manager::decommission` can safely
@@ -801,8 +771,11 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
         git_ref: &str,
         task: &str,
     ) -> Result<PreparedWorkspace, ProvisionError> {
-        let base_dir = project_dir.join(BASE_CHECKOUT_DIRNAME);
-        let workspace_path = base_dir
+        // #4270: the base checkout IS the project directory and worktrees sit
+        // beside it in `.worktrees/` — the git-standard shape the in-project
+        // spawn path already produces. Nothing writes `.base` any more.
+        let base_dir = project_dir.to_path_buf();
+        let workspace_path = project_dir
             .join(crate::session_manager::decommission::WORKTREES_DIRNAME)
             .join(session_id.to_string());
         // The branch backing this worktree is named after the session id

--- a/crates/trusty-mpm/src/provisioner/workspace.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace.rs
@@ -339,8 +339,9 @@ impl GitBackend for RealGitBackend {
     /// An occupied path yields an actionable error rather than a cryptic clone
     /// failure or any auto-delete: [`stale_base_dir_error`], whose recovery
     /// hint is a non-destructive `mv`-aside quarantine (#1937 item 1, #3605)
-    /// and which answers a live legacy `.base` store with a refusal that moves
-    /// nothing (#4270).
+    /// and which answers a directory already holding git or trusty-mpm state
+    /// with a refusal that moves nothing (#4270 — including, deliberately, the
+    /// half-clone that #1937 wrote the hint for; see `protected_dir_error`).
     /// Test: `ensure_base_checkout_recovers_from_concurrent_race` (spawns
     /// real threads racing on the same `base_dir`, asserts every one returns
     /// `Ok` and exactly one valid checkout results),
@@ -356,7 +357,10 @@ impl GitBackend for RealGitBackend {
         // named after the session id.
         if is_established_checkout(base_dir) {
             debug!(path = %base_dir.display(), "base checkout already present, reusing");
-            return Ok(());
+            // #4270: self-heal on reuse, exactly as `inproject::ensure_base_clone`
+            // does — a base established before this call site existed still owes
+            // its worktrees the `git clean -ffd` guard.
+            return exclude_worktrees(base_dir);
         }
         if let Some(parent) = base_dir.parent() {
             std::fs::create_dir_all(parent)?;
@@ -419,7 +423,10 @@ impl GitBackend for RealGitBackend {
             // operator via `tm repair push-guard`, which `tm doctor`'s
             // `push_guard` check names when it finds a clone unprotected.
             crate::core::push_guard::install_and_log(base_dir);
-            Ok(())
+            // #4270: without this, `git clean -ffd` in the base DELETES every
+            // session worktree, uncommitted work included — see
+            // `core::worktree_naming::ensure_worktrees_gitignored`.
+            exclude_worktrees(base_dir)
         } else {
             Err(ProvisionError::Git(format!(
                 "git clone failed: {}",
@@ -749,7 +756,7 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
     /// in-project path resolve to the SAME base clone for the same repo
     /// instead of keeping two stores side by side. A project directory that
     /// still holds the retired `.base` store is refused rather than cloned
-    /// over — see `base_lock::legacy_base_store_error`.
+    /// over — see `base_lock::protected_dir_error`.
     /// What: computes `base_dir = project_dir` and
     /// `workspace_path = project_dir/.worktrees/<session_id>`; ensures the base
     /// checkout exists, fetches `git_ref` fresh from `origin` into an isolated
@@ -970,6 +977,16 @@ impl<G: GitBackend> WorkspaceProvisioner<G> {
             branch: git_ref.to_owned(),
         })
     }
+}
+
+/// Add the base clone's `.worktrees/` exclude entry, as a [`ProvisionError`].
+///
+/// Why: [`crate::core::worktree_naming::ensure_worktrees_gitignored`] is shared
+/// with the in-project path and reports `String`; this adapts it to the
+/// provisioner's error type at the one place that needs it (#4270).
+/// Test: `worktrees_exclude_entry_protects_against_double_force_clean`.
+fn exclude_worktrees(base_dir: &Path) -> Result<(), ProvisionError> {
+    crate::core::worktree_naming::ensure_worktrees_gitignored(base_dir).map_err(ProvisionError::Git)
 }
 
 /// Derive a filesystem-safe slug from a repository URL.

--- a/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
@@ -95,42 +95,47 @@ pub(super) fn is_established_checkout(dir: &Path) -> bool {
 /// Test: `provision_in_leaves_an_existing_dot_base_store_untouched`.
 pub(super) use crate::core::harness_root::BASE_CLONE_DIRNAME as LEGACY_BASE_DIRNAME;
 
-/// Build the refusal for a project directory still occupied by a legacy
-/// `.base` store — or `None` when no such store is present.
+/// Build the refusal for a project directory holding git or trusty-mpm state —
+/// or `None` when it holds none.
 ///
 /// Why (#4270): provisioning now clones the base into `<project_dir>` itself,
-/// and `git clone` refuses a non-empty destination. A project provisioned only
-/// through the pre-#4270 clone path holds `<project_dir>/.base` — a bare
-/// repository that owns every `.base/.worktrees/<id>` worktree still checked
-/// out and, quite possibly, still running a live session. The generic
-/// [`stale_base_dir_error`] would tell the operator to `mv` that whole
-/// directory aside, which orphans all of them: precisely the #3605 blast
-/// radius, aimed at a bigger target. This refusal names the situation instead
-/// and suggests nothing that moves or deletes anything, because the owner
-/// ruling (#4270) makes `.base` cleanup a manual step taken once no session
-/// needs it.
-/// What: returns `Some(ProvisionError::Git(..))` naming `project_dir` and its
-/// `.base` store when that store exists; `None` otherwise, leaving the caller
-/// on its normal path.
-/// Test: `provision_in_leaves_an_existing_dot_base_store_untouched`.
-fn legacy_base_store_error(project_dir: &Path) -> Option<ProvisionError> {
-    let legacy = project_dir.join(LEGACY_BASE_DIRNAME);
-    if !legacy.exists() {
-        return None;
-    }
+/// and `git clone` refuses a non-empty destination. Before #4270 `base_dir` was
+/// `<project_dir>/.base`, which for an in-project-shaped project does not
+/// exist, so [`stale_base_dir_error`] returned `None` and its `mv` hint was
+/// unreachable there. Pointing `base_dir` at the project directory made that
+/// hint reachable — aimed at the directory holding `.worktrees/<id>` for every
+/// live session, and at `.base` with every worktree beneath it. That is the
+/// #3605 string with a bigger target, so the whole class is diverted here to a
+/// refusal that suggests nothing which moves or deletes anything.
+///
+/// Reaching this on a HEALTHY repository is the case that makes it matter:
+/// [`is_established_checkout`] reports `false` for a transient git spawn
+/// failure, a missing `git` binary, and a dubious-ownership rejection alike, so
+/// a momentary hiccup lands here with `.git` present. Naming that state and
+/// stopping is right in every one of those; suggesting a rename is not.
+/// What: returns `Some(ProvisionError::Git(..))` naming `project_dir` and the
+/// protected entry [`crate::core::harness_root::protected_state_in`] found;
+/// `None` otherwise, leaving the caller on its normal path.
+/// Test: `provision_in_leaves_an_existing_dot_base_store_untouched`,
+/// `stale_base_dir_error_never_offers_to_move_a_dir_holding_live_worktrees`.
+fn protected_dir_error(project_dir: &Path) -> Option<ProvisionError> {
+    let found = crate::core::harness_root::protected_state_in(project_dir)?;
     Some(ProvisionError::Git(format!(
-        "cannot establish the base checkout at {project} because it still holds the \
-         legacy {legacy} store retired by #4270.\n\
+        "cannot establish the base checkout at {project}: it holds {found}, so it \
+         already carries git or trusty-mpm state.\n\
          \n\
-         That store is a real git repository owning every {legacy}/.worktrees/<id> \
-         worktree under it, and one of those sessions may be live right now. \
-         trusty-mpm will not move, rename, or delete it. Retiring it is a manual step \
-         for once no session needs it.\n\
+         Anything under it may be in use — a `{worktrees}/<id>` worktree, or a \
+         `{legacy}` store owning worktrees of its own — and one of those sessions may \
+         be live right now. trusty-mpm will not move, rename, or delete any of it, and \
+         neither should you while a session is running.\n\
          \n\
-         Until then, spawn this project's sessions from a local checkout (the \
-         in-project path), which uses the same {project} base clone this path wants.",
+         If this project has a `{legacy}` store, retiring it is a manual step for once \
+         no session needs it (#4270). If `.git` is present, this path expected git to \
+         recognise a checkout here and it did not — check that `git -C {project} \
+         rev-parse --show-toplevel` succeeds before retrying.",
         project = project_dir.display(),
         legacy = LEGACY_BASE_DIRNAME,
+        worktrees = crate::session_manager::decommission::WORKTREES_DIRNAME,
     )))
 }
 
@@ -180,13 +185,14 @@ pub(super) fn stale_base_quarantine_path(base_dir: &Path) -> PathBuf {
 /// `Some(ProvisionError::Git(..))` whose message names the exact path, warns
 /// that the path is shared across sessions, and gives a single non-destructive
 /// `mv <path> <path>.stale-<timestamp>` command. It never emits a recursive
-/// delete. One case is answered ahead of that, via [`legacy_base_store_error`]:
-/// a directory hosting a live `.base` store gets a refusal that suggests moving
-/// nothing (#4270), because the `mv` hint aimed at a project directory would
-/// rename every worktree under that store out from under its session. Callers
-/// MUST invoke this only AFTER confirming the path is not already a valid
-/// checkout (via [`is_established_checkout`]) so a healthy base is never
-/// flagged.
+/// delete. A whole class is answered ahead of that, via [`protected_dir_error`]:
+/// a directory holding git or trusty-mpm state gets a refusal that suggests
+/// moving nothing (#4270), because the `mv` hint aimed at a project directory
+/// would rename live worktrees out from under their sessions. Only foreign
+/// debris — no `.git`, no `.base`, no `.worktrees` — still gets the quarantine
+/// hint. Callers MUST invoke this only AFTER confirming the path is not already
+/// a valid checkout (via [`is_established_checkout`]) so a healthy base is
+/// never flagged.
 /// Test: `ensure_base_checkout_rejects_stale_directory`,
 /// `fake_ensure_base_checkout_rejects_stale_directory` (both assert
 /// the message names the path and carries the quarantine hint), and
@@ -208,9 +214,10 @@ pub(super) fn stale_base_dir_error(base_dir: &Path) -> Option<ProvisionError> {
     if !non_empty {
         return None;
     }
-    // #4270: a live legacy `.base` store is occupied, but nothing about it is
-    // stale — and the quarantine hint below must never be aimed at it.
-    if let Some(err) = legacy_base_store_error(base_dir) {
+    // #4270: a directory holding git or trusty-mpm state is occupied, but
+    // nothing about it is stale — and the quarantine hint below must never be
+    // aimed at it. Only foreign debris reaches the `mv` suggestion.
+    if let Some(err) = protected_dir_error(base_dir) {
         return Some(err);
     }
     Some(ProvisionError::Git(format!(

--- a/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
@@ -1,69 +1,137 @@
-//! Advisory locking + bare-repo detection for `RealGitBackend::ensure_base_checkout`.
+//! Advisory locking + checkout detection for `RealGitBackend::ensure_base_checkout`.
 //!
 //! Why: split out of `workspace.rs` (which grew past the 500-SLOC production
 //! cap once trusty-review's PR #1936 / #1935 findings were fixed) to keep
 //! both files under the mechanical `scripts/check_line_cap.sh` gate. Grouping
 //! these items together here — rather than trimming their Why/What/Test
 //! documentation — keeps the fix's rationale fully documented in place.
-//! What: [`is_established_bare_checkout`] replaces the fragile
-//! `HEAD.is_file()` idempotency probe (review finding #2) with a real
-//! `git rev-parse --is-bare-repository` check; [`acquire_base_checkout_lock`]
-//! (backed by [`BaseCheckoutLock`], a dependency-free marker-file mutex) plus
-//! [`lock_is_stale`] serialize the check-and-clone window across concurrent
-//! callers to fix the TOCTOU provisioning race (review finding #1).
-//! [`stale_base_dir_error`] turns the "the base path is occupied by a broken,
-//! non-bare directory" state into an actionable operator error (issue #1937
-//! item 1), and is shared by BOTH backends; [`fake_is_established_bare_checkout`]
-//! / [`write_fake_bare_checkout`] let `FakeGitBackend` mirror the real backend's
-//! `rev-parse`-based validity semantics rather than a superficial file-exists
-//! probe (issue #1937 item 3).
+//! What: [`is_established_checkout`] replaces the fragile `HEAD.is_file()`
+//! idempotency probe (review finding #2) with a real `git rev-parse` check;
+//! [`acquire_base_checkout_lock`] (backed by [`BaseCheckoutLock`], a
+//! dependency-free marker-file mutex) plus [`lock_is_stale`] serialize the
+//! check-and-clone window across concurrent callers to fix the TOCTOU
+//! provisioning race (review finding #1). [`stale_base_dir_error`] turns the
+//! "the base path is occupied by a broken directory" state into an actionable
+//! operator error (issue #1937 item 1), and is shared by BOTH backends;
+//! [`fake_is_established_checkout`] / [`write_fake_checkout`] let
+//! `FakeGitBackend` mirror the real backend's `rev-parse`-based validity
+//! semantics rather than a superficial file-exists probe (issue #1937 item 3).
 //! [`stale_base_quarantine_path`] backs that error's non-destructive recovery
 //! hint (issue #3605: the hint used to be a literal `rm -rf`).
+//!
+//! #4270 moved the base checkout from `<project_dir>/.base` (bare) to
+//! `<project_dir>` itself (non-bare), converging on the shape the in-project
+//! spawn path already produces. The detection predicate moved with it, and
+//! [`legacy_base_store_error`] guards the one case that move introduces: a
+//! project directory that still holds a legacy `.base` store whose worktrees
+//! are live.
 //! Test: `ensure_base_checkout_recovers_from_concurrent_race`,
-//! `ensure_base_checkout_rejects_stale_non_bare_directory`,
+//! `ensure_base_checkout_rejects_stale_directory`,
 //! `base_checkout_lock_recovers_stale_lock_marker`,
-//! `fake_ensure_base_checkout_rejects_stale_non_bare_directory`,
-//! `stale_base_dir_error_suggests_quarantine_not_deletion`, all in
+//! `fake_ensure_base_checkout_rejects_stale_directory`,
+//! `stale_base_dir_error_suggests_quarantine_not_deletion`,
+//! `provision_in_leaves_an_existing_dot_base_store_untouched`, all in
 //! `provisioner/workspace/tests.rs`.
 
 use std::path::{Path, PathBuf};
 
 use super::ProvisionError;
 
-/// Determine whether `dir` is an already-established BARE git checkout.
+/// Determine whether `dir` is an already-established git checkout ROOT.
 ///
 /// Why: the previous idempotency guard for [`super::RealGitBackend`]'s
 /// `ensure_base_checkout` (`base_dir.join("HEAD").is_file()`) only checks for
 /// a file literally named `HEAD` at the root of `base_dir` — it never
 /// confirms that directory is actually a valid, complete git repository. A
 /// directory that merely contains a stray `HEAD` file (e.g. left behind by a
-/// `git clone --bare` that crashed mid-clone — git writes `HEAD` early,
-/// before the rest of the object database/refs — or any other stale/corrupt
-/// artifact) would pass the old check and be silently mistaken for an
-/// established shared base (trusty-review finding #2 on PR #1936 / #1935).
-/// `git rev-parse --is-bare-repository` is the canonical way git itself
-/// answers this question, so it cannot be fooled by directory layout alone.
-/// This helper is also reused to resolve the TOCTOU provisioning race
-/// (finding #1): after acquiring [`acquire_base_checkout_lock`], re-running
-/// this check tells the caller whether a concurrent caller already finished
-/// establishing a valid base while this one was waiting.
-/// What: shells out to `git -C dir rev-parse --is-bare-repository` and
-/// returns `true` only when the command exits successfully AND stdout trims
-/// to exactly `"true"`. Returns `false` (never panics) if the subprocess
-/// fails to spawn, exits non-zero (not a git repository at all), or prints
-/// anything else (e.g. `"false"` for a non-bare repo).
+/// clone that crashed mid-flight — git writes `HEAD` early, before the rest
+/// of the object database/refs — or any other stale/corrupt artifact) would
+/// pass the old check and be silently mistaken for an established shared base
+/// (trusty-review finding #2 on PR #1936 / #1935). Asking git itself cannot be
+/// fooled by directory layout alone. This helper is also reused to resolve the
+/// TOCTOU provisioning race (finding #1): after acquiring
+/// [`acquire_base_checkout_lock`], re-running this check tells the caller
+/// whether a concurrent caller already finished establishing a valid base
+/// while this one was waiting.
+///
+/// #4270: the base checkout is now the non-bare clone at `<project_dir>`, the
+/// same one `daemon::managed_routes::inproject::ensure_base_clone` establishes,
+/// so the predicate asks for a WORKING TREE whose root is `dir` itself. The
+/// toplevel comparison is load-bearing twice over: a `dir` nested inside some
+/// unrelated enclosing repository would otherwise report `true` without holding
+/// a clone of its own, and a bare repository (the legacy `.base` shape) reports
+/// `false` because it has no working tree at all.
+/// What: shells out to `git -C dir rev-parse --show-toplevel` and returns
+/// `true` only when the command exits successfully AND the printed toplevel
+/// canonicalizes to the same path as `dir`. Returns `false` (never panics) if
+/// the subprocess fails to spawn, exits non-zero (not a git working tree),
+/// or names a different root.
 /// Test: `ensure_base_checkout_recovers_from_concurrent_race`,
-/// `ensure_base_checkout_rejects_stale_non_bare_directory`.
-pub(super) fn is_established_bare_checkout(dir: &Path) -> bool {
+/// `ensure_base_checkout_rejects_stale_directory`.
+pub(super) fn is_established_checkout(dir: &Path) -> bool {
     use std::process::Command;
     let dir_s = dir.to_string_lossy();
-    match Command::new("git")
-        .args(["-C", &dir_s, "rev-parse", "--is-bare-repository"])
+    let out = match Command::new("git")
+        .args(["-C", &dir_s, "rev-parse", "--show-toplevel"])
         .output()
     {
-        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout).trim() == "true",
+        Ok(out) if out.status.success() => out,
+        _ => return false,
+    };
+    let toplevel = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim());
+    match (std::fs::canonicalize(&toplevel), std::fs::canonicalize(dir)) {
+        (Ok(top), Ok(here)) => top == here,
         _ => false,
     }
+}
+
+/// Directory name of the LEGACY per-project bare base store retired by #4270.
+///
+/// Why: one literal, shared by the two guards that must recognise a legacy
+/// store and refuse to touch it. Re-exported from [`crate::core::harness_root`]
+/// rather than respelled, so the reader that maps a `.base` common-dir back to
+/// its project and the writer that refuses to clobber it can never disagree.
+/// What: `.base`.
+/// Test: `provision_in_leaves_an_existing_dot_base_store_untouched`.
+pub(super) use crate::core::harness_root::BASE_CLONE_DIRNAME as LEGACY_BASE_DIRNAME;
+
+/// Build the refusal for a project directory still occupied by a legacy
+/// `.base` store — or `None` when no such store is present.
+///
+/// Why (#4270): provisioning now clones the base into `<project_dir>` itself,
+/// and `git clone` refuses a non-empty destination. A project provisioned only
+/// through the pre-#4270 clone path holds `<project_dir>/.base` — a bare
+/// repository that owns every `.base/.worktrees/<id>` worktree still checked
+/// out and, quite possibly, still running a live session. The generic
+/// [`stale_base_dir_error`] would tell the operator to `mv` that whole
+/// directory aside, which orphans all of them: precisely the #3605 blast
+/// radius, aimed at a bigger target. This refusal names the situation instead
+/// and suggests nothing that moves or deletes anything, because the owner
+/// ruling (#4270) makes `.base` cleanup a manual step taken once no session
+/// needs it.
+/// What: returns `Some(ProvisionError::Git(..))` naming `project_dir` and its
+/// `.base` store when that store exists; `None` otherwise, leaving the caller
+/// on its normal path.
+/// Test: `provision_in_leaves_an_existing_dot_base_store_untouched`.
+fn legacy_base_store_error(project_dir: &Path) -> Option<ProvisionError> {
+    let legacy = project_dir.join(LEGACY_BASE_DIRNAME);
+    if !legacy.exists() {
+        return None;
+    }
+    Some(ProvisionError::Git(format!(
+        "cannot establish the base checkout at {project} because it still holds the \
+         legacy {legacy} store retired by #4270.\n\
+         \n\
+         That store is a real git repository owning every {legacy}/.worktrees/<id> \
+         worktree under it, and one of those sessions may be live right now. \
+         trusty-mpm will not move, rename, or delete it. Retiring it is a manual step \
+         for once no session needs it.\n\
+         \n\
+         Until then, spawn this project's sessions from a local checkout (the \
+         in-project path), which uses the same {project} base clone this path wants.",
+        project = project_dir.display(),
+        legacy = LEGACY_BASE_DIRNAME,
+    )))
 }
 
 /// Build the timestamped sibling path a stale base directory should be
@@ -86,13 +154,13 @@ pub(super) fn stale_base_quarantine_path(base_dir: &Path) -> PathBuf {
     PathBuf::from(name)
 }
 
-/// Build an actionable error for a base-checkout path occupied by a broken,
-/// non-bare directory — or return `None` when the path is safe to clone into.
+/// Build an actionable error for a base-checkout path occupied by a broken
+/// directory — or return `None` when the path is safe to clone into.
 ///
-/// Why: `ensure_base_checkout` correctly refuses to reuse a `<project_dir>/.base`
-/// that is not a valid bare checkout (a leftover from a crashed mid-clone, or a
-/// stale non-bare directory), but the resulting failure used to be an opaque
-/// `git clone --bare` "destination path already exists" message that gives the
+/// Why: `ensure_base_checkout` correctly refuses to reuse a base path that is
+/// not a valid checkout (a leftover from a crashed mid-clone, or any other
+/// stale directory), but the resulting failure used to be an opaque
+/// `git clone` "destination path already exists" message that gives the
 /// operator no recovery path (issue #1937 item 1). This error is, however,
 /// consumed almost exclusively by an autonomous agent, which executes a
 /// suggested command verbatim — so the message's own recovery hint is a
@@ -108,25 +176,29 @@ pub(super) fn stale_base_quarantine_path(base_dir: &Path) -> PathBuf {
 /// message states the shared-ownership blast radius explicitly, which is the
 /// context whose absence made the destructive hint look safe to follow.
 /// What: returns `None` when `base_dir` is absent or empty (either is safe —
-/// `git clone --bare` accepts a missing or empty target); otherwise returns
+/// `git clone` accepts a missing or empty target); otherwise returns
 /// `Some(ProvisionError::Git(..))` whose message names the exact path, warns
 /// that the path is shared across sessions, and gives a single non-destructive
 /// `mv <path> <path>.stale-<timestamp>` command. It never emits a recursive
-/// delete. Callers MUST invoke this only AFTER confirming the path is not
-/// already a valid bare checkout (via [`is_established_bare_checkout`]) so a
-/// healthy base is never flagged.
-/// Test: `ensure_base_checkout_rejects_stale_non_bare_directory`,
-/// `fake_ensure_base_checkout_rejects_stale_non_bare_directory` (both assert
+/// delete. One case is answered ahead of that, via [`legacy_base_store_error`]:
+/// a directory hosting a live `.base` store gets a refusal that suggests moving
+/// nothing (#4270), because the `mv` hint aimed at a project directory would
+/// rename every worktree under that store out from under its session. Callers
+/// MUST invoke this only AFTER confirming the path is not already a valid
+/// checkout (via [`is_established_checkout`]) so a healthy base is never
+/// flagged.
+/// Test: `ensure_base_checkout_rejects_stale_directory`,
+/// `fake_ensure_base_checkout_rejects_stale_directory` (both assert
 /// the message names the path and carries the quarantine hint), and
 /// `stale_base_dir_error_suggests_quarantine_not_deletion` (asserts the message
 /// contains NO destructive command — the #3605 regression guard).
 pub(super) fn stale_base_dir_error(base_dir: &Path) -> Option<ProvisionError> {
-    // A missing dir (NotFound) or an empty dir (no entries) is fine: `git clone
-    // --bare` clones cleanly into either. Only a NON-empty dir that is not a
-    // valid bare checkout is the stale/broken state worth reporting. Any OTHER
+    // A missing dir (NotFound) or an empty dir (no entries) is fine: `git clone`
+    // clones cleanly into either. Only a NON-empty dir that is not a
+    // valid checkout is the stale/broken state worth reporting. Any OTHER
     // read_dir error (e.g. permission-denied) must NOT be swallowed as "absent":
     // treating an unreadable directory as non-empty forces an actionable error
-    // here instead of letting `git clone --bare` fail later with an opaque
+    // here instead of letting `git clone` fail later with an opaque
     // message — exactly the failure mode this helper exists to prevent.
     let non_empty = match std::fs::read_dir(base_dir) {
         Ok(mut entries) => entries.next().is_some(),
@@ -136,9 +208,14 @@ pub(super) fn stale_base_dir_error(base_dir: &Path) -> Option<ProvisionError> {
     if !non_empty {
         return None;
     }
+    // #4270: a live legacy `.base` store is occupied, but nothing about it is
+    // stale — and the quarantine hint below must never be aimed at it.
+    if let Some(err) = legacy_base_store_error(base_dir) {
+        return Some(err);
+    }
     Some(ProvisionError::Git(format!(
-        "base checkout path {path} exists but is not a valid bare git checkout \
-         (likely a leftover from a crashed clone, or a stale non-bare directory).\n\
+        "base checkout path {path} exists but is not a valid git checkout \
+         (likely a leftover from a crashed clone, or a stale directory).\n\
          \n\
          WARNING: this path is the SHARED git base for EVERY trusty-mpm worktree of \
          this project, and other sessions may be using it right now. Destroying it \
@@ -156,48 +233,49 @@ pub(super) fn stale_base_dir_error(base_dir: &Path) -> Option<ProvisionError> {
     )))
 }
 
-/// Determine whether `dir` is an already-established (fake) BARE checkout,
-/// mirroring [`is_established_bare_checkout`]'s intent for `FakeGitBackend`.
+/// Determine whether `dir` is an already-established (fake) checkout,
+/// mirroring [`is_established_checkout`]'s intent for `FakeGitBackend`.
 ///
 /// Why: `FakeGitBackend::ensure_base_checkout` used to treat a lone
 /// `dir.join("HEAD").is_file()` as proof of an established base — the exact
 /// superficial file-existence probe the real backend abandoned in favour of
-/// `git rev-parse --is-bare-repository` (issue #1937 item 3). A future test
-/// author using the fake to simulate a stale `.base` (a stray `HEAD` file with
-/// no repository structure) would have gotten a false-positive "already
-/// established" pass, hiding the very stale-directory bug a real-backend test
-/// would catch. This check restores that fidelity in the filesystem-light fake.
-/// What: returns `true` only when BOTH a root-level `HEAD` file exists AND a
-/// root-level `config` file marked `bare = true` exists — the structural
-/// markers [`write_fake_bare_checkout`] writes to simulate a real bare clone. A
-/// directory containing only a stray `HEAD` (the stale-mid-clone shape) fails
-/// the `config` check and reads as NOT established, matching the real backend.
-/// Test: `fake_ensure_base_checkout_rejects_stale_non_bare_directory`,
+/// asking git (issue #1937 item 3). A future test author using the fake to
+/// simulate a stale base (a stray `HEAD` file with no repository structure)
+/// would have gotten a false-positive "already established" pass, hiding the
+/// very stale-directory bug a real-backend test would catch. This check
+/// restores that fidelity in the filesystem-light fake.
+/// What: returns `true` only when the `.git/config` file
+/// [`write_fake_checkout`] writes exists — the same marker
+/// `FakeGitBackend::is_git_repo` and `clone_repo` already use, and the
+/// filesystem-light stand-in for the real backend's working-tree probe. A
+/// directory containing only a stray `HEAD` (the stale-mid-clone shape) reads
+/// as NOT established, matching the real backend.
+/// Test: `fake_ensure_base_checkout_rejects_stale_directory`,
 /// `provision_reuses_base_checkout_across_sessions`.
-pub(super) fn fake_is_established_bare_checkout(dir: &Path) -> bool {
-    dir.join("HEAD").is_file()
-        && std::fs::read_to_string(dir.join("config"))
-            .map(|c| c.contains("bare = true"))
-            .unwrap_or(false)
+pub(super) fn fake_is_established_checkout(dir: &Path) -> bool {
+    dir.join(".git").join("config").is_file()
 }
 
 /// Write the minimal structural markers that make a directory read as an
-/// established (fake) bare checkout.
+/// established (fake) checkout.
 ///
 /// Why: `FakeGitBackend::ensure_base_checkout` must leave behind enough state
-/// that [`fake_is_established_bare_checkout`] recognises it on the next call
+/// that [`fake_is_established_checkout`] recognises it on the next call
 /// (idempotent reuse across sessions) while still being distinguishable from a
 /// stale directory that merely holds a stray `HEAD` file (issue #1937 item 3).
-/// What: creates `dir` (and parents) and writes a `HEAD` ref pointer plus a
-/// `config` file carrying the `bare = true` marker — the two files
-/// [`fake_is_established_bare_checkout`] requires. Returns any I/O error as
-/// [`ProvisionError::Io`].
+/// What: creates `dir/.git` (and parents) and writes a `config` naming
+/// `repo_url` as `origin`, matching what `FakeGitBackend::clone_repo` produces
+/// so `is_git_repo`/`remote_url` answer consistently for a faked base clone.
+/// Returns any I/O error as [`ProvisionError::Io`].
 /// Test: `provision_reuses_base_checkout_across_sessions` (second provision is a
-/// no-op reuse), `fake_ensure_base_checkout_rejects_stale_non_bare_directory`.
-pub(super) fn write_fake_bare_checkout(dir: &Path) -> Result<(), ProvisionError> {
-    std::fs::create_dir_all(dir)?;
-    std::fs::write(dir.join("HEAD"), "ref: refs/heads/main\n")?;
-    std::fs::write(dir.join("config"), "[core]\n\tbare = true\n")?;
+/// no-op reuse), `fake_ensure_base_checkout_rejects_stale_directory`.
+pub(super) fn write_fake_checkout(dir: &Path, repo_url: &str) -> Result<(), ProvisionError> {
+    let git_dir = dir.join(".git");
+    std::fs::create_dir_all(&git_dir)?;
+    std::fs::write(
+        git_dir.join("config"),
+        format!("[core]\n\trepositoryformatversion = 0\n[remote \"origin\"]\n\turl = {repo_url}\n"),
+    )?;
     Ok(())
 }
 
@@ -239,7 +317,7 @@ pub(super) const LOCK_STALE_AFTER: std::time::Duration = std::time::Duration::fr
 /// Why: the lock must live NEXT TO `base_dir` (not inside it), since
 /// `base_dir` itself may not exist yet when the lock is first acquired.
 /// What: `<base_dir's parent>/<base_dir's file name>.lock`, e.g.
-/// `<project_dir>/.base.lock` for the standard `.base` base-checkout name.
+/// `<repos_root>/<owner>/<repo>.lock` for a `<owner>/<repo>` project dir.
 /// Test: exercised transitively by every `ensure_base_checkout` test.
 pub(super) fn base_checkout_lock_path(base_dir: &Path) -> PathBuf {
     match (base_dir.parent(), base_dir.file_name()) {
@@ -277,8 +355,8 @@ impl Drop for BaseCheckoutLock {
 ///
 /// Why: resolves the TOCTOU race (#1935 review finding #1) at its root by
 /// serializing the whole check-and-clone window, rather than trying to
-/// detect and recover from corruption after the fact — real `git clone
-/// --bare` is not safe against a concurrent writer into the same target
+/// detect and recover from corruption after the fact — a real `git clone`
+/// is not safe against a concurrent writer into the same target
 /// directory (empirically observed failure mode without this lock: two
 /// interleaved clones can corrupt each other's partial checkout, e.g.
 /// colliding on copying `hooks/commit-msg.sample`, rather than cleanly
@@ -318,7 +396,7 @@ pub(super) fn acquire_base_checkout_lock(
                 // after which BOTH callers could hold the lock at once. We
                 // accept this window deliberately: this is an ADVISORY lock, not
                 // a correctness-critical mutex — the only thing it guards is a
-                // rare first-provision `git clone --bare` collision (finding #1),
+                // rare first-provision `git clone` collision (finding #1),
                 // and `LOCK_STALE_AFTER` (5 min) is set comfortably longer than
                 // `LOCK_ACQUIRE_TIMEOUT` (60 s) precisely so a live,
                 // slow-but-progressing clone is never mistaken for an abandoned

--- a/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/base_lock.rs
@@ -22,9 +22,9 @@
 //! #4270 moved the base checkout from `<project_dir>/.base` (bare) to
 //! `<project_dir>` itself (non-bare), converging on the shape the in-project
 //! spawn path already produces. The detection predicate moved with it, and
-//! [`legacy_base_store_error`] guards the one case that move introduces: a
-//! project directory that still holds a legacy `.base` store whose worktrees
-//! are live.
+//! [`protected_dir_error`] guards the cases that move introduces: a project
+//! directory already holding git or trusty-mpm state, whose worktrees may be
+//! live.
 //! Test: `ensure_base_checkout_recovers_from_concurrent_race`,
 //! `ensure_base_checkout_rejects_stale_directory`,
 //! `base_checkout_lock_recovers_stale_lock_marker`,
@@ -113,6 +113,15 @@ pub(super) use crate::core::harness_root::BASE_CLONE_DIRNAME as LEGACY_BASE_DIRN
 /// failure, a missing `git` binary, and a dubious-ownership rejection alike, so
 /// a momentary hiccup lands here with `.git` present. Naming that state and
 /// stopping is right in every one of those; suggesting a rename is not.
+///
+/// KNOWN REGRESSION, accepted. A crashed `git clone` leaves a partial `.git`,
+/// so the half-clone #1937 item 1 was written for now lands here and gets NO
+/// quarantine command — on the pre-#4270 code it reached the `mv` hint, because
+/// a partial BARE clone writes no `.git`. Recovery for that case is genuinely
+/// worse. It is accepted because a half-clone and a healthy checkout whose git
+/// probe just failed are indistinguishable from here, and one of them holds
+/// live worktrees: guessing wrong in the recoverable direction destroys work,
+/// guessing wrong in this direction costs the operator one manual decision.
 /// What: returns `Some(ProvisionError::Git(..))` naming `project_dir` and the
 /// protected entry [`crate::core::harness_root::protected_state_in`] found;
 /// `None` otherwise, leaving the caller on its normal path.

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -272,13 +272,11 @@ fn provision_in_leaves_an_existing_dot_base_store_untouched() {
         msg.contains(crate::core::harness_root::BASE_CLONE_DIRNAME),
         "the refusal must name the legacy store, got: {msg}"
     );
-    for forbidden in ["rm -rf", "rm -fr", "    mv "] {
-        assert!(
-            !msg.contains(forbidden),
-            "the refusal must not suggest moving or deleting a live store, but it \
-             contains {forbidden:?}: {msg}"
-        );
-    }
+    assert_no_recursive_delete(&msg);
+    assert!(
+        !msg.contains("    mv "),
+        "the refusal must not suggest moving a live store, got: {msg}"
+    );
 
     assert_eq!(
         std::fs::read_to_string(&marker).expect("the pre-existing worktree must still be there"),
@@ -677,6 +675,69 @@ fn assert_no_destructive_hint(msg: &str) {
     assert!(
         msg.contains("SHARED"),
         "recovery message must warn that the base is shared across sessions, got: {msg}"
+    );
+}
+
+/// #4270: `git clean -ffd` in the base clone must not delete session worktrees.
+///
+/// Why: the two review rounds contradicted each other on whether the missing
+/// `.git/info/exclude` entry was cosmetic, and the disagreement was a data-loss
+/// question, so it is settled here in the suite rather than by hand. Measured
+/// against real git: single-force `clean` reports `Skipping repository` and is
+/// safe, which is what makes this look harmless — but `-ff` removes
+/// `.worktrees/` outright, uncommitted session work included. The exclude entry
+/// is therefore a safety guard, and the in-project path has always written it.
+/// The provisioner producing the identical topology must too.
+/// What: builds the shipping topology with the production
+/// `ensure_base_checkout` and `worktree_add`, writes an uncommitted file into
+/// the worktree, then runs a real `git clean -ffd` in the base and asserts the
+/// file survives. Skips gracefully when git is unavailable.
+/// Test: this function IS the test.
+#[test]
+fn worktrees_exclude_entry_protects_against_double_force_clean() {
+    let scratch = crate::test_support::hermetic_temp_dir();
+    let Some(bare) = make_local_bare_origin(&scratch) else {
+        eprintln!("worktrees_exclude_entry_protects_against_double_force_clean: no git, skipping");
+        return;
+    };
+    let repo_url = format!("file://{}", bare.display());
+    let base_dir = scratch.path().join("owner").join("repo");
+    let backend = RealGitBackend::default();
+    backend
+        .ensure_base_checkout(&repo_url, &base_dir)
+        .expect("ensure_base_checkout must succeed");
+
+    let worktree = base_dir.join(".worktrees").join("sess-1");
+    backend
+        .worktree_add(&base_dir, "main", &worktree, "sess-1")
+        .expect("worktree_add must succeed");
+    let wip = worktree.join("WIP.txt");
+    std::fs::write(&wip, b"uncommitted session work").unwrap();
+
+    // The guard itself: `.worktrees/` must be excluded in the base clone.
+    let exclude = std::fs::read_to_string(base_dir.join(".git").join("info").join("exclude"))
+        .expect("the base clone must have a .git/info/exclude");
+    assert!(
+        exclude.lines().any(|l| l.trim() == ".worktrees/"),
+        "ensure_base_checkout must exclude .worktrees/, got: {exclude}"
+    );
+
+    let out = std::process::Command::new("git")
+        .arg("-C")
+        .arg(&base_dir)
+        .args(["clean", "-ffd"])
+        .output()
+        .expect("git clean -ffd");
+    let said = String::from_utf8_lossy(&out.stdout);
+
+    assert!(
+        wip.exists(),
+        "#4270: `git clean -ffd` in the base DELETED a session worktree's \
+         uncommitted work — git said: {said}"
+    );
+    assert!(
+        !said.contains(".worktrees"),
+        "`git clean -ffd` must not touch .worktrees/ at all, got: {said}"
     );
 }
 

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -663,14 +663,13 @@ fn ensure_base_checkout_rejects_stale_directory() {
 /// Test: used by `ensure_base_checkout_rejects_stale_directory`,
 /// `fake_ensure_base_checkout_rejects_stale_directory`, and
 /// `stale_base_dir_error_suggests_quarantine_not_deletion`.
+///
+/// The recursive-delete half is split into [`assert_no_recursive_delete`]
+/// because it applies to EVERY operator-facing refusal, while the `mv`
+/// requirement applies only to the foreign-debris case — a message aimed at a
+/// directory holding live worktrees must offer no `mv` at all (#4270).
 fn assert_no_destructive_hint(msg: &str) {
-    for forbidden in ["rm -rf", "rm -fr", "rm -r ", "remove_dir_all", "rmdir"] {
-        assert!(
-            !msg.contains(forbidden),
-            "recovery message must never suggest a recursive delete of the SHARED \
-             base checkout (#3605), but it contains {forbidden:?}: {msg}"
-        );
-    }
+    assert_no_recursive_delete(msg);
     assert!(
         msg.contains("    mv "),
         "recovery message must offer the non-destructive quarantine command, got: {msg}"
@@ -679,6 +678,66 @@ fn assert_no_destructive_hint(msg: &str) {
         msg.contains("SHARED"),
         "recovery message must warn that the base is shared across sessions, got: {msg}"
     );
+}
+
+/// Assert an operator-facing message names no recursive delete (#3605).
+///
+/// Why: the delete prohibition binds every refusal this code emits, not only
+/// the ones that also offer a quarantine. Splitting it out lets the refusals
+/// that deliberately suggest NOTHING (#4270) still be checked for the thing
+/// that caused the 2026-07-21 incident.
+/// What: fails if the message names any recursive-delete form.
+/// Test: used by `assert_no_destructive_hint` and
+/// `stale_base_dir_error_never_offers_to_move_a_dir_holding_live_worktrees`.
+fn assert_no_recursive_delete(msg: &str) {
+    for forbidden in ["rm -rf", "rm -fr", "rm -r ", "remove_dir_all", "rmdir"] {
+        assert!(
+            !msg.contains(forbidden),
+            "recovery message must never suggest a recursive delete (#3605), but it \
+             contains {forbidden:?}: {msg}"
+        );
+    }
+}
+
+/// #4270: the quarantine hint must never be aimed at a directory that holds
+/// git or trusty-mpm state.
+///
+/// Why: before #4270 `base_dir` was `<project_dir>/.base`, which an
+/// in-project-shaped project does not have — `stale_base_dir_error` returned
+/// `None` and its `mv` hint was unreachable there. Pointing `base_dir` at the
+/// project directory made it reachable, aimed at the directory holding
+/// `.worktrees/<id>` for every live session. That is the #3605 string with a
+/// bigger target. The trigger is loose enough to matter: `is_established_checkout`
+/// reports `false` for a transient git spawn failure just as it does for a
+/// non-repo, so a momentary hiccup on a healthy project reaches this message.
+/// What: builds the error for a project dir holding `.worktrees/sess-1`, then
+/// for one holding `.git`, and asserts neither offers a `mv` — while the
+/// foreign-debris case in the sibling test still does, so the #1937 recovery
+/// path is not lost.
+/// Test: this function IS the test.
+#[test]
+fn stale_base_dir_error_never_offers_to_move_a_dir_holding_live_worktrees() {
+    let root = crate::test_support::hermetic_temp_dir();
+
+    for (label, entry) in [("live worktrees", ".worktrees"), ("a git dir", ".git")] {
+        let dir = root.path().join(label.replace(' ', "-")).join("repo");
+        std::fs::create_dir_all(dir.join(entry).join("sess-1")).unwrap();
+
+        let msg = super::base_lock::stale_base_dir_error(&dir)
+            .unwrap_or_else(|| panic!("an occupied project dir holding {label} must error"))
+            .to_string();
+
+        assert!(
+            !msg.contains("    mv "),
+            "#4270: the quarantine hint must never target a directory holding {entry} — \
+             moving it orphans every session under it, got: {msg}"
+        );
+        assert!(
+            msg.contains(entry),
+            "the refusal must name what it found, got: {msg}"
+        );
+        assert_no_recursive_delete(&msg);
+    }
 }
 
 /// #3605 regression guard: `stale_base_dir_error`'s message must recover the
@@ -957,17 +1016,28 @@ fn provisioner_worktree_add_writes_no_foreign_branch_merge() {
         return; // git unavailable
     };
     let repo_url = format!("file://{}", bare.display());
-    let base_dir = scratch.path().join("base.git");
+    // #4270: exercise the SHIPPING topology with real git — a non-bare base at
+    // the project dir and the worktree NESTED inside it at
+    // `<project_dir>/.worktrees/<id>`, not a sibling under a bare base. Whether
+    // real `git worktree add` accepts a path inside its own base's working tree
+    // is the load-bearing question of this change, and a `FakeGitBackend` whose
+    // `worktree_add` is a `create_dir_all` cannot answer it.
+    let base_dir = scratch.path().join("owner").join("repo");
     let backend = RealGitBackend::default();
     backend
         .ensure_base_checkout(&repo_url, &base_dir)
         .expect("ensure_base_checkout must succeed against a local bare origin");
 
-    let worktree = scratch.path().join("wt");
     let branch = "session/tm-2867-01";
+    let worktree = base_dir.join(".worktrees").join(branch.replace('/', "-"));
     backend
         .worktree_add(&base_dir, "main", &worktree, branch)
-        .expect("worktree_add must succeed");
+        .expect("worktree_add must succeed into <project_dir>/.worktrees/<id>");
+    assert!(
+        worktree.join(".git").exists(),
+        "real git must produce a working worktree nested under its own base at {}",
+        worktree.display()
+    );
 
     // Every branch.<name>.merge in the whole config must name its own branch.
     let listed = std::process::Command::new("git")

--- a/crates/trusty-mpm/src/provisioner/workspace/tests.rs
+++ b/crates/trusty-mpm/src/provisioner/workspace/tests.rs
@@ -130,8 +130,9 @@ fn provisioner_uses_session_id_subdir() {
 #[serial_test::serial]
 fn provision_in_uses_explicit_project_dir() {
     // The #1220 path: caller supplies a pre-resolved `<owner>/<repo>` project
-    // dir. #1935: the session worktree nests under the project dir's shared
-    // `.base/.worktrees/<session-id>/`, not directly under the project dir.
+    // dir. #1935 nested the session worktree under a shared base checkout;
+    // #4270 made that base the project dir itself, so the worktree is
+    // `<project_dir>/.worktrees/<session-id>/` — the git-standard shape.
     let root = crate::test_support::hermetic_temp_dir();
     let _home = set_home(root.path());
     let prov = make_provisioner(&root);
@@ -148,16 +149,142 @@ fn provision_in_uses_explicit_project_dir() {
         )
         .unwrap();
 
-    // Path must be exactly <project_dir>/.base/.worktrees/<session-id> —
-    // isolated under the project dir, nested under the shared base checkout.
     assert_eq!(
         ws.path,
-        project_dir
-            .join(".base")
-            .join(".worktrees")
-            .join(id.to_string())
+        project_dir.join(".worktrees").join(id.to_string()),
+        "#4270: the worktree must land directly under the project dir's .worktrees/"
     );
     assert!(ws.path.starts_with(&project_dir));
+}
+
+/// #4270 requirement 1: provisioning from a repo URL puts the worktree at
+/// `<project-root>/.worktrees/<name>`, not `<root>/.base/.worktrees/<name>`.
+///
+/// Why: this is the owner ruling ("all new worktrees should be in .worktrees --
+/// we need to follow the git convention here") stated as an executable
+/// assertion. The sibling `provision_in_uses_explicit_project_dir` pins the
+/// exact path; this one pins the NEGATIVE that the ruling is about, so a
+/// regression that restores the `.base/` nesting fails here by name.
+/// What: provisions one session and asserts the worktree path contains no
+/// `.base` component and equals the `.worktrees/<id>` shape.
+/// Test: this function IS the test.
+#[test]
+#[serial_test::serial]
+fn provision_in_puts_worktrees_under_the_project_root_not_dot_base() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let _home = set_home(root.path());
+    let prov = make_provisioner(&root);
+    let id = ManagedSessionId::new();
+    let project_dir = root.path().join("owner").join("repo");
+
+    let ws = prov
+        .provision_in(&project_dir, &id, "https://github.com/owner/repo", "", "t")
+        .unwrap();
+
+    assert!(
+        !ws.path
+            .components()
+            .any(|c| c.as_os_str() == crate::core::harness_root::BASE_CLONE_DIRNAME),
+        "#4270: no .base component may appear in a provisioned worktree path, got {}",
+        ws.path.display()
+    );
+    assert_eq!(ws.path, project_dir.join(".worktrees").join(id.to_string()));
+}
+
+/// #4270 requirement 2: the provisioning path creates no `.base` directory.
+///
+/// Why: moving the worktrees out of `.base/` while still cloning a bare store
+/// into it would satisfy the path assertion above and miss the point — the
+/// store itself is what #4270 retires. Asserting on the filesystem after a real
+/// provision is the only way to catch that half-fix.
+/// What: provisions one session and asserts `<project_dir>/.base` does not
+/// exist, while the base checkout markers DO exist at `<project_dir>` itself.
+/// Test: this function IS the test.
+#[test]
+#[serial_test::serial]
+fn provision_in_creates_no_dot_base_directory() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let _home = set_home(root.path());
+    let prov = make_provisioner(&root);
+    let id = ManagedSessionId::new();
+    let project_dir = root.path().join("owner").join("repo");
+
+    prov.provision_in(&project_dir, &id, "https://github.com/owner/repo", "", "t")
+        .unwrap();
+
+    assert!(
+        !project_dir
+            .join(crate::core::harness_root::BASE_CLONE_DIRNAME)
+            .exists(),
+        "#4270: provisioning must not create a .base store under {}",
+        project_dir.display()
+    );
+    assert!(
+        project_dir.join(".git").join("config").is_file(),
+        "the base checkout must be established at the project dir itself"
+    );
+}
+
+/// #4270 requirement 3: an EXISTING `.base` worktree survives provisioning
+/// untouched.
+///
+/// Why: this is the requirement that protects live sessions. Existing `.base`
+/// stores were deliberately not migrated, so the new path meets them on real
+/// installations — and the generic stale-directory recovery hint would have told
+/// an agent to `mv` the whole project directory aside, orphaning every worktree
+/// under it (the #3605 shape, one level up). The refusal must be loud, and it
+/// must move nothing.
+/// What: pre-seeds a `.base/.worktrees/live/` worktree holding a marker file,
+/// provisions against that project dir, and asserts (1) the call fails, (2) the
+/// error names `.base` and suggests no `mv`/`rm`, (3) the marker file is still
+/// there with its original content.
+/// Test: this function IS the test.
+#[test]
+#[serial_test::serial]
+fn provision_in_leaves_an_existing_dot_base_store_untouched() {
+    let root = crate::test_support::hermetic_temp_dir();
+    let _home = set_home(root.path());
+    let prov = make_provisioner(&root);
+    let project_dir = root.path().join("owner").join("repo");
+
+    let live_worktree = project_dir
+        .join(crate::core::harness_root::BASE_CLONE_DIRNAME)
+        .join(".worktrees")
+        .join("live");
+    std::fs::create_dir_all(&live_worktree).unwrap();
+    let marker = live_worktree.join("IN-USE.txt");
+    std::fs::write(&marker, "a live session is working here").unwrap();
+
+    let result = prov.provision_in(
+        &project_dir,
+        &ManagedSessionId::new(),
+        "https://github.com/owner/repo",
+        "",
+        "t",
+    );
+
+    assert!(
+        result.is_err(),
+        "provisioning over a live legacy .base store must fail loudly, got {result:?}"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains(crate::core::harness_root::BASE_CLONE_DIRNAME),
+        "the refusal must name the legacy store, got: {msg}"
+    );
+    for forbidden in ["rm -rf", "rm -fr", "    mv "] {
+        assert!(
+            !msg.contains(forbidden),
+            "the refusal must not suggest moving or deleting a live store, but it \
+             contains {forbidden:?}: {msg}"
+        );
+    }
+
+    assert_eq!(
+        std::fs::read_to_string(&marker).expect("the pre-existing worktree must still be there"),
+        "a live session is working here",
+        "#4270: an existing .base worktree must not be disturbed, relocated, or deleted"
+    );
 }
 
 /// #1935: a second session provisioned for the SAME project must reuse the
@@ -169,9 +296,9 @@ fn provision_in_uses_explicit_project_dir() {
 /// that project reuses it via `worktree_add`.
 /// What: provisions two sessions against the same project dir, asserts (1)
 /// `FakeGitBackend::ensure_base_checkout` observed exactly one call whose
-/// `HEAD` marker was absent (the actual clone) — the second call is a no-op
-/// because the marker now exists; (2) the two sessions get DISTINCT
-/// worktree paths sharing the same `.base/` parent.
+/// `.git/config` marker was absent (the actual clone) — the second call is a
+/// no-op because the marker now exists; (2) the two sessions get DISTINCT
+/// worktree paths sharing the same project-dir base.
 /// Test: this function IS the test.
 #[test]
 #[serial_test::serial]
@@ -203,15 +330,15 @@ fn provision_reuses_base_checkout_across_sessions() {
         )
         .unwrap();
 
-    let base_dir = project_dir.join(".base");
-    // Both worktrees share the same base checkout directory...
-    assert!(ws1.path.starts_with(&base_dir));
-    assert!(ws2.path.starts_with(&base_dir));
+    // #4270: both worktrees share the same base checkout — the project dir.
+    let worktrees_dir = project_dir.join(".worktrees");
+    assert!(ws1.path.starts_with(&worktrees_dir));
+    assert!(ws2.path.starts_with(&worktrees_dir));
     // ...but are otherwise distinct, isolated directories.
     assert_ne!(ws1.path, ws2.path);
     // The base checkout itself was established exactly once (idempotent
-    // `HEAD` marker check inside `FakeGitBackend::ensure_base_checkout`).
-    assert!(base_dir.join("HEAD").is_file());
+    // `.git/config` marker check inside `FakeGitBackend::ensure_base_checkout`).
+    assert!(project_dir.join(".git").join("config").is_file());
 }
 
 #[test]
@@ -408,7 +535,7 @@ fn make_local_bare_origin(scratch: &TempDir) -> Option<PathBuf> {
 /// race on `ensure_base_checkout`.
 ///
 /// Why: before the fix, both racing callers observed `base_dir.join("HEAD")`
-/// absent, both attempted `git clone --bare`, and the loser hit git's
+/// absent, both attempted a clone, and the loser hit git's
 /// "destination path ... already exists and is not an empty directory"
 /// error, surfacing as a hard `ProvisionError::Git` and failing that
 /// session's provisioning outright.
@@ -416,10 +543,9 @@ fn make_local_bare_origin(scratch: &TempDir) -> Option<PathBuf> {
 /// `RealGitBackend.ensure_base_checkout(repo_url, &base_dir)` concurrently
 /// against the exact same, not-yet-existing `base_dir`, then asserts (1)
 /// every thread returned `Ok(())` — no race loser propagates the "already
-/// exists" error — and (2) exactly one genuinely established bare checkout
-/// exists at `base_dir` afterward (`git rev-parse --is-bare-repository`
-/// reports `true`). Skips gracefully if the local `git` binary is
-/// unavailable.
+/// exists" error — and (2) exactly one genuinely established checkout
+/// exists at `base_dir` afterward. Skips gracefully if the local `git` binary
+/// is unavailable.
 /// Test: this function IS the test.
 #[test]
 fn ensure_base_checkout_recovers_from_concurrent_race() {
@@ -431,7 +557,8 @@ fn ensure_base_checkout_recovers_from_concurrent_race() {
     let repo_url = format!("file://{}", bare_origin.display());
 
     let root = crate::test_support::hermetic_temp_dir();
-    let base_dir = root.path().join("project").join(".base");
+    // #4270: the base checkout IS the project directory.
+    let base_dir = root.path().join("owner").join("repo");
 
     let handles: Vec<_> = (0..4)
         .map(|_| {
@@ -452,28 +579,27 @@ fn ensure_base_checkout_recovers_from_concurrent_race() {
     }
 
     assert!(
-        is_established_bare_checkout(&base_dir),
-        "base_dir must be a genuinely established bare checkout after the race settles"
+        is_established_checkout(&base_dir),
+        "base_dir must be a genuinely established checkout after the race settles"
     );
 }
 
-/// trusty-review finding #2 (fragile bare-clone detection, PR #1936): a
-/// stale NON-bare directory sitting at the base-checkout path must not be
-/// silently accepted as a valid shared base.
+/// trusty-review finding #2 (fragile clone detection, PR #1936): a stale
+/// directory sitting at the base-checkout path must not be silently accepted
+/// as a valid shared base.
 ///
 /// Why: the previous idempotency guard (`base_dir.join("HEAD").is_file()`)
 /// only checks for a file NAMED `HEAD` at the root of `base_dir` — it never
 /// confirms that directory is actually a valid, complete git repository.
-/// Verified empirically (see this test): a plain non-bare `git init`/`clone`
-/// does NOT put a `HEAD` file at its OWN root (that lives at `.git/HEAD`
-/// instead), but a directory that merely CONTAINS a stray file literally
-/// named `HEAD` — e.g. left over from a `git clone --bare` that crashed
-/// mid-clone (git writes `HEAD` early, before the rest of the object
-/// database/refs), or any other stale/corrupt artifact occupying
-/// `<project_dir>/.base/` — passes the old check and would be silently
-/// treated as an established base, so cloning is skipped and a corrupt
-/// directory is left as the "base"; later `git worktree add` /
-/// `git fetch` calls against it then fail confusingly.
+/// Verified empirically (see this test): a plain `git init`/`clone` does NOT
+/// put a `HEAD` file at its OWN root (that lives at `.git/HEAD` instead), but
+/// a directory that merely CONTAINS a stray file literally named `HEAD` — e.g.
+/// left over from a clone that crashed mid-flight (git writes `HEAD` early,
+/// before the rest of the object database/refs), or any other stale/corrupt
+/// artifact occupying the base path — passes the old check and would be
+/// silently treated as an established base, so cloning is skipped and a corrupt
+/// directory is left as the "base"; later `git worktree add` / `git fetch`
+/// calls against it then fail confusingly.
 /// What: pre-creates `base_dir` containing ONLY a `HEAD` file (no `.git`,
 /// no object database, no refs — the minimum needed to fool the OLD
 /// file-existence check) and calls `RealGitBackend.ensure_base_checkout`
@@ -483,18 +609,16 @@ fn ensure_base_checkout_recovers_from_concurrent_race() {
 /// binary is unavailable.
 /// Test: this function IS the test.
 #[test]
-fn ensure_base_checkout_rejects_stale_non_bare_directory() {
+fn ensure_base_checkout_rejects_stale_directory() {
     let scratch = crate::test_support::hermetic_temp_dir();
     let Some(bare_origin) = make_local_bare_origin(&scratch) else {
-        eprintln!(
-            "ensure_base_checkout_rejects_stale_non_bare_directory: git unavailable, skipping"
-        );
+        eprintln!("ensure_base_checkout_rejects_stale_directory: git unavailable, skipping");
         return;
     };
     let repo_url = format!("file://{}", bare_origin.display());
 
     let root = crate::test_support::hermetic_temp_dir();
-    let base_dir = root.path().join("project").join(".base");
+    let base_dir = root.path().join("owner").join("repo");
     std::fs::create_dir_all(&base_dir).unwrap();
     std::fs::write(base_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
@@ -503,8 +627,8 @@ fn ensure_base_checkout_rejects_stale_non_bare_directory() {
         "sanity check: the stale directory has a file literally named HEAD"
     );
     assert!(
-        !is_established_bare_checkout(&base_dir),
-        "sanity check: a lone HEAD file with no repo structure must NOT read as bare"
+        !is_established_checkout(&base_dir),
+        "sanity check: a lone HEAD file with no repo structure must NOT read as a checkout"
     );
 
     let result = RealGitBackend::default().ensure_base_checkout(&repo_url, &base_dir);
@@ -536,8 +660,8 @@ fn ensure_base_checkout_rejects_stale_non_bare_directory() {
 /// What: fails if the message names any recursive-delete form, and requires the
 /// non-destructive `mv`-aside quarantine hint plus the shared-ownership warning
 /// that was missing when the destructive hint was followed.
-/// Test: used by `ensure_base_checkout_rejects_stale_non_bare_directory`,
-/// `fake_ensure_base_checkout_rejects_stale_non_bare_directory`, and
+/// Test: used by `ensure_base_checkout_rejects_stale_directory`,
+/// `fake_ensure_base_checkout_rejects_stale_directory`, and
 /// `stale_base_dir_error_suggests_quarantine_not_deletion`.
 fn assert_no_destructive_hint(msg: &str) {
     for forbidden in ["rm -rf", "rm -fr", "rm -r ", "remove_dir_all", "rmdir"] {
@@ -568,7 +692,7 @@ fn assert_no_destructive_hint(msg: &str) {
 /// useless hint is not an improvement), and the quarantine destination must be
 /// a concrete, distinct sibling path — not the base path itself, which would
 /// make the suggested `mv` a no-op.
-/// What: builds the error for a non-empty, non-bare directory and asserts the
+/// What: builds the error for a non-empty, non-repo directory and asserts the
 /// message names the path, carries the quarantine + SHARED warning, offers no
 /// recursive delete, and targets a `.stale-` sibling destination that differs
 /// from the source path.
@@ -581,7 +705,7 @@ fn stale_base_dir_error_suggests_quarantine_not_deletion() {
     std::fs::write(base_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     let err = super::base_lock::stale_base_dir_error(&base_dir)
-        .expect("a non-empty, non-bare base dir must produce an error");
+        .expect("a non-empty, non-repo base dir must produce an error");
     let msg = err.to_string();
 
     assert!(
@@ -623,30 +747,30 @@ fn stale_base_dir_error_suggests_quarantine_not_deletion() {
 ///
 /// Why: before this fix `FakeGitBackend::ensure_base_checkout` reused any
 /// directory containing a stray `HEAD` file (the same superficial probe the
-/// real backend abandoned), so a future author simulating a stale `.base` with
+/// real backend abandoned), so a future author simulating a stale base with
 /// the fake would get a false-positive "already established" pass instead of
 /// the loud rejection the real backend now produces. This test mirrors
-/// `ensure_base_checkout_rejects_stale_non_bare_directory` against the fake.
-/// What: pre-seeds `base_dir` with ONLY a stray `HEAD` file (no `config`
-/// `bare = true` marker — the fake's stand-in for "not a valid bare checkout")
-/// and asserts `FakeGitBackend::ensure_base_checkout` returns an actionable
-/// `Err` naming the path and the non-destructive quarantine recovery command,
-/// exactly like the real backend — not a silent `Ok` reuse.
+/// `ensure_base_checkout_rejects_stale_directory` against the fake.
+/// What: pre-seeds `base_dir` with ONLY a stray `HEAD` file (no `.git/config`
+/// marker — the fake's stand-in for "not a valid checkout") and asserts
+/// `FakeGitBackend::ensure_base_checkout` returns an actionable `Err` naming
+/// the path and the non-destructive quarantine recovery command, exactly like
+/// the real backend — not a silent `Ok` reuse.
 /// Test: this function IS the test.
 #[test]
-fn fake_ensure_base_checkout_rejects_stale_non_bare_directory() {
+fn fake_ensure_base_checkout_rejects_stale_directory() {
     let root = crate::test_support::hermetic_temp_dir();
-    let base_dir = root.path().join("project").join(".base");
+    let base_dir = root.path().join("owner").join("repo");
     std::fs::create_dir_all(&base_dir).unwrap();
-    // A lone HEAD file with no `config bare = true` marker is the fake's
-    // stand-in for a stale, non-bare, mid-crash directory.
+    // A lone HEAD file with no `.git/config` marker is the fake's stand-in for
+    // a stale, mid-crash directory.
     std::fs::write(base_dir.join("HEAD"), "ref: refs/heads/main\n").unwrap();
 
     let fake = FakeGitBackend::new();
     let result = fake.ensure_base_checkout("https://github.com/owner/repo", &base_dir);
     assert!(
         result.is_err(),
-        "fake must reject a stale non-bare directory loudly, not silently reuse it: {result:?}"
+        "fake must reject a stale directory loudly, not silently reuse it: {result:?}"
     );
     let msg = result.unwrap_err().to_string();
     assert!(
@@ -657,34 +781,33 @@ fn fake_ensure_base_checkout_rejects_stale_non_bare_directory() {
 }
 
 /// #1937 item 3 (positive path): a FRESH `FakeGitBackend::ensure_base_checkout`
-/// establishes a valid fake bare checkout, and a SECOND call reuses it
+/// establishes a valid fake checkout, and a SECOND call reuses it
 /// idempotently (no error, no clobber).
 ///
 /// Why: locks in that the tightened validity check does not regress the
 /// happy-path reuse contract — the fake must still recognise the base it just
 /// wrote as established on the next call.
 /// What: calls `ensure_base_checkout` twice against an empty base path; asserts
-/// both return `Ok`, the second is recognised via `fake_is_established_bare_checkout`,
-/// and the written markers (`HEAD` + `bare = true` `config`) are present.
+/// both return `Ok`, the second is recognised via `fake_is_established_checkout`,
+/// and the written `.git/config` marker is present.
 /// Test: this function IS the test.
 #[test]
 fn fake_ensure_base_checkout_is_idempotent_on_valid_base() {
     let root = crate::test_support::hermetic_temp_dir();
-    let base_dir = root.path().join("project").join(".base");
+    let base_dir = root.path().join("owner").join("repo");
     let fake = FakeGitBackend::new();
 
     fake.ensure_base_checkout("https://github.com/owner/repo", &base_dir)
         .expect("first ensure must establish the fake base");
     assert!(
-        super::base_lock::fake_is_established_bare_checkout(&base_dir),
-        "a freshly-established fake base must read as a valid bare checkout"
+        super::base_lock::fake_is_established_checkout(&base_dir),
+        "a freshly-established fake base must read as a valid checkout"
     );
 
     // Second call must be an idempotent no-op reuse, not a stale rejection.
     fake.ensure_base_checkout("https://github.com/owner/repo", &base_dir)
         .expect("second ensure must reuse the established fake base");
-    assert!(base_dir.join("HEAD").is_file());
-    assert!(base_dir.join("config").is_file());
+    assert!(base_dir.join(".git").join("config").is_file());
 }
 
 /// A lock marker abandoned by a crashed holder must not permanently deadlock

--- a/crates/trusty-mpm/tests/local_spawn.rs
+++ b/crates/trusty-mpm/tests/local_spawn.rs
@@ -410,16 +410,15 @@ fn spawn_managed_local_redirects_to_managed_clone() {
         .expect("provision_in must succeed with FakeGitBackend");
 
     // KEY ASSERTIONS: the workspace is the MANAGED clone path, NOT the live checkout.
-    // #1935: the managed path now nests each session's git worktree under a
-    // shared, persistent base checkout (`<project_dir>/.base/.worktrees/<id>`)
-    // rather than a full clone directly at `<project_dir>/<id>`.
-    let expected = project_dir
-        .join(".base")
-        .join(".worktrees")
-        .join(session_id.to_string());
+    // #1935 nested each session's git worktree under a shared, persistent base
+    // checkout rather than a full clone directly at `<project_dir>/<id>`.
+    // #4270 made that base the project dir itself, so the worktree is
+    // `<project_dir>/.worktrees/<id>` — the git convention, and the same shape
+    // the in-project spawn path produces.
+    let expected = project_dir.join(".worktrees").join(session_id.to_string());
     assert_eq!(
         prepared.path, expected,
-        "spawn_managed_local must route to <project_dir>/.base/.worktrees/<session_id>, \
+        "spawn_managed_local must route to <project_dir>/.worktrees/<session_id>, \
          not the live checkout"
     );
     assert!(


### PR DESCRIPTION
## What changed

New sessions provisioned from a repo URL now get their worktree at
`<project-root>/.worktrees/<name>`, the git convention. They used to land inside
a `.base` bare clone at `<project-root>/.base/.worktrees/<id>`.

The base checkout moved with them: it is now the project directory's own clone —
the same clone `inproject::ensure_base_clone` establishes. A repo spawned from a
URL and the same repo spawned from a local checkout now share one base clone per
project instead of keeping two stores in one project directory. That is the
common-entry-point rule applied to the thing the two paths were duplicating.

Nothing writes `.base` any more.

## Map — corrected against the code

The dispatch map in the brief was right about the files. One correction and one
addition:

| Brief said | Code says |
|---|---|
| Make `spawn_managed_cloned` reuse the in-project provisioning | Not directly callable. `try_inproject_spawn` needs a LOCAL checkout to detect a remote from; a URL spawn has no local path. The reuse that IS available is the topology, so the provisioner now establishes the same base clone at the same place. Calling `ensure_base_clone` itself would have dropped the per-project `GitIdentity` (#2184) that `RealGitBackend` applies to every git subprocess — private-repo clone auth. |
| `harness_root.rs:52-60` doc is stale | Confirmed, corrected. `BASE_CLONE_DIRNAME` is now `pub(crate)` — one literal for `.base`, shared by the reader that maps a `.base` common-dir back to its project and the two writers that refuse to clobber one. |
| — | `inproject::migrate_old_layout_aside` needed a guard. A project directory holding a `.base` store matches the pre-#1803 old-layout signature exactly (non-empty, no top-level `.git`), so it renamed the directory to `<repo>.old-layout-backup-<ts>` — taking `.base` and every live worktree with it. This is requirement 3's actual mechanism; see the fail-before output below. |

`lifecycle.rs:626-636` needed only a comment correction: the dispatch is unchanged,
`provision_in` does the work.

## Out of scope, as instructed

No migration, no compatibility layer, no `.base` sweep, no config toggle. Existing
`.base` worktrees are git-native — `git worktree list` finds them, registry entries
hold absolute paths, and `harness_root`'s `.base`→project mapping is untouched — so
they keep working with no code supporting them. Cleanup stays manual and the
owner's.

Two guards exist only because the new topology makes both spawn paths meet a
project directory that holds a `.base`. Both refuse; neither moves anything.
The refusal message deliberately carries no `mv` hint: the generic quarantine hint
aimed at a project directory would rename every worktree under the store out from
under its session — the #3605 shape, one level up.

## Tests — fail before, pass after

Requirements 1 and 2 (`provisioner/workspace/tests.rs`), requirement 3 twice —
once per code path that could disturb a live store.

Fail-before, with the path computation temporarily reverted:

```
test provisioner::workspace::tests::provision_in_creates_no_dot_base_directory ... FAILED
test provisioner::workspace::tests::provision_in_leaves_an_existing_dot_base_store_untouched ... FAILED
test provisioner::workspace::tests::provision_in_puts_worktrees_under_the_project_root_not_dot_base ... FAILED
test result: FAILED. 0 passed; 3 failed; 0 ignored; 0 measured; 4610 filtered out
```

Fail-before for the migrator guard, with the guard removed — this is the data-loss
shape stated outright:

```
test daemon::managed_routes::inproject::tests::migrate_old_layout_aside_refuses_a_dir_holding_a_dot_base_store ... FAILED
assertion failed: a dir holding a .base store must be refused, not migrated:
  Some("/tmp/tm-test-dy17uI/owner/repo.old-layout-backup-1785941128950735000")
test result: FAILED. 0 passed; 1 failed
```

`tests/local_spawn.rs::spawn_managed_local_redirects_to_managed_clone` pinned the
old `.base` path and was updated to the new one — it now produces exactly the
target shape.

## Gates — Rust Test Ladder rung 5 (process lifecycle / session provisioning)

| Gate | Result |
|---|---|
| `cargo fmt --check` | EXIT=0 |
| `cargo clippy -p trusty-mpm --all-targets -- -D warnings` | EXIT=0 |
| `cargo test -p trusty-mpm -- --test-threads=1` | EXIT=0 — 4606 passed, 0 failed, 7 ignored (lib) + every integration target green |
| `bash scripts/check_line_cap.sh` | EXIT=0 — 3688 files, 0 violations |
| `bash scripts/check_sld.sh` | EXIT=0 |
| `bash scripts/check_changelog_fragment.sh` | EXIT=0 — scanned 9 paths |
| `cargo check --workspace` | EXIT=101 — known baseline: Tauri `frontendDist` proc-macro panic in `trusty-code-gui` and `trusty-mpm-gui`. Neither crate is touched by this diff. |

`--test-threads=1` per the documented `$HOME`-race baseline
(`docs/reference/test-ladder-baseline.md`).

`workspace.rs` hit 502 SLOC against the 500 cap. Fixed by folding the legacy-store
guard into `stale_base_dir_error` — the single "is this path safe to clone into?"
entry point — which removed the duplicated call at both backends rather than
allowlisting the file.

## Not done, deliberately

Issue #4270's table also lists routing `tm launch` and the guided default through
`spawn_managed_inproject`. Both already call `ensure_base_clone` and so already
produce `<project-root>/.worktrees/<name>`; routing them differently changes no
topology. Left out under the scope constraint.

A URL-provisioned project's `.worktrees/` is not added to the base clone's
`.git/info/exclude`, so it shows as untracked in `git status` run inside the base
clone. The in-project path does add it, and any project that has ever used that
path is already covered. Cosmetic, and the fix means moving
`ensure_worktrees_gitignored` out of the daemon-gated module.

Closes #4270

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
