### PR TITLE
feat(vmtest-harness): bring trusty-console into the verified scope

### DIFF
--- a/docs/research/tart-vm-testing-harness/02-design/01-vm-install-harness.md
+++ b/docs/research/tart-vm-testing-harness/02-design/01-vm-install-harness.md
@@ -75,7 +75,7 @@ so `cargo search` against the registry index is the evidence of record.)
 **The consequence.** `trusty-mpm` **is** installable by `cargo install trusty-mpm
 --locked` and is therefore **coverable by pattern (a)**. The "documented gap" this
 decision used to record **does not exist and is dissolved.** Pattern (a) covers the
-full eight-crate stack (D3), and the harness makes the same claim for all three
+full nine-crate stack (D3), and the harness makes the same claim for all three
 patterns.
 
 What survives the reversal is the *rule*, not the exception it was invented for:
@@ -94,7 +94,7 @@ count match. That rule now costs nothing, because nothing needs excluding.
 > keeping: a claim about publish status is checkable in one command, and this one
 > was never run until now.
 
-#### D3 — The stack is eight crates
+#### D3 — The stack is nine crates
 
 | # | Crate (workspace directory) | crates.io package | In pattern (a)? |
 |---|---|---|---|
@@ -106,10 +106,11 @@ count match. That rule now costs nothing, because nothing needs excluding.
 | 6 | `trusty-git-analytics` | **`tga`** | yes |
 | 7 | `trusty-installer` | `trusty-installer` | yes |
 | 8 | `trusty-review` | `trusty-review` (v0.10.1, verified 2026-07-31) | yes — **amended**, see below |
+| 9 | `trusty-console` | `trusty-console` (v0.4.0 published, v0.5.0 in tree, verified 2026-08-05) | yes — **amended**, see below |
 
-So **all three patterns cover all eight crates.** Row 5 previously read
+So **all three patterns cover all nine crates.** Row 5 previously read
 "— (`publish = false`)" / "**no** — D2"; that is corrected per the D2 reversal
-above. Row 8 is an addition, recorded immediately below.
+above. Rows 8 and 9 are additions, each recorded immediately below.
 
 > **Amendment, 2026-07-31 — D3 widened to eight crates; `trusty-review` added.**
 > This is a **product-owner decision**, not a correction of a false premise — D3 as
@@ -142,6 +143,40 @@ above. Row 8 is an addition, recorded immediately below.
 > the D2 reversal was: a design whose settled decisions quietly change is a design
 > nobody can audit. What is being reversed here is narrower than D2 — an omission
 > deliberately flagged as an omission, closed on purpose.
