### PR TITLE
fix(trusty-common): stop a poisoned ENV_LOCK cascading 1 embedder failure into 7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,27 +440,61 @@ jobs:
         with:
           key: test
 
-      # Restore the fastembed ONNX model cache (issue #865).
-      #
-      # Cache key: fastembed crate version (from Cargo.lock) + the two model
-      # repo IDs used by this workspace:
+      # Cache key for the fastembed ONNX models (issue #865, corrected #4940):
+      # the fastembed crate VERSION + the two model repo IDs used by this
+      # workspace:
       #   - Xenova/all-MiniLM-L6-v2  (AllMiniLML6V2Q — primary, ~22 MB)
       #   - Qdrant/all-MiniLM-L6-v2-onnx (AllMiniLML6V2 — CPU fallback, ~86 MB)
-      # Changing any of these (e.g. upgrading fastembed) rotates the key so
-      # the old model blobs are not served to the new version.
+      # Upgrading fastembed rotates the key so old model blobs are not served
+      # to a new model registry.
+      #
+      # #4940: this used to be `hashFiles('Cargo.lock')` — the hash of the
+      # WHOLE lockfile — while the comment claimed it was the fastembed
+      # version. Those are not the same thing. Any dependency bump anywhere in
+      # a 21-crate workspace rotated the key, so on a repo landing dozens of
+      # PRs a day the cache was almost always cold and almost every run
+      # re-downloaded ~110 MB from HuggingFace. Keying on the version the
+      # comment always described makes the key rotate when the models actually
+      # change and not otherwise.
+      - name: Resolve fastembed model cache key
+        if: needs.changes.outputs.docs_only != 'true'
+        id: fastembed-key
+        run: |
+          set -euo pipefail
+          ver=$(awk '/^name = "fastembed"$/ { found = 1; next }
+                     found && /^version = / { gsub(/[",]/, "", $3); print $3; exit }' Cargo.lock)
+          if [ -z "${ver}" ]; then
+            echo "::error::could not resolve the fastembed version from Cargo.lock — refusing to fall back to an unkeyed cache"
+            exit 1
+          fi
+          echo "Resolved fastembed version from Cargo.lock: ${ver}"
+          echo "key=fastembed-v${ver}-xenova-allminilm-l6-v2-qdrant-allminilm-l6-v2-onnx" >> "$GITHUB_OUTPUT"
+
+      # #4940: `actions/cache/restore` + an explicit `actions/cache/save`
+      # below, NOT the combined `actions/cache`. The combined action declares
+      # `post-if: success()`, so its save step is SKIPPED whenever the job
+      # fails — visible as "Post Restore fastembed model cache -> skipped" in
+      # run 31026363957's failed Test job. That produced a ratchet: HF
+      # rate-limits the pre-seed -> no model -> the accuracy gate fails -> the
+      # job fails -> the model is never cached -> the next run is cold and
+      # rate-limited again. Two unrelated PRs (#4920, #4926) failed identically
+      # inside the same hour because both raced the same permanently-empty
+      # cache. Saving explicitly, right after a successful download and BEFORE
+      # any test runs, removes the test outcome from that path entirely.
       - name: Restore fastembed model cache
         if: needs.changes.outputs.docs_only != 'true'
         id: fastembed-cache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: /home/runner/.cache/fastembed
-          key: fastembed-v${{ hashFiles('Cargo.lock') }}-xenova-allminilm-l6-v2-qdrant-allminilm-l6-v2-onnx
+          key: ${{ steps.fastembed-key.outputs.key }}
 
       # Pre-seed the model on a cache miss so tests never hit HuggingFace
       # concurrently (the root cause of the HTTP 429 flake). Uses hf-hub's
       # CLI-friendly URL pattern with exponential backoff: 5 attempts, waiting
       # 5, 10, 20, 40 seconds between retries. After a successful download the
-      # actions/cache post-step saves the populated directory for future runs.
+      # explicit "Save fastembed model cache" step below persists the populated
+      # directory for future runs (#4940 — no longer a post step).
       #
       # Primary model: Xenova/all-MiniLM-L6-v2 at the pinned snapshot.
       # The refs/main pointer, tokenizer files, and the quantized ONNX are
@@ -525,6 +559,7 @@ jobs:
       #       conditional's test) and capture its exit status via $?.
       - name: Pre-seed fastembed models (cache miss only)
         if: needs.changes.outputs.docs_only != 'true' && steps.fastembed-cache.outputs.cache-hit != 'true'
+        id: fastembed-preseed
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
@@ -544,9 +579,18 @@ jobs:
 
           # ── Retry helper ──────────────────────────────────────────────────
           # curl_retry <url> <dest>
-          # 5 attempts, starting with 5 s back-off, doubling each time.
+          # 7 attempts with a doubling back-off capped at 60 s: 10, 20, 40, 60,
+          # 60, 60 — ~250 s of patience.
+          #
+          # #4940: this was 5 attempts at 5/10/20/40 s, a 75-second window. In
+          # run 31026363957 HuggingFace returned HTTP 429 to all five attempts
+          # inside 75 s and the pre-seed gave up; an HF rate-limit window
+          # outlasts a minute routinely. 250 s costs nothing on the normal path
+          # (a cache hit skips this step entirely, and an un-limited download
+          # never retries) and is only spent on the runs that would otherwise
+          # fail outright.
           curl_retry() {
-            local url="$1" dest="$2" attempt=1 max=5 wait=5
+            local url="$1" dest="$2" attempt=1 max=7 wait=10
             until curl -fsSL --retry 0 "${CURL_AUTH[@]}" -o "${dest}" "${url}"; do
               if [ "${attempt}" -ge "${max}" ]; then
                 echo "ERROR: download failed after ${max} attempts: ${url}" >&2
@@ -556,6 +600,9 @@ jobs:
               sleep "${wait}"
               attempt=$(( attempt + 1 ))
               wait=$(( wait * 2 ))
+              # An `[ … ] && wait=60` one-liner would return 1 on the false
+              # branch and trip this step's `set -e`. Keep the `if`.
+              if [ "${wait}" -gt 60 ]; then wait=60; fi
             done
           }
 
@@ -696,13 +743,35 @@ jobs:
           set -e
 
           if [ "${rc}" -ne 0 ]; then
-            # Do not let actions/cache persist a partial/corrupt download
+            # Do not let the save step persist a partial/corrupt download
             # tree under this run's key: an absent cache is a safe "miss"
             # next run; a partial one would look like a permanent false
             # "hit" until the key rotates (issue #2554/#2981).
             rm -rf "${CACHE_DIR}"
-            echo "::warning::fastembed model pre-seed failed (rc=${rc}; HuggingFace rate-limit/403 or network issue) — continuing WITHOUT a pre-seeded cache. This is non-fatal: cargo test --workspace never needs the real model (non-ignored tests use a MockEmbedder via seed_shared_embedder_with_mock(), issue #850; the tests that need the real model are #[ignore]-gated and are not run in this job). See issue #2554 for details."
+            echo "seeded=false" >> "$GITHUB_OUTPUT"
+            # #4940: this warning used to end "the tests that need the real
+            # model are #[ignore]-gated and are not run in this job", which is
+            # FALSE and contradicted the block comment 30 lines above it —
+            # `default_model_matches_sentence_transformers_reference` is the
+            # documented exception and does run here. Reading that sentence is
+            # what made this failure get misdiagnosed as a flaky test rather
+            # than a missing model. State the actual consequence instead.
+            echo "::warning::fastembed model pre-seed failed (rc=${rc}; HuggingFace rate-limit/403 or network issue) — continuing WITHOUT a pre-seeded cache. CONSEQUENCE: default_model_matches_sentence_transformers_reference (crates/trusty-common/src/embedder/tests/reference_accuracy_tests.rs) is deliberately NOT #[ignore]d (issue #3493 P0 part 2) and WILL attempt its own HuggingFace download; if that is rate-limited too it fails with 'failed to initialise fastembed'. That is a missing MODEL, not an accuracy regression and not a flaky test — re-run once HuggingFace stops rate-limiting. Every other embedder test uses a MockEmbedder via seed_shared_embedder_with_mock() (issue #850) and is unaffected. See #2554 and #4940."
+          else
+            echo "seeded=true" >> "$GITHUB_OUTPUT"
           fi
+
+      # #4940: save explicitly, HERE — before any test runs — instead of
+      # relying on `actions/cache`'s post step, which is `post-if: success()`
+      # and therefore never fires on a failing job. Gated on the pre-seed
+      # having actually succeeded so a partial tree (already `rm -rf`'d above)
+      # can never be persisted as a false "hit".
+      - name: Save fastembed model cache
+        if: needs.changes.outputs.docs_only != 'true' && steps.fastembed-cache.outputs.cache-hit != 'true' && steps.fastembed-preseed.outputs.seeded == 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /home/runner/.cache/fastembed
+          key: ${{ steps.fastembed-key.outputs.key }}
 
       # Build phase only (no test execution yet): links all ~179 test
       # binaries so the intermediate .rcgu.o codegen objects below can be

--- a/crates/trusty-common/changelog.d/4940-embedder-env-lock-poison-cascade.md
+++ b/crates/trusty-common/changelog.d/4940-embedder-env-lock-poison-cascade.md
@@ -1,0 +1,3 @@
+Fixed
+
+- one failing embedder test no longer cascades into seven. `ENV_LOCK.lock().unwrap()` poisoned the shared `Mutex<()>` when the ONNX accuracy gate panicked, so the six `resolve_*` tests — pure model/provider/cache-dir resolution that never touches fastembed — failed with `PoisonError` and buried the real cause. Call sites now go through `test_env::env_lock()`, which recovers via `PoisonError::into_inner`; the lock guards no data, and `EnvVarGuard::drop` restores the environment during the panicking test's unwind (closes [#4940](https://github.com/bobmatnyc/trusty-tools/issues/4940))

--- a/crates/trusty-common/src/embedder/mod.rs
+++ b/crates/trusty-common/src/embedder/mod.rs
@@ -82,7 +82,9 @@ mod tests {
 
     // #3711: the shared lock + guard for the WHOLE embedder module tree,
     // including the sibling `provider_tests`. See `test_env`'s docs.
-    use super::test_env::{ENV_LOCK, EnvVarGuard};
+    // #4940: `env_lock()` rather than the raw static — see its doc for why a
+    // poisoned lock must not cascade one failure into seven.
+    use super::test_env::{EnvVarGuard, env_lock};
 
     /// Why: GH #58 — launchd runs trusty-memory with a read-only `TMPDIR`,
     /// and fastembed's default `./.fastembed_cache` is also unwritable from
@@ -97,7 +99,7 @@ mod tests {
     /// Test: this test.
     #[test]
     fn resolve_fastembed_cache_dir_prefers_env_vars() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
 
         let prev_dir = std::env::var("FASTEMBED_CACHE_DIR").ok();
         let prev_path = std::env::var("FASTEMBED_CACHE_PATH").ok();
@@ -157,7 +159,7 @@ mod tests {
     /// Test: this test.
     #[test]
     fn cuda_options_default_limit() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _b = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_BYTES", None);
         let _m = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_MB", None);
         assert_eq!(
@@ -170,7 +172,7 @@ mod tests {
 
     #[test]
     fn cuda_options_bytes_env() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _b = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_BYTES", Some("8589934592"));
         let _m = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_MB", None);
         assert_eq!(
@@ -182,7 +184,7 @@ mod tests {
 
     #[test]
     fn cuda_options_mb_env() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _b = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_BYTES", None);
         let _m = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_MB", Some("4096"));
         assert_eq!(
@@ -194,7 +196,7 @@ mod tests {
 
     #[test]
     fn cuda_options_bytes_takes_precedence() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _b = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_BYTES", Some("1073741824"));
         let _m = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_MB", Some("4096"));
         assert_eq!(
@@ -206,7 +208,7 @@ mod tests {
 
     #[test]
     fn cuda_options_ignores_malformed() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         {
             let _b = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_BYTES", Some("not-a-number"));
             let _m = EnvVarGuard::apply("TRUSTY_GPU_MEM_LIMIT_MB", Some("2048"));
@@ -243,7 +245,7 @@ mod tests {
     /// the two build-variant assertions.
     #[test]
     fn ort_threading_defaults() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", None);
         let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", None);
         let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", None);
@@ -309,7 +311,7 @@ mod tests {
     /// Test: this test.
     #[test]
     fn ort_threading_reads_env() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", Some("4"));
         let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", Some("2"));
         let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", None);
@@ -333,7 +335,7 @@ mod tests {
     /// Test: this test.
     #[test]
     fn ort_threading_ignores_malformed() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", Some("not-a-number"));
         let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", Some("0"));
         let _s = EnvVarGuard::apply("TRUSTY_ORT_ALLOW_SPINNING", None);
@@ -358,7 +360,7 @@ mod tests {
     /// Test: this test.
     #[test]
     fn ort_threading_spinning_truthy() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _i = EnvVarGuard::apply("TRUSTY_ORT_INTRA_THREADS", None);
         let _e = EnvVarGuard::apply("TRUSTY_ORT_INTER_THREADS", None);
 
@@ -380,7 +382,7 @@ mod tests {
 
     #[test]
     fn resolve_expected_provider_forces_cpu() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _d = EnvVarGuard::apply("TRUSTY_DEVICE", Some("CPU"));
         assert_eq!(resolve_expected_provider(), ExecutionProvider::Cpu);
     }
@@ -390,7 +392,7 @@ mod tests {
     /// activates just because `TRUSTY_DEVICE` is unset.
     #[test]
     fn resolve_expected_provider_default_matches_platform() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _d = EnvVarGuard::apply("TRUSTY_DEVICE", None);
         let _u = EnvVarGuard::apply("TRUSTY_COREML_COMPUTE_UNITS", None);
 
@@ -415,7 +417,7 @@ mod tests {
     #[cfg(not(feature = "embedder-cuda"))]
     #[test]
     fn resolve_expected_provider_coreml_units() {
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         {
             let _d = EnvVarGuard::apply("TRUSTY_DEVICE", None);
             let _u = EnvVarGuard::apply("TRUSTY_COREML_COMPUTE_UNITS", Some("all"));
@@ -445,7 +447,7 @@ mod tests {
     #[test]
     fn resolve_default_embedding_model_defaults_to_fp32() {
         use crate::embedder::fast_embedder::resolve_default_embedding_model;
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _m = EnvVarGuard::apply("TRUSTY_EMBEDDER_MODEL", None);
         assert_eq!(
             resolve_default_embedding_model(),
@@ -462,7 +464,7 @@ mod tests {
     #[test]
     fn resolve_default_embedding_model_int8_opt_in() {
         use crate::embedder::fast_embedder::resolve_default_embedding_model;
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         for spelling in ["int8", "INT8", "quantized", "Quantized", "q", "Q"] {
             let _m = EnvVarGuard::apply("TRUSTY_EMBEDDER_MODEL", Some(spelling));
             assert_eq!(
@@ -480,7 +482,7 @@ mod tests {
     #[test]
     fn resolve_default_embedding_model_ignores_unknown() {
         use crate::embedder::fast_embedder::resolve_default_embedding_model;
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _m = EnvVarGuard::apply("TRUSTY_EMBEDDER_MODEL", Some("not-a-real-model"));
         assert_eq!(
             resolve_default_embedding_model(),
@@ -538,7 +540,7 @@ mod tests {
     #[test]
     fn trusty_device_cpu_disables_coreml_on_apple_silicon() {
         use crate::embedder::fast_embedder::FastEmbedder as FE;
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
         let prev = std::env::var("TRUSTY_DEVICE").ok();
         unsafe { std::env::set_var("TRUSTY_DEVICE", "cpu") };
 
@@ -567,7 +569,7 @@ mod tests {
     #[test]
     fn default_apple_silicon_uses_cpu() {
         use crate::embedder::fast_embedder::FastEmbedder as FE;
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
 
         let prev_device = std::env::var("TRUSTY_DEVICE").ok();
         let prev_units = std::env::var("TRUSTY_COREML_COMPUTE_UNITS").ok();
@@ -603,7 +605,7 @@ mod tests {
     #[test]
     fn coreml_compute_units_all_opt_in() {
         use crate::embedder::fast_embedder::FastEmbedder as FE;
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
 
         let prev_device = std::env::var("TRUSTY_DEVICE").ok();
         let prev_units = std::env::var("TRUSTY_COREML_COMPUTE_UNITS").ok();
@@ -639,7 +641,7 @@ mod tests {
     #[test]
     fn trusty_device_gpu_enables_coreml_on_apple_silicon() {
         use crate::embedder::fast_embedder::FastEmbedder as FE;
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = env_lock();
 
         let prev_device = std::env::var("TRUSTY_DEVICE").ok();
         let prev_units = std::env::var("TRUSTY_COREML_COMPUTE_UNITS").ok();
@@ -715,7 +717,7 @@ mod tests {
         use crate::embedder::fast_embedder::{
             DEFAULT_COREML_INIT_TIMEOUT_SECS, coreml_init_timeout,
         };
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         let _t = EnvVarGuard::apply("TRUSTY_COREML_INIT_TIMEOUT_SECS", None);
         assert_eq!(
             coreml_init_timeout(),
@@ -734,7 +736,7 @@ mod tests {
         use crate::embedder::fast_embedder::{
             DEFAULT_COREML_INIT_TIMEOUT_SECS, coreml_init_timeout,
         };
-        let _g = ENV_LOCK.lock().unwrap();
+        let _g = env_lock();
         {
             let _t = EnvVarGuard::apply("TRUSTY_COREML_INIT_TIMEOUT_SECS", Some("120"));
             assert_eq!(coreml_init_timeout(), std::time::Duration::from_secs(120));

--- a/crates/trusty-common/src/embedder/provider_tests.rs
+++ b/crates/trusty-common/src/embedder/provider_tests.rs
@@ -21,7 +21,9 @@
 //! Test: this file.
 
 use super::*;
-use crate::embedder::test_env::{ENV_LOCK, EnvVarGuard};
+// #4940: `env_lock()` rather than the raw static — a panic in any sibling test
+// must not poison this file's tests into `PoisonError` failures.
+use crate::embedder::test_env::{EnvVarGuard, env_lock};
 
 /// Build a current-thread runtime for a synchronous test that must drive one
 /// async call while holding the synchronous [`ENV_LOCK`] (issue #3711).
@@ -36,7 +38,7 @@ fn current_thread_runtime() -> tokio::runtime::Runtime {
 /// sidecar prediction too, mirroring the ORT resolver's behaviour.
 #[test]
 fn resolve_expected_python_provider_forces_cpu() {
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = env_lock();
     let _d = EnvVarGuard::apply("TRUSTY_DEVICE", Some("CPU"));
     assert_eq!(resolve_expected_python_provider(), ExecutionProvider::Cpu);
 }
@@ -46,7 +48,7 @@ fn resolve_expected_python_provider_forces_cpu() {
 /// an `embedder-cuda` build predicts `Cuda`; every other host predicts `Cpu`.
 #[test]
 fn resolve_expected_python_provider_default_matches_platform() {
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = env_lock();
     let _d = EnvVarGuard::apply("TRUSTY_DEVICE", None);
 
     let got = resolve_expected_python_provider();
@@ -98,7 +100,7 @@ fn embedding_model_name_reports_resolved_variant() {
 fn fast_embedder_model_name_reports_fp32_default() {
     // #3711: sync test + explicit runtime so the SHARED std `ENV_LOCK` covers
     // the whole construct window without `clippy::await_holding_lock`.
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = env_lock();
     let _m = EnvVarGuard::apply("TRUSTY_EMBEDDER_MODEL", None);
     let name = current_thread_runtime().block_on(async {
         let e = FastEmbedder::new().await.unwrap();
@@ -113,7 +115,7 @@ fn fast_embedder_model_name_reports_fp32_default() {
 #[ignore]
 fn fast_embedder_model_name_reports_int8_opt_in() {
     // #3711: see the sibling test — same shared-lock discipline.
-    let _g = ENV_LOCK.lock().unwrap();
+    let _g = env_lock();
     let _m = EnvVarGuard::apply("TRUSTY_EMBEDDER_MODEL", Some("int8"));
     let name = current_thread_runtime().block_on(async {
         let e = FastEmbedder::new().await.unwrap();

--- a/crates/trusty-common/src/embedder/test_env.rs
+++ b/crates/trusty-common/src/embedder/test_env.rs
@@ -40,6 +40,31 @@
 /// `resolve_expected_python_provider_forces_cpu`.
 pub(super) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Acquire [`ENV_LOCK`], recovering from a poisoned lock instead of panicking.
+///
+/// Why (issue #4940): `ENV_LOCK.lock().unwrap()` turned one failing test into
+/// seven. When `default_model_matches_sentence_transformers_reference` panicked
+/// on a CI runner that could not download the ONNX model, it poisoned the lock,
+/// and the six `resolve_*` tests — pure model/provider/cache-dir resolution
+/// logic that never touches fastembed — then failed with `PoisonError` instead
+/// of passing, burying the one real cause under six casualties.
+///
+/// Why recovery is correct here, not papering over a failure: poisoning exists
+/// to warn that DATA behind the mutex may be half-updated. `ENV_LOCK` is a
+/// `Mutex<()>` — it guards no data, only serialisation order. The state it
+/// actually protects is the process environment, and that is restored by
+/// [`EnvVarGuard`]'s `Drop`, which runs during the panicking test's unwind. So
+/// the next `lock()` caller observes a consistent environment; propagating
+/// poison communicates nothing except "some other test failed", which the test
+/// harness already reports.
+/// What: `lock()`, mapping `PoisonError` to the guard it carries.
+/// Test: `poisoned_env_lock_is_still_acquirable`.
+pub(super) fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+    ENV_LOCK
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 /// RAII helper: set or clear an env var for the duration of a test and restore
 /// it on drop.
 ///
@@ -84,5 +109,53 @@ impl Drop for EnvVarGuard {
                 None => std::env::remove_var(self.key),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ENV_LOCK, env_lock};
+
+    /// Why: issue #4940 — a single ONNX-model initialisation failure in
+    /// `default_model_matches_sentence_transformers_reference` reported as
+    /// SEVEN failures, because the panic poisoned [`ENV_LOCK`] and the six
+    /// `resolve_*` tests then died on `PoisonError` at their
+    /// `ENV_LOCK.lock().unwrap()`. Those six exercise pure resolution logic
+    /// and must not be reachable from another test's failure.
+    /// What: poisons the real static the way a failing test does — unwind with
+    /// the guard live — then asserts [`env_lock`] still hands out a guard.
+    /// Test: this test.
+    #[test]
+    fn poisoned_env_lock_is_still_acquirable() {
+        let poisoner = std::thread::Builder::new()
+            .name("env-lock-poisoner-4940".into())
+            .spawn(|| {
+                let _g = env_lock();
+                panic!("deliberate panic while holding ENV_LOCK — see #4940");
+            })
+            .expect("spawning the poisoner thread must succeed");
+        assert!(
+            poisoner.join().is_err(),
+            "the poisoner thread must actually have panicked"
+        );
+        assert!(
+            ENV_LOCK.is_poisoned(),
+            "a panic with the guard live must poison ENV_LOCK — otherwise this \
+             test proves nothing"
+        );
+
+        // #4940: the line that used to be `ENV_LOCK.lock().unwrap()`. It is
+        // what turned one failure into seven.
+        drop(env_lock());
+
+        assert!(
+            ENV_LOCK.lock().is_err(),
+            "env_lock() must RECOVER from poison, not silently clear it — the \
+             flag stays set so a genuine data-guarding mutex elsewhere is \
+             unaffected by this policy"
+        );
+
+        // Leave the shared static clean for whatever test runs next.
+        ENV_LOCK.clear_poison();
     }
 }

--- a/crates/trusty-common/src/embedder/tests/reference_accuracy_tests.rs
+++ b/crates/trusty-common/src/embedder/tests/reference_accuracy_tests.rs
@@ -132,7 +132,7 @@ fn default_model_matches_sentence_transformers_reference() {
 
     // #3711: pin model selection for the whole construct-and-embed window
     // — an unlocked read raced a sibling test's TRUSTY_EMBEDDER_MODEL=int8.
-    let _guard = ENV_LOCK.lock().unwrap();
+    let _guard = env_lock();
     let _model_env = EnvVarGuard::apply("TRUSTY_EMBEDDER_MODEL", None);
 
     let rt = tokio::runtime::Builder::new_current_thread()


### PR DESCRIPTION
Closes [#4940](https://github.com/bobmatnyc/trusty-tools/issues/4940).

Two independent defects. Both are fixed here; they are described separately because they have separate causes and separate fixes.

## Defect 1 — the cascade

**Defect.** Every env-touching test in the `embedder` module tree acquired the shared `ENV_LOCK` with `ENV_LOCK.lock().unwrap()`. `ENV_LOCK` is a `Mutex<()>`. When one test panicked while holding the guard, the lock was poisoned and every subsequent acquisition panicked with `PoisonError` — so one failure reported as seven, and the six casualties buried the real cause.

Six of the seven (`resolve_default_embedding_model_*`, `resolve_expected_provider_*`, `resolve_fastembed_cache_dir_prefers_env_vars`) test pure model/provider/cache-dir resolution logic. None of them touches fastembed. They were unreachable-by-their-own-code failures.

**Evidence.** Reproduced locally by injecting a panic at the top of `default_model_matches_sentence_transformers_reference`, with the pre-fix `.lock().unwrap()` in place:

```
test embedder::tests::reference_accuracy_tests::default_model_matches_sentence_transformers_reference ... FAILED
test embedder::tests::resolve_default_embedding_model_ignores_unknown ... FAILED
test embedder::tests::resolve_default_embedding_model_int8_opt_in ... FAILED
test embedder::tests::resolve_expected_provider_coreml_units ... FAILED
test embedder::tests::resolve_expected_provider_default_matches_platform ... FAILED
test embedder::tests::resolve_expected_provider_forces_cpu ... FAILED
test embedder::tests::resolve_fastembed_cache_dir_prefers_env_vars ... FAILED
test embedder::tests::trusty_device_cpu_disables_coreml_on_apple_silicon ... FAILED
test embedder::tests::trusty_device_gpu_enables_coreml_on_apple_silicon ... FAILED

thread '…::resolve_default_embedding_model_ignores_unknown' panicked at crates/trusty-common/src/embedder/test_env.rs:63:21:
thread '…::resolve_expected_provider_forces_cpu'            panicked at crates/trusty-common/src/embedder/test_env.rs:63:21:
   [… all eight casualties panic at the same line — the `.lock().unwrap()` …]

test result: FAILED. 21 passed; 9 failed; 2 ignored
```

Same injected panic, with the fix in place:

```
test embedder::tests::reference_accuracy_tests::default_model_matches_sentence_transformers_reference ... FAILED
test embedder::tests::resolve_default_embedding_model_defaults_to_fp32 ... ok
test embedder::tests::resolve_default_embedding_model_ignores_unknown ... ok
test embedder::tests::resolve_default_embedding_model_int8_opt_in ... ok
test embedder::tests::resolve_expected_provider_coreml_units ... ok
test embedder::tests::resolve_expected_provider_default_matches_platform ... ok
test embedder::tests::resolve_expected_provider_forces_cpu ... ok
test embedder::tests::resolve_fastembed_cache_dir_prefers_env_vars ... ok
test embedder::tests::trusty_device_cpu_disables_coreml_on_apple_silicon ... ok
test embedder::tests::trusty_device_gpu_enables_coreml_on_apple_silicon ... ok
test embedder::test_env::tests::poisoned_env_lock_is_still_acquirable ... ok

test result: FAILED. 35 passed; 1 failed; 4 ignored
```

The injected panic was reverted before committing.

**Resolution.** `test_env::env_lock()` acquires the lock with `unwrap_or_else(PoisonError::into_inner)`; all 27 call sites in `mod.rs`, `provider_tests.rs`, and `reference_accuracy_tests.rs` go through it.

Recovery is correct here rather than a suppressed failure: poisoning exists to warn that DATA behind a mutex may be half-updated, and this mutex carries `()`. The state it actually protects is the process environment, which `EnvVarGuard::drop` restores during the panicking test's unwind. Propagating poison communicates only "some other test failed" — which the harness already reports. `poisoned_env_lock_is_still_acquirable` pins the behavior and asserts the poison flag is recovered from, not cleared.

## Defect 2 — the CI root cause

**Defect.** Three compounding problems in the `test` job of `.github/workflows/ci.yml`.

*(a) The cache key rotated on every lockfile change.* The comment said "Cache key: fastembed crate version (from Cargo.lock)". The code hashed the whole file:

```yaml
key: fastembed-v${{ hashFiles('Cargo.lock') }}-xenova-allminilm-l6-v2-qdrant-allminilm-l6-v2-onnx
```

Any dependency bump anywhere in a 21-crate workspace rotated the key. On a repo landing dozens of PRs a day the cache is almost always cold, so almost every run re-downloads ~110 MB from HuggingFace.

*(b) The cache was never saved when the job failed.* `actions/cache@v4` declares `post-if: "success()"`. Run [31026363957](https://github.com/bobmatnyc/trusty-tools/actions/runs/31026363957)'s failed Test job shows it directly:

```
 8. Restore fastembed model cache -> success
 9. Pre-seed fastembed models (cache miss only) -> success
12. cargo test --workspace -> failure
24. Post Restore fastembed model cache -> skipped
```

That is a ratchet. HuggingFace rate-limits the pre-seed → no model → the accuracy gate fails → the job fails → the model is never cached → the next run is cold and rate-limited again. It is why [#4920](https://github.com/bobmatnyc/trusty-tools/pull/4920) and [#4926](https://github.com/bobmatnyc/trusty-tools/pull/4926) failed identically inside the same hour: both raced the same permanently-empty cache.

*(c) The retry budget was 75 seconds.* Same run, raw:

```
Cache not found for input keys: fastembed-v07b0e45deb71cb…
Resolving Xenova/all-MiniLM-L6-v2 HEAD revision …
curl: (22) The requested URL returned error: 429
Downloading Xenova/all-MiniLM-L6-v2/tokenizer.json …
curl: (22) The requested URL returned error: 429
Download failed (attempt 1/5), retrying in 5s …
   [… attempts 2/5, 3/5, 4/5, all 429 …]
curl: (22) The requested URL returned error: 429
ERROR: download failed after 5 attempts: https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/751bff…/tokenizer.json
##[warning]fastembed model pre-seed failed (rc=1; …)
```

5 attempts at 5/10/20/40s. An HF rate-limit window outlasts 75 seconds routinely.

The step is fail-soft by design, so it reported `success` while having done nothing; `cargo test` then ran with no model, the accuracy gate attempted its own download, hit the same 429, and panicked with `failed to initialise fastembed (tried AllMiniLML6V2 and AllMiniLML6V2Q)`.

*(d) The warning text was false.* It ended:

> the tests that need the real model are `#[ignore]`-gated and are not run in this job

which contradicts the block comment 30 lines above it in the same file, and is the sentence that got this misdiagnosed as a flaky test rather than a missing model.

**Resolution.**
- Key on the fastembed version the comment always described, extracted from `Cargo.lock` by a new `Resolve fastembed model cache key` step. It now rotates when the models change and not otherwise.
- Split `actions/cache` into `actions/cache/restore` plus an explicit `actions/cache/save` that runs immediately after a successful pre-seed and **before any test**, removing the test outcome from the save path entirely.
- Retry budget 5 attempts / 75s → 7 attempts / ~250s, doubling capped at 60s.
- Warning text now states the actual consequence and names the test.

## Should the accuracy test be `#[ignore]`d? No.

`CLAUDE.md` marks ONNX-backed embedder tests `#[ignore]` to keep CI fast, and issue #3493 P0 part 2 made one documented exception. `crates/trusty-common/src/embedder/tests/reference_accuracy_tests.rs:94-98`:

> Test: this test. NOT `#[ignore]`d (issue #3493 P0 part 2 — this is the correctness gate that would have caught the CoreML-default accuracy regression had it been wired into CI; see `ci.yml`'s `test` job for the fastembed-model pre-seed step that makes this safe to run on every PR without HuggingFace-download flakiness).

The pre-seed step exists *specifically* to make this test safe to run on every PR. Ignoring it would delete the coverage the pre-seed was built to enable and reintroduce exactly the regression #3493 closed. The pre-seed is what was broken; it is what this PR fixes.

## Gates

Rung 4–5 (`trusty-common` is a shared library). All raw.

```
$ cargo fmt --check && cargo clippy -p trusty-common --features embedder-bundled-ort,embedder-test-support --all-targets -- -D warnings && cargo test -p trusty-common --features embedder-bundled-ort,embedder-test-support
EXIT=0
test result: ok. 296 passed; 0 failed; 10 ignored; 0 measured; 0 filtered out; finished in 0.79s
```

```
$ cargo test -p trusty-common --features embedder-bundled-ort,embedder-test-support --lib -- --include-ignored embedder::
test embedder::provider_tests::fast_embedder_model_name_reports_fp32_default ... ok
test embedder::tests::fastembed_cache_hit_is_idempotent ... ok
test embedder::tests::fastembed_returns_correct_dim ... ok
test embedder::provider_tests::fast_embedder_model_name_reports_int8_opt_in ... ok
test embedder::tests::reference_accuracy_tests::default_model_matches_sentence_transformers_reference ... ok
test result: ok. 40 passed; 0 failed; 0 ignored; 0 measured; 266 filtered out
```

```
$ cargo check --workspace --all-targets --exclude trusty-mpm-gui --exclude trusty-code-gui --exclude trusty-agents-ui
EXIT=0
```

```
$ bash scripts/check_line_cap.sh          → EXIT=0
$ bash scripts/check_sld.sh               → EXIT=0
$ bash scripts/check_changelog_fragment.sh → EXIT=0
```

`cargo check --workspace` without CI's GUI exclusions fails on a pre-existing, unrelated `trusty-code-gui` Tauri error (`frontendDist` is `"ui/dist"` but that path doesn't exist in an unbuilt worktree). The diff touches no file in that crate.

🤖🤖🤖 Generated with trusty-mpm — https://github.com/bobmatnyc/trusty-tools