+
+> **Amendment, 2026-08-05 — D3 widened to nine crates; `trusty-console` added
+> (#4921).** Like the 2026-07-31 amendment above, this is a **product-owner
+> decision**, not a correction of a false premise: D3 was accurate about the
+> crates it named and simply did not name this one.
+>
+> **What the stack now is.** Nine crates, **fourteen** in-scope binaries (row 9
+> adds exactly one), and **six** liveness-checked daemons.
+>
+> **Verified before deciding, 2026-08-05.** `crates/trusty-console/Cargo.toml`
+> declares no `publish` key, so it publishes by cargo default, and `cargo search
+> trusty-console` returns `trusty-console = "0.4.0"`. It has exactly **one**
+> `[[bin]]` target — `name = "trusty-console"`, `path = "src/main.rs"`, no
+> `required-features` (`Cargo.toml:33-35`) — so it adds one binary, not a sidecar
+> set, and no Single-Install gate of its own (§7.4). Its `/health` route exists at
+> `crates/trusty-console/src/server/mod.rs:318` and is behind **no** feature gate;
+> the crate declares no `[features]` section at all. `stable_set()` has always
+> carried it with `daemon = true`
+> (`crates/trusty-installer/src/commands/stable_set.rs:180`), which is why the
+> harness's derived daemon set picks it up **with no code change** — the TSV's
+> `in_scope` column was the only thing excluding it.
+>
+> **Row 9 has a LARGER version gap than row 8, and it is a known-red one.** The
+> registry has **0.4.0**; the working tree is **0.5.0**, and the published build
+> lacks the `service` subcommand the harness's lifecycle path uses. Pattern (a) is
+> therefore expected to FAIL on this crate until a release lands — tracked as
+> **#4917**, and deliberately not worked around in the harness. Patterns (b) and
+> (c) build from the tree and are unaffected. This is release skew being *found*
+> by the pattern that exists to find it, which is the argument for widening scope
+> rather than against it.
+>
+> Recorded as a dated amendment rather than a silent edit for the same reason the
+> D2 reversal and the 2026-07-31 amendment were: a design whose settled decisions
+> quietly change is a design nobody can audit.
 
 Note the package-name discontinuity on row 6: the workspace directory is
 `crates/trusty-git-analytics`, the published package name and the binary are both
@@ -537,7 +572,7 @@ per crate. No host→guest source transfer occurs; the host repository is not re
 
 #### 6.3 Pattern (a) — released
 
-`cargo install <crate> --locked` from crates.io, for all eight publishable crates in
+`cargo install <crate> --locked` from crates.io, for all nine publishable crates in
 D3. `--locked` is mandatory — it is what makes the run reproducible against the
 published lockfile rather than against whatever the resolver feels like today.
 
@@ -609,6 +644,7 @@ binaries that install must produce:
 | `tga` | `tga` |
 | `trusty-mpm` | `tm`, `trusty-mpm` |
 | `trusty-review` | `trusty-review` |
+| `trusty-console` | `trusty-console` |
 
 > **Amendment, 2026-07-31 — third `trusty-memory` sidecar added.** The row above
 > originally listed two binaries and **omitted `trusty-memory-mcp-bridge`**.
@@ -630,6 +666,14 @@ binaries that install must produce:
 > `required-features = []` — so it adds one expectation and no sidecar set. Note
 > what that means for §7.4: a single-binary crate has no Single-Install Convention
 > to gate, and none is asserted for it.
+
+> **Amendment, 2026-08-05 — `trusty-console` row added** *(#4921)*. D3 was widened
+> to nine crates by the owner decision recorded there, so the table gains a ninth
+> row. Like `trusty-review` it is a **single-binary** crate — one `[[bin]]`,
+> `name = "trusty-console"`, `path = "src/main.rs"`, no `required-features`
+> (`Cargo.toml:33-35`) — so it adds one expectation, no sidecar set, and no
+> Single-Install Convention gate. The stack is now **fourteen** binaries across
+> nine crates.
 
 **Why a table and not the documentation:** `docs/reference/release-workflow.md`
 (~lines 450–460) is **stale** with respect to `trusty-console`. Asserting against
@@ -930,7 +974,7 @@ Per D4:
 3. **Pattern (a) — released.** Adds `scenarios/install-released.sh` only. No new
    infrastructure. *(Amended 2026-07-31: this step previously also called for
    pattern-aware `trusty-mpm` known-absent handling in the oracle. The D2 reversal
-   removes that work item — pattern (a) now expects the same **eight** crates
+   removes that work item — pattern (a) now expects the same **nine** crates
    present as (b) and (c), per §7.5 and D3 as amended.)*
 
 > **Settled:** the architecture sketch annotates `scenarios/install-local.sh` with

--- a/docs/research/tart-vm-testing-harness/02-design/02-harness-contracts.md
+++ b/docs/research/tart-vm-testing-harness/02-design/02-harness-contracts.md
@@ -492,7 +492,7 @@ PASS  iff  tool_version is a non-empty string
 This is the one DOC-1 §7.1 source that does not exist as a contract.
 
 Every daemon does expose `GET /health`, and it returns JSON. But there is **no
-shared type in `trusty-common`** and no unified schema. There are **five**
+shared type in `trusty-common`** and no unified schema. There are **six**
 independently-evolved shapes, with no field in common beyond `status` and
 `version`:
 
@@ -503,6 +503,21 @@ independently-evolved shapes, with no field in common beyond `status` and
 | `trusty-analyze` | `crates/trusty-analyze/src/service/routes.rs:75` | `crates/trusty-analyze/src/service/routes.rs:176-180` — `status`, `version`, `search_reachable`. Handler at `routes.rs:188-201`. **The only daemon here that signals through the HTTP STATUS CODE**: 200 + `status:"ok"` when trusty-search is reachable, **503** + `status:"degraded"` when it is not. |
 | `trusty-mpm` | `crates/trusty-mpm/src/daemon/api.rs:181` | `crates/trusty-mpm/src/daemon/api/types.rs:41-87` — `status`, `catalog_stale`, `catalog_unknown`, `catalog_changes`, `supervised`, `version` |
 | `trusty-review` | `crates/trusty-review/src/service/mod.rs:130` | `crates/trusty-review/src/service/handlers.rs:171-186` — `status`, `version`, `dry_run`, `reviewer_model`, `inference`, `deps{…}` |
+| `trusty-console` | `crates/trusty-console/src/server/mod.rs:318` | **No struct at all** — an inline `json!` literal at `crates/trusty-console/src/server/mod.rs:433-438` with a hardcoded `"status":"ok"` and `CARGO_PKG_VERSION`. Exactly **two** fields, neither reflecting any state the daemon actually observes. |
+
+> **`trusty-console` added 2026-08-05** *(#4921)*, when D3 was widened to nine
+> crates and brought it into the harness's in-scope set. It was already a
+> `stable_set()` daemon, so the derived iteration set picked it up with no code
+> change — which is precisely the property the 2026-08-04 note below was written to
+> establish, now exercised for the first time.
+>
+> **It also widens the spread this section exists to document, rather than
+> narrowing it:** 22 fields at one end, 2 at the other. And its literal
+> `{"status":"ok"}` is exactly the payload the **#3364** squatter class describes —
+> a generic body on a stale port that the INTERIM predicate cannot distinguish from
+> a real one. That is not a new hazard, but `trusty-console` is now the cheapest
+> demonstration of why RC-1's envelope needs a `service` discriminator and not
+> merely an agreed field set.
 
 > **`trusty-analyze` WAS MISSING FROM THIS TABLE, AND THE OMISSION PROPAGATED**
 > *(added 2026-08-04)*. It is an in-scope package, `stable_set()` marks it a
@@ -1555,7 +1570,8 @@ that will be slow.
 ### 9. `expected-binaries.tsv` schema
 
 DOC-1 §7.2 establishes the table as the single authoritative expectation source and
-gives a seed table of eight rows (seven until D3 was widened on 2026-07-31).
+gives a seed table of nine rows (seven until D3 was widened on 2026-07-31, eight
+until it was widened again on 2026-08-05).
 DOC-1 §7.2's own note flags the `--check-table`
 diff source of truth as unnamed and recommends the `[[bin]]` targets. This section
 gives the real schema, the real seed content enumerated from the workspace, and
@@ -1621,9 +1637,9 @@ which is a further argument for keying on package name.
 #### 9.3 Seed content
 
 Enumerated from the workspace manifests. **27** explicit `[[bin]]` targets across 20
-manifests, plus one implicit target (§9.4) — **28** rows in total. **Thirteen** rows
-are in scope; DOC-1 D3's **eight** crates produce **thirteen** binaries, not eight.
-The eight in-scope `crate_dir` values are the eight D3 directories — see §12.5 and
+manifests, plus one implicit target (§9.4) — **28** rows in total. **Fourteen** rows
+are in scope; DOC-1 D3's **nine** crates produce **fourteen** binaries, not nine.
+The nine in-scope `crate_dir` values are the nine D3 directories — see §12.5 and
 the plan's §F-3 on why the loop over them must deduplicate.
 
 > **Correction, 2026-07-31 — the explicit count read 26.** The prose said "26
@@ -1636,6 +1652,31 @@ the plan's §F-3 on why the loop over them must deduplicate.
 > to read `cargo metadata` rather than a `crates/*/Cargo.toml` glob; the prose
 > counted the manifest but not its target. "20 manifests" was right; only the target
 > total was wrong, and the table was right all along.
+
+> **Amendment, 2026-08-05 — in scope goes from thirteen rows to fourteen;
+> `trusty-console` moved (#4921).** DOC-1 D3 was widened to nine crates by its own
+> dated amendment of the same date; this section follows it. The row below moved
+> from the out-of-scope block to the END of the in-scope block and now carries
+> `in_scope=yes` with `present` in all three `expect_*` columns.
+>
+> **The 28-row total is UNCHANGED, and that is the point of the out-of-scope
+> block.** Nothing was added to the table and nothing was removed from it — the
+> `in_scope` column flipped on a row that was already carried. The counts that
+> move are the derived ones: **fourteen** in-scope rows, **nine** `crate_dir`
+> values, **nine** package names. `--check-table` prints exactly those three
+> numbers and reported `in scope: 14 binaries, 9 crate directories, 9 packages`
+> against the shipped table.
+>
+> **END, not alphabetical, and the position is load-bearing.** Appending keeps
+> `trusty-git-analytics` at `crate_dir` position 6, which the pattern-(a) prose in
+> `lib/source.sh` cites when it says the directory/package discontinuity bites
+> after five successful installs. An alphabetical insert would have moved it to 7
+> and falsified that sentence silently.
+>
+> Evidence for the row itself is recorded in DOC-1 D3's 2026-08-05 amendment: one
+> `[[bin]]`, an unconditional `/health`, `publish` by cargo default, and
+> `daemon = true` in `stable_set()` since before the harness existed. The
+> crates.io release skew that makes pattern (a) known-red on it is #4917.
 
 ```
 package	crate_dir	binary	bin_path	req_features	in_scope	expect_a	expect_b	expect_c
@@ -1652,6 +1693,7 @@ tga	trusty-git-analytics	tga	src/main.rs	-	yes	present	present	present
 trusty-mpm	trusty-mpm	tm	src/bin/tm/main.rs	cli	yes	present	present	present
 trusty-mpm	trusty-mpm	trusty-mpm	src/bin/tm/main.rs	cli	yes	present	present	present
 trusty-review	trusty-review	trusty-review	src/main.rs	-	yes	present	present	present
+trusty-console	trusty-console	trusty-console	src/main.rs	-	yes	present	present	present
 # --- out of scope per DOC-1 D3; carried so --check-table can detect additions ---
 trusty-agents	trusty-agents	tagent	src/main.rs	-	no	-	-	-
 trusty-agents-ui	trusty-agents/ui/src-tauri	trusty-agents-ui	src/main.rs	-	no	-	-	-
@@ -1661,7 +1703,6 @@ trusty-channels	trusty-channels	telegram-mcp	src/bin/telegram-mcp.rs	-	no	-	-	-
 trusty-code-gui	trusty-code-gui	trusty-code-gui	src/main.rs	-	no	-	-	-
 trusty-common	trusty-common	candle_metal_bench	src/bin/candle_metal_bench.rs	embedder-candle	no	-	-	-
 trusty-common	trusty-common	tickets-mcp	src/bin/tickets_mcp.rs	tickets	no	-	-	-
-trusty-console	trusty-console	trusty-console	src/main.rs	-	no	-	-	-
 trusty-embedderd-py	trusty-embedderd-py	trusty-embedderd-py	src/main.rs	-	no	-	-	-
 trusty-gworkspace	trusty-gworkspace	trusty-gworkspace-mcp	src/bin/trusty-gworkspace-mcp.rs	-	no	-	-	-
 trusty-kb	trusty-kb	trusty-kb	src/main.rs	-	no	-	-	-
@@ -1765,9 +1806,10 @@ right call for a document that could only flag the premise. It is the wrong call
 that the premise has been checked and D2 amended: an assertion known in advance to
 be false is not a safety net, it is a scheduled failure. Both `trusty-mpm` rows
 above now carry **`expect_a = present`**, matching DOC-1 D2 and §7.5 as amended, and
-all **thirteen** in-scope binaries are expected present under all three patterns
+all **fourteen** in-scope binaries are expected present under all three patterns
 (twelve when this paragraph was written; the thirteenth is `trusty-review`, added
-by the D3 amendment of the same date — §9.3 note 2).
+by the D3 amendment of the same date — §9.3 note 2; the fourteenth is
+`trusty-console`, added by the D3 amendment of 2026-08-05 — §9.3's amendment).
 
 The `expect_*` columns and the pattern-aware oracle **stay** regardless. With the
 gap dissolved no in-scope row currently diverges across patterns, but the columns

--- a/docs/research/tart-vm-testing-harness/02-design/README.md
+++ b/docs/research/tart-vm-testing-harness/02-design/README.md
@@ -54,17 +54,22 @@ numbers live in [`../01-research/vm-install-probe-findings.md`](../01-research/v
 - **Three patterns:** (c) local source streamed to the guest, (b) branch cloned in
   the guest, (a) released from crates.io. Implementation order is **(c) → (b) →
   (a)**.
-- **Eight crates** in scope, and **all three patterns cover all eight** — including
-  `trusty-mpm`, published (~~v1.0.2~~ **v1.3.4** as of 2026-08-04) and asserted
-  present (D2 reversed 2026-07-31; the old "documented gap in pattern (a)" is
-  dissolved), and `trusty-review`, published (~~v0.10.1~~ **v0.11.0** as of
-  2026-08-04) and brought into scope by an owner decision the same day (D3
-  amended). They produce **thirteen** binaries between them.
+- ~~**Eight crates**~~ **Nine crates** in scope, and **all three patterns cover all
+  ~~eight~~ nine** — including `trusty-mpm`, published (~~v1.0.2~~ **v1.3.4** as of
+  2026-08-04) and asserted present (D2 reversed 2026-07-31; the old "documented gap
+  in pattern (a)" is dissolved); `trusty-review`, published (~~v0.10.1~~ **v0.11.0**
+  as of 2026-08-04) and brought into scope by an owner decision the same day (D3
+  amended); and `trusty-console`, brought into scope 2026-08-05 by a further D3
+  amendment (#4921). They produce ~~**thirteen**~~ **fourteen** binaries between
+  them, and the liveness probe now covers **six** daemons rather than five.
   *(Versions refreshed 2026-08-04, P8-T5. **Treat every published version in this
   doc set as illustrative, not as a fixture** — crates.io moves under the docs, and
   both of these moved within four days of being written down. What is load-bearing
-  is that all eight are **published and installable**, which Phase 7 proved with a
-  real pattern-(a) run rather than with a `cargo search`.)*
+  is that all ~~eight~~ nine are **published and installable**, which Phase 7 proved
+  with a real pattern-(a) run rather than with a `cargo search` — with one live
+  exception: `trusty-console` publishes at 0.4.0, which predates the `service`
+  subcommand `tctl start` needs, so **pattern (a) is known-red on that crate until
+  0.5.0 ships** (#4917). Patterns (b) and (c) build from the tree and are green.)*
 - **No golden image.** Clone-and-provision every run — the clone costs 0.31s and
   provisioning 30s, and baking failed three distinct ways in research.
 - **The host repo is never mounted**, in either direction. That rule is what closes

--- a/vmtest-harness/README.md
+++ b/vmtest-harness/README.md
@@ -29,7 +29,7 @@ echo "exit=$?"                              # 0 means everything passed
 ```
 
 `run local` clones the base image, boots it, provisions a Rust toolchain, streams
-your **working tree** into the guest, installs all eight in-scope crates from it,
+your **working tree** into the guest, installs all nine in-scope crates from it,
 runs the assertion oracle, and deletes the VM. Expect **9–16 minutes**.
 
 Try `vmtest-harness/vmtest run local --dry-run` first: it runs preflight and prints
@@ -272,15 +272,15 @@ The six steps:
 ## What a green run proves — and what it does not
 
 A `vmtest run <pattern>` exiting 0 proves: the stack **built from that source**,
-**all thirteen in-scope binaries landed**, no multi-binary package installed a
-partial set, the installed tool versions are internally consistent, and the four
+**all fourteen in-scope binaries landed**, no multi-binary package installed a
+partial set, the installed tool versions are internally consistent, and the six
 in-scope daemons **answered `/health`**. On a machine with none of your state on it.
 
 It does **not** prove the following, and each of these is a known, recorded gap
 rather than an oversight:
 
 - **Daemon health is LIVENESS ONLY.** There is no unified health envelope in the
-  product: five daemons, five different `/health` body shapes. The oracle therefore
+  product: six daemons, six different `/health` body shapes. The oracle therefore
   asserts only that each one answered, that the body parses as JSON, and that
   `.status` is a string outside `{down, error, unhealthy}`. Its own PASS line says
   `LIVENESS ONLY`. It does not assert that a daemon is *working*.
@@ -328,8 +328,14 @@ rather than an oversight:
 - **`--dir` mounts were never measured**, in either direction. See rule 2 above.
 - ~~**`trusty-analyze` is a daemon the oracle does NOT probe.**~~ **CLOSED
   2026-08-04 — and it was a real gap, not a cosmetic one.** The liveness probe now
-  covers **all five** in-scope daemons: `trusty-search`, `trusty-memory`,
-  `trusty-analyze`, `trusty-mpm`, `trusty-review`.
+  covers **all six** in-scope daemons: `trusty-search`, `trusty-memory`,
+  `trusty-analyze`, `trusty-mpm`, `trusty-review`, `trusty-console`.
+
+  **`trusty-console` joined that set on 2026-08-05 with no change to this
+  function** *(#4921)*. It was always a `stable_set` daemon; the intersection had
+  been excluding it because the expectation table marked it out of scope. Widening
+  scope in the TSV was the whole edit — which is the derived set behaving as
+  designed rather than a second transcription needing a second fix.
 
   **The earlier framing here understated it, and the correction is worth stating
   plainly.** It was tempting to call this a logging inaccuracy on the grounds that

--- a/vmtest-harness/expected-binaries.tsv
+++ b/vmtest-harness/expected-binaries.tsv
@@ -12,6 +12,7 @@ tga	trusty-git-analytics	tga	src/main.rs	-	yes	present	present	present
 trusty-mpm	trusty-mpm	tm	src/bin/tm/main.rs	cli	yes	present	present	present
 trusty-mpm	trusty-mpm	trusty-mpm	src/bin/tm/main.rs	cli	yes	present	present	present
 trusty-review	trusty-review	trusty-review	src/main.rs	-	yes	present	present	present
+trusty-console	trusty-console	trusty-console	src/main.rs	-	yes	present	present	present
 # --- out of scope per DOC-1 D3; carried so --check-table can detect additions ---
 trusty-agents	trusty-agents	tagent	src/main.rs	-	no	-	-	-
 trusty-agents-ui	trusty-agents/ui/src-tauri	trusty-agents-ui	src/main.rs	-	no	-	-	-
@@ -21,7 +22,6 @@ trusty-channels	trusty-channels	telegram-mcp	src/bin/telegram-mcp.rs	-	no	-	-	-
 trusty-code-gui	trusty-code-gui	trusty-code-gui	src/main.rs	-	no	-	-	-
 trusty-common	trusty-common	candle_metal_bench	src/bin/candle_metal_bench.rs	embedder-candle	no	-	-	-
 trusty-common	trusty-common	tickets-mcp	src/bin/tickets_mcp.rs	tickets	no	-	-	-
-trusty-console	trusty-console	trusty-console	src/main.rs	-	no	-	-	-
 trusty-embedderd-py	trusty-embedderd-py	trusty-embedderd-py	src/main.rs	-	no	-	-	-
 trusty-gworkspace	trusty-gworkspace	trusty-gworkspace-mcp	src/bin/trusty-gworkspace-mcp.rs	-	no	-	-	-
 trusty-kb	trusty-kb	trusty-kb	src/main.rs	-	no	-	-	-

--- a/vmtest-harness/lib/source.sh
+++ b/vmtest-harness/lib/source.sh
@@ -285,7 +285,7 @@ source_deliver_released() {
 # <binary>`, once per TSV row — looks like tidying up and is a change in
 # meaning: DOC-1 §7.4's Single-Install Convention gate asserts exactly one
 # thing, that ONE package-granular install yields EVERY sidecar. Install each
-# sidecar by name and `verify_binaries` reports 13/13 while
+# sidecar by name and `verify_binaries` reports 14/14 while
 # `verify_single_install` passes four times over, and NOTHING has tested the
 # convention. A crate that silently stopped shipping a sidecar would still show
 # green. Unlike a missing table row, `--check-table` cannot catch it, because
@@ -442,8 +442,8 @@ install_from_path() {
 # discontinuity between directory name and package name is exactly what DOC-1 D3
 # warns about and the whole reason `expected-binaries.tsv` carries BOTH columns.
 # A pattern-(a) loop written over crate directories fails on one crate out of
-# eight, and it fails at the LAST possible moment — after seven successful
-# multi-minute installs.
+# nine, and it fails at a LATE moment — after five successful multi-minute
+# installs, `trusty-git-analytics` being the sixth crate directory in TSV order.
 #
 # `--locked` IS MANDATORY, AND IT IS NOT A STYLE CHOICE. Default `cargo install`
 # RE-RESOLVES the dependency graph and IGNORES the lockfile the package was
@@ -567,7 +567,7 @@ install_from_registry() {
 # tripwire covering all three patterns. Patterns (b)/(c) install by DIRECTORY
 # (`tsv_scope_crate_dirs`, the default); pattern (a) installs by PACKAGE NAME
 # (`tsv_scope_packages`), because that is what `cargo install` takes (§9.2). Both
-# sets have eight members today, so a COUNT-ONLY check would pass pattern (a)
+# sets have nine members today, so a COUNT-ONLY check would pass pattern (a)
 # even if the loop had been driven off the wrong accessor and installed
 # `trusty-git-analytics` instead of `tga` — which is precisely the discontinuity
 # DOC-1 D3 warns about. The assertion is therefore on the SET, not the count:
@@ -621,14 +621,14 @@ install_assert_install_count() {
     expected=$("$accessor" | wc -l | tr -d ' ')
     actual=$(grep -c . "$ledger" | tr -d ' ')
     [ "$actual" = "$expected" ] \
-        || die 60 "install ran ${actual} times, expected ${expected} (one per ${unit}, from \`${accessor}\`). Thirteen in-scope ROWS resolve to ${expected} distinct values (§F-3); a count equal to the row count means the loop is iterating rows or binaries instead."
+        || die 60 "install ran ${actual} times, expected ${expected} (one per ${unit}, from \`${accessor}\`). Fourteen in-scope ROWS resolve to ${expected} distinct values (§F-3); a count equal to the row count means the loop is iterating rows or binaries instead."
 
     dups=$(sort "$ledger" | uniq -d)
     if [ -n "$dups" ]; then
         die 60 "a ${unit} was installed twice: $(printf '%s' "$dups" | tr '\n' ' ')"
     fi
 
-    # SET equality, not just count. Under pattern (a) both accessors emit eight
+    # SET equality, not just count. Under pattern (a) both accessors emit nine
     # values, so a count-only check cannot tell `tga` from
     # `trusty-git-analytics` — the one discontinuity DOC-1 D3 names.
     missing=$(comm -23 <("$accessor" | sort) <(sort "$ledger") | tr '\n' ' ')

--- a/vmtest-harness/lib/verify.sh
+++ b/vmtest-harness/lib/verify.sh
@@ -552,7 +552,7 @@ _verify_package_expectation() {
 #       doctor.rs:151` resolves `stable_set()` FILTERED TO `m.daemon`. So
 #       `trusty-code`, `trusty-installer` and `tga` are STRUCTURALLY ABSENT and
 #       can never satisfy a predicate quantified over `member(p)`. THEY ARE NOT
-#       EXEMPT FROM VERIFICATION: `verify_binaries` asserts all 13 in-scope
+#       EXEMPT FROM VERIFICATION: `verify_binaries` asserts all 14 in-scope
 #       binaries present (including `tcode`, `trusty-installer`, `tctl`, `tga`)
 #       and `verify_single_install` gates the multi-binary ones. Both are
 #       UNAFFECTED by this scoping and both are stronger evidence of a correct
@@ -676,7 +676,7 @@ _verify_package_expectation() {
 #
 # WHAT THIS DOES NOT NARROW, so nobody over-reads it: `on_path == true` and
 # `version != null` are STILL ASSERTED for every in-scope member doctor reports;
-# all 13 binaries are still asserted present; all 4 Single-Install gates still
+# all 14 binaries are still asserted present; all 4 Single-Install gates still
 # run; §1.3's RC-1 liveness-only rule is untouched. DAEMON HEALTH, and nothing
 # else, is what narrowed.
 #
@@ -899,7 +899,7 @@ verify_versions() {
 #
 # THERE IS NO UNIFIED DAEMON HEALTH JSON. Every daemon exposes `GET /health` and
 # every one returns JSON, but there is NO SHARED TYPE IN `trusty-common` and no
-# unified schema — four daemons, four independently-evolved shapes, with no field
+# unified schema — six daemons, six independently-evolved shapes, with no field
 # in common beyond `status` and `version`:
 #   - trusty-search  service/server/health.rs  — ~22 fields, several
 #                    `skip_serializing_if` (ABSENT, not null)
@@ -909,6 +909,23 @@ verify_versions() {
 #                    catalog_unknown, catalog_changes, supervised, version
 #   - trusty-review  service/handlers.rs       — status, version, dry_run,
 #                    reviewer_model, inference, deps{...}
+#   - trusty-analyze service/routes.rs:176-180 — status, version,
+#                    search_reachable. EXACTLY THREE fields (`HealthResponse`),
+#                    and `status` is computed: "ok" when search is reachable,
+#                    "degraded" when it is not — see the 503 discussion below.
+#   - trusty-console server/mod.rs:433-438     — status, version. EXACTLY TWO,
+#                    and both are literals: a `json!` with a hardcoded
+#                    `"status":"ok"` and `CARGO_PKG_VERSION`. It reports no
+#                    state of its own at all.
+#
+# THE LAST TWO ROWS WERE ADDED LATE AND THE OMISSION WAS ITSELF THE DEFECT.
+# `trusty-analyze` joined the probed set on 2026-08-04 and `trusty-console` on
+# 2026-08-05 (#4921), but this table kept saying "four" — the same transcription
+# drift that produced the hardcoded four-name list `_verify_daemon_set` was
+# written to eliminate. The spread got WIDER with them, not narrower: 22 fields
+# to 2. Note also that `trusty-console`'s literal `{"status":"ok"}` is precisely
+# the payload the #3364 squatter class describes, which is why RC-1's envelope
+# would need a `service` discriminator and not merely a shared field set.
 #
 # Two further hazards this must not paper over:
 #   - `trusty-mpm` HAS TWO DIFFERENT `/health` ENDPOINTS ON TWO DIFFERENT PORTS.
@@ -924,7 +941,7 @@ verify_versions() {
 #
 # A STRONG ASSERTION HERE WOULD HAVE TO BE INVENTED, and DOC-1 §7.1's whole
 # argument for JSON-only is that the oracle must not depend on surfaces free to
-# change underneath it. An envelope four crates have not agreed on is exactly
+# change underneath it. An envelope six crates have not agreed on is exactly
 # such a surface.
 #
 # WHAT CHANGES IF RC-1 EVER LANDS — exactly three things, and nothing else: this
@@ -1052,9 +1069,12 @@ verify_daemon_liveness() {
 # product surface: it is an in-scope package, `stable_set` marks it a daemon,
 # and `stack doctor` has reported it on every run. It was absent from a
 # HARDCODED FOUR-NAME LIST in this function, transcribed from §1.3's
-# four-shape table. Deriving the set removes the transcription and the drift
-# with it — `trusty-console` is a `stable_set` daemon too and is correctly
-# excluded here, by the intersection, because the TSV marks it out of scope.
+# health-shape table AS IT THEN STOOD — four rows; it carries six today, and
+# that table was itself corrected on 2026-08-05 for the same drift. Deriving
+# the set removes the transcription and the drift
+# with it — `trusty-console` is a `stable_set` daemon too and is now INCLUDED
+# here, by the same intersection and with no edit to this function, because the
+# TSV marks it in scope as of 2026-08-05 (#4921). Its liveness IS verified.
 _verify_daemon_set() {
     local vm="$1"
     LIVENESS_DAEMONS=$(_verify_doctor_json "$vm" | jq -r '.members[].member' 2>/dev/null \
@@ -1357,7 +1377,7 @@ verify_degraded_probe() {
 
     # ---- 1. FAULT A — trusty-search, gracefully, and BY ITSELF. ----------
     # `tctl stop <member>` resolves exactly the named member through
-    # `select_members` (lifecycle.rs), so the other four daemons are untouched;
+    # `select_members` (lifecycle.rs), so the other five daemons are untouched;
     # that they stay live is asserted, not assumed, by the negative direction's
     # verdict run below, which names every daemon it rejects.
     log 'degraded-check: FAULT A — `tctl stop trusty-search --json --yes` (that daemon only)'

--- a/vmtest-harness/scenarios/install-branch.sh
+++ b/vmtest-harness/scenarios/install-branch.sh
@@ -69,7 +69,7 @@ scenario_install_branch() {
     # 2. Install each in-scope CRATE from the cloned tree — "each in-scope
     #    crate", not each row and not each binary (§12.5's own loop comment).
     #    `tsv_scope_crate_dirs` emits UNIQUE crate directories in
-    #    first-appearance order: thirteen in-scope rows, eight directories
+    #    first-appearance order: fourteen in-scope rows, nine directories
     #    (§F-3). Install order is TSV row order (§F-10(b)) — performance-neutral
     #    under a shared CARGO_TARGET_DIR, and `trusty-installer` precedes N2 in
     #    row order already, which is what N2 needs.

--- a/vmtest-harness/scenarios/install-local.sh
+++ b/vmtest-harness/scenarios/install-local.sh
@@ -37,7 +37,7 @@ scenario_install_local() {
     # 2. Install each in-scope CRATE from the unpacked tree — "each in-scope
     #    crate", not each row and not each binary (§12.5's own loop comment).
     #    `tsv_scope_crate_dirs` emits UNIQUE crate directories in
-    #    first-appearance order: thirteen in-scope rows, eight directories
+    #    first-appearance order: fourteen in-scope rows, nine directories
     #    (§F-3). Install order is TSV row order (§F-10(b)) — performance-neutral
     #    under a shared CARGO_TARGET_DIR, and `trusty-installer` precedes N2 in
     #    row order already, which is what N2 needs.

--- a/vmtest-harness/scenarios/install-released.sh
+++ b/vmtest-harness/scenarios/install-released.sh
@@ -22,10 +22,19 @@
 #
 # Under the SUPERSEDED D2 this pattern covered SIX crates and asserted `tm`
 # KNOWN-ABSENT, on the premise that `trusty-mpm` was unpublished. Both halves
-# were wrong. It now covers EIGHT — seven after the D2 reversal restored
-# `trusty-mpm`, eight after the D3 amendment added `trusty-review` — and asserts
+# were wrong. It now covers NINE — seven after the D2 reversal restored
+# `trusty-mpm`, eight after the D3 amendment added `trusty-review`, nine after
+# the 2026-08-05 amendment added `trusty-console` (#4921) — and asserts
 # `tm` **PRESENT**. A run that does not find `tm` is a FAILURE, where under the
 # superseded D2 it was the expected result.
+#
+# PATTERN (a) IS KNOWN-RED ON `trusty-console` AS OF 2026-08-05 (#4917). The
+# registry has 0.4.0, which has no `service` subcommand; `tctl start` bootstraps
+# launchd membership by invoking `<binary> service install`, so the daemon never
+# comes up and `verify_daemon_liveness` fails. 0.5.0 in the working tree has it,
+# which is why (b)/(c) are green. That is this pattern doing its job — release
+# skew is the class of defect only (a) can produce — and the fix is a release,
+# tracked at #4917, NOT a special case here.
 #
 # NOTHING IN THIS FILE ENCODES THAT AS A LIST. The install set is
 # `tsv_scope_packages` and the assertion set is `expect_a` in
@@ -37,7 +46,7 @@
 # never `tsv_scope_crate_dirs` — `crates/trusty-git-analytics/` publishes as
 # **`tga`**, and `cargo install trusty-git-analytics --locked` does not exist
 # (DOC-2 §9.2, DOC-1 D3). This is the ONE place the two accessors are not
-# interchangeable, and both emit eight values, so the mistake is invisible to a
+# interchangeable, and both emit nine values, so the mistake is invisible to a
 # count. `install_assert_install_count` is therefore passed the accessor and
 # asserts SET equality.
 #
@@ -60,8 +69,8 @@ scenario_install_released() {
     source_deliver_released
 
     # 2. Install each in-scope PACKAGE from crates.io — `cargo install <pkg>
-    #    --locked`, once per package (EIGHT today), never once per binary
-    #    (THIRTEEN today) and never `--bin` (DOC-2 §12.2).
+    #    --locked`, once per package (NINE today), never once per binary
+    #    (FOURTEEN today) and never `--bin` (DOC-2 §12.2).
     #
     #    Install order is TSV row order (§F-10(b)); `trusty-installer` precedes
     #    N2 in row order already, which is what N2 needs.
@@ -93,7 +102,7 @@ scenario_install_released() {
 
     # 4. Expectations that follow from those steps (DOC-1 §3.6).
     #
-    #    `expect_a` is `present` on all THIRTEEN in-scope rows — including `tm`
+    #    `expect_a` is `present` on all FOURTEEN in-scope rows — including `tm`
     #    and `trusty-mpm`. That is the D2 reversal, asserted rather than
     #    described.
     verify_binaries "$VMTEST_VM" a

--- a/vmtest-harness/vmtest
+++ b/vmtest-harness/vmtest
@@ -212,7 +212,7 @@ _tsv_rows() {
 # invalidate DOC-1 §7.4's Single-Install gate — it would not; repeated
 # `cargo install --path` reinstalls the package's full binary set and the end
 # state is identical — but because P5's checkpoint COUNTS installs (one per
-# value) and thirteen installs of eight crates is waste and noise.
+# value) and fourteen installs of nine crates is waste and noise.
 #
 # The genuine hazard §F-3 does point at is a PER-BINARY install: `cargo install
 # --path <dir> --bin <binary>` defeats the gate silently and with a green
@@ -1182,7 +1182,7 @@ END {
     for (k in DK) if ((k in AK) && D[k] != A[k]) CHANGED[k] = 1
 
     for (k in ADDED)
-        printf "ADDED    package=%s binary=%s  %s  — a [[bin]] target the workspace declares and this table does not. Add the row (in_scope=no unless it belongs to one of DOC-1 D3'\''s eight packages).\n", \
+        printf "ADDED    package=%s binary=%s  %s  — a [[bin]] target the workspace declares and this table does not. Add the row (in_scope=no unless it belongs to one of DOC-1 D3'\''s nine packages).\n", \
                APKG[k], ABIN[k], A[k]
     for (k in REMOVED)
         printf "REMOVED  package=%s binary=%s  %s  — this table declares it and the workspace has no such [[bin]] target.\n", \
@@ -1275,7 +1275,7 @@ cmd_check_table() {
     # --- step 6 -------------------------------------------------------------
     if [ "$nfindings" -gt 0 ]; then
         while IFS= read -r _line; do out "$_line"; done < "$findings"
-        die 60 "${nfindings} finding(s) between expected-binaries.tsv and the workspace's actual [[bin]] targets. --check-table DOES NOT AUTO-FIX: edit the table by hand, in a PR, because that edit is the review step (DOC-2 §9.6). Do not widen DOC-1 D3's scope as a side effect — a genuinely new binary is in_scope=no unless it belongs to one of D3's eight packages."
+        die 60 "${nfindings} finding(s) between expected-binaries.tsv and the workspace's actual [[bin]] targets. --check-table DOES NOT AUTO-FIX: edit the table by hand, in a PR, because that edit is the review step (DOC-2 §9.6). Do not widen DOC-1 D3's scope as a side effect — a genuinely new binary is in_scope=no unless it belongs to one of D3's nine packages."
     fi
     log 'check-table OK: no ADDED, REMOVED or CHANGED findings'
     return 0


### PR DESCRIPTION
Closes #4921.

Brings `trusty-console` into the vmtest-harness verified scope: its TSV row flips from out-of-scope to in-scope, which mechanically widens the derived sets from 8→9 packages, 8→9 crate directories, 13→14 binaries, and 5→6 liveness-checked daemons.

## The change

One data edit plus count propagation. The `trusty-console` row moves to the **end** of the in-scope block in `vmtest-harness/expected-binaries.tsv` with `in_scope=yes` and all three pattern expectations `present`.

Placement is load-bearing: appending rather than inserting alphabetically keeps `trusty-git-analytics` at crate-directory position 6 of 9, which keeps the "five installs precede it" figure in `lib/source.sh` correct. Inserting alphabetically would have silently falsified it.

Everything else derives from that row — no accessor, control-flow, field-index, or logic change. The only non-comment lines touched are three message strings (`lib/source.sh` die message, and two in `vmtest`).

## Verification

`vmtest --check-table` runs in ~1s with no VM and is the only mechanical check available:

```
vmtest: declared rows: 28; workspace [[bin]] targets: 28
vmtest: in scope: 14 binaries, 9 crate directories, 9 packages
vmtest: check-table OK: no ADDED, REMOVED or CHANGED findings
exit=0
```

Also green: TSV field-count (`NF=9` on all 29 non-comment rows, real tabs), `bash -n` on all six touched shell files, `check_sld.sh`, `check_doc_numbers.sh`, and the changelog-fragment gate (no `crates/**` source changed, so no fragment required).

The six-daemon figure was derived independently rather than taken on the issue's word: `stable_set.rs` marks six members `daemon=true` (search, memory, analyze, review, console, mpm); `verify.sh` intersects `stack doctor`'s reported members against `tsv_scope_packages`. `trusty-console` was the one daemon the TSV excluded, so the intersection was 5 and is now 6.

**Not run:** `vmtest run local|branch|released` require `tart` and a VM image, neither available in this environment. No VM output is claimed here.

## Corrections to the issue as written

The issue was authored against a fork and is substantially stale. Implemented against a corrected spec:

- Its "Critical Blocker" (harness not on upstream `main`) is false — the harness landed in #4773 on 2026-08-04, before the issue was filed.
- Nearly every cited line number is wrong. `README.md` sites were at 32/275/276, not ~100-110/~1160/~1253; the two `vmtest` "thirteen binaries" sites do not exist in that file at all; `lib/source.sh`'s real defect is at 624 (install-row count), not ~230 (daemon count); `lib/verify.sh`'s comment is at 1051-1057, not ~1033.
- It cites `scenarios/all-patterns.sh`, which does not exist. The real files are `install-branch.sh`, `install-local.sh`, `install-released.sh`.
- Its proposed fix for the pre-existing "after seven successful installs" error was underspecified: correct only if the TSV row is appended, wrong if inserted alphabetically, and it omitted the "one crate out of eight"→nine half of the same sentence.
- It missed roughly a dozen live count sites across `vmtest`, all three `scenarios/*.sh`, `lib/source.sh`, `lib/verify.sh`, and three `02-design/` documents.

## Pre-existing errors corrected opportunistically

Fixed in this PR rather than deferred, since it exists precisely to correct this class of drift:

- `README.md` daemon count said four; the pre-change truth was five (it predated `trusty-analyze` joining the derived set on 2026-08-04). Now six.
- `lib/source.sh` said a pattern-(a) loop fails "at the LAST possible moment — after seven successful installs". `trusty-git-analytics` was 6th of 8, so five preceded it and it was never last. Both halves corrected.
- `lib/verify.sh`'s health-shape table said "four daemons, four shapes" and omitted `trusty-analyze`. DOC-2 §1.3 — the table that comment says it was transcribed from — had already been corrected to five on 2026-08-04 with a note recording the four-name transcription as the defect; the shell comment never followed. Both now carry six rows, with `trusty-analyze` (`HealthResponse { status, version, search_reachable }`) and `trusty-console` (inline `json!` with hardcoded `status` + version) read from source rather than guessed.
- DOC-2 §9.3's embedded seed table had gone stale against the shipped TSV. The two are now byte-identical, which is a check worth keeping.

## Deliberately left unchanged

Dated historical records, per this doc set's amend-don't-rewrite convention: `03-plan/`, `MANIFEST.md`, `01-research/`, the Phase-5 and 2026-08-04 incident records in `lib/verify.sh`, run-count measurements in `vmtest.defaults`, and superseded notes that already label themselves as such.

One reader-visible mismatch remains as a consequence: `03-plan/01-implementation-plan.md:1150` cites §F-3 with "thirteen in-scope rows", while the scenario comments now cite §F-3 with fourteen. Left because `03-plan/` is a dated phase log.

## Known-red consequence

Pattern (a) (`vmtest run released`) will now fail exit 60 on `trusty-console`: crates.io ships 0.4.0, whose `Commands` enum has no `Service` variant, so `tctl start`'s `<binary> service install` bootstrap fails and liveness never gets an address. Tracked in #4917, which the product owner has accepted as red until 0.5.0 publishes.

`expect_a` is deliberately kept at `present` rather than flipped to `absent`. The expectation is temporarily unmet, not false — flipping it would convert a release-readiness gap into a silently-green run.

**No CI impact:** no workflow in `.github/workflows/` invokes `vmtest` or `tart`. The harness is ad hoc and manually run, so there is no green job to break — and equally, no automated gate covers any of the prose counts in this PR.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
